### PR TITLE
autoformat jsdoc of some packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "overrides": [
       {
         "files": [
+          "packages/ERTP/**/*.{js,ts}",
           "packages/inter-protocol/**/*.{js,ts}",
           "packages/vats/**/*.{js,ts}"
         ],

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-github": "^4.8.0",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsdoc": "^46.4.3",
-    "eslint-plugin-prettier": "^5.0.0-alpha.2",
+    "eslint-plugin-prettier": "^5.0.0",
     "lerna": "^3.22.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "arrowParens": "avoid",
     "overrides": [
       {
-        "files": "packages/inter-protocol/**/*.{js,ts}",
+        "files": [
+          "packages/inter-protocol/**/*.{js,ts}",
+          "packages/vats/**/*.{js,ts}"
+        ],
         "options": {
           "plugins": [
             "prettier-plugin-jsdoc"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lerna": "^3.22.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0",
+    "prettier-plugin-jsdoc": "^1.0.0",
     "typescript": "~5.1.6"
   },
   "engines": {
@@ -37,6 +38,20 @@
   },
   "prettier": {
     "arrowParens": "avoid",
+    "overrides": [
+      {
+        "files": "packages/inter-protocol/**/*.{js,ts}",
+        "options": {
+          "plugins": [
+            "prettier-plugin-jsdoc"
+          ],
+          "jsdocAddDefaultToDescription": false,
+          "jsdocParser": true,
+          "jsdocCapitalizeDescription": false,
+          "tsdoc": true
+        }
+      }
+    ],
     "singleQuote": true
   },
   "scripts": {

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -11,7 +11,12 @@ const { quote: q, Fail } = assert;
 /**
  * Constants for the kinds of assets we support.
  *
- * @type {{ NAT: 'nat', SET: 'set', COPY_SET: 'copySet', COPY_BAG: 'copyBag' }}
+ * @type {{
+ *   NAT: 'nat';
+ *   SET: 'set';
+ *   COPY_SET: 'copySet';
+ *   COPY_BAG: 'copyBag';
+ * }}
  */
 const AssetKind = harden({
   NAT: 'nat',
@@ -21,9 +26,7 @@ const AssetKind = harden({
 });
 const assetKindNames = harden(Object.values(AssetKind).sort());
 
-/**
- * @param {AssetKind} allegedAK
- */
+/** @param {AssetKind} allegedAK */
 const assertAssetKind = allegedAK => {
   assetKindNames.includes(allegedAK) ||
     Fail`The assetKind ${allegedAK} must be one of ${q(assetKindNames)}`;
@@ -31,42 +34,37 @@ const assertAssetKind = allegedAK => {
 harden(assertAssetKind);
 
 /**
- * Amounts describe digital assets. From an amount, you can learn the
- * brand of digital asset as well as "how much" or "how many". Amounts
- * have two parts: a brand (loosely speaking, the type of digital
- * asset) and the value (the answer to "how much"). For example, in
- * the phrase "5 bucks", "bucks" takes the role of the brand and the
- * value is 5. Amounts can describe fungible and non-fungible digital
- * assets. Amounts are pass-by-copy and can be made by and sent to
- * anyone.
+ * Amounts describe digital assets. From an amount, you can learn the brand of
+ * digital asset as well as "how much" or "how many". Amounts have two parts: a
+ * brand (loosely speaking, the type of digital asset) and the value (the answer
+ * to "how much"). For example, in the phrase "5 bucks", "bucks" takes the role
+ * of the brand and the value is 5. Amounts can describe fungible and
+ * non-fungible digital assets. Amounts are pass-by-copy and can be made by and
+ * sent to anyone.
  *
- * The issuer is the authoritative source of the amount in payments
- * and purses. The issuer must be able to do things such as add
- * digital assets to a purse and withdraw digital assets from a purse.
- * To do so, it must know how to add and subtract digital assets.
- * Rather than hard-coding a particular solution, we chose to
- * parameterize the issuer with a collection of polymorphic functions,
- * which we call `AmountMath`. These math functions include concepts
+ * The issuer is the authoritative source of the amount in payments and purses.
+ * The issuer must be able to do things such as add digital assets to a purse
+ * and withdraw digital assets from a purse. To do so, it must know how to add
+ * and subtract digital assets. Rather than hard-coding a particular solution,
+ * we chose to parameterize the issuer with a collection of polymorphic
+ * functions, which we call `AmountMath`. These math functions include concepts
  * like addition, subtraction, and greater than or equal to.
  *
- * We also want to make sure there is no confusion as to what kind of
- * asset we are using. Thus, AmountMath includes checks of the
- * `brand`, the unique identifier for the type of digital asset. If
- * the wrong brand is used in AmountMath, an error is thrown and the
- * operation does not succeed.
+ * We also want to make sure there is no confusion as to what kind of asset we
+ * are using. Thus, AmountMath includes checks of the `brand`, the unique
+ * identifier for the type of digital asset. If the wrong brand is used in
+ * AmountMath, an error is thrown and the operation does not succeed.
  *
- * AmountMath uses mathHelpers to do most of the work, but then adds
- * the brand to the result. The function `value` gets the value from
- * the amount by removing the brand (amount -> value), and the
- * function `make` adds the brand to produce an amount (value ->
- * amount). The function `coerce` takes an amount and checks it,
- * returning an amount (amount -> amount).
+ * AmountMath uses mathHelpers to do most of the work, but then adds the brand
+ * to the result. The function `value` gets the value from the amount by
+ * removing the brand (amount -> value), and the function `make` adds the brand
+ * to produce an amount (value -> amount). The function `coerce` takes an amount
+ * and checks it, returning an amount (amount -> amount).
  *
- * Each issuer of digital assets has an associated brand in a
- * one-to-one mapping. In untrusted contexts, such as in analyzing
- * payments and amounts, we can get the brand and find the issuer
- * which matches the brand. The issuer and the brand mutually validate
- * each other.
+ * Each issuer of digital assets has an associated brand in a one-to-one
+ * mapping. In untrusted contexts, such as in analyzing payments and amounts, we
+ * can get the brand and find the issuer which matches the brand. The issuer and
+ * the brand mutually validate each other.
  */
 
 const helpers = {
@@ -137,7 +135,7 @@ const optionalBrandCheck = (allegedBrand, brand) => {
  * @param {Amount<K>} leftAmount
  * @param {Amount<K>} rightAmount
  * @param {Brand<K> | undefined} brand
- * @returns {MathHelpers<*>}
+ * @returns {MathHelpers<any>}
  */
 const checkLRAndGetHelpers = (leftAmount, rightAmount, brand = undefined) => {
   assertRecord(leftAmount, 'leftAmount');
@@ -172,11 +170,11 @@ const coerceLR = (h, leftAmount, rightAmount) => {
 };
 
 /**
- * Returns true if the leftAmount is greater than or equal to the
- * rightAmount. The notion of "greater than or equal to" depends
- * on the kind of amount, as defined by the MathHelpers. For example,
- * whether rectangle A is greater than rectangle B depends on whether rectangle
- * A includes rectangle B as defined by the logic in MathHelpers.
+ * Returns true if the leftAmount is greater than or equal to the rightAmount.
+ * The notion of "greater than or equal to" depends on the kind of amount, as
+ * defined by the MathHelpers. For example, whether rectangle A is greater than
+ * rectangle B depends on whether rectangle A includes rectangle B as defined by
+ * the logic in MathHelpers.
  *
  * @template {AssetKind} K
  * @param {Amount<K>} leftAmount
@@ -194,9 +192,8 @@ const isGTE = (leftAmount, rightAmount, brand = undefined) => {
  *
  * Amounts are the canonical description of tradable goods. They are manipulated
  * by issuers and mints, and represent the goods and currency carried by purses
- * and
- * payments. They can be used to represent things like currency, stock, and the
- * abstract right to participate in a particular exchange.
+ * and payments. They can be used to represent things like currency, stock, and
+ * the abstract right to participate in a particular exchange.
  */
 const AmountMath = {
   /**
@@ -215,8 +212,8 @@ const AmountMath = {
     return harden({ brand, value });
   },
   /**
-   * Make sure this amount is valid enough, and return a corresponding
-   * valid amount if so.
+   * Make sure this amount is valid enough, and return a corresponding valid
+   * amount if so.
    *
    * @template {AssetKind} K
    * @param {Brand<K>} brand
@@ -242,8 +239,8 @@ const AmountMath = {
    */
   getValue: (brand, amount) => AmountMath.coerce(brand, amount).value,
   /**
-   * Return the amount representing an empty amount. This is the
-   * identity element for MathHelpers.add and MatHelpers.subtract.
+   * Return the amount representing an empty amount. This is the identity
+   * element for MathHelpers.add and MatHelpers.subtract.
    *
    * @type {{
    *   (brand: Brand): Amount<'nat'>;
@@ -257,8 +254,8 @@ const AmountMath = {
     return harden({ brand, value });
   },
   /**
-   * Return the amount representing an empty amount, using another
-   * amount as the template for the brand and assetKind.
+   * Return the amount representing an empty amount, using another amount as the
+   * template for the brand and assetKind.
    *
    * @template {AssetKind} K
    * @param {Amount<K>} amount
@@ -289,8 +286,8 @@ const AmountMath = {
   },
   isGTE,
   /**
-   * Returns true if the leftAmount equals the rightAmount. We assume
-   * that if isGTE is true in both directions, isEqual is also true
+   * Returns true if the leftAmount equals the rightAmount. We assume that if
+   * isGTE is true in both directions, isEqual is also true
    *
    * @template {AssetKind} K
    * @param {Amount<K>} leftAmount
@@ -306,8 +303,8 @@ const AmountMath = {
    * Returns a new amount that is the union of both leftAmount and rightAmount.
    *
    * For fungible amount this means adding the values. For other kinds of
-   * amount, it usually means including all of the elements from both
-   * left and right.
+   * amount, it usually means including all of the elements from both left and
+   * right.
    *
    * @template {AssetKind} K
    * @param {Amount<K>} leftAmount
@@ -321,12 +318,11 @@ const AmountMath = {
     return harden({ brand: leftAmount.brand, value });
   },
   /**
-   * Returns a new amount that is the leftAmount minus the rightAmount
-   * (i.e. everything in the leftAmount that is not in the
-   * rightAmount). If leftAmount doesn't include rightAmount
-   * (subtraction results in a negative), throw  an error. Because the
-   * left amount must include the right amount, this is NOT equivalent
-   * to set subtraction.
+   * Returns a new amount that is the leftAmount minus the rightAmount (i.e.
+   * everything in the leftAmount that is not in the rightAmount). If leftAmount
+   * doesn't include rightAmount (subtraction results in a negative), throw an
+   * error. Because the left amount must include the right amount, this is NOT
+   * equivalent to set subtraction.
    *
    * @template {AssetKind} K
    * @param {Amount<K>} leftAmount
@@ -374,9 +370,7 @@ const AmountMath = {
 };
 harden(AmountMath);
 
-/**
- * @param {Amount} amount
- */
+/** @param {Amount} amount */
 const getAssetKind = amount => {
   assertRecord(amount, 'amount');
   const { value } = amount;

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -25,13 +25,13 @@ import './types-ambient.js';
  * @template {AssetKind} K
  * @param {IssuerRecord<K>} issuerRecord
  * @param {Baggage} issuerBaggage
- * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails
- * in the middle of an atomic action (which btw should never happen), it
- * potentially leaves its ledger in a corrupted state. If this function was
- * provided, then the failed atomic action will call it, so that some
- * larger unit of computation, like the enclosing vat, can be shutdown
- * before anything else is corrupted by that corrupted state.
- * See https://github.com/Agoric/agoric-sdk/issues/3434
+ * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
+ *   the middle of an atomic action (which btw should never happen), it
+ *   potentially leaves its ledger in a corrupted state. If this function was
+ *   provided, then the failed atomic action will call it, so that some larger
+ *   unit of computation, like the enclosing vat, can be shutdown before
+ *   anything else is corrupted by that corrupted state. See
+ *   https://github.com/Agoric/agoric-sdk/issues/3434
  * @returns {IssuerKit<K>}
  */
 const setupIssuerKit = (
@@ -80,13 +80,13 @@ const INSTANCE_KEY = 'issuer';
 /**
  * @template {AssetKind} K
  * @param {Baggage} issuerBaggage
- * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails
- * in the middle of an atomic action (which btw should never happen), it
- * potentially leaves its ledger in a corrupted state. If this function was
- * provided, then the failed atomic action will call it, so that some
- * larger unit of computation, like the enclosing vat, can be shutdown
- * before anything else is corrupted by that corrupted state.
- * See https://github.com/Agoric/agoric-sdk/issues/3434
+ * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
+ *   the middle of an atomic action (which btw should never happen), it
+ *   potentially leaves its ledger in a corrupted state. If this function was
+ *   provided, then the failed atomic action will call it, so that some larger
+ *   unit of computation, like the enclosing vat, can be shutdown before
+ *   anything else is corrupted by that corrupted state. See
+ *   https://github.com/Agoric/agoric-sdk/issues/3434
  * @returns {IssuerKit<K>}
  */
 export const prepareIssuerKit = (
@@ -99,43 +99,39 @@ export const prepareIssuerKit = (
 harden(prepareIssuerKit);
 
 /**
- * Does baggage already have an issuer from prepareIssuerKit()?
- * That is: does it have the relevant keys defined?
+ * Does baggage already have an issuer from prepareIssuerKit()? That is: does it
+ * have the relevant keys defined?
  *
  * @param {Baggage} baggage
  */
 export const hasIssuer = baggage => baggage.has(INSTANCE_KEY);
 
-/**
- * @typedef {Partial<{elementShape: Pattern}>} IssuerOptionsRecord
- */
+/** @typedef {Partial<{ elementShape: Pattern }>} IssuerOptionsRecord */
 
 /**
- * @template {AssetKind} K
- * The name becomes part of the brand in asset descriptions.
- * The name is useful for debugging and double-checking
- * assumptions, but should not be trusted wrt any external namespace.
- * For example, anyone could create a new issuer kit with name 'BTC', but
- * it is not bitcoin or even related. It is only the name according
- * to that issuer and brand.
+ * @template {AssetKind} K The name becomes part of the brand in asset
+ *   descriptions. The name is useful for debugging and double-checking
+ *   assumptions, but should not be trusted wrt any external namespace. For
+ *   example, anyone could create a new issuer kit with name 'BTC', but it is
+ *   not bitcoin or even related. It is only the name according to that issuer
+ *   and brand.
  *
- * The assetKind will be used to import a specific mathHelpers
- * from the mathHelpers library. For example, natMathHelpers, the
- * default, is used for basic fungible tokens.
+ *   The assetKind will be used to import a specific mathHelpers from the
+ *   mathHelpers library. For example, natMathHelpers, the default, is used for
+ *   basic fungible tokens.
  *
- *  `displayInfo` gives information to the UI on how to display the amount.
- *
+ *   `displayInfo` gives information to the UI on how to display the amount.
  * @param {Baggage} issuerBaggage
  * @param {string} name
  * @param {K} [assetKind=AssetKind.NAT]
  * @param {AdditionalDisplayInfo} [displayInfo={}]
- * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails
- * in the middle of an atomic action (which btw should never happen), it
- * potentially leaves its ledger in a corrupted state. If this function was
- * provided, then the failed atomic action will call it, so that some
- * larger unit of computation, like the enclosing vat, can be shutdown
- * before anything else is corrupted by that corrupted state.
- * See https://github.com/Agoric/agoric-sdk/issues/3434
+ * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
+ *   the middle of an atomic action (which btw should never happen), it
+ *   potentially leaves its ledger in a corrupted state. If this function was
+ *   provided, then the failed atomic action will call it, so that some larger
+ *   unit of computation, like the enclosing vat, can be shutdown before
+ *   anything else is corrupted by that corrupted state. See
+ *   https://github.com/Agoric/agoric-sdk/issues/3434
  * @param {IssuerOptionsRecord} [options]
  * @returns {IssuerKit<K>}
  */
@@ -155,30 +151,28 @@ export const makeDurableIssuerKit = (
 harden(makeDurableIssuerKit);
 
 /**
- * @template {AssetKind} [K='nat']
- * The name becomes part of the brand in asset descriptions.
- * The name is useful for debugging and double-checking
- * assumptions, but should not be trusted wrt any external namespace.
- * For example, anyone could create a new issuer kit with name 'BTC', but
- * it is not bitcoin or even related. It is only the name according
- * to that issuer and brand.
+ * @template {AssetKind} [K='nat'] The name becomes part of the brand in asset
+ *   descriptions. The name is useful for debugging and double-checking
+ *   assumptions, but should not be trusted wrt any external namespace. For
+ *   example, anyone could create a new issuer kit with name 'BTC', but it is
+ *   not bitcoin or even related. It is only the name according to that issuer
+ *   and brand.
  *
- * The assetKind will be used to import a specific mathHelpers
- * from the mathHelpers library. For example, natMathHelpers, the
- * default, is used for basic fungible tokens.
+ *   The assetKind will be used to import a specific mathHelpers from the
+ *   mathHelpers library. For example, natMathHelpers, the default, is used for
+ *   basic fungible tokens.
  *
- *  `displayInfo` gives information to the UI on how to display the amount.
- *
+ *   `displayInfo` gives information to the UI on how to display the amount.
  * @param {string} name
  * @param {K} [assetKind='nat']
  * @param {AdditionalDisplayInfo} [displayInfo={}]
- * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails
- * in the middle of an atomic action (which btw should never happen), it
- * potentially leaves its ledger in a corrupted state. If this function was
- * provided, then the failed atomic action will call it, so that some
- * larger unit of computation, like the enclosing vat, can be shutdown
- * before anything else is corrupted by that corrupted state.
- * See https://github.com/Agoric/agoric-sdk/issues/3434
+ * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
+ *   the middle of an atomic action (which btw should never happen), it
+ *   potentially leaves its ledger in a corrupted state. If this function was
+ *   provided, then the failed atomic action will call it, so that some larger
+ *   unit of computation, like the enclosing vat, can be shutdown before
+ *   anything else is corrupted by that corrupted state. See
+ *   https://github.com/Agoric/agoric-sdk/issues/3434
  * @param {IssuerOptionsRecord} [options]
  * @returns {IssuerKit<K>}
  */

--- a/packages/ERTP/src/legacy-payment-helpers.js
+++ b/packages/ERTP/src/legacy-payment-helpers.js
@@ -7,19 +7,17 @@ import { AmountMath } from './amountMath.js';
 const { Fail } = assert;
 
 /**
- * @file
- * This file contains safer helper function alternatives to the
- * similarly named methods on issuer.
- * These are parameterized by a purse used for recovering lost payments, which
- * we call a `recoveryPurse`. Any payments created by these
- * helper functions are in the recovery set of that `recoveryPurse` until
- * otherwise used up.
+ * @file This file contains safer helper function alternatives to the similarly
+ *   named methods on issuer. These are parameterized by a purse used for
+ *   recovering lost payments, which we call a `recoveryPurse`. Any payments
+ *   created by these helper functions are in the recovery set of that
+ *   `recoveryPurse` until otherwise used up.
  *
- * One of these helper functions is less safe in one way:
- * `combine` is not failure atomic. If the `combine` helper function
- * fails, some of the input payments may have been used up. However, even
- * in that case, no assets would be lost. The assets from the used up payments
- * will be in the argument `recoveryPurse`.
+ *   One of these helper functions is less safe in one way: `combine` is not
+ *   failure atomic. If the `combine` helper function fails, some of the input
+ *   payments may have been used up. However, even in that case, no assets would
+ *   be lost. The assets from the used up payments will be in the argument
+ *   `recoveryPurse`.
  */
 
 /**
@@ -43,11 +41,11 @@ harden(claim);
 
 /**
  * Note: Not failure atomic. But as long as you don't lose the argument
- * `recoveryPurse`, no assets are lost.
- * If any of the deposits fail, or the total does not
- * match optTotalAmount, some payments may still have been deposited. Those
- * assets will be in the argument `recoveryPurse`. All undeposited payments
- * will still be in the recovery sets of their purses of origin.
+ * `recoveryPurse`, no assets are lost. If any of the deposits fail, or the
+ * total does not match optTotalAmount, some payments may still have been
+ * deposited. Those assets will be in the argument `recoveryPurse`. All
+ * undeposited payments will still be in the recovery sets of their purses of
+ * origin.
  *
  * @template {AssetKind} K
  * @param {ERef<Purse<K>>} recoveryPurse
@@ -84,11 +82,10 @@ harden(combine);
 
 /**
  * Note: Not failure atomic. But as long as you don't lose the argument
- * `recoveryPurse`, no assets are lost.
- * If the amount in `srcPaymentP` is not >= `paymentAmountA`, the payment may
- * still be deposited anyway, before failing in the subsequent subtract.
- * In that case, those
- * assets will be in the argument `recoveryPurse`.
+ * `recoveryPurse`, no assets are lost. If the amount in `srcPaymentP` is not >=
+ * `paymentAmountA`, the payment may still be deposited anyway, before failing
+ * in the subsequent subtract. In that case, those assets will be in the
+ * argument `recoveryPurse`.
  *
  * @template {AssetKind} K
  * @param {ERef<Purse<K>>} recoveryPurse
@@ -111,12 +108,10 @@ harden(split);
 
 /**
  * Note: Not failure atomic. But as long as you don't lose the argument
- * `recoveryPurse`, no assets are lost.
- * If the amount in `srcPaymentP` is exactly the sum of the amounts,
- * the payment may
- * still be deposited anyway, before failing in the subsequent equality check.
- * In that case, those
- * assets will be in the argument `recoveryPurse`.
+ * `recoveryPurse`, no assets are lost. If the amount in `srcPaymentP` is
+ * exactly the sum of the amounts, the payment may still be deposited anyway,
+ * before failing in the subsequent equality check. In that case, those assets
+ * will be in the argument `recoveryPurse`.
  *
  * @template {AssetKind} K
  * @param {ERef<Purse<K>>} recoveryPurse

--- a/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
@@ -15,9 +15,7 @@ import '../types-ambient.js';
 /** @type {CopyBag} */
 const empty = makeCopyBag([]);
 
-/**
- * @type {MathHelpers<CopyBag>}
- */
+/** @type {MathHelpers<CopyBag>} */
 export const copyBagMathHelpers = harden({
   doCoerce: bag => {
     mustMatch(bag, M.bag(), 'bag of amount');

--- a/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
@@ -15,9 +15,7 @@ import '../types-ambient.js';
 /** @type {CopySet} */
 const empty = makeCopySet([]);
 
-/**
- * @type {MathHelpers<CopySet>}
- */
+/** @type {MathHelpers<CopySet>} */
 export const copySetMathHelpers = harden({
   doCoerce: set => {
     mustMatch(set, M.set(), 'set of amount');

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -8,14 +8,13 @@ const { Fail } = assert;
 const empty = 0n;
 
 /**
- * Fungible digital assets use the natMathHelpers to manage balances -
- * the operations are merely arithmetic on natural, non-negative
- * numbers.
+ * Fungible digital assets use the natMathHelpers to manage balances - the
+ * operations are merely arithmetic on natural, non-negative numbers.
  *
- * Natural numbers are used for fungible erights such as money because
- * rounding issues make floats problematic. All operations should be
- * done with the smallest whole unit such that the `natMathHelpers` never
- * deals with fractional parts.
+ * Natural numbers are used for fungible erights such as money because rounding
+ * issues make floats problematic. All operations should be done with the
+ * smallest whole unit such that the `natMathHelpers` never deals with
+ * fractional parts.
  *
  * @type {MathHelpers<NatValue>}
  */

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -70,8 +70,8 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
 };
 
 /**
- * Make the paymentLedger, the source of truth for the balances of
- * payments. All minting and transfer authority originates here.
+ * Make the paymentLedger, the source of truth for the balances of payments. All
+ * minting and transfer authority originates here.
  *
  * @template {AssetKind} K
  * @param {Baggage} issuerBaggage
@@ -146,22 +146,21 @@ export const preparePaymentLedger = (
   );
 
   /**
-   * A withdrawn live payment is associated with the recovery set of
-   * the purse it was withdrawn from. Let's call these "recoverable"
-   * payments. All recoverable payments are live, but not all live
-   * payments are recoverable. We do the bookkeeping for payment recovery
-   * with this weakmap from recoverable payments to the recovery set they are
-   * in.
-   * A bunch of interesting invariants here:
-   *    * Every payment that is a key in the outer `paymentRecoverySets`
-   *      weakMap is also in the recovery set indexed by that payment.
-   *    * Implied by the above but worth stating: the payment is only
-   *      in at most one recovery set.
-   *    * A recovery set only contains such payments.
-   *    * Every purse is associated with exactly one recovery set unique to
-   *      it.
-   *    * A purse's recovery set only contains payments withdrawn from
-   *      that purse and not yet consumed.
+   * A withdrawn live payment is associated with the recovery set of the purse
+   * it was withdrawn from. Let's call these "recoverable" payments. All
+   * recoverable payments are live, but not all live payments are recoverable.
+   * We do the bookkeeping for payment recovery with this weakmap from
+   * recoverable payments to the recovery set they are in. A bunch of
+   * interesting invariants here:
+   *
+   * - Every payment that is a key in the outer `paymentRecoverySets` weakMap is
+   *   also in the recovery set indexed by that payment.
+   * - Implied by the above but worth stating: the payment is only in at most one
+   *   recovery set.
+   * - A recovery set only contains such payments.
+   * - Every purse is associated with exactly one recovery set unique to it.
+   * - A purse's recovery set only contains payments withdrawn from that purse and
+   *   not yet consumed.
    *
    * @type {WeakMapStore<Payment, SetStore<Payment>>}
    */
@@ -172,8 +171,7 @@ export const preparePaymentLedger = (
 
   /**
    * To maintain the invariants listed in the `paymentRecoverySets` comment,
-   * `initPayment` should contain the only
-   * call to `paymentLedger.init`.
+   * `initPayment` should contain the only call to `paymentLedger.init`.
    *
    * @param {Payment} payment
    * @param {Amount} amount
@@ -189,8 +187,7 @@ export const preparePaymentLedger = (
 
   /**
    * To maintain the invariants listed in the `paymentRecoverySets` comment,
-   * `deletePayment` should contain the only
-   * call to `paymentLedger.delete`.
+   * `deletePayment` should contain the only call to `paymentLedger.delete`.
    *
    * @param {Payment} payment
    */
@@ -203,19 +200,18 @@ export const preparePaymentLedger = (
     }
   };
 
-  /** @type {(left: Amount, right: Amount) => Amount } */
+  /** @type {(left: Amount, right: Amount) => Amount} */
   const add = (left, right) => AmountMath.add(left, right, brand);
-  /** @type {(left: Amount, right: Amount) => Amount } */
+  /** @type {(left: Amount, right: Amount) => Amount} */
   const subtract = (left, right) => AmountMath.subtract(left, right, brand);
   /** @type {(allegedAmount: Amount) => Amount} */
   const coerce = allegedAmount => AmountMath.coerce(brand, allegedAmount);
-  /** @type {(left: Amount, right: Amount) => boolean } */
+  /** @type {(left: Amount, right: Amount) => boolean} */
 
   /**
-   * Methods like deposit() have an optional second parameter
-   * `optAmountShape`
-   * which, if present, is supposed to match the balance of the
-   * payment. This helper function does that check.
+   * Methods like deposit() have an optional second parameter `optAmountShape`
+   * which, if present, is supposed to match the balance of the payment. This
+   * helper function does that check.
    *
    * Note: `optAmountShape` is user-supplied with no previous validation.
    *
@@ -243,10 +239,10 @@ export const preparePaymentLedger = (
   /**
    * Used by the purse code to implement purse.deposit
    *
-   * @param {Amount} currentBalance - the current balance of the purse
-   * before a deposit
-   * @param {(newPurseBalance: Amount) => void} updatePurseBalance -
-   * commit the purse balance
+   * @param {Amount} currentBalance - the current balance of the purse before a
+   *   deposit
+   * @param {(newPurseBalance: Amount) => void} updatePurseBalance - commit the
+   *   purse balance
    * @param {Payment} srcPayment
    * @param {Pattern} [optAmountShape]
    * @returns {Amount}
@@ -282,10 +278,10 @@ export const preparePaymentLedger = (
   /**
    * Used by the purse code to implement purse.withdraw
    *
-   * @param {Amount} currentBalance - the current balance of the purse
-   * before a withdrawal
-   * @param {(newPurseBalance: Amount) => void} updatePurseBalance -
-   * commit the purse balance
+   * @param {Amount} currentBalance - the current balance of the purse before a
+   *   withdrawal
+   * @param {(newPurseBalance: Amount) => void} updatePurseBalance - commit the
+   *   purse balance
    * @param {Amount} amount - the amount to be withdrawn
    * @param {SetStore<Payment>} recoverySet
    * @returns {Payment}
@@ -378,9 +374,9 @@ export const preparePaymentLedger = (
   /**
    * Provides for the recovery of newly minted but not-yet-deposited payments.
    *
-   * Because the `mintRecoveryPurse` is placed in baggage, even if the
-   * caller of `makeIssuerKit` drops it on the floor, it can still be
-   * recovered in an emergency upgrade.
+   * Because the `mintRecoveryPurse` is placed in baggage, even if the caller of
+   * `makeIssuerKit` drops it on the floor, it can still be recovered in an
+   * emergency upgrade.
    *
    * @type {Purse<K>}
    */

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -11,62 +11,56 @@ export const NotifierShape = M.remotable('Notifier');
 export const MintShape = M.remotable('Mint');
 
 /**
- * When the AmountValue of an Amount fits the NatValueShape, i.e., when it is
- * a non-negative bigint, then it represents that many units of the
- * fungible asset represented by that amount. The brand of that amount
- * should indeed represent a kind of asset consisting of a countable
- * set of fungible units.
+ * When the AmountValue of an Amount fits the NatValueShape, i.e., when it is a
+ * non-negative bigint, then it represents that many units of the fungible asset
+ * represented by that amount. The brand of that amount should indeed represent
+ * a kind of asset consisting of a countable set of fungible units.
  */
 const NatValueShape = M.nat();
 
 /**
  * When the AmountValue of an Amount fits the CopySetValueShape, i.e., when it
- * is a CopySet, then it represents the set of those
- * keys, where each key represents some individual non-fungible
- * item, like a concert ticket, from the non-fungible asset class
- * represented by that amount's brand. The amount itself represents
- * the set of these items, as opposed to any of the other items
- * from the same asset class.
+ * is a CopySet, then it represents the set of those keys, where each key
+ * represents some individual non-fungible item, like a concert ticket, from the
+ * non-fungible asset class represented by that amount's brand. The amount
+ * itself represents the set of these items, as opposed to any of the other
+ * items from the same asset class.
  *
- * If a given value class represents concert tickets, it seems bizarre
- * that we can form amounts of any key. The hard constraint is that
- * the code that holds the mint for that asset class---the one associated
- * with that brand, only mints the items representing the real units
- * of that asset class as defined by it. Anyone else can put together
- * an amount expressing, for example, that they "want" some items that
- * will never be minted. That want will never be satisfied.
- * "You can't always get..."
+ * If a given value class represents concert tickets, it seems bizarre that we
+ * can form amounts of any key. The hard constraint is that the code that holds
+ * the mint for that asset class---the one associated with that brand, only
+ * mints the items representing the real units of that asset class as defined by
+ * it. Anyone else can put together an amount expressing, for example, that they
+ * "want" some items that will never be minted. That want will never be
+ * satisfied. "You can't always get..."
  */
 const CopySetValueShape = M.set();
 
 /**
- * When the AmountValue of an Amount fits the SetValueShape, i.e., when it
- * is a CopyArray of passable Keys. This representation is deprecated.
+ * When the AmountValue of an Amount fits the SetValueShape, i.e., when it is a
+ * CopyArray of passable Keys. This representation is deprecated.
  *
  * @deprecated Please change from using array-based SetValues to CopySet-based
- * CopySetValues.
+ *   CopySetValues.
  */
 const SetValueShape = M.arrayOf(M.key());
 
 /**
  * When the AmountValue of an Amount fits the CopyBagValueShape, i.e., when it
- * is a CopyBag, then it represents the bag (multiset) of those
- * keys, where each key represents some individual semi-fungible
- * item, like a concert ticket, from the semi-fungible asset class
- * represented by that amount's brand. The number of times that key
- * appears in the bag is the number of fungible units of that key.
- * The amount itself represents
- * the bag of these items, as opposed to any of the other items
- * from the same asset class.
+ * is a CopyBag, then it represents the bag (multiset) of those keys, where each
+ * key represents some individual semi-fungible item, like a concert ticket,
+ * from the semi-fungible asset class represented by that amount's brand. The
+ * number of times that key appears in the bag is the number of fungible units
+ * of that key. The amount itself represents the bag of these items, as opposed
+ * to any of the other items from the same asset class.
  *
- * If a given value class represents concert tickets, it seems bizarre
- * that we can form amounts of any key. The hard constraint is that
- * the code that holds the mint for that asset class---the one associated
- * with that brand, only mints the items representing the real units
- * of that asset class as defined by it. Anyone else can put together
- * an amount expressing, for example, that they "want" some items that
- * will never be minted. That want will never be satisfied.
- * "You can't always get..."
+ * If a given value class represents concert tickets, it seems bizarre that we
+ * can form amounts of any key. The hard constraint is that the code that holds
+ * the mint for that asset class---the one associated with that brand, only
+ * mints the items representing the real units of that asset class as defined by
+ * it. Anyone else can put together an amount expressing, for example, that they
+ * "want" some items that will never be minted. That want will never be
+ * satisfied. "You can't always get..."
  */
 const CopyBagValueShape = M.bag();
 
@@ -106,11 +100,11 @@ export const isCopySetValue = value => matches(value, CopySetValueShape);
 harden(isCopySetValue);
 
 /**
- * Returns true if value is a pass by copy array structure. Does not
- * check for duplicates. To check for duplicates, use setMathHelpers.coerce.
+ * Returns true if value is a pass by copy array structure. Does not check for
+ * duplicates. To check for duplicates, use setMathHelpers.coerce.
  *
  * @deprecated Please change from using array-based SetValues to CopySet-based
- * CopySetValues.
+ *   CopySetValues.
  * @param {AmountValue} value
  * @returns {value is SetValue}
  */

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -4,148 +4,134 @@
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {object} Amount
- * Amounts are descriptions of digital assets, answering the questions
- * "how much" and "of what kind". Amounts are values labeled with a brand.
- * AmountMath executes the logic of how amounts are changed when digital
- * assets are merged, separated, or otherwise manipulated. For
- * example, a deposit of 2 bucks into a purse that already has 3 bucks
- * gives a new purse balance of 5 bucks. An empty purse has 0 bucks. AmountMath
- * relies heavily on polymorphic MathHelpers, which manipulate the unbranded
- * portion.
- *
+ * @typedef {object} Amount Amounts are descriptions of digital assets,
+ *   answering the questions "how much" and "of what kind". Amounts are values
+ *   labeled with a brand. AmountMath executes the logic of how amounts are
+ *   changed when digital assets are merged, separated, or otherwise
+ *   manipulated. For example, a deposit of 2 bucks into a purse that already
+ *   has 3 bucks gives a new purse balance of 5 bucks. An empty purse has 0
+ *   bucks. AmountMath relies heavily on polymorphic MathHelpers, which
+ *   manipulate the unbranded portion.
  * @property {Brand<K>} brand
  * @property {AssetValueForKind<K>} value
  */
 
 /**
- * @typedef {NatValue | SetValue | CopySet | CopyBag} AmountValue
- * An `AmountValue` describes a set or quantity of assets that can be owned or
- * shared.
+ * @typedef {NatValue | SetValue | CopySet | CopyBag} AmountValue An
+ *   `AmountValue` describes a set or quantity of assets that can be owned or
+ *   shared.
  *
- * A fungible `AmountValue` uses a non-negative bigint to represent a quantity
- * of that many assets.
+ *   A fungible `AmountValue` uses a non-negative bigint to represent a quantity
+ *   of that many assets.
  *
- * A non-fungible `AmountValue` uses an array or CopySet of `Key`s to represent
- * a set of whatever asset each key represents. A `Key` is a passable value
- * that can be used as an element in a set (SetStore or CopySet) or as the
- * key in a map (MapStore or CopyMap).
+ *   A non-fungible `AmountValue` uses an array or CopySet of `Key`s to represent
+ *   a set of whatever asset each key represents. A `Key` is a passable value
+ *   that can be used as an element in a set (SetStore or CopySet) or as the key
+ *   in a map (MapStore or CopyMap).
  *
- * `SetValue` is for the deprecated set representation, using an array directly
- * to represent the array of its elements. `CopySet` is the proper
- * representation using a CopySet.
+ *   `SetValue` is for the deprecated set representation, using an array directly
+ *   to represent the array of its elements. `CopySet` is the proper
+ *   representation using a CopySet.
  *
- * A semi-fungible `CopyBag` is represented as a
- * `CopyBag` of `Key` objects. "Bag" is synonymous with MultiSet, where an
- * element of a bag can be present once or more times, i.e., some positive
- * bigint number of times, representing that quantity of the asset represented
- * by that key.
+ *   A semi-fungible `CopyBag` is represented as a `CopyBag` of `Key` objects.
+ *   "Bag" is synonymous with MultiSet, where an element of a bag can be present
+ *   once or more times, i.e., some positive bigint number of times,
+ *   representing that quantity of the asset represented by that key.
  */
 
 /**
- * @typedef {'nat' | 'set' | 'copySet' | 'copyBag' } AssetKind
- *
- * See doc-comment for `AmountValue`.
+ * @typedef {'nat' | 'set' | 'copySet' | 'copyBag'} AssetKind See doc-comment
+ *   for `AmountValue`.
  */
 
 /**
  * @template {AssetKind} K
- * @typedef {K extends 'nat' ? NatValue :
- * K extends 'set' ? SetValue :
- * K extends 'copySet' ? CopySet:
- * K extends 'copyBag' ? CopyBag :
- * never
- * } AssetValueForKind
+ * @typedef {K extends 'nat'
+ *   ? NatValue
+ *   : K extends 'set'
+ *   ? SetValue
+ *   : K extends 'copySet'
+ *   ? CopySet
+ *   : K extends 'copyBag'
+ *   ? CopyBag
+ *   : never} AssetValueForKind
  */
 
 /**
  * @template {AmountValue} V
- * @typedef {V extends NatValue ? 'nat' :
- *  V extends SetValue ? 'set' :
- *  V extends CopySet ? 'copySet' :
- *  V extends CopyBag ? 'copyBag' :
- *  never} AssetKindForValue
+ * @typedef {V extends NatValue
+ *   ? 'nat'
+ *   : V extends SetValue
+ *   ? 'set'
+ *   : V extends CopySet
+ *   ? 'copySet'
+ *   : V extends CopyBag
+ *   ? 'copyBag'
+ *   : never} AssetKindForValue
  */
 
 /**
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} DisplayInfo
- * @property {number} [decimalPlaces] Tells the display software how
- *   many decimal places to move the decimal over to the left, or in
- *   other words, which position corresponds to whole numbers. We
- *   require fungible digital assets to be represented in integers, in
- *   the smallest unit (i.e. USD might be represented in mill, a
- *   thousandth of a dollar. In that case, `decimalPlaces` would be
- *   3.) This property is optional, and for non-fungible digital
- *   assets, should not be specified. The decimalPlaces property
- *   should be used for *display purposes only*. Any other use is an
+ * @property {number} [decimalPlaces] Tells the display software how many
+ *   decimal places to move the decimal over to the left, or in other words,
+ *   which position corresponds to whole numbers. We require fungible digital
+ *   assets to be represented in integers, in the smallest unit (i.e. USD might
+ *   be represented in mill, a thousandth of a dollar. In that case,
+ *   `decimalPlaces` would be 3.) This property is optional, and for
+ *   non-fungible digital assets, should not be specified. The decimalPlaces
+ *   property should be used for _display purposes only_. Any other use is an
  *   anti-pattern.
- * @property {K} assetKind - the kind of asset, either
- *   AssetKind.NAT (fungible) or
- *   AssetKind.SET or AssetKind.COPY_SET (non-fungible)
+ * @property {K} assetKind - the kind of asset, either AssetKind.NAT (fungible)
+ *   or AssetKind.SET or AssetKind.COPY_SET (non-fungible)
  */
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {object} Brand
- * The brand identifies the kind of issuer, and has a function to get the
- * alleged name for the kind of asset described. The alleged name (such
- * as 'BTC' or 'moola') is provided by the maker of the issuer and should
- * not be trusted as accurate.
+ * @typedef {object} Brand The brand identifies the kind of issuer, and has a
+ *   function to get the alleged name for the kind of asset described. The
+ *   alleged name (such as 'BTC' or 'moola') is provided by the maker of the
+ *   issuer and should not be trusted as accurate.
  *
- * Every amount created by a particular AmountMath will share the same brand,
- * but recipients cannot rely on the brand to verify that a purported amount
- * represents the issuer they intended, since the same brand can be reused by
- * a misbehaving issuer.
- *
+ *   Every amount created by a particular AmountMath will share the same brand,
+ *   but recipients cannot rely on the brand to verify that a purported amount
+ *   represents the issuer they intended, since the same brand can be reused by
+ *   a misbehaving issuer.
  * @property {(allegedIssuer: ERef<Issuer>) => Promise<boolean>} isMyIssuer
- * Should be used with `issuer.getBrand` to ensure an issuer and brand match.
+ *   Should be used with `issuer.getBrand` to ensure an issuer and brand match.
  * @property {() => string} getAllegedName
- * @property {() => DisplayInfo<K>} getDisplayInfo
- * Give information to UI on how to display the amount.
+ * @property {() => DisplayInfo<K>} getDisplayInfo Give information to UI on how
+ *   to display the amount.
  * @property {() => Pattern} getAmountShape
  */
 
 // /////////////////////////// Issuer //////////////////////////////////////////
 
 /**
- * @callback IssuerIsLive
+ * @callback IssuerIsLive Return true if the payment continues to exist.
  *
- * Return true if the payment continues to exist.
- *
- * If the payment is a promise, the operation will proceed upon
- * resolution.
- *
+ *   If the payment is a promise, the operation will proceed upon resolution.
  * @param {ERef<Payment>} payment
  * @returns {Promise<boolean>}
  */
 /**
  * @template {AssetKind} K
- * @callback IssuerGetAmountOf
+ * @callback IssuerGetAmountOf Get the amount of digital assets in the payment.
+ *   Because the payment is not trusted, we cannot call a method on it directly,
+ *   and must use the issuer instead.
  *
- * Get the amount of digital assets in the payment. Because the
- * payment is not trusted, we cannot call a method on it directly, and
- * must use the issuer instead.
- *
- * If the payment is a promise, the operation will proceed upon
- * resolution.
- *
+ *   If the payment is a promise, the operation will proceed upon resolution.
  * @param {ERef<Payment>} payment
  * @returns {Promise<Amount<K>>}
  */
 
 /**
- * @callback IssuerBurn
+ * @callback IssuerBurn Burn all of the digital assets in the payment.
+ *   `optAmount` is optional. If `optAmount` is present, the code will insist
+ *   that the amount of the digital assets in the payment is equal to
+ *   `optAmount`, to prevent sending the wrong payment and other confusion.
  *
- * Burn all of the digital assets in the
- * payment. `optAmount` is optional. If `optAmount` is present, the
- * code will insist that the amount of the digital assets in the
- * payment is equal to `optAmount`, to prevent sending the wrong
- * payment and other confusion.
- *
- * If the payment is a promise, the operation will proceed upon
- * resolution.
- *
+ *   If the payment is a promise, the operation will proceed upon resolution.
  * @param {ERef<Payment>} payment
  * @param {Pattern} [optAmountShape]
  * @returns {Promise<Amount>}
@@ -153,17 +139,13 @@
 
 /**
  * @template {AssetKind} K
- * @callback IssuerClaim
+ * @callback IssuerClaim Transfer all digital assets from the payment to a new
+ *   payment and delete the original. `optAmount` is optional. If `optAmount` is
+ *   present, the code will insist that the amount of digital assets in the
+ *   payment is equal to `optAmount`, to prevent sending the wrong payment and
+ *   other confusion.
  *
- * Transfer all digital assets from the payment to a new payment and
- * delete the original. `optAmount` is optional. If `optAmount` is
- * present, the code will insist that the amount of digital assets in
- * the payment is equal to `optAmount`, to prevent sending the wrong
- * payment and other confusion.
- *
- * If the payment is a promise, the operation will proceed upon
- * resolution.
- *
+ *   If the payment is a promise, the operation will proceed upon resolution.
  * @param {ERef<Payment<K>>} payment
  * @param {Pattern} [optAmountShape]
  * @returns {Promise<Payment<K>>}
@@ -171,13 +153,10 @@
 
 /**
  * @template {AssetKind} K
- * @callback IssuerCombine
+ * @callback IssuerCombine Combine multiple payments into one payment.
  *
- * Combine multiple payments into one payment.
- *
- * If any of the payments is a promise, the operation will proceed
- * upon resolution.
- *
+ *   If any of the payments is a promise, the operation will proceed upon
+ *   resolution.
  * @param {ERef<Payment<K>>[]} paymentsArray
  * @param {Amount<K>} [optTotalAmount]
  * @returns {Promise<Payment<K>>}
@@ -185,28 +164,20 @@
 
 /**
  * @template {AssetKind} K
- * @callback IssuerSplit
+ * @callback IssuerSplit Split a single payment into two payments, A and B,
+ *   according to the paymentAmountA passed in.
  *
- * Split a single payment into two payments,
- * A and B, according to the paymentAmountA passed in.
- *
- * If the payment is a promise, the operation will proceed upon
- * resolution.
- *
+ *   If the payment is a promise, the operation will proceed upon resolution.
  * @param {ERef<Payment<K>>} payment
  * @param {Amount<K>} paymentAmountA
  * @returns {Promise<Payment<K>[]>}
  */
 
 /**
- * @callback IssuerSplitMany
+ * @callback IssuerSplitMany Split a single payment into many payments,
+ *   according to the amounts passed in.
  *
- * Split a single payment into many payments, according to the amounts
- * passed in.
- *
- * If the payment is a promise, the operation will proceed upon
- * resolution.
- *
+ *   If the payment is a promise, the operation will proceed upon resolution.
  * @param {ERef<Payment>} payment
  * @param {Amount[]} amounts
  * @returns {Promise<Payment[]>}
@@ -214,30 +185,24 @@
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {object} Issuer
- *
- * The issuer cannot mint a new amount, but it can create empty purses
- * and payments. The issuer can also transform payments (splitting
- * payments, combining payments, burning payments, and claiming
- * payments exclusively). The issuer should be gotten from a trusted
- * source and then relied upon as the decider of whether an untrusted
- * payment is valid.
- *
- * @property {() => Brand<K>} getBrand Get the Brand for this Issuer. The
- * Brand indicates the type of digital asset and is shared by the
- * mint, the issuer, and any purses and payments of this particular
- * kind. The brand is not closely held, so this function should not be
- * trusted to identify an issuer alone. Fake digital assets and amount
- * can use another issuer's brand.
- *
- * @property {() => string} getAllegedName Get the allegedName for
- * this mint/issuer
- * @property {() => AssetKind} getAssetKind Get the kind of
- * MathHelpers used by this Issuer.
- * @property {() => DisplayInfo<K>} getDisplayInfo Give information to UI
- *  on how to display amounts for this issuer.
- * @property {() => Purse<K>} makeEmptyPurse Make an empty purse of this
- * brand.
+ * @typedef {object} Issuer The issuer cannot mint a new amount, but it can
+ *   create empty purses and payments. The issuer can also transform payments
+ *   (splitting payments, combining payments, burning payments, and claiming
+ *   payments exclusively). The issuer should be gotten from a trusted source
+ *   and then relied upon as the decider of whether an untrusted payment is
+ *   valid.
+ * @property {() => Brand<K>} getBrand Get the Brand for this Issuer. The Brand
+ *   indicates the type of digital asset and is shared by the mint, the issuer,
+ *   and any purses and payments of this particular kind. The brand is not
+ *   closely held, so this function should not be trusted to identify an issuer
+ *   alone. Fake digital assets and amount can use another issuer's brand.
+ * @property {() => string} getAllegedName Get the allegedName for this
+ *   mint/issuer
+ * @property {() => AssetKind} getAssetKind Get the kind of MathHelpers used by
+ *   this Issuer.
+ * @property {() => DisplayInfo<K>} getDisplayInfo Give information to UI on how
+ *   to display amounts for this issuer.
+ * @property {() => Purse<K>} makeEmptyPurse Make an empty purse of this brand.
  * @property {IssuerIsLive} isLive
  * @property {IssuerGetAmountOf<K>} getAmountOf
  * @property {IssuerBurn} burn
@@ -264,33 +229,27 @@
 
 /**
  * @typedef {object} AdditionalDisplayInfo
- *
- * @property {number} [decimalPlaces] Tells the display software how
- *   many decimal places to move the decimal over to the left, or in
- *   other words, which position corresponds to whole numbers. We
- *   require fungible digital assets to be represented in integers, in
- *   the smallest unit (i.e. USD might be represented in mill, a
- *   thousandth of a dollar. In that case, `decimalPlaces` would be
- *   3.) This property is optional, and for non-fungible digital
- *   assets, should not be specified. The decimalPlaces property
- *   should be used for *display purposes only*. Any other use is an
+ * @property {number} [decimalPlaces] Tells the display software how many
+ *   decimal places to move the decimal over to the left, or in other words,
+ *   which position corresponds to whole numbers. We require fungible digital
+ *   assets to be represented in integers, in the smallest unit (i.e. USD might
+ *   be represented in mill, a thousandth of a dollar. In that case,
+ *   `decimalPlaces` would be 3.) This property is optional, and for
+ *   non-fungible digital assets, should not be specified. The decimalPlaces
+ *   property should be used for _display purposes only_. Any other use is an
  *   anti-pattern.
  * @property {AssetKind} [assetKind]
  */
 
-/**
- * @typedef {import('@agoric/swingset-vat').ShutdownWithFailure} ShutdownWithFailure
- */
+/** @typedef {import('@agoric/swingset-vat').ShutdownWithFailure} ShutdownWithFailure */
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {object} Mint
- * Holding a Mint carries the right to issue new digital assets. These
- * assets all have the same kind, which is called a Brand.
- *
+ * @typedef {object} Mint Holding a Mint carries the right to issue new digital
+ *   assets. These assets all have the same kind, which is called a Brand.
  * @property {() => Issuer<K>} getIssuer Gets the Issuer for this mint.
- * @property {(newAmount: Amount<K>) => Payment<K>} mintPayment
- * Creates a new Payment containing newly minted amount.
+ * @property {(newAmount: Amount<K>) => Payment<K>} mintPayment Creates a new
+ *   Payment containing newly minted amount.
  */
 
 /**
@@ -302,12 +261,12 @@
 
 /**
  * @typedef {object} DepositFacet
- * @property {DepositFacetReceive} receive
- * Deposit all the contents of payment into the purse that made this facet,
- * returning the amount. If the optional argument `optAmount` does not equal the
- * amount of digital assets in the payment, throw an error.
+ * @property {DepositFacetReceive} receive Deposit all the contents of payment
+ *   into the purse that made this facet, returning the amount. If the optional
+ *   argument `optAmount` does not equal the amount of digital assets in the
+ *   payment, throw an error.
  *
- * If payment is a promise, throw an error.
+ *   If payment is a promise, throw an error.
  */
 
 /**
@@ -320,121 +279,94 @@
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {object} Purse
- * Purses hold amount of digital assets of the same brand, but unlike Payments,
- * they are not meant to be sent to others. To transfer digital assets, a
- * Payment should be withdrawn from a Purse. The amount of digital
- * assets in a purse can change through the action of deposit() and withdraw().
+ * @typedef {object} Purse Purses hold amount of digital assets of the same
+ *   brand, but unlike Payments, they are not meant to be sent to others. To
+ *   transfer digital assets, a Payment should be withdrawn from a Purse. The
+ *   amount of digital assets in a purse can change through the action of
+ *   deposit() and withdraw().
  *
- * The primary use for Purses and Payments is for currency-like and goods-like
- * digital assets, but they can also be used to represent other kinds of rights,
- * such as the right to participate in a particular contract.
+ *   The primary use for Purses and Payments is for currency-like and goods-like
+ *   digital assets, but they can also be used to represent other kinds of
+ *   rights, such as the right to participate in a particular contract.
+ * @property {() => Brand<K>} getAllegedBrand Get the alleged Brand for this
+ *   Purse
+ * @property {() => Amount<K>} getCurrentAmount Get the amount contained in this
+ *   purse.
+ * @property {() => LatestTopic<Amount<K>>} getCurrentAmountNotifier Get a lossy
+ *   notifier for changes to this purse's balance.
+ * @property {PurseDeposit<K>} deposit Deposit all the contents of payment into
+ *   this purse, returning the amount. If the optional argument `optAmount` does
+ *   not equal the amount of digital assets in the payment, throw an error.
  *
- * @property {() => Brand<K>} getAllegedBrand Get the alleged Brand for this Purse
- *
- * @property {() => Amount<K>} getCurrentAmount
- * Get the amount contained in this purse.
- *
- * @property {() => LatestTopic<Amount<K>>} getCurrentAmountNotifier
- * Get a lossy notifier for changes to this purse's balance.
- *
- * @property {PurseDeposit<K>} deposit
- * Deposit all the contents of payment into this purse, returning the
- * amount. If the optional argument `optAmount` does not equal the
- * amount of digital assets in the payment, throw an error.
- *
- * If payment is a promise, throw an error.
- *
- * @property {() => DepositFacet} getDepositFacet
- * Return an object whose `receive` method deposits to the current Purse.
- *
- * @property {(amount: Amount<K>) => Payment<K>} withdraw
- * Withdraw amount from this purse into a new Payment.
- *
- * @property {() => CopySet<Payment<K>>} getRecoverySet
- * The set of payments withdrawn from this purse that are still live. These
- * are the payments that can still be recovered in emergencies by, for example,
- * depositing into this purse. Such a deposit action is like canceling an
- * outstanding check because you're tired of waiting for it. Once your
- * cancellation is acknowledged, you can spend the assets at stake on other
- * things. Afterwards, if the recipient of the original check finally gets
- * around to depositing it, their deposit fails.
- *
- * @property {() => Amount<K>} recoverAll
- * For use in emergencies, such as coming back from a traumatic crash and
- * upgrade. This deposits all the payments in this purse's recovery set
- * into the purse itself, returning the total amount of assets recovered.
+ *   If payment is a promise, throw an error.
+ * @property {() => DepositFacet} getDepositFacet Return an object whose
+ *   `receive` method deposits to the current Purse.
+ * @property {(amount: Amount<K>) => Payment<K>} withdraw Withdraw amount from
+ *   this purse into a new Payment.
+ * @property {() => CopySet<Payment<K>>} getRecoverySet The set of payments
+ *   withdrawn from this purse that are still live. These are the payments that
+ *   can still be recovered in emergencies by, for example, depositing into this
+ *   purse. Such a deposit action is like canceling an outstanding check because
+ *   you're tired of waiting for it. Once your cancellation is acknowledged, you
+ *   can spend the assets at stake on other things. Afterwards, if the recipient
+ *   of the original check finally gets around to depositing it, their deposit
+ *   fails.
+ * @property {() => Amount<K>} recoverAll For use in emergencies, such as coming
+ *   back from a traumatic crash and upgrade. This deposits all the payments in
+ *   this purse's recovery set into the purse itself, returning the total amount
+ *   of assets recovered.
  */
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {object} Payment
- * Payments hold amount of digital assets of the same brand in transit. Payments
- * can be deposited in purses, split into multiple payments, combined, and
- * claimed (getting an exclusive payment). Payments are linear, meaning
- * that either a payment has the same amount of digital assets it
- * started with, or it is used up entirely. It is impossible to partially use a
- * payment.
+ * @typedef {object} Payment Payments hold amount of digital assets of the same
+ *   brand in transit. Payments can be deposited in purses, split into multiple
+ *   payments, combined, and claimed (getting an exclusive payment). Payments
+ *   are linear, meaning that either a payment has the same amount of digital
+ *   assets it started with, or it is used up entirely. It is impossible to
+ *   partially use a payment.
  *
- * Payments are often received from other actors and therefore should
- * not be trusted themselves. To get the amount of digital assets in a payment,
- * use the trusted issuer: issuer.getAmountOf(payment),
+ *   Payments are often received from other actors and therefore should not be
+ *   trusted themselves. To get the amount of digital assets in a payment, use
+ *   the trusted issuer: issuer.getAmountOf(payment),
  *
- * Payments can be converted to Purses by getting a trusted issuer and
- * calling `issuer.makeEmptyPurse()` to create a purse, then
- * `purse.deposit(payment)`.
- *
- * @property {() => Brand<K>} getAllegedBrand
- * Get the allegedBrand, indicating the type of digital asset this
- * payment purports to be, and which issuer to use. Because payments
- * are not trusted, any method calls on payments should be treated
- * with suspicion and verified elsewhere.
+ *   Payments can be converted to Purses by getting a trusted issuer and calling
+ *   `issuer.makeEmptyPurse()` to create a purse, then
+ *   `purse.deposit(payment)`.
+ * @property {() => Brand<K>} getAllegedBrand Get the allegedBrand, indicating
+ *   the type of digital asset this payment purports to be, and which issuer to
+ *   use. Because payments are not trusted, any method calls on payments should
+ *   be treated with suspicion and verified elsewhere.
  */
 
 /**
  * @template {AmountValue} V
- * @typedef {object} MathHelpers
- * All of the difference in how digital asset amount are manipulated can be
- * reduced to the behavior of the math on values. We extract this
- * custom logic into mathHelpers. MathHelpers are about value
- * arithmetic, whereas AmountMath is about amounts, which are the
- * values labeled with a brand. AmountMath use mathHelpers to do their value
- * arithmetic, and then brand the results, making a new amount.
+ * @typedef {object} MathHelpers All of the difference in how digital asset
+ *   amount are manipulated can be reduced to the behavior of the math on
+ *   values. We extract this custom logic into mathHelpers. MathHelpers are
+ *   about value arithmetic, whereas AmountMath is about amounts, which are the
+ *   values labeled with a brand. AmountMath use mathHelpers to do their value
+ *   arithmetic, and then brand the results, making a new amount.
  *
- * The MathHelpers are designed to be called only from AmountMath, and so
- * all methods but coerce can assume their inputs are valid. They only
- * need to do output validation, and only when there is a possibility of
- * invalid output.
- *
- * @property {(allegedValue: V) => V} doCoerce
- * Check the kind of this value and throw if it is not the
- * expected kind.
- *
- * @property {() => V} doMakeEmpty
- * Get the representation for the identity element (often 0 or an
- * empty array)
- *
- * @property {(value: V) => boolean} doIsEmpty
- * Is the value the identity element?
- *
- * @property {(left: V, right: V) => boolean} doIsGTE
- * Is the left greater than or equal to the right?
- *
- * @property {(left: V, right: V) => boolean} doIsEqual
- * Does left equal right?
- *
- * @property {(left: V, right: V) => V} doAdd
- * Return the left combined with the right.
- *
- * @property {(left: V, right: V) => V} doSubtract
- * Return what remains after removing the right from the left. If
- * something in the right was not in the left, we throw an error.
+ *   The MathHelpers are designed to be called only from AmountMath, and so all
+ *   methods but coerce can assume their inputs are valid. They only need to do
+ *   output validation, and only when there is a possibility of invalid output.
+ * @property {(allegedValue: V) => V} doCoerce Check the kind of this value and
+ *   throw if it is not the expected kind.
+ * @property {() => V} doMakeEmpty Get the representation for the identity
+ *   element (often 0 or an empty array)
+ * @property {(value: V) => boolean} doIsEmpty Is the value the identity
+ *   element?
+ * @property {(left: V, right: V) => boolean} doIsGTE Is the left greater than
+ *   or equal to the right?
+ * @property {(left: V, right: V) => boolean} doIsEqual Does left equal right?
+ * @property {(left: V, right: V) => V} doAdd Return the left combined with the
+ *   right.
+ * @property {(left: V, right: V) => V} doSubtract Return what remains after
+ *   removing the right from the left. If something in the right was not in the
+ *   left, we throw an error.
  */
 
-/**
- * @typedef {bigint} NatValue
- */
+/** @typedef {bigint} NatValue */
 
-/**
- * @typedef {Array<Key>} SetValue
- */
+/** @typedef {Key[]} SetValue */

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -36,7 +36,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsdoc": "^40.1.0",
-    "eslint-plugin-prettier": "^5.0.0-alpha.2",
+    "eslint-plugin-prettier": "^5.0.0",
     "prettier": "^3.0.0"
   }
 }

--- a/packages/inter-protocol/scripts/deploy-contracts.js
+++ b/packages/inter-protocol/scripts/deploy-contracts.js
@@ -43,14 +43,24 @@ export default async (homeP, endowments) => {
   });
 
   console.log('getting installCache...');
-  /** @type {CopyMap<string, {installation: Installation, boardId: string, path?: string}>} */
+  /**
+   * @type {CopyMap<
+   *   string,
+   *   { installation: Installation; boardId: string; path?: string }
+   * >}
+   */
   const initial = await provideWhen(scratch, 'installCache', () =>
     makeCopyMap([]),
   );
   console.log('initially:', initial.payload.keys.length, 'entries');
 
   // ISSUE: getCopyMapEntries of CopyMap<K, V> loses K, V.
-  /** @type {Map<string, {installation: Installation, boardId: string, path?: string}>} */
+  /**
+   * @type {Map<
+   *   string,
+   *   { installation: Installation; boardId: string; path?: string }
+   * >}
+   */
   const working = new Map(getCopyMapEntries(initial));
 
   let added = 0;

--- a/packages/inter-protocol/scripts/init-core.js
+++ b/packages/inter-protocol/scripts/init-core.js
@@ -1,7 +1,8 @@
 /* global process */
 /**
- * @file can be run with `agoric deploy` after a chain is running (depends on chain state)
- * Only works with "local" chain and not sim-chain b/c it needs governance votes (n/a on sim-chain).
+ * @file can be run with `agoric deploy` after a chain is running (depends on
+ *   chain state) Only works with "local" chain and not sim-chain b/c it needs
+ *   governance votes (n/a on sim-chain).
  */
 import { makeHelpers } from '@agoric/deploy-script-support';
 import { objectMap } from '@agoric/internal';
@@ -53,9 +54,8 @@ const installKeyGroups = {
  * @param {(i: I) => R} opts.publishRef
  * @param {(m: string, b: string, opts?: any) => I} opts.install
  * @param {<T>(f: T) => T} [opts.wrapInstall]
- *
  * @param {object} [options]
- * @param {{ committeeName?: string, committeeSize?: number}} [options.econCommitteeOptions]
+ * @param {{ committeeName?: string; committeeSize?: number }} [options.econCommitteeOptions]
  */
 export const committeeProposalBuilder = async (
   { publishRef, install: install0, wrapInstall },
@@ -85,7 +85,6 @@ export const committeeProposalBuilder = async (
 /**
  * @template I
  * @template R
- *
  * @param {object} opts
  * @param {(i: I) => R} opts.publishRef
  * @param {(m: string, b: string, opts?: any) => I} opts.install
@@ -127,7 +126,7 @@ export const defaultProposalBuilder = async (
   options = {},
   { env = process.env } = {},
 ) => {
-  /** @param {string|undefined} s */
+  /** @param {string | undefined} s */
   const optBigInt = s => s && BigInt(s);
   const {
     vaultFactoryControllerAddress = env.VAULT_FACTORY_CONTROLLER_ADDR,

--- a/packages/inter-protocol/scripts/manual-price-feed.js
+++ b/packages/inter-protocol/scripts/manual-price-feed.js
@@ -8,24 +8,25 @@ import process from 'process';
  * After extracting the oracleAdmins to entries in home.scratch, you can use one
  * from the REPL like:
  *
- * lookup('agoricNames', 'oracleBrand', 'ATOM').then(brand => atom = brand)
- * -> [Object Alleged: ATOM brand]{}
- * lookup('agoricNames', 'oracleBrand', 'USD').then(brand => usd = brand)
- * -> [Object Alleged: USD brand]{}
- * pa = home.priceAuthority
- *  -> [Object Alleged: PriceAuthority]{}
- * qn = E(pa).makeQuoteNotifier({ value: 1n * 10n ** 6n, brand: atom }, usd)
- * -> [Object Alleged: QuoteNotifier]{}
- * oa = E(home.scratch).get("offerResult unknown#1652669688625")
- * -> [Object Alleged: OracleAdmin]{}
- * E(oa).pushResult('19.37')
- * E(qn).getUpdateSince()
+ * lookup('agoricNames', 'oracleBrand', 'ATOM').then(brand => atom = brand) ->
+ * [Object Alleged: ATOM brand]{} lookup('agoricNames', 'oracleBrand',
+ * 'USD').then(brand => usd = brand) -> [Object Alleged: USD brand]{} pa =
+ * home.priceAuthority -> [Object Alleged: PriceAuthority]{} qn =
+ * E(pa).makeQuoteNotifier({ value: 1n * 10n ** 6n, brand: atom }, usd) ->
+ * [Object Alleged: QuoteNotifier]{} oa = E(home.scratch).get("offerResult
+ * unknown#1652669688625") -> [Object Alleged: OracleAdmin]{}
+ * E(oa).pushResult('19.37') E(qn).getUpdateSince()
  *
- * @typedef {{ board: import('@agoric/vats').Board, chainTimerService, scratch, zoe }} Home
+ * @typedef {{
+ *   board: import('@agoric/vats').Board;
+ *   chainTimerService;
+ *   scratch;
+ *   zoe;
+ * }} Home
  * @param {Promise<Home>} homePromise
  * @param {object} root0
- * @param {(...path: string[]) => Promise<any>} root0.lookup
- * A promise for the references available from REPL home
+ * @param {(...path: string[]) => Promise<any>} root0.lookup A promise for the
+ *   references available from REPL home
  */
 export default async function priceAuthorityFromNotifier(
   homePromise,

--- a/packages/inter-protocol/scripts/manual-price-feed.js
+++ b/packages/inter-protocol/scripts/manual-price-feed.js
@@ -8,14 +8,18 @@ import process from 'process';
  * After extracting the oracleAdmins to entries in home.scratch, you can use one
  * from the REPL like:
  *
- * lookup('agoricNames', 'oracleBrand', 'ATOM').then(brand => atom = brand) ->
- * [Object Alleged: ATOM brand]{} lookup('agoricNames', 'oracleBrand',
- * 'USD').then(brand => usd = brand) -> [Object Alleged: USD brand]{} pa =
- * home.priceAuthority -> [Object Alleged: PriceAuthority]{} qn =
- * E(pa).makeQuoteNotifier({ value: 1n * 10n ** 6n, brand: atom }, usd) ->
- * [Object Alleged: QuoteNotifier]{} oa = E(home.scratch).get("offerResult
- * unknown#1652669688625") -> [Object Alleged: OracleAdmin]{}
- * E(oa).pushResult('19.37') E(qn).getUpdateSince()
+ *     lookup('agoricNames', 'oracleBrand', 'ATOM').then(brand => atom = brand)
+ *     -> [Object Alleged: ATOM brand]{}
+ *     lookup('agoricNames', 'oracleBrand', 'USD').then(brand => usd = brand)
+ *     -> [Object Alleged: USD brand]{}
+ *     pa = home.priceAuthority
+ *      -> [Object Alleged: PriceAuthority]{}
+ *     qn = E(pa).makeQuoteNotifier({ value: 1n * 10n ** 6n, brand: atom }, usd)
+ *     -> [Object Alleged: QuoteNotifier]{}
+ *     oa = E(home.scratch).get("offerResult unknown#1652669688625")
+ *     -> [Object Alleged: OracleAdmin]{}
+ *     E(oa).pushResult('19.37')
+ *     E(qn).getUpdateSince()
  *
  * @typedef {{
  *   board: import('@agoric/vats').Board;

--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -34,34 +34,38 @@ const DEFAULT_DECIMALS = 9;
 
 /**
  * @file The book represents the collateral-specific state of an ongoing
- * auction. It holds the book, the capturedPrice, and the collateralSeat that has
- * the allocation of assets for sale.
+ *   auction. It holds the book, the capturedPrice, and the collateralSeat that
+ *   has the allocation of assets for sale.
  *
- * The book contains orders for the collateral. It holds two kinds of
- * orders:
+ *   The book contains orders for the collateral. It holds two kinds of orders:
+ *
  *   - Prices express the bidding offer in terms of a Bid amount
- *   - ScaledBids express the offer in terms of a discount (or markup) from the
- *     most recent oracle price.
+ *   - ScaledBids express the offer in terms of a discount (or markup) from the most
+ *       recent oracle price.
  *
- * Offers can be added in three ways. 1) When the auction is not active, prices
- * are automatically added to the appropriate collection. When the auction is
- * active, 2) if a new offer is at or above the current price, it will be
- * settled immediately; 2) If the offer is below the current price, it will be
- * added in the appropriate place and settled when the price reaches that level.
+ *   Offers can be added in three ways. 1) When the auction is not active, prices
+ *   are automatically added to the appropriate collection. When the auction is
+ *   active, 2) if a new offer is at or above the current price, it will be
+ *   settled immediately; 2) If the offer is below the current price, it will be
+ *   added in the appropriate place and settled when the price reaches that
+ *   level.
  */
 
 const trace = makeTracer('AucBook', true);
 
 /**
  * @typedef {{
- *   maxBuy: Amount<'nat'>
+ *   maxBuy: Amount<'nat'>;
  * } & {
- *   exitAfterBuy?: boolean,
- * } & ({
- *   offerPrice: Ratio,
- * } | {
- *    offerBidScaling: Ratio,
- * })} OfferSpec
+ *   exitAfterBuy?: boolean;
+ * } & (
+ *     | {
+ *         offerPrice: Ratio;
+ *       }
+ *     | {
+ *         offerBidScaling: Ratio;
+ *       }
+ *   )} OfferSpec
  */
 /**
  * @param {Brand<'nat'>} bidBrand
@@ -88,17 +92,19 @@ export const makeOfferSpecShape = (bidBrand, collateralBrand) => {
 
 /**
  * @typedef {object} BookDataNotification
- *
- * @property {Ratio         | null}      startPrice identifies the priceAuthority and price
- * @property {Ratio         | null}      currentPriceLevel the price at the current auction tier
- * @property {Amount<'nat'> | null}      startProceedsGoal The proceeds the sellers were targeting to raise
- * @property {Amount<'nat'> | null}      remainingProceedsGoal The remainder of
- *     the proceeds the sellers were targeting to raise
- * @property {Amount<'nat'> | undefined} proceedsRaised The proceeds raised so far in the auction
- * @property {Amount<'nat'>}             startCollateral How much collateral was
- *    available for sale at the start. (If more is deposited later, it'll be
- *    added in.)
- * @property {Amount<'nat'> | null}      collateralAvailable The amount of collateral remaining
+ * @property {Ratio | null} startPrice identifies the priceAuthority and price
+ * @property {Ratio | null} currentPriceLevel the price at the current auction
+ *   tier
+ * @property {Amount<'nat'> | null} startProceedsGoal The proceeds the sellers
+ *   were targeting to raise
+ * @property {Amount<'nat'> | null} remainingProceedsGoal The remainder of the
+ *   proceeds the sellers were targeting to raise
+ * @property {Amount<'nat'> | undefined} proceedsRaised The proceeds raised so
+ *   far in the auction
+ * @property {Amount<'nat'>} startCollateral How much collateral was available
+ *   for sale at the start. (If more is deposited later, it'll be added in.)
+ * @property {Amount<'nat'> | null} collateralAvailable The amount of collateral
+ *   remaining
  */
 
 /**
@@ -231,8 +237,8 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
     {
       helper: {
         /**
-         * remove the key from the appropriate book, indicated by whether the price
-         * is defined.
+         * remove the key from the appropriate book, indicated by whether the
+         * price is defined.
          *
          * @param {string} key
          * @param {Ratio | undefined} price
@@ -247,8 +253,8 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
         },
 
         /**
-         * Update the entry in the appropriate book, indicated by whether the price
-         * is defined.
+         * Update the entry in the appropriate book, indicated by whether the
+         * price is defined.
          *
          * @param {string} key
          * @param {Amount} collateralSold
@@ -264,7 +270,8 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
         },
 
         /**
-         * Settle with seat. The caller is responsible for updating the book, if any.
+         * Settle with seat. The caller is responsible for updating the book, if
+         * any.
          *
          * @param {ZCFSeat} seat
          * @param {Amount<'nat'>} collateralWanted
@@ -341,15 +348,16 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
         },
 
         /**
-         *  Accept an offer expressed as a price. If the auction is active, attempt to
-         *  buy collateral. If any of the offer remains add it to the book.
+         * Accept an offer expressed as a price. If the auction is active,
+         * attempt to buy collateral. If any of the offer remains add it to the
+         * book.
          *
-         *  @param {ZCFSeat} seat
-         *  @param {Ratio} price
-         *  @param {Amount<'nat'>} maxBuy
-         *  @param {object} opts
-         *  @param {boolean} opts.trySettle
-         *  @param {boolean} [opts.exitAfterBuy]
+         * @param {ZCFSeat} seat
+         * @param {Ratio} price
+         * @param {Amount<'nat'>} maxBuy
+         * @param {object} opts
+         * @param {boolean} opts.trySettle
+         * @param {boolean} [opts.exitAfterBuy]
          */
         acceptPriceOffer(
           seat,
@@ -388,16 +396,16 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
         },
 
         /**
-         *  Accept an offer expressed as a discount (or markup). If the auction is
-         *  active, attempt to buy collateral. If any of the offer remains add it to
-         *  the book.
+         * Accept an offer expressed as a discount (or markup). If the auction
+         * is active, attempt to buy collateral. If any of the offer remains add
+         * it to the book.
          *
-         *  @param {ZCFSeat} seat
-         *  @param {Ratio} bidScaling
-         *  @param {Amount<'nat'>} maxBuy
-         *  @param {object} opts
-         *  @param {boolean} opts.trySettle
-         *  @param {boolean} [opts.exitAfterBuy]
+         * @param {ZCFSeat} seat
+         * @param {Ratio} bidScaling
+         * @param {Amount<'nat'>} maxBuy
+         * @param {object} opts
+         * @param {boolean} opts.trySettle
+         * @param {boolean} [opts.exitAfterBuy]
          */
         acceptScaledBidOffer(
           seat,
@@ -466,10 +474,10 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
          * @param {Amount<'nat'>} assetAmount
          * @param {ZCFSeat} sourceSeat
          * @param {Amount<'nat'>} [proceedsGoal] an amount that the depositor
-         *    would like to raise. The auction is requested to not sell more
-         *    collateral than required to raise that much. The auctioneer might
-         *    sell more if there is more than one supplier of collateral, and
-         *    they request inconsistent limits.
+         *   would like to raise. The auction is requested to not sell more
+         *   collateral than required to raise that much. The auctioneer might
+         *   sell more if there is more than one supplier of collateral, and
+         *   they request inconsistent limits.
          */
         addAssets(assetAmount, sourceSeat, proceedsGoal) {
           const { state, facets } = this;
@@ -754,7 +762,11 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
     },
   );
 
-  /** @type {(...args: Parameters<typeof makeAuctionBookKit>) => ReturnType<typeof makeAuctionBookKit>['self']} */
+  /**
+   * @type {(
+   *   ...args: Parameters<typeof makeAuctionBookKit>
+   * ) => ReturnType<typeof makeAuctionBookKit>['self']}
+   */
   const makeAuctionBook = (...args) => makeAuctionBookKit(...args).self;
   return makeAuctionBook;
 };

--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -43,11 +43,10 @@ const { add, multiply } = natSafeMath;
 const trace = makeTracer('Auction', true);
 
 /**
- * @file
- * In this file, 'Bid' is the name of the ERTP issuer used to purchase
- * collateral from various issuers. It's too confusing to also use Bid as a verb
- * or a description of amounts offered, so we've tried to find alternatives in
- * all those cases.
+ * @file In this file, 'Bid' is the name of the ERTP issuer used to purchase
+ *   collateral from various issuers. It's too confusing to also use Bid as a
+ *   verb or a description of amounts offered, so we've tried to find
+ *   alternatives in all those cases.
  */
 
 const MINIMUM_BID_GIVE = 1n;
@@ -66,18 +65,19 @@ const makeBPRatio = (rate, bidBrand, collateralBrand = bidBrand) =>
 /**
  * The auction sold some amount of collateral, and raised a certain amount of
  * Bid. The excess collateral was returned as `unsoldCollateral`. The Bid amount
- * collected from the auction participants is `proceeds`.
- * Return a set of transfers for atomicRearrange() that distribute
- * `unsoldCollateral` and `proceeds` proportionally to each seat's deposited
- * amount. Any uneven split should be allocated to the reserve.
+ * collected from the auction participants is `proceeds`. Return a set of
+ * transfers for atomicRearrange() that distribute `unsoldCollateral` and
+ * `proceeds` proportionally to each seat's deposited amount. Any uneven split
+ * should be allocated to the reserve.
  *
  * @param {Amount} unsoldCollateral
  * @param {Amount} proceeds
- * @param {{seat: ZCFSeat, amount: Amount<'nat'>, goal: Amount<'nat'>}[]} deposits
+ * @param {{ seat: ZCFSeat; amount: Amount<'nat'>; goal: Amount<'nat'> }[]} deposits
  * @param {ZCFSeat} collateralSeat
- * @param {ZCFSeat} bidHoldingSeat seat with the Bid allocation to be distributed
+ * @param {ZCFSeat} bidHoldingSeat seat with the Bid allocation to be
+ *   distributed
  * @param {string} collateralKeyword The Reserve will hold multiple collaterals,
- *      so they need distinct keywords
+ *   so they need distinct keywords
  * @param {ZCFSeat} reserveSeat
  * @param {Brand} brand
  */
@@ -131,41 +131,42 @@ const distributeProportionalShares = (
 /**
  * The auction sold some amount of collateral, and raised a certain amount of
  * Bid. The excess collateral was returned as `unsoldCollateral`. The Bid amount
- * collected from the auction participants is `proceeds`.
- * Return a set of transfers for atomicRearrange() that distribute
- * `unsoldCollateral` and `proceeds` proportionally to each seat's deposited
- * amount. Any uneven split should be allocated to the reserve.
+ * collected from the auction participants is `proceeds`. Return a set of
+ * transfers for atomicRearrange() that distribute `unsoldCollateral` and
+ * `proceeds` proportionally to each seat's deposited amount. Any uneven split
+ * should be allocated to the reserve.
  *
  * This function is exported for testability, and is not expected to be used
  * outside the contract below.
  *
  * Some or all of the depositors may have specified a goal amount.
- *  * A if none did, return collateral and Bid prorated to deposits.
- *  * B if proceeds < proceedsGoal everyone gets prorated amounts of both.
- *  * C if proceeds matches proceedsGoal, everyone gets the Bid they
- *    asked for, plus enough collateral to reach the same proportional payout.
- *    If any depositor's goal amount exceeded their share of the total,
- *    we'll fall back to the first approach.
- *  * D if proceeds > proceedsGoal && all depositors specified a limit,
- *    all depositors get their goal first, then we distribute the
- *    remainder (collateral and Bid) to get the same proportional payout.
- *  * E if proceeds > proceedsGoal && some depositors didn't specify a
- *    limit, depositors who did will get their goal first, then we distribute
- *    the remainder (collateral and Bid) to get the same proportional
- *    payout. If any depositor's goal amount exceeded their share of the
- *    total, we'll fall back as above.
- * Think of it this way: those who specified a limit want as much collateral
- * back as possible, consistent with raising a certain amount of Bid. Those
- * who didn't specify a limit are trying to sell collateral, and would prefer to
- * have as much as possible converted to Bid.
+ *
+ * - A if none did, return collateral and Bid prorated to deposits.
+ * - B if proceeds < proceedsGoal everyone gets prorated amounts of both.
+ * - C if proceeds matches proceedsGoal, everyone gets the Bid they asked for,
+ *   plus enough collateral to reach the same proportional payout. If any
+ *   depositor's goal amount exceeded their share of the total, we'll fall back
+ *   to the first approach.
+ * - D if proceeds > proceedsGoal && all depositors specified a limit, all
+ *   depositors get their goal first, then we distribute the remainder
+ *   (collateral and Bid) to get the same proportional payout.
+ * - E if proceeds > proceedsGoal && some depositors didn't specify a limit,
+ *   depositors who did will get their goal first, then we distribute the
+ *   remainder (collateral and Bid) to get the same proportional payout. If any
+ *   depositor's goal amount exceeded their share of the total, we'll fall back
+ *   as above. Think of it this way: those who specified a limit want as much
+ *   collateral back as possible, consistent with raising a certain amount of
+ *   Bid. Those who didn't specify a limit are trying to sell collateral, and
+ *   would prefer to have as much as possible converted to Bid.
  *
  * @param {Amount<'nat'>} unsoldCollateral
  * @param {Amount<'nat'>} proceeds
- * @param {{seat: ZCFSeat, amount: Amount<'nat'>, goal: Amount<'nat'>}[]} deposits
+ * @param {{ seat: ZCFSeat; amount: Amount<'nat'>; goal: Amount<'nat'> }[]} deposits
  * @param {ZCFSeat} collateralSeat
- * @param {ZCFSeat} bidHoldingSeat seat with the Bid allocation to be distributed
+ * @param {ZCFSeat} bidHoldingSeat seat with the Bid allocation to be
+ *   distributed
  * @param {string} collateralKeyword The Reserve will hold multiple collaterals,
- *      so they need distinct keywords
+ *   so they need distinct keywords
  * @param {ZCFSeat} reserveSeat
  * @param {Brand} brand
  */
@@ -378,15 +379,17 @@ export const distributeProportionalSharesWithLimits = (
 };
 
 /**
- * @param {ZCF<GovernanceTerms<typeof auctioneerParamTypes> & {
- *   timerService: import('@agoric/time/src/types').TimerService,
- *   reservePublicFacet: AssetReservePublicFacet,
- *   priceAuthority: PriceAuthority
- * }>} zcf
+ * @param {ZCF<
+ *   GovernanceTerms<typeof auctioneerParamTypes> & {
+ *     timerService: import('@agoric/time/src/types').TimerService;
+ *     reservePublicFacet: AssetReservePublicFacet;
+ *     priceAuthority: PriceAuthority;
+ *   }
+ * >} zcf
  * @param {{
- *   initialPoserInvitation: Invitation,
- *   storageNode: StorageNode,
- *   marshaller: Marshaller
+ *   initialPoserInvitation: Invitation;
+ *   storageNode: StorageNode;
+ *   marshaller: Marshaller;
  * }} privateArgs
  * @param {Baggage} baggage
  */
@@ -399,7 +402,12 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   /** @type {MapStore<Brand, import('./auctionBook.js').AuctionBook>} */
   const books = provideDurableMapStore(baggage, 'auctionBooks');
-  /** @type {MapStore<Brand, Array<{ seat: ZCFSeat, amount: Amount<'nat'>, goal: Amount<'nat'>}>>} */
+  /**
+   * @type {MapStore<
+   *   Brand,
+   *   { seat: ZCFSeat; amount: Amount<'nat'>; goal: Amount<'nat'> }[]
+   * >}
+   */
   const deposits = provideDurableMapStore(baggage, 'deposits');
   /** @type {MapStore<Brand, Keyword>} */
   const brandToKeyword = provideDurableMapStore(baggage, 'brandToKeyword');
@@ -427,9 +435,11 @@ export const start = async (zcf, privateArgs, baggage) => {
   });
   const scheduleKit = makeERecorderKit(
     E(privateArgs.storageNode).makeChildNode('schedule'),
-    /** @type {import('@agoric/zoe/src/contractSupport/recorder.js').TypedMatcher<import('./scheduler.js').ScheduleNotification>} */ (
-      M.any()
-    ),
+    /**
+     * @type {import('@agoric/zoe/src/contractSupport/recorder.js').TypedMatcher<
+     *     import('./scheduler.js').ScheduleNotification
+     *   >}
+     */ (M.any()),
   );
 
   /**
@@ -578,7 +588,7 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   /**
    * @param {ZCFSeat} zcfSeat
-   * @param {{ goal: Amount<'nat'>}} offerArgs
+   * @param {{ goal: Amount<'nat'> }} offerArgs
    */
   const depositOfferHandler = (zcfSeat, offerArgs) => {
     const goalMatcher = M.or(undefined, { goal: bidAmountShape });

--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -65,10 +65,11 @@ const makeBPRatio = (rate, bidBrand, collateralBrand = bidBrand) =>
 /**
  * The auction sold some amount of collateral, and raised a certain amount of
  * Bid. The excess collateral was returned as `unsoldCollateral`. The Bid amount
- * collected from the auction participants is `proceeds`. Return a set of
- * transfers for atomicRearrange() that distribute `unsoldCollateral` and
- * `proceeds` proportionally to each seat's deposited amount. Any uneven split
- * should be allocated to the reserve.
+ * collected from the auction participants is `proceeds`.
+ *
+ * Return a set of transfers for atomicRearrange() that distribute
+ * `unsoldCollateral` and `proceeds` proportionally to each seat's deposited
+ * amount. Any uneven split should be allocated to the reserve.
  *
  * @param {Amount} unsoldCollateral
  * @param {Amount} proceeds
@@ -131,10 +132,11 @@ const distributeProportionalShares = (
 /**
  * The auction sold some amount of collateral, and raised a certain amount of
  * Bid. The excess collateral was returned as `unsoldCollateral`. The Bid amount
- * collected from the auction participants is `proceeds`. Return a set of
- * transfers for atomicRearrange() that distribute `unsoldCollateral` and
- * `proceeds` proportionally to each seat's deposited amount. Any uneven split
- * should be allocated to the reserve.
+ * collected from the auction participants is `proceeds`.
+ *
+ * Return a set of transfers for atomicRearrange() that distribute
+ * `unsoldCollateral` and `proceeds` proportionally to each seat's deposited
+ * amount. Any uneven split should be allocated to the reserve.
  *
  * This function is exported for testability, and is not expected to be used
  * outside the contract below.

--- a/packages/inter-protocol/src/auction/offerBook.js
+++ b/packages/inter-protocol/src/auction/offerBook.js
@@ -25,12 +25,14 @@ const nextSequenceNumber = () => {
 
 /**
  * @typedef {{
- * seat: ZCFSeat,
- * wanted: Amount<'nat'>,
- * seqNum: NatValue,
- * received: Amount<'nat'>,
- * } &  {exitAfterBuy: boolean} & ({ bidScaling: Pattern, price: undefined } | { bidScaling: undefined, price: Ratio})
- * } BidderRecord
+ *   seat: ZCFSeat;
+ *   wanted: Amount<'nat'>;
+ *   seqNum: NatValue;
+ *   received: Amount<'nat'>;
+ * } & { exitAfterBuy: boolean } & (
+ *     | { bidScaling: Pattern; price: undefined }
+ *     | { bidScaling: undefined; price: Ratio }
+ *   )} BidderRecord
  */
 
 const ScaledBidBookStateShape = harden({
@@ -41,7 +43,8 @@ const ScaledBidBookStateShape = harden({
 
 /**
  * Prices in this book are expressed as percentage of the full oracle price
- * snapshot taken when the auction started. .4 is 60% off. 1.1 is 10% above par.
+ * snapshot taken when the auction started. .4 is 60% off. 1.1 is 10% above
+ * par.
  *
  * @param {Baggage} baggage
  */
@@ -51,7 +54,6 @@ export const prepareScaledBidBook = baggage =>
     'scaledBidBook',
     undefined,
     /**
-     *
      * @param {Pattern} bidScalingPattern
      * @param {Brand} collateralBrand
      */
@@ -134,8 +136,8 @@ const PriceBookStateShape = harden({
 });
 
 /**
- * Prices in this book are actual prices expressed in terms of bid amount
- * and collateral amount.
+ * Prices in this book are actual prices expressed in terms of bid amount and
+ * collateral amount.
  *
  * @param {Baggage} baggage
  */
@@ -145,7 +147,6 @@ export const preparePriceBook = baggage =>
     'priceBook',
     undefined,
     /**
-     *
      * @param {Pattern} priceRatioPattern
      * @param {Brand} collateralBrand
      */

--- a/packages/inter-protocol/src/auction/params.js
+++ b/packages/inter-protocol/src/auction/params.js
@@ -13,7 +13,7 @@ import { M } from '@agoric/store';
 export const InvitationShape = M.remotable('Invitation');
 
 /**
- * In seconds, how often to start an auction.  The auction will start at
+ * In seconds, how often to start an auction. The auction will start at
  * AUCTION_START_DELAY seconds after a multiple of START_FREQUENCY, with the
  * price at STARTING_RATE_BP. Every CLOCK_STEP, the price will be reduced by
  * DISCOUNT_STEP_BP, as long as the rate is at or above LOWEST_RATE_BP, or until
@@ -73,9 +73,7 @@ export const auctioneerParamTypes = harden({
  * @property {import('@agoric/time/src/types').TimerBrand} TimerBrand
  */
 
-/**
- * @param {AuctionParams} initial
- */
+/** @param {AuctionParams} initial */
 export const makeAuctioneerParams = ({
   ElectorateInvitationAmount,
   StartFrequency,
@@ -148,7 +146,7 @@ export const makeAuctioneerParamManager = (publisherKit, zcf, initial) => {
 harden(makeAuctioneerParamManager);
 
 /**
- * @param {{storageNode: ERef<StorageNode>, marshaller: ERef<Marshaller>}} caps
+ * @param {{ storageNode: ERef<StorageNode>; marshaller: ERef<Marshaller> }} caps
  * @param {ERef<Timer>} timer
  * @param {ERef<PriceAuthority>} priceAuthority
  * @param {ERef<AssetReservePublicFacet>} reservePublicFacet

--- a/packages/inter-protocol/src/auction/scheduleMath.js
+++ b/packages/inter-protocol/src/auction/scheduleMath.js
@@ -18,17 +18,18 @@ const subtract1 = relTime =>
 /**
  * The length of the auction has to be inferred from the governed params.
  *
- * 1. The auction starts by offering collateral at a `StartingRate` (e.g., 105%)
- *    of the market price at auction start, and continues until it reaches
- *    (or would exceed on its next step) LowestRate (e.g., 65%)
+ * 1. The auction starts by offering collateral at a `StartingRate` (e.g., 105%) of
+ *    the market price at auction start, and continues until it reaches (or
+ *    would exceed on its next step) LowestRate (e.g., 65%)
  * 2. The offer price changes every `ClockStep` seconds
- * 3. The offer price changes by `DiscountStep` amount (e.g., 5%) each step So
- *    it must run however many `ClockSteps` are required to get from
- *    `StartingRate` to `LowestRate` changing by `DiscountStep` each time.
+ * 3. The offer price changes by `DiscountStep` amount (e.g., 5%) each step So it
+ *    must run however many `ClockSteps` are required to get from `StartingRate`
+ *    to `LowestRate` changing by `DiscountStep` each time.
  *
- * Therefore, the duration is `(StartingRate - LowestRate) / DiscountStep * ClockStep`.
+ * Therefore, the duration is `(StartingRate - LowestRate) / DiscountStep *
+ * ClockStep`.
  *
- * Note that this is what's *scheduled*. More than one auction can be running
+ * Note that this is what's _scheduled_. More than one auction can be running
  * simultaneously, and some conditions can cause some of the auctions to stop
  * selling early (e.g. reaching their target debt to raise or selling all of
  * their collateral).
@@ -108,10 +109,10 @@ export const computeRoundTiming = (params, baseTime) => {
 harden(computeRoundTiming);
 
 /**
- * Calculate when the next descending step will start. If we're between
- * auctions (i.e. liveSchedule is undefined), or the last step of the current
- * auction has started, then it'll be nextSchedule.startTime. Otherwise, it's
- * the start of the step following the current step.
+ * Calculate when the next descending step will start. If we're between auctions
+ * (i.e. liveSchedule is undefined), or the last step of the current auction has
+ * started, then it'll be nextSchedule.startTime. Otherwise, it's the start of
+ * the step following the current step.
  *
  * @param {import('./scheduler.js').Schedule | null} liveSchedule
  * @param {import('./scheduler.js').Schedule | null} nextSchedule
@@ -143,7 +144,6 @@ export const nextDescendingStepTime = (liveSchedule, nextSchedule, now) => {
 harden(nextDescendingStepTime);
 
 /**
- *
  * @param {Timestamp} time
  * @param {import('./scheduler.js').Schedule} schedule
  * @returns {'before' | 'during' | 'endExactly' | 'after'}

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -20,21 +20,22 @@ const MAX_LATE_TICK = 300n;
 
 /**
  * @file The scheduler is presumed to be quiescent between auction rounds. Each
- * Auction round consists of a sequence of steps with decreasing prices. There
- * should always be a next schedule, but between rounds, liveSchedule is null.
+ *   Auction round consists of a sequence of steps with decreasing prices. There
+ *   should always be a next schedule, but between rounds, liveSchedule is
+ *   null.
  *
- * The lock period that the liquidators use might start before the previous
- * round has finished, so we need to schedule the next round each time an
- * auction starts. This means if the scheduling parameters change, it'll be a
- * full cycle before we switch. Otherwise, the vaults wouldn't know when to
- * start their lock period. If the lock period for the next auction hasn't
- * started when each aucion ends, we recalculate it, in case the parameters have
- * changed.
+ *   The lock period that the liquidators use might start before the previous
+ *   round has finished, so we need to schedule the next round each time an
+ *   auction starts. This means if the scheduling parameters change, it'll be a
+ *   full cycle before we switch. Otherwise, the vaults wouldn't know when to
+ *   start their lock period. If the lock period for the next auction hasn't
+ *   started when each aucion ends, we recalculate it, in case the parameters
+ *   have changed.
  *
- * If the clock skips forward (because of a chain halt, for instance), the
- * scheduler will try to cleanly and quickly finish any round already in
- * progress. It would take additional work on the manual timer to test this
- * thoroughly.
+ *   If the clock skips forward (because of a chain halt, for instance), the
+ *   scheduler will try to cleanly and quickly finish any round already in
+ *   progress. It would take additional work on the manual timer to test this
+ *   thoroughly.
  */
 
 const makeCancelToken = makeCancelTokenMaker('scheduler');
@@ -49,12 +50,11 @@ const makeCancelToken = makeCancelTokenMaker('scheduler');
 
 /**
  * @typedef {object} ScheduleNotification
- *
- * @property {Timestamp | null} activeStartTime start time of current
- *    auction if auction is active
+ * @property {Timestamp | null} activeStartTime start time of current auction if
+ *   auction is active
  * @property {Timestamp | null} nextStartTime start time of next auction
- * @property {Timestamp | null} nextDescendingStepTime when the next descending step
- *    will take place
+ * @property {Timestamp | null} nextDescendingStepTime when the next descending
+ *   step will take place
  */
 
 const safelyComputeRoundTiming = (params, baseTime) => {
@@ -92,7 +92,7 @@ export const makeScheduler = async (
    */
   let liveSchedule = null;
 
-  /** @returns {Promise<{ now: Timestamp, nextSchedule: Schedule | null }>} */
+  /** @returns {Promise<{ now: Timestamp; nextSchedule: Schedule | null }>} */
   const initializeNextSchedule = async () => {
     return E.when(
       // XXX manualTimer returns a bigint, not a timeRecord.
@@ -114,7 +114,7 @@ export const makeScheduler = async (
 
   const stepCancelToken = makeCancelToken();
 
-  /** @type {typeof AuctionState[keyof typeof AuctionState]} */
+  /** @type {(typeof AuctionState)[keyof typeof AuctionState]} */
   let auctionState = AuctionState.WAITING;
 
   /**

--- a/packages/inter-protocol/src/auction/sortedOffers.js
+++ b/packages/inter-protocol/src/auction/sortedOffers.js
@@ -13,12 +13,13 @@ const { Fail } = assert;
 
 /**
  * @file we use a floating point representation of the price or rate as the
- * first part of the key in the store. The second part is the sequence number of
- * the bid, but it doesn't matter for sorting. When we retrieve multiple bids,
- * it's only by bid value, so we don't care how the sequence numbers sort.
+ *   first part of the key in the store. The second part is the sequence number
+ *   of the bid, but it doesn't matter for sorting. When we retrieve multiple
+ *   bids, it's only by bid value, so we don't care how the sequence numbers
+ *   sort.
  *
- * We take advantage of the fact that encodeData takes a passable and turns it
- * into a sort key. Arrays of passable data sort like composite keys.
+ *   We take advantage of the fact that encodeData takes a passable and turns it
+ *   into a sort key. Arrays of passable data sort like composite keys.
  */
 
 /**
@@ -39,7 +40,7 @@ export const toPartialOfferKey = offerPrice => {
  * @param {Ratio} offerPrice IST/collateral
  * @param {bigint} sequenceNumber
  * @returns {string} lexically sortable string in which highest price is first,
- *    ties will be broken by sequenceNumber of offer
+ *   ties will be broken by sequenceNumber of offer
  */
 export const toPriceOfferKey = (offerPrice, sequenceNumber) => {
   mustMatch(offerPrice, RatioShape);
@@ -107,7 +108,7 @@ export const toBidScalingComparator = rate => {
  * @param {Ratio} rate discount/markup rate expressed as a ratio IST/IST
  * @param {bigint} sequenceNumber
  * @returns {string} lexically sortable string in which highest price is first,
- *    ties will be broken by sequenceNumber of offer
+ *   ties will be broken by sequenceNumber of offer
  */
 export const toScaledRateOfferKey = (rate, sequenceNumber) => {
   mustMatch(rate, RatioShape);

--- a/packages/inter-protocol/src/auction/util.js
+++ b/packages/inter-protocol/src/auction/util.js
@@ -10,7 +10,7 @@ import { Far } from '@endo/marshal';
 /**
  * Constants for Auction State.
  *
- * @type {{ ACTIVE: 'active', WAITING: 'waiting' }}
+ * @type {{ ACTIVE: 'active'; WAITING: 'waiting' }}
  */
 export const AuctionState = {
   ACTIVE: 'active',
@@ -18,8 +18,8 @@ export const AuctionState = {
 };
 
 /**
- * @param {{ brand: Brand, value: Pattern }} numeratorAmountShape
- * @param {{ brand: Brand, value: Pattern }} denominatorAmountShape
+ * @param {{ brand: Brand; value: Pattern }} numeratorAmountShape
+ * @param {{ brand: Brand; value: Pattern }} denominatorAmountShape
  */
 export const makeBrandedRatioPattern = (
   numeratorAmountShape,
@@ -36,7 +36,7 @@ export const makeBrandedRatioPattern = (
  * @param {Ratio} currentPrice
  * @param {Ratio} oraclePrice
  * @returns {boolean} TRUE iff the discount(/markup) applied to the price is
- *          higher than the quote.
+ *   higher than the quote.
  */
 export const isScaledBidPriceHigher = (bidScaling, currentPrice, oraclePrice) =>
   ratioGTE(multiplyRatios(oraclePrice, bidScaling), currentPrice);

--- a/packages/inter-protocol/src/clientSupport.js
+++ b/packages/inter-protocol/src/clientSupport.js
@@ -15,8 +15,16 @@ const scaleDecimals = num => BigInt(num * Number(COSMOS_UNIT));
 /**
  * Give/want
  *
- * @param {Pick<import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes, 'brand'>} agoricNames
- * @param {{ giveMinted?: number, wantMinted?: number } | { collateralBrandKey: string, giveCollateral?: number, wantCollateral?: number }} opts
+ * @param {Pick<
+ *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes,
+ *   'brand'
+ * >} agoricNames
+ * @param {| { giveMinted?: number; wantMinted?: number }
+ *   | {
+ *       collateralBrandKey: string;
+ *       giveCollateral?: number;
+ *       wantCollateral?: number;
+ *     }} opts
  * @returns {Proposal}
  */
 const makeVaultProposal = ({ brand }, opts) => {
@@ -54,8 +62,16 @@ const makeVaultProposal = ({ brand }, opts) => {
 };
 
 /**
- * @param {Pick<import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes, 'brand'>} agoricNames
- * @param {{ offerId: string, wantMinted: number, giveCollateral: number, collateralBrandKey: string }} opts
+ * @param {Pick<
+ *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes,
+ *   'brand'
+ * >} agoricNames
+ * @param {{
+ *   offerId: string;
+ *   wantMinted: number;
+ *   giveCollateral: number;
+ *   collateralBrandKey: string;
+ * }} opts
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
  */
 const makeOpenOffer = ({ brand }, opts) => {
@@ -82,8 +98,18 @@ const makeOpenOffer = ({ brand }, opts) => {
 };
 
 /**
- * @param {Pick<import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes, 'brand'>} agoricNames
- * @param {{ offerId: string, collateralBrandKey?: string, giveCollateral?: number, wantCollateral?: number, giveMinted?: number, wantMinted?: number }} opts
+ * @param {Pick<
+ *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes,
+ *   'brand'
+ * >} agoricNames
+ * @param {{
+ *   offerId: string;
+ *   collateralBrandKey?: string;
+ *   giveCollateral?: number;
+ *   wantCollateral?: number;
+ *   giveMinted?: number;
+ *   wantMinted?: number;
+ * }} opts
  * @param {string} previousOffer
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
  */
@@ -105,8 +131,15 @@ const makeAdjustOffer = ({ brand }, opts, previousOffer) => {
 };
 
 /**
- * @param {Pick<import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes, 'brand'>} agoricNames
- * @param {{ offerId: string, collateralBrandKey?: string, giveMinted: number }} opts
+ * @param {Pick<
+ *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes,
+ *   'brand'
+ * >} agoricNames
+ * @param {{
+ *   offerId: string;
+ *   collateralBrandKey?: string;
+ *   giveMinted: number;
+ * }} opts
  * @param {string} previousOffer
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
  */
@@ -126,7 +159,9 @@ const makeCloseOffer = ({ brand }, opts, previousOffer) => {
 
 /**
  * @param {string} vaultId
- * @param {Promise<import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord>} currentP
+ * @param {Promise<
+ *   import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord
+ * >} currentP
  * @returns {Promise<string>} offer id in which the vault was made
  */
 export const lookupOfferIdForVault = async (vaultId, currentP) => {
@@ -141,8 +176,12 @@ export const lookupOfferIdForVault = async (vaultId, currentP) => {
 };
 
 /**
- * @param {Record<string, import('@agoric/internal/src/marshal.js').BoardRemote>} brands
- * @param {({ wantMinted: number, giveMinted?: undefined } | { giveMinted: number, wantMinted?: undefined })} opts
+ * @param {Record<
+ *   string,
+ *   import('@agoric/internal/src/marshal.js').BoardRemote
+ * >} brands
+ * @param {| { wantMinted: number; giveMinted?: undefined }
+ *   | { giveMinted: number; wantMinted?: undefined }} opts
  * @param {number} [fee]
  * @param {string} [anchor]
  */
@@ -170,10 +209,15 @@ const makePsmProposal = (brands, opts, fee = 0, anchor = 'AUSD') => {
 };
 
 /**
- * @param {Pick<import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes, 'brand'>} agoricNames
+ * @param {Pick<
+ *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes,
+ *   'brand'
+ * >} agoricNames
  * @param {Instance} instance
- * @param {{ offerId: string, feePct?: number, pair: [string, string] } &
- *         ({ wantMinted: number } | { giveMinted: number })} opts
+ * @param {{ offerId: string; feePct?: number; pair: [string, string] } & (
+ *   | { wantMinted: number }
+ *   | { giveMinted: number }
+ * )} opts
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
  */
 const makePsmSwapOffer = ({ brand }, instance, opts) => {
@@ -205,7 +249,10 @@ const makePsmSwapOffer = ({ brand }, instance, opts) => {
 };
 
 /**
- * @param {Pick<import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes, 'brand' | 'vbankAsset'>} agoricNames
+ * @param {Pick<
+ *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes,
+ *   'brand' | 'vbankAsset'
+ * >} agoricNames
  * @param {(msg: string) => Error} makeError error constructor
  * @returns {(a: string) => Amount<'nat'>}
  */
@@ -243,17 +290,23 @@ export const makeParseAmount =
   };
 
 /**
- * @param {Pick<import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes, 'brand' | 'vbankAsset'>} agoricNames
+ * @param {Pick<
+ *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes,
+ *   'brand' | 'vbankAsset'
+ * >} agoricNames
  * @param {{
- *   offerId: string,
- *   give: string,
- *   maxBuy: string,
- *   wantMinimum?: string,
- * } & ({
- *   price: number,
- * } | {
- *   discount: number,  // -1 to 1. e.g. 0.10 for 10% discount, -0.05 for 5% markup
- * })} opts
+ *   offerId: string;
+ *   give: string;
+ *   maxBuy: string;
+ *   wantMinimum?: string;
+ * } & (
+ *   | {
+ *       price: number;
+ *     }
+ *   | {
+ *       discount: number; // -1 to 1. e.g. 0.10 for 10% discount, -0.05 for 5% markup
+ *     }
+ * )} opts
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
  */
 const makeBidOffer = (agoricNames, opts) => {
@@ -312,11 +365,14 @@ const makeBidOffer = (agoricNames, opts) => {
 };
 
 /**
- * @param {Pick<import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes, 'brand'>} agoricNames
+ * @param {Pick<
+ *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes,
+ *   'brand'
+ * >} agoricNames
  * @param {{
- *   offerId: string,
- *   give: number,
- *   collateralBrandKey: string,
+ *   offerId: string;
+ *   give: number;
+ *   collateralBrandKey: string;
  * }} opts
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
  */
@@ -344,12 +400,11 @@ const makeAddCollateralOffer = ({ brand }, opts) => {
 };
 
 /**
- *
  * @param {unknown} _agoricNames
  * @param {{
- *   offerId: string,
- *   roundId?: bigint,
- *   unitPrice: bigint,
+ *   offerId: string;
+ *   roundId?: bigint;
+ *   unitPrice: bigint;
  * }} opts
  * @param {string} previousOffer
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
@@ -370,7 +425,10 @@ const makePushPriceOffer = (_agoricNames, opts, previousOffer) => {
 };
 
 /**
- * @satisfies {Record<string, Record<string, import('@agoric/smart-wallet/src/types.js').OfferMaker>>}
+ * @satisfies {Record<
+ *   string,
+ *   Record<string, import('@agoric/smart-wallet/src/types.js').OfferMaker>
+ * >}
  */
 export const Offers = {
   auction: {

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -13,11 +13,11 @@ export const ratioPattern = harden({
 });
 
 /**
- * Apply a delta to the `base` Amount, where the delta is represented as
- * an amount to gain and an amount to lose. Typically one of those will
- * be empty because gain/loss comes from the give/want for a specific asset
- * on a proposal. We use two Amounts because an Amount cannot represent
- * a negative number (so we use a "loss" that will be subtracted).
+ * Apply a delta to the `base` Amount, where the delta is represented as an
+ * amount to gain and an amount to lose. Typically one of those will be empty
+ * because gain/loss comes from the give/want for a specific asset on a
+ * proposal. We use two Amounts because an Amount cannot represent a negative
+ * number (so we use a "loss" that will be subtracted).
  *
  * @template {AssetKind} K
  * @param {Amount<K>} base

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -13,12 +13,10 @@ import {
 import { E } from '@endo/far';
 
 /**
- * @file
- *
- * This contract makes it possible for those who govern contracts to call for
- * votes on changes. A more complete implementation would validate parameters,
- * constrain deadlines and possibly split the ability to call for votes into
- * separate capabilities for finer grain encapsulation.
+ * @file This contract makes it possible for those who govern contracts to call
+ *   for votes on changes. A more complete implementation would validate
+ *   parameters, constrain deadlines and possibly split the ability to call for
+ *   votes into separate capabilities for finer grain encapsulation.
  */
 
 export const INVITATION_MAKERS_DESC = 'charter member invitation';
@@ -28,7 +26,7 @@ export const INVITATION_MAKERS_DESC = 'charter member invitation';
  * @property {bigint} deadline
  * @property {Instance} instance
  * @property {Record<string, unknown>} params
- * @property {{paramPath: { key: string }}} [path]
+ * @property {{ paramPath: { key: string } }} [path]
  */
 const ParamChangesOfferArgsShape = M.splitRecord(
   {
@@ -41,15 +39,13 @@ const ParamChangesOfferArgsShape = M.splitRecord(
   },
 );
 
-/**
- * A pattern for Zoe to check custom terms before `start()`ing the contract.
- */
+/** A pattern for Zoe to check custom terms before `start()`ing the contract. */
 export const customTermsShape = harden({
   binaryVoteCounterInstallation: InstallationShape,
 });
 
 /**
- * @param {ZCF<{binaryVoteCounterInstallation: Installation}>} zcf
+ * @param {ZCF<{ binaryVoteCounterInstallation: Installation }>} zcf
  * @param {undefined} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */

--- a/packages/inter-protocol/src/feeDistributor.js
+++ b/packages/inter-protocol/src/feeDistributor.js
@@ -9,9 +9,7 @@ import { KeywordShape } from '@agoric/zoe/src/typeGuards.js';
 
 const KeywordSharesShape = M.recordOf(KeywordShape, M.nat());
 
-/**
- * A pattern for Zoe to check custom terms before `start()`ing the contract.
- */
+/** A pattern for Zoe to check custom terms before `start()`ing the contract. */
 export const customTermsShape = harden({
   keywordShares: KeywordSharesShape,
   timerService: M.eref(M.remotable('TimerService')),
@@ -20,12 +18,12 @@ export const customTermsShape = harden({
 
 /**
  * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime
+ *
  * @typedef {import('@agoric/time/src/types').TimerService} TimerService
  */
 
 /**
  * @typedef {object} FeeCollector
- *
  * @property {() => ERef<Payment<'nat'>>} collectFees
  */
 
@@ -65,10 +63,12 @@ export const makeContractFeeCollector = (zoe, creatorFacet) => {
  * for fees that have been collected to date and send that payment to the
  * depositFacet.
  *
- * @param {() => Promise<unknown>} schedulePayments - distribute to the destinations
- * @param {ERef<TimerService>} timerService - timer that is used to schedule collections
+ * @param {() => Promise<unknown>} schedulePayments - distribute to the
+ *   destinations
+ * @param {ERef<TimerService>} timerService - timer that is used to schedule
+ *   collections
  * @param {RelativeTime} [collectionInterval] - how often to collect fees in the
- * `timerService` unit
+ *   `timerService` unit
  */
 export const startDistributing = (
   schedulePayments,
@@ -99,8 +99,9 @@ export const startDistributing = (
 };
 
 /**
- * @typedef {{ pushPayment: (payment: Payment, issuer: ERef<Issuer>) => Promise<Amount>}} FeeDestination
- *
+ * @typedef {{
+ *   pushPayment: (payment: Payment, issuer: ERef<Issuer>) => Promise<Amount>;
+ * }} FeeDestination
  * @param {Record<Keyword, ERef<FeeDestination>>} [destinations]
  * @param {Record<Keyword, NatValue>} [keywordShares]
  */
@@ -161,17 +162,16 @@ export const sharePayment = async (
     .filter(([_, amt]) => !AmountMath.isEmpty(amt));
 
   /**
-   * If the `sharedPayment[i]` payments that are sent to the fee
-   * `destination` with `pushPayment` never arrive, or never get deposited
-   * (or otherwise used up), then they remain in the recovery set of the
-   * `recoveryPurse`. The purpose of this, and of recovery sets in general,
-   * is to be able, in emergencies, to recover the assets of payments in flight
-   * that seem to be stuck. This is much like cancelling a check that may still
-   * be undeposited.
+   * If the `sharedPayment[i]` payments that are sent to the fee `destination`
+   * with `pushPayment` never arrive, or never get deposited (or otherwise used
+   * up), then they remain in the recovery set of the `recoveryPurse`. The
+   * purpose of this, and of recovery sets in general, is to be able, in
+   * emergencies, to recover the assets of payments in flight that seem to be
+   * stuck. This is much like cancelling a check that may still be undeposited.
    *
    * TODO: However, for this to be possible, the `recoveryPurse` holding that
-   * recovery set must remain accessible to someone that should legitimately
-   * be able to recover those payments. But this `recoveryPurse` is currently
+   * recovery set must remain accessible to someone that should legitimately be
+   * able to recover those payments. But this `recoveryPurse` is currently
    * dropped on the floor instead.
    */
   const recoveryPurse = E(issuer).makeEmptyPurse();
@@ -193,7 +193,11 @@ export const sharePayment = async (
 
 /**
  * @param {ERef<Issuer<'nat'>>} feeIssuer
- * @param {{ keywordShares: Record<Keyword, NatValue>, timerService: ERef<TimerService>, collectionInterval: RelativeTime}} terms
+ * @param {{
+ *   keywordShares: Record<Keyword, NatValue>;
+ *   timerService: ERef<TimerService>;
+ *   collectionInterval: RelativeTime;
+ * }} terms
  */
 export const makeFeeDistributor = (feeIssuer, terms) => {
   const { timerService, collectionInterval } = terms;
@@ -261,9 +265,7 @@ export const makeFeeDistributor = (feeIssuer, terms) => {
       return periodicCollector;
     },
 
-    /**
-     * @param {import('@endo/far').EOnly<DepositFacet>} depositFacet
-     */
+    /** @param {import('@endo/far').EOnly<DepositFacet>} depositFacet */
     makeDepositFacetDestination: depositFacet => {
       return Far(`DepositFacetDestination`, {
         pushPayment: async (payment, _issuer) => {
@@ -315,9 +317,7 @@ export const makeFeeDistributor = (feeIssuer, terms) => {
       });
     },
 
-    /**
-     * @param {Record<Keyword, ERef<FeeDestination>>} newDestinations
-     */
+    /** @param {Record<Keyword, ERef<FeeDestination>>} newDestinations */
     setDestinations: async newDestinations => {
       destinations = newDestinations;
       shareConfig = makeShareConfig(destinations, keywordShares);
@@ -344,9 +344,7 @@ export const makeFeeDistributor = (feeIssuer, terms) => {
 /** @typedef {ReturnType<typeof makeFeeDistributor>['creatorFacet']} FeeDistributorCreatorFacet */
 /** @typedef {ReturnType<typeof makeFeeDistributor>['publicFacet']} FeeDistributorPublicFacet */
 
-/**
- * @param {ZCF<Parameters<typeof makeFeeDistributor>[1]>} zcf
- */
+/** @param {ZCF<Parameters<typeof makeFeeDistributor>[1]>} zcf */
 export const start = async zcf => {
   const feeIssuer = E(zcf.getZoeService()).getFeeIssuer();
   return makeFeeDistributor(feeIssuer, zcf.getTerms());

--- a/packages/inter-protocol/src/interest.js
+++ b/packages/inter-protocol/src/interest.js
@@ -12,6 +12,7 @@ import { TimeMath } from '@agoric/time';
 
 /**
  * @typedef {import('@agoric/time/src/types').Timestamp} Timestamp
+ *
  * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime
  */
 
@@ -20,9 +21,7 @@ const BASIS_POINTS = 10000;
 // single digit APR is less than a basis point per day.
 const LARGE_DENOMINATOR = BASIS_POINTS * BASIS_POINTS;
 
-/**
- * Number chosen from 6 digits for a basis point, doubled for multiplication.
- */
+/** Number chosen from 6 digits for a basis point, doubled for multiplication. */
 const COMPOUNDED_INTEREST_DENOMINATOR = 10n ** 20n;
 
 /**
@@ -144,23 +143,31 @@ const validatedBrand = (mint, debt) => {
 };
 
 /**
- * Charge interest accrued between `latestStabilityFeeUpdate` and `accruedUntil`.
+ * Charge interest accrued between `latestStabilityFeeUpdate` and
+ * `accruedUntil`.
  *
  * @param {{
- *  mint: ZCFMint<'nat'>,
- *  mintAndTransferWithFee: MintAndTransfer,
- *  poolIncrementSeat: ZCFSeat,
- *  seatAllocationKeyword: Keyword }} powers
+ *   mint: ZCFMint<'nat'>;
+ *   mintAndTransferWithFee: MintAndTransfer;
+ *   poolIncrementSeat: ZCFSeat;
+ *   seatAllocationKeyword: Keyword;
+ * }} powers
  * @param {{
- *  stabilityFee: Ratio,
- *  chargingPeriod: RelativeTime,
- *  recordingPeriod: RelativeTime}} params
+ *   stabilityFee: Ratio;
+ *   chargingPeriod: RelativeTime;
+ *   recordingPeriod: RelativeTime;
+ * }} params
  * @param {{
- *  latestStabilityFeeUpdate: Timestamp,
- *  compoundedStabilityFee: Ratio,
- *  totalDebt: Amount<'nat'>}} prior
+ *   latestStabilityFeeUpdate: Timestamp;
+ *   compoundedStabilityFee: Ratio;
+ *   totalDebt: Amount<'nat'>;
+ * }} prior
  * @param {Timestamp} accruedUntil
- * @returns {{compoundedStabilityFee: Ratio, latestStabilityFeeUpdate: Timestamp, totalDebt: Amount<'nat'> }}
+ * @returns {{
+ *   compoundedStabilityFee: Ratio;
+ *   latestStabilityFeeUpdate: Timestamp;
+ *   totalDebt: Amount<'nat'>;
+ * }}
  */
 export const chargeInterest = (powers, params, prior, accruedUntil) => {
   const brand = validatedBrand(powers.mint, prior.totalDebt);

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -18,6 +18,7 @@ import { prepareFluxAggregatorKit } from './fluxAggregatorKit.js';
 const trace = makeTracer('FluxAgg', false);
 /**
  * @typedef {import('@agoric/vat-data').Baggage} Baggage
+ *
  * @typedef {import('@agoric/time/src/types').TimerService} TimerService
  */
 
@@ -39,23 +40,25 @@ export const privateArgsShape = M.splitRecord(
 );
 
 /**
- * PriceAuthority for their median. Unlike the simpler `priceAggregator.js`, this approximates
- * the *Node Operator Aggregation* logic of [Chainlink price
+ * PriceAuthority for their median. Unlike the simpler `priceAggregator.js`,
+ * this approximates the _Node Operator Aggregation_ logic of [Chainlink price
  * feeds](https://blog.chain.link/levels-of-data-aggregation-in-chainlink-price-feeds/).
  *
- * @param {ZCF<import('./fluxAggregatorKit.js').ChainlinkConfig & {
- * timer: TimerService,
- * brandIn: Brand<'nat'>,
- * brandOut: Brand<'nat'>,
- * description: string,
- * unitAmountIn?: Amount<'nat'>,
- * }>} zcf
+ * @param {ZCF<
+ *   import('./fluxAggregatorKit.js').ChainlinkConfig & {
+ *     timer: TimerService;
+ *     brandIn: Brand<'nat'>;
+ *     brandOut: Brand<'nat'>;
+ *     description: string;
+ *     unitAmountIn?: Amount<'nat'>;
+ *   }
+ * >} zcf
  * @param {{
- * highPrioritySendersManager?: import('@agoric/internal/src/priority-senders.js').PrioritySendersManager,
- * initialPoserInvitation: Invitation,
- * marshaller: ERef<Marshaller>,
- * namesByAddressAdmin: ERef<import('@agoric/vats').NameAdmin>,
- * storageNode: StorageNode,
+ *   highPrioritySendersManager?: import('@agoric/internal/src/priority-senders.js').PrioritySendersManager;
+ *   initialPoserInvitation: Invitation;
+ *   marshaller: ERef<Marshaller>;
+ *   namesByAddressAdmin: ERef<import('@agoric/vats').NameAdmin>;
+ *   storageNode: StorageNode;
  * }} privateArgs
  * @param {Baggage} baggage
  */
@@ -151,20 +154,22 @@ export const prepare = async (zcf, privateArgs, baggage) => {
 
   const governedApis = {
     /**
-     * Add the specified oracles. May partially fail, such that some oracles are added and others aren't.
+     * Add the specified oracles. May partially fail, such that some oracles are
+     * added and others aren't.
      *
      * @param {string[]} addrs
-     * @returns {Promise<Array<PromiseSettledResult<string>>>}
+     * @returns {Promise<PromiseSettledResult<string>[]>}
      */
     addOracles: addrs => {
       return Promise.allSettled(addrs.map(addOracle));
     },
     /**
-     * Remove the specified oracles. May partially fail, such that some oracles are removed and others aren't.
-     * If the oracle was never part of the set that's a PromiseRejectedResult
+     * Remove the specified oracles. May partially fail, such that some oracles
+     * are removed and others aren't. If the oracle was never part of the set
+     * that's a PromiseRejectedResult
      *
      * @param {string[]} addrs
-     * @returns {Promise<Array<PromiseSettledResult<string>>>}
+     * @returns {Promise<PromiseSettledResult<string>[]>}
      */
     removeOracles: addrs => {
       return Promise.allSettled(addrs.map(removeOracle));

--- a/packages/inter-protocol/src/price/fluxAggregatorKit.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorKit.js
@@ -1,7 +1,7 @@
 /**
- * @file
- * Adaptation of Chainlink algorithm to the Agoric platform.
- * Modeled on https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/FluxAggregator.sol (version?)
+ * @file Adaptation of Chainlink algorithm to the Agoric platform. Modeled on
+ *   https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/FluxAggregator.sol
+ *   (version?)
  */
 import { AmountMath } from '@agoric/ertp';
 import { assertAllDefined, makeTracer } from '@agoric/internal';
@@ -24,10 +24,14 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
 
 /**
  * @typedef {import('@agoric/vat-data').Baggage} Baggage
+ *
  * @typedef {import('@agoric/time/src/types').Timestamp} Timestamp
- * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime
- * // TODO: use RelativeTime, not RelativeTimeValue
+ *
+ * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime //
+ *   TODO: use RelativeTime, not RelativeTimeValue
+ *
  * @typedef {import('@agoric/time/src/types').RelativeTimeValue} RelativeTimeValue
+ *
  * @typedef {import('@agoric/time/src/types').TimerService} TimerService
  */
 
@@ -49,30 +53,35 @@ const priceDescriptionFromQuote = quote => quote.quoteAmount.value[0];
  * @typedef {object} ChainlinkConfig
  * @property {number} maxSubmissionCount
  * @property {number} minSubmissionCount
- * @property {bigint} restartDelay the number of rounds an Oracle has to wait before they can initiate a round
- * @property {number} minSubmissionValue an immutable check for a lower bound of what
- * submission values are accepted from an oracle
- * @property {number} maxSubmissionValue an immutable check for an upper bound of what
- * submission values are accepted from an oracle
- * @property {number} timeout the number of seconds after the previous round that
- * allowed to lapse before allowing an oracle to skip an unfinished round
+ * @property {bigint} restartDelay the number of rounds an Oracle has to wait
+ *   before they can initiate a round
+ * @property {number} minSubmissionValue an immutable check for a lower bound of
+ *   what submission values are accepted from an oracle
+ * @property {number} maxSubmissionValue an immutable check for an upper bound
+ *   of what submission values are accepted from an oracle
+ * @property {number} timeout the number of seconds after the previous round
+ *   that allowed to lapse before allowing an oracle to skip an unfinished
+ *   round
  */
 
 /**
- * Returns a maker for a single durable FluxAggregatorKit, closed over the prepare() arguments.
+ * Returns a maker for a single durable FluxAggregatorKit, closed over the
+ * prepare() arguments.
  *
  * The kit aggregates price inputs to produce a PriceAuthority. Unlike the
- * simpler `priceAggregator.js`, this approximates the *Node Operator
- * Aggregation* logic of [Chainlink price
+ * simpler `priceAggregator.js`, this approximates the _Node Operator
+ * Aggregation_ logic of [Chainlink price
  * feeds](https://blog.chain.link/levels-of-data-aggregation-in-chainlink-price-feeds/).
  *
  * @param {Baggage} baggage
- * @param {ZCF<ChainlinkConfig & {
- * timer: TimerService,
- * brandIn: Brand<'nat'>,
- * brandOut: Brand<'nat'>,
- * unitAmountIn?: Amount<'nat'>,
- * }>} zcf
+ * @param {ZCF<
+ *   ChainlinkConfig & {
+ *     timer: TimerService;
+ *     brandIn: Brand<'nat'>;
+ *     brandOut: Brand<'nat'>;
+ *     unitAmountIn?: Amount<'nat'>;
+ *   }
+ * >} zcf
  * @param {TimerService} timerPresence
  * @param {import('./roundsManager.js').QuoteKit} quoteKit
  * @param {StorageNode} storageNode
@@ -128,7 +137,10 @@ export const prepareFluxAggregatorKit = async (
   // end of maker definitions /////////////////////////////////
 
   const { answerKit, latestRoundKit, priceKit } = await provideAll(baggage, {
-    /** This is just a signal that there's a new answer, which is read from `lastValueOutForUnitIn` */
+    /**
+     * This is just a signal that there's a new answer, which is read from
+     * `lastValueOutForUnitIn`
+     */
     answerKit: () => makeDurablePublishKit(),
     /** For publishing priceAuthority values to off-chain storage */
     priceKit: () =>
@@ -142,9 +154,11 @@ export const prepareFluxAggregatorKit = async (
       E.when(E(storageNode).makeChildNode('latestRound'), node =>
         makeRecorderKit(
           node,
-          /** @type {import('@agoric/zoe/src/contractSupport/recorder.js').TypedMatcher<import('./roundsManager.js').LatestRound>} */ (
-            M.any()
-          ),
+          /**
+           * @type {import('@agoric/zoe/src/contractSupport/recorder.js').TypedMatcher<
+           *     import('./roundsManager.js').LatestRound
+           *   >}
+           */ (M.any()),
         ),
       ),
   });
@@ -223,9 +237,9 @@ export const prepareFluxAggregatorKit = async (
          * An "oracle invitation" is an invitation to be able to submit data to
          * include in the priceAggregator's results.
          *
-         * The offer result from this invitation is a OracleAdmin, which can be used
-         * directly to manage the price submissions as well as to terminate the
-         * relationship.
+         * The offer result from this invitation is a OracleAdmin, which can be
+         * used directly to manage the price submissions as well as to terminate
+         * the relationship.
          *
          * @param {string} oracleId unique per contract instance
          */
@@ -235,8 +249,8 @@ export const prepareFluxAggregatorKit = async (
           /**
            * If custom arguments are supplied to the `zoe.offer` call, they can
            * indicate an OraclePriceSubmission notifier and a corresponding
-           * `shiftValueOut` that should be adapted as part of the priceAuthority's
-           * reported data.
+           * `shiftValueOut` that should be adapted as part of the
+           * priceAuthority's reported data.
            *
            * @param {ZCFSeat} seat
            */
@@ -299,8 +313,9 @@ export const prepareFluxAggregatorKit = async (
         },
 
         /**
-         * a method to provide all current info oracleStatuses need. Intended only
-         * only to be callable by oracleStatuses. Not for use by contracts to read state.
+         * a method to provide all current info oracleStatuses need. Intended
+         * only only to be callable by oracleStatuses. Not for use by contracts
+         * to read state.
          *
          * @param {string} oracleId
          * @param {bigint} queriedRoundId

--- a/packages/inter-protocol/src/price/priceOracleKit.js
+++ b/packages/inter-protocol/src/price/priceOracleKit.js
@@ -8,14 +8,17 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
 
 /**
  * @typedef {{
- *   oracleId: string,
- *   roundPowers: { handlePush: (status: OracleStatus, result: import('./roundsManager.js').PriceRound) => Promise<OracleStatus> }
+ *   oracleId: string;
+ *   roundPowers: {
+ *     handlePush: (
+ *       status: OracleStatus,
+ *       result: import('./roundsManager.js').PriceRound,
+ *     ) => Promise<OracleStatus>;
+ *   };
  * }} HeldParams
  */
 
-/**
- * @typedef {{ roundId: number | undefined, unitPrice: NatValue }} PriceDatum
- */
+/** @typedef {{ roundId: number | undefined; unitPrice: NatValue }} PriceDatum */
 
 /**
  * @typedef {object} OracleStatus
@@ -26,11 +29,9 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
  * @property {string} oracleId
  */
 /**
- * @typedef {Readonly<HeldParams & {
- * }>} ImmutableState
+ * @typedef {Readonly<HeldParams & {}>} ImmutableState
  *
- * @typedef {OracleStatus & {
- * }} MutableState
+ * @typedef {OracleStatus & {}} MutableState
  */
 /** @typedef {ImmutableState & MutableState} State */
 
@@ -106,10 +107,7 @@ export const prepareOracleAdminKit = baggage =>
           state.lastStartedRound = result.lastStartedRound;
           state.latestSubmission = result.latestSubmission;
         },
-        /**
-         *
-         * @returns {OracleStatus}
-         */
+        /** @returns {OracleStatus} */
         getStatus() {
           const { state } = this;
           return {

--- a/packages/inter-protocol/src/proposals/committee-proposal.js
+++ b/packages/inter-protocol/src/proposals/committee-proposal.js
@@ -4,14 +4,14 @@ import { reserveThenDeposit } from './utils.js';
 
 const { values } = Object;
 
-/** @type { <X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
+/** @type {<X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
 const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
 
 const EC_HIGH_PRIORITY_SENDERS_NAMESPACE = 'economicCommittee';
 
 /**
  * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
- * @param {{ options: { voterAddresses: Record<string, string> }}} param1
+ * @param {{ options: { voterAddresses: Record<string, string> } }} param1
  */
 export const inviteCommitteeMembers = async (
   {
@@ -26,9 +26,7 @@ export const inviteCommitteeMembers = async (
 
   const highPrioritySendersManager = await consume.highPrioritySendersManager;
 
-  /**
-   * @param {[string, Promise<Invitation>][]} addrInvitations
-   */
+  /** @param {[string, Promise<Invitation>][]} addrInvitations */
   const distributeInvitations = async addrInvitations => {
     await Promise.all(
       addrInvitations.map(async ([addr, invitationP]) => {
@@ -53,9 +51,7 @@ export const inviteCommitteeMembers = async (
 
 harden(inviteCommitteeMembers);
 
-/**
- * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
- */
+/** @param {import('./econ-behaviors').EconomyBootstrapPowers} powers */
 export const startEconCharter = async ({
   consume: { zoe },
   produce: { econCharterKit },
@@ -131,7 +127,7 @@ harden(addGovernorsToEconCharter);
 
 /**
  * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
- * @param {{ options: { voterAddresses: Record<string, string> }}} param1
+ * @param {{ options: { voterAddresses: Record<string, string> } }} param1
  */
 export const inviteToEconCharter = async (
   { consume: { namesByAddressAdmin, econCharterKit } },

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -15,9 +15,7 @@ export * from './startEconCommittee.js'; // eslint-disable-line import/export
 // require updating a lot of tests. So for now, we just
 // grab the kits afterward and store them.
 
-/**
- * @param {import('./econ-behaviors.js').EconomyBootstrapPowers} powers
- */
+/** @param {import('./econ-behaviors.js').EconomyBootstrapPowers} powers */
 export const storeInterContractStartKits = async ({
   consume: {
     contractKits,
@@ -31,8 +29,8 @@ export const storeInterContractStartKits = async ({
   },
 }) => {
   /**
-   * @param {Promise<MapStore<string, {instance: Instance}>>} storeP
-   * @param {Promise<{instance: Instance}>[]} kitPs
+   * @param {Promise<MapStore<string, { instance: Instance }>>} storeP
+   * @param {Promise<{ instance: Instance }>[]} kitPs
    */
   const storeAll = async (storeP, kitPs) => {
     const store = await storeP;

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -22,7 +22,9 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
 
 /**
  * @typedef {import('../vaultFactory/vaultFactory.js').VaultFactoryContract['publicFacet']} VaultFactoryPublicFacet
+ *
  * @typedef {import('../auction/auctioneer.js').AuctioneerPublicFacet} AuctioneerPublicFacet
+ *
  * @typedef {import('../auction/auctioneer.js').AuctioneerCreatorFacet} AuctioneerCreatorFacet
  */
 
@@ -31,43 +33,65 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
  * @property {string} label
  * @property {Instance} psm
  * @property {Instance} psmGovernor
- * @property {Awaited<ReturnType<Awaited<ReturnType<import('../psm/psm.js')['prepare']>>['creatorFacet']['getLimitedCreatorFacet']>>} psmCreatorFacet
+ * @property {Awaited<
+ *   ReturnType<
+ *     Awaited<
+ *       ReturnType<import('../psm/psm.js')['prepare']>
+ *     >['creatorFacet']['getLimitedCreatorFacet']
+ *   >
+ * >} psmCreatorFacet
  * @property {GovernorCreatorFacet<import('../../src/psm/psm.js')['prepare']>} psmGovernorCreatorFacet
  * @property {AdminFacet} psmAdminFacet
  */
 
-/**
- * @typedef {GovernanceFacetKit<import('../auction/auctioneer.js').start>} AuctioneerKit
- */
+/** @typedef {GovernanceFacetKit<import('../auction/auctioneer.js').start>} AuctioneerKit */
 
 /**
- * @typedef { WellKnownSpaces & ChainBootstrapSpace & EconomyBootstrapSpace
- * } EconomyBootstrapPowers
+ * @typedef {WellKnownSpaces & ChainBootstrapSpace & EconomyBootstrapSpace} EconomyBootstrapPowers
+ *
  * @typedef {PromiseSpaceOf<{
- *   economicCommitteeKit: CommitteeStartResult,
- *   economicCommitteeCreatorFacet: import('@agoric/governance/src/committee.js').CommitteeElectorateCreatorFacet,
- *   feeDistributorKit: StartedInstanceKit<typeof import('../feeDistributor.js').start>,
- *   periodicFeeCollectors: MapStore<number, import('../feeDistributor.js').PeriodicFeeCollector>,
- *   psmKit: MapStore<Brand, PSMKit>,
- *   anchorBalancePayments: MapStore<Brand, Payment<'nat'>>,
- *   econCharterKit: EconCharterStartResult,
- *   reserveKit: GovernanceFacetKit<import('../reserve/assetReserve.js')['prepare']>,
- *   vaultFactoryKit: GovernanceFacetKit<import('../vaultFactory/vaultFactory.js')['prepare']>,
- *   auctioneerKit: AuctioneerKit,
- *   minInitialDebt: NatValue,
+ *   economicCommitteeKit: CommitteeStartResult;
+ *   economicCommitteeCreatorFacet: import('@agoric/governance/src/committee.js').CommitteeElectorateCreatorFacet;
+ *   feeDistributorKit: StartedInstanceKit<
+ *     typeof import('../feeDistributor.js').start
+ *   >;
+ *   periodicFeeCollectors: MapStore<
+ *     number,
+ *     import('../feeDistributor.js').PeriodicFeeCollector
+ *   >;
+ *   psmKit: MapStore<Brand, PSMKit>;
+ *   anchorBalancePayments: MapStore<Brand, Payment<'nat'>>;
+ *   econCharterKit: EconCharterStartResult;
+ *   reserveKit: GovernanceFacetKit<
+ *     import('../reserve/assetReserve.js')['prepare']
+ *   >;
+ *   vaultFactoryKit: GovernanceFacetKit<
+ *     import('../vaultFactory/vaultFactory.js')['prepare']
+ *   >;
+ *   auctioneerKit: AuctioneerKit;
+ *   minInitialDebt: NatValue;
  * }>} EconomyBootstrapSpace
  */
 
-/** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('../econCommitteeCharter')['prepare']>} EconCharterStartResult */
-/** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('@agoric/governance/src/committee.js')['prepare']>} CommitteeStartResult */
+/**
+ * @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<
+ *   import('../econCommitteeCharter')['prepare']
+ * >} EconCharterStartResult
+ */
+/**
+ * @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<
+ *   import('@agoric/governance/src/committee.js')['prepare']
+ * >} CommitteeStartResult
+ */
 
 /**
  * @file A collection of productions, each of which declares inputs and outputs.
- * Each function is passed a set of powers for reading from and writing to the vat config.
+ *   Each function is passed a set of powers for reading from and writing to the
+ *   vat config.
  *
- * Each of the things they produce they're responsible for resolving or setting.
+ *   Each of the things they produce they're responsible for resolving or setting.
  *
- * In production called by @agoric/vats to bootstrap.
+ *   In production called by @agoric/vats to bootstrap.
  */
 
 /** @param {EconomyBootstrapPowers} powers */
@@ -299,7 +323,11 @@ export const startVaultFactory = async (
     }),
   );
 
-  /** @type {GovernorStartedInstallationKit<typeof vaultFactoryInstallation>} */
+  /**
+   * @type {GovernorStartedInstallationKit<
+   *   typeof vaultFactoryInstallation
+   * >}
+   */
   const g = await E(consume.zoe).startInstance(
     contractGovernorInstallation,
     undefined,
@@ -348,8 +376,8 @@ export const startVaultFactory = async (
 };
 
 /**
- * Grant access to the VaultFactory creatorFacet
- * to up to one user based on address.
+ * Grant access to the VaultFactory creatorFacet to up to one user based on
+ * address.
  *
  * @param {EconomyBootstrapPowers} powers
  * @param {object} [root0]
@@ -435,9 +463,8 @@ export const startRewardDistributor = async ({
 
   /**
    * @type {Awaited<
-   *   ReturnType<typeof import('../feeDistributor.js').makeFeeDistributor>>
-   *   & { adminFacet: AdminFacet, instance: Instance }
-   * }
+   *   ReturnType<typeof import('../feeDistributor.js').makeFeeDistributor>
+   * > & { adminFacet: AdminFacet; instance: Instance }}
    */
   const instanceKit = await E(zoe).startInstance(
     feeDistributor,

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -23,12 +23,12 @@ export const instanceNameFor = (inBrandName, outBrandName) =>
 
 /**
  * @typedef {{
- * brandIn?: ERef<Brand<'nat'> | undefined>,
- * brandOut?: ERef<Brand<'nat'> | undefined>,
- * IN_BRAND_NAME: string,
- * IN_BRAND_DECIMALS: string,
- * OUT_BRAND_NAME: string,
- * OUT_BRAND_DECIMALS: string,
+ *   brandIn?: ERef<Brand<'nat'> | undefined>;
+ *   brandOut?: ERef<Brand<'nat'> | undefined>;
+ *   IN_BRAND_NAME: string;
+ *   IN_BRAND_DECIMALS: string;
+ *   OUT_BRAND_NAME: string;
+ *   OUT_BRAND_DECIMALS: string;
  * }} PriceFeedOptions
  */
 
@@ -36,7 +36,7 @@ export const instanceNameFor = (inBrandName, outBrandName) =>
  * Create inert brands (no mint or issuer) referred to by price oracles.
  *
  * @param {ChainBootstrapSpace & NamedVatPowers} space
- * @param {{options: {priceFeedOptions: PriceFeedOptions}}} opt
+ * @param {{ options: { priceFeedOptions: PriceFeedOptions } }} opt
  * @returns {Promise<[Brand<'nat'>, Brand<'nat'>]>}
  */
 export const ensureOracleBrands = async (
@@ -81,7 +81,17 @@ export const ensureOracleBrands = async (
 
 /**
  * @param {ChainBootstrapSpace} powers
- * @param {{options: {priceFeedOptions: {AGORIC_INSTANCE_NAME: string, oracleAddresses: string[], contractTerms: import('@agoric/inter-protocol/src/price/fluxAggregatorKit.js').ChainlinkConfig, IN_BRAND_NAME: string, OUT_BRAND_NAME: string}}}} config
+ * @param {{
+ *   options: {
+ *     priceFeedOptions: {
+ *       AGORIC_INSTANCE_NAME: string;
+ *       oracleAddresses: string[];
+ *       contractTerms: import('@agoric/inter-protocol/src/price/fluxAggregatorKit.js').ChainlinkConfig;
+ *       IN_BRAND_NAME: string;
+ *       OUT_BRAND_NAME: string;
+ *     };
+ *   };
+ * }} config
  */
 export const createPriceFeed = async (
   {
@@ -120,9 +130,17 @@ export const createPriceFeed = async (
   const timer = await chainTimerService;
 
   /**
-   * Values come from economy-template.json, which at this writing had IN:ATOM, OUT:USD
+   * Values come from economy-template.json, which at this writing had IN:ATOM,
+   * OUT:USD
    *
-   * @type {[[Brand<'nat'>, Brand<'nat'>], [Installation<import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').prepare>]]}
+   * @type {[
+   *   [Brand<'nat'>, Brand<'nat'>],
+   *   [
+   *     Installation<
+   *       import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').prepare
+   *     >,
+   *   ],
+   * ]}
    */
   const [[brandIn, brandOut], [priceAggregator]] = await Promise.all([
     reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('oracleBrand'), [
@@ -215,7 +233,8 @@ export const createPriceFeed = async (
 
 const t = 'priceFeed';
 /**
- * Add a price feed to a running chain, returning the manifest, installations, and options.
+ * Add a price feed to a running chain, returning the manifest, installations,
+ * and options.
  *
  * @param {object} utils
  * @param {(ref: unknown) => Promise<unknown>} [utils.restoreRef]

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -35,10 +35,13 @@ export { inviteCommitteeMembers, startEconCharter, inviteToEconCharter };
 const stablePsmKey = `published.psm.${Stable.symbol}`;
 
 /**
- * @param {Array<[key: string, value: string]>} chainStorageEntries
+ * @param {[key: string, value: string][]} chainStorageEntries
  * @param {string} keyword
- * @param {{ minted: Brand<'nat'>, anchor: Brand<'nat'> }} brands
- * @returns {{ metrics?: MetricsNotification, governance?: GovernanceSubscriptionState }}
+ * @param {{ minted: Brand<'nat'>; anchor: Brand<'nat'> }} brands
+ * @returns {{
+ *   metrics?: MetricsNotification;
+ *   governance?: GovernanceSubscriptionState;
+ * }}
  */
 const findOldPSMState = (chainStorageEntries, keyword, brands) => {
   // In this reviver, object references are revived as boardIDs
@@ -80,7 +83,7 @@ const findOldPSMState = (chainStorageEntries, keyword, brands) => {
  * @param {bigint} [config.WantMintedFeeBP]
  * @param {bigint} [config.GiveMintedFeeBP]
  * @param {bigint} [config.MINT_LIMIT]
- * @param {{ anchorOptions?: AnchorOptions } } [config.options]
+ * @param {{ anchorOptions?: AnchorOptions }} [config.options]
  */
 export const startPSM = async (
   {
@@ -291,16 +294,16 @@ harden(startPSM);
  */
 
 /**
- * Make anchor issuer out of a Cosmos asset; presumably
- * USDC over IBC. Add it to BankManager.
+ * Make anchor issuer out of a Cosmos asset; presumably USDC over IBC. Add it to
+ * BankManager.
  *
- * Also, if vatParameters shows an anchorPoolBalance for this asset,
- * mint a payment for that balance.
+ * Also, if vatParameters shows an anchorPoolBalance for this asset, mint a
+ * payment for that balance.
  *
  * TODO: address redundancy with publishInterchainAssetFromBank
  *
  * @param {EconomyBootstrapPowers & WellKnownSpaces & ChainStorageVatParams} powers
- * @param {{options: { anchorOptions?: AnchorOptions } }} config
+ * @param {{ options: { anchorOptions?: AnchorOptions } }} config
  */
 export const makeAnchorAsset = async (
   {
@@ -345,14 +348,18 @@ export const makeAnchorAsset = async (
     }),
   );
 
-  const { creatorFacet: mint, publicFacet: issuer } =
-    /** @type {{ creatorFacet: ERef<Mint<'nat'>>, publicFacet: ERef<Issuer<'nat'>> }} */ (
-      await E(startUpgradable)({
-        installation: mintHolder,
-        label: keyword,
-        terms,
-      })
-    );
+  const { creatorFacet: mint, publicFacet: issuer } = /**
+   * @type {{
+   *   creatorFacet: ERef<Mint<'nat'>>;
+   *   publicFacet: ERef<Issuer<'nat'>>;
+   * }}
+   */ (
+    await E(startUpgradable)({
+      installation: mintHolder,
+      label: keyword,
+      terms,
+    })
+  );
 
   const brand = await E(issuer).getBrand();
   const kit = harden({ mint, issuer, brand });

--- a/packages/inter-protocol/src/proposals/utils.js
+++ b/packages/inter-protocol/src/proposals/utils.js
@@ -10,7 +10,6 @@ const { Fail } = assert;
  */
 export const reserveThenGetNamePaths = async (nameAdmin, paths) => {
   /**
-   *
    * @param {ERef<import('@agoric/vats').NameAdmin>} nextAdmin
    * @param {string[]} path
    */
@@ -54,7 +53,7 @@ export const reserveThenGetNames = async (nameAdmin, names) =>
  * @param {string} debugName
  * @param {ERef<import('@agoric/vats').NameAdmin>} namesByAddressAdmin
  * @param {string} addr
- * @param {Array<ERef<Payment>>} payments
+ * @param {ERef<Payment>[]} payments
  */
 export const reserveThenDeposit = async (
   debugName,
@@ -79,7 +78,15 @@ export const reserveThenDeposit = async (
   );
 };
 
-/** @type {<T>(store: ERef<Map<string, T> | import('@agoric/internal/src/scratch.js').ScratchPad>, key: string, make: () => T) => Promise<T>} */
+/**
+ * @type {<T>(
+ *   store: ERef<
+ *     Map<string, T> | import('@agoric/internal/src/scratch.js').ScratchPad
+ *   >,
+ *   key: string,
+ *   make: () => T,
+ * ) => Promise<T>}
+ */
 const provideWhen = async (store, key, make) => {
   const found = await E(store).get(key);
   if (found) {
@@ -91,21 +98,33 @@ const provideWhen = async (store, key, make) => {
 };
 
 /**
- * @param {{ scratch: ERef<import('@agoric/internal/src/scratch.js').ScratchPad> }} homeP
+ * @param {{
+ *   scratch: ERef<import('@agoric/internal/src/scratch.js').ScratchPad>;
+ * }} homeP
  * @param {object} opts
- * @param {(specifier: string) => Promise<{default: Bundle}>} opts.loadBundle
+ * @param {(specifier: string) => Promise<{ default: Bundle }>} opts.loadBundle
  * @param {string} [opts.installCacheKey]
  */
 export const makeInstallCache = async (
   homeP,
   { installCacheKey = 'installCache', loadBundle },
 ) => {
-  /** @type {CopyMap<string, {installation: Installation, boardId: string, path?: string}>} */
+  /**
+   * @type {CopyMap<
+   *   string,
+   *   { installation: Installation; boardId: string; path?: string }
+   * >}
+   */
   const initial = await provideWhen(E.get(homeP).scratch, installCacheKey, () =>
     makeCopyMap([]),
   );
   // ISSUE: getCopyMapEntries of CopyMap<K, V> loses K, V.
-  /** @type {Map<string, {installation: Installation, boardId: string, path?: string}>} */
+  /**
+   * @type {Map<
+   *   string,
+   *   { installation: Installation; boardId: string; path?: string }
+   * >}
+   */
   const working = new Map(getCopyMapEntries(initial));
 
   const saveCache = async () => {

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -41,28 +41,25 @@ const { Fail } = assert;
 
 /**
  * @file The Parity Stability Module supports efficiently minting/burning a
- * stable token at a specified fixed ratio to a reference stable token, which
- * thereby acts as an anchor to provide additional stability. For flexible
- * economic policies, the fee percentage for trading into and out of the stable
- * token are specified separately.
+ *   stable token at a specified fixed ratio to a reference stable token, which
+ *   thereby acts as an anchor to provide additional stability. For flexible
+ *   economic policies, the fee percentage for trading into and out of the
+ *   stable token are specified separately.
  */
 
 /**
- * @typedef {object} MetricsNotification
- * Metrics naming scheme is that nouns are present values and past-participles
- * are accumulative.
- *
- * @property {Amount<'nat'>} anchorPoolBalance  amount of Anchor token
- * available to be swapped
- * @property {Amount<'nat'>} mintedPoolBalance  amount of Minted token
- * outstanding (the amount minted minus the amount burned).
- * @property {Amount<'nat'>} feePoolBalance     amount of Minted token
- * fees available to be collected
- *
- * @property {Amount<'nat'>} totalAnchorProvided  running sum of Anchor
- * ever given by this contract
- * @property {Amount<'nat'>} totalMintedProvided  running sum of Minted
- * ever given by this contract
+ * @typedef {object} MetricsNotification Metrics naming scheme is that nouns are
+ *   present values and past-participles are accumulative.
+ * @property {Amount<'nat'>} anchorPoolBalance amount of Anchor token available
+ *   to be swapped
+ * @property {Amount<'nat'>} mintedPoolBalance amount of Minted token
+ *   outstanding (the amount minted minus the amount burned).
+ * @property {Amount<'nat'>} feePoolBalance amount of Minted token fees
+ *   available to be collected
+ * @property {Amount<'nat'>} totalAnchorProvided running sum of Anchor ever
+ *   given by this contract
+ * @property {Amount<'nat'>} totalMintedProvided running sum of Minted ever
+ *   given by this contract
  */
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
@@ -103,15 +100,22 @@ export const privateArgsShape = M.splitRecord(
 harden(privateArgsShape);
 
 /**
- * @param {ZCF<GovernanceTerms<{
- *    GiveMintedFee: 'ratio',
- *    WantMintedFee: 'ratio',
- *    MintLimit: 'amount',
+ * @param {ZCF<
+ *   GovernanceTerms<{
+ *     GiveMintedFee: 'ratio';
+ *     WantMintedFee: 'ratio';
+ *     MintLimit: 'amount';
  *   }> & {
- *    anchorBrand: Brand<'nat'>,
- *    anchorPerMinted: Ratio,
- * }>} zcf
- * @param {{feeMintAccess: FeeMintAccess, initialPoserInvitation: Invitation, storageNode: StorageNode, marshaller: Marshaller}} privateArgs
+ *     anchorBrand: Brand<'nat'>;
+ *     anchorPerMinted: Ratio;
+ *   }
+ * >} zcf
+ * @param {{
+ *   feeMintAccess: FeeMintAccess;
+ *   initialPoserInvitation: Invitation;
+ *   storageNode: StorageNode;
+ *   marshaller: Marshaller;
+ * }} privateArgs
  * @param {Baggage} baggage
  */
 export const prepare = async (zcf, privateArgs, baggage) => {
@@ -231,9 +235,7 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     updateMetrics();
   };
 
-  /**
-   * @param {Amount<'nat'>} toMint
-   */
+  /** @param {Amount<'nat'>} toMint */
   const assertUnderLimit = toMint => {
     const mintedAfter = AmountMath.add(
       baggage.get('mintedPoolBalance'),
@@ -262,7 +264,8 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   /**
    * @param {ZCFSeat} seat
    * @param {Amount<'nat'>} given
-   * @param {Amount<'nat'>} [wanted] defaults to maximum anchor (given exchange rate minus fees)
+   * @param {Amount<'nat'>} [wanted] defaults to maximum anchor (given exchange
+   *   rate minus fees)
    */
   const giveMinted = (seat, given, wanted = emptyAnchor) => {
     const fee = ceilMultiplyBy(given, params.getGiveMintedFee());

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -12,30 +12,30 @@ const trace = makeTracer('AR', true);
 
 /**
  * @typedef {{
- *   increaseLiquidationShortfall: (increase: Amount) => void
- *   reduceLiquidationShortfall: (reduction: Amount) => void
+ *   increaseLiquidationShortfall: (increase: Amount) => void;
+ *   reduceLiquidationShortfall: (reduction: Amount) => void;
  * }} ShortfallReportingFacet
  */
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
 /**
- * Asset Reserve holds onto assets for the Inter Protocol, and can
- * dispense it for various purposes under governance control.
+ * Asset Reserve holds onto assets for the Inter Protocol, and can dispense it
+ * for various purposes under governance control.
  *
  * This contract has the ability to mint Fee tokens, granted through its private
  * arguments.
  *
- * @param {ZCF<GovernanceTerms<{}> &
- * {
- *   governedApis: ['burnFeesToReduceShortfall'],
- * }
+ * @param {ZCF<
+ *   GovernanceTerms<{}> & {
+ *     governedApis: ['burnFeesToReduceShortfall'];
+ *   }
  * >} zcf
  * @param {{
- *   feeMintAccess: FeeMintAccess,
- *   initialPoserInvitation: Invitation,
- *   marshaller: ERef<Marshaller>,
- *   storageNode: ERef<StorageNode>,
+ *   feeMintAccess: FeeMintAccess;
+ *   initialPoserInvitation: Invitation;
+ *   marshaller: ERef<Marshaller>;
+ *   storageNode: ERef<StorageNode>;
  * }} privateArgs
  * @param {Baggage} baggage
  */
@@ -122,4 +122,7 @@ harden(prepare);
  */
 
 /** @typedef {Awaited<ReturnType<typeof prepare>>['publicFacet']} AssetReservePublicFacet */
-/** @typedef {Awaited<ReturnType<typeof prepare>>['creatorFacet']} AssetReserveCreatorFacet the creator facet for the governor */
+/**
+ * @typedef {Awaited<ReturnType<typeof prepare>>['creatorFacet']} AssetReserveCreatorFacet
+ *   the creator facet for the governor
+ */

--- a/packages/inter-protocol/src/reserve/assetReserveKit.js
+++ b/packages/inter-protocol/src/reserve/assetReserveKit.js
@@ -17,7 +17,6 @@ const trace = makeTracer('ReserveKit', true);
 
 /**
  * @typedef {object} MetricsNotification
- *
  * @property {AmountKeywordRecord} allocations
  * @property {Amount<'nat'>} shortfallBalance shortfall from liquidation that
  *   has not yet been compensated.
@@ -28,10 +27,11 @@ const trace = makeTracer('ReserveKit', true);
 /**
  * @param {import('@agoric/vat-data').Baggage} baggage
  * @param {{
- * feeMint: ZCFMint<'nat'>,
- * makeRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit,
- * storageNode: StorageNode,
- * zcf: ZCF}} powers
+ *   feeMint: ZCFMint<'nat'>;
+ *   makeRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit;
+ *   storageNode: StorageNode;
+ *   zcf: ZCF;
+ * }} powers
  */
 export const prepareAssetReserveKit = async (
   baggage,
@@ -63,10 +63,7 @@ export const prepareAssetReserveKit = async (
         reduceLiquidationShortfall: M.call(AmountShape).returns(),
       }),
     },
-    /**
-     *
-     * @param {StorageNode} metricsNode
-     */
+    /** @param {StorageNode} metricsNode */
     metricsNode => {
       /**
        * Used to look up the unique keyword for each brand, including Fee brand.
@@ -77,7 +74,8 @@ export const prepareAssetReserveKit = async (
         durable: true,
       });
       /**
-       * Used to look up the brands for keywords, excluding Fee because it's a special case.
+       * Used to look up the brands for keywords, excluding Fee because it's a
+       * special case.
        *
        * @type {MapStore<Keyword, Brand>}
        */
@@ -137,7 +135,6 @@ export const prepareAssetReserveKit = async (
       },
       governedApis: {
         /**
-         *
          * @param {Amount<'nat'>} reduction
          * @returns {void}
          */
@@ -205,12 +202,11 @@ export const prepareAssetReserveKit = async (
         },
       },
       /**
-       * XXX missing governance public methods https://github.com/Agoric/agoric-sdk/issues/5200
+       * XXX missing governance public methods
+       * https://github.com/Agoric/agoric-sdk/issues/5200
        */
       public: {
-        /**
-         * Anyone can deposit any assets to the reserve
-         */
+        /** Anyone can deposit any assets to the reserve */
         makeAddCollateralInvitation() {
           /** @type {OfferHandler<Promise<string>>} */
           const handler = async seat => {
@@ -247,9 +243,7 @@ export const prepareAssetReserveKit = async (
         },
       },
       shortfallReportingFacet: {
-        /**
-         * @param {Amount<"nat">} shortfall
-         */
+        /** @param {Amount<'nat'>} shortfall */
         increaseLiquidationShortfall(shortfall) {
           const { facets, state } = this;
           state.shortfallBalance = AmountMath.add(
@@ -260,9 +254,7 @@ export const prepareAssetReserveKit = async (
         },
 
         // currently exposed for testing. Maybe it only gets called internally?
-        /**
-         * @param {Amount<"nat">} reduction
-         */
+        /** @param {Amount<'nat'>} reduction */
         reduceLiquidationShortfall(reduction) {
           const { state } = this;
           if (AmountMath.isGTE(reduction, state.shortfallBalance)) {

--- a/packages/inter-protocol/src/tokens.js
+++ b/packages/inter-protocol/src/tokens.js
@@ -1,17 +1,17 @@
 // @ts-check
 
-/** @typedef { 'IST' | 'BLD' } TokenKeyword */
+/** @typedef {'IST' | 'BLD'} TokenKeyword */
 
 /**
- * Use static type check and unit tests rather than runtime import
- * to avoid bundling all of ERTP just to get Stable.symbol.
+ * Use static type check and unit tests rather than runtime import to avoid
+ * bundling all of ERTP just to get Stable.symbol.
  *
  * @type {typeof import('@agoric/ertp').AssetKind.NAT}
  */
 const NAT = 'nat';
 
 export const Stable = harden(
-  /** @type {const } */ ({
+  /** @type {const} */ ({
     symbol: 'IST',
     denom: 'uist',
     proposedName: 'Agoric stable token',
@@ -24,7 +24,7 @@ export const Stable = harden(
 );
 
 export const Stake = harden(
-  /** @type {const } */ ({
+  /** @type {const} */ ({
     symbol: 'BLD',
     denom: 'ubld',
     proposedName: 'Agoric staking token',

--- a/packages/inter-protocol/src/typeGuards.js
+++ b/packages/inter-protocol/src/typeGuards.js
@@ -2,9 +2,7 @@
 
 import { M } from '@agoric/store';
 
-/**
- * To be used only for 'helper' facets where the calls are from trusted code.
- */
+/** To be used only for 'helper' facets where the calls are from trusted code. */
 export const UnguardedHelperI = M.interface(
   'helper',
   {},

--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -22,7 +22,8 @@ const makeCancelToken = makeCancelTokenMaker('liq');
 
 /**
  * This will normally be set. If the schedule goes sideways, we'll unschedule
- * all events and unset it. When auction params are changed, we'll restart the schedule
+ * all events and unset it. When auction params are changed, we'll restart the
+ * schedule
  *
  * @type {object | undefined}
  */
@@ -47,15 +48,16 @@ const cancelWakeups = timer => {
 };
 
 /**
- * Schedule wakeups for the *next* auction round.
+ * Schedule wakeups for the _next_ auction round.
  *
- * In practice, there are these cases to handle (with N as "live" and N+1 is "next"):
+ * In practice, there are these cases to handle (with N as "live" and N+1 is
+ * "next"):
  *
- * | when (now within the range)      | what                                    |
- * | -------------------------------- | --------------------------------------- |
- * | [start N, nominalStart N+1]      | good: schedule normally the three wakers|
- * | (nominalStart N+1, endTime N+1]  | recover: skip round N+1 and schedule N+2|
- * | (endTime N+1, ∞)                 | give up: wait for repair by governance  |
+ * | when (now within the range)     | what                                     |
+ * | ------------------------------- | ---------------------------------------- |
+ * | [start N, nominalStart N+1]     | good: schedule normally the three wakers |
+ * | (nominalStart N+1, endTime N+1] | recover: skip round N+1 and schedule N+2 |
+ * | (endTime N+1, ∞)                | give up: wait for repair by governance   |
  *
  * @param {object} opts
  * @param {ERef<TimerService>} opts.timer
@@ -132,7 +134,7 @@ const setWakeups = ({
 };
 
 /**
- * Schedule wakeups for the *next* auction round.
+ * Schedule wakeups for the _next_ auction round.
  *
  * Called by vaultDirector's resetWakeupsForNextAuction at start() and every
  * time there's a "reschedule" wakeup.
@@ -185,7 +187,7 @@ harden(setWakeupsForNextAuction);
 /**
  * @param {Amount<'nat'>} debt
  * @param {Amount<'nat'>} minted
- * @returns {{ overage: Amount<'nat'>, shortfall: Amount<'nat'>}}
+ * @returns {{ overage: Amount<'nat'>; shortfall: Amount<'nat'> }}
  */
 export const liquidationResults = (debt, minted) => {
   if (AmountMath.isEmpty(minted)) {
@@ -240,15 +242,21 @@ export const watchForGovernanceChange = (
  * @param {PriceQuote} collateralizationDetails.quote
  * @param {Ratio} collateralizationDetails.interest
  * @param {Ratio} collateralizationDetails.margin
- * @param {ReturnType<typeof import('./prioritizedVaults.js').makePrioritizedVaults>} prioritizedVaults
+ * @param {ReturnType<
+ *   typeof import('./prioritizedVaults.js').makePrioritizedVaults
+ * >} prioritizedVaults
  * @param {SetStore<Vault>} liquidatingVaults
  * @param {Brand<'nat'>} debtBrand
  * @param {Brand<'nat'>} collateralBrand
  * @returns {{
- *    vaultData: MapStore<Vault, { collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>}>,
- *    totalDebt: Amount<'nat'>,
- *    totalCollateral: Amount<'nat'>,
- *    liqSeat: ZCFSeat}}
+ *   vaultData: MapStore<
+ *     Vault,
+ *     { collateralAmount: Amount<'nat'>; debtAmount: Amount<'nat'> }
+ *   >;
+ *   totalDebt: Amount<'nat'>;
+ *   totalCollateral: Amount<'nat'>;
+ *   liqSeat: ZCFSeat;
+ * }}
  */
 export const getLiquidatableVaults = (
   zcf,
@@ -261,7 +269,12 @@ export const getLiquidatableVaults = (
   const vaultsToLiquidate = prioritizedVaults.removeVaultsBelow(
     collateralizationDetails,
   );
-  /** @type {MapStore<Vault, { collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>}>} */
+  /**
+   * @type {MapStore<
+   *   Vault,
+   *   { collateralAmount: Amount<'nat'>; debtAmount: Amount<'nat'> }
+   * >}
+   */
   const vaultData = makeScalarMapStore();
 
   const { zcfSeat: liqSeat } = zcf.makeEmptySeatKit();

--- a/packages/inter-protocol/src/vaultFactory/math.js
+++ b/packages/inter-protocol/src/vaultFactory/math.js
@@ -1,8 +1,8 @@
 // @jessie-check
 
 /**
- * @file calculations specific to the Vault Factory contract
- * See also ../interest-math.js
+ * @file calculations specific to the Vault Factory contract See also
+ *   ../interest-math.js
  */
 
 import { AmountMath } from '@agoric/ertp';
@@ -17,8 +17,8 @@ import { priceFrom } from '../auction/util.js';
 import { addSubtract } from '../contractSupport.js';
 
 /**
- * Calculate the minimum collateralization given the liquidation margin and the "padding"
- * from that liquidation threshold.
+ * Calculate the minimum collateralization given the liquidation margin and the
+ * "padding" from that liquidation threshold.
  *
  * @param {Ratio} liquidationMargin
  * @param {Ratio} liquidationPadding
@@ -74,11 +74,10 @@ export const maxDebtForVault = (
 };
 
 /**
- * Calculate the fee, the amount to mint and the resulting debt.
- * The give and the want together reflect a delta, where typically
- * one is zero because they come from the gave/want of an offer
- * proposal. If the `want` is zero, the `fee` will also be zero,
- * so the simple math works.
+ * Calculate the fee, the amount to mint and the resulting debt. The give and
+ * the want together reflect a delta, where typically one is zero because they
+ * come from the gave/want of an offer proposal. If the `want` is zero, the
+ * `fee` will also be zero, so the simple math works.
  *
  * @param {Amount<'nat'>} currentDebt
  * @param {Amount<'nat'>} give excess of currentDebt is returned in 'surplus'

--- a/packages/inter-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/inter-protocol/src/vaultFactory/orderedVaultStore.js
@@ -3,22 +3,20 @@ import { fromVaultKey, toVaultKey } from './storeUtils.js';
 /**
  * Used by prioritizedVaults to wrap the Collections API for this use case.
  *
- * Designed to be replaceable by naked Collections API when composite keys are available.
+ * Designed to be replaceable by naked Collections API when composite keys are
+ * available.
  *
- * In this module debts are encoded as the inverse quotient (collateral over debt) so that
- * greater collateralization sorts after lower. (Higher debt-to-collateral come
- * first.)
+ * In this module debts are encoded as the inverse quotient (collateral over
+ * debt) so that greater collateralization sorts after lower. (Higher
+ * debt-to-collateral come first.)
  */
 
 /** @typedef {import('./vault').Vault} Vault */
 /** @typedef {import('./storeUtils').CompositeKey} CompositeKey */
 
-/**
- * @param {MapStore<string, Vault>} store
- */
+/** @param {MapStore<string, Vault>} store */
 export const makeOrderedVaultStore = store => {
   /**
-   *
    * @param {string} vaultId
    * @param {Vault} vault
    */
@@ -31,7 +29,6 @@ export const makeOrderedVaultStore = store => {
   };
 
   /**
-   *
    * @param {string} key
    * @returns {Vault}
    */

--- a/packages/inter-protocol/src/vaultFactory/params.js
+++ b/packages/inter-protocol/src/vaultFactory/params.js
@@ -75,7 +75,11 @@ const makeVaultDirectorParams = (
 };
 harden(makeVaultDirectorParams);
 
-/** @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager').ParamTypesMapFromRecord<ReturnType<typeof makeVaultDirectorParams>>} VaultDirectorParams */
+/**
+ * @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager').ParamTypesMapFromRecord<
+ *     ReturnType<typeof makeVaultDirectorParams>
+ *   >} VaultDirectorParams
+ */
 
 /** @type {(liquidationMargin: Ratio) => Ratio} */
 const zeroRatio = liquidationMargin =>
@@ -122,16 +126,16 @@ export const vaultParamPattern = M.splitRecord(
 
 /**
  * @param {{
- *   auctioneerPublicFacet: ERef<AuctioneerPublicFacet>,
- *   electorateInvitationAmount: Amount<'set'>,
- *   minInitialDebt: Amount<'nat'>,
- *   bootstrapPaymentValue: bigint,
- *   priceAuthority: ERef<PriceAuthority>,
- *   timer: ERef<import('@agoric/time/src/types').TimerService>,
- *   reservePublicFacet: AssetReservePublicFacet,
- *   interestTiming: InterestTiming,
- *   shortfallInvitationAmount: Amount<'set'>,
- *   referencedUi?: string,
+ *   auctioneerPublicFacet: ERef<AuctioneerPublicFacet>;
+ *   electorateInvitationAmount: Amount<'set'>;
+ *   minInitialDebt: Amount<'nat'>;
+ *   bootstrapPaymentValue: bigint;
+ *   priceAuthority: ERef<PriceAuthority>;
+ *   timer: ERef<import('@agoric/time/src/types').TimerService>;
+ *   reservePublicFacet: AssetReservePublicFacet;
+ *   interestTiming: InterestTiming;
+ *   shortfallInvitationAmount: Amount<'set'>;
+ *   referencedUi?: string;
  * }} opts
  */
 export const makeGovernedTerms = ({
@@ -163,8 +167,8 @@ export const makeGovernedTerms = ({
 };
 harden(makeGovernedTerms);
 /**
- * Stop-gap which restores initial param values
- * UNTIL https://github.com/Agoric/agoric-sdk/issues/5200
+ * Stop-gap which restores initial param values UNTIL
+ * https://github.com/Agoric/agoric-sdk/issues/5200
  *
  * NB: changes from initial values will be lost upon restart
  *
@@ -176,7 +180,12 @@ export const provideVaultParamManagers = (baggage, marshaller) => {
   const managers = makeScalarMapStore();
 
   // the managers aren't durable but their arguments are
-  /** @type {MapStore<Brand, {storageNode: StorageNode, initialParamValues: VaultManagerParamValues}>} */
+  /**
+   * @type {MapStore<
+   *   Brand,
+   *   { storageNode: StorageNode; initialParamValues: VaultManagerParamValues }
+   * >}
+   */
   const managerArgs = provideDurableMapStore(
     baggage,
     'vault param manager parts',
@@ -196,7 +205,6 @@ export const provideVaultParamManagers = (baggage, marshaller) => {
 
   return {
     /**
-     *
      * @param {Brand} brand
      * @param {StorageNode} storageNode
      * @param {VaultManagerParamValues} initialParamValues
@@ -206,9 +214,7 @@ export const provideVaultParamManagers = (baggage, marshaller) => {
       managerArgs.init(brand, args);
       return makeManager(brand, args);
     },
-    /**
-     * @param {Brand} brand
-     */
+    /** @param {Brand} brand */
     get(brand) {
       return managers.get(brand);
     },

--- a/packages/inter-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/inter-protocol/src/vaultFactory/prioritizedVaults.js
@@ -47,8 +47,8 @@ export const currentDebtToCollateral = vault =>
  * Vaults, ordered by their debt ratio so that all the vaults below a threshold
  * can be quickly found and liquidated.
  *
- * @param {MapStore<string, Vault>} store
- * vault has a higher debt ratio than the previous highest
+ * @param {MapStore<string, Vault>} store vault has a higher debt ratio than the
+ *   previous highest
  */
 export const makePrioritizedVaults = store => {
   const vaults = makeOrderedVaultStore(store);

--- a/packages/inter-protocol/src/vaultFactory/proceeds.js
+++ b/packages/inter-protocol/src/vaultFactory/proceeds.js
@@ -11,27 +11,32 @@ import { liquidationResults } from './liquidation.js';
 
 /**
  * @typedef {{
- *   overage: Amount<'nat'>,
- *   shortfallToReserve: Amount<'nat'>,
- *   collateralForReserve: Amount<'nat'>,
- *   actualCollateralSold: Amount<'nat'>,
- *   collateralSold: Amount<'nat'>,
- *   collatRemaining: Amount<'nat'>,
- *   debtToBurn: Amount<'nat'>,
- *   mintedForReserve: Amount<'nat'>,
- *   mintedProceeds: Amount<'nat'>,
- *   phantomDebt: Amount<'nat'>,
- *   totalPenalty: Amount<'nat'>,
- *   transfersToVault: Array<[number, AmountKeywordRecord]>,
- *   vaultsToReinstate: Array<number>
+ *   overage: Amount<'nat'>;
+ *   shortfallToReserve: Amount<'nat'>;
+ *   collateralForReserve: Amount<'nat'>;
+ *   actualCollateralSold: Amount<'nat'>;
+ *   collateralSold: Amount<'nat'>;
+ *   collatRemaining: Amount<'nat'>;
+ *   debtToBurn: Amount<'nat'>;
+ *   mintedForReserve: Amount<'nat'>;
+ *   mintedProceeds: Amount<'nat'>;
+ *   phantomDebt: Amount<'nat'>;
+ *   totalPenalty: Amount<'nat'>;
+ *   transfersToVault: [number, AmountKeywordRecord][];
+ *   vaultsToReinstate: number[];
  * }} DistributionPlan
+ *   The plan to execute for distributing proceeds of a liquidation.
  *
- * The plan to execute for distributing proceeds of a liquidation.
- *
- * Vaults are referenced by index in the list sent to the calculator.
+ *   Vaults are referenced by index in the list sent to the calculator.
  */
 
-/** @typedef {{ collateral: Amount<'nat'>, presaleDebt:  Amount<'nat'>, currentDebt: Amount<'nat'> }} VaultBalances */
+/**
+ * @typedef {{
+ *   collateral: Amount<'nat'>;
+ *   presaleDebt: Amount<'nat'>;
+ *   currentDebt: Amount<'nat'>;
+ * }} VaultBalances
+ */
 
 /**
  * Liquidation.md describes how to process liquidation proceeds.
@@ -46,7 +51,8 @@ import { liquidationResults } from './liquidation.js';
  * @param {Amount<'nat'>} inputs.totalDebt
  * @param {Amount<'nat'>} inputs.totalCollateral
  * @param {PriceDescription} inputs.oraclePriceAtStart
- * @param {Array<VaultBalances>} inputs.vaultsBalances ordered best to worst collateralized
+ * @param {VaultBalances[]} inputs.vaultsBalances ordered best to worst
+ *   collateralized
  * @param {Ratio} inputs.penaltyRate
  * @returns {DistributionPlan}
  */

--- a/packages/inter-protocol/src/vaultFactory/storeUtils.js
+++ b/packages/inter-protocol/src/vaultFactory/storeUtils.js
@@ -19,13 +19,9 @@ const { multiply } = natSafeMath;
 
 const trace = makeTracer('Store', true);
 
-/**
- * @typedef {import('@endo/marshal').PureData} PureData
- */
+/** @typedef {import('@endo/marshal').PureData} PureData */
 
-/**
- * @typedef {[normalizedCollateralization: number, vaultId: VaultId]} CompositeKey
- */
+/** @typedef {[normalizedCollateralization: number, vaultId: VaultId]} CompositeKey */
 
 // `makeEncodePassable` has three named options:
 // `encodeRemotable`, `encodeError`, and `encodePromise`.
@@ -69,12 +65,12 @@ const decodeNumber = encoded => {
 };
 
 // Type annotations to support static testing of amount values
-/** @typedef {Amount<'nat'> & {normalized: true}} NormalizedDebt */
-/** @typedef {Amount<'nat'> & {normalized: false}} ActualDebt */
+/** @typedef {Amount<'nat'> & { normalized: true }} NormalizedDebt */
+/** @typedef {Amount<'nat'> & { normalized: false }} ActualDebt */
 
 /**
- * Overcollateralized are greater than one.
- * The more undercollaterized the smaller in [0-1].
+ * Overcollateralized are greater than one. The more undercollaterized the
+ * smaller in [0-1].
  *
  * @param {NormalizedDebt} normalizedDebt normalized (not actual) total debt
  * @param {Amount<'nat'>} collateral
@@ -95,7 +91,7 @@ const collateralizationRatio = (normalizedDebt, collateral) => {
  * @param {Amount<'nat'>} collateral
  * @param {VaultId} vaultId
  * @returns {string} lexically sortable string in which highest
- * debt-to-collateral is earliest
+ *   debt-to-collateral is earliest
  */
 export const toVaultKey = (normalizedDebt, collateral, vaultId) => {
   assert(normalizedDebt);
@@ -162,7 +158,7 @@ harden(normalizedCollRatio);
  * @param {Ratio} compoundedStabilityFee
  * @param {Ratio} margin
  * @returns {string} lexically sortable string in which highest
- * debt-to-collateral is earliest
+ *   debt-to-collateral is earliest
  */
 export const normalizedCollRatioKey = (
   quote,

--- a/packages/inter-protocol/src/vaultFactory/types.js
+++ b/packages/inter-protocol/src/vaultFactory/types.js
@@ -2,21 +2,30 @@
 
 /**
  * @typedef {import('./vault').VaultNotification} VaultNotification
+ *
  * @typedef {import('./vault').Vault} Vault
+ *
  * @typedef {import('./vaultKit').VaultKit} VaultKit
+ *
  * @typedef {import('./vaultManager').VaultManager} VaultManager
+ *
  * @typedef {import('./vaultManager').CollateralManager} CollateralManager
+ *
  * @typedef {import('../reserve/assetReserve.js').AssetReserveLimitedCreatorFacet} AssetReserveCreatorFacet
+ *
  * @typedef {import('../reserve/assetReserve.js').AssetReservePublicFacet} AssetReservePublicFacet
+ *
  * @typedef {import('../auction/auctioneer.js').AuctioneerPublicFacet} AuctioneerPublicFacet
+ *
  * @typedef {import('./vaultFactory.js').VaultFactoryContract['publicFacet']} VaultFactoryPublicFacet
  *
  * @typedef {import('@agoric/time/src/types').Timestamp} Timestamp
+ *
  * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime
  */
 
 /**
- * @typedef  {object} AutoswapLocal
+ * @typedef {object} AutoswapLocal
  * @property {(amount: Amount, brand: Brand) => Amount} getInputPrice
  * @property {() => Invitation} makeSwapInvitation
  */
@@ -24,13 +33,16 @@
 /**
  * @typedef {object} VaultManagerParamValues
  * @property {Ratio} liquidationMargin - margin below which collateral will be
- * liquidated to satisfy the debt.
- * @property {Ratio} liquidationPenalty - penalty charged upon liquidation as proportion of debt
- * @property {Ratio} stabilityFee - annual interest rate charged on debt positions
- * @property {Ratio} mintFee - The fee (in BasisPoints) charged when creating
- * or increasing a debt position.
+ *   liquidated to satisfy the debt.
+ * @property {Ratio} liquidationPenalty - penalty charged upon liquidation as
+ *   proportion of debt
+ * @property {Ratio} stabilityFee - annual interest rate charged on debt
+ *   positions
+ * @property {Ratio} mintFee - The fee (in BasisPoints) charged when creating or
+ *   increasing a debt position.
  * @property {Amount<'nat'>} debtLimit
- * @property {Ratio} [liquidationPadding] - vault must maintain this in order to remove collateral or add debt
+ * @property {Ratio} [liquidationPadding] - vault must maintain this in order to
+ *   remove collateral or add debt
  */
 
 /**
@@ -42,7 +54,7 @@
  */
 
 /**
- * @typedef  {object} VaultFactoryCreatorFacet
+ * @typedef {object} VaultFactoryCreatorFacet
  * @property {AddVaultType} addVaultType
  * @property {() => Allocation} getRewardAllocation
  * @property {() => Promise<Invitation<string, never>>} makeCollectFeesInvitation
@@ -51,10 +63,10 @@
  */
 
 /**
- * @callback MintAndTransfer
- * Mint new debt `toMint` and transfer the `fee` portion to the vaultFactory's reward
- * pool. Then reallocate over all the seat arguments and the rewardPoolSeat. Update
- * the `totalDebt` if the reallocate succeeds.
+ * @callback MintAndTransfer Mint new debt `toMint` and transfer the `fee`
+ *   portion to the vaultFactory's reward pool. Then reallocate over all the
+ *   seat arguments and the rewardPoolSeat. Update the `totalDebt` if the
+ *   reallocate succeeds.
  * @param {ZCFSeat} mintReceiver
  * @param {Amount<'nat'>} toMint
  * @param {Amount<'nat'>} fee
@@ -63,11 +75,8 @@
  */
 
 /**
- * @callback BurnDebt
- *
- * Burn debt tokens off a seat and update
- * the `totalDebt` if the reallocate succeeds.
- *
+ * @callback BurnDebt Burn debt tokens off a seat and update the `totalDebt` if
+ *   the reallocate succeeds.
  * @param {Amount} toBurn
  * @param {ZCFSeat} fromSeat
  * @returns {void}
@@ -78,16 +87,15 @@
  * @property {() => Ratio} getLiquidationMargin
  * @property {() => Ratio} getMintFee
  * @property {() => Promise<PriceQuote>} getCollateralQuote
- * @property {() => Ratio} getStabilityFee - The annual interest rate on a debt position
+ * @property {() => Ratio} getStabilityFee - The annual interest rate on a debt
+ *   position
  * @property {() => RelativeTime} getChargingPeriod - The period (in seconds) at
  *   which interest is charged to the debt position.
  * @property {() => RelativeTime} getRecordingPeriod - The period (in seconds)
  *   at which interest is recorded to the debt position.
  */
 
-/**
- * @typedef {string} VaultId
- */
+/** @typedef {string} VaultId */
 
 /**
  * @typedef {object} InterestTiming
@@ -104,7 +112,9 @@
 
 /**
  * @typedef {object} Liquidator
- * @property {() => Promise<Invitation<void, { debt: Amount<'nat'>; penaltyRate: Ratio; }>>} makeLiquidateInvitation
+ * @property {() => Promise<
+ *   Invitation<void, { debt: Amount<'nat'>; penaltyRate: Ratio }>
+ * >} makeLiquidateInvitation
  */
 
 /**
@@ -124,11 +134,11 @@
 /**
  * @typedef {object} CalculatorKit
  * @property {Calculate} calculate calculate new debt for charging periods up to
- * the present.
+ *   the present.
  * @property {Calculate} calculateReportingPeriod calculate new debt for
- * reporting periods up to the present. If some charging periods have elapsed
- * that don't constitute whole reporting periods, the time is not updated past
- * them and interest is not accumulated for them.
+ *   reporting periods up to the present. If some charging periods have elapsed
+ *   that don't constitute whole reporting periods, the time is not updated past
+ *   them and interest is not accumulated for them.
  */
 
-/** @typedef {{key: 'governedParams' | {collateralBrand: Brand}}} VaultFactoryParamPath */
+/** @typedef {{ key: 'governedParams' | { collateralBrand: Brand } }} VaultFactoryParamPath */

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -43,13 +43,15 @@ const trace = makeTracer('Vault', true);
 /**
  * Constants for vault phase.
  *
- * ACTIVE - vault is in use and can be changed LIQUIDATING - vault is being
- * liquidated by the vault manager, and cannot be changed by the user. If
- * liquidation fails, vaults may remain in this state. An upgrade to the
- * contract might be able to recover them. TRANSFER - vault is able to be
- * transferred (payments and debits frozen until it has a new owner) CLOSED -
- * vault was closed by the user and all assets have been paid out LIQUIDATED -
- * vault was closed by the manager, with remaining assets paid to owner
+ * - ACTIVE - vault is in use and can be changed
+ * - LIQUIDATING - vault is being liquidated by the vault manager, and cannot be
+ *   changed by the user. If liquidation fails, vaults may remain in this state.
+ *   An upgrade to the contract might be able to recover them.
+ * - TRANSFER - vault is able to be transferred (payments and debits frozen until
+ *   it has a new owner)
+ * - CLOSED - vault was closed by the user and all assets have been paid out
+ * - LIQUIDATED - vault was closed by the manager, with remaining assets paid to
+ *   owner
  */
 export const Phase = /** @type {const} */ ({
   ACTIVE: 'active',

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -44,30 +44,34 @@ const trace = makeTracer('VD', true);
 
 /**
  * @typedef {{
- * collaterals: Brand[],
- * rewardPoolAllocation: AmountKeywordRecord,
+ *   collaterals: Brand[];
+ *   rewardPoolAllocation: AmountKeywordRecord;
  * }} MetricsNotification
  *
- * @typedef {Readonly<{
- * }>} ImmutableState
+ * @typedef {Readonly<{}>} ImmutableState
  *
- * @typedef {{
- * }} MutableState
+ * @typedef {{}} MutableState
  *
  * @typedef {ImmutableState & MutableState} State
  *
  * @typedef {{
- *  burnDebt: BurnDebt,
- *  getGovernedParams: (collateralBrand: Brand) => import('./vaultManager.js').GovernedParamGetters,
- *  mintAndTransfer: MintAndTransfer,
- *  getShortfallReporter: () => Promise<import('../reserve/assetReserve.js').ShortfallReporter>,
+ *   burnDebt: BurnDebt;
+ *   getGovernedParams: (
+ *     collateralBrand: Brand,
+ *   ) => import('./vaultManager.js').GovernedParamGetters;
+ *   mintAndTransfer: MintAndTransfer;
+ *   getShortfallReporter: () => Promise<
+ *     import('../reserve/assetReserve.js').ShortfallReporter
+ *   >;
  * }} FactoryPowersFacet
  *
  * @typedef {Readonly<{
  *   state: State;
  * }>} MethodContext
  *
- * @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager').TypedParamManager<import('./params.js').VaultDirectorParams>} VaultDirectorParamManager
+ * @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager').TypedParamManager<
+ *     import('./params.js').VaultDirectorParams
+ *   >} VaultDirectorParamManager
  */
 
 const shortfallInvitationKey = 'shortfallInvitation';
@@ -76,7 +80,7 @@ const shortfallInvitationKey = 'shortfallInvitation';
  * @param {import('@agoric/ertp').Baggage} baggage
  * @param {import('./vaultFactory.js').VaultFactoryZCF} zcf
  * @param {VaultDirectorParamManager} directorParamManager
- * @param {ZCFMint<"nat">} debtMint
+ * @param {ZCFMint<'nat'>} debtMint
  * @param {ERef<import('@agoric/time/src/types').TimerService>} timer
  * @param {ERef<import('../auction/auctioneer.js').AuctioneerPublicFacet>} auctioneer
  * @param {ERef<StorageNode>} storageNode
@@ -126,9 +130,7 @@ const prepareVaultDirector = (
 
   const managersNode = E(storageNode).makeChildNode('managers');
 
-  /**
-   * @returns {MetricsNotification}
-   */
+  /** @returns {MetricsNotification} */
   const sampleMetrics = () => {
     return harden({
       collaterals: Array.from(collateralManagers.keys()),
@@ -188,8 +190,8 @@ const prepareVaultDirector = (
     },
 
     /**
-     * Let the manager add rewards to the rewardPoolSeat without
-     * exposing the rewardPoolSeat to them.
+     * Let the manager add rewards to the rewardPoolSeat without exposing the
+     * rewardPoolSeat to them.
      *
      * @type {MintAndTransfer}
      */
@@ -264,9 +266,7 @@ const prepareVaultDirector = (
     });
   };
 
-  /**
-   * @returns {State}
-   */
+  /** @returns {State} */
   const initState = () => {
     return {};
   };
@@ -276,7 +276,7 @@ const prepareVaultDirector = (
    *
    * @param {import('./vaultFactory.js').VaultFactoryZCF} zcf
    * @param {VaultDirectorParamManager} directorParamManager
-   * @param {ZCFMint<"nat">} debtMint
+   * @param {ZCFMint<'nat'>} debtMint
    */
   const makeVaultDirector = prepareExoClassKit(
     baggage,
@@ -331,9 +331,7 @@ const prepareVaultDirector = (
               }
             },
           }),
-        /**
-         * @param {string} name
-         */
+        /** @param {string} name */
         getInvitation(name) {
           return directorParamManager.getInternalParamValue(name);
         },
@@ -442,9 +440,7 @@ const prepareVaultDirector = (
         },
       },
       public: {
-        /**
-         * @param {Brand} brandIn
-         */
+        /** @param {Brand} brandIn */
         getCollateralManager(brandIn) {
           collateralManagers.has(brandIn) ||
             Fail`Not a supported collateral type ${brandIn}`;
@@ -465,22 +461,16 @@ const prepareVaultDirector = (
         getPublicTopics() {
           return topics;
         },
-        /**
-         * subscription for the paramManager for the vaultFactory's electorate
-         */
+        /** subscription for the paramManager for the vaultFactory's electorate */
         getElectorateSubscription() {
           return directorParamManager.getSubscription();
         },
-        /**
-         * @param {{ collateralBrand: Brand }} selector
-         */
+        /** @param {{ collateralBrand: Brand }} selector */
         getGovernedParams({ collateralBrand }) {
           // TODO use named getters of TypedParamManager
           return vaultParamManagers.get(collateralBrand).getParams();
         },
-        /**
-         * @param {string} name
-         */
+        /** @param {string} name */
         getInvitationAmount(name) {
           return directorParamManager.getInvitationAmount(name);
         },
@@ -500,9 +490,7 @@ const prepareVaultDirector = (
             rescheduleWaker,
           );
         },
-        /**
-         * Start non-durable processes (or restart if needed after vat restart)
-         */
+        /** Start non-durable processes (or restart if needed after vat restart) */
         async start() {
           const { helper, machine } = this.facets;
 
@@ -527,7 +515,9 @@ harden(prepareVaultDirector);
 /**
  * Prepare the VaultDirector kind, get or make the singleton
  *
- * @type {(...pvdArgs: Parameters<typeof prepareVaultDirector>) => ReturnType<ReturnType<typeof prepareVaultDirector>>}
+ * @type {(
+ *   ...pvdArgs: Parameters<typeof prepareVaultDirector>
+ * ) => ReturnType<ReturnType<typeof prepareVaultDirector>>}
  */
 export const provideDirector = (...args) => {
   const makeVaultDirector = prepareVaultDirector(...args);

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -34,12 +34,14 @@ import { provideDirector } from './vaultDirector.js';
 const trace = makeTracer('VF', true);
 
 /**
- * @typedef {ZCF<GovernanceTerms<import('./params').VaultDirectorParams> & {
- *   auctioneerPublicFacet: import('../auction/auctioneer.js').AuctioneerPublicFacet,
- *   priceAuthority: ERef<PriceAuthority>,
- *   reservePublicFacet: AssetReservePublicFacet,
- *   timerService: import('@agoric/time/src/types').TimerService,
- * }>} VaultFactoryZCF
+ * @typedef {ZCF<
+ *   GovernanceTerms<import('./params').VaultDirectorParams> & {
+ *     auctioneerPublicFacet: import('../auction/auctioneer.js').AuctioneerPublicFacet;
+ *     priceAuthority: ERef<PriceAuthority>;
+ *     reservePublicFacet: AssetReservePublicFacet;
+ *     timerService: import('@agoric/time/src/types').TimerService;
+ *   }
+ * >} VaultFactoryZCF
  */
 
 export const privateArgsShape = M.splitRecord(
@@ -59,11 +61,11 @@ harden(privateArgsShape);
 /**
  * @param {VaultFactoryZCF} zcf
  * @param {{
- *   feeMintAccess: FeeMintAccess,
- *   initialPoserInvitation: Invitation,
- *   initialShortfallInvitation: Invitation,
- *   storageNode: ERef<StorageNode>,
- *   marshaller: ERef<Marshaller>,
+ *   feeMintAccess: FeeMintAccess;
+ *   initialPoserInvitation: Invitation;
+ *   initialShortfallInvitation: Invitation;
+ *   storageNode: ERef<StorageNode>;
+ *   marshaller: ERef<Marshaller>;
  * }} privateArgs
  * @param {import('@agoric/ertp').Baggage} baggage
  */

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -1,6 +1,4 @@
-/**
- * @file Use-object for the owner of a vault
- */
+/** @file Use-object for the owner of a vault */
 import { AmountShape } from '@agoric/ertp';
 import { M, prepareExoClassKit } from '@agoric/vat-data';
 import { TopicsRecordShape } from '@agoric/zoe/src/contractSupport/index.js';
@@ -10,8 +8,8 @@ const { Fail } = assert;
 
 /**
  * @typedef {{
- * topicKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<VaultNotification>,
- * vault: Vault | null,
+ *   topicKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<VaultNotification>;
+ *   vault: Vault | null;
  * }} State
  */
 
@@ -25,7 +23,7 @@ const HolderI = M.interface('holder', {
   makeTransferInvitation: M.call().returns(M.promise()),
 });
 
-/** @type {{ [name: string]: [ description: string, valueShape: Pattern ] }} */
+/** @type {{ [name: string]: [description: string, valueShape: Pattern] }} */
 const PUBLIC_TOPICS = {
   vault: ['Vault holder status', M.any()],
 };
@@ -48,7 +46,6 @@ export const prepareVaultHolder = (baggage, makeRecorderKit) => {
       }),
     },
     /**
-     *
      * @param {Vault} vault
      * @param {StorageNode} storageNode
      * @returns {State}
@@ -61,9 +58,7 @@ export const prepareVaultHolder = (baggage, makeRecorderKit) => {
     },
     {
       helper: {
-        /**
-         * @throws if this holder no longer owns the vault
-         */
+        /** @throws if this holder no longer owns the vault */
         owned() {
           const { vault } = this.state;
           if (!vault) {
@@ -104,8 +99,8 @@ export const prepareVaultHolder = (baggage, makeRecorderKit) => {
           return this.facets.helper.owned().makeCloseInvitation();
         },
         /**
-         * Starting a transfer revokes the vault holder. The associated updater will
-         * get a special notification that the vault is being transferred.
+         * Starting a transfer revokes the vault holder. The associated updater
+         * will get a special notification that the vault is being transferred.
          */
         makeTransferInvitation() {
           const vault = this.facets.helper.owned();

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -8,7 +8,8 @@ import { prepareVaultHolder } from './vaultHolder.js';
 const trace = makeTracer('VK', true);
 
 /**
- * Wrap the VaultHolder duration object in a record suitable for the result of an invitation.
+ * Wrap the VaultHolder duration object in a record suitable for the result of
+ * an invitation.
  *
  * @param {import('@agoric/ertp').Baggage} baggage
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit} makeRecorderKit
@@ -43,4 +44,4 @@ export const prepareVaultKit = (baggage, makeRecorderKit) => {
   return makeVaultKit;
 };
 
-/** @typedef {(ReturnType<ReturnType<typeof prepareVaultKit>>)} VaultKit */
+/** @typedef {ReturnType<ReturnType<typeof prepareVaultKit>>} VaultKit */

--- a/packages/inter-protocol/test/auction/test-auctionContract.js
+++ b/packages/inter-protocol/test/auction/test-auctionContract.js
@@ -39,14 +39,20 @@ const test = anyTest;
 
 /**
  * @typedef {Record<string, any> & {
- * bid: IssuerKit & import('../supports.js').AmountUtils,
- * collateral: IssuerKit & import('../supports.js').AmountUtils,
- * zoe: ZoeService,
+ *   bid: IssuerKit & import('../supports.js').AmountUtils;
+ *   collateral: IssuerKit & import('../supports.js').AmountUtils;
+ *   zoe: ZoeService;
  * }} Context
  */
 
 /**
- * @typedef {Awaited<ReturnType<subscriptionTracker<import('../../src/auction/auctionBook.js').BookDataNotification>>>} BookDataTracker
+ * @typedef {Awaited<
+ *   ReturnType<
+ *     subscriptionTracker<
+ *       import('../../src/auction/auctionBook.js').BookDataNotification
+ *     >
+ *   >
+ * >} BookDataTracker
  */
 
 const trace = makeTracer('Test AuctContract', false);
@@ -86,8 +92,10 @@ test.before(async t => {
 });
 
 /**
- * @param {import('ava').ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
- * @param {*} params
+ * @param {import('ava').ExecutionContext<
+ *   Awaited<ReturnType<makeTestContext>>
+ * >} t
+ * @param {any} params
  */
 export const setupServices = async (t, params = defaultParams) => {
   const {
@@ -122,7 +130,9 @@ export const setupServices = async (t, params = defaultParams) => {
 };
 
 /**
- * @param {import('ava').ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
+ * @param {import('ava').ExecutionContext<
+ *   Awaited<ReturnType<makeTestContext>>
+ * >} t
  * @param {any} [params]
  */
 const makeAuctionDriver = async (t, params = defaultParams) => {
@@ -208,7 +218,7 @@ const makeAuctionDriver = async (t, params = defaultParams) => {
     return seat;
   };
 
-  /** @type {MapStore<Brand,BookDataTracker>} */
+  /** @type {MapStore<Brand, BookDataTracker>} */
   const bookDataTrackers = makeScalarMapStore('trackers');
 
   /**

--- a/packages/inter-protocol/test/auction/test-proportionalDist.js
+++ b/packages/inter-protocol/test/auction/test-proportionalDist.js
@@ -29,13 +29,14 @@ test.before(async t => {
 });
 
 /**
- * @see {distributeProportionalSharesWithLimits} for logical cases A-E
- *
- * @param {import('ava').ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
+ * @param {import('ava').ExecutionContext<
+ *   Awaited<ReturnType<makeTestContext>>
+ * >} t
  * @param {[collateralReturned: bigint, bidRaise: bigint]} amountsReturned
- * @param {Array<{deposit: number, goal?: number}>} rawDeposits
- * @param {[transfers: Array<[bigint, bigint]>, leftovers: [bigint, bigint]]} rawExpected
+ * @param {{ deposit: number; goal?: number }[]} rawDeposits
+ * @param {[transfers: [bigint, bigint][], leftovers: [bigint, bigint]]} rawExpected
  * @param {string} kwd
+ * @see {distributeProportionalSharesWithLimits} for logical cases A-E
  */
 const checkProportions = (
   t,
@@ -191,7 +192,7 @@ test(
   ],
 );
 
-const transferSharing20 = /** @type {Array<[bigint, bigint]>} */ ([
+const transferSharing20 = /** @type {[bigint, bigint][]} */ ([
   [20n, 4n],
   [60n, 12n],
   [20n, 4n],

--- a/packages/inter-protocol/test/auction/test-scheduleMath.js
+++ b/packages/inter-protocol/test/auction/test-scheduleMath.js
@@ -37,7 +37,7 @@ const makeDefaultParams = ({
 
 /**
  * @param {any} t
- * @param {*} params
+ * @param {any} params
  * @param {number} baseTime
  * @param {any} rawExpect
  */
@@ -58,7 +58,7 @@ const checkSchedule = (t, params, baseTime, rawExpect) => {
 
 /**
  * @param {any} t
- * @param {*} params
+ * @param {any} params
  * @param {number} baseTime
  * @param {string | RegExp} message
  */

--- a/packages/inter-protocol/test/auction/test-scheduler.js
+++ b/packages/inter-protocol/test/auction/test-scheduler.js
@@ -27,7 +27,7 @@ import {
 test('schedule start to finish', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => bigint; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => bigint }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -258,7 +258,7 @@ test('schedule start to finish', async t => {
 test('lowest >= starting', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => void; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => void }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -306,7 +306,7 @@ test('lowest >= starting', async t => {
 test('zero time for auction', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => void; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => void }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -355,7 +355,7 @@ test('zero time for auction', async t => {
 test('discountStep 0', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => void; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => void }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -401,7 +401,7 @@ test('discountStep 0', async t => {
 test('discountStep larger than starting rate', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => void; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => void }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -448,7 +448,7 @@ test('discountStep larger than starting rate', async t => {
 test('start Freq 0', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => void; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => void }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -494,7 +494,7 @@ test('start Freq 0', async t => {
 test('delay > freq', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => void; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => void }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -541,7 +541,7 @@ test('delay > freq', async t => {
 test('lockPeriod > freq', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => void; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => void }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -590,7 +590,7 @@ test('lockPeriod > freq', async t => {
 test('duration = freq', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => void; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => void }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -671,7 +671,7 @@ test('duration = freq', async t => {
 test('change Schedule', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => void; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => void }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -864,7 +864,7 @@ test('change Schedule', async t => {
 test('change Schedule late', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => void; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => void }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
 
@@ -1087,7 +1087,7 @@ test('change Schedule late', async t => {
 test('schedule anomalies', async t => {
   const { zcf, zoe } = await setupZCFTest();
   const installations = await setUpInstallations(zoe);
-  /** @type {TimerService & { advanceTo: (when: Timestamp) => bigint; }} */
+  /** @type {TimerService & { advanceTo: (when: Timestamp) => bigint }} */
   const timer = buildManualTimer();
   const timerBrand = await timer.getTimerBrand();
   const timestamp = time => TimeMath.coerceTimestampRecord(time, timerBrand);

--- a/packages/inter-protocol/test/auction/tools.js
+++ b/packages/inter-protocol/test/auction/tools.js
@@ -12,16 +12,18 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
 
 /**
  * @typedef {{
- * autoRefund: Installation<import('@agoric/zoe/src/contracts/automaticRefund').start>,
- * auctioneer: Installation<import('../../src/auction/auctioneer').start>,
- * governor: Installation<import('@agoric/governance/src/contractGovernor.js')['prepare']>,
- * reserve: Installation<import('../../src/reserve/assetReserve.js').prepare>,
+ *   autoRefund: Installation<
+ *     import('@agoric/zoe/src/contracts/automaticRefund').start
+ *   >;
+ *   auctioneer: Installation<import('../../src/auction/auctioneer').start>;
+ *   governor: Installation<
+ *     import('@agoric/governance/src/contractGovernor.js')['prepare']
+ *   >;
+ *   reserve: Installation<import('../../src/reserve/assetReserve.js').prepare>;
  * }} AuctionTestInstallations
  */
 
-/**
- * @param {ZoeService} zoe
- */
+/** @param {ZoeService} zoe */
 export const setUpInstallations = async zoe => {
   const autoRefund = '@agoric/zoe/src/contracts/automaticRefund.js';
   const autoRefundUrl = await importMetaResolve(autoRefund, import.meta.url);

--- a/packages/inter-protocol/test/metrics.js
+++ b/packages/inter-protocol/test/metrics.js
@@ -15,7 +15,8 @@ const trace = makeTracer('TestMetrics', false);
 
 /**
  * @template {object} N
- * @param {AsyncIterable<N, N> | import('@agoric/zoe/src/contractSupport/topics.js').PublicTopic<N>} mixed
+ * @param {| AsyncIterable<N, N>
+ *   | import('@agoric/zoe/src/contractSupport/topics.js').PublicTopic<N>} mixed
  */
 const asNotifier = mixed => {
   if ('subscriber' in mixed) {
@@ -27,7 +28,8 @@ const asNotifier = mixed => {
 /**
  * @template {object} N
  * @param {import('ava').ExecutionContext} t
- * @param {AsyncIterable<N, N> | import('@agoric/zoe/src/contractSupport/topics.js').PublicTopic<N>} subscription
+ * @param {| AsyncIterable<N, N>
+ *   | import('@agoric/zoe/src/contractSupport/topics.js').PublicTopic<N>} subscription
  */
 export const subscriptionTracker = async (t, subscription) => {
   const metrics = asNotifier(subscription);
@@ -76,7 +78,9 @@ export const subscriptionTracker = async (t, subscription) => {
  *
  * @template {object} N
  * @param {import('ava').ExecutionContext} t
- * @param {ERef<{getPublicTopics?: () => {metrics: {subscriber: Subscriber<N>}}}>} publicFacet
+ * @param {ERef<{
+ *   getPublicTopics?: () => { metrics: { subscriber: Subscriber<N> } };
+ * }>} publicFacet
  */
 export const metricsTracker = async (t, publicFacet) => {
   const publicTopics = await E(publicFacet).getPublicTopics();
@@ -89,7 +93,15 @@ export const metricsTracker = async (t, publicFacet) => {
  */
 export const vaultManagerMetricsTracker = async (t, publicFacet) => {
   let totalDebtEver = 0n;
-  /** @type {Awaited<ReturnType<typeof subscriptionTracker<import('../src/vaultFactory/vaultManager').MetricsNotification>>>} */
+  /**
+   * @type {Awaited<
+   *   ReturnType<
+   *     typeof subscriptionTracker<
+   *       import('../src/vaultFactory/vaultManager').MetricsNotification
+   *     >
+   *   >
+   * >}
+   */
   const m = await metricsTracker(t, publicFacet);
 
   /** @returns {bigint} Proceeds - overage + shortfall */

--- a/packages/inter-protocol/test/psm/gov-add-psm.js
+++ b/packages/inter-protocol/test/psm/gov-add-psm.js
@@ -3,10 +3,10 @@
 
 /**
  * @typedef {{
- *   denom: string,
- *   keyword?: string,
- *   proposedName?: string,
- *   decimalPlaces?: number
+ *   denom: string;
+ *   keyword?: string;
+ *   proposedName?: string;
+ *   decimalPlaces?: number;
  * }} AnchorOptions
  */
 

--- a/packages/inter-protocol/test/psm/gov-replace-committee.js
+++ b/packages/inter-protocol/test/psm/gov-replace-committee.js
@@ -1,6 +1,9 @@
 /* global E */
 // @ts-nocheck
-/** @file Script to replace the econ governance committee in a SwingSet Core Eval (aka big hammer) */
+/**
+ * @file Script to replace the econ governance committee in a SwingSet Core Eval
+ *   (aka big hammer)
+ */
 
 const { Fail } = assert;
 
@@ -19,7 +22,7 @@ const trace = (...args) => console.log('GovReplaceCommitee', ...args);
 
 const { values } = Object;
 
-/** @type { <X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
+/** @type {<X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
 const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
 
 /**
@@ -28,7 +31,6 @@ const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
  */
 const reserveThenGetNamePaths = async (nameAdmin, paths) => {
   /**
-   *
    * @param {ERef<NameAdmin>} nextAdmin
    * @param {string[]} path
    */
@@ -90,9 +92,7 @@ const invitePSMCommitteeMembers = async (
   ).getVoterInvitations();
   assert.equal(invitations.length, values(voterAddresses).length);
 
-  /**
-   * @param {[string, Promise<Invitation>][]} addrInvitations
-   */
+  /** @param {[string, Promise<Invitation>][]} addrInvitations */
   const distributeInvitations = async addrInvitations => {
     await Promise.all(
       addrInvitations.map(async ([addr, invitationP]) => {
@@ -233,9 +233,9 @@ const main = async permittedPowers => {
 /**
  * How to test on chain
  *
- * Execute core eval with a dictorator (electorate n=1)
- * Have the old electorate and new electorate vote for different PSM param changes
- * Verify the old's were ignored and the new's were enacted
+ * Execute core eval with a dictorator (electorate n=1) Have the old electorate
+ * and new electorate vote for different PSM param changes Verify the old's were
+ * ignored and the new's were enacted
  */
 
 // "export" from script

--- a/packages/inter-protocol/test/psm/psm-storage-fixture.js
+++ b/packages/inter-protocol/test/psm/psm-storage-fixture.js
@@ -3,9 +3,10 @@
  *
  * Taken from mainnet; for example, the 1st value comes from...
  *
- * `agd --node https://main.rpc.agoric.net:443 query vstorage data published.agoricNames.brand -o json | jq .value`
+ * `agd --node https://main.rpc.agoric.net:443 query vstorage data
+ * published.agoricNames.brand -o json | jq .value`
  *
- * @type {Array<[key: string, value: string]>}
+ * @type {[key: string, value: string][]}
  */
 export const chainStorageEntries = [
   [

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -22,9 +22,7 @@ import { startPSM, startEconCharter } from '../../src/proposals/startPSM.js';
 const psmRoot = './src/psm/psm.js'; // package relative
 const charterRoot = './src/econCommitteeCharter.js'; // package relative
 
-/**
- * @typedef {ReturnType<typeof setUpZoeForTest>} FarZoeKit
- */
+/** @typedef {ReturnType<typeof setUpZoeForTest>} FarZoeKit */
 
 /**
  * @param {import('@agoric/time/src/types').TimerService} timer
@@ -39,7 +37,7 @@ export const setupPsmBootstrap = async (
 
   const space = /** @type {any} */ (makePromiseSpace());
   const { produce, consume } =
-    /** @type { import('../../src/proposals/econ-behaviors.js').EconomyBootstrapPowers } */ (
+    /** @type {import('../../src/proposals/econ-behaviors.js').EconomyBootstrapPowers} */ (
       space
     );
 
@@ -63,8 +61,8 @@ export const setupPsmBootstrap = async (
 };
 
 /**
- * @param {*} t
- * @param {{ committeeName: string, committeeSize: number}} electorateTerms
+ * @param {any} t
+ * @param {{ committeeName: string; committeeSize: number }} electorateTerms
  * @param {ManualTimer} [timer]
  * @param {FarZoeKit} [farZoeKit]
  */

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -179,7 +179,9 @@ test.before(async t => {
 });
 
 /**
- * @param {import('ava').ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
+ * @param {import('ava').ExecutionContext<
+ *   Awaited<ReturnType<makeTestContext>>
+ * >} t
  * @param {{}} [customTerms]
  */
 async function makePsmDriver(t, customTerms) {
@@ -396,7 +398,15 @@ test('limit is for minted', async t => {
   );
 });
 
-/** @type {[kind: 'want' | 'give', give: number, want: number, ok: boolean, wants?: number][]} */
+/**
+ * @type {[
+ *   kind: 'want' | 'give',
+ *   give: number,
+ *   want: number,
+ *   ok: boolean,
+ *   wants?: number,
+ * ][]}
+ */
 const trades = [
   ['give', 200, 190, false],
   ['want', 101, 100, true, 1],
@@ -740,7 +750,7 @@ const makeMockBankManager = t => {
 };
 
 test('restore PSM: startPSM with previous metrics, params', async t => {
-  /** @type { import('../../src/proposals/econ-behaviors').EconomyBootstrapPowers } */
+  /** @type {import('../../src/proposals/econ-behaviors').EconomyBootstrapPowers} */
   // @ts-expect-error mock
   const { produce, consume } = makePromiseSpace();
   const { agoricNames, agoricNamesAdmin, spaces } =

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -17,21 +17,19 @@ import { startEconomicCommittee } from '../../src/proposals/startEconCommittee.j
 const reserveRoot = './src/reserve/assetReserve.js'; // package relative
 const faucetRoot = './test/vaultFactory/faucet.js';
 
-/**
- * @typedef {ReturnType<typeof setUpZoeForTest>} FarZoeKit
- */
+/** @typedef {ReturnType<typeof setUpZoeForTest>} FarZoeKit */
 
 /**
  * NOTE: called separately by each test so zoe/priceAuthority don't interfere
  *
- * @param {*} t
+ * @param {any} t
  * @param {ManualTimer | undefined} timer
  * @param {FarZoeKit} farZoeKit
  */
 const setupReserveBootstrap = async (t, timer, farZoeKit) => {
   const space = /** @type {any} */ (makePromiseSpace());
   const { produce, consume } =
-    /** @type { import('../../src/proposals/econ-behaviors.js').EconomyBootstrapPowers } */ (
+    /** @type {import('../../src/proposals/econ-behaviors.js').EconomyBootstrapPowers} */ (
       space
     );
 
@@ -56,17 +54,17 @@ const setupReserveBootstrap = async (t, timer, farZoeKit) => {
 
 /**
  * @typedef {{
- * reserveCreatorFacet: import('../../src/reserve/assetReserve').AssetReserveLimitedCreatorFacet,
- * reservePublicFacet: import('../../src/reserve/assetReserve').AssetReservePublicFacet,
- * instance: Instance,
+ *   reserveCreatorFacet: import('../../src/reserve/assetReserve').AssetReserveLimitedCreatorFacet;
+ *   reservePublicFacet: import('../../src/reserve/assetReserve').AssetReservePublicFacet;
+ *   instance: Instance;
  * }} ReserveKit
  */
 
 /**
  * NOTE: called separately by each test so contracts don't interfere
  *
- * @param {import("ava").ExecutionContext<unknown>} t
- * @param {{ committeeName: string, committeeSize: number}} electorateTerms
+ * @param {import('ava').ExecutionContext<unknown>} t
+ * @param {{ committeeName: string; committeeSize: number }} electorateTerms
  * @param {ManualTimer} [timer]
  */
 export const setupReserveServices = async (

--- a/packages/inter-protocol/test/reserve/test-reserve.js
+++ b/packages/inter-protocol/test/reserve/test-reserve.js
@@ -12,8 +12,8 @@ import { setupReserveServices } from './setup.js';
 /**
  * @param {ERef<ZoeService>} zoe
  * @param {ERef<FeeMintAccess>} feeMintAccessP
- * @param {*} faucetInstallation
- * @param {*} stableInitialLiquidity
+ * @param {any} faucetInstallation
+ * @param {any} stableInitialLiquidity
  */
 const getRunFromFaucet = async (
   zoe,

--- a/packages/inter-protocol/test/smartWallet/boot-psm.js
+++ b/packages/inter-protocol/test/smartWallet/boot-psm.js
@@ -91,8 +91,7 @@ export const installGovAndPSMContracts = async ({
 };
 
 /**
- * PSM and gov contracts are available as
- * named swingset bundles only in
+ * PSM and gov contracts are available as named swingset bundles only in
  * decentral-psm-config.json
  *
  * @type {import('@agoric/vats/src/core/lib-boot.js').BootstrapManifest}
@@ -113,9 +112,7 @@ export const PSM_GOV_MANIFEST = {
   },
 };
 
-/**
- * We reserve these keys in name hubs.
- */
+/** We reserve these keys in name hubs. */
 export const agoricNamesReserved = harden(
   /** @type {const} */ ({
     issuer: {
@@ -157,10 +154,10 @@ export const agoricNamesReserved = harden(
 
 /**
  * @typedef {{
- *   denom: string,
- *   keyword?: string,
- *   proposedName?: string,
- *   decimalPlaces?: number
+ *   denom: string;
+ *   keyword?: string;
+ *   proposedName?: string;
+ *   decimalPlaces?: number;
  * }} AnchorOptions
  */
 const AnchorOptionsShape = M.splitRecord(
@@ -184,12 +181,12 @@ export const ParametersShape = M.splitRecord(
  * Build root object of the PSM-only bootstrap vat.
  *
  * @param {{
- *   D: DProxy
- *   logger?: (msg: string) => void
+ *   D: DProxy;
+ *   logger?: (msg: string) => void;
  * }} vatPowers
  * @param {{
- *     economicCommitteeAddresses: Record<string, string>,
- *     anchorAssets: { denom: string, keyword?: string }[],
+ *   economicCommitteeAddresses: Record<string, string>;
+ *   anchorAssets: { denom: string; keyword?: string }[];
  * }} vatParameters
  */
 export const buildRootObject = async (vatPowers, vatParameters) => {
@@ -207,7 +204,7 @@ export const buildRootObject = async (vatPowers, vatParameters) => {
 
   const runBootstrapParts = async (vats, devices) => {
     /** TODO: BootstrapPowers type puzzle */
-    /** @type { any } */
+    /** @type {any} */
     const allPowers = harden({
       vatPowers,
       vatParameters,

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -62,7 +62,11 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     `${dirname}/../../../smart-wallet/src/walletFactory.js`,
     'walletFactory',
   );
-  /** @type {Promise<Installation<import('@agoric/smart-wallet/src/walletFactory.js').prepare>>} */
+  /**
+   * @type {Promise<
+   *   Installation<import('@agoric/smart-wallet/src/walletFactory.js').prepare>
+   * >}
+   */
   const installation = E(zoe).install(bundle);
 
   const contractGovernorBundle = await bundleCache.load(
@@ -135,7 +139,6 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     provideWalletAndBalances(address).then(({ wallet }) => wallet);
 
   /**
-   *
    * @param {string[]} oracleAddresses
    * @param {string} inBrandName
    * @param {string} outBrandName
@@ -154,7 +157,13 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
       '../inter-protocol/src/price/fluxAggregatorContract.js',
       'priceAggregator',
     );
-    /** @type {Promise<Installation<import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').prepare>>} */
+    /**
+     * @type {Promise<
+     *   Installation<
+     *     import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').prepare
+     *   >
+     * >}
+     */
     const paInstallation = E(zoe).install(paBundle);
     await E(installAdmin).update('priceAggregator', paInstallation);
 
@@ -221,11 +230,14 @@ export const currentPurseBalance = (record, brand) => {
 };
 
 /**
- * Voting yes (first position) on the one open question using the continuing offer.
+ * Voting yes (first position) on the one open question using the continuing
+ * offer.
  *
  * @param {ERef<CommitteeElectoratePublic>} committeePublic
  * @param {string} voterAcceptanceOID
- * @returns {Promise<import('@agoric/smart-wallet/src/invitations').ContinuingInvitationSpec>}
+ * @returns {Promise<
+ *   import('@agoric/smart-wallet/src/invitations').ContinuingInvitationSpec
+ * >}
  */
 export const voteForOpenQuestion = async (
   committeePublic,

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -23,11 +23,11 @@ import {
 } from './contexts.js';
 
 /**
- * @typedef {Awaited<ReturnType<typeof makeDefaultTestContext>>
-  & { consume: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume'] } } TestContext */
-/**
- * @type {import('ava').TestFn<TestContext>}
+ * @typedef {Awaited<ReturnType<typeof makeDefaultTestContext>> & {
+ *   consume: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume'];
+ * }} TestContext
  */
+/** @type {import('ava').TestFn<TestContext>} */
 const test = anyTest;
 
 const committeeAddress = 'econCommitteeMemberA';
@@ -75,9 +75,8 @@ const makeTestSpace = async (log, bundleCache) => {
     OUT_BRAND_DECIMALS: '6',
   };
   /**
-   *
    * @param {string} name
-   * @param {number|string} decimals
+   * @param {number | string} decimals
    */
   const ensureOracleBrand = (name, decimals) => {
     const { brand } = makeIssuerKit(name, AssetKind.NAT, {
@@ -120,7 +119,11 @@ const setupFeedWithWallets = async (t, oracleAddresses) => {
 
   await t.context.simpleCreatePriceFeed(oracleAddresses, 'ATOM', 'USD');
 
-  /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').prepare>} */
+  /**
+   * @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<
+   *   import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').prepare
+   * >}
+   */
   const governedPriceAggregator = await E(agoricNames).lookup(
     'instance',
     instanceNameFor('ATOM', 'USD'),
@@ -151,7 +154,7 @@ const acceptInvitation = async (wallet, priceAggregator) => {
 
 let pushPriceCounter = 0;
 /**
- * @param {*} wallet
+ * @param {any} wallet
  * @param {string} adminOfferId
  * @param {import('@agoric/inter-protocol/src/price/roundsManager.js').PriceRound} priceRound
  * @returns {Promise<string>} offer id
@@ -195,7 +198,7 @@ test.serial('invitations', async t => {
    * @param {string} desc
    * @param {number} len
    * @param {any} balances XXX please improve this
-   * @returns {Promise<[{description: string, instance: Instance}]>}
+   * @returns {Promise<[{ description: string; instance: Instance }]>}
    */
   const getInvitationFor = async (desc, len, balances) => {
     await eventLoopIteration();
@@ -368,7 +371,11 @@ test.serial('govern oracles list', async t => {
     'instance',
     'econCommitteeCharter',
   );
-  /** @type {import('@agoric/zoe/src/zoeService/utils').Instance<import('@agoric/governance/src/committee.js')['prepare']> } */
+  /**
+   * @type {import('@agoric/zoe/src/zoeService/utils').Instance<
+   *   import('@agoric/governance/src/committee.js')['prepare']
+   * >}
+   */
   const economicCommittee = await E(agoricNames).lookup(
     'instance',
     'economicCommittee',
@@ -380,8 +387,8 @@ test.serial('govern oracles list', async t => {
    *
    * @param {string} desc
    * @param {number} len
-   * @param {{get: (b: Brand) => Amount | undefined}} balances
-   * @returns {Promise<[{description: string, instance: Instance}]>}
+   * @param {{ get: (b: Brand) => Amount | undefined }} balances
+   * @returns {Promise<[{ description: string; instance: Instance }]>}
    */
   const getInvitationFor = async (desc, len, balances) =>
     E(E(zoe).getInvitationIssuer())

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -19,9 +19,11 @@ import {
 import { headValue, sequenceCurrents, withAmountUtils } from '../supports.js';
 
 /**
- * @type {import('ava').TestFn<Awaited<ReturnType<makeDefaultTestContext>>
- * & {consume: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']}>
- * }
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<makeDefaultTestContext>> & {
+ *     consume: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume'];
+ *   }
+ * >}
  */
 const test = anyTest;
 
@@ -233,7 +235,7 @@ test('govern offerFilter', async t => {
    * @param {string} desc
    * @param {number} len
    * @param {any} balances XXX please improve this
-   * @returns {Promise<[{description: string, instance: Instance}]>}
+   * @returns {Promise<[{ description: string; instance: Instance }]>}
    */
   const getInvitationFor = async (desc, len, balances) =>
     // @ts-expect-error TS can't tell that it's going to satisfy the @returns.

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -26,7 +26,7 @@ export { makeMockChainStorageRoot };
 export const DENOM_UNIT = 1_000_000n;
 
 /**
- * @param {*} t
+ * @param {any} t
  * @param {string} sourceRoot
  * @param {string} bundleName
  * @returns {Promise<SourceBundle>}
@@ -54,16 +54,16 @@ export const setUpZoeForTest = async (setJig = () => {}) =>
 harden(setUpZoeForTest);
 
 /**
- * @param {*} t
+ * @param {any} t
  * @param {import('@agoric/time/src/types').TimerService} [optTimer]
  */
 export const setupBootstrap = async (t, optTimer) => {
   const trace = makeTracer('PromiseSpace', false);
   const space = /** @type {any} */ (makePromiseSpace(trace));
-  const { produce, consume } =
-    /** @type { import('../src/proposals/econ-behaviors.js').EconomyBootstrapPowers & BootstrapPowers } */ (
-      space
-    );
+  const { produce, consume } = /**
+   * @type {import('../src/proposals/econ-behaviors.js').EconomyBootstrapPowers &
+   *     BootstrapPowers}
+   */ (space);
 
   await produceDiagnostics(space);
 
@@ -112,9 +112,11 @@ export const installPuppetGovernance = (zoe, produce) => {
 /**
  * @param {bigint} value
  * @param {{
- *   centralSupply: ERef<Installation<import('@agoric/vats/src/centralSupply.js').start>>,
- *   feeMintAccess: ERef<FeeMintAccess>,
- *   zoe: ERef<ZoeService>,
+ *   centralSupply: ERef<
+ *     Installation<import('@agoric/vats/src/centralSupply.js').start>
+ *   >;
+ *   feeMintAccess: ERef<FeeMintAccess>;
+ *   zoe: ERef<ZoeService>;
  * }} powers
  * @returns {Promise<Payment<'nat'>>}
  */
@@ -135,9 +137,11 @@ export const mintRunPayment = async (
 
 /**
  * @typedef {import('../src/proposals/econ-behaviors.js').EconomyBootstrapPowers} Space
- *
  * @param {Space} space
- * @param {Record<keyof Space['installation']['produce'], Promise<Installation>>} installations
+ * @param {Record<
+ *   keyof Space['installation']['produce'],
+ *   Promise<Installation>
+ * >} installations
  */
 export const produceInstallations = (space, installations) => {
   for (const [key, installation] of Object.entries(installations)) {
@@ -147,16 +151,12 @@ export const produceInstallations = (space, installations) => {
 
 export const scale6 = x => BigInt(Math.round(x * 1_000_000));
 
-/**
- * @param {Pick<IssuerKit<'nat'>, 'brand' | 'issuer' | 'mint'>} kit
- */
+/** @param {Pick<IssuerKit<'nat'>, 'brand' | 'issuer' | 'mint'>} kit */
 export const withAmountUtils = kit => {
   const decimalPlaces = kit.issuer.getDisplayInfo?.()?.decimalPlaces ?? 6;
   return {
     ...kit,
-    /**
-     * @param {NatValue} v
-     */
+    /** @param {NatValue} v */
     make: v => AmountMath.make(kit.brand, v),
     makeEmpty: () => AmountMath.makeEmpty(kit.brand),
     /**
@@ -164,18 +164,14 @@ export const withAmountUtils = kit => {
      * @param {NatValue} [d]
      */
     makeRatio: (n, d) => makeRatio(n, kit.brand, d),
-    /**
-     * @param {number} n
-     */
+    /** @param {number} n */
     units: n =>
       AmountMath.make(kit.brand, BigInt(Math.round(n * 10 ** decimalPlaces))),
   };
 };
 /** @typedef {ReturnType<typeof withAmountUtils>} AmountUtils */
 
-/**
- * @param {ERef<StoredSubscription<unknown> | StoredSubscriber<unknown>>} subscription
- */
+/** @param {ERef<StoredSubscription<unknown> | StoredSubscriber<unknown>>} subscription */
 export const subscriptionKey = subscription => {
   return E(subscription)
     .getStoreKey()
@@ -190,7 +186,9 @@ export const subscriptionKey = subscription => {
 };
 
 /**
- * @param {ERef<{getPublicTopics: () => import('@agoric/zoe/src/contractSupport').TopicsRecord}>} hasTopics
+ * @param {ERef<{
+ *   getPublicTopics: () => import('@agoric/zoe/src/contractSupport').TopicsRecord;
+ * }>} hasTopics
  * @param {string} subscriberName
  */
 export const topicPath = (hasTopics, subscriberName) => {
@@ -208,9 +206,10 @@ export const headValue = async subscriber => {
 };
 
 /**
- * CAVEAT: the head may lag and you need to explicitly getUpdateSince(lastUpdateCount)
- * 
-  @type {<T>(subscription: ERef<Subscription<T>>) => Promise<T>}
+ * CAVEAT: the head may lag and you need to explicitly
+ * getUpdateSince(lastUpdateCount)
+ *
+ * @type {<T>(subscription: ERef<Subscription<T>>) => Promise<T>}
  */
 export const headValueLegacy = async subscription => {
   await eventLoopIteration();
@@ -222,7 +221,9 @@ export const headValueLegacy = async subscription => {
 
 /**
  * @param {import('ava').ExecutionContext} t
- * @param {ERef<{getPublicTopics: () => import('@agoric/zoe/src/contractSupport').TopicsRecord}>} hasTopics
+ * @param {ERef<{
+ *   getPublicTopics: () => import('@agoric/zoe/src/contractSupport').TopicsRecord;
+ * }>} hasTopics
  * @param {string} topicName
  * @param {string} path
  * @param {string[]} [dataKeys]
@@ -248,14 +249,20 @@ export const assertTopicPathData = async (
 };
 
 /**
- * Sequence currents from a wallet UpdateRecord publication feed. Note that local
- * state may not reflect the wallet's state if the initial currents are missed.
+ * Sequence currents from a wallet UpdateRecord publication feed. Note that
+ * local state may not reflect the wallet's state if the initial currents are
+ * missed.
  *
  * If this proves to be a problem we can add an option to this or a related
  * utility to reset state from RPC.
  *
- * @param {ERef<Subscriber<import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord>>} currents
- * @returns {Array<import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord>} array that grows as the subscription feeds
+ * @param {ERef<
+ *   Subscriber<
+ *     import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord
+ *   >
+ * >} currents
+ * @returns {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord[]}
+ *   array that grows as the subscription feeds
  */
 export const sequenceCurrents = currents => {
   const sequence = [];

--- a/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
@@ -39,17 +39,35 @@ export const buildRootObject = async () => {
   // for startInstance
   /**
    * @type {{
-   * committee?: Installation<import('@agoric/governance/src/committee.js')['prepare']>,
-   * fluxAggregatorV1?: Installation<import('../../../src/price/fluxAggregatorContract').prepare>,
-   * puppetContractGovernor?: Installation<import('@agoric/governance/tools/puppetContractGovernor').start>,
+   *   committee?: Installation<
+   *     import('@agoric/governance/src/committee.js')['prepare']
+   *   >;
+   *   fluxAggregatorV1?: Installation<
+   *     import('../../../src/price/fluxAggregatorContract').prepare
+   *   >;
+   *   puppetContractGovernor?: Installation<
+   *     import('@agoric/governance/tools/puppetContractGovernor').start
+   *   >;
    * }}
    */
   const installations = {};
 
   // @ts-expect-error TODO make fluxAggregator publicFacet support all governance methods (or pare down governance API)
-  /** @type {import('@agoric/governance/tools/puppetContractGovernor').PuppetContractGovernorKit<import('../../../src/price/fluxAggregatorContract.js').prepare>} */
+  /**
+   * @type {import('@agoric/governance/tools/puppetContractGovernor').PuppetContractGovernorKit<
+   *     import('../../../src/price/fluxAggregatorContract.js').prepare
+   *   >}
+   */
   let governorFacets;
-  /** @type {ReturnType<Awaited<ReturnType<import('../../../src/price/fluxAggregatorContract.js').prepare>>['creatorFacet']['getLimitedCreatorFacet']>} */
+  /**
+   * @type {ReturnType<
+   *   Awaited<
+   *     ReturnType<
+   *       import('../../../src/price/fluxAggregatorContract.js').prepare
+   *     >
+   *   >['creatorFacet']['getLimitedCreatorFacet']
+   * >}
+   */
   let faLimitedFacet;
 
   /** @type {import('../../../src/price/priceOracleKit.js').OracleKit} */
@@ -59,7 +77,14 @@ export const buildRootObject = async () => {
   /** @type {UpdateRecord<any>} */
   let lastQuote;
 
-  /** @type {Omit<import('@agoric/zoe/src/zoeService/utils.js').StartParams<import('../../../src/price/fluxAggregatorContract.js').prepare>['terms'], 'issuers' | 'brands'>} */
+  /**
+   * @type {Omit<
+   *   import('@agoric/zoe/src/zoeService/utils.js').StartParams<
+   *     import('../../../src/price/fluxAggregatorContract.js').prepare
+   *   >['terms'],
+   *   'issuers' | 'brands'
+   * >}
+   */
   const faTerms = {
     // driven by one oracle
     maxSubmissionCount: 1,

--- a/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
@@ -52,12 +52,6 @@ export const buildRootObject = async () => {
    */
   const installations = {};
 
-  // @ts-expect-error TODO make fluxAggregator publicFacet support all governance methods (or pare down governance API)
-  /**
-   * @type {import('@agoric/governance/tools/puppetContractGovernor').PuppetContractGovernorKit<
-   *     import('../../../src/price/fluxAggregatorContract.js').prepare
-   *   >}
-   */
   let governorFacets;
   /**
    * @type {ReturnType<
@@ -177,7 +171,6 @@ export const buildRootObject = async () => {
 
       // Complete round-trip without upgrade
       trace(`BOOT buildV1 startInstance`);
-      // @ts-expect-error
       governorFacets = await E(zoe).startInstance(
         NonNullish(installations.puppetContractGovernor),
         undefined,

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
@@ -44,9 +44,17 @@ export const buildRootObject = async () => {
   /** @type {PsmPublicFacet} */
   let psmPublicFacet;
 
-  /** @type {Subscriber<import('../../../src/psm/psm.js').MetricsNotification>} */
+  /**
+   * @type {Subscriber<
+   *   import('../../../src/psm/psm.js').MetricsNotification
+   * >}
+   */
   let metrics;
-  /** @type {UpdateRecord<import('../../../src/psm/psm.js').MetricsNotification>} */
+  /**
+   * @type {UpdateRecord<
+   *   import('../../../src/psm/psm.js').MetricsNotification
+   * >}
+   */
   let metricsRecord;
 
   /** @type {VatAdminSvc} */
@@ -58,9 +66,13 @@ export const buildRootObject = async () => {
   // for startInstance
   /**
    * @type {{
-   * committee?: Installation<import('@agoric/governance/src/committee.js')['prepare']>,
-   * psmV1?: Installation<PsmSF>,
-   * puppetContractGovernor?: Installation<import('@agoric/governance/tools/puppetContractGovernor').start>,
+   *   committee?: Installation<
+   *     import('@agoric/governance/src/committee.js')['prepare']
+   *   >;
+   *   psmV1?: Installation<PsmSF>;
+   *   puppetContractGovernor?: Installation<
+   *     import('@agoric/governance/tools/puppetContractGovernor').start
+   *   >;
    * }}
    */
   const installations = {};
@@ -68,7 +80,12 @@ export const buildRootObject = async () => {
   /** @type {import('@agoric/governance/tools/puppetContractGovernor').PuppetContractGovernorKit<PsmSF>} */
   let governorFacets;
 
-  /** @type {Omit<import('@agoric/zoe/src/zoeService/utils.js').StartParams<PsmSF>['terms'], 'issuers' | 'brands'>} */
+  /**
+   * @type {Omit<
+   *   import('@agoric/zoe/src/zoeService/utils.js').StartParams<PsmSF>['terms'],
+   *   'issuers' | 'brands'
+   * >}
+   */
   const psmTerms = {
     anchorBrand: anchor.brand,
 
@@ -103,12 +120,13 @@ export const buildRootObject = async () => {
 
   return Far('root', {
     /**
-     *
      * @param {{
-     * vatAdmin: ReturnType<import('@agoric/swingset-vat/src/vats/vat-admin/vat-vat-admin')['buildRootObject']>,
-     * zoe: ReturnType<import('@agoric/vats/src/vat-zoe')['buildRootObject']>,
+     *   vatAdmin: ReturnType<
+     *     import('@agoric/swingset-vat/src/vats/vat-admin/vat-vat-admin')['buildRootObject']
+     *   >;
+     *   zoe: ReturnType<import('@agoric/vats/src/vat-zoe')['buildRootObject']>;
      * }} vats
-     * @param {*} devices
+     * @param {any} devices
      */
     bootstrap: async (vats, devices) => {
       vatAdmin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);

--- a/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
@@ -33,9 +33,17 @@ export const buildRootObject = async () => {
   /** @type {FeeMintAccess} */
   let feeMintAccess;
 
-  /** @type {Subscriber<import('../../../src/reserve/assetReserveKit.js').MetricsNotification>} */
+  /**
+   * @type {Subscriber<
+   *   import('../../../src/reserve/assetReserveKit.js').MetricsNotification
+   * >}
+   */
   let metrics;
-  /** @type {UpdateRecord<import('../../../src/reserve/assetReserveKit.js').MetricsNotification>} */
+  /**
+   * @type {UpdateRecord<
+   *   import('../../../src/reserve/assetReserveKit.js').MetricsNotification
+   * >}
+   */
   let metricsRecord;
 
   /** @type {VatAdminSvc} */
@@ -47,19 +55,42 @@ export const buildRootObject = async () => {
   // for startInstance
   /**
    * @type {{
-   * committee?: Installation<import('@agoric/governance/src/committee')['prepare']>,
-   * assetReserveV1?: Installation<import('../../../src/reserve/assetReserve')['prepare']>,
-   * puppetContractGovernor?: Installation<import('@agoric/governance/tools/puppetContractGovernor')['start']>,
+   *   committee?: Installation<
+   *     import('@agoric/governance/src/committee')['prepare']
+   *   >;
+   *   assetReserveV1?: Installation<
+   *     import('../../../src/reserve/assetReserve')['prepare']
+   *   >;
+   *   puppetContractGovernor?: Installation<
+   *     import('@agoric/governance/tools/puppetContractGovernor')['start']
+   *   >;
    * }}
    */
   const installations = {};
 
-  /** @type {import('@agoric/governance/tools/puppetContractGovernor').PuppetContractGovernorKit<import('../../../src/reserve/assetReserve.js').prepare>} */
+  /**
+   * @type {import('@agoric/governance/tools/puppetContractGovernor').PuppetContractGovernorKit<
+   *     import('../../../src/reserve/assetReserve.js').prepare
+   *   >}
+   */
   let governorFacets;
-  /** @type {ReturnType<Awaited<ReturnType<import('../../../src/reserve/assetReserve.js').prepare>>['creatorFacet']['getLimitedCreatorFacet']>} */
+  /**
+   * @type {ReturnType<
+   *   Awaited<
+   *     ReturnType<import('../../../src/reserve/assetReserve.js').prepare>
+   *   >['creatorFacet']['getLimitedCreatorFacet']
+   * >}
+   */
   let arLimitedFacet;
 
-  /** @type {Omit<import('@agoric/zoe/src/zoeService/utils.js').StartParams<import('../../../src/reserve/assetReserve.js').prepare>['terms'], 'issuers' | 'brands'>} */
+  /**
+   * @type {Omit<
+   *   import('@agoric/zoe/src/zoeService/utils.js').StartParams<
+   *     import('../../../src/reserve/assetReserve.js').prepare
+   *   >['terms'],
+   *   'issuers' | 'brands'
+   * >}
+   */
   const arTerms = {
     governedParams: {
       // @ts-expect-error missing value
@@ -74,9 +105,7 @@ export const buildRootObject = async () => {
     namesByAddressAdmin,
   };
 
-  /**
-   * @param {Amount<'nat'>} amt
-   */
+  /** @param {Amount<'nat'>} amt */
   const addCollateral = async amt => {
     const arPublicFacet = await E(governorFacets.creatorFacet).getPublicFacet();
     const seat = E(zoeService).offer(

--- a/packages/inter-protocol/test/test-clientSupport.js
+++ b/packages/inter-protocol/test/test-clientSupport.js
@@ -9,7 +9,11 @@ const ist = withAmountUtils(makeIssuerKit('IST'));
 const atom = withAmountUtils(makeIssuerKit('ATOM'));
 
 // uses actual Brand objects instead of BoardRemote to make the test output more legible
-/** @satisfies {Partial<import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes>} */
+/**
+ * @satisfies {Partial<
+ *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes
+ * >}
+ */
 const agoricNames = {
   brand: {
     IST: /** @type {any} */ (ist.brand),

--- a/packages/inter-protocol/test/test-feeDistributor.js
+++ b/packages/inter-protocol/test/test-feeDistributor.js
@@ -10,9 +10,7 @@ import { E, Far } from '@endo/far';
 import { mustMatch } from '@agoric/store';
 import { makeFeeDistributor, customTermsShape } from '../src/feeDistributor.js';
 
-/**
- * @param {Issuer} feeIssuer
- */
+/** @param {Issuer} feeIssuer */
 const makeFakeFeeDepositFacetKit = feeIssuer => {
   const depositPayments = [];
 
@@ -40,10 +38,10 @@ const makeFakeFeeProducer = (makeEmptyPayment = () => {}) => {
   });
 };
 /**
- * @param {*} t
+ * @param {any} t
  * @param {Promise<Payment[]>} paymentsP
  * @param {number} count
- * @param {*} values
+ * @param {any} values
  * @param {Issuer} issuer
  * @param {Brand} brand
  */

--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -40,7 +40,11 @@ import { INVITATION_MAKERS_DESC } from '../src/econCommitteeCharter.js';
 const { Fail } = assert;
 const dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
+/**
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeTestContext>>
+ * >}
+ */
 const test = anyTest;
 
 const contractRoots = {
@@ -76,7 +80,11 @@ const makeTestContext = async () => {
     bundleCache.load(src, dest).then(b => E(zoe).install(b));
   const installation = {
     mintHolder: install(contractRoots.mintHolder, 'mintHolder'),
-    /** @type {Promise<Installation<import('@agoric/vats/src/centralSupply.js').start>>} */
+    /**
+     * @type {Promise<
+     *   Installation<import('@agoric/vats/src/centralSupply.js').start>
+     * >}
+     */
     centralSupply: E(zoe).install(centralSupplyBundle),
     econCommitteeCharter: install(
       contractRoots.econCommitteeCharter,
@@ -143,8 +151,10 @@ test.before(async t => {
 });
 
 /**
- * @param {import('ava').ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
- * @param {{ env?: Record<string, string|undefined> }} [io]
+ * @param {import('ava').ExecutionContext<
+ *   Awaited<ReturnType<makeTestContext>>
+ * >} t
+ * @param {{ env?: Record<string, string | undefined> }} [io]
  */
 const makeScenario = async (t, { env = process.env } = {}) => {
   const rawSpace = await setupBootstrap(t);
@@ -175,7 +185,13 @@ const makeScenario = async (t, { env = process.env } = {}) => {
     );
   };
 
-  /** @type {PromiseKit<{ mint: ERef<Mint>, issuer: ERef<Issuer>, brand: Brand}>} */
+  /**
+   * @type {PromiseKit<{
+   *   mint: ERef<Mint>;
+   *   issuer: ERef<Issuer>;
+   *   brand: Brand;
+   * }>}
+   */
   const ibcKitP = makePromiseKit();
 
   const startDevNet = async () => {
@@ -273,9 +289,7 @@ const makeScenario = async (t, { env = process.env } = {}) => {
       );
     };
 
-  /**
-   * @param {string[]} proposals
-   */
+  /** @param {string[]} proposals */
   const evalProposals = async proposals => {
     const { code, bundleHandleToAbsolutePaths } =
       await extractCoreProposalBundles(
@@ -329,15 +343,15 @@ const makeScenario = async (t, { env = process.env } = {}) => {
 
   /**
    * @param {{
-   *   agoricNames: ERef<NameHub>,
-   *   board: ERef<import('@agoric/vats').Board>,
-   *   zoe: ERef<ZoeService>,
+   *   agoricNames: ERef<NameHub>;
+   *   board: ERef<import('@agoric/vats').Board>;
+   *   zoe: ERef<ZoeService>;
    *   wallet: {
    *     purses: {
-   *       ist: ERef<Purse>,
-   *       atom: ERef<Purse>,
-   *     },
-   *   },
+   *       ist: ERef<Purse>;
+   *       atom: ERef<Purse>;
+   *     };
+   *   };
    * }} home
    */
   const makeBenefactor = home => {
@@ -350,7 +364,11 @@ const makeScenario = async (t, { env = process.env } = {}) => {
     return Far('benefactor', {
       depositInReserve: async (qty = 10_000n) => {
         const atomBrand = await E(agoricNames).lookup('brand', 'ATOM');
-        /** @type {ERef<import('../src/reserve/assetReserve').AssetReservePublicFacet>} */
+        /**
+         * @type {ERef<
+         *   import('../src/reserve/assetReserve').AssetReservePublicFacet
+         * >}
+         */
         const reserveAPI = E(zoe).getPublicFacet(
           E(agoricNames).lookup('instance', 'reserve'),
         );
@@ -481,7 +499,11 @@ test.skip('assets are in Vaults', async t => {
   const brand = await E(agoricNames).lookup('brand', 'ATOM');
   const stableBrand = await E(agoricNames).lookup('brand', Stable.symbol);
 
-  /** @type {ERef<import('../src/vaultFactory/vaultFactory').VaultFactoryContract['publicFacet']>} */
+  /**
+   * @type {ERef<
+   *   import('../src/vaultFactory/vaultFactory').VaultFactoryContract['publicFacet']
+   * >}
+   */
   const vaultsAPI = instanceP.VaultFactory.then(i => E(zoe).getPublicFacet(i));
 
   const params = await E(vaultsAPI).getGovernedParams({
@@ -542,8 +564,8 @@ test.skip('Committee can raise debt limit', async t => {
   const params = { DebtLimit: AmountMath.make(stableBrand, 100n) };
 
   // We happen to know how the timer is implemented.
-  /** @type { ERef<ManualTimer> } */
-  const timer = /** @type {any } */ (s.space.consume.chainTimerService);
+  /** @type {ERef<ManualTimer>} */
+  const timer = /** @type {any} */ (s.space.consume.chainTimerService);
 
   const now = await E(timer).getCurrentTimestamp();
   const deadline = TimeMath.addAbsRel(now, 3n);

--- a/packages/inter-protocol/test/test-interest-labeled.js
+++ b/packages/inter-protocol/test/test-interest-labeled.js
@@ -22,11 +22,11 @@ const HUNDRED_THOUSAND = 100000n;
 // const TEN_MILLION = 10000000n;
 
 /**
- * This file is originally an adaptation of test-interest.js to labeled
- * time. The original often used values like ONE_DAY both as RelativeTime
- * and as Timestamps, which this file can no longer get away with. We left
- * the original duration constants as RelativeTime and use this adapter for
- * those cases where it was used as a Timestamp.
+ * This file is originally an adaptation of test-interest.js to labeled time.
+ * The original often used values like ONE_DAY both as RelativeTime and as
+ * Timestamps, which this file can no longer get away with. We left the original
+ * duration constants as RelativeTime and use this adapter for those cases where
+ * it was used as a Timestamp.
  *
  * @param {RelativeTime} rel
  * @returns {Timestamp}

--- a/packages/inter-protocol/test/test-interest-math.js
+++ b/packages/inter-protocol/test/test-interest-math.js
@@ -7,7 +7,7 @@ import { calculateCurrentDebt, reverseInterest } from '../src/interest-math.js';
 const brand = makeIssuerKit('foo').brand;
 
 /**
- * @param {*} t
+ * @param {any} t
  * @param {readonly [bigint, bigint, bigint]} input
  * @param {bigint} result
  */

--- a/packages/inter-protocol/test/test-interest.js
+++ b/packages/inter-protocol/test/test-interest.js
@@ -436,7 +436,7 @@ test('calculateCompoundedStabilityFee on zero debt', t => {
 const M = 1_000_000n;
 
 test('calculateCompoundedStabilityFee', t => {
-  /** @type {Array<[bigint, bigint, bigint, number, bigint, number]>} */
+  /** @type {[bigint, bigint, bigint, number, bigint, number][]} */
   const cases = [
     [250n, BASIS_POINTS, M, 1, 1025000n, 10], // 2.5% APR over 1 year yields 2.5%
     [250n, BASIS_POINTS, M, 10, 1280090n, 5], // 2.5% APR over 10 year yields 28%
@@ -495,7 +495,7 @@ test('chargeInterest when no time elapsed', async t => {
   const stabilityFee = makeRatio(250n, brand, BASIS_POINTS);
 
   const now = BigInt(Date.now().toFixed());
-  /** @type {*} */
+  /** @type {any} */
   const powers = {
     mint: {
       getIssuerRecord: () =>

--- a/packages/inter-protocol/test/test-proposal-stuff.js
+++ b/packages/inter-protocol/test/test-proposal-stuff.js
@@ -22,7 +22,7 @@ const makeTestContext = t => {
     return JSON.parse(txt);
   };
 
-  /** @param {{ module: string, entrypoint: string}} proposal */
+  /** @param {{ module: string; entrypoint: string }} proposal */
   const loadEntryPoint = async proposal => {
     const { module, entrypoint } = proposal;
     t.is(typeof module, 'string');

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -74,21 +74,27 @@ const defaultParamValues = debt =>
 
 /**
  * @typedef {{
- * aeth: IssuerKit & import('../supports.js').AmountUtils,
- * aethInitialLiquidity: Amount<'nat'>,
- * consume: import('../../src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume'],
- * puppetGovernors: { [contractName: string]: undefined | ERef<import('@agoric/governance/tools/puppetContractGovernor.js').PuppetContractGovernorKit<any>['creatorFacet']> },
- * electorateTerms: any,
- * feeMintAccess: FeeMintAccess,
- * installation: Record<string, any>,
- * interestTiming: any,
- * minInitialDebt: bigint,
- * reserveCreatorFacet: ERef<AssetReserveCreatorFacet>,
- * rates: any,
- * run: IssuerKit & import('../supports.js').AmountUtils,
- * stableInitialLiquidity: Amount<'nat'>,
- * timer: ReturnType<typeof buildManualTimer>,
- * zoe: ZoeService,
+ *   aeth: IssuerKit & import('../supports.js').AmountUtils;
+ *   aethInitialLiquidity: Amount<'nat'>;
+ *   consume: import('../../src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume'];
+ *   puppetGovernors: {
+ *     [contractName: string]:
+ *       | undefined
+ *       | ERef<
+ *           import('@agoric/governance/tools/puppetContractGovernor.js').PuppetContractGovernorKit<any>['creatorFacet']
+ *         >;
+ *   };
+ *   electorateTerms: any;
+ *   feeMintAccess: FeeMintAccess;
+ *   installation: Record<string, any>;
+ *   interestTiming: any;
+ *   minInitialDebt: bigint;
+ *   reserveCreatorFacet: ERef<AssetReserveCreatorFacet>;
+ *   rates: any;
+ *   run: IssuerKit & import('../supports.js').AmountUtils;
+ *   stableInitialLiquidity: Amount<'nat'>;
+ *   timer: ReturnType<typeof buildManualTimer>;
+ *   zoe: ZoeService;
  * }} DriverContext
  */
 
@@ -136,9 +142,7 @@ export const makeDriverContext = async ({
   return { ...frozenCtx, bundleCache, run, aeth };
 };
 
-/**
- * @param {import('ava').ExecutionContext<DriverContext>} t
- */
+/** @param {import('ava').ExecutionContext<DriverContext>} t */
 const setupReserveAndElectorate = async t => {
   const {
     zoe,
@@ -254,7 +258,14 @@ const setupServices = async (t, initialPrice, priceBase) => {
     aethKeyword,
   );
 
-  /** @type {[any, VaultFactoryCreatorFacet, VFC['publicFacet'], VaultManager]} */
+  /**
+   * @type {[
+   *   any,
+   *   VaultFactoryCreatorFacet,
+   *   VFC['publicFacet'],
+   *   VaultManager,
+   * ]}
+   */
   const [governorInstance, vaultFactory, vfPublic, aethVaultManager] =
     await Promise.all([
       E(consume.agoricNames).lookup('instance', 'VaultFactoryGovernor'),
@@ -310,7 +321,6 @@ export const makeManagerDriver = async (
   let notification = {};
   let currentOfferResult;
   /**
-   *
    * @param {Amount<'nat'>} [collateral]
    * @param {Amount<'nat'>} [debt]
    */
@@ -340,7 +350,6 @@ export const makeManagerDriver = async (
       vaultSeat: () => vaultSeat,
       notification: () => notification,
       /**
-       *
        * @param {bigint} collValue
        * @param {import('../supports.js').AmountUtils} collUtils
        * @param {bigint} [mintedValue]
@@ -362,7 +371,6 @@ export const makeManagerDriver = async (
         return E(seat).getOfferResult();
       },
       /**
-       *
        * @param {bigint} mintedValue
        * @param {import('../supports.js').AmountUtils} collUtils
        * @param {bigint} [collValue]
@@ -403,10 +411,10 @@ export const makeManagerDriver = async (
         t.truthy(await E(vaultSeat).hasExited());
       },
       /**
-       *
        * @param {import('../../src/vaultFactory/vault.js').VaultPhase} phase
        * @param {object} [likeExpected]
-       * @param {AT_NEXT|number} [optSince] AT_NEXT is an alias for updateCount of the last update, forcing to wait for another
+       * @param {AT_NEXT | number} [optSince] AT_NEXT is an alias for
+       *   updateCount of the last update, forcing to wait for another
        */
       notified: async (phase, likeExpected, optSince) => {
         notification = await E(notifier).getUpdateSince(
@@ -475,8 +483,9 @@ export const makeManagerDriver = async (
     // and the director driver should `{ key: 'governedParams }`
     /**
      * @param {string} name
-     * @param {*} newValue
-     * @param {VaultFactoryParamPath} [paramPath] defaults to root path for the factory
+     * @param {any} newValue
+     * @param {VaultFactoryParamPath} [paramPath] defaults to root path for the
+     *   factory
      */
     setGovernedParam: (
       name,
@@ -492,18 +501,16 @@ export const makeManagerDriver = async (
         }),
       );
     },
-    /**
-     * @param {string[]} filters
-     */
+    /** @param {string[]} filters */
     setGovernedFilters: filters => {
       trace(t, 'setGovernedFilters', filters);
       const vfGov = NonNullish(t.context.puppetGovernors.vaultFactory);
       return E(vfGov).setFilters(harden(filters));
     },
     /**
-     *
      * @param {object} [likeExpected]
-     * @param {AT_NEXT|number} [optSince] AT_NEXT is an alias for updateCount of the last update, forcing to wait for another
+     * @param {AT_NEXT | number} [optSince] AT_NEXT is an alias for updateCount
+     *   of the last update, forcing to wait for another
      */
     managerNotified: async (likeExpected, optSince) => {
       managerNotification = await E(managerNotifier).getUpdateSince(
@@ -527,9 +534,7 @@ export const makeManagerDriver = async (
   return driver;
 };
 
-/**
- * @param {import('ava').ExecutionContext<DriverContext>} t
- */
+/** @param {import('ava').ExecutionContext<DriverContext>} t */
 export const makeAuctioneerDriver = async t => {
   const auctioneerKit = await t.context.consume.auctioneerKit;
 
@@ -576,7 +581,7 @@ export const makeAuctioneerDriver = async t => {
     },
     /**
      * @param {keyof import('../../src/auction/params.js').AuctionParams} name
-     * @param {*} newValue
+     * @param {any} newValue
      */
     setGovernedParam: async (name, newValue) => {
       trace('setGovernedParam', name);

--- a/packages/inter-protocol/test/vaultFactory/faucet.js
+++ b/packages/inter-protocol/test/vaultFactory/faucet.js
@@ -6,7 +6,7 @@ import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
  * needed.
  *
  * @param {ZCF} zcf
- * @param {{feeMintAccess: FeeMintAccess}} privateArgs
+ * @param {{ feeMintAccess: FeeMintAccess }} privateArgs
  */
 export async function start(zcf, { feeMintAccess }) {
   const stableMint = await zcf.registerFeeMint('RUN', feeMintAccess);

--- a/packages/inter-protocol/test/vaultFactory/interestSupport.js
+++ b/packages/inter-protocol/test/vaultFactory/interestSupport.js
@@ -22,8 +22,8 @@ export const makeCompoundedStabilityFeeProvider = brand => {
  * @param {VaultId} vaultId
  * @param {Amount<'nat'>} initDebt
  * @param {Amount<'nat'>} [initCollateral]
- * @param {*} [manager]
- * @returns {Vault & {setDebt: (Amount) => void}}
+ * @param {any} [manager]
+ * @returns {Vault & { setDebt: (Amount) => void }}
  */
 
 export const makeFakeVault = (

--- a/packages/inter-protocol/test/vaultFactory/test-auction.js
+++ b/packages/inter-protocol/test/vaultFactory/test-auction.js
@@ -9,10 +9,7 @@ import {
   makeManagerDriver,
 } from './driver.js';
 
-/**
- * @typedef {import('./driver.js').DriverContext & {
- * }} Context
- */
+/** @typedef {import('./driver.js').DriverContext & {}} Context */
 /** @type {import('ava').TestFn<Context>} */
 const test = unknownTest;
 

--- a/packages/inter-protocol/test/vaultFactory/test-liquidation-plans.js
+++ b/packages/inter-protocol/test/vaultFactory/test-liquidation-plans.js
@@ -8,10 +8,7 @@ import {
   makeManagerDriver,
 } from './driver.js';
 
-/**
- * @typedef {import('./driver.js').DriverContext & {
- * }} Context
- */
+/** @typedef {import('./driver.js').DriverContext & {}} Context */
 /** @type {import('ava').TestFn<Context>} */
 const test = unknownTest;
 
@@ -75,15 +72,17 @@ test('basic', async t => {
    * TODO consider having "test.skip" with directions for what throws to insert
    *
    * These are the cases we tested manually:
+   *
    * - Failure at the start of a flow
    * - Failure within the 2b flow
    *
    * These are the states we verified:
+   *
    * - All vaults to be liquidated are liquidated (none reinstated)
    * - Metrics of liquidation counts update correctly
    *
    * Failure to return a plan is not handled because `calculateDistributionPlan`
-   * has a try/catch within it that ensures it returns *some* plan. We
+   * has a try/catch within it that ensures it returns _some_ plan. We
    * considered falling back if it does fail, but the fallback would have to do
    * the same work that had just failed.
    */

--- a/packages/inter-protocol/test/vaultFactory/test-math.js
+++ b/packages/inter-protocol/test/vaultFactory/test-math.js
@@ -15,7 +15,7 @@ const aeth = withAmountUtils(makeIssuerKit('Aeth'));
 /**
  * Max debt for a fixed collateral of 1_000 aeth
  *
- * @param {*} t
+ * @param {any} t
  * @param {readonly [Number, Number, Number]} input
  * @param {bigint} result
  */
@@ -75,9 +75,14 @@ test('negative liquidationPadding throws', t => {
 /**
  * Max debt for a fixed collateral of 1_000 aeth
  *
- * @param {*} t
+ * @param {any} t
  * @param {readonly [Number, Number, Number]} input
- * @param {{ fee: number, newDebt: number, toMint: number, surplus: number }} result
+ * @param {{
+ *   fee: number;
+ *   newDebt: number;
+ *   toMint: number;
+ *   surplus: number;
+ * }} result
  */
 function checkDebtCosts(
   t,

--- a/packages/inter-protocol/test/vaultFactory/test-orderedVaultStore.js
+++ b/packages/inter-protocol/test/vaultFactory/test-orderedVaultStore.js
@@ -20,9 +20,10 @@ const mockVault = (vaultId, runCount, collateralCount) => {
 
 const BIGGER_INT = BigInt(Number.MAX_VALUE) + 1n;
 /**
- * Records to be inserted in this order. Jumbled to verify insertion order invariance.
+ * Records to be inserted in this order. Jumbled to verify insertion order
+ * invariance.
  *
- * @type {Array<[string, bigint, bigint]>}
+ * @type {[string, bigint, bigint][]}
  */
 const fixture = [
   ['vault-E', 40n, 100n],

--- a/packages/inter-protocol/test/vaultFactory/test-prioritizedVaults.js
+++ b/packages/inter-protocol/test/vaultFactory/test-prioritizedVaults.js
@@ -29,10 +29,7 @@ const makeCollector = () => {
   /** @type {Ratio[]} */
   const ratios = [];
 
-  /**
-   *
-   * @param {[string, Vault]} record
-   */
+  /** @param {[string, Vault]} record */
   function lookForRatio([_, vault]) {
     ratios.push(currentDebtToCollateral(vault));
   }

--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -9,10 +9,7 @@ import { makeDriverContext, makeManagerDriver } from './driver.js';
 
 import '../../src/vaultFactory/types.js';
 
-/**
- * @typedef {import('./driver.js').DriverContext & {
- * }} Context
- */
+/** @typedef {import('./driver.js').DriverContext & {}} Context */
 /** @type {import('ava').TestFn<Context>} */
 const test = unknownTest;
 

--- a/packages/inter-protocol/test/vaultFactory/test-vault-collateralization.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-collateralization.js
@@ -4,10 +4,7 @@ import { makeTracer } from '@agoric/internal';
 import { E } from '@endo/eventual-send';
 import { makeDriverContext, makeManagerDriver } from './driver.js';
 
-/**
- * @typedef {import('./driver.js').DriverContext & {
- * }} Context
- */
+/** @typedef {import('./driver.js').DriverContext & {}} Context */
 /** @type {import('ava').TestFn<Context>} */
 const test = unknownTest;
 

--- a/packages/inter-protocol/test/vaultFactory/test-vault-pause.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-pause.js
@@ -3,10 +3,7 @@ import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { makeTracer } from '@agoric/internal';
 import { makeDriverContext, makeManagerDriver } from './driver.js';
 
-/**
- * @typedef {import('./driver.js').DriverContext & {
- * }} Context
- */
+/** @typedef {import('./driver.js').DriverContext & {}} Context */
 /** @type {import('ava').TestFn<Context>} */
 const test = unknownTest;
 

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -43,12 +43,12 @@ import {
 
 /**
  * @typedef {Record<string, any> & {
- * aeth: IssuerKit & import('../supports.js').AmountUtils,
- * run: IssuerKit & import('../supports.js').AmountUtils,
- * bundleCache: Awaited<ReturnType<typeof unsafeMakeBundleCache>>,
- * rates: VaultManagerParamValues,
- * interestTiming: InterestTiming,
- * zoe: ZoeService,
+ *   aeth: IssuerKit & import('../supports.js').AmountUtils;
+ *   run: IssuerKit & import('../supports.js').AmountUtils;
+ *   bundleCache: Awaited<ReturnType<typeof unsafeMakeBundleCache>>;
+ *   rates: VaultManagerParamValues;
+ *   interestTiming: InterestTiming;
+ *   zoe: ZoeService;
  * }} Context
  */
 /** @type {import('ava').TestFn<Context>} */
@@ -126,7 +126,7 @@ test.before(async t => {
  * NOTE: called separately by each test so zoe/priceAuthority don't interfere
  *
  * @param {import('ava').ExecutionContext<Context>} t
- * @param {Array<NatValue> | Ratio} priceOrList
+ * @param {NatValue[] | Ratio} priceOrList
  * @param {Amount | undefined} unitAmountIn
  * @param {import('@agoric/time/src/types').TimerService} timer
  * @param {RelativeTime} quoteInterval
@@ -217,7 +217,16 @@ const setupServices = async (
     'AEth',
     rates,
   );
-  /** @type {[any, VaultFactoryCreatorFacet, VFC['publicFacet'], VaultManager, PriceAuthority, CollateralManager]} */
+  /**
+   * @type {[
+   *   any,
+   *   VaultFactoryCreatorFacet,
+   *   VFC['publicFacet'],
+   *   VaultManager,
+   *   PriceAuthority,
+   *   CollateralManager,
+   * ]}
+   */
   const [
     governorInstance,
     vaultFactory, // creator
@@ -1515,11 +1524,12 @@ test('debt too small - MinInitialDebt', async t => {
 });
 
 /**
- * Each vaultManager manages one collateral type and has a governed parameter, `debtLimit`,
- * that specifies a cap on the amount of debt the manager will allow.
+ * Each vaultManager manages one collateral type and has a governed parameter,
+ * `debtLimit`, that specifies a cap on the amount of debt the manager will
+ * allow.
  *
- * Attempts to adjust balances on vaults beyond the debt limit fail.
- * In other words, minting for anything other than charging stabilityFee fails.
+ * Attempts to adjust balances on vaults beyond the debt limit fail. In other
+ * words, minting for anything other than charging stabilityFee fails.
  */
 test('excessive debt on collateral type - debtLimit', async t => {
   const { zoe, aeth, run } = t.context;
@@ -1938,7 +1948,11 @@ test('manager notifiers, with snapshot', async t => {
     totalDebt: { value: totalDebt },
   });
 
-  /** @type {ReturnType<import('@agoric/internal/src/storage-test-utils.js').makeMockChainStorageRoot>} */
+  /**
+   * @type {ReturnType<
+   *   import('@agoric/internal/src/storage-test-utils.js').makeMockChainStorageRoot
+   * >}
+   */
   // @ts-expect-error mock
   const storage = await services.space.consume.chainStorage;
   const doc = {

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -42,12 +42,12 @@ import {
 
 /**
  * @typedef {Record<string, any> & {
- * aeth: IssuerKit & import('../supports.js').AmountUtils,
- * run: IssuerKit & import('../supports.js').AmountUtils,
- * bundleCache: Awaited<ReturnType<typeof unsafeMakeBundleCache>>,
- * rates: VaultManagerParamValues,
- * interestTiming: InterestTiming,
- * zoe: ZoeService,
+ *   aeth: IssuerKit & import('../supports.js').AmountUtils;
+ *   run: IssuerKit & import('../supports.js').AmountUtils;
+ *   bundleCache: Awaited<ReturnType<typeof unsafeMakeBundleCache>>;
+ *   rates: VaultManagerParamValues;
+ *   interestTiming: InterestTiming;
+ *   zoe: ZoeService;
  * }} Context
  */
 
@@ -124,7 +124,7 @@ test.before(async t => {
  * NOTE: called separately by each test so zoe/priceAuthority don't interfere
  *
  * @param {import('ava').ExecutionContext<Context>} t
- * @param {Array<NatValue> | Ratio} priceOrList
+ * @param {NatValue[] | Ratio} priceOrList
  * @param {Amount | undefined} unitAmountIn
  * @param {import('@agoric/time/src/types').TimerService} timer
  * @param {RelativeTime} quoteInterval
@@ -194,7 +194,17 @@ const setupServices = async (
   );
   /** @typedef {import('../../src/proposals/econ-behaviors.js').AuctioneerKit} AuctioneerKit */
   /** @typedef {import('@agoric/zoe/tools/manualPriceAuthority.js').ManualPriceAuthority} ManualPriceAuthority */
-  /** @type {[any, VaultFactoryCreatorFacet, VFC['publicFacet'], VaultManager, AuctioneerKit, ManualPriceAuthority, CollateralManager]} */
+  /**
+   * @type {[
+   *   any,
+   *   VaultFactoryCreatorFacet,
+   *   VFC['publicFacet'],
+   *   VaultManager,
+   *   AuctioneerKit,
+   *   ManualPriceAuthority,
+   *   CollateralManager,
+   * ]}
+   */
   const [
     governorInstance,
     vaultFactory, // creator

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -35,7 +35,7 @@ const marshaller = makeFakeMarshaller();
 
 /**
  * @param {ZCF} zcf
- * @param {{feeMintAccess: FeeMintAccess}} privateArgs
+ * @param {{ feeMintAccess: FeeMintAccess }} privateArgs
  * @param {import('@agoric/ertp').Baggage} baggage
  */
 export async function start(zcf, privateArgs, baggage) {

--- a/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
@@ -24,12 +24,16 @@ export const BASIS_POINTS = 10000n;
 
 /**
  * @typedef {Record<string, any> & {
- * aeth: IssuerKit & import('../supports.js').AmountUtils,
- * run: IssuerKit & import('../supports.js').AmountUtils,
- * bundleCache: Awaited<ReturnType<typeof import('@agoric/swingset-vat/tools/bundleTool.js').unsafeMakeBundleCache>>,
- * rates: VaultManagerParamValues,
- * interestTiming: InterestTiming,
- * zoe: ZoeService,
+ *   aeth: IssuerKit & import('../supports.js').AmountUtils;
+ *   run: IssuerKit & import('../supports.js').AmountUtils;
+ *   bundleCache: Awaited<
+ *     ReturnType<
+ *       typeof import('@agoric/swingset-vat/tools/bundleTool.js').unsafeMakeBundleCache
+ *     >
+ *   >;
+ *   rates: VaultManagerParamValues;
+ *   interestTiming: InterestTiming;
+ *   zoe: ZoeService;
  * }} Context
  */
 
@@ -56,7 +60,7 @@ export const defaultParamValues = debtBrand =>
  * @param {import('ava').ExecutionContext<Context>} t
  * @param {IssuerKit<'nat'>} run
  * @param {IssuerKit<'nat'>} aeth
- * @param {Array<NatValue> | Ratio} priceOrList
+ * @param {NatValue[] | Ratio} priceOrList
  * @param {RelativeTime} quoteInterval
  * @param {Amount | undefined} unitAmountIn
  * @param {Partial<import('../../src/auction/params.js').AuctionParams>} actionParamArgs
@@ -160,7 +164,8 @@ export const getRunFromFaucet = async (t, amount) => {
 };
 
 /**
- * Vault offer result used to include `publicNotifiers` but now is `publicSubscribers`.
+ * Vault offer result used to include `publicNotifiers` but now is
+ * `publicSubscribers`.
  *
  * @param {UserSeat<VaultKit>} vaultSeat
  */

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -34,16 +34,16 @@ const BridgeManagerIKit = harden({
   }),
 });
 
-/**
- * @param {import('@agoric/zone').Zone} zone
- */
+/** @param {import('@agoric/zone').Zone} zone */
 const prepareScopedManager = zone => {
   const makeScopedManager = zone.exoClass(
     'BridgeScopedManager',
     BridgeScopedManagerI,
     /**
      * @param {string} bridgeId
-     * @param {{ outbound: (bridgeId: string, obj: unknown) => Promise<any> }} toBridge
+     * @param {{
+     *   outbound: (bridgeId: string, obj: unknown) => Promise<any>;
+     * }} toBridge
      * @param {import('./types').BridgeHandler} [inboundHandler]
      */
     (bridgeId, toBridge, inboundHandler) => ({
@@ -93,14 +93,16 @@ export const prepareBridgeManager = (zone, D) => {
   const makeScopedManager = prepareScopedManager(zone);
 
   /**
-   * Create a bridge manager for multiplexing messages to and from a bridge device
-   * using string-named channels.
+   * Create a bridge manager for multiplexing messages to and from a bridge
+   * device using string-named channels.
    *
    * @param {BridgeDevice} bridgeDevice The bridge to manage
    * @returns {{
-   *   manager: import('./types.js').BridgeManager,
-   *   privateInbounder: { inbound(srcID: string, obj: unknown): void },
-   *   privateOutbounder: { outbound(dstID: string, obj: unknown): Promise<any> },
+   *   manager: import('./types.js').BridgeManager;
+   *   privateInbounder: { inbound(srcID: string, obj: unknown): void };
+   *   privateOutbounder: {
+   *     outbound(dstID: string, obj: unknown): Promise<any>;
+   *   };
    * }}
    */
   const makeBridgeManagerKit = zone.exoClassKit(
@@ -108,7 +110,12 @@ export const prepareBridgeManager = (zone, D) => {
     BridgeManagerIKit,
     /** @param {BridgeDevice} bridgeDevice */
     bridgeDevice => ({
-      /** @type {MapStore<string, ReturnType<ReturnType<typeof prepareScopedManager>>>} */
+      /**
+       * @type {MapStore<
+       *   string,
+       *   ReturnType<ReturnType<typeof prepareScopedManager>>
+       * >}
+       */
       scopedManagers: zone.detached().mapStore('scopedManagers'),
       bridgeDevice,
     }),
@@ -156,7 +163,12 @@ export const prepareBridgeManager = (zone, D) => {
     },
   );
 
-  /** @type {MapStore<BridgeDevice, ReturnType<typeof makeBridgeManagerKit>>} */
+  /**
+   * @type {MapStore<
+   *   BridgeDevice,
+   *   ReturnType<typeof makeBridgeManagerKit>
+   * >}
+   */
   const bridgeToManagerKit = zone.mapStore('bridgeToManagerKit');
 
   /**

--- a/packages/vats/src/centralSupply.js
+++ b/packages/vats/src/centralSupply.js
@@ -4,11 +4,11 @@ import { AmountMath } from '@agoric/ertp';
 import { E, Far } from '@endo/far';
 
 /**
- * The sole purpose of this contract is to mint the initial
- * supply of the central currency, RUN.
+ * The sole purpose of this contract is to mint the initial supply of the
+ * central currency, RUN.
  *
  * @param {ZCF<{
- *  bootstrapPaymentValue: bigint,
+ *   bootstrapPaymentValue: bigint;
  * }>} zcf
  * @param {object} privateArgs
  * @param {FeeMintAccess} privateArgs.feeMintAccess

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -22,12 +22,11 @@ import { feeIssuerConfig, makeMyAddressNameAdminKit } from './utils.js';
 const { details: X } = assert;
 
 /**
- * In golang/cosmos/app/app.go, we define
- * cosmosInitAction with type AG_COSMOS_INIT,
- * with the following shape.
+ * In golang/cosmos/app/app.go, we define cosmosInitAction with type
+ * AG_COSMOS_INIT, with the following shape.
  *
- * The uist supplyCoins value is taken from genesis,
- * thereby authorizing the minting an initial supply of RUN.
+ * The uist supplyCoins value is taken from genesis, thereby authorizing the
+ * minting an initial supply of RUN.
  */
 // eslint-disable-next-line no-unused-vars
 const bootMsgEx = {
@@ -45,15 +44,16 @@ const bootMsgEx = {
 };
 
 /**
- * TODO: review behaviors carefully for powers that go out of scope,
- * since we may want/need them later.
+ * TODO: review behaviors carefully for powers that go out of scope, since we
+ * may want/need them later.
  */
 
 /**
- * @param {BootstrapPowers & {
- * }} powers
+ * @param {BootstrapPowers & {}} powers
  *
- * @typedef {import('@agoric/swingset-vat').CreateVatResults} CreateVatResults as from createVatByName
+ * @typedef {import('@agoric/swingset-vat').CreateVatResults} CreateVatResults
+ *   as from createVatByName
+ *
  * @typedef {MapStore<string, CreateVatResults>} VatStore
  */
 export const makeVatsFromBundles = async ({
@@ -78,7 +78,7 @@ export const makeVatsFromBundles = async ({
       const vatInfoP = provideLazy(tmpStore, vatName, async _k => {
         if (bundleName) {
           console.info(`createVatByName(${bundleName})`);
-          /** @type { Promise<CreateVatResults> } */
+          /** @type {Promise<CreateVatResults>} */
           const vatInfo = E(svc).createVatByName(bundleName, {
             ...defaultVatCreationOptions,
             name: vatName,
@@ -88,7 +88,7 @@ export const makeVatsFromBundles = async ({
         console.info(`createVat(${bundleID})`);
         assert(bundleID);
         const bcap = await E(svc).getBundleCap(bundleID);
-        /** @type { Promise<CreateVatResults> } */
+        /** @type {Promise<CreateVatResults>} */
         const vatInfo = E(svc).createVat(bcap, {
           ...defaultVatCreationOptions,
           name: vatName,
@@ -134,7 +134,7 @@ export const produceStartUpgradable = async ({
   consume: { diagnostics, zoe },
   produce, // startUpgradable, contractKits
 }) => {
-  /** @type {MapStore<Instance, StartedInstanceKitWithLabel> } */
+  /** @type {MapStore<Instance, StartedInstanceKitWithLabel>} */
   const contractKits = zone.mapStore('ContractKits');
 
   /** @type {StartUpgradable} */
@@ -166,20 +166,19 @@ harden(produceStartUpgradable);
 
 /**
  * @template {GovernableStartFn} SF
- *
  * @param {{
- *   zoe: ERef<ZoeService>,
- *   governedContractInstallation: ERef<Installation<SF>>,
- *   issuerKeywordRecord?: IssuerKeywordRecord,
- *   terms: Record<string, unknown>,
- *   privateArgs: any, // TODO: connect with Installation type
- *   label: string,
+ *   zoe: ERef<ZoeService>;
+ *   governedContractInstallation: ERef<Installation<SF>>;
+ *   issuerKeywordRecord?: IssuerKeywordRecord;
+ *   terms: Record<string, unknown>;
+ *   privateArgs: any; // TODO: connect with Installation type
+ *   label: string;
  * }} zoeArgs
  * @param {{
- *   governedParams: Record<string, unknown>,
- *   timer: ERef<import('@agoric/time/src/types').TimerService>,
- *   contractGovernor: ERef<Installation>,
- *   economicCommitteeCreatorFacet: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']['economicCommitteeCreatorFacet']
+ *   governedParams: Record<string, unknown>;
+ *   timer: ERef<import('@agoric/time/src/types').TimerService>;
+ *   contractGovernor: ERef<Installation>;
+ *   economicCommitteeCreatorFacet: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']['economicCommitteeCreatorFacet'];
  * }} govArgs
  * @returns {Promise<GovernanceFacetKit<SF>>}
  */
@@ -257,10 +256,10 @@ const startGovernedInstance = async (
 
 /**
  * @param {BootstrapSpace & {
- *   zone: import('@agoric/zone').Zone,
+ *   zone: import('@agoric/zone').Zone;
  *   consume: {
- *     economicCommitteeCreatorFacet: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']['economicCommitteeCreatorFacet']
- *   }
+ *     economicCommitteeCreatorFacet: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']['economicCommitteeCreatorFacet'];
+ *   };
  * }} powers
  */
 export const produceStartGovernedUpgradable = async ({
@@ -276,7 +275,12 @@ export const produceStartGovernedUpgradable = async ({
     consume: { contractGovernor },
   },
 }) => {
-  /** @type {MapStore<Instance, GovernanceFacetKit<any> & {label: string}>} */
+  /**
+   * @type {MapStore<
+   *   Instance,
+   *   GovernanceFacetKit<any> & { label: string }
+   * >}
+   */
   const contractKits = zone.mapStore('GovernedContractKits');
 
   /** @type {startGovernedUpgradable} */
@@ -321,8 +325,8 @@ export const produceStartGovernedUpgradable = async ({
 harden(produceStartGovernedUpgradable);
 
 /**
- * @param { BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ZoeVat>> }
+ * @param {BootstrapPowers & {
+ *   consume: { loadCriticalVat: ERef<VatLoader<ZoeVat>> };
  * }} powers
  *
  * @typedef {ERef<ReturnType<import('../vat-zoe.js').buildRootObject>>} ZoeVat
@@ -355,10 +359,12 @@ harden(buildZoe);
 
 /**
  * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<PriceAuthorityVat>>},
+ *   consume: { loadCriticalVat: ERef<VatLoader<PriceAuthorityVat>> };
  * }} powers
  *
- * @typedef {ERef<ReturnType<import('../vat-priceAuthority.js').buildRootObject>>} PriceAuthorityVat
+ * @typedef {ERef<
+ *   ReturnType<import('../vat-priceAuthority.js').buildRootObject>
+ * >} PriceAuthorityVat
  */
 export const startPriceAuthorityRegistry = async ({
   consume: { loadCriticalVat, client },
@@ -398,9 +404,7 @@ export const makeOracleBrands = async ({
 };
 harden(makeOracleBrands);
 
-/**
- * @param {BootstrapPowers & NamedVatPowers} powers
- */
+/** @param {BootstrapPowers & NamedVatPowers} powers */
 export const produceBoard = async ({
   consume: { client },
   produce: { board: pBoard },
@@ -416,10 +420,9 @@ harden(produceBoard);
 
 /**
  * @deprecated use produceBoard
- *
  * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<BoardVat>>
- * }}} powers
+ *   consume: { loadCriticalVat: ERef<VatLoader<BoardVat>> };
+ * }} powers
  */
 export const makeBoard = async ({
   consume: { loadCriticalVat, client },
@@ -436,12 +439,11 @@ harden(makeBoard);
 /**
  * Produce the remote namesByAddress hierarchy.
  *
- * namesByAddress is a NameHub for each provisioned client,
- * available, for example, as `E(home.namesByAddress).lookup('agoric1...')`.
- * `depositFacet` as in `E(home.namesByAddress).lookup('agoric1...', 'depositFacet')`
- * is reserved for use by the Agoric wallet. Each client
- * is given `home.myAddressNameAdmin`, which they can use to
- * assign (update / reserve) any other names they choose.
+ * namesByAddress is a NameHub for each provisioned client, available, for
+ * example, as `E(home.namesByAddress).lookup('agoric1...')`. `depositFacet` as
+ * in `E(home.namesByAddress).lookup('agoric1...', 'depositFacet')` is reserved
+ * for use by the Agoric wallet. Each client is given `home.myAddressNameAdmin`,
+ * which they can use to assign (update / reserve) any other names they choose.
  *
  * @param {BootstrapPowers} powers
  */
@@ -564,8 +566,8 @@ export const installBootContracts = async ({
 /**
  * Mint IST genesis supply.
  *
- * @param { BootstrapPowers & {
- *   vatParameters: { argv: { bootMsg?: typeof bootMsgEx }},
+ * @param {BootstrapPowers & {
+ *   vatParameters: { argv: { bootMsg?: typeof bootMsgEx } };
  * }} powers
  */
 export const mintInitialSupply = async ({
@@ -586,7 +588,11 @@ export const mintInitialSupply = async ({
   ) || { amount: '0' };
   const bootstrapPaymentValue = Nat(BigInt(centralBootstrapSupply.amount));
 
-  /** @type {Awaited<ReturnType<typeof import('../centralSupply.js').start>>} */
+  /**
+   * @type {Awaited<
+   *   ReturnType<typeof import('../centralSupply.js').start>
+   * >}
+   */
   const { creatorFacet } = await E(zoe).startInstance(
     centralSupply,
     {},
@@ -603,8 +609,8 @@ harden(mintInitialSupply);
 /**
  * Add IST (with initialSupply payment), BLD (with mint) to BankManager.
  *
- * @param { BootstrapSpace & {
- *   consume: { loadCriticalVat: ERef<VatLoader<BankVat>> },
+ * @param {BootstrapSpace & {
+ *   consume: { loadCriticalVat: ERef<VatLoader<BankVat>> };
  * }} powers
  */
 export const addBankAssets = async ({

--- a/packages/vats/src/core/boot-chain.js
+++ b/packages/vats/src/core/boot-chain.js
@@ -25,11 +25,11 @@ export const MANIFEST = CHAIN_BOOTSTRAP_MANIFEST;
  * Build root object of the bootstrap vat.
  *
  * @param {VatPowers & {
- *   D: DProxy,
- *   logger: (msg) => void,
+ *   D: DProxy;
+ *   logger: (msg) => void;
  * }} vatPowers
  * @param {{
- *   coreProposalCode?: string,
+ *   coreProposalCode?: string;
  * }} vatParameters
  * @param {import('@agoric/vat-data').Baggage} baggage
  */

--- a/packages/vats/src/core/boot-sim.js
+++ b/packages/vats/src/core/boot-sim.js
@@ -27,11 +27,11 @@ const modules = harden({ behaviors: { ...behaviors }, utils: { ...utils } });
  * Build root object of the bootstrap vat for the simulated chain.
  *
  * @param {VatPowers & {
- *   D: DProxy,
- *   logger: (msg) => void,
+ *   D: DProxy;
+ *   logger: (msg) => void;
  * }} vatPowers
  * @param {{
- *   coreProposalCode?: string,
+ *   coreProposalCode?: string;
  * }} vatParameters
  */
 export const buildRootObject = (vatPowers, vatParameters) => {

--- a/packages/vats/src/core/boot-solo.js
+++ b/packages/vats/src/core/boot-solo.js
@@ -31,12 +31,12 @@ const modules = harden({
  * Build root object of the bootstrap vat.
  *
  * @param {VatPowers & {
- *   D: DProxy,
- *   logger: (msg) => void,
+ *   D: DProxy;
+ *   logger: (msg) => void;
  * }} vatPowers
  * @param {{
- *   bootstrapManifest?: Record<string, Record<string, unknown>>,
- *   coreProposalCode?: string,
+ *   bootstrapManifest?: Record<string, Record<string, unknown>>;
+ *   coreProposalCode?: string;
  * }} vatParameters
  */
 export const buildRootObject = (vatPowers, vatParameters) => {

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -23,7 +23,7 @@ const { keys } = Object;
 
 /**
  * This registers the code triggered by `agd tx gov submit-proposal
- * swingset-core-eval permit.json code.js`.  It is the "big hammer" governance
+ * swingset-core-eval permit.json code.js`. It is the "big hammer" governance
  * that allows code.js access to all powers permitted by permit.json.
  *
  * @param {BootstrapPowers} allPowers
@@ -59,9 +59,11 @@ export const bridgeCoreEval = async allPowers => {
       switch (obj.type) {
         case 'CORE_EVAL': {
           /**
-           * Type defined by `agoric-sdk/golang/cosmos/proto/agoric/swingset/swingset.proto` CoreEval.
+           * Type defined by
+           * `agoric-sdk/golang/cosmos/proto/agoric/swingset/swingset.proto`
+           * CoreEval.
            *
-           * @type {{ evals: { json_permits: string, js_code: string }[]}}
+           * @type {{ evals: { json_permits: string; js_code: string }[] }}
            */
           const { evals } = obj;
           return Promise.all(
@@ -114,7 +116,7 @@ harden(bridgeCoreEval);
 
 /**
  * @param {BootstrapPowers & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ProvisioningVat>> }
+ *   consume: { loadCriticalVat: ERef<VatLoader<ProvisioningVat>> };
  * }} powers
  */
 export const makeProvisioner = async ({
@@ -128,9 +130,7 @@ export const makeProvisioner = async ({
 };
 harden(makeProvisioner);
 
-/**
- * @param {BootstrapPowers} powers
- */
+/** @param {BootstrapPowers} powers */
 export const noProvisioner = async ({ produce: { provisioning } }) => {
   provisioning.resolve(undefined);
 };
@@ -309,9 +309,10 @@ export const startTimerService = async ({
 harden(startTimerService);
 
 /**
- * @param {BootDevices<ChainDevices> & BootstrapSpace & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> }
- * }} powers
+ * @param {BootDevices<ChainDevices> &
+ *   BootstrapSpace & {
+ *     consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> };
+ *   }} powers
  */
 export const makeBridgeManager = async ({
   consume: { loadCriticalVat },
@@ -348,7 +349,7 @@ harden(makeBridgeManager);
 
 /**
  * @param {BootstrapSpace & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> }
+ *   consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> };
  * }} powers
  */
 export const makeChainStorage = async ({
@@ -380,7 +381,7 @@ export const makeChainStorage = async ({
 
 /**
  * @param {BootstrapSpace & {
- *   consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> }
+ *   consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> };
  * }} powers
  */
 export const produceHighPrioritySendersManager = async ({
@@ -405,14 +406,15 @@ export const produceHighPrioritySendersManager = async ({
   );
 
   /**
-   * NB: this is a non-durable Far object. If the bootstrap vat (where this object is made)
-   * were to be terminated, the object references to this would be severed.
+   * NB: this is a non-durable Far object. If the bootstrap vat (where this
+   * object is made) were to be terminated, the object references to this would
+   * be severed.
    *
-   * See {@link ./README.md bootstrap documentation} for implications.
-   * If the bootstrap vat is replaced, the new bootstrap config must be made
-   * using state extracted from IAVL. Contracts holding this manager will need
-   * to be updated with the new object, which can be done with an upgrade
-   * (regular or null) with the new object in privateArgs.
+   * See {@link ./README.md bootstrap documentation} for implications. If the
+   * bootstrap vat is replaced, the new bootstrap config must be made using
+   * state extracted from IAVL. Contracts holding this manager will need to be
+   * updated with the new object, which can be done with an upgrade (regular or
+   * null) with the new object in privateArgs.
    */
   const manager = makePrioritySendersManager(sendersNode);
 
@@ -441,11 +443,14 @@ export const publishAgoricNamesToChainStorage = async ({
 
 /**
  * @deprecated use reflectAgoricNamesToChainStorage
- *
  * @param {BootstrapPowers} powers
- * @param {{ options?: {agoricNamesOptions?: {
- *   topLevel?: string[]
- * }}}} config
+ * @param {{
+ *   options?: {
+ *     agoricNamesOptions?: {
+ *       topLevel?: string[];
+ *     };
+ *   };
+ * }} config
  */
 export const publishAgoricNames = async (
   { consume: { agoricNamesAdmin, board, chainStorage: rootP } },

--- a/packages/vats/src/core/client-behaviors.js
+++ b/packages/vats/src/core/client-behaviors.js
@@ -84,10 +84,11 @@ async function createLocalBundle(vats, devices, vatAdminSvc, vatPowers) {
 }
 
 /**
- * @param { BootDevices<SoloDevices> & BootstrapSpace & {
- *   vatParameters: BootstrapVatParams,
- *   vats: SwingsetVats & SoloVats,
- * }} powers
+ * @param {BootDevices<SoloDevices> &
+ *   BootstrapSpace & {
+ *     vatParameters: BootstrapVatParams;
+ *     vats: SwingsetVats & SoloVats;
+ *   }} powers
  */
 export const startClient = async ({
   vatParameters: {

--- a/packages/vats/src/core/demoIssuers.js
+++ b/packages/vats/src/core/demoIssuers.js
@@ -25,7 +25,7 @@ export const DecimalPlaces = {
   simolean: 0,
 };
 
-/** @type {Record<string, { proposedName: string, balance: bigint}>} */
+/** @type {Record<string, { proposedName: string; balance: bigint }>} */
 const FaucetPurseDetail = {
   [Stake.symbol]: {
     proposedName: Stake.proposedName,
@@ -92,19 +92,21 @@ const defaultConfig = /** @type {const} */ ({
 
 /**
  * @typedef {readonly [bigint, bigint]} Rational
- *
- * @type { Record<string, {
- *   config?: {
- *     collateralValue: bigint,
- *     initialMargin: Rational,
- *     liquidationMargin: Rational,
- *     liquidationPenalty: Rational,
- *     stabilityFee: Rational,
- *     mintFee: Rational,
- *     liquidationPadding?: Rational,
- *   },
- *   trades: Array<{ central: number, collateral: bigint}>
- * }>}
+ * @type {Record<
+ *   string,
+ *   {
+ *     config?: {
+ *       collateralValue: bigint;
+ *       initialMargin: Rational;
+ *       liquidationMargin: Rational;
+ *       liquidationPenalty: Rational;
+ *       stabilityFee: Rational;
+ *       mintFee: Rational;
+ *       liquidationPadding?: Rational;
+ *     };
+ *     trades: { central: number; collateral: bigint }[];
+ *   }
+ * >}
  */
 export const AMMDemoState = {
   // TODO: getRUN makes BLD obsolete here
@@ -182,9 +184,9 @@ const run2places = f =>
 /**
  * @param {bigint} value
  * @param {{
- *   centralSupplyInstall: ERef<Installation>,
- *   feeMintAccess: ERef<FeeMintAccess>,
- *   zoe: ERef<ZoeService>,
+ *   centralSupplyInstall: ERef<Installation>;
+ *   feeMintAccess: ERef<FeeMintAccess>;
+ *   zoe: ERef<ZoeService>;
  * }} powers
  * @returns {Promise<Payment<'nat'>>}
  */
@@ -216,17 +218,15 @@ const provideCoin = async (name, mints) => {
 };
 
 /**
- * @param { BootstrapSpace &
- *   { consume: {loadVat: VatLoader<MintsVat>} }
- * } powers
+ * @param {BootstrapSpace & { consume: { loadVat: VatLoader<MintsVat> } }} powers
+ *   TODO: sync this type with end-user docs?
  *
- * TODO: sync this type with end-user docs?
  * @typedef {{
- *   issuer: ERef<Issuer>,
- *   issuerPetname: string,
- *   payment: Payment,
- *   brand: Brand,
- *   pursePetname: string,
+ *   issuer: ERef<Issuer>;
+ *   issuerPetname: string;
+ *   payment: Payment;
+ *   brand: Brand;
+ *   pursePetname: string;
  * }} UserPaymentRecord
  */
 export const connectFaucet = async ({
@@ -334,7 +334,7 @@ export const connectFaucet = async ({
       /**
        * reap the spoils of our on-chain provisioning.
        *
-       * @returns {Promise<Array<UserPaymentRecord>>}
+       * @returns {Promise<UserPaymentRecord[]>}
        */
       tapFaucet: async () => faucetPaymentInfo,
       getFeePurse() {
@@ -389,7 +389,7 @@ export const ammPoolRunDeposits = issuers => {
 /**
  * @param {Payment} bootstrapPayment
  * @param {Record<string, bigint>} balances
- * @param {{ issuer: ERef<Issuer>, brand: Brand }} central
+ * @param {{ issuer: ERef<Issuer>; brand: Brand }} central
  */
 export const splitAllCentralPayments = async (
   bootstrapPayment,
@@ -421,9 +421,9 @@ export const splitAllCentralPayments = async (
 
 /**
  * @param {string} issuerName
- * @param {typeof AMMDemoState['ATOM']} record
- * @param {Record<string, { issuer: ERef<Issuer>, brand: Brand }>} kits
- * @param {{ issuer: ERef<Issuer<'nat'>>, brand: Brand<'nat'> }} central
+ * @param {(typeof AMMDemoState)['ATOM']} record
+ * @param {Record<string, { issuer: ERef<Issuer>; brand: Brand }>} kits
+ * @param {{ issuer: ERef<Issuer<'nat'>>; brand: Brand<'nat'> }} central
  */
 export const poolRates = (issuerName, record, kits, central) => {
   /** @param {bigint} n */
@@ -462,7 +462,7 @@ export const poolRates = (issuerName, record, kits, central) => {
 };
 
 /**
- * @param { import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers & {
- *   consume: { mints }
- * }} powers
+ * @param {import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers & {
+ *     consume: { mints };
+ *   }} powers
  */

--- a/packages/vats/src/core/lib-boot.js
+++ b/packages/vats/src/core/lib-boot.js
@@ -12,29 +12,36 @@ import { makePromiseSpace } from './promise-space.js';
 const { Fail, quote: q } = assert;
 
 /**
- * @typedef {true | string | { [key: string]: BootstrapManifestPermit | undefined }} BootstrapManifestPermit
+ * @typedef {| true
+ *   | string
+ *   | { [key: string]: BootstrapManifestPermit | undefined }} BootstrapManifestPermit
  */
 
 /**
- * A manifest is an object in which each key is the name of a function to run
- * at bootstrap and the corresponding value is a "permit" describing an
- * attenuation of allPowers that should be provided as its first argument
- * (cf. packages/vats/src/core/boot.js).
+ * A manifest is an object in which each key is the name of a function to run at
+ * bootstrap and the corresponding value is a "permit" describing an attenuation
+ * of allPowers that should be provided as its first argument (cf.
+ * packages/vats/src/core/boot.js).
  *
  * A permit is either
- * - `true` or a string (both meaning no attenuation, with a string serving
- *   as a grouping label for convenience and diagram generation), or
- * - an object whose keys identify properties to preserve and whose values
- *   are themselves (recursive) permits.
+ *
+ * - `true` or a string (both meaning no attenuation, with a string serving as a
+ *   grouping label for convenience and diagram generation), or
+ * - an object whose keys identify properties to preserve and whose values are
+ *   themselves (recursive) permits.
  *
  * @typedef {Record<string, BootstrapManifestPermit>} BootstrapManifest
- *
  */
 
 /**
- * @typedef {(powers: *, config?: *) => Promise<void>} BootBehavior
+ * @typedef {(powers: any, config?: any) => Promise<void>} BootBehavior
+ *
  * @typedef {Record<string, unknown>} ModuleNamespace
- * @typedef {{ utils: typeof import('./utils.js') } & Record<string, Record<string, any>>} BootModules
+ *
+ * @typedef {{ utils: typeof import('./utils.js') } & Record<
+ *   string,
+ *   Record<string, any>
+ * >} BootModules
  */
 
 /** @type {<X>(a: X[], b: X[]) => X[]} */
@@ -42,8 +49,8 @@ const setDiff = (a, b) => a.filter(x => !b.includes(x));
 
 /**
  * @param {VatPowers & {
- *   D: DProxy,
- *   logger: (msg) => void,
+ *   D: DProxy;
+ *   logger: (msg) => void;
  * }} vatPowers
  * @param {Record<string, unknown>} vatParameters
  * @param {BootstrapManifest} bootManifest
@@ -147,7 +154,11 @@ export const makeBootstrap = (
         },
       ],
     };
-    /** @type {{coreEvalBridgeHandler: Promise<import('../types.js').BridgeHandler>}} */
+    /**
+     * @type {{
+     *   coreEvalBridgeHandler: Promise<import('../types.js').BridgeHandler>;
+     * }}
+     */
     // @ts-expect-error cast
     const { coreEvalBridgeHandler } = consume;
     await E(coreEvalBridgeHandler).fromBridge(coreEvalMessage);

--- a/packages/vats/src/core/promise-space.js
+++ b/packages/vats/src/core/promise-space.js
@@ -6,17 +6,17 @@ import { makePromiseKit } from '@endo/promise-kit';
 
 /**
  * @typedef {{
- *   onAddKey: (key: string) => void,
- *   onResolve: (key: string, value: ERef<unknown>) => void,
- *   onSettled: (key: string, remaining: Set<string>) => void,
- *   onReset: (key: string) => void,
+ *   onAddKey: (key: string) => void;
+ *   onResolve: (key: string, value: ERef<unknown>) => void;
+ *   onSettled: (key: string, remaining: Set<string>) => void;
+ *   onReset: (key: string) => void;
  * }} PromiseSpaceHooks
  */
 
 const noop = harden(() => {});
 
 /**
- * @param { typeof console.log } log
+ * @param {typeof console.log} log
  * @returns {PromiseSpaceHooks}
  */
 export const makeLogHooks = log =>
@@ -29,11 +29,11 @@ export const makeLogHooks = log =>
   });
 
 /**
- * Note: caller is responsible for synchronization
- * in case of onResolve() called with a promise.
+ * Note: caller is responsible for synchronization in case of onResolve() called
+ * with a promise.
  *
  * @param {MapStore<string, Passable>} store
- * @param { typeof console.log } [log]
+ * @param {typeof console.log} [log]
  * @returns {PromiseSpaceHooks}
  */
 export const makeStoreHooks = (store, log = noop) => {
@@ -77,9 +77,11 @@ export const makeStoreHooks = (store, log = noop) => {
  * Note: repeated resolve()s without an intervening reset() are noops.
  *
  * @template {Record<string, unknown>} [T=Record<string, unknown>]
- * @param {{ log?: typeof console.log } & (
- *  { hooks?: PromiseSpaceHooks } | { store: MapStore<string, any> }
- * ) | (typeof console.log)} [optsOrLog]
+ * @param {| ({ log?: typeof console.log } & (
+ *       | { hooks?: PromiseSpaceHooks }
+ *       | { store: MapStore<string, any> }
+ *     ))
+ *   | typeof console.log} [optsOrLog]
  * @returns {PromiseSpaceOf<T>}
  */
 export const makePromiseSpace = (optsOrLog = {}) => {
@@ -91,9 +93,7 @@ export const makePromiseSpace = (optsOrLog = {}) => {
       : opts.hooks || makeLogHooks(log);
   const { onAddKey, onSettled, onResolve, onReset } = hooks;
 
-  /**
-   * @typedef {{ pk: PromiseRecord<any>, isSettling: boolean }} PromiseState
-   */
+  /** @typedef {{ pk: PromiseRecord<any>; isSettling: boolean }} PromiseState */
   /** @type {Map<string, PromiseState>} */
   const nameToState = new Map();
   /** @type {Set<string>} */

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -17,7 +17,10 @@ const trace = makeTracer('StartWF');
 
 /**
  * @param {ERef<ZoeService>} zoe
- * @param {Installation<import('@agoric/smart-wallet/src/walletFactory').prepare>} inst
+ * @param {Installation<
+ *   import('@agoric/smart-wallet/src/walletFactory').prepare
+ * >} inst
+ *
  * @typedef {Awaited<ReturnType<typeof startFactoryInstance>>} WalletFactoryStartResult
  */
 // eslint-disable-next-line no-unused-vars
@@ -26,8 +29,8 @@ const startFactoryInstance = (zoe, inst) => E(zoe).startInstance(inst);
 const StableUnit = BigInt(10 ** Stable.displayInfo.decimalPlaces);
 
 /**
- * Publish an arbitrary wallet state so that clients
- * can tell that a wallet has been provisioned.
+ * Publish an arbitrary wallet state so that clients can tell that a wallet has
+ * been provisioned.
  *
  * @param {string[]} oldAddresses
  * @param {Marshaller} marshaller
@@ -53,22 +56,28 @@ const publishRevivableWalletState = async (
 };
 
 /**
- * Register for PLEASE_PROVISION bridge messages and handle
- * them by providing a smart wallet from the wallet factory.
+ * Register for PLEASE_PROVISION bridge messages and handle them by providing a
+ * smart wallet from the wallet factory.
  *
- * @param {BootstrapPowers & ChainStorageVatParams & PromiseSpaceOf<{
- *   economicCommitteeCreatorFacet: import('@agoric/governance/src/committee.js').CommitteeElectorateCreatorFacet
- *   econCharterKit: {
- *     creatorFacet: Awaited<ReturnType<import('@agoric/inter-protocol/src/econCommitteeCharter.js')['prepare']>>['creatorFacet'],
- *     adminFacet: AdminFacet,
- *   } ,
- *   walletBridgeManager: import('../types.js').ScopedBridgeManager;
- *   provisionWalletBridgeManager: import('../types.js').ScopedBridgeManager;
- * }>} powers
+ * @param {BootstrapPowers &
+ *   ChainStorageVatParams &
+ *   PromiseSpaceOf<{
+ *     economicCommitteeCreatorFacet: import('@agoric/governance/src/committee.js').CommitteeElectorateCreatorFacet;
+ *     econCharterKit: {
+ *       creatorFacet: Awaited<
+ *         ReturnType<
+ *           import('@agoric/inter-protocol/src/econCommitteeCharter.js')['prepare']
+ *         >
+ *       >['creatorFacet'];
+ *       adminFacet: AdminFacet;
+ *     };
+ *     walletBridgeManager: import('../types.js').ScopedBridgeManager;
+ *     provisionWalletBridgeManager: import('../types.js').ScopedBridgeManager;
+ *   }>} powers
  * @param {{
  *   options?: {
- *     perAccountInitialValue?: bigint,
- *   },
+ *     perAccountInitialValue?: bigint;
+ *   };
  * }} [config]
  */
 export const startWalletFactory = async (

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -12,66 +12,102 @@
 /**
  * SwingSet types
  *
- * @typedef { Device<ReturnType<typeof
- *   import('@agoric/swingset-vat/src/devices/bridge/device-bridge.js').buildRootDeviceNode>> } BridgeDevice
- * @typedef { Device<ReturnType<typeof
- *   import('@agoric/swingset-vat/src/devices/command/device-command.js').buildRootDeviceNode>> } CommandDevice
- * @typedef { Device<ReturnType<typeof
- *   import('@agoric/swingset-vat/src/devices/mailbox/device-mailbox.js').buildRootDeviceNode>> } MailboxDevice
- * @typedef { Device<ReturnType<typeof
- *   import('@agoric/swingset-vat/src/devices/plugin/device-plugin.js').buildRootDeviceNode>> } PluginDevice
- * @typedef { Device<ReturnType<typeof
- *   import('@agoric/swingset-vat/src/devices/timer/device-timer.js').buildRootDeviceNode>> } TimerDevice
- * @typedef { Device<
- *   import('@agoric/swingset-vat/src/devices/vat-admin/device-vat-admin.js').VatAdminRootDeviceNode> } VatAdminDevice
+ * @typedef {Device<
+ *   ReturnType<
+ *     typeof import('@agoric/swingset-vat/src/devices/bridge/device-bridge.js').buildRootDeviceNode
+ *   >
+ * >} BridgeDevice
  *
- * @typedef { ERef<ReturnType<typeof
- *   import('@agoric/swingset-vat/src/vats/vattp/vat-vattp.js').buildRootObject>> } VattpVat
- * @typedef { ERef<ReturnType<typeof
- *   import('@agoric/swingset-vat/src/vats/vat-admin/vat-vat-admin.js').buildRootObject>> } VatAdminVat
- * @typedef { ERef<ReturnType<typeof
- *   import('@agoric/swingset-vat/src/vats/timer/vat-timer.js').buildRootObject>> } TimerVat
+ * @typedef {Device<
+ *   ReturnType<
+ *     typeof import('@agoric/swingset-vat/src/devices/command/device-command.js').buildRootDeviceNode
+ *   >
+ * >} CommandDevice
  *
- * See deliverToController in packages/SwingSet/src/vats/comms/controller.js
+ * @typedef {Device<
+ *   ReturnType<
+ *     typeof import('@agoric/swingset-vat/src/devices/mailbox/device-mailbox.js').buildRootDeviceNode
+ *   >
+ * >} MailboxDevice
+ *
+ * @typedef {Device<
+ *   ReturnType<
+ *     typeof import('@agoric/swingset-vat/src/devices/plugin/device-plugin.js').buildRootDeviceNode
+ *   >
+ * >} PluginDevice
+ *
+ * @typedef {Device<
+ *   ReturnType<
+ *     typeof import('@agoric/swingset-vat/src/devices/timer/device-timer.js').buildRootDeviceNode
+ *   >
+ * >} TimerDevice
+ *
+ * @typedef {Device<
+ *   import('@agoric/swingset-vat/src/devices/vat-admin/device-vat-admin.js').VatAdminRootDeviceNode
+ * >} VatAdminDevice
+ *
+ * @typedef {ERef<
+ *   ReturnType<
+ *     typeof import('@agoric/swingset-vat/src/vats/vattp/vat-vattp.js').buildRootObject
+ *   >
+ * >} VattpVat
+ *
+ * @typedef {ERef<
+ *   ReturnType<
+ *     typeof import('@agoric/swingset-vat/src/vats/vat-admin/vat-vat-admin.js').buildRootObject
+ *   >
+ * >} VatAdminVat
+ *
+ * @typedef {ERef<
+ *   ReturnType<
+ *     typeof import('@agoric/swingset-vat/src/vats/timer/vat-timer.js').buildRootObject
+ *   >
+ * >} TimerVat
+ *   See deliverToController in packages/SwingSet/src/vats/comms/controller.js
+ *
  * @typedef {ERef<{
- *   addRemote: (name: string, tx: unknown, rx: unknown) => void,
- *   addEgress: (addr: string, ix: number, provider: unknown) => void,
- *   addIngress: (remoteID: string, remoteRefID: number, label?: string) => Promise<any>,
+ *   addRemote: (name: string, tx: unknown, rx: unknown) => void;
+ *   addEgress: (addr: string, ix: number, provider: unknown) => void;
+ *   addIngress: (
+ *     remoteID: string,
+ *     remoteRefID: number,
+ *     label?: string,
+ *   ) => Promise<any>;
  * }>} CommsVatRoot
  *
  * @typedef {{
- *   comms: CommsVatRoot,
- *   timer: TimerVat,
- *   vatAdmin: VatAdminVat,
- *   vattp: VattpVat,
+ *   comms: CommsVatRoot;
+ *   timer: TimerVat;
+ *   vatAdmin: VatAdminVat;
+ *   vattp: VattpVat;
  * }} SwingsetVats
  *
  * @typedef {{
- *   vatParameters: { chainStorageEntries?: Array<[k: string, v: string]>,
- * }}} ChainStorageVatParams
+ *   vatParameters: { chainStorageEntries?: [k: string, v: string][] };
+ * }} ChainStorageVatParams
  */
 
 /**
  * @typedef {{
- *   vatAdmin: VatAdminDevice,
- *   mailbox: MailboxDevice,
- *   command: CommandDevice,
- *   timer: TimerDevice,
- *   plugin: PluginDevice,
+ *   vatAdmin: VatAdminDevice;
+ *   mailbox: MailboxDevice;
+ *   command: CommandDevice;
+ *   timer: TimerDevice;
+ *   plugin: PluginDevice;
  * }} SoloDevices
  *
  * @typedef {{
- *   vatAdmin: VatAdminDevice,
- *   mailbox: MailboxDevice,
- *   timer: TimerDevice,
- *   bridge?: BridgeDevice,
+ *   vatAdmin: VatAdminDevice;
+ *   mailbox: MailboxDevice;
+ *   timer: TimerDevice;
+ *   bridge?: BridgeDevice;
  * }} ChainDevices
  */
 
 /**
  * @typedef {{
- *   getChainBundle: () => unknown,
- *   getChainConfigNotifier: () => Notifier<unknown>,
+ *   getChainBundle: () => unknown;
+ *   getChainConfigNotifier: () => Notifier<unknown>;
  * }} ClientProvider
  */
 
@@ -82,9 +118,7 @@
  * @property {(r: unknown) => void} reject
  * @property {(reason?: unknown) => void} reset
  */
-/**
- * @typedef {{ bundleName?: string, bundleID?: string }} VatSourceRef
- */
+/** @typedef {{ bundleName?: string; bundleID?: string }} VatSourceRef */
 /**
  * @template T
  * @typedef {(name: string, sourceRef?: VatSourceRef) => T} VatLoader<T>
@@ -92,10 +126,12 @@
 
 /**
  * @typedef {{
- *   assignBundle: (ps: PropertyMaker[]) => void
- * }} ClientManager tool to put properties onto the `home` object of the client
+ *   assignBundle: (ps: PropertyMaker[]) => void;
+ * }} ClientManager
+ *   tool to put properties onto the `home` object of the client
  *
- * @typedef {(addr: string, flags: string[]) => Record<string, unknown>} PropertyMaker callback to assign a property onto the `home` object of the client
+ * @typedef {(addr: string, flags: string[]) => Record<string, unknown>} PropertyMaker
+ *   callback to assign a property onto the `home` object of the client
  */
 
 /**
@@ -103,8 +139,8 @@
  * @template [C={}] Consume only
  * @template [P={}] Produce only
  * @typedef {{
- *   consume: { [K in keyof (B & C)]: Promise<(B & C)[K]> },
- *   produce: { [K in keyof (B & P)]: Producer<(B & P)[K]> },
+ *   consume: { [K in keyof (B & C)]: Promise<(B & C)[K]> };
+ *   produce: { [K in keyof (B & P)]: Producer<(B & P)[K]> };
  * }} PromiseSpaceOf
  */
 
@@ -116,232 +152,371 @@
  * @returns {Promise<Record<string, Promise<any>>>}
  *
  * @typedef {object} ClientFacet
- * @property {() => ERef<Record<string, any>>} getChainBundle Required for ag-solo, but deprecated in favour of getConfiguration
- *   NOTE: we use `any` rather than `unknown` because each client that wants to call a method such as
- *   `E(userBundle.bank).deposit(payment)` has to cast userBundle.bank;
- *   ideally, the cast is to some useful type. But unknown can't be cast directly to some other type;
- *   it has to be cast to any first.
+ * @property {() => ERef<Record<string, any>>} getChainBundle Required for
+ *   ag-solo, but deprecated in favour of getConfiguration NOTE: we use `any`
+ *   rather than `unknown` because each client that wants to call a method such
+ *   as `E(userBundle.bank).deposit(payment)` has to cast userBundle.bank;
+ *   ideally, the cast is to some useful type. But unknown can't be cast
+ *   directly to some other type; it has to be cast to any first.
  * @property {() => AsyncIterable<Configuration, Configuration>} getConfiguration
  *
- * @typedef {{ clientAddress: string, clientHome: Record<string, any>}} Configuration
+ * @typedef {{ clientAddress: string; clientHome: Record<string, any> }} Configuration
  *
  * @typedef {object} ClientCreator
- * @property {CreateUserBundle} createUserBundle Required for vat-provisioning, but deprecated in favor of {@link createClient}.
- * @property {(nickname: string, clientAddress: string, powerFlags: string[]) => Promise<ClientFacet>} createClientFacet
+ * @property {CreateUserBundle} createUserBundle Required for vat-provisioning,
+ *   but deprecated in favor of {@link createClient}.
+ * @property {(
+ *   nickname: string,
+ *   clientAddress: string,
+ *   powerFlags: string[],
+ * ) => Promise<ClientFacet>} createClientFacet
  */
 
 /**
  * @typedef {import('@agoric/inter-protocol/src/tokens.js').TokenKeyword} TokenKeyword
  *
  * @typedef {{
- *   issuer: |
- *     TokenKeyword | 'Invitation' | 'AUSD',
- *   installation: |
- *     'centralSupply' | 'mintHolder' |
- *     'walletFactory' | 'provisionPool' | 'auctioneer' |
- *     'feeDistributor' |
- *     'contractGovernor' | 'committee' | 'noActionElectorate' | 'binaryVoteCounter' |
- *     'VaultFactory' | 'liquidate' |
- *     'Pegasus' | 'reserve' | 'psm' | 'econCommitteeCharter' | 'priceAggregator',
- *   instance: |
- *     'economicCommittee' | 'feeDistributor' | 'auctioneer' |
- *     'VaultFactory' | 'VaultFactoryGovernor' |
- *     'econCommitteeCharter' |
- *     'walletFactory' | 'provisionPool' |
- *     'reserve' | 'reserveGovernor' | 'Pegasus',
- *   oracleBrand:
- *     'USD',
- *   uiConfig: |
- *     'VaultFactory'
+ *   issuer: TokenKeyword | 'Invitation' | 'AUSD';
+ *   installation:
+ *     | 'centralSupply'
+ *     | 'mintHolder'
+ *     | 'walletFactory'
+ *     | 'provisionPool'
+ *     | 'auctioneer'
+ *     | 'feeDistributor'
+ *     | 'contractGovernor'
+ *     | 'committee'
+ *     | 'noActionElectorate'
+ *     | 'binaryVoteCounter'
+ *     | 'VaultFactory'
+ *     | 'liquidate'
+ *     | 'Pegasus'
+ *     | 'reserve'
+ *     | 'psm'
+ *     | 'econCommitteeCharter'
+ *     | 'priceAggregator';
+ *   instance:
+ *     | 'economicCommittee'
+ *     | 'feeDistributor'
+ *     | 'auctioneer'
+ *     | 'VaultFactory'
+ *     | 'VaultFactoryGovernor'
+ *     | 'econCommitteeCharter'
+ *     | 'walletFactory'
+ *     | 'provisionPool'
+ *     | 'reserve'
+ *     | 'reserveGovernor'
+ *     | 'Pegasus';
+ *   oracleBrand: 'USD';
+ *   uiConfig: 'VaultFactory';
  * }} WellKnownName
  *
  * @typedef {{
  *   issuer: {
- *     produce: Record<WellKnownName['issuer'], Producer<Issuer>>,
- *     consume: Record<WellKnownName['issuer'], Promise<Issuer>> & { BLD: Promise<Issuer<'nat'>>, IST: Promise<Issuer<'nat'>> },
- *   },
+ *     produce: Record<WellKnownName['issuer'], Producer<Issuer>>;
+ *     consume: Record<WellKnownName['issuer'], Promise<Issuer>> & {
+ *       BLD: Promise<Issuer<'nat'>>;
+ *       IST: Promise<Issuer<'nat'>>;
+ *     };
+ *   };
  *   brand: {
- *     produce: Record<WellKnownName['issuer'], Producer<Brand>> &
- *              { timer: Producer<import('@agoric/time').TimerBrand> },
- *     consume: Record<WellKnownName['issuer'], Promise<Brand>> &
- *              { BLD: Promise<Brand<'nat'>>, IST: Promise<Brand<'nat'>>,
- *                timer: Producer<import('@agoric/time').TimerBrand> },
- *   },
+ *     produce: Record<WellKnownName['issuer'], Producer<Brand>> & {
+ *       timer: Producer<import('@agoric/time').TimerBrand>;
+ *     };
+ *     consume: Record<WellKnownName['issuer'], Promise<Brand>> & {
+ *       BLD: Promise<Brand<'nat'>>;
+ *       IST: Promise<Brand<'nat'>>;
+ *       timer: Producer<import('@agoric/time').TimerBrand>;
+ *     };
+ *   };
  *   oracleBrand: {
- *     produce: Record<WellKnownName['oracleBrand'], Producer<Brand>>,
- *     consume: Record<WellKnownName['oracleBrand'], Promise<Brand>>,
- *   },
- *   installation:{
- *     produce: Record<WellKnownName['installation'], Producer<Installation>>,
- *     consume: Record<WellKnownName['installation'], Promise<Installation<unknown>>> & {
- *       auctioneer: Promise<Installation<import('@agoric/inter-protocol/src/auction/auctioneer.js').start>>,
- *       centralSupply: Promise<Installation<import('@agoric/vats/src/centralSupply.js').start>>,
- *       committee: Promise<Installation<import('@agoric/governance/src/committee.js')['prepare']>>,
- *       contractGovernor: Promise<Installation<import('@agoric/governance/src/contractGovernor.js')['prepare']>>,
- *       econCommitteeCharter: Promise<Installation<import('@agoric/inter-protocol/src/econCommitteeCharter.js')['prepare']>>,
- *       feeDistributor: Promise<Installation<import('@agoric/inter-protocol/src/feeDistributor.js').start>>,
- *       mintHolder: Promise<Installation<import('@agoric/vats/src/mintHolder.js').prepare>>,
- *       psm: Promise<Installation<import('@agoric/inter-protocol/src/psm/psm.js')['prepare']>>,
- *       provisionPool: Promise<Installation<import('@agoric/vats/src/provisionPool.js')['prepare']>>,
- *       reserve: Promise<Installation<import('@agoric/inter-protocol/src/reserve/assetReserve.js')['prepare']>>,
- *       VaultFactory: Promise<Installation<import('@agoric/inter-protocol/src/vaultFactory/vaultFactory.js')['prepare']>>,
- *       walletFactory: Promise<Installation<import('@agoric/smart-wallet/src/walletFactory.js').prepare>>,
- *     },
- *   },
- *   instance:{
- *     produce: Record<WellKnownName['instance'], Producer<Instance>>,
- *     consume: Record<WellKnownName['instance'], Promise<Instance>>,
- *   },
+ *     produce: Record<WellKnownName['oracleBrand'], Producer<Brand>>;
+ *     consume: Record<WellKnownName['oracleBrand'], Promise<Brand>>;
+ *   };
+ *   installation: {
+ *     produce: Record<WellKnownName['installation'], Producer<Installation>>;
+ *     consume: Record<
+ *       WellKnownName['installation'],
+ *       Promise<Installation<unknown>>
+ *     > & {
+ *       auctioneer: Promise<
+ *         Installation<
+ *           import('@agoric/inter-protocol/src/auction/auctioneer.js').start
+ *         >
+ *       >;
+ *       centralSupply: Promise<
+ *         Installation<import('@agoric/vats/src/centralSupply.js').start>
+ *       >;
+ *       committee: Promise<
+ *         Installation<
+ *           import('@agoric/governance/src/committee.js')['prepare']
+ *         >
+ *       >;
+ *       contractGovernor: Promise<
+ *         Installation<
+ *           import('@agoric/governance/src/contractGovernor.js')['prepare']
+ *         >
+ *       >;
+ *       econCommitteeCharter: Promise<
+ *         Installation<
+ *           import('@agoric/inter-protocol/src/econCommitteeCharter.js')['prepare']
+ *         >
+ *       >;
+ *       feeDistributor: Promise<
+ *         Installation<
+ *           import('@agoric/inter-protocol/src/feeDistributor.js').start
+ *         >
+ *       >;
+ *       mintHolder: Promise<
+ *         Installation<import('@agoric/vats/src/mintHolder.js').prepare>
+ *       >;
+ *       psm: Promise<
+ *         Installation<
+ *           import('@agoric/inter-protocol/src/psm/psm.js')['prepare']
+ *         >
+ *       >;
+ *       provisionPool: Promise<
+ *         Installation<import('@agoric/vats/src/provisionPool.js')['prepare']>
+ *       >;
+ *       reserve: Promise<
+ *         Installation<
+ *           import('@agoric/inter-protocol/src/reserve/assetReserve.js')['prepare']
+ *         >
+ *       >;
+ *       VaultFactory: Promise<
+ *         Installation<
+ *           import('@agoric/inter-protocol/src/vaultFactory/vaultFactory.js')['prepare']
+ *         >
+ *       >;
+ *       walletFactory: Promise<
+ *         Installation<
+ *           import('@agoric/smart-wallet/src/walletFactory.js').prepare
+ *         >
+ *       >;
+ *     };
+ *   };
+ *   instance: {
+ *     produce: Record<WellKnownName['instance'], Producer<Instance>>;
+ *     consume: Record<WellKnownName['instance'], Promise<Instance>>;
+ *   };
  *   uiConfig: {
- *     produce: Record<WellKnownName['uiConfig'], Producer<Record<string, any>>>,
- *     consume: Record<WellKnownName['uiConfig'], Promise<Record<string, any>>>,
- *   },
+ *     produce: Record<
+ *       WellKnownName['uiConfig'],
+ *       Producer<Record<string, any>>
+ *     >;
+ *     consume: Record<WellKnownName['uiConfig'], Promise<Record<string, any>>>;
+ *   };
  * }} WellKnownSpaces
  */
 
 /**
  * @template {GovernableStartFn} SF
  * @typedef {{
- *   installation: ERef<Installation<SF>>,
- *   issuerKeywordRecord?: IssuerKeywordRecord,
- *   governedParams: Record<string, unknown>,
- *   terms: Omit<import('@agoric/zoe/src/zoeService/utils').StartParams<SF>['terms'], 'brands' | 'issuers' | 'governedParams' | 'electionManager'>,
- *   privateArgs: Omit<import('@agoric/zoe/src/zoeService/utils').StartParams<SF>['privateArgs'], 'initialPoserInvitation'>,
- *   label: string,
+ *   installation: ERef<Installation<SF>>;
+ *   issuerKeywordRecord?: IssuerKeywordRecord;
+ *   governedParams: Record<string, unknown>;
+ *   terms: Omit<
+ *     import('@agoric/zoe/src/zoeService/utils').StartParams<SF>['terms'],
+ *     'brands' | 'issuers' | 'governedParams' | 'electionManager'
+ *   >;
+ *   privateArgs: Omit<
+ *     import('@agoric/zoe/src/zoeService/utils').StartParams<SF>['privateArgs'],
+ *     'initialPoserInvitation'
+ *   >;
+ *   label: string;
  * }} StartGovernedUpgradableOpts
- *
  */
 /**
- * @typedef {<SF extends GovernableStartFn>(opts: StartGovernedUpgradableOpts<SF>) => Promise<GovernanceFacetKit<SF>>
- * } startGovernedUpgradable
+ * @typedef {<SF extends GovernableStartFn>(
+ *   opts: StartGovernedUpgradableOpts<SF>,
+ * ) => Promise<GovernanceFacetKit<SF>>} startGovernedUpgradable
  */
 
 /**
  * @template {import('@agoric/zoe/src/zoeService/utils').ContractStartFunction} SF
  * @typedef {{
- *   installation: ERef<Installation<SF>>,
- *   issuerKeywordRecord?: IssuerKeywordRecord,
- *   terms?: Omit<import('@agoric/zoe/src/zoeService/utils').StartParams<SF>['terms'], 'brands' | 'issuers'>,
- *   privateArgs?: import('@agoric/zoe/src/zoeService/utils').StartParams<SF>['privateArgs'],
- *   label: string,
+ *   installation: ERef<Installation<SF>>;
+ *   issuerKeywordRecord?: IssuerKeywordRecord;
+ *   terms?: Omit<
+ *     import('@agoric/zoe/src/zoeService/utils').StartParams<SF>['terms'],
+ *     'brands' | 'issuers'
+ *   >;
+ *   privateArgs?: import('@agoric/zoe/src/zoeService/utils').StartParams<SF>['privateArgs'];
+ *   label: string;
  * }} StartUpgradableOpts
  */
 /**
- * @typedef {<SF extends import('@agoric/zoe/src/zoeService/utils').ContractStartFunction>(opts: StartUpgradableOpts<SF>)
- *   => Promise<
- *     import('@agoric/zoe/src/zoeService/utils').StartedInstanceKit<SF> &
- *     { label: string }
- *   >
- * } StartUpgradable
+ * @typedef {<
+ *   SF extends
+ *     import('@agoric/zoe/src/zoeService/utils').ContractStartFunction,
+ * >(
+ *   opts: StartUpgradableOpts<SF>,
+ * ) => Promise<
+ *   import('@agoric/zoe/src/zoeService/utils').StartedInstanceKit<SF> & {
+ *     label: string;
+ *   }
+ * >} StartUpgradable
  */
 
-/** @template T @typedef {import('@agoric/zoe/src/zoeService/utils').StartedInstanceKit<T> } StartedInstanceKit */
+/**
+ * @template T @typedef
+ *   {import('@agoric/zoe/src/zoeService/utils').StartedInstanceKit<T> }
+ *   StartedInstanceKit
+ */
 
-/** @typedef {{label: string} & StartedInstanceKit<import('@agoric/zoe/src/zoeService/utils').ContractStartFunction>} StartedInstanceKitWithLabel */
+/**
+ * @typedef {{ label: string } & StartedInstanceKit<
+ *   import('@agoric/zoe/src/zoeService/utils').ContractStartFunction
+ * >} StartedInstanceKitWithLabel
+ */
 
 /**
  * @typedef {{
- *   agoricNames: NameHub,
- *   agoricNamesAdmin: import('@agoric/vats').NameAdmin,
- *   bankManager: BankManager,
- *   bldIssuerKit: RemoteIssuerKit,
- *   board: import('@agoric/vats').Board,
- *   bridgeManager: import('../types.js').BridgeManager | undefined,
- *   chainStorage: StorageNode | null,
- *   chainTimerService: import('@agoric/time/src/types').TimerService,
- *   client: ClientManager,
- *   clientCreator: ClientCreator,
- *   coreEvalBridgeHandler: import('../types.js').BridgeHandler,
- *   diagnostics: { savePrivateArgs: (instance: Instance, privateArgs: unknown) => void },
- *   feeMintAccess: FeeMintAccess,
- *   highPrioritySendersManager: import('@agoric/internal/src/priority-senders.js').PrioritySendersManager?,
- *   initialSupply: Payment<'nat'>,
- *   instancePrivateArgs: Map<Instance, unknown>,
- *   namesByAddress: NameHub,
- *   namesByAddressAdmin: import('../types').NamesByAddressAdmin,
- *   pegasusConnections: import('@agoric/vats').NameHubKit,
- *   pegasusConnectionsAdmin: import('@agoric/vats').NameAdmin,
- *   priceAuthorityVat: Awaited<PriceAuthorityVat>,
- *   priceAuthority: PriceAuthority,
- *   priceAuthorityAdmin: PriceAuthorityRegistryAdmin,
- *   provisioning: Awaited<ProvisioningVat> | undefined,
- *   provisionBridgeManager: import('../types.js').ScopedBridgeManager | undefined,
- *   provisionWalletBridgeManager: import('../types.js').ScopedBridgeManager | undefined,
- *   storageBridgeManager: import('../types.js').ScopedBridgeManager?,
- *   contractKits: MapStore<Instance, StartedInstanceKitWithLabel>,
- *   startUpgradable: StartUpgradable,
- *   governedContractKits: MapStore<Instance, GovernanceFacetKit<any> & {label: string}>,
- *   startGovernedUpgradable: startGovernedUpgradable,
- *   testFirstAnchorKit: import('../vat-bank.js').AssetIssuerKit<'nat'>,
- *   walletBridgeManager: import('../types.js').ScopedBridgeManager | undefined,
- *   walletFactoryStartResult: import('./startWalletFactory').WalletFactoryStartResult,
- *   provisionPoolStartResult: unknown,
- *   vatStore: import('./utils.js').VatStore,
- *   zoe: ZoeService,
+ *   agoricNames: NameHub;
+ *   agoricNamesAdmin: import('@agoric/vats').NameAdmin;
+ *   bankManager: BankManager;
+ *   bldIssuerKit: RemoteIssuerKit;
+ *   board: import('@agoric/vats').Board;
+ *   bridgeManager: import('../types.js').BridgeManager | undefined;
+ *   chainStorage: StorageNode | null;
+ *   chainTimerService: import('@agoric/time/src/types').TimerService;
+ *   client: ClientManager;
+ *   clientCreator: ClientCreator;
+ *   coreEvalBridgeHandler: import('../types.js').BridgeHandler;
+ *   diagnostics: {
+ *     savePrivateArgs: (instance: Instance, privateArgs: unknown) => void;
+ *   };
+ *   feeMintAccess: FeeMintAccess;
+ *   highPrioritySendersManager: import('@agoric/internal/src/priority-senders.js').PrioritySendersManager?;
+ *   initialSupply: Payment<'nat'>;
+ *   instancePrivateArgs: Map<Instance, unknown>;
+ *   namesByAddress: NameHub;
+ *   namesByAddressAdmin: import('../types').NamesByAddressAdmin;
+ *   pegasusConnections: import('@agoric/vats').NameHubKit;
+ *   pegasusConnectionsAdmin: import('@agoric/vats').NameAdmin;
+ *   priceAuthorityVat: Awaited<PriceAuthorityVat>;
+ *   priceAuthority: PriceAuthority;
+ *   priceAuthorityAdmin: PriceAuthorityRegistryAdmin;
+ *   provisioning: Awaited<ProvisioningVat> | undefined;
+ *   provisionBridgeManager:
+ *     | import('../types.js').ScopedBridgeManager
+ *     | undefined;
+ *   provisionWalletBridgeManager:
+ *     | import('../types.js').ScopedBridgeManager
+ *     | undefined;
+ *   storageBridgeManager: import('../types.js').ScopedBridgeManager?;
+ *   contractKits: MapStore<Instance, StartedInstanceKitWithLabel>;
+ *   startUpgradable: StartUpgradable;
+ *   governedContractKits: MapStore<
+ *     Instance,
+ *     GovernanceFacetKit<any> & { label: string }
+ *   >;
+ *   startGovernedUpgradable: startGovernedUpgradable;
+ *   testFirstAnchorKit: import('../vat-bank.js').AssetIssuerKit<'nat'>;
+ *   walletBridgeManager: import('../types.js').ScopedBridgeManager | undefined;
+ *   walletFactoryStartResult: import('./startWalletFactory').WalletFactoryStartResult;
+ *   provisionPoolStartResult: unknown;
+ *   vatStore: import('./utils.js').VatStore;
+ *   zoe: ZoeService;
  * }} ChainBootstrapSpaceT
+ *
  * @typedef {PromiseSpaceOf<ChainBootstrapSpaceT>} ChainBootstrapSpace
  *
- * @typedef {import('@agoric/vats').NameHub} NameHub
- * IDEA/TODO: make types of demo stuff invisible in production behaviors
+ * @typedef {import('@agoric/vats').NameHub} NameHub IDEA/TODO: make types of
+ *   demo stuff invisible in production behaviors
+ *
  * @typedef {{
  *   argv: {
- *     hardcodedClientAddresses?: string[],
- *     FIXME_GCI: string,
- *     PROVISIONER_INDEX?: number,
- *   },
+ *     hardcodedClientAddresses?: string[];
+ *     FIXME_GCI: string;
+ *     PROVISIONER_INDEX?: number;
+ *   };
  * }} BootstrapVatParams
- * @typedef { BootstrapSpace & {
- *   zone: import('@agoric/zone').Zone,
- *   devices: SoloDevices | ChainDevices,
- *   vats: SwingsetVats,
- *   vatPowers: { [prop: string]: any, D: DProxy },
- *   vatParameters: BootstrapVatParams,
- *   runBehaviors: (manifest: unknown) => Promise<unknown>,
- *   modules: Record<string, Record<string, any>>,
- * }} BootstrapPowers
- * @typedef { WellKnownSpaces & PromiseSpaceOf<ChainBootstrapSpaceT & {
- *     vatAdminSvc: VatAdminSvc,
- *   }, {}, {
- *     loadVat: VatLoader<unknown>,
- *     loadCriticalVat: VatLoader<unknown>,
- *   }>
- * } BootstrapSpace
- * @typedef {{ mint: ERef<Mint>, issuer: ERef<Issuer>, brand: Brand }} RemoteIssuerKit
- * @typedef {Awaited<ReturnType<Awaited<BankVat>['makeBankManager']>>} BankManager
- * @typedef {ERef<ReturnType<import('../vat-agoricNames').buildRootObject>>} AgoricNamesVat
- * @typedef {ERef<ReturnType<import('../vat-bank.js').buildRootObject>>} BankVat
- * @typedef {ERef<ReturnType<import('../vat-board.js').buildRootObject>>} BoardVat
- * @typedef {ERef<ReturnType<import('../vat-bridge.js').buildRootObject>>} ChainStorageVat
- * @typedef {ERef<ReturnType<import('../vat-provisioning.js').buildRootObject>>} ProvisioningVat
- * @typedef {ERef<ReturnType<import('../vat-mints.js').buildRootObject>>} MintsVat
- * @typedef {ERef<ReturnType<import('../vat-priceAuthority.js').buildRootObject>>} PriceAuthorityVat
- * @typedef {ERef<ReturnType<import('../vat-network.js').buildRootObject>>} NetworkVat
- * @typedef {ERef<ReturnType<import('../vat-ibc.js').buildRootObject>>} IBCVat
- * @typedef { import('@agoric/zoe/tools/priceAuthorityRegistry').PriceAuthorityRegistryAdmin } PriceAuthorityRegistryAdmin
  *
- * @typedef {{ namedVat: PromiseSpaceOf<{
- *   agoricNames: Awaited<AgoricNamesVat>,
- *   board: Awaited<BoardVat>,
- * }> }} NamedVatPowers
+ * @typedef {BootstrapSpace & {
+ *   zone: import('@agoric/zone').Zone;
+ *   devices: SoloDevices | ChainDevices;
+ *   vats: SwingsetVats;
+ *   vatPowers: { [prop: string]: any; D: DProxy };
+ *   vatParameters: BootstrapVatParams;
+ *   runBehaviors: (manifest: unknown) => Promise<unknown>;
+ *   modules: Record<string, Record<string, any>>;
+ * }} BootstrapPowers
+ *
+ * @typedef {WellKnownSpaces &
+ *   PromiseSpaceOf<
+ *     ChainBootstrapSpaceT & {
+ *       vatAdminSvc: VatAdminSvc;
+ *     },
+ *     {},
+ *     {
+ *       loadVat: VatLoader<unknown>;
+ *       loadCriticalVat: VatLoader<unknown>;
+ *     }
+ *   >} BootstrapSpace
+ *
+ * @typedef {{ mint: ERef<Mint>; issuer: ERef<Issuer>; brand: Brand }} RemoteIssuerKit
+ *
+ * @typedef {Awaited<ReturnType<Awaited<BankVat>['makeBankManager']>>} BankManager
+ *
+ * @typedef {ERef<ReturnType<import('../vat-agoricNames').buildRootObject>>} AgoricNamesVat
+ *
+ * @typedef {ERef<ReturnType<import('../vat-bank.js').buildRootObject>>} BankVat
+ *
+ * @typedef {ERef<ReturnType<import('../vat-board.js').buildRootObject>>} BoardVat
+ *
+ * @typedef {ERef<ReturnType<import('../vat-bridge.js').buildRootObject>>} ChainStorageVat
+ *
+ * @typedef {ERef<
+ *   ReturnType<import('../vat-provisioning.js').buildRootObject>
+ * >} ProvisioningVat
+ *
+ * @typedef {ERef<ReturnType<import('../vat-mints.js').buildRootObject>>} MintsVat
+ *
+ * @typedef {ERef<
+ *   ReturnType<import('../vat-priceAuthority.js').buildRootObject>
+ * >} PriceAuthorityVat
+ *
+ * @typedef {ERef<ReturnType<import('../vat-network.js').buildRootObject>>} NetworkVat
+ *
+ * @typedef {ERef<ReturnType<import('../vat-ibc.js').buildRootObject>>} IBCVat
+ *
+ * @typedef {import('@agoric/zoe/tools/priceAuthorityRegistry').PriceAuthorityRegistryAdmin} PriceAuthorityRegistryAdmin
+ *
+ * @typedef {{
+ *   namedVat: PromiseSpaceOf<{
+ *     agoricNames: Awaited<AgoricNamesVat>;
+ *     board: Awaited<BoardVat>;
+ *   }>;
+ * }} NamedVatPowers
  */
 
 /**
  * @typedef {PromiseSpaceOf<{
- *   mints: MintsVat
+ *   mints: MintsVat;
  * }>} DemoFaucetPowers
  */
 
 /**
  * @typedef {{
- *   spawner: SpawnerVat,
- *   http: HttpVat,
- *   network: NetworkVat,
- *   uploads: UploadsVat,
- *   bootstrap: unknown
+ *   spawner: SpawnerVat;
+ *   http: HttpVat;
+ *   network: NetworkVat;
+ *   uploads: UploadsVat;
+ *   bootstrap: unknown;
  * }} SoloVats
- * @typedef {ERef<ReturnType<import('@agoric/solo/src/vat-spawner.js').buildRootObject>>} SpawnerVat
- * @typedef {ERef<ReturnType<import('@agoric/solo/src/vat-http.js').buildRootObject>>} HttpVat
- * @typedef {ERef<ReturnType<import('@agoric/solo/src/vat-uploads.js').buildRootObject>>} UploadsVat
+ *
+ * @typedef {ERef<
+ *   ReturnType<import('@agoric/solo/src/vat-spawner.js').buildRootObject>
+ * >} SpawnerVat
+ *
+ * @typedef {ERef<
+ *   ReturnType<import('@agoric/solo/src/vat-http.js').buildRootObject>
+ * >} HttpVat
+ *
+ * @typedef {ERef<
+ *   ReturnType<import('@agoric/solo/src/vat-uploads.js').buildRootObject>
+ * >} UploadsVat
  */
 
-/** @template T @typedef  {{vatPowers: { D: DProxy }, devices: T}} BootDevices<T>  */
+/** @template T @typedef {{vatPowers: { D: DProxy }, devices: T}} BootDevices<T> */

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -14,7 +14,9 @@ const { Fail, quote: q } = assert;
 /**
  * We reserve these keys in name hubs.
  *
- * @type {{ [P in keyof WellKnownName]: { [P2 in WellKnownName[P]]: string } }}
+ * @type {{
+ *   [P in keyof WellKnownName]: { [P2 in WellKnownName[P]]: string };
+ * }}
  */
 export const agoricNamesReserved = harden({
   issuer: {
@@ -74,7 +76,7 @@ export const agoricNamesReserved = harden({
   },
 });
 
-/** @type { FeeIssuerConfig } */
+/** @type {FeeIssuerConfig} */
 export const feeIssuerConfig = {
   name: Stable.symbol,
   assetKind: Stable.assetKind,
@@ -85,7 +87,7 @@ export const feeIssuerConfig = {
  * Wire up a remote between the comms vat and vattp.
  *
  * @param {string} addr
- * @param {{ vats: { vattp: VattpVat, comms: CommsVatRoot }}} powers
+ * @param {{ vats: { vattp: VattpVat; comms: CommsVatRoot } }} powers
  */
 export const addRemote = async (addr, { vats: { comms, vattp } }) => {
   const { transmitter, setReceiver } = await E(vattp).addRemote(addr);
@@ -94,17 +96,19 @@ export const addRemote = async (addr, { vats: { comms, vattp } }) => {
 harden(addRemote);
 
 /**
- * @param {Array<(...args) => Record<string, unknown>>} builders
- * @param  {...unknown} args
+ * @param {((...args) => Record<string, unknown>)[]} builders
+ * @param {...unknown} args
  * @returns {Record<string, unknown>}
  */
 export const callProperties = (builders, ...args) =>
   fromEntries(builders.map(fn => entries(fn(...args))).flat());
 
 /**
- * Attenuate `specimen` to only allow acccess to properties specified in `template`
+ * Attenuate `specimen` to only allow acccess to properties specified in
+ * `template`
  *
- * @param {true | string | Record<string, *>} template true or vat name string or recursive object
+ * @param {true | string | Record<string, any>} template true or vat name string
+ *   or recursive object
  * @param {unknown} specimen
  * @param {string[]} [path]
  */
@@ -143,7 +147,8 @@ export const extract = (template, specimen, path = []) => {
 harden(extract);
 
 /**
- * @param {true | string | Record<string, *>} permit the permit supplied by the manifest
+ * @param {true | string | Record<string, any>} permit the permit supplied by
+ *   the manifest
  * @param {unknown} allPowers the powers to attenuate
  */
 export const extractPowers = (permit, allPowers) => {
@@ -164,7 +169,7 @@ harden(extractPowers);
  * @param {unknown} opts.allPowers
  * @param {Record<string, unknown>} opts.behaviors
  * @param {Record<string, Record<string, unknown>>} opts.manifest
- * @param { (name: string, permit: Record<string, unknown>) => unknown} opts.makeConfig
+ * @param {(name: string, permit: Record<string, unknown>) => unknown} opts.makeConfig
  */
 export const runModuleBehaviors = ({
   allPowers,
@@ -194,7 +199,6 @@ harden(runModuleBehaviors);
 const noop = harden(() => {});
 
 /**
- *
  * @param {ERef<import('../types').NameAdmin>} nameAdmin
  * @param {typeof console.log} [log]
  */
@@ -241,7 +245,7 @@ export const makeWellKnownSpaces = async (
     }),
   );
   const spaces = Object.fromEntries(spaceEntries);
-  const typedSpaces = /** @type { WellKnownSpaces } */ (
+  const typedSpaces = /** @type {WellKnownSpaces} */ (
     /** @type {any} */ (spaces)
   );
   return typedSpaces;
@@ -249,23 +253,20 @@ export const makeWellKnownSpaces = async (
 
 /**
  * Make the well-known agoricNames namespace so that we can
- * E(home.agoricNames).lookup('issuer', 'IST') and likewise
- * for brand, installation, instance, etc.
- *
- * @param {typeof console.log} [log]
- * @param {Record<string, Record<string, unknown>>} reserved a property
- *   for each of issuer, brand, etc. with a value whose keys are names
- *   to reserve.
- *
- * For static typing and integrating with the bootstrap permit system,
- * return { produce, consume } spaces rather than NameAdmins.
+ * E(home.agoricNames).lookup('issuer', 'IST') and likewise for brand,
+ * installation, instance, etc.
  *
  * @deprecated use vat-agoricNames, makeWellKnownSpaces
+ * @param {typeof console.log} [log]
+ * @param {Record<string, Record<string, unknown>>} reserved a property for each
+ *   of issuer, brand, etc. with a value whose keys are names to reserve.
  *
+ *   For static typing and integrating with the bootstrap permit system, return {
+ *   produce, consume } spaces rather than NameAdmins.
  * @returns {Promise<{
- *   agoricNames: import('../types.js').NameHub,
- *   agoricNamesAdmin: import('../types.js').NameAdmin,
- *   spaces: WellKnownSpaces,
+ *   agoricNames: import('../types.js').NameHub;
+ *   agoricNamesAdmin: import('../types.js').NameAdmin;
+ *   spaces: WellKnownSpaces;
  * }>}
  */
 export const makeAgoricNamesAccess = async (
@@ -280,7 +281,7 @@ export const makeAgoricNamesAccess = async (
     Object.keys(reserved),
   );
 
-  const typedSpaces = /** @type { WellKnownSpaces } */ (
+  const typedSpaces = /** @type {WellKnownSpaces} */ (
     /** @type {any} */ (spaces)
   );
   return {
@@ -291,9 +292,8 @@ export const makeAgoricNamesAccess = async (
 };
 
 /**
- * @param {string} address
- *
  * @deprecated use nameAdmin.provideChild() instead
+ * @param {string} address
  */
 export const makeMyAddressNameAdminKit = address => {
   // Create a name hub for this address.
@@ -317,7 +317,9 @@ export const makeMyAddressNameAdminKit = address => {
  * @param {(...args: any) => void} [log]
  * @param {string} [label]
  *
- * @typedef {import('@agoric/swingset-vat').CreateVatResults} CreateVatResults as from createVatByName
+ * @typedef {import('@agoric/swingset-vat').CreateVatResults} CreateVatResults
+ *   as from createVatByName
+ *
  * @typedef {MapStore<string, CreateVatResults>} VatStore
  */
 export const makeVatSpace = (

--- a/packages/vats/src/crc.js
+++ b/packages/vats/src/crc.js
@@ -9,15 +9,11 @@
 // @ts-check
 /* eslint-disable no-bitwise */
 
-/**
- * @typedef {string | number | Uint8Array | ArrayBuffer} Data
- */
+/** @typedef {string | number | Uint8Array | ArrayBuffer} Data */
 
 const encoder = new TextEncoder();
 
-/**
- * @param {Data} data
- */
+/** @param {Data} data */
 function convert(data) {
   if (typeof data === 'number') {
     const bytes = [];
@@ -77,9 +73,7 @@ export class CRC {
     this.table = table;
 
     if (this.width === 8 && !this.xorIn && !this.xorOut && !this.reflect) {
-      /**
-       * @param {Data} data
-       */
+      /** @param {Data} data */
       this.calculate = function calculate(data) {
         const buffer = convert(data);
         let crc = 0;
@@ -91,9 +85,7 @@ export class CRC {
     }
   }
 
-  /**
-   * @param {Data} data
-   */
+  /** @param {Data} data */
   calculate(data) {
     const buffer = convert(data);
     let crc;
@@ -118,9 +110,7 @@ export class CRC {
     return crc >>> 0;
   }
 
-  /**
-   * @param {Data} data
-   */
+  /** @param {Data} data */
   calculateNoTable(data) {
     const buffer = convert(data);
     let crc = this.xorIn;

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -21,13 +21,13 @@ const DEFAULT_ACKNOWLEDGEMENT = '\x00';
 // Default timeout after 10 minutes.
 const DEFAULT_PACKET_TIMEOUT_NS = 10n * 60n * 1_000_000_000n;
 
-/**
- * @typedef {import('./types.js').BridgeHandler} BridgeHandler
- */
+/** @typedef {import('./types.js').BridgeHandler} BridgeHandler */
 
 /**
  * @typedef {string} IBCPortID
+ *
  * @typedef {string} IBCChannelID
+ *
  * @typedef {string} IBCConnectionID
  */
 
@@ -41,8 +41,8 @@ const DEFAULT_PACKET_TIMEOUT_NS = 10n * 60n * 1_000_000_000n;
  */
 
 /**
- * Create a handler for the IBC protocol, both from the network
- * and from the bridge.
+ * Create a handler for the IBC protocol, both from the network and from the
+ * bridge.
  *
  * @param {typeof import('@endo/far').E} E
  * @param {(method: string, params: any) => Promise<any>} rawCallIBCDevice
@@ -56,9 +56,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
     console.info('IBC downcall', method, params);
     return rawCallIBCDevice(method, params);
   };
-  /**
-   * @type {MapStore<string, Promise<Connection>>}
-   */
+  /** @type {MapStore<string, Promise<Connection>>} */
   const channelKeyToConnP = makeScalarMapStore('CHANNEL:PORT');
 
   /**
@@ -67,7 +65,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
    * @property {string} channel_id
    *
    * @typedef {object} ConnectingInfo
-   * @property {'ORDERED'|'UNORDERED'} order
+   * @property {'ORDERED' | 'UNORDERED'} order
    * @property {string[]} connectionHops
    * @property {string} portID
    * @property {string} channelID
@@ -75,31 +73,25 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
    * @property {string} version
    *
    * @typedef {PromiseRecord<AttemptDescription>} OnConnectP
+   *
    * @typedef {Omit<ConnectingInfo, 'counterparty' | 'channelID'> & {
-   *   localAddr: Endpoint, onConnectP: OnConnectP
-   *   counterparty: { port_id: string },
+   *   localAddr: Endpoint;
+   *   onConnectP: OnConnectP;
+   *   counterparty: { port_id: string };
    * }} Outbound
    */
 
-  /**
-   * @type {LegacyMap<string, Array<Outbound>>}
-   */
+  /** @type {LegacyMap<string, Outbound[]>} */
   // Legacy because it holds a mutable Javascript Array
   const srcPortToOutbounds = makeLegacyMap('SRC-PORT');
 
-  /**
-   * @type {MapStore<string, ConnectingInfo>}
-   */
+  /** @type {MapStore<string, ConnectingInfo>} */
   const channelKeyToInfo = makeScalarMapStore('CHANNEL:PORT');
 
-  /**
-   * @type {MapStore<string, Promise<InboundAttempt>>}
-   */
+  /** @type {MapStore<string, Promise<InboundAttempt>>} */
   const channelKeyToAttemptP = makeScalarMapStore('CHANNEL:PORT');
 
-  /**
-   * @type {LegacyMap<string, LegacyMap<number, PromiseRecord<Bytes>>>}
-   */
+  /** @type {LegacyMap<string, LegacyMap<number, PromiseRecord<Bytes>>>} */
   // Legacy because it holds a LegacyMap
   const channelKeyToSeqAck = makeLegacyMap('CHANNEL:PORT');
 
@@ -124,9 +116,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
     // Extract the actual sequence number from the return.
     const { sequence } = fullPacket;
 
-    /**
-     * @type {PromiseRecord<Bytes>}
-     */
+    /** @type {PromiseRecord<Bytes>} */
     const ackDeferred = makePromiseKit();
 
     // Register the ack resolver/rejector with this sequence number.
@@ -139,7 +129,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
    * @param {string} portID
    * @param {string} rChannelID
    * @param {string} rPortID
-   * @param {'ORDERED'|'UNORDERED'} order
+   * @param {'ORDERED' | 'UNORDERED'} order
    * @returns {ConnectionHandler}
    */
   function makeIBCConnectionHandler(
@@ -213,9 +203,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
     });
   }
 
-  /**
-   * @param {string} localAddr
-   */
+  /** @param {string} localAddr */
   const localAddrToPortID = localAddr => {
     const m = localAddr.match(/^\/ibc-port\/([-a-zA-Z0-9._+#[\]<>]+)$/);
     if (!m) {
@@ -226,29 +214,23 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
     return m[1];
   };
 
-  /**
-   * @type {ProtocolImpl}
-   */
+  /** @type {ProtocolImpl} */
   let protocolImpl;
 
   /**
    * @typedef {object} OutboundCircuitRecord
    * @property {IBCConnectionID} dst
-   * @property {'ORDERED'|'UNORDERED'} order
+   * @property {'ORDERED' | 'UNORDERED'} order
    * @property {string} version
    * @property {IBCPacket} packet
    * @property {PromiseRecord<ConnectionHandler>} deferredHandler
    */
 
-  /**
-   * @type {LegacyMap<Port, Set<PromiseRecord<ConnectionHandler>>>}
-   */
+  /** @type {LegacyMap<Port, Set<PromiseRecord<ConnectionHandler>>>} */
   // Legacy because it holds a raw JavaScript Set
   const portToPendingConns = makeLegacyMap('Port');
 
-  /**
-   * @type {ProtocolHandler}
-   */
+  /** @type {ProtocolHandler} */
   const protocol = Far('IBCProtocolHandler', {
     async onCreate(impl, _protocolHandler) {
       console.debug('IBC onCreate');

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -1,7 +1,6 @@
 // @ts-check
 /**
  * @file lib-board: share objects by way of plain-data ids
- *
  * @see prepareBoardKit()
  */
 
@@ -48,11 +47,11 @@ const BoardKitIKit = {
 //#endregion
 
 /**
- * For a value with a known id in the board, we can use
- * that board id as a slot to preserve identity when marshaling.
+ * For a value with a known id in the board, we can use that board id as a slot
+ * to preserve identity when marshaling.
  *
  * The contents of the string depend on the `prefix` and `crcDigits` options:
- *    \`${prefix}${crc}${seq}\`
+ * `${prefix}${crc}${seq}`
  *
  * For example, 'board0371' for prefix: 'board0', seq: 1, 2 digits crc.
  *
@@ -75,14 +74,11 @@ const calcCrc = (data, crcDigits) => {
 };
 
 /**
+ * @typedef {ReturnType<typeof initDurableBoardState>} BoardState // TODO: use
+ *   Key from @agoric/store when available
  * @see {prepareExoClassKit}
- * @see {@link ../../SwingSet/docs/virtual-objects.md|SwingSet Virtual Objects}
+ * @see {@link ../../SwingSet/docs/virtual-objects.md|SwingSet Virtual Objects} Hoisting this function makes defining the state type concise.
  *
- * Hoisting this function makes defining the state type concise.
- * @typedef {ReturnType<typeof initDurableBoardState>} BoardState
- *
- *
- * // TODO: use Key from @agoric/store when available
  * @typedef {import('@endo/marshal').Passable} Key
  */
 
@@ -93,7 +89,8 @@ const calcCrc = (data, crcDigits) => {
  * @param {bigint | number} [initSequence]
  * @param {object} [options]
  * @param {string} [options.prefix] prefix for all ids generated
- * @param {number} [options.crcDigits] count of digits to use in CRC at end of the id
+ * @param {number} [options.crcDigits] count of digits to use in CRC at end of
+ *   the id
  */
 const initDurableBoardState = (
   initSequence = 0,
@@ -180,9 +177,7 @@ const getValue = (id, { prefix, crcDigits, idToVal }) => {
   throw Fail`board does not have id: ${id}`;
 };
 
-/**
- * @param {BoardState} state
- */
+/** @param {BoardState} state */
 const makeSlotToVal = state => {
   const ifaceAllegedPrefix = 'Alleged: ';
   const ifaceInaccessiblePrefix = 'SEVERED: ';
@@ -243,9 +238,9 @@ const makePublishingMarshaller = state => {
 //#endregion
 
 /**
- * A board is a two-way mapping between objects (such as issuers,
- * brands, installation handles) and plain-data string IDs.
- * A well-known board allows sharing objects by way of their ids.
+ * A board is a two-way mapping between objects (such as issuers, brands,
+ * installation handles) and plain-data string IDs. A well-known board allows
+ * sharing objects by way of their ids.
  *
  * @param {import('@agoric/vat-data').Baggage} baggage for upgrade successors
  * @see {@link packages/SwingSet/docs/vat-upgrade.md|Vat Upgrade}
@@ -261,13 +256,13 @@ export const prepareBoardKit = baggage => {
         /**
          * Provide an ID for a value, generating one if not already present.
          *
-         * Each board ID includes a CRC so that the last part is well-distributed,
-         * which mitigates typo risks.
+         * Each board ID includes a CRC so that the last part is
+         * well-distributed, which mitigates typo risks.
          *
-         * Scaling Consideration: since we cannot know when consumers
-         * are no longer interested in an ID, a board holds a strong reference
-         * to `value` for its entire lifetime. For a well-known board, this
-         * is essentially forever.
+         * Scaling Consideration: since we cannot know when consumers are no
+         * longer interested in an ID, a board holds a strong reference to
+         * `value` for its entire lifetime. For a well-known board, this is
+         * essentially forever.
          *
          * @param {Key} value
          * @throws if `value` is not a Key in the @agoric/store sense
@@ -283,14 +278,14 @@ export const prepareBoardKit = baggage => {
           return getValue(id, this.state);
         },
         /**
-         * Convenience method for recursively traversing boards and
-         * board-like remotables to get data associated with a sequence of ids
-         * corresponding to each successive board.
-         * For example, `lookup("foo", "bar")` gets the value associated with
-         * id "foo" and returns the result of invoking `lookup("bar")` upon it
-         * to get the value it associates with id "bar".
+         * Convenience method for recursively traversing boards and board-like
+         * remotables to get data associated with a sequence of ids
+         * corresponding to each successive board. For example, `lookup("foo",
+         * "bar")` gets the value associated with id "foo" and returns the
+         * result of invoking `lookup("bar")` upon it to get the value it
+         * associates with id "bar".
          *
-         * @param  {...string} path
+         * @param {...string} path
          */
         async lookup(...path) {
           const {
@@ -316,19 +311,19 @@ export const prepareBoardKit = baggage => {
           return harden([...state.idToVal.keys()]);
         },
         /**
-         * Get a marshaller that implements the convertValToSlot hook using getId(),
-         * "publishing" previously un-mapped objects.
+         * Get a marshaller that implements the convertValToSlot hook using
+         * getId(), "publishing" previously un-mapped objects.
          */
         getPublishingMarshaller() {
           return this.facets.publishingMarshaller;
         },
         /**
-         * Get a marshaller that implements the convertValToSlot hook using getId(),
-         * only for objects that the board has().
+         * Get a marshaller that implements the convertValToSlot hook using
+         * getId(), only for objects that the board has().
          *
          * For other objects, we don't throw, but we emit a null slot.
-         * Un-serializing a null slot always produces a fresh object
-         * rather than preserving object identity.
+         * Un-serializing a null slot always produces a fresh object rather than
+         * preserving object identity.
          */
         getReadonlyMarshaller() {
           return this.facets.readonlyMarshaller;
@@ -370,9 +365,7 @@ export const prepareBoardKit = baggage => {
   );
 };
 
-/**
- * @param {import('@agoric/zone').Zone} zone
- */
+/** @param {import('@agoric/zone').Zone} zone */
 export const prepareRecorderFactory = zone => {
   const baggage = zone.mapStore(`Recorder Baggage`);
   const makeDurablePublishKit = prepareDurablePublishKit(

--- a/packages/vats/src/mintHolder.js
+++ b/packages/vats/src/mintHolder.js
@@ -12,9 +12,9 @@ import {
 /**
  * @template {AssetKind} K
  * @typedef {{
- *   keyword: string,
- *   assetKind: K,
- *   displayInfo: DisplayInfo,
+ *   keyword: string;
+ *   assetKind: K;
+ *   displayInfo: DisplayInfo;
  * }} IssuerInfo<K>
  */
 
@@ -33,9 +33,8 @@ function provideIssuerKit(zcf, baggage) {
 }
 
 /**
- * This contract holds one mint; it basically wraps
- * makeIssuerKit in its own contract, and hence in
- * its own vat.
+ * This contract holds one mint; it basically wraps makeIssuerKit in its own
+ * contract, and hence in its own vat.
  *
  * @template {AssetKind} K
  * @param {ZCF<IssuerInfo<K>>} zcf

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -51,7 +51,11 @@ export const prepareMixinMyAddress = zone => {
     ...NameHubIKit.nameAdmin.methodGuards,
     getMyAddress: M.call().returns(M.string()),
   });
-  /** @type {import('@agoric/internal/src/callback.js').MakeAttenuator<import('./types.js').MyAddressNameAdmin>} */
+  /**
+   * @type {import('@agoric/internal/src/callback.js').MakeAttenuator<
+   *   import('./types.js').MyAddressNameAdmin
+   * >}
+   */
   const mixin = prepareGuardedAttenuator(zone, MixinI, {
     tag: 'MyAddressNameAdmin',
   });
@@ -122,8 +126,8 @@ const updated = (updateCallback, hub, _newValue = undefined) => {
 };
 
 /**
- * Make two facets of a node in a name hierarchy: the nameHub
- * is read access and the nameAdmin is write access.
+ * Make two facets of a node in a name hierarchy: the nameHub is read access and
+ * the nameAdmin is write access.
  *
  * @param {import('@agoric/zone').Zone} zone
  */
@@ -139,7 +143,7 @@ export const prepareNameHubKit = zone => {
   /** @param {{}} me */
   const my = me => provideWeak(ephemera, me, init1);
 
-  /** @type {() => import('./types').NameHubKit } */
+  /** @type {() => import('./types').NameHubKit} */
   const makeNameHubKit = zone.exoClassKit(
     'NameHubKit',
     NameHubIKit,
@@ -283,7 +287,13 @@ export const prepareNameHubKit = zone => {
           const { keyToPK, keyToAdminPK } = my(this.facets.nameHub);
           const { keyToValue, keyToAdmin, updateCallback } = this.state;
 
-          /** @type {[Map<string, PromiseKit<unknown>>, MapStore<string, unknown>, unknown][]} */
+          /**
+           * @type {[
+           *   Map<string, PromiseKit<unknown>>,
+           *   MapStore<string, unknown>,
+           *   unknown,
+           * ][]}
+           */
           const valueMapEntries = [
             [keyToAdminPK, keyToAdmin, adminValue],
             [keyToPK, keyToValue, newValue],
@@ -354,8 +364,8 @@ export const prepareNameHubKit = zone => {
 };
 
 /**
- * Make two facets of a node in a name hierarchy: the nameHub
- * is read access and the nameAdmin is write access.
+ * Make two facets of a node in a name hierarchy: the nameHub is read access and
+ * the nameAdmin is write access.
  *
  * @returns {import('./types.js').NameHubKit}
  */

--- a/packages/vats/src/proposals/network-proposal.js
+++ b/packages/vats/src/proposals/network-proposal.js
@@ -73,18 +73,21 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
 };
 
 /**
- * @param { BootstrapPowers & {
- *   consume: { loadCriticalVat: VatLoader<any> }
- *   produce: { networkVat: Producer<any> }
+ * @param {BootstrapPowers & {
+ *   consume: { loadCriticalVat: VatLoader<any> };
+ *   produce: { networkVat: Producer<any> };
  * }} powers
- *
  * @param {object} options
- * @param {{networkRef: VatSourceRef, ibcRef: VatSourceRef}} options.options
- * // TODO: why doesn't overloading VatLoader work???
- * @typedef { ((name: 'network') => NetworkVat) &
- *            ((name: 'ibc') => IBCVat) } VatLoader2
+ * @param {{ networkRef: VatSourceRef; ibcRef: VatSourceRef }} options.options
+ *   // TODO: why doesn't overloading VatLoader work???
  *
- * @typedef {{ network: ERef<NetworkVat>, ibc: ERef<IBCVat>, provisioning: ERef<ProvisioningVat | undefined>}} NetVats
+ * @typedef {((name: 'network') => NetworkVat) & ((name: 'ibc') => IBCVat)} VatLoader2
+ *
+ * @typedef {{
+ *   network: ERef<NetworkVat>;
+ *   ibc: ERef<IBCVat>;
+ *   provisioning: ERef<ProvisioningVat | undefined>;
+ * }} NetVats
  */
 export const setupNetworkProtocols = async (
   {
@@ -99,7 +102,7 @@ export const setupNetworkProtocols = async (
   options,
 ) => {
   const { networkRef, ibcRef } = options.options;
-  /** @type { NetVats } */
+  /** @type {NetVats} */
   const vats = {
     network: E(loadCriticalVat)('network', networkRef),
     ibc: E(loadCriticalVat)('ibc', ibcRef),

--- a/packages/vats/src/proposals/restart-vats-proposal.js
+++ b/packages/vats/src/proposals/restart-vats-proposal.js
@@ -24,9 +24,10 @@ const vatUpgradeStatus = {
 };
 
 /**
- * @param {BootstrapPowers & import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace} space
+ * @param {BootstrapPowers &
+ *   import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace} space
  * @param {object} config
- * @param {{ skip: Array<string>}} config.options
+ * @param {{ skip: string[] }} config.options
  */
 export const restartVats = async ({ consume }, { options }) => {
   console.log(HR);
@@ -52,7 +53,6 @@ export const restartVats = async ({ consume }, { options }) => {
 
   const failures = [];
   /**
-   *
    * @param {string} debugName
    * @param {Instance} instance
    * @param {ERef<AdminFacet>} adminFacet

--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -28,19 +28,18 @@ export const privateArgsShape = M.splitRecord(
 );
 
 /**
- * @typedef {StandardTerms & GovernanceTerms<{
- *    PerAccountInitialAmount: 'amount',
+ * @typedef {StandardTerms &
+ *   GovernanceTerms<{
+ *     PerAccountInitialAmount: 'amount';
  *   }>} ProvisionTerms
- *
- * TODO: ERef<GovernedCreatorFacet<ProvisionCreator>>
- *
+ *   TODO: ERef<GovernedCreatorFacet<ProvisionCreator>>
  * @param {ZCF<ProvisionTerms>} zcf
  * @param {{
- *   poolBank: import('@endo/far').ERef<import('./vat-bank.js').Bank>,
- *   initialPoserInvitation: Invitation,
- *   storageNode: StorageNode,
- *   marshaller: Marshaller,
- *   metricsOverride?: import('./provisionPoolKit').MetricsNotification,
+ *   poolBank: import('@endo/far').ERef<import('./vat-bank.js').Bank>;
+ *   initialPoserInvitation: Invitation;
+ *   storageNode: StorageNode;
+ *   marshaller: Marshaller;
+ *   metricsOverride?: import('./provisionPoolKit').MetricsNotification;
  * }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */

--- a/packages/vats/src/provisionPoolKit.js
+++ b/packages/vats/src/provisionPoolKit.js
@@ -23,38 +23,42 @@ import { PowerFlags } from './walletFlags.js';
 
 const { details: X, quote: q, Fail } = assert;
 
-/** @typedef {import('@agoric/zoe/src/zoeService/utils').Instance<import('@agoric/inter-protocol/src/psm/psm.js').prepare>} PsmInstance */
+/**
+ * @typedef {import('@agoric/zoe/src/zoeService/utils').Instance<
+ *   import('@agoric/inter-protocol/src/psm/psm.js').prepare
+ * >} PsmInstance
+ */
 
 /**
  * @typedef {object} ProvisionPoolKitReferences
  * @property {ERef<BankManager>} bankManager
  * @property {ERef<import('@agoric/vats').NameAdmin>} namesByAddressAdmin
- * @property {ERef<import('@agoric/vats/src/core/startWalletFactory').WalletFactoryStartResult['creatorFacet']>} walletFactory
+ * @property {ERef<
+ *   import('@agoric/vats/src/core/startWalletFactory').WalletFactoryStartResult['creatorFacet']
+ * >} walletFactory
  */
 
 /**
- * @typedef {object} MetricsNotification
- * Metrics naming scheme is that nouns are present values and past-participles
- * are accumulative.
- *
- * @property {bigint} walletsProvisioned  count of new wallets provisioned
- * @property {Amount<'nat'>} totalMintedProvided  running sum of Minted provided to new wallets
- * @property {Amount<'nat'>} totalMintedConverted  running sum of Minted
- * ever received by the contract from PSM
+ * @typedef {object} MetricsNotification Metrics naming scheme is that nouns are
+ *   present values and past-participles are accumulative.
+ * @property {bigint} walletsProvisioned count of new wallets provisioned
+ * @property {Amount<'nat'>} totalMintedProvided running sum of Minted provided
+ *   to new wallets
+ * @property {Amount<'nat'>} totalMintedConverted running sum of Minted ever
+ *   received by the contract from PSM
  */
 
 /**
- * Given attenuated access to the funding purse,
- * handle requests to provision smart wallets.
+ * Given attenuated access to the funding purse, handle requests to provision
+ * smart wallets.
  *
  * @param {(depositBank: ERef<Bank>) => Promise<void>} sendInitialPayment
  * @param {() => void} onProvisioned
+ *
  * @typedef {import('./vat-bank.js').Bank} Bank
  */
 export const makeBridgeProvisionTool = (sendInitialPayment, onProvisioned) => {
-  /**
-   * @param {ProvisionPoolKitReferences} refs
-   */
+  /** @param {ProvisionPoolKitReferences} refs */
   const makeBridgeHandler = ({
     bankManager,
     namesByAddressAdmin,
@@ -90,10 +94,10 @@ export const makeBridgeProvisionTool = (sendInitialPayment, onProvisioned) => {
 /**
  * @param {import('@agoric/vat-data').Baggage} baggage
  * @param {{
- *   makeRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit,
- *   params: *,
- *   poolBank: import('@endo/far').ERef<Bank>,
- *   zcf: ZCF,
+ *   makeRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit;
+ *   params: any;
+ *   poolBank: import('@endo/far').ERef<Bank>;
+ *   zcf: ZCF;
  * }} powers
  */
 export const prepareProvisionPoolKit = (
@@ -173,9 +177,7 @@ export const prepareProvisionPoolKit = (
     {
       // aka "limitedCreatorFacet"
       machine: {
-        /**
-         * @param {string[]} oldAddresses
-         */
+        /** @param {string[]} oldAddresses */
         addRevivableAddresses(oldAddresses) {
           console.log('revivableAddresses count', oldAddresses.length);
           this.state.revivableAddresses.addAll(oldAddresses);
@@ -183,9 +185,7 @@ export const prepareProvisionPoolKit = (
         getWalletReviver() {
           return this.facets.walletReviver;
         },
-        /**
-         * @param {ProvisionPoolKitReferences} erefs
-         */
+        /** @param {ProvisionPoolKitReferences} erefs */
         async setReferences(erefs) {
           const { bankManager, namesByAddressAdmin, walletFactory } = erefs;
           const obj = harden({
@@ -295,10 +295,7 @@ export const prepareProvisionPoolKit = (
           state.walletsProvisioned += 1n;
           facets.helper.publishMetrics();
         },
-        /**
-         *
-         * @param {ERef<Bank>} destBank
-         */
+        /** @param {ERef<Bank>} destBank */
         async sendInitialPayment(destBank) {
           const {
             facets: { helper },

--- a/packages/vats/src/repl.js
+++ b/packages/vats/src/repl.js
@@ -74,7 +74,7 @@ function dump0(value, spaces, inProgress, depth) {
 
     let sep = '';
     let closer;
-    /** @type {Array<string | symbol>} */
+    /** @type {(string | symbol)[]} */
     const names = Object.getOwnPropertyNames(value);
     const nonNumber = new Set(names);
     if (Array.isArray(value)) {

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -8,54 +8,51 @@ export {};
  */
 
 /**
- * @typedef {ReturnType<ReturnType<typeof import('./lib-board.js').prepareBoardKit>>['board']} Board
+ * @typedef {ReturnType<
+ *   ReturnType<typeof import('./lib-board.js').prepareBoardKit>
+ * >['board']} Board
  */
 
 /**
  * @typedef {object} NameHub read-only access to a node in a name hierarchy
  *
- * NOTE: We need to return arrays, not iterables, because even if marshal could
- * allow passing a remote iterable, there would be an inordinate number of round
- * trips for the contents of even the simplest nameHub.
- *
+ *   NOTE: We need to return arrays, not iterables, because even if marshal could
+ *   allow passing a remote iterable, there would be an inordinate number of
+ *   round trips for the contents of even the simplest nameHub.
  * @property {(key: string) => boolean} has
- * @property {(...path: Array<string>) => Promise<any>} lookup Look up a
- * path of keys starting from the current NameHub.  Wait on any reserved
- * promises.
- * @property {(includeReserved?: boolean) => [string, unknown][]} entries get all the entries
- * available in the current NameHub
- * @property {() => string[]} keys get all names available in the
- * current NameHub
- * @property {() => unknown[]} values get all values available in the
- * current NameHub
+ * @property {(...path: string[]) => Promise<any>} lookup Look up a path of keys
+ *   starting from the current NameHub. Wait on any reserved promises.
+ * @property {(includeReserved?: boolean) => [string, unknown][]} entries get
+ *   all the entries available in the current NameHub
+ * @property {() => string[]} keys get all names available in the current
+ *   NameHub
+ * @property {() => unknown[]} values get all values available in the current
+ *   NameHub
  */
 
 /**
  * @typedef {object} NameAdmin write access to a node in a name hierarchy
- *
  * @property {(key: string, reserved?: string[]) => Promise<NameHubKit>} provideChild
- * @property {(key: string) => Promise<void>} reserve Mark a key as reserved; will
- * return a promise that is fulfilled when the key is updated (or rejected when
- * deleted). If the key was already set it does nothing.
- * @property {<T>( key: string, newValue: T, newAdmin?: NameAdmin) =>
- *   T } default Update if not already updated.  Return
- *   existing value, or newValue if not existing.
- * @property {(
- *   key: string, newValue: unknown, newAdmin?: NameAdmin) => void
- * } set Update only if already initialized. Reject if not.
- * @property {(
- *   key: string, newValue: unknown, newAdmin?: NameAdmin) => void
- * } update Fulfill an outstanding reserved promise (if any) to the newValue and
- * set the key to the newValue.  If newAdmin is provided, set that to return via
- * lookupAdmin.
- * @property {(...path: Array<string>) => Promise<NameAdmin>} lookupAdmin Look up the
- * `newAdmin` from the path of keys starting from the current NameAdmin.  Wait
- * on any reserved promises.
+ * @property {(key: string) => Promise<void>} reserve Mark a key as reserved;
+ *   will return a promise that is fulfilled when the key is updated (or
+ *   rejected when deleted). If the key was already set it does nothing.
+ * @property {<T>(key: string, newValue: T, newAdmin?: NameAdmin) => T} default
+ *   Update if not already updated. Return existing value, or newValue if not
+ *   existing.
+ * @property {(key: string, newValue: unknown, newAdmin?: NameAdmin) => void} set
+ *   Update only if already initialized. Reject if not.
+ * @property {(key: string, newValue: unknown, newAdmin?: NameAdmin) => void} update
+ *   Fulfill an outstanding reserved promise (if any) to the newValue and set the
+ *   key to the newValue. If newAdmin is provided, set that to return via
+ *   lookupAdmin.
+ * @property {(...path: string[]) => Promise<NameAdmin>} lookupAdmin Look up the
+ *   `newAdmin` from the path of keys starting from the current NameAdmin. Wait
+ *   on any reserved promises.
  * @property {(key: string) => void} delete Delete a value and reject an
- * outstanding reserved promise (if any).
+ *   outstanding reserved promise (if any).
  * @property {() => NameHub} readonly get the NameHub corresponding to the
- * current NameAdmin
- * @property {(fn: undefined | (NameHubUpdateHandler)) => void} onUpdate
+ *   current NameAdmin
+ * @property {(fn: undefined | NameHubUpdateHandler) => void} onUpdate
  *
  * @typedef {{ write: (entries: [string, unknown][]) => void }} NameHubUpdateHandler
  */
@@ -66,26 +63,29 @@ export {};
  * @property {NameAdmin} nameAdmin write access
  */
 
-/**
- * @typedef {NameAdmin & { getMyAddress(): string }} MyAddressNameAdmin
- */
+/** @typedef {NameAdmin & { getMyAddress(): string }} MyAddressNameAdmin */
 /**
  * @typedef {NameAdmin & {
- *   provideChild(addr: string, reserved?: string[]): Promise<{
- *     nameHub: NameHub,
- *     nameAdmin: MyAddressNameAdmin,
- *   }>,
- *   lookupAdmin(addr: string): Promise<MyAddressNameAdmin>,
+ *   provideChild(
+ *     addr: string,
+ *     reserved?: string[],
+ *   ): Promise<{
+ *     nameHub: NameHub;
+ *     nameAdmin: MyAddressNameAdmin;
+ *   }>;
+ *   lookupAdmin(addr: string): Promise<MyAddressNameAdmin>;
  * }} NamesByAddressAdmin
  */
 
 /**
- * @typedef {object} BridgeHandler An object that can receive messages from the bridge device
+ * @typedef {object} BridgeHandler An object that can receive messages from the
+ *   bridge device
  * @property {(obj: any) => Promise<void>} fromBridge Handle an inbound message
  */
 
 /**
- * @typedef {object} ScopedBridgeManager An object which handles messages for a specific bridge
+ * @typedef {object} ScopedBridgeManager An object which handles messages for a
+ *   specific bridge
  * @property {(obj: any) => Promise<any>} toBridge
  * @property {(obj: any) => Promise<void>} fromBridge
  * @property {(handler: ERef<BridgeHandler>) => void} initHandler
@@ -94,5 +94,8 @@ export {};
 
 /**
  * @typedef {object} BridgeManager The object to manage this bridge
- * @property {(bridgeId: string, handler?: ERef<BridgeHandler | undefined>) => ScopedBridgeManager} register
+ * @property {(
+ *   bridgeId: string,
+ *   handler?: ERef<BridgeHandler | undefined>,
+ * ) => ScopedBridgeManager} register
  */

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -32,6 +32,7 @@ const BridgeChannelI = M.interface('BridgeChannel', {
 
 /**
  * @typedef {import('./virtual-purse').VirtualPurseController} VirtualPurseController
+ *
  * @typedef {Awaited<ReturnType<ReturnType<typeof prepareVirtualPurse>>>} VirtualPurse
  */
 
@@ -44,10 +45,14 @@ const BalanceUpdaterI = M.interface('BalanceUpdater', {
   update: M.call(M.string()).optional(M.string()).returns(),
 });
 
-/** @typedef {Pick<import('./types.js').ScopedBridgeManager, 'fromBridge' | 'toBridge'>} BridgeChannel */
+/**
+ * @typedef {Pick<
+ *   import('./types.js').ScopedBridgeManager,
+ *   'fromBridge' | 'toBridge'
+ * >} BridgeChannel
+ */
 
 /**
- *
  * @param {import('@agoric/zone').Zone} zone
  * @returns {(brand: Brand, publisher: Publisher<Amount>) => BalanceUpdater}
  */
@@ -76,9 +81,7 @@ const prepareBalanceUpdater = zone =>
     },
   );
 
-/**
- * @param {import('@agoric/zone').Zone} zone
- */
+/** @param {import('@agoric/zone').Zone} zone */
 const prepareBankPurseController = zone => {
   /**
    * @param {BridgeChannel} bankBridge
@@ -170,16 +173,12 @@ const prepareRewardPurseController = zone =>
     },
   );
 
-/**
- * @param {import('@agoric/zone').Zone} zone
- */
+/** @param {import('@agoric/zone').Zone} zone */
 const prepareBankChannelHandler = zone =>
   zone.exoClass(
     'BankChannelHandler',
     BridgeHandlerI,
-    /**
-     * @param {MapStore<string, MapStore<string, BalanceUpdater>>} denomToAddressUpdater
-     */
+    /** @param {MapStore<string, MapStore<string, BalanceUpdater>>} denomToAddressUpdater */
     denomToAddressUpdater => ({ denomToAddressUpdater }),
     {
       async fromBridge(obj) {
@@ -221,7 +220,7 @@ const prepareBankChannelHandler = zone =>
  * Concatenate multiple iterables to form a new one.
  *
  * @template T
- * @param {Array<Iterable<T> | AsyncIterable<T>>} iterables
+ * @param {(Iterable<T> | AsyncIterable<T>)[]} iterables
  */
 async function* concatAsyncIterables(iterables) {
   for (const asyncIterable of iterables) {
@@ -273,12 +272,15 @@ const makeHistoricalTopic = (historyValues, futureSubscriber, skipValue) => {
   return makeSubscriberFromAsyncIterable(allHistory, skipValue);
 };
 
-/** @type {WeakMap<MapStore<Brand, AssetDescriptor>, Promise<PublicationRecord<AssetDescriptor>>>} */
+/**
+ * @type {WeakMap<
+ *   MapStore<Brand, AssetDescriptor>,
+ *   Promise<PublicationRecord<AssetDescriptor>>
+ * >}
+ */
 const fullAssetPubLists = new WeakMap();
 
-/**
- * @param {import('@agoric/zone').Zone} zone
- */
+/** @param {import('@agoric/zone').Zone} zone */
 const prepareAssetSubscription = zone => {
   const assetSubscriptionCache = zone.weakMapStore('assetSubscriptionCache');
 
@@ -358,9 +360,7 @@ const AssetIssuerKitShape = M.splitRecord(BaseIssuerKitShape, {
   mint: M.remotable('Mint'),
 });
 
-/**
- * @typedef {AssetIssuerKit & { denom: string, escrowPurse?: ERef<Purse> }} AssetRecord
- */
+/** @typedef {AssetIssuerKit & { denom: string; escrowPurse?: ERef<Purse> }} AssetRecord */
 
 /**
  * @typedef {object} AssetDescriptor
@@ -372,18 +372,18 @@ const AssetIssuerKitShape = M.splitRecord(BaseIssuerKitShape, {
  */
 
 /**
- * @typedef { AssetDescriptor & {
- *   issuer: Issuer<'nat'>, // settled identity
- *   displayInfo: DisplayInfo,
+ * @typedef {AssetDescriptor & {
+ *   issuer: Issuer<'nat'>; // settled identity
+ *   displayInfo: DisplayInfo;
  * }} AssetInfo
  */
 
 /**
  * @typedef {object} Bank
- * @property {() => IterableEachTopic<AssetDescriptor>} getAssetSubscription Returns
- * assets as they are added to the bank
- * @property {(brand: Brand) => Promise<VirtualPurse>} getPurse Find any existing vpurse
- * (keyed by address and brand) or create a new one.
+ * @property {() => IterableEachTopic<AssetDescriptor>} getAssetSubscription
+ *   Returns assets as they are added to the bank
+ * @property {(brand: Brand) => Promise<VirtualPurse>} getPurse Find any
+ *   existing vpurse (keyed by address and brand) or create a new one.
  */
 
 export const BankI = M.interface('Bank', {
@@ -410,7 +410,12 @@ const prepareBank = (
   // we decide to partition the provider and use `brandToVPurse` directly, we'd
   // need ephemera for each `makeBank` call.
   const addressDenomToPurse = zone.mapStore('addressDenomToPurse');
-  /** @type {import('@agoric/store/src/stores/store-utils.js').AtomicProvider<string, VirtualPurse>} */
+  /**
+   * @type {import('@agoric/store/src/stores/store-utils.js').AtomicProvider<
+   *     string,
+   *     VirtualPurse
+   *   >}
+   */
   const purseProvider = makeAtomicProvider(addressDenomToPurse);
 
   const makeBank = zone.exoClass(
@@ -574,12 +579,17 @@ const prepareBankManager = (
       const brandToAssetDescriptor = detachedZone.mapStore(
         'brandToAssetDescriptor',
       );
-      /** @type {MapStore<string, { bank: Bank, brandToVPurse: MapStore<Brand, VirtualPurse> }>} */
+      /**
+       * @type {MapStore<
+       *   string,
+       *   { bank: Bank; brandToVPurse: MapStore<Brand, VirtualPurse> }
+       * >}
+       */
       const addressToBank = detachedZone.mapStore('addressToBank');
 
       /**
        * CAVEAT: The history for the assetSubscriber needs to be loaded into the
-       * heap on first use in this incarnation.  Use provideAssetSubscription to
+       * heap on first use in this incarnation. Use provideAssetSubscription to
        * set that up.
        *
        * @type {PublishKit<AssetDescriptor>}
@@ -637,7 +647,7 @@ const prepareBankManager = (
        *
        * @param {string} moduleName
        * @returns {Promise<string | null>} address of named module account, or
-       * null if unimplemented (no bankChannel)
+       *   null if unimplemented (no bankChannel)
        */
       async getModuleAccountAddress(moduleName) {
         const { bankChannel } = this.state;
@@ -652,16 +662,17 @@ const prepareBankManager = (
       },
 
       /**
-       * Add an asset to the bank, and publish it to the subscriptions.
-       * If nameAdmin is defined, update with denom to AssetInfo entry.
+       * Add an asset to the bank, and publish it to the subscriptions. If
+       * nameAdmin is defined, update with denom to AssetInfo entry.
        *
-       * Note that AssetInfo has the settled identity of the issuer,
-       * not just a promise for it.
+       * Note that AssetInfo has the settled identity of the issuer, not just a
+       * promise for it.
        *
        * @param {string} denom lower-level denomination string
        * @param {string} issuerName
        * @param {string} proposedName
-       * @param {AssetIssuerKit & { payment?: ERef<Payment> }} kit ERTP issuer kit (mint, brand, issuer)
+       * @param {AssetIssuerKit & { payment?: ERef<Payment> }} kit ERTP issuer
+       *   kit (mint, brand, issuer)
        */
       async addAsset(denom, issuerName, proposedName, kit) {
         const {
@@ -722,7 +733,7 @@ const prepareBankManager = (
           ([issuer, displayInfo]) =>
             E(nameAdmin).update(
               denom,
-              /** @type { AssetInfo } */ (
+              /** @type {AssetInfo} */ (
                 harden({
                   brand,
                   issuer,
@@ -774,9 +785,7 @@ const prepareBankManager = (
   return makeBankManager;
 };
 
-/**
- * @param {MapStore<string, any>} baggage
- */
+/** @param {MapStore<string, any>} baggage */
 const prepareFromBaggage = baggage => {
   const rootZone = makeDurableZone(baggage);
 
@@ -797,9 +806,7 @@ const prepareFromBaggage = baggage => {
   const makeRewardPurseController = prepareRewardPurseController(rootZone);
   const makeBankChannelHandler = prepareBankChannelHandler(rootZone);
 
-  /**
-   * @type {import('@agoric/internal/src/callback.js').MakeAttenuator<BridgeChannel>}
-   */
+  /** @type {import('@agoric/internal/src/callback.js').MakeAttenuator<BridgeChannel>} */
   const makeBridgeChannelAttenuator = prepareGuardedAttenuator(
     rootZone.subZone('attenuators'),
     BridgeChannelI,
@@ -839,11 +846,11 @@ export function buildRootObject(_vatPowers, _args, baggage) {
 
   return Far('bankMaker', {
     /**
-     * @param {ERef<import('./types.js').ScopedBridgeManager | undefined>} [bankBridgeManagerP] a bridge
-     * manager for the "remote" bank (such as on cosmos-sdk).  If not supplied
-     * (such as on sim-chain), we just use local purses.
-     * @param {ERef<{ update: import('./types.js').NameAdmin['update'] }>} [nameAdminP] update facet of
-     *   a NameAdmin; see addAsset() for detail.
+     * @param {ERef<import('./types.js').ScopedBridgeManager | undefined>} [bankBridgeManagerP]
+     *   a bridge manager for the "remote" bank (such as on cosmos-sdk). If not
+     *   supplied (such as on sim-chain), we just use local purses.
+     * @param {ERef<{ update: import('./types.js').NameAdmin['update'] }>} [nameAdminP]
+     *   update facet of a NameAdmin; see addAsset() for detail.
      */
     async makeBankManager(
       bankBridgeManagerP = undefined,
@@ -856,9 +863,7 @@ export function buildRootObject(_vatPowers, _args, baggage) {
         'denomToAddressUpdater',
       );
 
-      /**
-       * @param {ERef<import('./types.js').ScopedBridgeManager>} [bankBridgeMgr]
-       */
+      /** @param {ERef<import('./types.js').ScopedBridgeManager>} [bankBridgeMgr] */
       async function getBankChannel(bankBridgeMgr) {
         // We do the logic here if the bridge manager is available.  Otherwise,
         // the bank is not "remote" (such as on sim-chain), so we just use

--- a/packages/vats/src/vat-mints.js
+++ b/packages/vats/src/vat-mints.js
@@ -9,7 +9,7 @@ import { notForProductionUse } from '@agoric/internal/src/magic-cookie-test-only
 // simoleanMint.
 
 export function buildRootObject() {
-  /** @type {MapStore<string, { mint: Mint, brand: Brand}>} */
+  /** @type {MapStore<string, { mint: Mint; brand: Brand }>} */
   const mintsAndBrands = makeScalarMapStore('issuerName');
 
   const api = Far('api', {
@@ -22,9 +22,9 @@ export function buildRootObject() {
     getIssuers: issuerNames => issuerNames.map(api.getIssuer),
 
     /**
-     * WARNING: a mint is ability to mint new digital assets,
-     * a very powerful authority that is usually closely held.
-     * But this mint is for demo / faucet purposes.
+     * WARNING: a mint is ability to mint new digital assets, a very powerful
+     * authority that is usually closely held. But this mint is for demo /
+     * faucet purposes.
      *
      * @param {string} name
      */
@@ -35,8 +35,8 @@ export function buildRootObject() {
     /** @param {string[]} issuerNames */
     getMints: issuerNames => issuerNames.map(api.getMint),
     /**
-     * @param {*} issuerNameSingular For example, 'moola', or 'simolean'
-     * @param  {[AssetKind?, DisplayInfo?]} issuerArgs
+     * @param {any} issuerNameSingular For example, 'moola', or 'simolean'
+     * @param {[AssetKind?, DisplayInfo?]} issuerArgs
      */
     makeMintAndIssuer: (issuerNameSingular, ...issuerArgs) => {
       notForProductionUse();

--- a/packages/vats/src/vat-provisioning.js
+++ b/packages/vats/src/vat-provisioning.js
@@ -20,7 +20,11 @@ import {
 const prepareSpecializedNameAdmin = zone => {
   const mixinMyAddress = prepareMixinMyAddress(zone);
 
-  /** @type {import('@agoric/internal/src/callback.js').MakeAttenuator<import('./types.js').NamesByAddressAdmin>} */
+  /**
+   * @type {import('@agoric/internal/src/callback.js').MakeAttenuator<
+   *   import('./types.js').NamesByAddressAdmin
+   * >}
+   */
   const specialize = prepareGuardedAttenuator(zone, NameHubIKit.nameAdmin, {
     tag: 'NamesByAddressAdmin',
   });
@@ -34,7 +38,10 @@ const prepareSpecializedNameAdmin = zone => {
       /**
        * @param {string} address
        * @param {string[]} [reserved]
-       * @returns {Promise<{ nameHub: NameHub, nameAdmin: import('./types.js').MyAddressNameAdmin}>}
+       * @returns {Promise<{
+       *   nameHub: NameHub;
+       *   nameAdmin: import('./types.js').MyAddressNameAdmin;
+       * }>}
        */
       async provideChild(address, reserved) {
         const { nameAdmin } = this.state;
@@ -50,7 +57,7 @@ const prepareSpecializedNameAdmin = zone => {
         // XXX relies on callers not to provide other admins via update()
         // TODO: enforce?
 
-        /** @type { import('./types').MyAddressNameAdmin } */
+        /** @type {import('./types').MyAddressNameAdmin} */
         // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
         // @ts-ignore cast
         const myAdmin = nameAdmin.lookupAdmin(address);
@@ -59,9 +66,7 @@ const prepareSpecializedNameAdmin = zone => {
     },
   );
 
-  /**
-   * @param {import('./types.js').NameAdmin} nameAdmin
-   */
+  /** @param {import('./types.js').NameAdmin} nameAdmin */
   const makeMyAddressNameAdmin = nameAdmin => {
     const overrideFacet = makeOverrideFacet(nameAdmin);
     return specialize({

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -91,30 +91,28 @@ export const makeVirtualPurseKitIKit = (
 
 /**
  * @typedef {object} VirtualPurseController The object that determines the
- * remote behaviour of a virtual purse.
+ *   remote behaviour of a virtual purse.
  * @property {(amount: Amount) => Promise<void>} pushAmount Tell the controller
- * to send an amount from "us" to the "other side".  This should resolve on
- * success and reject on failure.  IT IS IMPORTANT NEVER TO FAIL in normal
- * operation.  That will irrecoverably lose assets.
+ *   to send an amount from "us" to the "other side". This should resolve on
+ *   success and reject on failure. IT IS IMPORTANT NEVER TO FAIL in normal
+ *   operation. That will irrecoverably lose assets.
  * @property {(amount: Amount) => Promise<void>} pullAmount Tell the controller
- * to send an amount from the "other side" to "us".  This should resolve on
- * success and reject on failure.  We can still recover assets from failure to
- * pull.
+ *   to send an amount from the "other side" to "us". This should resolve on
+ *   success and reject on failure. We can still recover assets from failure to
+ *   pull.
  * @property {(brand: Brand) => LatestTopic<Amount>} getBalances Return the
- * current balance iterable for a given brand.
+ *   current balance iterable for a given brand.
  */
 
-/**
- * @param {import('@agoric/zone').Zone} zone
- */
+/** @param {import('@agoric/zone').Zone} zone */
 const prepareVirtualPurseKit = zone =>
   zone.exoClassKit(
     'VirtualPurseKit',
     makeVirtualPurseKitIKit().VirtualPurseIKit,
     /**
      * @param {ERef<VirtualPurseController>} vpc
-     * @param {{ issuer: ERef<Issuer>, brand: Brand, mint?: ERef<Mint> }} issuerKit
-     * @param {{ recoveryPurse: ERef<Purse>, escrowPurse?: ERef<Purse> }} purses
+     * @param {{ issuer: ERef<Issuer>; brand: Brand; mint?: ERef<Mint> }} issuerKit
+     * @param {{ recoveryPurse: ERef<Purse>; escrowPurse?: ERef<Purse> }} purses
      */
     (vpc, issuerKit, purses) => ({
       vpc,
@@ -127,9 +125,9 @@ const prepareVirtualPurseKit = zone =>
     {
       utils: {
         /**
-         * Claim a payment for recovery via our `recoveryPurse`.  No need for this on
-         * the `retain` operations (since we are just burning the payment or
-         * depositing it directly in the `escrowPurse`).
+         * Claim a payment for recovery via our `recoveryPurse`. No need for
+         * this on the `retain` operations (since we are just burning the
+         * payment or depositing it directly in the `escrowPurse`).
          *
          * @param {ERef<Payment>} payment
          * @param {Amount} [optAmountShape]
@@ -267,28 +265,31 @@ const prepareVirtualPurseKit = zone =>
     },
   );
 
-/**
- * @param {import('@agoric/zone').Zone} zone
- */
+/** @param {import('@agoric/zone').Zone} zone */
 export const prepareVirtualPurse = zone => {
   const makeVirtualPurseKit = prepareVirtualPurseKit(zone);
 
   /**
-   * @param {ERef<VirtualPurseController>} vpc the controller that represents the
-   * "other side" of this purse.
-   * @param {{ issuer: ERef<Issuer>, brand: Brand, mint?: ERef<Mint>,
-   * escrowPurse?: ERef<Purse> }} params
-   * the contents of the issuer kit for "us".
+   * @param {ERef<VirtualPurseController>} vpc the controller that represents
+   *   the "other side" of this purse.
+   * @param {{
+   *   issuer: ERef<Issuer>;
+   *   brand: Brand;
+   *   mint?: ERef<Mint>;
+   *   escrowPurse?: ERef<Purse>;
+   * }} params
+   *   the contents of the issuer kit for "us".
    *
-   * If the mint is not specified, then the virtual purse will escrow local assets
-   * instead of minting/burning them.  That is a better option in general, but
-   * escrow doesn't support the case where the "other side" is also minting
-   * assets... our escrow purse may not have enough assets in it to redeem the
-   * ones that are sent from the "other side".
-   * @returns {Promise<Awaited<EOnly<Purse>>>} This is not just a Purse because it plays
-   * fast-and-loose with the synchronous Purse interface.  So, the consumer of
-   * this result must only interact with the virtual purse via eventual-send (to
-   * conceal the methods that are returning promises instead of synchronously).
+   *   If the mint is not specified, then the virtual purse will escrow local
+   *   assets instead of minting/burning them. That is a better option in
+   *   general, but escrow doesn't support the case where the "other side" is
+   *   also minting assets... our escrow purse may not have enough assets in it
+   *   to redeem the ones that are sent from the "other side".
+   * @returns {Promise<Awaited<EOnly<Purse>>>} This is not just a Purse because
+   *   it plays fast-and-loose with the synchronous Purse interface. So, the
+   *   consumer of this result must only interact with the virtual purse via
+   *   eventual-send (to conceal the methods that are returning promises instead
+   *   of synchronously).
    */
   const makeVirtualPurse = async (
     vpc,

--- a/packages/vats/src/walletFlags.js
+++ b/packages/vats/src/walletFlags.js
@@ -1,7 +1,6 @@
 // XXX domain of @agoric/cosmic-proto
 /**
- * non-exhaustive list of powerFlags
- * REMOTE_WALLET is currently a default.
+ * non-exhaustive list of powerFlags REMOTE_WALLET is currently a default.
  *
  * See also MsgProvision in golang/cosmos/proto/agoric/swingset/msgs.proto
  */

--- a/packages/vats/test/bootstrapTests/bench-vaults-performance.js
+++ b/packages/vats/test/bootstrapTests/bench-vaults-performance.js
@@ -1,7 +1,5 @@
 // @ts-check
-/**
- * @file Bootstrap stress test of vaults
- */
+/** @file Bootstrap stress test of vaults */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { PerformanceObserver, performance } from 'node:perf_hooks';
 import v8 from 'node:v8';
@@ -18,7 +16,9 @@ import { makeSwingsetTestKit } from './supports.js';
 import { makeWalletFactoryDriver } from './drivers.js';
 
 /**
- * @type {import('ava').TestFn<Awaited<ReturnType<typeof makeDefaultTestContext>>>}
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeDefaultTestContext>>
+ * >}
  */
 const test = anyTest;
 

--- a/packages/vats/test/bootstrapTests/drivers.js
+++ b/packages/vats/test/bootstrapTests/drivers.js
@@ -77,7 +77,8 @@ export const makeWalletFactoryDriver = async (
       return EV(walletPresence).handleBridgeAction(capData, true);
     },
     /**
-     * @template {import('@agoric/smart-wallet/src/types.js').OfferMaker} M offer maker function
+     * @template {import('@agoric/smart-wallet/src/types.js').OfferMaker} M
+     *   offer maker function
      * @param {M} makeOffer
      * @param {Parameters<M>[1]} firstArg
      * @param {Parameters<M>[2]} [secondArg]
@@ -88,7 +89,8 @@ export const makeWalletFactoryDriver = async (
       return this.executeOffer(offer);
     },
     /**
-     * @template {import('@agoric/smart-wallet/src/types.js').OfferMaker} M offer maker function
+     * @template {import('@agoric/smart-wallet/src/types.js').OfferMaker} M
+     *   offer maker function
      * @param {M} makeOffer
      * @param {Parameters<M>[1]} firstArg
      * @param {Parameters<M>[2]} [secondArg]
@@ -99,9 +101,7 @@ export const makeWalletFactoryDriver = async (
       return this.sendOffer(offer);
     },
 
-    /**
-     * @returns {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord}
-     */
+    /** @returns {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord} */
     getCurrentWalletRecord() {
       const fromCapData = (...args) =>
         Reflect.apply(marshaller.fromCapData, marshaller, args);
@@ -112,9 +112,7 @@ export const makeWalletFactoryDriver = async (
       );
     },
 
-    /**
-     * @returns {import('@agoric/smart-wallet/src/smartWallet.js').UpdateRecord}
-     */
+    /** @returns {import('@agoric/smart-wallet/src/smartWallet.js').UpdateRecord} */
     getLatestUpdateRecord() {
       const fromCapData = (...args) =>
         Reflect.apply(marshaller.fromCapData, marshaller, args);
@@ -326,7 +324,6 @@ export const makeGovernanceDriver = async (
 
   return {
     /**
-     *
      * @param {Instance} instance
      * @param {object} params
      * @param {object} [path]

--- a/packages/vats/test/bootstrapTests/liquidation.js
+++ b/packages/vats/test/bootstrapTests/liquidation.js
@@ -71,7 +71,12 @@ export const makeLiquidationTestContext = async t => {
   );
   console.timeLog('DefaultTestContext', 'governanceDriver');
 
-  /** @type {Record<string, Awaited<ReturnType<typeof makePriceFeedDriver>>>} */
+  /**
+   * @type {Record<
+   *   string,
+   *   Awaited<ReturnType<typeof makePriceFeedDriver>>
+   * >}
+   */
   const priceFeedDrivers = {};
 
   console.timeLog('DefaultTestContext', 'priceFeedDriver');
@@ -79,7 +84,6 @@ export const makeLiquidationTestContext = async t => {
   console.timeEnd('DefaultTestContext');
 
   /**
-   *
    * @param {object} opts
    * @param {string} opts.collateralBrandKey
    * @param {number} opts.managerIndex

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -29,7 +29,11 @@ const sink = () => {};
 
 const trace = makeTracer('BSTSupport', false);
 
-/** @typedef {Awaited<ReturnType<import('@agoric/vats/src/core/lib-boot').makeBootstrap>>} BootstrapRootObject */
+/**
+ * @typedef {Awaited<
+ *   ReturnType<import('@agoric/vats/src/core/lib-boot').makeBootstrap>
+ * >} BootstrapRootObject
+ */
 
 /** @type {{ [P in keyof BootstrapRootObject]: P }} */
 export const bootstrapMethods = {
@@ -55,9 +59,12 @@ const keysToObject = (keys, valueMaker) => {
 };
 
 /**
- * AVA's default t.deepEqual() is nearly unreadable for sorted arrays of strings.
+ * AVA's default t.deepEqual() is nearly unreadable for sorted arrays of
+ * strings.
  *
- * @param {{ deepEqual: (a: unknown, b: unknown, message?: string) => void}} t
+ * @param {{
+ *   deepEqual: (a: unknown, b: unknown, message?: string) => void;
+ * }} t
  * @param {PropertyKey[]} a
  * @param {PropertyKey[]} b
  * @param {string} [message]
@@ -126,9 +133,9 @@ export const makeRunUtils = (controller, log = (..._) => {}) => {
 
   /**
    * @type {typeof E & {
-   *   sendOnly: (presence: unknown) => Record<string, (...args: any) => void>,
-   *   vat: (name: string) => Record<string, (...args: any) => Promise<any>>,
-   *   rawBoot: Record<string, (...args: any) => Promise<any>>,
+   *   sendOnly: (presence: unknown) => Record<string, (...args: any) => void>;
+   *   vat: (name: string) => Record<string, (...args: any) => Promise<any>>;
+   *   rawBoot: Record<string, (...args: any) => Promise<any>>;
    * }}
    */
   // @ts-expect-error cast, approximate
@@ -183,7 +190,7 @@ export const getNodeTestVaultsConfig = async (
   const fullPath = await importMetaResolve(specifier, import.meta.url).then(
     u => new URL(u).pathname,
   );
-  const config = /** @type {SwingSetConfig & {coreProposals?: any[]}} */ (
+  const config = /** @type {SwingSetConfig & { coreProposals?: any[] }} */ (
     await loadSwingsetConfigFile(fullPath)
   );
   assert(config);
@@ -212,7 +219,7 @@ export const getNodeTestVaultsConfig = async (
 
 /**
  * @param {object} powers
- * @param {Pick<typeof import('node:child_process'), 'execFileSync' >} powers.childProcess
+ * @param {Pick<typeof import('node:child_process'), 'execFileSync'>} powers.childProcess
  * @param {typeof import('node:fs/promises')} powers.fs
  */
 const makeProposalExtractor = ({ childProcess, fs }) => {
@@ -309,11 +316,10 @@ const makeProposalExtractor = ({ childProcess, fs }) => {
  * For example, test accounts balances using separate wallets or test vault
  * factory metrics using separate collateral managers. (Or use test.serial)
  *
- * The shutdown() function *must* be called after the test is
- * complete, or else V8 will see the xsnap workers still running, and
- * will never exit (leading to a timeout error). Use
- * t.after.always(shutdown), because the normal t.after() hooks are
- * not run if a test fails.
+ * The shutdown() function _must_ be called after the test is complete, or else
+ * V8 will see the xsnap workers still running, and will never exit (leading to
+ * a timeout error). Use t.after.always(shutdown), because the normal t.after()
+ * hooks are not run if a test fails.
  *
  * @param {import('ava').ExecutionContext} t
  * @param {string} bundleDir directory to write bundles and config to
@@ -345,7 +351,7 @@ export const makeSwingsetTestKit = async (
    * changes there will sometimes require changes here.
    *
    * @param {string} bridgeId
-   * @param {*} obj
+   * @param {any} obj
    */
   const bridgeOutbound = (bridgeId, obj) => {
     switch (bridgeId) {
@@ -455,9 +461,8 @@ export const makeSwingsetTestKit = async (
     }
   };
   /**
-   *
    * @param {number} n
-   * @param {'seconds' | 'minutes' | 'hours'| 'days'} unit
+   * @param {'seconds' | 'minutes' | 'hours' | 'days'} unit
    */
   const advanceTimeBy = (n, unit) => {
     const multiplier = {

--- a/packages/vats/test/bootstrapTests/test-demo-config.js
+++ b/packages/vats/test/bootstrapTests/test-demo-config.js
@@ -7,7 +7,9 @@ import { makeSwingsetTestKit, keyArrayEqual } from './supports.js';
 
 const { keys } = Object;
 /**
- * @type {import('ava').TestFn<Awaited<ReturnType<typeof makeDefaultTestContext>>>}
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeDefaultTestContext>>
+ * >}
  */
 const test = anyTest;
 
@@ -78,15 +80,14 @@ test('sim/demo config launches Vaults as expected by loadgen', async t => {
 });
 
 /**
- * decentral-demo-config.json now uses boot-sim.js,
- * which includes connectFaucet, which re-introduced USDC.
- * That triggered a compatibility path in the loadgen that
- * caused it to try and fail to run the vaults task.
+ * decentral-demo-config.json now uses boot-sim.js, which includes
+ * connectFaucet, which re-introduced USDC. That triggered a compatibility path
+ * in the loadgen that caused it to try and fail to run the vaults task.
  * work-around: rename USDC to DAI in connectFaucet.
  *
- * TODO: move connectFaucet to a coreProposal and
- * separate decentral-demo-config.json into separate
- * configurations for sim-chain, loadgen.
+ * TODO: move connectFaucet to a coreProposal and separate
+ * decentral-demo-config.json into separate configurations for sim-chain,
+ * loadgen.
  */
 test('demo config meets loadgen constraint: no USDC', async t => {
   const { EV } = t.context.runUtils;

--- a/packages/vats/test/bootstrapTests/test-liquidation-1.js
+++ b/packages/vats/test/bootstrapTests/test-liquidation-1.js
@@ -1,7 +1,5 @@
 // @ts-check
-/**
- * @file Bootstrap test of liquidation across multiple collaterals
- */
+/** @file Bootstrap test of liquidation across multiple collaterals */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { NonNullish } from '@agoric/assert';
@@ -14,7 +12,9 @@ import {
 } from './liquidation.js';
 
 /**
- * @type {import('ava').TestFn<Awaited<ReturnType<typeof makeLiquidationTestContext>>>}
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeLiquidationTestContext>>
+ * >}
  */
 const test = anyTest;
 
@@ -126,10 +126,11 @@ test.after.always(t => {
 
 // Reference: Flow 1 from https://github.com/Agoric/agoric-sdk/issues/7123
 /**
- *
- * @param {import('ava').ExecutionContext<Awaited<ReturnType<typeof makeLiquidationTestContext>>>} t
- * @param {{collateralBrandKey: string, managerIndex: number}} case
- * @param {*} _expected
+ * @param {import('ava').ExecutionContext<
+ *   Awaited<ReturnType<typeof makeLiquidationTestContext>>
+ * >} t
+ * @param {{ collateralBrandKey: string; managerIndex: number }} case
+ * @param {any} _expected
  */
 const checkFlow1 = async (
   t,
@@ -339,7 +340,12 @@ const checkFlow1 = async (
     console.log(collateralBrandKey, 'step 10 of 10');
     // continuing after now would start a new auction
     {
-      /** @type {Record<string, import('@agoric/time/src/types.js').TimestampRecord>} */
+      /**
+       * @type {Record<
+       *   string,
+       *   import('@agoric/time/src/types.js').TimestampRecord
+       * >}
+       */
       const { nextDescendingStepTime, nextStartTime } = readLatest(
         'published.auction.schedule',
       );

--- a/packages/vats/test/bootstrapTests/test-liquidation-2b.js
+++ b/packages/vats/test/bootstrapTests/test-liquidation-2b.js
@@ -2,8 +2,9 @@
 /**
  * @file Bootstrap test integration vaults with smart-wallet
  *
- * Forks test-liquidation to test another scenario, but with a clean vault manager state.
- * TODO is there a way to *reset* the vaultmanager to make the two tests run faster?
+ *   Forks test-liquidation to test another scenario, but with a clean vault
+ *   manager state. TODO is there a way to _reset_ the vaultmanager to make the
+ *   two tests run faster?
  */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
@@ -12,7 +13,9 @@ import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { makeLiquidationTestContext, scale6 } from './liquidation.js';
 
 /**
- * @type {import('ava').TestFn<Awaited<ReturnType<typeof makeLiquidationTestContext>>>}
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeLiquidationTestContext>>
+ * >}
  */
 const test = anyTest;
 

--- a/packages/vats/test/bootstrapTests/test-vats-restart.js
+++ b/packages/vats/test/bootstrapTests/test-vats-restart.js
@@ -1,7 +1,5 @@
 // @ts-check
-/**
- * @file Bootstrap test of restarting (almost) all vats
- */
+/** @file Bootstrap test of restarting (almost) all vats */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { Fail } from '@agoric/assert';
@@ -12,7 +10,9 @@ import { makeWalletFactoryDriver } from './drivers.js';
 import { makeSwingsetTestKit } from './supports.js';
 
 /**
- * @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>}
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeTestContext>>
+ * >}
  */
 const test = anyTest;
 
@@ -121,7 +121,11 @@ test.serial('run restart-vats proposal', async t => {
 test.serial('read metrics', async t => {
   const { EV } = t.context.runUtils;
 
-  /** @type {Awaited<import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace['consume']['vaultFactoryKit']>} */
+  /**
+   * @type {Awaited<
+   *   import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace['consume']['vaultFactoryKit']
+   * >}
+   */
   const vaultFactoryKit = await EV.vat('bootstrap').consumeItem(
     'vaultFactoryKit',
   );

--- a/packages/vats/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-integration.js
@@ -1,7 +1,5 @@
 // @ts-check
-/**
- * @file Bootstrap test integration vaults with smart-wallet
- */
+/** @file Bootstrap test integration vaults with smart-wallet */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { Fail } from '@agoric/assert';
@@ -18,7 +16,9 @@ import { makeWalletFactoryDriver } from './drivers.js';
 import { makeSwingsetTestKit } from './supports.js';
 
 /**
- * @type {import('ava').TestFn<Awaited<ReturnType<typeof makeDefaultTestContext>>>}
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeDefaultTestContext>>
+ * >}
  */
 const test = anyTest;
 

--- a/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
@@ -1,9 +1,9 @@
 // @ts-check
 /**
- * @file Bootstrap test integration vaults with smart-wallet.
- * The tests in this file are NOT independent; a single `test.before()`
- * handler creates shared state with `makeSwingsetTestKit` and each
- * test is run serially and assumes changes from earlier tests.
+ * @file Bootstrap test integration vaults with smart-wallet. The tests in this
+ *   file are NOT independent; a single `test.before()` handler creates shared
+ *   state with `makeSwingsetTestKit` and each test is run serially and assumes
+ *   changes from earlier tests.
  */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
@@ -77,10 +77,12 @@ const makeDefaultTestContext = async (
 };
 
 /**
- * Shared context can be updated by re-bootstrapping, and is placed one
- * property deep so such changes propagate to later tests.
+ * Shared context can be updated by re-bootstrapping, and is placed one property
+ * deep so such changes propagate to later tests.
  *
- * @type {import('ava').TestFn<{shared: Awaited<ReturnType<typeof makeDefaultTestContext>>}>}
+ * @type {import('ava').TestFn<{
+ *   shared: Awaited<ReturnType<typeof makeDefaultTestContext>>;
+ * }>}
  */
 const test = anyTest;
 test.before(async t => {
@@ -287,7 +289,11 @@ test.serial('open vault', async t => {
 test.serial('restart vaultFactory', async t => {
   const { runUtils, readCollateralMetrics } = t.context.shared;
   const { EV } = runUtils;
-  /** @type {Awaited<import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace['consume']['vaultFactoryKit']>} */
+  /**
+   * @type {Awaited<
+   *   import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace['consume']['vaultFactoryKit']
+   * >}
+   */
   const vaultFactoryKit = await EV.vat('bootstrap').consumeItem(
     'vaultFactoryKit',
   );
@@ -314,7 +320,11 @@ test.serial('restart vaultFactory', async t => {
 
 test.serial('restart contractGovernor', async t => {
   const { EV } = t.context.shared.runUtils;
-  /** @type {Awaited<import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace['consume']['vaultFactoryKit']>} */
+  /**
+   * @type {Awaited<
+   *   import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace['consume']['vaultFactoryKit']
+   * >}
+   */
   const vaultFactoryKit = await EV.vat('bootstrap').consumeItem(
     'vaultFactoryKit',
   );
@@ -486,7 +496,7 @@ test.serial(
     /** @type {MapStore} */
     const powerStore = await EV.vat('bootstrap').consumeItem('powerStore');
 
-    /** @type {(n: string) => Promise<Array<[*, *]>>} */
+    /** @type {(n: string) => Promise<[any, any][]>} */
     const getStoreSnapshot = async name =>
       EV.vat('bootstrap').snapshotStore(await EV(powerStore).get(name));
 

--- a/packages/vats/test/test-board-utils.js
+++ b/packages/vats/test/test-board-utils.js
@@ -14,7 +14,7 @@ import {
 const streamCellTextFromArray = values =>
   JSON.stringify({ blockHeight: '0', values });
 
-/** @type {Array<[string, any]>} */
+/** @type {[string, any][]} */
 const agoricNamesDataEntriesFixture = [
   [
     'published.agoricNames.issuer',

--- a/packages/vats/test/test-boot-config.js
+++ b/packages/vats/test/test-boot-config.js
@@ -10,7 +10,11 @@ import { loadSwingsetConfigFile, shape as ssShape } from '@agoric/swingset-vat';
 import { provideBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { extractCoreProposalBundles } from '@agoric/deploy-script-support/src/extract-proposal.js';
 
-/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
+/**
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeTestContext>>
+ * >}
+ */
 const test = anyTest;
 
 const PROD_CONFIG_FILES = [
@@ -40,7 +44,7 @@ const NON_UPGRADEABLE_VATS = [
 export const pspawn =
   (bin, { spawn }) =>
   (args = [], opts = {}) => {
-    /** @type {ReturnType<typeof import('child_process').spawn> | undefined } */
+    /** @type {ReturnType<typeof import('child_process').spawn> | undefined} */
     let child;
     const exit = new Promise((resolve, reject) => {
       // console.debug('spawn', bin, args, { cwd: makefileDir, ...opts });

--- a/packages/vats/test/test-bootstrapPayment.js
+++ b/packages/vats/test/test-bootstrapPayment.js
@@ -12,14 +12,21 @@ import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import centralSupplyBundle from '../bundles/bundle-centralSupply.js';
 import { feeIssuerConfig } from '../src/core/utils.js';
 
-/** @template T @typedef {import('@agoric/zoe/src/zoeService/utils').Installation<T>} Installation<T> */
+/**
+ * @template T @typedef
+ *   {import('@agoric/zoe/src/zoeService/utils').Installation<T>}
+ *   Installation<T>
+ */
 /**
  * @typedef {import('ava').ExecutionContext<{
- *   zoe: ZoeService,
- *   feeMintAccess: FeeMintAccess,
- *   issuer: Record<'IST', Issuer>,
- *   brand: Record<'IST', Brand>,
- *   installation: Record<'centralSupply', Installation<import('../src/centralSupply.js').start>>,
+ *   zoe: ZoeService;
+ *   feeMintAccess: FeeMintAccess;
+ *   issuer: Record<'IST', Issuer>;
+ *   brand: Record<'IST', Brand>;
+ *   installation: Record<
+ *     'centralSupply',
+ *     Installation<import('../src/centralSupply.js').start>
+ *   >;
  * }>} CentralSupplyTestContext
  */
 

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -26,16 +26,18 @@ import { makeNameHubKit, prepareMixinMyAddress } from '../src/nameHub.js';
 
 /**
  * @typedef {{
- *   (n: 'board'): BoardVat
- *   (n: 'mint'): MintsVat
+ *   (n: 'board'): BoardVat;
+ *   (n: 'mint'): MintsVat;
  * }} LoadVat
  */
 test('connectFaucet produces payments', async t => {
   const space = /** @type {any} */ (makePromiseSpace(t.log));
-  const { consume, produce } =
-    /** @type { BootstrapPowers & DemoFaucetPowers & { consume: { loadVat: LoadVat, loadCriticalVat: LoadVat }} } */ (
-      space
-    );
+  const { consume, produce } = /**
+   * @type {BootstrapPowers &
+   *   DemoFaucetPowers & {
+   *     consume: { loadVat: LoadVat; loadCriticalVat: LoadVat };
+   *   }}
+   */ (space);
   const { agoricNames, agoricNamesAdmin, spaces } =
     await makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
@@ -129,7 +131,7 @@ test('connectFaucet produces payments', async t => {
 
   // t.deepEqual(Object.keys(userBundle), '@@todo');
 
-  /** @type { import('../src/core/demoIssuers.js').UserPaymentRecord[] } */
+  /** @type {import('../src/core/demoIssuers.js').UserPaymentRecord[]} */
   const pmts = await E(userBundle.faucet).tapFaucet();
 
   const detail = await Promise.all(
@@ -158,7 +160,7 @@ test('namesByAddressAdmin provideChild', async t => {
   const baggage = makeScalarBigMapStore('fake baggage', { durable: true });
   const provisioning = buildProvisioningRoot(undefined, undefined, baggage);
   const { namesByAddressAdmin } = await E(provisioning).getNamesByAddressKit();
-  /** @type {{ nameAdmin: import('../src/types.js').MyAddressNameAdmin}} */
+  /** @type {{ nameAdmin: import('../src/types.js').MyAddressNameAdmin }} */
   // @ts-expect-error XXX why doesn't the provideChild override work?
   const { nameAdmin } = E.get(E(namesByAddressAdmin).provideChild(addr));
   t.is(await E(nameAdmin).getMyAddress(), addr);

--- a/packages/vats/test/test-demoAMM.js
+++ b/packages/vats/test/test-demoAMM.js
@@ -13,7 +13,7 @@ import {
   splitAllCentralPayments,
 } from '../src/core/demoIssuers.js';
 
-/** @param { bigint } n */
+/** @param {bigint} n */
 const showIST = n => `${decimal(n, 6)} IST`;
 
 // TODO: prune showIST formatting utility

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -27,7 +27,9 @@ import { makeFakeBankKit } from '../tools/bank-utils.js';
 
 /**
  * @typedef {import('../src/vat-bank.js').Bank} Bank
+ *
  * @typedef {import('@agoric/smart-wallet/src/smartWallet.js').SmartWallet} SmartWallet
+ *
  * @typedef {import('@agoric/smart-wallet/src/walletFactory.js').WalletReviver} WalletReviver
  */
 
@@ -268,10 +270,9 @@ test('provisionPool trades provided assets for IST', async t => {
 });
 
 /**
- * This is a bit of a short-cut; rather than scaffold
- * everything needed to make a walletFactory, we factored
- * out the part that had a bug as `publishDepositFacet`
- * and we make a mock walletFactory that uses it.
+ * This is a bit of a short-cut; rather than scaffold everything needed to make
+ * a walletFactory, we factored out the part that had a bug as
+ * `publishDepositFacet` and we make a mock walletFactory that uses it.
  *
  * @param {string[]} addresses
  */

--- a/packages/vats/test/test-vat-bank-integration.js
+++ b/packages/vats/test/test-vat-bank-integration.js
@@ -22,11 +22,12 @@ import { makePopulatedFakeVatAdmin } from '../tools/boot-test-utils.js';
 
 test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
   // Supply bootstrap prerequisites.
-  const space = /** @type { any } */ (makePromiseSpace(t.log));
-  const { produce, consume } =
-    /** @type { BootstrapPowers & { consume: { loadCriticalVat: VatLoader<any> }}} */ (
-      space
-    );
+  const space = /** @type {any} */ (makePromiseSpace(t.log));
+  const { produce, consume } = /**
+   * @type {BootstrapPowers & {
+   *   consume: { loadCriticalVat: VatLoader<any> };
+   * }}
+   */ (space);
   const { agoricNames, agoricNamesAdmin, spaces } =
     await makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
@@ -66,10 +67,10 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
     zone: heapZone,
     consume,
     produce,
-    devices: /** @type { any } */ ({}),
-    vats: /** @type { any } */ ({}),
-    vatPowers: /** @type { any } */ ({}),
-    runBehaviors: /** @type { any } */ ({}),
+    devices: /** @type {any} */ ({}),
+    vats: /** @type {any} */ ({}),
+    vatPowers: /** @type {any} */ ({}),
+    runBehaviors: /** @type {any} */ ({}),
     modules: {},
     ...spaces,
   });

--- a/packages/vats/test/test-vat-bank.js
+++ b/packages/vats/test/test-vat-bank.js
@@ -148,7 +148,14 @@ test('communication', async t => {
     message: /not found/,
   });
 
-  /** @type {undefined | IteratorResult<{brand: Brand, issuer: ERef<Issuer>, proposedName: string}>} */
+  /**
+   * @type {| undefined
+   *   | IteratorResult<{
+   *       brand: Brand;
+   *       issuer: ERef<Issuer>;
+   *       proposedName: string;
+   *     }>}
+   */
   let itResult;
   const p = it.next().then(r => (itResult = r));
   t.is(itResult, undefined);

--- a/packages/vats/test/test-vpurse.js
+++ b/packages/vats/test/test-vpurse.js
@@ -24,7 +24,7 @@ test.before(t => {
 });
 
 /**
- * @param {*} t
+ * @param {any} t
  * @param {import('@agoric/zone').Zone} zone
  * @param {bigint} [escrowValue]
  */
@@ -43,9 +43,7 @@ const setup = (t, zone, escrowValue = 0n) => {
   /** @type {Amount} */
   let expectedAmount;
 
-  /**
-   * @param {Amount} amt
-   */
+  /** @param {Amount} amt */
   const expected = harden({
     /** @param {Amount} amt */
     pullAmount(amt) {

--- a/packages/vats/test/upgrading/test-upgrade-contracts.js
+++ b/packages/vats/test/upgrading/test-upgrade-contracts.js
@@ -1,20 +1,23 @@
 /**
- * @file
- *  cribbed from packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
+ * @file cribbed from
+ *   packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
  */
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { buildVatController } from '@agoric/swingset-vat';
 
-/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
+/**
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeTestContext>>
+ * >}
+ */
 const test = anyTest;
 
 /**
- * WARNING: uses ambient authority
- * of import.meta.url
+ * WARNING: uses ambient authority of import.meta.url
  *
- * We aim to use ambient authority only in test.before();
- * splitting out makeTestContext() lets us type t.context.
+ * We aim to use ambient authority only in test.before(); splitting out
+ * makeTestContext() lets us type t.context.
  */
 const makeTestContext = async () => {
   const bfile = name => new URL(name, import.meta.url).pathname;

--- a/packages/vats/test/upgrading/test-upgrade-vats.js
+++ b/packages/vats/test/upgrading/test-upgrade-vats.js
@@ -5,7 +5,11 @@ import { BridgeId } from '@agoric/internal';
 import { buildVatController } from '@agoric/swingset-vat';
 import { makeRunUtils } from '../bootstrapTests/supports.js';
 
-/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
+/**
+ * @type {import('ava').TestFn<
+ *   Awaited<ReturnType<typeof makeTestContext>>
+ * >}
+ */
 const test = anyTest;
 
 const { Fail } = assert;
@@ -21,10 +25,7 @@ const makeCallOutbound = t => (srcID, obj) => {
   return obj;
 };
 
-/**
- * NOTE: limit ambient authority such as import.meta.url
- * to test.before()
- */
+/** NOTE: limit ambient authority such as import.meta.url to test.before() */
 test.before(async t => {
   t.context = await makeTestContext(import.meta.url);
 });

--- a/packages/vats/tools/authorityViz.js
+++ b/packages/vats/tools/authorityViz.js
@@ -25,13 +25,14 @@ const styles = {
 
 /**
  * @param {Set<GraphNode>} nodes
- * @param {Map<string, Set<{ id: string, style?: string }>>} neighbors
- * @yields { string }
+ * @param {Map<string, Set<{ id: string; style?: string }>>} neighbors
+ * @yields {string}
+ *
  * @typedef {{
- *   id: string,
- *   cluster?: string,
- *   label: string,
- *   style?: string,
+ *   id: string;
+ *   cluster?: string;
+ *   label: string;
+ *   style?: string;
  * }} GraphNode
  */
 function* fmtGraph(nodes, neighbors) {
@@ -65,24 +66,32 @@ function* fmtGraph(nodes, neighbors) {
 
 /**
  * @param {Record<string, Permit>} manifest
- * @typedef { true | {
- *   vatParameters?: Record<string, Permit>,
- *   vatPowers?: Record<string, true>
- *   vats?: Record<string, Status>
- *   devices?: Record<string, true>
- *   home?: PowerSpace,
- *   issuer?: PowerSpace,
- *   brand?: PowerSpace,
- *   oracleBrand?: PowerSpace,
- *   installation?: PowerSpace,
- *   instance?: PowerSpace,
- * } & PowerSpace } Permit
- * @typedef {{produce?: Record<string, Status>, consume?: Record<string, Status>}} PowerSpace
- * @typedef { boolean | VatName } Status
- * @typedef { string } VatName
+ *
+ * @typedef {| true
+ *   | ({
+ *       vatParameters?: Record<string, Permit>;
+ *       vatPowers?: Record<string, true>;
+ *       vats?: Record<string, Status>;
+ *       devices?: Record<string, true>;
+ *       home?: PowerSpace;
+ *       issuer?: PowerSpace;
+ *       brand?: PowerSpace;
+ *       oracleBrand?: PowerSpace;
+ *       installation?: PowerSpace;
+ *       instance?: PowerSpace;
+ *     } & PowerSpace)} Permit
+ *
+ * @typedef {{
+ *   produce?: Record<string, Status>;
+ *   consume?: Record<string, Status>;
+ * }} PowerSpace
+ *
+ * @typedef {boolean | VatName} Status
+ *
+ * @typedef {string} VatName
  */
 const manifest2graph = manifest => {
-  /** @type { Set<GraphNode> } */
+  /** @type {Set<GraphNode>} */
   const nodes = new Set();
   const neighbors = new Map();
 
@@ -212,9 +221,9 @@ const loadConfig = async (specifier, { resolve, readFile }) => {
  * @param {typeof import('process').stdout} io.stdout
  * @param {typeof import('fs/promises')} io.fsp
  * @param {{
- *   resolve: Resolver,
- *   url: string,
- *   load: (specifier: string) => Promise<Record<string, any>>,
+ *   resolve: Resolver;
+ *   url: string;
+ *   load: (specifier: string) => Promise<Record<string, any>>;
  * }} io.meta
  *
  * @typedef {(specifier: string, parent: string) => Promise<string>} Resolver

--- a/packages/vats/tools/bank-utils.js
+++ b/packages/vats/tools/bank-utils.js
@@ -4,13 +4,16 @@ import { makeScalarMapStore } from '@agoric/vat-data';
 import { E } from '@endo/far';
 import { Far } from '@endo/marshal';
 
-/**
- * @param {Array<Pick<IssuerKit, 'brand' | 'issuer'>>} issuerKits
- */
+/** @param {Pick<IssuerKit, 'brand' | 'issuer'>[]} issuerKits */
 export const makeFakeBankKit = issuerKits => {
   /** @type {MapStore<Brand, ERef<Issuer>>} */
   const issuers = makeScalarMapStore();
-  /** @type {MapStore<Brand, ERef<import('../src/vat-bank.js').VirtualPurse>>} */
+  /**
+   * @type {MapStore<
+   *   Brand,
+   *   ERef<import('../src/vat-bank.js').VirtualPurse>
+   * >}
+   */
   const purses = makeScalarMapStore();
 
   // XXX setup purses without publishing
@@ -20,7 +23,11 @@ export const makeFakeBankKit = issuerKits => {
     purses.init(kit.brand, E(kit.issuer).makeEmptyPurse());
   });
 
-  /** @type {SubscriptionRecord<import('../src/vat-bank.js').AssetDescriptor>} */
+  /**
+   * @type {SubscriptionRecord<
+   *   import('../src/vat-bank.js').AssetDescriptor
+   * >}
+   */
   const { subscription, publication } = makeSubscriptionKit();
 
   /**

--- a/packages/vats/tools/board-utils.js
+++ b/packages/vats/tools/board-utils.js
@@ -1,20 +1,23 @@
 // @ts-check
 /**
  * @typedef {{
- *   brand: import('@agoric/internal/src/marshal.js').BoardRemote,
- *   denom: string,
- *   displayInfo: DisplayInfo,
- *   issuer: import('@agoric/internal/src/marshal.js').BoardRemote,
- *   issuerName: string,
- *   proposedName: string,
+ *   brand: import('@agoric/internal/src/marshal.js').BoardRemote;
+ *   denom: string;
+ *   displayInfo: DisplayInfo;
+ *   issuer: import('@agoric/internal/src/marshal.js').BoardRemote;
+ *   issuerName: string;
+ *   proposedName: string;
  * }} VBankAssetDetail
  */
 /**
  * @typedef {{
- *   brand: Record<string, import('@agoric/internal/src/marshal.js').BoardRemote>,
- *   instance: Record<string, Instance>,
- *   vbankAsset: Record<string, VBankAssetDetail>,
- *   reverse: Record<string, string>,
+ *   brand: Record<
+ *     string,
+ *     import('@agoric/internal/src/marshal.js').BoardRemote
+ *   >;
+ *   instance: Record<string, Instance>;
+ *   vbankAsset: Record<string, VBankAssetDetail>;
+ *   reverse: Record<string, string>;
  * }} AgoricNamesRemotes
  */
 
@@ -29,7 +32,7 @@ import { prepareBoardKit } from '../src/lib-board.js';
 export * from '@agoric/internal/src/marshal.js';
 
 /**
- * @param {import("@agoric/internal/src/storage-test-utils.js").FakeStorageKit} fakeStorageKit
+ * @param {import('@agoric/internal/src/storage-test-utils.js').FakeStorageKit} fakeStorageKit
  * @returns {AgoricNamesRemotes}
  */
 export const makeAgoricNamesRemotesFromFakeStorage = fakeStorageKit => {
@@ -41,7 +44,12 @@ export const makeAgoricNamesRemotesFromFakeStorage = fakeStorageKit => {
   const { fromCapData } = makeMarshal(undefined, slotToBoardRemote);
   const reverse = {};
   const entries = ['brand', 'instance'].map(kind => {
-    /** @type {Array<[string, import('@agoric/vats/tools/board-utils.js').BoardRemote]>} */
+    /**
+     * @type {[
+     *   string,
+     *   import('@agoric/vats/tools/board-utils.js').BoardRemote,
+     * ][]}
+     */
     const parts = unmarshalFromVstorage(
       data,
       `published.agoricNames.${kind}`,
@@ -69,8 +77,8 @@ export const makeAgoricNamesRemotesFromFakeStorage = fakeStorageKit => {
 harden(makeAgoricNamesRemotesFromFakeStorage);
 
 /**
- * Make a board that uses durable storage, but with fake baggage which will fail upgrade.
- * Suitable only for use in tests.
+ * Make a board that uses durable storage, but with fake baggage which will fail
+ * upgrade. Suitable only for use in tests.
  *
  * @param {bigint | number} [initSequence]
  * @param {object} [options]

--- a/packages/vats/tools/boot-test-utils.js
+++ b/packages/vats/tools/boot-test-utils.js
@@ -41,16 +41,16 @@ export const mockDProxy = d => d;
 export const makeMock = log =>
   harden({
     devices: {
-      command: /** @type { any } */ ({ registerInboundHandler: noop }),
-      mailbox: /** @type { any } */ ({
+      command: /** @type {any} */ ({ registerInboundHandler: noop }),
+      mailbox: /** @type {any} */ ({
         registerInboundHandler: noop,
       }),
-      timer: /** @type { any } */ ({}),
-      plugin: /** @type { any } */ ({ registerReceiver: noop }),
+      timer: /** @type {any} */ ({}),
+      plugin: /** @type {any} */ ({ registerReceiver: noop }),
       ...devices,
     },
     vats: {
-      vattp: /** @type { any } */ (
+      vattp: /** @type {any} */ (
         Far('vattp', {
           registerMailboxDevice: noop,
           addRemote: () => harden({}),
@@ -142,7 +142,7 @@ export const makePopulatedFakeVatAdmin = () => {
   const criticalVatKey = vatAdminState.getCriticalVatKey();
   const getCriticalVatKey = () => criticalVatKey;
   const createVatAdminService = () => vatAdminService;
-  /** @type { any } */
+  /** @type {any} */
   const vatAdminRoot = { getCriticalVatKey, createVatAdminService };
   return { vatAdminService, vatAdminRoot };
 };
@@ -156,9 +156,7 @@ export const mockSwingsetVats = mock => {
   return vats;
 };
 
-/**
- * @param {(msg: string) => void} log
- */
+/** @param {(msg: string) => void} log */
 export const mockPsmBootstrapArgs = log => {
   const mock = makeMock(log);
   const vats = mockSwingsetVats(mock);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,6 +1850,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/debug@^4.0.0":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.8.tgz#cef723a5d0a90990313faec2d1e22aee5eecb317"
+  integrity sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/eslint@^7.2.13":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.29.0.tgz#e56ddc8e542815272720bb0b4ccc2aff9c3e1c78"
@@ -1924,6 +1931,13 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
+"@types/mdast@^3.0.0":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
+  integrity sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/microtime@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/microtime/-/microtime-2.1.0.tgz#adbd99f501a85c88695eb1efd3515810f2563932"
@@ -1948,6 +1962,11 @@
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node-fetch@^2.6.2":
   version "2.6.2"
@@ -2019,6 +2038,11 @@
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.2.tgz#38ecb64f01aa0d02b7c8f4222d7c38af6316fef8"
   integrity sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==
+
+"@types/unist@*", "@types/unist@^2.0.0":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
+  integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
 "@types/yargs-parser@^21.0.0":
   version "21.0.0"
@@ -2288,7 +2312,7 @@ acorn-walk@^8.2.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.2.4, acorn@^8.8.2, acorn@^8.7.1, acorn@^8.9.0:
+acorn@^8.2.4, acorn@^8.7.1, acorn@^8.8.2, acorn@^8.9.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
@@ -2841,6 +2865,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+binary-searching@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/binary-searching/-/binary-searching-2.0.5.tgz#ab6d08d51cd1b58878ae208ab61988f885b22dd3"
+  integrity sha512-v4N2l3RxL+m4zDxyxz3Ne2aTmiPn8ZUpKFpdPtO+ItW1NcTCXA7JeHG5GMBSvoKSkQZ9ycS+EouDVxYB9ufKWA==
+
 bindings@^1.2.1, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
@@ -3218,6 +3247,11 @@ chalk@^5.2.0:
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
   integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
 
+character-entities@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -3476,7 +3510,7 @@ commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-comment-parser@1.3.1:
+comment-parser@1.3.1, comment-parser@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
   integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
@@ -3851,7 +3885,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -3882,6 +3916,13 @@ decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decode-named-character-reference@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz#daabac9690874c394c81e4162a0304b35d824f0e"
+  integrity sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==
+  dependencies:
+    character-entities "^2.0.0"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -4005,7 +4046,7 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
-dequal@^2.0.3:
+dequal@^2.0.0, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
@@ -4054,6 +4095,11 @@ diff-sequences@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
   integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
+
+diff@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 dir-glob@^2.2.2:
   version "2.2.2"
@@ -6635,6 +6681,11 @@ klaw-sync@^6.0.0:
   dependencies:
     graceful-fs "^4.1.11"
 
+kleur@^4.0.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
+  integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
+
 koalas@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/koalas/-/koalas-1.0.2.tgz#318433f074235db78fae5661a02a8ca53ee295cd"
@@ -7053,6 +7104,31 @@ md5-hex@^3.0.1:
   dependencies:
     blueimp-md5 "^2.10.0"
 
+mdast-util-from-markdown@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz#9421a5a247f10d31d2faed2a30df5ec89ceafcf0"
+  integrity sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    mdast-util-to-string "^3.1.0"
+    micromark "^3.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-decode-string "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    unist-util-stringify-position "^3.0.0"
+    uvu "^0.5.0"
+
+mdast-util-to-string@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz#66f7bb6324756741c5f47a53557f0cbf16b6f789"
+  integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -7154,6 +7230,200 @@ methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
+micromark-core-commonmark@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz#1386628df59946b2d39fb2edfd10f3e8e0a75bb8"
+  integrity sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-factory-destination "^1.0.0"
+    micromark-factory-label "^1.0.0"
+    micromark-factory-space "^1.0.0"
+    micromark-factory-title "^1.0.0"
+    micromark-factory-whitespace "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-classify-character "^1.0.0"
+    micromark-util-html-tag-name "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
+
+micromark-factory-destination@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz#eb815957d83e6d44479b3df640f010edad667b9f"
+  integrity sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-label@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz#cc95d5478269085cfa2a7282b3de26eb2e2dec68"
+  integrity sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-factory-space@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz#c8f40b0640a0150751d3345ed885a080b0d15faf"
+  integrity sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-title@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz#dd0fe951d7a0ac71bdc5ee13e5d1465ad7f50ea1"
+  integrity sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-whitespace@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz#798fb7489f4c8abafa7ca77eed6b5745853c9705"
+  integrity sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-character@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-1.2.0.tgz#4fedaa3646db249bc58caeb000eb3549a8ca5dcc"
+  integrity sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-chunked@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz#37a24d33333c8c69a74ba12a14651fd9ea8a368b"
+  integrity sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-classify-character@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz#6a7f8c8838e8a120c8e3c4f2ae97a2bff9190e9d"
+  integrity sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-combine-extensions@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz#192e2b3d6567660a85f735e54d8ea6e3952dbe84"
+  integrity sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-decode-numeric-character-reference@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz#b1e6e17009b1f20bc652a521309c5f22c85eb1c6"
+  integrity sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-decode-string@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz#dc12b078cba7a3ff690d0203f95b5d5537f2809c"
+  integrity sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz#92e4f565fd4ccb19e0dcae1afab9a173bbeb19a5"
+  integrity sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==
+
+micromark-util-html-tag-name@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz#48fd7a25826f29d2f71479d3b4e83e94829b3588"
+  integrity sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==
+
+micromark-util-normalize-identifier@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz#7a73f824eb9f10d442b4d7f120fecb9b38ebf8b7"
+  integrity sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-resolve-all@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz#4652a591ee8c8fa06714c9b54cd6c8e693671188"
+  integrity sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==
+  dependencies:
+    micromark-util-types "^1.0.0"
+
+micromark-util-sanitize-uri@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz#613f738e4400c6eedbc53590c67b197e30d7f90d"
+  integrity sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-subtokenize@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz#941c74f93a93eaf687b9054aeb94642b0e92edb1"
+  integrity sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-util-symbol@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz#813cd17837bdb912d069a12ebe3a44b6f7063142"
+  integrity sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==
+
+micromark-util-types@^1.0.0, micromark-util-types@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-1.1.0.tgz#e6676a8cae0bb86a2171c498167971886cb7e283"
+  integrity sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==
+
+micromark@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.2.0.tgz#1af9fef3f995ea1ea4ac9c7e2f19c48fd5c006e9"
+  integrity sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    micromark-core-commonmark "^1.0.1"
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-combine-extensions "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
 
 micromatch@^3.1.10:
   version "3.1.10"
@@ -7432,6 +7702,11 @@ move-concurrently@^1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
+
+mri@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
 ms@2.0.0:
   version "2.0.0"
@@ -8479,6 +8754,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier-plugin-jsdoc@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.0.1.tgz#7fb6741969cb503e8f40e96cdc4f5dd9b7ebd2a9"
+  integrity sha512-07q74MfX9m+xHK2+Lr4c+igiEzAKVDWhqkvlm65WoYJUlRiaV6STXcEtcZMhrPPYgNeQRgb9FJmgE/n+OI4MpQ==
+  dependencies:
+    binary-searching "^2.0.5"
+    comment-parser "^1.3.1"
+    mdast-util-from-markdown "^1.2.0"
+
 prettier@^2.2.1:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
@@ -9125,6 +9409,13 @@ rxjs@^7.5.5:
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
   dependencies:
     tslib "^2.1.0"
+
+sade@^1.7.3:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
+  integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
+  dependencies:
+    mri "^1.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -10311,6 +10602,13 @@ unique-slug@^3.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+unist-util-stringify-position@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz#03ad3348210c2d930772d64b489580c13a7db39d"
+  integrity sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
 universal-user-agent@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-4.0.1.tgz#fd8d6cb773a679a709e967ef8288a31fcc03e557"
@@ -10404,6 +10702,16 @@ uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uvu@^0.5.0:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.6.tgz#2754ca20bcb0bb59b64e9985e84d2e81058502df"
+  integrity sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==
+  dependencies:
+    dequal "^2.0.0"
+    diff "^5.0.0"
+    kleur "^4.0.3"
+    sade "^1.7.3"
 
 v8-to-istanbul@^9.0.0:
   version "9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4513,10 +4513,10 @@ eslint-plugin-prettier@^4.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-prettier@^5.0.0-alpha.2:
-  version "5.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0-alpha.2.tgz#4dd7edf88ff9bc13a3bbd91c059aae267dac4576"
-  integrity sha512-F6YBCbrRzvZwcINw3crm1+/uX/i+rJYaFErPtwCfUoPLywRfY7pwBtI3yMe5OpIotuaiws8cd29oM80ca6NQSQ==
+eslint-plugin-prettier@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz#6887780ed95f7708340ec79acfdf60c35b9be57a"
+  integrity sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==
   dependencies:
     prettier-linter-helpers "^1.0.0"
     synckit "^0.8.5"


### PR DESCRIPTION
## Description

Enable https://github.com/Agoric/agoric-sdk/pull/4903 just for these packages,
- `ertp`
- `inter-protocol`
- `vats`

There are more formatting options we could consider eventually. This adopts the minimum set to reduce the friction to getting the main value: auto-formatting type annotations.

### Security Considerations

--

### Documentation Considerations

Until #4900 is complete we'll have to selectively enable paths with the glob.

### Testing Considerations

- [X] Verify that re-reunning `yarn format` is stable and only affects opt-in packages.
- [X] verify that `yarn prettier` in a opt-in path is formatted and others aren't
- [X] verify that `formatOnSave` in a opt-in path is formatted and others aren't