### PR TITLE
WIP: Associate each payment with a home purse

### DIFF
--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -132,7 +132,7 @@
  */
 
 /**
- * @callback IssuerClaim
+ * @callback AdaptIssuerClaim
  *
  * Transfer all digital assets from the payment to a new payment and
  * delete the original. `optAmount` is optional. If `optAmount` is
@@ -143,6 +143,7 @@
  * If the payment is a promise, the operation will proceed upon
  * resolution.
  *
+ * @param {ERef<Purse>} home
  * @param {ERef<Payment>} payment
  * @param {Pattern=} optAmountShape
  * @returns {Promise<Payment>}
@@ -176,20 +177,21 @@
  */
 
 /**
- * @callback IssuerCombine
+ * @callback AdaptIssuerCombine
  *
  * Combine multiple payments into one payment.
  *
  * If any of the payments is a promise, the operation will proceed
  * upon resolution.
  *
+ * @param {ERef<Purse>} home
  * @param {ERef<Payment>[]} paymentsArray
  * @param {Amount=} optTotalAmount
  * @returns {Promise<Payment>}
  */
 
 /**
- * @callback IssuerSplit
+ * @callback AdaptIssuerSplit
  *
  * Split a single payment into two payments,
  * A and B, according to the paymentAmountA passed in.
@@ -197,13 +199,14 @@
  * If the payment is a promise, the operation will proceed upon
  * resolution.
  *
+ * @param {ERef<Purse>} home
  * @param {ERef<Payment>} payment
  * @param {Amount} paymentAmountA
  * @returns {Promise<Payment[]>}
  */
 
 /**
- * @callback IssuerSplitMany
+ * @callback AdaptIssuerSplitMany
  *
  * Split a single payment into many payments, according to the amounts
  * passed in.
@@ -211,6 +214,7 @@
  * If the payment is a promise, the operation will proceed upon
  * resolution.
  *
+ * @param {ERef<Purse>} home
  * @param {ERef<Payment>} payment
  * @param {Amount[]} amounts
  * @returns {Promise<Payment[]>}
@@ -246,10 +250,10 @@
  * @property {IssuerIsLive} isLive
  * @property {IssuerGetAmountOf} getAmountOf
  * @property {IssuerBurn} burn
- * @property {IssuerClaim} claim
- * @property {IssuerCombine} combine
- * @property {IssuerSplit} split
- * @property {IssuerSplitMany} splitMany
+ * @property {AdaptIssuerClaim} adaptClaim
+ * @property {AdaptIssuerCombine} adaptCombine
+ * @property {AdaptIssuerSplit} adaptSplit
+ * @property {AdaptIssuerSplitMany} adaptSplitMany
  */
 
 /**

--- a/packages/ERTP/test/swingsetTests/basicFunctionality/vat-alice.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/vat-alice.js
@@ -33,7 +33,8 @@ function makeAliceMaker(log) {
           const moola200 = AmountMath.make(brand, 200n);
           const [paymentToBurn, paymentToClaim, ...payments] = await E(
             issuer,
-          ).splitMany(
+          ).adaptSplitMany(
+            purse,
             newPayment,
             harden([moola200, moola200, moola200, moola200, moola200]),
           );
@@ -43,14 +44,17 @@ function makeAliceMaker(log) {
           log('burned amount: ', burnedAmount);
 
           // claim
-          const claimedPayment = await E(issuer).claim(paymentToClaim);
+          const claimedPayment = await E(issuer).adaptClaim(
+            purse,
+            paymentToClaim,
+          );
           const claimedPaymentAmount = await E(issuer).getAmountOf(
             claimedPayment,
           );
           log('claimedPayment amount: ', claimedPaymentAmount);
 
           // combine
-          const combinedPayment = E(issuer).combine(payments);
+          const combinedPayment = E(issuer).adaptCombine(purse, payments);
           const combinedPaymentAmount = await E(issuer).getAmountOf(
             combinedPayment,
           );

--- a/packages/ERTP/test/swingsetTests/splitPayments/vat-alice.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/vat-alice.js
@@ -7,10 +7,12 @@ import { AmountMath } from '../../../src/index.js';
 function makeAliceMaker(log) {
   return Far('aliceMaker', {
     make(issuer, brand, oldPaymentP) {
+      const homePurseP = E(issuer).makeEmptyPurse();
       const alice = Far('alice', {
         async testSplitPayments() {
           log('oldPayment balance:', await E(issuer).getAmountOf(oldPaymentP));
-          const splitPayments = await E(issuer).split(
+          const splitPayments = await E(issuer).adaptSplit(
+            homePurseP,
             oldPaymentP,
             AmountMath.make(brand, 10n),
           );

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -113,8 +113,10 @@ test('assertLivePayment', async t => {
 
   const paymentB = E(mintB).mintPayment(AmountMath.make(brandB, 837n));
 
+  const homePurseP = E(issuer).makeEmptyPurse();
+
   // payment is of the wrong brand
-  await t.throwsAsync(() => E(issuer).claim(paymentB), {
+  await t.throwsAsync(() => E(issuer).adaptClaim(homePurseP, paymentB), {
     message:
       '"[Alleged: fungibleB payment]" was not a live payment for brand "[Alleged: fungible brand]". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
   });
@@ -122,9 +124,9 @@ test('assertLivePayment', async t => {
   // payment is used up
   const payment = E(mint).mintPayment(AmountMath.make(brand, 10n));
   // use up payment
-  await E(issuer).claim(payment);
+  await E(issuer).adaptClaim(homePurseP, payment);
 
-  await t.throwsAsync(() => E(issuer).claim(payment), {
+  await t.throwsAsync(() => E(issuer).adaptClaim(homePurseP, payment), {
     message:
       '"[Alleged: fungible payment]" was not a live payment for brand "[Alleged: fungible brand]". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
   });
@@ -132,12 +134,13 @@ test('assertLivePayment', async t => {
 
 test('issuer.combine bad payments array', async t => {
   const { issuer } = makeIssuerKit('fungible');
+  const homePurseP = E(issuer).makeEmptyPurse();
   const notAnArray = {
     length: 2,
     split: () => {},
   };
   // @ts-expect-error Intentional wrong type for testing
-  await t.throwsAsync(() => E(issuer).combine(notAnArray), {
+  await t.throwsAsync(() => E(issuer).adaptCombine(homePurseP, notAnArray), {
     message:
       'cannot serialize Remotables with non-methods like "length" in {"length":2,"split":"[Function split]"}',
   });
@@ -147,7 +150,7 @@ test('issuer.combine bad payments array', async t => {
     split: () => {},
   });
   // @ts-ignore Intentional wrong type for testing
-  await t.throwsAsync(() => E(issuer).combine(notAnArray2), {
+  await t.throwsAsync(() => E(issuer).adaptCombine(homePurseP, notAnArray2), {
     message:
       '"fromPaymentsArray" "[Alleged: notAnArray2]" must be a pass-by-copy array, not "remotable"',
   });

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -3,6 +3,7 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { Far } from '@endo/marshal';
+import { E } from '@endo/eventual-send';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { assert } from '@agoric/assert';
 
@@ -98,6 +99,7 @@ test('non-fungible tokens example', async t => {
     issuer: balletTicketIssuer,
     brand,
   } = makeIssuerKit('Agoric Ballet Opera tickets', AssetKind.SET);
+  const homePurseP = E(balletTicketIssuer).makeEmptyPurse();
 
   const startDateString = new Date(2020, 1, 17, 20, 30).toISOString();
 
@@ -122,14 +124,18 @@ test('non-fungible tokens example', async t => {
   // Alice will buy ticket 1
   const paymentForAlice = balletTicketPayments[0];
   // Bob will buy tickets 3 and 4
-  const paymentForBob = balletTicketIssuer.combine(
+  const paymentForBob = balletTicketIssuer.adaptCombine(
+    homePurseP,
     harden([balletTicketPayments[2], balletTicketPayments[3]]),
   );
 
   // ALICE SIDE
   // Alice bought ticket 1 and has access to the balletTicketIssuer, because
   // it's public
-  const myTicketPaymentAlice = await balletTicketIssuer.claim(paymentForAlice);
+  const myTicketPaymentAlice = await balletTicketIssuer.adaptClaim(
+    homePurseP,
+    paymentForAlice,
+  );
   // the call to claim() hasn't thrown, so Alice knows myTicketPaymentAlice
   // is a genuine 'Agoric Ballet Opera tickets' payment and she has exclusive
   // access to its handle
@@ -145,7 +151,10 @@ test('non-fungible tokens example', async t => {
   // BOB SIDE
   // Bob bought ticket 3 and 4 and has access to the balletTicketIssuer, because
   // it's public
-  const bobTicketPayment = await balletTicketIssuer.claim(paymentForBob);
+  const bobTicketPayment = await balletTicketIssuer.adaptClaim(
+    homePurseP,
+    paymentForBob,
+  );
   const paymentAmountBob = await balletTicketIssuer.getAmountOf(
     bobTicketPayment,
   );

--- a/packages/run-protocol/test/vaultFactory/test-bootstrapPayment.js
+++ b/packages/run-protocol/test/vaultFactory/test-bootstrapPayment.js
@@ -100,7 +100,11 @@ test('bootstrap payment - only minted once', async t => {
 
   const issuers = { RUN: runIssuer };
 
-  const claimedPayment = await E(issuers.RUN).claim(bootstrapPayment);
+  const runPurseP = E(runIssuer).makeEmptyPurse();
+  const claimedPayment = await E(issuers.RUN).adaptClaim(
+    runPurseP,
+    bootstrapPayment,
+  );
   const bootstrapAmount = await E(issuers.RUN).getAmountOf(claimedPayment);
 
   t.true(
@@ -114,9 +118,12 @@ test('bootstrap payment - only minted once', async t => {
 
   const bootstrapPayment2 = E(creatorFacet).getBootstrapPayment();
 
-  await t.throwsAsync(() => E(issuers.RUN).claim(bootstrapPayment2), {
-    message: /was not a live payment/,
-  });
+  await t.throwsAsync(
+    () => E(issuers.RUN).adaptClaim(runPurseP, bootstrapPayment2),
+    {
+      message: /was not a live payment/,
+    },
+  );
 });
 
 test('bootstrap payment - default value is 0n', async t => {

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -346,6 +346,7 @@ test('first', async t => {
     runKit: { issuer: runIssuer, brand: runBrand },
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
+  const runPurseP = E(runIssuer).makeEmptyPurse();
 
   // Add a vault that will lend on aeth collateral
   const rates = makeRates(runBrand);
@@ -396,7 +397,8 @@ test('first', async t => {
   // partially payback
   const collateralWanted = AmountMath.make(aethBrand, 100n);
   const paybackAmount = AmountMath.make(runBrand, 200n);
-  const [paybackPayment, _remainingPayment] = await E(runIssuer).split(
+  const [paybackPayment, _remainingPayment] = await E(runIssuer).adaptSplit(
+    runPurseP,
     runLent,
     paybackAmount,
   );
@@ -1075,6 +1077,7 @@ test('adjust balances', async t => {
     runKit: { issuer: runIssuer, brand: runBrand },
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
+  const runPurseP = E(runIssuer).makeEmptyPurse();
 
   const rates = makeRates(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
@@ -1132,7 +1135,8 @@ test('adjust balances', async t => {
   runDebtLevel = AmountMath.subtract(runDebtLevel, depositRunAmount);
   collateralLevel = AmountMath.add(collateralLevel, collateralIncrement);
 
-  const [paybackPayment, _remainingPayment] = await E(runIssuer).split(
+  const [paybackPayment, _remainingPayment] = await E(runIssuer).adaptSplit(
+    runPurseP,
     runLent,
     depositRunAmount,
   );
@@ -1328,6 +1332,7 @@ test('transfer vault', async t => {
     runKit: { issuer: runIssuer, brand: runBrand },
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
+  const runPurseP = E(runIssuer).makeEmptyPurse();
 
   const rates = makeRates(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
@@ -1411,7 +1416,8 @@ test('transfer vault', async t => {
   t.deepEqual(lentAmount, aliceLoanAmount, 'received 5000 RUN');
   const borrowedRun = await aliceProceeds.RUN;
   const payoffRun2 = AmountMath.make(runBrand, 600n);
-  const [paybackPayment, _remainingPayment] = await E(runIssuer).split(
+  const [paybackPayment, _remainingPayment] = await E(runIssuer).adaptSplit(
+    runPurseP,
     borrowedRun,
     payoffRun2,
   );
@@ -1493,6 +1499,7 @@ test('overdeposit', async t => {
     runKit: { issuer: runIssuer, brand: runBrand },
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
+  const runPurseP = E(runIssuer).makeEmptyPurse();
 
   const rates = makeRates(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
@@ -1566,7 +1573,10 @@ test('overdeposit', async t => {
 
   // overpay debt ///////////////////////////////////// (give RUN)
 
-  const combinedRun = await E(runIssuer).combine(harden([borrowedRun, bobRun]));
+  const combinedRun = await E(runIssuer).adaptCombine(
+    runPurseP,
+    harden([borrowedRun, bobRun]),
+  );
   const depositRun2 = AmountMath.make(runBrand, 6000n);
 
   const aliceOverpaySeat = await E(zoe).offer(
@@ -1953,6 +1963,7 @@ test('close loan', async t => {
     runKit: { issuer: runIssuer, brand: runBrand },
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
+  const runPurseP = E(runIssuer).makeEmptyPurse();
 
   const rates = makeRates(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
@@ -2024,7 +2035,10 @@ test('close loan', async t => {
 
   // close loan, using Bob's RUN /////////////////////////////////////
 
-  const runRepayment = await E(runIssuer).combine(harden([bobRun, runLent]));
+  const runRepayment = await E(runIssuer).adaptCombine(
+    runPurseP,
+    harden([bobRun, runLent]),
+  );
 
   /** @type {UserSeat<string>} */
   const aliceCloseSeat = await E(zoe).offer(

--- a/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
@@ -25,6 +25,7 @@ async function build(name, zoe, issuers, payments, publicFacet) {
   const [moolaPurseP, simoleanPurseP] = purses;
 
   const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   async function preReport(quiet) {
     const useLog = quiet ? () => {} : log;
@@ -78,7 +79,10 @@ async function build(name, zoe, issuers, payments, publicFacet) {
     await preReport(quiet);
 
     const invitation = await invitationP;
-    const exclInvitation = await E(invitationIssuer).claim(invitation);
+    const exclInvitation = await E(invitationIssuer).adaptClaim(
+      invitationPurseP,
+      invitation,
+    );
 
     const myBuyOrderProposal = harden({
       want: { Asset: moola(1) },

--- a/packages/swingset-runner/demo/swapBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/swapBenchmark/exchanger.js
@@ -30,6 +30,7 @@ async function build(name, zoe, issuers, payments, installations) {
   });
   const invitationIssuer = await E(zoe).getInvitationIssuer();
   const { atomicSwap } = installations;
+  const invitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   async function preReport() {
     await showPurseBalance(moolaPurseP, `${name} moola before`, log);
@@ -78,7 +79,10 @@ async function build(name, zoe, issuers, payments, installations) {
   async function respondToSwap(invitation) {
     await preReport();
 
-    const exclInvitation = await E(invitationIssuer).claim(invitation);
+    const exclInvitation = await E(invitationIssuer).adaptClaim(
+      invitationPurseP,
+      invitation,
+    );
 
     const buyProposal = harden({
       want: { Asset: moola(1) },

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -13,6 +13,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
   const [moolaPayment, simoleanPayment] = payments;
   const [moolaIssuer, simoleanIssuer, bucksIssuer] = issuers;
   const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   let secondPriceAuctionSeatP;
 
@@ -20,7 +21,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     doAutomaticRefund: async invitation => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
 
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
@@ -71,7 +75,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob claims all with the Zoe invitationIssuer
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       const bobIntendedProposal = harden({
@@ -137,7 +144,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob claims all with the Zoe invitationIssuer
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
 
       const { UnderlyingAsset, StrikePrice } = await E(zoe).getIssuers(
         instance,
@@ -223,7 +233,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -269,7 +282,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -319,7 +335,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     doSimpleExchange: async invitation => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       assert(
@@ -360,7 +379,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
     doSimpleExchangeUpdates: async (invitationP, m, s) => {
-      const invitation = await E(invitationIssuer).claim(invitationP);
+      const invitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitationP,
+      );
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
@@ -530,7 +552,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     },
 
     doOTCDesk: async untrustedInvitation => {
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       assert(invitationValue.installation === installations.coveredCall);
 

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -12,12 +12,16 @@ const build = async (log, zoe, issuers, payments, installations) => {
   const [_moolaPayment, simoleanPayment] = payments;
   const [moolaIssuer, simoleanIssuer] = issuers;
   const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   let secondPriceAuctionSeatP;
 
   return Far('carolstuff', {
     doSecondPriceAuctionBid: async invitationP => {
-      const invitation = await E(invitationIssuer).claim(invitationP);
+      const invitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitationP,
+      );
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -13,6 +13,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
   const [_moolaPayment, simoleanPayment, bucksPayment] = payments;
   const [moolaIssuer, simoleanIssuer, bucksIssuer] = issuers;
   const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   let secondPriceAuctionSeatP;
 
@@ -21,7 +22,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -71,7 +75,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );

--- a/packages/vats/src/demoIssuers.js
+++ b/packages/vats/src/demoIssuers.js
@@ -265,6 +265,7 @@ export const connectFaucet = async ({
     zoe,
   });
   const runIssuer = await E(zoe).getFeeIssuer();
+  const runPurseP = E(runIssuer).makeEmptyPurse();
   const runBrand = await E(runIssuer).getBrand();
   const runIssuerKit = {
     issuer: runIssuer,
@@ -274,7 +275,8 @@ export const connectFaucet = async ({
         // TODO: what happens if faucetRunSupply doesn't have enough
         // remaining?
         let fragment;
-        [fragment, faucetRunSupply] = await E(runIssuer).split(
+        [fragment, faucetRunSupply] = await E(runIssuer).adaptSplit(
+          runPurseP,
           faucetRunSupply,
           amount,
         );

--- a/packages/vats/src/demoIssuers.js
+++ b/packages/vats/src/demoIssuers.js
@@ -404,11 +404,13 @@ export const splitAllCentralPayments = async (
   balances,
   central,
 ) => {
+  const runPurseP = E(central.issuer).makeEmptyPurse();
   const ammPoolAmounts = values(balances).map(b =>
     AmountMath.make(central.brand, b),
   );
 
-  const allPayments = await E(central.issuer).splitMany(
+  const allPayments = await E(central.issuer).adaptSplitMany(
+    runPurseP,
     bootstrapPayment,
     ammPoolAmounts,
   );

--- a/packages/vats/test/test-vpurse.js
+++ b/packages/vats/test/test-vpurse.js
@@ -271,10 +271,11 @@ test('vpurse.deposit', async t => {
 test('vpurse.deposit promise', async t => {
   t.plan(2);
   const { issuer, mint, brand, vpurse } = setup(t);
+  const homePurseP = E(issuer).makeEmptyPurse();
   const fungible25 = AmountMath.make(brand, 25n);
 
   const payment = mint.mintPayment(fungible25);
-  const exclusivePaymentP = E(issuer).claim(payment);
+  const exclusivePaymentP = E(issuer).adaptClaim(homePurseP, payment);
 
   await t.throwsAsync(
     // @ts-ignore deliberate invalid arguments for testing

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -14,6 +14,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
   const [moolaPayment, simoleanPayment] = payments;
   const [moolaIssuer, simoleanIssuer, bucksIssuer] = issuers;
   const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   let secondPriceAuctionSeatP;
 
@@ -21,7 +22,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     doAutomaticRefund: async invitation => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
 
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
@@ -72,7 +76,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob claims all with the Zoe invitationIssuer
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       const bobIntendedProposal = harden({
@@ -138,7 +145,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob claims all with the Zoe invitationIssuer
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
 
       const { UnderlyingAsset, StrikePrice } = await E(zoe).getIssuers(
         instance,
@@ -224,7 +234,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -270,7 +283,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -320,7 +336,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     doSimpleExchange: async invitation => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       assert(
@@ -361,7 +380,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
     doSimpleExchangeUpdates: async (invitationP, m, s) => {
-      const invitation = await E(invitationIssuer).claim(invitationP);
+      const invitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitationP,
+      );
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
@@ -535,7 +557,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     },
 
     doOTCDesk: async untrustedInvitation => {
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       assert(invitationValue.installation === installations.coveredCall);
 

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -12,12 +12,16 @@ const build = async (log, zoe, issuers, payments, installations) => {
   const [_moolaPayment, simoleanPayment] = payments;
   const [moolaIssuer, simoleanIssuer] = issuers;
   const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   let secondPriceAuctionSeatP;
 
   return Far('build', {
     doSecondPriceAuctionBid: async invitationP => {
-      const invitation = await E(invitationIssuer).claim(invitationP);
+      const invitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitationP,
+      );
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -13,6 +13,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
   const [_moolaPayment, simoleanPayment, bucksPayment] = payments;
   const [moolaIssuer, simoleanIssuer, bucksIssuer] = issuers;
   const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   let secondPriceAuctionSeatP;
 
@@ -21,7 +22,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -71,7 +75,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -86,14 +86,17 @@ test('zoe - atomicSwap', async t => {
   const makeBob = (installation, simoleanPayment) => {
     const moolaPurse = moolaKit.issuer.makeEmptyPurse();
     const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
+    const invitationIssuerP = E(zoe).getInvitationIssuer();
+    const invitationPurseP = E(invitationIssuerP).makeEmptyPurse();
     return Far('bob', {
       offer: async untrustedInvitation => {
-        const invitationIssuer = await E(zoe).getInvitationIssuer();
-
         // Bob is able to use the trusted invitationIssuer from Zoe to
         // transform an untrusted invitation that Alice also has access to, to
         // an
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await E(invitationIssuerP).adaptClaim(
+          invitationPurseP,
+          untrustedInvitation,
+        );
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
         t.is(
           invitationValue.installation,
@@ -247,17 +250,21 @@ test('zoe - non-fungible atomicSwap', async t => {
   };
 
   const makeBob = (installation, rpgPayment) => {
+    const invitationIssuerP = E(zoe).getInvitationIssuer();
+    const invitationPurseP = E(invitationIssuerP).makeEmptyPurse();
+
     return Far('bob', {
       offer: async (untrustedInvitation, calico37Amount, vorpalAmount) => {
         const ccPurse = ccIssuer.makeEmptyPurse();
         const rpgPurse = rpgIssuer.makeEmptyPurse();
 
-        const invitationIssuer = await E(zoe).getInvitationIssuer();
-
         // Bob is able to use the trusted invitationIssuer from Zoe to
         // transform an untrusted invitation that Alice also has access to, to
         // an
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await E(invitationIssuerP).adaptClaim(
+          invitationPurseP,
+          untrustedInvitation,
+        );
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
 
         t.is(
@@ -345,6 +352,7 @@ test('zoe - atomicSwap like-for-like', async t => {
   t.plan(13);
   const { moolaIssuer, moolaMint, moola, zoe, vatAdminState } = setup();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // pack the contract
   const bundle = await bundleSource(atomicSwapRoot);
@@ -390,7 +398,8 @@ test('zoe - atomicSwap like-for-like', async t => {
   // counter-party.
 
   const bobInvitationP = E(aliceSeat).getOfferResult();
-  const bobExclusiveInvitation = await E(invitationIssuer).claim(
+  const bobExclusiveInvitation = await E(invitationIssuer).adaptClaim(
+    invitationPurseP,
     bobInvitationP,
   );
   const bobInvitationValue = await E(zoe).getInvitationDetails(

--- a/packages/zoe/test/unitTests/contracts/test-auction.js
+++ b/packages/zoe/test/unitTests/contracts/test-auction.js
@@ -91,14 +91,17 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
   const makeBob = (installation, simoleanPayment) => {
     const moolaPurse = moolaKit.issuer.makeEmptyPurse();
     const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
+    const invitationIssuerP = E(zoe).getInvitationIssuer();
+    const invitationPurseP = E(invitationIssuerP).makeEmptyPurse();
     return Far('bob', {
       offer: async untrustedInvitation => {
-        const invitationIssuer = await E(zoe).getInvitationIssuer();
-
         // Bob is able to use the trusted invitationIssuer from Zoe to
         // transform an untrusted invitation that Alice also has access to, to
         // an
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await E(invitationIssuerP).adaptClaim(
+          invitationPurseP,
+          untrustedInvitation,
+        );
 
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
 
@@ -163,10 +166,14 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
   const makeLosingBidder = (bidAmount, simoleanPayment) => {
     const moolaPurse = moolaKit.issuer.makeEmptyPurse();
     const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
+    const invitationIssuerP = E(zoe).getInvitationIssuer();
+    const invitationPurseP = E(invitationIssuerP).makeEmptyPurse();
     return Far('losing bidder', {
       offer: async untrustedInvitation => {
-        const invitationIssuer = await E(zoe).getInvitationIssuer();
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await E(invitationIssuerP).adaptClaim(
+          invitationPurseP,
+          untrustedInvitation,
+        );
 
         const proposal = harden({
           give: { Bid: bidAmount },
@@ -546,16 +553,19 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   const bobMoolaPayment = moolaMint.mintPayment(moola(11n));
   const bobCcPurse = ccIssuer.makeEmptyPurse();
   const bobMoolaPurse = moolaIssuer.makeEmptyPurse();
+  const bobInvitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // Setup Carol
   const carolMoolaPayment = moolaMint.mintPayment(moola(7n));
   const carolCcPurse = ccIssuer.makeEmptyPurse();
   const carolMoolaPurse = moolaIssuer.makeEmptyPurse();
+  const carolInvitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // Setup Dave
   const daveMoolaPayment = moolaMint.mintPayment(moola(5n));
   const daveCcPurse = ccIssuer.makeEmptyPurse();
   const daveMoolaPurse = moolaIssuer.makeEmptyPurse();
+  const daveInvitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // Alice creates a secondPriceAuction instance
 
@@ -597,7 +607,10 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   // Alice spreads the invitations far and wide and Bob decides he
   // wants to participate in the auction.
-  const bobExclusiveInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const bobExclusiveInvitation = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    bobInvitation,
+  );
   const bobInvitationValue = await E(zoe).getInvitationDetails(
     bobExclusiveInvitation,
   );
@@ -635,7 +648,8 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   // Carol decides to bid for the one cc
 
-  const carolExclusiveInvitation = await E(invitationIssuer).claim(
+  const carolExclusiveInvitation = await E(invitationIssuer).adaptClaim(
+    carolInvitationPurseP,
     carolInvitation,
   );
   const carolInvitationValue = await E(zoe).getInvitationDetails(
@@ -678,7 +692,8 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   );
 
   // Dave decides to bid for the one moola
-  const daveExclusiveInvitation = await E(invitationIssuer).claim(
+  const daveExclusiveInvitation = await E(invitationIssuer).adaptClaim(
+    daveInvitationPurseP,
     daveInvitation,
   );
   const daveInvitationValue = await E(zoe).getInvitationDetails(
@@ -894,14 +909,17 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
   const makeBob = (installation, simoleanPayment) => {
     const moolaPurse = moolaKit.issuer.makeEmptyPurse();
     const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
+    const invitationIssuerP = E(zoe).getInvitationIssuer();
+    const invitationPurseP = E(invitationIssuerP).makeEmptyPurse();
     return Far('bob', {
       offer: async untrustedInvitation => {
-        const invitationIssuer = await E(zoe).getInvitationIssuer();
-
         // Bob is able to use the trusted invitationIssuer from Zoe to
         // transform an untrusted invitation that Alice also has access to, to
         // an
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await E(invitationIssuerP).adaptClaim(
+          invitationPurseP,
+          untrustedInvitation,
+        );
 
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
 
@@ -966,10 +984,14 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
   const makeLosingBidder = (bidAmount, simoleanPayment) => {
     const moolaPurse = moolaKit.issuer.makeEmptyPurse();
     const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
+    const invitationIssuerP = E(zoe).getInvitationIssuer();
+    const invitationPurseP = E(invitationIssuerP).makeEmptyPurse();
     return Far('losing bidder', {
       offer: async untrustedInvitation => {
-        const invitationIssuer = await E(zoe).getInvitationIssuer();
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await E(invitationIssuerP).adaptClaim(
+          invitationPurseP,
+          untrustedInvitation,
+        );
 
         const proposal = harden({
           give: { Bid: bidAmount },

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -112,6 +112,7 @@ test('zoe with automaticRefund', async t => {
   const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
   const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(17n));
+  const bobInvitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
@@ -154,7 +155,10 @@ test('zoe with automaticRefund', async t => {
   // will do a claim on the invitation with the Zoe invitation issuer and
   // will check that the installation and terms match what he
   // expects
-  const exclusBobInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const exclusBobInvitation = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    bobInvitation,
+  );
 
   const {
     value: [bobInvitationValue],
@@ -235,9 +239,11 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
   const { moolaR, simoleanR, moola, simoleans, zoe, vatAdminState } = setup();
 
   // Setup Alice
+  const aliceMoolaPurseP = E(moolaR.issuer).makeEmptyPurse();
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(30n));
   const moola10 = moola(10n);
-  const aliceMoolaPayments = await moolaR.issuer.splitMany(
+  const aliceMoolaPayments = await moolaR.issuer.adaptSplitMany(
+    aliceMoolaPurseP,
     aliceMoolaPayment,
     harden([moola10, moola10, moola10]),
   );

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -51,6 +51,7 @@ test('autoSwap API interactions, no jig', async t => {
   // Setup Bob
   const bobMoolaPayment = moolaMint.mintPayment(moola(3n));
   const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(3n));
+  const bobInvitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // Alice creates an autoswap instance
   const issuerKeywordRecord = harden({
@@ -107,7 +108,10 @@ test('autoSwap API interactions, no jig', async t => {
   const bobInvitation = await E(publicFacet).makeSwapInvitation();
 
   // Bob claims it
-  const bobExclInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const bobExclInvitation = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    bobInvitation,
+  );
   const bobInstance = await E(zoe).getInstance(bobExclInvitation);
   const bobInstallation = await E(zoe).getInstallation(bobExclInvitation);
   t.is(bobInstallation, installation, `installation`);

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -40,6 +40,7 @@ test('barter with valid offers', async t => {
 
   // Setup Bob
   const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(7n));
+  const bobInvitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // 1: Simon creates a barter instance and spreads the instance far and
   // wide with instructions on how to use it.
@@ -77,7 +78,10 @@ test('barter with valid offers', async t => {
   const bobInstallation = await E(zoe).getInstallation(bobInvitation);
 
   // 4: Bob decides to join.
-  const bobExclusiveInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const bobExclusiveInvitation = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    bobInvitation,
+  );
 
   t.is(bobInstallation, installation);
   t.is(bobInstance, instance);

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
@@ -47,6 +47,8 @@ test('zoe - coveredCall with swap for invitation', async t => {
 
   vatAdminState.installBundle('b1-atomicswap', atomicSwapBundle);
   const swapInstallationId = await E(zoe).installBundleID('b1-atomicswap');
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const invitationBrand = await E(invitationIssuer).getBrand();
 
   // Setup Alice
   // Alice starts with 3 moola
@@ -59,6 +61,7 @@ test('zoe - coveredCall with swap for invitation', async t => {
   const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
   const bobBucksPurse = bucksR.issuer.makeEmptyPurse();
+  const bobInvitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // Setup Dave
   // Dave starts with 1 buck
@@ -113,9 +116,10 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // party in the covered call: Did the covered call use the
   // expected covered call installation (code)? Does it use the issuers
   // that he expects (moola and simoleans)?
-  const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const invitationBrand = await E(invitationIssuer).getBrand();
-  const bobExclOption = await E(invitationIssuer).claim(optionP);
+  const bobExclOption = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    optionP,
+  );
   const optionAmount = await E(invitationIssuer).getAmountOf(bobExclOption);
   const optionDesc = optionAmount.value[0];
   t.is(optionDesc.installation, coveredCallInstallation);

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -117,13 +117,16 @@ test('zoe - coveredCall', async t => {
     const moolaPurse = moolaKit.issuer.makeEmptyPurse();
     const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
     const bucksPurse = bucksKit.issuer.makeEmptyPurse();
+    const invitationIssuerP = E(zoe).getInvitationIssuer();
+    const invitationPurseP = E(invitationIssuerP).makeEmptyPurse();
     return Far('bob', {
       offer: async untrustedInvitation => {
-        const invitationIssuer = await E(zoe).getInvitationIssuer();
-
         // Bob is able to use the trusted invitationIssuer from Zoe to
         // transform an untrusted invitation that Alice also has access to
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await E(invitationIssuerP).adaptClaim(
+          invitationPurseP,
+          untrustedInvitation,
+        );
 
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
 
@@ -235,6 +238,7 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     'b1-coveredcall',
   );
   const timer = buildManualTimer(console.log);
+  const invitationIssuerP = E(zoe).getInvitationIssuer();
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3n));
@@ -245,6 +249,7 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
   const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7n));
   const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  const bobInvitationPurseP = E(invitationIssuerP).makeEmptyPurse();
 
   // Alice creates a coveredCall instance
   const issuerKeywordRecord = harden({
@@ -286,7 +291,10 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
   // already escrowed.
 
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const bobExclOption = await E(invitationIssuer).claim(optionP);
+  const bobExclOption = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    optionP,
+  );
   const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
   t.is(optionValue.installation, coveredCallInstallation);
   t.is(optionValue.description, 'exerciseOption');
@@ -372,6 +380,7 @@ test('zoe - coveredCall with swap for invitation', async t => {
 
   vatAdminState.installBundle('b1-atomicswap', atomicSwapBundle);
   const swapInstallationId = await E(zoe).installBundleID('b1-atomicswap');
+  const invitationIssuerP = E(zoe).getInvitationIssuer();
 
   // Setup Alice
   // Alice starts with 3 moola
@@ -384,6 +393,7 @@ test('zoe - coveredCall with swap for invitation', async t => {
   const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
   const bobBucksPurse = bucksR.issuer.makeEmptyPurse();
+  const bobInvitationPurseP = E(invitationIssuerP).makeEmptyPurse();
 
   // Setup Dave
   // Dave starts with 1 buck
@@ -440,7 +450,10 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // that he expects (moola and simoleans)?
   const invitationIssuer = await E(zoe).getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
-  const bobExclOption = await E(invitationIssuer).claim(optionP);
+  const bobExclOption = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    optionP,
+  );
   const optionAmount = await E(invitationIssuer).getAmountOf(bobExclOption);
   const optionDesc = optionAmount.value[0];
   t.is(optionDesc.installation, coveredCallInstallation);
@@ -634,6 +647,7 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   const coveredCallInstallation = await E(zoe).installBundleID(
     'b1-coveredcall',
   );
+  const invitationIssuerP = E(zoe).getInvitationIssuer();
 
   // Setup Alice
   // Alice starts with 3 moola
@@ -646,6 +660,7 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
   const bobBucksPurse = bucksR.issuer.makeEmptyPurse();
+  const bobInvitationPurseP = E(invitationIssuerP).makeEmptyPurse();
 
   // Setup Dave
   // Dave starts with 1 buck and 7 simoleans
@@ -654,6 +669,7 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   const daveMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const daveSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
   const daveBucksPurse = bucksR.issuer.makeEmptyPurse();
+  const daveInvitationPurseP = E(invitationIssuerP).makeEmptyPurse();
 
   // Alice creates a coveredCall instance of moola for simoleans
   const issuerKeywordRecord = harden({
@@ -701,7 +717,10 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   // expected covered call installation (code)? Does it use the issuers
   // that he expects (moola and simoleans)?
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const bobExclOption = await E(invitationIssuer).claim(optionP);
+  const bobExclOption = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    optionP,
+  );
   const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
   t.is(optionValue.installation, coveredCallInstallation);
   t.is(optionValue.description, 'exerciseOption');
@@ -752,7 +771,10 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   // Dave is looking to buy the option to trade his 7 simoleans for
   // 3 moola, and is willing to pay 1 buck for the option. He
   // checks that this invitation matches what he wants
-  const daveExclOption = await E(invitationIssuer).claim(invitationForDaveP);
+  const daveExclOption = await E(invitationIssuer).adaptClaim(
+    daveInvitationPurseP,
+    invitationForDaveP,
+  );
   const daveOptionValue = await E(zoe).getInvitationDetails(daveExclOption);
   t.is(daveOptionValue.installation, coveredCallInstallation);
   t.is(daveOptionValue.description, 'exerciseOption');
@@ -912,6 +934,7 @@ test('zoe - coveredCall non-fungible', async t => {
     'b1-coveredcall',
   );
   const timer = buildManualTimer(console.log);
+  const invitationIssuerP = E(zoe).getInvitationIssuer();
 
   // Setup Alice
   const growlTiger = harden(['GrowlTiger']);
@@ -930,6 +953,7 @@ test('zoe - coveredCall non-fungible', async t => {
   const bobRpgPayment = rpgMint.mintPayment(aGloriousShieldAmount);
   const bobCcPurse = ccIssuer.makeEmptyPurse();
   const bobRpgPurse = rpgIssuer.makeEmptyPurse();
+  const bobInvitationPurseP = E(invitationIssuerP).makeEmptyPurse();
 
   // Alice creates a coveredCall instance
   const issuerKeywordRecord = harden({
@@ -965,7 +989,10 @@ test('zoe - coveredCall non-fungible', async t => {
   // already escrowed.
 
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const bobExclOption = await E(invitationIssuer).claim(optionP);
+  const bobExclOption = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    optionP,
+  );
   const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
   t.is(optionValue.installation, coveredCallInstallation);
   t.is(optionValue.description, 'exerciseOption');

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -39,14 +39,18 @@ test('zoe - mint payments', async t => {
   };
 
   const makeBob = installation => {
+    const invitationIssuerP = E(zoe).getInvitationIssuer();
+    const invitationPurseP = E(invitationIssuerP).makeEmptyPurse();
     return {
       offer: async untrustedInvitation => {
-        const invitationIssuer = E(zoe).getInvitationIssuer();
-        const invitation = E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = E(invitationIssuerP).adaptClaim(
+          invitationPurseP,
+          untrustedInvitation,
+        );
 
         const {
           value: [invitationValue],
-        } = await E(invitationIssuer).getAmountOf(invitation);
+        } = await E(invitationIssuerP).getAmountOf(invitation);
 
         t.is(
           invitationValue.installation,
@@ -118,14 +122,18 @@ test('zoe - mint payments with unrelated give and want', async t => {
   };
 
   const makeBob = (installation, moolaPayment) => {
+    const invitationIssuerP = E(zoe).getInvitationIssuer();
+    const invitationPurseP = E(invitationIssuerP).makeEmptyPurse();
     return {
       offer: async untrustedInvitation => {
-        const invitationIssuer = E(zoe).getInvitationIssuer();
-        const invitation = E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = E(invitationIssuerP).adaptClaim(
+          invitationPurseP,
+          untrustedInvitation,
+        );
 
         const {
           value: [invitationValue],
-        } = await E(invitationIssuer).getAmountOf(invitation);
+        } = await E(invitationIssuerP).getAmountOf(invitation);
 
         t.is(
           invitationValue.installation,

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -118,14 +118,18 @@ const makeBob = (
   const moolaPurse = moolaIssuer.makeEmptyPurse();
   const simoleanPurse = simoleanIssuer.makeEmptyPurse();
   const bucksPurse = bucksIssuer.makeEmptyPurse();
+  const invitationIssuerP = E(zoe).getInvitationIssuer();
+  const invitationPurseP = E(invitationIssuerP).makeEmptyPurse();
 
   moolaPurse.deposit(moolaPayment);
   simoleanPurse.deposit(simoleanPayment);
   bucksPurse.deposit(bucksPayment);
   return Far('Bob', {
     offerOk: async untrustedInvitation => {
-      const invitationIssuer = await E(zoe).getInvitationIssuer();
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await E(invitationIssuerP).adaptClaim(
+        invitationPurseP,
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       t.is(
         invitationValue.installation,
@@ -176,7 +180,10 @@ const makeBob = (
     },
     offerExpired: async untrustedInvitation => {
       const invitationIssuer = await E(zoe).getInvitationIssuer();
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       t.is(
         invitationValue.installation,
@@ -230,7 +237,10 @@ const makeBob = (
     },
     offerWantTooMuch: async untrustedInvitation => {
       const invitationIssuer = await E(zoe).getInvitationIssuer();
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       t.is(
         invitationValue.installation,
@@ -292,7 +302,10 @@ const makeBob = (
     },
     offerNotCovered: async untrustedInvitation => {
       const invitationIssuer = await E(zoe).getInvitationIssuer();
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await E(invitationIssuer).adaptClaim(
+        invitationPurseP,
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       t.is(
         invitationValue.installation,

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -150,6 +150,7 @@ test(`mint and sell opera tickets`, async t => {
 
   const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const invitationIssuerP = E(zoe).getInvitationIssuer();
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   vatAdminState.installBundle('b1-nft', mintAndSellNFTBundle);
@@ -278,12 +279,16 @@ test(`mint and sell opera tickets`, async t => {
     );
   };
 
+  const jokerInvitationPurseP = E(invitationIssuerP).makeEmptyPurse();
   // === Joker part ===
   // Joker starts with 100 moolas
   // Joker attempts to buy ticket 1 (and should fail)
   const jokerBuysTicket1 = async (untrustedInvitation, moola100Payment) => {
     const invitationIssuer = E(zoe).getInvitationIssuer();
-    const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+    const invitation = await E(invitationIssuer).adaptClaim(
+      jokerInvitationPurseP,
+      untrustedInvitation,
+    );
     const {
       value: [{ instance: ticketSalesInstance }],
     } = await E(invitationIssuer).getAmountOf(invitation);
@@ -356,7 +361,10 @@ test(`mint and sell opera tickets`, async t => {
     moola100Payment,
   ) => {
     const invitationIssuer = E(zoe).getInvitationIssuer();
-    const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+    const invitation = await E(invitationIssuer).adaptClaim(
+      jokerInvitationPurseP,
+      untrustedInvitation,
+    );
     const {
       value: [{ instance: ticketSalesInstance }],
     } = await E(invitationIssuer).getAmountOf(invitation);
@@ -421,12 +429,16 @@ test(`mint and sell opera tickets`, async t => {
     );
   };
 
+  const bobInvitationPurseP = E(invitationIssuerP).makeEmptyPurse();
+
   const bobBuysTicket2And3 = async (untrustedInvitation, moola100Payment) => {
-    const invitationIssuer = E(zoe).getInvitationIssuer();
-    const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+    const invitation = await E(invitationIssuerP).adaptClaim(
+      bobInvitationPurseP,
+      untrustedInvitation,
+    );
     const {
       value: [{ instance: ticketSalesInstance }],
-    } = await E(invitationIssuer).getAmountOf(invitation);
+    } = await E(invitationIssuerP).getAmountOf(invitation);
     const ticketSalesPublicFacet = await E(zoe).getPublicFacet(
       ticketSalesInstance,
     );

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -43,6 +43,7 @@ test('simpleExchange with valid offers', async t => {
 
   // Setup Bob
   const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(7n));
+  const bobInvitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // 1: Alice creates a simpleExchange instance and spreads the publicFacet far
   // and wide with instructions on how to call makeInvitation().
@@ -121,7 +122,10 @@ test('simpleExchange with valid offers', async t => {
   const bobInstallation = await E(zoe).getInstallation(bobInvitation);
 
   // 5: Bob decides to join.
-  const bobExclusiveInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const bobExclusiveInvitation = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    bobInvitation,
+  );
 
   const bobIssuers = await E(zoe).getIssuers(instance);
 
@@ -232,6 +236,7 @@ test('simpleExchange with multiple sell offers', async t => {
   const aliceSimoleanPurse = simoleanIssuer.makeEmptyPurse();
   await aliceMoolaPurse.deposit(aliceMoolaPayment);
   await aliceSimoleanPurse.deposit(aliceSimoleanPayment);
+  const aliceInvitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // 1: Simon creates a simpleExchange instance and spreads the publicFacet
   // far and wide with instructions on how to use it.
@@ -260,7 +265,8 @@ test('simpleExchange with multiple sell offers', async t => {
   );
 
   // 5: Alice adds another sell order to the exchange
-  const aliceInvitation2 = await E(invitationIssuer).claim(
+  const aliceInvitation2 = await E(invitationIssuer).adaptClaim(
+    aliceInvitationPurseP,
     await E(publicFacet).makeInvitation(),
   );
   const aliceSale2OrderProposal = harden({
@@ -278,7 +284,8 @@ test('simpleExchange with multiple sell offers', async t => {
   );
 
   // 5: Alice adds a buy order to the exchange
-  const aliceInvitation3 = await E(invitationIssuer).claim(
+  const aliceInvitation3 = await E(invitationIssuer).adaptClaim(
+    aliceInvitationPurseP,
     await E(publicFacet).makeInvitation(),
   );
   const aliceBuyOrderProposal = harden({
@@ -339,6 +346,7 @@ test('simpleExchange with non-fungible assets', async t => {
 
   // Setup Bob
   const bobCcPayment = ccMint.mintPayment(cryptoCats(harden(['Cheshire Cat'])));
+  const bobInvitationPurseP = E(invitationIssuer).makeEmptyPurse();
 
   // 1: Simon creates a simpleExchange instance and spreads the invitation far and
   // wide with instructions on how to use it.
@@ -368,7 +376,10 @@ test('simpleExchange with non-fungible assets', async t => {
   // 5: Bob decides to join.
   const bobInstance = await E(zoe).getInstance(bobInvitation);
   const bobInstallation = await E(zoe).getInstallation(bobInvitation);
-  const bobExclusiveInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const bobExclusiveInvitation = await E(invitationIssuer).adaptClaim(
+    bobInvitationPurseP,
+    bobInvitation,
+  );
 
   t.is(bobInstallation, installation);
 

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -45,7 +45,7 @@ const setup = () => {
    * @property {(value: AmountValue) => Amount} moola
    * @property {(value: AmountValue) => Amount} simoleans
    * @property {(value: AmountValue) => Amount} bucks
-   * @property {ERef<ZoeService>} zoe
+   * @property {ZoeService} zoe
    * @property {*} vatAdminState
    */
 


### PR DESCRIPTION
As an experiment, and as a record of where we would need to look, this PR renames the four payment-to-payment linear operations in zoe, adding a first purse argument to each. The idea is that each live payment could be tied to a home purse, to which it should return in an emergency if it is still live.

***Not to be reviewed***. It is an artifact of code-owners that reviewers were added to a Draft PR.