### PR TITLE
refactor(run-protocol): innerVault as virtual object

### DIFF
--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -13,7 +13,7 @@ import {
 
 import { assert } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
-import { Far } from '@endo/marshal';
+import { defineKind } from '@agoric/vat-data';
 import { makeTracer } from '../makeTracer.js';
 import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
 import { makeVaultKit } from './vaultKit.js';
@@ -117,7 +117,7 @@ const validTransitions = {
  * @param {ZCFMint} mint
  * @param {ERef<PriceAuthority>} priceAuthority
  */
-export const makeInnerVault = (
+const initState = (
   zcf,
   manager,
   assetNotifier,
@@ -125,14 +125,6 @@ export const makeInnerVault = (
   mint,
   priceAuthority,
 ) => {
-  // CONSTANTS
-  const collateralBrand = manager.getCollateralBrand();
-  /** @type {{brand: Brand<'nat'>}} */
-  const { brand: debtBrand } = mint.getIssuerRecord();
-
-  const emptyCollateral = AmountMath.makeEmpty(collateralBrand);
-  const emptyDebt = AmountMath.makeEmpty(debtBrand);
-
   /**
    * State object to support virtualization when available
    *
@@ -157,8 +149,24 @@ export const makeInnerVault = (
 
     // Two values from the same moment
     interestSnapshot: manager.getCompoundedInterest(),
-    debtSnapshot: emptyDebt,
+    debtSnapshot: AmountMath.makeEmpty(mint.getIssuerRecord().brand),
   };
+  return harden(state);
+};
+
+/** @param {ImmutableState & MutableState} state */
+const constructFromState = state => {
+  /** @type {ImmutableState} */
+  const { idInManager, manager, mint, priceAuthority, zcf } = state;
+
+  // #region Computed constants
+  const collateralBrand = manager.getCollateralBrand();
+  /** @type {{ brand: Brand<'nat'> }} */
+  const { brand: debtBrand } = mint.getIssuerRecord();
+
+  const emptyCollateral = AmountMath.makeEmpty(collateralBrand);
+  const emptyDebt = AmountMath.makeEmpty(debtBrand);
+  // #endregion
 
   // #region Phase logic
   /**
@@ -680,7 +688,7 @@ export const makeInnerVault = (
     return vaultKit;
   };
 
-  const innerVault = Far('innerVault', {
+  const innerVault = {
     getVaultSeat: () => state.vaultSeat,
 
     initVaultKit: seat => initVaultKit(seat, innerVault),
@@ -718,9 +726,15 @@ export const makeInnerVault = (
     getCollateralAmount,
     getCurrentDebt,
     getNormalizedDebt,
-  });
+  };
 
   return innerVault;
 };
+
+export const makeInnerVault = defineKind(
+  'InnerVault',
+  initState,
+  constructFromState,
+);
 
 /** @typedef {ReturnType<typeof makeInnerVault>} InnerVault */

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -125,12 +125,8 @@ const initState = (
   mint,
   priceAuthority,
 ) => {
-  /**
-   * State object to support virtualization when available
-   *
-   * @type {ImmutableState & MutableState}
-   */
-  const state = {
+  /** @type {ImmutableState & MutableState} */
+  return harden({
     assetNotifier,
     idInManager,
     manager,
@@ -150,8 +146,7 @@ const initState = (
     // Two values from the same moment
     interestSnapshot: manager.getCompoundedInterest(),
     debtSnapshot: AmountMath.makeEmpty(mint.getIssuerRecord().brand),
-  };
-  return harden(state);
+  });
 };
 
 /** @param {ImmutableState & MutableState} state */

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -343,7 +343,7 @@ export const makeVaultManager = (
   observeNotifier(periodNotifier, timeObserver);
 
   /** @type {Parameters<typeof makeInnerVault>[1]} */
-  const managerFacet = harden({
+  const managerFacet = Far('managerFacet', {
     ...shared,
     applyDebtDelta,
     reallocateWithFee,


### PR DESCRIPTION
Part of #4345 

## Description

Converts the `makeInnerVault` function to use the `defineKind` function of the Collections API so that vaults can be marshaled and eventually made durable.


### Security Considerations

This separates what was one function,`args => instance` into two with an intermediate marshallable state, `args => state` and `state => instance`. This makes the instance very dependent on the assumption that the state passed into the latter is what was returned by the former.


### Documentation Considerations

--

### Testing Considerations

The virtualObjectManager does to marshalling and unmarshalling. The two functions are both at module scope so share no closing state. I _think_ this is sufficient to ensure they can be unmarshalled elsewhere but reviewers please advise.