### PR TITLE
Endow a `lookup(...path)` function to REPL and deploy scripts

### DIFF
--- a/packages/solo/src/vat-http.js
+++ b/packages/solo/src/vat-http.js
@@ -22,10 +22,33 @@ export function buildRootObject(vatPowers) {
       },
     });
 
+  const lookup = async (...path) => {
+    // Take a snapshot of the current home.
+    // eslint-disable-next-line no-use-before-define
+    const root = replObjects.home;
+
+    if (path.length === 1 && Array.isArray(path[0])) {
+      // Convert single array argument to a path.
+      path = path[0];
+    }
+    if (path.length === 0) {
+      return root;
+    }
+    const [first, ...remaining] = path;
+    const firstValue = root[first];
+    if (remaining.length === 0) {
+      return firstValue;
+    }
+    assert(firstValue, X`${first} not found in home`);
+    return E(firstValue).lookup(...remaining);
+  };
+  harden(lookup);
+
   const replObjects = {
     home: antifreeze({ LOADING }),
     agoric: antifreeze({}),
     local: antifreeze({}),
+    lookup,
   };
 
   function doneLoading(subsystems) {

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { assert, details as X, q } from '@agoric/assert';
-import { Far } from '@endo/far';
+import { E, Far } from '@endo/far';
 import { makeStore } from '@agoric/store';
 import { crc6 } from './crc.js';
 
@@ -83,6 +83,18 @@ function makeBoard(
       );
       assert(idToVal.has(id), X`board does not have id: ${id}`);
       return idToVal.get(id);
+    },
+    // Adapter for lookup() protocol.
+    lookup: async (...path) => {
+      if (path.length === 0) {
+        return board;
+      }
+      const [first, ...rest] = path;
+      const firstValue = board.getValue(first);
+      if (rest.length === 0) {
+        return firstValue;
+      }
+      return E(firstValue).lookup(...rest);
     },
     has: valToId.has,
     ids: () => harden([...idToVal.keys()]),

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -8,9 +8,10 @@
 /**
  * @typedef {Object} Board
  * @property {(id: string) => any} getValue
- * @property {(value: any) => string} getId
- * @property {(value: any) => boolean} has
+ * @property {(value: unknown) => string} getId
+ * @property {(value: unknown) => boolean} has
  * @property {() => string[]} ids
+ * @property {(...path: string[]) => Promise<unknown>} lookup
  */
 
 /**

--- a/packages/vats/test/test-lib-board.js
+++ b/packages/vats/test/test-lib-board.js
@@ -7,17 +7,33 @@ import { makeBoard } from '../src/lib-board.js';
 test('makeBoard', async t => {
   const board = makeBoard();
 
-  const obj1 = Far('obj1', {});
+  const obj1 = Far('obj1', { lookup: async (...path) => path });
   const obj2 = Far('obj2', {});
 
   t.deepEqual(board.ids(), [], `board is empty to start`);
+  t.is(await board.lookup(), board, 'empty lookup returns board');
+
+  await t.throwsAsync(board.lookup('board0371'), {
+    message: /board does not have id: "board0371"/,
+  });
 
   const idObj1 = board.getId(obj1);
   t.is(idObj1, 'board0371');
   t.deepEqual(board.ids(), [idObj1], `board has one id`);
 
+  t.is(await board.lookup('board0371'), obj1, 'id lookup returns obj1');
+  t.deepEqual(
+    await board.lookup('board0371', 'a', 'b', 'c'),
+    ['a', 'b', 'c'],
+    'path lookup returns path',
+  );
+
   const idObj2 = board.getId(obj2);
   t.is(idObj2, 'board0592');
+  t.is(await board.lookup('board0592'), obj2, 'id lookup returns obj2');
+  await t.throwsAsync(board.lookup('board0592', 'a', 'b', 'c'), {
+    message: /target has no method "lookup"/,
+  });
   t.deepEqual(board.ids().length, 2, `board has two ids`);
 
   t.deepEqual(board.getValue(idObj1), obj1, `id matches value obj1`);

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -1528,7 +1528,86 @@ export function makeWallet({
     return offerResult.uiNotifier;
   }
 
+  // Create a map from the first "wallet" path element, to the next naming hub
+  // (which supports at least "lookup").
+  const createRootLookups = () => {
+    const rootPathToLookup = makeLegacyMap('lookups');
+
+    /**
+     * @param {string} kind
+     * @param {(...path: string[]) => any} lookup
+     */
+    const makeLookup = (kind, lookup) => {
+      rootPathToLookup.init(
+        kind,
+        Far(`${kind}Lookup`, {
+          lookup,
+        }),
+      );
+    };
+
+    // Adapt a lookup function to try looking for a string-only petname first,
+    // falling back on the array path if that fails.
+    const petnameOrPath =
+      lookup =>
+      (...path) => {
+        try {
+          if (path.length === 1) {
+            // Try the petname first.
+            return lookup(path[0]);
+          }
+        } catch (e) {
+          // do nothing
+        }
+        return lookup(path);
+      };
+
+    makeLookup('brand', petnameOrPath(brandMapping.petnameToVal.get));
+    makeLookup('contact', petnameOrPath(contactMapping.petnameToVal.get));
+    makeLookup('issuer', petnameOrPath(issuerManager.get));
+    makeLookup('instance', petnameOrPath(instanceMapping.petnameToVal.get));
+    makeLookup(
+      'installation',
+      petnameOrPath(installationMapping.petnameToVal.get),
+    );
+    makeLookup('purse', petnameOrPath(purseMapping.petnameToVal.get));
+
+    // Adapt a lookup function to try looking for only a single ID, not a path.
+    const idOnly =
+      (kind, lookup) =>
+      (...path) => {
+        assert.equal(
+          path.length,
+          1,
+          X`${assert.quote(
+            kind,
+          )} lookup must be called with a single offer ID, not ${path}`,
+        );
+        return lookup(path[0]);
+      };
+    makeLookup('offer', idOnly('offer', idToOffer.get));
+    makeLookup(
+      'offerResult',
+      idOnly('offerResult', id => idToOfferResultPromiseKit.get(id).promise),
+    );
+
+    return rootPathToLookup;
+  };
+
+  const firstPathToLookup = createRootLookups();
   const wallet = Far('wallet', {
+    lookup: (...path) => {
+      // Provide an entrypoint to the wallet's naming hub.
+      if (path.length === 0) {
+        return wallet;
+      }
+      const [first, ...remaining] = path;
+      const firstValue = firstPathToLookup.get(first);
+      if (remaining.length === 0) {
+        return firstValue;
+      }
+      return E(firstValue).lookup(...remaining);
+    },
     saveOfferResult,
     getOfferResult,
     waitForDappApproval,

--- a/packages/wallet/api/src/wallet.js
+++ b/packages/wallet/api/src/wallet.js
@@ -316,6 +316,8 @@ export function buildRootObject(vatPowers) {
       getIssuers: walletAdmin.getIssuers,
       getPurse: walletAdmin.getPurse,
       getPurses: walletAdmin.getPurses,
+
+      lookup: walletAdmin.lookup,
     });
     return harden(wallet);
   }

--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -252,7 +252,7 @@ test('lib-wallet issuer and purse methods', async t => {
 });
 
 test('lib-wallet dapp suggests issuer, instance, installation petnames', async t => {
-  t.plan(13);
+  t.plan(15);
   const {
     board,
     zoe,
@@ -508,6 +508,11 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
     `inboxStateChangeLog with names`,
   );
 
+  await t.throwsAsync(wallet.lookup('offer', 'bzzt'), {
+    message: '"offerId" not found: "bzzt"',
+  });
+  await t.notThrowsAsync(wallet.lookup('offer', 'unknown#1588645041696'));
+
   t.throws(
     () => wallet.getInstallation('whatever'),
     {
@@ -643,7 +648,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
 });
 
 test('lib-wallet offer methods', async t => {
-  t.plan(8);
+  t.plan(9);
   const {
     moolaBundle,
     wallet,
@@ -729,6 +734,9 @@ test('lib-wallet offer methods', async t => {
     ],
     `offer structure`,
   );
+  wallet
+    .lookup('offerResult', 'unknown#1588645041696')
+    .then(or => t.is(or, 'The offer was accepted'));
   const accepted = await wallet.acceptOffer(id);
   assert(accepted);
   const { depositedP } = accepted;
@@ -1487,4 +1495,22 @@ test('stamps from dateNow', async t => {
       status: 'deposited',
     },
   ]);
+});
+
+test('lookup', async t => {
+  const { moolaBundle, wallet } = await setupTest();
+  await wallet.addIssuer('moola', moolaBundle.issuer);
+
+  t.is(await E(wallet).lookup('brand', 'moola'), moolaBundle.brand);
+  t.is(await E(wallet).lookup('issuer', 'moola'), moolaBundle.issuer);
+  const inviteBrand = await E(wallet).lookup('brand', 'zoe invite');
+  t.deepEqual(
+    await E(
+      E(wallet).lookup('purse', 'Default Zoe invite purse'),
+    ).getCurrentAmount(),
+    { brand: inviteBrand, value: [] },
+  );
+  await t.throwsAsync(E(wallet).lookup('purse2'), {
+    message: /"lookups" not found: "purse2"/,
+  });
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4918

## Description

This feature exposes several different naming paths via a powerful `lookup(...)` function.   See the attached issue for architecture.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

No more powers granted besides what was already given to the REPL and deploy scripts.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

Backward compatible.

Intended to be first used in the oracle deploy scripts.  I expect this will be documented when more deploy scripts use the mechanism.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
