### PR TITLE
fix(swingset): initializeStoreKindInfo() earlier, unconditionally

### DIFF
--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -1215,6 +1215,8 @@ function build(
     }
 
     initializeIDCounters();
+    collectionManager.initializeStoreKindInfo();
+
     const vatParameters = m.unserialize(vatParametersCapData);
     baggage = collectionManager.provideBaggage();
 

--- a/packages/SwingSet/test/stores/test-storeGC.js
+++ b/packages/SwingSet/test/stores/test-storeGC.js
@@ -466,7 +466,6 @@ function validateCreateHolder(v, idx) {
 
 function validateInit(v) {
   validate(v, matchVatstoreGet('idCounters', NONE));
-  validate(v, matchVatstoreGet('baggageID', NONE));
   validate(v, matchVatstoreGet('storeKindIDTable', NONE));
   validate(
     v,
@@ -475,6 +474,7 @@ function validateInit(v) {
       '{"scalarMapStore":1,"scalarWeakMapStore":2,"scalarSetStore":3,"scalarWeakSetStore":4,"scalarDurableMapStore":5,"scalarDurableWeakMapStore":6,"scalarDurableSetStore":7,"scalarDurableWeakSetStore":8}',
     ),
   );
+  validate(v, matchVatstoreGet('baggageID', NONE));
   validateCreateBaggage(v, 1);
   validateCreateHolder(v, 2);
 }

--- a/packages/SwingSet/test/test-baggage.js
+++ b/packages/SwingSet/test/test-baggage.js
@@ -47,7 +47,6 @@ function validateCreateBaggage(v, idx) {
 
 function validateSetup(v) {
   validate(v, matchVatstoreGet('idCounters', NONE));
-  validate(v, matchVatstoreGet('baggageID', NONE));
   validate(v, matchVatstoreGet('storeKindIDTable', NONE));
   validate(
     v,
@@ -56,6 +55,7 @@ function validateSetup(v) {
       '{"scalarMapStore":1,"scalarWeakMapStore":2,"scalarSetStore":3,"scalarWeakSetStore":4,"scalarDurableMapStore":5,"scalarDurableWeakMapStore":6,"scalarDurableSetStore":7,"scalarDurableWeakSetStore":8}',
     ),
   );
+  validate(v, matchVatstoreGet('baggageID', NONE));
   validateCreateBaggage(v, 1);
 }
 

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -461,7 +461,6 @@ function validateCreateBaggage(v, idx) {
 
 function validateSetup(v) {
   validate(v, matchVatstoreGet('idCounters', NONE));
-  validate(v, matchVatstoreGet('baggageID', NONE));
   validate(v, matchVatstoreGet('storeKindIDTable', NONE));
   validate(
     v,
@@ -470,6 +469,7 @@ function validateSetup(v) {
       '{"scalarMapStore":1,"scalarWeakMapStore":2,"scalarSetStore":3,"scalarWeakSetStore":4,"scalarDurableMapStore":5,"scalarDurableWeakMapStore":6,"scalarDurableSetStore":7,"scalarDurableWeakSetStore":8}',
     ),
   );
+  validate(v, matchVatstoreGet('baggageID', NONE));
   validateCreateBaggage(v, 1);
   validate(v, matchVatstoreSet(stateKey(cacheDisplacerVref), cacheObjValue));
   validate(v, matchVatstoreSet(stateKey(fCacheDisplacerVref), cacheObjValue));

--- a/packages/SwingSet/tools/fakeCollectionManager.js
+++ b/packages/SwingSet/tools/fakeCollectionManager.js
@@ -6,6 +6,7 @@ export function makeFakeCollectionManager(vrm, fakeStuff, _options = {}) {
     makeScalarBigWeakMapStore,
     makeScalarBigSetStore,
     makeScalarBigWeakSetStore,
+    initializeStoreKindInfo,
   } = makeCollectionManager(
     fakeStuff.syscall,
     vrm,
@@ -17,6 +18,7 @@ export function makeFakeCollectionManager(vrm, fakeStuff, _options = {}) {
     fakeStuff.marshal.serialize,
     fakeStuff.marshal.unserialize,
   );
+  initializeStoreKindInfo();
 
   const normalCM = {
     makeScalarBigMapStore,


### PR DESCRIPTION
The liveslots "collection manager" assigns a virtual-object Kind ID to
each of the collection types it supports. Currently there are 8: (weak
vs strong) times (map vs set) times (virtual vs durable). These Kind
IDs live in the same numberspace as the virtual/durable Kinds that
userspace creates by calling `defineKind` or `defineDurableKind`. This
numberspace is also used for Export IDs, the `o+NN` values assigned to
exported Remotables.

Previously, the Kind IDs for the collections were allocated on-demand,
the first time anybody created a collection. The IDs they got could
vary, depend upon whether userspace created a collection first, or
used `defineKind` first. This also changed when we introduced
"baggage" (which is a durable collection, created by liveslots
itself).

This commit moves the allocation step: it is now done unconditionally
during startVat(), before userspace gets control. This should make the
allocated IDs more consistent across all vats.

This should behave correctly when we add new kinds of Stores in the
future: when the vat is upgraded to a new liveslots, it will read the
existing IDs from the DB, add any new ones, then write the updated
table back to the DB.

As a side-effect of this change, *all* vats now have kvStore keys to
record the IDs, not just the once which use collections. And the first
Export ID allocated after startup (either an object export or a Kind
definition) will get a different ID: instead of `o+1`, it is likely to
be `o+9`. Several unit tests needed to be updated as a result, however
now they won't have to be updated further if e.g. `startVat` changes
to create collections before userspace runs.
