### PR TITLE
feat(swingset): get a small upgrade to work

### DIFF
--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -361,6 +361,13 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
     }
   }
 
+  async function destroyWorker(vatID) {
+    // stop any existing worker, delete transcript and any snapshot
+    await evict(vatID);
+    const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
+    vatKeeper.removeSnapshotAndTranscript();
+  }
+
   // mostly used by tests, only needed with thread/process-based workers
   function shutdown() {
     const work = Array.from(ephemeral.vats.values(), ({ manager }) =>
@@ -377,6 +384,8 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
     kernelDeliveryToVatDelivery,
     deliverToVat,
     maybeSaveSnapshot,
+
+    destroyWorker,
 
     // mostly for testing?
     activeVatsInfo: () =>

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -1267,6 +1267,8 @@ function build(
     assert(didStartVat);
     assert(!didStopVat);
     didStopVat = true;
+    // eslint-disable-next-line no-use-before-define
+    await bringOutYourDead();
     // empty for now
   }
 

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -54,13 +54,9 @@ async function testUpgrade(t, defaultManagerType) {
 
   // upgrade should work
   const [v2status, v2capdata] = await run('upgradeV2', []);
-  // t.is(v2status, 'fulfilled');
-  // t.deepEqual(JSON.parse(v2capdata.body), ['v2', { youAre: 'v2', marker }]);
-  // t.deepEqual(v2capdata.slots, [markerKref]);
-
-  // but for now, upgrade is just a stub
-  t.is(v2status, 'rejected');
-  t.deepEqual(JSON.parse(v2capdata.body), { error: 'not implemented' });
+  t.is(v2status, 'fulfilled');
+  t.deepEqual(JSON.parse(v2capdata.body), ['v2', { youAre: 'v2', marker }]);
+  t.deepEqual(v2capdata.slots, [markerKref]);
 }
 
 test('vat upgrade - local', async t => {


### PR DESCRIPTION
This enables a partial vat upgrade test to work. It makes a lot of
assumptions and is missing a lot of functionality, but it's a concrete
step forward. Limitations include:

* if the stopVat or startVat fail somehow, the vat will be left in an
unusable state, and the caller will not be notified
* stopVat does not clean up the non-durable objects
* stopVat does not reject the lingering promises
* startVat does not assert that userspace reconnects all Kinds
* nothing about reconnecting Kinds is tested at all
* nothing about remaining durable objects is tested at all
* the kernel does not unsubscribe the vat from remaining promises
* transcript pointers are cleared, but the contents are not deleted
* the snapshot decref/deletion is not tested
* stopVat is metered, but probably shouldn't be
* startVat metering needs more thought

refs #1848
