### PR TITLE
feat(run-protocol): liquidate serially

### DIFF
--- a/packages/run-protocol/src/vaultFactory/liquidation.js
+++ b/packages/run-protocol/src/vaultFactory/liquidation.js
@@ -42,6 +42,7 @@ const liquidate = async (
     collateralBrand,
   );
 
+  // XXX problems with upgrade
   const { deposited, userSeatPromise: liqSeat } = await offerTo(
     zcf,
     strategy.makeInvitation(debt),

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -298,7 +298,7 @@ const constructFromState = state => {
     }
     const { phase } = state;
     const uiState = snapshotState(phase);
-    trace('updateUiState', uiState);
+    trace('updateUiState', idInManager, uiState);
 
     switch (phase) {
       case VaultPhase.ACTIVE:
@@ -482,7 +482,7 @@ const constructFromState = state => {
     // then mint, reallocate, and burn.
     const { newDebt, fee, toMint } = loanFee(debt, giveRUN, wantRUN);
 
-    trace('adjustBalancesHook', {
+    trace('adjustBalancesHook', idInManager, {
       newCollateralPre,
       newCollateral,
       fee,
@@ -526,7 +526,10 @@ const constructFromState = state => {
     // TODO should this be simplified to know that the oldDebt mut be empty?
     const debtPre = getCurrentDebt();
     const collateralPre = getCollateralAmount();
-    trace('initVaultKit start: collateral', { debtPre, collateralPre });
+    trace('initVaultKit start: collateral', idInManager, {
+      debtPre,
+      collateralPre,
+    });
 
     // get the payout to provide access to the collateral if the
     // contract abandons
@@ -546,8 +549,8 @@ const constructFromState = state => {
     );
     assert(AmountMath.isEqual(newDebtPre, toMint), X`fee mismatch for vault`);
     trace(
-      idInManager,
       'initVault',
+      idInManager,
       { wantedRun: wantRUN, fee },
       getCollateralAmount(),
     );

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -133,25 +133,25 @@ export const makeVaultManager = (
    *
    * @param {[key: string, vaultKit: InnerVault]} record
    */
-  const liquidateAndRemove = async ([key, vault]) => {
-    assert(prioritizedVaults);
+  const liquidateAndRemove = ([key, vault]) => {
     trace('liquidating', vault.getVaultSeat().getProposal());
 
-    try {
-      // Start liquidation (vaultState: LIQUIDATING)
-      await liquidate(
-        zcf,
-        vault,
-        debtMint.burnLosses,
-        liquidationStrategy,
-        collateralBrand,
-      );
-
-      await prioritizedVaults.removeVault(key);
-    } catch (e) {
-      // XXX should notify interested parties
-      console.error('liquidateAndRemove failed with', e);
-    }
+    // Start liquidation (vaultState: LIQUIDATING)
+    return liquidate(
+      zcf,
+      vault,
+      debtMint.burnLosses,
+      liquidationStrategy,
+      collateralBrand,
+    )
+      .then(() => {
+        assert(prioritizedVaults);
+        prioritizedVaults?.removeVault(key);
+      })
+      .catch(e => {
+        // XXX should notify interested parties
+        console.error('liquidateAndRemove failed with', e);
+      });
   };
 
   // When any Vault's debt ratio is higher than the current high-water level,

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1787,14 +1787,14 @@ test('mutable liquidity triggers and interest', async t => {
     ),
   );
 
-  aliceUpdate = await E(aliceNotifier).getUpdateSince();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince(aliceUpdate.updateCount);
   t.deepEqual(aliceUpdate.value.debtSnapshot.debt, aliceRunDebtLevel);
 
   await manualTimer.tick();
   // price levels changed and interest was charged.
 
   // expect Alice to be liquidated because her collateral is too low.
-  aliceUpdate = await E(aliceNotifier).getUpdateSince();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince(aliceUpdate.updateCount);
 
   // Bob's loan is now 777 RUN (including interest) on 100 Aeth, with the price
   // at 7. 100 * 7 > 1.05 * 777. When interest is charged again, Bob should get
@@ -1805,14 +1805,14 @@ test('mutable liquidity triggers and interest', async t => {
   }
   await waitForPromisesToSettle();
   aliceUpdate = await E(aliceNotifier).getUpdateSince(aliceUpdate.updateCount);
-  bobUpdate = await E(bobNotifier).getUpdateSince();
+  bobUpdate = await E(bobNotifier).getUpdateSince(bobUpdate.updateCount);
   t.is(aliceUpdate.value.vaultState, Phase.LIQUIDATED);
 
   for (let i = 0; i < 5; i += 1) {
     manualTimer.tick();
   }
   await waitForPromisesToSettle();
-  bobUpdate = await E(bobNotifier).getUpdateSince();
+  bobUpdate = await E(bobNotifier).getUpdateSince(bobUpdate.updateCount);
 
   t.is(bobUpdate.value.vaultState, Phase.LIQUIDATED);
 });
@@ -2137,7 +2137,7 @@ test('excessive loan', async t => {
 // prices drop. Bob will be charged interest (twice), which will trigger
 // liquidation. Alice's withdrawal is precisely gauged so the difference between
 // a floorDivideBy and a ceilingDivideBy will leave her unliquidated.
-test('mutable liquidity triggers and interest sensitivity', async t => {
+test('mutable liquidity sensitivity of triggers and interest', async t => {
   const {
     aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
   } = setupAssets();
@@ -2294,14 +2294,12 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
     ),
   );
 
-  aliceUpdate = await E(aliceNotifier).getUpdateSince();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince(aliceUpdate.updateCount);
   t.deepEqual(aliceUpdate.value.debtSnapshot.debt, aliceRunDebtLevel);
+  t.is(aliceUpdate.value.vaultState, Phase.ACTIVE);
 
   await manualTimer.tick();
   // price levels changed and interest was charged.
-
-  // expect Alice to be liquidated because her collateral is too low.
-  aliceUpdate = await E(aliceNotifier).getUpdateSince();
 
   // Bob's loan is now 777 RUN (including interest) on 100 Aeth, with the price
   // at 7. 100 * 7 > 1.05 * 777. When interest is charged again, Bob should get
@@ -2311,8 +2309,10 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
     manualTimer.tick();
   }
   await waitForPromisesToSettle();
-  aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  bobUpdate = await E(bobNotifier).getUpdateSince();
-  t.is(aliceUpdate.value.vaultState, Phase.ACTIVE);
+  bobUpdate = await E(bobNotifier).getUpdateSince(bobUpdate.updateCount);
   t.is(bobUpdate.value.vaultState, Phase.LIQUIDATED);
+
+  // No change for Alice
+  aliceUpdate = await E(aliceNotifier).getUpdateSince(); // can't use updateCount because there's no newer update
+  t.is(aliceUpdate.value.vaultState, Phase.ACTIVE);
 });


### PR DESCRIPTION
closes: #4750
refs: #XXXX

## Description

Restores `liquidateAndRemove` promise from #4715 but changes the high-water-mark case to liquidate serially instead of starting them all at once in parallel.

For the `liquidateAll` case it continues start them all at once in parallel, assuming that that would maximize the throughput and efficiency is not a concern for that case.

### Security Considerations

Reduces dependence on durable state.

### Documentation Considerations

--

### Testing Considerations

Existing unit tests.