### PR TITLE
fix(swingset): stopVat rejects lingering promises

### DIFF
--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -5,10 +5,19 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 import { assert } from '@agoric/assert';
 import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
-import { capargs, capSlot, capdataOneSlot } from '../util.js';
+import { capargs, capdataOneSlot } from '../util.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
+}
+
+function get(capdata, propname) {
+  const body = JSON.parse(capdata.body);
+  const value = body[propname];
+  if (typeof value === 'object' && value['@qclass'] === 'slot') {
+    return ['slot', capdata.slots[value.index]];
+  }
+  return value;
 }
 
 async function testUpgrade(t, defaultManagerType) {
@@ -44,19 +53,31 @@ async function testUpgrade(t, defaultManagerType) {
   t.is(mcd[0], 'fulfilled');
   const markerKref = mcd[1].slots[0]; // probably ko26
   t.deepEqual(mcd[1], capdataOneSlot(markerKref, 'marker'));
-  const marker = capSlot(0, 'marker');
 
   // create initial version
   const [v1status, v1capdata] = await run('buildV1', []);
   t.is(v1status, 'fulfilled');
-  t.deepEqual(JSON.parse(v1capdata.body), ['v1', { youAre: 'v1', marker }]);
-  t.deepEqual(v1capdata.slots, [markerKref]);
+  t.deepEqual(get(v1capdata, 'version'), 'v1');
+  t.deepEqual(get(v1capdata, 'youAre'), 'v1');
+  t.deepEqual(get(v1capdata, 'marker'), ['slot', markerKref]);
+  // grab the promises that should be rejected
+  t.is(get(v1capdata, 'p1')[0], 'slot');
+  const v1p1Kref = get(v1capdata, 'p1')[1];
+  t.is(get(v1capdata, 'p2')[0], 'slot');
+  const v1p2Kref = get(v1capdata, 'p2')[1];
 
   // upgrade should work
   const [v2status, v2capdata] = await run('upgradeV2', []);
   t.is(v2status, 'fulfilled');
-  t.deepEqual(JSON.parse(v2capdata.body), ['v2', { youAre: 'v2', marker }]);
-  t.deepEqual(v2capdata.slots, [markerKref]);
+  t.deepEqual(get(v2capdata, 'version'), 'v2');
+  t.deepEqual(get(v2capdata, 'youAre'), 'v2');
+  t.deepEqual(get(v2capdata, 'marker'), ['slot', markerKref]);
+
+  // the old version's non-durable promises should be rejected
+  t.is(c.kpStatus(v1p1Kref), 'rejected');
+  t.deepEqual(c.kpResolution(v1p1Kref), capargs('vat upgraded'));
+  t.is(c.kpStatus(v1p2Kref), 'rejected');
+  t.deepEqual(c.kpResolution(v1p2Kref), capargs('vat upgraded'));
 }
 
 test('vat upgrade - local', async t => {

--- a/packages/SwingSet/test/upgrade/vat-ulrik-1.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-1.js
@@ -1,12 +1,30 @@
 import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
 
 export function buildRootObject(_vatPowers, vatParameters) {
+  const { promise: p1 } = makePromiseKit();
+  const { promise: p2 } = makePromiseKit();
+  let heldPromise;
+
   return Far('root', {
     getVersion() {
       return 'v1';
     },
     getParameters() {
       return vatParameters;
+    },
+    acceptPromise(p) {
+      // stopVat will reject the promises that we decide, but should
+      // not touch the ones we don't decide, so we hold onto this
+      // until upgrade, to probe for bugs in that loop
+      heldPromise = p;
+      heldPromise.catch(() => 'hush');
+    },
+    getEternalPromise() {
+      return { p1 };
+    },
+    returnEternalPromise() {
+      return p2;
     },
   });
 }


### PR DESCRIPTION
Any promise that is decided by a vat but not resolved by the time
upgrade happens should be rejected by `stopVat()`. This tracks decided
promises (both exported promises and the `result` vpid of inbound
deliveries) in a new `deciderVPIDs` Set. We remove vpids from the Set
when we send `syscall.resolve`, and we send rejections for everything
remaining during `stopVat`.

`dispatch.notify` (specifically `notifyOnePromise`) was changed to
ignore the kernel when it notifies us about a promise that we don't
recognize. This can now happen when version-1 subscribed to a Promise
that didn't get resolved before the vat got upgraded to
version-2. Rather than figure out a way to unsubscribe from these
promises (there shouldn't be very many of them), we just tolerate the
late resolution notification.

Note that this introduces a strong requirement that the kernel does
not re-use imported vpids, which was previously merely a
recommendation. Vat upgrade does not reset `v$NN.p.nextID`, so this
should be ok.

refs #1848
