### PR TITLE
fix(SwingSet): report but don't crash on unhandled rejections

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -45,8 +45,13 @@ function makeConsole(tag) {
   return harden(cons);
 }
 
-/** @param {Error} e */
-function unhandledRejectionHandler(e) {
+/**
+ * @param {unknown} e
+ * @param {Promise} pr
+ */
+function unhandledRejectionHandler(e, pr) {
+  // Don't trigger sensitive hosts (like AVA).
+  pr.catch(() => {});
   console.error('UnhandledPromiseRejectionWarning:', e);
 }
 

--- a/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
@@ -342,4 +342,10 @@ function makeWorker(port) {
 // xsnap provides issueCommand global
 const port = managerPort(globalThis.issueCommand);
 const worker = makeWorker(port);
+
+// Send unexpected console messages to the manager port.
+globalThis.print = (...args) => {
+  port.send(['console', 'error', ...args]);
+};
+
 globalThis.handleCommand = port.handlerFrom(worker.handleItem);

--- a/packages/SwingSet/test/workers/vat-target.js
+++ b/packages/SwingSet/test/workers/vat-target.js
@@ -71,6 +71,7 @@ export function buildRootObject(vatPowers, vatParameters) {
   //   syscall.reject(pC, Error('oops'))
   //   syscall.fulfillToData(rp3, 'rp3 good')
   function one() {
+    Promise.reject(Error('one unhandled rejection'));
     precB.resolve(callbackObj); // syscall.fulfillToPresence
     precC.reject(Error('oops')); // syscall.reject
     return 'rp3 good';


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: agoric-labs/xsnap-pub#21
closes: #4938

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

After this patch and the referenced xsnap-pub PR, unhandled rejections are logged consistently by the kernel and don't crash AVA, for example.

Here is output from the local (Node.js) worker running `cd packages/SwingSet && yarn test test/workers/test-worker.js`:

```
UnhandledPromiseRejectionWarning: (Error#3)
Error#3: one unhandled rejection
  at Alleged: root.one (.../swingset-vat/test/workers/vat-target.js:74:20)
```

And the corresponding output from the XS worker:

```
UnhandledPromiseRejectionWarning: (Error#2)
Error#2: one unhandled rejection
Error: one unhandled rejection
 at apply ()
 at Error (/Users/michael/agoric/agoric-sdk/packages/SwingSet/src/supervisors/subprocess-xsnap/lockdown-subprocess-xsnap.js:7593)
 at one (.../swingset-vat/test/workers/vat-target.js:74)
 at apply ()
 at apply ()
 at dispatchToHandler (/Users/michael/agoric/agoric-sdk/packages/SwingSet/src/supervisors/subprocess-xsnap/lockdown-subprocess-xsnap.js:10951)
 at (/Users/michael/agoric/agoric-sdk/packages/SwingSet/src/supervisors/subprocess-xsnap/lockdown-subprocess-xsnap.js:10589)
 at win (/Users/michael/agoric/agoric-sdk/packages/SwingSet/src/supervisors/subprocess-xsnap/lockdown-subprocess-xsnap.js:11294)
 at ()
```

The XS worker still has some way to go before it's as legible as the local worker, but this PR at least makes sure the errors don't disappear.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Unhandled rejections are reported at the correct level: the kernel output and not under control of the vat.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
