### PR TITLE
chore(swingset): improve virtual-object code and tests

### DIFF
--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -135,7 +135,10 @@ export function makeCollectionManager(
     keySchema = M.any(),
     valueSchema,
   ) {
-    const { hasWeakKeys, durable } = storeKindInfo[kindName];
+    assert.typeof(kindName, 'string');
+    const kindInfo = storeKindInfo[kindName];
+    assert(kindInfo, `unknown collection kind ${kindName}`);
+    const { hasWeakKeys, durable } = kindInfo;
     const dbKeyPrefix = `vc.${collectionID}.`;
     let currentGenerationNumber = 0;
 
@@ -523,6 +526,7 @@ export function makeCollectionManager(
   function storeSizeInternal(vobjID) {
     const { id, subid } = parseVatSlot(vobjID);
     const kindName = storeKindIDToName.get(`${id}`);
+    assert(kindName, `unknown kind ID ${id}`);
     const collection = summonCollectionInternal(false, 'test', subid, kindName);
     return collection.sizeInternal();
   }
@@ -804,7 +808,7 @@ export function makeCollectionManager(
       : collectionToWeakSetStore(reanimateCollection(vobjID));
   }
 
-  const testHooks = { storeSizeInternal, makeCollection };
+  const testHooks = { obtainStoreKindID, storeSizeInternal, makeCollection };
 
   return harden({
     initializeStoreKindInfo,

--- a/packages/SwingSet/src/liveslots/virtualReferences.js
+++ b/packages/SwingSet/src/liveslots/virtualReferences.js
@@ -311,7 +311,9 @@ export function makeVirtualReferenceManager(
   function reanimate(baseRef, proForma) {
     const { id } = parseVatSlot(baseRef);
     const kindID = `${id}`;
-    const { reanimator } = kindInfoTable.get(kindID);
+    const kindInfo = kindInfoTable.get(kindID);
+    assert(kindInfo, `no kind info for ${kindID}, call defineDurableKind`);
+    const { reanimator } = kindInfo;
     if (reanimator) {
       return reanimator(baseRef, proForma);
     } else {

--- a/packages/SwingSet/test/stores/test-storeGC.js
+++ b/packages/SwingSet/test/stores/test-storeGC.js
@@ -521,6 +521,20 @@ function validateRetireExports(v, idx) {
 // collection during one test can interfere with the deterministic behavior of a
 // different test.
 
+// prettier-ignore
+test.serial('assert known scalarMapStore ID', async t => {
+  // The KindID for scalarMapStore is referenced by many of these
+  // tests (it is baked into our `mapRef()` function), and it might
+  // change if new IDs are allocated before the collection types are
+  // registered. Check it explicity here. If this test fails, consider
+  // updating `mapRef()` to use the new value.
+
+  const { testHooks } = await setupTestLiveslots(t, buildRootObject, 'bob', true);
+  const id = testHooks.obtainStoreKindID('scalarMapStore');
+  t.is(id, 1);
+  t.is(mapRef('INDEX'), 'o+1/INDEX');
+});
+
 // test 1: lerv -> Lerv -> LerV -> Lerv -> lerv
 test.serial('store lifecycle 1', async t => {
   const { v, dispatchMessage } = await setupTestLiveslots(

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -115,6 +115,7 @@ test('multifaceted virtual objects', t => {
       };
     },
   );
+  const kid = 'o+1';
   const { incr, decr } = makeMultiThing('foo');
   t.is(incr.getName(), 'foo');
   t.is(incr.getCount(), 0);
@@ -127,17 +128,17 @@ test('multifaceted virtual objects', t => {
   decr.dec();
   t.is(decr.getCount(), 1);
   const other = makeMultiThing('other');
-  t.is(log.shift(), `set vom.o+1/1 ${multiThingVal('foo', 1)}`);
+  t.is(log.shift(), `set vom.${kid}/1 ${multiThingVal('foo', 1)}`);
   t.deepEqual(log, []);
   incr.inc();
-  t.is(log.shift(), `set vom.o+1/2 ${multiThingVal('other', 0)}`);
-  t.is(log.shift(), `get vom.o+1/1 => ${multiThingVal('foo', 1)}`);
+  t.is(log.shift(), `set vom.${kid}/2 ${multiThingVal('other', 0)}`);
+  t.is(log.shift(), `get vom.${kid}/1 => ${multiThingVal('foo', 1)}`);
   other.decr.dec();
-  t.is(log.shift(), `set vom.o+1/1 ${multiThingVal('foo', 2)}`);
-  t.is(log.shift(), `get vom.o+1/2 => ${multiThingVal('other', 0)}`);
+  t.is(log.shift(), `set vom.${kid}/1 ${multiThingVal('foo', 2)}`);
+  t.is(log.shift(), `get vom.${kid}/2 => ${multiThingVal('other', 0)}`);
   incr.inc();
-  t.is(log.shift(), `set vom.o+1/2 ${multiThingVal('other', -1)}`);
-  t.is(log.shift(), `get vom.o+1/1 => ${multiThingVal('foo', 2)}`);
+  t.is(log.shift(), `set vom.${kid}/2 ${multiThingVal('other', -1)}`);
+  t.is(log.shift(), `get vom.${kid}/1 => ${multiThingVal('foo', 2)}`);
   t.deepEqual(log, []);
 });
 
@@ -147,7 +148,9 @@ test('virtual object operations', t => {
   const { defineKind, flushCache, dumpStore } = makeFakeVirtualObjectManager({ cacheSize: 3, log });
 
   const makeThing = defineKind('thing', initThing, actualizeThing);
+  const tid = 'o+1';
   const makeZot = defineKind('zot', initZot, actualizeZot);
+  const zid = 'o+2';
 
   // phase 0: start
   t.deepEqual(dumpStore(), []);
@@ -165,41 +168,41 @@ test('virtual object operations', t => {
 
   const zot1 = makeZot(23, 'Alice', 'is this on?'); // [z1-0 t4-0 t3-0 t2-0] evict t1-0
   // z1-0: 23 'Alice' 'is this on?' 0
-  t.is(log.shift(), `set vom.o+1/1 ${thingVal(0, 'thing-1', 0)}`); // evict t1-0
+  t.is(log.shift(), `set vom.${tid}/1 ${thingVal(0, 'thing-1', 0)}`); // evict t1-0
   t.deepEqual(log, []);
 
   const zot2 = makeZot(29, 'Bob', 'what are you saying?'); // [z2-0 z1-0 t4-0 t3-0] evict t2-0
   // z2-0: 29 'Bob' 'what are you saying?' 0
-  t.is(log.shift(), `set vom.o+1/2 ${thingVal(100, 'thing-2', 0)}`); // evict t2-0
+  t.is(log.shift(), `set vom.${tid}/2 ${thingVal(100, 'thing-2', 0)}`); // evict t2-0
   t.deepEqual(log, []);
 
   const zot3 = makeZot(47, 'Carol', 'as if...'); // [z3-0 z2-0 z1-0 t4-0] evict t3-0
   // z3-0: 47 'Carol' 'as if...' 0
-  t.is(log.shift(), `set vom.o+1/3 ${thingVal(200, 'thing-3', 0)}`); // evict t3-0
+  t.is(log.shift(), `set vom.${tid}/3 ${thingVal(200, 'thing-3', 0)}`); // evict t3-0
   t.deepEqual(log, []);
 
   const zot4 = makeZot(66, 'Dave', 'you and what army?'); // [z4-0 z3-0 z2-0 z1-0] evict t4-0
   // z4-0: 66 'Dave' 'you and what army?' 0
-  t.is(log.shift(), `set vom.o+1/4 ${thingVal(300, 'thing-4', 0)}`); // evict t4-0
+  t.is(log.shift(), `set vom.${tid}/4 ${thingVal(300, 'thing-4', 0)}`); // evict t4-0
   t.deepEqual(log, []);
 
   t.deepEqual(dumpStore(), [
-    ['vom.o+1/1', thingVal(0, 'thing-1', 0)], // =t1-0
-    ['vom.o+1/2', thingVal(100, 'thing-2', 0)], // =t2-0
-    ['vom.o+1/3', thingVal(200, 'thing-3', 0)], // =t3-0
-    ['vom.o+1/4', thingVal(300, 'thing-4', 0)], // =t4-0
+    [`vom.${tid}/1`, thingVal(0, 'thing-1', 0)], // =t1-0
+    [`vom.${tid}/2`, thingVal(100, 'thing-2', 0)], // =t2-0
+    [`vom.${tid}/3`, thingVal(200, 'thing-3', 0)], // =t3-0
+    [`vom.${tid}/4`, thingVal(300, 'thing-4', 0)], // =t4-0
   ]);
 
   // phase 2: first batch-o-stuff
   t.is(thing1.inc(), 1); // [t1-1 z4-0 z3-0 z2-0] evict z1-0
-  t.is(log.shift(), `set vom.o+2/1 ${zotVal(23, 'Alice', 'is this on?', 0)}`); // evict z1-0
-  t.is(log.shift(), `get vom.o+1/1 => ${thingVal(0, 'thing-1', 0)}`); // load t1-0
+  t.is(log.shift(), `set vom.${zid}/1 ${zotVal(23, 'Alice', 'is this on?', 0)}`); // evict z1-0
+  t.is(log.shift(), `get vom.${tid}/1 => ${thingVal(0, 'thing-1', 0)}`); // load t1-0
   t.deepEqual(log, []);
 
   // t1-1: 'thing-1' 1 0
   t.is(zot1.sayHello('hello'), 'hello Alice'); // [z1-1 t1-1 z4-0 z3-0] evict z2-0
-  t.is(log.shift(), `set vom.o+2/2 ${zotVal(29, 'Bob', 'what are you saying?', 0)}`); // evict z2-0
-  t.is(log.shift(), `get vom.o+2/1 => ${zotVal(23, 'Alice', 'is this on?', 0)}`); // load z1-0
+  t.is(log.shift(), `set vom.${zid}/2 ${zotVal(29, 'Bob', 'what are you saying?', 0)}`); // evict z2-0
+  t.is(log.shift(), `get vom.${zid}/1 => ${zotVal(23, 'Alice', 'is this on?', 0)}`); // load z1-0
   t.deepEqual(log, []);
 
   // z1-1: 23 'Alice' 'is this on?' 1
@@ -208,8 +211,8 @@ test('virtual object operations', t => {
 
   // t1-2: 'thing-1' 2 0
   t.is(zot2.sayHello('hi'), 'hi Bob'); // [z2-1 t1-2 z1-1 z4-0] evict z3-0
-  t.is(log.shift(), `set vom.o+2/3 ${zotVal(47, 'Carol', 'as if...', 0)}`); // evict z3-0
-  t.is(log.shift(), `get vom.o+2/2 => ${zotVal(29, 'Bob', 'what are you saying?', 0)}`); // load z2-0
+  t.is(log.shift(), `set vom.${zid}/3 ${zotVal(47, 'Carol', 'as if...', 0)}`); // evict z3-0
+  t.is(log.shift(), `get vom.${zid}/2 => ${zotVal(29, 'Bob', 'what are you saying?', 0)}`); // load z2-0
   t.deepEqual(log, []);
 
   // z2-1: 29 'Bob' 'what are you saying?' 1
@@ -218,20 +221,20 @@ test('virtual object operations', t => {
 
   // t1-3: 'thing-1' 3 0
   t.is(zot3.sayHello('aloha'), 'aloha Carol'); // [z3-1 t1-3 z2-1 z1-1] evict z4-0
-  t.is(log.shift(), `set vom.o+2/4 ${zotVal(66, 'Dave', 'you and what army?', 0)}`); // evict z4-0
-  t.is(log.shift(), `get vom.o+2/3 => ${zotVal(47, 'Carol', 'as if...', 0)}`); // load z3-0
+  t.is(log.shift(), `set vom.${zid}/4 ${zotVal(66, 'Dave', 'you and what army?', 0)}`); // evict z4-0
+  t.is(log.shift(), `get vom.${zid}/3 => ${zotVal(47, 'Carol', 'as if...', 0)}`); // load z3-0
   t.deepEqual(log, []);
 
   // z3-1: 47 'Carol' 'as if...' 1
   t.is(zot4.sayHello('bonjour'), 'bonjour Dave'); // [z4-1 z3-1 t1-3 z2-1] evict z1-1
-  t.is(log.shift(), `set vom.o+2/1 ${zotVal(23, 'Alice', 'is this on?', 1)}`); // evict z1-1
-  t.is(log.shift(), `get vom.o+2/4 => ${zotVal(66, 'Dave', 'you and what army?', 0)}`); // load z4-0
+  t.is(log.shift(), `set vom.${zid}/1 ${zotVal(23, 'Alice', 'is this on?', 1)}`); // evict z1-1
+  t.is(log.shift(), `get vom.${zid}/4 => ${zotVal(66, 'Dave', 'you and what army?', 0)}`); // load z4-0
   t.deepEqual(log, []);
 
   // z4-1: 66 'Dave' 'you and what army?' 1
   t.is(zot1.sayHello('hello again'), 'hello again Alice'); // [z1-2 z4-1 z3-1 t1-3] evict z2-1
-  t.is(log.shift(), `set vom.o+2/2 ${zotVal(29, 'Bob', 'what are you saying?', 1)}`); // evict z2-1
-  t.is(log.shift(), `get vom.o+2/1 => ${zotVal(23, 'Alice', 'is this on?', 1)}`); // get z1-1
+  t.is(log.shift(), `set vom.${zid}/2 ${zotVal(29, 'Bob', 'what are you saying?', 1)}`); // evict z2-1
+  t.is(log.shift(), `get vom.${zid}/1 => ${zotVal(23, 'Alice', 'is this on?', 1)}`); // get z1-1
   t.deepEqual(log, []);
 
   // z1-2: 23 'Alice' 'is this on?' 2
@@ -239,25 +242,25 @@ test('virtual object operations', t => {
     thing2.describe(), // [t2-0 z1-2 z4-1 z3-1] evict t1-3
     'thing-2 counter has been reset 0 times and is now 100',
   );
-  t.is(log.shift(), `set vom.o+1/1 ${thingVal(3, 'thing-1', 0)}`); // evict t1-3
-  t.is(log.shift(), `get vom.o+1/2 => ${thingVal(100, 'thing-2', 0)}`); // load t2-0
+  t.is(log.shift(), `set vom.${tid}/1 ${thingVal(3, 'thing-1', 0)}`); // evict t1-3
+  t.is(log.shift(), `get vom.${tid}/2 => ${thingVal(100, 'thing-2', 0)}`); // load t2-0
   t.deepEqual(log, []);
 
   t.deepEqual(dumpStore(), [
-    ['vom.o+1/1', thingVal(3, 'thing-1', 0)], // =t1-3
-    ['vom.o+1/2', thingVal(100, 'thing-2', 0)], // =t2-0
-    ['vom.o+1/3', thingVal(200, 'thing-3', 0)], // =t3-0
-    ['vom.o+1/4', thingVal(300, 'thing-4', 0)], // =t4-0
-    ['vom.o+2/1', zotVal(23, 'Alice', 'is this on?', 1)], // =z1-1
-    ['vom.o+2/2', zotVal(29, 'Bob', 'what are you saying?', 1)], // =z2-1
-    ['vom.o+2/3', zotVal(47, 'Carol', 'as if...', 0)], // =z3-0
-    ['vom.o+2/4', zotVal(66, 'Dave', 'you and what army?', 0)], // =z4-0
+    [`vom.${tid}/1`, thingVal(3, 'thing-1', 0)], // =t1-3
+    [`vom.${tid}/2`, thingVal(100, 'thing-2', 0)], // =t2-0
+    [`vom.${tid}/3`, thingVal(200, 'thing-3', 0)], // =t3-0
+    [`vom.${tid}/4`, thingVal(300, 'thing-4', 0)], // =t4-0
+    [`vom.${zid}/1`, zotVal(23, 'Alice', 'is this on?', 1)], // =z1-1
+    [`vom.${zid}/2`, zotVal(29, 'Bob', 'what are you saying?', 1)], // =z2-1
+    [`vom.${zid}/3`, zotVal(47, 'Carol', 'as if...', 0)], // =z3-0
+    [`vom.${zid}/4`, zotVal(66, 'Dave', 'you and what army?', 0)], // =z4-0
   ]);
 
   // phase 3: second batch-o-stuff
   t.is(thing1.get(), 3); // [t1-3 t2-0 z1-2 z4-1] evict z3-1
-  t.is(log.shift(), `set vom.o+2/3 ${zotVal(47, 'Carol', 'as if...', 1)}`); // evict z3-1
-  t.is(log.shift(), `get vom.o+1/1 => ${thingVal(3, 'thing-1', 0)}`); // load t1-3
+  t.is(log.shift(), `set vom.${zid}/3 ${zotVal(47, 'Carol', 'as if...', 1)}`); // evict z3-1
+  t.is(log.shift(), `get vom.${tid}/1 => ${thingVal(3, 'thing-1', 0)}`); // load t1-3
   t.deepEqual(log, []);
 
   t.is(thing1.inc(), 4); // [t1-4 t2-0 z1-2 z4-1]
@@ -265,26 +268,26 @@ test('virtual object operations', t => {
 
   // t1-4: 'thing-1' 4 0
   t.is(thing4.reset(1000), 1); // [t4-1 t1-4 t2-0 z1-2] evict z4-1
-  t.is(log.shift(), `set vom.o+2/4 ${zotVal(66, 'Dave', 'you and what army?', 1)}`); // evict z4-1
-  t.is(log.shift(), `get vom.o+1/4 => ${thingVal(300, 'thing-4', 0)}`); // load t4-0
+  t.is(log.shift(), `set vom.${zid}/4 ${zotVal(66, 'Dave', 'you and what army?', 1)}`); // evict z4-1
+  t.is(log.shift(), `get vom.${tid}/4 => ${thingVal(300, 'thing-4', 0)}`); // load t4-0
   t.deepEqual(log, []);
 
   // t4-1: 'thing-4' 1000 1
   t.is(zot3.rename('Chester'), 'Chester'); // [z3-2 t4-1 t1-4 t2-0] evict z1-2
-  t.is(log.shift(), `set vom.o+2/1 ${zotVal(23, 'Alice', 'is this on?', 2)}`); // evict z1-2
-  t.is(log.shift(), `get vom.o+2/3 => ${zotVal(47, 'Carol', 'as if...', 1)}`); // load z3-1
+  t.is(log.shift(), `set vom.${zid}/1 ${zotVal(23, 'Alice', 'is this on?', 2)}`); // evict z1-2
+  t.is(log.shift(), `get vom.${zid}/3 => ${zotVal(47, 'Carol', 'as if...', 1)}`); // load z3-1
   t.deepEqual(log, []);
 
   // z3-2: 47 'Chester' 'as if...' 2
   t.is(zot1.getInfo(), 'zot Alice tag=is this on? count=3 arbitrary=23'); // [z1-3 z3-2 t4-1 t1-4] evict t2-0
   // evict t2-0 does nothing because t2 is not dirty
-  t.is(log.shift(), `get vom.o+2/1 => ${zotVal(23, 'Alice', 'is this on?', 2)}`); // load z1-2
+  t.is(log.shift(), `get vom.${zid}/1 => ${zotVal(23, 'Alice', 'is this on?', 2)}`); // load z1-2
   t.deepEqual(log, []);
 
   // z1-3: 23 'Alice' 'is this on?' 3
   t.is(zot2.getInfo(), 'zot Bob tag=what are you saying? count=2 arbitrary=29'); // [z2-2 z1-3 z3-2 t4-1] evict t1-4
-  t.is(log.shift(), `set vom.o+1/1 ${thingVal(4, 'thing-1', 0)}`); // evict t1-4
-  t.is(log.shift(), `get vom.o+2/2 => ${zotVal(29, 'Bob', 'what are you saying?', 1)}`); // load z2-1
+  t.is(log.shift(), `set vom.${tid}/1 ${thingVal(4, 'thing-1', 0)}`); // evict t1-4
+  t.is(log.shift(), `get vom.${zid}/2 => ${zotVal(29, 'Bob', 'what are you saying?', 1)}`); // load z2-1
   t.deepEqual(log, []);
 
   // z2-2: 29 'Bob' 'what are you saying?' 1
@@ -292,8 +295,8 @@ test('virtual object operations', t => {
     thing2.describe(), // [t2-0 z2-2 z1-3 z3-2] evict t4-1
     'thing-2 counter has been reset 0 times and is now 100',
   );
-  t.is(log.shift(), `set vom.o+1/4 ${thingVal(1000, 'thing-4', 1)}`); // evict t4-1
-  t.is(log.shift(), `get vom.o+1/2 => ${thingVal(100, 'thing-2', 0)}`); // load t2-0
+  t.is(log.shift(), `set vom.${tid}/4 ${thingVal(1000, 'thing-4', 1)}`); // evict t4-1
+  t.is(log.shift(), `get vom.${tid}/2 => ${thingVal(100, 'thing-2', 0)}`); // load t2-0
   t.deepEqual(log, []);
 
   t.is(zot3.getInfo(), 'zot Chester tag=as if... count=3 arbitrary=47'); // [z3-3 t2-0 z2-2 z1-3]
@@ -301,14 +304,14 @@ test('virtual object operations', t => {
 
   // z3-3: 47 'Chester' 'as if...' 3
   t.is(zot4.getInfo(), 'zot Dave tag=you and what army? count=2 arbitrary=66'); // [z4-1 z3-3 t2-0 z2-2] evict z1-3
-  t.is(log.shift(), `set vom.o+2/1 ${zotVal(23, 'Alice', 'is this on?', 3)}`); // evict z1-3
-  t.is(log.shift(), `get vom.o+2/4 => ${zotVal(66, 'Dave', 'you and what army?', 1)}`); // load z4-1
+  t.is(log.shift(), `set vom.${zid}/1 ${zotVal(23, 'Alice', 'is this on?', 3)}`); // evict z1-3
+  t.is(log.shift(), `get vom.${zid}/4 => ${zotVal(66, 'Dave', 'you and what army?', 1)}`); // load z4-1
   t.deepEqual(log, []);
 
   // z4-2: 66 'Dave' 'you and what army?' 2
   t.is(thing3.inc(), 201); // [t3-1 z4-2 z3-3 t2-0] evict z2-2
-  t.is(log.shift(), `set vom.o+2/2 ${zotVal(29, 'Bob', 'what are you saying?', 2)}`); // evict z2-2
-  t.is(log.shift(), `get vom.o+1/3 => ${thingVal(200, 'thing-3', 0)}`); // load t3-0
+  t.is(log.shift(), `set vom.${zid}/2 ${zotVal(29, 'Bob', 'what are you saying?', 2)}`); // evict z2-2
+  t.is(log.shift(), `get vom.${tid}/3 => ${thingVal(200, 'thing-3', 0)}`); // load t3-0
   t.deepEqual(log, []);
 
   // t3-1: 'thing-3' 201 0
@@ -317,43 +320,43 @@ test('virtual object operations', t => {
     'thing-4 counter has been reset 1 times and is now 1000',
   );
   // evict t2-0 does nothing because t2 is not dirty
-  t.is(log.shift(), `get vom.o+1/4 => ${thingVal(1000, 'thing-4', 1)}`); // load t4-1
+  t.is(log.shift(), `get vom.${tid}/4 => ${thingVal(1000, 'thing-4', 1)}`); // load t4-1
   t.deepEqual(log, []);
 
   t.deepEqual(dumpStore(), [
-    ['vom.o+1/1', thingVal(4, 'thing-1', 0)], // =t1-4
-    ['vom.o+1/2', thingVal(100, 'thing-2', 0)], // =t2-0
-    ['vom.o+1/3', thingVal(200, 'thing-3', 0)], // =t3-0
-    ['vom.o+1/4', thingVal(1000, 'thing-4', 1)], // =t4-1
-    ['vom.o+2/1', zotVal(23, 'Alice', 'is this on?', 3)], // =z1-3
-    ['vom.o+2/2', zotVal(29, 'Bob', 'what are you saying?', 2)], // =z2-2
-    ['vom.o+2/3', zotVal(47, 'Carol', 'as if...', 1)], // =z3-1
-    ['vom.o+2/4', zotVal(66, 'Dave', 'you and what army?', 1)], // =z4-1
+    [`vom.${tid}/1`, thingVal(4, 'thing-1', 0)], // =t1-4
+    [`vom.${tid}/2`, thingVal(100, 'thing-2', 0)], // =t2-0
+    [`vom.${tid}/3`, thingVal(200, 'thing-3', 0)], // =t3-0
+    [`vom.${tid}/4`, thingVal(1000, 'thing-4', 1)], // =t4-1
+    [`vom.${zid}/1`, zotVal(23, 'Alice', 'is this on?', 3)], // =z1-3
+    [`vom.${zid}/2`, zotVal(29, 'Bob', 'what are you saying?', 2)], // =z2-2
+    [`vom.${zid}/3`, zotVal(47, 'Carol', 'as if...', 1)], // =z3-1
+    [`vom.${zid}/4`, zotVal(66, 'Dave', 'you and what army?', 1)], // =z4-1
   ]);
 
   // phase 4: flush test
   t.is(thing1.inc(), 5); // [t1-5 t4-1 t3-1 z4-2] evict z3-3
-  t.is(log.shift(), `set vom.o+2/3 ${zotVal(47, 'Chester', 'as if...', 3)}`); // evict z3-3
-  t.is(log.shift(), `get vom.o+1/1 => ${thingVal(4, 'thing-1', 0)}`); // load t1-4
+  t.is(log.shift(), `set vom.${zid}/3 ${zotVal(47, 'Chester', 'as if...', 3)}`); // evict z3-3
+  t.is(log.shift(), `get vom.${tid}/1 => ${thingVal(4, 'thing-1', 0)}`); // load t1-4
   t.deepEqual(log, []);
 
   // t1-5: 'thing-1' 5 0
   flushCache(); // [] evict z4-2 t3-1 t4-1 t1-5
-  t.is(log.shift(), `set vom.o+2/4 ${zotVal(66, 'Dave', 'you and what army?', 2)}`); // evict z4-2
-  t.is(log.shift(), `set vom.o+1/3 ${thingVal(201, 'thing-3', 0)}`); // evict t3-1
+  t.is(log.shift(), `set vom.${zid}/4 ${zotVal(66, 'Dave', 'you and what army?', 2)}`); // evict z4-2
+  t.is(log.shift(), `set vom.${tid}/3 ${thingVal(201, 'thing-3', 0)}`); // evict t3-1
   // evict t4-1 does nothing because t4 is not dirty
-  t.is(log.shift(), `set vom.o+1/1 ${thingVal(5, 'thing-1', 0)}`); // evict t1-5
+  t.is(log.shift(), `set vom.${tid}/1 ${thingVal(5, 'thing-1', 0)}`); // evict t1-5
   t.deepEqual(log, []);
 
   t.deepEqual(dumpStore(), [
-    ['vom.o+1/1', thingVal(5, 'thing-1', 0)], // =t1-5
-    ['vom.o+1/2', thingVal(100, 'thing-2', 0)], // =t2-0
-    ['vom.o+1/3', thingVal(201, 'thing-3', 0)], // =t3-1
-    ['vom.o+1/4', thingVal(1000, 'thing-4', 1)], // =t4-1
-    ['vom.o+2/1', zotVal(23, 'Alice', 'is this on?', 3)], // =z1-3
-    ['vom.o+2/2', zotVal(29, 'Bob', 'what are you saying?', 2)], // =z2-2
-    ['vom.o+2/3', zotVal(47, 'Chester', 'as if...', 3)], // =z3-3
-    ['vom.o+2/4', zotVal(66, 'Dave', 'you and what army?', 2)], // =z4-2
+    [`vom.${tid}/1`, thingVal(5, 'thing-1', 0)], // =t1-5
+    [`vom.${tid}/2`, thingVal(100, 'thing-2', 0)], // =t2-0
+    [`vom.${tid}/3`, thingVal(201, 'thing-3', 0)], // =t3-1
+    [`vom.${tid}/4`, thingVal(1000, 'thing-4', 1)], // =t4-1
+    [`vom.${zid}/1`, zotVal(23, 'Alice', 'is this on?', 3)], // =z1-3
+    [`vom.${zid}/2`, zotVal(29, 'Bob', 'what are you saying?', 2)], // =z2-2
+    [`vom.${zid}/3`, zotVal(47, 'Chester', 'as if...', 3)], // =z3-3
+    [`vom.${zid}/4`, zotVal(66, 'Dave', 'you and what army?', 2)], // =z4-2
   ]);
 });
 
@@ -411,15 +414,16 @@ test('durable kind IDs can be reanimated', t => {
   t.is(log.shift(), 'set kindIDID 9');
   t.is(log.shift(), 'set vom.kind.10 {"kindID":"10","tag":"testkind"}');
   t.deepEqual(log, []);
+  const khid = `o+9/10`;
 
   // Store it in the store without having used it
   placeToPutIt.init('savedKindID', kindHandle);
   t.is(log.shift(), 'get vc.1.ssavedKindID => undefined');
-  t.is(log.shift(), 'get vom.rc.o+9/10 => undefined');
-  t.is(log.shift(), 'set vom.rc.o+9/10 1');
+  t.is(log.shift(), `get vom.rc.${khid} => undefined`);
+  t.is(log.shift(), `set vom.rc.${khid} 1`);
   const kindBody =
     '"{\\"@qclass\\":\\"slot\\",\\"iface\\":\\"Alleged: kind\\",\\"index\\":0}"';
-  const kindSer = `{"body":${kindBody},"slots":["o+9/10"]}`;
+  const kindSer = `{"body":${kindBody},"slots":["${khid}"]}`;
   t.is(log.shift(), `set vc.1.ssavedKindID ${kindSer}`);
   t.is(log.shift(), 'get vc.1.|entryCount => 0');
   t.is(log.shift(), 'set vc.1.|entryCount 1');
@@ -427,10 +431,10 @@ test('durable kind IDs can be reanimated', t => {
 
   // Forget its existence
   kindHandle = null;
-  deleteEntry('o+9/10');
-  possibleVirtualObjectDeath('o+9/10');
-  t.is(log.shift(), 'get vom.rc.o+9/10 => 1');
-  t.is(log.shift(), 'get vom.es.o+9/10 => undefined');
+  deleteEntry(khid);
+  possibleVirtualObjectDeath(khid);
+  t.is(log.shift(), `get vom.rc.${khid} => 1`);
+  t.is(log.shift(), `get vom.es.${khid} => undefined`);
   t.deepEqual(log, []);
 
   // Fetch it from the store, which should reanimate it


### PR DESCRIPTION
Make some small non-functionality-changing improvements to the
virtual-object code and its tests.

collectionManager.js and virtualReferesnces.js add some internal
asserts, to catch things I stumbled across during development.

test-storeGC.js acquired a new test case which checks our assumption
that the `scalarMapStore` collection type will be alloced a specific
ID (`o+1`). This assumption is baked into the rest of test-storeGC.js,
and will change when liveslots is modified to perform more allocations
at startup. By testing our test's assumption, it should be easier to
safely update the test. collectionManager.js now exports
testHooks.obtainStoreKindID to support this test.

In test-virtualObjectManager.js I factored out the kindHandle
IDs. This should not change the behavior of the current test, it just
consolidates a number of hard-coded identifiers into a single
place. We'll be changing the way kindHandle allocation happens soon,
and it will be easier to review the corresponding test changes if they
only modify the one variable.
