### PR TITLE
chore: drop an extraneous reference to `main`.

### DIFF
--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -146,7 +146,7 @@ const start = async zcf => {
   /** @type {() => Promise<PoserFacet>} */
   const getUpdatedPoserFacet = async () => {
     const newInvitation = await E(
-      E(E(governedCF).getParamMgrRetriever()).get({ key: 'main' }),
+      E(E(governedCF).getParamMgrRetriever()).get(),
     ).getInternalParamValue(CONTRACT_ELECTORATE);
 
     if (newInvitation !== currentInvitation) {

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -146,7 +146,7 @@ const start = async zcf => {
   /** @type {() => Promise<PoserFacet>} */
   const getUpdatedPoserFacet = async () => {
     const newInvitation = await E(
-      E(E(governedCF).getParamMgrRetriever()).get(),
+      E(E(governedCF).getParamMgrRetriever()).get({ key: 'governedParams' }),
     ).getInternalParamValue(CONTRACT_ELECTORATE);
 
     if (newInvitation !== currentInvitation) {

--- a/packages/run-protocol/src/psm/psm.js
+++ b/packages/run-protocol/src/psm/psm.js
@@ -47,7 +47,7 @@ function stageTransfer(from, to, txFrom, txTo = txFrom) {
  * @param {ZCF<{
  *    anchorBrand: Brand,
  *    anchorPerStable: Ratio,
- *    main: {
+ *    governedParams: {
  *      WantStableFeeBP: bigint,
  *      GiveStableFeeBP: bigint,
  *      MintLimit: Amount } }>
@@ -77,7 +77,7 @@ export const start = async (zcf, privateArgs) => {
   // Mock simple goverannce API for parameters that will be controlled by governance
   const getGovernance = _ => {
     const {
-      main: { WantStableFeeBP, GiveStableFeeBP, MintLimit },
+      governedParams: { WantStableFeeBP, GiveStableFeeBP, MintLimit },
     } = zcf.getTerms();
     assert(
       AmountMath.isGTE(MintLimit, emptyAnchor),

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -255,7 +255,7 @@ export const start = async (zcf, privateArgs) => {
   const getParamMgrRetriever = () =>
     Far('paramManagerRetriever', {
       get: paramDesc => {
-        if (paramDesc.key === 'main') {
+        if (paramDesc.key === 'governedParams') {
           return electorateParamManager;
         } else {
           return vaultParamManagers.get(paramDesc.collateralBrand);

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-governance.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-governance.js
@@ -59,7 +59,7 @@ test('amm change param via Governance', async t => {
   const invitations = await E(committeeCreator).getVoterInvitations();
   const { governorCreatorFacet } = governor;
   const { details } = await E(governorCreatorFacet).voteOnParamChange(
-    { key: 'main', parameterName: PROTOCOL_FEE_KEY },
+    { key: 'governedParams', parameterName: PROTOCOL_FEE_KEY },
     20n,
     installs.counter,
     2n,
@@ -158,7 +158,7 @@ test('price check after Governance param change', async t => {
   const invitations = await E(committeeCreator).getVoterInvitations();
   const { governorCreatorFacet } = governor;
   const { details } = await E(governorCreatorFacet).voteOnParamChange(
-    { key: 'main', parameterName: PROTOCOL_FEE_KEY },
+    { key: 'governedParams', parameterName: PROTOCOL_FEE_KEY },
     20n,
     installs.counter,
     2n,

--- a/packages/run-protocol/test/psm/test-psm.js
+++ b/packages/run-protocol/test/psm/test-psm.js
@@ -113,7 +113,7 @@ test.before(async t => {
   t.context.terms = {
     anchorBrand,
     anchorPerStable: makeRatio(100n, anchorBrand, 100n, runBrand),
-    main: { WantStableFeeBP, GiveStableFeeBP, MintLimit: mintLimit },
+    governedParams: { WantStableFeeBP, GiveStableFeeBP, MintLimit: mintLimit },
   };
 });
 


### PR DESCRIPTION
refs: #4868
closes: #4818

## Description

Drop an extraneous reference to `main`.
It was in an ignored position.

### Security Considerations

type checking didn't notice it.

### Documentation Considerations

None

### Testing Considerations

The test didn't notice it, either, since it was an ignored parameter.