### PR TITLE
feat(run-protocol): debtLimit governed param

### DIFF
--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -7,6 +7,7 @@ import '@agoric/governance/exported.js';
 import '@agoric/vats/exported.js';
 import '@agoric/vats/src/core/types.js';
 
+import { AmountMath } from '@agoric/ertp';
 import { makeGovernedTerms } from './vaultFactory/params.js';
 import { makeAmmTerms } from './vpool-xyk-amm/params.js';
 import { makeReserveTerms } from './reserve/params.js';
@@ -251,11 +252,17 @@ export const startVaultFactory = async (
 
   const centralBrand = await centralBrandP;
 
-  // declare governed params for the vaultFactory; addVaultType() sets actual rates
-  const rates = {
-    liquidationMargin: makeRatio(105n, centralBrand),
-    interestRate: makeRatio(250n, centralBrand, BASIS_POINTS),
-    loanFee: makeRatio(200n, centralBrand, BASIS_POINTS),
+  /**
+   * Types for the governed params for the vaultFactory; addVaultType() sets actual values
+   *
+   * @type {VaultManagerParamValues}
+   */
+  const vaultManagerParams = {
+    // XXX the values aren't used. May be addressed by https://github.com/Agoric/agoric-sdk/issues/4861
+    debtLimit: AmountMath.make(centralBrand, 0n),
+    liquidationMargin: makeRatio(0n, centralBrand),
+    interestRate: makeRatio(0n, centralBrand, BASIS_POINTS),
+    loanFee: makeRatio(0n, centralBrand, BASIS_POINTS),
   };
 
   const [ammInstance, electorateInstance, contractGovernorInstall] =
@@ -273,7 +280,7 @@ export const startVaultFactory = async (
     installations.liquidate,
     chainTimerService,
     invitationAmount,
-    rates,
+    vaultManagerParams,
     ammPublicFacet,
   );
   const governorTerms = harden({

--- a/packages/run-protocol/src/vaultFactory/params.js
+++ b/packages/run-protocol/src/vaultFactory/params.js
@@ -12,6 +12,7 @@ import {
 export const CHARGING_PERIOD_KEY = 'ChargingPeriod';
 export const RECORDING_PERIOD_KEY = 'RecordingPeriod';
 
+export const DEBT_LIMIT_KEY = 'DebtLimit';
 export const LIQUIDATION_MARGIN_KEY = 'LiquidationMargin';
 export const INTEREST_RATE_KEY = 'InterestRate';
 export const LOAN_FEE_KEY = 'LoanFee';
@@ -29,13 +30,14 @@ const makeElectorateParams = electorateInvitationAmount => {
 };
 
 /**
- * @param {Rates} rates
+ * @param {VaultManagerParamValues} initial
  */
-const makeVaultParamManager = rates =>
+const makeVaultParamManager = initial =>
   makeParamManagerSync({
-    [LIQUIDATION_MARGIN_KEY]: [ParamTypes.RATIO, rates.liquidationMargin],
-    [INTEREST_RATE_KEY]: [ParamTypes.RATIO, rates.interestRate],
-    [LOAN_FEE_KEY]: [ParamTypes.RATIO, rates.loanFee],
+    [DEBT_LIMIT_KEY]: [ParamTypes.AMOUNT, initial.debtLimit],
+    [LIQUIDATION_MARGIN_KEY]: [ParamTypes.RATIO, initial.liquidationMargin],
+    [INTEREST_RATE_KEY]: [ParamTypes.RATIO, initial.interestRate],
+    [LOAN_FEE_KEY]: [ParamTypes.RATIO, initial.loanFee],
   });
 /** @typedef {ReturnType<typeof makeVaultParamManager>} VaultParamManager */
 
@@ -58,7 +60,7 @@ const makeElectorateParamManager = async (zoe, electorateInvitation) => {
  * @param {Installation} liquidationInstall
  * @param {ERef<TimerService>} timerService
  * @param {Amount} invitationAmount
- * @param {Rates} rates
+ * @param {VaultManagerParamValues} vaultManagerParams
  * @param {XYKAMMPublicFacet} ammPublicFacet
  * @param {bigint=} bootstrapPaymentValue
  */
@@ -68,7 +70,7 @@ const makeGovernedTerms = (
   liquidationInstall,
   timerService,
   invitationAmount,
-  rates,
+  vaultManagerParams,
   ammPublicFacet,
   bootstrapPaymentValue = 0n,
 ) => {
@@ -77,12 +79,12 @@ const makeGovernedTerms = (
     [RECORDING_PERIOD_KEY]: ['nat', loanTiming.recordingPeriod],
   });
 
-  const rateParamMgr = makeVaultParamManager(rates);
+  const vmParamMgr = makeVaultParamManager(vaultManagerParams);
 
   return harden({
     ammPublicFacet,
     priceAuthority,
-    loanParams: rateParamMgr.getParams(),
+    loanParams: vmParamMgr.getParams(),
     loanTimingParams: timingParamMgr.getParams(),
     timerService,
     liquidationInstall,

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -22,19 +22,20 @@
  */
 
 /**
- * @typedef {Object} Rates
+ * @typedef {Object} VaultManagerParamValues
  * @property {Ratio} liquidationMargin - margin below which collateral will be
  * liquidated to satisfy the debt.
  * @property {Ratio} interestRate - annual interest rate charged on loans
  * @property {Ratio} loanFee - The fee (in BasisPoints) charged when opening
  * or increasing a loan.
+ * @property {Amount<'nat'>} debtLimit
  */
 
 /**
  * @callback AddVaultType
  * @param {Issuer} collateralIssuer
  * @param {Keyword} collateralKeyword
- * @param {Rates} rates
+ * @param {VaultManagerParamValues} params
  * @returns {Promise<VaultManager>}
  */
 
@@ -53,8 +54,6 @@
  * Mint new debt `toMint` and transfer the `fee` portion to the vaultFactory's reward
  * pool. Then reallocate over all the seat arguments and the rewardPoolSeat. Update
  * the `totalDebt` if the reallocate succeeds.
- *
- * TODO check limits.
  *
  * @param {Amount} toMint
  * @param {Amount} fee

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -122,13 +122,15 @@ export const start = async (zcf, privateArgs) => {
   /** @type {Store<Brand,VaultManager>} */
   const collateralTypes = makeScalarMap('brand');
 
-  const zoe = zcf.getZoeService();
-
   /** @type { Store<Brand, import('./params.js').VaultParamManager> } */
   const vaultParamManagers = makeScalarMap('brand');
 
   /** @type {AddVaultType} */
-  const addVaultType = async (collateralIssuer, collateralKeyword, rates) => {
+  const addVaultType = async (
+    collateralIssuer,
+    collateralKeyword,
+    initialParamValues,
+  ) => {
     await zcf.saveIssuer(collateralIssuer, collateralKeyword);
     const collateralBrand = zcf.getBrandForIssuer(collateralIssuer);
     // We create only one vault per collateralType.
@@ -138,9 +140,10 @@ export const start = async (zcf, privateArgs) => {
     );
 
     /** a powerful object; can modify parameters */
-    const vaultParamManager = makeVaultParamManager(rates);
+    const vaultParamManager = makeVaultParamManager(initialParamValues);
     vaultParamManagers.init(collateralBrand, vaultParamManager);
 
+    const zoe = zcf.getZoeService();
     const { creatorFacet: liquidationFacet } = await E(zoe).startInstance(
       liquidationInstall,
       harden({ RUN: debtIssuer, Collateral: collateralIssuer }),
@@ -219,6 +222,7 @@ export const start = async (zcf, privateArgs) => {
   // bookkeeping. It's needed in tests.
   const getRewardAllocation = () => rewardPoolSeat.getCurrentAllocation();
 
+  // TODO use named getters of TypedParamManager
   const getGovernedParams = paramDesc => {
     return vaultParamManagers.get(paramDesc.collateralBrand).getParams();
   };
@@ -265,6 +269,7 @@ export const start = async (zcf, privateArgs) => {
 
   /** @type {VaultFactory} */
   const vaultFactory = Far('vaultFactory machine', {
+    // TODO move this under governance #3972
     addVaultType,
     getCollaterals,
     getRewardAllocation,

--- a/packages/run-protocol/test/swingsetTests/setup.js
+++ b/packages/run-protocol/test/swingsetTests/setup.js
@@ -47,11 +47,18 @@ const installContracts = async (zoe, cb) => {
   return installations;
 };
 
-const makeRates = runBrand => {
+/**
+ * Provide initial values for governed vault manager params.
+ *
+ * @param {Brand} debtBrand
+ * @returns {VaultManagerParamValues}
+ */
+const makeRates = debtBrand => {
   return {
-    liquidationMargin: makeRatio(105n, runBrand),
-    interestRate: makeRatio(250n, runBrand, BASIS_POINTS),
-    loanFee: makeRatio(200n, runBrand, BASIS_POINTS),
+    debtLimit: AmountMath.make(debtBrand, 1_000_000n),
+    liquidationMargin: makeRatio(105n, debtBrand),
+    interestRate: makeRatio(250n, debtBrand, BASIS_POINTS),
+    loanFee: makeRatio(200n, debtBrand, BASIS_POINTS),
   };
 };
 

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -91,14 +91,19 @@ async function waitForPromisesToSettle() {
   return pk.promise;
 }
 
-function makeRates(runBrand) {
+/**
+ * @param {Brand} debtBrand
+ * @returns dL: 1M, lM: 105, iR: 100, lF: 500
+ */
+function defaultParamValues(debtBrand) {
   return harden({
+    debtLimit: AmountMath.make(debtBrand, 1_000_000n),
     // margin required to maintain a loan
-    liquidationMargin: makeRatio(105n, runBrand),
+    liquidationMargin: makeRatio(105n, debtBrand),
     // periodic interest rate (per charging period)
-    interestRate: makeRatio(100n, runBrand, BASIS_POINTS),
+    interestRate: makeRatio(100n, debtBrand, BASIS_POINTS),
     // charge to create or increase loan balance
-    loanFee: makeRatio(500n, runBrand, BASIS_POINTS),
+    loanFee: makeRatio(500n, debtBrand, BASIS_POINTS),
   });
 }
 
@@ -348,7 +353,7 @@ test('first', async t => {
   const { vaultFactory, lender } = services.vaultFactory;
 
   // Add a vault that will lend on aeth collateral
-  const rates = makeRates(runBrand);
+  const rates = defaultParamValues(runBrand);
   const aethVaultManager = await E(vaultFactory).addVaultType(
     aethIssuer,
     'AEth',
@@ -496,7 +501,7 @@ test('price drop', async t => {
   const { vaultFactory, lender } = services.vaultFactory;
 
   // Add a vault that will lend on aeth collateral
-  const rates = makeRates(runBrand);
+  const rates = defaultParamValues(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
   // Create a loan for 270 RUN with 400 aeth collateral
@@ -644,7 +649,7 @@ test('price falls precipitously', async t => {
   const { vaultFactory, lender } = services.vaultFactory;
 
   // Add a vault that will lend on aeth collateral
-  const rates = makeRates(runBrand);
+  const rates = defaultParamValues(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
   // Create a loan for 370 RUN with 400 aeth collateral
@@ -804,8 +809,7 @@ test('vaultFactory display collateral', async t => {
   const { vaultFactory } = services.vaultFactory;
 
   const rates = harden({
-    liquidationMargin: makeRatio(105n, runBrand),
-    interestRate: makeRatio(100n, runBrand, BASIS_POINTS),
+    ...defaultParamValues(runBrand),
     loanFee: makeRatio(530n, runBrand, BASIS_POINTS),
   });
 
@@ -859,12 +863,10 @@ test('interest on multiple vaults', async t => {
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
 
-  const interestRate = makeRatio(5n, runBrand);
-  const rates = harden({
-    liquidationMargin: makeRatio(105n, runBrand),
-    interestRate,
-    loanFee: makeRatio(500n, runBrand, BASIS_POINTS),
-  });
+  const rates = {
+    ...defaultParamValues(runBrand),
+    interestRate: makeRatio(5n, runBrand),
+  };
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
   // Create a loan for Alice for 4700 RUN with 1100 aeth collateral
@@ -966,7 +968,7 @@ test('interest on multiple vaults', async t => {
     ),
     AmountMath.make(runBrand, 3200n + bobAddedDebt),
   );
-  t.deepEqual(bobUpdate.value.interestRate, interestRate);
+  t.deepEqual(bobUpdate.value.interestRate, rates.interestRate);
   t.deepEqual(
     bobUpdate.value.liquidationRatio,
     makeRatio(105n, runBrand, 100n),
@@ -988,7 +990,7 @@ test('interest on multiple vaults', async t => {
     debt: AmountMath.make(runBrand, 4935n),
     interest: makeRatio(100n, runBrand, 100n),
   });
-  t.deepEqual(aliceUpdate.value.interestRate, interestRate);
+  t.deepEqual(aliceUpdate.value.interestRate, rates.interestRate);
   t.deepEqual(aliceUpdate.value.liquidationRatio, makeRatio(105n, runBrand));
 
   const rewardAllocation = await E(vaultFactory).getRewardAllocation();
@@ -1086,7 +1088,7 @@ test('adjust balances', async t => {
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
 
-  const rates = makeRates(runBrand);
+  const rates = defaultParamValues(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
   // initial loan /////////////////////////////////////
@@ -1340,7 +1342,7 @@ test('transfer vault', async t => {
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
 
-  const rates = makeRates(runBrand);
+  const rates = defaultParamValues(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
   // initial loan /////////////////////////////////////
@@ -1508,7 +1510,7 @@ test('overdeposit', async t => {
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
 
-  const rates = makeRates(runBrand);
+  const rates = defaultParamValues(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
   // Alice's loan /////////////////////////////////////
@@ -1669,10 +1671,9 @@ test('mutable liquidity triggers and interest', async t => {
 
   // Add a vaultManager with 10000 aeth collateral at a 200 aeth/RUN rate
   const rates = harden({
-    liquidationMargin: makeRatio(105n, runBrand),
+    ...defaultParamValues(runBrand),
     // charge 5% interest
     interestRate: makeRatio(5n, runBrand),
-    loanFee: makeRatio(500n, runBrand, BASIS_POINTS),
   });
 
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
@@ -1872,7 +1873,7 @@ test('collect fees from loan and AMM', async t => {
   const { vaultFactory, lender } = services.vaultFactory;
 
   // Add a pool with 900 aeth collateral at a 201 aeth/RUN rate
-  const rates = makeRates(runBrand);
+  const rates = defaultParamValues(runBrand);
 
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
@@ -1971,7 +1972,7 @@ test('close loan', async t => {
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
 
-  const rates = makeRates(runBrand);
+  const rates = defaultParamValues(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
   // initial loan /////////////////////////////////////
@@ -2108,7 +2109,7 @@ test('excessive loan', async t => {
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
 
-  const rates = makeRates(runBrand);
+  const rates = defaultParamValues(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
   // Try to Create a loan for Alice for 5000 RUN with 100 aeth collateral
@@ -2127,6 +2128,69 @@ test('excessive loan', async t => {
   );
   await t.throwsAsync(() => E(aliceLoanSeat).getOfferResult(), {
     message: /exceeds max/,
+  });
+});
+
+/**
+ * Each vaultManager manages one collateral type and has a governed parameter, `debtLimit`,
+ * that specifies a cap on the amount of debt the manager will allow.
+ *
+ * Attempts to adjust balances on vaults beyond the debt limit fail.
+ * In other words, minting for anything other than charging interest fails.
+ */
+test('excessive debt on collateral type', async t => {
+  const {
+    aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
+  } = setupAssets();
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
+  const loanTiming = {
+    chargingPeriod: 2n,
+    recordingPeriod: 6n,
+  };
+  const services = await setupServices(
+    loanTiming,
+    [15n],
+    AmountMath.make(aethBrand, 1n),
+    aethBrand,
+    {
+      committeeName: 'Star Chamber',
+      committeeSize: 5,
+    },
+    buildManualTimer(console.log),
+    undefined,
+    aethLiquidity,
+    500n,
+    aethIssuer,
+  );
+  const {
+    zoe,
+    runKit: { brand: runBrand },
+  } = services;
+  const { vaultFactory, lender } = services.vaultFactory;
+
+  const rates = defaultParamValues(runBrand);
+  await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
+
+  const collateralAmount = AmountMath.make(aethBrand, 1_000_000n);
+  const centralAmount = AmountMath.make(runBrand, 1_000_000n);
+  /** @type {UserSeat<VaultKit>} */
+  const loanSeat = await E(zoe).offer(
+    E(lender).makeVaultInvitation(),
+    harden({
+      give: { Collateral: collateralAmount },
+      want: { RUN: centralAmount },
+    }),
+    harden({
+      Collateral: aethMint.mintPayment(collateralAmount),
+    }),
+  );
+  await t.throwsAsync(() => E(loanSeat).getOfferResult(), {
+    message:
+      'Minting would exceed total debt limit {"brand":"[Alleged: RUN brand]","value":"[1000000n]"}',
   });
 });
 
@@ -2178,9 +2242,8 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
 
   // Add a vaultManager with 10000 aeth collateral at a 200 aeth/RUN rate
   const rates = harden({
-    liquidationMargin: makeRatio(105n, runBrand),
+    ...defaultParamValues(runBrand),
     // charge 5% interest
-    interestRate: makeRatio(5n, runBrand),
     loanFee: makeRatio(500n, runBrand, BASIS_POINTS),
   });
 

--- a/packages/vats/src/demoIssuers.js
+++ b/packages/vats/src/demoIssuers.js
@@ -446,6 +446,7 @@ export const poolRates = (issuerName, record, kits, central) => {
    */
   const toRatio = ([n, d], b) => makeRatio(n, b, d);
   const rates = {
+    debtLimit: AmountMath.make(central.brand, 1_000_000n),
     initialPrice: makeRatio(
       initialPriceNumerator,
       central.brand,


### PR DESCRIPTION
advances: #3501 (might close, depending on what's left for UI work)

## Description

Add a param to vault-manager governance: `debtLimit`.

If minting triggered by a vault operation would exceed the debt limit, fail. Minting for charging interest is always allowed.

### Security Considerations

New governed param. Malicious manipulation could halt minting.

### Documentation Considerations

Other packages calling `addVaultType` will need to include an initial value for `debtLimit`.

### Testing Considerations

The param and check are tested. I'm not sure how to test this requirement of the work item,
> UIs should be able to show a user before attempting to make a transaction if it would fail for this reason

Any advice @samsiegart ?
