### PR TITLE
Eliminate the propertyNames Set

### DIFF
--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -498,7 +498,6 @@ export function makeVirtualObjectManager(
    */
   function defineKindInternal(kindID, tag, init, actualize, finish, durable) {
     let nextInstanceID = 1;
-    const propertyNames = new Set();
 
     function makeRepresentative(innerSelf, initializing, proForma) {
       if (!proForma) {
@@ -518,7 +517,10 @@ export function makeVirtualObjectManager(
       }
 
       const wrappedState = {};
-      for (const prop of propertyNames) {
+      if (!initializing) {
+        ensureState();
+      }
+      for (const prop of Object.getOwnPropertyNames(innerSelf.rawState)) {
         Object.defineProperty(wrappedState, prop, {
           get: () => {
             ensureState();
@@ -631,7 +633,6 @@ export function makeVirtualObjectManager(
         }
         data.slots.map(vrm.addReachableVref);
         rawState[prop] = data;
-        propertyNames.add(prop);
       }
       const innerSelf = { baseRef, rawState, repCount: 0 };
       const [toHold, toExpose, state] = makeRepresentative(

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -295,6 +295,7 @@ test.serial('exercise cache', async t => {
   done();
 
   await hold(T8); // cache unchanged - [t1 t2 t3 t4]
+  ck('get', dataKey(8), thingVal('thing8'));
   ck('get', rcKey(4), undefined);
   ck('get', esKey(4), 'r');
   done();
@@ -306,7 +307,6 @@ test.serial('exercise cache', async t => {
   done();
 
   await writeHeld('thing8 updated'); // reanimate t8, evict t3 - [t8 t7 t1 t2]
-  ck('get', dataKey(8), thingVal('thing8'));
   ck('set', dataKey(8), thingVal('thing8 updated'));
   done();
 });

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -576,17 +576,19 @@ function validateExport(v, rp, what, esp, second) {
   validateDone(v);
 }
 
-function validateImport(v, rp) {
+function validateImport(v, rp, what, whatValue) {
+  validate(v, matchVatstoreGet(stateKey(what), whatValue));
   validate(v, matchVatstoreGet(stateKey(cacheDisplacerVref), cacheObjValue));
   validateReturned(v, rp);
   validateDone(v);
 }
 
-function validateLoad(v, rp, what) {
+function validateLoad(v, rp, what, whatValue) {
   validate(
     v,
     matchVatstoreGet(stateKey(virtualHolderVref), heldThingValue(what)),
   );
+  validate(v, matchVatstoreGet(stateKey(what), whatValue));
   validate(v, matchVatstoreGet(stateKey(cacheDisplacerVref), cacheObjValue));
   validateReturned(v, rp);
   validateDone(v);
@@ -704,7 +706,7 @@ async function voLifeCycleTest2(t, isf) {
 
   // lerV -> LerV  Read virtual reference, now there's an in-memory reference again too
   rp = await dispatchMessage('fetchAndHold');
-  validateLoad(v, rp, thingf);
+  validateLoad(v, rp, thingf, testObjValue);
 
   // LerV -> LERV  Export the reference, now all three legs hold it
   rp = await dispatchMessage('exportHeld');
@@ -716,7 +718,7 @@ async function voLifeCycleTest2(t, isf) {
 
   // lERV -> LERV  Reread from storage, all three legs again
   rp = await dispatchMessage('fetchAndHold');
-  validateLoad(v, rp, thingf);
+  validateLoad(v, rp, thingf, testObjValue);
 
   // LERV -> lERV  Drop in-memory reference (stepping stone to other states)
   rp = await dispatchMessage('dropHeld');
@@ -724,7 +726,7 @@ async function voLifeCycleTest2(t, isf) {
 
   // lERV -> LERV  Reintroduce the in-memory reference via message
   rp = await dispatchMessage('importAndHold', thingArgs(thing, isf));
-  validateImport(v, rp);
+  validateImport(v, rp, thingf, testObjValue);
 
   // LERV -> lERV  Drop in-memory reference
   rp = await dispatchMessage('dropHeld');
@@ -736,7 +738,7 @@ async function voLifeCycleTest2(t, isf) {
 
   // leRV -> LeRV  Fetch from storage
   rp = await dispatchMessage('fetchAndHold');
-  validateLoad(v, rp, thingf);
+  validateLoad(v, rp, thingf, testObjValue);
 
   // LeRV -> leRV  Forget about it *again*
   rp = await dispatchMessage('dropHeld');
@@ -744,7 +746,7 @@ async function voLifeCycleTest2(t, isf) {
 
   // leRV -> LeRV  Fetch from storage *again*
   rp = await dispatchMessage('fetchAndHold');
-  validateLoad(v, rp, thingf);
+  validateLoad(v, rp, thingf, testObjValue);
 
   // LeRV -> LerV  Retire the export
   await dispatchRetireExports(thingf);
@@ -939,7 +941,7 @@ async function voLifeCycleTest7(t, isf) {
 
   // lERv -> LERv  Reintroduce the in-memory reference via message
   rp = await dispatchMessage('importAndHold', thingArgs(thing, isf));
-  validateImport(v, rp);
+  validateImport(v, rp, thingf, testObjValue);
 
   // LERv -> lERv  Drop in-memory reference again, still no GC because exported
   rp = await dispatchMessage('dropHeld');


### PR DESCRIPTION
Eliminate the `propertyNames` Set used by the virtual object manager to track what properties are "live".  Instead, believe each instance with respect to which properties it actually has.

Closes #4935