### PR TITLE
feat(swingset-runner): add option to dump out the activityhash after each crank

### DIFF
--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -61,6 +61,7 @@ FLAGS may be:
   --forcegc        - run garbage collector after each block
   --batchsize N    - set BATCHSIZE to N cranks (default 200)
   --verbose        - output verbose debugging messages as it runs
+  --activityhash   - print out the current activity hash after each crank
   --audit          - audit kernel promise reference counts after each crank
   --dump           - dump a kernel state store snapshot after each crank
   --dumpdir DIR    - place kernel state dumps in directory DIR (default ".")
@@ -177,10 +178,14 @@ export async function main() {
   let dbSize = 0;
   let initOnly = false;
   let useXS = false;
+  let activityHash = false;
 
   while (argv[0] && argv[0].startsWith('-')) {
     const flag = argv.shift();
     switch (flag) {
+      case '--activityhash':
+        activityHash = true;
+        break;
       case '--init':
         forceReset = true;
         break;
@@ -609,6 +614,9 @@ export async function main() {
       if (doAudits) {
         auditRefCounts(swingStore.kvStore);
       }
+      if (activityHash) {
+        log(`activityHash: ${controller.getActivityhash()}`);
+      }
       if (verbose) {
         log(`===> end of crank ${crankNumber}`);
       }
@@ -645,6 +653,9 @@ export async function main() {
         data = data.concat(Object.values(controller.getStats()));
       }
       statLogger.log(data);
+    }
+    if (activityHash) {
+      log(`activityHash: ${controller.getActivityhash()}`);
     }
     return actualSteps;
   }


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4955

## Description
adds an `--activityhash` option to swingset-runner to dump the activity-hash
