### PR TITLE
test(swingset): test that baggage and durables survive vat upgrade

### DIFF
--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
@@ -1,5 +1,6 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { assert } from '@agoric/assert';
 import { makePromiseKit } from '@endo/promise-kit';
 
 export function buildRootObject() {
@@ -8,6 +9,7 @@ export function buildRootObject() {
   let ulrikAdmin;
   const marker = Far('marker', {});
   const { promise, resolve } = makePromiseKit();
+  let dur;
 
   return Far('root', {
     async bootstrap(vats, devices) {
@@ -28,13 +30,21 @@ export function buildRootObject() {
       ulrikAdmin = res.adminNode;
       const version = await E(ulrikRoot).getVersion();
       const parameters = await E(ulrikRoot).getParameters();
+      await E(ulrikRoot).acceptPresence(marker);
+      const m2 = await E(ulrikRoot).getPresence();
+      assert.equal(m2, marker);
+      const data = await E(ulrikRoot).getData();
+      dur = await E(ulrikRoot).getDurandal('d1');
+      const d1arg = await E(dur).get();
+      assert.equal(d1arg, 'd1');
+
       // give v1 a promise that won't be resolved until v2
       await E(ulrikRoot).acceptPromise(promise);
       const { p1 } = await E(ulrikRoot).getEternalPromise();
       p1.catch(() => 'hush');
       const p2 = E(ulrikRoot).returnEternalPromise(); // never resolves
       p2.catch(() => 'hush');
-      return { version, p1, p2, ...parameters };
+      return { version, data, p1, p2, ...parameters };
     },
 
     async upgradeV2() {
@@ -43,8 +53,13 @@ export function buildRootObject() {
       await E(ulrikAdmin).upgrade(bcap, vatParameters);
       const version = await E(ulrikRoot).getVersion();
       const parameters = await E(ulrikRoot).getParameters();
+      const m2 = await E(ulrikRoot).getPresence();
+      assert.equal(m2, marker);
+      const data = await E(ulrikRoot).getData();
+      const d1arg = await E(dur).get();
+      assert.equal(d1arg, 'new d1'); // durable object still works, in new way
       resolve(`message for your predecessor, don't freak out`);
-      return { version, ...parameters };
+      return { version, data, ...parameters };
     },
   });
 }

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -60,6 +60,7 @@ async function testUpgrade(t, defaultManagerType) {
   t.deepEqual(get(v1capdata, 'version'), 'v1');
   t.deepEqual(get(v1capdata, 'youAre'), 'v1');
   t.deepEqual(get(v1capdata, 'marker'), ['slot', markerKref]);
+  t.deepEqual(get(v1capdata, 'data'), ['some', 'data']);
   // grab the promises that should be rejected
   t.is(get(v1capdata, 'p1')[0], 'slot');
   const v1p1Kref = get(v1capdata, 'p1')[1];
@@ -72,6 +73,7 @@ async function testUpgrade(t, defaultManagerType) {
   t.deepEqual(get(v2capdata, 'version'), 'v2');
   t.deepEqual(get(v2capdata, 'youAre'), 'v2');
   t.deepEqual(get(v2capdata, 'marker'), ['slot', markerKref]);
+  t.deepEqual(get(v2capdata, 'data'), ['some', 'data']);
 
   // the old version's non-durable promises should be rejected
   t.is(c.kpStatus(v1p1Kref), 'rejected');

--- a/packages/SwingSet/test/upgrade/vat-ulrik-1.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-1.js
@@ -1,10 +1,36 @@
+/* global VatData */
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+// import { makeKindHandle, defineDurableKind } from '@agoric/vat-data';
+const { makeKindHandle, defineDurableKind } = VatData;
 
-export function buildRootObject(_vatPowers, vatParameters) {
+const durandalHandle = makeKindHandle('durandal');
+function initializeDurandal(arg) {
+  return { arg };
+}
+function actualizeDurandal(state) {
+  return {
+    get() {
+      return state.arg;
+    },
+    set(arg) {
+      state.arg = arg;
+    },
+  };
+}
+const makeDurandal = defineDurableKind(
+  durandalHandle,
+  initializeDurandal,
+  actualizeDurandal,
+);
+
+export function buildRootObject(_vatPowers, vatParameters, baggage) {
   const { promise: p1 } = makePromiseKit();
   const { promise: p2 } = makePromiseKit();
   let heldPromise;
+
+  baggage.init('data', harden(['some', 'data']));
+  baggage.init('durandalHandle', durandalHandle);
 
   return Far('root', {
     getVersion() {
@@ -13,6 +39,20 @@ export function buildRootObject(_vatPowers, vatParameters) {
     getParameters() {
       return vatParameters;
     },
+
+    acceptPresence(pres) {
+      baggage.init('presence', pres);
+    },
+    getPresence() {
+      return baggage.get('presence');
+    },
+    getData() {
+      return baggage.get('data');
+    },
+    getDurandal(arg) {
+      return makeDurandal(arg);
+    },
+
     acceptPromise(p) {
       // stopVat will reject the promises that we decide, but should
       // not touch the ones we don't decide, so we hold onto this

--- a/packages/SwingSet/test/upgrade/vat-ulrik-2.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-2.js
@@ -1,12 +1,38 @@
+/* global VatData */
 import { Far } from '@endo/marshal';
+// import { defineDurableKind } from '@agoric/vat-data';
+const { defineDurableKind } = VatData;
 
-export function buildRootObject(_vatPowers, vatParameters) {
+function initializeDurandal(arg) {
+  return { arg };
+}
+function actualizeDurandal(state) {
+  return {
+    get() {
+      return `new ${state.arg}`;
+    },
+    set(arg) {
+      state.arg = arg;
+    },
+  };
+}
+
+export function buildRootObject(_vatPowers, vatParameters, baggage) {
+  const durandalHandle = baggage.get('durandalHandle');
+  defineDurableKind(durandalHandle, initializeDurandal, actualizeDurandal);
+
   return Far('root', {
     getVersion() {
       return 'v2';
     },
     getParameters() {
       return vatParameters;
+    },
+    getPresence() {
+      return baggage.get('presence');
+    },
+    getData() {
+      return baggage.get('data');
     },
   });
 }


### PR DESCRIPTION
We create a durable Kind, and reattach behavior to it in v2. The
handle must travel through baggage, demonstrating that baggage works.

I'm still looking for the right way to use VatData these from with
swingset tests.. other packages should import @agoric/vat-data, but
that might be circular from here

refs #1848
