### PR TITLE
fix: check that all durable kinds are reconnected in new version

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -691,8 +691,13 @@ export default function buildKernel(
       // TODO: this is the message we want to send on failure, but we
       // need to queue it after the crank was unwound, else this
       // message will be unwound too
+      const err = {
+        '@qclass': 'error',
+        name: 'Error',
+        message: 'vat-upgrade failure notification not implemented',
+      };
       const args = {
-        body: JSON.stringify([upgradeID, false, { error: `not implemented` }]),
+        body: JSON.stringify([upgradeID, false, err]),
         slots: [],
       };
       queueToKref(vatAdminRootKref, 'vatUpgradeCallback', args, 'logFailure');

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -1271,6 +1271,8 @@ function build(
     slotToVal.set(rootSlot, new WeakRef(rootObject));
     retainExportedVref(rootSlot);
     // we do not use vreffedObjectRegistry for root objects
+
+    vom.insistAllDurableKindsReconnected();
   }
 
   /**

--- a/packages/SwingSet/test/stores/test-storeGC.js
+++ b/packages/SwingSet/test/stores/test-storeGC.js
@@ -479,6 +479,7 @@ function validateInit(v) {
   validate(v, matchVatstoreGet('baggageID', NONE));
   validateCreateBaggage(v, 1);
   validateCreateHolder(v, 2);
+  validate(v, matchVatstoreGetAfter('', 'vom.kind.', NONE, [NONE, NONE]));
 }
 
 function validateDropHeld(v, rp, rc, es) {

--- a/packages/SwingSet/test/test-baggage.js
+++ b/packages/SwingSet/test/test-baggage.js
@@ -5,6 +5,7 @@ import { Far } from '@endo/marshal';
 import {
   setupTestLiveslots,
   matchVatstoreGet,
+  matchVatstoreGetAfter,
   matchVatstoreSet,
   validate,
   validateDone,
@@ -74,6 +75,7 @@ test.serial('exercise baggage', async t => {
   validate(v, matchVatstoreSet('vc.1.soutside', stringVal('outer val')));
   validate(v, matchVatstoreGet('vc.1.|entryCount', '0'));
   validate(v, matchVatstoreSet('vc.1.|entryCount', '1'));
+  validate(v, matchVatstoreGetAfter('', 'vom.kind.', NONE, [NONE, NONE]));
   validateDone(v);
 
   const rp = await dispatchMessage('doSomething', capargs([]));

--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
@@ -61,5 +61,21 @@ export function buildRootObject() {
       resolve(`message for your predecessor, don't freak out`);
       return { version, data, ...parameters };
     },
+
+    async buildV1WithLostKind() {
+      const bcap = await E(vatAdmin).getNamedBundleCap('ulrik1');
+      const vatParameters = { youAre: 'v1', marker };
+      const options = { vatParameters };
+      const res = await E(vatAdmin).createVat(bcap, options);
+      ulrikRoot = res.root;
+      ulrikAdmin = res.adminNode;
+      await E(ulrikRoot).makeLostKind();
+    },
+
+    async upgradeV2WhichLosesKind() {
+      const bcap = await E(vatAdmin).getNamedBundleCap('ulrik2');
+      const vatParameters = { youAre: 'v2', marker };
+      await E(ulrikAdmin).upgrade(bcap, vatParameters); // throws
+    },
   });
 }

--- a/packages/SwingSet/test/upgrade/vat-ulrik-1.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-1.js
@@ -66,5 +66,9 @@ export function buildRootObject(_vatPowers, vatParameters, baggage) {
     returnEternalPromise() {
       return p2;
     },
+
+    makeLostKind() {
+      makeKindHandle('unhandled', []);
+    },
   });
 }

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -6,6 +6,7 @@ import {
   setupTestLiveslots,
   matchResolveOne,
   matchVatstoreGet,
+  matchVatstoreGetAfter,
   matchVatstoreDelete,
   matchVatstoreSet,
   matchRetireExports,
@@ -477,6 +478,7 @@ function validateSetup(v) {
   validateCreateBaggage(v, 1);
   validate(v, matchVatstoreSet(stateKey(cacheDisplacerVref), cacheObjValue));
   validate(v, matchVatstoreSet(stateKey(fCacheDisplacerVref), cacheObjValue));
+  validate(v, matchVatstoreGetAfter('', 'vom.kind.', NONE, [NONE, NONE]));
   validate(
     v,
     matchVatstoreSet(stateKey(virtualHolderVref), heldThingValue(null)),


### PR DESCRIPTION
This iterates through all previously-defined durable Kinds and asserts
that they have been reconnected by the time buildRootObject()
completes.

still needs better error delivery path

refs #1848
