### PR TITLE
chore: remove dckc from * "everything" owner list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default code owners when not specified.
 # We prefer to explicitly specify owners for all subdirectories.
-*                                @warner @dckc @Chris-Hibbert @FUDCo @michaelfig
+*                                @warner @Chris-Hibbert @FUDCo @michaelfig
 
 /*                               @kriskowal @michaelfig @erights
 /.github/                        @kriskowal @michaelfig @erights


### PR DESCRIPTION
I'm assigned as an owner of #4962 , but I don't see much reason for that. I think the `*` line at the top was intended to match things that don't match other lines, but I don't think it works that way. I think it tags me as an owner of every PR.

refs: #3382

