### PR TITLE
updates to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,11 +9,11 @@
 /scripts/                        @kriskowal @michaelfig @erights
 /yarn.lock                       @mhofman
 
-# Golang @parts @of @the @repo.
+# Golang parts of the repo.
 /go.*                            @JimLarson
 /golang/                         @JimLarson
 
-# Explicit @owners @for @our @packages
+# Explicit owners for our packages
 /packages/ERTP/                  @erights @Chris-Hibbert
 /packages/SwingSet/              @warner @FUDCo
 /packages/access-token/          @kriskowal @michaelfig

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # We prefer to explicitly specify owners for all subdirectories.
 *                                @warner @Chris-Hibbert @FUDCo @michaelfig
 
-/*                               @kriskowal @michaelfig @erights
+/*.*                             @kriskowal @michaelfig @erights
 /.github/                        @kriskowal @michaelfig @erights
 /docker/                         @kriskowal @michaelfig @erights
 /patches/                        @kriskowal @michaelfig @erights

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,9 @@
 /packages/telemetry              @kriskowal @michaelfig @erights
 /packages/ui-components/         @michaelfig @samsiegart  @turadg
 /packages/vats/                  @michaelfig
+/packages/vat-data/              @turadg
 /packages/wallet/                @michaelfig @samsiegart
 /packages/wallet-connection/     @michaelfig @samsiegart
+/packages/web-components/        @samsiegart
 /packages/xsnap/                 @warner @dckc @kriskowal
 /packages/zoe                    @erights @Chris-Hibbert


### PR DESCRIPTION
## Description

- Adds an owner for /vat-data I had added (per https://github.com/Agoric/agoric-sdk/pull/4963#issuecomment-1083296820)
- Adds an owner for /web-components (don't know why this didn't have one)
- Remove the redundant catch-all wildcard (all paths are under `/`)
