### PR TITLE
feat(run-protocol): debt limit for RUNstake

### DIFF
--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -72,7 +72,7 @@ const facetHelpers = (zcf, paramManager) => {
    * @template {{}} CF creator facet
    * @param {ERef<CF>} originalCreatorFacet
    * @param {Record<string, (...args: any[]) => any>} governedApis
-   * @returns { ERef<GovernedCreatorFacet<CF>> }
+   * @returns {ERef<GovernedCreatorFacet<CF>>}
    */
   const makeGovernorFacet = (originalCreatorFacet, governedApis = {}) => {
     const limitedCreatorFacet = makeLimitedCreatorFacet(originalCreatorFacet);
@@ -116,7 +116,7 @@ const facetHelpers = (zcf, paramManager) => {
  *
  * @template {import('./contractGovernance/typedParamManager').ParamTypesMap} M
  *   Map of types of custom governed terms
- * @template {Record<string, ParamRecord>} CGT Custom governed terms
+ * @template {Record<keyof M, ParamRecord>} CGT Custom governed terms
  * @param {ZCF<GovernanceTerms<CGT>>} zcf
  * @param {Invitation} initialPoserInvitation
  * @param {M} paramTypesMap

--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -525,6 +525,7 @@ harden(startRewardDistributor);
 /**
  * @param {RunStakeBootstrapPowers } powers
  * @param {Object} config
+ * @param {bigint} config.debtLimit count of RUN
  * @param {Rational} config.mintingRatio ratio of RUN minted to BLD
  * @param {bigint} config.interestRateBP
  * @param {bigint} config.loanFeeBP
@@ -565,6 +566,7 @@ export const startRunStake = async (
     },
   },
   config = {
+    debtLimit: 1_000_000n,
     mintingRatio: [1n, 4n],
     interestRateBP: 250n,
     loanFeeBP: 200n,
@@ -604,6 +606,7 @@ export const startRunStake = async (
       recordingPeriod: config.recordingPeriod,
     },
     {
+      debtLimit: AmountMath.make(runBrand, config.debtLimit),
       mintingRatio: makeRatio(
         config.mintingRatio[0],
         runBrand,

--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -566,7 +566,7 @@ export const startRunStake = async (
     },
   },
   config = {
-    debtLimit: 1_000_000n,
+    debtLimit: 1_000_000_000_000n,
     mintingRatio: [1n, 4n],
     interestRateBP: 250n,
     loanFeeBP: 200n,

--- a/packages/run-protocol/src/runStake/params.js
+++ b/packages/run-protocol/src/runStake/params.js
@@ -7,18 +7,27 @@ import { KW } from './runStakeKit.js';
 export { KW };
 
 const PKey = /** @type { const } */ ({
+  DebtLimit: 'DebtLimit',
   MintingRatio: 'MintingRatio',
   InterestRate: 'InterestRate',
   LoanFee: 'LoanFee',
 });
 
-const makeRunStakeParams = ({
-  electorateInvitationAmount,
-  mintingRatio,
-  interestRate,
-  loanFee,
-}) => {
-  return harden({
+export const makeRunStakeTerms = (
+  { timerService, chargingPeriod, recordingPeriod },
+  {
+    electorateInvitationAmount,
+    debtLimit,
+    mintingRatio,
+    interestRate,
+    loanFee,
+  },
+) => ({
+  timerService,
+  chargingPeriod,
+  recordingPeriod,
+  governedParams: harden({
+    [PKey.DebtLimit]: { type: ParamTypes.AMOUNT, value: debtLimit },
     [PKey.MintingRatio]: { type: ParamTypes.RATIO, value: mintingRatio },
     [PKey.InterestRate]: { type: ParamTypes.RATIO, value: interestRate },
     [PKey.LoanFee]: { type: ParamTypes.RATIO, value: loanFee },
@@ -26,22 +35,6 @@ const makeRunStakeParams = ({
       type: ParamTypes.INVITATION,
       value: electorateInvitationAmount,
     },
-  });
-};
-harden(makeRunStakeParams);
-
-export const makeRunStakeTerms = (
-  { timerService, chargingPeriod, recordingPeriod },
-  { electorateInvitationAmount, mintingRatio, interestRate, loanFee },
-) => ({
-  timerService,
-  chargingPeriod,
-  recordingPeriod,
-  governedParams: makeRunStakeParams({
-    electorateInvitationAmount,
-    mintingRatio,
-    interestRate,
-    loanFee,
   }),
 });
 harden(makeRunStakeTerms);

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -20,6 +20,7 @@ const { values } = Object;
  * and `electionManager` terms.
  *
  * @typedef {{
+ *   DebtLimit: ParamRecord<'amount'>,
  *   MintingRatio: ParamRecord<'ratio'>,
  *   InterestRate: ParamRecord<'ratio'>,
  *   LoanFee: ParamRecord<'ratio'>,
@@ -96,6 +97,7 @@ export const start = async (
 
   const { augmentPublicFacet, makeGovernorFacet, params } =
     await handleParamGovernance(zcf, initialPoserInvitation, {
+      DebtLimit: ParamTypes.AMOUNT,
       InterestRate: ParamTypes.RATIO,
       LoanFee: ParamTypes.RATIO,
       MintingRatio: ParamTypes.RATIO,

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -761,3 +761,21 @@ const makeTests = async () => {
 };
 
 makeTests();
+
+test('borrowing past the debt limit', async t => {
+  const driver = await makeWorld(t);
+
+  // provide ample BLD
+  await driver.buyBLD(100_000_000n);
+  await driver.stakeBLD(100_000_000n);
+  await driver.lienBLD(100_000_000n);
+
+  // XXX assumes debt limit of 1_000_000_000_000n
+  const threshold = 1_000_000_000_000n / micro.unit;
+
+  await t.throwsAsync(driver.borrowRUN(threshold), {
+    message:
+      // XXX brittle string to fail if numeric parameters change
+      'Minting {"brand":"[Alleged: RUN brand]","value":"[1020000000000n]"} past {"brand":"[Alleged: RUN brand]","value":"[0n]"} would exceed total debt limit {"brand":"[Alleged: RUN brand]","value":"[1000000000000n]"}',
+  });
+});

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -92,8 +92,9 @@ async function waitForPromisesToSettle() {
 }
 
 /**
+ * dL: 1M, lM: 105, iR: 100, lF: 500
+ *
  * @param {Brand} debtBrand
- * @returns dL: 1M, lM: 105, iR: 100, lF: 500
  */
 function defaultParamValues(debtBrand) {
   return harden({


### PR DESCRIPTION
closes: #3501

## Description

Repeat https://github.com/Agoric/agoric-sdk/pull/4948 for RUNstake

### Security Considerations

New governed param. Malicious manipulation could halt minting.


### Documentation Considerations

Downstream has to now provide a debtLimit initial value. I don't think loadgen has RUNstake yet but cc @mhofman  in case.

### Testing Considerations

Test using the RUNstake driver