### PR TITLE
fix(dockerfile): add terrible retry logic for yarn install on failure

### DIFF
--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -25,7 +25,8 @@ ARG XSNAP_NATIVE_URL
 WORKDIR /usr/src/agoric-sdk
 COPY . .
 
-RUN yarn install --network-timeout 1000000
+# add retry for qemu arm64 network fetching and mui issues with qemu
+RUN bash -c "for i in {1..3}; do yarn install --network-timeout 1000000 && exit 0 || (echo retrying; sleep 15;) done; exit 1"
 
 # Need to build the Node.js node extension that uses our above Golang shared library.
 COPY --from=cosmos-go /usr/src/agoric-sdk/golang/cosmos/build golang/cosmos/build/


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4972

## Description

Attempts to absorb the infrequent network instability / latency issues with the qemu dockerfile image building into the dockerfile build process on failure

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

