### PR TITLE
test: lint Ava tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -50,12 +50,17 @@ module.exports = {
       }
     : undefined,
   plugins: ['@typescript-eslint', 'prettier'],
-  extends: ['@agoric'],
+  extends: ['@agoric', 'plugin:ava/recommended'],
   rules: {
     '@typescript-eslint/prefer-ts-expect-error': 'warn',
     '@typescript-eslint/no-floating-promises': lintTypes ? 'warn' : 'off',
     // so that floating-promises can be explicitly permitted with void operator
     'no-void': ['error', { allowAsStatement: true }],
+
+    // We allow disabled tests in master
+    'ava/no-skip-test': 'off',
+    // Contrary to recommendation https://github.com/avajs/ava/blob/main/docs/recipes/typescript.md#typing-tcontext
+    'ava/use-test': 'off',
 
     // The rule is “safe await separator" which implements the architectural
     // goal of “clearly separate an async function's synchronous prelude from

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-jessie": "^0.0.6",
     "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-ava": "^14.0.0",
     "eslint-plugin-github": "^4.8.0",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsdoc": "^46.4.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ava": "^5.3.0",
     "c8": "^7.13.0",
     "conventional-changelog-conventionalcommits": "^4.6.0",
-    "eslint": "^8.44.0",
+    "eslint": "^8.47.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-jessie": "^0.0.6",
     "eslint-config-prettier": "^8.8.0",

--- a/packages/SwingSet/test/test-bundle-handler.js
+++ b/packages/SwingSet/test/test-bundle-handler.js
@@ -56,8 +56,8 @@ test('bundle handler', async t => {
   t.is(store.size, 2);
   t.deepEqual(ids, ['b0-lockdown.sha', 'b0-supervisor.sha']);
   // contents were fetched from bundleData
-  t.deepEqual(await handler.getBundle('b0-lockdown.sha'), 'lockdown');
-  t.deepEqual(await handler.getBundle('b0-supervisor.sha'), 'supervisor');
+  t.is(await handler.getBundle('b0-lockdown.sha'), 'lockdown');
+  t.is(await handler.getBundle('b0-supervisor.sha'), 'supervisor');
 
   // subsequent queries should check hashes/ids but not re-read bundles
   const ids2 = await handler.getCurrentBundleIDs();
@@ -67,7 +67,7 @@ test('bundle handler', async t => {
 
   // getBundle is served from bundleStore, not elsewhere
   store.set('b0-lockdown.sha', 'other');
-  t.deepEqual(await handler.getBundle('b0-lockdown.sha'), 'other');
+  t.is(await handler.getBundle('b0-lockdown.sha'), 'other');
 });
 
 test('bundle data', async t => {

--- a/packages/agoric-cli/test/test-inter-cli.js
+++ b/packages/agoric-cli/test/test-inter-cli.js
@@ -349,11 +349,11 @@ test('diagnostic for agd ENOENT', async t => {
   });
 
   await t.throwsAsync(cmd.parseAsync(argv), { instanceOf: CommanderError });
-  t.deepEqual(
+  t.is(
     diag.join('').trim(),
     "error: option '--from <address>' argument 'gov1' is invalid. ENOENT: is agd in your $PATH?",
   );
-  t.deepEqual(out.join('').trim(), '');
+  t.is(out.join('').trim(), '');
 });
 
 test.todo('agd ENOENT clue outside normalizeAddress');

--- a/packages/agoric-cli/test/test-publish-bundle.js
+++ b/packages/agoric-cli/test/test-publish-bundle.js
@@ -164,7 +164,7 @@ test('publish bundle with fake HTTP server ok', async t => {
       t.deepEqual(bundle, request);
       res.end('{"ok": true}');
     })().catch(error => {
-      t.fail(error);
+      t.fail(`${error.message}`);
     });
   });
   t.teardown(

--- a/packages/boot/test/upgrading/test-upgrade-vats.js
+++ b/packages/boot/test/upgrading/test-upgrade-vats.js
@@ -105,7 +105,7 @@ test('upgrade vat-board', async t => {
   t.is(actualThing, thing, 'must get original value back');
 });
 
-test.skip('upgrade bootstrap vat', async t => {
+test.failing('upgrade bootstrap vat', async t => {
   const bundles = {
     chain: {
       sourceSpec: await importSpec('@agoric/vats/src/core/boot-chain.js'),

--- a/packages/cosmic-swingset/test/test-export-storage.js
+++ b/packages/cosmic-swingset/test/test-export-storage.js
@@ -58,7 +58,7 @@ const makeBatchChainStorage = published => {
   return { batchChainStorage, deleted };
 };
 
-test('exportStorage example', async t => {
+test('exportStorage example', t => {
   const exportStorageSubtrees = ['published.c.o'];
   const expected = [
     ['published.c.o', 'top'],
@@ -82,7 +82,7 @@ test('exportStorage example', async t => {
   t.deepEqual(actual, expected);
 });
 
-test('exportStorage clears crufty ToyUSD PSM', async t => {
+test('exportStorage clears crufty ToyUSD PSM', t => {
   const config = {
     clearStorageSubtrees: ['published'],
     exportStorageSubtrees: [

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -29,7 +29,7 @@
     "@jessie.js/eslint-plugin": "^0.4.0",
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "@typescript-eslint/parser": "^6.1.0",
-    "eslint": "^8.36.0",
+    "eslint": "^8.47.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-github": "^4.8.0",
     "eslint-config-jessie": "^0.0.6",

--- a/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
@@ -1,3 +1,5 @@
+/* eslint-disable ava/assertion-arguments -- the standard diff is unreadable */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import '@endo/init/debug.js';
 import test from 'ava';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';

--- a/packages/import-manager/test/unitTests/test-importsA.js
+++ b/packages/import-manager/test/unitTests/test-importsA.js
@@ -27,12 +27,3 @@ test('import listIsEmpty (true)', t => {
   const op = 'listIsEmpty';
   t.truthy(importer[op]([]));
 });
-
-// TODO: This test throws because `lookupImport` does not exist. This
-// test needs to be fixed.
-test.skip('import not found', t => {
-  const importer = makeGoodImportManager();
-  t.throws(() => importer.lookupImport('emptyPixel'), {
-    message: /There is no entry for "c"./,
-  });
-});

--- a/packages/internal/test/test-callback.js
+++ b/packages/internal/test/test-callback.js
@@ -188,7 +188,7 @@ test('far function callbacks', async t => {
   t.is(await p2r, '19go');
 });
 
-test('bad callbacks', async t => {
+test('bad callbacks', t => {
   t.throws(
     // @ts-expect-error deliberate: number is not assignable to function
     () => cb.makeFunctionCallback(42),

--- a/packages/internal/test/test-netstring.js
+++ b/packages/internal/test/test-netstring.js
@@ -56,7 +56,7 @@ test('encode', t => {
   eq(emojiBuffer, expectedBuffer);
 });
 
-test('encode stream', async t => {
+test('encode stream', t => {
   const e = netstringEncoderStream();
   const chunks = [];
   e.on('data', data => chunks.push(data));
@@ -112,7 +112,7 @@ test('decode', t => {
   bad('26:x', /size .* exceeds limit of 25/);
 });
 
-test('decode stream', async t => {
+test('decode stream', t => {
   const d = netstringDecoderStream();
   function write(s) {
     d.write(Buffer.from(s));

--- a/packages/internal/test/test-priority-senders.js
+++ b/packages/internal/test/test-priority-senders.js
@@ -71,7 +71,7 @@ test('normalization', async t => {
   await manager.add('this,has,commas,', 'addr');
 
   await writesSettled();
-  t.deepEqual(
+  t.is(
     storage.data.get(`${HIGH_PRIORITY_SENDERS}.addr`),
     'something_with_spaces,something_with_spaces_and___,this_has_commas_',
   );

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -395,6 +395,7 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
   const eachIterator2 = await run('messageVatObject', [
     { presence: eachIterable, methodName: Symbol.asyncIterator },
   ]);
+  // eslint-disable-next-line ava/prefer-async-await
   const assertDisconnection = (p, label) => {
     const expected = {
       incarnationNumber: 0,
@@ -402,7 +403,8 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
       upgradeMessage: 'vat upgraded',
     };
     return p.then(
-      (...args) => t.deepEqual(args, undefined, `${label} must be rejected`),
+      // @ts-expect-error Argument of type 'undefined' is not assignable to parameter of type 'any[]'.
+      (...args) => t.is(args, undefined, `${label} must be rejected`),
       failure =>
         t.deepEqual(failure, expected, `${label} must indicate disconnection`),
     );
@@ -458,7 +460,7 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
 // TODO: Find a way to test virtual object rehydration
 // without the overhead of vats.
 // https://github.com/Agoric/agoric-sdk/pull/6502#discussion_r1008492055
-test.skip('durable publish kit upgrade trauma', async t => {
+test.failing('durable publish kit upgrade trauma', async t => {
   const baggage = makeBaggage();
   const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,

--- a/packages/solo/test/test-home.js
+++ b/packages/solo/test/test-home.js
@@ -155,7 +155,7 @@ test.serial('home.localTimerService makeNotifier', async t => {
   const notifier = E(localTimerService).makeNotifier(1n, 1n);
   const update1 = await E(notifier).getUpdateSince();
   const firstUpdate = update1.updateCount;
-  t.truthy(firstUpdate > 0);
+  t.true(firstUpdate > 0);
   const update2 = await E(notifier).getUpdateSince(update1.updateCount);
   t.truthy(BigInt(update2.updateCount) > BigInt(firstUpdate));
 

--- a/packages/swing-store/test/exports.js
+++ b/packages/swing-store/test/exports.js
@@ -1,0 +1,99 @@
+import { Buffer } from 'buffer';
+import { makeB0ID } from './util.js';
+
+export const snapshotData = 'snapshot data';
+// this snapHash was computed manually
+export const snapHash =
+  'e7dee7266896538616b630a5da40a90e007726a383e005a9c9c5dd0c2daf9329';
+
+/** @type {import('../src/bundleStore.js').Bundle} */
+export const bundle0 = { moduleFormat: 'nestedEvaluate', source: '1+1' };
+export const bundle0ID = makeB0ID(bundle0);
+
+export function buildData() {
+  // build an export manually
+  const exportData = new Map();
+  const artifacts = new Map();
+
+  // shadow kvStore
+  exportData.set('kv.key1', 'value1');
+
+  // now add artifacts and metadata in pairs
+
+  artifacts.set(`bundle.${bundle0ID}`, JSON.stringify(bundle0));
+  exportData.set(`bundle.${bundle0ID}`, bundle0ID);
+
+  const sbase = { vatID: 'v1', hash: snapHash, inUse: 0 };
+  const tbase = { vatID: 'v1', startPos: 0, isCurrent: 0, incarnation: 1 };
+  const addTS = (key, obj) =>
+    exportData.set(key, JSON.stringify({ ...tbase, ...obj }));
+  const t0hash =
+    '5bee0f44eca02f23eab03703e84ed2647d5d117fed99e1c30a3b424b7f082ab9';
+  const t2hash =
+    '57152efdd7fdf75c03371d2b4f1088d5bf3eae7fe643babce527ff81df38998c';
+  const t5hash =
+    '1947001e78e01bd1e773feb22b4ffc530447373b9de9274d5d5fbda3f23dbf2b';
+  const t8hash =
+    'e6b42c6a3fb94285a93162f25a9fc0145fd4c5bb144917dc572c50ae2d02ee69';
+
+  addTS(`transcript.v1.0`, { incarnation: 0, endPos: 2, hash: t0hash });
+  artifacts.set(`transcript.v1.0.2`, 'start-worker\nshutdown-worker\n');
+
+  addTS(`transcript.v1.2`, { startPos: 2, endPos: 5, hash: t2hash });
+  artifacts.set(
+    `transcript.v1.2.5`,
+    'start-worker\ndelivery1\nsave-snapshot\n',
+  );
+  exportData.set(`snapshot.v1.4`, JSON.stringify({ ...sbase, snapPos: 4 }));
+  artifacts.set(`snapshot.v1.4`, snapshotData);
+
+  addTS(`transcript.v1.5`, { startPos: 5, endPos: 8, hash: t5hash });
+  artifacts.set(
+    'transcript.v1.5.8',
+    'load-snapshot\ndelivery2\nsave-snapshot\n',
+  );
+  exportData.set(
+    `snapshot.v1.7`,
+    JSON.stringify({ ...sbase, snapPos: 7, inUse: 1 }),
+  );
+  artifacts.set(`snapshot.v1.7`, snapshotData);
+
+  artifacts.set('transcript.v1.8.10', 'load-snapshot\ndelivery3\n');
+  exportData.set(`snapshot.v1.current`, 'snapshot.v1.7');
+  addTS(`transcript.v1.current`, {
+    startPos: 8,
+    endPos: 10,
+    isCurrent: 1,
+    hash: t8hash,
+  });
+
+  return { exportData, artifacts, t0hash, t2hash, t5hash, t8hash };
+}
+
+/**
+ * @param { Map<string, string | null> } exportData
+ * @param { Map<string, string> } artifacts
+ */
+export function makeExporter(exportData, artifacts) {
+  return {
+    async *getExportData() {
+      for (const [key, value] of exportData.entries()) {
+        /** @type { import('../src/exporter.js').KVPair } */
+        const pair = [key, value];
+        yield pair;
+      }
+    },
+    async *getArtifactNames() {
+      for (const name of artifacts.keys()) {
+        yield name;
+      }
+    },
+    async *getArtifact(name) {
+      const data = artifacts.get(name);
+      assert(data, `missing artifact ${name}`);
+      yield Buffer.from(data);
+    },
+    // eslint-disable-next-line no-empty-function
+    async close() {},
+  };
+}

--- a/packages/swing-store/test/test-import.js
+++ b/packages/swing-store/test/test-import.js
@@ -14,7 +14,15 @@ import { decodeBase64 } from '@endo/base64';
 import { buffer } from '../src/util.js';
 import { importSwingStore, makeSwingStoreExporter } from '../src/index.js';
 
-import { tmpDir, makeB0ID } from './util.js';
+import { tmpDir } from './util.js';
+import {
+  buildData,
+  bundle0,
+  bundle0ID,
+  makeExporter,
+  snapHash,
+  snapshotData,
+} from './exports.js';
 
 const rank = {
   operational: 1,
@@ -22,15 +30,6 @@ const rank = {
   archival: 3,
   debug: 4,
 };
-
-const snapshotData = 'snapshot data';
-// this snapHash was computed manually
-const snapHash =
-  'e7dee7266896538616b630a5da40a90e007726a383e005a9c9c5dd0c2daf9329';
-
-/** @type {import('../src/bundleStore.js').Bundle} */
-const bundle0 = { moduleFormat: 'nestedEvaluate', source: '1+1' };
-const bundle0ID = makeB0ID(bundle0);
 
 function convert(orig) {
   const bundles = Object.fromEntries(
@@ -42,38 +41,6 @@ function convert(orig) {
     }),
   );
   return { ...orig, bundles };
-}
-
-/**
- * @typedef { import('../src/exporter').KVPair } KVPair
- */
-
-/**
- * @param { Map<string, string | null> } exportData
- * @param { Map<string, string> } artifacts
- */
-export function makeExporter(exportData, artifacts) {
-  return {
-    async *getExportData() {
-      for (const [key, value] of exportData.entries()) {
-        /** @type { KVPair } */
-        const pair = [key, value];
-        yield pair;
-      }
-    },
-    async *getArtifactNames() {
-      for (const name of artifacts.keys()) {
-        yield name;
-      }
-    },
-    async *getArtifact(name) {
-      const data = artifacts.get(name);
-      assert(data, `missing artifact ${name}`);
-      yield Buffer.from(data);
-    },
-    // eslint-disable-next-line no-empty-function
-    async close() {},
-  };
 }
 
 test('import empty', async t => {
@@ -90,66 +57,6 @@ test('import empty', async t => {
     bundles: {},
   });
 });
-
-export function buildData() {
-  // build an export manually
-  const exportData = new Map();
-  const artifacts = new Map();
-
-  // shadow kvStore
-  exportData.set('kv.key1', 'value1');
-
-  // now add artifacts and metadata in pairs
-
-  artifacts.set(`bundle.${bundle0ID}`, JSON.stringify(bundle0));
-  exportData.set(`bundle.${bundle0ID}`, bundle0ID);
-
-  const sbase = { vatID: 'v1', hash: snapHash, inUse: 0 };
-  const tbase = { vatID: 'v1', startPos: 0, isCurrent: 0, incarnation: 1 };
-  const addTS = (key, obj) =>
-    exportData.set(key, JSON.stringify({ ...tbase, ...obj }));
-  const t0hash =
-    '5bee0f44eca02f23eab03703e84ed2647d5d117fed99e1c30a3b424b7f082ab9';
-  const t2hash =
-    '57152efdd7fdf75c03371d2b4f1088d5bf3eae7fe643babce527ff81df38998c';
-  const t5hash =
-    '1947001e78e01bd1e773feb22b4ffc530447373b9de9274d5d5fbda3f23dbf2b';
-  const t8hash =
-    'e6b42c6a3fb94285a93162f25a9fc0145fd4c5bb144917dc572c50ae2d02ee69';
-
-  addTS(`transcript.v1.0`, { incarnation: 0, endPos: 2, hash: t0hash });
-  artifacts.set(`transcript.v1.0.2`, 'start-worker\nshutdown-worker\n');
-
-  addTS(`transcript.v1.2`, { startPos: 2, endPos: 5, hash: t2hash });
-  artifacts.set(
-    `transcript.v1.2.5`,
-    'start-worker\ndelivery1\nsave-snapshot\n',
-  );
-  exportData.set(`snapshot.v1.4`, JSON.stringify({ ...sbase, snapPos: 4 }));
-  artifacts.set(`snapshot.v1.4`, snapshotData);
-
-  addTS(`transcript.v1.5`, { startPos: 5, endPos: 8, hash: t5hash });
-  artifacts.set(
-    'transcript.v1.5.8',
-    'load-snapshot\ndelivery2\nsave-snapshot\n',
-  );
-  exportData.set(
-    `snapshot.v1.7`,
-    JSON.stringify({ ...sbase, snapPos: 7, inUse: 1 }),
-  );
-  artifacts.set(`snapshot.v1.7`, snapshotData);
-
-  artifacts.set('transcript.v1.8.10', 'load-snapshot\ndelivery3\n');
-  exportData.set(`snapshot.v1.current`, 'snapshot.v1.7');
-  addTS(`transcript.v1.current`, {
-    startPos: 8,
-    endPos: 10,
-    isCurrent: 1,
-    hash: t8hash,
-  });
-
-  return { exportData, artifacts, t0hash, t2hash, t5hash, t8hash };
-}
 
 const importTest = test.macro(async (t, mode) => {
   /** @typedef {import('../src/internal.js').ArtifactMode} ArtifactMode */

--- a/packages/swing-store/test/test-repair-metadata.js
+++ b/packages/swing-store/test/test-repair-metadata.js
@@ -8,7 +8,7 @@ import sqlite3 from 'better-sqlite3';
 
 import { importSwingStore } from '../src/index.js';
 
-import { makeExporter, buildData } from './test-import.js';
+import { makeExporter, buildData } from './exports.js';
 import { tmpDir } from './util.js';
 
 test('repair metadata', async t => {

--- a/packages/swingset-liveslots/test/test-durabilityChecks.js
+++ b/packages/swingset-liveslots/test/test-durabilityChecks.js
@@ -269,5 +269,5 @@ async function runDurabilityCheckTest(t, relaxDurabilityRules) {
   }
 }
 
-test('durability checks (strict)', t => runDurabilityCheckTest(t, false));
-test('durability checks (relaxed)', t => runDurabilityCheckTest(t, true));
+test('durability checks (strict)', runDurabilityCheckTest, false);
+test('durability checks (relaxed)', runDurabilityCheckTest, true);

--- a/packages/swingset-liveslots/test/test-facetiousness.js
+++ b/packages/swingset-liveslots/test/test-facetiousness.js
@@ -126,7 +126,7 @@ test('checkAndUpdateFacetiousness', t => {
   t.deepEqual(cauf({}, barfoo), barfoo);
 
   // a single Kind can only be redefined as another single
-  t.deepEqual(cauf(desc(), undefined), undefined);
+  t.is(cauf(desc(), undefined), undefined);
   t.throws(() => cauf(desc(), foo), {
     message: 'defineDurableKindMulti called for unfaceted KindHandle "tag"',
   });

--- a/packages/swingset-liveslots/test/test-handled-promises.js
+++ b/packages/swingset-liveslots/test/test-handled-promises.js
@@ -232,12 +232,12 @@ test('past-incarnation watched promises', async t => {
   t.deepEqual(getDispatchLogs(), [
     fulfillmentMessage(`p-${nextPImport()}`, 'created local promise: rejected'),
   ]);
-  t.deepEqual(
+  t.is(
     lastPImport - firstPImport + 1,
     4,
     'imported 4 promises (1 per dispatch)',
   );
-  t.deepEqual(lastPExport - firstPExport + 1, 1, 'exported 1 promise: first');
+  t.is(lastPExport - firstPExport + 1, 1, 'exported 1 promise: first');
 
   await dispatchMessage('watchLocalPromise', 'orphaned');
   t.deepEqual(getDispatchLogs(), [
@@ -259,12 +259,12 @@ test('past-incarnation watched promises', async t => {
     fulfillmentMessage(`p-${nextPImport()}`, 'watched local promise: rejected'),
     rejectionMessage(`p+${lastPExport}`, S),
   ]);
-  t.deepEqual(
+  t.is(
     lastPImport - firstPImport + 1,
     7,
     'imported 7 promises (1 per dispatch)',
   );
-  t.deepEqual(
+  t.is(
     lastPExport - firstPExport + 1,
     4,
     'exported 4 promises: first, orphaned, fulfilled, rejected',

--- a/packages/swingset-liveslots/test/test-initial-vrefs.js
+++ b/packages/swingset-liveslots/test/test-initial-vrefs.js
@@ -148,5 +148,5 @@ test('vrefs', async t => {
   const expectedStore1Vref = `o+v${initialKindIDs.scalarMapStore}/5`;
   const store1Vref = (await run('getStore1')).slots[0];
   t.is(store1Vref, expectedStore1Vref);
-  t.deepEqual(kunser(JSON.parse(fakestore.get(`vc.5.s${'key'}`))), 'value');
+  t.is(kunser(JSON.parse(fakestore.get(`vc.5.s${'key'}`))), 'value');
 });

--- a/packages/swingset-liveslots/test/test-liveslots.js
+++ b/packages/swingset-liveslots/test/test-liveslots.js
@@ -46,14 +46,14 @@ test('calls', async t => {
 
   // root!one() // sendOnly
   await dispatch(makeMessage(rootA, 'one', ['args']));
-  t.deepEqual(log.shift(), 'one');
+  t.is(log.shift(), 'one');
 
   // pr = makePromise()
   // root!two(pr.promise)
   // pr.resolve('result')
   await dispatch(makeMessage(rootA, 'two', [kslot('p-1')]));
   t.deepEqual(log.shift(), { type: 'subscribe', target: 'p-1' });
-  t.deepEqual(log.shift(), 'two true');
+  t.is(log.shift(), 'two true');
 
   await dispatch(makeResolve('p-1', kser('result')));
   t.deepEqual(log.shift(), ['res', 'result']);
@@ -64,7 +64,7 @@ test('calls', async t => {
 
   await dispatch(makeMessage(rootA, 'two', [kslot('p-2')]));
   t.deepEqual(log.shift(), { type: 'subscribe', target: 'p-2' });
-  t.deepEqual(log.shift(), 'two true');
+  t.is(log.shift(), 'two true');
 
   await dispatch(makeReject('p-2', kser('rejection')));
   t.deepEqual(log.shift(), ['rej', 'rejection']);
@@ -100,7 +100,7 @@ test('liveslots pipelines to syscall.send', async t => {
   // for x!pipe1(), a second pipelined to the result promise of it, and a
   // third pipelined to the result of the second.
 
-  t.deepEqual(log.shift(), 'sent p1p2p3');
+  t.is(log.shift(), 'sent p1p2p3');
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: x,
@@ -657,8 +657,7 @@ test('capdata size limit on syscalls', async t => {
   };
 
   const send = op => dispatch(makeMessage(rootA, op, [kslot(target)], rp));
-  const expectFail = () =>
-    t.deepEqual(log.shift(), 'fail: syscall capdata too large');
+  const expectFail = () => t.is(log.shift(), 'fail: syscall capdata too large');
   const expectVoidReturn = () =>
     t.deepEqual(log.shift(), {
       type: 'resolve',
@@ -907,7 +906,7 @@ test('disable disavow', async t => {
 
   // root~.one() // sendOnly
   await dispatch(makeMessage(rootA, 'one', []));
-  t.deepEqual(log.shift(), false);
+  t.is(log.shift(), false);
   t.deepEqual(log, []);
 });
 
@@ -968,7 +967,7 @@ test('disavow', async t => {
   // root~.one(import1) // sendOnly
   await dispatch(makeMessage(rootA, 'one', [kslot(import1)]));
   t.deepEqual(log.shift(), { type: 'dropImports', slots: [import1] });
-  t.deepEqual(log.shift(), 'disavowed pres1');
+  t.is(log.shift(), 'disavowed pres1');
 
   function loggedError(re) {
     const l = log.shift();
@@ -976,11 +975,11 @@ test('disavow', async t => {
     t.truthy(re.test(l.message));
   }
   loggedError(/attempt to disavow unknown/);
-  t.deepEqual(log.shift(), 'tried duplicate disavow');
+  t.is(log.shift(), 'tried duplicate disavow');
   loggedError(/attempt to disavow unknown/);
-  t.deepEqual(log.shift(), 'tried to disavow Promise');
+  t.is(log.shift(), 'tried to disavow Promise');
   loggedError(/attempt to disavow an export/);
-  t.deepEqual(log.shift(), 'tried to disavow export');
+  t.is(log.shift(), 'tried to disavow export');
   const msg = log.shift();
   t.like(msg, {
     type: 'exit',
@@ -988,7 +987,7 @@ test('disavow', async t => {
   });
   expectError(t, msg.info, /this Presence has been disavowed/);
   t.deepEqual(log.shift(), Error('this Presence has been disavowed'));
-  t.deepEqual(log.shift(), 'tried to send to disavowed');
+  t.is(log.shift(), 'tried to send to disavowed');
   t.deepEqual(log, []);
 });
 

--- a/packages/swingset-liveslots/test/util.js
+++ b/packages/swingset-liveslots/test/util.js
@@ -48,7 +48,7 @@ export function buildDispatch(onDispatchCallback) {
 
 /**
  * @param {unknown} target
- * @param {string} method
+ * @param {string | symbol} method
  * @param {any[]} args
  * @param {unknown} result
  */

--- a/packages/swingset-liveslots/test/virtual-objects/test-cease-recognition.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-cease-recognition.js
@@ -39,7 +39,7 @@ function weakKeyCheck(t, log, vref) {
   t.true(result === undefined || !result.startsWith(prefix), `ew:${result}`);
 }
 
-test('only enumerate virtual objects', async t => {
+test('only enumerate virtual objects', t => {
   const { log, vrm } = makeVRM();
 
   // retiring a plain Remotable does a is-it-a-weak-key chck

--- a/packages/swingset-liveslots/test/virtual-objects/test-cross-facet.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-cross-facet.js
@@ -15,7 +15,7 @@ function attack2(mut1, immut2) {
   Reflect.apply(mutableProto.set, immut2, [6]);
 }
 
-test('forbid cross-facet prototype attack', async t => {
+test('forbid cross-facet prototype attack', t => {
   const vom = makeFakeVirtualObjectManager();
   const init = () => ({ value: 0 });
   const behavior = {

--- a/packages/swingset-liveslots/test/virtual-objects/test-empty-data.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-empty-data.js
@@ -3,7 +3,7 @@ import '@endo/init/debug.js';
 
 import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualSupport.js';
 
-test('non-object initial data message', async t => {
+test('non-object initial data message', t => {
   const vom = makeFakeVirtualObjectManager();
   const goodInit = () => ({ value: 0 });
   // 'badInit' is  () =>  { value: 0 }

--- a/packages/swingset-liveslots/test/virtual-objects/test-facets.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-facets.js
@@ -3,7 +3,7 @@ import '@endo/init/debug.js';
 
 import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualSupport.js';
 
-test('facets', async t => {
+test('facets', t => {
   const vom = makeFakeVirtualObjectManager();
   const init = () => ({ value: 0 });
   const behavior = {

--- a/packages/swingset-liveslots/test/virtual-objects/test-reachable-vrefs.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-reachable-vrefs.js
@@ -8,7 +8,7 @@ import { initEmpty } from '@agoric/store';
 import { makeVatSlot } from '../../src/parseVatSlots.js';
 import { makeFakeVirtualStuff } from '../../tools/fakeVirtualSupport.js';
 
-test('VOM tracks reachable vrefs', async t => {
+test('VOM tracks reachable vrefs', t => {
   const { vom, vrm, cm } = makeFakeVirtualStuff();
   const { defineKind } = vom;
   const { makeScalarBigWeakMapStore } = cm;

--- a/packages/swingset-liveslots/test/virtual-objects/test-rep-tostring.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-rep-tostring.js
@@ -16,7 +16,7 @@ const init = () => ({});
 const behavior = {};
 const facets = { foo: {}, bar: {} };
 
-test('representatives with label-instances', async t => {
+test('representatives with label-instances', t => {
   const { fakeStuff, vom } = makeFakeVirtualStuff();
   const { getSlotForVal } = fakeStuff;
   const makeThing = vom.defineKind('thing', init, behavior);
@@ -33,7 +33,7 @@ test('representatives with label-instances', async t => {
   t.is(`${q(thing2)}`, `"[Alleged: thing#${thing2vref}]"`);
 });
 
-test('facets with label-instances', async t => {
+test('facets with label-instances', t => {
   const { fakeStuff, vom } = makeFakeVirtualStuff();
   const { getSlotForVal } = fakeStuff;
   const makeThings = vom.defineKindMulti('thing', init, facets);

--- a/packages/swingset-liveslots/test/virtual-objects/test-weakcollections-vref-handling.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-weakcollections-vref-handling.js
@@ -3,7 +3,7 @@ import '@endo/init/debug.js';
 
 import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualSupport.js';
 
-test('weakMap vref handling', async t => {
+test('weakMap vref handling', t => {
   const log = [];
   const {
     VirtualObjectAwareWeakMap,

--- a/packages/time/test/test-timeMath.js
+++ b/packages/time/test/test-timeMath.js
@@ -56,7 +56,7 @@ test('timeMath one label', t => {
 });
 
 test('timeMath no labels', t => {
-  t.deepEqual(TimeMath.addAbsRel(100n, 3n), 103n);
+  t.is(TimeMath.addAbsRel(100n, 3n), 103n);
 });
 
 // TODO: < should fail

--- a/packages/vats/test/test-dump.js
+++ b/packages/vats/test/test-dump.js
@@ -5,7 +5,7 @@ import test from 'ava';
 import { dump } from '../src/repl.js';
 
 // Taken from https://github.com/endojs/endo/blob/43b796232634b54c9e7de1c0a2349d22c29fc384/packages/ses/test/error/test-assert-log.js#L414
-test('dump: the @erights challenge', async t => {
+test('dump: the @erights challenge', t => {
   const superTagged = { [Symbol.toStringTag]: 'Tagged' };
   const subTagged = { __proto__: superTagged };
   const subTaggedNonEmpty = { __proto__: superTagged, foo: 'x' };

--- a/packages/vats/test/test-repl.js
+++ b/packages/vats/test/test-repl.js
@@ -25,7 +25,7 @@ test('repl: basic eval, eventual promise resolution', async t => {
   const { doEval, sentMessages, getHighestHistory } = make();
 
   let m = sentMessages.shift();
-  t.deepEqual(m.type, 'updateHistory');
+  t.is(m.type, 'updateHistory');
   t.is(sentMessages.length, 0);
 
   t.deepEqual(getHighestHistory(), { highestHistory: -1 });
@@ -62,13 +62,13 @@ test('repl: basic eval, eventual promise resolution', async t => {
   t.deepEqual(sentMessages, []);
 });
 
-test('repl: bigInts', async t => {
+test('repl: bigInts', t => {
   const { doEval, sentMessages } = make();
 
   let m = sentMessages.shift();
   t.deepEqual(doEval(0, '3n'), {});
   m = sentMessages.shift();
-  t.deepEqual(m.type, 'updateHistory');
+  t.is(m.type, 'updateHistory');
   t.is(sentMessages.length, 1);
 
   t.is(m.histnum, 0);
@@ -80,7 +80,7 @@ test('repl: bigInts', async t => {
   t.deepEqual(sentMessages, []);
 });
 
-test('repl: Symbols', async t => {
+test('repl: Symbols', t => {
   const { doEval, sentMessages } = make();
 
   let m = sentMessages.shift();
@@ -96,7 +96,7 @@ test('repl: Symbols', async t => {
   for (const [expr, display] of exprDisplays) {
     t.deepEqual(doEval(histnum, expr), {});
     m = sentMessages.shift();
-    t.deepEqual(m.type, 'updateHistory');
+    t.is(m.type, 'updateHistory');
     t.is(sentMessages.length, 1);
 
     t.is(m.histnum, histnum);
@@ -110,7 +110,7 @@ test('repl: Symbols', async t => {
   }
 });
 
-test('repl: unjsonables', async t => {
+test('repl: unjsonables', t => {
   const { doEval, sentMessages } = make();
 
   let m = sentMessages.shift();
@@ -119,7 +119,7 @@ test('repl: unjsonables', async t => {
   for (const valStr of ['NaN', 'Infinity', '-Infinity', 'undefined']) {
     t.deepEqual(doEval(histnum, valStr), {});
     m = sentMessages.shift();
-    t.deepEqual(m.type, 'updateHistory');
+    t.is(m.type, 'updateHistory');
     t.is(sentMessages.length, 1);
 
     t.is(m.histnum, histnum);
@@ -133,11 +133,11 @@ test('repl: unjsonables', async t => {
   }
 });
 
-test('repl: sloppyGlobals, home, endowments', async t => {
+test('repl: sloppyGlobals, home, endowments', t => {
   const { doEval, sentMessages } = make();
 
   let m = sentMessages.shift();
-  t.deepEqual(m.type, 'updateHistory');
+  t.is(m.type, 'updateHistory');
   t.is(sentMessages.length, 0);
 
   t.deepEqual(
@@ -170,7 +170,7 @@ test('repl: eventual send', async t => {
   const { doEval, sentMessages } = make();
 
   let m = sentMessages.shift();
-  t.deepEqual(m.type, 'updateHistory');
+  t.is(m.type, 'updateHistory');
   t.is(sentMessages.length, 0);
 
   t.deepEqual(doEval(0, 'target = harden({ foo(x) { return x+1; } })'), {});

--- a/packages/xsnap-lockdown/test/test-inspect.js
+++ b/packages/xsnap-lockdown/test/test-inspect.js
@@ -85,7 +85,7 @@ const testCases = [
   ],
 ];
 
-test('unconfined inspect', async t => {
+test('unconfined inspect', t => {
   for (const testCase of testCases) {
     const [toEval, toRender] = Array.isArray(testCase)
       ? testCase
@@ -94,6 +94,7 @@ test('unconfined inspect', async t => {
     // eslint-disable-next-line no-eval
     const evaled = (1, eval)(`(${toEval})`);
     // t.log(evaled);
+    // eslint-disable-next-line ava/assertion-arguments
     t.is(unconfinedInspect(evaled), toRender, toEval);
   }
 });

--- a/packages/xsnap/test/test-boot-lockdown.js
+++ b/packages/xsnap/test/test-boot-lockdown.js
@@ -66,7 +66,7 @@ test('bootstrap to SES lockdown', async t => {
   const name = 'SES lockdown worker';
   const vat = await xsnap({ ...opts, name });
   await vat.evaluate(bootScript);
-  t.deepEqual([], opts.messages);
+  t.deepEqual(opts.messages, []);
 
   await vat.evaluate(`
     const encoder = new TextEncoder();
@@ -76,7 +76,7 @@ test('bootstrap to SES lockdown', async t => {
     send([ typeof harden, typeof Compartment, typeof HandledPromise ]);
   `);
   await vat.close();
-  t.deepEqual(['["function","function","function"]'], opts.messages);
+  t.deepEqual(opts.messages, ['["function","function","function"]']);
 });
 
 test('child compartment cannot access start powers', async t => {
@@ -137,7 +137,7 @@ test('TextDecoder under xsnap handles TypedArray and subarrays', async t => {
 test('console - symbols', async t => {
   // our console-shim.js handles Symbol specially
   const { worker: vat, opts } = await bootSESWorker(t);
-  t.deepEqual([], opts.messages);
+  t.deepEqual(opts.messages, []);
   await vat.evaluate(`
     const encoder = new TextEncoder();
     globalThis.send = msg => issueCommand(encoder.encode(JSON.stringify(msg)).buffer);
@@ -146,7 +146,7 @@ test('console - symbols', async t => {
     console.log('console:', Symbol.for('registered'));
     send('ok');
   `);
-  t.deepEqual(['"ok"'], opts.messages);
+  t.deepEqual(opts.messages, ['"ok"']);
 });
 
 test('console - objects should include detail', async t => {

--- a/packages/xsnap/test/test-gc.js
+++ b/packages/xsnap/test/test-gc.js
@@ -55,7 +55,7 @@ provokeGC(globalThis.gc).then(data => issueCommand(new TextEncoder().encode(JSON
 `;
   await vat.evaluate(code);
   await vat.close();
-  t.truthy(opts.messages.length === 1, `xsnap didn't send response`);
+  t.true(opts.messages.length === 1, `xsnap didn't send response`);
   const { wrState, finalizerState } = JSON.parse(opts.messages[0]);
   // console.log([wrState, finalizerState]);
   t.is(wrState, 'weakref is dead');

--- a/packages/xsnap/test/test-replay.js
+++ b/packages/xsnap/test/test-replay.js
@@ -41,7 +41,7 @@ test('record: evaluate and issueCommand', async t => {
     `issueCommand(new TextEncoder().encode("Hello, World!").buffer);`,
   );
   await vat.close();
-  t.deepEqual(['Hello, World!'], opts.messages);
+  t.deepEqual(opts.messages, ['Hello, World!']);
 
   t.deepEqual(
     transcript1,

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -68,7 +68,7 @@ test('meter details', async t => {
 // test disabled until rewritten to tolerate fast CI hosts getting
 // multiple events within the same microsecond, #5951
 // (globalThis.performance ? test : test.skip)('meter timestamps', async t => {
-
+// eslint-disable-next-line ava/no-skip-test
 test.skip('meter timestamps', async t => {
   const kernelTimes = [];
   function addTimestamp(name) {
@@ -204,7 +204,7 @@ test('high resolution timer', async t => {
     `);
   const [milliseconds] = opts.messages.map(s => JSON.parse(s));
   t.log({ milliseconds, date: new Date(milliseconds) });
-  t.is('number', typeof milliseconds);
+  t.is(typeof milliseconds, 'number');
 });
 
 test('metering can be switched off / on at run-time', async t => {
@@ -254,7 +254,7 @@ test('metering switch - start compartment only', async t => {
     }
   `);
   await vat.close();
-  t.deepEqual(['no meteringSwitch in Compartment'], opts.messages);
+  t.deepEqual(opts.messages, ['no meteringSwitch in Compartment']);
 });
 
 /** @param {number} logn */
@@ -298,6 +298,7 @@ function dataStructurePerformance(logn) {
 // Rather than have a very low-probability failing test, we skip this, but
 // retain the benchmark for future verification in the unlikely event that the
 // performance character of XS collections regresses.
+// eslint-disable-next-line ava/no-skip-test
 test.skip('Array, Map, Set growth is O(log(n))', async t => {
   const opts = options(io);
   const vat = await xsnap({ ...opts, meteringLimit: 0 });

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -26,7 +26,7 @@ test('evaluate and issueCommand', async t => {
     `issueCommand(new TextEncoder().encode("Hello, World!").buffer);`,
   );
   await vat.close();
-  t.deepEqual(['Hello, World!'], opts.messages);
+  t.deepEqual(opts.messages, ['Hello, World!']);
 });
 
 test('evaluate until idle', async t => {
@@ -38,7 +38,7 @@ test('evaluate until idle', async t => {
     })();
   `);
   await vat.close();
-  t.deepEqual(['Hello, World!'], opts.messages);
+  t.deepEqual(opts.messages, ['Hello, World!']);
 });
 
 test('evaluate infinite loop', async t => {
@@ -49,7 +49,7 @@ test('evaluate infinite loop', async t => {
     code: ExitCode.E_TOO_MUCH_COMPUTATION,
     instanceOf: ErrorCode,
   });
-  t.deepEqual([], opts.messages);
+  t.deepEqual(opts.messages, []);
 });
 
 // TODO: Re-enable when this doesn't take 3.6 seconds.
@@ -69,7 +69,7 @@ test('evaluate promise loop', async t => {
       instanceOf: ErrorCode,
     },
   );
-  t.deepEqual([], opts.messages);
+  t.deepEqual(opts.messages, []);
 });
 
 test('evaluate and report', async t => {
@@ -84,7 +84,7 @@ test('evaluate and report', async t => {
   })()`);
   await vat.close();
   const { reply } = result;
-  t.deepEqual('hi', decode(reply));
+  t.is(decode(reply), 'hi');
 });
 
 test('evaluate error', async t => {
@@ -123,7 +123,7 @@ test('idle includes setImmediate too', async t => {
     send("turn 1");
   `);
   await vat.close();
-  t.deepEqual(['turn 1', 'turn 2', 'end of crank'], opts.messages);
+  t.deepEqual(opts.messages, ['turn 1', 'turn 2', 'end of crank']);
 });
 
 test('print - start compartment only', async t => {
@@ -172,7 +172,7 @@ test('run script until idle', async t => {
   const vat = await xsnap(opts);
   await vat.execute(ld.resolve('fixture-xsnap-script.js'));
   await vat.close();
-  t.deepEqual(['Hello, World!'], opts.messages);
+  t.deepEqual(opts.messages, ['Hello, World!']);
 });
 
 test('issueCommand is synchronous inside, async outside', async t => {
@@ -191,7 +191,7 @@ test('issueCommand is synchronous inside, async outside', async t => {
     issueCommand(new TextEncoder().encode(String(number + 1)).buffer);
   `);
   await vat.close();
-  t.deepEqual([0, 2], messages);
+  t.deepEqual(messages, [0, 2]);
 });
 
 test('deliver a message', async t => {
@@ -211,7 +211,7 @@ test('deliver a message', async t => {
   await vat.issueStringCommand('1');
   await vat.issueStringCommand('2');
   await vat.close();
-  t.deepEqual([1, 2, 3], messages);
+  t.deepEqual(messages, [1, 2, 3]);
 });
 
 test('receive a response', async t => {
@@ -227,9 +227,9 @@ test('receive a response', async t => {
       return new TextEncoder().encode(String(number + 1)).buffer;
     };
   `);
-  t.is('1', (await vat.issueStringCommand('0')).reply);
-  t.is('2', (await vat.issueStringCommand('1')).reply);
-  t.is('3', (await vat.issueStringCommand('2')).reply);
+  t.is((await vat.issueStringCommand('0')).reply, '1');
+  t.is((await vat.issueStringCommand('1')).reply, '2');
+  t.is((await vat.issueStringCommand('2')).reply, '3');
   await vat.close();
 });
 
@@ -345,6 +345,7 @@ hashes.
 
     const hexHash = hash.digest('hex');
     t.log(`${description} produces golden hash ${hexHash}`);
+    // eslint-disable-next-line ava/assertion-arguments -- xxx, use macros
     t.snapshot(hexHash, description);
     t.deepEqual(messages, [], `${description} messages`);
   }
@@ -378,7 +379,7 @@ test('execute immediately after makeSnapshotStream', async t => {
   `);
   await vat1.close();
 
-  t.deepEqual(['before'], messages);
+  t.deepEqual(messages, ['before']);
 });
 
 function delay(ms) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,14 +21,7 @@
   resolved "https://registry.yarnpkg.com/@agoric/wallet-ui/-/wallet-ui-0.1.3-solo.0.tgz#5f05c3dd2820d4f1efcbccbd2dc1292847ecbd2b"
   integrity sha512-NbhCrTH9u2af+6ituM99M8Mo10VOP1nQRTZoYEXW+esBwJId/7cRniMmAC7qmkbXs8POA31S8EQ5gAhkWq08WA==
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
-  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
-  dependencies:
-    "@babel/highlight" "^7.16.7"
-
-"@babel/code-frame@^7.18.6":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
   integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
@@ -77,24 +70,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
   integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
 
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
-  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
-
-"@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1", "@babel/helper-validator-identifier@^7.22.5":
+"@babel/helper-validator-identifier@^7.19.1", "@babel/helper-validator-identifier@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
   integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
-
-"@babel/highlight@^7.16.7":
-  version "7.16.10"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
-  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
 
 "@babel/highlight@^7.18.6":
   version "7.22.5"
@@ -105,12 +84,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.17.3", "@babel/parser@^7.7.0":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
-  integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
-
-"@babel/parser@^7.20.7":
+"@babel/parser@^7.17.3", "@babel/parser@^7.20.7", "@babel/parser@^7.7.0":
   version "7.21.8"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.8.tgz#642af7d0333eab9c0ad70b14ac5e76dbde7bfdf8"
   integrity sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==
@@ -147,23 +121,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.17.0", "@babel/types@^7.7.0":
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
-  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.18.6":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.9.tgz#7148d64ba133d8d73a41b3172ac4b83a1452205f"
-  integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.18.6"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.5":
+"@babel/types@^7.17.0", "@babel/types@^7.18.6", "@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.5", "@babel/types@^7.7.0":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.5.tgz#18dfbd47c39d3904d5db3d3dc2cc80bedb60e5b6"
   integrity sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==
@@ -632,12 +590,7 @@
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
-"@eslint-community/regexpp@^4.4.0", "@eslint-community/regexpp@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
-  integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
-
-"@eslint-community/regexpp@^4.6.1":
+"@eslint-community/regexpp@^4.4.0", "@eslint-community/regexpp@^4.5.1", "@eslint-community/regexpp@^4.6.1":
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.6.2.tgz#1816b5f6948029c5eaacb0703b850ee0cb37d8f8"
   integrity sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==
@@ -768,15 +721,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
-  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
-  dependencies:
-    "@jridgewell/resolve-uri" "3.1.0"
-    "@jridgewell/sourcemap-codec" "1.4.14"
-
-"@jridgewell/trace-mapping@^0.3.17":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.18"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
   integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
@@ -2537,7 +2482,7 @@ acorn-walk@^8.2.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.2.4, acorn@^8.8.0, acorn@^8.8.2, acorn@^8.9.0:
+acorn@^8.2.4, acorn@^8.8.2, acorn@^8.9.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
@@ -4501,22 +4446,7 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
-  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
-
-eslint-visitor-keys@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz#c7f0f956124ce677047ddbc192a68f999454dedc"
-  integrity sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==
-
-eslint-visitor-keys@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
-  integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
-
-eslint-visitor-keys@^3.4.3:
+eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
@@ -4568,25 +4498,7 @@ esm@agoric-labs/esm#Agoric-built:
   version "3.2.25"
   resolved "https://codeload.github.com/agoric-labs/esm/tar.gz/3603726ad4636b2f865f463188fcaade6375638e"
 
-espree@^9.0.0:
-  version "9.5.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.1.tgz#4f26a4d5f18905bf4f2e0bd99002aab807e96dd4"
-  integrity sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==
-  dependencies:
-    acorn "^8.8.0"
-    acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^3.4.0"
-
-espree@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.0.tgz#80869754b1c6560f32e3b6929194a3fe07c5b82f"
-  integrity sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==
-  dependencies:
-    acorn "^8.9.0"
-    acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^3.4.1"
-
-espree@^9.6.1:
+espree@^9.0.0, espree@^9.6.0, espree@^9.6.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
   integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
@@ -4778,29 +4690,7 @@ fast-glob@3.2.7:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@^3.2.11:
-  version "3.2.12"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
-  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
-fast-glob@^3.2.9:
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
-  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
-fast-glob@^3.3.0:
+fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.0.tgz#7c40cb491e1e2ed5664749e87bfb516dbe8727c0"
   integrity sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==
@@ -5543,20 +5433,10 @@ ignore-walk@^5.0.1:
   dependencies:
     minimatch "^5.0.1"
 
-ignore@^5.0.4, ignore@^5.2.4:
+ignore@^5.0.4, ignore@^5.0.5, ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
-
-ignore@^5.0.5:
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
-  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
-
-ignore@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
-  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 import-fresh@^3.2.1:
   version "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,10 +588,15 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
   integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
 
-"@eslint/eslintrc@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.0.tgz#82256f164cc9e0b59669efc19d57f8092706841d"
-  integrity sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==
+"@eslint-community/regexpp@^4.6.1":
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.6.2.tgz#1816b5f6948029c5eaacb0703b850ee0cb37d8f8"
+  integrity sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==
+
+"@eslint/eslintrc@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.2.tgz#c6936b4b328c64496692f76944e755738be62396"
+  integrity sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
@@ -603,10 +608,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@8.44.0":
-  version "8.44.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.44.0.tgz#961a5903c74139390478bdc808bcde3fc45ab7af"
-  integrity sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==
+"@eslint/js@^8.47.0":
+  version "8.47.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.47.0.tgz#5478fdf443ff8158f9de171c704ae45308696c7d"
+  integrity sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==
 
 "@fast-check/ava@^1.1.5":
   version "1.1.5"
@@ -2527,7 +2532,7 @@ ajv@7.1.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-ajv@^6.10.0, ajv@^6.12.4:
+ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -4393,10 +4398,10 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
-  integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
+eslint-scope@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
+  integrity sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -4423,27 +4428,32 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
   integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
-eslint@^8.44.0:
-  version "8.44.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.44.0.tgz#51246e3889b259bbcd1d7d736a0c10add4f0e500"
-  integrity sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==
+eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
+eslint@^8.47.0:
+  version "8.47.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.47.0.tgz#c95f9b935463fb4fad7005e626c7621052e90806"
+  integrity sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
-    "@eslint-community/regexpp" "^4.4.0"
-    "@eslint/eslintrc" "^2.1.0"
-    "@eslint/js" "8.44.0"
+    "@eslint-community/regexpp" "^4.6.1"
+    "@eslint/eslintrc" "^2.1.2"
+    "@eslint/js" "^8.47.0"
     "@humanwhocodes/config-array" "^0.11.10"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
-    ajv "^6.10.0"
+    ajv "^6.12.4"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
     debug "^4.3.2"
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^7.2.0"
-    eslint-visitor-keys "^3.4.1"
-    espree "^9.6.0"
+    eslint-scope "^7.2.2"
+    eslint-visitor-keys "^3.4.3"
+    espree "^9.6.1"
     esquery "^1.4.2"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -4453,7 +4463,6 @@ eslint@^8.44.0:
     globals "^13.19.0"
     graphemer "^1.4.0"
     ignore "^5.2.0"
-    import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
     is-path-inside "^3.0.3"
@@ -4465,7 +4474,6 @@ eslint@^8.44.0:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
     strip-ansi "^6.0.1"
-    strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
 esm@agoric-labs/esm#Agoric-built:
@@ -4476,6 +4484,15 @@ espree@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.0.tgz#80869754b1c6560f32e3b6929194a3fe07c5b82f"
   integrity sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==
+  dependencies:
+    acorn "^8.9.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.4.1"
+
+espree@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
+  integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
   dependencies:
     acorn "^8.9.0"
     acorn-jsx "^5.3.2"
@@ -5407,7 +5424,7 @@ ignore@^5.0.4, ignore@^5.0.5, ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
+import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -8846,7 +8863,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,55 +21,82 @@
   resolved "https://registry.yarnpkg.com/@agoric/wallet-ui/-/wallet-ui-0.1.3-solo.0.tgz#5f05c3dd2820d4f1efcbccbd2dc1292847ecbd2b"
   integrity sha512-NbhCrTH9u2af+6ituM99M8Mo10VOP1nQRTZoYEXW+esBwJId/7cRniMmAC7qmkbXs8POA31S8EQ5gAhkWq08WA==
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.18.6":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.5.tgz#234d98e1551960604f1246e6475891a570ad5658"
-  integrity sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
   dependencies:
-    "@babel/highlight" "^7.22.5"
+    "@babel/highlight" "^7.16.7"
 
-"@babel/generator@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.9.tgz#68337e9ea8044d6ddc690fb29acae39359cca0a5"
-  integrity sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==
+"@babel/code-frame@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
   dependencies:
-    "@babel/types" "^7.18.9"
+    "@babel/highlight" "^7.18.6"
+
+"@babel/generator@^7.17.3":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.5.tgz#c0c0e5449504c7b7de8236d99338c3e2a340745f"
+  integrity sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==
+  dependencies:
+    "@babel/types" "^7.21.5"
     "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
-"@babel/helper-environment-visitor@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
-  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
+"@babel/helper-environment-visitor@^7.16.7":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz#c769afefd41d171836f7cb63e295bedf689d48ba"
+  integrity sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==
 
-"@babel/helper-function-name@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz#940e6084a55dee867d33b4e487da2676365e86b0"
-  integrity sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==
+"@babel/helper-function-name@^7.16.7":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz#d552829b10ea9f120969304023cd0645fa00b1b4"
+  integrity sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==
   dependencies:
-    "@babel/template" "^7.18.6"
-    "@babel/types" "^7.18.9"
+    "@babel/template" "^7.20.7"
+    "@babel/types" "^7.21.0"
 
-"@babel/helper-hoist-variables@^7.18.6":
+"@babel/helper-hoist-variables@^7.16.7":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
   integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-split-export-declaration@^7.18.6":
+"@babel/helper-split-export-declaration@^7.16.7":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
   integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.22.5":
+"@babel/helper-string-parser@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
+  integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
+
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
+"@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1", "@babel/helper-validator-identifier@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
   integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
 
-"@babel/highlight@^7.22.5":
+"@babel/highlight@^7.16.7":
+  version "7.16.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
+  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.18.6":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.5.tgz#aa6c05c5407a67ebce408162b7ede789b4d22031"
   integrity sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==
@@ -78,10 +105,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.17.3", "@babel/parser@^7.18.6", "@babel/parser@^7.18.9", "@babel/parser@^7.7.0":
+"@babel/parser@^7.17.3", "@babel/parser@^7.7.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
   integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
+
+"@babel/parser@^7.20.7":
+  version "7.21.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.8.tgz#642af7d0333eab9c0ad70b14ac5e76dbde7bfdf8"
+  integrity sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==
 
 "@babel/runtime@^7.20.7":
   version "7.22.5"
@@ -90,37 +122,54 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/template@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.6.tgz#1283f4993e00b929d6e2d3c72fdc9168a2977a31"
-  integrity sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==
+"@babel/template@^7.20.7":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
+  integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/parser" "^7.18.6"
-    "@babel/types" "^7.18.6"
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
 
 "@babel/traverse@^7.17.3", "@babel/traverse@^7.7.0":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.9.tgz#deeff3e8f1bad9786874cb2feda7a2d77a904f98"
-  integrity sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
+  integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
   dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.9"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.18.9"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.18.9"
-    "@babel/types" "^7.18.9"
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.3"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.3"
+    "@babel/types" "^7.17.0"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.17.0", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.7.0":
+"@babel/types@^7.17.0", "@babel/types@^7.7.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.18.6":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.9.tgz#7148d64ba133d8d73a41b3172ac4b83a1452205f"
   integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.18.6"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.5.tgz#18dfbd47c39d3904d5db3d3dc2cc80bedb60e5b6"
+  integrity sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==
+  dependencies:
+    "@babel/helper-string-parser" "^7.21.5"
+    "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -723,6 +772,14 @@
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
   integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.17":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
+  integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
@@ -2480,7 +2537,7 @@ acorn-walk@^8.2.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.2.4, acorn@^8.8.2, acorn@^8.9.0:
+acorn@^8.2.4, acorn@^8.8.0, acorn@^8.8.2, acorn@^8.9.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
@@ -4075,6 +4132,13 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   dependencies:
     once "^1.4.0"
 
+enhance-visitors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/enhance-visitors/-/enhance-visitors-1.0.0.tgz#aa945d05da465672a1ebd38fee2ed3da8518e95a"
+  integrity sha512-+29eJLiUixTEDRaZ35Vu8jP3gPLNcQQkQkOQjLp2X+6cZGGPDD/uasbFzvLsJKnGZnvmyZ0srxudwOtskHeIDA==
+  dependencies:
+    lodash "^4.13.1"
+
 enquirer@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -4248,6 +4312,20 @@ eslint-module-utils@^2.7.4:
   integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
   dependencies:
     debug "^3.2.7"
+
+eslint-plugin-ava@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ava/-/eslint-plugin-ava-14.0.0.tgz#3319e5e470342c17a467a3a3e08b0cebb88050ca"
+  integrity sha512-XmKT6hppaipwwnLVwwvQliSU6AF1QMHiNoLD5JQfzhUhf0jY7CO0O624fQrE+Y/fTb9vbW8r77nKf7M/oHulxw==
+  dependencies:
+    enhance-visitors "^1.0.0"
+    eslint-utils "^3.0.0"
+    espree "^9.0.0"
+    espurify "^2.1.1"
+    import-modules "^2.1.0"
+    micro-spelling-correcter "^1.1.1"
+    pkg-dir "^5.0.0"
+    resolve-from "^5.0.0"
 
 eslint-plugin-escompat@^3.3.3:
   version "3.4.0"
@@ -4423,7 +4501,17 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
+
+eslint-visitor-keys@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz#c7f0f956124ce677047ddbc192a68f999454dedc"
+  integrity sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==
+
+eslint-visitor-keys@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
   integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
@@ -4480,6 +4568,15 @@ esm@agoric-labs/esm#Agoric-built:
   version "3.2.25"
   resolved "https://codeload.github.com/agoric-labs/esm/tar.gz/3603726ad4636b2f865f463188fcaade6375638e"
 
+espree@^9.0.0:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.1.tgz#4f26a4d5f18905bf4f2e0bd99002aab807e96dd4"
+  integrity sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.4.0"
+
 espree@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.0.tgz#80869754b1c6560f32e3b6929194a3fe07c5b82f"
@@ -4502,6 +4599,11 @@ esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+espurify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/espurify/-/espurify-2.1.1.tgz#afb043f22fac908d991dd25f7bf40bcf03935b9c"
+  integrity sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==
 
 esquery@^1.4.2, esquery@^1.5.0:
   version "1.5.0"
@@ -4676,7 +4778,29 @@ fast-glob@3.2.7:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0:
+fast-glob@^3.2.11:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.9:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.0.tgz#7c40cb491e1e2ed5664749e87bfb516dbe8727c0"
   integrity sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==
@@ -5419,10 +5543,20 @@ ignore-walk@^5.0.1:
   dependencies:
     minimatch "^5.0.1"
 
-ignore@^5.0.4, ignore@^5.0.5, ignore@^5.2.0, ignore@^5.2.4:
+ignore@^5.0.4, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+
+ignore@^5.0.5:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
+  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
+
+ignore@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 import-fresh@^3.2.1:
   version "3.3.0"
@@ -5451,6 +5585,11 @@ import-meta-resolve@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-2.2.1.tgz#80fdeddbc15d7f3992c37425023ffb4aca7cb583"
   integrity sha512-C6lLL7EJPY44kBvA80gq4uMsVFw5x3oSKfuMl1cuZ2RkI5+UJqQXgn+6hlUew0y4ig7Ypt4CObAAIzU53Nfpuw==
+
+import-modules@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-modules/-/import-modules-2.1.0.tgz#abe7df297cb6c1f19b57246eb8b8bd9664b6d8c2"
+  integrity sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -6294,7 +6433,7 @@ lodash.upperfirst@4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.13.1, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6539,6 +6678,11 @@ methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
+micro-spelling-correcter@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz#805a06a26ccfcad8f3e5c6a1ac5ff29d4530166e"
+  integrity sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==
 
 micromark-core-commonmark@^1.0.1:
   version "1.1.0"
@@ -7877,6 +8021,13 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-dir@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
+  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
+  dependencies:
+    find-up "^5.0.0"
 
 plur@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
closes: #4941

## Description

Motivation in #4941.

- Adds https://github.com/avajs/eslint-plugin-ava
- Disabled [`use-test`](https://github.com/avajs/eslint-plugin-ava/blob/v13.2.0/docs/rules/use-test.md) due to https://github.com/avajs/eslint-plugin-ava/pull/294#issuecomment-1084648317 
- Selectively disabled [`no-lone-blocks`](https://eslint.org/docs/rules/no-lone-blocks) that started erroring, I suppose because a dep that was updated caught more cases. Alternately we could disable the rule.
- A test that imported from another test required refactoring

### Security Considerations

--
### Documentation Considerations

--

### Testing Considerations

--