### PR TITLE
ci(mergify): fix mergify branch pattern

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -3,7 +3,7 @@
 #  Require branches to be up to date before merging
 on:
   push:
-    branches: [mergify/*]
+    branches: [mergify/merge-queue/master/*]
 
 jobs:
   build:

--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -5,7 +5,7 @@ name: ag-solo on xs
 
 on:
   push:
-    branches: [ mergify/* ] # $default-branch
+    branches: [ mergify/merge-queue/master/* ] # $default-branch
 
 jobs:
   xs-build:

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   # Otherwise, run on default branch.
   push:
-    branches: [mergify/*] # $default-branch
+    branches: [mergify/merge-queue/master/*] # $default-branch
 
 jobs:
   deployment-test:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Build release Docker Images
 
 on:
   push:
-    branches: [mergify/*] # $default-branch
+    branches: [master] # $default-branch
     tags:
       - '@agoric/sdk@*'
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       - v*
-    branches: [mergify/*]
+    branches: [mergify/merge-queue/master/*]
   pull_request:
 permissions:
   contents: read


### PR DESCRIPTION
refs: #4969

## Description

Update the branch pattern for GH workflow jobs which should only run before a merge to `mergify/merge-queue/master/*`.

Move the `docker` jobs back to `master` branch trigger since the snapshot tag uses the sha which would be different on the integration branch. We should parametrize the `push: ` option of the docker action instead.

### Security Considerations

N/A

### Documentation Considerations

Needs documentation that some CI jobs only run before merge and not part of regular Pull Request CI

### Testing Considerations

Will check that these jobs trigger before requiring them in a future PR.
