### PR TITLE
refactor(run-protocol): `const` for `prioritizedVaults`

### DIFF
--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -46,8 +46,17 @@ export const currentDebtToCollateral = vault =>
  * @param {() => void} reschedulePriceCheck called when there is a new
  * least-collateralized vault
  */
-export const makePrioritizedVaults = reschedulePriceCheck => {
+export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
   const vaults = makeOrderedVaultStore();
+
+  /**
+   * Set the callback for when there is a new least-collateralized vault
+   *
+   * @param {() => void} rescheduleFn
+   */
+  const setRescheduler = rescheduleFn => {
+    reschedulePriceCheck = rescheduleFn;
+  };
 
   // To deal with fluctuating prices and varying collateralization, we schedule a
   // new request to the priceAuthority when some vault's debtToCollateral ratio
@@ -180,5 +189,6 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
     refreshVaultPriority,
     removeVault,
     removeVaultByAttributes,
+    setRescheduler,
   });
 };

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -103,8 +103,7 @@ export const makeVaultManager = (
    *
    * @type {ReturnType<typeof makePrioritizedVaults>}
    */
-  // eslint-disable-next-line no-use-before-define
-  const prioritizedVaults = makePrioritizedVaults(reschedulePriceCheck);
+  const prioritizedVaults = makePrioritizedVaults();
 
   /** @type {MutableQuote=} */
   let outstandingQuote;
@@ -168,7 +167,7 @@ export const makeVaultManager = (
    * high-water level when the request was made matches the current high-water
    * level.
    */
-  async function reschedulePriceCheck() {
+  const reschedulePriceCheck = async () => {
     const highestDebtRatio = prioritizedVaults.highestRatio();
     if (!highestDebtRatio) {
       // if there aren't any open vaults, we don't need an outstanding RFQ.
@@ -231,7 +230,8 @@ export const makeVaultManager = (
     await (next ? liquidateAndRemove(next) : null);
 
     reschedulePriceCheck();
-  }
+  };
+  prioritizedVaults.setRescheduler(reschedulePriceCheck);
 
   /**
    * In extreme situations, system health may require liquidating all vaults.


### PR DESCRIPTION
closes: #4916

## Description

Change `prioritizedVaults` to be const to eliminate all the asserts that it is assigned, when it should always be set.

### Security Considerations

Having mutable cells for things that should be constant is an unnecessary weakness.

### Documentation Considerations

N/A

### Testing Considerations

This is a pure refactor and so existing tests are sufficient.
