### PR TITLE
Clear up some `NameAdmin` power access

### DIFF
--- a/packages/vats/src/core/boot.js
+++ b/packages/vats/src/core/boot.js
@@ -55,8 +55,9 @@ const buildRootObject = (vatPowers, vatParameters) => {
   // @ts-expect-error no TS defs for rickety test scaffolding
   const log = vatPowers.logger || console.info;
   const { produce, consume } = makePromiseSpace(log);
-  const { agoricNames, spaces } = makeAgoricNamesAccess(log);
+  const { agoricNames, agoricNamesAdmin, spaces } = makeAgoricNamesAccess(log);
   produce.agoricNames.resolve(agoricNames);
+  produce.agoricNamesAdmin.resolve(agoricNamesAdmin);
 
   const {
     argv: { ROLE },

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -99,6 +99,14 @@
  */
 
 /**
+ * @template T
+ * @typedef {{
+ *   consume: { [P in keyof T]: ERef<T[P]> },
+ *   produce: { [P in keyof T]: Producer<T[P]> },
+ * }} PromiseSpaceOf
+ */
+
+/**
  * @callback CreateUserBundle
  * @param {string} nickname
  * @param {string} clientAddress
@@ -169,65 +177,38 @@
  */
 
 /**
- * @typedef { WellKnownSpaces & {
- *   consume: {
- *     agoricNames: Promise<NameHub>,
- *     agoricNamesAdmin: Promise<NameAdmin>,
- *     ammCreatorFacet: ERef<XYKAMMCreatorFacet>,
- *     ammGovernorCreatorFacet: ERef<GovernedContractFacetAccess<unknown>>,
- *     chainTimerService: ERef<TimerService>,
- *     economicCommitteeCreatorFacet: ERef<CommitteeElectorateCreatorFacet>,
- *     ammBundle: ERef<SourceBundle>,
- *     reserveBundle: ERef<SourceBundle>,
- *     reserveCreatorFacet: ERef<GovernedContractFacetAccess<any>>,
- *     reserveGovernorCreatorFacet: ERef<GovernedContractFacetAccess<any>>,
- *     vaultBundles: ERef<Record<string, SourceBundle>>,
- *     centralSupplyBundle: ERef<SourceBundle>,
- *     mintHolderBundle: ERef<SourceBundle>,
- *     feeMintAccess: ERef<FeeMintAccess>,
- *     governanceBundles: ERef<Record<string, SourceBundle>>,
- *     initialSupply: ERef<Payment>,
- *     pegasusBundle: Promise<SourceBundle>,
- *     pegasusConnections: Promise<NameHub>,
- *     pegasusConnectionsAdmin: Promise<NameAdmin>,
- *     priceAuthorityVat: PriceAuthorityVat,
- *     priceAuthority: ERef<PriceAuthority>,
- *     priceAuthorityAdmin: ERef<PriceAuthorityRegistryAdmin>,
- *     vaultFactoryCreator: ERef<VaultFactory>,
- *     vaultFactoryGovernorCreator: ERef<GovernedContractFacetAccess<unknown>>,
- *     zoe: ERef<ZoeService>,
- *   },
- *   produce: {
- *     agoricNames: Producer<NameHub>,
- *     agoricNamesAdmin: Producer<NameAdmin>,
- *     ammCreatorFacet: Producer<unknown>,
- *     ammGovernorCreatorFacet: Producer<unknown>,
- *     chainTimerService: Producer<ERef<TimerService>>,
- *     economicCommitteeCreatorFacet: Producer<CommitteeElectorateCreatorFacet>,
- *     runStakeBundle: Producer<{ moduleFormat: string }>,
- *     ammBundle: Producer<SourceBundle>,
- *     reserveBundle: Producer<SourceBundle>,
- *     reservePublicFacet: Producer<unknown>,
- *     reserveCreatorFacet: Producer<unknown>,
- *     reserveGovernorCreatorFacet: Producer<GovernedContractFacetAccess<any>>,
- *     vaultBundles: Producer<Record<string, SourceBundle>>,
- *     governanceBundles: Producer<Record<string, SourceBundle>>,
- *     initialSupply: Producer<Payment>,
- *     centralSupplyBundle: Producer<SourceBundle>,
- *     mintHolderBundle: Producer<SourceBundle>,
- *     feeMintAccess: Producer<FeeMintAccess>,
- *     priceAuthorityVat: Producer<PriceAuthorityVat>,
- *     priceAuthority: Producer<PriceAuthority>,
- *     priceAuthorityAdmin: Producer<PriceAuthorityRegistryAdmin>,
- *     pegasusBundle: Producer<SourceBundle>,
- *     pegasusConnections: Producer<NameHub>,
- *     pegasusConnectionsAdmin: Producer<NameAdmin>,
- *     vaultFactoryCreator: Producer<{ makeCollectFeesInvitation: () => Promise<Invitation> }>,
- *     vaultFactoryGovernorCreator: Producer<unknown>,
- *     vaultFactoryVoteCreator: Producer<unknown>,
- *     zoe: Producer<ERef<ZoeService>>,
- *   },
- * }} EconomyBootstrapPowers
+ * @typedef { WellKnownSpaces & EconomyBootstrapSpace
+ * } EconomyBootstrapPowers
+ * @typedef {PromiseSpaceOf<{
+ *   agoricNames: NameHub,
+ *   agoricNamesAdmin: NameAdmin,
+ *   ammCreatorFacet: XYKAMMCreatorFacet,
+ *   ammGovernorCreatorFacet: GovernedContractFacetAccess<unknown>,
+ *   chainTimerService: TimerService,
+ *   economicCommitteeCreatorFacet: CommitteeElectorateCreatorFacet,
+ *   getRUNBundle: { moduleFormat: string },
+ *   ammBundle: SourceBundle,
+ *   reserveBundle: SourceBundle,
+ *   reservePublicFacet: unknown,
+ *   reserveCreatorFacet: GovernedContractFacetAccess<any>,
+ *   reserveGovernorCreatorFacet: GovernedContractFacetAccess<any>,
+ *   vaultBundles: Record<string, SourceBundle>,
+ *   centralSupplyBundle: SourceBundle,
+ *   mintHolderBundle: SourceBundle,
+ *   feeMintAccess: FeeMintAccess,
+ *   governanceBundles: Record<string, SourceBundle>,
+ *   initialSupply: Payment,
+ *   pegasusBundle: SourceBundle,
+ *   pegasusConnections: NameHub,
+ *   pegasusConnectionsAdmin: NameAdmin,
+ *   priceAuthorityVat: Awaited<PriceAuthorityVat>,
+ *   priceAuthority: PriceAuthority,
+ *   priceAuthorityAdmin: PriceAuthorityRegistryAdmin,
+ *   vaultFactoryCreator: VaultFactory,
+ *   vaultFactoryGovernorCreator: GovernedContractFacetAccess<unknown>,
+ *   vaultFactoryVoteCreator: unknown,
+ *   zoe: ZoeService,
+ * }>} EconomyBootstrapSpace
  *
  * IDEA/TODO: make types of demo stuff invisible in production behaviors
  * @typedef {{
@@ -249,35 +230,22 @@
  *   runBehaviors: (manifest: unknown) => Promise<unknown>,
  *   modules: Record<string, Record<string, any>>,
  * }} BootstrapPowers
- * @typedef { WellKnownSpaces & {
- *   consume: EconomyBootstrapPowers['consume'] & {
- *     bankManager: BankManager,
- *     board: ERef<Board>,
- *     bldIssuerKit: ERef<RemoteIssuerKit>,
- *     bridgeManager: ERef<OptionalBridgeManager>,
- *     client: ERef<ClientManager>,
- *     clientCreator: ERef<ClientCreator>,
- *     mints: ERef<MintsVat>,
- *     provisioning: ProvisioningVat,
- *     vatAdminSvc: ERef<VatAdminSvc>,
- *     namesByAddress: ERef<NameHub>,
- *     namesByAddressAdmin: ERef<NameAdmin>,
- *   },
- *   produce: EconomyBootstrapPowers['produce'] & {
- *     bankManager: Producer<BankManager>,
- *     bldIssuerKit: Producer<RemoteIssuerKit>,
- *     board: Producer<ERef<Board>>,
- *     bridgeManager: Producer<OptionalBridgeManager>,
- *     client: Producer<ClientManager>,
- *     clientCreator: Producer<ClientCreator>,
+ * @typedef { WellKnownSpaces & EconomyBootstrapSpace & PromiseSpaceOf<{
+ *     bankManager: Awaited<BankManager>,
+ *     board: Board,
+ *     bldIssuerKit: RemoteIssuerKit,
+ *     bridgeManager: OptionalBridgeManager,
+ *     client: ClientManager,
+ *     clientCreator: ClientCreator,
+ *     mints: MintsVat,
+ *     provisioning: Awaited<ProvisioningVat>,
+ *     vatAdminSvc: VatAdminSvc,
+ *     namesByAddress: NameHub,
+ *     namesByAddressAdmin: NameAdmin,
+ *   }> & { produce: {
  *     loadVat: Producer<VatLoader<unknown>>,
- *     mints: Producer<MintsVat>,
- *     provisioning: Producer<unknown>,
- *     vatAdminSvc: Producer<ERef<VatAdminSvc>>,
- *     namesByAddress: Producer<NameHub>,
- *     namesByAddressAdmin: Producer<NameAdmin>,
- *   },
- * }} BootstrapSpace
+ *   }}
+ * } BootstrapSpace
  * @typedef {{ mint: ERef<Mint>, issuer: ERef<Issuer>, brand: Brand }} RemoteIssuerKit
  * @typedef {ReturnType<Awaited<BankVat>['makeBankManager']>} BankManager
  * @typedef {ERef<ReturnType<import('../vat-bank.js').buildRootObject>>} BankVat

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -172,6 +172,7 @@
  * @typedef { WellKnownSpaces & {
  *   consume: {
  *     agoricNames: Promise<NameHub>,
+ *     agoricNamesAdmin: Promise<NameAdmin>,
  *     ammCreatorFacet: ERef<XYKAMMCreatorFacet>,
  *     ammGovernorCreatorFacet: ERef<GovernedContractFacetAccess<unknown>>,
  *     chainTimerService: ERef<TimerService>,
@@ -198,6 +199,7 @@
  *   },
  *   produce: {
  *     agoricNames: Producer<NameHub>,
+ *     agoricNamesAdmin: Producer<NameAdmin>,
  *     ammCreatorFacet: Producer<unknown>,
  *     ammGovernorCreatorFacet: Producer<unknown>,
  *     chainTimerService: Producer<ERef<TimerService>>,

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -219,6 +219,7 @@ harden(extractPowers);
  *
  * @returns {{
  *   agoricNames: NameHub,
+ *   agoricNamesAdmin: NameAdmin,
  *   spaces: WellKnownSpaces,
  * }}
  *
@@ -249,6 +250,7 @@ export const makeAgoricNamesAccess = (
   );
   return {
     agoricNames,
+    agoricNamesAdmin,
     spaces: typedSpaces,
   };
 };

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -230,9 +230,10 @@ export const makeAgoricNamesAccess = (
 ) => {
   const { nameHub: agoricNames, nameAdmin: agoricNamesAdmin } =
     makeNameHubKit();
+
   const hubs = mapEntries(reserved, (key, _d) => {
     const { nameHub, nameAdmin } = makeNameHubKit();
-    agoricNamesAdmin.update(key, nameHub);
+    agoricNamesAdmin.update(key, nameHub, nameAdmin);
     return [key, { nameHub, nameAdmin }];
   });
   const spaces = mapEntries(reserved, (key, detail) => {

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -94,6 +94,7 @@ export const makeNameHubKit = () => {
       // This delete may throw.  Reflect it to callers.
       keyToRecord.delete(key);
     },
+    readonly: () => nameHub,
   });
 
   const nameHubKit = harden({

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -38,13 +38,18 @@
  * @property {(key: string) => void} reserve Mark a key as reserved; will
  * return a promise that is fulfilled when the key is updated (or rejected when
  * deleted).
- * @property {(key: string, newValue: unknown) => void} update Fulfill an
- * outstanding reserved promise (if any) to the newValue and set the key to the
- * newValue.
+ * @property {(
+ *   key: string, newValue: unknown, newAdmin?: unknown) => void
+ * } update Fulfill an outstanding reserved promise (if any) to the newValue and
+ * set the key to the newValue.  If newAdmin is provided, set that to return via
+ * lookupAdmin.
+ * @property {(...path: Array<string>) => Promise<any>} lookupAdmin Look up the
+ * `newAdmin` from the path of keys starting from the current NameAdmin.  Wait
+ * on any reserved promises.
  * @property {(key: string) => void} delete Delete a value and reject an
  * outstanding reserved promise (if any).
- * @property {() => NameHub} readonly get a read-only view of the current
- * NameAdmin
+ * @property {() => NameHub} readonly get the NameHub corresponding to the
+ * current NameAdmin
  */
 
 /**

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -43,6 +43,8 @@
  * newValue.
  * @property {(key: string) => void} delete Delete a value and reject an
  * outstanding reserved promise (if any).
+ * @property {() => NameHub} readonly get a read-only view of the current
+ * NameAdmin
  */
 
 /**

--- a/packages/vats/test/test-name-hub.js
+++ b/packages/vats/test/test-name-hub.js
@@ -21,12 +21,16 @@ test('makeNameHubKit - lookup paths', async t => {
   t.is(na2.readonly(), nh2);
   t.is(na3.readonly(), nh3);
 
-  na1.update('path1', nh2);
+  na1.update('path1', nh2, na2);
   t.is(await nh1.lookup('path1'), nh2);
-  na2.update('path2', nh3);
+  na2.update('path2', nh3, na3);
   t.is(await nh2.lookup('path2'), nh3);
   na3.update('path3', 'finish');
   t.is(await nh3.lookup('path3'), 'finish');
+
+  await na1
+    .lookupAdmin('path1', 'path2')
+    .then(na3b => na3b.update('path3', 'finish2'));
 
   t.deepEqual(nh1.keys(), ['path1']);
   t.deepEqual(nh1.values(), [nh2]);
@@ -35,13 +39,13 @@ test('makeNameHubKit - lookup paths', async t => {
   t.deepEqual(nh2.values(), [nh3]);
   t.deepEqual(nh2.entries(), [['path2', nh3]]);
   t.deepEqual(nh3.keys(), ['path3']);
-  t.deepEqual(nh3.values(), ['finish']);
-  t.deepEqual(nh3.entries(), [['path3', 'finish']]);
+  t.deepEqual(nh3.values(), ['finish2']);
+  t.deepEqual(nh3.entries(), [['path3', 'finish2']]);
 
   t.is(await nh1.lookup(), nh1);
   t.is(await nh1.lookup('path1'), nh2);
   t.is(await nh1.lookup('path1', 'path2'), nh3);
-  t.is(await nh1.lookup('path1', 'path2', 'path3'), 'finish');
+  t.is(await nh1.lookup('path1', 'path2', 'path3'), 'finish2');
   await t.throwsAsync(() => nh1.lookup('path1', 'path2', 'path3', 'path4'), {
     message: /^target has no method "lookup", has/,
   });

--- a/packages/vats/test/test-name-hub.js
+++ b/packages/vats/test/test-name-hub.js
@@ -17,6 +17,10 @@ test('makeNameHubKit - lookup paths', async t => {
   t.deepEqual(nh3.values(), []);
   t.deepEqual(nh3.entries(), []);
 
+  t.is(na1.readonly(), nh1);
+  t.is(na2.readonly(), nh2);
+  t.is(na3.readonly(), nh3);
+
   na1.update('path1', nh2);
   t.is(await nh1.lookup('path1'), nh2);
   na2.update('path2', nh3);
@@ -45,6 +49,8 @@ test('makeNameHubKit - lookup paths', async t => {
 
 test('makeNameHubKit - reserve and update', async t => {
   const { nameAdmin, nameHub } = makeNameHubKit();
+
+  t.is(nameAdmin.readonly(), nameHub);
 
   await t.throwsAsync(() => nameHub.lookup('hello'), {
     message: /"nameKey" not found: .*/,
@@ -80,6 +86,8 @@ test('makeNameHubKit - reserve and update', async t => {
 
 test('makeNameHubKit - reserve and delete', async t => {
   const { nameAdmin, nameHub } = makeNameHubKit();
+
+  t.is(nameAdmin.readonly(), nameHub);
 
   await t.throwsAsync(() => nameHub.lookup('goodbye'), {
     message: /"nameKey" not found: .*/,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Give holders of `NameAdmin` objects access to the corresponding read-only facet (`NameAdmin.readonly()` returns a `NameHub`).

Also, keep `agoricNamesAdmin` in the core boot powers so that arbitrary names can be added by big-hammer governance.

As a drive-by, use PromiseSpaceOf to DRY out produce/consume types (this was a good change by @dckc that didn't make it into another PR).

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

`NameAdmin`s already have unconditional power to mutate the set of names they control, so this isn't really an increase of scope.

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
