### PR TITLE
fix: Make payments recoverable

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -60,9 +60,7 @@ export const makePaymentLedger = (
    */
   const initPayment = (payment, amount, optRecoverySet = undefined) => {
     if (optRecoverySet !== undefined) {
-      if (!optRecoverySet.has(payment)) {
-        optRecoverySet.add(payment);
-      }
+      optRecoverySet.add(payment);
       paymentRecoverySets.init(payment, optRecoverySet);
     }
     paymentLedger.init(payment, amount);
@@ -73,9 +71,7 @@ export const makePaymentLedger = (
     if (paymentRecoverySets.has(payment)) {
       const recoverySet = paymentRecoverySets.get(payment);
       paymentRecoverySets.delete(payment);
-      if (recoverySet.has(payment)) {
-        recoverySet.delete(payment);
-      }
+      recoverySet.delete(payment);
     }
   };
 

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -216,11 +216,8 @@ export const makePaymentLedger = (
     });
   };
 
-  const claimInternal = (
-    paymentP,
-    optAmountShape = undefined,
-    optRecoverSet = undefined,
-  ) => {
+  /** @type {IssuerClaim} */
+  const claim = (paymentP, optAmountShape = undefined) => {
     return E.when(paymentP, srcPayment => {
       assertLivePayment(srcPayment);
       const srcPaymentBalance = paymentLedger.get(srcPayment);
@@ -229,15 +226,11 @@ export const makePaymentLedger = (
       const [payment] = moveAssets(
         harden([srcPayment]),
         harden([srcPaymentBalance]),
-        optRecoverSet,
+        undefined,
       );
       return payment;
     });
   };
-
-  /** @type {IssuerClaim} */
-  const claim = (paymentP, optAmountShape = undefined) =>
-    claimInternal(paymentP, optAmountShape, undefined);
 
   /** @type {IssuerCombine} */
   const combine = (fromPaymentsPArray, optTotalAmount = undefined) => {
@@ -386,7 +379,6 @@ export const makePaymentLedger = (
   const purseMethods = {
     depositInternal,
     withdrawInternal,
-    claimInternal,
   };
 
   const makeEmptyPurse = makePurseMaker(

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -158,14 +158,9 @@ export const makePaymentLedger = (
    *
    * @param {Payment[]} payments
    * @param {Amount[]} newPaymentBalances
-   * @param {SetStore<Payment>} [optRecoverySet]
    * @returns {Payment[]}
    */
-  const moveAssets = (
-    payments,
-    newPaymentBalances,
-    optRecoverySet = undefined,
-  ) => {
+  const moveAssets = (payments, newPaymentBalances) => {
     assertCopyArray(payments, 'payments');
     assertCopyArray(newPaymentBalances, 'newPaymentBalances');
 
@@ -205,7 +200,7 @@ export const makePaymentLedger = (
 
       newPayments = newPaymentBalances.map(balance => {
         const newPayment = makePayment();
-        initPayment(newPayment, balance, optRecoverySet);
+        initPayment(newPayment, balance, undefined);
         return newPayment;
       });
     } catch (err) {
@@ -257,7 +252,6 @@ export const makePaymentLedger = (
       const [payment] = moveAssets(
         harden([srcPayment]),
         harden([srcPaymentBalance]),
-        undefined,
       );
       return payment;
     });
@@ -278,7 +272,6 @@ export const makePaymentLedger = (
       const [payment] = moveAssets(
         harden(fromPaymentsArray),
         harden([totalPaymentsBalance]),
-        undefined,
       );
       return payment;
     });
@@ -296,7 +289,6 @@ export const makePaymentLedger = (
       const newPayments = moveAssets(
         harden([srcPayment]),
         harden([paymentAmountA, paymentAmountB]),
-        undefined,
       );
       return newPayments;
     });
@@ -309,11 +301,7 @@ export const makePaymentLedger = (
       assertCopyArray(amounts, 'amounts');
       amounts = amounts.map(coerce);
       // Note COMMIT POINT within moveAssets.
-      const newPayments = moveAssets(
-        harden([srcPayment]),
-        harden(amounts),
-        undefined,
-      );
+      const newPayments = moveAssets(harden([srcPayment]), harden(amounts));
       return newPayments;
     });
   };

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -16,7 +16,7 @@ export const makePurseMaker = (allegedName, assetKind, brand, purseMethods) => {
   // - An alternative design considered was to have this return a Purse alone
   //   that created depositFacet as needed. But this approach ensures a constant
   //   identity for the facet and exercises the multi-faceted object style.
-  const { depositInternal, withdrawInternal, claimInternal } = purseMethods;
+  const { depositInternal, withdrawInternal } = purseMethods;
   const makePurseKit = defineKind(
     allegedName,
     () => {
@@ -62,8 +62,6 @@ export const makePurseMaker = (allegedName, assetKind, brand, purseMethods) => {
         // eslint-disable-next-line no-use-before-define
         getDepositFacet: ({ facets }) => facets.depositFacet,
 
-        claim: ({ state }, paymentP, optAmountShape) =>
-          claimInternal(paymentP, optAmountShape, state.recoverySet),
         getRecoverySet: ({ state }) => state.recoverySet.snapshot(),
         recoverAll: ({ state, facets }) => {
           let amount = AmountMath.makeEmpty(brand, assetKind);

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -350,6 +350,24 @@
  *
  * @property {(amount: Amount) => Payment} withdraw
  * Withdraw amount from this purse into a new Payment.
+ *
+ * @property {IssuerClaim} claim
+ * Like `issuer.claim`, but also associates the new payment with this purse's
+ * recovery set, so the payment can be recovered in emergencies.
+ *
+ * @property {() => CopySet<Payment>} getRecoverySet
+ * The set of payments associated with this purse that are still live. These
+ * are the payments that can still be recovered in emergencies by, for example,
+ * depositing into this purse. Such a deposit action is like canceling an
+ * outstanding check because you're tired of waiting for it. Once your
+ * cancellation is acknowledged, ypu can spend the assets at stake on other
+ * things. Afterwards, if the recipient of the original check finally gets
+ * around to depositing it, their deposit fails.
+ *
+ * @property {() => Amount} recoverAll
+ * For use in emergencies, such as coming back from a traumatic crash and
+ * upgrade. This deposits all the payments in this purse's recovery set
+ * into the purse itself, returning the total amount of assets recovered.
  */
 
 /**

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -360,7 +360,7 @@
  * are the payments that can still be recovered in emergencies by, for example,
  * depositing into this purse. Such a deposit action is like canceling an
  * outstanding check because you're tired of waiting for it. Once your
- * cancellation is acknowledged, ypu can spend the assets at stake on other
+ * cancellation is acknowledged, you can spend the assets at stake on other
  * things. Afterwards, if the recipient of the original check finally gets
  * around to depositing it, their deposit fails.
  *

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -351,10 +351,6 @@
  * @property {(amount: Amount) => Payment} withdraw
  * Withdraw amount from this purse into a new Payment.
  *
- * @property {IssuerClaim} claim
- * Like `issuer.claim`, but also associates the new payment with this purse's
- * recovery set, so the payment can be recovered in emergencies.
- *
  * @property {() => CopySet<Payment>} getRecoverySet
  * The set of payments associated with this purse that are still live. These
  * are the payments that can still be recovered in emergencies by, for example,

--- a/packages/ERTP/test/unitTests/test-recovery.js
+++ b/packages/ERTP/test/unitTests/test-recovery.js
@@ -1,0 +1,42 @@
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { keyEQ, makeCopySet } from '@agoric/store';
+
+import { makeIssuerKit, AmountMath } from '../../src/index.js';
+
+const { isEmpty, isEqual } = AmountMath;
+const emptySet = makeCopySet([]);
+
+test('payment recovery', async t => {
+  const { issuer, mint, brand } = makeIssuerKit('precious');
+  const precious = num => AmountMath.make(brand, num);
+  const payment1 = mint.mintPayment(precious(37n));
+  const payment2 = mint.mintPayment(precious(41n));
+  const alicePurse = issuer.makeEmptyPurse();
+  const bobPurse = issuer.makeEmptyPurse();
+
+  t.assert(keyEQ(alicePurse.getRecoverySet(), emptySet));
+  alicePurse.deposit(payment1);
+  bobPurse.deposit(payment2);
+  t.assert(keyEQ(alicePurse.getRecoverySet(), emptySet));
+
+  const payment3 = alicePurse.withdraw(precious(5n));
+  t.assert(issuer.isLive(payment3));
+  t.assert(keyEQ(alicePurse.getRecoverySet(), makeCopySet([payment3])));
+  t.assert(issuer.isLive(payment3));
+
+  const payment4 = await bobPurse.claim(payment3);
+  t.assert(keyEQ(alicePurse.getRecoverySet(), emptySet));
+  t.assert(keyEQ(bobPurse.getRecoverySet(), makeCopySet([payment4])));
+
+  const aliceRecovered = alicePurse.recoverAll();
+  t.assert(isEmpty(aliceRecovered));
+  t.assert(isEqual(alicePurse.getCurrentAmount(), precious(32n)));
+
+  t.assert(isEqual(bobPurse.getCurrentAmount(), precious(41n)));
+  const bobRecovered = bobPurse.recoverAll();
+  t.assert(isEqual(bobRecovered, precious(5n)));
+  t.assert(isEqual(bobPurse.getCurrentAmount(), precious(46n)));
+  t.assert(keyEQ(bobPurse.getRecoverySet(), emptySet));
+});

--- a/packages/ERTP/test/unitTests/test-recovery.js
+++ b/packages/ERTP/test/unitTests/test-recovery.js
@@ -28,17 +28,16 @@ test('payment recovery', async t => {
   t.assert(keyEQ(alicePurse.getRecoverySet(), makeCopySet([payment3])));
   t.assert(issuer.isLive(payment3));
 
-  const payment4 = await bobPurse.claim(payment3);
+  bobPurse.deposit(payment3);
   t.assert(keyEQ(alicePurse.getRecoverySet(), emptySet));
-  t.assert(keyEQ(bobPurse.getRecoverySet(), makeCopySet([payment4])));
 
   const aliceRecovered = alicePurse.recoverAll();
   t.assert(isEmpty(aliceRecovered));
   t.assert(isEqual(alicePurse.getCurrentAmount(), precious(32n)));
 
-  t.assert(isEqual(bobPurse.getCurrentAmount(), precious(41n)));
+  t.assert(isEqual(bobPurse.getCurrentAmount(), precious(46n)));
   const bobRecovered = bobPurse.recoverAll();
-  t.assert(isEqual(bobRecovered, precious(5n)));
+  t.assert(isEqual(bobRecovered, precious(0n)));
   t.assert(isEqual(bobPurse.getCurrentAmount(), precious(46n)));
   t.assert(keyEQ(bobPurse.getRecoverySet(), emptySet));
 });

--- a/packages/ERTP/test/unitTests/test-recovery.js
+++ b/packages/ERTP/test/unitTests/test-recovery.js
@@ -17,9 +17,11 @@ test('payment recovery', async t => {
   const bobPurse = issuer.makeEmptyPurse();
 
   t.assert(keyEQ(alicePurse.getRecoverySet(), emptySet));
+  t.assert(keyEQ(bobPurse.getRecoverySet(), emptySet));
   alicePurse.deposit(payment1);
   bobPurse.deposit(payment2);
   t.assert(keyEQ(alicePurse.getRecoverySet(), emptySet));
+  t.assert(keyEQ(bobPurse.getRecoverySet(), emptySet));
 
   const payment3 = alicePurse.withdraw(precious(5n));
   t.assert(issuer.isLive(payment3));

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -6,6 +6,8 @@ import { isPromise } from '@endo/promise-kit';
 import '@agoric/ertp/exported.js';
 import '@agoric/notifier/exported.js';
 
+const { details: X } = assert;
+
 /**
  * @template T
  * @typedef {import('@endo/far').EOnly<T>} EOnly
@@ -142,6 +144,18 @@ function makeVirtualPurse(vpc, kit) {
         throw e;
       });
       return pmt;
+    },
+    claim: (_paymentP, _optAmountShape) => {
+      // TODO implement
+      assert.fail(X`virtual purses do not yet implement claim`);
+    },
+    getRecoverySet: () => {
+      // TODO implement
+      assert.fail(X`virtual purses do not yet implement getRecoverySet`);
+    },
+    recoverAll: () => {
+      // TODO implement
+      assert.fail(X`virtual purses do not yet implement recoverAll`);
     },
   });
   return purse;

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -145,10 +145,6 @@ function makeVirtualPurse(vpc, kit) {
       });
       return pmt;
     },
-    claim: (_paymentP, _optAmountShape) => {
-      // TODO implement
-      assert.fail(X`virtual purses do not yet implement claim`);
-    },
     getRecoverySet: () => {
       // TODO implement
       assert.fail(X`virtual purses do not yet implement getRecoverySet`);

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -6,8 +6,6 @@ import { isPromise } from '@endo/promise-kit';
 import '@agoric/ertp/exported.js';
 import '@agoric/notifier/exported.js';
 
-const { details: X } = assert;
-
 /**
  * @template T
  * @typedef {import('@endo/far').EOnly<T>} EOnly
@@ -48,22 +46,47 @@ const { details: X } = assert;
 function makeVirtualPurse(vpc, kit) {
   const { brand, issuer, mint, escrowPurse } = kit;
 
-  /** @type {(amt: Amount) => Promise<Payment>} */
-  let redeem;
-  /** @type {(pmt: Payment, optAmountShape?: Pattern) => Promise<Amount>} */
-  let retain;
+  const recoveryPurse = E(issuer).makeEmptyPurse();
 
-  if (mint) {
-    retain = (payment, optAmountShape) =>
-      E(issuer).burn(payment, optAmountShape);
-    redeem = amount => E(mint).mintPayment(amount);
-  } else {
+  /**
+   * Claim a payment for recovery via our `recoveryPurse`.  No need for this on
+   * the `retain` operations (since we are just burning the payment or
+   * depositing it directly in the `escrowPurse`).
+   *
+   * @param {ERef<Payment>} payment
+   * @param {Amount} [optAmountShape]
+   */
+  const recoverableClaim = async (payment, optAmountShape) => {
+    const pmt = await payment;
+    const amt = await E(recoveryPurse).deposit(pmt, optAmountShape);
+    return E(recoveryPurse).withdraw(optAmountShape || amt);
+  };
+
+  /**
+   * @returns {{
+   *   retain: (pmt: Payment, optAmountShape?: Pattern) => Promise<Amount>,
+   *   redeem: (amt: Amount) => Promise<Payment>,
+   * }}
+   */
+  const makeRetainRedeem = () => {
+    if (mint) {
+      const retain = (payment, optAmountShape = undefined) =>
+        E(issuer).burn(payment, optAmountShape);
+      const redeem = amount => recoverableClaim(E(mint).mintPayment(amount));
+      return { retain, redeem };
+    }
+
     // If we can't mint, then we need to escrow.
     const myEscrowPurse = escrowPurse || E(issuer).makeEmptyPurse();
-    retain = (payment, optAmountShape) =>
+    const retain = async (payment, optAmountShape = undefined) =>
       E(myEscrowPurse).deposit(payment, optAmountShape);
-    redeem = amount => E(myEscrowPurse).withdraw(amount);
-  }
+    const redeem = amount =>
+      recoverableClaim(E(myEscrowPurse).withdraw(amount));
+
+    return { retain, redeem };
+  };
+
+  const { retain, redeem } = makeRetainRedeem();
 
   /** @type {NotifierRecord<Amount>} */
   const { notifier: balanceNotifier, updater: balanceUpdater } =
@@ -100,6 +123,7 @@ function makeVirtualPurse(vpc, kit) {
           `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: paymentPromise.then(actualPayment => deposit(actualPayment))`,
         );
       }
+
       const amt = await retain(payment, optAmountShape);
 
       // The push must always succeed.
@@ -145,14 +169,8 @@ function makeVirtualPurse(vpc, kit) {
       });
       return pmt;
     },
-    getRecoverySet: () => {
-      // TODO implement
-      assert.fail(X`virtual purses do not yet implement getRecoverySet`);
-    },
-    recoverAll: () => {
-      // TODO implement
-      assert.fail(X`virtual purses do not yet implement recoverAll`);
-    },
+    getRecoverySet: () => E(recoveryPurse).getRecoverySet(),
+    recoverAll: () => E(recoveryPurse).recoverAll(),
   });
   return purse;
 }


### PR DESCRIPTION
Associate with each purse a recover set of live payments that can be recovered in emergencies, such as when a payment seems lost or stuck. Recovering a payment is like cancelling an outstanding check.

Withdrawing from a purse puts the resulting payment in that purse's recovery set.