### PR TITLE
refactor(run-protocol)!: remove `interestRate` and `liquidationRatio` from vault notifier

### DIFF
--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -170,7 +170,6 @@ const helperBehavior = {
     const result = harden({
       // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
       interestRate: manager.getInterestRate(),
-      liquidationRatio: manager.getMintingRatio(),
       debtSnapshot: { debt, interest },
       locked: helper.getCollateralAmount(),
       // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -164,12 +164,10 @@ const helperBehavior = {
    * @param {MethodContext} context
    *  @param {boolean} newActive */
   snapshotState: ({ state, facets }, newActive) => {
-    const { debtSnapshot: debt, interestSnapshot: interest, manager } = state;
+    const { debtSnapshot: debt, interestSnapshot: interest } = state;
     const { helper } = facets;
     /** @type {VaultNotification} */
     const result = harden({
-      // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
-      interestRate: manager.getInterestRate(),
       debtSnapshot: { debt, interest },
       locked: helper.getCollateralAmount(),
       // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -70,7 +70,6 @@ const validTransitions = {
  * @typedef {object} VaultNotification
  * @property {Amount<'nat'>} locked Amount of Collateral locked
  * @property {{debt: Amount<'nat'>, interest: Ratio}} debtSnapshot 'debt' at the point the compounded interest was 'interest'
- * @property {Ratio} interestRate Annual interest rate charge
  * @property {HolderPhase} vaultState
  */
 
@@ -309,8 +308,6 @@ const helperBehavior = {
     const { debtSnapshot: debt, interestSnapshot: interest } = state;
     /** @type {VaultNotification} */
     return harden({
-      // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
-      interestRate: state.manager.getGovernedParams().getInterestRate(),
       debtSnapshot: { debt, interest },
       locked: facets.self.getCollateralAmount(),
       // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -71,7 +71,6 @@ const validTransitions = {
  * @property {Amount<'nat'>} locked Amount of Collateral locked
  * @property {{debt: Amount<'nat'>, interest: Ratio}} debtSnapshot 'debt' at the point the compounded interest was 'interest'
  * @property {Ratio} interestRate Annual interest rate charge
- * @property {Ratio} liquidationRatio
  * @property {HolderPhase} vaultState
  */
 
@@ -312,9 +311,6 @@ const helperBehavior = {
     return harden({
       // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
       interestRate: state.manager.getGovernedParams().getInterestRate(),
-      liquidationRatio: state.manager
-        .getGovernedParams()
-        .getLiquidationMargin(),
       debtSnapshot: { debt, interest },
       locked: facets.self.getCollateralAmount(),
       // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -243,8 +243,8 @@ const getLiquidationConfig = directorParamManager => ({
  *
  * @param {State['directorParamManager']} govParams
  * @param {VaultManager} vaultManager
- * @param {*} oldInstall
- * @param {*} oldTerms
+ * @param {Installation<unknown>} oldInstall
+ * @param {unknown} oldTerms
  */
 const watchGovernance = (govParams, vaultManager, oldInstall, oldTerms) => {
   const subscription = govParams.getSubscription();

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -295,7 +295,11 @@ const helperBehavior = {
       compoundedInterest: state.compoundedInterest,
       interestRate,
       latestInterestUpdate: state.latestInterestUpdate,
-      // XXX move to governance and type as present with null
+      // NB: the liquidator is determined by governance but the resulting
+      // instance is a concern of the manager. The param manager knows only
+      // about the installation and terms of the liqudation contract. We could
+      // have another notifier for state downstream of governance changes, but
+      // that doesn't seem to be cost-effective.
       liquidatorInstance: state.liquidatorInstance,
     });
     state.assetUpdater.updateState(payload);

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -979,7 +979,6 @@ test('interest on multiple vaults', async t => {
     ),
     run.make(3200n + bobAddedDebt),
   );
-  t.deepEqual(bobUpdate.value.interestRate, rates.interestRate);
 
   // 236 is the initial fee. Interest is ~4n/week
   const aliceAddedDebt = 236n + 4n;
@@ -997,7 +996,6 @@ test('interest on multiple vaults', async t => {
     debt: run.make(4935n),
     interest: makeRatio(100n, run.brand, 100n),
   });
-  t.deepEqual(aliceUpdate.value.interestRate, rates.interestRate);
 
   const rewardAllocation = await E(vaultFactory).getRewardAllocation();
   const rewardRunCount = aliceAddedDebt + bobAddedDebt;

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -980,10 +980,6 @@ test('interest on multiple vaults', async t => {
     run.make(3200n + bobAddedDebt),
   );
   t.deepEqual(bobUpdate.value.interestRate, rates.interestRate);
-  t.deepEqual(
-    bobUpdate.value.liquidationRatio,
-    makeRatio(105n, run.brand, 100n),
-  );
 
   // 236 is the initial fee. Interest is ~4n/week
   const aliceAddedDebt = 236n + 4n;
@@ -1002,7 +998,6 @@ test('interest on multiple vaults', async t => {
     interest: makeRatio(100n, run.brand, 100n),
   });
   t.deepEqual(aliceUpdate.value.interestRate, rates.interestRate);
-  t.deepEqual(aliceUpdate.value.liquidationRatio, makeRatio(105n, run.brand));
 
   const rewardAllocation = await E(vaultFactory).getRewardAllocation();
   const rewardRunCount = aliceAddedDebt + bobAddedDebt;


### PR DESCRIPTION
closes: #4685

## Description

Neither were used anywhere.

When needed, `interestRate` is now on `AssetNotifier`.


### Security Considerations

--
### Documentation Considerations

Breaking change, denoted in conventionalcommit syntax.

### Testing Considerations

- [x] test for asset notifier on a new Collateral Manager ([exists](0f11c9c87c130277c439d2fa7cf4aa3bb844561d))
- [ ] test improvements so dapp-treasury integration test fails on this breaking change (probably https://github.com/Agoric/dapp-treasury/issues/97 ) 