### PR TITLE
fix(swingset): disable metering on both initial and from-snapshot workers

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -100,16 +100,22 @@ export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
     metered,
     snapshotHash = undefined,
   ) {
+    const meterOpts = metered ? {} : { meteringLimit: 0 };
     if (snapStore && snapshotHash) {
       // console.log('startXSnap from', { snapshotHash });
       return snapStore.load(snapshotHash, async snapshot => {
-        const xs = doXSnap({ snapshot, name, handleCommand, ...xsnapOpts });
+        const xs = doXSnap({
+          snapshot,
+          name,
+          handleCommand,
+          ...meterOpts,
+          ...xsnapOpts,
+        });
         await xs.isReady();
         return xs;
       });
     }
     // console.log('fresh xsnap', { snapStore: snapStore });
-    const meterOpts = metered ? {} : { meteringLimit: 0 };
     const worker = doXSnap({ handleCommand, name, ...meterOpts, ...xsnapOpts });
 
     for (const bundle of bundles) {

--- a/packages/SwingSet/test/test-xsnap-metering.js
+++ b/packages/SwingSet/test/test-xsnap-metering.js
@@ -1,0 +1,79 @@
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava.js';
+
+import { spawn } from 'child_process';
+import fs from 'fs';
+import tmp from 'tmp';
+import { makePromiseKit } from '@endo/promise-kit';
+import { makeSnapStore, makeSnapStoreIO } from '@agoric/swing-store';
+
+import { makeStartXSnap } from '../src/controller/controller.js';
+
+// controller.js had a bug (#5040) wherein 'meterOpts' were applied
+// inconsistently to fresh workers vs ones from snapshot, allowing
+// fresh workers more runtime than ones reloaded from snapshot
+
+function handleCommand() {}
+
+function make(snapStore) {
+  const pk = makePromiseKit();
+  const startXSnap = makeStartXSnap([], {
+    snapStore,
+    env: {},
+    spawn: (command, args, opts) => {
+      pk.resolve(args);
+      return spawn(command, args, opts);
+    },
+  });
+  return { p: pk.promise, startXSnap };
+}
+
+function checkMetered(t, args, metered) {
+  const a = args.join(' ');
+  if (metered) {
+    // metered workers either have '-l NN' (with NN>0)
+    t.notRegex(a, /-l 0/);
+  } else {
+    // unmetered workers have '-l 0', or omit -l entirely
+    const elli = args.indexOf('-l');
+    if (elli === -1) {
+      t.pass();
+    } else {
+      t.is(args[elli + 1], '0');
+    }
+  }
+}
+
+async function doTest(t, metered) {
+  const pool = tmp.dirSync({ unsafeCleanup: true });
+  t.teardown(() => pool.removeCallback());
+  await fs.promises.mkdir(pool.name, { recursive: true });
+  const store = makeSnapStore(pool.name, makeSnapStoreIO());
+
+  const { p: p1, startXSnap: start1 } = make(store);
+  let snapshotHash;
+  const worker1 = await start1('name', handleCommand, metered, snapshotHash);
+  const spawnArgs1 = await p1;
+  checkMetered(t, spawnArgs1, metered);
+  await worker1.evaluate('1+2');
+  t.teardown(() => worker1.close());
+
+  // now extract a snapshot
+  snapshotHash = await store.save(worker1.snapshot);
+
+  // and load it into a new worker
+  const { p: p2, startXSnap: start2 } = make(store);
+  const worker2 = await start2('name', handleCommand, metered, snapshotHash);
+  const spawnArgs2 = await p2;
+  checkMetered(t, spawnArgs2, metered);
+  await worker2.evaluate('1+2');
+  t.teardown(() => worker2.close());
+}
+
+test('no metering', async t => {
+  await doTest(t, false);
+});
+
+test('yes metering', async t => {
+  await doTest(t, true);
+});


### PR DESCRIPTION
When vat options instruct swingset to disable metering in a vat, a bug
in `makeStartXSnap()` caused metering to be enabled anyways for the
second and subsequent worker used to host that vat. The first worker
starts from an empty XS engine, but after a few deliveries the
vat-manager will write out a heap snapshot, after which any new worker
will start from the snapshot. The `xsnap()` options that would disable
metering were not applied to the call that loaded a worker from
snapshot.

The consequence was that the first launch of a kernel would allow vats
to perform CPU-intense deliveries (as intended), but once the kernel
was restarted, those same delieries would terminate the vat (`compute
meter exceeded`) during transcript replay. If the snapshot was taken
recently enough that the remaining transcript did not include the
CPU-intense delivery, the new kernel would start, but the vat would
still be killed by any new delivery that exceeded the
unintentionally-imposed meter.

closes #5040
