### PR TITLE
fix(swingset): track doMoreGC correctly

### DIFF
--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -333,18 +333,18 @@ export function makeCollectionManager(
       const rawValue = syscall.vatstoreGet(dbKey);
       assert(rawValue, X`key ${key} not found in collection ${q(label)}`);
       const value = JSON.parse(rawValue);
-      value.slots.map(vrm.removeReachableVref);
+      const doMoreGC1 = value.slots.map(vrm.removeReachableVref).some(b => b);
       syscall.vatstoreDelete(dbKey);
-      let doMoreGC = false;
+      let doMoreGC2 = false;
       if (passStyleOf(key) === 'remotable') {
         deleteOrdinal(key);
         if (hasWeakKeys) {
           vrm.removeRecognizableValue(key, `${collectionID}`, true);
         } else {
-          doMoreGC = vrm.removeReachableVref(convertValToSlot(key));
+          doMoreGC2 = vrm.removeReachableVref(convertValToSlot(key));
         }
       }
-      return doMoreGC;
+      return doMoreGC1 || doMoreGC2;
     }
 
     function del(key) {

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -687,9 +687,9 @@ export function makeVirtualObjectManager(
       const rawState = fetch(baseRef);
       if (rawState) {
         for (const propValue of Object.values(rawState)) {
-          propValue.slots.map(
-            vref => (doMoreGC = doMoreGC || vrm.removeReachableVref(vref)),
-          );
+          propValue.slots.forEach(vref => {
+            doMoreGC = vrm.removeReachableVref(vref) || doMoreGC;
+          });
         }
       }
       syscall.vatstoreDelete(`vom.${baseRef}`);

--- a/packages/SwingSet/test/virtualObjects/collection-slots/bootstrap-collection-slots.js
+++ b/packages/SwingSet/test/virtualObjects/collection-slots/bootstrap-collection-slots.js
@@ -1,0 +1,31 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+export function buildRootObject() {
+  // build the import sensor
+  const imp1 = Far(`import-1`, {});
+
+  let targetvat;
+
+  return Far('root', {
+    async bootstrap(vats) {
+      targetvat = vats.target;
+    },
+
+    async getImportSensors() {
+      return [imp1];
+    },
+
+    async step1() {
+      await E(targetvat).build(imp1);
+    },
+
+    async step2() {
+      await E(targetvat).delete();
+    },
+
+    async step3() {
+      await E(targetvat).flush();
+    },
+  });
+}

--- a/packages/SwingSet/test/virtualObjects/collection-slots/test-collection-slots.js
+++ b/packages/SwingSet/test/virtualObjects/collection-slots/test-collection-slots.js
@@ -1,0 +1,123 @@
+// eslint-disable-next-line import/order
+import { test } from '../../../tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { assert } from '@agoric/assert';
+import { provideHostStorage } from '../../../src/controller/hostStorage.js';
+import { parseReachableAndVatSlot } from '../../../src/kernel/state/reachable.js';
+import {
+  initializeSwingset,
+  makeSwingsetController,
+} from '../../../src/index.js';
+import { capargs } from '../../util.js';
+
+function bfile(name) {
+  return new URL(name, import.meta.url).pathname;
+}
+
+function getImportSensorKref(impcapdata, i) {
+  const body = JSON.parse(impcapdata.body);
+  const value = body[i];
+  if (typeof value === 'object' && value['@qclass'] === 'slot') {
+    return ['slot', impcapdata.slots[value.index]];
+  }
+  return value;
+}
+
+test('collection entry slots trigger doMoreGC', async t => {
+  const config = {
+    bootstrap: 'bootstrap',
+    // defaultReapInterval: 'never',
+    // defaultReapInterval: 1,
+    vats: {
+      bootstrap: { sourceSpec: bfile('bootstrap-collection-slots.js') },
+      target: {
+        sourceSpec: bfile('vat-collection-slots.js'),
+        creationOptions: {
+          virtualObjectCacheSize: 0,
+        },
+      },
+    },
+  };
+
+  const hostStorage = provideHostStorage();
+  const { kvStore } = hostStorage;
+  await initializeSwingset(config, [], hostStorage);
+  const c = await makeSwingsetController(hostStorage);
+  c.pinVatRoot('bootstrap');
+  c.pinVatRoot('target');
+  const vatID = c.vatNameToID('target');
+  await c.run();
+
+  async function run(name, args = []) {
+    assert(Array.isArray(args));
+    const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+    await c.run();
+    const status = c.kpStatus(kpid);
+    const capdata = c.kpResolution(kpid);
+    return [status, capdata];
+  }
+
+  function has(kref) {
+    const s = kvStore.get(`${vatID}.c.${kref}`);
+    // returns undefined, or { vatSlot, isReachable }
+    return s && parseReachableAndVatSlot(s);
+  }
+
+  // fetch the "importSensor": exported by bootstrap, imported by the
+  // other vat. We'll determine its kref and later query the other vat
+  // to see if it's still importing one or not
+  const [impstatus, impcapdata] = await run('getImportSensors', []);
+  t.is(impstatus, 'fulfilled');
+  const imp1kref = getImportSensorKref(impcapdata, 0)[1];
+
+  // at this point, vat-target has not yet seen the sensors
+  t.is(has(imp1kref), undefined);
+
+  // step1() creates vc1 -> vc2 -> rem1 -> imp1 . That is, it makes a
+  // virtual collection (vc1) with an entry whose value is a second
+  // virtual collection (vc2). "vc2" has an entry whose value is a
+  // Remotable (rem1). The Remotable closes over the imported Presence
+  // imp1.
+
+  const [step1status] = await run('step1', []);
+  t.is(step1status, 'fulfilled');
+
+  // now vat-target should be importing the sensor
+  t.true(has(imp1kref).isReachable);
+
+  // step2() deletes vc2 from vc1. This adds vc2 to `possiblyDeadSet`,
+  // so the subsequent bringOutYourDead() and scanForDeadObjects()
+  // checks its refcounts (now zero) and deletes it. While deleting
+  // vc2, it deletes the entry whose value is rem1 by calling
+  // removeReachableVref(). As this was the only vdata reference to
+  // rem1, it removes rem1 from `remotableRefCounts` (removing the
+  // last RAM reference to the Remotable) and is thus supposed to
+  // return `doMoreGC = true` to inform scanForDeadObjects() that it
+  // needs to run `gcAndFinalize` again (and repeat the
+  // `scanForDeadObjects loop). It needs to do this because if the
+  // Remotable is really gone, it's no longer closing over anything,
+  // and the only way to sense that is to force GC and let the
+  // finalizers run.
+
+  // The bug (#5044) was that the collection's deleteInternal() was
+  // not reporting the doMoreGC returned by removeReachableVref(): it
+  // did value.slots.forEach(vrm.removeReachableVref) and didn't pay
+  // attention to the return value.
+  const [step2status] = await run('step2', []);
+  t.is(step2status, 'fulfilled');
+
+  // If the bug is happening, 'rem1' is released but we don't repeat
+  // the loop, so we don't run `gcAndFinalize` in that crank, and
+  // neither 'rem1' nor 'imp1' get released. If the bug is fixed, the
+  // finalizer sees both 'rem1' and 'imp1' released, and we can see
+  // 'imp1' get removed from the c-list.
+
+  t.is(has(imp1kref), undefined);
+
+  const [step3status] = await run('step3', []);
+  t.is(step3status, 'fulfilled');
+
+  // even with the bug, a subsequent BOYD should let rem1/imp1 drop
+  t.is(has(imp1kref), undefined);
+});

--- a/packages/SwingSet/test/virtualObjects/collection-slots/vat-collection-slots.js
+++ b/packages/SwingSet/test/virtualObjects/collection-slots/vat-collection-slots.js
@@ -1,0 +1,28 @@
+/* global VatData */
+import { Far } from '@endo/marshal';
+
+// import { makeScalarBigMapStore } from '@agoric/vat-data';
+const { makeScalarBigMapStore } = VatData;
+
+function makeRemotable(imp1) {
+  return Far('rem1', { get: () => imp1 });
+}
+
+// vc1 -> vc2 -> rem1 -> imp1
+
+export function buildRootObject() {
+  const vc1 = makeScalarBigMapStore('vc1');
+
+  return Far('root', {
+    build(imp1) {
+      const vc2 = makeScalarBigMapStore('vc2');
+      const rem1 = makeRemotable(imp1);
+      vc2.init('key', rem1);
+      vc1.init('vc2', vc2);
+    },
+    delete() {
+      vc1.delete('vc2');
+    },
+    flush() {},
+  });
+}

--- a/packages/SwingSet/test/virtualObjects/delete-stored-vo/bootstrap-delete-stored-vo.js
+++ b/packages/SwingSet/test/virtualObjects/delete-stored-vo/bootstrap-delete-stored-vo.js
@@ -1,0 +1,27 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+export function buildRootObject() {
+  // build the import sensor
+  const imp1 = Far(`import-1`, {});
+
+  let targetvat;
+
+  return Far('root', {
+    async bootstrap(vats) {
+      targetvat = vats.target;
+    },
+
+    async getImportSensors() {
+      return [imp1];
+    },
+
+    async step1() {
+      await E(targetvat).build(imp1);
+    },
+
+    async step2() {
+      await E(targetvat).delete();
+    },
+  });
+}

--- a/packages/SwingSet/test/virtualObjects/delete-stored-vo/test-delete-stored-vo.js
+++ b/packages/SwingSet/test/virtualObjects/delete-stored-vo/test-delete-stored-vo.js
@@ -1,0 +1,116 @@
+// eslint-disable-next-line import/order
+import { test } from '../../../tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { assert } from '@agoric/assert';
+import { provideHostStorage } from '../../../src/controller/hostStorage.js';
+import { parseReachableAndVatSlot } from '../../../src/kernel/state/reachable.js';
+import {
+  initializeSwingset,
+  makeSwingsetController,
+} from '../../../src/index.js';
+import { capargs } from '../../util.js';
+
+function bfile(name) {
+  return new URL(name, import.meta.url).pathname;
+}
+
+function getImportSensorKref(impcapdata, i) {
+  const body = JSON.parse(impcapdata.body);
+  const value = body[i];
+  if (typeof value === 'object' && value['@qclass'] === 'slot') {
+    return ['slot', impcapdata.slots[value.index]];
+  }
+  return value;
+}
+
+test('VO property deletion is not short-circuited', async t => {
+  const config = {
+    bootstrap: 'bootstrap',
+    // defaultReapInterval: 'never',
+    // defaultReapInterval: 1,
+    vats: {
+      bootstrap: { sourceSpec: bfile('bootstrap-delete-stored-vo.js') },
+      target: {
+        sourceSpec: bfile('vat-delete-stored-vo.js'),
+        creationOptions: {
+          virtualObjectCacheSize: 0,
+        },
+      },
+    },
+  };
+
+  const hostStorage = provideHostStorage();
+  const { kvStore } = hostStorage;
+  await initializeSwingset(config, [], hostStorage);
+  const c = await makeSwingsetController(hostStorage);
+  c.pinVatRoot('bootstrap');
+  c.pinVatRoot('target');
+  const vatID = c.vatNameToID('target');
+  await c.run();
+
+  async function run(name, args = []) {
+    assert(Array.isArray(args));
+    const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+    await c.run();
+    const status = c.kpStatus(kpid);
+    const capdata = c.kpResolution(kpid);
+    return [status, capdata];
+  }
+
+  function has(kref) {
+    const s = kvStore.get(`${vatID}.c.${kref}`);
+    // returns undefined, or { vatSlot, isReachable }
+    return s && parseReachableAndVatSlot(s);
+  }
+
+  // fetch the "importSensor": exported by bootstrap, imported by the
+  // other vat. We'll determine its kref and later query the other vat
+  // to see if it's still importing one or not
+  const [impstatus, impcapdata] = await run('getImportSensors', []);
+  t.is(impstatus, 'fulfilled');
+  const imp1kref = getImportSensorKref(impcapdata, 0)[1];
+
+  // at this point, vat-target has not yet seen the sensors
+  t.is(has(imp1kref), undefined);
+
+  // step1() creates vc1 -> vo1 -> [rem1, imp1]
+
+  const [step1status] = await run('step1', []);
+  t.is(step1status, 'fulfilled');
+
+  // now vat-target should be importing the sensor
+  t.true(has(imp1kref).isReachable);
+
+  // step2() deletes vo1 from vc1. This walks all properties of vo1's
+  // state, and for each one, it walks all slots of the values. For
+  // each slot, it uses vrm.removeReachableVref(vref) to decref the
+  // now-unreferenced object, and pays attention to the doMoreGC
+  // return value of removeReachableVref (which is 'true' if the
+  // object was a Remotable, requiring another gcAndFinalize pass).
+
+  // The bug (#5044) was that this loop short-circuited the decref if
+  // doMoreGC was true. That is, it did:
+  //
+  // propValue.slots.map(
+  //   vref => (doMoreGC = doMoreGC || vrm.removeReachableVref(vref)),
+  // );
+  //
+  // instead of:
+  //
+  // propValue.slots.map(
+  //   vref => (doMoreGC = vrm.removeReachableVref(vref) || doMoreGC),
+  // );
+  //
+  // as a result, the removeReachableVref() would not be called on any
+  // slot after a Remotable.
+
+  const [step2status] = await run('step2', []);
+  t.is(step2status, 'fulfilled');
+
+  // If the bug is happening, 'rem1' is released not 'imp1'. If the
+  // bug is fixed, we call removeReachableVref(imp1), and we can see
+  // 'imp1' get removed from the c-list.
+
+  t.is(has(imp1kref), undefined);
+});

--- a/packages/SwingSet/test/virtualObjects/delete-stored-vo/vat-delete-stored-vo.js
+++ b/packages/SwingSet/test/virtualObjects/delete-stored-vo/vat-delete-stored-vo.js
@@ -1,0 +1,38 @@
+/* global VatData */
+import { Far } from '@endo/marshal';
+
+// import { defineKind, makeScalarBigMapStore } from '@agoric/vat-data';
+const { defineKind, makeScalarBigMapStore } = VatData;
+
+function initialize(value) {
+  return harden({ value });
+}
+
+const makeVir = defineKind('virtual', initialize, {});
+const makeDummy = defineKind('dummy', initialize, {});
+
+function makeRemotable(imp1) {
+  return Far('rem1', { get: () => imp1 });
+}
+
+// vc1 -> vo1 -> [rem1, imp1]
+
+export function buildRootObject() {
+  const vc1 = makeScalarBigMapStore('vc1');
+
+  return Far('root', {
+    build(imp1) {
+      const rem1 = makeRemotable(imp1);
+      const vo1 = makeVir(harden([rem1, imp1]));
+      vc1.init('vo1', vo1);
+      // kick vo1 out of the virtual-object cache's leftover slot
+      makeDummy();
+      makeDummy();
+      makeDummy();
+      makeDummy();
+    },
+    delete() {
+      vc1.delete('vo1');
+    },
+  });
+}


### PR DESCRIPTION
Virtual collections `deleteInternal()` was ignoring the `doMoreGC`
result when dropping the value of a collection entry. This could fail
to re-run `gcAndFinalize` when necessary, allowing a Remotable (and
any in-memory objects it referenced) to survive longer than
appropriate before getting GCed.

Also, `deleteStoredVO()` allowed `doMoreGC` to short-circuit a call to
`removeReachableVref`, so if a Remotable appeared in the slots of a
virtual object's state, any slots after that point would not be
collected.

fixes #5044
