### PR TITLE
chore: weaken swingset dependency on vat-data to dev-dependency

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -21,6 +21,7 @@
     "lint:eslint": "eslint '**/*.js'"
   },
   "devDependencies": {
+    "@agoric/vat-data": "^0.1.0",
     "@endo/ses-ava": "^0.2.21",
     "@types/tmp": "^0.2.0",
     "ava": "^3.12.1",
@@ -34,7 +35,6 @@
     "@agoric/store": "^0.6.10",
     "@agoric/swing-store": "^0.6.5",
     "@agoric/xsnap": "^0.11.2",
-    "@agoric/vat-data": "^0.1.0",
     "@endo/base64": "^0.2.21",
     "@endo/bundle-source": "^2.1.1",
     "@endo/captp": "^2.0.3",

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -23,6 +23,7 @@ function get(capdata, propname) {
 
 async function testUpgrade(t, defaultManagerType) {
   const config = {
+    includeDevDependencies: true, // for vat-data
     defaultManagerType,
     bootstrap: 'bootstrap',
     defaultReapInterval: 'never',
@@ -93,6 +94,7 @@ test('vat upgrade - xsnap', async t => {
 
 test('failed upgrade - lost kind', async t => {
   const config = {
+    includeDevDependencies: true, // for vat-data
     defaultManagerType: 'xs-worker',
     bootstrap: 'bootstrap',
     defaultReapInterval: 'never',

--- a/packages/SwingSet/test/virtualObjects/collection-slots/test-collection-slots.js
+++ b/packages/SwingSet/test/virtualObjects/collection-slots/test-collection-slots.js
@@ -26,6 +26,7 @@ function getImportSensorKref(impcapdata, i) {
 
 test('collection entry slots trigger doMoreGC', async t => {
   const config = {
+    includeDevDependencies: true, // for vat-data
     bootstrap: 'bootstrap',
     // defaultReapInterval: 'never',
     // defaultReapInterval: 1,

--- a/packages/SwingSet/test/virtualObjects/delete-stored-vo/test-delete-stored-vo.js
+++ b/packages/SwingSet/test/virtualObjects/delete-stored-vo/test-delete-stored-vo.js
@@ -26,6 +26,7 @@ function getImportSensorKref(impcapdata, i) {
 
 test('VO property deletion is not short-circuited', async t => {
   const config = {
+    includeDevDependencies: true, // for vat-data
     bootstrap: 'bootstrap',
     // defaultReapInterval: 'never',
     // defaultReapInterval: 1,

--- a/packages/SwingSet/test/virtualObjects/double-retire-import/test-double-retire-import.js
+++ b/packages/SwingSet/test/virtualObjects/double-retire-import/test-double-retire-import.js
@@ -15,6 +15,7 @@ function bfile(name) {
 
 async function testUpgrade(t, defaultManagerType) {
   const config = {
+    includeDevDependencies: true, // for vat-data
     defaultManagerType,
     bootstrap: 'bootstrap',
     vats: {

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -26,6 +26,7 @@ function slot0(iface, kid) {
 
 test.serial('exercise cache', async t => {
   const config = {
+    includeDevDependencies: true, // for vat-data
     bootstrap: 'bootstrap',
     vats: {
       bootstrap: {
@@ -350,6 +351,7 @@ test('virtual object gc', async t => {
   */
 
   const config = {
+    includeDevDependencies: true, // for vat-data
     bootstrap: 'bootstrap',
     defaultManagerType: 'xs-worker',
     vats: {
@@ -403,6 +405,7 @@ test('virtual object gc', async t => {
 // Check that facets which don't reference their state still kill their cohort alive
 async function orphanTest(t, mode) {
   const config = {
+    includeDevDependencies: true, // for vat-data
     bootstrap: 'bootstrap',
     vats: {
       bob: {

--- a/packages/SwingSet/test/virtualObjects/test-weakcollections.js
+++ b/packages/SwingSet/test/virtualObjects/test-weakcollections.js
@@ -17,6 +17,7 @@ function capargs(args, slots = []) {
 
 test('weakMap in vat', async t => {
   const config = {
+    includeDevDependencies: true, // for vat-data
     bootstrap: 'bootstrap',
     vats: {
       bootstrap: {


### PR DESCRIPTION
Swingset *tests* use `@agoric/vat-data`, but not `src/`, so this
changes swingset/package.json to list it in `devDependencies`, not
`dependencies`.

Meanwhile, `@agoric/vat-data` lists swingset in its `devDependencies`
for its own tests. This gives us a cycle of `devDependencies` but not
normal dependencies.

Code which imports vat-data must (generally) be running inside a vat,
which means the application that decided to put that code into a vat
probably depends upon swingset: it had to import
`makeSwingsetController` to create the housing. But the vat-data
-importing code doesn't know that, and doesn't need a direct
dependency on swingset, because it never imports anything from
swingset itself.
