### PR TITLE
feat(vat-data) pickFacet

### DIFF
--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -9,7 +9,7 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { assert } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
-import { defineKind } from '@agoric/vat-data';
+import { defineKind, pickFacet } from '@agoric/vat-data';
 import { makeTracer } from '../makeTracer.js';
 import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
 import { makeVaultKit } from './vaultKit.js';
@@ -705,7 +705,6 @@ const makeInnerVaultBase = defineKind('InnerVault', initState, {
  * @param {InnerVaultManagerBase & GetVaultParams} manager
  * @param {VaultId} idInManager
  */
-export const makeInnerVault = (zcf, manager, idInManager) =>
-  makeInnerVaultBase(zcf, manager, idInManager).self;
+export const makeInnerVault = pickFacet(makeInnerVaultBase, 'self');
 
 /** @typedef {ReturnType<typeof makeInnerVault>} InnerVault */

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -48,6 +48,14 @@ export const {
 } = VatDataGlobal;
 
 /**
+ * When making a multi-facet kind, it's common to pick one facet to expose. E.g.,
+ *
+ *     const makeFoo = (a, b, c, d) => makeFooBase(a, b, c, d).self;
+ *
+ * This helper reduces the duplication:
+ *
+ *     const makeFoo = pickFacet(makeFooBase, 'self');
+ *
  * @type {import('./types').PickFacet}
  */
 export const pickFacet =

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -46,3 +46,11 @@ export const {
   makeScalarBigSetStore,
   makeScalarBigWeakSetStore,
 } = VatDataGlobal;
+
+/**
+ * @type {import('./types').PickFacet}
+ */
+export const pickFacet =
+  (maker, facetName) =>
+  (...args) =>
+    maker(...args)[facetName];

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -59,7 +59,18 @@ export type VatData = {
   ) => WeakSetStore<K>;
 };
 
+// The JSDoc is repeated here and at the function definition so it appears
+// in IDEs where it's used, regardless of type resolution.
 interface PickFacet {
+  /**
+   * When making a multi-facet kind, it's common to pick one facet to expose. E.g.,
+   *
+   *     const makeFoo = (a, b, c, d) => makeFooBase(a, b, c, d).self;
+   *
+   * This helper reduces the duplication:
+   *
+   *     const makeFoo = pickFacet(makeFooBase, 'self');
+   */
   <M extends (...args: any[]) => any, F extends keyof ReturnType<M>>(
     maker: M,
     facetName: F,

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -58,3 +58,10 @@ export type VatData = {
     options?: StoreOptions,
   ) => WeakSetStore<K>;
 };
+
+interface PickFacet {
+  <M extends (...args: any[]) => any, F extends keyof ReturnType<M>>(
+    maker: M,
+    facetName: F,
+  ): (...args: Parameters<M>) => ReturnType<M>[F];
+}


### PR DESCRIPTION
## Description

It's common when defining a kind to export a function that makes the kind and returns one of its facets. That can get unwieldy: https://github.com/Agoric/agoric-sdk/blob/d390e21c1e5fde116f2ba00913e3e3bde294707d/packages/run-protocol/src/vaultFactory/vaultManager.js#L563-L584

So this adds a simplifying helper,
```
export const makeVaultManager = pickFacet(makeVaultManagerKit, 'self');
```


### Security Considerations

None, simple helper.

### Documentation Considerations

Optional, apparent from uses.

### Testing Considerations

Tested by uses of it.