### PR TITLE
fix(swingset): only ceaseRecognition facets on virtual objects

### DIFF
--- a/packages/SwingSet/src/liveslots/virtualReferences.js
+++ b/packages/SwingSet/src/liveslots/virtualReferences.js
@@ -525,15 +525,15 @@ export function makeVirtualReferenceManager(
    */
   function ceaseRecognition(vref) {
     let doMoreGC = false;
-    const { id, facet } = parseVatSlot(vref);
-    if (facet === undefined) {
+    const p = parseVatSlot(vref);
+    if (p.allocatedByVat && p.virtual && p.facet === undefined) {
       // If `vref` identifies a multi-faceted object that should no longer be
       // "recognized", what that really means that all references to its
       // individual facets should no longer be recognized -- nobody actually
       // references the object itself except internal data structures.  So in
       // this case we need individually to stop recognizing the facets
       // themselves.
-      const kindInfo = kindInfoTable.get(`${id}`);
+      const kindInfo = kindInfoTable.get(`${p.id}`);
       // This function can be called either from `dispatch.retireImports` or
       // from `possibleVirtualObjectDeath`.  In the latter case the vref is
       // actually a baseRef and so needs to be expanded to cease recognition of

--- a/packages/SwingSet/test/virtualObjects/test-cease-recognition.js
+++ b/packages/SwingSet/test/virtualObjects/test-cease-recognition.js
@@ -1,0 +1,53 @@
+/* global FinalizationRegistry */
+// eslint-disable-next-line import/order
+import { test } from '../../tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { buildSyscall, matchVatstoreGetAfter } from '../liveslots-helpers.js';
+import { makeVirtualReferenceManager } from '../../src/liveslots/virtualReferences.js';
+
+function makeVRM() {
+  const { log, syscall } = buildSyscall();
+  const getSlotForVal = undefined;
+  const requiredValForSlot = undefined;
+  const addToPossiblyDeadSet = undefined;
+  const addToPossiblyRetiredSet = undefined;
+  const vrm = makeVirtualReferenceManager(
+    syscall,
+    getSlotForVal,
+    requiredValForSlot,
+    FinalizationRegistry,
+    addToPossiblyDeadSet,
+    addToPossiblyRetiredSet,
+  );
+  return { log, vrm };
+}
+
+function weakKeyCheck(vref) {
+  return matchVatstoreGetAfter('', vref, undefined, [undefined, undefined]);
+}
+
+test('only enumerate virtual objects', async t => {
+  const { log, vrm } = makeVRM();
+
+  // retiring a plain Remotable does a is-it-a-weak-key chck
+  vrm.ceaseRecognition('o+4');
+  t.deepEqual(log.shift(), weakKeyCheck('vom.ir.o+4|'));
+  t.is(log.length, 0);
+
+  // retiring a virtual object causes the facets to be enumerated and
+  // checked, not the baseref
+  vrm.registerKind('5');
+  vrm.rememberFacetNames('5', ['facet0', 'facet1']);
+  vrm.ceaseRecognition('o+5/2');
+  t.deepEqual(log.shift(), weakKeyCheck('vom.ir.o+5/2:0|'));
+  t.deepEqual(log.shift(), weakKeyCheck('vom.ir.o+5/2:1|'));
+  // skips 'vom.ir.o+5/2|'
+  t.is(log.length, 0);
+
+  // retiring an import does the weak-key check, even though the ID
+  // numerically collides with the virtual kind
+  vrm.ceaseRecognition('o-5');
+  t.deepEqual(log.shift(), weakKeyCheck('vom.ir.o-5|'));
+  t.is(log.length, 0);
+});


### PR DESCRIPTION
`ceaseRecognition()` is called when an object is retired, to allow
weak-keyed collections to delete their corresponding entries. When a
cohort of facets is retired, it is called with a "baseRef" like
`o+145/3`, and then ceaseRecognition is responsible for enumerating
all the facets of that baseRef, so it can retire all the
pieces (e.g. `o+145/3:0` and `o+145/3:1`).

`ceaseRecognition` was not looking carefully enough at the properties
of the vref it was given, so when the kernel issued a
`dispatch.retireImports` on a normal object whose numeric ID happened
to collide with a locally-defined virtual Kind (e.g. `o-145`),
ceaseRecognition attempted to enumerate facets anyways. This caused it
to recurse with vrefs like `o-145:0` and `o-145:0:0`, etc. Eventually
this caused `parseVatSlot` to balk, making the `retireImports`
fail. This killed the vat.

The fix is to limit the facet-enumeration clause to vrefs which are
really virtual object baserefs: we must check the `allocatedByVat` and
`virtual` flags too.

fixes #5113
