### PR TITLE
fix(run-protocol): store Presences, not Promises, in VaultManager

### DIFF
--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -283,18 +283,19 @@ export const startVaultFactory = async (
     ]);
   const ammPublicFacet = await E(zoe).getPublicFacet(ammInstance);
   const feeMintAccess = await feeMintAccessP;
-
+  const pa = await priceAuthority;
+  const timer = await chainTimerService;
   const vaultFactoryTerms = makeGovernedTerms(
-    priceAuthority,
+    pa,
     loanParams,
     installations.liquidate,
-    chainTimerService,
+    timer,
     invitationAmount,
     vaultManagerParams,
     ammPublicFacet,
   );
   const governorTerms = harden({
-    timer: chainTimerService,
+    timer,
     electorateInstance,
     governedContractInstallation: installations.VaultFactory,
     governed: {


### PR DESCRIPTION
To avoid triggering a swingset bug (#5106), and to prepare for turning
our virtual Kinds into durable Kinds, we need to not store Promises in
virtualized data. In addition, storing a Presence instead of a Promise
can provide a small performance improvement.

Currently, the only case where we store Promises in vdata is in
VaultManager, which stores Promises for `priceAuthority` and
`timerService` in its `state` object.

This changes the setup code to `await` both objects before handing
them to `makeVaultManager`, to ensure that we store Presences, not
Promises.

closes #5121
refs #5106
