### PR TITLE
feat(amm): support `maxOut` optional arg to `swap`

### DIFF
--- a/packages/run-protocol/src/vaultFactory/liquidateMinimum.js
+++ b/packages/run-protocol/src/vaultFactory/liquidateMinimum.js
@@ -6,7 +6,6 @@ import { AmountMath } from '@agoric/ertp';
 import { Far } from '@endo/marshal';
 
 import { defineKind } from '@agoric/vat-data';
-import { makeDefaultLiquidationStrategy } from './liquidation.js';
 import { makeTracer } from '../makeTracer.js';
 
 const trace = makeTracer('LiqMin');
@@ -34,59 +33,35 @@ const start = async zcf => {
     const {
       give: { In: amountIn },
     } = debtorSeat.getProposal();
-    const swapInvitation = E(amm).makeSwapOutInvitation();
+
+    const swapInvitation = E(amm).makeSwapInvitation();
     const liqProposal = harden({
       give: { In: amountIn },
-      want: { Out: debt },
+      want: { Out: AmountMath.makeEmpty(debtBrand) },
     });
     trace(`OFFER TO DEBT: `, debt, amountIn);
-    const { deposited, userSeatPromise: liqSeat } = await offerTo(
+    const { deposited } = await offerTo(
       zcf,
       swapInvitation,
       undefined, // The keywords were mapped already
       liqProposal,
       debtorSeat,
+      debtorSeat,
+      { maxOut: debt },
     );
 
-    // Three (!) awaits coming here. We can't use Promise.all because
+    // Multiple awaits coming here. We can't use Promise.all because
     // offerTo() can return before getOfferResult() is valid, and we can't
     // check whether swapIn liquidated assets until getOfferResult() returns.
     // Of course, we also can't exit the seat until one or the other
     // liquidation takes place.
     const amounts = await deposited;
-    await E(liqSeat).getOfferResult();
-    trace('exact sell result', amounts);
-
-    // if swapOut failed to make the trade, we'll sell it all
-    const sellAllIfUnsold = async () => {
-      const unsold = debtorSeat.getAmountAllocated('In');
-      // We cannot easily directly check that the `offerTo` succeeded, so we
-      // check that amotun unsold is not what we started with.
-      if (!AmountMath.isEqual(amountIn, unsold)) {
-        trace('Changed', { inBefore: amountIn, unsold });
-        return;
-      }
-
-      trace('liquidating all collateral because swapIn did not succeed');
-      const strategy = makeDefaultLiquidationStrategy(amm);
-      const { deposited: sellAllDeposited, userSeatPromise: sellAllSeat } =
-        await offerTo(
-          zcf,
-          strategy.makeInvitation(debt),
-          undefined, // The keywords were mapped already
-          strategy.makeProposal(amountIn, AmountMath.makeEmpty(debtBrand)),
-          debtorSeat,
-        );
-      // await sellAllDeposited, but don't need the value
-      await Promise.all([
-        E(sellAllSeat).getOfferResult(),
-        sellAllDeposited,
-      ]).catch(sellAllError => {
-        throw Error(`Unable to liquidate ${sellAllError}`);
-      });
-    };
-    await sellAllIfUnsold();
-    trace(`Liq results`, debt, debtorSeat.getAmountAllocated('RUN', debtBrand));
+    trace(
+      `Liq results`,
+      debt,
+      debtorSeat.getAmountAllocated('RUN', debtBrand),
+      amounts,
+    );
     debtorSeat.exit();
   };
 

--- a/packages/run-protocol/src/vaultFactory/liquidateMinimum.js
+++ b/packages/run-protocol/src/vaultFactory/liquidateMinimum.js
@@ -49,19 +49,13 @@ const start = async zcf => {
       debtorSeat,
       { maxOut: debt },
     );
-
-    // Multiple awaits coming here. We can't use Promise.all because
-    // offerTo() can return before getOfferResult() is valid, and we can't
-    // check whether swapIn liquidated assets until getOfferResult() returns.
-    // Of course, we also can't exit the seat until one or the other
-    // liquidation takes place.
     const amounts = await deposited;
-    trace(
-      `Liq results`,
+    trace(`Liq results`, {
       debt,
-      debtorSeat.getAmountAllocated('RUN', debtBrand),
+      amountIn,
+      paid: debtorSeat.getCurrentAllocation(),
       amounts,
-    );
+    });
     debtorSeat.exit();
   };
 

--- a/packages/run-protocol/src/vaultFactory/liquidateMinimum.js
+++ b/packages/run-protocol/src/vaultFactory/liquidateMinimum.js
@@ -47,7 +47,7 @@ const start = async zcf => {
       liqProposal,
       debtorSeat,
       debtorSeat,
-      { maxOut: debt },
+      { stopAfter: debt },
     );
     const amounts = await deposited;
     trace(`Liq results`, {

--- a/packages/run-protocol/src/vpool-xyk-amm/doublePool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/doublePool.js
@@ -27,7 +27,7 @@ const publicPrices = prices => {
  * @param {() => bigint} getProtocolFeeBP - retrieve governed protocol fee value
  * @param {() => bigint} getPoolFeeBP - retrieve governed pool fee value
  * @param {ZCFSeat} feeSeat
- * @returns {VPoolWrapper<VPoolInternalFacet>}
+ * @returns {VPoolWrapper<DoublePoolInternalFacet>}
  */
 export const makeDoublePool = (
   zcf,

--- a/packages/run-protocol/src/vpool-xyk-amm/doublePool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/doublePool.js
@@ -127,11 +127,6 @@ export const makeDoublePool = (
     return publicPrices(getPriceForInput(amountIn, amountOut));
   };
 
-  const swapIn = (seat, amountIn, amountOut) => {
-    const prices = getPriceForInput(amountIn, amountOut);
-    return allocateGainsAndLosses(seat, prices);
-  };
-
   const getPriceForOutput = (amountIn, amountOut) => {
     const protocolFeeRatio = makeFeeRatio(getProtocolFeeBP(), centralBrand);
     const poolFeeRatioCentral = makeFeeRatio(getPoolFeeBP(), centralBrand);
@@ -187,21 +182,16 @@ export const makeDoublePool = (
   const getOutputPrice = (amountIn, amountOut) => {
     return publicPrices(getPriceForOutput(amountIn, amountOut));
   };
-  const swapOut = (seat, amountIn, amountOut) => {
-    const prices = getPriceForOutput(amountIn, amountOut);
-    return allocateGainsAndLosses(seat, prices);
-  };
 
   const externalFacet = Far('double pool', {
     getInputPrice,
     getOutputPrice,
-    swapIn,
-    swapOut,
   });
 
   const internalFacet = Far('single pool', {
     getPriceForInput,
     getPriceForOutput,
+    allocateGainsAndLosses,
   });
 
   return { externalFacet, internalFacet };

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -178,7 +178,7 @@ const start = async (zcf, privateArgs) => {
   /**
    * @param {Brand} brandIn
    * @param {Brand} brandOut
-   * @returns {VPoolWrapper<unknown>}
+   * @returns {VPoolWrapper<DoublePoolInternalFacet>}
    */
   const provideVPool = (brandIn, brandOut) => {
     if (isSecondary(brandIn) && isSecondary(brandOut)) {
@@ -193,6 +193,7 @@ const start = async (zcf, privateArgs) => {
     }
 
     const pool = isSecondary(brandOut) ? getPool(brandOut) : getPool(brandIn);
+    // @ts-expect-error cast
     return pool.getVPool();
   };
 

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -178,7 +178,7 @@ const start = async (zcf, privateArgs) => {
   /**
    * @param {Brand} brandIn
    * @param {Brand} brandOut
-   * @returns {VPoolWrapper<DoublePoolInternalFacet>}
+   * @returns {VPoolWrapper<SinglePoolInternalFacet> | VPoolWrapper<DoublePoolInternalFacet>}
    */
   const provideVPool = (brandIn, brandOut) => {
     if (isSecondary(brandIn) && isSecondary(brandOut)) {
@@ -193,7 +193,6 @@ const start = async (zcf, privateArgs) => {
     }
 
     const pool = isSecondary(brandOut) ? getPool(brandOut) : getPool(brandIn);
-    // @ts-expect-error cast
     return pool.getVPool();
   };
 
@@ -207,6 +206,7 @@ const start = async (zcf, privateArgs) => {
   };
 
   const { makeSwapInInvitation, makeSwapOutInvitation } =
+    // @ts-expect-error we know this is the Double variety
     makeMakeSwapInvitation(zcf, provideVPool);
   const makeAddLiquidityInvitation = makeMakeAddLiquidityInvitation(
     zcf,

--- a/packages/run-protocol/src/vpool-xyk-amm/singlePool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/singlePool.js
@@ -35,12 +35,13 @@ export const makeSinglePool = (
     amountOut: prices.swapperGets,
   });
 
-  const allocateGainsAndLosses = (inBrand, prices, seat) => {
+  const allocateGainsAndLosses = (seat, prices) => {
     const poolSeat = pool.getPoolSeat();
     seat.decrementBy(harden({ In: prices.swapperGives }));
     seat.incrementBy(harden({ Out: prices.swapperGets }));
     feeSeat.incrementBy(harden({ RUN: prices.protocolFee }));
 
+    const inBrand = prices.swapperGives.brand;
     if (inBrand === secondaryBrand) {
       poolSeat.decrementBy(harden({ Central: prices.yDecrement }));
       poolSeat.incrementBy(harden({ Secondary: prices.xIncrement }));
@@ -65,11 +66,6 @@ export const makeSinglePool = (
     );
   };
 
-  const swapIn = (seat, amountIn, amountOut) => {
-    const prices = getPriceForInput(amountIn, amountOut);
-    return allocateGainsAndLosses(amountIn.brand, prices, seat);
-  };
-
   const getPriceForOutput = (amountIn, amountOut) => {
     return pricesForStatedOutput(
       amountIn,
@@ -79,10 +75,6 @@ export const makeSinglePool = (
       makeFeeRatio(getPoolFeeBP(), amountIn.brand),
     );
   };
-  const swapOut = (seat, amountIn, amountOut) => {
-    const prices = getPriceForOutput(amountIn, amountOut);
-    return allocateGainsAndLosses(amountIn.brand, prices, seat);
-  };
 
   /** @type {VPool} */
   const externalFacet = Far('single pool', {
@@ -90,14 +82,13 @@ export const makeSinglePool = (
       publicPrices(getPriceForInput(amountIn, amountOut)),
     getOutputPrice: (amountIn, amountOut) =>
       publicPrices(getPriceForOutput(amountIn, amountOut)),
-    swapIn,
-    swapOut,
   });
 
   const internalFacet = Far('single pool', {
     getPriceForInput,
     getPriceForOutput,
     addLiquidityActual,
+    allocateGainsAndLosses,
   });
 
   return { externalFacet, internalFacet };

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -10,8 +10,13 @@ import { AmountMath } from '@agoric/ertp';
  * @param {(brandIn: Brand, brandOut: Brand) => VPoolWrapper<unknown>} provideVPool
  */
 export const makeMakeSwapInvitation = (zcf, provideVPool) => {
-  // trade with a stated amountIn.
-  const swapIn = (seat, { maxOut } = {}) => {
+  /**
+   * trade with a stated amountIn.
+   *
+   * @param {ZCFSeat} seat
+   * @param {{ maxOut: Amount }} args
+   */
+  const swapIn = (seat, args) => {
     assertProposalShape(seat, {
       give: { In: null },
       want: { Out: null },
@@ -20,22 +25,17 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
       give: { In: amountIn },
       want: { Out: amountOut },
     } = seat.getProposal();
-    // const pool = provideVPool(amountIn.brand, amountOut.brand).externalFacet;
-    // return pool.swapIn(seat, amountIn, amountOut);
-    console.log('start trade', { amountIn, amountOut, maxOut });
     const pool = provideVPool(amountIn.brand, amountOut.brand).internalFacet;
     let prices;
+    const maxOut = args.maxOut;
     if (maxOut) {
       AmountMath.coerce(amountOut.brand, maxOut);
       prices = pool.getPriceForOutput(amountIn, maxOut);
-      console.log('had maxOut', maxOut, prices);
     }
     if (!prices || !AmountMath.isGTE(prices.swapperGets, maxOut)) {
       // `amountIn` is not enough to sell for maxOut so just sell it all
       prices = pool.getPriceForInput(amountIn, amountOut);
-      console.log('just swap in', prices);
     }
-    console.log('HELP', prices);
     assert(amountIn.brand === prices.swapperGives.brand);
     return pool.allocateGainsAndLosses(seat, prices);
   };

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -1,10 +1,8 @@
 // @ts-check
 
-// @ts-ignore
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 
 import '@agoric/zoe/exported.js';
-// @ts-ignore
 import { AmountMath } from '@agoric/ertp';
 
 /**
@@ -37,16 +35,13 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
     const stopAfter = args && args.stopAfter;
     if (stopAfter) {
       AmountMath.coerce(amountOut.brand, stopAfter);
-      // @ts-ignore
       prices = pool.getPriceForOutput(amountIn, stopAfter);
     }
     if (!prices || !AmountMath.isGTE(prices.swapperGets, stopAfter)) {
       // `amountIn` is not enough to sell for stopAfter so just sell it all
-      // @ts-ignore
       prices = pool.getPriceForInput(amountIn, amountOut);
     }
     assert(amountIn.brand === prices.swapperGives.brand);
-    // @ts-ignore
     return pool.allocateGainsAndLosses(seat, prices);
   };
 

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -1,8 +1,10 @@
 // @ts-check
 
+// @ts-ignore
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 
 import '@agoric/zoe/exported.js';
+// @ts-ignore
 import { AmountMath } from '@agoric/ertp';
 
 /**
@@ -25,18 +27,26 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
       give: { In: amountIn },
       want: { Out: amountOut },
     } = seat.getProposal();
+    if (args) {
+      AmountMath.coerce(amountOut.brand, args.maxOut);
+      // TODO check that there are no other keys
+    }
+
     const pool = provideVPool(amountIn.brand, amountOut.brand).internalFacet;
     let prices;
-    const maxOut = args.maxOut;
+    const maxOut = args && args.maxOut;
     if (maxOut) {
       AmountMath.coerce(amountOut.brand, maxOut);
+      // @ts-ignore
       prices = pool.getPriceForOutput(amountIn, maxOut);
     }
     if (!prices || !AmountMath.isGTE(prices.swapperGets, maxOut)) {
       // `amountIn` is not enough to sell for maxOut so just sell it all
+      // @ts-ignore
       prices = pool.getPriceForInput(amountIn, amountOut);
     }
     assert(amountIn.brand === prices.swapperGives.brand);
+    // @ts-ignore
     return pool.allocateGainsAndLosses(seat, prices);
   };
 

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -16,7 +16,7 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
    * trade with a stated amountIn.
    *
    * @param {ZCFSeat} seat
-   * @param {{ maxOut: Amount }} args
+   * @param {{ stopAfter: Amount }} args
    */
   const swapIn = (seat, args) => {
     assertProposalShape(seat, {
@@ -28,20 +28,20 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
       want: { Out: amountOut },
     } = seat.getProposal();
     if (args) {
-      AmountMath.coerce(amountOut.brand, args.maxOut);
+      AmountMath.coerce(amountOut.brand, args.stopAfter);
       // TODO check that there are no other keys
     }
 
     const pool = provideVPool(amountIn.brand, amountOut.brand).internalFacet;
     let prices;
-    const maxOut = args && args.maxOut;
-    if (maxOut) {
-      AmountMath.coerce(amountOut.brand, maxOut);
+    const stopAfter = args && args.stopAfter;
+    if (stopAfter) {
+      AmountMath.coerce(amountOut.brand, stopAfter);
       // @ts-ignore
-      prices = pool.getPriceForOutput(amountIn, maxOut);
+      prices = pool.getPriceForOutput(amountIn, stopAfter);
     }
-    if (!prices || !AmountMath.isGTE(prices.swapperGets, maxOut)) {
-      // `amountIn` is not enough to sell for maxOut so just sell it all
+    if (!prices || !AmountMath.isGTE(prices.swapperGets, stopAfter)) {
+      // `amountIn` is not enough to sell for stopAfter so just sell it all
       // @ts-ignore
       prices = pool.getPriceForInput(amountIn, amountOut);
     }
@@ -54,9 +54,9 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
   const swapOut = seat => {
     // The offer's amountOut is a minimum; the offeredAmountIn is a max.
     const {
-      want: { Out: maxOut },
+      want: { Out: stopAfter },
     } = seat.getProposal();
-    return swapIn(seat, { maxOut });
+    return swapIn(seat, { stopAfter });
   };
 
   const makeSwapInInvitation = () =>

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -1,15 +1,13 @@
 // @ts-check
 
-// @ts-ignore
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 
 import '@agoric/zoe/exported.js';
-// @ts-ignore
 import { AmountMath } from '@agoric/ertp';
 
 /**
  * @param {ZCF} zcf
- * @param {(brandIn: Brand, brandOut: Brand) => VPoolWrapper<unknown>} provideVPool
+ * @param {(brandIn: Brand, brandOut: Brand) => VPoolWrapper<DoublePoolInternalFacet>} provideVPool
  */
 export const makeMakeSwapInvitation = (zcf, provideVPool) => {
   /**
@@ -32,16 +30,13 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
     const maxOut = args.maxOut;
     if (maxOut) {
       AmountMath.coerce(amountOut.brand, maxOut);
-      // @ts-ignore
       prices = pool.getPriceForOutput(amountIn, maxOut);
     }
     if (!prices || !AmountMath.isGTE(prices.swapperGets, maxOut)) {
       // `amountIn` is not enough to sell for maxOut so just sell it all
-      // @ts-ignore
       prices = pool.getPriceForInput(amountIn, amountOut);
     }
     assert(amountIn.brand === prices.swapperGives.brand);
-    // @ts-ignore
     return pool.allocateGainsAndLosses(seat, prices);
   };
 

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -1,8 +1,10 @@
 // @ts-check
 
+// @ts-ignore
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 
 import '@agoric/zoe/exported.js';
+// @ts-ignore
 import { AmountMath } from '@agoric/ertp';
 
 /**
@@ -30,13 +32,16 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
     const maxOut = args.maxOut;
     if (maxOut) {
       AmountMath.coerce(amountOut.brand, maxOut);
+      // @ts-ignore
       prices = pool.getPriceForOutput(amountIn, maxOut);
     }
     if (!prices || !AmountMath.isGTE(prices.swapperGets, maxOut)) {
       // `amountIn` is not enough to sell for maxOut so just sell it all
+      // @ts-ignore
       prices = pool.getPriceForInput(amountIn, amountOut);
     }
     assert(amountIn.brand === prices.swapperGives.brand);
+    // @ts-ignore
     return pool.allocateGainsAndLosses(seat, prices);
   };
 

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -47,11 +47,17 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
 
   // trade with a stated amount out.
   const swapOut = seat => {
-    // The offer's amountOut is a minimum; the offeredAmountIn is a max.
+    assertProposalShape(seat, {
+      give: { In: null },
+      want: { Out: null },
+    });
     const {
-      want: { Out: stopAfter },
+      give: { In: amountIn },
+      want: { Out: amountOut },
     } = seat.getProposal();
-    return swapIn(seat, { stopAfter });
+    const pool = provideVPool(amountIn.brand, amountOut.brand).internalFacet;
+    const prices = pool.getPriceForOutput(amountIn, amountOut);
+    return pool.allocateGainsAndLosses(seat, prices);
   };
 
   const makeSwapInInvitation = () =>

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -3,6 +3,7 @@
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 
 import '@agoric/zoe/exported.js';
+import { AmountMath } from '@agoric/ertp';
 
 /**
  * @param {ZCF} zcf
@@ -10,7 +11,7 @@ import '@agoric/zoe/exported.js';
  */
 export const makeMakeSwapInvitation = (zcf, provideVPool) => {
   // trade with a stated amountIn.
-  const swapIn = seat => {
+  const swapIn = (seat, { maxOut } = {}) => {
     assertProposalShape(seat, {
       give: { In: null },
       want: { Out: null },
@@ -19,23 +20,33 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
       give: { In: amountIn },
       want: { Out: amountOut },
     } = seat.getProposal();
-    const pool = provideVPool(amountIn.brand, amountOut.brand).externalFacet;
-    return pool.swapIn(seat, amountIn, amountOut);
+    // const pool = provideVPool(amountIn.brand, amountOut.brand).externalFacet;
+    // return pool.swapIn(seat, amountIn, amountOut);
+    console.log('start trade', { amountIn, amountOut, maxOut });
+    const pool = provideVPool(amountIn.brand, amountOut.brand).internalFacet;
+    let prices;
+    if (maxOut) {
+      AmountMath.coerce(amountOut.brand, maxOut);
+      prices = pool.getPriceForOutput(amountIn, maxOut);
+      console.log('had maxOut', maxOut, prices);
+    }
+    if (!prices || !AmountMath.isGTE(prices.swapperGets, maxOut)) {
+      // `amountIn` is not enough to sell for maxOut so just sell it all
+      prices = pool.getPriceForInput(amountIn, amountOut);
+      console.log('just swap in', prices);
+    }
+    console.log('HELP', prices);
+    assert(amountIn.brand === prices.swapperGives.brand);
+    return pool.allocateGainsAndLosses(seat, prices);
   };
 
   // trade with a stated amount out.
   const swapOut = seat => {
-    assertProposalShape(seat, {
-      give: { In: null },
-      want: { Out: null },
-    });
     // The offer's amountOut is a minimum; the offeredAmountIn is a max.
     const {
-      give: { In: amountIn },
-      want: { Out: amountOut },
+      want: { Out: maxOut },
     } = seat.getProposal();
-    const pool = provideVPool(amountIn.brand, amountOut.brand).externalFacet;
-    return pool.swapOut(seat, amountIn, amountOut);
+    return swapIn(seat, { maxOut });
   };
 
   const makeSwapInInvitation = () =>

--- a/packages/run-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/types.js
@@ -38,10 +38,10 @@
  */
 
 /**
- * @typedef {Object} VPoolInternalFacet - virtual pool for price quotes and trading
+ * @typedef {Object} DoublePoolInternalFacet - virtual pool for price quotes and trading
  * @property {GetDoublePoolSwapQuote} getPriceForInput
  * @property {GetDoublePoolSwapQuote} getPriceForOutput
- * @property {(ZCFSeat, DoublePoolSwapResult) => string} allocateGainsAndLosses
+ * @property {(seat: ZCFSeat, result: DoublePoolSwapResult) => string} allocateGainsAndLosses
  */
 
 /**

--- a/packages/run-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/types.js
@@ -41,7 +41,7 @@
  * @typedef {Object} DoublePoolInternalFacet - virtual pool for price quotes and trading
  * @property {GetDoublePoolSwapQuote} getPriceForInput
  * @property {GetDoublePoolSwapQuote} getPriceForOutput
- * @property {(seat: ZCFSeat, result: DoublePoolSwapResult) => string} allocateGainsAndLosses
+ * @property {(ZCFSeat, DoublePoolSwapResult) => string} allocateGainsAndLosses
  */
 
 /**

--- a/packages/run-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/types.js
@@ -10,8 +10,6 @@
  * @typedef {Object} VPool - virtual pool for price quotes and trading
  * @property {(amountIn: Amount, amountOut: Amount) => VPoolPriceQuote} getInputPrice
  * @property {(amountIn: Amount, amountOut: Amount) => VPoolPriceQuote} getOutputPrice
- * @property {(seat: ZCFSeat, amountIn: Amount, amountOut: Amount) => string} swapIn
- * @property {(seat: ZCFSeat, amountIn: Amount, amountOut: Amount) => string} swapOut
  */
 
 /**
@@ -43,6 +41,7 @@
  * @typedef {Object} VPoolInternalFacet - virtual pool for price quotes and trading
  * @property {GetDoublePoolSwapQuote} getPriceForInput
  * @property {GetDoublePoolSwapQuote} getPriceForOutput
+ * @property {(ZCFSeat, DoublePoolSwapResult) => string} allocateGainsAndLosses
  */
 
 /**

--- a/packages/run-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/types.js
@@ -41,7 +41,7 @@
  * @typedef {Object} DoublePoolInternalFacet - virtual pool for price quotes and trading
  * @property {GetDoublePoolSwapQuote} getPriceForInput
  * @property {GetDoublePoolSwapQuote} getPriceForOutput
- * @property {(ZCFSeat, DoublePoolSwapResult) => string} allocateGainsAndLosses
+ * @property {(seat: ZCFSeat, swapResult: DoublePoolSwapResult) => string} allocateGainsAndLosses
  */
 
 /**
@@ -81,7 +81,7 @@
  * @property {() => void} updateState
  * @property {() => PriceAuthority} getToCentralPriceAuthority
  * @property {() => PriceAuthority} getFromCentralPriceAuthority
- * @property {() => VPoolWrapper<unknown>} getVPool
+ * @property {() => VPoolWrapper<SinglePoolInternalFacet>} getVPool
  */
 
 /**

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -569,7 +569,7 @@ test('amm doubleSwap', async t => {
     simsForMoolaPayments,
   );
   const bobMoolaPayout = await E(bobSeat1).getPayout('Out');
-
+  console.log('payout', await moolaR.issuer.getAmountOf(bobMoolaPayout));
   t.deepEqual(
     await moolaR.issuer.getAmountOf(bobMoolaPayout),
     moola(7234n),


### PR DESCRIPTION
refs: #4856

## Description

Implements the new API in terms of the existing underlying implementation.

* Move swap implementation into shared `swap.js`
* Implement `maxOut` using existing pricing operations
* implement `swapOut` in terms of `swapIn` with `maxOut`
* remove now-unneeded code in pool implementations
* make `allocateGainsAndLosses` API the same for single and double pools

### Security Considerations

N/A

### Documentation Considerations

Need to deprecate the old API and add the new argument to Swap.

### Testing Considerations

SwapOut is defined in terms of the new API, so it gets lot of testing now. Additional specific cases should be added for which the `want` is not the same as the `maxOut`.

[Test cases from the liquidation branch](https://github.com/Agoric/agoric-sdk/blob/c76e38190713ae908fdec6bbcc381c9c86fdf4fb/packages/run-protocol/test/vaultFactory/test-liquidator.js#L584)