### PR TITLE
fix: interface guards

### DIFF
--- a/packages/ERTP/src/interfaces.js
+++ b/packages/ERTP/src/interfaces.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-use-before-define */
-/* global foo */
-const M = foo();
+import { M, I } from '@agoric/store';
 
 export const MatchDisplayInfo = M.rest(
   {
@@ -10,10 +9,10 @@ export const MatchDisplayInfo = M.rest(
   }),
 );
 
-export const BrandI = M.interface({
-  isMyIssuer: M.callWhen(M.await(IssuerI)).returns(M.boolean()),
-  getAllegedName: M.call().returns(M.string()),
-  getDisplayInfo: M.call().returns(MatchDisplayInfo),
+export const BrandI = I.interface('Brand', {
+  isMyIssuer: I.callWhen(I.await(IssuerI)).returns(M.boolean()),
+  getAllegedName: I.call().returns(M.string()),
+  getDisplayInfo: I.call().returns(MatchDisplayInfo),
 });
 
 export const MatchAmount = {
@@ -21,25 +20,25 @@ export const MatchAmount = {
   value: M.or(M.bigint(), M.array()),
 };
 
-export const IssuerI = M.interface({
-  getBrand: M.call().returns(BrandI),
-  getAllegedName: M.call().returns(M.string()),
-  getAssetKind: M.call().returns(M.or('nat', 'set')),
-  getDisplayInfo: M.call().returns(MatchDisplayInfo),
-  makeEmptyPurse: M.call().returns(PurseI),
+export const IssuerI = I.interface('Issuer', {
+  getBrand: I.call().returns(BrandI),
+  getAllegedName: I.call().returns(M.string()),
+  getAssetKind: I.call().returns(M.or('nat', 'set')),
+  getDisplayInfo: I.call().returns(MatchDisplayInfo),
+  makeEmptyPurse: I.call().returns(PurseI),
 
-  isLive: M.callWhen(M.await(PaymentI)).returns(M.boolean()),
-  getAmountOf: M.callWhen(M.await(PaymentI)).returns(MatchAmount),
+  isLive: I.callWhen(I.await(PaymentI)).returns(M.boolean()),
+  getAmountOf: I.callWhen(I.await(PaymentI)).returns(MatchAmount),
 });
 
-export const PaymentI = M.interface({
-  getAllegedBrand: M.call().returns(BrandI),
+export const PaymentI = I.interface('Payment', {
+  getAllegedBrand: I.call().returns(BrandI),
 });
 
-export const PurseI = M.interface({
-  getAllegedBrand: M.call().returns(BrandI),
-  deposit: M.apply(M.rest([PaymentI]).optionals([MatchAmount])).returns(
+export const PurseI = I.interface('Purse', {
+  getAllegedBrand: I.call().returns(BrandI),
+  deposit: I.apply(M.rest([PaymentI], M.partial([MatchAmount]))).returns(
     MatchAmount,
   ),
-  withdraw: M.call(MatchAmount).returns(PaymentI),
+  withdraw: I.call(MatchAmount).returns(PaymentI),
 });

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -509,4 +509,4 @@ export const vivifyPaymentLedger = (
 };
 harden(vivifyPaymentLedger);
 
-/** @typedef {ReturnType<vivifyPaymentLedger>} PaymentLedger */
+/** @typedef {ReturnType<typeof vivifyPaymentLedger>} PaymentLedger */

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -32,7 +32,10 @@ test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
         // @ts-expect-error Intentional wrong type for testing
         harden({ decimalPlaces: 'hello' }),
       ),
-    { message: /^displayInfo: "hello" - Must be >= -100$/ },
+    {
+      message:
+        /^displayInfo: partial-base: decimalPlaces: "hello" - Must be >= -100$/,
+    },
   );
 
   t.throws(
@@ -58,13 +61,19 @@ test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
   t.throws(
     () =>
       makeIssuerKit('myTokens', AssetKind.NAT, harden({ decimalPlaces: 101 })),
-    { message: /^displayInfo: 101 - Must be <= 100$/ },
+    {
+      message:
+        /^displayInfo: partial-base: decimalPlaces: 101 - Must be <= 100$/,
+    },
   );
 
   t.throws(
     () =>
       makeIssuerKit('myTokens', AssetKind.NAT, harden({ decimalPlaces: -101 })),
-    { message: /^displayInfo: -101 - Must be >= -100$/ },
+    {
+      message:
+        /^displayInfo: partial-base: decimalPlaces: -101 - Must be >= -100$/,
+    },
   );
 });
 
@@ -81,7 +90,7 @@ test('makeIssuerKit bad displayInfo.assetKind', async t => {
       ),
     {
       message:
-        /^displayInfo: "something" - Must match one of \["nat","set","copySet","copyBag"\]$/,
+        /^displayInfo: partial-base: assetKind: "something" - Must match one of \["nat","set","copySet","copyBag"\]$/,
     },
   );
 });
@@ -99,7 +108,7 @@ test('makeIssuerKit bad displayInfo.whatever', async t => {
       ),
     {
       message:
-        /^displayInfo: Remainder \{"whatever":"something"\} - Must match \{\}$/,
+        /displayInfo: partial-rest: {"whatever":"something"} - Must be: {}/,
     },
   );
 });
@@ -114,8 +123,7 @@ test('makeIssuerKit malicious displayInfo', async t => {
         'badness',
       ),
     {
-      message:
-        /^displayInfo: "badness" - Must have shape of base: "copyRecord"$/,
+      message: /^displayInfo: string "badness" - Must be a copyRecord$/,
     },
   );
 });

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -45,7 +45,7 @@ test('bad display info', t => {
   // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => makeIssuerKit('fungible', AssetKind.NAT, displayInfo), {
     message:
-      /^displayInfo: Remainder \{"somethingUnexpected":3\} - Must match \{\}$/,
+      /displayInfo: partial-rest: {"somethingUnexpected":3} - Must be: {}/,
   });
 });
 

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -45,7 +45,8 @@ test('mint.mintPayment set w strings AssetKind', async t => {
 
   const badAmount = AmountMath.make(brand, harden([['badElement']]));
   t.throws(() => mint.mintPayment(badAmount), {
-    message: / - Must have passStyle or tag "string"/,
+    message:
+      /minted amount: value: \[0\]: copyArray \["badElement"\] - Must be a string/,
   });
 });
 

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2510,7 +2510,10 @@ test('addVaultType: extra, unexpected params', async t => {
   await t.throwsAsync(
     // @ts-expect-error bad args
     E(vaultFactory).addVaultType(chit.issuer, 'Chit', missingParams),
-    { message: /Must have same property names/ },
+    {
+      message:
+        /initialParamValues: split-base: .* - Must have missing properties \["interestRate"\]/,
+    },
   );
 
   const actual = await E(vaultFactory).addVaultType(

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -55,6 +55,7 @@ export {
   matches,
   fit,
 } from './patterns/patternMatchers.js';
+export { I } from './patterns/interface-tools.js';
 export { compareRank, isRankSorted, sortByRank } from './patterns/rankOrder.js';
 export {
   makeDecodePassable,

--- a/packages/store/src/patterns/defineHeapKind.js
+++ b/packages/store/src/patterns/defineHeapKind.js
@@ -1,0 +1,37 @@
+import { makeLegacyWeakMap } from '../legacy/legacyWeakMap.js';
+import { defendVTable } from './interface-tools.js';
+
+const { create, freeze, seal } = Object;
+
+export const defineHeapKind = (
+  ifaceGuard,
+  init,
+  rawVTable,
+  { finish = undefined } = {},
+) => {
+  if (typeof ifaceGuard === 'string') {
+    ifaceGuard = harden({
+      klass: 'Interface',
+      farName: ifaceGuard,
+      methodGuards: {},
+    });
+  }
+  const { klass } = ifaceGuard;
+  assert(klass === 'Interface');
+  // legacyWeakMap to avoid hardening state
+  const contextMapStore = makeLegacyWeakMap();
+  const defensiveVTable = defendVTable(rawVTable, contextMapStore, ifaceGuard);
+  const makeInstance = (...args) => {
+    // Don't freeze state
+    const state = seal(init(...args));
+    const self = harden(create(defensiveVTable));
+    const context = freeze({ state, self });
+    contextMapStore.init(self, context);
+    if (finish) {
+      finish(context);
+    }
+    return self;
+  };
+  return harden(makeInstance);
+};
+harden(defineHeapKind);

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -1,0 +1,179 @@
+import { PASS_STYLE, assertRemotable } from '@endo/marshal';
+import { E } from '@endo/eventual-send';
+import { M, fit } from './patternMatchers.js';
+
+const { details: X, quote: q } = assert;
+const { apply, ownKeys } = Reflect;
+const { fromEntries, entries, create, setPrototypeOf, defineProperties } =
+  Object;
+
+const makeMethodGuardMaker = (callKind, argGuards) =>
+  harden({
+    returns: (returnGuard = M.undefined()) =>
+      harden({
+        klass: 'methodGuard',
+        callKind,
+        argGuards,
+        returnGuard,
+      }),
+  });
+
+const makeAwaitArgGuard = argGuard =>
+  harden({
+    klass: 'awaitArg',
+    argGuard,
+  });
+
+const isAwaitArgGuard = argGuard =>
+  argGuard && typeof argGuard === 'object' && argGuard.klass === 'awaitArg';
+
+export const I = harden({
+  interface: (farName, methodGuards) => {
+    for (const [_, methodGuard] of entries(methodGuards)) {
+      assert(
+        methodGuard.klass === 'methodGuard',
+        X`unrecognize method guard ${methodGuard}`,
+      );
+    }
+    return harden({
+      klass: 'Interface',
+      farName,
+      methodGuards,
+    });
+  },
+  call: (...argGuards) => makeMethodGuardMaker('sync', argGuards),
+  callWhen: (...argGuards) => makeMethodGuardMaker('async', argGuards),
+  apply: argGuards => makeMethodGuardMaker('sync', argGuards),
+  applyWhen: argGuards => makeMethodGuardMaker('async', argGuards),
+
+  await: argGuard => makeAwaitArgGuard(argGuard),
+});
+
+const mimicMethodNameLength = (defensiveMethod, rawMethod) => {
+  defineProperties(defensiveMethod, {
+    name: { value: rawMethod.name },
+    length: { value: rawMethod.length - 1 },
+  });
+};
+
+const defendSyncMethod = (rawMethod, contextMapStore, methodGuard, label) => {
+  const { argGuards, returnGuard } = methodGuard;
+
+  const { defensiveSyncMethod } = {
+    // Note purposeful use of `this` and concise method syntax
+    defensiveSyncMethod(...args) {
+      assert(
+        contextMapStore.has(this),
+        X`method can only be used on its own instances: ${rawMethod}`,
+      );
+      const context = contextMapStore.get(this);
+      fit(harden(args), argGuards, `${label}: args`);
+      const result = apply(rawMethod, undefined, [context, ...args]);
+      fit(result, returnGuard, `${label}: result`);
+      return result;
+    },
+  };
+  mimicMethodNameLength(defensiveSyncMethod, rawMethod);
+  return harden(defensiveSyncMethod);
+};
+
+const defendAsyncMethod = (rawMethod, contextMapStore, methodGuard, label) => {
+  const { argGuards, returnGuard } = methodGuard;
+
+  const rawArgGuards = [];
+  const awaitIndexes = [];
+  for (let i = 0; i < argGuards.length; i += 1) {
+    const argGuard = argGuards[i];
+    if (isAwaitArgGuard(argGuard)) {
+      rawArgGuards.push(argGuard.argGuard);
+      awaitIndexes.push(i);
+    } else {
+      rawArgGuards.push(argGuard);
+    }
+  }
+  harden(rawArgGuards);
+  harden(awaitIndexes);
+  const { defensiveAsyncMethod } = {
+    // Note purposeful use of `this` and concise method syntax
+    defensiveAsyncMethod(...args) {
+      assert(
+        contextMapStore.has(this),
+        X`method can only be used on its own instances: ${rawMethod}`,
+      );
+      const context = contextMapStore.get(this);
+      const awaitList = awaitIndexes.map(i => args[i]);
+      const p = Promise.all(awaitList);
+      const rawArgs = [...args];
+      return E.when(p, awaitedArgs => {
+        for (let j = 0; j < awaitIndexes.length; j += 1) {
+          rawArgs[awaitIndexes[j]] = awaitedArgs[j];
+        }
+        fit(harden(rawArgs), rawArgGuards, `${label}: args`);
+        const resultP = apply(rawMethod, undefined, [context, ...rawArgs]);
+        return E.when(resultP, result => {
+          fit(result, returnGuard, `${label}: result`);
+          return result;
+        });
+      });
+    },
+  };
+  mimicMethodNameLength(defensiveAsyncMethod, rawMethod);
+  return harden(defensiveAsyncMethod);
+};
+
+const defendMethod = (rawMethod, contextMapStore, methodGuard, label) => {
+  const { klass, callKind } = methodGuard;
+  assert(klass === 'methodGuard');
+
+  if (callKind === 'sync') {
+    return defendSyncMethod(rawMethod, contextMapStore, methodGuard, label);
+  } else {
+    assert(callKind === 'async');
+    return defendAsyncMethod(rawMethod, contextMapStore, methodGuard, label);
+  }
+};
+
+const defaultMethodGuard = I.apply(M.array()).returns();
+
+export const defendVTable = (rawVTable, contextMapStore, iface) => {
+  const { klass, farName, methodGuards } = iface;
+  assert(klass === 'Interface');
+  assert.typeof(farName, 'string');
+
+  const methodGuardNames = ownKeys(methodGuards);
+  for (const methodGuardName of methodGuardNames) {
+    assert(
+      methodGuardName in rawVTable,
+      X`${q(methodGuardName)} not implemented by ${rawVTable}`,
+    );
+  }
+  const methodNames = ownKeys(rawVTable);
+  // like Object.entries, but unenumerable and symbol as well.
+  const rawMethodEntries = methodNames.map(mName => [mName, rawVTable[mName]]);
+  const defensiveMethodEntries = rawMethodEntries.map(([mName, rawMethod]) => {
+    const methodGuard = methodGuards[mName] || defaultMethodGuard;
+    const defensiveMethod = defendMethod(
+      rawMethod,
+      contextMapStore,
+      methodGuard,
+      `${farName}.${mName}`,
+    );
+    return [mName, defensiveMethod];
+  });
+  // Return the defensive VTable, which can be use on a shared
+  // prototype and shared by instances, avoiding the per-object-per-method
+  // allocation cost of the objects as closure pattern. That's why we
+  // use `this` above. To make it safe, each defensive method starts with
+  // a fail-fast brand check on `this`, ensuring that the methods can only be
+  // applied to legitimate instances.
+  const defensiveVTable = fromEntries(defensiveMethodEntries);
+  const remotableProto = create(Object.prototype, {
+    [PASS_STYLE]: { value: 'remotable' },
+    [Symbol.toStringTag]: { value: `Alleged: ${farName}` },
+  });
+  setPrototypeOf(defensiveVTable, remotableProto);
+  harden(defensiveVTable);
+  assertRemotable(defensiveVTable);
+  return defensiveVTable;
+};
+harden(defendVTable);

--- a/packages/store/src/patterns/match-helpers.js
+++ b/packages/store/src/patterns/match-helpers.js
@@ -5,11 +5,14 @@ const { details: X } = assert;
 
 /**
  * @param {Error} innerErr
- * @param {string} label
+ * @param {string|number} label
  * @param {ErrorConstructor=} ErrorConstructor
  * @returns {never}
  */
 export const throwLabeled = (innerErr, label, ErrorConstructor = undefined) => {
+  if (typeof label === 'number') {
+    label = `[${label}]`;
+  }
   const outerErr = assert.error(
     `${label}: ${innerErr.message}`,
     ErrorConstructor,
@@ -23,14 +26,13 @@ harden(throwLabeled);
  * @template A,R
  * @param {(...args: A) => R} func
  * @param {A} args
- * @param {string} [label]
+ * @param {string|number} [label]
  * @returns {R}
  */
 export const applyLabelingError = (func, args, label = undefined) => {
   if (label === undefined) {
     return func(...args);
   }
-  assert.typeof(label, 'string');
   let result;
   try {
     result = func(...args);

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -255,15 +255,28 @@ const makePatternKit = () => {
 
   // /////////////////////// matches ///////////////////////////////////////////
 
-  /** @type {CheckMatches} */
-  const checkMatches = (specimen, patt, check = x => x) => {
+  /**
+   * @param {Passable} specimen
+   * @param {Pattern} pattern
+   * @param {Checker=} check
+   * @param {string|number} [label]
+   * @returns {boolean}
+   */
+  const checkMatches = (specimen, pattern, check = x => x, label = undefined) =>
+    // eslint-disable-next-line no-use-before-define
+    applyLabelingError(checkMatchesInternal, [specimen, pattern, check], label);
+
+  /**
+   * @param {Passable} specimen
+   * @param {Pattern} patt
+   * @param {Checker=} check
+   * @returns {boolean}
+   */
+  const checkMatchesInternal = (specimen, patt, check = x => x) => {
     if (isKey(patt)) {
       // Takes care of all patterns which are keys, so the rest of this
       // logic can assume patterns that are not key.
-      return check(
-        keyEQ(specimen, patt),
-        X`${specimen} - Must be equivalent to: ${patt}`,
-      );
+      return check(keyEQ(specimen, patt), X`${specimen} - Must be: ${patt}`);
     }
     assertPattern(patt);
     const specStyle = passStyleOf(specimen);
@@ -283,7 +296,7 @@ const makePatternKit = () => {
             X`Array ${specimen} - Must be as long as copyArray pattern: ${patt}`,
           );
         }
-        return patt.every((p, i) => checkMatches(specimen[i], p, check));
+        return patt.every((p, i) => checkMatches(specimen[i], p, check, i));
       }
       case 'copyRecord': {
         if (specStyle !== 'copyRecord') {
@@ -295,12 +308,32 @@ const makePatternKit = () => {
         const [specNames, specValues] = recordParts(specimen);
         const [pattNames, pattValues] = recordParts(patt);
         if (!keyEQ(specNames, pattNames)) {
+          const specNameSet = new Set(specNames);
+          const missing = pattNames.filter(name => !specNameSet.has(name));
+          if (missing.length >= 1) {
+            return check(
+              false,
+              X`${specimen} - Must have missing properties ${q(missing)}`,
+            );
+          }
+          const passNameSet = new Set(pattNames);
+          const unexpected = specNames.filter(name => !passNameSet.has(name));
+          assert(
+            unexpected.length >= 1,
+            X`Internal: must have either missing or extra: ${q(
+              specNames,
+            )} vs ${q(pattNames)}`,
+          );
           return check(
             false,
-            X`Record ${specimen} - Must have same property names as record pattern: ${patt}`,
+            X`${specimen} - Must not have unexpected properties: ${q(
+              unexpected,
+            )}`,
           );
         }
-        return checkMatches(specValues, pattValues, check);
+        return pattNames.every((label, i) =>
+          checkMatches(specValues[i], pattValues[i], check, label),
+        );
       }
       case 'tagged': {
         const pattTag = getTag(patt);
@@ -338,7 +371,7 @@ const makePatternKit = () => {
               patt.payload.length === 1,
               X`Non-singleton copySets with matcher not yet implemented: ${patt}`,
             );
-            return checkMatches(specPayload[0], pattPayload[0], check);
+            return checkMatches(specPayload[0], pattPayload[0], check, 0);
           }
           case 'copyMap': {
             if (!checkCopySet(specimen, check)) {
@@ -376,11 +409,10 @@ const makePatternKit = () => {
   /**
    * @param {Passable} specimen
    * @param {Pattern} patt
-   * @param {string} [label]
+   * @param {string|number} [label]
    */
-  const fit = (specimen, patt, label = undefined) => {
-    applyLabelingError(checkMatches, [specimen, patt, assertChecker], label);
-  };
+  const fit = (specimen, patt, label = undefined) =>
+    checkMatches(specimen, patt, assertChecker, label);
 
   // /////////////////////// getRankCover //////////////////////////////////////
 
@@ -494,6 +526,49 @@ const makePatternKit = () => {
     return getPassStyleCover(passStyle);
   };
 
+  /**
+   * @typedef {string} Kind
+   * It is either a PassStyle other than 'tagged', or, if the underlying
+   * PassStyle is 'tagged', then the `getTag` value.
+   *
+   * We cannot further restrict this to only possible passStyles
+   * or known tags, because we wish to allow matching of tags that we
+   * don't know ahead of time. Do we need to separate the namespaces?
+   * TODO are we asking for trouble by lumping passStyles and tags
+   * together into kinds?
+   */
+
+  /**
+   * @param {Passable} specimen
+   * @returns {Kind}
+   */
+  const kindOf = specimen => {
+    const style = passStyleOf(specimen);
+    if (style === 'tagged') {
+      return getTag(specimen);
+    } else {
+      return style;
+    }
+  };
+
+  /**
+   * @param {Passable} specimen
+   * @param {Kind} kind
+   * @param {Checker} [check]
+   */
+  const checkKind = (specimen, kind, check = x => x) => {
+    const specimenKind = kindOf(specimen);
+    if (specimenKind === kind) {
+      return true;
+    }
+    const details = X(
+      // quoting without quotes
+      [`${specimenKind} `, ` - Must be a ${kind}`],
+      specimen,
+    );
+    return check(false, details);
+  };
+
   // /////////////////////// Match Helpers /////////////////////////////////////
 
   /** @type {MatchHelper} */
@@ -545,13 +620,13 @@ const makePatternKit = () => {
       if (length === 0) {
         return check(
           false,
-          X`${specimen} - no pattern disjuncts to match: ${q(patts)}`,
+          X`${specimen} - no pattern disjuncts to match: ${patts}`,
         );
       }
       if (patts.some(patt => matches(specimen, patt))) {
         return true;
       }
-      return check(false, X`${specimen} - Must match one of ${q(patts)}`);
+      return check(false, X`${specimen} - Must match one of ${patts}`);
     },
 
     checkIsMatcherPayload: matchAndHelper.checkIsMatcherPayload,
@@ -625,20 +700,10 @@ const makePatternKit = () => {
 
   /** @type {MatchHelper} */
   const matchKindHelper = Far('M.kind helper', {
-    checkMatches: (specimen, kind, check = x => x) =>
-      check(
-        passStyleOf(specimen) === kind ||
-          (passStyleOf(specimen) === 'tagged' && getTag(specimen) === kind),
-        X`${specimen} - Must have passStyle or tag ${q(kind)}`,
-      ),
+    checkMatches: checkKind,
 
     checkIsMatcherPayload: (allegedKeyKind, check = x => x) =>
       check(
-        // We cannot further restrict this to only possible passStyles
-        // or tags, because we wish to allow matching of tags that we
-        // don't know ahead of time. Do we need to separate the namespaces?
-        // TODO are we asking for trouble by lumping passStyles and tags
-        // together into kinds?
         typeof allegedKeyKind === 'string',
         X`A kind name must be a string: ${allegedKeyKind}`,
       ),
@@ -767,7 +832,7 @@ const makePatternKit = () => {
       check(
         passStyleOf(specimen) === 'copyArray',
         X`${specimen} - Must be an array`,
-      ) && specimen.every(el => checkMatches(el, subPatt, check)),
+      ) && specimen.every((el, i) => checkMatches(el, subPatt, check, i)),
 
     checkIsMatcherPayload: checkPattern,
 
@@ -785,7 +850,7 @@ const makePatternKit = () => {
         X`${specimen} - Must be a record`,
       ) &&
       Object.entries(specimen).every(el =>
-        checkMatches(harden(el), entryPatt, check),
+        checkMatches(harden(el), entryPatt, check, el[0]),
       ),
 
     checkIsMatcherPayload: (entryPatt, check = x => x) =>
@@ -806,7 +871,8 @@ const makePatternKit = () => {
       check(
         passStyleOf(specimen) === 'tagged' && getTag(specimen) === 'copySet',
         X`${specimen} - Must be a a CopySet`,
-      ) && specimen.payload.every(el => checkMatches(el, keyPatt, check)),
+      ) &&
+      specimen.payload.every((el, i) => checkMatches(el, keyPatt, check, i)),
 
     checkIsMatcherPayload: checkPattern,
 
@@ -824,9 +890,9 @@ const makePatternKit = () => {
         X`${specimen} - Must be a a CopyBag`,
       ) &&
       specimen.payload.every(
-        ([key, count]) =>
-          checkMatches(key, keyPatt, check) &&
-          checkMatches(count, countPatt, check),
+        ([key, count], i) =>
+          checkMatches(key, keyPatt, check, `keys[${i}]`) &&
+          checkMatches(count, countPatt, check, `counts[${i}]`),
       ),
 
     checkIsMatcherPayload: (entryPatt, check = x => x) =>
@@ -848,8 +914,12 @@ const makePatternKit = () => {
         passStyleOf(specimen) === 'tagged' && getTag(specimen) === 'copyMap',
         X`${specimen} - Must be a CopyMap`,
       ) &&
-      specimen.payload.keys.every(k => checkMatches(k, keyPatt, check)) &&
-      specimen.payload.values.every(v => checkMatches(v, valuePatt, check)),
+      specimen.payload.keys.every((k, i) =>
+        checkMatches(k, keyPatt, check, `keys[${i}]`),
+      ) &&
+      specimen.payload.values.every((v, i) =>
+        checkMatches(v, valuePatt, check, `values[${i}]`),
+      ),
 
     checkIsMatcherPayload: (entryPatt, check = x => x) =>
       check(
@@ -866,13 +936,9 @@ const makePatternKit = () => {
   /** @type {MatchHelper} */
   const matchSplitHelper = Far('match:split helper', {
     checkMatches: (specimen, [base, rest = undefined], check = x => x) => {
-      const specimenStyle = passStyleOf(specimen);
       const baseStyle = passStyleOf(base);
-      if (specimenStyle !== baseStyle) {
-        return check(
-          false,
-          X`${specimen} - Must have shape of base: ${q(baseStyle)}`,
-        );
+      if (!checkKind(specimen, baseStyle, check)) {
+        return false;
       }
       let specB;
       let specR;
@@ -897,12 +963,8 @@ const makePatternKit = () => {
       harden(specB);
       harden(specR);
       return (
-        checkMatches(specB, base, check) &&
-        (rest === undefined ||
-          check(
-            matches(specR, rest),
-            X`Remainder ${specR} - Must match ${rest}`,
-          ))
+        checkMatches(specB, base, check, 'split-base') &&
+        (rest === undefined || checkMatches(specR, rest, check, 'split-rest'))
       );
     },
 
@@ -937,13 +999,9 @@ const makePatternKit = () => {
   /** @type {MatchHelper} */
   const matchPartialHelper = Far('match:partial helper', {
     checkMatches: (specimen, [base, rest = undefined], check = x => x) => {
-      const specimenStyle = passStyleOf(specimen);
       const baseStyle = passStyleOf(base);
-      if (specimenStyle !== baseStyle) {
-        return check(
-          false,
-          X`${specimen} - Must have shape of base: ${q(baseStyle)}`,
-        );
+      if (!checkKind(specimen, baseStyle, check)) {
+        return false;
       }
       let specB;
       let specR;
@@ -976,12 +1034,8 @@ const makePatternKit = () => {
       harden(specR);
       harden(newBase);
       return (
-        checkMatches(specB, newBase, check) &&
-        (rest === undefined ||
-          check(
-            matches(specR, rest),
-            X`Remainder ${specR} - Must match ${rest}`,
-          ))
+        checkMatches(specB, newBase, check, 'partial-base') &&
+        (rest === undefined || checkMatches(specR, rest, check, 'partial-rest'))
       );
     },
 

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -432,14 +432,6 @@
  */
 
 /**
- * @callback CheckMatches
- * @param {Passable} specimen
- * @param {Pattern} pattern
- * @param {Checker=} check
- * @returns {boolean}
- */
-
-/**
  * @callback CheckPattern
  * @param {Passable} allegedPattern
  * @param {Checker=} check
@@ -564,7 +556,7 @@
 /**
  * @typedef {object} PatternKit
  * @property {(specimen: Passable, patt: Pattern) => boolean} matches
- * @property {(specimen: Passable, patt: Pattern, label?: string) => void} fit
+ * @property {(specimen: Passable, patt: Pattern, label?: string|number) => void} fit
  * @property {(patt: Pattern) => void} assertPattern
  * @property {(patt: Passable) => boolean} isPattern
  * @property {(patt: Pattern) => void} assertKeyPattern
@@ -596,7 +588,7 @@
  *
  * @property {(specimen: Passable,
  *             matcherPayload: Passable,
- *             check?: Checker
+ *             check?: Checker,
  * ) => boolean} checkMatches
  * Assuming a valid Matcher of this type with `matcherPayload` as its
  * payload, does this specimen match that Matcher?

--- a/packages/store/test/test-interface-tools.js
+++ b/packages/store/test/test-interface-tools.js
@@ -1,0 +1,31 @@
+// @ts-check
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { passStyleOf } from '@endo/marshal';
+
+import { I } from '../src/patterns/interface-tools.js';
+import { defineHeapKind } from '../src/patterns/defineHeapKind.js';
+import { M } from '../src/patterns/patternMatchers.js';
+
+test('how far-able is defineHeapKind', t => {
+  const bobIFace = I.interface('bob', {
+    foo: I.call(M.number()).returns(M.undefined()),
+  });
+  const makeBob = defineHeapKind(bobIFace, field => ({ field }), {
+    foo: ({ state, self }, carol) => {
+      t.is(state.field, 8);
+      t.is(typeof self.foo, 'function');
+      t.is(self.foo.name, 'foo');
+      t.is(self.foo.length, 1);
+      t.is(carol, 77);
+      state.field += carol;
+      t.is(state.field, 85);
+    },
+  });
+  const bob = makeBob(8);
+  t.is(passStyleOf(bob), 'remotable');
+  bob.foo(77);
+  t.throws(() => bob.foo(true), {
+    message: /^bob.foo: args: \[0\]: boolean true - Must be a number$/,
+  });
+});

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -15,13 +15,14 @@ import {
 const { entries, fromEntries } = Object;
 
 /**
- * Make a version of the argument function that takes a kind context but ignores it.
+ * Make a version of the argument function that takes a kind context but
+ * ignores it.
  *
  * @type {<T extends Function>(fn: T) => import('./types.js').PlusContext<never, T>}
  */
 export const ignoreContext =
   fn =>
-  (context, ...args) =>
+  (_context, ...args) =>
     fn(...args);
 // @ts-expect-error TODO statically recognize harden
 harden(ignoreContext);

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -222,13 +222,13 @@ test('cleanProposal - other wrong stuff', t => {
     t,
     { exit: 'foo' },
     'nat',
-    /"foo" - Must have shape of base: "copyRecord"/,
+    /^proposal: exit: string "foo" - Must be a copyRecord$/,
   );
   proposeBad(
     t,
     { exit: { onDemand: 'foo' } },
     'nat',
-    /{"onDemand":"foo"} - Must be equivalent to: {"onDemand":null}/,
+    /{"onDemand":"foo"} - Must be: {"onDemand":null}/,
   );
   proposeBad(
     t,
@@ -240,7 +240,7 @@ test('cleanProposal - other wrong stuff', t => {
     t,
     { exit: { afterDeadline: { timer: 'foo', deadline: 3n } } },
     'nat',
-    /"foo" - Must have passStyle or tag "remotable"/,
+    /proposal: exit: partial-base: afterDeadline: timer: string "foo" - Must be a remotable/,
   );
   proposeBad(
     t,
@@ -252,19 +252,19 @@ test('cleanProposal - other wrong stuff', t => {
     t,
     { exit: { afterDeadline: { timer, deadline: 3n, extra: 'foo' } } },
     'nat',
-    /.* - Must have same property names as record pattern:.*/,
+    /proposal: exit: partial-base: afterDeadline: {"timer":"\[Alleged: ManualTimer\]","deadline":"\[3n\]","extra":"foo"} - Must not have unexpected properties: \["extra"\]/,
   );
   proposeBad(
     t,
     { exit: { afterDeadline: { timer } } },
     'nat',
-    /.* - Must have same property names as record pattern:.*/,
+    /proposal: exit: partial-base: afterDeadline: {"timer":"\[Alleged: ManualTimer\]"} - Must have missing properties \["deadline"\]/,
   );
   proposeBad(
     t,
     { exit: { afterDeadline: { deadline: 3n } } },
     'nat',
-    /.* - Must have same property names as record pattern:.*/,
+    /proposal: exit: partial-base: afterDeadline: {"deadline":"\[3n\]"} - Must have missing properties \["timer"\]/,
   );
   proposeBad(
     t,

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -299,13 +299,13 @@ test(`zoeHelper with zcf - fit proposal patterns`, async t => {
   });
 
   t.throws(() => fit(proposal, harden([])), {
-    message: /.* - Must be equivalent to: \[\]/,
+    message: /.* - Must be: \[\]/,
   });
   t.throws(
     () => fit(proposal, M.split({ want: { C: M.any() } })),
     {
       message:
-        /Must have same property names as record pattern: {"C":"\[match:any\]"}/,
+        /want: {"A":{"brand":"\[Alleged: moola brand\]","value":"\[20n\]"}} - Must have missing properties \["C"\]/,
     },
     'empty keywordRecord does not match',
   );
@@ -315,15 +315,14 @@ test(`zoeHelper with zcf - fit proposal patterns`, async t => {
     () => fit(proposal, M.split({ give: { c: M.any() } })),
     {
       message:
-        /Must have same property names as record pattern: {"c":"\[match:any\]"}/,
+        /give: {"B":{"brand":"\[Alleged: simoleans brand\]","value":"\[3n\]"}} - Must have missing properties \["c"\]/,
     },
     'wrong key in keywordRecord does not match',
   );
   t.throws(
     () => fit(proposal, M.split({ exit: { onDemaind: M.any() } })),
     {
-      message:
-        /Must have same property names as record pattern: {"exit":{"onDemaind":"\[match:any\]"}}/,
+      message: /split-base: {} - Must have missing properties \["exit"\]/,
     },
     'missing exit rule',
   );
@@ -619,7 +618,7 @@ test(`zcf/zoeHelper - fit proposal pattern w/bad Expected`, async t => {
   });
 
   t.throws(() => fit(proposal, M.split({ give: { B: moola(3n) } })), {
-    message: /.* - Must be equivalent to: .*/,
+    message: /.* - Must be: .*/,
   });
 });
 

--- a/patches/@endo+marshal+0.6.9.patch
+++ b/patches/@endo+marshal+0.6.9.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/@endo/marshal/src/helpers/remotable.js b/node_modules/@endo/marshal/src/helpers/remotable.js
+index c19adca..645bf10 100644
+--- a/node_modules/@endo/marshal/src/helpers/remotable.js
++++ b/node_modules/@endo/marshal/src/helpers/remotable.js
+@@ -77,6 +77,22 @@ const checkRemotableProtoOf = (original, check = x => x) => {
+    *        }}
+    */
+   const proto = getPrototypeOf(original);
++
++  // From agoric-sdk patch in anticipation of
++  // https://github.com/endojs/endo/pull/1251
++  // TODO: once agoric-sdk is upgraded to depend on that PR, remove this patch.
++  const protoProto = getPrototypeOf(proto);
++  if (
++    typeof original === 'object' &&
++    proto !== objectPrototype &&
++    protoProto !== objectPrototype
++  ) {
++    return (
++      // eslint-disable-next-line no-use-before-define
++      RemotableHelper.canBeValid(proto, check) && checkRemotable(proto, check)
++    );
++  }
++
+   if (
+     !(
+       check(
+@@ -95,8 +111,6 @@ const checkRemotableProtoOf = (original, check = x => x) => {
+     return false;
+   }
+ 
+-  const protoProto = getPrototypeOf(proto);
+-
+   if (typeof original === 'object') {
+     if (
+       !check(


### PR DESCRIPTION
Stacked on https://github.com/Agoric/agoric-sdk/pull/5947

Wraps raw methods with a pattern-based defensive wrapper. Like dynamic type enforcement.

Uses an efficient class-like representation, where all methods of a kind are inherited from a per-kind common object.

Endo marshal patch mirrors https://github.com/endojs/endo/pull/1251