### PR TITLE
feat(run-protocol): convert RunStakeManager to vobj

### DIFF
--- a/packages/run-protocol/src/runStake/attestation.js
+++ b/packages/run-protocol/src/runStake/attestation.js
@@ -211,8 +211,8 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
  * Authorize each account holder to lien some of their staked assets
  * and get an attestation that the lien is in place.
  *
- * @param {ZCF} zcf
- * @param {Brand} stakeBrand
+ * @param {ZCF<import('./runStake').RunStakeTerms>} zcf
+ * @param {Brand<'nat'>} stakeBrand
  * @param {ERef<StakingAuthority>} lienBridge
  *
  * NOTE: the liened amount is kept both here in JS and on the

--- a/packages/run-protocol/src/runStake/attestation.js
+++ b/packages/run-protocol/src/runStake/attestation.js
@@ -211,7 +211,7 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
  * Authorize each account holder to lien some of their staked assets
  * and get an attestation that the lien is in place.
  *
- * @param {ZCF<import('./runStake').RunStakeTerms>} zcf
+ * @param {ZCF} zcf
  * @param {Brand<'nat'>} stakeBrand
  * @param {ERef<StakingAuthority>} lienBridge
  *

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -160,7 +160,7 @@ export const start = async (
   });
 
   const startTimeStamp = await E(timerService).getCurrentTimestamp();
-  const manager = makeRunStakeManager(
+  const { manager } = makeRunStakeManager(
     zcf,
     debtMint,
     harden({ Attestation: attestBrand, debt: debtBrand, Stake: stakeBrand }),

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -153,14 +153,18 @@ export const start = async (
     debtMint.burnLosses(harden({ [KW.Debt]: toBurn }), seat);
   };
 
+  const mintPowers = Far('mintPowers', {
+    burnDebt,
+    getGovernedParams: () => params, // XXX until governance support is durable
+    mintAndReallocate,
+  });
+
   const startTimeStamp = await E(timerService).getCurrentTimestamp();
   const manager = makeRunStakeManager(
     zcf,
     debtMint,
-    { Attestation: attestBrand, debt: debtBrand, Stake: stakeBrand },
-    params,
-    mintAndReallocate,
-    burnDebt,
+    harden({ Attestation: attestBrand, debt: debtBrand, Stake: stakeBrand }),
+    mintPowers,
     { timerService, chargingPeriod, recordingPeriod, startTimeStamp },
   );
 

--- a/packages/run-protocol/src/runStake/runStakeManager.js
+++ b/packages/run-protocol/src/runStake/runStakeManager.js
@@ -13,7 +13,7 @@ import { checkDebtLimit } from '../contractSupport.js';
 
 const { details: X } = assert;
 
-const trace = makeTracer('RM'); // TODO: how to turn this off?
+const trace = makeTracer('RSM', false);
 
 /**
  * @typedef {{

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -108,13 +108,13 @@ const validTransitions = {
  */
 
 /**
- * @typedef {{
+ * @typedef {Readonly<{
  *   state: ImmutableState & MutableState,
  *   facets: {
  *     self: import('@agoric/vat-data/src/types').KindFacet<typeof selfBehavior>,
  *     helper: import('@agoric/vat-data/src/types').KindFacet<typeof helperBehavior>,
  *   },
- * }} MethodContext
+ * }>} MethodContext
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -49,10 +49,10 @@ const { details: X } = assert;
  *  mintAndReallocate: MintAndReallocate,
  * }} FactoryPowersFacet
  *
- * @typedef {{
+ * @typedef {Readonly<{
  *   state: ImmutableState;
  *   facets: import('@agoric/vat-data/src/types').KindFacets<typeof behavior>;
- * }} MethodContext
+ * }>} MethodContext
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -79,7 +79,7 @@ const trace = makeTracer('VM', false);
  */
 
 /**
- * @typedef {{
+ * @typedef {Readonly<{
  *   state: ImmutableState & MutableState,
  *   facets: {
  *     collateral: import('@agoric/vat-data/src/types').KindFacet<typeof collateralBehavior>,
@@ -87,7 +87,7 @@ const trace = makeTracer('VM', false);
  *     manager: import('@agoric/vat-data/src/types').KindFacet<typeof managerBehavior>,
  *     self: import('@agoric/vat-data/src/types').KindFacet<typeof selfBehavior>,
  *   }
- * }} MethodContext
+ * }>} MethodContext
  */
 
 /**


### PR DESCRIPTION
part of #4534

## Description

Converts `RunStakeManager` to be a virtual object. RunStakeKit also needs to be converted (https://github.com/Agoric/agoric-sdk/pull/5168 ) . It's more important since it has higher cardinality, but ordering wise it's better to have this one first. 

It defers the governance param durability to https://github.com/Agoric/agoric-sdk/issues/4343

### Security Considerations

Relies on disk IO for state.

### Documentation Considerations

--

### Testing Considerations

Refactor, existing tests suffice. Durability is not in scope.