### PR TITLE
fix(xsnap): template snapshot reload

### DIFF
--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -48,7 +48,7 @@ then
   SOLO_COINS=40000000000urun \
     "$AG_SETUP_COSMOS_HOME/faucet-helper.sh" add-egress loadgen "$SOLO_ADDR"
   SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
-    --no-stage.save-storage --stages=1 --stage.duration=11 \
+    --no-stage.save-storage --stages=3 --stage.duration=4 \
     --stage.loadgen.vault.interval=12 --stage.loadgen.vault.limit=2 \
     --stage.loadgen.amm.interval=12 --stage.loadgen.amm.wait=6 --stage.loadgen.amm.limit=2 \
     --profile=testnet "--testnet-origin=file://$RESULTSDIR" \


### PR DESCRIPTION
closes #4870 #4911

## Description

Update moddable to upstream, which includes a fix for #4870, which is believe to be the cause of #4911 
Revert removal of restart in CI job to exercise snapshot reload again.

### Security Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

Patch was verified earlier.
Running integration test locally to validate no other issues are introduces, and will kick off a manual integration test in CI as well.
