### PR TITLE
fix: Correct a dead link for package @agoric/cosmos

### DIFF
--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -28,7 +28,7 @@
   "bugs": {
     "url": "https://github.com/Agoric/agoric-sdk/issues"
   },
-  "homepage": "https://github.com/Agoric/agoric-sdk/packages/connector-cosmos",
+  "homepage": "https://github.com/Agoric/agoric-sdk/tree/HEAD/golang/cosmos",
   "eslintConfig": {
     "extends": [
       "@agoric"


### PR DESCRIPTION
## Description

Fix the dead "Homepage" link at https://www.npmjs.com/package/@agoric/cosmos .

### Security Considerations

n/a

### Documentation Considerations

See above.

### Testing Considerations

n/a