### PR TITLE
feat: cli for sending Wallet{Spend}Action transactions

### DIFF
--- a/golang/cosmos/x/swingset/client/cli/tx.go
+++ b/golang/cosmos/x/swingset/client/cli/tx.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	FlagSpend = "spend"
+	FlagAllowSpend = "allow-spend"
 )
 
 func GetTxCmd(storeKey string) *cobra.Command {
@@ -136,7 +136,7 @@ func GetCmdWalletAction() *cobra.Command {
 			owner := clientCtx.GetFromAddress()
 			action := args[0]
 
-			spend, err := cmd.Flags().GetBool(FlagSpend)
+			spend, err := cmd.Flags().GetBool(FlagAllowSpend)
 			if err != nil {
 				return err
 			}
@@ -154,7 +154,7 @@ func GetCmdWalletAction() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Bool(FlagSpend, false, "Send a WalletSpendAction transaction if true")
+	cmd.Flags().Bool(FlagAllowSpend, false, "Allow the WalletAction to spend assets")
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }

--- a/golang/cosmos/x/swingset/types/msgs.go
+++ b/golang/cosmos/x/swingset/types/msgs.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
@@ -91,6 +92,13 @@ func (msg MsgDeliverInbound) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Submitter}
 }
 
+func NewMsgWalletAction(owner sdk.AccAddress, action string) *MsgWalletAction {
+	return &MsgWalletAction{
+		Owner:  owner,
+		Action: action,
+	}
+}
+
 func (msg MsgWalletAction) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Owner}
 }
@@ -103,7 +111,17 @@ func (msg MsgWalletAction) ValidateBasic() error {
 	if len(strings.TrimSpace(msg.Action)) == 0 {
 		return sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "Action cannot be empty")
 	}
+	if !json.Valid([]byte(msg.Action)) {
+		return sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, "Wallet action must be valid JSON")
+	}
 	return nil
+}
+
+func NewMsgWalletSpendAction(owner sdk.AccAddress, spendAction string) *MsgWalletSpendAction {
+	return &MsgWalletSpendAction{
+		Owner:       owner,
+		SpendAction: spendAction,
+	}
 }
 
 func (msg MsgWalletSpendAction) GetSigners() []sdk.AccAddress {
@@ -117,6 +135,9 @@ func (msg MsgWalletSpendAction) ValidateBasic() error {
 	}
 	if len(strings.TrimSpace(msg.SpendAction)) == 0 {
 		return sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "Spend action cannot be empty")
+	}
+	if !json.Valid([]byte(msg.SpendAction)) {
+		return sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, "Wallet spend action must be valid JSON")
 	}
 	return nil
 }

--- a/golang/cosmos/x/swingset/types/msgs_test.go
+++ b/golang/cosmos/x/swingset/types/msgs_test.go
@@ -1,0 +1,90 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var (
+	key  = secp256k1.GenPrivKey()
+	pub  = key.PubKey()
+	addr = sdk.AccAddress(pub.Address())
+)
+
+func TestWalletAction(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		msg       *MsgWalletAction
+		shouldErr bool
+	}{
+		{
+			name:      "empty",
+			msg:       &MsgWalletAction{},
+			shouldErr: true,
+		},
+		{
+			name: "normal",
+			msg:  NewMsgWalletAction(addr, "null"),
+		},
+		{
+			name:      "empty action",
+			msg:       NewMsgWalletAction(addr, ""),
+			shouldErr: true,
+		},
+		{
+			name:      "bad json",
+			msg:       NewMsgWalletAction(addr, "foo"),
+			shouldErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if err != nil && !tt.shouldErr {
+				t.Fatalf("unexpected validation error %s", err)
+			}
+			if err == nil && tt.shouldErr {
+				t.Fatalf("wanted validation error")
+			}
+		})
+	}
+}
+
+func TestWalletSpendAction(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		msg       *MsgWalletSpendAction
+		shouldErr bool
+	}{
+		{
+			name:      "empty",
+			msg:       &MsgWalletSpendAction{},
+			shouldErr: true,
+		},
+		{
+			name: "normal",
+			msg:  NewMsgWalletSpendAction(addr, "null"),
+		},
+		{
+			name:      "empty action",
+			msg:       NewMsgWalletSpendAction(addr, ""),
+			shouldErr: true,
+		},
+		{
+			name:      "bad json",
+			msg:       NewMsgWalletSpendAction(addr, "foo"),
+			shouldErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if err != nil && !tt.shouldErr {
+				t.Fatalf("unexpected validation error %s", err)
+			}
+			if err == nil && tt.shouldErr {
+				t.Fatalf("wanted validation error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes: #5141

## Description

Commands for sending `WalletAction` and `WalletSpendAction` transactions.

### Security Considerations

Ensures address and JSON are valid but performs no other checks.

### Documentation Considerations

Needs long description?

### Testing Considerations

Needs some end-to-end testing, currently difficult to automate.
