### PR TITLE
fix(attestation): handle return of empty attestation

### DIFF
--- a/packages/run-protocol/src/runStake/attestation.js
+++ b/packages/run-protocol/src/runStake/attestation.js
@@ -174,6 +174,10 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
     const {
       give: { [KW.Attestation]: attestationAmount },
     } = seat.getProposal();
+    if (AmountMath.isEmpty(attestationAmount)) {
+      seat.exit();
+      return;
+    }
     const { address, lienedAmount: amountReturned } =
       unwrapLienedAmount(attestationAmount);
 


### PR DESCRIPTION
@samsiegart ran into a bug in handling return of empty attestation:
https://gist.github.com/samsiegart/da0a5a519cc20ec343d962abae1317ef

refs: #3788

### Testing Considerations

includes unit test
