### PR TITLE
style(run-protocol): @jessie-check for runStake

### DIFF
--- a/packages/run-protocol/src/runStake/attestation.js
+++ b/packages/run-protocol/src/runStake/attestation.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { E, Far } from '@endo/far';

--- a/packages/run-protocol/src/runStake/params.js
+++ b/packages/run-protocol/src/runStake/params.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
 

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 import { AmountMath } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
 import { E, Far } from '@endo/far';

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 import { Far } from '@endo/far';
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
@@ -212,8 +213,8 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
     const debt = getCurrentDebt();
     const collateral = getCollateralAllocated(vaultSeat);
 
-    const giveColl = proposal.give[KW.Attestation] || emptyCollateral;
-    const wantColl = proposal.want[KW.Attestation] || emptyCollateral;
+    const giveColl = proposal.give.Attestation || emptyCollateral;
+    const wantColl = proposal.want.Attestation || emptyCollateral;
 
     // new = after the transaction gets applied
     const newCollateral = addSubtract(collateral, giveColl, wantColl);
@@ -221,8 +222,8 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
     const { amountLiened, maxDebt: newMaxDebt } =
       manager.maxDebtForLien(newCollateral);
 
-    const giveRUN = AmountMath.min(proposal.give[KW.Debt] || emptyDebt, debt);
-    const wantRUN = proposal.want[KW.Debt] || emptyDebt;
+    const giveRUN = AmountMath.min(proposal.give.Debt || emptyDebt, debt);
+    const wantRUN = proposal.want.Debt || emptyDebt;
     const giveRUNonly = matches(
       proposal,
       harden({ give: { [KW.Debt]: M.record() }, want: {}, exit: M.any() }),

--- a/packages/run-protocol/src/runStake/runStakeManager.js
+++ b/packages/run-protocol/src/runStake/runStakeManager.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 import { AmountMath } from '@agoric/ertp';
 import { floorMultiplyBy } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';


### PR DESCRIPTION
refs: #3788

Zoe API design question: The only part of this code that wasn't already in Jessie was an attempt to have a single-source of truth for keywords in the contract: `proposal.give[KW.Attestation]`. `proposal.give.Attestation` looks nicer, but it's a use that is not checked against any defining occurrence.
