### PR TITLE
fix(run-protocol): vault debt ratio ordering after interest charges

### DIFF
--- a/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
@@ -27,7 +27,7 @@ export const makeOrderedVaultStore = () => {
    * @param {InnerVault} vault
    */
   const addVault = (vaultId, vault) => {
-    const debt = vault.getCurrentDebt();
+    const debt = vault.getNormalizedDebt();
     const collateral = vault.getCollateralAmount();
     const key = toVaultKey(debt, collateral, vaultId);
     store.init(key, vault);

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -38,17 +38,6 @@ export const currentDebtToCollateral = vault =>
   );
 
 /**
- *
- * @param {InnerVault} vault
- * @returns {Ratio}
- */
-export const normalizedDebtToCollateral = vault =>
-  calculateDebtToCollateral(
-    vault.getNormalizedDebt(),
-    vault.getCollateralAmount(),
-  );
-
-/**
  * InnerVaults, ordered by their liquidation ratio so that all the
  * vaults below a threshold can be quickly found and liquidated.
  *

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -31,9 +31,9 @@ const calculateDebtToCollateral = (debtAmount, collateralAmount) => {
  * @param {InnerVault} vault
  * @returns {Ratio}
  */
-export const currentDebtToCollateral = vault =>
+export const normalizedDebtToCollateral = vault =>
   calculateDebtToCollateral(
-    vault.getCurrentDebt(),
+    vault.getNormalizedDebt(),
     vault.getCollateralAmount(),
   );
 
@@ -108,7 +108,7 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
    */
   const removeVault = key => {
     const vault = vaults.removeByKey(key);
-    const debtToCollateral = currentDebtToCollateral(vault);
+    const debtToCollateral = normalizedDebtToCollateral(vault);
     if (
       !oracleQueryThreshold ||
       ratioGTE(debtToCollateral, oracleQueryThreshold)
@@ -139,7 +139,7 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
   const addVault = (vaultId, vault) => {
     const key = vaults.addVault(vaultId, vault);
 
-    const debtToCollateral = currentDebtToCollateral(vault);
+    const debtToCollateral = normalizedDebtToCollateral(vault);
     rescheduleIfHighest(debtToCollateral);
     return key;
   };
@@ -161,7 +161,7 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
   function* entriesPrioritizedGTE(ratio) {
     // TODO use a Pattern to limit the query https://github.com/Agoric/agoric-sdk/issues/4550
     for (const [key, vault] of vaults.entries()) {
-      const debtToCollateral = currentDebtToCollateral(vault);
+      const debtToCollateral = normalizedDebtToCollateral(vault);
       if (ratioGTE(debtToCollateral, ratio)) {
         yield [key, vault];
       } else {

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -1,60 +1,18 @@
 // @ts-check
 /* global setImmediate */
 
-import { E } from '@endo/far';
-import { AmountMath } from '@agoric/ertp';
-import { Far } from '@endo/marshal';
-import { makeLoopback } from '@endo/captp';
-
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
-import { makeZoeKit } from '@agoric/zoe';
+import binaryVoteCounterBundle from '@agoric/governance/bundles/bundle-binaryVoteCounter.js';
+import committeeBundle from '@agoric/governance/bundles/bundle-committee.js';
+import contractGovernorBundle from '@agoric/governance/bundles/bundle-contractGovernor.js';
 import {
   makeAgoricNamesAccess,
   makePromiseSpace,
 } from '@agoric/vats/src/core/utils.js';
+import { makeZoeKit } from '@agoric/zoe';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
-import committeeBundle from '@agoric/governance/bundles/bundle-committee.js';
-import contractGovernorBundle from '@agoric/governance/bundles/bundle-contractGovernor.js';
-import binaryVoteCounterBundle from '@agoric/governance/bundles/bundle-binaryVoteCounter.js';
-import {
-  floorMultiplyBy,
-  makeRatio,
-} from '@agoric/zoe/src/contractSupport/ratio.js';
-import { reverseInterest } from '../src/interest-math.js';
-
-/**
- * @param {VaultId} vaultId
- * @param {Amount<'nat'>} initDebt
- * @param {Amount<'nat'>} initCollateral
- * @returns {InnerVault & {chargeHundredPercentInterest: () => void, setDebt: (Amount) => void}}
- */
-export const makeFakeInnerVault = (
-  vaultId,
-  initDebt,
-  initCollateral = AmountMath.make(initDebt.brand, 100n),
-) => {
-  let compoundedInterest = makeRatio(100n, initDebt.brand);
-  let normalizedDebt = initDebt;
-  let collateral = initCollateral;
-  const vault = Far('Vault', {
-    chargeHundredPercentInterest: () => {
-      compoundedInterest = makeRatio(
-        compoundedInterest.numerator.value * 2n,
-        initDebt.brand,
-      );
-    },
-    getCollateralAmount: () => collateral,
-    getNormalizedDebt: () => normalizedDebt,
-    getCurrentDebt: () => floorMultiplyBy(normalizedDebt, compoundedInterest),
-    setDebt: newDebt =>
-      (normalizedDebt = reverseInterest(newDebt, compoundedInterest)),
-    setCollateral: newCollateral => (collateral = newCollateral),
-    getIdInManager: () => vaultId,
-    liquidate: () => {},
-  });
-  // @ts-expect-error cast
-  return vault;
-};
+import { makeLoopback } from '@endo/captp';
+import { E } from '@endo/far';
 
 /**
  * @param {*} t

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -16,26 +16,38 @@ import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import committeeBundle from '@agoric/governance/bundles/bundle-committee.js';
 import contractGovernorBundle from '@agoric/governance/bundles/bundle-contractGovernor.js';
 import binaryVoteCounterBundle from '@agoric/governance/bundles/bundle-binaryVoteCounter.js';
+import {
+  floorMultiplyBy,
+  makeRatio,
+} from '@agoric/zoe/src/contractSupport/ratio.js';
+import { reverseInterest } from '../src/interest-math.js';
 
 /**
- *
  * @param {VaultId} vaultId
- * @param {Amount} initDebt
- * @param {Amount} initCollateral
- * @returns {InnerVault & {setDebt: (Amount) => void}}
+ * @param {Amount<'nat'>} initDebt
+ * @param {Amount<'nat'>} initCollateral
+ * @returns {InnerVault & {chargeHundredPercentInterest: () => void, setDebt: (Amount) => void}}
  */
 export const makeFakeInnerVault = (
   vaultId,
   initDebt,
   initCollateral = AmountMath.make(initDebt.brand, 100n),
 ) => {
-  let debt = initDebt;
+  let compoundedInterest = makeRatio(100n, initDebt.brand);
+  let normalizedDebt = initDebt;
   let collateral = initCollateral;
   const vault = Far('Vault', {
+    chargeHundredPercentInterest: () => {
+      compoundedInterest = makeRatio(
+        compoundedInterest.numerator.value * 2n,
+        initDebt.brand,
+      );
+    },
     getCollateralAmount: () => collateral,
-    getNormalizedDebt: () => debt,
-    getCurrentDebt: () => debt,
-    setDebt: newDebt => (debt = newDebt),
+    getNormalizedDebt: () => normalizedDebt,
+    getCurrentDebt: () => floorMultiplyBy(normalizedDebt, compoundedInterest),
+    setDebt: newDebt =>
+      (normalizedDebt = reverseInterest(newDebt, compoundedInterest)),
     setCollateral: newCollateral => (collateral = newCollateral),
     getIdInManager: () => vaultId,
     liquidate: () => {},

--- a/packages/run-protocol/test/vaultFactory/interestSupport.js
+++ b/packages/run-protocol/test/vaultFactory/interestSupport.js
@@ -1,0 +1,56 @@
+import { AmountMath } from '@agoric/ertp';
+import {
+  floorMultiplyBy,
+  makeRatio,
+} from '@agoric/zoe/src/contractSupport/ratio.js';
+import { Far } from '@endo/marshal';
+import { reverseInterest } from '../../src/interest-math.js';
+
+export const makeCompoundedInterestProvider = brand => {
+  let compoundedInterest = makeRatio(100n, brand);
+  return {
+    getCompoundedInterest: () => compoundedInterest,
+    chargeHundredPercentInterest: () => {
+      compoundedInterest = makeRatio(
+        compoundedInterest.numerator.value * 2n,
+        brand,
+      );
+    },
+  };
+};
+/**
+ * @param {VaultId} vaultId
+ * @param {Amount<'nat'>} initDebt
+ * @param {Amount<'nat'>} [initCollateral]
+ * @param {*} [manager]
+ * @returns {InnerVault & {setDebt: (Amount) => void}}
+ */
+
+export const makeFakeInnerVault = (
+  vaultId,
+  initDebt,
+  initCollateral = AmountMath.make(initDebt.brand, 100n),
+  manager = makeCompoundedInterestProvider(initDebt.brand),
+) => {
+  let normalizedDebt = reverseInterest(
+    initDebt,
+    manager.getCompoundedInterest(),
+  );
+  let collateral = initCollateral;
+  const vault = Far('Vault', {
+    getCollateralAmount: () => collateral,
+    getNormalizedDebt: () => normalizedDebt,
+    getCurrentDebt: () =>
+      floorMultiplyBy(normalizedDebt, manager.getCompoundedInterest()),
+    setDebt: newDebt =>
+      (normalizedDebt = reverseInterest(
+        newDebt,
+        manager.getCompoundedInterest(),
+      )),
+    setCollateral: newCollateral => (collateral = newCollateral),
+    getIdInManager: () => vaultId,
+    liquidate: () => {},
+  });
+  // @ts-expect-error cast
+  return vault;
+};

--- a/packages/run-protocol/test/vaultFactory/test-orderedVaultStore.js
+++ b/packages/run-protocol/test/vaultFactory/test-orderedVaultStore.js
@@ -6,17 +6,15 @@ import { AmountMath } from '@agoric/ertp';
 import { Far } from '@endo/marshal';
 import { makeOrderedVaultStore } from '../../src/vaultFactory/orderedVaultStore.js';
 import { fromVaultKey } from '../../src/vaultFactory/storeUtils.js';
+import { makeFakeInnerVault } from './interestSupport.js';
 
 const brand = Far('brand');
 
-const mockVault = (runCount, collateralCount) => {
+const mockVault = (vaultId, runCount, collateralCount) => {
   const debtAmount = AmountMath.make(brand, runCount);
   const collateralAmount = AmountMath.make(brand, collateralCount);
 
-  return Far('vault', {
-    getCurrentDebt: () => debtAmount,
-    getCollateralAmount: () => collateralAmount,
-  });
+  return makeFakeInnerVault(vaultId, debtAmount, collateralAmount);
 };
 
 const BIGGER_INT = BigInt(Number.MAX_VALUE) + 1n;
@@ -44,8 +42,7 @@ test('ordering', t => {
   const vaults = makeOrderedVaultStore();
 
   for (const [vaultId, runCount, collateralCount] of fixture) {
-    const vault = mockVault(runCount, collateralCount);
-    // @ts-expect-error mock
+    const vault = mockVault(vaultId, runCount, collateralCount);
     vaults.addVault(vaultId, vault);
   }
   const contents = Array.from(vaults.entries());
@@ -58,8 +55,7 @@ test('uniqueness', t => {
   const vaults = makeOrderedVaultStore();
 
   for (const [vaultId, runCount, collateralCount] of fixture) {
-    const vault = mockVault(runCount, collateralCount);
-    // @ts-expect-error mock
+    const vault = mockVault(vaultId, runCount, collateralCount);
     vaults.addVault(vaultId, vault);
   }
   const numberParts = Array.from(vaults.entries()).map(


### PR DESCRIPTION
## Description

https://github.com/Agoric/agoric-sdk/pull/4527 made it so that `orderedVaultStore` would maintain ordering by actual debt-to-collateral even as interest was charged. That required ordering by the normalized debt that was stable as interest charges accrurred.

There was a bug in `orderedVaultStore`'s `addVault` that keyed on the debt-to-collateral at the time of addition. This fixes that bug and also the tests that should have caught it.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

New tests with higher fidelity fake vaults.