### PR TITLE
fix: repair types left as <any>

### DIFF
--- a/packages/governance/src/contractGovernance/governParam.js
+++ b/packages/governance/src/contractGovernance/governParam.js
@@ -62,7 +62,7 @@ const validateParamChangeQuestion = details => {
  * assert that the parameter described by paramSpec is proposed to be changed in
  * the question described by questionSpec.
  *
- * @param {any} paramSpec
+ * @param {{ parameterName: string, paramPath: unknown}} paramSpec
  * @param {QuestionSpec<ParamChangeIssue<unknown>>} questionSpec
  */
 const assertBallotConcernsParam = (paramSpec, questionSpec) => {

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -562,7 +562,7 @@
  */
 
 /**
- * @typedef {{key: string, parameterName: string}} StandardParamPath
+ * @typedef {{key: string}} StandardParamPath
  */
 
 /**
@@ -571,10 +571,12 @@
  */
 
 /**
+ * @template [P=StandardParamPath]
+ *
  * @callback VoteOnParamChanges
  * @param {Installation} voteCounterInstallation
  * @param {Timestamp} deadline
- * @param {ParamChangesSpec<any>} paramSpec
+ * @param {ParamChangesSpec<P>} paramSpec
  * @returns {ContractGovernanceVoteResult}
  */
 

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -25,6 +25,7 @@ const voteToChangeParameter = async (
   contractFacetAccess,
   deadline,
 ) => {
+  /** @type {ParamChangesSpec<StandardParamPath>} */
   const paramChangeSpec = harden({
     paramPath: { key: 'governedParams' },
     changes: { [MALLEABLE_NUMBER]: 299792458n },


### PR DESCRIPTION
refs: #5151

## Description

5151 inadvertently declared some types as any. This replaces those with better choices.

### Security Considerations

None

### Documentation Considerations

None

### Testing Considerations

None
