### PR TITLE
feat(ertp): more AmountMath helpers

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -346,6 +346,24 @@ const AmountMath = {
     return !AmountMath.isGTE(leftAmount, rightAmount, brand);
   },
   /**
+   * Returns true if the leftAmount is less than or equal to the
+   * rightAmount.
+   *
+   * For non-scalars, "greater than or equal to" depends on the kind of amount,
+   * as defined by the MathHelpers. For example, whether rectangle A is greater
+   * than rectangle B depends on whether rectangle A includes rectangle B as
+   * defined by the logic in MathHelpers.
+   *
+   * @template {AssetKind} [K=AssetKind]
+   * @param {Amount<K>} leftAmount
+   * @param {Amount<K>} rightAmount
+   * @param {Brand<K>} [brand]
+   * @returns {boolean}
+   */
+  isLTE: (leftAmount, rightAmount, brand) => {
+    return AmountMath.isGTE(rightAmount, leftAmount, brand);
+  },
+  /**
    * Returns true if the leftAmount equals the rightAmount. We assume
    * that if isGTE is true in both directions, isEqual is also true
    *

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -291,11 +291,31 @@ const AmountMath = {
     return h.doIsEmpty(h.doCoerce(value));
   },
   /**
+   * Returns true if the leftAmount is greater than (and not equal to) the
+   * rightAmount.
+   *
+   * For non-scalars, "greater than or equal to" depends on the kind of amount,
+   * as defined by the MathHelpers. For example, whether rectangle A is greater
+   * than rectangle B depends on whether rectangle A includes rectangle B as
+   * defined by the logic in MathHelpers.
+   *
+   * @template {AssetKind} [K=AssetKind]
+   * @param {Amount<K>} leftAmount
+   * @param {Amount<K>} rightAmount
+   * @param {Brand<K>=} brand
+   * @returns {boolean}
+   */
+  isGT: (leftAmount, rightAmount, brand = undefined) => {
+    return !AmountMath.isGTE(rightAmount, leftAmount, brand);
+  },
+  /**
    * Returns true if the leftAmount is greater than or equal to the
-   * rightAmount. For non-scalars, "greater than or equal to" depends
-   * on the kind of amount, as defined by the MathHelpers. For example,
-   * whether rectangle A is greater than rectangle B depends on whether rectangle
-   * A includes rectangle B as defined by the logic in MathHelpers.
+   * rightAmount.
+   *
+   * For non-scalars, "greater than or equal to" depends on the kind of amount,
+   * as defined by the MathHelpers. For example, whether rectangle A is greater
+   * than rectangle B depends on whether rectangle A includes rectangle B as
+   * defined by the logic in MathHelpers.
    *
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} leftAmount
@@ -306,6 +326,24 @@ const AmountMath = {
   isGTE: (leftAmount, rightAmount, brand = undefined) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
     return h.doIsGTE(...coerceLR(h, leftAmount, rightAmount));
+  },
+  /**
+   * Returns true if the leftAmount is less than (not equal to) the
+   * rightAmount.
+   *
+   * For non-scalars, "greater than or equal to" depends on the kind of amount,
+   * as defined by the MathHelpers. For example, whether rectangle A is greater
+   * than rectangle B depends on whether rectangle A includes rectangle B as
+   * defined by the logic in MathHelpers.
+   *
+   * @template {AssetKind} [K=AssetKind]
+   * @param {Amount<K>} leftAmount
+   * @param {Amount<K>} rightAmount
+   * @param {Brand<K>=} brand
+   * @returns {boolean}
+   */
+  isLT: (leftAmount, rightAmount, brand = undefined) => {
+    return !AmountMath.isGTE(leftAmount, rightAmount, brand);
   },
   /**
    * Returns true if the leftAmount equals the rightAmount. We assume

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -149,7 +149,7 @@ const optionalBrandCheck = (allegedBrand, brand) => {
  * @param {Brand<K> | undefined} brand
  * @returns {MathHelpers<*>}
  */
-const checkLRAndGetHelpers = (leftAmount, rightAmount, brand = undefined) => {
+const checkLRAndGetHelpers = (leftAmount, rightAmount, brand) => {
   assertRecord(leftAmount, 'leftAmount');
   assertRecord(rightAmount, 'rightAmount');
   const { value: leftValue, brand: leftBrand } = leftAmount;
@@ -282,7 +282,7 @@ const AmountMath = {
    * @param {Brand=} brand
    * @returns {boolean}
    */
-  isEmpty: (amount, brand = undefined) => {
+  isEmpty: (amount, brand) => {
     assertRecord(amount, 'amount');
     const { brand: allegedBrand, value } = amount;
     assertRemotable(allegedBrand, 'brand');
@@ -302,10 +302,10 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} leftAmount
    * @param {Amount<K>} rightAmount
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {boolean}
    */
-  isGT: (leftAmount, rightAmount, brand = undefined) => {
+  isGT: (leftAmount, rightAmount, brand) => {
     return !AmountMath.isGTE(rightAmount, leftAmount, brand);
   },
   /**
@@ -320,10 +320,10 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} leftAmount
    * @param {Amount<K>} rightAmount
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {boolean}
    */
-  isGTE: (leftAmount, rightAmount, brand = undefined) => {
+  isGTE: (leftAmount, rightAmount, brand) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
     return h.doIsGTE(...coerceLR(h, leftAmount, rightAmount));
   },
@@ -339,10 +339,10 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} leftAmount
    * @param {Amount<K>} rightAmount
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {boolean}
    */
-  isLT: (leftAmount, rightAmount, brand = undefined) => {
+  isLT: (leftAmount, rightAmount, brand) => {
     return !AmountMath.isGTE(leftAmount, rightAmount, brand);
   },
   /**
@@ -370,10 +370,10 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} leftAmount
    * @param {Amount<K>} rightAmount
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {boolean}
    */
-  isEqual: (leftAmount, rightAmount, brand = undefined) => {
+  isEqual: (leftAmount, rightAmount, brand) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
     return h.doIsEqual(...coerceLR(h, leftAmount, rightAmount));
   },
@@ -387,10 +387,10 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} leftAmount
    * @param {Amount<K>} rightAmount
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {Amount<K>}
    */
-  add: (leftAmount, rightAmount, brand = undefined) => {
+  add: (leftAmount, rightAmount, brand) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
     const value = h.doAdd(...coerceLR(h, leftAmount, rightAmount));
     return harden({ brand: leftAmount.brand, value });
@@ -406,10 +406,10 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} leftAmount
    * @param {Amount<K>} rightAmount
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {Amount<K>}
    */
-  subtract: (leftAmount, rightAmount, brand = undefined) => {
+  subtract: (leftAmount, rightAmount, brand) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
     const value = h.doSubtract(...coerceLR(h, leftAmount, rightAmount));
     return harden({ brand: leftAmount.brand, value });
@@ -420,20 +420,20 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} x
    * @param {Amount<K>} y
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {Amount<K>}
    */
-  min: (x, y, brand = undefined) => (AmountMath.isGTE(x, y, brand) ? y : x),
+  min: (x, y, brand) => (AmountMath.isGTE(x, y, brand) ? y : x),
   /**
    * Returns the max value between x and y using isGTE
    *
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} x
    * @param {Amount<K>} y
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {Amount<K>}
    */
-  max: (x, y, brand = undefined) => (AmountMath.isGTE(x, y, brand) ? x : y),
+  max: (x, y, brand) => (AmountMath.isGTE(x, y, brand) ? x : y),
 };
 harden(AmountMath);
 

--- a/packages/ERTP/test/unitTests/test-amountProperties.js
+++ b/packages/ERTP/test/unitTests/test-amountProperties.js
@@ -2,6 +2,7 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { makeCopyBag } from '@agoric/store';
 import fc from 'fast-check';
 
+import { q } from '@agoric/assert';
 import { AmountMath as m, AssetKind } from '../../src/index.js';
 import { mockBrand } from './mathHelpers/mockBrand.js';
 import { assertionPassed } from '../../../store/test/test-store.js';
@@ -59,6 +60,21 @@ test('isEqual is a (total) equivalence relation', async t => {
   );
 });
 
+test('isGT definition', async t => {
+  await fc.assert(
+    fc.property(fc.record({ x: arbAmount, y: arbAmount }), ({ x, y }) => {
+      const definition = m.isGTE(x, y) && !m.isEqual(x, y);
+      console.log('DEBUG x', x.value);
+      console.log('DEBUG y', y.value);
+      console.log('DEBUG isGTE', m.isGTE(x, y));
+      console.log('DEBUG isEqual', m.isEqual(x, y));
+      console.log('DEBUG definition', definition);
+      console.log('DEBUG actual isGT', m.isGT(x, y));
+      return t.is(m.isGT(x, y), definition);
+    }),
+  );
+});
+
 test('isGTE is a partial order with empty as minimum', async t => {
   const empty = m.makeEmpty(mockBrand, AssetKind.COPY_BAG);
   await fc.assert(
@@ -77,6 +93,30 @@ test('isGTE is a partial order with empty as minimum', async t => {
           () => implies(m.isGTE(x, y) && m.isGTE(y, x), m.isEqual(x, y)),
         )
       );
+    }),
+  );
+});
+
+test('isLT definition', async t => {
+  await fc.assert(
+    fc.property(fc.record({ x: arbAmount, y: arbAmount }), ({ x, y }) => {
+      const definition = !m.isGTE(x, y);
+      return t.is(m.isLT(x, y), definition);
+    }),
+  );
+});
+
+test.only('isLTE definition', async t => {
+  await fc.assert(
+    fc.property(fc.record({ x: arbAmount, y: arbAmount }), ({ x, y }) => {
+      const definition = !m.isGTE(x, y) || m.isEqual(x, y);
+      console.log('DEBUG x', x.value);
+      console.log('DEBUG y', y.value);
+      console.log('DEBUG isGTE', m.isGTE(x, y));
+      console.log('DEBUG isEqual', m.isEqual(x, y));
+      console.log('DEBUG definition', definition);
+      console.log('DEBUG actual isLTE', m.isLTE(x, y));
+      return t.is(m.isLTE(x, y), definition);
     }),
   );
 });

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -10,26 +10,6 @@ import { makeNotifier } from '@agoric/notifier';
 import '../../exported.js';
 
 /**
- * @callback CompareAmount
- * @param {Amount} amount
- * @param {Amount} amountLimit
- * @returns {boolean}
- */
-
-/** @type {CompareAmount} */
-const isLT = (amountOut, amountLimit) =>
-  !AmountMath.isGTE(amountOut, amountLimit);
-
-/** @type {CompareAmount} */
-const isLTE = (amount, amountLimit) => AmountMath.isGTE(amountLimit, amount);
-
-/** @type {CompareAmount} */
-const isGTE = (amount, amountLimit) => AmountMath.isGTE(amount, amountLimit);
-
-/** @type {CompareAmount} */
-const isGT = (amount, amountLimit) => !AmountMath.isGTE(amountLimit, amount);
-
-/**
  * @typedef {Object} OnewayPriceAuthorityOptions
  * @property {Issuer} quoteIssuer
  * @property {ERef<Notifier<Timestamp>>} notifier
@@ -87,7 +67,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
   /**
    * Create a quoteWhen* function.
    *
-   * @param {CompareAmount} compareAmountsFn
+   * @param {(l: Amount, r: Amount) => boolean} compareAmountsFn
    */
   const makeQuoteWhenOut = compareAmountsFn =>
     /**
@@ -333,14 +313,14 @@ export function makeOnewayPriceAuthorityKit(opts) {
       // Wait until the wakeup passes.
       return quotePK.promise;
     },
-    quoteWhenLT: makeQuoteWhenOut(isLT),
-    quoteWhenLTE: makeQuoteWhenOut(isLTE),
-    quoteWhenGTE: makeQuoteWhenOut(isGTE),
-    quoteWhenGT: makeQuoteWhenOut(isGT),
-    mutableQuoteWhenLT: makeMutableQuote(isLT),
-    mutableQuoteWhenLTE: makeMutableQuote(isLTE),
-    mutableQuoteWhenGT: makeMutableQuote(isGT),
-    mutableQuoteWhenGTE: makeMutableQuote(isGTE),
+    quoteWhenLT: makeQuoteWhenOut(AmountMath.isLT),
+    quoteWhenLTE: makeQuoteWhenOut(AmountMath.isLTE),
+    quoteWhenGTE: makeQuoteWhenOut(AmountMath.isGTE),
+    quoteWhenGT: makeQuoteWhenOut(AmountMath.isGT),
+    mutableQuoteWhenLT: makeMutableQuote(AmountMath.isLT),
+    mutableQuoteWhenLTE: makeMutableQuote(AmountMath.isLTE),
+    mutableQuoteWhenGT: makeMutableQuote(AmountMath.isGT),
+    mutableQuoteWhenGTE: makeMutableQuote(AmountMath.isGTE),
   });
 
   return { priceAuthority, adminFacet: { fireTriggers } };


### PR DESCRIPTION
## Description

I needed `isGT` and I thought it would be useful to have in `AmountMath`. I wondered with `priceAuthority.js` had defined them there instead of AmountMath. By trying to implement, I learned a little more about non-Nat amounts. Is it feasible to have generic definitions for all amount kinds?

If not, would it be okay to have a NatMath utility that works with `Amount<'nat'>`?

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
