### PR TITLE
ci: eslint and fix .ts files

### DIFF
--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -12,7 +12,7 @@
     "build:gyp-debug": "make compile-gyp GYP_DEBUG=--debug",
     "test:xs": "exit 0",
     "build": "exit 0",
-    "lint-fix": "eslint --fix '**/*.{cjs,js}'",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint": "eslint '**/*.{cjs,js}'"
   },
   "dependencies": {

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -15,7 +15,7 @@
     "test:xs-worker": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 'test/swingsetTests/**/test-*.js'",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json"
   },
   "repository": {

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -18,7 +18,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "yarn lint:types&&yarn lint:eslint",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
-    "lint:eslint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "devDependencies": {
     "@agoric/vat-data": "^0.2.0",

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -13,7 +13,7 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "dependencies": {
     "@agoric/assert": "^0.4.0",

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -12,7 +12,7 @@
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint --ext .js,.ts ."
   },
   "dependencies": {

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -18,7 +18,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
-    "lint:eslint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "devDependencies": {
     "@agoric/swingset-vat": "^0.26.0",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -14,7 +14,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
-    "lint:eslint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "keywords": [],
   "author": "Agoric",

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -12,7 +12,7 @@
     "test": "ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:eslint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc --maxNodeModuleJsDepth 5 -p jsconfig.json",
     "lint": "run-s --continue-on-error lint:*"
   },

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -13,7 +13,7 @@
     "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -12,7 +12,7 @@
     "test": "exit 0",
     "test:xs": "exit 0",
     "build": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": "https://github.com/Agoric/agoric-sdk",

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -15,7 +15,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json"
   },
   "repository": {

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -13,7 +13,7 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {
     "type": "git",

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -12,7 +12,7 @@
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -14,7 +14,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json"
   },
   "repository": {

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -15,7 +15,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json"
   },
   "repository": {

--- a/packages/run-protocol/package.json
+++ b/packages/run-protocol/package.json
@@ -15,7 +15,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc --maxNodeModuleJsDepth 5 -p jsconfig.json"
   },
   "repository": {

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -12,7 +12,7 @@
     "test": "exit 0",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {
     "type": "git",

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -11,7 +11,7 @@
     "build": "exit 0",
     "test": "exit 0",
     "test:xs": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -13,7 +13,7 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {
     "type": "git",

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -12,7 +12,7 @@
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
-    "lint:eslint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "keywords": [],
   "author": "Agoric",

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -12,7 +12,7 @@
     "test": "exit 0",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {
     "type": "git",

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -11,7 +11,7 @@
     "build": "exit 0",
     "test": "exit 0",
     "test:xs": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -14,7 +14,7 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {
     "type": "git",

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -13,7 +13,7 @@
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -12,7 +12,7 @@
     "test": "exit 0",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "peerDependencies": {
     "canvas": "^2.6.1",

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -11,7 +11,7 @@
     "build": "exit 0",
     "test": "exit 0",
     "test:xs": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint --ext .js,.ts ."
   },
   "peerDependencies": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,7 +14,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
-    "lint:eslint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "repository": {
     "type": "git",

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc -p jsconfig.json",
-    "lint:eslint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "dependencies": {
     "@agoric/assert": "^0.4.0",

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -13,7 +13,7 @@
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint --ext .js,.ts .",
     "ci:autobench": "./autobench.js"
   },

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -14,7 +14,7 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "ci:autobench": "./autobench.js"
   },
   "dependencies": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -13,7 +13,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
-    "lint:eslint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "bin": {
     "frcat": "./src/frcat-entrypoint.js"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -27,7 +27,7 @@
     "build": "yarn build:src && yarn build:tests",
     "lint-fix": "yarn lint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json"
   },
   "eslintConfig": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -25,7 +25,7 @@
     "build:tests": "rm -rf compiled && BABEL_ENV='test' ./node_modules/.bin/babel test/components --out-dir compiled/test/components",
     "build:src": "rm -rf dist && BABEL_ENV='test' ./node_modules/.bin/babel src --out-dir dist",
     "build": "yarn build:src && yarn build:tests",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json"

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -12,7 +12,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc"
   },
   "keywords": [],

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -19,7 +19,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
-    "lint:eslint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "keywords": [],
   "author": "Agoric",

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -11,7 +11,7 @@
     "lint": "run-s --continue-on-error lint:*",
     "lint-fix": "yarn lint:eslint --fix",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
-    "lint:eslint": "eslint '**/*.js'"
+    "lint:eslint": "eslint --ext .js,.ts ."
   },
   "devDependencies": {
     "@agoric/deploy-script-support": "^0.7.0",

--- a/packages/wallet/ui/package.json
+++ b/packages/wallet/ui/package.json
@@ -47,7 +47,7 @@
     "build:ses": "cp ../../../node_modules/ses/dist/lockdown.umd.js public/",
     "build:react": "react-scripts build",
     "lint": "eslint '**/*.{js,jsx}'",
-    "lint-fix": "eslint --fix '**/*.{js,jsx}'",
+    "lint-fix": "yarn lint:eslint --fix",
     "test": "CI=true react-scripts test",
     "test:watch": "react-scripts test",
     "test:xs": "exit 0",

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -20,7 +20,7 @@
     "build-zcfBundle": "yarn build:bundles",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint '**/*.js'",
+    "lint:eslint": "eslint --ext .js,.ts .",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json"
   },
   "repository": {


### PR DESCRIPTION
## Description

Each package has its own lint glob but formatting (with Prettier) is configured repo-wide. When a developer runs `yarn lint` in a package, it may not lint the same files that the formatting check covers.

Eventually I think we should separate auto-formatting concerns from linting (https://github.com/Agoric/agoric-sdk/issues/4339 ) but until then the `yarn lint` command should cover the same files that CI reports in the "lint" job.

This changes the per-package config to include .ts files, using `ext` instead of a glob.

It also makes `lint-fix` re-use the `lint:eslint` command to ensure it always fixes the same set of files.

I tried to make `.ts` inclusion be at the repo level but can't due to https://github.com/eslint/eslint/issues/11223

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

- [x] introduce a prettier deviation into a .ts file and confirm that `lint-fix` corrects it