### PR TITLE
fix: hotfix for @endo/init#1166

### DIFF
--- a/patches/@endo+init+0.5.41.patch
+++ b/patches/@endo+init+0.5.41.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@endo/init/src/node-async_hooks.js b/node_modules/@endo/init/src/node-async_hooks.js
+index d212650..fb6768d 100644
+--- a/node_modules/@endo/init/src/node-async_hooks.js
++++ b/node_modules/@endo/init/src/node-async_hooks.js
+@@ -172,7 +172,8 @@ const getAsyncHookSymbolPromiseProtoDesc = (
+     if (Object.isExtensible(this)) {
+       Object.defineProperty(this, symbol, {
+         value,
+-        writable: false,
++        // Workaround a Node bug setting the destroyed sentinel multiple times
++        writable: disallowGet,
+         configurable: false,
+         enumerable: false,
+       });


### PR DESCRIPTION
Integrate https://github.com/endojs/endo/pull/1166 as a patch so that we don't need to wait for a full release crank.