### PR TITLE
feat(swingset-vat): Include alleged bundleID in checkBundle diagnostics

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -318,7 +318,7 @@ export async function makeSwingsetController(
    * Validate and install a code bundle.
    *
    * @param { EndoZipBase64Bundle } bundle
-   * @param { BundleID? } allegedBundleID
+   * @param { BundleID } [allegedBundleID]
    * @returns { Promise<BundleID> }
    */
   async function validateAndInstallBundle(bundle, allegedBundleID) {
@@ -335,7 +335,7 @@ export async function makeSwingsetController(
       ),
       `Bundle with alleged ID ${allegedBundleID} must be a frozen object with only string value properties, no accessors`,
     );
-    await checkBundle(bundle, computeSha512);
+    await checkBundle(bundle, computeSha512, allegedBundleID);
     const { endoZipBase64Sha512 } = bundle;
     assert.typeof(endoZipBase64Sha512, 'string');
     const bundleID = `b1-${endoZipBase64Sha512}`;


### PR DESCRIPTION

## Description

Recent bundle caching introduced a class of errors that is difficult to inspect.
This change threads the bundle ID through to checkBundle so it can be included in error messages.
Further work in checkBundle finishes threading the diagnostic bundle name through to the error message in question.

See: https://github.com/endojs/endo/pull/1167

