### PR TITLE
feat(vat-data): partialAssign function

### DIFF
--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -66,3 +66,15 @@ export const pickFacet =
   (maker, facetName) =>
   (...args) =>
     maker(...args)[facetName];
+
+/**
+ * Assign the values of all of the enumerable own properties from the source
+ * object to their keys in the target object.
+ *
+ * @template T
+ * @param {T} target
+ * @param {Partial<T>} source
+ */
+export const partialAssign = (target, source) => {
+  Object.assign(target, source);
+};

--- a/packages/vat-data/src/index.test-d.ts
+++ b/packages/vat-data/src/index.test-d.ts
@@ -5,6 +5,7 @@ import {
   defineKindMulti,
   makeKindHandle,
   defineDurableKind,
+  partialAssign,
 } from '.';
 import { KindFacets, DurableKindHandle, KindFacet } from './types.js';
 
@@ -131,3 +132,11 @@ const foo = makeFoo('Doody');
 expectType<string>(foo.sayHi());
 // @ts-expect-error missing method
 foo.sayBye();
+
+// partialAssign
+const state = { name: 'ted', color: 'red' };
+partialAssign(state, { name: 'ed' });
+// @ts-expect-error
+partialAssign(state, { key: 'ted' });
+// @ts-expect-error
+partialAssign(state, { name: 3 });


### PR DESCRIPTION
## Description
With virtual objects we need to update properties of a `state` object. Destructuring would be nice but it would require assignment to the `state` object and it has to be mutated. `Object.assign` does this but without any type safety.

This adds a `partialAssign` method that's like `Object.assign` but only takes one source object and enforces that it's a subset of the target object.

### Security Considerations

--
### Documentation Considerations

--

### Testing Considerations

Types test. Implementation too trivial to test.

