### PR TITLE
refactor(run-protocol): RunStakeKit facets for vobj

### DIFF
--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -164,13 +164,30 @@ export const start = async (
     { timerService, chargingPeriod, recordingPeriod, startTimeStamp },
   );
 
+  /**
+   * @param {ZCFSeat} seat
+   */
+  const offerHandler = seat => {
+    const { helper, pot } = makeRunStakeKit(zcf, seat, manager);
+
+    return harden({
+      publicNotifiers: {
+        asset: manager.getAssetNotifier(),
+        vault: pot.getNotifier(),
+      },
+      invitationMakers: Far('invitation makers', {
+        AdjustBalances: () =>
+          zcf.makeInvitation(helper.adjustBalancesHook, 'AdjustBalances'),
+        CloseVault: () => zcf.makeInvitation(helper.closeHook, 'CloseVault'),
+      }),
+      vault: Far('RUNstake pot', pot),
+    });
+  };
+
   const publicFacet = augmentPublicFacet(
     Far('runStake public', {
       makeLoanInvitation: () =>
-        zcf.makeInvitation(
-          seat => makeRunStakeKit(zcf, seat, manager),
-          'make RUNstake',
-        ),
+        zcf.makeInvitation(offerHandler, 'make RUNstake'),
       makeReturnAttInvitation: att.publicFacet.makeReturnAttInvitation,
     }),
   );

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -41,8 +41,10 @@ const calculateFee = (feeCoeff, currentDebt, giveAmount, wantAmount) => {
  *   debtBrand: Brand,
  *   emptyCollateral: Amount<'copyBag'>,
  *   emptyDebt: Amount<'nat'>,
+ *   manager: import('./runStakeManager.js').RunStakeManager,
  *   notifier: NotifierRecord<unknown>['notifier'],
  *   vaultSeat: ZCFSeat,
+ *   zcf: ZCF,
  * }>} ImmutableState
  * @typedef {{
  *   open: boolean,
@@ -122,8 +124,10 @@ const initState = (zcf, startSeat, manager) => {
     debtBrand,
     emptyCollateral, // XXX not worth keeping on disk
     emptyDebt, // XXX not worth keeping on disk
+    manager,
     notifier,
     vaultSeat,
+    zcf,
   };
   return {
     ...fixed,

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-use-before-define */
 // @ts-check
 // @jessie-check
 import { AmountMath, AssetKind } from '@agoric/ertp';
@@ -241,6 +240,7 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
       const proposal = clientSeat.getProposal();
       assertOnlyKeys(proposal, [KW.Attestation, KW.Debt]);
 
+      // eslint-disable-next-line no-use-before-define
       const debt = pot.getCurrentDebt();
       const collateral = helper.getCollateralAllocated(vaultSeat);
 
@@ -313,6 +313,7 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
         want: { [KW.Attestation]: null },
       });
 
+      // eslint-disable-next-line no-use-before-define
       const currentDebt = pot.getCurrentDebt();
       const {
         give: { [KW.Debt]: runOffered },

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -240,7 +240,7 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
       const proposal = clientSeat.getProposal();
       assertOnlyKeys(proposal, [KW.Attestation, KW.Debt]);
 
-      const debt = vault.getCurrentDebt();
+      const debt = pot.getCurrentDebt();
       const collateral = helper.getCollateralAllocated(vaultSeat);
 
       const giveColl = proposal.give.Attestation || emptyCollateral;
@@ -312,7 +312,7 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
         want: { [KW.Attestation]: null },
       });
 
-      const currentDebt = vault.getCurrentDebt();
+      const currentDebt = pot.getCurrentDebt();
       const {
         give: { [KW.Debt]: runOffered },
       } = seat.getProposal();
@@ -342,7 +342,7 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
     },
   };
 
-  const vault = Far('RUNstake', {
+  const pot = {
     getNotifier: () => state.notifier,
     makeAdjustBalancesInvitation: () => {
       assert(state.open);
@@ -373,20 +373,20 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
     },
     getNormalizedDebt: () =>
       reverseInterest(state.debtSnapshot, state.interestSnapshot),
-  });
+  };
 
   helper.updateUiState();
 
   return harden({
     publicNotifiers: {
       asset: manager.getAssetNotifier(),
-      vault: state.notifier,
+      vault: pot.getNotifier(),
     },
     invitationMakers: Far('invitation makers', {
       AdjustBalances: () =>
         zcf.makeInvitation(helper.adjustBalancesHook, 'AdjustBalances'),
       CloseVault: () => zcf.makeInvitation(helper.closeHook, 'CloseVault'),
     }),
-    vault,
+    vault: Far('RUNstake pot', pot),
   });
 };

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -1,8 +1,6 @@
-// FIXME fix lint before merge
 /* eslint-disable no-use-before-define */
 // @ts-check
 // @jessie-check
-import { Far } from '@endo/far';
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 import { ceilMultiplyBy } from '@agoric/zoe/src/contractSupport/ratio.js';
@@ -377,16 +375,5 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
 
   helper.updateUiState();
 
-  return harden({
-    publicNotifiers: {
-      asset: manager.getAssetNotifier(),
-      vault: pot.getNotifier(),
-    },
-    invitationMakers: Far('invitation makers', {
-      AdjustBalances: () =>
-        zcf.makeInvitation(helper.adjustBalancesHook, 'AdjustBalances'),
-      CloseVault: () => zcf.makeInvitation(helper.closeHook, 'CloseVault'),
-    }),
-    vault: Far('RUNstake pot', pot),
-  });
+  return { helper, pot };
 };

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -141,7 +141,6 @@ const initState = (zcf, startSeat, manager) => {
  * @param {ZCF} zcf
  * @param {ZCFSeat} startSeat
  * @param {import('./runStakeManager.js').RunStakeManager} manager
- * return value follows the wallet invitationMakers pattern
  * @throws {Error} if startSeat proposal is not consistent with governance parameters in manager
  */
 export const makeRunStakeKit = (zcf, startSeat, manager) => {


### PR DESCRIPTION
part of https://github.com/Agoric/agoric-sdk/issues/4534

## Description

Refactors `runStakeKit.js` to support virtual objects. Principally:
- initial state is constructed in a single `initState`
- facets to be exposed on the vobj are named (`helper` and `pot` for what holds the stake, fka `vault` which has another meaning)
- offer result concern is moved to the contract

Probably easiest to review by commit. I'll try avoid rebasing and instead make add fixup commits.

### Security Considerations

--

### Documentation Considerations

"Pot" term, which may not last long. I thought it better than "vault" even for now.

### Testing Considerations

Existing tests since purely refactor.