### PR TITLE
refactor(run-protocol): convert runStakeKit to vobj

### DIFF
--- a/packages/run-protocol/src/runStake/attestation.js
+++ b/packages/run-protocol/src/runStake/attestation.js
@@ -5,13 +5,9 @@ import { AmountMath, AssetKind } from '@agoric/ertp';
 import { E, Far } from '@endo/far';
 import { fit, M, makeCopyBag, makeStore } from '@agoric/store';
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
+import { AttKW as KW } from './constants.js';
 
 const { details: X } = assert;
-
-export const KW = /** @type { const } */ ({
-  /** seat keyword for use in offers to return an attestation. */
-  Attestation: 'Attestation',
-});
 
 /**
  * Find-or-create value in store.

--- a/packages/run-protocol/src/runStake/constants.js
+++ b/packages/run-protocol/src/runStake/constants.js
@@ -1,0 +1,16 @@
+export const AttKW = /** @type { const } */ ({
+  /** seat keyword for use in offers to return an attestation. */
+  Attestation: 'Attestation',
+});
+
+export const ManagerKW = /** @type { const } */ ({
+  [AttKW.Attestation]: AttKW.Attestation,
+  Debt: 'Debt',
+});
+
+export const ParamKW = /** @type { const } */ ({
+  DebtLimit: 'DebtLimit',
+  MintingRatio: 'MintingRatio',
+  InterestRate: 'InterestRate',
+  LoanFee: 'LoanFee',
+});

--- a/packages/run-protocol/src/runStake/params.js
+++ b/packages/run-protocol/src/runStake/params.js
@@ -2,19 +2,7 @@
 // @jessie-check
 
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
-import { KW as AttKW } from './attestation.js';
-
-export const KW = /** @type { const } */ ({
-  [AttKW.Attestation]: AttKW.Attestation,
-  Debt: 'Debt',
-});
-
-const PKey = /** @type { const } */ ({
-  DebtLimit: 'DebtLimit',
-  MintingRatio: 'MintingRatio',
-  InterestRate: 'InterestRate',
-  LoanFee: 'LoanFee',
-});
+import { ParamKW as PKey } from './constants.js';
 
 export const makeRunStakeTerms = (
   { timerService, chargingPeriod, recordingPeriod },

--- a/packages/run-protocol/src/runStake/params.js
+++ b/packages/run-protocol/src/runStake/params.js
@@ -2,10 +2,12 @@
 // @jessie-check
 
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
+import { KW as AttKW } from './attestation.js';
 
-import { KW } from './runStakeKit.js';
-
-export { KW };
+export const KW = /** @type { const } */ ({
+  [AttKW.Attestation]: AttKW.Attestation,
+  Debt: 'Debt',
+});
 
 const PKey = /** @type { const } */ ({
   DebtLimit: 'DebtLimit',

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -4,7 +4,8 @@ import { AmountMath } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
 import { E, Far } from '@endo/far';
 import { makeAttestationFacets } from './attestation.js';
-import { makeRunStakeKit, KW } from './runStakeKit.js';
+import { ManagerKW as KW } from './constants.js';
+import { makeRunStakeKit } from './runStakeKit.js';
 import { makeRunStakeManager } from './runStakeManager.js';
 
 const { details: X } = assert;

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -184,7 +184,7 @@ export const start = async (
           zcf.makeInvitation(helper.adjustBalancesHook, 'AdjustBalances'),
         CloseVault: () => zcf.makeInvitation(helper.closeHook, 'CloseVault'),
       }),
-      vault: Far('RUNstake pot', pot),
+      vault: pot,
     });
   };
 

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -9,16 +9,11 @@ import { defineKindMulti } from '@agoric/vat-data';
 import { makeTracer } from '../makeTracer.js';
 import { addSubtract, assertOnlyKeys, stageDelta } from '../contractSupport.js';
 import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
-import { KW as AttKW } from './attestation.js';
+import { KW } from './params.js';
 
 const { details: X, quote: q } = assert;
 
 const trace = makeTracer('R1');
-
-export const KW = /** @type { const } */ ({
-  [AttKW.Attestation]: AttKW.Attestation,
-  Debt: 'Debt',
-});
 
 /**
  * Calculate the fee, the amount to mint and the resulting debt.

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -154,6 +154,7 @@ const helperBehavior = {
    */
   getCollateralAmount: ({ state, facets }) => {
     const { collateralBrand, vaultSeat } = state;
+    const { helper } = facets;
     const emptyCollateral = AmountMath.makeEmpty(
       collateralBrand,
       AssetKind.COPY_BAG,
@@ -161,7 +162,7 @@ const helperBehavior = {
     // getCollateralAllocated would return final allocations
     return vaultSeat.hasExited()
       ? emptyCollateral
-      : facets.helper.getCollateralAllocated(vaultSeat);
+      : helper.getCollateralAllocated(vaultSeat);
   },
 
   /**
@@ -169,13 +170,14 @@ const helperBehavior = {
    *  @param {boolean} newActive */
   snapshotState: ({ state, facets }, newActive) => {
     const { debtSnapshot: debt, interestSnapshot: interest, manager } = state;
+    const { helper } = facets;
     /** @type {VaultUIState} */
     const result = harden({
       // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
       interestRate: manager.getInterestRate(),
       liquidationRatio: manager.getMintingRatio(),
       debtSnapshot: { debt, interest },
-      locked: facets.helper.getCollateralAmount(),
+      locked: helper.getCollateralAmount(),
       // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
       // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
       vaultState: newActive ? 'active' : 'closed',

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -5,6 +5,7 @@ import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 import { ceilMultiplyBy } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { makeNotifierKit } from '@agoric/notifier';
 import { M, matches } from '@agoric/store';
+import { defineKindMulti } from '@agoric/vat-data';
 import { makeTracer } from '../makeTracer.js';
 import { addSubtract, assertOnlyKeys, stageDelta } from '../contractSupport.js';
 import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
@@ -50,6 +51,13 @@ const calculateFee = (feeCoeff, currentDebt, giveAmount, wantAmount) => {
  *   updater: NotifierRecord<unknown>['updater'] | null,
  * }} MutableState
  * @typedef {MutableState & ImmutableState} State
+ * @typedef {{
+ *   state: State,
+ *   facets: {
+ *     helper: import('@agoric/vat-data/src/types').KindFacet<typeof helperBehavior>,
+ *     pot: import('@agoric/vat-data/src/types').KindFacet<typeof potBehavior>,
+ *   },
+ * }} MethodContext
  */
 
 /**
@@ -128,6 +136,292 @@ const initState = (zcf, startSeat, manager) => {
     updater,
   };
 };
+const helperBehavior = {
+  /**
+   * @param {MethodContext} context
+   * @param {ZCFSeat} seat
+   */
+  getCollateralAllocated: ({ state }, seat) =>
+    seat.getAmountAllocated(KW.Attestation, state.collateralBrand),
+  /**
+   * @param {MethodContext} context
+   * @param {ZCFSeat} seat
+   */
+  getRunAllocated: ({ state }, seat) =>
+    seat.getAmountAllocated(KW.Debt, state.debtBrand),
+  /**
+   * @param {MethodContext} context
+   */
+  getCollateralAmount: ({ state, facets }) => {
+    const { collateralBrand, vaultSeat } = state;
+    const emptyCollateral = AmountMath.makeEmpty(
+      collateralBrand,
+      AssetKind.COPY_BAG,
+    );
+    // getCollateralAllocated would return final allocations
+    return vaultSeat.hasExited()
+      ? emptyCollateral
+      : facets.helper.getCollateralAllocated(vaultSeat);
+  },
+
+  /**
+   * @param {MethodContext} context
+   *  @param {boolean} newActive */
+  snapshotState: ({ state, facets }, newActive) => {
+    const { debtSnapshot: debt, interestSnapshot: interest, manager } = state;
+    /** @type {VaultUIState} */
+    const result = harden({
+      // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
+      interestRate: manager.getInterestRate(),
+      liquidationRatio: manager.getMintingRatio(),
+      debtSnapshot: { debt, interest },
+      locked: facets.helper.getCollateralAmount(),
+      // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
+      // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
+      vaultState: newActive ? 'active' : 'closed',
+    });
+    return result;
+  },
+
+  /**
+   * call this whenever anything changes!
+   *
+   * @param {MethodContext} context
+   */
+  updateUiState: async ({ state, facets }) => {
+    const { open: active, updater } = state;
+    if (!updater) {
+      console.warn('updateUiState called after ui.updater removed');
+      return;
+    }
+    const uiState = facets.helper.snapshotState(active);
+    trace('updateUiState', uiState);
+
+    if (active) {
+      updater.updateState(uiState);
+    } else {
+      updater.finish(uiState);
+      state.updater = null;
+    }
+  },
+
+  /**
+   * Called whenever the debt is paid or created through a transaction,
+   * but not for interest accrual.
+   *
+   * @param {MethodContext} context
+   * @param {Amount} newDebt - principal and all accrued interest
+   */
+  updateDebtSnapshot: ({ state }, newDebt) => {
+    const { manager } = state;
+    // update local state
+    state.debtSnapshot = newDebt;
+    state.interestSnapshot = manager.getCompoundedInterest();
+  },
+
+  /**
+   * Update the debt balance and propagate upwards to
+   * maintain aggregate debt and liquidation order.
+   *
+   * @param {MethodContext} context
+   * @param {Amount} oldDebt - prior principal and all accrued interest
+   * @param {Amount} newDebt - actual principal and all accrued interest
+   */
+  updateDebtAccounting: ({ state, facets }, oldDebt, newDebt) => {
+    const { manager } = state;
+    const { helper } = facets;
+    helper.updateDebtSnapshot(newDebt);
+    // update vault manager which tracks total debt
+    manager.applyDebtDelta(oldDebt, newDebt);
+  },
+
+  /**
+   * @param {MethodContext} context
+   */
+  assertVaultHoldsNoRun: ({ state, facets }) => {
+    const { vaultSeat } = state;
+    const { helper } = facets;
+    assert(
+      AmountMath.isEmpty(helper.getRunAllocated(vaultSeat)),
+      X`Vault should be empty of debt`,
+    );
+  },
+
+  /**
+   * Adjust principal and collateral (atomically for offer safety)
+   *
+   * @param {MethodContext} context
+   * @param {ZCFSeat} clientSeat
+   */
+  adjustBalancesHook: ({ state, facets }, clientSeat) => {
+    const { collateralBrand, debtBrand, manager, vaultSeat } = state;
+    const { helper, pot } = facets;
+    assert(state.open);
+
+    const proposal = clientSeat.getProposal();
+    assertOnlyKeys(proposal, [KW.Attestation, KW.Debt]);
+
+    const debt = pot.getCurrentDebt();
+    const collateral = helper.getCollateralAllocated(vaultSeat);
+
+    const emptyCollateral = AmountMath.makeEmpty(
+      collateralBrand,
+      AssetKind.COPY_BAG,
+    );
+    const giveColl = proposal.give.Attestation || emptyCollateral;
+    const wantColl = proposal.want.Attestation || emptyCollateral;
+
+    // new = after the transaction gets applied
+    const newCollateral = addSubtract(collateral, giveColl, wantColl);
+    // max debt supported by current Collateral as modified by proposal
+    const { amountLiened, maxDebt: newMaxDebt } =
+      manager.maxDebtForLien(newCollateral);
+
+    const emptyDebt = AmountMath.makeEmpty(debtBrand);
+    const giveRUN = AmountMath.min(proposal.give.Debt || emptyDebt, debt);
+    const wantRUN = proposal.want.Debt || emptyDebt;
+    const giveRUNonly = matches(
+      proposal,
+      harden({ give: { [KW.Debt]: M.record() }, want: {}, exit: M.any() }),
+    );
+
+    // Calculate the fee, the amount to mint and the resulting debt. We'll
+    // verify that the target debt doesn't violate the collateralization ratio,
+    // then mint, reallocate, and burn.
+    const { newDebt, fee, toMint } = calculateFee(
+      manager.getLoanFee(),
+      debt,
+      giveRUN,
+      wantRUN,
+    );
+    assert(
+      giveRUNonly || AmountMath.isGTE(newMaxDebt, newDebt),
+      `cannot borrow ${q(newDebt)} against ${q(amountLiened)}; max is ${q(
+        newMaxDebt,
+      )}`,
+    );
+
+    trace('adjustBalancesHook', {
+      targetCollateralAmount: newCollateral,
+      vaultCollateral: newCollateral,
+      fee,
+      toMint,
+      newDebt,
+    });
+
+    stageDelta(clientSeat, vaultSeat, giveColl, wantColl, KW.Attestation);
+    stageDelta(clientSeat, vaultSeat, giveRUN, emptyDebt, KW.Debt);
+    manager.mintAndReallocate(toMint, fee, clientSeat, vaultSeat);
+
+    // parent needs to know about the change in debt
+    helper.updateDebtAccounting(debt, newDebt);
+
+    manager.burnDebt(giveRUN, vaultSeat);
+
+    helper.assertVaultHoldsNoRun();
+
+    helper.updateUiState();
+    clientSeat.exit();
+
+    return 'We have adjusted your balances; thank you for your business.';
+  },
+
+  /**
+   * Given sufficient RUN payoff, refund the attestation.
+   *
+   * @type {import('@agoric/vat-data/src/types').PlusContext<MethodContext, OfferHandler>}
+   */
+  closeHook: ({ state, facets }, seat) => {
+    const { debtBrand, manager, vaultSeat, zcf } = state;
+    const { helper, pot } = facets;
+    assert(state.open);
+    assertProposalShape(seat, {
+      give: { [KW.Debt]: null },
+      want: { [KW.Attestation]: null },
+    });
+
+    const currentDebt = pot.getCurrentDebt();
+    const {
+      give: { [KW.Debt]: runOffered },
+    } = seat.getProposal();
+    assert(
+      AmountMath.isGTE(runOffered, currentDebt),
+      X`Offer ${runOffered} is not sufficient to pay off debt ${currentDebt}`,
+    );
+    vaultSeat.incrementBy(seat.decrementBy(harden({ [KW.Debt]: currentDebt })));
+    seat.incrementBy(
+      vaultSeat.decrementBy(
+        harden({ Attestation: vaultSeat.getAmountAllocated('Attestation') }),
+      ),
+    );
+
+    zcf.reallocate(seat, vaultSeat);
+
+    manager.burnDebt(currentDebt, vaultSeat);
+    state.open = false;
+    helper.updateDebtSnapshot(AmountMath.makeEmpty(debtBrand));
+    helper.updateUiState();
+    helper.assertVaultHoldsNoRun();
+    seat.exit();
+
+    return 'Your RUNstake is closed; thank you for your business.';
+  },
+};
+
+const potBehavior = {
+  /** @param {MethodContext} context */
+  getNotifier: ({ state }) => state.notifier,
+  /** @param {MethodContext} context */
+  makeAdjustBalancesInvitation: ({ state, facets }) => {
+    const { zcf } = state;
+    const { helper } = facets;
+    assert(state.open);
+    return zcf.makeInvitation(helper.adjustBalancesHook, 'AdjustBalances');
+  },
+  /** @param {MethodContext} context */
+  makeCloseInvitation: ({ state, facets }) => {
+    const { zcf } = state;
+    const { helper } = facets;
+    assert(state.open);
+    return zcf.makeInvitation(helper.closeHook, 'CloseVault');
+  },
+  /**
+   * The actual current debt, including accrued interest.
+   *
+   * This looks like a simple getter but it does a lot of the heavy lifting for
+   * interest accrual. Rather than updating all records when interest accrues,
+   * the vault manager updates just its rolling compounded interest. Here we
+   * calculate what the current debt is given what's recorded in this vault and
+   * what interest has compounded since this vault record was written.
+   *
+   * @see getNormalizedDebt
+   * @param {MethodContext} context
+   * @returns {Amount<'nat'>}
+   */
+  getCurrentDebt: ({ state }) => {
+    return calculateCurrentDebt(
+      state.debtSnapshot,
+      state.interestSnapshot,
+      state.manager.getCompoundedInterest(),
+    );
+  },
+  /** @param {MethodContext} context */
+  getNormalizedDebt: ({ state }) =>
+    reverseInterest(state.debtSnapshot, state.interestSnapshot),
+};
+
+const behavior = {
+  helper: helperBehavior,
+  pot: potBehavior,
+};
+
+/**
+ * @param {MethodContext} context
+ */
+const finish = ({ facets }) => {
+  const { helper } = facets;
+  helper.updateUiState();
+};
 
 /**
  * Make RUNstake kit, subject to runStake terms.
@@ -137,246 +431,9 @@ const initState = (zcf, startSeat, manager) => {
  * @param {import('./runStakeManager.js').RunStakeManager} manager
  * @throws {Error} if startSeat proposal is not consistent with governance parameters in manager
  */
-export const makeRunStakeKit = (zcf, startSeat, manager) => {
-  const state = initState(zcf, startSeat, manager);
-  const { collateralBrand, debtBrand, vaultSeat } = state;
-
-  const helper = {
-    getCollateralAllocated: seat =>
-      seat.getAmountAllocated(KW.Attestation, collateralBrand),
-    getRunAllocated: seat => seat.getAmountAllocated(KW.Debt, debtBrand),
-    getCollateralAmount: () => {
-      const emptyCollateral = AmountMath.makeEmpty(
-        collateralBrand,
-        AssetKind.COPY_BAG,
-      );
-      // getCollateralAllocated would return final allocations
-      return vaultSeat.hasExited()
-        ? emptyCollateral
-        : helper.getCollateralAllocated(vaultSeat);
-    },
-
-    /** @param {boolean} newActive */
-    snapshotState: newActive => {
-      const { debtSnapshot: debt, interestSnapshot: interest } = state;
-      /** @type {VaultUIState} */
-      const result = harden({
-        // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
-        interestRate: manager.getInterestRate(),
-        liquidationRatio: manager.getMintingRatio(),
-        debtSnapshot: { debt, interest },
-        locked: helper.getCollateralAmount(),
-        // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
-        // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
-        vaultState: newActive ? 'active' : 'closed',
-      });
-      return result;
-    },
-
-    /** call this whenever anything changes! */
-    updateUiState: async () => {
-      const { open: active, updater } = state;
-      if (!updater) {
-        console.warn('updateUiState called after ui.updater removed');
-        return;
-      }
-      const uiState = helper.snapshotState(active);
-      trace('updateUiState', uiState);
-
-      if (active) {
-        updater.updateState(uiState);
-      } else {
-        updater.finish(uiState);
-        state.updater = null;
-      }
-    },
-
-    /**
-     * Called whenever the debt is paid or created through a transaction,
-     * but not for interest accrual.
-     *
-     * @param {Amount} newDebt - principal and all accrued interest
-     */
-    updateDebtSnapshot: newDebt => {
-      // update local state
-      state.debtSnapshot = newDebt;
-      state.interestSnapshot = manager.getCompoundedInterest();
-    },
-
-    /**
-     * Update the debt balance and propagate upwards to
-     * maintain aggregate debt and liquidation order.
-     *
-     * @param {Amount} oldDebt - prior principal and all accrued interest
-     * @param {Amount} newDebt - actual principal and all accrued interest
-     */
-    updateDebtAccounting: (oldDebt, newDebt) => {
-      helper.updateDebtSnapshot(newDebt);
-      // update vault manager which tracks total debt
-      manager.applyDebtDelta(oldDebt, newDebt);
-    },
-
-    assertVaultHoldsNoRun: () => {
-      assert(
-        AmountMath.isEmpty(helper.getRunAllocated(vaultSeat)),
-        X`Vault should be empty of debt`,
-      );
-    },
-
-    /**
-     * Adjust principal and collateral (atomically for offer safety)
-     *
-     * @param {ZCFSeat} clientSeat
-     */
-    adjustBalancesHook: clientSeat => {
-      assert(state.open);
-
-      const proposal = clientSeat.getProposal();
-      assertOnlyKeys(proposal, [KW.Attestation, KW.Debt]);
-
-      // eslint-disable-next-line no-use-before-define
-      const debt = pot.getCurrentDebt();
-      const collateral = helper.getCollateralAllocated(vaultSeat);
-
-      const emptyCollateral = AmountMath.makeEmpty(
-        collateralBrand,
-        AssetKind.COPY_BAG,
-      );
-      const giveColl = proposal.give.Attestation || emptyCollateral;
-      const wantColl = proposal.want.Attestation || emptyCollateral;
-
-      // new = after the transaction gets applied
-      const newCollateral = addSubtract(collateral, giveColl, wantColl);
-      // max debt supported by current Collateral as modified by proposal
-      const { amountLiened, maxDebt: newMaxDebt } =
-        manager.maxDebtForLien(newCollateral);
-
-      const emptyDebt = AmountMath.makeEmpty(debtBrand);
-      const giveRUN = AmountMath.min(proposal.give.Debt || emptyDebt, debt);
-      const wantRUN = proposal.want.Debt || emptyDebt;
-      const giveRUNonly = matches(
-        proposal,
-        harden({ give: { [KW.Debt]: M.record() }, want: {}, exit: M.any() }),
-      );
-
-      // Calculate the fee, the amount to mint and the resulting debt. We'll
-      // verify that the target debt doesn't violate the collateralization ratio,
-      // then mint, reallocate, and burn.
-      const { newDebt, fee, toMint } = calculateFee(
-        manager.getLoanFee(),
-        debt,
-        giveRUN,
-        wantRUN,
-      );
-      assert(
-        giveRUNonly || AmountMath.isGTE(newMaxDebt, newDebt),
-        `cannot borrow ${q(newDebt)} against ${q(amountLiened)}; max is ${q(
-          newMaxDebt,
-        )}`,
-      );
-
-      trace('adjustBalancesHook', {
-        targetCollateralAmount: newCollateral,
-        vaultCollateral: newCollateral,
-        fee,
-        toMint,
-        newDebt,
-      });
-
-      stageDelta(clientSeat, vaultSeat, giveColl, wantColl, KW.Attestation);
-      stageDelta(clientSeat, vaultSeat, giveRUN, emptyDebt, KW.Debt);
-      manager.mintAndReallocate(toMint, fee, clientSeat, vaultSeat);
-
-      // parent needs to know about the change in debt
-      helper.updateDebtAccounting(debt, newDebt);
-
-      manager.burnDebt(giveRUN, vaultSeat);
-
-      helper.assertVaultHoldsNoRun();
-
-      helper.updateUiState();
-      clientSeat.exit();
-
-      return 'We have adjusted your balances; thank you for your business.';
-    },
-
-    /**
-     * Given sufficient RUN payoff, refund the attestation.
-     *
-     * @type {OfferHandler}
-     */
-    closeHook: seat => {
-      assert(state.open);
-      assertProposalShape(seat, {
-        give: { [KW.Debt]: null },
-        want: { [KW.Attestation]: null },
-      });
-
-      // eslint-disable-next-line no-use-before-define
-      const currentDebt = pot.getCurrentDebt();
-      const {
-        give: { [KW.Debt]: runOffered },
-      } = seat.getProposal();
-      assert(
-        AmountMath.isGTE(runOffered, currentDebt),
-        X`Offer ${runOffered} is not sufficient to pay off debt ${currentDebt}`,
-      );
-      vaultSeat.incrementBy(
-        seat.decrementBy(harden({ [KW.Debt]: currentDebt })),
-      );
-      seat.incrementBy(
-        vaultSeat.decrementBy(
-          harden({ Attestation: vaultSeat.getAmountAllocated('Attestation') }),
-        ),
-      );
-
-      zcf.reallocate(seat, vaultSeat);
-
-      manager.burnDebt(currentDebt, vaultSeat);
-      state.open = false;
-      helper.updateDebtSnapshot(AmountMath.makeEmpty(debtBrand));
-      helper.updateUiState();
-      helper.assertVaultHoldsNoRun();
-      seat.exit();
-
-      return 'Your RUNstake is closed; thank you for your business.';
-    },
-  };
-
-  const pot = {
-    getNotifier: () => state.notifier,
-    makeAdjustBalancesInvitation: () => {
-      assert(state.open);
-      return zcf.makeInvitation(helper.adjustBalancesHook, 'AdjustBalances');
-    },
-    makeCloseInvitation: () => {
-      assert(state.open);
-      return zcf.makeInvitation(helper.closeHook, 'CloseVault');
-    },
-    /**
-     * The actual current debt, including accrued interest.
-     *
-     * This looks like a simple getter but it does a lot of the heavy lifting for
-     * interest accrual. Rather than updating all records when interest accrues,
-     * the vault manager updates just its rolling compounded interest. Here we
-     * calculate what the current debt is given what's recorded in this vault and
-     * what interest has compounded since this vault record was written.
-     *
-     * @see getNormalizedDebt
-     * @returns {Amount<'nat'>}
-     */
-    getCurrentDebt: () => {
-      return calculateCurrentDebt(
-        state.debtSnapshot,
-        state.interestSnapshot,
-        manager.getCompoundedInterest(),
-      );
-    },
-    getNormalizedDebt: () =>
-      reverseInterest(state.debtSnapshot, state.interestSnapshot),
-  };
-
-  helper.updateUiState();
-
-  return { helper, pot };
-};
+export const makeRunStakeKit = defineKindMulti(
+  'RUNStakeKit',
+  initState,
+  behavior,
+  { finish },
+);

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -9,7 +9,7 @@ import { defineKindMulti } from '@agoric/vat-data';
 import { makeTracer } from '../makeTracer.js';
 import { addSubtract, assertOnlyKeys, stageDelta } from '../contractSupport.js';
 import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
-import { KW } from './params.js';
+import { ManagerKW as KW } from './constants.js';
 
 const { details: X, quote: q } = assert;
 

--- a/packages/run-protocol/src/runStake/runStakeManager.js
+++ b/packages/run-protocol/src/runStake/runStakeManager.js
@@ -9,7 +9,7 @@ import { E } from '@endo/far';
 import { defineKindMulti, partialAssign } from '@agoric/vat-data';
 import { makeTracer } from '../makeTracer.js';
 import { chargeInterest } from '../interest.js';
-import { KW } from './runStakeKit.js';
+import { ManagerKW as KW } from './constants.js';
 import { checkDebtLimit } from '../contractSupport.js';
 
 const { details: X } = assert;

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -24,7 +24,7 @@ import {
 } from '../../src/econ-behaviors.js';
 import * as Collect from '../../src/collect.js';
 import { setUpZoeForTest } from '../supports.js';
-import { KW } from '../../src/runStake/params.js';
+import { ManagerKW as KW } from '../../src/runStake/constants.js';
 import { unsafeMakeBundleCache } from '../bundleTool.js';
 
 // 8	Partial repayment from reward stream - TODO

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -31,7 +31,7 @@ type KindFacets<B> = {
 
 type MultiKindContext<S, B> = { state: S; facets: KindFacets<B> };
 
-type PlusContext<C, M> = (c: any, ...args: Parameters<M>) => ReturnType<M>;
+type PlusContext<C, M> = (c: C, ...args: Parameters<M>) => ReturnType<M>;
 type FunctionsPlusContext<O> = { [K in keyof O]: PlusContext<O[K]> };
 
 declare class DurableKindHandleClass {


### PR DESCRIPTION
closes: #4534

## Description

RunStakeKit is the high cardinality object of RUNstake. This converts it to being a virtual object, completing #4534.

It also fixes part of the typedef for PlusContext. I'll do a merge commit to separate them in master.

### Security Considerations

State can be paged out and in. Relies on security of vobj system.

### Documentation Considerations

--

### Testing Considerations

Refactor. Existing tests suffice. Durability out of scope.