### PR TITLE
refactor(run-protocol): vault title vobj

### DIFF
--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -620,6 +620,7 @@ const selfBehavior = {
 
   /**
    * @param {MethodContext} context
+   * @returns {Promise<unknown>}
    */
   makeTransferInvitation: ({ state, facets }) => {
     const { self, helper } = facets;

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -1,62 +1,7 @@
 // @ts-check
-import { makeNotifierKit } from '@agoric/notifier';
 import '@agoric/zoe/exported.js';
 import { Far } from '@endo/marshal';
-
-const { details: X } = assert;
-
-/**
- * @typedef {{
- * inner: InnerVault | null,
- * }} State
- */
-/**
- *
- * @param {InnerVault} innerVault
- */
-const wrapVault = innerVault => {
-  /** @type {NotifierRecord<VaultUIState>} */
-  const { updater, notifier } = makeNotifierKit();
-
-  /** @type {State} */
-  const state = {
-    inner: innerVault,
-  };
-
-  // Throw if this wrapper no longer owns the inner vault
-  const owned = v => {
-    const { inner } = state;
-    // console.log('OUTER', v, 'INNER', inner);
-    assert(inner, X`Using ${v} after transfer`);
-    return inner;
-  };
-
-  /**
-   * Public API of the vault.
-   *
-   * @see {InnerVault} for the internal API it wraps.
-   */
-  const vault = Far('vault', {
-    getNotifier: () => notifier,
-    makeAdjustBalancesInvitation: () =>
-      owned(vault).makeAdjustBalancesInvitation(),
-    makeCloseInvitation: () => owned(vault).makeCloseInvitation(),
-    /**
-     * Starting a transfer revokes the outer vault. The associated updater will
-     * get a special notification the the vault is being transferred.
-     */
-    makeTransferInvitation: () => {
-      const tmpInner = owned(vault);
-      state.inner = null;
-      return tmpInner.makeTransferInvitation();
-    },
-    // for status/debugging
-    getCollateralAmount: () => owned(vault).getCollateralAmount(),
-    getCurrentDebt: () => owned(vault).getCurrentDebt(),
-    getNormalizedDebt: () => owned(vault).getNormalizedDebt(),
-  });
-  return { vault, vaultUpdater: updater };
-};
+import { makeVaultTitle } from './vaultTitle';
 
 /**
  * Create a kit of utilities for use of the (inner) vault.
@@ -65,19 +10,19 @@ const wrapVault = innerVault => {
  * @param {Notifier<import('./vaultManager').AssetState>} assetNotifier
  */
 export const makeVaultKit = (inner, assetNotifier) => {
-  const { vault, vaultUpdater } = wrapVault(inner);
+  const { title, helper } = makeVaultTitle(inner);
   const vaultKit = harden({
     publicNotifiers: {
-      vault: vault.getNotifier(),
+      vault: title.getNotifier(),
       asset: assetNotifier,
     },
     invitationMakers: Far('invitation makers', {
-      AdjustBalances: vault.makeAdjustBalancesInvitation,
-      CloseVault: vault.makeCloseInvitation,
-      TransferVault: vault.makeTransferInvitation,
+      AdjustBalances: title.makeAdjustBalancesInvitation,
+      CloseVault: title.makeCloseInvitation,
+      TransferVault: title.makeTransferInvitation,
     }),
-    vault,
-    vaultUpdater,
+    vault: title,
+    vaultUpdater: helper.getUpdater(),
   });
   return vaultKit;
 };

--- a/packages/run-protocol/src/vaultFactory/vaultTitle.js
+++ b/packages/run-protocol/src/vaultFactory/vaultTitle.js
@@ -1,0 +1,88 @@
+/**
+ * @file Object representing ownership of a vault
+ */
+// @ts-check
+import { makeNotifierKit } from '@agoric/notifier';
+import { defineKindMulti } from '@agoric/vat-data';
+import '@agoric/zoe/exported.js';
+
+const { details: X } = assert;
+
+/**
+ * @typedef {{
+ * notifier: NotifierRecord<VaultUIState>['notifier'],
+ * updater: NotifierRecord<VaultUIState>['updater'],
+ * vault: InnerVault | null,
+ * }} State
+ * @typedef {Readonly<{
+ *   state: State,
+ *   facets: {
+ *     helper: import('@agoric/vat-data/src/types').KindFacet<typeof helper>,
+ *     self: import('@agoric/vat-data/src/types').KindFacet<typeof title>,
+ *   },
+ * }>} MethodContext
+ */
+
+/**
+ *
+ * @param {InnerVault} vault
+ * @returns {State}
+ */
+const initState = vault => {
+  /** @type {NotifierRecord<VaultUIState>} */
+  const { updater, notifier } = makeNotifierKit();
+
+  return { notifier, updater, vault };
+};
+
+const helper = {
+  /**
+   * @param {MethodContext} context
+   * @throws if this title no longer owns the vault
+   */
+  owned: ({ state }) => {
+    const { vault } = state;
+    assert(vault, X`Using vault title after transfer`);
+    return vault;
+  },
+  /** @param {MethodContext} context */
+  getUpdater: ({ state }) => state.updater,
+};
+
+const title = {
+  /** @param {MethodContext} context */
+  getNotifier: ({ state }) => state.notifier,
+  /** @param {MethodContext} context */
+  makeAdjustBalancesInvitation: ({ facets }) =>
+    facets.helper.owned().makeAdjustBalancesInvitation(),
+  /** @param {MethodContext} context */
+  makeCloseInvitation: ({ facets }) =>
+    facets.helper.owned().makeCloseInvitation(),
+  /**
+   * Starting a transfer revokes the outer vault. The associated updater will
+   * get a special notification the the vault is being transferred.
+   *
+   * @param {MethodContext} context
+   */
+  makeTransferInvitation: ({ state, facets }) => {
+    const vault = facets.helper.owned();
+    state.vault = null;
+    return vault.makeTransferInvitation();
+  },
+  // for status/debugging
+  /** @param {MethodContext} context */
+  getCollateralAmount: ({ facets }) =>
+    facets.helper.owned().getCollateralAmount(),
+  /** @param {MethodContext} context */
+  getCurrentDebt: ({ facets }) => facets.helper.owned().getCurrentDebt(),
+  /** @param {MethodContext} context */
+  getNormalizedDebt: ({ facets }) => facets.helper.owned().getNormalizedDebt(),
+};
+
+const behavior = { helper, title };
+
+export const makeVaultTitle = defineKindMulti(
+  'VaultTitle',
+  initState,
+  behavior,
+);


### PR DESCRIPTION
closes: #4345 

## Description

One last stateful object in vaultFactory.

This is the "outer vault" that end users hold, allowing the "inner vault" that has the assets to be transferred. In the interests of clarity this renames the "outer" entity to "title", since it's a record of ownership of the vault. "Vault" can then be referred to consistently without a qualifier.

In the UI there need not be any distinction. Users will think of a vault and transferring the vault.

### Security Considerations

--

### Documentation Considerations

Outer/inner wasn't documented so nothing to change. Not user facing.

### Testing Considerations

Refactor so existing tests.
