### PR TITLE
refactor(run-protocol): consistence invitation patterns

### DIFF
--- a/packages/run-protocol/CONTRIBUTING.md
+++ b/packages/run-protocol/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contract style
+
+## Invitations
+
+Facet methods that create invitations should adhere to this style:
+
+```
+makeFooInvitation: () => {
+    …
+    return zcf.makeInvitation(helper.handleFooOffer, 'Foo');
+},
+```
+
+For example,
+```
+makeVaultCloseInvitation: () => {
+    …
+    return zcf.makeInvitation(helper.handleVaultCloseOffer, 'VaultClose');
+},
+```

--- a/packages/run-protocol/src/collectFees.js
+++ b/packages/run-protocol/src/collectFees.js
@@ -13,7 +13,7 @@ export const makeMakeCollectFeesInvitation = (
   feeBrand,
   keyword,
 ) => {
-  const collectFees = seat => {
+  const handleCollectFeesOffer = seat => {
     const amount = feeSeat.getAmountAllocated(keyword, feeBrand);
     feeSeat.decrementBy(harden({ [keyword]: amount }));
     seat.incrementBy(harden({ RUN: amount }));
@@ -24,7 +24,7 @@ export const makeMakeCollectFeesInvitation = (
   };
 
   const makeCollectFeesInvitation = () =>
-    zcf.makeInvitation(collectFees, 'collect fees');
+    zcf.makeInvitation(handleCollectFeesOffer, 'CollectFees');
 
   return { makeCollectFeesInvitation };
 };

--- a/packages/run-protocol/src/psm/psm.js
+++ b/packages/run-protocol/src/psm/psm.js
@@ -146,7 +146,8 @@ export const start = async (zcf, privateArgs) => {
     }
   };
 
-  const swapHook = seat => {
+  /** @param {ZCFSeat} seat */
+  const handleSwapOffer = seat => {
     assertProposalShape(seat, {
       give: { In: null },
     });
@@ -163,7 +164,7 @@ export const start = async (zcf, privateArgs) => {
     }
     seat.exit();
   };
-  const makeSwapInvitation = () => zcf.makeInvitation(swapHook, 'swap');
+  const makeSwapInvitation = () => zcf.makeInvitation(handleSwapOffer, 'swap');
 
   const publicFacet = Far('Parity Stability Module', {
     getPoolBalance: () => anchorPool.getAmountAllocated('Anchor', anchorBrand),

--- a/packages/run-protocol/src/reserve/assetReserve.js
+++ b/packages/run-protocol/src/reserve/assetReserve.js
@@ -74,7 +74,7 @@ const start = async (zcf, privateArgs) => {
   };
 
   // Anyone can deposit collateral to the reserve.
-  const addCollateralHook = async seat => {
+  const handleAddCollateralOffer = async seat => {
     const {
       give: { Collateral: amountIn },
     } = seat.getProposal();
@@ -90,7 +90,7 @@ const start = async (zcf, privateArgs) => {
   };
 
   const makeAddCollateralInvitation = () =>
-    zcf.makeInvitation(addCollateralHook, 'Add Collateal');
+    zcf.makeInvitation(handleAddCollateralOffer, 'Add Collateal');
 
   /** @type {ZCFMint} */
   const runMint = await zcf.registerFeeMint('RUN', feeMintAccess);

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -171,7 +171,7 @@ export const start = async (
   /**
    * @param {ZCFSeat} seat
    */
-  const offerHandler = seat => {
+  const handleLoanOffer = seat => {
     const { helper, pot } = makeRunStakeKit(zcf, seat, manager);
 
     return harden({
@@ -181,8 +181,12 @@ export const start = async (
       },
       invitationMakers: Far('invitation makers', {
         AdjustBalances: () =>
-          zcf.makeInvitation(helper.adjustBalancesHook, 'AdjustBalances'),
-        CloseVault: () => zcf.makeInvitation(helper.closeHook, 'CloseVault'),
+          zcf.makeInvitation(
+            helper.handleAdjustBalancesOffer,
+            'AdjustBalances',
+          ),
+        CloseVault: () =>
+          zcf.makeInvitation(helper.handleCloseOffer, 'CloseVault'),
       }),
       vault: Far('RUNstake pot', pot),
     });
@@ -191,7 +195,7 @@ export const start = async (
   const publicFacet = augmentPublicFacet(
     Far('runStake public', {
       makeLoanInvitation: () =>
-        zcf.makeInvitation(offerHandler, 'make RUNstake'),
+        zcf.makeInvitation(handleLoanOffer, 'make RUNstake'),
       makeReturnAttInvitation: att.publicFacet.makeReturnAttInvitation,
     }),
   );

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -228,7 +228,7 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
      *
      * @param {ZCFSeat} clientSeat
      */
-    adjustBalancesHook: clientSeat => {
+    handleAdjustBalancesOffer: clientSeat => {
       assert(state.open);
 
       const proposal = clientSeat.getProposal();
@@ -303,9 +303,9 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
     /**
      * Given sufficient RUN payoff, refund the attestation.
      *
-     * @type {OfferHandler}
+     * @param {ZCFSeat} seat
      */
-    closeHook: seat => {
+    handleCloseOffer: seat => {
       assert(state.open);
       assertProposalShape(seat, {
         give: { [KW.Debt]: null },
@@ -347,11 +347,14 @@ export const makeRunStakeKit = (zcf, startSeat, manager) => {
     getNotifier: () => state.notifier,
     makeAdjustBalancesInvitation: () => {
       assert(state.open);
-      return zcf.makeInvitation(helper.adjustBalancesHook, 'AdjustBalances');
+      return zcf.makeInvitation(
+        helper.handleAdjustBalancesOffer,
+        'AdjustBalances',
+      );
     },
     makeCloseInvitation: () => {
       assert(state.open);
-      return zcf.makeInvitation(helper.closeHook, 'CloseVault');
+      return zcf.makeInvitation(helper.handleCloseOffer, 'CloseVault');
     },
     /**
      * The actual current debt, including accrued interest.

--- a/packages/run-protocol/src/vaultFactory/liquidateMinimum.js
+++ b/packages/run-protocol/src/vaultFactory/liquidateMinimum.js
@@ -28,7 +28,7 @@ const start = async zcf => {
    * @param {ZCFSeat} debtorSeat
    * @param {{ debt: Amount<'nat'> }} options
    */
-  const debtorHook = async (debtorSeat, { debt }) => {
+  const handleDebtorOffer = async (debtorSeat, { debt }) => {
     const debtBrand = debt.brand;
     const {
       give: { In: amountIn },
@@ -60,7 +60,8 @@ const start = async zcf => {
   };
 
   const creatorFacet = Far('debtorInvitationCreator', {
-    makeDebtorInvitation: () => zcf.makeInvitation(debtorHook, 'Liquidate'),
+    makeDebtorInvitation: () =>
+      zcf.makeInvitation(handleDebtorOffer, 'Liquidate'),
   });
 
   return harden({ creatorFacet });

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -427,7 +427,7 @@ const helperBehavior = {
    * @param {ZCFSeat} clientSeat
    * @returns {Promise<string>} success message
    */
-  adjustBalancesHook: async ({ state, facets }, clientSeat) => {
+  handleAdjustBalancesOffer: async ({ state, facets }, clientSeat) => {
     const { self, helper } = facets;
     const { vaultSeat, outerUpdater: updaterPre } = state;
     const proposal = clientSeat.getProposal();
@@ -474,7 +474,7 @@ const helperBehavior = {
     });
 
     if (checkRestart(newCollateralPre, maxDebtPre, newCollateral, newDebt)) {
-      return helper.adjustBalancesHook(clientSeat);
+      return helper.handleAdjustBalancesOffer(clientSeat);
     }
 
     stageDelta(clientSeat, vaultSeat, giveColl, wantColl, 'Collateral');
@@ -604,7 +604,7 @@ const selfBehavior = {
     const { helper } = facets;
     helper.assertActive();
     return state.zcf.makeInvitation(
-      helper.adjustBalancesHook,
+      helper.handleAdjustBalancesOffer,
       'AdjustBalances',
     );
   },


### PR DESCRIPTION
## Description

We have a lot of different ways to name the parts of an invitation. More consistency would reduce effort in code review and navigation.


### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
