### PR TITLE
refactor(run-protocol): AttestationTool vobj

### DIFF
--- a/packages/run-protocol/src/runStake/attestation.js
+++ b/packages/run-protocol/src/runStake/attestation.js
@@ -14,7 +14,7 @@ const { details: X } = assert;
  * @typedef {{
  *   mintAttestation: unknown,
  *   returnAttestation: OfferHandler,
- *   getLiened: unknown,
+ *   getLiened: (address: Address, brand: Brand<'nat'>) => Amount<'nat'>,
  *   getAccountState: unknown,
  *   wrapLienedAmount: unknown,
  *   unwrapLienedAmount: unknown,
@@ -237,7 +237,7 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
  * The keyword for use in returnAttestation offers is `Attestation`.
  */
 export const makeAttestationFacets = async (zcf, stakeBrand, lienBridge) => {
-  /** @type {Store<Address, AttestationMaker>} */
+  /** @type {Store<Address, AttestationTool>} */
   const attMakerByAddress = makeStore('address');
 
   const { issuer, brand, lienMint } = await makeAttestationIssuerKit(

--- a/packages/run-protocol/src/runStake/attestationTool.js
+++ b/packages/run-protocol/src/runStake/attestationTool.js
@@ -1,0 +1,59 @@
+// @ts-check
+/**
+ * @typedef {Readonly<{
+ *   address: Address,
+ *   lienMint: *,
+ *   stakeBrand: Brand<'nat'>,
+ *   zcf: ZCF,
+ * }>} State
+ * @typedef {{
+ *   state: State,
+ * }} MethodContext
+ */
+
+import { defineKind } from '@agoric/vat-data';
+/**
+ * @param {Address} address
+ * @param {import('./attestation').LienMint} lienMint
+ * @param {Brand<'nat'>} stakeBrand
+ * @param {ZCF} zcf
+ */
+const initState = (address, lienMint, stakeBrand, zcf) => {
+  return { address, lienMint, stakeBrand, zcf };
+};
+
+const behavior = {
+  /**
+   * @param {MethodContext} context
+   * @param { Amount<'nat'> } lienedDelta
+   */
+  makeAttestation: ({ state }, lienedDelta) =>
+    state.lienMint.mintAttestation(state.address, lienedDelta),
+
+  /** @param {MethodContext} context */
+  getAccountState: ({ state }) =>
+    state.lienMint.getAccountState(state.address, state.stakeBrand),
+
+  /** @param {MethodContext} context */
+  makeReturnAttInvitation: ({ state }) =>
+    state.zcf.makeInvitation(
+      state.lienMint.returnAttestation,
+      'returnAttestation',
+    ),
+
+  /** @param {MethodContext} context */
+  unwrapLienedAmount: ({ state }) => state.lienMint.unwrapLienedAmount,
+
+  /**
+   * @param {MethodContext} context
+   * @param { Amount<'nat'> } lienedAmount
+   */
+  wrapLienedAmount: ({ state }, lienedAmount) =>
+    state.lienMint.wrapLienedAmount(state.address, lienedAmount),
+};
+
+export const makeAttestationTool = defineKind(
+  'AttestationTool',
+  initState,
+  behavior,
+);

--- a/packages/run-protocol/src/runStake/attestationTool.js
+++ b/packages/run-protocol/src/runStake/attestationTool.js
@@ -40,18 +40,11 @@ const behavior = {
       state.lienMint.returnAttestation,
       'returnAttestation',
     ),
-
-  /** @param {MethodContext} context */
-  unwrapLienedAmount: ({ state }) => state.lienMint.unwrapLienedAmount,
-
-  /**
-   * @param {MethodContext} context
-   * @param { Amount<'nat'> } lienedAmount
-   */
-  wrapLienedAmount: ({ state }, lienedAmount) =>
-    state.lienMint.wrapLienedAmount(state.address, lienedAmount),
 };
 
+/**
+ * @returns {AttestationTool}
+ */
 export const makeAttestationTool = defineKind(
   'AttestationTool',
   initState,

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -70,7 +70,7 @@ const { values } = Object;
  * The creator facet can make an `AttestationMaker` for each account, which
  * authorizes placing a lien some of the staked assets in that account.
  * @typedef {{
- *   provideAttestationMaker: (addr: string) => AttestationMaker,
+ *   provideAttestationMaker: (addr: string) => AttestationTool,
  *   getLiened: (address: string, brand: Brand<'nat'>) => Amount<'nat'>,
  * }} RunStakeCreator
  *

--- a/packages/run-protocol/src/runStake/types.js
+++ b/packages/run-protocol/src/runStake/types.js
@@ -1,5 +1,5 @@
 /**
- * @typedef AttestationMaker
+ * @typedef AttestationTool
  * @property {(amountToLien: Amount<'nat'>) => Promise<Payment>} makeAttestation
  * @property {() => Promise<AccountState>} getAccountState
  * @property {() => Promise<Invitation>} makeReturnAttInvitation Make an invitation for returning an attestation.


### PR DESCRIPTION
closes: #4534

## Description

`makeAttestationFacets` holds a `Store<Address, AttestationMaker>` so AttestionMaker needs to be a vobj.

This makes it so and cleans up types. (`AttestationMaker` --> `AttestationTool`)

### Security Considerations

State paged out, relies on VatData.

### Documentation Considerations

--

### Testing Considerations

Refactor, existing tests suffice. Durability out of scope.