### PR TITLE
fix(ci): use a stable docker snapshot-tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     branches: [master] # $default-branch
     tags:
       - '@agoric/sdk@*'
-    workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   snapshot:
@@ -16,7 +16,12 @@ jobs:
       - name: Generate Snapshot Tag
         id: snapshot-tag
         run: |
-          TIMESTAMP=`date +%Y%m%d%H%M%S`
+          COMMIT_TIME=$(curl --fail --silent \
+              --url https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }} \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'content-type: application/json' \
+            | jq '(.commit.committer.date | fromdate)')
+          TIMESTAMP=`date +%Y%m%d%H%M%S --date="@${COMMIT_TIME}"`
           SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-6)
           SNAPSHOT_TAG="${TIMESTAMP}${SHORT_SHA}"
           echo "::set-output name=tag::$SNAPSHOT_TAG"


### PR DESCRIPTION
refs: #5182 

## Description

While it might not solve the issue, this should allow us to generate a well-known docker tag given a revision in case we ever need it later for any purpose.

### Security Considerations

None

### Testing Considerations

The manual trigger is busted (bad yaml indentation), but I manually tried this with a tag
