### PR TITLE
Add swing store trace option

### DIFF
--- a/packages/SwingSet/src/controller/hostStorage.js
+++ b/packages/SwingSet/src/controller/hostStorage.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { initSwingStore, openSwingStore } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 
 /*
 The "Storage API" is a set of functions { has, getKeys, get, set, delete } that
@@ -12,28 +12,10 @@ directly.
 */
 
 /**
- * Helper function to initialize the appropriate storage objects for the kernel
- *
- * @param {boolean} initialize  If true, initialize a new store; if false, open an existing one
- * @param {string|undefined} kernelStateDBDir Pathname to the LMDB database
- *    directory or undefined to create a volatile in-memory store
- *
- * @returns {HostStore} a host store as described by the parameters
+ * Helper function to initialize an ephemeral storage used as fallback or for tests
  */
-export function provideHostStorage(
-  initialize = true,
-  kernelStateDBDir = undefined,
-) {
-  let swingStore;
-  if (kernelStateDBDir) {
-    if (initialize) {
-      swingStore = initSwingStore(kernelStateDBDir);
-    } else {
-      swingStore = openSwingStore(kernelStateDBDir);
-    }
-  } else {
-    swingStore = initSwingStore(null);
-  }
+export function provideHostStorage() {
+  const swingStore = initSwingStore(null);
   return {
     kvStore: swingStore.kvStore,
     streamStore: swingStore.streamStore,

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -162,7 +162,8 @@ export default async function main(progname, args, { env, homedir, agcc }) {
   // Try to determine the cosmos chain home.
   function getFlagValue(flagName, deflt) {
     let flagValue = deflt;
-    const envValue = env[`AG_CHAIN_COSMOS_${flagName.toUpperCase()}`];
+    const envValue =
+      env[`AG_CHAIN_COSMOS_${flagName.toUpperCase().replace(/-/g, '_')}`];
     if (envValue !== undefined) {
       flagValue = envValue;
     }
@@ -334,7 +335,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       serviceName: TELEMETRY_SERVICE_NAME,
     });
 
-    const { SLOGFILE, SLOGSENDER, LMDB_MAP_SIZE } = env;
+    const { SLOGFILE, SLOGSENDER, LMDB_MAP_SIZE, SWING_STORE_TRACE } = env;
     const slogSender = await makeSlogSenderFromModule(SLOGSENDER, {
       stateDir: stateDBDir,
       env,
@@ -342,6 +343,9 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     });
 
     const mapSize = (LMDB_MAP_SIZE && parseInt(LMDB_MAP_SIZE, 10)) || undefined;
+
+    const enableTrace =
+      SWING_STORE_TRACE === '1' || !!getFlagValue('trace-store');
 
     const s = await launch({
       actionQueue,
@@ -355,6 +359,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       slogFile: SLOGFILE,
       slogSender,
       mapSize,
+      enableTrace,
     });
     return s;
   }

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -170,12 +170,13 @@ export async function launch({
   slogFile = undefined,
   slogSender,
   mapSize = DEFAULT_LMDB_MAP_SIZE,
+  enableTrace,
 }) {
   console.info('Launching SwingSet kernel');
 
   const { kvStore, streamStore, snapStore, commit } = openSwingStore(
     kernelStateDBDir,
-    { mapSize },
+    { mapSize, enableTrace },
   );
   const hostStorage = {
     kvStore,

--- a/packages/deployment/scripts/capture-integration-results.sh
+++ b/packages/deployment/scripts/capture-integration-results.sh
@@ -15,5 +15,12 @@ for node in validator{0,1}; do
   "$thisdir/setup.sh" ssh "$node" cat "$home/config/genesis.json" > "$RESULTSDIR/$node-genesis.json" || true
   "$thisdir/setup.sh" ssh "$node" cat "$home/data/chain.slog" > "$RESULTSDIR/$node.slog" || true
   "$thisdir/setup.sh" ssh "$node" cat "$home/data/ag-cosmos-chain-state/flight-recorder.bin" > "$RESULTSDIR/$node-flight-recorder.bin" || true
+  "$thisdir/setup.sh" ssh "$node" cat "$home/data/ag-cosmos-chain-state/store-trace.log" > "$RESULTSDIR/$node-store-trace.log" || true
   "$thisdir/setup.sh" ssh "$node" cat "$home/data/kvstore.trace" > "$RESULTSDIR/$node-kvstore.trace" || true
 done
+
+if [ -d /usr/src/testnet-load-generator ]
+then
+  cp ~/.ag-chain-cosmos/data/ag-cosmos-chain-state/flight-recorder.bin "$RESULTSDIR/flight-recorder.bin" || true
+  cp ~/.ag-chain-cosmos/data/ag-cosmos-chain-state/store-trace.log "$RESULTSDIR/store-trace.log" || true
+fi

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -47,7 +47,7 @@ then
   cd /usr/src/testnet-load-generator
   SOLO_COINS=40000000000urun \
     "$AG_SETUP_COSMOS_HOME/faucet-helper.sh" add-egress loadgen "$SOLO_ADDR"
-  SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
+  SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" SWING_STORE_TRACE=1 ./start.sh \
     --no-stage.save-storage --stages=3 --stage.duration=4 \
     --stage.loadgen.vault.interval=12 --stage.loadgen.vault.limit=2 \
     --stage.loadgen.amm.interval=12 --stage.loadgen.amm.wait=6 --stage.loadgen.amm.limit=2 \


### PR DESCRIPTION
## Description

We noticed that the app hash diverges when trying to diagnose why the deployment-test sometimes results in consensus failures, but nothing else seemed different in the slog. This change adds an option to trace modifying calls to the swing store, which is enabled for the integration test

### Security Considerations

None

### Documentation Considerations

This tracing can be enabled through a new environment variable `SWING_STORE_TRACE` as well as by sniffing for the presence of the `--trace-store` argument that triggers cosmos to write its own trace (though ignoring the path value and using a hardcoded one)

Since it looks like we may need this on for a bit, I decided to wire it properly

### Testing Considerations

[Tried this based on 3 different revisions so far](https://github.com/Agoric/agoric-sdk/actions/workflows/deployment-test.yml?query=event%3Aworkflow_dispatch+actor%3Amhofman), including the last known failure, and haven't been able to reproduce, which really means something either non-deterministic or environmental is at play here.
