### PR TITLE
ci: Prototype of run integration tests before merge

### DIFF
--- a/.github/workflows/mergify-test.yml
+++ b/.github/workflows/mergify-test.yml
@@ -1,12 +1,36 @@
+name: Proto merge integration
+
 on:
+  workflow_dispatch:
   push:
+    branches:
+      - master
+    tags:
+      - '@agoric/sdk@*'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - auto_merge_enabled
 
 jobs:
+  pre_check:
+    uses: ./.github/workflows/pre-check-integration.yml
+
   mergify-merge-queue-test:
+    needs: pre_check
+    if: needs.pre_check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: wait for a while on this branch
         shell: bash
         run: |
           echo "$GITHUB_REF"
+          echo 'needs ${{ toJSON(needs) }}'
+          echo 'github ${{ toJSON(github) }}'
+          echo 'job ${{ toJSON(job) }}'
+          echo 'env ${{ toJSON(env) }}'
           sleep 120

--- a/.github/workflows/mergify-test.yml
+++ b/.github/workflows/mergify-test.yml
@@ -29,8 +29,16 @@ jobs:
         shell: bash
         run: |
           echo "$GITHUB_REF"
-          echo 'needs ${{ toJSON(needs) }}'
-          echo 'github ${{ toJSON(github) }}'
-          echo 'job ${{ toJSON(job) }}'
-          echo 'env ${{ toJSON(env) }}'
+          cat <<EOF
+            needs ${{ toJSON(needs) }}
+          EOF
+          cat <<EOF
+            github ${{ toJSON(github) }}
+          EOF
+          cat <<EOF
+            job ${{ toJSON(job) }}
+          EOF
+          cat <<EOF
+            env ${{ toJSON(env) }}
+          EOF
           sleep 120

--- a/.github/workflows/pre-check-integration.yml
+++ b/.github/workflows/pre-check-integration.yml
@@ -1,0 +1,51 @@
+name: Pre-check Integration Test
+
+on:
+  workflow_call:
+    outputs:
+      should_run:
+        description: "'true' if the test should run"
+        value: "${{ jobs.check_and_cancel.outcome != 'skipped' && jobs.check_and_cancel.outputs.should_skip != 'true' }}"
+
+jobs:
+  check_and_cancel:
+    name: Check preconditions and cancel previous jobs
+    if: >-
+      github.event_name != 'pull_request' || (
+        github.event.pull_request.base.ref == 'master' &&
+        github.event.pull_request.draft == false &&
+        (
+          contains(github.event.pull_request.labels.*.name, 'manualmerge') || 
+          contains(github.event.pull_request.labels.*.name, 'automerge:squash') || 
+          contains(github.event.pull_request.labels.*.name, 'automerge:merge') ||
+          contains(github.event.pull_request.labels.*.name, 'automerge:rebase') ||
+          github.event.pull_request.auto_merge != null
+        ) && 
+        !contains(github.event.pull_request.labels.*.name, 'bypass:integration')
+      )
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ (steps.step2.outcome == 'skipped' || steps.step2.outputs.concurrent_conclusion == 'success') && steps.step1.outputs.should_skip || 'false' }}
+    steps:
+      - id: step1
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: 'true'
+          concurrent_skipping: 'same_content_newer'
+      - id: step2
+        name: Wait for concurrent run conclusion
+        if: >-
+          steps.step1.outputs.should_skip == 'true' && 
+          steps.step1.outputs.reason == 'concurrent_skipping' && 
+          fromJSON(steps.step1.outputs.skipped_by).status != 'completed'
+        run: |
+          while : ; do 
+            conclusion="$(curl --fail --silent \
+              --url https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ fromJSON(steps.step1.outputs.skipped_by).runId }} \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'content-type: application/json' \
+            | jq -r '.conclusion')"
+            [ "$conclusion" != "null" ] && break
+            sleep 10
+          done
+          echo "::set-output name=concurrent_conclusion::$conclusion"


### PR DESCRIPTION
This PR add the ability to run integration style tests as part of the PR checks, but only under the following combined conditions:
- If the PR is not a draft
- If the PR targets `master`
- If the PR is labeled as `automerge` or `manualmerge` and not `bypass:integration`
- A check has not already run for the same files state

Furthermore it should attempt to run the test on master only if it hadn't previously run on the same state of the git tree, avoiding unnecessary duplicate checks.

The ultimate goal with the `manualmerge` label is that the GH checks would require one of the "merge" labels to enable merging, but that's for a future improvement.

I have setup the branch protections to require the always passing `mergify-merge-queue-test` which I've updated to use this new shared integration workflow.