### PR TITLE
feat(run-protocol): collect runStake fees

### DIFF
--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -40,6 +40,7 @@ const CENTRAL_DENOM_NAME = 'urun';
  *   reservePublicFacet: unknown,
  *   reserveCreatorFacet: GovernedContractFacetAccess<any>,
  *   reserveGovernorCreatorFacet: GovernedContractFacetAccess<any>,
+ *   runStakeCreatorFacet: import('./runStake/runStake.js').RunStakeCreator,
  *   vaultFactoryCreator: VaultFactory,
  *   vaultFactoryGovernorCreator: GovernedContractFacetAccess<unknown>,
  *   vaultFactoryVoteCreator: unknown,
@@ -463,6 +464,7 @@ export const startRewardDistributor = async ({
     loadVat,
     vaultFactoryCreator,
     ammCreatorFacet,
+    runStakeCreatorFacet,
     zoe,
   },
   issuer: {
@@ -496,12 +498,13 @@ export const startRewardDistributor = async ({
   }
 
   const vats = { distributeFees: E(loadVat)('distributeFees') };
-  const [vaultAdmin, ammAdmin] = await Promise.all([
+  const [vaultAdmin, ammAdmin, runStakeAdmin] = await Promise.all([
     vaultFactoryCreator,
     ammCreatorFacet,
+    runStakeCreatorFacet,
   ]);
   await E(vats.distributeFees).buildDistributor(
-    [vaultAdmin, ammAdmin].map(cf =>
+    [vaultAdmin, ammAdmin, runStakeAdmin].map(cf =>
       E(vats.distributeFees).makeFeeCollector(zoe, cf),
     ),
     feeCollectorDepositFacet,

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -3,6 +3,7 @@
 import { AmountMath } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
 import { E, Far } from '@endo/far';
+import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import { makeAttestationFacets } from './attestation.js';
 import { ManagerKW as KW } from './constants.js';
 import { makeRunStakeKit } from './runStakeKit.js';
@@ -71,10 +72,10 @@ const { values } = Object;
  * authorizes placing a lien some of the staked assets in that account.
  * @typedef {{
  *   provideAttestationMaker: (addr: string) => AttestationTool,
- *   getLiened: (address: string, brand: Brand<'nat'>) => Amount<'nat'>,
+ *   makeCollectFeesInvitation: () => Promise<Invitation>,
  * }} RunStakeCreator
  *
- * @type {ContractStartFn<RunStakePublic, RunStakeCreator,
+ * @type {ContractStartFn<RunStakePublic, ERef<GovernedCreatorFacet<RunStakeCreator>>,
  *                        RunStakeTerms, RunStakePrivateArgs>}
  */
 export const start = async (
@@ -197,13 +198,19 @@ export const start = async (
     }),
   );
 
-  const creatorFacet = makeGovernorFacet(
-    Far('runStake creator', {
-      provideAttestationMaker: att.creatorFacet.provideAttestationTool,
-    }),
-  );
+  /** @type {ERef<RunStakeCreator>} */
+  const creatorFacet = Far('runStake creator', {
+    provideAttestationMaker: att.creatorFacet.provideAttestationTool,
+    makeCollectFeesInvitation: () => {
+      return makeMakeCollectFeesInvitation(
+        zcf,
+        rewardPoolSeat,
+        debtMint.getIssuerRecord().brand,
+        'RUN',
+      ).makeCollectFeesInvitation();
+    },
+  });
 
-  // @ts-expect-error makeGovernorFacet loses type info
-  return { publicFacet, creatorFacet };
+  return { publicFacet, creatorFacet: makeGovernorFacet(creatorFacet) };
 };
 harden(start);

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -205,7 +205,7 @@ export const start = async (
       return makeMakeCollectFeesInvitation(
         zcf,
         rewardPoolSeat,
-        debtMint.getIssuerRecord().brand,
+        debtBrand,
         'RUN',
       ).makeCollectFeesInvitation();
     },

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -291,7 +291,6 @@ test('runStake API usage', async (/** @type {RunStakeTestContext} */ t) => {
 
   const { chain, space } = await bootstrapRunStake(t, timer);
   const { consume } = space;
-  // @ts-expect-error TODO: add runStakeCreatorFacet to EconomyBootstrapPowers
   const { zoe, runStakeCreatorFacet: creatorFacet } = consume;
   const runBrand = await space.brand.consume.RUN;
   const bldBrand = await space.brand.consume.BLD;
@@ -339,7 +338,6 @@ test('extra offer keywords are rejected', async (/** @type {RunStakeTestContext}
 
   const { chain, space } = await bootstrapRunStake(t, timer);
   const { consume } = space;
-  // @ts-expect-error TODO: add runStakeCreatorFacet to EconomyBootstrapPowers
   const { zoe, runStakeCreatorFacet: creatorFacet } = consume;
   const runBrand = await space.brand.consume.RUN;
   const bldBrand = await space.brand.consume.BLD;


### PR DESCRIPTION
## Description

- add `makeCollectFeesInvitation` to RunStake's creator
- fix types
- add runStakeCreator to the list in `startRewardDistributor`

### Security Considerations

RunStake creator facet exposes a way to collect its fees

fixes: #5004

### Documentation Considerations

--

### Testing Considerations

Relying on types. Open to requests for additional coverage.