### PR TITLE
fix(bundleTool): don't ignore module path in metadata check

### DIFF
--- a/packages/run-protocol/test/bundleTool.js
+++ b/packages/run-protocol/test/bundleTool.js
@@ -90,7 +90,7 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
     return meta;
   };
 
-  const validate = async targetName => {
+  const validate = async (targetName, rootOpt) => {
     const metaRd = wr.readOnly().neighbor(toBundleMeta(targetName));
     let txt;
     try {
@@ -108,6 +108,13 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
       moduleSource: { absolute: moduleSource },
     } = meta;
     assert.equal(bundleFileName, toBundleName(targetName));
+    if (rootOpt) {
+      assert.equal(
+        moduleSource,
+        cwd.neighbor(rootOpt).absolute(),
+        X`bundle ${targetName} was for ${moduleSource}, not ${rootOpt}`,
+      );
+    }
     const { mtime: actualBundleTime } = await wr
       .readOnly()
       .neighbor(bundleFileName)
@@ -135,7 +142,7 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
     let meta;
     if (wr.readOnly().neighbor(toBundleMeta(targetName)).exists()) {
       try {
-        meta = await validate(targetName);
+        meta = await validate(targetName, rootPath);
         const { bundleTime, contents } = meta;
         log(
           `${wr}`,


### PR DESCRIPTION
## Description

commit, originally by @dckc extracted from #5129

[See also](https://github.com/Agoric/agoric-sdk/pull/5129/commits/00d32a7e84d8d4fd9309a1e115145d5164c93b19#r854207585)


### Security Considerations

This is updating bundleTool.  I dunno what the security implications are?

### Documentation Considerations

I think there are none. This is an internal tool.

### Testing Considerations

None
