### PR TITLE
refactor: change notification of param changes to be once per set

### DIFF
--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -76,7 +76,6 @@ const makeParamManagerBuilder = zoe => {
     const setParamValue = newValue => {
       assertion(newValue);
       current = newValue;
-      publication.updateState({ name, type, value: current });
       return harden({ [name]: newValue });
     };
     setParamValue(value);
@@ -220,11 +219,6 @@ const makeParamManagerBuilder = zoe => {
     const setInvitation = async ([newInvitation, amount]) => {
       currentAmount = amount;
       currentInvitation = newInvitation;
-      publication.updateState({
-        name,
-        type: ParamTypes.INVITATION,
-        value: currentAmount,
-      });
       return harden({ [name]: currentAmount });
     };
     const inviteAndAmount = await prepareToSetInvitation(invitation);
@@ -312,6 +306,7 @@ const makeParamManagerBuilder = zoe => {
       return [name, setFn(results[i])];
     });
     const newValues = Object.fromEntries(tuples);
+    publication.updateState({ paramNames });
 
     return deeplyFulfilled(harden(newValues));
   };

--- a/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
@@ -95,11 +95,9 @@ const expectedcontractGovernorStartLog = [
   '&& running a task scheduled for 3. &&',
   'vote outcome: {"changes":{"MalleableNumber":"[299792458n]"}}',
   'updated to {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'MalleableNumber was "[602214090000000000000000n]" after the vote.',
+  'MalleableNumber changed in a vote.',
   'current value of MalleableNumber is 299792458',
-  'Electorate was {"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]} after the vote.',
   'Number after: 299792458',
-  'MalleableNumber was "[299792458n]" after the vote.',
 ];
 
 test.serial('contract governance', async t => {
@@ -132,11 +130,9 @@ const expectedChangeElectorateLog = [
   '&& running a task scheduled for 4. &&',
   'vote outcome: {"changes":{"MalleableNumber":"[299792458n]"}}',
   'updated to {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'MalleableNumber was "[602214090000000000000000n]" after the vote.',
+  'Electorate changed in a vote.',
   'current value of MalleableNumber is 299792458',
-  'Electorate was {"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]} after the vote.',
-  'Electorate was {"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]} after the vote.',
-  'MalleableNumber was "[299792458n]" after the vote.',
+  'MalleableNumber changed in a vote.',
 ];
 
 test.serial('change electorate', async t => {
@@ -159,14 +155,36 @@ const expectedBrokenUpdateLog = [
   'Validation complete: true',
   'vote rejected outcome: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
   'update failed: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
-  'MalleableNumber was "[602214090000000000000000n]" after the vote.',
   'current value of MalleableNumber is 602214090000000000000000',
-  'Electorate was {"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]} after the vote.',
 ];
 
 test.serial('brokenUpdateStart', async t => {
   const dump = await main(t, ['brokenUpdateStart']);
   t.deepEqual(dump.log, expectedBrokenUpdateLog);
+});
+
+const changeTwoParamsLog = [
+  '=> voter and electorate vats are set up',
+  '@@ schedule task for:2, currently: 0 @@',
+  'Voter Alice voted for {"noChange":["Electorate","MalleableNumber"]}',
+  'Voter Bob voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+  'Voter Carol voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+  'Voter Dave voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+  'Voter Emma voted for {"noChange":["Electorate","MalleableNumber"]}',
+  '@@ tick:1 @@',
+  '@@ tick:2 @@',
+  '&& running a task scheduled for 2. &&',
+  'vote outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+  'Validation complete: true',
+  'updated to ({"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}})',
+  'successful outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}} ',
+  'Electorate,MalleableNumber changed in a vote.',
+  'current value of MalleableNumber is 42',
+];
+
+test.serial('changeTwoParams', async t => {
+  const dump = await main(t, ['changeTwoParams']);
+  t.deepEqual(dump.log, changeTwoParamsLog);
 });
 
 const expectedApiGovernanceLog = [


### PR DESCRIPTION
spin-off of #5129

## Description

When converting parameter changes under governance to be done atomically as a set of changes, I didn't update the notification. This changes it to only notify once when a collection of changes is processed.

### Security Considerations

It no longer gives the new values, so the recipient of the notification has to look it up if they care.

### Documentation Considerations

None.

### Testing Considerations

Added a new test to show successful update of multiple params
