### PR TITLE
feat(vault): governance upgrade of liquidation

### DIFF
--- a/packages/SwingSet/misc-tools/vat-map.py
+++ b/packages/SwingSet/misc-tools/vat-map.py
@@ -20,7 +20,8 @@ abbreviations = {
     "packages/run-protocol/src/vaultFactory/vaultFactory.js": "vaultFactory",
     "packages/pegasus/src/pegasus.js": "pegasus",
     "packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js": "amm",
-    "packages/run-protocol/src/vaultFactory/liquidateMinimum.js": "liquidate",
+    "packages/run-protocol/src/vaultFactory/liquidateMinimum.js": "liquidateMinimum",
+    "packages/run-protocol/src/vaultFactory/liquidateIncrementally.js": "liquidate",
     }
 
 EPRE = re.compile(r'const entrypoint = "([^"]+)"')

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -312,6 +312,8 @@ const makeParamManagerBuilder = zoe => {
   };
 
   const makeParamManager = () => {
+    publication.updateState(harden({ paramNames: [...namesToParams.keys()] }));
+
     // CRUCIAL: Contracts that call buildParamManager should only export the
     // resulting paramManager to their creatorFacet, where it will be picked up by
     // contractGovernor. The getParams method can be shared widely.

--- a/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
@@ -95,8 +95,9 @@ const expectedcontractGovernorStartLog = [
   '&& running a task scheduled for 3. &&',
   'vote outcome: {"changes":{"MalleableNumber":"[299792458n]"}}',
   'updated to {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'MalleableNumber changed in a vote.',
+  'Electorate,MalleableNumber changed in a vote.',
   'current value of MalleableNumber is 299792458',
+  'MalleableNumber changed in a vote.',
   'Number after: 299792458',
 ];
 
@@ -130,8 +131,9 @@ const expectedChangeElectorateLog = [
   '&& running a task scheduled for 4. &&',
   'vote outcome: {"changes":{"MalleableNumber":"[299792458n]"}}',
   'updated to {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'Electorate changed in a vote.',
+  'Electorate,MalleableNumber changed in a vote.',
   'current value of MalleableNumber is 299792458',
+  'Electorate changed in a vote.',
   'MalleableNumber changed in a vote.',
 ];
 
@@ -155,6 +157,7 @@ const expectedBrokenUpdateLog = [
   'Validation complete: true',
   'vote rejected outcome: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
   'update failed: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
+  'Electorate,MalleableNumber changed in a vote.',
   'current value of MalleableNumber is 602214090000000000000000',
 ];
 
@@ -180,6 +183,7 @@ const changeTwoParamsLog = [
   'successful outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}} ',
   'Electorate,MalleableNumber changed in a vote.',
   'current value of MalleableNumber is 42',
+  'Electorate,MalleableNumber changed in a vote.',
 ];
 
 test.serial('changeTwoParams', async t => {

--- a/packages/run-protocol/scripts/init-core.js
+++ b/packages/run-protocol/scripts/init-core.js
@@ -40,9 +40,13 @@ const installKeyGroups = {
       '../src/vaultFactory/vaultFactory.js',
       '../bundles/bundle-vaultFactory.js',
     ],
-    liquidate: [
+    liquidateMinimum: [
       '../src/vaultFactory/liquidateMinimum.js',
       '../bundles/bundle-liquidateMinimum.js',
+    ],
+    liquidate: [
+      '../src/vaultFactory/liquidateIncrementally.js',
+      '../bundles/bundle-liquidateIncrementally.js',
     ],
     reserve: ['../src/reserve/assetReserve.js', '../bundles/bundle-reserve.js'],
   },

--- a/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -93,9 +93,9 @@ const start = async zcf => {
     );
   };
 
-  function computeOracleLimit(oracleQuote, oracleTolerance) {
+  const computeOracleLimit = (oracleQuote, oracleTolerance) => {
     return ceilMultiplyBy(getAmountOut(oracleQuote), oneMinus(oracleTolerance));
-  }
+  };
 
   const getAMMFeeBP = async () => {
     const zoe = zcf.getZoeService();

--- a/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -15,7 +15,7 @@ import { Far } from '@endo/marshal';
 import { makeTracer } from '../makeTracer.js';
 
 const { details: X } = assert;
-const trace = makeTracer('LiqI');
+const trace = makeTracer('LiqI', false);
 
 /**
  * @file
@@ -266,36 +266,12 @@ const start = async zcf => {
   };
 
   const creatorFacet = Far('debtorInvitationCreator', {
-    makeDebtorInvitation: () => zcf.makeInvitation(debtorHook, 'Liquidate'),
+    makeLiquidateInvitation: () => zcf.makeInvitation(debtorHook, 'Liquidate'),
   });
 
   // @ts-ignore
   return harden({ creatorFacet });
 };
 
-const makeLiquidationStrategy = creatorFacet => {
-  const makeInvitation = () => E(creatorFacet).makeDebtorInvitation();
-
-  const keywordMapping = () =>
-    harden({
-      Collateral: 'In',
-      RUN: 'Out',
-    });
-
-  const makeProposal = (collateral, run) =>
-    harden({
-      give: { In: collateral },
-      want: { Out: AmountMath.makeEmptyFromAmount(run) },
-    });
-
-  return {
-    makeInvitation,
-    keywordMapping,
-    makeProposal,
-  };
-};
-
 harden(start);
-harden(makeLiquidationStrategy);
-
-export { start, makeLiquidationStrategy };
+export { start };

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -111,6 +111,11 @@
  */
 
 /**
+ * @typedef {Object} Liquidator
+ * @property {() => Promise<Invitation>} makeLiquidateInvitation
+ */
+
+/**
  * @typedef {Object} DebtStatus
  * @property {Timestamp} latestInterestUpdate
  * @property {NatValue} interest interest accrued since latestInterestUpdate

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -153,7 +153,7 @@ const watchGovernance = (govParams, vaultManager, oldInstall, oldTerms) => {
   observeIteration(subscription, {
     updateState(_paramUpdate) {
       const { install, terms } = getLiquidationConfig(govParams);
-      if (install === oldInstall || keyEQ(terms, oldTerms)) {
+      if (install === oldInstall && keyEQ(terms, oldTerms)) {
         return;
       }
       oldInstall = install;
@@ -274,7 +274,7 @@ const machineBehavior = {
     );
     collateralTypes.init(collateralBrand, vm);
     const { install, terms } = getLiquidationConfig(directorParamManager);
-    console.log('PARAM UPDATE', install, terms);
+    // console.log('PARAM UPDATE', install, terms);
     await vm.setupLiquidator(install, terms);
     watchGovernance(directorParamManager, vm, install, terms);
     return vm;

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -27,7 +27,7 @@ import { checkDebtLimit } from '../contractSupport.js';
 
 const { details: X } = assert;
 
-const trace = makeTracer('VM', false);
+const trace = makeTracer('VM', true);
 
 /**
  * @typedef {{
@@ -35,6 +35,7 @@ const trace = makeTracer('VM', false);
  *  interestRate: Ratio,
  *  latestInterestUpdate: bigint,
  *  totalDebt: Amount<'nat'>,
+ *  liquidatorInstance?: Instance,
  * }} AssetState */
 
 /**
@@ -72,6 +73,7 @@ const trace = makeTracer('VM', false);
  * latestInterestUpdate: bigint,
  * liquidationInProgress: boolean,
  * liquidator?: Liquidator
+ * liquidatorInstance?: Instance
  * outstandingQuote: Promise<MutableQuote>| null,
  * totalDebt: Amount<'nat'>,
  * vaultCounter: number,
@@ -145,6 +147,7 @@ const initState = (
       interestRate: fixed.factoryPowers.getGovernedParams().getInterestRate(),
       latestInterestUpdate,
       totalDebt,
+      liquidationInstance: undefined,
     }),
   );
 
@@ -157,6 +160,7 @@ const initState = (
     vaultCounter: 0,
     liquidationInProgress: false,
     liquidator: undefined,
+    liquidatorInstance: undefined,
     totalDebt,
     compoundedInterest,
     latestInterestUpdate,
@@ -205,19 +209,24 @@ const helperBehavior = {
       updateTime,
     );
     Object.assign(state, stateUpdates);
+    facets.helper.notify();
+    trace('chargeAllVaults complete');
+    facets.helper.reschedulePriceCheck();
+  },
 
+  notify: ({ state }) => {
+    const interestRate = state.factoryPowers
+      .getGovernedParams()
+      .getInterestRate();
     /** @type {AssetState} */
     const payload = harden({
       compoundedInterest: state.compoundedInterest,
       interestRate,
       latestInterestUpdate: state.latestInterestUpdate,
       totalDebt: state.totalDebt,
+      liquidatorInstance: state.liquidatorInstance,
     });
     state.assetUpdater.updateState(payload);
-
-    trace('chargeAllVaults complete', payload);
-
-    facets.helper.reschedulePriceCheck();
   },
 
   /**
@@ -500,7 +509,11 @@ const selfBehavior = {
    * @param {Installation} liquidationInstall
    * @param {Object} liquidationTerms
    */
-  setupLiquidator: async ({ state }, liquidationInstall, liquidationTerms) => {
+  setupLiquidator: async (
+    { state, facets },
+    liquidationInstall,
+    liquidationTerms,
+  ) => {
     const { zcf, debtBrand, collateralBrand } = state;
     const { ammPublicFacet, priceAuthority, timerService } = zcf.getTerms();
     const zoe = zcf.getZoeService();
@@ -512,7 +525,7 @@ const selfBehavior = {
       collateralBrand,
       liquidationTerms,
     });
-    const { creatorFacet } = await E(zoe).startInstance(
+    const { creatorFacet, instance } = await E(zoe).startInstance(
       liquidationInstall,
       harden({ RUN: debtIssuer, Collateral: collateralIssuer }),
       harden({
@@ -523,7 +536,14 @@ const selfBehavior = {
         debtBrand,
       }),
     );
+    trace('setup liquidator complete', {
+      instance,
+      old: state.liquidatorInstance,
+      equal: state.liquidatorInstance === instance,
+    });
+    state.liquidatorInstance = instance;
     state.liquidator = creatorFacet;
+    facets.helper.notify();
   },
 
   /** @param {MethodContext} context */

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -23,7 +23,7 @@ import {
   startRunStake,
 } from '../../src/econ-behaviors.js';
 import * as Collect from '../../src/collect.js';
-import { setUpZoeForTest } from '../supports.js';
+import { makeVoterTool, setUpZoeForTest } from '../supports.js';
 import { ManagerKW as KW } from '../../src/runStake/constants.js';
 import { unsafeMakeBundleCache } from '../bundleTool.js';
 
@@ -430,42 +430,6 @@ test('forged Attestation fails', async (/** @type {RunStakeTestContext} */ t) =>
   await t.throwsAsync(E(seat).getOfferResult());
 });
 
-/**
- * Economic Committee of one.
- *
- * @param {ERef<ZoeService>} zoe
- * @param {ERef<CommitteeElectorateCreatorFacet>} electorateCreator
- * @param {ERef<GovernedContractFacetAccess<unknown>>} runStakeGovernorCreatorFacet
- * @param {Installation} counter
- */
-const makeC1 = async (
-  zoe,
-  electorateCreator,
-  runStakeGovernorCreatorFacet,
-  counter,
-) => {
-  const [invitation] = await E(electorateCreator).getVoterInvitations();
-  const seat = E(zoe).offer(invitation);
-  const voteFacet = E(seat).getOfferResult();
-  return harden({
-    setMintingRatio: async (newValue, deadline) => {
-      const paramsSpec = harden({
-        paramPath: { key: 'governedParams' },
-        changes: { MintingRatio: newValue },
-      });
-      /** @type { ContractGovernanceVoteResult } */
-      const { details, instance } = await E(
-        runStakeGovernorCreatorFacet,
-      ).voteOnParamChanges(counter, deadline, paramsSpec);
-      const { questionHandle, positions } = await details;
-      const cast = E(voteFacet).castBallotFor(questionHandle, [positions[0]]);
-      const count = E(zoe).getPublicFacet(instance);
-      const outcome = E(count).getOutcome();
-      return { cast, outcome };
-    },
-  });
-};
-
 const approxEqual = (t, actual, expected, epsilon) => {
   const { min, max, subtract, isGTE } = AmountMath;
   if (isGTE(epsilon, subtract(max(actual, expected), min(actual, expected)))) {
@@ -495,7 +459,7 @@ const makeWorld = async (/** @type {RunStakeTestContext} */ t) => {
   };
 
   const counter = await space.installation.consume.binaryVoteCounter;
-  const committee = makeC1(
+  const committee = makeVoterTool(
     zoe,
     space.consume.economicCommitteeCreatorFacet,
     // @ts-expect-error TODO: add runStakeGovernorCreatorFacet to vats/src/types.js
@@ -720,8 +684,11 @@ const makeWorld = async (/** @type {RunStakeTestContext} */ t) => {
       const newValue = pairToRatio(newRunToBld, bldBrand);
 
       const deadline = 3n * SECONDS_PER_DAY;
-      const { cast, outcome } = await E(committee).setMintingRatio(
-        newValue,
+      const { cast, outcome } = await E(committee).changeParam(
+        harden({
+          paramPath: { key: 'governedParams' },
+          changes: { MintingRatio: newValue },
+        }),
         deadline,
       );
       await cast;

--- a/packages/run-protocol/test/swingsetTests/governance/test-governance.js
+++ b/packages/run-protocol/test/swingsetTests/governance/test-governance.js
@@ -97,7 +97,7 @@ test.serial('vaultFactory', async t => {
     'after vote on (InterestRate), InterestRate numerator is 4321',
     'at 3 days: vote closed',
     'at 3 days: Alice owes {"brand":"[Alleged: RUN brand]","value":"[510105n]"}',
-    'at 3 days: 1 day after votes cast, assetNotifier update #6 has interestRate.numerator 250',
-    'at 4 days: 2 days after votes cast, assetNotifier update #7 has interestRate.numerator 4321',
+    'at 3 days: 1 day after votes cast, assetNotifier update #7 has interestRate.numerator 250',
+    'at 4 days: 2 days after votes cast, assetNotifier update #8 has interestRate.numerator 4321',
   ]);
 });


### PR DESCRIPTION
closes: #5015

## Description

* move liquidator spawning into vaultManager
* react to governance by setting up a new liq contract
*   only if the install or parameters have changed
* remove liquidation strategy

### Security Considerations

The old liquidation contract remains; it just has no customers.

### Documentation Considerations
N/A

### Testing Considerations

Added "update liquidator" to vote in a change to the liquidation terms and observe that the liquidation instance was updated