### PR TITLE
refactor(vault): make liquidation recursion a loop

### DIFF
--- a/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -156,7 +156,7 @@ const start = async zcf => {
         AmountMath.isGTE(proceedsSoFar, originalDebt) ||
         AmountMath.isEmpty(toSell)
       ) {
-        trace('exiting async loop');
+        trace('exiting processTranches loop');
         return;
       }
       await oncePerBlock();

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -167,7 +167,7 @@ const watchGovernance = (govParams, vaultManager, oldInstall, oldTerms) => {
   observeIteration(subscription, {
     updateState(_paramUpdate) {
       const { install, terms } = getLiquidationConfig(govParams);
-      if (install === oldInstall || keyEQ(terms, oldTerms)) {
+      if (install === oldInstall && keyEQ(terms, oldTerms)) {
         return;
       }
       oldInstall = install;

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -167,7 +167,7 @@ const watchGovernance = (govParams, vaultManager, oldInstall, oldTerms) => {
   observeIteration(subscription, {
     updateState(_paramUpdate) {
       const { install, terms } = getLiquidationConfig(govParams);
-      if (install === oldInstall && keyEQ(terms, oldTerms)) {
+      if (install === oldInstall || keyEQ(terms, oldTerms)) {
         return;
       }
       oldInstall = install;

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -268,8 +268,8 @@ const helperBehavior = {
       return;
     }
 
-    // INTERLOCK: the first time through, start the process to process
-    // liquidations over time.
+    // INTERLOCK: the first time through, start the activity to wait for
+    // and process liquidations over time.
     if (!liquidationInProgress) {
       liquidationInProgress = true;
       // eslint-disable-next-line consistent-return


### PR DESCRIPTION
refs: #5211

## Description

The liquidation recursion was unbounded, and so could consume a lot of space, depending on implementation details. This should remove that risk.

### Security Considerations

Users could tickle the vulnerability by changing their collateralization ration.

### Documentation Considerations

N/A

### Testing Considerations

The existing tests confirm that liquidation still works. 