### PR TITLE
replace ts-ignore with ts-expect-error

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -181,7 +181,6 @@ const checkLRAndGetHelpers = (leftAmount, rightAmount, brand = undefined) => {
  * @returns {[K, K]}
  */
 const coerceLR = (h, leftAmount, rightAmount) => {
-  // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
   return [h.doCoerce(leftAmount.value), h.doCoerce(rightAmount.value)];
 };
 
@@ -208,7 +207,6 @@ const AmountMath = {
     assertRemotable(brand, 'brand');
     const h = assertValueGetHelpers(allegedValue);
     const value = h.doCoerce(allegedValue);
-    // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
     return harden({ brand, value });
   },
   /**
@@ -229,7 +227,6 @@ const AmountMath = {
       X`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the specified brand ${brand}.`,
     );
     // Will throw on inappropriate value
-    // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
     return AmountMath.make(brand, allegedValue);
   },
   /**
@@ -256,7 +253,6 @@ const AmountMath = {
     assertRemotable(brand, 'brand');
     assertAssetKind(assetKind);
     const value = helpers[assetKind].doMakeEmpty();
-    // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
     return harden({ brand, value });
   },
   /**

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -181,7 +181,7 @@ const checkLRAndGetHelpers = (leftAmount, rightAmount, brand = undefined) => {
  * @returns {[K, K]}
  */
 const coerceLR = (h, leftAmount, rightAmount) => {
-  // @ts-ignore cast (ignore b/c erroring in CI but not my IDE)
+  // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
   return [h.doCoerce(leftAmount.value), h.doCoerce(rightAmount.value)];
 };
 
@@ -208,7 +208,7 @@ const AmountMath = {
     assertRemotable(brand, 'brand');
     const h = assertValueGetHelpers(allegedValue);
     const value = h.doCoerce(allegedValue);
-    // @ts-ignore cast (ignore b/c erroring in CI but not my IDE)
+    // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
     return harden({ brand, value });
   },
   /**
@@ -229,7 +229,7 @@ const AmountMath = {
       X`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the specified brand ${brand}.`,
     );
     // Will throw on inappropriate value
-    // @ts-ignore cast (ignore b/c erroring in CI but not my IDE)
+    // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
     return AmountMath.make(brand, allegedValue);
   },
   /**
@@ -256,7 +256,7 @@ const AmountMath = {
     assertRemotable(brand, 'brand');
     assertAssetKind(assetKind);
     const value = helpers[assetKind].doMakeEmpty();
-    // @ts-ignore cast (ignore b/c erroring in CI but not my IDE)
+    // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
     return harden({ brand, value });
   },
   /**
@@ -272,7 +272,7 @@ const AmountMath = {
     const { brand, value } = amount;
     // @ts-expect-error cast
     const assetKind = assertValueGetAssetKind(value);
-    // @ts-ignore cast (ignore b/c erroring in CI but not my IDE)
+    // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
     return AmountMath.makeEmpty(brand, assetKind);
   },
   /**
@@ -388,7 +388,7 @@ harden(AmountMath);
 const getAssetKind = amount => {
   assertRecord(amount, 'amount');
   const { value } = amount;
-  // @ts-ignore cast (ignore b/c erroring in CI but not my IDE)
+  // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
   return assertValueGetAssetKind(value);
 };
 harden(getAssetKind);

--- a/packages/ERTP/test/unitTests/mathHelpers/test-copyBagMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-copyBagMathHelpers.js
@@ -23,7 +23,7 @@ test('copyBag with strings make', t => {
     `[6] is a valid bag even though it isn't a string`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, 'abc'),
     {
       message:
@@ -49,7 +49,7 @@ test('copyBag with strings coerce', t => {
     `[6] is a valid bag`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.coerce(mockBrand, harden({ brand: mockBrand, value: '6' })),
     {
       message:

--- a/packages/ERTP/test/unitTests/mathHelpers/test-copySetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-copySetMathHelpers.js
@@ -19,7 +19,7 @@ test('copySet with strings make', t => {
     `[6] is a valid set even though it isn't a string`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, 'abc'),
     {
       message:
@@ -52,7 +52,7 @@ test('copySet with strings coerce', t => {
     `[6] is a valid set`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.coerce(mockBrand, harden({ brand: mockBrand, value: '6' })),
     {
       message:

--- a/packages/ERTP/test/unitTests/mathHelpers/test-copySetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-copySetMathHelpers.js
@@ -126,7 +126,7 @@ test('copySet with strings isGTE', t => {
         harden({ brand: mockBrand, value: makeCopySet(['a', 'a']) }),
         harden({ brand: mockBrand, value: makeCopySet(['b']) }),
       ),
-    null,
+    undefined,
     `duplicates in the left of isGTE should throw`,
   );
   t.throws(
@@ -135,7 +135,7 @@ test('copySet with strings isGTE', t => {
         harden({ brand: mockBrand, value: makeCopySet(['a']) }),
         harden({ brand: mockBrand, value: makeCopySet(['b', 'b']) }),
       ),
-    null,
+    undefined,
     `duplicates in the right of isGTE should throw`,
   );
   t.assert(

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -12,13 +12,13 @@ import { mockBrand } from './mockBrand.js';
 
 test('natMathHelpers make', t => {
   t.deepEqual(m.make(mockBrand, 4n), { brand: mockBrand, value: 4n });
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => m.make(mockBrand, 4), {
     message:
       'value 4 must be a bigint, copySet, copyBag, or an array, not "number"',
   });
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, 'abc'),
     {
       message:
@@ -27,7 +27,7 @@ test('natMathHelpers make', t => {
     `'abc' is not a nat`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, -1),
     {
       message:
@@ -39,7 +39,7 @@ test('natMathHelpers make', t => {
 
 test('natMathHelpers make no brand', t => {
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(4n),
     {
       message: '"brand" "[4n]" must be a remotable, not "bigint"',
@@ -77,7 +77,7 @@ test('natMathHelpers coerce', t => {
     `coerce can't take the wrong brand`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.coerce(3n, mockBrand),
     {
       message: '"brand" "[3n]" must be a remotable, not "bigint"',
@@ -88,7 +88,7 @@ test('natMathHelpers coerce', t => {
 
 test('natMathHelpers coerce no brand', t => {
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.coerce(m.make(4n, mockBrand)),
     {
       message: '"brand" "[4n]" must be a remotable, not "bigint"',
@@ -99,7 +99,7 @@ test('natMathHelpers coerce no brand', t => {
 
 test('natMathHelpers getValue', t => {
   t.is(m.getValue(mockBrand, m.make(mockBrand, 4n)), 4n);
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => m.getValue(mockBrand, m.make(mockBrand, 4)), {
     message:
       'value 4 must be a bigint, copySet, copyBag, or an array, not "number"',
@@ -108,7 +108,7 @@ test('natMathHelpers getValue', t => {
 
 test('natMathHelpers getValue no brand', t => {
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.getValue(m.make(4n, mockBrand)),
     {
       message: '"brand" "[4n]" must be a remotable, not "bigint"',
@@ -125,7 +125,7 @@ test('natMathHelpers makeEmpty', t => {
 
 test('natMathHelpers makeEmpty no brand', t => {
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.makeEmpty(AssetKind.NAT),
     {
       message: '"brand" "nat" must be a remotable, not "string"',
@@ -146,7 +146,7 @@ test('natMathHelpers isEmpty', t => {
   t.assert(m.isEmpty(m.make(mockBrand, 0n)), `isEmpty(0) is true`);
   t.falsy(m.isEmpty(m.make(mockBrand, 6n)), `isEmpty(6) is false`);
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.isEmpty('abc'),
     {
       message: '"amount" "abc" must be a pass-by-copy record, not "string"',
@@ -154,7 +154,7 @@ test('natMathHelpers isEmpty', t => {
     `isEmpty('abc') throws because it cannot be coerced`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.isEmpty(harden({ brand: mockBrand, value: 'abc' })),
     {
       message:
@@ -163,7 +163,7 @@ test('natMathHelpers isEmpty', t => {
     `isEmpty('abc') throws because it cannot be coerced`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.isEmpty(0n),
     {
       message: '"amount" "[0n]" must be a pass-by-copy record, not "bigint"',

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -50,7 +50,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2) => {
     'any key is a valid element',
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, 'a'),
     {
       message:
@@ -97,7 +97,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2) => {
     'any key is a valid element',
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.coerce(mockBrand, harden({ brand: mockBrand, value: 'a' })),
     {
       message:
@@ -133,7 +133,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2) => {
     `m.isEmpty([]) is true`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.isEmpty(harden({ brand: mockBrand, value: {} })),
     {
       message:

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -19,7 +19,7 @@ test('set with strings make', t => {
     `[6] is a valid set even though it isn't a string`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.make(mockBrand, 'abc'),
     {
       message:
@@ -45,7 +45,7 @@ test('set with strings coerce', t => {
     `[6] is a valid set`,
   );
   t.throws(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => m.coerce(mockBrand, harden({ brand: mockBrand, value: '6' })),
     {
       message:

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -97,7 +97,7 @@ test('set with strings isGTE', t => {
         harden({ brand: mockBrand, value: ['a', 'a'] }),
         harden({ brand: mockBrand, value: ['b'] }),
       ),
-    null,
+    undefined,
     `duplicates in the left of isGTE should throw`,
   );
   t.throws(
@@ -106,7 +106,7 @@ test('set with strings isGTE', t => {
         harden({ brand: mockBrand, value: ['a'] }),
         harden({ brand: mockBrand, value: ['b', 'b'] }),
       ),
-    null,
+    undefined,
     `duplicates in the right of isGTE should throw`,
   );
   t.assert(

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -7,12 +7,12 @@ import { Far } from '@endo/marshal';
 import { AssetKind, makeIssuerKit, AmountMath } from '../../src/index.js';
 
 test('makeIssuerKit bad allegedName', async t => {
-  // @ts-ignore Intentional wrong type for testing
+  // @ts-expect-error Intentional wrong type for testing
   t.throws(() => makeIssuerKit({}), { message: `{} must be a string` });
 });
 
 test('makeIssuerKit bad assetKind', async t => {
-  // @ts-ignore Intentional wrong type for testing
+  // @ts-expect-error Intentional wrong type for testing
   t.throws(() => makeIssuerKit('myTokens', 'somethingWrong'), {
     message:
       /The assetKind "somethingWrong" must be one of \["copyBag","copySet","nat","set"\]/,
@@ -25,7 +25,7 @@ test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
       makeIssuerKit(
         'myTokens',
         AssetKind.NAT,
-        // @ts-ignore Intentional wrong type for testing
+        // @ts-expect-error Intentional wrong type for testing
         harden({ decimalPlaces: 'hello' }),
       ),
     {
@@ -40,7 +40,7 @@ test('makeIssuerKit bad displayInfo.assetKind', async t => {
       makeIssuerKit(
         'myTokens',
         AssetKind.NAT,
-        // @ts-ignore Intentional wrong type for testing
+        // @ts-expect-error Intentional wrong type for testing
         harden({
           assetKind: 'something',
         }),
@@ -58,7 +58,7 @@ test('makeIssuerKit bad displayInfo.whatever', async t => {
       makeIssuerKit(
         'myTokens',
         AssetKind.NAT,
-        // @ts-ignore Intentional wrong type for testing
+        // @ts-expect-error Intentional wrong type for testing
         harden({
           whatever: 'something',
         }),
@@ -76,7 +76,7 @@ test('makeIssuerKit malicious displayInfo', async t => {
       makeIssuerKit(
         'myTokens',
         AssetKind.NAT,
-        // @ts-ignore Intentional wrong type for testing
+        // @ts-expect-error Intentional wrong type for testing
         Far('malicious', { doesSomething: () => {} }),
       ),
     {
@@ -90,7 +90,7 @@ test('makeIssuerKit malicious displayInfo', async t => {
 // reached, we can't easily test that pathway.
 test('makeIssuerKit bad optShutdownWithFailure', async t => {
   t.throws(
-    // @ts-ignore Intentional wrong type for testing
+    // @ts-expect-error Intentional wrong type for testing
     () => makeIssuerKit('myTokens', AssetKind.NAT, undefined, 'not a function'),
     {
       message: '"not a function" must be a function',
@@ -100,7 +100,7 @@ test('makeIssuerKit bad optShutdownWithFailure', async t => {
 
 test('brand.isMyIssuer bad issuer', async t => {
   const { brand } = makeIssuerKit('myTokens');
-  // @ts-ignore Intentional wrong type for testing
+  // @ts-expect-error Intentional wrong type for testing
   const result = await brand.isMyIssuer('not an issuer');
   t.false(result);
 });
@@ -146,7 +146,7 @@ test('issuer.combine bad payments array', async t => {
     length: () => 2,
     split: () => {},
   });
-  // @ts-ignore Intentional wrong type for testing
+  // @ts-expect-error Intentional wrong type for testing
   await t.throwsAsync(() => E(issuer).combine(notAnArray2), {
     message:
       '"fromPaymentsArray" "[Alleged: notAnArray2]" must be a pass-by-copy array, not "remotable"',

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -42,7 +42,7 @@ test('brand.getDisplayInfo()', t => {
 
 test('bad display info', t => {
   const displayInfo = harden({ somethingUnexpected: 3 });
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => makeIssuerKit('fungible', AssetKind.NAT, displayInfo), {
     message:
       /key "somethingUnexpected" was not one of the expected keys \["decimalPlaces","assetKind"\]/,
@@ -197,7 +197,7 @@ test('purse.deposit promise', async t => {
   const exclusivePaymentP = E(issuer).claim(payment);
 
   await t.throwsAsync(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => E(purse).deposit(exclusivePaymentP, fungible25),
     { message: /deposit does not accept promises/ },
     'failed to reject a promise for a payment',

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -230,7 +230,7 @@ export async function makeSwingsetController(
   function kernelRequire(what) {
     assert.fail(X`kernelRequire unprepared to satisfy require(${what})`);
   }
-  // @ts-ignore assume kernelBundle is set
+  // @ts-expect-error assume kernelBundle is set
   const kernelBundle = JSON.parse(kvStore.get('kernelBundle'));
   writeSlogObject({ type: 'import-kernel-start' });
   const kernelNS = await importBundle(kernelBundle, {
@@ -269,9 +269,9 @@ export async function makeSwingsetController(
   }
 
   const bundles = [
-    // @ts-ignore assume lockdownBundle is set
+    // @ts-expect-error assume lockdownBundle is set
     JSON.parse(kvStore.get('lockdownBundle')),
-    // @ts-ignore assume supervisorBundle is set
+    // @ts-expect-error assume supervisorBundle is set
     JSON.parse(kvStore.get('supervisorBundle')),
   ];
   const startXSnap = makeStartXSnap(bundles, {

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -561,7 +561,7 @@ export default function buildKernel(
     vatKeeper.initializeReapCountdown(options.reapInterval);
 
     function sendNewVatCallback(args) {
-      // @ts-ignore see assert(...) above
+      // @ts-expect-error see assert(...) above
       queueToKref(vatAdminRootKref, 'newVatCallback', args, 'logFailure');
     }
 

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -561,7 +561,6 @@ export default function buildKernel(
     vatKeeper.initializeReapCountdown(options.reapInterval);
 
     function sendNewVatCallback(args) {
-      // @ts-expect-error see assert(...) above
       queueToKref(vatAdminRootKref, 'newVatCallback', args, 'logFailure');
     }
 

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -191,7 +191,7 @@ export default function makeKernelKeeper(
    */
   function getRequired(key) {
     assert(kvStore.has(key), X`storage lacks required key ${key}`);
-    // @ts-ignore already checked .has()
+    // @ts-expect-error already checked .has()
     return kvStore.get(key);
   }
 

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -324,7 +324,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
   function kernelDeliveryToVatDelivery(vatID, kd) {
     const translators = provideTranslators(vatID);
 
-    // @ts-ignore TODO: types for kernelDeliveryToVatDelivery
+    // @ts-expect-error TODO: types for kernelDeliveryToVatDelivery
     return translators.kernelDeliveryToVatDelivery(kd);
   }
 

--- a/packages/SwingSet/src/liveslots/watchedPromises.js
+++ b/packages/SwingSet/src/liveslots/watchedPromises.js
@@ -124,9 +124,9 @@ export function makeWatchedPromiseManager(
     assert.typeof(rejectHandler, 'function');
 
     const makeWatcher = defineDurableKind(kindHandle, () => ({}), {
-      // @ts-ignore  TS is confused by the spread operator
+      // @ts-expect-error  TS is confused by the spread operator
       onFulfilled: (_context, res, ...args) => fulfillHandler(res, ...args),
-      // @ts-ignore
+      // @ts-expect-error
       onRejected: (_context, rej, ...args) => rejectHandler(rej, ...args),
     });
 

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -26,7 +26,7 @@ test('child termination distinguished from meter exhaustion', async t => {
   const startXSnap = makeStartXSnap(bundles, {
     snapstorePath: undefined, // close enough for this test
     env: {},
-    // @ts-ignore we only need one path thru spawn
+    // @ts-expect-error we only need one path thru spawn
     spawn: (command, args, opts) => {
       const noMetering = ['-l', '0'];
       theProc = spawn(command, [args, ...noMetering], opts);
@@ -46,7 +46,7 @@ test('child termination distinguished from meter exhaustion', async t => {
   const xsWorkerFactory = makeXsSubprocessFactory({
     startXSnap,
     kernelKeeper,
-    // @ts-ignore kernelSlog is not used in this test
+    // @ts-expect-error kernelSlog is not used in this test
     kernelSlog: {},
     allVatPowers: undefined,
     testLog: undefined,
@@ -56,7 +56,7 @@ test('child termination distinguished from meter exhaustion', async t => {
   const bundle = await bundleSource(fn);
 
   /** @type { ManagerOptions } */
-  // @ts-ignore close enough for this test
+  // @ts-expect-error close enough for this test
   const managerOptions = { useTranscript: true };
   const schandler = _vso => ['ok', null];
   const m = await xsWorkerFactory.createFromBundle(

--- a/packages/access-token/src/json-store.js
+++ b/packages/access-token/src/json-store.js
@@ -185,7 +185,7 @@ function makeJSONStore(dirPath, forceReset = false) {
       if (lines) {
         let line = lines.next();
         while (line) {
-          // @ts-ignore JSON.parse can take a Buffer
+          // @ts-expect-error JSON.parse can take a Buffer
           const [key, value] = JSON.parse(line);
           storage.set(key, value);
           line = lines.next();
@@ -289,7 +289,7 @@ export function getAllState(storage) {
   /** @type { Record<string, string> } */
   const stuff = {};
   for (const key of Array.from(storage.getKeys('', ''))) {
-    // @ts-ignore get(key) of key from getKeys() is not undefined
+    // @ts-expect-error get(key) of key from getKeys() is not undefined
     stuff[key] = storage.get(key);
   }
   return stuff;

--- a/packages/governance/src/contractGovernance/assertions.js
+++ b/packages/governance/src/contractGovernance/assertions.js
@@ -8,7 +8,7 @@ const { details: X } = assert;
 const makeLooksLikeBrand = name => {
   return brand => {
     assert(
-      // @ts-ignore value is undifferentiated to this point
+      // @ts-expect-error value is undifferentiated to this point
       isRemotable(brand),
       X`value for ${name} must be a brand, was ${brand}`,
     );

--- a/packages/governance/src/contractGovernance/assertions.js
+++ b/packages/governance/src/contractGovernance/assertions.js
@@ -6,9 +6,9 @@ import { assertIsRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 const { details: X } = assert;
 
 const makeLooksLikeBrand = name => {
+  /** @param {Brand} brand */
   return brand => {
     assert(
-      // @ts-expect-error value is undifferentiated to this point
       isRemotable(brand),
       X`value for ${name} must be a brand, was ${brand}`,
     );

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -188,8 +188,6 @@ const start = async zcf => {
   // this conditional was extracted so both sides are equally asynchronous
   /** @type {() => Promise<ApiGovernor>} */
   const initApiGovernance = async () => {
-    // @ts-expect-error `governedApis` is present on contracts wiht API invocation.
-
     const [governedApis, governedNames] = await Promise.all([
       E(governedCF).getGovernedApis(),
       E(governedCF).getGovernedApiNames(),

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -188,7 +188,7 @@ const start = async zcf => {
   // this conditional was extracted so both sides are equally asynchronous
   /** @type {() => Promise<ApiGovernor>} */
   const initApiGovernance = async () => {
-    // @ts-ignore `governedApis` is present on contracts wiht API invocation.
+    // @ts-expect-error `governedApis` is present on contracts wiht API invocation.
 
     const [governedApis, governedNames] = await Promise.all([
       E(governedCF).getGovernedApis(),

--- a/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
@@ -54,7 +54,7 @@ test.before(async t => {
   const ttime = `${(step4 - start) / 1000}s total`;
   console.log(`bundling: ${ktime}, ${ctime}, ${vtime}, ${ttime}`);
 
-  // @ts-ignore
+  // @ts-expect-error
   t.context.data = { kernelBundles, config };
 });
 

--- a/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
@@ -68,7 +68,7 @@ test.before(async t => {
   const ttime = `${(step4 - start) / 1000}s total`;
   console.log(`bundling: ${ktime}, ${ctime}, ${vtime}, ${ttime}`);
 
-  // @ts-ignore
+  // @ts-expect-error
   t.context.data = { kernelBundles, config };
 });
 

--- a/packages/governance/test/unitTests/test-ballotBuilder.js
+++ b/packages/governance/test/unitTests/test-ballotBuilder.js
@@ -36,7 +36,7 @@ test('bad Question', t => {
   t.throws(
     () =>
       coerceQuestionSpec(
-        // @ts-ignore Illegal Question
+        // @ts-expect-error Illegal Question
         harden({
           method: ChoiceMethod.UNRANKED,
           issue: 'will it blend?',
@@ -58,7 +58,7 @@ test('bad timer', t => {
   t.throws(
     () =>
       coerceQuestionSpec(
-        // @ts-ignore Illegal timer
+        // @ts-expect-error Illegal timer
         harden({
           method: ChoiceMethod.UNRANKED,
           issue,
@@ -78,7 +78,7 @@ test('bad method', t => {
   t.throws(
     () =>
       coerceQuestionSpec(
-        // @ts-ignore Illegal Method
+        // @ts-expect-error Illegal Method
         harden({
           method: 'choose',
           issue,
@@ -98,7 +98,7 @@ test('bad Quorum', t => {
   t.throws(
     () =>
       coerceQuestionSpec(
-        // @ts-ignore Illegal Quorum
+        // @ts-expect-error Illegal Quorum
         harden({
           method: ChoiceMethod.ORDER,
           issue,
@@ -118,7 +118,7 @@ test('bad tieOutcome', t => {
   t.throws(
     () =>
       coerceQuestionSpec(
-        // @ts-ignore Illegal tieOutcome
+        // @ts-expect-error Illegal tieOutcome
         harden({
           method: ChoiceMethod.ORDER,
           issue,

--- a/packages/governance/test/unitTests/test-ballotCount.js
+++ b/packages/governance/test/unitTests/test-ballotCount.js
@@ -279,7 +279,6 @@ test('binary question too many', async t => {
 
   const alicePositions = aliceTemplate.getDetails().positions;
   await t.throwsAsync(
-    // @ts-expect-error  illegal value for testing
     () => E(creatorFacet).submitVote(aliceSeat, alicePositions),
     {
       message: 'only 1 position allowed',

--- a/packages/governance/test/unitTests/test-ballotCount.js
+++ b/packages/governance/test/unitTests/test-ballotCount.js
@@ -279,7 +279,7 @@ test('binary question too many', async t => {
 
   const alicePositions = aliceTemplate.getDetails().positions;
   await t.throwsAsync(
-    // @ts-ignore  illegal value for testing
+    // @ts-expect-error  illegal value for testing
     () => E(creatorFacet).submitVote(aliceSeat, alicePositions),
     {
       message: 'only 1 position allowed',

--- a/packages/governance/test/unitTests/test-buildParamManager.js
+++ b/packages/governance/test/unitTests/test-buildParamManager.js
@@ -218,7 +218,7 @@ test('Invitation', async t => {
     paramManager.getInvitationAmount('Invite').value;
   t.deepEqual(invitationActualAmount, invitationAmount.value);
   t.assert(keyEQ(invitationActualAmount, invitationAmount.value));
-  // @ts-ignore invitationActualAmount's type is unknown
+  // @ts-expect-error invitationActualAmount's type is unknown
   t.is(invitationActualAmount[0].description, 'simple');
 
   t.is(await paramManager.getInternalParamValue('Invite'), invitation);
@@ -304,10 +304,10 @@ test('Strings', async t => {
     .build();
   t.is(paramManager.getString('OurWeapons'), 'fear');
 
-  // @ts-ignore updateOurWeapons is a generated name
+  // @ts-expect-error updateOurWeapons is a generated name
   await paramManager.updateParams({ OurWeapons: 'fear,surprise' });
   t.is(paramManager.getString('OurWeapons'), 'fear,surprise');
-  // @ts-ignore updateOurWeapons is a generated name
+  // @ts-expect-error updateOurWeapons is a generated name
   await t.throwsAsync(
     () =>
       paramManager.updateParams({
@@ -330,7 +330,7 @@ test('Unknown', async t => {
     .build();
   t.is(paramManager.getUnknown('Surprise'), 'party');
 
-  // @ts-ignore updateSurprise is a generated name
+  // @ts-expect-error updateSurprise is a generated name
   await paramManager.updateParams({ Surprise: 'gift' });
   t.is(paramManager.getUnknown('Surprise'), 'gift');
   await paramManager.updateParams({ Surprise: ['gift', 'party'] });

--- a/packages/governance/test/unitTests/test-buildParamManager.js
+++ b/packages/governance/test/unitTests/test-buildParamManager.js
@@ -218,7 +218,6 @@ test('Invitation', async t => {
     paramManager.getInvitationAmount('Invite').value;
   t.deepEqual(invitationActualAmount, invitationAmount.value);
   t.assert(keyEQ(invitationActualAmount, invitationAmount.value));
-  // @ts-expect-error invitationActualAmount's type is unknown
   t.is(invitationActualAmount[0].description, 'simple');
 
   t.is(await paramManager.getInternalParamValue('Invite'), invitation);
@@ -304,10 +303,8 @@ test('Strings', async t => {
     .build();
   t.is(paramManager.getString('OurWeapons'), 'fear');
 
-  // @ts-expect-error updateOurWeapons is a generated name
   await paramManager.updateParams({ OurWeapons: 'fear,surprise' });
   t.is(paramManager.getString('OurWeapons'), 'fear,surprise');
-  // @ts-expect-error updateOurWeapons is a generated name
   await t.throwsAsync(
     () =>
       paramManager.updateParams({
@@ -330,7 +327,6 @@ test('Unknown', async t => {
     .build();
   t.is(paramManager.getUnknown('Surprise'), 'party');
 
-  // @ts-expect-error updateSurprise is a generated name
   await paramManager.updateParams({ Surprise: 'gift' });
   t.is(paramManager.getUnknown('Surprise'), 'gift');
   await paramManager.updateParams({ Surprise: ['gift', 'party'] });

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -273,7 +273,7 @@ export const bob = async asyncIterableP => {
  * @returns {Promise<Passable[]>}
  */
 export const carol = async subscriptionP => {
-  // @ts-ignore
+  // @ts-expect-error
   const subscriptionIteratorP = E(subscriptionP)[Symbol.asyncIterator]();
   const { promise: afterA, resolve: afterAResolve } = makePromiseKit();
 

--- a/packages/notifier/test/test-notifier-examples.js
+++ b/packages/notifier/test/test-notifier-examples.js
@@ -35,7 +35,7 @@ test('notifier for-await-of cannot eat promise', async t => {
   const { updater, notifier } = makeNotifierKit();
   paula(updater);
   const subP = Promise.resolve(notifier);
-  // @ts-ignore We are testing a case which violates the static types
+  // @ts-expect-error We are testing a case which violates the static types
   const log = await alice(subP);
 
   // This TypeError is thrown by JavaScript when a for-await-in loop

--- a/packages/pegasus/src/ics20.js
+++ b/packages/pegasus/src/ics20.js
@@ -77,7 +77,7 @@ export const makeICS20TransferPacket = async ({
   depositAddress,
 }) => {
   // We're using Nat as a dynamic check for overflow.
-  // @ts-ignore - this causes errors on some versions of TS, but not others.
+  // @ts-expect-error - this causes errors on some versions of TS, but not others.
   const stringValue = String(Nat(value));
 
   // Generate the ics20-1 packet.

--- a/packages/run-protocol/scripts/init-core.js
+++ b/packages/run-protocol/scripts/init-core.js
@@ -59,7 +59,7 @@ const { entries, fromEntries } = Object;
 
 /** @type { <K extends string, T, U>(obj: Record<K, T>, f: (t: T) => U) => Record<K, U>} */
 const mapValues = (obj, f) =>
-  // @ts-ignore entries() loses the K type
+  // @ts-expect-error entries() loses the K type
   harden(fromEntries(entries(obj).map(([p, v]) => [p, f(v)])));
 
 const committeeProposalBuilder = async ({ publishRef, install }) => {

--- a/packages/run-protocol/src/collect.js
+++ b/packages/run-protocol/src/collect.js
@@ -4,7 +4,7 @@ const { entries, fromEntries, keys, values } = Object;
 
 /** @type { <K extends string, T, U>(obj: Record<K, T>, f: (t: T, k: K) => U) => Record<K, U>} */
 export const mapValues = (obj, f) =>
-  // @ts-ignore entries() loses the K type
+  // @ts-expect-error entries() loses the K type
   harden(fromEntries(entries(obj).map(([p, v]) => [p, f(v, p)])));
 
 /** @type { <X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */

--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -567,7 +567,7 @@ export const startRunStake = async (
       chainTimerService,
       economicCommitteeCreatorFacet,
     },
-    // @ts-ignore TODO: add to BootstrapPowers
+    // @ts-expect-error TODO: add to BootstrapPowers
     produce: { runStakeCreatorFacet, runStakeGovernorCreatorFacet },
     installation: {
       consume: { contractGovernor, runStake: installationP },

--- a/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -269,7 +269,7 @@ const start = async zcf => {
     makeLiquidateInvitation: () => zcf.makeInvitation(debtorHook, 'Liquidate'),
   });
 
-  // @ts-ignore
+  // @ts-expect-error
   return harden({ creatorFacet });
 };
 

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -19,7 +19,6 @@ import '@agoric/zoe/src/contracts/exported.js';
 // to satisfy contractGovernor. It needs to return a creatorFacet with
 // { getParamMgrRetriever, getInvitation, getLimitedCreatorFacet }.
 
-// @ts-expect-error
 import { assertElectorateMatches } from '@agoric/governance';
 import {
   makeVaultDirectorParamManager,

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -19,7 +19,7 @@ import '@agoric/zoe/src/contracts/exported.js';
 // to satisfy contractGovernor. It needs to return a creatorFacet with
 // { getParamMgrRetriever, getInvitation, getLimitedCreatorFacet }.
 
-// @ts-ignore
+// @ts-expect-error
 import { assertElectorateMatches } from '@agoric/governance';
 import {
   makeVaultDirectorParamManager,

--- a/packages/run-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addPool.js
@@ -74,7 +74,7 @@ export const makeAddPool = (
     );
     const { zcfSeat: poolSeat } = zcf.makeEmptySeatKit();
     const pool = makePool(liquidityZCFMint, poolSeat, secondaryBrand);
-    // @ts-ignore xxx fix types
+    // @ts-expect-error xxx fix types
     initPool(secondaryBrand, pool);
     return liquidityZCFMint.getIssuerRecord().issuer;
   };

--- a/packages/run-protocol/src/vpool-xyk-amm/constantProduct/getXY.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/constantProduct/getXY.js
@@ -32,7 +32,7 @@ export const getXY = ({ amountGiven, poolAllocation, amountWanted }) => {
   };
 
   if (secondaryBrand === xBrand || centralBrand === yBrand) {
-    // @ts-ignore at least one of amountGiven and amountWanted is non-null
+    // @ts-expect-error at least one of amountGiven and amountWanted is non-null
     return harden({
       x: poolAllocation.Secondary,
       y: poolAllocation.Central,
@@ -40,7 +40,7 @@ export const getXY = ({ amountGiven, poolAllocation, amountWanted }) => {
     });
   }
   if (centralBrand === xBrand || secondaryBrand === yBrand) {
-    // @ts-ignore at least one of amountGiven and amountWanted is non-null
+    // @ts-expect-error at least one of amountGiven and amountWanted is non-null
     return harden({
       x: poolAllocation.Central,
       y: poolAllocation.Secondary,

--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -236,7 +236,6 @@ const finish = context => {
     return publicPrices(
       context.facets.singlePool.getPriceForInput(
         amountIn,
-        // @ts-expect-error confused about whether it needs a context
         AmountMath.makeEmpty(brandOut),
       ),
     );
@@ -245,7 +244,6 @@ const finish = context => {
     publicPrices(
       context.facets.singlePool.getPriceForOutput(
         AmountMath.makeEmpty(brandIn),
-        // @ts-expect-error confused about whether it needs a context
         amountout,
       ),
     );
@@ -300,7 +298,6 @@ export const definePoolKind = (
 
     // XXX why does the paramAccessor have to be repackaged as a Far object?
     const params = Far('pool param accessor', {
-      // @ts-expect-error confused
       ...paramAccessor,
     });
 

--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -236,7 +236,7 @@ const finish = context => {
     return publicPrices(
       context.facets.singlePool.getPriceForInput(
         amountIn,
-        // @ts-ignore confused about whether it needs a context
+        // @ts-expect-error confused about whether it needs a context
         AmountMath.makeEmpty(brandOut),
       ),
     );
@@ -245,7 +245,7 @@ const finish = context => {
     publicPrices(
       context.facets.singlePool.getPriceForOutput(
         AmountMath.makeEmpty(brandIn),
-        // @ts-ignore confused about whether it needs a context
+        // @ts-expect-error confused about whether it needs a context
         amountout,
       ),
     );
@@ -271,9 +271,9 @@ const finish = context => {
     quoteIssuerKit,
   );
 
-  // @ts-ignore declared read-only, set value once
+  // @ts-expect-error declared read-only, set value once
   context.state.toCentralPriceAuthority = toCentralPriceAuthority;
-  // @ts-ignore declared read-only, set value once
+  // @ts-expect-error declared read-only, set value once
   context.state.fromCentralPriceAuthority = fromCentralPriceAuthority;
 };
 
@@ -300,7 +300,7 @@ export const definePoolKind = (
 
     // XXX why does the paramAccessor have to be repackaged as a Far object?
     const params = Far('pool param accessor', {
-      // @ts-ignore confused
+      // @ts-expect-error confused
       ...paramAccessor,
     });
 
@@ -330,6 +330,6 @@ export const definePoolKind = (
     singlePool,
   });
 
-  // @ts-ignore unhappy about finish's type
+  // @ts-expect-error unhappy about finish's type
   return defineKindMulti('pool', poolInit, facets, { finish });
 };

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -2,7 +2,6 @@
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 
 import '@agoric/zoe/exported.js';
-// @ts-expect-error
 import { AmountMath } from '@agoric/ertp';
 
 /**
@@ -42,7 +41,6 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
       prices = pool.getPriceForInput(amountIn, amountOut);
     }
     assert(amountIn.brand === prices.swapperGives.brand);
-    // @ts-expect-error
     return pool.allocateGainsAndLosses(seat, prices);
   };
 

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -2,7 +2,7 @@
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 
 import '@agoric/zoe/exported.js';
-// @ts-ignore
+// @ts-expect-error
 import { AmountMath } from '@agoric/ertp';
 
 /**
@@ -42,7 +42,7 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
       prices = pool.getPriceForInput(amountIn, amountOut);
     }
     assert(amountIn.brand === prices.swapperGives.brand);
-    // @ts-ignore
+    // @ts-expect-error
     return pool.allocateGainsAndLosses(seat, prices);
   };
 

--- a/packages/run-protocol/test/amm/constantProduct/test-checkInvariants.js
+++ b/packages/run-protocol/test/amm/constantProduct/test-checkInvariants.js
@@ -119,7 +119,7 @@ function checkGetOutput(t, args, result) {
 
 const testGetInputPrice = (t, inputs, runIn) => {
   const args = runIn ? prepareRUNInTest(inputs) : prepareRUNOutTest(inputs);
-  // @ts-ignore typescript doesn't like param list built by destructuring
+  // @ts-expect-error typescript doesn't like param list built by destructuring
   const result = pricesForStatedInput(...args);
   checkGetInput(t, args, result);
 };
@@ -128,7 +128,7 @@ const testGetInputPriceThrows = (t, inputs, message, runIn) => {
   t.throws(
     _ => {
       const args = runIn ? prepareRUNInTest(inputs) : prepareRUNOutTest(inputs);
-      // @ts-ignore typescript doesn't like param list built by destructuring
+      // @ts-expect-error typescript doesn't like param list built by destructuring
       return pricesForStatedInput(...args);
     },
     {
@@ -139,7 +139,7 @@ const testGetInputPriceThrows = (t, inputs, message, runIn) => {
 
 const testGetInputPriceNoTrade = (t, inputs, runIn) => {
   const args = runIn ? prepareRUNInTest(inputs) : prepareRUNOutTest(inputs);
-  // @ts-ignore typescript doesn't like param list built by destructuring
+  // @ts-expect-error typescript doesn't like param list built by destructuring
   const result = pricesForStatedInput(...args);
   t.truthy(AmountMath.isEmpty(result.swapperGets));
   t.truthy(AmountMath.isEmpty(result.swapperGives));
@@ -147,7 +147,7 @@ const testGetInputPriceNoTrade = (t, inputs, runIn) => {
 
 const testGetOutputPrice = (t, inputs, runIn) => {
   const args = runIn ? prepareRUNInTest(inputs) : prepareRUNOutTest(inputs);
-  // @ts-ignore typescript doesn't like param list built by destructuring
+  // @ts-expect-error typescript doesn't like param list built by destructuring
   const result = pricesForStatedOutput(...args);
   checkGetOutput(t, args, result);
 };
@@ -156,7 +156,7 @@ const getOutputPriceThrows = (t, inputs, message, runIn) => {
   t.throws(
     _ => {
       const args = runIn ? prepareRUNInTest(inputs) : prepareRUNOutTest(inputs);
-      // @ts-ignore typescript doesn't like param list built by destructuring
+      // @ts-expect-error typescript doesn't like param list built by destructuring
       return pricesForStatedOutput(...args);
     },
     {
@@ -167,7 +167,7 @@ const getOutputPriceThrows = (t, inputs, message, runIn) => {
 
 const testGetOutputPriceNoTrade = (t, inputs, runIn) => {
   const args = runIn ? prepareRUNInTest(inputs) : prepareRUNOutTest(inputs);
-  // @ts-ignore typescript doesn't like param list built by destructuring
+  // @ts-expect-error typescript doesn't like param list built by destructuring
   const result = pricesForStatedOutput(...args);
   t.truthy(AmountMath.isEmpty(result.swapperGets));
   t.truthy(AmountMath.isEmpty(result.swapperGives));

--- a/packages/run-protocol/test/amm/constantProduct/test-compareBondingCurves.js
+++ b/packages/run-protocol/test/amm/constantProduct/test-compareBondingCurves.js
@@ -39,7 +39,7 @@ const prepareSwapInTest = ({ inputReserve, outputReserve, inputValue }) => {
 
 const testInputGetPrice = (t, inputs, expectedOutput) => {
   const { args, bld } = prepareSwapInTest(inputs);
-  // @ts-ignore typescript doesn't like param list built by destructuring
+  // @ts-expect-error typescript doesn't like param list built by destructuring
   const result = pricesForStatedInput(...args);
   t.deepEqual(result.swapperGets, bld(expectedOutput));
 };
@@ -48,7 +48,7 @@ const getInputPriceThrows = (t, inputs, message) => {
   t.throws(
     _ => {
       const { args } = prepareSwapInTest(inputs);
-      // @ts-ignore typescript doesn't like param list built by destructuring
+      // @ts-expect-error typescript doesn't like param list built by destructuring
       return pricesForStatedInput(...args);
     },
     {
@@ -87,14 +87,14 @@ const prepareSwapOutTest = ({ inputReserve, outputReserve, outputValue }) => {
 
 const testGetOutputPrice = (t, inputs, expectedInput) => {
   const { args, run } = prepareSwapOutTest(inputs);
-  // @ts-ignore typescript doesn't like param list built by destructuring
+  // @ts-expect-error typescript doesn't like param list built by destructuring
   const result = pricesForStatedOutput(...args);
   t.deepEqual(result.swapperGives, run(expectedInput));
 };
 
 const getOutputPriceThrows = (t, inputs, message) => {
   const { args } = prepareSwapOutTest(inputs);
-  // @ts-ignore typescript doesn't like param list built by destructuring
+  // @ts-expect-error typescript doesn't like param list built by destructuring
   t.throws(_ => pricesForStatedOutput(...args), {
     message,
   });

--- a/packages/run-protocol/test/amm/constantProduct/test-readmeScenario.js
+++ b/packages/run-protocol/test/amm/constantProduct/test-readmeScenario.js
@@ -47,7 +47,7 @@ test('pricesForStatedInput  README example', async t => {
   const protocolFeeRatio = makeRatio(5n, moolaKit.brand, BASIS_POINTS);
   const poolFeeRatio = makeRatio(25n, bucksKit.brand, BASIS_POINTS);
 
-  // @ts-ignore typescript doesn't like param list built by destructuring
+  // @ts-expect-error typescript doesn't like param list built by destructuring
   const noFeesResult = swapInNoFees({ amountGiven, poolAllocation });
   t.deepEqual(noFeesResult.amountIn, moola(29996n));
   t.deepEqual(noFeesResult.amountOut, bucks(2248n));

--- a/packages/run-protocol/test/amm/constantProduct/test-swapScenarios.js
+++ b/packages/run-protocol/test/amm/constantProduct/test-swapScenarios.js
@@ -51,7 +51,7 @@ const prepareSwapInTest = ({
 
 const testGetPrice = (t, inputs, expectedOutput) => {
   const { args, run, bld } = prepareSwapInTest(inputs);
-  // @ts-ignore typescript doesn't like param list built by destructuring
+  // @ts-expect-error typescript doesn't like param list built by destructuring
   const result = pricesForStatedInput(...args);
   const expected = harden({
     protocolFee: run(expectedOutput.protocolFee),

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
@@ -77,9 +77,9 @@ test('balancesToReachRatio calculations are to spec', async t => {
 
         // target X / targetY approximately equals poolXAfter / poolYAfter
         const ratiosWithinRange = withinEpsilon(
-          // @ts-ignore targetX.value is a Nat
+          // @ts-expect-error targetX.value is a Nat
           targetX.value * add(poolY.value, giveY.value),
-          // @ts-ignore targetY.value is a Nat
+          // @ts-expect-error targetY.value is a Nat
           targetY.value * add(poolX.value, giveX.value),
         );
         t.truthy(

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -834,7 +834,7 @@ test('amm jig - swapOut uneven', async t => {
   );
   sPoolState = updatePoolState(sPoolState, initSimLiqExpected);
 
-  // @ts-ignore
+  // @ts-expect-error
   t.deepEqual(await E(publicFacet).getProtocolPoolBalance(), {});
 
   // trade for central specifying 30000 output: moola price 15092

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -834,7 +834,6 @@ test('amm jig - swapOut uneven', async t => {
   );
   sPoolState = updatePoolState(sPoolState, initSimLiqExpected);
 
-  // @ts-expect-error
   t.deepEqual(await E(publicFacet).getProtocolPoolBalance(), {});
 
   // trade for central specifying 30000 output: moola price 15092

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -505,7 +505,6 @@ const makeWorld = async (/** @type {RunStakeTestContext} */ t) => {
   const { chain, space } = await bootstrapRunStake(t, timer);
   const { consume } = space;
 
-  // @ts-expect-error TODO: runStakeCreatorFacet type in vats
   const { zoe, runStakeCreatorFacet, lienBridge } = consume;
   const { RUN: runIssuer } = space.issuer.consume;
   const [bldBrand, runBrand] = await Promise.all([

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -505,7 +505,7 @@ const makeWorld = async (/** @type {RunStakeTestContext} */ t) => {
   const { chain, space } = await bootstrapRunStake(t, timer);
   const { consume } = space;
 
-  // @ts-ignore TODO: runStakeCreatorFacet type in vats
+  // @ts-expect-error TODO: runStakeCreatorFacet type in vats
   const { zoe, runStakeCreatorFacet, lienBridge } = consume;
   const { RUN: runIssuer } = space.issuer.consume;
   const [bldBrand, runBrand] = await Promise.all([

--- a/packages/run-protocol/test/swingsetTests/setup.js
+++ b/packages/run-protocol/test/swingsetTests/setup.js
@@ -206,7 +206,7 @@ const buildOwner = async (
     timer,
     poserInvitationAmount,
     rates,
-    // @ts-ignore It's not a real AMM public facet
+    // @ts-expect-error It's not a real AMM public facet
     ammMock,
     liquidationDetailTerms(runBrand),
   );

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1758,7 +1758,7 @@ test('bad chargingPeriod', async t => {
   t.throws(
     () =>
       makeParamManagerBuilder()
-        // @ts-ignore It's not a bigint.
+        // @ts-expect-error It's not a bigint.
         .addNat(CHARGING_PERIOD_KEY, loanTiming.chargingPeriod)
         .addNat(RECORDING_PERIOD_KEY, loanTiming.recordingPeriod)
         .build(),
@@ -2244,12 +2244,12 @@ test('addVaultType: invalid args do not modify state', async t => {
       .catch(reason1 => t.throwsAsync(p, { message: reason1.message }));
   await failsForSameReason(
     E(vaultFactory)
-      // @ts-ignore bad args on purpose for test
+      // @ts-expect-error bad args on purpose for test
       .addVaultType(chit.issuer, kw, null),
   );
   await failsForSameReason(
     E(vaultFactory)
-      // @ts-ignore bad args on purpose for test
+      // @ts-expect-error bad args on purpose for test
       .addVaultType(chit.issuer, 'bogus kw', params),
   );
 

--- a/packages/store/src/keys/merge-bag-operators.js
+++ b/packages/store/src/keys/merge-bag-operators.js
@@ -149,7 +149,7 @@ const merge = (xbagEntries, ybagEntries) => {
           let value;
           if (xDone && yDone) {
             done = true;
-            // @ts-ignore Because the terminating value does not matter
+            // @ts-expect-error Because the terminating value does not matter
             value = [null, 0n, 0n];
           } else if (xDone) {
             // only ys are left

--- a/packages/store/src/keys/merge-set-operators.js
+++ b/packages/store/src/keys/merge-set-operators.js
@@ -131,7 +131,7 @@ const merge = (xelements, yelements) => {
           let value;
           if (xDone && yDone) {
             done = true;
-            // @ts-ignore Because the terminating value does not matter
+            // @ts-expect-error Because the terminating value does not matter
             value = [null, 0n, 0n];
           } else if (xDone) {
             // only ys are left

--- a/packages/swing-store/src/ephemeralSwingStore.js
+++ b/packages/swing-store/src/ephemeralSwingStore.js
@@ -263,7 +263,7 @@ export function getAllState(swingStore) {
   /** @type { Record<string, string> } */
   const kvStuff = {};
   for (const key of Array.from(kvStore.getKeys('', ''))) {
-    // @ts-ignore get(key) of key from getKeys() is not undefined
+    // @ts-expect-error get(key) of key from getKeys() is not undefined
     kvStuff[key] = kvStore.get(key);
   }
   const streamStuff = new Map();

--- a/packages/swing-store/test/test-snapstore.js
+++ b/packages/swing-store/test/test-snapstore.js
@@ -62,7 +62,7 @@ test('snapStore prepare / commit delete is robust', async t => {
 
   t.notThrows(() => store.commitDeletes());
 
-  // @ts-ignore
+  // @ts-expect-error
   t.throws(() => store.prepareToDelete(1));
   t.throws(() => store.prepareToDelete('../../../etc/passwd'));
   t.throws(() => store.prepareToDelete('/etc/passwd'));

--- a/packages/ui-components/src/display/display.js
+++ b/packages/ui-components/src/display/display.js
@@ -65,7 +65,6 @@ export const stringifyValue = (
     return stringifyNat(value, decimalPlaces, placesToShow);
   }
   if (assetKind === AssetKind.SET) {
-    // @ts-expect-error AmountValue is a SetValue
     return stringifySet(value);
   }
   assert.fail(details`AssetKind ${assetKind} must be NAT or SET`);

--- a/packages/ui-components/src/display/display.js
+++ b/packages/ui-components/src/display/display.js
@@ -61,11 +61,11 @@ export const stringifyValue = (
   placesToShow = 2,
 ) => {
   if (assetKind === AssetKind.NAT) {
-    // @ts-ignore AmountValue is a Nat
+    // @ts-expect-error AmountValue is a Nat
     return stringifyNat(value, decimalPlaces, placesToShow);
   }
   if (assetKind === AssetKind.SET) {
-    // @ts-ignore AmountValue is a SetValue
+    // @ts-expect-error AmountValue is a SetValue
     return stringifySet(value);
   }
   assert.fail(details`AssetKind ${assetKind} must be NAT or SET`);

--- a/packages/ui-components/src/display/natValue/stringifyRatioAsFraction.js
+++ b/packages/ui-components/src/display/natValue/stringifyRatioAsFraction.js
@@ -38,13 +38,13 @@ export const stringifyRatioAsFraction = (
     `decimalPlaces for denominator ${ratio.denominator} must be provided`,
   );
   const numeratorString = stringifyNat(
-    // @ts-ignore value is BigInt
+    // @ts-expect-error value is BigInt
     ratio.numerator.value,
     numDecimalPlaces,
     numPlacesToShow,
   );
   const denominatorString = stringifyNat(
-    // @ts-ignore value is BigInt
+    // @ts-expect-error value is BigInt
     ratio.denominator.value,
     denomDecimalPlaces,
     denomPlacesToShow,

--- a/packages/ui-components/src/display/natValue/stringifyRatioAsFraction.js
+++ b/packages/ui-components/src/display/natValue/stringifyRatioAsFraction.js
@@ -38,13 +38,11 @@ export const stringifyRatioAsFraction = (
     `decimalPlaces for denominator ${ratio.denominator} must be provided`,
   );
   const numeratorString = stringifyNat(
-    // @ts-expect-error value is BigInt
     ratio.numerator.value,
     numDecimalPlaces,
     numPlacesToShow,
   );
   const denominatorString = stringifyNat(
-    // @ts-expect-error value is BigInt
     ratio.denominator.value,
     denomDecimalPlaces,
     denomPlacesToShow,

--- a/packages/ui-components/src/display/natValue/stringifyRatioAsPercent.js
+++ b/packages/ui-components/src/display/natValue/stringifyRatioAsPercent.js
@@ -41,9 +41,7 @@ export const stringifyRatioAsPercent = (
   );
   const denomPower = 10n ** BigInt(denomDecimalPlaces);
   const numPower = 10n ** BigInt(numDecimalPlaces);
-  // @ts-expect-error value is BigInt
   const numerator = ratio.numerator.value * denomPower * PERCENT_BASE;
-  // @ts-expect-error value is BigInt
   const denominator = ratio.denominator.value * numPower;
   const str = `${Number(numerator) / Number(denominator)}`;
   const capturedNum = captureNum(str);

--- a/packages/ui-components/src/display/natValue/stringifyRatioAsPercent.js
+++ b/packages/ui-components/src/display/natValue/stringifyRatioAsPercent.js
@@ -41,9 +41,9 @@ export const stringifyRatioAsPercent = (
   );
   const denomPower = 10n ** BigInt(denomDecimalPlaces);
   const numPower = 10n ** BigInt(numDecimalPlaces);
-  // @ts-ignore value is BigInt
+  // @ts-expect-error value is BigInt
   const numerator = ratio.numerator.value * denomPower * PERCENT_BASE;
-  // @ts-ignore value is BigInt
+  // @ts-expect-error value is BigInt
   const denominator = ratio.denominator.value * numPower;
   const str = `${Number(numerator) / Number(denominator)}`;
   const capturedNum = captureNum(str);

--- a/packages/ui-components/test/components/test-NatAmountInput.js
+++ b/packages/ui-components/test/components/test-NatAmountInput.js
@@ -118,6 +118,7 @@ test('error=true', t => {
 });
 
 test('can simulate input - just calls onChange', t => {
+  /** @type {bigint | undefined} */
   let receivedValue;
   const onChange = newValue => {
     receivedValue = newValue;
@@ -188,6 +189,7 @@ test('displays 3 eth correctly', t => {
 });
 
 test('discards negative values', t => {
+  /** @type {bigint | undefined} */
   let receivedValue;
   const onChange = newValue => {
     receivedValue = newValue;

--- a/packages/ui-components/test/components/test-NatAmountInput.js
+++ b/packages/ui-components/test/components/test-NatAmountInput.js
@@ -7,7 +7,7 @@ import { TextField } from '@material-ui/core';
 import test from 'ava';
 import enzyme from 'enzyme';
 
-// @ts-ignore path is correct for compiled output
+// @ts-expect-error path is correct for compiled output
 import { makeNatAmountInput } from '../../../dist/index.js'; // eslint-disable-line import/no-unresolved
 
 const { shallow, render } = enzyme; // CJS so no named imports

--- a/packages/ui-components/test/display/natValue/test-roundToDecimalPlaces.js
+++ b/packages/ui-components/test/display/natValue/test-roundToDecimalPlaces.js
@@ -15,14 +15,14 @@ test('roundToDecimalPlaces', t => {
 });
 
 test('roundToDecimalPlaces non-string throws', t => {
-  // @ts-ignore deliberate error for testing
+  // @ts-expect-error deliberate error for testing
   t.throws(() => round({}, 0), {
     message: /.* must be a string/,
   });
 });
 
 test('roundToDecimalPlaces non-num decimalPlaces throws', t => {
-  // @ts-ignore deliberate error for testing
+  // @ts-expect-error deliberate error for testing
   t.throws(() => round('020', '0'), {
     message: /.* must be a number/,
   });

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -9,7 +9,7 @@ const { details: X, quote: q } = assert;
 
 /** @type { <K extends string, T, U>(obj: Record<K, T>, f: (k: K, v: T) => [K, U]) => Record<K, U>} */
 const mapEntries = (obj, f) =>
-  // @ts-ignore entries() loses key type
+  // @ts-expect-error entries() loses key type
   fromEntries(entries(obj).map(([p, v]) => f(p, v)));
 
 export const CENTRAL_ISSUER_NAME = 'RUN';

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -175,7 +175,7 @@ test('evaluateInstallation is available to core eval', async t => {
 
   const instId = await prepare();
 
-  // @ts-ignore
+  // @ts-expect-error
   await bridgeCoreEval({ produce, consume });
   t.truthy(handler);
 
@@ -201,10 +201,10 @@ test('evaluateInstallation is available to core eval', async t => {
   };
   t.log({ bridgeMessage });
 
-  // @ts-ignore
+  // @ts-expect-error
   await E(handler).fromBridge('arbitrary srcID', bridgeMessage);
   const actual = await consume.thing;
 
-  // @ts-ignore
+  // @ts-expect-error
   t.deepEqual(typeof actual.extract, 'function');
 });

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -61,13 +61,13 @@ test('connectFaucet produces payments', async t => {
   produce.bldIssuerKit.resolve(bldKit);
   const runIssuer = E(zoe).getFeeIssuer();
   produce.bankManager.resolve(
-    // @ts-ignore never mind other methods
+    // @ts-expect-error never mind other methods
     Promise.resolve(
-      // @ts-ignore never mind other methods
+      // @ts-expect-error never mind other methods
       Far('mockBankManager', {
         getBankForAddress: _a =>
           Far('mockBank', {
-            // @ts-ignore never mind other methods
+            // @ts-expect-error never mind other methods
             getPurse: brand => ({
               deposit: async (pmt, _x) => {
                 const isBLD = brand === bldKit.brand;

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -61,7 +61,6 @@ test('connectFaucet produces payments', async t => {
   produce.bldIssuerKit.resolve(bldKit);
   const runIssuer = E(zoe).getFeeIssuer();
   produce.bankManager.resolve(
-    // @ts-expect-error never mind other methods
     Promise.resolve(
       // @ts-expect-error never mind other methods
       Far('mockBankManager', {

--- a/packages/vats/test/test-vpurse.js
+++ b/packages/vats/test/test-vpurse.js
@@ -277,7 +277,7 @@ test('vpurse.deposit promise', async t => {
   const exclusivePaymentP = E(issuer).claim(payment);
 
   await t.throwsAsync(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => E(vpurse).deposit(exclusivePaymentP, fungible25),
     { message: /deposit does not accept promises/ },
     'failed to reject a promise for a payment',

--- a/packages/xsnap/src/avaHandler.js
+++ b/packages/xsnap/src/avaHandler.js
@@ -69,18 +69,18 @@ function handler(rawMessage) {
     case 'loadScript': {
       const { source } = msg;
       const virtualObjectGlobals =
-        // @ts-expect-error
+        // @ts-ignore
         // eslint-disable-next-line no-undef
         typeof VatData !== 'undefined' ? { VatData } : {};
-      // @ts-expect-error How do I get ses types in scope?!?!?!
+      // @ts-ignore How do I get ses types in scope?!?!?!
       const c = new Compartment({
         require: testRequire,
         __dirname,
         __filename,
         console,
-        // @ts-expect-error
+        // @ts-ignore
         assert,
-        // @ts-expect-error
+        // @ts-ignore
         HandledPromise,
         TextEncoder,
         TextDecoder,

--- a/packages/xsnap/src/avaHandler.js
+++ b/packages/xsnap/src/avaHandler.js
@@ -69,18 +69,18 @@ function handler(rawMessage) {
     case 'loadScript': {
       const { source } = msg;
       const virtualObjectGlobals =
-        // @ts-ignore
+        // @ts-expect-error
         // eslint-disable-next-line no-undef
         typeof VatData !== 'undefined' ? { VatData } : {};
-      // @ts-ignore How do I get ses types in scope?!?!?!
+      // @ts-expect-error How do I get ses types in scope?!?!?!
       const c = new Compartment({
         require: testRequire,
         __dirname,
         __filename,
         console,
-        // @ts-ignore
+        // @ts-expect-error
         assert,
-        // @ts-ignore
+        // @ts-expect-error
         HandledPromise,
         TextEncoder,
         TextDecoder,

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -185,7 +185,7 @@ test('metering switch - start compartment only', async t => {
 function dataStructurePerformance(logn) {
   // eslint-disable-next-line no-bitwise
   const n = 1 << logn;
-  // @ts-ignore
+  // @ts-expect-error
   const send = it => {
     // eslint-disable-next-line no-undef
     return issueCommand(new TextEncoder().encode(JSON.stringify(it)).buffer);

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -48,7 +48,6 @@ export const makeZCFZygote = (
     E(zoeInstanceAdmin).failAllSeats(reason);
     // eslint-disable-next-line no-use-before-define
     dropAllReferences();
-    // @ts-expect-error powers is not typed correctly:
     // https://github.com/Agoric/agoric-sdk/issues/3239
     powers.exitVatWithFailure(reason);
   };

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -48,7 +48,7 @@ export const makeZCFZygote = (
     E(zoeInstanceAdmin).failAllSeats(reason);
     // eslint-disable-next-line no-use-before-define
     dropAllReferences();
-    // @ts-ignore powers is not typed correctly:
+    // @ts-expect-error powers is not typed correctly:
     // https://github.com/Agoric/agoric-sdk/issues/3239
     powers.exitVatWithFailure(reason);
   };

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -92,7 +92,7 @@ export const makeRatioFromAmounts = (numeratorAmount, denominatorAmount) => {
   AmountMath.coerce(numeratorAmount.brand, numeratorAmount);
   AmountMath.coerce(denominatorAmount.brand, denominatorAmount);
   return makeRatio(
-    // @ts-ignore value can be any AmountValue but makeRatio() supports only bigint
+    // @ts-expect-error value can be any AmountValue but makeRatio() supports only bigint
     numeratorAmount.value,
     numeratorAmount.brand,
     denominatorAmount.value,
@@ -121,13 +121,13 @@ const multiplyHelper = (amount, ratio, divideOp) => {
 
 /** @type {ScaleAmount} */
 export const floorMultiplyBy = (amount, ratio) => {
-  // @ts-ignore cast
+  // @ts-expect-error cast
   return multiplyHelper(amount, ratio, floorDivide);
 };
 
 /** @type {ScaleAmount} */
 export const ceilMultiplyBy = (amount, ratio) => {
-  // @ts-ignore cast
+  // @ts-expect-error cast
   return multiplyHelper(amount, ratio, ceilDivide);
 };
 
@@ -152,13 +152,13 @@ const divideHelper = (amount, ratio, divideOp) => {
 
 /** @type {ScaleAmount} */
 export const floorDivideBy = (amount, ratio) => {
-  // @ts-ignore cast
+  // @ts-expect-error cast
   return divideHelper(amount, ratio, floorDivide);
 };
 
 /** @type {ScaleAmount} */
 export const ceilDivideBy = (amount, ratio) => {
-  // @ts-ignore cast
+  // @ts-expect-error cast
   return divideHelper(amount, ratio, ceilDivide);
 };
 
@@ -244,7 +244,7 @@ export const oneMinus = ratio => {
   return makeRatio(
     subtract(ratio.denominator.value, ratio.numerator.value),
     ratio.numerator.brand,
-    // @ts-ignore value can be any AmountValue but makeRatio() supports only bigint
+    // @ts-expect-error value can be any AmountValue but makeRatio() supports only bigint
     ratio.denominator.value,
     ratio.numerator.brand,
   );

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -121,13 +121,11 @@ const multiplyHelper = (amount, ratio, divideOp) => {
 
 /** @type {ScaleAmount} */
 export const floorMultiplyBy = (amount, ratio) => {
-  // @ts-expect-error cast
   return multiplyHelper(amount, ratio, floorDivide);
 };
 
 /** @type {ScaleAmount} */
 export const ceilMultiplyBy = (amount, ratio) => {
-  // @ts-expect-error cast
   return multiplyHelper(amount, ratio, ceilDivide);
 };
 
@@ -152,13 +150,11 @@ const divideHelper = (amount, ratio, divideOp) => {
 
 /** @type {ScaleAmount} */
 export const floorDivideBy = (amount, ratio) => {
-  // @ts-expect-error cast
   return divideHelper(amount, ratio, floorDivide);
 };
 
 /** @type {ScaleAmount} */
 export const ceilDivideBy = (amount, ratio) => {
-  // @ts-expect-error cast
   return divideHelper(amount, ratio, ceilDivide);
 };
 
@@ -244,7 +240,6 @@ export const oneMinus = ratio => {
   return makeRatio(
     subtract(ratio.denominator.value, ratio.numerator.value),
     ratio.numerator.brand,
-    // @ts-expect-error value can be any AmountValue but makeRatio() supports only bigint
     ratio.denominator.value,
     ratio.numerator.brand,
   );

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -377,7 +377,7 @@ export const checkZCF = (zcf, assertFn) => {
     ...zcf,
     reallocate: (...seats) => {
       assertFn(seats);
-      // @ts-ignore The types aren't right for spreading
+      // @ts-expect-error The types aren't right for spreading
       zcf.reallocate(...seats);
     },
   });

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -95,22 +95,22 @@ test('ratio - multiplyBy non Amount', t => {
     value: 3.5,
     brand,
   });
-  // @ts-ignore Incorrect values for testing
+  // @ts-expect-error Incorrect values for testing
   t.throws(() => floorMultiplyBy(badAmount, makeRatio(25n, brand)), {
     message:
       'value 3.5 must be a bigint, copySet, copyBag, or an array, not "number"',
   });
-  // @ts-ignore Incorrect values for testing
+  // @ts-expect-error Incorrect values for testing
   t.throws(() => ceilMultiplyBy(badAmount, makeRatio(25n, brand)), {
     message:
       'value 3.5 must be a bigint, copySet, copyBag, or an array, not "number"',
   });
-  // @ts-ignore Incorrect values for testing
+  // @ts-expect-error Incorrect values for testing
   t.throws(() => floorDivideBy(badAmount, makeRatio(25n, brand)), {
     message:
       'value 3.5 must be a bigint, copySet, copyBag, or an array, not "number"',
   });
-  // @ts-ignore Incorrect values for testing
+  // @ts-expect-error Incorrect values for testing
   t.throws(() => ceilDivideBy(badAmount, makeRatio(25n, brand)), {
     message:
       'value 3.5 must be a bigint, copySet, copyBag, or an array, not "number"',
@@ -190,7 +190,7 @@ test('ratio - larger than 100%', t => {
 test('ratio - Nats', t => {
   const { brand } = makeIssuerKit('moe');
 
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => makeRatio(10.1, brand), {
     message:
       'value 10.1 must be a bigint, copySet, copyBag, or an array, not "number"',
@@ -229,33 +229,33 @@ test('ratio bad inputs', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
   const moe = value => AmountMath.make(brand, value);
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => makeRatio(-3, brand), {
     message:
       'value -3 must be a bigint, copySet, copyBag, or an array, not "number"',
   });
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => makeRatio(3n, brand, 100.5), {
     message:
       'value 100.5 must be a bigint, copySet, copyBag, or an array, not "number"',
   });
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => makeRatioFromAmounts(3n, moe(30n)), {
     message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => floorMultiplyBy(37, makeRatioFromAmounts(moe(3n), moe(5n))), {
     message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => ceilMultiplyBy(37, makeRatioFromAmounts(moe(3n), moe(5n))), {
     message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => floorDivideBy(makeRatioFromAmounts(moe(3n), moe(5n)), 37), {
     message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => ceilDivideBy(makeRatioFromAmounts(moe(3n), moe(5n)), 37), {
     message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
@@ -326,7 +326,7 @@ test('ratio - complement', t => {
   amountsEqual(t, floorMultiplyBy(moe(100000n), twoThirds), moe(66666n), brand);
   amountsEqual(t, ceilMultiplyBy(moe(100000n), twoThirds), moe(66667n), brand);
 
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => oneMinus(moe(3n)), {
     message:
       'Parameter must be a Ratio record, but {"brand":"[Alleged: moe brand]","value":"[3n]"} has "brand"',

--- a/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
+++ b/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
@@ -20,7 +20,7 @@ const start = zcf => {
   );
   // should be makeRefundInvitation(). Intentionally wrong to provoke
   // an error.
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   return { creatorInvitation: makeRefundInvitation };
 };
 

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -145,7 +145,7 @@ test('median aggregator', /** @param {ExecutionContext} t */ async t => {
   const pa = E(aggregator.publicFacet).getPriceAuthority();
 
   // TODO: Port this to makeQuoteNotifier(amountIn, brandOut)
-  // @ts-ignore fix needed
+  // @ts-expect-error fix needed
   const notifier = E(pa).makeQuoteNotifier(
     AmountMath.make(brandIn, 1n),
     brandOut,

--- a/packages/zoe/test/unitTests/test-zoe-env.js
+++ b/packages/zoe/test/unitTests/test-zoe-env.js
@@ -3,13 +3,13 @@
 import { test, VatData } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 test('harden from SES is in the zoe contract environment', t => {
-  // @ts-ignore testing existence of function only
+  // @ts-expect-error testing existence of function only
   harden();
   t.pass();
 });
 
 test('(mock) kind makers from SwingSet are in the zoe contract environment', t => {
-  // @ts-ignore testing existence of function only
+  // @ts-expect-error testing existence of function only
   VatData.defineKind('x', () => {}, {});
   VatData.defineKindMulti('x', () => {}, { x: {}, y: {} });
   const kh = VatData.makeKindHandle();
@@ -19,7 +19,7 @@ test('(mock) kind makers from SwingSet are in the zoe contract environment', t =
 });
 
 test('(mock) store makers from SwingSet are in the zoe contract environment', t => {
-  // @ts-ignore testing existence of function only
+  // @ts-expect-error testing existence of function only
   VatData.makeScalarBigMapStore();
   VatData.makeScalarBigWeakMapStore();
   VatData.makeScalarBigSetStore();

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -35,7 +35,7 @@ test(`zoe.getInvitationIssuer`, async t => {
 
 test(`E(zoe).install bad bundle`, async t => {
   const { zoe } = setup();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).install(), {
     message: 'a bundle must be provided',
   });
@@ -51,7 +51,7 @@ test(`E(zoe).install(bundle)`, async t => {
 
 test(`E(zoe).installBundleID bad id`, async t => {
   const { zoe } = setup();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).installBundleID(), {
     message: 'a bundle ID must be provided',
   });
@@ -73,7 +73,7 @@ test(`E(zoe).installBundleID(bundleID)`, async t => {
 
 test(`E(zoe).startInstance bad installation`, async t => {
   const { zoe } = setup();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).startInstance(), {
     message:
       // Should be able to use more informative error once SES double
@@ -146,7 +146,7 @@ test(`E(zoe).startInstance - terms, issuerKeywordRecord switched`, async t => {
     () =>
       E(zoe).startInstance(
         installation,
-        // @ts-ignore deliberate invalid arguments for testing
+        // @ts-expect-error deliberate invalid arguments for testing
         { something: 2 },
         { Moola: moolaKit.issuer },
       ),
@@ -176,7 +176,7 @@ test(`E(zoe).startInstance - bad issuer, makeEmptyPurse throws`, async t => {
     getBrand: () => brand,
   });
   await t.throwsAsync(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => E(zoe).startInstance(installation, { Money: badIssuer }),
     {
       message:
@@ -194,7 +194,7 @@ test(`E(zoe).offer`, async t => {
 
 test(`E(zoe).offer - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).offer(), {
     message: /A Zoe invitation is required, not "\[undefined\]"/,
   });
@@ -208,7 +208,7 @@ test(`E(zoe).offer - payment instead of paymentKeywordRecord`, async t => {
   const proposal = harden({ give: { Keyword: amount } });
   const payment = mint.mintPayment(amount);
   const invitation = zcf.makeInvitation(() => {}, 'noop');
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).offer(invitation, proposal, payment), {
     message:
       '"keywordRecord" "[Alleged: Token payment]" must be a pass-by-copy record, not "remotable"',
@@ -250,7 +250,7 @@ test(`E(zoe).getPublicFacet promise for instance`, async t => {
 
 test(`E(zoe).getPublicFacet - no instance`, async t => {
   const { zoe } = setup();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getPublicFacet(), {
     message:
       // Should be able to use more informative error once SES double
@@ -286,7 +286,7 @@ test(`zoe.getIssuers - none`, async t => {
 
 test(`zoe.getIssuers - no instance`, async t => {
   const { zoe } = setup();
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getIssuers(), {
     message:
       // Should be able to use more informative error once SES double
@@ -322,7 +322,7 @@ test(`zoe.getBrands - none`, async t => {
 
 test(`zoe.getBrands - no instance`, async t => {
   const { zoe } = setup();
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getBrands(), {
     message:
       // Should be able to use more informative error once SES double
@@ -380,7 +380,7 @@ test(`zoe.getTerms`, async t => {
 
 test(`zoe.getTerms - no instance`, async t => {
   const { zoe } = setup();
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getTerms(), {
     message:
       // Should be able to use more informative error once SES double
@@ -423,7 +423,7 @@ test(`zoe.getInstance`, async t => {
 
 test(`zoe.getInstance - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInstance(), {
     message: /A Zoe invitation is required, not "\[undefined\]"/,
   });
@@ -438,7 +438,7 @@ test(`zoe.getInstallation`, async t => {
 
 test(`zoe.getInstallation - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInstallation(), {
     message: /A Zoe invitation is required, not "\[undefined\]"/,
   });
@@ -458,7 +458,7 @@ test(`zoe.getInvitationDetails`, async t => {
 
 test(`zoe.getInvitationDetails - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInvitationDetails(), {
     message: /A Zoe invitation is required, not "\[undefined\]"/,
   });

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -59,7 +59,7 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
     feeMintAccess,
 
     // Additional ZCF
-    // @ts-ignore zcf2 is accessible before it is set
+    // @ts-expect-error zcf2 is accessible before it is set
     zcf2,
     creatorFacet2,
     instance2,

--- a/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
@@ -43,7 +43,7 @@ test(`zcf.reallocate undefined`, async t => {
   const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();
   const { zcfSeat: zcfSeat2 } = zcf.makeEmptySeatKit();
 
-  // @ts-ignore Deliberate wrong type for testing
+  // @ts-expect-error Deliberate wrong type for testing
   t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2, undefined), {
     message:
       // TODO: Improve error message if something other than a seat is
@@ -61,7 +61,7 @@ test(`zcf.reallocate unstaged`, async t => {
   const { brand } = zcfMint.getIssuerRecord();
   const empty = AmountMath.makeEmpty(brand, AssetKind.NAT);
   zcfSeat1.incrementBy(harden({ RUN: empty }));
-  // @ts-ignore Deliberate wrong type for testing
+  // @ts-expect-error Deliberate wrong type for testing
   t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2), {
     message:
       'Reallocate failed because a seat had no staged allocation. Please add or subtract from the seat and then reallocate.',

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -191,7 +191,7 @@ test(`zcf.saveIssuer & zoe.getTerms`, async t => {
 test(`zcf.saveIssuer - bad issuer`, async t => {
   const { moolaKit } = setup();
   const { zcf } = await setupZCFTest();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => zcf.saveIssuer(moolaKit.brand, 'A'), {
     // TODO: improve error message
     // https://github.com/Agoric/agoric-sdk/issues/1701
@@ -214,7 +214,7 @@ test(`zcf.saveIssuer - bad issuer, makeEmptyPurse throws`, async t => {
     getBrand: () => brand,
   });
   await t.throwsAsync(
-    // @ts-ignore deliberate invalid arguments for testing
+    // @ts-expect-error deliberate invalid arguments for testing
     () => zcf.saveIssuer(badIssuer, 'A'),
     {
       message:
@@ -245,7 +245,7 @@ test(`zcf.saveIssuer - args reversed`, async t => {
   const { zcf } = await setupZCFTest();
   // TODO: improve error message
   // https://github.com/Agoric/agoric-sdk/issues/1702
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(async () => zcf.saveIssuer('A', moolaKit.issuer), {
     message: /.* must be a string/,
   });
@@ -290,7 +290,7 @@ test(`zcf.makeInvitation - throwing offerHandler`, async t => {
 
 test(`zcf.makeInvitation - no description`, async t => {
   const { zcf } = await setupZCFTest();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcf.makeInvitation(() => {}), {
     message: /invitations must have a description string: "\[undefined\]"/,
   });
@@ -300,7 +300,7 @@ test(`zcf.makeInvitation - non-string description`, async t => {
   const { zcf } = await setupZCFTest();
   // TODO: improve error message
   // https://github.com/Agoric/agoric-sdk/issues/1704
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcf.makeInvitation(() => {}, { something: 'a' }), {
     message: /invitations must have a description string: .*/,
   });
@@ -355,7 +355,7 @@ test(`zcf.makeInvitation - customProperties overwritten`, async t => {
 
 test(`zcf.makeZCFMint - no keyword`, async t => {
   const { zcf } = await setupZCFTest();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => zcf.makeZCFMint(), {
     message:
       // Should be able to use more informative error once SES double
@@ -390,7 +390,7 @@ test(`zcf.makeZCFMint - bad keyword`, async t => {
 
 test(`zcf.makeZCFMint - not a math kind`, async t => {
   const { zcf } = await setupZCFTest();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => zcf.makeZCFMint('A', 'whatever'), {
     message:
       /The assetKind "whatever" must be one of \["copyBag","copySet","nat","set"\]/,
@@ -427,7 +427,7 @@ test(`zcf.makeZCFMint - SET`, async t => {
 test(`zcf.makeZCFMint - mintGains - no args`, async t => {
   const { zcf } = await setupZCFTest();
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcfMint.mintGains(), {
     message:
       '"keywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
@@ -453,7 +453,7 @@ test(`zcf.makeZCFMint - mintGains - no gains`, async t => {
   const { zcfSeat } = zcf.makeEmptySeatKit();
   // TODO: create seat if one is not provided
   // https://github.com/Agoric/agoric-sdk/issues/1696
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcfMint.mintGains(undefined, zcfSeat), {
     message:
       '"keywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
@@ -463,7 +463,7 @@ test(`zcf.makeZCFMint - mintGains - no gains`, async t => {
 test(`zcf.makeZCFMint - burnLosses - no args`, async t => {
   const { zcf } = await setupZCFTest();
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcfMint.burnLosses(), {
     message:
       '"keywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
@@ -474,7 +474,7 @@ test(`zcf.makeZCFMint - burnLosses - no losses`, async t => {
   const { zcf } = await setupZCFTest();
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   const { zcfSeat } = zcf.makeEmptySeatKit();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcfMint.burnLosses(undefined, zcfSeat), {
     message:
       '"keywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
@@ -710,7 +710,7 @@ test(`zcfSeat.isOfferSafe from zcf.makeEmptySeatKit`, async t => {
   const { moola } = setup();
   const { zcfSeat } = zcf.makeEmptySeatKit();
   // Anything is offer safe with no want or give
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.truthy(zcfSeat.isOfferSafe());
   t.truthy(zcfSeat.isOfferSafe({ Moola: moola(0n) }));
   t.truthy(zcfSeat.isOfferSafe({ Moola: moola(10n) }));
@@ -1090,7 +1090,7 @@ test(`userSeat.getPayouts, getPayout from zcf.makeEmptySeatKit`, async t => {
 test(`userSeat.getPayout() should throw from zcf.makeEmptySeatKit`, async t => {
   const { zcf } = await setupZCFTest();
   const { userSeat } = zcf.makeEmptySeatKit();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(userSeat).getPayout(), {
     message: 'A keyword must be provided',
   });
@@ -1098,7 +1098,7 @@ test(`userSeat.getPayout() should throw from zcf.makeEmptySeatKit`, async t => {
 
 test(`zcf.reallocate < 2 seats`, async t => {
   const { zcf } = await setupZCFTest();
-  // @ts-ignore deliberate invalid arguments for testing
+  // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcf.reallocate(), {
     message: 'reallocating must be done over two or more seats',
   });

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
@@ -54,7 +54,7 @@ test(`zoe - wrongly throw zcfSeat.exit()`, async t => {
 
   /** @type {OfferHandler} */
   const throwSeatExit = seat => {
-    // @ts-ignore Linting correctly identifies that exit takes no argument.
+    // @ts-expect-error Linting correctly identifies that exit takes no argument.
     throw seat.exit('here is a string');
   };
 
@@ -70,7 +70,7 @@ test(`zoe - wrongly throw zcfSeat.exit()`, async t => {
 
   /** @type {OfferHandler} */
   const throwSeatFail = seat => {
-    // @ts-ignore Linting correctly identifies that the argument to
+    // @ts-expect-error Linting correctly identifies that the argument to
     // fail must be an error, not a string.
     throw seat.fail('here is a string');
   };

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -295,7 +295,7 @@ test(`zoeHelper with zcf - fit proposal patterns`, async t => {
     give: { B: simoleans(3n) },
   });
 
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => fit(proposal, harden([])), {
     message: /.* - Must be equivalent to: \[\]/,
   });
@@ -340,7 +340,7 @@ test(`zoeHelper with zcf - assertProposalShape`, async t => {
     { B: simoleanMint.mintPayment(simoleans(3n)) },
   );
 
-  // @ts-ignore invalid arguments for testing
+  // @ts-expect-error invalid arguments for testing
   t.throws(() => assertProposalShape(zcfSeat, []), {
     message: 'Expected must be an non-array object',
   });

--- a/packages/zoe/test/unitTests/zoe/test-burnInvitation.js
+++ b/packages/zoe/test/unitTests/zoe/test-burnInvitation.js
@@ -31,7 +31,7 @@ test('burnInvitation - not an invitation', async t => {
   const mockInvitationKit = makeIssuerKit('mockInvitation', AssetKind.SET);
 
   await t.throwsAsync(
-    // @ts-ignore invalid payment for the purposes of testing
+    // @ts-expect-error invalid payment for the purposes of testing
     () => burnInvitation(mockInvitationKit.issuer, undefined),
     { message: 'A Zoe invitation is required, not "[undefined]"' },
   );

--- a/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
+++ b/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
@@ -23,9 +23,9 @@ test('setupCreateZCFVat', async t => {
     },
   });
 
-  // @ts-ignore fakeVatAdminSvc is mocked
+  // @ts-expect-error fakeVatAdminSvc is mocked
   t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, { name: 'zcf' })(), {
-    // @ts-ignore fakeVatAdminSvc is mocked
+    // @ts-expect-error fakeVatAdminSvc is mocked
     adminNode: undefined,
     root: undefined,
   });

--- a/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
@@ -36,39 +36,39 @@ test('makeInstanceAdminStorage', async t => {
     getInstallationForInstance: () => 'installation2',
   });
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   initInstanceAdmin(mockInstance2, mockInstanceAdmin2);
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   t.is(getInstanceAdmin(mockInstance1), mockInstanceAdmin1);
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   t.is(await getPublicFacet(mockInstance1), 'publicFacet1');
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   t.is(await getBrands(mockInstance2), 'brands2');
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   t.is(await getIssuers(mockInstance1), 'issuers1');
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   t.is(await getTerms(mockInstance1), 'terms1');
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   t.is(await getInstallationForInstance(mockInstance1), 'installation1');
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   deleteInstanceAdmin(mockInstance2);
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   t.throws(() => getInstanceAdmin(mockInstance2), {
     message: '"instance" not found: "[Alleged: mockInstance2]"',
   });
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   await t.throwsAsync(() => getPublicFacet(mockInstance2), {
     message: '"instance" not found: "[Alleged: mockInstance2]"',
   });
@@ -81,10 +81,10 @@ test('add another instance admin for same instance', async t => {
   const mockInstanceAdmin1 = Far('mockInstanceAdmin1', {});
   const mockInstanceAdmin2 = Far('mockInstanceAdmin2', {});
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
 
-  // @ts-ignore instance is mocked
+  // @ts-expect-error instance is mocked
   t.throws(() => initInstanceAdmin(mockInstance1, mockInstanceAdmin2), {
     message: '"instance" already registered: "[Alleged: mockInstance1]"',
   });

--- a/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
+++ b/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
@@ -13,7 +13,7 @@ test('createInvitationKit', async t => {
   const mockInstance = harden({});
   const mockInstallation = harden({});
 
-  // @ts-ignore mockInstance is mocked
+  // @ts-expect-error mockInstance is mocked
   const makeInvitation = setupMakeInvitation(mockInstance, mockInstallation);
 
   const mockInvitationHandle = harden({});
@@ -23,7 +23,7 @@ test('createInvitationKit', async t => {
   });
 
   const invitation = makeInvitation(
-    // @ts-ignore mockInvitationHandle is mocked
+    // @ts-expect-error mockInvitationHandle is mocked
     mockInvitationHandle,
     description,
     customProperties,
@@ -55,7 +55,7 @@ test('description is omitted, wrongly', async t => {
   const mockInstance = harden({});
   const mockInstallation = harden({});
 
-  // @ts-ignore mockInstance is mocked
+  // @ts-expect-error mockInstance is mocked
   const makeInvitation = setupMakeInvitation(mockInstance, mockInstallation);
 
   const mockInvitationHandle = harden({});
@@ -67,7 +67,7 @@ test('description is omitted, wrongly', async t => {
   await t.throwsAsync(
     () =>
       makeInvitation(
-        // @ts-ignore mockInvitationHandle is mocked
+        // @ts-expect-error mockInvitationHandle is mocked
         mockInvitationHandle,
         description,
         customProperties,
@@ -82,14 +82,14 @@ test('customProperties ok to omit', async t => {
   const mockInstance = harden({});
   const mockInstallation = harden({});
 
-  // @ts-ignore mockInstance is mocked
+  // @ts-expect-error mockInstance is mocked
   const makeInvitation = setupMakeInvitation(mockInstance, mockInstallation);
 
   const mockInvitationHandle = harden({});
   const description = 'myInvitation';
 
   const invitation = makeInvitation(
-    // @ts-ignore mockInvitationHandle is mocked
+    // @ts-expect-error mockInvitationHandle is mocked
     mockInvitationHandle,
     description,
   );


### PR DESCRIPTION
## Description

`ts-expect-error` is better than `ts-ignore` because it notifies when the suppression is no longer necessary. More in prefer-ts-expect-error

This doesn't enable that lint rule due to the implications for downstream users of the `@agoric` eslint config. Could be included once we have https://github.com/Agoric/agoric-sdk/issues/4893

Meanwhile here we have a find-replace commit and a commit to clean up to get back to green.

### Security Considerations

--

### Documentation Considerations

Developers still may not know that they should use `ts-expect-error` but I think the proper solution will be to lint that. See https://github.com/Agoric/agoric-sdk/issues/4893


### Testing Considerations

--