### PR TITLE
fix(deployment): default `faucet-helper.sh` to `show-rpcaddrs`

### DIFF
--- a/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
+++ b/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
@@ -29,9 +29,13 @@ show-faucet-address)
 esac
 
 networkName=$(basename "$thisdir")
-netconfig=$(curl "https://$networkName.agoric.net/network-config")
-chainName=$(echo "$netconfig" | jq -r .chainName)
-read -r -a origRpcAddrs <<<"$(echo "$netconfig" | jq -r .rpcAddrs[])"
+if netconfig=$(curl "https://$networkName.agoric.net/network-config"); then
+  chainName=$(echo "$netconfig" | jq -r .chainName)
+  read -r -a origRpcAddrs <<<"$(echo "$netconfig" | jq -r .rpcAddrs[])"
+else
+  chainName=$(cat "$thisdir/ag-chain-cosmos/chain-name.txt")
+  IFS=, read -r -a origRpcAddrs <<<"$(AG_SETUP_COSMOS_HOME=$thisdir ag-setup-cosmos show-rpcaddrs)"
+fi
 
 read -ra rpcAddrs <<<"${origRpcAddrs[@]}"
 while [[ ${#rpcAddrs[@]} -gt 0 ]]; do


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #5220

## Description

Default to local configuration if remote `*.agoric.net` config is not available.
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
