### PR TITLE
fix: fix types of stopAcceptingOffers

### DIFF
--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -43,7 +43,7 @@
  * @property {ZCFRegisterFeeMint} registerFeeMint
  * @property {ZCFMakeEmptySeatKit} makeEmptySeatKit
  * @property {SetTestJig} setTestJig
- * @property {() => void} stopAcceptingOffers
+ * @property {() => Promise<void>} stopAcceptingOffers
  * @property {() => Instance} getInstance
  */
 

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -97,7 +97,9 @@ export const makeStartInstance = (
           acceptingOffers = false;
           zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.fail(reason));
         },
-        stopAcceptingOffers: () => (acceptingOffers = false),
+        stopAcceptingOffers: () => {
+          acceptingOffers = false;
+        },
         makeUserSeat: (
           invitationHandle,
           initialAllocation,


### PR DESCRIPTION
refs: #5036 (Found while exploring it)

zcf.stopAcceptingOffers was declared as returning `void` but it actually returns a `Promise<void>` (or should given the other fix explained below). The test in test-zcf.js `await`s it, so is clearly relying on it to return a promise.

After all the delegation, the actual implementation is declared as returning `void`, which seems correct to me. However, the implementation was returning `false`. In general, when something is declared as returning `void` we should be careful to return only `undefined`, as anything else could be a capability leak. Though it is not in this case. Since it returns `false` unconditionally, it is not even an information leak.

@turadg @michaelfig @mhofman Shouldn't TS have caught both of these problems? Do you understand why it did not?
