### PR TITLE
Add more deployment tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ dist
 .idea/
 
 /packages.png
+
+chaintest

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -2,6 +2,7 @@
 /* global globalThis, WeakRef, FinalizationRegistry */
 
 import fs from 'fs';
+import path from 'path';
 import process from 'process';
 import crypto from 'crypto';
 import { performance } from 'perf_hooks';
@@ -79,7 +80,8 @@ export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
     console.log('SwingSet xs-worker tracing:', { XSNAP_TEST_RECORD });
     let serial = 0;
     doXSnap = opts => {
-      const workerTrace = `${XSNAP_TEST_RECORD}/${serial}/`;
+      const workerTrace =
+        path.resolve(`${XSNAP_TEST_RECORD}/${serial}`) + path.sep;
       serial += 1;
       fs.mkdirSync(workerTrace, { recursive: true });
       return recordXSnap(opts, workerTrace, {

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -373,6 +373,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       bridgeOutbound: doOutboundBridge,
       vatconfig,
       argv,
+      env,
       metricsProvider,
       slogFile: SLOGFILE,
       slogSender,

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 import {
   importMailbox,
@@ -346,8 +347,23 @@ export default async function main(progname, args, { env, homedir, agcc }) {
 
     const mapSize = (LMDB_MAP_SIZE && parseInt(LMDB_MAP_SIZE, 10)) || undefined;
 
-    const enableTrace =
-      SWING_STORE_TRACE === '1' || !!getFlagValue('trace-store');
+    const defaultTraceFile = path.resolve(stateDBDir, 'store-trace.log');
+    let swingStoreTraceFile;
+    switch (SWING_STORE_TRACE) {
+      case '0':
+      case 'false':
+        break;
+      case '1':
+      case 'true':
+        swingStoreTraceFile = defaultTraceFile;
+        break;
+      default:
+        if (SWING_STORE_TRACE) {
+          swingStoreTraceFile = path.resolve(SWING_STORE_TRACE);
+        } else if (getFlagValue('trace-store')) {
+          swingStoreTraceFile = defaultTraceFile;
+        }
+    }
 
     const s = await launch({
       actionQueue,
@@ -361,7 +377,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       slogFile: SLOGFILE,
       slogSender,
       mapSize,
-      enableTrace,
+      swingStoreTraceFile,
     });
     return s;
   }

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -38,6 +38,7 @@ async function buildSwingset(
   hostStorage,
   vatconfig,
   argv,
+  env,
   { debugName = undefined, slogCallbacks, slogFile, slogSender },
 ) {
   const debugPrefix = debugName === undefined ? '' : `${debugName}:`;
@@ -50,6 +51,7 @@ async function buildSwingset(
   if (config.coreProposals) {
     // FIXME: Find a better way to propagate the role.
     process.env.ROLE = argv.ROLE;
+    env.ROLE = argv.ROLE;
     const { bundles, code } = await extractCoreProposalBundles(
       config.coreProposals,
       vatconfig,
@@ -98,6 +100,7 @@ async function buildSwingset(
     hostStorage,
     deviceEndowments,
     {
+      env,
       slogCallbacks,
       slogFile,
       slogSender,
@@ -165,6 +168,7 @@ export async function launch({
   bridgeOutbound,
   vatconfig,
   argv,
+  env = process.env,
   debugName = undefined,
   metricsProvider = DEFAULT_METER_PROVIDER,
   slogFile = undefined,
@@ -197,6 +201,7 @@ export async function launch({
     hostStorage,
     vatconfig,
     argv,
+    env,
     {
       debugName,
       slogCallbacks,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -170,13 +170,13 @@ export async function launch({
   slogFile = undefined,
   slogSender,
   mapSize = DEFAULT_LMDB_MAP_SIZE,
-  enableTrace,
+  swingStoreTraceFile,
 }) {
   console.info('Launching SwingSet kernel');
 
   const { kvStore, streamStore, snapStore, commit } = openSwingStore(
     kernelStateDBDir,
-    { mapSize, enableTrace },
+    { mapSize, traceFile: swingStoreTraceFile },
   );
   const hostStorage = {
     kvStore,

--- a/packages/deployment/scripts/capture-integration-results.sh
+++ b/packages/deployment/scripts/capture-integration-results.sh
@@ -15,12 +15,8 @@ for node in validator{0,1}; do
   "$thisdir/setup.sh" ssh "$node" cat "$home/config/genesis.json" > "$RESULTSDIR/$node-genesis.json" || true
   "$thisdir/setup.sh" ssh "$node" cat "$home/data/chain.slog" > "$RESULTSDIR/$node.slog" || true
   "$thisdir/setup.sh" ssh "$node" cat "$home/data/ag-cosmos-chain-state/flight-recorder.bin" > "$RESULTSDIR/$node-flight-recorder.bin" || true
-  "$thisdir/setup.sh" ssh "$node" cat "$home/data/ag-cosmos-chain-state/store-trace.log" > "$RESULTSDIR/$node-store-trace.log" || true
-  "$thisdir/setup.sh" ssh "$node" cat "$home/data/kvstore.trace" > "$RESULTSDIR/$node-kvstore.trace" || true
+  "$thisdir/setup.sh" ssh "$node" cat "$home/data/swingstore-trace" > "$RESULTSDIR/$node-swingstore-trace" || true
+  "$thisdir/setup.sh" ssh "$node" cat "$home/data/kvstore-trace" > "$RESULTSDIR/$node-kvstore-trace" || true
+  mkdir -p "$RESULTSDIR/$node-xsnap-trace" && "$thisdir/setup.sh" ssh "$node" tar -c -C "$home/data/xsnap-trace" . | tar -x -C "$RESULTSDIR/$node-xsnap-trace" || true
+  mkdir -p "$RESULTSDIR/$node-xs-snapshots" && "$thisdir/setup.sh" ssh "$node" tar -c -C "$home/data/ag-cosmos-chain-state/xs-snapshots" . | tar -x -C "$RESULTSDIR/$node-xs-snapshots" || true
 done
-
-if [ -d /usr/src/testnet-load-generator ]
-then
-  cp ~/.ag-chain-cosmos/data/ag-cosmos-chain-state/flight-recorder.bin "$RESULTSDIR/flight-recorder.bin" || true
-  cp ~/.ag-chain-cosmos/data/ag-cosmos-chain-state/store-trace.log "$RESULTSDIR/store-trace.log" || true
-fi

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -34,9 +34,11 @@ DOCKER_VOLUMES="$(cd "$thisdir/../../.." > /dev/null && pwd -P):/usr/src/agoric-
 "$thisdir/setup.sh" init --noninteractive
 
 # Go ahead and bootstrap with detailed debug logging.
-AG_COSMOS_START_ARGS="--log_level=info --trace-store=.ag-chain-cosmos/data/kvstore.trace" \
+AG_COSMOS_START_ARGS="--log_level=info --trace-store=.ag-chain-cosmos/data/kvstore-trace" \
 VAULT_FACTORY_CONTROLLER_ADDR="$SOLO_ADDR" \
 CHAIN_BOOTSTRAP_VAT_CONFIG="$VAT_CONFIG" \
+XSNAP_TEST_RECORD=.ag-chain-cosmos/data/xsnap-trace \
+SWING_STORE_TRACE=.ag-chain-cosmos/data/swingstore-trace \
   "$thisdir/setup.sh" bootstrap ${1+"$@"}
 
 if [ -d /usr/src/testnet-load-generator ]
@@ -47,8 +49,9 @@ then
   cd /usr/src/testnet-load-generator
   SOLO_COINS=40000000000urun \
     "$AG_SETUP_COSMOS_HOME/faucet-helper.sh" add-egress loadgen "$SOLO_ADDR"
-  SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" SWING_STORE_TRACE=1 ./start.sh \
-    --no-stage.save-storage --stages=3 --stage.duration=4 \
+  SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
+    --stage.save-storage --trace kvstore swingstore xsnap \
+    --stages=3 --stage.duration=4 \
     --stage.loadgen.vault.interval=12 --stage.loadgen.vault.limit=2 \
     --stage.loadgen.amm.interval=12 --stage.loadgen.amm.wait=6 --stage.loadgen.amm.limit=2 \
     --profile=testnet "--testnet-origin=file://$RESULTSDIR" \

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -27,7 +27,7 @@ then
 fi
 
 # Speed up the docker deployment by pre-mounting /usr/src/agoric-sdk.
-DOCKER_VOLUMES="$(cd "$thisdir/../../.." > /dev/null && pwd -P):/usr/src/agoric-sdk" \
+DOCKER_VOLUMES="${AGORIC_SDK_PATH-$(cd "$thisdir/../../.." > /dev/null && pwd -P)}:/usr/src/agoric-sdk" \
   "$thisdir/docker-deployment.cjs" > deployment.json
 
 # Set up the network from our above deployment.json.

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -469,6 +469,8 @@ show-config      display the client connection parameters
       for (const envName of [
         'VAULT_FACTORY_CONTROLLER_ADDR',
         'CHAIN_BOOTSTRAP_VAT_CONFIG',
+        'XSNAP_TEST_RECORD',
+        'SWING_STORE_TRACE',
       ]) {
         if (env[envName]) {
           serviceLines.push(`Environment="${envName}=${env[envName]}"`);

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -181,11 +181,33 @@ const buildSwingset = async (
     serviceName: 'solo',
   });
 
-  const { SLOGFILE: slogFile, SLOGSENDER, LMDB_MAP_SIZE } = env;
+  const {
+    SLOGFILE: slogFile,
+    SLOGSENDER,
+    LMDB_MAP_SIZE,
+    SWING_STORE_TRACE,
+  } = env;
   const mapSize = (LMDB_MAP_SIZE && parseInt(LMDB_MAP_SIZE, 10)) || undefined;
+
+  const defaultTraceFile = path.resolve(kernelStateDBDir, 'store-trace.log');
+  let swingStoreTraceFile;
+  switch (SWING_STORE_TRACE) {
+    case '0':
+    case 'false':
+      break;
+    case '1':
+    case 'true':
+      swingStoreTraceFile = defaultTraceFile;
+      break;
+    default:
+      if (SWING_STORE_TRACE) {
+        swingStoreTraceFile = path.resolve(SWING_STORE_TRACE);
+      }
+  }
+
   const { kvStore, streamStore, snapStore, commit } = openSwingStore(
     kernelStateDBDir,
-    { mapSize },
+    { mapSize, swingStoreTraceFile },
   );
   const hostStorage = {
     kvStore,

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -235,7 +235,7 @@ const buildSwingset = async (
   const controller = await makeSwingsetController(
     hostStorage,
     deviceEndowments,
-    { slogCallbacks, slogFile, slogSender },
+    { env, slogCallbacks, slogFile, slogSender },
   );
 
   const { crankScheduler } = exportKernelStats({

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -207,7 +207,7 @@ const buildSwingset = async (
 
   const { kvStore, streamStore, snapStore, commit } = openSwingStore(
     kernelStateDBDir,
-    { mapSize, swingStoreTraceFile },
+    { mapSize, traceFile: swingStoreTraceFile },
   );
   const hostStorage = {
     kvStore,

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -130,23 +130,23 @@ function makeSwingStore(dirPath, forceReset, options) {
   }
   fs.mkdirSync(dirPath, { recursive: true });
 
-  const { mapSize = DEFAULT_LMDB_MAP_SIZE, enableTrace } = options;
+  const { mapSize = DEFAULT_LMDB_MAP_SIZE, traceFile } = options;
 
-  let debugOutput = enableTrace
-    ? fs.createWriteStream(path.resolve(dirPath, 'store-trace.log'), {
+  let traceOutput = traceFile
+    ? fs.createWriteStream(path.resolve(traceFile), {
         flags: 'a',
       })
     : null;
 
   function trace(...args) {
-    if (!debugOutput) return;
+    if (!traceOutput) return;
 
-    debugOutput.write(args.join(' '));
-    debugOutput.write('\n');
+    traceOutput.write(args.join(' '));
+    traceOutput.write('\n');
   }
   function stopTrace() {
-    debugOutput && debugOutput.end();
-    debugOutput = null;
+    traceOutput && traceOutput.end();
+    traceOutput = null;
   }
 
   let lmdbEnv = new lmdb.Env();

--- a/scripts/run-deployment-integration.sh
+++ b/scripts/run-deployment-integration.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+SDK_REAL_DIR="$(cd "$(dirname "$(readlink -f -- "$0")")/.." > /dev/null && pwd -P)"
+
+# For some reason something in the integration script
+# relies on the SDK being at that location
+# Set AGORIC_SDK_PATH to the SDK path on the host if this
+# script is running inside a docker environment (and make sure to 
+# bind mount /var/run/docker.sock)
+if [ "$SDK_REAL_DIR" != "/usr/src/agoric-sdk" ]; then
+  echo 'Agoric SDK must be mounted in "/usr/src/agoric-sdk"'
+  exit 1
+fi
+
+export NETWORK_NAME=chaintest
+
+sudo ln -sf /usr/src/agoric-sdk/packages/deployment/bin/ag-setup-cosmos /usr/local/bin/ag-setup-cosmos
+rm -rf /usr/src/agoric-sdk/chaintest  ~/.ag-chain-cosmos/ /usr/src/testnet-load-generator/_agstate/agoric-servers/testnet-8000
+
+cd /usr/src/agoric-sdk/
+sudo ./packages/deployment/scripts/install-deps.sh
+yarn install && yarn build && make -C packages/cosmic-swingset/
+/usr/src/agoric-sdk/packages/deployment/scripts/integration-test.sh
+
+/usr/src/agoric-sdk/packages/deployment/scripts/setup.sh play stop || true
+/usr/src/agoric-sdk/packages/deployment/scripts/capture-integration-results.sh
+echo yes | /usr/src/agoric-sdk/packages/deployment/scripts/setup.sh destroy


### PR DESCRIPTION
## Description

- Wire the solo to capture xsnap traces to `SOLO_XSNAP_TEST_RECORD`
- Update the [`SWING_STORE_TRACE` env](https://github.com/Agoric/agoric-sdk/pull/5192) to accept a path, and wire the solo to use `SOLO_SWING_STORE_TRACE`
- Record xsnap and swingstore traces for both the solo and chain nodes in addition to kvstore traces and swingstore traces during the deployment integration test. Relies on https://github.com/Agoric/testnet-load-generator/pull/79 landing, but passing extra args is backwards compatible so this change can land first.
- Add the shell script I've been using to locally replicate the deployment integration test in one shot (extracted from https://github.com/Agoric/agoric-sdk/issues/4911)
- Drive-by fix/support of relative path for `XSNAP_TEST_RECORD`

### Security Considerations

The env is now passed through from the chain and solo's main into Swingset instead of being read from `process` by `makeSwingsetController`

### Documentation Considerations

IOU some docs for `SWING_STORE_TRACE` and `SOLO_` variants

### Testing Considerations

Tested locally. Will trigger a deployment integration test.
