### PR TITLE
chore(swingset-vat): declare deps of testing tools

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -22,9 +22,7 @@
   },
   "devDependencies": {
     "@agoric/vat-data": "^0.2.0",
-    "@endo/ses-ava": "^0.2.25",
     "@types/tmp": "^0.2.0",
-    "ava": "^3.12.1",
     "tmp": "^0.2.1"
   },
   "dependencies": {
@@ -49,6 +47,10 @@
     "import-meta-resolve": "^1.1.1",
     "node-lmdb": "^0.9.5",
     "semver": "^6.3.0"
+  },
+  "peerDependencies": {
+    "@endo/ses-ava": "^0.2.25",
+    "ava": "^3.12.1"
   },
   "files": [
     "bin/vat",

--- a/packages/SwingSet/tools/prepare-test-env-ava.js
+++ b/packages/SwingSet/tools/prepare-test-env-ava.js
@@ -8,17 +8,9 @@ import '@endo/init/pre-bundle-source.js';
 
 import './prepare-test-env.js';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import '@endo/ses-ava/exported.js';
 
-// eslint thinks these are extraneous dependencies because this file
-// is in the tools/ directory rather than the test/ directory.
-// TODO How do we tell eslint that tools/ is dev-only? Either
-// that, or should we just move tools/* into test/ ?
-//
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { wrapTest } from '@endo/ses-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import rawTest from 'ava';
 
 /** @type {typeof rawTest} */


### PR DESCRIPTION
in pursuit of https://github.com/Agoric/agoric-sdk/pull/5201

## Description
The `ava` and `@endo/ses-ava` deps of `@agoric/swingset-vat` weren't declared in its package.json. In projects that imported that package and used `tools/prepare-test-env-ava.js`, they would get errors like this on test:
```
  Error: Cannot find package '@endo/ses-ava' imported from /opt/agoric/documentation/node_modules/@agoric/swingset-vat/tools/prepare-test-env-ava.js
```

I think this was due to a [misconception](https://github.com/Agoric/agoric-sdk/blame/d5f9cadb93f7881bab173b926a149e58b6cee3d7/packages/SwingSet/tools/prepare-test-env-ava.js#L14-L17) about `devDependencies`.  It doesn't mean dependencies used only for development; it means dependencies only for development of _this package_ and not needed by any consumers of this package. `tools` files are exported by this package (and consumed in dapps) so for those modules to work the dependencies have to be available too.

This uses `peerDependencies` to ensure that the test environment has the right deps and that they're compatible with those at the package parent scope.

### Security Considerations

--

### Documentation Considerations

Some guidance around which kind of dep to use?
Maybe an audit of Eslint suppressions to see which are legitimate. Those that aren't we might disable.

### Testing Considerations

CI 