### PR TITLE
chore: drop no-longer-needed deeplyFulfilled

### DIFF
--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { deeplyFulfilled, Far } from '@endo/marshal';
+import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
 import { Nat } from '@agoric/nat';
@@ -308,7 +308,7 @@ const makeParamManagerBuilder = zoe => {
     const newValues = Object.fromEntries(tuples);
     publication.updateState({ paramNames });
 
-    return deeplyFulfilled(harden(newValues));
+    return harden(newValues);
   };
 
   const makeParamManager = () => {


### PR DESCRIPTION

## Description

Recently noticed that deeplyFulfilled is no longer needed in `updateParams()` while pairing with Dean.

### Security Considerations

No effect

### Documentation Considerations

Not visible.

### Testing Considerations

Tests continue to pass, including some that would have produced async results before recent refactorings.
