### PR TITLE
feat(governance): add the ability to govern json parameters

### DIFF
--- a/packages/governance/src/constants.js
+++ b/packages/governance/src/constants.js
@@ -11,6 +11,7 @@ export const ParamTypes = /** @type {const} */ ({
   INSTALLATION: 'installation',
   INSTANCE: 'instance',
   INVITATION: 'invitation',
+  JSON: 'json',
   NAT: 'nat',
   RATIO: 'ratio',
   STRING: 'string',

--- a/packages/governance/src/contractGovernance/assertions.js
+++ b/packages/governance/src/contractGovernance/assertions.js
@@ -49,7 +49,6 @@ const makeAssertBrandedRatio = (name, modelRatio) => {
       ratio.denominator.brand === modelRatio.denominator.brand,
       X`Denominator brand for ${name} must be ${modelRatio.denominator.brand}`,
     );
-    return true;
   };
 };
 harden(makeAssertBrandedRatio);

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -45,6 +45,7 @@ const assertElectorateMatches = (paramManager, governedParams) => {
  * @property {(name: string, value: bigint) => ParamManagerBuilder} addNat
  * @property {(name: string, value: Ratio) => ParamManagerBuilder} addRatio
  * @property {(name: string, value: string) => ParamManagerBuilder} addString
+ * @property {(name: string, value: string) => ParamManagerBuilder} addJson
  * @property {(name: string, value: any) => ParamManagerBuilder} addUnknown
  * @property {() => AnyParamManager} build
  */
@@ -160,6 +161,21 @@ const makeParamManagerBuilder = zoe => {
   const addString = (name, value, builder) => {
     const assertString = v => assert.typeof(v, 'string');
     buildCopyParam(name, value, assertString, ParamTypes.STRING);
+    return builder;
+  };
+
+  /** @type {(name: string, value: string, builder: ParamManagerBuilder) => ParamManagerBuilder} */
+  const addJson = (name, value, builder) => {
+    const assertJson = v => {
+      try {
+        assert.typeof(v, 'string');
+        JSON.parse(v);
+      } catch (e) {
+        throw Error(`Expected a json string. "${v}" is not valid json.`);
+      }
+      return true;
+    };
+    buildCopyParam(name, value, assertJson, ParamTypes.JSON);
     return builder;
   };
 
@@ -328,6 +344,7 @@ const makeParamManagerBuilder = zoe => {
       getNat: name => getTypedParam(ParamTypes.NAT, name),
       getRatio: name => getTypedParam(ParamTypes.RATIO, name),
       getString: name => getTypedParam(ParamTypes.STRING, name),
+      getJson: name => getTypedParam(ParamTypes.JSON, name),
       getUnknown: name => getTypedParam(ParamTypes.UNKNOWN, name),
       getVisibleValue,
       getInternalParamValue,
@@ -350,6 +367,7 @@ const makeParamManagerBuilder = zoe => {
     addNat: (n, v) => addNat(n, v, builder),
     addRatio: (n, v) => addRatio(n, v, builder),
     addString: (n, v) => addString(n, v, builder),
+    addJson: (n, v) => addJson(n, v, builder),
     build: () => makeParamManager(),
   };
   return builder;

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -112,7 +112,7 @@ const makeParamManagerBuilder = zoe => {
   const addAmount = (name, value, builder) => {
     const assertAmount = a => {
       assert(a.brand, `Expected an Amount for ${name}, got "${a}"`);
-      return AmountMath.coerce(value.brand, a);
+      AmountMath.coerce(value.brand, a);
     };
     buildCopyParam(name, value, assertAmount, ParamTypes.AMOUNT);
     return builder;
@@ -144,7 +144,6 @@ const makeParamManagerBuilder = zoe => {
     const assertNat = v => {
       assert.typeof(v, 'bigint');
       Nat(v);
-      return true;
     };
     buildCopyParam(name, value, assertNat, ParamTypes.NAT);
     return builder;
@@ -173,7 +172,6 @@ const makeParamManagerBuilder = zoe => {
       } catch (e) {
         throw Error(`Expected a json string. "${v}" is not valid json.`);
       }
-      return true;
     };
     buildCopyParam(name, value, assertJson, ParamTypes.JSON);
     return builder;

--- a/packages/governance/test/unitTests/test-buildParamManager.js
+++ b/packages/governance/test/unitTests/test-buildParamManager.js
@@ -320,6 +320,41 @@ test('Strings', async t => {
   });
 });
 
+test('JSON blobs', async t => {
+  const paramManager = makeParamManagerBuilder()
+    .addNat('Acres', 50n)
+    .addJson('Blob', '{ "author": "Crockford" }')
+    .build();
+  t.is(paramManager.getJson('Blob'), '{ "author": "Crockford" }');
+
+  await paramManager.updateParams({
+    Blob: '{ "authors": "Crockford,Morningstar" }',
+  });
+  t.is(paramManager.getBlob(), '{ "authors": "Crockford,Morningstar" }');
+  await t.throwsAsync(
+    () =>
+      paramManager.updateParams({
+        Blob: 300000000,
+      }),
+    {
+      message: 'Expected a json string. "300000000" is not valid json.',
+    },
+  );
+  await t.throwsAsync(
+    () =>
+      paramManager.updateParams({
+        Blob: 'author: bob',
+      }),
+    {
+      message: 'Expected a json string. "author: bob" is not valid json.',
+    },
+  );
+
+  t.throws(() => paramManager.getNat('Blob'), {
+    message: '"Blob" is not "nat"',
+  });
+});
+
 test('Unknown', async t => {
   const paramManager = makeParamManagerBuilder()
     .addString('Label', 'birthday')

--- a/packages/governance/test/unitTests/test-buildParamManager.js
+++ b/packages/governance/test/unitTests/test-buildParamManager.js
@@ -331,6 +331,13 @@ test('JSON blobs', async t => {
     Blob: '{ "authors": "Crockford,Morningstar" }',
   });
   t.is(paramManager.getBlob(), '{ "authors": "Crockford,Morningstar" }');
+
+  await paramManager.updateParams({
+    // trailing whitespace is preserved
+    Blob: '{ "authors": "Crockford,Morningstar" }    ',
+  });
+  t.is(paramManager.getBlob(), '{ "authors": "Crockford,Morningstar" }    ');
+
   await t.throwsAsync(
     () =>
       paramManager.updateParams({
@@ -347,6 +354,17 @@ test('JSON blobs', async t => {
       }),
     {
       message: 'Expected a json string. "author: bob" is not valid json.',
+    },
+  );
+
+  await t.throwsAsync(
+    () =>
+      paramManager.updateParams({
+        Blob: '{ author: "bob" };',
+      }),
+    {
+      message:
+        'Expected a json string. "{ author: "bob" };" is not valid json.',
     },
   );
 


### PR DESCRIPTION
closes: #5184

## Description

Adds the ability to govern json parametes.

### Security Considerations

A new type for governance. 

### Documentation Considerations

Nothing special required. we still need to document governance.

### Testing Considerations

Added positive, negative, and regression tests for json blobs.
