### PR TITLE
ci(docker): tolerate unordered arches in create manifest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,12 +87,10 @@ jobs:
         run: |
           IMAGE=agoric/deployment
           for TAG in ${{ steps.docker-tags.outputs.tags }} ${{ needs.snapshot.outputs.tag }}; do
-            AMENDS=
             for ARCH in $ALL_ARCHES; do
               ARCHTAG=$(echo "$ARCH" | tr / _)
-              AMENDS="$AMENDS --amend $IMAGE:${{ needs.snapshot.outputs.tag }}-$ARCHTAG"
+              docker manifest create "$IMAGE:$TAG" --amend "$IMAGE:${{ needs.snapshot.outputs.tag }}-$ARCHTAG" || true
             done
-            docker manifest create "$IMAGE:$TAG" $AMENDS || true
             docker manifest push "$IMAGE:$TAG"
           done
       - name: Build and Push sdk
@@ -116,12 +114,10 @@ jobs:
         run: |
           IMAGE=agoric/agoric-sdk
           for TAG in ${{ steps.docker-tags.outputs.tags }} ${{ needs.snapshot.outputs.tag }}; do
-            AMENDS=
             for ARCH in $ALL_ARCHES; do
               ARCHTAG=$(echo "$ARCH" | tr / _)
-              AMENDS="$AMENDS --amend $IMAGE:${{ needs.snapshot.outputs.tag }}-$ARCHTAG"
+              docker manifest create "$IMAGE:$TAG" --amend "$IMAGE:${{ needs.snapshot.outputs.tag }}-$ARCHTAG" || true
             done
-            docker manifest create "$IMAGE:$TAG" $AMENDS || true
             docker manifest push "$IMAGE:$TAG"
           done
       - name: Build and Push setup
@@ -138,12 +134,10 @@ jobs:
         run: |
           IMAGE=agoric/cosmic-swingset-setup
           for TAG in ${{ steps.docker-tags.outputs.tags }} ${{ needs.snapshot.outputs.tag }}; do
-            AMENDS=
             for ARCH in $ALL_ARCHES; do
               ARCHTAG=$(echo "$ARCH" | tr / _)
-              AMENDS="$AMENDS --amend $IMAGE:${{ needs.snapshot.outputs.tag }}-$ARCHTAG"
+              docker manifest create "$IMAGE:$TAG" --amend "$IMAGE:${{ needs.snapshot.outputs.tag }}-$ARCHTAG" || true
             done
-            docker manifest create "$IMAGE:$TAG" $AMENDS || true
             docker manifest push "$IMAGE:$TAG"
           done
       - name: notify on failure


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

During Docker build CI when using `docker create manifest xxx --amend image:a --amend image:b || true` the manifest wasn't created at all when `image:a` was missing but `image:b` was present.  It's better to separate these out into:

```sh
docker create manifest xxx --amend image:a || true
docker create manifest xxx --amend image:b || true
```

which I've verified creates `xxx` with all the available images, regardless of their ordering.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Should prevent a CI flake.
