### PR TITLE
fix: conform to Agoric arrow-only function style

### DIFF
--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
@@ -5,7 +5,7 @@ import { makePromiseKit } from '@endo/promise-kit';
 
 import { NUM_SENSORS } from './num-sensors.js';
 
-function insistMissing(ref, isCollection = false) {
+const insistMissing = (ref, isCollection = false) => {
   let p;
   if (isCollection) {
     p = E(ref).set(1, 2);
@@ -20,9 +20,9 @@ function insistMissing(ref, isCollection = false) {
       assert.equal(err.message, 'vat terminated');
     },
   );
-}
+};
 
-export function buildRootObject() {
+export const buildRootObject = () => {
   let vatAdmin;
   let ulrikRoot;
   let ulrikAdmin;
@@ -37,19 +37,15 @@ export function buildRootObject() {
   let retain;
 
   return Far('root', {
-    async bootstrap(vats, devices) {
+    bootstrap: async (vats, devices) => {
       vatAdmin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
     },
 
-    getMarker() {
-      return marker;
-    },
+    getMarker: () => marker,
 
-    getImportSensors() {
-      return importSensors;
-    },
+    getImportSensors: () => importSensors,
 
-    async buildV1() {
+    buildV1: async () => {
       // build Ulrik, the upgrading vat
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik1');
       const vatParameters = { youAre: 'v1', marker };
@@ -80,7 +76,7 @@ export function buildRootObject() {
       return { version, data, p1, p2, retain, ...parameters };
     },
 
-    async upgradeV2() {
+    upgradeV2: async () => {
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik2');
       const vatParameters = { youAre: 'v2', marker };
       await E(ulrikAdmin).upgrade(bcap, vatParameters);
@@ -140,7 +136,7 @@ export function buildRootObject() {
       return { version, data, remoerr, ...parameters };
     },
 
-    async buildV1WithLostKind() {
+    buildV1WithLostKind: async () => {
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik1');
       const vatParameters = { youAre: 'v1', marker };
       const options = { vatParameters };
@@ -150,10 +146,10 @@ export function buildRootObject() {
       await E(ulrikRoot).makeLostKind();
     },
 
-    async upgradeV2WhichLosesKind() {
+    upgradeV2WhichLosesKind: async () => {
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik2');
       const vatParameters = { youAre: 'v2', marker };
       await E(ulrikAdmin).upgrade(bcap, vatParameters); // throws
     },
   });
-}
+};

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -13,39 +13,37 @@ import { capargs, capdataOneSlot } from '../util.js';
 
 import { NUM_SENSORS } from './num-sensors.js';
 
-function bfile(name) {
-  return new URL(name, import.meta.url).pathname;
-}
+const bfile = name => new URL(name, import.meta.url).pathname;
 
-function get(capdata, propname) {
+const get = (capdata, propname) => {
   const body = JSON.parse(capdata.body);
   const value = body[propname];
   if (typeof value === 'object' && value['@qclass'] === 'slot') {
     return ['slot', capdata.slots[value.index]];
   }
   return value;
-}
+};
 
-function getRetained(capdata, propname) {
+const getRetained = (capdata, propname) => {
   const body = JSON.parse(capdata.body);
   const value = body.retain[propname];
   if (typeof value === 'object' && value['@qclass'] === 'slot') {
     return ['slot', capdata.slots[value.index]];
   }
   return value;
-}
+};
 
-function getImportSensorKref(impcapdata, i) {
+const getImportSensorKref = (impcapdata, i) => {
   const body = JSON.parse(impcapdata.body);
   const value = body[i];
   if (typeof value === 'object' && value['@qclass'] === 'slot') {
     return ['slot', impcapdata.slots[value.index]];
   }
   return value;
-}
+};
 
 // eslint-disable-next-line no-unused-vars
-function dumpState(hostStorage, vatID) {
+const dumpState = (hostStorage, vatID) => {
   const s = getAllState(hostStorage).kvStuff;
   const keys = Array.from(Object.keys(s)).sort();
   for (const k of keys) {
@@ -53,9 +51,9 @@ function dumpState(hostStorage, vatID) {
       console.log(k, s[k]);
     }
   }
-}
+};
 
-async function testUpgrade(t, defaultManagerType) {
+const testUpgrade = async (t, defaultManagerType) => {
   const config = {
     includeDevDependencies: true, // for vat-data
     defaultManagerType,
@@ -78,14 +76,14 @@ async function testUpgrade(t, defaultManagerType) {
   c.pinVatRoot('bootstrap');
   await c.run();
 
-  async function run(name, args = []) {
+  const run = async (name, args = []) => {
     assert(Array.isArray(args));
     const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
     await c.run();
     const status = c.kpStatus(kpid);
     const capdata = c.kpResolution(kpid);
     return [status, capdata];
-  }
+  };
 
   const mcd = await run('getMarker');
   t.is(mcd[0], 'fulfilled');
@@ -124,19 +122,19 @@ async function testUpgrade(t, defaultManagerType) {
   const vir7Kref = getRetained(v1capdata, 'vir7')[1];
 
   const vatID = kvStore.get(`${dur1Kref}.owner`); // probably v6
-  function getVref(kref) {
+  const getVref = kref => {
     const s = kvStore.get(`${vatID}.c.${kref}`);
     return parseReachableAndVatSlot(s).vatSlot;
-  }
-  function krefReachable(kref) {
+  };
+  const krefReachable = kref => {
     const s = kvStore.get(`${vatID}.c.${kref}`);
     return !!(s && parseReachableAndVatSlot(s).isReachable);
-  }
+  };
   // We look in the vat's vatstore to see if the virtual/durable
   // object exists or not (as a state record).
-  function vomHas(vref) {
+  const vomHas = vref => {
     return kvStore.has(`${vatID}.vs.vom.${vref}`);
-  }
+  };
 
   // dumpState(hostStorage, vatID);
 
@@ -145,15 +143,15 @@ async function testUpgrade(t, defaultManagerType) {
   const dur1Vref = getVref(dur1Kref);
   t.is(parseVatSlot(dur1Vref).subid, 1n);
   const durBase = dur1Vref.slice(0, dur1Vref.length - 2);
-  function durVref(i) {
+  const durVref = i => {
     return `${durBase}/${i}`;
-  }
+  };
   const vir2Vref = getVref(vir2Kref);
   t.is(parseVatSlot(vir2Vref).subid, 2n);
   const virBase = vir2Vref.slice(0, vir2Vref.length - 2);
-  function virVref(i) {
+  const virVref = i => {
     return `${virBase}/${i}`;
-  }
+  };
 
   t.true(vomHas(durVref(1)));
   t.true(vomHas(virVref(2)));
@@ -254,7 +252,7 @@ async function testUpgrade(t, defaultManagerType) {
   t.false(kvStore.has(`${vir2Kref}.owner`));
   t.false(kvStore.has(`${vir5Kref}.owner`));
   t.false(kvStore.has(`${vir7Kref}.owner`));
-}
+};
 
 test('vat upgrade - local', async t => {
   return testUpgrade(t, 'local');
@@ -285,14 +283,14 @@ test('failed upgrade - lost kind', async t => {
   c.pinVatRoot('bootstrap');
   await c.run();
 
-  async function run(name, args = []) {
+  const run = async (name, args = []) => {
     assert(Array.isArray(args));
     const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
     await c.run();
     const status = c.kpStatus(kpid);
     const capdata = c.kpResolution(kpid);
     return [status, capdata];
-  }
+  };
 
   // create initial version
   const [v1status] = await run('buildV1WithLostKind', []);

--- a/packages/SwingSet/test/upgrade/vat-ulrik-1.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-1.js
@@ -10,15 +10,13 @@ import {
 import { NUM_SENSORS } from './num-sensors.js';
 
 const durandalHandle = makeKindHandle('durandal');
-function initialize(name, imp, value) {
+const initialize = (name, imp, value) => {
   return harden({ name, imp, value });
-}
+};
 
 const behavior = {
-  get({ state }) {
-    return state.value;
-  },
-  set({ state }, value) {
+  get: ({ state }) => state.value,
+  set: ({ state }, value) => {
     state.value = value;
   },
 };
@@ -34,11 +32,11 @@ let modRetains;
 // we set up a lot of virtual and durable objects to test what gets
 // deleted vs retained (see object-graph.pdf for the test plan)
 
-function makeRemotable(name, held) {
+const makeRemotable = (name, held) => {
   return Far(name, { get: () => held });
-}
+};
 
-function buildExports(baggage, imp) {
+const buildExports = (baggage, imp) => {
   // each virtual/durable object has a unique import, some of which
   // should be dropped during upgrade
 
@@ -133,9 +131,9 @@ function buildExports(baggage, imp) {
     rem2,
     rem3,
   };
-}
+};
 
-export function buildRootObject(_vatPowers, vatParameters, baggage) {
+export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const { promise: p1 } = makePromiseKit();
   const { promise: p2 } = makePromiseKit();
   let heldPromise;
@@ -144,45 +142,29 @@ export function buildRootObject(_vatPowers, vatParameters, baggage) {
   baggage.init('durandalHandle', durandalHandle);
 
   return Far('root', {
-    getVersion() {
-      return 'v1';
-    },
-    getParameters() {
-      return vatParameters;
-    },
+    getVersion: () => 'v1',
+    getParameters: () => vatParameters,
 
-    acceptPresence(pres) {
+    acceptPresence: pres => {
       baggage.init('presence', pres);
     },
-    getPresence() {
-      return baggage.get('presence');
-    },
-    getData() {
-      return baggage.get('data');
-    },
-    getDurandal(arg) {
-      return makeDurandal('durandal', 0, arg);
-    },
-    getExports(imp) {
-      return buildExports(baggage, imp);
-    },
+    getPresence: () => baggage.get('presence'),
+    getData: () => baggage.get('data'),
+    getDurandal: arg => makeDurandal('durandal', 0, arg),
+    getExports: imp => buildExports(baggage, imp),
 
-    acceptPromise(p) {
+    acceptPromise: p => {
       // stopVat will reject the promises that we decide, but should
       // not touch the ones we don't decide, so we hold onto this
       // until upgrade, to probe for bugs in that loop
       heldPromise = p;
       heldPromise.catch(() => 'hush');
     },
-    getEternalPromise() {
-      return { p1 };
-    },
-    returnEternalPromise() {
-      return p2;
-    },
+    getEternalPromise: () => ({ p1 }),
+    returnEternalPromise: () => p2,
 
-    makeLostKind() {
+    makeLostKind: () => {
       makeKindHandle('unhandled', []);
     },
   });
-}
+};

--- a/packages/SwingSet/test/upgrade/vat-ulrik-2.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-2.js
@@ -2,43 +2,29 @@ import { Far } from '@endo/marshal';
 import { assert } from '@agoric/assert';
 import { defineDurableKind } from '@agoric/vat-data';
 
-function initialize(name, imp, value) {
+const initialize = (name, imp, value) => {
   return harden({ name, imp, value });
-}
+};
 
 const behavior = {
-  get({ state }) {
-    return { new: 'new', ...state.value };
-  },
-  getImport({ state }) {
-    return state.imp;
-  },
-  set({ state }, value) {
+  get: ({ state }) => ({ new: 'new', ...state.value }),
+  getImport: ({ state }) => state.imp,
+  set: ({ state }, value) => {
     state.value = value;
   },
 };
 
-export function buildRootObject(_vatPowers, vatParameters, baggage) {
+export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const durandalHandle = baggage.get('durandalHandle');
   defineDurableKind(durandalHandle, initialize, behavior);
 
   return Far('root', {
-    getVersion() {
-      return 'v2';
-    },
-    getParameters() {
-      return vatParameters;
-    },
-    getPresence() {
-      return baggage.get('presence');
-    },
-    getData() {
-      return baggage.get('data');
-    },
-    getEntries(collection) {
-      return Array.from(collection.entries());
-    },
-    checkBaggage(imp32, imp36) {
+    getVersion: () => 'v2',
+    getParameters: () => vatParameters,
+    getPresence: () => baggage.get('presence'),
+    getData: () => baggage.get('data'),
+    getEntries: collection => Array.from(collection.entries()),
+    checkBaggage: (imp32, imp36) => {
       // console.log(`baggage:`, Array.from(baggage.keys()));
       const dc5 = baggage.get('dc5');
       const dc6 = baggage.get('dc6');
@@ -56,4 +42,4 @@ export function buildRootObject(_vatPowers, vatParameters, baggage) {
       return { imp33, imp35, imp37, imp38 };
     },
   });
-}
+};


### PR DESCRIPTION
Should be a pure semantics-free refactoring, as if fully automated, changing function syntaxes that violate Agoric style into the Agoric arrow-only style.