### PR TITLE
feat(swingset): allow buildRootObject to return a Promise

### DIFF
--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -131,6 +131,9 @@ export function makeXsSubprocessFactory({
     async function issueTagged(item) {
       parentLog(item[0], '...', item.length - 1);
       const result = await worker.issueStringCommand(JSON.stringify(item));
+      // note: if 'result.reply' is empty, that probably means the
+      // worker reached end-of-crank (idle) without seeing the
+      // `dispatch()` promise resolve
       const reply = JSON.parse(result.reply);
       assert(Array.isArray(reply));
       const [tag, ...rest] = reply;

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -1275,7 +1275,7 @@ function build(
     );
 
     // here we finally invoke the vat code, and get back the root object
-    const rootObject = buildRootObject(
+    const rootObject = await buildRootObject(
       harden(vpow),
       harden(vatParameters),
       baggage,
@@ -1447,18 +1447,23 @@ function build(
     } else if (delivery[0] === 'stopVat') {
       return meterControl.runWithoutMeteringAsync(stopVat);
     } else {
+      let complete = false;
       // Start user code running, record any internal liveslots errors. We do
       // *not* directly wait for the userspace function to complete, nor for
       // any promise it returns to fire.
       const p = Promise.resolve(delivery).then(unmeteredDispatch);
+      p.finally(() => (complete = true));
 
-      // Instead, we wait for userspace to become idle by draining the promise
-      // queue. We clean up and then return 'p' so any bugs in liveslots that
-      // cause an error during unmeteredDispatch will be reported to the
-      // supervisor (but only after userspace is idle).
+      // Instead, we wait for userspace to become idle by draining the
+      // promise queue. We clean up and then examine/return 'p' so any
+      // bugs in liveslots that cause an error during
+      // unmeteredDispatch (or a 'buildRootObject' that fails to
+      // complete in time) will be reported to the supervisor (but
+      // only after userspace is idle).
       return gcTools.waitUntilQuiescent().then(() => {
         afterDispatchActions();
-        return p;
+        // eslint-disable-next-line prefer-promise-reject-errors
+        return complete ? p : Promise.reject('buildRootObject unresolved');
       });
     }
   }

--- a/packages/SwingSet/src/supervisors/supervisor-helper.js
+++ b/packages/SwingSet/src/supervisors/supervisor-helper.js
@@ -37,7 +37,7 @@ function makeSupervisorDispatch(dispatch) {
         err => {
           // TODO react more thoughtfully, maybe terminate the vat
           console.log(`error ${err} during vat dispatch() of ${delivery}`);
-          return harden(['error', `${err.message}`, null]);
+          return harden(['error', `${err}`, null]);
         },
       );
   }

--- a/packages/SwingSet/test/upgrade/vat-ulrik-2.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-2.js
@@ -22,7 +22,7 @@ export function buildRootObject(_vatPowers, vatParameters, baggage) {
   const durandalHandle = baggage.get('durandalHandle');
   defineDurableKind(durandalHandle, initialize, behavior);
 
-  return Far('root', {
+  const root = Far('root', {
     getVersion() {
       return 'v2';
     },
@@ -56,4 +56,6 @@ export function buildRootObject(_vatPowers, vatParameters, baggage) {
       return { imp33, imp35, imp37, imp38 };
     },
   });
+  // exercise async return
+  return Promise.resolve(root);
 }

--- a/packages/SwingSet/test/vat-admin/broken-hang-vat.js
+++ b/packages/SwingSet/test/vat-admin/broken-hang-vat.js
@@ -1,0 +1,6 @@
+import { makePromiseKit } from '@endo/promise-kit';
+
+export function buildRootObject() {
+  const pk = makePromiseKit();
+  return pk.promise; // never resolves
+}

--- a/packages/SwingSet/test/vat-admin/new-vat-13.js
+++ b/packages/SwingSet/test/vat-admin/new-vat-13.js
@@ -20,7 +20,7 @@ export function buildRootObject(_vatPowers, vatParameters) {
       },
     });
   }
-  return Far('root', {
+  const root = Far('root', {
     getANumber() {
       return 13;
     },
@@ -31,4 +31,6 @@ export function buildRootObject(_vatPowers, vatParameters) {
       return rcvrMaker(init);
     },
   });
+  // exercise async return
+  return Promise.resolve(root);
 }


### PR DESCRIPTION
New (or upgraded) vats are defined by a user-provided
`buildRootObject` function. This function has two responsibilities:

* provide a root object
* use `defineDurableKind` to bind behavior to any pre-existing durable
  kinds

Previously, `buildRootObject` was given exactly one "turn" to fulfill
these responsibilities: it was required to return the root object
synchronously. If it returned a Promise, that was rejected as an
error.

This requirement is at odds with the needs for updated ZCF vats to
evaluate their contract code and interact with it (giving the contract
a chance to bind their own Kind behavior). The `importBundle` function
we use to load contracts is async. However, it is still "prompt": it
needs no IO, nor any messages leaving the vat. So it will still
complete within the *crank*, just not synchronously within the turn.

So this commit changes liveslots to allow `buildRootObject` to return
a Promise for the root object. The requirement, however, is that this
Promise must resolve by the end of the initial crank (before
`waitUntilQuiescent` / `setImmediate` determines that the promise
queue is empty). If the Promise is not fulfilled by then, the vat
creation/update is considered broken.

closes #5246
