### PR TITLE
feat(swingset): queue to promise

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -737,7 +737,7 @@ export default function buildKernel(
    * This does not decrement any refcounts. The caller should do that.
    *
    * @param { RunQueueEventSend } message
-   * @returns { { vatID: VatID, targetObject: string } | null }
+   * @returns { { vatID: VatID | null, target: string } | null }
    */
   function routeSendEvent(message) {
     const { target, msg } = message;
@@ -759,12 +759,12 @@ export default function buildKernel(
       if (!vatID) {
         return splat(VAT_TERMINATION_ERROR);
       }
-      return { vatID, targetObject };
+      return { vatID, target: targetObject };
     }
 
-    function enqueue() {
-      kernelKeeper.addMessageToPromiseQueue(target, msg);
-      return null; // message is queued, not sent to a vat right now
+    function requeue() {
+      // message will be requeued, not sent to a vat right now
+      return { vatID: null, target };
     }
 
     if (type === 'object') {
@@ -788,7 +788,7 @@ export default function buildKernel(
       }
       case 'unresolved': {
         if (!kp.decider) {
-          return enqueue();
+          return requeue();
         } else {
           insistVatID(kp.decider);
           // eslint-disable-next-line no-use-before-define
@@ -798,9 +798,9 @@ export default function buildKernel(
             return splat(VAT_TERMINATION_ERROR);
           }
           if (deciderVat.enablePipelining) {
-            return { vatID: kp.decider, targetObject: target };
+            return { vatID: kp.decider, target };
           }
-          return enqueue();
+          return requeue();
         }
       }
       default:
@@ -878,13 +878,25 @@ export default function buildKernel(
     let useMeter = false;
     let deliverP = null;
 
+    // The common action should be delivering events to the vat. Any references
+    // in the events should no longer be the kernel's responsibility and the
+    // refcounts should be decremented
     if (message.type === 'send') {
       useMeter = true;
       const route = routeSendEvent(message);
-      decrementSendEventRefCount(message);
-      if (route) {
+      if (!route) {
+        // Message went splat
+        decrementSendEventRefCount(message);
+      } else {
         vatID = route.vatID;
-        deliverP = processSend(vatID, route.targetObject, message.msg);
+        if (vatID) {
+          decrementSendEventRefCount(message);
+          deliverP = processSend(vatID, route.target, message.msg);
+        } else {
+          // Message is requeued and stays the kernel's responsibility, do not
+          // decrement refcounts in this case
+          kernelKeeper.addMessageToPromiseQueue(route.target, message.msg);
+        }
       }
     } else if (message.type === 'notify') {
       useMeter = true;
@@ -1089,7 +1101,32 @@ export default function buildKernel(
     /** @type { PolicyInput } */
     const policyInput = ['none'];
 
-    kernelKeeper.addToRunQueue(message);
+    // By default we're moving events from one queue to another. Any references
+    // in the events remain the kernel's responsibility and the refcounts persist
+    if (message.type === 'send') {
+      const route = routeSendEvent(message);
+      if (!route) {
+        // Message went splat, no longer the kernel's responsibility
+        decrementSendEventRefCount(message);
+      } else {
+        const { vatID, target } = route;
+        if (target !== message.target) {
+          // Message has been re-targeted, other refcounts stay intact
+          kernelKeeper.decrementRefCount(message.target, `deq|msg|t`);
+          kernelKeeper.incrementRefCount(target, `enq|msg|t`);
+        }
+        if (vatID) {
+          kernelKeeper.addToRunQueue({
+            ...message,
+            target,
+          });
+        } else {
+          kernelKeeper.addMessageToPromiseQueue(target, message.msg);
+        }
+      }
+    } else {
+      kernelKeeper.addToRunQueue(message);
+    }
 
     kernelKeeper.processRefcounts();
     kernelKeeper.saveStats();

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -557,7 +557,7 @@ export function buildPatterns(log) {
       return pipe2;
     };
   }
-  out.a70 = ['pipe1', 'pipe2', 'pipe3', 'p1.then', 'p2.then', 'p3.then'];
+  out.a70 = ['pipe1', 'p1.then', 'pipe2', 'p2.then', 'pipe3', 'p3.then'];
   outPipelined.a70 = [
     'pipe1',
     'pipe2',

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -1577,7 +1577,7 @@ const pipelinedSendTest = async (t, delayed) => {
 };
 
 test('pipelined promise queueing', pipelinedSendTest, false);
-test.failing('pipelined promise queueing with delay', pipelinedSendTest, true);
+test('pipelined promise queueing with delay', pipelinedSendTest, true);
 
 test('xs-worker default manager type', async t => {
   const endowments = makeKernelEndowments();

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -1433,17 +1433,11 @@ const pipelinedSendTest = async (t, delayed) => {
     },
   ]);
 
-  // move foo send from acceptance to run-queue
+  // move foo send from acceptance to run-queue/p0-queue
   await kernel.step();
-  // move bar send from acceptance to run-queue
+  // move bar send from acceptance to p1-queue
   await kernel.step();
-  // move urgh send from acceptance to run-queue
-  await kernel.step();
-  // deliver/move foo send from run-queue to vatB/p0-queue
-  await kernel.step();
-  // deliver/move bar send from run-queue to vatB/p1-queue
-  await kernel.step();
-  // deliver/move urgh send from run-queue to vatB/p2-queue
+  // move urgh send from acceptance to p2-queue
   await kernel.step();
 
   if (delayed) {
@@ -1509,17 +1503,19 @@ const pipelinedSendTest = async (t, delayed) => {
 
     // move foo send from acceptance to run-queue
     await kernel.step();
-    // deliver foo send from run-queue to vatB
-    await kernel.step();
-    // move bar send from acceptance to run-queue
-    await kernel.step();
-    // deliver bar send from run-queue to vatB
-    await kernel.step();
-    // move urgh send from acceptance to run-queue
-    await kernel.step();
-    // deliver urgh send from run-queue to vatB
-    await kernel.step();
   }
+  // deliver foo send from run-queue to vatB
+  // move bar send from p1-queue to acceptance queue
+  await kernel.step();
+  // move bar send from acceptance to run-queue
+  await kernel.step();
+  // deliver bar send from run-queue to vatB
+  // move urgh send from p2-queue to acceptance queue
+  await kernel.step();
+  // move urgh send from acceptance to run-queue
+  await kernel.step();
+  // deliver urgh send from run-queue to vatB
+  await kernel.step();
 
   const p1ForB = kernel.addImport(vatB, p1ForKernel);
   const p2ForB = kernel.addImport(vatB, p2ForKernel);

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -493,11 +493,13 @@ test('kernelKeeper promises', async t => {
   const expectedAcceptanceQueue = [];
   const m1 = { method: 'm1', args: { body: '', slots: [] } };
   k.addMessageToPromiseQueue(p1, m1);
+  k.incrementRefCount(p1);
   t.deepEqual(k.getKernelPromise(p1).refCount, 1);
   expectedAcceptanceQueue.push({ type: 'send', target: 'kp40', msg: m1 });
 
   const m2 = { method: 'm2', args: { body: '', slots: [] } };
   k.addMessageToPromiseQueue(p1, m2);
+  k.incrementRefCount(p1);
   t.deepEqual(k.getKernelPromise(p1).queue, [m1, m2]);
   t.deepEqual(k.getKernelPromise(p1).refCount, 2);
   expectedAcceptanceQueue.push({ type: 'send', target: 'kp40', msg: m2 });

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -47,8 +47,8 @@ async function doTerminate(t, mode, reference, extraMessage = []) {
     ...extraMessage,
     'foreverP.catch Error: vat terminated',
     'query3P.catch Error: vat terminated',
-    'foo4P.catch Error: vat terminated',
     'afterForeverP.catch Error: vat terminated',
+    'foo4P.catch Error: vat terminated',
     reference,
     'done',
   ]);

--- a/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
@@ -95,10 +95,10 @@ const expectedcontractGovernorStartLog = [
   '&& running a task scheduled for 3. &&',
   'vote outcome: {"changes":{"MalleableNumber":"[299792458n]"}}',
   'updated to {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'Electorate,MalleableNumber changed in a vote.',
   'current value of MalleableNumber is 299792458',
-  'MalleableNumber changed in a vote.',
+  'Electorate,MalleableNumber changed in a vote.',
   'Number after: 299792458',
+  'MalleableNumber changed in a vote.',
 ];
 
 test.serial('contract governance', async t => {
@@ -131,8 +131,8 @@ const expectedChangeElectorateLog = [
   '&& running a task scheduled for 4. &&',
   'vote outcome: {"changes":{"MalleableNumber":"[299792458n]"}}',
   'updated to {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'Electorate,MalleableNumber changed in a vote.',
   'current value of MalleableNumber is 299792458',
+  'Electorate,MalleableNumber changed in a vote.',
   'Electorate changed in a vote.',
   'MalleableNumber changed in a vote.',
 ];
@@ -155,10 +155,18 @@ const expectedBrokenUpdateLog = [
   '&& running a task scheduled for 2. &&',
   'vote outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
   'Validation complete: true',
-  'vote rejected outcome: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
-  'update failed: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
-  'Electorate,MalleableNumber changed in a vote.',
+  // [`prepareToSetInvitation`](https://github.com/Agoric/agoric-sdk/blob/c6570b015fd23c411e48981bec309b32eedd3a28/packages/governance/src/contractGovernance/paramManager.js#L199-L212)
+  // does a `Promise.all` on 2 calls using the `invite` promise. If that promise
+  // is rejected, this will result in a rejection race between the 2 paths. The
+  // following 2 entries may come back as the commented out lines if the kernel
+  // changes the order in which messages are processed.
+  // TODO: allow either message
+  // 'vote rejected outcome: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
+  // 'update failed: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
+  'vote rejected outcome: Error: A Zoe invitation is required, not (an object)',
+  'update failed: Error: A Zoe invitation is required, not (an object)',
   'current value of MalleableNumber is 602214090000000000000000',
+  'Electorate,MalleableNumber changed in a vote.',
 ];
 
 test.serial('brokenUpdateStart', async t => {
@@ -181,8 +189,8 @@ const changeTwoParamsLog = [
   'Validation complete: true',
   'updated to ({"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}})',
   'successful outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}} ',
-  'Electorate,MalleableNumber changed in a vote.',
   'current value of MalleableNumber is 42',
+  'Electorate,MalleableNumber changed in a vote.',
   'Electorate,MalleableNumber changed in a vote.',
 ];
 


### PR DESCRIPTION
closes: #4542
refs: #4318 #5024

Best reviewed commit-by-commit.

## Description

This PR updates the processing of message sends onto promises so that:
- The target is checked when plucking the send from the acceptance queue and either queued onto the run-queue or to the corresponding promise queue if the promise is neither resolved nor pipelined
- Sends queued onto promises are moved to the acceptance-queue when their decider changes to a pipelining vat, or when they are resolved (without a target update)

Ultimately the sends should not transit back through the acceptance queue, and should have their target updated right away to release the resolved promise. This will be done in the follow-up PR addressing #5024 (along with immediate queueing of notifies on the run-queue).

### Security Considerations

While this change may update the order of message sends between objects and promises, this is valid per our ordering guarantees. In consideration, this is a small ordering update compared to the relaxed ordering we want to introduce.

### Documentation Considerations

IOU an update to docs once the queue processing churn has settled

### Testing Considerations

Added a test for a preexisting limitation of message sends onto pipelined promises. Update existing tests to account for new message order.
