### PR TITLE
ci: improve test parallelism

### DIFF
--- a/.github/actions/build-node/action.yml
+++ b/.github/actions/build-node/action.yml
@@ -5,6 +5,11 @@ inputs:
   node-version:
     description: 'The version of Node.js to use'
     required: true
+  cache-built:
+    description: 'Cache the result of the build'
+    type: boolean
+    required: false
+    default: true
 
 runs:
   using: composite
@@ -40,5 +45,6 @@ runs:
       run: yarn build
 
     - uses: ./.github/actions/save-node
+      if: inputs.cache-built == true
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -35,9 +35,10 @@ jobs:
         with:
           go-version: 1.17
           cache-key: trusty
-      - uses: ./.github/actions/restore-node
+      - uses: ./.github/actions/build-node
         with:
           node-version: 14.x
+          cache-built: false
 
       # Select a branch on loadgen to test against by adding text to the body of the
       # pull request. For example: #loadgen-branch: user-123-update-foo

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -3,6 +3,9 @@ name: Protobuf
 # This workflow is only run when a .proto file has been changed
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -18,20 +18,16 @@ jobs:
           submodules: 'true'
       - uses: ./.github/actions/build-node
         with:
-          node-version: ${{ matrix.node-version}}
+          node-version: ${{ matrix.node-version }}
 
   lint:
     needs: build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # note: only use one node-version
-        node-version: ['14.x']
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '14.x'
 
       - name: lint check
         run: yarn lint
@@ -44,12 +40,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        engine: ['14.x', '16.x', 'xs']
     steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
+          echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
 
       # We run separate steps for each package, to make it easier to drill down
@@ -59,43 +60,43 @@ jobs:
       # This list should include all packages, except ones that are in another
       #  category here, or that don't have a package.json.
       #- name: yarn test (everything)
-      #  run: yarn test
+      #  run: yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (access-token)
-        run: cd packages/access-token && yarn test
+        run: cd packages/access-token && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (agoric-cli)
-        run: cd packages/agoric-cli && yarn test
+        run: cd packages/agoric-cli && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (assert)
-        run: cd packages/assert && yarn test
+        run: cd packages/assert && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (wallet/api)
-        run: cd packages/wallet/api && yarn test
+        run: cd packages/wallet/api && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (deployment)
-        run: cd packages/deployment && yarn test
+        run: cd packages/deployment && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (ERTP)
-        run: cd packages/ERTP && yarn test
+        run: cd packages/ERTP && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (governance)
-        run: cd packages/governance && yarn test
+        run: cd packages/governance && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (import-manager)
-        run: cd packages/import-manager && yarn test
+        run: cd packages/import-manager && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (notifier)
-        run: cd packages/notifier && yarn test
+        run: cd packages/notifier && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (same-structure)
-        run: cd packages/same-structure && yarn test
+        run: cd packages/same-structure && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (sharing-service)
-        run: cd packages/sharing-service && yarn test
+        run: cd packages/sharing-service && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (sparse-ints)
-        run: cd packages/sparse-ints && yarn test
+        run: cd packages/sparse-ints && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (spawner)
-        run: cd packages/spawner && yarn test
+        run: cd packages/spawner && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (stat-logger)
-        run: cd packages/stat-logger && yarn test
+        run: cd packages/stat-logger && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (store)
-        run: cd packages/store && yarn test
+        run: cd packages/store && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (swing-store)
-        run: cd packages/swing-store && yarn test
+        run: cd packages/swing-store && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (web-components)
-        run: cd packages/web-components && yarn test
+        run: cd packages/web-components && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (wallet-connection)
-        run: cd packages/wallet-connection && yarn test
+        run: cd packages/wallet-connection && yarn ${{ steps.vars.outputs.test }}
 
   test-quick2:
     # BEGIN-TEST-BOILERPLATE
@@ -103,37 +104,42 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        engine: ['14.x', '16.x', 'xs']
     steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
+          echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
       - name: yarn test (cosmos)
-        run: cd golang/cosmos && yarn test
+        run: cd golang/cosmos && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (run-protocol)
-        run: cd packages/run-protocol && yarn test
+        run: cd packages/run-protocol && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (pegasus)
-        run: cd packages/pegasus && yarn test
+        run: cd packages/pegasus && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (vats)
-        run: cd packages/vats && yarn test
+        run: cd packages/vats && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (swingset-runner)
-        run: cd packages/swingset-runner && yarn test
+        run: cd packages/swingset-runner && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (telemetry)
-        run: cd packages/telemetry && yarn test
+        run: cd packages/telemetry && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (deploy-script-support)
-        run: cd packages/deploy-script-support && yarn test
+        run: cd packages/deploy-script-support && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (ui-components)
-        run: cd packages/ui-components && yarn test
+        run: cd packages/ui-components && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (wallet/ui)
-        run: cd packages/wallet/ui && yarn test
+        run: cd packages/wallet/ui && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (wallet)
-        run: cd packages/wallet && yarn test
+        run: cd packages/wallet && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (eslint-config)
-        run: cd packages/eslint-config && yarn test
+        run: cd packages/eslint-config && yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (vat-data)
-        run: cd packages/vat-data && yarn test
+        run: cd packages/vat-data && yarn ${{ steps.vars.outputs.test }}
 
         # The meta-test!
       - name: Check for untested packages
@@ -147,16 +153,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        engine: ['14.x', '16.x', 'xs']
     steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
+          echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
       - name: yarn test (solo)
         timeout-minutes: 20
-        run: cd packages/solo && yarn test
+        run: cd packages/solo && yarn ${{ steps.vars.outputs.test }}
 
   test-cosmic-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -164,18 +175,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        engine: ['14.x', '16.x', 'xs']
     steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
+          echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
       - uses: ./.github/actions/restore-golang
         with:
           go-version: 1.17
       - name: yarn test (cosmic-swingset)
-        run: cd packages/cosmic-swingset && yarn test
+        run: cd packages/cosmic-swingset && yarn ${{ steps.vars.outputs.test }}
 
   # The test-swingset* tests are split by alphabetical test name.
   test-swingset:
@@ -184,15 +200,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        engine: ['14.x', '16.x', 'xs']
     steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
+          echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
       - name: yarn test (SwingSet)
-        run: cd packages/SwingSet && yarn test 'test/**/test-[A-Da-d]*.js'
+        run: cd packages/SwingSet && yarn ${{ steps.vars.outputs.test }} 'test/**/test-[A-Da-d]*.js'
 
   test-swingset2:
     # BEGIN-TEST-BOILERPLATE
@@ -200,19 +221,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        engine: ['14.x', '16.x', 'xs']
     steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
+          echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
       - name: yarn test (SwingSet)
-        run: cd packages/SwingSet && yarn test 'test/**/test-[E-Ie-i]*.js'
+        run: cd packages/SwingSet && yarn ${{ steps.vars.outputs.test }} 'test/**/test-[E-Ie-i]*.js'
       - name: yarn test (xsnap)
-        run: cd packages/xsnap && yarn test
+        run: cd packages/xsnap && yarn ${{ steps.vars.outputs.test }}
       # explicitly test the XS worker, for visibility
       - name: yarn test (SwingSet XS Worker)
+        if: matrix.engine != 'xs'
         run: cd packages/SwingSet && yarn test:xs-worker
 
   test-swingset3:
@@ -221,15 +248,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        engine: ['14.x', '16.x', 'xs']
     steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
+          echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
       - name: yarn test (SwingSet)
-        run: cd packages/SwingSet && yarn test 'test/**/test-[J-Rj-r]*.js'
+        run: cd packages/SwingSet && yarn ${{ steps.vars.outputs.test }} 'test/**/test-[J-Rj-r]*.js'
 
   test-swingset4:
     # BEGIN-TEST-BOILERPLATE
@@ -237,16 +269,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        engine: ['14.x', '16.x', 'xs']
     steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
+          echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
 
       - name: yarn test (SwingSet)
-        run: cd packages/SwingSet && yarn test 'test/**/test-[S-Zs-z0-9]*.js'
+        run: cd packages/SwingSet && yarn ${{ steps.vars.outputs.test }} 'test/**/test-[S-Zs-z0-9]*.js'
 
   test-zoe-unit:
     # BEGIN-TEST-BOILERPLATE
@@ -254,16 +291,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        engine: ['14.x', '16.x', 'xs']
     steps:
+      - name: set vars
+        id: vars
+        # END-TEST-BOILERPLATE
+        run: |
+          echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
+          echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs-unit' || 'test:unit' }}
+        # BEGIN-TEST-BOILERPLATE
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
       - name: yarn test (zoe)
         timeout-minutes: 30
-        run: cd packages/zoe && yarn test:unit
+        run: cd packages/zoe && yarn ${{ steps.vars.outputs.test }}
 
   test-zoe-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -271,86 +315,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        engine: ['14.x', '16.x', 'xs']
     steps:
+      - name: set vars
+        id: vars
+        # END-TEST-BOILERPLATE
+        run: |
+          echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
+          echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs-worker' || 'test:swingset' }}
+        # BEGIN-TEST-BOILERPLATE
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
       - name: yarn test (zoe)
         timeout-minutes: 30
-        run: cd packages/zoe && yarn test:swingset
-
-  # The test-xs* tests are split by alphabetical test name.
-  test-xs:
-    # BEGIN-TEST-BOILERPLATE
-    needs: build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # note: only use one node-version, maybe
-        node-version: ['14.x']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/restore-node
-        with:
-          node-version: ${{ matrix.node-version }}
-      # END-TEST-BOILERPLATE
-      - name: yarn test (xs)
-        timeout-minutes: 30
-        run: yarn test:xs 'test/**/test-[A-Da-d]*.js'
-
-  test-xs2:
-    # BEGIN-TEST-BOILERPLATE
-    needs: build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # note: only use one node-version, maybe
-        node-version: ['14.x']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/restore-node
-        with:
-          node-version: ${{ matrix.node-version }}
-      # END-TEST-BOILERPLATE
-      - name: yarn test (xs)
-        timeout-minutes: 30
-        run: yarn test:xs 'test/**/test-[E-Ie-i]*.js'
-
-  test-xs3:
-    # BEGIN-TEST-BOILERPLATE
-    needs: build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # note: only use one node-version, maybe
-        node-version: ['14.x']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/restore-node
-        with:
-          node-version: ${{ matrix.node-version }}
-      # END-TEST-BOILERPLATE
-      - name: yarn test (xs)
-        timeout-minutes: 30
-        run: yarn test:xs 'test/**/test-[J-Rj-r]*.js'
-
-  test-xs4:
-    # BEGIN-TEST-BOILERPLATE
-    needs: build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # note: only use one node-version, maybe
-        node-version: ['14.x']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/restore-node
-        with:
-          node-version: ${{ matrix.node-version }}
-      # END-TEST-BOILERPLATE
-      - name: yarn test (xs)
-        timeout-minutes: 30
-        run: yarn test:xs 'test/**/test-[S-Zs-z0-9]*.js'
+        run: cd packages/zoe && yarn ${{ steps.vars.outputs.test }}

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -4,6 +4,9 @@ name: Test all Packages
 
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # set ESM_DISABLE_CACHE=true (will be JSON parsed)
 jobs:

--- a/.github/workflows/test-dapp-card-store.yml
+++ b/.github/workflows/test-dapp-card-store.yml
@@ -2,6 +2,9 @@ name: Test Dapp Card Store
 
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-dapp:

--- a/.github/workflows/test-dapp-fungible-faucet.yml
+++ b/.github/workflows/test-dapp-fungible-faucet.yml
@@ -2,6 +2,9 @@ name: Test Dapp Fungible Faucet
 
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-dapp:

--- a/.github/workflows/test-dapp-oracle.yml
+++ b/.github/workflows/test-dapp-oracle.yml
@@ -2,6 +2,9 @@ name: Test Dapp Oracle
 
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-dapp:

--- a/.github/workflows/test-dapp-otc.yml
+++ b/.github/workflows/test-dapp-otc.yml
@@ -2,6 +2,9 @@ name: Test Dapp OTC Desk
 
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-dapp:

--- a/.github/workflows/test-dapp-pegasus.yml
+++ b/.github/workflows/test-dapp-pegasus.yml
@@ -2,6 +2,9 @@ name: Test Dapp Pegasus
 
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-dapp:

--- a/.github/workflows/test-dapp-simple-exchange.yml
+++ b/.github/workflows/test-dapp-simple-exchange.yml
@@ -2,6 +2,9 @@ name: Test Dapp Simple Exchange
 
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-dapp:

--- a/.github/workflows/test-dapp-treasury.yml
+++ b/.github/workflows/test-dapp-treasury.yml
@@ -2,6 +2,9 @@ name: Test Dapp Treasury
 
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-dapp:

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -2,6 +2,9 @@ name: Test Documentation
 
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-dapp:

--- a/.github/workflows/test-golang.yml
+++ b/.github/workflows/test-golang.yml
@@ -2,6 +2,9 @@ name: Test Golang
 
 on:
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # set ESM_DISABLE_CACHE=true (will be JSON parsed)
 jobs:

--- a/scripts/check-untested-packages.mjs
+++ b/scripts/check-untested-packages.mjs
@@ -6,17 +6,23 @@ import { execFileSync } from 'child_process';
 const parent = new URL('..', import.meta.url).pathname;
 const yarnCmd = ['yarn', '--silent', 'workspaces', 'info'];
 console.log('Getting', yarnCmd.join(' '));
-const workspacesInfo = execFileSync(yarnCmd[0], yarnCmd.slice(1), { cwd: parent, encoding: 'utf8' });
+const workspacesInfo = execFileSync(yarnCmd[0], yarnCmd.slice(1), {
+  cwd: parent,
+  encoding: 'utf8',
+});
 const workspacesInfoJson = JSON.parse(workspacesInfo);
 
-const testYaml = path.resolve(parent, '.github/workflows/test-all-packages.yml');
+const testYaml = path.resolve(
+  parent,
+  '.github/workflows/test-all-packages.yml',
+);
 console.log('Reading', testYaml);
 const testYamlContent = fs.readFileSync(testYaml, 'utf-8');
 
-console.log('Searching for "cd <location> && yarn test"...')
+console.log('Searching for "cd <location> && yarn test"...');
 let status = 0;
 for (const [pkg, { location }] of Object.entries(workspacesInfoJson)) {
-  const cmd = `cd ${location} && yarn test`;
+  const cmd = `cd ${location} && yarn \${{ steps.vars.outputs.test }}`;
   if (!testYamlContent.includes(cmd)) {
     console.error(`Cannot find ${location} (${pkg})`);
     status = 1;


### PR DESCRIPTION
## Description

I've seen some of the XS tests take long times (over 20 minutes). This updates the matrix strategy of the "Test all packages" job to include `xs` as one of the strategies alongside both node versions. It also enables the `concurrency` actions option to cancel jobs that were still running on the same PR. Finally it fixes the `deployment-test` job to not reuse node_modules and built output if it was previously cached.

### Security Considerations

None

### Documentation Considerations

None

### Testing Considerations

Need to update required tests in branch protections
