### PR TITLE
Ratios for `priceAggregator`

### DIFF
--- a/packages/spawner/src/vat-spawned.js
+++ b/packages/spawner/src/vat-spawned.js
@@ -1,9 +1,10 @@
-/* global globalThis */
+/* global globalThis VatData */
 
 import { importBundle } from '@endo/import-bundle';
 import { Far } from '@endo/marshal';
 
 const endowments = {
+  VatData,
   console,
   assert,
   Base64: globalThis.Base64, // Present only on XSnap

--- a/packages/zoe/src/contractSupport/statistics.js
+++ b/packages/zoe/src/contractSupport/statistics.js
@@ -2,7 +2,7 @@
  * @template T
  * @typedef {Object} TypedMath
  * @property {(a: T, b: T) => T} add
- * @property {(a: T, b: T) => T} divide
+ * @property {(a: T, b: bigint) => T} divide
  * @property {(a: T, b: T) => boolean} isGTE
  */
 
@@ -37,5 +37,5 @@ export const calculateMedian = (samples, math) => {
   // Even length, take the mean of the two middle values.
   const secondIndex = sorted.length / 2;
   const sum = math.add(sorted[secondIndex - 1], sorted[secondIndex]);
-  return math.divide(sum, 2);
+  return math.divide(sum, 2n);
 };

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -5,17 +5,23 @@ import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makeNotifierKit } from '@agoric/notifier';
 import { makeLegacyMap } from '@agoric/store';
-import { Nat, isNat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';
 import {
   calculateMedian,
-  natSafeMath,
   makeOnewayPriceAuthorityKit,
 } from '../contractSupport/index.js';
+import {
+  makeRatio,
+  makeRatioFromAmounts,
+  parseRatio,
+  addRatios,
+  ratioGTE,
+  floorMultiplyBy,
+  ceilDivideBy,
+  multiplyRatios,
+} from '../contractSupport/ratio.js';
 
 import '../../tools/types.js';
-
-const { add, multiply, floorDivide, ceilDivide, isGTE } = natSafeMath;
 
 /**
  * This contract aggregates price values from a set of oracles and provides a
@@ -26,7 +32,6 @@ const { add, multiply, floorDivide, ceilDivide, isGTE } = natSafeMath;
  * POLL_INTERVAL: bigint,
  * brandIn: Brand,
  * brandOut: Brand,
- * unitAmountIn: Amount,
  * }>} zcf
  * @param {object} root0
  * @param {ERef<Mint>} [root0.quoteMint]
@@ -35,15 +40,17 @@ const start = async (
   zcf,
   { quoteMint = makeIssuerKit('quote', AssetKind.SET).mint } = {},
 ) => {
-  const {
-    timer,
-    POLL_INTERVAL,
-    brandIn,
-    brandOut,
-    unitAmountIn = AmountMath.make(brandIn, 1n),
-  } = zcf.getTerms();
+  const { timer, POLL_INTERVAL, brandIn, brandOut } = zcf.getTerms();
 
-  const unitIn = AmountMath.getValue(brandIn, unitAmountIn);
+  /** @param {ERef<Brand>} brand */
+  const getDecimalP = async brand => {
+    const displayInfo = E(brand).getDisplayInfo();
+    return E.get(displayInfo).decimalPlaces;
+  };
+  const [decimalPlacesIn = 0, decimalPlacesOut = 0] = await Promise.all([
+    getDecimalP(brandIn),
+    getDecimalP(brandOut),
+  ]);
 
   const quoteIssuerRecord = await zcf.saveIssuer(
     E(quoteMint).getIssuer(),
@@ -54,8 +61,8 @@ const start = async (
     mint: quoteMint,
   };
 
-  /** @type {bigint} */
-  let lastValueOutForUnitIn;
+  /** @type {Ratio} */
+  let lastPrice;
 
   /**
    *
@@ -75,7 +82,7 @@ const start = async (
   /**
    * @typedef {Object} OracleRecord
    * @property {(timestamp: Timestamp) => Promise<void>=} querier
-   * @property {bigint} lastSample
+   * @property {Ratio} lastSample
    * @property {OracleKey} oracleKey
    */
 
@@ -112,21 +119,21 @@ const start = async (
 
   /**
    * @param {Object} param0
-   * @param {bigint} [param0.overrideValueOut]
+   * @param {Ratio} [param0.overridePrice]
    * @param {Timestamp} [param0.timestamp]
    */
-  const makeCreateQuote = ({ overrideValueOut, timestamp } = {}) =>
+  const makeCreateQuote = ({ overridePrice, timestamp } = {}) =>
     /**
      * @param {PriceQuery} priceQuery
      * @returns {ERef<PriceQuote>=}
      */
     function createQuote(priceQuery) {
-      // Sniff the current baseValueOut.
-      const valueOutForUnitIn =
-        overrideValueOut === undefined
-          ? lastValueOutForUnitIn // Use the latest value.
-          : overrideValueOut; // Override the value.
-      if (valueOutForUnitIn === undefined) {
+      // Use the current price.
+      const price =
+        overridePrice === undefined
+          ? lastPrice // Use the latest value.
+          : overridePrice; // Override the value.
+      if (price === undefined) {
         // We don't have a quote, so abort.
         return undefined;
       }
@@ -136,11 +143,7 @@ const start = async (
        * @returns {Amount} the amountOut that will be received
        */
       const calcAmountOut = amountIn => {
-        const valueIn = AmountMath.getValue(brandIn, amountIn);
-        return AmountMath.make(
-          brandOut,
-          floorDivide(multiply(valueIn, valueOutForUnitIn), unitIn),
-        );
+        return floorMultiplyBy(amountIn, price);
       };
 
       /**
@@ -148,11 +151,7 @@ const start = async (
        * @returns {Amount} the amountIn needed to give
        */
       const calcAmountIn = amountOut => {
-        const valueOut = AmountMath.getValue(brandOut, amountOut);
-        return AmountMath.make(
-          brandIn,
-          ceilDivide(multiply(valueOut, unitIn), valueOutForUnitIn),
-        );
+        return ceilDivideBy(amountOut, price);
       };
 
       // Calculate the quote.
@@ -191,29 +190,47 @@ const start = async (
     });
 
   /**
+   * @param {Ratio} r
+   * @param {bigint} n
+   */
+  const divide = (r, n) =>
+    makeRatio(
+      r.numerator.value,
+      r.numerator.brand,
+      r.denominator.value * n,
+      r.denominator.brand,
+    );
+
+  /**
    * @param {Timestamp} timestamp
    */
   const updateQuote = async timestamp => {
     const submitted = [...oracleRecords.values()].map(
-      ({ oracleKey, lastSample }) => [oracleKey, lastSample],
+      ({ oracleKey, lastSample }) =>
+        /** @type {[OracleKey, Ratio]} */ ([oracleKey, lastSample]),
     );
     const median = calculateMedian(
       submitted
         .map(([_k, v]) => v)
-        .filter(sample => isNat(sample) && sample > 0n),
-      { add, divide: floorDivide, isGTE },
+        .filter(
+          sample =>
+            sample.numerator.value > 0n && sample.denominator.value > 0n,
+        ),
+      {
+        add: addRatios,
+        divide,
+        isGTE: ratioGTE,
+      },
     );
 
     if (median === undefined) {
       return;
     }
 
-    const amountOut = AmountMath.make(brandOut, median);
-
     /** @type {PriceDescription} */
     const quote = {
-      amountIn: unitAmountIn,
-      amountOut,
+      amountIn: median.denominator,
+      amountOut: median.numerator,
       timer,
       timestamp,
     };
@@ -225,7 +242,7 @@ const start = async (
     // Fire any triggers now; we don't care if the timestamp is fully ordered,
     // only if the limit has ever been met.
     await priceAuthorityAdmin.fireTriggers(
-      makeCreateQuote({ overrideValueOut: median, timestamp }),
+      makeCreateQuote({ overridePrice: median, timestamp }),
     );
 
     if (timestamp < publishedTimestamp) {
@@ -235,8 +252,19 @@ const start = async (
 
     // Publish a new authenticated quote.
     publishedTimestamp = timestamp;
-    lastValueOutForUnitIn = median;
+    lastPrice = median;
     updater.updateState(authenticatedQuote);
+  };
+
+  const outScale = makeRatio(
+    10n ** BigInt(Math.max(decimalPlacesOut - decimalPlacesIn, 0)),
+    brandOut,
+    10n ** BigInt(Math.max(decimalPlacesIn - decimalPlacesOut, 0)),
+    brandOut,
+  );
+  const makeRatioFromData = numericData => {
+    const unscaled = parseRatio(numericData, brandOut, brandIn);
+    return multiplyRatios(unscaled, outScale);
   };
 
   /** @type {PriceAggregatorCreatorFacet} */
@@ -255,13 +283,13 @@ const start = async (
       /**
        * If custom arguments are supplied to the `zoe.offer` call, they can
        * indicate an OraclePriceSubmission notifier and a corresponding
-       * `scaleValueOut` that should be adapted as part of the priceAuthority's
+       * `shiftValueOut` that should be adapted as part of the priceAuthority's
        * reported data.
        *
        * @param {ZCFSeat} seat
        * @param {Object} param1
        * @param {Notifier<OraclePriceSubmission>} [param1.notifier] optional notifier that produces oracle price submissions
-       * @param {number} [param1.scaleValueOut] scale used to multiply the notifier price submissions
+       * @param {number} [param1.scaleValueOut]
        * @returns {Promise<OracleAdmin>}
        */
       const offerHandler = async (
@@ -274,6 +302,14 @@ const start = async (
           // No notifier to track, just let them have the direct admin.
           return admin;
         }
+
+        // Support for notifiers that don't produce ratios, but need scaling for
+        // their numeric data.
+        const priceScale = parseRatio(scaleValueOut, brandOut);
+        const makeScaledRatioFromData = numericData => {
+          const ratio = makeRatioFromData(numericData);
+          return multiplyRatios(ratio, priceScale);
+        };
 
         /**
          * Adapt the notifier to push results.
@@ -289,21 +325,24 @@ const start = async (
           // Queue the next update.
           E(oracleNotifier).getUpdateSince(updateCount).then(recurse);
 
-          // Push the current scaled result.
-          const scaleData = numericData =>
-            BigInt(Math.floor(parseInt(numericData, 10) * scaleValueOut));
-
           // See if we have associated parameters or just a raw value.
           let result;
           switch (typeof value) {
             case 'number':
             case 'bigint':
             case 'string': {
-              result = scaleData(value);
+              result = makeScaledRatioFromData(value);
               break;
             }
             default: {
-              result = { ...value, data: scaleData(value.data) };
+              if (value && value.data !== undefined) {
+                result = {
+                  ...value,
+                  data: makeScaledRatioFromData(value.data),
+                };
+              } else {
+                result = value;
+              }
             }
           }
 
@@ -342,7 +381,10 @@ const start = async (
       const oracleKey = oracleInstance || Far('fresh key', {});
 
       /** @type {OracleRecord} */
-      const record = { oracleKey, lastSample: 0n };
+      const record = {
+        oracleKey,
+        lastSample: makeRatio(0n, brandOut, 1n, brandIn),
+      };
 
       /** @type {Set<OracleRecord>} */
       let records;
@@ -355,11 +397,19 @@ const start = async (
       records.add(record);
       oracleRecords.add(record);
 
+      // Push the current price ratio.
       const pushResult = result => {
         // Sample of NaN, 0, or negative numbers get culled in the median
         // calculation.
-        const sample = Nat(parseInt(result, 10));
-        record.lastSample = sample;
+        let ratio;
+        if (result && result.numerator && result.denominator) {
+          ratio = makeRatioFromAmounts(result.numerator, result.denominator);
+          AmountMath.coerce(brandOut, ratio.numerator);
+          AmountMath.coerce(brandIn, ratio.denominator);
+        } else {
+          ratio = makeRatioFromData(result);
+        }
+        record.lastSample = ratio;
       };
 
       /** @type {OracleAdmin} */

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -579,7 +579,7 @@ const start = async (
   };
 
   /**
-   * @type {PriceAggregatorCreatorFacet & {
+   * @type {Omit<PriceAggregatorCreatorFacet, 'makeOracleInvitation'> & {
    *   getRoundData(_roundId: BigInt): Promise<any>,
    *   oracleRoundState(_oracle: OracleKey, _queriedRoundId: BigInt): Promise<any>
    * }}

--- a/packages/zoe/src/contracts/priceAggregatorTypes.js
+++ b/packages/zoe/src/contracts/priceAggregatorTypes.js
@@ -21,6 +21,7 @@
  * @typedef {Object} PriceAggregatorCreatorFacet
  * @property {PriceAggregatorCreatorFacetInitOracle} initOracle
  * @property {(oracleKey: OracleKey) => Promise<void>} deleteOracle
+ * @property {(oracleKey?: OracleKey) => Promise<Invitation>} makeOracleInvitation
  */
 
 /**

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -43,5 +43,6 @@
  */
 
 /**
+ * @template [OfferResult]
  * @typedef {Payment<'set'>} Invitation
  */

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -18,6 +18,8 @@ import {
   addRatios,
   quantize,
   multiplyBy,
+  subtractRatios,
+  parseRatio,
 } from '../../../src/contractSupport/ratio.js';
 
 /**
@@ -294,31 +296,152 @@ test('ratio bad inputs w/brand names', t => {
 });
 
 test('multiply ratios', t => {
-  const { brand } = makeIssuerKit('moe');
+  const { brand: moeBrand } = makeIssuerKit('moe');
 
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(brand, value);
+  const moe = value => AmountMath.make(moeBrand, value);
 
-  const twoFifths = makeRatioFromAmounts(moe(2n), moe(5n));
-  const fiveSixths = makeRatioFromAmounts(moe(5n), moe(6n));
+  const twoFifthsMM = makeRatioFromAmounts(moe(2n), moe(5n));
+  const fiveSixthsMM = makeRatioFromAmounts(moe(5n), moe(6n));
   t.deepEqual(
-    makeRatio(10n, brand, 30n, brand),
-    multiplyRatios(fiveSixths, twoFifths),
+    makeRatio(10n, moeBrand, 30n, moeBrand),
+    multiplyRatios(fiveSixthsMM, twoFifthsMM),
   );
+
+  const { brand: larryBrand } = makeIssuerKit('larry');
+
+  /** @param {bigint} value */
+  const larry = value => AmountMath.make(larryBrand, value);
+
+  const twoFifthsML = makeRatioFromAmounts(moe(2n), larry(5n));
+  const fiveSixthsML = makeRatioFromAmounts(moe(5n), larry(6n));
+
+  const twoFifthsLM = makeRatioFromAmounts(larry(2n), moe(5n));
+  const fiveSixthsLM = makeRatioFromAmounts(larry(5n), moe(6n));
+
+  const twoFifthsLL = makeRatioFromAmounts(larry(2n), larry(5n));
+  const fiveSixthsLL = makeRatioFromAmounts(larry(5n), larry(6n));
+
+  t.deepEqual(
+    makeRatio(10n, moeBrand, 30n, moeBrand),
+    multiplyRatios(fiveSixthsML, twoFifthsLM),
+  );
+  t.deepEqual(
+    makeRatio(10n, larryBrand, 30n, larryBrand),
+    multiplyRatios(fiveSixthsLM, twoFifthsML),
+  );
+  t.deepEqual(
+    makeRatio(10n, moeBrand, 30n, moeBrand),
+    multiplyRatios(fiveSixthsMM, twoFifthsLL),
+  );
+  t.deepEqual(
+    makeRatio(10n, larryBrand, 30n, larryBrand),
+    multiplyRatios(fiveSixthsLL, twoFifthsMM),
+  );
+
+  t.deepEqual(
+    makeRatio(10n, moeBrand, 30n, larryBrand),
+    multiplyRatios(fiveSixthsML, twoFifthsMM),
+  );
+  t.deepEqual(
+    makeRatio(10n, moeBrand, 30n, larryBrand),
+    multiplyRatios(fiveSixthsML, twoFifthsLL),
+  );
+  t.deepEqual(
+    makeRatio(10n, larryBrand, 30n, moeBrand),
+    multiplyRatios(fiveSixthsLM, twoFifthsLL),
+  );
+  t.deepEqual(
+    makeRatio(10n, larryBrand, 30n, moeBrand),
+    multiplyRatios(fiveSixthsLM, twoFifthsMM),
+  );
+
+  t.throws(() => multiplyRatios(fiveSixthsML, twoFifthsML), {
+    message: /must cancel out/,
+  });
+  t.throws(() => multiplyRatios(fiveSixthsLM, twoFifthsLM), {
+    message: /must cancel out/,
+  });
 });
 
 test('add ratios', t => {
-  const { brand } = makeIssuerKit('moe');
+  const { brand: moeBrand } = makeIssuerKit('moe');
 
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(brand, value);
+  const moe = value => AmountMath.make(moeBrand, value);
 
-  const twoFifths = makeRatioFromAmounts(moe(2n), moe(5n));
-  const fiveSixths = makeRatioFromAmounts(moe(5n), moe(6n));
+  const twoFifthsMM = makeRatioFromAmounts(moe(2n), moe(5n));
+  const fiveSixthsMM = makeRatioFromAmounts(moe(5n), moe(6n));
   t.deepEqual(
-    makeRatio(37n, brand, 30n, brand),
-    addRatios(fiveSixths, twoFifths),
+    makeRatio(37n, moeBrand, 30n, moeBrand),
+    addRatios(fiveSixthsMM, twoFifthsMM),
   );
+
+  const { brand: larryBrand } = makeIssuerKit('larry');
+
+  /** @param {bigint} value */
+  const larry = value => AmountMath.make(larryBrand, value);
+
+  const twoFifthsLL = makeRatioFromAmounts(larry(2n), larry(5n));
+  const fiveSixthsLL = makeRatioFromAmounts(larry(5n), larry(6n));
+  t.deepEqual(
+    makeRatio(37n, larryBrand, 30n, larryBrand),
+    addRatios(fiveSixthsLL, twoFifthsLL),
+  );
+
+  const twoFifthsLM = makeRatioFromAmounts(larry(2n), moe(5n));
+  const fiveSixthsLM = makeRatioFromAmounts(larry(5n), moe(6n));
+  t.deepEqual(
+    makeRatio(37n, larryBrand, 30n, moeBrand),
+    addRatios(fiveSixthsLM, twoFifthsLM),
+  );
+
+  t.throws(() => addRatios(fiveSixthsMM, twoFifthsLL), {
+    message: /numerator brands must match/,
+  });
+  t.throws(() => addRatios(fiveSixthsLM, twoFifthsLL), {
+    message: /denominator brands must match/,
+  });
+});
+
+test('subtract ratios', t => {
+  const { brand: moeBrand } = makeIssuerKit('moe');
+
+  /** @param {bigint} value */
+  const moe = value => AmountMath.make(moeBrand, value);
+
+  const twoFifthsMM = makeRatioFromAmounts(moe(2n), moe(5n));
+  const fiveSixthsMM = makeRatioFromAmounts(moe(5n), moe(6n));
+  t.deepEqual(
+    makeRatio(13n, moeBrand, 30n, moeBrand),
+    subtractRatios(fiveSixthsMM, twoFifthsMM),
+  );
+
+  const { brand: larryBrand } = makeIssuerKit('larry');
+
+  /** @param {bigint} value */
+  const larry = value => AmountMath.make(larryBrand, value);
+
+  const twoFifthsLL = makeRatioFromAmounts(larry(2n), larry(5n));
+  const fiveSixthsLL = makeRatioFromAmounts(larry(5n), larry(6n));
+  t.deepEqual(
+    makeRatio(13n, larryBrand, 30n, larryBrand),
+    subtractRatios(fiveSixthsLL, twoFifthsLL),
+  );
+
+  const twoFifthsLM = makeRatioFromAmounts(larry(2n), moe(5n));
+  const fiveSixthsLM = makeRatioFromAmounts(larry(5n), moe(6n));
+  t.deepEqual(
+    makeRatio(13n, larryBrand, 30n, moeBrand),
+    subtractRatios(fiveSixthsLM, twoFifthsLM),
+  );
+
+  t.throws(() => subtractRatios(fiveSixthsMM, twoFifthsLL), {
+    message: /numerator brands must match/,
+  });
+  t.throws(() => subtractRatios(fiveSixthsLM, twoFifthsLL), {
+    message: /denominator brands must match/,
+  });
 });
 
 test('ratio - rounding', t => {
@@ -395,4 +518,46 @@ test('ratio - quantize', t => {
       `${numBefore}/${denBefore} quantized to ${denAfter} should be ${numAfter}/${denAfter}`,
     );
   }
+});
+
+test('ratio - parse', t => {
+  const { brand: moeBrand } = makeIssuerKit('moe');
+  const { brand: larryBrand } = makeIssuerKit('larry');
+
+  t.deepEqual(
+    parseRatio(1024.93803, moeBrand),
+    makeRatio(102493803n, moeBrand, 10n ** 5n, moeBrand),
+  );
+  t.deepEqual(
+    parseRatio(1024.93803, moeBrand, larryBrand),
+    makeRatio(102493803n, moeBrand, 10n ** 5n, larryBrand),
+  );
+  t.deepEqual(parseRatio('123400', moeBrand), makeRatio(123400n, moeBrand, 1n));
+
+  t.deepEqual(
+    parseRatio('123.456', larryBrand),
+    makeRatio(123456n, larryBrand, 10n ** 3n),
+  );
+
+  t.deepEqual(
+    parseRatio(1, moeBrand, larryBrand),
+    makeRatio(1n, moeBrand, 1n, larryBrand),
+  );
+
+  t.deepEqual(
+    parseRatio('0.000039', moeBrand),
+    makeRatio(39n, moeBrand, 10n ** 6n),
+  );
+
+  t.deepEqual(
+    parseRatio('0.000039100', larryBrand, moeBrand),
+    makeRatio(39100n, larryBrand, 10n ** 9n, moeBrand),
+  );
+
+  t.throws(() => parseRatio(-1024.93803, moeBrand), {
+    message: /Invalid numeric data/,
+  });
+  t.throws(() => parseRatio('abc', moeBrand), {
+    message: /Invalid numeric data/,
+  });
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -528,6 +528,7 @@ test('ratio - parse', t => {
     parseRatio(1024.93803, moeBrand),
     makeRatio(102493803n, moeBrand, 10n ** 5n, moeBrand),
   );
+
   t.deepEqual(
     parseRatio(1024.93803, moeBrand, larryBrand),
     makeRatio(102493803n, moeBrand, 10n ** 5n, larryBrand),
@@ -560,4 +561,19 @@ test('ratio - parse', t => {
   t.throws(() => parseRatio('abc', moeBrand), {
     message: /Invalid numeric data/,
   });
+
+  // It's floats that have roundoff errors, but we properly parse and propagate
+  // those errors.
+  t.deepEqual(
+    parseRatio(0.1 + 0.2, moeBrand),
+    makeRatio(30000000000000004n, moeBrand, 100000000000000000n, moeBrand),
+  );
+  t.deepEqual(
+    parseRatio(Number.MAX_SAFE_INTEGER + 1, moeBrand),
+    makeRatio(9007199254740992n, moeBrand, 1n, moeBrand),
+  );
+  t.deepEqual(
+    parseRatio(Number.MAX_SAFE_INTEGER + 2, moeBrand),
+    makeRatio(9007199254740992n, moeBrand, 1n, moeBrand),
+  );
 });

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -21,7 +21,6 @@ import '../../../exported.js';
 import '../../../src/contracts/exported.js';
 import {
   addRatios,
-  floorDivideBy,
   makeRatio,
   multiplyBy,
   multiplyRatios,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

More improvements for Agoric/dapp-oracle#33.  This can be reviewed commit-by-commit

- accept Ratios as input to the priceAggregator and use them internally
- more tolerant (and accurate) brand rules for several Ratio operations, based on working out the algebra
- `parseRatio` and `subtractRatios` to fill some API gaps
- propagate VatData into solo-spawned vats, so that ERTP doesn't crash due to its absence

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
Should make the priceAggregator more reviewable and easy to verify that it calculates prices correctly.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Tested end-to-end against dapp-oracle.
