### PR TITLE
TypeScript 4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lerna": "^3.22.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",
-    "typescript": "~4.6.3"
+    "typescript": "~4.7.2"
   },
   "engines": {
     "node": ">=14.15.0"

--- a/packages/run-protocol/test/attestation/test-attestation.js
+++ b/packages/run-protocol/test/attestation/test-attestation.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
@@ -75,6 +74,7 @@ const makeContext = async t => {
 
 test.before(async t => {
   const properties = await makeContext(t);
+  // @ts-expect-error t.context is unknown so could be null
   Object.assign(t.context, properties);
 });
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "react": "^16.14.0",
     "react-dom": "^16.8.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.7.2"
   },
   "ava": {
     "files": [

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -75,7 +75,7 @@ export const pickFacet =
  * Assign the values of all of the enumerable own properties from the source
  * object to their keys in the target object.
  *
- * @template T
+ * @template {{}} T
  * @param {T} target
  * @param {Partial<T>} source
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -16770,10 +16770,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.2, typescript@~4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@^4.3.2, typescript@~4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
+  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
_no tickets_

## Description

[Release notes for TypeScript 4.7](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-rc//) describe many improvements useful to this codebase.

For example a bug fix that found this problem 03446a1c4ae3d22fb10b063510e179662462d043

One that may prove useful:
> a new preview editor command for [Go to Source Definition](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-rc/#go-to-source-definition). This can be helpful in cases where an ordinary Go to Definition comand would take you to a declaration file instead of the actual JavaScript or TypeScript source. [We’re still looking for feedback on this feature](https://github.com/microsoft/TypeScript/issues/49003)!

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

- [x] wait for TS 4.7 release and verify CI