### PR TITLE
bump eslint-plugin-jsdoc

### DIFF
--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -78,7 +78,7 @@
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {Object} DisplayInfo
+ * @typedef {object} DisplayInfo
  * @property {number=} decimalPlaces Tells the display software how
  *   many decimal places to move the decimal over to the left, or in
  *   other words, which position corresponds to whole numbers. We
@@ -96,7 +96,7 @@
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {Object} Brand
+ * @typedef {object} Brand
  * The brand identifies the kind of issuer, and has a function to get the
  * alleged name for the kind of asset described. The alleged name (such
  * as 'BTC' or 'moola') is provided by the maker of the issuer and should
@@ -219,7 +219,7 @@
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {Object} Issuer
+ * @typedef {object} Issuer
  *
  * The issuer cannot mint a new amount, but it can create empty purses
  * and payments. The issuer can also transform payments (splitting
@@ -253,7 +253,7 @@
  */
 
 /**
- * @typedef {Object} AdditionalDisplayInfo
+ * @typedef {object} AdditionalDisplayInfo
  *
  * @property {number=} decimalPlaces Tells the display software how
  *   many decimal places to move the decimal over to the left, or in
@@ -287,7 +287,7 @@
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {Object} Mint
+ * @typedef {object} Mint
  * Holding a Mint carries the right to issue new digital assets. These
  * assets all have the same kind, which is called a Brand.
  *
@@ -303,7 +303,7 @@
  */
 
 /**
- * @typedef {Object} DepositFacet
+ * @typedef {object} DepositFacet
  * @property {DepositFacetReceive} receive
  * Deposit all the contents of payment into the purse that made this facet,
  * returning the amount. If the optional argument `optAmount` does not equal the
@@ -320,7 +320,7 @@
  */
 
 /**
- * @typedef {Object} Purse
+ * @typedef {object} Purse
  * Purses hold amount of digital assets of the same brand, but unlike Payments,
  * they are not meant to be sent to others. To transfer digital assets, a
  * Payment should be withdrawn from a Purse. The amount of digital
@@ -368,7 +368,7 @@
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {Object} Payment
+ * @typedef {object} Payment
  * Payments hold amount of digital assets of the same brand in transit. Payments
  * can be deposited in purses, split into multiple payments, combined, and
  * claimed (getting an exclusive payment). Payments are linear, meaning
@@ -393,7 +393,7 @@
 
 /**
  * @template {AssetKind} K
- * @typedef {Object} MathHelpers<K>
+ * @typedef {object} MathHelpers<K>
  * All of the difference in how digital asset amount are manipulated can be
  * reduced to the behavior of the math on values. We extract this
  * custom logic into mathHelpers. MathHelpers are about value

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -31,7 +31,7 @@ const allValues = async obj =>
 /**
  * Build the source bundles for the kernel and xsnap vat worker.
  *
- * @param {Object} [options]
+ * @param {object} [options]
  * @param {ModuleFormat} [options.bundleFormat]
  */
 export async function buildKernelBundles(options = {}) {
@@ -84,7 +84,7 @@ function byName(a, b) {
  * 'bootstrap.js'.
  *
  * @param {string} basedir  The directory to scan
- * @param {Object} [options]
+ * @param {object} [options]
  * @param {boolean} [options.includeDevDependencies] whether to include devDependencies
  * @param {ModuleFormat} [options.bundleFormat] the bundle format to use
  * @returns {SwingSetConfig} a swingset config object: {

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -48,15 +48,15 @@ function copyState(schedState) {
 }
 
 /**
- * @typedef {Object} Event
+ * @typedef {object} Event
  * @property {bigint} time
  * @property {Array<IndexedHandler>} handlers
  *
- * @typedef {Object} IndexedHandler
+ * @typedef {object} IndexedHandler
  * @property {number} [index]
  * @property {Waker} handler
  *
- * @typedef {Object} Waker
+ * @typedef {object} Waker
  * @property {(now: bigint) => void} wake
  */
 

--- a/packages/SwingSet/src/kernel/kernelQueue.js
+++ b/packages/SwingSet/src/kernel/kernelQueue.js
@@ -5,7 +5,7 @@ import { insistMessage } from '../lib/message.js';
 import { insistVatID } from '../lib/id.js';
 
 /**
- * @param {Object} tools
+ * @param {object} tools
  * @param {KernelKeeper} tools.kernelKeeper  Kernel keeper managing persistent kernel state
  * @param {(problem: unknown, err?: Error) => void } [tools.panic]
  */

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -235,7 +235,7 @@ export function makeVatKeeper(
    * allocate, we insist that the reachable flag was already set.
    *
    * @param {string} vatSlot  The vat slot of interest
-   * @param {Object} [options]
+   * @param {object} [options]
    * @param {boolean} [options.setReachable] set the 'reachable' flag on vat exports
    * @param {boolean} [options.required] refuse to allocate a missing entry
    * @param {boolean} [options.requireNew] require that the entry be newly allocated
@@ -468,7 +468,7 @@ export function makeVatKeeper(
   /**
    * Append an entry to the vat's transcript.
    *
-   * @param {Object} entry  The transcript entry to append.
+   * @param {object} entry  The transcript entry to append.
    */
   function addToTranscript(entry) {
     const oldPos = JSON.parse(getRequired(`${vatID}.t.endPosition`));

--- a/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
+++ b/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
@@ -128,7 +128,7 @@ export function makeVatLoader(stuff) {
    *
    * @param { Translators } translators
    *
-   * @param {Object} options  an options bag. These options are currently understood:
+   * @param {object} options  an options bag. These options are currently understood:
    *
    * @param {ManagerType} options.managerType
    *

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -20,12 +20,12 @@ const unweakable = new WeakSet();
  *
  * @param {number} size  Maximum number of entries to keep in the cache before
  *    starting to throw them away.
- * @param {(baseRef: string) => Object} fetch  Function to retrieve an
+ * @param {(baseRef: string) => object} fetch  Function to retrieve an
  *    object's raw state from the store by its baseRef
- * @param {(baseRef: string, rawState: Object) => void} store  Function to
+ * @param {(baseRef: string, rawState: object) => void} store  Function to
  *   store raw object state by its baseRef
  *
- * @returns {Object}  An LRU cache of (up to) the given size
+ * @returns {object}  An LRU cache of (up to) the given size
  *
  * This cache is part of the virtual object manager and is not intended to be
  * used independently; it is exported only for the benefit of test code.
@@ -140,7 +140,7 @@ export function makeCache(size, fetch, store) {
  *   of virtual references.
  * @param {() => number} allocateExportID  Function to allocate the next object
  *   export ID for the enclosing vat.
- * @param { (val: Object) => string} getSlotForVal  A function that returns the
+ * @param {(val: object) => string} getSlotForVal  A function that returns the
  *   object ID (vref) for a given object, if any.  their corresponding export
  *   IDs
  * @param {*} registerValue  Function to register a new slot+value in liveSlot's
@@ -150,7 +150,7 @@ export function makeCache(size, fetch, store) {
  * @param {number} cacheSize  How many virtual objects this manager should cache
  *   in memory.
  *
- * @returns {Object} a new virtual object manager.
+ * @returns {object} a new virtual object manager.
  *
  * The virtual object manager allows the creation of persistent objects that do
  * not need to occupy memory when they are not in use.  It provides five

--- a/packages/SwingSet/src/liveslots/virtualReferences.js
+++ b/packages/SwingSet/src/liveslots/virtualReferences.js
@@ -7,10 +7,10 @@ import { parseVatSlot } from '../lib/parseVatSlots.js';
 
 /**
  * @param {*} syscall  Vat's syscall object, used to access the vatstore operations.
- * @param { (val: Object) => string} getSlotForVal  A function that returns the
+ * @param {(val: object) => string} getSlotForVal  A function that returns the
  *   object ID (vref) for a given object, if any.  their corresponding export
  *   IDs
- * @param { (slot: string) => Object} requiredValForSlot  A function that
+ * @param {(slot: string) => object} requiredValForSlot  A function that
  *   converts an object ID (vref) to an object.
  * @param {*} FinalizationRegistry  Powerful JavaScript intrinsic normally denied
  *   by SES
@@ -209,7 +209,7 @@ export function makeVirtualReferenceManager(
    * Register information describing a persistent object kind.
    *
    * @param {string} kindID  The kind of persistent object being handle
-   * @param {(string, boolean) => Object} reanimator  Reanimator function for the given kind.
+   * @param {(string, boolean) => object} reanimator  Reanimator function for the given kind.
    * @param {(string) => boolean} deleter  Deleter function for the given kind.
    * @param {boolean} durable  Flag indicating if instances survive vat termination
    */
@@ -274,7 +274,7 @@ export function makeVirtualReferenceManager(
    *
    * @param {string} baseRef  The baseRef of the object being reanimated
    *
-   * @returns {Object}  A representative of the object identified by `baseRef`
+   * @returns {object}  A representative of the object identified by `baseRef`
    */
   function reanimate(baseRef) {
     const { id } = parseVatSlot(baseRef);
@@ -313,7 +313,7 @@ export function makeVirtualReferenceManager(
    * offline data later, we must ensure the Remotable remains alive. This Map
    * keeps a strong reference to the Remotable along with its (virtual) refcount.
    */
-  /** @type {Map<Object, number>} Remotable->refcount */
+  /** @type {Map<object, number>} Remotable->refcount */
   const remotableRefCounts = new Map();
 
   // Note that since presence refCounts are keyed by vref, `processDeadSet` must

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -245,7 +245,7 @@ export {};
  */
 
 /**
- * @typedef {Object} SwingSetConfig a swingset config object
+ * @typedef {object} SwingSetConfig a swingset config object
  * @property {string} [bootstrap]
  * @property {boolean} [includeDevDependencies] indicates that
  * `devDependencies` of the surrounding `package.json` should be accessible to
@@ -259,7 +259,7 @@ export {};
  */
 
 /**
- * @typedef {Object} SwingSetKernelConfig the config object passed to initializeKernel
+ * @typedef {object} SwingSetKernelConfig the config object passed to initializeKernel
  * @property {string} [bootstrap]
  * @property {boolean} [includeDevDependencies] indicates that
  * `devDependencies` of the surrounding `package.json` should be accessible to
@@ -313,7 +313,7 @@ export {};
  * tests). MeterControl.isMeteringDisabled()===false does not mean metering is happening, it just
  * means that MeterControl isn't disabling it.
  *
- * @typedef {Object} MeterControl
+ * @typedef {object} MeterControl
  * @property {() => boolean} isMeteringDisabled Ask whether metering is currently disabled.
  * @property {*} assertIsMetered
  * @property {*} assertNotMetered

--- a/packages/SwingSet/src/vats/network/router.js
+++ b/packages/SwingSet/src/vats/network/router.js
@@ -10,7 +10,7 @@ import '@agoric/store/exported.js';
 import './types.js';
 
 /**
- * @typedef {Object} Router A delimited string router implementation
+ * @typedef {object} Router A delimited string router implementation
  * @property {(addr: string) => [string, Protocol][]} getRoutes Return the match and route in order of preference
  * @property {(prefix: string, route: Protocol) => void} register Add a prefix->route to the database
  * @property {(prefix: string, route: Protocol) => void} unregister Remove a prefix->route from the database
@@ -64,7 +64,7 @@ export default function makeRouter() {
   });
 }
 /**
- * @typedef {Object} RouterProtocol
+ * @typedef {object} RouterProtocol
  * @property {(prefix: string) => Promise<Port>} bind
  * @property {(paths: string[], protocolHandler: ProtocolHandler) => void} registerProtocolHandler
  * @property {(prefix: string, protocolHandler: ProtocolHandler) => void} unregisterProtocolHandler

--- a/packages/SwingSet/src/vats/network/types.js
+++ b/packages/SwingSet/src/vats/network/types.js
@@ -11,17 +11,17 @@
  */
 
 /**
- * @typedef {Object} Closable A closable object
+ * @typedef {object} Closable A closable object
  * @property {() => Promise<void>} close Terminate the object
  */
 
 /**
- * @typedef {Object} Protocol The network Protocol
+ * @typedef {object} Protocol The network Protocol
  * @property {(prefix: Endpoint) => Promise<Port>} bind Claim a port, or if ending in ENDPOINT_SEPARATOR, a fresh name
  */
 
 /**
- * @typedef {Object} Port A port that has been bound to a protocol
+ * @typedef {object} Port A port that has been bound to a protocol
  * @property {() => Endpoint} getLocalAddress Get the locally bound name of this port
  * @property {(acceptHandler: ListenHandler) => Promise<void>} addListener Begin accepting incoming connections
  * @property {(remote: Endpoint, connectionHandler?: ConnectionHandler) => Promise<Connection>} connect Make an outbound connection
@@ -30,7 +30,7 @@
  */
 
 /**
- * @typedef {Object} ListenHandler A handler for incoming connections
+ * @typedef {object} ListenHandler A handler for incoming connections
  * @property {(port: Port, l: ListenHandler) => Promise<void>} [onListen] The listener has been registered
  * @property {(port: Port, localAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<ConnectionHandler>} onAccept A new connection is incoming
  * @property {(port: Port, localAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<void>} [onReject] The connection was rejected
@@ -39,7 +39,7 @@
  */
 
 /**
- * @typedef {Object} Connection
+ * @typedef {object} Connection
  * @property {(packetBytes: Data, opts?: Record<string, any>) => Promise<Bytes>} send Send a packet on the connection
  * @property {() => Promise<void>} close Close both ends of the connection
  * @property {() => Endpoint} getLocalAddress Get the locally bound name of this connection
@@ -47,7 +47,7 @@
  */
 
 /**
- * @typedef {Object} ConnectionHandler A handler for a given Connection
+ * @typedef {object} ConnectionHandler A handler for a given Connection
  * @property {(connection: Connection, localAddr: Endpoint, remoteAddr: Endpoint, c: ConnectionHandler) => void} [onOpen] The connection has been opened
  * @property {(connection: Connection, packetBytes: Bytes, c: ConnectionHandler, opts?: Record<string, any>) => Promise<Data>} [onReceive] The connection received a packet
  * @property {(connection: Connection, reason?: CloseReason, c?: ConnectionHandler) => Promise<void>} [onClose] The connection has been closed
@@ -56,14 +56,14 @@
  */
 
 /**
- * @typedef {Object} AttemptDescription
+ * @typedef {object} AttemptDescription
  * @property {ConnectionHandler} handler
  * @property {Endpoint} [remoteAddress]
  * @property {Endpoint} [localAddress]
  */
 
 /**
- * @typedef {Object} ProtocolHandler A handler for things the protocol implementation will invoke
+ * @typedef {object} ProtocolHandler A handler for things the protocol implementation will invoke
  * @property {(protocol: ProtocolImpl, p: ProtocolHandler) => Promise<void>} onCreate This protocol is created
  * @property {(localAddr: Endpoint, p: ProtocolHandler) => Promise<string>} generatePortID Create a fresh port identifier for this protocol
  * @property {(port: Port, localAddr: Endpoint, p: ProtocolHandler) => Promise<void>} onBind A port will be bound
@@ -74,13 +74,13 @@
  * @property {(port: Port, localAddr: Endpoint, remote: Endpoint, c: ConnectionHandler, p: ProtocolHandler) => Promise<AttemptDescription>} onConnect A port initiates an outbound connection
  * @property {(port: Port, localAddr: Endpoint, p: ProtocolHandler) => Promise<void>} onRevoke The port is being completely destroyed
  *
- * @typedef {Object} InboundAttempt An inbound connection attempt
+ * @typedef {object} InboundAttempt An inbound connection attempt
  * @property {(desc: AttemptDescription) => Promise<Connection>} accept Establish the connection
  * @property {() => Endpoint} getLocalAddress Return the local address for this attempt
  * @property {() => Endpoint} getRemoteAddress Return the remote address for this attempt
  * @property {() => Promise<void>} close Abort the attempt
  *
- * @typedef {Object} ProtocolImpl Things the protocol can do for us
+ * @typedef {object} ProtocolImpl Things the protocol can do for us
  * @property {(prefix: Endpoint) => Promise<Port>} bind Claim a port, or if ending in ENDPOINT_SEPARATOR, a fresh name
  * @property {(listenAddr: Endpoint, remoteAddr: Endpoint) => Promise<InboundAttempt>} inbound Make an attempt to connect into this protocol
  * @property {(port: Port, remoteAddr: Endpoint, connectionHandler: ConnectionHandler) => Promise<Connection>} outbound Create an outbound connection

--- a/packages/SwingSet/src/vats/plugin-manager.js
+++ b/packages/SwingSet/src/vats/plugin-manager.js
@@ -38,18 +38,18 @@ const DEFAULT_WALKER = Far('walker', { walk: pluginRootP => pluginRootP });
  */
 
 /**
- * @typedef {Object} PluginManager
+ * @typedef {object} PluginManager
  * @property {LoadPlugin} load
  */
 
 /**
- * @typedef {Object} Receiver
+ * @typedef {object} Receiver
  * @property {(index: number, obj: Record<string, any>) => void} dispatch
  * @property {(index: number, epoch: number) => void} reset
  */
 
 /**
- * @typedef {Object} PluginDevice
+ * @typedef {object} PluginDevice
  * @property {(mod: string) => number} connect
  * @property {(receiver: Receiver) => void} registerReceiver
  * @property {(index: number, obj: Record<string, any>) => void} send
@@ -65,7 +65,7 @@ const DEFAULT_WALKER = Far('walker', { walk: pluginRootP => pluginRootP });
  */
 export function makePluginManager(pluginDevice, { D, ...vatPowers }) {
   /**
-   * @typedef {Object} AbortDispatch
+   * @typedef {object} AbortDispatch
    * @property {(epoch: number) => void} reset
    * @property {(obj: Record<string,any>) => void} dispatch
    */

--- a/packages/SwingSet/src/vats/timer/types.js
+++ b/packages/SwingSet/src/vats/timer/types.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @typedef {Object} TimerService
+ * @typedef {object} TimerService
  * Gives the ability to get the current time,
  * schedule a single wake() call, create a repeater that will allow scheduling
  * of events at regular intervals, or remove scheduled calls.
@@ -54,14 +54,14 @@
  */
 
 /**
- * @typedef {Object} TimerWaker
+ * @typedef {object} TimerWaker
  *
  * @property {(timestamp: Timestamp) => void} wake The timestamp passed to
  * `wake()` is the time that the call was scheduled to occur.
  */
 
 /**
- * @typedef {Object} TimerRepeater
+ * @typedef {object} TimerRepeater
  *
  * @property {(waker: ERef<TimerWaker>) => Timestamp} schedule
  * Returns the time scheduled for

--- a/packages/agoric-cli/src/helpers.js
+++ b/packages/agoric-cli/src/helpers.js
@@ -24,7 +24,7 @@ export const getSDKBinaries = ({
 /**
  * Create a promisified spawn function with the following built-in parameters.
  *
- * @param {Object} param0
+ * @param {object} param0
  * @param {Record<string, string | undefined>} [param0.env] the default environment
  * @param {*} [param0.chalk] a colorizer
  * @param {Console} [param0.log] a console object
@@ -41,7 +41,7 @@ export const makePspawn = ({
    *
    * @param {string} cmd command name to run
    * @param {Array<string>} cargs arguments to the command
-   * @param {Object} param2
+   * @param {object} param2
    * @param {string | [string, string, string]} [param2.stdio] standard IO
    * specification
    * @param {Record<string, string | undefined>} [param2.env] environment

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -19,7 +19,7 @@
  */
 
 /**
- * @typedef {Object} AssertMakeErrorOptions
+ * @typedef {object} AssertMakeErrorOptions
  * @property {string=} errorName
  */
 
@@ -164,7 +164,7 @@
  */
 
 /**
- * @typedef {Object} StringablePayload
+ * @typedef {object} StringablePayload
  * Holds the payload passed to quote so that its printed form is visible.
  * @property {() => string} toString How to print the payload
  */

--- a/packages/cosmic-swingset/src/kernel-stats.js
+++ b/packages/cosmic-swingset/src/kernel-stats.js
@@ -199,7 +199,7 @@ export function makeSlogCallbacks({ metricMeter, attributes = {} }) {
 }
 
 /**
- * @param {Object} param0
+ * @param {object} param0
  * @param {any} param0.controller
  * @param {import('@opentelemetry/sdk-metrics-base').Meter} param0.metricMeter
  * @param {Console} param0.log

--- a/packages/deploy-script-support/src/externalTypes.js
+++ b/packages/deploy-script-support/src/externalTypes.js
@@ -6,7 +6,7 @@
  */
 
 /**
- * @typedef {Object} StartInstanceResultWithDetailsNoInvitation
+ * @typedef {object} StartInstanceResultWithDetailsNoInvitation
  * @property {any} creatorFacet
  * @property {any} publicFacet
  * @property {Instance} instance
@@ -15,7 +15,7 @@
  */
 
 /**
- * @typedef {Object} OfferHelperConfig
+ * @typedef {object} OfferHelperConfig
  * @property {ERef<Invitation>=} invitation
  * @property {Partial<InvitationDetails>=} partialInvitationDetails
  * @property {Proposal} proposal

--- a/packages/deploy-script-support/src/startInstance.js
+++ b/packages/deploy-script-support/src/startInstance.js
@@ -5,7 +5,7 @@ import { E, passStyleOf } from '@endo/far';
 
 /**
  * @template T
- * @typedef {Object} PetnameManager
+ * @typedef {object} PetnameManager
  * @property {(petname: Petname, object: T) => Promise<void>} rename
  * @property {(petname: Petname) => T} get
  * @property { () => Array<[Petname, T]>} getAll
@@ -58,7 +58,7 @@ export const makeStartInstance = (
    * installation: I,
    * issuerKeywordRecord?: IssuerKeywordRecord,
    * issuerPetnameKeywordRecord?: Record<Keyword,Petname>,
-   * terms?: Object,
+   * terms?: object,
    * }} config
    */
   const startInstance = async config => {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,7 @@
     "eslint-config-jessie": "^0.0.6",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.25.3",
-    "eslint-plugin-jsdoc": "^37.9.7",
+    "eslint-plugin-jsdoc": "^39.2.9",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.28.0",

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -70,7 +70,7 @@ const makeBinaryVoteCounter = (questionSpec, threshold, instance) => {
   // choice with the new selection.
 
   /**
-   * @typedef {Object} RecordedBallot
+   * @typedef {object} RecordedBallot
    * @property {Position} chosen
    * @property {bigint} shares
    */

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -36,7 +36,7 @@ const assertElectorateMatches = (paramManager, governedParams) => {
 };
 
 /**
- * @typedef {Object} ParamManagerBuilder
+ * @typedef {object} ParamManagerBuilder
  * @property {(name: string, value: Amount) => ParamManagerBuilder} addAmount
  * @property {(name: string, value: Brand) => ParamManagerBuilder} addBrand
  * @property {(name: string, value: Installation) => ParamManagerBuilder} addInstallation

--- a/packages/governance/src/internalTypes.js
+++ b/packages/governance/src/internalTypes.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {Object} QuestionRecord
+ * @typedef {object} QuestionRecord
  * @property {ERef<VoteCounterCreatorFacet>} voteCap
  * @property {VoteCounterPublicFacet} publicFacet
  * @property {Timestamp} deadline

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -26,7 +26,7 @@
  */
 
 /**
- * @typedef {Object} SimpleIssue
+ * @typedef {object} SimpleIssue
  * @property {string} text
  */
 
@@ -70,7 +70,7 @@
  */
 
 /**
- * @typedef {Object} QuestionTerms - QuestionSpec plus the Electorate Instance and
+ * @typedef {object} QuestionTerms - QuestionSpec plus the Electorate Instance and
  *   a numerical threshold for the quorum. (The voteCounter doesn't know the
  *   size of the electorate, so the Electorate has to say what limit to enforce.)
  * @property {QuestionSpec} questionSpec
@@ -79,7 +79,7 @@
  */
 
 /**
- * @typedef {Object} TextPosition
+ * @typedef {object} TextPosition
  * @property {string} text
  */
 
@@ -91,7 +91,7 @@
  * Specification when requesting creation of a Question
  *
  * @template {Issue} [I=Issue]
- * @typedef {Object} QuestionSpec
+ * @typedef {object} QuestionSpec
  * @property {ChoiceMethod} method
  * @property {I} issue
  * @property {Position[]} positions
@@ -103,7 +103,7 @@
  */
 
 /**
- * @typedef {Object} QuestionDetailsExtraProperties
+ * @typedef {object} QuestionDetailsExtraProperties
  * @property {Instance} counterInstance - instance of the VoteCounter
  * @property {Handle<'Question'>} questionHandle
  */
@@ -114,26 +114,26 @@
  */
 
 /**
- * @typedef {Object} GovernancePair
+ * @typedef {object} GovernancePair
  * @property {Instance} governor
  * @property {Instance} governed
  */
 
 /**
- * @typedef {Object} Question
+ * @typedef {object} Question
  * @property {() => Instance} getVoteCounter
  * @property {() => QuestionDetails} getDetails
  */
 
 /**
- * @typedef {Object} CompleteUnrankedQuestion
+ * @typedef {object} CompleteUnrankedQuestion
  * @property {Handle<'Question'>} questionHandle
  * @property {Position[]} chosen - a list of equal-weight preferred positions
  */
 
 // not yet in use
 /**
- * @typedef {Object} CompleteWeightedBallot
+ * @typedef {object} CompleteWeightedBallot
  * @property {Handle<'Question'>} questionHandle
  * @property {[Position,bigint][]} weighted - list of positions with
  *   weights. VoteCounter may limit weights to a range or require uniqueness.
@@ -141,27 +141,27 @@
 
 // not yet in use
 /**
- * @typedef {Object} CompleteOrderedBallot
+ * @typedef {object} CompleteOrderedBallot
  * @property {Handle<'Question'>} questionHandle
  * @property {Position[]} ordered - ordered list of position from most preferred
  *   to least preferred
  */
 
 /**
- * @typedef {Object} PositionCount
+ * @typedef {object} PositionCount
  * @property {Position} position
  * @property {bigint} total
  */
 
 /**
- * @typedef {Object} VoteStatistics
+ * @typedef {object} VoteStatistics
  * @property {bigint} spoiled
  * @property {number} votes
  * @property {PositionCount[]} results
  */
 
 /**
- * @typedef {Object} QuorumCounter
+ * @typedef {object} QuorumCounter
  * @property {(stats: VoteStatistics) => boolean} check
  */
 
@@ -173,7 +173,7 @@
  */
 
 /**
- * @typedef {Object} VoteCounterCreatorFacet - a facet that the Electorate should
+ * @typedef {object} VoteCounterCreatorFacet - a facet that the Electorate should
  *   hold tightly. submitVote() is the core capability that allows the holder to
  *   specify the identity and choice of a voter. The voteCounter is making that
  *   available to the Electorate, which should wrap and attenuate it so each
@@ -183,7 +183,7 @@
  */
 
 /**
- * @typedef {Object} VoteCounterPublicFacet
+ * @typedef {object} VoteCounterPublicFacet
  * @property {() => boolean} isOpen
  * @property {() => Question} getQuestion
  * @property {() => Promise<Position>} getOutcome
@@ -192,13 +192,13 @@
  */
 
 /**
- * @typedef {Object} VoteCounterCloseFacet
+ * @typedef {object} VoteCounterCloseFacet
  *   TEST ONLY: Should not be allowed to escape from contracts
  * @property {() => void} closeVoting
  */
 
 /**
- * @typedef {Object} VoteCounterFacets
+ * @typedef {object} VoteCounterFacets
  * @property {VoteCounterPublicFacet} publicFacet
  * @property {VoteCounterCreatorFacet} creatorFacet
  * @property {VoteCounterCloseFacet} closeFacet
@@ -232,7 +232,7 @@
  */
 
 /**
- * @typedef {Object} ElectoratePublic
+ * @typedef {object} ElectoratePublic
  * @property {() => Subscription<QuestionDetails>} getQuestionSubscription
  * @property {GetOpenQuestions} getOpenQuestions,
  * @property {() => Instance} getInstance
@@ -245,12 +245,12 @@
  */
 
 /**
- * @typedef {Object} PoserFacet
+ * @typedef {object} PoserFacet
  * @property {AddQuestion} addQuestion
  */
 
 /**
- * @typedef {Object} ElectorateCreatorFacet
+ * @typedef {object} ElectorateCreatorFacet
  * @property {AddQuestion} addQuestion can be used directly when the creator doesn't need any
  *  reassurance. When someone needs to connect addQuestion to the Electorate
  *  instance, getPoserInvitation() lets them get addQuestion with assurance.
@@ -266,19 +266,19 @@
  */
 
 /**
- * @typedef {Object} GetVoterInvitations
+ * @typedef {object} GetVoterInvitations
  * @property {() => Invitation[]} getVoterInvitations
  */
 
 /**
- * @typedef {Object} VoterFacet - a facet that the Electorate should hold
+ * @typedef {object} VoterFacet - a facet that the Electorate should hold
  *   tightly. It allows specification of the vote's weight, so the Electorate
  *   should distribute an attenuated wrapper that doesn't make that available!
  * @property {SubmitVote} submitVote
  */
 
 /**
- * @typedef {Object} ClosingRule
+ * @typedef {object} ClosingRule
  * @property {ERef<Timer>} timer
  * @property {Timestamp} deadline
  */
@@ -290,7 +290,7 @@
  */
 
 /**
- * @typedef {Object} AddQuestionReturn
+ * @typedef {object} AddQuestionReturn
  * @property {VoteCounterPublicFacet} publicFacet
  * @property {VoteCounterCreatorFacet} creatorFacet
  * @property {Instance} instance
@@ -323,25 +323,25 @@
 
 /**
  * @template [P=StandardParamPath] path for a paramManagerRetriever
- * @typedef {Object} ParamChangeIssue
+ * @typedef {object} ParamChangeIssue
  * @property {ParamChangesSpec<P>} spec
  * @property {Instance} contract
  */
 
 /**
- * @typedef {Object} ApiInvocationIssue
+ * @typedef {object} ApiInvocationIssue
  * @property {string} apiMethodName
  * @property {unknown[]} methodArgs
  */
 
 /**
- * @typedef {Object} ParamChangePositions
+ * @typedef {object} ParamChangePositions
  * @property {ChangeParamsPosition} positive
  * @property {NoChangeParamsPosition} negative
  */
 
 /**
- * @typedef {Object} ParamChangeIssueDetails
+ * @typedef {object} ParamChangeIssueDetails
  *    details for a question that can change a contract parameter
  * @property {ChoiceMethod} method
  * @property {ParamChangeIssue<unknown>} issue
@@ -362,7 +362,7 @@
  */
 
 /**
- * @typedef {Object} ParamManagerBase The base paramManager with typed getters
+ * @typedef {object} ParamManagerBase The base paramManager with typed getters
  * @property {() => Record<Keyword, ParamRecord>} getParams
  * @property {(name: string) => Amount} getAmount
  * @property {(name: string) => Brand} getBrand
@@ -423,34 +423,34 @@
  */
 
 /**
- * @typedef {Object} ChangeParamsPosition
+ * @typedef {object} ChangeParamsPosition
  * @property {Record<string,ParamValue>} changes one or more changes to parameters
  */
 
 /**
- * @typedef {Object} InvokeApiPosition
+ * @typedef {object} InvokeApiPosition
  * @property {string} apiMethodName
  * @property {unknown[]} methodArgs
  */
 
 /**
- * @typedef {Object} DontInvokeApiPosition
+ * @typedef {object} DontInvokeApiPosition
  * @property {string} dontInvoke
  */
 
 /**
- * @typedef {Object} NoChangeParamsPosition
+ * @typedef {object} NoChangeParamsPosition
  * @property {string[]} noChange Parameters in the proposal that this position
  *   is opposed to
  */
 
 /**
- * @typedef {Object} Governor
+ * @typedef {object} Governor
  * @property {CreateQuestion} createQuestion
  */
 
 /**
- * @typedef {Object} GovernorPublic
+ * @typedef {object} GovernorPublic
  * @property {() => Promise<Instance>} getElectorate
  * @property {() => Instance} getGovernedContract
  * @property {(voteCounter: Instance) => Promise<boolean>} validateVoteCounter
@@ -459,7 +459,7 @@
  */
 
 /**
- * @typedef {Object} ParamKey identifier for a paramManager within a contract
+ * @typedef {object} ParamKey identifier for a paramManager within a contract
  * @property {string} key
  */
 
@@ -473,7 +473,7 @@
  */
 
 /**
- * @typedef {Object} ContractGovernanceVoteResult
+ * @typedef {object} ContractGovernanceVoteResult
  * @property {Instance} instance - instance of the VoteCounter
  * @property {ERef<QuestionDetails>} details
  * @property {Promise<ParamValue>} outcomeOfUpdate - A promise for the result
@@ -491,7 +491,7 @@
  */
 
 /**
- * @typedef {Object} ContractPowerfulCreatorFacet
+ * @typedef {object} ContractPowerfulCreatorFacet
  *
  *   A powerful facet that carries access to both the creatorFacet to be passed
  *   to the caller and the paramManager, which will be used exclusively by the
@@ -502,7 +502,7 @@
 
 /**
  * @template {object} PF Public facet of governed contract
- * @typedef {Object} GovernedContractFacetAccess
+ * @typedef {object} GovernedContractFacetAccess
  * @property {VoteOnParamChanges} voteOnParamChanges
  * @property {VoteOnApiInvocation} voteOnApiInvocation
  * @property {() => Promise<LimitedCreatorFacet<any>>} getCreatorFacet - creator
@@ -566,7 +566,7 @@
  */
 
 /**
- * @typedef {Object} ParamManagerRetriever
+ * @typedef {object} ParamManagerRetriever
  * @property {(paramKey?: ParamKey) => AnyParamManager} get
  */
 
@@ -590,13 +590,13 @@
  */
 
 /**
- * @typedef {Object} ParamGovernor
+ * @typedef {object} ParamGovernor
  * @property {VoteOnParamChanges} voteOnParamChanges
  * @property {CreatedQuestion} createdQuestion
  */
 
 /**
- * @typedef {Object} ApiGovernor
+ * @typedef {object} ApiGovernor
  * @property {VoteOnApiInvocation} voteOnApiInvocation
  * @property {CreatedQuestion} createdQuestion
  */
@@ -626,10 +626,10 @@
  */
 
 /**
- * @typedef {Object} GovernedContractTerms
+ * @typedef {object} GovernedContractTerms
  * @property {TimerService} timer
  * @property {IssuerKeywordRecord} issuerKeywordRecord
- * @property {Object} privateArgs
+ * @property {object} privateArgs
  */
 
 /**

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -38,7 +38,7 @@ const setUpZoeForTest = async setJig => {
   /**
    * These properties will be assigned by `setJig` in the contract.
    *
-   * @typedef {Object} TestContext
+   * @typedef {object} TestContext
    * @property {ZCF} zcf
    * @property {IssuerRecord} runIssuerRecord
    * @property {IssuerRecord} govIssuerRecord

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -20,7 +20,7 @@
 
 /**
  * @template T
- * @typedef {Object} IterationObserver<T>
+ * @typedef {object} IterationObserver<T>
  * A valid sequence of calls to the methods of an `IterationObserver`
  * represents an iteration. A valid sequence consists of any number of calls
  * to `updateState` with the successive non-final values, followed by a
@@ -42,7 +42,7 @@
 
 /**
  * @template T
- * @typedef {Object} UpdateRecord<T>
+ * @typedef {object} UpdateRecord<T>
  * @property {T} value is whatever state the service wants to publish
  * @property {UpdateCount} updateCount is a value that identifies the update
  */
@@ -62,7 +62,7 @@
 
 /**
  * @template T
- * @typedef {Object} BaseNotifier<T> an object that can be used to get the
+ * @typedef {object} BaseNotifier<T> an object that can be used to get the
  * current state or updates
  * @property {GetUpdateSince<T>} getUpdateSince return update record as of an
  * update count.
@@ -85,7 +85,7 @@
 
 /**
  * @template T
- * @typedef {Object} SharableNotifier
+ * @typedef {object} SharableNotifier
  * @property {() => ERef<NotifierInternals<T>>} getSharableNotifierInternals
  * Used to replicate the multicast values at other sites. To manually create a
  * local representative of a Notification, do
@@ -99,7 +99,7 @@
 
 /**
  * @template T
- * @typedef {Object} NotifierRecord<T> the produced notifier/updater pair
+ * @typedef {object} NotifierRecord<T> the produced notifier/updater pair
  * @property {IterationObserver<T>} updater the (closely-held) notifier producer
  * @property {Notifier<T>} notifier the (widely-held) notifier consumer
  */
@@ -114,7 +114,7 @@
 
 /**
  * @template T
- * @typedef {Object} SubscriptionInternals
+ * @typedef {object} SubscriptionInternals
  * Will be shared between machines, so it must be safe to expose. But other
  * software should avoid depending on its internal structure.
  * @property {ERef<IteratorResult<T, T>>} head internal only
@@ -131,7 +131,7 @@
 
 /**
  * @template T
- * @typedef {Object} SharableSubscription
+ * @typedef {object} SharableSubscription
  * @property {() => ERef<SubscriptionInternals<T>>} getSharableSubscriptionInternals
  * Used to replicate the multicast values at other sites. To manually create a
  * local representative of a Subscription, do
@@ -155,7 +155,7 @@
 
 /**
  * @template T
- * @typedef {Object} SubscriptionRecord<T>
+ * @typedef {object} SubscriptionRecord<T>
  * @property {IterationObserver<T>} publication
  * @property {Subscription<T>} subscription
  */

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -28,7 +28,7 @@ export const getCourierPK = (key, keyToCourierPK) => {
 /**
  * Create the [send, receive] pair.
  *
- * @typedef {Object} CourierArgs
+ * @typedef {object} CourierArgs
  * @property {ZCF} zcf
  * @property {ERef<BoardDepositFacet>} board
  * @property {ERef<NameHub>} namesByAddress

--- a/packages/pegasus/src/ics20.js
+++ b/packages/pegasus/src/ics20.js
@@ -4,7 +4,7 @@ import { Far } from '@endo/far';
 import { assert, details as X } from '@agoric/assert';
 
 /**
- * @typedef {Object} ICS20TransferPacket Packet shape defined at:
+ * @typedef {object} ICS20TransferPacket Packet shape defined at:
  * https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer#data-structures
  * @property {string} amount The extent of the amount
  * @property {Denom} denom The denomination of the amount

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -33,7 +33,7 @@ const TRANSFER_PROPOSAL_SHAPE = {
  */
 const makePegasus = (zcf, board, namesByAddress) => {
   /**
-   * @typedef {Object} LocalDenomState
+   * @typedef {object} LocalDenomState
    * @property {Address} localAddr
    * @property {Address} remoteAddr
    * @property {LegacyMap<Denom, PromiseRecord<Courier>>} receiveDenomToCourierPK
@@ -64,7 +64,7 @@ const makePegasus = (zcf, board, namesByAddress) => {
   /**
    * Create a fresh Peg associated with a descriptor.
    *
-   * @typedef {Object} PegasusDescriptor
+   * @typedef {object} PegasusDescriptor
    * @property {Brand} localBrand
    * @property {Denom} receiveDenom
    * @property {Denom} sendDenom
@@ -96,7 +96,7 @@ const makePegasus = (zcf, board, namesByAddress) => {
   };
 
   /**
-   * @param {Object} param0
+   * @param {object} param0
    * @param {ReturnType<typeof makeCourierMaker>} param0.makeCourier
    * @param {LocalDenomState} param0.localDenomState
    * @param {ERef<TransferProtocol>} param0.transferProtocol

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -8,14 +8,14 @@
  */
 
 /**
- * @typedef {Object} PacketParts
+ * @typedef {object} PacketParts
  * @property {AmountValue} value
  * @property {Denom} remoteDenom
  * @property {DepositAddress} depositAddress
  */
 
 /**
- * @typedef {Object} TransferProtocol
+ * @typedef {object} TransferProtocol
  * @property {(parts: PacketParts) => Promise<Bytes>} makeTransferPacket
  * @property {(packet: Bytes) => Promise<PacketParts>} parseTransferPacket
  * @property {(success: boolean, error?: any) => Promise<Bytes>} makeTransferPacketAck
@@ -23,7 +23,7 @@
  */
 
 /**
- * @typedef {Object} DenomTransformer
+ * @typedef {object} DenomTransformer
  * @property {(remoteDenom: Denom, localAddr: Address, remoteAddr: Address)
  *   => Promise<{ sendDenom: Denom, receiveDenom: Denom }>
  * } getDenomsForLocalPeg
@@ -33,7 +33,7 @@
  */
 
 /**
- * @typedef {Object} Peg
+ * @typedef {object} Peg
  * @property {() => string} getAllegedName get the debug name
  * @property {() => Brand} getLocalBrand get the brand associated with the peg
  * @property {() => Denom} getReceiveDenom get the remote denomination identifier we receive
@@ -41,7 +41,7 @@
  */
 
 /**
- * @typedef {Object} BoardDepositFacet a registry for depositAddresses
+ * @typedef {object} BoardDepositFacet a registry for depositAddresses
  * @property {(id: string) => any} getValue return the corresponding DepositFacet
  */
 
@@ -49,7 +49,7 @@
  * @typedef {(zcfSeat: ZCFSeat, depositAddress: DepositAddress) => Promise<void>} Sender
  * Successive transfers are not guaranteed to be processed in the order in which they were sent.
  * @typedef {(parts: PacketParts) => Promise<Bytes>} Receiver
- * @typedef {Object} Courier
+ * @typedef {object} Courier
  * @property {Sender} send
  * @property {Receiver} receive
  */
@@ -90,7 +90,7 @@
  */
 
 /**
- * @typedef {Object} PegasusConnectionActions
+ * @typedef {object} PegasusConnectionActions
  * @property {PegLocal} pegLocal
  * @property {PegRemote} pegRemote
  * @property {RejectTransfersWaitingForPegRemote} rejectTransfersWaitingForPegRemote
@@ -98,7 +98,7 @@
  */
 
 /**
- * @typedef {Object} PegasusConnection
+ * @typedef {object} PegasusConnection
  * @property {PegasusConnectionActions} [actions]
  * @property {Address} localAddr
  * @property {Address} remoteAddr
@@ -106,7 +106,7 @@
  */
 
 /**
- * @typedef {Object} PegasusConnectionKit
+ * @typedef {object} PegasusConnectionKit
  * @property {ConnectionHandler} handler
  * @property {Subscription<PegasusConnection>} subscription
  */

--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -224,7 +224,7 @@ export const setupReserve = async ({
 
 /**
  * @param { EconomyBootstrapPowers } powers
- * @param { Object } config
+ * @param {object} config
  * @param { LoanTiming } [config.loanParams]
  */
 export const startVaultFactory = async (
@@ -545,7 +545,7 @@ export const startLienBridge = async ({
 
 /**
  * @param {RunStakeBootstrapPowers } powers
- * @param {Object} config
+ * @param {object} config
  * @param {bigint} [config.debtLimit] count of RUN
  * @param {Rational} [config.mintingRatio] ratio of RUN minted to BLD
  * @param {bigint} [config.interestRateBP]

--- a/packages/run-protocol/src/psm/startPSM.js
+++ b/packages/run-protocol/src/psm/startPSM.js
@@ -8,7 +8,7 @@ const BASIS_POINTS = 10000n;
 
 /**
  * @param {EconomyBootstrapPowers & WellKnownSpaces} powers
- * @param {Object} [config]
+ * @param {object} [config]
  * @param {bigint} [config.WantStableFeeBP]
  * @param {bigint} [config.GiveStableFeeBP]
  * @param {bigint} [config.MINT_LIMIT]

--- a/packages/run-protocol/src/runStake/runStakeManager.js
+++ b/packages/run-protocol/src/runStake/runStakeManager.js
@@ -55,7 +55,7 @@ const trace = makeTracer('RSM', false);
  * @param {ZCFMint<'nat'>} debtMint
  * @param {{ debt: Brand<'nat'>, Attestation: Brand<'copyBag'>, Stake: Brand<'nat'> }} brands
  * @param {{ burnDebt: BurnDebt, getGovernedParams: () => ParamManager, mintAndReallocate: MintAndReallocate }} mintPowers
- * @param {Object} timing
+ * @param {object} timing
  * @param {ERef<TimerService>} timing.timerService
  * @param {bigint} timing.chargingPeriod
  * @param {bigint} timing.recordingPeriod

--- a/packages/run-protocol/src/runStake/types.js
+++ b/packages/run-protocol/src/runStake/types.js
@@ -17,10 +17,10 @@
  */
 
 /**
- * @typedef {Object} StakingAuthority
+ * @typedef {object} StakingAuthority
  * @property {(address: Address, previous: Amount, target: Amount<'nat'>) => Promise<void>} setLiened
  * @property {(address: Address, brand: Brand<'nat'>) => ERef<AccountState> } getAccountState
- * @typedef {Object} AccountState
+ * @typedef {object} AccountState
  * @property {Amount<'nat'>} bonded
  * @property {Amount<'nat'>} liened
  * @property {Amount<'nat'>} locked

--- a/packages/run-protocol/src/vaultFactory/params.js
+++ b/packages/run-protocol/src/vaultFactory/params.js
@@ -25,7 +25,7 @@ export const LIQUIDATION_TERMS_KEY = 'LiquidationTerms';
 /**
  * @param {Amount} electorateInvitationAmount
  * @param {Installation} liquidationInstall
- * @param {Object} liquidationTerms
+ * @param {object} liquidationTerms
  */
 const makeVaultDirectorParams = (
   electorateInvitationAmount,
@@ -76,7 +76,7 @@ export const vaultParamPattern = M.split(
  * @param {ERef<ZoeService>} zoe
  * @param {Invitation} electorateInvitation
  * @param {Installation} liquidationInstall
- * @param {Object} liquidationTerms
+ * @param {object} liquidationTerms
  */
 const makeVaultDirectorParamManager = async (
   zoe,
@@ -102,7 +102,7 @@ const makeVaultDirectorParamManager = async (
  * @param {Amount} invitationAmount
  * @param {VaultManagerParamValues} vaultManagerParams
  * @param {XYKAMMPublicFacet} ammPublicFacet
- * @param {Object} liquidationTerms
+ * @param {object} liquidationTerms
  * @param {bigint=} bootstrapPaymentValue
  */
 const makeGovernedTerms = (

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -7,13 +7,13 @@
 /** @typedef {import('./vaultManager').CollateralManager} CollateralManager */
 
 /**
- * @typedef  {Object} AutoswapLocal
+ * @typedef  {object} AutoswapLocal
  * @property {(amount: Amount, brand: Brand) => Amount} getInputPrice
  * @property {() => Invitation} makeSwapInvitation
  */
 
 /**
- * @typedef {Object} Collateral
+ * @typedef {object} Collateral
  * @property {Ratio} liquidationMargin
  * @property {Ratio} stabilityFee
  * @property {Ratio} marketPrice
@@ -22,7 +22,7 @@
  */
 
 /**
- * @typedef {Object} VaultManagerParamValues
+ * @typedef {object} VaultManagerParamValues
  * @property {Ratio} liquidationMargin - margin below which collateral will be
  * liquidated to satisfy the debt.
  * @property {Ratio} liquidationPenalty - penalty charged upon liquidation as proportion of debt
@@ -41,7 +41,7 @@
  */
 
 /**
- * @typedef  {Object} VaultFactory - the creator facet
+ * @typedef  {object} VaultFactory - the creator facet
  * @property {AddVaultType} addVaultType
  * @property {() => Promise<Array<Collateral>>} getCollaterals
  * @property {() => Allocation} getRewardAllocation
@@ -76,7 +76,7 @@
  */
 
 /**
- * @typedef {Object} GetVaultParams
+ * @typedef {object} GetVaultParams
  * @property {() => Ratio} getLiquidationMargin
  * @property {() => Ratio} getLoanFee
  * @property {() => Promise<PriceQuote>} getCollateralQuote
@@ -92,31 +92,31 @@
  */
 
 /**
- * @typedef {Object} LoanTiming
+ * @typedef {object} LoanTiming
  * @property {RelativeTime} chargingPeriod
  * @property {RelativeTime} recordingPeriod
  */
 
 /**
- * @typedef {Object} AMMFees
+ * @typedef {object} AMMFees
  * @property {bigint} poolFee
  * @property {bigint} protocolFee
  */
 
 /**
- * @typedef {Object} LiquidationStrategy
+ * @typedef {object} LiquidationStrategy
  * @property {() => KeywordKeywordRecord} keywordMapping
  * @property {(collateral: Amount, run: Amount) => Proposal} makeProposal
  * @property {(runDebt: Amount) => Promise<Invitation>} makeInvitation
  */
 
 /**
- * @typedef {Object} Liquidator
+ * @typedef {object} Liquidator
  * @property {() => Promise<Invitation>} makeLiquidateInvitation
  */
 
 /**
- * @typedef {Object} DebtStatus
+ * @typedef {object} DebtStatus
  * @property {Timestamp} latestInterestUpdate
  * @property {NatValue} interest interest accrued since latestInterestUpdate
  * @property {NatValue} newDebt total including principal and interest
@@ -130,7 +130,7 @@
  */
 
 /**
- * @typedef {Object} CalculatorKit
+ * @typedef {object} CalculatorKit
  * @property {Calculate} calculate calculate new debt for charging periods up to
  * the present.
  * @property {Calculate} calculateReportingPeriod calculate new debt for

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -66,7 +66,7 @@ const validTransitions = {
 /**
  * @typedef {Phase[keyof typeof Phase]} TitlePhase
  *
- * @typedef {Object} VaultUIState
+ * @typedef {object} VaultUIState
  * @property {Amount<'nat'>} locked Amount of Collateral locked
  * @property {{debt: Amount<'nat'>, interest: Ratio}} debtSnapshot 'debt' at the point the compounded interest was 'interest'
  * @property {Ratio} interestRate Annual interest rate charge
@@ -75,7 +75,7 @@ const validTransitions = {
  */
 
 /**
- * @typedef {Object} VaultManager
+ * @typedef {object} VaultManager
  * @property {() => Notifier<import('./vaultManager').AssetState>} getNotifier
  * @property {(collateralAmount: Amount) => ERef<Amount>} maxDebtFor
  * @property {() => Brand} getCollateralBrand

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -507,7 +507,7 @@ const selfBehavior = {
    *
    * @param {MethodContext} param
    * @param {Installation} liquidationInstall
-   * @param {Object} liquidationTerms
+   * @param {object} liquidationTerms
    */
   setupLiquidator: async (
     { state, facets },

--- a/packages/run-protocol/src/vpool-xyk-amm/constantProduct/internal-types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/constantProduct/internal-types.js
@@ -1,27 +1,27 @@
 // @ts-check
 
 /**
- * @typedef {Object} ImprovedNoFeeSwapResult
+ * @typedef {object} ImprovedNoFeeSwapResult
  * @property {Amount} amountIn
  * @property {Amount} amountOut
  */
 
 /**
- * @typedef {Object} FeePair
+ * @typedef {object} FeePair
  *
  * @property {Amount} poolFee
  * @property {Amount} protocolFee
  */
 
 /**
- * @typedef {Object} PoolAllocation
+ * @typedef {object} PoolAllocation
  *
  * @property {Amount} Central
  * @property {Amount} Secondary
  */
 
 /**
- * @typedef {Object} NoFeeSwapFnInput
+ * @typedef {object} NoFeeSwapFnInput
  * @property {Amount} amountGiven
  * @property {Amount} amountWanted
  * @property {Brand=} brand
@@ -29,7 +29,7 @@
  */
 
 /**
- * @typedef {Object} SwapResult
+ * @typedef {object} SwapResult
  *
  * @property {Amount} xIncrement
  * @property {Amount} swapperGives
@@ -96,14 +96,14 @@
  */
 
 /**
- * @typedef {Object} GetXYParam
+ * @typedef {object} GetXYParam
  * @property {Amount=} amountGiven
  * @property {PoolAllocation} poolAllocation
  * @property {Amount=} amountWanted
  */
 
 /**
- * @typedef {Object} GetXYResultDeltaX
+ * @typedef {object} GetXYResultDeltaX
  * @property {Amount} x
  * @property {Amount} y
  * @property {Amount} deltaX
@@ -111,7 +111,7 @@
  */
 
 /**
- * @typedef {Object} GetXYResultDeltaY
+ * @typedef {object} GetXYResultDeltaY
  * @property {Amount} x
  * @property {Amount} y
  * @property {Amount} deltaY

--- a/packages/run-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/types.js
@@ -1,19 +1,19 @@
 // @ts-check
 
 /**
- * @typedef {Object} VPoolPriceQuote
+ * @typedef {object} VPoolPriceQuote
  * @property {Amount} amountIn
  * @property {Amount} amountOut
  */
 
 /**
- * @typedef {Object} VPool - virtual pool for price quotes and trading
+ * @typedef {object} VPool - virtual pool for price quotes and trading
  * @property {(amountIn: Amount, amountOut: Amount) => VPoolPriceQuote} getInputPrice
  * @property {(amountIn: Amount, amountOut: Amount) => VPoolPriceQuote} getOutputPrice
  */
 
 /**
- * @typedef {Object} DoublePoolSwapResult
+ * @typedef {object} DoublePoolSwapResult
  * @property {Amount} swapperGives
  * @property {Amount} swapperGets
  * @property {Amount} inPoolIncrement
@@ -38,7 +38,7 @@
  */
 
 /**
- * @typedef {Object} VirtualPool - virtual pool for price quotes and trading
+ * @typedef {object} VirtualPool - virtual pool for price quotes and trading
  * @property {GetDoublePoolSwapQuote} getPriceForInput
  * @property {GetDoublePoolSwapQuote} getPriceForOutput
  * @property {(seat: ZCFSeat, swapResult: DoublePoolSwapResult) => string} allocateGainsAndLosses
@@ -55,7 +55,7 @@
  */
 
 /**
- * @typedef {Object} XYKPool
+ * @typedef {object} XYKPool
  * @property {() => bigint} getLiquiditySupply
  * @property {() => Issuer} getLiquidityIssuer
  * @property {(seat: ZCFSeat) => string} addLiquidity
@@ -71,18 +71,18 @@
  */
 
 /**
- * @typedef {Object} PoolFacets
+ * @typedef {object} PoolFacets
  * @property {XYKPool} pool
  * @property {{addLiquidityActual: AddLiquidityActual}} helper
  * @property {VirtualPool} singlePool
  */
 
 /**
- * @typedef {Object} XYKAMMCreatorFacet
+ * @typedef {object} XYKAMMCreatorFacet
  * @property {() => Promise<Invitation>} makeCollectFeesInvitation
  */
 /**
- * @typedef {Object} XYKAMMPublicFacet
+ * @typedef {object} XYKAMMPublicFacet
  * @property {(issuer: ERef<Issuer>, keyword: Keyword) => Promise<Issuer>} addPool
  * add a new liquidity pool
  * @property {() => Promise<Invitation>} makeSwapInvitation synonym for

--- a/packages/run-protocol/test/amm/constantProduct/test-checkInvariants.js
+++ b/packages/run-protocol/test/amm/constantProduct/test-checkInvariants.js
@@ -13,7 +13,7 @@ import { checkKInvariantSellingX } from '../../../src/vpool-xyk-amm/constantProd
 import { getXY } from '../../../src/vpool-xyk-amm/constantProduct/getXY.js';
 
 /**
- * @typedef {Object} SwapPriceArgs
+ * @typedef {object} SwapPriceArgs
  * @property {Amount} amountGiven
  * @property {PoolAllocation} poolAllocation
  * @property {Amount=} amountWanted

--- a/packages/run-protocol/test/vaultFactory/test-vault-interest.js
+++ b/packages/run-protocol/test/vaultFactory/test-vault-interest.js
@@ -21,7 +21,7 @@ const trace = makeTracer('TestVault');
 /**
  * The properties will be asssigned by `setTestJig` in the contract.
  *
- * @typedef {Object} TestContext
+ * @typedef {object} TestContext
  * @property {ZCF} zcf
  * @property {ZCFMint} runMint
  * @property {IssuerKit} collateralKit

--- a/packages/run-protocol/test/vaultFactory/test-vault.js
+++ b/packages/run-protocol/test/vaultFactory/test-vault.js
@@ -22,7 +22,7 @@ const trace = makeTracer('TestVault');
 /**
  * The properties will be asssigned by `setTestJig` in the contract.
  *
- * @typedef {Object} TestContext
+ * @typedef {object} TestContext
  * @property {ZCF} zcf
  * @property {ZCFMint} runMint
  * @property {IssuerKit} collateralKit

--- a/packages/solo/src/outbound.js
+++ b/packages/solo/src/outbound.js
@@ -10,7 +10,7 @@ const SOLO_MAX_DEBUG_LENGTH =
 const log = anylogger('outbound');
 
 /**
- * @typedef {Object} TargetRecord
+ * @typedef {object} TargetRecord
  * @property {(newMessages: Array<[number, string]>, acknum: number) => void} deliverator
  * @property {number} highestSent
  * @property {number} highestAck

--- a/packages/solo/src/vat-http.js
+++ b/packages/solo/src/vat-http.js
@@ -135,9 +135,9 @@ export function buildRootObject(vatPowers) {
     },
 
     /**
-     * @param {Object} [privateObjects]
-     * @param {Object} [decentralObjects]
-     * @param {Object} [deprecatedObjects]
+     * @param {object} [privateObjects]
+     * @param {object} [decentralObjects]
+     * @param {object} [deprecatedObjects]
      */
     setPresences(
       privateObjects = undefined,

--- a/packages/store/src/legacy/legacyWeakMap.js
+++ b/packages/store/src/legacy/legacyWeakMap.js
@@ -12,7 +12,7 @@ import '../types.js';
  * @returns {LegacyWeakMap<K,V>}
  */
 export const makeLegacyWeakMap = (keyName = 'key') => {
-  /** @type {WeakMap<K & Object,V>} */
+  /** @type {WeakMap<K & object, V>} */
   const wm = new WeakMap();
   const assertKeyDoesNotExist = key =>
     assert(!wm.has(key), X`${q(keyName)} already registered: ${key}`);

--- a/packages/store/src/patterns/encodePassable.js
+++ b/packages/store/src/patterns/encodePassable.js
@@ -255,10 +255,10 @@ const decodeTagged = (encoded, decodePassable) => {
 };
 
 /**
- * @typedef {Object} EncodeOptionsRecord
- * @property {(remotable: Object) => string} encodeRemotable
- * @property {(promise: Object) => string} encodePromise
- * @property {(error: Object) => string} encodeError
+ * @typedef {object} EncodeOptionsRecord
+ * @property {(remotable: object) => string} encodeRemotable
+ * @property {(promise: object) => string} encodePromise
+ * @property {(error: object) => string} encodeError
  */
 
 /**
@@ -343,8 +343,8 @@ export const makeEncodePassable = ({
 harden(makeEncodePassable);
 
 /**
- * @typedef {Object} DecodeOptionsRecord
- * @property {(encodedRemotable: string) => Object} decodeRemotable
+ * @typedef {object} DecodeOptionsRecord
+ * @property {(encodedRemotable: string) => object} decodeRemotable
  * @property {(encodedPromise: string) => Promise} decodePromise
  * @property {(encodedError: string) => Error} decodeError
  */

--- a/packages/store/src/patterns/internal-types.js
+++ b/packages/store/src/patterns/internal-types.js
@@ -10,7 +10,7 @@
 // and in exports.js
 
 // /**
-//  * @typedef {Object} MatchHelper
+//  * @typedef {object} MatchHelper
 //  * This factors out only the parts specific to each kind of Matcher. It is
 //  * encapsulated, and its methods can make the stated unchecker assumptions
 //  * enforced by the common calling logic.

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -7,7 +7,7 @@ const { details: X, quote: q } = assert;
 
 /**
  * @template K,V
- * @param {WeakMap<K & Object,V>} jsmap
+ * @param {WeakMap<K & object, V>} jsmap
  * @param {(k: K, v: V) => void} assertKVOkToAdd
  * @param {(k: K, v: V) => void} assertKVOkToSet
  * @param {((k: K) => void)=} assertKeyOkToDelete

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -7,7 +7,7 @@ const { details: X, quote: q } = assert;
 
 /**
  * @template K
- * @param {WeakSet<K & Object>} jsset
+ * @param {WeakSet<K & object>} jsset
  * @param {(k: K) => void} assertKeyOkToAdd
  * @param {((k: K) => void)=} assertKeyOkToDelete
  * @param {string=} keyName

--- a/packages/store/src/stores/store-utils.js
+++ b/packages/store/src/stores/store-utils.js
@@ -6,7 +6,7 @@ const { details: X, quote: q } = assert;
 
 /**
  * @template K,V
- * @typedef {Object} CurrentKeysKit
+ * @typedef {object} CurrentKeysKit
  * @property {(k: K, v?: V) => void} assertUpdateOnAdd
  * @property {(k: K) => void} assertUpdateOnDelete
  * @property {Iterable<K>} iterableKeys

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -92,7 +92,7 @@
  */
 
 /**
- * @typedef {Object} StoreOptions
+ * @typedef {object} StoreOptions
  * Of the dimensions on which KeyedStores can differ, we only represent a few
  * of them as standard options. A given store maker should document which
  * options it supports, as well as its positions on dimensions for which it
@@ -124,7 +124,7 @@
 
 /**
  * @template K
- * @typedef {Object} WeakSetStore
+ * @typedef {object} WeakSetStore
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
  * answer will always be false for keys that cannot be found in this store.
@@ -140,7 +140,7 @@
 
 /**
  * @template K
- * @typedef {Object} SetStore
+ * @typedef {object} SetStore
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
  * answer will always be false for keys that cannot be found in this store.
@@ -161,7 +161,7 @@
 
 /**
  * @template K,V
- * @typedef {Object} WeakMapStore
+ * @typedef {object} WeakMapStore
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
  * answer will always be false for keys that cannot be found in this store.
@@ -180,7 +180,7 @@
 
 /**
  * @template K,V
- * @typedef {Object} MapStore
+ * @typedef {object} MapStore
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
  * answer will always be false for keys that cannot be found in this map
@@ -222,7 +222,7 @@
 
 /**
  * @template K,V
- * @typedef {Object} LegacyWeakMap
+ * @typedef {object} LegacyWeakMap
  * LegacyWeakMap is deprecated. Use WeakMapStore instead.
  * @property {(key: K) => boolean} has
  * Check if a key exists
@@ -239,7 +239,7 @@
 
 /**
  * @template K,V
- * @typedef {Object} LegacyMap
+ * @typedef {object} LegacyMap
  * LegacyWeakMap is deprecated. Use WeakMapStore instead.
  * @property {(key: K) => boolean} has
  * Check if a key exists
@@ -317,13 +317,13 @@
  */
 
 /**
- * @typedef {Object} RankComparatorKit
+ * @typedef {object} RankComparatorKit
  * @property {RankCompare} comparator
  * @property {RankCompare} antiComparator
  */
 
 /**
- * @typedef {Object} FullComparatorKit
+ * @typedef {object} FullComparatorKit
  * @property {FullCompare} comparator
  * @property {FullCompare} antiComparator
  */
@@ -459,7 +459,7 @@
  */
 
 /**
- * @typedef {Object} MatcherNamespace
+ * @typedef {object} MatcherNamespace
  * @property {() => Matcher} any
  * Matches any passable
  * @property {(...patts: Pattern[]) => Matcher} and
@@ -546,7 +546,7 @@
  */
 
 /**
- * @typedef {Object} PatternKit
+ * @typedef {object} PatternKit
  * @property {(specimen: Passable, patt: Pattern) => boolean} matches
  * @property {(specimen: Passable, patt: Pattern) => void} fit
  * @property {(patt: Pattern) => void} assertPattern
@@ -567,7 +567,7 @@
 // in internal-types.js and exports.js
 
 /**
- * @typedef {Object} MatchHelper
+ * @typedef {object} MatchHelper
  * This factors out only the parts specific to each kind of Matcher. It is
  * encapsulated, and its methods can make the stated unchecker assumptions
  * enforced by the common calling logic.

--- a/packages/swing-store/src/ephemeralSwingStore.js
+++ b/packages/swing-store/src/ephemeralSwingStore.js
@@ -146,8 +146,8 @@ export function initEphemeralSwingStore() {
    * Generator function that returns an iterator over the items in a stream.
    *
    * @param {string} streamName  The stream to read
-   * @param {Object} startPosition  The position to start reading from
-   * @param {Object} endPosition  The position of the end of the stream
+   * @param {object} startPosition  The position to start reading from
+   * @param {object} endPosition  The position of the end of the stream
    *
    * @returns {Iterable<string>} an iterable for the items in the named stream
    */
@@ -195,9 +195,9 @@ export function initEphemeralSwingStore() {
    *
    * @param {string} streamName  The stream to be written
    * @param {string} item  The item to write
-   * @param {Object} position  The position to write the item
+   * @param {object} position  The position to write the item
    *
-   * @returns {Object} the new position after writing
+   * @returns {object} the new position after writing
    */
   function writeStreamItem(streamName, item, position) {
     insistStreamName(streamName);

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -105,7 +105,7 @@ export function makeSnapStoreIO() {
  *
  * @param {string} dirPath  Path to a directory in which database files may be kept.
  * @param {boolean} forceReset  If true, initialize the database to an empty state
- * @param {Object} options  Configuration options
+ * @param {object} options  Configuration options
  *
  * @returns {SwingAndSnapStore}
  */
@@ -343,7 +343,7 @@ function makeSwingStore(dirPath, forceReset, options) {
  *   be kept.  This directory need not actually exist yet (if it doesn't it will
  *   be created) but it is reserved (by the caller) for the exclusive use of
  *   this swing store instance.  If null, an ephemeral store will be created.
- * @param {Object?} options  Optional configuration options
+ * @param {object?} options  Optional configuration options
  *
  * @returns {SwingStore}
  */
@@ -364,7 +364,7 @@ export function initSwingStore(dirPath, options = {}) {
  *   This directory need not actually exist yet (if it doesn't it will be
  *   created) but it is reserved (by the caller) for the exclusive use of this
  *   swing store instance.
- * @param {Object?} options  Optional configuration options
+ * @param {object?} options  Optional configuration options
  *
  * @returns {SwingAndSnapStore}
  */

--- a/packages/telemetry/src/index.js
+++ b/packages/telemetry/src/index.js
@@ -41,7 +41,7 @@ export const getResourceAttributes = ({
 };
 
 /**
- * @typedef {Object} Powers
+ * @typedef {object} Powers
  * @property {{ warn: Console['warn'] }} console
  * @property {NodeJS.ProcessEnv} env
  * @property {string} [serviceName]

--- a/packages/telemetry/src/otel-trace.js
+++ b/packages/telemetry/src/otel-trace.js
@@ -17,7 +17,7 @@ export const SPAN_MAX_QUEUE_SIZE = 100_000;
 export const SPAN_EXPORT_DELAY_MS = 1_000;
 
 /**
- * @param {Object} opts
+ * @param {object} opts
  * @param {Record<string, string>} opts.env
  */
 export const makeOtelTracingProvider = opts => {

--- a/packages/vats/src/authorityViz.js
+++ b/packages/vats/src/authorityViz.js
@@ -170,7 +170,7 @@ const manifest2graph = manifest => {
 
 /**
  * @param { string[] } args
- * @param { Object } io
+ * @param {object} io
  * @param { typeof import('process').stdout } io.stdout
  */
 const main = async (args, { stdout }) => {

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -11,16 +11,16 @@ import { Far } from '@endo/far';
  */
 
 /**
- * @typedef {Object} BridgeDevice
+ * @typedef {object} BridgeDevice
  * @property {(dstID: string, obj: any) => any} callOutbound
  * @property {(handler: { inbound: (srcID: string, obj: any) => void}) => void} registerInboundHandler
  */
 
 /**
- * @typedef {Object} BridgeHandler An object that can receive messages from the bridge device
+ * @typedef {object} BridgeHandler An object that can receive messages from the bridge device
  * @property {(srcId: string, obj: any) => Promise<any>} fromBridge Handle an inbound message
  *
- * @typedef {Object} BridgeManager The object to manage this bridge
+ * @typedef {object} BridgeManager The object to manage this bridge
  * @property {(dstID: string, obj: any) => any} toBridge
  * @property {(srcID: string, handler: BridgeHandler) => void} register
  * @property {(srcID: string, handler: BridgeHandler) => void} unregister

--- a/packages/vats/src/centralSupply.js
+++ b/packages/vats/src/centralSupply.js
@@ -10,7 +10,7 @@ import { E, Far } from '@endo/far';
  * @param {ZCF<{
  *  bootstrapPaymentValue: bigint,
  * }>} zcf
- * @param {Object} privateArgs
+ * @param {object} privateArgs
  * @param {FeeMintAccess} privateArgs.feeMintAccess
  */
 export const start = async (zcf, { feeMintAccess }) => {

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -113,7 +113,7 @@
  * @param {string[]} powerFlags
  * @returns {Promise<Record<string, Promise<any>>>}
  *
- * @typedef {Object} ClientFacet
+ * @typedef {object} ClientFacet
  * @property {() => ERef<Record<string, any>>} getChainBundle Required for ag-solo, but deprecated in favour of getConfiguration
  *   NOTE: we use `any` rather than `unknown` because each client that wants to call a method such as
  *   `E(userBundle.bank).deposit(payment)` has to cast userBundle.bank;
@@ -123,7 +123,7 @@
  *
  * @typedef {{ clientAddress: string, clientHome: Record<string, any>}} Configuration
  *
- * @typedef {Object} ClientCreator
+ * @typedef {object} ClientCreator
  * @property {CreateUserBundle} createUserBundle Required for vat-provisioning, but deprecated in favor of {@link createClient}.
  * @property {(nickname: string, clientAddress: string, powerFlags: string[]) => Promise<ClientFacet>} createClientFacet
  */

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -32,7 +32,7 @@ const DEFAULT_PACKET_TIMEOUT_NS = 10n * 60n * 1_000_000_000n;
  */
 
 /**
- * @typedef {Object} IBCPacket
+ * @typedef {object} IBCPacket
  * @property {Bytes} [data]
  * @property {IBCChannelID} source_channel
  * @property {IBCPortID} source_port
@@ -62,11 +62,11 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
   const channelKeyToConnP = makeStore('CHANNEL:PORT');
 
   /**
-   * @typedef {Object} Counterparty
+   * @typedef {object} Counterparty
    * @property {string} port_id
    * @property {string} channel_id
    *
-   * @typedef {Object} ConnectingInfo
+   * @typedef {object} ConnectingInfo
    * @property {'ORDERED'|'UNORDERED'} order
    * @property {string[]} connectionHops
    * @property {string} portID
@@ -158,7 +158,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
      * @param {Connection} _conn
      * @param {Bytes} packetBytes
      * @param {ConnectionHandler} _handler
-     * @param {Object} root0
+     * @param {object} root0
      * @param {bigint} [root0.relativeTimeoutNs]
      * @returns {Promise<Bytes>} Acknowledgement data
      */
@@ -232,7 +232,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
   let protocolImpl;
 
   /**
-   * @typedef {Object} OutboundCircuitRecord
+   * @typedef {object} OutboundCircuitRecord
    * @property {IBCConnectionID} dst
    * @property {'ORDERED'|'UNORDERED'} order
    * @property {string} version

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -30,7 +30,7 @@ const calcCrc = (data, crcDigits) => {
  * Create a board to post things on.
  *
  * @param {bigint | number} [initSequence]
- * @param {Object} [options]
+ * @param {object} [options]
  * @param {string} [options.prefix]
  * @param {number} [options.crcDigits]
  * @returns {Board}

--- a/packages/vats/src/my-lien.js
+++ b/packages/vats/src/my-lien.js
@@ -21,7 +21,7 @@ const XLien = {
  */
 
 /**
- * @typedef {Object} StakingAuthority
+ * @typedef {object} StakingAuthority
  * @property {(address: string, wantedBrand: Brand) => Promise<{
  *   bonded: Amount,
  *   liened: Amount,

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -6,7 +6,7 @@
  */
 
 /**
- * @typedef {Object} Board
+ * @typedef {object} Board
  * @property {(id: string) => any} getValue
  * @property {(value: unknown) => string} getId
  * @property {(value: unknown) => boolean} has
@@ -15,7 +15,7 @@
  */
 
 /**
- * @typedef {Object} NameHub read-only access to a node in a name hierarchy
+ * @typedef {object} NameHub read-only access to a node in a name hierarchy
  *
  * NOTE: We need to return arrays, not iterables, because even if marshal could
  * allow passing a remote iterable, there would be an inordinate number of round
@@ -33,7 +33,7 @@
  */
 
 /**
- * @typedef {Object} NameAdmin write access to a node in a name hierarchy
+ * @typedef {object} NameAdmin write access to a node in a name hierarchy
  *
  * @property {(key: string) => void} reserve Mark a key as reserved; will
  * return a promise that is fulfilled when the key is updated (or rejected when
@@ -57,19 +57,19 @@
  */
 
 /**
- * @typedef {Object} NameHubKit a node in a name hierarchy
+ * @typedef {object} NameHubKit a node in a name hierarchy
  * @property {NameHub} nameHub read access
  * @property {NameAdmin} nameAdmin write access
  */
 
 /**
- * @typedef {Object} FeeCollector
+ * @typedef {object} FeeCollector
  *
  * @property {() => ERef<Payment>} collectFees
  */
 
 /**
- * @typedef {Object} DistributorParams
+ * @typedef {object} DistributorParams
  *
  * @property {bigint} [epochInterval=1n] - parameter to the epochTimer
  *  controlling the interval at which rewards should be sent to the bank.

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -75,7 +75,7 @@ const makePurseController = (
 };
 
 /**
- * @typedef {Object} AssetIssuerKit
+ * @typedef {object} AssetIssuerKit
  * @property {ERef<Mint>} [mint]
  * @property {ERef<Issuer>} issuer
  * @property {Brand} brand
@@ -86,7 +86,7 @@ const makePurseController = (
  */
 
 /**
- * @typedef {Object} AssetDescriptor
+ * @typedef {object} AssetDescriptor
  * @property {Brand} brand
  * @property {ERef<Issuer>} issuer
  * @property {string} issuerName
@@ -95,7 +95,7 @@ const makePurseController = (
  */
 
 /**
- * @typedef {Object} Bank
+ * @typedef {object} Bank
  * @property {() => Subscription<AssetDescriptor>} getAssetSubscription Returns
  * assets as they are added to the bank
  * @property {(brand: Brand) => VirtualPurse} getPurse Find any existing vpurse

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -12,7 +12,7 @@ import '@agoric/notifier/exported.js';
  */
 
 /**
- * @typedef {Object} VirtualPurseController The object that determines the
+ * @typedef {object} VirtualPurseController The object that determines the
  * remote behaviour of a virtual purse.
  * @property {(amount: Amount) => Promise<void>} pushAmount Tell the controller
  * to send an amount from "us" to the "other side".  This should resolve on

--- a/packages/wallet/api/src/findOrMakeInvitation.js
+++ b/packages/wallet/api/src/findOrMakeInvitation.js
@@ -22,7 +22,7 @@ const assertFirstCapASCII = str => {
 
 /**
  * @param {Amount} invitationPurseBalance
- * @param {Object} query
+ * @param {object} query
  * @param {Board} query.board
  * @param {string} query.boardId
  * @returns {Array}

--- a/packages/wallet/api/src/internal-types.js
+++ b/packages/wallet/api/src/internal-types.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @typedef {Object} PursesAddedState
+ * @typedef {object} PursesAddedState
  * @property {Purse} purse
  * @property {Brand} brand
  * @property {PurseActions} actions
@@ -12,26 +12,26 @@
  */
 
 /**
- * @typedef {Object} PurseActions
+ * @typedef {object} PurseActions
  * @property {(receiverP: ERef<{ receive: (payment: Payment) => void }>, valueToSend: AmountValue) => Promise<void>} send
  * @property {(payment: Payment) => Promise<Amount>} receive
  * @property {(payment: Payment, amount?: Amount) => Promise<Amount>} deposit
  */
 
 /**
- * @typedef {Object} BrandRecord
+ * @typedef {object} BrandRecord
  * @property {Brand} brand
  * @property {Issuer} issuer
  * @property {string} issuerBoardId
  */
 
 /**
- * @typedef {Object} Contact
+ * @typedef {object} Contact
  * @property {string=} depositBoardId
  */
 
 /**
- * @typedef {Object} DappRecord
+ * @typedef {object} DappRecord
  * @property {Promise<void>=} approvalP
  * @property {Petname} suggestedPetname
  * @property {Petname} petname
@@ -41,7 +41,7 @@
  */
 
 /**
- * @typedef {Object} DappActions
+ * @typedef {object} DappActions
  * @property {(petname: Petname) => DappActions} setPetname
  * @property {() => DappActions} enable
  * @property {(reason: any) => DappActions} disable
@@ -49,7 +49,7 @@
 
 /**
  * @template T
- * @typedef {Object} Mapping
+ * @typedef {object} Mapping
  * @property {(petname: Petname) => string} implode
  * @property {(str: string) => Petname} explode
  * @property {LegacyWeakMap<T, Petname>} valToPetname
@@ -67,7 +67,7 @@
  */
 
 /**
- * @typedef {Object} PaymentRecord
+ * @typedef {object} PaymentRecord
  * @property {RecordMetadata} meta
  * @property {Issuer} [issuer]
  * @property {Payment} [payment]
@@ -78,7 +78,7 @@
  * @property {Amount} [depositedAmount]
  * @property {string} [issuerBoardId]
  *
- * @typedef {Object} PaymentActions
+ * @typedef {object} PaymentActions
  * @property {(purseOrPetname?: (Purse | Petname)) => Promise<AmountValue>} deposit
  * @property {() => Promise<boolean>} refresh
  * @property {() => Promise<boolean>} getAmountOf

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -52,7 +52,7 @@ const cmp = (a, b) => {
 };
 
 /**
- * @typedef {Object} MakeWalletParams
+ * @typedef {object} MakeWalletParams
  * @property {ERef<ZoeService>} zoe
  * @property {Board} board
  * @property {NameHub} [agoricNames]

--- a/packages/wallet/api/src/types.js
+++ b/packages/wallet/api/src/types.js
@@ -10,7 +10,7 @@
  */
 
 /**
- * @typedef {Object} WalletUser
+ * @typedef {object} WalletUser
  * The presence exposed as `local.wallet` (or
  * `home.wallet`).  The idea is to provide someplace from which all the rest of
  * the API can be obtained.
@@ -51,7 +51,7 @@
  */
 
 /**
- * @typedef {Object} WalletBridge
+ * @typedef {object} WalletBridge
  * The methods that can be used by an untrusted
  * Dapp without breaching the wallet's integrity.  These methods are also
  * exposed via the iframe/WebSocket bridge that a Dapp UI can use to access the
@@ -97,7 +97,7 @@
  */
 
 /**
- * @typedef {Object} RecordMetadata
+ * @typedef {object} RecordMetadata
  * @property {number} id
  * Identifies a particular record in the context of the wallet backend. This id
  * is stable and unique for a wallet backend (even across different record
@@ -113,7 +113,7 @@
  */
 
 /**
- * @typedef {Object} PursesJSONState
+ * @typedef {object} PursesJSONState
  * @property {Brand} brand
  * @property {string} brandBoardId
  * The board ID for this purse's brand
@@ -132,14 +132,14 @@
  */
 
 /**
- * @typedef {Object} OfferState
+ * @typedef {object} OfferState
  * @property {any} requestContext
  * @property {string} id
  */
 
 /**
  * @template T
- * @typedef {Object} PetnameManager
+ * @typedef {object} PetnameManager
  * @property {(petname: Petname, object: T) => Promise<void>} rename
  * @property {(petname: Petname) => T} get
  * @property { () => Array<[Petname, T]>} getAll
@@ -159,7 +159,7 @@
  */
 
 /**
- * @typedef {Object} IssuerTable
+ * @typedef {object} IssuerTable
  * @property {(brand: Brand) => boolean} hasByBrand
  * @property {(brand: Brand) => IssuerRecord} getByBrand
  * @property {(issuer: Issuer) => boolean} hasByIssuer

--- a/packages/wallet/api/src/wallet.js
+++ b/packages/wallet/api/src/wallet.js
@@ -373,7 +373,7 @@ export function buildRootObject(vatPowers) {
   function getBridgeURLHandler() {
     return Far('bridgeURLHandler', {
       /**
-       * @typedef {Object} WalletOtherSide
+       * @typedef {object} WalletOtherSide
        * The callbacks from a CapTP wallet client.
        * @property {(dappOrigin: string,
        *             suggestedDappPetname: Petname

--- a/packages/web-components/src/states.js
+++ b/packages/web-components/src/states.js
@@ -9,7 +9,7 @@ import {
 } from 'robot3';
 
 /**
- * @typedef {Object} Context
+ * @typedef {object} Context
  * @property {any?} error
  * @property {string?} location
  * @property {Record<string,any>} connectionParams

--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -39,7 +39,7 @@ function deepDifference(x, y) {
     }
 
     const { hasOwnProperty } = Object.prototype;
-    /** @type {(obj: Object, prop: string | symbol | number) => boolean} */
+    /** @type {(obj: object, prop: string | symbol | number) => boolean} */
     const hasOwnPropertyOf = (obj, prop) =>
       Reflect.apply(hasOwnProperty, obj, [prop]);
     for (const prop of Reflect.ownKeys(x)) {
@@ -105,7 +105,7 @@ let theHarness = null; // ISSUE: ambient
  */
 function createHarness(send) {
   let testNum = 0;
-  /** @type {((ot: { context: Object }) => Promise<void>)[]} */
+  /** @type {((ot: { context: object }) => Promise<void>)[]} */
   const beforeHooks = [];
   /** @type {Record<string, () => Promise<void>>} */
   const suitesToRun = {};

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -210,7 +210,7 @@ async function runTestScript(
  * Get ava / ava-xs config from package.json
  *
  * @param { string[] } args
- * @param {Object} options
+ * @param {object} options
  * @param {string} [options.packageFilename]
  * @param {{
  *   readFile: typeof import('fs').promises.readFile,
@@ -218,7 +218,7 @@ async function runTestScript(
  * }} io
  * @returns {Promise<AvaXSConfig>}
  *
- * @typedef {Object} AvaXSConfig
+ * @typedef {object} AvaXSConfig
  * @property {string[]} files - files from args or else ava.files
  * @property {string[]} require - specifiers of modules to run before each test script
  * @property {string[]=} exclude - files containing any of these should be skipped

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -41,7 +41,7 @@ function echoCommand(arg) {
 /**
  * @param {XSnapOptions} options
  *
- * @typedef {Object} XSnapOptions
+ * @typedef {object} XSnapOptions
  * @property {string} os
  * @property {Spawn} spawn
  * @property {(request:Uint8Array) => Promise<Uint8Array>} [handleCommand]
@@ -148,7 +148,7 @@ export function xsnap(options) {
 
   /**
    * @template T
-   * @typedef {Object} RunResult
+   * @typedef {object} RunResult
    * @property {T} reply
    * @property {{ meterType: string, allocate: number|null, compute: number|null }} meterUsage
    */

--- a/packages/zoe/docs/seats.md
+++ b/packages/zoe/docs/seats.md
@@ -26,7 +26,7 @@ type:
 
 ```js
 /**
- * @typedef {Object} UserSeat
+ * @typedef {object} UserSeat
  * @property {() => Promise<Allocation>} getCurrentAllocation
  * @property {() => Promise<ProposalRecord>} getProposal
  * @property {() => Promise<PaymentPKeywordRecord>} getPayouts
@@ -59,7 +59,7 @@ The type of the ZCFSeat is:
 
 ```js
 /**
- * @typedef {Object} ZCFSeat
+ * @typedef {object} ZCFSeat
  * @property {() => void} exit
  * @property {ZCFSeatFail} fail
  * @property {() => Notifier<Allocation>} getNotifier
@@ -89,7 +89,7 @@ The type of the `ZoeSeatAdmin` is:
 
 ```js
 /**
- * @typedef {Object} ZoeSeatAdmin
+ * @typedef {object} ZoeSeatAdmin
  * @property {(allocation: Allocation) => void} replaceAllocation
  * @property {ZoeSeatAdminExit} exit
  * @property {ShutdownWithFailure} fail called with the reason

--- a/packages/zoe/src/contractFacet/internal-types.js
+++ b/packages/zoe/src/contractFacet/internal-types.js
@@ -24,6 +24,6 @@
  * @property {(instanceAdminFromZoe: ERef<ZoeInstanceAdmin>,
  *     instanceRecordFromZoe: InstanceRecord,
  *     issuerStorageFromZoe: IssuerRecords,
- *     privateArgs?: Object,
+ *     privateArgs?: object,
  * ) => Promise<ExecuteContractResult>} startContract
  */

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -14,7 +14,7 @@
 
 /**
  * @template {object} [CT=Record<string, unknown>] Contract's custom terms
- * @typedef {Object} ZCF Zoe Contract Facet
+ * @typedef {object} ZCF Zoe Contract Facet
  *
  * The Zoe interface specific to a contract instance. The Zoe Contract
  * Facet is an API object used by running contract instances to access
@@ -99,7 +99,7 @@
  * @param {OfferHandler<OR>} offerHandler - a contract specific function
  * that handles the offer, such as saving it or performing a trade
  * @param {string} description
- * @param {Object=} customProperties
+ * @param {object=} customProperties
  * @returns {Promise<Invitation<OR>>}
  */
 
@@ -139,7 +139,7 @@
 
 /**
  * @template {AssetKind} [K=AssetKind]
- * @typedef {Object} ZCFMint
+ * @typedef {object} ZCFMint
  * @property {() => IssuerRecord<K>} getIssuerRecord
  * @property {ZCFMintMintGains} mintGains
  * All the amounts in gains must be of this ZCFMint's brand.
@@ -184,7 +184,7 @@
  */
 
 /**
- * @typedef {Object} ZCFSeat
+ * @typedef {object} ZCFSeat
  * @property {() => void} exit
  * @property {ZCFSeatFail} fail
  * @property {() => Notifier<Allocation>} getNotifier
@@ -205,10 +205,10 @@
  */
 
 /**
- * @template {Object} [OR=any]
+ * @template {object} [OR=any]
  * @callback OfferHandler
  * @param {ZCFSeat} seat
- * @param {Object=} offerArgs
+ * @param {object=} offerArgs
  * @returns {OR}
  */
 
@@ -229,7 +229,7 @@
 /**
  * @template PF Public facet
  * @template CF Creator facet
- * @typedef {Object} ContractStartFnResult
+ * @typedef {object} ContractStartFnResult
  * @property {PF} publicFacet
  * @property {CF} creatorFacet
  * @property {Promise<Invitation>=} [creatorInvitation]

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -29,7 +29,7 @@ const isGTE = (amount, amountLimit) => AmountMath.isGTE(amount, amountLimit);
 const isGT = (amount, amountLimit) => !AmountMath.isGTE(amountLimit, amount);
 
 /**
- * @typedef {Object} OnewayPriceAuthorityOptions
+ * @typedef {object} OnewayPriceAuthorityOptions
  * @property {Issuer} quoteIssuer
  * @property {ERef<Notifier<Timestamp>>} notifier
  * @property {ERef<TimerService>} timer

--- a/packages/zoe/src/contractSupport/statistics.js
+++ b/packages/zoe/src/contractSupport/statistics.js
@@ -1,6 +1,6 @@
 /**
  * @template T
- * @typedef {Object} TypedMath
+ * @typedef {object} TypedMath
  * @property {(a: T, b: T) => T} add
  * @property {(a: T, b: bigint) => T} divide
  * @property {(a: T, b: T) => boolean} isGTE

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -2,7 +2,7 @@
 /// <reference types="ses"/>
 
 /**
- * @typedef {Object} SeatGainsLossesRecord
+ * @typedef {object} SeatGainsLossesRecord
  * @property {ZCFSeat} seat
  * @property {AmountKeywordRecord} gains - what the seat will
  * gain as a result of this trade
@@ -80,7 +80,7 @@
  */
 
 /**
- * @typedef {Object} Ratio
+ * @typedef {object} Ratio
  * @property {Amount<'nat'>} numerator
  * @property {Amount<'nat'>} denominator
  */

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -25,7 +25,7 @@ export const assertIssuerKeywords = (zcf, expected) => {
 };
 
 /**
- * @typedef {Object} ZcfSeatPartial
+ * @typedef {object} ZcfSeatPartial
  * @property {() => ProposalRecord} getProposal
  * @property {() => Allocation} getCurrentAllocation
  */
@@ -304,7 +304,7 @@ const reverse = (keywordRecord = {}) => {
  *   The seat in contractA to deposit the payout of the offer to.
  *   If `toSeat` is not provided, this defaults to the `fromSeat`.
  *
- * @param {Object=} offerArgs
+ * @param {object=} offerArgs
  *   Aditional contract-specific optional arguments in a record.
  *
  * @returns {Promise<{userSeatPromise: Promise<UserSeat>, deposited: Promise<AmountKeywordRecord>}>}

--- a/packages/zoe/src/contracts/callSpread/types.js
+++ b/packages/zoe/src/contracts/callSpread/types.js
@@ -9,13 +9,13 @@
  */
 
 /**
- * @typedef {Object} PayoffHandler
+ * @typedef {object} PayoffHandler
  * @property {() => void} schedulePayoffs
  * @property  {MakeOptionInvitation} makeOptionInvitation
  */
 
 /**
- * @typedef {Object} CalculateSharesReturn
+ * @typedef {object} CalculateSharesReturn
  * Return value from calculateShares, which represents the portions assigned to
  * the long and short side of a transaction. These will be two non-negative
  * integers that sum to 100.

--- a/packages/zoe/src/contracts/loan/types.js
+++ b/packages/zoe/src/contracts/loan/types.js
@@ -154,7 +154,7 @@
  */
 
 /**
- * @typedef {Object} DebtCalculatorConfig
+ * @typedef {object} DebtCalculatorConfig
  * @property {CalcInterestFn} calcInterestFn
  *
  *   A function to calculate the interest, given the debt value and an
@@ -181,7 +181,7 @@
  */
 
 /**
- * @typedef {Object} ConfigMinusGetDebt
+ * @typedef {object} ConfigMinusGetDebt
  * @property {ZCFSeat} collateralSeat
  * @property {PromiseRecord<any>} liquidationPromiseKit
  * @property {bigint} [mmr]
@@ -194,7 +194,7 @@
  */
 
 /**
- * @typedef {Object} BorrowFacet
+ * @typedef {object} BorrowFacet
  *
  * @property {() => Promise<Invitation>} makeCloseLoanInvitation
  *

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -70,7 +70,7 @@ const start = async (
   const zoe = zcf.getZoeService();
 
   /**
-   * @typedef {Object} OracleRecord
+   * @typedef {object} OracleRecord
    * @property {(timestamp: Timestamp) => Promise<void>=} querier
    * @property {Ratio} lastSample
    * @property {OracleKey} oracleKey
@@ -108,7 +108,7 @@ const start = async (
   E(repeaterP).schedule(waker);
 
   /**
-   * @param {Object} param0
+   * @param {object} param0
    * @param {Ratio} [param0.overridePrice]
    * @param {Timestamp} [param0.timestamp]
    */
@@ -301,7 +301,7 @@ const start = async (
        * reported data.
        *
        * @param {ZCFSeat} seat
-       * @param {Object} param1
+       * @param {object} param1
        * @param {Notifier<OraclePriceSubmission>} [param1.notifier] optional notifier that produces oracle price submissions
        * @param {number} [param1.scaleValueOut]
        * @returns {Promise<OracleAdmin>}

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -168,7 +168,7 @@ const start = async (
   const { notifier } = makeNotifierKit();
 
   /**
-   * @typedef {Object} OracleRecord
+   * @typedef {object} OracleRecord
    * @property {(timestamp: Timestamp) => Promise<void>=} querier
    * @property {number} lastSample
    */
@@ -181,7 +181,7 @@ const start = async (
   const keyToRecords = makeLegacyMap('oracleKey');
 
   /**
-   * @param {Object} param0
+   * @param {object} param0
    * @param {number} [param0.overrideValueOut]
    * @param {Timestamp} [param0.timestamp]
    */

--- a/packages/zoe/src/contracts/priceAggregatorTypes.js
+++ b/packages/zoe/src/contracts/priceAggregatorTypes.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {Object} OracleAdmin
+ * @typedef {object} OracleAdmin
  * @property {() => Promise<void>} delete
  * Remove the oracle from the aggregator
  * @property {(result: any) => Promise<void>} pushResult
@@ -18,14 +18,14 @@
  */
 
 /**
- * @typedef {Object} PriceAggregatorCreatorFacet
+ * @typedef {object} PriceAggregatorCreatorFacet
  * @property {PriceAggregatorCreatorFacetInitOracle} initOracle
  * @property {(oracleKey: OracleKey) => Promise<void>} deleteOracle
  * @property {(oracleKey?: OracleKey) => Promise<Invitation>} makeOracleInvitation
  */
 
 /**
- * @typedef {Object} PriceAggregatorPublicFacet
+ * @typedef {object} PriceAggregatorPublicFacet
  * @property {() => PriceAuthority} getPriceAuthority
  * @property {() => Promise<Notifier<bigint> | undefined>} getRoundStartNotifier
  * @property {() => Promise<Notifier<{
@@ -35,7 +35,7 @@
  */
 
 /**
- * @typedef {Object} PriceAggregatorKit
+ * @typedef {object} PriceAggregatorKit
  * @property {PriceAggregatorPublicFacet} publicFacet
  * @property {PriceAggregatorCreatorFacet} creatorFacet
  */
@@ -46,7 +46,7 @@
  */
 
 /**
- * @typedef {Object} OraclePublicFacet
+ * @typedef {object} OraclePublicFacet
  * The public methods accessible from the contract instance
  * @property {(query: any) => ERef<Invitation>} makeQueryInvitation
  * Create an invitation for an oracle query
@@ -61,7 +61,7 @@
  */
 
 /**
- * @typedef {Object} OracleCreatorFacet
+ * @typedef {object} OracleCreatorFacet
  * The private methods accessible from the contract instance
  * @property {() => AmountKeywordRecord} getCurrentFees
  * Get the current fee amounts
@@ -72,38 +72,38 @@
  */
 
 /**
- * @typedef {Object} OraclePrivateParameters
+ * @typedef {object} OraclePrivateParameters
  * @property {OracleHandler} oracleHandler
  */
 
 /**
- * @typedef {Object} OracleInitializationFacet
+ * @typedef {object} OracleInitializationFacet
  * @property {(privateParams: OraclePrivateParameters
  * ) => OracleCreatorFacet} initialize
  */
 
 /**
- * @typedef {Object} OracleStartFnResult
+ * @typedef {object} OracleStartFnResult
  * @property {OracleInitializationFacet} creatorFacet
  * @property {OraclePublicFacet} publicFacet
  * @property {Instance} instance
  */
 
 /**
- * @typedef {Object} OracleKit
+ * @typedef {object} OracleKit
  * @property {OracleCreatorFacet} creatorFacet
  * @property {OraclePublicFacet} publicFacet
  * @property {Instance} instance
  */
 
 /**
- * @typedef {Object} OracleReply
+ * @typedef {object} OracleReply
  * @property {any} reply
  * @property {Amount} [requiredFee]
  */
 
 /**
- * @typedef {Object} OracleHandler
+ * @typedef {object} OracleHandler
  * @property {(query: any, fee: Amount) => Promise<OracleReply>} onQuery
  * Callback to reply to a query
  * @property {(query: any, reason: any) => void} onError

--- a/packages/zoe/src/contracts/types.js
+++ b/packages/zoe/src/contracts/types.js
@@ -1,41 +1,41 @@
 /**
- * @typedef {Object} SellItemsPublicFacet
+ * @typedef {object} SellItemsPublicFacet
  * @property {() => Issuer} getItemsIssuer
  * @property {() => Amount} getAvailableItems
  *
- * @typedef {Object} SellItemsCreatorOnly
+ * @typedef {object} SellItemsCreatorOnly
  * @property {() => Promise<Invitation>} makeBuyerInvitation
  *
  * @typedef {SellItemsPublicFacet & SellItemsCreatorOnly} SellItemsCreatorFacet
  */
 
 /**
- * @typedef {Object} SellItemsParameters
+ * @typedef {object} SellItemsParameters
  * @property {Record<string, any>} customValueProperties
  * @property {number} count
  * @property {Issuer} moneyIssuer
  * @property {Installation} sellItemsInstallation
  * @property {Amount} pricePerItem
  *
- * @typedef {Object} SellItemsResult
+ * @typedef {object} SellItemsResult
  * @property {UserSeat} sellItemsCreatorSeat
  * @property {SellItemsCreatorFacet} sellItemsCreatorFacet
  * @property {Instance} sellItemsInstance
  * @property {SellItemsPublicFacet} sellItemsPublicFacet
  *
- * @typedef {Object} MintAndSellNFTCreatorFacet
+ * @typedef {object} MintAndSellNFTCreatorFacet
  * @property {(sellParams: SellItemsParameters) => Promise<SellItemsResult>} sellTokens
  * @property {() => Issuer} getIssuer
  */
 
 /**
- * @typedef {Object} AutomaticRefundPublicFacet
+ * @typedef {object} AutomaticRefundPublicFacet
  * @property {() => bigint} getOffersCount
  * @property {() => Promise<Invitation>} makeInvitation
  */
 
 /**
- * @typedef {Object} AutoswapPublicFacet
+ * @typedef {object} AutoswapPublicFacet
  * @property {() => Promise<Invitation>} makeSwapInvitation synonym for
  * makeSwapInInvitation
  * @property {() => Promise<Invitation>} makeSwapInInvitation make an invitation

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -107,7 +107,7 @@ export const makeInstanceRecordStorage = () => {
  *
  * @param {Installation} installation
  * @param {Instance} instance
- * @param {Object} customTerms
+ * @param {object} customTerms
  * @param {IssuerKeywordRecord} issuers
  * @param {BrandKeywordRecord} brands
  * @returns {InstanceRecordManager}

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -1,11 +1,11 @@
 // @ts-check
 /**
- * @typedef {Object} SeatData
+ * @typedef {object} SeatData
  * @property {ProposalRecord} proposal
  * @property {Notifier<Allocation>} notifier
  * @property {Allocation} initialAllocation
  * @property {SeatHandle} seatHandle
- * @property {Object=} offerArgs
+ * @property {object=} offerArgs
  */
 
 /**
@@ -17,7 +17,7 @@
  */
 
 /**
- * @typedef {Object} ZoeSeatAdminKit
+ * @typedef {object} ZoeSeatAdminKit
  * @property {UserSeat} userSeat
  * @property {ZoeSeatAdmin} zoeSeatAdmin
  * @property {Notifier<Allocation>} notifier
@@ -41,7 +41,7 @@
  */
 
 /**
- * @typedef {Object} ZoeSeatAdmin
+ * @typedef {object} ZoeSeatAdmin
  * @property {(allocation: Allocation) => void} replaceAllocation
  * @property {ZoeSeatAdminExit} exit
  * @property {ShutdownWithFailure} fail called with the reason
@@ -53,9 +53,9 @@
  */
 
 /**
- * @typedef {Object} HandleOfferResult
+ * @typedef {object} HandleOfferResult
  * @property {Promise<any>} offerResultP
- * @property {Object} exitObj
+ * @property {object} exitObj
  */
 
 /**
@@ -63,19 +63,19 @@
  * depending on whether the seat comes from a normal offer or a
  * request by the contract for an "empty" seat.
  *
- * @typedef {Object} InstanceAdmin
+ * @typedef {object} InstanceAdmin
  * @property {() => void} assertAcceptingOffers
  * @property {(invitationHandle: InvitationHandle,
  *     initialAllocation: Allocation,
  *     proposal: ProposalRecord,
- *     offerArgs?: Object,
+ *     offerArgs?: object,
  * ) => UserSeat } makeUserSeat
  * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {() => Instance} getInstance
- * @property {() => Object} getPublicFacet
+ * @property {() => object} getPublicFacet
  * @property {() => IssuerKeywordRecord} getIssuers
  * @property {() => BrandKeywordRecord} getBrands
- * @property {() => Object} getTerms
+ * @property {() => object} getTerms
  * @property {() => Installation} getInstallationForInstance
  * @property {(completion: Completion) => void} exitAllSeats
  * @property {ShutdownWithFailure} failAllSeats
@@ -87,7 +87,7 @@
  * depending on whether the seat comes from a normal offer or a
  * request by the contract for an "empty" seat.
  *
- * @typedef {Object} HandleOfferObj
+ * @typedef {object} HandleOfferObj
  * @property {(invitationHandle: InvitationHandle,
  *             zoeSeatAdmin: ZoeSeatAdmin,
  *             seatData: SeatData,
@@ -103,7 +103,7 @@
  */
 
 /**
- * @typedef {Object} ZoeInstanceAdmin
+ * @typedef {object} ZoeInstanceAdmin
  * @property {ZoeInstanceAdminMakeInvitation} makeInvitation
  * @property {(issuerP: ERef<Issuer>,
  *             keyword: Keyword
@@ -155,13 +155,13 @@
  */
 
 /**
- * @typedef {Object} SeatHandleAllocation
+ * @typedef {object} SeatHandleAllocation
  * @property {SeatHandle} seatHandle
  * @property {Allocation} allocation
  */
 
 /**
- * @typedef {Object} ZoeMint
+ * @typedef {object} ZoeMint
  * @property {() => IssuerRecord} getIssuerRecord
  * @property {(totalToMint: Amount) => void} mintAndEscrow
  * @property {(totalToBurn: Amount) => void} withdrawAndBurn
@@ -172,13 +172,13 @@
  */
 
 /**
- * @typedef {Object} ZCFRoot
+ * @typedef {object} ZCFRoot
  * @property {ExecuteContract} executeContract
  *
- * @typedef {Object} ExecuteContractResult
- * @property {Object} creatorFacet
+ * @typedef {object} ExecuteContractResult
+ * @property {object} creatorFacet
  * @property {Promise<Invitation>} creatorInvitation
- * @property {Object} publicFacet
+ * @property {object} publicFacet
  * @property {HandleOfferObj} handleOfferObj
  */
 
@@ -190,7 +190,7 @@
  * @param {ERef<ZoeInstanceAdmin>} zoeInstanceAdmin
  * @param {InstanceRecord} instanceRecordFromZoe
  * @param {IssuerRecords} issuerStorageFromZoe
- * @param {Object=} privateArgs
+ * @param {object=} privateArgs
  * @returns {Promise<ExecuteContractResult>}
  */
 
@@ -202,7 +202,7 @@
  */
 
 /**
- * @typedef {Object} ExitObj
+ * @typedef {object} ExitObj
  * @property {() => void} exit
  */
 
@@ -212,12 +212,12 @@
 
 /**
  * @typedef RootAndAdminNode
- * @property {Object} root
+ * @property {object} root
  * @property {AdminNode} adminNode
  */
 
 /**
- * @typedef {Object} AdminNode
+ * @typedef {object} AdminNode
  * A powerful object that can be used to terminate the vat in which a contract
  * is running, to get statistics, or to be notified when it terminates.
  *
@@ -314,7 +314,7 @@
  */
 
 /**
- * @typedef {Object} InstanceRecordManager
+ * @typedef {object} InstanceRecordManager
  * @property {AddIssuerToInstanceRecord} addIssuerToInstanceRecord
  * @property {GetInstanceRecord} getInstanceRecord
  * @property {InstanceRecordManagerGetTerms} getTerms

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -17,7 +17,7 @@
  */
 
 /**
- * @typedef {Object} StandardTerms
+ * @typedef {object} StandardTerms
  * @property {IssuerKeywordRecord} issuers - record with
  * keywords keys, issuer values
  * @property {BrandKeywordRecord} brands - record with keywords
@@ -25,14 +25,14 @@
  *
  * @typedef {StandardTerms & Record<string, any>} AnyTerms
  *
- * @typedef {Object} InstanceRecord
+ * @typedef {object} InstanceRecord
  * @property {Installation} installation
  * @property {Instance} instance
  * @property {AnyTerms} terms - contract parameters
  
  *
  * @template {AssetKind} [K=AssetKind]
- * @typedef {Object} IssuerRecord
+ * @typedef {object} IssuerRecord
  * @property {Brand<K>} brand
  * @property {Issuer<K>} issuer
  * @property {K} assetKind

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -74,7 +74,7 @@
  */
 
 /**
- * @typedef {Object} ZoeInstanceStorageManager
+ * @typedef {object} ZoeInstanceStorageManager
  * @property {InstanceRecordManagerGetTerms} getTerms
  * @property {InstanceRecordManagerGetInstallationForInstance} getInstallationForInstance
  * @property {InstanceRecordGetIssuers} getIssuers
@@ -89,7 +89,7 @@
  * @property {DeleteInstanceAdmin} deleteInstanceAdmin
  * @property {ZoeInstanceAdminMakeInvitation} makeInvitation
  * @property {Issuer} invitationIssuer
- * @property {Object} root of a RootAndAdminNode
+ * @property {object} root of a RootAndAdminNode
  * @property {AdminNode} adminNode of a RootAndAdminNode
  */
 
@@ -101,7 +101,7 @@
  *
  * @callback MakeZoeInstanceStorageManager
  * @param {Installation} installation
- * @param {Object} customTerms
+ * @param {object} customTerms
  * @param {IssuerKeywordRecord} uncleanIssuerKeywordRecord
  * @param {Instance} instance
  * @returns {ZoeInstanceStorageManager}

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -1,7 +1,7 @@
 /// <reference types="ses"/>
 
 /**
- * @typedef {Object} ZoeService
+ * @typedef {object} ZoeService
  *
  * Zoe provides a framework for deploying and working with smart
  * contracts. It is accessed as a long-lived and well-trusted service
@@ -69,7 +69,7 @@
 /**
  * @callback GetPublicFacet
  * @param {ERef<Instance>} instanceP
- * @returns {Promise<Object>}
+ * @returns {Promise<object>}
  */
 
 /**
@@ -169,13 +169,13 @@
  * @param {ERef<Invitation<OR>>} invitation
  * @param {Proposal=} proposal
  * @param {PaymentPKeywordRecord=} paymentKeywordRecord
- * @param {Object=} offerArgs
+ * @param {object=} offerArgs
  * @returns {Promise<UserSeat<OR>>} seat
  */
 
 /**
- * @template {Object} [OR=any]
- * @typedef {Object} UserSeat
+ * @template {object} [OR=any]
+ * @typedef {object} UserSeat
  * @property {() => Promise<Allocation>} getCurrentAllocation
  * TODO remove getCurrentAllocation query
  * @property {() => Promise<ProposalRecord>} getProposal
@@ -206,7 +206,7 @@
  */
 
 /**
- * @typedef {Object} Waker
+ * @typedef {object} Waker
  * @property {() => void} wake
  */
 
@@ -215,22 +215,22 @@
  */
 
 /**
- * @typedef {Object} Timer
+ * @typedef {object} Timer
  * @property {(deadline: Deadline, wakerP: ERef<Waker>) => void} setWakeup
  */
 
 /**
- * @typedef {Object} OnDemandExitRule
+ * @typedef {object} OnDemandExitRule
  * @property {null} onDemand
  */
 
 /**
- * @typedef {Object} WaivedExitRule
+ * @typedef {object} WaivedExitRule
  * @property {null} waived
  */
 
 /**
- * @typedef {Object} AfterDeadlineExitRule
+ * @typedef {object} AfterDeadlineExitRule
  * @property {{timer:Timer, deadline:Deadline}} afterDeadline
  */
 
@@ -250,7 +250,7 @@
  */
 
 /**
- * @typedef {Object} VatAdminSvc
+ * @typedef {object} VatAdminSvc
  * @property {(BundleID: id) => Promise<BundleCap>} getBundleCap
  * @property {(name: string) => Promise<BundleCap>} getNamedBundleCap
  * @property {(bundleCap: BundleCap) => Promise<RootAndAdminNode>} createVat
@@ -271,7 +271,7 @@
  */
 
 /**
- * @typedef {Object} StandardInvitationDetails
+ * @typedef {object} StandardInvitationDetails
  * @property {Installation} installation
  * @property {Instance} instance
  * @property {InvitationHandle} handle
@@ -293,13 +293,13 @@
  */
 
 /**
- * @typedef {Object} FeeIssuerConfig
+ * @typedef {object} FeeIssuerConfig
  * @property {string} name
  * @property {AssetKind} assetKind
  * @property {DisplayInfo} displayInfo
  */
 
 /**
- * @typedef {Object} ZoeFeesConfig
+ * @typedef {object} ZoeFeesConfig
  * @property {NatValue} getPublicFacetFee
  */

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -44,8 +44,8 @@ export type ContractOf<S> = StartParams<S> & StartResult<S>;
 type StartContractInstance<C> = (
   installation: Installation<C>,
   issuerKeywordRecord?: IssuerKeywordRecord,
-  terms?: Object,
-  privateArgs?: Object,
+  terms?: object,
+  privateArgs?: object,
 ) => Promise<{
   creatorFacet: C['creatorFacet'];
   publicFacet: C['publicFacet'];
@@ -74,7 +74,7 @@ export type StartInstance = <I extends Installation>(
   installation: I | PromiseLike<I>,
   issuerKeywordRecord?: IssuerKeywordRecord,
   terms?: object,
-  privateArgs?: Object,
+  privateArgs?: object,
 ) => Promise<
   {
     instance: Instance;

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -18,7 +18,7 @@ import '../../../exported.js';
 import '../../../src/contracts/exported.js';
 
 /**
- * @typedef {Object} TestContext
+ * @typedef {object} TestContext
  * @property {ZoeService} zoe
  * @property {(t: ExecutionContext) => Promise<OracleKit>} makePingOracle
  * @property {Amount} feeAmount

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -35,7 +35,7 @@ import {
  */
 
 /**
- * @typedef {Object} TestContext
+ * @typedef {object} TestContext
  * @property {ZoeService} zoe
  * @property {MakeFakePriceOracle} makeFakePriceOracle
  * @property {(POLL_INTERVAL: bigint) => Promise<PriceAggregatorKit & { instance: Instance }>} makeMedianAggregator

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -25,7 +25,7 @@ import '../../../src/contracts/exported.js';
  */
 
 /**
- * @typedef {Object} TestContext
+ * @typedef {object} TestContext
  * @property {ZoeService} zoe
  * @property {MakeFakePriceOracle} makeFakePriceOracle
  * @property {(POLL_INTERVAL: bigint) => Promise<PriceAggregatorKit & { instance: Instance }>} makeMedianAggregator

--- a/packages/zoe/test/unitTests/contracts/test-scaledPriceAuthority.js
+++ b/packages/zoe/test/unitTests/contracts/test-scaledPriceAuthority.js
@@ -26,7 +26,7 @@ import '../../../src/contracts/exported.js';
  */
 
 /**
- * @typedef {Object} TestContext
+ * @typedef {object} TestContext
  * @property {ZoeService} zoe
  * @property {Installation<typeof import('../../../src/contracts/scaledPriceAuthority.js').start>} scaledPriceInstallation
  * @property {Brand} atomBrand

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -28,7 +28,7 @@ const setup = () => {
   const makeSimpleMake = brand => value => AmountMath.make(brand, value);
 
   /**
-   * @typedef {Object} BasicMints
+   * @typedef {object} BasicMints
    * @property {Issuer} moolaIssuer
    * @property {Mint} moolaMint
    * @property {IssuerKit} moolaR

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -28,7 +28,7 @@ const oracleContractPath = `${dirname}/../../src/contracts/oracle.js`;
 const bountyContractPath = `${dirname}/bounty.js`;
 
 /**
- * @typedef {Object} TestContext
+ * @typedef {object} TestContext
  * @property {ZoeService} zoe
  * @property {Installation} oracleInstallation
  * @property {Installation} bountyInstallation

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -15,7 +15,7 @@ import './types.js';
 import '../exported.js';
 
 /**
- * @typedef {Object} FakePriceAuthorityOptions
+ * @typedef {object} FakePriceAuthorityOptions
  * @property {Brand} actualBrandIn
  * @property {Brand} actualBrandOut
  * @property {Array<number>} [priceList]

--- a/packages/zoe/tools/internal-types.js
+++ b/packages/zoe/tools/internal-types.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @typedef {Object} ManualTimerAdmin
+ * @typedef {object} ManualTimerAdmin
  * @property {ManualTimerTick} tick
  */
 

--- a/packages/zoe/tools/priceAuthorityRegistry.js
+++ b/packages/zoe/tools/priceAuthorityRegistry.js
@@ -6,12 +6,12 @@ import { assert, details as X } from '@agoric/assert';
 import { Far } from '@endo/marshal';
 
 /**
- * @typedef {Object} Deleter
+ * @typedef {object} Deleter
  * @property {() => void} delete
  */
 
 /**
- * @typedef {Object} PriceAuthorityRegistryAdmin
+ * @typedef {object} PriceAuthorityRegistryAdmin
  * @property {(pa: ERef<PriceAuthority>,
  *             brandIn: Brand,
  *             brandOut: Brand,
@@ -20,7 +20,7 @@ import { Far } from '@endo/marshal';
  */
 
 /**
- * @typedef {Object} PriceAuthorityRegistry A price authority that is a facade
+ * @typedef {object} PriceAuthorityRegistry A price authority that is a facade
  * for other backing price authorities registered for a given asset and price
  * brand
  * @property {PriceAuthority} priceAuthority
@@ -32,7 +32,7 @@ import { Far } from '@endo/marshal';
  */
 export const makePriceAuthorityRegistry = () => {
   /**
-   * @typedef {Object} PriceAuthorityRecord A record indicating a registered
+   * @typedef {object} PriceAuthorityRecord A record indicating a registered
    * price authority.  We put a box around the priceAuthority to ensure the
    * deleter doesn't delete the wrong thing.
    * @property {ERef<PriceAuthority>} priceAuthority the sub-authority for a

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {Object} PriceQuote
+ * @typedef {object} PriceQuote
  * @property {Amount<'set'>} quoteAmount
  * Amount whose value is a PriceQuoteValue
  * @property {ERef<Payment<'set'>>} quotePayment
@@ -13,7 +13,7 @@
  */
 
 /**
- * @typedef {Object} PriceDescription
+ * @typedef {object} PriceDescription
  * A description of a single quote
  * @property {Amount} amountIn
  * The amount supplied to a trade
@@ -39,25 +39,25 @@
  */
 
 /**
- * @typedef {Object} PriceAuthorityAdmin
+ * @typedef {object} PriceAuthorityAdmin
  * @property {(createQuote: PriceQuoteCreate) => Promise<void>} fireTriggers
  */
 
 /**
- * @typedef {Object} PriceAuthorityKit
+ * @typedef {object} PriceAuthorityKit
  * @property {PriceAuthority} priceAuthority
  * @property {PriceAuthorityAdmin} adminFacet
  */
 
 /**
- * @typedef {Object} MutableQuote
+ * @typedef {object} MutableQuote
  * @property {(reason?: any) => void} cancel
  * @property {(amountIn: Amount, amountOut: Amount) => void} updateLevel
  * @property {() => ERef<PriceQuote>} getPromise
  */
 
 /**
- * @typedef {Object} PriceAuthority
+ * @typedef {object} PriceAuthority
  * An object that mints PriceQuotes and handles
  * triggers and notifiers for changes in the price
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -1569,14 +1569,14 @@
   resolved "https://registry.yarnpkg.com/@endo/zip/-/zip-0.2.25.tgz#0e6ed3dfb42bac40ce6e1d90dea0f01cc1ee801b"
   integrity sha512-HzjHt3xIDSTLz0ldBmsS2F7sKLIxb67y29fJzeBMqUigGwYvF6mHeV38/5YClc3POVJYdfARgFs2FufRVFOzrA==
 
-"@es-joy/jsdoccomment@~0.20.1":
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.20.1.tgz#fe89f435f045ae5aaf89c7a4df3616c03e9d106e"
-  integrity sha512-oeJK41dcdqkvdZy/HctKklJNkt/jh+av3PZARrZEl+fs/8HaHeeYoAvEwOV0u5I6bArTF17JEsTZMY359e/nfQ==
+"@es-joy/jsdoccomment@~0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.29.0.tgz#527c7eefadeaf5c5d0c3b2721b5fa425d2119e98"
+  integrity sha512-4yKy5t+/joLihG+ei6CCU6sc08sjUdEdXCQ2U+9h9VP13EiqHQ4YMgDC18ys/AsLdJDBX3KRx/AWY6PR7hn52Q==
   dependencies:
-    comment-parser "1.3.0"
+    comment-parser "1.3.1"
     esquery "^1.4.0"
-    jsdoc-type-pratt-parser "~2.2.3"
+    jsdoc-type-pratt-parser "~3.0.1"
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -6361,7 +6361,12 @@ commander@^6.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
-comment-parser@1.3.0, comment-parser@^1.2.0:
+comment-parser@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
+  integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
+
+comment-parser@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.0.tgz#68beb7dbe0849295309b376406730cd16c719c44"
   integrity sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==
@@ -7183,7 +7188,7 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -7203,6 +7208,13 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -8167,18 +8179,17 @@ eslint-plugin-jest@^24.1.0, eslint-plugin-jest@^25.3.0, eslint-plugin-jest@^26.0
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
-eslint-plugin-jsdoc@^37.9.7:
-  version "37.9.7"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz#ef46141aa2e5fcbb89adfa658eef8126435e9eac"
-  integrity sha512-8alON8yYcStY94o0HycU2zkLKQdcS+qhhOUNQpfONHHwvI99afbmfpYuPqf6PbLz5pLZldG3Te5I0RbAiTN42g==
+eslint-plugin-jsdoc@^39.2.9:
+  version "39.2.9"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.9.tgz#bc351de403f1862f1ef8c440d12dedc28e74cbbb"
+  integrity sha512-gaPYJT94rWlWyQcisQyyEJHtLaaJqN4baFlLCEr/LcXVibS9wzQTL2dskqk327ggwqQopR+Xecu2Lng1IJ9Ypw==
   dependencies:
-    "@es-joy/jsdoccomment" "~0.20.1"
-    comment-parser "1.3.0"
-    debug "^4.3.3"
+    "@es-joy/jsdoccomment" "~0.29.0"
+    comment-parser "1.3.1"
+    debug "^4.3.4"
     escape-string-regexp "^4.0.0"
     esquery "^1.4.0"
-    regextras "^0.8.0"
-    semver "^7.3.5"
+    semver "^7.3.7"
     spdx-expression-parse "^3.0.1"
 
 eslint-plugin-jsx-a11y@^6.3.1, eslint-plugin-jsx-a11y@^6.4.0, eslint-plugin-jsx-a11y@^6.5.1:
@@ -11268,10 +11279,10 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdoc-type-pratt-parser@~2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.3.tgz#3910cd0120054a512a73942d644ef1eb5a9df6e9"
-  integrity sha512-QPyxq62Q8veBSDtDrWmqaEPjSCeknUV9dH/OAGt3q9an8qC8UQDqitQiw1NvoMskIESpoRZ6qzt4H3rlK0xo8A==
+jsdoc-type-pratt-parser@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.0.1.tgz#ccbc7a4180bc8748af64d2cc431aaa92f88175bb"
+  integrity sha512-vqMCdAFVIiFhVgBYE/X8naf3L/7qiJsaYWTfUJZZZ124dR3OUz9HrmaMUGpYIYAN4VSuodf6gIZY0e8ktPw9cg==
 
 jsdom@^16.4.0:
   version "16.7.0"
@@ -15596,11 +15607,6 @@ regexpu-core@^4.7.1:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
-regextras@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/regextras/-/regextras-0.8.0.tgz#ec0f99853d4912839321172f608b544814b02217"
-  integrity sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==
-
 registry-auth-token@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.0.tgz#1d37dffda72bbecd0f581e4715540213a65eb7da"
@@ -16170,6 +16176,13 @@ semver@^7.0.0, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
## Description

The version we have would error when doing `yarn install` under Node 18. (not in its list of supported engines)

The latest version changed https://github.com/gajus/eslint-plugin-jsdoc/pull/855 to align more with TypeScript. This fixes those warnings too (mostly with `yarn lint-fix` and then manually a few stragglers)


### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

--