### PR TITLE
test(swingset): improve tests on result promises that appear in args

### DIFF
--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -972,6 +972,15 @@ function build(
     let notifySuccess = () => undefined;
     let notifyFailure = () => undefined;
     if (result) {
+      // If this vpid was imported earlier (and we just now became the
+      // decider), we'll have a local Promise object for it, and
+      // importedPromisesByPromiseID will have the resolve/reject
+      // functions to handle a dispatch.notify. If it gets imported
+      // later, we'll wind up in the same state.  TODO: it would be
+      // nice to forward that promise to `res`, so locally-sent
+      // messages are queued locally instead of being sent into the
+      // kernel (and back again after the kernel hears our
+      // syscall.resolve).
       insistVatType('promise', result);
       deciderVPIDs.add(result);
       // eslint-disable-next-line no-use-before-define


### PR DESCRIPTION
This doesn't change any behavior, but asserts that we're more tolerant
of messages whose arguments reference their own result
promise. Liveslots cannot generate these, and the kernel refuses to
accept them from non-pipelining vats, but remote systems might
construct such messages. So comms accept them, the kernel must not
kill comms when they appear, and they must be translatable and
deliverable to other vats. And liveslots must not choke when they
arrive.

The original concern of #5189 is a non-issue for liveslots-based vats,
because HandledPromise and E automatically harden the arguments before
the caller can mutate them. But this provides test coverage beyond
that point.

closes #5189
