### PR TITLE
ci: only notify if integration job fails on master

### DIFF
--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -112,7 +112,7 @@ jobs:
           path: chaintest/results
 
       - name: notify on failure
-        if: failure()
+        if: failure() && github.event_name != 'pull_request'
         uses: ./.github/actions/notify-status
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -114,3 +114,12 @@ jobs:
           AGORIC_INIT_OPTIONS: '["--dapp-branch=${{steps.get-branch.outputs.result}}"]'
           # Try to avoid hitting a pessimal Actions output rate-limitation.
           SOLO_MAX_DEBUG_LENGTH: '1024'
+
+      - name: notify on failure
+        if: failure() && github.event_name != 'pull_request'
+        uses: ./.github/actions/notify-status
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          from: ${{ secrets.NOTIFY_EMAIL_FROM }}
+          to: ${{ secrets.NOTIFY_EMAIL_TO }}
+          password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}


### PR DESCRIPTION
Avoid pinging slack and emails if the deployment job fails in PRs, as the author should be directly notified through Github. In case the PR is merged regardless of the failed job (bypassed, or not required), the jobs should re-run on the merge commit in the "push" branches or tags, and will then trigger the email/slack notifications.

Add notifications to the integration-test job.