### PR TITLE
feat: add governance for RECORDS as a parameter type

### DIFF
--- a/packages/governance/src/constants.js
+++ b/packages/governance/src/constants.js
@@ -14,10 +14,9 @@ export const ParamTypes = /** @type {const} */ ({
   NAT: 'nat',
   RATIO: 'ratio',
   STRING: 'string',
-
-  // passable record
-  RECORD: 'record',
+  PASSABLE_RECORD: 'record',
   UNKNOWN: 'unknown',
 });
+
 harden(ParamTypes);
 /** @typedef {typeof ParamTypes[keyof typeof ParamTypes]} ParamType */

--- a/packages/governance/src/constants.js
+++ b/packages/governance/src/constants.js
@@ -14,6 +14,9 @@ export const ParamTypes = /** @type {const} */ ({
   NAT: 'nat',
   RATIO: 'ratio',
   STRING: 'string',
+
+  // passable record
+  RECORD: 'record',
   UNKNOWN: 'unknown',
 });
 harden(ParamTypes);

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { Far } from '@endo/marshal';
+import { Far, passStyleOf } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
 import { Nat } from '@agoric/nat';
@@ -44,6 +44,7 @@ const assertElectorateMatches = (paramManager, governedParams) => {
  * @property {(name: string, value: Invitation) => Promise<ParamManagerBuilder>} addInvitation
  * @property {(name: string, value: bigint) => ParamManagerBuilder} addNat
  * @property {(name: string, value: Ratio) => ParamManagerBuilder} addRatio
+ * @property {(name: string, value: Object) => ParamManagerBuilder} addRecord
  * @property {(name: string, value: string) => ParamManagerBuilder} addString
  * @property {(name: string, value: any) => ParamManagerBuilder} addUnknown
  * @property {() => AnyParamManager} build
@@ -153,6 +154,16 @@ const makeParamManagerBuilder = zoe => {
   const addRatio = (name, value, builder) => {
     const assertBrandedRatio = makeAssertBrandedRatio(name, value);
     buildCopyParam(name, value, assertBrandedRatio, ParamTypes.RATIO);
+    return builder;
+  };
+
+  /** @type {(name: string, value: string, builder: ParamManagerBuilder) => ParamManagerBuilder} */
+  const addRecord = (name, value, builder) => {
+    const assertRecord = v => {
+      passStyleOf(v);
+      assert.typeof(v, 'object');
+    };
+    buildCopyParam(name, value, assertRecord, ParamTypes.RECORD);
     return builder;
   };
 
@@ -327,6 +338,7 @@ const makeParamManagerBuilder = zoe => {
       getInvitationAmount: name => getTypedParam(ParamTypes.INVITATION, name),
       getNat: name => getTypedParam(ParamTypes.NAT, name),
       getRatio: name => getTypedParam(ParamTypes.RATIO, name),
+      getRecord: name => getTypedParam(ParamTypes.RECORD, name),
       getString: name => getTypedParam(ParamTypes.STRING, name),
       getUnknown: name => getTypedParam(ParamTypes.UNKNOWN, name),
       getVisibleValue,
@@ -349,6 +361,7 @@ const makeParamManagerBuilder = zoe => {
     addInvitation: (n, v) => addInvitation(n, v, builder),
     addNat: (n, v) => addNat(n, v, builder),
     addRatio: (n, v) => addRatio(n, v, builder),
+    addRecord: (n, v) => addRecord(n, v, builder),
     addString: (n, v) => addString(n, v, builder),
     build: () => makeParamManager(),
   };

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -163,7 +163,7 @@ const makeParamManagerBuilder = zoe => {
       passStyleOf(v);
       assert.typeof(v, 'object');
     };
-    buildCopyParam(name, value, assertRecord, ParamTypes.RECORD);
+    buildCopyParam(name, value, assertRecord, ParamTypes.PASSABLE_RECORD);
     return builder;
   };
 
@@ -338,7 +338,7 @@ const makeParamManagerBuilder = zoe => {
       getInvitationAmount: name => getTypedParam(ParamTypes.INVITATION, name),
       getNat: name => getTypedParam(ParamTypes.NAT, name),
       getRatio: name => getTypedParam(ParamTypes.RATIO, name),
-      getRecord: name => getTypedParam(ParamTypes.RECORD, name),
+      getRecord: name => getTypedParam(ParamTypes.PASSABLE_RECORD, name),
       getString: name => getTypedParam(ParamTypes.STRING, name),
       getUnknown: name => getTypedParam(ParamTypes.UNKNOWN, name),
       getVisibleValue,

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -44,7 +44,7 @@ const assertElectorateMatches = (paramManager, governedParams) => {
  * @property {(name: string, value: Invitation) => Promise<ParamManagerBuilder>} addInvitation
  * @property {(name: string, value: bigint) => ParamManagerBuilder} addNat
  * @property {(name: string, value: Ratio) => ParamManagerBuilder} addRatio
- * @property {(name: string, value: Object) => ParamManagerBuilder} addRecord
+ * @property {(name: string, value: import('@endo/marshal').CopyRecord<unknown>) => ParamManagerBuilder} addRecord
  * @property {(name: string, value: string) => ParamManagerBuilder} addString
  * @property {(name: string, value: any) => ParamManagerBuilder} addUnknown
  * @property {() => AnyParamManager} build
@@ -157,7 +157,7 @@ const makeParamManagerBuilder = zoe => {
     return builder;
   };
 
-  /** @type {(name: string, value: string, builder: ParamManagerBuilder) => ParamManagerBuilder} */
+  /** @type {(name: string, value: import('@endo/marshal').CopyRecord<unknown>, builder: ParamManagerBuilder) => ParamManagerBuilder} */
   const addRecord = (name, value, builder) => {
     const assertRecord = v => {
       passStyleOf(v);

--- a/packages/governance/test/unitTests/test-buildParamManager.js
+++ b/packages/governance/test/unitTests/test-buildParamManager.js
@@ -296,6 +296,64 @@ test('Ratio', async t => {
   );
 });
 
+test('Record', async t => {
+  const epRecord = harden({
+    A1: 'Magical Mystery Tour',
+    A2: 'Your Mother Should Know',
+    B: 'I Am the Walrus',
+    C1: 'The Fool on the Hill',
+    C2: 'Flying',
+    D: 'Blue Jay Way',
+  });
+  const paramManager = makeParamManagerBuilder()
+    .addRecord('BestEP', epRecord)
+    .build();
+  t.is(paramManager.getRecord('BestEP'), epRecord);
+
+  const replacement = harden({
+    A1: "Wouldn't It Be Nice",
+    A2: "Don't Talk",
+    B1: 'God Only Knows',
+    B2: "I Know There's an Answer",
+  });
+  await paramManager.updateParams({ BestEP: replacement });
+  t.is(paramManager.getRecord('BestEP'), replacement);
+
+  const brokenRecord = {
+    A1: 'Long Tall Sally',
+    A2: 'I Call Your Name',
+    B1: 'Slow Down',
+    B2: 'Matchbox',
+  };
+  await t.throwsAsync(
+    () => paramManager.updateParams({ BestEP: brokenRecord }),
+    {
+      message:
+        'Cannot pass non-frozen objects like {"A1":"Long Tall Sally","A2":"I Call Your Name","B1":"Slow Down","B2":"Matchbox"}. Use harden()',
+    },
+  );
+
+  await t.throwsAsync(
+    () =>
+      paramManager.updateParams({
+        duration: '2:37',
+      }),
+    {
+      message: 'setters[name] is not a function',
+    },
+  );
+
+  await t.throwsAsync(
+    () =>
+      paramManager.updateParams({
+        BestEP: '2:37',
+      }),
+    {
+      message: '"2:37" must be an object',
+    },
+  );
+});
+
 test('Strings', async t => {
   const paramManager = makeParamManagerBuilder()
     .addNat('Acres', 50n)


### PR DESCRIPTION
closes: #5216
see-also: #5239 

## Description

Add the ability for governance to manage passable records.

### Security Considerations

Allows more distinction in parameter types.

### Documentation Considerations

Nothing special

### Testing Considerations

Includes tests parallel to other parameter types.
