### PR TITLE
Store metadata for each virtual object kind

### DIFF
--- a/packages/SwingSet/src/liveslots/vatstore-usage.md
+++ b/packages/SwingSet/src/liveslots/vatstore-usage.md
@@ -94,6 +94,11 @@ Durable Kinds are defined just like virtual Kinds, but they use a different cons
 The KindHandle is a durable virtual object of a special internal Kind. This is the first Kind allocated, so it generally gets Kind ID "1", and the handles will get vrefs of `o+1/N`.
 
 
+# Kind Metadata
+
+For each virtual object kind that is defined we store a metadata record for purposes of scanning directly through the defined kinds when a vat is stopped or upgraded.  For durable kinds this record is stored in `vom.dkind.${kindID}`; for non-durable kinds it is stored in `vom.vkind.${kindID}`.  Currently this metadata takes the form of a JSON-serialized record `{ kindID, tag }`, where the `kindID` property is the kind ID (redundantly) and `tag` is the tag string as provided in the `defineKind` or `makeKindHandle` call.
+
+
 # Virtual/Durable Collections (aka Stores)
 
 Liveslots provides a handful of "virtual collection" types to vats, to store high-cardinality data on disk rather than in RAM. These are also known as a `Store`. They provide limited range queries and offer a single fixed sort index: numbers sort as usual, BigInts sort as usual but separate from numbers, strings sort lexicographically by UTF-8 encoding, and object references sort by insertion order).

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -746,6 +746,7 @@ export function makeVirtualObjectManager(
 
   function defineKind(tag, init, behavior, options) {
     const kindID = `${allocateExportID()}`;
+    syscall.vatstoreSet(`vom.vkind.${kindID}`, JSON.stringify({ kindID, tag }));
     return defineKindInternal(
       kindID,
       tag,
@@ -759,6 +760,7 @@ export function makeVirtualObjectManager(
 
   function defineKindMulti(tag, init, behavior, options) {
     const kindID = `${allocateExportID()}`;
+    syscall.vatstoreSet(`vom.vkind.${kindID}`, JSON.stringify({ kindID, tag }));
     return defineKindInternal(
       kindID,
       tag,
@@ -785,7 +787,7 @@ export function makeVirtualObjectManager(
 
   function reanimateDurableKindID(vobjID) {
     const { subid: kindID } = parseVatSlot(vobjID);
-    const raw = syscall.vatstoreGet(`vom.kind.${kindID}`);
+    const raw = syscall.vatstoreGet(`vom.dkind.${kindID}`);
     assert(raw, X`unknown kind ID ${kindID}`);
     const durableKindDescriptor = harden(JSON.parse(raw));
     const kindHandle = Far('kind', {});
@@ -806,7 +808,7 @@ export function makeVirtualObjectManager(
     kindDescriptors.set(kindHandle, durableKindDescriptor);
     registerValue(kindIDvref, kindHandle, false);
     syscall.vatstoreSet(
-      `vom.kind.${kindID}`,
+      `vom.dkind.${kindID}`,
       JSON.stringify(durableKindDescriptor),
     );
     return kindHandle;
@@ -847,9 +849,9 @@ export function makeVirtualObjectManager(
   }
 
   function insistAllDurableKindsReconnected() {
-    // identify all user-defined durable kinds by iterating `vom.kind.*`
+    // identify all user-defined durable kinds by iterating `vom.dkind.*`
     const missing = [];
-    const prefix = 'vom.kind.';
+    const prefix = 'vom.dkind.';
     let [key, value] = syscall.vatstoreGetAfter('', prefix);
     while (key) {
       const descriptor = JSON.parse(value);

--- a/packages/SwingSet/test/stores/test-storeGC/gc-helpers.js
+++ b/packages/SwingSet/test/stores/test-storeGC/gc-helpers.js
@@ -530,7 +530,7 @@ export function validateInit(v) {
   validate(v, matchVatstoreGet('deadPromises', NONE));
   validate(v, matchVatstoreDelete('deadPromises'));
   validate(v, matchVatstoreGetAfter('', 'vc.3.', 'vc.3.{', [NONE, NONE]));
-  validate(v, matchVatstoreGetAfter('', 'vom.kind.', NONE, [NONE, NONE]));
+  validate(v, matchVatstoreGetAfter('', 'vom.dkind.', NONE, [NONE, NONE]));
 }
 
 export function validateDropHeld(v, rp, rc, es) {

--- a/packages/SwingSet/test/test-baggage.js
+++ b/packages/SwingSet/test/test-baggage.js
@@ -120,7 +120,7 @@ test.serial('exercise baggage', async t => {
   validate(v, matchVatstoreGet('deadPromises', NONE));
   validate(v, matchVatstoreDelete('deadPromises'));
   validate(v, matchVatstoreGetAfter('', 'vc.3.', 'vc.3.{', [NONE, NONE]));
-  validate(v, matchVatstoreGetAfter('', 'vom.kind.', NONE, [NONE, NONE]));
+  validate(v, matchVatstoreGetAfter('', 'vom.dkind.', NONE, [NONE, NONE]));
   validateDone(v);
 
   const rp = await dispatchMessage('doSomething', capargs([]));

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -411,6 +411,7 @@ test('virtual object gc', async t => {
     'v1.vs.vom.rc.o+6/1': '1',
     'v1.vs.vom.rc.o+6/2': '1',
     'v1.vs.vom.rc.o+6/3': '1',
+    'v1.vs.vom.vkind.10': '{"kindID":"10","tag":"thing"}',
     'v1.vs.watchedPromiseTableID': 'o+6/3',
     'v1.vs.watcherTableID': 'o+6/2',
   });


### PR DESCRIPTION
Previously we only stored metadata for durable virtual object kinds, as this metadata is only strictly required for restart after an upgrade.  This PR changes things so we also store this metadata for non-durable kinds (in a separately prefixed portion of the store) so that the non-durable virtual objects can efficiently be scanned for deletion during either `stop-vat` or as part of an incremental cleanup that runs after upgrade.

Closes #5262
