### PR TITLE
ci: require integration tests only before merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,22 @@ queue_rules:
   - name: main
     conditions:
       - base=master
-      # - check-success=mergify-merge-queue-test
+      # Require integration tests before merging only
+      - or:
+       - check-success=deployment-test
+       - check-neutral=deployment-test
+       - check-skipped=deployment-test
+       - label=bypass:integration
+      - or:
+       - check-success=getting-started (link-cli)
+       - check-neutral=getting-started (link-cli)
+       - check-skipped=getting-started (link-cli)
+       - label=bypass:integration
+      - or:
+       - check-success=getting-started (local-npm)
+       - check-neutral=getting-started (local-npm)
+       - check-skipped=getting-started (local-npm)
+       - label=bypass:integration
 
 pull_request_rules:
   - name: merge to master


### PR DESCRIPTION
refs: #5254

## Description

Instead of adding integration tests to branch protection, add them as required for the mergify merge queue. This should allow the PR to be embarked on the merge train before these long tests complete, so that if a merge or rebase is necessary, we don't wait for nothing.

### Security Considerations

None, these tests will ultimately run

### Testing Considerations

We'll see how this goes and I'll fast follow in case of issues.
