### PR TITLE
chore: Better document use of StorageAPI

### DIFF
--- a/packages/SwingSet/docs/state.md
+++ b/packages/SwingSet/docs/state.md
@@ -88,10 +88,10 @@ boundary).
 ## Transactions
 
 This implies a string-to-string key-value store, with a two-level write-back
-cache. We define **StorageAPI** as a set of functions `{ has, getKeys, get,
-set, delete }`, with the usual semantics (`has` takes a string and returns a
-boolean, `get` returns `undefined` for missing objects). `getKeys(start,
-end)` returns an iterator of sorted keys `start <= key < end`.
+cache. We define **StorageAPI** (typed as **KVStore**) as a set of functions
+`{ has, getKeys, get, set, delete }`, with the usual semantics (`has` takes a
+string and returns a boolean, `get` returns `undefined` for missing objects).
+`getKeys(start, end)` returns an iterator of sorted keys `start <= key < end`.
 
 We also define a **HostDB** as an object with functions `{ has, getKeys, get,
 applyBatch }`. The batch is a list of `{op: 'set', key, value}` or `{op:
@@ -127,7 +127,7 @@ construction of these objects starting from the host side:
   then wrapped with some helper methods: `{ enumeratePrefixedKeys,
   getPrefixedValues, deletePrefixedKeys }` to produce the
   `enhancedCrankBuffer`, which provides both StorageAPI plus the helper
-  methods.
+  methods (typed as **KVStorePlus**).
 * All `kernelKeeper` and `vatKeeper` operations use the
   `enhancedCrankBuffer`. They are unaware of Crank or Block boundaries, nor
   can they sense the operation of the read cache.

--- a/packages/SwingSet/src/controller/hostStorage.js
+++ b/packages/SwingSet/src/controller/hostStorage.js
@@ -2,10 +2,11 @@
 import { initSwingStore } from '@agoric/swing-store';
 
 /*
-The "Storage API" is a set of functions { has, getKeys, get, set, delete } that
-work on string keys and accept string values.  A lot of kernel-side code
-expects to get an object which implements the Storage API, which is usually
-associated with a write-back buffer wrapper.
+StorageAPI is a set of functions { has, getKeys, get, set, delete }
+that work on string keys and accept string values
+(cf. packages/SwingSet/docs/state.md#transactions). A lot of kernel-side
+code expects to get a StorageAPI object, which is usually associated with
+a write-back buffer wrapper.
 
 A more sophisticated host will build a hostDB that writes changes to disk
 directly.

--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -1,8 +1,9 @@
 import { assert } from '@agoric/assert';
 import { insistStorageAPI } from '../../lib/storageAPI.js';
 
-// We wrap a provided object implementing the Storage API (has/get/set/delete/getKeys)
-// and add some convenience methods.
+// We wrap a provided object implementing StorageAPI methods { has, getKeys,
+// get, set, delete } (cf. packages/SwingSet/docs/state.md#transactions) and
+// add some convenience methods.
 
 // NOTE: There's a lot of suspenders-and-belt paranoia here because we have to
 // be vewy, vewy careful with host-realm objects.  This raises a question
@@ -54,7 +55,7 @@ function* mergeUtf16SortedIterators(it1, it2) {
  * Create and return a crank buffer, which wraps a storage object with logic
  * that buffers any mutations until told to commit them.
  *
- * @param {*} kvStore  The storage object that this crank buffer will be based on.
+ * @param {*} kvStore  The StorageAPI object that this crank buffer will be based on.
  * @param {CreateSHA256}  createSHA256
  * @param { (key: string) => boolean } isConsensusKey
  * @returns {*} an object {

--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -55,7 +55,7 @@ function* mergeUtf16SortedIterators(it1, it2) {
  * Create and return a crank buffer, which wraps a storage object with logic
  * that buffers any mutations until told to commit them.
  *
- * @param {*} kvStore  The StorageAPI object that this crank buffer will be based on.
+ * @param {KVStore} kvStore  The StorageAPI object that this crank buffer will be based on.
  * @param {CreateSHA256}  createSHA256
  * @param { (key: string) => boolean } isConsensusKey
  * @returns {*} an object {

--- a/packages/SwingSet/src/lib/storageAPI.js
+++ b/packages/SwingSet/src/lib/storageAPI.js
@@ -1,9 +1,9 @@
 import { assert, details as X } from '@agoric/assert';
 
 /**
- * Assert function to ensure that something expected to be a storage object
- * actually implements the storage API.  It should have methods `has`,
- * `getKeys`, `get`, `set`, and `delete`.
+ * Assert function to ensure that an object implements the StorageAPI
+ * interface: methods { has, getKeys, get, set, delete }
+ * (cf. packages/SwingSet/docs/state.md#transactions).
  *
  * @param {*} kvStore  The object to be tested
  *
@@ -19,10 +19,9 @@ export function insistStorageAPI(kvStore) {
 }
 
 /**
- * Assert function to ensure that something expected to be an enhanced storage
- * object actually implements the enhanced storage API.  It should be a storage
- * object that additionally has the methods `enumeratePrefixedKeys`,
- * `getPrefixedValues`, and `deletePrefixedKeys`.
+ * Assert function to ensure that an object implements the enhanced storage API.
+ * (StorageAPI plus methods { enumeratePrefixedKeys, getPrefixedValues,
+ * deletePrefixedKeys }), also known as "KVStorePlus".
  *
  * @param {*} kvStore  The object to be tested
  *

--- a/packages/access-token/src/json-store.js
+++ b/packages/access-token/src/json-store.js
@@ -26,10 +26,11 @@ function safeUnlink(filePath) {
 }
 
 /**
- * Create a new instance of a RAM-based implementation of the Storage API.
+ * Create a new instance of a RAM-based StorageAPI implementation.
  *
- * The "Storage API" is a set of functions { has, getKeys, get, set, delete }
- * that work on string keys and accept string values.
+ * StorageAPI is a set of functions { has, getKeys, get, set, delete }
+ * that work on string keys and accept string values
+ * (cf. packages/SwingSet/docs/state.md#transactions).
  *
  * returns an object: {
  *   storage,  // the storage API object itself

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -49,7 +49,7 @@ export function makeSnapStoreIO() {
  * }} StreamStore
  *
  * @typedef {{
- *   kvStore: KVStore, // a key-value storage API object to load and store data
+ *   kvStore: KVStore, // a key-value StorageAPI object to load and store data
  *   streamStore: StreamStore, // a stream-oriented API object to append and read streams of data
  *   commit: () => void,  // commit changes made since the last commit
  *   close: () => void,   // shutdown the store, abandoning any uncommitted changes


### PR DESCRIPTION
## Description

Consistently use and reference documentation regarding **StorageAPI** (typed as `KVStore`) and "enhanced storage API" (typed as `KVStorePlus`).

### Security Considerations

n/a

### Documentation Considerations

It would be nice to eliminate one concept from each pair, but I'm not taking that step in this PR.

### Testing Considerations

n/a