### PR TITLE
fix: provide provide, a get-or-make for mapStores

### DIFF
--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -75,6 +75,8 @@ export {
   makeScalarMapStore as makeStore, // Deprecated legacy
 } from './stores/scalarMapStore.js';
 
+export { provide } from './stores/store-utils.js';
+
 // /////////////////////// Deprecated Legacy ///////////////////////////////////
 
 // export default as well as makeLegacy* only for compatibility

--- a/packages/store/src/stores/store-utils.js
+++ b/packages/store/src/stores/store-utils.js
@@ -86,3 +86,23 @@ export const makeCurrentKeysKit = (
   });
 };
 harden(makeCurrentKeysKit);
+
+/**
+ * Call `provide` to get or make the value associated with the key.
+ * If there already is one, return that. Otherwise,
+ * call `makeValue(key)`, remember it as the value for
+ * that key, and return it.
+ *
+ * @template K,V
+ * @param {MapStore<K,V>} mapStore
+ * @param {K} key
+ * @param {(key: K) => V} makeValue
+ * @returns {V}
+ */
+export const provide = (mapStore, key, makeValue) => {
+  if (!mapStore.has(key)) {
+    mapStore.init(key, makeValue(key));
+  }
+  return mapStore.get(key);
+};
+harden(provide);

--- a/packages/store/test/test-store.js
+++ b/packages/store/test/test-store.js
@@ -9,6 +9,7 @@ import { makeLegacyWeakMap } from '../src/legacy/legacyWeakMap.js';
 import { makeScalarMapStore } from '../src/stores/scalarMapStore.js';
 import { makeScalarSetStore } from '../src/stores/scalarSetStore.js';
 import { makeScalarWeakMapStore } from '../src/stores/scalarWeakMapStore.js';
+import { provide } from '../src/stores/store-utils.js';
 
 import '../src/types.js';
 
@@ -226,4 +227,14 @@ test('iteration succeeds with concurrent deletion', t => {
     }
   }
   t.deepEqual(seenValues, [0, 1, 2, 3, 5]);
+});
+
+test('provide for mapStores', t => {
+  const m = makeScalarMapStore('provider');
+  let i = 1;
+  const makeValue = k => `${k} ${(i += 1)}`;
+  t.is(provide(m, 'a', makeValue), 'a 2');
+  t.is(provide(m, 'b', makeValue), 'b 3');
+  t.is(provide(m, 'a', makeValue), 'a 2');
+  t.is(provide(m, 'b', makeValue), 'b 3');
 });


### PR DESCRIPTION
Call `provide(mapStore, key, makeValue)` to get or make the value associated with the key.
If there already is one, return that. Otherwise,
call `makeValue(key)`, remember it as the value for
that key, and return it.

This is related to the upsert or emplace of https://github.com/tc39/proposal-upsert . 

As shown at https://gist.github.com/warner/95594e60b194673420bd515ab8d3662c#file-util-js , durability patterns make heavy use of such a `provide` notion. 

Note to reviewers: perhaps we should instead make this an instance method of all mapStores. But this involves changing all the mapStore implementations and types, which I wish to avoid for the moment. Please comment on this, but separately from other comments.