### PR TITLE
ci: cancel other jobs on pull-requests only

### DIFF
--- a/.github/workflows/pre-check-integration.yml
+++ b/.github/workflows/pre-check-integration.yml
@@ -30,7 +30,7 @@ jobs:
       - id: step1
         uses: fkirc/skip-duplicate-actions@master
         with:
-          cancel_others: 'true'
+          cancel_others: "${{ github.event_name == 'pull_request' }}"
           concurrent_skipping: 'same_content_newer'
       - id: step2
         name: Wait for concurrent run conclusion


### PR DESCRIPTION
## Description

#5254 added the ability to cancel previously running integration jobs, with the intent to cancel outdated jobs
#5256 did the same for pull request jobs

However the integration jobs were cancelled regardless of the branch on which the job was running. Only integration jobs on pull requests should be canceled and it's perfectly valid for multiple master and beta branches integration jobs to be running concurrently.

### Security Considerations

Make sure we have integration running fully on all master commits.

### Testing Considerations

Hard to test but I have 100% confidence this will work
