### PR TITLE
refactor: Add a buffered StorageAPI helper

### DIFF
--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -1,7 +1,7 @@
 // @ts-check
 
-import { assert, details as X } from '@agoric/assert';
-import { insistStorageAPI } from '../../lib/storageAPI.js';
+import { assert } from '@agoric/assert';
+import { insistStorageAPI, makeBufferedStorage } from '../../lib/storageAPI.js';
 
 // We wrap a provided object implementing StorageAPI methods { has, getKeys,
 // get, set, delete } (cf. packages/SwingSet/docs/state.md#transactions) and
@@ -14,88 +14,6 @@ import { insistStorageAPI } from '../../lib/storageAPI.js';
 // nature of that parameter, perhaps we should establish some naming convention
 // that signals that the object could be foreign and thus deserving of
 // xenophobia.
-
-/**
- * Given two iterators over sequences of unique strings sorted in ascending
- * order lexicographically by UTF-16 code unit, produce a new iterator that will
- * output the ascending sequence of unique strings from their merged output.
- *
- * @param { Iterator } it1
- * @param { Iterator } it2
- *
- * @yields any
- */
-function* mergeUtf16SortedIterators(it1, it2) {
-  /** @type {IteratorResult<any> | null} */
-  let v1 = null;
-  /** @type {IteratorResult<any> | null} */
-  let v2 = null;
-  /** @type {IteratorResult<any> | null} */
-  let vrest = null;
-  /** @type {Iterator<any> | null} */
-  let itrest = null;
-
-  try {
-    v1 = it1.next();
-    v2 = it2.next();
-    while (!v1.done && !v2.done) {
-      if (v1.value < v2.value) {
-        const result = v1.value;
-        v1 = it1.next();
-        yield result;
-      } else if (v1.value === v2.value) {
-        const result = v1.value;
-        v1 = it1.next();
-        v2 = it2.next();
-        yield result;
-      } else {
-        const result = v2.value;
-        v2 = it2.next();
-        yield result;
-      }
-    }
-
-    itrest = v1.done ? it2 : it1;
-    vrest = v1.done ? v2 : v1;
-    v1 = null;
-    v2 = null;
-
-    while (!vrest.done) {
-      const result = vrest.value;
-      vrest = itrest.next();
-      yield result;
-    }
-  } finally {
-    const errors = [];
-    try {
-      if (vrest && !vrest.done && itrest && itrest.return) {
-        itrest.return();
-      }
-    } catch (e) {
-      errors.push(e);
-    }
-    try {
-      if (v1 && !v1.done && it1.return) {
-        it1.return();
-      }
-    } catch (e) {
-      errors.push(e);
-    }
-    try {
-      if (v2 && !v2.done && it2.return) {
-        it2.return();
-      }
-    } catch (e) {
-      errors.push(e);
-    }
-    if (errors.length) {
-      const err = assert.error(X`Merged iterator failed to close cleanly`);
-      for (const e of errors) {
-        assert.note(err, X`Caused by ${e}`);
-      }
-    }
-  }
-}
 
 /**
  * Create and return a crank buffer, which wraps a storage object with logic
@@ -120,84 +38,16 @@ export function buildCrankBuffer(
   function resetCrankhash() {
     crankhasher = createSHA256();
   }
-
-  // To avoid confusion, additions and deletions are prevented from sharing
-  // the same key at any given time.
-  const additions = new Map();
-  const deletions = new Set();
   resetCrankhash();
 
-  const crankBuffer = {
-    has(key) {
-      if (additions.has(key)) {
-        return true;
-      }
-      if (deletions.has(key)) {
-        return false;
-      }
-      return kvStore.has(key);
-    },
-
-    *getKeys(start, end) {
-      // Warning: this function introduces a consistency risk that callers must
-      // take into account in their usage of it.  If keys are added to the store
-      // within the range from `start` to `end` while iteration is in progress,
-      // these additions will not be visible to this iterator and thus not
-      // reflected in the stream of keys it returns.  Callers who might be
-      // vulnerable to any resulting data inconsistencies thus introduced must
-      // take measures to protect themselves, either by avoiding making such
-      // changes while iterating or by arranging to invalidate and reconstruct
-      // the iterator when such changes are made.  At this layer of abstraction,
-      // the store does not possess the necessary knowledge to protect the
-      // caller from these kinds of risks, as the nature of the risks themselves
-      // varies depending on what the caller is trying to do.  This API should
-      // not be made available to user (i.e., vat) code.  Rather, it is intended
-      // as a low-level mechanism to use in implementating higher level storage
-      // abstractions that are expected to provide their own consistency
-      // protections as appropriate to their own circumstances.
-
-      assert.typeof(start, 'string');
-      assert.typeof(end, 'string');
-
-      // Find additions within the query range for use during iteration.
-      const added = [];
-      for (const k of additions.keys()) {
-        if ((start === '' || start <= k) && (end === '' || k < end)) {
-          added.push(k);
-        }
-      }
-      added.sort();
-
-      for (const k of mergeUtf16SortedIterators(
-        added.values(),
-        kvStore.getKeys(start, end),
-      )) {
-        if ((start === '' || start <= k) && (end === '' || k < end)) {
-          if (!deletions.has(k)) {
-            yield k;
-          }
-        }
-      }
-    },
-
-    get(key) {
-      assert.typeof(key, 'string');
-      if (additions.has(key)) {
-        return additions.get(key);
-      }
-      if (deletions.has(key)) {
-        return undefined;
-      }
-      return kvStore.get(key);
-    },
-
-    set(key, value) {
-      assert.typeof(key, 'string');
-      assert.typeof(value, 'string');
+  const {
+    kvStore: crankBuffer,
+    commit,
+    abort,
+  } = makeBufferedStorage(kvStore, {
+    onPendingSet(key, value) {
       const keyType = getKeyType(key);
       assert(keyType !== 'invalid');
-      additions.set(key, value);
-      deletions.delete(key);
       if (keyType === 'consensus') {
         crankhasher.add('add');
         crankhasher.add('\n');
@@ -207,13 +57,9 @@ export function buildCrankBuffer(
         crankhasher.add('\n');
       }
     },
-
-    delete(key) {
-      assert.typeof(key, 'string');
+    onPendingDelete(key) {
       const keyType = getKeyType(key);
       assert(keyType !== 'invalid');
-      additions.delete(key);
-      deletions.add(key);
       if (keyType === 'consensus') {
         crankhasher.add('delete');
         crankhasher.add('\n');
@@ -221,7 +67,8 @@ export function buildCrankBuffer(
         crankhasher.add('\n');
       }
     },
-  };
+    onAbort: resetCrankhash,
+  });
 
   /**
    * Flush any buffered mutations to the underlying storage, and update the
@@ -230,17 +77,14 @@ export function buildCrankBuffer(
    * @returns { { crankhash: string, activityhash: string } }
    */
   function commitCrank() {
-    for (const [key, value] of additions) {
-      kvStore.set(key, value);
-    }
-    for (const key of deletions) {
-      kvStore.delete(key);
-    }
-    additions.clear();
-    deletions.clear();
+    // Flush the buffered operations.
+    commit();
+
+    // Calculate the resulting crankhash and reset for the next crank.
     const crankhash = crankhasher.finish();
     resetCrankhash();
 
+    // Digest the old activityhash and new crankhash into the new activityhash.
     let oldActivityhash = kvStore.get('activityhash');
     if (oldActivityhash === undefined) {
       oldActivityhash = '';
@@ -252,22 +96,15 @@ export function buildCrankBuffer(
     hasher.add('\n');
     hasher.add(crankhash);
     hasher.add('\n');
+
+    // Store the new activityhash.
     const activityhash = hasher.finish();
     kvStore.set('activityhash', activityhash);
 
     return { crankhash, activityhash };
   }
 
-  /**
-   * Discard any buffered mutations.
-   */
-  function abortCrank() {
-    additions.clear();
-    deletions.clear();
-    resetCrankhash();
-  }
-
-  return harden({ crankBuffer, commitCrank, abortCrank });
+  return harden({ crankBuffer, commitCrank, abortCrank: abort });
 }
 
 /**

--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -84,11 +84,13 @@ export function buildCrankBuffer(
     const crankhash = crankhasher.finish();
     resetCrankhash();
 
-    // Digest the old activityhash and new crankhash into the new activityhash.
+    // Get the old activityhash directly from (unbuffered) backing storage.
     let oldActivityhash = kvStore.get('activityhash');
     if (oldActivityhash === undefined) {
       oldActivityhash = '';
     }
+
+    // Digest the old activityhash and new crankhash into the new activityhash.
     const hasher = createSHA256();
     hasher.add('activityhash');
     hasher.add('\n');
@@ -97,7 +99,7 @@ export function buildCrankBuffer(
     hasher.add(crankhash);
     hasher.add('\n');
 
-    // Store the new activityhash.
+    // Store the new activityhash directly into (unbuffered) backing storage.
     const activityhash = hasher.finish();
     kvStore.set('activityhash', activityhash);
 

--- a/packages/SwingSet/src/lib/storageAPI.js
+++ b/packages/SwingSet/src/lib/storageAPI.js
@@ -154,22 +154,14 @@ export function makeBufferedStorage(kvStore, listeners = {}) {
   const buffered = {
     has(key) {
       assert.typeof(key, 'string');
-      if (additions.has(key)) {
-        return true;
-      }
-      if (deletions.has(key)) {
-        return false;
-      }
+      if (additions.has(key)) return true;
+      if (deletions.has(key)) return false;
       return kvStore.has(key);
     },
     get(key) {
       assert.typeof(key, 'string');
-      if (additions.has(key)) {
-        return additions.get(key);
-      }
-      if (deletions.has(key)) {
-        return undefined;
-      }
+      if (additions.has(key)) return additions.get(key);
+      if (deletions.has(key)) return undefined;
       const value = kvStore.get(key);
       if (onGet !== undefined) onGet(key, value);
       return value;

--- a/packages/SwingSet/src/lib/storageAPI.js
+++ b/packages/SwingSet/src/lib/storageAPI.js
@@ -1,5 +1,7 @@
 import { assert, details as X } from '@agoric/assert';
 
+// XXX Do these "StorageAPI" functions belong in their own package?
+
 /**
  * Assert function to ensure that an object implements the StorageAPI
  * interface: methods { has, getKeys, get, set, delete }
@@ -39,4 +41,219 @@ export function insistEnhancedStorageAPI(kvStore) {
   ]) {
     assert(n in kvStore, X`kvStore.${n} is missing, cannot use`);
   }
+}
+
+/**
+ * Given two iterators over sequences of unique strings sorted in ascending
+ * order lexicographically by UTF-16 code unit, produce a new iterator that will
+ * output the ascending sequence of unique strings from their merged output.
+ *
+ * @param { Iterator } it1
+ * @param { Iterator } it2
+ *
+ * @yields any
+ */
+function* mergeUtf16SortedIterators(it1, it2) {
+  /** @type {IteratorResult<any> | null} */
+  let v1 = null;
+  /** @type {IteratorResult<any> | null} */
+  let v2 = null;
+  /** @type {IteratorResult<any> | null} */
+  let vrest = null;
+  /** @type {Iterator<any> | null} */
+  let itrest = null;
+
+  try {
+    v1 = it1.next();
+    v2 = it2.next();
+    while (!v1.done && !v2.done) {
+      if (v1.value < v2.value) {
+        const result = v1.value;
+        v1 = it1.next();
+        yield result;
+      } else if (v1.value > v2.value) {
+        const result = v2.value;
+        v2 = it2.next();
+        yield result;
+      } else {
+        // Each iterator produced the same value; consume it from both.
+        const result = v1.value;
+        v1 = it1.next();
+        v2 = it2.next();
+        yield result;
+      }
+    }
+
+    itrest = v1.done ? it2 : it1;
+    vrest = v1.done ? v2 : v1;
+    v1 = null;
+    v2 = null;
+
+    while (!vrest.done) {
+      const result = vrest.value;
+      vrest = itrest.next();
+      yield result;
+    }
+  } finally {
+    const errors = [];
+    try {
+      if (vrest && !vrest.done && itrest && itrest.return) {
+        itrest.return();
+      }
+    } catch (e) {
+      errors.push(e);
+    }
+    try {
+      if (v1 && !v1.done && it1.return) {
+        it1.return();
+      }
+    } catch (e) {
+      errors.push(e);
+    }
+    try {
+      if (v2 && !v2.done && it2.return) {
+        it2.return();
+      }
+    } catch (e) {
+      errors.push(e);
+    }
+    if (errors.length) {
+      const err = assert.error(X`Merged iterator failed to close cleanly`);
+      for (const e of errors) {
+        assert.note(err, X`Caused by ${e}`);
+      }
+    }
+  }
+}
+
+/**
+ * Create a StorageAPI object that buffers writes to a wrapped StorageAPI object
+ * until told to commit (or abort) them.
+ *
+ * @param {KVStore} kvStore  The StorageAPI object to wrap
+ * @param {{
+ *   onGet?: (key: string, value: string) => void, // a callback invoked after getting a value from kvStore
+ *   onPendingSet?: (key: string, value: string) => void, // a callback invoked after a new uncommitted value is set
+ *   onPendingDelete?: (key: string) => void, // a callback invoked after a new uncommitted delete
+ *   onCommit?: () => void, // a callback invoked after pending operations have been committed
+ *   onAbort?: () => void, // a callback invoked after pending operations have been aborted
+ * }?} listeners  Optional callbacks to be invoked when respective events occur
+ *
+ * @returns {{kvStore: KVStore, commit: () => void, abort: () => void}}
+ */
+export function makeBufferedStorage(kvStore, listeners = {}) {
+  insistStorageAPI(kvStore);
+
+  const { onGet, onPendingSet, onPendingDelete, onCommit, onAbort } = listeners;
+
+  // To avoid confusion, additions and deletions are prevented from sharing
+  // the same key at any given time.
+  const additions = new Map();
+  const deletions = new Set();
+
+  const buffered = {
+    has(key) {
+      assert.typeof(key, 'string');
+      if (additions.has(key)) {
+        return true;
+      }
+      if (deletions.has(key)) {
+        return false;
+      }
+      return kvStore.has(key);
+    },
+    get(key) {
+      assert.typeof(key, 'string');
+      if (additions.has(key)) {
+        return additions.get(key);
+      }
+      if (deletions.has(key)) {
+        return undefined;
+      }
+      const value = kvStore.get(key);
+      if (onGet !== undefined) onGet(key, value);
+      return value;
+    },
+    set(key, value) {
+      assert.typeof(key, 'string');
+      additions.set(key, value);
+      deletions.delete(key);
+      if (onPendingSet !== undefined) onPendingSet(key, value);
+    },
+    delete(key) {
+      assert.typeof(key, 'string');
+      additions.delete(key);
+      deletions.add(key);
+      if (onPendingDelete !== undefined) onPendingDelete(key);
+    },
+
+    /**
+     * Generator function that returns an iterator over all the keys within a
+     * given range, in lexicographical order by UTF-16 code unit.
+     *
+     * Warning: this function introduces consistency risks that callers must
+     * take into account. Results do not include include keys added during
+     * iteration.  This layer of abstraction lacks the knowledge necessary to
+     * protect callers, as the nature of the risks varies depending on what a
+     * caller is trying to do.  This API should not be made available to user
+     * vat code.  Rather, it is intended as a low-level mechanism to use in
+     * implementating higher level storage abstractions that are expected to
+     * provide their own consistency protections as appropriate to their own
+     * circumstances.
+     *
+     * @param {string} start  Start of the key range of interest (inclusive).  An empty
+     *    string indicates a range from the beginning of the key set.
+     * @param {string} end  End of the key range of interest (exclusive).  An empty string
+     *    indicates a range through the end of the key set.
+     *
+     * @yields {string} an iterator for the keys from start <= key < end
+     *
+     * @throws if either parameter is not a string.
+     */
+    *getKeys(start, end) {
+      assert.typeof(start, 'string');
+      assert.typeof(end, 'string');
+
+      // Merge keys reported by the backing store and a snapshot of in-range
+      // additions into a single duplicate-free iterator.
+      const added = [];
+      for (const k of additions.keys()) {
+        if ((start === '' || start <= k) && (end === '' || k < end)) {
+          added.push(k);
+        }
+      }
+      // Note that this implicitly compares keys lexicographically by UTF-16
+      // code unit (e.g., "\u{1D306}" _precedes_ "\u{FFFD}").
+      // If kvStore.getKeys() results are not in ascending order subject to the
+      // same comparison, then output may include duplicates.
+      added.sort();
+      const merged = mergeUtf16SortedIterators(
+        added.values(),
+        kvStore.getKeys(start, end),
+      );
+
+      for (const k of merged) {
+        if (!deletions.has(k)) {
+          yield k;
+        }
+      }
+    },
+  };
+  function commit() {
+    for (const [key, value] of additions) {
+      kvStore.set(key, value);
+    }
+    for (const key of deletions) {
+      kvStore.delete(key);
+    }
+    additions.clear();
+    deletions.clear();
+    if (onCommit !== undefined) onCommit();
+  }
+  function abort() {
+    additions.clear();
+    deletions.clear();
+    if (onAbort !== undefined) onAbort();
+  }
+  return { kvStore: buffered, commit, abort };
 }

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -133,7 +133,7 @@ const makeChainQueue = (call, prefix = '') => {
     push: obj => {
       const tail = storage.get('tail') || 0;
       storage.set('tail', tail + 1);
-      storage.set(tail, obj);
+      storage.set(`${tail}`, obj);
       storage.commit();
     },
     /** @type {Iterable<unknown>} */

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -4,6 +4,7 @@ import {
   importMailbox,
   exportMailbox,
 } from '@agoric/swingset-vat/src/devices/mailbox/mailbox.js';
+import { makeBufferedStorage } from '@agoric/swingset-vat/src/lib/storageAPI.js';
 
 import { assert, details as X } from '@agoric/assert';
 import { makeSlogSenderFromModule } from '@agoric/telemetry';
@@ -38,22 +39,16 @@ const makeChainStorage = (call, prefix = '', options = {}) => {
 
   const { fromChainShape, toChainShape } = options;
 
-  let cache = new Map();
-  let changedKeys = new Set();
+  // In addition to the wrapping write buffer, keep a simple cache of
+  // read values for has and get.
+  let cache;
+  function resetCache() {
+    cache = new Map();
+  }
+  resetCache();
   const storage = {
     has(key) {
-      // Fetch the value to avoid a second round trip for any followup get.
       return storage.get(key) !== undefined;
-    },
-    set(key, obj) {
-      if (cache.get(key) !== obj) {
-        cache.set(key, obj);
-        changedKeys.add(key);
-      }
-    },
-    delete(key) {
-      cache.delete(key);
-      changedKeys.add(key);
     },
     get(key) {
       if (cache.has(key)) return cache.get(key);
@@ -67,35 +62,49 @@ const makeChainStorage = (call, prefix = '', options = {}) => {
           ? chainShapeValue
           : fromChainShape(chainShapeValue);
       cache.set(key, value);
-      // We need to add this in case the caller mutates the state, as in
-      // mailbox.js, which mutates on basically every get.
-      changedKeys.add(key);
       return value;
     },
-    commit() {
-      for (const key of changedKeys.keys()) {
-        const value = cache.get(key);
-        const chainShapeValue =
-          value === undefined || !toChainShape ? value : toChainShape(value);
-        const valueStr = value === undefined ? '' : stringify(chainShapeValue);
-        call(
-          stringify({
-            method: 'set',
-            key: `${prefix}${key}`,
-            value: valueStr,
-          }),
-        );
-      }
-      // Reset our state.
-      storage.abort();
+    set(key, value) {
+      // Set the value and cache it until the next commit or abort (which is
+      // expected immediately, since the buffered wrapper only calls set
+      // *during* a commit).
+      cache.set(key, value);
+      const chainShapeValue =
+        value === undefined || !toChainShape ? value : toChainShape(value);
+      const valueStr = value === undefined ? '' : stringify(chainShapeValue);
+      call(
+        stringify({
+          method: 'set',
+          key: `${prefix}${key}`,
+          value: valueStr,
+        }),
+      );
     },
-    abort() {
-      // Just reset our state.
-      cache = new Map();
-      changedKeys = new Set();
+    delete(key) {
+      // Deletion in chain storage manifests as set-to-undefined.
+      storage.set(key, undefined);
+    },
+    // eslint-disable-next-line require-yield
+    *getKeys(_start, _end) {
+      throw new Error('not implemented');
     },
   };
-  return storage;
+  const {
+    kvStore: buffered,
+    commit,
+    abort,
+  } = makeBufferedStorage(storage, {
+    // Enqueue a write of any retrieved value, to handle callers like mailbox.js
+    // that expect local mutations to be automatically written back.
+    onGet(key, value) {
+      buffered.set(key, value);
+    },
+
+    // Reset the read cache upon commit or abort.
+    onCommit: resetCache,
+    onAbort: resetCache,
+  });
+  return { ...buffered, commit, abort };
 };
 
 /**

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -147,8 +147,9 @@ const makeChainQueue = (call, prefix = '') => {
             if (done) return { done };
             if (head < tail) {
               // Still within the queue.
-              const value = storage.get(head);
-              storage.delete(head);
+              const headKey = `${head}`;
+              const value = storage.get(headKey);
+              storage.delete(headKey);
               head += 1;
               return { value, done };
             }


### PR DESCRIPTION
As suggested at https://github.com/Agoric/agoric-sdk/pull/5258#discussion_r863276862

## Description

This PR extends #5292, and lays some groundwork for #4558. c67df20001ff1a034a50d3807e0ce1e687492c7f is the most relevant commit.

### Security Considerations

None that I can see.

### Documentation Considerations

As commented, I wonder if StorageAPI functions should be extracted into their own module.

### Testing Considerations

`makeBufferedStorage` really should be tested. Any pointers on a good analog?