### PR TITLE
fix(deployment): Update CI script

### DIFF
--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -101,7 +101,7 @@ jobs:
           /usr/src/agoric-sdk/packages/deployment/scripts/capture-integration-results.sh "${{ job.status == 'failure' }}"
 
           # Tear down the nodes.
-          echo yes | /usr/src/agoric-sdk/packages/deployment/scripts/setup.sh destroy
+          echo yes | /usr/src/agoric-sdk/packages/deployment/scripts/setup.sh destroy || true
         env:
           NETWORK_NAME: chaintest
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION

refs: #5301

## Description

Print details on swingstore mismatch failures
Ensure that teardown doesn't cause job failure
`tar` xsnap-trace folders to avoid large number of files slowing CI


### Testing Considerations

Tested extensively locally, will force integrations on this PR