### PR TITLE
Prevent bootstrap coreProposal path nondeterminism

### DIFF
--- a/packages/deploy-script-support/src/coreProposalBehavior.js
+++ b/packages/deploy-script-support/src/coreProposalBehavior.js
@@ -19,7 +19,7 @@ export const permits = {
  * @param {[string, ...unknown[]]} opts.getManifestCall
  * @param {typeof import('@endo/far').E} opts.E
  * @param {(...args: unknown[]) => void} [opts.log]
- * @param {(ref: string) => Promise<unknown>} [opts.restoreRef]
+ * @param {(ref: unknown) => Promise<unknown>} [opts.restoreRef]
  * @returns {(vatPowers: unknown) => Promise<unknown>}
  */
 export const makeCoreProposalBehavior = ({

--- a/packages/deploy-script-support/src/extract-proposal.js
+++ b/packages/deploy-script-support/src/extract-proposal.js
@@ -45,52 +45,63 @@ const pathResolve = (...paths) => {
  * proposals to run at chain bootstrap for scenarios such as sim-chain.
  * @param {FilePath} [dirname]
  * @param {typeof makeEnactCoreProposalsFromBundleCap} [makeEnactCoreProposals]
+ * @param {(i: number) => number} [getSequenceForProposal]
  */
 export const extractCoreProposalBundles = async (
   coreProposals,
   dirname = '.',
   makeEnactCoreProposals = makeEnactCoreProposalsFromBundleCap,
+  getSequenceForProposal,
 ) => {
+  if (!getSequenceForProposal) {
+    // Deterministic proposal numbers.
+    getSequenceForProposal = i => i;
+  }
+
   dirname = pathResolve(dirname);
   dirname = await fs.promises
     .stat(dirname)
     .then(stbuf => (stbuf.isDirectory() ? dirname : path.dirname(dirname)));
 
+  /** @type {Map<{ bundleID?: string }, { source: string, bundle?: string }>} */
+  const bundleHandleToAbsolutePaths = new Map();
+
   const bundleToSource = new Map();
   const extracted = await Promise.all(
     coreProposals.map(async (initCore, i) => {
-      /** @type {Set<{ source: string, bundle?: string, bundleID?: string }>} */
-      const bundleHandles = new Set();
-
       console.log(`Parsing core proposal:`, initCore);
+      assert(getSequenceForProposal);
+      const thisProposalSequence = getSequenceForProposal(i);
       const initPath = pathResolve(dirname, initCore);
       const initDir = path.dirname(initPath);
       const ns = await import(initPath);
-      const install = (srcPath, bundlePath) => {
-        const absSrc = pathResolve(initDir, srcPath);
-        const bundleHandle = { source: absSrc };
+      const install = (srcSpec, bundlePath) => {
+        const absoluteSrc = pathResolve(initDir, srcSpec);
+        const bundleHandle = {};
+        const absolutePaths = { source: absoluteSrc };
         if (bundlePath) {
-          const absBundle = pathResolve(initDir, bundlePath);
-          const oldSource = bundleToSource.get(absBundle);
+          const absoluteBundle = pathResolve(initDir, bundlePath);
+          absolutePaths.bundle = absoluteBundle;
+          const oldSource = bundleToSource.get(absoluteBundle);
           if (oldSource) {
             assert.equal(
               oldSource,
-              absSrc,
-              X`${bundlePath} already installed from ${oldSource}, now ${absSrc}`,
+              absoluteSrc,
+              X`${bundlePath} already installed from ${oldSource}, now ${absoluteSrc}`,
             );
           } else {
-            bundleToSource.set(absBundle, absSrc);
+            bundleToSource.set(absoluteBundle, absoluteSrc);
           }
-          bundleHandle.bundle = absBundle;
         }
-        // Don't harden since we need to set the bundleID later.
-        bundleHandles.add(bundleHandle);
+        // Don't harden the bundleHandle since we need to set the bundleID on
+        // its unique identity later.
+        bundleHandleToAbsolutePaths.set(bundleHandle, harden(absolutePaths));
         return bundleHandle;
       };
       const publishRef = async handleP => {
         const handle = await handleP;
         assert(
-          bundleHandles.has(handle),
+          bundleHandleToAbsolutePaths.has(handle),
           X`${handle} not in installed bundles`,
         );
         return handle;
@@ -98,8 +109,8 @@ export const extractCoreProposalBundles = async (
       const proposal = await ns.defaultProposalBuilder({ publishRef, install });
 
       // Add the proposal bundle handles in sorted order.
-      const bundleSpecEntries = [...bundleHandles.values()]
-        .sort(({ source: a }, { source: b }) => {
+      const bundleSpecEntries = [...bundleHandleToAbsolutePaths.entries()]
+        .sort(([_hnda, { source: a }], [_hndb, { source: b }]) => {
           if (a < b) {
             return -1;
           }
@@ -108,11 +119,16 @@ export const extractCoreProposalBundles = async (
           }
           return 0;
         })
-        .map((handle, j) => {
-          handle.bundleID = `coreProposal${i}_${j}`;
+        .map(([handle, absolutePaths], j) => {
+          // Transform the bundle handle identity into just a bundleID reference.
+          handle.bundleID = `coreProposal${thisProposalSequence}_${j}`;
           harden(handle);
+
           /** @type {[string, { sourceSpec: string }]} */
-          const specEntry = [handle.bundleID, { sourceSpec: handle.source }];
+          const specEntry = [
+            handle.bundleID,
+            { sourceSpec: absolutePaths.source },
+          ];
           return specEntry;
         });
 
@@ -121,15 +137,20 @@ export const extractCoreProposalBundles = async (
       const { sourceSpec, getManifestCall } = await deeplyFulfilled(
         harden(proposal),
       );
-      const absSrc = pathResolve(initDir, sourceSpec);
       const behaviorBundleHandle = harden({
-        bundleID: `coreProposal${i}_behaviors`,
-        source: absSrc,
+        bundleID: `coreProposal${thisProposalSequence}_behaviors`,
       });
+      const behaviorAbsolutePaths = harden({
+        source: pathResolve(initDir, sourceSpec),
+      });
+      bundleHandleToAbsolutePaths.set(
+        behaviorBundleHandle,
+        behaviorAbsolutePaths,
+      );
 
       bundleSpecEntries.unshift([
         behaviorBundleHandle.bundleID,
-        { sourceSpec: behaviorBundleHandle.source },
+        { sourceSpec: behaviorAbsolutePaths.source },
       ]);
 
       return harden({
@@ -161,6 +182,10 @@ const makeCoreProposalBehavior = ${makeCoreProposalBehavior};
 (${makeEnactCoreProposals})({ makeCoreProposalArgs, E });
 `;
 
-  console.debug('created bundles from proposals:', coreProposals, bundles);
-  return { bundles, code: defangAndTrim(code) };
+  // console.debug('created bundles from proposals:', coreProposals, bundles);
+  return {
+    bundles,
+    code: defangAndTrim(code),
+    bundleHandleToAbsolutePaths,
+  };
 };

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -82,8 +82,7 @@ export const bridgeCoreEval = async allPowers => {
                   const globals = harden({
                     ...allPowers.modules,
                     ...farExports,
-                    assert,
-                    console,
+                    ...endowments,
                   });
 
                   // Evaluate the code in the context of the globals.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Validators on the `agoricdev-11` network were getting AppHash errors for block 1.  As it turned out, the diverging validators had their `agoric-sdk` living in a different directory (such as /root/agoric-sdk) than the instagoric validators (/usr/src/agoric-sdk).

It turns out that the bootstrap `coreProposal` code, specifically `extractCoreProposalBundles`, was putting the absolute source and bundle paths into the proposal that was being evaluated on chain in block 1.  This resulted in divergent behaviour when those paths were different, because the core proposal code was attached to the first bootstrap message delivery, and hence recorded in the bootstrap vat's transcript.

The solution is to only record the `bundleID` in the on-chain proposal.  The local paths should only be added to the SwingSet config, since that configuration is outside of consensus.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
Improves resilience by removing local path considerations from the kernel db.  This also prevents a potential privacy leak if validators share their kernel db with other parties.

### Documentation Considerations

No doc concerns.
<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

Manual testing was performed.  Will be tested in a stage network as well by adding a validator with a different path to the coreProposals.
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
