### PR TITLE
fix: array.map that should be array.forEach

### DIFF
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -611,7 +611,7 @@ export default function makeKernelKeeper(
           body: kvStore.get(`${kernelSlot}.data.body`),
           slots: commaSplit(kvStore.get(`${kernelSlot}.data.slots`)),
         };
-        p.data.slots.map(parseKernelSlot);
+        p.data.slots.forEach(parseKernelSlot);
         break;
       default:
         assert.fail(X`unknown state for ${kernelSlot}: ${p.state}`);

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -117,7 +117,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     const vrefs = krefs.map(kref =>
       mapKernelSlotToVatSlot(kref, gcDeliveryMapOpts),
     );
-    krefs.map(kref => vatKeeper.clearReachableFlag(kref, 'dropE'));
+    krefs.forEach(kref => vatKeeper.clearReachableFlag(kref, 'dropE'));
     /** @type { VatDeliveryDropExports } */
     const vatDelivery = harden(['dropExports', vrefs]);
     return vatDelivery;

--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -328,7 +328,7 @@ export function makeCollectionManager(
       currentGenerationNumber += 1;
       const serializedValue = serialize(value);
       if (durable) {
-        serializedValue.slots.map(vref =>
+        serializedValue.slots.forEach(vref =>
           assert(vrm.isDurable(vref), X`value is not durable`),
         );
       }
@@ -344,7 +344,7 @@ export function makeCollectionManager(
           vrm.addReachableVref(vref);
         }
       }
-      serializedValue.slots.map(vrm.addReachableVref);
+      serializedValue.slots.forEach(vrm.addReachableVref);
       syscall.vatstoreSet(keyToDBKey(key), JSON.stringify(serializedValue));
       updateEntryCount(1);
     }
@@ -362,7 +362,7 @@ export function makeCollectionManager(
       }
       const after = serialize(harden(value));
       if (durable) {
-        after.slots.map(vref =>
+        after.slots.forEach(vref =>
           assert(vrm.isDurable(vref), X`value is not durable`),
         );
       }

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -633,7 +633,7 @@ export function makeVirtualObjectManager(
             const before = innerSelf.rawState[prop];
             const after = serialize(value);
             if (durable) {
-              after.slots.map(vref =>
+              after.slots.forEach(vref =>
                 assert(
                   vrm.isDurable(vref),
                   X`value for ${prop} is not durable`,
@@ -720,11 +720,11 @@ export function makeVirtualObjectManager(
       for (const prop of Object.getOwnPropertyNames(initialData)) {
         const data = serialize(initialData[prop]);
         if (durable) {
-          data.slots.map(vref =>
-            assert(vrm.isDurable(vref), X`value for ${prop} is not durable`),
-          );
+          data.slots.forEach(vref => {
+            assert(vrm.isDurable(vref), X`value for ${prop} is not durable`);
+          });
         }
-        data.slots.map(vrm.addReachableVref);
+        data.slots.forEach(vrm.addReachableVref);
         rawState[prop] = data;
       }
       const innerSelf = { baseRef, rawState, repCount: 0 };

--- a/packages/SwingSet/test/virtualObjects/delete-stored-vo/test-delete-stored-vo.js
+++ b/packages/SwingSet/test/virtualObjects/delete-stored-vo/test-delete-stored-vo.js
@@ -93,13 +93,13 @@ test('VO property deletion is not short-circuited', async t => {
   // The bug (#5044) was that this loop short-circuited the decref if
   // doMoreGC was true. That is, it did:
   //
-  // propValue.slots.map(
+  // propValue.slots.forEach(
   //   vref => (doMoreGC = doMoreGC || vrm.removeReachableVref(vref)),
   // );
   //
   // instead of:
   //
-  // propValue.slots.map(
+  // propValue.slots.forEach(
   //   vref => (doMoreGC = vrm.removeReachableVref(vref) || doMoreGC),
   // );
   //


### PR DESCRIPTION
## Description

Calls to `array.map` that do not use the resulting array should call `array.forEach` instead.

### Security Considerations

None

### Documentation Considerations

None

### Testing Considerations

None