### PR TITLE
fix(run-protocol): raise demo issuer debt limit

### DIFF
--- a/packages/run-protocol/src/demoIssuers.js
+++ b/packages/run-protocol/src/demoIssuers.js
@@ -430,7 +430,7 @@ export const poolRates = (issuerName, record, kits, central) => {
    */
   const toRatio = ([n, d], b) => makeRatio(n, b, d);
   const rates = {
-    debtLimit: AmountMath.make(central.brand, 1_000_000n),
+    debtLimit: AmountMath.make(central.brand, 1_000_000_000n),
     initialPrice: makeRatio(
       initialPriceNumerator,
       central.brand,


### PR DESCRIPTION
The minimum initial debt is 5 RUN on sim chain, so the debt limit has to be higher than that