### PR TITLE
Scaled unit ratios and `overrideManifest`

### DIFF
--- a/packages/deploy-script-support/src/coreProposalBehavior.js
+++ b/packages/deploy-script-support/src/coreProposalBehavior.js
@@ -17,6 +17,7 @@ export const permits = {
  * @param {object} opts
  * @param {string} opts.manifestInstallRef
  * @param {[string, ...unknown[]]} opts.getManifestCall
+ * @param {Record<string, Record<string, unknown>>} [opts.overrideManifest]
  * @param {typeof import('@endo/far').E} opts.E
  * @param {(...args: unknown[]) => void} [opts.log]
  * @param {(ref: unknown) => Promise<unknown>} [opts.restoreRef]
@@ -25,6 +26,7 @@ export const permits = {
 export const makeCoreProposalBehavior = ({
   manifestInstallRef,
   getManifestCall,
+  overrideManifest,
   E,
   log = console.info,
   restoreRef: overrideRestoreRef,
@@ -97,7 +99,7 @@ export const makeCoreProposalBehavior = ({
     return runModuleBehaviors({
       allPowers,
       behaviors,
-      manifest,
+      manifest: overrideManifest || manifest,
       makeConfig: (name, _permit) => {
         log('coreProposal:', name);
         return { options };
@@ -126,10 +128,11 @@ export const makeEnactCoreProposalsFromBundleCap =
     };
 
     return Promise.all(
-      makeCoreProposalArgs.map(async ({ ref, call }) => {
+      makeCoreProposalArgs.map(async ({ ref, call, overrideManifest }) => {
         const subBehavior = makeCoreProposalBehavior({
           manifestInstallRef: ref,
           getManifestCall: call,
+          overrideManifest,
           E,
           restoreRef,
         });

--- a/packages/deploy-script-support/src/writeCoreProposal.js
+++ b/packages/deploy-script-support/src/writeCoreProposal.js
@@ -49,7 +49,10 @@ export const makeWriteCoreProposal = (
     );
 
     const mergedPermits = mergePermits(manifest);
-    return mergePermits({ mergedPermits, additionalPermits });
+    return {
+      manifest,
+      permits: mergePermits({ mergedPermits, additionalPermits }),
+    };
   };
 
   let mutex = Promise.resolve();
@@ -91,7 +94,8 @@ export const makeWriteCoreProposal = (
     console.log('created', { filePrefix, sourceSpec, getManifestCall });
 
     // Extract the top-level permit.
-    const proposalPermit = await mergeProposalPermit(proposal, permits);
+    const { permits: proposalPermit, manifest: overrideManifest } =
+      await mergeProposalPermit(proposal, permits);
 
     // Get an install
     const manifestInstallRef = await publishRef(install(sourceSpec));
@@ -102,9 +106,10 @@ export const makeWriteCoreProposal = (
 
 const manifestInstallRef = ${stringify(manifestInstallRef)};
 const getManifestCall = harden(${stringify(getManifestCall, true)});
+const overrideManifest = ${stringify(overrideManifest, true)};
 
 // Make the behavior the completion value.
-(${makeCoreProposalBehavior})({ manifestInstallRef, getManifestCall, E });
+(${makeCoreProposalBehavior})({ manifestInstallRef, getManifestCall, overrideManifest, E });
 `;
 
     const trimmed = defangAndTrim(code);

--- a/packages/run-protocol/test/test-gov-collateral.js
+++ b/packages/run-protocol/test/test-gov-collateral.js
@@ -196,10 +196,11 @@ const makeScenario = async t => {
       };
 
       return Promise.all(
-        makeCoreProposalArgs.map(async ({ ref, call }) => {
+        makeCoreProposalArgs.map(async ({ ref, call, overrideManifest }) => {
           const subBehavior = makeCoreProposalBehavior({
             manifestInstallRef: ref,
             getManifestCall: call,
+            overrideManifest,
             E: cpE,
             restoreRef,
           });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Fixes a hardcoded price scaling ratio to be calculated for the actual brands.  Also, to prepare for installing just this change on devnet, provide an `overrideManifest` in the governance proposals to make the manifest explicit in the core proposal.
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
Improved legibility of core proposals generated by writeCoreProposal and extractCoreProposalBundles.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
None.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Tested by run-protocol governance unit tests and chain integration testing, as well as manually inspecting a generated core-proposal.
