### PR TITLE
fix: deployment job should capture results on failure

### DIFF
--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -90,6 +90,7 @@ jobs:
         env:
           NETWORK_NAME: chaintest
       - name: capture results
+        if: always()
         run: |
           NOW=$(date -u +%Y%m%dT%H%M%S)
           echo "NOW=$NOW" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Description
 
#5301 introduced a bug where the results of failing deployment tests are no longer processed. This fixes that.

