### PR TITLE
fix(deployment): Do not override explicit faucet SOLO_COINS

### DIFF
--- a/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
+++ b/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
@@ -11,7 +11,8 @@ MAX_LINES=-1
 STAKE=75000000ubld
 # GIFT=251000000000urun
 GIFT=100000000urun
-SOLO_COINS=100000000urun
+# Use the env value if already set, e.g. by the deployment integration test
+SOLO_COINS=${SOLO_COINS-100000000urun}
 # SOLO_COINS=220000000000urun,75000000ubld
 
 


### PR DESCRIPTION
## Description

Apparently the vault tasks of the loadgen have been failing in CI since https://github.com/Agoric/agoric-sdk/pull/5235 landed with the following error: `The request must be for at least (a bigint). (a bigint) is too small` It doesn't fail when running a loadgen locally, which indicates that the issue is specific to the setup of a testnet setup vs a local chain. Given the name of the PR, I figured this had something to do with the amount of RUN given to a solo through the faucet, which has been drastically reduced as a side effect of #5190 

### Security Considerations

None

### Documentation Considerations

Added a comment indicating we need to use existing value if any

### Testing Considerations

I will look into requiring that all loadgen tests succeed, for the CI test to succeed to avoid similar issues in the future.
