### PR TITLE
fix(swingset): move upgrade() vatParameters into options bag

### DIFF
--- a/packages/SwingSet/docs/vat-upgrade.md
+++ b/packages/SwingSet/docs/vat-upgrade.md
@@ -1,5 +1,3 @@
-(NOTE: none of this is implemented yet)
-
 # Vat Upgrade
 
 Dynamic vats can be upgraded to use a new code bundle. This might be used to fix a bug, to add new functionality, or merely to delete accumulated state and reduce memory usage.
@@ -13,13 +11,15 @@ For convenience, this description will use "v1" to describe the old version of t
 Vat upgrade is triggered by an `upgrade()` message to the vat's "adminNode" (the one returned by `E(vatAdminService).createVat()`). This schedules an upgrade event on the kernel run-queue. When this event is processed, the following takes place:
 
 * the vat's current worker (if any) is shut down
+  * outstanding promises are rejected
+  * non-durable exported objects are abandoned
 * any heap snapshot for the vat is deleted
-* the vat's transcript is deleted
-* the vat's non-durable data is deleted
+* the vat's transcript is (effectively) deleted
+* (TOD) the vat's non-durable data is deleted
 * the vat's source record is updated to point at the v2 source bundle
 * a new worker is started, and loads the v2 source bundle
 * the v2 code performs its "upgrade phase"
-  * TODO: how is it informed this has started? `buildRootObject()`? or `upgrade()` or something?
+  * this is signaled with a call to `buildRootObject()`
   * the upgrade invocation gets new `vatParameters`
 * the v2 upgrade phase rewires all durable virtual object kinds, and
   reassociates objects with all export obligations
@@ -134,7 +134,7 @@ Upgrades use bundlecaps, just like the initial `createVat()` call. So the first 
 
 Once the governance object is holding the v2 bundlecap, it triggers the upgrade with `E(adminNode).upgrade(newBundlecap, options)`. This schedules the upgrade sequence (described above), and returns a Promise that resolves when the upgrade is complete. If the upgrade fails, the Promise is rejected and the old vat is reinstalled. An upgrade might fail because the new source bundle has a syntax error (preventing evaluation), or because the upgrade phase throws an exception or returns a Promise that rejects. It will also fail if the ugprade phase does not fulfill all of its obligations, such as leaving a durable Kind unattached.
 
-An important property of the `options` bag is `vatParameters`. This value is passed to the upgrade phase (how? TBD) and can be used to communicate with the upgrade-time code before any external messages have a chance to be delivered. In the Zoe ZCF vat, this is how new contract code will be delivered, so it can be executed (and can assume responsibility for v1 obligations) to completion by the time the upgrade phase finishes.
+An important property of the `options` bag is `vatParameters`. This value is passed to the upgrade phase (as the usual second argument to `buildRootObject()`) and can be used to communicate with the upgrade-time code before any external messages have a chance to be delivered. In the Zoe ZCF vat, this is how new contract code will be delivered, so it can be executed (and can assume responsibility for v1 obligations) to completion by the time the upgrade phase finishes.
 
 ## From Inside: V2 Executes the Upgrade
 
@@ -153,4 +153,4 @@ When `buildRootObject()` finishes and the upgrade phase completes successfully, 
 
 TBD: we might terminate any Durable exported objects which v2 does not reattach, or we might treat that as an error.
 
-TBD: ideally, if the v2 code experiences an error during the upgrade phase, the entire upgrade is aborted and the v1 code is reinstated.
+(TODO) If the v2 code experiences an error during the upgrade phase, the entire upgrade is aborted and the v1 code is reinstated.

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -98,7 +98,13 @@ export function buildRootObject(vatPowers) {
       done() {
         return doneP;
       },
-      upgrade(bundlecap, vatParameters) {
+      upgrade(bundlecap, options) {
+        const { vatParameters, ...rest } = options;
+        const leftovers = Object.keys(rest);
+        if (leftovers.length) {
+          const bad = leftovers.join(',');
+          assert.fail(`upgrade() received unknown options: ${bad}`);
+        }
         let bundleID;
         try {
           bundleID = D(bundlecap).getBundleID();

--- a/packages/SwingSet/test/promise-watcher/bootstrap-promise-watcher.js
+++ b/packages/SwingSet/test/promise-watcher/bootstrap-promise-watcher.js
@@ -54,7 +54,7 @@ export function buildRootObject() {
     async upgradeV2() {
       const bcap = await E(vatAdmin).getNamedBundleCap('upton');
       const vatParameters = { version: 'v2' };
-      await E(uptonAdmin).upgrade(bcap, vatParameters);
+      await E(uptonAdmin).upgrade(bcap, { vatParameters });
       pk3.resolve('val3');
       pk4.reject('err4');
       for (const { rp, withSuccess } of resolveAfterUpgrade) {

--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade-replay.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade-replay.js
@@ -26,7 +26,7 @@ export function buildRootObject() {
       // upgrade Upton to version 2
       const bcap = await E(vatAdmin).getNamedBundleCap('upton');
       const vatParameters = { version: 'v2' };
-      await E(uptonAdmin).upgrade(bcap, vatParameters);
+      await E(uptonAdmin).upgrade(bcap, { vatParameters });
       return E(uptonRoot).phase2();
     },
 

--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
@@ -79,7 +79,7 @@ export const buildRootObject = () => {
     upgradeV2: async () => {
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik2');
       const vatParameters = { youAre: 'v2', marker };
-      await E(ulrikAdmin).upgrade(bcap, vatParameters);
+      await E(ulrikAdmin).upgrade(bcap, { vatParameters });
       const version = await E(ulrikRoot).getVersion();
       const parameters = await E(ulrikRoot).getParameters();
       const m2 = await E(ulrikRoot).getPresence();
@@ -149,7 +149,21 @@ export const buildRootObject = () => {
     upgradeV2WhichLosesKind: async () => {
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik2');
       const vatParameters = { youAre: 'v2', marker };
-      await E(ulrikAdmin).upgrade(bcap, vatParameters); // throws
+      await E(ulrikAdmin).upgrade(bcap, { vatParameters }); // throws
+    },
+
+    doUpgradeWithBadOption: async () => {
+      const bcap1 = await E(vatAdmin).getNamedBundleCap('ulrik1');
+      const options1 = { vatParameters: { youAre: 'v1', marker } };
+      const res = await E(vatAdmin).createVat(bcap1, options1);
+      ulrikAdmin = res.adminNode;
+
+      const bcap2 = await E(vatAdmin).getNamedBundleCap('ulrik2');
+      const options2 = {
+        vatParameters: { youAre: 'v2', marker },
+        bad: 'unknown option',
+      };
+      await E(ulrikAdmin).upgrade(bcap2, options2); // throws
     },
   });
 };

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -308,3 +308,40 @@ test('failed upgrade - lost kind', async t => {
   // TODO: who should see the details of what v2 did wrong? calling
   // vat? only the console?
 });
+
+test('failed upgrade - unknown options', async t => {
+  const config = {
+    includeDevDependencies: true, // for vat-data
+    defaultManagerType: 'xs-worker',
+    bootstrap: 'bootstrap',
+    defaultReapInterval: 'never',
+    vats: {
+      bootstrap: { sourceSpec: bfile('bootstrap-upgrade.js') },
+    },
+    bundles: {
+      ulrik1: { sourceSpec: bfile('vat-ulrik-1.js') },
+      ulrik2: { sourceSpec: bfile('vat-ulrik-2.js') },
+    },
+  };
+
+  const hostStorage = provideHostStorage();
+  await initializeSwingset(config, [], hostStorage);
+  const c = await makeSwingsetController(hostStorage);
+  c.pinVatRoot('bootstrap');
+  await c.run();
+
+  const run = async (name, args = []) => {
+    assert(Array.isArray(args));
+    const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+    await c.run();
+    const status = c.kpStatus(kpid);
+    const capdata = c.kpResolution(kpid);
+    return [status, capdata];
+  };
+
+  const [status, capdata] = await run('doUpgradeWithBadOption', []);
+  t.is(status, 'rejected');
+  const e = parse(capdata.body);
+  t.truthy(e instanceof Error);
+  t.regex(e.message, /upgrade\(\) received unknown options: bad/);
+});

--- a/packages/SwingSet/tools/bootstrap-dvo-test.js
+++ b/packages/SwingSet/tools/bootstrap-dvo-test.js
@@ -43,7 +43,7 @@ export function buildRootObject() {
 
     async upgradeV2(vatParameters) {
       const bcap = await E(vatAdmin).getNamedBundleCap('testVat');
-      await E(testVatAdmin).upgrade(bcap, vatParameters);
+      await E(testVatAdmin).upgrade(bcap, { vatParameters });
       await runTests('after');
       return testLog;
     },


### PR DESCRIPTION
Previously, the parent vat did `E(adminFacet).upgrade(vatParameters)`

Now it does `E(adminFacet).upgrade(bundleCap, { vatParameters })`

This matches the way `vatParameters` are passed to the original
`createVat()` call.

All other options are rejected.

This changes the `adminFacet` API, but internally continues to send
`vatParameters` in their own argument to the underlying device
nodes. If/when we send actual options, we'll need to decide whether to
change the shape of the device node API by converting `vatParameters`
into `options`, or just add additional arguments.

closes #5435
