### PR TITLE
fix(swingset): move upgrade() vatParameters into options bag

### DIFF
--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -98,7 +98,13 @@ export function buildRootObject(vatPowers) {
       done() {
         return doneP;
       },
-      upgrade(bundlecap, vatParameters) {
+      upgrade(bundlecap, options = {}) {
+        const { vatParameters, ...rest } = options;
+        const leftovers = Object.keys(rest);
+        if (leftovers.length) {
+          const bad = leftovers.join(',');
+          assert.fail(`upgrade() received unknown options: ${bad}`);
+        }
         let bundleID;
         try {
           bundleID = D(bundlecap).getBundleID();

--- a/packages/SwingSet/test/promise-watcher/bootstrap-promise-watcher.js
+++ b/packages/SwingSet/test/promise-watcher/bootstrap-promise-watcher.js
@@ -54,7 +54,7 @@ export function buildRootObject() {
     async upgradeV2() {
       const bcap = await E(vatAdmin).getNamedBundleCap('upton');
       const vatParameters = { version: 'v2' };
-      await E(uptonAdmin).upgrade(bcap, vatParameters);
+      await E(uptonAdmin).upgrade(bcap, { vatParameters });
       pk3.resolve('val3');
       pk4.reject('err4');
       for (const { rp, withSuccess } of resolveAfterUpgrade) {

--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade-replay.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade-replay.js
@@ -26,7 +26,7 @@ export function buildRootObject() {
       // upgrade Upton to version 2
       const bcap = await E(vatAdmin).getNamedBundleCap('upton');
       const vatParameters = { version: 'v2' };
-      await E(uptonAdmin).upgrade(bcap, vatParameters);
+      await E(uptonAdmin).upgrade(bcap, { vatParameters });
       return E(uptonRoot).phase2();
     },
 

--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
@@ -79,7 +79,7 @@ export const buildRootObject = () => {
     upgradeV2: async () => {
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik2');
       const vatParameters = { youAre: 'v2', marker };
-      await E(ulrikAdmin).upgrade(bcap, vatParameters);
+      await E(ulrikAdmin).upgrade(bcap, { vatParameters });
       const version = await E(ulrikRoot).getVersion();
       const parameters = await E(ulrikRoot).getParameters();
       const m2 = await E(ulrikRoot).getPresence();
@@ -149,7 +149,35 @@ export const buildRootObject = () => {
     upgradeV2WhichLosesKind: async () => {
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik2');
       const vatParameters = { youAre: 'v2', marker };
-      await E(ulrikAdmin).upgrade(bcap, vatParameters); // throws
+      await E(ulrikAdmin).upgrade(bcap, { vatParameters }); // throws
+    },
+
+    doUpgradeWithBadOption: async () => {
+      const bcap1 = await E(vatAdmin).getNamedBundleCap('ulrik1');
+      const options1 = { vatParameters: { youAre: 'v1', marker } };
+      const res = await E(vatAdmin).createVat(bcap1, options1);
+      ulrikAdmin = res.adminNode;
+
+      const bcap2 = await E(vatAdmin).getNamedBundleCap('ulrik2');
+      const options2 = {
+        vatParameters: { youAre: 'v2', marker },
+        bad: 'unknown option',
+      };
+      await E(ulrikAdmin).upgrade(bcap2, options2); // throws
+    },
+
+    doUpgradeWithoutVatParameters: async () => {
+      const bcap1 = await E(vatAdmin).getNamedBundleCap('ulrik1');
+      const res = await E(vatAdmin).createVat(bcap1);
+      ulrikAdmin = res.adminNode;
+      const root = res.root;
+      const paramA = await E(root).getParameters();
+
+      const bcap2 = await E(vatAdmin).getNamedBundleCap('ulrik2');
+      await E(ulrikAdmin).upgrade(bcap2); // no options
+      const paramB = await E(root).getParameters();
+
+      return [paramA, paramB];
     },
   });
 };

--- a/packages/SwingSet/tools/bootstrap-dvo-test.js
+++ b/packages/SwingSet/tools/bootstrap-dvo-test.js
@@ -43,7 +43,7 @@ export function buildRootObject() {
 
     async upgradeV2(vatParameters) {
       const bcap = await E(vatAdmin).getNamedBundleCap('testVat');
-      await E(testVatAdmin).upgrade(bcap, vatParameters);
+      await E(testVatAdmin).upgrade(bcap, { vatParameters });
       await runTests('after');
       return testLog;
     },


### PR DESCRIPTION
Previously, the parent vat did `E(adminFacet).upgrade(vatParameters)`

Now it does `E(adminFacet).upgrade(bundleCap, { vatParameters })`

This matches the way `vatParameters` are passed to the original
`createVat()` call.

All other options are rejected.

This changes the `adminFacet` API, but internally continues to send
`vatParameters` in their own argument to the underlying device
nodes. If/when we send actual options, we'll need to decide whether to
change the shape of the device node API by converting `vatParameters`
into `options`, or just add additional arguments.

closes #5345
