### PR TITLE
refactor(swingset): Reserve host prefix in the store

### DIFF
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -116,6 +116,9 @@ const enableKernelGC = true;
 // // if fulfilled or rejected:
 // kp$NN.data.body = missing | JSON
 // kp$NN.data.slots = '' | $vatID[,$vatID..]
+//
+// Prefix reserved for host written data:
+// host.
 
 export function commaSplit(s) {
   if (s === '') {
@@ -164,20 +167,21 @@ export default function makeKernelKeeper(
 
   /**
    * @param { string } key
-   * @returns { boolean }
    */
-  function isConsensusKey(key) {
+  function getKeyType(key) {
     if (key.startsWith('local.')) {
-      return false;
+      return 'local';
+    } else if (key.startsWith('host.')) {
+      return 'invalid';
     }
-    return true;
+    return 'consensus';
   }
 
   const {
     abortCrank: storeAbortCrank,
     commitCrank: storeCommitCrank,
     enhancedCrankBuffer: kvStore,
-  } = wrapStorage(rawKVStore, createSHA256, isConsensusKey);
+  } = wrapStorage(rawKVStore, createSHA256, getKeyType);
   insistEnhancedStorageAPI(kvStore);
   const { streamStore, snapStore } = hostStorage;
 

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -797,6 +797,7 @@ test('crankhash - skip keys', t => {
     'local.v1234.lastSnapshot',
     '{"snapshotID":"XYZ","startPos":4}',
   );
+  t.throws(() => k.kvStore.set('host.foo', 'bar'));
   t.is(k.commitCrank().crankhash, expCrankhash);
 });
 

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -31,7 +31,12 @@ import {
 
 const console = anylogger('launch-chain');
 
-const SWING_STORE_HOST_PREFIX = 'host';
+/**
+ * Return the key in the reserved "host.*" section of the swing-store
+ *
+ * @param {string} path
+ */
+const getHostKey = path => `host.${path}`;
 
 async function buildSwingset(
   mailboxStorage,
@@ -266,12 +271,9 @@ export async function launch({
     savedBlockTime,
     savedChainSends,
   ) {
-    kvStore.set(`${SWING_STORE_HOST_PREFIX}.height`, `${savedHeight}`);
-    kvStore.set(`${SWING_STORE_HOST_PREFIX}.blockTime`, `${savedBlockTime}`);
-    kvStore.set(
-      `${SWING_STORE_HOST_PREFIX}.chainSends`,
-      JSON.stringify(savedChainSends),
-    );
+    kvStore.set(getHostKey('height'), `${savedHeight}`);
+    kvStore.set(getHostKey('blockTime'), `${savedBlockTime}`);
+    kvStore.set(getHostKey('chainSends'), JSON.stringify(savedChainSends));
     await commit();
   }
 
@@ -312,14 +314,10 @@ export async function launch({
     );
   }
 
-  const savedHeight = Number(
-    kvStore.get(`${SWING_STORE_HOST_PREFIX}.height`) || 0,
-  );
-  const savedBlockTime = Number(
-    kvStore.get(`${SWING_STORE_HOST_PREFIX}.blockTime`) || 0,
-  );
+  const savedHeight = Number(kvStore.get(getHostKey('height')) || 0);
+  const savedBlockTime = Number(kvStore.get(getHostKey('blockTime')) || 0);
   const savedChainSends = JSON.parse(
-    kvStore.get(`${SWING_STORE_HOST_PREFIX}.chainSends`) || '[]',
+    kvStore.get(getHostKey('chainSends')) || '[]',
   );
 
   return {

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -31,7 +31,7 @@ import {
 
 const console = anylogger('launch-chain');
 
-const SWING_STORE_META_KEY = 'cosmos/meta';
+const SWING_STORE_HOST_PREFIX = 'host';
 
 async function buildSwingset(
   mailboxStorage,
@@ -266,9 +266,11 @@ export async function launch({
     savedBlockTime,
     savedChainSends,
   ) {
+    kvStore.set(`${SWING_STORE_HOST_PREFIX}.height`, `${savedHeight}`);
+    kvStore.set(`${SWING_STORE_HOST_PREFIX}.blockTime`, `${savedBlockTime}`);
     kvStore.set(
-      SWING_STORE_META_KEY,
-      JSON.stringify([savedHeight, savedBlockTime, savedChainSends]),
+      `${SWING_STORE_HOST_PREFIX}.chainSends`,
+      JSON.stringify(savedChainSends),
     );
     await commit();
   }
@@ -310,8 +312,14 @@ export async function launch({
     );
   }
 
-  const [savedHeight, savedBlockTime, savedChainSends] = JSON.parse(
-    kvStore.get(SWING_STORE_META_KEY) || '[0, 0, []]',
+  const savedHeight = Number(
+    kvStore.get(`${SWING_STORE_HOST_PREFIX}.height`) || 0,
+  );
+  const savedBlockTime = Number(
+    kvStore.get(`${SWING_STORE_HOST_PREFIX}.blockTime`) || 0,
+  );
+  const savedChainSends = JSON.parse(
+    kvStore.get(`${SWING_STORE_HOST_PREFIX}.chainSends`) || '[]',
   );
 
   return {


### PR DESCRIPTION
closes: #5349

## Description

Designate a section of the swingstore prefixed by `host.` for `cosmic-swingset`'s usage.

### Security Considerations

None

### Documentation Considerations

Should there be?

### Testing Considerations

Added assertion so Swingset will never write to these keys.
Added a unit test verifying that assertion.
