### PR TITLE
fix(vats): store results of createVatByName for zoe etc.

### DIFF
--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -28,6 +28,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
     produce: {
       vatAdminSvc: 'vatAdmin',
       loadVat: true,
+      vatStore: true,
     },
   },
   buildZoe: {
@@ -192,6 +193,7 @@ export const CLIENT_BOOTSTRAP_MANIFEST = harden({
     produce: {
       vatAdminSvc: 'vatAdmin',
       loadVat: true,
+      vatStore: true,
     },
   },
   startClient: {


### PR DESCRIPTION
closes #5013

## Description

In order to not lose the adminNode generated in E(loadVat)('zoe'),
add a store of the results of createVatByName.

This also means multiple calls to `loadVat()` on the same name
return the same vat root.

### Security Considerations

adminNodes are high privilege; keeping them around carries a risk of leaks. This risk is mitigated by the permit mechanism, which makes it statically evident from `manifest.js` that `makeVatsFromBundles` is the only function that produces it, and currently, no functions consume it.

Plus, losing them altogether leaves no means to upgrade zoe or any of the vats created using `loadVat`.

### Documentation Considerations

cleaned up a TODO, actually.

### Testing Considerations

I tried to test this mechanism in `test-boot.js` but the `consume` object is not in scope, so it's not straightforward.

I manually tested it by logging the keys of the store each time one was added. (Then I took that debug logging out.)

I trust we will eventually come up with tests for actually upgrading Zoe, though I don't see an issue that says so in so many words.
