### PR TITLE
test(zoe): offerTo handling of broken invitation

### DIFF
--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -283,9 +283,6 @@ const reverse = (keywordRecord = {}) => {
  * contract instance (contractA) and depositing the payouts in another
  * seat in the current contract instance (contractA).
  *
- * @template {object=} A Offer args
- * @template {object=} R Offer result
- *
  * @param {ZCF} zcf
  *   Zoe Contract Facet for contractA
  *
@@ -313,7 +310,11 @@ const reverse = (keywordRecord = {}) => {
  * @returns {Promise<{userSeatPromise: Promise<UserSeat<R>>, deposited: Promise<AmountKeywordRecord>}>}
  *   A promise for the userSeat for the offer to the other contract, and a
  *   promise (`deposited`) which resolves when the payout for the offer has been
- *   deposited to the `toSeat`
+ *   deposited to the `toSeat`.
+ *   Any failures of the invitation will be returned by `userSeatPromise.getOfferResult()`.
+ *
+ * @template {object=} A Offer args
+ * @template {object=} R Offer result
  */
 export const offerTo = async (
   zcf,


### PR DESCRIPTION
## Description

While working on https://github.com/Agoric/agoric-sdk/pull/5387 I had an error in my invitation handled but didn't get any errors back. I thought this might be that the error was swallowed but it just doesn't come out until `getOfferResult()`.

This adds a test documenting that. 

### Security Considerations

--

### Documentation Considerations

Because this behavior is surprising, should it be documented more conspicuously? Perhaps the `offerTo` docs should recommend always calling `getOfferResult` to check whether the handler succeeded? (Or is there a way to detect earlier?)

### Testing Considerations

This is a test. 