### PR TITLE
Serialize method names in message encoding

### DIFF
--- a/packages/SwingSet/docs/comms.md
+++ b/packages/SwingSet/docs/comms.md
@@ -43,10 +43,10 @@ messages. There are four different types, with some formatting variations
 that depend upon the presence of slots and/or a result promise:
 
 ```
-deliver:${remoteTargetSlot}:${method}:;${args.body}
-deliver:${remoteTargetSlot}:${method}::${slots..};${args.body}
-deliver:${remoteTargetSlot}:${method}:${remoteResultSlot};${args.body}
-deliver:${remoteTargetSlot}:${method}:${remoteResultSlot}:${slots..};${args.body}
+deliver:${remoteTargetSlot}:;${methargs.body}
+deliver:${remoteTargetSlot}::${slots..};${methargs.body}
+deliver:${remoteTargetSlot}:${remoteResultSlot};${methargs.body}
+deliver:${remoteTargetSlot}:${remoteResultSlot}:${slots..};${methargs.body}
 resolve:object:${target}:${resolutionRef};
 resolve:data:${target};${resolution.data.body}
 resolve:data:${target}:${slots..};${resolution.data.body}
@@ -99,16 +99,20 @@ message is being delivered, and thus will always be an *egress* (export) of
 the machine which receives the message (if it were an ingress, the message
 was sent to the wrong place).
 
-`method` is a simple string.
-
 `remoteResultSlot` is either an empty string, or a `rp+NN` promise identifier.
 
 `slots..` is a colon-joined list of any slots in the message arguments, which
 can be `ro+NN`, `ro-NN`, `rp+NN`, or `rp-NN`.
 
-`args.body` is the JSON-encoded argument body (using our `marshal` library).
-As JSON, it can have arbitrary characters except for a newline. The comms
-message always ends with a newline.
+`methargs.body` is the JSON-encoded method+argument message body (using our
+`marshal` library).  The value that `methargs` encodes is always a pair (which
+is to say, a two-element array) consisting of the method name and the arguments
+list.  The latter is itself always an array, though it can be an empty array if
+there are no arguments.  As far as the comms encoding is concerned, the method
+"name" can be any serialized value, though it actually is limited by use to
+being a string, a symbol, or `undefined`.  As JSON, the methargs body can
+contain arbitrary characters except for a newline. The comms message always ends
+with a newline.
 
 ### Examples
 
@@ -230,10 +234,9 @@ The inbound parser will locate the first semicolon and tokenize the string up
 to that point as a series of colon-separated fields. The first field is the
 message type (`deliver` or `resolve`).
 
-For `deliver`, the second field is the target slot, and the third is the
-method name. The fourth field (which might be an empty string) is the result
-promise. Any remaining fields are slots for the arguments. Everything after
-the semicolon is the body for the arguments.
+For `deliver`, the second field is the target slot. The third field (which might
+be an empty string) is the result promise. Any remaining fields are slots for
+the arguments. Everything after the semicolon is the body for the arguments.
 
 If the type is `resolve`, the second field is used as the subtype (`object`
 or `data` or `reject`). The next field is the target (the promise being

--- a/packages/SwingSet/misc-tools/measure-metering/measure.js
+++ b/packages/SwingSet/misc-tools/measure-metering/measure.js
@@ -9,7 +9,6 @@ import { xsnap } from '@agoric/xsnap';
 import * as proc from 'child_process';
 import * as os from 'os';
 import { buildVatController } from '../../src/index.js';
-import { capargs } from '../../test/util.js';
 
 function countingPolicy() {
   let computrons = 0n;
@@ -79,7 +78,7 @@ async function run() {
   await c.run();
 
   async function runOneMode(mode) {
-    const kp = c.queueToVatRoot('bootstrap', 'measure', capargs([mode]));
+    const kp = c.queueToVatRoot('bootstrap', 'measure', [mode]);
     await c.run();
     const cd = c.kpResolution(kp);
     const used = JSON.parse(cd.body);
@@ -129,7 +128,7 @@ async function run() {
   // of the target vat.
 
   async function doCounted(method, args = []) {
-    const kp = c.queueToVatRoot('bootstrap', method, capargs(args));
+    const kp = c.queueToVatRoot('bootstrap', method, args);
     const p = countingPolicy();
     await c.run(p);
     c.kpResolution(kp);

--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -196,15 +196,10 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       // See https://github.com/Agoric/agoric-sdk/issues/2780
       errorIdNum: 60000,
     });
-    const args = harden([vatObj0s, deviceObj0s]);
+    const methargs = harden(['bootstrap', [vatObj0s, deviceObj0s]]);
     // doQueueToKref() takes kernel-refs (ko+NN, kd+NN) in s.slots
     const rootKref = exportRootObject(kernelKeeper, bootstrapVatID);
-    const resultKpid = queueToKref(
-      rootKref,
-      'bootstrap',
-      m.serialize(args),
-      'panic',
-    );
+    const resultKpid = queueToKref(rootKref, m.serialize(methargs), 'panic');
     kernelKeeper.incrementRefCount(resultKpid, 'external');
     return resultKpid;
   }

--- a/packages/SwingSet/src/devices/lib/deviceTools.js
+++ b/packages/SwingSet/src/devices/lib/deviceTools.js
@@ -24,8 +24,8 @@ export function buildSerializationTools(syscall, deviceName) {
         assert.typeof(method, 'string');
         assert(Array.isArray(args), args);
         // eslint-disable-next-line no-use-before-define
-        const capdata = serialize(args);
-        syscall.sendOnly(slot, method, capdata);
+        const capdata = serialize([method, args]);
+        syscall.sendOnly(slot, capdata);
       },
     });
     presences.set(p, slot);

--- a/packages/SwingSet/src/kernel/deviceManager.js
+++ b/packages/SwingSet/src/kernel/deviceManager.js
@@ -36,8 +36,8 @@ export default function makeDeviceManager(
   deviceSyscallHandler,
 ) {
   const syscall = harden({
-    sendOnly: (target, method, args) => {
-      const dso = harden(['sendOnly', target, method, args]);
+    sendOnly: (target, methargs) => {
+      const dso = harden(['sendOnly', target, methargs]);
       deviceSyscallHandler(dso);
     },
     vatstoreGet: key => {

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -117,8 +117,9 @@ export function makeDeviceSlots(
           return undefined;
         }
         const p = (...args) => {
-          const capdata = m.serialize(harden(args));
-          syscall.sendOnly(importSlot, prop, capdata);
+          const methargs = [prop, args];
+          const capdata = m.serialize(harden(methargs));
+          syscall.sendOnly(importSlot, capdata);
         };
         return p;
       },

--- a/packages/SwingSet/src/kernel/deviceTranslator.js
+++ b/packages/SwingSet/src/kernel/deviceTranslator.js
@@ -76,19 +76,19 @@ export function makeDSTranslator(deviceID, deviceName, kernelKeeper) {
   const { mapDeviceSlotToKernelSlot } = deviceKeeper;
 
   // syscall.sendOnly is translated into a kernel send() with result=null
-  function translateSendOnly(targetSlot, method, args) {
+  function translateSendOnly(targetSlot, methargs) {
     assert.typeof(targetSlot, 'string', 'non-string targetSlot');
     insistVatType('object', targetSlot);
-    insistCapData(args);
+    insistCapData(methargs);
     const target = mapDeviceSlotToKernelSlot(targetSlot);
     assert(target, 'unable to find target');
-    kdebug(`syscall[${deviceName}].send(${targetSlot}/${target}).${method}`);
-    kdebug(`  ^target is ${target}`);
+    // const method = JSON.parse(methargs.body)[0];
+    // kdebug(`syscall[${deviceName}].send(${targetSlot}/${target}).${method}`);
+    // kdebug(`  ^target is ${target}`);
     const msg = harden({
-      method,
-      args: {
-        ...args,
-        slots: args.slots.map(slot => mapDeviceSlotToKernelSlot(slot)),
+      methargs: {
+        ...methargs,
+        slots: methargs.slots.map(slot => mapDeviceSlotToKernelSlot(slot)),
       },
       result: null, // this makes it sendOnly
     });

--- a/packages/SwingSet/src/kernel/kernelQueue.js
+++ b/packages/SwingSet/src/kernel/kernelQueue.js
@@ -74,7 +74,7 @@ export function makeKernelQueueHandler(tools) {
       kernelKeeper.incrementRefCount(msg.result, `enq|msg|r`);
     }
     let idx = 0;
-    for (const argSlot of msg.args.slots) {
+    for (const argSlot of msg.methargs.slots) {
       kernelKeeper.incrementRefCount(argSlot, `enq|msg|s${idx}`);
       idx += 1;
     }
@@ -86,8 +86,7 @@ export function makeKernelQueueHandler(tools) {
    * by some other vat. This requires a kref as a target.
    *
    * @param {string} kref  Target of the message
-   * @param {string} method  The message verb
-   * @param {*} args  The message arguments
+   * @param {*} methargs  The method and arguments
    * @param {ResolutionPolicy=} policy How the kernel should handle an eventual
    *    resolution or rejection of the message's result promise. Should be
    *    one of 'none' (don't even create a result promise), 'ignore' (do
@@ -96,11 +95,11 @@ export function makeKernelQueueHandler(tools) {
    *    rejection).
    * @returns {string | undefined} the kpid of the sent message's result promise, if any
    */
-  function queueToKref(kref, method, args, policy = 'ignore') {
+  function queueToKref(kref, methargs, policy = 'ignore') {
     // queue a message on the end of the queue, with 'absolute' krefs.
     // Use 'step' or 'run' to execute it
-    insistCapData(args);
-    args.slots.forEach(s => parseKernelSlot(s));
+    insistCapData(methargs);
+    methargs.slots.forEach(s => parseKernelSlot(s));
     let resultKPID;
     if (policy !== 'none') {
       resultKPID = kernelKeeper.addKernelPromise(policy);
@@ -108,7 +107,7 @@ export function makeKernelQueueHandler(tools) {
     // Should we actually increment these stats in this case?
     kernelKeeper.incStat('syscalls');
     kernelKeeper.incStat('syscallSend');
-    const msg = harden({ method, args, result: resultKPID });
+    const msg = harden({ methargs, result: resultKPID });
     doSend(kref, msg);
     return resultKPID;
   }

--- a/packages/SwingSet/src/kernel/notifyTermination.js
+++ b/packages/SwingSet/src/kernel/notifyTermination.js
@@ -7,7 +7,7 @@ import { insistCapData } from '../lib/capdata.js';
  * @param {string} vatAdminRootKref
  * @param {boolean} shouldReject
  * @param {import('@endo/marshal').CapData<unknown>} info
- * @param {(kref: string, method: string, args: unknown, policy?: string) => void} queueToKref
+ * @param {(kref: string, methargs: unknown, policy?: string) => void} queueToKref
  */
 export function notifyTermination(
   vatID,
@@ -21,10 +21,13 @@ export function notifyTermination(
   // Embedding the info capdata into the arguments list, taking advantage of
   // the fact that neither vatID (which is a string) nor shouldReject (which
   // is a boolean) can contain any slots.
-  const args = {
-    body: JSON.stringify([vatID, shouldReject, JSON.parse(info.body)]),
+  const methargs = {
+    body: JSON.stringify([
+      'vatTerminated',
+      [vatID, shouldReject, JSON.parse(info.body)],
+    ]),
     slots: info.slots,
   };
 
-  queueToKref(vatAdminRootKref, 'vatTerminated', args, 'logFailure');
+  queueToKref(vatAdminRootKref, methargs, 'logFailure');
 }

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -26,7 +26,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
   const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
   const { mapKernelSlotToVatSlot } = vatKeeper;
 
-  // msg is { method, args, result }, all slots are kernel-centric
+  // msg is { methargs, result }, all slots are kernel-centric
   function translateMessage(target, msg) {
     insistMessage(msg);
     const targetSlot = mapKernelSlotToVatSlot(target);
@@ -37,7 +37,9 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
       const p = kernelKeeper.getKernelPromise(target);
       assert(p.decider === vatID, 'wrong decider');
     }
-    const inputSlots = msg.args.slots.map(slot => mapKernelSlotToVatSlot(slot));
+    const inputSlots = msg.methargs.slots.map(slot =>
+      mapKernelSlotToVatSlot(slot),
+    );
     let resultSlot = null;
     if (msg.result) {
       insistKernelType('promise', msg.result);
@@ -56,8 +58,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     }
 
     const vatMessage = harden({
-      method: msg.method,
-      args: { ...msg.args, slots: inputSlots },
+      methargs: { ...msg.methargs, slots: inputSlots },
       result: resultSlot,
     });
     /** @type { VatDeliveryMessage } */
@@ -246,15 +247,17 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
   function translateSend(targetSlot, msg) {
     assert.typeof(targetSlot, 'string', 'non-string targetSlot');
     insistMessage(msg);
-    const { method, args, result: resultSlot } = msg;
-    insistCapData(args);
+    const { methargs, result: resultSlot } = msg;
+    insistCapData(methargs);
     // TODO: disable send-to-self for now, qv issue #43
     const target = mapVatSlotToKernelSlot(targetSlot);
-    const argList = legibilizeMessageArgs(args).join(', ');
+    const [method, argList] = legibilizeMessageArgs(methargs);
     // prettier-ignore
     kdebug(`syscall[${vatID}].send(${targetSlot}/${target}).${method}(${argList})`);
-    const kernelSlots = args.slots.map(slot => mapVatSlotToKernelSlot(slot));
-    const kernelArgs = harden({ ...args, slots: kernelSlots });
+    const kernelSlots = methargs.slots.map(slot =>
+      mapVatSlotToKernelSlot(slot),
+    );
+    const kernelArgs = harden({ ...methargs, slots: kernelSlots });
     let result = null;
     if (resultSlot) {
       insistVatType('promise', resultSlot);
@@ -292,8 +295,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
     }
 
     const kmsg = harden({
-      method,
-      args: kernelArgs,
+      methargs: kernelArgs,
       result,
     });
     insistMessage(kmsg);

--- a/packages/SwingSet/src/lib/makeUndeliverableError.js
+++ b/packages/SwingSet/src/lib/makeUndeliverableError.js
@@ -13,7 +13,8 @@
 
 const QCLASS = '@';
 
-export function makeUndeliverableError(method) {
+export function makeUndeliverableError(methargs) {
+  const method = JSON.parse(methargs.body)[0];
   const s = {
     [QCLASS]: 'error',
     name: 'TypeError',

--- a/packages/SwingSet/src/lib/message.js
+++ b/packages/SwingSet/src/lib/message.js
@@ -15,12 +15,7 @@ import { insistCapData } from './capdata.js';
  * @returns { asserts message is Message }
  */
 export function insistMessage(message) {
-  assert.typeof(
-    message.method,
-    'string',
-    X`message has non-string .method ${message.method}`,
-  );
-  insistCapData(message.args);
+  insistCapData(message.methargs);
   if (message.result) {
     assert.typeof(
       message.result,

--- a/packages/SwingSet/src/supervisors/supervisor-helper.js
+++ b/packages/SwingSet/src/supervisors/supervisor-helper.js
@@ -98,8 +98,8 @@ function makeSupervisorSyscall(syscallToManager, workerCanBlock) {
   // return immediate results or throw errors
   const syscallForVat = {
     /** @type {(target: string, method: string, args: SwingSetCapData, result?: string) => unknown } */
-    send: (target, method, args, result) =>
-      doSyscall(['send', target, { method, args, result }]),
+    send: (target, methargs, result) =>
+      doSyscall(['send', target, { methargs, result }]),
     subscribe: vpid => doSyscall(['subscribe', vpid]),
     resolve: resolutions => doSyscall(['resolve', resolutions]),
     exit: (isFailure, data) => doSyscall(['exit', isFailure, data]),

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -71,15 +71,14 @@ export {};
 
 /*
  * `['message', targetSlot, msg]`
- * msg is `{ method, args, result }`
+ * msg is `{ methargs, result }`
  * `['notify', resolutions]`
  * `['dropExports', vrefs]`
  */
 
 /**
  * @typedef {{
- * method: string,
- * args: SwingSetCapData,
+ * methargs: SwingSetCapData, // of [method, args]
  * result: string | undefined | null,
  * }} Message
  *

--- a/packages/SwingSet/test/bundling/test-bundles.js
+++ b/packages/SwingSet/test/bundling/test-bundles.js
@@ -8,7 +8,6 @@ import { assert } from '@agoric/assert';
 import { parse } from '@endo/marshal';
 import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
-import { capargs } from '../util.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
@@ -89,9 +88,9 @@ test('bundles', async t => {
   c.pinVatRoot('bootstrap');
   await c.run();
 
-  async function run(name, args) {
+  async function run(method, args) {
     assert(Array.isArray(args));
-    const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
     const capdata = c.kpResolution(kpid);
@@ -147,11 +146,7 @@ test('bundles', async t => {
   );
 
   // vatAdminService~.waitForBundleCap(bid1) should hang until installed
-  const waitKPID = c.queueToVatRoot(
-    'bootstrap',
-    'waitForBundleCap',
-    capargs([bid1]),
-  );
+  const waitKPID = c.queueToVatRoot('bootstrap', 'waitForBundleCap', [bid1]);
   await c.run();
   t.is(c.kpStatus(waitKPID), 'unresolved');
 

--- a/packages/SwingSet/test/definition/test-vat-definition.js
+++ b/packages/SwingSet/test/definition/test-vat-definition.js
@@ -26,13 +26,13 @@ test('create with setup and buildRootObject', async t => {
   const c = await buildVatController(config, []);
   c.pinVatRoot('setup');
   c.pinVatRoot('liveslots');
-  let r = c.queueToVatRoot('setup', 'increment', capargs([]), 'panic');
+  let r = c.queueToVatRoot('setup', 'increment', [], 'panic');
   await c.run();
   t.deepEqual(c.kpResolution(r), capargs(mUndefined), 'setup incr');
-  r = c.queueToVatRoot('setup', 'read', capargs([]), 'panic');
+  r = c.queueToVatRoot('setup', 'read', [], 'panic');
   await c.run();
   t.deepEqual(c.kpResolution(r), capargs(1), 'setup read');
-  r = c.queueToVatRoot('setup', 'remotable', capargs([]), 'panic');
+  r = c.queueToVatRoot('setup', 'remotable', [], 'panic');
   await c.run();
   t.deepEqual(
     c.kpResolution(r),
@@ -40,13 +40,13 @@ test('create with setup and buildRootObject', async t => {
     'setup Remotable/getInterfaceOf',
   );
 
-  r = c.queueToVatRoot('liveslots', 'increment', capargs([]), 'panic');
+  r = c.queueToVatRoot('liveslots', 'increment', [], 'panic');
   await c.run();
   t.deepEqual(c.kpResolution(r), capargs(mUndefined), 'ls incr');
-  r = c.queueToVatRoot('liveslots', 'read', capargs([]), 'panic');
+  r = c.queueToVatRoot('liveslots', 'read', [], 'panic');
   await c.run();
   t.deepEqual(c.kpResolution(r), capargs(1), 'ls read');
-  r = c.queueToVatRoot('liveslots', 'remotable', capargs([]), 'panic');
+  r = c.queueToVatRoot('liveslots', 'remotable', [], 'panic');
   await c.run();
   t.deepEqual(
     c.kpResolution(r),

--- a/packages/SwingSet/test/device-hooks/test-device-hooks.js
+++ b/packages/SwingSet/test/device-hooks/test-device-hooks.js
@@ -113,7 +113,7 @@ test('add hook', async t => {
   // basic test: callKernelHook() with static data, returns capdata(static)
   {
     setHookReturn({ y: 2 });
-    const kp = c.queueToVatRoot('bootstrap', 'doCapdata', capargs([{ x: 1 }]));
+    const kp = c.queueToVatRoot('bootstrap', 'doCapdata', [{ x: 1 }]);
     await c.run();
     t.deepEqual(hooklog.shift(), capargs([{ x: 1 }]));
     t.deepEqual(hooklog, []);
@@ -124,7 +124,7 @@ test('add hook', async t => {
   // which serializes the capdata
   {
     setHookReturn({ y: 4 });
-    const kp = c.queueToVatRoot('bootstrap', 'doActual', capargs([{ x: 3 }]));
+    const kp = c.queueToVatRoot('bootstrap', 'doActual', [{ x: 3 }]);
     await c.run();
     t.deepEqual(hooklog.shift(), capargs([{ x: 3 }]));
     t.deepEqual(hooklog, []);
@@ -135,7 +135,7 @@ test('add hook', async t => {
   let o1kref;
   let o2kref;
   {
-    const kp = c.queueToVatRoot('bootstrap', 'returnObjects', capargs([]));
+    const kp = c.queueToVatRoot('bootstrap', 'returnObjects', []);
     await c.run();
     const res3 = c.kpResolution(kp);
     t.is(res3.slots.length, 3);
@@ -151,7 +151,7 @@ test('add hook', async t => {
   // capdata emerge in the hooklog as krefs, not drefs
   {
     setHookReturn(0); // 'undefined' isn't handled by our lazy JSON marshaller
-    const kp = c.queueToVatRoot('bootstrap', 'doObjects', capargs([]));
+    const kp = c.queueToVatRoot('bootstrap', 'doObjects', []);
     await c.run();
     const exp = [capSlot(0, 'root'), capSlot(1, 'obj'), capSlot(2, 'obj')];
     t.deepEqual(hooklog.shift(), {
@@ -164,7 +164,7 @@ test('add hook', async t => {
 
   // do it again, to make sure they get serialized the same way twice
   {
-    const kp = c.queueToVatRoot('bootstrap', 'doObjects', capargs([]));
+    const kp = c.queueToVatRoot('bootstrap', 'doObjects', []);
     await c.run();
     const exp = [capSlot(0, 'root'), capSlot(1, 'obj'), capSlot(2, 'obj')];
     t.deepEqual(hooklog.shift(), {
@@ -182,7 +182,7 @@ test('add hook', async t => {
     const cargs = [capSlot(0, 'root'), capSlot(1, 'obj'), capSlot(2, 'root')];
     const kslots = [bootkref, o1kref, extra1kref];
     setHookReturn(cargs, kslots);
-    const kp = c.queueToVatRoot('bootstrap', 'doCapdata', capargs([0]));
+    const kp = c.queueToVatRoot('bootstrap', 'doCapdata', [0]);
     await c.run();
     t.deepEqual(hooklog.shift(), capargs([0]));
     t.deepEqual(hooklog, []);
@@ -201,7 +201,7 @@ test('add hook', async t => {
   {
     // return root
     setHookReturn(capSlot(0, 'root'), [bootkref]);
-    const kp = c.queueToVatRoot('bootstrap', 'checkObjects1', capargs([0]));
+    const kp = c.queueToVatRoot('bootstrap', 'checkObjects1', [0]);
     await c.run();
     t.deepEqual(hooklog.shift(), capargs([0]));
     t.deepEqual(hooklog, []);
@@ -212,7 +212,7 @@ test('add hook', async t => {
   {
     // return r2
     setHookReturn(capSlot(0, 'obj'), [o2kref]);
-    const kp = c.queueToVatRoot('bootstrap', 'checkObjects2', capargs([0]));
+    const kp = c.queueToVatRoot('bootstrap', 'checkObjects2', [0]);
     await c.run();
     t.deepEqual(hooklog.shift(), capargs([0]));
     t.deepEqual(hooklog, []);
@@ -223,7 +223,7 @@ test('add hook', async t => {
   {
     // return extra2
     setHookReturn(capSlot(0, 'root'), [extra2kref]);
-    const kp = c.queueToVatRoot('bootstrap', 'checkObjects3', capargs([0]));
+    const kp = c.queueToVatRoot('bootstrap', 'checkObjects3', [0]);
     await c.run();
     t.deepEqual(hooklog.shift(), capargs([0]));
     t.deepEqual(hooklog, []);
@@ -235,7 +235,7 @@ test('add hook', async t => {
   {
     // exercise passing device nodes into the hook
     setHookReturn(0);
-    const kp = c.queueToVatRoot('bootstrap', 'checkDevNodeIn', capargs([0]));
+    const kp = c.queueToVatRoot('bootstrap', 'checkDevNodeIn', [0]);
     await c.run();
     // hooklog should get kref for devnode d+1
     const got = hooklog.shift();
@@ -251,7 +251,7 @@ test('add hook', async t => {
   {
     // exercise returning device nodes from the hook
     setHookReturn(capSlot(0, 'device node'), [deviceKref]);
-    const kp = c.queueToVatRoot('bootstrap', 'checkDevNodeOut', capargs([0]));
+    const kp = c.queueToVatRoot('bootstrap', 'checkDevNodeOut', [0]);
     await c.run();
     t.deepEqual(hooklog.shift(), capargs([0]));
     t.deepEqual(hooklog, []);
@@ -270,7 +270,7 @@ test('add hook', async t => {
     setHookReturn(0);
     // writes "dm.invoke failed, informing calling vat" and "deliberate hook
     // error" to logs
-    const kp = c.queueToVatRoot('bootstrap', 'throwError', capargs([0]));
+    const kp = c.queueToVatRoot('bootstrap', 'throwError', [0]);
     await c.run();
     const exp = { worked: false, err };
     t.deepEqual(parse(c.kpResolution(kp).body), exp);
@@ -281,7 +281,7 @@ test('add hook', async t => {
     setHookReturn(0);
     // writes "dm.invoke failed, informing calling vat" and "device d7 has no
     // hook named missingHook" to logs
-    const kp = c.queueToVatRoot('bootstrap', 'missingHook', capargs([0]));
+    const kp = c.queueToVatRoot('bootstrap', 'missingHook', [0]);
     await c.run();
     const exp = { worked: false, err };
     t.deepEqual(parse(c.kpResolution(kp).body), exp);

--- a/packages/SwingSet/test/device-mailbox/test-device-mailbox.js
+++ b/packages/SwingSet/test/device-mailbox/test-device-mailbox.js
@@ -13,7 +13,6 @@ import {
   buildMailboxStateMap,
   buildMailbox,
 } from '../../src/devices/mailbox/mailbox.js';
-import { capargs } from '../util.js';
 
 test.before(async t => {
   const kernelBundles = await buildKernelBundles();
@@ -178,14 +177,14 @@ test('mailbox determinism', async t => {
   t.true(mb1a.deliverInbound('peer1', msg1, 0));
   await c1a.run();
   t.deepEqual(c1a.dump().log, ['comms receive msg1']);
-  const kp1 = c1a.queueToVatRoot('bootstrap', 'getNumReceived', capargs([]));
+  const kp1 = c1a.queueToVatRoot('bootstrap', 'getNumReceived', []);
   await c1a.run();
   t.deepEqual(JSON.parse(c1a.kpResolution(kp1).body), 1);
 
   t.true(mb2.deliverInbound('peer1', msg1, 0));
   await c2.run();
   t.deepEqual(c2.dump().log, ['comms receive msg1']);
-  const kp2 = c2.queueToVatRoot('bootstrap', 'getNumReceived', capargs([]));
+  const kp2 = c2.queueToVatRoot('bootstrap', 'getNumReceived', []);
   await c2.run();
   t.deepEqual(JSON.parse(c2.kpResolution(kp2).body), 1);
 
@@ -210,7 +209,7 @@ test('mailbox determinism', async t => {
   // original message, delivered during the second run
   t.deepEqual(c1b.dump().log, ['comms receive msg1']);
   // but vattp dedups, so only one message should be delivered to comms
-  const kp3 = c1b.queueToVatRoot('bootstrap', 'getNumReceived', capargs([]));
+  const kp3 = c1b.queueToVatRoot('bootstrap', 'getNumReceived', []);
   await c1b.run();
   t.deepEqual(JSON.parse(c1b.kpResolution(kp3).body), 1);
 
@@ -219,7 +218,7 @@ test('mailbox determinism', async t => {
   // the second kernel still has that ephemeral testlog, however the vat is
   // still running, so we only see the original message from the first run
   t.deepEqual(c2.dump().log, ['comms receive msg1']);
-  const kp4 = c2.queueToVatRoot('bootstrap', 'getNumReceived', capargs([]));
+  const kp4 = c2.queueToVatRoot('bootstrap', 'getNumReceived', []);
   await c2.run();
   t.deepEqual(JSON.parse(c2.kpResolution(kp4).body), 1);
 

--- a/packages/SwingSet/test/devices/test-devices.js
+++ b/packages/SwingSet/test/devices/test-devices.js
@@ -120,7 +120,7 @@ test.serial('d1', async t => {
   c.pinVatRoot('bootstrap');
   await c.run();
 
-  c.queueToVatRoot('bootstrap', 'step1', capargs([]));
+  c.queueToVatRoot('bootstrap', 'step1', []);
   await c.run();
   t.deepEqual(c.dump().log, [
     'callNow',
@@ -156,7 +156,7 @@ async function test2(t, mode) {
   await c.run(); // startup
 
   function qv(method) {
-    c.queueToVatRoot('bootstrap', method, capargs([]), 'panic');
+    c.queueToVatRoot('bootstrap', method, [], 'panic');
   }
 
   if (mode === '1') {
@@ -274,7 +274,7 @@ test.serial('command broadcast', async t => {
   await initializeSwingset(config, [], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   c.pinVatRoot('bootstrap');
-  c.queueToVatRoot('bootstrap', 'doCommand1', capargs([]), 'panic');
+  c.queueToVatRoot('bootstrap', 'doCommand1', [], 'panic');
   await c.run();
   t.deepEqual(broadcasts, [{ hello: 'everybody' }]);
 });
@@ -302,7 +302,7 @@ test.serial('command deliver', async t => {
   await initializeSwingset(config, [], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   c.pinVatRoot('bootstrap');
-  c.queueToVatRoot('bootstrap', 'doCommand2', capargs([]), 'panic');
+  c.queueToVatRoot('bootstrap', 'doCommand2', [], 'panic');
   await c.run();
 
   t.deepEqual(c.dump().log.length, 0);
@@ -346,7 +346,7 @@ test.serial('liveslots throws when D() gets promise', async t => {
 
   // When liveslots catches an attempt to send a promise into D(), it throws
   // a regular error, which the vat can catch.
-  c.queueToVatRoot('bootstrap', 'doPromise1', capargs([]), 'panic');
+  c.queueToVatRoot('bootstrap', 'doPromise1', [], 'panic');
   await c.run();
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);
 
@@ -354,7 +354,7 @@ test.serial('liveslots throws when D() gets promise', async t => {
   // syscall.callNow, the translator will notice and kill the vat. We send a
   // ping() to it to make sure it's still alive. If the vat were dead,
   // queueToVatRoot would throw because the vat was deleted.
-  c.queueToVatRoot('bootstrap', 'ping', capargs([]), 'panic');
+  c.queueToVatRoot('bootstrap', 'ping', [], 'panic');
   await c.run();
 
   // If the translator doesn't catch the promise and it makes it to the device,
@@ -385,13 +385,13 @@ test.serial('syscall.callNow(promise) is vat-fatal', async t => {
 
   // deliver doBadCallNow, which will fail, which kills vat-bootstrap, which
   // emits "DANGER: static vat v1 terminated", but does not panic the kernel
-  c.queueToVatRoot('bootstrap', 'doBadCallNow', capargs([]), 'ignore');
+  c.queueToVatRoot('bootstrap', 'doBadCallNow', [], 'ignore');
   await c.run();
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);
 
   // now check that the vat was terminated: this should throw an exception
   // because the entire bootstrap vat was deleted
-  t.throws(() => c.queueToVatRoot('bootstrap', 'ping', capargs([])), {
+  t.throws(() => c.queueToVatRoot('bootstrap', 'ping', []), {
     message: /vat name .* must exist, but doesn't/,
   });
 });

--- a/packages/SwingSet/test/devices/test-raw-device.js
+++ b/packages/SwingSet/test/devices/test-raw-device.js
@@ -11,7 +11,6 @@ import {
   makeSwingsetController,
   buildKernelBundles,
 } from '../../src/index.js';
-import { capargs } from '../util.js';
 
 function dfile(name) {
   return new URL(`./${name}`, import.meta.url).pathname;
@@ -55,7 +54,7 @@ test('d1', async t => {
   await c.run();
 
   // first, exercise plain arguments and return values
-  const r1 = c.queueToVatRoot('bootstrap', 'step1', capargs([]));
+  const r1 = c.queueToVatRoot('bootstrap', 'step1', []);
   await c.run();
   t.deepEqual(JSON.parse(c.kpResolution(r1).body), { a: 4, b: [5, 6] });
   t.deepEqual(sharedArray, ['pushed']);
@@ -63,13 +62,13 @@ test('d1', async t => {
 
   // exercise giving objects to devices, getting them back, and the device's
   // ability to do sendOnly to those objects
-  const r2 = c.queueToVatRoot('bootstrap', 'step2', capargs([]));
+  const r2 = c.queueToVatRoot('bootstrap', 'step2', []);
   await c.run();
   const expected2 = ['got', true, 'hi ping1', true, 'hi ping2', true];
   t.deepEqual(JSON.parse(c.kpResolution(r2).body), expected2);
 
   // create and pass around new device nodes
-  const r3 = c.queueToVatRoot('bootstrap', 'step3', capargs([]));
+  const r3 = c.queueToVatRoot('bootstrap', 'step3', []);
   await c.run();
   const expected3 = [
     ['dn1', 21, true, true],
@@ -78,7 +77,7 @@ test('d1', async t => {
   t.deepEqual(JSON.parse(c.kpResolution(r3).body), expected3);
 
   // check that devices can manage state through vatstore
-  const r4 = c.queueToVatRoot('bootstrap', 'step4', capargs([]));
+  const r4 = c.queueToVatRoot('bootstrap', 'step4', []);
   await c.run();
   const expected4 = [
     [undefined, undefined],
@@ -88,7 +87,7 @@ test('d1', async t => {
   t.deepEqual(parse(c.kpResolution(r4).body), expected4);
 
   // check that device exceptions do not kill the device, calling vat, or kernel
-  const r5 = c.queueToVatRoot('bootstrap', 'step5', capargs([]));
+  const r5 = c.queueToVatRoot('bootstrap', 'step5', []);
   await c.run();
   // body: '{"@qclass":"error","errorId":"error:liveSlots:v1#70001","message":"syscall.callNow failed: device.invoke failed, see logs for details","name":"Error"}',
   const expected5 = Error(
@@ -97,7 +96,7 @@ test('d1', async t => {
   t.deepEqual(parse(c.kpResolution(r5).body), expected5);
 
   // and raw devices can return an error result
-  const r6 = c.queueToVatRoot('bootstrap', 'step6', capargs([]));
+  const r6 = c.queueToVatRoot('bootstrap', 'step6', []);
   await c.run();
   // body: '{"@qclass":"error","errorId":"error:liveSlots:v1#70001","message":"syscall.callNow failed: device.invoke failed, see logs for details","name":"Error"}',
   const expected6 = Error(

--- a/packages/SwingSet/test/gc/test-gc-vat.js
+++ b/packages/SwingSet/test/gc/test-gc-vat.js
@@ -3,7 +3,7 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
 import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
-import { capargs } from '../util.js';
+import { extractMethod } from '../../src/lib/kdebug.js';
 
 function dumpObjects(c) {
   const out = {};
@@ -49,9 +49,9 @@ async function dropPresence(t, dropExport) {
   await c.run();
 
   const bootstrapID = c.vatNameToID('bootstrap');
-  c.queueToVatRoot('bootstrap', 'one', capargs([]));
+  c.queueToVatRoot('bootstrap', 'one', []);
   if (dropExport) {
-    c.queueToVatRoot('bootstrap', 'drop', capargs([]));
+    c.queueToVatRoot('bootstrap', 'drop', []);
     await c.step(); // acceptance
     await c.step(); // message
     await c.step(); // reap
@@ -63,8 +63,8 @@ async function dropPresence(t, dropExport) {
   // examine the run-queue to learn the krefs for objects A and B
   const rq = c.dump().runQueue;
   t.is(rq[0].type, 'send');
-  t.is(rq[0].msg.method, 'two');
-  const [krefA, krefB] = rq[0].msg.args.slots;
+  t.is(extractMethod(rq[0].msg.methargs), 'two');
+  const [krefA, krefB] = rq[0].msg.methargs.slots;
   t.is(krefA, 'ko26'); // arbitrary but this is what we currently expect
   t.is(krefB, 'ko27'); // same
   // both are exported by the bootstrap vat, and are reachable+recognizable
@@ -126,7 +126,7 @@ test('forward to fake zoe', async t => {
 
   // first we ask vat-fake-zoe for the invitation object, to learn its kref
 
-  const r1 = c.queueToVatRoot('zoe', 'makeInvitationZoe', capargs([]));
+  const r1 = c.queueToVatRoot('zoe', 'makeInvitationZoe', []);
   await c.run();
   const invitation = c.kpResolution(r1).slots[0];
   // ko27/v3/o+1 is the export
@@ -147,7 +147,7 @@ test('forward to fake zoe', async t => {
   // tap-fungible-faucet loadgen task, which is where I observed XS not
   // releasing the invitation object.
 
-  c.queueToVatRoot('bootstrap', 'makeInvitation0', capargs([]));
+  c.queueToVatRoot('bootstrap', 'makeInvitation0', []);
   await c.run();
   // console.log(c.dump().kernelTable);
 

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -47,8 +47,8 @@ export function buildSyscall(skipLogging) {
   }
 
   const syscall = {
-    send(targetSlot, method, args, resultSlot) {
-      appendLog({ type: 'send', targetSlot, method, args, resultSlot });
+    send(targetSlot, methargs, resultSlot) {
+      appendLog({ type: 'send', targetSlot, methargs, resultSlot });
     },
     subscribe(target) {
       appendLog({ type: 'subscribe', target });
@@ -182,9 +182,9 @@ export async function setupTestLiveslots(
   );
   const [testHooks] = th;
 
-  async function dispatchMessage(message, args = capargs([])) {
+  async function dispatchMessage(message, args = [], slots = []) {
     const rp = nextRP();
-    await dispatch(makeMessage('o+0', message, args, rp));
+    await dispatch(makeMessage('o+0', message, args, slots, rp));
     if (forceGC) {
       // XXX TERRIBLE HACK WARNING XXX The following GC call is terrible but
       // apparently sometimes necessary.  Without it, certain tests in some

--- a/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
@@ -36,19 +36,14 @@ test('unmetered dynamic vat', async t => {
   await c.run();
 
   // 'createVat' will import the bundle
-  const kp1 = c.queueToVatRoot(
-    'bootstrap',
-    'createVat',
-    capargs(['dynamic']),
-    'panic',
-  );
+  const kp1 = c.queueToVatRoot('bootstrap', 'createVat', ['dynamic'], 'panic');
   await c.run();
   const res1 = c.kpResolution(kp1);
   t.is(JSON.parse(res1.body)[0], 'created', res1.body);
   // const doneKPID = res1.slots[0];
 
   // Now send a message to the dynamic vat that runs normally
-  const kp2 = c.queueToVatRoot('bootstrap', 'run', capargs([]), 'panic');
+  const kp2 = c.queueToVatRoot('bootstrap', 'run', [], 'panic');
   await c.run();
   t.is(c.kpStatus(kp2), 'fulfilled');
   t.deepEqual(c.kpResolution(kp2), capargs(42));

--- a/packages/SwingSet/test/promise-watcher/test-promise-watcher.js
+++ b/packages/SwingSet/test/promise-watcher/test-promise-watcher.js
@@ -11,7 +11,6 @@ import { assert } from '@agoric/assert';
 import { getAllState } from '@agoric/swing-store';
 import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
-import { capargs } from '../util.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
@@ -50,9 +49,9 @@ async function testPromiseWatcher(t) {
   c.pinVatRoot('bootstrap');
   await c.run();
 
-  async function run(name, args = []) {
+  async function run(method, args = []) {
     assert(Array.isArray(args));
-    const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
     const capdata = c.kpResolution(kpid);

--- a/packages/SwingSet/test/run-policy/test-run-policy.js
+++ b/packages/SwingSet/test/run-policy/test-run-policy.js
@@ -3,7 +3,7 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
 import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
-import { capargsOneSlot, capSlot, capargs } from '../util.js';
+import { capSlot, capargs } from '../util.js';
 import {
   crankCounter,
   computronCounter,
@@ -37,18 +37,21 @@ async function testCranks(t, mode) {
     // doMessage() to right, which makes right send doMessage() to left, etc.
     // This uses four cranks per cycle, since each doMessage() also has a
     // return promise that must be resolved.
-    const args = capargs([capSlot(0), 'disabled'], [rightKref]);
-    c.queueToVatRoot('left', 'doMessage', args);
+    c.queueToVatRoot('left', 'doMessage', [capSlot(0), 'disabled'], 'ignore', [
+      rightKref,
+    ]);
   } else if (mode === 'resolutions') {
     // This triggers a back-and-forth cycle of promise resolution, which uses
     // two cranks per cycle. The setup takes three cranks.
-    const args = capargsOneSlot(rightKref);
-    c.queueToVatRoot('left', 'startPromise', args);
+    c.queueToVatRoot('left', 'startPromise', [capSlot(0)], 'ignore', [
+      rightKref,
+    ]);
   } else if (mode === 'computrons') {
     // Use doMessage() like above, but once every 10 cycles, do enough extra
     // CPU to trigger a computron-limiting policy.
-    const args = capargs([capSlot(0), 0], [rightKref]);
-    c.queueToVatRoot('left', 'doMessage', args);
+    c.queueToVatRoot('left', 'doMessage', [capSlot(0), 0], 'ignore', [
+      rightKref,
+    ]);
   } else {
     throw Error(`unknown mode ${mode}`);
   }

--- a/packages/SwingSet/test/stores/test-storeGC/gc-helpers.js
+++ b/packages/SwingSet/test/stores/test-storeGC/gc-helpers.js
@@ -197,17 +197,11 @@ export function refValString(vref, type) {
 }
 
 export function refArg(vref, type) {
-  return capargs(
-    [{ '@qclass': 'slot', iface: `Alleged: ${type}`, index: 0 }],
-    [vref],
-  );
+  return [{ '@qclass': 'slot', iface: `Alleged: ${type}`, index: 0 }, vref];
 }
 
 export function thingArg(vref) {
-  return capargs(
-    [{ '@qclass': 'slot', iface: 'Alleged: thing', index: 0 }],
-    [vref],
-  );
+  return refArg(vref, 'thing');
 }
 
 export function thingRefValString(vref) {

--- a/packages/SwingSet/test/stores/test-storeGC/test-lifecycle.js
+++ b/packages/SwingSet/test/stores/test-storeGC/test-lifecycle.js
@@ -98,7 +98,8 @@ test.serial('store lifecycle 2', async t => {
   validateDropHeld(v, rp, '1', 'r');
 
   // lERV -> LERV  Reintroduce the in-memory reference via message
-  rp = await dispatchMessage('importAndHold', mapRefArg(mainHeldIdx));
+  const [marg, mslot] = mapRefArg(mainHeldIdx);
+  rp = await dispatchMessage('importAndHold', [marg], [mslot]);
   validateImportAndHold(v, rp, mainHeldIdx);
 
   // LERV -> lERV  Drop in-memory reference
@@ -281,7 +282,8 @@ test.serial('store lifecycle 7', async t => {
   validateDropHeld(v, rp, NONE, 'r');
 
   // lERv -> LERv  Reintroduce the in-memory reference via message
-  rp = await dispatchMessage('importAndHold', mapRefArg(mainHeldIdx));
+  const [marg, mslot] = mapRefArg(mainHeldIdx);
+  rp = await dispatchMessage('importAndHold', [marg], [mslot]);
   validateImportAndHold(v, rp, mainHeldIdx);
 
   // LERv -> lERv  Drop in-memory reference again, still no GC because exported

--- a/packages/SwingSet/test/stores/test-storeGC/test-refcount-management.js
+++ b/packages/SwingSet/test/stores/test-storeGC/test-refcount-management.js
@@ -223,7 +223,8 @@ test.serial('presence refcount management 1', async t => {
   const base = mainHeldIdx;
   const presenceRef = 'o-5';
 
-  let rp = await dispatchMessage('importAndHold', thingArg(presenceRef));
+  const [targ, tslot] = thingArg(presenceRef);
+  let rp = await dispatchMessage('importAndHold', [targ], [tslot]);
   validateInit(v);
   validateImportAndHold(v, rp);
 
@@ -264,7 +265,8 @@ test.serial('presence refcount management 2', async t => {
   const base = mainHeldIdx;
   const presenceRef = 'o-5';
 
-  let rp = await dispatchMessage('importAndHold', thingArg(presenceRef));
+  const [targ, tslot] = thingArg(presenceRef);
+  let rp = await dispatchMessage('importAndHold', [targ], [tslot]);
   validateInit(v);
   validateImportAndHold(v, rp);
 

--- a/packages/SwingSet/test/stores/test-storeGC/test-weak-key.js
+++ b/packages/SwingSet/test/stores/test-storeGC/test-weak-key.js
@@ -204,7 +204,8 @@ test.serial('verify presence weak key GC', async t => {
   const presenceRef = 'o-5';
 
   // Import a presence to use as a key and hold onto it weakly
-  let rp = await dispatchMessage('importAndHoldAndKey', thingArg(presenceRef));
+  const [targ, tslot] = thingArg(presenceRef);
+  let rp = await dispatchMessage('importAndHoldAndKey', [targ], [tslot]);
   validateInit(v);
   const mapID = mainHeldIdx;
   validateCreateStore(v, mapID, true); // map

--- a/packages/SwingSet/test/test-activityhash-vs-start.js
+++ b/packages/SwingSet/test/test-activityhash-vs-start.js
@@ -5,7 +5,6 @@ import { test } from '../tools/prepare-test-env-ava.js';
 import { getAllState, setAllState } from '@agoric/swing-store';
 import { provideHostStorage } from '../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../src/index.js';
-import { capargs } from './util.js';
 import { buildTimer } from '../src/devices/timer/timer.js';
 
 const TimerSrc = new URL(
@@ -60,7 +59,7 @@ test.serial('restarting kernel does not change activityhash', async t => {
   await c1.run();
 
   // console.log(`--c1 dummy()`);
-  c1.queueToVatRoot('bootstrap', 'dummy', capargs([]));
+  c1.queueToVatRoot('bootstrap', 'dummy', []);
   // console.log(`--c1 run3`);
   await c1.run();
   const c1ah = c1.getActivityhash();
@@ -84,7 +83,7 @@ test.serial('restarting kernel does not change activityhash', async t => {
   await c2.run();
 
   // console.log(`--c2 dummy()`);
-  c2.queueToVatRoot('bootstrap', 'dummy', capargs([]));
+  c2.queueToVatRoot('bootstrap', 'dummy', []);
   // console.log(`--c2 run3`);
   await c2.run();
 
@@ -114,7 +113,7 @@ test.serial('comms initialize is deterministic', async t => {
   const state = getAllState(hs1);
 
   // but the second message should not
-  c1.queueToVatRoot('bootstrap', 'addRemote', capargs(['remote2']));
+  c1.queueToVatRoot('bootstrap', 'addRemote', ['remote2']);
   await c1.run();
   const c1ah = c1.getActivityhash();
   await c1.shutdown();
@@ -127,7 +126,7 @@ test.serial('comms initialize is deterministic', async t => {
   // the "am I already initialized?" check must be identical to the
   // non-restarted version
 
-  c2.queueToVatRoot('bootstrap', 'addRemote', capargs(['remote2']));
+  c2.queueToVatRoot('bootstrap', 'addRemote', ['remote2']);
   await c2.run();
   const c2ah = c2.getActivityhash();
   await c2.shutdown();

--- a/packages/SwingSet/test/test-baggage.js
+++ b/packages/SwingSet/test/test-baggage.js
@@ -123,7 +123,7 @@ test.serial('exercise baggage', async t => {
   validate(v, matchVatstoreGetAfter('', 'vom.dkind.', NONE, [NONE, NONE]));
   validateDone(v);
 
-  const rp = await dispatchMessage('doSomething', capargs([]));
+  const rp = await dispatchMessage('doSomething', []);
   validate(v, matchVatstoreGet('vc.1.soutside', stringVal('outer val')));
   validate(v, matchVatstoreGet('vc.1.sinside', NONE));
   validate(v, matchVatstoreSet('vc.1.sinside', stringVal('inner val')));

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -10,7 +10,7 @@ import {
   initializeSwingset,
   makeSwingsetController,
 } from '../src/index.js';
-import { checkKT, capdata, capargs } from './util.js';
+import { checkKT, capargs } from './util.js';
 
 const emptyVP = capargs({});
 
@@ -64,7 +64,7 @@ async function simpleCall(t) {
   t.deepEqual(data.kernelTable, [vatAdminRoot]);
 
   // vat1:o+0 will map to ko21
-  controller.queueToVatRoot('vat1', 'foo', capdata('args'));
+  controller.queueToVatRoot('vat1', 'foo', ['args']);
   t.deepEqual(controller.dump().runQueue, []);
   t.deepEqual(controller.dump().acceptanceQueue, [
     { type: 'startVat', vatID: 'v1', vatParameters: emptyVP },
@@ -74,8 +74,7 @@ async function simpleCall(t) {
     { type: 'startVat', vatID: 'v5', vatParameters: emptyVP },
     {
       msg: {
-        method: 'foo',
-        args: capdata('args'),
+        methargs: capargs(['foo', ['args']]),
         result: 'kp40',
       },
       target: 'ko21',
@@ -86,7 +85,7 @@ async function simpleCall(t) {
   t.deepEqual(JSON.parse(controller.dump().log[0]), {
     target: 'o+0',
     method: 'foo',
-    args: capdata('args'),
+    args: capargs(['args']),
   });
 
   controller.log('2');
@@ -230,9 +229,8 @@ test.serial('bootstrap export', async t => {
     {
       msg: {
         result: 'kp40',
-        method: 'bootstrap',
-        args: {
-          body: '[{"bootstrap":{"@qclass":"slot","iface":"Alleged: root","index":0},"comms":{"@qclass":"slot","iface":"Alleged: root","index":1},"left":{"@qclass":"slot","iface":"Alleged: root","index":2},"right":{"@qclass":"slot","iface":"Alleged: root","index":3},"timer":{"@qclass":"slot","iface":"Alleged: root","index":4},"vatAdmin":{"@qclass":"slot","iface":"Alleged: root","index":5},"vattp":{"@qclass":"slot","iface":"Alleged: root","index":6}},{"vatAdmin":{"@qclass":"slot","iface":"Alleged: device","index":7}}]',
+        methargs: {
+          body: '["bootstrap",[{"bootstrap":{"@qclass":"slot","iface":"Alleged: root","index":0},"comms":{"@qclass":"slot","iface":"Alleged: root","index":1},"left":{"@qclass":"slot","iface":"Alleged: root","index":2},"right":{"@qclass":"slot","iface":"Alleged: root","index":3},"timer":{"@qclass":"slot","iface":"Alleged: root","index":4},"vatAdmin":{"@qclass":"slot","iface":"Alleged: root","index":5},"vattp":{"@qclass":"slot","iface":"Alleged: root","index":6}},{"vatAdmin":{"@qclass":"slot","iface":"Alleged: device","index":7}}]]',
           slots: [
             boot0,
             comms0,
@@ -295,9 +293,8 @@ test.serial('bootstrap export', async t => {
       type: 'send',
       target: left0,
       msg: {
-        method: 'foo',
-        args: {
-          body: '[1,{"@qclass":"slot","iface":"Alleged: root","index":0}]',
+        methargs: {
+          body: '["foo",[1,{"@qclass":"slot","iface":"Alleged: root","index":0}]]',
           slots: [right0],
         },
         result: fooP,
@@ -319,9 +316,8 @@ test.serial('bootstrap export', async t => {
       type: 'send',
       target: right0,
       msg: {
-        method: 'bar',
-        args: {
-          body: '[2,{"@qclass":"slot","iface":"Alleged: root","index":0}]',
+        methargs: {
+          body: '["bar",[2,{"@qclass":"slot","iface":"Alleged: root","index":0}]]',
           slots: [right0],
         },
         result: barP,

--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -77,11 +77,10 @@ async function extraMessage(t, mode, status, body, slots) {
   const controller = await beginning(t, 'data');
   controller.pinVatRoot('bootstrap');
   await controller.run();
-  const args = { body: `["${mode}"]`, slots: [] };
   const extraResult = controller.queueToVatRoot(
     'bootstrap',
     'extra',
-    args,
+    [mode],
     'ignore',
   );
   await controller.run();

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -83,28 +83,27 @@ test('simple call', async t => {
   t.deepEqual(log, []);
 
   const o1 = kernel.addExport(vat1, 'o+1');
-  kernel.queueToKref(o1, 'foo', capdata('args'));
+  kernel.queueToKref(o1, capargs(['foo', ['args']]));
   t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'send',
       target: 'ko20',
       msg: {
-        method: 'foo',
-        args: capdata('args'),
+        methargs: capargs(['foo', ['args']]),
         result: 'kp40',
       },
     },
   ]);
   t.deepEqual(log, []);
   await kernel.run();
-  t.deepEqual(log, [['o+1', 'foo', capdata('args')]]);
+  t.deepEqual(log, [['o+1', 'foo', capargs(['args'])]]);
 
   data = kernel.dump();
   t.is(data.log.length, 1);
   t.deepEqual(JSON.parse(data.log[0]), {
     facetID: 'o+1',
     method: 'foo',
-    args: capdata('args'),
+    args: capargs(['args']),
   });
 });
 
@@ -144,19 +143,19 @@ test('vat store', async t => {
   const vat = kernel.vatNameToID('vat');
 
   const o1 = kernel.addExport(vat, 'o+1');
-  kernel.queueToKref(o1, 'get', capdata('[]'));
-  kernel.queueToKref(o1, 'store', capdata('first value'));
-  kernel.queueToKref(o1, 'get', capdata('[]'));
-  kernel.queueToKref(o1, 'store', capdata('second value'));
-  kernel.queueToKref(o1, 'get', capdata('[]'));
-  kernel.queueToKref(o1, 'delete', capdata('[]'));
-  kernel.queueToKref(o1, 'get', capdata('[]'));
+  kernel.queueToKref(o1, capargs(['get', ['[]']]));
+  kernel.queueToKref(o1, capargs(['store', ['first value']]));
+  kernel.queueToKref(o1, capargs(['get', ['[]']]));
+  kernel.queueToKref(o1, capargs(['store', ['second value']]));
+  kernel.queueToKref(o1, capargs(['get', ['[]']]));
+  kernel.queueToKref(o1, capargs(['delete', ['[]']]));
+  kernel.queueToKref(o1, capargs(['get', ['[]']]));
   t.deepEqual(log, []);
   await kernel.run();
   t.deepEqual(log, [
     'undefined',
-    '"first value"',
-    '"second value"',
+    '"["first value"]"',
+    '"["second value"]"',
     'undefined',
   ]);
   const data = kernel.dump();
@@ -193,21 +192,20 @@ test('map inbound', async t => {
   const o1 = kernel.addExport(vat1, 'o+1');
   const koFor5 = kernel.addExport(vat1, 'o+5');
   const koFor6 = kernel.addExport(vat2, 'o+6');
-  kernel.queueToKref(o1, 'foo', capdata('args', [koFor5, koFor6]));
+  kernel.queueToKref(o1, capargs(['foo', ['args']], [koFor5, koFor6]));
   t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'send',
       target: o1,
       msg: {
-        method: 'foo',
-        args: capdata('args', [koFor5, koFor6]),
+        methargs: capargs(['foo', ['args']], [koFor5, koFor6]),
         result: 'kp40',
       },
     },
   ]);
   t.deepEqual(log, []);
   await kernel.run();
-  t.deepEqual(log, [['o+1', 'foo', capdata('args', ['o+5', 'o-50'])]]);
+  t.deepEqual(log, [['o+1', 'foo', capargs(['args'], ['o+5', 'o-50'])]]);
   t.deepEqual(kernel.dump().kernelTable, [
     [o1, vat1, 'o+1'],
     [koFor5, vat1, 'o+5'],
@@ -261,8 +259,7 @@ test('outbound call', async t => {
       const pid = allocatePromise();
       syscall.send(
         v1tovat25,
-        'bar',
-        capdata('bargs', [v1tovat25, 'o+7', p7]),
+        capargs(['bar', ['bargs']], [v1tovat25, 'o+7', p7]),
         pid,
       );
     }
@@ -307,7 +304,7 @@ test('outbound call', async t => {
 
   // o1!foo(args)
   const o1 = kernel.addExport(vat1, 'o+1');
-  kernel.queueToKref(o1, 'foo', capdata('args'));
+  kernel.queueToKref(o1, capargs(['foo', ['args']]));
   t.deepEqual(log, []);
   t.deepEqual(kernel.dump().runQueue, []);
   t.deepEqual(kernel.dump().acceptanceQueue, [
@@ -315,8 +312,7 @@ test('outbound call', async t => {
       type: 'send',
       target: t1,
       msg: {
-        method: 'foo',
-        args: capdata('args'),
+        methargs: capargs(['foo', ['args']]),
         result: 'kp40',
       },
     },
@@ -330,8 +326,7 @@ test('outbound call', async t => {
       type: 'send',
       target: t1,
       msg: {
-        method: 'foo',
-        args: capdata('args'),
+        methargs: capargs(['foo', ['args']]),
         result: 'kp40',
       },
     },
@@ -342,7 +337,7 @@ test('outbound call', async t => {
   await kernel.step();
   // that queues pid=o2!bar(o2, o7, p7)
 
-  t.deepEqual(log.shift(), ['d1', 'o+1', 'foo', capdata('args')]);
+  t.deepEqual(log.shift(), ['d1', 'o+1', 'foo', capargs(['args'])]);
   t.deepEqual(log, []);
 
   t.deepEqual(kernel.dump().runQueue, []);
@@ -351,8 +346,7 @@ test('outbound call', async t => {
       type: 'send',
       target: vat2Obj5,
       msg: {
-        method: 'bar',
-        args: capdata('bargs', [vat2Obj5, 'ko22', 'kp41']),
+        methargs: capargs(['bar', ['bargs']], [vat2Obj5, 'ko22', 'kp41']),
         result: 'kp42',
       },
     },
@@ -397,7 +391,7 @@ test('outbound call', async t => {
   await kernel.step();
   t.deepEqual(log, [
     // todo: check result
-    ['d2', 'o+5', 'bar', capdata('bargs', ['o+5', 'o-50', 'p-60'])],
+    ['d2', 'o+5', 'bar', capargs(['bargs'], ['o+5', 'o-50', 'p-60'])],
     [
       'd2 promises',
       [
@@ -494,7 +488,7 @@ test('three-party', async t => {
       // console.log(`vatA/${facetID} called`);
       log.push(['vatA', facetID, method, args]);
       const pid = allocatePromise();
-      syscall.send(bobForA, 'intro', capdata('bargs', [carolForA]), pid);
+      syscall.send(bobForA, capargs(['intro', ['bargs']], [carolForA]), pid);
       log.push(['vatA', 'promiseID', pid]);
     }
     return dispatch;
@@ -559,13 +553,13 @@ test('three-party', async t => {
   t.deepEqual(log, []);
 
   const o4 = kernel.addExport(vatA, 'o+4');
-  kernel.queueToKref(o4, 'foo', capdata('args'));
+  kernel.queueToKref(o4, capargs(['foo', ['args']]));
   // Move the send to the run-queue
   await kernel.step();
   // Deliver the send
   await kernel.step();
 
-  t.deepEqual(log.shift(), ['vatA', 'o+4', 'foo', capdata('args')]);
+  t.deepEqual(log.shift(), ['vatA', 'o+4', 'foo', capargs(['args'])]);
   t.deepEqual(log.shift(), ['vatA', 'promiseID', 'p+5']);
   t.deepEqual(log, []);
 
@@ -575,8 +569,7 @@ test('three-party', async t => {
       type: 'send',
       target: bob,
       msg: {
-        method: 'intro',
-        args: capdata('bargs', [carol]),
+        methargs: capargs(['intro', ['bargs']], [carol]),
         result: 'kp42',
       },
     },
@@ -616,7 +609,7 @@ test('three-party', async t => {
 
   await kernel.step();
   await kernel.step();
-  t.deepEqual(log, [['vatB', 'o+5', 'intro', capdata('bargs', ['o-50'])]]);
+  t.deepEqual(log, [['vatB', 'o+5', 'intro', capargs(['bargs'], ['o-50'])]]);
   kt.push([carol, vatB, 'o-50']);
   kt.push(['kp42', vatB, 'p-60']);
   checkKT(t, kernel, kt);
@@ -678,14 +671,13 @@ test('transfer promise', async t => {
   checkPromises(t, kernel, kp);
 
   // sending a promise should arrive as a promise
-  syscallA.send(B, 'foo1', capdata('args', [pr1]));
+  syscallA.send(B, capargs(['foo1', ['args']], [pr1]));
   t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'send',
       target: bob,
       msg: {
-        method: 'foo1',
-        args: capdata('args', ['kp40']),
+        methargs: capargs(['foo1', ['args']], ['kp40']),
         result: null,
       },
     },
@@ -703,31 +695,31 @@ test('transfer promise', async t => {
   });
   checkPromises(t, kernel, kp);
   await kernel.run();
-  t.deepEqual(logB.shift(), ['o+5', 'foo1', capdata('args', ['p-60'])]);
+  t.deepEqual(logB.shift(), ['o+5', 'foo1', capargs(['args'], ['p-60'])]);
   t.deepEqual(logB, []);
   kt.push(['kp40', vatB, 'p-60']); // pr1 for B
   checkKT(t, kernel, kt);
 
   // sending it a second time should arrive as the same thing
-  syscallA.send(B, 'foo2', capdata('args', [pr1]));
+  syscallA.send(B, capargs(['foo2', ['args']], [pr1]));
   await kernel.run();
-  t.deepEqual(logB.shift(), ['o+5', 'foo2', capdata('args', ['p-60'])]);
+  t.deepEqual(logB.shift(), ['o+5', 'foo2', capargs(['args'], ['p-60'])]);
   t.deepEqual(logB, []);
   checkKT(t, kernel, kt);
   checkPromises(t, kernel, kp);
 
   // sending it back should arrive with the sender's index
-  syscallB.send(A, 'foo3', capdata('args', ['p-60']));
+  syscallB.send(A, capargs(['foo3', ['args']], ['p-60']));
   await kernel.run();
-  t.deepEqual(logA.shift(), ['o+6', 'foo3', capdata('args', [pr1])]);
+  t.deepEqual(logA.shift(), ['o+6', 'foo3', capargs(['args'], [pr1])]);
   t.deepEqual(logA, []);
   checkKT(t, kernel, kt);
   checkPromises(t, kernel, kp);
 
   // sending it back a second time should arrive as the same thing
-  syscallB.send(A, 'foo4', capdata('args', ['p-60']));
+  syscallB.send(A, capargs(['foo4', ['args']], ['p-60']));
   await kernel.run();
-  t.deepEqual(logA.shift(), ['o+6', 'foo4', capdata('args', [pr1])]);
+  t.deepEqual(logA.shift(), ['o+6', 'foo4', capargs(['args'], [pr1])]);
   t.deepEqual(logA, []);
   checkPromises(t, kernel, kp);
   checkKT(t, kernel, kt);
@@ -830,7 +822,7 @@ test('promise resolveToData', async t => {
     },
   ]);
 
-  syscallB.resolve([[pForB, false, capdata('"args"', [aliceForA])]]);
+  syscallB.resolve([[pForB, false, capargs('"args"', [aliceForA])]]);
   // this causes a notify message to be queued
   t.deepEqual(log, []); // no other dispatch calls
   t.deepEqual(kernel.dump().acceptanceQueue, [
@@ -849,7 +841,7 @@ test('promise resolveToData', async t => {
   // the kernelPromiseID gets mapped back to the vat PromiseID
   t.deepEqual(log.shift(), [
     'notify',
-    oneResolution(pForA, false, capdata('"args"', ['o-50'])),
+    oneResolution(pForA, false, capargs('"args"', ['o-50'])),
   ]);
   t.deepEqual(log, []); // no other dispatch calls
   t.deepEqual(kernel.dump().runQueue, []);
@@ -1116,15 +1108,18 @@ async function doResultInArgs(t, enablePipelining) {
   const bobForA = kernel.addImport(vatA, bobKref);
 
   const resP = 'p+1';
-  const args = { resP: { '@qclass': 'slot', index: 0 } };
+  const args = [{ resP: { '@qclass': 'slot', index: 0 } }];
   if (!enablePipelining) {
     console.log(`intentional error, should get 'p+1 is already allocated'`);
-    t.throws(() => syscallA.send(bobForA, 'one', capargs(args, [resP]), resP), {
-      message: /syscall translation error: prepare to die/,
-    });
+    t.throws(
+      () => syscallA.send(bobForA, capargs(['one', args], [resP]), resP),
+      {
+        message: /syscall translation error: prepare to die/,
+      },
+    );
     return;
   }
-  syscallA.send(bobForA, 'one', capargs(args, [resP]), resP);
+  syscallA.send(bobForA, capargs(['one', args], [resP]), resP);
 
   const q1 = kernel.dump().acceptanceQueue[0];
   const m1 = q1.msg;
@@ -1140,7 +1135,7 @@ async function doResultInArgs(t, enablePipelining) {
   await kernel.run();
   const b1 = logB.shift();
   t.is(b1[0], 'message');
-  t.is(b1[2].result, b1[2].args.slots[0]);
+  t.is(b1[2].result, b1[2].methargs.slots[0]);
 
   t.is(kernel.dump().promises.length, 1);
   // vatB should now hold decision-making authority
@@ -1165,7 +1160,7 @@ test('transcript', async t => {
       }
       const { facetID, args } = extractMessage(vatDeliverObject);
       if (facetID === aliceForAlice) {
-        syscall.send(args.slots[1], 'foo', capdata('fooarg'), 'p+5');
+        syscall.send(args.slots[1], capargs(['foo', ['fooarg']]), 'p+5');
       }
     }
     return dispatch;
@@ -1179,7 +1174,7 @@ test('transcript', async t => {
   const bob = kernel.addExport(vatB, 'o+2');
   const bobForAlice = kernel.addImport(vatA, bob);
 
-  kernel.queueToKref(alice, 'store', capdata('args string', [alice, bob]));
+  kernel.queueToKref(alice, capargs(['store', ['args string']], [alice, bob]));
   // Move the send to the run-queue
   await kernel.step();
   // Deliver the send
@@ -1195,8 +1190,10 @@ test('transcript', async t => {
       'message',
       aliceForAlice,
       {
-        method: 'store',
-        args: capdata('args string', [aliceForAlice, bobForAlice]),
+        methargs: capargs(
+          ['store', ['args string']],
+          [aliceForAlice, bobForAlice],
+        ),
         result: 'p-60',
       },
     ],
@@ -1205,7 +1202,7 @@ test('transcript', async t => {
         d: [
           'send',
           bobForAlice,
-          { method: 'foo', args: capdata('fooarg'), result: 'p+5' },
+          { methargs: capargs(['foo', ['fooarg']]), result: 'p+5' },
         ],
         response: null,
       },
@@ -1251,15 +1248,15 @@ test('non-pipelined promise queueing', async t => {
   const bobForA = kernel.addImport(vatA, bobForKernel);
 
   const p1ForA = 'p+1';
-  syscall.send(bobForA, 'foo', capdata('fooargs'), p1ForA);
+  syscall.send(bobForA, capargs(['foo', ['fooargs']]), p1ForA);
   const p1ForKernel = kernel.addExport(vatA, p1ForA);
 
   const p2ForA = 'p+2';
-  syscall.send(p1ForA, 'bar', capdata('barargs'), p2ForA);
+  syscall.send(p1ForA, capargs(['bar', ['barargs']]), p2ForA);
   const p2ForKernel = kernel.addExport(vatA, p2ForA);
 
   const p3ForA = 'p+3';
-  syscall.send(p2ForA, 'urgh', capdata('urghargs'), p3ForA);
+  syscall.send(p2ForA, capargs(['urgh', ['urghargs']]), p3ForA);
   const p3ForKernel = kernel.addExport(vatA, p3ForA);
 
   t.deepEqual(kernel.dump().promises, [
@@ -1295,7 +1292,7 @@ test('non-pipelined promise queueing', async t => {
   await kernel.run();
 
   const p1ForB = kernel.addImport(vatB, p1ForKernel);
-  t.deepEqual(log.shift(), [bobForB, 'foo', capdata('fooargs'), p1ForB]);
+  t.deepEqual(log.shift(), [bobForB, 'foo', capargs(['fooargs']), p1ForB]);
   t.deepEqual(log, []);
 
   t.deepEqual(kernel.dump().promises, [
@@ -1308,8 +1305,7 @@ test('non-pipelined promise queueing', async t => {
       subscribers: [],
       queue: [
         {
-          method: 'bar',
-          args: capdata('barargs'),
+          methargs: capargs(['bar', ['barargs']]),
           result: p2ForKernel,
         },
       ],
@@ -1323,8 +1319,7 @@ test('non-pipelined promise queueing', async t => {
       subscribers: [],
       queue: [
         {
-          method: 'urgh',
-          args: capdata('urghargs'),
+          methargs: capargs(['urgh', ['urghargs']]),
           result: p3ForKernel,
         },
       ],
@@ -1383,15 +1378,15 @@ const pipelinedSendTest = async (t, delayed) => {
   const initialTarget = delayed ? p0ForA : bobForA;
 
   const p1ForA = 'p+1';
-  syscall.send(initialTarget, 'foo', capdata('fooargs'), p1ForA);
+  syscall.send(initialTarget, capargs(['foo', ['fooargs']]), p1ForA);
   const p1ForKernel = kernel.addExport(vatA, p1ForA);
 
   const p2ForA = 'p+2';
-  syscall.send(p1ForA, 'bar', capdata('barargs'), p2ForA);
+  syscall.send(p1ForA, capargs(['bar', ['barargs']]), p2ForA);
   const p2ForKernel = kernel.addExport(vatA, p2ForA);
 
   const p3ForA = 'p+3';
-  syscall.send(p2ForA, 'urgh', capdata('urghargs'), p3ForA);
+  syscall.send(p2ForA, capargs(['urgh', ['urghargs']]), p3ForA);
   const p3ForKernel = kernel.addExport(vatA, p3ForA);
 
   t.deepEqual(kernel.dump().promises, [
@@ -1452,8 +1447,7 @@ const pipelinedSendTest = async (t, delayed) => {
         subscribers: [],
         queue: [
           {
-            method: 'foo',
-            args: capdata('fooargs'),
+            methargs: capargs(['foo', ['fooargs']]),
             result: p1ForKernel,
           },
         ],
@@ -1467,8 +1461,7 @@ const pipelinedSendTest = async (t, delayed) => {
         subscribers: [],
         queue: [
           {
-            method: 'bar',
-            args: capdata('barargs'),
+            methargs: capargs(['bar', ['barargs']]),
             result: p2ForKernel,
           },
         ],
@@ -1482,8 +1475,7 @@ const pipelinedSendTest = async (t, delayed) => {
         subscribers: [],
         queue: [
           {
-            method: 'urgh',
-            args: capdata('urghargs'),
+            methargs: capargs(['urgh', ['urghargs']]),
             result: p3ForKernel,
           },
         ],
@@ -1520,9 +1512,9 @@ const pipelinedSendTest = async (t, delayed) => {
   const p1ForB = kernel.addImport(vatB, p1ForKernel);
   const p2ForB = kernel.addImport(vatB, p2ForKernel);
   const p3ForB = kernel.addImport(vatB, p3ForKernel);
-  t.deepEqual(log.shift(), [bobForB, 'foo', capdata('fooargs'), p1ForB]);
-  t.deepEqual(log.shift(), [p1ForB, 'bar', capdata('barargs'), p2ForB]);
-  t.deepEqual(log.shift(), [p2ForB, 'urgh', capdata('urghargs'), p3ForB]);
+  t.deepEqual(log.shift(), [bobForB, 'foo', capargs(['fooargs']), p1ForB]);
+  t.deepEqual(log.shift(), [p1ForB, 'bar', capargs(['barargs']), p2ForB]);
+  t.deepEqual(log.shift(), [p2ForB, 'urgh', capargs(['urghargs']), p3ForB]);
   t.deepEqual(log, []);
 
   t.deepEqual(kernel.dump().promises, [
@@ -1604,18 +1596,17 @@ async function reapTest(t, freq) {
 
   const vatRoot = kernel.addExport(vat1, 'o+1');
   function deliverMessage(ordinal) {
-    kernel.queueToKref(vatRoot, `msg_${ordinal}`, capdata('[]'));
+    kernel.queueToKref(vatRoot, capargs([`msg_${ordinal}`, []]));
   }
   function matchMsg(ordinal) {
     return [
       'message',
       'o+1',
       {
-        args: {
-          body: '[]',
+        methargs: {
+          body: `["msg_${ordinal}",[]]`,
           slots: [],
         },
-        method: `msg_${ordinal}`,
         result: `p-${60 + ordinal}`,
       },
     ];

--- a/packages/SwingSet/test/test-promises.js
+++ b/packages/SwingSet/test/test-promises.js
@@ -195,7 +195,7 @@ test('refcount while queued', async t => {
   await c.run();
 
   // then we tell that vat to resolve pk1 to a value (4)
-  c.queueToVatRoot('bootstrap', 'two', capargs([]), 'ignore');
+  c.queueToVatRoot('bootstrap', 'two', [], 'ignore');
   await c.run();
 
   // Now we have a resolved promise 'pk1' whose only reference is the
@@ -207,7 +207,7 @@ test('refcount while queued', async t => {
   // tell vat-right to resolve p2, which should transfer the 'four' message
   // from the p2 promise queue to the run-queue for vat-right. That message
   // will be delivered, with a new promise that is promptly resolved to '3'.
-  const kpid4 = c.queueToVatRoot('right', 'three', capargs([]), 'ignore');
+  const kpid4 = c.queueToVatRoot('right', 'three', [], 'ignore');
   await c.run();
   t.deepEqual(c.kpResolution(kpid4), capargs([true, 3]));
 });

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -497,13 +497,13 @@ test('kernelKeeper promises', async t => {
   t.deepEqual(k.getKernelPromise(p1).subscribers, ['v3', 'v5']);
 
   const expectedAcceptanceQueue = [];
-  const m1 = { method: 'm1', args: { body: '', slots: [] } };
+  const m1 = { methargs: { body: '["m1", []]', slots: [] } };
   k.addMessageToPromiseQueue(p1, m1);
   k.incrementRefCount(p1);
   t.deepEqual(k.getKernelPromise(p1).refCount, 1);
   expectedAcceptanceQueue.push({ type: 'send', target: 'kp40', msg: m1 });
 
-  const m2 = { method: 'm2', args: { body: '', slots: [] } };
+  const m2 = { methargs: { body: '["m2", []]', slots: [] } };
   k.addMessageToPromiseQueue(p1, m2);
   k.incrementRefCount(p1);
   t.deepEqual(k.getKernelPromise(p1).queue, [m1, m2]);

--- a/packages/SwingSet/test/test-transcriptlessness.js
+++ b/packages/SwingSet/test/test-transcriptlessness.js
@@ -3,7 +3,6 @@ import { test } from '../tools/prepare-test-env-ava.js';
 
 import { provideHostStorage } from '../src/controller/hostStorage.js';
 import { buildVatController } from '../src/index.js';
-import { capargs } from './util.js';
 
 async function testTranscriptlessness(t, useTranscript) {
   const config = {
@@ -29,7 +28,7 @@ async function testTranscriptlessness(t, useTranscript) {
   const c2 = await buildVatController(config, [], {
     hostStorage,
   });
-  c2.queueToVatRoot('bootstrap', 'go', capargs([]), 'panic');
+  c2.queueToVatRoot('bootstrap', 'go', [], 'panic');
   await c2.run();
   if (useTranscript) {
     t.deepEqual(c2.dump().log, [

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -277,7 +277,7 @@ async function doTest123(t, which, mode) {
     p1VatA = exportedP1VatA;
     p1VatB = importedP1VatB;
     dataPromiseB = 'p-61';
-    syscallA.send(rootBvatA, 'one', capargs([slot0arg], [exportedP1VatA]));
+    syscallA.send(rootBvatA, capargs(['one', [slot0arg]], [exportedP1VatA]));
     p1kernel = clistVatToKernel(kernel, vatA, exportedP1VatA);
     t.is(p1kernel, expectedP1kernel);
     await kernel.run();
@@ -285,8 +285,7 @@ async function doTest123(t, which, mode) {
     t.deepEqual(logB.shift(), {
       type: 'deliver',
       targetSlot: rootBvatB,
-      method: 'one',
-      args: capargs([slot0arg], [importedP1VatB]),
+      methargs: capargs(['one', [slot0arg]], [importedP1VatB]),
       resultSlot: null,
     });
     t.deepEqual(logB, []);
@@ -301,7 +300,7 @@ async function doTest123(t, which, mode) {
     // A: function one() { return resolution; }
     p1VatB = exportedP1VatB;
     p1VatA = importedP1VatA;
-    syscallB.send(rootAvatB, 'one', capargs([], []), exportedP1VatB);
+    syscallB.send(rootAvatB, capargs(['one', []]), exportedP1VatB);
     syscallB.subscribe(exportedP1VatB);
     p1kernel = clistVatToKernel(kernel, vatB, p1VatB);
     await kernel.run();
@@ -309,8 +308,7 @@ async function doTest123(t, which, mode) {
     t.deepEqual(logA.shift(), {
       type: 'deliver',
       targetSlot: rootAvatA,
-      method: 'one',
-      args: capargs([], []),
+      methargs: capargs(['one', []], []),
       resultSlot: importedP1VatA,
     });
     t.deepEqual(logA, []);
@@ -323,15 +321,14 @@ async function doTest123(t, which, mode) {
     // A: function two { return resolution }
     p1VatB = exportedP1VatB;
     p1VatA = importedP1VatA;
-    syscallB.send(rootAvatB, 'one', capargs([slot0arg], [exportedP1VatB]));
+    syscallB.send(rootAvatB, capargs(['one', [slot0arg]], [exportedP1VatB]));
     p1kernel = clistVatToKernel(kernel, vatB, p1VatB);
     await kernel.run();
     // expect logA to have deliver(one)
     t.deepEqual(logA.shift(), {
       type: 'deliver',
       targetSlot: rootAvatA,
-      method: 'one',
-      args: capargs([slot0arg], [importedP1VatA]),
+      methargs: capargs(['one', [slot0arg]], [importedP1VatA]),
       resultSlot: null,
     });
     t.deepEqual(logA, []);
@@ -341,14 +338,13 @@ async function doTest123(t, which, mode) {
     t.deepEqual(logA, []);
     t.deepEqual(logB, []);
 
-    syscallB.send(rootAvatB, 'two', capargs([], []), exportedP1VatB);
+    syscallB.send(rootAvatB, capargs(['two', []]), exportedP1VatB);
     await kernel.run();
     // expect logA to have deliver(two)
     t.deepEqual(logA.shift(), {
       type: 'deliver',
       targetSlot: rootAvatA,
-      method: 'two',
-      args: capargs([], []),
+      methargs: capargs(['two', []], []),
       resultSlot: importedP1VatA,
     });
     t.deepEqual(logA, []);
@@ -452,7 +448,7 @@ async function doTest4567(t, which, mode) {
     p1VatB = exportedP1VatB;
     p1VatA = importedP1VatA;
     dataPromiseA = 'p-61';
-    syscallB.send(rootAvatB, 'one', capargs([slot0arg], [exportedP1VatB]));
+    syscallB.send(rootAvatB, capargs(['one', [slot0arg]], [exportedP1VatB]));
     p1kernel = clistVatToKernel(kernel, vatB, exportedP1VatB);
     t.is(p1kernel, expectedP1kernel);
     await kernel.run();
@@ -460,8 +456,7 @@ async function doTest4567(t, which, mode) {
     t.deepEqual(logA.shift(), {
       type: 'deliver',
       targetSlot: rootAvatA,
-      method: 'one',
-      args: capargs([slot0arg], [importedP1VatA]),
+      methargs: capargs(['one', [slot0arg]], [importedP1VatA]),
       resultSlot: null,
     });
     t.deepEqual(logB, []);
@@ -475,7 +470,7 @@ async function doTest4567(t, which, mode) {
     // B: function one() { return resolution; }
     p1VatA = exportedP1VatA;
     p1VatB = importedP1VatB;
-    syscallA.send(rootBvatA, 'one', capargs([], []), exportedP1VatA);
+    syscallA.send(rootBvatA, capargs(['one', []]), exportedP1VatA);
     syscallA.subscribe(exportedP1VatA);
     p1kernel = clistVatToKernel(kernel, vatA, p1VatA);
     await kernel.run();
@@ -483,8 +478,7 @@ async function doTest4567(t, which, mode) {
     t.deepEqual(logB.shift(), {
       type: 'deliver',
       targetSlot: rootBvatB,
-      method: 'one',
-      args: capargs([], []),
+      methargs: capargs(['one', []], []),
       resultSlot: importedP1VatB,
     });
     t.deepEqual(logA, []);
@@ -496,24 +490,22 @@ async function doTest4567(t, which, mode) {
     // B: function one() { return resolution; }
     p1VatA = exportedP1VatA;
     p1VatB = importedP1VatB;
-    syscallA.send(rootBvatA, 'one', capargs([], []), exportedP1VatA);
+    syscallA.send(rootBvatA, capargs(['one', []]), exportedP1VatA);
     syscallA.subscribe(exportedP1VatA);
-    syscallA.send(rootBvatA, 'two', capargs([slot0arg], [exportedP1VatA]));
+    syscallA.send(rootBvatA, capargs(['two', [slot0arg]], [exportedP1VatA]));
     p1kernel = clistVatToKernel(kernel, vatA, p1VatA);
     await kernel.run();
     // expect logB to have deliver(one) and deliver(two)
     t.deepEqual(logB.shift(), {
       type: 'deliver',
       targetSlot: rootBvatB,
-      method: 'one',
-      args: capargs([], []),
+      methargs: capargs(['one', []], []),
       resultSlot: importedP1VatB,
     });
     t.deepEqual(logB.shift(), {
       type: 'deliver',
       targetSlot: rootBvatB,
-      method: 'two',
-      args: capargs([slot0arg], [importedP1VatB]),
+      methargs: capargs(['two', [slot0arg]], [importedP1VatB]),
       resultSlot: null,
     });
     t.deepEqual(logA, []);
@@ -525,8 +517,8 @@ async function doTest4567(t, which, mode) {
     // B: function two() { return resolution; }
     p1VatA = exportedP1VatA;
     p1VatB = importedP1VatB;
-    syscallA.send(rootBvatA, 'one', capargs([slot0arg], [exportedP1VatA]));
-    syscallA.send(rootBvatA, 'two', capargs([], []), exportedP1VatA);
+    syscallA.send(rootBvatA, capargs(['one', [slot0arg]], [exportedP1VatA]));
+    syscallA.send(rootBvatA, capargs(['two', []]), exportedP1VatA);
     syscallA.subscribe(exportedP1VatA);
     p1kernel = clistVatToKernel(kernel, vatA, p1VatA);
     await kernel.run();
@@ -534,15 +526,13 @@ async function doTest4567(t, which, mode) {
     t.deepEqual(logB.shift(), {
       type: 'deliver',
       targetSlot: rootBvatB,
-      method: 'one',
-      args: capargs([slot0arg], [importedP1VatB]),
+      methargs: capargs(['one', [slot0arg]], [importedP1VatB]),
       resultSlot: null,
     });
     t.deepEqual(logB.shift(), {
       type: 'deliver',
       targetSlot: rootBvatB,
-      method: 'two',
-      args: capargs([], []),
+      methargs: capargs(['two', []], []),
       resultSlot: importedP1VatB,
     });
     t.deepEqual(logA, []);
@@ -659,31 +649,19 @@ test(`kernel vpid handling crossing resolutions`, async t => {
   // X: bob~.usePromise(pa)     // bob resolves promise pb to an array containing pa
 
   // **** begin Crank 1 (X) ****
-  syscallX.send(
-    rootAvatX,
-    'genPromise',
-    capargs([], []),
-    exportedGenResultAvatX,
-  );
+  syscallX.send(rootAvatX, capargs(['genPromise', []]), exportedGenResultAvatX);
   syscallX.subscribe(exportedGenResultAvatX);
-  syscallX.send(
-    rootBvatX,
-    'genPromise',
-    capargs([], []),
-    exportedGenResultBvatX,
-  );
+  syscallX.send(rootBvatX, capargs(['genPromise', []]), exportedGenResultBvatX);
   syscallX.subscribe(exportedGenResultBvatX);
   syscallX.send(
     rootAvatX,
-    'usePromise',
-    capargs([slot0arg], [exportedGenResultBvatX]),
+    capargs(['usePromise', [slot0arg]], [exportedGenResultBvatX]),
     exportedUseResultAvatX,
   );
   syscallX.subscribe(exportedUseResultAvatX);
   syscallX.send(
     rootBvatX,
-    'usePromise',
-    capargs([slot0arg], [exportedGenResultAvatX]),
+    capargs(['usePromise', [slot0arg]], [exportedGenResultAvatX]),
     exportedUseResultBvatX,
   );
   syscallX.subscribe(exportedUseResultBvatX);
@@ -693,32 +671,28 @@ test(`kernel vpid handling crossing resolutions`, async t => {
     // reacted to on Crank 2 (A)
     type: 'deliver',
     targetSlot: rootAvatA,
-    method: 'genPromise',
-    args: capargs([], []),
+    methargs: capargs(['genPromise', []], []),
     resultSlot: importedGenResultAvatA,
   });
   t.deepEqual(logB.shift(), {
     // reacted to on Crank 3 (B)
     type: 'deliver',
     targetSlot: rootBvatB,
-    method: 'genPromise',
-    args: capargs([], []),
+    methargs: capargs(['genPromise', []], []),
     resultSlot: importedGenResultBvatB,
   });
   t.deepEqual(logA.shift(), {
     // reacted to on Crank 4 (A)
     type: 'deliver',
     targetSlot: rootAvatA,
-    method: 'usePromise',
-    args: capargs([slot0arg], [importedGenResultBvatA]),
+    methargs: capargs(['usePromise', [slot0arg]], [importedGenResultBvatA]),
     resultSlot: importedUseResultAvatA,
   });
   t.deepEqual(logB.shift(), {
     // reacted to on Crank 5 (B)
     type: 'deliver',
     targetSlot: rootBvatB,
-    method: 'usePromise',
-    args: capargs([slot0arg], [importedGenResultAvatB]),
+    methargs: capargs(['usePromise', [slot0arg]], [importedGenResultAvatB]),
     resultSlot: importedUseResultBvatB,
   });
   t.deepEqual(logA, []);
@@ -903,7 +877,7 @@ async function doReflectedMessageTest(t, enablePipelining) {
   // B: alice~.two(result=r)
 
   const exportedPVatB = 'p+1';
-  syscallB.send(rootAvatB, 'one', capargs([slot0arg], [exportedPVatB]));
+  syscallB.send(rootAvatB, capargs(['one', [slot0arg]], [exportedPVatB]));
   const pKernel = clistVatToKernel(kernel, vatB, exportedPVatB);
   await kernel.run();
   const importedPVatA = clistKernelToVat(kernel, vatA, pKernel);
@@ -912,15 +886,14 @@ async function doReflectedMessageTest(t, enablePipelining) {
   t.deepEqual(logA.shift(), {
     type: 'deliver',
     targetSlot: rootAvatA,
-    method: 'one',
-    args: capargs([slot0arg], [importedPVatA]),
+    methargs: capargs(['one', [slot0arg]], [importedPVatA]),
     resultSlot: null,
   });
   t.deepEqual(logA, []);
   t.deepEqual(logB, []);
 
   const exportedRPVatA = 'p+2';
-  syscallA.send(importedPVatA, 'two', capargs([], []), exportedRPVatA);
+  syscallA.send(importedPVatA, capargs(['two', []]), exportedRPVatA);
   syscallA.subscribe(exportedRPVatA);
   const rpKernel = clistVatToKernel(kernel, vatA, exportedRPVatA);
   await kernel.run();
@@ -931,14 +904,13 @@ async function doReflectedMessageTest(t, enablePipelining) {
     t.deepEqual(logB.shift(), {
       type: 'deliver',
       targetSlot: exportedPVatB,
-      method: 'two',
-      args: capargs([], []),
+      methargs: capargs(['two', []], []),
       resultSlot: importedRPVatB,
     });
     t.deepEqual(logA, []);
     t.deepEqual(logB, []);
 
-    syscallB.send(rootAvatB, 'two', capargs([], []), importedRPVatB);
+    syscallB.send(rootAvatB, capargs(['two', []]), importedRPVatB);
     await kernel.run();
   } else {
     // Send is queued to promise
@@ -953,8 +925,7 @@ async function doReflectedMessageTest(t, enablePipelining) {
   t.deepEqual(logA.shift(), {
     type: 'deliver',
     targetSlot: rootAvatA,
-    method: 'two',
-    args: capargs([], []),
+    methargs: capargs(['two', []], []),
     resultSlot: exportedRPVatA,
   });
   t.deepEqual(logA, []);
@@ -1009,7 +980,7 @@ test('kernel vpid handling rejects imported result promise', async t => {
   // B: alice~.two(result=r)
 
   const exportedPRVatA = 'p+1';
-  syscallA.send(rootBvatA, 'one', capargs([], []), exportedPRVatA);
+  syscallA.send(rootBvatA, capargs(['one', []]), exportedPRVatA);
   syscallA.subscribe(exportedPRVatA);
   const prKernel = clistVatToKernel(kernel, vatA, exportedPRVatA);
   await kernel.run();
@@ -1019,15 +990,14 @@ test('kernel vpid handling rejects imported result promise', async t => {
   t.deepEqual(logB.shift(), {
     type: 'deliver',
     targetSlot: rootBvatB,
-    method: 'one',
-    args: capargs([], []),
+    methargs: capargs(['one', []], []),
     resultSlot: importedPRVatB,
   });
   t.deepEqual(logA, []);
   t.deepEqual(logB, []);
 
   t.throws(
-    () => syscallB.send(rootAvatB, 'two', capargs([], []), importedPRVatB),
+    () => syscallB.send(rootAvatB, capargs(['two', []]), importedPRVatB),
     undefined,
     'Send reusing imported promise should throw',
   );
@@ -1076,8 +1046,7 @@ test('kernel vpid handling rejects previously exported result promise', async t 
   t.throws(() =>
     syscallA.send(
       rootBvatA,
-      'one',
-      capargs(slot0arg, [exportedPRVatA]),
+      capargs(['one', [slot0arg]], [exportedPRVatA]),
       exportedPRVatA,
     ),
   );

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -186,19 +186,14 @@ async function doVatResolveCase1(t, mode) {
   const expectedP4 = 'p+8';
 
   await dispatch(
-    makeMessage(
-      rootA,
-      'run',
-      capargs([slot0arg, slot1arg], [target1, target2]),
-    ),
+    makeMessage(rootA, 'run', [slot0arg, slot1arg], [target1, target2]),
   );
 
   // The vat should send 'one' and subscribe to the result promise
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: target1,
-    method: 'one',
-    args: capargs([slot0arg], [expectedP1]),
+    methargs: capargs(['one', [slot0arg]], [expectedP1]),
     resultSlot: expectedP2,
   });
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP2 });
@@ -213,8 +208,7 @@ async function doVatResolveCase1(t, mode) {
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: target1,
-    method: 'two',
-    args: capargs([slot0arg], [expectedTwoArg]),
+    methargs: capargs(['two', [slot0arg]], [expectedTwoArg]),
     resultSlot: expectedResultOfTwo,
   });
   const targets2 = { target2, localTarget, p1: expectedP3 };
@@ -343,11 +337,11 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   const target2 = 'o-2';
 
   if (which === 2) {
-    await dispatch(makeMessage(rootA, 'result', capargs([], []), p1));
-    await dispatch(makeMessage(rootA, 'promise', capargs([slot0arg], [p1])));
+    await dispatch(makeMessage(rootA, 'result', [], [], p1));
+    await dispatch(makeMessage(rootA, 'promise', [slot0arg], [p1]));
   } else if (which === 3) {
-    await dispatch(makeMessage(rootA, 'promise', capargs([slot0arg], [p1])));
-    await dispatch(makeMessage(rootA, 'result', capargs([], []), p1));
+    await dispatch(makeMessage(rootA, 'promise', [slot0arg], [p1]));
+    await dispatch(makeMessage(rootA, 'result', [], [], p1));
   } else {
     assert.fail(X`bad which=${which}`);
   }
@@ -361,11 +355,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   t.deepEqual(log, []);
 
   await dispatch(
-    makeMessage(
-      rootA,
-      'run',
-      capargs([slot0arg, slot1arg], [target1, target2]),
-    ),
+    makeMessage(rootA, 'run', [slot0arg, slot1arg], [target1, target2]),
   );
 
   // At the end of the turn in which run() is executed, the promise queue
@@ -395,8 +385,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: target1,
-    method: 'one',
-    args: capargs([slot0arg], [p1]),
+    methargs: capargs(['one', [slot0arg]], [p1]),
     resultSlot: expectedP2,
   });
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP2 });
@@ -405,8 +394,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: p1,
-    method: 'two',
-    args: capargs([], []),
+    methargs: capargs(['two', []], []),
     resultSlot: expectedP3,
   });
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP3 });
@@ -450,8 +438,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: target1,
-    method: 'three',
-    args: capargs([slot0arg], [expectedVPIDInThree]),
+    methargs: capargs(['three', [slot0arg]], [expectedVPIDInThree]),
     resultSlot: expectedResultOfThree,
   });
   t.deepEqual(log.shift(), {
@@ -467,8 +454,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
     t.deepEqual(log.shift(), {
       type: 'send',
       targetSlot: target2,
-      method: 'four',
-      args: capargs([], []),
+      methargs: capargs(['four', []], []),
       resultSlot: expectedResultOfFour,
     });
     t.deepEqual(log.shift(), {
@@ -567,19 +553,18 @@ async function doVatResolveCase4(t, mode) {
   }
   const target2 = 'o-2';
 
-  await dispatch(makeMessage(rootA, 'get', capargs([slot0arg], [p1])));
+  await dispatch(makeMessage(rootA, 'get', [slot0arg], [p1]));
   t.deepEqual(log.shift(), { type: 'subscribe', target: p1 });
   matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
-  await dispatch(makeMessage(rootA, 'first', capargs([slot0arg], [target1])));
+  await dispatch(makeMessage(rootA, 'first', [slot0arg], [target1]));
 
   const expectedP2 = nextP();
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: target1,
-    method: 'one',
-    args: capargs([slot0arg], [p1]),
+    methargs: capargs(['one', [slot0arg]], [p1]),
     resultSlot: expectedP2,
   });
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP2 });
@@ -588,8 +573,7 @@ async function doVatResolveCase4(t, mode) {
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: p1,
-    method: 'two',
-    args: capargs([], []),
+    methargs: capargs(['two', []], []),
     resultSlot: expectedP3,
   });
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP3 });
@@ -615,15 +599,14 @@ async function doVatResolveCase4(t, mode) {
   await dispatch(r);
   t.deepEqual(log, []);
 
-  await dispatch(makeMessage(rootA, 'second', capargs([slot0arg], [target1])));
+  await dispatch(makeMessage(rootA, 'second', [slot0arg], [target1]));
 
   const expectedP4 = nextP();
   const expectedP5 = nextP();
   t.deepEqual(log.shift(), {
     type: 'send',
     targetSlot: target1,
-    method: 'three',
-    args: capargs([slot0arg], [expectedP4]),
+    methargs: capargs(['three', [slot0arg]], [expectedP4]),
     resultSlot: expectedP5,
   });
   t.deepEqual(log.shift(), {
@@ -636,8 +619,7 @@ async function doVatResolveCase4(t, mode) {
     t.deepEqual(log.shift(), {
       type: 'send',
       targetSlot: target2, // this depends on #823 being fixed
-      method: 'four',
-      args: capargs([], []),
+      methargs: capargs(['four', []], []),
       resultSlot: expectedP6,
     });
     t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP6 });
@@ -695,16 +677,14 @@ test('inter-vat circular promise references', async t => {
   // const pbB = 'p-18';
   // const paB = 'p-19';
 
-  await dispatchA(makeMessage(rootA, 'genPromise', capargs([], []), paA));
+  await dispatchA(makeMessage(rootA, 'genPromise', [], [], paA));
   matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
-  // await dispatchB(makeMessage(rootB, 'genPromise', capargs([], []), pbB));
+  // await dispatchB(makeMessage(rootB, 'genPromise', [], [], pbB));
   // t.deepEqual(log, []);
 
-  await dispatchA(
-    makeMessage(rootA, 'usePromise', capargs([[slot0arg]], [pbA])),
-  );
+  await dispatchA(makeMessage(rootA, 'usePromise', [[slot0arg]], [pbA]));
   t.deepEqual(log.shift(), { type: 'subscribe', target: pbA });
   t.deepEqual(log.shift(), {
     type: 'resolve',
@@ -712,7 +692,7 @@ test('inter-vat circular promise references', async t => {
   });
   t.deepEqual(log, []);
 
-  // await dispatchB(makeMessage(rootB, 'usePromise', capargs([[slot0arg]], [paB])));
+  // await dispatchB(makeMessage(rootB, 'usePromise', [slot0arg], [paB]));
   // t.deepEqual(log.shift(), { type: 'subscribe', target: paB });
   // t.deepEqual(log.shift(), {
   //   type: 'resolve',

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -68,7 +68,7 @@ test('child termination distinguished from meter exhaustion', async t => {
 
   await m.deliver(['startVat', capargs()]);
 
-  const msg = { method: 'hang', args: capargs([]) };
+  const msg = { methargs: capargs(['hang', []]) };
   /** @type { VatDeliveryObject } */
   const delivery = ['message', 'o+0', msg];
 

--- a/packages/SwingSet/test/upgrade/test-upgrade-replay.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade-replay.js
@@ -19,9 +19,9 @@ function copy(data) {
   return JSON.parse(JSON.stringify(data));
 }
 
-async function run(c, name, args = []) {
+async function run(c, method, args = []) {
   assert(Array.isArray(args));
-  const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+  const kpid = c.queueToVatRoot('bootstrap', method, args);
   await c.run();
   const status = c.kpStatus(kpid);
   const capdata = c.kpResolution(kpid);

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -76,9 +76,9 @@ const testUpgrade = async (t, defaultManagerType) => {
   c.pinVatRoot('bootstrap');
   await c.run();
 
-  const run = async (name, args = []) => {
+  const run = async (method, args = []) => {
     assert(Array.isArray(args));
-    const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
     const capdata = c.kpResolution(kpid);
@@ -283,9 +283,9 @@ test('failed upgrade - lost kind', async t => {
   c.pinVatRoot('bootstrap');
   await c.run();
 
-  const run = async (name, args = []) => {
+  const run = async (method, args = []) => {
     assert(Array.isArray(args));
-    const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
     const capdata = c.kpResolution(kpid);

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -52,12 +52,11 @@ export function buildDispatch(onDispatchCallback = undefined) {
     const [type, ...vdoargs] = vatDeliverObject;
     if (type === 'message') {
       const [target, msg] = vdoargs;
-      const { method, args, result } = msg;
+      const { methargs, result } = msg;
       const d = {
         type: 'deliver',
         targetSlot: target,
-        method,
-        args,
+        methargs,
         resultSlot: result,
       };
       log.push(d);
@@ -89,6 +88,11 @@ export function capSlot(index, iface = 'export') {
   return { '@qclass': 'slot', iface, index };
 }
 
+export function methargsOneSlot(method, slot, iface = 'export') {
+  iface = iface ? `Alleged: ${iface}` : undefined;
+  return capargs([method, [{ '@qclass': 'slot', iface, index: 0 }]], [slot]);
+}
+
 export function capdataOneSlot(slot, iface = 'export') {
   iface = iface ? `Alleged: ${iface}` : undefined;
   return capargs({ '@qclass': 'slot', iface, index: 0 }, [slot]);
@@ -99,8 +103,15 @@ export function capargsOneSlot(slot, iface = 'export') {
   return capargs([{ '@qclass': 'slot', iface, index: 0 }], [slot]);
 }
 
-export function makeMessage(target, method, args, result = null) {
-  const msg = { method, args, result };
+export function makeMessage(
+  target,
+  method,
+  args = [],
+  slots = [],
+  result = null,
+) {
+  const methargs = capargs([method, args], slots);
+  const msg = { methargs, result };
   const vatDeliverObject = harden(['message', target, msg]);
   return vatDeliverObject;
 }

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -138,12 +138,7 @@ test.serial('dispatches to the dead do not harm kernel', async t => {
       hostStorage: hostStorage2,
       kernelBundles: t.context.data.kernelBundles,
     });
-    const r2 = c2.queueToVatRoot(
-      'bootstrap',
-      'speakAgain',
-      capargs([]),
-      'panic',
-    );
+    const r2 = c2.queueToVatRoot('bootstrap', 'speakAgain', [], 'panic');
     await c2.run();
     t.is(c2.kpStatus(r2), 'fulfilled');
     t.deepEqual(c2.dump().log, [
@@ -176,7 +171,7 @@ test('dead vat state removed', async t => {
   t.is(kvStore.get('ko26.owner'), 'v6');
   t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 33);
 
-  controller.queueToVatRoot('bootstrap', 'phase2', capargs([]));
+  controller.queueToVatRoot('bootstrap', 'phase2', []);
   await controller.run();
   t.is(kvStore.get('vat.dynamicIDs'), '[]');
   t.is(kvStore.get('ko26.owner'), undefined);

--- a/packages/SwingSet/test/vat-admin/test-replay.js
+++ b/packages/SwingSet/test/vat-admin/test-replay.js
@@ -39,12 +39,7 @@ test.serial('replay dynamic vat', async t => {
       kernelBundles: t.context.data.kernelBundles,
     });
     c1.pinVatRoot('bootstrap');
-    const r1 = c1.queueToVatRoot(
-      'bootstrap',
-      'createVat',
-      capargs([]),
-      'panic',
-    );
+    const r1 = c1.queueToVatRoot('bootstrap', 'createVat', [], 'panic');
     await c1.run();
     t.deepEqual(c1.kpResolution(r1), capargs('created'));
   }
@@ -60,7 +55,7 @@ test.serial('replay dynamic vat', async t => {
     const c2 = await buildVatController(copy(config), [], {
       hostStorage: hostStorage2,
     });
-    const r2 = c2.queueToVatRoot('bootstrap', 'check', capargs([]), 'panic');
+    const r2 = c2.queueToVatRoot('bootstrap', 'check', [], 'panic');
     await c2.run();
     t.deepEqual(c2.kpResolution(r2), capargs('ok'));
   }

--- a/packages/SwingSet/test/vat-syscall-failure.js
+++ b/packages/SwingSet/test/vat-syscall-failure.js
@@ -16,7 +16,7 @@ export default function setup(syscall, _state, _helpers, vatPowers) {
     const { method, args } = extractMessage(vatDeliverObject);
     vatPowers.testLog(`${method}`);
     const thing = method === 'begood' ? args.slots[0] : 'o-3414159';
-    syscall.send(thing, 'pretendToBeAThing', capargs([method]));
+    syscall.send(thing, capargs(['pretendToBeAThing', [method]]));
   }
   return dispatch;
 }

--- a/packages/SwingSet/test/vat-util.js
+++ b/packages/SwingSet/test/vat-util.js
@@ -8,7 +8,10 @@ export function extractMessage(vatDeliverObject) {
   const [type, ...vdoargs] = vatDeliverObject;
   assert.equal(type, 'message', `util.js .extractMessage got type ${type}`);
   const [facetID, msg] = vdoargs;
-  const { method, args, result } = msg;
+  const { methargs, result } = msg;
+  const methargsdata = JSON.parse(methargs.body);
+  const [method, argsdata] = methargsdata;
+  const args = { body: JSON.stringify(argsdata), slots: methargs.slots };
   return { facetID, method, args, result };
 }
 

--- a/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
+++ b/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
@@ -5,7 +5,6 @@ import tmp from 'tmp';
 import { makeSnapStore, makeSnapStoreIO } from '@agoric/swing-store';
 import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
-import { capargs } from '../util.js';
 
 test('vat reload from snapshot', async t => {
   const config = {
@@ -44,14 +43,14 @@ test('vat reload from snapshot', async t => {
   }
 
   const expected1 = [];
-  c1.queueToVatRoot('target', 'count', capargs([]));
+  c1.queueToVatRoot('target', 'count', []);
   expected1.push(`count = 0`);
   await c1.run();
   t.deepEqual(c1.dump().log, expected1);
   t.deepEqual(getPositions(), [0, 2]);
 
   for (let i = 1; i < 11; i += 1) {
-    c1.queueToVatRoot('target', 'count', capargs([]));
+    c1.queueToVatRoot('target', 'count', []);
     expected1.push(`count = ${i}`);
   }
   await c1.run();
@@ -62,7 +61,7 @@ test('vat reload from snapshot', async t => {
   const c2 = await makeSwingsetController(hostStorage);
   const expected2 = [`count = 7`, `count = 8`, `count = 9`, `count = 10`];
   t.deepEqual(c2.dump().log, expected2); // replayed 4 deliveries
-  c2.queueToVatRoot('target', 'count', capargs([]));
+  c2.queueToVatRoot('target', 'count', []);
   expected2.push(`count = 11`);
   await c2.run();
   t.deepEqual(c2.dump().log, expected2); // note: *not* 0-11

--- a/packages/SwingSet/test/vat-warehouse/test-warehouse.js
+++ b/packages/SwingSet/test/vat-warehouse/test-warehouse.js
@@ -19,16 +19,6 @@ async function makeController(managerType, runtimeOptions) {
   return c;
 }
 
-/** @type { (body: string, slots?: string[]) => SwingSetCapData } */
-function capdata(body, slots = []) {
-  return harden({ body, slots });
-}
-
-/** @type { (args: unknown[], slots?: string[]) => SwingSetCapData } */
-function capargs(args, slots = []) {
-  return capdata(JSON.stringify(args), slots);
-}
-
 const maxVatsOnline = 2;
 const steps = [
   {
@@ -74,7 +64,7 @@ async function runSteps(c, t) {
   await c.run();
   for (const { vat, online } of steps) {
     t.log('sending to vat', vat);
-    c.queueToVatRoot(vat, 'append', capargs([1]));
+    c.queueToVatRoot(vat, 'append', [1]);
     // eslint-disable-next-line no-await-in-loop
     await c.run();
     t.log(

--- a/packages/SwingSet/test/virtualObjects/collection-slots/test-collection-slots.js
+++ b/packages/SwingSet/test/virtualObjects/collection-slots/test-collection-slots.js
@@ -9,7 +9,6 @@ import {
   initializeSwingset,
   makeSwingsetController,
 } from '../../../src/index.js';
-import { capargs } from '../../util.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
@@ -50,9 +49,9 @@ test('collection entry slots trigger doMoreGC', async t => {
   const vatID = c.vatNameToID('target');
   await c.run();
 
-  async function run(name, args = []) {
+  async function run(method, args = []) {
     assert(Array.isArray(args));
-    const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
     const capdata = c.kpResolution(kpid);

--- a/packages/SwingSet/test/virtualObjects/delete-stored-vo/test-delete-stored-vo.js
+++ b/packages/SwingSet/test/virtualObjects/delete-stored-vo/test-delete-stored-vo.js
@@ -9,7 +9,6 @@ import {
   initializeSwingset,
   makeSwingsetController,
 } from '../../../src/index.js';
-import { capargs } from '../../util.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
@@ -50,9 +49,9 @@ test('VO property deletion is not short-circuited', async t => {
   const vatID = c.vatNameToID('target');
   await c.run();
 
-  async function run(name, args = []) {
+  async function run(method, args = []) {
     assert(Array.isArray(args));
-    const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
     const capdata = c.kpResolution(kpid);

--- a/packages/SwingSet/test/virtualObjects/double-retire-import/test-double-retire-import.js
+++ b/packages/SwingSet/test/virtualObjects/double-retire-import/test-double-retire-import.js
@@ -7,7 +7,6 @@ import {
   initializeSwingset,
   makeSwingsetController,
 } from '../../../src/index.js';
-import { capargs } from '../../util.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
@@ -32,7 +31,7 @@ async function testUpgrade(t, defaultManagerType) {
   c.pinVatRoot('bootstrap');
   await c.run();
 
-  const kpid = c.queueToVatRoot('bootstrap', 'build', capargs([]));
+  const kpid = c.queueToVatRoot('bootstrap', 'build', []);
   await c.run();
   t.is(c.kpStatus(kpid), 'fulfilled');
   // the bug manifests as a fatal vat error (illegal syscall), causing

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -89,18 +89,18 @@ test.serial('exercise cache', async t => {
   const nextLog = makeNextLog(c);
 
   async function doSimple(method, what, ...args) {
-    let sendArgs;
+    let sendArgs = args;
+    let slots = [];
     if (what) {
       const whatArg = {
         '@qclass': 'slot',
         iface: 'Alleged: thing',
         index: 0,
       };
-      sendArgs = capargs([whatArg, ...args], [what]);
-    } else {
-      sendArgs = capargs(args);
+      sendArgs = [whatArg, ...args];
+      slots = [what];
     }
-    const r = c.queueToVatRoot('bootstrap', method, sendArgs);
+    const r = c.queueToVatRoot('bootstrap', method, sendArgs, 'ignore', slots);
     await c.run();
     t.is(c.kpStatus(r), 'fulfilled');
     t.deepEqual(nextLog(), []);

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -395,27 +395,18 @@ function holderSer(vref) {
   }
 }
 
-function boolArgs(flag) {
-  return capargs([flag], []);
-}
-
-function thingArgs(vref, isf) {
+function thingArg(vref, isf) {
   if (isf) {
-    return capargs(
-      [
-        {
-          '@qclass': 'slot',
-          iface: 'Alleged: thing facetB',
-          index: 0,
-        },
-      ],
-      [`${vref}:1`],
-    );
+    return [
+      {
+        '@qclass': 'slot',
+        iface: 'Alleged: thing facetB',
+        index: 0,
+      },
+      `${vref}:1`,
+    ];
   } else {
-    return capargs(
-      [{ '@qclass': 'slot', iface: 'Alleged: thing', index: 0 }],
-      [vref],
-    );
+    return [{ '@qclass': 'slot', iface: 'Alleged: thing', index: 0 }, vref];
   }
 }
 
@@ -742,7 +733,7 @@ async function voLifeCycleTest1(t, isf) {
   const thingf = facetRef(isf, thing, '1');
 
   // lerv -> Lerv  Create VO
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   // Lerv -> LerV  Store VO reference virtually
@@ -773,7 +764,7 @@ async function voLifeCycleTest2(t, isf) {
   const thingf = facetRef(isf, thing, '1');
 
   // lerv -> Lerv  Create VO
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   // Lerv -> LerV  Store VO reference virtually (permanent for now)
@@ -805,7 +796,8 @@ async function voLifeCycleTest2(t, isf) {
   validateDropHeld(v, rp, thing, esf(isf), '1', 'r');
 
   // lERV -> LERV  Reintroduce the in-memory reference via message
-  rp = await dispatchMessage('importAndHold', thingArgs(thing, isf));
+  const [targ, tslot] = thingArg(thing, isf);
+  rp = await dispatchMessage('importAndHold', [targ], [tslot]);
   validateImport(v, rp, thingf, testObjValue);
 
   // LERV -> lERV  Drop in-memory reference
@@ -847,7 +839,7 @@ async function voLifeCycleTest3(t, isf) {
   const thingf = facetRef(isf, thing, '1');
 
   // lerv -> Lerv  Create VO
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   // Lerv -> LerV  Store VO reference virtually (permanent for now)
@@ -893,7 +885,7 @@ async function voLifeCycleTest4(t, isf) {
   const thingf = facetRef(isf, thing, '1');
 
   // lerv -> Lerv  Create VO
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   // Lerv -> LERv  Export the reference, now two legs hold it
@@ -923,7 +915,7 @@ async function voLifeCycleTest5(t, isf) {
   const thingf = facetRef(isf, thing, '1');
 
   // lerv -> Lerv  Create VO
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   // Lerv -> LERv  Export the reference, now all three legs hold it
@@ -961,7 +953,7 @@ async function voLifeCycleTest6(t, isf) {
   const thingf = facetRef(isf, thing, '1');
 
   // lerv -> Lerv  Create VO
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   // Lerv -> LERv  Export the reference, now all three legs hold it
@@ -1011,7 +1003,7 @@ async function voLifeCycleTest7(t, isf) {
   const thingf = facetRef(isf, thing, '1');
 
   // lerv -> Lerv  Create VO
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   // Lerv -> LERv  Export the reference, now all three legs hold it
@@ -1023,7 +1015,8 @@ async function voLifeCycleTest7(t, isf) {
   validateDropHeld(v, rp, thing, esf(isf), NONE, 'r');
 
   // lERv -> LERv  Reintroduce the in-memory reference via message
-  rp = await dispatchMessage('importAndHold', thingArgs(thing, isf));
+  const [targ, tslot] = thingArg(thing, isf);
+  rp = await dispatchMessage('importAndHold', [targ], [tslot]);
   validateImport(v, rp, thingf, testObjValue);
 
   // LERv -> lERv  Drop in-memory reference again, still no GC because exported
@@ -1053,7 +1046,7 @@ async function voLifeCycleTest8(t, isf) {
   const thingf = facetRef(isf, thing, '1');
 
   // lerv -> Lerv  Create VO
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   // Lerv -> LERv  Export the reference
@@ -1288,7 +1281,7 @@ async function voRefcountManagementTest1(t, isf) {
   const thing = thingVref(isf, 2);
   const thingf = facetRef(isf, thing, '1');
 
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   rp = await dispatchMessage('prepareStore3');
@@ -1327,7 +1320,7 @@ async function voRefcountManagementTest2(t, isf) {
   const thing = thingVref(isf, 2);
   const thingf = facetRef(isf, thing, '1');
 
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   rp = await dispatchMessage('prepareStore3');
@@ -1376,7 +1369,7 @@ async function voRefcountManagementTest3(t, isf) {
   const thing = thingVref(isf, 2);
   const thingf = facetRef(isf, thing, '1');
 
-  let rp = await dispatchMessage('makeAndHold', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHold', [isf]);
   validateSetupAndCreate(v, rp, thing);
 
   rp = await dispatchMessage('prepareStoreLinked');
@@ -1442,7 +1435,8 @@ test.serial('presence refcount management 1', async t => {
   const { v, dispatchMessage } = await setupTestLiveslots(t, buildRootObject, 'bob', true);
 
   const presRef = 'o-5';
-  let rp = await dispatchMessage('importAndHold', thingArgs(presRef));
+  const [targ, tslot] = thingArg(presRef);
+  let rp = await dispatchMessage('importAndHold', [targ], [tslot]);
   validateSetup(v);
   validate(v, matchVatstoreGet(stateKey(cacheDisplacerVref), cacheObjValue));
   validateReturned(v, rp);
@@ -1494,7 +1488,8 @@ test.serial('presence refcount management 2', async t => {
   const { v, dispatchMessage } = await setupTestLiveslots(t, buildRootObject, 'bob', true);
 
   const presRef = 'o-5';
-  let rp = await dispatchMessage('importAndHold', thingArgs(presRef));
+  const [targ, tslot] = thingArg(presRef);
+  let rp = await dispatchMessage('importAndHold', [targ], [tslot]);
   validateSetup(v);
   validate(v, matchVatstoreGet(stateKey(cacheDisplacerVref), cacheObjValue));
   validateReturned(v, rp);
@@ -1623,7 +1618,7 @@ async function voWeakKeyGCTest(t, isf) {
   const thingf = facetRef(isf, thing, '1');
 
   // Create VO and hold onto it weakly
-  let rp = await dispatchMessage('makeAndHoldAndKey', boolArgs(isf));
+  let rp = await dispatchMessage('makeAndHoldAndKey', [isf]);
   validateSetupAndCreate(v, rp, thing);
   t.is(testHooks.countCollectionsForWeakKey(facetRef(isf, thing, '1')), 2);
   t.is(testHooks.countWeakKeysForCollection(aWeakMap), 1);
@@ -1649,7 +1644,8 @@ test.serial('verify presence weak key GC', async t => {
   const { v, dispatchMessage, dispatchRetireImports, testHooks } =
         await setupTestLiveslots(t, buildRootObject, 'bob', true);
 
-  let rp = await dispatchMessage('importAndHoldAndKey', thingArgs('o-5'));
+  const [targ, tslot] = thingArg('o-5');
+  let rp = await dispatchMessage('importAndHoldAndKey', [targ], [tslot]);
   validateSetup(v);
   validate(v, matchVatstoreGet(stateKey(cacheDisplacerVref), cacheObjValue));
   validateReturned(v, rp);

--- a/packages/SwingSet/test/virtualObjects/test-weakcollections.js
+++ b/packages/SwingSet/test/virtualObjects/test-weakcollections.js
@@ -42,8 +42,7 @@ test('weakMap in vat', async t => {
   t.deepEqual(c.kpResolution(bootstrapResult), capargs('bootstrap done'));
 
   async function doSimple(method) {
-    const sendArgs = capargs([], []);
-    const r = c.queueToVatRoot('bootstrap', method, sendArgs);
+    const r = c.queueToVatRoot('bootstrap', method, []);
     await c.run();
     t.is(c.kpStatus(r), 'fulfilled');
     return c.kpResolution(r);

--- a/packages/SwingSet/tools/vo-test-harness.js
+++ b/packages/SwingSet/tools/vo-test-harness.js
@@ -7,7 +7,6 @@ import { Far, makeMarshal } from '@endo/marshal';
 import { provideHostStorage } from '../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../src/index.js';
 import { setupTestLiveslots } from '../test/liveslots-helpers.js';
-import { capargs } from '../test/util.js';
 
 export { test };
 
@@ -150,11 +149,11 @@ export async function runVOTest(t, prepare, makeTestObject, testTestObject) {
   );
 
   await dispatchMessage('makeAndHold');
-  await dispatchMessage('testHeld', capargs(['before']));
+  await dispatchMessage('testHeld', ['before']);
   await dispatchMessage('storeHeld');
   await dispatchMessage('dropHeld');
   await dispatchMessage('fetchAndHold');
-  await dispatchMessage('testHeld', capargs(['after']));
+  await dispatchMessage('testHeld', ['after']);
 }
 
 function bfile(name) {
@@ -266,9 +265,9 @@ export async function runDVOTest(t, logCheck, testVatSource, testVatParams) {
   c.pinVatRoot('bootstrap');
   await c.run();
 
-  async function run(name, args = []) {
+  async function run(method, args = []) {
     assert(Array.isArray(args));
-    const kpid = c.queueToVatRoot('bootstrap', name, capargs(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
     const capdata = c.kpResolution(kpid);


### PR DESCRIPTION
Changes message encoding to eliminate the `method` field and move its contents into the `args` capdata object (now renamed `methargs`) so that the method name will be serialized, allowing non-string values (notably symbols) to be used as method selectors (and also allows remote function call, i.e., no method selector at all, to be supported).

Fixes #2481