### PR TITLE
feat: permissionless AMM pools from Interchain assets

### DIFF
--- a/packages/run-protocol/scripts/add-collateral-core.js
+++ b/packages/run-protocol/scripts/add-collateral-core.js
@@ -10,16 +10,18 @@ import { makeInstallCache } from '../src/proposals/utils.js';
 export const defaultProposalBuilder = async (
   { publishRef, install: install0, wrapInstall },
   { interchainAssetOptions = /** @type {object} */ ({}) } = {},
+  { env = process.env } = {},
 ) => {
+  /** @type {import('../src/proposals/addAssetToVault.js').InterchainAssetOptions} */
   const {
+    issuerBoardId = env.INTERCHAIN_ISSUER_BOARD_ID,
     oracleBrand = 'ATOM',
-    denom = process.env.INTERCHAIN_DENOM,
     decimalPlaces = 6,
     keyword = 'IbcATOM',
     proposedName = oracleBrand,
   } = interchainAssetOptions;
 
-  assert(denom, 'INTERCHAIN_DENOM is required');
+  assert(issuerBoardId, 'INTERCHAIN_ISSUER_BOARD_ID is required');
 
   const install = wrapInstall ? wrapInstall(install0) : install0;
 
@@ -29,7 +31,7 @@ export const defaultProposalBuilder = async (
       getManifestForAddAssetToVault.name,
       {
         interchainAssetOptions: {
-          denom,
+          issuerBoardId,
           decimalPlaces,
           keyword,
           proposedName,
@@ -50,8 +52,9 @@ export const defaultProposalBuilder = async (
 export const psmProposalBuilder = async (
   { publishRef, install: install0, wrapInstall },
   { anchorOptions = /** @type {object} */ ({}) } = {},
+  { env = process.env } = {},
 ) => {
-  const { denom = process.env.ANCHOR_DENOM, decimalPlaces = 6 } = anchorOptions;
+  const { denom = env.ANCHOR_DENOM, decimalPlaces = 6 } = anchorOptions;
 
   assert(denom, 'ANCHOR_DENOM is required');
 

--- a/packages/run-protocol/scripts/build-bundles.js
+++ b/packages/run-protocol/scripts/build-bundles.js
@@ -7,7 +7,8 @@ import process from 'process';
 import { defaultProposalBuilder } from './init-core.js';
 import { defaultProposalBuilder as collateralProposalBuilder } from './add-collateral-core.js';
 
-process.env.INTERCHAIN_DENOM = 'arbitrary value to prevent build error';
+process.env.INTERCHAIN_ISSUER_BOARD_ID =
+  'arbitrary value to prevent build error';
 
 const dirname = url.fileURLToPath(new URL('.', import.meta.url));
 extractProposalBundles(

--- a/packages/run-protocol/scripts/init-core.js
+++ b/packages/run-protocol/scripts/init-core.js
@@ -33,6 +33,10 @@ const installKeyGroups = {
       '../src/vpool-xyk-amm/multipoolMarketMaker.js',
       '../bundles/bundle-amm.js',
     ],
+    interchainPool: [
+      '../src/interchainPool.js',
+      '../bundles/bundle-interchainPool.js',
+    ],
     vaultFactory: [
       '../src/vaultFactory/vaultFactory.js',
       '../bundles/bundle-vaultFactory.js',

--- a/packages/run-protocol/src/interchainPool.js
+++ b/packages/run-protocol/src/interchainPool.js
@@ -1,0 +1,137 @@
+// @ts-check
+import { E, Far } from '@endo/far';
+import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
+import { offerTo } from '@agoric/zoe/src/contractSupport/index.js';
+
+const { details: X, quote: q } = assert;
+
+const COSMOS_DECIMALS = 6;
+
+/**
+ * Given sufficient IST, create an issuer for an IBC denom
+ * and an invitation to add a pool for it to the AMM.
+ *
+ * @param {ZCF<InterchainPoolTerms>} zcf
+ * @param {{
+ *   bankManager: ERef<BankManager>,
+ * }} privateArgs
+ *
+ * TODO: get minimumCentral dynamically from the AMM
+ * @typedef {{
+ *   minimumCentral: Amount<'nat'>,
+ *   amm: Instance,
+ * }} InterchainPoolTerms
+ *
+ * @typedef {{
+ *   denom: string,
+ *   decimalPlaces: number,
+ * }} AssetDetail
+ */
+export const start = (zcf, { bankManager }) => {
+  const {
+    brands: { Central: centralBrand },
+    minimumCentral,
+    amm,
+  } = zcf.getTerms();
+  AmountMath.coerce(centralBrand, minimumCentral);
+
+  const zoe = zcf.getZoeService();
+  /** @type {ERef<XYKAMMPublicFacet>} */
+  const ammPub = E(zoe).getPublicFacet(amm);
+
+  let kwNonce = 0;
+
+  /**
+   * @param {ZCFSeat} seat
+   * @param {AssetDetail} detail
+   */
+  const step1Handler = async (seat, detail) => {
+    assert.typeof(
+      detail,
+      'object',
+      'offer arg must be { denom, decimalPlaces? }',
+    );
+    const { denom, decimalPlaces = COSMOS_DECIMALS } = detail;
+    assert.typeof(denom, 'string');
+    assert.typeof(decimalPlaces, 'number');
+
+    const {
+      give: { Central: centralAmt },
+    } = seat.getProposal();
+    assert(
+      AmountMath.isGTE(centralAmt, minimumCentral),
+      X`at least ${q(minimumCentral)} required; only ${q(centralAmt)} given`,
+    );
+
+    const interAsset = makeIssuerKit(
+      denom,
+      AssetKind.NAT,
+      harden({ decimalPlaces }),
+    );
+    kwNonce += 1;
+
+    await zcf.saveIssuer(interAsset.issuer, `Interchain${kwNonce}`);
+
+    /** @type { OfferHandler } */
+    const step2Handler = async seat2 => {
+      const {
+        give: { Secondary: secondaryAmt },
+      } = seat2.getProposal();
+      AmountMath.coerce(interAsset.brand, secondaryAmt);
+
+      const liquidityIssuer = await E(ammPub).addPool(
+        interAsset.issuer,
+        `Interchain${kwNonce}`,
+      );
+      await zcf.saveIssuer(liquidityIssuer, `Liquidity${kwNonce}`);
+
+      const proposal = harden({
+        give: {
+          Central: centralAmt,
+          Secondary: secondaryAmt,
+        },
+      });
+
+      seat2.incrementBy(seat.decrementBy(harden({ Central: centralAmt })));
+      zcf.reallocate(seat, seat2);
+
+      const invitation = await E(ammPub).makeAddLiquidityInvitation();
+      const { userSeatPromise, deposited } = await offerTo(
+        zcf,
+        invitation,
+        undefined,
+        proposal,
+        seat2,
+      );
+      return deposited.then(_ => {
+        seat.exit();
+        seat2.exit();
+
+        return E(userSeatPromise).getOfferResult();
+      });
+    };
+
+    const keyword = denom; // ISSUE #5412: should not show up in all wallets.
+    const proposedName = denom;
+    const [invitation] = await Promise.all([
+      zcf.makeInvitation(step2Handler, 'interchain pool step 2'),
+      E(bankManager).addAsset(
+        denom,
+        keyword,
+        proposedName,
+        interAsset, // with mint
+      ),
+    ]);
+
+    return harden({
+      issuer: interAsset.issuer,
+      invitation,
+    });
+  };
+
+  const publicFacet = Far('InterchainPoolGateway', {
+    makeInterchainPoolInvitation: () =>
+      zcf.makeInvitation(step1Handler, 'interchain pool step 1'),
+  });
+  return { publicFacet };
+};

--- a/packages/run-protocol/src/proposals/core-proposal.js
+++ b/packages/run-protocol/src/proposals/core-proposal.js
@@ -43,6 +43,22 @@ const SHARED_MAIN_MANIFEST = harden({
       produce: { amm: 'amm', ammGovernor: 'ammGovernor' },
     },
   },
+  [econBehaviors.startInterchainPool.name]: {
+    consume: { bankManager: 'bank', zoe: 'zoe', agoricNamesAdmin: true },
+    installation: {
+      consume: { interchainPool: 'zoe' },
+    },
+    brand: {
+      consume: { RUN: 'zoe' },
+    },
+    issuer: {
+      consume: { RUN: 'zoe' },
+    },
+    instance: {
+      consume: { amm: 'amm' },
+      produce: { interchainPool: 'interchainPool' },
+    },
+  },
   [econBehaviors.startVaultFactory.name]: {
     consume: {
       feeMintAccess: 'zoe',
@@ -248,6 +264,7 @@ export const getManifestForMain = (
       VaultFactory: restoreRef(installKeys.vaultFactory),
       liquidate: restoreRef(installKeys.liquidate),
       reserve: restoreRef(installKeys.reserve),
+      interchainPool: restoreRef(installKeys.interchainPool),
     },
     options: {
       vaultFactoryControllerAddress,

--- a/packages/run-protocol/src/proposals/econ-behaviors.js
+++ b/packages/run-protocol/src/proposals/econ-behaviors.js
@@ -25,6 +25,7 @@ const SECONDS_PER_HOUR = 60n * 60n;
 const SECONDS_PER_DAY = 24n * SECONDS_PER_HOUR;
 
 const BASIS_POINTS = 10_000n;
+const MILLI = 1_000_000n;
 
 const CENTRAL_DENOM_NAME = 'urun';
 
@@ -101,6 +102,60 @@ export const startEconomicCommittee = async (
   economicCommittee.resolve(instance);
 };
 harden(startEconomicCommittee);
+
+/**
+ * @param { EconomyBootstrapPowers } powers
+ * @param {{
+ *   interchainPoolOptions?: { minimumCentral?: bigint }
+ * }} [options]
+ */
+export const startInterchainPool = async (
+  {
+    consume: { bankManager: mgrP, zoe, agoricNamesAdmin },
+    installation: {
+      consume: { interchainPool: installationP },
+    },
+    instance: {
+      consume: { amm: ammP },
+      produce: { interchainPool: _viaAgoricNamesAdmin },
+    },
+    brand: {
+      consume: { RUN: centralBrandP },
+    },
+    issuer: {
+      consume: { RUN: centralIssuerP },
+    },
+  },
+  { interchainPoolOptions = {} } = {},
+) => {
+  // TODO: get minimumCentral dynamically from the AMM
+  const { minimumCentral = 100n * MILLI } = interchainPoolOptions;
+  const [centralIssuer, centralBrand, installation, bankManager, amm] =
+    await Promise.all([
+      centralIssuerP,
+      centralBrandP,
+      installationP,
+      mgrP,
+      ammP,
+    ]);
+
+  const terms = {
+    minimumCentral: AmountMath.make(centralBrand, minimumCentral),
+    amm,
+  };
+  const { instance } = await E(zoe).startInstance(
+    installation,
+    { Central: centralIssuer },
+    terms,
+    {
+      bankManager,
+    },
+  );
+
+  const instanceAdmin = E(agoricNamesAdmin).lookupAdmin('instance');
+  await E(instanceAdmin).update('interchainPool', instance);
+};
+harden(startInterchainPool);
 
 /** @param { EconomyBootstrapPowers } powers */
 export const setupAmm = async ({

--- a/packages/run-protocol/src/vpool-xyk-amm/addLiquidity.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addLiquidity.js
@@ -21,7 +21,6 @@ const makeMakeAddLiquidityInvitation = (zcf, getPool) => {
         Central: null,
         Secondary: null,
       },
-      want: { Liquidity: null },
     });
     // Get the brand of the secondary token so we can identify the liquidity pool.
     const secondaryBrand = seat.getProposal().give.Secondary.brand;

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/setup.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/setup.js
@@ -53,8 +53,9 @@ export const setupAMMBootstrap = async (
   produce.chainTimerService.resolve(timer);
   produce.zoe.resolve(zoe);
 
-  const { agoricNames, spaces } = makeAgoricNamesAccess();
+  const { agoricNames, agoricNamesAdmin, spaces } = makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
+  produce.agoricNamesAdmin.resolve(agoricNamesAdmin);
 
   installGovernance(zoe, spaces.installation.produce);
 

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -23,7 +23,7 @@ import {
   startRunStake,
 } from '../../src/proposals/econ-behaviors.js';
 import * as Collect from '../../src/collect.js';
-import { makeVoterTool, setUpZoeForTest } from '../supports.js';
+import { makeVoterTool, setUpZoeForTest, mintRunPayment } from '../supports.js';
 import { ManagerKW as KW } from '../../src/runStake/constants.js';
 import { unsafeMakeBundleCache } from '../bundleTool.js';
 
@@ -269,31 +269,6 @@ const makeWalletMaker = creatorFacet => {
     return harden({ attMaker });
   };
   return makeWallet;
-};
-
-/**
- * @param {bigint} value
- * @param {{
- *   centralSupply: ERef<Installation>,
- *   feeMintAccess: ERef<FeeMintAccess>,
- *   zoe: ERef<ZoeService>,
- * }} powers
- * @returns { Promise<Payment> }
- */
-const mintRunPayment = async (
-  value,
-  { centralSupply, feeMintAccess: feeMintAccessP, zoe },
-) => {
-  const feeMintAccess = await feeMintAccessP;
-
-  const { creatorFacet: ammSupplier } = await E(zoe).startInstance(
-    centralSupply,
-    {},
-    { bootstrapPaymentValue: value },
-    { feeMintAccess },
-  );
-  // TODO: stop the contract vat?
-  return E(ammSupplier).getBootstrapPayment();
 };
 
 test('wrap liened amount', async (/** @type {RunStakeTestContext} */ t) => {

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -126,3 +126,27 @@ export const makeVoterTool = async (
     },
   });
 };
+
+/**
+ * @param {bigint} value
+ * @param {{
+ *   centralSupply: ERef<Installation>,
+ *   feeMintAccess: ERef<FeeMintAccess>,
+ *   zoe: ERef<ZoeService>,
+ * }} powers
+ * @returns { Promise<Payment> }
+ */
+export const mintRunPayment = async (
+  value,
+  { centralSupply, feeMintAccess: feeMintAccessP, zoe },
+) => {
+  const feeMintAccess = await feeMintAccessP;
+
+  const { creatorFacet: ammSupplier } = await E(zoe).startInstance(
+    centralSupply,
+    {},
+    { bootstrapPaymentValue: value },
+    { feeMintAccess },
+  );
+  return E(ammSupplier).getBootstrapPayment();
+};

--- a/packages/run-protocol/test/test-gov-collateral.js
+++ b/packages/run-protocol/test/test-gov-collateral.js
@@ -4,6 +4,7 @@ import process from 'process';
 import url from 'url';
 import path from 'path';
 import { E, Far } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
 import {
   addBankAssets,
   makeAddressNameHubs,
@@ -11,6 +12,7 @@ import {
   makeBoard,
   startPriceAuthority,
 } from '@agoric/vats/src/core/basic-behaviors.js';
+import centralSupplyBundle from '@agoric/vats/bundles/bundle-centralSupply.js';
 import {
   bridgeCoreEval,
   makeClientManager,
@@ -20,7 +22,9 @@ import { makeCoreProposalBehavior } from '@agoric/deploy-script-support/src/core
 import { makeNameHubKit } from '@agoric/vats/src/nameHub.js';
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { makeNodeBundleCache } from './bundleTool.js';
-import { setupBootstrap, setUpZoeForTest } from './supports.js';
+import { setupBootstrap, setUpZoeForTest, mintRunPayment } from './supports.js';
+
+/** @template T @typedef {import('@endo/promise-kit').PromiseKit<T>} PromiseKit */
 
 const { details: X } = assert;
 const dirname = url.fileURLToPath(new URL('.', import.meta.url));
@@ -60,6 +64,7 @@ const makeTestContext = async () => {
     bundleCache.load(src, dest).then(b => E(zoe).install(b));
   const installation = {
     mintHolder: install(contractRoots.mintHolder, 'mintHolder'),
+    centralSupply: E(zoe).install(centralSupplyBundle),
     econCommitteeCharter: install(
       contractRoots.econCommitteeCharter,
       'econCommitteeCharter',
@@ -106,6 +111,9 @@ test.before(async t => {
   t.context = await makeTestContext();
 });
 
+/**
+ * @param {import('ava').ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
+ */
 const makeScenario = async t => {
   const space = await setupBootstrap(t);
 
@@ -127,9 +135,26 @@ const makeScenario = async t => {
     );
   };
 
+  /** @type {PromiseKit<IssuerKit>} */
+  const ibcKitP = makePromiseKit();
+
   const startDevNet = async () => {
     // If we don't have a proper bridge manager, we need it to be undefined.
     space.produce.bridgeManager.resolve(undefined);
+
+    const bankManager = Far('mock BankManager', {
+      addAsset: (denom, keyword, proposedName, kit) => {
+        t.log('addAsset', { denom, keyword, issuer: `${kit.issuer}` });
+        t.truthy(kit.mint);
+        ibcKitP.resolve(kit);
+      },
+      getFeeCollectorDepositFacet: () =>
+        harden({
+          receive: () => {},
+        }),
+    });
+    // @ts-ignore mock doesn't have all the methods
+    space.produce.bankManager.resolve(bankManager);
 
     space.installation.produce.mintHolder.resolve(
       t.context.installation.mintHolder,
@@ -253,15 +278,12 @@ const makeScenario = async t => {
     ]);
   };
 
-  const enactVaultAssetProposal = async (denom = 'ibc/abc123') => {
-    // If necessary, this is how to hobble interchainMints in production:
-    /*
-      space.produce.interchainMints.reject(
-        Error('no interchain mints in production'),
-      );
-      space.consume.interchainMints.catch(() => {});
-    */
-    process.env.INTERCHAIN_DENOM = denom;
+  /** @type {PromiseKit<string>} */
+  const atomIssuerPK = makePromiseKit();
+
+  const enactVaultAssetProposal = async () => {
+    const boardId = await atomIssuerPK.promise;
+    process.env.INTERCHAIN_ISSUER_BOARD_ID = boardId;
     await evalProposals([coreProposals.addCollateral]);
   };
 
@@ -270,26 +292,107 @@ const makeScenario = async t => {
     await evalProposals([coreProposals.inviteCommittee]);
   };
 
-  const benefactorDeposit = async (qty = 10_000n) => {
-    const { interchainMints, agoricNames, zoe } = space.consume;
-    const ibcAtomBrand = await E(agoricNames).lookup('brand', 'IbcATOM');
-    /** @type {ERef<import('../src/reserve/assetReserve').AssetReservePublicFacet>} */
-    const reserveAPI = E(zoe).getPublicFacet(
-      E(agoricNames).lookup('instance', 'reserve'),
-    );
-    const proposal = harden({
-      give: { Collateral: AmountMath.make(ibcAtomBrand, qty * 1_000_000n) },
-    });
+  /**
+   * @param {{
+   *   agoricNames: ERef<NameHub>,
+   *   board: ERef<Board>,
+   *   zoe: ERef<ZoeService>,
+   *   wallet: {
+   *     purses: {
+   *       ist: ERef<Purse>,
+   *       atom: ERef<Purse>,
+   *     },
+   *   },
+   * }} home
+   */
+  const makeBenefactor = home => {
+    const {
+      agoricNames,
+      board,
+      zoe,
+      wallet: { purses },
+    } = home;
 
-    const atom10k = await E(E.get(interchainMints)[0]).mintPayment(
-      proposal.give.Collateral,
+    return harden({
+      makePool: async (atomQty = 100n, istQty = 500n) => {
+        const istBrand = await E(agoricNames).lookup('brand', 'RUN');
+        const istAmt = qty => AmountMath.make(istBrand, qty * 1_000_000n);
+        const interchainPoolAPI = E(zoe).getPublicFacet(
+          E(agoricNames).lookup('instance', 'interchainPool'),
+        );
+
+        const proposal1 = harden({ give: { Central: istAmt(istQty) } });
+        const centralPmt = await E(purses.ist).withdraw(proposal1.give.Central);
+        const inv1 = await E(interchainPoolAPI).makeInterchainPoolInvitation();
+        const seat1 = await E(zoe).offer(
+          inv1,
+          proposal1,
+          harden({ Central: centralPmt }),
+          harden({ denom: 'ibc/abc123' }),
+        );
+        const { invitation: inv2, issuer: ibcIssuer } = await E(
+          seat1,
+        ).getOfferResult();
+        atomIssuerPK.resolve(E(board).getId(ibcIssuer));
+        const ibcBrand = await E(ibcIssuer).getBrand();
+        const atomAmt = qty => AmountMath.make(ibcBrand, qty * 1_000_000n);
+
+        const proposal2 = harden({ give: { Secondary: atomAmt(atomQty) } });
+        const pmt2 = await E(purses.atom).withdraw(proposal2.give.Secondary);
+        const seat2 = await E(zoe).offer(
+          inv2,
+          proposal2,
+          harden({ Secondary: pmt2 }),
+        );
+        t.deepEqual(await E(seat2).getOfferResult(), 'Added liquidity.');
+      },
+
+      depositInReserve: async (qty = 10_000n) => {
+        const ibcAtomBrand = await E(agoricNames).lookup('brand', 'IbcATOM');
+        /** @type {ERef<import('../src/reserve/assetReserve').AssetReservePublicFacet>} */
+        const reserveAPI = E(zoe).getPublicFacet(
+          E(agoricNames).lookup('instance', 'reserve'),
+        );
+
+        const proposal = harden({
+          give: { Collateral: AmountMath.make(ibcAtomBrand, qty * 1_000_000n) },
+        });
+        const atom10k = await E(purses.atom).withdraw(proposal.give.Collateral);
+        const seat = E(zoe).offer(
+          await E(reserveAPI).makeAddCollateralInvitation(),
+          proposal,
+          harden({ Collateral: atom10k }),
+        );
+        return E(seat).getOfferResult();
+      },
+    });
+  };
+
+  const { agoricNames, zoe, board } = space.consume;
+  const makeRunPurse = async value => {
+    /** @type {Promise<Issuer<'nat'>>} */
+    const issuerP = E(agoricNames).lookup('issuer', 'RUN');
+    const purseP = E(issuerP).makeEmptyPurse();
+    return mintRunPayment(value, {
+      centralSupply: t.context.installation.centralSupply,
+      feeMintAccess: t.context.feeMintAccess,
+      zoe,
+    }).then(pmt =>
+      E(purseP)
+        .deposit(pmt)
+        .then(_ => purseP),
     );
-    const seat = E(zoe).offer(
-      await E(reserveAPI).makeAddCollateralInvitation(),
-      proposal,
-      harden({ Collateral: atom10k }),
-    );
-    return E(seat).getOfferResult();
+  };
+  const makeAtomPurse = async value => {
+    const { issuer, mint, brand } = await ibcKitP.promise;
+    const purseP = E(issuer).makeEmptyPurse();
+    const pmt = await E(mint).mintPayment(AmountMath.make(brand, value));
+    await E(purseP).deposit(pmt);
+    return purseP;
+  };
+  const purses = {
+    ist: makeRunPurse(10_000n * 1_000_000n),
+    atom: makeAtomPurse(10_000n * 1_000_000n),
   };
 
   return {
@@ -298,7 +401,7 @@ const makeScenario = async t => {
     startRunPreview,
     enactVaultAssetProposal,
     enactInviteEconCommitteeProposal,
-    benefactorDeposit,
+    benefactor: makeBenefactor({ agoricNames, board, zoe, wallet: { purses } }),
     space,
   };
 };
@@ -308,12 +411,13 @@ test('Benefactor can add to reserve', async t => {
   await s.startDevNet();
   await s.provisionMembers();
   await s.startRunPreview();
+  await s.benefactor.makePool(2000n, 100n);
   await Promise.all([
     s.enactVaultAssetProposal(),
     s.enactInviteEconCommitteeProposal(),
   ]);
 
-  const result = await s.benefactorDeposit();
+  const result = await s.benefactor.depositInReserve(4000n);
   t.deepEqual(result, 'added Collateral to the Reserve');
 });
 
@@ -322,6 +426,7 @@ test('voters get invitations', async t => {
   await s.startDevNet();
   const purses = await s.provisionMembers();
   await s.startRunPreview();
+  await s.benefactor.makePool();
   await Promise.all([
     s.enactVaultAssetProposal(),
     s.enactInviteEconCommitteeProposal(),
@@ -353,6 +458,7 @@ test('assets are in AMM, Vaults', async t => {
   await s.startDevNet();
   await s.provisionMembers();
   await s.startRunPreview();
+  await s.benefactor.makePool(2000n, 100n);
 
   await Promise.all([
     s.enactVaultAssetProposal(),
@@ -387,7 +493,8 @@ test('Committee can raise debt limit', async t => {
   const s = await makeScenario(t);
   await s.startDevNet();
   const purses = await s.provisionMembers();
-  s.startRunPreview();
+  await s.startRunPreview();
+  await s.benefactor.makePool(2000n, 100n);
 
   await Promise.all([
     s.enactVaultAssetProposal(),
@@ -429,7 +536,6 @@ test('Committee can raise debt limit', async t => {
     deadline,
   );
 
-  t.log('@@actual', actual);
   t.deepEqual(actual, {
     details: actual.details,
     instance: votingInv.instance,

--- a/packages/run-protocol/test/test-interchainPool.js
+++ b/packages/run-protocol/test/test-interchainPool.js
@@ -1,0 +1,174 @@
+// @ts-check
+import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+
+import { E, Far } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
+import { makeNodeBundleCache } from './bundleTool.js';
+import { setUpZoeForTest } from './supports.js';
+import { setupAmmServices } from './amm/vpool-xyk-amm/setup.js';
+import { startInterchainPool } from '../src/proposals/econ-behaviors.js';
+
+/** @template T @typedef {import('@endo/promise-kit').PromiseKit<T>} PromiseKit */
+
+/** @type {import('ava').TestInterface<Awaited<ReturnType<makeTestContext>>>} */
+// @ts-expect-error cast
+const test = anyTest;
+
+const contractRoots = {
+  interchainPool: './src/interchainPool.js',
+};
+
+const makeTestContext = async () => {
+  const bundleCache = await makeNodeBundleCache('bundles/', s => import(s));
+  const { zoe } = setUpZoeForTest();
+
+  const istKit = makeIssuerKit('IST');
+
+  const install = (src, dest) =>
+    bundleCache.load(src, dest).then(b => E(zoe).install(b));
+  const installation = {
+    interchainPool: install(contractRoots.interchainPool, 'interchainPool'),
+  };
+
+  return {
+    bundleCache,
+    zoe: await zoe,
+    istKit,
+    installation,
+  };
+};
+
+test.before(async t => {
+  t.context = await makeTestContext();
+});
+
+const { keys } = Object;
+
+test('make interchain pool', async t => {
+  const { make, add } = AmountMath;
+  const { zoe, istKit, installation } = t.context;
+
+  const minimumCentral = make(istKit.brand, 100n * 1_000_000n);
+
+  // Start AMM
+  const {
+    amm: { ammPublicFacet: ammPub },
+    space,
+  } = await setupAmmServices(t, undefined, istKit, undefined, zoe);
+
+  const bootstrap = async () => {
+    // Mock VBANK / BankManager
+    /** @type {PromiseKit<{ mint: ERef<Mint>, issuer: ERef<Issuer>, brand: Brand}>} */
+    const ibcKitP = makePromiseKit();
+
+    /** @type {Awaited<BankManager>} */
+    const bankManager = Far('mock BankManager', {
+      getAssetSubscription: () => assert.fail('not impl'),
+      getModuleAccountAddress: () => assert.fail('not impl'),
+      getRewardDistributorDepositFacet: () => assert.fail('not impl'),
+      addAsset: async (denom, keyword, proposedName, kit) => {
+        t.log('addAsset', { denom, keyword, issuer: `${kit.issuer}` });
+        t.truthy(kit.mint);
+        ibcKitP.resolve({ ...kit, mint: kit.mint || assert.fail() });
+      },
+      getBankForAddress: () => assert.fail('not impl'),
+    });
+
+    space.produce.bankManager.resolve(bankManager);
+    // space.installation.produce.interchainPool.reset();
+    space.installation.produce.interchainPool.resolve(
+      installation.interchainPool,
+    );
+
+    // Start the contract
+    await startInterchainPool(space);
+    const agoricNames = space.consume.agoricNames;
+    const instance = await E(agoricNames).lookup('instance', 'interchainPool');
+    const publicFacet = E(zoe).getPublicFacet(instance);
+
+    const makeVPurse = value =>
+      ibcKitP.promise.then(async ({ issuer, mint, brand }) => {
+        const amt = make(brand, value);
+        const purse = E(issuer).makeEmptyPurse();
+        const pmt = await E(mint).mintPayment(amt);
+        await E(purse).deposit(pmt);
+        return purse;
+      });
+    return { publicFacet, makeVPurse };
+  };
+  const { publicFacet, makeVPurse } = await bootstrap();
+
+  const checkPayouts = async (seat, amts, issuers) => {
+    const actualPayouts = await E(seat).getPayouts();
+    t.log({ seat, actualPayouts });
+    t.deepEqual(keys(actualPayouts).sort(), keys(amts).sort());
+    for (const kw of keys(amts)) {
+      // eslint-disable-next-line no-await-in-loop
+      const pmt = await actualPayouts[kw];
+      // eslint-disable-next-line no-await-in-loop
+      const actual = await E(issuers[kw]).getAmountOf(pmt);
+      t.deepEqual(actual, amts[kw]);
+    }
+  };
+
+  const moneyPants = async purses => {
+    const denom = 'ibc/123';
+    const inv1 = await E(publicFacet).makeInterchainPoolInvitation();
+    const proposal1 = harden({
+      give: { Central: add(minimumCentral, make(istKit.brand, 500n)) },
+    });
+    const centralPmt = await E(purses.ist).withdraw(proposal1.give.Central);
+
+    const seat1 = await E(zoe).offer(
+      inv1,
+      proposal1,
+      harden({ Central: centralPmt }),
+      harden({ denom }),
+    );
+    const { invitation: inv2, issuer: ibcIssuer } = await E(
+      seat1,
+    ).getOfferResult();
+    const ibcBrand = await E(ibcIssuer).getBrand();
+
+    const proposal2 = harden({
+      give: { Secondary: make(ibcBrand, 100n) },
+    });
+    const pmt2 = await E(purses.ibc).withdraw(proposal2.give.Secondary);
+    const seat2 = await E(zoe).offer(
+      inv2,
+      proposal2,
+      harden({ Secondary: pmt2 }),
+    );
+    t.deepEqual(await E(seat2).getOfferResult(), 'Added liquidity.');
+
+    const liquidityIssuer = await E(ammPub).getLiquidityIssuer(ibcBrand);
+    const liqBrand = await E(liquidityIssuer).getBrand();
+
+    await checkPayouts(
+      seat1,
+      { Central: make(istKit.brand, 0n) },
+      { Central: istKit.issuer },
+    );
+
+    await checkPayouts(
+      seat2,
+      {
+        Central: make(istKit.brand, 0n),
+        Secondary: make(ibcBrand, 0n),
+        Liquidity: make(liqBrand, proposal1.give.Central.value),
+      },
+      {
+        Central: istKit.issuer,
+        Secondary: ibcIssuer,
+        Liquidity: liquidityIssuer,
+      },
+    );
+  };
+
+  const istPurse = istKit.issuer.makeEmptyPurse();
+  istPurse.deposit(
+    istKit.mint.mintPayment(make(istKit.brand, 10_000n * 1_000_000n)),
+  );
+  await moneyPants({ ist: istPurse, ibc: makeVPurse(1000n) });
+});

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -139,12 +139,12 @@
  *     'centralSupply' | 'mintHolder' |
  *     'contractGovernor' | 'committee' | 'noActionElectorate' | 'binaryVoteCounter' |
  *     'amm' | 'VaultFactory' | 'liquidate' | 'runStake' |
- *     'Pegasus' | 'reserve' | 'psm',
+ *     'Pegasus' | 'reserve' | 'psm' | 'interchainPool',
  *   instance: |
  *     'economicCommittee' |
  *     'amm' | 'ammGovernor' | 'VaultFactory' | 'VaultFactoryGovernor' |
  *     'runStake' | 'runStakeGovernor' |
- *     'psm' | 'psmGovernor' |
+ *     'psm' | 'psmGovernor' | 'interchainPool' |
  *     'Treasury' | 'reserve' | 'reserveGovernor' | 'Pegasus',
  *   oracleBrand:
  *     'USD',

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -46,6 +46,7 @@ export const agoricNamesReserved = harden({
     Pegasus: 'pegasus',
     reserve: 'collateral reserve',
     psm: 'Parity Stability Module',
+    interchainPool: 'interchainPool',
   },
   instance: {
     economicCommittee: 'Economic Committee',
@@ -61,6 +62,7 @@ export const agoricNamesReserved = harden({
     reserveGovernor: 'ReserveGovernor',
     psm: 'Parity Stability Module',
     psmGovernor: 'PSM Governor',
+    interchainPool: 'interchainPool',
   },
   oracleBrand: {
     USD: 'US Dollar',


### PR DESCRIPTION
refs: #5075, #4643

## Description

Given sufficient IST, create an issuer for an IBC denom and an invitation to add a pool for it to the AMM.

There are 2 steps:
  1. offer IST (Central) and provide a denom in the offer args; get back the issuer for that denom in the VBANK
  2. offer the new asset (Secondary) and get back liquidity.

Un-ties knots discussed in https://github.com/Agoric/agoric-sdk/issues/4643#issuecomment-1130411097 , https://github.com/Agoric/agoric-sdk/issues/5075#issuecomment-1115225570

TODO:
 - [x] `bankManager` should have a method like `addAsset` that does _not_ propagate to every wallet in the system.
   - postponed as #5412
 - [x] bootstrap wiring

### Security Considerations

Does not provide offer safety, due to usual propoerties of `offerTo`.

Requires `bankManager` as a private arg.

### Documentation Considerations

Yet Another Contract to document / review.
cc @jessysaurusrex 

### Testing Considerations

Lightly tested. Reviewers will please suggest further tests.
