### PR TITLE
fix(deploy): enforce `--hostport` URLs use `/private/captp`

### DIFF
--- a/packages/agoric-cli/src/deploy.js
+++ b/packages/agoric-cli/src/deploy.js
@@ -13,6 +13,8 @@ import { createRequire } from 'module';
 
 import { getAccessToken } from '@agoric/access-token';
 
+const { details: X } = assert;
+
 const require = createRequire(import.meta.url);
 const esmRequire = createEsmRequire({});
 
@@ -80,11 +82,11 @@ export default async function deployMain(progname, rawArgs, powers, opts) {
   const port = match ? match[2] : '8000';
 
   const wsurl = opts.hostport.includes('//')
-    ? new URL(opts.hostport)
+    ? new URL(opts.hostport, 'ws://localhost:8000')
     : new URL(`ws://${host}:${port}`);
-  if (wsurl.pathname === '/' && !opts.hostport.endsWith('/')) {
-    wsurl.pathname = '/private/captp';
-  }
+
+  assert.equal(wsurl.pathname, '/', X`${opts.hostport} cannot contain a path`);
+  wsurl.pathname = '/private/captp';
 
   const exit = makePromiseKit();
   let connected = false;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Just a tweak to reduce footguns.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
