### PR TITLE
Publish amm pool list subscription to chain storage

### DIFF
--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -99,7 +99,7 @@ export const makeAsyncIterableFromNotifier = notifierP => {
  * @returns {Promise<undefined>}
  */
 export const observeIterator = (asyncIteratorP, iterationObserver) => {
-  return new Promise(ack => {
+  return new Promise((ack, observerError) => {
     const recur = () => {
       E.when(
         E(asyncIteratorP).next(),
@@ -117,7 +117,7 @@ export const observeIterator = (asyncIteratorP, iterationObserver) => {
           iterationObserver.fail && iterationObserver.fail(reason);
           ack(undefined);
         },
-      );
+      ).catch(observerError);
     };
     recur();
   });

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -16,3 +16,4 @@ export {
   // Consider deprecating or not reexporting
   makeAsyncIterableFromNotifier,
 } from './asyncIterableAdaptor.js';
+export * from './storesub.js';

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -1,0 +1,78 @@
+// @ts-check
+import { E } from '@endo/eventual-send';
+import { Far, makeMarshal } from '@endo/marshal';
+import { observeIteration } from './asyncIterableAdaptor.js';
+
+/**
+ * Begin iterating the source, storing serialized iteration values.  If the
+ * storageNode's `setValue` operation rejects, the iteration will be terminated.
+ *
+ * Returns a StoredSubscription that can be used by a client to directly follow
+ * the iteration themselves, or obtain information to subscribe to the stored
+ * data out-of-band.
+ *
+ * @template T
+ * @param {Subscription<T>} subscription
+ * @param {ERef<StorageNode>} [storageNode]
+ * @param {ERef<ReturnType<typeof makeMarshal>>} [marshaller]
+ * @returns {StoredSubscription<T>}
+ */
+export const makeStoredSubscription = (
+  subscription,
+  storageNode,
+  marshaller = makeMarshal(undefined, undefined, {
+    marshalSaveError: () => {},
+  }),
+) => {
+  /** @type {Unserializer} */
+  const unserializer = Far('unserializer', {
+    unserialize: E(marshaller).unserialize,
+  });
+
+  // Abort the iteration on the next observation if the publisher ever fails.
+  let publishFailed = false;
+  let publishException;
+
+  const fail = err => {
+    publishFailed = true;
+    publishException = err;
+  };
+
+  // Must *not* be an async function, because it sometimes must throw to abort
+  // the iteration.
+  const publishValue = obj => {
+    assert(storageNode);
+    if (publishFailed) {
+      // To properly abort the iteration, this must be a synchronous exception.
+      throw publishException;
+    }
+
+    // Publish the value, capturing any error.
+    E(marshaller)
+      .serialize(obj)
+      .then(serialized => {
+        const encoded = JSON.stringify(serialized);
+        return E(storageNode).setValue(encoded);
+      })
+      .catch(fail);
+  };
+
+  if (storageNode) {
+    // Start publishing the source.
+    observeIteration(subscription, {
+      updateState: publishValue,
+      finish: publishValue,
+    }).catch(fail);
+  }
+
+  /** @type {StoredSubscription<T>} */
+  const storesub = Far('StoredSubscription', {
+    getStoreKey: () => storageNode && E(storageNode).getStoreKey(),
+    getUnserializer: () => unserializer,
+    getSharableSubscriptionInternals:
+      subscription.getSharableSubscriptionInternals,
+    [Symbol.asyncIterator]: subscription[Symbol.asyncIterator],
+  });
+  return storesub;
+};
+harden(makeStoredSubscription);

--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -57,9 +57,10 @@ const makeSubscriptionIterator = tailP => {
  * distributed pub/sub.
  *
  * @template T
+ * @param {T[]} optionalInitialState
  * @returns {SubscriptionRecord<T>}
  */
-const makeSubscriptionKit = () => {
+const makeSubscriptionKit = (...optionalInitialState) => {
   /** @type {((internals: ERef<SubscriptionInternals<T>>) => void) | undefined} */
   let rear;
   const hp = new HandledPromise(r => (rear = r));
@@ -96,6 +97,10 @@ const makeSubscriptionKit = () => {
       rear = undefined;
     },
   });
+
+  if (optionalInitialState.length > 0) {
+    publication.updateState(optionalInitialState[0]);
+  }
   return harden({ publication, subscription });
 };
 harden(makeSubscriptionKit);

--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -46,6 +46,7 @@ const makeSubscriptionIterator = tailP => {
     next: () => {
       const resultP = E.get(tailP).head;
       tailP = E.get(tailP).tail;
+      Promise.resolve(tailP).catch(() => {}); // suppress unhandled rejection error
       return resultP;
     },
   });

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -158,3 +158,29 @@
  * @property {IterationObserver<T>} publication
  * @property {Subscription<T>} subscription
  */
+
+/** @typedef {ReturnType<typeof import('@endo/marshal').makeMarshal>} Marshaller */
+
+/**
+ * @typedef {object} Unserializer
+ * @property {Marshaller['unserialize']} unserialize
+ */
+
+/**
+ * @typedef {object} StorageNode
+ * @property {(data: string) => void} setValue publishes some data
+ * @property {() => unknown} getStoreKey get the externally-reachable store key
+ * for this storage item
+ * @property {(subPath: string) => StorageNode} getChildNode TODO: makeChildNode
+ */
+
+/**
+ * @typedef {object} StoredFacet
+ * @property {StorageNode['getStoreKey']} getStoreKey get the externally-reachable store key
+ * @property {() => Unserializer} getUnserializer get the unserializer for the stored data
+ */
+
+/**
+ * @template T
+ * @typedef {Subscription<T> & StoredFacet} StoredSubscription
+ */

--- a/packages/notifier/test/marshal-corpus.js
+++ b/packages/notifier/test/marshal-corpus.js
@@ -1,0 +1,73 @@
+/**
+ * Based on roundTripPairs from test-marshal.js
+ *
+ * A list of `[body, justinSrc]` pairs, where the body parses into
+ * an encoding that decodes to a Justin expression that evaluates to something
+ * that has the same encoding.
+ */
+export const jsonPairs = harden([
+  // Justin is the same as the JSON encoding but without unnecessary quoting
+  ['[1,2]', '[1,2]'],
+  ['{"foo":1}', '{foo:1}'],
+  ['{"a":1,"b":2}', '{a:1,b:2}'],
+  ['{"a":1,"b":{"c":3}}', '{a:1,b:{c:3}}'],
+  ['true', 'true'],
+  ['1', '1'],
+  ['"abc"', '"abc"'],
+  ['null', 'null'],
+
+  // Primitives not representable in JSON
+  ['{"@qclass":"undefined"}', 'undefined'],
+  // FIGME: Uncomment when this is in agoric-sdk: https://github.com/endojs/endo/pull/1204
+  // ['{"@qclass":"NaN"}', 'NaN'], // TODO: uncomment
+  ['{"@qclass":"Infinity"}', 'Infinity'],
+  ['{"@qclass":"-Infinity"}', '-Infinity'],
+  ['{"@qclass":"bigint","digits":"4"}', '4n'],
+  ['{"@qclass":"bigint","digits":"9007199254740993"}', '9007199254740993n'],
+  ['{"@qclass":"symbol","name":"@@asyncIterator"}', 'Symbol.asyncIterator'],
+  ['{"@qclass":"symbol","name":"@@match"}', 'Symbol.match'],
+  ['{"@qclass":"symbol","name":"foo"}', 'Symbol.for("foo")'],
+  ['{"@qclass":"symbol","name":"@@@@foo"}', 'Symbol.for("@@foo")'],
+
+  // Arrays and objects
+  ['[{"@qclass":"undefined"}]', '[undefined]'],
+  ['{"foo":{"@qclass":"undefined"}}', '{foo:undefined}'],
+  ['{"@qclass":"error","message":"","name":"Error"}', 'Error("")'],
+  [
+    '{"@qclass":"error","message":"msg","name":"ReferenceError"}',
+    'ReferenceError("msg")',
+  ],
+
+  // The one case where JSON is not a semantic subset of JS
+  ['{"__proto__":8}', '{["__proto__"]:8}'],
+
+  // The Hilbert Hotel is always tricky
+  ['{"@qclass":"hilbert","original":8}', '{"@qclass":8}'],
+  ['{"@qclass":"hilbert","original":"@qclass"}', '{"@qclass":"@qclass"}'],
+  [
+    '{"@qclass":"hilbert","original":{"@qclass":"hilbert","original":8}}',
+    '{"@qclass":{"@qclass":8}}',
+  ],
+  [
+    '{"@qclass":"hilbert","original":{"@qclass":"hilbert","original":8,"rest":{"foo":"foo1"}},"rest":{"bar":{"@qclass":"hilbert","original":{"@qclass":"undefined"}}}}',
+    '{"@qclass":{"@qclass":8,foo:"foo1"},bar:{"@qclass":undefined}}',
+  ],
+
+  // tagged
+  ['{"@qclass":"tagged","tag":"x","payload":8}', 'makeTagged("x",8)'],
+  [
+    '{"@qclass":"tagged","tag":"x","payload":{"@qclass":"undefined"}}',
+    'makeTagged("x",undefined)',
+  ],
+
+  // Slots
+  [
+    '[{"@qclass":"slot","iface":"Alleged: for testing Justin","index":0}]',
+    '[slot(0,"Alleged: for testing Justin")]',
+  ],
+  // Tests https://github.com/endojs/endo/issues/1185 fix
+  [
+    '[{"@qclass":"slot","iface":"Alleged: for testing Justin","index":0},{"@qclass":"slot","index":0}]',
+    '[slot(0,"Alleged: for testing Justin"),slot(0)]',
+  ],
+]);

--- a/packages/notifier/test/test-notifier-adaptor.js
+++ b/packages/notifier/test/test-notifier-adaptor.js
@@ -49,6 +49,52 @@ test('observeIteration - update from iterator fails', t => {
   return observeIteration(explodingStream, u);
 });
 
+test('observeIteration - synchronous throw from observer stops hard', async t => {
+  t.plan(2);
+  await t.throwsAsync(
+    () =>
+      observeIteration(finiteStream, {
+        updateState: state => {
+          t.is(state, 1);
+          throw new Error('sync propagates');
+        },
+        finish: state => {
+          t.fail(`unexpected finish with state ${state}`);
+        },
+        fail: reason => {
+          t.is(reason.message, 'sync propagates');
+        },
+      }),
+    { message: 'sync propagates' },
+  );
+});
+
+test('observeIteration - rejection from observer does nothing', async t => {
+  const u = makeTestIterationObserver(t, true, false);
+  const handledRejection = reason => {
+    const r = Promise.reject(reason);
+    r.catch(() => {});
+    return r;
+  };
+  await observeIteration(finiteStream, {
+    ...u,
+    updateState: state => {
+      u.updateState(state);
+      return handledRejection(
+        Error('updateState rejection does not propagate'),
+      );
+    },
+    finish: state => {
+      u.finish(state);
+      return handledRejection(Error('finish rejection does not propagate'));
+    },
+    fail: reason => {
+      u.fail(reason);
+      return handledRejection(Error('fail rejection does not propagate'));
+    },
+  });
+});
+
 // /////////////////////////////// NotifierKit /////////////////////////////////
 
 test('notifier adaptor - manual finishes', async t => {

--- a/packages/notifier/test/test-stored-subscription.js
+++ b/packages/notifier/test/test-stored-subscription.js
@@ -1,0 +1,79 @@
+// @ts-check
+
+// eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava.js';
+
+import { E } from '@endo/eventual-send';
+import { Far, makeMarshal } from '@endo/marshal';
+import { makeSubscriptionKit, makeStoredSubscription } from '../src/index.js';
+
+import '../src/types.js';
+import { jsonPairs } from './marshal-corpus.js';
+
+const makeFakeStorage = (path, publication) => {
+  const fullPath = `publish.${path}`;
+  const storeKey = harden({
+    storeName: 'swingset',
+    storeSubkey: `swingset/data:${fullPath}`,
+  });
+  /** @type {StorageNode} */
+  const storage = Far('fakeStorage', {
+    getStoreKey: () => storeKey,
+    setValue: value => {
+      assert.typeof(value, 'string');
+      publication.updateState(value);
+    },
+    getChildNode: () => storage,
+  });
+  return storage;
+};
+
+test('stored subscription', async t => {
+  t.plan((jsonPairs.length + 1) * 4 + 1);
+  const { publication: pubStorage, subscription: subStorage } =
+    makeSubscriptionKit();
+  const storage = makeFakeStorage('publish.foo.bar', pubStorage);
+  const { subscription, publication } = makeSubscriptionKit();
+  const storesub = makeStoredSubscription(subscription, storage);
+
+  t.is(await E(storesub).getStoreKey(), await E(storage).getStoreKey());
+  const unserializer = E(storesub).getUnserializer();
+
+  const ait = E(storesub)[Symbol.asyncIterator]();
+  const storeAit = subStorage[Symbol.asyncIterator]();
+
+  const { unserialize } = makeMarshal();
+  const updateAndCheck = async (description, origValue, expectDone) => {
+    const nextP = E(ait).next();
+    if (expectDone) {
+      await E(publication).finish(origValue);
+    } else {
+      await E(publication).updateState(origValue);
+    }
+
+    const { done, value } = await nextP;
+    t.is(done, expectDone, `check doneness for ${description}`);
+    t.deepEqual(
+      value,
+      origValue,
+      `check value against original ${description}`,
+    );
+
+    const { done: storedDone, value: storedEncoded } = await storeAit.next();
+    t.assert(!storedDone, `check not stored done for ${description}`);
+    const storedDecoded = JSON.parse(storedEncoded);
+    const storedValue = await E(unserializer).unserialize(storedDecoded);
+    t.deepEqual(
+      storedValue,
+      origValue,
+      `check stored value against original ${description}`,
+    );
+  };
+
+  for await (const [encoded] of jsonPairs) {
+    const origValue = unserialize({ body: encoded, slots: [] });
+    await updateAndCheck(encoded, origValue, false);
+  }
+
+  await updateAndCheck('terminal', null, true);
+});

--- a/packages/run-protocol/src/proposals/core-proposal.js
+++ b/packages/run-protocol/src/proposals/core-proposal.js
@@ -26,6 +26,8 @@ const ECON_COMMITTEE_MANIFEST = harden({
 const SHARED_MAIN_MANIFEST = harden({
   [econBehaviors.setupAmm.name]: {
     consume: {
+      board: 'board',
+      chainStorage: true,
       chainTimerService: 'timer',
       zoe: 'zoe',
       economicCommitteeCreatorFacet: 'economicCommittee',

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -5,7 +5,7 @@ import { Far } from '@endo/marshal';
 
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
-import { makeSubscriptionKit } from '@agoric/notifier';
+import { makeStoredSubscription, makeSubscriptionKit } from '@agoric/notifier';
 
 import {
   assertIssuerKeywords,
@@ -111,7 +111,11 @@ const trace = makeTracer('XykAmm');
  * creator.
  *
  * @param {ZCF<AMMTerms>} zcf
- * @param {{initialPoserInvitation: Invitation}} privateArgs
+ * @param {{
+ *   initialPoserInvitation: Invitation,
+ *   storageNode?: ERef<StorageNode>,
+ *   marshaller?: ERef<Marshaller>,
+ * }} privateArgs
  */
 const start = async (zcf, privateArgs) => {
   /**
@@ -161,8 +165,18 @@ const start = async (zcf, privateArgs) => {
   const quoteIssuerKit = makeIssuerKit('Quote', AssetKind.SET);
 
   /** @type {SubscriptionRecord<MetricsNotification>} */
-  const { publication: metricsPublication, subscription: metricsSubscription } =
-    makeSubscriptionKit();
+  const {
+    publication: metricsPublication,
+    subscription: rawMetricsSubscription,
+  } = makeSubscriptionKit();
+  const { storageNode, marshaller } = privateArgs;
+  const metricsStorageNode =
+    storageNode && E(storageNode).getChildNode('metrics'); // TODO: magic string
+  const metricsSubscription = makeStoredSubscription(
+    rawMetricsSubscription,
+    metricsStorageNode,
+    marshaller,
+  );
   const updateMetrics = () => {
     metricsPublication.updateState(
       harden({ XYK: Array.from(secondaryBrandToPool.keys()) }),

--- a/packages/run-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/types.js
@@ -82,7 +82,7 @@
  * @property {() => PriceAuthority} getToCentralPriceAuthority
  * @property {() => PriceAuthority} getFromCentralPriceAuthority
  * @property {() => VirtualPool} getVPool
- * @property {() => Subscription<PoolMetricsNotification>} getMetrics
+ * @property {() => StoredSubscription<PoolMetricsNotification>} getMetrics
  */
 
 /**
@@ -136,7 +136,7 @@
  * Prices and notifications about changing prices.
  * @property {() => Brand[]} getAllPoolBrands
  * @property {() => Allocation} getProtocolPoolBalance
- * @property {() => Subscription<MetricsNotification>} getMetrics
+ * @property {() => StoredSubscription<MetricsNotification>} getMetrics
  * @property {(brand: Brand) => Subscription<PoolMetricsNotification>} getPoolMetrics
  */
 

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/setup.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/setup.js
@@ -71,6 +71,7 @@ export const setupAMMBootstrap = async (
   produce.agoricNamesAdmin.resolve(agoricNamesAdmin);
 
   installGovernance(zoe, spaces.installation.produce);
+  produce.chainStorage.resolve(undefined);
 
   return { produce, consume, ...spaces };
 };

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -71,6 +71,7 @@ export const setupBootstrap = (t, optTimer = undefined) => {
 
   const timer = optTimer || buildManualTimer(t.log);
   produce.chainTimerService.resolve(timer);
+  produce.chainStorage.resolve(undefined);
 
   const {
     zoe,

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -189,7 +189,7 @@
  *   bldIssuerKit: RemoteIssuerKit,
  *   board: Board,
  *   bridgeManager: OptionalBridgeManager,
- *   chainStorage: unknown,
+ *   chainStorage: ChainStorageNode | undefined,
  *   chainTimerService: TimerService,
  *   client: ClientManager,
  *   clientCreator: ClientCreator,
@@ -207,6 +207,8 @@
  *   provisioning: Awaited<ProvisioningVat>,
  *   zoe: ZoeService,
  * }>} ChainBootstrapSpace
+ *
+ * @typedef {ReturnType<import('../lib-chainStorage.js').makeChainStorageRoot>} ChainStorageNode
  *
  * IDEA/TODO: make types of demo stuff invisible in production behaviors
  * @typedef {{

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -2,6 +2,7 @@
 
 import { assert, details as X, q } from '@agoric/assert';
 import { E, Far } from '@endo/far';
+import { makeMarshal } from '@endo/marshal';
 import { makeStore } from '@agoric/store';
 import { crc6 } from './crc.js';
 
@@ -44,8 +45,48 @@ function makeBoard(
   const idToVal = makeStore('boardId');
   const valToId = makeStore('value');
 
+  const ifaceAllegedPrefix = 'Alleged: ';
+  const ifaceInaccessiblePrefix = 'INACCESSIBLE: ';
+  const slotToVal = (slot, iface) => {
+    if (slot !== null) {
+      // eslint-disable-next-line no-use-before-define
+      return board.getValue(slot);
+    }
+
+    // Private object.
+    if (typeof iface === 'string' && iface.startsWith(ifaceAllegedPrefix)) {
+      iface = iface.slice(ifaceAllegedPrefix.length);
+    }
+    return Far(`${ifaceInaccessiblePrefix}${iface}`, {});
+  };
+
+  // Create a marshaller that just looks up objects, not publish them.
+  const readonlyMarshaller = Far('board readonly marshaller', {
+    ...makeMarshal(val => {
+      if (!valToId.has(val)) {
+        // Unpublished value.
+        return null;
+      }
+
+      // Published value.
+      return valToId.get(val);
+    }, slotToVal),
+  });
+
+  // Create a marshaller useful for publishing all ocaps.
+  const publishingMarshaller = Far('board publishing marshaller', {
+    ...makeMarshal(
+      // Always put the value in the board.
+      // eslint-disable-next-line no-use-before-define
+      val => board.getId(val),
+      slotToVal,
+    ),
+  });
+
   /** @type {Board} */
   const board = Far('Board', {
+    getPublishingMarshaller: () => publishingMarshaller,
+    getReadonlyMarshaller: () => readonlyMarshaller,
     // Add if not already present
     getId: value => {
       if (!valToId.has(value)) {

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -34,7 +34,6 @@ const calcCrc = (data, crcDigits) => {
  * @param {object} [options]
  * @param {string} [options.prefix]
  * @param {number} [options.crcDigits]
- * @returns {Board}
  */
 function makeBoard(
   initSequence = 0,
@@ -83,7 +82,6 @@ function makeBoard(
     ),
   });
 
-  /** @type {Board} */
   const board = Far('Board', {
     getPublishingMarshaller: () => publishingMarshaller,
     getReadonlyMarshaller: () => readonlyMarshaller,

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -6,12 +6,7 @@
  */
 
 /**
- * @typedef {object} Board
- * @property {(id: string) => any} getValue
- * @property {(value: unknown) => string} getId
- * @property {(value: unknown) => boolean} has
- * @property {() => string[]} ids
- * @property {(...path: string[]) => Promise<unknown>} lookup
+ * @typedef {ReturnType<typeof import('./lib-board.js').makeBoard>} Board
  */
 
 /**

--- a/packages/vats/test/test-lib-board.js
+++ b/packages/vats/test/test-lib-board.js
@@ -48,3 +48,78 @@ test('makeBoard', async t => {
   const idObj2b = board2.getId(obj2);
   t.is(idObj2b, 'tooboard012');
 });
+
+const testBoardMarshaller = async (t, board, marshaller, publishing) => {
+  const published = Far('published', {});
+  const unpublished = Far('unpublished', {});
+
+  const published1id = board.getId(published);
+  const ser = marshaller.serialize(
+    harden({
+      published1: published,
+      unpublished1: unpublished,
+      published2: published,
+      unpublished2: unpublished,
+    }),
+  );
+  const pub1ser = `{"@qclass":"slot","iface":"Alleged: published","index":0}`;
+  const pub2ser = `{"@qclass":"slot","index":0}`;
+  const unpub1ser = `{"@qclass":"slot","iface":"Alleged: unpublished","index":1}`;
+  const unpub2ser = `{"@qclass":"slot","index":1}`;
+  t.is(
+    ser.body,
+    `{"published1":${pub1ser},"published2":${pub2ser},"unpublished1":${unpub1ser},"unpublished2":${unpub2ser}}`,
+  );
+  t.is(ser.slots.length, 2);
+  t.is(ser.slots[0], published1id);
+  if (publishing) {
+    t.assert(ser.slots[1].startsWith('board0'));
+  } else {
+    t.is(ser.slots[1], null);
+  }
+
+  const { published1, unpublished1, published2, unpublished2 } =
+    marshaller.unserialize(ser);
+  t.is(published1, published);
+  t.is(published2, published);
+  t.is(published1.toString(), '[object Alleged: published]');
+  t.is(published2.toString(), '[object Alleged: published]');
+  t.is(unpublished1, unpublished2);
+  if (publishing) {
+    t.is(unpublished1, unpublished);
+    t.is(unpublished2, unpublished);
+    t.is(unpublished1.toString(), '[object Alleged: unpublished]');
+    t.is(unpublished2.toString(), '[object Alleged: unpublished]');
+  } else {
+    t.not(unpublished1, unpublished);
+    t.not(unpublished2, unpublished);
+    t.is(
+      unpublished1.toString(),
+      '[object Alleged: INACCESSIBLE: unpublished]',
+    );
+    t.is(
+      unpublished2.toString(),
+      '[object Alleged: INACCESSIBLE: unpublished]',
+    );
+
+    // Separate marshals do not compare.
+    const unpublished3 = marshaller.unserialize(
+      marshaller.serialize(unpublished),
+    );
+    t.not(unpublished3, unpublished);
+    t.not(unpublished3, unpublished1);
+    t.not(unpublished3, unpublished2);
+  }
+};
+
+test('getPublishingMarshaller round trips unpublished objects', async t => {
+  const board = makeBoard();
+  const marshaller = board.getPublishingMarshaller();
+  await testBoardMarshaller(t, board, marshaller, true);
+});
+
+test(`getReadonlyMarshaller doesn't leak unpublished objects`, async t => {
+  const board = makeBoard();
+  const marshaller = board.getReadonlyMarshaller();
+  await testBoardMarshaller(t, board, marshaller, false);
+});

--- a/packages/zoe/src/contractSupport/priceAuthorityTransform.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityTransform.js
@@ -35,10 +35,6 @@ export const makePriceAuthorityTransform = async ({
 }) => {
   const quoteIssuer = E(quoteMint).getIssuer();
   const quoteBrand = await E(quoteIssuer).getBrand();
-  const sourceQuoteIssuer = E(sourcePriceAuthority).getQuoteIssuer(
-    sourceBrandIn,
-    sourceBrandOut,
-  );
 
   /**
    * Ensure that the brandIn/brandOut pair is supported.
@@ -65,6 +61,11 @@ export const makePriceAuthorityTransform = async ({
    */
   const scaleQuote = async sourceQuote => {
     const { quotePayment: sourceQuotePayment } = sourceQuote;
+
+    const sourceQuoteIssuer = E(sourcePriceAuthority).getQuoteIssuer(
+      sourceBrandIn,
+      sourceBrandOut,
+    );
 
     /** @type {Amount<'set'>} */
     const { value: sourceQuoteValue } = await E(sourceQuoteIssuer).getAmountOf(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #4398
refs: #5386

## Description

Created new `makeStoredSubscription` to produce a `StoredSubscription<T>` (a subscription with Merkle tree query information).  Passed a `storageNode` and `marshaller` from bootstrap to the AMM contract for a new `StoredSubscription<{ XYK: Brand[] }>`.

Drive by:
- reenabled CI build cache
- allow synchronous throws in `iterationObserver`s to terminate the iteration
- fix `makeScaledPriceAuthority` to query its underlying authority just-in-time

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Here's a demo:

```
snow:cosmic-swingset michael$ agd query swingset keys ''
keys:
- activityhash
- published
pagination: null
snow:cosmic-swingset michael$ agd query swingset keys published
keys:
- amm
pagination: null
snow:cosmic-swingset michael$ agd query swingset keys published.amm
keys:
- metrics
pagination: null
snow:cosmic-swingset michael$ agd query swingset keys published.amm.metrics
keys: []
pagination: null
snow:cosmic-swingset michael$ agd query swingset storage published.amm.metrics
value: '{"body":"{\"XYK\":[{\"@qclass\":\"slot\",\"iface\":\"Alleged: IbcATOM brand\",\"index\":0}]}","slots":["board0371"]}'
snow:cosmic-swingset michael$
```
