### PR TITLE
refactor: improved debugging messages for durability

### DIFF
--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -64,14 +64,28 @@ function pattEq(p1, p2) {
 }
 
 function throwNotDurable(value, slotIndex, serializedValue) {
-  assert.fail(
-    X`value is not durable: ${value} at slot ${slotIndex} of ${decodeToJustin(
+  const body = JSON.parse(serializedValue.body);
+  let encodedValue;
+  try {
+    encodedValue = decodeToJustin(
       {
-        body: JSON.parse(serializedValue.body),
+        body,
         slots: serializedValue.slots,
       },
       true,
-    )}`,
+    );
+  } catch (justinError) {
+    const err = assert.error(
+      X`value is not durable: ${value} at slot ${slotIndex} of ${serializedValue}`,
+    );
+    assert.note(
+      err,
+      X`decodeToJustin(${serializedValue}) threw ${justinError} `,
+    );
+    throw err;
+  }
+  assert.fail(
+    X`value is not durable: ${value} at slot ${slotIndex} of ${encodedValue}`,
   );
 }
 

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -637,12 +637,12 @@ export function makeVirtualObjectManager(
             const before = innerSelf.rawState[prop];
             const after = serialize(value);
             if (durable) {
-              after.slots.forEach(vref =>
+              after.slots.forEach((vref, index) => {
                 assert(
                   vrm.isDurable(vref),
-                  X`value for ${prop} is not durable`,
-                ),
-              );
+                  X`value for ${prop} is not durable at slot ${index} of ${after}`,
+                );
+              });
             }
             vrm.updateReferenceCounts(before.slots, after.slots);
             innerSelf.rawState[prop] = after;

--- a/packages/SwingSet/test/stores/test-durabilityChecks.js
+++ b/packages/SwingSet/test/stores/test-durabilityChecks.js
@@ -81,7 +81,7 @@ function m(s) {
 test('durability checks', t => {
   const failKey = f => t.throws(f, m(/^key .* is not durable in /));
   const failVal = f => t.throws(f, m(/^value is not durable: /));
-  const failHold = f => t.throws(f, m(/^value for "held" is not durable$/));
+  const failHold = f => t.throws(f, m(/^value for "held" is not durable/));
   const passKey = f => t.notThrows(f);
   const passVal = f => t.notThrows(f);
   const passHold = f => t.notThrows(f);

--- a/packages/SwingSet/test/stores/test-durabilityChecks.js
+++ b/packages/SwingSet/test/stores/test-durabilityChecks.js
@@ -79,9 +79,9 @@ function m(s) {
 
 // prettier-ignore
 test('durability checks', t => {
-  const failKey = f => t.throws(f, m('key is not durable'));
-  const failVal = f => t.throws(f, m('value is not durable'));
-  const failHold = f => t.throws(f, m('value for "held" is not durable'));
+  const failKey = f => t.throws(f, m(/^key .* is not durable in /));
+  const failVal = f => t.throws(f, m(/^value is not durable: /));
+  const failHold = f => t.throws(f, m(/^value for "held" is not durable$/));
   const passKey = f => t.notThrows(f);
   const passVal = f => t.notThrows(f);
   const passHold = f => t.notThrows(f);


### PR DESCRIPTION
## Description

While working on durability (#5283), we (@erights and I) improved some error message so they explicitly told us where our problem was.

Our first version threw *undefined must be a string* from inside `decodeToJustin`, even when there was not problem in the serialization. We eventually traced that to `decodeToJustin` not understanding the current representation of `ibid`s. This version sidesteps that issue when there's no durability problem.

```js
      if (durable) {
        serializedValue.slots.forEach((vref, slotIndex) =>
          assert(
            vrm.isDurable(vref),
            X`value is not durable: ${value} at slot ${slotIndex} of ${decodeToJustin(
              {
                body: JSON.parse(serializedValue.body),
                slots: serializedValue.slots,
              },
              true,
            )}`,
          ),
        );
      }
```

### Security Considerations

Reveals some internal information, but should only appear when debugging.

### Documentation Considerations

No user-serviceable parts inside.

### Testing Considerations

This is useful during tests.