### PR TITLE
test: metrics subscription testing support

### DIFF
--- a/packages/run-protocol/package.json
+++ b/packages/run-protocol/package.json
@@ -52,6 +52,7 @@
     "@endo/init": "^0.5.41",
     "ava": "^3.12.1",
     "c8": "^7.11.0",
+    "deep-object-diff": "^1.1.7",
     "fast-check": "^2.21.0",
     "import-meta-resolve": "^1.1.1"
   },

--- a/packages/run-protocol/test/metrics.js
+++ b/packages/run-protocol/test/metrics.js
@@ -1,26 +1,20 @@
 // @ts-check
 import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
-import { detailedDiff, diff } from 'deep-object-diff';
-
-const { details: X, quote: q } = assert;
-const size = o => Object.entries(o).length;
+import { diff } from 'deep-object-diff';
 
 /**
  *
+ * @param {import('ava').ExecutionContext} t
  * @param {{getMetrics: () => Subscription<object>}} publicFacet
  */
-export const metricsTracker = async publicFacet => {
+export const metricsTracker = async (t, publicFacet) => {
   const metricsSub = await E(publicFacet).getMetrics();
   const metrics = makeNotifierFromAsyncIterable(metricsSub);
   let notif;
   const assertInitial = async expectedValue => {
     notif = await metrics.getUpdateSince();
-    const difference = diff(notif.value, expectedValue);
-    assert(
-      Object.entries(difference).length === 0,
-      `Unexpected metric initial value: ${q(notif.value)}`,
-    );
+    t.deepEqual(notif.value, expectedValue);
   };
   /**
    *
@@ -30,14 +24,7 @@ export const metricsTracker = async publicFacet => {
     const prevNotif = notif;
     notif = await metrics.getUpdateSince(notif.updateCount);
     const actualDelta = diff(prevNotif.value, notif.value);
-    const deltaDiff = detailedDiff(actualDelta, expectedDelta);
-    const diffCount =
-      // @ts-expect-error bad types
-      size(deltaDiff.added) + size(deltaDiff.deleted) + size(deltaDiff.updated);
-    assert(
-      diffCount === 0,
-      X`Unexpected metric delta: ${actualDelta}; ${deltaDiff}`,
-    );
+    t.deepEqual(actualDelta, expectedDelta, 'Unexpected metric delta');
   };
   return { assertChange, assertInitial };
 };

--- a/packages/run-protocol/test/metrics.js
+++ b/packages/run-protocol/test/metrics.js
@@ -1,0 +1,43 @@
+// @ts-check
+import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
+import { E } from '@endo/eventual-send';
+import { detailedDiff, diff } from 'deep-object-diff';
+
+const { details: X, quote: q } = assert;
+const size = o => Object.entries(o).length;
+
+/**
+ *
+ * @param {{getMetrics: () => Subscription<object>}} publicFacet
+ */
+export const metricsTracker = async publicFacet => {
+  const metricsSub = await E(publicFacet).getMetrics();
+  const metrics = makeNotifierFromAsyncIterable(metricsSub);
+  let notif;
+  const assertInitial = async expectedValue => {
+    notif = await metrics.getUpdateSince();
+    const difference = diff(notif.value, expectedValue);
+    assert(
+      Object.entries(difference).length === 0,
+      `Unexpected metric initial value: ${q(notif.value)}`,
+    );
+  };
+  /**
+   *
+   * @param {Record<string, unknown>} expectedDelta
+   */
+  const assertChange = async expectedDelta => {
+    const prevNotif = notif;
+    notif = await metrics.getUpdateSince(notif.updateCount);
+    const actualDelta = diff(prevNotif.value, notif.value);
+    const deltaDiff = detailedDiff(actualDelta, expectedDelta);
+    const diffCount =
+      // @ts-expect-error bad types
+      size(deltaDiff.added) + size(deltaDiff.deleted) + size(deltaDiff.updated);
+    assert(
+      diffCount === 0,
+      X`Unexpected metric delta: ${actualDelta}; ${deltaDiff}`,
+    );
+  };
+  return { assertChange, assertInitial };
+};

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -7,7 +7,6 @@ import { E } from '@endo/eventual-send';
 import { deeplyFulfilled } from '@endo/marshal';
 
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
-import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import {
   makeRatio,
@@ -42,6 +41,8 @@ import {
   installGovernance,
 } from '../supports.js';
 import { unsafeMakeBundleCache } from '../bundleTool.js';
+
+import { metricsTracker } from '../metrics.js';
 
 /** @type {import('ava').TestInterface<any>} */
 const test = unknownTest;
@@ -2370,11 +2371,9 @@ test('director notifiers', async t => {
 
   const { lender, vaultFactory } = services.vaultFactory;
 
-  const metricsSub = await E(lender).getMetrics();
-  const metrics = makeNotifierFromAsyncIterable(metricsSub);
+  const m = await metricsTracker(lender);
 
-  let state = await E(metrics).getUpdateSince();
-  t.deepEqual(state.value, {
+  await m.assertInitial({
     collaterals: [aethBrand],
     rewardPoolAllocation: {},
   });
@@ -2386,14 +2385,14 @@ test('director notifiers', async t => {
     'Chit',
     defaultParamValues(chit.brand),
   );
-  state = await E(metrics).getUpdateSince(state.updateCount);
-  t.deepEqual(state.value, {
-    collaterals: [aethBrand, chit.brand],
-    rewardPoolAllocation: {},
+  await m.assertChange({
+    collaterals: { 1: chit.brand },
   });
 
   // Not testing rewardPoolAllocation contents because those are simply those values.
   // We could refactor the tests of those allocations to use the data now exposed by a notifier.
+
+  t.pass();
 });
 
 test('manager notifiers', async t => {
@@ -2414,10 +2413,9 @@ test('manager notifiers', async t => {
   const { aethVaultManager, lender } = services.vaultFactory;
   const cm = await E(aethVaultManager).getPublicFacet();
 
-  const metricsSub = await E(cm).getMetrics();
-  const metrics = makeNotifierFromAsyncIterable(metricsSub);
-  let state = await E(metrics).getUpdateSince();
-  t.deepEqual(state.value, {
+  const m = await metricsTracker(cm);
+
+  await m.assertInitial({
     numVaults: 0,
     totalCollateral: AmountMath.makeEmpty(aethKit.brand),
     totalDebt: AmountMath.makeEmpty(t.context.runKit.brand),
@@ -2440,18 +2438,16 @@ test('manager notifiers', async t => {
 
   await E(vaultSeat).getOfferResult();
 
-  state = await E(metrics).getUpdateSince(state.updateCount);
-  t.deepEqual(state.value, {
+  await m.assertChange({
     numVaults: 1,
-    totalCollateral: collateralAmount,
-    totalDebt: AmountMath.make(runKit.brand, DEBT),
+    totalCollateral: { value: collateralAmount.value },
+    totalDebt: { value: DEBT },
   });
 
   await E(aethVaultManager).liquidateAll();
-  state = await E(metrics).getUpdateSince(state.updateCount);
-  t.deepEqual(state.value, {
+  await m.assertChange({
     numVaults: 0,
-    totalCollateral: collateralAmount,
-    totalDebt: AmountMath.make(runKit.brand, 0n),
+    totalDebt: { value: 0n },
   });
+  t.pass();
 });

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2371,7 +2371,7 @@ test('director notifiers', async t => {
 
   const { lender, vaultFactory } = services.vaultFactory;
 
-  const m = await metricsTracker(lender);
+  const m = await metricsTracker(t, lender);
 
   await m.assertInitial({
     collaterals: [aethBrand],
@@ -2391,8 +2391,6 @@ test('director notifiers', async t => {
 
   // Not testing rewardPoolAllocation contents because those are simply those values.
   // We could refactor the tests of those allocations to use the data now exposed by a notifier.
-
-  t.pass();
 });
 
 test('manager notifiers', async t => {
@@ -2413,7 +2411,7 @@ test('manager notifiers', async t => {
   const { aethVaultManager, lender } = services.vaultFactory;
   const cm = await E(aethVaultManager).getPublicFacet();
 
-  const m = await metricsTracker(cm);
+  const m = await metricsTracker(t, cm);
 
   await m.assertInitial({
     numVaults: 0,
@@ -2449,5 +2447,4 @@ test('manager notifiers', async t => {
     numVaults: 0,
     totalDebt: { value: 0n },
   });
-  t.pass();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7290,6 +7290,11 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deep-object-diff@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.7.tgz#348b3246f426427dd633eaa50e1ed1fc2eafc7e4"
+  integrity sha512-QkgBca0mL08P6HiOjoqvmm6xOAl2W6CT2+34Ljhg0OeFan8cwlcdq8jrLKsBBuUFAZLsN5b6y491KdKEoSo9lg==
+
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"


### PR DESCRIPTION
## Description

For the epic https://github.com/Agoric/agoric-sdk/issues/4639 we're creating many new subscription streams. We want them to all work consistently in the Inter Protocol. While working on https://github.com/Agoric/agoric-sdk/pull/5393 I found it worthwhile to make a support utility. This makes it available throughout the package.

It takes a public facet and requires that it have a method `getMetrics` to help enforce that convention.

### Security Considerations

non-prod

### Documentation Considerations

helps codify a nascent convention

### Testing Considerations

test utility itself