### PR TITLE
feat(notifier): subscription kit history limit

### DIFF
--- a/packages/notifier/README.md
+++ b/packages/notifier/README.md
@@ -52,7 +52,7 @@ You can use the JavaScript `AsyncIterable` API directly, but it is more convenie
 the JavaScript `for-await-of` syntax or
 the `observeIteration` adaptor.
 
-Below, Paula publishes an iteration with the non-final sequence `'a'`, `'b'`, `'c'` which terminates 
+Below, Paula publishes an iteration with the non-final sequence `'a'`, `'b'` which terminates 
 with `'done'` as its completion value.
 
 ```js

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -5,7 +5,11 @@ export {
   makeNotifierKit,
   makeNotifierFromAsyncIterable,
 } from './notifier.js';
-export { makeSubscription, makeSubscriptionKit } from './subscriber.js';
+export {
+  DEFAULT_SUBSCRIPTION_HISTORY_LIMIT,
+  makeSubscription,
+  makeSubscriptionKit,
+} from './subscriber.js';
 export {
   observeNotifier,
   observeIterator,

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -273,7 +273,6 @@ export const bob = async asyncIterableP => {
  * @returns {Promise<Passable[]>}
  */
 export const carol = async subscriptionP => {
-  // @ts-expect-error
   const subscriptionIteratorP = E(subscriptionP)[Symbol.asyncIterator]();
   const { promise: afterA, resolve: afterAResolve } = makePromiseKit();
 
@@ -281,11 +280,16 @@ export const carol = async subscriptionP => {
     harden({
       updateState: val => {
         if (val === 'a') {
+          // @ts-expect-error
           afterAResolve(E(subscriptionIteratorP).subscribe());
         }
         log.push(['non-final', val]);
       },
-      finish: completion => log.push(['finished', completion]),
+      finish: completion => {
+        // If our keepStates was too small, we should resolve afterA here.
+        afterAResolve(subscriptionP);
+        log.push(['finished', completion]);
+      },
       fail: reason => log.push(['failed', reason]),
     });
 

--- a/packages/notifier/test/test-subscriber-examples.js
+++ b/packages/notifier/test/test-subscriber-examples.js
@@ -5,6 +5,7 @@ import { test } from './prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
 import { E } from '@endo/eventual-send';
 import {
+  DEFAULT_SUBSCRIPTION_HISTORY_LIMIT,
   observeIteration,
   makeSubscriptionKit,
   makeSubscription,
@@ -13,121 +14,138 @@ import { paula, alice, bob, carol } from './iterable-testing-tools.js';
 
 import '../src/types.js';
 
-test('subscription for-await-of success example', async t => {
-  const { publication, subscription } = makeSubscriptionKit();
-  paula(publication);
-  const log = await alice(subscription);
+/**
+ * @param {number} historyLimit
+ */
+const makeSubscriberExampleTests = historyLimit => {
+  const history = (...states) => states.slice(states.length - historyLimit);
 
-  t.deepEqual(log, [['non-final', 'a'], ['non-final', 'b'], ['finished']]);
-});
+  test(`subscription(${historyLimit}) for-await-of success example`, async t => {
+    const { publication, subscription } = makeSubscriptionKit(historyLimit);
+    paula(publication);
+    const log = await alice(subscription);
 
-test('subscription observeIteration success example', async t => {
-  const { publication, subscription } = makeSubscriptionKit();
-  paula(publication);
-  const log = await bob(subscription);
+    t.deepEqual(log, [
+      ...history(['non-final', 'a'], ['non-final', 'b']),
+      ['finished'],
+    ]);
+  });
 
-  t.deepEqual(log, [
-    ['non-final', 'a'],
-    ['non-final', 'b'],
-    ['finished', 'done'],
-  ]);
-});
+  test(`subscription(${historyLimit}) observeIteration success example`, async t => {
+    const { publication, subscription } = makeSubscriptionKit(historyLimit);
+    paula(publication);
+    const log = await bob(subscription);
 
-test('subscription for-await-of cannot eat promise', async t => {
-  const { publication, subscription } = makeSubscriptionKit();
-  paula(publication);
-  const subP = Promise.resolve(subscription);
-  // Type cast because this test demonstrates the failure that results from
-  // giving Alice a promise for a subscription.
-  const log = await alice(/** @type {any} */ (subP));
-
-  // This TypeError is thrown by JavaScript when a for-await-in loop
-  // attempts to iterate a promise that is not an async iterable.
-  t.is(log[0][0], 'failed');
-  t.assert(log[0][1] instanceof TypeError);
-});
-
-test('subscription observeIteration can eat promise', async t => {
-  const { publication, subscription } = makeSubscriptionKit();
-  paula(publication);
-  const subP = Promise.resolve(subscription);
-  const log = await bob(subP);
-
-  t.deepEqual(log, [
-    ['non-final', 'a'],
-    ['non-final', 'b'],
-    ['finished', 'done'],
-  ]);
-});
-
-test('subscription for-await-of on local representative', async t => {
-  const { publication, subscription } = makeSubscriptionKit();
-  paula(publication);
-  const subP = Promise.resolve(subscription);
-  const localSub = makeSubscription(E(subP).getSharableSubscriptionInternals());
-  const log = await alice(localSub);
-
-  t.deepEqual(log, [['non-final', 'a'], ['non-final', 'b'], ['finished']]);
-});
-
-test('subscription observeIteration on local representative', async t => {
-  const { publication, subscription } = makeSubscriptionKit();
-  paula(publication);
-  const subP = Promise.resolve(subscription);
-  const localSub = makeSubscription(E(subP).getSharableSubscriptionInternals());
-  const log = await bob(localSub);
-
-  t.deepEqual(log, [
-    ['non-final', 'a'],
-    ['non-final', 'b'],
-    ['finished', 'done'],
-  ]);
-});
-
-test('subscription for-await-of on generic representative', async t => {
-  const { publication, subscription } = makeSubscriptionKit();
-  paula(publication);
-  const subP = Promise.resolve(subscription);
-  const { publication: p, subscription: localSub } = makeSubscriptionKit();
-  observeIteration(subP, p);
-  const log = await alice(localSub);
-
-  t.deepEqual(log, [['non-final', 'a'], ['non-final', 'b'], ['finished']]);
-});
-
-test('subscription observeIteration on generic representative', async t => {
-  const { publication, subscription } = makeSubscriptionKit();
-  paula(publication);
-  const subP = Promise.resolve(subscription);
-  const { publication: p, subscription: localSub } = makeSubscriptionKit();
-  observeIteration(subP, p);
-  const log = await bob(localSub);
-
-  t.deepEqual(log, [
-    ['non-final', 'a'],
-    ['non-final', 'b'],
-    ['finished', 'done'],
-  ]);
-});
-
-// /////////////////////////////////////////////////////////////////////////////
-// Carol is specific to subscription, so there is nothing analogous to the
-// following in test-notifier-examples
-
-test('subscribe to subscriptionIterator success example', async t => {
-  const { publication, subscription } = makeSubscriptionKit();
-  paula(publication);
-  const log = await carol(subscription);
-
-  t.deepEqual(log, [
-    [
-      ['non-final', 'a'],
-      ['non-final', 'b'],
+    t.deepEqual(log, [
+      ...history(['non-final', 'a'], ['non-final', 'b']),
       ['finished', 'done'],
-    ],
-    [
-      ['non-final', 'b'],
+    ]);
+  });
+
+  test(`subscription(${historyLimit}) for-await-of cannot eat promise`, async t => {
+    const { publication, subscription } = makeSubscriptionKit(historyLimit);
+    paula(publication);
+    const subP = Promise.resolve(subscription);
+    // Type cast because this test demonstrates the failure that results from
+    // giving Alice a promise for a subscription.
+    const log = await alice(/** @type {any} */ (subP));
+
+    // This TypeError is thrown by JavaScript when a for-await-in loop
+    // attempts to iterate a promise that is not an async iterable.
+    t.is(log[0][0], 'failed');
+    t.assert(log[0][1] instanceof TypeError);
+  });
+
+  test(`subscription(${historyLimit}) observeIteration can eat promise`, async t => {
+    const { publication, subscription } = makeSubscriptionKit(historyLimit);
+    paula(publication);
+    const subP = Promise.resolve(subscription);
+    const log = await bob(subP);
+
+    t.deepEqual(log, [
+      ...history(['non-final', 'a'], ['non-final', 'b']),
       ['finished', 'done'],
-    ],
-  ]);
-});
+    ]);
+  });
+
+  test(`subscription(${historyLimit}) for-await-of on local representative`, async t => {
+    const { publication, subscription } = makeSubscriptionKit(historyLimit);
+    paula(publication);
+    const subP = Promise.resolve(subscription);
+    const localSub = makeSubscription(
+      E(subP).getSharableSubscriptionInternals(),
+    );
+    const log = await alice(localSub);
+
+    t.deepEqual(log, [
+      ...history(['non-final', 'a'], ['non-final', 'b']),
+      ['finished'],
+    ]);
+  });
+
+  test(`subscription(${historyLimit}) observeIteration on local representative`, async t => {
+    const { publication, subscription } = makeSubscriptionKit(historyLimit);
+    paula(publication);
+    const subP = Promise.resolve(subscription);
+    const localSub = makeSubscription(
+      E(subP).getSharableSubscriptionInternals(),
+    );
+    const log = await bob(localSub);
+
+    t.deepEqual(log, [
+      ...history(['non-final', 'a'], ['non-final', 'b']),
+      ['finished', 'done'],
+    ]);
+  });
+
+  test(`subscription(${historyLimit}) for-await-of on generic representative`, async t => {
+    const { publication, subscription } = makeSubscriptionKit(historyLimit);
+    paula(publication);
+    const subP = Promise.resolve(subscription);
+    const { publication: p, subscription: localSub } = makeSubscriptionKit();
+    observeIteration(subP, p);
+    const log = await alice(localSub);
+
+    t.deepEqual(log, [
+      ...history(['non-final', 'a'], ['non-final', 'b']),
+      ['finished'],
+    ]);
+  });
+
+  test(`subscription(${historyLimit}) observeIteration on generic representative`, async t => {
+    const { publication, subscription } = makeSubscriptionKit(historyLimit);
+    paula(publication);
+    const subP = Promise.resolve(subscription);
+    const { publication: p, subscription: localSub } = makeSubscriptionKit();
+    observeIteration(subP, p);
+    const log = await bob(localSub);
+
+    t.deepEqual(log, [
+      ...history(['non-final', 'a'], ['non-final', 'b']),
+      ['finished', 'done'],
+    ]);
+  });
+
+  // /////////////////////////////////////////////////////////////////////////////
+  // Carol is specific to subscription, so there is nothing analogous to the
+  // following in test-notifier-examples
+
+  test(`subscribe to subscriptionIterator(${historyLimit}) success example`, async t => {
+    const { publication, subscription } = makeSubscriptionKit(historyLimit);
+    paula(publication);
+    const log = await carol(subscription);
+
+    t.deepEqual(log, [
+      [
+        ...history(['non-final', 'a'], ['non-final', 'b']),
+        ['finished', 'done'],
+      ],
+      [...history(['non-final', 'b']), ['finished', 'done']],
+    ]);
+  });
+};
+
+// Test all the significant historyLimit values.
+new Set([0, 1, 2, Infinity, DEFAULT_SUBSCRIPTION_HISTORY_LIMIT]).forEach(
+  makeSubscriberExampleTests,
+);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #5346

## Description

Implements "prefix lossy subscriptions" via `makeSubscriptionKit(historyLimit)` parameter (default=Infinity).

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
Improves memory profile, given cooperating subscribers (an old and slow subscription may still hold references to the entire history, but new ones won't).

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
Documented in README.md and backwards compatible.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
The test suite tests several important values of historyLimit.
