### PR TITLE
lint floating promises

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,6 +2,17 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
+  parserOptions: {
+    sourceType: 'module',
+    project: [
+      './packages/*/jsconfig.json',
+      './packages/*/tsconfig.json',
+      './packages/wallet/*/jsconfig.json',
+      './tsconfig.json',
+    ],
+    tsconfigRootDir: __dirname,
+    extraFileExtensions: ['.cjs'],
+  },
   plugins: [
     '@jessie.js/eslint-plugin',
     '@typescript-eslint',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,9 @@ module.exports = {
   extends: ['@agoric'],
   rules: {
     '@typescript-eslint/prefer-ts-expect-error': 'warn',
+    '@typescript-eslint/no-floating-promises': 'warn',
+    // so that floating-promises can be explicitly permitted with void operator
+    'no-void': ['error', { allowAsStatement: true }],
     'jsdoc/no-multi-asterisks': 'off',
     'jsdoc/multiline-blocks': 'off',
     // Use these rules to warn about JSDoc type problems, such as after

--- a/packages/SwingSet/misc-tools/measure-metering/measurement-target.js
+++ b/packages/SwingSet/misc-tools/measure-metering/measurement-target.js
@@ -65,7 +65,7 @@ export function buildRootObject(vatPowers) {
       purse.deposit(payment);
     },
     getUpdateSince() {
-      notifier.getUpdateSince();
+      return notifier.getUpdateSince();
     },
   });
 }

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -3,6 +3,7 @@
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 import { spawn } from 'child_process';
+// @ts-ignore
 import bundleSource from '@endo/bundle-source';
 
 import { makeXsSubprocessFactory } from '../src/kernel/vat-loader/manager-subprocess-xsnap.js';
@@ -48,7 +49,9 @@ test('child termination distinguished from meter exhaustion', async t => {
     kernelKeeper,
     // @ts-expect-error kernelSlog is not used in this test
     kernelSlog: {},
+    // @ts-expect-error
     allVatPowers: undefined,
+    // @ts-expect-error
     testLog: undefined,
   });
 
@@ -70,6 +73,7 @@ test('child termination distinguished from meter exhaustion', async t => {
 
   const msg = { methargs: capargs(['hang', []]) };
   /** @type { VatDeliveryObject } */
+  // @ts-expect-error
   const delivery = ['message', 'o+0', msg];
 
   const p = m.deliver(delivery); // won't resolve until child dies

--- a/packages/SwingSet/test/vat-warehouse/test-warehouse.js
+++ b/packages/SwingSet/test/vat-warehouse/test-warehouse.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 
 // eslint-disable-next-line import/order
 import { test } from '../../tools/prepare-test-env-ava.js';

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -63,11 +63,6 @@
     ],
     "timeout": "10m"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/governance/scripts/build-bundles.js
+++ b/packages/governance/scripts/build-bundles.js
@@ -12,4 +12,4 @@ const sourceToBundle = [
   ['../src/binaryVoteCounter.js', '../bundles/bundle-binaryVoteCounter.js'],
 ];
 
-createBundles(sourceToBundle, dirname);
+await createBundles(sourceToBundle, dirname);

--- a/packages/governance/src/closingRule.js
+++ b/packages/governance/src/closingRule.js
@@ -10,7 +10,7 @@ import { Far } from '@endo/marshal';
 /** @type {CloseVoting} */
 export const scheduleClose = (closingRule, closeVoting) => {
   const { timer, deadline } = closingRule;
-  E(timer).setWakeup(
+  return E(timer).setWakeup(
     deadline,
     Far('close voting', {
       wake: closeVoting,

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -231,7 +231,7 @@ const makeParamManagerBuilder = zoe => {
      *
      * @param {SetInvitationParam} param0
      */
-    const setInvitation = async ([newInvitation, amount]) => {
+    const setInvitation = ([newInvitation, amount]) => {
       currentAmount = amount;
       currentInvitation = newInvitation;
       return harden({ [name]: currentAmount });

--- a/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
@@ -228,11 +228,15 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   const [testName] = argv;
   switch (testName) {
     case 'committeeBinaryStart':
-      committeeBinaryStart(zoe, voterCreator, timer, log, installations);
-      break;
+      return committeeBinaryStart(zoe, voterCreator, timer, log, installations);
     case 'committeeBinaryTwoQuestions':
-      committeeBinaryTwoQuestions(zoe, voterCreator, timer, log, installations);
-      break;
+      return committeeBinaryTwoQuestions(
+        zoe,
+        voterCreator,
+        timer,
+        log,
+        installations,
+      );
     default:
       log(`didn't find test: ${argv}`);
   }

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
@@ -43,7 +43,7 @@ const build = async (log, zoe) => {
         },
       });
       const subscription = E(electoratePublicFacet).getQuestionSubscription();
-      observeIteration(subscription, votingObserver);
+      void observeIteration(subscription, votingObserver);
 
       return Far(`Voter ${name}`, {
         verifyBallot: (question, instances) =>
@@ -69,7 +69,7 @@ const build = async (log, zoe) => {
         },
       });
       const subscription = E(electoratePublicFacet).getQuestionSubscription();
-      observeIteration(subscription, votingObserver);
+      void observeIteration(subscription, votingObserver);
 
       return Far(`Voter ${name}`, {
         verifyBallot: (question, instances) =>

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -144,7 +144,7 @@ const checkContractState = async (zoe, contractInstanceP, log) => {
   const paramChangeObserver = Far('param observer', {
     updateState: update => log(`${update.paramNames} changed in a vote.`),
   });
-  observeIteration(subscription, paramChangeObserver);
+  void observeIteration(subscription, paramChangeObserver);
 
   // it takes a while for the update to propagate. The second time it seems good
   paramValues = await E(contractPublic).getGovernedParams();
@@ -390,7 +390,7 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
 
       await E(timer).tick();
       await E(timer).tick();
-      E.when(
+      await E.when(
         electorateOutcome,
         o => log(`vote (unexpected) successful outcome: ${o} `),
         e => log(`vote rejected outcome: ${e}`),
@@ -443,7 +443,7 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
 
       await E(timer).tick();
       await E(timer).tick();
-      E.when(
+      await E.when(
         electorateOutcome,
         o => log(`successful outcome: ${q(o)} `),
         e => log(`vote (unexpected) rejected outcome: ${e}`),

--- a/packages/governance/test/unitTests/test-committee.js
+++ b/packages/governance/test/unitTests/test-committee.js
@@ -135,7 +135,7 @@ test('committee-open question:mixed', async t => {
     .getOutcome()
     .catch(e => t.deepEqual(e, 'No quorum'));
 
-  timer.tick();
+  await timer.tick();
 
   const questions = await publicFacet.getOpenQuestions();
   t.deepEqual(questions.length, 2);

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -101,7 +101,7 @@ export const makeAsyncIterableFromNotifier = notifierP => {
 export const observeIterator = (asyncIteratorP, iterationObserver) => {
   return new Promise(ack => {
     const recur = () => {
-      E.when(
+      void E.when(
         E(asyncIteratorP).next(),
         ({ value, done }) => {
           if (done) {

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -259,7 +259,7 @@ export const bob = async asyncIterableP => {
     finish: completion => log.push(['finished', completion]),
     fail: reason => log.push(['failed', reason]),
   });
-  await observeIteration(asyncIterableP, observer);
+  void observeIteration(asyncIterableP, observer);
   return log;
 };
 

--- a/packages/notifier/test/map-unum.js
+++ b/packages/notifier/test/map-unum.js
@@ -117,7 +117,7 @@ export const makeMapFollower = snapshotNotifierP => {
   const snapshotObserver = harden({
     updateState: ({ entries, deltaSubscription }) => {
       m = new Map(entries);
-      observeIteration(deltaSubscription, deltaObserver);
+      void observeIteration(deltaSubscription, deltaObserver);
     },
     finish: _completion => {
       m = undefined;
@@ -126,7 +126,7 @@ export const makeMapFollower = snapshotNotifierP => {
       m = undefined;
     },
   });
-  observeIteration(snapshotNotifierP, snapshotObserver);
+  void observeIteration(snapshotNotifierP, snapshotObserver);
 
   return mapFollower;
 };

--- a/packages/notifier/test/test-notifier-examples.js
+++ b/packages/notifier/test/test-notifier-examples.js
@@ -78,7 +78,7 @@ test('notifier for-await-of on generic representative', async t => {
   paula(updater);
   const subP = Promise.resolve(notifier);
   const { updater: p, notifier: localSub } = makeNotifierKit();
-  observeIteration(subP, p);
+  void observeIteration(subP, p);
   const log = await alice(localSub);
 
   t.deepEqual(last(log), ['finished']);
@@ -89,7 +89,7 @@ test('notifier observeIteration on generic representative', async t => {
   paula(updater);
   const subP = Promise.resolve(notifier);
   const { updater: p, notifier: localSub } = makeNotifierKit();
-  observeIteration(subP, p);
+  void observeIteration(subP, p);
   const log = await bob(localSub);
 
   t.deepEqual(last(log), ['finished', 'done']);

--- a/packages/notifier/test/test-notifier.js
+++ b/packages/notifier/test/test-notifier.js
@@ -76,7 +76,7 @@ test('notifier - update after state change', async t => {
   const all = Promise.all([updateInWaiting]).then(([update1]) => {
     t.is(update1.value, 3, '4th check (delayed) 3');
     const thirdStatePromise = notifier.getUpdateSince(update1.updateCount);
-    Promise.all([thirdStatePromise]).then(([update2]) => {
+    return Promise.all([thirdStatePromise]).then(([update2]) => {
       t.is(update2.value, 5, '5th check (delayed) 5');
     });
   });
@@ -101,7 +101,7 @@ test('notifier - final state', async t => {
     t.is(update.value, 'final', 'state is "final"');
     t.falsy(update.updateCount, 'no handle after close');
     const postFinalUpdate = notifier.getUpdateSince(update.updateCount);
-    Promise.all([postFinalUpdate]).then(([after]) => {
+    return Promise.all([postFinalUpdate]).then(([after]) => {
       t.is(after.value, 'final', 'stable');
       t.falsy(after.updateCount, 'no handle after close');
     });

--- a/packages/notifier/test/test-subscriber-examples.js
+++ b/packages/notifier/test/test-subscriber-examples.js
@@ -89,7 +89,7 @@ test('subscription for-await-of on generic representative', async t => {
   paula(publication);
   const subP = Promise.resolve(subscription);
   const { publication: p, subscription: localSub } = makeSubscriptionKit();
-  observeIteration(subP, p);
+  void observeIteration(subP, p);
   const log = await alice(localSub);
 
   t.deepEqual(log, [['non-final', 'a'], ['non-final', 'b'], ['finished']]);
@@ -100,7 +100,7 @@ test('subscription observeIteration on generic representative', async t => {
   paula(publication);
   const subP = Promise.resolve(subscription);
   const { publication: p, subscription: localSub } = makeSubscriptionKit();
-  observeIteration(subP, p);
+  void observeIteration(subP, p);
   const log = await bob(localSub);
 
   t.deepEqual(log, [

--- a/packages/run-protocol/scripts/build-bundles.js
+++ b/packages/run-protocol/scripts/build-bundles.js
@@ -11,7 +11,7 @@ process.env.INTERCHAIN_ISSUER_BOARD_ID =
   'arbitrary value to prevent build error';
 
 const dirname = url.fileURLToPath(new URL('.', import.meta.url));
-extractProposalBundles(
+await extractProposalBundles(
   [
     ['.', defaultProposalBuilder],
     ['.', collateralProposalBuilder],

--- a/packages/run-protocol/src/proposals/demoIssuers.js
+++ b/packages/run-protocol/src/proposals/demoIssuers.js
@@ -560,6 +560,7 @@ export const fundAMM = async ({
           give: { Secondary: secondaryAmount, Central: centralAmount },
         });
 
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         E(zoe).offer(
           E(ammPublicFacet).addPoolInvitation(),
           proposal,

--- a/packages/run-protocol/src/proposals/econ-behaviors.js
+++ b/packages/run-protocol/src/proposals/econ-behaviors.js
@@ -495,11 +495,11 @@ export const startVaultFactory = async (
  * @param {object} [root0.options]
  * @param {string} [root0.options.vaultFactoryControllerAddress]
  */
-export const grantVaultFactoryControl = async (
+export const grantVaultFactoryControl = (
   { consume: { client, priceAuthorityAdmin, vaultFactoryCreator } },
   { options: { vaultFactoryControllerAddress } = {} } = {},
 ) => {
-  E(client).assignBundle([
+  return E(client).assignBundle([
     addr => ({
       vaultFactoryCreatorFacet:
         typeof vaultFactoryControllerAddress === 'string' &&

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -317,7 +317,7 @@ const helperBehavior = {
 
     helper.assertVaultHoldsNoRun();
 
-    helper.updateUiState();
+    void helper.updateUiState();
     clientSeat.exit();
 
     return 'We have adjusted your balances; thank you for your business.';
@@ -357,7 +357,7 @@ const helperBehavior = {
     manager.burnDebt(currentDebt, vaultSeat);
     state.open = false;
     helper.updateDebtSnapshot(AmountMath.makeEmpty(debtBrand));
-    helper.updateUiState();
+    void helper.updateUiState();
     helper.assertVaultHoldsNoRun();
     seat.exit();
 
@@ -417,7 +417,7 @@ const behavior = {
  */
 const finish = ({ facets }) => {
   const { helper } = facets;
-  helper.updateUiState();
+  void helper.updateUiState();
 };
 
 /**

--- a/packages/run-protocol/src/runStake/runStakeManager.js
+++ b/packages/run-protocol/src/runStake/runStakeManager.js
@@ -113,7 +113,7 @@ const finish = ({ state, facets }) => {
 
   const periodNotifier = E(timerService).makeNotifier(0n, recordingPeriod);
 
-  observeNotifier(periodNotifier, {
+  void observeNotifier(periodNotifier, {
     updateState: updateTime =>
       helper
         .chargeAllVaults(updateTime)

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -212,7 +212,7 @@ const getLiquidationConfig = directorParamManager => ({
  */
 const watchGovernance = (govParams, vaultManager, oldInstall, oldTerms) => {
   const subscription = govParams.getSubscription();
-  observeIteration(subscription, {
+  void observeIteration(subscription, {
     updateState(_paramUpdate) {
       const { install, terms } = getLiquidationConfig(govParams);
       if (install === oldInstall && keyEQ(terms, oldTerms)) {

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -262,7 +262,7 @@ const helperBehavior = {
 
     facets.helper.assetNotify();
     trace('chargeAllVaults complete');
-    facets.helper.reschedulePriceCheck();
+    void facets.helper.reschedulePriceCheck();
   },
 
   /** @param {MethodContext} context */
@@ -452,6 +452,7 @@ const helperBehavior = {
         facets.helper.updateMetrics();
 
         if (!AmountMath.isEmpty(accounting.shortfall)) {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises -- FIXME to return the promise
           E(factoryPowers.getShortfallReporter()).increaseLiquidationShortfall(
             accounting.shortfall,
           );
@@ -691,7 +692,7 @@ const finish = ({ state, facets: { helper } }) => {
   // push initial state of metrics
   helper.updateMetrics();
 
-  observeNotifier(state.periodNotifier, {
+  void observeNotifier(state.periodNotifier, {
     updateState: updateTime =>
       helper
         .chargeAllVaults(updateTime, state.poolIncrementSeat)

--- a/packages/run-protocol/src/vpool-xyk-amm/priceAuthority.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/priceAuthority.js
@@ -69,11 +69,11 @@ export const makePriceAuthority = (
   // for each active trigger.
   const priceObserver = Far('priceObserver', {
     updateState: () => {
-      fireTriggers(createQuote);
+      void fireTriggers(createQuote);
     },
   });
 
-  observeNotifier(notifier, priceObserver);
+  void observeNotifier(notifier, priceObserver);
 
   return priceAuthority;
 };

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-governance.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-governance.js
@@ -28,7 +28,7 @@ test.before(async t => {
 test('start Economic Committee', async t => {
   const space = await setupAMMBootstrap();
   const { consume } = space;
-  startEconomicCommittee(space, {
+  await startEconomicCommittee(space, {
     options: {
       econCommitteeOptions: {
         committeeName: 'The Cabal',

--- a/packages/run-protocol/test/reserve/test-reserve.js
+++ b/packages/run-protocol/test/reserve/test-reserve.js
@@ -217,8 +217,8 @@ test('governance add Liquidity to the AMM', async t => {
   await E(voterFacet).castBallotFor(details.questionHandle, [
     details.positions[0],
   ]);
-  timer.tick();
-  timer.tick();
+  await timer.tick();
+  await timer.tick();
   await waitForPromisesToSettle();
 
   t.deepEqual(
@@ -297,8 +297,8 @@ test('request more collateral than available', async t => {
   await E(voterFacet).castBallotFor(details.questionHandle, [
     details.positions[0],
   ]);
-  timer.tick();
-  timer.tick();
+  await timer.tick();
+  await timer.tick();
   await waitForPromisesToSettle();
 
   await outcomeOfUpdate

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -604,7 +604,7 @@ const makeWorld = async (/** @type {RunStakeTestContext} */ t) => {
         harden({ [KW.Attestation]: attPmt }),
       );
       const runPmt = await E(seat).getPayout(KW.Debt);
-      E(runPurse).deposit(runPmt);
+      await E(runPurse).deposit(runPmt);
       offerResult = await E(seat).getOfferResult();
     },
     earnRUNReward: async n => {

--- a/packages/run-protocol/test/swingsetTests/governance/vat-alice.js
+++ b/packages/run-protocol/test/swingsetTests/governance/vat-alice.js
@@ -62,34 +62,34 @@ const build = async (log, zoe, brands, payments, timer) => {
       return `assetNotifier update #${lastAssetN.updateCount} has interestRate.numerator ${lastAssetN.value.interestRate.numerator.value}`;
     };
 
-    timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
+    await timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
 
     // accrue one day of interest at initial rate
     await E(timer).tick();
     await assetUpdate();
-    timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
+    await timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
 
     // advance time enough that governance updates the interest rate
     await Promise.all(new Array(daysForVoting).fill(E(timer).tick()));
-    timeLog('vote ready to close');
+    await timeLog('vote ready to close');
     await assetUpdate();
-    timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
+    await timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
 
     await E(timer).tick();
-    timeLog('vote closed');
+    await timeLog('vote closed');
     await assetUpdate();
-    timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
+    await timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
 
     const uiDescription = () => {
       return `assetNotifier update #${lastAssetN.updateCount} has interestRate.numerator ${lastAssetN.value.interestRate.numerator.value}`;
     };
 
-    timeLog(`1 day after votes cast, ${uiDescription()}`);
+    await timeLog(`1 day after votes cast, ${uiDescription()}`);
     await E(timer).tick();
     await assetUpdate();
-    timeLog(`2 days after votes cast, ${uiDescription()}`);
+    await timeLog(`2 days after votes cast, ${uiDescription()}`);
     await assetUpdate();
-    timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
+    await timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
   };
 
   return Far('build', {

--- a/packages/run-protocol/test/vaultFactory/test-liquidator.js
+++ b/packages/run-protocol/test/vaultFactory/test-liquidator.js
@@ -442,7 +442,7 @@ const makeDriver = async (t, initialPrice, priceBase) => {
     timer: () => timer,
     tick: (ticks = 1) => {
       for (let i = 0; i < ticks; i += 1) {
-        timer.tick();
+        void timer.tick();
       }
     },
     makeVaultDriver,

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -986,7 +986,7 @@ test('interest on multiple vaults', async t => {
   // { chargingPeriod: weekly, recordingPeriod: weekly }
   // Advance 8 days, past one charging and recording period
   for (let i = 0; i < 8; i += 1) {
-    manualTimer.tick();
+    await manualTimer.tick();
   }
   await waitForPromisesToSettle();
 
@@ -1056,7 +1056,7 @@ test('interest on multiple vaults', async t => {
 
   // Advance another 7 days, past one charging and recording period
   for (let i = 0; i < 8; i += 1) {
-    manualTimer.tick();
+    await manualTimer.tick();
   }
   await waitForPromisesToSettle();
 
@@ -1384,7 +1384,7 @@ test('transfer vault', async t => {
     vault: transferVault,
     publicNotifiers: { vault: transferNotifier },
   } = await E(transferSeat).getOfferResult();
-  t.throwsAsync(() => E(aliceVault).getCurrentDebt());
+  await t.throwsAsync(() => E(aliceVault).getCurrentDebt());
   const debtAfter = await E(transferVault).getCurrentDebt();
   t.deepEqual(debtAfter, debtAmount, 'vault lent 5000 RUN + fees');
   const collateralAfter = await E(transferVault).getCollateralAmount();
@@ -1446,14 +1446,14 @@ test('transfer vault', async t => {
     vault: t2Vault,
     publicNotifiers: { vault: t2Notifier },
   } = await E(t2Seat).getOfferResult();
-  t.throwsAsync(
+  await t.throwsAsync(
     () => E(adjustSeatPromise).getOfferResult(),
     {
       message: 'Transfer during vault adjustment',
     },
     'adjust balances should have been rejected',
   );
-  t.throwsAsync(() => E(transferVault).getCurrentDebt());
+  await t.throwsAsync(() => E(transferVault).getCurrentDebt());
   const debtAfter2 = await E(t2Vault).getCurrentDebt();
   t.deepEqual(debtAmount, debtAfter2, 'vault lent 5000 RUN + fees');
 
@@ -1807,7 +1807,7 @@ test('mutable liquidity triggers and interest', async t => {
   // liquidated.
 
   for (let i = 0; i < 8; i += 1) {
-    manualTimer.tick();
+    await manualTimer.tick();
   }
   t.is(bobUpdate.value.vaultState, Phase.ACTIVE);
   trace(
@@ -1829,10 +1829,10 @@ test('mutable liquidity triggers and interest', async t => {
     await E(bobVault).getCurrentDebt(),
   );
   // 5 days pass
-  manualTimer.tick();
-  manualTimer.tick();
-  manualTimer.tick();
-  manualTimer.tick();
+  await manualTimer.tick();
+  await manualTimer.tick();
+  await manualTimer.tick();
+  await manualTimer.tick();
   await manualTimer.tick();
   await waitForPromisesToSettle();
 
@@ -2353,7 +2353,7 @@ test('mutable liquidity sensitivity of triggers and interest', async t => {
   // liquidated.
   // Advance time to trigger interest collection.
   for (let i = 0; i < 8; i += 1) {
-    manualTimer.tick();
+    await manualTimer.tick();
   }
   await waitForPromisesToSettle();
   bobUpdate = await E(bobNotifier).getUpdateSince(bobUpdate.updateCount);

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -156,7 +156,7 @@ export async function start(zcf, privateArgs) {
   );
 
   const advanceRecordingPeriod = () => {
-    timer.tick();
+    void timer.tick();
 
     // skip the debt calculation for this mock manager
     const currentInterestAsMultiplicand = makeRatio(

--- a/packages/spawner/scripts/build-bundles.js
+++ b/packages/spawner/scripts/build-bundles.js
@@ -9,4 +9,4 @@ const sourceToBundle = [
   [`../src/vat-spawned.js`, `../bundles/bundle-spawn.js`],
 ];
 
-createBundles(sourceToBundle, dirname);
+await createBundles(sourceToBundle, dirname);

--- a/packages/vats/scripts/build-bundles.js
+++ b/packages/vats/scripts/build-bundles.js
@@ -10,4 +10,4 @@ const sourceToBundle = [
   [`../src/mintHolder.js`, `../bundles/bundle-mintHolder.js`],
 ];
 
-createBundles(sourceToBundle, dirname);
+await createBundles(sourceToBundle, dirname);

--- a/packages/wallet/api/scripts/build-bundles.js
+++ b/packages/wallet/api/scripts/build-bundles.js
@@ -7,4 +7,4 @@ const dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 const sourceToBundle = [[`../src/wallet.js`, `../bundles/bundle-wallet.js`]];
 
-createBundles(sourceToBundle, dirname);
+await createBundles(sourceToBundle, dirname);

--- a/packages/web-components/src/AgoricWalletConnection.js
+++ b/packages/web-components/src/AgoricWalletConnection.js
@@ -117,6 +117,7 @@ export const makeAgoricWalletConnection = (makeCapTP = defaultMakeCapTP) =>
           return this._bridgePK.promise;
         },
         reset: () => {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.reset();
         },
       });

--- a/packages/zoe/scripts/build-bundles.js
+++ b/packages/zoe/scripts/build-bundles.js
@@ -9,4 +9,4 @@ const sourceToBundle = [
   ['../src/contractFacet/vatRoot.js', '../bundles/bundle-contractFacet.js'],
 ];
 
-createBundles(sourceToBundle, dirname);
+await createBundles(sourceToBundle, dirname);


### PR DESCRIPTION
closes: #5407

## Description

working draft of #5407

will probably land some of these changes before this PR

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

The collection of type information slows down linting.  Measured with `time yarn lerna run --no-bail lint:eslint` on my machine:

- before: `84.86s user 5.35s system 454% cpu 19.827 total` (1.4min)
- after: `824.27s user 135.32s system 556% cpu 2:52.39 total` (14min)

In CI the `lint` job went from [5 min before](https://github.com/Agoric/agoric-sdk/runs/6693643820?check_suite_focus=true) to [21 min after](https://github.com/Agoric/agoric-sdk/runs/6694898124?check_suite_focus=true)