### PR TITLE
Cosmos vbank reserve purse

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -107,6 +107,7 @@ import (
 	swingsetclient "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/client"
 	swingsettypes "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/vbank"
+	vbanktypes "github.com/Agoric/agoric-sdk/golang/cosmos/x/vbank/types"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/vibc"
 
 	// unnamed import of statik for swagger UI support
@@ -166,6 +167,7 @@ var (
 		govtypes.ModuleName:            {authtypes.Burner},
 		ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
 		vbank.ModuleName:               {authtypes.Minter, authtypes.Burner},
+		vbanktypes.ReserveName:         nil,
 	}
 )
 
@@ -438,7 +440,7 @@ func NewAgoricApp(
 
 	app.VbankKeeper = vbank.NewKeeper(
 		appCodec, keys[vbank.StoreKey], app.GetSubspace(vbank.ModuleName),
-		app.BankKeeper, authtypes.FeeCollectorName,
+		app.AccountKeeper, app.BankKeeper, authtypes.FeeCollectorName,
 		app.SwingSetKeeper.PushAction,
 	)
 	vbankModule := vbank.NewAppModule(app.VbankKeeper)

--- a/golang/cosmos/x/vbank/keeper/keeper.go
+++ b/golang/cosmos/x/vbank/keeper/keeper.go
@@ -18,6 +18,7 @@ type Keeper struct {
 	cdc        codec.Codec
 	paramSpace paramtypes.Subspace
 
+	accountKeeper    types.AccountKeeper
 	bankKeeper       types.BankKeeper
 	feeCollectorName string
 	PushAction       vm.ActionPusher
@@ -26,7 +27,7 @@ type Keeper struct {
 // NewKeeper creates a new vbank Keeper instance
 func NewKeeper(
 	cdc codec.Codec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
-	bankKeeper types.BankKeeper,
+	accountKeeper types.AccountKeeper, bankKeeper types.BankKeeper,
 	feeCollectorName string,
 	pushAction vm.ActionPusher,
 ) Keeper {
@@ -40,6 +41,7 @@ func NewKeeper(
 		storeKey:         key,
 		cdc:              cdc,
 		paramSpace:       paramSpace,
+		accountKeeper:    accountKeeper,
 		bankKeeper:       bankKeeper,
 		feeCollectorName: feeCollectorName,
 		PushAction:       pushAction,
@@ -54,7 +56,7 @@ func (k Keeper) GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
 	return k.bankKeeper.GetAllBalances(ctx, addr)
 }
 
-func (k Keeper) StoreFeeCoins(ctx sdk.Context, amt sdk.Coins) error {
+func (k Keeper) StoreRewardCoins(ctx sdk.Context, amt sdk.Coins) error {
 	return k.bankKeeper.MintCoins(ctx, types.ModuleName, amt)
 }
 
@@ -74,6 +76,10 @@ func (k Keeper) GrabCoins(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coins) e
 		return err
 	}
 	return k.bankKeeper.BurnCoins(ctx, types.ModuleName, amt)
+}
+
+func (k Keeper) GetModuleAccountAddress(ctx sdk.Context, name string) sdk.AccAddress {
+	return k.accountKeeper.GetModuleAddress(name)
 }
 
 func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {

--- a/golang/cosmos/x/vbank/types/expected_keepers.go
+++ b/golang/cosmos/x/vbank/types/expected_keepers.go
@@ -14,3 +14,7 @@ type BankKeeper interface {
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins) error
 }
+
+type AccountKeeper interface {
+	GetModuleAddress(name string) sdk.AccAddress
+}

--- a/golang/cosmos/x/vbank/types/key.go
+++ b/golang/cosmos/x/vbank/types/key.go
@@ -6,4 +6,6 @@ const (
 
 	// StoreKey to be used when creating the KVStore
 	StoreKey = ModuleName
+
+	ReserveName = "vbank/reserve"
 )

--- a/golang/cosmos/x/vbank/vbank.go
+++ b/golang/cosmos/x/vbank/vbank.go
@@ -238,7 +238,7 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string
 
 	case "VBANK_GET_MODULE_ACCOUNT_ADDRESS":
 		addr := keeper.GetModuleAccountAddress(ctx.Context, msg.ModuleName).String()
-		if addr == "" {
+		if len(addr) == 0 {
 			return "", fmt.Errorf("module account %s not found", msg.ModuleName)
 		}
 		bz, err := marshal(addr)

--- a/packages/run-protocol/src/proposals/econ-behaviors.js
+++ b/packages/run-protocol/src/proposals/econ-behaviors.js
@@ -510,8 +510,8 @@ export const startRewardDistributor = async ({
     centralIssuerP,
     centralBrandP,
   ]);
-  const feeCollectorDepositFacet = await E(bankManager)
-    .getFeeCollectorDepositFacet(CENTRAL_DENOM_NAME, {
+  const rewardDistributorDepositFacet = await E(bankManager)
+    .getRewardDistributorDepositFacet(CENTRAL_DENOM_NAME, {
       issuer: centralIssuer,
       brand: centralBrand,
     })
@@ -520,8 +520,8 @@ export const startRewardDistributor = async ({
       return undefined;
     });
 
-  // Only distribute fees if there is a collector.
-  if (!feeCollectorDepositFacet) {
+  // Only distribute rewards if there is a collector.
+  if (!rewardDistributorDepositFacet) {
     return;
   }
 
@@ -535,7 +535,7 @@ export const startRewardDistributor = async ({
     [vaultAdmin, ammAdmin, runStakeAdmin].map(cf =>
       E(vats.distributeFees).makeFeeCollector(zoe, cf),
     ),
-    feeCollectorDepositFacet,
+    rewardDistributorDepositFacet,
     epochTimerService,
     harden(distributorParams),
   );

--- a/packages/run-protocol/test/test-gov-collateral.js
+++ b/packages/run-protocol/test/test-gov-collateral.js
@@ -128,12 +128,8 @@ const makeScenario = async t => {
   };
 
   const startDevNet = async () => {
-    const bridgeManager = {
-      toBridge: () => {},
-      register: () => {},
-      unregister: () => {},
-    };
-    space.produce.bridgeManager.resolve(bridgeManager);
+    // If we don't have a proper bridge manager, we need it to be undefined.
+    space.produce.bridgeManager.resolve(undefined);
 
     space.installation.produce.mintHolder.resolve(
       t.context.installation.mintHolder,

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -127,9 +127,9 @@ export function buildRootObject(_vatPowers) {
                 const updater = addressToUpdater.get(address);
 
                 updater(value, obj.nonce);
-                console.error('Successful update', update);
+                console.info('bank balance update', update);
               } catch (e) {
-                console.error('Unregistered update', update);
+                // console.error('Unregistered update', update);
               }
             }
             return true;
@@ -272,9 +272,9 @@ export function buildRootObject(_vatPowers) {
          * @param {AssetIssuerKit} feeKit
          * @returns {import('@endo/far').EOnly<DepositFacet>}
          */
-        getFeeCollectorDepositFacet(denom, feeKit) {
+        getRewardDistributorDepositFacet(denom, feeKit) {
           if (!bankCall) {
-            throw Error(`Bank doesn't implement fee collectors`);
+            throw Error(`Bank doesn't implement reward collectors`);
           }
 
           /** @type {VirtualPurseController} */
@@ -284,12 +284,12 @@ export function buildRootObject(_vatPowers) {
               yield new Promise(_ => {});
             },
             async pullAmount(_amount) {
-              throw Error(`Cannot pull from fee collector`);
+              throw Error(`Cannot pull from reward distributor`);
             },
             async pushAmount(amount) {
               const value = AmountMath.getValue(feeKit.brand, amount);
               await bankCall({
-                type: 'VBANK_GIVE_TO_FEE_COLLECTOR',
+                type: 'VBANK_GIVE_TO_REWARD_DISTRIBUTOR',
                 denom,
                 amount: `${value}`,
               });
@@ -297,6 +297,24 @@ export function buildRootObject(_vatPowers) {
           });
           const vp = makeVirtualPurse(feeVpc, feeKit);
           return E(vp).getDepositFacet();
+        },
+
+        /**
+         * Get the address of named module account.
+         *
+         * @param {string} moduleName
+         * @returns {Promise<string | null>} address of named module account, or
+         * null if unimplemented (no bankCall)
+         */
+        getModuleAccountAddress: async moduleName => {
+          if (!bankCall) {
+            return null;
+          }
+
+          return bankCall({
+            type: 'VBANK_GET_MODULE_ACCOUNT_ADDRESS',
+            moduleName,
+          });
         },
 
         /**

--- a/packages/vats/test/test-vat-bank.js
+++ b/packages/vats/test/test-vat-bank.js
@@ -80,7 +80,7 @@ test('communication', async t => {
           break;
         }
 
-        case 'VBANK_GIVE_TO_FEE_COLLECTOR': {
+        case 'VBANK_GIVE_TO_REWARD_DISTRIBUTOR': {
           const { amount, denom, type: _type, ...rest } = obj;
           t.is(denom, 'ufee');
           t.is(amount, '12');
@@ -192,7 +192,7 @@ test('communication', async t => {
   const feeAmount = AmountMath.make(feeKit.brand, 12n);
   const feePayment = mint.mintPayment(feeAmount);
   const feeReceived = await E(
-    E(bankMgr).getFeeCollectorDepositFacet('ufee', feeKit),
+    E(bankMgr).getRewardDistributorDepositFacet('ufee', feeKit),
   ).receive(feePayment);
   t.assert(AmountMath.isEqual(feeReceived, feeAmount));
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #4399

## Description

This clarifies the separation of the reserve flow from the reward flow.

Also, implements Cosmos module accounts for vbank purses, such as the `'vbank/reserve'` module acount for reserve purses.  That module account has a fixed `agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl` address (hashed from `'vbank/reserve'`).

Work still needed includes the logic around diverting the `x/swingset` fees and reward stream, and also integrating the module account purses in the JS reserve contract.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
