### PR TITLE
fix(swing-store): check fs streams are ready

### DIFF
--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -21,7 +21,7 @@ const { freeze } = Object;
 const encoder = new TextEncoder();
 
 /** @param { number } n */
-const pad5 = n => `00000${n}`.slice(-5);
+const pad5 = n => `${n}`.padStart(5, '0');
 
 /**
  * @param {string} path
@@ -33,7 +33,8 @@ function makeSyncStorage(path, { writeFileSync }) {
     /** @param {string} fn */
     file: fn => {
       /** @param { Uint8Array } data */
-      const put = data => writeFileSync(new URL(fn, base).pathname, data);
+      const put = data =>
+        writeFileSync(new URL(fn, base).pathname, data, { flag: 'wx' });
 
       return freeze({
         put,


### PR DESCRIPTION
refs: #5419 

## Description

I wondering if something is causing the fs streams to not be in a good state and pipe to fail silently in that case. I had to add a [similar helper in the loadgen](https://github.com/Agoric/testnet-load-generator/commit/7d8ef1793b7115d9d58e041f94e321a18912ab9c), and it shouldn't hurt here.

### Security Considerations

None, this is doing extra error checking

### Documentation Considerations

N/A

### Testing Considerations

I'd like to experimentally test this commit
