### PR TITLE
Add addPool to AMM creatorFacet and reinstate economy boot

### DIFF
--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -137,10 +137,12 @@ scenario2-setup-nobuild:
 	mv t1/n0/config/genesis2.json t1/n0/config/genesis.json
 	$(MAKE) set-local-gci-ingress
 
-scenario2-run-chain-economy:
+t1/decentral-economy-config.json: $(ECONOMY_PROPOSALS)
 	jq -s '.[0] * { coreProposals: .[1] }' \
 		../vats/decentral-core-config.json \
 		'$(ECONOMY_PROPOSALS)' > t1/decentral-economy-config.json
+
+scenario2-run-chain-economy: t1/decentral-economy-config.json
 	CHAIN_BOOTSTRAP_VAT_CONFIG="$$PWD/t1/decentral-economy-config.json" \
 		OTEL_EXPORTER_PROMETHEUS_PORT=$(OTEL_EXPORTER_PROMETHEUS_PORT) \
 		$(AGC) --home=t1/n0 start --log_level=warn $(AGC_START_ARGS)
@@ -150,8 +152,9 @@ scenario2-run-chain:
 		$(AGC) --home=t1/n0 start --log_level=warn $(AGC_START_ARGS)
 
 # Run a chain with an explicit halt.
-scenario2-run-chain-to-halt:
-	$(AGC) --home=t1/n0 start --log_level=warn --halt-height=$$(($(INITIAL_HEIGHT) + 3)); \
+scenario2-run-chain-to-halt: t1/decentral-economy-config.json
+	CHAIN_BOOTSTRAP_VAT_CONFIG="$$PWD/t1/decentral-economy-config.json" \
+		$(AGC) --home=t1/n0 start --log_level=warn --halt-height=$$(($(INITIAL_HEIGHT) + 3)); \
 		test "$$?" -eq 98
 
 # Blow away all client state to try again without resetting the chain.

--- a/packages/run-protocol/scripts/add-collateral-core.js
+++ b/packages/run-protocol/scripts/add-collateral-core.js
@@ -6,7 +6,6 @@ import { getManifestForAddAssetToVault } from '../src/proposals/addAssetToVault.
 import { getManifestForPsm } from '../src/proposals/startPSM.js';
 import { makeInstallCache } from '../src/proposals/utils.js';
 
-// Build proposal for sim-chain etc.
 export const defaultProposalBuilder = async (
   { publishRef, install: install0, wrapInstall },
   { interchainAssetOptions = /** @type {object} */ ({}) } = {},
@@ -15,13 +14,16 @@ export const defaultProposalBuilder = async (
   /** @type {import('../src/proposals/addAssetToVault.js').InterchainAssetOptions} */
   const {
     issuerBoardId = env.INTERCHAIN_ISSUER_BOARD_ID,
+    denom,
     oracleBrand = 'ATOM',
     decimalPlaces = 6,
     keyword = 'IbcATOM',
     proposedName = oracleBrand,
   } = interchainAssetOptions;
 
-  assert(issuerBoardId, 'INTERCHAIN_ISSUER_BOARD_ID is required');
+  if (!denom) {
+    assert(issuerBoardId, 'INTERCHAIN_ISSUER_BOARD_ID is required');
+  }
 
   const install = wrapInstall ? wrapInstall(install0) : install0;
 
@@ -31,6 +33,7 @@ export const defaultProposalBuilder = async (
       getManifestForAddAssetToVault.name,
       {
         interchainAssetOptions: {
+          denom,
           issuerBoardId,
           decimalPlaces,
           keyword,

--- a/packages/run-protocol/src/proposals/addAssetToVault.js
+++ b/packages/run-protocol/src/proposals/addAssetToVault.js
@@ -203,7 +203,9 @@ export const addAssetToVault = async (
   );
 
   await Promise.all([
-    E(ammCreatorFacet).addPool(interchainIssuer, keyword),
+    ...(interchainAssetOptions.denom
+      ? [E(ammCreatorFacet).addPool(interchainIssuer, keyword)]
+      : []),
     E(reserveCreatorFacet).addIssuer(interchainIssuer, keyword),
   ]);
 

--- a/packages/run-protocol/src/proposals/addAssetToVault.js
+++ b/packages/run-protocol/src/proposals/addAssetToVault.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { AmountMath } from '@agoric/ertp';
+import { AmountMath, AssetKind } from '@agoric/ertp';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/far';
 
@@ -9,10 +9,11 @@ export * from './startPSM.js';
 
 /**
  * @typedef {object} InterchainAssetOptions
- * @property {string} issuerBoardId
+ * @property {string} [issuerBoardId]
+ * @property {string} [denom]
+ * @property {number} [decimalPlaces]
+ * @property {string} [proposedName]
  * @property {string} keyword
- * @property {string} proposedName
- * @property {number} decimalPlaces
  * @property {string} oracleBrand
  */
 
@@ -22,22 +23,76 @@ export * from './startPSM.js';
  * @param {object} config.options
  * @param {InterchainAssetOptions} config.options.interchainAssetOptions
  */
-export const addInterchainAsset = async (
+export const publishInterchainAssetFromBoardId = async (
   { consume: { board, agoricNamesAdmin } },
   { options: { interchainAssetOptions } },
 ) => {
-  const { issuerBoardId, keyword, decimalPlaces, proposedName } =
-    interchainAssetOptions;
+  const { issuerBoardId, keyword } = interchainAssetOptions;
+  // Incompatible with denom.
+  assert.equal(interchainAssetOptions.denom, undefined);
   assert.typeof(issuerBoardId, 'string');
   assert.typeof(keyword, 'string');
-  assert.typeof(decimalPlaces, 'number');
-  assert.typeof(proposedName, 'string');
 
   const issuer = await E(board).getValue(issuerBoardId);
   const brand = await E(issuer).getBrand();
 
   E(E(agoricNamesAdmin).lookupAdmin('issuer')).update(keyword, issuer);
   E(E(agoricNamesAdmin).lookupAdmin('brand')).update(keyword, brand);
+};
+
+/**
+ * @param { EconomyBootstrapPowers } powers
+ * @param {object} config
+ * @param {object} config.options
+ * @param {InterchainAssetOptions} config.options.interchainAssetOptions
+ */
+export const publishInterchainAssetFromBank = async (
+  {
+    consume: { zoe, bankManager, agoricNamesAdmin, bankMints },
+    produce: { bankMints: produceBankMints },
+    installation: {
+      consume: { mintHolder },
+    },
+  },
+  { options: { interchainAssetOptions } },
+) => {
+  const { denom, decimalPlaces, proposedName, keyword } =
+    interchainAssetOptions;
+
+  // Incompatible with issuerBoardId.
+  assert.equal(interchainAssetOptions.issuerBoardId, undefined);
+  assert.typeof(denom, 'string');
+  assert.typeof(keyword, 'string');
+  assert.typeof(decimalPlaces, 'number');
+  assert.typeof(proposedName, 'string');
+
+  /** @type {import('@agoric/vats/src/mintHolder.js').AssetTerms} */
+  const terms = {
+    keyword,
+    assetKind: AssetKind.NAT,
+    displayInfo: {
+      decimalPlaces,
+      assetKind: AssetKind.NAT,
+    },
+  };
+  const { creatorFacet: mint, publicFacet: issuer } = E.get(
+    E(zoe).startInstance(mintHolder, {}, terms),
+  );
+
+  const brand = await E(issuer).getBrand();
+  const kit = { mint, issuer, brand };
+
+  // Create the mint list if it doesn't exist and wasn't already rejected.
+  produceBankMints.resolve([]);
+  await Promise.all([
+    Promise.resolve(bankMints).then(
+      mints => mints.push(mint),
+      () => {}, // If the bankMints list was rejected, ignore the error.
+    ),
+    E(E(agoricNamesAdmin).lookupAdmin('issuer')).update(keyword, issuer),
+    E(E(agoricNamesAdmin).lookupAdmin('brand')).update(keyword, brand),
+    E(bankManager).addAsset(denom, keyword, proposedName, kit),
+  ]);
 };
 
 /**
@@ -167,16 +222,35 @@ export const getManifestForAddAssetToVault = (
   { restoreRef },
   { interchainAssetOptions, scaledPriceAuthorityRef },
 ) => {
+  const publishIssuerFromBoardId =
+    typeof interchainAssetOptions.issuerBoardId === 'string';
+  const publishIssuerFromBank =
+    !publishIssuerFromBoardId &&
+    typeof interchainAssetOptions.denom === 'string';
   return {
     manifest: {
-      [addInterchainAsset.name]: {
-        consume: {
-          board: true,
-          zoe: true,
-          bankManager: true,
-          agoricNamesAdmin: true,
+      ...(publishIssuerFromBoardId && {
+        [publishInterchainAssetFromBoardId.name]: {
+          consume: {
+            board: true,
+            agoricNamesAdmin: true,
+          },
         },
-      },
+      }),
+      ...(publishIssuerFromBank && {
+        [publishInterchainAssetFromBank.name]: {
+          consume: {
+            zoe: true,
+            bankManager: true,
+            agoricNamesAdmin: true,
+            bankMints: true,
+          },
+          produce: { bankMints: true },
+          installation: {
+            consume: { mintHolder: true },
+          },
+        },
+      }),
       [registerScaledPriceAuthority.name]: {
         consume: {
           agoricNamesAdmin: true,
@@ -191,6 +265,7 @@ export const getManifestForAddAssetToVault = (
       [addAssetToVault.name]: {
         consume: {
           vaultFactoryCreator: true,
+          ammCreatorFacet: true,
           reserveCreatorFacet: true,
           agoricNamesAdmin: true,
         },

--- a/packages/run-protocol/src/proposals/addAssetToVault.js
+++ b/packages/run-protocol/src/proposals/addAssetToVault.js
@@ -127,7 +127,12 @@ export const registerScaledPriceAuthority = async (
  */
 export const addAssetToVault = async (
   {
-    consume: { vaultFactoryCreator, reserveCreatorFacet, agoricNamesAdmin },
+    consume: {
+      ammCreatorFacet,
+      vaultFactoryCreator,
+      reserveCreatorFacet,
+      agoricNamesAdmin,
+    },
     brand: {
       consume: { RUN: runP },
     },
@@ -142,7 +147,10 @@ export const addAssetToVault = async (
     [keyword],
   );
 
-  await E(reserveCreatorFacet).addIssuer(interchainIssuer, keyword);
+  await Promise.all([
+    E(ammCreatorFacet).addPool(interchainIssuer, keyword),
+    E(reserveCreatorFacet).addIssuer(interchainIssuer, keyword),
+  ]);
 
   const RUN = await runP;
   await E(vaultFactoryCreator).addVaultType(interchainIssuer, oracleBrand, {

--- a/packages/run-protocol/src/proposals/econ-behaviors.js
+++ b/packages/run-protocol/src/proposals/econ-behaviors.js
@@ -36,7 +36,7 @@ const CENTRAL_DENOM_NAME = 'urun';
  *   ammCreatorFacet: XYKAMMCreatorFacet,
  *   ammGovernorCreatorFacet: GovernedContractFacetAccess<unknown>,
  *   economicCommitteeCreatorFacet: CommitteeElectorateCreatorFacet,
- *   interchainMints: Mint[],
+ *   bankMints: Mint[],
  *   psmCreatorFacet: unknown,
  *   psmGovernorCreatorFacet: GovernedContractFacetAccess<unknown>,
  *   reservePublicFacet: AssetReservePublicFacet,

--- a/packages/run-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addPool.js
@@ -55,38 +55,22 @@ export const makeAddIssuer = (zcf, isInSecondaries, brandToLiquidityMint) => {
 /**
  * @param {ZCF<import('./multipoolMarketMaker.js').AMMTerms>} zcf
  * @param {(brand: Brand, pool: PoolFacets) => void} initPool add new pool to store
- * @param {Brand} centralBrand
- * @param {ERef<Timer>} timer
- * @param {IssuerKit} quoteIssuerKit
  * @param {import('./multipoolMarketMaker.js').AMMParamGetters} params retrieve governed params
- * @param {ZCFSeat} protocolSeat seat that holds collected fees
  * @param {ZCFSeat} reserveLiquidityTokenSeat seat that holds liquidity tokens
  *   from adding pool liquidity. It is expected to be collected by the Reserve.
  * @param {WeakStore<Brand,ZCFMint>} brandToLiquidityMint
  * @param {() => void} updateMetrics
+ * @param {ReturnType<typeof definePoolKind>} makePool
  */
 export const makeAddPoolInvitation = (
   zcf,
   initPool,
-  centralBrand,
-  timer,
-  quoteIssuerKit,
   params,
-  protocolSeat,
   reserveLiquidityTokenSeat,
   brandToLiquidityMint,
   updateMetrics,
+  makePool,
 ) => {
-  // TODO: get this as an argument from start()
-  const makePool = definePoolKind(
-    zcf,
-    centralBrand,
-    timer,
-    quoteIssuerKit,
-    params,
-    protocolSeat,
-  );
-
   /** @type {(Brand) => Promise<{poolFacets: PoolFacets, liquidityZcfMint: ZCFMint}>} */
   const addPool = async secondaryBrand => {
     const liquidityZcfMint = brandToLiquidityMint.get(secondaryBrand);

--- a/packages/run-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addPool.js
@@ -41,8 +41,9 @@ export const makeAddIssuer = (zcf, isInSecondaries, brandToLiquidityMint) => {
         AssetKind.NAT,
         harden({ decimalPlaces: 6 }),
       ),
-      mint => {
-        zcf.saveIssuer(secondaryIssuer, keyword);
+      /** @param {ZCFMint} mint */
+      async mint => {
+        await zcf.saveIssuer(secondaryIssuer, keyword);
         brandToLiquidityMint.init(secondaryBrand, mint);
         const { issuer: liquidityIssuer } = mint.getIssuerRecord();
         return liquidityIssuer;

--- a/packages/run-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addPool.js
@@ -77,6 +77,7 @@ export const makeAddPoolInvitation = (
   brandToLiquidityMint,
   updateMetrics,
 ) => {
+  // TODO: get this as an argument from start()
   const makePool = definePoolKind(
     zcf,
     centralBrand,

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -171,14 +171,21 @@ const start = async (zcf, privateArgs) => {
 
   const getLiquiditySupply = brand => getPool(brand).getLiquiditySupply();
   const getLiquidityIssuer = brand => getPool(brand).getLiquidityIssuer();
-  const addPoolInvitation = makeAddPoolInvitation(
+
+  const makePool = definePoolKind(
     zcf,
-    initPool,
     centralBrand,
     timer,
     quoteIssuerKit,
     params,
     protocolSeat,
+  );
+
+  const addPoolInvitation = makeAddPoolInvitation(
+    zcf,
+    initPool,
+    makePool,
+    params,
     reserveLiquidityTokenSeat,
     secondaryBrandToLiquidityMint,
     updateMetrics,
@@ -289,16 +296,6 @@ const start = async (zcf, privateArgs) => {
       getMetrics: () => metricsSubscription,
       getPoolMetrics,
     }),
-  );
-
-  // TODO: pass this into makeAddPoolInvitation
-  const makePool = definePoolKind(
-    zcf,
-    centralBrand,
-    timer,
-    quoteIssuerKit,
-    params,
-    protocolSeat,
   );
 
   /**

--- a/packages/run-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/types.js
@@ -95,6 +95,7 @@
 /**
  * @typedef {object} XYKAMMCreatorFacet
  * @property {() => Promise<Invitation>} makeCollectFeesInvitation
+ * @property {(secondaryIssuer: Issuer, keyword: string) => Promise<Issuer>} addPool
  */
 /**
  * @typedef {object} XYKAMMPublicFacet

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -1138,3 +1138,20 @@ test('amm adding liquidity', async t => {
     `poolAllocation after initialization`,
   );
 });
+
+test('addPool on creatorFacet', async t => {
+  const centralR = makeIssuerKit('central');
+  const moolaR = makeIssuerKit('moola');
+
+  const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
+  const timer = buildManualTimer(t.log, 30n);
+
+  const { amm } = await setupAmmServices(t, electorateTerms, centralR, timer);
+
+  await E(amm.ammCreatorFacet).addPool(moolaR.issuer, 'Moola');
+
+  const brands = await E(amm.ammPublicFacet).getAllPoolBrands();
+  t.deepEqual(brands, [moolaR.brand]);
+  const actual = await E(amm.ammPublicFacet).getPoolAllocation(moolaR.brand);
+  t.deepEqual(actual, {});
+});


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #5375

## Description

- Put addPool on the AMM creatorFacet, primarily to un-tie knots in automated bootstrap; not intended for normal production use.
- Fix economy bootstrap, and add to CI.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
