### PR TITLE
feat: Add a helper for publishing iteration results to chain storage

### DIFF
--- a/packages/vats/decentral-core-config.json
+++ b/packages/vats/decentral-core-config.json
@@ -21,6 +21,9 @@
     "board": {
       "sourceSpec": "@agoric/vats/src/vat-board.js"
     },
+    "chainStorage": {
+      "sourceSpec": "./src/vat-chainStorage.js"
+    },
     "distributeFees": {
       "sourceSpec": "@agoric/vats/src/vat-distributeFees.js"
     },

--- a/packages/vats/src/bridge-ids.js
+++ b/packages/vats/src/bridge-ids.js
@@ -2,5 +2,6 @@
 export const BANK = 'bank';
 export const CORE = 'core';
 export const DIBC = 'dibc';
+export const STORAGE = 'storage';
 export const PROVISION = 'provision';
 export const WALLET = 'wallet';

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -284,7 +284,7 @@ harden(makeBridgeManager);
 
 /**
  * @param {BootstrapPowers & {
- *   consume: { loadVat: ERef<VatLoader<ProvisioningVat>> }
+ *   consume: { loadVat: ERef<VatLoader<ChainStorageVat>> }
  * }} powers
  */
 export const makeChainStorage = async ({

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -287,7 +287,7 @@ harden(makeBridgeManager);
  * @param { BootstrapPowers } powers
  */
 export const makeChainStorage = async ({
-  consume: { bridgeManager: bridgeManagerP },
+  consume: { bridgeManager: bridgeManagerP, loadVat },
   produce: { chainStorage: chainStorageP },
 }) => {
   const bridgeManager = await bridgeManagerP;
@@ -296,60 +296,19 @@ export const makeChainStorage = async ({
     chainStorageP.resolve(undefined);
     return;
   }
-  const toStorage = message =>
-    E(bridgeManager).toBridge(BRIDGE_ID.STORAGE, message);
 
   // TODO: Formalize root key.
   // Must not be any of {activityhash,beansOwing,egress,mailbox},
   // and must be reserved in sites that use those keys (both Go and JS).
   const ROOT_KEY = 'published';
-  // TODO: Formalize segment constraints.
-  // Must be nonempty and disallow (unescaped) `.`, and for simplicity
-  // (and future possibility of e.g. escaping) we currently limit to
-  // ASCII alphanumeric plus underscore.
-  const pathSegmentPattern = /^[a-zA-Z0-9_]{1,100}$/;
-  const makeChainStorageNode = key => {
-    const node = {
-      getKey() {
-        return key;
-      },
-      getChildNode(name) {
-        assert.typeof(name, 'string');
-        if (!pathSegmentPattern.test(name)) {
-          assert.fail(
-            X`Path segment must be a short ASCII identifier: ${name}`,
-          );
-        }
-        return makeChainStorageNode(`${key}.${name}`);
-      },
-      setValue(value) {
-        assert.typeof(value, 'string');
-        // TODO: Fix on the Go side.
-        // https://github.com/Agoric/agoric-sdk/issues/5381
-        assert(value !== '');
-        toStorage({ key, method: 'set', value });
-      },
-      async delete() {
-        assert(key !== ROOT_KEY);
-        const childKeys = await toStorage({ key, method: 'keys' });
-        if (childKeys.length > 0) {
-          assert.fail(X`Refusing to delete node with children: ${key}`);
-        }
-        toStorage({ key, method: 'set' });
-      },
-      // Possible extensions:
-      // * getValue()
-      // * getChildNames() and/or getChildNodes()
-      // * getName()
-      // * recursive delete
-      // * batch operations
-      // * local buffering (with end-of-block commit)
-    };
-    return Far('chainStorageNode', node);
-  };
 
-  const rootNode = makeChainStorageNode(ROOT_KEY);
-  chainStorageP.resolve(rootNode);
+  const vat = E(loadVat)('chainStorage');
+  const rootNodeP = E(vat).createChainStorageRoot(
+    bridgeManager,
+    BRIDGE_ID.STORAGE,
+    ROOT_KEY,
+  );
+  chainStorageP.resolve(rootNodeP);
 };
 
 /**

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -283,7 +283,9 @@ export const makeBridgeManager = async ({
 harden(makeBridgeManager);
 
 /**
- * @param { BootstrapPowers } powers
+ * @param {BootstrapPowers & {
+ *   consume: { loadVat: ERef<VatLoader<ProvisioningVat>> }
+ * }} powers
  */
 export const makeChainStorage = async ({
   consume: { bridgeManager: bridgeManagerP, loadVat },

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -302,7 +302,7 @@ export const makeChainStorage = async ({
   const ROOT_KEY = 'published';
 
   const vat = E(loadVat)('chainStorage');
-  const rootNodeP = E(vat).createChainStorageRoot(
+  const rootNodeP = E(vat).makeBridgedChainStorageRoot(
     bridgeManager,
     BRIDGE_ID.STORAGE,
     ROOT_KEY,

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -282,7 +282,6 @@ export const makeBridgeManager = async ({
 };
 harden(makeBridgeManager);
 
-// TODO: Refine typing... maybe something like PromiseSpace or PromiseSpaceOf?
 /**
  * @param { BootstrapPowers } powers
  */

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -82,6 +82,14 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
     },
     home: { produce: { chainTimerService: 'timer' } },
   },
+  makeChainStorage: {
+    consume: {
+      bridgeManager: true,
+    },
+    produce: {
+      chainStorage: true,
+    },
+  },
   makeClientBanks: {
     consume: {
       bankManager: 'bank',

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -85,6 +85,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
   makeChainStorage: {
     consume: {
       bridgeManager: true,
+      loadVat: true,
     },
     produce: {
       chainStorage: true,

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -189,6 +189,7 @@
  *   bldIssuerKit: RemoteIssuerKit,
  *   board: Board,
  *   bridgeManager: OptionalBridgeManager,
+ *   chainStorage: unknown,
  *   chainTimerService: TimerService,
  *   client: ClientManager,
  *   clientCreator: ClientCreator,

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -236,6 +236,7 @@
  * @typedef {{ mint: ERef<Mint>, issuer: ERef<Issuer>, brand: Brand }} RemoteIssuerKit
  * @typedef {ReturnType<Awaited<BankVat>['makeBankManager']>} BankManager
  * @typedef {ERef<ReturnType<import('../vat-bank.js').buildRootObject>>} BankVat
+ * @typedef {ERef<ReturnType<import('../vat-chainStorage.js').buildRootObject>>} ChainStorageVat
  * @typedef {ERef<ReturnType<import('../vat-provisioning.js').buildRootObject>>} ProvisioningVat
  * @typedef {ERef<ReturnType<import('../vat-mints.js').buildRootObject>>} MintsVat
  * @typedef {ERef<ReturnType<import('../vat-priceAuthority.js').buildRootObject>>} PriceAuthorityVat

--- a/packages/vats/src/lib-chainPublish.js
+++ b/packages/vats/src/lib-chainPublish.js
@@ -10,8 +10,8 @@ import { E } from '@endo/far';
  * Array items are possibly-duplicated [index, value] pairs, where index is a
  * string (ascending numeric or terminal "finish" or "fail").
  *
- * @param {AsyncIterator} iterable
- * @param {ReturnType<typeof import('./lib-chainStorage.js').makeChainStorageRoot>} chainStorageNode
+ * @param {ERef<AsyncIterator>} iterable
+ * @param {{ setValue: (val: any) => void }} chainStorageNode
  * @param {{ timerService: ERef<TimerService>, serialize?: (obj: any) => string }} powers
  */
 export async function publishToChainNode(

--- a/packages/vats/src/lib-chainPublish.js
+++ b/packages/vats/src/lib-chainPublish.js
@@ -10,12 +10,12 @@ import { E } from '@endo/far';
  * Array items are possibly-duplicated [index, value] pairs, where index is a
  * string (ascending numeric or terminal "finish" or "fail").
  *
- * @param {ERef<AsyncIterator>} iterable
+ * @param {ERef<AsyncIterable>} source
  * @param {{ setValue: (val: any) => void }} chainStorageNode
  * @param {{ timerService: ERef<TimerService>, serialize?: (obj: any) => string }} powers
  */
 export async function publishToChainNode(
-  iterable,
+  source,
   chainStorageNode,
   { timerService, serialize = JSON.stringify },
 ) {
@@ -49,7 +49,7 @@ export async function publishToChainNode(
       E(chainStorageNode).setValue(serialize(combined));
     };
   };
-  await observeIteration(iterable, {
+  await observeIteration(source, {
     updateState: makeAcceptor(),
     finish: makeAcceptor('finish'),
     fail: makeAcceptor('fail'),

--- a/packages/vats/src/lib-chainPublish.js
+++ b/packages/vats/src/lib-chainPublish.js
@@ -1,11 +1,14 @@
 // @ts-check
 
+import { observeIteration } from '@agoric/notifier';
 import { E } from '@endo/far';
 
 /**
  * Publish results of an async iterable into a chain storage node as an array
  * serialized using JSON.stringify or an optionally provided function (e.g.,
  * leveraging a serialize function from makeMarshal).
+ * Array items are possibly-duplicated [index, value] pairs, where index is a
+ * string (ascending numeric or terminal "finish" or "fail").
  *
  * @param {AsyncIterator} iterable
  * @param {ReturnType<typeof import('./lib-chainStorage.js').makeChainStorageRoot>} chainStorageNode
@@ -20,27 +23,35 @@ export async function publishToChainNode(
   let isNewBlock = true;
   let oldResults = [];
   let results = [];
-  for await (const result of iterable) {
-    if (isNewBlock) {
-      isNewBlock = false;
-      oldResults = results;
-      results = [];
-      E(timerService)
-        .delay(1n)
-        .then(() => {
-          isNewBlock = true;
-        });
-    }
-    // To avoid loss when detecting the new block *after* already consuming
-    // results produced within it, we associate each result with an index and
-    // include "old" results in the batch.
-    // Downstream consumers are expected to deduplicate by index.
-    // We represent the index as a string to maintain compatibility with
-    // JSON.stringify and to avoid overly inflating the data size (e.g. with
-    // "@qclass" objects from makeMarshal serialize functions).
-    results.push([String(nextIndex), result]);
-    nextIndex += 1n;
-    const batch = harden(oldResults.slice().concat(results));
-    E(chainStorageNode).setValue(serialize(batch));
-  }
+  const makeAcceptor = forceIndex => {
+    return value => {
+      if (isNewBlock) {
+        isNewBlock = false;
+        oldResults = results;
+        results = [];
+        E(timerService)
+          .delay(1n)
+          .then(() => {
+            isNewBlock = true;
+          });
+      }
+      // To avoid loss when detecting the new block *after* already consuming
+      // results produced within it, we associate each result with an index and
+      // include "old" results in the batch.
+      // Downstream consumers are expected to deduplicate by index.
+      // We represent the index as a string to maintain compatibility with
+      // JSON.stringify and to avoid overly inflating the data size (e.g. with
+      // "@qclass" objects from makeMarshal serialize functions).
+      const index = forceIndex || String(nextIndex);
+      nextIndex += 1n;
+      results.push([index, value]);
+      const batch = harden(oldResults.slice().concat(results));
+      E(chainStorageNode).setValue(serialize(batch));
+    };
+  };
+  await observeIteration(iterable, {
+    updateState: makeAcceptor(),
+    finish: makeAcceptor('finish'),
+    fail: makeAcceptor('fail'),
+  });
 }

--- a/packages/vats/src/lib-chainPublish.js
+++ b/packages/vats/src/lib-chainPublish.js
@@ -37,7 +37,7 @@ export async function publishToChainNode(
       }
       // To avoid loss when detecting the new block *after* already consuming
       // results produced within it, we associate each result with an index and
-      // include "old" results in the batch.
+      // include results of the previous batch.
       // Downstream consumers are expected to deduplicate by index.
       // We represent the index as a string to maintain compatibility with
       // JSON.stringify and to avoid overly inflating the data size (e.g. with
@@ -45,8 +45,8 @@ export async function publishToChainNode(
       const index = forceIndex || String(nextIndex);
       nextIndex += 1n;
       results.push([index, value]);
-      const batch = harden(oldResults.slice().concat(results));
-      E(chainStorageNode).setValue(serialize(batch));
+      const combined = harden(oldResults.slice().concat(results));
+      E(chainStorageNode).setValue(serialize(combined));
     };
   };
   await observeIteration(iterable, {

--- a/packages/vats/src/lib-chainPublish.js
+++ b/packages/vats/src/lib-chainPublish.js
@@ -1,0 +1,46 @@
+// @ts-check
+
+import { E } from '@endo/far';
+
+/**
+ * Publish results of an async iterable into a chain storage node as an array
+ * serialized using JSON.stringify or an optionally provided function (e.g.,
+ * leveraging a serialize function from makeMarshal).
+ *
+ * @param {AsyncIterator} iterable
+ * @param {ReturnType<typeof import('./lib-chainStorage.js').makeChainStorageRoot>} chainStorageNode
+ * @param {{ timerService: ERef<TimerService>, serialize?: (obj: any) => string }} powers
+ */
+export async function publishToChainNode(
+  iterable,
+  chainStorageNode,
+  { timerService, serialize = JSON.stringify },
+) {
+  let nextIndex = 0n;
+  let isNewBlock = true;
+  let oldResults = [];
+  let results = [];
+  for await (const result of iterable) {
+    if (isNewBlock) {
+      isNewBlock = false;
+      oldResults = results;
+      results = [];
+      E(timerService)
+        .delay(1n)
+        .then(() => {
+          isNewBlock = true;
+        });
+    }
+    // To avoid loss when detecting the new block *after* already consuming
+    // results produced within it, we associate each result with an index and
+    // include "old" results in the batch.
+    // Downstream consumers are expected to deduplicate by index.
+    // We represent the index as a string to maintain compatibility with
+    // JSON.stringify and to avoid overly inflating the data size (e.g. with
+    // "@qclass" objects from makeMarshal serialize functions).
+    results.push([String(nextIndex), result]);
+    nextIndex += 1n;
+    const batch = harden(oldResults.slice().concat(results));
+    E(chainStorageNode).setValue(serialize(batch));
+  }
+}

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -13,7 +13,7 @@ const pathSegmentPattern = /^[a-zA-Z0-9_]{1,100}$/;
 /**
  * Create a root storage node for a given backing function and root key.
  *
- * @param {(message: any) => any} toStorage a function for sending a message to the storage implementation
+ * @param {(message: any) => any} toStorage a function for sending a storageMessage object to the storage implementation (cf. golang/cosmos/x/swingset/storage.go)
  * @param {string} rootKey
  */
 export function makeChainStorageRoot(toStorage, rootKey) {
@@ -34,26 +34,22 @@ export function makeChainStorageRoot(toStorage, rootKey) {
       },
       setValue(value) {
         assert.typeof(value, 'string');
-        // TODO: Fix on the chain side.
-        // https://github.com/Agoric/agoric-sdk/issues/5381
-        assert(value !== '');
         toStorage({ key, method: 'set', value });
       },
       async delete() {
         assert(key !== rootKey);
-        // A 'set' with no value deletes a key but leaves any descendants.
-        // We therefore want to disallow that (at least for now).
+        // A 'set' with no value deletes a key if it has no children, but
+        // otherwise sets data to the empty string and leaves all nodes intact.
+        // We want to reject silently incomplete deletes (at least for now).
         // This check is unfortunately racy (e.g., a vat could wake up
         // and set data for a child before _this_ vat receives an
-        // already-enqueued no-children response), but we can tolerate
-        // that once https://github.com/Agoric/agoric-sdk/issues/5381
-        // is fixed because then the 'set' message sent after erroneously
-        // passing the no-children check will be transformed into a
-        // set-to-empty which is at least *visibly* not deleted and
-        // indistinguishable from a valid deep-create scenario (in which
-        // parent keys are created automatically).
-        const childKeys = await toStorage({ key, method: 'keys' });
-        if (childKeys.length > 0) {
+        // already-enqueued response claiming no children), but we can tolerate
+        // that because transforming a deletion into a set-to-empty is
+        // effectively indistinguishable from a valid reordering where a fully
+        // successful 'delete' is followed by a child-key 'set' (for which
+        // absent parent keys are automatically created with empty-string data).
+        const childCount = await toStorage({ key, method: 'size' });
+        if (childCount > 0) {
           assert.fail(X`Refusing to delete node with children: ${key}`);
         }
         toStorage({ key, method: 'set' });

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -8,7 +8,7 @@ const { details: X } = assert;
 // Must be nonempty and disallow (unescaped) `.`, and for simplicity
 // (and future possibility of e.g. escaping) we currently limit to
 // ASCII alphanumeric plus underscore.
-const pathSegmentPattern = /^[a-zA-Z0-9_\-]{1,100}$/;
+const pathSegmentPattern = /^[a-zA-Z0-9_-]{1,100}$/;
 
 /**
  * Create a root storage node for a given backing function and root key.

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -1,0 +1,74 @@
+// @ts-check
+
+import { Far } from '@endo/far';
+
+const { details: X } = assert;
+
+// TODO: Formalize segment constraints.
+// Must be nonempty and disallow (unescaped) `.`, and for simplicity
+// (and future possibility of e.g. escaping) we currently limit to
+// ASCII alphanumeric plus underscore.
+const pathSegmentPattern = /^[a-zA-Z0-9_]{1,100}$/;
+
+/**
+ * Create a root storage node for a given backing function and root key.
+ *
+ * @param {(message: any) => any} toStorage a function for sending a message to the storage implementation
+ * @param {string} rootKey
+ */
+export function makeChainStorageRoot(toStorage, rootKey) {
+  assert.typeof(rootKey, 'string');
+
+  function makeChainStorageNode(key) {
+    const node = {
+      getKey() {
+        return key;
+      },
+      getChildNode(name) {
+        assert.typeof(name, 'string');
+        assert(
+          pathSegmentPattern.test(name),
+          X`Path segment must be a short ASCII identifier: ${name}`,
+        );
+        return makeChainStorageNode(`${key}.${name}`);
+      },
+      setValue(value) {
+        assert.typeof(value, 'string');
+        // TODO: Fix on the chain side.
+        // https://github.com/Agoric/agoric-sdk/issues/5381
+        assert(value !== '');
+        toStorage({ key, method: 'set', value });
+      },
+      async delete() {
+        assert(key !== rootKey);
+        // A 'set' with no value deletes a key but leaves any descendants.
+        // We therefore want to disallow that (at least for now).
+        // This check is unfortunately racy (e.g., a vat could wake up
+        // and set data for a child before _this_ vat receives an
+        // already-enqueued no-children response), but we can tolerate
+        // that once https://github.com/Agoric/agoric-sdk/issues/5381
+        // is fixed because then the 'set' message sent after erroneously
+        // passing the no-children check will be transformed into a
+        // set-to-empty which is at least *visibly* not deleted and
+        // indistinguishable from a valid deep-create scenario (in which
+        // parent keys are created automatically).
+        const childKeys = await toStorage({ key, method: 'keys' });
+        if (childKeys.length > 0) {
+          assert.fail(X`Refusing to delete node with children: ${key}`);
+        }
+        toStorage({ key, method: 'set' });
+      },
+      // Possible extensions:
+      // * getValue()
+      // * getChildNames() and/or getChildNodes()
+      // * getName()
+      // * recursive delete
+      // * batch operations
+      // * local buffering (with end-of-block commit)
+    };
+    return Far('chainStorageNode', node);
+  }
+
+  const rootNode = makeChainStorageNode(rootKey);
+  return rootNode;
+}

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -8,7 +8,7 @@ const { details: X } = assert;
 // Must be nonempty and disallow (unescaped) `.`, and for simplicity
 // (and future possibility of e.g. escaping) we currently limit to
 // ASCII alphanumeric plus underscore.
-const pathSegmentPattern = /^[a-zA-Z0-9_]{1,100}$/;
+const pathSegmentPattern = /^[a-zA-Z0-9_\-]{1,100}$/;
 
 /**
  * Create a root storage node for a given backing function and root key.

--- a/packages/vats/src/vat-chainStorage.js
+++ b/packages/vats/src/vat-chainStorage.js
@@ -1,0 +1,61 @@
+import { E, Far } from '@endo/far';
+
+const { details: X } = assert;
+
+// TODO: Extract into testable library?
+export function buildRootObject(_vatPowers) {
+  function createChainStorageRoot(bridgeManager, bridgeId, rootKey) {
+    const toStorage = message => E(bridgeManager).toBridge(bridgeId, message);
+
+    // TODO: Formalize segment constraints.
+    // Must be nonempty and disallow (unescaped) `.`, and for simplicity
+    // (and future possibility of e.g. escaping) we currently limit to
+    // ASCII alphanumeric plus underscore.
+    const pathSegmentPattern = /^[a-zA-Z0-9_]{1,100}$/;
+    const makeChainStorageNode = key => {
+      const node = {
+        getKey() {
+          return key;
+        },
+        getChildNode(name) {
+          assert.typeof(name, 'string');
+          if (!pathSegmentPattern.test(name)) {
+            assert.fail(
+              X`Path segment must be a short ASCII identifier: ${name}`,
+            );
+          }
+          return makeChainStorageNode(`${key}.${name}`);
+        },
+        setValue(value) {
+          assert.typeof(value, 'string');
+          // TODO: Fix on the Go side.
+          // https://github.com/Agoric/agoric-sdk/issues/5381
+          assert(value !== '');
+          toStorage({ key, method: 'set', value });
+        },
+        async delete() {
+          assert(key !== rootKey);
+          const childKeys = await toStorage({ key, method: 'keys' });
+          if (childKeys.length > 0) {
+            assert.fail(X`Refusing to delete node with children: ${key}`);
+          }
+          toStorage({ key, method: 'set' });
+        },
+        // Possible extensions:
+        // * getValue()
+        // * getChildNames() and/or getChildNodes()
+        // * getName()
+        // * recursive delete
+        // * batch operations
+        // * local buffering (with end-of-block commit)
+      };
+      return Far('chainStorageNode', node);
+    };
+
+    const rootNode = makeChainStorageNode(rootKey);
+    return rootNode;
+  }
+  return Far('root', {
+    createChainStorageRoot,
+  });
+}

--- a/packages/vats/src/vat-chainStorage.js
+++ b/packages/vats/src/vat-chainStorage.js
@@ -19,22 +19,32 @@ export function buildRootObject(_vatPowers) {
         },
         getChildNode(name) {
           assert.typeof(name, 'string');
-          if (!pathSegmentPattern.test(name)) {
-            assert.fail(
-              X`Path segment must be a short ASCII identifier: ${name}`,
-            );
-          }
+          assert(
+            pathSegmentPattern.test(name),
+            X`Path segment must be a short ASCII identifier: ${name}`,
+          );
           return makeChainStorageNode(`${key}.${name}`);
         },
         setValue(value) {
           assert.typeof(value, 'string');
-          // TODO: Fix on the Go side.
+          // TODO: Fix on the chain side.
           // https://github.com/Agoric/agoric-sdk/issues/5381
           assert(value !== '');
           toStorage({ key, method: 'set', value });
         },
         async delete() {
           assert(key !== rootKey);
+          // A 'set' with no value deletes a key but leaves any descendants.
+          // We therefore want to disallow that (at least for now).
+          // This check is unfortunately racy (e.g., a vat could wake up
+          // and set data for a child before _this_ vat receives an
+          // already-enqueued no-children response), but we can tolerate
+          // that once https://github.com/Agoric/agoric-sdk/issues/5381
+          // is fixed because then the 'set' message sent after erroneously
+          // passing the no-children check will be transformed into a
+          // set-to-empty which is at least *visibly* not deleted and
+          // indistinguishable from a valid deep-create scenario (in which
+          // parent keys are created automatically).
           const childKeys = await toStorage({ key, method: 'keys' });
           if (childKeys.length > 0) {
             assert.fail(X`Refusing to delete node with children: ${key}`);

--- a/packages/vats/src/vat-chainStorage.js
+++ b/packages/vats/src/vat-chainStorage.js
@@ -1,71 +1,15 @@
 import { E, Far } from '@endo/far';
+import { makeChainStorageRoot } from './lib-chainStorage.js';
 
-const { details: X } = assert;
-
-// TODO: Extract into testable library?
 export function buildRootObject(_vatPowers) {
-  function createChainStorageRoot(bridgeManager, bridgeId, rootKey) {
+  function makeBridgedChainStorageRoot(bridgeManager, bridgeId, rootKey) {
+    // XXX: Should we validate uniqueness of rootKey, or is that an external concern?
     const toStorage = message => E(bridgeManager).toBridge(bridgeId, message);
-
-    // TODO: Formalize segment constraints.
-    // Must be nonempty and disallow (unescaped) `.`, and for simplicity
-    // (and future possibility of e.g. escaping) we currently limit to
-    // ASCII alphanumeric plus underscore.
-    const pathSegmentPattern = /^[a-zA-Z0-9_]{1,100}$/;
-    const makeChainStorageNode = key => {
-      const node = {
-        getKey() {
-          return key;
-        },
-        getChildNode(name) {
-          assert.typeof(name, 'string');
-          assert(
-            pathSegmentPattern.test(name),
-            X`Path segment must be a short ASCII identifier: ${name}`,
-          );
-          return makeChainStorageNode(`${key}.${name}`);
-        },
-        setValue(value) {
-          assert.typeof(value, 'string');
-          // TODO: Fix on the chain side.
-          // https://github.com/Agoric/agoric-sdk/issues/5381
-          assert(value !== '');
-          toStorage({ key, method: 'set', value });
-        },
-        async delete() {
-          assert(key !== rootKey);
-          // A 'set' with no value deletes a key but leaves any descendants.
-          // We therefore want to disallow that (at least for now).
-          // This check is unfortunately racy (e.g., a vat could wake up
-          // and set data for a child before _this_ vat receives an
-          // already-enqueued no-children response), but we can tolerate
-          // that once https://github.com/Agoric/agoric-sdk/issues/5381
-          // is fixed because then the 'set' message sent after erroneously
-          // passing the no-children check will be transformed into a
-          // set-to-empty which is at least *visibly* not deleted and
-          // indistinguishable from a valid deep-create scenario (in which
-          // parent keys are created automatically).
-          const childKeys = await toStorage({ key, method: 'keys' });
-          if (childKeys.length > 0) {
-            assert.fail(X`Refusing to delete node with children: ${key}`);
-          }
-          toStorage({ key, method: 'set' });
-        },
-        // Possible extensions:
-        // * getValue()
-        // * getChildNames() and/or getChildNodes()
-        // * getName()
-        // * recursive delete
-        // * batch operations
-        // * local buffering (with end-of-block commit)
-      };
-      return Far('chainStorageNode', node);
-    };
-
-    const rootNode = makeChainStorageNode(rootKey);
+    const rootNode = makeChainStorageRoot(toStorage, rootKey);
     return rootNode;
   }
+
   return Far('root', {
-    createChainStorageRoot,
+    makeBridgedChainStorageRoot,
   });
 }

--- a/packages/vats/test/test-lib-chainPublish.js
+++ b/packages/vats/test/test-lib-chainPublish.js
@@ -244,8 +244,9 @@ test('publishToChainNode does not drop values', async t => {
   // negative value.
   let nextValue = 0;
   let step = 1;
+  /** @type TimerService */
   const timerService = {
-    delay() {
+    delay(_n) {
       if (step < 0) return Promise.resolve();
       let slow = Promise.resolve();
       for (let i = 0; i < 10; i += 1) slow = slow.then();
@@ -300,6 +301,7 @@ function getMockInputs(t) {
       advanceTimerR = resolve;
     });
   };
+  /** @type TimerService */
   const timerService = {
     delay(n) {
       t.is(n, 1n);
@@ -308,7 +310,8 @@ function getMockInputs(t) {
   };
 
   // Create an async iterable with a function for supplying results.
-  const pendingResults = [{ resolve(_val) {}, reject(_reason) {} }];
+  /** @type Array<{ promise: Promise<any>, resolve: (val: any) => void, reject: (reason: any) => void }> */
+  const pendingResults = [{ resolve(_val) {} }];
   const supplyIterationResult = value => {
     const nextDeferred = {};
     nextDeferred.promise = new Promise((resolve, reject) => {

--- a/packages/vats/test/test-lib-chainPublish.js
+++ b/packages/vats/test/test-lib-chainPublish.js
@@ -18,9 +18,10 @@ test('publishToChainNode', async t => {
     supplyIterationResult,
   } = inputs;
   publishToChainNode(customAsyncIterable, storageNode, { timerService });
+  await E(Promise).resolve();
 
   supplyIterationResult('foo');
-  await E(Promise).resolve();
+  await E(Promise).resolve().then();
   t.is(nodeValueHistory.length, 1, 'first result is communicated promptly');
   t.deepEqual(
     nodeValueHistory.pop(),
@@ -29,7 +30,7 @@ test('publishToChainNode', async t => {
   );
 
   supplyIterationResult('bar');
-  await E(Promise).resolve();
+  await E(Promise).resolve().then();
   t.is(nodeValueHistory.length, 1, 'second result is communicated promptly');
   t.deepEqual(
     nodeValueHistory.pop(),
@@ -42,7 +43,7 @@ test('publishToChainNode', async t => {
 
   advanceTimer();
   supplyIterationResult('baz');
-  await E(Promise).resolve();
+  await E(Promise).resolve().then();
   t.is(
     nodeValueHistory.length,
     1,
@@ -62,7 +63,7 @@ test('publishToChainNode', async t => {
   advanceTimer();
   advanceTimer();
   supplyIterationResult('qux');
-  await E(Promise).resolve();
+  await E(Promise).resolve().then();
   t.is(
     nodeValueHistory.length,
     1,
@@ -78,7 +79,7 @@ test('publishToChainNode', async t => {
   );
 
   supplyIterationResult('quux');
-  await E(Promise).resolve();
+  await E(Promise).resolve().then();
   t.is(nodeValueHistory.length, 1);
   t.deepEqual(
     nodeValueHistory.pop(),
@@ -94,7 +95,7 @@ test('publishToChainNode', async t => {
   advanceTimer();
   advanceTimer();
   supplyIterationResult('corge');
-  await E(Promise).resolve();
+  await E(Promise).resolve().then();
   t.is(nodeValueHistory.length, 1);
   t.deepEqual(
     nodeValueHistory.pop(),
@@ -105,6 +106,120 @@ test('publishToChainNode', async t => {
     ],
     'the full previous batch is preserved after multiple timer advances',
   );
+});
+
+test('publishToChainNode captures finish value', async t => {
+  // eslint-disable-next-line no-use-before-define
+  const inputs = getMockInputs(t);
+  const {
+    // external facets
+    storageNode,
+    timerService,
+    customAsyncIterable,
+    // internal facets
+    nodeValueHistory,
+    supplyIterationResult,
+  } = inputs;
+  publishToChainNode(customAsyncIterable, storageNode, { timerService });
+  await E(Promise).resolve();
+
+  supplyIterationResult.finish('foo');
+  await E(Promise).resolve().then();
+  t.is(nodeValueHistory.length, 1, 'finish is communicated promptly');
+  t.deepEqual(
+    nodeValueHistory.pop(),
+    [['finish', 'foo']],
+    'result has index "finish"',
+  );
+});
+
+test('publishToChainNode captures fail value', async t => {
+  // eslint-disable-next-line no-use-before-define
+  const inputs = getMockInputs(t);
+  const {
+    // external facets
+    storageNode,
+    timerService,
+    customAsyncIterable,
+    // internal facets
+    nodeValueHistory,
+    supplyIterationResult,
+  } = inputs;
+  publishToChainNode(customAsyncIterable, storageNode, { timerService });
+  await E(Promise).resolve();
+
+  supplyIterationResult.fail('foo');
+  await E(Promise).resolve().then();
+  t.is(nodeValueHistory.length, 1, 'fail is communicated promptly');
+  t.deepEqual(
+    nodeValueHistory.pop(),
+    [['fail', 'foo']],
+    'result has index "fail"',
+  );
+});
+
+test('publishToChainNode custom serialization', async t => {
+  // eslint-disable-next-line no-use-before-define
+  const inputs = getMockInputs(t);
+  const {
+    // external facets
+    storageNode,
+    timerService,
+    customAsyncIterable,
+    // internal facets
+    nodeValueHistory,
+    supplyIterationResult,
+  } = inputs;
+  const serializeInputHistory = [];
+  const serialize = val => {
+    const length = serializeInputHistory.push(val);
+    return String(length);
+  };
+  publishToChainNode(customAsyncIterable, storageNode, {
+    timerService,
+    serialize,
+  });
+  await E(Promise).resolve();
+
+  supplyIterationResult('foo');
+  await E(Promise).resolve().then();
+  t.is(serializeInputHistory.length, 1, 'first result is serialized promptly');
+  t.deepEqual(
+    serializeInputHistory[0],
+    [['0', 'foo']],
+    'first result has index 0',
+  );
+  t.is(nodeValueHistory.length, 1, 'first result is communicated promptly');
+  t.is(nodeValueHistory[0], 1, 'first result is output from serialize()');
+
+  supplyIterationResult('bar');
+  await E(Promise).resolve().then();
+  t.is(serializeInputHistory.length, 2, 'second result is serialized promptly');
+  t.deepEqual(
+    serializeInputHistory[1],
+    [
+      ['0', 'foo'],
+      ['1', 'bar'],
+    ],
+    'second result is appended',
+  );
+  t.is(nodeValueHistory.length, 2, 'second result is communicated promptly');
+  t.is(nodeValueHistory[1], 2, 'second result is output from serialize()');
+
+  supplyIterationResult.finish('baz');
+  await E(Promise).resolve().then();
+  t.is(serializeInputHistory.length, 3, 'finish result is serialized promptly');
+  t.deepEqual(
+    serializeInputHistory[2],
+    [
+      ['0', 'foo'],
+      ['1', 'bar'],
+      ['finish', 'baz'],
+    ],
+    'finish result is appended',
+  );
+  t.is(nodeValueHistory.length, 3, 'finish result is communicated promptly');
+  t.is(nodeValueHistory[2], 3, 'finish result is output from serialize()');
 });
 
 // TODO: Move to a testing library.
@@ -134,24 +249,38 @@ function getMockInputs(t) {
   };
 
   // Create an async iterable with a function for supplying results.
-  let nextResultP;
-  let nextResultR = _result => {};
-  const supplyIterationResult = result => {
-    nextResultR(result);
-    nextResultP = new Promise(resolve => {
-      nextResultR = resolve;
+  const pendingResults = [{ resolve() {} }];
+  const supplyIterationResult = value => {
+    const nextDeferred = {};
+    nextDeferred.promise = new Promise((resolve, reject) => {
+      nextDeferred.resolve = resolve;
+      nextDeferred.reject = reject;
     });
+    const newLength = pendingResults.push(nextDeferred);
+    pendingResults[newLength - 2].resolve({ value });
+  };
+  supplyIterationResult.finish = value => {
+    pendingResults[pendingResults.length - 1].resolve({ value, done: true });
+  };
+  supplyIterationResult.fail = value => {
+    pendingResults[pendingResults.length - 1].reject(value);
   };
   const customAsyncIterable = (async function* makeCustomAsyncIterable() {
     while (true) {
       // eslint-disable-next-line no-await-in-loop
-      yield await nextResultP;
+      const iterationResult = await pendingResults[0].promise;
+      pendingResults.shift();
+      if (iterationResult.done) {
+        return iterationResult.value;
+      }
+      yield iterationResult.value;
     }
   })();
 
   // Initialize.
   advanceTimer();
   supplyIterationResult();
+  pendingResults.shift();
 
   return {
     // external facets

--- a/packages/vats/test/test-lib-chainPublish.js
+++ b/packages/vats/test/test-lib-chainPublish.js
@@ -293,7 +293,7 @@ function getMockInputs(t) {
 
   // Mock a timerService.
   let advanceTimerP;
-  let advanceTimerR = () => {};
+  let advanceTimerR = _val => {};
   const advanceTimer = () => {
     advanceTimerR();
     advanceTimerP = new Promise(resolve => {
@@ -308,7 +308,7 @@ function getMockInputs(t) {
   };
 
   // Create an async iterable with a function for supplying results.
-  const pendingResults = [{ resolve() {} }];
+  const pendingResults = [{ resolve(_val) {}, reject(_reason) {} }];
   const supplyIterationResult = value => {
     const nextDeferred = {};
     nextDeferred.promise = new Promise((resolve, reject) => {

--- a/packages/vats/test/test-lib-chainPublish.js
+++ b/packages/vats/test/test-lib-chainPublish.js
@@ -17,23 +17,25 @@ test('publishToChainNode', async t => {
     advanceTimer,
     supplyIterationResult,
   } = inputs;
-  publishToChainNode(customAsyncIterable, storageNode, { timerService });
+  publishToChainNode(customAsyncIterable, storageNode, { timerService }).catch(
+    err => t.fail(`unexpected error: ${err}`),
+  );
   await E(Promise).resolve();
 
   supplyIterationResult('foo');
   await E(Promise).resolve().then();
-  t.is(nodeValueHistory.length, 1, 'first result is communicated promptly');
+  t.is(nodeValueHistory.length, 1, 'first result is sent promptly');
   t.deepEqual(
-    nodeValueHistory.pop(),
+    JSON.parse(nodeValueHistory[0]),
     [['0', 'foo']],
     'first result has index 0',
   );
 
   supplyIterationResult('bar');
   await E(Promise).resolve().then();
-  t.is(nodeValueHistory.length, 1, 'second result is communicated promptly');
+  t.is(nodeValueHistory.length, 2, 'second result is sent promptly');
   t.deepEqual(
-    nodeValueHistory.pop(),
+    JSON.parse(nodeValueHistory[1]),
     [
       ['0', 'foo'],
       ['1', 'bar'],
@@ -46,11 +48,11 @@ test('publishToChainNode', async t => {
   await E(Promise).resolve().then();
   t.is(
     nodeValueHistory.length,
-    1,
-    'result following timer advance is communicated promptly',
+    3,
+    'result following timer advance is sent promptly',
   );
   t.deepEqual(
-    nodeValueHistory.pop(),
+    JSON.parse(nodeValueHistory[2]),
     [
       ['0', 'foo'],
       ['1', 'bar'],
@@ -66,11 +68,11 @@ test('publishToChainNode', async t => {
   await E(Promise).resolve().then();
   t.is(
     nodeValueHistory.length,
-    1,
-    'results following multiple timer advances are communicated promptly',
+    4,
+    'results following multiple timer advances are sent promptly',
   );
   t.deepEqual(
-    nodeValueHistory.pop(),
+    JSON.parse(nodeValueHistory[3]),
     [
       ['2', 'baz'],
       ['3', 'qux'],
@@ -80,9 +82,9 @@ test('publishToChainNode', async t => {
 
   supplyIterationResult('quux');
   await E(Promise).resolve().then();
-  t.is(nodeValueHistory.length, 1);
+  t.is(nodeValueHistory.length, 5);
   t.deepEqual(
-    nodeValueHistory.pop(),
+    JSON.parse(nodeValueHistory[4]),
     [
       ['2', 'baz'],
       ['3', 'qux'],
@@ -96,9 +98,9 @@ test('publishToChainNode', async t => {
   advanceTimer();
   supplyIterationResult('corge');
   await E(Promise).resolve().then();
-  t.is(nodeValueHistory.length, 1);
+  t.is(nodeValueHistory.length, 6);
   t.deepEqual(
-    nodeValueHistory.pop(),
+    JSON.parse(nodeValueHistory[5]),
     [
       ['3', 'qux'],
       ['4', 'quux'],
@@ -120,14 +122,16 @@ test('publishToChainNode captures finish value', async t => {
     nodeValueHistory,
     supplyIterationResult,
   } = inputs;
-  publishToChainNode(customAsyncIterable, storageNode, { timerService });
+  publishToChainNode(customAsyncIterable, storageNode, { timerService }).catch(
+    err => t.fail(`unexpected error: ${err}`),
+  );
   await E(Promise).resolve();
 
   supplyIterationResult.finish('foo');
   await E(Promise).resolve().then();
-  t.is(nodeValueHistory.length, 1, 'finish is communicated promptly');
+  t.is(nodeValueHistory.length, 1, 'finish is sent promptly');
   t.deepEqual(
-    nodeValueHistory.pop(),
+    JSON.parse(nodeValueHistory[0]),
     [['finish', 'foo']],
     'result has index "finish"',
   );
@@ -145,14 +149,16 @@ test('publishToChainNode captures fail value', async t => {
     nodeValueHistory,
     supplyIterationResult,
   } = inputs;
-  publishToChainNode(customAsyncIterable, storageNode, { timerService });
+  publishToChainNode(customAsyncIterable, storageNode, { timerService }).catch(
+    err => t.fail(`unexpected error: ${err}`),
+  );
   await E(Promise).resolve();
 
   supplyIterationResult.fail('foo');
   await E(Promise).resolve().then();
-  t.is(nodeValueHistory.length, 1, 'fail is communicated promptly');
+  t.is(nodeValueHistory.length, 1, 'fail is sent promptly');
   t.deepEqual(
-    nodeValueHistory.pop(),
+    JSON.parse(nodeValueHistory[0]),
     [['fail', 'foo']],
     'result has index "fail"',
   );
@@ -178,7 +184,7 @@ test('publishToChainNode custom serialization', async t => {
   publishToChainNode(customAsyncIterable, storageNode, {
     timerService,
     serialize,
-  });
+  }).catch(err => t.fail(`unexpected error: ${err}`));
   await E(Promise).resolve();
 
   supplyIterationResult('foo');
@@ -189,8 +195,8 @@ test('publishToChainNode custom serialization', async t => {
     [['0', 'foo']],
     'first result has index 0',
   );
-  t.is(nodeValueHistory.length, 1, 'first result is communicated promptly');
-  t.is(nodeValueHistory[0], 1, 'first result is output from serialize()');
+  t.is(nodeValueHistory.length, 1, 'first result is sent promptly');
+  t.is(nodeValueHistory[0], '1', 'first result is output from serialize()');
 
   supplyIterationResult('bar');
   await E(Promise).resolve().then();
@@ -203,8 +209,8 @@ test('publishToChainNode custom serialization', async t => {
     ],
     'second result is appended',
   );
-  t.is(nodeValueHistory.length, 2, 'second result is communicated promptly');
-  t.is(nodeValueHistory[1], 2, 'second result is output from serialize()');
+  t.is(nodeValueHistory.length, 2, 'second result is sent promptly');
+  t.is(nodeValueHistory[1], '2', 'second result is output from serialize()');
 
   supplyIterationResult.finish('baz');
   await E(Promise).resolve().then();
@@ -218,8 +224,8 @@ test('publishToChainNode custom serialization', async t => {
     ],
     'finish result is appended',
   );
-  t.is(nodeValueHistory.length, 3, 'finish result is communicated promptly');
-  t.is(nodeValueHistory[2], 3, 'finish result is output from serialize()');
+  t.is(nodeValueHistory.length, 3, 'finish result is sent promptly');
+  t.is(nodeValueHistory[2], '3', 'finish result is output from serialize()');
 });
 
 // TODO: Move to a testing library.
@@ -228,7 +234,7 @@ function getMockInputs(t) {
   const nodeValueHistory = [];
   const storageNode = {
     setValue(val) {
-      nodeValueHistory.push(JSON.parse(val));
+      nodeValueHistory.push(val);
     },
   };
 

--- a/packages/vats/test/test-lib-chainPublish.js
+++ b/packages/vats/test/test-lib-chainPublish.js
@@ -1,0 +1,166 @@
+// @ts-check
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { E } from '@endo/far';
+import { publishToChainNode } from '../src/lib-chainPublish.js';
+
+test('publishToChainNode', async t => {
+  // eslint-disable-next-line no-use-before-define
+  const inputs = getMockInputs(t);
+  const {
+    // external facets
+    storageNode,
+    timerService,
+    customAsyncIterable,
+    // internal facets
+    nodeValueHistory,
+    advanceTimer,
+    supplyIterationResult,
+  } = inputs;
+  publishToChainNode(customAsyncIterable, storageNode, { timerService });
+
+  supplyIterationResult('foo');
+  await E(Promise).resolve();
+  t.is(nodeValueHistory.length, 1, 'first result is communicated promptly');
+  t.deepEqual(
+    nodeValueHistory.pop(),
+    [['0', 'foo']],
+    'first result has index 0',
+  );
+
+  supplyIterationResult('bar');
+  await E(Promise).resolve();
+  t.is(nodeValueHistory.length, 1, 'second result is communicated promptly');
+  t.deepEqual(
+    nodeValueHistory.pop(),
+    [
+      ['0', 'foo'],
+      ['1', 'bar'],
+    ],
+    'second result is appended',
+  );
+
+  advanceTimer();
+  supplyIterationResult('baz');
+  await E(Promise).resolve();
+  t.is(
+    nodeValueHistory.length,
+    1,
+    'result following timer advance is communicated promptly',
+  );
+  t.deepEqual(
+    nodeValueHistory.pop(),
+    [
+      ['0', 'foo'],
+      ['1', 'bar'],
+      ['2', 'baz'],
+    ],
+    'last-batch results are preserved after timer advance',
+  );
+
+  advanceTimer();
+  advanceTimer();
+  advanceTimer();
+  supplyIterationResult('qux');
+  await E(Promise).resolve();
+  t.is(
+    nodeValueHistory.length,
+    1,
+    'results following multiple timer advances are communicated promptly',
+  );
+  t.deepEqual(
+    nodeValueHistory.pop(),
+    [
+      ['2', 'baz'],
+      ['3', 'qux'],
+    ],
+    'batches older than the previous are dropped when a new result is supplied',
+  );
+
+  supplyIterationResult('quux');
+  await E(Promise).resolve();
+  t.is(nodeValueHistory.length, 1);
+  t.deepEqual(
+    nodeValueHistory.pop(),
+    [
+      ['2', 'baz'],
+      ['3', 'qux'],
+      ['4', 'quux'],
+    ],
+    'batches older than the previous are dropped when a second new result is supplied',
+  );
+
+  advanceTimer();
+  advanceTimer();
+  advanceTimer();
+  supplyIterationResult('corge');
+  await E(Promise).resolve();
+  t.is(nodeValueHistory.length, 1);
+  t.deepEqual(
+    nodeValueHistory.pop(),
+    [
+      ['3', 'qux'],
+      ['4', 'quux'],
+      ['5', 'corge'],
+    ],
+    'the full previous batch is preserved after multiple timer advances',
+  );
+});
+
+// TODO: Move to a testing library.
+function getMockInputs(t) {
+  // Mock a chainStorage node.
+  const nodeValueHistory = [];
+  const storageNode = {
+    setValue(val) {
+      nodeValueHistory.push(JSON.parse(val));
+    },
+  };
+
+  // Mock a timerService.
+  let advanceTimerP;
+  let advanceTimerR = () => {};
+  const advanceTimer = () => {
+    advanceTimerR();
+    advanceTimerP = new Promise(resolve => {
+      advanceTimerR = resolve;
+    });
+  };
+  const timerService = {
+    delay(n) {
+      t.is(n, 1n);
+      return advanceTimerP;
+    },
+  };
+
+  // Create an async iterable with a function for supplying results.
+  let nextResultP;
+  let nextResultR = _result => {};
+  const supplyIterationResult = result => {
+    nextResultR(result);
+    nextResultP = new Promise(resolve => {
+      nextResultR = resolve;
+    });
+  };
+  const customAsyncIterable = (async function* makeCustomAsyncIterable() {
+    while (true) {
+      // eslint-disable-next-line no-await-in-loop
+      yield await nextResultP;
+    }
+  })();
+
+  // Initialize.
+  advanceTimer();
+  supplyIterationResult();
+
+  return {
+    // external facets
+    storageNode,
+    timerService,
+    customAsyncIterable,
+    // internal facets
+    nodeValueHistory,
+    advanceTimer,
+    supplyIterationResult,
+  };
+}

--- a/packages/vats/test/test-lib-chainStorage.js
+++ b/packages/vats/test/test-lib-chainStorage.js
@@ -76,24 +76,25 @@ test('makeChainStorageRoot', async t => {
   // Valid key segments are strings of up to 100 ASCII alphanumeric/dash/underscore characters.
   const validSegmentChars = `${
     Array(26)
-      .fill()
+      .fill(undefined)
       .map((_, i) => 'a'.charCodeAt(0) + i)
       .map(code => String.fromCharCode(code))
       .join('') +
     Array(26)
-      .fill()
+      .fill(undefined)
       .map((_, i) => 'A'.charCodeAt(0) + i)
       .map(code => String.fromCharCode(code))
       .join('') +
     Array(10)
-      .fill()
+      .fill(undefined)
       .map((_, i) => '0'.charCodeAt(0) + i)
       .map(code => String.fromCharCode(code))
       .join('')
   }-_`;
-  const extremeSegments = validSegmentChars
-    .repeat(Math.ceil(100 / validSegmentChars.length))
-    .match(/.{1,100}/gsu) || [];
+  const extremeSegments =
+    validSegmentChars
+      .repeat(Math.ceil(100 / validSegmentChars.length))
+      .match(/.{1,100}/gsu) || [];
   for (const segment of extremeSegments) {
     const child = rootNode.getChildNode(segment);
     const childKey = `${rootKey}.${segment}`;

--- a/packages/vats/test/test-lib-chainStorage.js
+++ b/packages/vats/test/test-lib-chainStorage.js
@@ -76,7 +76,7 @@ test('makeChainStorageRoot', async t => {
     'second setValue message',
   );
 
-  // Valid key segments are strings of up to 100 ASCII alphanumeric/underscore characters.
+  // Valid key segments are strings of up to 100 ASCII alphanumeric/dash/underscore characters.
   const validSegmentChars = `${
     String.fromCharCode(
       ...Array(26)
@@ -93,7 +93,7 @@ test('makeChainStorageRoot', async t => {
         .fill()
         .map((_, i) => '0'.charCodeAt(0) + i),
     )
-  }_`;
+  }-_`;
   const extremeSegments = validSegmentChars
     .repeat(Math.ceil(100 / validSegmentChars.length))
     .match(/.{1,100}/gsu);

--- a/packages/vats/test/test-lib-chainStorage.js
+++ b/packages/vats/test/test-lib-chainStorage.js
@@ -32,23 +32,20 @@ test('makeChainStorageRoot', async t => {
   t.is(rootNode.getKey(), rootKey, 'root key matches initialization input');
 
   // Values must be strings.
-  const nonStrings = new Map([
-    ['number', 1],
-    ['bigint', 1n],
-    ['boolean', true],
-    ['null', null],
-    ['undefined', undefined],
-    ['symbol', Symbol('foo')],
-    ['array', ['foo']],
-    [
-      'object',
-      {
-        toString() {
-          return 'foo';
-        },
-      },
-    ],
-  ]);
+  /** @type { Map<string, any> } */
+  const nonStrings = new Map();
+  nonStrings.set('number', 1);
+  nonStrings.set('bigint', 1n);
+  nonStrings.set('boolean', true);
+  nonStrings.set('null', null);
+  nonStrings.set('undefined', undefined);
+  nonStrings.set('symbol', Symbol('foo'));
+  nonStrings.set('array', ['foo']);
+  nonStrings.set('object', {
+    toString() {
+      return 'foo';
+    },
+  });
   for (const [label, val] of nonStrings) {
     t.throws(
       () => rootNode.setValue(val),
@@ -78,25 +75,25 @@ test('makeChainStorageRoot', async t => {
 
   // Valid key segments are strings of up to 100 ASCII alphanumeric/dash/underscore characters.
   const validSegmentChars = `${
-    String.fromCharCode(
-      ...Array(26)
-        .fill()
-        .map((_, i) => 'a'.charCodeAt(0) + i),
-    ) +
-    String.fromCharCode(
-      ...Array(26)
-        .fill()
-        .map((_, i) => 'A'.charCodeAt(0) + i),
-    ) +
-    String.fromCharCode(
-      ...Array(10)
-        .fill()
-        .map((_, i) => '0'.charCodeAt(0) + i),
-    )
+    Array(26)
+      .fill()
+      .map((_, i) => 'a'.charCodeAt(0) + i)
+      .map(code => String.fromCharCode(code))
+      .join('') +
+    Array(26)
+      .fill()
+      .map((_, i) => 'A'.charCodeAt(0) + i)
+      .map(code => String.fromCharCode(code))
+      .join('') +
+    Array(10)
+      .fill()
+      .map((_, i) => '0'.charCodeAt(0) + i)
+      .map(code => String.fromCharCode(code))
+      .join('')
   }-_`;
   const extremeSegments = validSegmentChars
     .repeat(Math.ceil(100 / validSegmentChars.length))
-    .match(/.{1,100}/gsu);
+    .match(/.{1,100}/gsu) || [];
   for (const segment of extremeSegments) {
     const child = rootNode.getChildNode(segment);
     const childKey = `${rootKey}.${segment}`;

--- a/packages/vats/test/test-lib-chainStorage.js
+++ b/packages/vats/test/test-lib-chainStorage.js
@@ -1,0 +1,180 @@
+// @ts-check
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { makeChainStorageRoot } from '../src/lib-chainStorage.js';
+
+test('makeChainStorageRoot', async t => {
+  // Instantiate chain storage over a simple in-memory implementation.
+  const data = new Map();
+  const messages = [];
+  // eslint-disable-next-line consistent-return
+  const toStorage = message => {
+    messages.push(message);
+    switch (message.method) {
+      case 'set':
+        if ('value' in message) {
+          data.set(message.key, message.value);
+        } else {
+          data.delete(message.key);
+        }
+        break;
+      case 'size':
+        // Intentionally incorrect because it counts non-child descendants,
+        // but nevertheless supports a "has children" test.
+        return [...data.keys()].filter(k => k.startsWith(`${message.key}.`))
+          .length;
+      default:
+        throw new Error(`unsupported method: ${message.method}`);
+    }
+  };
+  const rootKey = 'root';
+  const rootNode = makeChainStorageRoot(toStorage, rootKey);
+  t.is(rootNode.getKey(), rootKey, 'root key matches initialization input');
+
+  // Values must be strings.
+  const nonStrings = new Map([
+    ['number', 1],
+    ['bigint', 1n],
+    ['boolean', true],
+    ['null', null],
+    ['undefined', undefined],
+    ['symbol', Symbol('foo')],
+    ['array', ['foo']],
+    [
+      'object',
+      {
+        toString() {
+          return 'foo';
+        },
+      },
+    ],
+  ]);
+  for (const [label, val] of nonStrings) {
+    t.throws(
+      () => rootNode.setValue(val),
+      undefined,
+      `${label} value for root node is rejected`,
+    );
+  }
+
+  // The root node cannot be deleted, but is otherwise normal.
+  await t.throwsAsync(
+    rootNode.delete(),
+    undefined,
+    'root node deletion is disallowed',
+  );
+  rootNode.setValue('foo');
+  t.deepEqual(
+    messages.slice(-1),
+    [{ key: rootKey, method: 'set', value: 'foo' }],
+    'root node setValue message',
+  );
+  rootNode.setValue('bar');
+  t.deepEqual(
+    messages.slice(-1),
+    [{ key: rootKey, method: 'set', value: 'bar' }],
+    'second setValue message',
+  );
+
+  // Valid key segments are strings of up to 100 ASCII alphanumeric/underscore characters.
+  const validSegmentChars = `${
+    String.fromCharCode(
+      ...Array(26)
+        .fill()
+        .map((_, i) => 'a'.charCodeAt(0) + i),
+    ) +
+    String.fromCharCode(
+      ...Array(26)
+        .fill()
+        .map((_, i) => 'A'.charCodeAt(0) + i),
+    ) +
+    String.fromCharCode(
+      ...Array(10)
+        .fill()
+        .map((_, i) => '0'.charCodeAt(0) + i),
+    )
+  }_`;
+  const extremeSegments = validSegmentChars
+    .repeat(Math.ceil(100 / validSegmentChars.length))
+    .match(/.{1,100}/gsu);
+  for (const segment of extremeSegments) {
+    const child = rootNode.getChildNode(segment);
+    const childKey = `${rootKey}.${segment}`;
+    t.is(child.getKey(), childKey, 'key segments are dot-separated');
+    child.setValue('foo');
+    t.deepEqual(
+      messages.slice(-1),
+      [{ key: childKey, method: 'set', value: 'foo' }],
+      'non-root setValue message',
+    );
+    // eslint-disable-next-line no-await-in-loop
+    await child.delete();
+    t.deepEqual(
+      messages.slice(-1),
+      [{ key: childKey, method: 'set' }],
+      'non-root delete message',
+    );
+  }
+
+  // Invalid key segments are non-strings, empty, too long, or contain unacceptable characters.
+  const badSegments = new Map(nonStrings);
+  badSegments.set('empty', '');
+  badSegments.set('long', 'x'.repeat(101));
+  for (let i = 0; i < 128; i += 1) {
+    const segment = String.fromCharCode(i);
+    if (!validSegmentChars.includes(segment)) {
+      badSegments.set(
+        `U+${i.toString(16).padStart(4, '0')} ${JSON.stringify(segment)}`,
+        segment,
+      );
+    }
+  }
+  badSegments.set('non-ASCII', '\u00E1');
+  badSegments.set('ASCII with combining diacritical mark', 'a\u0301');
+  for (const [label, val] of badSegments) {
+    t.throws(
+      () => rootNode.getChildNode(val),
+      undefined,
+      `${label} segment is rejected`,
+    );
+  }
+
+  // Level-skipping creation is allowed.
+  const childNode = rootNode.getChildNode('child');
+  const childKey = `${rootKey}.child`;
+  const deepNode = childNode.getChildNode('grandchild');
+  const deepKey = `${childKey}.grandchild`;
+  t.is(deepNode.getKey(), deepKey);
+  for (const [label, val] of nonStrings) {
+    t.throws(
+      () => deepNode.setValue(val),
+      undefined,
+      `${label} value for non-root node is rejected`,
+    );
+  }
+  deepNode.setValue('foo');
+  t.deepEqual(
+    messages.slice(-1),
+    [{ key: deepKey, method: 'set', value: 'foo' }],
+    'level-skipping setValue message',
+  );
+
+  // Deletion requires absence of children.
+  await t.throwsAsync(
+    childNode.delete(),
+    undefined,
+    'deleting a node with a child is disallowed',
+  );
+  await deepNode.delete();
+  t.deepEqual(
+    messages.slice(-1),
+    [{ key: deepKey, method: 'set' }],
+    'granchild delete message',
+  );
+  await childNode.delete();
+  t.deepEqual(
+    messages.slice(-1),
+    [{ key: childKey, method: 'set' }],
+    'child delete message',
+  );
+});


### PR DESCRIPTION
closes: #5353
refs: #5385 ([diff](https://github.com/Agoric/agoric-sdk/compare/gibson-4558-chainStorage...gibson-5353-publish-to-chainStorage))

## Description

Adds a `publishToChainNode` helper for consuming iteration results and losslessly publishing them to chain storage.

### Security Considerations

We should be mindful about publishing too much data, but some redundancy seems necessary to avoid loss.

### Documentation Considerations

Nothing specific.

### Testing Considerations

TypeScript gave me some trouble with mocks. :confused: