### PR TITLE
refactor(vaults): rename VaultTitle to VaultHolder

### DIFF
--- a/packages/run-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/run-protocol/src/vaultFactory/vaultHolder.js
@@ -59,7 +59,7 @@ const title = {
   makeCloseInvitation: ({ facets }) =>
     facets.helper.owned().makeCloseInvitation(),
   /**
-   * Starting a transfer revokes the vaultTitle. The associated updater will
+   * Starting a transfer revokes the vault holder. The associated updater will
    * get a special notification that the vault is being transferred.
    *
    * @param {MethodContext} context
@@ -81,8 +81,8 @@ const title = {
 
 const behavior = { helper, title };
 
-export const makeVaultTitle = defineKindMulti(
-  'VaultTitle',
+export const makeVaultHolder = defineKindMulti(
+  'VaultHolder',
   initState,
   behavior,
 );

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -1,7 +1,7 @@
 // @ts-check
 import '@agoric/zoe/exported.js';
 import { Far } from '@endo/marshal';
-import { makeVaultTitle } from './vaultTitle.js';
+import { makeVaultHolder } from './vaultHolder.js';
 
 /**
  * Create a kit of utilities for use of the vault.
@@ -10,7 +10,7 @@ import { makeVaultTitle } from './vaultTitle.js';
  * @param {Notifier<import('./vaultManager').AssetState>} assetNotifier
  */
 export const makeVaultKit = (vault, assetNotifier) => {
-  const { title, helper } = makeVaultTitle(vault);
+  const { title, helper } = makeVaultHolder(vault);
   const vaultKit = harden({
     publicNotifiers: {
       vault: title.getNotifier(),


### PR DESCRIPTION
_no ticket_, decided in meeting and small enough to PR directly

## Description

A _title_ is metadata about ownership. E.g. a pink slip is something I can give you about ownership of the car, but it's not the car itself. Whereas the object wrapping a vault with ownership _can be used as a vault_. 

This [revokable authority with the caretaker pattern ](https://www.researchgate.net/figure/Revocable-authority-with-the-Caretaker-pattern_fig17_267401630) will come up again and we need a consistent name, but we're deferring that more general decision.

### Security Considerations

Clearer ocaps.

### Documentation Considerations

--

### Testing Considerations

No tests should be affected.