### PR TITLE
feat: allow vats to be marked critical and panic the kernel if a critical vat fails

### DIFF
--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -67,6 +67,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
         'enableSetup',
         'virtualObjectCacheSize',
         'useTranscript',
+        'critical',
         'reapInterval',
       ]);
       creationOptions.description = `static name=${name}`;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-factory.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-factory.js
@@ -58,6 +58,7 @@ export function makeVatManagerFactory({
       'enableSetup',
       'virtualObjectCacheSize',
       'useTranscript',
+      'critical',
       'reapInterval',
       'sourcedConsole',
       'name',

--- a/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
+++ b/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
@@ -94,6 +94,7 @@ export function makeVatLoader(stuff) {
     'enablePipelining',
     'virtualObjectCacheSize',
     'useTranscript',
+    'critical',
     'reapInterval',
   ];
 
@@ -106,6 +107,7 @@ export function makeVatLoader(stuff) {
     'enablePipelining',
     'virtualObjectCacheSize',
     'useTranscript',
+    'critical',
     'reapInterval',
   ];
 
@@ -171,6 +173,7 @@ export function makeVatLoader(stuff) {
    * @param {string} [options.name]
    * @param {string} [options.description]
    * @param {boolean} [options.enableDisavow]
+   * @param {boolean} [options.critical]
    *
    * @param {boolean} isDynamic  If true, the vat being created is a dynamic vat;
    *    if false, it's a static vat (these have differences in their allowed
@@ -215,6 +218,7 @@ export function makeVatLoader(stuff) {
       enablePipelining = false,
       virtualObjectCacheSize,
       useTranscript = true,
+      critical = false,
       name,
     } = options;
 
@@ -239,6 +243,7 @@ export function makeVatLoader(stuff) {
       sourcedConsole: makeSourcedConsole(vatID),
       virtualObjectCacheSize,
       useTranscript,
+      critical,
       name,
       ...overrideVatManagerOptions,
     };

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -34,6 +34,7 @@ export {};
  *   managerType: ManagerType,
  *   gcEveryCrank?: boolean,
  *   metered?: boolean,
+ *   critical?: boolean,
  *   enableDisavow?: boolean,
  *   useTranscript?: boolean,
  *   reapInterval?: number | 'never',
@@ -336,6 +337,7 @@ export {};
  *              virtualObjectCacheSize?: number,
  *              useTranscript?: boolean,
  *              reapInterval? : number | 'never',
+ *              critical?: boolean,
  *            }} DynamicVatOptionsWithoutMeter
  * @typedef { { meter?: Meter } } HasMeter
  * @typedef { DynamicVatOptionsWithoutMeter & HasMeter } DynamicVatOptions

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -121,6 +121,11 @@ export function buildRootObject(vatPowers) {
     });
   }
 
+  const criticalVatKey = Far('criticalVatKey', {});
+  function getCriticalVatKey() {
+    return criticalVatKey;
+  }
+
   function assertType(name, obj, type) {
     if (obj) {
       assert.typeof(obj, type, `CreateVatOptions(${name})`);
@@ -138,6 +143,7 @@ export function buildRootObject(vatPowers) {
       virtualObjectCacheSize,
       useTranscript,
       reapInterval,
+      critical, // converted from cap key to boolean
       ...rest
     } = origOptions;
 
@@ -168,6 +174,12 @@ export function buildRootObject(vatPowers) {
       meterID = meterIDByMeter.get(origOptions.meter);
     }
 
+    let isCriticalVat = false;
+    if (critical) {
+      assert(critical === criticalVatKey, 'invalid criticalVatKey');
+      isCriticalVat = true;
+    }
+
     // TODO: assert vatParameters is Durable
 
     // now glue everything back together
@@ -181,6 +193,7 @@ export function buildRootObject(vatPowers) {
       virtualObjectCacheSize,
       useTranscript,
       reapInterval,
+      critical: isCriticalVat,
     };
     return harden(options);
   }
@@ -325,6 +338,7 @@ export function buildRootObject(vatPowers) {
 
   return Far('root', {
     createVatAdminService,
+    getCriticalVatKey,
     bundleInstalled,
     newVatCallback,
     vatUpgradeCallback,

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-badVatKey.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-badVatKey.js
@@ -1,0 +1,13 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+export function buildRootObject() {
+  return Far('root', {
+    async bootstrap(vats, devices) {
+      const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      await E(vatMaker).createVatByName('dude', {
+        critical: true, // this is bogus and should fail
+      });
+    },
+  });
+}

--- a/packages/SwingSet/test/vat-admin/terminate/swingset-bad-vat-key.json
+++ b/packages/SwingSet/test/vat-admin/terminate/swingset-bad-vat-key.json
@@ -1,0 +1,13 @@
+{
+  "bootstrap": "bootstrap",
+  "bundles": {
+    "dude": {
+      "sourceSpec": "vat-dude-terminate.js"
+    }
+  },
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "bootstrap-badVatKey.js"
+    }
+  }
+}

--- a/packages/SwingSet/test/vat-admin/terminate/swingset-terminate.json
+++ b/packages/SwingSet/test/vat-admin/terminate/swingset-terminate.json
@@ -8,6 +8,15 @@
   "vats": {
     "bootstrap": {
       "sourceSpec": "bootstrap-terminate.js"
+    },
+    "staticNonCritical": {
+      "bundleName": "dude"
+    },
+    "staticCritical": {
+      "bundleName": "dude",
+      "creationOptions": {
+        "critical": true
+      }
     }
   }
 }

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate-critical.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate-critical.js
@@ -1,0 +1,110 @@
+// eslint-disable-next-line import/order
+import { test } from '../../../tools/prepare-test-env-ava.js';
+// eslint-disable-next-line import/order
+import { provideHostStorage } from '../../../src/controller/hostStorage.js';
+
+import {
+  buildVatController,
+  loadSwingsetConfigFile,
+  buildKernelBundles,
+} from '../../../src/index.js';
+
+test.before(async t => {
+  const kernelBundles = await buildKernelBundles();
+  t.context.data = { kernelBundles };
+});
+
+async function doTerminateCritical(t, deadVatID, mode, dynamic) {
+  const configPath = new URL('swingset-terminate.json', import.meta.url)
+    .pathname;
+  const config = await loadSwingsetConfigFile(configPath);
+  const hostStorage = provideHostStorage();
+  const controller = await buildVatController(config, [mode, true, dynamic], {
+    ...t.context.data,
+    hostStorage,
+  });
+  t.is(controller.kpStatus(controller.bootstrapResult), 'unresolved');
+  const preProbe = hostStorage.kvStore.get(`${deadVatID}.options`);
+  if (!dynamic) {
+    t.truthy(preProbe);
+  }
+
+  const err = await t.throwsAsync(() => controller.run());
+  const body = JSON.parse(err.message);
+  if (typeof body === 'string') {
+    t.is(body, mode);
+  } else {
+    t.is(body['@qclass'], 'error');
+    t.is(body.message, mode);
+  }
+  t.is(
+    controller.kpStatus(controller.bootstrapResult),
+    dynamic ? 'unresolved' : 'fulfilled',
+  );
+  const postProbe = hostStorage.kvStore.get(`${deadVatID}.options`);
+  t.is(postProbe, undefined);
+}
+
+test('terminate (dynamic, critical)', async t => {
+  await doTerminateCritical(t, 'v8', 'kill', true);
+});
+
+// no test 'terminate (static, critical)' because static vats can't be killed
+
+test('exit happy path simple result (dynamic, critical)', async t => {
+  await doTerminateCritical(t, 'v8', 'happy', true);
+});
+
+test('exit happy path simple result (static, critical)', async t => {
+  await doTerminateCritical(t, 'v3', 'happy', false);
+});
+
+test('exit happy path complex result (dynamic, critical)', async t => {
+  await doTerminateCritical(t, 'v8', 'exceptionallyHappy', true);
+});
+
+test('exit happy path complex result (static, critical)', async t => {
+  await doTerminateCritical(t, 'v3', 'exceptionallyHappy', false);
+});
+
+test('exit sad path simple result (dynamic, critical)', async t => {
+  await doTerminateCritical(t, 'v8', 'sad', true);
+});
+
+test('exit sad path simple result (static, critical)', async t => {
+  await doTerminateCritical(t, 'v3', 'sad', false);
+});
+
+test('exit sad path complex result (dynamic, critical)', async t => {
+  await doTerminateCritical(t, 'v8', 'exceptionallySad', true);
+});
+
+test('exit sad path complex result (static, critical)', async t => {
+  await doTerminateCritical(t, 'v3', 'exceptionallySad', false);
+});
+
+test('exit happy path with ante-mortem message (dynamic, critical)', async t => {
+  await doTerminateCritical(t, 'v8', 'happyTalkFirst', true);
+});
+
+test('exit happy path with ante-mortem message (static, critical)', async t => {
+  await doTerminateCritical(t, 'v3', 'happyTalkFirst', false);
+});
+
+test('exit sad path with ante-mortem message (dynamic, critical)', async t => {
+  await doTerminateCritical(t, 'v8', 'sadTalkFirst', true);
+});
+
+test('exit sad path with ante-mortem message (static, critical)', async t => {
+  await doTerminateCritical(t, 'v3', 'sadTalkFirst', false);
+});
+
+test('invalid criticalVatKey causes vat creation to fail', async t => {
+  const configPath = new URL('swingset-bad-vat-key.json', import.meta.url)
+    .pathname;
+  const config = await loadSwingsetConfigFile(configPath);
+  const controller = await buildVatController(config, [], t.context.data);
+  await t.throwsAsync(() => controller.run(), {
+    message: /invalid criticalVatKey/,
+  });
+});

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -14,6 +14,7 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
+    "lint": "yarn lint:eslint",
     "lint:eslint": "eslint --ext .js,.ts .",
     "ci:autobench": "./autobench.js"
   },

--- a/packages/swingset-runner/src/vat-launcher.js
+++ b/packages/swingset-runner/src/vat-launcher.js
@@ -27,6 +27,7 @@ export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      const criticalVatKey = await E(vats.vatAdmin).getCriticalVatKey();
       const vatRoots = {};
       for (const vatName of Object.keys(vatParameters.config.vats)) {
         const vatDesc = vatParameters.config.vats[vatName];
@@ -37,11 +38,15 @@ export function buildRootObject(_vatPowers, vatParameters) {
         if (vatParameters.config.bootstrap === vatName) {
           subvatParameters.argv = vatParameters.argv;
         }
+        let critical = vatDesc.critical;
+        if (critical) {
+          critical = criticalVatKey;
+        }
         // prettier-ignore
         // eslint-disable-next-line no-await-in-loop
         const vat = await E(vatMaker).createVatByName(
           bundleName,
-          { vatParameters: harden(subvatParameters) },
+          { vatParameters: harden(subvatParameters), critical },
         );
         vatRoots[vatName] = vat.root;
       }


### PR DESCRIPTION
Vats now accept a `critical` property as one of their creation options.  If a vat is marked as critical, failure of that vat causes a kernel panic.

In order to avoid allowing just anyone to set up a situation that could bring down the kernel and thus the chain, dynamic vats cannot be configured as critical simply by setting the `critical` option to true (as they can with static vats).  Instead, for the `critical` option value you must provide the "critical vat key", a capability that can only be obtained from the vatAdmin vat.  The vatAdmin root now supports an additional method, `getCriticalVatKey()` which returns this capability.  Note that this is only available on the vatAdmin root object, not on any vatAdminService object, and thus is initially only available to the bootstrap vat.

Fixes #4279
