### PR TITLE
fix: record XS snapshots and file sizes to slog and console

### DIFF
--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -590,6 +590,12 @@ export function makeVatKeeper(
       JSON.stringify({ snapshotID, startPos: endPosition }),
     );
     addToSnapshot(snapshotID);
+    kernelSlog.write({
+      type: 'heap-snapshot-save',
+      vatID,
+      snapshotID,
+      endPosition,
+    });
     return true;
   }
 

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -113,6 +113,11 @@ export function makeXsSubprocessFactory({
 
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
     const lastSnapshot = vatKeeper.getLastSnapshot();
+    if (lastSnapshot) {
+      const { snapshotID } = lastSnapshot;
+      kernelSlog.write({ type: 'heap-snapshot-load', vatID, snapshotID });
+    }
+
     // `startXSnap` adds `argName` as a dummy argument so that 'ps'
     // shows which worker is for which vat, but is careful to prevent
     // a shell-escape attack

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -24,6 +24,7 @@ export function makeSnapStoreIO() {
     createWriteStream: fs.createWriteStream,
     open: fs.promises.open,
     rename: fs.promises.rename,
+    stat: fs.promises.stat,
     unlink: fs.promises.unlink,
     unlinkSync: fs.unlinkSync,
     resolve: path.resolve,


### PR DESCRIPTION
This logs some additional information about XS heap snapshots, to help debug #5419 

* when snapshots files are first created, print the filename and size (both raw and compressed) to console.log
* when we record a vat snapshot, write the snapshot name and vatID into the slog trace
* when we create a worker from a snapshot, write the snapshot name and vatID into the slog trace

The console.log line a bit noisy, so we should remove it once we figure out what's going on with #5419 . The slog entries can remain.

cc @arirubinstein 
