### PR TITLE
feat(Reserve):  Reserve can burn RUN to reduce shortfall

### DIFF
--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1811,6 +1811,11 @@ test('mutable liquidity triggers and interest', async t => {
   await manualTimer.tick();
   await waitForPromisesToSettle();
 
+  shortfallBalance += 42n;
+  await m.assertChange({
+    shortfallBalance: { value: shortfallBalance },
+  });
+
   bobUpdate = await E(bobNotifier).getUpdateSince();
   trace(
     t,
@@ -1823,11 +1828,6 @@ test('mutable liquidity triggers and interest', async t => {
   bobUpdate = await E(bobNotifier).getUpdateSince();
   t.is(bobUpdate.value.vaultState, Phase.LIQUIDATED);
   trace(t, 'bob liquidated');
-
-  shortfallBalance += 42n;
-  await m.assertChange({
-    shortfallBalance: { value: shortfallBalance },
-  });
 });
 
 test('bad chargingPeriod', async t => {


### PR DESCRIPTION
closes: #5299

## Description

Add an ability (controlled by governance) to burn RUN from the Reserve to reduce shortfalls from liquidations.

### Security Considerations

Governance & economic

### Documentation Considerations

We haven't started documenting the capabilities accessible to the econ committee.  This is one.

### Testing Considerations

Add tests so show that the shortfall is reduced.