### PR TITLE
fix(amm): update metrics whenever pool balances change, including init

### DIFF
--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -256,7 +256,8 @@ const poolBehavior = {
     return 'Liquidity successfully removed.';
   },
   getNotifier: ({ state: { notifier } }) => notifier,
-  updateState: ({ state: { updater }, facets: { pool } }) => {
+  updateState: ({ state: { updater }, facets: { pool, helper } }) => {
+    helper.updateMetrics();
     return updater.updateState(pool);
   },
   getToCentralPriceAuthority: ({ state }) => state.toCentralPriceAuthority,

--- a/packages/run-protocol/src/vpool-xyk-amm/singlePool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/singlePool.js
@@ -16,7 +16,7 @@ const getPools = pool => ({
 
 export const singlePool = {
   allocateGainsAndLosses: (context, seat, prices) => {
-    const { pool, helper } = context.facets;
+    const { pool } = context.facets;
     const { poolSeat, zcf, protocolSeat } = context.state;
     seat.decrementBy(harden({ In: prices.swapperGives }));
     seat.incrementBy(harden({ Out: prices.swapperGets }));
@@ -34,7 +34,6 @@ export const singlePool = {
     zcf.reallocate(poolSeat, seat, protocolSeat);
     seat.exit();
     pool.updateState();
-    helper.updateMetrics();
     return `Swap successfully completed.`;
   },
 

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
@@ -10,6 +10,7 @@ import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { assertPayoutAmount } from '@agoric/zoe/test/zoeTestHelpers.js';
 import { setupAmmServices } from './setup.js';
 import { unsafeMakeBundleCache } from '../../bundleTool.js';
+import { subscriptionTracker } from '../../metrics.js';
 
 test.before(async t => {
   const bundleCache = await unsafeMakeBundleCache('bundles/');
@@ -188,6 +189,20 @@ test('amm add and remove liquidity', async t => {
     `Added Moola and Central Liquidity`,
   );
 
+  const poolMetrics = await E(amm.ammPublicFacet).getPoolMetrics(moolaR.brand);
+  const tracker = await subscriptionTracker(t, poolMetrics);
+  await tracker.assertInitial({
+    centralAmount: central(0n),
+    liquidityTokens: 0n,
+    secondaryAmount: moola(0n),
+  });
+  const poolLiquidity = {
+    centralAmount: { value: 1500000000n },
+    liquidityTokens: 1500000000n,
+    secondaryAmount: { value: 300000000n },
+  };
+  await tracker.assertChange(poolLiquidity);
+
   const alloc = await E(addLiquiditySeat).getCurrentAllocation();
   t.deepEqual(alloc, {
     Central: central(0n),
@@ -244,6 +259,11 @@ test('amm add and remove liquidity', async t => {
     `poolAllocation after initialization`,
   );
 
+  poolLiquidity.centralAmount.value += 50000n;
+  poolLiquidity.liquidityTokens += 50000n;
+  poolLiquidity.secondaryAmount.value += 10000n;
+  await tracker.assertChange(poolLiquidity);
+
   // Add liquidity. Offer 20_000:70_000. It will be accepted at a ratio of 5:1
   const {
     Central: c2,
@@ -262,6 +282,11 @@ test('amm add and remove liquidity', async t => {
     ),
     `poolAllocation after adding more`,
   );
+
+  poolLiquidity.centralAmount.value += 70000n;
+  poolLiquidity.liquidityTokens += 70000n;
+  poolLiquidity.secondaryAmount.value += 14000n;
+  await tracker.assertChange(poolLiquidity);
 
   const [l40Payment, _l30Payment] = await E(liquidityIssuer).split(
     l2,
@@ -284,4 +309,9 @@ test('amm add and remove liquidity', async t => {
     ),
     `poolAllocation after removing liquidity`,
   );
+
+  poolLiquidity.centralAmount.value -= 40000n;
+  poolLiquidity.liquidityTokens -= 40000n;
+  poolLiquidity.secondaryAmount.value -= 8000n;
+  await tracker.assertChange(poolLiquidity);
 });

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -1065,6 +1065,22 @@ test('amm adding liquidity', async t => {
     `poolAllocation after initialization`,
   );
 
+  const expected0 = {
+    c: 50_000n,
+    s: 10_000n,
+    l: 50_000n,
+    k: 500_000_000n,
+    payoutL: 84_115n,
+    payoutC: 0n,
+    payoutS: 11n,
+  };
+
+  await p.assertState({
+    centralAmount: AmountMath.make(centralR.brand, expected0.c),
+    secondaryAmount: moola(expected0.s),
+    liquidityTokens: expected0.l,
+  });
+
   const poolState1 = {
     c: 50_000n,
     s: 10_000n,
@@ -1089,6 +1105,7 @@ test('amm adding liquidity', async t => {
     centralR,
     liquidityIssuer,
   );
+
   // Add liquidity. Offer 20_000:70_000.
   await addLiquidity(20_000n, 70_000n, poolState1, expected1);
   // After the trade, this will increase the pool by about 150%


### PR DESCRIPTION
closes: #5442

## Description

The AMM wasn't updating the pool balances to the metrics stream when pools were created with an initial balance. This fixes that.

### Security Considerations

None.

### Documentation Considerations

None

### Testing Considerations

Added tests that show the updates at initialization, when trades happen, and when liquidity changes.
