### PR TITLE
refactor: notification of pool balances use amount for liquidity

### DIFF
--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -147,7 +147,10 @@ const helperBehavior = {
     const payload = harden({
       centralAmount: facets.pool.getCentralAmount(),
       secondaryAmount: facets.pool.getSecondaryAmount(),
-      liquidityTokens: state.liqTokenSupply,
+      liquidityTokens: AmountMath.make(
+        state.liquidityBrand,
+        state.liqTokenSupply,
+      ),
     });
 
     state.metricsPublication.updateState(payload);

--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -60,7 +60,7 @@ export const publicPrices = prices => {
  * @typedef {object} PoolMetricsNotification
  * @property {Amount} centralAmount
  * @property {Amount} secondaryAmount
- * @property {NatValue} liquidityTokens - outstanding tokens
+ * @property {Amount} liquidityTokens - outstanding tokens
  */
 
 export const updateUpdaterState = (updater, pool) =>

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
@@ -193,12 +193,13 @@ test('amm add and remove liquidity', async t => {
   const tracker = await subscriptionTracker(t, poolMetrics);
   await tracker.assertInitial({
     centralAmount: central(0n),
-    liquidityTokens: 0n,
+    liquidityTokens: AmountMath.makeEmpty(liquidityBrand),
     secondaryAmount: moola(0n),
   });
+
   const poolLiquidity = {
     centralAmount: { value: 1500000000n },
-    liquidityTokens: 1500000000n,
+    liquidityTokens: { value: 1500000000n },
     secondaryAmount: { value: 300000000n },
   };
   await tracker.assertChange(poolLiquidity);
@@ -260,7 +261,7 @@ test('amm add and remove liquidity', async t => {
   );
 
   poolLiquidity.centralAmount.value += 50000n;
-  poolLiquidity.liquidityTokens += 50000n;
+  poolLiquidity.liquidityTokens.value += 50000n;
   poolLiquidity.secondaryAmount.value += 10000n;
   await tracker.assertChange(poolLiquidity);
 
@@ -284,7 +285,7 @@ test('amm add and remove liquidity', async t => {
   );
 
   poolLiquidity.centralAmount.value += 70000n;
-  poolLiquidity.liquidityTokens += 70000n;
+  poolLiquidity.liquidityTokens.value += 70000n;
   poolLiquidity.secondaryAmount.value += 14000n;
   await tracker.assertChange(poolLiquidity);
 
@@ -311,7 +312,7 @@ test('amm add and remove liquidity', async t => {
   );
 
   poolLiquidity.centralAmount.value -= 40000n;
-  poolLiquidity.liquidityTokens -= 40000n;
+  poolLiquidity.liquidityTokens.value -= 40000n;
   poolLiquidity.secondaryAmount.value -= 8000n;
   await tracker.assertChange(poolLiquidity);
 });

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -1050,7 +1050,7 @@ test('amm adding liquidity', async t => {
   await p.assertInitial({
     centralAmount: AmountMath.makeEmpty(centralR.brand),
     secondaryAmount: moola(0n),
-    liquidityTokens: 0n,
+    liquidityTokens: AmountMath.makeEmpty(liquidityBrand),
   });
 
   const allocation = (c, l, s) => ({
@@ -1078,7 +1078,7 @@ test('amm adding liquidity', async t => {
   await p.assertState({
     centralAmount: AmountMath.make(centralR.brand, expected0.c),
     secondaryAmount: moola(expected0.s),
-    liquidityTokens: expected0.l,
+    liquidityTokens: AmountMath.make(liquidityBrand, expected0.l),
   });
 
   const poolState1 = {
@@ -1113,7 +1113,7 @@ test('amm adding liquidity', async t => {
   await p.assertState({
     centralAmount: AmountMath.make(centralR.brand, expected1.c),
     secondaryAmount: moola(expected1.s),
-    liquidityTokens: expected1.l,
+    liquidityTokens: AmountMath.make(liquidityBrand, expected1.l),
   });
 
   // The pool will have 10K + 20K and 50K + 70K after
@@ -1145,7 +1145,7 @@ test('amm adding liquidity', async t => {
   await p.assertState({
     centralAmount: AmountMath.make(centralR.brand, expected2.c),
     secondaryAmount: moola(expected2.s),
-    liquidityTokens: expected2.l,
+    liquidityTokens: AmountMath.make(liquidityBrand, expected2.l),
   });
 
   // The pool should now have just under 50K + 70K + 60K and 10K + 14K + 12K


### PR DESCRIPTION
refs: #5446

## Description

The Liquidity in the AMM's notifications about pool balances was gratuitously inconsistent in being a bigInt rather than an Amount. This corrects it.

### Security Considerations

None. just improved clarity and consistency.

### Documentation Considerations

None

### Testing Considerations

tests updated.