### PR TITLE
fix(swingset): fsync snapshots 

### DIFF
--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -21,8 +21,7 @@ export function makeSnapStoreIO() {
   return {
     tmpName,
     existsSync: fs.existsSync,
-    createReadStream: fs.createReadStream,
-    createWriteStream: fs.createWriteStream,
+    open: fs.promises.open,
     rename: fs.promises.rename,
     unlink: fs.promises.unlink,
     unlinkSync: fs.unlinkSync,

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -21,6 +21,8 @@ export function makeSnapStoreIO() {
   return {
     tmpName,
     existsSync: fs.existsSync,
+    createReadStream: fs.createReadStream,
+    createWriteStream: fs.createWriteStream,
     open: fs.promises.open,
     rename: fs.promises.rename,
     unlink: fs.promises.unlink,


### PR DESCRIPTION
closes: #5419

## Description

Explicitely open file handles for snapStore files, which allows us to fsync gzipped snapshots before closing and renaming them.

### Motivation

From: https://github.com/Agoric/agoric-sdk/issues/5419#issuecomment-1139867492:
> That said I've parsed through the node.js code and read about Unix fs syscalls, and I now understand that an fclose of a file does not guarantee that the OS will flush the data to the actual device, and Node does not implicitly call fsync anywhere. I'm ready to bet that both LMDB and SQLite both perform an fsync. What probably happen is that the write of the snapshots by the snapStore succeeded from the kernel process point of view, but wasn't synced to disk, unlike the writes for the swingStore and streamStore, which were explicitly synced.

### Security Considerations

This should make our precious data safer.

### Documentation Considerations

None

### Testing Considerations

Besides passing tests to ensure there is no regression, I have no idea how to test this besides trying to reproduce the original issue.
