### PR TITLE
rename Store param 'keyName'  to 'tag'

### DIFF
--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* eslint-disable no-use-before-define */
+/* eslint-disable no-use-before-define, jsdoc/require-returns-type */
 
 import { assert, details as X, q } from '@agoric/assert';
 import { Far } from '@endo/marshal';
@@ -25,7 +25,7 @@ const unweakable = new WeakSet();
  * @param {(baseRef: string, rawState: object) => void} store  Function to
  *   store raw object state by its baseRef
  *
- * @returns {object}  An LRU cache of (up to) the given size
+ * @returns An LRU cache of (up to) the given size
  *
  * This cache is part of the virtual object manager and is not intended to be
  * used independently; it is exported only for the benefit of test code.
@@ -150,7 +150,7 @@ export function makeCache(size, fetch, store) {
  * @param {number} cacheSize  How many virtual objects this manager should cache
  *   in memory.
  *
- * @returns {object} a new virtual object manager.
+ * @returns a new virtual object manager.
  *
  * The virtual object manager allows the creation of persistent objects that do
  * not need to occupy memory when they are not in use.  It provides five
@@ -900,3 +900,6 @@ export function makeVirtualObjectManager(
     testHooks,
   });
 }
+/**
+ * @typedef { ReturnType<typeof makeVirtualObjectManager> } VirtualObjectManager
+ */

--- a/packages/SwingSet/src/liveslots/virtualReferences.js
+++ b/packages/SwingSet/src/liveslots/virtualReferences.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* eslint-disable no-use-before-define */
+/* eslint-disable no-use-before-define, jsdoc/require-returns-type */
 
 import { assert, details as X } from '@agoric/assert';
 import { Nat } from '@agoric/nat';
@@ -274,7 +274,7 @@ export function makeVirtualReferenceManager(
    *
    * @param {string} baseRef  The baseRef of the object being reanimated
    *
-   * @returns {object}  A representative of the object identified by `baseRef`
+   * @returns A representative of the object identified by `baseRef`
    */
   function reanimate(baseRef) {
     const { id } = parseVatSlot(baseRef);

--- a/packages/SwingSet/src/liveslots/watchedPromises.js
+++ b/packages/SwingSet/src/liveslots/watchedPromises.js
@@ -7,6 +7,16 @@ import { assert } from '@agoric/assert';
 import { M } from '@agoric/store';
 import { parseVatSlot } from '../lib/parseVatSlots.js';
 
+/**
+ *
+ * @param {*} syscall
+ * @param {*} vrm
+ * @param {import('./virtualObjectManager.js').VirtualObjectManager} vom
+ * @param {*} cm
+ * @param {*} convertValToSlot
+ * @param {*} convertSlotToVal
+ * @param {*} revivePromise
+ */
 export function makeWatchedPromiseManager(
   syscall,
   vrm,

--- a/packages/store/src/legacy/legacyMap.js
+++ b/packages/store/src/legacy/legacyMap.js
@@ -30,15 +30,15 @@ import { assert, details as X, q } from '@agoric/assert';
  *
  * @deprecated switch to ScalarMap if possible, Map otherwise
  * @template K,V
- * @param {string} [keyName='key'] - the column name for the key
+ * @param {string} [tag='key'] - tag for debugging
  * @returns {LegacyMap<K,V>}
  */
-export const makeLegacyMap = (keyName = 'key') => {
+export const makeLegacyMap = (tag = 'key') => {
   const m = new Map();
   const assertKeyDoesNotExist = key =>
-    assert(!m.has(key), X`${q(keyName)} already registered: ${key}`);
+    assert(!m.has(key), X`${q(tag)} already registered: ${key}`);
   const assertKeyExists = key =>
-    assert(m.has(key), X`${q(keyName)} not found: ${key}`);
+    assert(m.has(key), X`${q(tag)} not found: ${key}`);
   return harden({
     has: key => {
       // Check if a key exists. The key can be any JavaScript value,

--- a/packages/store/src/legacy/legacyWeakMap.js
+++ b/packages/store/src/legacy/legacyWeakMap.js
@@ -8,16 +8,16 @@ import '../types.js';
  *
  * @deprecated switch to ScalarWeakMap if possible, WeakMap otherwise
  * @template K,V
- * @param {string} [keyName='key'] - the column name for the key
+ * @param {string} [tag='key'] - tag for debugging
  * @returns {LegacyWeakMap<K,V>}
  */
-export const makeLegacyWeakMap = (keyName = 'key') => {
+export const makeLegacyWeakMap = (tag = 'key') => {
   /** @type {WeakMap<K & object, V>} */
   const wm = new WeakMap();
   const assertKeyDoesNotExist = key =>
-    assert(!wm.has(key), X`${q(keyName)} already registered: ${key}`);
+    assert(!wm.has(key), X`${q(tag)} already registered: ${key}`);
   const assertKeyExists = key =>
-    assert(wm.has(key), X`${q(keyName)} not found: ${key}`);
+    assert(wm.has(key), X`${q(tag)} not found: ${key}`);
   return harden({
     has: key => {
       // Check if a key exists. The key can be any JavaScript value,

--- a/packages/store/src/stores/scalarMapStore.js
+++ b/packages/store/src/stores/scalarMapStore.js
@@ -20,7 +20,7 @@ const { quote: q } = assert;
  * @param {(k: K, v: V) => void} assertKVOkToAdd
  * @param {(k: K, v: V) => void} assertKVOkToSet
  * @param {((k: K) => void)=} assertKeyOkToDelete
- * @param {string=} keyName
+ * @param {string=} tag
  * @returns {MapStore<K,V>}
  */
 export const makeMapStoreMethods = (
@@ -28,7 +28,7 @@ export const makeMapStoreMethods = (
   assertKVOkToAdd,
   assertKVOkToSet,
   assertKeyOkToDelete = undefined,
-  keyName = 'key',
+  tag = 'key',
 ) => {
   const { assertUpdateOnAdd, assertUpdateOnDelete, iterableKeys } =
     makeCurrentKeysKit(
@@ -37,7 +37,7 @@ export const makeMapStoreMethods = (
       compareRank,
       assertKVOkToAdd,
       assertKeyOkToDelete,
-      keyName,
+      tag,
     );
 
   /**
@@ -87,7 +87,7 @@ export const makeMapStoreMethods = (
       /** @type {(k: K, v: V) => void} */ (assertUpdateOnAdd),
       assertKVOkToSet,
       assertUpdateOnDelete,
-      keyName,
+      tag,
     ),
     keys,
     values,
@@ -124,12 +124,12 @@ export const makeMapStoreMethods = (
  * copyRecords, as keys and look them up based on equality of their contents.
  *
  * @template K,V
- * @param {string} [keyName='key'] - the column name for the key
+ * @param {string} [tag='key'] - the column name for the key
  * @param {StoreOptions=} options
  * @returns {MapStore<K,V>}
  */
 export const makeScalarMapStore = (
-  keyName = 'key',
+  tag = 'key',
   { keySchema = undefined, valueSchema = undefined } = {},
 ) => {
   const jsmap = new Map();
@@ -163,13 +163,13 @@ export const makeScalarMapStore = (
     assertKVOkToSet(key, value);
   };
 
-  return Far(`scalar MapStore of ${q(keyName)}`, {
+  return Far(`scalar MapStore of ${q(tag)}`, {
     ...makeMapStoreMethods(
       jsmap,
       assertKVOkToAdd,
       assertKVOkToSet,
       undefined,
-      keyName,
+      tag,
     ),
   });
 };

--- a/packages/store/src/stores/scalarSetStore.js
+++ b/packages/store/src/stores/scalarSetStore.js
@@ -82,12 +82,12 @@ export const makeSetStoreMethods = (
  * copyRecords, as keys and look them up based on equality of their contents.
  *
  * @template K
- * @param {string} [keyName='key'] - the column name for the key
+ * @param {string} [tag='key'] - tag for debugging
  * @param {StoreOptions=} options
  * @returns {SetStore<K>}
  */
 export const makeScalarSetStore = (
-  keyName = 'key',
+  tag = 'key',
   { keySchema = undefined } = {},
 ) => {
   const jsset = new Set();
@@ -106,8 +106,8 @@ export const makeScalarSetStore = (
     }
   };
 
-  return Far(`scalar SetStore of ${q(keyName)}`, {
-    ...makeSetStoreMethods(jsset, assertKeyOkToAdd, undefined, keyName),
+  return Far(`scalar SetStore of ${q(tag)}`, {
+    ...makeSetStoreMethods(jsset, assertKeyOkToAdd, undefined, tag),
   });
 };
 harden(makeScalarSetStore);

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -82,12 +82,12 @@ export const makeWeakMapStoreMethods = (
  * remotables, since the other primitives may always reappear.
  *
  * @template K,V
- * @param {string} [keyName='key'] - the column name for the key
+ * @param {string} [tag='key'] - tag for debugging
  * @param {StoreOptions=} options
  * @returns {WeakMapStore<K,V>}
  */
 export const makeScalarWeakMapStore = (
-  keyName = 'key',
+  tag = 'key',
   { longLived = true, keySchema = undefined, valueSchema = undefined } = {},
 ) => {
   const jsmap = new (longLived ? WeakMap : Map)();
@@ -124,13 +124,13 @@ export const makeScalarWeakMapStore = (
     assertKVOkToSet(key, value);
   };
 
-  return Far(`scalar WeakMapStore of ${q(keyName)}`, {
+  return Far(`scalar WeakMapStore of ${q(tag)}`, {
     ...makeWeakMapStoreMethods(
       jsmap,
       assertKVOkToAdd,
       assertKVOkToSet,
       undefined,
-      keyName,
+      tag,
     ),
   });
 };

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -64,12 +64,12 @@ export const makeWeakSetStoreMethods = (
  * remotables, since the other primitives may always appear.
  *
  * @template K
- * @param {string} [keyName='key'] - the column name for the key
+ * @param {string} [tag='key'] - tag for debugging
  * @param {StoreOptions=} options
  * @returns {WeakSetStore<K>}
  */
 export const makeScalarWeakSetStore = (
-  keyName = 'key',
+  tag = 'key',
   { longLived = true, keySchema = undefined } = {},
 ) => {
   const jsset = new (longLived ? WeakSet : Set)();
@@ -91,8 +91,8 @@ export const makeScalarWeakSetStore = (
     }
   };
 
-  return Far(`scalar WeakSetStore of ${q(keyName)}`, {
-    ...makeWeakSetStoreMethods(jsset, assertKeyOkToAdd, undefined, keyName),
+  return Far(`scalar WeakSetStore of ${q(tag)}`, {
+    ...makeWeakSetStoreMethods(jsset, assertKeyOkToAdd, undefined, tag),
   });
 };
 harden(makeScalarWeakSetStore);

--- a/packages/swing-store/src/ephemeralSwingStore.js
+++ b/packages/swing-store/src/ephemeralSwingStore.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint-disable jsdoc/require-returns-type */
 import { assert, details as X, q } from '@agoric/assert';
 
 /**
@@ -197,7 +198,7 @@ export function initEphemeralSwingStore() {
    * @param {string} item  The item to write
    * @param {object} position  The position to write the item
    *
-   * @returns {object} the new position after writing
+   * @returns the new position after writing
    */
   function writeStreamItem(streamName, item, position) {
     insistStreamName(streamName);


### PR DESCRIPTION
## Description

makeStore() [docs](https://github.com/Agoric/agoric-sdk/blob/358c8b7bef2c9a659344d72fd52aa80f14a93b68/packages/store/src/stores/scalarMapStore.js#L127) seems to be outdated. Per @FUDCo , "It’s just an arbitrary tag string for documentary and debugging purposes."

This also has some typedef annotation for VirtualObjectManager that I used while investigating code for the primary change. It's in a separate commit so it will appear separately in master history.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

Shouldn't affect any tests.