### PR TITLE
fix(amm): Prevent calls to remove Liquidity when the pool is empty

### DIFF
--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -218,6 +218,12 @@ const poolBehavior = {
       'Liquidity',
       liquidityBrand,
     );
+    if (AmountMath.isEmpty(liquidityIn)) {
+      // prevent divide-by-zero. If the caller has tokens, the pool is not empty
+      userSeat.exit();
+      return 'request to remove zero liquidity';
+    }
+
     const liquidityValueIn = liquidityIn.value;
     assert(isNatValue(liquidityValueIn), 'User Liquidity');
     const centralTokenAmountOut = AmountMath.make(

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -1,10 +1,10 @@
 // @ts-check
 
-import { assert, details as X } from '@agoric/assert';
 import { Nat } from '@agoric/nat';
 import { natSafeMath } from './safeMath.js';
 
 const { subtract, add, multiply, floorDivide } = natSafeMath;
+const { details: X } = assert;
 
 const BASIS_POINTS = 10000n; // TODO change to 10_000n once tooling copes.
 
@@ -103,12 +103,12 @@ export const getOutputPrice = (
   return add(floorDivide(numerator, denominator), 1n);
 };
 
-// Calculate how many liquidity tokens we should be minting to send back to the
-// user when adding liquidity. We provide new liquidity equal to the existing
-// liquidity multiplied by the ratio of new central tokens to central tokens
-// already held. If the current supply is zero, return the inputValue as the
-// initial liquidity to mint is arbitrary.
 /**
+ * Calculate how many liquidity tokens we should be minting to send back to the
+ * user when adding liquidity. We provide new liquidity equal to the existing
+ * liquidity multiplied by the ratio of new central tokens to central tokens
+ * already held. If the current supply is zero, return the inputValue as the
+ * initial liquidity to mint is arbitrary.
  *
  * @param {bigint} liqTokenSupply
  * @param {bigint} inputValue

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -183,7 +183,9 @@ const start = async zcf => {
   const addLiquidity = (seat, secondaryAmount) => {
     const userAllocation = seat.getCurrentAllocation();
     const centralPool = getPoolAmount(brands.Central).value;
+    assert(!AmountMath.isEmpty(userAllocation.Central), 'Pool is empty');
     const centralIn = userAllocation.Central.value;
+
     const liquidityValueOut = calcLiqValueToMint(
       liqTokenSupply,
       centralIn,
@@ -273,9 +275,12 @@ const start = async zcf => {
       want: { Central: null, Secondary: null },
       give: { Liquidity: null },
     });
+
     // TODO (hibbert) should we burn tokens?
     const userAllocation = removeLiqSeat.getCurrentAllocation();
-    const liquidityValueIn = userAllocation.Liquidity.value;
+    const liquidityIn = userAllocation.Liquidity;
+    assert(!AmountMath.isEmpty(liquidityIn), 'Pool is empty');
+    const liquidityValueIn = liquidityIn.value;
     assert(isNatValue(liquidityValueIn));
 
     const newUserCentralAmount = AmountMath.make(


### PR DESCRIPTION
fixes: #5131

## Description

Prevent calls to remove Liquidity when the pool is empty

Preventing calls to remove liquidity that don't include any liquidity tokens is sufficient to head off the divide-by-zero. If there are liquidity tokens outstanding, then the pool won't be empty, and the divide-by-zero is impossible.

The corresponding issue doesn't arise when adding liquidity, because the AMM code explicitly checks for an empty pool and uses the central token amount to decide how much liquidity to create. All trading goes through methods that ensure that the pools are non-empty and requested amounts are positive.


### Security Considerations

Just prevents a divide-by-zero. No downstream consequences.

### Documentation Considerations

Not an issue

### Testing Considerations

added a test.
