### PR TITLE
lint ts-ignore

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -44,6 +44,7 @@ module.exports = {
     'coverage/**',
     '**/output/**',
     'bundles/**',
+    'bundle-*',
     'dist/**',
     'examples/**',
     'test262/**',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,6 +48,16 @@ module.exports = {
     'dist/**',
     'examples/**',
     'test262/**',
+    '*.html',
     'ava*.config.js',
+  ],
+  overrides: [
+    {
+      // disable type-aware linting in HTML
+      files: ['*.html'],
+      parserOptions: {
+        project: false,
+      },
+    },
   ],
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,52 @@
+/* eslint-env node */
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: [
+    '@jessie.js/eslint-plugin',
+    '@typescript-eslint',
+    'eslint-plugin-import',
+    'eslint-plugin-prettier',
+  ],
+  extends: ['@agoric'],
+  rules: {
+    '@typescript-eslint/prefer-ts-expect-error': 'warn',
+    'jsdoc/no-multi-asterisks': 'off',
+    'jsdoc/multiline-blocks': 'off',
+    // Use these rules to warn about JSDoc type problems, such as after
+    // upgrading eslint-plugin-jsdoc.
+    // Bump the 1's to 2's to get errors.
+    // "jsdoc/valid-types": 1,
+    // "jsdoc/no-undefined-types": [1, {"definedTypes": ["never", "unknown"]}],
+    'jsdoc/tag-lines': 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: [
+          '**/*.config.js',
+          '**/*.config.*.js',
+          '**/*test*/**/*.js',
+          '**/demo*/**/*.js',
+          '**/scripts/**/*.js',
+        ],
+      },
+    ],
+    // CI has a separate format check but keep this warn to maintain that "eslint --fix" prettifies
+    // UNTIL https://github.com/Agoric/agoric-sdk/issues/4339
+    'prettier/prettier': 'warn',
+  },
+  settings: {
+    jsdoc: {
+      mode: 'typescript',
+    },
+  },
+  ignorePatterns: [
+    'coverage/**',
+    '**/output/**',
+    'bundles/**',
+    'dist/**',
+    'examples/**',
+    'test262/**',
+    'ava*.config.js',
+  ],
+};

--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -29,11 +29,6 @@
     "url": "https://github.com/Agoric/agoric-sdk/issues"
   },
   "homepage": "https://github.com/Agoric/agoric-sdk/tree/HEAD/golang/cosmos",
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "files": [
     "Makefile*",
     "app",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,16 @@
     "ava": "^3.15.0",
     "c8": "^7.11.0",
     "conventional-changelog-conventionalcommits": "^4.6.0",
-    "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.0",
+    "eslint-config-jessie": "^0.0.6",
+    "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.25.3",
-    "eslint-plugin-jsx-a11y": "^6.4.0",
+    "eslint-plugin-jsdoc": "^39.2.9",
+    "eslint-plugin-jsx-a11y": "^6.5.1",
+    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-react": "^7.28.0",
+    "eslint": "^7.32.0",
     "lerna": "^3.22.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",
@@ -28,9 +34,6 @@
   },
   "engines": {
     "node": ">=14.15.0"
-  },
-  "eslintConfig": {
-    "root": true
   },
   "prettier": {
     "arrowParens": "avoid",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@endo/eslint-config": "^0.4.10",
     "@jessie.js/eslint-plugin": "^0.1.3",
     "@types/node": "^16.7.10",
-    "@typescript-eslint/parser": "^5.15.0",
+    "@typescript-eslint/parser": "^5.27.0",
     "ava": "^3.15.0",
     "c8": "^7.11.0",
     "conventional-changelog-conventionalcommits": "^4.6.0",

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -15,7 +15,7 @@
     "test:xs-worker": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 'test/swingsetTests/**/test-*.js'",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json"
   },
   "repository": {

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -65,11 +65,6 @@
     ],
     "timeout": "2m"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -18,7 +18,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "yarn lint:types&&yarn lint:eslint",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "devDependencies": {
     "@agoric/vat-data": "^0.3.1",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -71,11 +71,6 @@
   "directories": {
     "example": "examples"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "ava": {
     "files": [
       "test/**/test-*.js"

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -1,5 +1,5 @@
 /* global setTimeout */
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 import { spawn } from 'child_process';

--- a/packages/SwingSet/test/vat-warehouse/test-warehouse.js
+++ b/packages/SwingSet/test/vat-warehouse/test-warehouse.js
@@ -10,6 +10,7 @@ import { makeLRU } from '../../src/kernel/vat-warehouse.js';
 
 async function makeController(managerType, runtimeOptions) {
   const config = await loadBasedir(new URL('./', import.meta.url).pathname);
+  assert(config.vats);
   config.vats.target.creationOptions = { managerType, enableDisavow: true };
   config.vats.target2 = config.vats.target;
   config.vats.target3 = config.vats.target;

--- a/packages/access-token/jsconfig.json
+++ b/packages/access-token/jsconfig.json
@@ -11,16 +11,13 @@
     "declaration": true,
     "emitDeclarationOnly": true,
 */
+    "downlevelIteration": true,
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
   "include": [
     "exported.js",
-    "demo/**/*.js", 
-    "lib/**/*.js", 
-    "src/**/*.js", 
-    "misc-tools/**/*.js", 
-    "test/**/*.js", 
-    "tools/**/*.js", 
-  ],
+    "src/**/*.js",
+    "test/**/*.js"
+  ]
 }

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -13,7 +13,7 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "dependencies": {
     "@agoric/assert": "^0.4.0",

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -31,10 +31,5 @@
       "test/**/test-*.js"
     ],
     "timeout": "2m"
-  },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
   }
 }

--- a/packages/agoric-cli/jsconfig.json
+++ b/packages/agoric-cli/jsconfig.json
@@ -15,5 +15,12 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js", "test/**/*.js"],
+  "include": [
+    "*.js",
+    "integration-tests/**/*.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+    "tools/**/*.js",
+  ],
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -57,11 +57,6 @@
     "url": "https://github.com/Agoric/agoric/agoric-sdk"
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "ava": {
     "files": [
       "test/**/test-*.js"

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -18,7 +18,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "devDependencies": {
     "@agoric/swingset-vat": "^0.28.0",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -14,7 +14,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -44,11 +44,6 @@
       "test/**/test-*.js"
     ]
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/cosmic-swingset/jsconfig.json
+++ b/packages/cosmic-swingset/jsconfig.json
@@ -15,5 +15,10 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js"],
+  "include": [
+    "calc-*.js",
+    "exported.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
 }

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -48,11 +48,6 @@
     "ava": "^3.12.1",
     "c8": "^7.7.2"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "keywords": [],
   "author": "Agoric",

--- a/packages/deploy-script-support/jsconfig.json
+++ b/packages/deploy-script-support/jsconfig.json
@@ -15,5 +15,9 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js", "globals.d.ts"],
+  "include": [
+    "*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
 }

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -12,7 +12,7 @@
     "test": "ava",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "lint:types": "tsc --maxNodeModuleJsDepth 5 -p jsconfig.json",
     "lint": "run-s --continue-on-error lint:*"
   },

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -64,11 +64,6 @@
       "test/**/test-*.js"
     ]
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/deploy-script-support/src/externalTypes.js
+++ b/packages/deploy-script-support/src/externalTypes.js
@@ -48,7 +48,7 @@
  * @param {ERef<Issuer>} issuer
  * @param {Petname} brandPetname
  * @param {Petname} pursePetname
- * @returns {Promise<Array<Promise>}
+ * @returns {Promise<Petname>}
  */
 
 /**

--- a/packages/deploy-script-support/src/startInstance.js
+++ b/packages/deploy-script-support/src/startInstance.js
@@ -55,7 +55,7 @@ export const makeStartInstance = (
    * @template {Installation} I
    * @param {{
    * instancePetname: Petname,
-   * installation: I,
+   * installation: I | PromiseLike<I>,
    * issuerKeywordRecord?: IssuerKeywordRecord,
    * issuerPetnameKeywordRecord?: Record<Keyword,Petname>,
    * terms?: object,

--- a/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
+++ b/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
@@ -1,10 +1,12 @@
 // @ts-check
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { assertOfferResult } from '../../src/assertOfferResult.js';
 
 test('assertOfferResult', async t => {
+  /** @type {UserSeat} */
   const mockSeat = {
+    // @ts-expect-error mock
     getOfferResult: () => 'result',
   };
   await t.notThrowsAsync(() => assertOfferResult(mockSeat, 'result'));

--- a/packages/deploy-script-support/test/unitTests/test-coreProposalBehavior.js
+++ b/packages/deploy-script-support/test/unitTests/test-coreProposalBehavior.js
@@ -1,6 +1,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { E } from '@endo/far';
+import '@agoric/vats/src/core/types.js';
 import { runModuleBehaviors } from '@agoric/vats/src/core/utils.js';
 import { makeCoreProposalBehavior } from '../../src/coreProposalBehavior.js';
 

--- a/packages/deploy-script-support/test/unitTests/test-findInvitationAmount.js
+++ b/packages/deploy-script-support/test/unitTests/test-findInvitationAmount.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
@@ -25,7 +25,6 @@ test('findInvitationAmount', async t => {
     walletAdmin,
     zoe,
     zoeInvitationPurse,
-    brand,
   );
 
   const notFoundResult = await findInvitationAmount({

--- a/packages/deployment/jsconfig.json
+++ b/packages/deployment/jsconfig.json
@@ -11,16 +11,13 @@
     "declaration": true,
     "emitDeclarationOnly": true,
 */
+    "downlevelIteration": true,
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
   "include": [
     "exported.js",
-    "demo/**/*.js", 
-    "lib/**/*.js", 
-    "src/**/*.js", 
-    "misc-tools/**/*.js", 
-    "test/**/*.js", 
-    "tools/**/*.js", 
-  ],
+    "src/**/*.js",
+    "test/**/*.js"
+  ]
 }

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -32,11 +32,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "devDependencies": {
     "readline-transform": "^1.0.0"
   }

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -13,7 +13,7 @@
     "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -2,44 +2,5 @@
   "extends": [
     "@endo",
     "plugin:@jessie.js/recommended"
-  ],
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
-  "rules": {
-    "@typescript-eslint/prefer-ts-expect-error": "warn",
-    "jsdoc/no-multi-asterisks": "off",
-    "jsdoc/multiline-blocks": "off",
-    // Use these rules to warn about JSDoc type problems, such as after
-    // upgrading eslint-plugin-jsdoc.
-    // Bump the 1's to 2's to get errors.
-    // "jsdoc/valid-types": 1,
-    // "jsdoc/no-undefined-types": [1, {"definedTypes": ["never", "unknown"]}],
-    "jsdoc/tag-lines": "off",
-    "import/no-extraneous-dependencies": [
-      "error",
-      {
-        "devDependencies": [
-          "**/*.config.js",
-          "**/*.config.*.js",
-          "**/*test*/**/*.js",
-          "**/demo*/**/*.js",
-          "**/scripts/**/*.js"
-        ]
-      }
-    ],
-    "prettier/prettier": "warn" // @jessie.js/recommended errors. This repo checks format separately but keeps warn to maintain that "eslint --fix" prettifies
-  },
-  "settings": {
-    "jsdoc": {
-      "mode": "typescript"
-    }
-  },
-  "ignorePatterns": [
-    "coverage/**",
-    "**/output/**",
-    "bundles/**",
-    "dist/**",
-    "test262/**",
-    "ava*.config.js"
   ]
 }

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -3,7 +3,10 @@
     "@endo",
     "plugin:@jessie.js/recommended"
   ],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
   "rules": {
+    "@typescript-eslint/prefer-ts-expect-error": "warn",
     "jsdoc/no-multi-asterisks": "off",
     "jsdoc/multiline-blocks": "off",
     // Use these rules to warn about JSDoc type problems, such as after

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,7 +24,7 @@
   "files": [
     "eslint-config.json"
   ],
-  "devDependencies": {
+  "peerDependencies": {
     "@endo/eslint-config": "^0.4.10",
     "@jessie.js/eslint-plugin": "^0.1.3",
     "@typescript-eslint/parser": "^5.27.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@endo/eslint-config": "^0.4.10",
     "@jessie.js/eslint-plugin": "^0.1.3",
-    "@typescript-eslint/parser": "^5.15.0",
+    "@typescript-eslint/parser": "^5.27.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-jessie": "^0.0.6",

--- a/packages/governance/jsconfig.json
+++ b/packages/governance/jsconfig.json
@@ -15,5 +15,10 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "test/**/*.js"],
+  "include": [
+    "build/**/*.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
 }

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -15,7 +15,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json"
   },
   "repository": {

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -63,11 +63,6 @@
     ],
     "timeout": "10m"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -63,6 +63,11 @@
     ],
     "timeout": "10m"
   },
+  "eslintConfig": {
+    "extends": [
+      "@agoric"
+    ]
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -41,7 +41,6 @@ const QuorumRule = /** @type {const} */ ({
   ALL: 'all',
 });
 
-// eslint-disable-next-line jsdoc/require-returns-check
 /**
  * @param {unknown} issue
  * @returns { asserts issue is SimpleIssue }
@@ -54,7 +53,6 @@ const assertSimpleIssue = issue => {
   );
 };
 
-// eslint-disable-next-line jsdoc/require-returns-check
 /**
  * @param {unknown} issue
  * @returns { asserts issue is ParamChangeIssue<unknown> }
@@ -75,7 +73,6 @@ const assertParamChangeIssue = issue => {
   assertInstance(issue.contract);
 };
 
-// eslint-disable-next-line jsdoc/require-returns-check
 /**
  * @param {unknown} issue
  * @returns {asserts issue is ApiInvocationIssue}
@@ -88,7 +85,6 @@ const assertApiInvocation = issue => {
   );
 };
 
-// eslint-disable-next-line jsdoc/require-returns-check
 /**
  * @param {ElectionType} electionType
  * @param {unknown} issue

--- a/packages/import-manager/jsconfig.json
+++ b/packages/import-manager/jsconfig.json
@@ -1,0 +1,25 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+    "compilerOptions": {
+      "target": "esnext",
+      "module": "esnext",
+  
+      "noEmit": true,
+  /*
+      // The following flags are for creating .d.ts files:
+      "noEmit": false,
+      "declaration": true,
+      "emitDeclarationOnly": true,
+  */
+      "downlevelIteration": true,
+      "strictNullChecks": true,
+      "moduleResolution": "node",
+    },
+    "include": [
+      "*.js",
+      "scripts/**/*.js",
+      "src/**/*.js",
+      "test/**/*.js",
+    ],
+  }
+  

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -13,7 +13,7 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -42,11 +42,6 @@
       "test/**/test-*.js"
     ]
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/notifier/jsconfig.json
+++ b/packages/notifier/jsconfig.json
@@ -15,5 +15,10 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js"],
+  "include": [
+    "exports.js",
+    "exported.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
 }

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -14,7 +14,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json"
   },
   "repository": {

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -47,11 +47,6 @@
     "exported.js",
     "NEWS.md"
   ],
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -106,7 +106,6 @@
 
 // /////////////////////////////////////////////////////////////////////////////
 
-// eslint-disable-next-line jsdoc/require-property
 /**
  * @template T
  * @typedef {{}} BaseSubscription<T>

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -273,7 +273,6 @@ export const bob = async asyncIterableP => {
  * @returns {Promise<Passable[]>}
  */
 export const carol = async subscriptionP => {
-  // @ts-expect-error
   const subscriptionIteratorP = E(subscriptionP)[Symbol.asyncIterator]();
   const { promise: afterA, resolve: afterAResolve } = makePromiseKit();
 
@@ -281,6 +280,7 @@ export const carol = async subscriptionP => {
     harden({
       updateState: val => {
         if (val === 'a') {
+          // @ts-expect-error
           afterAResolve(E(subscriptionIteratorP).subscribe());
         }
         log.push(['non-final', val]);

--- a/packages/notifier/test/map-unum.js
+++ b/packages/notifier/test/map-unum.js
@@ -7,7 +7,6 @@
 // If this experiment works out, it or something like it may eventually move
 // from test/ to src/
 
-// @ts-check
 import { assert, details as X, q } from '@agoric/assert';
 import {
   makeNotifierKit,

--- a/packages/notifier/test/prepare-test-env-ava.js
+++ b/packages/notifier/test/prepare-test-env-ava.js
@@ -4,5 +4,4 @@ import '@endo/init';
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';
 
-/** @type {typeof rawTest} */
 export const test = wrapTest(rawTest);

--- a/packages/pegasus/jsconfig.json
+++ b/packages/pegasus/jsconfig.json
@@ -15,5 +15,11 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js", "globals.d.ts"],
+  "include": [
+    "*.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+    "tools/**/*.js",
+  ],
 }

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -15,7 +15,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json"
   },
   "repository": {

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -61,11 +61,6 @@
     ],
     "timeout": "10m"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/run-protocol/jsconfig.json
+++ b/packages/run-protocol/jsconfig.json
@@ -15,5 +15,11 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "test/**/*.js", "exported.js", "globals.d.ts"],
+  "include": [
+    "exported.js",
+    "globals.d.ts",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js"
+  ]
 }

--- a/packages/run-protocol/package.json
+++ b/packages/run-protocol/package.json
@@ -69,11 +69,6 @@
     ],
     "timeout": "10m"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/run-protocol/package.json
+++ b/packages/run-protocol/package.json
@@ -15,7 +15,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "lint:types": "tsc --maxNodeModuleJsDepth 5 -p jsconfig.json"
   },
   "repository": {

--- a/packages/run-protocol/test/test-gov-collateral.js
+++ b/packages/run-protocol/test/test-gov-collateral.js
@@ -158,7 +158,6 @@ const makeScenario = async (t, { env = process.env } = {}) => {
       },
       getBankForAddress: () => assert.fail('not impl'),
     });
-    // @ts-ignore mock doesn't have all the methods
     space.produce.bankManager.resolve(bankManager);
 
     space.installation.produce.mintHolder.resolve(

--- a/packages/same-structure/jsconfig.json
+++ b/packages/same-structure/jsconfig.json
@@ -1,0 +1,25 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+    "compilerOptions": {
+      "target": "esnext",
+      "module": "esnext",
+  
+      "noEmit": true,
+  /*
+      // The following flags are for creating .d.ts files:
+      "noEmit": false,
+      "declaration": true,
+      "emitDeclarationOnly": true,
+  */
+      "downlevelIteration": true,
+      "strictNullChecks": true,
+      "moduleResolution": "node",
+    },
+    "include": [
+      "*.js",
+      "scripts/**/*.js",
+      "src/**/*.js",
+      "test/**/*.js",
+    ],
+  }
+  

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -12,7 +12,7 @@
     "test": "exit 0",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -40,11 +40,6 @@
     "*.js",
     "NEWS.md"
   ],
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/sharing-service/jsconfig.json
+++ b/packages/sharing-service/jsconfig.json
@@ -1,0 +1,25 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+    "compilerOptions": {
+      "target": "esnext",
+      "module": "esnext",
+  
+      "noEmit": true,
+  /*
+      // The following flags are for creating .d.ts files:
+      "noEmit": false,
+      "declaration": true,
+      "emitDeclarationOnly": true,
+  */
+      "downlevelIteration": true,
+      "strictNullChecks": true,
+      "moduleResolution": "node",
+    },
+    "include": [
+      "*.js",
+      "scripts/**/*.js",
+      "src/**/*.js",
+      "test/**/*.js",
+    ],
+  }
+  

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -13,7 +13,7 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -40,11 +40,6 @@
     "src/",
     "NEWS.md"
   ],
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/solo/jsconfig.json
+++ b/packages/solo/jsconfig.json
@@ -15,5 +15,10 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js"],
+  "include": [
+    "exported.js",
+    "public/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
 }

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "keywords": [],
   "author": "Agoric",

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -59,11 +59,6 @@
     "ava": "^3.12.1",
     "c8": "^7.7.2"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sparse-ints/jsconfig.json
+++ b/packages/sparse-ints/jsconfig.json
@@ -11,16 +11,13 @@
     "declaration": true,
     "emitDeclarationOnly": true,
 */
+    "downlevelIteration": true,
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
   "include": [
     "exported.js",
-    "demo/**/*.js", 
-    "lib/**/*.js", 
-    "src/**/*.js", 
-    "misc-tools/**/*.js", 
-    "test/**/*.js", 
-    "tools/**/*.js", 
-  ],
+    "src/**/*.js",
+    "test/**/*.js"
+  ]
 }

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -37,11 +37,6 @@
       "test/**/test-*.js"
     ]
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -12,7 +12,7 @@
     "test": "exit 0",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/packages/spawner/jsconfig.json
+++ b/packages/spawner/jsconfig.json
@@ -1,0 +1,25 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+    "compilerOptions": {
+      "target": "esnext",
+      "module": "esnext",
+  
+      "noEmit": true,
+  /*
+      // The following flags are for creating .d.ts files:
+      "noEmit": false,
+      "declaration": true,
+      "emitDeclarationOnly": true,
+  */
+      "downlevelIteration": true,
+      "strictNullChecks": true,
+      "moduleResolution": "node",
+    },
+    "include": [
+      "*.js",
+      "scripts/**/*.js",
+      "src/**/*.js",
+      "test/**/*.js",
+    ],
+  }
+  

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -14,7 +14,7 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -48,11 +48,6 @@
     "bundles/",
     "NEWS.md"
   ],
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/stat-logger/jsconfig.json
+++ b/packages/stat-logger/jsconfig.json
@@ -11,16 +11,13 @@
     "declaration": true,
     "emitDeclarationOnly": true,
 */
+    "downlevelIteration": true,
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
   "include": [
     "exported.js",
-    "demo/**/*.js", 
-    "lib/**/*.js", 
-    "src/**/*.js", 
-    "misc-tools/**/*.js", 
-    "test/**/*.js", 
-    "tools/**/*.js", 
-  ],
+    "src/**/*.js",
+    "test/**/*.js"
+  ]
 }

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -30,10 +30,5 @@
       "test/**/test-*.js"
     ],
     "timeout": "2m"
-  },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
   }
 }

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -12,7 +12,7 @@
     "test": "exit 0",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "peerDependencies": {
     "canvas": "^2.6.1",

--- a/packages/store/jsconfig.json
+++ b/packages/store/jsconfig.json
@@ -15,5 +15,9 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js"],
+  "include": [
+    "exported.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,7 +14,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -45,11 +45,6 @@
     "exported.js",
     "NEWS.md"
   ],
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/store/test/test-encodePassable.js
+++ b/packages/store/test/test-encodePassable.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 /* eslint-disable no-bitwise */
 
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';

--- a/packages/store/test/test-rankOrder.js
+++ b/packages/store/test/test-rankOrder.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { Far, makeTagged } from '@endo/marshal';
 import fc from 'fast-check';

--- a/packages/swing-store/jsconfig.json
+++ b/packages/swing-store/jsconfig.json
@@ -14,5 +14,9 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js"],
+  "include": [
+    "exported.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
 }

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -36,10 +36,5 @@
       "test/**/test-*.js"
     ],
     "timeout": "2m"
-  },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
   }
 }

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "dependencies": {
     "@agoric/assert": "^0.4.0",

--- a/packages/swingset-runner/jsconfig.json
+++ b/packages/swingset-runner/jsconfig.json
@@ -2,6 +2,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
+    "module": "esnext",
 
     "noEmit": true,
 /*
@@ -14,5 +15,10 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["**/*.js"],
+  "include": [
+    "*.js",
+    "demo/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js"
+  ]
 }

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -42,11 +42,6 @@
     "c8": "^7.11.0",
     "import-meta-resolve": "^1.1.1"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -15,7 +15,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "yarn lint:eslint",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "ci:autobench": "./autobench.js"
   },
   "dependencies": {

--- a/packages/telemetry/jsconfig.json
+++ b/packages/telemetry/jsconfig.json
@@ -15,5 +15,11 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "*.js"],
+  "include": [
+    "*.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+    "tools/**/*.js",
+  ],
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -43,11 +43,6 @@
     "c8": "^7.11.0",
     "tmp": "^0.2.1"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -13,7 +13,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "bin": {
     "frcat": "./src/frcat-entrypoint.js"

--- a/packages/telemetry/test/prepare-test-env-ava.js
+++ b/packages/telemetry/test/prepare-test-env-ava.js
@@ -4,5 +4,4 @@ import '@endo/init';
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';
 
-/** @type {typeof rawTest} */
 export const test = wrapTest(rawTest);

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -51,7 +51,7 @@
     "@babel/core": "^7.12.13",
     "@babel/plugin-syntax-jsx": "^7.12.1",
     "@material-ui/core": "4.11.3",
-    "@typescript-eslint/eslint-plugin": "^5.15.0",
+    "@typescript-eslint/eslint-plugin": "^5.27.0",
     "ava": "^3.15.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-named-asset-import": "^0.3.7",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -27,7 +27,7 @@
     "build": "yarn build:src && yarn build:tests",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json"
   },
   "eslintConfig": {

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -27,11 +27,6 @@
     "ava": "^3.12.1",
     "tsd": "^0.20.0"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -12,7 +12,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "lint:types": "tsc"
   },
   "keywords": [],

--- a/packages/vat-data/tsconfig.json
+++ b/packages/vat-data/tsconfig.json
@@ -12,5 +12,9 @@
 
     "noEmit": true,
   },
-  "include": ["src/**/*.js", "src/**/*.ts"]
+  "include": [
+    "src/**/*.js",
+    "src/**/*.ts",
+    "test/**/*.js",
+  ]
 }

--- a/packages/vats/jsconfig.json
+++ b/packages/vats/jsconfig.json
@@ -15,5 +15,10 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "test/**/*.js", "globals.d.ts"],
+  "include": [
+    "*.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -19,7 +19,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "keywords": [],
   "author": "Agoric",

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -52,11 +52,6 @@
     "c8": "^7.7.2",
     "import-meta-resolve": "^1.1.1"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "files": [
     "CHANGELOG.md",
     "src/",

--- a/packages/wallet/api/jsconfig.json
+++ b/packages/wallet/api/jsconfig.json
@@ -15,5 +15,11 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "test/**/*.js", "exported.js"],
+  "include": [
+    "*.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+    "tools/**/*.js",
+  ],
 }

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -33,11 +33,6 @@
     "@endo/promise-kit": "^0.2.41",
     "import-meta-resolve": "^1.1.1"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "keywords": [],
   "repository": {
     "type": "git",

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -11,7 +11,7 @@
     "lint": "run-s --continue-on-error lint:*",
     "lint-fix": "yarn lint:eslint --fix",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.ts ."
+    "lint:eslint": "eslint ."
   },
   "devDependencies": {
     "@agoric/deploy-script-support": "^0.9.0",

--- a/packages/wallet/api/src/types.js
+++ b/packages/wallet/api/src/types.js
@@ -1,15 +1,6 @@
 // @ts-check
 
 /**
- * @typedef {string | string[]} Petname
- * A petname can either be a plain string
- * or a path for which the first element is a petname for the origin, and the
- * rest of the elements are a snapshot of the names that were first given by
- * that origin.  We are migrating away from using plain strings, for
- * consistency.
- */
-
-/**
  * @typedef {object} WalletUser
  * The presence exposed as `local.wallet` (or
  * `home.wallet`).  The idea is to provide someplace from which all the rest of

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -26,10 +26,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
   }
 }

--- a/packages/web-components/demo/index.html
+++ b/packages/web-components/demo/index.html
@@ -14,7 +14,6 @@
   <script type="module">
     import './install-ses-lockdown.js';
 
-    // eslint-disable-next-line import/no-extraneous-dependencies
     import { E } from '@endo/eventual-send';
     import { html, render } from 'lit';
     import '../agoric-wallet-connection.js';
@@ -31,7 +30,7 @@
       c.globalThis.state = state;
       c.globalThis.walletConnection = walletConnection;
     };
-    
+
     const onKeyPress = ev => {
       if (ev.key === 'Enter') {
         const cmd = ev.target.value;

--- a/packages/web-components/jsconfig.json
+++ b/packages/web-components/jsconfig.json
@@ -15,5 +15,10 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js"],
+  "include": [
+    "*.js",
+    "exported.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
 }

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.ts . --ignore-path .gitignore",
+    "lint:eslint": "eslint . --ignore-path .gitignore",
     "analyze": "cem analyze --litelement",
     "start": "web-dev-server --port 8100"
   },

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.html . --ignore-path .gitignore",
+    "lint:eslint": "eslint --ext .js,.ts . --ignore-path .gitignore",
     "analyze": "cem analyze --litelement",
     "start": "web-dev-server --port 8100"
   },

--- a/packages/xsnap/jsconfig.json
+++ b/packages/xsnap/jsconfig.json
@@ -16,10 +16,11 @@
     "moduleResolution": "node",
   },
   "include": [
-    "src/**/*.js",
+    "*.js",
+    "lib/**/*.js",
     "src/**/*.d.ts",
-    "exported.js",
+    "src/**/*.js",
+    "test/**/*.js",
     "tools/**/*.js",
-    "api.js"
   ],
 }

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -56,14 +56,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ],
-    "ignorePatterns": [
-      "examples/**/*.js"
-    ]
-  },
   "ava": {
     "files": [
       "test/**/test-*.js"

--- a/packages/xsnap/src/avaHandler.js
+++ b/packages/xsnap/src/avaHandler.js
@@ -13,6 +13,7 @@ HandledPromise is defined by eventual send shim.
 /// <reference types="ses" />
 /// <reference types="@endo/eventual-send" />
 
+// @ts-expect-error cannot redeclare encoder
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -33,6 +34,7 @@ function send(item) {
  */
 const bundleSource = async (startFilename, ...args) => {
   const msg = await send({ bundleSource: [startFilename, ...args] });
+  // @ts-expect-error send() returns void
   return JSON.parse(decoder.decode(msg));
 };
 
@@ -69,18 +71,16 @@ function handler(rawMessage) {
     case 'loadScript': {
       const { source } = msg;
       const virtualObjectGlobals =
-        // @ts-ignore
+        // @ts-expect-error
         // eslint-disable-next-line no-undef
         typeof VatData !== 'undefined' ? { VatData } : {};
-      // @ts-ignore How do I get ses types in scope?!?!?!
       const c = new Compartment({
         require: testRequire,
         __dirname,
         __filename,
         console,
-        // @ts-ignore
         assert,
-        // @ts-ignore
+        // @ts-expect-error
         HandledPromise,
         TextEncoder,
         TextDecoder,

--- a/packages/xsnap/src/defer.js
+++ b/packages/xsnap/src/defer.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line jsdoc/require-returns-check
 /**
  * @param {boolean} _flag
  * @returns {asserts _flag}

--- a/packages/xsnap/test/message-tools.js
+++ b/packages/xsnap/test/message-tools.js
@@ -23,6 +23,7 @@ export function loader(url, readFile = undefined) {
   return freeze({
     resolve,
     /**  @param { string } ref */
+    // @ts-expect-error possibly undefined
     asset: async ref => readFile(resolve(ref), 'utf-8'),
   });
 }

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -112,7 +112,9 @@ test('meter details are still available with no limit', async t => {
   t.log(meters);
   t.is(typeof meters.compute, 'number');
   t.is(typeof meters.allocate, 'number');
+  // @ts-expect-error until ava assertion types
   t.true(meters.compute > 0);
+  // @ts-expect-error until ava assertion types
   t.true(meters.allocate > 0);
 });
 
@@ -185,7 +187,6 @@ test('metering switch - start compartment only', async t => {
 function dataStructurePerformance(logn) {
   // eslint-disable-next-line no-bitwise
   const n = 1 << logn;
-  // @ts-expect-error
   const send = it => {
     // eslint-disable-next-line no-undef
     return issueCommand(new TextEncoder().encode(JSON.stringify(it)).buffer);
@@ -234,6 +235,7 @@ test.skip('Array, Map, Set growth is O(log(n))', async t => {
     const {
       meterUsage: { compute },
     } = await vat.evaluate(`dataStructurePerformance(${size})`);
+    // @ts-expect-error pop() may return undefined
     const r = JSON.parse(opts.messages.pop());
     t.log({ compute, r });
     return { compute, r };

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -344,6 +344,7 @@ test('normal close of pathological script', async t => {
 async function runToGC() {
   const trashCan = [{}];
   const wr = new WeakRef(trashCan[0]);
+  // @ts-expect-error
   trashCan[0] = undefined;
 
   let qty;

--- a/packages/zoe/jsconfig.json
+++ b/packages/zoe/jsconfig.json
@@ -15,7 +15,13 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  // To include tests, change to:
-  //  "include": ["src/**/*.js", "exported.js", "tools/**/*.js", "test/**/*.js"], 
-  "include": ["src/**/*.js", "exported.js", "tools/**/*.js", "src/zoeService/types.d.ts"],
+  "include": [
+    "contractFacet.js",
+    "exported.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "src/**/*.ts",
+    "test/**/*.js",
+    "tools/**/*.js",
+  ],
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -83,11 +83,6 @@
     ],
     "timeout": "20m"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -20,7 +20,7 @@
     "build-zcfBundle": "yarn build:bundles",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:eslint": "eslint --ext .js,.ts .",
+    "lint:eslint": "eslint .",
     "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json"
   },
   "repository": {

--- a/packages/zoe/src/contractFacet/internal-types.js
+++ b/packages/zoe/src/contractFacet/internal-types.js
@@ -5,20 +5,6 @@
  */
 
 /**
- * @callback MakeZCFZygote
- *
- * Make the ZCF vat in zygote-usable form. First, a generic ZCF is
- * made, then the contract code is evaluated, then a particular
- * instance is made.
- *
- * @param {VatPowers} powers
- * @param {ERef<ZoeService>} zoeService
- * @param {Issuer} invitationIssuer
- * @param {TestJigSetter} testJigSetter
- * @returns {ZCFZygote}
- */
-
-/**
  * @typedef ZCFZygote
  * @property {(bundleOrBundleCap: SourceBundle | BundleCap) => void} evaluateContract
  * @property {(instanceAdminFromZoe: ERef<ZoeInstanceAdmin>,

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -21,10 +21,21 @@ import { addToAllocation, subtractFromAllocation } from './allocationMath.js';
 
 import '../../exported.js';
 import '../internal-types.js';
+import './internal-types.js';
 
 import '@agoric/swingset-vat/src/types-ambient.js';
 
-/** @type {MakeZCFZygote} */
+/**
+ * Make the ZCF vat in zygote-usable form. First, a generic ZCF is
+ * made, then the contract code is evaluated, then a particular
+ * instance is made.
+ *
+ * @param {VatPowers} powers
+ * @param {ERef<ZoeService>} zoeService
+ * @param {Issuer} invitationIssuer
+ * @param {TestJigSetter} testJigSetter
+ * @returns {ZCFZygote}
+ */
 export const makeZCFZygote = (
   powers,
   zoeService,

--- a/packages/zoe/test/offerArgsUsageContract.js
+++ b/packages/zoe/test/offerArgsUsageContract.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @type {ContractStartFn} */
+/** @param {ZCF} zcf */
 const start = zcf => {
   /** @type {OfferHandler} */
   const handler = (_seat, offerArgs) => {

--- a/packages/zoe/test/privateArgsUsageContract.js
+++ b/packages/zoe/test/privateArgsUsageContract.js
@@ -8,6 +8,7 @@ const start = (_zcf, privateArgs) => {
   const creatorFacet = Far('creatorFacet', {
     usePrivateArgs: () => E(privateArgs.myArg).doTest(),
   });
+  // @ts-expect-error missing publicFacet for ContractStartFn
   return harden({ creatorFacet });
 };
 harden(start);

--- a/packages/zoe/test/runMintContract.js
+++ b/packages/zoe/test/runMintContract.js
@@ -4,7 +4,7 @@ import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 
-/** @type {ContractStartFn} */
+/** @param {ZCF} zcf */
 const start = async (zcf, privateArgs) => {
   const runMint = await zcf.registerFeeMint('RUN', privateArgs.feeMintAccess);
 

--- a/packages/zoe/test/runMintContract.js
+++ b/packages/zoe/test/runMintContract.js
@@ -4,7 +4,10 @@ import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 
-/** @param {ZCF} zcf */
+/**
+ * @param {ZCF} zcf
+ * @param {{feeMintAccess: FeeMintAccess}} privateArgs
+ */
 const start = async (zcf, privateArgs) => {
   const runMint = await zcf.registerFeeMint('RUN', privateArgs.feeMintAccess);
 

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -87,6 +87,7 @@ const start = zcf => {
 
   const creatorInvitation = makeSafeInvitation();
 
+  // @ts-expect-error missing creatorFacet of ContractStartFn
   return harden({ creatorInvitation, publicFacet });
 };
 

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@endo/init';

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@endo/init';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -39,11 +39,15 @@ function makeMockTradingZcfBuilder() {
 
 test('ZoeHelpers satisfies blank proposal', t => {
   const { moola } = setup();
+  /** @type {ZCFSeat} */
+  // @ts-expect-error cast
   const fakeZcfSeat = Far('fakeZcfSeat', {
     getCurrentAllocation: () => harden({ Asset: moola(10n) }),
     getProposal: () => harden({}),
   });
   const mockZCFBuilder = makeMockTradingZcfBuilder();
+  /** @type {ZCF} */
+  // @ts-expect-error cast
   const mockZCF = mockZCFBuilder.build();
   t.truthy(
     satisfies(mockZCF, fakeZcfSeat, { Gift: moola(3n) }),
@@ -53,11 +57,14 @@ test('ZoeHelpers satisfies blank proposal', t => {
 
 test('ZoeHelpers satisfies simple proposal', t => {
   const { moola, simoleans } = setup();
+  /** @type {ZCFSeat} */
+  // @ts-expect-error cast
   const fakeZcfSeat = Far('fakeZcfSeat', {
     getCurrentAllocation: () => harden({ Asset: moola(10n) }),
     getProposal: () => harden({ want: { Desire: moola(30n) } }),
   });
-  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  /** @type {ZCF} */
+  // @ts-expect-error cast
   const mockZCF = mockZCFBuilder.build();
   t.falsy(
     satisfies(mockZCF, fakeZcfSeat, { Desire: moola(3n) }),
@@ -86,12 +93,16 @@ test('ZoeHelpers satisfies simple proposal', t => {
 
 test('ZoeHelpers satisfies() with give', t => {
   const { moola, bucks } = setup();
+  /** @type {ZCFSeat} */
+  // @ts-expect-error cast
   const fakeZcfSeat = Far('fakeZcfSeat', {
     getCurrentAllocation: () => harden({ Charge: moola(30n) }),
     getProposal: () =>
       harden({ give: { Charge: moola(30n) }, want: { Desire: bucks(5n) } }),
   });
   const mockZCFBuilder = makeMockTradingZcfBuilder();
+  /** @type {ZCF} */
+  // @ts-expect-error cast
   const mockZCF = mockZCFBuilder.build();
   t.falsy(
     satisfies(mockZCF, fakeZcfSeat, { Charge: moola(0n), Desire: bucks(1n) }),

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -26,8 +26,10 @@ function makeMockTradingZcfBuilder() {
   return Far('mockTradingZcfBuilder', {
     addOffer: (keyword, offer) => offers.init(keyword, offer),
     addAllocation: (keyword, alloc) => allocs.init(keyword, alloc),
+    /** @returns {ZCF} */
     build: () =>
       Far('mockZCF', {
+        // @ts-expect-error mock
         getZoeService: () => {},
         reallocate: (...seatStagings) => {
           reallocatedStagings.push(...seatStagings);
@@ -46,8 +48,6 @@ test('ZoeHelpers satisfies blank proposal', t => {
     getProposal: () => harden({}),
   });
   const mockZCFBuilder = makeMockTradingZcfBuilder();
-  /** @type {ZCF} */
-  // @ts-expect-error cast
   const mockZCF = mockZCFBuilder.build();
   t.truthy(
     satisfies(mockZCF, fakeZcfSeat, { Gift: moola(3n) }),
@@ -63,8 +63,7 @@ test('ZoeHelpers satisfies simple proposal', t => {
     getCurrentAllocation: () => harden({ Asset: moola(10n) }),
     getProposal: () => harden({ want: { Desire: moola(30n) } }),
   });
-  /** @type {ZCF} */
-  // @ts-expect-error cast
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
   const mockZCF = mockZCFBuilder.build();
   t.falsy(
     satisfies(mockZCF, fakeZcfSeat, { Desire: moola(3n) }),
@@ -101,8 +100,6 @@ test('ZoeHelpers satisfies() with give', t => {
       harden({ give: { Charge: moola(30n) }, want: { Desire: bucks(5n) } }),
   });
   const mockZCFBuilder = makeMockTradingZcfBuilder();
-  /** @type {ZCF} */
-  // @ts-expect-error cast
   const mockZCF = mockZCFBuilder.build();
   t.falsy(
     satisfies(mockZCF, fakeZcfSeat, { Charge: moola(0n), Desire: bucks(1n) }),

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -1,5 +1,4 @@
-// @ts-check
-
+// @ts-nocheck
 import { assert, details as X, q } from '@agoric/assert';
 import { Far } from '@endo/marshal';
 import { makeStore } from '@agoric/store';

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env.js';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/loan/test-close.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-close.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/loan/test-lend.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-lend.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import '../../../../exported.js';

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -322,7 +322,7 @@ test('zoe - non-fungible atomicSwap', async t => {
   // Alice makes an instance and makes her offer.
   const installation = await alice.installCode();
 
-  const vorpalSword = createRpgItem('Vorpal Sword', 38);
+  const vorpalSword = createRpgItem('Vorpal Sword', 'vorping');
   const vorpalAmount = rpgItems(vorpalSword);
   const bobRpgPayment = await E(rpgMint).mintPayment(vorpalAmount);
   const bob = await makeBob(installation, bobRpgPayment);

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -157,6 +157,7 @@ test('zoe with automaticRefund', async t => {
   const exclusBobInvitation = await E(invitationIssuer).claim(bobInvitation);
 
   const {
+    // @ts-expect-error poor typing of Payment
     value: [bobInvitationValue],
   } = await E(invitationIssuer).getAmountOf(exclusBobInvitation);
   t.is(bobInvitationValue.installation, installation);

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -923,7 +923,7 @@ test('zoe - coveredCall non-fungible', async t => {
   // Setup Bob
   const aGloriousShield = createRpgItem(
     'Glorious Shield',
-    25,
+    'blinding',
     'a Glorious Shield, burnished to a blinding brightness',
   );
   const aGloriousShieldAmount = rpgItems(aGloriousShield);

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -162,6 +162,7 @@ test('zoe - escrowToVote', async t => {
 
     // Voter3 exits before the election is closed. Voter3's vote will
     // not be counted.
+    assert(seat.tryExit);
     seat.tryExit();
 
     return { voter, seat };

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -425,7 +425,9 @@ test('simpleExchange with non-fungible assets', async t => {
   // Assert that the correct payout were received.
   // Alice has an empty RPG purse, and the Cheshire Cat.
   // Bob has an empty CryptoCat purse, and the Spell of Binding he wanted.
+  // @ts-expect-error get may fail
   const noCats = AmountMath.makeEmpty(brands.get('cc'), AssetKind.SET);
+  // @ts-expect-error get may fail
   const noRpgItems = AmountMath.makeEmpty(brands.get('rpg'), AssetKind.SET);
   await assertPayoutAmount(t, rpgIssuer, aliceRpgPayout, noRpgItems);
   const cheshireCatAmount = cryptoCats(harden(['Cheshire Cat']));

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -63,6 +63,7 @@ test('zoe - useObj', async t => {
     `use of use object works`,
   );
 
+  assert(aliceSeat.tryExit);
   aliceSeat.tryExit();
 
   const aliceMoolaPayoutPayment = await E(aliceSeat).getPayout('Pixels');

--- a/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
@@ -10,7 +10,7 @@ import { depositToSeat } from '../../../src/contractSupport/index.js';
  * This is a a broken contact to test that
  * errors in offerHandlers are appropriately handled
  *
- * @type {ContractStartFn<undefined, {makeThrowInOfferHandlerInvitation: unknown, makeThrowInDepositToSeatInvitation: unknown}>}
+ * @param {ZCF} zcf
  */
 const start = zcf => {
   const throwInOfferHandler = _seat => {

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -13,7 +13,7 @@ import {
 /**
  * Give a use object when a payment is escrowed
  *
- * @type {ContractStartFn}
+ * @param {ZCF} zcf
  */
 const start = zcf => {
   const {

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -45,7 +45,7 @@ const setup = () => {
    * @property {(value: AmountValue) => Amount} moola
    * @property {(value: AmountValue) => Amount} simoleans
    * @property {(value: AmountValue) => Amount} bucks
-   * @property {ERef<ZoeService>} zoe
+   * @property {ZoeService} zoe
    * @property {*} vatAdminState
    */
 

--- a/packages/zoe/test/unitTests/setupNonFungibleMints.js
+++ b/packages/zoe/test/unitTests/setupNonFungibleMints.js
@@ -21,7 +21,13 @@ const setupNonFungible = () => {
     brands.set(k, allBundles[k].brand);
   }
 
-  function createRpgItem(name, power, desc = undefined) {
+  /**
+   *
+   * @param {string} name
+   * @param {number} power
+   * @param {string} [desc]
+   */
+  function createRpgItem(name, power, desc) {
     return harden([{ name, description: desc || name, power }]);
   }
   const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
@@ -31,9 +37,9 @@ const setupNonFungible = () => {
   const rpgIssuer = rpgBundle.issuer;
   const ccMint = ccBundle.mint;
   const rpgMint = rpgBundle.mint;
-  /** @param {AmountValue} value */
+  /** @param {SetValue} value */
   const cryptoCats = value => AmountMath.make(allBundles.cc.brand, value);
-  /** @param {AmountValue} value */
+  /** @param {SetValue} value */
   const rpgItems = value => AmountMath.make(allBundles.rpg.brand, value);
   return {
     ccIssuer,

--- a/packages/zoe/test/unitTests/setupNonFungibleMints.js
+++ b/packages/zoe/test/unitTests/setupNonFungibleMints.js
@@ -24,7 +24,7 @@ const setupNonFungible = () => {
   /**
    *
    * @param {string} name
-   * @param {number} power
+   * @param {string} power
    * @param {string} [desc]
    */
   function createRpgItem(name, power, desc) {

--- a/packages/zoe/test/unitTests/test-instanceStorage.js
+++ b/packages/zoe/test/unitTests/test-instanceStorage.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -1,6 +1,8 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+/** @type {import('ava').TestInterface<any>} */
+const test = unknownTest;
 
 import path from 'path';
 

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -1,8 +1,6 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-/** @type {import('ava').TestInterface<any>} */
-const test = unknownTest;
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import path from 'path';
 

--- a/packages/zoe/test/unitTests/test-zoe-env.js
+++ b/packages/zoe/test/unitTests/test-zoe-env.js
@@ -9,7 +9,6 @@ test('harden from SES is in the zoe contract environment', t => {
 });
 
 test('(mock) kind makers from SwingSet are in the zoe contract environment', t => {
-  // @ts-expect-error testing existence of function only
   VatData.defineKind('x', () => {}, {});
   VatData.defineKindMulti('x', () => {}, { x: {}, y: {} });
   const kh = VatData.makeKindHandle();
@@ -19,7 +18,6 @@ test('(mock) kind makers from SwingSet are in the zoe contract environment', t =
 });
 
 test('(mock) store makers from SwingSet are in the zoe contract environment', t => {
-  // @ts-expect-error testing existence of function only
   VatData.makeScalarBigMapStore();
   VatData.makeScalarBigWeakMapStore();
   VatData.makeScalarBigSetStore();

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -21,6 +21,7 @@ const dirname = path.dirname(filename);
 test(`zoe.getInvitationIssuer`, async t => {
   const { zoe, zcf } = await setupZCFTest();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
+  // @ts-expect-error
   const invitation = zcf.makeInvitation(undefined, 'invite');
 
   // A few basic tests that the invitation issuer acts like an issuer.
@@ -146,7 +147,6 @@ test(`E(zoe).startInstance - terms, issuerKeywordRecord switched`, async t => {
     () =>
       E(zoe).startInstance(
         installation,
-        // @ts-expect-error deliberate invalid arguments for testing
         { something: 2 },
         { Moola: moolaKit.issuer },
       ),
@@ -176,7 +176,6 @@ test(`E(zoe).startInstance - bad issuer, makeEmptyPurse throws`, async t => {
     getBrand: () => brand,
   });
   await t.throwsAsync(
-    // @ts-expect-error deliberate invalid arguments for testing
     () => E(zoe).startInstance(installation, { Money: badIssuer }),
     {
       message:
@@ -416,6 +415,7 @@ test(`zoe.getInstallationForInstance`, async t => {
 
 test(`zoe.getInstance`, async t => {
   const { zoe, zcf, instance } = await setupZCFTest();
+  // @ts-expect-error
   const invitation = await E(zcf).makeInvitation(undefined, 'invitation');
   const actualInstance = await E(zoe).getInstance(invitation);
   t.is(actualInstance, instance);
@@ -431,6 +431,7 @@ test(`zoe.getInstance - no invitation`, async t => {
 
 test(`zoe.getInstallation`, async t => {
   const { zoe, zcf, installation } = await setupZCFTest();
+  // @ts-expect-error
   const invitation = await E(zcf).makeInvitation(undefined, 'invitation');
   const actualInstallation = await E(zoe).getInstallation(invitation);
   t.is(actualInstallation, installation);
@@ -446,6 +447,7 @@ test(`zoe.getInstallation - no invitation`, async t => {
 
 test(`zoe.getInvitationDetails`, async t => {
   const { zoe, zcf, installation, instance } = await setupZCFTest();
+  // @ts-expect-error
   const invitation = await E(zcf).makeInvitation(undefined, 'invitation');
   const details = await E(zoe).getInvitationDetails(invitation);
   t.deepEqual(details, {

--- a/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
@@ -61,7 +61,6 @@ test(`zcf.reallocate unstaged`, async t => {
   const { brand } = zcfMint.getIssuerRecord();
   const empty = AmountMath.makeEmpty(brand, AssetKind.NAT);
   zcfSeat1.incrementBy(harden({ RUN: empty }));
-  // @ts-expect-error Deliberate wrong type for testing
   t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2), {
     message:
       'Reallocate failed because a seat had no staged allocation. Please add or subtract from the seat and then reallocate.',

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -47,7 +47,8 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
 
   // The contract uses the testJig so the contractFacet
   // is available here for testing purposes
-  /** @type {ContractFacet} */
+  /** @type {ZCF} */
+  // @ts-expect-error cast
   const zcf = testJig.zcf;
 
   let firstSeat;

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -295,7 +295,6 @@ test(`zoeHelper with zcf - fit proposal patterns`, async t => {
     give: { B: simoleans(3n) },
   });
 
-  // @ts-expect-error invalid arguments for testing
   t.throws(() => fit(proposal, harden([])), {
     message: /.* - Must be equivalent to: \[\]/,
   });
@@ -624,6 +623,7 @@ test(`zcf/zoeHelper - assertProposalShape w/bad Expected`, async t => {
     { B: simoleanMint.mintPayment(simoleans(3n)) },
   );
 
+  // @ts-expect-error
   t.throws(() => assertProposalShape(zcfSeat, { give: { B: moola(3n) } }), {
     message: /The value of the expected record must be null but was .*/,
   });

--- a/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
@@ -6,7 +6,7 @@ import { Far } from '@endo/far';
 /**
  * Tests ZCF
  *
- * @type {ContractStartFn<{makeInvitation: unknown}>}
+ * @param {ZCF} zcf
  */
 const start = async zcf => {
   // make the `zcf` and `instance` available to the tests

--- a/packages/zoe/test/unitTests/zoe/test-burnInvitation.js
+++ b/packages/zoe/test/unitTests/zoe/test-burnInvitation.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';

--- a/packages/zoe/test/unitTests/zoe/test-installationStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-installationStorage.js
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';

--- a/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
+++ b/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
@@ -65,6 +65,7 @@ test('description is omitted, wrongly', async t => {
   });
 
   await t.throwsAsync(
+    // @ts-expect-error
     () =>
       makeInvitation(
         // @ts-expect-error mockInvitationHandle is mocked

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+      "target": "esnext",
+      "module": "esnext",
+      "moduleResolution": "node",
+      "skipLibCheck": true,
+  
+      "allowJs": true,
+      "checkJs": true,
+      "strict": true,
+  
+      "noEmit": true,
+    },
+    "include": [
+      ".eslintrc.cjs",
+    ]
+  }
+  

--- a/yarn.lock
+++ b/yarn.lock
@@ -4212,85 +4212,85 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^5.15.0", "@typescript-eslint/eslint-plugin@^5.5.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.15.0.tgz#c28ef7f2e688066db0b6a9d95fb74185c114fb9a"
-  integrity sha512-u6Db5JfF0Esn3tiAKELvoU5TpXVSkOpZ78cEGn/wXtT2RVqs2vkt4ge6N8cRCyw7YVKhmmLDbwI2pg92mlv7cA==
+"@typescript-eslint/eslint-plugin@^5.27.0", "@typescript-eslint/eslint-plugin@^5.5.0":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.0.tgz#23d82a4f21aaafd8f69dbab7e716323bb6695cc8"
+  integrity sha512-DDrIA7GXtmHXr1VCcx9HivA39eprYBIFxbQEHI6NyraRDxCGpxAFiYQAT/1Y0vh1C+o2vfBiy4IuPoXxtTZCAQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.15.0"
-    "@typescript-eslint/type-utils" "5.15.0"
-    "@typescript-eslint/utils" "5.15.0"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "5.27.0"
+    "@typescript-eslint/type-utils" "5.27.0"
+    "@typescript-eslint/utils" "5.27.0"
+    debug "^4.3.4"
     functional-red-black-tree "^1.0.1"
-    ignore "^5.1.8"
+    ignore "^5.2.0"
     regexpp "^3.2.0"
-    semver "^7.3.5"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.15.0", "@typescript-eslint/parser@^5.5.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.15.0.tgz#95f603f8fe6eca7952a99bfeef9b85992972e728"
-  integrity sha512-NGAYP/+RDM2sVfmKiKOCgJYPstAO40vPAgACoWPO/+yoYKSgAXIFaBKsV8P0Cc7fwKgvj27SjRNX4L7f4/jCKQ==
+"@typescript-eslint/parser@^5.27.0", "@typescript-eslint/parser@^5.5.0":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.27.0.tgz#62bb091ed5cf9c7e126e80021bb563dcf36b6b12"
+  integrity sha512-8oGjQF46c52l7fMiPPvX4It3u3V3JipssqDfHQ2hcR0AeR8Zge+OYyKUCm5b70X72N1qXt0qgHenwN6Gc2SXZA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.15.0"
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/typescript-estree" "5.15.0"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "5.27.0"
+    "@typescript-eslint/types" "5.27.0"
+    "@typescript-eslint/typescript-estree" "5.27.0"
+    debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.15.0.tgz#d97afab5e0abf4018d1289bd711be21676cdd0ee"
-  integrity sha512-EFiZcSKrHh4kWk0pZaa+YNJosvKE50EnmN4IfgjkA3bTHElPtYcd2U37QQkNTqwMCS7LXeDeZzEqnsOH8chjSg==
+"@typescript-eslint/scope-manager@5.27.0":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.27.0.tgz#a272178f613050ed62f51f69aae1e19e870a8bbb"
+  integrity sha512-VnykheBQ/sHd1Vt0LJ1JLrMH1GzHO+SzX6VTXuStISIsvRiurue/eRkTqSrG0CexHQgKG8shyJfR4o5VYioB9g==
   dependencies:
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/visitor-keys" "5.15.0"
+    "@typescript-eslint/types" "5.27.0"
+    "@typescript-eslint/visitor-keys" "5.27.0"
 
-"@typescript-eslint/type-utils@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.15.0.tgz#d2c02eb2bdf54d0a645ba3a173ceda78346cf248"
-  integrity sha512-KGeDoEQ7gHieLydujGEFLyLofipe9PIzfvA/41urz4hv+xVxPEbmMQonKSynZ0Ks2xDhJQ4VYjB3DnRiywvKDA==
+"@typescript-eslint/type-utils@5.27.0":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.27.0.tgz#36fd95f6747412251d79c795b586ba766cf0974b"
+  integrity sha512-vpTvRRchaf628Hb/Xzfek+85o//zEUotr1SmexKvTfs7czXfYjXVT/a5yDbpzLBX1rhbqxjDdr1Gyo0x1Fc64g==
   dependencies:
-    "@typescript-eslint/utils" "5.15.0"
-    debug "^4.3.2"
+    "@typescript-eslint/utils" "5.27.0"
+    debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.15.0.tgz#c7bdd103843b1abae97b5518219d3e2a0d79a501"
-  integrity sha512-yEiTN4MDy23vvsIksrShjNwQl2vl6kJeG9YkVJXjXZnkJElzVK8nfPsWKYxcsGWG8GhurYXP4/KGj3aZAxbeOA==
+"@typescript-eslint/types@5.27.0":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.27.0.tgz#c3f44b9dda6177a9554f94a74745ca495ba9c001"
+  integrity sha512-lY6C7oGm9a/GWhmUDOs3xAVRz4ty/XKlQ2fOLr8GAIryGn0+UBOoJDWyHer3UgrHkenorwvBnphhP+zPmzmw0A==
 
-"@typescript-eslint/typescript-estree@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.15.0.tgz#81513a742a9c657587ad1ddbca88e76c6efb0aac"
-  integrity sha512-Hb0e3dGc35b75xLzixM3cSbG1sSbrTBQDfIScqdyvrfJZVEi4XWAT+UL/HMxEdrJNB8Yk28SKxPLtAhfCbBInA==
+"@typescript-eslint/typescript-estree@5.27.0":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.0.tgz#7965f5b553c634c5354a47dcce0b40b94611e995"
+  integrity sha512-QywPMFvgZ+MHSLRofLI7BDL+UczFFHyj0vF5ibeChDAJgdTV8k4xgEwF0geFhVlPc1p8r70eYewzpo6ps+9LJQ==
   dependencies:
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/visitor-keys" "5.15.0"
-    debug "^4.3.2"
-    globby "^11.0.4"
+    "@typescript-eslint/types" "5.27.0"
+    "@typescript-eslint/visitor-keys" "5.27.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
     is-glob "^4.0.3"
-    semver "^7.3.5"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.15.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.10.2":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.15.0.tgz#468510a0974d3ced8342f37e6c662778c277f136"
-  integrity sha512-081rWu2IPKOgTOhHUk/QfxuFog8m4wxW43sXNOMSCdh578tGJ1PAaWPsj42LOa7pguh173tNlMigsbrHvh/mtA==
+"@typescript-eslint/utils@5.27.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.10.2":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.27.0.tgz#d0021cbf686467a6a9499bd0589e19665f9f7e71"
+  integrity sha512-nZvCrkIJppym7cIbP3pOwIkAefXOmfGPnCM0LQfzNaKxJHI6VjI8NC662uoiPlaf5f6ymkTy9C3NQXev2mdXmA==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.15.0"
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/typescript-estree" "5.15.0"
+    "@typescript-eslint/scope-manager" "5.27.0"
+    "@typescript-eslint/types" "5.27.0"
+    "@typescript-eslint/typescript-estree" "5.27.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.15.0.tgz#5669739fbf516df060f978be6a6dce75855a8027"
-  integrity sha512-+vX5FKtgvyHbmIJdxMJ2jKm9z2BIlXJiuewI8dsDYMp5LzPUcuTT78Ya5iwvQg3VqSVdmxyM8Anj1Jeq7733ZQ==
+"@typescript-eslint/visitor-keys@5.27.0":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.0.tgz#97aa9a5d2f3df8215e6d3b77f9d214a24db269bd"
+  integrity sha512-46cYrteA2MrIAjv9ai44OQDUoCZyHeGIc4lsjCUX2WT6r4C+kidz1bNiR4017wHOPUythYeH+Sc7/cFP97KEAA==
   dependencies:
-    "@typescript-eslint/types" "5.15.0"
-    eslint-visitor-keys "^3.0.0"
+    "@typescript-eslint/types" "5.27.0"
+    eslint-visitor-keys "^3.3.0"
 
 "@web/browser-logs@^0.2.1", "@web/browser-logs@^0.2.2":
   version "0.2.5"
@@ -8093,7 +8093,7 @@ eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
+eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
@@ -8498,7 +8498,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.1.1, fast-glob@^3.2.11:
+fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -9198,16 +9198,16 @@ globalthis@^1.0.1:
   dependencies:
     define-properties "^1.1.3"
 
-globby@^11.0.1, globby@^11.0.4:
-  version "11.0.4"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
-  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
+globby@^11.0.1, globby@^11.0.4, globby@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
     slash "^3.0.0"
 
 globby@^9.2.0:
@@ -9702,7 +9702,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.5, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.0.5, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -11962,7 +11962,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3, merge2@^1.3.0:
+merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,14 +1645,14 @@
   resolved "https://registry.yarnpkg.com/@endo/zip/-/zip-0.2.25.tgz#0e6ed3dfb42bac40ce6e1d90dea0f01cc1ee801b"
   integrity sha512-HzjHt3xIDSTLz0ldBmsS2F7sKLIxb67y29fJzeBMqUigGwYvF6mHeV38/5YClc3POVJYdfARgFs2FufRVFOzrA==
 
-"@es-joy/jsdoccomment@~0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.29.0.tgz#527c7eefadeaf5c5d0c3b2721b5fa425d2119e98"
-  integrity sha512-4yKy5t+/joLihG+ei6CCU6sc08sjUdEdXCQ2U+9h9VP13EiqHQ4YMgDC18ys/AsLdJDBX3KRx/AWY6PR7hn52Q==
+"@es-joy/jsdoccomment@~0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.30.0.tgz#12e3e220ee8e1a4b48c6db30c4a77fce0bd21d34"
+  integrity sha512-U30cjaHCjdUqtbMgChJl80BP25GSRWg0/1R3UdB2ksitAo2oDYdRMrvzwuM21jcsFbEcLNAqwQGTCg+5CVbSIA==
   dependencies:
     comment-parser "1.3.1"
     esquery "^1.4.0"
-    jsdoc-type-pratt-parser "~3.0.1"
+    jsdoc-type-pratt-parser "~3.1.0"
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -7935,11 +7935,11 @@ eslint-plugin-jest@^25.3.0, eslint-plugin-jest@^26.0.0:
     "@typescript-eslint/utils" "^5.10.0"
 
 eslint-plugin-jsdoc@^39.2.9:
-  version "39.2.9"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.9.tgz#bc351de403f1862f1ef8c440d12dedc28e74cbbb"
-  integrity sha512-gaPYJT94rWlWyQcisQyyEJHtLaaJqN4baFlLCEr/LcXVibS9wzQTL2dskqk327ggwqQopR+Xecu2Lng1IJ9Ypw==
+  version "39.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.0.tgz#7318ac217a44401fc42fda1a051a6b7cd010a18a"
+  integrity sha512-zEdkpezjIhG7gq4MbwLBKaD3cWsJkT7uTAJcIbLohQWR7OVwhPOBLPqpftBt8uzy0ZL+3jlbiaSXik4+VmN6JQ==
   dependencies:
-    "@es-joy/jsdoccomment" "~0.29.0"
+    "@es-joy/jsdoccomment" "~0.30.0"
     comment-parser "1.3.1"
     debug "^4.3.4"
     escape-string-regexp "^4.0.0"
@@ -10948,10 +10948,10 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdoc-type-pratt-parser@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.0.1.tgz#ccbc7a4180bc8748af64d2cc431aaa92f88175bb"
-  integrity sha512-vqMCdAFVIiFhVgBYE/X8naf3L/7qiJsaYWTfUJZZZ124dR3OUz9HrmaMUGpYIYAN4VSuodf6gIZY0e8ktPw9cg==
+jsdoc-type-pratt-parser@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz#a4a56bdc6e82e5865ffd9febc5b1a227ff28e67e"
+  integrity sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==
 
 jsdom@^16.6.0:
   version "16.7.0"


### PR DESCRIPTION
## Description

https://github.com/Agoric/agoric-sdk/pull/5410 required a lot of plumbing work to make the actual lint rule enable-able. This pulls that work out into a separate PR.

To make it a little more worthy, this also enables the `prefer-ts-expect-error` rule.

This also refactors config responsibilities to be in line with https://github.com/endojs/endo/pull/1201#issue-1256332542

Recommended to review by commit.

### Security Considerations

n/a

### Documentation Considerations

Reduces need for documenting ts-ignore vs ts-expect-error because the linting system will provide feedback.

### Testing Considerations

The collection of type information slowed down linting so it was postponed to #5410 