### PR TITLE
fix(agoric-cli): publishBundle types

### DIFF
--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -205,6 +205,7 @@ export const makeCosmosBundlePublisher = ({
 
 /**
  * @typedef HttpConnectionSpec
+ * @property {'http'} type
  * @property {string} host
  * @property {number} port
  */
@@ -224,7 +225,7 @@ export const makeCosmosBundlePublisher = ({
  */
 
 /**
- * @typedef {unknown} ConnectionSpec
+ * @typedef {HttpConnectionSpec | CosmosConnectionSpec} ConnectionSpec
  */
 
 /**
@@ -235,19 +236,16 @@ export const makeCosmosBundlePublisher = ({
  */
 
 /**
- * @callback PublishBundle
- * @param {SourceBundle} bundle
- * @param {HttpConnectionSpec | CosmosConnectionSpec} connectionSpec
- * @returns {Promise<Bundle>}
+ * @typedef {ReturnType<typeof makeBundlePublisher>} PublishBundle
  */
 
 /**
  * @param {SourceBundle} bundle
- * @param {ConnectionSpec} connectionSpec
+ * @param {ConnectionSpec | undefined} connectionSpec
  * @param {object} powers
  * @param {PublishBundleCosmos} [powers.publishBundleCosmos]
  * @param {PublishBundleHttp} [powers.publishBundleHttp]
- * @param {() => unknown} [powers.getDefaultConnection]
+ * @param {() => ConnectionSpec} [powers.getDefaultConnection]
  * @returns {Promise<Bundle>}
  */
 const publishBundle = async (
@@ -349,7 +347,7 @@ const publishBundle = async (
 export const makeBundlePublisher = powers => {
   /**
    * @param {SourceBundle} bundle
-   * @param {ConnectionSpec} connectionSpec
+   * @param {ConnectionSpec} [connectionSpec]
    */
   return async (bundle, connectionSpec) =>
     publishBundle(bundle, connectionSpec, powers);

--- a/packages/agoric-cli/test/test-publish-bundle.js
+++ b/packages/agoric-cli/test/test-publish-bundle.js
@@ -64,6 +64,7 @@ test('fake publish bundle not ok invalid connection type', async t => {
 
   await t.throwsAsync(
     publishBundle(bundle, {
+      // @ts-expect-error
       type: 'bogus',
     }),
   );
@@ -85,6 +86,7 @@ test('fake publish bundle not ok invalid HTTP connection spec non-string host', 
   await t.throwsAsync(
     publishBundle(bundle, {
       type: 'http',
+      // @ts-expect-error
       host: 1,
       port: 8080,
     }),


### PR DESCRIPTION
refs: https://github.com/Agoric/dapp-fungible-faucet/pull/46#discussion_r884026026

## Description

Trying to use `publishBundle` in the loadgen, but running into mis-typings.

### Security Considerations
None

### Documentation Considerations
Well improving types so improving docs?

### Testing Considerations
We don't have good coverage of this, but the loadgen is picky, and this satisfies it.
