### PR TITLE
fix: schema limit minting and offers

### DIFF
--- a/packages/ERTP/src/brand.js
+++ b/packages/ERTP/src/brand.js
@@ -1,14 +1,25 @@
 // @ts-check
+import { M } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+
+const { details: X, quote: q } = assert;
 
 /**
  * @param {string} allegedName
  * @param {(allegedIssuer: Issuer) => boolean} isMyIssuerNow
  * @param {DisplayInfo} displayInfo
+ * @param {AssetKind} assetKind
+ * @param {Pattern} elementSchema
  * @returns {Brand}
  */
-export const makeBrand = (allegedName, isMyIssuerNow, displayInfo) => {
+export const makeBrand = (
+  allegedName,
+  isMyIssuerNow,
+  displayInfo,
+  assetKind,
+  elementSchema,
+) => {
   /** @type {Brand} */
   const brand = Far(`${allegedName} brand`, {
     isMyIssuer: allegedIssuerP => E.when(allegedIssuerP, isMyIssuerNow),
@@ -17,6 +28,54 @@ export const makeBrand = (allegedName, isMyIssuerNow, displayInfo) => {
 
     // Give information to UI on how to display the amount.
     getDisplayInfo: () => displayInfo,
+
+    // eslint-disable-next-line no-use-before-define
+    getAmountSchema: () => amountSchema,
   });
+
+  let valueSchema;
+  switch (assetKind) {
+    case 'nat': {
+      valueSchema = M.nat();
+      assert(
+        elementSchema === undefined,
+        X`Fungible assets cannot have an elementSchema: ${q(elementSchema)}`,
+      );
+      break;
+    }
+    case 'set': {
+      if (elementSchema === undefined) {
+        valueSchema = M.arrayOf(M.key());
+      } else {
+        valueSchema = M.arrayOf(M.and(M.key(), elementSchema));
+      }
+      break;
+    }
+    case 'copySet': {
+      if (elementSchema === undefined) {
+        valueSchema = M.set();
+      } else {
+        valueSchema = M.setOf(elementSchema);
+      }
+      break;
+    }
+    case 'copyBag': {
+      if (elementSchema === undefined) {
+        valueSchema = M.bag();
+      } else {
+        valueSchema = M.bagOf(elementSchema);
+      }
+      break;
+    }
+    default: {
+      assert.fail(X`unexpected asset kind ${q(assetKind)}`);
+    }
+  }
+
+  const amountSchema = harden({
+    brand, // matches only this exact brand
+    value: valueSchema,
+  });
+
   return brand;
 };

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -21,6 +21,7 @@ import '@agoric/store/exported.js';
  * @param {Brand} brand
  * @param {AssetKind} assetKind
  * @param {DisplayInfo} displayInfo
+ * @param {Pattern} amountSchema
  * @param {ShutdownWithFailure=} optShutdownWithFailure
  * @returns {{ issuer: Issuer<K>, mint: Mint<K> }}
  */
@@ -29,6 +30,7 @@ export const makePaymentLedger = (
   brand,
   assetKind,
   displayInfo,
+  amountSchema,
   optShutdownWithFailure = undefined,
 ) => {
   const makePayment = definePaymentKind(allegedName, brand);
@@ -314,6 +316,7 @@ export const makePaymentLedger = (
    */
   const mintPayment = newAmount => {
     newAmount = coerce(newAmount);
+    fit(newAmount, amountSchema);
     const payment = makePayment();
     initPayment(payment, newAmount, undefined);
     return payment;

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -112,6 +112,7 @@
  * @property {() => string} getAllegedName
  * @property {() => DisplayInfo} getDisplayInfo
  * Give information to UI on how to display the amount.
+ * @property {() => Pattern} getAmountSchema
  */
 
 /**

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -1,6 +1,7 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { M } from '@agoric/store';
 
 import { Far } from '@endo/marshal';
 import { AmountMath as m, AssetKind } from '../../../src/index.js';
@@ -66,6 +67,7 @@ test('natMathHelpers coerce', t => {
             getAllegedName: () => 'somename',
             isMyIssuer: async () => false,
             getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
+            getAmountSchema: () => M.any(),
           }),
           value: 4n,
         }),
@@ -193,6 +195,7 @@ test('natMathHelpers isGTE mixed brands', t => {
             getAllegedName: () => 'somename',
             isMyIssuer: async () => false,
             getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
+            getAmountSchema: () => M.any(),
           }),
           5n,
         ),
@@ -214,6 +217,7 @@ test(`natMathHelpers isGTE - brands don't match objective brand`, t => {
           getAllegedName: () => 'somename',
           isMyIssuer: async () => false,
           getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
+          getAmountSchema: () => M.any(),
         }),
       ),
     {
@@ -242,6 +246,7 @@ test('natMathHelpers isEqual mixed brands', t => {
             getAllegedName: () => 'somename',
             isMyIssuer: async () => false,
             getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
+            getAmountSchema: () => M.any(),
           }),
           4n,
         ),
@@ -263,6 +268,7 @@ test(`natMathHelpers isEqual - brands don't match objective brand`, t => {
           getAllegedName: () => 'somename',
           isMyIssuer: async () => false,
           getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
+          getAmountSchema: () => M.any(),
         }),
       ),
     {
@@ -288,6 +294,7 @@ test('natMathHelpers add mixed brands', t => {
             getAllegedName: () => 'somename',
             isMyIssuer: async () => false,
             getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
+            getAmountSchema: () => M.any(),
           }),
           5n,
         ),
@@ -309,6 +316,7 @@ test(`natMathHelpers add - brands don't match objective brand`, t => {
           getAllegedName: () => 'somename',
           isMyIssuer: async () => false,
           getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
+          getAmountSchema: () => M.any(),
         }),
       ),
     {
@@ -334,6 +342,7 @@ test('natMathHelpers subtract mixed brands', t => {
             getAllegedName: () => 'somename',
             isMyIssuer: async () => false,
             getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
+            getAmountSchema: () => M.any(),
           }),
           6n,
         ),
@@ -355,6 +364,7 @@ test(`natMathHelpers subtract brands don't match brand`, t => {
           getAllegedName: () => 'somename',
           isMyIssuer: async () => false,
           getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
+          getAmountSchema: () => M.any(),
         }),
       ),
     {

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -1,10 +1,8 @@
 // @ts-check
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { Far } from '@endo/marshal';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { assert } from '@agoric/assert';
+import { M } from '@agoric/store';
 
 import { makeIssuerKit, AssetKind, AmountMath } from '../../src/index.js';
 
@@ -26,7 +24,13 @@ test('mint.mintPayment default nat AssetKind', async t => {
 });
 
 test('mint.mintPayment set w strings AssetKind', async t => {
-  const { mint, issuer, brand } = makeIssuerKit('items', AssetKind.SET);
+  const { mint, issuer, brand } = makeIssuerKit(
+    'items',
+    AssetKind.SET,
+    undefined,
+    undefined,
+    { elementSchema: M.string() },
+  );
   const items1and2and4 = AmountMath.make(brand, harden(['1', '2', '4']));
   const payment1 = mint.mintPayment(items1and2and4);
   const paymentBalance1 = await issuer.getAmountOf(payment1);
@@ -36,6 +40,11 @@ test('mint.mintPayment set w strings AssetKind', async t => {
   const payment2 = mint.mintPayment(items5and6);
   const paymentBalance2 = await issuer.getAmountOf(payment2);
   t.assert(AmountMath.isEqual(paymentBalance2, items5and6));
+
+  const badAmount = AmountMath.make(brand, harden([['badElement']]));
+  t.throws(() => mint.mintPayment(badAmount), {
+    message: / - Must have passStyle or tag "string"/,
+  });
 });
 
 test('mint.mintPayment set AssetKind', async t => {

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -100,6 +100,7 @@
  * that handles the offer, such as saving it or performing a trade
  * @param {string} description
  * @param {object=} customProperties
+ * @param {Pattern} [proposalSchema]
  * @returns {Promise<Invitation<OR>>}
  */
 

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -6,6 +6,7 @@ import { Far, Remotable, passStyleOf } from '@endo/marshal';
 import { AssetKind, AmountMath } from '@agoric/ertp';
 import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import { makePromiseKit } from '@endo/promise-kit';
+import { assertPattern } from '@agoric/store';
 
 import { cleanProposal, coerceAmountKeywordRecord } from '../cleanProposal.js';
 import { evalContractBundle } from './evalContractCode.js';
@@ -273,12 +274,16 @@ export const makeZCFZygote = (
       offerHandler = Far('default offer handler', () => {}),
       description,
       customProperties = harden({}),
+      proposalSchema = undefined,
     ) => {
       assert.typeof(
         description,
         'string',
         X`invitations must have a description string: ${description}`,
       );
+      if (proposalSchema !== undefined) {
+        assertPattern(proposalSchema);
+      }
 
       const invitationHandle = storeOfferHandler(offerHandler);
       /** @type {Promise<Payment>} */
@@ -286,6 +291,7 @@ export const makeZCFZygote = (
         invitationHandle,
         description,
         customProperties,
+        proposalSchema,
       );
       return invitationP;
     },

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -99,6 +99,7 @@
  * @param {InvitationHandle} invitationHandle
  * @param {string} description
  * @param {Record<string, any>=} customProperties
+ * @param {Pattern} [proposalSchema]
  * @returns {Payment}
  */
 
@@ -137,6 +138,7 @@
  * @param {Keyword} keyword
  * @param {AssetKind=} assetKind
  * @param {AdditionalDisplayInfo=} displayInfo
+ * @param {Partial<{elementSchema: Pattern}>} [options]
  * @returns {ZoeMint}
  */
 

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -53,3 +53,10 @@ export const isAfterDeadlineExitRule = exit => {
   const [exitKey] = Object.getOwnPropertyNames(exit);
   return exitKey === 'afterDeadline';
 };
+
+export const InvitationElementShape = M.split({
+  description: M.string(),
+  handle: M.remotable(), // invitationHandle
+  instance: M.remotable(),
+  installation: M.remotable(),
+});

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -114,6 +114,12 @@
  */
 
 /**
+ * @callback GetProposalSchemaForInvitation
+ * @param {InvitationHandle} invitationHandle
+ * @returns {Pattern | undefined}
+ */
+
+/**
  * @typedef ZoeStorageManager
  * @property {MakeZoeInstanceStorageManager} makeZoeInstanceStorageManager
  * @property {GetAssetKindByBrand} getAssetKindByBrand
@@ -129,6 +135,7 @@
  * @property {GetInstallationForInstance} getInstallationForInstance
  * @property {GetInstanceAdmin} getInstanceAdmin
  * @property {UnwrapInstallation} unwrapInstallation
+ * @property {GetProposalSchemaForInvitation} getProposalSchemaForInvitation
  */
 
 /**

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
+import { InvitationElementShape } from '../typeGuards.js';
 
 /**
  * @param {ShutdownWithFailure | undefined} shutdownZoeVat
@@ -11,14 +12,16 @@ export const createInvitationKit = (shutdownZoeVat = undefined) => {
     AssetKind.SET,
     undefined,
     shutdownZoeVat,
+    { elementSchema: InvitationElementShape },
   );
 
   /**
    * @param {Instance} instance
    * @param {Installation} installation
+   * @param {MapStore<InvitationHandle, Pattern>} proposalSchemas
    * @returns {ZoeInstanceAdminMakeInvitation}
    */
-  const setupMakeInvitation = (instance, installation) => {
+  const setupMakeInvitation = (instance, installation, proposalSchemas) => {
     assert.typeof(instance, 'object');
     assert.typeof(installation, 'object');
 
@@ -26,7 +29,8 @@ export const createInvitationKit = (shutdownZoeVat = undefined) => {
     const makeInvitation = async (
       invitationHandle,
       description,
-      customProperties,
+      customProperties = undefined,
+      proposalSchema = undefined,
     ) => {
       assert.typeof(invitationHandle, 'object');
       assert.typeof(
@@ -54,6 +58,9 @@ export const createInvitationKit = (shutdownZoeVat = undefined) => {
           },
         ]),
       );
+      if (proposalSchema !== undefined) {
+        proposalSchemas.init(invitationHandle, proposalSchema);
+      }
       return invitationKit.mint.mintPayment(invitationAmount);
     };
     return makeInvitation;

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -18,7 +18,7 @@ export const createInvitationKit = (shutdownZoeVat = undefined) => {
   /**
    * @param {Instance} instance
    * @param {Installation} installation
-   * @param {MapStore<InvitationHandle, Pattern>} proposalSchemas
+   * @param {WeakMapStore<InvitationHandle, Pattern>} proposalSchemas
    * @returns {ZoeInstanceAdminMakeInvitation}
    */
   const setupMakeInvitation = (instance, installation, proposalSchemas) => {

--- a/packages/zoe/src/zoeService/offer/burnInvitation.js
+++ b/packages/zoe/src/zoeService/offer/burnInvitation.js
@@ -31,10 +31,10 @@ export const burnInvitation = (invitationIssuer, invitation) => {
     );
     const [{ instance: instanceHandle, handle: invitationHandle }] =
       invitationValue;
-    return {
+    return harden({
       instanceHandle,
       invitationHandle,
-    };
+    });
   };
 
   return E.when(

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { passStyleOf } from '@endo/marshal';
+import { fit } from '@agoric/store';
 
 import { cleanProposal } from '../../cleanProposal.js';
 import { burnInvitation } from './burnInvitation.js';
@@ -16,6 +17,7 @@ const { details: X, quote: q } = assert;
  * @param {GetInstanceAdmin} getInstanceAdmin
  * @param {DepositPayments} depositPayments
  * @param {GetAssetKindByBrand} getAssetKindByBrand
+ * @param {GetProposalSchemaForInvitation} getProposalSchemaForInvitation
  * @returns {Offer}
  */
 export const makeOfferMethod = (
@@ -23,6 +25,7 @@ export const makeOfferMethod = (
   getInstanceAdmin,
   depositPayments,
   getAssetKindByBrand,
+  getProposalSchemaForInvitation,
 ) => {
   /** @type {Offer} */
   const offer = async (
@@ -41,6 +44,10 @@ export const makeOfferMethod = (
     instanceAdmin.assertAcceptingOffers();
 
     const proposal = cleanProposal(uncleanProposal, getAssetKindByBrand);
+    const proposalSchema = getProposalSchemaForInvitation(invitationHandle);
+    if (proposalSchema !== undefined) {
+      fit(proposal, proposalSchema);
+    }
 
     if (offerArgs !== undefined) {
       const passStyle = passStyleOf(offerArgs);

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -47,6 +47,7 @@
  * code breaks.
  * @property {GetConfiguration} getConfiguration
  * @property {GetBundleIDFromInstallation} getBundleIDFromInstallation
+ * @property {GetProposalSchemaForInvitation} getProposalSchemaForInvitation
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -87,6 +87,7 @@ const makeZoeKit = (
     getInstallationForInstance,
     getInstanceAdmin,
     invitationIssuer,
+    getProposalSchemaForInvitation,
   } = makeZoeStorageManager(
     createZCFVat,
     getBundleCapFromID,
@@ -109,6 +110,7 @@ const makeZoeKit = (
     getInstanceAdmin,
     depositPayments,
     getAssetKindByBrand,
+    getProposalSchemaForInvitation,
   );
 
   // Make the methods that allow users to easily and credibly get
@@ -154,6 +156,7 @@ const makeZoeKit = (
     getInvitationDetails,
     getConfiguration,
     getBundleIDFromInstallation,
+    getProposalSchemaForInvitation,
   });
 
   // startInstance must pass the ZoeService to the newly created ZCF

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -2,7 +2,7 @@
 
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { Far } from '@endo/marshal';
-import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { makeScalarBigWeakMapStore } from '@agoric/vat-data';
 
 import { makeIssuerStorage } from '../issuerStorage.js';
 import { makeAndStoreInstanceRecord } from '../instanceRecordStorage.js';
@@ -92,7 +92,7 @@ export const makeZoeStorageManager = (
     getBundleIDFromInstallation,
   } = makeInstallationStorage(getBundleCapForID);
 
-  const proposalSchemas = makeScalarBigMapStore('proposal schemas');
+  const proposalSchemas = makeScalarBigWeakMapStore('proposal schemas');
 
   const getProposalSchemaForInvitation = invitationHandle => {
     if (proposalSchemas.has(invitationHandle)) {

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -10,11 +10,7 @@ import bundleSource from '@endo/bundle-source';
 import { setup } from '../setupBasicMints.js';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
-import {
-  offerTo,
-  assertProposalShape,
-  swapExact,
-} from '../../../src/contractSupport/zoeHelpers.js';
+import { offerTo, swapExact } from '../../../src/contractSupport/zoeHelpers.js';
 import { makeOffer } from '../makeOffer.js';
 
 const filename = new URL(import.meta.url).pathname;
@@ -103,25 +99,28 @@ test(`offerTo - basic usage`, async t => {
 
   const successMsg = 'offer to contractB successful';
 
-  const offerHandler = seat => {
-    assertProposalShape(seat, {
-      give: {
-        TokenM: null,
-      },
-      want: {
-        TokenL: null,
-      },
-      exit: {
-        onDemand: null,
-      },
-    });
+  const proposalBSchema = harden({
+    give: {
+      TokenM: bucksIssuer.getBrand().getAmountSchema(),
+    },
+    want: {
+      TokenL: moolaIssuer.getBrand().getAmountSchema(),
+    },
+    // multiples: 1n,
+    exit: {
+      onDemand: null,
+    },
+  });
 
+  const offerHandler = seat => {
     swapExact(zcfB, contractBCollateralSeat, seat);
     return successMsg;
   };
   const contractBInvitation = zcfB.makeInvitation(
     offerHandler,
     'contractB invitation',
+    undefined,
+    proposalBSchema,
   );
 
   // Map the keywords in contract A to the keywords in contract B

--- a/packages/zoe/test/unitTests/makeOffer.js
+++ b/packages/zoe/test/unitTests/makeOffer.js
@@ -8,14 +8,26 @@ import { assert } from '@agoric/assert';
  * @param {ZCF} zcf
  * @param {Proposal=} proposal
  * @param {PaymentPKeywordRecord=} payments
+ * @param {Pattern} [proposalSchema]
  * @returns {Promise<{zcfSeat: ZCFSeat, userSeat: UserSeat}>}
  */
-export const makeOffer = async (zoe, zcf, proposal, payments) => {
+export const makeOffer = async (
+  zoe,
+  zcf,
+  proposal,
+  payments,
+  proposalSchema = undefined,
+) => {
   let zcfSeat;
   const getSeat = seat => {
     zcfSeat = seat;
   };
-  const invitationP = zcf.makeInvitation(getSeat, 'seat');
+  const invitationP = zcf.makeInvitation(
+    getSeat,
+    'seat',
+    undefined,
+    proposalSchema,
+  );
   const userSeat = await E(zoe).offer(invitationP, proposal, payments);
   assert(zcfSeat);
   return { zcfSeat, userSeat };

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -195,8 +195,7 @@ test(`zcf.saveIssuer - bad issuer`, async t => {
   await t.throwsAsync(() => zcf.saveIssuer(moolaKit.brand, 'A'), {
     // TODO: improve error message
     // https://github.com/Agoric/agoric-sdk/issues/1701
-    message:
-      'target has no method "getBrand", has ["getAllegedName","getDisplayInfo","isMyIssuer"]',
+    message: /target has no method "getBrand", has /,
   });
 });
 

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -623,7 +623,7 @@ test(`zcf/zoeHelper - assertProposalShape w/bad Expected`, async t => {
     { B: simoleanMint.mintPayment(simoleans(3n)) },
   );
 
-  // @ts-expect-error
+  // @ts-expect-error purposeful type violation to test enforcement
   t.throws(() => assertProposalShape(zcfSeat, { give: { B: moola(3n) } }), {
     message: /The value of the expected record must be null but was .*/,
   });

--- a/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
+++ b/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
@@ -3,20 +3,28 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { AmountMath } from '@agoric/ertp';
-
 import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
+
 import { createInvitationKit } from '../../../src/zoeService/makeInvitation.js';
+
+const proposalSchemas = makeScalarBigMapStore('proposal schemas');
 
 test('createInvitationKit', async t => {
   const { setupMakeInvitation, invitationIssuer } = createInvitationKit();
 
-  const mockInstance = harden({});
-  const mockInstallation = harden({});
+  const mockInstance = Far('mockInstance', {});
+  const mockInstallation = Far('mockInstallation', {});
 
-  // @ts-expect-error mockInstance is mocked
-  const makeInvitation = setupMakeInvitation(mockInstance, mockInstallation);
+  const makeInvitation = setupMakeInvitation(
+    // @ts-expect-error mockInstance is mocked
+    mockInstance,
+    mockInstallation,
+    proposalSchemas,
+  );
 
-  const mockInvitationHandle = harden({});
+  const mockInvitationHandle = Far('mockInvitationHandle', {});
   const description = 'myInvitation';
   const customProperties = harden({
     fruit: 'apple',
@@ -52,21 +60,24 @@ test('createInvitationKit', async t => {
 test('description is omitted, wrongly', async t => {
   const { setupMakeInvitation } = createInvitationKit();
 
-  const mockInstance = harden({});
-  const mockInstallation = harden({});
+  const mockInstance = Far('mockInstance', {});
+  const mockInstallation = Far('mockInstallation', {});
 
-  // @ts-expect-error mockInstance is mocked
-  const makeInvitation = setupMakeInvitation(mockInstance, mockInstallation);
+  const makeInvitation = setupMakeInvitation(
+    // @ts-expect-error mockInstance is mocked
+    mockInstance,
+    mockInstallation,
+    proposalSchemas,
+  );
 
-  const mockInvitationHandle = harden({});
+  const mockInvitationHandle = Far('mockInvitationHandle', {});
   const description = undefined;
   const customProperties = harden({
     fruit: 'apple',
   });
 
   await t.throwsAsync(
-    // @ts-expect-error
-    () =>
+    async () =>
       makeInvitation(
         // @ts-expect-error mockInvitationHandle is mocked
         mockInvitationHandle,
@@ -80,13 +91,17 @@ test('description is omitted, wrongly', async t => {
 test('customProperties ok to omit', async t => {
   const { setupMakeInvitation, invitationIssuer } = createInvitationKit();
 
-  const mockInstance = harden({});
-  const mockInstallation = harden({});
+  const mockInstance = Far('mockInstance', {});
+  const mockInstallation = Far('mockInstallation', {});
 
-  // @ts-expect-error mockInstance is mocked
-  const makeInvitation = setupMakeInvitation(mockInstance, mockInstallation);
+  const makeInvitation = setupMakeInvitation(
+    // @ts-expect-error mockInstance is mocked
+    mockInstance,
+    mockInstallation,
+    proposalSchemas,
+  );
 
-  const mockInvitationHandle = harden({});
+  const mockInvitationHandle = Far('mockInvitationHandle', {});
   const description = 'myInvitation';
 
   const invitation = makeInvitation(

--- a/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
+++ b/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
@@ -5,11 +5,11 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { makeScalarBigWeakMapStore } from '@agoric/vat-data';
 
 import { createInvitationKit } from '../../../src/zoeService/makeInvitation.js';
 
-const proposalSchemas = makeScalarBigMapStore('proposal schemas');
+const proposalSchemas = makeScalarBigWeakMapStore('proposal schemas');
 
 test('createInvitationKit', async t => {
   const { setupMakeInvitation, invitationIssuer } = createInvitationKit();


### PR DESCRIPTION
Introduce patterns in some strategic places to do earlier or better conformance checking of passables against some requirements.

This PR introduces an optional `elementSchema` pattern to `makeIssuerKit` for use with non-fungible or semi-fungible assets, where each asset description must match the pattern. Thus, for example, the invitation issuer knows the schema that all invitation amount elements need to satisfy. Minting a malformed invitation amount element could be caught earlier and more reliably.

The `brand`, `assetType`, and optional `elementSchema` together determine the `amountSchema`, which is the pattern than valid amounts for that issuer need to satisfy. For example, an invitation amount must have the invitation brand, and its value must represent a set (currently by an array) each of whose elements satisfy the invitation element schema. Anyone knowing the brand can ask it for the amount pattern and check their own amounts against it. They can do this with remote brands, since patterns are pass-by-copy, and pattern matching is pass-invariant.

This PR introduces an optional `proposalSchema` as an additional optional argument to `makeInvitation`. A contract could use this rather than the current ad-hoc `assertProposalShape`. As a result, an offer with a proposal that doesn't match would be rejected by zoe, never reaching the contract.