### PR TITLE
fix: addLiquidity wasn't validating brand of want

### DIFF
--- a/packages/run-protocol/src/vpool-xyk-amm/addLiquidity.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addLiquidity.js
@@ -22,9 +22,17 @@ const makeMakeAddLiquidityInvitation = (zcf, getPool) => {
         Secondary: null,
       },
     });
+
     // Get the brand of the secondary token so we can identify the liquidity pool.
     const secondaryBrand = seat.getProposal().give.Secondary.brand;
+
     const pool = getPool(secondaryBrand);
+    const liquidityBrand = pool.getLiquidityIssuer().getBrand();
+    assert(
+      seat.getProposal().want.Liquidity.brand === liquidityBrand,
+      `liquidity brand must be ${liquidityBrand}`,
+    );
+
     return pool.addLiquidity(seat);
   };
 

--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -238,8 +238,6 @@ const poolBehavior = {
       ),
     );
 
-    state.liqTokenSupply -= liquidityValueIn;
-
     poolSeat.incrementBy(
       userSeat.decrementBy(harden({ Liquidity: liquidityIn })),
     );
@@ -252,6 +250,7 @@ const poolBehavior = {
       ),
     );
     state.zcf.reallocate(userSeat, poolSeat);
+    state.liqTokenSupply -= liquidityValueIn;
 
     userSeat.exit();
     updateUpdaterState(state.updater, facets.pool);


### PR DESCRIPTION
closes: #5293

## Description

`addLiquidity()` wasn't validating the brand of want, which was allowing it to increment `liqTokenSupply` before failing.

I also moved the decrement to `liqTokenSupply` in `removeLiquidity()` after
`reallocate()`, since that's what will fail if those brands aren't correct.

### Security Considerations

No security impact.

### Documentation Considerations

No doc changes required

### Testing Considerations

added a test for `addLiquidity()`.