### PR TITLE
eslint warn floating promises

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,18 +1,23 @@
 /* eslint-env node */
+const process = require('process');
+const lintTypes = !!process.env.AGORIC_ESLINT_TYPES;
+
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  parserOptions: {
-    sourceType: 'module',
-    project: [
-      './packages/*/jsconfig.json',
-      './packages/*/tsconfig.json',
-      './packages/wallet/*/jsconfig.json',
-      './tsconfig.json',
-    ],
-    tsconfigRootDir: __dirname,
-    extraFileExtensions: ['.cjs'],
-  },
+  parserOptions: lintTypes
+    ? {
+        sourceType: 'module',
+        project: [
+          './packages/*/jsconfig.json',
+          './packages/*/tsconfig.json',
+          './packages/wallet/*/jsconfig.json',
+          './tsconfig.json',
+        ],
+        tsconfigRootDir: __dirname,
+        extraFileExtensions: ['.cjs'],
+      }
+    : undefined,
   plugins: [
     '@jessie.js/eslint-plugin',
     '@typescript-eslint',
@@ -22,7 +27,7 @@ module.exports = {
   extends: ['@agoric'],
   rules: {
     '@typescript-eslint/prefer-ts-expect-error': 'warn',
-    '@typescript-eslint/no-floating-promises': 'warn',
+    '@typescript-eslint/no-floating-promises': lintTypes ? 'warn' : 'off',
     // so that floating-promises can be explicitly permitted with void operator
     'no-void': ['error', { allowAsStatement: true }],
     'jsdoc/no-multi-asterisks': 'off',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,6 +2,17 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
+  parserOptions: {
+    sourceType: 'module',
+    project: [
+      './packages/*/jsconfig.json',
+      './packages/*/tsconfig.json',
+      './packages/wallet/*/jsconfig.json',
+      './tsconfig.json',
+    ],
+    tsconfigRootDir: __dirname,
+    extraFileExtensions: ['.cjs'],
+  },
   plugins: [
     '@jessie.js/eslint-plugin',
     '@typescript-eslint',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,9 @@ module.exports = {
   extends: ['@agoric'],
   rules: {
     '@typescript-eslint/prefer-ts-expect-error': 'warn',
+    '@typescript-eslint/no-floating-promises': 'warn',
+    // so that floating-promises can be explicitly permitted with void operator
+    'no-void': ['error', { allowAsStatement: true }],
     'jsdoc/no-multi-asterisks': 'off',
     'jsdoc/multiline-blocks': 'off',
     // Use these rules to warn about JSDoc type problems, such as after

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -23,17 +23,40 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-  lint:
+  ##################
+  # Lint tests
+  # We run per package bc of https://github.com/typescript-eslint/typescript-eslint/issues/1192
+  # We split the package tests into two jobs because type linting
+  # is inefficient and slow https://github.com/typescript-eslint/typescript-eslint/issues/2094
+  lint-primary:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: '14.x'
+          node-version: '16.x'
 
-      - name: lint check
-        run: yarn lint
+      # first job also does repo-level linting
+      - name: lint repo format
+        run: yarn lint:format
+      # eslint
+      - name: yarn lint primary
+        # run on packages that use roughly half the time
+        run: yarn lerna run --scope=@agoric/{cosmos,ertp,governance,run-protocol,swing-store,swingset-vat,vats,wallet,zoe} --no-bail lint
+
+  lint-rest:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/restore-node
+        with:
+          node-version: '16.x'
+
+      - name: yarn lint rest
+        # invert selection of lint-primary (--ignore instead of --scope)
+        run: yarn lerna run --ignore=@agoric/{cosmos,ertp,governance,run-protocol,swing-store,swingset-vat,vats,wallet,zoe} --no-bail lint
 
   ##################
   # Fast-running tests run as a group:

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -42,8 +42,7 @@ jobs:
         run: yarn lint:format
       # eslint
       - name: yarn lint primary
-        # run on packages that use roughly half the time
-        run: yarn lerna run --scope=@agoric/{cosmos,ertp,governance,run-protocol,swing-store,swingset-vat,vats,wallet,zoe} --no-bail lint
+        run: ./scripts/lint-with-types.sh primary
 
   lint-rest:
     needs: build
@@ -55,8 +54,7 @@ jobs:
           node-version: '16.x'
 
       - name: yarn lint rest
-        # invert selection of lint-primary (--ignore instead of --scope)
-        run: yarn lerna run --ignore=@agoric/{cosmos,ertp,governance,run-protocol,swing-store,swingset-vat,vats,wallet,zoe} --no-bail lint
+        run: ./scripts/lint-with-types.sh rest
 
   ##################
   # Fast-running tests run as a group:

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -63,11 +63,6 @@
     ],
     "timeout": "10m"
   },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/wallet/ui/package.json
+++ b/packages/wallet/ui/package.json
@@ -81,7 +81,8 @@
       "react/prop-types": "off",
       "react/react-in-jsx-scope": "off",
       "import/no-extraneous-dependencies": "off",
-      "react/display-name": "off"
+      "react/display-name": "off",
+      "@typescript-eslint/no-floating-promises": "off"
     },
     "env": {
       "browser": true,

--- a/scripts/lint-with-types.sh
+++ b/scripts/lint-with-types.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# we don't collect type info by default because it can slow eslint by 8-10x
+export AGORIC_ESLINT_TYPES='true'
+# CI and some VMs OOM without this
+export NODE_OPTIONS='--max-old-space-size=8192'
+
+# argument used by CI to split this across two jobs
+SCOPE=$1
+
+# taking roughly half the time to eslint all packages
+PRIMARY_PACKAGES="@agoric/{cosmos,ertp,governance,run-protocol,swing-store,swingset-vat,vats,wallet,zoe}"
+
+case $SCOPE in
+primary)
+    yarn lerna run --scope=$PRIMARY_PACKAGES --no-bail lint
+    ;;
+rest)
+    yarn lerna run --ignore=$PRIMARY_PACKAGES --no-bail lint
+    ;;
+*)
+    # all scopes
+    yarn lint
+    ;;
+esac


### PR DESCRIPTION
closes: #5407

## Description

Enable [no-floating-promises](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-floating-promises.md). This defers solving all the floating promises by using `warn` level instead of `error`. Eventually we'll want to `error` but I propose we get there incrementally, distributed among teams.

This [rule from @typescript-eslint](https://typescript-eslint.io/rules/) is the first we've enabled to require type information (by setting `parserOptions.project`) . That increases the time cost of linting. Measured with `time yarn lerna run --no-bail lint:eslint` on my machine:
- before: 84.86s user 5.35s system 454% cpu 19.827 total (1.4min)
- after: 824.27s user 135.32s system 556% cpu 2:52.39 total (14min)

In CI the lint job went from [5 min before](https://github.com/Agoric/agoric-sdk/runs/6693643820?check_suite_focus=true) to [21 min after](https://github.com/Agoric/agoric-sdk/runs/6694898124?check_suite_focus=true). To prevent developers having to wait longer for PRs to complete, this splits the lint job into two `lint-primary` and `lint-rest`. 

The comments in that job config note that performance could be greatly improved if the linter were able to [reuse type information across projects](https://github.com/typescript-eslint/typescript-eslint/issues/2094). Alternately we could [unify the packages into one TypeScript project](https://github.com/Agoric/agoric-sdk/pull/4404).

I also tried cutting the lint job time by shortening the setup step, replacing `restore-node` with `setup-node` and yarn install from cache. This cut [5min setup time](https://github.com/Agoric/agoric-sdk/runs/6710173722?check_suite_focus=true) down to [2min](https://github.com/Agoric/agoric-sdk/runs/6710773587?check_suite_focus=true).  (Saving 6min compute over the two jobs.) But it failed because there are build artifacts the linting depends on, such as:
- eslint `import/no-unresolved` fails when `@agoric/ui-components` isn't built
- typescript cannot find module '../bundles/bundle-contractFacet.js' in ./zoe/tools/fakeVatAdmin.js (maybe this one should use bundleCache instead?)

### Security Considerations

--

### Documentation Considerations

Notify developers that they'll begin seeing new warnings and that the Github PR annotations may show many more in the code review web UI.

### Testing Considerations

Verified that lint jobs are not the slowest zebra: iIn last run lint-primary (10m) and lint-rest (12m) were both less than test-cosmic-swingset (13m) and test-swingset3 (13min).