### PR TITLE
jessie-check contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "devDependencies": {
     "@endo/eslint-config": "^0.4.10",
-    "@jessie.js/eslint-plugin": "^0.1.3",
+    "@jessie.js/eslint-plugin": "^0.2.0",
     "@types/node": "^16.7.10",
     "@typescript-eslint/parser": "^5.27.0",
     "ava": "^3.15.0",

--- a/packages/deploy-script-support/src/endo-pieces-contract.js
+++ b/packages/deploy-script-support/src/endo-pieces-contract.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 import { E, Far } from '@endo/far';
 import { encodeBase64, decodeBase64 } from '@endo/base64';
 import { ZipWriter } from '@endo/zip';

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -26,7 +26,7 @@
   ],
   "peerDependencies": {
     "@endo/eslint-config": "^0.4.10",
-    "@jessie.js/eslint-plugin": "^0.1.3",
+    "@jessie.js/eslint-plugin": "^0.2.0",
     "@typescript-eslint/parser": "^5.27.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';

--- a/packages/governance/src/noActionElectorate.js
+++ b/packages/governance/src/noActionElectorate.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { Far } from '@endo/marshal';
 import { makeSubscriptionKit } from '@agoric/notifier';

--- a/packages/run-protocol/src/econCommitteeCharter.js
+++ b/packages/run-protocol/src/econCommitteeCharter.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import '@agoric/governance/src/exported.js';
 import '@agoric/zoe/exported.js';

--- a/packages/run-protocol/src/psm/psm.js
+++ b/packages/run-protocol/src/psm/psm.js
@@ -1,4 +1,6 @@
 // @ts-check
+// @jessie-check
+
 import '@agoric/zoe/exported.js';
 import '@agoric/zoe/src/contracts/exported.js';
 import '@agoric/governance/src/exported.js';

--- a/packages/run-protocol/src/reserve/assetReserve.js
+++ b/packages/run-protocol/src/reserve/assetReserve.js
@@ -247,11 +247,11 @@ const start = async (zcf, privateArgs) => {
     const collateralKeyword = getKeywordForBrand(collateralAmount.brand);
     if (
       !AmountMath.isGTE(
-        collateralSeat.getCurrentAllocation()[collateralKeyword],
+        collateralSeat.getCurrentAllocation()[+collateralKeyword],
         collateralAmount,
       )
     ) {
-      throw new Error('insufficient reserves for that transaction');
+      throw assert.fail('insufficient reserves for that transaction');
     }
 
     // create the RUN

--- a/packages/run-protocol/src/reserve/assetReserve.js
+++ b/packages/run-protocol/src/reserve/assetReserve.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { E, Far } from '@endo/far';
 import { makeStore } from '@agoric/store';

--- a/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-await-in-loop */
 // @ts-check
+// @jessie-check
 
 import { E } from '@endo/eventual-send';
 import {

--- a/packages/run-protocol/src/vaultFactory/liquidateMinimum.js
+++ b/packages/run-protocol/src/vaultFactory/liquidateMinimum.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { E } from '@endo/eventual-send';
 import {

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import '@agoric/governance/src/exported.js';
 import '@agoric/zoe/exported.js';

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { makeStore, makeWeakStore } from '@agoric/store';
 import { Far } from '@endo/marshal';

--- a/packages/vats/src/centralSupply.js
+++ b/packages/vats/src/centralSupply.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { AmountMath } from '@agoric/ertp';
 import { E, Far } from '@endo/far';

--- a/packages/wallet/api/test/attestationExample.js
+++ b/packages/wallet/api/test/attestationExample.js
@@ -1,4 +1,6 @@
 // @ts-check
+// @jessie-check
+
 import '@agoric/zoe/exported.js';
 import { AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -53,7 +53,8 @@
     "@endo/far": "^0.2.3",
     "@endo/import-bundle": "^0.2.45",
     "@endo/marshal": "^0.6.7",
-    "@endo/promise-kit": "^0.2.41"
+    "@endo/promise-kit": "^0.2.41",
+    "jessie.js": "^0.3.0"
   },
   "devDependencies": {
     "@agoric/deploy-script-support": "^0.9.0",

--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { Far } from '@endo/marshal';
 

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -4,6 +4,7 @@
 import { Far } from '@endo/marshal';
 import { assert } from '@agoric/assert';
 import { AmountMath, isNatValue } from '@agoric/ertp';
+import { makeMap } from 'jessie.js';
 
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
@@ -71,7 +72,7 @@ const start = async zcf => {
   const { brands } = zcf.getTerms();
   Object.values(brands).forEach(brand => assertNatAssetKind(zcf, brand));
   /** @type {Map<Brand,Keyword>} */
-  const brandToKeyword = new Map(
+  const brandToKeyword = makeMap(
     Object.entries(brands).map(([keyword, brand]) => [brand, keyword]),
   );
   /**

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { Far } from '@endo/marshal';
 import { assert } from '@agoric/assert';

--- a/packages/zoe/src/contracts/barterExchange.js
+++ b/packages/zoe/src/contracts/barterExchange.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { Far } from '@endo/marshal';
 import { makeLegacyMap } from '@agoric/store';

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import '../../../exported.js';
 import './types.js';

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import '../../../exported.js';
 import './types.js';

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { assert } from '@agoric/assert';
 import { M, fit } from '@agoric/store';

--- a/packages/zoe/src/contracts/loan/index.js
+++ b/packages/zoe/src/contracts/loan/index.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import '../../../exported.js';
 

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@endo/marshal';

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { E } from '@endo/eventual-send';
 import { assert } from '@agoric/assert';

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -8,6 +8,7 @@ import { makeNotifierKit } from '@agoric/notifier';
 import { makeLegacyMap } from '@agoric/store';
 import { Nat, isNat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';
+import { makeSet } from 'jessie.js';
 import {
   calculateMedian,
   natSafeMath,
@@ -295,7 +296,9 @@ const start = async (
     }
 
     const roundTimedOut = timedOut(_roundId, blockTimestamp);
-    if (!roundTimedOut) return;
+    if (!roundTimedOut) {
+      return;
+    }
 
     const prevId = subtract(_roundId, 1);
 
@@ -348,10 +351,13 @@ const start = async (
    * @param {bigint} blockTimestamp
    */
   const oracleInitializeNewRound = (_roundId, _oracle, blockTimestamp) => {
-    if (!newRound(_roundId)) return;
-    const lastStarted = oracleStatuses.get(_oracle).lastStartedRound; // cache storage reads
-    if (_roundId <= add(lastStarted, restartDelay) && lastStarted !== 0n)
+    if (!newRound(_roundId)) {
       return;
+    }
+    const lastStarted = oracleStatuses.get(_oracle).lastStartedRound; // cache storage reads
+    if (_roundId <= add(lastStarted, restartDelay) && lastStarted !== 0n) {
+      return;
+    }
     initializeNewRound(_roundId, blockTimestamp);
 
     oracleStatuses.get(_oracle).lastStartedRound = _roundId;
@@ -414,8 +420,9 @@ const start = async (
     if (
       details.get(_roundId).submissions.length <
       details.get(_roundId).maxSubmissions
-    )
+    ) {
       return;
+    }
     details.delete(_roundId);
   };
 
@@ -466,20 +473,28 @@ const start = async (
       canSupersede = supersedable(subtract(_roundId, 1), blockTimestamp);
     }
 
-    if (startingRound === 0n) return 'not enabled oracle';
-    if (startingRound > _roundId) return 'not yet enabled oracle';
-    if (oracleStatuses.get(_oracle).endingRound < _roundId)
+    if (startingRound === 0n) {
+      return 'not enabled oracle';
+    }
+    if (startingRound > _roundId) {
+      return 'not yet enabled oracle';
+    }
+    if (oracleStatuses.get(_oracle).endingRound < _roundId) {
       return 'no longer allowed oracle';
-    if (oracleStatuses.get(_oracle).lastReportedRound >= _roundId)
+    }
+    if (oracleStatuses.get(_oracle).lastReportedRound >= _roundId) {
       return 'cannot report on previous rounds';
+    }
     if (
       _roundId !== rrId &&
       _roundId !== add(rrId, 1) &&
       !previousAndCurrentUnanswered(_roundId, rrId)
-    )
+    ) {
       return 'invalid round to report';
-    if (_roundId !== 1n && !canSupersede)
+    }
+    if (_roundId !== 1n && !canSupersede) {
       return 'previous round not supersedable';
+    }
     return '';
   };
 
@@ -611,7 +626,7 @@ const start = async (
       if (keyToRecords.has(oracleKey)) {
         records = keyToRecords.get(oracleKey);
       } else {
-        records = new Set();
+        records = makeSet();
         keyToRecords.init(oracleKey, records);
 
         const oracleStatus = makeOracleStatus(

--- a/packages/zoe/src/contracts/scaledPriceAuthority.js
+++ b/packages/zoe/src/contracts/scaledPriceAuthority.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { Far } from '@endo/marshal';
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@endo/marshal';

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -91,7 +91,7 @@ const start = zcf => {
     // Check that the wanted items are still for sale.
     if (!AmountMath.isGTE(currentItemsForSale, wantedItems)) {
       const rejectMsg = `Some of the wanted items were not available for sale`;
-      throw buyerSeat.fail(new Error(rejectMsg));
+      throw buyerSeat.fail(assert.fail(rejectMsg));
     }
 
     // All items are the same price.

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -128,7 +128,7 @@ const start = zcf => {
     }
     // Eject because the offer must be invalid
     throw seat.fail(
-      new Error(`The proposal did not match either a buy or sell order.`),
+      assert.fail(`The proposal did not match either a buy or sell order.`),
     );
   };
 

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { makeNotifierKit } from '@agoric/notifier';
 import { Far } from '@endo/marshal';

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,7 +54,14 @@
     "@nicolo-ribaudo/chokidar-2" "2.1.8-no-fsevents.3"
     chokidar "^3.4.0"
 
-"@babel/code-frame@7.12.11", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
   integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
@@ -304,7 +311,7 @@
     "@babel/traverse" "^7.17.9"
     "@babel/types" "^7.17.0"
 
-"@babel/highlight@^7.16.7":
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
   version "7.17.12"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.12.tgz#257de56ee5afbd20451ac0a75686b6b404257351"
   integrity sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==
@@ -4234,6 +4241,13 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/experimental-utils@^5.0.0":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.27.0.tgz#dfe4c6087f60be8950e32fa83f4a8f2fccd86e47"
+  integrity sha512-ZOn342bYh19IYvkiorrqnzNoRAr91h3GiFSSfa4tlHV+R9GgR8SxCwAi8PKMyT8+pfwMxfQdNbwKsMurbF9hzg==
+  dependencies:
+    "@typescript-eslint/utils" "5.27.0"
+
 "@typescript-eslint/parser@^5.27.0", "@typescript-eslint/parser@^5.5.0":
   version "5.27.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.27.0.tgz#62bb091ed5cf9c7e126e80021bb563dcf36b6b12"
@@ -4688,7 +4702,12 @@ acorn-walk@^8.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.0.0.tgz#56ae4c0f434a45fff4a125e7ea95fa9c98f67a16"
   integrity sha512-oZRad/3SMOI/pxbbmqyurIx7jHw1wZDcR9G44L8pUVFEomX/0dH89SrM1KaDXuv1NpzAXz6Op/Xu/Qd5XXzdEA==
 
-acorn@^7.0.0, acorn@^7.1.1, acorn@^7.4.0, acorn@^8.0.4, acorn@^8.2.4, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.1:
+acorn@^7.0.0, acorn@^7.1.1, acorn@^7.4.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.0.4, acorn@^8.2.4, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.1:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
@@ -7206,10 +7225,15 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@2.0.0, depd@^1.1.2, depd@^2.0.0, depd@~1.1.2, depd@~2.0.0:
+depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
+depd@^1.1.2, depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
 dependency-graph@^0.11.0:
   version "0.11.0"
@@ -7934,7 +7958,14 @@ eslint-plugin-import@^2.18.2, eslint-plugin-import@^2.25.3:
     resolve "^1.20.0"
     tsconfig-paths "^3.12.0"
 
-eslint-plugin-jest@^25.3.0, eslint-plugin-jest@^26.0.0:
+eslint-plugin-jest@^25.3.0:
+  version "25.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-25.7.0.tgz#ff4ac97520b53a96187bad9c9814e7d00de09a6a"
+  integrity sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.0.0"
+
+eslint-plugin-jest@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.0.0.tgz#f83a25a23ab90ce5b375b1d44389b8c391be5ce8"
   integrity sha512-Fvs0YgJ/nw9FTrnqTuMGVrkozkd07jkQzWm0ajqyHlfcsdkxGfAuv30fgfWHOnHiCr9+1YQ365CcDX7vrNhqQg==
@@ -12503,7 +12534,14 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.6.5, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.5:
+node-fetch@2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
+  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1814,10 +1814,17 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jessie.js/eslint-plugin@^0.1.1", "@jessie.js/eslint-plugin@^0.1.3":
+"@jessie.js/eslint-plugin@^0.1.1":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@jessie.js/eslint-plugin/-/eslint-plugin-0.1.3.tgz#4df87d639dbc8ffb4c0b0168de1311b7f522cc75"
   integrity sha512-wyx/Wz/5gx87GRijQ3U6XGBYh9AnJdkw5pNgz0xZrLv6a6+l/t1p/7AeqYeolu5nDPuic/jSxfybkcWgYaP7UA==
+  dependencies:
+    requireindex "~1.1.0"
+
+"@jessie.js/eslint-plugin@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@jessie.js/eslint-plugin/-/eslint-plugin-0.2.0.tgz#47e81ddacf909b68f484955f20f9bf0bf9de6f57"
+  integrity sha512-Llym/BGtFu1pq15U73Rkb+kflTCI8LRxGfCufN+jcIX00m1+nDIhcgqVqmVKrghrSte+UXwDEzb/EO/Zl9K7hA==
   dependencies:
     requireindex "~1.1.0"
 
@@ -10423,6 +10430,13 @@ jake@^10.8.5:
     chalk "^4.0.2"
     filelist "^1.0.1"
     minimatch "^3.0.4"
+
+jessie.js@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/jessie.js/-/jessie.js-0.3.0.tgz#beff0a28ba22d41cdb683fed54539385d727020e"
+  integrity sha512-sIIcKAAuBGYXw8NbQben5H0hHG1qPMk/r1iplvAhjO5qe4+wNjH6vP0WYb/2BKFNBN0B5cqn+E0mCT4lfiohBA==
+  dependencies:
+    "@endo/far" "^0.2.3"
 
 jest-changed-files@^27.5.1:
   version "27.5.1"


### PR DESCRIPTION
## Description

A discussion on https://github.com/Agoric/agoric-sdk/issues/4770 suggested we should be using `@jessie-check` in all our contracts. This PR attempts that.

TODO
- [ ] solve `new Uint8Array`
- [ ] solve `do/while statements are not allowed in Jessie`  (why is this a rule?)
- [ ] solve `generators are not allowed in Jessie`. Would it suffice to pull [this](https://github.com/Agoric/agoric-sdk/blob/34807542f0888f08e1397fc343e6ed2717dd8c60/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js#L171-L182) out of the contract? there'd still be [processTranches](https://github.com/Agoric/agoric-sdk/blob/34807542f0888f08e1397fc343e6ed2717dd8c60/packages/run-protocol/src/vaultFactory/liquidateIncrementally.js#L190)
- [ ] solve `Unexpected `await` expression (not top of function body)` without changing semantics (several in liquidateIncrementally)
- [ ] reconsider the `curly` rule. Why is this in Jessie?

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
