### PR TITLE
fix: handle adjustBalances with two empty amounts

### DIFF
--- a/packages/run-protocol/src/contractSupport.js
+++ b/packages/run-protocol/src/contractSupport.js
@@ -48,6 +48,12 @@ export const assertOnlyKeys = (proposal, keys) => {
  * the gain and a loss on the `fromSeat`. The gain/loss are typically from the
  * give/want respectively of a proposal. The `key` is the allocation keyword.
  *
+ * Warning! if the amounts are both empty, this won't add a staged allocation to
+ * either seat, so the seats must only be passed to reallocate() if something
+ * else does stage an allocation. It would be wrong to throw here, since the
+ * common pattern of use is to call this twice, with one of the two calls not
+ * staging anything. It's only a mistake if both do nothing.
+ *
  * @param {ZCFSeat} fromSeat
  * @param {ZCFSeat} toSeat
  * @param {Amount} fromLoses

--- a/packages/run-protocol/src/contractSupport.js
+++ b/packages/run-protocol/src/contractSupport.js
@@ -48,12 +48,6 @@ export const assertOnlyKeys = (proposal, keys) => {
  * the gain and a loss on the `fromSeat`. The gain/loss are typically from the
  * give/want respectively of a proposal. The `key` is the allocation keyword.
  *
- * Warning! if the amounts are both empty, this won't add a staged allocation to
- * either seat, so the seats must only be passed to reallocate() if something
- * else does stage an allocation. It would be wrong to throw here, since the
- * common pattern of use is to call this twice, with one of the two calls not
- * staging anything. It's only a mistake if both do nothing.
- *
  * @param {ZCFSeat} fromSeat
  * @param {ZCFSeat} toSeat
  * @param {Amount} fromLoses

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -462,6 +462,10 @@ const helperBehavior = {
       debt,
     );
     const wantRUN = proposal.want.RUN || helper.emptyDebt();
+    if ([giveColl, giveRUN, wantColl].every(a => AmountMath.isEmpty(a))) {
+      clientSeat.exit();
+      return 'no transaction, as requested';
+    }
 
     // Calculate the fee, the amount to mint and the resulting debt. We'll
     // verify that the target debt doesn't violate the collateralization ratio,

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -799,6 +799,7 @@ test('Starting LoC', async (/** @type {RunStakeTestContext} */ t) => {
   await d.checkBLDLiened(8000n);
   await d.borrowMoreRUN(1400n);
   await d.checkRUNDebt(1632n);
+  await d.borrowMoreRUN(0n);
 });
 
 test('Extending LoC - CR increases (FAIL)', async (/** @type {RunStakeTestContext} */ t) => {

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -817,6 +817,44 @@ test('Extending LoC - CR increases (FAIL)', async (/** @type {RunStakeTestContex
   await d.checkBLDLiened(0n);
 });
 
+test('test borrow zero', async (/** @type {RunStakeTestContext} */ t) => {
+  const d = await makeWorld(t);
+  await d.buyBLD(80000n);
+  await d.stakeBLD(80000n);
+  await d.lienBLD(8000n);
+  await t.throwsAsync(async () => d.borrowRUN(0n));
+});
+
+test('test zero amounts', async (/** @type {RunStakeTestContext} */ t) => {
+  const d = await makeWorld(t);
+  await d.buyBLD(80000n);
+  await d.stakeBLD(80000n);
+  await d.lienBLD(8000n);
+  await t.throwsAsync(async () => d.borrowRUN(0n));
+});
+
+test('test payoff zero', async (/** @type {RunStakeTestContext} */ t) => {
+  const d = await makeWorld(t);
+  await d.buyBLD(80000n);
+  await d.stakeBLD(80000n);
+  await d.lienBLD(8000n);
+  await d.borrowRUN(200n);
+  await t.throwsAsync(async () => d.payoffRUN(200n));
+});
+
+test('test no Lien', async (/** @type {RunStakeTestContext} */ t) => {
+  const d = await makeWorld(t);
+  await d.buyBLD(10000n);
+  await d.stakeBLD(80000n);
+  await t.throwsAsync(async () => d.lienBLD(0n));
+});
+
+test('test no Stake', async (/** @type {RunStakeTestContext} */ t) => {
+  const d = await makeWorld(t);
+  await d.buyBLD(80000n);
+  await t.throwsAsync(async () => d.lienBLD(8000n));
+});
+
 test('Partial repayment - CR remains the same', async (/** @type {RunStakeTestContext} */ t) => {
   const d = await makeWorld(t);
   await d.buyBLD(10000n);

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1303,8 +1303,8 @@ test('adjust balances', async t => {
     E(aliceVault).makeAdjustBalancesInvitation(),
     harden({
       want: {
-        RUN: AmountMath.makeEmpty(runBrand),
-        Collateral: AmountMath.makeEmpty(aethBrand),
+        RUN: run.makeEmpty(),
+        Collateral: aeth.makeEmpty(),
       },
     }),
   );

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1297,6 +1297,22 @@ test('adjust balances', async t => {
     message: / is more than the collateralization ratio allows:/,
     // message: /The requested debt {.*} is more than the collateralization ratio allows: {.*}/,
   });
+
+  // try to trade zero for zero
+  const aliceReduceCollateralSeat3 = await E(zoe).offer(
+    E(aliceVault).makeAdjustBalancesInvitation(),
+    harden({
+      want: {
+        RUN: AmountMath.makeEmpty(runBrand),
+        Collateral: AmountMath.makeEmpty(aethBrand),
+      },
+    }),
+  );
+
+  t.is(
+    await E(aliceReduceCollateralSeat3).getOfferResult(),
+    'no transaction, as requested',
+  );
 });
 
 test('transfer vault', async t => {


### PR DESCRIPTION
fixes: #4805

## Description

vault's `adjustBalances()` wasn't protecting itself from calls with two empty amounts. The issue arises because `stageDelta` is called twice, and it's expected that one of those calls won't make a change. With two empty amounts, neither call changed allocations, and so reallocation failed because no changes were staged. The fix is to return a successful empty trade in that case.

Once I was looking at `stageDelta`, I saw that runStake also calls `stageDelta` in the same way. I added some tests of empty requests to runStake, but none of them caused a problem there, since runStake creates attestations for each trade, and fails when empty attestations are requested.

### Security Considerations

Not a security issue

### Documentation Considerations

No change needed.

### Testing Considerations

Added tests.