### PR TITLE
fix(swingset): fix handling of promises in virtual data

### DIFF
--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -106,10 +106,21 @@ function build(
   const slotToVal = new Map(); // baseRef -> WeakRef(object)
   const exportedRemotables = new Set(); // objects
   const kernelRecognizableRemotables = new Set(); // vrefs
-  const pendingPromises = new Set(); // Promises
   const importedDevices = new Set(); // device nodes
   const possiblyDeadSet = new Set(); // baseRefs that need to be checked for being dead
   const possiblyRetiredSet = new Set(); // vrefs that might need to be rechecked for being retired
+
+  // importedVPIDs and exportedVPIDs track all promises which the
+  // kernel knows about: the kernel is the decider for importedVPIDs,
+  // and we are the decider for exportedVPIDs
+
+  // We do not need to include the ancillary promises that
+  // resolutionCollector() creates: those are resolved immediately
+  // after export. However we remove those during resolution just in
+  // case they overlap with non-ancillary ones.
+
+  const exportedVPIDs = new Map(); // VPID -> Promise, kernel-known, vat-decided
+  const importedVPIDs = new Map(); // VPID -> { promise, resolve, reject }, kernel-known+decided
 
   function retainExportedVref(vref) {
     // if the vref corresponds to a Remotable, keep a strong reference to it
@@ -294,18 +305,6 @@ function build(
   const disavowedPresences = new WeakSet();
   const disavowalError = harden(Error(`this Presence has been disavowed`));
 
-  // This tracks all promises that we decide (i.e. we are obligated to
-  // call syscall.resolve on them before the end of stopVat). We add
-  // their vpid when we export the promise (or receive it as the
-  // 'result' of a dispatch.deliver) and remove it when we make the
-  // syscall.resolve . We do not need to include the ancillary
-  // promises that resolutionCollector() creates: those are resolved
-  // immediately after export. However we remove those during
-  // resolution just in case they overlap with non-ancillary ones.
-  const deciderVPIDs = new Set(); // vpids
-
-  const importedPromisesByPromiseID = new Map(); // vpid -> { resolve, reject }
-
   function makeImportedPresence(slot, iface = `Alleged: presence ${slot}`) {
     // Called by convertSlotToVal for type=object (an `o-NN` reference). We
     // build a Presence for application-level code to receive. This Presence
@@ -430,6 +429,7 @@ function build(
     // about how we interact with HandledPromise, just use harden({ resolve,
     // reject }).
     const pRec = harden({
+      promise: p,
       resolve(resolution) {
         handlerActive = false;
         resolve(resolution);
@@ -440,9 +440,7 @@ function build(
         reject(rejection);
       },
     });
-    importedPromisesByPromiseID.set(vpid, pRec);
-
-    return harden(p);
+    return pRec;
   }
 
   function makeDeviceNode(id, iface = `Alleged: device ${id}`) {
@@ -496,7 +494,7 @@ function build(
   }
 
   // TODO: fix awkward non-orthogonality: allocateExportID() returns a number,
-  // allocatePromiseID() returns a slot, exportPromise() uses the slot from
+  // allocatePromiseID() returns a slot, registerPromise() uses the slot from
   // allocatePromiseID(), exportPassByPresence() generates a slot itself using
   // the number from allocateExportID().  Both allocateX fns should return a
   // number or return a slot; both exportY fns should either create a slot or
@@ -517,14 +515,26 @@ function build(
 
   const knownResolutions = new WeakMap();
 
-  function exportPromise(p) {
-    const pid = allocatePromiseID();
-    lsdebug(`Promise allocation ${forVatID}:${pid} in exportPromise`);
-    if (!knownResolutions.has(p)) {
+  // this is called with all outbound argument vrefs
+  function maybeExportPromise(vref) {
+    // we only care about new vpids
+    if (
+      parseVatSlot(vref).type === 'promise' &&
+      !exportedVPIDs.has(vref) &&
+      !importedVPIDs.has(vref)
+    ) {
+      const vpid = vref;
+      // The kernel is about to learn about this promise (syscall.send
+      // arguments or syscall.resolve resolution data), so prepare to
+      // do a syscall.resolve when it fires. The caller must finish
+      // doing their syscall before this turn finishes, to ensure the
+      // kernel isn't surprised by a spurious resolution.
       // eslint-disable-next-line no-use-before-define
-      p.then(thenResolve(p, pid), thenReject(p, pid));
+      const p = requiredValForSlot(vpid);
+      // if (!knownResolutions.has(p)) { // TODO really?
+      // eslint-disable-next-line no-use-before-define
+      followForKernel(vpid, p);
     }
-    return pid;
   }
 
   function exportPassByPresence() {
@@ -633,12 +643,14 @@ function build(
 
     if (!valToSlot.has(val)) {
       let slot;
-      // must be a new export
+      // must be a new export/store
       // lsdebug('must be a new export', JSON.stringify(val));
       if (isPromise(val)) {
-        slot = exportPromise(val);
-        pendingPromises.add(val); // keep it alive until resolved
-        deciderVPIDs.add(slot);
+        // the promise either appeared in outbound arguments, or in a
+        // virtual-object store operation, so immediately after
+        // serialization we'll either add it to exportedVPIDs or
+        // increment a vdata refcount
+        slot = allocatePromiseID();
       } else {
         if (disavowedPresences.has(val)) {
           // eslint-disable-next-line no-use-before-define
@@ -724,23 +736,20 @@ function build(
         // this is a new import value
         val = makeImportedPresence(slot, iface);
       } else if (type === 'promise') {
-        // XXX note: this assert is the same as the one 5 lines above and therefor pointless
-        assert(
-          !parseVatSlot(slot).allocatedByVat,
-          X`kernel is being presumptuous: vat got unrecognized vatSlot ${slot}`,
-        );
-        val = makePipelinablePromise(slot);
+        const pRec = makePipelinablePromise(slot);
+        importedVPIDs.set(slot, pRec);
+        val = pRec.promise;
         // ideally we'd wait until .then is called on p before subscribing,
         // but the current Promise API doesn't give us a way to discover
         // this, so we must subscribe right away. If we were using Vows or
         // some other then-able, we could just hook then() to notify us.
         if (importedPromises) {
+          // leave the subscribe() up to dispatch.notify()
           importedPromises.add(slot);
         } else {
+          // probably in dispatch.deliver(), so subscribe now
           syscall.subscribe(slot);
         }
-        // keep the imported promise alive until it resolves
-        pendingPromises.add(val);
       } else if (type === 'device') {
         val = makeDeviceNode(slot, iface);
         importedDevices.add(val);
@@ -763,8 +772,9 @@ function build(
       !getValForSlot(slot),
       X`revivePromise called on pre-existing ${slot}`,
     );
-    const p = makePipelinablePromise(slot);
-    pendingPromises.add(p);
+    const pRec = makePipelinablePromise(slot);
+    importedVPIDs.set(slot, pRec);
+    const p = pRec.promise;
     registerValue(slot, p);
     return p;
   }
@@ -801,6 +811,7 @@ function build(
         rejected = true;
       }
       valueSer.slots.map(retainExportedVref);
+      // do maybeExportPromise() next to the syscall, not here
       resolutions.push([promiseID, rejected, valueSer]);
       scanSlots(valueSer.slots);
     }
@@ -827,23 +838,76 @@ function build(
     meterControl.assertIsMetered(); // else userspace getters could escape
     const serMethargs = m.serialize(harden(methargs));
     serMethargs.slots.map(retainExportedVref);
+
     const resultVPID = allocatePromiseID();
     lsdebug(`Promise allocation ${forVatID}:${resultVPID} in queueMessage`);
     // create a Promise which callers follow for the result, give it a
     // handler so we can pipeline messages to it, and prepare for the kernel
     // to notify us of its resolution
-    const p = makePipelinablePromise(resultVPID);
+    const pRec = makePipelinablePromise(resultVPID);
+
+    // userspace sees `returnedP` (so that's what we need to register
+    // in slotToVal, and what's what we need to retain with a strong
+    // reference via importedVPIDs), but when dispatch.notify arrives,
+    // we need to fire `pRec.promise` because that's what we've got
+    // the firing controls for
+    importedVPIDs.set(resultVPID, harden({ ...pRec, promise: returnedP }));
+    valToSlot.set(returnedP, resultVPID);
+    slotToVal.set(resultVPID, new WeakRef(returnedP));
 
     // prettier-ignore
     lsdebug(
       `ls.qm send(${JSON.stringify(targetSlot)}, ${legibilizeMethod(prop)}) -> ${resultVPID}`,
     );
     syscall.send(targetSlot, serMethargs, resultVPID);
+
+    // The vpids in the syscall.send might be in A:exportedVPIDs,
+    // B:importedVPIDs, or C:neither. Just after the send(), we are
+    // newly on the hook for following the ones in C:neither. One
+    // option would be to feed all the syscall.send slots to
+    // maybeExportPromise(), which will sort them into A/B/C, then
+    // take everything in C:neither and do a .then on it and add it to
+    // exportedVPIDs. Then we call it a day, and allow all the
+    // resolutions to be delivered in a later turn.
+    //
+    // But instead, we choose the option that says "but many of those
+    // promises might already be resolved", and if there's more than
+    // one, we could amortize some syscall overhead by emitting all
+    // the known resolutions in a 2-or-larger batch, and in this
+    // moment (in this turn) we have a whole list of them that we can
+    // check synchronously.
+    //
+    // To implement this option, the sequence is:
+    // * use W to name the vpids in syscall.send
+    // * feed W into resolutionCollector(), to get 'resolutions'
+    //   * that provides the resolution of any promise in W that is
+    //     known to be resolved, plus any known-resolved promises
+    //     transitively referenced through their resolution data
+    //   * all these resolutions will use the original vpid, which the
+    //     kernel does not currently know about, because the vpid was
+    //     retired earlier, the previous time that promise was
+    //     resolved
+    // * name X the set of vpids resolved in 'resolutions'
+    //   * assert that X vpids are not in exportedVPIDs or importedVPIDs
+    //   * they can only be in X if we remembered the Promise's
+    //     resolution, which means we observed the vpid resolve
+    //   * at that moment of observation, we would have removed it
+    //     from exportedVPIDs, as we did a syscall.resolve on it
+    // * name Y the set of vpids *referenced* by 'resolutions'
+    // * emit syscall.resolve(resolutions)
+    // * Z = (W+Y)-X: the set of vpids we told the kernel but didn't resolve
+    // * feed Z into maybeExportPromise()
+
+    const maybeNewVPIDs = new Set(serMethargs.slots);
     const resolutions = resolutionCollector().forSlots(serMethargs.slots);
     if (resolutions.length > 0) {
       syscall.resolve(resolutions);
-      resolutions.map(([vpid]) => deciderVPIDs.delete(vpid));
+      resolutions.forEach(([_xvpid, _isReject, resolutionCD]) => {
+        resolutionCD.slots.forEach(vref => maybeNewVPIDs.add(vref));
+      });
+      resolutions.forEach(([xvpid]) => maybeNewVPIDs.delete(xvpid));
     }
+    Array.from(maybeNewVPIDs).sort().forEach(maybeExportPromise);
 
     // ideally we'd wait until .then is called on p before subscribing, but
     // the current Promise API doesn't give us a way to discover this, so we
@@ -851,22 +915,20 @@ function build(
     // then-able, we could just hook then() to notify us.
     syscall.subscribe(resultVPID);
 
-    // We return 'p' to the handler, and the eventual resolution of 'p' will
-    // be used to resolve the caller's Promise, but the caller never sees 'p'
-    // itself. The caller got back their Promise before the handler ever got
-    // invoked, and thus before queueMessage was called.. If that caller
-    // passes the Promise they received as argument or return value, we want
-    // it to serialize as resultVPID. And if someone passes resultVPID to
-    // them, we want the user-level code to get back that Promise, not 'p'.
-    // As a result, we do not retain or track 'p'. Only 'returnedP' is
-    // registered and retained by pendingPromises.
+    // We return our new 'pRec.promise' to the handler, and when we
+    // resolve it (during dispatch.notify) its resolution will be used
+    // to resolve the caller's 'returnedP' Promise, but the caller
+    // never sees pRec.promise itself. The caller got back their
+    // 'returnedP' Promise before the handler even got invoked, and
+    // thus before this queueMessage() was called.. If that caller
+    // passes the 'returnedP' Promise they received as argument or
+    // return value, we want it to serialize as resultVPID. And if
+    // someone passes resultVPID to them, we want the user-level code
+    // to get back that Promise, not 'pRec.promise'.  As a result, we
+    // do not retain or track 'pRec.promise'. Only 'returnedP' is
+    // registered and retained by importedVPIDs.
 
-    valToSlot.set(returnedP, resultVPID);
-    slotToVal.set(resultVPID, new WeakRef(returnedP));
-    pendingPromises.add(returnedP);
-    // we do not use vreffedObjectRegistry for promises, even result promises
-
-    return p;
+    return pRec.promise;
   }
 
   function forbidPromises(serArgs) {
@@ -888,9 +950,12 @@ function build(
           meterControl.assertIsMetered(); // userspace getters shouldn't escape
           const serArgs = m.serialize(harden(args));
           serArgs.slots.map(retainExportedVref);
+          // if we didn't forbid promises, we'd need to
+          // maybeExportPromise() here
           forbidPromises(serArgs);
           const ret = syscall.callNow(slot, prop, serArgs);
           insistCapData(ret);
+          forbidPromises(ret);
           // but the unserialize must be unmetered, to prevent divergence
           const retval = unmeteredUnserialize(ret);
           return retval;
@@ -914,19 +979,19 @@ function build(
     return pr;
   }
 
-  function deliver(target, methargsdata, result) {
+  function deliver(target, methargsdata, resultVPID) {
     assert(didStartVat);
     assert(!didStopVat);
     insistCapData(methargsdata);
 
     // prettier-ignore
     lsdebug(
-      `ls[${forVatID}].dispatch.deliver ${target}.${extractMethod(methargsdata)} -> ${result}`,
+      `ls[${forVatID}].dispatch.deliver ${target}.${extractMethod(methargsdata)} -> ${resultVPID}`,
     );
     const t = convertSlotToVal(target);
     assert(t, X`no target ${target}`);
     // TODO: if we acquire new decision-making authority over a promise that
-    // we already knew about ('result' is already in slotToVal), we should no
+    // we already knew about ('resultVPID' is already in slotToVal), we should no
     // longer accept dispatch.notify from the kernel. We currently use
     // importedPromisesByPromiseID to track a combination of "we care about
     // when this promise resolves" and "we are listening for the kernel to
@@ -965,73 +1030,89 @@ function build(
       // TODO: untested, but in principle sound.
       res = HandledPromise.get(t, method);
     }
-    let notifySuccess = () => undefined;
-    let notifyFailure = () => undefined;
-    if (result) {
-      // If this vpid was imported earlier (and we just now became the
-      // decider), we'll have a local Promise object for it, and
-      // importedPromisesByPromiseID will have the resolve/reject
-      // functions to handle a dispatch.notify. If it gets imported
-      // later, we'll wind up in the same state.  TODO: it would be
-      // nice to forward that promise to `res`, so locally-sent
-      // messages are queued locally instead of being sent into the
-      // kernel (and back again after the kernel hears our
-      // syscall.resolve).
-      insistVatType('promise', result);
-      deciderVPIDs.add(result);
-      // eslint-disable-next-line no-use-before-define
-      notifySuccess = thenResolve(res, result);
-      // eslint-disable-next-line no-use-before-define
-      notifyFailure = thenReject(res, result);
-    }
-    res.then(notifySuccess, notifyFailure);
-  }
 
-  function retirePromiseID(promiseID) {
-    lsdebug(`Retiring ${forVatID}:${promiseID}`);
-    importedPromisesByPromiseID.delete(promiseID);
-    const p = getValForSlot(promiseID);
-    if (p) {
-      valToSlot.delete(p);
-      pendingPromises.delete(p);
-    }
-    slotToVal.delete(promiseID);
-  }
-
-  function thenHandler(p, promiseID, rejected) {
-    // this runs metered
-    insistVatType('promise', promiseID);
-    return value => {
-      knownResolutions.set(p, harden([rejected, value]));
-      harden(value);
-      lsdebug(`ls.thenHandler fired`, value);
-      const resolutions = resolutionCollector().forPromise(
-        promiseID,
-        rejected,
-        value,
-      );
-
-      syscall.resolve(resolutions);
-      resolutions.map(([vpid]) => deciderVPIDs.delete(vpid));
-
-      const pRec = importedPromisesByPromiseID.get(promiseID);
-      if (pRec) {
-        if (rejected) {
-          pRec.reject(value);
-        } else {
-          pRec.resolve(value);
-        }
+    let p = res; // the promise tied to resultVPID
+    if (resultVPID) {
+      if (importedVPIDs.has(resultVPID)) {
+        // This vpid was imported earlier, and we just now became the
+        // decider, so we already have a local Promise object for
+        // it. We keep using that object.
+        // , but forward it to 'res', and
+        // move it from importedVPIDs to exportedVPIDs.
+        const pRec = importedVPIDs.get(resultVPID);
+        // remove it from importedVPIDs: the kernel will no longer be
+        // telling us about its resolution
+        importedVPIDs.delete(resultVPID);
+        // forward it to the userspace-fired result promise (despite
+        // using resolve(), this could either fulfill or reject)
+        pRec.resolve(res);
+        // exportedVPIDs will hold a strong reference to the pRec
+        // promise that everyone is already using, and when it fires
+        // we'll notify the kernel
+        p = pRec.promise;
+        // note: the kernel does not unsubscribe vats that acquire
+        // decider status (but it probably should), so after we do our
+        // syscall.resolve, the kernel will give us a
+        // dispatch.notify. But we'll ignore the stale vpid by
+        // checking importedVPIDs in notifyOnePromise()
+      } else {
+        // new vpid
+        registerValue(resultVPID, res, false);
       }
-      meterControl.runWithoutMetering(() => retirePromiseID(promiseID));
-    };
+      // in both cases, we are now the decider, so treat it like an
+      // exported promise
+      // eslint-disable-next-line no-use-before-define
+      followForKernel(resultVPID, p);
+    }
   }
 
-  function thenResolve(p, promiseID) {
-    return thenHandler(p, promiseID, false);
+  function unregisterUnreferencedVPID(vpid) {
+    lsdebug(`unregisterUnreferencedVPID ${forVatID}:${vpid}`);
+    assert.equal(parseVatSlot(vpid).type, 'promise');
+    // we are only called with vpids that are in exportedVPIDs or
+    // importedVPIDs, so the WeakRef should still be populated, making
+    // this safe to call from metered code
+    const p = requiredValForSlot(vpid);
+    if (vrm.getReachablePromiseRefCount(p) === 0) {
+      // unregister
+      valToSlot.delete(p);
+      slotToVal.delete(vpid);
+      // the caller will remove the vpid from
+      // exportedVPIDs/importedVPIDs in a moment
+    }
   }
 
-  function thenReject(p, promiseID) {
-    return thenHandler(p, promiseID, true);
+  function followForKernel(vpid, p) {
+    insistVatType('promise', vpid);
+    exportedVPIDs.set(vpid, p);
+
+    function handle(isReject, value) {
+      knownResolutions.set(p, harden([isReject, value]));
+      lsdebug(`ls.thenHandler fired`, value);
+      assert(exportedVPIDs.has(vpid), vpid);
+      const rc = resolutionCollector();
+      const resolutions = rc.forPromise(vpid, isReject, value);
+      syscall.resolve(resolutions);
+
+      const maybeNewVPIDs = new Set();
+      // if we mention a vpid, we might need to track it
+      resolutions.forEach(([_xvpid, _isReject, resolutionCD]) => {
+        resolutionCD.slots.forEach(vref => maybeNewVPIDs.add(vref));
+      });
+      // but not if we just resolved it (including the primary)
+      resolutions.forEach(([xvpid]) => maybeNewVPIDs.delete(xvpid));
+      // track everything that's left
+      Array.from(maybeNewVPIDs).sort().forEach(maybeExportPromise);
+
+      // only the primary can possibly be newly resolved
+      unregisterUnreferencedVPID(vpid);
+      exportedVPIDs.delete(vpid);
+    }
+
+    p.then(
+      value => handle(false, value),
+      value => handle(true, value),
+    );
   }
 
   function notifyOnePromise(promiseID, rejected, data) {
@@ -1040,7 +1121,10 @@ function build(
       `ls.dispatch.notify(${promiseID}, ${rejected}, ${data.body}, [${data.slots}])`,
     );
     insistVatType('promise', promiseID);
-    const pRec = importedPromisesByPromiseID.get(promiseID);
+    const pRec = importedVPIDs.get(promiseID);
+    // we check pRec to ignore stale notifies, either from before an
+    // upgrade, or if we acquire decider authority for a
+    // previously-imported promise
     if (pRec) {
       // TODO: insist that we do not have decider authority for promiseID
       meterControl.assertNotMetered();
@@ -1050,29 +1134,39 @@ function build(
       } else {
         pRec.resolve(val);
       }
+      return true; // caller will remove from importedVPIDs
     }
     // else ignore: our predecessor version might have subscribed
+    return false;
   }
 
   function notify(resolutions) {
     assert(didStartVat);
     assert(!didStopVat);
+    // notifyOnePromise() will tell us whether each vpid in the batch
+    // was retired or stale
+    const retiredVPIDs = [];
+    // Deserializing the batch of resolutions may import new promises,
+    // some of which are resolved later in the batch. We'll need to
+    // subscribe to the remaining (new+unresolved) ones.
     beginCollectingPromiseImports();
     for (const resolution of resolutions) {
       const [vpid, rejected, data] = resolution;
-      notifyOnePromise(vpid, rejected, data);
-    }
-    for (const resolution of resolutions) {
-      const [vpid] = resolution;
-      retirePromiseID(vpid);
-    }
-    const imports = finishCollectingPromiseImports();
-    meterControl.assertNotMetered();
-    for (const slot of imports) {
-      if (slotToVal.get(slot)) {
-        // we'll only subscribe to new promises, which is within consensus
-        syscall.subscribe(slot);
+      const retired = notifyOnePromise(vpid, rejected, data);
+      if (retired) {
+        retiredVPIDs.push(vpid); // not stale
       }
+    }
+    // 'imports' is an exclusively-owned Set that holds all new
+    // promise vpids, both resolved and unresolved
+    const imports = finishCollectingPromiseImports();
+    retiredVPIDs.forEach(vpid => {
+      unregisterUnreferencedVPID(vpid); // unregisters if not in vdata
+      importedVPIDs.delete(vpid);
+      imports.delete(vpid); // resolved, so don't subscribe()
+    });
+    for (const vpid of Array.from(imports).sort()) {
+      syscall.subscribe(vpid);
     }
   }
 
@@ -1325,8 +1419,18 @@ function build(
     assert(!didStopVat);
     didStopVat = true;
 
+    // all vpids are either "imported" (kernel knows about it and
+    // kernel decides), "exported" (kernel knows about it but we
+    // decide), or neither (local, we decide, kernel is unaware). TODO
+    // this could be cheaper if we tracked all three states (make a
+    // Set for "neither") instead of doing enumeration and set math.
+
     try {
-      watchedPromiseManager.prepareShutdownRejections(deciderVPIDs);
+      // mark "imported" plus "neither" for rejection at next startup
+      const importedVPIDsSet = new Set(importedVPIDs.keys());
+      watchedPromiseManager.prepareShutdownRejections(importedVPIDsSet);
+      // reject all "exported" vpids now
+      const deciderVPIDs = Array.from(exportedVPIDs.keys()).sort();
       await releaseOldState({
         m,
         deciderVPIDs,

--- a/packages/SwingSet/src/liveslots/stop-vat.js
+++ b/packages/SwingSet/src/liveslots/stop-vat.js
@@ -42,8 +42,7 @@ function rejectAllPromises({ m, deciderVPIDs, syscall }) {
   // userspace to gain agency.
 
   const rejectCapData = m.serialize('vat upgraded');
-  const vpids = Array.from(deciderVPIDs.keys()).sort();
-  const rejections = vpids.map(vpid => [vpid, true, rejectCapData]);
+  const rejections = deciderVPIDs.map(vpid => [vpid, true, rejectCapData]);
   if (rejections.length) {
     syscall.resolve(rejections);
   }

--- a/packages/SwingSet/src/liveslots/virtualReferences.js
+++ b/packages/SwingSet/src/liveslots/virtualReferences.js
@@ -349,6 +349,11 @@ export function makeVirtualReferenceManager(
         // syscall.dropImport when the Presence itself goes away.
         incRefCount(baseRef);
       }
+    } else if (type === 'promise') {
+      // need to track promises too, maybe in remotableRefCounts
+      const p = requiredValForSlot(vref);
+      const oldRefCount = remotableRefCounts.get(p) || 0;
+      remotableRefCounts.set(p, oldRefCount + 1);
     }
   }
 
@@ -374,8 +379,22 @@ export function makeVirtualReferenceManager(
       } else {
         decRefCount(baseRef);
       }
+    } else if (type === 'promise') {
+      const p = requiredValForSlot(vref);
+      const oldRefCount = remotableRefCounts.get(p) || 0;
+      assert(oldRefCount > 0, `attempt to decref ${vref} below 0`);
+      if (oldRefCount === 1) {
+        remotableRefCounts.delete(p);
+        droppedMemoryReference = true; // true for promises too
+      } else {
+        remotableRefCounts.set(p, oldRefCount - 1);
+      }
     }
     return droppedMemoryReference;
+  }
+
+  function getReachablePromiseRefCount(p) {
+    return remotableRefCounts.get(p) || 0;
   }
 
   // for testing only
@@ -633,6 +652,7 @@ export function makeVirtualReferenceManager(
     addReachableVref,
     removeReachableVref,
     updateReferenceCounts,
+    getReachablePromiseRefCount,
     addRecognizableValue,
     removeRecognizableVref,
     removeRecognizableValue,

--- a/packages/SwingSet/src/liveslots/vpid-tracking.md
+++ b/packages/SwingSet/src/liveslots/vpid-tracking.md
@@ -1,0 +1,87 @@
+# Promise/VPID Management in Liveslots
+
+Kernels and vats communicate about promises by referring to their VPIDs: vat(-centric) promise IDs. These are strings like `p+12` and `p-23`. Like VOIDs (object IDs), the plus/minus sign indicates which side of the boundary allocated the number (`p+12` and `o+12` are allocated by the vat, `p-13` and `o-13` are allocated by the kernel). But where the object ID sign also indicates which side "owns" the object (i.e. where the behavior lives), the promise ID sign is generally irrelevant.
+
+Instead, we care about which side holds the resolution authority. This is not indicated by the VPID sign, and in fact is not necessarily static. Liveslots does not currently have any mechanism to allow one promise to be forwarded to another, but if it acquires this some day, then the decider of a promise could shift from kernel to vat to kernel again before it finally gets resolved. And there *is* a sequence that allows a vat to receive a reference to a promise in method arguments first, then receive a message whose result promise uses that VPID second (`p1 = p2~.foo(); x~.bar(p1)`, then someone resolves `p2` to `x`). In this case, the decider is initially the kernel, then the authority is transferred to the vat later.
+
+Each `Promise` starts out in the "unresolved" state, then later transitions irrevocably to the "resolved" state. Liveslots frequently (but not always) pays attention to this transition by calling `.then`, to attach a callback. To handle resolution cycles, liveslots remembers the resolution of old promises in a `WeakMap` for as long as the `Promise` exists. Consequently, for liveslots' purposes, every `Promise` is either resolved (the callback has fired and liveslots remembers the resolution), or unresolved (liveslots has not yet seen a resolution).
+
+There are roughly four ways that liveslots might become aware of a promise:
+
+* serialization: a `Promise` instance is serialized, either for the arguments of an outbound `syscall.send` or `syscall.resolve`, the argument of `watchPromise()`, or to be stored into virtualized data (e.g. `bigMapStore.set(key, promise)`, or assignment to a property of a virtual object)
+* creation for outbound result: liveslots allocates a VPID for the `.result` of an outbound `syscall.send`, and creates a new `Promise` instance to give back to userspace
+* deserialization: the arguments of an inbound `dispatch.deliver` or `dispatch.notify` are deserialized, and a new `Promise` instance is created
+* inbound result: the kernel-allocated `.result` VPID of an inbound `dispatch.deliver` is associated with the `Promise` we get back from `HandledPromise.applyMethod`
+
+A `Promise` may be associated with a VPID even though the kernel does not know about it (i.e. the VPID is not in the c-list): this can occur when a Promise is merely stored into virtual data without also being sent to (or received from) the kernel. The kernel's knowledge is temporary: once the promise is resolved (either `syscall.resolve` or `dispatch.notify`), the VPID is retired from the vat's c-list. So a VPID might start out stored only in vdata, then get sent to the kernel, then get resolved, leaving it solely in vdata once more.
+
+Each unresolved VPID has a decider: either the vat or the kernel. The VPID is resolved by the first of the following events:
+
+* if/when userspace resolves the corresponding `Promise` and liveslots learns of the resolution, then liveslots will perform a `syscall.resolve()`
+* if/when the vat is upgraded, liveslots will perform a `syscall.resolve()` of all remaining VPIDs during the delivery of `dispatch.stopVat()` (after which all `Promise`s evaporate along with the rest of the JS heap)
+* if/when the vat is terminated, the kernel internally rejects all remaining vat-decided KPIDs, without involving the vat
+* otherwise, the VPID remains unresolved until the heat death of the universe
+
+Liveslots tracks promises in the following data structures:
+
+* `slotToVal` / `valToSlot` : these manage *registration*, the mapping from VPID to `Promise` and vice versa. These also register objects (Presences, Remotables, and Representatives) to/from VOIDs, and device nodes.
+  * to support GC of objects, `slotToVal.get(vref)` is a WeakRef, and `valToSlot` is a WeakMap
+  * liveslots uses independent strong references to maintain object/promise lifetimes
+* `exportedVPIDs`: a `Map<VPID, Promise>`: all Promises currently known to the kernel and decided by the vat
+* `importedVPIDs`: a `Map<VPID, PromiseKit>`: all Promises currently known to the kernel and decided by the kernel
+* `remotableRefCounts`: a `Map<Object|Promise, Number>`: all Promises (and Remotables) referenced by virtual data
+
+The vat-kernel c-list contains all VPIDs in `exportedVPIDs` and `importedVPIDs`. The vat is the decider for `exportedVPIDs`, while the kernel is the decider for `importedVPIDs`. For every VPID in `exportedVPIDs`, we've used `.then` on the `Promise` instance to arrange for a `syscall.resolve` when the promise resolves or rejects. For every VPID key of the `importedVPIDs` Map, the corresponding value is a `[resolve, reject]` "`pRec`", so one of them can be called during `dispatch.notify`. Every VPID in `slotToVal` is either in `exportedVPIDs`, `importedVPIDs`, or neither.
+
+If a VPID in `importedVPIDs` is resolved (by the kernel, via `dispatch.notify`), the VPID is removed from `importedVPIDs`. If a VPID in `exportedVPIDs` is resolved (by the vat, i.e. liveslots observes the previously-added `.then` callback be executed), liveslots invokes `syscall.resolve` and removes the VPID from `exportedVPIDs`. The c-list will not contain VPIDs for any resolved promise.
+
+The `slotToVal`/`valToSlot` registration must remain until 1: the kernel is no longer aware of the VPID, 2: the Promise is not present in any virtual data, and 3: the promise is not being watched by a `promiseWatcher`. If the registration were to be lost while one of those three conditions were still true, a replacement `Promise` might be created while the original was still around, causing confusion.
+
+## Maintaining Strong References
+
+Remember that the `slotToVal` registration uses a WeakRef, so being registered there does not keep the `Promise` object alive.
+ 
+`exportedVPIDs` and `importedVPIDs` keep their `Promise` alive in their value. vdata keeps it alive through the key of `remotableRefCounts`. `promiseWatcher` uses an internal `ScalarBigMapStore` to keep the `Promise` alive.
+
+## Promise/VPID Management Algorithm
+
+* When a `Promise` is first serialized (it appears in `convertValToSlot`), a VPID is assigned and the VPID/`Promise` mapping is registered in `valToSlot`/`slotToVal`
+  * at this point, there is not yet a strong reference to the Promise
+* When a VPID appears in the serialized arguments of `syscall.send` or `syscall.resolve`:
+  * if the VPID already exists in `exportedVPIDs` or `importedVPIDs`: do nothing
+  * else: use `followForKernel` to add to `exportedVPIDs` and use `.then()` to attach a `handle` callback
+* When `followForKernel`'s `handle` callback is executed:
+  * do `syscall.resolve()`
+  * remove from `exportedVPIDs`
+  * check `remotableRefCounts`. If 0: unregister from `valToSlot`/`slotToVal`
+* When the kernel delivers a `dispatch.notify`:
+  * retrieve the `resolve`/`reject` "`pRec`" from `importedVPIDs`
+  * invoke the appropriate function with the deserialized argument
+  * check `remotableRefCounts`. If 0: unregister from `valToSlot`/`slotToVal`
+* When the vdata refcount for a VPID drops to zero:
+  * if the VPID still exists in `exportedVPIDs` or `importedVPIDs`: do nothing
+  * else: unregister from `valToSlot`/`slotToVal`
+* When a new VPID is deserialized (it appears in `convertSlotToVal`), this must be the arguments of a delivery (not vdata)
+  * use `makePipelinablePromise` to create a HandledPromise for the VPID
+  * add the Promise and it's `resolve`/`reject` pair to `importedVPIDs`
+  * register the Promise in `valToSlot`/`slotToVal'`
+  * use `syscall.subscribe` to request a `dispatch.notify` delivery when the kernel resolves this promise
+* When a VPID appears as the `.result` of an outbound `syscall.send`:
+  * use `allocateVPID` to allocate a new VPID
+  * use `makePipelinablePromise` to create a HandledPromise for the VPID
+  * add the Promise and it's `resolve`/`reject` pair to `importedVPIDs`
+  * register the Promise in `valToSlot`/`slotToVal'`
+  * use `syscall.subscribe` to request a `dispatch.notify` delivery when the kernel resolves this promise
+* When a VPID appears as the `.result` of an inbound `dispatch.deliver`:
+  * check to see if the VPID is present in `importedVPIDs`:
+    * if yes: extract `pRec`, use `pRec.resolve(res)` to forward the invocation result promise to the previously-imported promise, then remove the VPID from `importedVPIDs`
+    * if no: register `res` the invocation result promise under the VPID
+  * in either case, next we add the VPID to `exportedVPIDs`
+  * then we call `followForKernel` to attach a callback to the `res` promise
+
+
+If the serialization is for storage in virtual data, the act of storing the `VPID` will add the `Promise` to `remotableRefCounts`, which maintains a strong reference for as long as the VPID is held. When it is removed from virtual data (or the object/collection is deleted), the refcount will be decremented. When the refcount drops to zero, we perform the `exportedVPIDs`/`importedVPIDs` check and then maybe unregister the promise.
+
+If the serialization is for the arguments of an outbound `syscall.send` or `syscall.resolve` (or `syscall.callNow`, or `syscall.exit`), the VPID will be added to `exportedVPIDs`.
+
+If the *un*serialization occurred when processing the arguments of an *in*bound `dispatch.deliver` or `dispatch.notify`, the VPID (and the "promise kit" trio of Promise, `resolve`, and `reject`) will be stored in `importedVPIDs`.

--- a/packages/SwingSet/test/gc-helpers.js
+++ b/packages/SwingSet/test/gc-helpers.js
@@ -21,8 +21,8 @@ import { capargs } from './util.js';
 let aWeakMapStore;
 let aWeakSetStore;
 
-export const mainHolderIdx = 4;
-export const mainHeldIdx = 5;
+export const mainHolderIdx = 5;
+export const mainHeldIdx = 6;
 
 export function buildRootObject(vatPowers) {
   const { VatData } = vatPowers;
@@ -32,7 +32,7 @@ export function buildRootObject(vatPowers) {
     makeScalarBigWeakSetStore,
   } = VatData;
 
-  let nextStoreNumber = 4;
+  let nextStoreNumber = 5;
   let heldStore = null;
 
   const holders = [];
@@ -239,6 +239,22 @@ export function validateStatusCheck(v, vref, rc, es) {
   validateExportStatusCheck(v, vref, es);
 }
 
+function validateCreateBuiltInNonDurableTable(v, idx, schema, label) {
+  validate(v, matchVatstoreSet(`vc.${idx}.|nextOrdinal`, `1`));
+  validate(v, matchVatstoreSet(`vc.${idx}.|entryCount`, `0`));
+  validate(v, matchVatstoreSet(`vc.${idx}.|schemata`, schema));
+  validate(v, matchVatstoreSet(`vc.${idx}.|label`, label));
+}
+
+function validateCreatePromiseRegistrationTable(v, idx) {
+  validateCreateBuiltInNonDurableTable(
+    v,
+    idx,
+    anyScalarSchema,
+    'promiseRegistrations',
+  );
+}
+
 export function validateCreateBuiltInTable(v, idx, idKey, schema, label) {
   validate(v, matchVatstoreGet(idKey, NONE));
   validate(v, matchVatstoreSet(`vc.${idx}.|nextOrdinal`, `1`));
@@ -276,8 +292,9 @@ export function validateCreateBaggage(v, idx) {
 
 export function validateCreateBuiltInTables(v) {
   validateCreateBaggage(v, 1);
-  validateCreatePromiseWatcherKindTable(v, 2);
-  validateCreateWatchedPromiseTable(v, 3);
+  validateCreatePromiseRegistrationTable(v, 2);
+  validateCreatePromiseWatcherKindTable(v, 3);
+  validateCreateWatchedPromiseTable(v, 4);
 }
 
 export function validateCreate(v, idx, isWeak = false) {
@@ -520,10 +537,11 @@ export function validateInit(v) {
     ),
   );
   validateCreateBuiltInTables(v);
-  validateCreateHolder(v, 4);
+  validateCreateHolder(v, 5);
+
   validate(v, matchVatstoreGet('deadPromises', NONE));
   validate(v, matchVatstoreDelete('deadPromises'));
-  validate(v, matchVatstoreGetAfter('', 'vc.3.', 'vc.3.{', [NONE, NONE]));
+  validate(v, matchVatstoreGetAfter('', 'vc.4.', 'vc.4.{', [NONE, NONE]));
   validate(v, matchVatstoreGetAfter('', 'vom.dkind.', NONE, [NONE, NONE]));
 }
 

--- a/packages/SwingSet/test/gc-helpers.js
+++ b/packages/SwingSet/test/gc-helpers.js
@@ -12,8 +12,8 @@ import {
   validate,
   validateDone,
   validateReturned,
-} from '../../liveslots-helpers.js';
-import { capargs } from '../../util.js';
+} from './liveslots-helpers.js';
+import { capargs } from './util.js';
 
 // These tests follow the model described in
 // ../virtualObjects/test-virtualObjectGC.js

--- a/packages/SwingSet/test/stores/test-storeGC/test-lifecycle.js
+++ b/packages/SwingSet/test/stores/test-storeGC/test-lifecycle.js
@@ -22,7 +22,7 @@ import {
   validateMakeAndHold,
   validateRetireExports,
   validateStoreHeld,
-} from './gc-helpers.js';
+} from '../../gc-helpers.js';
 
 // These tests follow the model described in
 // ../virtualObjects/test-virtualObjectGC.js

--- a/packages/SwingSet/test/stores/test-storeGC/test-refcount-management.js
+++ b/packages/SwingSet/test/stores/test-storeGC/test-refcount-management.js
@@ -32,7 +32,7 @@ import {
   validateStatusCheck,
   validateUpdate,
   validateWeakCheckEmpty,
-} from './gc-helpers.js';
+} from '../../gc-helpers.js';
 
 // These tests follow the model described in
 // ../virtualObjects/test-virtualObjectGC.js

--- a/packages/SwingSet/test/stores/test-storeGC/test-scalar-store-kind.js
+++ b/packages/SwingSet/test/stores/test-storeGC/test-scalar-store-kind.js
@@ -2,7 +2,7 @@
 import { test } from '../../../tools/prepare-test-env-ava.js';
 
 import { setupTestLiveslots } from '../../liveslots-helpers.js';
-import { buildRootObject, mapRef } from './gc-helpers.js';
+import { buildRootObject, mapRef } from '../../gc-helpers.js';
 
 // These tests follow the model described in
 // ../virtualObjects/test-virtualObjectGC.js

--- a/packages/SwingSet/test/stores/test-storeGC/test-weak-key.js
+++ b/packages/SwingSet/test/stores/test-storeGC/test-weak-key.js
@@ -30,7 +30,7 @@ import {
   validateStatusCheck,
   validateUpdate,
   validateWeakCheckEmpty,
-} from './gc-helpers.js';
+} from '../../gc-helpers.js';
 
 // These tests follow the model described in
 // ../virtualObjects/test-virtualObjectGC.js

--- a/packages/SwingSet/test/test-baggage.js
+++ b/packages/SwingSet/test/test-baggage.js
@@ -12,7 +12,7 @@ import {
   validateDone,
   validateReturned,
 } from './liveslots-helpers.js';
-import { capargs } from './util.js';
+import { validateCreateBuiltInTables } from './gc-helpers.js';
 
 function buildRootObject(vatPowers, vatParameters, baggage) {
   baggage.has('outside');
@@ -32,61 +32,6 @@ function stringVal(str) {
     body: JSON.stringify(str),
     slots: [],
   });
-}
-
-const stringSchema = JSON.stringify(
-  capargs([{ '@qclass': 'tagged', tag: 'match:kind', payload: 'string' }]),
-);
-
-const anyScalarSchema = JSON.stringify(
-  capargs([
-    {
-      '@qclass': 'tagged',
-      tag: 'match:scalar',
-      payload: { '@qclass': 'undefined' },
-    },
-  ]),
-);
-
-function validateCreateBuiltInTable(v, idx, idKey, schema, label) {
-  validate(v, matchVatstoreGet(idKey, NONE));
-  validate(v, matchVatstoreSet(`vc.${idx}.|nextOrdinal`, `1`));
-  validate(v, matchVatstoreSet(`vc.${idx}.|entryCount`, `0`));
-  validate(v, matchVatstoreSet(`vc.${idx}.|schemata`, schema));
-  validate(v, matchVatstoreSet(`vc.${idx}.|label`, label));
-  validate(v, matchVatstoreSet(idKey, `o+6/${idx}`));
-  validate(v, matchVatstoreGet(`vom.rc.o+6/${idx}`, NONE));
-  validate(v, matchVatstoreSet(`vom.rc.o+6/${idx}`, '1'));
-}
-
-function validateCreatePromiseWatcherKindTable(v, idx) {
-  validateCreateBuiltInTable(
-    v,
-    idx,
-    'watcherTableID',
-    anyScalarSchema,
-    'promiseWatcherByKind',
-  );
-}
-
-function validateCreateWatchedPromiseTable(v, idx) {
-  validateCreateBuiltInTable(
-    v,
-    idx,
-    'watchedPromiseTableID',
-    stringSchema,
-    'watchedPromises',
-  );
-}
-
-function validateCreateBaggage(v, idx) {
-  validateCreateBuiltInTable(v, idx, 'baggageID', stringSchema, 'baggage');
-}
-
-function validateCreateBuiltInTables(v) {
-  validateCreateBaggage(v, 1);
-  validateCreatePromiseWatcherKindTable(v, 2);
-  validateCreateWatchedPromiseTable(v, 3);
 }
 
 function validateSetup(v) {

--- a/packages/SwingSet/test/test-baggage.js
+++ b/packages/SwingSet/test/test-baggage.js
@@ -64,7 +64,7 @@ test.serial('exercise baggage', async t => {
   validate(v, matchVatstoreSet('vc.1.|entryCount', '1'));
   validate(v, matchVatstoreGet('deadPromises', NONE));
   validate(v, matchVatstoreDelete('deadPromises'));
-  validate(v, matchVatstoreGetAfter('', 'vc.3.', 'vc.3.{', [NONE, NONE]));
+  validate(v, matchVatstoreGetAfter('', 'vc.4.', 'vc.4.{', [NONE, NONE]));
   validate(v, matchVatstoreGetAfter('', 'vom.dkind.', NONE, [NONE, NONE]));
   validateDone(v);
 

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -772,7 +772,7 @@ test('GC syscall.dropImports', async t => {
   t.deepEqual(log.shift(), {
     type: 'vatstoreSet',
     key: 'idCounters',
-    value: '{"exportID":10,"collectionID":4,"promiseID":5}',
+    value: '{"exportID":10,"collectionID":5,"promiseID":5}',
   });
   const l2 = log.shift();
   t.deepEqual(l2, {
@@ -1181,7 +1181,7 @@ test('GC dispatch.dropExports', async t => {
   t.deepEqual(log.shift(), {
     type: 'vatstoreSet',
     key: 'idCounters',
-    value: '{"exportID":11,"collectionID":4,"promiseID":5}',
+    value: '{"exportID":11,"collectionID":5,"promiseID":5}',
   });
   t.deepEqual(log, []);
 
@@ -1248,7 +1248,7 @@ test('GC dispatch.retireExports inhibits syscall.retireExports', async t => {
   t.deepEqual(log.shift(), {
     type: 'vatstoreSet',
     key: 'idCounters',
-    value: '{"exportID":11,"collectionID":4,"promiseID":5}',
+    value: '{"exportID":11,"collectionID":5,"promiseID":5}',
   });
   t.deepEqual(log, []);
 
@@ -1535,34 +1535,37 @@ test('result promise in args', async t => {
   // sequence is a bit weird. We'll document it here:
 
   // * when the promise is imported (in msg.args), we create a Promise
-  //   object, track it in slotToVal/valToSlot, and hold the resolve /
-  //   reject functions in importedPromisesByPromiseID . Userspace
-  //   sees this Promise. A `dispatch.notify` will resolve it. Any
-  //   messages sent to it will be queued into the kernel, which will
-  //   wait for a `syscall.resolve` and then send the messages to the
-  //   resulting object's home vat.
+  //   object, register it in slotToVal/valToSlot, and hold the
+  //   resolve / reject functions in importedVPIDs . Userspace sees
+  //   this Promise. A `dispatch.notify` will resolve it. Any messages
+  //   sent to it will be queued into the kernel, which will wait for
+  //   a `syscall.resolve` and then send the messages to the resulting
+  //   object's home vat.
 
   // * Each dispatch.deliver causes the creation of a `res` Promise
-  //   for the result of the local delivery. If a result= vpid was
-  //   provided, we use `res.then` to wait for it to resolve. If/when
-  //   that happens, `thenHandler` does both a syscall.resolve() and
-  //   checks/resolves `importedPromisesByPromiseID`.
+  //   for the result of the local delivery. If a new result= vpid was
+  //   provided, we register `res` under `resultVPID` and use
+  //   `res.then` to wait for it to resolve. If/when that happens,
+  //   `followForKernel` does both a syscall.resolve() and removes it
+  //   from `exportedVPIDs`.
 
-  // * So if we wind up with both a real "imported" Promise and a
-  //   result vpid, any messages our userspace sends to the Promise
-  //   will be queued into the kernel, even though we're going to be
-  //   calling syscall.resolve . If we resolve it to something local,
-  //   those messages will take a round-trip through the kernel. It
-  //   might be nice to forward `res` to the generated Promise, to
-  //   avoid that trip in some cases.
+  // * If dispatch.deliver was given an *existing* (importedVPIDs)
+  //   resultVPID, we leave that old+imported promise registered as
+  //   resultVPID, but we forward it to `res`. We then remove it from
+  //   importedVPIDs and add it to exportedVPIDs. And we use a `.then`
+  //   on the old promise and `followForKernel` to wait for it to
+  //   resolve, which won't happen until `res` resolves.
+
+  //  * As a result, any messages our userspace sends to the Promise
+  //    will be forwarded(?) to 'res', and will be queued locally, and
+  //    won't go to the kernel.
 
   // * Also, our vat will do both `syscall.subscribe` and
   //   `syscall.resolve` for the same vpid. The `resolve` will
   //   schedule a `dispatch.notify` to us, as a subscriber, however it
   //   will also retire the c-list entry, so the notify will be
   //   cancelled when it finally gets to the front of the queue. Which
-  //   is good, because we won't recognize the vpid by that point, and
-  //   besides `thenHandler` did the necessary resolve/reject already.
+  //   is good, because we won't recognize the vpid by that point.
 
   function build(_vatPowers) {
     return Far('root', {
@@ -1602,14 +1605,9 @@ test('result promise in args', async t => {
   t.is(log.shift().type, 'subscribe'); // result of two()
 
   const s3 = log.shift();
-  t.is(s3.type, 'send');
-  t.is(s3.targetSlot, resP); // huh, this will be queued in the kernel
-  t.is(log.shift().type, 'subscribe'); // result of three()
-
-  const s4 = log.shift();
-  t.is(s4.type, 'resolve');
-  t.is(s4.resolutions.length, 1);
-  t.deepEqual(s4.resolutions[0], [resP, false, capargs('four')]);
+  t.is(s3.type, 'resolve');
+  t.is(s3.resolutions.length, 1);
+  t.deepEqual(s3.resolutions[0], [resP, false, capargs('four')]);
 
   t.deepEqual(vatlog, ['res: four']);
 });

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -1,4 +1,4 @@
-/* global setImmediate, WeakRef, FinalizationRegistry */
+/* global WeakRef, FinalizationRegistry */
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 
@@ -99,16 +99,12 @@ test('serialize imports', async t => {
 });
 
 test('serialize promise', async t => {
-  const log = [];
   const syscall = {
-    resolve(resolutions) {
-      log.push(resolutions);
-    },
     vatstoreGet: () => undefined,
   };
 
   const { m, unmeteredUnserialize } = makeUnmeteredMarshaller(syscall);
-  const { promise, resolve } = makePromiseKit();
+  const { promise } = makePromiseKit();
   t.deepEqual(m.serialize(promise), {
     body: '{"@qclass":"slot","index":0}',
     slots: ['p+5'],
@@ -127,14 +123,6 @@ test('serialize promise', async t => {
     }),
     promise,
   );
-
-  resolve(5);
-  t.deepEqual(log, []);
-
-  const { promise: pauseP, resolve: pauseRes } = makePromiseKit();
-  setImmediate(() => pauseRes());
-  await pauseP;
-  t.deepEqual(log, [[['p+5', false, { body: '5', slots: [] }]]]);
 });
 
 test('unserialize promise', async t => {

--- a/packages/SwingSet/test/test-promises.js
+++ b/packages/SwingSet/test/test-promises.js
@@ -161,21 +161,21 @@ test('circular promise resolution data', async t => {
       },
     },
     {
-      id: 'kp45',
+      id: 'kp42',
       state: 'fulfilled',
       refCount: 1,
       data: {
         body: '[{"@qclass":"slot","index":0}]',
-        slots: ['kp46'],
+        slots: ['kp44'],
       },
     },
     {
-      id: 'kp46',
+      id: 'kp44',
       state: 'fulfilled',
       refCount: 1,
       data: {
         body: '[{"@qclass":"slot","index":0}]',
-        slots: ['kp45'],
+        slots: ['kp42'],
       },
     },
   ];

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate-non-critical.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate-non-critical.js
@@ -283,7 +283,7 @@ test('dead vat state removed', async t => {
   const kvStore = hostStorage.kvStore;
   t.is(kvStore.get('vat.dynamicIDs'), '["v6"]');
   t.is(kvStore.get('ko26.owner'), 'v6');
-  t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 33);
+  t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length > 30, true);
 
   controller.queueToVatRoot('bootstrap', 'phase2', []);
   await controller.run();

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -384,7 +384,7 @@ test('virtual object gc', async t => {
   }
   t.deepEqual(remainingVOs, {
     'v1.vs.baggageID': 'o+6/1',
-    'v1.vs.idCounters': '{"exportID":11,"collectionID":4,"promiseID":8}',
+    'v1.vs.idCounters': '{"exportID":11,"collectionID":5,"promiseID":8}',
     'v1.vs.kindIDID': '1',
     'v1.vs.storeKindIDTable':
       '{"scalarMapStore":2,"scalarWeakMapStore":3,"scalarSetStore":4,"scalarWeakSetStore":5,"scalarDurableMapStore":6,"scalarDurableWeakMapStore":7,"scalarDurableSetStore":8,"scalarDurableWeakSetStore":9}',
@@ -394,14 +394,19 @@ test('virtual object gc', async t => {
     'v1.vs.vc.1.|schemata':
       '{"body":"[{\\"@qclass\\":\\"tagged\\",\\"tag\\":\\"match:kind\\",\\"payload\\":\\"string\\"}]","slots":[]}',
     'v1.vs.vc.2.|entryCount': '0',
-    'v1.vs.vc.2.|label': 'promiseWatcherByKind',
+    'v1.vs.vc.2.|label': 'promiseRegistrations',
     'v1.vs.vc.2.|nextOrdinal': '1',
     'v1.vs.vc.2.|schemata':
       '{"body":"[{\\"@qclass\\":\\"tagged\\",\\"tag\\":\\"match:scalar\\",\\"payload\\":{\\"@qclass\\":\\"undefined\\"}}]","slots":[]}',
     'v1.vs.vc.3.|entryCount': '0',
-    'v1.vs.vc.3.|label': 'watchedPromises',
+    'v1.vs.vc.3.|label': 'promiseWatcherByKind',
     'v1.vs.vc.3.|nextOrdinal': '1',
     'v1.vs.vc.3.|schemata':
+      '{"body":"[{\\"@qclass\\":\\"tagged\\",\\"tag\\":\\"match:scalar\\",\\"payload\\":{\\"@qclass\\":\\"undefined\\"}}]","slots":[]}',
+    'v1.vs.vc.4.|entryCount': '0',
+    'v1.vs.vc.4.|label': 'watchedPromises',
+    'v1.vs.vc.4.|nextOrdinal': '1',
+    'v1.vs.vc.4.|schemata':
       '{"body":"[{\\"@qclass\\":\\"tagged\\",\\"tag\\":\\"match:kind\\",\\"payload\\":\\"string\\"}]","slots":[]}',
     'v1.vs.vom.es.o+10/3': 'r',
     'v1.vs.vom.o+10/2': '{"label":{"body":"\\"thing #2\\"","slots":[]}}',
@@ -409,11 +414,11 @@ test('virtual object gc', async t => {
     'v1.vs.vom.o+10/8': '{"label":{"body":"\\"thing #8\\"","slots":[]}}',
     'v1.vs.vom.o+10/9': '{"label":{"body":"\\"thing #9\\"","slots":[]}}',
     'v1.vs.vom.rc.o+6/1': '1',
-    'v1.vs.vom.rc.o+6/2': '1',
     'v1.vs.vom.rc.o+6/3': '1',
+    'v1.vs.vom.rc.o+6/4': '1',
     'v1.vs.vom.vkind.10': '{"kindID":"10","tag":"thing"}',
-    'v1.vs.watchedPromiseTableID': 'o+6/3',
-    'v1.vs.watcherTableID': 'o+6/2',
+    'v1.vs.watchedPromiseTableID': 'o+6/4',
+    'v1.vs.watcherTableID': 'o+6/3',
   });
 });
 

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -16,6 +16,7 @@ import {
   validateDone,
   validateReturned,
 } from '../liveslots-helpers.js';
+import { validateCreateBuiltInTables } from '../gc-helpers.js';
 import { capargs } from '../util.js';
 
 // Legs:
@@ -191,20 +192,6 @@ function facetRef(isf, vref, facet) {
 const cacheDisplacerVref = thingVref(false, 1);
 const fCacheDisplacerVref = thingVref(true, 1);
 const virtualHolderVref = `${holderBaseRef}/1`;
-
-const stringSchema = JSON.stringify(
-  capargs([{ '@qclass': 'tagged', tag: 'match:kind', payload: 'string' }]),
-);
-
-const anyScalarSchema = JSON.stringify(
-  capargs([
-    {
-      '@qclass': 'tagged',
-      tag: 'match:scalar',
-      payload: { '@qclass': 'undefined' },
-    },
-  ]),
-);
 
 function buildRootObject(vatPowers) {
   const { VatData, WeakMap, WeakSet } = vatPowers;
@@ -451,47 +438,6 @@ function validateFauxCacheDisplacerDeletion(v) {
   validateDelete(v, fCacheDisplacerVref);
   validateCheckNoWeakKeys(v, `${fCacheDisplacerVref}:0`);
   validateCheckNoWeakKeys(v, `${fCacheDisplacerVref}:1`);
-}
-
-function validateCreateBuiltInTable(v, idx, idKey, schema, label) {
-  validate(v, matchVatstoreGet(idKey, NONE));
-  validate(v, matchVatstoreSet(`vc.${idx}.|nextOrdinal`, `1`));
-  validate(v, matchVatstoreSet(`vc.${idx}.|entryCount`, `0`));
-  validate(v, matchVatstoreSet(`vc.${idx}.|schemata`, schema));
-  validate(v, matchVatstoreSet(`vc.${idx}.|label`, label));
-  validate(v, matchVatstoreSet(idKey, `o+6/${idx}`));
-  validate(v, matchVatstoreGet(`vom.rc.o+6/${idx}`, NONE));
-  validate(v, matchVatstoreSet(`vom.rc.o+6/${idx}`, '1'));
-}
-
-function validateCreatePromiseWatcherKindTable(v, idx) {
-  validateCreateBuiltInTable(
-    v,
-    idx,
-    'watcherTableID',
-    anyScalarSchema,
-    'promiseWatcherByKind',
-  );
-}
-
-function validateCreateWatchedPromiseTable(v, idx) {
-  validateCreateBuiltInTable(
-    v,
-    idx,
-    'watchedPromiseTableID',
-    stringSchema,
-    'watchedPromises',
-  );
-}
-
-function validateCreateBaggage(v, idx) {
-  validateCreateBuiltInTable(v, idx, 'baggageID', stringSchema, 'baggage');
-}
-
-function validateCreateBuiltInTables(v) {
-  validateCreateBaggage(v, 1);
-  validateCreatePromiseWatcherKindTable(v, 2);
-  validateCreateWatchedPromiseTable(v, 3);
 }
 
 function validateKindMetadata(v, kindID, tag) {

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -471,7 +471,7 @@ function validateSetup(v) {
   validateKindMetadata(v, markerKindID, 'marker');
   validate(v, matchVatstoreGet('deadPromises', NONE));
   validate(v, matchVatstoreDelete('deadPromises'));
-  validate(v, matchVatstoreGetAfter('', 'vc.3.', 'vc.3.{', [NONE, NONE]));
+  validate(v, matchVatstoreGetAfter('', 'vc.4.', 'vc.4.{', [NONE, NONE]));
   validate(v, matchVatstoreGetAfter('', 'vom.dkind.', NONE, [NONE, NONE]));
   validate(
     v,

--- a/packages/SwingSet/test/virtualObjects/vdata-promises/bootstrap-vdata-promises.js
+++ b/packages/SwingSet/test/virtualObjects/vdata-promises/bootstrap-vdata-promises.js
@@ -1,0 +1,62 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
+
+export function buildRootObject() {
+  let targetvat;
+  // imported into target vat
+  const pk1 = makePromiseKit();
+  const pk2 = makePromiseKit();
+  const pk3 = makePromiseKit();
+  const [p1, p2, p3] = [pk1.promise, pk2.promise, pk3.promise];
+
+  const subscriberStash = [];
+  const subscriber = Far('subscriber', {
+    subscribe(name, p) {
+      const entryP = p.then(res => [name, res]);
+      subscriberStash.push(entryP);
+    },
+  });
+
+  return Far('root', {
+    async bootstrap(vats) {
+      targetvat = vats.target;
+    },
+
+    // exercised imported promises
+    doImportTest1() {
+      E(targetvat).importPromiseStep1(p1, p2, p3);
+      return [p1, p2, p3];
+    },
+    doImportTest2() {
+      pk1.resolve(1);
+      pk2.resolve(2);
+      pk3.resolve(3);
+    },
+    doImportTest3() {
+      return E(targetvat).importPromiseStep2();
+    },
+
+    doResultTest1() {
+      const p4 = E(targetvat).returnPromise4();
+      const p5 = E(targetvat).returnPromise5();
+      const p6 = E(targetvat).returnPromise6();
+      E(targetvat).resultPromiseStep1(p4, p5, p6);
+      return harden([p4, p5, p6]);
+    },
+    doResultTest2() {
+      E(targetvat).resultPromiseStep2();
+    },
+    doResultTest3() {
+      return E(targetvat).resultPromiseStep3();
+    },
+
+    async doStoreTest1() {
+      const data = await E(targetvat).storePromiseStep1(subscriber);
+      const subscriberEntries = await Promise.all(subscriberStash);
+      const resolutions = {};
+      subscriberEntries.forEach(([name, res]) => (resolutions[name] = res));
+      return { data, resolutions };
+    },
+  });
+}

--- a/packages/SwingSet/test/virtualObjects/vdata-promises/test-vdata-promises.js
+++ b/packages/SwingSet/test/virtualObjects/vdata-promises/test-vdata-promises.js
@@ -1,0 +1,163 @@
+// eslint-disable-next-line import/order
+import { test } from '../../../tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { provideHostStorage } from '../../../src/controller/hostStorage.js';
+import { parseReachableAndVatSlot } from '../../../src/kernel/state/reachable.js';
+import {
+  initializeSwingset,
+  makeSwingsetController,
+} from '../../../src/index.js';
+import { capargs } from '../../util.js';
+
+function bfile(name) {
+  return new URL(name, import.meta.url).pathname;
+}
+
+const config = {
+  includeDevDependencies: true, // for vat-data
+  bootstrap: 'bootstrap',
+  // defaultReapInterval: 'never',
+  // defaultReapInterval: 1,
+  vats: {
+    bootstrap: { sourceSpec: bfile('bootstrap-vdata-promises.js') },
+    target: {
+      sourceSpec: bfile('vat-vdata-promises.js'),
+      creationOptions: {
+        virtualObjectCacheSize: 0,
+      },
+    },
+  },
+};
+
+test('imported promises in vdata', async t => {
+  const hostStorage = provideHostStorage();
+  const { kvStore } = hostStorage;
+  await initializeSwingset(config, [], hostStorage);
+  const c = await makeSwingsetController(hostStorage);
+  c.pinVatRoot('bootstrap');
+  c.pinVatRoot('target');
+  const vatID = c.vatNameToID('target');
+  await c.run();
+
+  const kpid1 = c.queueToVatRoot('bootstrap', 'doImportTest1', []);
+  await c.run();
+  t.is(c.kpStatus(kpid1), 'fulfilled');
+  const res1 = c.kpResolution(kpid1);
+  console.log(res1); // [p1, p2, p3]
+  t.deepEqual(JSON.parse(res1.body), [
+    { '@qclass': 'slot', index: 0 },
+    { '@qclass': 'slot', index: 1 },
+    { '@qclass': 'slot', index: 2 },
+  ]);
+  const [p1kref, p2kref, p3kref] = res1.slots;
+
+  c.queueToVatRoot('bootstrap', 'doImportTest2', [], 'panic');
+  await c.run();
+
+  const kpid2 = c.queueToVatRoot('bootstrap', 'doImportTest3', []);
+  await c.run();
+  t.is(c.kpStatus(kpid2), 'fulfilled');
+  const res2 = c.kpResolution(kpid2);
+  console.log(res2); // [1, 2, 2, 3, 3]
+  t.deepEqual(res2, capargs([1, 2, 2, 3, 3]));
+
+  // check clist for promise retirement
+
+  function has(kref) {
+    const s = kvStore.get(`${vatID}.c.${kref}`);
+    // returns undefined, or { vatSlot, isReachable }
+    return s && parseReachableAndVatSlot(s);
+  }
+  t.falsy(has(p1kref));
+  t.falsy(has(p2kref));
+  t.falsy(has(p3kref));
+});
+
+test('result promises in vdata', async t => {
+  const hostStorage = provideHostStorage();
+  const { kvStore } = hostStorage;
+  await initializeSwingset(config, [], hostStorage);
+  const c = await makeSwingsetController(hostStorage);
+  c.pinVatRoot('bootstrap');
+  c.pinVatRoot('target');
+  const vatID = c.vatNameToID('target');
+  await c.run();
+
+  const kpid1 = c.queueToVatRoot('bootstrap', 'doResultTest1', []);
+  await c.run();
+  t.is(c.kpStatus(kpid1), 'fulfilled');
+  const res1 = c.kpResolution(kpid1);
+  console.log(res1); // [p4, p5, p6]
+  t.deepEqual(JSON.parse(res1.body), [
+    { '@qclass': 'slot', index: 0 },
+    { '@qclass': 'slot', index: 1 },
+    { '@qclass': 'slot', index: 2 },
+  ]);
+  const [p4kref, p5kref, p6kref] = res1.slots;
+
+  c.queueToVatRoot('bootstrap', 'doResultTest2', [], 'panic');
+  await c.run();
+
+  const kpid2 = c.queueToVatRoot('bootstrap', 'doResultTest3', []);
+  await c.run();
+  t.is(c.kpStatus(kpid2), 'fulfilled');
+  const res2 = c.kpResolution(kpid2);
+  t.deepEqual(res2, capargs([4, 5, 5, 6, 6]));
+
+  // check clist for promise retirement
+
+  function has(kref) {
+    const s = kvStore.get(`${vatID}.c.${kref}`);
+    // returns undefined, or { vatSlot, isReachable }
+    return s && parseReachableAndVatSlot(s);
+  }
+  t.falsy(has(p4kref));
+  t.falsy(has(p5kref));
+  t.falsy(has(p6kref));
+});
+
+test('exported promises in vdata', async t => {
+  const hostStorage = provideHostStorage();
+  const { kvStore } = hostStorage;
+  await initializeSwingset(config, [], hostStorage);
+  const c = await makeSwingsetController(hostStorage);
+  c.pinVatRoot('bootstrap');
+  c.pinVatRoot('target');
+  const vatID = c.vatNameToID('target');
+  await c.run();
+
+  const kpid1 = c.queueToVatRoot('bootstrap', 'doStoreTest1', []);
+  await c.run();
+  t.is(c.kpStatus(kpid1), 'fulfilled');
+  const res1 = c.kpResolution(kpid1);
+  console.log(res1); // { data, resolutions }
+  t.deepEqual(JSON.parse(res1.body).data.is, {
+    p7is: true,
+    p8is: true,
+    p9is: true,
+    p10is: true,
+    p14is: true,
+  });
+  t.deepEqual(JSON.parse(res1.body).resolutions, {
+    p9: 9,
+    p10: 10,
+    p11: 11,
+    p12: 12,
+    p13: 13,
+    p14: 14,
+  });
+  const promises = JSON.parse(res1.body).ret;
+  console.log(promises);
+  // all these promises should be resolved by now, and retired from
+  // the clist
+
+  function has(kref) {
+    const s = kvStore.get(`${vatID}.c.${kref}`);
+    // returns undefined, or { vatSlot, isReachable }
+    return s && parseReachableAndVatSlot(s);
+  }
+  for (const kref of res1.slots) {
+    t.falsy(has(kref));
+  }
+});

--- a/packages/SwingSet/test/virtualObjects/vdata-promises/vat-vdata-promises.js
+++ b/packages/SwingSet/test/virtualObjects/vdata-promises/vat-vdata-promises.js
@@ -1,0 +1,196 @@
+/* global VatData */
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
+
+// import { makeScalarBigMapStore } from '@agoric/vat-data';
+const { makeScalarBigMapStore } = VatData;
+
+export function buildRootObject() {
+  const vc = makeScalarBigMapStore('vc');
+
+  // used to resolve result promises
+  const pk4 = makePromiseKit();
+  const pk5 = makePromiseKit();
+  const pk6 = makePromiseKit();
+
+  // used to store promises
+  const pk7 = makePromiseKit();
+  const pk8 = makePromiseKit();
+  const pk9 = makePromiseKit();
+  const pk10 = makePromiseKit();
+  const pk11 = makePromiseKit();
+  const pk12 = makePromiseKit();
+  const pk13 = makePromiseKit();
+  const pk14 = makePromiseKit();
+
+  const importStash = [];
+  const resultStash = [];
+
+  return Far('root', {
+    importPromiseStep1(p1, p2, p3) {
+      // imported p1 is resolved without ever being put into vdata
+      importStash.push(p1);
+
+      // imported p2 is added to vdata, fetched from vdata, deleted
+      // from vdata, then resolved
+      vc.init('p2', p2);
+      const p2a = vc.get('p2');
+      vc.delete('p2');
+      importStash.push(p2);
+      importStash.push(p2a);
+
+      // imported p3 is added to vdata, resolved, fetched from vdata,
+      // then deleted from vdata
+      vc.init('p3', p3);
+      importStash.push(p3);
+    },
+
+    // p1/p2/p3 are resolved before importPromiseStep2 is called
+
+    importPromiseStep2() {
+      console.log(`vc.get(p3)`);
+      const p3a = vc.get('p3');
+      console.log(` got ${p3a}`);
+      importStash.push(p3a);
+      vc.delete('p3');
+
+      return Promise.all(importStash);
+    },
+
+    // these three methods return p4/p5/p6 (note these are not the
+    // same as pk4.promise/etc, but pk4.resolve() will cause p4 to be
+    // resolved)
+    returnPromise4() {
+      return pk4.promise;
+    },
+    returnPromise5() {
+      return pk5.promise;
+    },
+    returnPromise6() {
+      return pk6.promise;
+    },
+
+    resultPromiseStep1(p4, p5, p6) {
+      // result p4 is resolved without ever being put into vdata
+      resultStash.push(p4);
+      // result p5 is added to vdata, fetched from vdata, deleted
+      // from vdata, then resolved
+      vc.init('p5', p5);
+      const p5a = vc.get('p5');
+      vc.delete('p5');
+      resultStash.push(p5);
+      resultStash.push(p5a);
+
+      // result p6 is added to vdata, resolved, fetched from vdata,
+      // then deleted from vdata
+      vc.init('p6', p6);
+      resultStash.push(p6);
+    },
+
+    resultPromiseStep2() {
+      pk4.resolve(4);
+      pk5.resolve(5);
+      pk6.resolve(6);
+    },
+
+    resultPromiseStep3() {
+      console.log(`vc.get(p6)`);
+      const p6a = vc.get('p6');
+      console.log(` got ${p6a}`);
+      resultStash.push(p6a);
+      vc.delete('p6');
+
+      return Promise.all(resultStash);
+    },
+
+    async storePromiseStep1(subscriber) {
+      const ret = {};
+
+      // p7: basic retrieval: store, fetch, delete, resolve
+      ret.p7 = pk7.promise;
+      vc.init('p7', pk7.promise);
+      ret.p7a = vc.get('p7');
+      vc.delete('p7');
+      pk7.resolve(7);
+
+      // p8: unexported resolution doesn't unregister, can delete
+      // after resolution: store, resolve, (pause), fetch, delete
+      ret.p8 = pk8.promise;
+      vc.init('p8', pk8.promise);
+      pk8.resolve(8);
+      await pk8.promise;
+      ret.p8a = vc.get('p8'); // unexported resolution doesn't unregister
+      vc.delete('p8');
+
+      // p9: can export while stored+unresolved: store, export,
+      // resolve, (notify), (pause), fetch, delete
+      ret.p9 = pk9.promise;
+      vc.init('p9', pk9.promise);
+      E(subscriber).subscribe('p9', pk9.promise);
+      await Promise.resolve(); // serialize before resolution
+      pk9.resolve(9);
+      await pk9.promise;
+      ret.p9a = vc.get('p9'); // exported resolution doesn't unregister
+      vc.delete('p9');
+
+      // p10: can export while stored+resolved: store, resolve,
+      // (pause), export, fetch, delete
+      ret.p10 = pk10.promise;
+      vc.init('p10', pk10.promise);
+      pk10.resolve(10);
+      await pk10.promise;
+      E(subscriber).subscribe('p10', pk10.promise);
+      await Promise.resolve(); // allow serialize+send
+      ret.p10a = vc.get('p10');
+      vc.delete('p10');
+
+      // p11: delete while unresolved: store, export, delete, resolve,
+      // (notify)
+      ret.p11 = pk11.promise;
+      vc.init('p11', pk11.promise);
+      E(subscriber).subscribe('p11', pk11.promise);
+      await Promise.resolve(); // allow serialize+send
+      vc.delete('p11');
+      pk11.resolve(11);
+
+      // p12: delete+re-store while unresolved: store, export, delete,
+      // store, resolve, (notify), delete
+      ret.p12 = pk12.promise;
+      vc.init('p12', pk12.promise);
+      E(subscriber).subscribe('p12', pk12.promise);
+      await Promise.resolve(); // allow serialize+send
+      vc.delete('p12');
+      vc.init('p12', pk12.promise);
+      pk12.resolve(12);
+      await pk12.promise;
+      vc.delete('p12');
+
+      // p13: basic export: export, resolve, (notify)
+      ret.p13 = pk13.promise;
+      E(subscriber).subscribe('p13', pk13.promise);
+      pk13.resolve(13);
+      await pk13.promise;
+
+      // p14: export first: export, store, resolve, (notify), fetch,
+      // delete
+      ret.p14 = pk14.promise;
+      E(subscriber).subscribe('p14', pk14.promise);
+      await Promise.resolve(); // allow serialize+send
+      vc.init('p14', pk14.promise);
+      pk14.resolve(14);
+      await pk14.promise;
+      ret.p14a = vc.get('p14');
+      vc.delete('p14');
+
+      const is = {
+        p7is: ret.p7 === ret.p7a,
+        p8is: ret.p8 === ret.p8a,
+        p9is: ret.p9 === ret.p9a,
+        p10is: ret.p10 === ret.p10a,
+        p14is: ret.p14 === ret.p14a,
+      };
+      return { is, ret };
+    },
+  });
+}


### PR DESCRIPTION
fix(swingset): fix handling of promises in virtual data

Previously, liveslots managed the lifecycle of VPID (promise ID)
registration as if the only consumer was the kernel: every time we
serialized a promise, we assumed it was being shared with the kernel,
so we would use `.then` to prepare a `syscall.resolve` message, and
we'd retire the VPID<->`Promise` mapping immediately upon resolution.

But #5106 reveals that storing a Promise in virtual data introduces a
different lifecycle. The VPID/Promise registration needs to survive as
long as 1: any virtual data references the promise, or 2: the kernel
is aware of the VPID. The latter happens either through "import" (the
kernel is the decider, and the vat's `Promise` is a follower, waiting
for `dispatch.notify`), or "export" (the vat is the decider, waiting
to do a `syscall.resolve`).

This changes the state machine for VPIDs, to maintain the registration
as long as necessary. VPIDs are tracked in two Maps named
`exportedVPIDs` and `importedVPIDs`.

A new virtual table (`makeScalarBigMapStore`) is used for Promises
currently being tracked by `watchPromise`, to keep the registration
alive until they are resolved or the vat is upgraded. This causes some
test churn as the identifiers for other tables are now one larger.

fixes #5106
