### PR TITLE
fix(swingset): record full VatSyscallResult in transcript, even errors

### DIFF
--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -246,20 +246,18 @@ function makeManagerKit(
 
       // but if the puppy deviates one inch from previous twitches, explode
       kernelSlog.syscall(vatID, undefined, vso);
-      const data = transcriptManager.simulateSyscall(vso);
-      return harden(['ok', data]);
+      const vres = transcriptManager.simulateSyscall(vso);
+      return vres;
     }
 
     const vres = vatSyscallHandler(vso);
     // vres is ['error', reason] or ['ok', null] or ['ok', capdata] or ['ok', string]
     const [successFlag, data] = vres;
-    if (successFlag === 'ok') {
-      if (data && !workerCanBlock) {
-        console.log(`warning: syscall returns data, but worker cannot get it`);
-      }
-      if (transcriptManager) {
-        transcriptManager.addSyscall(vso, data);
-      }
+    if (successFlag === 'ok' && data && !workerCanBlock) {
+      console.log(`warning: syscall returns data, but worker cannot get it`);
+    }
+    if (transcriptManager) {
+      transcriptManager.addSyscall(vso, vres);
     }
     return vres;
   }

--- a/packages/SwingSet/test/test-gc-transcript.js
+++ b/packages/SwingSet/test/test-gc-transcript.js
@@ -66,8 +66,8 @@ test('gc syscalls are not included in transcript', async t => {
   t.deepEqual(transcript[0], {
     d: m1,
     syscalls: [
-      { d: ['subscribe', 'p-1'], response: null },
-      { d: ['subscribe', 'p-2'], response: null },
+      { d: ['subscribe', 'p-1'], response: ['ok', null] },
+      { d: ['subscribe', 'p-2'], response: ['ok', null] },
     ],
   });
 });
@@ -77,8 +77,8 @@ test('gc syscalls are ignored during replay', async t => {
     {
       d: m1,
       syscalls: [
-        { d: ['subscribe', 'p-1'], response: null },
-        { d: ['subscribe', 'p-2'], response: null },
+        { d: ['subscribe', 'p-1'], response: ['ok', null] },
+        { d: ['subscribe', 'p-2'], response: ['ok', null] },
       ],
     },
   ];

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -160,7 +160,10 @@ test('vat store', async t => {
   ]);
   const data = kernel.dump();
   // check that we're not sticking an undefined into the transcript
-  t.is(data.vatTables[0].state.transcript[1].syscalls[0].response, null);
+  t.deepEqual(data.vatTables[0].state.transcript[1].syscalls[0].response, [
+    'ok',
+    null,
+  ]);
 });
 
 test('map inbound', async t => {
@@ -1204,7 +1207,7 @@ test('transcript', async t => {
           bobForAlice,
           { methargs: capargs(['foo', ['fooarg']]), result: 'p+5' },
         ],
-        response: null,
+        response: ['ok', null],
       },
     ],
   });

--- a/packages/SwingSet/test/vat-admin/replay-bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/replay-bootstrap.js
@@ -14,6 +14,11 @@ export function buildRootObject() {
     },
 
     async createVat() {
+      // cause vat-vattp to record a device error in its transcript,
+      // to exercise the fix for #5511
+      E(vatAdminSvc)
+        .getNamedBundleCap('missing')
+        .catch(_err => 0);
       const bcap = await E(vatAdminSvc).getNamedBundleCap('dynamic');
       const vc = await E(vatAdminSvc).createVat(bcap);
       root = vc.root;


### PR DESCRIPTION
Previously, the transcript only recorded the return data of syscalls,
and assumed that all syscalls succeeded (specifically it assumed that
a failed syscall would terminate the vat, thus removing the need for a
transcript).

But e.g. E(vatAdminSvc).getNamedBundleCap('missing') will provoke a
failing `syscall.invoke` to device-vat-admin, and we need to allow
vat-vat-admin to replay that correctly. So this changes the transcript
to record the full `VatSyscallResult` for all syscalls, including the
`ok`/`err` indicator, and the data of an error.

test-replay.js was changed to include a failed syscall in
vat-vat-admin. If the transcript patch is removed, this causes the
test to fail with "historical inaccuracy in replay of v2".

closes #5511
