### PR TITLE
fix(swingset): use dynamic vat options.name for the xsnap no-op argument

### DIFF
--- a/packages/SwingSet/docs/dynamic-vats.md
+++ b/packages/SwingSet/docs/dynamic-vats.md
@@ -68,7 +68,7 @@ const control = await E(vatAdminService).createVat(bundlecap, options);
 
 `createVat()` recognizes the following options:
 
-* `description` (string): used in debug messages to describe the vat
+* `name` (string): used in debug messages and the `ps`-visible worker argments, to name the vat
 * `meter` (`Meter` object, default none): a Meter object to impose upon the vat. If provided, the Meter will be deducted for each computron spent executing, and the vat will be terminated if the Meter runs out. See docs/metering.md for details.
 * `managerType` (`'local'` or `'xs-worker'` or `'nodeWorker'` or `'node-subprocess'`): the type of worker that will host the vat. `xs-worker` is the only sensible choice. Defaults to a value set by `config.defaultManagerType`, or `xs-worker` if that is not set
 * `vatParameters` (JSON-serializable object): data passed to `buildRootObject` in the `vatParameters` argument

--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -71,7 +71,6 @@ export function initializeKernel(config, hostStorage, verbose = false) {
         'critical',
         'reapInterval',
       ]);
-      creationOptions.description = `static name=${name}`;
       creationOptions.name = name;
       if (creationOptions.useTranscript === undefined) {
         creationOptions.useTranscript = true;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -54,7 +54,7 @@ export function makeXsSubprocessFactory({
       virtualObjectCacheSize,
       enableDisavow,
       gcEveryCrank = true,
-      name,
+      name: vatName,
       metered,
       compareSyscalls,
       useTranscript,
@@ -113,10 +113,14 @@ export function makeXsSubprocessFactory({
 
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
     const lastSnapshot = vatKeeper.getLastSnapshot();
+    // `startXSnap` adds `argName` as a dummy argument so that 'ps'
+    // shows which worker is for which vat, but is careful to prevent
+    // a shell-escape attack
+    const argName = `${vatID}:${vatName !== undefined ? vatName : ''}`;
 
     // start the worker and establish a connection
     const worker = await startXSnap(
-      `${vatID}:${name}`,
+      argName,
       handleCommand,
       metered,
       lastSnapshot ? lastSnapshot.snapshotID : undefined,

--- a/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
+++ b/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
@@ -87,7 +87,7 @@ export function makeVatLoader(stuff) {
   }
 
   const allowedDynamicOptions = [
-    'description',
+    'name',
     'meterID',
     'managerType', // TODO: not sure we want vats to be able to control this
     'enableSetup',
@@ -99,7 +99,6 @@ export function makeVatLoader(stuff) {
   ];
 
   const allowedStaticOptions = [
-    'description',
     'name',
     'managerType',
     'enableDisavow',
@@ -171,7 +170,6 @@ export function makeVatLoader(stuff) {
    *        kernel's configured 'defaultReapInterval' value.
    *
    * @param {string} [options.name]
-   * @param {string} [options.description]
    * @param {boolean} [options.enableDisavow]
    * @param {boolean} [options.critical]
    *
@@ -222,7 +220,7 @@ export function makeVatLoader(stuff) {
       name,
     } = options;
 
-    const description = `${options.description || ''} (${sourceDesc})`.trim();
+    const description = `${options.name || ''} (${sourceDesc})`.trim();
 
     const { starting } = kernelSlog.provideVatSlogger(
       vatID,

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -75,7 +75,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
    * @typedef {{
    *   manager: VatManager,
    *   enablePipelining: boolean,
-   *   options: { name?: string, description?: string, managerType?: ManagerType },
+   *   options: { name?: string, managerType?: ManagerType },
    * }} VatInfo
    * @typedef { ReturnType<typeof import('./vatTranslator').makeVatTranslators> } VatTranslators
    */
@@ -145,7 +145,6 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
     //   vatID,
     //   'online:',
     //   options.managerType,
-    //   options.description || '',
     //   'transcript entries replayed:',
     //   entriesReplayed, // retval of replayTranscript() above
     // );
@@ -249,9 +248,9 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
       return;
     }
     // const {
-    //   options: { description, managerType },
+    //   options: { managerType },
     // } = ephemeral.vats.get(lru) || assert.fail();
-    // console.info('evict', lru, description, managerType, 'for', currentVatID);
+    // console.info('evict', lru, managerType, 'for', currentVatID);
     await evict(lru);
   }
 

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -140,7 +140,7 @@ export function buildRootObject(vatPowers) {
 
   function convertOptions(origOptions) {
     const {
-      description,
+      name,
       meter, // stripped out and converted
       managerType, // TODO: not sure we want vats to be able to control this
       vatParameters, // stripped out and re-added
@@ -154,12 +154,28 @@ export function buildRootObject(vatPowers) {
     } = origOptions;
 
     // these are all flat data: no slots (Presences/Promises/etc)
-    assertType('description', description, 'string');
+    assertType('name', name, 'string');
+    if (name !== undefined) {
+      // The name might be used to build a no-op `xsnap`
+      // argument. xsnap.js guards against shell attacks, but limit
+      // the length to something reasonable. The actual argv length
+      // will be in bytes, not JS chars, so any OS limits will depend
+      // upon encoding, but this ought to avoid any problems.
+      assert(
+        name.length < 200,
+        `CreateVatOptions: oversized vat name '${name}'`,
+      );
+      // more limits to help the 'ps' output be readable
+      assert(
+        /^[A-Za-z0-9._-]+$/.test(name),
+        `CreateVatOptions: bad vat name '${name}'`,
+      );
+    }
     assertType('managerType', managerType, 'string');
     if (managerType) {
       assert(
         managerTypes.includes(managerType),
-        `CreateVatOptions bad managerType ${managerType}`,
+        `CreateVatOptions: bad managerType ${managerType}`,
       );
     }
     assertType('enableSetup', enableSetup, 'boolean');
@@ -171,7 +187,7 @@ export function buildRootObject(vatPowers) {
     // reject unknown options
     const unknown = Object.keys(rest).join(',');
     if (unknown) {
-      assert.fail(`CreateVatOptions unknown options ${unknown}`);
+      assert.fail(`CreateVatOptions: unknown options ${unknown}`);
     }
 
     // convert meter to meterID
@@ -190,7 +206,7 @@ export function buildRootObject(vatPowers) {
 
     // now glue everything back together
     const options = {
-      description,
+      name,
       meterID, // replaces 'meter'
       managerType,
       vatParameters,

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -86,6 +86,6 @@ test('child termination distinguished from meter exhaustion', async t => {
   await t.throwsAsync(p, {
     instanceOf: Error,
     code: 'SIGTERM',
-    message: 'v1:undefined exited due to signal SIGTERM',
+    message: 'v1: exited due to signal SIGTERM',
   });
 });

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -6,7 +6,7 @@ export function buildRootObject() {
   let held;
 
   const adder = Far('adder', { add1: x => x + 1 });
-  const options = { vatParameters: { adder } };
+  const options = { name: 'newvat', vatParameters: { adder } };
 
   return Far('root', {
     async bootstrap(vats, devices) {
@@ -57,6 +57,17 @@ export function buildRootObject() {
 
     async nonBundleCap() {
       return E(admin).createVat(Far('non-bundlecap', {})); // should reject
+    },
+
+    async vatName(name) {
+      const opts = { name, vatParameters: {} };
+      await E(admin).createVatByName('new13', opts);
+      return 'ok';
+    },
+
+    async badOptions() {
+      const opts = { bogus: 'nope' };
+      return E(admin).createVatByName('new13', opts); // should reject
     },
 
     getHeld() {

--- a/packages/SwingSet/test/vat-admin/test-create-vat.js
+++ b/packages/SwingSet/test/vat-admin/test-create-vat.js
@@ -156,6 +156,49 @@ test('error creating vat from non-bundle', async t => {
   );
 });
 
+test('create vat with good-sized name', async t => {
+  const { c } = await doTestSetup(t);
+  const name = 'n'.repeat(199);
+  const kpid = c.queueToVatRoot('bootstrap', 'vatName', [name]);
+  await c.run();
+  t.deepEqual(JSON.parse(c.kpResolution(kpid).body), 'ok');
+});
+
+test('error creating vat with oversized name', async t => {
+  const { c } = await doTestSetup(t);
+  const name = 'n'.repeat(200);
+  const kpid = c.queueToVatRoot('bootstrap', 'vatName', [name]);
+  await c.run();
+  t.is(c.kpStatus(kpid), 'rejected');
+  t.deepEqual(
+    parse(c.kpResolution(kpid).body),
+    Error(`CreateVatOptions: oversized vat name '${'n'.repeat(200)}'`),
+  );
+});
+
+test('error creating vat with bad characters in name', async t => {
+  const { c } = await doTestSetup(t);
+  const name = 'no spaces';
+  const kpid = c.queueToVatRoot('bootstrap', 'vatName', [name]);
+  await c.run();
+  t.is(c.kpStatus(kpid), 'rejected');
+  t.deepEqual(
+    parse(c.kpResolution(kpid).body),
+    Error(`CreateVatOptions: bad vat name 'no spaces'`),
+  );
+});
+
+test('error creating vat with unknown options', async t => {
+  const { c } = await doTestSetup(t);
+  const kpid = c.queueToVatRoot('bootstrap', 'badOptions', []);
+  await c.run();
+  t.is(c.kpStatus(kpid), 'rejected');
+  t.deepEqual(
+    parse(c.kpResolution(kpid).body),
+    Error('CreateVatOptions: unknown options bogus'),
+  );
+});
+
 function findRefs(kvStore, koid) {
   const refs = [];
   const nextVatID = Number(kvStore.get('vat.nextID'));

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -89,6 +89,8 @@ export function xsnap(options) {
   /** @type {Deferred<void>} */
   const vatExit = defer();
 
+  assert(!/^-/.test(name), `name '${name}' cannot start with hyphen`);
+
   let args = [name];
   if (snapshot) {
     args.push('-r', snapshot);

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -421,3 +421,8 @@ test('GC after snapshot vs restore', async t => {
   t.log({ beforeClone, workerGC, cloneGC, iters });
   t.is(workerGC, cloneGC);
 });
+
+test('bad option.name', async t => {
+  const opts = Object.freeze({ ...options(io), name: '--sneaky' });
+  t.throws(() => xsnap(opts), { message: /cannot start with hyphen/ });
+});


### PR DESCRIPTION
fix(swingset): use dynamic vat options.name for the xsnap no-op argument

Previously, static vats would glean a "name" value from the config
structure, and dynamic vats would not get a name. Both kinds of vats
would glean a "description" that combined this name, a `description`
argument provided to `createVat()`, and information about the source
bundle used to create the vat. If `name` was available, it would be
used as an extra no-op argument to `xsnap`, so by looking at `ps`, you
could tell which `xsnap` worker process was hosting which vat.

As we move to bundlecaps (especially as the chain bootstrap code moves
to bundlecaps), we've lost the `name` field in `ps` for most initial
vats.

This change allows the creator of a dynamic vat to provide a `name`
field, just like the config structure can provide then for static
vats. This `name` is now uniformly used in the `ps` arguments.

The `description` option has been removed. Slogfiles still include a
description, and it incorporates the assigned name and source bundle
information, but userspace can no longer provide
`E(vatAdminSvc).createVat(bcap, { description })` in the options.

The `name` field is arbitrarily limited to 200 characters, to avoid
running into OS limitations when `xsnap` includes in in `argv`.

fixes #5516
