### PR TITLE
feat: add config flag to control `fakeDurable`

### DIFF
--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -27,6 +27,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
   kernelKeeper.createStartingKernelState(
     config.defaultManagerType || 'local',
     config.defaultReapInterval || 1,
+    !!config.enableFakeDurable,
   );
 
   for (const id of Object.keys(config.idToBundle || {})) {

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -58,6 +58,7 @@ const enableKernelGC = true;
 //
 // kernel.defaultManagerType = managerType
 // kernel.defaultReapInterval = $NN
+// kernel.enableFakeDurable = missing | 'true'
 
 // v$NN.source = JSON({ bundle }) or JSON({ bundleName })
 // v$NN.options = JSON
@@ -259,8 +260,13 @@ export default function makeKernelKeeper(
   /**
    * @param { ManagerType } defaultManagerType
    * @param { number } defaultReapInterval
+   * @param { boolean } enableFakeDurable
    */
-  function createStartingKernelState(defaultManagerType, defaultReapInterval) {
+  function createStartingKernelState(
+    defaultManagerType,
+    defaultReapInterval,
+    enableFakeDurable,
+  ) {
     kvStore.set('vat.names', '[]');
     kvStore.set('vat.dynamicIDs', '[]');
     kvStore.set('vat.nextID', `${FIRST_VAT_ID}`);
@@ -278,6 +284,9 @@ export default function makeKernelKeeper(
     kvStore.set('crankNumber', `${FIRST_CRANK_NUMBER}`);
     kvStore.set('kernel.defaultManagerType', defaultManagerType);
     kvStore.set('kernel.defaultReapInterval', `${defaultReapInterval}`);
+    if (enableFakeDurable) {
+      kvStore.set('kernel.enableFakeDurable', 'true');
+    }
     // Will be saved in the bootstrap commit
     initializeStats();
   }
@@ -315,6 +324,13 @@ export default function makeKernelKeeper(
     const ri = r === 'never' ? r : Number.parseInt(r, 10);
     assert(ri === 'never' || typeof ri === 'number', `k.dri is '${ri}'`);
     return ri;
+  }
+
+  /**
+   * @returns { boolean }
+   */
+  function getEnableFakeDurable() {
+    return !!kvStore.get('kernel.enableFakeDurable');
   }
 
   const bundleIDRE = new RegExp('^b1-[0-9a-f]{128}$');
@@ -1474,6 +1490,7 @@ export default function makeKernelKeeper(
     createStartingKernelState,
     getDefaultManagerType,
     getDefaultReapInterval,
+    getEnableFakeDurable,
 
     addNamedBundleID,
     getNamedBundleID,

--- a/packages/SwingSet/src/kernel/vat-loader/manager-local.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-local.js
@@ -143,6 +143,7 @@ export function makeLocalVatManagerFactory(tools) {
         gcTools,
         makeVatConsole(makeLogMaker('ls')),
         buildVatNamespace,
+        kernelKeeper.getEnableFakeDurable(),
       );
       assert(ls.dispatch);
       return finish(ls.dispatch);

--- a/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
@@ -105,7 +105,13 @@ export function makeNodeWorkerVatManagerFactory(tools) {
     gotWorker(worker);
 
     parentLog(`instructing worker to load bundle..`);
-    sendToWorker(['setBundle', bundle, virtualObjectCacheSize, enableDisavow]);
+    sendToWorker([
+      'setBundle',
+      bundle,
+      virtualObjectCacheSize,
+      enableDisavow,
+      kernelKeeper.getEnableFakeDurable(),
+    ]);
 
     function deliverToWorker(delivery) {
       parentLog(`sending delivery`, delivery);

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -100,7 +100,13 @@ export function makeNodeSubprocessFactory(tools) {
     fromChild.on('data', handleUpstream);
 
     parentLog(`instructing worker to load bundle..`);
-    sendToWorker(['setBundle', bundle, virtualObjectCacheSize, enableDisavow]);
+    sendToWorker([
+      'setBundle',
+      bundle,
+      virtualObjectCacheSize,
+      enableDisavow,
+      kernelKeeper.getEnableFakeDurable(),
+    ]);
 
     function shutdown() {
       terminate();

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -145,6 +145,7 @@ export function makeXsSubprocessFactory({
         bundle,
         virtualObjectCacheSize,
         enableDisavow,
+        kernelKeeper.getEnableFakeDurable(),
         gcEveryCrank,
       ]);
       if (bundleReply[0] === 'dispatchReady') {

--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -102,6 +102,7 @@ export function makeCollectionManager(
   registerValue,
   serialize,
   unserialize,
+  enableFakeDurable,
 ) {
   // TODO(#5058): we hold a list of all collections (both virtual and
   // durable) in RAM, so we can delete the virtual ones during
@@ -784,6 +785,19 @@ export function makeCollectionManager(
     return Far('weakSetStore', weakSetStore);
   }
 
+  function assertCorrectDurabilityFlags(durable, fakeDurable) {
+    if (fakeDurable) {
+      assert(
+        enableFakeDurable,
+        'fakeDurable may only be used if enableFakeDurable is true',
+      );
+    }
+    assert(
+      !durable || !fakeDurable,
+      'durable and fakeDurable are mutually exclusive',
+    );
+  }
+
   /**
    * Produce a *scalar* big map: keys can only be atomic values, primitives, or
    * remotables.
@@ -802,10 +816,7 @@ export function makeCollectionManager(
       fakeDurable = false,
     } = {},
   ) {
-    assert(
-      !durable || !fakeDurable,
-      'durable and fakeDurable are mutually exclusive',
-    );
+    assertCorrectDurabilityFlags(durable, fakeDurable);
     const kindName = durable ? 'scalarDurableMapStore' : 'scalarMapStore';
     const [vobjID, collection] = makeCollection(
       label,
@@ -856,10 +867,7 @@ export function makeCollectionManager(
       fakeDurable = false,
     } = {},
   ) {
-    assert(
-      !durable || !fakeDurable,
-      'durable and fakeDurable are mutually exclusive',
-    );
+    assertCorrectDurabilityFlags(durable, fakeDurable);
     const kindName = durable
       ? 'scalarDurableWeakMapStore'
       : 'scalarWeakMapStore';
@@ -895,10 +903,7 @@ export function makeCollectionManager(
       fakeDurable = false,
     } = {},
   ) {
-    assert(
-      !durable || !fakeDurable,
-      'durable and fakeDurable are mutually exclusive',
-    );
+    assertCorrectDurabilityFlags(durable, fakeDurable);
     const kindName = durable ? 'scalarDurableSetStore' : 'scalarSetStore';
     const [vobjID, collection] = makeCollection(
       label,
@@ -932,10 +937,7 @@ export function makeCollectionManager(
       fakeDurable = false,
     } = {},
   ) {
-    assert(
-      !durable || !fakeDurable,
-      'durable and fakeDurable are mutually exclusive',
-    );
+    assertCorrectDurabilityFlags(durable, fakeDurable);
     const kindName = durable
       ? 'scalarDurableWeakSetStore'
       : 'scalarWeakSetStore';

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -40,6 +40,7 @@ const DEFAULT_VIRTUAL_OBJECT_CACHE_SIZE = 3; // XXX ridiculously small value to 
  *                      meterControl }
  * @param {Console} console
  * @param {*} buildVatNamespace
+ * @param {boolean} enableFakeDurable
  *
  * @returns {*} { dispatch }
  */
@@ -52,6 +53,7 @@ function build(
   gcTools,
   console,
   buildVatNamespace,
+  enableFakeDurable,
 ) {
   const { WeakRef, FinalizationRegistry, meterControl } = gcTools;
   const enableLSDebug = false;
@@ -601,6 +603,7 @@ function build(
     m.serialize,
     unmeteredUnserialize,
     cacheSize,
+    enableFakeDurable,
   );
 
   const collectionManager = makeCollectionManager(
@@ -615,6 +618,7 @@ function build(
     registerValue,
     m.serialize,
     unmeteredUnserialize,
+    enableFakeDurable,
   );
 
   const watchedPromiseManager = makeWatchedPromiseManager(
@@ -1556,6 +1560,7 @@ function build(
  * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent }
  * @param {Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>} [liveSlotsConsole]
  * @param {*} buildVatNamespace
+ * @param {boolean} enableFakeDurable
  *
  * @returns {*} { vatGlobals, inescapableGlobalProperties, dispatch }
  *
@@ -1590,6 +1595,7 @@ export function makeLiveSlots(
   gcTools,
   liveSlotsConsole = console,
   buildVatNamespace,
+  enableFakeDurable = false,
 ) {
   const allVatPowers = {
     ...vatPowers,
@@ -1604,6 +1610,7 @@ export function makeLiveSlots(
     gcTools,
     liveSlotsConsole,
     buildVatNamespace,
+    enableFakeDurable,
   );
   const { dispatch, startVat, possiblyDeadSet, testHooks } = r; // omit 'm'
   return harden({

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -149,6 +149,7 @@ export function makeCache(size, fetch, store) {
  * @param {*} unserialize  Unserializer for this vat
  * @param {number} cacheSize  How many virtual objects this manager should cache
  *   in memory.
+ * @param {boolean} enableFakeDurable  True iff the associated kernel is running in dev mode.
  *
  * @returns a new virtual object manager.
  *
@@ -189,6 +190,7 @@ export function makeVirtualObjectManager(
   serialize,
   unserialize,
   cacheSize,
+  enableFakeDurable,
 ) {
   const cache = makeCache(cacheSize, fetch, store);
 
@@ -578,6 +580,10 @@ export function makeVirtualObjectManager(
       ({ finish, fakeDurable } = options);
     }
     if (fakeDurable) {
+      assert(
+        enableFakeDurable,
+        `fakeDurable may only be used if enableFakeDurable is true`,
+      );
       assert(
         durable,
         `the fakeDurable option may only be applied to durable objects`,

--- a/packages/SwingSet/src/supervisors/nodeworker/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/supervisors/nodeworker/supervisor-nodeworker.js
@@ -45,7 +45,8 @@ parentPort.on('message', ([type, ...margs]) => {
     workerLog(`got start`);
     sendUplink(['gotStart']);
   } else if (type === 'setBundle') {
-    const [bundle, virtualObjectCacheSize, enableDisavow] = margs;
+    const [bundle, virtualObjectCacheSize, enableDisavow, enableFakeDurable] =
+      margs;
 
     function testLog(...args) {
       sendUplink(['testLog', ...args]);
@@ -111,6 +112,7 @@ parentPort.on('message', ([type, ...margs]) => {
       gcTools,
       makeVatConsole(makeLogMaker(`SwingSet:ls:${vatID}`)),
       buildVatNamespace,
+      enableFakeDurable,
     );
 
     sendUplink(['gotBundle']);

--- a/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
@@ -65,7 +65,8 @@ fromParent.on('data', ([type, ...margs]) => {
     workerLog(`got start`);
     sendUplink(['gotStart']);
   } else if (type === 'setBundle') {
-    const [bundle, virtualObjectCacheSize, enableDisavow] = margs;
+    const [bundle, virtualObjectCacheSize, enableDisavow, enableFakeDurable] =
+      margs;
 
     function testLog(...args) {
       sendUplink(['testLog', ...args]);
@@ -131,6 +132,7 @@ fromParent.on('data', ([type, ...margs]) => {
       gcTools,
       makeVatConsole(makeLogMaker(`SwingSet:ls:${vatID}`)),
       buildVatNamespace,
+      enableFakeDurable,
     );
 
     sendUplink(['gotBundle']);

--- a/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
@@ -185,6 +185,7 @@ function makeWorker(port) {
    * @param {unknown} bundle
    * @param {unknown} virtualObjectCacheSize
    * @param {boolean} enableDisavow
+   * @param {boolean} enableFakeDurable
    * @param {boolean} [gcEveryCrank]
    * @returns { Promise<Tagged> }
    */
@@ -193,6 +194,7 @@ function makeWorker(port) {
     bundle,
     virtualObjectCacheSize,
     enableDisavow,
+    enableFakeDurable,
     gcEveryCrank,
   ) {
     /** @type { (vso: VatSyscallObject) => VatSyscallResult } */
@@ -293,6 +295,7 @@ function makeWorker(port) {
       gcTools,
       makeVatConsole(makeLogMaker('ls')),
       buildVatNamespace,
+      enableFakeDurable,
     );
 
     assert(ls.dispatch);
@@ -308,12 +311,14 @@ function makeWorker(port) {
       case 'setBundle': {
         assert(!dispatch, 'cannot setBundle again');
         const enableDisavow = !!args[3];
-        const gcEveryCrank = args[4] === undefined ? true : !!args[4];
+        const enableFakeDurable = !!args[4];
+        const gcEveryCrank = args[5] === undefined ? true : !!args[5];
         return setBundle(
           args[0],
           args[1],
           args[2],
           enableDisavow,
+          enableFakeDurable,
           gcEveryCrank,
         );
       }

--- a/packages/SwingSet/test/enable-fake-durable/bootstrap-enable-fake-durable.js
+++ b/packages/SwingSet/test/enable-fake-durable/bootstrap-enable-fake-durable.js
@@ -1,0 +1,21 @@
+import { Far } from '@endo/marshal';
+import {
+  makeKindHandle,
+  defineDurableKind,
+  makeScalarBigMapStore,
+} from '@agoric/vat-data';
+
+export function buildRootObject() {
+  return Far('root', {
+    bootstrap() {},
+
+    testStore() {
+      makeScalarBigMapStore('dfstore', { fakeDurable: true });
+    },
+
+    testObj() {
+      const kh = makeKindHandle('kh');
+      defineDurableKind(kh, () => ({}), {}, { fakeDurable: true });
+    },
+  });
+}

--- a/packages/SwingSet/test/enable-fake-durable/test-enable-fake-durable.js
+++ b/packages/SwingSet/test/enable-fake-durable/test-enable-fake-durable.js
@@ -1,0 +1,64 @@
+// eslint-disable-next-line import/order
+import { test } from '../../tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { assert } from '@agoric/assert';
+import { parse } from '@endo/marshal';
+// eslint-disable-next-line import/order
+import { provideHostStorage } from '../../src/controller/hostStorage.js';
+import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
+
+function bfile(name) {
+  return new URL(name, import.meta.url).pathname;
+}
+
+async function testEnableFakeDurable(t, enableFakeDurable) {
+  const config = {
+    bootstrap: 'bootstrap',
+    includeDevDependencies: true, // for vat-data
+    enableFakeDurable,
+    vats: {
+      bootstrap: { sourceSpec: bfile('bootstrap-enable-fake-durable.js') },
+    },
+  };
+
+  const hostStorage = provideHostStorage();
+  await initializeSwingset(config, [], hostStorage);
+  const c = await makeSwingsetController(hostStorage);
+  c.pinVatRoot('bootstrap');
+  await c.run();
+
+  const run = async (method, args = []) => {
+    assert(Array.isArray(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
+    await c.run();
+    const status = c.kpStatus(kpid);
+    const capdata = c.kpResolution(kpid);
+    return [status, capdata];
+  };
+
+  for (const mode of ['testStore', 'testObj']) {
+    // eslint-disable-next-line no-await-in-loop
+    const [status, capdata] = await run(mode);
+    if (enableFakeDurable) {
+      t.is(status, 'fulfilled');
+      t.deepEqual(capdata, { body: '{"@qclass":"undefined"}', slots: [] });
+    } else {
+      t.is(status, 'rejected');
+      const err = parse(capdata.body);
+      t.truthy(err instanceof Error);
+      t.is(
+        err.message,
+        'fakeDurable may only be used if enableFakeDurable is true',
+      );
+    }
+  }
+}
+
+test('enableFakeDurable=true', async t => {
+  return testEnableFakeDurable(t, true);
+});
+
+test('enableFakeDurable=false', async t => {
+  return testEnableFakeDurable(t, false);
+});

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -146,6 +146,7 @@ export async function makeDispatch(
     () => {
       return { buildRootObject: build };
     },
+    false,
   );
   await startVat(capargs());
   if (returnTestHooks) {

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -1005,6 +1005,7 @@ test('dropImports', async t => {
     () => {
       return { buildRootObject: build };
     },
+    false,
   );
   const { dispatch, startVat, possiblyDeadSet } = ls;
   await startVat(capargs());
@@ -1142,6 +1143,7 @@ test('buildVatNamespace not called until after startVat', async t => {
     gcTools,
     undefined,
     () => ({ buildRootObject }),
+    false,
   );
   t.falsy(buildCalled);
   await ls.startVat(capargs());

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -41,6 +41,7 @@ test('child termination distinguished from meter exhaustion', async t => {
       getLastSnapshot: () => undefined,
       addToTranscript: () => undefined,
     }),
+    getEnableFakeDurable: () => false,
   };
 
   const xsWorkerFactory = makeXsSubprocessFactory({

--- a/packages/SwingSet/tools/fakeCollectionManager.js
+++ b/packages/SwingSet/tools/fakeCollectionManager.js
@@ -17,6 +17,7 @@ export function makeFakeCollectionManager(vrm, fakeStuff, _options = {}) {
     fakeStuff.registerEntry,
     fakeStuff.marshal.serialize,
     fakeStuff.marshal.unserialize,
+    true,
   );
   initializeStoreKindInfo();
 

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -33,6 +33,7 @@ export function makeFakeVirtualObjectManager(vrm, fakeStuff, options = {}) {
     fakeStuff.marshal.serialize,
     fakeStuff.marshal.unserialize,
     cacheSize,
+    true,
   );
 
   const normalVOM = {


### PR DESCRIPTION
Swingset now forbids the use of the `fakeDurable` feature unless a global config flag `enableFakeDurable` is set to true in the kernel's config options.

`fakeDurable` is enabled without configuration in the mock virtual stuff.

Closes #5489
