### PR TITLE
fix: don't add manager-helper method, use kernelKeeper directly

### DIFF
--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -51,7 +51,6 @@ import { makeTranscriptManager } from './transcript.js';
  *                           makeSnapshot?: (ss: SnapStore) => Promise<string>) => VatManager,
  *              syscallFromWorker: (vso: VatSyscallObject) => VatSyscallResult,
  *              setDeliverToWorker: (dtw: unknown) => void,
- *              getEnableFakeDurable: () => boolean,
  *            } } ManagerKit
  *
  */
@@ -266,13 +265,6 @@ function makeManagerKit(
   }
 
   /**
-   * @returns { boolean }
-   */
-  function getEnableFakeDurable() {
-    return kernelKeeper.getEnableFakeDurable();
-  }
-
-  /**
    *
    * @param { () => Promise<void>} shutdown
    * @param { (ss: SnapStore) => Promise<string> } makeSnapshot
@@ -288,12 +280,7 @@ function makeManagerKit(
     });
   }
 
-  return harden({
-    getManager,
-    syscallFromWorker,
-    setDeliverToWorker,
-    getEnableFakeDurable,
-  });
+  return harden({ getManager, syscallFromWorker, setDeliverToWorker });
 }
 harden(makeManagerKit);
 export { makeManagerKit };

--- a/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
@@ -110,7 +110,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       bundle,
       virtualObjectCacheSize,
       enableDisavow,
-      mk.getEnableFakeDurable(),
+      kernelKeeper.getEnableFakeDurable(),
     ]);
 
     function deliverToWorker(delivery) {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -105,7 +105,7 @@ export function makeNodeSubprocessFactory(tools) {
       bundle,
       virtualObjectCacheSize,
       enableDisavow,
-      mk.getEnableFakeDurable(),
+      kernelKeeper.getEnableFakeDurable(),
     ]);
 
     function shutdown() {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -145,7 +145,7 @@ export function makeXsSubprocessFactory({
         bundle,
         virtualObjectCacheSize,
         enableDisavow,
-        mk.getEnableFakeDurable(),
+        kernelKeeper.getEnableFakeDurable(),
         gcEveryCrank,
       ]);
       if (bundleReply[0] === 'dispatchReady') {


### PR DESCRIPTION
test to see if we can remove the manager-helper.js `mk.getEnableFakeDurable()` helper method
