### PR TITLE
fix(swingset): improve timer device

### DIFF
--- a/packages/SwingSet/docs/timer.md
+++ b/packages/SwingSet/docs/timer.md
@@ -5,71 +5,104 @@ architecture](devices.md). In order to install a Timer device, you first build
 a timer object in order to create the timer's endowments, source code, and 
 `poll()` function.
 
+## Kernel Configuration
+
+The timer service consists of a device (`device-timer`) and a helper vat (`vat-timer`). The host application must configure the device as it builds the swingset kernel, and then the bootstrap vat must finish the job by wiring the device and vat together.
+
 ```
-import { buildTimer, getTimerWrapperSourcePath } from `@agoric/swingset-vat`;
+import { buildTimer } from `@agoric/swingset-vat`;
 const timer = buildTimer();
 ```
 
-Then when configuring devices, the timer device can be added:
+The `timer` record contains three items: a `srcPath` that points to the timer device source code, an `endowments` which must be provided to the timer device instance, and a `poll` function for use by the host application.
 
-```
+The timer vat is added automatically, but the `config` record must still define the timer device:
+
+```js
 config.devices = [
    ...
-  ['timer', timer.srcPath, timer.endowments],
+  timer: { sourceSpec: timer.srcPath },
 ];
 ```
-    
-and the Timer vat set up: 
-```
-config.vats.set('timer', { sourcepath: getTimerWrapperSourcePath() });
-```
 
-The `t.poll(now)` must be called periodically (usually at Block start time)
-with the current time. When `poll()` returns true, the kernel has work to do, 
-and we must call `controller.run()` and manage any resulting state updates.
-
-The "wrapper" vat has to provide a function to allow registering the device
-and creating the service. The vat is responsible for creating repeater objects
-to wrap the device node as a capability that can be accessed by regular vat
-code.
-
-In `bootstrap()` for a particular SwingSet, we create a timerService, and make
-it accessible to the user in `home.localTimerService` (whose timestamps are
-measured in milliseconds).
-
-```
-const timerService = E(vats.timerWrapper).createTimerService(devices.timer);
-```
-
-Then users in the REPL can use the `localTimerService` (in milliseconds since
-the epoch) or `chainTimerService` (in seconds since the epoch) to schedule wakeups.
-
-There is a simple promise-based `delay` function that resolves its returned promise
-when at least its first `delay` argument has passed.
+and when creating the swingset controller, the `deviceEndowments` record must include the timer's endowments:
 
 ```js
-E(home.localTimerService).delay(60_000n);
+const deviceEndowments = {
+  timer: { timer.endowments },
+};
+..
+await initializeSwingset(config, [], hostStorage);
+const c = await makeSwingsetController(hostStorage, deviceEndowments);
 ```
 
-This promise will resolve to the current timestamp after 60 seconds from now.
+## Bootstrap Registration
 
-Alteratively, if you wish to be able to cancel the delay, you can use the more
-powerful `setWakeup` method:
+The timer vat is created automatically, but it must still be wired up. Within your `bootstrap` vat, during the `bootstrap()` call, do the following:
 
 ```js
-timestamp = E(home.localTimerService).getCurrentTimestamp();
-
-handler = Far('waker', { wake(now) { console.log(`woke up ${now}`); } });
-willWakeAt = E(home.localTimerService).setWakeup(timestamp + 60_000n, handler);
+async function bootstrap(vats, devices) {
+  const timerService = await E(vats.timer).createTimerService(devices.timer);
+  ...
+  // use timerService
+}
 ```
 
-The handler will fire somewhat after 60 seconds from now.
+The `timerService` Presence returned by `createTimerService` is the API handle from which all timer services are obtained.
+
+## Host Application Invokes poll()
+
+Once the kernel is started, the host application will call `timer.poll(now)` periodically with the current time. This is the device's only way to learn about the passing of time. It remembers the most recent value to satisfy `getCurrentTimestamp()` requests, and it compares `now` against the list of upcoming wakeups and repeating timers to decide if something needs to be scheduled.
+
+This should be called when the kernel is idle (i.e. *not* in the middle of a `controller.run()`), as it will push callback events onto the run-queue. In a consensus machine (blockchain), this is typically called at the beginning of each block's transaction processing phase.
+
+`poll()` will return `true` if any work was pushed onto the queue, or `false` if not. In a non-consensus (solo)  machine, it may be appropriate to skip a `controller.run()` if `poll()` does not report any work being added. In a consensus machine, the return value should be ignored.
+
+Note that `poll()` (and indeed the entire timer service) is agnostic as to what "time" means. You might choose to use seconds, milliseconds, a block height, or any non-decreasing integer. In a blockchain application, you might either use block height, or a consensus-managed block time. In a solo application, the standard unix seconds-since-epoch would be appropriate. The one constraint is that the value is a BigInt that never decreases (`poll(oldTime)` will throw an Error).
+
+A single application might have multiple sources of time, which would require the creation and configuration of multiple timer device+vat pairs.
+
+## Using the Timer Service
+
+The `timerService` object can be distributed to other vats as necessary.
 
 ```js
-repeater = E(home.localTimerService).makeRepeater(20_000n, 60_000n);
-E(repeater).schedule(handler);
-```
+  // for this example, assume poll() provides seconds-since-epoch as a BigInt
 
-The handler will fire in somewhat after 80 seconds from now, and every 60
-seconds thereafter. Calling `E(repeater).disable()` will cancel the repeater and
-prevent it from scheduling future activations
+  const now = await E(timerService).getCurrentTimestamp();
+  
+  // simple non-cancellable Promise-based delay
+  const p = E(timerService).delay(30); // fires 30 seconds from now
+  await p;
+
+  // to cancel wakeups, first build a handler
+
+  const handler = Far('handler', {
+    wake(t) { console.log(`woken up at ${t}`); },
+  });
+  
+  // then for one-shot wakeups:
+  await E(timerService).setWakeup(startTime, handler);
+  // handler.wake(t) will be called shortly after 'startTime'
+
+  // cancel early:
+  await E(timerService).removeWakeup(handler);
+
+  // wake up at least 60 seconds from now:
+  await E(timerService).setWakeup(now + 60n, handler);
+
+
+  // makeRepeater() creates a repeating wakeup service: the handler will
+  // fire somewhat after 80 seconds from now (delay+interval), and again
+  // every 60 seconds thereafter. Individual wakeups might be delayed,
+  // but the repeater will not accumulate drift.
+
+  const delay = 20n;
+  const interval = 60n;
+  const r = E(timerService).makeRepeater(delay, interval);
+  E(r).schedule(handler);
+  E(r).disable(); // cancel and delete entire repeater
+  
+  // repeating wakeup service, Notifier-style
+  const notifier = E(timerService).makeNotifier(delay, interval);
+```

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -134,12 +134,15 @@ function makeTimerMap(state = undefined) {
   // We don't expect this to be called often, so we don't optimize for it.
   function remove(targetHandler) {
     const droppedTimes = [];
-    for (let i = 0; i < schedule.length; i += 1) {
+    let i = 0;
+    while (i < schedule.length) {
       const { time, handlers } = schedule[i];
       if (handlers.length === 1) {
         if (handlers[0].handler === targetHandler) {
           schedule.splice(i, 1);
           droppedTimes.push(time);
+        } else {
+          i += 1;
         }
       } else {
         // Nothing prevents a particular handler from appearing more than once
@@ -151,6 +154,8 @@ function makeTimerMap(state = undefined) {
         }
         if (handlers.length === 0) {
           schedule.splice(i, 1);
+        } else {
+          i += 1;
         }
       }
     }
@@ -274,7 +279,7 @@ export function buildRootDeviceNode(tools) {
     removeWakeup(handler) {
       const times = deadlines.remove(handler);
       saveState();
-      return times;
+      return harden(times);
     },
     getLastPolled,
 

--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -2,7 +2,7 @@
 
 import { Nat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';
-import { Far } from '@endo/marshal';
+import { Far, passStyleOf } from '@endo/marshal';
 import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeTimedIterable } from './timed-iteration.js';
@@ -18,11 +18,16 @@ export function buildRootObject(vatPowers) {
         return Nat(D(timerNode).getLastPolled());
       },
       setWakeup(baseTime, handler) {
+        assert(passStyleOf(handler) === 'remotable', 'bad setWakeup() handler');
         baseTime = Nat(baseTime);
         return D(timerNode).setWakeup(baseTime, handler);
       },
       // can be used after setWakeup(h) or schedule(h)
       removeWakeup(handler) {
+        assert(
+          passStyleOf(handler) === 'remotable',
+          'bad removeWakeup() handler',
+        );
         return D(timerNode).removeWakeup(handler);
       },
       makeRepeater(delay, interval) {

--- a/packages/SwingSet/test/timer/bootstrap-timer.js
+++ b/packages/SwingSet/test/timer/bootstrap-timer.js
@@ -1,0 +1,41 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+export function buildRootObject() {
+  let ts;
+  const events = [];
+  const handler = Far('handler', {
+    wake(time) {
+      events.push(time);
+    },
+  });
+
+  return Far('root', {
+    async bootstrap(vats, devices) {
+      ts = await E(vats.timer).createTimerService(devices.timer);
+    },
+    async installWakeup(baseTime) {
+      return E(ts).setWakeup(baseTime, handler);
+    },
+    async getEvents() {
+      // we need 'events' to remain mutable, but return values are
+      // hardened, so clone the array first
+      const ret = Array.from(events);
+      events.length = 0;
+      return ret;
+    },
+    async removeWakeup() {
+      return E(ts).removeWakeup(handler);
+    },
+
+    async banana(baseTime) {
+      try {
+        console.log(`intentional 'bad setWakeup() handler' error follows`);
+        await E(ts).setWakeup(baseTime, 'banana');
+      } catch (e) {
+        return e.message;
+      }
+      throw Error('banana too slippery');
+    },
+  });
+}

--- a/packages/SwingSet/test/timer/test-timer.js
+++ b/packages/SwingSet/test/timer/test-timer.js
@@ -1,0 +1,74 @@
+import { test } from '../../tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { parse } from '@endo/marshal';
+import { provideHostStorage } from '../../src/controller/hostStorage.js';
+import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
+import { buildTimer } from '../../src/devices/timer/timer.js';
+
+const bfile = name => new URL(name, import.meta.url).pathname;
+
+test('timer vat', async t => {
+  const timer = buildTimer();
+  const config = {
+    bootstrap: 'bootstrap',
+    vats: { bootstrap: { sourceSpec: bfile('bootstrap-timer.js') } },
+    devices: { timer: { sourceSpec: timer.srcPath } },
+  };
+
+  const hostStorage = provideHostStorage();
+  const deviceEndowments = {
+    timer: { ...timer.endowments },
+  };
+  await initializeSwingset(config, [], hostStorage);
+  const c = await makeSwingsetController(hostStorage, deviceEndowments);
+  c.pinVatRoot('bootstrap');
+  timer.poll(1n); // initial time
+  await c.run();
+
+  const run = async (method, args = []) => {
+    assert(Array.isArray(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
+    await c.run();
+    const status = c.kpStatus(kpid);
+    const capdata = c.kpResolution(kpid);
+    t.is(status, 'fulfilled', JSON.stringify([status, capdata]));
+    return capdata;
+  };
+
+  const cd1 = await run('installWakeup', [3n]); // baseTime=3
+  t.deepEqual(parse(cd1.body), 3n); // echoes the wakeup time
+
+  const cd2 = await run('getEvents');
+  t.deepEqual(parse(cd2.body), []); // no wakeups yet
+
+  timer.poll(2n); // time passes but not enough
+  await c.run();
+
+  const cd3 = await run('getEvents');
+  t.deepEqual(parse(cd3.body), []); // no wakeups yet
+
+  timer.poll(4n); // yes enough
+  await c.run();
+
+  const cd4 = await run('getEvents');
+  t.deepEqual(parse(cd4.body), [3n]); // scheduled time
+
+  const cd5 = await run('installWakeup', [5n]);
+  t.deepEqual(parse(cd5.body), 5n);
+  const cd6 = await run('installWakeup', [6n]);
+  t.deepEqual(parse(cd6.body), 6n);
+  // If you added the same handler multiple times, removeWakeup()
+  // would remove them all. It returns a list of wakeup timestamps.
+  const cd7 = await run('removeWakeup');
+  t.deepEqual(parse(cd7.body), [5n, 6n]);
+
+  timer.poll(7n);
+  await c.run();
+
+  const cd8 = await run('getEvents');
+  t.deepEqual(parse(cd8.body), []); // cancelled before wakeup
+
+  const cd9 = await run('banana', [10n]);
+  t.deepEqual(parse(cd9.body), 'bad setWakeup() handler');
+});


### PR DESCRIPTION
Previously, calling `setWakeup()` with an invalid handler would cause
the chain to halt when the wakeup time arrived: an exception was
raised while the host application called `poll()`. Now we check the
handler earlier, during `setWakeup()`, and throw an error immediately,
which is delivered as a rejected promise to the vat that invoked
`E(timerService).setWakeup()`.

fixes #4297

While writing the test, I found and fixed another bug. If the same
handler was added multiple times, `removeWakeup()` is supposed to
remove all instances. An iteration-over-shrinking-array bug caused
some instances to remain if they appeared in immediately successive
time slots.

The docs were updated to current configuration practices.
