### PR TITLE
fix adjusting balances after interest charged

### DIFF
--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -13,6 +13,7 @@ import { makeTracer } from '../makeTracer.js';
 const trace = makeTracer('PV');
 
 /** @typedef {import('./vault').Vault} Vault */
+/** @typedef {import('./storeUtils.js').NormalizedDebt} NormalizedDebt */
 
 /**
  *
@@ -112,7 +113,7 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
 
   /**
    *
-   * @param {Amount<'nat'>} oldDebt
+   * @param {NormalizedDebt} oldDebt
    * @param {Amount<'nat'>} oldCollateral
    * @param {string} vaultId
    */
@@ -164,7 +165,7 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
   }
 
   /**
-   * @param {Amount<'nat'>} oldDebt
+   * @param {NormalizedDebt} oldDebt
    * @param {Amount<'nat'>} oldCollateral
    * @param {string} vaultId
    */

--- a/packages/run-protocol/src/vaultFactory/storeUtils.js
+++ b/packages/run-protocol/src/vaultFactory/storeUtils.js
@@ -57,11 +57,15 @@ const decodeNumber = encoded => {
   return result;
 };
 
+// Type annotations to support static testing of amount values
+/** @typedef {Amount<'nat'> & {normalized: true}} NormalizedDebt */
+/** @typedef {Amount<'nat'> & {normalized: false}} ActualDebt */
+
 /**
  * Overcollateralized are greater than one.
  * The more undercollaterized the smaller in [0-1].
  *
- * @param {Amount<'nat'>} normalizedDebt normalized (not actual) total debt
+ * @param {NormalizedDebt} normalizedDebt normalized (not actual) total debt
  * @param {Amount<'nat'>} collateral
  * @returns {number}
  */
@@ -76,7 +80,7 @@ const collateralizationRatio = (normalizedDebt, collateral) => {
 /**
  * Sorts by ratio in descending debt. Ordering of vault id is undefined.
  *
- * @param {Amount<'nat'>} normalizedDebt normalized (not actual) total debt
+ * @param {NormalizedDebt} normalizedDebt normalized (not actual) total debt
  * @param {Amount<'nat'>} collateral
  * @param {VaultId} vaultId
  * @returns {string} lexically sortable string in which highest

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -242,21 +242,21 @@ const helperBehavior = {
    * maintain aggregate debt and liquidation order.
    *
    * @param {MethodContext} context
-   * @param {NormalizedDebt} oldDebt - prior principal and all accrued interest
+   * @param {NormalizedDebt} oldDebtNormalized - prior principal and all accrued interest, normalized to the launch of the vaultManager
    * @param {Amount<'nat'>} oldCollateral - actual collateral
-   * @param {Amount<'nat'>} newDebt - actual principal and all accrued interest
+   * @param {Amount<'nat'>} newDebtActual - actual principal and all accrued interest
    */
   updateDebtAccounting: (
     { state, facets },
-    oldDebt,
+    oldDebtNormalized,
     oldCollateral,
-    newDebt,
+    newDebtActual,
   ) => {
     const { helper } = facets;
-    helper.updateDebtSnapshot(newDebt);
+    helper.updateDebtSnapshot(newDebtActual);
     // update position of this vault in liquidation priority queue
     state.manager.updateVaultAccounting(
-      oldDebt,
+      oldDebtNormalized,
       oldCollateral,
       state.idInManager,
     );
@@ -438,7 +438,7 @@ const helperBehavior = {
     const proposal = clientSeat.getProposal();
     assertOnlyKeys(proposal, ['Collateral', 'RUN']);
 
-    const debtPre = self.getCurrentDebt();
+    const normalizedDebtPre = self.getNormalizedDebt();
     const collateralPre = helper.getCollateralAllocated(vaultSeat);
 
     const giveColl = proposal.give.Collateral || helper.emptyCollateral();
@@ -492,9 +492,7 @@ const helperBehavior = {
     state.manager.mintAndReallocate(toMint, fee, clientSeat, vaultSeat);
 
     // parent needs to know about the change in debt
-    console.log('DEBUG updateDebtAccounting', { debtPre });
-    console.trace();
-    helper.updateDebtAccounting(debtPre, collateralPre, newDebt);
+    helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebt);
     state.manager.burnAndRecord(giveRUN, vaultSeat);
     helper.assertVaultHoldsNoRun();
 
@@ -539,10 +537,11 @@ const selfBehavior = {
       X`vault must be empty initially`,
     );
     // TODO should this be simplified to know that the oldDebt mut be empty?
-    const debtPre = self.getCurrentDebt();
+    const normalizedDebtPre = self.getNormalizedDebt();
+    const actualDebtPre = self.getCurrentDebt();
     const collateralPre = self.getCollateralAmount();
     trace('initVaultKit start: collateral', state.idInManager, {
-      debtPre,
+      actualDebtPre,
       collateralPre,
     });
 
@@ -557,7 +556,7 @@ const selfBehavior = {
       newDebt: newDebtPre,
       fee,
       toMint,
-    } = helper.loanFee(debtPre, helper.emptyDebt(), wantRUN);
+    } = helper.loanFee(actualDebtPre, helper.emptyDebt(), wantRUN);
     assert(
       !AmountMath.isEmpty(fee),
       X`loan requested (${wantRUN}) is too small; cannot accrue interest`,
@@ -577,7 +576,7 @@ const selfBehavior = {
       seat.decrementBy(harden({ Collateral: giveCollateral })),
     );
     state.manager.mintAndReallocate(toMint, fee, seat, vaultSeat);
-    helper.updateDebtAccounting(debtPre, collateralPre, newDebtPre);
+    helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebtPre);
 
     const vaultKit = makeVaultKit(self, state.manager.getNotifier());
     state.outerUpdater = vaultKit.vaultUpdater;

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -536,19 +536,19 @@ const managerBehavior = {
    * Called by a vault when its balances change.
    *
    * @param {MethodContext} context
-   * @param {NormalizedDebt} oldDebt
+   * @param {NormalizedDebt} oldDebtNormalized
    * @param {Amount<'nat'>} oldCollateral
    * @param {VaultId} vaultId
    */
   updateVaultAccounting: (
     { state, facets },
-    oldDebt,
+    oldDebtNormalized,
     oldCollateral,
     vaultId,
   ) => {
     const { prioritizedVaults } = state;
     const vault = prioritizedVaults.refreshVaultPriority(
-      oldDebt,
+      oldDebtNormalized,
       oldCollateral,
       vaultId,
     );

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -33,6 +33,8 @@ const { details: X } = assert;
 
 const trace = makeTracer('VM', false);
 
+/** @typedef {import('./storeUtils.js').NormalizedDebt} NormalizedDebt */
+
 // Metrics naming scheme: nouns are present values; past-participles are accumulative.
 /**
  * @typedef {object} MetricsNotification
@@ -534,7 +536,7 @@ const managerBehavior = {
    * Called by a vault when its balances change.
    *
    * @param {MethodContext} context
-   * @param {Amount<'nat'>} oldDebt
+   * @param {NormalizedDebt} oldDebt
    * @param {Amount<'nat'>} oldCollateral
    * @param {VaultId} vaultId
    */

--- a/packages/run-protocol/test/vaultFactory/test-prioritizedVaults.js
+++ b/packages/run-protocol/test/vaultFactory/test-prioritizedVaults.js
@@ -127,6 +127,7 @@ test('update changes ratio', async t => {
   // update the fake debt of the vault and then refresh priority queue
   fakeVault1.setDebt(AmountMath.make(brand, 95n));
   vaults.refreshVaultPriority(
+    // @ts-expect-error cast
     AmountMath.make(brand, 20n),
     AmountMath.make(brand, 100n), // default collateral of makeFakeVaultKit
     'id-fakeVault1',
@@ -170,6 +171,7 @@ test('removals', async t => {
   // remove fake 3
   rescheduler.resetCalled();
   vaults.removeVaultByAttributes(
+    // @ts-expect-error cast
     AmountMath.make(brand, 140n),
     AmountMath.make(brand, 100n), // default collateral of makeFakeVaultKit
     'id-fakeVault3',
@@ -180,6 +182,7 @@ test('removals', async t => {
   // remove fake 1
   rescheduler.resetCalled();
   vaults.removeVaultByAttributes(
+    // @ts-expect-error cast
     AmountMath.make(brand, 150n),
     AmountMath.make(brand, 100n), // default collateral of makeFakeVaultKit
     'id-fakeVault1',
@@ -189,6 +192,7 @@ test('removals', async t => {
 
   t.throws(() =>
     vaults.removeVaultByAttributes(
+      // @ts-expect-error cast
       AmountMath.make(brand, 150n),
       AmountMath.make(brand, 100n),
       'id-fakeVault1',

--- a/packages/run-protocol/test/vaultFactory/test-storeUtils.js
+++ b/packages/run-protocol/test/vaultFactory/test-storeUtils.js
@@ -38,6 +38,7 @@ for (const [debt, collat, vaultId, expectedKey, numberOut] of [
 ]) {
   test(`vault keys: (${debt}/${collat}, ${vaultId}) => ${expectedKey} ==> ${numberOut}, ${vaultId}`, t => {
     const key = StoreUtils.toVaultKey(
+      // @ts-expect-error cast to NormalizedDebt
       AmountMath.make(mockBrand, BigInt(debt)),
       AmountMath.make(mockBrand, BigInt(collat)),
       String(vaultId),

--- a/packages/run-protocol/test/vaultFactory/test-vault-interest.js
+++ b/packages/run-protocol/test/vaultFactory/test-vault-interest.js
@@ -16,7 +16,7 @@ import { assert } from '@agoric/assert';
 import { makeTracer } from '../../src/makeTracer.js';
 
 const vaultRoot = './vault-contract-wrapper.js';
-const trace = makeTracer('TestVault');
+const trace = makeTracer('TestVaultInterest');
 
 /**
  * The properties will be asssigned by `setTestJig` in the contract.
@@ -111,7 +111,8 @@ test('charges', async t => {
 
   let interest = 0n;
   for (const [i, charge] of [3n, 4n, 4n, 4n].entries()) {
-    testJig.advanceRecordingPeriod();
+    // eslint-disable-next-line no-await-in-loop
+    await testJig.advanceRecordingPeriod();
     interest += charge;
     t.is(
       vault.getCurrentDebt().value,
@@ -121,7 +122,7 @@ test('charges', async t => {
     t.is(vault.getNormalizedDebt().value, startingDebt);
   }
 
-  // partially payback
+  trace('partially payback');
   const paybackValue = 3n;
   const collateralWanted = AmountMath.make(cBrand, 1n);
   const paybackAmount = AmountMath.make(runBrand, paybackValue);
@@ -148,7 +149,8 @@ test('charges', async t => {
   testJig.setInterestRate(25n);
 
   for (const [i, charge] of [21n, 27n, 33n].entries()) {
-    testJig.advanceRecordingPeriod();
+    // eslint-disable-next-line no-await-in-loop
+    await testJig.advanceRecordingPeriod();
     interest += charge;
     t.is(
       vault.getCurrentDebt().value,


### PR DESCRIPTION
closes: #5530

## Description

Fixes #5530

We did have a test that charged interest and then adjusted balances: https://github.com/Agoric/agoric-sdk/blob/4c9e50ac3a9420e18b789adb618c4503af097b1c/packages/run-protocol/test/vaultFactory/test-vault-interest.js#L112-L125

But the error required exercising `updateVaultAccounting` and the test ran https://github.com/Agoric/agoric-sdk/blob/4c9e50ac3a9420e18b789adb618c4503af097b1c/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js#L143-L145
Adds to the motivation to remove that wrapper. https://github.com/Agoric/agoric-sdk/issues/5443 (h/t Hibbert)

I made a new test case in `test-vaultFactory` which reproed. Then I added a static type `NormalizedDebt` to find exactly where the wrong kind of value was being passed in.

### Security Considerations

--
### Documentation Considerations

Will land as merge commit.

### Testing Considerations

New test. 