### PR TITLE
only hold vaults that aren't settled

### DIFF
--- a/packages/run-protocol/src/reserve/assetReserve.js
+++ b/packages/run-protocol/src/reserve/assetReserve.js
@@ -10,7 +10,7 @@ import { makeSubscriptionKit } from '@agoric/notifier';
 import { AMM_INSTANCE } from './params.js';
 import { makeTracer } from '../makeTracer.js';
 
-const trace = makeTracer('Reserve', true);
+const trace = makeTracer('Reserve', false);
 
 const makeLiquidityKeyword = keyword => `${keyword}Liquidity`;
 
@@ -166,7 +166,6 @@ const start = async (zcf, privateArgs) => {
     const issuer = await E(ammPublicFacet).getSecondaryIssuer(
       ammSecondaryBrand,
     );
-    console.debug({ issuer });
     await addIssuer(issuer, keyword);
   };
 

--- a/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
@@ -46,15 +46,17 @@ export const makeOrderedVaultStore = () => {
       store.delete(key);
       return vault;
     } catch (e) {
-      const keys = Array.from(store.keys());
       console.error(
         'removeByKey failed to remove',
         key,
         'parts:',
         fromVaultKey(key),
       );
-      console.error('  key literals:', keys);
-      console.error('  key parts:', keys.map(fromVaultKey));
+      const keys = Array.from(store.keys());
+      console.error(
+        '  contents:',
+        keys.map(k => [k, fromVaultKey[k]]),
+      );
       throw e;
     }
   };

--- a/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
@@ -49,7 +49,7 @@ export const makeOrderedVaultStore = () => {
       console.error(
         'removeByKey failed to remove',
         key,
-        'parts:',
+        '[ratio, vaultId]:',
         fromVaultKey(key),
       );
       const keys = Array.from(store.keys());
@@ -64,6 +64,7 @@ export const makeOrderedVaultStore = () => {
   return harden({
     addVault,
     removeByKey,
+    has: store.has,
     keys: store.keys,
     entries: store.entries,
     getSize: store.getSize,

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -10,7 +10,7 @@ import { makeOrderedVaultStore } from './orderedVaultStore.js';
 import { toVaultKey } from './storeUtils.js';
 import { makeTracer } from '../makeTracer.js';
 
-const trace = makeTracer('PV');
+const trace = makeTracer('PV', false);
 
 /** @typedef {import('./vault').Vault} Vault */
 /** @typedef {import('./storeUtils.js').NormalizedDebt} NormalizedDebt */

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -86,7 +86,7 @@ const validTransitions = {
  * @property {MintAndReallocate} mintAndReallocate
  * @property {(amount: Amount, seat: ZCFSeat) => void} burnAndRecord
  * @property {() => Ratio} getCompoundedInterest
- * @property {(oldDebt: import('./storeUtils.js').NormalizedDebt, oldCollateral: Amount<'nat'>, vaultId: VaultId) => void} updateVaultAccounting
+ * @property {(oldDebt: import('./storeUtils.js').NormalizedDebt, oldCollateral: Amount<'nat'>, vaultId: VaultId, vaultPhase: VaultPhase) => void} handleBalanceChange
  * @property {() => import('./vaultManager.js').GovernedParamGetters} getGovernedParams
  */
 
@@ -254,11 +254,12 @@ const helperBehavior = {
   ) => {
     const { helper } = facets;
     helper.updateDebtSnapshot(newDebtActual);
-    // update position of this vault in liquidation priority queue
-    state.manager.updateVaultAccounting(
+    // notify manager so it can notify and clean up as appropriate
+    state.manager.handleBalanceChange(
       oldDebtNormalized,
       oldCollateral,
       state.idInManager,
+      state.phase,
     );
   },
 
@@ -405,10 +406,11 @@ const helperBehavior = {
     helper.assertVaultHoldsNoRun();
     vaultSeat.exit();
 
-    state.manager.updateVaultAccounting(
+    state.manager.handleBalanceChange(
       oldDebtNormalized,
       oldCollateral,
       state.idInManager,
+      state.phase,
     );
 
     return 'your loan is closed, thank you for your business';

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -360,6 +360,11 @@ const helperBehavior = {
     const { self, helper } = facets;
     helper.assertCloseable();
     const { phase, vaultSeat } = state;
+
+    // Held as keys for cleanup in the manager
+    const oldDebtNormalized = self.getNormalizedDebt();
+    const oldCollateral = self.getCollateralAmount();
+
     if (phase === Phase.ACTIVE) {
       assertProposalShape(seat, {
         give: { RUN: null },
@@ -399,6 +404,12 @@ const helperBehavior = {
 
     helper.assertVaultHoldsNoRun();
     vaultSeat.exit();
+
+    state.manager.updateVaultAccounting(
+      oldDebtNormalized,
+      oldCollateral,
+      state.idInManager,
+    );
 
     return 'your loan is closed, thank you for your business';
   },

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -283,6 +283,7 @@ const machineBehavior = {
         seat.incrementBy(mintSeat.decrementBy(harden({ RUN: kept })));
         zcf.reallocate(rewardPoolSeat, mintSeat, seat, ...otherSeats);
       } catch (e) {
+        console.error('mintAndReallocate caught', e);
         mintSeat.clear();
         rewardPoolSeat.clear();
         // Make best efforts to burn the newly minted tokens, for hygiene.
@@ -292,6 +293,9 @@ const machineBehavior = {
         debtMint.burnLosses(harden({ RUN: toMint }), mintSeat);
         throw e;
       } finally {
+        // Note that if this assertion may fail because of an error in the
+        // try{} block, but that error won't be thrown because this executes
+        // before the catch that rethrows it.
         assert(
           Object.values(mintSeat.getCurrentAllocation()).every(a =>
             AmountMath.isEmpty(a),

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -299,8 +299,6 @@ const machineBehavior = {
           X`Stage should be empty of RUN`,
         );
       }
-      // TODO add aggregate debt tracking at the vaultFactory level #4482
-      // totalDebt = AmountMath.add(totalDebt, toMint);
       facets.machine.updateMetrics();
     };
 

--- a/packages/run-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addPool.js
@@ -47,15 +47,6 @@ export const makeAddIssuer = (
       harden({ decimalPlaces: 6 }),
     );
     await zcf.saveIssuer(secondaryIssuer, keyword);
-    const issuer = zcf.getIssuerForBrand(secondaryBrand);
-    console.log(
-      'Saved issuer',
-      secondaryIssuer,
-      'to keyword',
-      keyword,
-      'and got back',
-      issuer,
-    );
     // this ensures that getSecondaryIssuer(thisIssuer) will return even before the pool is created
     brandToLiquidityMint.init(secondaryBrand, mint);
     const { issuer: liquidityIssuer } = mint.getIssuerRecord();

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -33,7 +33,7 @@ import { makeTracer } from '../makeTracer.js';
 
 const { quote: q, details: X } = assert;
 
-const trace = makeTracer('XykAmm');
+const trace = makeTracer('XykAmm', false);
 
 /**
  * @typedef {object} MetricsNotification

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -806,6 +806,8 @@ test('price falls precipitously', async t => {
 
   const finalNotification = await E(vaultNotifier).getUpdateSince();
   t.is(finalNotification.value.vaultState, Phase.LIQUIDATED);
+  // vault holds no debt after liquidation
+  t.is(finalNotification.value.debtSnapshot.debt.value, 0n);
 
   /** @type {UserSeat<string>} */
   const closeSeat = await E(zoe).offer(E(vault).makeCloseInvitation());
@@ -2763,8 +2765,7 @@ test('manager notifiers', async t => {
   );
   await E(vaultSeat).getOfferResult();
   await m.assertChange({
-    // FIXME in https://github.com/Agoric/agoric-sdk/issues/5531
-    // numVaults: 0,
+    numVaults: 0,
     totalCollateral: { value: 0n },
     totalDebt: { value: leftoverDebt },
   });

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2540,7 +2540,7 @@ test('manager notifiers', async t => {
     totalOverageReceived: { value: totalOverageReceived },
     totalProceedsReceived: { value: totalProceedsReceived },
   });
-  await m.assertFullyLiquidated();
+  m.assertFullyLiquidated();
 
   trace('4. Make another LOAN1 loan');
   vaultSeat = await E(services.zoe).offer(
@@ -2599,7 +2599,7 @@ test('manager notifiers', async t => {
     totalCollateral: { value: 0n },
     totalProceedsReceived: { value: totalProceedsReceived },
   });
-  await m.assertFullyLiquidated();
+  m.assertFullyLiquidated();
 
   trace('7. Make another LOAN2 loan');
   vaultSeat = await E(services.zoe).offer(
@@ -2701,5 +2701,5 @@ test('manager notifiers', async t => {
       value: DEBT1 + DEBT2 + interestAccrued - nextProceeds - 53n - 1n, // compensate for previous proceeds and rounding
     },
   });
-  await m.assertFullyLiquidated();
+  m.assertFullyLiquidated();
 });

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2514,10 +2514,9 @@ test('manager notifiers', async t => {
   });
 
   trace('2. Remove collateral');
-  const adjustBalances1 = await E(vault1).makeAdjustBalancesInvitation();
-  const taken = aeth.make(50_000n);
+  let taken = aeth.make(50_000n);
   const takeCollateralSeat = await E(services.zoe).offer(
-    adjustBalances1,
+    await E(vault1).makeAdjustBalancesInvitation(),
     harden({
       give: {},
       want: { Collateral: taken },
@@ -2702,4 +2701,71 @@ test('manager notifiers', async t => {
     },
   });
   m.assertFullyLiquidated();
+  // FIXME there shouldn't be any leftover debt once fully liquidated
+  // https://github.com/Agoric/agoric-sdk/issues/5550
+  const leftoverDebt = DEBT1 - nextProceeds + interestAccrued;
+
+  trace('11. Create a loan with ample collateral');
+  /** @type {UserSeat<VaultKit>} */
+  vaultSeat = await E(services.zoe).offer(
+    await E(lender).makeVaultInvitation(),
+    harden({
+      give: { Collateral: aeth.make(AMPLE) },
+      want: { RUN: run.make(LOAN1) },
+    }),
+    harden({
+      Collateral: t.context.aeth.mint.mintPayment(aeth.make(AMPLE)),
+    }),
+  );
+  const { vault: vault2 } = await E(vaultSeat).getOfferResult();
+  m.addDebt(DEBT1);
+  await m.assertChange({
+    numVaults: 1,
+    totalCollateral: { value: AMPLE },
+    totalDebt: { value: DEBT1 + leftoverDebt },
+  });
+
+  trace('12. Borrow more');
+  taken = run.make(400n);
+  // 20n? fix in https://github.com/Agoric/agoric-sdk/issues/5550
+  const debtPostBorrowingMore = DEBT1 + leftoverDebt + taken.value + 20n;
+  // can't use 0n because of https://github.com/Agoric/agoric-sdk/issues/5548
+  // but since this test is of metrics, we take the opportunity to check totalCollateral changing
+  const given = aeth.make(2n);
+  vaultSeat = await E(services.zoe).offer(
+    await E(vault2).makeAdjustBalancesInvitation(),
+    harden({
+      // nominal collateral
+      give: { Collateral: given },
+      want: { RUN: taken },
+    }),
+    harden({
+      Collateral: t.context.aeth.mint.mintPayment(given),
+    }),
+  );
+  console.log('DEBUG', { DEBT1, leftoverDebt, taken });
+  await E(vaultSeat).getOfferResult();
+  await m.assertChange({
+    totalDebt: { value: debtPostBorrowingMore },
+    totalCollateral: { value: AMPLE + given.value },
+  });
+
+  trace('13. Close loan');
+  vaultSeat = await E(services.zoe).offer(
+    await E(vault2).makeCloseInvitation(),
+    harden({
+      give: { RUN: run.make(debtPostBorrowingMore) },
+      want: {},
+    }),
+    harden({
+      RUN: await getRunFromFaucet(t, debtPostBorrowingMore),
+    }),
+  );
+  await E(vaultSeat).getOfferResult();
+  await m.assertChange({
+    // FIXME in https://github.com/Agoric/agoric-sdk/issues/5531
+    // numVaults: 0,
+    totalCollateral: { value: 0n },
+    totalDebt: { value: leftoverDebt },
+  });
 });

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -140,8 +140,8 @@ export async function start(zcf, privateArgs) {
       return Promise.reject(Error('Not implemented'));
     },
     getCompoundedInterest: () => compoundedInterest,
-    updateVaultAccounting: () => {
-      // noop
+    handleBalanceChange: () => {
+      console.warn('mock handleBalanceChange does nothing');
     },
     mintforVault: async amount => {
       runMint.mintGains({ RUN: amount });


### PR DESCRIPTION
closes: #5531

## Description

This introduces the concept of "settled", which means that they have no debts remaining. When vaults are liquidated, they are settled even though they may have had a shortfall, because the contract covered the shortfall using the reserve. Vaults can also be settled by closure.

Once a vault is settled, the manager has no more concern with it. Vault manager was removing vaults in the liquidation case and not the closure case. This makes it remove vaults upon settling.


### Security Considerations

`prioritizedVaults` adds a new `hasVaultByAttributes` lookup. This authority for information is subsumed by the extant `removeVaultByAttributes`.


### Documentation Considerations

Added a file comment for vaultManager explaining its scope and the invariant on what it retains.

### Testing Considerations

New tests. Updates to existing tests.