### PR TITLE
ops: automate generation of snapshot divergence traces

### DIFF
--- a/packages/deployment/scripts/capture-integration-results.sh
+++ b/packages/deployment/scripts/capture-integration-results.sh
@@ -16,27 +16,30 @@ for node in validator{0,1}; do
   "$thisdir/setup.sh" ssh "$node" cat "$home/data/swingstore-trace" > "$RESULTSDIR/$node-swingstore-trace" || true
 done
 
-val0len=$(wc -l < $RESULTSDIR/validator0-swingstore-trace)
-val1len=$(wc -l < $RESULTSDIR/validator1-swingstore-trace)
-commonlen=$((val0len < val1len ? val0len : val1len))
-
 ret=0
-diff -U0 <(head -n $commonlen $RESULTSDIR/validator0-swingstore-trace) <(head -n $commonlen $RESULTSDIR/validator1-swingstore-trace) > $RESULTSDIR/validator-swingstore-trace.diff || ret=$?
+"$thisdir/../../../scripts/process-integration-swingstore-traces.sh" "$RESULTSDIR" || ret=$?
 
 failedtest=${1:-"unknown"}
 
-if [ $ret -eq 0 ]
-then
-  if [ "$failedtest" = "false" ]
-  then
-    echo "Successful test"
-    exit 0
+if [ -f "$RESULTSDIR/divergent_snapshots" ]; then
+  if [ -s "$RESULTSDIR/validator-swingstore-trace.diff" ]; then
+    cat "$RESULTSDIR/validator-swingstore-trace.diff" | cut -c -80 || true
+    echo "Error: Swingstore trace mismatch between validators"
   fi
-else 
-  cat "$RESULTSDIR/validator-swingstore-trace.diff" | cut -c -80 || true
-  echo "Error: Swingstore trace mismatch"
-  # disable failing the test until transient divergences are solved
-  ret=0
+
+  if [ -f "$RESULTSDIR/monitor-vs-validator-swingstore-trace.diff" ] && \
+     [ -s "$RESULTSDIR/monitor-vs-validator-swingstore-trace.diff" ]
+  then
+    cat "$RESULTSDIR/monitor-vs-validator-swingstore-trace.diff" | cut -c -80 || true
+    echo "Error: Swingstore trace mismatch between loadgen monitor and validators"
+  fi
+
+  # Snapshot divergences were found, fail the test after capturing results
+  # TODO: uncomment once transient divergences are solved
+  # ret=1
+elif [ $ret -eq 0 -a "$failedtest" = "false" ]; then 
+  echo "Successful test"
+  exit 0
 fi
 
 for node in validator{0,1}; do

--- a/scripts/process-integration-results.sh
+++ b/scripts/process-integration-results.sh
@@ -1,0 +1,187 @@
+#! /bin/bash
+set -ueo pipefail
+
+[ "x${DEBUG-}" = "x1" -o "x${DEBUG-}" = "x2" ] && set -x
+
+real0=$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")
+thisdir=$(cd "$(dirname -- "$real0")" > /dev/null && pwd -P)
+
+NETWORK_NAME=${NETWORK_NAME-localtest}
+RESULTSDIR=${RESULTSDIR-"$NETWORK_NAME/results"}
+
+[ $# -gt 0 ] && RESULTSDIR="$1"
+
+"$thisdir/process-integration-swingstore-traces.sh" "$RESULTSDIR"
+
+[ -f "$RESULTSDIR/divergent_snapshots" ] || exit 0
+
+cd "$RESULTSDIR"
+
+mkdir -p "xs-snapshots"
+cp -a validator0-xs-snapshots/* "xs-snapshots/" || true
+cp -a validator1-xs-snapshots/* "xs-snapshots/" || true
+for s in chain-*-storage.tar.xz; do
+  [ -f "$s" ] || continue
+  tar -C "xs-snapshots/" -xJf $s --wildcards '**/xs-snapshots/*.gz' --transform='s/.*\///'
+done
+
+to_backup="divergent_snapshots divergent_snapshot_vats validator-swingstore-trace.diff"
+to_delete="xs-snapshots"
+
+snapshots=""
+for trace in chain-*-swingstore-trace validator*-swingstore-trace; do
+  [ -f "$trace" ] || continue
+  snapshots_dir=${trace%"-swingstore-trace"}-snapshots
+  mkdir -p $snapshots_dir
+  to_delete="$to_delete $snapshots_dir"
+  for v in $({ grep -E 'set local\.v[0-9]+\.lastSnapshot' $trace || true; } | cut -d ' ' -f 2 | cut -d '.' -f 2 | sort | uniq ); do
+    mkdir -p $snapshots_dir/$v
+    if grep -q -e "^$v\$" divergent_snapshot_vats; then
+      to_backup="$to_backup $snapshots_dir/$v"
+      v_divergent=1
+    else
+      v_divergent=0
+    fi
+    while read -r parsed; do
+      set $parsed
+      [ $v_divergent -eq 1 ] && snapshots="$snapshots $1"
+      ln -sf -T ../../xs-snapshots/$1 $snapshots_dir/$v/$2
+    done < <({ grep "set local.$v.lastSnapshot" $trace || true; } | \
+      cut -d ' ' -f 3 | \
+      jq -src '[.[] | [.startPos.itemCount, .snapshotID] ] | to_entries[] | [.value[1], " ", (1 + .key | tostring | length | if . >= 3 then "" else "0" * (3 - .) end), (1 + .key | tostring), "-", (.value[0] | tostring)] | join("")' \
+    )
+  done
+done
+
+gunzip -f xs-snapshots/*.gz || true
+to_backup="$to_backup $(for h in $snapshots $(<divergent_snapshots); do
+  [ -f xs-snapshots/$h ] && echo xs-snapshots/$h || true
+done | sort | uniq)"
+
+# TODO: handle vat suspension (aka same vatID, multiple workers)
+(mkdir -p validator0-xsnap-trace && cd $_ && tar -xzf ../$_.tgz && for v in *; do [ -d $v -a ! -h $v ] && ln -sf -T $v $(jq -r '.name | split(":") | .[0]' $v/00000-options.json) ; done; true)
+(mkdir -p validator1-xsnap-trace && cd $_ && tar -xzf ../$_.tgz && for v in *; do [ -d $v -a ! -h $v ] && ln -sf -T $v $(jq -r '.name | split(":") | .[0]' $v/00000-options.json) ; done; true)
+[ "x${DEBUG-}" = "x1" ] && set +x
+for v in validator0-xsnap-trace/v*; do
+  [ -d $v ] || continue
+  for file in $v/*; do
+    file2=validator1${file#validator0}
+    [ ${file%-snapshot.dat} = $file -o ! -f $file2 ] && diff -U0 $file $file2 2>&1 || true
+  done
+done | grep -v "No newline at end of file" > validator-xsnap-trace.diff || true
+[ "x${DEBUG-}" = "x1" ] && set -x
+to_backup="$to_backup validator-xsnap-trace.diff"
+to_delete="$to_delete validator0-xsnap-trace validator1-xsnap-trace"
+
+for stage_trace in chain-stage-*-xsnap-trace.tgz; do
+  [ -f "$stage_trace" ] || continue
+  stage_trace=${stage_trace%".tgz"}
+  mkdir -p $stage_trace
+  to_delete="$to_delete $stage_trace"
+  tar -xz -C "$stage_trace" -f "$stage_trace.tgz" || continue
+  (cd $stage_trace && for v in *; do [ -d $v -a ! -h $v ] && ln -sf -T $v $(jq -r '.name | split(":") | .[0]' $v/00000-options.json) ; done; true)
+done
+
+[ "x${DEBUG-}" = "x1" ] && set +x
+for v in validator0-xsnap-trace/v*; do
+  v=${v#validator0-xsnap-trace/}
+  i=1
+  s=-1
+  while true; do
+    s=$(( s + 1 ))
+    [ -d chain-stage-$s-xsnap-trace ] || break
+    [ -d chain-stage-$s-xsnap-trace/$v ] || continue
+    last_snapshot="$(echo chain-stage-$s-xsnap-trace/$v/*-snapshot.dat)"
+    last_snapshot="${last_snapshot##* }"
+    other_chain_trace=0
+    ns=$s
+    while true; do
+      ns=$(( ns + 1 ))
+      [ -d chain-stage-$ns-xsnap-trace ] || break
+      if [ -d chain-stage-$ns-xsnap-trace/$v ]; then
+        other_chain_trace=1
+        break
+      fi
+    done
+    if [ $other_chain_trace -eq 1 ]; then
+      if [ -f $last_snapshot ]; then
+        last_snapshot="${last_snapshot#chain-stage-$s-xsnap-trace/$v/}"
+        last_snapshot="${last_snapshot%-snapshot.dat}"
+        last_snapshot=$(( 10#$last_snapshot ))
+      else
+        continue
+      fi
+    else
+      last_snapshot=999999
+    fi
+    j=$(jq -r 'if .snapshot == null then 1 else 2 end' chain-stage-$s-xsnap-trace/$v/00000-options.json)
+    while [ $j -le $last_snapshot ]; do
+      printf -v pi "%05d" $i
+      file="$(echo validator0-xsnap-trace/$v/$pi-*)"
+      file=${file##*/}
+      [ -f validator0-xsnap-trace/$v/$file ] || break
+      printf -v pj "%05d" $j
+      file2="$(echo chain-stage-$s-xsnap-trace/$v/$pj-*)"
+      file2=${file2##*/}
+      [ -f chain-stage-$s-xsnap-trace/$v/$file2 ] || break
+      [ ${file%-snapshot.dat} = $file -a ${file2%-snapshot.dat} = $file2 ] && diff -U0 validator0-xsnap-trace/$v/$file chain-stage-$s-xsnap-trace/$v/$file2 2>&1 || true
+      i=$(( 1 + i ))
+      j=$(( 1 + j ))
+    done
+  done
+done | grep -v "No newline at end of file" > monitor-vs-validator-xsnap-trace.diff || true
+[ "x${DEBUG-}" = "x1" ] && set -x
+to_backup="$to_backup monitor-vs-validator-xsnap-trace.diff"
+
+[ -f monitor-vs-validator-swingstore-trace.diff ] && to_backup="$to_backup monitor-vs-validator-swingstore-trace.diff"
+
+for trace in *-xsnap-trace; do
+  [ -d "$trace" ] || continue
+  snapshots_dir=${trace%"-xsnap-trace"}-snapshots
+  for v in $trace/v*; do
+    [ -h "$v" ] || continue
+    v=${v#"$trace/"}
+    if grep -q -e "^$v\$" divergent_snapshot_vats; then
+      v_divergent=1
+      to_backup="$to_backup $trace/$v $trace/$(readlink $trace/$v)"
+    else
+      v_divergent=0
+    fi
+    if [ -f $trace/$v/00000-options.json ]; then
+      snapshot_tmp_file="$(jq -r '.snapshot | select (.!=null)' $trace/$v/00000-options.json)"
+      snapshot_tmp_file="${snapshot_tmp_file##*/}"
+      snapshot="${snapshot_tmp_file%%-*}"
+      if [ ! -z "$snapshot_tmp_file" ]; then
+        ln -sf -T $snapshot xs-snapshots/$snapshot_tmp_file
+        [ $v_divergent -eq 1 ] && to_backup="$to_backup xs-snapshots/$snapshot_tmp_file"
+      fi
+    fi
+
+    set $(echo $snapshots_dir/$v/*)
+    for trace_command in $(echo $trace/$v/*-snapshot.dat); do
+      [ -f $trace_command ] || continue
+      [ $# -gt 0 ] || exit 1
+      snapshot_tmp_file="$(<$trace_command)"
+      snapshot_tmp_file="${snapshot_tmp_file##*/}"
+      snapshot=$(readlink $1)
+      snapshot="${snapshot##*/}"
+      shift
+      ln -sf -T $snapshot xs-snapshots/$snapshot_tmp_file
+      [ $v_divergent -eq 1 ] && to_backup="$to_backup xs-snapshots/$snapshot_tmp_file"
+    done
+  done
+done
+
+diff <(cat validator0.slog | jq -cr 'del(.time)') <(cat validator1.slog | jq -cr 'del(.time)') > validator-slog.diff || true
+to_backup="$to_backup validator-slog.diff"
+
+if [ -f chain-stage-0.slog.gz ]; then
+  gunzip -fk chain-stage-0.slog.gz
+  to_delete="$to_delete chain-stage-0.slog"
+  chain_slog_len=$(cat chain-stage-0.slog | wc -l)
+  diff <(head -n $chain_slog_len validator0.slog | jq -cr 'del(.time)') <(cat chain-stage-0.slog | jq -cr 'del(.time)') > monitor-stage-0-vs-validator-slog.diff || true
+  to_backup="$to_backup monitor-stage-0-vs-validator-slog.diff"
+fi
+
+tar -czf divergent_traces.tgz $to_backup
+[ "x${DEBUG-}" = "x2" ] || rm -rf $to_delete

--- a/scripts/process-integration-swingstore-traces.sh
+++ b/scripts/process-integration-swingstore-traces.sh
@@ -1,0 +1,52 @@
+#! /bin/bash
+set -ueo pipefail
+
+[ "x${DEBUG-}" = "x1" -o "x${DEBUG-}" = "x2" ] && set -x
+
+NETWORK_NAME=${NETWORK_NAME-localtest}
+RESULTSDIR=${RESULTSDIR-"$NETWORK_NAME/results"}
+
+[ $# -gt 0 ] && RESULTSDIR="$1"
+
+get_trace_len() {
+  grep -n commit-tx $1 | tail -1 | cut -d : -f 1 || echo 0
+}
+
+get_vats_from_diff() {
+  grep 'set local\.v' $1 | cut -d . -f 2 | sort | uniq
+}
+
+get_snapshots_from_diff() {
+  grep 'set local\.snapshot\.' $1 | cut -d ' ' -f 2 | cut -d . -f 3 | sort | uniq
+}
+
+val0len=$(get_trace_len $RESULTSDIR/validator0-swingstore-trace)
+val1len=$(get_trace_len $RESULTSDIR/validator1-swingstore-trace)
+commonlen=$((val0len < val1len ? val0len : val1len))
+
+[ $commonlen -eq 0 ] && exit 0
+
+val_diff_ret=0
+diff -U0 <(head -n $commonlen $RESULTSDIR/validator0-swingstore-trace) <(head -n $commonlen $RESULTSDIR/validator1-swingstore-trace) > $RESULTSDIR/validator-swingstore-trace.diff || val_diff_ret=$?
+diffs=$RESULTSDIR/validator-swingstore-trace.diff
+
+chain_diff_ret=0
+if [ -f $RESULTSDIR/chain-stage-0-swingstore-trace ] ; then
+  chain0len=$(get_trace_len $RESULTSDIR/chain-stage-0-swingstore-trace)
+  chain1len=0
+  chain1trace=$RESULTSDIR/chain-stage-1-swingstore-trace
+  if [ -f $chain1trace ]; then
+    chain1len=$(get_trace_len $RESULTSDIR/chain-stage-1-swingstore-trace)
+  else
+    chain1trace=/dev/null
+  fi
+  chainlen=$((chain0len + chain1len))
+  
+  diff -U0 -I 'set cosmos/meta .*' -I 'set host\..*' <(head -n $chainlen $RESULTSDIR/validator0-swingstore-trace) <(cat <(head -n $chain0len $RESULTSDIR/chain-stage-0-swingstore-trace) <(head -n $chain1len $chain1trace)) > $RESULTSDIR/monitor-vs-validator-swingstore-trace.diff || chain_diff_ret=$?
+  diffs="$diffs $RESULTSDIR/monitor-vs-validator-swingstore-trace.diff"
+fi
+
+[ $val_diff_ret -eq 0 -a $chain_diff_ret -eq 0 ] && exit 0
+
+get_snapshots_from_diff <(cat $diffs) > $RESULTSDIR/divergent_snapshots
+get_vats_from_diff <(cat $diffs) > $RESULTSDIR/divergent_snapshot_vats

--- a/scripts/run-deployment-integration.sh
+++ b/scripts/run-deployment-integration.sh
@@ -31,3 +31,6 @@ testfailure="unknown"
 /usr/src/agoric-sdk/packages/deployment/scripts/setup.sh play stop || true
 /usr/src/agoric-sdk/packages/deployment/scripts/capture-integration-results.sh $testfailure
 echo yes | /usr/src/agoric-sdk/packages/deployment/scripts/setup.sh destroy || true
+
+# Not part of CI
+/usr/src/agoric-sdk/scripts/process-integration-results.sh $NETWORK_NAME/results

--- a/scripts/run-deployment-integration.sh
+++ b/scripts/run-deployment-integration.sh
@@ -28,9 +28,9 @@ testfailure="unknown"
   testfailure="true"
 }
 
-/usr/src/agoric-sdk/packages/deployment/scripts/setup.sh play stop || true
-/usr/src/agoric-sdk/packages/deployment/scripts/capture-integration-results.sh $testfailure
-echo yes | /usr/src/agoric-sdk/packages/deployment/scripts/setup.sh destroy || true
+packages/deployment/scripts/setup.sh play stop || true
+packages/deployment/scripts/capture-integration-results.sh $testfailure
+echo yes | packages/deployment/scripts/setup.sh destroy || true
 
 # Not part of CI
 /usr/src/agoric-sdk/scripts/process-integration-results.sh $NETWORK_NAME/results


### PR DESCRIPTION
refs: #5227

## Description

I've been heavily updating the scripts I use to compare trace outputs from, including generating artifacts to report snapshot divergences. This is extracted from #5338 

Since the deployment integration test now captures an artifact regardless of success or failure, I also changed to remove heavy trace and storage files that are likely not needed.

### Security Considerations

None, only scripts used to process traces from the deployment integration test artifact.

### Documentation Considerations

The script implementation could use some explanations, but the usage of the script and content of the artifact should be fairly self explanatory.

The scripts produce an artifact with the following data:
- Difference of swingstore traces (minus host specific data, but including "local" data) between the 2 validator nodes
- Difference of swingstore traces (minus host specific data, but including "local" data) between the first validator node and the loadgen follower node
- The list of vats with diverging snapshots
- The list of snapshot hashes that are not common to all nodes (divergent)
- The divergent snapshots themselves stored by hash, as well as symlinks to them:
  - symlink in a structure of the shape `${node-desc}-xs-snapshots/v${vatId}/${i}-${startPos.itemCount}` where `i` is a `0` 3 digit padded 1-based index of snapshot for that execution of the node (aka 1st, 2nd, etc. snapshot taken by the worker process)
  - symlinks from the temporary file names used to load and save a snapshot (for easier trace reproductions)
- The XS worker debug traces for the divergent vats, stored under `${node-desc}-xsnap-trace/v${vatId}`
- A diff from the XS debug traces (minus snapshot command and options init) between the 2 validator nodes
- A diff from the XS debug traces (minus snapshot command and options init) between the first validator and the loadgen follow node
  - This handles offsetting between traces that start from different places (scratch or one of the snapshots). If a later restart of the node contains a trace for that vat, command executed after the last snapshot is taken are ignored
  - The offset logic only supports one of the 2 nodes restarting (loadgen monitor in this case) and relies on one of the node (validator in this case) staying up (continuous) as reference.
- Difference of the slog file (minus time field) between the 2 validator nodes
- Difference of the slog file (minus time field) between the first validator node and the stage 0 of the loadgen monitor node (I still need to automatically stitch slogs ignoring replays to include later stages)

An example of the output artifact on f513604013: https://drive.google.com/file/d/1-UyjKv0b_MlyyEegLNbvDGJUHgo1TaP-/view?usp=sharing

### Testing Considerations

Loads of manual tests against various CI artifacts I've collected here and there, or traces from local runs. It should be handling most edge cases (missing files, etc.)
