### PR TITLE
ci: ensure actions have triggered before mergify queue

### DIFF
--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -1,0 +1,27 @@
+name: Integration tests triggered
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - auto_merge_enabled
+
+jobs:
+  pre_check:
+    uses: ./.github/workflows/pre-check-integration.yml
+
+  wait-integration-pre-checks:
+    needs: pre_check
+    runs-on: ubuntu-latest
+    steps:
+      - name: wait
+        shell: bash
+        run: |
+          cat <<EOF
+            needs ${{ toJSON(needs.pre_check.outputs) }}
+          EOF
+          sleep 5

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,6 +39,9 @@ pull_request_rules:
     conditions:
       - label=automerge:merge
       - or:
+          - check-success=wait-integration-pre-checks
+          - label=bypass:integration
+      - or:
           - and: # breakage succeeds like we thought
               - check-success=breakage
               - -label=proto:expect-breakage
@@ -52,6 +55,9 @@ pull_request_rules:
   - name: rebase updates then merge to master
     conditions:
       - label=automerge:rebase
+      - or:
+          - check-success=wait-integration-pre-checks
+          - label=bypass:integration
       - or:
           - and: # breakage succeeds like we thought
               - check-success=breakage
@@ -67,6 +73,9 @@ pull_request_rules:
   - name: squash to master
     conditions:
       - label=automerge:squash
+      - or:
+          - check-success=wait-integration-pre-checks
+          - label=bypass:integration
       - or:
           - and: # breakage succeeds like we thought
               - check-success=breakage


### PR DESCRIPTION
## Description

In https://github.com/Agoric/agoric-sdk/runs/6798585781 I noticed that the PR got merged before integration tests ran, which should not have been possible. My running hypothesis is that when the mergify checks ran, the `getting-started` and `deployment-test` job were still in `skipped` status from before the labelling which triggered mergify. Aka mergify raced the GH actions triggers, and won.

This change introduces a no-op action which is required to be successful by mergify before proceeding, which hopefully means all other GH actions have similarly been triggered. Unfortunately we can't remove the `check-skipped` checks in the mergify config because those test can legitimately be skipped for other reasons (e.g. they would have run on the same content).

### Security Considerations

None

### Testing Considerations

This PR will be used for testing