### PR TITLE
ci: remove getting-started npm job from required checks

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,7 @@ jobs:
     needs: pre_check
     if: needs.pre_check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.cli == 'local-npm' }}
     strategy:
       matrix:
         cli: [link-cli, local-npm]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,21 +18,25 @@ queue_rules:
           - and:
               - '-check-failure=getting-started'
               - '-check-failure=getting-started (link-cli)'
-              - '-check-failure=getting-started (local-npm)'
+              # - '-check-failure=getting-started (local-npm)'
               - or:
                   - '#commits-behind>0'
                   - queue-position<0
           - label=bypass:integration
           - check-skipped=getting-started
-          - and:
-              - or:
-                  - check-success=getting-started (link-cli)
-                  - check-neutral=getting-started (link-cli)
-                  - check-skipped=getting-started (link-cli)
-              - or:
-                  - check-success=getting-started (local-npm)
-                  - check-neutral=getting-started (local-npm)
-                  - check-skipped=getting-started (local-npm)
+          - or:
+              - check-success=getting-started (link-cli)
+              - check-neutral=getting-started (link-cli)
+              - check-skipped=getting-started (link-cli)
+          # - and:
+          #     - or:
+          #         - check-success=getting-started (link-cli)
+          #         - check-neutral=getting-started (link-cli)
+          #         - check-skipped=getting-started (link-cli)
+          #     - or:
+          #         - check-success=getting-started (local-npm)
+          #         - check-neutral=getting-started (local-npm)
+          #         - check-skipped=getting-started (local-npm)
 
 pull_request_rules:
   - name: merge to master


### PR DESCRIPTION
## Description

Looks like something is causing the `getting-started` integration test to fail. Until we figure out the cause, remove the job from the required checks and prevent fast-fail.

### Security Considerations
None

### Testing Considerations

Experimenting on this PR