### PR TITLE
feat(vaultFactory): liquidated vaults have debts cleared

### DIFF
--- a/packages/run-protocol/src/vaultFactory/liquidation.js
+++ b/packages/run-protocol/src/vaultFactory/liquidation.js
@@ -82,7 +82,7 @@ const liquidate = async (
   burnLosses(runToBurn, vaultZcfSeat);
 
   // Accounting complete. Update the vault state.
-  vault.liquidated(AmountMath.subtract(debt, runToBurn));
+  vault.liquidated();
   // remaining funds are left on the vault for the user to close and claim
 
   // for accounting

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -585,6 +585,8 @@ const selfBehavior = {
   },
 
   /**
+   * Called by manager at start of liquidation.
+   *
    * @param {MethodContext} context
    */
   liquidating: ({ facets }) => {
@@ -594,14 +596,17 @@ const selfBehavior = {
   },
 
   /**
-   * Call must check for and remember shortfall
+   * Called by manager at end of liquidation, at which point all debts have been
+   * covered.
    *
    * @param {MethodContext} context
-   * @param {Amount} newDebt
    */
-  liquidated: ({ facets }, newDebt) => {
+  liquidated: ({ facets }) => {
     const { helper } = facets;
-    helper.updateDebtSnapshot(newDebt);
+    helper.updateDebtSnapshot(
+      // liquidated vaults retain no debt
+      AmountMath.makeEmpty(helper.debtBrand()),
+    );
 
     helper.assignPhase(Phase.LIQUIDATED);
     helper.updateUiState();


### PR DESCRIPTION
closes: #5286

## Description

[5531](https://github.com/Agoric/agoric-sdk/issues/5531) specifies:
> vault manager only holds vaults that:
> - can accrue interest
> - can be liquidated

It implicates vault accounting because right now when a vault closes we update accounting in the manager. But this has a wrinkle because the vault’s idea of its debt and the manager’s are out of sync. The manager has already recorded the shortfall but the vault still holds onto that shortfall in its state as debt. ( When a vault is liquidated for less than its debt, the difference we call shortfall. We then burn the debt minus the shortfall. After this, the vault itself holds state of its debt being equal to shortfall. )

Liquidation means the vault manager took on the debt. It later hands any shortfall to the reserve but the vault can clean be cleaned up before that. This changes the `liquidate()` function on vaults to zero out the debt. 

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
