### PR TITLE
fix(xsnap): fix test which reused a mutable ArrayBuffer

### DIFF
--- a/packages/xsnap/test/test-replay.js
+++ b/packages/xsnap/test/test-replay.js
@@ -24,7 +24,7 @@ const transcript1 = [
     '/xsnap-tests/00001-evaluate.dat',
     'issueCommand(new TextEncoder().encode("Hello, World!").buffer);',
   ],
-  ['/xsnap-tests/00002-command.dat', '{"currentHeap'],
+  ['/xsnap-tests/00002-command.dat', 'Hello, World!'],
   ['/xsnap-tests/00003-reply.dat', ''],
 ];
 
@@ -33,7 +33,7 @@ test('record: evaluate and issueCommand', async t => {
 
   /** @type { Map<string, Uint8Array> } */
   const files = new Map();
-  const writeFileSync = (fn, bs) => files.set(fn, bs);
+  const writeFileSync = (fn, bs) => files.set(fn, bs.slice());
 
   const vat = recordXSnap(opts, '/xsnap-tests/', { writeFileSync });
 


### PR DESCRIPTION
test-replay.js was providing a mock `writeFileSync()` to record the
replay records in RAM instead of on disk. However the caller is using
the same ArrayBuffer each time, and the mock was holding onto the
buffer, not the contents, which means it wound up with the last thing
written (corrupted by subsequent writes). The `transcript1` comparison
data was corrupted in a matching way.

This fixes the mock to make a copy of the buffer, and updates the
comparison data to be the real expected string ("Hello, World!").
