### PR TITLE
fix(swingset): simulate full response for gc syscalls

### DIFF
--- a/packages/SwingSet/src/kernel/vat-loader/transcript.js
+++ b/packages/SwingSet/src/kernel/vat-loader/transcript.js
@@ -67,7 +67,7 @@ export function makeTranscriptManager(
   function simulateSyscall(newSyscall) {
     const type = newSyscall[0];
     if (gcSyscalls.has(type)) {
-      return undefined;
+      return ['ok', undefined];
     }
     const s = playbackSyscalls.shift();
     const newReplayError = compareSyscalls(vatID, s.d, newSyscall);


### PR DESCRIPTION
refs: #5557

## Description

Fixes a transcript replay bug introduced in https://github.com/Agoric/agoric-sdk/issues/5511

### Security Considerations

None

### Documentation Considerations

None

### Testing Considerations

We detected this somewhat luckily. Plan is in a follow up PR to move gc calls in consensus, and enforce that all delivery results during replay are successful.