### PR TITLE
fix: allow vault owner to only withdraw RUN

### DIFF
--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -439,9 +439,7 @@ const helperBehavior = {
     assertOnlyKeys(proposal, ['Collateral', 'RUN']);
 
     const allEmpty = amounts => {
-      // phrased negatively allows early return. This is equal to
-      // amounts.every(a => AmountMath.isEmpty(a));
-      return !amounts.some(a => !AmountMath.isEmpty(a));
+      return amounts.every(a => AmountMath.isEmpty(a));
     };
 
     const normalizedDebtPre = self.getNormalizedDebt();
@@ -497,10 +495,9 @@ const helperBehavior = {
     stageDelta(clientSeat, vaultSeat, giveRUN, helper.emptyDebt(), 'RUN');
 
     /** @type {Array<ZCFSeat>} */
-    const vaultSeatOpt = [];
-    if (!allEmpty([giveColl, giveRUN, wantColl])) {
-      vaultSeatOpt.push(vaultSeat);
-    }
+    const vaultSeatOpt = allEmpty([giveColl, giveRUN, wantColl])
+      ? []
+      : [vaultSeat];
     state.manager.mintAndReallocate(toMint, fee, clientSeat, ...vaultSeatOpt);
 
     // parent needs to know about the change in debt

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1342,28 +1342,9 @@ test('adjust balances - withdraw RUN', async t => {
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   let runDebtLevel = AmountMath.add(aliceLoanAmount, fee);
 
-  t.deepEqual(debtAmount, runDebtLevel, 'vault lent 5000 RUN + fees');
-  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocation();
-  const loanProceeds = await E(aliceLoanSeat).getPayouts();
-  t.deepEqual(lentAmount, aliceLoanAmount, 'received 5000 RUN');
-
-  const runLent = await loanProceeds.RUN;
-  t.truthy(
-    AmountMath.isEqual(
-      await E(run.issuer).getAmountOf(runLent),
-      run.make(5000n),
-    ),
-  );
-
   let aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, runDebtLevel);
-  t.deepEqual(aliceUpdate.value.debtSnapshot, {
-    debt: run.make(5250n),
-    interest: makeRatio(100n, run.brand),
-  });
 
   // Withdraw add'l RUN /////////////////////////////////////
-
   // Alice deposits nothing; requests more RUN
 
   const additionalRUN = run.make(100n);
@@ -1389,12 +1370,7 @@ test('adjust balances - withdraw RUN', async t => {
   t.deepEqual(lentAmount2, additionalRUN, '100 RUN');
 
   const runLent2 = await loanProceeds2.RUN;
-  t.truthy(
-    AmountMath.isEqual(
-      await E(run.issuer).getAmountOf(runLent2),
-      additionalRUN,
-    ),
-  );
+  t.deepEqual(await E(run.issuer).getAmountOf(runLent2), additionalRUN);
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debtSnapshot.debt, runDebtLevel);


### PR DESCRIPTION
closes: #5548

## Description

When the only change is withdrawing RUN, there's no change to the vaultSeat, so it has to be omitted from the list of seats sent to reallocateAndMint.

### Security Considerations

None

### Documentation Considerations

None

### Testing Considerations

Added a test.