### PR TITLE
fix: patch mistaken overrides

### DIFF
--- a/patches/bl++readable-stream+3.6.0.patch
+++ b/patches/bl++readable-stream+3.6.0.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/bl/node_modules/readable-stream/errors.js b/node_modules/bl/node_modules/readable-stream/errors.js
+index 8471526..c1c08cf 100644
+--- a/node_modules/bl/node_modules/readable-stream/errors.js
++++ b/node_modules/bl/node_modules/readable-stream/errors.js
+@@ -21,7 +21,14 @@ function createErrorType(code, message, Base) {
+     }
+   }
+ 
+-  NodeError.prototype.name = Base.name;
++  Object.defineProperties(NodeError.prototype, {
++    name: {
++      value: Base.name,
++      writable: true,
++      enumerable: false,
++      configurable: true,
++    }
++  })
+   NodeError.prototype.code = code;
+ 
+   codes[code] = NodeError;

--- a/patches/bl++readable-stream+3.6.0.patch
+++ b/patches/bl++readable-stream+3.6.0.patch
@@ -2,7 +2,7 @@ diff --git a/node_modules/bl/node_modules/readable-stream/errors.js b/node_modul
 index 8471526..c1c08cf 100644
 --- a/node_modules/bl/node_modules/readable-stream/errors.js
 +++ b/node_modules/bl/node_modules/readable-stream/errors.js
-@@ -21,7 +21,14 @@ function createErrorType(code, message, Base) {
+@@ -21,7 +21,18 @@ function createErrorType(code, message, Base) {
      }
    }
  
@@ -11,6 +11,10 @@ index 8471526..c1c08cf 100644
 +    name: {
 +      value: Base.name,
 +      writable: true,
++      // enumerable: true would accurately preserve the behavior of the
++      // original assignment, but I'm guessing that was not intentional.
++      // For an actual error subclass, this property would not
++      // be enumerable.
 +      enumerable: false,
 +      configurable: true,
 +    }

--- a/patches/cosmjs-types++protobufjs+6.11.3.patch
+++ b/patches/cosmjs-types++protobufjs+6.11.3.patch
@@ -1,0 +1,38 @@
+diff --git a/node_modules/cosmjs-types/node_modules/protobufjs/src/util/minimal.js b/node_modules/cosmjs-types/node_modules/protobufjs/src/util/minimal.js
+index 3c406de..fb88de4 100644
+--- a/node_modules/cosmjs-types/node_modules/protobufjs/src/util/minimal.js
++++ b/node_modules/cosmjs-types/node_modules/protobufjs/src/util/minimal.js
+@@ -280,13 +280,26 @@ function newError(name) {
+             merge(this, properties);
+     }
+ 
+-    (CustomError.prototype = Object.create(Error.prototype)).constructor = CustomError;
+-
+-    Object.defineProperty(CustomError.prototype, "name", { get: function() { return name; } });
+-
+-    CustomError.prototype.toString = function toString() {
+-        return this.name + ": " + this.message;
+-    };
++    CustomError.prototype = Object.create(Error.prototype, {
++        constructor: {
++            value: CustomError,
++            writable: true,
++            enumerable: false,
++            configurable: true,
++        },
++        name: {
++            get() { return name; },
++            set: undefined,
++            enumerable: false,
++            configurable: true,
++        },
++        toString: {
++            value() { return this.name + ": " + this.message; },
++            writable: true,
++            enumerable: false,
++            configurable: true,
++        },
++    });
+ 
+     return CustomError;
+ }

--- a/patches/cosmjs-types++protobufjs+6.11.3.patch
+++ b/patches/cosmjs-types++protobufjs+6.11.3.patch
@@ -2,7 +2,7 @@ diff --git a/node_modules/cosmjs-types/node_modules/protobufjs/src/util/minimal.
 index 3c406de..fb88de4 100644
 --- a/node_modules/cosmjs-types/node_modules/protobufjs/src/util/minimal.js
 +++ b/node_modules/cosmjs-types/node_modules/protobufjs/src/util/minimal.js
-@@ -280,13 +280,26 @@ function newError(name) {
+@@ -280,13 +280,38 @@ function newError(name) {
              merge(this, properties);
      }
  
@@ -17,6 +17,10 @@ index 3c406de..fb88de4 100644
 +        constructor: {
 +            value: CustomError,
 +            writable: true,
++            // enumerable: true would accurately preserve the behavior of the
++            // original assignment, but I'm guessing that was not intentional.
++            // For an actual error subclass, this property would not
++            // be enumerable.
 +            enumerable: false,
 +            configurable: true,
 +        },
@@ -24,11 +28,19 @@ index 3c406de..fb88de4 100644
 +            get() { return name; },
 +            set: undefined,
 +            enumerable: false,
++            // configurable: false would accurately preserve the behavior of
++            // the original, but I'm guessing that was not intentional.
++            // For an actual error subclass, this property would
++            // be configurable.
 +            configurable: true,
 +        },
 +        toString: {
 +            value() { return this.name + ": " + this.message; },
 +            writable: true,
++            // enumerable: true would accurately preserve the behavior of the
++            // original assignment, but I'm guessing that was not intentional.
++            // For an actual error subclass, this property would not
++            // be enumerable.
 +            enumerable: false,
 +            configurable: true,
 +        },

--- a/patches/inquirer++rxjs+7.5.5.patch
+++ b/patches/inquirer++rxjs+7.5.5.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/inquirer/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js b/node_modules/inquirer/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js
+index 98a6e52..2c8122e 100644
+--- a/node_modules/inquirer/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js
++++ b/node_modules/inquirer/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js
+@@ -7,8 +7,14 @@ function createErrorClass(createImpl) {
+         instance.stack = new Error().stack;
+     };
+     var ctorFunc = createImpl(_super);
+-    ctorFunc.prototype = Object.create(Error.prototype);
+-    ctorFunc.prototype.constructor = ctorFunc;
++    ctorFunc.prototype = Object.create(Error.prototype, {
++        constructor: {
++            value: ctorFunc,
++            writable: true,
++            enumerable: false,
++            configurable: true,
++        }
++    });
+     return ctorFunc;
+ }
+ exports.createErrorClass = createErrorClass;

--- a/patches/inquirer++rxjs+7.5.5.patch
+++ b/patches/inquirer++rxjs+7.5.5.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/inquirer/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js b/node_modules/inquirer/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js
-index 98a6e52..2c8122e 100644
+index 98a6e52..af7d91a 100644
 --- a/node_modules/inquirer/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js
 +++ b/node_modules/inquirer/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js
-@@ -7,8 +7,14 @@ function createErrorClass(createImpl) {
+@@ -7,8 +7,18 @@ function createErrorClass(createImpl) {
          instance.stack = new Error().stack;
      };
      var ctorFunc = createImpl(_super);
@@ -12,6 +12,10 @@ index 98a6e52..2c8122e 100644
 +        constructor: {
 +            value: ctorFunc,
 +            writable: true,
++            // enumerable: true would accurately preserve the behavior of the
++            // original assignment, but I'm guessing that was not intentional.
++            // For an actual error subclass, this property would not
++            // be enumerable.
 +            enumerable: false,
 +            configurable: true,
 +        }


### PR DESCRIPTION
Patch mistaken overrides.

These were the overrides that prevent us from changing https://github.com/Agoric/agoric-sdk/blob/09b239d797e67dde2a12f62f12ff154a1e402ab7/packages/agoric-cli/test/test-main.js#L4
to
```js
import '@endo/init/debug.js';
```
at 
https://github.com/Agoric/agoric-sdk/pull/5567
since `debug.js` also sets `overrideTaming` to `'min'` as it should, in order to catch such problems.