### PR TITLE
fix vault manager totalDebt metric

### DIFF
--- a/packages/run-protocol/src/interest-math.js
+++ b/packages/run-protocol/src/interest-math.js
@@ -1,8 +1,8 @@
 // @ts-check
 
 import {
-  floorDivideBy,
-  floorMultiplyBy,
+  divideBy,
+  multiplyBy,
   invertRatio,
   multiplyRatios,
   ratiosSame,
@@ -46,7 +46,7 @@ export const calculateCurrentDebt = (
     interestSnapshot,
   );
 
-  return floorMultiplyBy(debtSnapshot, interestSinceSnapshot);
+  return multiplyBy(debtSnapshot, interestSinceSnapshot);
 };
 
 /**
@@ -56,5 +56,5 @@ export const calculateCurrentDebt = (
  * @returns {Amount<'nat'>}
  */
 export const reverseInterest = (debt, interestApplied) => {
-  return floorDivideBy(debt, interestApplied);
+  return divideBy(debt, interestApplied);
 };

--- a/packages/run-protocol/src/vaultFactory/liquidation.js
+++ b/packages/run-protocol/src/vaultFactory/liquidation.js
@@ -18,9 +18,6 @@ const trace = makeTracer('LIQ', false);
  *
  * @param {ZCF} zcf
  * @param {Vault} vault
- * @param {(losses: Amount,
- *             zcfSeat: ZCFSeat
- *            ) => void} burnLosses
  * @param {Liquidator}  liquidator
  * @param {Brand} collateralBrand
  * @param {Ratio} penaltyRate
@@ -28,7 +25,6 @@ const trace = makeTracer('LIQ', false);
 const liquidate = async (
   zcf,
   vault,
-  burnLosses,
   liquidator,
   collateralBrand,
   penaltyRate,
@@ -80,16 +76,13 @@ const liquidate = async (
   const runToBurn = AmountMath.min(proceeds.RUN, debt);
   // debt is fully settled, with runToBurn and shortfall
   assert(AmountMath.isEqual(debt, AmountMath.add(runToBurn, shortfall)));
-  trace('before burn', { debt, proceeds, overage, shortfall, runToBurn });
-  // TODO why grant this power; we can burn it from the caller
-  burnLosses(runToBurn, vaultZcfSeat);
 
-  // Accounting complete. Update the vault state.
+  // Manager accounting changes determined. Update the vault state.
   vault.liquidated();
   // remaining funds are left on the vault for the user to close and claim
 
-  // for accounting
-  return { proceeds: proceeds.RUN, overage, shortfall };
+  // for manager's accounting
+  return { proceeds: proceeds.RUN, overage, runToBurn, shortfall };
 };
 
 const liquidationDetailTerms = debtBrand =>

--- a/packages/run-protocol/src/vaultFactory/liquidation.js
+++ b/packages/run-protocol/src/vaultFactory/liquidation.js
@@ -78,7 +78,10 @@ const liquidate = async (
       ];
 
   const runToBurn = AmountMath.min(proceeds.RUN, debt);
+  // debt is fully settled, with runToBurn and shortfall
+  assert(AmountMath.isEqual(debt, AmountMath.add(runToBurn, shortfall)));
   trace('before burn', { debt, proceeds, overage, shortfall, runToBurn });
+  // TODO why grant this power; we can burn it from the caller
   burnLosses(runToBurn, vaultZcfSeat);
 
   // Accounting complete. Update the vault state.

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -87,8 +87,8 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
     const [vault] = vaults.values();
     const collateralAmount = vault.getCollateralAmount();
     if (AmountMath.isEmpty(collateralAmount)) {
-      // ??? can currentDebtToCollateral() handle this?
-      // Would be an infinite ratio
+      // This should only happen when the vault has been added but not funded yet
+      // TODO remove exceptional case for new vaults; if it's in the store it must be liquidatable
       return undefined;
     }
     return currentDebtToCollateral(vault);
@@ -140,6 +140,11 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
    */
   const addVault = (vaultId, vault) => {
     const key = vaults.addVault(vaultId, vault);
+    // TODO refactor to fulfill this invariant
+    // assert(
+    //   !AmountMath.isEmpty(vault.getCollateralAmount()),
+    //   'Tracked vaults must have collateral (be liquidatable',
+    // );
     trace('addVault', key, 'when first:', firstKey);
     if (!firstKey || keyLT(key, firstKey)) {
       firstKey = key;

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -46,19 +46,19 @@ export const currentDebtToCollateral = vault =>
  * Vaults, ordered by their liquidation ratio so that all the
  * vaults below a threshold can be quickly found and liquidated.
  *
- * @param {() => void} reschedulePriceCheck called when there is a new
- * least-collateralized vault
+ * @param {() => void} highestChanged called when there is a new
+ * `highestRatio` (least-collateralized vault)
  */
-export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
+export const makePrioritizedVaults = (highestChanged = () => {}) => {
   const vaults = makeOrderedVaultStore();
 
   /**
    * Set the callback for when there is a new least-collateralized vault
    *
-   * @param {() => void} rescheduleFn
+   * @param {() => void} callback
    */
-  const setRescheduler = rescheduleFn => {
-    reschedulePriceCheck = rescheduleFn;
+  const onHighestRatioChanged = callback => {
+    highestChanged = callback;
   };
 
   // To deal with fluctuating prices and varying collateralization, we schedule a
@@ -79,7 +79,7 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
    *
    * @returns {Ratio=} actual debt over collateral
    */
-  const firstDebtRatio = () => {
+  const highestRatio = () => {
     if (vaults.getSize() === 0) {
       return undefined;
     }
@@ -145,7 +145,7 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
     trace('addVault', key, 'when first:', firstKey);
     if (!firstKey || keyLT(key, firstKey)) {
       firstKey = key;
-      reschedulePriceCheck();
+      highestChanged();
     }
     return key;
   };
@@ -183,9 +183,9 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
     entriesPrioritizedGTE,
     getCount: vaults.getSize,
     hasVaultByAttributes,
-    highestRatio: firstDebtRatio,
+    highestRatio,
     removeVault,
     removeVaultByAttributes,
-    setRescheduler,
+    onHighestRatioChanged,
   });
 };

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -85,12 +85,10 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
     }
     // Get the first vault.
     const [vault] = vaults.values();
-    const collateralAmount = vault.getCollateralAmount();
-    if (AmountMath.isEmpty(collateralAmount)) {
-      // This should only happen when the vault has been added but not funded yet
-      // TODO remove exceptional case for new vaults; if it's in the store it must be liquidatable
-      return undefined;
-    }
+    assert(
+      !AmountMath.isEmpty(vault.getCollateralAmount()),
+      'First vault had no collateral',
+    );
     return currentDebtToCollateral(vault);
   };
 
@@ -140,11 +138,10 @@ export const makePrioritizedVaults = (reschedulePriceCheck = () => {}) => {
    */
   const addVault = (vaultId, vault) => {
     const key = vaults.addVault(vaultId, vault);
-    // TODO refactor to fulfill this invariant
-    // assert(
-    //   !AmountMath.isEmpty(vault.getCollateralAmount()),
-    //   'Tracked vaults must have collateral (be liquidatable',
-    // );
+    assert(
+      !AmountMath.isEmpty(vault.getCollateralAmount()),
+      'Tracked vaults must have collateral (be liquidatable)',
+    );
     trace('addVault', key, 'when first:', firstKey);
     if (!firstKey || keyLT(key, firstKey)) {
       firstKey = key;

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -86,7 +86,7 @@ const validTransitions = {
  * @property {MintAndReallocate} mintAndReallocate
  * @property {(amount: Amount, seat: ZCFSeat) => void} burnAndRecord
  * @property {() => Ratio} getCompoundedInterest
- * @property {(oldDebt: import('./storeUtils.js').NormalizedDebt, oldCollateral: Amount<'nat'>, vaultId: VaultId, vaultPhase: VaultPhase) => void} handleBalanceChange
+ * @property {(oldDebt: import('./storeUtils.js').NormalizedDebt, oldCollateral: Amount<'nat'>, vaultId: VaultId, vaultPhase: VaultPhase, vault: Vault) => void} handleBalanceChange
  * @property {() => import('./vaultManager.js').GovernedParamGetters} getGovernedParams
  */
 
@@ -260,6 +260,7 @@ const helperBehavior = {
       oldCollateral,
       state.idInManager,
       state.phase,
+      facets.self,
     );
   },
 
@@ -411,6 +412,7 @@ const helperBehavior = {
       oldCollateral,
       state.idInManager,
       state.phase,
+      facets.self,
     );
 
     return 'your loan is closed, thank you for your business';
@@ -545,13 +547,15 @@ const selfBehavior = {
    */
   initVaultKit: async ({ state, facets }, seat) => {
     const { self, helper } = facets;
-    assert(
-      AmountMath.isEmpty(state.debtSnapshot),
-      X`vault must be empty initially`,
-    );
-    // TODO should this be simplified to know that the oldDebt mut be empty?
+
     const normalizedDebtPre = self.getNormalizedDebt();
     const actualDebtPre = self.getCurrentDebt();
+    assert(
+      AmountMath.isEmpty(normalizedDebtPre) &&
+        AmountMath.isEmpty(actualDebtPre),
+      X`vault must be empty initially`,
+    );
+
     const collateralPre = self.getCollateralAmount();
     trace('initVaultKit start: collateral', state.idInManager, {
       actualDebtPre,

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -43,7 +43,7 @@ import { checkDebtLimit } from '../contractSupport.js';
 
 const { details: X } = assert;
 
-const trace = makeTracer('VM', false);
+const trace = makeTracer('VM');
 
 /** @typedef {import('./storeUtils.js').NormalizedDebt} NormalizedDebt */
 
@@ -444,6 +444,17 @@ const helperBehavior = {
       factoryPowers.getGovernedParams().getLiquidationPenalty(),
     )
       .then(accounting => {
+        // current values
+        state.totalCollateral = AmountMath.subtract(
+          state.totalCollateral,
+          collateralPre,
+        );
+        state.totalDebt = AmountMath.subtract(
+          state.totalDebt,
+          accounting.shortfall,
+        );
+
+        // cumulative values
         state.totalProceedsReceived = AmountMath.add(
           state.totalProceedsReceived,
           accounting.proceeds,
@@ -455,10 +466,6 @@ const helperBehavior = {
         state.totalShortfallReceived = AmountMath.add(
           state.totalShortfallReceived,
           accounting.shortfall,
-        );
-        state.totalCollateral = AmountMath.subtract(
-          state.totalCollateral,
-          collateralPre,
         );
         prioritizedVaults.removeVault(key);
         trace('liquidated');

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -565,6 +565,7 @@ const managerBehavior = {
    * @param {Amount<'nat'>} oldCollateral
    * @param {VaultId} vaultId
    * @param {import('./vault.js').VaultPhase} vaultPhase at the end of whatever change updated balances
+   * @param {Vault} vault
    */
   handleBalanceChange: (
     { state, facets },
@@ -572,6 +573,7 @@ const managerBehavior = {
     oldCollateral,
     vaultId,
     vaultPhase,
+    vault,
   ) => {
     const { prioritizedVaults } = state;
 
@@ -591,12 +593,20 @@ const managerBehavior = {
         'Settled vaults must not be retained in storage',
       );
     } else {
-      // its position in the queue is no longer valid
-      const vault = prioritizedVaults.removeVaultByAttributes(
-        oldDebtNormalized,
-        oldCollateral,
-        vaultId,
-      );
+      const isNew = AmountMath.isEmpty(oldDebtNormalized);
+      if (!isNew) {
+        // its position in the queue is no longer valid
+
+        const vaultInStore = prioritizedVaults.removeVaultByAttributes(
+          oldDebtNormalized,
+          oldCollateral,
+          vaultId,
+        );
+        assert(
+          vault === vaultInStore,
+          'handleBalanceChange for two different vaults',
+        );
+      }
 
       // replace in queue, but only if it can accrue interest or be liquidated (i.e. has debt).
       // getCurrentDebt() would also work (0x = 0) but require more computation.
@@ -661,19 +671,38 @@ const selfBehavior = {
 
     const vault = makeVault(zcf, manager, vaultId);
 
-    // TODO Don't record the vault until it gets opened
-    const addedVaultKey = prioritizedVaults.addVault(vaultId, vault);
-
     try {
       // TODO `await` is allowed until the above ordering is fixed
       // eslint-disable-next-line @jessie.js/no-nested-await
       const vaultKit = await vault.initVaultKit(seat);
+      // initVaultKit calls back to handleBalanceChange() which will add the
+      // vault to prioritizedVaults
       seat.exit();
       return vaultKit;
     } catch (err) {
-      // remove it from prioritizedVaults
-      // XXX openLoan shouldn't assume it's already in the prioritizedVaults
-      prioritizedVaults.removeVault(addedVaultKey);
+      // ??? do we still need this cleanup? it won't get into the store unless it has collateral,
+      // which should qualify it to be in the store. If we drop this catch then the nested await
+      // for `vault.initVaultKit()` goes away.
+
+      // remove it from the store if it got in
+      /** @type {NormalizedDebt} */
+      // @ts-expect-error cast
+      const normalizedDebt = AmountMath.makeEmpty(state.debtBrand);
+      const collateralPre = seat.getCurrentAllocation().Collateral;
+      try {
+        prioritizedVaults.removeVaultByAttributes(
+          normalizedDebt,
+          collateralPre,
+          vaultId,
+        );
+        console.error('removed vault', vaultId, 'after initVaultKit failure');
+      } catch {
+        console.error(
+          'vault',
+          vaultId,
+          'never stored during initVaultKit failure',
+        );
+      }
       throw err;
     }
   },

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -770,7 +770,7 @@ const selfBehavior = {
 
 /** @param {MethodContext} context */
 const finish = ({ state, facets: { helper } }) => {
-  state.prioritizedVaults.setRescheduler(helper.reschedulePriceCheck);
+  state.prioritizedVaults.onHighestRatioChanged(helper.reschedulePriceCheck);
 
   // push initial state of metrics
   helper.updateMetrics();

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -427,23 +427,24 @@ const helperBehavior = {
    */
   liquidateAndRemove: ({ state, facets }, [key, vault]) => {
     const { factoryPowers, prioritizedVaults, zcf } = state;
-    trace('liquidating', vault.getVaultSeat().getProposal());
+    const vaultSeat = vault.getVaultSeat();
+    trace('liquidating', vaultSeat.getProposal());
 
     const collateralPre = vault.getCollateralAmount();
 
     // Start liquidation (vaultState: LIQUIDATING)
     const liquidator = state.liquidator;
     assert(liquidator);
-    trace('liquidating 2', vault.getVaultSeat().getProposal());
     return liquidate(
       zcf,
       vault,
-      (amount, seat) => facets.manager.burnAndRecord(amount, seat),
       liquidator,
       state.collateralBrand,
       factoryPowers.getGovernedParams().getLiquidationPenalty(),
     )
       .then(accounting => {
+        facets.manager.burnAndRecord(accounting.runToBurn, vaultSeat);
+
         // current values
         state.totalCollateral = AmountMath.subtract(
           state.totalCollateral,

--- a/packages/run-protocol/test/metrics.js
+++ b/packages/run-protocol/test/metrics.js
@@ -5,7 +5,6 @@ import { diff } from 'deep-object-diff';
 
 /**
  * @param {import('ava').ExecutionContext} t
- * @param {Subscription<object>} subscription
  * @param {Subscription<N>} subscription
  * @template {object} N
  */
@@ -18,13 +17,13 @@ export const subscriptionTracker = async (t, subscription) => {
   /** @param {Record<keyof N, N[keyof N]>} expectedValue */
   const assertInitial = async expectedValue => {
     notif = await metrics.getUpdateSince();
-    t.log('assertInitial notif', notif);
+    console.log('assertInitial notif', notif);
     t.deepEqual(notif.value, expectedValue);
   };
   const assertChange = async expectedDelta => {
     const prevNotif = notif;
     notif = await metrics.getUpdateSince(notif.updateCount);
-    t.log('assertChange notif', notif);
+    console.log('assertChange notif', notif);
     // @ts-expect-error diff() overly constrains
     const actualDelta = diff(prevNotif.value, notif.value);
     t.deepEqual(actualDelta, expectedDelta, 'Unexpected delta');
@@ -87,6 +86,8 @@ export const vaultManagerMetricsTracker = async (t, publicFacet) => {
       totalDebtEver - liquidated <= 1,
       `Liquidated ${liquidated} must approx equal total debt ever ${totalDebtEver}`,
     );
+    const notif = m.getLastNotif();
+    t.is(notif.value.totalDebt.value, 0n);
   };
   return harden({
     ...m,

--- a/packages/run-protocol/test/metrics.js
+++ b/packages/run-protocol/test/metrics.js
@@ -6,22 +6,26 @@ import { diff } from 'deep-object-diff';
 /**
  * @param {import('ava').ExecutionContext} t
  * @param {Subscription<object>} subscription
+ * @param {Subscription<N>} subscription
+ * @template {object} N
  */
 export const subscriptionTracker = async (t, subscription) => {
   const metrics = makeNotifierFromAsyncIterable(subscription);
+  /** @type {UpdateRecord<N>} */
   let notif;
   const getLastNotif = () => notif;
 
+  /** @param {Record<keyof N, N[keyof N]>} expectedValue */
   const assertInitial = async expectedValue => {
     notif = await metrics.getUpdateSince();
     t.log('assertInitial notif', notif);
     t.deepEqual(notif.value, expectedValue);
   };
-  /** @param {Record<string, unknown>} expectedDelta */
   const assertChange = async expectedDelta => {
     const prevNotif = notif;
     notif = await metrics.getUpdateSince(notif.updateCount);
     t.log('assertChange notif', notif);
+    // @ts-expect-error diff() overly constrains
     const actualDelta = diff(prevNotif.value, notif.value);
     t.deepEqual(actualDelta, expectedDelta, 'Unexpected delta');
   };
@@ -36,7 +40,8 @@ export const subscriptionTracker = async (t, subscription) => {
  * For public facets that have a `getMetrics` method.
  *
  * @param {import('ava').ExecutionContext} t
- * @param {{getMetrics?: () => Subscription<object>}} publicFacet
+ * @param {{getMetrics?: () => Subscription<unknown>}} publicFacet
+ * @template {object} N
  */
 export const metricsTracker = async (t, publicFacet) => {
   const metricsSub = await E(publicFacet).getMetrics();
@@ -49,6 +54,8 @@ export const metricsTracker = async (t, publicFacet) => {
  */
 export const vaultManagerMetricsTracker = async (t, publicFacet) => {
   let totalDebtEver = 0n;
+  /** @type {Awaited<ReturnType<typeof subscriptionTracker<import('../src/vaultFactory/vaultManager').MetricsNotification>>>} */
+  // @ts-expect-error cast
   const m = await metricsTracker(t, publicFacet);
 
   /** @returns {bigint} Proceeds - overage + shortfall */

--- a/packages/run-protocol/test/test-interest-math.js
+++ b/packages/run-protocol/test/test-interest-math.js
@@ -40,7 +40,7 @@ for (const [input, result] of /** @type {const} */ ([
   // some debt and previous interest
   [[1_000_000n, 2n, 0n], 980_392n], // negative interest since snapshot
   [[1_000_000n, 2n, 2n], 1_000_000n],
-  [[1_000_000n, 2n, 4n], 1_019_607n],
+  [[1_000_000n, 2n, 4n], 1_019_608n],
 ])) {
   test(
     `calculateCurrentDebt ${input} returns ${result}`,

--- a/packages/run-protocol/test/vaultFactory/test-vault-interest.js
+++ b/packages/run-protocol/test/vaultFactory/test-vault-interest.js
@@ -110,7 +110,7 @@ test('charges', async t => {
   t.deepEqual(vault.getNormalizedDebt().value, startingDebt);
 
   let interest = 0n;
-  for (const [i, charge] of [3n, 4n, 4n, 4n].entries()) {
+  for (const [i, charge] of [4n, 4n, 4n, 4n].entries()) {
     // XXX https://github.com/Agoric/agoric-sdk/issues/5527
     // eslint-disable-next-line no-await-in-loop
     await testJig.advanceRecordingPeriod();
@@ -141,7 +141,7 @@ test('charges', async t => {
     vault.getCurrentDebt(),
     AmountMath.make(runBrand, startingDebt + interest - paybackValue),
   );
-  const normalizedPaybackValue = paybackValue + 1n;
+  const normalizedPaybackValue = paybackValue - 1n;
   t.deepEqual(
     vault.getNormalizedDebt(),
     AmountMath.make(runBrand, startingDebt - normalizedPaybackValue),
@@ -149,7 +149,7 @@ test('charges', async t => {
 
   testJig.setInterestRate(25n);
 
-  for (const [i, charge] of [21n, 27n, 33n].entries()) {
+  for (const [i, charge] of [22n, 27n, 34n].entries()) {
     // XXX https://github.com/Agoric/agoric-sdk/issues/5527
     // eslint-disable-next-line no-await-in-loop
     await testJig.advanceRecordingPeriod();

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2590,7 +2590,7 @@ test('manager notifiers', async t => {
     numLiquidationsCompleted: 2,
     numVaults: 1,
     totalCollateral: { value: AMPLE },
-    totalDebt: { value: 0n },
+    totalDebt: { value: DEBT1 },
     totalOverageReceived: { value: totalOverageReceived },
     totalProceedsReceived: { value: totalProceedsReceived },
   });
@@ -2599,6 +2599,7 @@ test('manager notifiers', async t => {
     numLiquidationsCompleted: 3,
     numVaults: 0,
     totalCollateral: { value: 0n },
+    totalDebt: { value: 0n },
     totalProceedsReceived: { value: totalProceedsReceived },
   });
   m.assertFullyLiquidated();
@@ -2693,7 +2694,7 @@ test('manager notifiers', async t => {
     numLiquidationsCompleted: 5,
     numVaults: 1,
     totalCollateral: { value: AMPLE },
-    totalDebt: { value: DEBT1 + DEBT2 + interestAccrued - nextProceeds - 296n }, // debt changed already with proceeds from next notification
+    totalDebt: { value: DEBT1 + DEBT2 + interestAccrued - nextProceeds },
     totalProceedsReceived: { value: totalProceedsReceived },
   });
   nextProceeds = 296n;

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2703,9 +2703,6 @@ test('manager notifiers', async t => {
     },
   });
   m.assertFullyLiquidated();
-  // FIXME there shouldn't be any leftover debt once fully liquidated
-  // https://github.com/Agoric/agoric-sdk/issues/5550
-  const leftoverDebt = DEBT1 - nextProceeds + interestAccrued;
 
   trace('11. Create a loan with ample collateral');
   /** @type {UserSeat<VaultKit>} */
@@ -2724,13 +2721,13 @@ test('manager notifiers', async t => {
   await m.assertChange({
     numVaults: 1,
     totalCollateral: { value: AMPLE },
-    totalDebt: { value: DEBT1 + leftoverDebt },
+    totalDebt: { value: DEBT1 },
   });
 
   trace('12. Borrow more');
   taken = run.make(400n);
   // 20n? fix in https://github.com/Agoric/agoric-sdk/issues/5550
-  const debtPostBorrowingMore = DEBT1 + leftoverDebt + taken.value + 20n;
+  const debtPostBorrowingMore = DEBT1 + taken.value + 20n;
   // can't use 0n because of https://github.com/Agoric/agoric-sdk/issues/5548
   // but since this test is of metrics, we take the opportunity to check totalCollateral changing
   const given = aeth.make(2n);
@@ -2745,7 +2742,6 @@ test('manager notifiers', async t => {
       Collateral: t.context.aeth.mint.mintPayment(given),
     }),
   );
-  console.log('DEBUG', { DEBT1, leftoverDebt, taken });
   await E(vaultSeat).getOfferResult();
   await m.assertChange({
     totalDebt: { value: debtPostBorrowingMore },
@@ -2767,6 +2763,6 @@ test('manager notifiers', async t => {
   await m.assertChange({
     numVaults: 0,
     totalCollateral: { value: 0n },
-    totalDebt: { value: leftoverDebt },
+    totalDebt: { value: 0n },
   });
 });


### PR DESCRIPTION
closes: #5550
stacks on: #5531

## Description

The `totalDebt` tracker wasn't accounting for shortfalls. While debugging I also encountered off-by-one rounding errors with apparently inconsistent of ceil/floor, so this also changes to use bankers' rounding in interest calculations.


### Security Considerations

No changes here but noted some opportunities to reduce powers of the `liquidate` module.

### Documentation Considerations

--

### Testing Considerations

The metrics tests would take less effort to read and maintain if they used a driver. Should that be done in this PR? (e.g. moving into a new file modeled after `test-liquidator.js`.