### PR TITLE
fix: missed a duplication of #5569 patch

### DIFF
--- a/packages/agoric-cli/test/test-main.js
+++ b/packages/agoric-cli/test/test-main.js
@@ -1,8 +1,7 @@
 /* global globalThis */
 import '@endo/init/pre.js';
 import 'esm';
-// Not yet '@endo/init/debug.js' because esm needs moderate override taming
-import '@endo/init';
+import '@endo/init/debug.js';
 import test from 'ava';
 import fs from 'fs';
 import anylogger from 'anylogger';

--- a/patches/@confio+ics23++protobufjs+6.11.3.patch
+++ b/patches/@confio+ics23++protobufjs+6.11.3.patch
@@ -1,0 +1,50 @@
+diff --git a/node_modules/@confio/ics23/node_modules/protobufjs/src/util/minimal.js b/node_modules/@confio/ics23/node_modules/protobufjs/src/util/minimal.js
+index 3c406de..083f71c 100644
+--- a/node_modules/@confio/ics23/node_modules/protobufjs/src/util/minimal.js
++++ b/node_modules/@confio/ics23/node_modules/protobufjs/src/util/minimal.js
+@@ -280,13 +280,38 @@ function newError(name) {
+             merge(this, properties);
+     }
+ 
+-    (CustomError.prototype = Object.create(Error.prototype)).constructor = CustomError;
+-
+-    Object.defineProperty(CustomError.prototype, "name", { get: function() { return name; } });
+-
+-    CustomError.prototype.toString = function toString() {
+-        return this.name + ": " + this.message;
+-    };
++    CustomError.prototype = Object.create(Error.prototype, {
++        constructor: {
++            value: CustomError,
++            writable: true,
++            // enumerable: true would accurately preserve the behavior of the
++            // original assignment, but I'm guessing that was not intentional.
++            // For an actual error subclass, this property would not
++            // be enumerable.
++            enumerable: false,
++            configurable: true,
++        },
++        name: {
++            get() { return name; },
++            set: undefined,
++            enumerable: false,
++            // configurable: false would accurately preserve the behavior of
++            // the original, but I'm guessing that was not intentional.
++            // For an actual error subclass, this property would
++            // be configurable.
++            configurable: true,
++        },
++        toString: {
++            value() { return this.name + ": " + this.message; },
++            writable: true,
++            // enumerable: true would accurately preserve the behavior of the
++            // original assignment, but I'm guessing that was not intentional.
++            // For an actual error subclass, this property would not
++            // be enumerable.
++            enumerable: false,
++            configurable: true,
++        },
++    });
+ 
+     return CustomError;
+ }


### PR DESCRIPTION
#5569 patched the package sources needed to get test-main.js working, but did not patch a duplicated occurrence of one of them. This fixes that oversight and also makes the change to test-main.js that needed these patches.