### PR TITLE
fix: minor tweak to make `sortObjectProperties` use `hasOwn`

### DIFF
--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -271,7 +271,7 @@ function sortObjectProperties(obj, firsts = []) {
   const sorted = [...firsts, ...Object.keys(obj).sort()];
   const result = {};
   for (const prop of sorted) {
-    if (prop && result[prop] === undefined && obj[prop] !== undefined) {
+    if (prop && !Object.hasOwn(result, prop) && Object.hasOwn(obj, prop)) {
       result[prop] = obj[prop];
     }
   }


### PR DESCRIPTION
Yesterday's PR #5552 originally used `Object.hasOwn` but the XS engine lacked the `Object.hasOwn` function and so all the XS-based tests failed, so the code was tweaked to do something lesser.  But today a new version of XS appeared that does have `hasOwn` so this small PR puts things to right.
