### PR TITLE
feat: Meaningful dynamic vat names

### DIFF
--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -14,7 +14,7 @@ function makeSpawner(vatAdminSvc) {
       return Far('installer', {
         async spawn(argsP) {
           const meter = await E(vatAdminSvc).createUnlimitedMeter();
-          const opts = { meter };
+          const opts = { name: 'spawn', meter };
           const { root } = await E(vatAdminSvc).createVat(spawnBundle, opts);
           return E(E(root).loadBundle(bundle)).start(argsP);
         },

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -84,7 +84,7 @@ export const makeVatsFromBundles = ({
     return provide(store, bundleName, _k => {
       console.info(`createVatByName(${bundleName})`);
       /** @type { Promise<VatInfo> } */
-      const vatInfo = E(svc).createVatByName(bundleName);
+      const vatInfo = E(svc).createVatByName(bundleName, { name: bundleName });
       return vatInfo;
     }).then(r => r.root);
   });

--- a/packages/zoe/src/zoeService/createZCFVat.js
+++ b/packages/zoe/src/zoeService/createZCFVat.js
@@ -26,7 +26,9 @@ export const setupCreateZCFVat = (vatAdminSvc, zcfSpec) => {
     /** @type {BundleCap} */
     const bundleCap = await bundleCapP;
     assert(bundleCap, `setupCreateZCFVat did not get bundleCap`);
-    const rootAndAdminNodeP = E(vatAdminSvc).createVat(bundleCap);
+    const rootAndAdminNodeP = E(vatAdminSvc).createVat(bundleCap, {
+      name: 'zcf',
+    });
     const rootAndAdminNode = await rootAndAdminNodeP;
     return rootAndAdminNode;
   };

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -253,7 +253,7 @@
  * @property {(BundleID: id) => Promise<BundleCap>} waitForBundleCap
  * @property {(BundleID: id) => Promise<BundleCap>} getBundleCap
  * @property {(name: string) => Promise<BundleCap>} getNamedBundleCap
- * @property {(bundleCap: BundleCap) => Promise<RootAndAdminNode>} createVat
+ * @property {(bundleCap: BundleCap, options?: Record<string, any>) => Promise<RootAndAdminNode>} createVat
  */
 
 /**


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #5516

## Description

As on the tin.  Here is the xsnap process arguments of a solo with sim-chain after this PR:
```
$ ps -ef | sed -n '/xsnap/{ s/.*\(v[0-9]*:[^ ]*\).*/\1/; p; }' | sort -V
v1:bootstrap
v1:bootstrap
v2:vatAdmin
v2:vatAdmin
v4:vattp
v4:vattp
v5:timer
v5:timer
v6:http
v6:priceAuthority
v7:network
v7:zoe
v8:board
v8:spawner
v9:provisioning
v9:uploads
v10:network
v10:spawned
v11:ibc
v12:mints
v14:zcf
v15:bank
v17:zcf
v18:zcf
v19:zcf
v20:zcf
v21:zcf
v22:zcf
v23:zcf
v25:zcf
v26:zcf
v27:zcf
v28:zcf
v29:zcf
v30:zcf
v31:zcf
```

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
