### PR TITLE
fix: when zcfMint.burnLosses() fails for offerSafety, don't stage an allocation

### DIFF
--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -193,17 +193,18 @@ export const makeZCFZygote = (
           losses,
         );
 
+        // verifies offer safety
+        assert(
+          zcfSeat.isOfferSafe(allocationMinusLosses),
+          `The allocation after burning losses ${allocationMinusLosses}for the zcfSeat was not offer safe`,
+        );
+
         // Decrement the stagedAllocation if it exists so that the
         // stagedAllocation is kept up to the currentAllocation
         if (zcfSeat.hasStagedAllocation()) {
           zcfSeat.decrementBy(losses);
         }
 
-        // verifies offer safety
-        assert(
-          zcfSeat.isOfferSafe(allocationMinusLosses),
-          `The allocation after burning losses ${allocationMinusLosses}for the zcfSeat was not offer safe`,
-        );
         // No effects above, apart from decrementBy. Note COMMIT POINT within
         // reallocateForZCFMint. The following two steps *should* be
         // committed atomically, but it is not a disaster if they are

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -590,8 +590,7 @@ test(`zcf.makeZCFMint - burnLosses - seat exited`, async t => {
   );
 });
 
-// reported as a bug in https://github.com/Agoric/agoric-sdk/issues/5544
-test.failing('burnLosses - not offer safe', async t => {
+test('burnLosses - offer safety violation no staged allocation', async t => {
   const { zcf } = await setupZCFTest();
   const doubloonMint = await zcf.makeZCFMint('Doubloons');
   const yenMint = await zcf.makeZCFMint('Yen');
@@ -635,7 +634,7 @@ test.failing('burnLosses - not offer safe', async t => {
     },
   );
   t.truthy(zcfSeat.hasStagedAllocation());
-  t.deepEqual(staged.DownPayment, zcfSeat.getStagedAllocation().DownPayment);
+  t.deepEqual(zcfSeat.getStagedAllocation().DownPayment, staged.DownPayment);
 });
 
 test(`zcf.makeZCFMint - displayInfo`, async t => {


### PR DESCRIPTION
closes: #5544
fixes:  #5560

## Description

When burnLosses() failed due to offerSafety, it left a newly staged allocation behind

### Security Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

Updated tests.
