### PR TITLE
style: trivial changes to make lint happy

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -113,8 +113,8 @@ export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
   /**
    * @param {string} name
    * @param {(request: Uint8Array) => Promise<Uint8Array>} handleCommand
-   * @param { boolean } [metered]
-   * @param { string } [snapshotHash]
+   * @param {boolean} [metered]
+   * @param {string} [snapshotHash]
    */
   async function startXSnap(
     name,
@@ -347,9 +347,9 @@ export async function makeSwingsetController(
   /**
    * Validate and install a code bundle.
    *
-   * @param { EndoZipBase64Bundle } bundle
-   * @param { BundleID } [allegedBundleID]
-   * @returns { Promise<BundleID> }
+   * @param {EndoZipBase64Bundle} bundle
+   * @param {BundleID} [allegedBundleID]
+   * @returns {Promise<BundleID>}
    */
   async function validateAndInstallBundle(bundle, allegedBundleID) {
     // TODO The following assertion may be removed when checkBundle subsumes

--- a/packages/SwingSet/src/kernel/deviceManager.js
+++ b/packages/SwingSet/src/kernel/deviceManager.js
@@ -87,8 +87,8 @@ export default function makeDeviceManager(
   /**
    * Invoke a method on a device node.
    *
-   * @param { DeviceInvocation } deviceInvocation
-   * @returns { DeviceInvocationResult }
+   * @param {DeviceInvocation} deviceInvocation
+   * @returns {DeviceInvocationResult}
    */
   function invoke(deviceInvocation) {
     const [target, method, args] = deviceInvocation;

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -189,10 +189,10 @@ export function makeDeviceSlots(
   // device node itself throws an exception during invocation
   /**
    *
-   * @param { string } deviceID
-   * @param { string } method
-   * @param { SwingSetCapData } args
-   * @returns { DeviceInvocationResult }
+   * @param {string} deviceID
+   * @param {string} method
+   * @param {SwingSetCapData} args
+   * @returns {DeviceInvocationResult}
    */
   function invoke(deviceID, method, args) {
     insistVatType('device', deviceID);

--- a/packages/SwingSet/src/kernel/deviceTranslator.js
+++ b/packages/SwingSet/src/kernel/deviceTranslator.js
@@ -40,8 +40,8 @@ function makeDRTranslator(deviceID, kernelKeeper) {
 
   /**
    *
-   * @param { DeviceInvocationResult } deviceInvocationResult
-   * @returns { KernelSyscallResult }
+   * @param {DeviceInvocationResult} deviceInvocationResult
+   * @returns {KernelSyscallResult}
    */
   function deviceResultToKernelResult(deviceInvocationResult) {
     // deviceInvocationResult is ['ok', capdata]
@@ -66,10 +66,10 @@ function makeDRTranslator(deviceID, kernelKeeper) {
  * return a function that converts DeviceSyscall objects into KernelSyscall
  * objects
  *
- * @param { string } deviceID
- * @param { string } deviceName
- * @param { * } kernelKeeper
- * @returns { (dsc: DeviceSyscallObject) => KernelSyscallObject }
+ * @param {string} deviceID
+ * @param {string} deviceName
+ * @param {*} kernelKeeper
+ * @returns {(dsc: DeviceSyscallObject) => KernelSyscallObject}
  */
 export function makeDSTranslator(deviceID, deviceName, kernelKeeper) {
   const deviceKeeper = kernelKeeper.allocateDeviceKeeperIfNeeded(deviceID);
@@ -152,8 +152,8 @@ export function makeDSTranslator(deviceID, deviceName, kernelKeeper) {
   /**
    * Convert syscalls from device space to kernel space
    *
-   * @param { DeviceSyscallObject } vsc
-   * @returns { KernelSyscallObject }
+   * @param {DeviceSyscallObject} vsc
+   * @returns {KernelSyscallObject}
    */
   function deviceSyscallToKernelSyscall(vsc) {
     const [type, ...args] = vsc;

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -401,10 +401,10 @@ export default function buildKernel(
   /**
    * Deliver one message to a vat.
    *
-   * @param { VatID } vatID
-   * @param { string } target
-   * @param { Message } msg
-   * @returns { Promise<DeliveryStatus | null> }
+   * @param {VatID} vatID
+   * @param {string} target
+   * @param {Message} msg
+   * @returns {Promise<DeliveryStatus | null>}
    */
   async function processSend(vatID, target, msg) {
     insistMessage(msg);
@@ -435,8 +435,8 @@ export default function buildKernel(
 
   /**
    *
-   * @param { RunQueueEventNotify } message
-   * @returns { Promise<DeliveryStatus | null> }
+   * @param {RunQueueEventNotify} message
+   * @returns {Promise<DeliveryStatus | null>}
    */
   async function processNotify(message) {
     const { vatID, kpid } = message;
@@ -482,8 +482,8 @@ export default function buildKernel(
 
   /**
    *
-   * @param { RunQueueEventDropExports | RunQueueEventRetireImports | RunQueueEventRetireExports } message
-   * @returns { Promise<DeliveryStatus | null> }
+   * @param {RunQueueEventDropExports | RunQueueEventRetireImports | RunQueueEventRetireExports} message
+   * @returns {Promise<DeliveryStatus | null>}
    */
   async function processGCMessage(message) {
     // used for dropExports, retireExports, and retireImports
@@ -511,8 +511,8 @@ export default function buildKernel(
 
   /**
    *
-   * @param { RunQueueEventBringOutYourDead } message
-   * @returns { Promise<DeliveryStatus | null> }
+   * @param {RunQueueEventBringOutYourDead} message
+   * @returns {Promise<DeliveryStatus | null>}
    */
   async function processBringOutYourDead(message) {
     const { type, vatID } = message;
@@ -542,8 +542,8 @@ export default function buildKernel(
    * but doing it this way simply guarantees there won't be such a problem
    * without requiring any further analysis to be sure).
    *
-   * @param { RunQueueEventStartVat } message
-   * @returns { Promise<DeliveryStatus> }
+   * @param {RunQueueEventStartVat} message
+   * @returns {Promise<DeliveryStatus>}
    */
   async function processStartVat(message) {
     const { vatID, vatParameters } = message;
@@ -568,8 +568,8 @@ export default function buildKernel(
 
   /**
    *
-   * @param { RunQueueEventCreateVat } message
-   * @returns { Promise<DeliveryStatus | null> }
+   * @param {RunQueueEventCreateVat} message
+   * @returns {Promise<DeliveryStatus | null>}
    */
   async function processCreateVat(message) {
     assert(vatAdminRootKref, `initializeKernel did not set vatAdminRootKref`);
@@ -653,8 +653,8 @@ export default function buildKernel(
 
   /**
    *
-   * @param { RunQueueEventChangeVatOptions } message
-   * @returns { Promise<DeliveryStatus | null> }
+   * @param {RunQueueEventChangeVatOptions} message
+   * @returns {Promise<DeliveryStatus | null>}
    */
   async function processChangeVatOptions(message) {
     const { vatID, options } = message;
@@ -687,8 +687,8 @@ export default function buildKernel(
 
   /**
    *
-   * @param { RunQueueEventUpgradeVat } message
-   * @returns { Promise<DeliveryStatus | null> }
+   * @param {RunQueueEventUpgradeVat} message
+   * @returns {Promise<DeliveryStatus | null>}
    */
   async function processUpgradeVat(message) {
     assert(vatAdminRootKref, `initializeKernel did not set vatAdminRootKref`);
@@ -809,8 +809,8 @@ export default function buildKernel(
    *
    * This does not decrement any refcounts. The caller should do that.
    *
-   * @param { RunQueueEventSend } message
-   * @returns { { vatID: VatID | null, target: string } | null }
+   * @param {RunQueueEventSend} message
+   * @returns {{ vatID: VatID | null, target: string } | null}
    */
   function routeSendEvent(message) {
     const { target, msg } = message;
@@ -934,8 +934,8 @@ export default function buildKernel(
    * ahead of time. For now, this is called for each run-queue event, so
    * 'send' does not yet know which vat will be involved (if any).
    *
-   * @param { RunQueueEvent } message
-   * @returns { Promise<DeliveryStatus | null> }
+   * @param {RunQueueEvent} message
+   * @returns {Promise<DeliveryStatus | null>}
    */
   async function deliverRunQueueEvent(message) {
     // Decref everything in the message, under the assumption that most of
@@ -1247,8 +1247,8 @@ export default function buildKernel(
     // not
     /**
      *
-     * @param { VatSyscallObject } vatSyscallObject
-     * @returns { VatSyscallResult }
+     * @param {VatSyscallObject} vatSyscallObject
+     * @returns {VatSyscallResult}
      */
     function vatSyscallHandler(vatSyscallObject) {
       // eslint-disable-next-line no-use-before-define
@@ -1588,7 +1588,7 @@ export default function buildKernel(
    * Run the kernel until the policy says to stop, or the queue is empty.
    *
    * @param {RunPolicy?} policy - a RunPolicy to limit the work being done
-   * @returns { Promise<number> } The number of cranks that were executed.
+   * @returns {Promise<number>} The number of cranks that were executed.
    */
   async function run(policy = foreverPolicy()) {
     assert(policy);
@@ -1646,8 +1646,8 @@ export default function buildKernel(
   /**
    * Install a pre-validated bundle under the given ID.
    *
-   * @param { BundleID } bundleID
-   * @param { EndoZipBase64Bundle } bundle
+   * @param {BundleID} bundleID
+   * @param {EndoZipBase64Bundle} bundle
    */
   async function installBundle(bundleID, bundle) {
     // bundleID is b1-HASH

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -70,9 +70,9 @@ export function makeKernelSyscallHandler(tools) {
 
   /**
    *
-   * @param { string } vatID
-   * @param { string } key
-   * @returns { KernelSyscallResult }
+   * @param {string} vatID
+   * @param {string} key
+   * @returns {KernelSyscallResult}
    */
   function vatstoreGet(vatID, key) {
     const actualKey = vatstoreKeyKey(vatID, key);
@@ -84,10 +84,10 @@ export function makeKernelSyscallHandler(tools) {
 
   /**
    *
-   * @param { string } vatID
-   * @param { string } key
-   * @param { string } value
-   * @returns { KernelSyscallResult }
+   * @param {string} vatID
+   * @param {string} key
+   * @param {string} value
+   * @returns {KernelSyscallResult}
    */
   function vatstoreSet(vatID, key, value) {
     const actualKey = vatstoreKeyKey(vatID, key);
@@ -226,9 +226,9 @@ export function makeKernelSyscallHandler(tools) {
 
   /**
    *
-   * @param { string } vatID
-   * @param { string } key
-   * @returns { KernelSyscallResult }
+   * @param {string} vatID
+   * @param {string} key
+   * @returns {KernelSyscallResult}
    */
 
   function vatstoreDelete(vatID, key) {
@@ -242,10 +242,10 @@ export function makeKernelSyscallHandler(tools) {
 
   /**
    *
-   * @param { string } deviceSlot
-   * @param { string } method
-   * @param { SwingSetCapData } args
-   * @returns { KernelSyscallResult }
+   * @param {string} deviceSlot
+   * @param {string} method
+   * @param {SwingSetCapData} args
+   * @returns {KernelSyscallResult}
    */
   function invoke(deviceSlot, method, args) {
     insistKernelType('device', deviceSlot);
@@ -338,8 +338,8 @@ export function makeKernelSyscallHandler(tools) {
   }
 
   /**
-   * @param { KernelSyscallObject } ksc
-   * @returns {  KernelSyscallResult }
+   * @param {KernelSyscallObject} ksc
+   * @returns { KernelSyscallResult}
    */
   function kernelSyscallHandler(ksc) {
     // this repeated pattern is necessary to get the typechecker to refine 'ksc' and 'args' properly

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -75,7 +75,7 @@ function makeCallbackRegistry(callbacks) {
  *
  * @param {*} slogCallbacks
  * @param {Pick<Console, 'debug'|'log'|'info'|'warn'|'error'>} dummyConsole
- * @returns { KernelSlog }
+ * @returns {KernelSlog}
  */
 export function makeDummySlogger(slogCallbacks, dummyConsole) {
   const { registerCallback: reg, doneRegistering } =
@@ -105,7 +105,7 @@ export function makeDummySlogger(slogCallbacks, dummyConsole) {
  *
  * @param {*} slogCallbacks
  * @param {*} writeObj
- * @returns { KernelSlog }
+ * @returns {KernelSlog}
  */
 export function makeSlogger(slogCallbacks, writeObj) {
   const safeWrite = e => {

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -169,7 +169,7 @@ export default function makeKernelKeeper(
   insistStorageAPI(rawKVStore);
 
   /**
-   * @param { string } key
+   * @param {string} key
    */
   function getKeyType(key) {
     if (key.startsWith('local.')) {
@@ -260,7 +260,7 @@ export default function makeKernelKeeper(
   }
 
   /**
-   * @param { KernelOptions } kernelOptions
+   * @param {KernelOptions} kernelOptions
    */
   function createStartingKernelState(kernelOptions) {
     const {
@@ -300,8 +300,9 @@ export default function makeKernelKeeper(
   /**
    *
    * @param {string} mt
-   * @returns { asserts mt is ManagerType }
+   * @returns {asserts mt is ManagerType}
    */
+
   function insistManagerType(mt) {
     assert(
       [
@@ -312,7 +313,6 @@ export default function makeKernelKeeper(
         'xs-worker-no-gc',
       ].includes(mt),
     );
-    return undefined; // hush JSDoc
   }
 
   function getDefaultManagerType() {
@@ -322,7 +322,7 @@ export default function makeKernelKeeper(
   }
 
   /**
-   * @returns { boolean }
+   * @returns {boolean}
    */
   function getEnableFakeDurable() {
     return !!kvStore.get('kernel.enableFakeDurable');
@@ -330,7 +330,7 @@ export default function makeKernelKeeper(
 
   /**
    *
-   * @returns { number | 'never' }
+   * @returns {number | 'never'}
    */
   function getDefaultReapInterval() {
     const r = getRequired('kernel.defaultReapInterval');
@@ -369,9 +369,9 @@ export default function makeKernelKeeper(
   const bundleIDRE = new RegExp('^b1-[0-9a-f]{128}$');
 
   /**
-   * @param { string } name
-   * @param { BundleID } bundleID
-   * @returns { void }
+   * @param {string} name
+   * @param {BundleID} bundleID
+   * @returns {void}
    */
   function addNamedBundleID(name, bundleID) {
     assert.typeof(bundleID, 'string');
@@ -380,16 +380,16 @@ export default function makeKernelKeeper(
   }
 
   /**
-   * @param { string } name
-   * @returns { BundleID }
+   * @param {string} name
+   * @returns {BundleID}
    */
   function getNamedBundleID(name) {
     return harden(getRequired(`namedBundleID.${name}`));
   }
 
   /**
-   * @param { BundleID } bundleID
-   * @returns { string }
+   * @param {BundleID} bundleID
+   * @returns {string}
    */
   function bundleIDToKey(bundleID) {
     // bundleID is b1-HASH
@@ -401,9 +401,9 @@ export default function makeKernelKeeper(
   /**
    * Store a bundle (by ID) in the kernel DB.
    *
-   * @param { BundleID } bundleID The claimed bundleID: the caller
+   * @param {BundleID} bundleID The claimed bundleID: the caller
    *        (controller.js) must validate it first, we assume it is correct.
-   * @param { EndoZipBase64Bundle } bundle The code bundle, whose format must
+   * @param {EndoZipBase64Bundle} bundle The code bundle, whose format must
    *        be 'endoZipBase64'.
    */
   function addBundle(bundleID, bundle) {
@@ -418,16 +418,16 @@ export default function makeKernelKeeper(
   }
 
   /**
-   * @param { BundleID } bundleID
-   * @returns { boolean }
+   * @param {BundleID} bundleID
+   * @returns {boolean}
    */
   function hasBundle(bundleID) {
     return kvStore.has(bundleIDToKey(bundleID));
   }
 
   /**
-   * @param { BundleID } bundleID
-   * @returns { EndoZipBase64Bundle | undefined }
+   * @param {BundleID} bundleID
+   * @returns {EndoZipBase64Bundle | undefined}
    */
   function getBundle(bundleID) {
     const value = kvStore.get(bundleIDToKey(bundleID));
@@ -483,8 +483,8 @@ export default function makeKernelKeeper(
   }
 
   /**
-   * @param { string } vatID
-   * @param { string } kernelSlot
+   * @param {string} vatID
+   * @param {string} kernelSlot
    */
   function getReachableAndVatSlot(vatID, kernelSlot) {
     const kernelKey = `${vatID}.c.${kernelSlot}`;
@@ -519,9 +519,9 @@ export default function makeKernelKeeper(
   /**
    * Allocate a new koid.
    *
-   * @param { string } ownerID
-   * @param { undefined | bigint } id
-   * @returns { string }
+   * @param {string} ownerID
+   * @param {undefined | bigint} id
+   * @returns {string}
    */
   function addKernelObject(ownerID, id = undefined) {
     // providing id= is only for unit tests
@@ -1129,7 +1129,7 @@ export default function makeKernelKeeper(
   // replay).
 
   const maybeFreeKrefs = new Set();
-  /** @param { string } kref */
+  /** @param {string} kref */
   function addMaybeFreeKref(kref) {
     insistKernelType('object', kref);
     maybeFreeKrefs.add(kref);
@@ -1144,7 +1144,7 @@ export default function makeKernelKeeper(
    *
    * @param {unknown} kernelSlot  The kernel slot whose refcount is to be incremented.
    * @param {string?} tag  Debugging note with rough source of the reference.
-   * @param { { isExport?: boolean, onlyRecognizable?: boolean } } options
+   * @param {{ isExport?: boolean, onlyRecognizable?: boolean }} options
    * 'isExport' means the reference comes from a clist export, which counts
    * for promises but not objects. 'onlyRecognizable' means the reference
    * provides only recognition, not reachability
@@ -1316,7 +1316,7 @@ export default function makeKernelKeeper(
   /**
    * Cease writing to the vat's transcript.
    *
-   * @param { string } vatID
+   * @param {string} vatID
    */
   function closeVatTranscript(vatID) {
     insistVatID(vatID);
@@ -1348,7 +1348,7 @@ export default function makeKernelKeeper(
   }
 
   /*
-   * @returns { DeviceID | undefined }
+   * @returns {DeviceID | undefined}
    */
   function getDeviceIDForName(name) {
     assert.typeof(name, 'string');

--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -21,7 +21,7 @@ import { insistStorageAPI, makeBufferedStorage } from '../../lib/storageAPI.js';
  *
  * @param {KVStore} kvStore  The StorageAPI object that this crank buffer will be based on.
  * @param {import('../../lib-nodejs/hasher.js').CreateSHA256}  createSHA256
- * @param { (key: string) => 'consensus' | 'local' | 'invalid' } getKeyType
+ * @param {(key: string) => 'consensus' | 'local' | 'invalid'} getKeyType
  * @returns {*} an object {
  * crankBuffer,  // crank buffer as described, wrapping `kvStore`
  * commitCrank,  // function to save buffered mutations to `kvStore`
@@ -74,7 +74,7 @@ export function buildCrankBuffer(
    * Flush any buffered mutations to the underlying storage, and update the
    * activityhash.
    *
-   * @returns { { crankhash: string, activityhash: string } }
+   * @returns {{ crankhash: string, activityhash: string }}
    */
   function commitCrank() {
     // Flush the buffered operations.

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -66,7 +66,7 @@ export function initializeVatState(kvStore, streamStore, vatID) {
  * @param {*} incStat
  * @param {*} decStat
  * @param {*} getCrankNumber
- * @param { SnapStore= } snapStore
+ * @param {SnapStore=} snapStore
  * returns an object to hold and access the kernel's state for the given vat
  */
 export function makeVatKeeper(
@@ -493,7 +493,7 @@ export function makeVatKeeper(
     kvStore.set(`${vatID}.t.endPosition`, `${JSON.stringify(newPos)}`);
   }
 
-  /** @returns { StreamPosition } */
+  /** @returns {StreamPosition} */
   function getTranscriptEndPosition() {
     return JSON.parse(
       kvStore.get(`${vatID}.t.endPosition`) ||
@@ -569,8 +569,8 @@ export function makeVatKeeper(
   /**
    * Store a snapshot, if given a snapStore.
    *
-   * @param { VatManager } manager
-   * @returns { Promise<boolean> }
+   * @param {VatManager} manager
+   * @returns {Promise<boolean>}
    */
   async function saveSnapshot(manager) {
     if (!snapStore || !manager.makeSnapshot) {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -98,14 +98,14 @@ import { makeTranscriptManager } from './transcript.js';
  * The returned getManager() function will return a VatManager suitable for
  * handing to the kernel, which can use it to send deliveries to the vat.
  *
- * @param { string } vatID
- * @param { KernelKeeper } kernelKeeper
- * @param { KernelSlog } kernelSlog
- * @param { (vso: VatSyscallObject) => VatSyscallResult } vatSyscallHandler
- * @param { boolean } workerCanBlock
- * @param { (vatID: any, originalSyscall: any, newSyscall: any) => Error | undefined } [compareSyscalls]
- * @param { boolean } [useTranscript]
- * @returns { ManagerKit }
+ * @param {string} vatID
+ * @param {KernelKeeper} kernelKeeper
+ * @param {KernelSlog} kernelSlog
+ * @param {(vso: VatSyscallObject) => VatSyscallResult} vatSyscallHandler
+ * @param {boolean} workerCanBlock
+ * @param {(vatID: any, originalSyscall: any, newSyscall: any) => Error | undefined} [compareSyscalls]
+ * @param {boolean} [useTranscript]
+ * @returns {ManagerKit}
  */
 
 function makeManagerKit(
@@ -132,7 +132,7 @@ function makeManagerKit(
   let deliverToWorker;
 
   /**
-   * @param { (delivery: VatDeliveryObject) => Promise<VatDeliveryResult> } dtw
+   * @param {(delivery: VatDeliveryObject) => Promise<VatDeliveryResult>} dtw
    */
   function setDeliverToWorker(dtw) {
     assert(!deliverToWorker, `setDeliverToWorker called twice`);
@@ -141,8 +141,8 @@ function makeManagerKit(
 
   /**
    *
-   * @param { VatDeliveryObject } delivery
-   * @returns { Promise<VatDeliveryResult> } // or Error
+   * @param {VatDeliveryObject} delivery
+   * @returns {Promise<VatDeliveryResult>} // or Error
    */
   async function deliver(delivery) {
     if (transcriptManager) {
@@ -194,7 +194,7 @@ function makeManagerKit(
 
   /**
    * @param {StreamPosition | undefined} startPos
-   * @returns { Promise<number?> } number of deliveries, or null if !useTranscript
+   * @returns {Promise<number?>} number of deliveries, or null if !useTranscript
    */
   async function replayTranscript(startPos) {
     // console.log('replay from', { vatID, startPos });
@@ -235,8 +235,8 @@ function makeManagerKit(
    * bytes over a socket or pipe, postMessage to an in-process Worker, or
    * just direct).
    *
-   * @param { VatSyscallObject } vso
-   * @returns { VatSyscallResult }
+   * @param {VatSyscallObject} vso
+   * @returns {VatSyscallResult}
    */
   function syscallFromWorker(vso) {
     if (transcriptManager && transcriptManager.inReplay()) {
@@ -265,8 +265,8 @@ function makeManagerKit(
   /**
    *
    * @param { () => Promise<void>} shutdown
-   * @param { (ss: SnapStore) => Promise<string> } makeSnapshot
-   * @returns { VatManager }
+   * @param {(ss: SnapStore) => Promise<string>} makeSnapshot
+   * @returns {VatManager}
    */
   function getManager(shutdown, makeSnapshot) {
     return harden({

--- a/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
@@ -30,7 +30,7 @@ function parentLog(first, ...args) {
  *   kernelSlog: KernelSlog,
  *   testLog: (...args: unknown[]) => void,
  * }} tools
- * @returns { VatManagerFactory }
+ * @returns {VatManagerFactory}
  */
 export function makeNodeWorkerVatManagerFactory(tools) {
   const { makeNodeWorker, kernelKeeper, kernelSlog, testLog } = tools;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -55,8 +55,8 @@ export function makeNodeSubprocessFactory(tools) {
     let waiting;
 
     /**
-     * @param { VatDeliveryObject } delivery
-     * @returns { Promise<VatDeliveryResult> }
+     * @param {VatDeliveryObject} delivery
+     * @returns {Promise<VatDeliveryResult>}
      */
     function deliverToWorker(delivery) {
       parentLog(`sending delivery`, delivery);

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -26,7 +26,7 @@ const decoder = new TextDecoder();
  *   startXSnap: (name: string, handleCommand: AsyncHandler, metered?: boolean, snapshotHash?: string) => Promise<XSnap>,
  *   testLog: (...args: unknown[]) => void,
  * }} tools
- * @returns { VatManagerFactory }
+ * @returns {VatManagerFactory}
  *
  * @typedef { { moduleFormat: 'getExport', source: string } } ExportBundle
  * @typedef { (msg: Uint8Array) => Promise<Uint8Array> } AsyncHandler
@@ -38,10 +38,10 @@ export function makeXsSubprocessFactory({
   testLog,
 }) {
   /**
-   * @param { string } vatID
-   * @param { unknown } bundle
-   * @param { ManagerOptions } managerOptions
-   * @param { (vso: VatSyscallObject) => VatSyscallResult } vatSyscallHandler
+   * @param {string} vatID
+   * @param {unknown} bundle
+   * @param {ManagerOptions} managerOptions
+   * @param {(vso: VatSyscallObject) => VatSyscallResult} vatSyscallHandler
    */
   async function createFromBundle(
     vatID,
@@ -162,7 +162,7 @@ export function makeXsSubprocessFactory({
 
     /**
      * @param { VatDeliveryObject} delivery
-     * @returns { Promise<VatDeliveryResult> }
+     * @returns {Promise<VatDeliveryResult>}
      */
     async function deliverToWorker(delivery) {
       parentLog(vatID, `sending delivery`, delivery);

--- a/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
+++ b/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
@@ -25,9 +25,9 @@ export function makeVatLoader(stuff) {
    * Create a new vat at runtime (called when a 'create-vat' event reaches
    * the top of the run-queue).
    *
-   * @param { string } vatID  The pre-allocated vatID
-   * @param { SourceOfBundle } source  The source object implementing the vat
-   * @param { Translators } translators
+   * @param {string} vatID  The pre-allocated vatID
+   * @param {SourceOfBundle} source  The source object implementing the vat
+   * @param {Translators} translators
    * @param {*} dynamicOptions  Options bag governing vat creation
    *
    * @returns {Promise<VatManager>}
@@ -47,8 +47,8 @@ export function makeVatLoader(stuff) {
    * Recreate a dynamic vat from persistent state at kernel startup time.
    *
    * @param {string} vatID  The vatID of the vat to create
-   * @param { SourceOfBundle } source  The source object implementing the vat
-   * @param { Translators } translators
+   * @param {SourceOfBundle} source  The source object implementing the vat
+   * @param {Translators} translators
    * @param {*} dynamicOptions  Options bag governing vat creation
    *
    * @returns {Promise<VatManager>} fires when the vat is ready for messages
@@ -69,8 +69,8 @@ export function makeVatLoader(stuff) {
    * Recreate a static vat from persistent state at kernel startup time.
    *
    * @param {string} vatID  The vatID of the vat to create
-   * @param { SourceOfBundle } source  The source object implementing the vat
-   * @param { Translators } translators
+   * @param {SourceOfBundle} source  The source object implementing the vat
+   * @param {Translators} translators
    * @param {*} staticOptions  Options bag governing vat creation
    *
    * @returns {Promise<VatManager>} A Promise which fires when the
@@ -125,7 +125,7 @@ export function makeVatLoader(stuff) {
    *    used, it must identify a bundle already known to the kernel (via the
    *    `config.bundles` table) which satisfies these constraints.
    *
-   * @param { Translators } translators
+   * @param {Translators} translators
    *
    * @param {object} options  an options bag. These options are currently understood:
    *

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -4,13 +4,13 @@ import { isNat } from '@agoric/nat';
 import { makeVatTranslators } from './vatTranslator.js';
 import { insistVatDeliveryResult } from '../lib/message.js';
 
-/** @param { number } max */
+/** @param {number} max */
 export const makeLRU = max => {
   /** @type { string[] } */
   const items = [];
 
   return harden({
-    /** @param { string } item */
+    /** @param {string} item */
     add: item => {
       const pos = items.indexOf(item);
       // already most recently used
@@ -34,7 +34,7 @@ export const makeLRU = max => {
       return items.length;
     },
 
-    /** @param { string } item */
+    /** @param {string} item */
     remove: item => {
       const pos = items.indexOf(item);
       if (pos >= 0) {
@@ -45,8 +45,8 @@ export const makeLRU = max => {
 };
 
 /**
- * @param { KernelKeeper } kernelKeeper
- * @param { ReturnType<typeof import('./vat-loader/vat-loader.js').makeVatLoader> } vatLoader
+ * @param {KernelKeeper} kernelKeeper
+ * @param {ReturnType<typeof import('./vat-loader/vat-loader.js').makeVatLoader>} vatLoader
  * @param {{
  *   maxVatsOnline?: number,
  * }=} policyOptions
@@ -82,7 +82,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
 
   /** @type {Map<string, VatTranslators> } */
   const xlate = new Map();
-  /** @param { string } vatID */
+  /** @param {string} vatID */
   function provideTranslators(vatID) {
     let translators = xlate.get(vatID);
     if (!translators) {
@@ -97,7 +97,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
   /**
    * @param {string} vatID
    * @param {boolean} recreate
-   * @returns { Promise<VatInfo> }
+   * @returns {Promise<VatInfo>}
    */
   async function ensureVatOnline(vatID, recreate) {
     const info = ephemeral.vats.get(vatID);
@@ -159,7 +159,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
     return ensureVatOnline(vatID, false);
   }
 
-  /** @param { typeof console.log } logStartup */
+  /** @param {typeof console.log} logStartup */
   async function start(logStartup) {
     const recreate = true; // note: PANIC on failure to recreate
 
@@ -181,7 +181,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
   }
 
   /**
-   * @param { string } vatID
+   * @param {string} vatID
    * @returns {{ enablePipelining?: boolean }
    *  | undefined // if the vat is dead or never initialized
    * }
@@ -207,7 +207,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
    * does not modify the kernelDB
    *
    * @param {string} vatID
-   * @returns { Promise<unknown> }
+   * @returns {Promise<unknown>}
    */
   async function evict(vatID) {
     assert(lookup(vatID));
@@ -314,7 +314,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
   /**
    * @param {string} vatID
    * @param {unknown[]} kd
-   * @returns { VatDeliveryObject }
+   * @returns {VatDeliveryObject}
    */
   function kernelDeliveryToVatDelivery(vatID, kd) {
     const translators = provideTranslators(vatID);
@@ -351,7 +351,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
 
   /**
    * @param {string} vatID
-   * @returns { Promise<void> }
+   * @returns {Promise<void>}
    */
   async function vatWasTerminated(vatID) {
     try {

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -18,9 +18,9 @@ export function assertValidVatstoreKey(key) {
  * Return a function that converts KernelDelivery objects into VatDelivery
  * objects
  *
- * @param { string } vatID
- * @param { KernelKeeper } kernelKeeper
- * @returns { (kd: KernelDeliveryObject) => VatDeliveryObject }
+ * @param {string} vatID
+ * @param {KernelKeeper} kernelKeeper
+ * @returns {(kd: KernelDeliveryObject) => VatDeliveryObject}
  */
 function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
   const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
@@ -68,7 +68,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { { state: string, data: SwingSetCapData } } kp
+   * @param {{ state: string, data: SwingSetCapData }} kp
    * @returns { [ isReject: boolean, resolution: SwingSetCapData ]}
    */
   function translatePromiseDescriptor(kp) {
@@ -92,8 +92,8 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { KernelDeliveryOneNotify[] } kResolutions
-   * @returns { VatDeliveryNotify }
+   * @param {KernelDeliveryOneNotify[]} kResolutions
+   * @returns {VatDeliveryNotify}
    */
   function translateNotify(kResolutions) {
     const vResolutions = [];
@@ -151,7 +151,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
   /**
    *
    * @param {Record<string, unknown>} options
-   * @returns { VatDeliveryChangeVatOptions }
+   * @returns {VatDeliveryChangeVatOptions}
    */
   function translateChangeVatOptions(options) {
     /** @type { VatDeliveryChangeVatOptions } */
@@ -165,7 +165,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
   /**
    *
    * @param {SwingSetCapData} kernelVP
-   * @returns { VatDeliveryStartVat }
+   * @returns {VatDeliveryStartVat}
    */
   function translateStartVat(kernelVP) {
     const slots = kernelVP.slots.map(slot => mapKernelSlotToVatSlot(slot));
@@ -191,8 +191,8 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { KernelDeliveryObject } kd
-   * @returns { VatDeliveryObject }
+   * @param {KernelDeliveryObject} kd
+   * @returns {VatDeliveryObject}
    */
   function kernelDeliveryToVatDelivery(kd) {
     switch (kd[0]) {
@@ -253,9 +253,9 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
  * return a function that converts VatSyscall objects into KernelSyscall
  * objects
  *
- * @param { string } vatID
- * @param { KernelKeeper } kernelKeeper
- * @returns { (vsc: VatSyscallObject) => KernelSyscallObject }
+ * @param {string} vatID
+ * @param {KernelKeeper} kernelKeeper
+ * @returns {(vsc: VatSyscallObject) => KernelSyscallObject}
  */
 function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
   const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
@@ -324,9 +324,9 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { boolean } isFailure
-   * @param { SwingSetCapData } info
-   * @returns { KernelSyscallExit }
+   * @param {boolean} isFailure
+   * @param {SwingSetCapData} info
+   * @returns {KernelSyscallExit}
    */
   function translateExit(isFailure, info) {
     insistCapData(info);
@@ -338,8 +338,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { string } key
-   * @returns { KernelSyscallVatstoreGet }
+   * @param {string} key
+   * @returns {KernelSyscallVatstoreGet}
    */
   function translateVatstoreGet(key) {
     assertValidVatstoreKey(key);
@@ -349,9 +349,9 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { string } key
-   * @param { string } value
-   * @returns { KernelSyscallVatstoreSet }
+   * @param {string} key
+   * @param {string} value
+   * @returns {KernelSyscallVatstoreSet}
    */
   function translateVatstoreSet(key, value) {
     assertValidVatstoreKey(key);
@@ -362,10 +362,10 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { string } priorKey
-   * @param { string } lowerBound
-   * @param { string | undefined } upperBound
-   * @returns { KernelSyscallVatstoreGetAfter }
+   * @param {string} priorKey
+   * @param {string} lowerBound
+   * @param {string | undefined} upperBound
+   * @returns {KernelSyscallVatstoreGetAfter}
    */
   function translateVatstoreGetAfter(priorKey, lowerBound, upperBound) {
     if (priorKey !== '') {
@@ -392,8 +392,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { string } key
-   * @returns { KernelSyscallVatstoreDelete }
+   * @param {string} key
+   * @returns {KernelSyscallVatstoreDelete}
    */
   function translateVatstoreDelete(key) {
     assertValidVatstoreKey(key);
@@ -405,8 +405,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { string[] } vrefs
-   * @returns { KernelSyscallDropImports }
+   * @param {string[]} vrefs
+   * @returns {KernelSyscallDropImports}
    */
   function translateDropImports(vrefs) {
     assert(Array.isArray(vrefs), X`dropImports() given non-Array ${vrefs}`);
@@ -428,8 +428,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { string[] } vrefs
-   * @returns { KernelSyscallRetireImports }
+   * @param {string[]} vrefs
+   * @returns {KernelSyscallRetireImports}
    */
   function translateRetireImports(vrefs) {
     assert(Array.isArray(vrefs), X`retireImports() given non-Array ${vrefs}`);
@@ -453,8 +453,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { string[] } vrefs
-   * @returns { KernelSyscallRetireExports }
+   * @param {string[]} vrefs
+   * @returns {KernelSyscallRetireExports}
    */
   function translateRetireExports(vrefs) {
     assert(Array.isArray(vrefs), X`retireExports() given non-Array ${vrefs}`);
@@ -475,8 +475,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { string[] } vrefs
-   * @returns { import('../types-external.js').KernelSyscallAbandonExports }
+   * @param {string[]} vrefs
+   * @returns {import('../types-external.js').KernelSyscallAbandonExports}
    */
   function translateAbandonExports(vrefs) {
     assert(Array.isArray(vrefs), X`abandonExports() given non-Array ${vrefs}`);
@@ -496,10 +496,10 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { string } target
-   * @param { string } method
-   * @param { SwingSetCapData } args
-   * @returns { KernelSyscallInvoke }
+   * @param {string} target
+   * @param {string} method
+   * @param {SwingSetCapData} args
+   * @returns {KernelSyscallInvoke}
    */
   function translateCallNow(target, method, args) {
     insistCapData(args);
@@ -533,8 +533,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
 
   /**
    *
-   * @param { VatOneResolution[] } vresolutions
-   * @returns { KernelSyscallResolve }
+   * @param {VatOneResolution[]} vresolutions
+   * @returns {KernelSyscallResolve}
    */
   function translateResolve(vresolutions) {
     /** @type { KernelOneResolution[] } */
@@ -580,8 +580,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
   //  ['send', ktarget, kmsg]
   /**
    *
-   * @param { VatSyscallObject } vsc
-   * @returns { KernelSyscallObject }
+   * @param {VatSyscallObject} vsc
+   * @returns {KernelSyscallObject}
    */
   function vatSyscallToKernelSyscall(vsc) {
     switch (vsc[0]) {
@@ -662,9 +662,9 @@ function makeTranslateKernelSyscallResultToVatSyscallResult(
   // invoke() can return ['error', problem].
   /**
    *
-   * @param { string } type
-   * @param { KernelSyscallResult } kres
-   * @returns { VatSyscallResult }
+   * @param {string} type
+   * @param {KernelSyscallResult} kres
+   * @returns {VatSyscallResult}
    */
   function kernelSyscallResultToVatSyscallResult(type, kres) {
     const [successFlag, resultData] = kres;

--- a/packages/SwingSet/src/lib/message.js
+++ b/packages/SwingSet/src/lib/message.js
@@ -12,8 +12,9 @@ import { insistCapData } from './capdata.js';
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
  *
- * @returns { asserts message is Message }
+ * @returns {asserts message is Message}
  */
+
 export function insistMessage(message) {
   insistCapData(message.methargs);
   if (message.result) {
@@ -23,13 +24,13 @@ export function insistMessage(message) {
       X`message has non-string non-null .result ${message.result}`,
     );
   }
-  return undefined;
 }
 
 /**
  * @param {unknown} vdo
- * @returns { asserts vdo is VatDeliveryObject }
+ * @returns {asserts vdo is VatDeliveryObject}
  */
+
 export function insistVatDeliveryObject(vdo) {
   assert(Array.isArray(vdo));
   const [type, ...rest] = vdo;
@@ -81,13 +82,13 @@ export function insistVatDeliveryObject(vdo) {
     default:
       assert.fail(`unknown delivery type ${type}`);
   }
-  return undefined;
 }
 
 /**
  * @param {unknown} vdr
- * @returns { asserts vdr is VatDeliveryResult }
+ * @returns {asserts vdr is VatDeliveryResult}
  */
+
 export function insistVatDeliveryResult(vdr) {
   assert(Array.isArray(vdr));
   const [type, problem, _usage] = vdr;
@@ -103,14 +104,14 @@ export function insistVatDeliveryResult(vdr) {
     default:
       assert.fail(`unknown delivery result type ${type}`);
   }
-  return undefined;
 }
 
 /**
  *
  * @param {unknown} vso
- * @returns { asserts vso is VatSyscallObject }
+ * @returns {asserts vso is VatSyscallObject}
  */
+
 export function insistVatSyscallObject(vso) {
   assert(Array.isArray(vso));
   const [type, ...rest] = vso;
@@ -188,13 +189,13 @@ export function insistVatSyscallObject(vso) {
     default:
       assert.fail(`unknown syscall type ${type}`);
   }
-  return undefined;
 }
 
 /**
- * @param { unknown } vsr
- * @returns { asserts vsr is VatSyscallResult }
+ * @param {unknown} vsr
+ * @returns {asserts vsr is VatSyscallResult}
  */
+
 export function insistVatSyscallResult(vsr) {
   assert(Array.isArray(vsr));
   const [type, ...rest] = vsr;
@@ -210,5 +211,4 @@ export function insistVatSyscallResult(vsr) {
     default:
       assert.fail(`unknown syscall result type ${type}`);
   }
-  return undefined;
 }

--- a/packages/SwingSet/src/lib/storageAPI.js
+++ b/packages/SwingSet/src/lib/storageAPI.js
@@ -48,8 +48,8 @@ export function insistEnhancedStorageAPI(kvStore) {
  * order lexicographically by UTF-16 code unit, produce a new iterator that will
  * output the ascending sequence of unique strings from their merged output.
  *
- * @param { Iterator } it1
- * @param { Iterator } it2
+ * @param {Iterator} it1
+ * @param {Iterator} it2
  *
  * @yields any
  */

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -1379,8 +1379,8 @@ function build(
   }
 
   /**
-   * @param { VatDeliveryObject } delivery
-   * @returns { void | Promise<void> }
+   * @param {VatDeliveryObject} delivery
+   * @returns {void | Promise<void>}
    */
   function dispatchToUserspace(delivery) {
     let result;
@@ -1443,7 +1443,7 @@ function build(
   }
 
   /**
-   * @returns { Promise<void> }
+   * @returns {Promise<void>}
    */
   async function stopVat() {
     assert(didStartVat);
@@ -1527,8 +1527,8 @@ function build(
    * terminate the vat). Userspace should not be able to cause the delivery
    * to fail: only a bug in liveslots should trigger a failure.
    *
-   * @param { VatDeliveryObject } delivery
-   * @returns { Promise<void> }
+   * @param {VatDeliveryObject} delivery
+   * @returns {Promise<void>}
    */
   async function dispatch(delivery) {
     // We must short-circuit dispatch to bringOutYourDead here because it has to

--- a/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
@@ -93,7 +93,7 @@ const meterControl = makeMeterControl();
 /**
  * Wrap byte-level protocols with tagged array codec.
  *
- * @param { (cmd: ArrayBuffer) => ArrayBuffer } issueCommand as from xsnap
+ * @param {(cmd: ArrayBuffer) => ArrayBuffer} issueCommand as from xsnap
  * @typedef { [unknown, ...unknown[]] } Tagged tagged array
  */
 function managerPort(issueCommand) {
@@ -132,8 +132,8 @@ function managerPort(issueCommand) {
     /**
      * Wrap an async Tagged handler in the xsnap async reporting idiom.
      *
-     * @param { (item: Tagged) => Promise<Tagged> } f async Tagged handler
-     * @returns { (msg: ArrayBuffer) => Report<ArrayBuffer> } xsnap style handleCommand
+     * @param {(item: Tagged) => Promise<Tagged>} f async Tagged handler
+     * @returns {(msg: ArrayBuffer) => Report<ArrayBuffer>} xsnap style handleCommand
      *
      * @typedef { { result?: T } } Report<T> report T when idle
      * @template T
@@ -174,7 +174,7 @@ function abbreviateReplacer(_, arg) {
 }
 
 /**
- * @param { ReturnType<typeof managerPort> } port
+ * @param {ReturnType<typeof managerPort>} port
  */
 function makeWorker(port) {
   /** @type { ((delivery: VatDeliveryObject) => Promise<VatDeliveryResult>) | null } */
@@ -187,7 +187,7 @@ function makeWorker(port) {
    * @param {boolean} enableDisavow
    * @param {boolean} enableFakeDurable
    * @param {boolean} [gcEveryCrank]
-   * @returns { Promise<Tagged> }
+   * @returns {Promise<Tagged>}
    */
   async function setBundle(
     vatID,

--- a/packages/SwingSet/src/supervisors/supervisor-helper.js
+++ b/packages/SwingSet/src/supervisors/supervisor-helper.js
@@ -18,13 +18,13 @@ import '../types-ambient.js';
  * function with this one, and call it in response to messages from the
  * manager process.
  *
- * @param { VatDispatcherSyncAsync } dispatch
- * @returns { VatDispatcher }
+ * @param {VatDispatcherSyncAsync} dispatch
+ * @returns {VatDispatcher}
  */
 function makeSupervisorDispatch(dispatch) {
   /**
-   * @param { VatDeliveryObject } delivery
-   * @returns { Promise<VatDeliveryResult> }
+   * @param {VatDeliveryObject} delivery
+   * @returns {Promise<VatDeliveryResult>}
    *
    */
   async function dispatchToVat(delivery) {
@@ -56,10 +56,10 @@ export { makeSupervisorDispatch };
  * I should be given a `syscallToManager` function that accepts a
  * VatSyscallObject and (synchronously) returns a VatSyscallResult.
  *
- * @param { VatSyscaller } syscallToManager
- * @param { boolean } workerCanBlock
+ * @param {VatSyscaller} syscallToManager
+ * @param {boolean} workerCanBlock
  * @typedef { unknown } TheSyscallObjectWithMethodsThatLiveslotsWants
- * @returns { TheSyscallObjectWithMethodsThatLiveslotsWants }
+ * @returns {TheSyscallObjectWithMethodsThatLiveslotsWants}
  */
 function makeSupervisorSyscall(syscallToManager, workerCanBlock) {
   function doSyscall(fields) {

--- a/packages/SwingSet/test/test-xsnap-store.js
+++ b/packages/SwingSet/test/test-xsnap-store.js
@@ -13,7 +13,7 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
 const { freeze } = Object;
 
 const ld = (() => {
-  /** @param { string } ref */
+  /** @param {string} ref */
   // WARNING: ambient
   const resolve = async ref => {
     const parsed = await importMetaResolve(ref, import.meta.url);
@@ -22,7 +22,7 @@ const ld = (() => {
   const readFile = fs.promises.readFile;
   return freeze({
     resolve,
-    /**  @param { string } ref */
+    /**  @param {string} ref */
     asset: async ref => readFile(await resolve(ref), 'utf-8'),
   });
 })();

--- a/packages/deploy-script-support/src/endo-pieces-contract.js
+++ b/packages/deploy-script-support/src/endo-pieces-contract.js
@@ -9,7 +9,7 @@ export const start = () => {
   /** @type { Map<string, [string, Uint8Array]>} */
   const hashToEntry = new Map();
 
-  /** @param { string[] } hashes */
+  /** @param {string[]} hashes */
   const preFilter = hashes => {
     assert(Array.isArray(hashes));
     return hashes.filter(hash => {

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -43,8 +43,9 @@ const QuorumRule = /** @type {const} */ ({
 
 /**
  * @param {unknown} issue
- * @returns { asserts issue is SimpleIssue }
+ * @returns {asserts issue is SimpleIssue}
  */
+
 const assertSimpleIssue = issue => {
   assert.typeof(issue, 'object', X`Issue ("${issue}") must be a record`);
   assert(
@@ -55,8 +56,9 @@ const assertSimpleIssue = issue => {
 
 /**
  * @param {unknown} issue
- * @returns { asserts issue is ParamChangeIssue<unknown> }
+ * @returns {asserts issue is ParamChangeIssue<unknown>}
  */
+
 const assertParamChangeIssue = issue => {
   assert(issue, X`argument to assertParamChangeIssue cannot be null`);
   assert.typeof(issue, 'object', X`Issue ("${issue}") must be a record`);
@@ -77,6 +79,7 @@ const assertParamChangeIssue = issue => {
  * @param {unknown} issue
  * @returns {asserts issue is ApiInvocationIssue}
  */
+
 const assertApiInvocation = issue => {
   assert.typeof(issue, 'object', X`Issue ("${issue}") must be a record`);
   assert(
@@ -88,8 +91,9 @@ const assertApiInvocation = issue => {
 /**
  * @param {ElectionType} electionType
  * @param {unknown} issue
- * @returns { asserts issue is Issue }
+ * @returns {asserts issue is Issue}
  */
+
 const assertIssueForType = (electionType, issue) => {
   assert(
     passStyleOf(issue) === 'copyRecord',
@@ -118,7 +122,7 @@ const positionIncluded = (positions, p) => positions.some(e => keyEQ(e, p));
 // QuestionSpec contains the subset of QuestionDetails that can be specified before
 /**
  * @param {unknown} closingRule
- * @returns { asserts closingRule is ClosingRule }
+ * @returns {asserts closingRule is ClosingRule}
  */
 
 function assertClosingRule(closingRule) {

--- a/packages/run-protocol/scripts/init-core.js
+++ b/packages/run-protocol/scripts/init-core.js
@@ -83,7 +83,7 @@ export const committeeProposalBuilder = async ({
 
   const install = wrapInstall ? wrapInstall(install0) : install0;
 
-  /** @param { Record<string, [string, string]> } group */
+  /** @param {Record<string, [string, string]>} group */
   const publishGroup = group =>
     mapValues(group, ([mod, bundle]) =>
       publishRef(install(mod, bundle, { persist: true })),
@@ -122,7 +122,7 @@ export const mainProposalBuilder = async ({
   const install = wrapInstall ? wrapInstall(install0) : install0;
 
   const persist = true;
-  /** @param { Record<string, [string, string]> } group */
+  /** @param {Record<string, [string, string]>} group */
   const publishGroup = group =>
     mapValues(group, ([mod, bundle]) =>
       publishRef(install(mod, bundle, { persist })),
@@ -166,7 +166,7 @@ export const defaultProposalBuilder = async (
     } = {},
   } = options;
 
-  /** @param { Record<string, [string, string]> } group */
+  /** @param {Record<string, [string, string]>} group */
   const publishGroup = group =>
     mapValues(group, ([mod, bundle]) => publishRef(install(mod, bundle)));
 

--- a/packages/run-protocol/src/contractSupport.js
+++ b/packages/run-protocol/src/contractSupport.js
@@ -30,7 +30,7 @@ export const addSubtract = (base, gain, loss) =>
  * @param {string[]} keys usually 'Collateral' and 'RUN'
  */
 export const assertOnlyKeys = (proposal, keys) => {
-  /** @param { AmountKeywordRecord } clause */
+  /** @param {AmountKeywordRecord} clause */
   const onlyKeys = clause =>
     Object.getOwnPropertyNames(clause).every(c => keys.includes(c));
   assert(

--- a/packages/run-protocol/src/proposals/addAssetToVault.js
+++ b/packages/run-protocol/src/proposals/addAssetToVault.js
@@ -18,7 +18,7 @@ export * from './startPSM.js';
  */
 
 /**
- * @param { EconomyBootstrapPowers } powers
+ * @param {EconomyBootstrapPowers} powers
  * @param {object} config
  * @param {object} config.options
  * @param {InterchainAssetOptions} config.options.interchainAssetOptions
@@ -81,7 +81,7 @@ const addPool = async (
 };
 
 /**
- * @param { EconomyBootstrapPowers } powers
+ * @param {EconomyBootstrapPowers} powers
  * @param {object} config
  * @param {object} config.options
  * @param {InterchainAssetOptions} config.options.interchainAssetOptions

--- a/packages/run-protocol/src/proposals/committee-proposal.js
+++ b/packages/run-protocol/src/proposals/committee-proposal.js
@@ -9,7 +9,7 @@ const { values } = Object;
 const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
 
 /**
- * @param { import('./econ-behaviors').EconomyBootstrapPowers } powers
+ * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
  * @param {{ options: { voterAddresses: Record<string, string> }}} param1
  */
 export const inviteCommitteeMembers = async (

--- a/packages/run-protocol/src/proposals/demoIssuers.js
+++ b/packages/run-protocol/src/proposals/demoIssuers.js
@@ -46,7 +46,7 @@ const BASIS = 10_000n;
 const pad0 = (frac, exp) =>
   `${`${'0'.repeat(exp)}${frac}`.slice(-exp)}`.replace(/0+$/, '');
 
-/** @param { bigint } whole */
+/** @param {bigint} whole */
 const separators = whole => {
   const sep = '_';
   // ack: https://stackoverflow.com/a/45950572/7963, https://regex101.com/
@@ -168,7 +168,7 @@ export const AMMDemoState = {
   },
 };
 
-/** @param { number } f */
+/** @param {number} f */
 const run2places = f =>
   BigInt(Math.round(f * 100)) *
   10n ** BigInt(DecimalPlaces[CENTRAL_ISSUER_NAME] - 2);
@@ -180,7 +180,7 @@ const run2places = f =>
  *   feeMintAccess: ERef<FeeMintAccess>,
  *   zoe: ERef<ZoeService>,
  * }} powers
- * @returns { Promise<Payment> }
+ * @returns {Promise<Payment>}
  */
 const mintRunPayment = async (
   value,
@@ -352,7 +352,7 @@ export const ammPoolRunDeposits = issuers => {
       assert(record.config);
       assert(record.trades);
 
-      /** @param { bigint } n */
+      /** @param {bigint} n */
       const inCollateral = n => n * 10n ** BigInt(DecimalPlaces[issuerName]);
 
       // The initial trade represents the fair value of RUN for collateral.
@@ -415,7 +415,7 @@ export const splitAllCentralPayments = async (
  * @param {{ issuer: ERef<Issuer>, brand: Brand }} central
  */
 export const poolRates = (issuerName, record, kits, central) => {
-  /** @param { bigint } n */
+  /** @param {bigint} n */
   const inCollateral = n => n * 10n ** BigInt(DecimalPlaces[issuerName]);
   const config = record.config;
   assert(config);
@@ -605,7 +605,7 @@ export const fundAMM = async ({
       console.debug(`Creating ${issuerName}-${CENTRAL_ISSUER_NAME}`);
       const issuer = kits[issuerName].issuer;
       const { trades } = record;
-      /** @param { bigint } n */
+      /** @param {bigint} n */
       const inCollateral = n => n * 10n ** BigInt(DecimalPlaces[issuerName]);
       const tradesGivenCentral = trades.map(
         ({ central: num, collateral: unit }) =>

--- a/packages/run-protocol/src/proposals/econ-behaviors.js
+++ b/packages/run-protocol/src/proposals/econ-behaviors.js
@@ -113,7 +113,7 @@ export const startEconomicCommittee = async (
 harden(startEconomicCommittee);
 
 /**
- * @param { EconomyBootstrapPowers } powers
+ * @param {EconomyBootstrapPowers} powers
  * @param {{
  *   interchainPoolOptions?: { minimumCentral?: bigint }
  * }} [options]
@@ -169,7 +169,7 @@ harden(startInterchainPool);
 const AMM_STORAGE_PATH = 'amm'; // TODO: share with agoricNames?
 
 /**
- * @param { EconomyBootstrapPowers } powers
+ * @param {EconomyBootstrapPowers} powers
  * @param {{ options?: { minInitialPoolLiquidity?: bigint }}} opts
  */
 export const setupAmm = async (
@@ -261,7 +261,7 @@ export const setupAmm = async (
   return ammInstallation;
 };
 
-/** @param { EconomyBootstrapPowers } powers */
+/** @param {EconomyBootstrapPowers} powers */
 export const setupReserve = async ({
   consume: {
     ammCreatorFacet,
@@ -357,9 +357,9 @@ export const setupReserve = async ({
 };
 
 /**
- * @param { EconomyBootstrapPowers } powers
+ * @param {EconomyBootstrapPowers} powers
  * @param {object} config
- * @param { LoanTiming } [config.loanParams]
+ * @param {LoanTiming} [config.loanParams]
  * @param {bigint} minInitialDebt
  */
 export const startVaultFactory = async (
@@ -503,7 +503,7 @@ export const startVaultFactory = async (
  * Grant access to the VaultFactory creatorFacet
  * to up to one user based on address.
  *
- * @param { EconomyBootstrapPowers } powers
+ * @param {EconomyBootstrapPowers} powers
  * @param {object} [root0]
  * @param {object} [root0.options]
  * @param {string} [root0.options.vaultFactoryControllerAddress]
@@ -529,7 +529,7 @@ export const grantVaultFactoryControl = async (
 };
 harden(grantVaultFactoryControl);
 
-/** @param { BootstrapPowers } powers */
+/** @param {BootstrapPowers} powers */
 export const configureVaultFactoryUI = async ({
   consume: { board, zoe },
   issuer: {

--- a/packages/run-protocol/src/proposals/sim-behaviors.js
+++ b/packages/run-protocol/src/proposals/sim-behaviors.js
@@ -4,7 +4,7 @@ import { addRemote } from '@agoric/vats/src/core/utils.js';
 
 export { connectFaucet, fundAMM } from './demoIssuers.js';
 
-/** @param { BootstrapPowers } powers */
+/** @param {BootstrapPowers} powers */
 export const installSimEgress = async ({
   vatParameters: { argv },
   vats: { vattp, comms },

--- a/packages/run-protocol/src/runStake/attestation.js
+++ b/packages/run-protocol/src/runStake/attestation.js
@@ -141,8 +141,8 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
   };
 
   /**
-   * @param { Address } address
-   * @param { Amount<'nat'> } lienDelta
+   * @param {Address} address
+   * @param {Amount<'nat'>} lienDelta
    */
   const mintAttestation = async (address, lienDelta) => {
     // This account state check is primarily to provide useful diagnostics.
@@ -208,7 +208,7 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
     getAccountState,
     wrapLienedAmount,
     /**
-     * @param { Amount<'copyBag'> } attAmt
+     * @param {Amount<'copyBag'>} attAmt
      * @throws if `attAmt` payload length is not 1
      */
     unwrapLienedAmount: attAmt => unwrapLienedAmount(attAmt).lienedAmount,
@@ -259,7 +259,7 @@ export const makeAttestationFacets = async (zcf, stakeBrand, lienBridge) => {
        * address. Only the owner can authorize creation of attestations and
        * the resulting liens on their underlying tokens.
        *
-       * @param { Address } address
+       * @param {Address} address
        */
       provideAttestationTool: address => {
         assert.typeof(address, 'string');

--- a/packages/run-protocol/src/runStake/attestationTool.js
+++ b/packages/run-protocol/src/runStake/attestationTool.js
@@ -25,7 +25,7 @@ const initState = (address, lienMint, stakeBrand, zcf) => {
 const behavior = {
   /**
    * @param {MethodContext} context
-   * @param { Amount<'nat'> } lienedDelta
+   * @param {Amount<'nat'>} lienedDelta
    */
   makeAttestation: ({ state }, lienedDelta) =>
     state.lienMint.mintAttestation(state.address, lienedDelta),

--- a/packages/run-protocol/test/attestation/test-attestation.js
+++ b/packages/run-protocol/test/attestation/test-attestation.js
@@ -133,7 +133,7 @@ test('attestations can be combined and split', async t => {
     AmountMath.add(stake50, stake25),
   );
 
-  /** @param { Payment } att */
+  /** @param {Payment} att */
   const returnAttestation = async att => {
     const invitation = E(publicFacet).makeReturnAttInvitation();
     const attestationAmount = await E(issuer).getAmountOf(att);

--- a/packages/run-protocol/test/runStake/attestationFaker.js
+++ b/packages/run-protocol/test/runStake/attestationFaker.js
@@ -2,7 +2,7 @@ import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { makeCopyBag } from '@agoric/store';
 import { Far } from '@endo/marshal';
 
-/** @param { ContractFacet } zcf */
+/** @param {ContractFacet} zcf */
 export const start = zcf => {
   const a = makeIssuerKit('Bogus', AssetKind.COPY_BAG);
   zcf.saveIssuer(a.issuer, 'Attestation');
@@ -10,8 +10,8 @@ export const start = zcf => {
   return {
     publicFacet: Far('pub', {
       /**
-       * @param { string } address
-       * @param { Amount<bigint> } amountLiened
+       * @param {string} address
+       * @param {Amount<bigint>} amountLiened
        * @returns {[Amount, Payment]}
        */
       fakeAttestation: (address, amountLiened) => {

--- a/packages/run-protocol/test/runStake/test-runStake.js
+++ b/packages/run-protocol/test/runStake/test-runStake.js
@@ -177,14 +177,14 @@ const mockChain = genesisData => {
     },
     /** @param {Brand<'nat'>} stakingBrand */
     makeLienBridge: stakingBrand => {
-      /** @param { bigint } v */
+      /** @param {bigint} v */
       const ubld = v => AmountMath.make(stakingBrand, v);
 
       /** @type {StakingAuthority} */
       const authority = Far('stakeReporter', {
         /**
-         * @param { string } address
-         * @param { Brand } brand
+         * @param {string} address
+         * @param {Brand} brand
          */
         getAccountState: (address, brand) => {
           assert(brand === stakingBrand, X`unexpected brand: ${brand}`);
@@ -424,9 +424,9 @@ test('extra offer keywords are rejected', async t => {
 });
 
 /**
- * @param { StartFaker['publicFacet'] } faker
- * @param { Brand } bldBrand
- * @returns { Promise<[Amount, Payment]> }
+ * @param {StartFaker['publicFacet']} faker
+ * @param {Brand} bldBrand
+ * @returns {Promise<[Amount, Payment]>}
  *
  * @param { (faker: ERef<StartFaker['publicFacet']>, bldBrand: Brand)
  *            => Promise<[Amount, Payment]> } [mockAttestation]
@@ -515,7 +515,7 @@ const makeWorld = async t => {
     brands: { [KW.Attestation]: attBrand },
   } = await E(zoe).getTerms(await runStake.instance);
 
-  /** @param { Payment } att */
+  /** @param {Payment} att */
   const returnAttestation = async att => {
     const invitation = E(runStake.publicFacet).makeReturnAttInvitation();
     const attestationAmount = await E(attIssuer).getAmountOf(att);

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -141,7 +141,7 @@ export const makeVoterTool = async (
  *   feeMintAccess: ERef<FeeMintAccess>,
  *   zoe: ERef<ZoeService>,
  * }} powers
- * @returns { Promise<Payment> }
+ * @returns {Promise<Payment>}
  */
 export const mintRunPayment = async (
   value,

--- a/packages/run-protocol/test/test-demoAMM.js
+++ b/packages/run-protocol/test/test-demoAMM.js
@@ -14,7 +14,7 @@ import {
   splitAllCentralPayments,
 } from '../src/proposals/demoIssuers.js';
 
-/** @param { bigint } n */
+/** @param {bigint} n */
 const showRUN = n => `${decimal(n, 6)} RUN`;
 
 test('urun -> RUN formatting test utility', t => {

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -84,9 +84,9 @@ export function makeSnapStore(
   /** @type {(opts: unknown) => Promise<string>} */
   const ptmpName = promisify(tmpName);
   /**
-   * @param { (name: string) => Promise<T> } thunk
-   * @param { string= } prefix
-   * @returns { Promise<T> }
+   * @param {(name: string) => Promise<T>} thunk
+   * @param {string=} prefix
+   * @returns {Promise<T>}
    * @template T
    */
   async function withTempName(thunk, prefix = 'tmp') {
@@ -109,8 +109,8 @@ export function makeSnapStore(
 
   /**
    * @param {string} dest basename, relative to root
-   * @param { (name: string) => Promise<T> } thunk
-   * @returns { Promise<T> }
+   * @param {(name: string) => Promise<T>} thunk
+   * @returns {Promise<T>}
    * @template T
    */
   async function atomicWrite(dest, thunk) {
@@ -173,7 +173,7 @@ export function makeSnapStore(
     return hash.digest('hex');
   }
 
-  /** @param { unknown } hash */
+  /** @param {unknown} hash */
   function hashPath(hash) {
     assert.typeof(hash, 'string');
     assert(!hash.includes('/'));
@@ -185,7 +185,7 @@ export function makeSnapStore(
 
   /**
    * @param {(fn: string) => Promise<void>} saveRaw
-   * @returns { Promise<string> } sha256 hash of (uncompressed) snapshot
+   * @returns {Promise<string>} sha256 hash of (uncompressed) snapshot
    */
   async function save(saveRaw) {
     return withTempName(async snapFile => {

--- a/packages/swing-store/src/sqlStreamStore.js
+++ b/packages/swing-store/src/sqlStreamStore.js
@@ -13,25 +13,25 @@ function* empty() {
 }
 
 /**
- * @param { unknown } streamName
- * @returns { asserts streamName is string }
+ * @param {unknown} streamName
+ * @returns {asserts streamName is string}
  */
+
 function insistStreamName(streamName) {
   assert.typeof(streamName, 'string');
   assert(streamName.match(/^[-\w]+$/), X`invalid stream name ${q(streamName)}`);
-  return undefined;
 }
 
 /**
  * @param {unknown} position
- * @returns { asserts position is StreamPosition }
+ * @returns {asserts position is StreamPosition}
  */
+
 function insistStreamPosition(position) {
   assert.typeof(position, 'object');
   assert(position);
   assert.typeof(position.itemCount, 'number');
   assert(position.itemCount >= 0);
-  return undefined;
 }
 
 /**
@@ -133,7 +133,7 @@ export function sqlStreamStore(dbDir, io) {
     return { itemCount: position.itemCount + 1 };
   };
 
-  /** @param { string } streamName */
+  /** @param {string} streamName */
   const closeStream = streamName => {
     insistStreamName(streamName);
     streamStatus.delete(streamName);

--- a/packages/vats/src/authorityViz.js
+++ b/packages/vats/src/authorityViz.js
@@ -21,7 +21,7 @@ const styles = {
 };
 
 /**
- * @param { Set<GraphNode> } nodes
+ * @param {Set<GraphNode>} nodes
  * @param {Map<string, Set<{ id: string, style?: string }>>} neighbors
  * @yields { string }
  * @typedef {{
@@ -169,9 +169,9 @@ const manifest2graph = manifest => {
 };
 
 /**
- * @param { string[] } args
+ * @param {string[]} args
  * @param {object} io
- * @param { typeof import('process').stdout } io.stdout
+ * @param {typeof import('process').stdout} io.stdout
  */
 const main = async (args, { stdout }) => {
   const [...opts] = args;

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -49,7 +49,7 @@ export const bridgeCoreEval = async allPowers => {
     Base64: globalThis.Base64, // Present only on XSnap
     URL: globalThis.URL, // Absent only on XSnap
   };
-  /** @param { Installation } installation */
+  /** @param {Installation} installation */
   const evaluateInstallation = async installation => {
     const bundle = await E(installation).getBundle();
     const imported = await importBundle(bundle, { endowments });

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -267,7 +267,7 @@ harden(extractPowers);
  * @param {object} opts
  * @param {unknown} opts.allPowers
  * @param {Record<string, unknown>} opts.behaviors
- * @param { Record<string, Record<string, unknown>> } opts.manifest
+ * @param {Record<string, Record<string, unknown>>} opts.manifest
  * @param { (name: string, permit: Record<string, unknown>) => unknown} opts.makeConfig
  */
 export const runModuleBehaviors = ({

--- a/packages/vats/src/vat-mints.js
+++ b/packages/vats/src/vat-mints.js
@@ -17,7 +17,7 @@ export function buildRootObject(_vatPowers) {
       const { mint } = mintsAndBrands.get(issuerName);
       return mint.getIssuer();
     },
-    /** @param { string[] } issuerNames */
+    /** @param {string[]} issuerNames */
     getIssuers: issuerNames => issuerNames.map(api.getIssuer),
 
     /**
@@ -25,10 +25,10 @@ export function buildRootObject(_vatPowers) {
      * a very powerful authority that is usually closely held.
      * But this mint is for demo / faucet purposes.
      *
-     * @param { string } name
+     * @param {string} name
      */
     getMint: name => mintsAndBrands.get(name).mint,
-    /** @param { string[] } issuerNames */
+    /** @param {string[]} issuerNames */
     getMints: issuerNames => issuerNames.map(api.getMint),
     /**
      * @param {*} issuerNameSingular For example, 'moola', or 'simolean'

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -81,7 +81,7 @@ test('connectFaucet produces payments', async t => {
     ),
   );
 
-  /** @param { BootstrapSpace } powers */
+  /** @param {BootstrapSpace} powers */
   const stubProps = async ({ consume: { client } }) => {
     const stub = {
       agoricNames: true,

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -560,7 +560,7 @@ export function makeWallet({
   }
 
   /**
-   * @param { () => ( Promise | undefined ) } get - The function whose return value
+   * @param {() => ( Promise | undefined )} get - The function whose return value
    * to memoize.
    */
   const makeMemoizedGetter = get => {

--- a/packages/xsnap/api.js
+++ b/packages/xsnap/api.js
@@ -30,7 +30,7 @@ export const ErrorMessage = {
 
 export class ErrorSignal extends Error {
   /**
-   * @param { string } signal
+   * @param {string} signal
    * @param {...string | undefined} params
    */
   constructor(signal, ...params) {
@@ -42,7 +42,7 @@ export class ErrorSignal extends Error {
 
 export class ErrorCode extends Error {
   /**
-   * @param { number } code
+   * @param {number} code
    * @param {...string | undefined} params
    */
   constructor(code, ...params) {

--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -138,7 +138,7 @@ function createHarness(send) {
     },
     /**
      * @param {string} name
-     * @returns { Promise<void> }
+     * @returns {Promise<void>}
      */
     async run(name) {
       for await (const hook of beforeHooks) {

--- a/packages/xsnap/src/avaHandler.js
+++ b/packages/xsnap/src/avaHandler.js
@@ -18,7 +18,7 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 /**
- * @param { { testNames: string[] } |
+ * @param {{ testNames: string[]} |
  *          { bundleSource: [string, ...unknown[]] } |
  *          TapMessage | Summary } item
  * @typedef {import('./avaXS').Summary} Summary
@@ -29,7 +29,7 @@ function send(item) {
 }
 
 /**
- * @param { string } startFilename
+ * @param {string} startFilename
  * @param {...unknown} args
  */
 const bundleSource = async (startFilename, ...args) => {

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -76,8 +76,8 @@ function isMatch(specimen, pattern) {
  *   total: number,
  * }} Summary
  *
- * @param { string } filename
- * @param { string[] } preamble scripts to run in XS start compartment
+ * @param {string} filename
+ * @param {string[]} preamble scripts to run in XS start compartment
  * @param {{ verbose?: boolean, titleMatch?: string }} options
  * @param {{
  *   spawnXSnap: (opts: object) => XSnap,
@@ -210,7 +210,7 @@ async function runTestScript(
 /**
  * Get ava / ava-xs config from package.json
  *
- * @param { string[] } args
+ * @param {string[]} args
  * @param {object} options
  * @param {string} [options.packageFilename]
  * @param {{
@@ -229,8 +229,8 @@ async function runTestScript(
  */
 async function avaConfig(args, options, { glob, readFile }) {
   /**
-   * @param { string } pattern
-   * @returns { Promise<string[]> }
+   * @param {string} pattern
+   * @returns {Promise<string[]>}
    */
   const globFiles = pattern =>
     new Promise((res, rej) =>
@@ -339,7 +339,7 @@ export async function main(
    * SES objects to `import(...)`
    * avaAssert and avaHandler only use import() in type comments
    *
-   * @param { string } src
+   * @param {string} src
    */
   const hideImport = src => src.replace(/import\(/g, '');
 

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -7,7 +7,7 @@ import osTop from 'os';
 
 const { freeze } = Object;
 
-/** @param { string } path */
+/** @param {string} path */
 const asset = path => new URL(path, import.meta.url).pathname;
 
 const ModdableSDK = {
@@ -30,7 +30,7 @@ const ModdableSDK = {
  * }} io
  */
 function makeCLI(command, { spawn }) {
-  /** @param { import('child_process').ChildProcess } child */
+  /** @param {import('child_process').ChildProcess} child */
   const wait = child =>
     new Promise((resolve, reject) => {
       child.on('close', () => {
@@ -85,7 +85,7 @@ function makeCLI(command, { spawn }) {
  * @param {{ git: ReturnType<typeof makeCLI> }} io
  */
 const makeSubmodule = (path, repoUrl, { git }) => {
-  /** @param { string } text */
+  /** @param {string} text */
   const parseStatus = text =>
     text
       .split('\n')
@@ -110,13 +110,13 @@ const makeSubmodule = (path, repoUrl, { git }) => {
   return freeze({
     path,
     clone: async () => git.run(['clone', repoUrl, path]),
-    /** @param { string } commitHash */
+    /** @param {string} commitHash */
     checkout: async commitHash =>
       git.run(['checkout', commitHash], { cwd: path }),
     init: async () => git.run(['submodule', 'update', '--init', '--checkout']),
     status: async () =>
       git.pipe(['submodule', 'status', path]).then(parseStatus),
-    /** @param { string } leaf */
+    /** @param {string} leaf */
     config: async leaf => {
       // git rev-parse --show-toplevel
       const top = await git
@@ -140,7 +140,7 @@ const makeSubmodule = (path, repoUrl, { git }) => {
 };
 
 /**
- * @param { string[] } args
+ * @param {string[]} args
  * @param {{
  *   env: Record<string, string | undefined>,
  *   stdout: typeof process.stdout,

--- a/packages/xsnap/src/defer.js
+++ b/packages/xsnap/src/defer.js
@@ -4,6 +4,7 @@
  * @param {boolean} _flag
  * @returns {asserts _flag}
  */
+
 function assert(_flag) {}
 
 /**

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -20,7 +20,7 @@ const { freeze } = Object;
 
 const encoder = new TextEncoder();
 
-/** @param { number } n */
+/** @param {number} n */
 const pad5 = n => `${n}`.padStart(5, '0');
 
 /**
@@ -32,13 +32,13 @@ function makeSyncStorage(path, { writeFileSync }) {
   return freeze({
     /** @param {string} fn */
     file: fn => {
-      /** @param { Uint8Array } data */
+      /** @param {Uint8Array} data */
       const put = data =>
         writeFileSync(new URL(fn, base).pathname, data, { flag: 'wx' });
 
       return freeze({
         put,
-        /** @param { string } txt */
+        /** @param {string} txt */
         putText: txt => put(encoder.encode(txt)),
       });
     },
@@ -70,11 +70,11 @@ function makeSyncAccess(path, { readdirSync, readFileSync }) {
  * Start an xsnap subprocess controller that records data
  * flowing to it for replay.
  *
- * @param { XSnapOptions } options used
+ * @param {XSnapOptions} options used
  *        to create the underlying xsnap subprocess. Note that
  *        options.handleCommand is wrapped in order to capture
  *        data sent to the process.
- * @param { string } folderPath where to store files of the form
+ * @param {string} folderPath where to store files of the form
  *        00000-options.json
  *        00001-evaluate.dat
  *        00002-issueCommand.dat
@@ -93,8 +93,8 @@ export function recordXSnap(options, folderPath, { writeFileSync }) {
   let ix = 0;
 
   /**
-   * @param { string } kind
-   * @param { string= } ext
+   * @param {string} kind
+   * @param {string=} ext
    */
   const nextFile = (kind, ext = 'dat') => {
     const fn = `${pad5(ix)}-${kind}.${ext}`;
@@ -140,7 +140,7 @@ export function recordXSnap(options, folderPath, { writeFileSync }) {
       nextFile('isReady');
       return it.isReady();
     },
-    /** @param { Uint8Array } msg */
+    /** @param {Uint8Array} msg */
     issueCommand: async msg => {
       nextFile('issueCommand').put(msg);
       return it.issueCommand(msg);
@@ -172,7 +172,7 @@ export function recordXSnap(options, folderPath, { writeFileSync }) {
  * Replay an xsnap subprocess from one or more folders of steps.
  *
  * @param {XSnapOptions} opts
- * @param { string[] } folders
+ * @param {string[]} folders
  * @param {{
  *   readdirSync: typeof import('fs').readdirSync,
  *   readFileSync: typeof import('fs').readFileSync,
@@ -190,7 +190,7 @@ export async function replayXSnap(
     return r;
   }
 
-  /** @param { string } folder */
+  /** @param {string} folder */
   function start(folder) {
     const rd = makeSyncAccess(folder, { readdirSync, readFileSync });
     const [optionsFn] = rd.readdir();
@@ -205,8 +205,8 @@ export async function replayXSnap(
   const it = start(folders[0]);
 
   /**
-   * @param { ReturnType<typeof makeSyncAccess> } rd
-   * @param { string[] } steps
+   * @param {ReturnType<typeof makeSyncAccess>} rd
+   * @param {string[]} steps
    */
   async function runSteps(rd, steps) {
     const folder = rd.path;

--- a/packages/xsnap/test/message-tools.js
+++ b/packages/xsnap/test/message-tools.js
@@ -18,11 +18,11 @@ export const encode = (encoder => encoder.encode.bind(encoder))(
  * @param {typeof import('fs').promises.readFile=} readFile
  */
 export function loader(url, readFile = undefined) {
-  /** @param { string } ref */
+  /** @param {string} ref */
   const resolve = ref => new URL(ref, url).pathname;
   return freeze({
     resolve,
-    /**  @param { string } ref */
+    /**  @param {string} ref */
     // @ts-expect-error possibly undefined
     asset: async ref => readFile(resolve(ref), 'utf-8'),
   });
@@ -33,12 +33,12 @@ export function loader(url, readFile = undefined) {
  *   spawn: typeof import('child_process').spawn,
  *   os: string,
  * }} io
- * @returns { import('../src/xsnap.js').XSnapOptions & { messages: string[] }}
+ * @returns {import('../src/xsnap.js').XSnapOptions & { messages: string[]}}
  */
 export function options({ spawn, os }) {
   const messages = [];
 
-  /** @param { Uint8Array } message */
+  /** @param {Uint8Array} message */
   async function handleCommand(message) {
     messages.push(decode(message));
     return new Uint8Array();

--- a/packages/xsnap/test/test-err-stack.js
+++ b/packages/xsnap/test/test-err-stack.js
@@ -43,7 +43,7 @@ async function makeWorker() {
   `);
 
   return {
-    /** @param { string } src */
+    /** @param {string} src */
     async run(src) {
       const { reply } = await vat.issueStringCommand(src);
       return JSON.parse(reply);

--- a/packages/xsnap/test/test-inspect.js
+++ b/packages/xsnap/test/test-inspect.js
@@ -95,7 +95,7 @@ async function makeWorker() {
   await vat.evaluate(boot);
 
   return {
-    /** @param { string } src */
+    /** @param {string} src */
     run: async src => {
       const { reply } = await vat.issueStringCommand(src);
       return JSON.parse(reply);

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -21,8 +21,8 @@ const fakeBundleCap = () => makeHandle('BundleCap');
 export const zcfBundleCap = fakeBundleCap();
 
 /**
- * @param { (...args) => unknown } [testContextSetter]
- * @param { (x: unknown) => unknown } [makeRemote]
+ * @param {(...args) => unknown} [testContextSetter]
+ * @param {(x: unknown) => unknown} [makeRemote]
  */
 function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // FakeVatPowers isn't intended to support testing of vat termination, it is


### PR DESCRIPTION
For some reason, when a newline is placed between a function jsdoc-type declaration and the function itself, ts type checking makes fewer bad rejections while otherwise seeming to stay as accurate. Discovered by accident. I have no idea why.

Also removing extraneous spaces within the outer curlies of jsdoc type decls, as our style is generally to omit them. By omitting them consistently, it is easier to find things with trivial greps.

See https://github.com/endojs/endo/pull/1218

An example is the `insistManagerType` function, which before the PR can be found at
https://github.com/Agoric/agoric-sdk/blob/f677509537bcfd3c7a1a2a88e7c865db1fdb60d5/packages/SwingSet/src/kernel/state/kernelKeeper.js#L300-L316

In that state, it generated no warnings. But if the unnecessary 
```js
return undefined;
```
on line 315 is removed, then we get
```
$ yarn lint
yarn run v1.22.17
$ yarn lint:types&&yarn lint:eslint
$ tsc --maxNodeModuleJsDepth 3 -p jsconfig.json
$ eslint .

.../SwingSet/src/kernel/state/kernelKeeper.js
  300:3  warning  JSDoc @returns declaration present but return expression not available in function  jsdoc/require-returns-check

✖ 1 problem (0 errors, 1 warning)
```
However, bizarrely, this PR by inserting a newline after line 304 causes `yarn lint` to pass with no warnings.
