### PR TITLE
fix(xsnap): upgrade to latest xsnap, now with timestamps, and update METER_TYPE

### DIFF
--- a/packages/xsnap/api.js
+++ b/packages/xsnap/api.js
@@ -3,7 +3,7 @@
 /** The version identifier for our meter type.
  * TODO Bump this whenever there's a change to metering semantics.
  */
-export const METER_TYPE = 'xs-meter-13';
+export const METER_TYPE = 'xs-meter-14';
 
 export const ExitCode = {
   E_UNKNOWN_ERROR: -1,

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -152,7 +152,7 @@ export function xsnap(options) {
    * @template T
    * @typedef {object} RunResult
    * @property {T} reply
-   * @property {{ meterType: string, allocate: number|null, compute: number|null }} meterUsage
+   * @property {{ meterType: string, allocate: number|null, compute: number|null, timestamps: number[]|null }} meterUsage
    */
 
   /**
@@ -172,7 +172,7 @@ export function xsnap(options) {
         xsnapProcess.kill();
         throw new Error('xsnap protocol error: received empty message');
       } else if (message[0] === OK) {
-        let meterInfo = { compute: null, allocate: null };
+        let meterInfo = { compute: null, allocate: null, timestamps: [] };
         const meterSeparator = message.indexOf(OK_SEPARATOR, 1);
         if (meterSeparator >= 0) {
           // The message is `.meterdata\1reply`.

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -62,7 +62,7 @@ test('meter details', async t => {
     },
     'evaluate returns meter details',
   );
-  t.is(meterType, 'xs-meter-13');
+  t.is(meterType, 'xs-meter-14');
 });
 
 test('isReady does not compute / allocate', async t => {


### PR DESCRIPTION
fix(xsnap): upgrade to latest xsnap, now with timestamps

This moves to the version of `xsnap-worker.c` which includes
receipt/transmit timestamps in the metering results.

Tests are updated to expect 'timestamps' in xsnap metering results,
and to assert that they correctly interleave with the times of
upstream/downstream commands as seen by the parent process.

refs #5152
