### PR TITLE
fix(swingset): use gettimeofday() in the slogfile, not CLOCK_MONOTONIC

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -46,6 +46,7 @@
     "anylogger": "^0.21.0",
     "import-meta-resolve": "^1.1.1",
     "lmdb": "^2.4.5",
+    "microtime": "^3.1.0",
     "semver": "^6.3.0"
   },
   "peerDependencies": {

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -10,6 +10,7 @@ import { spawn as ambientSpawn } from 'child_process';
 import { type as osType } from 'os';
 import { Worker } from 'worker_threads';
 import anylogger from 'anylogger';
+import microtime from 'microtime';
 
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@endo/import-bundle';
@@ -205,12 +206,13 @@ export async function makeSwingsetController(
       return;
     }
 
-    // Create an object with the property order that loadgen expects.
-    const timedObj = { time: undefined, type: undefined, ...obj };
+    // microtime gives POSIX gettimeofday() with microsecond resolution
+    const time = microtime.nowDouble();
+    // this is CLOCK_MONOTONIC, seconds since process start
+    const monotime = performance.now() / 1000;
 
-    // Update the timedObj timestamp.
-    const timeMS = performance.timeOrigin + performance.now();
-    timedObj.time = timeMS / 1000;
+    // rearrange the fields a bit to make it more legible to humans
+    const timedObj = { type: undefined, ...obj, time, monotime };
 
     // Serialise just once.
     const jsonObj = JSON.stringify(timedObj, (_, arg) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12086,6 +12086,14 @@ micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
+microtime@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/microtime/-/microtime-3.1.0.tgz#599a71250e3116c59f0fe5271dae4cc44321869c"
+  integrity sha512-GcjhfC2y/DF2znac8IRwri7+YUIy34QRHz/iZK3bHrh74qrNNOpAJQwiOMnIG+v1J0K4eiqd+RiGzN3F1eofTQ==
+  dependencies:
+    node-addon-api "^5.0.0"
+    node-gyp-build "^4.4.0"
+
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -12580,6 +12588,11 @@ node-addon-api@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
   integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
+node-addon-api@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
+  integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
+
 node-environment-flags@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.5.tgz#fa930275f5bf5dae188d6192b24b4c8bbac3d76a"
@@ -12618,6 +12631,11 @@ node-gyp-build-optional-packages@5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz#92a89d400352c44ad3975010368072b41ad66c17"
   integrity sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==
+
+node-gyp-build@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.4.0.tgz#42e99687ce87ddeaf3a10b99dc06abc11021f3f4"
+  integrity sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==
 
 node-gyp@8.1.0:
   version "8.1.0"


### PR DESCRIPTION
fix(swingset): use gettimeofday() in the slogfile, not CLOCK_MONOTONIC

Unix provides multiple time APIs. `gettimeofday()` reports
seconds-since-epoch with microsecond resolution, and can jump around,
speed up, or even go backwards if/when someone changes the clock on
the host computer. `clock_gettime(CLOCK_MONOTONIC)` never goes
backwards, has nanosecond resolution, and in practice reports
seconds-since-last-reboot (of the host computer). `CLOCK_MONOTONIC` is
implemented (at least on linux) by initializing an offset (to the
current time) at boot, and reporting `gettimeofday() - offset`. If
someone calls `settimeofday()`, the kernel measures the delta, and
subtracts it from the offset, so the `CLOCK_MONOTONIC` value does
change even though the `gettimeofday()` does. However both
`gettimeofday()` and `CLOCK_MONOTONIC` will reflect the gentler
frequency adjustments that NTP makes (through `adjtime()`) to keep the
clock in sync without timequakes.

Previously, our slogfile's `.time` property recorded
`performance.timeOrigin + performance.now()`, which is effectively the
sum of `gettimeofday()` at process start, plus the delta in
`CLOCK_MONOTONIC` between one sample at process start and another when
`now()` is called, plus a tiny offset because `gettimeofday()` and the
initial sample cannot happen exactly simultaneously. This has the
benefit of never decreasing, and preserves the accuracy of
intervals (timestamp subtractions) that span a `settimeofday()`
timequake. But has the downside of becoming unique per-process when
timequakes happen: if you compare this value against a similar one
built in a different process, they will be different by the sum of any
timequakes that occurred between the first process launching and the
second one launching. If a process restarts, the timestamps before and
after the restart will be offset by a similar amount.

This changes the slogfile to use `gettimeofday()`, via a small C
module named `microtime`. This matches what #5152 changes in
`xsnap-worker.c` to record delivery/syscall send+receive
timestamps. By using `gettimeofday()` on both sides, the timestamps
remain comparable independent of when the processes are started or
restarted. The drawback is that spans which cross a timequake will be
corrupted, even becoming negative if `settimeofday()` causes the
system clock to go backwards far enough. However we only really pay
attention to one span at a time (a single block, or delivery, or
syscall), so the damage is limited. I care more about comparability of
timestamps across long-running processes (potentially across multiple
hopefully-NTP-synced machines) than I'm worried about the occasional
timequake-corrupted span.

If we manage to make swingset fast enough that the microsecond
resolution of `gettimeofday()` feels insufficient, we should probably
change both the slogger and `xsnap-worker.c` to use the earlier
approach: `timeOrigin + CLOCK_MONOTONIC` (which will involve writing
new code on the `xsnap-worker.c` side).

refs #5152
