### PR TITLE
fix(vat-data): utility type FunctionsPlusContext

### DIFF
--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -263,7 +263,7 @@ const watchGovernance = (govParams, vaultManager, oldInstall, oldTerms) => {
   });
 };
 
-/** @type {import('@agoric/vat-data/src/types').FunctionsPlusContext<VaultFactory>} */
+/** @type {import('@agoric/vat-data/src/types').FunctionsPlusContext<MethodContext, VaultFactory>} */
 const machineBehavior = {
   // TODO move this under governance #3924
   /**

--- a/packages/vat-data/src/index.test-d.ts
+++ b/packages/vat-data/src/index.test-d.ts
@@ -7,7 +7,12 @@ import {
   defineDurableKind,
   partialAssign,
 } from '.';
-import { KindFacets, DurableKindHandle, KindFacet } from './types.js';
+import {
+  KindFacets,
+  DurableKindHandle,
+  KindFacet,
+  FunctionsPlusContext,
+} from './types.js';
 
 /*
 export const makePaymentMaker = (allegedName: string, brand: unknown) => {
@@ -140,3 +145,18 @@ partialAssign(state, { name: 'ed' });
 partialAssign(state, { key: 'ted' });
 // @ts-expect-error
 partialAssign(state, { name: 3 });
+
+// test FunctionsPlusContext
+type SomeFacet = {
+  gt(b: number): boolean;
+};
+type SomeContext = { state: { a: number } };
+const someBehavior: FunctionsPlusContext<SomeContext, SomeFacet> = {
+  gt(context: SomeContext, b: number) {
+    return b > context.state.a;
+  },
+};
+const someFacet: KindFacet<typeof someBehavior> = null as any;
+// @ts-expect-error
+someFacet.gt();
+expectType<boolean>(someFacet.gt(1));

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -32,7 +32,7 @@ type KindFacets<B> = {
 type MultiKindContext<S, B> = { state: S; facets: KindFacets<B> };
 
 type PlusContext<C, M> = (c: C, ...args: Parameters<M>) => ReturnType<M>;
-type FunctionsPlusContext<O> = { [K in keyof O]: PlusContext<O[K]> };
+type FunctionsPlusContext<C, O> = { [K in keyof O]: PlusContext<C, O[K]> };
 
 declare class DurableKindHandleClass {
   private descriptionTag: string;


### PR DESCRIPTION
## Description

@erights noticed `FunctionsPlusContext` never had the Context bound. I think the reason there wasn't an error was https://github.com/Agoric/agoric-sdk/issues/3916

This adds an explicit test, takes the Context type parameter and provides in vaultDirector where needed.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

New types test