### PR TITLE
fix: tests offer with invitation promise

### DIFF
--- a/packages/zoe/test/unitTests/makeOffer.js
+++ b/packages/zoe/test/unitTests/makeOffer.js
@@ -15,8 +15,8 @@ export const makeOffer = async (zoe, zcf, proposal, payments) => {
   const getSeat = seat => {
     zcfSeat = seat;
   };
-  const invitation = zcf.makeInvitation(getSeat, 'seat');
-  const userSeat = await E(zoe).offer(invitation, proposal, payments);
+  const invitationP = zcf.makeInvitation(getSeat, 'seat');
+  const userSeat = await E(zoe).offer(invitationP, proposal, payments);
   assert(zcfSeat);
   return { zcfSeat, userSeat };
 };

--- a/packages/zoe/test/unitTests/makeOffer.js
+++ b/packages/zoe/test/unitTests/makeOffer.js
@@ -15,7 +15,7 @@ export const makeOffer = async (zoe, zcf, proposal, payments) => {
   const getSeat = seat => {
     zcfSeat = seat;
   };
-  const invitation = await zcf.makeInvitation(getSeat, 'seat');
+  const invitation = zcf.makeInvitation(getSeat, 'seat');
   const userSeat = await E(zoe).offer(invitation, proposal, payments);
   assert(zcfSeat);
   return { zcfSeat, userSeat };


### PR DESCRIPTION
It was thought that `offer` requires an invitation, not a promise for an invitation. This removes one `await` in test code used by many tests. If everything is still green, then it demonstrates that `offer` is fine with promises for invitations. Which is great for pipelining!
