### PR TITLE
5556 getLiquidityIssuer

### DIFF
--- a/packages/run-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addPool.js
@@ -29,7 +29,6 @@ export const makeAddIssuer = (
       E(secondaryIssuer).getAssetKind(),
       E(secondaryIssuer).getBrand(),
     ]);
-
     assert(
       !isInSecondaries(secondaryBrand),
       X`issuer ${secondaryIssuer} already has a pool`,
@@ -176,7 +175,6 @@ export const makeAddPoolInvitation = (
     zcf.reallocate(reserveLiquidityTokenSeat, seat);
     seat.exit();
     pool.updateState();
-    brandToLiquidityMint.delete(secondaryBrand);
 
     await onOfferHandled(
       secondaryBrand,

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -157,7 +157,7 @@ const start = async (zcf, privateArgs) => {
   );
 
   /** @type {Store<Brand,PoolFacets>} */
-  const secondaryBrandToPool = makeStore('secondaryBrand');
+  const secondaryBrandToPool = makeStore('secondaryBrandToPool');
   const getPool = brand => secondaryBrandToPool.get(brand).pool;
   const getPoolHelper = brand => secondaryBrandToPool.get(brand).helper;
   const initPool = secondaryBrandToPool.init;
@@ -239,8 +239,12 @@ const start = async (zcf, privateArgs) => {
     trace('handlePoolAdded done');
   };
 
+  /** @param {Brand} brand */
+  const getLiquidityIssuer = brand =>
+    secondaryBrandToLiquidityMint.get(brand).getIssuerRecord().issuer;
+  /** @param {Brand} brand */
   const getLiquiditySupply = brand => getPool(brand).getLiquiditySupply();
-  const getLiquidityIssuer = brand => getPool(brand).getLiquidityIssuer();
+
   /** @param {Brand} brand */
   const getSecondaryIssuer = brand => {
     assert(

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
@@ -662,6 +662,6 @@ test('amm bad add liquidity offer', async t => {
 
   await t.throwsAsync(
     async () => E(amm.ammPublicFacet).getPoolMetrics(moolaKit.brand),
-    { message: '"secondaryBrand" not found: "[Alleged: moola brand]"' },
+    { message: '"secondaryBrandToPool" not found: "[Alleged: moola brand]"' },
   );
 });

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -1050,7 +1050,7 @@ test('amm adding liquidity', async t => {
 
   await t.throwsAsync(
     () => E(amm.ammPublicFacet).getPoolAllocation(moolaKit.brand),
-    { message: /"secondaryBrand" not found: / },
+    { message: /"secondaryBrandToPool" not found: / },
     "The pool hasn't been created yet",
   );
 


### PR DESCRIPTION
closes: #5556


## Description

Allow `getLiquidityIssuer` after the issuer is added, before the pool is defined.

### Security Considerations

No additional privileges, just a convenience and reduction in surprise.

### Documentation Considerations

--
### Testing Considerations

No new tests since a corner case for which there isn't consensus that it was a bug.