### PR TITLE
5386 stored metrics

### DIFF
--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -67,10 +67,13 @@ export const makeStoredSubscription = (
 
   /** @type {StoredSubscription<T>} */
   const storesub = Far('StoredSubscription', {
-    getStoreKey: () =>
-      (storageNode ? E(storageNode).getStoreKey() : Promise.resolve({})).then(
-        storeKey => ({ ...storeKey, subscription }),
-      ),
+    getStoreKey: async () => {
+      if (!storageNode) {
+        return harden({ subscription });
+      }
+      const storeKey = await E(storageNode).getStoreKey();
+      return harden({ ...storeKey, subscription });
+    },
     getUnserializer: () => unserializer,
     getSharableSubscriptionInternals:
       subscription.getSharableSubscriptionInternals,

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -2,6 +2,7 @@
 import { E } from '@endo/eventual-send';
 import { Far, makeMarshal } from '@endo/marshal';
 import { observeIteration } from './asyncIterableAdaptor.js';
+import { makeSubscriptionKit } from './subscriber.js';
 
 /**
  * Begin iterating the source, storing serialized iteration values.  If the
@@ -82,3 +83,37 @@ export const makeStoredSubscription = (
   return storesub;
 };
 harden(makeStoredSubscription);
+
+/**
+ * @template T
+ * @typedef {object} StoredPublisherKit
+ * @property {StoredSubscription<T>} subscriber TODO: change to StoredSubscriber<T> when available
+ * @property {IterationObserver<T>} publisher
+ */
+
+/**
+ * @template [T=unknown]
+ * @param {ERef<StorageNode>} [storageNode]
+ * @param {ERef<Marshaller>} [marshaller]
+ * @param {string} [childPath]
+ * @returns {StoredPublisherKit<T>}
+ */
+export const makeStoredPublisherKit = (storageNode, marshaller, childPath) => {
+  const { publication, subscription } = makeSubscriptionKit();
+
+  if (storageNode && childPath) {
+    storageNode = E(storageNode).getChildNode(childPath);
+  }
+
+  // wrap the subscription to tee events to storage, repeating to this `subscriber`
+  const subscriber = makeStoredSubscription(
+    subscription,
+    storageNode,
+    marshaller,
+  );
+
+  return {
+    publisher: publication,
+    subscriber,
+  };
+};

--- a/packages/run-protocol/src/contractSupport.js
+++ b/packages/run-protocol/src/contractSupport.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { AmountMath } from '@agoric/ertp';
+import { makeStoredPublisherKit } from '@agoric/notifier';
 import { M } from '@agoric/store';
 
 const { details: X, quote: q } = assert;
@@ -79,3 +80,26 @@ export const checkDebtLimit = (debtLimit, totalDebt, toMint) => {
     )}`,
   );
 };
+
+/**
+ * @template T
+ * @param {ERef<StorageNode>} [storageNode]
+ * @param {ERef<Marshaller>} [marshaller]
+ * @returns {MetricsPublisherKit<T>}
+ */
+export const makeMetricsPublisherKit = (storageNode, marshaller) => {
+  /** @type {import('@agoric/notifier').StoredPublisherKit<T>} */
+  const kit = makeStoredPublisherKit(storageNode, marshaller, 'metrics');
+  return {
+    metricsPublication: kit.publisher,
+    metricsSubscription: kit.subscriber,
+  };
+};
+harden(makeMetricsPublisherKit);
+
+/**
+ * @template T
+ * @typedef {object} MetricsPublisherKit<T>
+ * @property {IterationObserver<T>} metricsPublication
+ * @property {StoredSubscription<T>} metricsSubscription
+ */

--- a/packages/run-protocol/src/proposals/core-proposal.js
+++ b/packages/run-protocol/src/proposals/core-proposal.js
@@ -65,6 +65,8 @@ const SHARED_MAIN_MANIFEST = harden({
   },
   [econBehaviors.startVaultFactory.name]: {
     consume: {
+      board: 'board',
+      chainStorage: true,
       feeMintAccess: 'zoe',
       chainTimerService: 'timer',
       zoe: 'zoe',
@@ -111,6 +113,8 @@ const SHARED_MAIN_MANIFEST = harden({
     consume: {
       ammCreatorFacet: 'amm',
       ammInstanceWithoutReserve: 'amm',
+      board: 'board',
+      chainStorage: true,
       feeMintAccess: 'zoe',
       chainTimerService: 'timer',
       zoe: 'zoe',

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -66,14 +66,14 @@ const validTransitions = {
 };
 
 /**
- * @typedef {Phase[keyof typeof Phase]} TitlePhase
+ * @typedef {Phase[keyof typeof Phase]} HolderPhase
  *
  * @typedef {object} VaultNotification
  * @property {Amount<'nat'>} locked Amount of Collateral locked
  * @property {{debt: Amount<'nat'>, interest: Ratio}} debtSnapshot 'debt' at the point the compounded interest was 'interest'
  * @property {Ratio} interestRate Annual interest rate charge
  * @property {Ratio} liquidationRatio
- * @property {TitlePhase} vaultState
+ * @property {HolderPhase} vaultState
  */
 
 // XXX masks typedef from types.js, but using that causes circular def problems
@@ -305,7 +305,7 @@ const helperBehavior = {
   /**
    *
    * @param {MethodContext} context
-   * @param {TitlePhase} newPhase
+   * @param {HolderPhase} newPhase
    */
   getStateSnapshot: ({ state, facets }, newPhase) => {
     const { debtSnapshot: debt, interestSnapshot: interest } = state;

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -67,7 +67,7 @@ const { details: X } = assert;
 /**
  * @param {ERef<ZoeService>} zoe
  * @param {ImmutableState['directorParamManager']} paramMgr
- * @param {unknown} [oldShortfallReporter]
+ * @param {import('../reserve/assetReserve.js').ShortfallReporter} [oldShortfallReporter]
  * @param {ERef<Invitation>} [oldInvitation]
  */
 const updateShortfallReporter = async (
@@ -340,7 +340,6 @@ const machineBehavior = {
       debtMint,
       collateralBrand,
       zcf.getTerms().priceAuthority,
-      // @ts-expect-error promise issues?
       factoryPowers,
       timerService,
       startTimeStamp,

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -43,7 +43,13 @@ import { makeVaultDirector } from './vaultDirector.js';
 
 /**
  * @param {VaultFactoryZCF} zcf
- * @param {{feeMintAccess: FeeMintAccess, initialPoserInvitation: Invitation, initialShortfallInvitation: Invitation}} privateArgs
+ * @param {{
+ *   feeMintAccess: FeeMintAccess,
+ *   initialPoserInvitation: Invitation,
+ *   initialShortfallInvitation: Invitation,
+ *   storageNode?: ERef<StorageNode>,
+ *   marshaller?: ERef<Marshaller>,
+ * }} privateArgs
  */
 export const start = async (zcf, privateArgs) => {
   const { feeMintAccess, initialPoserInvitation, initialShortfallInvitation } =
@@ -73,7 +79,13 @@ export const start = async (zcf, privateArgs) => {
     zcf.getTerms().governedParams,
   );
 
-  const factory = makeVaultDirector(zcf, vaultDirectorParamManager, debtMint);
+  const factory = makeVaultDirector(
+    zcf,
+    vaultDirectorParamManager,
+    debtMint,
+    privateArgs.storageNode,
+    privateArgs.marshaller,
+  );
 
   return harden({
     creatorFacet: factory.creator,

--- a/packages/run-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/run-protocol/src/vaultFactory/vaultHolder.js
@@ -18,7 +18,7 @@ const { details: X } = assert;
  *   state: State,
  *   facets: {
  *     helper: import('@agoric/vat-data/src/types').KindFacet<typeof helper>,
- *     self: import('@agoric/vat-data/src/types').KindFacet<typeof title>,
+ *     self: import('@agoric/vat-data/src/types').KindFacet<typeof holder>,
  *   },
  * }>} MethodContext
  */
@@ -38,18 +38,18 @@ const initState = vault => {
 const helper = {
   /**
    * @param {MethodContext} context
-   * @throws if this title no longer owns the vault
+   * @throws if this holder no longer owns the vault
    */
   owned: ({ state }) => {
     const { vault } = state;
-    assert(vault, X`Using vault title after transfer`);
+    assert(vault, X`Using vault holder after transfer`);
     return vault;
   },
   /** @param {MethodContext} context */
   getUpdater: ({ state }) => state.updater,
 };
 
-const title = {
+const holder = {
   /** @param {MethodContext} context */
   getNotifier: ({ state }) => state.notifier,
   /** @param {MethodContext} context */
@@ -79,7 +79,7 @@ const title = {
   getNormalizedDebt: ({ facets }) => facets.helper.owned().getNormalizedDebt(),
 };
 
-const behavior = { helper, title };
+const behavior = { helper, holder };
 
 export const makeVaultHolder = defineKindMulti(
   'VaultHolder',

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -10,18 +10,18 @@ import { makeVaultHolder } from './vaultHolder.js';
  * @param {Notifier<import('./vaultManager').AssetState>} assetNotifier
  */
 export const makeVaultKit = (vault, assetNotifier) => {
-  const { title, helper } = makeVaultHolder(vault);
+  const { holder, helper } = makeVaultHolder(vault);
   const vaultKit = harden({
     publicNotifiers: {
-      vault: title.getNotifier(),
+      vault: holder.getNotifier(),
       asset: assetNotifier,
     },
     invitationMakers: Far('invitation makers', {
-      AdjustBalances: title.makeAdjustBalancesInvitation,
-      CloseVault: title.makeCloseInvitation,
-      TransferVault: title.makeTransferInvitation,
+      AdjustBalances: holder.makeAdjustBalancesInvitation,
+      CloseVault: holder.makeCloseInvitation,
+      TransferVault: holder.makeTransferInvitation,
     }),
-    vault: title,
+    vault: holder,
     vaultUpdater: helper.getUpdater(),
   });
   return vaultKit;

--- a/packages/run-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addPool.js
@@ -69,6 +69,8 @@ export const makeAddIssuer = (
  * @param {ZCFSeat} protocolSeat seat that holds collected fees
  * @param {WeakStore<Brand,ZCFMint>} brandToLiquidityMint
  * @param {(secondaryBrand: Brand, reserveLiquidityTokenSeat: ZCFSeat, liquidityKeyword: Keyword) => Promise<void>} onOfferHandled
+ * @param {ERef<StorageNode>} [storageNode]
+ * @param {ERef<Marshaller>} [marshaller]
  */
 export const makeAddPoolInvitation = (
   zcf,
@@ -80,6 +82,8 @@ export const makeAddPoolInvitation = (
   protocolSeat,
   brandToLiquidityMint,
   onOfferHandled,
+  storageNode,
+  marshaller,
 ) => {
   const makePool = definePoolKind(
     zcf,
@@ -88,6 +92,8 @@ export const makeAddPoolInvitation = (
     quoteIssuerKit,
     params,
     protocolSeat,
+    storageNode,
+    marshaller,
   );
 
   /** @type {(Brand) => Promise<{poolFacets: PoolFacets, liquidityZcfMint: ZCFMint}>} */

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -160,7 +160,9 @@ const start = async (zcf, privateArgs) => {
 
   // The liquidityBrand has to exist to allow the addPool Offer to specify want
   /** @type {WeakStore<Brand,ZCFMint>} */
-  const secondaryBrandToLiquidityMint = makeWeakStore('secondaryBrand');
+  const secondaryBrandToLiquidityMint = makeWeakStore(
+    'secondaryBrandToLiquidityMint',
+  );
 
   const quoteIssuerKit = makeIssuerKit('Quote', AssetKind.SET);
 
@@ -240,6 +242,11 @@ const start = async (zcf, privateArgs) => {
     );
     return zcf.getIssuerForBrand(brand);
   };
+  const poolStorageNode = await (privateArgs.storageNode &&
+    E(privateArgs.storageNode).getChildNode(
+      // NB: the set of pools grows monotonically
+      `pool${secondaryBrandToPool.getSize()}`,
+    ));
   const addPoolInvitation = makeAddPoolInvitation(
     zcf,
     initPool,
@@ -250,6 +257,8 @@ const start = async (zcf, privateArgs) => {
     protocolSeat,
     secondaryBrandToLiquidityMint,
     handlePoolAdded,
+    poolStorageNode,
+    privateArgs.marshaller,
   );
   const addIssuer = makeAddIssuer(
     zcf,

--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { AmountMath, isNatValue } from '@agoric/ertp';
-import { makeNotifierKit, makeSubscriptionKit } from '@agoric/notifier';
+import { makeNotifierKit, makeStoredPublisherKit } from '@agoric/notifier';
 
 import {
   calcLiqValueToMint,
@@ -330,6 +330,8 @@ const finish = context => {
  * @param {IssuerKit} quoteIssuerKit
  * @param {import('./multipoolMarketMaker.js').AMMParamGetters} paramAccessor retrieve governed params
  * @param {ZCFSeat} protocolSeat seat that holds collected fees
+ * @param {ERef<StorageNode>} [storageNode]
+ * @param {ERef<Marshaller>} [marshaller]
  */
 export const definePoolKind = (
   zcf,
@@ -338,15 +340,15 @@ export const definePoolKind = (
   quoteIssuerKit,
   paramAccessor,
   protocolSeat,
+  storageNode,
+  marshaller,
 ) => {
   const poolInit = (liquidityZcfMint, poolSeat, secondaryBrand) => {
     const { brand: liquidityBrand, issuer: liquidityIssuer } =
       liquidityZcfMint.getIssuerRecord();
     const { notifier, updater } = makeNotifierKit();
-    const {
-      publication: metricsPublication,
-      subscription: metricsSubscription,
-    } = makeSubscriptionKit();
+    const { publisher: metricsPublication, subscriber: metricsSubscription } =
+      makeStoredPublisherKit(storageNode, marshaller, 'metrics');
 
     // XXX why does the paramAccessor have to be repackaged as a Far object?
     const params = Far('pool param accessor', {

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/setup.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/setup.js
@@ -16,7 +16,11 @@ import {
   setupReserve,
   startEconomicCommittee,
 } from '../../../src/proposals/econ-behaviors.js';
-import { installGovernance, provideBundle } from '../../supports.js';
+import {
+  installGovernance,
+  mockChainStorageRoot,
+  provideBundle,
+} from '../../supports.js';
 import { makeTracer } from '../../../src/makeTracer.js';
 
 const ammRoot = './src/vpool-xyk-amm/multipoolMarketMaker.js'; // package relative
@@ -71,7 +75,7 @@ export const setupAMMBootstrap = async (
   produce.agoricNamesAdmin.resolve(agoricNamesAdmin);
 
   installGovernance(zoe, spaces.installation.produce);
-  produce.chainStorage.resolve(undefined);
+  produce.chainStorage.resolve(mockChainStorageRoot());
 
   return { produce, consume, ...spaces };
 };

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -1168,3 +1168,36 @@ test('amm adding liquidity', async t => {
     `poolAllocation after initialization`,
   );
 });
+
+test('storage keys', async t => {
+  // Set up central token
+  const centralR = makeIssuerKit('central');
+  const moolaR = makeIssuerKit('moola');
+
+  const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
+  // This timer is only used to build quotes. Let's make it non-zero
+  const timer = buildManualTimer(t.log, 30n);
+  const { zoe, amm } = await setupAmmServices(
+    t,
+    electorateTerms,
+    centralR,
+    timer,
+  );
+
+  const rootMetrics = await E(amm.ammPublicFacet).getMetrics();
+  const rootStoreKey = await E(rootMetrics).getStoreKey();
+  t.is(rootStoreKey.key, 'mockChainStorageRoot.amm.metrics');
+
+  const addInitialLiquidity = await makeAddInitialLiquidity(
+    t,
+    zoe,
+    amm,
+    moolaR,
+    centralR,
+  );
+  await addInitialLiquidity(10000n, 50000n);
+
+  const poolMetrics = await E(amm.ammPublicFacet).getPoolMetrics(moolaR.brand);
+  const poolStoreKey = await E(poolMetrics).getStoreKey();
+  t.is(poolStoreKey.key, 'mockChainStorageRoot.amm.pool0.metrics');
+});

--- a/packages/run-protocol/test/metrics.js
+++ b/packages/run-protocol/test/metrics.js
@@ -3,6 +3,13 @@ import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
 import { diff } from 'deep-object-diff';
 
+import { makeTracer } from '../src/makeTracer.js';
+
+// While t.log has the advantage of omitting by default when tests pass,
+// when debugging it's most valuable to have the messages in sequence with app
+// code logging which doesn't have access to t.log.
+const trace = makeTracer('TestMetrics', false);
+
 /**
  * @param {import('ava').ExecutionContext} t
  * @param {Subscription<N>} subscription
@@ -17,13 +24,13 @@ export const subscriptionTracker = async (t, subscription) => {
   /** @param {Record<keyof N, N[keyof N]>} expectedValue */
   const assertInitial = async expectedValue => {
     notif = await metrics.getUpdateSince();
-    console.log('assertInitial notif', notif);
+    trace('assertInitial notif', notif);
     t.deepEqual(notif.value, expectedValue);
   };
   const assertChange = async expectedDelta => {
     const prevNotif = notif;
     notif = await metrics.getUpdateSince(notif.updateCount);
-    console.log('assertChange notif', notif);
+    trace('assertChange notif', notif);
     // @ts-expect-error diff() overly constrains
     const actualDelta = diff(prevNotif.value, notif.value);
     t.deepEqual(actualDelta, expectedDelta, 'Unexpected delta');
@@ -66,7 +73,7 @@ export const vaultManagerMetricsTracker = async (t, publicFacet) => {
       v.totalOverageReceived,
       v.totalShortfallReceived,
     ].map(a => a.value);
-    console.log('liquidatedYet', { p, o, s });
+    trace('liquidatedYet', { p, o, s });
     return p - o + s;
   };
 

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -9,6 +9,7 @@ import {
   makeAgoricNamesAccess,
   makePromiseSpace,
 } from '@agoric/vats/src/core/utils.js';
+import { makeChainStorageRoot } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeZoeKit } from '@agoric/zoe';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
@@ -55,6 +56,11 @@ export const setUpZoeForTest = (setJig = () => {}) => {
 };
 harden(setUpZoeForTest);
 
+export const mockChainStorageRoot = () => {
+  const toStorage = v => v;
+  return makeChainStorageRoot(toStorage, 'swingset', 'mockChainStorageRoot');
+};
+
 export const setupBootstrap = (t, optTimer = undefined) => {
   const trace = makeTracer('PromiseSpace', false);
   const space = /** @type {any} */ (makePromiseSpace(trace));
@@ -65,7 +71,7 @@ export const setupBootstrap = (t, optTimer = undefined) => {
 
   const timer = optTimer || buildManualTimer(t.log);
   produce.chainTimerService.resolve(timer);
-  produce.chainStorage.resolve(undefined);
+  produce.chainStorage.resolve(mockChainStorageRoot());
 
   const { zoe, feeMintAccess, run } = t.context;
   produce.zoe.resolve(zoe);

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -39,7 +39,7 @@
  * @property {(issuer: Issuer) => Brand} getBrandForIssuer
  * @property {(brand: Brand) => Issuer} getIssuerForBrand
  * @property {GetAssetKindByBrand} getAssetKind
- * @property {MakeZCFMint} makeZCFMint
+ * @property {<K extends AssetKind>(keyword: Keyword, assetKind?: K, displayInfo?: AdditionalDisplayInfo) => Promise<ZCFMint<K>>} makeZCFMint
  * @property {ZCFRegisterFeeMint} registerFeeMint
  * @property {ZCFMakeEmptySeatKit} makeEmptySeatKit
  * @property {SetTestJig} setTestJig

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -223,7 +223,7 @@ export const makeZCFZygote = (
    * @param {Keyword} keyword
    * @param {K} [assetKind]
    * @param {AdditionalDisplayInfo=} displayInfo
-   * @returns {Promise<ZCFMint>}
+   * @returns {Promise<ZCFMint<K>>}
    */
   const makeZCFMint = async (
     keyword,


### PR DESCRIPTION
## Description

As part of #5386 , makes all metrics subscriptions use chain storage as in https://github.com/Agoric/agoric-sdk/pull/5400/

### Security Considerations

Metrics data stored on chain

### Documentation Considerations

Consumers will need to know where to get metrics. The establishes a pattern that it's in `metrics` 

### Testing Considerations

Existing tests pass.

New tests?