### PR TITLE
fix vaultManager state isolation

### DIFF
--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -66,14 +66,14 @@ const validTransitions = {
 };
 
 /**
- * @typedef {Phase[keyof typeof Phase]} TitlePhase
+ * @typedef {Phase[keyof typeof Phase]} HolderPhase
  *
  * @typedef {object} VaultNotification
  * @property {Amount<'nat'>} locked Amount of Collateral locked
  * @property {{debt: Amount<'nat'>, interest: Ratio}} debtSnapshot 'debt' at the point the compounded interest was 'interest'
  * @property {Ratio} interestRate Annual interest rate charge
  * @property {Ratio} liquidationRatio
- * @property {TitlePhase} vaultState
+ * @property {HolderPhase} vaultState
  */
 
 // XXX masks typedef from types.js, but using that causes circular def problems
@@ -305,7 +305,7 @@ const helperBehavior = {
   /**
    *
    * @param {MethodContext} context
-   * @param {TitlePhase} newPhase
+   * @param {HolderPhase} newPhase
    */
   getStateSnapshot: ({ state, facets }, newPhase) => {
     const { debtSnapshot: debt, interestSnapshot: interest } = state;

--- a/packages/run-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/run-protocol/src/vaultFactory/vaultHolder.js
@@ -18,7 +18,7 @@ const { details: X } = assert;
  *   state: State,
  *   facets: {
  *     helper: import('@agoric/vat-data/src/types').KindFacet<typeof helper>,
- *     self: import('@agoric/vat-data/src/types').KindFacet<typeof title>,
+ *     self: import('@agoric/vat-data/src/types').KindFacet<typeof holder>,
  *   },
  * }>} MethodContext
  */
@@ -38,18 +38,18 @@ const initState = vault => {
 const helper = {
   /**
    * @param {MethodContext} context
-   * @throws if this title no longer owns the vault
+   * @throws if this holder no longer owns the vault
    */
   owned: ({ state }) => {
     const { vault } = state;
-    assert(vault, X`Using vault title after transfer`);
+    assert(vault, X`Using vault holder after transfer`);
     return vault;
   },
   /** @param {MethodContext} context */
   getUpdater: ({ state }) => state.updater,
 };
 
-const title = {
+const holder = {
   /** @param {MethodContext} context */
   getNotifier: ({ state }) => state.notifier,
   /** @param {MethodContext} context */
@@ -79,7 +79,7 @@ const title = {
   getNormalizedDebt: ({ facets }) => facets.helper.owned().getNormalizedDebt(),
 };
 
-const behavior = { helper, title };
+const behavior = { helper, holder };
 
 export const makeVaultHolder = defineKindMulti(
   'VaultHolder',

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -10,18 +10,18 @@ import { makeVaultHolder } from './vaultHolder.js';
  * @param {Notifier<import('./vaultManager').AssetState>} assetNotifier
  */
 export const makeVaultKit = (vault, assetNotifier) => {
-  const { title, helper } = makeVaultHolder(vault);
+  const { holder, helper } = makeVaultHolder(vault);
   const vaultKit = harden({
     publicNotifiers: {
-      vault: title.getNotifier(),
+      vault: holder.getNotifier(),
       asset: assetNotifier,
     },
     invitationMakers: Far('invitation makers', {
-      AdjustBalances: title.makeAdjustBalancesInvitation,
-      CloseVault: title.makeCloseInvitation,
-      TransferVault: title.makeTransferInvitation,
+      AdjustBalances: holder.makeAdjustBalancesInvitation,
+      CloseVault: holder.makeCloseInvitation,
+      TransferVault: holder.makeTransferInvitation,
     }),
-    vault: title,
+    vault: holder,
     vaultUpdater: helper.getUpdater(),
   });
   return vaultKit;


### PR DESCRIPTION
## Description

Fixes bug introduced in https://github.com/Agoric/agoric-sdk/pull/5214 that made vault managers share some ephemeral state.

Two variables were moved out of virtual state into mere runtime state, but in doing so moved up to module scope.

### Security Considerations

Improved state isolation.

### Documentation Considerations

--

### Testing Considerations

Feasible to regression test?