### PR TITLE
BREAKING CHANGE: no optionalInitialState in makeSubscriptionKit()

### DIFF
--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -60,10 +60,9 @@ const makeSubscriptionIterator = tailP => {
  * distributed pub/sub.
  *
  * @template T
- * @param {T[]} optionalInitialState
  * @returns {SubscriptionRecord<T>}
  */
-const makeSubscriptionKit = (...optionalInitialState) => {
+const makeSubscriptionKit = () => {
   const { publisher, subscriber } = makeEmptyPublishKit();
 
   // The publish kit subscriber is prefix-lossy, so making *this* subscriber completely
@@ -79,9 +78,6 @@ const makeSubscriptionKit = (...optionalInitialState) => {
     fail: publisher.fail,
   });
 
-  if (optionalInitialState.length > 0) {
-    publication.updateState(optionalInitialState[0]);
-  }
   return harden({ publication, subscription });
 };
 harden(makeSubscriptionKit);

--- a/packages/notifier/test/test-stored-subscription.js
+++ b/packages/notifier/test/test-stored-subscription.js
@@ -31,12 +31,12 @@ const makeFakeStorage = (path, publication) => {
 test('stored subscription', async t => {
   t.plan((jsonPairs.length + 2) * 4 + 1);
 
-  /** @type {any} */
   const initialValue = 'first value';
   const { publication: pubStorage, subscription: subStorage } =
     makeSubscriptionKit();
   const storage = makeFakeStorage('publish.foo.bar', pubStorage);
-  const { subscription, publication } = makeSubscriptionKit(initialValue);
+  const { subscription, publication } = makeSubscriptionKit();
+  publication.updateState(initialValue);
   const storesub = makeStoredSubscription(subscription, storage);
 
   t.deepEqual(await E(storesub).getStoreKey(), {

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -168,7 +168,8 @@ const start = async (zcf, privateArgs) => {
   const {
     publication: metricsPublication,
     subscription: rawMetricsSubscription,
-  } = makeSubscriptionKit(harden({ XYK: [] }));
+  } = makeSubscriptionKit();
+  metricsPublication.updateState(harden({ XYK: [] }));
   const { storageNode, marshaller } = privateArgs;
   const metricsStorageNode =
     storageNode && E(storageNode).getChildNode('metrics'); // TODO: magic string


### PR DESCRIPTION
## Description

There was [some debate](https://github.com/Agoric/agoric-sdk/pull/5613#discussion_r899691493) over whether going forward we would support an optional initial state in `makePublisherKit`. The conclusion was that we should either require an initial state or remove the option.

This PR proposes (and implements) that we remove the option since all it does is call `updateState` for the caller, which they can do whenever they want to. This flexibility make it so a virtual kind can create its state with the publisher in it and then use that state to generate a publication payload.

### Security Considerations

--

### Documentation Considerations

Breaking change, noted in conventional commit.

### Testing Considerations

Tests updated.