### PR TITLE
Throw error on attempt to reuse a kind handle

### DIFF
--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -833,6 +833,10 @@ export function makeVirtualObjectManager(
     const durableKindDescriptor = kindDescriptors.get(kindHandle);
     assert(durableKindDescriptor);
     const { kindID, tag } = durableKindDescriptor;
+    assert(
+      !definedDurableKinds.has(kindID),
+      `redefinition of durable kind "${tag}"`,
+    );
     const maker = defineKindInternal(
       kindID,
       tag,
@@ -850,6 +854,10 @@ export function makeVirtualObjectManager(
     const durableKindDescriptor = kindDescriptors.get(kindHandle);
     assert(durableKindDescriptor);
     const { kindID, tag } = durableKindDescriptor;
+    assert(
+      !definedDurableKinds.has(kindID),
+      `redefinition of durable kind "${tag}"`,
+    );
     const maker = defineKindInternal(
       kindID,
       tag,

--- a/packages/SwingSet/test/test-vat-env.js
+++ b/packages/SwingSet/test/test-vat-env.js
@@ -32,8 +32,9 @@ test('kind makers are in the test environment', t => {
   const dthing = makeDThing('dthing');
   t.is(dthing.ping(), 4);
 
+  const kind2 = VatData.makeKindHandle('thing2');
   const makeDMThing = VatData.defineDurableKindMulti(
-    kind,
+    kind2,
     null,
     multiThingBehavior,
   );

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -513,6 +513,17 @@ test('virtual object cycles using the finish function', t => {
   t.is(thing.getOtherThing().getFirstThing(), thing);
 });
 
+test('durable kind IDs cannot be reused', t => {
+  const { vom } = makeFakeVirtualStuff();
+  const { makeKindHandle, defineDurableKind } = vom;
+
+  const kindHandle = makeKindHandle('testkind');
+  defineDurableKind(kindHandle, initThing, thingBehavior);
+  t.throws(() => defineDurableKind(kindHandle, initThing, thingBehavior), {
+    message: 'redefinition of durable kind "testkind"',
+  });
+});
+
 test('durable kind IDs can be reanimated', t => {
   const log = [];
   const { vom, vrm, cm, fakeStuff } = makeFakeVirtualStuff({

--- a/packages/zoe/test/minimalMakeKindContract.js
+++ b/packages/zoe/test/minimalMakeKindContract.js
@@ -5,7 +5,8 @@ const start = _zcf => {
   VatData.defineKindMulti('x', () => {}, { x: {}, y: {} });
   const kh = VatData.makeKindHandle();
   VatData.defineDurableKind(kh, () => {}, {});
-  VatData.defineDurableKindMulti(kh, () => {}, { x: {}, y: {} });
+  const kh2 = VatData.makeKindHandle();
+  VatData.defineDurableKindMulti(kh2, () => {}, { x: {}, y: {} });
   VatData.makeScalarBigMapStore();
   VatData.makeScalarBigWeakMapStore();
   VatData.makeScalarBigSetStore();

--- a/packages/zoe/test/unitTests/test-makeKind.js
+++ b/packages/zoe/test/unitTests/test-makeKind.js
@@ -26,8 +26,9 @@ test('defineKind non-swingset', async t => {
   t.notThrows(() => VatData.makeKindHandle());
   const kh = VatData.makeKindHandle();
   t.notThrows(() => VatData.defineDurableKind(kh, () => {}, {}));
+  const kh2 = VatData.makeKindHandle();
   t.notThrows(() =>
-    VatData.defineDurableKindMulti(kh, () => {}, { x: {}, y: {} }),
+    VatData.defineDurableKindMulti(kh2, () => {}, { x: {}, y: {} }),
   );
   t.notThrows(() => VatData.makeScalarBigMapStore());
   t.notThrows(() => VatData.makeScalarBigWeakMapStore());

--- a/packages/zoe/test/unitTests/test-zoe-env.js
+++ b/packages/zoe/test/unitTests/test-zoe-env.js
@@ -13,7 +13,8 @@ test('(mock) kind makers from SwingSet are in the zoe contract environment', t =
   VatData.defineKindMulti('x', () => {}, { x: {}, y: {} });
   const kh = VatData.makeKindHandle();
   VatData.defineDurableKind(kh, () => {}, {});
-  VatData.defineDurableKindMulti(kh, () => {}, { x: {}, y: {} });
+  const kh2 = VatData.makeKindHandle();
+  VatData.defineDurableKindMulti(kh2, () => {}, { x: {}, y: {} });
   t.pass();
 });
 


### PR DESCRIPTION
It turns out that we weren't checking for double use of a kind handle.  Now we are.

Fixes #5628
