### PR TITLE
Make stopVat do less work

### DIFF
--- a/packages/SwingSet/src/liveslots/stop-vat.js
+++ b/packages/SwingSet/src/liveslots/stop-vat.js
@@ -166,6 +166,7 @@ function finalizeEverything(tools) {
   }
 }
 
+// eslint-disable-next-line no-unused-vars
 function deleteVirtualObjectsWithoutDecref({ vrm, syscall }) {
   // delete the data of all non-durable virtual objects, without
   // attempting to decrement the refcounts of the surviving
@@ -311,6 +312,15 @@ export async function releaseOldState(tools) {
   identifyExportedFacets(abandonedVrefSet, tools);
   abandonExports(abandonedVrefSet, tools);
 
+  /* Disabling the rest of this in the interest of stop-vat performance.  We
+   * expect that in the fullness of time the following will be superseded by a
+   * post-upgrade scavenger process that cleans up dead database debris
+   * incrementally, rather than taking the hit of a potentially large delay at
+   * shutdown time.  If that change happens, the below code can simply be
+   * removed.  Until then, I'm leaving it in place as scaffolding, just in case,
+   * on the theory that it will be easier to reconstruct as a unified whole
+   * without having to navigate through a confusing maze of twisty git branches.
+
   // Then we pretend userspace RAM has dropped all the vref-based
   // objects that it was holding onto.
   finalizeEverything(tools);
@@ -389,4 +399,6 @@ export async function releaseOldState(tools) {
 
     // At this point we declare sufficient victory and return.
   }
+
+  */
 }

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -126,10 +126,11 @@ const testUpgrade = async (t, defaultManagerType) => {
     const s = kvStore.get(`${vatID}.c.${kref}`);
     return parseReachableAndVatSlot(s).vatSlot;
   };
-  const krefReachable = kref => {
-    const s = kvStore.get(`${vatID}.c.${kref}`);
-    return !!(s && parseReachableAndVatSlot(s).isReachable);
-  };
+  // const krefReachable = kref => {
+  //   const s = kvStore.get(`${vatID}.c.${kref}`);
+  //   return !!(s && parseReachableAndVatSlot(s).isReachable);
+  // };
+
   // We look in the vat's vatstore to see if the virtual/durable
   // object exists or not (as a state record).
   const vomHas = vref => {
@@ -190,9 +191,12 @@ const testUpgrade = async (t, defaultManagerType) => {
   // dumpState(hostStorage, vatID);
 
   // all the merely-virtual exports should be gone
-  for (let i = 1; i < NUM_SENSORS + 1; i += 1) {
-    t.false(vomHas(virVref(i)));
-  }
+  // for (let i = 1; i < NUM_SENSORS + 1; i += 1) {
+  //   t.false(vomHas(virVref(i)));
+  // }
+
+  /* Disabling this portion of the test as it is irrelevant and non-working so
+     long as non-durable object cleanup in stop-vat is also disabled.
 
   // of the durables, only these survive
   const survivingDurables = [
@@ -247,6 +251,7 @@ const testUpgrade = async (t, defaultManagerType) => {
     // const s = kvStore.get(`${vatID}.c.${impKref}`);
     // console.log(`${i}: ${vomS} imp: ${reachS} ${matchS}  ${impKref} ${s}`);
   }
+  */
 
   // check koNN.owner to confirm the exported virtuals (2/5/7) are abandoned
   t.false(kvStore.has(`${vir2Kref}.owner`));


### PR DESCRIPTION
Closes #5342

This PR disables a bunch of machinery inside `stopVat` per the specification laid out in #5342

After much study and lengthy pondering I have persuaded myself that it _will_ be possible to perform comparable database cleaning in a post-upgrade process of some kind, details to be determined later.

The disabled code in `stopVat` has been commented out rather than removed, on the theory that later on we'll be glad of that.