### PR TITLE
feat(cosmic-swingset): Add memory stats to new commit block slog event

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1011,7 +1011,12 @@ export default function buildKernel(
   async function processDeliveryMessage(message) {
     kdebug(`processQ ${JSON.stringify(message)}`);
     kdebug(legibilizeMessage(message));
-    kernelSlog.write({ type: 'crank-start', message });
+    kernelSlog.write({
+      type: 'crank-start',
+      crankType: 'delivery',
+      crankNum: kernelKeeper.getCrankNumber(),
+      message,
+    });
     /** @type { PolicyInput } */
     let policyInput = ['none'];
     if (message.type === 'create-vat') {
@@ -1184,7 +1189,12 @@ export default function buildKernel(
   async function processAcceptanceMessage(message) {
     // kdebug(`processAcceptanceQ ${JSON.stringify(message)}`);
     // kdebug(legibilizeMessage(message));
-    kernelSlog.write({ type: 'crank-start', message });
+    kernelSlog.write({
+      type: 'crank-start',
+      crankType: 'routing',
+      crankNum: kernelKeeper.getCrankNumber(),
+      message,
+    });
     /** @type { PolicyInput } */
     const policyInput = ['none'];
 

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -1,4 +1,6 @@
 import path from 'path';
+import v8 from 'node:v8';
+import process from 'node:process';
 import { performance } from 'perf_hooks';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 import engineGC from '@agoric/swingset-vat/src/lib-nodejs/engine-gc.js';
@@ -412,10 +414,18 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       const t0 = performance.now();
       engineGC();
       const t1 = performance.now();
+      const memoryUsage = process.memoryUsage();
+      const t2 = performance.now();
+      const heapStats = v8.getHeapStatistics();
+      const t3 = performance.now();
 
       return {
+        memoryUsage,
+        heapStats,
         statsTime: {
           forcedGc: t1 - t0,
+          memoryUsage: t2 - t1,
+          heapStats: t3 - t2,
         },
       };
     };

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -1,5 +1,7 @@
 import path from 'path';
+import { performance } from 'perf_hooks';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
+import engineGC from '@agoric/swingset-vat/src/lib-nodejs/engine-gc.js';
 import { waitUntilQuiescent } from '@agoric/swingset-vat/src/lib-nodejs/waitUntilQuiescent.js';
 import {
   importMailbox,
@@ -407,7 +409,15 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       // that the commit-block reply has been sent to agcc through replier.resolve
       await waitUntilQuiescent();
 
-      return {};
+      const t0 = performance.now();
+      engineGC();
+      const t1 = performance.now();
+
+      return {
+        statsTime: {
+          forcedGc: t1 - t0,
+        },
+      };
     };
 
     const s = await launch({

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -473,6 +473,7 @@ show-config      display the client connection parameters
         'XSNAP_TEST_RECORD',
         'SWING_STORE_TRACE',
         'XSNAP_KEEP_SNAPSHOTS',
+        'NODE_HEAP_SNAPSHOTS',
       ]) {
         if (env[envName]) {
           serviceLines.push(`Environment="${envName}=${env[envName]}"`);

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -19,14 +19,12 @@ export { makeSnapStore };
 export function makeSnapStoreIO() {
   return {
     tmpName,
-    existsSync: fs.existsSync,
     createReadStream: fs.createReadStream,
     createWriteStream: fs.createWriteStream,
     open: fs.promises.open,
     rename: fs.promises.rename,
     stat: fs.promises.stat,
     unlink: fs.promises.unlink,
-    unlinkSync: fs.unlinkSync,
     resolve: path.resolve,
   };
 }
@@ -328,7 +326,7 @@ function makeSwingStore(dirPath, forceReset, options) {
     //   MUST be committed BEFORE we delete snapshot1.
     //   Otherwise, on restart, we'll consult the kvstore and see snapshot1,
     //   but we'll fail to load it because it's been deleted already.
-    snapStore.commitDeletes();
+    await snapStore.commitDeletes();
   }
 
   /**

--- a/packages/swing-store/test/test-snapstore.js
+++ b/packages/swing-store/test/test-snapstore.js
@@ -60,7 +60,7 @@ test('snapStore prepare / commit delete is robust', async t => {
   }
   t.is(fs.readdirSync(pool.name).length, 5);
 
-  t.notThrows(() => store.commitDeletes());
+  await t.notThrowsAsync(() => store.commitDeletes());
 
   // @ts-expect-error
   t.throws(() => store.prepareToDelete(1));
@@ -68,24 +68,24 @@ test('snapStore prepare / commit delete is robust', async t => {
   t.throws(() => store.prepareToDelete('/etc/passwd'));
 
   store.prepareToDelete(hashes[2]);
-  store.commitDeletes();
+  await store.commitDeletes();
   t.deepEqual(fs.readdirSync(pool.name).length, 4);
 
   // Restore (re-save) between prepare and commit.
   store.prepareToDelete(hashes[3]);
   await store.save(async fn => fs.promises.writeFile(fn, `file 3`));
-  store.commitDeletes();
+  await store.commitDeletes();
   t.true(fs.readdirSync(pool.name).includes(`${hashes[3]}.gz`));
 
   hashes.forEach(store.prepareToDelete);
   store.prepareToDelete('does not exist');
-  t.throws(() => store.commitDeletes());
+  await t.throwsAsync(() => store.commitDeletes());
   // but it deleted the rest of the files
   t.deepEqual(fs.readdirSync(pool.name), []);
 
   // ignore errors while clearing out pending deletes
-  store.commitDeletes(true);
+  await store.commitDeletes(true);
 
   // now we shouldn't see any errors
-  store.commitDeletes();
+  await store.commitDeletes();
 });

--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -78,10 +78,11 @@ async function run() {
 
   console.log(`parsing`, slogFileName);
 
+  let update = false;
   for await (const line of lines) {
     lineCount += 1;
     const obj = JSON.parse(line);
-    const update = obj.time >= progress.lastSlogTime;
+    update ||= obj.time >= progress.lastSlogTime;
     if (update) {
       progress.lastSlogTime = obj.time;
     }

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -632,12 +632,17 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         break;
       }
       case 'crank-start': {
-        const [name, crankAttrs, links] = extractMessageAttrs(
-          slogAttrs.message,
+        const { message, ...crankAttrs } = slogAttrs;
+        const [name, messageAttrs, links] = extractMessageAttrs(message);
+        spans.startNamed(
+          name,
+          getCrankKey(true),
+          spans.top(),
+          { ...crankAttrs, ...messageAttrs },
+          {
+            links,
+          },
         );
-        spans.startNamed(name, getCrankKey(true), spans.top(), crankAttrs, {
-          links,
-        });
         break;
       }
       case 'clist': {


### PR DESCRIPTION
refs: #5507

## Description

- Cleanup various otel spans, handling events that were previously not handled, and removing data that is unactionable raw (will be extended upon in a follow up PR)
- Adds a new `cosmic-swingset-commit-block-*` slog events, with their own timing
  - `commit-block-start` and `commit-block-finish` measure the time taken by cosmic-swingset to save/flush its data.
  - `after-commit-block` is an event containing post block cleanup stats related to node/v8 memory.
- Adds a `NODE_HEAP_SNAPSHOTS` environment option to control the generation of node heap snapshots after a block commit
  - `-1` (or any negative number) to disable, `0` to only trigger on large block interval (hardcoded at 30 seconds), any positive number to generate a snapshot at an interval
  - The snapshot should be generated after node has informed the go side of the block commit completion, which means it should happen while node is idle waiting for the next block (unless the cosmos node is already late)
- Forces a GC after every commit to remove variance based on local GC schedule.

### Security Considerations

This adds an option to dump the node heap, which shouldn't contain any sensitive data as it's all based on the consensus execution.

### Documentation Considerations

TBD

### Testing Considerations

Manual local testing with the loadgen deployment test, and ingest slot to otel script.
