### PR TITLE
fix(xsnap): do not leak through vat termination race

### DIFF
--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -32,6 +32,7 @@
     "@endo/eventual-send": "^0.15.5",
     "@endo/init": "^0.5.43",
     "@endo/netstring": "^0.3.13",
+    "@endo/promise-kit": "^0.2.43",
     "@endo/stream": "^0.3.12",
     "@endo/stream-node": "^0.2.13",
     "glob": "^7.1.6",


### PR DESCRIPTION
refs: #5507 

## Description

- Fixes the promise memory leak discovered through the diagnostics added in #5637

### Security Considerations

None

### Documentation Considerations

We should have some documentation for developers regarding the memory leak risks of promises.

### Testing Considerations

Tested locally with the loadgen. The snapshot does not seem to accumulate any significant program objects.
