### PR TITLE
Enforce size limits on syscalls containing capdata

### DIFF
--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -106,6 +106,7 @@ export function makeCollectionManager(
   registerValue,
   serialize,
   unserialize,
+  assertAcceptableSyscallCapdataSize,
 ) {
   // TODO(#5058): we hold a list of all collections (both virtual and
   // durable) in RAM, so we can delete the virtual ones during
@@ -361,6 +362,7 @@ export function makeCollectionManager(
       }
       currentGenerationNumber += 1;
       const serializedValue = serialize(value);
+      assertAcceptableSyscallCapdataSize([serializedValue]);
       if (durable) {
         serializedValue.slots.forEach((vref, slotIndex) => {
           if (!vrm.isDurable(vref)) {
@@ -400,6 +402,7 @@ export function makeCollectionManager(
         );
       }
       const after = serialize(harden(value));
+      assertAcceptableSyscallCapdataSize([after]);
       if (durable) {
         after.slots.forEach((vref, i) => {
           if (!vrm.isDurable(vref)) {

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -639,6 +639,7 @@ function build(
     m.serialize,
     unmeteredUnserialize,
     cacheSize,
+    assertAcceptableSyscallCapdataSize,
   );
 
   const collectionManager = makeCollectionManager(
@@ -653,6 +654,7 @@ function build(
     registerValue,
     m.serialize,
     unmeteredUnserialize,
+    assertAcceptableSyscallCapdataSize,
   );
 
   const watchedPromiseManager = makeWatchedPromiseManager(

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -157,6 +157,8 @@ export function makeCache(size, fetch, store) {
  * @param {*} unserialize  Unserializer for this vat
  * @param {number} cacheSize  How many virtual objects this manager should cache
  *   in memory.
+ * @param {*} assertAcceptableSyscallCapdataSize  Function to check for oversized
+ *   syscall params
  *
  * @returns a new virtual object manager.
  *
@@ -197,6 +199,7 @@ export function makeVirtualObjectManager(
   serialize,
   unserialize,
   cacheSize,
+  assertAcceptableSyscallCapdataSize,
 ) {
   const canBeDurable = specimen => {
     const capData = serialize(specimen);
@@ -648,6 +651,7 @@ export function makeVirtualObjectManager(
             ensureState();
             const before = innerSelf.rawState[prop];
             const after = serialize(value);
+            assertAcceptableSyscallCapdataSize([after]);
             if (durable) {
               after.slots.forEach((vref, index) => {
                 assert(
@@ -737,6 +741,7 @@ export function makeVirtualObjectManager(
       const rawState = {};
       for (const prop of Object.getOwnPropertyNames(initialData)) {
         const data = serialize(initialData[prop]);
+        assertAcceptableSyscallCapdataSize([data]);
         if (durable) {
           data.slots.forEach(vref => {
             assert(vrm.isDurable(vref), X`value for ${q(prop)} is not durable`);

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -672,7 +672,7 @@ test('capdata size limit on syscalls', async t => {
     returnTestHooks,
   );
   const { setSyscallCapdataLimits } = returnTestHooks[0];
-  setSyscallCapdataLimits(130, 2);
+  setSyscallCapdataLimits(130, 1);
 
   log.length = 0; // assume pre-build vatstore operations are correct
   const rootA = 'o+0';
@@ -683,7 +683,7 @@ test('capdata size limit on syscalls', async t => {
   await dispatch(
     makeMessage(rootA, 'sendTooManySlots', [slot0arg], [target], rp1),
   );
-  t.deepEqual(log.shift(), 'fail: syscall capdata slots array too long');
+  t.deepEqual(log.shift(), 'fail: syscall capdata too large');
   t.deepEqual(log.shift(), {
     type: 'resolve',
     resolutions: [[rp1, false, undefinedArg]],
@@ -695,7 +695,7 @@ test('capdata size limit on syscalls', async t => {
   await dispatch(
     makeMessage(rootA, 'sendBodyTooBig', [slot0arg], [target], rp2),
   );
-  t.deepEqual(log.shift(), 'fail: syscall capdata body too large');
+  t.deepEqual(log.shift(), 'fail: syscall capdata too large');
   t.deepEqual(log.shift(), {
     type: 'resolve',
     resolutions: [[rp2, false, undefinedArg]],
@@ -706,7 +706,7 @@ test('capdata size limit on syscalls', async t => {
   await dispatch(
     makeMessage(rootA, 'callTooManySlots', [slot0arg], [device], rp3),
   );
-  t.deepEqual(log.shift(), 'fail: syscall capdata slots array too long');
+  t.deepEqual(log.shift(), 'fail: syscall capdata too large');
   t.deepEqual(log.shift(), {
     type: 'resolve',
     resolutions: [[rp3, false, undefinedArg]],
@@ -717,7 +717,7 @@ test('capdata size limit on syscalls', async t => {
   await dispatch(
     makeMessage(rootA, 'callBodyTooBig', [slot0arg], [device], rp4),
   );
-  t.deepEqual(log.shift(), 'fail: syscall capdata body too large');
+  t.deepEqual(log.shift(), 'fail: syscall capdata too large');
   t.deepEqual(log.shift(), {
     type: 'resolve',
     resolutions: [[rp4, false, undefinedArg]],
@@ -742,7 +742,7 @@ test('capdata size limit on syscalls', async t => {
   t.deepEqual(log.shift(), {
     type: 'exit',
     isFailure: true,
-    info: Error('syscall capdata slots array too long'),
+    info: Error('syscall capdata too large'),
   });
   t.deepEqual(log.shift(), {
     type: 'resolve',
@@ -768,7 +768,7 @@ test('capdata size limit on syscalls', async t => {
   t.deepEqual(log.shift(), {
     type: 'exit',
     isFailure: true,
-    info: Error('syscall capdata body too large'),
+    info: Error('syscall capdata too large'),
   });
   t.deepEqual(log.shift(), {
     type: 'resolve',
@@ -781,7 +781,7 @@ test('capdata size limit on syscalls', async t => {
   t.deepEqual(log.shift(), {
     type: 'exit',
     isFailure: true,
-    info: Error('syscall capdata slots array too long'),
+    info: Error('syscall capdata too large'),
   });
   t.deepEqual(log, []);
 
@@ -790,7 +790,7 @@ test('capdata size limit on syscalls', async t => {
   t.deepEqual(log.shift(), {
     type: 'exit',
     isFailure: true,
-    info: Error('syscall capdata body too large'),
+    info: Error('syscall capdata too large'),
   });
   t.deepEqual(log, []);
 });
@@ -1599,7 +1599,7 @@ test('promise cycle', async t => {
   t.deepEqual(log, []);
 });
 
-test.serial('unserializable promise resolution', async t => {
+test('unserializable promise resolution', async t => {
   // method-bearing objects must be marked as Far, else they cannot be
   // serialized
   const unserializable = harden({ deliberate: () => {} });
@@ -1660,7 +1660,7 @@ test.serial('unserializable promise resolution', async t => {
   t.deepEqual(l2.resolutions[0], [expectedPA, true, expectedError]);
 });
 
-test.serial('unserializable promise rejection', async t => {
+test('unserializable promise rejection', async t => {
   // method-bearing objects must be marked as Far, else they cannot be
   // serialized
   const unserializable = harden({ deliberate: () => {} });

--- a/packages/SwingSet/tools/fakeCollectionManager.js
+++ b/packages/SwingSet/tools/fakeCollectionManager.js
@@ -17,6 +17,7 @@ export function makeFakeCollectionManager(vrm, fakeStuff, _options = {}) {
     fakeStuff.registerEntry,
     fakeStuff.marshal.serialize,
     fakeStuff.marshal.unserialize,
+    fakeStuff.assertAcceptableSyscallCapdataSize,
   );
   initializeStoreKindInfo();
 

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -34,6 +34,7 @@ export function makeFakeVirtualObjectManager(vrm, fakeStuff, options = {}) {
     fakeStuff.marshal.serialize,
     fakeStuff.marshal.unserialize,
     cacheSize,
+    fakeStuff.assertAcceptableSyscallCapdataSize,
   );
 
   const normalVOM = {

--- a/packages/SwingSet/tools/fakeVirtualSupport.js
+++ b/packages/SwingSet/tools/fakeVirtualSupport.js
@@ -224,6 +224,8 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     valToSlot.delete(val);
   }
 
+  function assertAcceptableSyscallCapdataSize(_capdatas) {}
+
   return {
     syscall,
     allocateExportID,
@@ -243,6 +245,7 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     addToPossiblyRetiredSet,
     dumpStore,
     setVrm,
+    assertAcceptableSyscallCapdataSize,
   };
 }
 


### PR DESCRIPTION
Per #3242 these changes add limits to the size of the `body` string and `slots` array of capdata parameters to the syscalls that contain capdata (`send`, `callNow`, and `resolve`).  In the case of `send` and `callNow`, overflowing either of these limits throws an exception.  In the case of `resolve` it forces an error exit on the offending vat.

Closes #3242