### PR TITLE
fix(swingset): decrement kernelObjects stat when deleting an object

### DIFF
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -556,11 +556,14 @@ export default function makeKernelKeeper(
     const ownerVat = kvStore.get(ownerKey);
     assert.equal(ownerVat, oldVat, `export ${kref} not owned by old vat`);
     kvStore.delete(ownerKey);
+    // note that we do not delete the object here: it will be
+    // colelcted if/when all other references are dropped
   }
 
   function deleteKernelObject(koid) {
     kvStore.delete(`${koid}.owner`);
     kvStore.delete(`${koid}.refCount`);
+    decStat('kernelObjects');
     // TODO: decref auxdata slots and delete auxdata, when #2069 is added
   }
 

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -526,6 +526,7 @@ test('kernelKeeper promises', async t => {
   t.deepEqual(k2.getKernelPromise(p1).queue, [m1, m2]);
 
   const ko = k.addKernelObject('v1');
+  t.is(k.getStats().kernelObjects, 1);
   // when we resolve the promise, all its queued messages are moved to the
   // run-queue, and its refcount remains the same
   const capdata = harden({
@@ -569,6 +570,9 @@ test('kernelKeeper promises', async t => {
     ['kernel.snapshotInterval', '200'],
     ['meter.nextID', '1'],
   ]);
+
+  k.deleteKernelObject(ko);
+  t.is(k.getStats().kernelObjects, 0);
 });
 
 test('kernelKeeper promise resolveToData', async t => {


### PR DESCRIPTION
Oops, we incremented this counter, but never decremented it. So our
reported `kernelObjects` value was drastically inflated, making it
look like we were leaking objects, when we probably aren't.

closes #5652
