### PR TITLE
Guard netstring decode with an optional max size

### DIFF
--- a/packages/SwingSet/src/lib-nodejs/spawnSubprocessWorker.js
+++ b/packages/SwingSet/src/lib-nodejs/spawnSubprocessWorker.js
@@ -23,6 +23,8 @@ function parentLog(first, ...args) {
 // always be Node.
 const stdio = harden(['inherit', 'inherit', 'inherit', 'pipe', 'pipe']);
 
+const NETSTRING_MAX_CHUNK_SIZE = 12_000_000;
+
 export function startSubprocessWorker(execPath, procArgs = []) {
   const proc = spawn(execPath, procArgs, { stdio });
 
@@ -30,7 +32,7 @@ export function startSubprocessWorker(execPath, procArgs = []) {
   toChild.pipe(netstringEncoderStream()).pipe(proc.stdio[3]);
   // proc.stdio[4].setEncoding('utf-8');
   const fromChild = proc.stdio[4]
-    .pipe(netstringDecoderStream())
+    .pipe(netstringDecoderStream(NETSTRING_MAX_CHUNK_SIZE))
     .pipe(arrayDecoderStream());
 
   // fromChild.addListener('data', data => parentLog(`fd4 data`, data));

--- a/packages/SwingSet/test/test-netstring.js
+++ b/packages/SwingSet/test/test-netstring.js
@@ -81,7 +81,7 @@ test('decode', t => {
     const encPayloads = expPayloads.map(Buffer.from);
     const encLeftover = Buffer.from(expLeftover);
 
-    const { payloads, leftover } = decode(Buffer.from(input));
+    const { payloads, leftover } = decode(Buffer.from(input), 25);
     t.deepEqual(payloads, encPayloads);
     t.deepEqual(leftover, encLeftover);
   }
@@ -102,12 +102,13 @@ test('decode', t => {
   eq(expectedBuffer, [emoji], '');
 
   function bad(input, message) {
-    t.throws(() => decode(Buffer.from(input)), { message });
+    t.throws(() => decode(Buffer.from(input), 25), { message });
   }
 
   // bad('a', 'non-numeric length prefix');
   bad('a:', /unparseable size .*, should be integer/);
   bad('1:ab', 'malformed netstring: not terminated by comma');
+  bad('26:x', /size .* exceeds limit of 25/);
 });
 
 test('decode stream', async t => {


### PR DESCRIPTION
Per #3242 this puts a length check on the netstring decoder associated with the streams from worker processes to the kernel.

For now I've set this to 12,000,000 on the theory that given the capdata limits implemented in #5651 of 10,000,000 bytes for the body string plus 10,000 slot entries, overflowing this would require a full body string plus 10,000 slots with vrefs averaging 200 bytes each.  I think this is unlikely to happen by accident.