### PR TITLE
feat(wallet/ui): localStorage bridge functional in AMM (WIP)

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -122,6 +122,21 @@ for the Prometheus scrape endpoint to export telemetry.
 
 Lifetime: until we decide not to support Prometheus for metrics export
 
+## SOLO_BRIDGE_TARGET
+
+Affects: solo
+
+Until dApps are converted to connect to the smart-wallet UI directly,
+this allows them to continue to connect to `/wallet-bridge.html` and such
+on the solo and have these endpoints serviced by `/wallet/bridge.html`
+and such in a wallet UI.
+
+```
+BRIDGE_TARGET=http://localhost:3001 make BASE_PORT=8002 scenario3-run
+```
+
+Lifetime: smart wallet transition period
+
 ## SOLO_LMDB_MAP_SIZE
 
 Affects: solo

--- a/packages/casting/README.md
+++ b/packages/casting/README.md
@@ -13,7 +13,7 @@ An example of following an on-chain mailbox in code (using this package) is:
 ```js
 // First, obtain a Hardened JS environment via Endo.
 import '@endo/init/pre-remoting.js'; // needed only for the next line
-import '@agoric/castingSpec/node-fetch-shim.js'; // needed for Node.js
+import '@agoric/casting/node-fetch-shim.js'; // needed for Node.js
 import '@endo/init';
 
 import {

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -45,6 +45,7 @@
     "deterministic-json": "^1.0.5",
     "esm": "agoric-labs/esm#Agoric-built",
     "express": "^4.17.1",
+    "http-proxy-middleware": "^2.0.6",
     "import-meta-resolve": "^1.1.1",
     "minimist": "^1.2.0",
     "morgan": "^1.9.1",

--- a/packages/wallet/api/src/wallet.js
+++ b/packages/wallet/api/src/wallet.js
@@ -332,7 +332,11 @@ export function buildRootObject(vatPowers) {
       },
       getDepositFacetId: walletAdmin.getDepositFacetId,
       getAdminFacet() {
-        return Far('adminFacet', { ...walletAdmin, ...notifiers });
+        return Far('adminFacet', {
+          ...walletAdmin,
+          ...notifiers,
+          getScopedBridge: wallet.getScopedBridge,
+        });
       },
       getIssuer: walletAdmin.getIssuer,
       getIssuers: walletAdmin.getIssuers,

--- a/packages/wallet/ui/config-overrides/index.js
+++ b/packages/wallet/ui/config-overrides/index.js
@@ -1,5 +1,52 @@
+// cribbed from https://www.npmjs.com/package/react-app-rewire-multiple-entry
+/* global __dirname, require, module */
+
+const path = require('path');
+const HtmlWebPackPlugin = require('html-webpack-plugin');
+const multiEntry = require('react-app-rewire-multiple-entry');
+
+const bridgeTemplate = path.resolve(
+  path.join(__dirname, '..', 'public', 'bridge.html'),
+);
+
+const multipleEntry = multiEntry([
+  {
+    template: 'public/index.html',
+    entry: 'src/index.jsx',
+  },
+  {
+    template: 'public/bridge.html',
+    entry: 'src/bridge.jsx',
+  },
+]);
+
 module.exports = function override(config, _env) {
   config.resolve.fallback = { path: false, crypto: false };
   config.ignoreWarnings = [/Failed to parse source map/];
+
+  const htmlWebpackPlugin = config.plugins.find(
+    plugin => plugin.constructor.name === 'HtmlWebpackPlugin',
+  );
+  if (!htmlWebpackPlugin) {
+    throw new Error("Can't find HtmlWebpackPlugin");
+  }
+
+  multipleEntry.addMultiEntry(config);
+
+  const bridgeKeys = Object.keys(config.entry).filter(k =>
+    k.startsWith('bridge'),
+  );
+  const opts = {
+    ...htmlWebpackPlugin.userOptions,
+    template: bridgeTemplate,
+    filename: './bridge.html',
+    chunks: bridgeKeys,
+  };
+  htmlWebpackPlugin.userOptions = {
+    ...htmlWebpackPlugin.userOptions,
+    excludeChunks: bridgeKeys,
+  };
+  const plug2 = new HtmlWebPackPlugin(opts);
+  config.plugins.push(plug2);
   return config;
 };

--- a/packages/wallet/ui/package.json
+++ b/packages/wallet/ui/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "process": "^0.11.10",
     "react": "^16.8.0",
+    "react-app-rewire-multiple-entry": "^2.2.3",
     "react-app-rewired": "^2.2.1",
     "react-dom": "^16.8.0",
     "react-router-dom": "^5.3.0",

--- a/packages/wallet/ui/public/bridge.html
+++ b/packages/wallet/ui/public/bridge.html
@@ -5,11 +5,39 @@
     <meta charset="utf-8" />
     <script src="%PUBLIC_URL%/lockdown.umd.js"></script>
     <title>Agoric Wallet Bridge</title>
+    <style>
+        .logo {
+            object-fit: contain;
+        }
+
+        .expand100 {
+            height: 100%;
+            width: 100%;
+        }
+
+        .pulse {
+            animation: pulse 2s infinite;
+        }
+
+        @keyframes pulse {
+            0% {
+                opacity: 100%;
+            }
+
+            50% {
+                opacity: 0%;
+            }
+
+            100% {
+                opacity: 100%;
+            }
+        }
+    </style>
 </head>
 
-<body style="overflow-x: hidden; overflow-y: scroll">
+<body class="expand100">
     <noscript>Without JavaScript enabled, this page cannot function.</noscript>
-    <div id="root"></div>
+    <div id="root" class="expand100"></div>
 </body>
 
 </html>

--- a/packages/wallet/ui/public/bridge.html
+++ b/packages/wallet/ui/public/bridge.html
@@ -4,34 +4,12 @@
 <head>
     <meta charset="utf-8" />
     <script src="%PUBLIC_URL%/lockdown.umd.js"></script>
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Agoric wallet" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Agoric Wallet Bridge!@@@</title>
+    <title>Agoric Wallet Bridge</title>
 </head>
 
 <body style="overflow-x: hidden; overflow-y: scroll">
-    <noscript>This app isn't much use without JavaScript.</noscript>
+    <noscript>Without JavaScript enabled, this page cannot function.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
 </body>
 
 </html>

--- a/packages/wallet/ui/public/bridge.html
+++ b/packages/wallet/ui/public/bridge.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <script src="%PUBLIC_URL%/lockdown.umd.js"></script>
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Agoric wallet" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <title>Agoric Wallet Bridge!@@@</title>
+</head>
+
+<body style="overflow-x: hidden; overflow-y: scroll">
+    <noscript>This app isn't much use without JavaScript.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+</body>
+
+</html>

--- a/packages/wallet/ui/src/bridge.jsx
+++ b/packages/wallet/ui/src/bridge.jsx
@@ -6,6 +6,8 @@ import './lockdown.js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import logo from './Agoric-logo-color.svg';
+
 Error.stackTraceLimit = Infinity;
 
 /** ISSUE: where are these defined? */
@@ -19,37 +21,27 @@ const BridgeProtocol = /** @type {const} */ ({
  * the dApp are forwarded to localStorage and vice versa.
  *
  * @param {{
- *   sameParent: () => boolean,
  *   addEventListener: typeof window.addEventListener,
- *   storage: typeof window.localStorage,
  *   parentPost: typeof window.postMessage,
  *   t0: number,
  * }} io
  */
-const installDappConnection = async ({
-  addEventListener,
-  sameParent,
-  parentPost,
-  storage,
-  t0,
-}) => {
+const installDappConnection = ({ addEventListener, parentPost, t0 }) => {
   /** @type { string } */
   let origin;
+  let setItem;
+  const buffer = [];
 
-  console.debug('bridge: installDappConnection');
-
-  if (sameParent()) {
-    // console.debug('bridge: ignored message to self');
-    return;
-  }
-
-  parentPost({ type: BridgeProtocol.loaded }, '*');
-  parentPost({ type: BridgeProtocol.opened }, '*');
+  console.debug('bridge: installDappConnection', new Date(t0).toISOString());
 
   let outIx = 0; // TODO: persist index in storage
-  /** @param {Record<string, any>} payload */
-
   const { stringify, parse } = JSON;
+  /** @param {Record<string, any>} payload */
+  const send = payload => {
+    // console.debug('bridge: send', payload);
+    setItem(stringify(['out', origin, t0, outIx]), stringify(payload));
+    outIx += 1; // ISSUE: overflow?
+  };
 
   addEventListener('message', ev => {
     // console.debug('bridge: handling message:', ev.data);
@@ -66,36 +58,102 @@ const installDappConnection = async ({
       // console.debug('bridge: setting origin to', origin);
       origin = ev.origin;
     }
-    console.debug('bridge: message from dapp->localStorage', origin, ev.data);
-    storage.setItem(stringify(['out', origin, t0, outIx]), stringify(ev.data));
-    outIx += 1; // ISSUE: overflow?
+    if (setItem) {
+      console.debug('bridge: message from dapp->localStorage', origin, ev.data);
+      send(ev.data);
+    } else {
+      buffer.push(ev.data);
+      outIx += 1; // ISSUE: overflow?
+    }
   });
 
-  addEventListener('storage', ev => {
-    // console.debug('from storage', origin, ev.key, ev.newValue);
-    if (!ev.key || !ev.newValue) {
-      return;
-    }
-    const [tag, targetOrigin, targetT, _keyIx] = JSON.parse(ev.key); // or throw
-    if (tag !== 'in' || targetOrigin !== origin || targetT !== t0) {
-      return;
-    }
-    const payload = parse(ev.newValue); // or throw
-    storage.removeItem(ev.key);
-    console.debug('bridge: storage -> message to dapp', origin, payload);
-    parentPost(payload, '*');
-  });
+  // ISSUE: this fires much earlier than expected.
+  // addEventListener('beforeunload', () => {
+  //   const bye = { type: 'CTP_DISCONNECT', reason: `bye from ${origin}` };
+  //   parentPost(bye, '*');
+  // });
+
+  console.debug('bridge: Start the flow of messages.');
+  parentPost({ type: BridgeProtocol.loaded }, '*');
+  // ISSUE: wallet-bridge.html waits for the websocket side to open
+  // before sending this, but if we wait for the storage side to open,
+  // it doesn't seem to work.
+  parentPost({ type: BridgeProtocol.opened }, '*');
+
+  return {
+    /** @param {typeof window.localStorage} storage */
+    connectStorage: storage => {
+      if (setItem) {
+        return;
+      }
+
+      addEventListener('storage', ev => {
+        // console.debug('from storage', origin, ev.key, ev.newValue);
+        if (!ev.key || !ev.newValue) {
+          return;
+        }
+        const [tag, targetOrigin, targetT, _keyIx] = JSON.parse(ev.key); // or throw
+        if (tag !== 'in' || targetOrigin !== origin || targetT !== t0) {
+          return;
+        }
+        const payload = parse(ev.newValue); // or throw
+        storage.removeItem(ev.key);
+        console.debug('bridge: storage -> message to dapp', origin, payload);
+        parentPost(payload, '*');
+      });
+      setItem = (k, v) => storage.setItem(k, v);
+      if (buffer.length) {
+        console.debug('sending', buffer.length, 'queued messages from', origin);
+      }
+      while (buffer.length) {
+        send(buffer.shift());
+      }
+    },
+  };
 };
 
-installDappConnection({
+const conn = installDappConnection({
   addEventListener: window.addEventListener,
-  sameParent: () => window.parent === window,
-  parentPost: (payload, origin) => window.parent.postMessage(payload, origin),
-  storage: window.localStorage,
+  parentPost: (payload, origin) =>
+    window.parent !== window
+      ? window.parent.postMessage(payload, origin)
+      : undefined,
   t0: Date.now(),
 });
 
+const signalWallet = () => {
+  if ('requestStorageAccess' in document) {
+    document
+      .requestStorageAccess()
+      .then(() => {
+        console.debug('bridge: storage access granted');
+        conn.connectStorage(window.localStorage);
+      })
+      .catch(whyNot =>
+        console.error('bridge: requestStorageAccess rejected with', whyNot),
+      );
+  } else {
+    console.debug('bridge: SKIP document.requestStorageAccess');
+    conn.connectStorage(window.localStorage);
+  }
+
+  // TODO: get URL from local.agoric.com
+  // use 'locating' protocol from packages/web-components/src/AgoricWalletConnection.js
+  // onLocateMessage
+
+  // ISSUE: is this causing the wallet bridge to reload???
+  const walletAddress = 'http://localhost:8002/wallet/'; // ISSUE: how to get this???
+  window.open(walletAddress, 'target_agoric_wallet');
+};
+
+// TODO: pulse as state
+// TODO: logo centered; aspect ratio preserved; no iframe scrollbar
 ReactDOM.render(
-  <button id="signalBridge">Signal Bridge</button>,
+  <img
+    className="pulse logo expand100"
+    src={logo}
+    onClick={signalWallet}
+    alt="Agoric logo"
+  />,
   document.getElementById('root'),
 );

--- a/packages/wallet/ui/src/bridge.jsx
+++ b/packages/wallet/ui/src/bridge.jsx
@@ -1,0 +1,101 @@
+// @ts-check
+/* eslint-disable import/no-extraneous-dependencies */
+import '@endo/eventual-send/shim';
+import './lockdown.js';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+Error.stackTraceLimit = Infinity;
+
+/** ISSUE: where are these defined? */
+const BridgeProtocol = /** @type {const} */ ({
+  loaded: 'walletBridgeLoaded',
+  opened: 'walletBridgeOpened',
+});
+
+/**
+ * Install a dApp "connection" where messages posted from
+ * the dApp are forwarded to localStorage and vice versa.
+ *
+ * @param {{
+ *   sameParent: () => boolean,
+ *   addEventListener: typeof window.addEventListener,
+ *   storage: typeof window.localStorage,
+ *   parentPost: typeof window.postMessage,
+ *   t0: number,
+ * }} io
+ */
+const installDappConnection = async ({
+  addEventListener,
+  sameParent,
+  parentPost,
+  storage,
+  t0,
+}) => {
+  /** @type { string } */
+  let origin;
+
+  console.debug('bridge: installDappConnection');
+
+  if (sameParent()) {
+    // console.debug('bridge: ignored message to self');
+    return;
+  }
+
+  parentPost({ type: BridgeProtocol.loaded }, '*');
+  parentPost({ type: BridgeProtocol.opened }, '*');
+
+  let outIx = 0; // TODO: persist index in storage
+  /** @param {Record<string, any>} payload */
+
+  const { stringify, parse } = JSON;
+
+  addEventListener('message', ev => {
+    // console.debug('bridge: handling message:', ev.data);
+    if (
+      !ev.data ||
+      typeof ev.data.type !== 'string' ||
+      !ev.data.type.startsWith('CTP_')
+    ) {
+      return;
+    }
+
+    if (origin === undefined) {
+      // First-come, first-serve.
+      // console.debug('bridge: setting origin to', origin);
+      origin = ev.origin;
+    }
+    console.debug('bridge: message from dapp->localStorage', origin, ev.data);
+    storage.setItem(stringify(['out', origin, t0, outIx]), stringify(ev.data));
+    outIx += 1; // ISSUE: overflow?
+  });
+
+  addEventListener('storage', ev => {
+    // console.debug('from storage', origin, ev.key, ev.newValue);
+    if (!ev.key || !ev.newValue) {
+      return;
+    }
+    const [tag, targetOrigin, targetT, _keyIx] = JSON.parse(ev.key); // or throw
+    if (tag !== 'in' || targetOrigin !== origin || targetT !== t0) {
+      return;
+    }
+    const payload = parse(ev.newValue); // or throw
+    storage.removeItem(ev.key);
+    console.debug('bridge: storage -> message to dapp', origin, payload);
+    parentPost(payload, '*');
+  });
+};
+
+installDappConnection({
+  addEventListener: window.addEventListener,
+  sameParent: () => window.parent === window,
+  parentPost: (payload, origin) => window.parent.postMessage(payload, origin),
+  storage: window.localStorage,
+  t0: Date.now(),
+});
+
+ReactDOM.render(
+  <button id="signalBridge">Signal Bridge</button>,
+  document.getElementById('root'),
+);

--- a/packages/wallet/ui/src/lockdown.js
+++ b/packages/wallet/ui/src/lockdown.js
@@ -1,0 +1,25 @@
+// Allow the React dev environment to extend the console for debugging
+// features.
+// eslint-disable-next-line no-constant-condition
+const consoleTaming = '%NODE_ENV%' === 'production' ? 'safe' : 'unsafe';
+
+// eslint-disable-next-line no-restricted-properties
+const { pow: mathPow } = Math;
+// eslint-disable-next-line no-restricted-properties
+Math.pow = (base, exp) =>
+  typeof base === 'bigint' && typeof exp === 'bigint'
+    ? base ** exp
+    : mathPow(base, exp);
+
+lockdown({
+  __allowUnsafeMonkeyPatching__: 'unsafe',
+  errorTaming: 'unsafe',
+  overrideTaming: 'severe',
+  consoleTaming,
+});
+
+console.log('lockdown done.');
+
+window.addEventListener('unhandledrejection', ev => {
+  ev.stopImmediatePropagation();
+});

--- a/packages/web-components/demo/index.html
+++ b/packages/web-components/demo/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="en-GB">
+
 <head>
   <meta charset="utf-8">
   <style>
@@ -8,6 +9,7 @@
     }
   </style>
 </head>
+
 <body>
   <div id="demo"></div>
 
@@ -15,12 +17,9 @@
     import './install-ses-lockdown.js';
 
     import { E } from '@endo/eventual-send';
-    // import { makeFollower, iterateLatest } from '@agoric/casting';
     import { html, render } from 'lit';
     import '../agoric-wallet-connection.js';
 
-     // FIXME import these @agoric/casting when it doesn't crash our browser.
-    const { makeFollower, iterateLatest } = {};
     const demo = document.querySelector('#demo');
 
     const cmds = [];
@@ -29,11 +28,10 @@
     const c = new Compartment({ E, h: history, makeFollower, iterateLatest });
 
     const onState = ev => {
-      const { cache, makeDefaultLeader, walletConnection, state } = ev.detail;
+      const { cache, walletConnection, state } = ev.detail;
       c.globalThis.state = state;
       c.globalThis.walletConnection = walletConnection;
       c.globalThis.cache = cache;
-      c.globalThis.makeDefaultLeader = makeDefaultLeader;
     };
 
     const onKeyPress = ev => {
@@ -57,8 +55,6 @@
               <dd>the wallet connection</dd>
               <dt>cache</dt>
               <dd>the bridge or admin cache</dd>
-              <dt>makeDefaultLeader</dt>
-              <dd>the default <tt>@agoric/casting</tt> leader</dd>
               <dt>state</dt>
               <dd>the wallet connection state</dd>
               <dt>E(x).method(...args)</dt>
@@ -68,11 +64,11 @@
           <hr />
           <ol start="0">
             ${cmds.map(
-              (cmd, i) =>
-                html`
+          (cmd, i) =>
+            html`
                   <li>${cmd}<br />${history[i]}</li>
                 `,
-            )}
+        )}
           </ol>
           h[${cmds.length}]>&nbsp;<input
             type="text"
@@ -107,4 +103,5 @@
     rerender();
   </script>
 </body>
+
 </html>

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@agoric/assert": "^0.4.0",
     "@agoric/cache": "^0.1.0",
-    "@agoric/casting": "^0.1.0",
     "@endo/captp": "^2.0.7",
     "@endo/marshal": "^0.6.7",
     "@endo/promise-kit": "^0.2.41",

--- a/packages/web-components/src/AgoricWalletConnection.js
+++ b/packages/web-components/src/AgoricWalletConnection.js
@@ -4,7 +4,6 @@ import { html, css, LitElement } from 'lit';
 
 import { assert, details as X } from '@agoric/assert';
 import { makeCache } from '@agoric/cache';
-import { makeLeader } from '@agoric/casting/src/leader-netconfig.js';
 import { makeCapTP as defaultMakeCapTP } from '@endo/captp';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
@@ -72,13 +71,6 @@ export const makeAgoricWalletConnection = (makeCapTP = defaultMakeCapTP) =>
 
       this.service.send({ type: 'reset' });
       this.isResetting = false;
-    }
-
-    get makeDefaultLeader() {
-      if (!this._makeDefaultLeader) {
-        this._makeDefaultLeader = leaderOptions => makeLeader(leaderOptions);
-      }
-      return this._makeDefaultLeader;
     }
 
     get cache() {
@@ -160,7 +152,6 @@ export const makeAgoricWalletConnection = (makeCapTP = defaultMakeCapTP) =>
             state: this.machine.state.name,
             walletConnection: this.walletConnection,
             cache: this.cache,
-            makeDefaultLeader: this.makeDefaultLeader,
           },
         });
         this.dispatchEvent(ev);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: #XXXX _IOU_

## Description

TODO:
 - [ ] when opening the wallet UI, iterate over existing localStorage data (send it)
 - [ ] storage request API: don't try to listen to localStorage until user guesture (w/pulse animation). open wallet UI in a new tab... or new window?
 - [x] clean up debugging, ambient authority

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
