### PR TITLE
chore(swingset): misc-tools need LMDB pre-import now

### DIFF
--- a/packages/SwingSet/misc-tools/correlate-timestamps.py
+++ b/packages/SwingSet/misc-tools/correlate-timestamps.py
@@ -1,0 +1,189 @@
+import sys, json, gzip, re, time
+from collections import defaultdict
+from pprint import pprint
+
+# Point this at a slogfile, and optionally a vatid to filter upon. It
+# will produce a report per delivery that breaks out the various times
+# spent processing within the worker, piping message to/from the
+# kernel process, and waiting for the kernel to respond to syscalls.
+
+class Syscall:
+    def __init__(self, vsc, num, rx_request):
+        self.num = num
+        self.vsc = vsc
+        self.tx_request = None
+        self.rx_request = rx_request
+        self.tx_result = None
+        self.rx_result = None
+        if vsc[0] == "send":
+            target = vsc[1]
+            msg = vsc[2]
+            methargsCD = msg["methargs"]
+            method = json.loads(methargsCD["body"])[0]
+            result = msg.get("result")
+            self.description = "(%s).%s -> %s" % (target, method, result)
+        elif vsc[0] == "callNow":
+            target = vsc[1]
+            method = vsc[2]
+            self.description = "D(%s).%s" % (target, method)
+        elif vsc[0] == "subscribe":
+            vpid = vsc[1]
+            self.description = "subscribe(%s)" % vpid
+        elif vsc[0] == "resolve":
+            vpid_strings = []
+            for [vpid, reject, data] in vsc[1]:
+                r = "!" if reject else ""
+                vpid_strings.append(r + vpid)
+            self.description = "resolve %s" % ",".join(vpid_strings)
+        elif vsc[0] in ["dropImports", "retireImports", "retireExports"]:
+            self.description = "%s(%s)" % (vsc[0], ",".join(vsc[1]))
+        else:
+            self.description = vsc[0]
+    def got_result(self, when):
+        self.tx_result = when
+    def set_tx_request(self, when):
+        self.tx_request = when
+    def set_rx_result(self, when):
+        self.rx_result = when
+
+class Delivery:
+    def __init__(self, cranknum, vd, when):
+        self.cranknum = cranknum
+        self.syscalls = []
+        self.tx_delivery = when
+        self.rx_delivery = None
+        self.tx_result = None
+        self.rx_result = None
+        self.vd = vd
+        if vd[0] == "message":
+            target = vd[1]
+            msg = vd[2]
+            methargsCD = msg["methargs"]
+            method = json.loads(methargsCD["body"])[0]
+            result = msg.get("result")
+            self.description = "(%s).%s -> %s" % (target, method, result)
+        elif vd[0] == "notify":
+            vpid_strings = []
+            for [vpid, reject, data] in vd[1]:
+                r = "!" if reject else ""
+                vpid_strings.append(r + vpid)
+            self.description = "notify %s" % ",".join(vpid_strings)
+        else:
+            self.description = vd[0]
+    def add_syscall(self, vsc, when):
+        num = len(self.syscalls)
+        s = Syscall(vsc, num, when)
+        self.syscalls.append(s)
+    def num_syscalls(self):
+        return len(self.syscalls)
+    def get_syscall(self, which):
+        return self.syscalls[which]
+    def set_rx_result(self, when):
+        self.rx_result = when
+    def set_rx_delivery(self, when):
+        self.rx_delivery = when
+    def set_tx_result(self, when):
+        self.tx_result = when
+
+fn = sys.argv[1]
+vatID = sys.argv[2] if len(sys.argv) > 2 else None
+
+deliveries = []
+
+opener = gzip.open if fn.endswith(".gz") else open
+with opener(sys.argv[1]) as f:
+    for line in f:
+        if isinstance(line, bytes):
+            line = line.decode("utf-8")
+        if not line.strip():
+            continue
+
+        data = json.loads(line.strip())
+        if vatID and data["vatID"] != vat:
+            continue
+        type = data["type"]
+        when = data["time"]
+
+        if type == 'deliver':
+            cranknum = data["crankNum"]
+            deliverynum = data["deliveryNum"]
+            d = Delivery(cranknum, data["vd"], when)
+            deliveries.append(d)
+        if type == 'syscall':
+            deliveries[-1].add_syscall(data['vsc'], when)
+        if type == 'syscall-result':
+            deliveries[-1].get_syscall(-1).got_result(when)
+        if type == 'deliver-result':
+            deliveries[-1].set_rx_result(when)
+            dr = data["dr"]
+            mr = dr[2]
+            if mr and "timestamps" in dr[2]:
+                timestamps = mr["timestamps"]
+                d = deliveries[-1]
+                if len(timestamps):
+                    d.set_rx_delivery(timestamps.pop(0))
+                for syscallnum in range(d.num_syscalls()):
+                    s = d.get_syscall(syscallnum)
+                    if len(timestamps):
+                        s.set_tx_request(timestamps.pop(0))
+                    if len(timestamps):
+                        s.set_rx_result(timestamps.pop(0))
+                if len(timestamps):
+                    d.set_tx_result(timestamps.pop(0))
+
+fill = "                         "
+prev_d = None
+for d in deliveries:
+    total_worker = 0
+    total_kernel = 0
+    total_pipe = 0
+    if prev_d:
+        kerneltime = d.tx_delivery - prev_d.rx_result
+        print("                                          %.6f kern between-cranks" % kerneltime)
+    prev_d = d
+    print("c%d %s" % (d.cranknum, d.description))
+    if d.rx_delivery:
+        print("                                                          k -> %.6f -> w   (send delivery)" % (d.rx_delivery - d.tx_delivery))
+        #d.tx_result - d.rx_delivery,
+        total_pipe += (d.rx_delivery - d.tx_delivery)
+    else:
+        print("                                             k -> w   (send delivery)")
+    prev_s = None
+    for s in d.syscalls:
+        if not prev_s and d.rx_delivery and s.tx_request:
+            print("%s%.6f worker" % (fill, s.tx_request - d.rx_delivery))
+            total_worker += (s.tx_request - d.rx_delivery)
+        if prev_s and prev_s.rx_result and s.tx_request:
+            print("%s%.6f worker" % (fill, s.tx_request - prev_s.rx_result))
+            total_worker += (s.tx_request - prev_s.rx_result)
+        prev_s = s
+        if s.tx_request and s.rx_result:
+            print("   w -> %.6f -> k,                    %.6f kern,  k -> %.6f -> w : %s" % (
+                s.rx_request - s.tx_request,
+                s.tx_result - s.rx_request,
+                s.rx_result - s.tx_result,
+                s.description))
+            total_pipe += (s.rx_request - s.tx_request)
+            total_kernel += (s.tx_result - s.rx_request)
+            total_pipe += (s.rx_result - s.tx_result)
+        else:
+            print("  w -> k,                    %.6f kern,  k -> w : %s" % (
+                s.tx_result - s.rx_request,
+                s.description))
+    if prev_s and d.tx_result:
+        print("%s%.6f worker" % (fill, d.tx_result - prev_s.rx_result))
+        total_worker += (d.tx_result - prev_s.rx_result)
+    if not prev_s and d.tx_result:
+        print("%s%.6f worker" % (fill, d.tx_result - d.rx_delivery))
+        total_worker += (d.tx_result - d.rx_delivery)
+    if d.tx_result:
+        print("   w -> %.6f -> k                                                          (return result)" % (d.rx_result - d.tx_result))
+        total_pipe += (d.rx_result - d.tx_result)
+    else:
+        print("  w -> k                                              (return result)")
+    k_to_k = d.rx_result - d.tx_delivery
+    if d.tx_result:
+        print("   pipe %.6f, worker %.6f, kernel %.6f    total  (k->k %.6f)" % (
+            total_pipe, total_worker, total_kernel, k_to_k))
+    else:
+        print("         total  (k->k %.6f)" % k_to_k)

--- a/packages/SwingSet/misc-tools/db-delete.js
+++ b/packages/SwingSet/misc-tools/db-delete.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+import 'lmdb';
 import '@endo/init';
 import process from 'process';
 import { openSwingStore } from '@agoric/swing-store';

--- a/packages/SwingSet/misc-tools/db-dump.js
+++ b/packages/SwingSet/misc-tools/db-dump.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import 'lmdb';
 import '@endo/init';
 import process from 'process';
 import { openSwingStore } from '@agoric/swing-store';

--- a/packages/SwingSet/misc-tools/db-get.js
+++ b/packages/SwingSet/misc-tools/db-get.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+import 'lmdb';
 import '@endo/init';
 import process from 'process';
 import { openSwingStore } from '@agoric/swing-store';

--- a/packages/SwingSet/misc-tools/db-set.js
+++ b/packages/SwingSet/misc-tools/db-set.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+import 'lmdb';
 import '@endo/init';
 import process from 'process';
 import { openSwingStore } from '@agoric/swing-store';

--- a/packages/SwingSet/misc-tools/extract-contract.js
+++ b/packages/SwingSet/misc-tools/extract-contract.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-continue */
+import fs from 'fs';
+import zlib from 'zlib';
+import readline from 'readline';
+import process from 'process';
+import '@endo/init';
+
+import { decodeBase64 } from '@endo/base64';
+
+async function run() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.log(
+      `extract-contract-from-transcript.js transcript-vNN.sst >contract-bundle.zip`,
+    );
+  }
+  const [transcriptFile] = args;
+  let transcriptF = fs.createReadStream(transcriptFile);
+  if (transcriptFile.endsWith('.gz')) {
+    transcriptF = transcriptF.pipe(zlib.createGunzip());
+  }
+  const lines = readline.createInterface({ input: transcriptF });
+  for await (const line of lines) {
+    const t = JSON.parse(line);
+    // find the first message
+    // 0: create-vat
+    // 1: startVat
+    // 2: bringOutYourDead
+    // 3: message(executeContract(bundle, ...args))
+    if (!t.d) continue;
+    if (t.d[0] !== 'message') continue;
+    assert.equal(t.d[0], 'message');
+    assert.equal(t.d[1], 'o+0');
+    const methargs = t.d[2].methargs;
+    const body = JSON.parse(methargs.body);
+    const [_method, margs] = body;
+    const bundle = margs[0];
+    assert.equal(bundle.moduleFormat, 'endoZipBase64');
+    const b64 = bundle.endoZipBase64;
+    const zipBytes = decodeBase64(b64);
+    fs.writeFileSync('contract-bundle.zip', zipBytes);
+    break;
+  }
+}
+
+run().catch(err => console.log('err', err));

--- a/packages/SwingSet/misc-tools/find-leaks.py
+++ b/packages/SwingSet/misc-tools/find-leaks.py
@@ -2,6 +2,13 @@ import sys, json, gzip, re, time
 from collections import defaultdict
 from pprint import pprint
 
+# Point this at a slogfile and an optional vatID to filter on. It
+# rebuilds the state of the c-lists and emits a report with the
+# objects that are still present at the end of the slog. For each
+# object, it reports the Remotable-registered interface of the object,
+# and the delivery which introduced it. These may represent leaked
+# objects.
+
 # we track current vat imports and exports by vref
 vat_clist = {} # vref => { kref, reachable, block, crank, delivery, data }
 block_height = None
@@ -34,8 +41,53 @@ def retire_from_vat(vrefs, krefs):
             assert not vat_clist[vref]["reachable"], vref
         del vat_clist[vref]
 
+def get_iface(vref, vcapdata):
+    ifaces = [""]
+    def check(dct):
+        if dct.get("@qclass") == "slot" and vcapdata["slots"][dct["index"]] == vref:
+            ifaces.append("(%s)" % dct.get("iface"))
+        return dct
+    json.loads(vcapdata["body"], object_hook=check)
+    return ifaces[-1]
+
+def describe_delivery(vref, d):
+    data = d["data"]
+    if data["type"] == "deliver":
+        kd = data["kd"]
+        vd = data["vd"]
+        if kd[0] == "message":
+            vtarget = vd[1]
+            ktarget = kd[1]
+            method = json.loads(kd[2]["methargs"]["body"])[0]
+            kresult = kd[2].get("result")
+            vresult = vd[2].get("result")
+            iface = get_iface(vref, vd[2]["methargs"])
+            return "d.deliver %s/%s.%s() -> r=%s/%s %s" % (vtarget, ktarget, method, vresult, kresult, iface)
+        if kd[0] == "notify":
+            vpids = ",".join([res[0] for res in vd[1]])
+            kpids = ",".join([res[0] for res in kd[1]])
+            iface = get_iface(vref, [res[2] for res in vd[1] if vref in res[2]["slots"]][0])
+            return "d.notify %s/%s %s" % (vpids, kpids, iface)
+    if data["type"] == "syscall":
+        ksc = data["ksc"]
+        vsc = data["vsc"]
+        if ksc[0] == "send":
+            ktarget = ksc[1]
+            vtarget = vsc[1]
+            method = json.loads(ksc[2]["methargs"]["body"])[0]
+            iface = get_iface(vref, vsc[2]["methargs"])
+            kresult = ksc[2].get("result")
+            vresult = vsc[2].get("result")
+            return "s.send %s/%s.%s() -> r=%s/%s %s" % (vtarget, ktarget, method, vresult, kresult, iface)
+        if ksc[0] == "resolve":
+            vpids = ",".join([res[0] for res in vsc[1]])
+            kpids = ",".join([res[0] for res in ksc[2]])
+            iface = get_iface(vref, [res[2] for res in vsc[1] if vref in res[2]["slots"]][0])
+            return "s.resolve %s/%s %s" % (vpids, kpids, iface)
+    return "?"
+
 fn = sys.argv[1]
-vat = sys.argv[2]
+vatID = sys.argv[2] if len(sys.argv) > 2 else None
 
 opener = gzip.open if fn.endswith(".gz") else open
 with opener(sys.argv[1]) as f:
@@ -51,7 +103,7 @@ with opener(sys.argv[1]) as f:
             block_height = data["blockHeight"]
         if type not in ["deliver", "syscall"]:
             continue
-        if data["vatID"] != vat:
+        if vatID and data["vatID"] != vatID:
             continue
         #print()
         #print(sorted(vat_clist.keys()))
@@ -69,11 +121,11 @@ with opener(sys.argv[1]) as f:
             dtype = vd[0]
 
             if dtype == "message":
-                added[0].extend(vd[2]["args"]["slots"])
+                added[0].extend(vd[2]["methargs"]["slots"])
                 result_vpid = vd[2].get("result") # maybe null/None
                 if result_vpid:
                     added[0].append(result_vpid)
-                added[1].extend(kd[2]["args"]["slots"])
+                added[1].extend(kd[2]["methargs"]["slots"])
                 result_kpid = kd[2].get("result") # maybe null/None
                 if result_vpid:
                     added[1].append(result_kpid)
@@ -102,11 +154,11 @@ with opener(sys.argv[1]) as f:
             ksc = data["ksc"]
             stype = vsc[0]
             if stype == "send":
-                added[0].extend(vsc[2]["args"]["slots"])
+                added[0].extend(vsc[2]["methargs"]["slots"])
                 result_vpid = vsc[2].get("result")
                 if result_vpid:
                     added[0].append(result_vpid)
-                added[1].extend(ksc[2]["args"]["slots"])
+                added[1].extend(ksc[2]["methargs"]["slots"])
                 result_kpid = ksc[2].get("result")
                 if result_kpid:
                     added[1].append(result_kpid)
@@ -138,9 +190,9 @@ with opener(sys.argv[1]) as f:
 print("%d leftover entries after %d vat cranks" % (len(vat_clist), vat_cranks))
 for vref in sorted(vat_clist, key=lambda vref: vat_clist[vref]["crank"]):
     d = vat_clist[vref]
-    print("-- %6s (%6s) [%s]: added bl%s cr%d dl%d" % (
+    print("  b %6s (%6s) [%s]: added bl%s cr%d dl%d %s" % (
         vref, d["kref"], "reachable" if d["reachable"] else "recognizable",
-        d["block"], d["crank"], d["delivery"],
+        d["block"], d["crank"], d["delivery"], describe_delivery(vref, d),
         ))
-    pprint(d["data"]) ; print()
+    #pprint(d["data"]) ; print()
 print()

--- a/packages/SwingSet/misc-tools/list-remotes.py
+++ b/packages/SwingSet/misc-tools/list-remotes.py
@@ -1,0 +1,83 @@
+import sys, json, gzip, re, time
+from collections import defaultdict
+from pprint import pprint
+
+# point this at a slogfile and it will figure out the comms
+# connections, printing the remote address, the transmitter object
+# (within vat-vattp), and the receiver object (within vat-comms)
+
+def extract(kd):
+    methargs = kd[2]["methargs"]
+    (method, args) = json.loads(methargs["body"])
+    return method, args, methargs["slots"]
+
+class Remote:
+    def __init__(self, remote, tx_kref):
+        self.remote = remote
+        self.tx_kref_vattp = tx_kref
+    def set_rx_kref_comms(self, rx_kref_comms):
+        self.rx_kref_comms = rx_kref_comms
+    def print(self):
+        print(self.remote, self.tx_kref_vattp, self.rx_kref_comms)
+
+comms_vatid = None
+vattp_vatid = None
+remotes = {} # remote -> Remote
+setters = {} # setter kref -> remote
+
+print("remote                                        tx    rx")
+#      agoric164mdr2vmh2vy3kge6k9a79rf0rjlpqsqg5c8az ko666 ko711
+
+fn = sys.argv[1]
+opener = gzip.open if fn.endswith(".gz") else open
+with opener(sys.argv[1]) as f:
+    for line in f:
+        if isinstance(line, bytes):
+            line = line.decode("utf-8")
+        if not line.strip():
+            continue
+
+        data = json.loads(line.strip())
+        type = data["type"]
+        if type == "create-vat":
+            if data["description"].startswith("comms "):
+                comms_vatid = data["vatID"]
+            if data["description"].startswith("vattp "):
+                vattp_vatid = data["vatID"]
+
+        if comms_vatid and type == "deliver" and data["vatID"] == comms_vatid:
+            kd = data["kd"]
+            if kd[0] == "message":
+                (method, args, slots) = extract(kd)
+                if method == "addRemote":
+                    remote = args[0]
+                    assert args[1]["@qclass"] == "slot"
+                    assert args[1]["iface"] == "Alleged: transmitter"
+                    assert args[1]["index"] == 0
+                    tx_kref = slots[0]
+                    assert args[2]["@qclass"] == "slot"
+                    assert args[2]["iface"] == "Alleged: receiver setter"
+                    assert args[2]["index"] == 1
+                    setter_kref = slots[1]
+                    remotes[remote] = Remote(remote, tx_kref)
+                    setters[setter_kref] = remote
+                    #print(remote, tx_kref, setter_kref)
+
+        if vattp_vatid and type == "deliver" and data["vatID"] == vattp_vatid:
+            kd = data["kd"]
+            if kd[0] == "message":
+                (method, args, slots) = extract(kd)
+                target = kd[1]
+                if target in setters:
+                    remote = setters[target]
+                    (method, args, slogs) = extract(kd)
+                    assert method == "setReceiver"
+                    assert args[0]["@qclass"] == "slot"
+                    # no iface
+                    assert args[0]["index"] == 0
+                    rx_kref_comms = slots[0]
+                    remotes[remote].set_rx_kref_comms(rx_kref_comms)
+                    remotes[remote].print()
+
+
+print()

--- a/packages/SwingSet/misc-tools/remote-leaks.py
+++ b/packages/SwingSet/misc-tools/remote-leaks.py
@@ -1,0 +1,281 @@
+import sys, json, gzip, re, time
+from collections import defaultdict
+from pprint import pprint
+
+# point this at a slogfile and it will scan the inbound/outbound comms
+# messages, emitting a report on all objects/promises that are still
+# outstanding by the end of the log
+
+
+# incidentally, here's a snippet to extract the comms messages for a
+# single remote, if you know ko716 is the "receiver" object on
+# v3-comms, and ko676 is the "transmitter" object on v4-vattp:
+#
+# gzcat slogfile.slog.gz |jq -c --raw-output 'select(.type=="deliver" and .vatID=="v3" and .kd[0]=="message" and .kd[1]=="ko716") | .kd[2].methargs.body|fromjson|.[1]|.[0]' >rx-ko716
+# gzcat slogfile.slog.gz |jq -c --raw-output 'select(.type=="deliver" and .vatID=="v4" and .kd[0]=="message" and .kd[1]=="ko676") | .kd[2].methargs.body|fromjson|.[1]|.[0]' >tx-ko676
+
+def extract(kd):
+    methargs = kd[2]["methargs"]
+    (method, args) = json.loads(methargs["body"])
+    return method, args, methargs["slots"]
+
+def parse_remote(payload):
+    (seq1, seq2, rest) = payload.split(":", 2)
+    messages = []
+    for msg in rest.split("\n"):
+        target = None
+        result = None
+        header = msg.split(";", 1)[0] # ignore body for now
+        p = header.split(":")
+        action = p[0]
+        if action == "deliver":
+            target = p[1]
+            mode = None
+            result = p[2] if p[2] else None # maybe empty string
+            slots = p[3:]
+        if action == "resolve":
+            mode = p[1] # 'fulfill' or 'reject'
+            target = p[2]
+            slots = p[3:]
+        if action == "gc":
+            mode = p[1] # 'dropExport' or 'retireExport' or 'retireImport'
+            slots = p[2:]
+        #print (action, mode, target, result, slots)
+        messages.append((action, mode, target, result, slots))
+    return messages
+
+def polarity(rref):
+    return rref[2]
+
+def flip(rref):
+    if rref[2] == "+":
+        return rref[:2] + "-" + rref[3:]
+    elif rref[2] == "-":
+        return rref[:2] + "+" + rref[3:]
+    else:
+        raise Error("bad rref '%s'" % rref)
+
+REACHABLE = "reachable"
+RECOGNIZABLE = "recognizable"
+
+class Remote:
+    def __init__(self, remote, tx_kref):
+        self.remote = remote
+        self.tx_kref_vattp = tx_kref
+        self.exports = {} # ro+N, all are mine
+        self.imports = {} # ro-N, all are theirs, arrives in rx deliver/resolve
+    def set_rx_kref_comms(self, rx_kref_comms):
+        self.rx_kref_comms = rx_kref_comms
+    def print(self):
+        print(self.remote, self.tx_kref_vattp, self.rx_kref_comms)
+
+    def rx(self, payload):
+        #print("rx payload", payload.replace("\n", " \n"))
+        for (action, mode, target, result, slots) in parse_remote(payload):
+            # they are polite, so 'slots' contains our-format rrefs
+            if action in ("deliver", "resolve"):
+                allslots = slots[:]
+                if result:
+                    allslots.append(result)
+                for my_rref in allslots:
+                    if polarity(my_rref) == "-": # import
+                        if my_rref not in self.imports:
+                            self.imports[my_rref] = [REACHABLE, payload]
+                    if polarity(my_rref) == "+": # must be one of our exports
+                        assert my_rref in self.exports, "fake export %s" % my_rref
+            if action == "resolve": # assumer we're the decider
+                my_rref = target
+                if my_rref in self.exports:
+                    del self.exports[my_rref]
+                if my_rref in self.imports:
+                    del self.imports[my_rref]
+            if action == "gc":
+                if mode == "dropExport":
+                    for my_rref in slots:
+                        assert my_rref in self.exports
+                        assert self.exports[my_rref][0] == REACHABLE
+                        self.exports[my_rref][0] = RECOGNIZABLE
+                if mode == "retireExport":
+                    for my_rref in slots:
+                        assert my_rref in self.exports
+                        assert self.exports[my_rref][0] == RECOGNIZABLE
+                        del self.exports[my_rref]
+                if mode == "retireImport":
+                    for my_rref in slots:
+                        assert my_rref in self.imports
+                        assert self.imports[my_rref][0] == RECOGNIZABLE
+                        del self.imports[my_rref]
+
+    def tx(self, payload):
+        #print("tx payload", payload.replace("\n", " \n"))
+        for (action, mode, target, result, slots) in parse_remote(payload):
+            # we are polite, so we sent their-format refs, and must flip to our-format
+            if action in ("deliver", "resolve"):
+                allslots = slots[:]
+                if result:
+                    allslots.append(result)
+                for their_rref in allslots:
+                    my_rref = flip(their_rref)
+                    if polarity(my_rref) == "-": # must be one of our imports
+                        assert my_rref in self.imports, "fake import %s" % my_rref
+                    if polarity(my_rref) == "+": # export
+                        if my_rref in self.exports:
+                            self.exports[my_rref][0] = REACHABLE # maybe only RECOGNIZABLE before
+                        else:
+                            self.exports[my_rref] = [REACHABLE, payload] # new
+            if action == "resolve": # assumer we're the decider
+                my_rref = flip(target)
+                if my_rref in self.exports:
+                    del self.exports[my_rref]
+                if my_rref in self.imports:
+                    del self.imports[my_rref]
+            if action == "gc":
+                if mode == "dropExport":
+                    for their_rref in slots:
+                        my_rref = flip(their_rref)
+                        assert my_rref in self.imports
+                        assert self.imports[my_rref][0] == REACHABLE
+                        self.imports[my_rref][0] = RECOGNIZABLE
+                if mode == "retireExport":
+                    for their_rref in slots:
+                        my_rref = flip(their_rref)
+                        assert my_rref in self.imports
+                        assert self.imports[my_rref][0] == RECOGNIZABLE
+                        del self.imports[my_rref]
+                if mode == "retireImport":
+                    for their_rref in slots:
+                        my_rref = flip(their_rref)
+                        assert my_rref in self.exports
+                        assert self.exports[my_rref][0] == RECOGNIZABLE
+                        del self.exports[my_rref]
+
+
+
+
+comms_vatid = None
+vattp_vatid = None
+remotes = {} # remote -> Remote
+setters = {} # setter kref -> remote
+transmitters = {} # tx kref -> remote
+receivers = {} # rx kref -> remote
+
+follow = set([
+    #"agoric15rz7vcgxegyhdr7crmagkaur56c8rrv4s6py4y",
+])
+
+fn = sys.argv[1]
+opener = gzip.open if fn.endswith(".gz") else open
+with opener(sys.argv[1]) as f:
+    for line in f:
+        if isinstance(line, bytes):
+            line = line.decode("utf-8")
+        if not line.strip():
+            continue
+
+        data = json.loads(line.strip())
+        type = data["type"]
+        if type == "create-vat":
+            if data["description"].startswith("comms "):
+                comms_vatid = data["vatID"]
+            if data["description"].startswith("vattp "):
+                vattp_vatid = data["vatID"]
+
+        if comms_vatid and type == "deliver" and data["vatID"] == comms_vatid:
+            kd = data["kd"]
+            if kd[0] == "message":
+                target = kd[1]
+                (method, args, slots) = extract(kd)
+                if method == "addRemote":
+                    remote = args[0]
+                    assert args[1]["@qclass"] == "slot"
+                    assert args[1]["iface"] == "Alleged: transmitter"
+                    assert args[1]["index"] == 0
+                    tx_kref = slots[0]
+                    assert args[2]["@qclass"] == "slot"
+                    assert args[2]["iface"] == "Alleged: receiver setter"
+                    assert args[2]["index"] == 1
+                    setter_kref = slots[1]
+                    remotes[remote] = Remote(remote, tx_kref)
+                    transmitters[tx_kref] = remote
+                    setters[setter_kref] = remote
+                    #print("addRemote", remote, tx_kref)
+                if target in receivers:
+                    remote = receivers[target]
+                    payload = args[0]
+                    #if remote in follow:
+                    #    print("RX", payload.replace("\n", " \n"))
+                    remotes[remote].rx(payload)
+
+        if vattp_vatid and type == "deliver" and data["vatID"] == vattp_vatid:
+            kd = data["kd"]
+            if kd[0] == "message":
+                target = kd[1]
+                (method, args, slots) = extract(kd)
+                if target in setters:
+                    remote = setters[target]
+                    assert method == "setReceiver"
+                    assert args[0]["@qclass"] == "slot"
+                    # no iface
+                    assert args[0]["index"] == 0
+                    rx_kref_comms = slots[0]
+                    remotes[remote].set_rx_kref_comms(rx_kref_comms)
+                    receivers[rx_kref_comms] = remote
+                    #print("SETRECEIVER rx", remote, rx_kref_comms)
+                if target in transmitters:
+                    remote = transmitters[target]
+                    payload = args[0]
+                    #if remote in follow:
+                    #    print("tx", payload.replace("\n","\n "))
+                    remotes[remote].tx(payload)
+
+def rref_sort_key(rref):
+    typ = rref[1] # o or p
+    polarity = rref[2]
+    num = int(rref[3:])
+    return (polarity, typ, num)
+
+only_stats = not True
+
+print()
+for remote in sorted(remotes):
+    r = remotes[remote]
+    print("REMOTE %s" % remote)
+    import_objects = 0
+    import_promises = 0
+    lines = []
+    for my_rref in sorted(r.imports, key=rref_sort_key):
+        payload = r.imports[my_rref]
+        if my_rref[1] == "o":
+            import_objects += 1
+            label = "IMPORT-OBJ"
+        else:
+            import_promises += 1
+            label = "IMPORT-PROMISE"
+        lines.append("  %s %s %s %s" % (label, my_rref, payload[0], payload[1][:200]))
+    if only_stats:
+        print(" %s import-obj, %s import-promise" % (import_objects, import_promises))
+    else:
+        for line in lines:
+            print(line)
+        print()
+
+    export_objects = 0
+    export_promises = 0
+    lines = []
+    for my_rref in sorted(r.exports, key=rref_sort_key):
+        payload = r.exports[my_rref]
+        if my_rref[1] == "o":
+            export_objects += 1
+            label = "EXPORT-OBJ"
+        else:
+            export_promises += 1
+            label = "EXPORT-PROMISE"
+        label = "EXPORT-OBJ" if my_rref[1] == "o" else "EXPORT-PROMISE"
+        lines.append("  %s %s %s %s" % (label, my_rref, payload[0], payload[1][:200]))
+    if only_stats:
+        print(" %s export-obj, %s export-promise" % (export_objects, export_promises))
+    else:
+        for line in lines:
+            print(line)
+
+    print()

--- a/packages/SwingSet/misc-tools/replace-bundle.js
+++ b/packages/SwingSet/misc-tools/replace-bundle.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import 'lmdb';
 import '@endo/init';
 import process from 'process';
 import { openSwingStore } from '@agoric/swing-store';

--- a/packages/SwingSet/misc-tools/vat-stats.js
+++ b/packages/SwingSet/misc-tools/vat-stats.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import 'lmdb';
 import '@endo/init';
 import process from 'process';
 import { openSwingStore } from '@agoric/swing-store';


### PR DESCRIPTION
Some tiny tools in misc-tools/ (like db-dump.js) needed to be updated:
swing-store now uses a different LMDB backend, and that backend uses a
package (for serialization of some sort) which uses `eval` as a macro,
which is not compatible with SES. The quick fix, for these tools, is
to import the `lmdb` backend before doing `@endo/init`.
