### PR TITLE
fix(agoric-cli): Thread rpcAddresses for Cosmos publishBundle

### DIFF
--- a/packages/agoric-cli/src/deploy.js
+++ b/packages/agoric-cli/src/deploy.js
@@ -199,6 +199,7 @@ export default async function deployMain(progname, rawArgs, powers, opts) {
     pathResolve: path.resolve,
     writeFile: fs.writeFile,
     tmpDirSync: tmp.dirSync,
+    random: Math.random,
   });
   const publishBundleHttp = makeHttpBundlePublisher({
     getAccessToken,

--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -175,6 +175,18 @@ export const makeHttpBundlePublisher = ({ jsonHttpCall, getAccessToken }) => {
 };
 
 /**
+ * @param {string} address - a host or URL
+ */
+const urlForRpcAddress = address => {
+  try {
+    return new URL(address).href;
+  } catch {
+    // lift host strings to HTTP URLs.
+    return `http://${address}`;
+  }
+};
+
+/**
  * @param {object} args
  * @param {ReturnType<import('./helpers.js').makePspawn>} args.pspawn
  * @param {string} args.cosmosHelper
@@ -218,7 +230,7 @@ export const makeCosmosBundlePublisher = ({
         '--home',
         homeDirectory,
         '--node',
-        `http://${rpcAddress}`,
+        urlForRpcAddress(rpcAddress),
         '--keyring-backend',
         'test',
         '--from',

--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -42,6 +42,17 @@
 
 const { details: X, quote: q } = assert;
 
+/**
+ * @template T
+ * @param {Array<T>} array
+ * @returns {T}
+ */
+const choose = array => {
+  assert(array.length > 0);
+  const index = Math.floor(array.length * Math.random());
+  return array[index];
+};
+
 // eslint-disable-next-line jsdoc/require-returns-check
 /**
  * @param {unknown} connectionSpec
@@ -85,7 +96,7 @@ const assertCosmosConnectionSpec = connectionSpec => {
   );
   assert(connectionSpec !== null, 'Connection details must not be null');
 
-  const { chainID = 'agoric', homeDirectory } = connectionSpec;
+  const { chainID = 'agoric', homeDirectory, rpcAddresses } = connectionSpec;
 
   assert.typeof(
     chainID,
@@ -103,6 +114,22 @@ const assertCosmosConnectionSpec = connectionSpec => {
     'string',
     `connection homeDirectory must be a string, got ${homeDirectory}`,
   );
+
+  assert(
+    Array.isArray(rpcAddresses),
+    `connection rpcAddresses must be an array, got ${rpcAddresses}`,
+  );
+  assert(
+    rpcAddresses.length > 0,
+    `connection rpcAddresseses must not be empty`,
+  );
+  for (const rpcAddress of rpcAddresses) {
+    assert.typeof(
+      rpcAddress,
+      'string',
+      `every connection rpcAddress must be a string, got one ${rpcAddress}`,
+    );
+  }
 };
 
 /**
@@ -166,7 +193,9 @@ export const makeCosmosBundlePublisher = ({
    * @param {CosmosConnectionSpec} connectionSpec
    */
   const publishBundleCosmos = async (bundle, connectionSpec) => {
-    const { chainID = 'agoric', homeDirectory } = connectionSpec;
+    const { chainID = 'agoric', homeDirectory, rpcAddresses } = connectionSpec;
+
+    const rpcAddress = choose(rpcAddresses);
 
     const { name: tempDirPath, removeCallback } = tmpDirSync({
       unsafeCleanup: true,
@@ -185,6 +214,8 @@ export const makeCosmosBundlePublisher = ({
         '1.2',
         '--home',
         homeDirectory,
+        '--node',
+        `http://${rpcAddress}`,
         '--keyring-backend',
         'test',
         '--from',
@@ -222,6 +253,7 @@ export const makeCosmosBundlePublisher = ({
  * @property {'chain-cosmos-sdk' | 'fake-chain'} type
  * @property {string} chainID
  * @property {string} homeDirectory
+ * @property {Array<string>} rpcAddresses
  */
 
 /**

--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -178,10 +178,9 @@ export const makeHttpBundlePublisher = ({ jsonHttpCall, getAccessToken }) => {
  * @param {string} address - a host or URL
  */
 const urlForRpcAddress = address => {
-  try {
-    return new URL(address).href;
-  } catch {
-    // lift host strings to HTTP URLs.
+  if (address.includes('://')) {
+    return address;
+  } else {
     return `http://${address}`;
   }
 };

--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -45,11 +45,12 @@ const { details: X, quote: q } = assert;
 /**
  * @template T
  * @param {Array<T>} array
+ * @param {number} randomNumber
  * @returns {T}
  */
-const choose = array => {
+const choose = (array, randomNumber) => {
   assert(array.length > 0);
-  const index = Math.floor(array.length * Math.random());
+  const index = Math.floor(array.length * randomNumber);
   return array[index];
 };
 
@@ -180,6 +181,7 @@ export const makeHttpBundlePublisher = ({ jsonHttpCall, getAccessToken }) => {
  * @param {typeof import('path').resolve} args.pathResolve
  * @param {typeof import('fs').promises.writeFile} args.writeFile
  * @param {typeof import('tmp').dirSync} args.tmpDirSync
+ * @param {() => number} args.random
  */
 export const makeCosmosBundlePublisher = ({
   pspawn,
@@ -187,6 +189,7 @@ export const makeCosmosBundlePublisher = ({
   pathResolve,
   writeFile,
   tmpDirSync,
+  random,
 }) => {
   /**
    * @param {unknown} bundle
@@ -195,7 +198,7 @@ export const makeCosmosBundlePublisher = ({
   const publishBundleCosmos = async (bundle, connectionSpec) => {
     const { chainID = 'agoric', homeDirectory, rpcAddresses } = connectionSpec;
 
-    const rpcAddress = choose(rpcAddresses);
+    const rpcAddress = choose(rpcAddresses, random());
 
     const { name: tempDirPath, removeCallback } = tmpDirSync({
       unsafeCleanup: true,


### PR DESCRIPTION

closes: #5601

## Description

This change fixes #5601 which manifested as a failure to connect to a remote chain when publishing a bundle. This addresses the specific problem that publishBundle did not thread the `rpcAddresses` from the connection spec down to `agd`. This solution will be replaced with a system based on casting in cosmjs, with retries and feedback about installation success and failure #5460, but this addresses the problem until then.
