### PR TITLE
5268 governance subscription for VaultFactory

### DIFF
--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -4,7 +4,6 @@ import { Far, passStyleOf } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
 import { Nat } from '@agoric/nat';
-import { makeStoredPublisherKit } from '@agoric/notifier';
 import { keyEQ, makeStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { ParamTypes } from '../constants.js';
@@ -55,13 +54,16 @@ const assertElectorateMatches = (paramManager, governedParams) => {
  */
 
 /**
+ * @param {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} publisherKit
  * @param {ERef<ZoeService>} [zoe]
  */
-const makeParamManagerBuilder = zoe => {
+const makeParamManagerBuilder = (publisherKit, zoe) => {
   /** @type {Store<Keyword, any>} */
   const namesToParams = makeStore('Parameter Name');
-  /** @type {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} */
-  const { publisher, subscriber } = makeStoredPublisherKit();
+  const { publisher, subscriber } = publisherKit;
+  assert(publisher, 'missing publisher');
+  assert(subscriber, 'missing subscriber');
+
   const getters = {};
   const setters = {};
 

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -21,7 +21,7 @@ const { details: X, quote: q } = assert;
 
 /**
  * @param {ParamManagerBase} paramManager
- * @param {{[CONTRACT_ELECTORATE]: ParamRecord<'invitation'>}} governedParams
+ * @param {{[CONTRACT_ELECTORATE]: ParamValueTyped<'invitation'>}} governedParams
  */
 const assertElectorateMatches = (paramManager, governedParams) => {
   const managerElectorate =
@@ -58,6 +58,7 @@ const assertElectorateMatches = (paramManager, governedParams) => {
  * @param {ERef<ZoeService>} [zoe]
  */
 const makeParamManagerBuilder = zoe => {
+  /** @type {Store<Keyword, any>} */
   const namesToParams = makeStore('Parameter Name');
   const { publication, subscription } = makeSubscriptionKit();
   const getters = {};
@@ -298,7 +299,7 @@ const makeParamManagerBuilder = zoe => {
   };
 
   const getParams = () => {
-    /** @type {Record<Keyword,ParamRecord>} */
+    /** @type {ParamStateRecord} */
     const descriptions = {};
     for (const [name, param] of namesToParams.entries()) {
       descriptions[name] = param.makeDescription();

--- a/packages/governance/src/contractGovernance/typedParamManager.js
+++ b/packages/governance/src/contractGovernance/typedParamManager.js
@@ -70,12 +70,13 @@ const isAsync = {
 /**
  * @see makeParamManagerSync
  * @template {Record<Keyword, AsyncSpecTuple | SyncSpecTuple>} T
+ * @param {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} publisherKit
  * @param {T} spec
  * @param {ERef<ZoeService>} zoe
  * @returns {Promise<TypedParamManager<{[K in keyof T]: T[K][0]}>>}
  */
-const makeParamManager = async (spec, zoe) => {
-  const builder = makeParamManagerBuilder(zoe);
+const makeParamManager = async (publisherKit, spec, zoe) => {
+  const builder = makeParamManagerBuilder(publisherKit, zoe);
 
   const promises = [];
   for (const [name, [type, value]] of Object.entries(spec)) {
@@ -98,11 +99,12 @@ const makeParamManager = async (spec, zoe) => {
  *
  * @see makeParamManager
  * @template {Record<Keyword, SyncSpecTuple>} T
+ * @param {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} publisherKit
  * @param {T} spec
  * @returns {TypedParamManager<{[K in keyof T]: T[K][0]}>}
  */
-const makeParamManagerSync = spec => {
-  const builder = makeParamManagerBuilder();
+const makeParamManagerSync = (publisherKit, spec) => {
+  const builder = makeParamManagerBuilder(publisherKit);
 
   for (const [name, [type, value]] of Object.entries(spec)) {
     const add = builder[builderMethodName(type)];
@@ -116,12 +118,14 @@ const makeParamManagerSync = spec => {
 
 /**
  * @template {ParamTypesMap} M Map of types of custom governed terms
+ * @param {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} publisherKit
  * @param {ZCF<GovernanceTerms<M>>} zcf
  * @param {Payment} initialPoserInvitation
  * @param {M} paramTypesMap
  * @returns {Promise<TypedParamManager<M & {Electorate: 'invitation'}>>}
  */
 const makeParamManagerFromTerms = async (
+  publisherKit,
   zcf,
   initialPoserInvitation,
   paramTypesMap,
@@ -144,6 +148,7 @@ const makeParamManagerFromTerms = async (
   ]);
   // @ts-expect-error cast
   return makeParamManager(
+    publisherKit,
     Object.fromEntries(makerSpecEntries),
     zcf.getZoeService(),
   );

--- a/packages/governance/src/contractGovernance/typedParamManager.js
+++ b/packages/governance/src/contractGovernance/typedParamManager.js
@@ -8,8 +8,8 @@ import { makeParamManagerBuilder } from './paramManager.js';
  * @typedef {Record<Keyword, ParamType>} ParamTypesMap
  */
 /**
- * @template {Record<Keyword, ParamRecord>} M
- * @typedef {{ [R in keyof M]: M[R]['type']}} ParamTypesMapFromRecords
+ * @template {ParamStateRecord} M
+ * @typedef {{ [R in keyof M]: M[R]['type']}} ParamTypesMapFromRecord
  */
 /**
  * @template {ParamTypesMap} M

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -116,16 +116,19 @@ const facetHelpers = (zcf, paramManager) => {
  *
  * @template {import('./contractGovernance/typedParamManager').ParamTypesMap} M
  *   Map of types of custom governed terms
+ * @param {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} publisherKit
  * @param {ZCF<GovernanceTerms<M>>} zcf
  * @param {Invitation} initialPoserInvitation
  * @param {M} paramTypesMap
  */
 const handleParamGovernance = async (
+  publisherKit,
   zcf,
   initialPoserInvitation,
   paramTypesMap,
 ) => {
   const paramManager = await makeParamManagerFromTerms(
+    publisherKit,
     zcf,
     initialPoserInvitation,
     paramTypesMap,

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -55,7 +55,7 @@
 
 /**
  * @template {ParamType} [T=ParamType]
- * @typedef {{ type: T, value: ParamValueForType<T> }} ParamRecord<T>
+ * @typedef {{ type: T, value: ParamValueForType<T> }} ParamValueTyped<T>
  */
 
 /**
@@ -356,14 +356,13 @@
  */
 
 /**
- * @callback GetParams - getParams() retrieves a Record containing
+ * @typedef {Record<Keyword, ParamValueTyped>} ParamStateRecord a Record containing
  *   keyword pairs with descriptions of parameters under governance.
- * @returns {Record<Keyword,ParamRecord>}
  */
 
 /**
  * @typedef {object} ParamManagerBase The base paramManager with typed getters
- * @property {() => Record<Keyword, ParamRecord>} getParams
+ * @property {() => ParamStateRecord} getParams
  * @property {(name: string) => Amount} getAmount
  * @property {(name: string) => Brand} getBrand
  * @property {(name: string) => Instance} getInstance
@@ -377,7 +376,7 @@
  *   most types, the visible value is the same as proposedValue. For Invitations
  *   the visible value is the amount of the invitation.
  * @property {(name: string) => Promise<Invitation>} getInternalParamValue
- * @property {() => Subscription<ParamRecord>} getSubscription
+ * @property {() => StoredSubscription<ParamStateRecord>} getSubscription
  */
 
 /**
@@ -394,10 +393,6 @@
  *
  * @typedef {Record<string, any>} ParamManagerGettersAndUpdaters
  * @typedef {ParamManagerBase & ParamManagerGettersAndUpdaters & {updateParams: UpdateParams}} AnyParamManager
- */
-
-/**
- * @typedef {Iterable<ParamRecord>} ParamRecords
  */
 
 /**
@@ -418,7 +413,7 @@
  *   instantiated inside the contract, the contract has synchronous access to
  *   the values, and clients of the contract can verify that a ContractGovernor
  *   can change the values in a legible way.
- * @param {ParamRecords} paramDescriptions
+ * @param {Iterable<ParamValueTyped>} paramDescriptions
  * @returns {AnyParamManager}
  */
 
@@ -515,9 +510,9 @@
 
 /**
  * @typedef GovernedPublicFacetMethods
- * @property {() => Subscription<ParamRecord>} getSubscription
+ * @property {() => StoredSubscription<ParamStateRecord>} getSubscription
  * @property {() => Instance} getContractGovernor
- * @property {GetParams} getGovernedParams - get descriptions of
+ * @property {() => ParamStateRecord} getGovernedParams - get descriptions of
  *   all the governed parameters
  * @property {(name: string) => Amount} getAmount
  * @property {(name: string) => Brand} getBrand

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -360,6 +360,8 @@
  *   keyword pairs with descriptions of parameters under governance.
  */
 
+/** @typedef {{current: ParamStateRecord}} GovernanceSubscriptionState */
+
 /**
  * @typedef {object} ParamManagerBase The base paramManager with typed getters
  * @property {() => ParamStateRecord} getParams
@@ -376,13 +378,12 @@
  *   most types, the visible value is the same as proposedValue. For Invitations
  *   the visible value is the amount of the invitation.
  * @property {(name: string) => Promise<Invitation>} getInternalParamValue
- * @property {() => StoredSubscription<ParamStateRecord>} getSubscription
+ * @property {() => StoredSubscription<GovernanceSubscriptionState>} getSubscription
  */
 
 /**
  * @callback UpdateParams
  * @param {Record<string,ParamValue>} paramChanges
- * @returns {Promise<ParamValue[]>}
  */
 
 /**
@@ -510,7 +511,7 @@
 
 /**
  * @typedef GovernedPublicFacetMethods
- * @property {() => StoredSubscription<ParamStateRecord>} getSubscription
+ * @property {() => StoredSubscription<GovernanceSubscriptionState>} getSubscription
  * @property {() => Instance} getContractGovernor
  * @property {() => ParamStateRecord} getGovernedParams - get descriptions of
  *   all the governed parameters

--- a/packages/governance/test/swingsetTests/contractGovernor/governedContract.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/governedContract.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { makeStoredPublisherKit } from '@agoric/notifier';
 import { handleParamGovernance } from '../../../src/contractHelper.js';
 import { ParamTypes } from '../../../src/index.js';
 import { CONTRACT_ELECTORATE } from '../../../src/contractGovernance/governParam.js';
@@ -29,9 +30,14 @@ const makeTerms = (number, invitationAmount) => {
  */
 const start = async (zcf, privateArgs) => {
   const { augmentPublicFacet, makeGovernorFacet, params } =
-    await handleParamGovernance(zcf, privateArgs.initialPoserInvitation, {
-      [MALLEABLE_NUMBER]: ParamTypes.NAT,
-    });
+    await handleParamGovernance(
+      makeStoredPublisherKit(),
+      zcf,
+      privateArgs.initialPoserInvitation,
+      {
+        [MALLEABLE_NUMBER]: ParamTypes.NAT,
+      },
+    );
 
   let governanceAPICalled = 0;
   const governanceApi = () => (governanceAPICalled += 1);

--- a/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
@@ -79,144 +79,140 @@ const main = async (t, argv) => {
   return controller.dump();
 };
 
-const expectedcontractGovernorStartLog = [
-  '=> voter and electorate vats are set up',
-  'Number before: 602214090000000000000000',
-  '@@ schedule task for:3, currently: 0 @@',
-  'Voter Alice voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'Voter Bob voted for {"noChange":["MalleableNumber"]}',
-  'Voter Carol voted for {"noChange":["MalleableNumber"]}',
-  'Voter Dave voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'Voter Emma voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'Voter Alice validated all the things',
-  '@@ tick:1 @@',
-  '@@ tick:2 @@',
-  '@@ tick:3 @@',
-  '&& running a task scheduled for 3. &&',
-  'vote outcome: {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'updated to {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'current value of MalleableNumber is 299792458',
-  'Electorate,MalleableNumber changed in a vote.',
-  'Number after: 299792458',
-  'MalleableNumber changed in a vote.',
-];
-
 test.serial('contract governance', async t => {
   const dump = await main(t, ['contractGovernorStart']);
-  t.deepEqual(dump.log, expectedcontractGovernorStartLog);
+  t.deepEqual(dump.log, [
+    '=> voter and electorate vats are set up',
+    'Number before: 602214090000000000000000',
+    'params update: ',
+    'current value of MalleableNumber is 602214090000000000000000',
+    '@@ schedule task for:3, currently: 0 @@',
+    'Voter Alice voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
+    'Voter Bob voted for {"noChange":["MalleableNumber"]}',
+    'Voter Carol voted for {"noChange":["MalleableNumber"]}',
+    'Voter Dave voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
+    'Voter Emma voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
+    'Voter Alice validated all the things',
+    '@@ tick:1 @@',
+    '@@ tick:2 @@',
+    '@@ tick:3 @@',
+    '&& running a task scheduled for 3. &&',
+    'vote outcome: {"changes":{"MalleableNumber":"[299792458n]"}}',
+    'params update: MalleableNumber',
+    'current value of MalleableNumber is 299792458',
+    'updated to {"changes":{"MalleableNumber":"[299792458n]"}}',
+    'Number after: 299792458',
+  ]);
 });
-
-const expectedChangeElectorateLog = [
-  '=> voter and electorate vats are set up',
-  '@@ schedule task for:2, currently: 0 @@',
-  'Voter Alice voted for {"noChange":["Electorate"]}',
-  'Voter Bob voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]}}}',
-  'Voter Carol voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]}}}',
-  'Voter Dave voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]}}}',
-  'Voter Emma voted for {"noChange":["Electorate"]}',
-  '@@ tick:1 @@',
-  '@@ tick:2 @@',
-  '&& running a task scheduled for 2. &&',
-  'vote outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]}}}',
-  'updated to ({"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]}}})',
-  'Validation complete: true',
-  '@@ schedule task for:4, currently: 2 @@',
-  'Voter Alice voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'Voter Bob voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'Voter Carol voted for {"noChange":["MalleableNumber"]}',
-  'Voter Dave voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'Voter Emma voted for {"noChange":["MalleableNumber"]}',
-  '@@ tick:3 @@',
-  '@@ tick:4 @@',
-  '&& running a task scheduled for 4. &&',
-  'vote outcome: {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'updated to {"changes":{"MalleableNumber":"[299792458n]"}}',
-  'current value of MalleableNumber is 299792458',
-  'Electorate,MalleableNumber changed in a vote.',
-  'Electorate changed in a vote.',
-  'MalleableNumber changed in a vote.',
-];
 
 test.serial('change electorate', async t => {
   const dump = await main(t, ['changeElectorateStart']);
-  t.deepEqual(dump.log, expectedChangeElectorateLog);
+  t.deepEqual(dump.log, [
+    '=> voter and electorate vats are set up',
+    'params update: ',
+    'current value of MalleableNumber is 602214090000000000000000',
+    '@@ schedule task for:2, currently: 0 @@',
+    'Voter Alice voted for {"noChange":["Electorate"]}',
+    'Voter Bob voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]}}}',
+    'Voter Carol voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]}}}',
+    'Voter Dave voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]}}}',
+    'Voter Emma voted for {"noChange":["Electorate"]}',
+    '@@ tick:1 @@',
+    '@@ tick:2 @@',
+    '&& running a task scheduled for 2. &&',
+    'vote outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]}}}',
+    'params update: Electorate',
+    'current value of MalleableNumber is 602214090000000000000000',
+    'updated to ({"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]}}})',
+    'Validation complete: true',
+    '@@ schedule task for:4, currently: 2 @@',
+    'Voter Alice voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
+    'Voter Bob voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
+    'Voter Carol voted for {"noChange":["MalleableNumber"]}',
+    'Voter Dave voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
+    'Voter Emma voted for {"noChange":["MalleableNumber"]}',
+    '@@ tick:3 @@',
+    '@@ tick:4 @@',
+    '&& running a task scheduled for 4. &&',
+    'vote outcome: {"changes":{"MalleableNumber":"[299792458n]"}}',
+    'params update: MalleableNumber',
+    'current value of MalleableNumber is 299792458',
+    'updated to {"changes":{"MalleableNumber":"[299792458n]"}}',
+  ]);
 });
-
-const expectedBrokenUpdateLog = [
-  '=> voter and electorate vats are set up',
-  '@@ schedule task for:2, currently: 0 @@',
-  'Voter Alice voted for {"noChange":["Electorate","MalleableNumber"]}',
-  'Voter Bob voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
-  'Voter Carol voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
-  'Voter Dave voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
-  'Voter Emma voted for {"noChange":["Electorate","MalleableNumber"]}',
-  '@@ tick:1 @@',
-  '@@ tick:2 @@',
-  '&& running a task scheduled for 2. &&',
-  'vote outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
-  'Validation complete: true',
-  // [`prepareToSetInvitation`](https://github.com/Agoric/agoric-sdk/blob/c6570b015fd23c411e48981bec309b32eedd3a28/packages/governance/src/contractGovernance/paramManager.js#L199-L212)
-  // does a `Promise.all` on 2 calls using the `invite` promise. If that promise
-  // is rejected, this will result in a rejection race between the 2 paths. The
-  // following 2 entries may come back as the commented out lines if the kernel
-  // changes the order in which messages are processed.
-  // TODO: allow either message
-  // 'vote rejected outcome: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
-  // 'update failed: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
-  'vote rejected outcome: Error: A Zoe invitation is required, not (an object)',
-  'update failed: Error: A Zoe invitation is required, not (an object)',
-  'current value of MalleableNumber is 602214090000000000000000',
-  'Electorate,MalleableNumber changed in a vote.',
-];
 
 test.serial('brokenUpdateStart', async t => {
   const dump = await main(t, ['brokenUpdateStart']);
-  t.deepEqual(dump.log, expectedBrokenUpdateLog);
+  t.deepEqual(dump.log, [
+    '=> voter and electorate vats are set up',
+    'params update: ',
+    'current value of MalleableNumber is 602214090000000000000000',
+    '@@ schedule task for:2, currently: 0 @@',
+    'Voter Alice voted for {"noChange":["Electorate","MalleableNumber"]}',
+    'Voter Bob voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+    'Voter Carol voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+    'Voter Dave voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+    'Voter Emma voted for {"noChange":["Electorate","MalleableNumber"]}',
+    '@@ tick:1 @@',
+    '@@ tick:2 @@',
+    '&& running a task scheduled for 2. &&',
+    'vote outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+    'Validation complete: true',
+    // [`prepareToSetInvitation`](https://github.com/Agoric/agoric-sdk/blob/c6570b015fd23c411e48981bec309b32eedd3a28/packages/governance/src/contractGovernance/paramManager.js#L199-L212)
+    // does a `Promise.all` on 2 calls using the `invite` promise. If that promise
+    // is rejected, this will result in a rejection race between the 2 paths. The
+    // following 2 entries may come back as the commented out lines if the kernel
+    // changes the order in which messages are processed.
+    // TODO: allow either message
+    // 'vote rejected outcome: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
+    // 'update failed: Error: (an object) was not a live payment for brand (an object). It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
+    'vote rejected outcome: Error: A Zoe invitation is required, not (an object)',
+    'update failed: Error: A Zoe invitation is required, not (an object)',
+  ]);
 });
-
-const changeTwoParamsLog = [
-  '=> voter and electorate vats are set up',
-  '@@ schedule task for:2, currently: 0 @@',
-  'Voter Alice voted for {"noChange":["Electorate","MalleableNumber"]}',
-  'Voter Bob voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
-  'Voter Carol voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
-  'Voter Dave voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
-  'Voter Emma voted for {"noChange":["Electorate","MalleableNumber"]}',
-  '@@ tick:1 @@',
-  '@@ tick:2 @@',
-  '&& running a task scheduled for 2. &&',
-  'vote outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
-  'Validation complete: true',
-  'updated to ({"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}})',
-  'successful outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}} ',
-  'current value of MalleableNumber is 42',
-  'Electorate,MalleableNumber changed in a vote.',
-  'Electorate,MalleableNumber changed in a vote.',
-];
 
 test.serial('changeTwoParams', async t => {
   const dump = await main(t, ['changeTwoParams']);
-  t.deepEqual(dump.log, changeTwoParamsLog);
+  t.deepEqual(dump.log, [
+    '=> voter and electorate vats are set up',
+    'params update: ',
+    'current value of MalleableNumber is 602214090000000000000000',
+    '@@ schedule task for:2, currently: 0 @@',
+    'Voter Alice voted for {"noChange":["Electorate","MalleableNumber"]}',
+    'Voter Bob voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+    'Voter Carol voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+    'Voter Dave voted for {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+    'Voter Emma voted for {"noChange":["Electorate","MalleableNumber"]}',
+    '@@ tick:1 @@',
+    '@@ tick:2 @@',
+    '&& running a task scheduled for 2. &&',
+    'vote outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
+    'Validation complete: true',
+    'params update: Electorate,MalleableNumber',
+    'current value of MalleableNumber is 42',
+    'updated to ({"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}})',
+    'successful outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: Installation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}} ',
+  ]);
 });
-
-const expectedApiGovernanceLog = [
-  '=> voter and electorate vats are set up',
-  'Number before: 0',
-  '@@ schedule task for:2, currently: 0 @@',
-  'Voter Alice voted for {"dontInvoke":"governanceApi"}',
-  'Voter Bob voted for {"apiMethodName":"governanceApi","methodArgs":[]}',
-  'Voter Carol voted for {"apiMethodName":"governanceApi","methodArgs":[]}',
-  'Voter Dave voted for {"apiMethodName":"governanceApi","methodArgs":[]}',
-  'Voter Emma voted for {"dontInvoke":"governanceApi"}',
-  '@@ tick:1 @@',
-  '@@ tick:2 @@',
-  '&& running a task scheduled for 2. &&',
-  'vote outcome: {"apiMethodName":"governanceApi","methodArgs":[]}',
-  'update value: {"apiMethodName":"governanceApi","methodArgs":[]}',
-  'Number after: 1',
-];
 
 test.serial('api Governance', async t => {
   const dump = await main(t, ['contractApiGovernanceStart']);
-  t.deepEqual(dump.log, expectedApiGovernanceLog);
+  t.deepEqual(dump.log, [
+    '=> voter and electorate vats are set up',
+    'Number before: 0',
+    'params update: ',
+    'current value of MalleableNumber is 602214090000000000000000',
+    '@@ schedule task for:2, currently: 0 @@',
+    'Voter Alice voted for {"dontInvoke":"governanceApi"}',
+    'Voter Bob voted for {"apiMethodName":"governanceApi","methodArgs":[]}',
+    'Voter Carol voted for {"apiMethodName":"governanceApi","methodArgs":[]}',
+    'Voter Dave voted for {"apiMethodName":"governanceApi","methodArgs":[]}',
+    'Voter Emma voted for {"dontInvoke":"governanceApi"}',
+    '@@ tick:1 @@',
+    '@@ tick:2 @@',
+    '&& running a task scheduled for 2. &&',
+    'vote outcome: {"apiMethodName":"governanceApi","methodArgs":[]}',
+    'update value: {"apiMethodName":"governanceApi","methodArgs":[]}',
+    'Number after: 1',
+  ]);
 });

--- a/packages/governance/test/unitTests/test-buildParamManager.js
+++ b/packages/governance/test/unitTests/test-buildParamManager.js
@@ -1,21 +1,21 @@
 // @ts-check
-
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
+
+import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
+import { makeStoredPublisherKit } from '@agoric/notifier';
+import { keyEQ } from '@agoric/store';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
+import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { keyEQ } from '@agoric/store';
-
-import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
-import { ParamTypes, makeParamManagerBuilder } from '../../src/index.js';
+import { makeParamManagerBuilder, ParamTypes } from '../../src/index.js';
 
 test('two parameters', t => {
   const drachmaKit = makeIssuerKit('drachma');
 
   const drachmaBrand = drachmaKit.brand;
-  const paramManager = makeParamManagerBuilder()
+  const paramManager = makeParamManagerBuilder(makeStoredPublisherKit())
     .addBrand('Currency', drachmaBrand)
     .addAmount('Amt', AmountMath.make(drachmaBrand, 37n))
     .build();
@@ -33,7 +33,7 @@ test('getParams', t => {
 
   const drachmaBrand = drachmaKit.brand;
   const drachmas = AmountMath.make(drachmaBrand, 37n);
-  const paramManager = makeParamManagerBuilder()
+  const paramManager = makeParamManagerBuilder(makeStoredPublisherKit())
     .addBrand('Currency', drachmaBrand)
     .addAmount('Amt', drachmas)
     .build();
@@ -58,7 +58,7 @@ test('params duplicate entry', async t => {
   const { brand: stiltonBrand } = makeIssuerKit('stilton', AssetKind.SET);
   t.throws(
     () =>
-      makeParamManagerBuilder()
+      makeParamManagerBuilder(makeStoredPublisherKit())
         .addNat(stuffKey, 37n)
         .addUnknown(stuffKey, stiltonBrand)
         .build(),
@@ -71,7 +71,7 @@ test('params duplicate entry', async t => {
 test('Amount', async t => {
   const { brand: floorBrand } = makeIssuerKit('floor wax');
   const { brand: dessertBrand } = makeIssuerKit('dessertTopping');
-  const paramManager = makeParamManagerBuilder()
+  const paramManager = makeParamManagerBuilder(makeStoredPublisherKit())
     .addAmount('Shimmer', AmountMath.make(floorBrand, 2n))
     .build();
   t.deepEqual(
@@ -117,7 +117,7 @@ test('params one installation', async t => {
     getBundle: () => ({ obfuscated: 42 }),
   });
 
-  const paramManager = makeParamManagerBuilder()
+  const paramManager = makeParamManagerBuilder(makeStoredPublisherKit())
     .addInstallation('PName', installationHandle)
     .build();
 
@@ -158,7 +158,7 @@ test('params one instance', async t => {
   // isInstallation() (#3344), we'll need to make a mockZoe.
   const instanceHandle = makeHandle(handleType);
 
-  const paramManager = makeParamManagerBuilder()
+  const paramManager = makeParamManagerBuilder(makeStoredPublisherKit())
     .addInstance('PName', instanceHandle)
     .build();
 
@@ -205,7 +205,10 @@ test('Invitation', async t => {
 
   const drachmaBrand = drachmaKit.brand;
   const drachmaAmount = AmountMath.make(drachmaBrand, 37n);
-  const paramManagerBuilder = makeParamManagerBuilder(zoe)
+  const paramManagerBuilder = makeParamManagerBuilder(
+    makeStoredPublisherKit(),
+    zoe,
+  )
     .addBrand('Currency', drachmaBrand)
     .addAmount('Amt', drachmaAmount);
   // addInvitation is async, so it can't be part of the cascade.
@@ -242,7 +245,7 @@ test('Invitation', async t => {
 });
 
 test('two Nats', async t => {
-  const paramManager = makeParamManagerBuilder()
+  const paramManager = makeParamManagerBuilder(makeStoredPublisherKit())
     .addNat('Acres', 50n)
     .addNat('SpeedLimit', 299_792_458n)
     .build();
@@ -266,7 +269,7 @@ test('Ratio', async t => {
   const unitlessBrand = makeIssuerKit('unitless').brand;
 
   const ratio = makeRatio(16180n, unitlessBrand, 10_000n);
-  const paramManager = makeParamManagerBuilder()
+  const paramManager = makeParamManagerBuilder(makeStoredPublisherKit())
     .addRatio('GoldenRatio', ratio)
     .build();
   t.is(paramManager.getRatio('GoldenRatio'), ratio);
@@ -305,7 +308,7 @@ test('Record', async t => {
     C2: 'Flying',
     D: 'Blue Jay Way',
   });
-  const paramManager = makeParamManagerBuilder()
+  const paramManager = makeParamManagerBuilder(makeStoredPublisherKit())
     .addRecord('BestEP', epRecord)
     .build();
   t.is(paramManager.getRecord('BestEP'), epRecord);
@@ -355,7 +358,7 @@ test('Record', async t => {
 });
 
 test('Strings', async t => {
-  const paramManager = makeParamManagerBuilder()
+  const paramManager = makeParamManagerBuilder(makeStoredPublisherKit())
     .addNat('Acres', 50n)
     .addString('OurWeapons', 'fear')
     .build();
@@ -379,7 +382,7 @@ test('Strings', async t => {
 });
 
 test('Unknown', async t => {
-  const paramManager = makeParamManagerBuilder()
+  const paramManager = makeParamManagerBuilder(makeStoredPublisherKit())
     .addString('Label', 'birthday')
     .addUnknown('Surprise', 'party')
     .build();

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -227,7 +227,7 @@ test('change multiple params', async t => {
     await E(publicFacet).getSubscription(),
   );
   const update1 = await notifier.getUpdateSince();
-  // this part of the update has objects that can't be literals here for deepEqual
+  // constructing the fixture to deepEqual would complicate this with insufficient benefit
   t.is(
     // @ts-expect-error reaching into unknown values
     update1.value.current.Electorate.value.value[0].description,

--- a/packages/governance/test/unitTests/test-typedParamManager.js
+++ b/packages/governance/test/unitTests/test-typedParamManager.js
@@ -2,6 +2,7 @@
 
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+import { makeStoredPublisherKit } from '@agoric/notifier';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
 import { E } from '@endo/eventual-send';
@@ -20,7 +21,7 @@ const drachmaBrand = drachmaKit.brand;
 
 test('types', async t => {
   t.throws(() =>
-    makeParamManagerSync({
+    makeParamManagerSync(makeStoredPublisherKit(), {
       // @ts-expect-error invalid value for the declared type
       BrokenBrand: [ParamTypes.BRAND, 'not a brand'],
 
@@ -31,7 +32,7 @@ test('types', async t => {
       ],
     }),
   );
-  const mgr = makeParamManagerSync({
+  const mgr = makeParamManagerSync(makeStoredPublisherKit(), {
     Working: [ParamTypes.NAT, 0n],
   });
   mgr.getWorking().valueOf();
@@ -50,6 +51,7 @@ test('makeParamManagerFromTerms', async t => {
   const { zcf } = await setupZCFTest(issuerKeywordRecord, terms);
 
   const paramManager = await makeParamManagerFromTerms(
+    makeStoredPublisherKit(),
     // @ts-expect-error missing governance terms
     zcf,
     zcf.makeInvitation(() => null, 'mock poser invitation'),
@@ -62,7 +64,7 @@ test('makeParamManagerFromTerms', async t => {
 
 test('readonly', t => {
   const drachmas = AmountMath.make(drachmaBrand, 37n);
-  const paramManager = makeParamManagerSync({
+  const paramManager = makeParamManagerSync(makeStoredPublisherKit(), {
     Currency: [ParamTypes.BRAND, drachmaBrand],
     Amt: [ParamTypes.AMOUNT, drachmas],
   });
@@ -73,7 +75,7 @@ test('readonly', t => {
 
 test('two parameters', t => {
   const drachmas = AmountMath.make(drachmaBrand, 37n);
-  const paramManager = makeParamManagerSync({
+  const paramManager = makeParamManagerSync(makeStoredPublisherKit(), {
     Currency: [ParamTypes.BRAND, drachmaBrand],
     Amt: [ParamTypes.AMOUNT, drachmas],
   });
@@ -99,7 +101,7 @@ test('two parameters', t => {
 test('Amount', async t => {
   const { brand: floorBrand } = makeIssuerKit('floor wax');
   const { brand: dessertBrand } = makeIssuerKit('dessertTopping');
-  const paramManager = makeParamManagerSync({
+  const paramManager = makeParamManagerSync(makeStoredPublisherKit(), {
     Shimmer: [ParamTypes.AMOUNT, AmountMath.make(floorBrand, 2n)],
   });
   t.deepEqual(paramManager.getShimmer(), AmountMath.make(floorBrand, 2n));
@@ -149,6 +151,7 @@ test('params one installation', async t => {
   });
 
   const paramManager = await makeParamManager(
+    makeStoredPublisherKit(),
     {
       PName: ['installation', installationHandle],
     },
@@ -188,7 +191,7 @@ test('params one instance', async t => {
   // isInstallation() (#3344), we'll need to make a mockZoe.
   const instanceHandle = makeHandle(instanceKey);
 
-  const paramManager = makeParamManagerSync({
+  const paramManager = makeParamManagerSync(makeStoredPublisherKit(), {
     PName: ['instance', instanceHandle],
   });
 
@@ -234,6 +237,7 @@ test('Invitation', async t => {
 
   const drachmaAmount = AmountMath.make(drachmaBrand, 37n);
   const paramManager = await makeParamManager(
+    makeStoredPublisherKit(),
     {
       Currency: [ParamTypes.BRAND, drachmaBrand],
       Amt: [ParamTypes.AMOUNT, drachmaAmount],
@@ -270,7 +274,7 @@ test('Invitation', async t => {
 });
 
 test('two Nats', async t => {
-  const paramManager = makeParamManagerSync({
+  const paramManager = makeParamManagerSync(makeStoredPublisherKit(), {
     Acres: [ParamTypes.NAT, 50n],
     SpeedLimit: [ParamTypes.NAT, 299_792_458n],
   });
@@ -294,7 +298,7 @@ test('Ratio', async t => {
   const unitlessBrand = makeIssuerKit('unitless').brand;
 
   const ratio = makeRatio(16180n, unitlessBrand, 10_000n);
-  const paramManager = makeParamManagerSync({
+  const paramManager = makeParamManagerSync(makeStoredPublisherKit(), {
     Acres: [ParamTypes.NAT, 50n],
     GoldenRatio: ['ratio', ratio],
   });
@@ -326,7 +330,7 @@ test('Ratio', async t => {
 });
 
 test('Strings', async t => {
-  const paramManager = makeParamManagerSync({
+  const paramManager = makeParamManagerSync(makeStoredPublisherKit(), {
     Acres: [ParamTypes.NAT, 50n],
     OurWeapons: ['string', 'fear'],
   });
@@ -343,7 +347,7 @@ test('Strings', async t => {
 });
 
 test('Unknown', async t => {
-  const paramManager = makeParamManagerSync({
+  const paramManager = makeParamManagerSync(makeStoredPublisherKit(), {
     Label: ['string', 'birthday'],
     Surprise: ['unknown', 'party'],
   });

--- a/packages/run-protocol/src/proposals/econ-behaviors.js
+++ b/packages/run-protocol/src/proposals/econ-behaviors.js
@@ -459,25 +459,29 @@ export const startVaultFactory = async (
   const priceAuthority = await priceAuthorityP;
   const reservePublicFacet = await E(zoe).getPublicFacet(reserveInstance);
   const timer = await chainTimerService;
-  const vaultFactoryTerms = makeGovernedTerms({
-    priceAuthority,
-    reservePublicFacet,
-    loanTiming: loanParams,
-    liquidationInstall: installations.liquidate,
-    timer,
-    electorateInvitationAmount: poserInvitationAmount,
-    vaultManagerParams,
-    ammPublicFacet,
-    liquidationTerms: liquidationDetailTerms(centralBrand),
-    minInitialDebt: AmountMath.make(centralBrand, minInitialDebt),
-    bootstrapPaymentValue: 0n,
-    shortfallInvitationAmount,
-  });
 
   const chainStoragePresence = await chainStorage;
   const storageNode = await (chainStoragePresence &&
     E(chainStoragePresence).getChildNode(STORAGE_PATH));
   const marshaller = E(board).getReadonlyMarshaller();
+
+  const vaultFactoryTerms = makeGovernedTerms(
+    { storageNode, marshaller },
+    {
+      priceAuthority,
+      reservePublicFacet,
+      loanTiming: loanParams,
+      liquidationInstall: installations.liquidate,
+      timer,
+      electorateInvitationAmount: poserInvitationAmount,
+      vaultManagerParams,
+      ammPublicFacet,
+      liquidationTerms: liquidationDetailTerms(centralBrand),
+      minInitialDebt: AmountMath.make(centralBrand, minInitialDebt),
+      bootstrapPaymentValue: 0n,
+      shortfallInvitationAmount,
+    },
+  );
 
   const governorTerms = harden({
     timer,

--- a/packages/run-protocol/src/psm/psm.js
+++ b/packages/run-protocol/src/psm/psm.js
@@ -10,6 +10,7 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { Far } from '@endo/marshal';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
+import { makeStoredPublisherKit } from '@agoric/notifier';
 
 import { AmountMath } from '@agoric/ertp';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
@@ -71,11 +72,17 @@ export const start = async (zcf, { feeMintAccess, initialPoserInvitation }) => {
   const emptyAnchor = AmountMath.makeEmpty(anchorBrand);
 
   const { augmentPublicFacet, makeGovernorFacet, params } =
-    await handleParamGovernance(zcf, initialPoserInvitation, {
-      GiveStableFee: ParamTypes.RATIO,
-      MintLimit: ParamTypes.AMOUNT,
-      WantStableFee: ParamTypes.RATIO,
-    });
+    await handleParamGovernance(
+      // TODO https://github.com/Agoric/agoric-sdk/issues/5386
+      makeStoredPublisherKit(),
+      zcf,
+      initialPoserInvitation,
+      {
+        GiveStableFee: ParamTypes.RATIO,
+        MintLimit: ParamTypes.AMOUNT,
+        WantStableFee: ParamTypes.RATIO,
+      },
+    );
 
   const { zcfSeat: anchorPool } = zcf.makeEmptySeatKit();
   const { zcfSeat: feePool } = zcf.makeEmptySeatKit();

--- a/packages/run-protocol/src/reserve/assetReserve.js
+++ b/packages/run-protocol/src/reserve/assetReserve.js
@@ -4,6 +4,7 @@ import { E, Far } from '@endo/far';
 import { makeStore } from '@agoric/store';
 import { AmountMath } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
+import { makeStoredPublisherKit } from '@agoric/notifier';
 import { offerTo } from '@agoric/zoe/src/contractSupport/index.js';
 
 import { AMM_INSTANCE } from './params.js';
@@ -76,9 +77,15 @@ const start = async (zcf, privateArgs) => {
   };
 
   const { augmentPublicFacet, makeGovernorFacet, params } =
-    await handleParamGovernance(zcf, privateArgs.initialPoserInvitation, {
-      [AMM_INSTANCE]: ParamTypes.INSTANCE,
-    });
+    await handleParamGovernance(
+      // TODO https://github.com/Agoric/agoric-sdk/issues/5386
+      makeStoredPublisherKit(),
+      zcf,
+      privateArgs.initialPoserInvitation,
+      {
+        [AMM_INSTANCE]: ParamTypes.INSTANCE,
+      },
+    );
 
   /** @type {Promise<XYKAMMPublicFacet>} */
   const ammPublicFacet = E(zcf.getZoeService()).getPublicFacet(

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -2,6 +2,7 @@
 // @jessie-check
 import { AmountMath } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
+import { makeStoredPublisherKit } from '@agoric/notifier';
 import { E, Far } from '@endo/far';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import { makeAttestationFacets } from './attestation.js';
@@ -99,12 +100,18 @@ export const start = async (
   const attestBrand = await E(att.publicFacet).getBrand();
 
   const { augmentPublicFacet, makeGovernorFacet, params } =
-    await handleParamGovernance(zcf, initialPoserInvitation, {
-      DebtLimit: ParamTypes.AMOUNT,
-      InterestRate: ParamTypes.RATIO,
-      LoanFee: ParamTypes.RATIO,
-      MintingRatio: ParamTypes.RATIO,
-    });
+    await handleParamGovernance(
+      // TODO https://github.com/Agoric/agoric-sdk/issues/5386
+      makeStoredPublisherKit(),
+      zcf,
+      initialPoserInvitation,
+      {
+        DebtLimit: ParamTypes.AMOUNT,
+        InterestRate: ParamTypes.RATIO,
+        LoanFee: ParamTypes.RATIO,
+        MintingRatio: ParamTypes.RATIO,
+      },
+    );
 
   /** For temporary staging of newly minted tokens */
   const { zcfSeat: mintSeat } = zcf.makeEmptySeatKit();

--- a/packages/run-protocol/src/vaultFactory/params.js
+++ b/packages/run-protocol/src/vaultFactory/params.js
@@ -8,6 +8,7 @@ import {
   makeParamManager,
   ParamTypes,
 } from '@agoric/governance';
+import { makeStoredPublisherKit } from '@agoric/notifier';
 import { M } from '@agoric/store';
 import { amountPattern, ratioPattern } from '../contractSupport.js';
 
@@ -65,10 +66,11 @@ const makeVaultDirectorParams = (
 /** @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager').ParamTypesMapFromRecord<ReturnType<typeof makeVaultDirectorParams>>} VaultDirectorParams */
 
 /**
+ * @param {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} publisherKit
  * @param {VaultManagerParamValues} initial
  */
-const makeVaultParamManager = initial =>
-  makeParamManagerSync({
+const makeVaultParamManager = (publisherKit, initial) =>
+  makeParamManagerSync(publisherKit, {
     [DEBT_LIMIT_KEY]: [ParamTypes.AMOUNT, initial.debtLimit],
     [LIQUIDATION_MARGIN_KEY]: [ParamTypes.RATIO, initial.liquidationMargin],
     [LIQUIDATION_PENALTY_KEY]: [ParamTypes.RATIO, initial.liquidationPenalty],
@@ -89,6 +91,7 @@ export const vaultParamPattern = M.split(
 );
 
 /**
+ * @param {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} publisherKit
  * @param {ERef<ZoeService>} zoe
  * @param {Invitation} electorateInvitation
  * @param {Installation} liquidationInstall
@@ -97,6 +100,7 @@ export const vaultParamPattern = M.split(
  * @param {Invitation} shortfallInvitation
  */
 const makeVaultDirectorParamManager = async (
+  publisherKit,
   zoe,
   electorateInvitation,
   liquidationInstall,
@@ -105,6 +109,7 @@ const makeVaultDirectorParamManager = async (
   shortfallInvitation,
 ) => {
   return makeParamManager(
+    publisherKit,
     {
       [CONTRACT_ELECTORATE]: [ParamTypes.INVITATION, electorateInvitation],
       [LIQUIDATION_INSTALL_KEY]: [ParamTypes.INSTALLATION, liquidationInstall],
@@ -117,6 +122,7 @@ const makeVaultDirectorParamManager = async (
 };
 
 /**
+ * @param {{storageNode?: ERef<StorageNode>, marshaller?: ERef<Marshaller>}} caps
  * @param {{
  *   electorateInvitationAmount: Amount,
  *   minInitialDebt: Amount,
@@ -132,26 +138,35 @@ const makeVaultDirectorParamManager = async (
  *   shortfallInvitationAmount: Amount,
  * }} opts
  */
-const makeGovernedTerms = ({
-  ammPublicFacet,
-  bootstrapPaymentValue,
-  electorateInvitationAmount,
-  liquidationInstall,
-  liquidationTerms,
-  loanTiming,
-  minInitialDebt,
-  priceAuthority,
-  reservePublicFacet,
-  timer,
-  vaultManagerParams,
-  shortfallInvitationAmount,
-}) => {
-  const loanTimingParams = makeParamManagerSync({
-    [CHARGING_PERIOD_KEY]: ['nat', loanTiming.chargingPeriod],
-    [RECORDING_PERIOD_KEY]: ['nat', loanTiming.recordingPeriod],
-  }).getParams();
+const makeGovernedTerms = (
+  { storageNode, marshaller },
+  {
+    ammPublicFacet,
+    bootstrapPaymentValue,
+    electorateInvitationAmount,
+    liquidationInstall,
+    liquidationTerms,
+    loanTiming,
+    minInitialDebt,
+    priceAuthority,
+    reservePublicFacet,
+    timer,
+    vaultManagerParams,
+    shortfallInvitationAmount,
+  },
+) => {
+  const loanTimingParams = makeParamManagerSync(
+    makeStoredPublisherKit(storageNode, marshaller, 'timingParams'),
+    {
+      [CHARGING_PERIOD_KEY]: ['nat', loanTiming.chargingPeriod],
+      [RECORDING_PERIOD_KEY]: ['nat', loanTiming.recordingPeriod],
+    },
+  ).getParams();
 
-  const loanParams = makeVaultParamManager(vaultManagerParams).getParams();
+  const loanParams = makeVaultParamManager(
+    makeStoredPublisherKit(storageNode, marshaller, 'collateralParams'),
+    vaultManagerParams,
+  ).getParams();
 
   return harden({
     ammPublicFacet,

--- a/packages/run-protocol/src/vaultFactory/params.js
+++ b/packages/run-protocol/src/vaultFactory/params.js
@@ -62,7 +62,7 @@ const makeVaultDirectorParams = (
   });
 };
 
-/** @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager').ParamTypesMapFromRecords<ReturnType<typeof makeVaultDirectorParams>>} VaultDirectorParams */
+/** @typedef {import('@agoric/governance/src/contractGovernance/typedParamManager').ParamTypesMapFromRecord<ReturnType<typeof makeVaultDirectorParams>>} VaultDirectorParams */
 
 /**
  * @param {VaultManagerParamValues} initial

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -478,10 +478,8 @@ const publicBehavior = {
    *
    * @param {MethodContext} context
    */
-  getSubscription:
-    ({ state }) =>
-    paramDesc =>
-      state.vaultParamManagers.get(paramDesc.collateralBrand).getSubscription(),
+  getSubscription: ({ state }, { collateralBrand }) =>
+    state.vaultParamManagers.get(collateralBrand).getSubscription(),
   /**
    * subscription for the paramManager for the vaultFactory's electorate
    *

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -536,7 +536,7 @@ const finish = async ({ state }) => {
  * @param {ZCF<GovernanceTerms<{}> & {
  *   ammPublicFacet: AutoswapPublicFacet,
  *   liquidationInstall: Installation<import('./liquidateMinimum.js').start>,
- *   loanTimingParams: {ChargingPeriod: ParamRecord<'nat'>, RecordingPeriod: ParamRecord<'nat'>},
+ *   loanTimingParams: {ChargingPeriod: ParamValueTyped<'nat'>, RecordingPeriod: ParamValueTyped<'nat'>},
  *   reservePublicFacet: AssetReservePublicFacet,
  *   timerService: TimerService,
  *   priceAuthority: ERef<PriceAuthority>

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -18,7 +18,7 @@ import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
 import { defineKindMulti } from '@agoric/vat-data';
-import { observeIteration } from '@agoric/notifier';
+import { makeStoredPublisherKit, observeIteration } from '@agoric/notifier';
 import { makeVaultManager } from './vaultManager.js';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import {
@@ -298,8 +298,20 @@ const machineBehavior = {
       `Collateral brand ${collateralBrand} has already been added`,
     );
 
+    const managerStorageNode =
+      state.storageNode &&
+      E(state.storageNode).getChildNode(`manager${state.managerCounter}`);
+    state.managerCounter += 1;
+
     /** a powerful object; can modify parameters */
-    const vaultParamManager = makeVaultParamManager(initialParamValues);
+    const vaultParamManager = makeVaultParamManager(
+      makeStoredPublisherKit(
+        managerStorageNode,
+        state.marshaller,
+        'governance',
+      ),
+      initialParamValues,
+    );
     vaultParamManagers.init(collateralBrand, vaultParamManager);
 
     const { timerService } = zcf.getTerms();
@@ -370,11 +382,6 @@ const machineBehavior = {
       },
       burnDebt,
     });
-
-    const managerStorageNode =
-      state.storageNode &&
-      E(state.storageNode).getChildNode(`manager${state.managerCounter}`);
-    state.managerCounter += 1;
 
     const vm = makeVaultManager(
       zcf,
@@ -477,6 +484,7 @@ const publicBehavior = {
    * subscription for the paramManager for a particular vaultManager
    *
    * @param {MethodContext} context
+   * @param {{ collateralBrand: Brand }} selector
    */
   getSubscription: ({ state }, { collateralBrand }) =>
     state.vaultParamManagers.get(collateralBrand).getSubscription(),

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -32,7 +32,7 @@ import { makeVaultDirector } from './vaultDirector.js';
  * @typedef {ZCF<GovernanceTerms<import('./params').VaultDirectorParams> & {
  *   ammPublicFacet: AutoswapPublicFacet,
  *   liquidationInstall: Installation<import('./liquidateMinimum.js').start>,
- *   loanTimingParams: {ChargingPeriod: ParamRecord<'nat'>, RecordingPeriod: ParamRecord<'nat'>},
+ *   loanTimingParams: {ChargingPeriod: ParamValueTyped<'nat'>, RecordingPeriod: ParamValueTyped<'nat'>},
  *   minInitialDebt: Amount,
  *   priceAuthority: ERef<PriceAuthority>,
  *   reservePublicFacet: AssetReservePublicFacet,

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -20,6 +20,7 @@ import '@agoric/zoe/src/contracts/exported.js';
 // { getParamMgrRetriever, getInvitation, getLimitedCreatorFacet }.
 
 import { assertElectorateMatches } from '@agoric/governance';
+import { makeStoredPublisherKit } from '@agoric/notifier';
 import {
   makeVaultDirectorParamManager,
   LIQUIDATION_INSTALL_KEY,
@@ -66,6 +67,11 @@ export const start = async (zcf, privateArgs) => {
   } = zcf.getTerms().governedParams;
   /** a powerful object; can modify the invitation */
   const vaultDirectorParamManager = await makeVaultDirectorParamManager(
+    makeStoredPublisherKit(
+      privateArgs.storageNode,
+      privateArgs.marshaller,
+      'governance',
+    ),
     zcf.getZoeService(),
     initialPoserInvitation,
     liqInstall,

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -85,7 +85,7 @@ const trace = makeTracer('VM');
  * factoryPowers: import('./vaultDirector.js').FactoryPowersFacet,
  * marshaller?: ERef<Marshaller>,
  * metricsPublication: IterationObserver<MetricsNotification>,
- * metricsSubscription: Subscription<MetricsNotification>,
+ * metricsSubscription: StoredSubscription<MetricsNotification>,
  * periodNotifier: ERef<Notifier<bigint>>,
  * poolIncrementSeat: ZCFSeat,
  * priceAuthority: ERef<PriceAuthority>,

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -5,7 +5,7 @@ import { Far } from '@endo/marshal';
 
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
-
+import { makeStoredPublisherKit } from '@agoric/notifier';
 import {
   assertIssuerKeywords,
   offerTo,
@@ -133,11 +133,17 @@ const start = async (zcf, privateArgs) => {
     { augmentPublicFacet, makeGovernorFacet, params },
     centralDisplayInfo,
   ] = await Promise.all([
-    handleParamGovernance(zcf, privateArgs.initialPoserInvitation, {
-      [POOL_FEE_KEY]: ParamTypes.NAT,
-      [PROTOCOL_FEE_KEY]: ParamTypes.NAT,
-      [MIN_INITIAL_POOL_LIQUIDITY_KEY]: ParamTypes.AMOUNT,
-    }),
+    handleParamGovernance(
+      // TODO https://github.com/Agoric/agoric-sdk/issues/5386
+      makeStoredPublisherKit(),
+      zcf,
+      privateArgs.initialPoserInvitation,
+      {
+        [POOL_FEE_KEY]: ParamTypes.NAT,
+        [PROTOCOL_FEE_KEY]: ParamTypes.NAT,
+        [MIN_INITIAL_POOL_LIQUIDITY_KEY]: ParamTypes.AMOUNT,
+      },
+    ),
     E(centralBrand).getDisplayInfo(),
   ]);
 

--- a/packages/run-protocol/src/vpool-xyk-amm/params.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/params.js
@@ -5,6 +5,7 @@ import {
   makeParamManager,
   ParamTypes,
 } from '@agoric/governance';
+import { makeStoredPublisherKit } from '@agoric/notifier';
 
 export const POOL_FEE_KEY = 'PoolFee';
 export const PROTOCOL_FEE_KEY = 'ProtocolFee';
@@ -28,6 +29,8 @@ const makeAmmParamManager = async (
   poserInvitation,
 ) => {
   return makeParamManager(
+    // TODO https://github.com/Agoric/agoric-sdk/issues/5386
+    makeStoredPublisherKit(),
     {
       [POOL_FEE_KEY]: [ParamTypes.NAT, poolFeeBP],
       [PROTOCOL_FEE_KEY]: [ParamTypes.NAT, protocolFeeBP],

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -185,3 +185,13 @@ export const withAmountUtils = kit => {
   };
 };
 /** @typedef {ReturnType<typeof withAmountUtils>} AmountUtils */
+
+/**
+ *
+ * @param {Promise<StoredSubscription<unknown>>} subscription
+ */
+export const subscriptionKey = subscription => {
+  return E(subscription)
+    .getStoreKey()
+    .then(storeKey => storeKey.key);
+};

--- a/packages/run-protocol/test/swingsetTests/setup.js
+++ b/packages/run-protocol/test/swingsetTests/setup.js
@@ -207,20 +207,23 @@ const buildOwner = async (
   // @ts-expect-error cast, never used
   const shortfallInvitationAmount = null;
 
-  const terms = makeVaultFactoryTerms({
-    priceAuthority: priceAuthorityKit.priceAuthority,
-    loanTiming,
-    liquidationInstall: installations.liquidateMinimum,
-    timer,
-    electorateInvitationAmount: poserInvitationAmount,
-    vaultManagerParams,
-    ammPublicFacet: ammMock,
-    liquidationTerms: liquidationDetailTerms(runBrand),
-    minInitialDebt: AmountMath.make(runBrand, 100n),
-    bootstrapPaymentValue: 0n,
-    reservePublicFacet,
-    shortfallInvitationAmount,
-  });
+  const terms = makeVaultFactoryTerms(
+    {},
+    {
+      priceAuthority: priceAuthorityKit.priceAuthority,
+      loanTiming,
+      liquidationInstall: installations.liquidateMinimum,
+      timer,
+      electorateInvitationAmount: poserInvitationAmount,
+      vaultManagerParams,
+      ammPublicFacet: ammMock,
+      liquidationTerms: liquidationDetailTerms(runBrand),
+      minInitialDebt: AmountMath.make(runBrand, 100n),
+      bootstrapPaymentValue: 0n,
+      reservePublicFacet,
+      shortfallInvitationAmount,
+    },
+  );
 
   const privateVaultFactoryArgs = { feeMintAccess, initialPoserInvitation };
 

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -17,13 +17,14 @@ const contractRoot = `${dirname}/zcfTesterContract.js`;
 /**
  * Test setup utility
  *
+ * @template {object} [T=object] terms
  * @param {IssuerKeywordRecord} [issuerKeywordRecord]
- * @param {Record<string, unknown>} [terms]
+ * @param {T} [terms]
  */
 export const setupZCFTest = async (issuerKeywordRecord, terms) => {
-  /** @type {ZCF} */
+  /** @type {ZCF<T>} */
   let zcf;
-  /** @type {ZCF} */
+  /** @type {ZCF<T>} */
   let zcf2;
 
   // We would like to start two contract instances in order to get two
@@ -46,12 +47,18 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   const { creatorFacet, instance } = await E(zoe).startInstance(
     installation,
     issuerKeywordRecord,
+    // @ts-expect-error generics mismatch
     terms,
   );
   // In case a second zcf is needed
   const { creatorFacet: creatorFacet2, instance: instance2 } = await E(
     zoe,
-  ).startInstance(installation, issuerKeywordRecord, terms);
+  ).startInstance(
+    installation,
+    issuerKeywordRecord,
+    // @ts-expect-error generics mismatch
+    terms,
+  );
   const { vatAdminState } = fakeVatAdmin;
   // @ts-expect-error setZCF may not have been called yet
   assert(zcf, 'zcf is required; did you forget to setZCF?');


### PR DESCRIPTION
progress on: #5268

## Description

Make the existing `getSubscription` on param managers use off-chain storage.

Refactor some types and internal methods to support that. One breaking refactor for an untested method `getSubscription` on vaultDirector.

### Security Considerations

Exposes governance parameter values and changes. This should all be public.

### Documentation Considerations

--

### Testing Considerations

Had to update swingset tests and they test less now, though what's missing is now tested elsewhere.