### PR TITLE
chore(xsnap): update to latest moddable XS version

### DIFF
--- a/packages/xsnap/api.js
+++ b/packages/xsnap/api.js
@@ -3,7 +3,7 @@
 /** The version identifier for our meter type.
  * TODO Bump this whenever there's a change to metering semantics.
  */
-export const METER_TYPE = 'xs-meter-14';
+export const METER_TYPE = 'xs-meter-15';
 
 export const ExitCode = {
   E_UNKNOWN_ERROR: -1,

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -63,7 +63,7 @@ test('meter details', async t => {
     },
     'evaluate returns meter details',
   );
-  t.is(meterType, 'xs-meter-14');
+  t.is(meterType, 'xs-meter-15');
 });
 
 (globalThis.performance ? test : test.skip)('meter timestamps', async t => {


### PR DESCRIPTION
The biggest change is a fix for Linux/ARM, where certain Promise
rejections were doing a fulfill by mistake.

I'm not sure if this changes the metering behavior, but there are
enough changes to the C code that I think it's likely. So I've also
bumped the metering version to 'xs-meter-15'.

closes #5587
