### PR TITLE
fix: simplify singletons

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -487,7 +487,6 @@ export const makeDurablePaymentLedger = (
     mintPayment,
   });
 
-  // @ts-expect-error Cannot figure out types.
   const brand = /** @type {Brand} */ (
     ProvideFar(issuerBaggage, `${allegedName} brand`, {
       isMyIssuer: allegedIssuerP =>
@@ -508,7 +507,6 @@ export const makeDurablePaymentLedger = (
     assetKind,
     elementSchema,
   );
-  // @ts-expect-error Just too much typing foo for now.
   return issuerKit;
 };
 harden(makeDurablePaymentLedger);

--- a/packages/ERTP/test/swingsetTests/ertpService/vat-ertp-service.js
+++ b/packages/ERTP/test/swingsetTests/ertpService/vat-ertp-service.js
@@ -4,7 +4,7 @@ import { Far } from '@endo/marshal';
 import {
   makeScalarBigMapStore,
   makeScalarBigSetStore,
-  provideDurableSingleton,
+  ProvideFar,
 } from '@agoric/vat-data/src';
 import { provide } from '@agoric/store';
 
@@ -24,9 +24,8 @@ function makeErtpService(baggage, exitVatWithFailure) {
     });
   });
 
-  const ertpService = provideDurableSingleton(baggage, 'ERTPService', {
+  const ertpService = ProvideFar(baggage, 'ERTPService', {
     makeIssuerKit: (
-      _context,
       allegedName,
       assetKind = AssetKind.NAT,
       displayInfo = harden({}),

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -16,6 +16,29 @@ export const provideKindHandle = (baggage, kindName) =>
 harden(provideKindHandle);
 
 /**
+ * By analogy with how `Array.prototype.map` will map the elements of
+ * an array to transformed elements of an array of the same shape,
+ * `objectMap` will do likewise for the string-named own enumerable
+ * properties of an object.
+ *
+ * See the comment at
+ * https://github.com/Agoric/agoric-sdk/pull/5674#discussion_r908883510
+ * TODO need to move this to a common place.
+ *
+ * @template T, U
+ * @template {keyof T} K
+ * @param {{ [K2 in keyof T]: T[K2] }} original
+ * @param {(pair: [K, T[K]]) => [K, U]} mapPairFn
+ * @returns {Record<K, U>}
+ */
+export const objectMap = (original, mapPairFn) => {
+  const ents = /** @type {[K, T[K]][]} */ (Object.entries(original));
+  const mapEnts = ents.map(ent => mapPairFn(ent));
+  // @ts-expect-error TODO statically recognize harden
+  return /** @type {Record<K, U>} */ (harden(Object.fromEntries(mapEnts)));
+};
+
+/**
  * @template T
  * @param {import('@agoric/store').MapStore<string, unknown>} baggage
  * @param {string} kindName
@@ -25,9 +48,7 @@ harden(provideKindHandle);
  */
 export const ProvideFar = (baggage, kindName, methods, options = undefined) => {
   const kindHandle = provideKindHandle(baggage, kindName);
-  const behavior = fromEntries(
-    entries(methods).map(([k, m]) => [k, dropContext(m)]),
-  );
+  const behavior = objectMap(methods, ([k, m]) => [k, dropContext(m)]);
   const makeSingleton = defineDurableKind(
     kindHandle,
     () => ({}),

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -15,6 +15,14 @@ export const provideKindHandle = (baggage, kindName) =>
 // @ts-expect-error TODO statically recognize harden
 harden(provideKindHandle);
 
+/**
+ * @template T
+ * @param {import('@agoric/store').MapStore<string, unknown>} baggage
+ * @param {string} kindName
+ * @param {T} methods
+ * @param {import('./types.js').DefineKindOptions<unknown>} [options]
+ * @returns {T}
+ */
 export const ProvideFar = (baggage, kindName, methods, options = undefined) => {
   const kindHandle = provideKindHandle(baggage, kindName);
   const behavior = fromEntries(

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -1,22 +1,25 @@
 import { provide } from '@agoric/store';
-import {
-  defineDurableKind,
-  defineDurableKindMulti,
-  makeKindHandle,
-} from './vat-data-bindings.js';
+import { defineDurableKind, makeKindHandle } from './vat-data-bindings.js';
+
+const { fromEntries, entries } = Object;
+
+export const dropContext =
+  fn =>
+  (_, ...args) =>
+    fn(...args);
+// @ts-expect-error TODO statically recognize harden
+harden(dropContext);
 
 export const provideKindHandle = (baggage, kindName) =>
   provide(baggage, `${kindName}_kindHandle`, () => makeKindHandle(kindName));
 // @ts-expect-error TODO statically recognize harden
 harden(provideKindHandle);
 
-export const provideDurableSingleton = (
-  baggage,
-  kindName,
-  behavior,
-  options = undefined,
-) => {
+export const ProvideFar = (baggage, kindName, methods, options = undefined) => {
   const kindHandle = provideKindHandle(baggage, kindName);
+  const behavior = fromEntries(
+    entries(methods).map(([k, m]) => [k, dropContext(m)]),
+  );
   const makeSingleton = defineDurableKind(
     kindHandle,
     () => ({}),
@@ -26,29 +29,4 @@ export const provideDurableSingleton = (
   return provide(baggage, `the_${kindName}`, () => makeSingleton());
 };
 // @ts-expect-error TODO statically recognize harden
-harden(provideDurableSingleton);
-
-export const provideDurableSingletonKit = (
-  baggage,
-  kindName,
-  behaviorFacets,
-  options = undefined,
-) => {
-  const kindHandle = provideKindHandle(baggage, kindName);
-  const makeSingletonKit = defineDurableKindMulti(
-    kindHandle,
-    () => ({}),
-    behaviorFacets,
-    options,
-  );
-  return provide(baggage, `the_${kindName}`, () => makeSingletonKit());
-};
-// @ts-expect-error TODO statically recognize harden
-harden(provideDurableSingletonKit);
-
-export const dropContext =
-  fn =>
-  (_, ...args) =>
-    fn(...args);
-// @ts-expect-error TODO statically recognize harden
-harden(dropContext);
+harden(ProvideFar);


### PR DESCRIPTION
We've already noticed that singletons always have empty state records, and so their behavior methods never need to use their `state`. @dtribble noticed that we can simply use JS's const scoping (temporal dead zone) to make the `self` or `facets` arguments unnecessary. At that point the context is unnecessary and we just need the "normal" methods. Without common state, there's also little reason to group these into a cohort. Thus, our support for singletons can be much closer to `Far`. To emphasize this, at this time this PR used the term `ProvideFar`, but we should bikeshed.
