### PR TITLE
5268 governance StoredSubscriptions

### DIFF
--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -1,13 +1,14 @@
 // @ts-check
 
 import { Far } from '@endo/marshal';
+import { makeStoredPublisherKit } from '@agoric/notifier';
 import { keyEQ } from '@agoric/store';
-// eslint-disable-next-line -- https://github.com/Agoric/agoric-sdk/pull/4837
-import { CONTRACT_ELECTORATE } from './contractGovernance/governParam.js';
 import { assertElectorateMatches } from './contractGovernance/paramManager.js';
 import { makeParamManagerFromTerms } from './contractGovernance/typedParamManager.js';
 
 const { details: X, quote: q } = assert;
+
+export const GOVERNANCE_STORAGE_KEY = 'governance';
 
 /**
  * Utility function for `makeParamGovernance`.
@@ -116,17 +117,25 @@ const facetHelpers = (zcf, paramManager) => {
  *
  * @template {import('./contractGovernance/typedParamManager').ParamTypesMap} M
  *   Map of types of custom governed terms
- * @param {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} publisherKit
  * @param {ZCF<GovernanceTerms<M>>} zcf
  * @param {Invitation} initialPoserInvitation
  * @param {M} paramTypesMap
+ * @param {ERef<StorageNode>} [storageNode]
+ * @param {ERef<Marshaller>} [marshaller]
  */
 const handleParamGovernance = async (
-  publisherKit,
   zcf,
   initialPoserInvitation,
   paramTypesMap,
+  storageNode,
+  marshaller,
 ) => {
+  /** @type {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} */
+  const publisherKit = makeStoredPublisherKit(
+    storageNode,
+    marshaller,
+    GOVERNANCE_STORAGE_KEY,
+  );
   const paramManager = await makeParamManagerFromTerms(
     publisherKit,
     zcf,

--- a/packages/governance/test/swingsetTests/contractGovernor/governedContract.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/governedContract.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import { makeStoredPublisherKit } from '@agoric/notifier';
 import { handleParamGovernance } from '../../../src/contractHelper.js';
 import { ParamTypes } from '../../../src/index.js';
 import { CONTRACT_ELECTORATE } from '../../../src/contractGovernance/governParam.js';
@@ -30,14 +29,9 @@ const makeTerms = (number, invitationAmount) => {
  */
 const start = async (zcf, privateArgs) => {
   const { augmentPublicFacet, makeGovernorFacet, params } =
-    await handleParamGovernance(
-      makeStoredPublisherKit(),
-      zcf,
-      privateArgs.initialPoserInvitation,
-      {
-        [MALLEABLE_NUMBER]: ParamTypes.NAT,
-      },
-    );
+    await handleParamGovernance(zcf, privateArgs.initialPoserInvitation, {
+      [MALLEABLE_NUMBER]: ParamTypes.NAT,
+    });
 
   let governanceAPICalled = 0;
   const governanceApi = () => (governanceAPICalled += 1);

--- a/packages/run-protocol/src/proposals/README.md
+++ b/packages/run-protocol/src/proposals/README.md
@@ -1,0 +1,7 @@
+# Proposals
+
+These are code snippets that go into propoals to the BLDer DAO to start the Inter Protocol.
+
+One of the latest is `startPSM.js` so best to model after that. The style in `econ-behaviors.js` will be refactored to be like startPSM.
+
+[syntax of the manifests](../../packages/vats/src/core/manifest.js)

--- a/packages/run-protocol/src/proposals/core-proposal.js
+++ b/packages/run-protocol/src/proposals/core-proposal.js
@@ -193,6 +193,8 @@ const RUN_STAKE_MANIFEST = harden({
   },
   [econBehaviors.startRunStake.name]: {
     consume: {
+      board: 'board',
+      chainStorage: true,
       zoe: 'zoe',
       feeMintAccess: 'zoe',
       lienBridge: true,

--- a/packages/run-protocol/src/proposals/startPSM.js
+++ b/packages/run-protocol/src/proposals/startPSM.js
@@ -22,9 +22,11 @@ export const startPSM = async (
   {
     consume: {
       agoricNamesAdmin,
+      board,
       zoe,
       feeMintAccess: feeMintAccessP,
       economicCommitteeCreatorFacet,
+      chainStorage,
       chainTimerService,
     },
     produce: { psmCreatorFacet, psmGovernorCreatorFacet },
@@ -105,6 +107,11 @@ export const startPSM = async (
     },
   };
 
+  const chainStoragePresence = await chainStorage;
+  const storageNode = await (chainStoragePresence &&
+    E(chainStoragePresence).getChildNode('psm'));
+  const marshaller = E(board).getPublishingMarshaller();
+
   const governorFacets = await E(zoe).startInstance(
     governor,
     {},
@@ -115,7 +122,12 @@ export const startPSM = async (
       governed: harden({
         terms,
         issuerKeywordRecord: { [keyword]: anchorIssuer },
-        privateArgs: { feeMintAccess, initialPoserInvitation },
+        privateArgs: {
+          feeMintAccess,
+          initialPoserInvitation,
+          marshaller,
+          storageNode,
+        },
       }),
     },
     harden({ economicCommitteeCreatorFacet }),
@@ -211,6 +223,8 @@ export const PSM_MANIFEST = harden({
   [startPSM.name]: {
     consume: {
       agoricNamesAdmin: true,
+      board: true,
+      chainStorage: true,
       zoe: 'zoe',
       feeMintAccess: 'zoe',
       economicCommitteeCreatorFacet: 'economicCommittee',

--- a/packages/run-protocol/src/psm/psm.js
+++ b/packages/run-protocol/src/psm/psm.js
@@ -72,17 +72,12 @@ export const start = async (zcf, { feeMintAccess, initialPoserInvitation }) => {
   const emptyAnchor = AmountMath.makeEmpty(anchorBrand);
 
   const { augmentPublicFacet, makeGovernorFacet, params } =
-    await handleParamGovernance(
-      // TODO https://github.com/Agoric/agoric-sdk/issues/5386
-      makeStoredPublisherKit(),
-      zcf,
-      initialPoserInvitation,
-      {
-        GiveStableFee: ParamTypes.RATIO,
-        MintLimit: ParamTypes.AMOUNT,
-        WantStableFee: ParamTypes.RATIO,
-      },
-    );
+    // TODO https://github.com/Agoric/agoric-sdk/issues/5386
+    await handleParamGovernance(zcf, initialPoserInvitation, {
+      GiveStableFee: ParamTypes.RATIO,
+      MintLimit: ParamTypes.AMOUNT,
+      WantStableFee: ParamTypes.RATIO,
+    });
 
   const { zcfSeat: anchorPool } = zcf.makeEmptySeatKit();
   const { zcfSeat: feePool } = zcf.makeEmptySeatKit();

--- a/packages/run-protocol/src/reserve/assetReserve.js
+++ b/packages/run-protocol/src/reserve/assetReserve.js
@@ -4,7 +4,6 @@ import { E, Far } from '@endo/far';
 import { makeStore } from '@agoric/store';
 import { AmountMath } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
-import { makeStoredPublisherKit } from '@agoric/notifier';
 import { offerTo } from '@agoric/zoe/src/contractSupport/index.js';
 
 import { AMM_INSTANCE } from './params.js';
@@ -77,10 +76,15 @@ const start = async (zcf, privateArgs) => {
   };
 
   const { augmentPublicFacet, makeGovernorFacet, params } =
-    // TODO https://github.com/Agoric/agoric-sdk/issues/5386
-    await handleParamGovernance(zcf, privateArgs.initialPoserInvitation, {
-      [AMM_INSTANCE]: ParamTypes.INSTANCE,
-    });
+    await handleParamGovernance(
+      zcf,
+      privateArgs.initialPoserInvitation,
+      {
+        [AMM_INSTANCE]: ParamTypes.INSTANCE,
+      },
+      privateArgs.storageNode,
+      privateArgs.marshaller,
+    );
 
   /** @type {Promise<XYKAMMPublicFacet>} */
   const ammPublicFacet = E(zcf.getZoeService()).getPublicFacet(

--- a/packages/run-protocol/src/reserve/assetReserve.js
+++ b/packages/run-protocol/src/reserve/assetReserve.js
@@ -77,15 +77,10 @@ const start = async (zcf, privateArgs) => {
   };
 
   const { augmentPublicFacet, makeGovernorFacet, params } =
-    await handleParamGovernance(
-      // TODO https://github.com/Agoric/agoric-sdk/issues/5386
-      makeStoredPublisherKit(),
-      zcf,
-      privateArgs.initialPoserInvitation,
-      {
-        [AMM_INSTANCE]: ParamTypes.INSTANCE,
-      },
-    );
+    // TODO https://github.com/Agoric/agoric-sdk/issues/5386
+    await handleParamGovernance(zcf, privateArgs.initialPoserInvitation, {
+      [AMM_INSTANCE]: ParamTypes.INSTANCE,
+    });
 
   /** @type {Promise<XYKAMMPublicFacet>} */
   const ammPublicFacet = E(zcf.getZoeService()).getPublicFacet(

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -2,7 +2,6 @@
 // @jessie-check
 import { AmountMath } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
-import { makeStoredPublisherKit } from '@agoric/notifier';
 import { E, Far } from '@endo/far';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import { makeAttestationFacets } from './attestation.js';
@@ -67,6 +66,8 @@ const { values } = Object;
  *   feeMintAccess: FeeMintAccess,
  *   initialPoserInvitation: Invitation,
  *   lienBridge: ERef<StakingAuthority>,
+ *   storageNode?: StorageNode,
+ *   marshaller?: Marshaller,
  * }} RunStakePrivateArgs
  *
  * The creator facet can make an `AttestationMaker` for each account, which
@@ -81,7 +82,13 @@ const { values } = Object;
  */
 export const start = async (
   zcf,
-  { feeMintAccess, initialPoserInvitation, lienBridge },
+  {
+    feeMintAccess,
+    initialPoserInvitation,
+    lienBridge,
+    storageNode,
+    marshaller,
+  },
 ) => {
   const {
     brands: { Stake: stakeBrand },
@@ -100,13 +107,18 @@ export const start = async (
   const attestBrand = await E(att.publicFacet).getBrand();
 
   const { augmentPublicFacet, makeGovernorFacet, params } =
-    // TODO https://github.com/Agoric/agoric-sdk/issues/5386
-    await handleParamGovernance(zcf, initialPoserInvitation, {
-      DebtLimit: ParamTypes.AMOUNT,
-      InterestRate: ParamTypes.RATIO,
-      LoanFee: ParamTypes.RATIO,
-      MintingRatio: ParamTypes.RATIO,
-    });
+    await handleParamGovernance(
+      zcf,
+      initialPoserInvitation,
+      {
+        DebtLimit: ParamTypes.AMOUNT,
+        InterestRate: ParamTypes.RATIO,
+        LoanFee: ParamTypes.RATIO,
+        MintingRatio: ParamTypes.RATIO,
+      },
+      storageNode,
+      marshaller,
+    );
 
   /** For temporary staging of newly minted tokens */
   const { zcfSeat: mintSeat } = zcf.makeEmptySeatKit();

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -100,18 +100,13 @@ export const start = async (
   const attestBrand = await E(att.publicFacet).getBrand();
 
   const { augmentPublicFacet, makeGovernorFacet, params } =
-    await handleParamGovernance(
-      // TODO https://github.com/Agoric/agoric-sdk/issues/5386
-      makeStoredPublisherKit(),
-      zcf,
-      initialPoserInvitation,
-      {
-        DebtLimit: ParamTypes.AMOUNT,
-        InterestRate: ParamTypes.RATIO,
-        LoanFee: ParamTypes.RATIO,
-        MintingRatio: ParamTypes.RATIO,
-      },
-    );
+    // TODO https://github.com/Agoric/agoric-sdk/issues/5386
+    await handleParamGovernance(zcf, initialPoserInvitation, {
+      DebtLimit: ParamTypes.AMOUNT,
+      InterestRate: ParamTypes.RATIO,
+      LoanFee: ParamTypes.RATIO,
+      MintingRatio: ParamTypes.RATIO,
+    });
 
   /** For temporary staging of newly minted tokens */
   const { zcfSeat: mintSeat } = zcf.makeEmptySeatKit();

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -5,7 +5,6 @@ import { Far } from '@endo/marshal';
 
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
-import { makeStoredPublisherKit } from '@agoric/notifier';
 import {
   assertIssuerKeywords,
   offerTo,
@@ -133,18 +132,15 @@ const start = async (zcf, privateArgs) => {
     { augmentPublicFacet, makeGovernorFacet, params },
     centralDisplayInfo,
   ] = await Promise.all([
-    handleParamGovernance(
-      // TODO https://github.com/Agoric/agoric-sdk/issues/5386
-      makeStoredPublisherKit(),
-      zcf,
-      privateArgs.initialPoserInvitation,
-      {
-        [POOL_FEE_KEY]: ParamTypes.NAT,
-        [PROTOCOL_FEE_KEY]: ParamTypes.NAT,
-        [MIN_INITIAL_POOL_LIQUIDITY_KEY]: ParamTypes.AMOUNT,
-      },
-    ),
+    // TODO https://github.com/Agoric/agoric-sdk/issues/5386
+    handleParamGovernance(zcf, privateArgs.initialPoserInvitation, {
+      [POOL_FEE_KEY]: ParamTypes.NAT,
+      [PROTOCOL_FEE_KEY]: ParamTypes.NAT,
+      [MIN_INITIAL_POOL_LIQUIDITY_KEY]: ParamTypes.AMOUNT,
+    }),
     E(centralBrand).getDisplayInfo(),
+    privateArgs.storageNode,
+    privateArgs.marshaller,
   ]);
 
   assert.equal(

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -132,12 +132,17 @@ const start = async (zcf, privateArgs) => {
     { augmentPublicFacet, makeGovernorFacet, params },
     centralDisplayInfo,
   ] = await Promise.all([
-    // TODO https://github.com/Agoric/agoric-sdk/issues/5386
-    handleParamGovernance(zcf, privateArgs.initialPoserInvitation, {
-      [POOL_FEE_KEY]: ParamTypes.NAT,
-      [PROTOCOL_FEE_KEY]: ParamTypes.NAT,
-      [MIN_INITIAL_POOL_LIQUIDITY_KEY]: ParamTypes.AMOUNT,
-    }),
+    handleParamGovernance(
+      zcf,
+      privateArgs.initialPoserInvitation,
+      {
+        [POOL_FEE_KEY]: ParamTypes.NAT,
+        [PROTOCOL_FEE_KEY]: ParamTypes.NAT,
+        [MIN_INITIAL_POOL_LIQUIDITY_KEY]: ParamTypes.AMOUNT,
+      },
+      privateArgs.storageNode,
+      privateArgs.marshaller,
+    ),
     E(centralBrand).getDisplayInfo(),
     privateArgs.storageNode,
     privateArgs.marshaller,
@@ -348,7 +353,7 @@ const start = async (zcf, privateArgs) => {
     'RUN',
   );
 
-  /** @type {XYKAMMPublicFacet} */
+  /** @type {GovernedPublicFacet<XYKAMMPublicFacet>} */
   const publicFacet = augmentPublicFacet(
     Far('AMM public facet', {
       addPoolInvitation,

--- a/packages/run-protocol/src/vpool-xyk-amm/params.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/params.js
@@ -1,11 +1,6 @@
 // @ts-check
 
-import {
-  CONTRACT_ELECTORATE,
-  makeParamManager,
-  ParamTypes,
-} from '@agoric/governance';
-import { makeStoredPublisherKit } from '@agoric/notifier';
+import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
 
 export const POOL_FEE_KEY = 'PoolFee';
 export const PROTOCOL_FEE_KEY = 'ProtocolFee';
@@ -15,37 +10,13 @@ const DEFAULT_POOL_FEE_BP = 24n;
 const DEFAULT_PROTOCOL_FEE_BP = 6n;
 
 /**
- * @param {ERef<ZoeService>} zoe
- * @param {bigint} poolFeeBP
+ * @param {Invitation} electorateInvitation - invitation for the question poser
  * @param {bigint} protocolFeeBP
+ * @param {bigint} poolFeeBP
  * @param {Amount} minInitialLiquidity
- * @param {Invitation} poserInvitation - invitation for the question poser
  */
-const makeAmmParamManager = async (
-  zoe,
-  poolFeeBP,
-  protocolFeeBP,
-  minInitialLiquidity,
-  poserInvitation,
-) => {
-  return makeParamManager(
-    // TODO https://github.com/Agoric/agoric-sdk/issues/5386
-    makeStoredPublisherKit(),
-    {
-      [POOL_FEE_KEY]: [ParamTypes.NAT, poolFeeBP],
-      [PROTOCOL_FEE_KEY]: [ParamTypes.NAT, protocolFeeBP],
-      [MIN_INITIAL_POOL_LIQUIDITY_KEY]: [
-        ParamTypes.AMOUNT,
-        minInitialLiquidity,
-      ],
-      [CONTRACT_ELECTORATE]: [ParamTypes.INVITATION, poserInvitation],
-    },
-    zoe,
-  );
-};
-
 const makeAmmParams = (
-  electorateInvitationAmount,
+  electorateInvitation,
   protocolFeeBP,
   poolFeeBP,
   minInitialLiquidity,
@@ -59,7 +30,7 @@ const makeAmmParams = (
     },
     [CONTRACT_ELECTORATE]: {
       type: ParamTypes.INVITATION,
-      value: electorateInvitationAmount,
+      value: electorateInvitation,
     },
   });
 };
@@ -82,8 +53,7 @@ const makeAmmTerms = (
   ),
 });
 
-harden(makeAmmParamManager);
 harden(makeAmmTerms);
 harden(makeAmmParams);
 
-export { makeAmmParamManager, makeAmmTerms, makeAmmParams };
+export { makeAmmTerms, makeAmmParams };

--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -24,6 +24,10 @@ export const publicPrices = prices => {
 };
 
 /**
+ * @typedef {Record<string, Amount>} NotificationState
+ */
+
+/**
  * @typedef {Readonly<{
  * liquidityBrand: Brand<'nat'>,
  * secondaryBrand: Brand<'nat'>,
@@ -36,14 +40,14 @@ export const publicPrices = prices => {
  * protocolSeat: ZCFSeat,
  * zcf: ZCF,
  * timer: TimerService,
- * paramAccessor,
+ * paramAccessor: import('./multipoolMarketMaker.js').AMMParamGetters,
+ * updater: IterationObserver<NotificationState>,
+ * notifier: Notifier<NotificationState>,
+ * metricsPublication: IterationObserver<PoolMetricsNotification>,
+ * metricsSubscription: Subscription<PoolMetricsNotification>
  * }>} ImmutableState
  *
  * @typedef {{
- * updater: IterationObserver<any>,
- * notifier: Notifier<any>,
- * metricsPublication: IterationObserver<PoolMetricsNotification>,
- * metricsSubscription: Subscription<PoolMetricsNotification>
  * poolSeat: ZCFSeat,
  * liqTokenSupply: bigint,
  * }} MutableState
@@ -263,10 +267,11 @@ const poolBehavior = {
     facets.helper.updateMetrics();
     return 'Liquidity successfully removed.';
   },
-  getNotifier: ({ state: { notifier } }) => notifier,
+  getNotifier: (/** @type {MethodContext} */ { state: { notifier } }) =>
+    notifier,
   updateState: ({ state: { updater }, facets: { pool, helper } }) => {
     helper.updateMetrics();
-    return updater.updateState(pool);
+    updater.updateState(pool);
   },
   getToCentralPriceAuthority: ({ state }) => state.toCentralPriceAuthority,
   getFromCentralPriceAuthority: ({ state }) => state.fromCentralPriceAuthority,

--- a/packages/run-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/types.js
@@ -137,7 +137,7 @@
  * @property {() => Brand[]} getAllPoolBrands
  * @property {() => Allocation} getProtocolPoolBalance
  * @property {() => StoredSubscription<MetricsNotification>} getMetrics
- * @property {(brand: Brand) => Subscription<PoolMetricsNotification>} getPoolMetrics
+ * @property {(brand: Brand) => StoredSubscription<PoolMetricsNotification>} getPoolMetrics
  */
 
 /**

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/setup.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/setup.js
@@ -9,6 +9,7 @@ import {
   makeAgoricNamesAccess,
   makePromiseSpace,
 } from '@agoric/vats/src/core/utils.js';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
 
 import * as Collect from '../../../src/collect.js';
 import {
@@ -59,6 +60,7 @@ export const setupAMMBootstrap = async (
   if (!farZoeKit) {
     farZoeKit = await setUpZoeForTest();
   }
+  trace('setupAMMBootstrap');
   const { zoe } = farZoeKit;
 
   const space = /** @type {any} */ (makePromiseSpace());
@@ -76,6 +78,7 @@ export const setupAMMBootstrap = async (
 
   installGovernance(zoe, spaces.installation.produce);
   produce.chainStorage.resolve(mockChainStorageRoot());
+  produce.board.resolve(makeBoard());
 
   return { produce, consume, ...spaces };
 };

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -1195,6 +1195,11 @@ test('storage keys', async t => {
   );
 
   t.is(
+    await subscriptionKey(E(amm.ammPublicFacet).getSubscription()),
+    'mockChainStorageRoot.amm.governance',
+  );
+
+  t.is(
     await subscriptionKey(E(amm.ammPublicFacet).getMetrics()),
     'mockChainStorageRoot.amm.metrics',
   );

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -27,6 +27,7 @@ import { BASIS_POINTS } from '../../../src/vpool-xyk-amm/constantProduct/default
 import { setupAmmServices } from './setup.js';
 import { unsafeMakeBundleCache } from '../../bundleTool.js';
 import { subscriptionTracker } from '../../metrics.js';
+import { subscriptionKey } from '../../supports.js';
 
 const { quote: q } = assert;
 const { ceilDivide } = natSafeMath;
@@ -1193,9 +1194,10 @@ test('storage keys', async t => {
     timer,
   );
 
-  const rootMetrics = await E(amm.ammPublicFacet).getMetrics();
-  const rootStoreKey = await E(rootMetrics).getStoreKey();
-  t.is(rootStoreKey.key, 'mockChainStorageRoot.amm.metrics');
+  t.is(
+    await subscriptionKey(E(amm.ammPublicFacet).getMetrics()),
+    'mockChainStorageRoot.amm.metrics',
+  );
 
   const addInitialLiquidity = await makeAddInitialLiquidity(
     t,
@@ -1206,7 +1208,8 @@ test('storage keys', async t => {
   );
   await addInitialLiquidity(10000n, 50000n);
 
-  const poolMetrics = await E(amm.ammPublicFacet).getPoolMetrics(moolaR.brand);
-  const poolStoreKey = await E(poolMetrics).getStoreKey();
-  t.is(poolStoreKey.key, 'mockChainStorageRoot.amm.pool0.metrics');
+  t.is(
+    await subscriptionKey(E(amm.ammPublicFacet).getPoolMetrics(moolaR.brand)),
+    'mockChainStorageRoot.amm.pool0.metrics',
+  );
 });

--- a/packages/run-protocol/test/reserve/test-reserve.js
+++ b/packages/run-protocol/test/reserve/test-reserve.js
@@ -11,6 +11,7 @@ import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { setupReserveServices } from './setup.js';
 import { unsafeMakeBundleCache } from '../bundleTool.js';
 import { subscriptionTracker } from '../metrics.js';
+import { subscriptionKey } from '../supports.js';
 
 const addLiquidPool = async (
   runPayment,
@@ -454,4 +455,23 @@ test('reserve burn IST', async t => {
     },
     allocations: { RUN: AmountMath.makeEmpty(runBrand) },
   });
+});
+
+test('storage keys', async t => {
+  /** @param {NatValue} value */
+  const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
+  const timer = buildManualTimer(t.log);
+
+  const { reserve } = await setupReserveServices(t, electorateTerms, timer);
+
+  t.is(
+    // @ts-expect-error problem with E() and GovernedPublicFacet<>
+    await subscriptionKey(E(reserve.reservePublicFacet).getSubscription()),
+    'mockChainStorageRoot.reserve.governance',
+  );
+
+  t.is(
+    await subscriptionKey(E(reserve.reserveCreatorFacet).getMetrics()),
+    'mockChainStorageRoot.reserve.metrics',
+  );
 });

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -9,6 +9,7 @@ import {
   makeAgoricNamesAccess,
   makePromiseSpace,
 } from '@agoric/vats/src/core/utils.js';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
 import { makeChainStorageRoot } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeZoeKit } from '@agoric/zoe';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
@@ -72,6 +73,7 @@ export const setupBootstrap = (t, optTimer = undefined) => {
   const timer = optTimer || buildManualTimer(t.log);
   produce.chainTimerService.resolve(timer);
   produce.chainStorage.resolve(mockChainStorageRoot());
+  produce.board.resolve(makeBoard());
 
   const { zoe, feeMintAccess, run } = t.context;
   produce.zoe.resolve(zoe);

--- a/packages/run-protocol/test/test-voPool.js
+++ b/packages/run-protocol/test/test-voPool.js
@@ -1,12 +1,43 @@
 // @ts-check
 
 import { runVOTest, test } from '@agoric/swingset-vat/tools/vo-test-harness.js';
+
+import { makeParamManager } from '@agoric/governance';
+import { makeStoredPublisherKit } from '@agoric/notifier';
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 
 import { definePoolKind } from '../src/vpool-xyk-amm/pool.js';
-import { makeAmmParamManager } from '../src/vpool-xyk-amm/params.js';
+import { makeAmmParams } from '../src/vpool-xyk-amm/params.js';
+import { mapValues } from '../src/collect.js';
+
+/**
+ * @param {ERef<ZoeService>} zoe
+ * @param {bigint} poolFeeBP
+ * @param {bigint} protocolFeeBP
+ * @param {Amount} minInitialLiquidity
+ * @param {Invitation} poserInvitation - invitation for the question poser
+ */
+const makeAmmParamManager = async (
+  zoe,
+  poolFeeBP,
+  protocolFeeBP,
+  minInitialLiquidity,
+  poserInvitation,
+) => {
+  const initial = mapValues(
+    makeAmmParams(
+      poserInvitation,
+      protocolFeeBP,
+      poolFeeBP,
+      minInitialLiquidity,
+    ),
+    v => [v.type, v.value],
+  );
+  // @ts-expect-error loose
+  return makeParamManager(makeStoredPublisherKit(), initial, zoe);
+};
 
 const voPoolTest = async (t, mutation, postTest) => {
   let makePool;
@@ -45,6 +76,7 @@ const voPoolTest = async (t, mutation, postTest) => {
       centralBrand,
       timer,
       quoteIssuerKit,
+      // @ts-expect-error loose
       paramAccessor,
       protocolSeat,
     );


### PR DESCRIPTION
closes: Agoric/agoric-sdk#5268

## Description

Makes the `getSubscription` added by `augmentPublicFacet` use `StoredSubscription` so it can be read off-chain.

Makes each contract that uses it provide the storageNode and marshaller necessary to write to off-chain store. Node presence and path are confirmed by new `storage key` tests. Nothing tests the marshaller.


### Security Considerations

Marshaller provided to each contract. Opted for readonly.

### Documentation Considerations

Should we maintain a list of paths somewhere? They can be collected from the 'storage keys' tests (with the proper renaming of root):
```
mockChainStorageRoot.amm.governance
mockChainStorageRoot.amm.metrics
mockChainStorageRoot.amm.pool0.metrics

mockChainStorageRoot.psm.governance

mockChainStorageRoot.reserve.governance
mockChainStorageRoot.reserve.metrics

mockChainStorageRoot.stakeFactory.governance

mockChainStorageRoot.vaultFactory.governance
mockChainStorageRoot.vaultFactory.metrics
mockChainStorageRoot.vaultFactory.manager0.governance
mockChainStorageRoot.vaultFactory.manager0.metrics
mockChainStorageRoot.vaultFactory.manager1.governance
mockChainStorageRoot.vaultFactory.manager1.metrics
```

### Testing Considerations

Note that the PSM test doesn't integrate bootstrap because I re-used what was already there, which was a direct startInstance. It looks like we have no tests of startPSM. I've added the need to https://github.com/Agoric/agoric-sdk/issues/4432
