### PR TITLE
refactor: rm obsolete vaultManagerParams in vaultFactory

### DIFF
--- a/packages/run-protocol/src/proposals/econ-behaviors.js
+++ b/packages/run-protocol/src/proposals/econ-behaviors.js
@@ -427,20 +427,6 @@ export const startVaultFactory = async (
 
   const centralBrand = await centralBrandP;
 
-  /**
-   * Types for the governed params for the vaultFactory; addVaultType() sets actual values
-   *
-   * @type {VaultManagerParamValues}
-   */
-  const vaultManagerParams = {
-    // XXX the values aren't used. May be addressed by https://github.com/Agoric/agoric-sdk/issues/4861
-    debtLimit: AmountMath.make(centralBrand, 0n),
-    liquidationMargin: makeRatio(0n, centralBrand),
-    liquidationPenalty: makeRatio(10n, centralBrand, 100n),
-    interestRate: makeRatio(0n, centralBrand, BASIS_POINTS),
-    loanFee: makeRatio(0n, centralBrand, BASIS_POINTS),
-  };
-
   const [
     ammInstance,
     electorateInstance,
@@ -472,7 +458,6 @@ export const startVaultFactory = async (
       liquidationInstall: installations.liquidate,
       timer,
       electorateInvitationAmount: poserInvitationAmount,
-      vaultManagerParams,
       ammPublicFacet,
       liquidationTerms: liquidationDetailTerms(centralBrand),
       minInitialDebt: AmountMath.make(centralBrand, minInitialDebt),

--- a/packages/run-protocol/src/vaultFactory/params.js
+++ b/packages/run-protocol/src/vaultFactory/params.js
@@ -133,7 +133,6 @@ const makeVaultDirectorParamManager = async (
  *   liquidationInstall: Installation,
  *   loanTiming: LoanTiming,
  *   liquidationTerms: import('./liquidation.js').LiquidationTerms,
- *   vaultManagerParams: VaultManagerParamValues,
  *   ammPublicFacet: XYKAMMPublicFacet,
  *   shortfallInvitationAmount: Amount,
  * }} opts
@@ -151,7 +150,6 @@ const makeGovernedTerms = (
     priceAuthority,
     reservePublicFacet,
     timer,
-    vaultManagerParams,
     shortfallInvitationAmount,
   },
 ) => {
@@ -163,15 +161,9 @@ const makeGovernedTerms = (
     },
   ).getParams();
 
-  const loanParams = makeVaultParamManager(
-    makeStoredPublisherKit(storageNode, marshaller, 'collateralParams'),
-    vaultManagerParams,
-  ).getParams();
-
   return harden({
     ammPublicFacet,
     priceAuthority,
-    loanParams,
     loanTimingParams,
     reservePublicFacet,
     timerService: timer,

--- a/packages/run-protocol/test/swingsetTests/setup.js
+++ b/packages/run-protocol/test/swingsetTests/setup.js
@@ -215,7 +215,6 @@ const buildOwner = async (
       liquidationInstall: installations.liquidateMinimum,
       timer,
       electorateInvitationAmount: poserInvitationAmount,
-      vaultManagerParams,
       ammPublicFacet: ammMock,
       liquidationTerms: liquidationDetailTerms(runBrand),
       minInitialDebt: AmountMath.make(runBrand, 100n),


### PR DESCRIPTION
## Description

The `vaultManagerParams` in vaultFactory scope were never being read. I think the need for it went away sometime in the refactoring of the governance helpers.

Once this lands, it may be worth taking a fresh look at #4861 (mentioned in the code comments) to see if it can be closed.

### Security Considerations

I think these param settings were meant to constrain what values could be set, but addVaultType does that itself now: https://github.com/Agoric/agoric-sdk/blob/7a9a7a301d67cc681ed4753114f0aba8e9339581/packages/run-protocol/src/vaultFactory/vaultDirector.js#L292


### Documentation Considerations

--

### Testing Considerations

Existing tests pass.