### PR TITLE
fix(swingset): fix transcript extract/replay tools

### DIFF
--- a/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
+++ b/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
@@ -66,19 +66,7 @@ async function run() {
       }
       case 'syscall-result': {
         console.log(` -- syscall-result`);
-        // The vatstoreGet result is null when key was missing. To match the
-        // transcript extracted from a DB (in which a missing key gets
-        // 'undefined', causing the .response to be omitted entirely),
-        // special-case a vatstoreGet with a null result.
-        //
-        // vatstoreSet result is always null
-        const [status, result] = e.vsr; // e.g. ["ok", string]
-        if (status !== 'ok') {
-          throw Error(`encountered non-ok syscall result`);
-        }
-        if (!(syscall.d[0] === 'vatstoreGet' && result === null)) {
-          syscall.response = result;
-        }
+        syscall.response = e.vsr;
         syscalls.push(syscall);
         break;
       }


### PR DESCRIPTION
These had bitrotted:
* transcript now includes whole syscall result, even failures
* handle kerneldb bundleIDs
* new LMDB in swingstore
* gcEveryCrank=false else all GC is disabled (refs #5600)
* fake kernelKeeper/slogger needed new methods

The new code also attempts to track `deliveryNum`, to align it with
the original slog, but I'm not positive it is accurate.

closes #5602
