### PR TITLE
fix(notifier): Make makeNotifierFromAsyncIterable lossy

### DIFF
--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -223,10 +223,9 @@ test('change multiple params', async t => {
 
   /** @type {GovernedPublicFacet<unknown>} */
   const publicFacet = await E(governorFacets.creatorFacet).getPublicFacet();
-  const notifier = makeNotifierFromAsyncIterable(
-    await E(publicFacet).getSubscription(),
-  );
-  const update1 = await notifier.getUpdateSince();
+  const governorSubscription = await E(publicFacet).getSubscription();
+  const governorUpdates = await E(governorSubscription)[Symbol.asyncIterator]();
+  const update1 = await E(governorUpdates).next();
   // constructing the fixture to deepEqual would complicate this with insufficient benefit
   t.is(
     // @ts-expect-error reaching into unknown values
@@ -279,7 +278,7 @@ test('change multiple params', async t => {
     t.fail(`expected success, got ${e}`);
   });
 
-  const update2 = await notifier.getUpdateSince(update1.updateCount);
+  const update2 = await E(governorUpdates).next();
   t.like(update2, {
     value: {
       current: {

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -182,6 +182,7 @@ export const makeNotifierFromAsyncIterable = asyncIterableP => {
       let done = false;
       while (!done) {
         // TODO: Fix this typing friction.
+        // Possibly related: https://github.com/microsoft/TypeScript/issues/38479
         // @ts-expect-error Tolerate done: undefined.
         latestResultInP = E(iteratorP).next();
         if (nextResultInR) {
@@ -189,7 +190,8 @@ export const makeNotifierFromAsyncIterable = asyncIterableP => {
           nextResultInR = undefined;
         }
         // eslint-disable-next-line no-await-in-loop
-        ({ done } = await latestResultInP);
+        const latestResultIn = await latestResultInP;
+        ({ done } = latestResultIn);
       }
     } catch (err) {} // eslint-disable-line no-empty
     if (nextResultInR) {

--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -46,8 +46,8 @@ const makeSubscriptionIterator = tailP => {
   return Far('SubscriptionIterator', {
     subscribe: () => makeSubscription(tailP),
     [Symbol.asyncIterator]: () => makeSubscriptionIterator(tailP),
-    next: () => {
-      const resultP = E.get(tailP).head;
+    next: async () => {
+      const resultP = await E.get(tailP).head;
       tailP = E.get(tailP).tail;
       Promise.resolve(tailP).catch(() => {}); // suppress unhandled rejection error
       return resultP;

--- a/packages/run-protocol/test/metrics.js
+++ b/packages/run-protocol/test/metrics.js
@@ -1,5 +1,4 @@
 // @ts-check
-import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
 import { diff } from 'deep-object-diff';
 
@@ -17,7 +16,7 @@ const trace = makeTracer('TestMetrics', false);
  */
 export const subscriptionTracker = async (t, subscription) => {
   const metrics = await E(subscription)[Symbol.asyncIterator]();
-  /** @type {UpdateRecord<N>} */
+  /** @type {IteratorResult<N, N>} */
   let notif;
   const getLastNotif = () => notif;
 


### PR DESCRIPTION
Fixes #5413

## Description

Separate iterable consumption from `getUpdateSince` peeking.

### Security Considerations

Because the consumption is now greedy, there is a risk of getting stuck in a produce–consume pattern where each step enqueues a subsequent turn and forward progress halts. But I don't think any of our code fits that pattern, and at any rate I don't know if any mitigation is even possible.

### Documentation Considerations

n/a

### Testing Considerations

WIP