### PR TITLE
feat!(swingset): remove vatPowers.makeMarshal

### DIFF
--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -1628,16 +1628,12 @@ export function makeLiveSlots(
   buildVatNamespace,
   relaxDurabilityRules = false,
 ) {
-  const allVatPowers = {
-    ...vatPowers,
-    makeMarshal,
-  };
   const r = build(
     syscall,
     forVatID,
     cacheSize,
     enableDisavow,
-    allVatPowers,
+    vatPowers,
     gcTools,
     liveSlotsConsole,
     buildVatNamespace,


### PR DESCRIPTION
We added `vatPowers.makeMarshal` eons ago, long enough that we don't
remember why. (I know there was a time that we needed vats to share a
`Remotable` registry WeakMap with the marshal instance used by
liveslots, so objects that the vat tagged with Far()/Remotable() would
be recognized as such by liveslots. But that was sharing
`Far`/`Remotable` and not `makeMarshal`, which exists to make new
marshallers).

We're concerned that the full-powered WeakMap used internally by
marshal (specifically the `passStyleOf` memoization cache) might be
usable to sense GC of virtual-object Representatives, which would
allow userspace to violate our determinism goals.

Lots of vat code does:
```js
import { makeMarshal } from '@endo/marshal';
```

which is fine: as vat code, that copy of `@endo/marshal` will get the
`WeakMap` provided by liveslots a vat global, and that's the tamed
version which maps multiple (sequential) Representative to the same
key.

It looks like nothing in agoric-sdk is using `makeMarshal` from
`vatPowers`, so the easy fix is to remove it.

closes #5639
