### PR TITLE
5346 replace uses of makeNotifierKit with makeNotifierFromSubscriber

### DIFF
--- a/packages/run-protocol/src/contractSupport.js
+++ b/packages/run-protocol/src/contractSupport.js
@@ -83,11 +83,12 @@ export const checkDebtLimit = (debtLimit, totalDebt, toMint) => {
 
 /**
  * @template T
- * @param {ERef<StorageNode>} [storageNode]
- * @param {ERef<Marshaller>} [marshaller]
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
  * @returns {MetricsPublisherKit<T>}
  */
 export const makeMetricsPublisherKit = (storageNode, marshaller) => {
+  assert(storageNode && marshaller, 'Missing storageNode or marshaller');
   /** @type {import('@agoric/notifier').StoredPublisherKit<T>} */
   const kit = makeStoredPublisherKit(storageNode, marshaller, 'metrics');
   return {

--- a/packages/run-protocol/src/contractSupport.js
+++ b/packages/run-protocol/src/contractSupport.js
@@ -88,7 +88,10 @@ export const checkDebtLimit = (debtLimit, totalDebt, toMint) => {
  * @returns {MetricsPublisherKit<T>}
  */
 export const makeMetricsPublisherKit = (storageNode, marshaller) => {
-  assert(storageNode && marshaller, 'Missing storageNode or marshaller');
+  assert(
+    storageNode && marshaller,
+    'makeMetricsPublisherKit missing storageNode or marshaller',
+  );
   /** @type {import('@agoric/notifier').StoredPublisherKit<T>} */
   const kit = makeStoredPublisherKit(storageNode, marshaller, 'metrics');
   return {
@@ -130,3 +133,14 @@ export const makeEphemeraProvider = init => {
   };
 };
 harden(makeEphemeraProvider);
+
+/**
+ * @template {Record<string, unknown>} T
+ * @param {T} specimen
+ * @param {Array<keyof T>} keyList
+ */
+export const assertKeysDefined = (specimen, keyList) => {
+  for (const key of keyList) {
+    assert(specimen[key], X`Missing ${q(key)}`);
+  }
+};

--- a/packages/run-protocol/src/proposals/econ-behaviors.js
+++ b/packages/run-protocol/src/proposals/econ-behaviors.js
@@ -7,7 +7,7 @@ import '@agoric/governance/exported.js';
 import '@agoric/vats/exported.js';
 import '@agoric/vats/src/core/types.js';
 import { CENTRAL_ISSUER_NAME } from '@agoric/vats/src/core/utils.js';
-import { getChildNode } from '@agoric/vats/src/lib-chainStorage.js';
+import { makeStorageNode } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E, Far } from '@endo/far';
 import * as Collect from '../collect.js';
@@ -215,7 +215,7 @@ export const setupAmm = async (
     AmountMath.make(runBrand, minInitialPoolLiquidity),
   );
 
-  const storageNode = await getChildNode(chainStorage, AMM_STORAGE_PATH);
+  const storageNode = await makeStorageNode(chainStorage, AMM_STORAGE_PATH);
   const marshaller = await E(board).getPublishingMarshaller();
 
   const ammGovernorTerms = {
@@ -309,7 +309,7 @@ export const setupReserve = async ({
 
   const feeMintAccess = await feeMintAccessP;
 
-  const storageNode = await getChildNode(chainStorage, STORAGE_PATH);
+  const storageNode = await makeStorageNode(chainStorage, STORAGE_PATH);
   const marshaller = E(board).getReadonlyMarshaller();
 
   const reserveGovernorTerms = {
@@ -439,7 +439,7 @@ export const startVaultFactory = async (
   const reservePublicFacet = await E(zoe).getPublicFacet(reserveInstance);
   const timer = await chainTimerService;
 
-  const storageNode = await getChildNode(chainStorage, STORAGE_PATH);
+  const storageNode = await makeStorageNode(chainStorage, STORAGE_PATH);
   const marshaller = E(board).getReadonlyMarshaller();
 
   const vaultFactoryTerms = makeGovernedTerms(
@@ -844,7 +844,7 @@ export const startRunStake = async (
     },
   );
 
-  const storageNode = await getChildNode(chainStorage, STORAGE_PATH);
+  const storageNode = await makeStorageNode(chainStorage, STORAGE_PATH);
   const marshaller = await E(board).getReadonlyMarshaller();
 
   /** @type {{ publicFacet: GovernorPublic, creatorFacet: GovernedContractFacetAccess<unknown>}} */

--- a/packages/run-protocol/src/proposals/startPSM.js
+++ b/packages/run-protocol/src/proposals/startPSM.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
-import { getChildNode } from '@agoric/vats/src/lib-chainStorage.js';
+import { makeStorageNode } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/far';
 import { reserveThenGetNamePaths } from './utils.js';
@@ -108,7 +108,7 @@ export const startPSM = async (
     },
   };
 
-  const storageNode = await getChildNode(chainStorage, 'psm');
+  const storageNode = await makeStorageNode(chainStorage, 'psm');
   const marshaller = E(board).getPublishingMarshaller();
 
   const governorFacets = await E(zoe).startInstance(

--- a/packages/run-protocol/src/reserve/assetReserve.js
+++ b/packages/run-protocol/src/reserve/assetReserve.js
@@ -48,8 +48,8 @@ const nonalphanumeric = /[^A-Za-z0-9]/g;
  * @param {{
  *   feeMintAccess: FeeMintAccess,
  *   initialPoserInvitation: Payment,
- *   marshaller?: ERef<Marshaller>,
- *   storageNode?: ERef<StorageNode>,
+ *   marshaller: ERef<Marshaller>,
+ *   storageNode: ERef<StorageNode>,
  * }} privateArgs
  */
 const start = async (zcf, privateArgs) => {

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -66,8 +66,8 @@ const { values } = Object;
  *   feeMintAccess: FeeMintAccess,
  *   initialPoserInvitation: Invitation,
  *   lienBridge: ERef<StakingAuthority>,
- *   storageNode?: StorageNode,
- *   marshaller?: Marshaller,
+ *   storageNode: StorageNode,
+ *   marshaller: Marshaller,
  * }} RunStakePrivateArgs
  *
  * The creator facet can make an `AttestationMaker` for each account, which
@@ -98,6 +98,7 @@ export const start = async (
   } = zcf.getTerms();
   assert.typeof(chargingPeriod, 'bigint', 'chargingPeriod must be a bigint');
   assert.typeof(recordingPeriod, 'bigint', 'recordingPeriod must be a bigint');
+  assert(storageNode && marshaller, 'missing storageNode or marshaller');
 
   /** @type {ZCFMint<'nat'>} */
   const debtMint = await zcf.registerFeeMint(KW.Debt, feeMintAccess);

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -192,7 +192,7 @@ export const start = async (
 
     return harden({
       publicNotifiers: {
-        asset: manager.getAssetNotifier(),
+        asset: manager.getAssetSubscriber(),
         vault: pot.getNotifier(),
       },
       invitationMakers: Far('invitation makers', {

--- a/packages/run-protocol/src/runStake/runStake.js
+++ b/packages/run-protocol/src/runStake/runStake.js
@@ -193,7 +193,7 @@ export const start = async (
     return harden({
       publicNotifiers: {
         asset: manager.getAssetSubscriber(),
-        vault: pot.getNotifier(),
+        vault: pot.getSubscriber(),
       },
       invitationMakers: Far('invitation makers', {
         AdjustBalances: () =>

--- a/packages/run-protocol/src/runStake/runStakeKit.js
+++ b/packages/run-protocol/src/runStake/runStakeKit.js
@@ -3,7 +3,7 @@
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 import { ceilMultiplyBy } from '@agoric/zoe/src/contractSupport/ratio.js';
-import { makeNotifierKit } from '@agoric/notifier';
+import { makePublishKit } from '@agoric/notifier';
 import { M, matches } from '@agoric/store';
 import { defineKindMulti } from '@agoric/vat-data';
 import { makeTracer } from '../makeTracer.js';
@@ -111,7 +111,7 @@ const initState = (zcf, startSeat, manager) => {
   })();
   manager.applyDebtDelta(emptyDebt, initialDebt);
 
-  const { notifier, publisher } = makeNotifierKit();
+  const { publisher, subscriber } = makePublishKit();
 
   /** @type {ImmutableState} */
   const immutable = {
@@ -192,7 +192,7 @@ const helperBehavior = {
     trace('updateUiState', uiState);
 
     if (active) {
-      publisher.updateState(uiState);
+      publisher.publish(uiState);
     } else {
       publisher.finish(uiState);
       state.publisher = null;
@@ -362,7 +362,7 @@ const helperBehavior = {
 
 const potBehavior = {
   /** @param {MethodContext} context */
-  getNotifier: ({ state }) => state.notifier,
+  getSubscriber: ({ state }) => state.subscriber,
   /** @param {MethodContext} context */
   makeAdjustBalancesInvitation: ({ state, facets }) => {
     const { zcf } = state;

--- a/packages/run-protocol/src/vaultFactory/params.js
+++ b/packages/run-protocol/src/vaultFactory/params.js
@@ -122,7 +122,7 @@ const makeVaultDirectorParamManager = async (
 };
 
 /**
- * @param {{storageNode?: ERef<StorageNode>, marshaller?: ERef<Marshaller>}} caps
+ * @param {{storageNode: ERef<StorageNode>, marshaller: ERef<Marshaller>}} caps
  * @param {{
  *   electorateInvitationAmount: Amount,
  *   minInitialDebt: Amount,

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -101,7 +101,7 @@ const validTransitions = {
  *
  * @typedef {{
  *   interestSnapshot: Ratio,
- *   outerUpdater: IterationObserver<VaultNotification> | null,
+ *   outerUpdater: Publisher<VaultNotification> | null,
  *   phase: VaultPhase,
  *   debtSnapshot: Amount<'nat'>,
  * }} MutableState
@@ -335,7 +335,7 @@ const helperBehavior = {
       case Phase.ACTIVE:
       case Phase.LIQUIDATING:
       case Phase.LIQUIDATED:
-        outerUpdater.updateState(uiState);
+        outerUpdater.publish(uiState);
         break;
       case Phase.CLOSED:
         outerUpdater.finish(uiState);

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -76,7 +76,7 @@ const validTransitions = {
 // XXX masks typedef from types.js, but using that causes circular def problems
 /**
  * @typedef {object} VaultManager
- * @property {() => Notifier<import('./vaultManager').AssetState>} getNotifier
+ * @property {() => Promise<Notifier<import('./vaultManager').AssetState>>} getNotifier
  * @property {(collateralAmount: Amount) => ERef<Amount<'nat'>>} maxDebtFor
  * @property {() => Brand} getCollateralBrand
  * @property {() => Brand<'nat'>} getDebtBrand

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -76,7 +76,7 @@ const validTransitions = {
 // XXX masks typedef from types.js, but using that causes circular def problems
 /**
  * @typedef {object} VaultManager
- * @property {() => Promise<Notifier<import('./vaultManager').AssetState>>} getNotifier
+ * @property {() => Subscriber<import('./vaultManager').AssetState>} getAssetSubscriber
  * @property {(collateralAmount: Amount) => ERef<Amount<'nat'>>} maxDebtFor
  * @property {() => Brand} getCollateralBrand
  * @property {() => Brand<'nat'>} getDebtBrand
@@ -528,7 +528,7 @@ const helperBehavior = {
     helper.assertCloseable();
     seat.exit();
     // eslint-disable-next-line no-use-before-define
-    const vaultKit = makeVaultKit(self, state.manager.getNotifier());
+    const vaultKit = makeVaultKit(self, state.manager.getAssetSubscriber());
     state.outerUpdater = vaultKit.vaultUpdater;
     helper.updateUiState();
 
@@ -596,7 +596,7 @@ const selfBehavior = {
     state.manager.mintAndReallocate(toMint, fee, seat, vaultSeat);
     helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebtPre);
 
-    const vaultKit = makeVaultKit(self, state.manager.getNotifier());
+    const vaultKit = makeVaultKit(self, state.manager.getAssetSubscriber());
     state.outerUpdater = vaultKit.vaultUpdater;
     helper.updateUiState();
     return vaultKit;

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -50,8 +50,8 @@ const { details: X, quote: q } = assert;
  * zcf: import('./vaultFactory.js').VaultFactoryZCF,
  * shortfallInvitation: Invitation,
  * shortfallReporter: import('../reserve/assetReserve.js').ShortfallReporter,
- * storageNode?: ERef<StorageNode>,
- * marshaller?: ERef<Marshaller>,
+ * storageNode: ERef<StorageNode>,
+ * marshaller: ERef<Marshaller>,
  * }>} ImmutableState
  *
  * @typedef {{
@@ -117,8 +117,8 @@ const metricsOf = state => {
  * @param {State['zcf']} zcf
  * @param {State['directorParamManager']} directorParamManager
  * @param {State['debtMint']} debtMint
- * @param {ERef<StorageNode>} [storageNode]
- * @param {ERef<Marshaller>} [marshaller]
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
  * @returns {State}
  */
 const initState = (

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -28,6 +28,7 @@ import {
   MIN_INITIAL_DEBT_KEY,
 } from './params.js';
 import { makeVaultDirector } from './vaultDirector.js';
+import { assertKeysDefined } from '../contractSupport.js';
 
 /**
  * @typedef {ZCF<GovernanceTerms<import('./params').VaultDirectorParams> & {
@@ -53,6 +54,13 @@ import { makeVaultDirector } from './vaultDirector.js';
  * }} privateArgs
  */
 export const start = async (zcf, privateArgs) => {
+  assertKeysDefined(privateArgs, [
+    'feeMintAccess',
+    'initialPoserInvitation',
+    'initialShortfallInvitation',
+    'storageNode',
+    'marshaller',
+  ]);
   const { feeMintAccess, initialPoserInvitation, initialShortfallInvitation } =
     privateArgs;
   const debtMint = await zcf.registerFeeMint('RUN', feeMintAccess);

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -48,8 +48,8 @@ import { makeVaultDirector } from './vaultDirector.js';
  *   feeMintAccess: FeeMintAccess,
  *   initialPoserInvitation: Invitation,
  *   initialShortfallInvitation: Invitation,
- *   storageNode?: ERef<StorageNode>,
- *   marshaller?: ERef<Marshaller>,
+ *   storageNode: ERef<StorageNode>,
+ *   marshaller: ERef<Marshaller>,
  * }} privateArgs
  */
 export const start = async (zcf, privateArgs) => {

--- a/packages/run-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/run-protocol/src/vaultFactory/vaultHolder.js
@@ -2,7 +2,7 @@
  * @file Object representing ownership of a vault
  */
 // @ts-check
-import { makeNotifierKit } from '@agoric/notifier';
+import { makePublishKit } from '@agoric/notifier';
 import { defineKindMulti } from '@agoric/vat-data';
 import '@agoric/zoe/exported.js';
 
@@ -10,8 +10,8 @@ const { details: X } = assert;
 
 /**
  * @typedef {{
- * notifier: NotifierRecord<VaultNotification>['notifier'],
- * updater: NotifierRecord<VaultNotification>['updater'],
+ * publisher: PublishKit<VaultNotification>['publisher'],
+ * subscriber: PublishKit<VaultNotification>['subscriber'],
  * vault: Vault | null,
  * }} State
  * @typedef {Readonly<{
@@ -29,10 +29,10 @@ const { details: X } = assert;
  * @returns {State}
  */
 const initState = vault => {
-  /** @type {NotifierRecord<VaultNotification>} */
-  const { updater, notifier } = makeNotifierKit();
+  /** @type {PublishKit<VaultNotification>} */
+  const { subscriber, publisher } = makePublishKit();
 
-  return { notifier, updater, vault };
+  return { publisher, subscriber, vault };
 };
 
 const helper = {
@@ -46,12 +46,12 @@ const helper = {
     return vault;
   },
   /** @param {MethodContext} context */
-  getUpdater: ({ state }) => state.updater,
+  getUpdater: ({ state }) => state.publisher,
 };
 
 const holder = {
   /** @param {MethodContext} context */
-  getNotifier: ({ state }) => state.notifier,
+  getSubscriber: ({ state }) => state.subscriber,
   /** @param {MethodContext} context */
   makeAdjustBalancesInvitation: ({ facets }) =>
     facets.helper.owned().makeAdjustBalancesInvitation(),

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { makeNotifierFromSubscriber } from '@agoric/notifier';
 import '@agoric/zoe/exported.js';
 import { Far } from '@endo/marshal';
 import { makeVaultHolder } from './vaultHolder.js';
@@ -7,14 +8,14 @@ import { makeVaultHolder } from './vaultHolder.js';
  * Create a kit of utilities for use of the vault.
  *
  * @param {Vault} vault
- * @param {Promise<Notifier<import('./vaultManager').AssetState>>} assetSubscriber
+ * @param {Subscriber<import('./vaultManager').AssetState>} assetSubscriber
  */
 export const makeVaultKit = (vault, assetSubscriber) => {
   const { holder, helper } = makeVaultHolder(vault);
   const vaultKit = harden({
     publicNotifiers: {
       vault: holder.getNotifier(),
-      asset: assetSubscriber,
+      asset: makeNotifierFromSubscriber(assetSubscriber),
     },
     invitationMakers: Far('invitation makers', {
       AdjustBalances: holder.makeAdjustBalancesInvitation,

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -7,14 +7,14 @@ import { makeVaultHolder } from './vaultHolder.js';
  * Create a kit of utilities for use of the vault.
  *
  * @param {Vault} vault
- * @param {Notifier<import('./vaultManager').AssetState>} assetNotifier
+ * @param {Promise<Notifier<import('./vaultManager').AssetState>>} assetSubscriber
  */
-export const makeVaultKit = (vault, assetNotifier) => {
+export const makeVaultKit = (vault, assetSubscriber) => {
   const { holder, helper } = makeVaultHolder(vault);
   const vaultKit = harden({
     publicNotifiers: {
       vault: holder.getNotifier(),
-      asset: assetNotifier,
+      asset: assetSubscriber,
     },
     invitationMakers: Far('invitation makers', {
       AdjustBalances: holder.makeAdjustBalancesInvitation,

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -14,7 +14,7 @@ export const makeVaultKit = (vault, assetSubscriber) => {
   const { holder, helper } = makeVaultHolder(vault);
   const vaultKit = harden({
     publicNotifiers: {
-      vault: holder.getNotifier(),
+      vault: makeNotifierFromSubscriber(holder.getSubscriber()),
       asset: makeNotifierFromSubscriber(assetSubscriber),
     },
     invitationMakers: Far('invitation makers', {

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -672,7 +672,7 @@ const collateralBehavior = {
   makeVaultInvitation: ({ state: { zcf }, facets: { self } }) =>
     zcf.makeInvitation(self.makeVaultKit, 'MakeVault'),
   /** @param {MethodContext} context */
-  getNotifier: ({ state }) => state.assetSubscriber,
+  getSubscriber: ({ state }) => state.assetSubscriber,
   /** @param {MethodContext} context */
   getMetrics: ({ state }) => state.metricsSubscription,
   /** @param {MethodContext} context */

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -169,7 +169,10 @@ const initState = (
   storageNode,
   marshaller,
 ) => {
-  assert(storageNode && marshaller, 'Missing storageNode or marshaller');
+  assert(
+    storageNode && marshaller,
+    'VaultManager missing storageNode or marshaller',
+  );
 
   const periodNotifier = E(timerService).makeNotifier(
     0n,

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -89,14 +89,14 @@ const trace = makeTracer('VM');
  * debtBrand: Brand<'nat'>,
  * debtMint: ZCFMint<'nat'>,
  * factoryPowers: import('./vaultDirector.js').FactoryPowersFacet,
- * marshaller?: ERef<Marshaller>,
+ * marshaller: ERef<Marshaller>,
  * metricsPublication: IterationObserver<MetricsNotification>,
  * metricsSubscription: StoredSubscription<MetricsNotification>,
  * periodNotifier: ERef<Notifier<bigint>>,
  * poolIncrementSeat: ZCFSeat,
  * priceAuthority: ERef<PriceAuthority>,
  * prioritizedVaults: ReturnType<typeof makePrioritizedVaults>,
- * storageNode?: ERef<StorageNode>,
+ * storageNode: ERef<StorageNode>,
  * zcf: import('./vaultFactory.js').VaultFactoryZCF,
  * }>} ImmutableState
  */
@@ -155,8 +155,8 @@ const provideEphemera = makeEphemeraProvider(() => ({
  * @param {import('./vaultDirector.js').FactoryPowersFacet} factoryPowers
  * @param {ERef<TimerService>} timerService
  * @param {Timestamp} startTimeStamp
- * @param {ERef<StorageNode>} [storageNode]
- * @param {ERef<Marshaller>} [marshaller]
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
  */
 const initState = (
   zcf,
@@ -169,6 +169,8 @@ const initState = (
   storageNode,
   marshaller,
 ) => {
+  assert(storageNode && marshaller, 'Missing storageNode or marshaller');
+
   const periodNotifier = E(timerService).makeNotifier(
     0n,
     factoryPowers.getGovernedParams().getChargingPeriod(),
@@ -195,6 +197,7 @@ const initState = (
     debtBrand,
     debtMint,
     factoryPowers,
+    marshaller,
     metricsSubscription,
     metricsPublication,
     periodNotifier,
@@ -204,6 +207,7 @@ const initState = (
      * A store for vaultKits prioritized by their collaterization ratio.
      */
     prioritizedVaults: makePrioritizedVaults(),
+    storageNode,
     zcf,
   };
 

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -17,11 +17,7 @@ import '@agoric/zoe/exported.js';
 
 import { AmountMath } from '@agoric/ertp';
 import { Nat } from '@agoric/nat';
-import {
-  makeNotifierFromSubscriber,
-  makeStoredPublishKit,
-  observeNotifier,
-} from '@agoric/notifier';
+import { makeStoredPublishKit, observeNotifier } from '@agoric/notifier';
 import { defineKindMulti, pickFacet } from '@agoric/vat-data';
 import {
   assertProposalShape,
@@ -588,7 +584,7 @@ const managerBehavior = {
     state.totalDebt = AmountMath.subtract(state.totalDebt, toBurn);
   },
   /** @param {MethodContext} context */
-  getNotifier: ({ state }) => makeNotifierFromSubscriber(state.assetSubscriber),
+  getAssetSubscriber: ({ state }) => state.assetSubscriber,
   /** @param {MethodContext} context */
   getCollateralBrand: ({ state }) => state.collateralBrand,
   /** @param {MethodContext} context */

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -112,8 +112,8 @@ const trace = makeTracer('XykAmm', false);
  * @param {ZCF<AMMTerms>} zcf
  * @param {{
  *   initialPoserInvitation: Invitation,
- *   storageNode?: ERef<StorageNode>,
- *   marshaller?: ERef<Marshaller>,
+ *   storageNode: ERef<StorageNode>,
+ *   marshaller: ERef<Marshaller>,
  * }} privateArgs
  */
 const start = async (zcf, privateArgs) => {

--- a/packages/run-protocol/src/vpool-xyk-amm/priceAuthority.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/priceAuthority.js
@@ -7,13 +7,23 @@ import { observeNotifier } from '@agoric/notifier';
 
 import { makeOnewayPriceAuthorityKit } from '@agoric/zoe/src/contractSupport/index.js';
 
+/**
+ *
+ * @param {*} getOutputForGivenInput
+ * @param {*} getInputForWantedOutput
+ * @param {Brand} actualBrandIn
+ * @param {Brand} actualBrandOut
+ * @param {TimerService} timer
+ * @param {Notifier<import('./pool').NotificationState>} notifier
+ * @param {IssuerKit} quoteIssuerKit
+ * @returns {PriceAuthority}
+ */
 export const makePriceAuthority = (
   getOutputForGivenInput,
   getInputForWantedOutput,
   actualBrandIn,
   actualBrandOut,
   timer,
-  zcf,
   notifier,
   quoteIssuerKit,
 ) => {

--- a/packages/run-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/types.js
@@ -77,7 +77,7 @@
  * @property {() => ZCFSeat} getPoolSeat
  * @property {() => Amount} getSecondaryAmount
  * @property {() => Amount} getCentralAmount
- * @property {() => Notifier<Record<string, Amount>>} getNotifier
+ * @property {() => Subscriber<Record<string, Amount>>} getSubscriber
  * @property {() => void} updateState
  * @property {() => PriceAuthority} getToCentralPriceAuthority
  * @property {() => PriceAuthority} getFromCentralPriceAuthority

--- a/packages/run-protocol/test/metrics.js
+++ b/packages/run-protocol/test/metrics.js
@@ -12,7 +12,7 @@ const trace = makeTracer('TestMetrics', false);
 
 /**
  * @param {import('ava').ExecutionContext} t
- * @param {Subscription<N>} subscription
+ * @param {ConsistentAsyncIterable<N>} subscription
  * @template {object} N
  */
 export const subscriptionTracker = async (t, subscription) => {
@@ -46,7 +46,7 @@ export const subscriptionTracker = async (t, subscription) => {
  * For public facets that have a `getMetrics` method.
  *
  * @param {import('ava').ExecutionContext} t
- * @param {{getMetrics?: () => Subscription<unknown>}} publicFacet
+ * @param {{getMetrics?: () => ConsistentAsyncIterable<unknown>}} publicFacet
  * @template {object} N
  */
 export const metricsTracker = async (t, publicFacet) => {

--- a/packages/run-protocol/test/swingsetTests/setup.js
+++ b/packages/run-protocol/test/swingsetTests/setup.js
@@ -208,6 +208,7 @@ const buildOwner = async (
   const shortfallInvitationAmount = null;
 
   const terms = makeVaultFactoryTerms(
+    // @ts-expect-error missing storageNode and marshaller
     {},
     {
       priceAuthority: priceAuthorityKit.priceAuthority,

--- a/packages/run-protocol/test/vaultFactory/test-liquidator.js
+++ b/packages/run-protocol/test/vaultFactory/test-liquidator.js
@@ -571,15 +571,10 @@ test('price drop', async t => {
   await d.checkRewards(run.make(14n));
 
   await dv.close();
-  await dv.notified(
-    Phase.CLOSED,
-    {
-      locked: aeth.makeEmpty(),
-      updateCount: undefined,
-    },
-    // ??? why is AT_NEXT necessary now
-    AT_NEXT,
-  );
+  await dv.notified(Phase.CLOSED, {
+    locked: aeth.makeEmpty(),
+    updateCount: undefined,
+  });
   await d.checkPayouts(debtExpected, collateralExpected);
   await dv.checkBalance(debtExpected, aeth.makeEmpty());
 });
@@ -671,8 +666,7 @@ test('update liquidator', async t => {
     }),
   );
   await eventLoopIteration();
-  // ??? why is AT_NEXT necessary now
-  govNotify = await d.managerNotified(undefined, AT_NEXT);
+  govNotify = await d.managerNotified();
   const newLiquidator = govNotify.value.liquidatorInstance;
   t.not(oldLiquidator, newLiquidator);
 
@@ -723,10 +717,8 @@ test('liquidate many', async t => {
 
   await d.setPrice(await overThreshold(dv5));
   await eventLoopIteration();
-  // ??? why is AT_NEXT necessary now
-  await dv1.notified(Phase.LIQUIDATED, null, AT_NEXT);
-  // FIXME this one triggers: argument must be a previously-issued updateCount.
-  await dv2.notified(Phase.LIQUIDATED, null, AT_NEXT);
+  await dv1.notified(Phase.LIQUIDATED);
+  await dv2.notified(Phase.LIQUIDATED);
   await dv3.notified(Phase.LIQUIDATED);
   await dv4.notified(Phase.LIQUIDATED);
   await dv5.notified(Phase.ACTIVE);

--- a/packages/run-protocol/test/vaultFactory/test-liquidator.js
+++ b/packages/run-protocol/test/vaultFactory/test-liquidator.js
@@ -4,6 +4,7 @@ import '@agoric/zoe/exported.js';
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
+import { makeNotifierFromSubscriber } from '@agoric/notifier';
 import {
   ceilMultiplyBy,
   makeRatioFromAmounts,
@@ -359,9 +360,9 @@ const makeDriver = async (t, initialPrice, priceBase) => {
     vaultFactory: { lender, vaultFactory },
     priceAuthority,
   } = services;
-  const managerNotifier = await E(
-    E(lender).getCollateralManager(aeth.brand),
-  ).getNotifier();
+  const managerNotifier = await makeNotifierFromSubscriber(
+    E(E(lender).getCollateralManager(aeth.brand)).getSubscriber(),
+  );
   let managerNotification = await E(managerNotifier).getUpdateSince();
 
   /** @type {UserSeat} */
@@ -402,11 +403,9 @@ const makeDriver = async (t, initialPrice, priceBase) => {
        *
        * @param {import('../../src/vaultFactory/vault.js').VaultPhase} phase
        * @param {object} [likeExpected]
-       * @param {AT_NEXT|number} [optSince]
+       * @param {AT_NEXT|number} [optSince] AT_NEXT is an alias for updateCount of the last update, forcing to wait for another
        */
       notified: async (phase, likeExpected, optSince) => {
-        // optSince can be AT_NEXT in order to wait for the
-        // next update.
         notification = await E(notifier).getUpdateSince(
           optSince === AT_NEXT ? notification.updateCount : optSince,
         );
@@ -490,6 +489,11 @@ const makeDriver = async (t, initialPrice, priceBase) => {
       await driver.tick(3);
       await outcome;
     },
+    /**
+     *
+     * @param {object} [likeExpected]
+     * @param {AT_NEXT|number} [optSince] AT_NEXT is an alias for updateCount of the last update, forcing to wait for another
+     */
     managerNotified: async (likeExpected, optSince) => {
       managerNotification = await E(managerNotifier).getUpdateSince(
         optSince === AT_NEXT ? managerNotification.updateCount : optSince,
@@ -662,7 +666,8 @@ test('update liquidator', async t => {
     }),
   );
   await eventLoopIteration();
-  govNotify = await d.managerNotified();
+  // ??? why is AT_NEXT necessary now
+  govNotify = await d.managerNotified(undefined, AT_NEXT);
   const newLiquidator = govNotify.value.liquidatorInstance;
   t.not(oldLiquidator, newLiquidator);
 

--- a/packages/run-protocol/test/vaultFactory/test-liquidator.js
+++ b/packages/run-protocol/test/vaultFactory/test-liquidator.js
@@ -571,10 +571,15 @@ test('price drop', async t => {
   await d.checkRewards(run.make(14n));
 
   await dv.close();
-  await dv.notified(Phase.CLOSED, {
-    locked: aeth.makeEmpty(),
-    updateCount: undefined,
-  });
+  await dv.notified(
+    Phase.CLOSED,
+    {
+      locked: aeth.makeEmpty(),
+      updateCount: undefined,
+    },
+    // ??? why is AT_NEXT necessary now
+    AT_NEXT,
+  );
   await d.checkPayouts(debtExpected, collateralExpected);
   await dv.checkBalance(debtExpected, aeth.makeEmpty());
 });
@@ -718,8 +723,10 @@ test('liquidate many', async t => {
 
   await d.setPrice(await overThreshold(dv5));
   await eventLoopIteration();
-  await dv1.notified(Phase.LIQUIDATED);
-  await dv2.notified(Phase.LIQUIDATED);
+  // ??? why is AT_NEXT necessary now
+  await dv1.notified(Phase.LIQUIDATED, null, AT_NEXT);
+  // FIXME this one triggers: argument must be a previously-issued updateCount.
+  await dv2.notified(Phase.LIQUIDATED, null, AT_NEXT);
   await dv3.notified(Phase.LIQUIDATED);
   await dv4.notified(Phase.LIQUIDATED);
   await dv5.notified(Phase.ACTIVE);

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -14,7 +14,7 @@ import {
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { Far } from '@endo/marshal';
 
-import { makeNotifierKit } from '@agoric/notifier';
+import { makePublishKit } from '@agoric/notifier';
 import { getAmountOut } from '@agoric/zoe/src/contractSupport';
 import { E } from '@endo/eventual-send';
 import { makeVault } from '../../src/vaultFactory/vault.js';
@@ -50,7 +50,7 @@ export async function start(zcf, privateArgs) {
 
   const { zcfSeat: stage } = zcf.makeEmptySeatKit();
 
-  const { notifier: managerNotifier } = makeNotifierKit();
+  const { subscriber: assetSubscriber } = makePublishKit();
 
   const timer = buildManualTimer(console.log, 0n, DAY);
   const options = {
@@ -132,7 +132,7 @@ export async function start(zcf, privateArgs) {
     },
     getDebtBrand: () => runBrand,
 
-    getNotifier: () => Promise.resolve(managerNotifier),
+    getAssetSubscriber: () => assetSubscriber,
     maxDebtFor,
     mintAndReallocate,
     burnAndRecord,

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -132,7 +132,7 @@ export async function start(zcf, privateArgs) {
     },
     getDebtBrand: () => runBrand,
 
-    getNotifier: () => managerNotifier,
+    getNotifier: () => Promise.resolve(managerNotifier),
     maxDebtFor,
     mintAndReallocate,
     burnAndRecord,

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -4,7 +4,7 @@ import { Nat } from '@agoric/nat';
 import { makeScalarMapStore } from '@agoric/store';
 import { provide } from '@agoric/store/src/stores/store-utils.js';
 import { E, Far } from '@endo/far';
-import { getChildNode } from '../lib-chainStorage.js';
+import { makeStorageNode } from '../lib-chainStorage.js';
 import { makeNameHubKit } from '../nameHub.js';
 import { feeIssuerConfig } from './utils.js';
 
@@ -241,7 +241,7 @@ export const makeClientBanks = async ({
 }) => {
   const STORAGE_PATH = 'wallet';
 
-  const storageNode = await getChildNode(chainStorage, STORAGE_PATH);
+  const storageNode = await makeStorageNode(chainStorage, STORAGE_PATH);
   const { creatorFacet } = await E(zoe).startInstance(
     walletFactory,
     {},

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -295,7 +295,7 @@ export const makeChainStorage = async ({
   const bridgeManager = await bridgeManagerP;
   if (!bridgeManager) {
     console.warn('Cannot support chainStorage without an actual chain.');
-    chainStorageP.resolve(undefined);
+    chainStorageP.resolve(null);
     return;
   }
 

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -193,7 +193,7 @@
  *   bldIssuerKit: RemoteIssuerKit,
  *   board: Board,
  *   bridgeManager: OptionalBridgeManager,
- *   chainStorage: ChainStorageNode | undefined,
+ *   chainStorage: ChainStorageNode | null,
  *   chainTimerService: TimerService,
  *   client: ClientManager,
  *   clientCreator: ClientCreator,

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -61,14 +61,26 @@ export function makeChainStorageRoot(toStorage, storeName, rootPath) {
 }
 
 /**
- *
- * @param {ERef<ChainStorageNode | undefined>} chainStorage
- * @param {string} childName
+ * @returns {StorageNode} an object that confirms to StorageNode API but does not store anywhere.
  */
-export async function getChildNode(chainStorage, childName) {
-  const chainStoragePresence = await chainStorage;
-  const storageNode = await (chainStoragePresence &&
-    E(chainStoragePresence).getChildNode(childName));
+const makeNullStorageNode = () => {
+  // XXX re-use "ChainStorage" methods above which don't actually depend on chains
+  return makeChainStorageRoot(() => null, 'swingset', 'null');
+};
+
+/**
+ * Convience function for falling back to non-storage when chain storage isn't available.
+ * Also takes an optional childname.
+ *
+ * @param {ERef<ChainStorageNode?>} chainStorage
+ * @param {string} [childName]
+ * @returns {Promise<StorageNode>}
+ */
+export async function makeStorageNode(chainStorage, childName) {
+  const storageNode = (await chainStorage) || makeNullStorageNode();
+  if (childName) {
+    return E(storageNode).getChildNode(childName);
+  }
   return storageNode;
 }
-harden(getChildNode);
+harden(makeStorageNode);

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -72,7 +72,7 @@ test('connectFaucet produces payments', async t => {
 
   const bldKit = makeIssuerKit('BLD');
   produce.bldIssuerKit.resolve(bldKit);
-  produce.chainStorage.resolve(undefined);
+  produce.chainStorage.resolve(null);
 
   const runIssuer = E(zoe).getFeeIssuer();
   produce.bankManager.resolve(

--- a/packages/wallet/contract/test/test-singleWallet.js
+++ b/packages/wallet/contract/test/test-singleWallet.js
@@ -1,4 +1,4 @@
-// @ts-nocheck FIXME
+// @ts-check
 
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
@@ -20,7 +20,7 @@ import {
   makePromiseSpace,
 } from '@agoric/vats/src/core/utils.js';
 import {
-  getChildNode,
+  makeStorageNode,
   makeChainStorageRoot,
 } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeNameHubKit } from '@agoric/vats/src/nameHub.js';
@@ -88,6 +88,7 @@ const makeTestContext = async t => {
   produce.bankManager.resolve(
     Promise.resolve(
       Far('mockBankManager', {
+        // @ts-expect-error
         getBankForAddress: _a =>
           Far('mockBank', {
             getPurse: () => ({
@@ -147,7 +148,8 @@ const makeTestContext = async t => {
     `${dirname}/../src/singleWallet.js`,
     'singleWallet',
   );
-  /** @type {Installation<import('../src/singleWallet.js').start>} */
+  /** @type {Promise<Installation<import('../src/singleWallet.js').start>>} */
+  // @ts-expect-error cast
   const installation = E(zoe).install(bundle);
   // #endregion
 
@@ -158,7 +160,7 @@ const makeTestContext = async t => {
   );
 
   // copied from makeClientBanks()
-  const storageNode = await getChildNode(consume.chainStorage, 'wallet');
+  const storageNode = await makeStorageNode(consume.chainStorage, 'wallet');
   const marshaller = E(consume.board).getPublishingMarshaller();
 
   const singleWallet = E(zoe).startInstance(

--- a/packages/wallet/contract/test/test-walletFactory.js
+++ b/packages/wallet/contract/test/test-walletFactory.js
@@ -1,4 +1,4 @@
-// @ts-nocheck FIXME
+// @ts-check
 
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
@@ -20,7 +20,7 @@ import {
   makePromiseSpace,
 } from '@agoric/vats/src/core/utils.js';
 import {
-  getChildNode,
+  makeStorageNode,
   makeChainStorageRoot,
 } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeNameHubKit } from '@agoric/vats/src/nameHub.js';
@@ -92,6 +92,7 @@ const makeTestContext = async t => {
   produce.bankManager.resolve(
     Promise.resolve(
       Far('mockBankManager', {
+        // @ts-expect-error
         getBankForAddress: _a =>
           Far('mockBank', {
             getPurse: () => ({
@@ -148,12 +149,13 @@ const makeTestContext = async t => {
     `${dirname}/../src/walletFactory.js`,
     'walletFactory',
   );
-  /** @type {Installation<import('../src/walletFactory.js').start>} */
+  /** @type {Promise<Installation<import('../src/walletFactory.js').start>>} */
+  // @ts-expect-error case
   const installation = E(zoe).install(bundle);
   // #endregion
 
   // copied from makeClientBanks()
-  const storageNode = await getChildNode(consume.chainStorage, 'wallet');
+  const storageNode = await makeStorageNode(consume.chainStorage, 'wallet');
   const marshaller = E(consume.board).getPublishingMarshaller();
 
   const walletFactory = E(zoe).startInstance(

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -31,7 +31,7 @@ const isGT = (amount, amountLimit) => !AmountMath.isGTE(amountLimit, amount);
 /**
  * @typedef {object} OnewayPriceAuthorityOptions
  * @property {Issuer} quoteIssuer
- * @property {ERef<Notifier<Timestamp>>} notifier
+ * @property {ERef<Notifier<unknown>>} notifier
  * @property {ERef<TimerService>} timer
  * @property {PriceQuoteCreate} createQuote
  * @property {Brand} actualBrandIn


### PR DESCRIPTION
refs: #5346

## Description

This with https://github.com/Agoric/agoric-sdk/issues/5739 will enable https://github.com/Agoric/agoric-sdk/issues/5386

This one removes `makeNotifierKit` from VaultFactory without changing its API. Next will update the external API to provide Subscriber, for off-chain reads.

Review recommendation: by commit

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

Tests needed updates for refactors, but there should be no change in behavior.
Also test locally `agoric start --reset` to ensure sim-chain hasn't broken on making storageNode and marshaller no longer optional.