### PR TITLE
fix(telemetry): do not mutate the original slog object

### DIFF
--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -81,7 +81,7 @@ async function run() {
   let update = false;
   for await (const line of lines) {
     lineCount += 1;
-    const obj = JSON.parse(line);
+    const obj = harden(JSON.parse(line));
     update ||= obj.time >= progress.lastSlogTime;
     if (update) {
       progress.lastSlogTime = obj.time;

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -454,13 +454,11 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
       }
       case 'deliver-result': {
         const {
-          dr: [status, _1, meterResult],
+          dr: [status, _1, rawMeterResult],
           // ...attrs
         } = slogAttrs;
         // remove timestamps for now
-        if (meterResult) {
-          delete meterResult.timestamps;
-        }
+        const { timestamps: _t, ...meterResult } = rawMeterResult ?? {};
         spans.get(getCrankKey()).setAttributes(
           cleanAttrs({
             status,


### PR DESCRIPTION

refs: #5637

## Description

I had a stupid error in #5637 which fell through the cracks since the ingest script didn't harden it's the slog object like the kernel does.

### Security Considerations

Don't mutate objects!

### Documentation Considerations

None

### Testing Considerations

Updated the test tools (ingest script) to harden and prevent future issues like this.
