### PR TITLE
fix(swingset): stop using a persistent kernel bundle

### DIFF
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -52,7 +52,6 @@ const enableKernelGC = true;
 // device.nextID = $NN
 // meter.nextID = $NN // used to make m$NN
 
-// kernelBundle = JSON(bundle)
 // namedBundleID.$NAME = bundleID
 // bundle.$BUNDLEID = JSON(bundle)
 //

--- a/packages/SwingSet/test/device-hooks/test-device-hooks.js
+++ b/packages/SwingSet/test/device-hooks/test-device-hooks.js
@@ -59,8 +59,10 @@ test('add hook', async t => {
     addVattp: false,
     addTimer: false,
   };
+  const { kernelBundle } = t.context.data.kernelBundles;
+  const runtimeOpts = { kernelBundle };
   await initializeSwingset(config, [], hostStorage, initOpts);
-  const c = await makeSwingsetController(hostStorage, {});
+  const c = await makeSwingsetController(hostStorage, {}, runtimeOpts);
 
   let hookreturn;
   function setHookReturn(args, slots = []) {

--- a/packages/SwingSet/test/devices/test-devices.js
+++ b/packages/SwingSet/test/devices/test-devices.js
@@ -12,6 +12,7 @@ import {
   buildKernelBundles,
 } from '../../src/index.js';
 import buildCommand from '../../src/devices/command/command.js';
+import { bundleOpts } from '../util.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });
@@ -61,9 +62,10 @@ test.serial('d0', async t => {
       },
     },
   };
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [], hostStorage);
-  const c = await makeSwingsetController(hostStorage, {});
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, {}, runtimeOpts);
   await c.run();
 
   // console.log(util.inspect(c.dump(), { depth: null }));
@@ -108,15 +110,16 @@ test.serial('d1', async t => {
       },
     },
   };
-  const deviceEndowments = {
+  const devEndows = {
     d1: {
       shared: sharedArray,
     },
   };
 
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [], hostStorage, t.context.data);
-  const c = await makeSwingsetController(hostStorage, deviceEndowments);
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, devEndows, runtimeOpts);
   c.pinVatRoot('bootstrap');
   await c.run();
 
@@ -149,9 +152,10 @@ async function test2(t, mode) {
       },
     },
   };
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [], hostStorage, t.context.data);
-  const c = await makeSwingsetController(hostStorage, {});
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, {}, runtimeOpts);
   c.pinVatRoot('bootstrap');
   await c.run(); // startup
 
@@ -238,10 +242,11 @@ test.serial('device state', async t => {
     },
   };
 
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   // The initial state should be missing (null). Then we set it with the call
   // from bootstrap, and read it back.
-  await initializeSwingset(config, ['write+read'], hostStorage, t.context.data);
-  const c1 = await makeSwingsetController(hostStorage, {});
+  await initializeSwingset(config, ['write+read'], hostStorage, initOpts);
+  const c1 = await makeSwingsetController(hostStorage, {}, runtimeOpts);
   const d3 = c1.deviceNameToID('d3');
   await c1.run();
   t.deepEqual(c1.dump().log, ['undefined', 'w+r', 'called', 'got {"s":"new"}']);
@@ -266,13 +271,14 @@ test.serial('command broadcast', async t => {
       },
     },
   };
-  const deviceEndowments = {
+  const devEndows = {
     command: { ...cm.endowments },
   };
 
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [], hostStorage, t.context.data);
-  const c = await makeSwingsetController(hostStorage, deviceEndowments);
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, devEndows, runtimeOpts);
   c.pinVatRoot('bootstrap');
   c.queueToVatRoot('bootstrap', 'doCommand1', [], 'panic');
   await c.run();
@@ -294,13 +300,14 @@ test.serial('command deliver', async t => {
       },
     },
   };
-  const deviceEndowments = {
+  const devEndows = {
     command: { ...cm.endowments },
   };
 
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [], hostStorage, t.context.data);
-  const c = await makeSwingsetController(hostStorage, deviceEndowments);
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, devEndows, runtimeOpts);
   c.pinVatRoot('bootstrap');
   c.queueToVatRoot('bootstrap', 'doCommand2', [], 'panic');
   await c.run();
@@ -339,9 +346,10 @@ test.serial('liveslots throws when D() gets promise', async t => {
       },
     },
   };
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [], hostStorage, t.context.data);
-  const c = await makeSwingsetController(hostStorage, {});
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, {}, runtimeOpts);
   c.pinVatRoot('bootstrap');
 
   // When liveslots catches an attempt to send a promise into D(), it throws
@@ -377,9 +385,10 @@ test.serial('syscall.callNow(promise) is vat-fatal', async t => {
       },
     },
   };
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [], hostStorage, t.context.data);
-  const c = await makeSwingsetController(hostStorage, {});
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, {}, runtimeOpts);
   c.pinVatRoot('bootstrap');
   await c.run();
 
@@ -413,13 +422,14 @@ test.serial('device errors cause vat-catchable D error', async t => {
     },
   };
 
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const bootstrapResult = await initializeSwingset(
     config,
     [],
     hostStorage,
-    t.context.data,
+    initOpts,
   );
-  const c = await makeSwingsetController(hostStorage, {});
+  const c = await makeSwingsetController(hostStorage, {}, runtimeOpts);
   await c.run();
 
   t.is(c.kpStatus(bootstrapResult), 'fulfilled'); // not 'rejected'
@@ -451,13 +461,14 @@ test.serial('foreign device nodes cause a catchable error', async t => {
     },
   };
 
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const bootstrapResult = await initializeSwingset(
     config,
     [],
     hostStorage,
-    t.context.data,
+    initOpts,
   );
-  const c = await makeSwingsetController(hostStorage, {});
+  const c = await makeSwingsetController(hostStorage, {}, runtimeOpts);
   await c.run();
 
   t.is(c.kpStatus(bootstrapResult), 'fulfilled'); // not 'rejected'

--- a/packages/SwingSet/test/devices/test-raw-device.js
+++ b/packages/SwingSet/test/devices/test-raw-device.js
@@ -11,6 +11,7 @@ import {
   makeSwingsetController,
   buildKernelBundles,
 } from '../../src/index.js';
+import { bundleOpts } from '../util.js';
 
 function dfile(name) {
   return new URL(`./${name}`, import.meta.url).pathname;
@@ -41,15 +42,16 @@ test('d1', async t => {
       },
     },
   };
-  const deviceEndowments = {
+  const devEndows = {
     dr: {
       shared: sharedArray,
     },
   };
 
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [], hostStorage, t.context.data);
-  const c = await makeSwingsetController(hostStorage, deviceEndowments);
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, devEndows, runtimeOpts);
   c.pinVatRoot('bootstrap');
   await c.run();
 

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -19,6 +19,7 @@ import {
   buildVatController,
   buildKernelBundles,
 } from '../src/index.js';
+import { bundleOpts } from './util.js';
 import { buildLoopbox } from '../src/devices/loopbox/loopbox.js';
 import { buildPatterns } from './message-patterns.js';
 
@@ -127,7 +128,7 @@ for (const name of Array.from(bp.patterns.keys()).sort()) {
 }
 
 export async function runVatsInComms(t, name) {
-  const { commsConfig, kernelBundles } = t.context.data;
+  const { commsConfig } = t.context.data;
   const { passOneMessage, loopboxSrcPath, loopboxEndowments } =
     buildLoopbox('queued');
   const devices = {
@@ -139,12 +140,13 @@ export async function runVatsInComms(t, name) {
     },
   };
   const config = { ...commsConfig, devices };
-  const deviceEndowments = {
+  const devEndows = {
     loopbox: { ...loopboxEndowments },
   };
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [name], hostStorage, { kernelBundles });
-  const c = await makeSwingsetController(hostStorage, deviceEndowments);
+  await initializeSwingset(config, [name], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, devEndows, runtimeOpts);
   t.teardown(c.shutdown);
 
   // await runWithTrace(c);

--- a/packages/SwingSet/test/upgrade/test-upgrade-replay.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade-replay.js
@@ -9,7 +9,7 @@ import {
   initializeSwingset,
   makeSwingsetController,
 } from '../../src/index.js';
-import { capargs } from '../util.js';
+import { capargs, bundleOpts } from '../util.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
@@ -43,13 +43,12 @@ test('replay after upgrade', async t => {
       upton: { sourceSpec: bfile('vat-upton-replay.js') },
     },
   };
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
 
   const hostStorage1 = provideHostStorage();
   {
-    await initializeSwingset(copy(config), [], hostStorage1, {
-      kernelBundles: t.context.data.kernelBundles,
-    });
-    const c1 = await makeSwingsetController(hostStorage1);
+    await initializeSwingset(copy(config), [], hostStorage1, initOpts);
+    const c1 = await makeSwingsetController(hostStorage1, {}, runtimeOpts);
     c1.pinVatRoot('bootstrap');
     await c1.run();
 
@@ -70,7 +69,7 @@ test('replay after upgrade', async t => {
   const hostStorage2 = provideHostStorage();
   setAllState(hostStorage2, state1);
   {
-    const c2 = await makeSwingsetController(hostStorage2);
+    const c2 = await makeSwingsetController(hostStorage2, {}, runtimeOpts);
     c2.pinVatRoot('bootstrap');
     await c2.run();
 

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -171,3 +171,10 @@ export function makeKernelEndowments() {
     createSHA256,
   };
 }
+
+export function bundleOpts(data, extraRuntimeOpts) {
+  const { kernel: kernelBundle, ...kernelBundles } = data.kernelBundles;
+  const initOpts = { kernelBundles };
+  const runtimeOpts = { kernelBundle, ...extraRuntimeOpts };
+  return { initOpts, runtimeOpts };
+}

--- a/packages/SwingSet/test/vat-admin/test-create-vat.js
+++ b/packages/SwingSet/test/vat-admin/test-create-vat.js
@@ -10,7 +10,7 @@ import {
   makeSwingsetController,
   loadBasedir,
 } from '../../src/index.js';
-import { capSlot } from '../util.js';
+import { capSlot, bundleOpts } from '../util.js';
 import { extractMethod } from '../../src/lib/kdebug.js';
 
 function nonBundleFunction(_E) {
@@ -51,7 +51,7 @@ test.before(async t => {
 });
 
 async function doTestSetup(t, enableSlog = false) {
-  const { bundles, kernelBundles } = t.context.data;
+  const { bundles } = t.context.data;
   const config = await loadBasedir(new URL('./', import.meta.url).pathname);
   config.defaultManagerType = 'xs-worker';
   config.bundles = {
@@ -60,8 +60,6 @@ async function doTestSetup(t, enableSlog = false) {
     brokenRoot: { bundle: bundles.brokenRootVatBundle },
     brokenHang: { bundle: bundles.brokenHangVatBundle },
   };
-  const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [], hostStorage, { kernelBundles });
   let doSlog = false;
   function slogSender(_, s) {
     if (!doSlog) return;
@@ -74,7 +72,10 @@ async function doTestSetup(t, enableSlog = false) {
       console.log(JSON.stringify(o));
     }
   }
-  const c = await makeSwingsetController(hostStorage, {}, { slogSender });
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data, { slogSender });
+  const hostStorage = provideHostStorage();
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, {}, runtimeOpts);
   const id44 = await c.validateAndInstallBundle(bundles.vat44Bundle);
   const idRC = await c.validateAndInstallBundle(bundles.vatRefcountBundle);
   c.pinVatRoot('bootstrap');


### PR DESCRIPTION
Previously, the kernel sources were bundled during
`initializeSwingset()`, and stored in the kvStore portion of the
swingstore kernelDB. It was read from that DB each time
makeSwingsetController() launched the application process.

That ensured the kernel behavior would remain consistent (and
deterministic) even if the user's source tree changed. Using a
persistent kernel bundle also speeds up application launch: we save
about 1.8s by not re-running `bundleSource` on each launch.

Once upon a time I thought this consistency was important/useful, but
now I see that it causes more problems than it's worth. In particular,
upgrading a chain requires an awkward "rekernelize" action to replace
the kernel bundle in the database. And we believe we can reclaim about
1.0s per launch by moving to a not-yet-written `importLocation()` Endo
tool that loads module graphs from disk without serializing the
archive in the middle.

This patch changes swingset to stop using a persistent kernel
bundle. Each application launch (i.e. `makeSwingsetController()` call)
re-bundles the kernel sources just before importing that bundle, so
that updated source trees are automatically picked up without
additional API calls or rekernelize steps. The bundle is no longer
stored in the kvStore.

The other bundles (vats, devices, xsnap helpers) are still created
during `initializeSwingset` and stored in the DB, since these become
part of the deterministic history of each vat (#4376 and #5703 will
inform changes to how those bundles are managed). Only the kernel
bundle has become non-persistent.

Bundling is slow enough that many unit tests pre-bundle both the
kernel and the sources of built-in vats, devices, and xsnap helper
bundles. This provides a considerable speedup for tests that build (or
launch) multiple kernels within a single test file. These
`kernelBundles` are passed into `initializationOptions`, which then
bypassed the swingset-bundles-it-for-you code. This saves a minute or
two when running the full swingset test suite.

Unit tests can still use `initializationOptions` to amortize bundling
costs for the non-kernel bundles. `runtimeOptions` now accepts a
`kernelBundle` member to amortize bundling the kernel itself. Tests
which use this trick and also use `makeSwingsetController()` need to
be updated (else they'll run 1.8s slower). All such tests were inside
`packages/SwingSet/test/` and have been updated, which would otherwise
cause the test suite to run about 50-60s slower.

The other agoric-sdk packages that do swingset-style tests are mostly
using the deprecated `buildVatController()`, whose options continue to
accept both kinds of bundles, and do not need changes.

closes #5679
