### PR TITLE
fix(swingset): remove xs-worker-no-gc and gcEveryCrank

### DIFF
--- a/packages/SwingSet/docs/configuration.md
+++ b/packages/SwingSet/docs/configuration.md
@@ -104,10 +104,10 @@ bootstrap vat.  If this property is missing, there will be no
 bootstrap vat, which may be disallowed in certain use cases.
 
 The `defaultManagerType` property indicates what sort of vat worker to run vats
-in if they are not specifically configured otherwise.  Currently allowed manager
-types are `'local'`, `'nodeWorker'`, `'node-subprocess'`, `'xs-worker'`, and
-`'xs-worker-no-gc'`.  Of these, only `'local'` and `'xs-worker'` are fully
-supported; the others are experimental.  If omitted, it defaults to `'local'`.
+in if they are not specifically configured otherwise.  Currently allowed
+manager types are `'local'`, `'nodeWorker'`, `'node-subprocess'`, and
+`'xs-worker'`.  Of these, only `'local'` and `'xs-worker'` are fully supported;
+the others are experimental.  If omitted, it defaults to `'local'`.
 
 The `includeDevDependencies` property, if `true`, instructs the bundler which
 creates bundles to include the SwingSet package's dev dependencies as well as

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -47,7 +47,6 @@ function compareSyscalls(vatID, originalSyscall, newSyscall) {
 // 3.8s v8-false, 27.5s v8-gc
 // 10.8s xs-no-gc, 15s xs-gc
 const worker = 'xs-worker';
-const gcEveryCrank = true; // false means GC is hard-disabled
 
 async function replay(transcriptFile) {
   let vatID; // we learn this from the first line of the transcript
@@ -71,7 +70,7 @@ async function replay(transcriptFile) {
     WeakRef,
     FinalizationRegistry,
     waitUntilQuiescent,
-    gcAndFinalize: makeGcAndFinalize(gcEveryCrank ? engineGC : false),
+    gcAndFinalize: makeGcAndFinalize(engineGC),
     meterControl,
   });
   const allVatPowers = { testLog };
@@ -151,7 +150,6 @@ async function replay(transcriptFile) {
         vatParameters,
         compareSyscalls,
         useTranscript: true,
-        gcEveryCrank,
       };
       const vatSyscallHandler = undefined;
       manager = await factory.createFromBundle(

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -323,7 +323,6 @@ export async function initializeSwingset(
     case 'nodeWorker':
     case 'node-subprocess':
     case 'xs-worker':
-    case 'xs-worker-no-gc':
       config.defaultManagerType = defaultManagerType;
       break;
     case undefined:

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -304,13 +304,7 @@ export default function makeKernelKeeper(
 
   function insistManagerType(mt) {
     assert(
-      [
-        'local',
-        'nodeWorker',
-        'node-subprocess',
-        'xs-worker',
-        'xs-worker-no-gc',
-      ].includes(mt),
+      ['local', 'nodeWorker', 'node-subprocess', 'xs-worker'].includes(mt),
     );
   }
 

--- a/packages/SwingSet/src/kernel/vat-loader/manager-factory.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-factory.js
@@ -50,7 +50,6 @@ export function makeVatManagerFactory({
     assertKnownOptions(managerOptions, [
       'enablePipelining',
       'managerType',
-      'gcEveryCrank',
       'setup',
       'bundle',
       'metered',
@@ -85,12 +84,7 @@ export function makeVatManagerFactory({
       enableSetup,
     } = managerOptions;
 
-    if (
-      metered &&
-      managerType !== 'local' &&
-      managerType !== 'xs-worker' &&
-      managerType !== 'xs-worker-no-gc'
-    ) {
+    if (metered && managerType !== 'local' && managerType !== 'xs-worker') {
       console.warn(`TODO: support metered with ${managerType}`);
     }
     if (setup && managerType !== 'local') {
@@ -139,19 +133,11 @@ export function makeVatManagerFactory({
       );
     }
 
-    if (managerType === 'xs-worker' || managerType === 'xs-worker-no-gc') {
-      const transformedOptions = {
-        ...managerOptions,
-        managerType: 'xs-worker',
-      };
-      if (managerOptions.gcEveryCrank === undefined) {
-        // Explicitly enable/disable gcEveryCrank.
-        transformedOptions.gcEveryCrank = managerType !== 'xs-worker-no-gc';
-      }
+    if (managerType === 'xs-worker') {
       return xsWorkerFactory.createFromBundle(
         vatID,
         bundle,
-        transformedOptions,
+        managerOptions,
         vatSyscallHandler,
       );
     }

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -53,7 +53,6 @@ export function makeXsSubprocessFactory({
     const {
       virtualObjectCacheSize,
       enableDisavow,
-      gcEveryCrank = true,
       name: vatName,
       metered,
       compareSyscalls,
@@ -155,7 +154,6 @@ export function makeXsSubprocessFactory({
         virtualObjectCacheSize,
         enableDisavow,
         kernelKeeper.getRelaxDurabilityRules(),
-        gcEveryCrank,
       ]);
       if (bundleReply[0] === 'dispatchReady') {
         parentLog(vatID, `bundle loaded. dispatch ready.`);

--- a/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
@@ -186,7 +186,6 @@ function makeWorker(port) {
    * @param {unknown} virtualObjectCacheSize
    * @param {boolean} enableDisavow
    * @param {boolean} relaxDurabilityRules
-   * @param {boolean} [gcEveryCrank]
    * @returns {Promise<Tagged>}
    */
   async function setBundle(
@@ -195,7 +194,6 @@ function makeWorker(port) {
     virtualObjectCacheSize,
     enableDisavow,
     relaxDurabilityRules,
-    gcEveryCrank,
   ) {
     /** @type { (vso: VatSyscallObject) => VatSyscallResult } */
     function syscallToManager(vatSyscallObject) {
@@ -230,9 +228,7 @@ function makeWorker(port) {
       WeakRef,
       FinalizationRegistry,
       waitUntilQuiescent,
-      // FIXME(mfig): Here is where GC-per-crank is silently disabled.
-      // We need to do a better analysis of the tradeoffs.
-      gcAndFinalize: makeGcAndFinalize(gcEveryCrank && globalThis.gc),
+      gcAndFinalize: makeGcAndFinalize(globalThis.gc),
       meterControl,
     });
 
@@ -312,14 +308,12 @@ function makeWorker(port) {
         assert(!dispatch, 'cannot setBundle again');
         const enableDisavow = !!args[3];
         const relaxDurabilityRules = !!args[4];
-        const gcEveryCrank = args[5] === undefined ? true : !!args[5];
         return setBundle(
           args[0],
           args[1],
           args[2],
           enableDisavow,
           relaxDurabilityRules,
-          gcEveryCrank,
         );
       }
       case 'deliver': {

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -28,11 +28,10 @@ export {};
  *   enableSetup: true,
  * }} HasSetup
  *
- * @typedef { 'local' | 'nodeWorker' | 'node-subprocess' | 'xs-worker' | 'xs-worker-no-gc' } ManagerType
+ * @typedef { 'local' | 'nodeWorker' | 'node-subprocess' | 'xs-worker' } ManagerType
  * @typedef {{
  *   enablePipelining?: boolean,
  *   managerType: ManagerType,
- *   gcEveryCrank?: boolean,
  *   metered?: boolean,
  *   critical?: boolean,
  *   enableDisavow?: boolean,

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -12,13 +12,7 @@ import { Nat, isNat } from '@agoric/nat';
 
 const { details: X } = assert;
 
-const managerTypes = [
-  'local',
-  'nodeWorker',
-  'node-subprocess',
-  'xs-worker',
-  'xs-worker-no-gc',
-];
+const managerTypes = ['local', 'nodeWorker', 'node-subprocess', 'xs-worker'];
 
 function producePRR() {
   const { promise, resolve, reject } = makePromiseKit();


### PR DESCRIPTION
While we were debugging performance problems last year, we introduced
`managerType: 'xs-worker-no-gc'`, which is a variant of `xs-worker`
that disables the forced GC we were doing at the end of every
delivery.

Since then, we've improved performance in several ways:

* XS bugs were retaining objects, which have since been fixed
* we only do a forced GC during special `dispatch.bringOutYourDead`
cranks
* we deliver BOYD less often (according to a configurable schedule,
see #4160 for our decisions, but we're thinking once every 100 to 1000
deliveries)

The `xs-worker-no-gc` manager type controlled a flag named
`gcEveryCrank`, which replaced the GC primitive available to liveslots
with a dummy version.

This commit removes both `xs-worker-no-gc` and `gcEveryCrank`.

closes #5600
