### PR TITLE
fix(wallet-api): dont rely on attestation brand

### DIFF
--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -580,8 +580,6 @@ export function makeWallet({
     E(agoricNames)?.lookup('issuer', 'Attestation'),
   );
 
-  const getAttBrand = makeMemoizedGetter(() => E(getAttIssuer()).getBrand());
-
   /** @type import('@endo/promise-kit').PromiseKit<AttestationTool> */
   const attMakerPK = makePromiseKit();
 
@@ -670,9 +668,9 @@ export function makeWallet({
         keywordPaymentPs.map(async keywordPaymentP => {
           // Wait for the withdrawal to complete.  This protects against a race
           // when updating paymentToPurse.
-          const [_keyword, payment] = await keywordPaymentP;
+          const [keyword, payment] = await keywordPaymentP;
 
-          if ((await E(payment).getAllegedBrand()) === (await getAttBrand())) {
+          if (keywordToAttestation.has(keyword)) {
             return depositAttestation(payment);
           }
 

--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -1011,7 +1011,7 @@ test('lib-wallet offer methods', async (/** @type {LibWalletTestContext} */ t) =
           description: 'getRefund',
           handle: {
             kind: 'unnamed',
-            petname: 'unnamed-6',
+            petname: 'unnamed-7',
           },
           installation: {
             kind: 'unnamed',
@@ -1024,7 +1024,7 @@ test('lib-wallet offer methods', async (/** @type {LibWalletTestContext} */ t) =
         },
         inviteHandleBoardId: 'board0257',
         meta: {
-          id: 8,
+          id: 9,
         },
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },


### PR DESCRIPTION
fixes: https://github.com/Agoric/agoric-sdk/issues/5675

Testing: Created an offer proposal that would cause an error in Zoe with an `attestation` in the give--observed the wallet create the attestation payment, fail to execute the offer, then unlien the attestation. Screenshot:
![image](https://user-images.githubusercontent.com/8848650/176972036-31853a7b-b61a-441d-a4d1-89f9b4399868.png)
