### PR TITLE
fix(swingset): don't double-allocate durable object vrefs

### DIFF
--- a/packages/SwingSet/src/liveslots/vatstore-usage.md
+++ b/packages/SwingSet/src/liveslots/vatstore-usage.md
@@ -98,6 +98,7 @@ The KindHandle is a durable virtual object of a special internal Kind. This is t
 
 For each virtual object kind that is defined we store a metadata record for purposes of scanning directly through the defined kinds when a vat is stopped or upgraded.  For durable kinds this record is stored in `vom.dkind.${kindID}`; for non-durable kinds it is stored in `vom.vkind.${kindID}`.  Currently this metadata takes the form of a JSON-serialized record `{ kindID, tag }`, where the `kindID` property is the kind ID (redundantly) and `tag` is the tag string as provided in the `defineKind` or `makeKindHandle` call.
 
+Durable kinds need to store their `nextInstanceID` in the DB, so subsequent versions can begin allocating new instances from a non-overlapping starting point. For durable kinds, the metadata record is `{ kindID, tag, nextInstanceID }`, and is updated after every durable-object allocation.
 
 # Virtual/Durable Collections (aka Stores)
 

--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
@@ -133,7 +133,10 @@ export const buildRootObject = () => {
       await insistMissing(retain.rem3);
 
       resolve(`message for your predecessor, don't freak out`);
-      return { version, data, remoerr, ...parameters };
+
+      const newDur = await E(ulrikRoot).getNewDurandal();
+
+      return { version, data, remoerr, newDur, ...parameters };
     },
 
     buildV1WithLostKind: async () => {

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -191,6 +191,17 @@ const testUpgrade = async (t, defaultManagerType) => {
   const remoerr = parse(JSON.stringify(get(v2capdata, 'remoerr')));
   t.deepEqual(remoerr, Error('vat terminated'));
 
+  // newDur() (the first Durandal instance created in vat-ulrik-2)
+  // should get a new vref, because the per-Kind instance counter
+  // should persist and pick up where it left off. If that was broken,
+  // newDur would have the same vref as dur1 (the first Durandal
+  // instance created in vat-ulrik-1). And since it's durable, the
+  // c-list entry will still exist, so we'll see the same kref as
+  // before.
+  t.is(get(v2capdata, 'newDur')[0], 'slot');
+  const newDurKref = get(v2capdata, 'newDur')[1];
+  t.not(newDurKref, dur1Kref);
+
   // the old version's non-durable promises should be rejected
   t.is(c.kpStatus(v1p1Kref), 'rejected');
   const vatUpgradedError = capargs('vat upgraded');

--- a/packages/SwingSet/test/upgrade/vat-ulrik-1.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-1.js
@@ -48,6 +48,9 @@ const buildExports = (baggage, imp) => {
     dur.push(makeDurandal(`d${i}`, imp[i], { name: `d${i}` }));
   }
 
+  // note: to test #5725, dur[0] must be the first new Durandal
+  // instance created in this version of the vat
+
   // vc1+vc2 form a cycle, as do vir[7]+vir[8], and our lack of
   // cycle-collection means we don't GC it during the lifetime of the
   // vat, however they'll be deleted during upgrade because stopVat()

--- a/packages/SwingSet/test/upgrade/vat-ulrik-2.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-2.js
@@ -16,7 +16,10 @@ const behavior = {
 
 export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const durandalHandle = baggage.get('durandalHandle');
-  defineDurableKind(durandalHandle, initialize, behavior);
+  const makeDurandal = defineDurableKind(durandalHandle, initialize, behavior);
+  // note: to test #5725, newDur must be the first new Durandal
+  // instance in this version of the vat
+  const newDur = makeDurandal('dur-new', undefined, { name: 'd1' });
 
   const root = Far('root', {
     getVersion: () => 'v2',
@@ -41,6 +44,7 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
       const imp38 = baggage.get('imp38');
       return { imp33, imp35, imp37, imp38 };
     },
+    getNewDurandal: () => newDur,
   });
   // exercise async return
   return Promise.resolve(root);

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -542,7 +542,10 @@ test('durable kind IDs can be reanimated', t => {
 
   // Create a durable kind ID, but don't use it yet
   let kindHandle = makeKindHandle('testkind');
-  t.is(log.shift(), 'set vom.dkind.10 {"kindID":"10","tag":"testkind"}');
+  t.is(
+    log.shift(),
+    'set vom.dkind.10 {"kindID":"10","tag":"testkind","nextInstanceID":1}',
+  );
   t.deepEqual(log, []);
   const khid = `o+1/10`;
 
@@ -570,7 +573,10 @@ test('durable kind IDs can be reanimated', t => {
   // Fetch it from the store, which should reanimate it
   const fetchedKindID = placeToPutIt.get('savedKindID');
   t.is(log.shift(), `get vc.1.ssavedKindID => ${kindSer}`);
-  t.is(log.shift(), 'get vom.dkind.10 => {"kindID":"10","tag":"testkind"}');
+  t.is(
+    log.shift(),
+    'get vom.dkind.10 => {"kindID":"10","tag":"testkind","nextInstanceID":1}',
+  );
   t.deepEqual(log, []);
 
   // Use it now, to define a durable kind
@@ -580,6 +586,10 @@ test('durable kind IDs can be reanimated', t => {
   // Make an instance of the new kind, just to be sure it's there
   makeThing('laterThing');
   flushCache();
+  t.is(
+    log.shift(),
+    'set vom.dkind.10 {"kindID":"10","tag":"testkind","nextInstanceID":2}',
+  );
   t.is(
     log.shift(),
     'set vom.o+10/1 {"counter":{"body":"0","slots":[]},"label":{"body":"\\"laterThing\\"","slots":[]},"resetCounter":{"body":"0","slots":[]}}',


### PR DESCRIPTION
The `nextInstanceID` for durable objects, used to allocate vrefs for
new instances, was held ephemerally in RAM. As a result, the first
call to `makeFoo()` (for `makeFoo = defineDurableKind(fooHandle..)`)
in version-2 would get the same vref as the first `makeFoo()` from
version-1, when these should be entirely distinct objects. In
practice, the new object tended to displace the old one.

This changes the virtual object manager to track `nextInstanceID`
durably, by writing it into the `vom.dkind.${kindID}` metadata. This
metadata now as `{ kindID, tag, nextInstanceID }`. We write this out
after every durable object allocation (previously, the metadata was
only written once, during `makeKindHandle`). Non-durable (merely
virtual) objects do not include this counter in the metadata, nor do
they write it to DB more frequently than before.

The upgrade test was modified to look for this overlapping vref
problem.

closes #5725
