### PR TITLE
use atomic store provider in AMM

### DIFF
--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -1,34 +1,33 @@
 // @ts-check
 
-import { makeStore, makeWeakStore } from '@agoric/store';
-import { Far } from '@endo/marshal';
+import '@agoric/zoe/exported.js';
 
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
+import { makeStore, makeWeakStore } from '@agoric/store';
 import {
   assertIssuerKeywords,
   offerTo,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/far';
-import { makeAddIssuer, makeAddPoolInvitation } from './addPool.js';
-import { publicPrices } from './pool.js';
+import { Far } from '@endo/marshal';
+import { makeMakeCollectFeesInvitation } from '../collectFees.js';
+import { makeMetricsPublisherKit } from '../contractSupport.js';
+import { makeTracer } from '../makeTracer.js';
 import {
   makeMakeAddLiquidityAtRateInvitation,
   makeMakeAddLiquidityInvitation,
 } from './addLiquidity.js';
-import { makeMakeRemoveLiquidityInvitation } from './removeLiquidity.js';
-
-import '@agoric/zoe/exported.js';
-import { makeMakeCollectFeesInvitation } from '../collectFees.js';
-import { makeMakeSwapInvitation } from './swap.js';
+import { makeAddIssuer, makeAddPoolInvitation } from './addPool.js';
 import { makeDoublePool } from './doublePool.js';
 import {
+  MIN_INITIAL_POOL_LIQUIDITY_KEY,
   POOL_FEE_KEY,
   PROTOCOL_FEE_KEY,
-  MIN_INITIAL_POOL_LIQUIDITY_KEY,
 } from './params.js';
-import { makeTracer } from '../makeTracer.js';
-import { makeMetricsPublisherKit } from '../contractSupport.js';
+import { publicPrices } from './pool.js';
+import { makeMakeRemoveLiquidityInvitation } from './removeLiquidity.js';
+import { makeMakeSwapInvitation } from './swap.js';
 
 const { quote: q, details: X } = assert;
 

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -5,6 +5,7 @@ import '@agoric/zoe/exported.js';
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
 import { makeStore, makeWeakStore } from '@agoric/store';
+import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import {
   assertIssuerKeywords,
   offerTo,
@@ -165,15 +166,13 @@ const start = async (zcf, privateArgs) => {
   const isSecondary = secondaryBrandToPool.has;
 
   // The liquidityBrand has to exist to allow the addPool Offer to specify want
-  /** @type {WeakStore<Brand,ZCFMint<'nat'>>} */
+  /** @type {WeakMapStore<Brand,ZCFMint<'nat'>>} */
   const secondaryBrandToLiquidityMint = makeWeakStore(
     'secondaryBrandToLiquidityMint',
   );
-  // To manage races in addIssuer, we keep a promise from the time of the
-  // first request until the Issuer is set up.
-  /** @type {WeakStore<Brand,ERef<Issuer<'nat'>>>} */
-  const secondaryBrandToLiquidityIssuerPromise =
-    makeWeakStore('secondaryBrand');
+  const secondaryBrandToLiquidityMintProvider = makeAtomicProvider(
+    secondaryBrandToLiquidityMint,
+  );
 
   const quoteIssuerKit = makeIssuerKit('Quote', AssetKind.SET);
 
@@ -278,8 +277,7 @@ const start = async (zcf, privateArgs) => {
   const addIssuer = makeAddIssuer(
     zcf,
     isSecondary,
-    secondaryBrandToLiquidityMint,
-    secondaryBrandToLiquidityIssuerPromise,
+    secondaryBrandToLiquidityMintProvider,
     () => {
       assert(reserveFacet, 'Must first resolveReserveFacet');
       return E(reserveFacet).addIssuerFromAmm;

--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -1,16 +1,15 @@
 // @ts-check
 
+import '@agoric/zoe/exported.js';
+
 import { AmountMath, isNatValue } from '@agoric/ertp';
 import { makeNotifierKit, makeStoredPublisherKit } from '@agoric/notifier';
-
+import { defineKindMulti } from '@agoric/vat-data';
 import {
   calcLiqValueToMint,
   calcSecondaryRequired,
   calcValueToRemove,
 } from '@agoric/zoe/src/contractSupport/index.js';
-
-import '@agoric/zoe/exported.js';
-import { defineKindMulti } from '@agoric/vat-data';
 import { Far } from '@endo/marshal';
 import { makePriceAuthority } from './priceAuthority.js';
 import { singlePool } from './singlePool.js';

--- a/packages/store/src/stores/store-utils.js
+++ b/packages/store/src/stores/store-utils.js
@@ -114,15 +114,15 @@ harden(provide);
  * the key.) This prevents that race condition by immediately storing a Promise
  * for the maker in an ephemeral store.
  *
- * Upon termination, the ephemeral store of pending makes will be lost. It's
- * possible for termination to happen after the make completes and before it
- * reaches durable storage.
+ * When the `store` argument is durable storage, note that it's possible for
+ * termination to happen after the make completes and before it reaches durable
+ * storage.
  *
  * @template K
  * @template V
- * @param {MapStore<K, V>} durableStore
+ * @param {WeakMapStore<K, V>} store
  */
-export const makeAtomicProvider = durableStore => {
+export const makeAtomicProvider = store => {
   /** @type {Map<K, Promise<V>>} */
   const pending = new Map();
 
@@ -139,13 +139,13 @@ export const makeAtomicProvider = durableStore => {
    * @returns {Promise<V>}
    */
   const provideAsync = (key, makeValue, finishValue) => {
-    if (durableStore.has(key)) {
-      return Promise.resolve(durableStore.get(key));
+    if (store.has(key)) {
+      return Promise.resolve(store.get(key));
     }
     if (!pending.has(key)) {
       const valP = makeValue(key)
         .then(v => {
-          durableStore.init(key, v);
+          store.init(key, v);
           return v;
         })
         .then(v => {

--- a/packages/store/src/stores/store-utils.js
+++ b/packages/store/src/stores/store-utils.js
@@ -134,8 +134,8 @@ export const makeAtomicProvider = durableStore => {
    * that key, and return it.
    *
    * @param {K} key
-   * @param {(key: K) => Promise<V>} makeValue
-   * @param {(key: K, value: V) => Promise<void>} [finishValue]
+   * @param {(key: K) => Promise<V>} makeValue make the value for the store if it hasn't been made yet or the last make failed
+   * @param {(key: K, value: V) => Promise<void>} [finishValue] runs exactly once after a new value is added to the store
    * @returns {Promise<V>}
    */
   const provideAsync = (key, makeValue, finishValue) => {


### PR DESCRIPTION
## Description

For https://github.com/Agoric/agoric-sdk/pull/5721 I had to make an atomic provider helper to avoid a race condition. @dtribble pointed out this is similar to what https://github.com/Agoric/agoric-sdk/pull/5596 did.

#5721 landed. This PR refactors the AMM's `makeAddIssuer` to use the new `makeAtomicProvider` helper. It improves the helper's types, docs and tests.

### Security Considerations

--

### Documentation Considerations

Post in chat about new helper

### Testing Considerations

Expanded test coverage on helper, to have confidence in `finish` option.