### PR TITLE
rewrite delivery-result processing, rewind failed upgrades

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -251,7 +251,7 @@ export default function buildKernel(
    * @param {boolean} shouldReject
    * @param {SwingSetCapData} info
    */
-  function terminateVat(vatID, shouldReject, info) {
+  async function terminateVat(vatID, shouldReject, info) {
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
     const critical = vatKeeper.getOptions().critical;
     insistCapData(info);
@@ -264,7 +264,7 @@ export default function buildKernel(
       // TODO: if a static vat terminates, panic the kernel?
 
       // ISSUE: terminate stuff in its own crank like creation?
-      void vatWarehouse.vatWasTerminated(vatID);
+      await vatWarehouse.vatWasTerminated(vatID);
     }
     if (critical) {
       // The following error construction is a bit awkward, but (1) it saves us
@@ -1119,7 +1119,7 @@ export default function buildKernel(
 
       // state changes reflecting the termination must also survive, so these
       // happen after a possible abortCrank()
-      terminateVat(vatID, reject, info);
+      await terminateVat(vatID, reject, info);
       kernelSlog.terminateVat(vatID, reject, info);
       kdebug(`vat terminated: ${JSON.stringify(info)}`);
     }

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -648,6 +648,7 @@ export default function buildKernel(
       kdebug(`vat ${vatID} terminated before startVat delivered`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
+    const { meterID } = vatInfo;
     /** @type { KernelDeliveryStartVat } */
     const kd = harden(['startVat', vatParameters]);
     const vd = vatWarehouse.kernelDeliveryToVatDelivery(vatID, kd);
@@ -660,7 +661,7 @@ export default function buildKernel(
     // note: if deliveryCrankResults() learns to suspend vats,
     // startVat errors should still terminate them
     const results = harden({
-      ...deliveryCrankResults(vatID, status, true),
+      ...deliveryCrankResults(vatID, status, true, meterID),
       popDelivery: true,
     });
     return results;
@@ -1168,6 +1169,12 @@ export default function buildKernel(
     /** @type { PolicyInput } */
     let policyInput = ['crank', {}];
     if (message.type === 'create-vat') {
+      // TODO: create-vat now gets metering, at least for the
+      // dispatch.startVat . We should probably tell the policy about
+      // the creation too since there's extra overhead (we're
+      // launching a new child process, at least, although that
+      // sometimes happens randomly because of vat eviction policy
+      // which should not affect the in-consensus policyInput)
       policyInput = ['create-vat', {}];
     }
 

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1042,10 +1042,8 @@ export default function buildKernel(
         // and if both vat and delivery are metered, deduct from the Meter
         if (useMeter && meterID) {
           deduction = { meterID, computrons }; // in case we must rededuct
-          const { notify, underflow } = kernelKeeper.deductMeter(
-            meterID,
-            computrons,
-          );
+          const underflow = !kernelKeeper.checkMeter(meterID, computrons);
+          const notify = kernelKeeper.deductMeter(meterID, computrons);
           if (notify) {
             notifyMeterThreshold(meterID);
           }
@@ -1099,7 +1097,7 @@ export default function buildKernel(
         // but metering deductions and underflow notifications must survive
         if (deduction) {
           const { meterID, computrons } = deduction; // re-deduct metering
-          const { notify } = kernelKeeper.deductMeter(meterID, computrons);
+          const notify = kernelKeeper.deductMeter(meterID, computrons);
           if (notify) {
             notifyMeterThreshold(meterID); // re-queue notification
           }

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -255,6 +255,7 @@ export default function buildKernel(
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
     const critical = vatKeeper.getOptions().critical;
     insistCapData(info);
+    // ISSUE: terminate stuff in its own crank like creation?
     // guard against somebody telling vatAdmin to kill a vat twice
     if (kernelKeeper.vatIsAlive(vatID)) {
       const promisesToReject = kernelKeeper.cleanupAfterTerminatedVat(vatID);
@@ -263,8 +264,8 @@ export default function buildKernel(
       }
       // TODO: if a static vat terminates, panic the kernel?
 
-      // ISSUE: terminate stuff in its own crank like creation?
-      await vatWarehouse.vatWasTerminated(vatID);
+      // worker needs to be stopped, if any
+      await vatWarehouse.terminate(vatID);
     }
     if (critical) {
       // The following error construction is a bit awkward, but (1) it saves us
@@ -695,7 +696,7 @@ export default function buildKernel(
     }
 
     // stop the worker, delete the transcript and any snapshot
-    await vatWarehouse.destroyWorker(vatID);
+    await vatWarehouse.abandonWorker(vatID);
     const source = { bundleID };
     const { options } = vatKeeper.getSourceAndOptions();
     vatKeeper.setSourceAndOptions(source, options);

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -298,7 +298,7 @@ export default function buildKernel(
     }
 
     // worker needs to be stopped, if any
-    await vatWarehouse.terminate(vatID);
+    await vatWarehouse.stopWorker(vatID);
   }
 
   function notifyMeterThreshold(meterID) {
@@ -418,8 +418,8 @@ export default function buildKernel(
         //   Kinds, and we're not going to use the worker
         //
         // So in all cases, our caller should abandon the worker.
-        await vatWarehouse.killWorker(vatID);
-        // TODO: does killWorker work if the worker just died?
+        await vatWarehouse.stopWorker(vatID);
+        // TODO: does stopWorker work if the worker process just died?
         status.deliveryError = deliveryResult[1];
       }
       return harden(status);
@@ -862,7 +862,7 @@ export default function buildKernel(
     if (results1.terminate) {
       // get rid of the worker, so the next delivery to this vat will
       // re-create one from the previous state
-      await vatWarehouse.killWorker(vatID);
+      await vatWarehouse.stopWorker(vatID);
 
       // notify vat-admin of the failed upgrade
       const vatAdminMethargs = makeFailure(results1.terminate.info);
@@ -882,7 +882,7 @@ export default function buildKernel(
     // stopVat succeeded, so now we stop the worker, delete the
     // transcript and any snapshot
 
-    await vatWarehouse.abandonWorker(vatID);
+    await vatWarehouse.resetWorker(vatID);
     const source = { bundleID };
     const { options } = vatKeeper.getSourceAndOptions();
     vatKeeper.setSourceAndOptions(source, options);
@@ -905,7 +905,7 @@ export default function buildKernel(
 
     if (results2.terminate) {
       // unwind just like above
-      await vatWarehouse.killWorker(vatID);
+      await vatWarehouse.stopWorker(vatID);
       const vatAdminMethargs = makeFailure(results2.terminate.info);
       const results = harden({
         ...results2,

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -1024,6 +1024,10 @@ export default function makeKernelKeeper(
       return true;
     } else {
       return BigInt(oldRemaining) >= spent;
+      // note: this function is read-only, but if it indicates
+      // underrun, then the caller in kernel.js (probably
+      // processDeliveryMessage) will turn around and call
+      // deductMeter() to zero out the stored value
     }
   }
 

--- a/packages/SwingSet/src/kernel/vat-admin-hooks.js
+++ b/packages/SwingSet/src/kernel/vat-admin-hooks.js
@@ -109,7 +109,10 @@ export function makeVatAdminHooks(tools) {
       // we don't need to incrementRefCount because if terminateVat sends
       // 'reason' to vat-admin, it uses notifyTermination / queueToKref /
       // doSend, and doSend() does its own incref
-      terminateVat(vatID, true, reasonCD);
+      void terminateVat(vatID, true, reasonCD);
+      // TODO: terminateVat is async, result doesn't fire until worker
+      // is dead. To fix this we'll probably need to move termination
+      // to a run-queue ['terminate-vat', vatID] event, like createVat
       return harden({ body: stringify(undefined), slots: [] });
     },
 

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -108,8 +108,9 @@ export {};
  *            | VatDeliveryRetireExports | VatDeliveryRetireImports | VatDeliveryChangeVatOptions
  *            | VatDeliveryStartVat | VatDeliveryStopVat | VatDeliveryBringOutYourDead
  *          } VatDeliveryObject
- * @typedef { [tag: 'ok', message: null, usage: { compute: number } | null] |
- *            [tag: 'error', message: string, usage: unknown | null] } VatDeliveryResult
+ * @typedef { { compute: number } } MeterConsumption
+ * @typedef { [tag: 'ok', message: null, usage: MeterConsumption | null] |
+ *            [tag: 'error', message: string, usage: MeterConsumption | null] } VatDeliveryResult
  *
  * @typedef { [tag: 'send', target: string, msg: Message] } VatSyscallSend
  * @typedef { [tag: 'callNow', target: string, method: string, args: SwingSetCapData]} VatSyscallCallNow

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -303,10 +303,11 @@ export {};
  */
 
 /**
- * @typedef { [tag: 'none'] } PolicyInputNone
- * @typedef { [tag: 'create-vat', details: {} ]} PolicyInputCreateVat
- * @typedef { [tag: 'crank', details: { computrons?: bigint }] } PolicyInputCrankComplete
- * @typedef { [tag: 'crank-failed', details: {}]} PolicyInputCrankFailed
+ * @typedef { { computrons?: bigint } } PolicyInputDetails
+ * @typedef { [tag: 'none', details: PolicyInputDetails ] } PolicyInputNone
+ * @typedef { [tag: 'create-vat', details: PolicyInputDetails  ]} PolicyInputCreateVat
+ * @typedef { [tag: 'crank', details: PolicyInputDetails ] } PolicyInputCrankComplete
+ * @typedef { [tag: 'crank-failed', details: PolicyInputDetails ]} PolicyInputCrankFailed
  * @typedef { PolicyInputNone | PolicyInputCreateVat | PolicyInputCrankComplete | PolicyInputCrankFailed } PolicyInput
  * @typedef { boolean } PolicyOutput
  * @typedef { { vatCreated: (details: {}) => PolicyOutput,

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -324,7 +324,13 @@ export function buildRootObject(vatPowers) {
     }
   }
 
-  // the kernel queues this to us when a vat upgrade completes or fails
+  /**
+   * the kernel queues this to us when a vat upgrade completes or fails
+   *
+   * @param {UpgradeID} upgradeID
+   * @param {boolean} success
+   * @param {Error | undefined} error
+   */
   function vatUpgradeCallback(upgradeID, success, error) {
     const { resolve, reject } = pendingUpgrades.get(upgradeID);
     pendingUpgrades.delete(upgradeID);

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -693,34 +693,52 @@ test('meters', async t => {
   t.not(m1, m2);
   k.deleteMeter(m2);
   t.deepEqual(k.getMeter(m1), { remaining: 100n, threshold: 10n });
-  t.deepEqual(k.deductMeter(m1, 10n), { underflow: false, notify: false });
-  t.deepEqual(k.deductMeter(m1, 10n), { underflow: false, notify: false });
+  // checkMeter has no side-effects
+  t.is(k.checkMeter(m1, 10n), true);
+  t.is(k.checkMeter(m1, 100n), true);
+  t.is(k.checkMeter(m1, 101n), false);
+  t.is(k.checkMeter(m1, 10n), true);
+
+  t.is(k.checkMeter(m1, 10n), true);
+  t.is(k.deductMeter(m1, 10n), false);
+  t.is(k.checkMeter(m1, 10n), true);
+  t.is(k.deductMeter(m1, 10n), false);
   t.deepEqual(k.getMeter(m1), { remaining: 80n, threshold: 10n });
-  t.deepEqual(k.deductMeter(m1, 70n), { underflow: false, notify: false });
-  t.deepEqual(k.deductMeter(m1, 1n), { underflow: false, notify: true });
+  t.is(k.checkMeter(m1, 70n), true);
+  t.is(k.deductMeter(m1, 70n), false);
+  t.is(k.checkMeter(m1, 1n), true);
+  t.is(k.deductMeter(m1, 1n), true);
   t.deepEqual(k.getMeter(m1), { remaining: 9n, threshold: 10n });
-  t.deepEqual(k.deductMeter(m1, 1n), { underflow: false, notify: false });
-  t.deepEqual(k.deductMeter(m1, 9n), { underflow: true, notify: false });
+  t.is(k.checkMeter(m1, 1n), true);
+  t.is(k.deductMeter(m1, 1n), false);
+  t.is(k.checkMeter(m1, 9n), false);
+  t.is(k.deductMeter(m1, 9n), false);
   t.deepEqual(k.getMeter(m1), { remaining: 0n, threshold: 10n });
-  t.deepEqual(k.deductMeter(m1, 2n), { underflow: true, notify: false });
+  t.is(k.checkMeter(m1, 2n), false);
+  t.is(k.deductMeter(m1, 2n), false);
   t.deepEqual(k.getMeter(m1), { remaining: 0n, threshold: 10n });
   k.addMeterRemaining(m1, 50n);
   t.deepEqual(k.getMeter(m1), { remaining: 50n, threshold: 10n });
-  t.deepEqual(k.deductMeter(m1, 30n), { underflow: false, notify: false });
-  t.deepEqual(k.deductMeter(m1, 25n), { underflow: true, notify: true });
+  t.is(k.checkMeter(m1, 30n), true);
+  t.is(k.deductMeter(m1, 30n), false);
+  t.is(k.checkMeter(m1, 25n), false);
+  t.is(k.deductMeter(m1, 25n), true);
   t.deepEqual(k.getMeter(m1), { remaining: 0n, threshold: 10n });
 
   k.addMeterRemaining(m1, 50n);
   k.setMeterThreshold(m1, 40n);
   t.deepEqual(k.getMeter(m1), { remaining: 50n, threshold: 40n });
-  t.deepEqual(k.deductMeter(m1, 10n), { underflow: false, notify: false });
-  t.deepEqual(k.deductMeter(m1, 10n), { underflow: false, notify: true });
+  t.is(k.checkMeter(m1, 10n), true);
+  t.is(k.deductMeter(m1, 10n), false);
+  t.is(k.checkMeter(m1, 10n), true);
+  t.is(k.deductMeter(m1, 10n), true);
   t.deepEqual(k.getMeter(m1), { remaining: 30n, threshold: 40n });
 
   const m3 = k.allocateMeter('unlimited', 10n);
   k.setMeterThreshold(m3, 5n);
   t.deepEqual(k.getMeter(m3), { remaining: 'unlimited', threshold: 5n });
-  t.deepEqual(k.deductMeter(m3, 1000n), { underflow: false, notify: false });
+  t.is(k.checkMeter(m3, 1000n), true);
+  t.is(k.deductMeter(m3, 1000n), false);
   t.deepEqual(k.getMeter(m3), { remaining: 'unlimited', threshold: 5n });
 });
 

--- a/packages/SwingSet/test/upgrade/vat-ulrik-1.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-1.js
@@ -1,4 +1,5 @@
 import { Far } from '@endo/marshal';
+import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import {
   makeKindHandle,
@@ -140,9 +141,14 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const { promise: p1 } = makePromiseKit();
   const { promise: p2 } = makePromiseKit();
   let heldPromise;
+  let counter = 0;
 
   baggage.init('data', harden(['some', 'data']));
   baggage.init('durandalHandle', durandalHandle);
+
+  if (vatParameters?.handler) {
+    E(vatParameters.handler).ping('hello from v1');
+  }
 
   return Far('root', {
     getVersion: () => 'v1',
@@ -168,6 +174,10 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
 
     makeLostKind: () => {
       makeKindHandle('unhandled', []);
+    },
+    pingback: handler => {
+      counter += 1;
+      return E(handler).ping(`ping ${counter}`);
     },
   });
 };

--- a/packages/SwingSet/test/upgrade/vat-ulrik-2.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-2.js
@@ -1,4 +1,5 @@
 import { Far } from '@endo/marshal';
+import { E } from '@endo/eventual-send';
 import { assert } from '@agoric/assert';
 import { defineDurableKind } from '@agoric/vat-data';
 
@@ -20,6 +21,15 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   // note: to test #5725, newDur must be the first new Durandal
   // instance in this version of the vat
   const newDur = makeDurandal('dur-new', undefined, { name: 'd1' });
+  let counter = 20;
+
+  if (vatParameters?.handler) {
+    E(vatParameters.handler).ping('hello from v2');
+  }
+
+  if (vatParameters?.explode) {
+    throw Error(vatParameters.explode);
+  }
 
   const root = Far('root', {
     getVersion: () => 'v2',
@@ -43,6 +53,10 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
       const imp37 = baggage.get('dur37').getImport();
       const imp38 = baggage.get('imp38');
       return { imp33, imp35, imp37, imp38 };
+    },
+    pingback: handler => {
+      counter += 1;
+      return E(handler).ping(`ping ${counter}`);
     },
     getNewDurandal: () => newDur,
   });


### PR DESCRIPTION
This PR modifies vat-upgrade to respond correctly to failures during
the upgrade process, by rewinding the vat back to it's pre-upgrade
state.

From the outside world, it will appear as if upgrade was never
requested, except that `upgradeVat()` rejects.

It also deducts the computrons used during `dispatch.startVat`
(including the userspace `buildRootObject()` execution) from both the
vat's Meter and the host application's `runPolicy`. Metered vats
should plan to provide an additional (estimated) 8M computrons to pay
for the work done during startVat. For block-based host applications,
the blocks that include new vat creation should now be smaller and
closer to the policy-guided limits.

closes #5344
