### PR TITLE
4550 vault factory durable (unreachably)

### DIFF
--- a/packages/SwingSet/tools/fakeVirtualSupport.js
+++ b/packages/SwingSet/tools/fakeVirtualSupport.js
@@ -274,7 +274,12 @@ export function makeFakeWatchedPromiseManager(vrm, vom, cm, fakeStuff) {
     fakeStuff.convertSlotToVal,
   );
 }
-
+/**
+ * Configure virtual stuff with relaxed durability rules and fake liveslots
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.relaxDurabilityRules=true]
+ */
 export function makeFakeVirtualStuff(options = {}) {
   const fakeStuff = makeFakeLiveSlotsStuff(options);
   const { relaxDurabilityRules = true } = options;

--- a/packages/inter-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/inter-protocol/src/vaultFactory/orderedVaultStore.js
@@ -1,5 +1,4 @@
 // @ts-check
-import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { fromVaultKey, toVaultKey } from './storeUtils.js';
 
 /**
@@ -15,10 +14,10 @@ import { fromVaultKey, toVaultKey } from './storeUtils.js';
 /** @typedef {import('./vault').Vault} Vault */
 /** @typedef {import('./storeUtils').CompositeKey} CompositeKey */
 
-export const makeOrderedVaultStore = () => {
-  /** @type {MapStore<string, Vault>} */
-  const store = makeScalarBigMapStore('orderedVaultStore', { durable: true });
-
+/**
+ * @param {MapStore<string, Vault>} store
+ */
+export const makeOrderedVaultStore = store => {
   /**
    *
    * @param {string} vaultId

--- a/packages/inter-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/inter-protocol/src/vaultFactory/orderedVaultStore.js
@@ -1,5 +1,4 @@
 // @ts-check
-// XXX avoid deep imports https://github.com/Agoric/agoric-sdk/issues/4255#issuecomment-1032117527
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { fromVaultKey, toVaultKey } from './storeUtils.js';
 
@@ -17,9 +16,8 @@ import { fromVaultKey, toVaultKey } from './storeUtils.js';
 /** @typedef {import('./storeUtils').CompositeKey} CompositeKey */
 
 export const makeOrderedVaultStore = () => {
-  // TODO make it work durably https://github.com/Agoric/agoric-sdk/issues/4550
   /** @type {MapStore<string, Vault>} */
-  const store = makeScalarBigMapStore('orderedVaultStore', { durable: false });
+  const store = makeScalarBigMapStore('orderedVaultStore', { durable: true });
 
   /**
    *

--- a/packages/inter-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/inter-protocol/src/vaultFactory/prioritizedVaults.js
@@ -46,11 +46,12 @@ export const currentDebtToCollateral = vault =>
  * Vaults, ordered by their debt ratio so that all the vaults below a threshold
  * can be quickly found and liquidated.
  *
- * @param {(highestRatio: Ratio) => void} higherHighestCb called when a new
+ * @param {MapStore<string, Vault>} store
+ * @param {(highestRatio: Ratio) => void} [higherHighestCb] called when a new
  * vault has a higher debt ratio than the previous highest
  */
-export const makePrioritizedVaults = (higherHighestCb = () => {}) => {
-  const vaults = makeOrderedVaultStore();
+export const makePrioritizedVaults = (store, higherHighestCb = () => {}) => {
+  const vaults = makeOrderedVaultStore(store);
 
   /**
    * Called back when there's a new highestRatio and it's higher than the previous.

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -8,7 +8,11 @@ import {
   floorMultiplyBy,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { AmountMath } from '@agoric/ertp';
-import { defineKindMulti, pickFacet } from '@agoric/vat-data';
+import {
+  defineDurableKindMulti,
+  makeKindHandle,
+  pickFacet,
+} from '@agoric/vat-data';
 import { makeTracer } from '../makeTracer.js';
 import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
 import { makeVaultKit } from './vaultKit.js';
@@ -777,10 +781,14 @@ const selfBehavior = {
   },
 };
 
-const makeVaultBase = defineKindMulti('Vault', initState, {
-  self: selfBehavior,
-  helper: helperBehavior,
-});
+const makeVaultBase = defineDurableKindMulti(
+  makeKindHandle('Vault'),
+  initState,
+  {
+    self: selfBehavior,
+    helper: helperBehavior,
+  },
+);
 
 /**
  * @param {ZCF} zcf

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -17,7 +17,7 @@ import { Far } from '@endo/marshal';
 
 import { AmountMath } from '@agoric/ertp';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
-import { defineKindMulti } from '@agoric/vat-data';
+import { defineDurableKindMulti, makeKindHandle } from '@agoric/vat-data';
 import { makeStoredPublisherKit, observeIteration } from '@agoric/notifier';
 import { makeVaultManager } from './vaultManager.js';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
@@ -547,8 +547,8 @@ const finish = async ({ state }) => {
  * @param {import('@agoric/governance/src/contractGovernance/typedParamManager').TypedParamManager<import('./params.js').VaultDirectorParams>} directorParamManager
  * @param {ZCFMint<"nat">} debtMint
  */
-const makeVaultDirector = defineKindMulti(
-  'VaultDirector',
+const makeVaultDirector = defineDurableKindMulti(
+  makeKindHandle('VaultDirector'),
   initState,
   behavior,
   { finish },

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -3,7 +3,7 @@
  */
 // @ts-check
 import { makeStoredPublishKit } from '@agoric/notifier';
-import { defineKindMulti } from '@agoric/vat-data';
+import { defineDurableKindMulti, makeKindHandle } from '@agoric/vat-data';
 import '@agoric/zoe/exported.js';
 
 const { details: X } = assert;
@@ -86,8 +86,8 @@ const holder = {
 
 const behavior = { helper, holder };
 
-export const makeVaultHolder = defineKindMulti(
-  'VaultHolder',
+export const makeVaultHolder = defineDurableKindMulti(
+  makeKindHandle('VaultHolder'),
   initState,
   behavior,
 );

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -2,16 +2,29 @@
  * @file Use-object for the owner of a vault
  */
 // @ts-check
+import '@agoric/zoe/exported.js';
+
 import { makeStoredPublishKit } from '@agoric/notifier';
 import { defineDurableKindMulti, makeKindHandle } from '@agoric/vat-data';
-import '@agoric/zoe/exported.js';
+import { makeEphemeraProvider } from '../contractSupport';
 
 const { details: X } = assert;
 
+// XXX durable key to an ephemeral object
+// UNTIL https://github.com/Agoric/agoric-sdk/issues/4567
+let holderId = 0n;
+
 /**
- * @typedef {{
+ * @type {(key: bigint) => {
  * publisher: StoredPublishKit<VaultNotification>['publisher'],
  * subscriber: StoredPublishKit<VaultNotification>['subscriber'],
+ * }} */
+// @ts-expect-error not yet defined
+const provideEphemera = makeEphemeraProvider(() => ({}));
+
+/**
+ * @typedef {{
+ * holderId: bigint,
  * vault: Vault | null,
  * }} State
  * @typedef {Readonly<{
@@ -37,7 +50,12 @@ const initState = (vault, storageNode, marshaller) => {
     marshaller,
   );
 
-  return { publisher, subscriber, vault };
+  holderId += 1n;
+  const ephemera = provideEphemera(holderId);
+  // UNTIL https://github.com/Agoric/agoric-sdk/issues/4567
+  Object.assign(ephemera, { subscriber, publisher });
+
+  return { holderId, vault };
 };
 
 const helper = {
@@ -51,12 +69,12 @@ const helper = {
     return vault;
   },
   /** @param {MethodContext} context */
-  getUpdater: ({ state }) => state.publisher,
+  getUpdater: ({ state }) => provideEphemera(state.holderId).publisher,
 };
 
 const holder = {
   /** @param {MethodContext} context */
-  getSubscriber: ({ state }) => state.subscriber,
+  getSubscriber: ({ state }) => provideEphemera(state.holderId).subscriber,
   /** @param {MethodContext} context */
   makeAdjustBalancesInvitation: ({ facets }) =>
     facets.helper.owned().makeAdjustBalancesInvitation(),

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -18,7 +18,11 @@ import '@agoric/zoe/exported.js';
 import { AmountMath } from '@agoric/ertp';
 import { Nat } from '@agoric/nat';
 import { makeStoredPublishKit, observeNotifier } from '@agoric/notifier';
-import { defineKindMulti, pickFacet } from '@agoric/vat-data';
+import {
+  defineDurableKindMulti,
+  makeKindHandle,
+  pickFacet,
+} from '@agoric/vat-data';
 import {
   assertProposalShape,
   ceilDivideBy,
@@ -861,8 +865,8 @@ const behavior = {
   self: selfBehavior,
 };
 
-const makeVaultManagerKit = defineKindMulti(
-  'VaultManagerKit',
+const makeVaultManagerKit = defineDurableKindMulti(
+  makeKindHandle('VaultManagerKit'),
   initState,
   behavior,
   {

--- a/packages/inter-protocol/test/vaultFactory/test-orderedVaultStore.js
+++ b/packages/inter-protocol/test/vaultFactory/test-orderedVaultStore.js
@@ -3,6 +3,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath } from '@agoric/ertp';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { Far } from '@endo/marshal';
 import { makeOrderedVaultStore } from '../../src/vaultFactory/orderedVaultStore.js';
 import { fromVaultKey } from '../../src/vaultFactory/storeUtils.js';
@@ -39,7 +40,11 @@ const fixture = [
 ];
 
 test('ordering', t => {
-  const vaults = makeOrderedVaultStore();
+  const vaults = makeOrderedVaultStore(
+    makeScalarBigMapStore('orderedVaultStore', {
+      durable: true,
+    }),
+  );
 
   for (const [vaultId, runCount, collateralCount] of fixture) {
     const vault = mockVault(vaultId, runCount, collateralCount);
@@ -52,7 +57,11 @@ test('ordering', t => {
 });
 
 test('uniqueness', t => {
-  const vaults = makeOrderedVaultStore();
+  const vaults = makeOrderedVaultStore(
+    makeScalarBigMapStore('orderedVaultStore', {
+      durable: true,
+    }),
+  );
 
   for (const [vaultId, runCount, collateralCount] of fixture) {
     const vault = mockVault(vaultId, runCount, collateralCount);

--- a/packages/inter-protocol/test/vaultFactory/test-prioritizedVaults.js
+++ b/packages/inter-protocol/test/vaultFactory/test-prioritizedVaults.js
@@ -1,18 +1,19 @@
 // @ts-check
 
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import '@agoric/zoe/exported.js';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 import {
   currentDebtToCollateral,
   makePrioritizedVaults,
 } from '../../src/vaultFactory/prioritizedVaults.js';
 import {
-  makeFakeVault,
   makeCompoundedInterestProvider,
+  makeFakeVault,
 } from './interestSupport.js';
 
 /** @typedef {import('../../src/vaultFactory/vault.js').Vault} Vault */
@@ -55,8 +56,9 @@ function makeRescheduler() {
 }
 
 test('add to vault', async t => {
+  const store = makeScalarBigMapStore('orderedVaultStore');
   const rescheduler = makeRescheduler();
-  const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
+  const vaults = makePrioritizedVaults(store, rescheduler.fakeReschedule);
   vaults.addVault(
     'id-fakeVaultKit',
     makeFakeVault('id-fakeVaultKit', AmountMath.make(brand, 130n)),
@@ -76,8 +78,9 @@ test('add to vault', async t => {
 });
 
 test('updates', async t => {
+  const store = makeScalarBigMapStore('orderedVaultStore');
   const rescheduler = makeRescheduler();
-  const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
+  const vaults = makePrioritizedVaults(store, rescheduler.fakeReschedule);
 
   vaults.addVault(
     'id-fakeVault1',
@@ -99,8 +102,9 @@ test('updates', async t => {
 });
 
 test('update changes ratio', async t => {
+  const store = makeScalarBigMapStore('orderedVaultStore');
   const rescheduler = makeRescheduler();
-  const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
+  const vaults = makePrioritizedVaults(store, rescheduler.fakeReschedule);
 
   // default collateral of makeFakeVaultKit
   const defaultCollateral = AmountMath.make(brand, 100n);
@@ -166,8 +170,9 @@ test('update changes ratio', async t => {
 });
 
 test('removals', async t => {
+  const store = makeScalarBigMapStore('orderedVaultStore');
   const rescheduler = makeRescheduler();
-  const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
+  const vaults = makePrioritizedVaults(store, rescheduler.fakeReschedule);
 
   // Add fakes 1,2,3
   vaults.addVault(
@@ -216,9 +221,10 @@ test('removals', async t => {
 });
 
 test('highestRatio', async t => {
-  const reschedulePriceCheck = makeRescheduler();
-  const vaults = makePrioritizedVaults();
-  vaults.onHigherHighest(reschedulePriceCheck.fakeReschedule);
+  const store = makeScalarBigMapStore('orderedVaultStore');
+  const rescheduler = makeRescheduler();
+  const vaults = makePrioritizedVaults(store);
+  vaults.onHigherHighest(rescheduler.fakeReschedule);
 
   vaults.addVault(
     'id-fakeVault1',
@@ -265,8 +271,9 @@ test('highestRatio', async t => {
 });
 
 test('stable ordering as interest accrues', async t => {
-  const reschedulePriceCheck = makeRescheduler();
-  const vaults = makePrioritizedVaults(reschedulePriceCheck.fakeReschedule);
+  const store = makeScalarBigMapStore('orderedVaultStore');
+  const rescheduler = makeRescheduler();
+  const vaults = makePrioritizedVaults(store, rescheduler.fakeReschedule);
 
   const m = makeCompoundedInterestProvider(brand);
 

--- a/packages/inter-protocol/test/vaultFactory/test-vault.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault.js
@@ -1,19 +1,18 @@
 // @ts-check
 
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import '@agoric/zoe/exported.js';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { E } from '@endo/eventual-send';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
-import { makeLoopback } from '@endo/captp';
 import { makeZoeKit } from '@agoric/zoe';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import bundleSource from '@endo/bundle-source';
+import { makeLoopback } from '@endo/captp';
+import { E } from '@endo/eventual-send';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 
-import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 
 import { assert } from '@agoric/assert';
-import { makeFakeLiveSlotsStuff } from '@agoric/swingset-vat/tools/fakeVirtualSupport.js';
 import { makeTracer } from '../../src/makeTracer.js';
 
 const vaultRoot = './vault-contract-wrapper.js';
@@ -218,13 +217,4 @@ test('bad collateral', async t => {
   //       rej => console.log('reg', rej));
   // t.rejects(p, / /, 'addCollateral requires the right kind', {});
   // t.throws(async () => { await p; }, /was not a live payment/);
-});
-
-test('serializable with collectionManager', async t => {
-  // Necessary to initialize the testjig
-  await helperContract;
-
-  const { vault } = testJig;
-  const stuff = makeFakeLiveSlotsStuff();
-  t.notThrows(() => stuff.marshal.serialize(vault));
 });

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -97,14 +97,22 @@
  * of them as standard options. A given store maker should document which
  * options it supports, as well as its positions on dimensions for which it
  * does not support options.
- * @property {boolean=} longLived Which way to optimize a weak store. True means
+ * @property {boolean} [longLived=true] Which way to optimize a weak store. True means
  * that we expect this weak store to outlive most of its keys, in which
  * case we internally may use a JavaScript `WeakMap`. Otherwise we internally
  * may use a JavaScript `Map`.
  * Defaults to true, so please mark short lived stores explicitly.
- * @property {boolean=} durable  The contents of this store survive termination
+ * @property {boolean} [durable=false]  The contents of this store survive termination
  *   of its containing process, allowing for restart or upgrade but at the cost
  *   of forbidding storage of references to ephemeral data.  Defaults to false.
+ * @property {boolean} [fakeDurable=false]  This store pretends to be a durable store
+ *   but does not enforce that the things stored in it actually be themselves
+ *   durable (whereas an actual durable store would forbid storage of such
+ *   items).  This is in service of allowing incremental transition to use of
+ *   durable stores, to enable normal operation and testing when some stuff
+ *   intended to eventually be durable has not yet been made durable.  A store
+ *   marked as fakeDurable will appear to operate normally but any attempt to
+ *   upgrade its containing vat will fail with an error.
  * @property {Pattern=} keySchema
  * @property {Pattern=} valueSchema
  */

--- a/packages/wallet/contract/src/walletFactory.js
+++ b/packages/wallet/contract/src/walletFactory.js
@@ -8,10 +8,10 @@ import '@agoric/deploy-script-support/exported.js';
 import '@agoric/wallet-backend/src/types.js'; // TODO avoid ambient types
 import '@agoric/zoe/exported.js';
 
-import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils';
+import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { Far } from '@endo/far';
-import { makeSmartWallet } from './smartWallet';
+import { makeSmartWallet } from './smartWallet.js';
 
 /**
  * @typedef {{


### PR DESCRIPTION
closes: #4550
refs: #5285

## Description

Basic mechanics to enable durability for Vault Factory. Leaves #5285 open until the requirements are fleshed out.

This is shy of "reachably durable", let alone "upgradeable". That's scheduled work.

It also required some hacks, but it works and is prone to merge conflicts so I think it's better to get in and solve the rest on top of it. https://github.com/Agoric/agoric-sdk/issues/5759 may help but needn't be a release blocker.

### Security Considerations

Storing on disk.

### Documentation Considerations

--

### Testing Considerations

Existing tests pass, in particular `make scenario2-run-chain-to-halt`.

Doesn't need to demonstrate upgrade or reachability which are out of scope.

A bug was [detected by loadgen](https://github.com/Agoric/agoric-sdk/runs/7438623238?check_suite_focus=true) and fixed in [d04981c](https://github.com/Agoric/agoric-sdk/pull/5736/commits/d04981c33e15bdadb0b858a5d1c3652376c8ea66). I'm noting here because we debated how to add a regression test for that and decided for now to rely on loadgen as the test. https://github.com/Agoric/agoric-sdk/issues/5801 explores another option.