### PR TITLE
wip: load snapshot after taking it

### DIFF
--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -213,8 +213,11 @@ export function makeXsSubprocessFactory({
      * @param {SnapStore} snapStore
      * @returns {Promise<string>}
      */
-    function makeSnapshot(snapStore) {
-      return snapStore.save(fn => worker.snapshot(fn));
+    async function makeSnapshot(snapStore) {
+      return snapStore.save(async fileName => {
+        await worker.snapshot(fileName);
+        return { done: worker.load(fileName) };
+      });
     }
 
     return mk.getManager(shutdown, makeSnapshot);

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -137,7 +137,7 @@ export function recordXSnap(options, folderPath, { writeFileSync }) {
   return freeze({
     name: it.name,
     isReady: async () => {
-      nextFile('isReady');
+      nextFile('isReady').putText('');
       return it.isReady();
     },
     /** @param {Uint8Array} msg */
@@ -164,6 +164,10 @@ export function recordXSnap(options, folderPath, { writeFileSync }) {
     snapshot: async file => {
       nextFile('snapshot').putText(file);
       return it.snapshot(file);
+    },
+    load: async file => {
+      nextFile('load').putText(file);
+      return it.load(file);
     },
   });
 }

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -285,6 +285,19 @@ export function xsnap(options) {
    * @param {string} file
    * @returns {Promise<void>}
    */
+  async function readSnapshot(file) {
+    const result = baton.then(async () => {
+      await messagesToXsnap.next(encoder.encode(`r${file}`));
+      await runToIdle();
+    });
+    baton = result.then(noop, noop);
+    return racePromises([vatExit.promise, baton]);
+  }
+
+  /**
+   * @param {string} file
+   * @returns {Promise<void>}
+   */
   async function writeSnapshot(file) {
     const result = baton.then(async () => {
       await messagesToXsnap.next(encoder.encode(`w${file}`));
@@ -328,5 +341,6 @@ export function xsnap(options) {
     execute,
     import: importModule,
     snapshot: writeSnapshot,
+    load: readSnapshot,
   });
 }

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -39,7 +39,7 @@ async function main() {
     output: process.stdout,
   });
 
-  let vat = xsnap({ ...xsnapOptions, handleCommand });
+  const vat = xsnap({ ...xsnapOptions, handleCommand });
 
   await vat.evaluate(`
     const compartment = new Compartment({
@@ -73,8 +73,9 @@ async function main() {
       break;
     } else if (answer === 'load') {
       const file = await ask('file> ');
-      await vat.close();
-      vat = xsnap({ ...xsnapOptions, handleCommand, snapshot: file });
+      // await vat.close();
+      // vat = xsnap({ ...xsnapOptions, handleCommand, snapshot: file });
+      await vat.load(file);
     } else if (answer === 'save') {
       const file = await ask('file> ');
       await vat.snapshot(file);


### PR DESCRIPTION
closes: #5330
refs: #3769

## Description

Reload a worker from snapshot after taking the snapshot to avoid divergences in memory layout.

### Security Considerations

If the snapshot reload mechanism has a bug (like https://github.com/Agoric/agoric-sdk/issues/4870), this would completely hide it under the rug and all nodes would now always reload from snapshot, deterministically adopting the corrupted state. One approach to mitigate this is discussed below.

### Documentation Considerations

N/A

### Testing Considerations

The divergence checks between validators in the deployment integration test now all pass.

To address the risk of reload based corruption, we could have a debug mode that runs a second copy of the worker without snapshot reloading enabled, and ensures that all computations match between the workers.