### PR TITLE
refactor(notifier)!: no initial state for makePublishKit

### DIFF
--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 export {
-  makeEmptyPublishKit,
   makePublishKit,
   subscribeEach,
   subscribeLatest,

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -30,7 +30,7 @@ const makeEachIterator = pubList => {
       // Since we are wrapping that error with eventual send, we sink the
       // rejection here too so it doesn't become an invalid unhandled rejection
       // later.
-      E.when(pubList, sink, sink);
+      void E.when(pubList, sink, sink);
       return resultP;
     },
   });

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -110,7 +110,7 @@ harden(subscribeLatest);
  * @template T
  * @returns {PublishKit<T>}
  */
-export const makeEmptyPublishKit = () => {
+export const makePublishKit = () => {
   /** @type {Promise<PublicationRecord<T>>} */
   let tailP;
   /** @type {undefined | ((value: ERef<PublicationRecord<T>>) => void)} */
@@ -187,22 +187,5 @@ export const makeEmptyPublishKit = () => {
     },
   });
   return harden({ publisher, subscriber });
-};
-harden(makeEmptyPublishKit);
-
-/**
- * Makes a `{ publisher, subscriber }` pair for doing efficient
- * distributed pub/sub supporting both "each" and "latest" iteration
- * of published values.
- *
- * @template T
- * @param {T} initialValue The initial published value, as if with a call
- * to `.publish(initialValue)`
- * @returns {PublishKit<T>}
- */
-export const makePublishKit = initialValue => {
-  const publishKit = makeEmptyPublishKit();
-  publishKit.publisher.publish(initialValue);
-  return publishKit;
 };
 harden(makePublishKit);

--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -4,7 +4,7 @@
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeEmptyPublishKit } from './publish-kit.js';
+import { makePublishKit } from './publish-kit.js';
 
 import './types.js';
 
@@ -63,7 +63,7 @@ const makeSubscriptionIterator = tailP => {
  * @returns {SubscriptionRecord<T>}
  */
 const makeSubscriptionKit = () => {
-  const { publisher, subscriber } = makeEmptyPublishKit();
+  const { publisher, subscriber } = makePublishKit();
 
   // The publish kit subscriber is prefix-lossy, so making *this* subscriber completely
   // lossless requires eager consumption of the former.

--- a/packages/notifier/test/map-unum.js
+++ b/packages/notifier/test/map-unum.js
@@ -117,7 +117,7 @@ export const makeMapFollower = snapshotNotifierP => {
   const snapshotObserver = harden({
     updateState: ({ entries, deltaSubscription }) => {
       m = new Map(entries);
-      observeIteration(deltaSubscription, deltaObserver);
+      void observeIteration(deltaSubscription, deltaObserver);
     },
     finish: _completion => {
       m = undefined;
@@ -126,7 +126,7 @@ export const makeMapFollower = snapshotNotifierP => {
       m = undefined;
     },
   });
-  observeIteration(snapshotNotifierP, snapshotObserver);
+  void observeIteration(snapshotNotifierP, snapshotObserver);
 
   return mapFollower;
 };

--- a/packages/notifier/test/test-notifier-examples.js
+++ b/packages/notifier/test/test-notifier-examples.js
@@ -78,7 +78,7 @@ test('notifier for-await-of on generic representative', async t => {
   paula(updater);
   const subP = Promise.resolve(notifier);
   const { updater: p, notifier: localSub } = makeNotifierKit();
-  observeIteration(subP, p);
+  await observeIteration(subP, p);
   const log = await alice(localSub);
 
   t.deepEqual(last(log), ['finished']);
@@ -89,7 +89,7 @@ test('notifier observeIteration on generic representative', async t => {
   paula(updater);
   const subP = Promise.resolve(notifier);
   const { updater: p, notifier: localSub } = makeNotifierKit();
-  observeIteration(subP, p);
+  await observeIteration(subP, p);
   const log = await bob(localSub);
 
   t.deepEqual(last(log), ['finished', 'done']);

--- a/packages/notifier/test/test-notifier.js
+++ b/packages/notifier/test/test-notifier.js
@@ -76,7 +76,7 @@ test('notifier - update after state change', async t => {
   const all = Promise.all([updateInWaiting]).then(([update1]) => {
     t.is(update1.value, 3, '4th check (delayed) 3');
     const thirdStatePromise = notifier.getUpdateSince(update1.updateCount);
-    Promise.all([thirdStatePromise]).then(([update2]) => {
+    return Promise.all([thirdStatePromise]).then(([update2]) => {
       t.is(update2.value, 5, '5th check (delayed) 5');
     });
   });
@@ -101,7 +101,7 @@ test('notifier - final state', async t => {
     t.is(update.value, 'final', 'state is "final"');
     t.falsy(update.updateCount, 'no handle after close');
     const postFinalUpdate = notifier.getUpdateSince(update.updateCount);
-    Promise.all([postFinalUpdate]).then(([after]) => {
+    return Promise.all([postFinalUpdate]).then(([after]) => {
       t.is(after.value, 'final', 'stable');
       t.falsy(after.updateCount, 'no handle after close');
     });

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -2,7 +2,6 @@
 
 import { test } from './prepare-test-env-ava.js';
 import {
-  makeEmptyPublishKit,
   makePublishKit,
   subscribeEach,
   subscribeLatest,
@@ -10,8 +9,8 @@ import {
 import '../src/types.js';
 import { invertPromiseSettlement } from './iterable-testing-tools.js';
 
-test('makeEmptyPublishKit', async t => {
-  const { publisher, subscriber } = makeEmptyPublishKit();
+test('makePublishKit', async t => {
+  const { publisher, subscriber } = makePublishKit();
 
   const pubFirst = Symbol('first');
   publisher.publish(pubFirst);
@@ -136,8 +135,8 @@ test('makeEmptyPublishKit', async t => {
   );
 });
 
-test('makeEmptyPublishKit - immediate finish', async t => {
-  const { publisher, subscriber } = makeEmptyPublishKit();
+test('makePublishKit - immediate finish', async t => {
+  const { publisher, subscriber } = makePublishKit();
 
   const pubFinal = Symbol('done');
   publisher.finish(pubFinal);
@@ -189,8 +188,8 @@ test('makeEmptyPublishKit - immediate finish', async t => {
   );
 });
 
-test('makeEmptyPublishKit - fail', async t => {
-  const { publisher, subscriber } = makeEmptyPublishKit();
+test('makePublishKit - fail', async t => {
+  const { publisher, subscriber } = makePublishKit();
 
   publisher.publish(undefined);
   const subFirst = await subscriber.subscribeAfter();
@@ -231,8 +230,8 @@ test('makeEmptyPublishKit - fail', async t => {
   );
 });
 
-test('makeEmptyPublishKit - immediate fail', async t => {
-  const { publisher, subscriber } = makeEmptyPublishKit();
+test('makePublishKit - immediate fail', async t => {
+  const { publisher, subscriber } = makePublishKit();
 
   const pubFailure = Symbol('fail');
   publisher.fail(pubFailure);
@@ -265,51 +264,8 @@ test('makeEmptyPublishKit - immediate fail', async t => {
   );
 });
 
-test('makePublishKit', async t => {
-  const expectedInitialCount = (
-    await makePublishKit(undefined).subscriber.subscribeAfter()
-  ).publishCount;
-  t.true(expectedInitialCount > 0n);
-  const initialValues = {
-    // harden([1, -0, undefined, NaN, obj, unresP, rejP, null]);
-    array: [],
-    bigint: 0n,
-    date: new Date(0),
-    error: new Error(''),
-    false: false,
-    infinity: Infinity,
-    math: Math,
-    nan: NaN,
-    'negative zero': -0,
-    null: null,
-    object: {},
-    symbol: Symbol(''),
-    true: true,
-    undefined,
-  };
-  for (const [label, initialValue] of Object.entries(initialValues)) {
-    const { subscriber } = makePublishKit(initialValue);
-    // eslint-disable-next-line no-await-in-loop
-    const subAll = await Promise.all([
-      subscriber.subscribeAfter(),
-      subscriber.subscribeAfter(expectedInitialCount - 1n),
-    ]);
-    const [subFirst] = subAll;
-    t.like(subFirst, {
-      head: { done: false },
-      publishCount: expectedInitialCount,
-    });
-    t.is(
-      subFirst.head.value,
-      initialValue,
-      `initial value should be accepted: ${label}`,
-    );
-    t.deepEqual(new Set(subAll), new Set([subFirst]));
-  }
-});
-
 test('subscribeLatest', async t => {
-  const { publisher, subscriber } = makeEmptyPublishKit();
+  const { publisher, subscriber } = makePublishKit();
   const latestIterator = subscribeLatest(subscriber);
 
   // Publish in geometric batches: [1], [2], [3, 4], [5, 6, 7, 8], ...
@@ -336,7 +292,7 @@ test('subscribeLatest', async t => {
 });
 
 test('subscribeEach', async t => {
-  const { publisher, subscriber } = makeEmptyPublishKit();
+  const { publisher, subscriber } = makePublishKit();
   const latestIterator = subscribeEach(subscriber);
 
   // Publish in geometric batches: [1], [2], [3, 4], [5, 6, 7, 8], ...
@@ -370,7 +326,7 @@ test('subscribeEach', async t => {
 });
 
 test('subscribeAfter bounds checking', async t => {
-  const { publisher, subscriber } = makeEmptyPublishKit();
+  const { publisher, subscriber } = makePublishKit();
 
   for (const badCount of [1n, 0, '', false]) {
     const repr =
@@ -390,17 +346,17 @@ test('subscribeAfter bounds checking', async t => {
 
 test('subscribeAfter resolution sequencing', async t => {
   // Demonstrate sequencing by publishing to two destinations.
-  const { publisher: pub1, subscriber: sub1 } = makeEmptyPublishKit();
-  const { publisher: pub2, subscriber: sub2 } = makeEmptyPublishKit();
+  const { publisher: pub1, subscriber: sub1 } = makePublishKit();
+  const { publisher: pub2, subscriber: sub2 } = makePublishKit();
   const sub2LIFO = [];
 
   const sub1FirstAll = [];
-  Promise.resolve(sub1.subscribeAfter()).then(result =>
-    sub1FirstAll.push(result),
-  );
-  Promise.resolve(sub1.subscribeAfter(0n)).then(result =>
-    sub1FirstAll.push(result),
-  );
+  Promise.resolve(sub1.subscribeAfter())
+    .then(result => sub1FirstAll.push(result))
+    .catch(t.fail);
+  Promise.resolve(sub1.subscribeAfter(0n))
+    .then(result => sub1FirstAll.push(result))
+    .catch(t.fail);
 
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter());

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -383,15 +383,15 @@ test('subscribeAfter resolution sequencing', async t => {
 
   const sub1FirstLateAll = [];
   const sub1SecondAll = [];
-  Promise.resolve(sub1.subscribeAfter()).then(result =>
-    sub1FirstLateAll.push(result),
-  );
-  Promise.resolve(sub1.subscribeAfter(0n)).then(result =>
-    sub1FirstLateAll.push(result),
-  );
-  Promise.resolve(sub1.subscribeAfter(sub1FirstAll[0].publishCount)).then(
-    result => sub1SecondAll.push(result),
-  );
+  Promise.resolve(sub1.subscribeAfter())
+    .then(result => sub1FirstLateAll.push(result))
+    .catch(t.fail);
+  Promise.resolve(sub1.subscribeAfter(0n))
+    .then(result => sub1FirstLateAll.push(result))
+    .catch(t.fail);
+  Promise.resolve(sub1.subscribeAfter(sub1FirstAll[0].publishCount))
+    .then(result => sub1SecondAll.push(result))
+    .catch(t.fail);
 
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter(sub2LIFO[0].publishCount));
@@ -427,15 +427,15 @@ test('subscribeAfter resolution sequencing', async t => {
 
   const sub1SecondLateAll = [];
   const sub1FinalAll = [];
-  Promise.resolve(sub1.subscribeAfter()).then(result =>
-    sub1SecondLateAll.push(result),
-  );
-  Promise.resolve(sub1.subscribeAfter(0n)).then(result =>
-    sub1SecondLateAll.push(result),
-  );
-  Promise.resolve(sub1.subscribeAfter(sub1SecondAll[0].publishCount)).then(
-    result => sub1FinalAll.push(result),
-  );
+  Promise.resolve(sub1.subscribeAfter())
+    .then(result => sub1SecondLateAll.push(result))
+    .catch(t.fail);
+  Promise.resolve(sub1.subscribeAfter(0n))
+    .then(result => sub1SecondLateAll.push(result))
+    .catch(t.fail);
+  Promise.resolve(sub1.subscribeAfter(sub1SecondAll[0].publishCount))
+    .then(result => sub1FinalAll.push(result))
+    .catch(t.fail);
 
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter(sub2LIFO[0].publishCount));

--- a/packages/notifier/test/test-subscriber-examples.js
+++ b/packages/notifier/test/test-subscriber-examples.js
@@ -89,7 +89,7 @@ test('subscription for-await-of on generic representative', async t => {
   paula(publication);
   const subP = Promise.resolve(subscription);
   const { publication: p, subscription: localSub } = makeSubscriptionKit();
-  observeIteration(subP, p);
+  await observeIteration(subP, p);
   const log = await alice(localSub);
 
   t.deepEqual(log, [['non-final', 'a'], ['non-final', 'b'], ['finished']]);
@@ -100,7 +100,7 @@ test('subscription observeIteration on generic representative', async t => {
   paula(publication);
   const subP = Promise.resolve(subscription);
   const { publication: p, subscription: localSub } = makeSubscriptionKit();
-  observeIteration(subP, p);
+  await observeIteration(subP, p);
   const log = await bob(localSub);
 
   t.deepEqual(log, [


### PR DESCRIPTION
Extracted from https://github.com/Agoric/agoric-sdk/pull/5704

## Description

All publishing kits start empty: https://github.com/Agoric/agoric-sdk/pull/5621

So `makePublishKit` shouldn't take an initial value and there's no need to have a separate `makeEmptyPublishKit`.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

Updated