### PR TITLE
5622 vaultManager ephemera

### DIFF
--- a/packages/run-protocol/src/contractSupport.js
+++ b/packages/run-protocol/src/contractSupport.js
@@ -103,3 +103,29 @@ harden(makeMetricsPublisherKit);
  * @property {IterationObserver<T>} metricsPublication
  * @property {StoredSubscription<T>} metricsSubscription
  */
+
+/**
+ * @template K Key
+ * @template {{}} E Ephemeral state
+ * @param {() => E} init
+ */
+export const makeEphemeraProvider = init => {
+  /** @type {Map<K, E>} */
+  const ephemeras = new Map();
+
+  /**
+   * Provide an object to hold state that need not (or cannot) be durable.
+   *
+   * @type {(key: K) => E}
+   */
+  return key => {
+    if (ephemeras.has(key)) {
+      // @ts-expect-error cast
+      return ephemeras.get(key);
+    }
+    const newEph = init();
+    ephemeras.set(key, newEph);
+    return newEph;
+  };
+};
+harden(makeEphemeraProvider);

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -313,7 +313,7 @@ const setupServices = async (
   const { consume, produce } = space;
   trace(t, 'amm', { ammFacets });
 
-  const quoteMint = makeIssuerKit('quote', AssetKind.SET).mint;
+  const quoteIssuerKit = makeIssuerKit('quote', AssetKind.SET);
   // Cheesy hack for easy use of manual price authority
   const pa = Array.isArray(priceOrList)
     ? makeScriptedPriceAuthority({
@@ -321,7 +321,7 @@ const setupServices = async (
         actualBrandOut: run.brand,
         priceList: priceOrList,
         timer,
-        quoteMint,
+        quoteMint: quoteIssuerKit.mint,
         unitAmountIn,
         quoteInterval,
       })
@@ -330,7 +330,7 @@ const setupServices = async (
         actualBrandOut: run.brand,
         initialPrice: priceOrList,
         timer,
-        quoteMint,
+        quoteIssuerKit,
       });
   produce.priceAuthority.resolve(pa);
 

--- a/packages/zoe/tools/manualPriceAuthority.js
+++ b/packages/zoe/tools/manualPriceAuthority.js
@@ -10,6 +10,16 @@ import {
   floorDivideBy,
 } from '../src/contractSupport/index.js';
 
+/**
+ *
+ * @param {object} options
+ * @param {Brand} options.actualBrandIn
+ * @param {Brand} options.actualBrandOut
+ * @param {Ratio} options.initialPrice
+ * @param {TimerService} options.timer
+ * @param {IssuerKit} [options.quoteIssuerKit]
+ * @returns {PriceAuthority & { setPrice: (Ratio) => void }}
+ */
 export function makeManualPriceAuthority(options) {
   const {
     actualBrandIn,
@@ -70,7 +80,7 @@ export function makeManualPriceAuthority(options) {
     adminFacet: { fireTriggers },
   } = makeOnewayPriceAuthorityKit(priceAuthorityOptions);
 
-  return Far('PriceAuthority', {
+  return Far('ManualPriceAuthority', {
     setPrice: newPrice => {
       currentPrice = newPrice;
       updater.updateState(currentPrice);


### PR DESCRIPTION
closes: #5622

## Description

Vault Manager has some ephemeral state in module scope that is unique per VMgr instance. This makes a map that can hold such state, keyed by the VMgr instance. The singleton pattern was also sketched and [ruled out](https://github.com/Agoric/agoric-sdk/pull/5650#issuecomment-1180486256).

It also extracts `makeEphemeralProvider` to be used in other cases for state on durable kinds that need not (or cannot) be durable.

### Security Considerations

`vaultManager.js` continues to trust `contractSupport.js`.

### Documentation Considerations

This is a solution to a challenge common with durable kinds. It may be worth documenting more. At the point I think it's sufficient to have the example and shared utility function.

### Testing Considerations

Ideally we'd have add a regression test that breaks in master and go green now, but the only way I see to cover this case is have liquidations going on one brand while another one is starting and that requires setting up multiple concurrent priceAuthorities which we don't currently support in our test code.