### PR TITLE
fix(swingstore): clarify promise handling

### DIFF
--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -270,7 +270,9 @@ function makeSwingStore(dirPath, forceReset, options) {
   function set(key, value) {
     assert.typeof(key, 'string');
     assert.typeof(value, 'string');
-    ensureTxn().put(key, value);
+    // synchronous read after write within a transaction is safe
+    // The transaction's overall success will be awaited during commit
+    void ensureTxn().put(key, value);
     trace('set', key, value);
   }
 
@@ -285,7 +287,9 @@ function makeSwingStore(dirPath, forceReset, options) {
   function del(key) {
     assert.typeof(key, 'string');
     if (has(key)) {
-      ensureTxn().remove(key);
+      // synchronous read after write within a transaction is safe
+      // The transaction's overall success will be awaited during commit
+      void ensureTxn().remove(key);
       trace('del', key);
     }
   }


### PR DESCRIPTION
closes: #5729

## Description

Captured in code comment why it's safe to ignore the promise result of the `put` and `remove` LMDB operations [within a transaction](https://github.com/kriszyp/lmdb-js#dbtransactioncallback-function-promise):
> Any `put` or `remove` operations are immediately written to the transaction and can be immediately read afterwards (you can call `get()` or `getRange()` without awaiting for a returned promise) in the transaction.

Drive by fix of the nested await warning

### Security Considerations

None

### Documentation Considerations

This PR content serves as documentation

### Testing Considerations

CI