### PR TITLE
ta/ephemeral in durable

### DIFF
--- a/packages/SwingSet/test/stores/test-durabilityChecks.js
+++ b/packages/SwingSet/test/stores/test-durabilityChecks.js
@@ -272,3 +272,34 @@ async function runDurabilityCheckTest(t, relaxDurabilityRules) {
 
 test('durability checks (strict)', t => runDurabilityCheckTest(t, false));
 test('durability checks (relaxed)', t => runDurabilityCheckTest(t, true));
+
+test('heapOnly', async t => {
+  const { vom } = makeFakeVirtualStuff({
+    cacheSize: 3,
+  });
+
+  const { defineDurableKind, makeKindHandle } = vom;
+
+  const handle = makeKindHandle('mixed');
+
+  const initState = () => ({
+    greeting: 'hello',
+    promise: Promise.resolve('success'),
+  });
+  const behavior = {
+    getGreeting: ({ state }) => {
+      return state.greeting;
+    },
+    getPromise: ({ state }) => {
+      return state.promise;
+    },
+  };
+
+  const make = defineDurableKind(handle, initState, behavior, {
+    heapOnly: ['promise'],
+  });
+
+  const first = make();
+  t.is(first.getGreeting(), 'hello');
+  t.is(await first.getPromise(), 'success');
+});

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -41,8 +41,11 @@ declare class DurableKindHandleClass {
 export type DurableKindHandle = DurableKindHandleClass;
 
 type DefineKindOptions<C> = {
+  heapOnly?: string[];
   finish?: (context: C) => void;
+  // FIXME option not read by anything
   durable?: boolean;
+  // FIXME option not read by anything
   fakeDurable?: boolean;
 };
 


### PR DESCRIPTION
## Description

While working on https://github.com/Agoric/agoric-sdk/pull/5736 there's a ton of refactoring to make ephemeral that was durable. I expect developers while iterating on contracts will need to be able to move values between ephemeral, virtual, durable often and it should be easy if it can be.

It's already pretty declarative to move from virtual to durable (and vice-versa). This PR is a stab at an API for making it equally declarative for heap/ephemeral values (not durable or virtual).

It reworks vaultManager to provide an alternative solution to https://github.com/Agoric/agoric-sdk/issues/5622. That this approach wasn't considered makes me think there's some fundamental problem with it. That the tests are failing with the following error also lowers my confidence :) 
```
TypeError#1: Cannot set properties of undefined (setting 'outstandingQuote')
  at Object.set (packages/SwingSet/src/liveslots/virtualObjectManager.js:653:39)
  at eventualLiquidations (.../run-protocol/src/vaultFactory/vaultManager.js:406:23)
  at eventualLiquidations.next (<anonymous>)
  at processLiquidations (.../run-protocol/src/vaultFactory/vaultManager.js:435:17)
  at Alleged: VaultManagerKit helper.method [as processLiquidations] (packages/SwingSet/src/liveslots/virtualObjectManager.js:486:43)
  at reschedulePriceCheck (.../run-protocol/src/vaultFactory/vaultManager.js:355:1)
  at method (packages/SwingSet/src/liveslots/virtualObjectManager.js:486:43)
  at Alleged: PrioritizedVaults.addVault (.../run-protocol/src/vaultFactory/prioritizedVaults.js:150:1)
  at handleBalanceChange (.../run-protocol/src/vaultFactory/vaultManager.js:634:19)
  at Alleged: VaultManagerKit manager.method [as handleBalanceChange] (packages/SwingSet/src/liveslots/virtualObjectManager.js:486:43)
  at updateDebtAccounting (.../run-protocol/src/vaultFactory/vault.js:255:15)
  at Alleged: Vault helper.method [as updateDebtAccounting] (packages/SwingSet/src/liveslots/virtualObjectManager.js:486:43)
  at initVaultKit (.../run-protocol/src/vaultFactory/vault.js:597:8)
  at async makeVaultKit (.../run-protocol/src/vaultFactory/vaultManager.js:697:16)
```
The `ensureState` doesn't handle `heapState`. I don't know how hard it will be to make it do so. I made a small time box to try this out and I'm  floating it now to get feedback.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
