### PR TITLE
feat(vats): bootstrap.produceItem(), consumeItem, resetItem

### DIFF
--- a/packages/vats/src/core/boot.js
+++ b/packages/vats/src/core/boot.js
@@ -137,6 +137,18 @@ const buildRootObject = (vatPowers, vatParameters) => {
         console.error('BOOTSTRAP FAILED:', e);
         throw e;
       }),
+    consumeItem: name => {
+      assert.typeof(name, 'string');
+      return consume[name];
+    },
+    produceItem: (name, resolution) => {
+      assert.typeof(name, 'string');
+      produce[name].resolve(resolution);
+    },
+    resetItem: name => {
+      assert.typeof(name, 'string');
+      produce[name].reset();
+    },
   });
 };
 

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -211,3 +211,17 @@ test('evaluateInstallation is available to core eval', async t => {
   // @ts-expect-error
   t.deepEqual(typeof actual.extract, 'function');
 });
+
+test('bootstrap provides a way to pass items to CORE_EVAL', async t => {
+  const root = buildRootObject(
+    // @ts-expect-error Device<T> is a little goofy
+    { D: d => d, logger: t.log },
+    { argv: argvByRole.chain, governanceActions: false },
+  );
+
+  await E(root).produceItem('swissArmyKnife', [1, 2, 3]);
+  t.deepEqual(await E(root).consumeItem('swissArmyKnife'), [1, 2, 3]);
+  await E(root).resetItem('swissArmyKnife');
+  await E(root).produceItem('swissArmyKnife', 4);
+  t.deepEqual(await E(root).consumeItem('swissArmyKnife'), 4);
+});


### PR DESCRIPTION

closes: #5740

## Description

Allow the bootstrap vat holders such as the kernel to manipulate the
items passed to CORE_EVAL.

### Security Considerations

`consumeItem` allows the kernel access to existing items up to and including the IST mint. Perhaps it's not strictly needed, but I struggled to come up with a test without it.

### Documentation Considerations

?

### Testing Considerations

Ideally we would actually test the interaction with CORE_EVAL, but I don't see a straightforward way to arrange it.