### PR TITLE
5764 upgrade contracts

### DIFF
--- a/packages/SwingSet/src/supervisors/supervisor-helper.js
+++ b/packages/SwingSet/src/supervisors/supervisor-helper.js
@@ -36,7 +36,7 @@ function makeSupervisorDispatch(dispatch) {
         () => harden(['ok', null, null]),
         err => {
           // TODO react more thoughtfully, maybe terminate the vat
-          console.log(`error ${err} during vat dispatch() of ${delivery}`);
+          console.log(`error [${err}] during vat dispatch() of ${delivery}`);
           return harden(['error', `${err}`, null]);
         },
       );

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -91,3 +91,8 @@ export const vivifySingleton = (
 };
 // @ts-expect-error TODO statically recognize harden
 harden(vivifySingleton);
+
+export const vivifyKind = (baggage, name, init, behavior) =>
+  defineDurableKind(provideKindHandle(baggage, name), init, behavior);
+// @ts-expect-error TODO statically recognize harden
+harden(vivifyKind);

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -2,6 +2,10 @@ import { provide } from '@agoric/store';
 import { defineDurableKind, makeKindHandle } from './vat-data-bindings.js';
 
 /** @template L,R @typedef {import('@endo/eventual-send').RemotableBrand<L, R>} RemotableBrand */
+/** @typedef {import('@agoric/store').MapStore<string,unknown>} Baggage */
+/** @template T @typedef {import('./types.js').DefineKindOptions<T>} DefineKindOptions */
+/** @template T @typedef {import('./types.js').KindFacet<T>} KindFacet */
+/** @typedef {import('./types.js').DurableKindHandle} DurableKindHandle */
 
 const { entries, fromEntries } = Object;
 
@@ -12,6 +16,11 @@ export const dropContext =
 // @ts-expect-error TODO statically recognize harden
 harden(dropContext);
 
+/**
+ * @param {Baggage} baggage
+ * @param {string} kindName
+ * @returns {DurableKindHandle}
+ */
 export const provideKindHandle = (baggage, kindName) =>
   provide(baggage, `${kindName}_kindHandle`, () => makeKindHandle(kindName));
 // @ts-expect-error TODO statically recognize harden
@@ -62,14 +71,32 @@ export const objectMap = (original, mapFn) => {
   return /** @type {Record<K, U>} */ (harden(fromEntries(mapEnts)));
 };
 
-/** @typedef {import('@agoric/store').MapStore<string,unknown>} Baggage */
+/**
+ * @template P,S,T
+ * @param {Baggage} baggage
+ * @param {string} name
+ * @param {(...args: P[]) => S} init
+ * @param {T} behavior
+ * @param {DefineKindOptions<unknown>} [options]
+ * @returns {(...args: P[]) => KindFacet<T>}
+ */
+export const vivifyKind = (
+  baggage,
+  name,
+  init,
+  behavior,
+  options = undefined,
+) =>
+  defineDurableKind(provideKindHandle(baggage, name), init, behavior, options);
+// @ts-expect-error TODO statically recognize harden
+harden(vivifyKind);
 
 /**
  * @template T
  * @param {Baggage} baggage
  * @param {string} kindName
  * @param {T} methods
- * @param {import('./types.js').DefineKindOptions<unknown>} [options]
+ * @param {DefineKindOptions<unknown>} [options]
  * @returns {T & RemotableBrand<{}, T>}
  */
 export const vivifySingleton = (
@@ -78,10 +105,10 @@ export const vivifySingleton = (
   methods,
   options = undefined,
 ) => {
-  const kindHandle = provideKindHandle(baggage, kindName);
   const behavior = objectMap(methods, dropContext);
-  const makeSingleton = defineDurableKind(
-    kindHandle,
+  const makeSingleton = vivifyKind(
+    baggage,
+    kindName,
     () => ({}),
     behavior,
     options,
@@ -91,8 +118,3 @@ export const vivifySingleton = (
 };
 // @ts-expect-error TODO statically recognize harden
 harden(vivifySingleton);
-
-export const vivifyKind = (baggage, name, init, behavior) =>
-  defineDurableKind(provideKindHandle(baggage, name), init, behavior);
-// @ts-expect-error TODO statically recognize harden
-harden(vivifyKind);

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -43,7 +43,6 @@ export type DurableKindHandle = DurableKindHandleClass;
 type DefineKindOptions<C> = {
   finish?: (context: C) => void;
   durable?: boolean;
-  fakeDurable?: boolean;
 };
 
 export type VatData = {

--- a/packages/wallet/api/test/attestationExample.js
+++ b/packages/wallet/api/test/attestationExample.js
@@ -2,6 +2,7 @@
 import '@agoric/zoe/exported.js';
 import { AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
 
 /** @param {ZCF} zcf */
 export const start = async zcf => {
@@ -53,12 +54,12 @@ export const start = async zcf => {
 
   const getCallHistory = () => callHistory;
 
-  const publicFacet = {
+  const publicFacet = Far('attestation public facet', {
     mintAttestation,
     makeWantAttInvitation,
     makeReturnAttInvitation,
     getCallHistory,
-  };
+  });
 
   return harden({ publicFacet });
 };

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -67,11 +67,9 @@ const sellSeatExpiredMsg = `The covered call option is expired.`;
  * specified in the invitation value, and want the underlying assets
  * exactly.
  *
- * @param _privateArgs unknown
+ * @param {ZCF} zcf
+ * @param {unknown} _privateArgs
  * @param {import('@agoric/vat-data').Baggage} instanceBaggage
- * @param {ZCF} zcf passed in setupInstallation, but not completely initialized
- *    until setupInstance. Passed early because it will often need to be
- *    captured lexically by durable kinds.
  */
 const start = async (zcf, _privateArgs, instanceBaggage) => {
   const makeExerciser = vivifyKind(

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -72,6 +72,9 @@ const sellSeatExpiredMsg = `The covered call option is expired.`;
  * @param {import('@agoric/vat-data').Baggage} instanceBaggage
  */
 const start = async (zcf, _privateArgs, instanceBaggage) => {
+  // TODO the exerciseOption offer handler that this makes is an object rather
+  // than a function for now only because we do not yet support durable
+  // functions.
   const makeExerciser = vivifyKind(
     instanceBaggage,
     'makeExerciserKindHandle',

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -1,14 +1,9 @@
 // @ts-check
 
 import { fit, M } from '@agoric/store';
-import { Far } from '@endo/marshal';
 import '../../exported.js';
 
-import {
-  defineDurableKind,
-  provideDurableMapStore,
-  provideKindHandle,
-} from '@agoric/vat-data';
+import { vivifyKind, vivifySingleton } from '@agoric/vat-data';
 import { swapExact } from '../contractSupport/index.js';
 import { isAfterDeadlineExitRule } from '../typeGuards.js';
 
@@ -72,24 +67,16 @@ const sellSeatExpiredMsg = `The covered call option is expired.`;
  * specified in the invitation value, and want the underlying assets
  * exactly.
  *
- * @param {import('@agoric/vat-data').Baggage} installationBaggage
+ * @param _privateArgs unknown
+ * @param {import('@agoric/vat-data').Baggage} instanceBaggage
  * @param {ZCF} zcf passed in setupInstallation, but not completely initialized
  *    until setupInstance. Passed early because it will often need to be
  *    captured lexically by durable kinds.
  */
-const setupInstallation = (installationBaggage, zcf) => {
-  const instanceBaggage = provideDurableMapStore(
-    installationBaggage,
-    'instance',
-  );
-
-  const makeExerciserKindHandle = provideKindHandle(
+const start = async (zcf, _privateArgs, instanceBaggage) => {
+  const makeExerciser = vivifyKind(
     instanceBaggage,
     'makeExerciserKindHandle',
-  );
-
-  const makeExerciser = defineDurableKind(
-    makeExerciserKindHandle,
     sellSeat => ({ sellSeat }),
     {
       handle: ({ state: { sellSeat } }, buySeat) => {
@@ -128,24 +115,11 @@ const setupInstallation = (installationBaggage, zcf) => {
     return zcf.makeInvitation(exerciseOption, 'exerciseOption', customProps);
   };
 
-  const setupInstance = _privateArgs => {
-    // define instance kinds
-
-    const makeInstanceKit = () => {
-      // the creatorFacet could be made durable for this demonstration, but if
-      // it's not initiated before upgrade, there's no state to lose.
-      const creatorFacet = Far('creatorFacet', {
-        makeInvitation: () => zcf.makeInvitation(makeOption, 'makeCallOption'),
-      });
-      return harden({ creatorFacet });
-    };
-    return harden(makeInstanceKit);
-  };
-
-  // redefine kinds.
-
-  return harden(setupInstance);
+  const creatorFacet = vivifySingleton(instanceBaggage, 'creatorFacet', {
+    makeInvitation: () => zcf.makeInvitation(makeOption, 'makeCallOption'),
+  });
+  return harden({ creatorFacet });
 };
 
-harden(setupInstallation);
-export { setupInstallation };
+harden(start);
+export { start };

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -182,22 +182,11 @@
  */
 
 /**
- * @typedef {object} ExecuteClassicContractResult
+ * @typedef {object} ExecuteContractResult
  * @property {object} creatorFacet
  * @property {Promise<Invitation>} creatorInvitation
  * @property {object} publicFacet
  * @property {HandleOfferObj} handleOfferObj
- */
-
-/**
- * @typedef {object} ExecuteUpgradeableContractResult
- * @property {object} creatorFacet
- * @property {object} publicFacet
- * @property {HandleOfferObj} handleOfferObj
- */
-
-/**
- * @typedef {ExecuteClassicContractResult|ExecuteUpgradeableContractResult} ExecuteContractResult
  */
 
 /**

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -234,7 +234,6 @@ export const makeStartInstance = (
     const {
       creatorFacet = Far('emptyCreatorFacet', {}),
       publicFacet = Far('emptyPublicFacet', {}),
-      // @ts-expect-error classic contracts can return creatorInvititation
       creatorInvitation: creatorInvitationP,
       handleOfferObj,
     } = await E(zcfRoot).startZcf(

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -3,12 +3,7 @@
 import { M, fit } from '@agoric/store';
 import '../../../exported.js';
 
-import {
-  defineDurableKind,
-  provideDurableMapStore,
-  provideKindHandle,
-} from '@agoric/vat-data';
-import { Far } from '@endo/marshal';
+import { vivifyKind, vivifySingleton } from '@agoric/vat-data';
 import { swapExact } from '../../../src/contractSupport/index.js';
 import { isAfterDeadlineExitRule } from '../../../src/typeGuards.js';
 
@@ -72,22 +67,14 @@ const sellSeatExpiredMsg = `The covered call option is expired.`;
  * specified in the invitation value, and want the underlying assets
  * exactly.
  *
- * @param {import('@agoric/vat-data').Baggage} installationBaggage
+ * @param _privateArgs
+ * @param {import('@agoric/vat-data').Baggage} instanceBaggage
  * @param {ZCF} zcf
  */
-const setupInstallation = (installationBaggage, zcf) => {
-  const instanceBaggage = provideDurableMapStore(
-    installationBaggage,
-    'instance',
-  );
-
-  const makeExerciserKindHandle = provideKindHandle(
+const vivify = async (zcf, _privateArgs, instanceBaggage) => {
+  const makeExerciser = vivifyKind(
     instanceBaggage,
     'makeExerciserKindHandle',
-  );
-
-  const makeExerciser = defineDurableKind(
-    makeExerciserKindHandle,
     sellSeat => ({ sellSeat }),
     {
       handle: ({ state: { sellSeat } }, buySeat) => {
@@ -126,24 +113,11 @@ const setupInstallation = (installationBaggage, zcf) => {
     return zcf.makeInvitation(exerciseOption, 'exerciseOption', customProps);
   };
 
-  const setupInstance = _privateArgs => {
-    // define instance kinds
-
-    const makeInstanceKit = () => {
-      // the creatorFacet could be made durable for this demonstration, but if
-      // it's not initiated before upgrade, there's no state to lose.
-      const creatorFacet = Far('creatorFacet', {
-        makeInvitation: () => zcf.makeInvitation(makeOption, 'makeCallOption'),
-      });
-      return harden({ creatorFacet });
-    };
-    return harden(makeInstanceKit);
-  };
-
-  // redefine kinds.
-
-  return harden(setupInstance);
+  const creatorFacet = vivifySingleton(instanceBaggage, 'creatorFacet', {
+    makeInvitation: () => zcf.makeInvitation(makeOption, 'makeCallOption'),
+  });
+  return harden({ creatorFacet });
 };
 
-harden(setupInstallation);
-export { setupInstallation };
+harden(vivify);
+export { vivify };

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -72,6 +72,9 @@ const sellSeatExpiredMsg = `The covered call option is expired.`;
  * @param {import('@agoric/vat-data').Baggage} instanceBaggage
  */
 const vivify = async (zcf, _privateArgs, instanceBaggage) => {
+  // TODO the exerciseOption offer handler that this makes is an object rather
+  // than a function for now only because we do not yet support durable
+  // functions.
   const makeExerciser = vivifyKind(
     instanceBaggage,
     'makeExerciserKindHandle',

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -67,9 +67,9 @@ const sellSeatExpiredMsg = `The covered call option is expired.`;
  * specified in the invitation value, and want the underlying assets
  * exactly.
  *
- * @param _privateArgs
- * @param {import('@agoric/vat-data').Baggage} instanceBaggage
  * @param {ZCF} zcf
+ * @param {unknown} _privateArgs
+ * @param {import('@agoric/vat-data').Baggage} instanceBaggage
  */
 const vivify = async (zcf, _privateArgs, instanceBaggage) => {
   const makeExerciser = vivifyKind(

--- a/packages/zoe/test/unitTests/zcf/registerFeeMintContract.js
+++ b/packages/zoe/test/unitTests/zcf/registerFeeMintContract.js
@@ -2,6 +2,7 @@
 
 import { AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
 
 /**
  * Tests zcf.registerFeeMint
@@ -26,7 +27,7 @@ const start = async (zcf, privateArgs) => {
     zcfSeat,
   );
 
-  const creatorFacet = harden({
+  const creatorFacet = Far('mint creator facet', {
     getMintedAmount: () => zcfSeat.getAmountAllocated('Winnings'),
     getMintedPayout: () => {
       zcfSeat.exit();


### PR DESCRIPTION
closes: #5764

## Description

Refator #5635 to be more compatible with classic contracts. `start` continues to be a supported export for contracts. In order to be upgradeable, start has to be renamed to `vivify`, though the author can wait until V2 to do so. `start` now includes a baggage parameter that the contract can use to make reachably durable contracts.

### Security Considerations

Continue to maintain Zoe's invariants.

### Documentation Considerations

#5708 needs to be updated with the revised interface.

### Testing Considerations

There's a test that demonstrates that the coveredCall contract can be upgraded.