### PR TITLE
testing improvements

### DIFF
--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -2,13 +2,8 @@
 /* eslint dot-notation: "off" */
 /* eslint object-shorthand: "off" */
 
-// `test.serial` does not yet seem compatible with ses-ava
-// See https://github.com/endojs/endo/issues/647
-// TODO restore
-// import { test } from '../tools/prepare-test-env-ava.js';
-import '../tools/prepare-test-env.js';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+// eslint-disable-next-line import/order -- has side-effects AND exports
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import path from 'path';
 import bundleSource from '@endo/bundle-source';

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -124,13 +124,13 @@ test('makePublishKit', async t => {
     'failure should not be allowed after finalization',
   );
   await t.throwsAsync(
-    // @ts-ignore known to be promise version of PublicationList; expect after https://github.com/Agoric/agoric-sdk/pull/5774/
+    // @ts-expect-error known to be promise version of PublicationList
     subFinal.tail,
     undefined,
     'tail promise of final result should be rejected',
   );
   await t.throwsAsync(
-    // @ts-ignore known to be promise version of PublicationList; expect after https://github.com/Agoric/agoric-sdk/pull/5774/
+    // @ts-expect-error known to be promise version of PublicationList
     subscriber.subscribeAfter(subFinal.publishCount),
     undefined,
     'subscribeAfter(finalPublishCount) should be rejected',
@@ -179,13 +179,13 @@ test('makePublishKit - immediate finish', async t => {
     'failure should not be allowed after finalization',
   );
   await t.throwsAsync(
-    // @ts-ignore known to be promise version of PublicationList; expect after https://github.com/Agoric/agoric-sdk/pull/5774/
+    // @ts-expect-error known to be promise version of PublicationList
     subFinal.tail,
     undefined,
     'tail promise of final result should be rejected',
   );
   await t.throwsAsync(
-    // @ts-ignore known to be promise version of PublicationList; expect after https://github.com/Agoric/agoric-sdk/pull/5774/
+    // @ts-expect-error known to be promise version of PublicationList
     subscriber.subscribeAfter(subFinal.publishCount),
     undefined,
     'subscribeAfter(finalPublishCount) should be rejected',

--- a/packages/run-protocol/test/test-gov-collateral.js
+++ b/packages/run-protocol/test/test-gov-collateral.js
@@ -586,4 +586,4 @@ test('Committee can raise debt limit', async t => {
   });
 });
 
-// test.todo('users can open vaults');
+test.todo('users can open vaults');

--- a/packages/solo/test/test-home.js
+++ b/packages/solo/test/test-home.js
@@ -1,12 +1,6 @@
 /* global process */
 
-// `test.after.always` does not yet seem compatible with ses-ava
-// See https://github.com/endojs/endo/issues/647
-// TODO restore
-// import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import '@agoric/swingset-vat/tools/prepare-test-env.js';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import bundleSource from '@endo/bundle-source';
 import { AmountMath } from '@agoric/ertp';

--- a/packages/ui-components/test/display/test-display.js
+++ b/packages/ui-components/test/display/test-display.js
@@ -1,7 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava'; // TODO ses-ava doesn't yet have test.todo
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { parseAsValue } from '../../src/display/display.js';
 

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -319,7 +319,6 @@ export const makeZCFZygote = (
     /** @type {SetTestJig} */
     setTestJig: (testFn = () => ({})) => {
       if (testJigSetter) {
-        console.warn('TEST ONLY: capturing test data', testFn);
         testJigSetter({ ...testFn(), zcf });
       }
     },

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -1,8 +1,7 @@
 // @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava'; // TODO ses-ava doesn't yet have test.todo
 import '../../../../exported.js';
 
 import { AmountMath } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -1,8 +1,6 @@
 // @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava.js';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava'; // TODO ses-ava doesn't yet have test.todo
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import '../../../../exported.js';
 
 import { AmountMath } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contracts/loan/test-close.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-close.js
@@ -1,8 +1,6 @@
 // @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava.js';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava'; // TODO ses-ava doesn't yet have test.todo
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import '../../../../exported.js';
 
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -1,8 +1,7 @@
 // @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava'; // TODO ses-ava doesn't yet have test.todo
 import path from 'path';
 
 import '../../../../exported.js';

--- a/patches/@endo+ses-ava+0.2.27.patch
+++ b/patches/@endo+ses-ava+0.2.27.patch
@@ -1,0 +1,269 @@
+diff --git a/node_modules/@endo/ses-ava/exported.js b/node_modules/@endo/ses-ava/exported.js
+index f4cba01..e69de29 100644
+--- a/node_modules/@endo/ses-ava/exported.js
++++ b/node_modules/@endo/ses-ava/exported.js
+@@ -1 +0,0 @@
+-import './src/types.js';
+diff --git a/node_modules/@endo/ses-ava/src/ses-ava-test.js b/node_modules/@endo/ses-ava/src/ses-ava-test.js
+index 36038ad..de65de7 100644
+--- a/node_modules/@endo/ses-ava/src/ses-ava-test.js
++++ b/node_modules/@endo/ses-ava/src/ses-ava-test.js
+@@ -1,18 +1,8 @@
+ // @ts-check
+ import 'ses';
+-import './types.js';
+ 
+ const { apply } = Reflect;
+ 
+-/**
+- * Just forwards to global `console.error`.
+- *
+- * @type {Logger}
+- */
+-const defaultLogger = (...args) => {
+-  console.error(...args);
+-};
+-
+ /**
+  * Determine if the argument is a Promise.
+  * (Approximately copied from promiseKit.js)
+@@ -24,21 +14,48 @@ const isPromise = maybePromise =>
+   Promise.resolve(maybePromise) === maybePromise;
+ 
+ /**
+- * @type {LogCallError}
++ * @typedef {(...args: unknown[]) => void} Logger
+  */
+-const logErrorFirst = (func, args, name, logger = defaultLogger) => {
++
++/**
++ * Calls `func(...args)` passing back approximately its outcome, but first
++ * logging any erroneous outcome to the `logger`, which defaults to
++ * `console.log`.
++ *
++ *    * If `func(...args)` returns a non-promise, silently return it.
++ *    * If `func(...args)` throws, log what was thrown and then rethrow it.
++ *    * If `func(...args)` returns a promise, immediately return a new
++ *      unresolved promise.
++ *       * If the first promise fulfills, silently fulfill the returned promise
++ *         even if the fulfillment was an error.
++ *       * If the first promise rejects, log the rejection reason and then
++ *         reject the returned promise with the same reason.
++ *
++ * The delayed rejection of the returned promise is an observable difference
++ * from directly calling `func(...args)` but will be equivalent enough for most
++ * purposes.
++ *
++ * TODO This function is useful independent of Ava, so consider moving it
++ * somewhere and exporting it for general reuse.
++ *
++ * @param {(...unknown) => unknown} func
++ * @param {unknown[]} args
++ * @param {string} name
++ * @param {Logger=} logError
++ */
++const logErrorFirst = (func, args, name, logError = console.error) => {
+   let result;
+   try {
+     result = apply(func, undefined, args);
+   } catch (err) {
+-    logger(`THROWN from ${name}:`, err);
++    logError(`THROWN from ${name}:`, err);
+     throw err;
+   }
+   if (isPromise(result)) {
+     return result.then(
+       v => v,
+       reason => {
+-        logger(`REJECTED from ${name}:`, reason);
++        logError(`REJECTED from ${name}:`, reason);
+         return result;
+       },
+     );
+@@ -47,7 +64,7 @@ const logErrorFirst = (func, args, name, logger = defaultLogger) => {
+   }
+ };
+ 
+-const testerMethodsWhitelist = [
++const overrideList = [
+   'after',
+   'afterEach',
+   'before',
+@@ -56,32 +73,52 @@ const testerMethodsWhitelist = [
+   'failing',
+   'serial',
+   'only',
+-  'skip',
+ ];
+ 
+ /**
+- * @param {TesterFunc} testerFunc
+- * @param {Logger} [logger]
+- * @returns {TesterFunc} Not yet frozen!
++* @callback BaseImplFunc
++* This is the function that invariably starts `t => {`.
++* Ava's types call this `Implementation`, but that's just too confusing.
++* @param {Assertions} t
++* @returns {unknown}
++*
++* @typedef {BaseImplFunc | Object} ImplFunc
++* @property {(...unknown) => string} [title]
++*
++* @callback TesterFunc
++* @param {string} title
++* @param {ImplFunc} [implFunc]
++* @returns {void}
++*/
++
++/**
++ * @template {TesterFunc} T
++ * @param {T} testerFunc
++ * @param {Logger} [logError]
++ * @returns {T} Not yet frozen!
+  */
+-const wrapTester = (testerFunc, logger = defaultLogger) => {
++const augmentLogging = (testerFunc, logError = console.error) => {
+   /** @type {TesterFunc} */
+-  const testerWrapper = (title, implFunc, ...otherArgs) => {
+-    /** @type {ImplFunc} */
++  const augmented = (title, implFunc, ...otherArgs) => {
+     const testFuncWrapper = t => {
+       harden(t);
+-      return logErrorFirst(implFunc, [t, ...otherArgs], 'ava test', logger);
++      return logErrorFirst(implFunc, [t, ...otherArgs], 'ava test', logError);
+     };
+     if (implFunc && implFunc.title) {
+       testFuncWrapper.title = implFunc.title;
+     }
+     return testerFunc(title, testFuncWrapper, ...otherArgs);
+   };
+-  return testerWrapper;
++  // re-use other properties (e.g. `.always`)
++  // https://github.com/endojs/endo/issues/647#issuecomment-809010961
++  Object.assign(augmented, testerFunc);
++  // @ts-expect-error cast
++  return augmented;
+ };
+ 
++// TODO check whether this is still necessary in Ava 4
+ /**
+- * The ava `test` function takes a callback argument of the form
++ * The Ava 3 `test` function takes a callback argument of the form
+  * `t => {...}`. If the outcome of this function indicates an error, either
+  * by throwing or by eventually rejecting a returned promise, ava does its
+  * own peculiar console-like display of this error and its stacktrace.
+@@ -105,25 +142,18 @@ const wrapTester = (testerFunc, logger = defaultLogger) => {
+  * that eventually rejects, the error is first sent to the `console` before
+  * propagating into `rawTest`.
+  *
+- * @param {TesterInterface} avaTest
+- * @param {Logger} [logger]
+- * @returns {TesterInterface}
++ * @template {TesterFunc} T Ava `test`
++ * @param {T} avaTest
++ * @param {Logger} [logError]
++ * @returns {T}
+  */
+-const wrapTest = (avaTest, logger = defaultLogger) => {
+-  const testerWrapper = /** @type {TesterInterface} */ (wrapTester(
+-    avaTest,
+-    logger,
+-  ));
+-  for (const methodName of testerMethodsWhitelist) {
+-    if (methodName in avaTest) {
+-      /** @type {TesterFunc} */
+-      const testerMethod = (title, implFunc, ...otherArgs) =>
+-        avaTest[methodName](title, implFunc, ...otherArgs);
+-      testerWrapper[methodName] = wrapTester(testerMethod);
+-    }
++const wrapTest = (avaTest, logError = console.error) => {
++  const sesAvaTest = augmentLogging(avaTest, logError);
++  for (const methodName of overrideList) {
++    sesAvaTest[methodName] = augmentLogging(avaTest[methodName]);
+   }
+-  harden(testerWrapper);
+-  return testerWrapper;
++  harden(sesAvaTest);
++  return sesAvaTest;
+ };
+-// harden(wrapTest);
++harden(wrapTest);
+ export { wrapTest };
+diff --git a/node_modules/@endo/ses-ava/src/types.js b/node_modules/@endo/ses-ava/src/types.js
+deleted file mode 100644
+index 9bddf17..0000000
+--- a/node_modules/@endo/ses-ava/src/types.js
++++ /dev/null
+@@ -1,72 +0,0 @@
+-// @ts-check
+-
+-/**
+- * @typedef {(...args: unknown[]) => void} Logger
+- */
+-
+-/**
+- * @callback LogCallError
+- *
+- * Calls `thunk()` passing back approximately its outcome, but first
+- * logging any erroneous outcome to the `logger`, which defaults to
+- * `console.log`.
+- *
+- * If thunk returns a non-promise, silently return it.
+- * If thunk throws, log what was thrown and then rethrow it.
+- * If thunk returns a promise, immediately return a new unresolved promise.
+- * If the first promise fulfills, silently fulfill the returned promise even if
+- * the fulfillment was an error.
+- * If the first promise rejects, log the rejection reason and then reject the
+- * returned promise with the same reason.
+- * The delayed rejection of the returned promise is an observable difference
+- * from directly calling `thunk()` but will be equivalent enough for most
+- * purposes.
+- *
+- * TODO This function is useful independent of ava, so consider moving it
+- * somewhere and exporting it for general reuse.
+- *
+- * @param {(...unknown) => unknown} func
+- * @param {unknown[]} args
+- * @param {string} name
+- * @param {Logger=} logger
+- */
+-
+-/**
+- * Simplified form of ava's types.
+- * TODO perhaps just import ava's type declarations instead
+- * TODO reconcile also with types and API defined in avaAssertXS.js
+- *
+- * @typedef {Object} Assertions
+- * @property {(actual: unknown, message?: string) => void} assert
+- * // TODO is, deepEqual, truthy, falsy, etc...
+- */
+-
+-/**
+- * @callback BaseImplFunc
+- * This is the function that invariably starts `t => {`.
+- * Ava's types call this `Implementation`, but that's just too confusing.
+- *
+- * @param {Assertions} t
+- * @returns {unknown}
+- *
+- * @typedef {BaseImplFunc | Object} ImplFunc
+- * @property {(...unknown) => string} [title]
+- *
+- * @callback TesterFunc
+- * @param {string} title
+- * @param {ImplFunc} implFunc
+- * @returns {void}
+- *
+- * @typedef {Object} TesterProperties
+- * @property {TesterFunc} after
+- * @property {TesterFunc} afterEach
+- * @property {TesterFunc} before
+- * @property {TesterFunc} beforeEach
+- * @property {TesterFunc} cb
+- * @property {TesterFunc} failing
+- * @property {TesterFunc} serial
+- * @property {TesterFunc} only
+- * @property {TesterFunc} skip
+- *
+- * @typedef {TesterFunc & TesterProperties} TesterInterface
+- */


### PR DESCRIPTION
## Description

https://github.com/Agoric/agoric-sdk/pull/5766 ran into a problem with `test.todo` not being available in ses-ava. 524e7de69408414abcfed42d6468b01953f9897b adds it. (fyi @erights )

I also got fed up with this noise in test output. 295c8aadf1840e1a315ab0354c83659e161db369 removes it.
<img width="587" alt="Screen Shot 2022-07-12 at 7 55 13 AM" src="https://user-images.githubusercontent.com/21505/179321113-dff43859-586a-4858-b5a9-7fde3a3c691b.png">


### Security Considerations

none

### Documentation Considerations

--

### Testing Considerations

Better