### PR TITLE
fix(golang): complete ledger support for MsgWallet{Spend}Action

### DIFF
--- a/golang/cosmos/x/swingset/types/codec.go
+++ b/golang/cosmos/x/swingset/types/codec.go
@@ -31,6 +31,8 @@ func init() {
 func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgDeliverInbound{}, ModuleName+"/DeliverInbound", nil)
 	cdc.RegisterConcrete(&MsgProvision{}, ModuleName+"/Provision", nil)
+	cdc.RegisterConcrete(&MsgWalletAction{}, ModuleName+"/WalletAction", nil)
+	cdc.RegisterConcrete(&MsgWalletSpendAction{}, ModuleName+"/WalletSpendAction", nil)
 }
 
 // RegisterInterfaces registers the x/swingset interfaces types with the interface registry

--- a/golang/cosmos/x/swingset/types/msgs.go
+++ b/golang/cosmos/x/swingset/types/msgs.go
@@ -109,11 +109,6 @@ func (msg MsgWalletAction) GetSignBytes() []byte {
 	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
-// GetSignBytes encodes the message for signing
-func (msg MsgWalletSpendAction) GetSignBytes() []byte {
-	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
-}
-
 // Route should return the name of the module
 func (msg MsgWalletAction) Route() string { return RouterKey }
 
@@ -125,6 +120,11 @@ func (msg MsgWalletSpendAction) Route() string { return RouterKey }
 
 // Type should return the action
 func (msg MsgWalletSpendAction) Type() string { return "wallet_spend_action" }
+
+// GetSignBytes encodes the message for signing
+func (msg MsgWalletSpendAction) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+}
 
 // ValidateBasic runs stateless checks on the message
 func (msg MsgWalletAction) ValidateBasic() error {

--- a/golang/cosmos/x/swingset/types/msgs.go
+++ b/golang/cosmos/x/swingset/types/msgs.go
@@ -104,6 +104,28 @@ func (msg MsgWalletAction) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Owner}
 }
 
+// GetSignBytes encodes the message for signing
+func (msg MsgWalletAction) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+}
+
+// GetSignBytes encodes the message for signing
+func (msg MsgWalletSpendAction) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+}
+
+// Route should return the name of the module
+func (msg MsgWalletAction) Route() string { return RouterKey }
+
+// Type should return the action
+func (msg MsgWalletAction) Type() string { return "wallet_action" }
+
+// Route should return the name of the module
+func (msg MsgWalletSpendAction) Route() string { return RouterKey }
+
+// Type should return the action
+func (msg MsgWalletSpendAction) Type() string { return "wallet_spend_action" }
+
 // ValidateBasic runs stateless checks on the message
 func (msg MsgWalletAction) ValidateBasic() error {
 	if msg.Owner.Empty() {


### PR DESCRIPTION
refs #3628

register amino codec for WalletAction, SpendAction filling in LegacyMsg methods.

This avoids:

```
panic: expected *legacytx.LegacyMsg when using amino JSON
```

### Testing Considerations

I've been testing it manually:
https://github.com/Agoric/agoric-sdk/issues/3628#issuecomment-1188017709
