### PR TITLE
5386 off chain reads

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lerna": "^3.22.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",
-    "typescript": "~4.7.2"
+    "typescript": "~4.7.4"
   },
   "engines": {
     "node": ">=14.15.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@endo/eslint-config": "^0.5.1",
     "@jessie.js/eslint-plugin": "^0.2.0",
     "@types/node": "^16.7.10",
-    "@typescript-eslint/parser": "^5.27.0",
+    "@typescript-eslint/parser": "^5.30.7",
     "ava": "^3.15.0",
     "c8": "^7.11.0",
     "conventional-changelog-conventionalcommits": "^4.6.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "@endo/eslint-config": "^0.5.1",
     "@jessie.js/eslint-plugin": "^0.2.0",
-    "@typescript-eslint/parser": "^5.27.0",
+    "@typescript-eslint/parser": "^5.30.7",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-jessie": "^0.0.6",

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -44,6 +44,7 @@
   },
   "files": [
     "src/",
+    "tools",
     "exported.js",
     "NEWS.md"
   ],

--- a/packages/notifier/test/test-stored-subscription.js
+++ b/packages/notifier/test/test-stored-subscription.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* global setImmediate */
 
 // eslint-disable-next-line import/order
 import { test } from './prepare-test-env-ava.js';
@@ -14,47 +13,14 @@ import {
   makeSubscriptionKit,
   subscribeEach,
 } from '../src/index.js';
+import {
+  eventLoopIteration,
+  makeFakeStorage,
+  makeFakeMarshaller,
+} from '../tools/testSupports.js';
 
 import '../src/types.js';
 import { jsonPairs } from './marshal-corpus.js';
-
-export const eventLoopIteration = async () =>
-  new Promise(resolve => setImmediate(resolve));
-
-/**
- *
- * @param {string} path
- * @param {IterationObserver<unknown>} [publication]
- */
-const makeFakeStorage = (path, publication) => {
-  let setValueCalls = 0;
-  const fullPath = `publish.${path}`;
-  const storeKey = harden({
-    storeName: 'swingset',
-    storeSubkey: `swingset/data:${fullPath}`,
-  });
-  /** @type {StorageNode} */
-  const storage = {
-    getStoreKey: () => storeKey,
-    setValue: value => {
-      setValueCalls += 1;
-      assert.typeof(value, 'string');
-      if (!publication) {
-        throw Error('publication undefined');
-      }
-      publication.updateState(value);
-    },
-    getChildNode: () => storage,
-    // @ts-expect-error
-    countSetValueCalls: () => setValueCalls,
-  };
-  return storage;
-};
-
-const makeFakeMarshaller = () =>
-  makeMarshal(undefined, undefined, {
-    marshalSaveError: () => {},
-  });
 
 test('stored subscription', async t => {
   t.plan((jsonPairs.length + 2) * 4 + 1);

--- a/packages/notifier/tools/testSupports.js
+++ b/packages/notifier/tools/testSupports.js
@@ -1,0 +1,47 @@
+// @ts-check
+/* global setImmediate */
+
+// eslint-disable-next-line import/order
+import { makeMarshal } from '@endo/marshal';
+
+import '../src/types.js';
+
+export const eventLoopIteration = async () =>
+  new Promise(resolve => setImmediate(resolve));
+
+/**
+ *
+ * @param {string} path
+ * @param {IterationObserver<unknown>} [publication]
+ */
+export const makeFakeStorage = (path, publication) => {
+  let setValueCalls = 0;
+  const fullPath = `publish.${path}`;
+  const storeKey = harden({
+    storeName: 'swingset',
+    storeSubkey: `swingset/data:${fullPath}`,
+  });
+  /** @type {StorageNode} */
+  const storage = {
+    getStoreKey: () => storeKey,
+    setValue: value => {
+      setValueCalls += 1;
+      assert.typeof(value, 'string');
+      if (!publication) {
+        throw Error('publication undefined');
+      }
+      publication.updateState(value);
+    },
+    getChildNode: () => storage,
+    // @ts-expect-error
+    countSetValueCalls: () => setValueCalls,
+  };
+  return storage;
+};
+harden(makeFakeStorage);
+
+export const makeFakeMarshaller = () =>
+  makeMarshal(undefined, undefined, {
+    marshalSaveError: () => {},
+  });
+harden(makeFakeMarshaller);

--- a/packages/run-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/run-protocol/src/vaultFactory/vaultDirector.js
@@ -203,11 +203,8 @@ const makeVaultInvitation = ({ state }) => {
   return zcf.makeInvitation(makeVaultHook, 'MakeVault');
 };
 
-// TODO put on machineFacet for use again in publicFacet
 /**
- * Make a loan in the vaultManager based on the collateral type.
- *
- * @deprecated
+ * @deprecated get `collaterals` list from metrics
  * @param {MethodContext} context
  */
 const getCollaterals = async ({ state }) => {

--- a/packages/run-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/run-protocol/src/vaultFactory/vaultHolder.js
@@ -1,8 +1,8 @@
 /**
- * @file Object representing ownership of a vault
+ * @file Use-object for the owner of a vault
  */
 // @ts-check
-import { makePublishKit } from '@agoric/notifier';
+import { makeStoredPublishKit } from '@agoric/notifier';
 import { defineKindMulti } from '@agoric/vat-data';
 import '@agoric/zoe/exported.js';
 
@@ -10,8 +10,8 @@ const { details: X } = assert;
 
 /**
  * @typedef {{
- * publisher: PublishKit<VaultNotification>['publisher'],
- * subscriber: PublishKit<VaultNotification>['subscriber'],
+ * publisher: StoredPublishKit<VaultNotification>['publisher'],
+ * subscriber: StoredPublishKit<VaultNotification>['subscriber'],
  * vault: Vault | null,
  * }} State
  * @typedef {Readonly<{
@@ -26,11 +26,16 @@ const { details: X } = assert;
 /**
  *
  * @param {Vault} vault
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
  * @returns {State}
  */
-const initState = vault => {
-  /** @type {PublishKit<VaultNotification>} */
-  const { subscriber, publisher } = makePublishKit();
+const initState = (vault, storageNode, marshaller) => {
+  /** @type {StoredPublishKit<VaultNotification>} */
+  const { subscriber, publisher } = makeStoredPublishKit(
+    storageNode,
+    marshaller,
+  );
 
   return { publisher, subscriber, vault };
 };

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -8,14 +8,25 @@ import { makeVaultHolder } from './vaultHolder.js';
  * Create a kit of utilities for use of the vault.
  *
  * @param {Vault} vault
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
  * @param {Subscriber<import('./vaultManager').AssetState>} assetSubscriber
  */
-export const makeVaultKit = (vault, assetSubscriber) => {
-  const { holder, helper } = makeVaultHolder(vault);
+export const makeVaultKit = (
+  vault,
+  storageNode,
+  marshaller,
+  assetSubscriber,
+) => {
+  const { holder, helper } = makeVaultHolder(vault, storageNode, marshaller);
   const vaultKit = harden({
+    /** @deprecated */
     publicNotifiers: {
       vault: makeNotifierFromSubscriber(holder.getSubscriber()),
       asset: makeNotifierFromSubscriber(assetSubscriber),
+    },
+    publicSubscribers: {
+      vault: holder.getSubscriber(),
     },
     invitationMakers: Far('invitation makers', {
       AdjustBalances: holder.makeAdjustBalancesInvitation,

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -714,12 +714,26 @@ const selfBehavior = {
     state.vaultCounter += 1;
     const vaultId = String(state.vaultCounter);
 
-    const vault = makeVault(zcf, manager, vaultId);
+    const storageNode = E(
+      E(state.storageNode).getChildNode(`vaults`),
+    ).getChildNode(`vault${vaultId}`);
+
+    const vault = makeVault(
+      zcf,
+      manager,
+      vaultId,
+      storageNode,
+      state.marshaller,
+    );
 
     try {
       // TODO `await` is allowed until the above ordering is fixed
       // eslint-disable-next-line @jessie.js/no-nested-await
-      const vaultKit = await vault.initVaultKit(seat);
+      const vaultKit = await vault.initVaultKit(
+        seat,
+        storageNode,
+        state.marshaller,
+      );
       // initVaultKit calls back to handleBalanceChange() which will add the
       // vault to prioritizedVaults
       seat.exit();

--- a/packages/run-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addPool.js
@@ -99,8 +99,8 @@ export const makeAddIssuer = (
  * @param {ZCFSeat} protocolSeat seat that holds collected fees
  * @param {WeakStore<Brand,ZCFMint>} brandToLiquidityMint
  * @param {(secondaryBrand: Brand, reserveLiquidityTokenSeat: ZCFSeat, liquidityKeyword: Keyword) => Promise<void>} onOfferHandled
- * @param {ERef<StorageNode>} [storageNode]
- * @param {ERef<Marshaller>} [marshaller]
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
  */
 export const makeAddPoolInvitation = (
   zcf,

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -195,7 +195,7 @@ export const withAmountUtils = kit => {
 
 /**
  *
- * @param {Promise<StoredSubscription<unknown>>} subscription
+ * @param {Promise<StoredSubscription<unknown>> | StoredSubscriber<unknown>} subscription
  */
 export const subscriptionKey = subscription => {
   return E(subscription)

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -62,7 +62,12 @@ export const mockChainStorageRoot = () => {
   return makeChainStorageRoot(toStorage, 'swingset', 'mockChainStorageRoot');
 };
 
-export const setupBootstrap = (t, optTimer = undefined) => {
+/**
+ *
+ * @param {*} t
+ * @param {TimerService} [optTimer]
+ */
+export const setupBootstrap = (t, optTimer) => {
   const trace = makeTracer('PromiseSpace', false);
   const space = /** @type {any} */ (makePromiseSpace(trace));
   const { produce, consume } =

--- a/packages/run-protocol/test/test-voPool.js
+++ b/packages/run-protocol/test/test-voPool.js
@@ -2,18 +2,21 @@
 
 import { runVOTest, test } from '@agoric/swingset-vat/tools/vo-test-harness.js';
 
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { makeParamManager } from '@agoric/governance';
 import {
   makeNotifierFromSubscriber,
   makeStoredPublisherKit,
 } from '@agoric/notifier';
+import {
+  makeFakeMarshaller,
+  makeFakeStorage,
+} from '@agoric/notifier/tools/testSupports.js';
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
-import { makeIssuerKit, AmountMath } from '@agoric/ertp';
-
-import { definePoolKind } from '../src/vpool-xyk-amm/pool.js';
-import { makeAmmParams } from '../src/vpool-xyk-amm/params.js';
 import { mapValues } from '../src/collect.js';
+import { makeAmmParams } from '../src/vpool-xyk-amm/params.js';
+import { definePoolKind } from '../src/vpool-xyk-amm/pool.js';
 
 /** @typedef {ReturnType<typeof definePoolKind>} MakePoolMulti */
 /** @typedef {ReturnType<MakePoolMulti>} PoolMulti */
@@ -78,6 +81,9 @@ const voPoolTest = async (t, mutation, postTest) => {
 
     const paramAccessor = paramManager.readonly();
 
+    const storageNode = makeFakeStorage('voPoolTest');
+    const marshaller = makeFakeMarshaller();
+
     return definePoolKind(
       zcf,
       centralBrand,
@@ -86,6 +92,8 @@ const voPoolTest = async (t, mutation, postTest) => {
       // @ts-expect-error loose
       paramAccessor,
       protocolSeat,
+      storageNode,
+      marshaller,
     );
   };
 

--- a/packages/run-protocol/test/vaultFactory/driver.js
+++ b/packages/run-protocol/test/vaultFactory/driver.js
@@ -1,0 +1,533 @@
+// @ts-check
+
+import '@agoric/zoe/exported.js';
+
+import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
+import {
+  ceilMultiplyBy,
+  makeRatioFromAmounts,
+} from '@agoric/zoe/src/contractSupport/index.js';
+import { E } from '@endo/eventual-send';
+import { deeplyFulfilled } from '@endo/marshal';
+import * as Collect from '../../src/collect.js';
+import { makeTracer } from '../../src/makeTracer.js';
+import '../../src/vaultFactory/types.js';
+import { unsafeMakeBundleCache } from '../bundleTool.js';
+import {
+  installGovernance,
+  makeVoterTool,
+  setupBootstrap,
+  setUpZoeForTest,
+  withAmountUtils,
+} from '../supports.js';
+import {
+  setupAmm,
+  setupReserve,
+  startEconomicCommittee,
+  startVaultFactory,
+} from '../../src/proposals/econ-behaviors.js';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority.js';
+import { makeNotifierFromSubscriber } from '@agoric/notifier';
+
+/** @typedef {import('../../src/vaultFactory/vaultFactory').VaultFactoryContract} VFC */
+
+const trace = makeTracer('VFDriver');
+
+export const AT_NEXT = Symbol('AT_NEXT');
+
+export const BASIS_POINTS = 10000n;
+
+// Define locally to test that vaultFactory uses these values
+export const Phase = /** @type {const} */ ({
+  ACTIVE: 'active',
+  LIQUIDATING: 'liquidating',
+  CLOSED: 'closed',
+  LIQUIDATED: 'liquidated',
+  TRANSFER: 'transfer',
+});
+
+const contractRoots = {
+  faucet: './test/vaultFactory/faucet.js',
+  liquidate: './src/vaultFactory/liquidateIncrementally.js',
+  VaultFactory: './src/vaultFactory/vaultFactory.js',
+  amm: './src/vpool-xyk-amm/multipoolMarketMaker.js',
+  reserve: './src/reserve/assetReserve.js',
+};
+
+/**
+ * dL: 1M, lM: 105%, lP: 10%, iR: 100, lF: 500
+ *
+ * @param {import('../supports.js').AmountUtils} debt
+ */
+const defaultParamValues = debt =>
+  harden({
+    debtLimit: debt.make(1_000_000n),
+    // margin required to maintain a loan
+    liquidationMargin: debt.makeRatio(105n),
+    // penalty upon liquidation as proportion of debt
+    liquidationPenalty: debt.makeRatio(10n),
+    // periodic interest rate (per charging period)
+    interestRate: debt.makeRatio(100n, BASIS_POINTS),
+    // charge to create or increase loan balance
+    loanFee: debt.makeRatio(500n, BASIS_POINTS),
+  });
+
+/**
+ * @typedef {{
+ * aeth: IssuerKit & import('../supports.js').AmountUtils,
+ * aethInitialLiquidity: Amount<'nat'>,
+ * committee: any,
+ * electorateTerms: any,
+ * feeMintAccess: FeeMintAccess,
+ * installation: Record<string, any>,
+ * loanTiming: any,
+ * minInitialDebt: bigint,
+ * reserveCreatorFacet: ERef<AssetReserveCreatorFacet>,
+ * rates: any,
+ * run: IssuerKit & import('../supports.js').AmountUtils,
+ * runInitialLiquidity: Amount<'nat'>,
+ * timer: TimerService,
+ * zoe: ZoeService,
+ * }} DriverContext
+ */
+
+/**
+ * @returns {Promise<DriverContext>}
+ */
+export const makeDriverContext = async () => {
+  const { zoe, feeMintAccess } = setUpZoeForTest();
+  const runIssuer = await E(zoe).getFeeIssuer();
+  const runBrand = await E(runIssuer).getBrand();
+  const run = withAmountUtils({ issuer: runIssuer, brand: runBrand });
+  const aeth = withAmountUtils(makeIssuerKit('aEth'));
+  const bundleCache = await unsafeMakeBundleCache('./bundles/'); // package-relative
+
+  // note that the liquidation might be a different bundle name
+  // Collect.mapValues(contractRoots, (root, k) => loader.load(root, k)),
+  const bundles = await Collect.allValues({
+    faucet: bundleCache.load(contractRoots.faucet, 'faucet'),
+    liquidate: bundleCache.load(
+      contractRoots.liquidate,
+      'liquidateIncrementally',
+    ),
+    VaultFactory: bundleCache.load(contractRoots.VaultFactory, 'VaultFactory'),
+    amm: bundleCache.load(contractRoots.amm, 'amm'),
+    reserve: bundleCache.load(contractRoots.reserve, 'reserve'),
+  });
+  const installation = Collect.mapValues(bundles, bundle =>
+    E(zoe).install(bundle),
+  );
+  const contextPs = {
+    bundles,
+    installation,
+    zoe,
+    feeMintAccess,
+    loanTiming: {
+      chargingPeriod: 2n,
+      recordingPeriod: 6n,
+    },
+    minInitialDebt: 50n,
+    rates: defaultParamValues(run),
+    runInitialLiquidity: run.make(1_500_000_000n),
+    aethInitialLiquidity: AmountMath.make(aeth.brand, 900_000_000n),
+  };
+  const frozenCtx = await deeplyFulfilled(harden(contextPs));
+  return { ...frozenCtx, bundleCache, run, aeth };
+};
+
+/**
+ * @param {import('ava').ExecutionContext<DriverContext>} t
+ * @param {any} aethLiquidity
+ * @param {any} runLiquidity
+ */
+const setupAmmAndElectorate = async (t, aethLiquidity, runLiquidity) => {
+  const {
+    zoe,
+    aeth,
+    electorateTerms = { committeeName: 'The Cabal', committeeSize: 1 },
+    timer,
+  } = t.context;
+
+  const space = setupBootstrap(t, timer);
+  const { consume, instance } = space;
+  installGovernance(zoe, space.installation.produce);
+  // TODO consider using produceInstallations()
+  space.installation.produce.amm.resolve(t.context.installation.amm);
+  space.installation.produce.reserve.resolve(t.context.installation.reserve);
+  await startEconomicCommittee(space, {
+    options: { econCommitteeOptions: electorateTerms },
+  });
+  await setupAmm(space, {
+    options: { minInitialPoolLiquidity: 1000n },
+  });
+  await setupReserve(space);
+
+  const governorCreatorFacet = consume.ammGovernorCreatorFacet;
+  const governorInstance = await instance.consume.ammGovernor;
+  const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
+  const governedInstance = E(governorPublicFacet).getGovernedContract();
+
+  const counter = await space.installation.consume.binaryVoteCounter;
+  t.context.committee = makeVoterTool(
+    zoe,
+    space.consume.economicCommitteeCreatorFacet,
+    space.consume.vaultFactoryGovernorCreator,
+    counter,
+  );
+
+  /** @type { GovernedPublicFacet<XYKAMMPublicFacet> } */
+  // @ts-expect-error cast from unknown
+  const ammPublicFacet = await E(governorCreatorFacet).getPublicFacet();
+
+  const liquidityIssuer = await E(ammPublicFacet).addIssuer(
+    aeth.issuer,
+    'Aeth',
+  );
+  const liquidityBrand = await E(liquidityIssuer).getBrand();
+
+  const liqProposal = harden({
+    give: {
+      Secondary: aethLiquidity.proposal,
+      Central: runLiquidity.proposal,
+    },
+    want: { Liquidity: AmountMath.makeEmpty(liquidityBrand) },
+  });
+  const liqInvitation = await E(ammPublicFacet).addPoolInvitation();
+
+  const ammLiquiditySeat = await E(zoe).offer(
+    liqInvitation,
+    liqProposal,
+    harden({
+      Secondary: aethLiquidity.payment,
+      Central: runLiquidity.payment,
+    }),
+  );
+
+  // TODO get the creator directly
+  const newAmm = {
+    ammCreatorFacet: await consume.ammCreatorFacet,
+    ammPublicFacet,
+    instance: governedInstance,
+    ammLiquidity: E(ammLiquiditySeat).getPayout('Liquidity'),
+  };
+
+  return { amm: newAmm, space };
+};
+
+/**
+ *
+ * @param {import('ava').ExecutionContext<DriverContext>} t
+ * @param {Amount<'nat'>} runInitialLiquidity
+ */
+const getRunFromFaucet = async (t, runInitialLiquidity) => {
+  const {
+    installation: { faucet: installation },
+    zoe,
+    feeMintAccess,
+  } = t.context;
+  /** @type {Promise<Installation<import('./faucet.js').start>>} */
+  // @ts-expect-error cast
+  // On-chain, there will be pre-existing RUN. The faucet replicates that
+  const { creatorFacet: faucetCreator } = await E(zoe).startInstance(
+    installation,
+    {},
+    {},
+    harden({ feeMintAccess }),
+  );
+  const faucetSeat = E(zoe).offer(
+    await E(faucetCreator).makeFaucetInvitation(),
+    harden({
+      give: {},
+      want: { RUN: runInitialLiquidity },
+    }),
+  );
+
+  const runPayment = await E(faucetSeat).getPayout('RUN');
+  return runPayment;
+};
+
+/**
+ * NOTE: called separately by each test so AMM/zoe/priceAuthority don't interfere
+ *
+ * @param {import('ava').ExecutionContext<DriverContext>} t
+ * @param {Amount} initialPrice
+ * @param {Amount} priceBase
+ * @param {TimerService} timer
+ */
+const setupServices = async (
+  t,
+  initialPrice,
+  priceBase,
+  timer = buildManualTimer(t.log),
+) => {
+  const {
+    zoe,
+    run,
+    aeth,
+    loanTiming,
+    minInitialDebt,
+    rates,
+    aethInitialLiquidity,
+    runInitialLiquidity,
+  } = t.context;
+  t.context.timer = timer;
+
+  const runPayment = await getRunFromFaucet(t, runInitialLiquidity);
+  trace(t, 'faucet', { runInitialLiquidity, runPayment });
+  const runLiquidity = {
+    proposal: runInitialLiquidity,
+    payment: runPayment,
+  };
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aeth.mint.mintPayment(aethInitialLiquidity),
+  };
+  const { amm: ammFacets, space } = await setupAmmAndElectorate(
+    t,
+    aethLiquidity,
+    runLiquidity,
+  );
+  const { consume, produce } = space;
+  trace(t, 'amm', { ammFacets });
+
+  // Cheesy hack for easy use of manual price authority
+  const priceAuthority = makeManualPriceAuthority({
+    actualBrandIn: aeth.brand,
+    actualBrandOut: run.brand,
+    initialPrice: makeRatioFromAmounts(initialPrice, priceBase),
+    timer,
+    quoteIssuerKit: makeIssuerKit('quote', AssetKind.SET),
+  });
+  produce.priceAuthority.resolve(priceAuthority);
+
+  const {
+    installation: { produce: iProduce },
+  } = space;
+  t.context.reserveCreatorFacet = space.consume.reserveCreatorFacet;
+  iProduce.VaultFactory.resolve(t.context.installation.VaultFactory);
+  iProduce.liquidate.resolve(t.context.installation.liquidate);
+  await startVaultFactory(space, { loanParams: loanTiming }, minInitialDebt);
+
+  const governorCreatorFacet = consume.vaultFactoryGovernorCreator;
+  /** @type {Promise<VaultFactory & LimitedCreatorFacet<any>>} */
+  const vaultFactoryCreatorFacet = /** @type { any } */ (
+    E(governorCreatorFacet).getCreatorFacet()
+  );
+
+  // Add a vault that will lend on aeth collateral
+  const aethVaultManagerP = E(vaultFactoryCreatorFacet).addVaultType(
+    aeth.issuer,
+    'AEth',
+    rates,
+  );
+
+  /** @type {[any, VaultFactory, VFC['publicFacet'], VaultManager]} */
+  // @ts-expect-error cast
+  const [governorInstance, vaultFactory, lender, aethVaultManager] =
+    await Promise.all([
+      E(consume.agoricNames).lookup('instance', 'VaultFactoryGovernor'),
+      vaultFactoryCreatorFacet,
+      E(governorCreatorFacet).getPublicFacet(),
+      aethVaultManagerP,
+    ]);
+  trace(t, 'pa', { governorInstance, vaultFactory, lender, priceAuthority });
+
+  return {
+    zoe,
+    // installs,
+    governor: {
+      governorInstance,
+      governorPublicFacet: E(zoe).getPublicFacet(governorInstance),
+      governorCreatorFacet,
+    },
+    vaultFactory: {
+      vaultFactory,
+      lender,
+      aethVaultManager,
+    },
+    ammFacets,
+    priceAuthority,
+  };
+};
+
+/**
+ * @param {import('ava').ExecutionContext<DriverContext>} t
+ * @param {Amount<'nat'>} initialPrice
+ * @param {Amount<'nat'>} priceBase
+ */
+export const makeManagerDriver = async (t, initialPrice, priceBase) => {
+  const timer = buildManualTimer(t.log);
+  const services = await setupServices(t, initialPrice, priceBase, timer);
+
+  const { zoe, aeth, run } = t.context;
+  const {
+    vaultFactory: { lender, vaultFactory },
+    priceAuthority,
+  } = services;
+  const managerNotifier = await makeNotifierFromSubscriber(
+    E(E(lender).getCollateralManager(aeth.brand)).getSubscriber(),
+  );
+  let managerNotification = await E(managerNotifier).getUpdateSince();
+
+  /** @type {UserSeat} */
+  let currentSeat;
+  let notification = {};
+  let currentOfferResult;
+  /**
+   *
+   * @param {Amount<'nat'>} collateral
+   * @param {Amount<'nat'>} debt
+   */
+  const makeVaultDriver = async (collateral, debt) => {
+    /** @type {UserSeat<VaultKit>} */
+    const vaultSeat = await E(zoe).offer(
+      await E(lender).makeVaultInvitation(),
+      harden({
+        give: { Collateral: collateral },
+        want: { RUN: debt },
+      }),
+      harden({
+        Collateral: aeth.mint.mintPayment(collateral),
+      }),
+    );
+    const {
+      vault,
+      publicNotifiers: { vault: notifier },
+    } = await E(vaultSeat).getOfferResult();
+    t.true(await E(vaultSeat).hasExited());
+    return {
+      vault: () => vault,
+      vaultSeat: () => vaultSeat,
+      notification: () => notification,
+      close: async () => {
+        currentSeat = await E(zoe).offer(E(vault).makeCloseInvitation());
+        currentOfferResult = await E(currentSeat).getOfferResult();
+        t.is(
+          currentOfferResult,
+          'your loan is closed, thank you for your business',
+        );
+        t.truthy(await E(vaultSeat).hasExited());
+      },
+      /**
+       *
+       * @param {import('../../src/vaultFactory/vault.js').VaultPhase} phase
+       * @param {object} [likeExpected]
+       * @param {AT_NEXT|number} [optSince] AT_NEXT is an alias for updateCount of the last update, forcing to wait for another
+       */
+      notified: async (phase, likeExpected, optSince) => {
+        notification = await E(notifier).getUpdateSince(
+          optSince === AT_NEXT ? notification.updateCount : optSince,
+        );
+        t.is(notification.value.vaultState, phase);
+        if (likeExpected) {
+          t.like(notification.value, likeExpected);
+        }
+        return notification;
+      },
+      checkBorrowed: async (loanAmount, loanFee) => {
+        const debtAmount = await E(vault).getCurrentDebt();
+        const fee = ceilMultiplyBy(loanAmount, loanFee);
+        t.deepEqual(
+          debtAmount,
+          AmountMath.add(loanAmount, fee),
+          'borrower RUN amount does not match',
+        );
+        return debtAmount;
+      },
+      checkBalance: async (expectedDebt, expectedAEth) => {
+        t.deepEqual(await E(vault).getCurrentDebt(), expectedDebt);
+        t.deepEqual(await E(vault).getCollateralAmount(), expectedAEth);
+      },
+    };
+  };
+
+  const driver = {
+    managerNotification: () => managerNotification,
+    currentSeat: () => currentSeat,
+    lastOfferResult: () => currentOfferResult,
+    timer: () => timer,
+    tick: async (ticks = 1) => {
+      await timer.tickN(ticks, 'TestLiq driver');
+    },
+    makeVaultDriver,
+    checkPayouts: async (expectedRUN, expectedAEth) => {
+      const payouts = await E(currentSeat).getPayouts();
+      const collProceeds = await aeth.issuer.getAmountOf(payouts.Collateral);
+      const runProceeds = await E(run.issuer).getAmountOf(payouts.RUN);
+      t.deepEqual(runProceeds, expectedRUN);
+      t.deepEqual(collProceeds, expectedAEth);
+    },
+    checkRewards: async expectedRUN => {
+      t.deepEqual(await E(vaultFactory).getRewardAllocation(), {
+        RUN: expectedRUN,
+      });
+    },
+    sellOnAMM: async (give, want, optStopAfter, expected) => {
+      const swapInvitation = E(
+        services.ammFacets.ammPublicFacet,
+      ).makeSwapInvitation();
+      trace(t, 'AMM sell', { give, want, optStopAfter });
+      const offerArgs = optStopAfter
+        ? harden({ stopAfter: optStopAfter })
+        : undefined;
+      currentSeat = await E(zoe).offer(
+        await swapInvitation,
+        harden({ give: { In: give }, want: { Out: want } }),
+        harden({ In: aeth.mint.mintPayment(give) }),
+        offerArgs,
+      );
+      currentOfferResult = await E(currentSeat).getOfferResult();
+      if (expected) {
+        const payouts = await E(currentSeat).getCurrentAllocation();
+        trace(t, 'AMM payouts', payouts);
+        t.like(payouts, expected);
+      }
+    },
+    setPrice: p => priceAuthority.setPrice(makeRatioFromAmounts(p, priceBase)),
+    // setLiquidationTerms('MaxImpactBP', 80n)
+    setLiquidationTerms: async (name, newValue) => {
+      const deadline = 3n;
+      const { cast, outcome } = await E(t.context.committee).changeParam(
+        harden({
+          paramPath: { key: 'governedParams' },
+          changes: { [name]: newValue },
+        }),
+        deadline,
+      );
+      await cast;
+      await driver.tick(3);
+      await outcome;
+    },
+    /**
+     *
+     * @param {object} [likeExpected]
+     * @param {AT_NEXT|number} [optSince] AT_NEXT is an alias for updateCount of the last update, forcing to wait for another
+     */
+    managerNotified: async (likeExpected, optSince) => {
+      managerNotification = await E(managerNotifier).getUpdateSince(
+        optSince === AT_NEXT ? managerNotification.updateCount : optSince,
+      );
+      trace(t, 'manager notifier', managerNotification);
+      if (likeExpected) {
+        t.like(managerNotification.value, likeExpected);
+      }
+      return managerNotification;
+    },
+    checkReserveAllocation: async (liquidityValue, stableValue) => {
+      const { reserveCreatorFacet } = t.context;
+      const reserveAllocations = await E(reserveCreatorFacet).getAllocations();
+
+      const liquidityIssuer = await E(
+        services.ammFacets.ammPublicFacet,
+      ).getLiquidityIssuer(aeth.brand);
+      const liquidityBrand = await E(liquidityIssuer).getBrand();
+
+      t.deepEqual(reserveAllocations, {
+        RaEthLiquidity: AmountMath.make(liquidityBrand, liquidityValue),
+        RUN: run.make(stableValue),
+      });
+    },
+  };
+  return driver;
+};

--- a/packages/run-protocol/test/vaultFactory/test-liquidator.js
+++ b/packages/run-protocol/test/vaultFactory/test-liquidator.js
@@ -162,7 +162,7 @@ test('update liquidator', async t => {
   let govNotify = await d.managerNotified();
   const oldLiquidator = govNotify.value.liquidatorInstance;
   trace(t, 'gov start', oldLiquidator, govNotify);
-  await d.setLiquidationTerms(
+  await d.setGovernedParam(
     'LiquidationTerms',
     harden({
       MaxImpactBP: 80n,

--- a/packages/run-protocol/test/vaultFactory/test-liquidator.js
+++ b/packages/run-protocol/test/vaultFactory/test-liquidator.js
@@ -3,525 +3,30 @@
 import '@agoric/zoe/exported.js';
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
-import { makeNotifierFromSubscriber } from '@agoric/notifier';
-import {
-  ceilMultiplyBy,
-  makeRatioFromAmounts,
-} from '@agoric/zoe/src/contractSupport/index.js';
+import { ceilMultiplyBy } from '@agoric/zoe/src/contractSupport/index.js';
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
-import { makeManualPriceAuthority } from '@agoric/zoe/tools/manualPriceAuthority.js';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
-import { deeplyFulfilled } from '@endo/marshal';
-import * as Collect from '../../src/collect.js';
 import { makeTracer } from '../../src/makeTracer.js';
-import {
-  setupAmm,
-  setupReserve,
-  startEconomicCommittee,
-  startVaultFactory,
-} from '../../src/proposals/econ-behaviors.js';
 import '../../src/vaultFactory/types.js';
-import { unsafeMakeBundleCache } from '../bundleTool.js';
 import {
-  installGovernance,
-  makeVoterTool,
-  setupBootstrap,
-  setUpZoeForTest,
-  withAmountUtils,
-} from '../supports.js';
+  AT_NEXT,
+  makeManagerDriver,
+  makeDriverContext,
+  Phase,
+} from './driver.js';
 
-/** @typedef {Record<string, any> & {
- *   aeth: IssuerKit & import('../supports.js').AmountUtils,
- *   reserveCreatorFacet: AssetReserveCreatorFacet,
- *   run: IssuerKit & import('../supports.js').AmountUtils,
+/** @typedef {import('./driver.js').DriverContext & {
  * }} Context */
 /** @type {import('ava').TestInterface<Context>} */
 // @ts-expect-error cast
 const test = unknownTest;
 
-// #region Support
-
-// TODO path resolve these so refactors detect
-const contractRoots = {
-  faucet: './test/vaultFactory/faucet.js',
-  liquidate: './src/vaultFactory/liquidateIncrementally.js',
-  VaultFactory: './src/vaultFactory/vaultFactory.js',
-  amm: './src/vpool-xyk-amm/multipoolMarketMaker.js',
-  reserve: './src/reserve/assetReserve.js',
-};
-
-/** @typedef {import('../../src/vaultFactory/vaultFactory').VaultFactoryContract} VFC */
-
 const trace = makeTracer('TestLiq');
 
-const BASIS_POINTS = 10000n;
-
-// Define locally to test that vaultFactory uses these values
-export const Phase = /** @type {const} */ ({
-  ACTIVE: 'active',
-  LIQUIDATING: 'liquidating',
-  CLOSED: 'closed',
-  LIQUIDATED: 'liquidated',
-  TRANSFER: 'transfer',
-});
-
-/**
- * dL: 1M, lM: 105%, lP: 10%, iR: 100, lF: 500
- *
- * @param {import('../supports.js').AmountUtils} debt
- */
-const defaultParamValues = debt =>
-  harden({
-    debtLimit: debt.make(1_000_000n),
-    // margin required to maintain a loan
-    liquidationMargin: debt.makeRatio(105n),
-    // penalty upon liquidation as proportion of debt
-    liquidationPenalty: debt.makeRatio(10n),
-    // periodic interest rate (per charging period)
-    interestRate: debt.makeRatio(100n, BASIS_POINTS),
-    // charge to create or increase loan balance
-    loanFee: debt.makeRatio(500n, BASIS_POINTS),
-  });
-
 test.before(async t => {
-  const { zoe, feeMintAccess } = setUpZoeForTest();
-  const runIssuer = await E(zoe).getFeeIssuer();
-  const runBrand = await E(runIssuer).getBrand();
-  const run = withAmountUtils({ issuer: runIssuer, brand: runBrand });
-  const aeth = withAmountUtils(makeIssuerKit('aEth'));
-  const bundleCache = await unsafeMakeBundleCache('./bundles/'); // package-relative
-
-  // note that the liquidation might be a different bundle name
-  // Collect.mapValues(contractRoots, (root, k) => loader.load(root, k)),
-  const bundles = await Collect.allValues({
-    faucet: bundleCache.load(contractRoots.faucet, 'faucet'),
-    liquidate: bundleCache.load(
-      contractRoots.liquidate,
-      'liquidateIncrementally',
-    ),
-    VaultFactory: bundleCache.load(contractRoots.VaultFactory, 'VaultFactory'),
-    amm: bundleCache.load(contractRoots.amm, 'amm'),
-    reserve: bundleCache.load(contractRoots.reserve, 'reserve'),
-  });
-  const installation = Collect.mapValues(bundles, bundle =>
-    E(zoe).install(bundle),
-  );
-  const contextPs = {
-    bundles,
-    installation,
-    zoe,
-    feeMintAccess,
-    loanTiming: {
-      chargingPeriod: 2n,
-      recordingPeriod: 6n,
-    },
-    minInitialDebt: 50n,
-    rates: defaultParamValues(run),
-    runInitialLiquidity: run.make(1_500_000_000n),
-    aethInitialLiquidity: AmountMath.make(aeth.brand, 900_000_000n),
-  };
-  const frozenCtx = await deeplyFulfilled(harden(contextPs));
-  t.context = { ...frozenCtx, bundleCache, run, aeth };
+  t.context = await makeDriverContext();
   trace(t, 'CONTEXT');
 });
-
-/**
- * @param {import('ava').ExecutionContext<Context>} t
- * @param {any} aethLiquidity
- * @param {any} runLiquidity
- */
-const setupAmmAndElectorate = async (t, aethLiquidity, runLiquidity) => {
-  const {
-    zoe,
-    aeth,
-    electorateTerms = { committeeName: 'The Cabal', committeeSize: 1 },
-    timer,
-  } = t.context;
-
-  const space = setupBootstrap(t, timer);
-  const { consume, instance } = space;
-  installGovernance(zoe, space.installation.produce);
-  // TODO consider using produceInstallations()
-  space.installation.produce.amm.resolve(t.context.installation.amm);
-  space.installation.produce.reserve.resolve(t.context.installation.reserve);
-  await startEconomicCommittee(space, {
-    options: { econCommitteeOptions: electorateTerms },
-  });
-  await setupAmm(space, {
-    options: { minInitialPoolLiquidity: 1000n },
-  });
-  await setupReserve(space);
-
-  const governorCreatorFacet = consume.ammGovernorCreatorFacet;
-  const governorInstance = await instance.consume.ammGovernor;
-  const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
-  const governedInstance = E(governorPublicFacet).getGovernedContract();
-
-  const counter = await space.installation.consume.binaryVoteCounter;
-  t.context.committee = makeVoterTool(
-    zoe,
-    space.consume.economicCommitteeCreatorFacet,
-    space.consume.vaultFactoryGovernorCreator,
-    counter,
-  );
-
-  /** @type { GovernedPublicFacet<XYKAMMPublicFacet> } */
-  // @ts-expect-error cast from unknown
-  const ammPublicFacet = await E(governorCreatorFacet).getPublicFacet();
-
-  const liquidityIssuer = await E(ammPublicFacet).addIssuer(
-    aeth.issuer,
-    'Aeth',
-  );
-  const liquidityBrand = await E(liquidityIssuer).getBrand();
-
-  const liqProposal = harden({
-    give: {
-      Secondary: aethLiquidity.proposal,
-      Central: runLiquidity.proposal,
-    },
-    want: { Liquidity: AmountMath.makeEmpty(liquidityBrand) },
-  });
-  const liqInvitation = await E(ammPublicFacet).addPoolInvitation();
-
-  const ammLiquiditySeat = await E(zoe).offer(
-    liqInvitation,
-    liqProposal,
-    harden({
-      Secondary: aethLiquidity.payment,
-      Central: runLiquidity.payment,
-    }),
-  );
-
-  // TODO get the creator directly
-  const newAmm = {
-    ammCreatorFacet: await consume.ammCreatorFacet,
-    ammPublicFacet,
-    instance: governedInstance,
-    ammLiquidity: E(ammLiquiditySeat).getPayout('Liquidity'),
-  };
-
-  return { amm: newAmm, space };
-};
-
-/**
- *
- * @param {import('ava').ExecutionContext<Context>} t
- * @param {bigint} runInitialLiquidity
- */
-const getRunFromFaucet = async (t, runInitialLiquidity) => {
-  const {
-    installation: { faucet: installation },
-    zoe,
-    feeMintAccess,
-  } = t.context;
-  /** @type {Promise<Installation<import('./faucet.js').start>>} */
-  // @ts-expect-error cast
-  // On-chain, there will be pre-existing RUN. The faucet replicates that
-  const { creatorFacet: faucetCreator } = await E(zoe).startInstance(
-    installation,
-    {},
-    {},
-    harden({ feeMintAccess }),
-  );
-  const faucetSeat = E(zoe).offer(
-    await E(faucetCreator).makeFaucetInvitation(),
-    harden({
-      give: {},
-      want: { RUN: runInitialLiquidity },
-    }),
-  );
-
-  const runPayment = await E(faucetSeat).getPayout('RUN');
-  return runPayment;
-};
-
-/**
- * NOTE: called separately by each test so AMM/zoe/priceAuthority don't interfere
- *
- * @param {import('ava').ExecutionContext} t
- * @param {Amount} initialPrice
- * @param {Amount} priceBase
- * @param {TimerService} timer
- */
-const setupServices = async (
-  t,
-  initialPrice,
-  priceBase,
-  timer = buildManualTimer(t.log),
-) => {
-  const {
-    zoe,
-    run,
-    aeth,
-    loanTiming,
-    minInitialDebt,
-    rates,
-    aethInitialLiquidity,
-    runInitialLiquidity,
-  } = t.context;
-  t.context.timer = timer;
-
-  const runPayment = await getRunFromFaucet(t, runInitialLiquidity);
-  trace(t, 'faucet', { runInitialLiquidity, runPayment });
-  const runLiquidity = {
-    proposal: runInitialLiquidity,
-    payment: runPayment,
-  };
-  const aethLiquidity = {
-    proposal: aethInitialLiquidity,
-    payment: aeth.mint.mintPayment(aethInitialLiquidity),
-  };
-  const { amm: ammFacets, space } = await setupAmmAndElectorate(
-    t,
-    aethLiquidity,
-    runLiquidity,
-  );
-  const { consume, produce } = space;
-  trace(t, 'amm', { ammFacets });
-
-  // Cheesy hack for easy use of manual price authority
-  const priceAuthority = makeManualPriceAuthority({
-    actualBrandIn: aeth.brand,
-    actualBrandOut: run.brand,
-    initialPrice: makeRatioFromAmounts(initialPrice, priceBase),
-    timer,
-    quoteIssuerKit: makeIssuerKit('quote', AssetKind.SET),
-  });
-  produce.priceAuthority.resolve(priceAuthority);
-
-  const {
-    installation: { produce: iProduce },
-  } = space;
-  t.context.reserveCreatorFacet = space.consume.reserveCreatorFacet;
-  iProduce.VaultFactory.resolve(t.context.installation.VaultFactory);
-  iProduce.liquidate.resolve(t.context.installation.liquidate);
-  await startVaultFactory(space, { loanParams: loanTiming }, minInitialDebt);
-
-  const governorCreatorFacet = consume.vaultFactoryGovernorCreator;
-  /** @type {Promise<VaultFactory & LimitedCreatorFacet<any>>} */
-  const vaultFactoryCreatorFacet = /** @type { any } */ (
-    E(governorCreatorFacet).getCreatorFacet()
-  );
-
-  // Add a vault that will lend on aeth collateral
-  const aethVaultManagerP = E(vaultFactoryCreatorFacet).addVaultType(
-    aeth.issuer,
-    'AEth',
-    rates,
-  );
-
-  /** @type {[any, VaultFactory, VFC['publicFacet'], VaultManager]} */
-  // @ts-expect-error cast
-  const [governorInstance, vaultFactory, lender, aethVaultManager] =
-    await Promise.all([
-      E(consume.agoricNames).lookup('instance', 'VaultFactoryGovernor'),
-      vaultFactoryCreatorFacet,
-      E(governorCreatorFacet).getPublicFacet(),
-      aethVaultManagerP,
-    ]);
-  trace(t, 'pa', { governorInstance, vaultFactory, lender, priceAuthority });
-
-  return {
-    zoe,
-    // installs,
-    governor: {
-      governorInstance,
-      governorPublicFacet: E(zoe).getPublicFacet(governorInstance),
-      governorCreatorFacet,
-    },
-    vaultFactory: {
-      vaultFactory,
-      lender,
-      aethVaultManager,
-    },
-    ammFacets,
-    priceAuthority,
-  };
-};
-// #endregion
-
-// #region driver
-const AT_NEXT = {};
-
-/**
- * @param {import('ava').ExecutionContext<Context>} t
- * @param {Amount<'nat'>} initialPrice
- * @param {Amount<'nat'>} priceBase
- */
-const makeDriver = async (t, initialPrice, priceBase) => {
-  const timer = buildManualTimer(t.log);
-  const services = await setupServices(t, initialPrice, priceBase, timer);
-
-  const { zoe, aeth, run } = t.context;
-  const {
-    vaultFactory: { lender, vaultFactory },
-    priceAuthority,
-  } = services;
-  const managerNotifier = await makeNotifierFromSubscriber(
-    E(E(lender).getCollateralManager(aeth.brand)).getSubscriber(),
-  );
-  let managerNotification = await E(managerNotifier).getUpdateSince();
-
-  /** @type {UserSeat} */
-  let currentSeat;
-  let notification = {};
-  let currentOfferResult;
-  const makeVaultDriver = async (collateral, debt) => {
-    /** @type {UserSeat<VaultKit>} */
-    const vaultSeat = await E(zoe).offer(
-      await E(lender).makeVaultInvitation(),
-      harden({
-        give: { Collateral: collateral },
-        want: { RUN: debt },
-      }),
-      harden({
-        Collateral: aeth.mint.mintPayment(collateral),
-      }),
-    );
-    const {
-      vault,
-      publicNotifiers: { vault: notifier },
-    } = await E(vaultSeat).getOfferResult();
-    t.true(await E(vaultSeat).hasExited());
-    return {
-      vault: () => vault,
-      vaultSeat: () => vaultSeat,
-      notification: () => notification,
-      close: async () => {
-        currentSeat = await E(zoe).offer(E(vault).makeCloseInvitation());
-        currentOfferResult = await E(currentSeat).getOfferResult();
-        t.is(
-          currentOfferResult,
-          'your loan is closed, thank you for your business',
-        );
-        t.truthy(await E(vaultSeat).hasExited());
-      },
-      /**
-       *
-       * @param {import('../../src/vaultFactory/vault.js').VaultPhase} phase
-       * @param {object} [likeExpected]
-       * @param {AT_NEXT|number} [optSince] AT_NEXT is an alias for updateCount of the last update, forcing to wait for another
-       */
-      notified: async (phase, likeExpected, optSince) => {
-        notification = await E(notifier).getUpdateSince(
-          optSince === AT_NEXT ? notification.updateCount : optSince,
-        );
-        t.is(notification.value.vaultState, phase);
-        if (likeExpected) {
-          t.like(notification.value, likeExpected);
-        }
-        return notification;
-      },
-      checkBorrowed: async (loanAmount, loanFee) => {
-        const debtAmount = await E(vault).getCurrentDebt();
-        const fee = ceilMultiplyBy(loanAmount, loanFee);
-        t.deepEqual(
-          debtAmount,
-          AmountMath.add(loanAmount, fee),
-          'borrower RUN amount does not match',
-        );
-        return debtAmount;
-      },
-      checkBalance: async (expectedDebt, expectedAEth) => {
-        t.deepEqual(await E(vault).getCurrentDebt(), expectedDebt);
-        t.deepEqual(await E(vault).getCollateralAmount(), expectedAEth);
-      },
-    };
-  };
-
-  const driver = {
-    managerNotification: () => managerNotification,
-    currentSeat: () => currentSeat,
-    lastOfferResult: () => currentOfferResult,
-    timer: () => timer,
-    tick: async (ticks = 1) => {
-      await timer.tickN(ticks, 'TestLiq driver');
-    },
-    makeVaultDriver,
-    checkPayouts: async (expectedRUN, expectedAEth) => {
-      const payouts = await E(currentSeat).getPayouts();
-      const collProceeds = await aeth.issuer.getAmountOf(payouts.Collateral);
-      const runProceeds = await E(run.issuer).getAmountOf(payouts.RUN);
-      t.deepEqual(runProceeds, expectedRUN);
-      t.deepEqual(collProceeds, expectedAEth);
-    },
-    checkRewards: async expectedRUN => {
-      t.deepEqual(await E(vaultFactory).getRewardAllocation(), {
-        RUN: expectedRUN,
-      });
-    },
-    sellOnAMM: async (give, want, optStopAfter, expected) => {
-      const swapInvitation = E(
-        services.ammFacets.ammPublicFacet,
-      ).makeSwapInvitation();
-      trace(t, 'AMM sell', { give, want, optStopAfter });
-      const offerArgs = optStopAfter
-        ? harden({ stopAfter: optStopAfter })
-        : undefined;
-      currentSeat = await E(zoe).offer(
-        await swapInvitation,
-        harden({ give: { In: give }, want: { Out: want } }),
-        harden({ In: aeth.mint.mintPayment(give) }),
-        offerArgs,
-      );
-      currentOfferResult = await E(currentSeat).getOfferResult();
-      if (expected) {
-        const payouts = await E(currentSeat).getCurrentAllocation();
-        trace(t, 'AMM payouts', payouts);
-        t.like(payouts, expected);
-      }
-    },
-    setPrice: p => priceAuthority.setPrice(makeRatioFromAmounts(p, priceBase)),
-    // setLiquidationTerms('MaxImpactBP', 80n)
-    setLiquidationTerms: async (name, newValue) => {
-      const deadline = 3n;
-      const { cast, outcome } = await E(t.context.committee).changeParam(
-        harden({
-          paramPath: { key: 'governedParams' },
-          changes: { [name]: newValue },
-        }),
-        deadline,
-      );
-      await cast;
-      await driver.tick(3);
-      await outcome;
-    },
-    /**
-     *
-     * @param {object} [likeExpected]
-     * @param {AT_NEXT|number} [optSince] AT_NEXT is an alias for updateCount of the last update, forcing to wait for another
-     */
-    managerNotified: async (likeExpected, optSince) => {
-      managerNotification = await E(managerNotifier).getUpdateSince(
-        optSince === AT_NEXT ? managerNotification.updateCount : optSince,
-      );
-      trace(t, 'manager notifier', managerNotification);
-      if (likeExpected) {
-        t.like(managerNotification.value, likeExpected);
-      }
-      return managerNotification;
-    },
-    checkReserveAllocation: async (liquidityValue, stableValue) => {
-      const { reserveCreatorFacet } = t.context;
-      const reserveAllocations = await E(reserveCreatorFacet).getAllocations();
-
-      const liquidityIssuer = await E(
-        services.ammFacets.ammPublicFacet,
-      ).getLiquidityIssuer(aeth.brand);
-      const liquidityBrand = await E(liquidityIssuer).getBrand();
-
-      t.deepEqual(reserveAllocations, {
-        RaEthLiquidity: AmountMath.make(liquidityBrand, liquidityValue),
-        RUN: run.make(stableValue),
-      });
-    },
-  };
-  return driver;
-};
-// #endregion
 
 test('price drop', async t => {
   const { aeth, run, rates } = t.context;
@@ -534,7 +39,7 @@ test('price drop', async t => {
     recordingPeriod: 10n,
   };
 
-  const d = await makeDriver(t, run.make(1000n), aeth.make(900n));
+  const d = await makeManagerDriver(t, run.make(1000n), aeth.make(900n));
   // Create a loan for 270 RUN with 400 aeth collateral
   const collateralAmount = aeth.make(400n);
   const loanAmount = run.make(270n);
@@ -586,7 +91,7 @@ test('price falls precipitously', async t => {
     recordingPeriod: 10n,
   };
 
-  const d = await makeDriver(t, run.make(2200n), aeth.make(900n));
+  const d = await makeManagerDriver(t, run.make(2200n), aeth.make(900n));
   // Create a loan for 370 RUN with 400 aeth collateral
   const collateralAmount = aeth.make(400n);
   const loanAmount = run.make(370n);
@@ -646,7 +151,7 @@ test('update liquidator', async t => {
   t.context.runInitialLiquidity = debt.make(500_000_000n);
   t.context.aethInitialLiquidity = aeth.make(100_000_000n);
 
-  const d = await makeDriver(t, debt.make(500n), aeth.make(100n));
+  const d = await makeManagerDriver(t, debt.make(500n), aeth.make(100n));
   const loanAmount = debt.make(300n);
   const collateralAmount = aeth.make(100n);
   /* * @type {UserSeat<VaultKit>} */
@@ -689,7 +194,7 @@ test('liquidate many', async t => {
       run.makeRatio(300n),
     );
   };
-  const d = await makeDriver(t, run.make(1500n), aeth.make(900n));
+  const d = await makeManagerDriver(t, run.make(1500n), aeth.make(900n));
   const collateral = aeth.make(300n);
   const dv0 = await d.makeVaultDriver(collateral, run.make(390n));
   const dv1 = await d.makeVaultDriver(collateral, run.make(380n));
@@ -739,7 +244,7 @@ test('liquidate many', async t => {
 // 1) `give` sells for more than `stopAfter`, and got some of the input back
 test('amm stopAfter - input back', async t => {
   const { aeth, run } = t.context;
-  const d = await makeDriver(t, run.make(2_199n), aeth.make(999n));
+  const d = await makeManagerDriver(t, run.make(2_199n), aeth.make(999n));
   const give = aeth.make(100n);
   const want = run.make(80n);
   const stopAfter = run.make(100n);
@@ -755,7 +260,7 @@ test('amm stopAfter - input back', async t => {
 test('amm stopAfter - shortfall', async t => {
   const { aeth, run } = t.context;
   // uses off-by-one amounts to force rounding errors
-  const d = await makeDriver(t, run.make(2_199n), aeth.make(999n));
+  const d = await makeManagerDriver(t, run.make(2_199n), aeth.make(999n));
   const give = aeth.make(100n);
   const want = run.make(80n);
   // 164 is the most I could get
@@ -773,7 +278,7 @@ test('amm stopAfter - shortfall', async t => {
 test('amm stopAfter - want too much', async t => {
   const { aeth, run } = t.context;
   // uses off-by-one amounts to force rounding errors
-  const d = await makeDriver(t, run.make(2_199n), aeth.make(999n));
+  const d = await makeManagerDriver(t, run.make(2_199n), aeth.make(999n));
   const give = aeth.make(100n);
   const want = run.make(170n);
   const stopAfter = run.make(180n);
@@ -788,7 +293,7 @@ test('amm stopAfter - want too much', async t => {
 test('penalties to reserve', async t => {
   const { aeth, run } = t.context;
 
-  const d = await makeDriver(t, run.make(1000n), aeth.make(900n));
+  const d = await makeManagerDriver(t, run.make(1000n), aeth.make(900n));
   // Create a loan for 270 RUN with 400 aeth collateral
   const collateralAmount = aeth.make(400n);
   const loanAmount = run.make(270n);

--- a/packages/run-protocol/test/vaultFactory/test-storage.js
+++ b/packages/run-protocol/test/vaultFactory/test-storage.js
@@ -67,4 +67,17 @@ test('storage keys', async t => {
     'mockChainStorageRoot.vaultFactory.manager1.governance',
   );
 
+  // First aeth vault
+  const vda1 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
+  t.is(
+    await subscriptionKey(vda1.getVaultSubscriber()),
+    'mockChainStorageRoot.vaultFactory.manager0.vaults.vault1',
+  );
+
+  // Second aeth vault
+  const vda2 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
+  t.is(
+    await subscriptionKey(vda2.getVaultSubscriber()),
+    'mockChainStorageRoot.vaultFactory.manager0.vaults.vault2',
+  );
 });

--- a/packages/run-protocol/test/vaultFactory/test-storage.js
+++ b/packages/run-protocol/test/vaultFactory/test-storage.js
@@ -1,0 +1,70 @@
+// @ts-check
+
+import '@agoric/zoe/exported.js';
+import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { E } from '@endo/eventual-send';
+import { makeTracer } from '../../src/makeTracer.js';
+import '../../src/vaultFactory/types.js';
+import { subscriptionKey } from '../supports.js';
+import { makeDriverContext, makeManagerDriver } from './driver.js';
+
+/** @typedef {import('./driver.js').DriverContext & {
+ * }} Context */
+/** @type {import('ava').TestInterface<Context>} */
+// @ts-expect-error cast
+const test = unknownTest;
+
+const trace = makeTracer('TestLiq');
+
+test.before(async t => {
+  t.context = await makeDriverContext();
+  trace(t, 'CONTEXT');
+});
+
+test('storage keys', async t => {
+  const { aeth, run } = t.context;
+  const d = await makeManagerDriver(t);
+
+  // Root vault factory
+  const vdp = d.getVaultDirectorPublic();
+  t.is(
+    await subscriptionKey(E(vdp).getMetrics()),
+    'mockChainStorageRoot.vaultFactory.metrics',
+  );
+  t.is(
+    await subscriptionKey(E(vdp).getElectorateSubscription()),
+    'mockChainStorageRoot.vaultFactory.governance',
+  );
+
+  // First manager
+  const managerA = await E(vdp).getCollateralManager(aeth.brand);
+  t.is(
+    await subscriptionKey(E(managerA).getMetrics()),
+    'mockChainStorageRoot.vaultFactory.manager0.metrics',
+  );
+  t.is(
+    await subscriptionKey(
+      E(vdp).getSubscription({
+        collateralBrand: aeth.brand,
+      }),
+    ),
+    'mockChainStorageRoot.vaultFactory.manager0.governance',
+  );
+
+  // Second manager
+  const [managerC, chit] = await d.addVaultType('Chit');
+  t.is(
+    await subscriptionKey(E(E(managerC).getPublicFacet()).getMetrics()),
+    'mockChainStorageRoot.vaultFactory.manager1.metrics',
+  );
+  t.is(
+    await subscriptionKey(
+      E(vdp).getSubscription({
+        collateralBrand: chit.brand,
+      }),
+    ),
+    'mockChainStorageRoot.vaultFactory.manager1.governance',
+  );
+
+});

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -45,7 +45,6 @@ import {
   setUpZoeForTest,
   withAmountUtils,
   produceInstallations,
-  subscriptionKey,
 } from '../supports.js';
 import { unsafeMakeBundleCache } from '../bundleTool.js';
 import {
@@ -2470,64 +2469,6 @@ test('addVaultType: extra, unexpected params', async t => {
     extraParams,
   );
   t.true(matches(actual, M.remotable()), 'unexpected params are ignored');
-});
-
-test('storage keys', async t => {
-  const { aeth } = t.context;
-  const services = await setupServices(
-    t,
-    [500n, 15n],
-    aeth.make(900n),
-    undefined,
-    undefined,
-    500n,
-  );
-
-  // Root vault factory
-  const { lender, vaultFactory } = services.vaultFactory;
-  t.is(
-    await subscriptionKey(E(lender).getMetrics()),
-    'mockChainStorageRoot.vaultFactory.metrics',
-  );
-  t.is(
-    await subscriptionKey(E(lender).getElectorateSubscription()),
-    'mockChainStorageRoot.vaultFactory.governance',
-  );
-
-  // First manager
-  const manager0 = await E(lender).getCollateralManager(aeth.brand);
-  t.is(
-    await subscriptionKey(E(manager0).getMetrics()),
-    'mockChainStorageRoot.vaultFactory.manager0.metrics',
-  );
-  t.is(
-    await subscriptionKey(
-      E(lender).getSubscription({
-        collateralBrand: aeth.brand,
-      }),
-    ),
-    'mockChainStorageRoot.vaultFactory.manager0.governance',
-  );
-
-  // Second manager
-  const chit = makeIssuerKit('chit');
-  const manager1 = await E(vaultFactory).addVaultType(
-    chit.issuer,
-    'Chit',
-    defaultParamValues(chit.brand),
-  );
-  t.is(
-    await subscriptionKey(E(E(manager1).getPublicFacet()).getMetrics()),
-    'mockChainStorageRoot.vaultFactory.manager1.metrics',
-  );
-  t.is(
-    await subscriptionKey(
-      E(lender).getSubscription({
-        collateralBrand: chit.brand,
-      }),
-    ),
-    'mockChainStorageRoot.vaultFactory.manager1.governance',
-  );
 });
 
 test('director notifiers', async t => {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "react": "^16.14.0",
     "react-dom": "^16.8.0",
-    "typescript": "~4.7.2"
+    "typescript": "~4.7.4"
   },
   "ava": {
     "files": [

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -51,7 +51,7 @@
     "@babel/core": "^7.12.13",
     "@babel/plugin-syntax-jsx": "^7.12.1",
     "@material-ui/core": "4.11.3",
-    "@typescript-eslint/eslint-plugin": "^5.27.0",
+    "@typescript-eslint/eslint-plugin": "^5.30.7",
     "ava": "^3.15.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-named-asset-import": "^0.3.7",

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -34,7 +34,7 @@ export function makeChainStorageRoot(toStorage, storeName, rootPath) {
         assert.typeof(name, 'string');
         assert(
           pathSegmentPattern.test(name),
-          X`Path segment must be a short ASCII identifier: ${name}`,
+          X`Path segment must be a short snake_case alphanumeric identifier: ${name}`,
         );
         return makeChainStorageNode(`${path}.${name}`);
       },

--- a/scripts/lint-with-types.sh
+++ b/scripts/lint-with-types.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 # we don't collect type info by default because it can slow eslint by 8-10x
-export AGORIC_ESLINT_TYPES='true'
+# FIXME even in CI it has become too slow so disable until https://github.com/Agoric/agoric-sdk/issues/5788
+# export AGORIC_ESLINT_TYPES='keypresent'
+
 # CI and some VMs OOM without this
 export NODE_OPTIONS='--max-old-space-size=8192'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4284,14 +4284,14 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^5.27.0", "@typescript-eslint/eslint-plugin@^5.5.0":
-  version "5.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.0.tgz#23d82a4f21aaafd8f69dbab7e716323bb6695cc8"
-  integrity sha512-DDrIA7GXtmHXr1VCcx9HivA39eprYBIFxbQEHI6NyraRDxCGpxAFiYQAT/1Y0vh1C+o2vfBiy4IuPoXxtTZCAQ==
+"@typescript-eslint/eslint-plugin@^5.30.7", "@typescript-eslint/eslint-plugin@^5.5.0":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.7.tgz#1621dabc1ae4084310e19e9efc80dfdbb97e7493"
+  integrity sha512-l4L6Do+tfeM2OK0GJsU7TUcM/1oN/N25xHm3Jb4z3OiDU4Lj8dIuxX9LpVMS9riSXQs42D1ieX7b85/r16H9Fw==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.27.0"
-    "@typescript-eslint/type-utils" "5.27.0"
-    "@typescript-eslint/utils" "5.27.0"
+    "@typescript-eslint/scope-manager" "5.30.7"
+    "@typescript-eslint/type-utils" "5.30.7"
+    "@typescript-eslint/utils" "5.30.7"
     debug "^4.3.4"
     functional-red-black-tree "^1.0.1"
     ignore "^5.2.0"
@@ -4299,14 +4299,14 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.27.0", "@typescript-eslint/parser@^5.5.0":
-  version "5.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.27.0.tgz#62bb091ed5cf9c7e126e80021bb563dcf36b6b12"
-  integrity sha512-8oGjQF46c52l7fMiPPvX4It3u3V3JipssqDfHQ2hcR0AeR8Zge+OYyKUCm5b70X72N1qXt0qgHenwN6Gc2SXZA==
+"@typescript-eslint/parser@^5.30.7", "@typescript-eslint/parser@^5.5.0":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.30.7.tgz#99d09729392aec9e64b1de45cd63cb81a4ddd980"
+  integrity sha512-Rg5xwznHWWSy7v2o0cdho6n+xLhK2gntImp0rJroVVFkcYFYQ8C8UJTSuTw/3CnExBmPjycjmUJkxVmjXsld6A==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.27.0"
-    "@typescript-eslint/types" "5.27.0"
-    "@typescript-eslint/typescript-estree" "5.27.0"
+    "@typescript-eslint/scope-manager" "5.30.7"
+    "@typescript-eslint/types" "5.30.7"
+    "@typescript-eslint/typescript-estree" "5.30.7"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.27.0":
@@ -4317,6 +4317,14 @@
     "@typescript-eslint/types" "5.27.0"
     "@typescript-eslint/visitor-keys" "5.27.0"
 
+"@typescript-eslint/scope-manager@5.30.7":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.30.7.tgz#8269a931ef1e5ae68b5eb80743cc515c4ffe3dd7"
+  integrity sha512-7BM1bwvdF1UUvt+b9smhqdc/eniOnCKxQT/kj3oXtj3LqnTWCAM0qHRHfyzCzhEfWX0zrW7KqXXeE4DlchZBKw==
+  dependencies:
+    "@typescript-eslint/types" "5.30.7"
+    "@typescript-eslint/visitor-keys" "5.30.7"
+
 "@typescript-eslint/type-utils@5.27.0":
   version "5.27.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.27.0.tgz#36fd95f6747412251d79c795b586ba766cf0974b"
@@ -4326,10 +4334,24 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
+"@typescript-eslint/type-utils@5.30.7":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.30.7.tgz#5693dc3db6f313f302764282d614cfdbc8a9fcfd"
+  integrity sha512-nD5qAE2aJX/YLyKMvOU5jvJyku4QN5XBVsoTynFrjQZaDgDV6i7QHFiYCx10wvn7hFvfuqIRNBtsgaLe0DbWhw==
+  dependencies:
+    "@typescript-eslint/utils" "5.30.7"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/types@5.27.0":
   version "5.27.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.27.0.tgz#c3f44b9dda6177a9554f94a74745ca495ba9c001"
   integrity sha512-lY6C7oGm9a/GWhmUDOs3xAVRz4ty/XKlQ2fOLr8GAIryGn0+UBOoJDWyHer3UgrHkenorwvBnphhP+zPmzmw0A==
+
+"@typescript-eslint/types@5.30.7":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.7.tgz#18331487cc92d0f1fb1a6f580c8ec832528079d0"
+  integrity sha512-ocVkETUs82+U+HowkovV6uxf1AnVRKCmDRNUBUUo46/5SQv1owC/EBFkiu4MOHeZqhKz2ktZ3kvJJ1uFqQ8QPg==
 
 "@typescript-eslint/typescript-estree@5.27.0":
   version "5.27.0"
@@ -4344,7 +4366,20 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.27.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.10.2":
+"@typescript-eslint/typescript-estree@5.30.7":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.7.tgz#05da9f1b281985bfedcf62349847f8d168eecc07"
+  integrity sha512-tNslqXI1ZdmXXrHER83TJ8OTYl4epUzJC0aj2i4DMDT4iU+UqLT3EJeGQvJ17BMbm31x5scSwo3hPM0nqQ1AEA==
+  dependencies:
+    "@typescript-eslint/types" "5.30.7"
+    "@typescript-eslint/visitor-keys" "5.30.7"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.27.0":
   version "5.27.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.27.0.tgz#d0021cbf686467a6a9499bd0589e19665f9f7e71"
   integrity sha512-nZvCrkIJppym7cIbP3pOwIkAefXOmfGPnCM0LQfzNaKxJHI6VjI8NC662uoiPlaf5f6ymkTy9C3NQXev2mdXmA==
@@ -4356,12 +4391,32 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/utils@5.30.7", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.10.2":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.30.7.tgz#7135be070349e9f7caa262b0ca59dc96123351bb"
+  integrity sha512-Z3pHdbFw+ftZiGUnm1GZhkJgVqsDL5CYW2yj+TB2mfXDFOMqtbzQi2dNJIyPqPbx9mv2kUxS1gU+r2gKlKi1rQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.30.7"
+    "@typescript-eslint/types" "5.30.7"
+    "@typescript-eslint/typescript-estree" "5.30.7"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@5.27.0":
   version "5.27.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.0.tgz#97aa9a5d2f3df8215e6d3b77f9d214a24db269bd"
   integrity sha512-46cYrteA2MrIAjv9ai44OQDUoCZyHeGIc4lsjCUX2WT6r4C+kidz1bNiR4017wHOPUythYeH+Sc7/cFP97KEAA==
   dependencies:
     "@typescript-eslint/types" "5.27.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.30.7":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.7.tgz#c093abae75b4fd822bfbad9fc337f38a7a14909a"
+  integrity sha512-KrRXf8nnjvcpxDFOKej4xkD7657+PClJs5cJVSG7NNoCNnjEdc46juNAQt7AyuWctuCgs6mVRc1xGctEqrjxWw==
+  dependencies:
+    "@typescript-eslint/types" "5.30.7"
     eslint-visitor-keys "^3.3.0"
 
 "@web/browser-logs@^0.2.1", "@web/browser-logs@^0.2.2":

--- a/yarn.lock
+++ b/yarn.lock
@@ -4309,14 +4309,6 @@
     "@typescript-eslint/typescript-estree" "5.30.7"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.27.0":
-  version "5.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.27.0.tgz#a272178f613050ed62f51f69aae1e19e870a8bbb"
-  integrity sha512-VnykheBQ/sHd1Vt0LJ1JLrMH1GzHO+SzX6VTXuStISIsvRiurue/eRkTqSrG0CexHQgKG8shyJfR4o5VYioB9g==
-  dependencies:
-    "@typescript-eslint/types" "5.27.0"
-    "@typescript-eslint/visitor-keys" "5.27.0"
-
 "@typescript-eslint/scope-manager@5.30.7":
   version "5.30.7"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.30.7.tgz#8269a931ef1e5ae68b5eb80743cc515c4ffe3dd7"
@@ -4324,15 +4316,6 @@
   dependencies:
     "@typescript-eslint/types" "5.30.7"
     "@typescript-eslint/visitor-keys" "5.30.7"
-
-"@typescript-eslint/type-utils@5.27.0":
-  version "5.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.27.0.tgz#36fd95f6747412251d79c795b586ba766cf0974b"
-  integrity sha512-vpTvRRchaf628Hb/Xzfek+85o//zEUotr1SmexKvTfs7czXfYjXVT/a5yDbpzLBX1rhbqxjDdr1Gyo0x1Fc64g==
-  dependencies:
-    "@typescript-eslint/utils" "5.27.0"
-    debug "^4.3.4"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/type-utils@5.30.7":
   version "5.30.7"
@@ -4343,28 +4326,10 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.27.0":
-  version "5.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.27.0.tgz#c3f44b9dda6177a9554f94a74745ca495ba9c001"
-  integrity sha512-lY6C7oGm9a/GWhmUDOs3xAVRz4ty/XKlQ2fOLr8GAIryGn0+UBOoJDWyHer3UgrHkenorwvBnphhP+zPmzmw0A==
-
 "@typescript-eslint/types@5.30.7":
   version "5.30.7"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.7.tgz#18331487cc92d0f1fb1a6f580c8ec832528079d0"
   integrity sha512-ocVkETUs82+U+HowkovV6uxf1AnVRKCmDRNUBUUo46/5SQv1owC/EBFkiu4MOHeZqhKz2ktZ3kvJJ1uFqQ8QPg==
-
-"@typescript-eslint/typescript-estree@5.27.0":
-  version "5.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.0.tgz#7965f5b553c634c5354a47dcce0b40b94611e995"
-  integrity sha512-QywPMFvgZ+MHSLRofLI7BDL+UczFFHyj0vF5ibeChDAJgdTV8k4xgEwF0geFhVlPc1p8r70eYewzpo6ps+9LJQ==
-  dependencies:
-    "@typescript-eslint/types" "5.27.0"
-    "@typescript-eslint/visitor-keys" "5.27.0"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-glob "^4.0.3"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@5.30.7":
   version "5.30.7"
@@ -4379,18 +4344,6 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.27.0":
-  version "5.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.27.0.tgz#d0021cbf686467a6a9499bd0589e19665f9f7e71"
-  integrity sha512-nZvCrkIJppym7cIbP3pOwIkAefXOmfGPnCM0LQfzNaKxJHI6VjI8NC662uoiPlaf5f6ymkTy9C3NQXev2mdXmA==
-  dependencies:
-    "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.27.0"
-    "@typescript-eslint/types" "5.27.0"
-    "@typescript-eslint/typescript-estree" "5.27.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
-
 "@typescript-eslint/utils@5.30.7", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.10.2":
   version "5.30.7"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.30.7.tgz#7135be070349e9f7caa262b0ca59dc96123351bb"
@@ -4402,14 +4355,6 @@
     "@typescript-eslint/typescript-estree" "5.30.7"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
-
-"@typescript-eslint/visitor-keys@5.27.0":
-  version "5.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.0.tgz#97aa9a5d2f3df8215e6d3b77f9d214a24db269bd"
-  integrity sha512-46cYrteA2MrIAjv9ai44OQDUoCZyHeGIc4lsjCUX2WT6r4C+kidz1bNiR4017wHOPUythYeH+Sc7/cFP97KEAA==
-  dependencies:
-    "@typescript-eslint/types" "5.27.0"
-    eslint-visitor-keys "^3.3.0"
 
 "@typescript-eslint/visitor-keys@5.30.7":
   version "5.30.7"
@@ -16980,10 +16925,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.2, typescript@~4.7.2:
+typescript@^4.3.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
   integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
+
+typescript@~4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
refs: #5386 (open until `publicNotifiers` is removed, which won't be this PR)

## Description

Provides vault-level data off-chain. Following on https://github.com/Agoric/agoric-sdk/pull/5704. This exposes the new StoredSubscription. It also adds tests, documentation and type annotations for consuming off-chain.

### Security Considerations

All vault published info gets published to RPC nodes. It's keyed by serial vaultId within a manager, so anyone can read all vault publications. This includes the vault holder even after they're transferred the vault and their own subscription terminates. (The new one tees to the same storage node as before.)

### Documentation Considerations

Added some docs to the package README

### Testing Considerations

- [x] start up an ag-solo, `agoric follow` a vault, and make sure the publications come

 Wrote up and followed steps in README.md. I had to comment out some checks that depended on pricing info that wasn't resolving. Otherwise it's working.
```
❯ agoric follow :published.vaultFactory.manager0.vaults.vault1
SES Lockdown using options from environment variables "LOCKDOWN_ERROR_TAMING"
{
  debtSnapshot: {
    debt: {
      brand: slot(0,"Alleged: RUN brand"),
      value: 2n,
    },
    interest: {
      denominator: {
        brand: slot(0),
        value: 100n,
      },
      numerator: {
        brand: slot(0),
        value: 100n,
      },
    },
  },
  locked: {
    brand: slot(1,"Alleged: IbcATOM brand"),
    value: 1000n,
  },
  vaultState: "active",
}
```