### PR TITLE
fix: SMART_WALLET account flag for smart wallet vs. ag-solo client

### DIFF
--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -16,6 +16,16 @@ const RESERVE_MODULE_ACCOUNT = 'vbank/reserve';
 const RESERVE_ADDRESS = 'agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl';
 
 /**
+ * non-exhaustive list of powerFlags
+ * REMOTE_WALLET is currently a default.
+ */
+const PowerFlags = /** @type {const} */ ({
+  SMART_WALLET: 'SMART_WALLET',
+  /** The ag-solo wallet is remote. */
+  REMOTE_WALLET: 'REMOTE_WALLET',
+});
+
+/**
  * In golang/cosmos/app/app.go, we define
  * cosmosInitAction with type AG_COSMOS_INIT,
  * with the following shape.
@@ -207,11 +217,6 @@ export const makeAddressNameHubs = async ({
 };
 harden(makeAddressNameHubs);
 
-const AccountFlags = /** @type {const} */ ({
-  SMART_WALLET: 'SMART_WALLET', // TODO: make this the default
-  REMOTE_WALLET: 'REMOTE_WALLET',
-});
-
 /** @param {BootstrapSpace} powers */
 export const makeClientBanks = async ({
   consume: {
@@ -238,11 +243,15 @@ export const makeClientBanks = async ({
     { storageNode },
   );
   return E(client).assignBundle([
-    (address, accountFlags) => {
+    (address, powerFlags) => {
       const bank = E(bankManager).getBankForAddress(address);
-      if (!accountFlags.includes(AccountFlags.SMART_WALLET)) {
+      if (!powerFlags.includes(PowerFlags.SMART_WALLET)) {
         return { bank };
       }
+      assert(
+        !powerFlags.includes(PowerFlags.REMOTE_WALLET),
+        `REMOTE and SMART_WALLET are exclusive`,
+      );
       /** @type {ERef<MyAddressNameAdmin>} */
       const myAddressNameAdmin = E(namesByAddressAdmin).lookupAdmin(address);
 

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -207,6 +207,11 @@ export const makeAddressNameHubs = async ({
 };
 harden(makeAddressNameHubs);
 
+const AccountFlags = /** @type {const} */ ({
+  SMART_WALLET: 'SMART_WALLET', // TODO: make this the default
+  REMOTE_WALLET: 'REMOTE_WALLET',
+});
+
 /** @param {BootstrapSpace} powers */
 export const makeClientBanks = async ({
   consume: {
@@ -233,8 +238,11 @@ export const makeClientBanks = async ({
     { storageNode },
   );
   return E(client).assignBundle([
-    address => {
+    (address, accountFlags) => {
       const bank = E(bankManager).getBankForAddress(address);
+      if (!accountFlags.includes(AccountFlags.SMART_WALLET)) {
+        return { bank };
+      }
       /** @type {ERef<MyAddressNameAdmin>} */
       const myAddressNameAdmin = E(namesByAddressAdmin).lookupAdmin(address);
 

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -208,14 +208,18 @@ export const setupClientManager = async (
       );
       return E(c).getChainBundle();
     },
-    createClientFacet: async (_nickname, clientAddress, _powerFlags) => {
+    createClientFacet: async (_nickname, clientAddress, powerFlags) => {
       /** @type {Record<string, unknown>} */
       let clientHome = {};
       const bundleReady = makePromiseKit();
 
       const makeUpdatedConfiguration = async (newPropertyMakers = []) => {
         // Specialize the property makers with the client address.
-        const newProperties = callProperties(newPropertyMakers, clientAddress);
+        const newProperties = callProperties(
+          newPropertyMakers,
+          clientAddress,
+          powerFlags,
+        );
         clientHome = { ...clientHome, ...newProperties };
 
         const todo = missingKeys(template, clientHome);

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -98,7 +98,7 @@
  *   assignBundle: (ps: PropertyMaker[]) => void
  * }} ClientManager tool to put properties onto the `home` object of the client
  *
- * @typedef {(addr: string) => Record<string, unknown>} PropertyMaker callback to assign a property onto the `home` object of the client
+ * @typedef {(addr: string, flags: string[]) => Record<string, unknown>} PropertyMaker callback to assign a property onto the `home` object of the client
  */
 
 /**


### PR DESCRIPTION
quick hack based on discussion with @warner ; completely untested.
cc @turadg @arirubinstein 

REMOTE_WALLET is really a new feat, but w.r.t. the smart wallet
depositFacet conflict in #5783, this is (the start of) a fix.

  - [x] TODO: default to ag-solo compatible remote client wallet
          during a transition to smart-wallet-default


<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #5783
refs: #4654

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
