### PR TITLE
fix: userSeat allocation only for testing

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -265,7 +265,9 @@ const start = async zcf => {
       { stopAfter: debt },
     );
     await Promise.all([E(liqSeat).getOfferResult(), deposited]);
-    const amounts = await E(liqSeat).getCurrentAllocation();
+
+    // This uses getCurrentAllocationJig only to support testing, so is ok
+    const amounts = await E(liqSeat).getCurrentAllocationJig();
     trace('offerResult', { amounts });
   }
 

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
@@ -256,7 +256,7 @@ test('amm add and remove liquidity', async t => {
   };
   await tracker.assertChange(poolLiquidity);
 
-  const alloc = await E(addLiquiditySeat).getCurrentAllocation();
+  const alloc = await E(addLiquiditySeat).getCurrentAllocationJig();
   t.deepEqual(alloc, {
     Central: central(0n),
     Liquidity: AmountMath.make(liquidityBrand, 1_499_999_000n),
@@ -496,7 +496,7 @@ test('add wrong liquidity', async t => {
     }),
   );
 
-  const alloc = await E(addLiquiditySeat).getCurrentAllocation();
+  const alloc = await E(addLiquiditySeat).getCurrentAllocationJig();
   t.deepEqual(alloc, {
     Central: central(0n),
     Liquidity: AmountMath.make(liquidityBrand, 1_499_999_000n),

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -202,8 +202,9 @@ test('simple trades', async t => {
     E(limitedCreatorFacet).makeCollectFeesInvitation(),
   );
   await E(collectFeesSeat).getOfferResult();
-  const feePayoutAmount = await E.get(E(collectFeesSeat).getCurrentAllocation())
-    .RUN;
+  const feePayoutAmount = await E.get(
+    E(collectFeesSeat).getCurrentAllocationJig(),
+  ).RUN;
   const expectedFee = AmountMath.make(run.brand, 50000n);
   trace('Reward Fee', { feePayoutAmount, expectedFee });
   t.truthy(AmountMath.isEqual(feePayoutAmount, expectedFee));

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -496,7 +496,7 @@ export const makeManagerDriver = async (
       );
       currentOfferResult = await E(currentSeat).getOfferResult();
       if (expected) {
-        const payouts = await E(currentSeat).getCurrentAllocation();
+        const payouts = await E(currentSeat).getCurrentAllocationJig();
         trace(t, 'AMM payouts', payouts);
         t.like(payouts, expected);
       }

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -476,7 +476,7 @@ test('first', async t => {
   );
   trace(t, 'correct debt', debtAmount);
 
-  const { RUN: lentAmount } = await E(vaultSeat).getCurrentAllocation();
+  const { RUN: lentAmount } = await E(vaultSeat).getCurrentAllocationJig();
   const loanProceeds = await E(vaultSeat).getPayouts();
   const runLent = await loanProceeds.RUN;
   t.deepEqual(lentAmount, loanAmount, 'received 47 RUN');
@@ -611,7 +611,7 @@ test('price drop', async t => {
     debt: AmountMath.add(loanAmount, fee),
     interest: makeRatio(100n, run.brand),
   });
-  const { RUN: lentAmount } = await E(vaultSeat).getCurrentAllocation();
+  const { RUN: lentAmount } = await E(vaultSeat).getCurrentAllocationJig();
   t.truthy(AmountMath.isEqual(lentAmount, loanAmount), 'received 470 RUN');
   t.deepEqual(
     await E(vault).getCollateralAmount(),
@@ -751,7 +751,7 @@ test('price falls precipitously', async t => {
   );
   trace(t, 'correct debt', debtAmount);
 
-  const { RUN: lentAmount } = await E(userSeat).getCurrentAllocation();
+  const { RUN: lentAmount } = await E(userSeat).getCurrentAllocationJig();
   t.deepEqual(lentAmount, loanAmount, 'received 470 RUN');
   t.deepEqual(
     await E(vault).getCollateralAmount(),
@@ -928,7 +928,7 @@ test('interest on multiple vaults', async t => {
     'vault lent 4700 RUN + fees',
   );
 
-  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocation();
+  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocationJig();
   const loanProceeds = await E(aliceLoanSeat).getPayouts();
   t.deepEqual(lentAmount, aliceLoanAmount, 'received 4700 RUN');
 
@@ -967,7 +967,7 @@ test('interest on multiple vaults', async t => {
     'vault lent 3200 RUN + fees',
   );
 
-  const { RUN: bobLentAmount } = await E(bobLoanSeat).getCurrentAllocation();
+  const { RUN: bobLentAmount } = await E(bobLoanSeat).getCurrentAllocationJig();
   const bobLoanProceeds = await E(bobLoanSeat).getPayouts();
   t.deepEqual(bobLentAmount, bobLoanAmount, 'received 4700 RUN');
 
@@ -1115,7 +1115,7 @@ test('adjust balances', async t => {
   let collateralLevel = aeth.make(1000n);
 
   t.deepEqual(debtAmount, runDebtLevel, 'vault lent 5000 RUN + fees');
-  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocation();
+  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocationJig();
   const loanProceeds = await E(aliceLoanSeat).getPayouts();
   t.deepEqual(lentAmount, aliceLoanAmount, 'received 5000 RUN');
 
@@ -1164,7 +1164,7 @@ test('adjust balances', async t => {
 
   const { RUN: lentAmount2 } = await E(
     aliceAddCollateralSeat1,
-  ).getCurrentAllocation();
+  ).getCurrentAllocationJig();
   const loanProceeds2 = await E(aliceAddCollateralSeat1).getPayouts();
   t.deepEqual(lentAmount2, run.makeEmpty(), 'no payout');
 
@@ -1208,7 +1208,7 @@ test('adjust balances', async t => {
   await E(aliceAddCollateralSeat2).getOfferResult();
   const { RUN: lentAmount3 } = await E(
     aliceAddCollateralSeat2,
-  ).getCurrentAllocation();
+  ).getCurrentAllocationJig();
   const loanProceeds3 = await E(aliceAddCollateralSeat2).getPayouts();
   t.deepEqual(lentAmount3, run.make(50n));
 
@@ -1257,7 +1257,7 @@ test('adjust balances', async t => {
 
   const { RUN: lentAmount4 } = await E(
     aliceReduceCollateralSeat,
-  ).getCurrentAllocation();
+  ).getCurrentAllocationJig();
   const loanProceeds4 = await E(aliceReduceCollateralSeat).getPayouts();
   t.deepEqual(lentAmount4, run.make(50n));
 
@@ -1384,7 +1384,7 @@ test('adjust balances - withdraw RUN', async t => {
 
   const { RUN: lentAmount2 } = await E(
     aliceWithdrawRunSeat,
-  ).getCurrentAllocation();
+  ).getCurrentAllocationJig();
   const loanProceeds2 = await E(aliceWithdrawRunSeat).getPayouts();
   t.deepEqual(lentAmount2, additionalRUN, '100 RUN');
 
@@ -1541,7 +1541,7 @@ test('transfer vault', async t => {
   // make the invitation first so that we can arrange the interleaving
   // of adjust and tranfer
   const adjustInvitation = E(transferVault).makeAdjustBalancesInvitation();
-  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocation();
+  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocationJig();
   const aliceProceeds = await E(aliceLoanSeat).getPayouts();
   t.deepEqual(lentAmount, aliceLoanAmount, 'received 5000 RUN');
   const borrowedRun = await aliceProceeds.RUN;
@@ -1636,7 +1636,7 @@ test('overdeposit', async t => {
   const runDebt = AmountMath.add(aliceLoanAmount, fee);
 
   t.deepEqual(debtAmount, runDebt, 'vault lent 5000 RUN + fees');
-  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocation();
+  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocationJig();
   const aliceProceeds = await E(aliceLoanSeat).getPayouts();
   t.deepEqual(lentAmount, aliceLoanAmount, 'received 5000 RUN');
 
@@ -1697,7 +1697,9 @@ test('overdeposit', async t => {
   debtAmount = await E(aliceVault).getCurrentDebt();
   t.deepEqual(debtAmount, run.makeEmpty());
 
-  const { RUN: lentAmount5 } = await E(aliceOverpaySeat).getCurrentAllocation();
+  const { RUN: lentAmount5 } = await E(
+    aliceOverpaySeat,
+  ).getCurrentAllocationJig();
   const loanProceeds5 = await E(aliceOverpaySeat).getPayouts();
   t.deepEqual(lentAmount5, run.make(750n));
 
@@ -1713,7 +1715,7 @@ test('overdeposit', async t => {
   await E(collectFeesSeat).getOfferResult();
   assertAmountsEqual(
     t,
-    await E.get(E(collectFeesSeat).getCurrentAllocation()).RUN,
+    await E.get(E(collectFeesSeat).getCurrentAllocationJig()).RUN,
     run.make(300n),
   );
 });
@@ -1795,7 +1797,7 @@ test('mutable liquidity triggers and interest', async t => {
   t.deepEqual(aliceDebtAmount, aliceRunDebtLevel, 'vault lent 5000 RUN + fees');
   const { RUN: aliceLentAmount } = await E(
     aliceLoanSeat,
-  ).getCurrentAllocation();
+  ).getCurrentAllocationJig();
   const aliceLoanProceeds = await E(aliceLoanSeat).getPayouts();
   t.deepEqual(aliceLentAmount, aliceLoanAmount, 'received 5000 RUN');
   trace(t, 'alice vault');
@@ -1837,7 +1839,7 @@ test('mutable liquidity triggers and interest', async t => {
   const bobRunDebtLevel = AmountMath.add(bobLoanAmount, bobFee);
 
   t.deepEqual(bobDebtAmount, bobRunDebtLevel, 'vault lent 5000 RUN + fees');
-  const { RUN: bobLentAmount } = await E(bobLoanSeat).getCurrentAllocation();
+  const { RUN: bobLentAmount } = await E(bobLoanSeat).getCurrentAllocationJig();
   const bobLoanProceeds = await E(bobLoanSeat).getPayouts();
   t.deepEqual(bobLentAmount, bobLoanAmount, 'received 5000 RUN');
   trace(t, 'bob vault');
@@ -1868,7 +1870,7 @@ test('mutable liquidity triggers and interest', async t => {
 
   const { Collateral: aliceWithdrawnAeth } = await E(
     aliceReduceCollateralSeat,
-  ).getCurrentAllocation();
+  ).getCurrentAllocationJig();
   const loanProceeds4 = await E(aliceReduceCollateralSeat).getPayouts();
   t.deepEqual(aliceWithdrawnAeth, aeth.make(300n));
 
@@ -2005,7 +2007,7 @@ test('collect fees from loan and AMM', async t => {
   t.deepEqual(debtAmount, AmountMath.add(loanAmount, fee), 'vault loaned RUN');
   trace(t, 'correct debt', debtAmount);
 
-  const { RUN: lentAmount } = await E(vaultSeat).getCurrentAllocation();
+  const { RUN: lentAmount } = await E(vaultSeat).getCurrentAllocationJig();
   const loanProceeds = await E(vaultSeat).getPayouts();
   await loanProceeds.RUN;
   t.deepEqual(lentAmount, loanAmount, 'received 47 RUN');
@@ -2043,8 +2045,9 @@ test('collect fees from loan and AMM', async t => {
     E(vaultFactory).makeCollectFeesInvitation(),
   );
   await E(collectFeesSeat).getOfferResult();
-  const feePayoutAmount = await E.get(E(collectFeesSeat).getCurrentAllocation())
-    .RUN;
+  const feePayoutAmount = await E.get(
+    E(collectFeesSeat).getCurrentAllocationJig(),
+  ).RUN;
   trace(t, 'Fee', feePoolBalance, feePayoutAmount);
   t.truthy(AmountMath.isGTE(feePayoutAmount, feePoolBalance.RUN));
 });
@@ -2089,7 +2092,7 @@ test('close loan', async t => {
   const runDebtLevel = AmountMath.add(aliceLoanAmount, fee);
 
   t.deepEqual(debtAmount, runDebtLevel, 'vault lent 5000 RUN + fees');
-  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocation();
+  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocationJig();
   const loanProceeds = await E(aliceLoanSeat).getPayouts();
   t.deepEqual(lentAmount, aliceLoanAmount, 'received 5000 RUN');
 
@@ -2146,7 +2149,7 @@ test('close loan', async t => {
   const closeOfferResult = await E(aliceCloseSeat).getOfferResult();
   t.is(closeOfferResult, 'your loan is closed, thank you for your business');
 
-  const closeAlloc = await E(aliceCloseSeat).getCurrentAllocation();
+  const closeAlloc = await E(aliceCloseSeat).getCurrentAllocationJig();
   t.deepEqual(closeAlloc, {
     RUN: run.make(750n),
     Collateral: aeth.make(1000n),
@@ -2327,7 +2330,7 @@ test('mutable liquidity sensitivity of triggers and interest', async t => {
   t.deepEqual(aliceDebtAmount, aliceRunDebtLevel, 'vault lent 5000 RUN + fees');
   const { RUN: aliceLentAmount } = await E(
     aliceLoanSeat,
-  ).getCurrentAllocation();
+  ).getCurrentAllocationJig();
   const aliceLoanProceeds = await E(aliceLoanSeat).getPayouts();
   t.deepEqual(aliceLentAmount, aliceLoanAmount, 'received 5000 RUN');
 
@@ -2366,7 +2369,7 @@ test('mutable liquidity sensitivity of triggers and interest', async t => {
   const bobRunDebtLevel = AmountMath.add(bobLoanAmount, bobFee);
 
   t.deepEqual(bobDebtAmount, bobRunDebtLevel, 'vault lent 5000 RUN + fees');
-  const { RUN: bobLentAmount } = await E(bobLoanSeat).getCurrentAllocation();
+  const { RUN: bobLentAmount } = await E(bobLoanSeat).getCurrentAllocationJig();
   const bobLoanProceeds = await E(bobLoanSeat).getPayouts();
   t.deepEqual(bobLentAmount, bobLoanAmount, 'received 5000 RUN');
 
@@ -2395,7 +2398,7 @@ test('mutable liquidity sensitivity of triggers and interest', async t => {
 
   await E(aliceReduceCollateralSeat).getOfferResult();
 
-  await E(aliceReduceCollateralSeat).getCurrentAllocation();
+  await E(aliceReduceCollateralSeat).getCurrentAllocationJig();
   const loanProceeds4 = await E(aliceReduceCollateralSeat).getPayouts();
   // t.deepEqual(aliceWithdrawnAeth, aeth.make(210n));
 

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -552,7 +552,10 @@ export function makeWallet({
    */
   async function subscribeToNotifier(id, seat) {
     E(seat)
-      .getNotifier()
+      // TODO This uses getAllocationNotifierJig for production, and so
+      // is likely wrong
+      // See https://github.com/Agoric/agoric-sdk/issues/5834
+      .getAllocationNotifierJig()
       .then(offerNotifierP => {
         if (!idToNotifierP.has(id)) {
           idToNotifierP.init(id, offerNotifierP);

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -354,7 +354,10 @@ export const offerTo = async (
   const depositedPromiseKit = makePromiseKit();
 
   const doDeposit = async payoutPayments => {
-    const amounts = await E(userSeatPromise).getCurrentAllocation();
+    // TODO This uses getCurrentAllocationJig for production, and so
+    // is likely wrong
+    // https://github.com/Agoric/agoric-sdk/issues/5833
+    const amounts = await E(userSeatPromise).getCurrentAllocationJig();
 
     // Map back to the original contract's keywords
     const mappedAmounts = mapKeywords(amounts, mappingReversed);

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -176,15 +176,19 @@
 /**
  * @template {object} [OR=unknown]
  * @typedef {object} UserSeat
- * @property {() => Promise<Allocation>} getCurrentAllocation
- * TODO remove getCurrentAllocation query
  * @property {() => Promise<ProposalRecord>} getProposal
  * @property {() => Promise<PaymentPKeywordRecord>} getPayouts
  * @property {(keyword: Keyword) => Promise<Payment>} getPayout
  * @property {() => Promise<OR>} getOfferResult
  * @property {() => void=} tryExit
  * @property {() => Promise<boolean>} hasExited
- * @property {() => Promise<Notifier<Allocation>>} getNotifier
+ *
+ * @property {() => Promise<Allocation>} getCurrentAllocationJig
+ * Labelled "Jig" because it *should* only be used for tests, though
+ * nothing prevents it from being used otherwise.
+ * @property {() => Promise<Notifier<Allocation>>} getAllocationNotifierJig
+ * Labelled "Jig" because it *should* only be used for tests, though
+ * nothing prevents it from being used otherwise.
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -83,7 +83,6 @@ export const makeZoeSeatAdminKit = (
 
   /** @type {UserSeat} */
   const userSeat = Far('userSeat', {
-    getCurrentAllocation: async () => currentAllocation,
     getProposal: async () => proposal,
     getPayouts: async () => payoutPromiseKit.promise,
     getPayout: async keyword => {
@@ -93,7 +92,9 @@ export const makeZoeSeatAdminKit = (
     getOfferResult: async () => offerResult,
     hasExited: async () => hasExited(zoeSeatAdmin),
     tryExit: async () => E(exitObj).exit(),
-    getNotifier: async () => notifier,
+
+    getCurrentAllocationJig: async () => currentAllocation,
+    getAllocationNotifierJig: async () => notifier,
   });
 
   return { userSeat, zoeSeatAdmin, notifier };

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -669,8 +669,8 @@ const similarToNormalUserSeat = async (t, emptySeat, normalSeat) => {
   t.deepEqual(Object.keys(emptySeat), Object.keys(normalSeat));
   t.deepEqual(await emptySeat.getProposal(), await normalSeat.getProposal());
   t.deepEqual(
-    await emptySeat.getCurrentAllocation(),
-    await normalSeat.getCurrentAllocation(),
+    await emptySeat.getCurrentAllocationJig(),
+    await normalSeat.getCurrentAllocationJig(),
   );
   t.is(await emptySeat.hasExited(), await normalSeat.hasExited());
   t.is(await emptySeat.getOfferResult(), await normalSeat.getOfferResult());
@@ -839,7 +839,7 @@ test(`zcfSeat.getCurrentAllocation from zcf.makeEmptySeatKit`, async t => {
 
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    await E(userSeat).getCurrentAllocation(),
+    await E(userSeat).getCurrentAllocationJig(),
   );
   t.deepEqual(zcfSeat.getCurrentAllocation(), {});
 
@@ -869,7 +869,7 @@ test(`zcfSeat.getCurrentAllocation from zcf.makeEmptySeatKit`, async t => {
 
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    await E(userSeat).getCurrentAllocation(),
+    await E(userSeat).getCurrentAllocationJig(),
   );
 });
 
@@ -925,14 +925,14 @@ test(`zcfSeat.incrementBy, decrementBy, zcf.reallocate from zcf.makeEmptySeatKit
 
 test(`userSeat from zcf.makeEmptySeatKit - only these properties exist`, async t => {
   const expectedMethods = [
-    'getCurrentAllocation',
     'getProposal',
     'getPayouts',
     'getPayout',
     'getOfferResult',
     'hasExited',
     'tryExit',
-    'getNotifier',
+    'getCurrentAllocationJig',
+    'getAllocationNotifierJig',
   ];
   const { zcf } = await setupZCFTest();
   const { userSeat: userSeatP } = zcf.makeEmptySeatKit();
@@ -997,20 +997,20 @@ test(`userSeat.tryExit from zcf.makeEmptySeatKit - afterDeadline`, async t => {
   t.deepEqual(payouts, {});
 });
 
-test(`userSeat.getCurrentAllocation from zcf.makeEmptySeatKit`, async t => {
+test(`userSeat.getCurrentAllocationJig from zcf.makeEmptySeatKit`, async t => {
   const { zcf } = await setupZCFTest();
   const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
 
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    await E(userSeat).getCurrentAllocation(),
+    await E(userSeat).getCurrentAllocationJig(),
   );
-  t.deepEqual(await E(userSeat).getCurrentAllocation(), {});
+  t.deepEqual(await E(userSeat).getCurrentAllocationJig(), {});
 
   // Mint some gains to change the allocation.
   const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3n);
 
-  t.deepEqual(await E(userSeat).getCurrentAllocation(), {
+  t.deepEqual(await E(userSeat).getCurrentAllocationJig(), {
     A: {
       brand: brand1,
       value: 3n,
@@ -1020,7 +1020,7 @@ test(`userSeat.getCurrentAllocation from zcf.makeEmptySeatKit`, async t => {
   // Again, mint some gains to change the allocation.
   const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6n);
 
-  t.deepEqual(await E(userSeat).getCurrentAllocation(), {
+  t.deepEqual(await E(userSeat).getCurrentAllocationJig(), {
     A: {
       brand: brand1,
       value: 3n,
@@ -1033,7 +1033,7 @@ test(`userSeat.getCurrentAllocation from zcf.makeEmptySeatKit`, async t => {
 
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    await E(userSeat).getCurrentAllocation(),
+    await E(userSeat).getCurrentAllocationJig(),
   );
 });
 
@@ -1044,10 +1044,10 @@ test(`userSeat.getOfferResult from zcf.makeEmptySeatKit`, async t => {
   t.is(result, undefined);
 });
 
-test(`userSeat.getNotifier`, async t => {
+test(`userSeat.getAllocationNotifierJig`, async t => {
   const { zcf } = await setupZCFTest();
   const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
-  const notifier = await E(userSeat).getNotifier();
+  const notifier = await E(userSeat).getAllocationNotifierJig();
 
   // Mint some gains to change the allocation.
   const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3n);
@@ -1110,7 +1110,7 @@ test(`userSeat.getPayouts, getPayout from zcf.makeEmptySeatKit`, async t => {
     6n,
   );
 
-  t.deepEqual(await E(userSeat).getCurrentAllocation(), {
+  t.deepEqual(await E(userSeat).getCurrentAllocationJig(), {
     A: {
       brand: brand1,
       value: 3n,
@@ -1393,7 +1393,7 @@ test(`zcf.stopAcceptingOffers`, async t => {
   );
 
   t.deepEqual(
-    await E(seat).getCurrentAllocation(),
+    await E(seat).getCurrentAllocationJig(),
     {},
     'can still query live seat',
   );


### PR DESCRIPTION
Renames the UserSeat allocation methods to end in "Jig" to flag that they should only be used for testing.

Insert comments to flag that we need to reexamine all uses of these for non-test production purposes.

By doing this PR, we identified two such problematic uses #5833 and #5834 . This PR adds todo comments at each of those locations pointing to their respective bugs.