### PR TITLE
ci: ensure deployment test runs some loadgen cycles

### DIFF
--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -54,7 +54,7 @@ then
     "$AG_SETUP_COSMOS_HOME/faucet-helper.sh" add-egress loadgen "$SOLO_ADDR"
   SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
     --stage.save-storage --trace kvstore swingstore xsnap \
-    --stages=3 --stage.duration=4 \
+    --stages=3 --stage.duration=10 --stage.loadgen.cycles=4 \
     --stage.loadgen.vault.interval=12 --stage.loadgen.vault.limit=2 \
     --stage.loadgen.amm.interval=12 --stage.loadgen.amm.wait=6 --stage.loadgen.amm.limit=2 \
     --profile=testnet "--testnet-origin=file://$RESULTSDIR" \


### PR DESCRIPTION
refs: https://github.com/Agoric/testnet-load-generator/issues/89

## Description

Update the deployment integration test's loadgen options to use the new `cycles` option to ensure 4 loadgen cycles run, avoiding issues like https://github.com/Agoric/agoric-sdk/pull/5820.

### Security Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

Loadgen repo has been updated to use new option in its own integration tests, and this repo will run its own integration before merging.
