### PR TITLE
chore: let virtual-object state be enumerable, for debugging

### DIFF
--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -713,6 +713,7 @@ export function makeVirtualObjectManager(
             innerSelf.rawState[prop] = after;
             cache.markDirty(innerSelf);
           },
+          enumerable: true,
         });
       }
       harden(state);


### PR DESCRIPTION
This helps dispel confusion when debugging, and `console.log(state)`
within a virtual-object method shows what looks like an empty object,
when in fact there are getters and setters for specific names.
