### PR TITLE
feat(wallet): shared unserializer for dapps and wallet

### DIFF
--- a/packages/wallet/api/src/internal-types.js
+++ b/packages/wallet/api/src/internal-types.js
@@ -55,6 +55,7 @@
  * @property {(str: string) => Petname} explode
  * @property {LegacyWeakMap<T, Petname>} valToPetname
  * @property {WeakStore<T, string[][]>} valToPaths
+ * @property {WeakMapStore<T, string>} valToBoardId
  *   TODO What about when useLegacyMap is true because contact have
  *   identity? `T` would be `Contact`. Shouldn't `valToPaths` be
  *   a `LegacyWeakMap`?
@@ -64,6 +65,7 @@
  * @property {(petname: Petname, val: T) => void} renamePetname
  * @property {(petname: Petname) => void} deletePetname
  * @property {(petname: Petname, val: T) => Petname} suggestPetname
+ * @property {(boardId: string, val: T) => void} addBoardId
  * @property {string} kind
  */
 

--- a/packages/wallet/api/src/lib-dehydrate.js
+++ b/packages/wallet/api/src/lib-dehydrate.js
@@ -337,7 +337,7 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
         return harden({
           kind,
           petname: valToPetname.get(val),
-          boardId,
+          ...(boardId ? { boardId } : {}),
         });
       }
     }

--- a/packages/wallet/api/src/lib-dehydrate.js
+++ b/packages/wallet/api/src/lib-dehydrate.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { makeMarshal, mapIterable } from '@endo/marshal';
-import { makeLegacyMap, makeScalarMap } from '@agoric/store';
+import { makeLegacyMap, makeScalarMap, makeScalarWeakMap } from '@agoric/store';
 import { assert, details as X, q } from '@agoric/assert';
 
 /**
@@ -159,6 +159,8 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
       },
     };
 
+    const valToBoardId = makeScalarWeakMap('boardId');
+
     /**
      * @param {Path} path
      * @param {any} val
@@ -217,6 +219,11 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
       if (isPath(petname)) {
         addPath(petname, val);
       }
+    };
+
+    const addBoardId = (boardId, val) => {
+      assert(!valToBoardId.has(val), X`val ${val} already has a board id`);
+      valToBoardId.init(val, boardId);
     };
 
     const renamePetname = (petname, val) => {
@@ -289,12 +296,14 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
       valToPetname,
       valToPaths,
       petnameToVal,
+      valToBoardId,
       addPetname,
       addPath,
       renamePetname,
       deletePetname,
       suggestPetname,
       kind,
+      addBoardId,
     });
     petnameKindToMapping.init(kind, mapping);
     return mapping;
@@ -319,11 +328,16 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
   const convertValToName = val => {
     for (let i = 0; i < searchOrder.length; i += 1) {
       const kind = searchOrder[i];
-      const { valToPetname } = petnameKindToMapping.get(kind);
+      const { valToPetname, valToBoardId } = petnameKindToMapping.get(kind);
       if (valToPetname.has(val)) {
+        let boardId;
+        if (valToBoardId.has(val)) {
+          boardId = valToBoardId.get(val);
+        }
         return harden({
           kind,
           petname: valToPetname.get(val),
+          boardId,
         });
       }
     }
@@ -340,6 +354,10 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
     return placeholderName;
   };
 
+  /**
+   * @param {{ kind: string, petname: Petname, boardId?: string}} slot
+   * @param {string} [_iface]
+   */
   const convertNameToVal = ({ kind, petname }, _iface = undefined) => {
     const { petnameToVal } = petnameKindToMapping.get(kind);
     return petnameToVal.get(petname);

--- a/packages/wallet/api/src/sharingUnserializer.js
+++ b/packages/wallet/api/src/sharingUnserializer.js
@@ -1,0 +1,72 @@
+// @ts-check
+import { Far, makeMarshal } from '@endo/marshal';
+
+/**
+ * Make a pair of unserializers that share low-privilege values.
+ *
+ * @param {string} [lowProperty]
+ */
+export const makeSharingUnserializer = (lowProperty = 'boardId') => {
+  const seen = {
+    // high privilege - e.g. wallet purses
+    // hi: new WeakMap(),  // ISSUE: WeakMap conflicts with string keys
+    high: new Map(),
+    // low privilege - e.g. stuff on the board
+    low: new Map(),
+  };
+
+  const slotToVal = {
+    /**
+     * @param {Record<string, any>} slot
+     * @param {string} iface
+     */
+    high: (slot, iface) => {
+      let obj;
+      let key;
+
+      if (lowProperty in slot) {
+        key = slot[lowProperty];
+        if (seen.low.has(key)) {
+          return seen.low.get(key);
+        }
+        obj = Far(iface, {});
+        seen.low.set(key, obj);
+      } else {
+        key = JSON.stringify(slot);
+        if (seen.high.has(key)) {
+          return seen.high.get(key);
+        }
+        obj = Far(iface, {});
+        seen.high.set(key, obj);
+      }
+      return obj;
+    },
+
+    /**
+     * @param {Record<string, any>} slot
+     * @param {string} iface
+     */
+    low: (slot, iface) => {
+      if (seen.low.has(slot)) {
+        return seen.low.get(slot);
+      }
+      const obj = Far(iface, {});
+      seen.low.set(slot, obj);
+      return obj;
+    },
+  };
+
+  const marshal = {
+    high: makeMarshal(undefined, slotToVal.high, { marshalName: 'high' }),
+    low: makeMarshal(undefined, slotToVal.low, { marshalName: 'low' }),
+  };
+
+  return {
+    high: Far('high privilege unserializer', {
+      unserialize: marshal.high.unserialize,
+    }),
+    low: Far('low privilege unserializer', {
+      unserialize: marshal.low.unserialize,
+    }),
+  };
+};

--- a/packages/wallet/api/src/sharingUnserializer.js
+++ b/packages/wallet/api/src/sharingUnserializer.js
@@ -4,14 +4,23 @@ import { Far, makeMarshal } from '@endo/marshal';
 /**
  * Make a pair of unserializers that share low-privilege values.
  *
- * @param {string} [lowProperty]
+ * The "high" privilege unserializer can understand objects as slots, such as
+ * those from the wallet serializer. The "low" privilege unserializer can only
+ * understand strings as slots, such as those from the board serializer.
+ *
+ * This provides a way, for instance, to get identical brand references from
+ * both a public contract and a user's purses.
+ *
+ * @param {string} [lowProperty] - The key name to check on a high privilege
+ * slot object. If the string value at this key is equivalent to the value of
+ * another low privilege slot, the high privilege unserializer will return the
+ * same object for both slots.
  */
-export const makeSharingUnserializer = (lowProperty = 'boardId') => {
+export const makeSharingUnserializer = lowProperty => {
+  assert(lowProperty, 'lowProperty must be specified for sharing unserializer');
   const seen = {
-    // high privilege - e.g. wallet purses
-    // hi: new WeakMap(),  // ISSUE: WeakMap conflicts with string keys
+    // high: new WeakMap(),  // ISSUE: WeakMap conflicts with string keys
     high: new Map(),
-    // low privilege - e.g. stuff on the board
     low: new Map(),
   };
 

--- a/packages/wallet/api/test/test-getPursesNotifier.js
+++ b/packages/wallet/api/test/test-getPursesNotifier.js
@@ -62,13 +62,14 @@ test('getPursesNotifier', async t => {
   t.is(moolaPurseInfo.brandBoardId, 'board0425');
   t.is(moolaPurseInfo.brandPetname, MOOLA_ISSUER_PETNAME);
   t.deepEqual(moolaPurseInfo.currentAmount, {
-    brand: { kind: 'brand', petname: 'moola' }, // not a real amount
+    brand: { boardId: 'board0425', kind: 'brand', petname: 'moola' }, // not a real amount
     value: 0n,
   });
   t.deepEqual(moolaPurseInfo.currentAmountSlots, {
     body: '{"brand":{"@qclass":"slot","iface":"Alleged: moola brand","index":0},"value":{"@qclass":"bigint","digits":"0"}}',
     slots: [
       {
+        boardId: 'board0425',
         kind: 'brand',
         petname: 'moola',
       },
@@ -96,13 +97,14 @@ test('getAttenuatedPursesNotifier', async t => {
   t.is(moolaPurseInfo.brandBoardId, 'board0425');
   t.is(moolaPurseInfo.brandPetname, MOOLA_ISSUER_PETNAME);
   t.deepEqual(moolaPurseInfo.currentAmount, {
-    brand: { kind: 'brand', petname: 'moola' }, // not a real amount
+    brand: { boardId: 'board0425', kind: 'brand', petname: 'moola' }, // not a real amount
     value: 0n,
   });
   t.deepEqual(moolaPurseInfo.currentAmountSlots, {
     body: '{"brand":{"@qclass":"slot","iface":"Alleged: moola brand","index":0},"value":{"@qclass":"bigint","digits":"0"}}',
     slots: [
       {
+        boardId: 'board0425',
         kind: 'brand',
         petname: 'moola',
       },

--- a/packages/wallet/api/test/test-lib-dehydrate.js
+++ b/packages/wallet/api/test/test-lib-dehydrate.js
@@ -114,7 +114,6 @@ test('makeDehydrator', async t => {
       body: '{"handle":{"@qclass":"slot","iface":"Alleged: handle1","index":0}}',
       slots: [
         {
-          boardId: undefined,
           kind: 'instanceHandle',
           petname: 'simpleExchange',
         },
@@ -141,7 +140,7 @@ test('makeDehydrator', async t => {
     dehydrate(harden({ brand: brand1, value: 40 })),
     harden({
       body: '{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":0},"value":40}',
-      slots: [{ boardId: undefined, kind: 'brand', petname: 'moola' }],
+      slots: [{ kind: 'brand', petname: 'moola' }],
     }),
     `serialize brand with petname`,
   );
@@ -176,11 +175,10 @@ test('makeDehydrator', async t => {
       body: '{"exit":{"afterDeadline":{"deadline":55,"timer":{"@qclass":"slot","iface":"Alleged: timer","index":0}}},"give":{"Price":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":1},"value":3}},"want":{"Asset1":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":2},"value":60},"Asset2":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":3},"value":{"instanceHandle":{"@qclass":"slot","iface":"Alleged: handle3","index":4}}}}}',
       slots: [
         { kind: 'unnamed', petname: 'unnamed-1' },
-        { boardId: undefined, kind: 'brand', petname: 'simolean' },
-        { boardId: undefined, kind: 'brand', petname: 'moola' },
-        { boardId: undefined, kind: 'brand', petname: 'zoeInvite' },
+        { kind: 'brand', petname: 'simolean' },
+        { kind: 'brand', petname: 'moola' },
+        { kind: 'brand', petname: 'zoeInvite' },
         {
-          boardId: undefined,
           kind: 'instanceHandle',
           petname: 'automaticRefund',
         },
@@ -229,9 +227,7 @@ test('makeDehydrator', async t => {
     dehydrate(harden({ handle: handle4 })),
     {
       body: '{"handle":{"@qclass":"slot","iface":"Alleged: handle4","index":0}}',
-      slots: [
-        { boardId: undefined, kind: 'instanceHandle', petname: 'autoswap' },
-      ],
+      slots: [{ kind: 'instanceHandle', petname: 'autoswap' }],
     },
     `serialize val with new petname`,
   );

--- a/packages/wallet/api/test/test-lib-dehydrate.js
+++ b/packages/wallet/api/test/test-lib-dehydrate.js
@@ -112,7 +112,13 @@ test('makeDehydrator', async t => {
     dehydrate(harden({ handle: handle1 })),
     {
       body: '{"handle":{"@qclass":"slot","iface":"Alleged: handle1","index":0}}',
-      slots: [{ kind: 'instanceHandle', petname: 'simpleExchange' }],
+      slots: [
+        {
+          boardId: undefined,
+          kind: 'instanceHandle',
+          petname: 'simpleExchange',
+        },
+      ],
     },
     `serialize val with petname`,
   );
@@ -135,7 +141,7 @@ test('makeDehydrator', async t => {
     dehydrate(harden({ brand: brand1, value: 40 })),
     harden({
       body: '{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":0},"value":40}',
-      slots: [{ kind: 'brand', petname: 'moola' }],
+      slots: [{ boardId: undefined, kind: 'brand', petname: 'moola' }],
     }),
     `serialize brand with petname`,
   );
@@ -170,10 +176,14 @@ test('makeDehydrator', async t => {
       body: '{"exit":{"afterDeadline":{"deadline":55,"timer":{"@qclass":"slot","iface":"Alleged: timer","index":0}}},"give":{"Price":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":1},"value":3}},"want":{"Asset1":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":2},"value":60},"Asset2":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":3},"value":{"instanceHandle":{"@qclass":"slot","iface":"Alleged: handle3","index":4}}}}}',
       slots: [
         { kind: 'unnamed', petname: 'unnamed-1' },
-        { kind: 'brand', petname: 'simolean' },
-        { kind: 'brand', petname: 'moola' },
-        { kind: 'brand', petname: 'zoeInvite' },
-        { kind: 'instanceHandle', petname: 'automaticRefund' },
+        { boardId: undefined, kind: 'brand', petname: 'simolean' },
+        { boardId: undefined, kind: 'brand', petname: 'moola' },
+        { boardId: undefined, kind: 'brand', petname: 'zoeInvite' },
+        {
+          boardId: undefined,
+          kind: 'instanceHandle',
+          petname: 'automaticRefund',
+        },
       ],
     },
     `dehydrated proposal`,
@@ -219,7 +229,9 @@ test('makeDehydrator', async t => {
     dehydrate(harden({ handle: handle4 })),
     {
       body: '{"handle":{"@qclass":"slot","iface":"Alleged: handle4","index":0}}',
-      slots: [{ kind: 'instanceHandle', petname: 'autoswap' }],
+      slots: [
+        { boardId: undefined, kind: 'instanceHandle', petname: 'autoswap' },
+      ],
     },
     `serialize val with new petname`,
   );

--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -318,16 +318,18 @@ test('lib-wallet issuer and purse methods', async (/** @type {LibWalletTestConte
         value: [],
         currentAmountSlots: {
           body: '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe Invitation brand","index":0},"value":[]}',
-          slots: [{ kind: 'brand', petname: 'zoe invite' }],
+          slots: [
+            { boardId: 'board0223', kind: 'brand', petname: 'zoe invite' },
+          ],
         },
         currentAmount: {
-          brand: { kind: 'brand', petname: 'zoe invite' },
+          brand: { boardId: 'board0223', kind: 'brand', petname: 'zoe invite' },
           value: [],
         },
       },
       {
         brand: purseLog[1].brand,
-        brandBoardId: 'board0566',
+        brandBoardId: 'board0425',
         brandPetname: 'moola',
         depositBoardId: 'board0371',
         displayInfo: {
@@ -340,10 +342,10 @@ test('lib-wallet issuer and purse methods', async (/** @type {LibWalletTestConte
         value: 100,
         currentAmountSlots: {
           body: '{"brand":{"@qclass":"slot","iface":"Alleged: moola brand","index":0},"value":{"@qclass":"bigint","digits":"100"}}',
-          slots: [{ kind: 'brand', petname: 'moola' }],
+          slots: [{ boardId: 'board0425', kind: 'brand', petname: 'moola' }],
         },
         currentAmount: {
-          brand: { kind: 'brand', petname: 'moola' },
+          brand: { boardId: 'board0425', kind: 'brand', petname: 'moola' },
           value: 100,
         },
       },
@@ -471,14 +473,14 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async (
       currentAmountSlots: {
         body: '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe Invitation brand","index":0},"value":[{"description":"getRefund","handle":{"@qclass":"slot","iface":"Alleged: InvitationHandle","index":1},"installation":{"@qclass":"slot","iface":"Alleged: BundleInstallation","index":2},"instance":{"@qclass":"slot","iface":"Alleged: InstanceHandle","index":3}}]}',
         slots: [
-          { kind: 'brand', petname: 'zoe invite' },
+          { boardId: 'board0223', kind: 'brand', petname: 'zoe invite' },
           { kind: 'unnamed', petname: 'unnamed-4' },
           { kind: 'unnamed', petname: 'unnamed-2' },
           { kind: 'unnamed', petname: 'unnamed-3' },
         ],
       },
       currentAmount: {
-        brand: { kind: 'brand', petname: 'zoe invite' },
+        brand: { boardId: 'board0223', kind: 'brand', petname: 'zoe invite' },
         value: [
           {
             description: 'getRefund',
@@ -558,14 +560,14 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async (
       currentAmountSlots: {
         body: '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe Invitation brand","index":0},"value":[{"description":"getRefund","handle":{"@qclass":"slot","iface":"Alleged: InvitationHandle","index":1},"installation":{"@qclass":"slot","iface":"Alleged: BundleInstallation","index":2},"instance":{"@qclass":"slot","iface":"Alleged: InstanceHandle","index":3}}]}',
         slots: [
-          { kind: 'brand', petname: 'zoe invite' },
+          { boardId: 'board0223', kind: 'brand', petname: 'zoe invite' },
           { kind: 'unnamed', petname: 'unnamed-4' },
           { kind: 'installation', petname: 'automaticRefund' },
           { kind: 'instance', petname: 'automaticRefund' },
         ],
       },
       currentAmount: {
-        brand: { kind: 'brand', petname: 'zoe invite' },
+        brand: { kind: 'brand', petname: 'zoe invite', boardId: 'board0223' },
         value: [
           {
             description: 'getRefund',
@@ -697,14 +699,14 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async (
       currentAmountSlots: {
         body: '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe Invitation brand","index":0},"value":[{"description":"getRefund","handle":{"@qclass":"slot","iface":"Alleged: InvitationHandle","index":1},"installation":{"@qclass":"slot","iface":"Alleged: BundleInstallation","index":2},"instance":{"@qclass":"slot","iface":"Alleged: InstanceHandle","index":3}}]}',
         slots: [
-          { kind: 'brand', petname: 'zoe invite' },
+          { boardId: 'board0223', kind: 'brand', petname: 'zoe invite' },
           { kind: 'unnamed', petname: 'unnamed-4' },
           { kind: 'installation', petname: 'automaticRefund2' },
           { kind: 'instance', petname: 'automaticRefund' },
         ],
       },
       currentAmount: {
-        brand: { kind: 'brand', petname: 'zoe invite' },
+        brand: { kind: 'brand', petname: 'zoe invite', boardId: 'board0223' },
         value: [
           {
             description: 'getRefund',
@@ -903,10 +905,10 @@ test('lib-wallet offer methods', async (/** @type {LibWalletTestContext} */ t) =
       value: [],
       currentAmountSlots: {
         body: '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe Invitation brand","index":0},"value":[]}',
-        slots: [{ kind: 'brand', petname: 'zoe invite' }],
+        slots: [{ kind: 'brand', petname: 'zoe invite', boardId: 'board0223' }],
       },
       currentAmount: {
-        brand: { kind: 'brand', petname: 'zoe invite' },
+        brand: { boardId: 'board0223', kind: 'brand', petname: 'zoe invite' },
         value: [],
       },
     },
@@ -926,13 +928,13 @@ test('lib-wallet offer methods', async (/** @type {LibWalletTestContext} */ t) =
       value: 100,
       currentAmountSlots: {
         body: '{"brand":{"@qclass":"slot","iface":"Alleged: moola brand","index":0},"value":{"@qclass":"bigint","digits":"100"}}',
-        slots: [{ kind: 'brand', petname: 'moola' }],
+        slots: [{ boardId: 'board0425', kind: 'brand', petname: 'moola' }],
       },
       meta: {
         id: 5,
       },
       currentAmount: {
-        brand: { kind: 'brand', petname: 'moola' },
+        brand: { boardId: 'board0425', kind: 'brand', petname: 'moola' },
         value: 100,
       },
     },
@@ -990,6 +992,7 @@ test('lib-wallet offer methods', async (/** @type {LibWalletTestContext} */ t) =
               purse: {}, // JSON doesn't keep the purse.
               amount: {
                 brand: {
+                  boardId: 'board0425',
                   kind: 'brand',
                   petname: 'moola',
                 },
@@ -1042,6 +1045,7 @@ test('lib-wallet offer methods', async (/** @type {LibWalletTestContext} */ t) =
               purse: {}, // JSON doesn't keep the purse.
               amount: {
                 brand: {
+                  boardId: 'board0425',
                   kind: 'brand',
                   petname: 'moola',
                 },

--- a/packages/wallet/api/test/test-sharing-unserializer.js
+++ b/packages/wallet/api/test/test-sharing-unserializer.js
@@ -55,7 +55,7 @@ const makeWallet = board => {
 };
 
 test('preserve identity of brands across AMM and wallet', t => {
-  const { low: fromAMM, high: fromWallet } = makeSharingUnserializer();
+  const { low: fromAMM, high: fromWallet } = makeSharingUnserializer('boardId');
 
   const board = makeBoard(0, { prefix: 'b' });
   const amm = makeAMM(board);
@@ -84,7 +84,6 @@ test('preserve identity of brands across AMM and wallet', t => {
         petname: 'ATOM',
       },
       {
-        boardId: undefined,
         kind: 'purse',
         petname: 'ATOM',
       },

--- a/packages/wallet/api/test/test-sharing-unserializer.js
+++ b/packages/wallet/api/test/test-sharing-unserializer.js
@@ -1,0 +1,103 @@
+// @ts-check
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Far } from '@endo/far';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
+import { makeDehydrator } from '../src/lib-dehydrate.js';
+import { makeSharingUnserializer } from '../src/sharingUnserializer.js';
+
+const { freeze } = Object;
+
+/**
+ * @param {ReturnType<typeof makeBoard>} board
+ */
+const makeAMM = board => {
+  const atom = Far('ATOM brand', {});
+  const pub = board.getPublishingMarshaller();
+  return freeze({ getMetrics: () => pub.serialize(harden([atom])) });
+};
+
+/**
+ * @param {ReturnType<typeof makeBoard>} board
+ */
+const makeWallet = board => {
+  const { hydrate: _h, dehydrate, makeMapping } = makeDehydrator();
+  const brandMapping = makeMapping('brand');
+  const purseMapping = makeMapping('purse');
+  let brand;
+  return harden({
+    suggestIssuer: (name, boardId) => {
+      brand = board.getValue(boardId);
+      const purse = Far(`${name} purse`, {
+        getCurrentAmount: () => harden({ brand, value: 100 }),
+      });
+      brandMapping.suggestPetname(name, brand);
+      brandMapping.addBoardId(boardId, brand);
+      purseMapping.suggestPetname(name, purse);
+    },
+    publish: () =>
+      dehydrate(
+        harden(
+          [...purseMapping.petnameToVal.entries()].map(([name, purse], id) => ({
+            meta: { id },
+            // displayInfo
+            // brandBoardId,
+            purse,
+            brand,
+            currentAmount: purse.getCurrentAmount(),
+            // actions
+            brandPetname: name,
+            pursePetname: `${name} purse`,
+          })),
+        ),
+      ),
+  });
+};
+
+test('preserve identity of brands across AMM and wallet', t => {
+  const { low: fromAMM, high: fromWallet } = makeSharingUnserializer();
+
+  const board = makeBoard(0, { prefix: 'b' });
+  const amm = makeAMM(board);
+  const ammMetricsCapData = amm.getMetrics();
+
+  t.deepEqual(ammMetricsCapData, {
+    body: '[{"@qclass":"slot","iface":"Alleged: ATOM brand","index":0}]',
+    slots: ['b101'],
+  });
+
+  /** @type {Brand[]} */
+  const [b1] = fromAMM.unserialize(ammMetricsCapData);
+  /** @type {Brand[]} */
+  const [b2] = fromAMM.unserialize(amm.getMetrics());
+  t.is(b1, b2, 'unserialization twice from same source');
+
+  const myWallet = makeWallet(board);
+  myWallet.suggestIssuer('ATOM', 'b101');
+  const walletCapData = myWallet.publish();
+  t.deepEqual(walletCapData, {
+    body: '[{"brand":{"@qclass":"slot","iface":"Alleged: ATOM brand","index":0},"brandPetname":"ATOM","currentAmount":{"brand":{"@qclass":"slot","index":0},"value":100},"meta":{"id":0},"purse":{"@qclass":"slot","iface":"Alleged: ATOM purse","index":1},"pursePetname":"ATOM purse"}]',
+    slots: [
+      {
+        boardId: 'b101',
+        kind: 'brand',
+        petname: 'ATOM',
+      },
+      {
+        boardId: undefined,
+        kind: 'purse',
+        petname: 'ATOM',
+      },
+    ],
+  });
+
+  const walletState = fromWallet.unserialize(walletCapData);
+  t.is(walletState[0].brand, b1, 'unserialization across sources');
+
+  const failSafeState = fromAMM.unserialize(walletCapData);
+  t.not(
+    failSafeState[0].purse,
+    walletState[0].purse,
+    'AMM cannot refer to purses',
+  );
+});

--- a/packages/wallet/ui/src/components/SmartWalletConnection.jsx
+++ b/packages/wallet/ui/src/components/SmartWalletConnection.jsx
@@ -76,7 +76,7 @@ const SmartWalletConnection = ({
         setConnectionState('error');
       };
 
-      const { high, low } = makeSharingUnserializer();
+      const { high, low } = makeSharingUnserializer('boardId');
       const leader = makeLeader(href);
       const follower = makeFollower(
         `:published.wallet.${publicAddress}`,

--- a/packages/wallet/ui/src/components/SmartWalletConnection.jsx
+++ b/packages/wallet/ui/src/components/SmartWalletConnection.jsx
@@ -1,9 +1,10 @@
-import { makeFollower, makeLeader, makeCastingSpec } from '@agoric/casting';
+import { makeFollower, makeLeader } from '@agoric/casting';
 import React, { useEffect, useState } from 'react';
 import Snackbar from '@mui/material/Snackbar';
 import MuiAlert from '@mui/material/Alert';
 import { observeIterator } from '@agoric/notifier';
 
+import { makeSharingUnserializer } from '@agoric/wallet-backend/src/sharingUnserializer';
 import { withApplicationContext } from '../contexts/Application';
 import {
   makeBackendFromWalletBridge,
@@ -75,13 +76,17 @@ const SmartWalletConnection = ({
         setConnectionState('error');
       };
 
+      const { high, low } = makeSharingUnserializer();
       const leader = makeLeader(href);
       const follower = makeFollower(
-        makeCastingSpec(`:published.wallet.${publicAddress}`),
+        `:published.wallet.${publicAddress}`,
         leader,
+        { unserializer: high },
       );
       const bridge = makeWalletBridgeFromFollower(
         follower,
+        leader,
+        low,
         publicAddress,
         backendError,
         () => setConnectionState('bridged'),

--- a/packages/wallet/ui/src/service/Dapps.js
+++ b/packages/wallet/ui/src/service/Dapps.js
@@ -43,9 +43,6 @@ export const getDappService = publicAddress => {
         res();
       };
     });
-    if (d.enable) {
-      enableAction();
-    }
 
     dapps.set(d.origin, {
       ...d,
@@ -56,6 +53,10 @@ export const getDappService = publicAddress => {
         delete: () => deleteDapp(d.origin),
       },
     });
+
+    if (d.enable) {
+      enableAction();
+    }
   });
   broadcastUpdates();
 

--- a/packages/wallet/ui/src/service/ScopedBridge.js
+++ b/packages/wallet/ui/src/service/ScopedBridge.js
@@ -1,7 +1,14 @@
+import { makeFollower } from '@agoric/casting';
 import { Far } from '@endo/captp';
 
 export const getScopedBridge = (origin, suggestedDappPetname, bridge) => {
-  const { getPursesNotifier, getOffersNotifier, dappService } = bridge;
+  const {
+    getPursesNotifier,
+    getOffersNotifier,
+    dappService,
+    leader,
+    unserializer,
+  } = bridge;
 
   const { dapps, addDapp, setDappPetname, deleteDapp, enableDapp } =
     dappService;
@@ -60,6 +67,10 @@ export const getScopedBridge = (origin, suggestedDappPetname, bridge) => {
       await dapp.approvedP;
       // TODO: filter offers by dapp origin
       return getOffersNotifier();
+    },
+    async makeFollower(spec) {
+      await dapp.approvedP;
+      return makeFollower(spec, leader, { unserializer });
     },
   });
 };

--- a/packages/wallet/ui/src/util/WalletBackendAdapter.js
+++ b/packages/wallet/ui/src/util/WalletBackendAdapter.js
@@ -89,12 +89,16 @@ export const makeBackendFromWalletBridge = walletBridge => {
 
 /**
  * @param {import('@agoric/casting').Follower} follower
+ * @param {import('@agoric/casting').Leader} leader
+ * @param {import('@agoric/casting').Unserializer} unserializer
  * @param {string} publicAddress
  * @param {(e: unknown) => void} [errorHandler]
  * @param {() => void} [firstCallback]
  */
 export const makeWalletBridgeFromFollower = (
   follower,
+  leader,
+  unserializer,
   publicAddress,
   errorHandler = e => {
     // Make an unhandled rejection.
@@ -161,6 +165,9 @@ export const makeWalletBridgeFromFollower = (
     getScopedBridge: (origin, suggestedDappPetname) =>
       getScopedBridge(origin, suggestedDappPetname, {
         dappService,
+        leader,
+        unserializer,
+        publicAddress,
         ...getNotifierMethods,
       }),
   });


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/issues/4398

- Adds a shared unserializer to the wallet package
- Changes the wallet API to provide board ids in its slots so the shared unserializer can map brands together
- Adds a `makeFollower` method to the dapp UI bridge so dapps can use the low privilege unserializer from the wallet