### PR TITLE
4652 public priceAggregator medians off-chain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -125,6 +125,10 @@ require (
 // Silence a warning on MacOS
 replace github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 
+// At least until post-v0.9.0 is released with
+// https://github.com/Zondax/hid/issues/4 resolved.
+replace github.com/zondax/hid => github.com/zondax/hid v0.9.1-0.20220302062450-5552068d2266
+
 replace github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.sum
+++ b/go.sum
@@ -842,8 +842,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/zondax/hid v0.9.0 h1:eiT3P6vNxAEVxXMw66eZUAAnU2zD33JBkfG/EnfAKl8=
-github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
+github.com/zondax/hid v0.9.1-0.20220302062450-5552068d2266 h1:O9XLFXGkVswDFmH9LaYpqu+r/AAFWqr0DL6V00KEVFg=
+github.com/zondax/hid v0.9.1-0.20220302062450-5552068d2266/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -196,7 +196,7 @@
  *   bldIssuerKit: RemoteIssuerKit,
  *   board: Board,
  *   bridgeManager: OptionalBridgeManager,
- *   chainStorage: ChainStorageNode | null,
+ *   chainStorage: import('../lib-chainStorage.js').ChainStorageNode | null,
  *   chainTimerService: TimerService,
  *   client: ClientManager,
  *   clientCreator: ClientCreator,
@@ -214,8 +214,6 @@
  *   provisioning: Awaited<ProvisioningVat>,
  *   zoe: ZoeService,
  * }>} ChainBootstrapSpace
- *
- * @typedef {ReturnType<import('../lib-chainStorage.js').makeChainStorageRoot>} ChainStorageNode
  *
  * IDEA/TODO: make types of demo stuff invisible in production behaviors
  * @typedef {{

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -191,6 +191,7 @@
  * @typedef {PromiseSpaceOf<{
  *   agoricNames: NameHub,
  *   agoricNamesAdmin: NameAdmin,
+ *   aggregators: Map<unknown, { aggregator: PriceAuthority, deleter: import('@agoric/zoe/tools/priceAuthorityRegistry').Deleter }>,
  *   bankManager: Awaited<BankManager>,
  *   bldIssuerKit: RemoteIssuerKit,
  *   board: Board,

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -72,6 +72,7 @@ export function makeChainStorageRoot(toStorage, storeName, rootPath) {
   const rootNode = makeChainStorageNode(rootPath);
   return rootNode;
 }
+/** @typedef {ReturnType<typeof makeChainStorageRoot>} ChainStorageNode */
 
 /**
  * @returns {StorageNode} an object that confirms to StorageNode API but does not store anywhere.

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -11,6 +11,19 @@ const { details: X } = assert;
 const pathSegmentPattern = /^[a-zA-Z0-9_-]{1,100}$/;
 
 /**
+ * @param {string} name
+ */
+export const sanitizePathSegment = name => {
+  const candidate = name.replace(/[- ]/g, '_');
+  assert(
+    pathSegmentPattern.test(candidate),
+    `Path sanitization failed for ${name}`,
+  );
+  return candidate;
+};
+harden(sanitizePathSegment);
+
+/**
  * Create a root storage node for a given backing function and root path.
  *
  * @param {(message: any) => any} toStorage a function for sending a storageMessage object to the storage implementation (cf. golang/cosmos/x/swingset/storage.go)

--- a/packages/zoe/README.md
+++ b/packages/zoe/README.md
@@ -18,3 +18,36 @@ smart contract on Zoe is easy: all of the Zoe smart contracts are
 written in the familiar language of JavaScript.
 
 To learn more, please see the [Zoe guide](https://agoric.com/documentation/zoe/guide/). 
+
+## Reading data off-chain
+
+Some Zoe contracts publish data using StoredPublishKit which tees writes to off-chain storage. These can then be followed off-chain like so,
+```js
+  const key = `published.priceAggregator`; // or whatever the stream of interest is
+  const leader = makeDefaultLeader();
+  const follower = makeFollower(storeKey, leader);
+  for await (const { value } of iterateLatest(follower)) {
+    console.log(`here's a value`, value);
+  }
+```
+
+The canonical keys (under `published`) are as follows. Non-terminal nodes could have data but don't yet. A `0` indicates the index of that child in added order. To get the actual key look it up in parent. High cardinality types get a parent key for enumeration (e.g. `vaults`.)
+- `published`
+    - `priceAggregator`
+
+### Demo
+
+Start the chain in one terminal:
+```sh
+cd packages/cosmic-swingset
+make scenario2-setup scenario2-run-chain-economy
+```
+Once you see a string like `block 17 commit` then the chain is available. In another terminal,
+```sh
+# shows keys of the priceAggregator
+agd query vstorage keys 'published.priceFeed'
+# follow quotes
+agoric follow :published.priceFeed.ATOM_USD_price_feed
+```
+
+ TODO document more of https://github.com/Agoric/documentation/issues/672

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -29,23 +29,19 @@ const isGTE = (amount, amountLimit) => AmountMath.isGTE(amount, amountLimit);
 const isGT = (amount, amountLimit) => !AmountMath.isGTE(amountLimit, amount);
 
 /**
- * @typedef {object} OnewayPriceAuthorityOptions
- * @property {Issuer} quoteIssuer
- * @property {ERef<Notifier<unknown>>} notifier
- * @property {ERef<TimerService>} timer
- * @property {PriceQuoteCreate} createQuote
- * @property {Brand} actualBrandIn
- * @property {Brand} actualBrandOut
- */
-
-/**
  * @callback Trigger
  * @param {PriceQuoteCreate} createInstantQuote
  * @returns {Promise<void>}
  */
 
 /**
- * @param {OnewayPriceAuthorityOptions} opts
+ * @param {object} opts
+ * @param {Issuer} opts.quoteIssuer
+ * @param {ERef<Notifier<unknown>>} opts.notifier
+ * @param {ERef<TimerService>} opts.timer
+ * @param {PriceQuoteCreate} opts.createQuote
+ * @param {Brand} opts.actualBrandIn
+ * @param {Brand} opts.actualBrandOut
  * @returns {PriceAuthorityKit}
  */
 export function makeOnewayPriceAuthorityKit(opts) {

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -107,3 +107,4 @@ const start = async zcf => {
 
 harden(start);
 export { start };
+/** @typedef {ContractOf<typeof start>} OracleContract */

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -588,7 +588,7 @@ const start = async (
   };
 
   /**
-   * @type {Omit<PriceAggregatorCreatorFacet, 'makeOracleInvitation'> & {
+   * @type {Omit<import('./priceAggregator').PriceAggregatorContract['creatorFacet'], 'makeOracleInvitation'> & {
    *   getRoundData(_roundId: BigInt): Promise<any>,
    *   oracleRoundState(_oracle: OracleKey, _queriedRoundId: BigInt): Promise<any>
    * }}

--- a/packages/zoe/src/contracts/priceAggregatorTypes.js
+++ b/packages/zoe/src/contracts/priceAggregatorTypes.js
@@ -18,9 +18,7 @@
  */
 
 /**
- * @typedef {object} PriceAggregatorKit
- * @property {import("./priceAggregator").PriceAggregatorContract['publicFacet']} publicFacet
- * @property {import("./priceAggregator").PriceAggregatorContract['creatorFacet']} creatorFacet
+ * @typedef {Pick<import("./priceAggregator").PriceAggregatorContract, 'creatorFacet' | 'publicFacet'>} PriceAggregatorKit
  */
 
 /**

--- a/packages/zoe/src/contracts/priceAggregatorTypes.js
+++ b/packages/zoe/src/contracts/priceAggregatorTypes.js
@@ -18,26 +18,9 @@
  */
 
 /**
- * @typedef {object} PriceAggregatorCreatorFacet
- * @property {PriceAggregatorCreatorFacetInitOracle} initOracle
- * @property {(oracleKey: OracleKey) => Promise<void>} deleteOracle
- * @property {(oracleKey?: OracleKey) => Promise<Invitation>} makeOracleInvitation
- */
-
-/**
- * @typedef {object} PriceAggregatorPublicFacet
- * @property {() => PriceAuthority} getPriceAuthority
- * @property {() => Promise<Notifier<bigint> | undefined>} getRoundStartNotifier
- * @property {() => Promise<Notifier<{
- *   submitted: [OracleKey, bigint][],
- *   authenticatedQuote: Payment<'set'>,
- * }>>} getRoundCompleteNotifier
- */
-
-/**
  * @typedef {object} PriceAggregatorKit
- * @property {PriceAggregatorPublicFacet} publicFacet
- * @property {PriceAggregatorCreatorFacet} creatorFacet
+ * @property {import("./priceAggregator").PriceAggregatorContract['publicFacet']} publicFacet
+ * @property {import("./priceAggregator").PriceAggregatorContract['creatorFacet']} creatorFacet
  */
 
 /**
@@ -46,11 +29,18 @@
  */
 
 /**
+ * @typedef {Record<string, unknown> & {
+ * kind?: string,
+ * increment?: bigint,
+ * }} OracleQuery
+ */
+
+/**
  * @typedef {object} OraclePublicFacet
  * The public methods accessible from the contract instance
- * @property {(query: any) => ERef<Invitation>} makeQueryInvitation
+ * @property {(query: OracleQuery) => ERef<Invitation>} makeQueryInvitation
  * Create an invitation for an oracle query
- * @property {(query: any) => ERef<any>} query
+ * @property {(query: OracleQuery) => ERef<unknown>} query
  * Make an unpaid query
  */
 
@@ -104,12 +94,12 @@
 
 /**
  * @typedef {object} OracleHandler
- * @property {(query: any, fee: Amount) => Promise<OracleReply>} onQuery
+ * @property {(query: OracleQuery, fee: Amount) => Promise<OracleReply>} onQuery
  * Callback to reply to a query
- * @property {(query: any, reason: any) => void} onError
+ * @property {(query: OracleQuery, reason: unknown) => void} onError
  * Notice an error
- * @property {(query: any,
- *             reply: any,
+ * @property {(query: OracleQuery,
+ *             reply: unknown,
  *             requiredFee: Amount | undefined
  * ) => void} onReply
  * Notice a successful reply


### PR DESCRIPTION
closes: #4652

## Description

For each priceAggregator instance, create an off-chain storage stream.

Whenever a quote is produced by its priceAuthority, publish it on that strream.

### Security Considerations

Publishes prices, already public. For marshalling uses readonly.

### Documentation Considerations

zoe README updated.

### Testing Considerations

Updated the primary `priceAggregator` test to verify the publications along with other quotes.

To test off-chain I needed a publication, but it doesn't publish on boot. So to test that I hacked in a `.publish()` and verified the value came out at the desired key. Documented in README. Advice and requests welcomed for any other testing needed.