### PR TITLE
chore: route WalletAction, WalletSpendAction to walletFactory contract

### DIFF
--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -207,6 +207,25 @@ t1-provision-one-with-powers: wait-for-cosmos
 		  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
 		  t1/$(BASE_PORT) $$addr $(AGORIC_POWERS) -ojson | tee /dev/stderr | grep -q '"code":0'; }
 	
+fund-acct: wait-for-cosmos
+	$(AGCH) \
+	  --home=t1/bootstrap --keyring-backend=test --from=bootstrap \
+	  tx bank send bootstrap $(ACCT_ADDR) $(SOLO_COINS) \
+	  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID)
+
+FROM_KEY=bootstrap
+SIGN_MODE=
+wallet-action: wait-for-cosmos
+	$(AGCH) \
+	  --home=t1/bootstrap --keyring-backend=test --from=$(FROM_KEY) $(SIGN_MODE)\
+	  tx swingset wallet-action '{"give": 10, "want": 1}' \
+	  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID)
+
+wallet-action-gen:
+	$(AGCH) --chain-id=$(CHAIN_ID) \
+	  --home=t1/bootstrap --keyring-backend=test --from=$$(cat t1/bootstrap-address) $(SIGN_MODE)\
+	  tx swingset wallet-action '{"action":1}' \
+	  --generate-only --offline
 
 t1-provision-one: wait-for-cosmos
 	@addrfile=t1/$(BASE_PORT)/cosmos-client-account; \

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -213,6 +213,12 @@ fund-acct: wait-for-cosmos
 	  tx bank send bootstrap $(ACCT_ADDR) $(SOLO_COINS) \
 	  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID)
 
+provision-acct: wait-for-cosmos
+	$(AGCH) --chain-id=$(CHAIN_ID) \
+	  --home=t1/bootstrap --keyring-backend=test --from=bootstrap \
+	  tx swingset provision-one t1/$(BASE_PORT) $(ACCT_ADDR) $(AGORIC_POWERS) \
+	  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes
+
 FROM_KEY=bootstrap
 SIGN_MODE=
 wallet-action: wait-for-cosmos

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -18,7 +18,7 @@ import { Far } from '@endo/far';
 
 /**
  * @typedef {object} BridgeHandler An object that can receive messages from the bridge device
- * @property {(srcId: string, obj: any) => Promise<any>} fromBridge Handle an inbound message
+ * @property {(srcId: string, obj: any) => Promise<undefined>} fromBridge Handle an inbound message
  *
  * @typedef {object} BridgeManager The object to manage this bridge
  * @property {(dstID: string, obj: any) => any} toBridge
@@ -46,7 +46,7 @@ export function makeBridgeManager(E, D, bridgeDevice) {
     // );
 
     // Notify the specific handler, if there was one.
-    E(srcHandlers.get(srcID)).fromBridge(srcID, obj);
+    void E(srcHandlers.get(srcID)).fromBridge(srcID, obj);
 
     // No return value.
   }

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -18,7 +18,7 @@ import { Far } from '@endo/far';
 
 /**
  * @typedef {object} BridgeHandler An object that can receive messages from the bridge device
- * @property {(srcId: string, obj: any) => Promise<undefined>} fromBridge Handle an inbound message
+ * @property {(srcId: string, obj: any) => Promise<void>} fromBridge Handle an inbound message
  *
  * @typedef {object} BridgeManager The object to manage this bridge
  * @property {(dstID: string, obj: any) => any} toBridge

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -227,6 +227,7 @@ export const makeClientBanks = async ({
     client,
     chainStorage,
     bankManager,
+    bridgeManager: bridgeManagerP,
     zoe,
   },
   installation: {
@@ -235,12 +236,15 @@ export const makeClientBanks = async ({
 }) => {
   const STORAGE_PATH = 'wallet';
 
-  const storageNode = await makeStorageNode(chainStorage, STORAGE_PATH);
+  const [storageNode, bridgeManager] = await Promise.all([
+    makeStorageNode(chainStorage, STORAGE_PATH),
+    bridgeManagerP,
+  ]);
   const { creatorFacet } = await E(zoe).startInstance(
     walletFactory,
     {},
     { agoricNames, namesByAddress, board },
-    { storageNode },
+    { storageNode, bridgeManager },
   );
   return E(client).assignBundle([
     (address, powerFlags) => {

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -97,7 +97,7 @@ export const bridgeCoreEval = async allPowers => {
                   throw err;
                 }),
             ),
-          );
+          ).then(_ => {});
         }
         default:
           assert.fail(X`Unrecognized request ${obj.type}`);
@@ -150,7 +150,8 @@ export const bridgeProvisioner = async ({
             .pleaseProvision(nickname, address, powerFlags)
             .catch(e =>
               console.error(`Error provisioning ${nickname} ${address}:`, e),
-            );
+            )
+            .then(_ => {});
         }
         default:
           assert.fail(X`Unrecognized request ${obj.type}`);

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -108,6 +108,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
       namesByAddress: true,
       namesByAddressAdmin: true,
       bankManager: 'bank',
+      bridgeManager: true,
       board: 'board',
       client: true,
       chainStorage: true,

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -63,6 +63,7 @@ test('connectFaucet produces payments', async t => {
   const { zoe, feeMintAccess } = await setUpZoeForTest();
   produce.zoe.resolve(zoe);
   produce.feeMintAccess.resolve(feeMintAccess);
+  produce.bridgeManager.resolve(undefined);
 
   produce.loadVat.resolve(name => {
     switch (name) {

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -114,7 +114,7 @@ test('connectFaucet produces payments', async t => {
       board: true,
       zoe: true,
     };
-    E(client).assignBundle([_a => stub]);
+    void E(client).assignBundle([_a => stub]);
   };
 
   const vatPowers = {

--- a/packages/wallet/contract/package.json
+++ b/packages/wallet/contract/package.json
@@ -25,6 +25,7 @@
     "@agoric/deploy-script-support": "^0.9.0",
     "@agoric/store": "^0.7.2",
     "@agoric/vat-data": "^0.3.1",
+    "@agoric/vats": "^0.10.0",
     "@agoric/zoe": "^0.24.0",
     "@agoric/notifier": "^0.4.0",
     "@endo/far": "^0.2.5"

--- a/packages/wallet/contract/src/walletFactory.js
+++ b/packages/wallet/contract/src/walletFactory.js
@@ -63,7 +63,7 @@ export const start = async (zcf, privateArgs) => {
       assert.typeof(obj.owner, 'string');
       const wallet = walletsByAddress.get(obj.owner); // or throw
       console.log('walletFactory:', { wallet });
-      return E(wallet).performAction(obj); // TODO: add performAction to lib-wallet.js
+      // return E(wallet).performAction(obj); // TODO: add performAction to lib-wallet.js
     },
   });
 

--- a/packages/wallet/contract/src/walletFactory.js
+++ b/packages/wallet/contract/src/walletFactory.js
@@ -10,8 +10,9 @@ import '@agoric/zoe/exported.js';
 
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
-import { Far } from '@endo/far';
-import { makeSmartWallet } from './smartWallet.js';
+import * as BRIDGE_ID from '@agoric/vats/src/bridge-ids.js';
+import { E, Far } from '@endo/far';
+import { makeSmartWallet } from './smartWallet';
 
 /**
  * @typedef {{
@@ -19,6 +20,14 @@ import { makeSmartWallet } from './smartWallet.js';
  *   board: Board,
  *   namesByAddress: NameHub,
  * }} SmartWalletContractTerms
+ *
+ * @typedef {{
+ * 	 type: string, // WALLET_ACTION
+ *   owner: string,
+ *   spendAction: string,
+ *   blockHeight: unknown, // int64
+ *   blockTime: unknown, // int64
+ * }} WalletAction
  */
 
 /**
@@ -26,6 +35,7 @@ import { makeSmartWallet } from './smartWallet.js';
  * @param {ZCF<SmartWalletContractTerms>} zcf
  * @param {{
  *   storageNode?: ERef<StorageNode>,
+ *   bridgeManager?: BridgeManager,
  * }} privateArgs
  */
 export const start = async (zcf, privateArgs) => {
@@ -34,11 +44,31 @@ export const start = async (zcf, privateArgs) => {
   assert(namesByAddress, 'missing namesByAddress');
   assert(agoricNames, 'missing agoricNames');
   const zoe = zcf.getZoeService();
-  const { storageNode } = privateArgs;
+  const { storageNode, bridgeManager } = privateArgs;
 
   /** @type {MapStore<string, import('./smartWallet').SmartWallet>} */
   const walletsByAddress = makeScalarBigMapStore('walletsByAddress');
   const provider = makeAtomicProvider(walletsByAddress);
+
+  const handleWalletAction = Far('walletActionHandler', {
+    /**
+     *
+     * @param {string} srcID
+     * @param {WalletAction} obj
+     */
+    fromBridge: async (srcID, obj) => {
+      console.log('walletFactory.fromBridge:', srcID, obj);
+      assert(obj, 'missing wallet action');
+      assert.typeof(obj, 'object');
+      assert.typeof(obj.owner, 'string');
+      const wallet = walletsByAddress.get(obj.owner); // or throw
+      console.log('walletFactory:', { wallet });
+      return E(wallet).performAction(obj); // TODO: add performAction to lib-wallet.js
+    },
+  });
+
+  await (bridgeManager &&
+    E(bridgeManager).register(BRIDGE_ID.WALLET, handleWalletAction));
 
   const shared = {
     agoricNames,

--- a/packages/wallet/contract/src/walletFactory.js
+++ b/packages/wallet/contract/src/walletFactory.js
@@ -67,6 +67,8 @@ export const start = async (zcf, privateArgs) => {
     },
   });
 
+  // NOTE: both `MsgWalletAction` and `MsgWalletSpendAction` arrive as BRIDGE_ID.WALLET
+  // by way of makeBlockManager() in cosmic-swingset/src/block-manager.js
   await (bridgeManager &&
     E(bridgeManager).register(BRIDGE_ID.WALLET, handleWalletAction));
 

--- a/packages/wallet/contract/src/walletFactory.js
+++ b/packages/wallet/contract/src/walletFactory.js
@@ -22,12 +22,19 @@ import { makeSmartWallet } from './smartWallet';
  * }} SmartWalletContractTerms
  *
  * @typedef {{
- * 	 type: string, // WALLET_ACTION
+ * 	 type: 'WALLET_ACTION',
+ *   owner: string,
+ *   action: string,
+ *   blockHeight: unknown, // int64
+ *   blockTime: unknown, // int64
+ * }} WalletAction
+ * @typedef {{
+ * 	 type: 'WALLET_SPEND_ACTION',
  *   owner: string,
  *   spendAction: string,
  *   blockHeight: unknown, // int64
  *   blockTime: unknown, // int64
- * }} WalletAction
+ * }} WalletSpendAction
  */
 
 /**
@@ -54,7 +61,7 @@ export const start = async (zcf, privateArgs) => {
     /**
      *
      * @param {string} srcID
-     * @param {WalletAction} obj
+     * @param {WalletAction|WalletSpendAction} obj
      */
     fromBridge: async (srcID, obj) => {
       console.log('walletFactory.fromBridge:', srcID, obj);


### PR DESCRIPTION
refs: #4398 

## Description

route WalletAction, WalletSpendAction through the `bridgeManager` to walletFactory contract

 - cosmic-swingset integration test helpers:: fund-acct, wallet-action, provision-acct Makefile rules

### Security Considerations

relies on golang to authenticate the `.owner` address before we use it to look up the relevant wallet.

### Documentation Considerations

?

### Testing Considerations

Tested manually, so far.

Automated testing golang+JS stuff is beyond the current state-of-the-art.