### PR TITLE
docs: Reminder to flush next-release label

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,9 @@
 # Maintainer Hints
 
+Review the [next release](
+https://github.com/Agoric/agoric-sdk/labels/next%20release
+) label for additional tasks particular to this release.
+
 ```sh
 # Create a release branch.
 now=`date -u +%Y%m%dT%H%M%S`


### PR DESCRIPTION
This codifies our new process for signaling to the maintainer of Agoric-SDK that there are additional tasks for the release process cataloged in `MAINTAINERS.md`.
