### PR TITLE
feat(wallet/api): marshal contexts for wallet, board

### DIFF
--- a/packages/wallet/api/src/marshal-contexts.js
+++ b/packages/wallet/api/src/marshal-contexts.js
@@ -20,25 +20,10 @@ export const makeExportContext = () => {
   const toVal = {
     /** @type {MapStore<string, Purse>} */
     purse: makeScalarMap(),
-    /** @type {MapStore<string, Brand>} */
-    brand: makeScalarMap(),
-    /** @type {MapStore<string, Issuer>} */
-    issuer: makeScalarMap(),
-    // TODO: 6 in total, right?
-    // offer
-    // contact
-    // dapp
   };
   const fromVal = {
     /** @type {MapStore<Purse, string>} */
     purse: makeScalarMap(),
-    /** @type {MapStore<Brand, string>} */
-    brand: makeScalarMap(),
-    /** @type {MapStore<Issuer, string>} */
-    issuer: makeScalarMap(),
-    // offer
-    // contact
-    // dapp
   };
   /** @type {MapStore<unknown, string>} */
   const sharedData = makeScalarMap();
@@ -79,15 +64,6 @@ export const makeExportContext = () => {
       fromVal.purse.init(purse, id);
     },
     purseEntries: toVal.purse.entries,
-    initBrandId: (id, brand) => {
-      toVal.brand.init(id, brand);
-      fromVal.brand.init(brand, id);
-    },
-    brandEntries: toVal.purse.entries,
-    initIssuerId: (id, issuer) => {
-      toVal.issuer.init(id, issuer);
-      fromVal.issuer.init(issuer, id);
-    },
     // Public values.
     initBoardId: (id, val) => {
       sharedData.init(val, id);
@@ -96,7 +72,6 @@ export const makeExportContext = () => {
       if (sharedData.has(val)) return;
       sharedData.init(val, id);
     },
-    issuerEntries: toVal.purse.entries,
     ...makeMarshal(valToSlot, slotToVal),
   });
 };
@@ -110,13 +85,6 @@ export const makeImportContext = () => {
   const myData = {
     /** @type {MapStore<string, Purse>} */
     purse: makeScalarMap(),
-    /** @type {MapStore<string, Brand>} */
-    brand: makeScalarMap(),
-    /** @type {MapStore<string, Issuer>} */
-    issuer: makeScalarMap(),
-    // offer
-    // contact
-    // dapp
   };
   /** @type {MapStore<string, unknown>} */
   const sharedData = makeScalarMap();
@@ -136,7 +104,6 @@ export const makeImportContext = () => {
       if (kind) {
         assert.fail(X`bad shared slot ${q(slot)}`);
       }
-      // TODO: assert(slot.startswith('board'))?
       const it = makePresence(slot, iface);
 
       sharedData.init(slot, it);

--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -327,7 +327,7 @@ test('lib-wallet issuer and purse methods', async (/** @type {LibWalletTestConte
       },
       {
         brand: purseLog[1].brand,
-        brandBoardId: 'board0566',
+        brandBoardId: 'board0425',
         brandPetname: 'moola',
         depositBoardId: 'board0371',
         displayInfo: {

--- a/packages/wallet/api/test/test-wallet-marshal.js
+++ b/packages/wallet/api/test/test-wallet-marshal.js
@@ -1,0 +1,92 @@
+// @ts-check
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Far } from '@endo/far';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
+import {
+  makeExportContext,
+  makeImportContext,
+} from '../src/marshal-contexts.js';
+
+/**
+ * @param {ReturnType<typeof makeBoard>} board
+ */
+const makeAMM = board => {
+  const atom = Far('ATOM brand', {});
+  const pub = board.getPublishingMarshaller();
+  return harden({ getMetrics: () => pub.serialize(harden([atom])) });
+};
+
+/**
+ * @param {ReturnType<typeof makeBoard>} board
+ */
+const makeWallet = board => {
+  const context = makeExportContext();
+  let brand;
+  return harden({
+    suggestIssuer: (name, boardId) => {
+      brand = board.getValue(boardId);
+      const purse = Far(`${name} purse`, {
+        getCurrentAmount: () => harden({ brand, value: 100 }),
+      });
+      // only for private brands
+      //   context.initBrandId(boardId, brand);
+      context.initBoardId(boardId, brand);
+      context.initPurseId(name, purse); // TODO: strong id rather than name?
+    },
+    publish: () =>
+      context.serialize(
+        harden(
+          [...context.purseEntries()].map(([name, purse], id) => ({
+            meta: { id },
+            // displayInfo
+            // brandBoardId,
+            purse,
+            brand,
+            currentAmount: purse.getCurrentAmount(),
+            // actions
+            brandPetname: name,
+            pursePetname: `${name} purse`,
+          })),
+        ),
+      ),
+  });
+};
+
+test('preserve identity of brands across AMM and wallet', t => {
+  const context = makeImportContext();
+
+  const board = makeBoard(0, { prefix: 'board' });
+  const amm = makeAMM(board);
+  const ammMetricsCapData = amm.getMetrics();
+
+  t.deepEqual(ammMetricsCapData, {
+    body: '[{"@qclass":"slot","iface":"Alleged: ATOM brand","index":0}]',
+    slots: ['board011'],
+  });
+
+  /** @type {Brand[]} */
+  const [b1] = context.fromBoard.unserialize(ammMetricsCapData);
+  /** @type {Brand[]} */
+  const [b2] = context.fromBoard.unserialize(amm.getMetrics());
+  t.is(b1, b2, 'unserialization twice from same source');
+
+  const myWallet = makeWallet(board);
+  myWallet.suggestIssuer('ATOM', 'board011');
+  const walletCapData = myWallet.publish();
+  t.deepEqual(walletCapData, {
+    body: '[{"brand":{"@qclass":"slot","iface":"Alleged: ATOM brand","index":0},"brandPetname":"ATOM","currentAmount":{"brand":{"@qclass":"slot","index":0},"value":100},"meta":{"id":0},"purse":{"@qclass":"slot","iface":"Alleged: ATOM purse","index":1},"pursePetname":"ATOM purse"}]',
+    slots: ['board011', 'purse:ATOM'],
+  });
+
+  const walletState = context.fromWallet.unserialize(walletCapData);
+  t.is(walletState[0].brand, b1, 'unserialization across sources');
+
+  t.throws(
+    () => context.fromBoard.unserialize(walletCapData),
+    { message: /bad shared slot/ },
+    'AMM cannot refer to purses',
+  );
+});
+
+// TODO: test consistent deserialization of unregistered objects in fromWallet


### PR DESCRIPTION
refs: #4398

cc @samsiegart @turadg @warner @michaelfig 

## Description

marshal contexts for:
 - on-chain smart wallet
 - off-chain wallet ui
   - from AMM etc. (board)
   - from private wallet state

not yet integrated with either walletFactory contract nor wallet ui. Should that be in this PR or a separate one?

### Security Considerations

It's essential that the AMM can't refer to private objects such as purses.

### Documentation Considerations

?

### Testing Considerations

Unit tests, so far.
