### PR TITLE
fix(vat-data)!: diagnose provide collisions

### DIFF
--- a/packages/vat-data/src/environment-options.js
+++ b/packages/vat-data/src/environment-options.js
@@ -1,0 +1,135 @@
+// @ts-check
+
+// NOTE This module is essentially a duplicate of a module by the same name
+// in the endo repository. It is copied here *temporarily* until the one in
+// endo exports bindings we can import.
+// The prelude below --- the import and initial const declarations, are
+// stated differently that the original because of the change of context,
+// but the rest should remain identical.
+// TODO make the environment-options.js in endo one that can be imported from,
+// and then delete this duplicate.
+
+import { assert } from '@agoric/assert';
+
+const { details: X, quote: q } = assert;
+const { freeze } = Object;
+const arrayPushMethod = Array.prototype.push;
+const arrayPush = (array, thing) =>
+  Reflect.apply(arrayPushMethod, array, [thing]);
+
+/**
+ * JavaScript module semantics resists attempts to parameterize a module's
+ * initialization behavior. A module initializes in order according to
+ * the path by which it is first imported, and then the initialized module
+ * is reused by all the other times it is imported. Compartments give us
+ * the opportunity to bind the same import name to different imported
+ * modules, depending on the package/compartment doing the import. Compartments
+ * also address the difficulty of parameterizing a module's initialization
+ * logic, but not in a pleasant manner.
+ *
+ * A pleasant parameterization would be for a static module to be function-like
+ * with explicit parameters, and for the parameterization to be like
+ * calling the static module with parameters in order to derive from it a
+ * module instance. Compartments instead lets us parameterize the meaning
+ * of a module instance derived from a static module according to the
+ * three namespaces provided by the JavaScript semantics, affecting the
+ * meaning of a module instance.
+ *    * The global variable namespaces.
+ *       * The global scope, aliased to properties of the global object.
+ *         This is necessarily compartment-wide, and therefore in our
+ *         recommened usage pattern, package-wide.
+ *       * The global lexical scope. The SES-shim compartments support
+ *         these both compartment-wide as well as per-module. But it is
+ *         not yet clear what we will propose in the Compartment proposal.
+ *    * The import namespace.
+ *    * The host hooks.
+ *
+ * This `environment-options.js` module looks for a setting of an
+ * `optionName` parameter rooted in the global scope. If follows the Node
+ * precedent for finding Unix environment variable settings, looking for a
+ * global `process` object holding an `env` object,
+ * optionally holding a property named for the `optionName` whose value is the
+ * configuration setting of that option. For example, for the optionName
+ * `FOO_BAR` it would look in
+ * `globalThis.process.env.FOO_BAR`.
+ *
+ * If setting is either absent or `undefined`, that indicates that
+ * this configuration option should have its default behavior, whatever that is.
+ * Otherwise, reflecting Unix environment variables, the setting must be a
+ * string. This also helps ensure that this channel is used only to pass data,
+ * not authority beyond the ability to read this global state.
+ */
+
+/**
+ * makeEnvironmentCaptor provides a mechanism for getting environment
+ * variables, if they are needed, and a way to catalog the names of all
+ * the environment variables that were captured.
+ *
+ * @param {object} aGlobal
+ */
+export const makeEnvironmentCaptor = aGlobal => {
+  const capturedEnvironmentOptionNames = [];
+
+  /**
+   * Gets an environment option by name and returns the option value or the
+   * given default.
+   *
+   * @param {string} optionName
+   * @param {string} defaultSetting
+   * @returns {string}
+   */
+  const getEnvironmentOption = (optionName, defaultSetting) => {
+    // eslint-disable-next-line @endo/no-polymorphic-call
+    assert.typeof(
+      optionName,
+      'string',
+      X`Environment option name ${q(optionName)} must be a string.`,
+    );
+    // eslint-disable-next-line @endo/no-polymorphic-call
+    assert.typeof(
+      defaultSetting,
+      'string',
+      X`Environment option default setting ${q(
+        defaultSetting,
+      )} must be a string.`,
+    );
+
+    /** @type {string} */
+    let setting = defaultSetting;
+    const globalProcess = aGlobal.process;
+    if (globalProcess && typeof globalProcess === 'object') {
+      const globalEnv = globalProcess.env;
+      if (globalEnv && typeof globalEnv === 'object') {
+        if (optionName in globalEnv) {
+          arrayPush(capturedEnvironmentOptionNames, optionName);
+          const optionValue = globalEnv[optionName];
+          // eslint-disable-next-line @endo/no-polymorphic-call
+          assert.typeof(
+            optionValue,
+            'string',
+            X`Environment option named ${q(
+              optionName,
+            )}, if present, must have a corresponding string value, got ${q(
+              optionValue,
+            )}`,
+          );
+          setting = optionValue;
+        }
+      }
+    }
+    assert(
+      setting === undefined || typeof setting === 'string',
+      X`Environment option value ${q(setting)}, if present, must be a string.`,
+    );
+    return setting;
+  };
+  freeze(getEnvironmentOption);
+
+  const getCapturedEnvironmentOptionNames = () => {
+    return freeze([...capturedEnvironmentOptionNames]);
+  };
+  freeze(getCapturedEnvironmentOptionNames);
+
+  return freeze({ getEnvironmentOption, getCapturedEnvironmentOptionNames });
+};
+freeze(makeEnvironmentCaptor);

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -24,8 +24,13 @@ export {
 };
 
 const { getEnvironmentOption } = makeEnvironmentCaptor(globalThis);
+// TODO DANGER HAZARD DO NOT MERGE UNTIL FIXED
+// Since this is not on master yet or even ready-for-review, and we don't know
+// when it will be, by temporarily flipping the default here to `'true'`,
+// I can get CI to run our entire system under this constraint to see what
+// breaks.
 const DETECT_PROVIDE_COLLISIONS =
-  getEnvironmentOption('DETECT_PROVIDE_COLLISIONS', 'false') === 'true';
+  getEnvironmentOption('DETECT_PROVIDE_COLLISIONS', 'true') === 'true';
 
 const { details: X, quote: q } = assert;
 

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -1,7 +1,33 @@
 /* global globalThis */
 
-import { Fail } from '@agoric/assert';
-import { provideLazy } from '@agoric/store';
+import { Fail, assert } from '@agoric/assert';
+import {
+  M,
+  makeScalarMapStore,
+  makeScalarWeakMapStore,
+  makeScalarSetStore,
+  makeScalarWeakSetStore,
+  provideLazy,
+} from '@agoric/store';
+
+// TODO import from proper place. See note in that module.
+import { makeEnvironmentCaptor } from './environment-options.js';
+
+/** @typedef {import('./types.js').Baggage} Baggage */
+
+export {
+  M,
+  makeScalarMapStore,
+  makeScalarWeakMapStore,
+  makeScalarSetStore,
+  makeScalarWeakSetStore,
+};
+
+const { getEnvironmentOption } = makeEnvironmentCaptor(globalThis);
+const DETECT_PROVIDE_COLLISIONS =
+  getEnvironmentOption('DETECT_PROVIDE_COLLISIONS', 'false') === 'true';
+
+const { details: X, quote: q } = assert;
 
 /** @type {import('./types').VatData} */
 let VatDataGlobal;
@@ -111,6 +137,83 @@ harden(partialAssign);
  * @property {import('./types').Pattern} [valueShape]
  */
 /**
+ * @template {string} K
+ * @template V
+ * @typedef {Map<K, (key:K) => V>} ProvisionEntries
+ */
+
+/**
+ * @template {string} K
+ * @template V
+ * @type {WeakMap<Baggage, ProvisionEntries<K,V>>}
+ */
+// @ts-expect-error I only use it when DETECT_PROVIDE_COLLISIONS , so I
+// know it is not `undefined` in those cases.
+const provisionTracker = DETECT_PROVIDE_COLLISIONS ? new WeakMap() : undefined;
+
+/**
+ * HAZARD: `assertUniqueProvide` uses top-level mutable state, but only for
+ * diagnostic purposes.
+ * Aside from being able to provoke it to throw an error, it is not
+ * otherwise usable as a top-level communications channel. The throwing-or-not
+ * of the error is the only way in which this top level state is observable.
+ *
+ * TODO since this still does violate our security assumptions, we should
+ * consider making it development-time only, and turn it off in production.
+ * Or better, adapt it to stop using top-level state.
+ *
+ * The condition it checks for is that, within one incarnation, the
+ * `provide` is never called twice with the same `mapStore`
+ * and the same `key`. For a given `mapStore` and `key`, there should be at
+ * most one `provide` call but any number of `get` calls.
+ *
+ * When the `mapStore` is baggage, for purposes of upgrade, then we
+ * expect `provide` to be called with the same `baggage` and `key`
+ * (and some `makeValue`) in each incarnation of that vat.
+ * In the incarnation that first registers this `baggage`,`key` pair, the
+ * `provide` will actually call the `makeValue`. The one `provide` call
+ * for this pair in each succeeding incarnation will merely retrieve the value it
+ * inherited from the previous incarnation. But even for this case, it should
+ * only call `provide` for that pair once during that incarnation.
+ *
+ * @template {string} K
+ * @template V
+ * @param {Baggage} baggage
+ * @param {K} key
+ * @param {(key: K) => V} makeValue
+ */
+const assertUniqueProvide = (baggage, key, makeValue) => {
+  if (provisionTracker.has(baggage)) {
+    /** @type {ProvisionEntries<K,V>} */
+    // @ts-expect-error TS doesn't understand that .has guarantees .get
+    const submap = provisionTracker.get(baggage);
+    assert(submap !== undefined);
+    if (submap.has(key)) {
+      if (submap.get(key) === makeValue) {
+        // The error message also tells us if the colliding calls happened
+        // to use the same `makeValue` only as a clue about whether
+        // these are two separate evaluations at of the same call site or
+        // two distinct call sites. However, this clue is unreliable in
+        // both directions.
+        assert.fail(
+          X`provide collision on ${q(
+            key,
+          )} with same makeValue. Consider provideLazy()`,
+        );
+      } else {
+        assert.fail(X`provide collision on ${q(key)} with different makeValue`);
+      }
+    } else {
+      submap.set(key, makeValue);
+    }
+  } else {
+    const submap = new Map([[key, makeValue]]);
+    // @ts-expect-error This type error I don't understand
+    provisionTracker.set(baggage, submap);
+  }
+};
+
+/**
  * Unlike `provideLazy`, `provide` should be called at most once
  * within any vat incarnation with a given `baggage`,`key` pair.
  *
@@ -134,13 +237,21 @@ harden(partialAssign);
  * `provide` violates the above prescription, and is called more
  * than once in the same vat incarnation with the same
  * baggage,key pair.
+ *
+ * @template {string} K
+ * @template V
+ * @param {Baggage} baggage
+ * @param {K} key
+ * @param {(key: K) => V} makeValue
+ * @returns {V}
  */
-
-export const provide =
-  // XXX cast because provideLazy is `any` due to broken type import
-  /** @type {<K, V>(baggage: import('./types.js').Baggage, key: K, makeValue: (key: K) => V) => V} */ (
-    provideLazy
-  );
+export const provide = (baggage, key, makeValue) => {
+  if (DETECT_PROVIDE_COLLISIONS) {
+    assertUniqueProvide(baggage, key, makeValue);
+  }
+  return provideLazy(baggage, key, makeValue);
+};
+harden(provide);
 
 // TODO: Find a good home for this function used by @agoric/vat-data and testing code
 /** @param {import('@agoric/vat-data/src/types').VatData} VatData */


### PR DESCRIPTION
@Chris-Hibbert , if this is green under CI, what do you think of the invariant that this check enforces? By doing it here in `provide` is it inherited by all our other `provide*` and `vivify*` abstractions? (I think so) Should we make that invariant part of the spec of all the `provide*` and `vivify*` abstractions? (aside from `provideAsync` I think)

@turadg @samsiegart @Chris-Hibbert @FUDCo @warner @mhofman , once this is ready, I will ask you to review. Until then, please ignore. Though I'm keeping @turadg and @samsiegart listed since they've already commented.