### PR TITLE
fix: correct input validation of displayInfo

### DIFF
--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -11,7 +11,7 @@ import { DisplayInfoShape } from './typeGuards.js';
  * @returns {DisplayInfo}
  */
 export const coerceDisplayInfo = (allegedDisplayInfo, assetKind) => {
-  fit(allegedDisplayInfo, DisplayInfoShape);
+  fit(allegedDisplayInfo, DisplayInfoShape, 'displayInfo');
 
   if (allegedDisplayInfo.assetKind !== undefined) {
     assert(

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -1,53 +1,9 @@
 // @ts-check
 
-import { assert, details as X, q } from '@agoric/assert';
-import { assertRecord, isObject, passStyleOf } from '@endo/marshal';
+import { assert, details as X } from '@agoric/assert';
+import { fit } from '@agoric/store';
 
-// One GOOGOLth should be enough decimal places for anybody.
-export const MAX_ABSOLUTE_DECIMAL_PLACES = 100;
-
-// TODO Once https://github.com/endojs/endo/pull/1061 is merged, then we
-// should add `assertPure` to the imports from `@endo/marshal` and remove
-// the redundant definition here.
-const assertPure = (pureData, optNameOfData = 'Allegedly pure data') => {
-  const passStyle = passStyleOf(pureData);
-  switch (passStyle) {
-    case 'copyArray':
-    case 'copyRecord':
-    case 'tagged': {
-      return true;
-    }
-    default: {
-      if (!isObject(pureData)) {
-        return true;
-      }
-      assert.fail(
-        X`${q(optNameOfData)} ${pureData} must be pure, not a ${q(passStyle)}`,
-      );
-    }
-  }
-};
-
-// TODO: assertSubset is copied from Zoe. Move this code to a location
-// where it can be used by ERTP and Zoe easily. Perhaps another
-// package.
-
-/**
- * Assert all values from `part` appear in `whole`.
- *
- * @param {string[]} whole
- * @param {string[]} part
- */
-const assertSubset = (whole, part) => {
-  part.forEach(key => {
-    assert(
-      whole.includes(key),
-      X`key ${q(key)} was not one of the expected keys ${q(whole)}`,
-    );
-  });
-};
-
-const displayInfoKeys = harden(['decimalPlaces', 'assetKind']);
+import { DisplayInfoShape } from './typeGuards.js';
 
 /**
  * @param {AdditionalDisplayInfo} allegedDisplayInfo
@@ -55,9 +11,7 @@ const displayInfoKeys = harden(['decimalPlaces', 'assetKind']);
  * @returns {DisplayInfo}
  */
 export const coerceDisplayInfo = (allegedDisplayInfo, assetKind) => {
-  // We include this check for a better error message
-  assertRecord(allegedDisplayInfo, 'displayInfo');
-  assertPure(allegedDisplayInfo, 'displayInfo');
+  fit(allegedDisplayInfo, DisplayInfoShape);
 
   if (allegedDisplayInfo.assetKind !== undefined) {
     assert(
@@ -67,19 +21,10 @@ export const coerceDisplayInfo = (allegedDisplayInfo, assetKind) => {
   }
   const displayInfo = harden({ ...allegedDisplayInfo, assetKind });
 
-  assertSubset(displayInfoKeys, Object.keys(displayInfo));
   if (displayInfo.decimalPlaces !== undefined) {
     assert(
       Number.isSafeInteger(displayInfo.decimalPlaces),
       X`decimalPlaces ${displayInfo.decimalPlaces} is not a safe integer`,
-    );
-    assert(
-      displayInfo.decimalPlaces <= MAX_ABSOLUTE_DECIMAL_PLACES,
-      X`decimalPlaces ${displayInfo.decimalPlaces} exceeds ${MAX_ABSOLUTE_DECIMAL_PLACES}`,
-    );
-    assert(
-      displayInfo.decimalPlaces >= -MAX_ABSOLUTE_DECIMAL_PLACES,
-      X`decimalPlaces ${displayInfo.decimalPlaces} is less than -${MAX_ABSOLUTE_DECIMAL_PLACES}`,
     );
   }
 

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -110,3 +110,22 @@ harden(isSetValue);
  */
 export const isCopyBagValue = value => matches(value, CopyBagValueShape);
 harden(isCopyBagValue);
+
+// One GOOGOLth should be enough decimal places for anybody.
+export const MAX_ABSOLUTE_DECIMAL_PLACES = 100;
+
+export const AssetValueShape = M.or('nat', 'set', 'copySet', 'copyBag');
+
+export const DisplayInfoShape = M.partial(
+  harden({
+    decimalPlaces: M.and(
+      M.gte(-MAX_ABSOLUTE_DECIMAL_PLACES),
+      M.lte(MAX_ABSOLUTE_DECIMAL_PLACES),
+    ),
+    assetKind: AssetValueShape,
+  }),
+  harden({
+    // Including this empty `rest` ensures that there are no other
+    // properties beyond those in the `base` record.
+  }),
+);

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -32,7 +32,7 @@ test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
         // @ts-expect-error Intentional wrong type for testing
         harden({ decimalPlaces: 'hello' }),
       ),
-    { message: /"hello" - Must be >= -100/ },
+    { message: /^displayInfo: "hello" - Must be >= -100$/ },
   );
 
   t.throws(
@@ -58,13 +58,13 @@ test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
   t.throws(
     () =>
       makeIssuerKit('myTokens', AssetKind.NAT, harden({ decimalPlaces: 101 })),
-    { message: /101 - Must be <= 100/ },
+    { message: /^displayInfo: 101 - Must be <= 100$/ },
   );
 
   t.throws(
     () =>
       makeIssuerKit('myTokens', AssetKind.NAT, harden({ decimalPlaces: -101 })),
-    { message: /-101 - Must be >= -100/ },
+    { message: /^displayInfo: -101 - Must be >= -100$/ },
   );
 });
 
@@ -81,7 +81,7 @@ test('makeIssuerKit bad displayInfo.assetKind', async t => {
       ),
     {
       message:
-        /"something" - Must match one of \["nat","set","copySet","copyBag"\]/,
+        /^displayInfo: "something" - Must match one of \["nat","set","copySet","copyBag"\]$/,
     },
   );
 });
@@ -98,7 +98,8 @@ test('makeIssuerKit bad displayInfo.whatever', async t => {
         }),
       ),
     {
-      message: /Remainder \{"whatever":"something"\} - Must match \{\}/,
+      message:
+        /^displayInfo: Remainder \{"whatever":"something"\} - Must match \{\}$/,
     },
   );
 });
@@ -110,10 +111,11 @@ test('makeIssuerKit malicious displayInfo', async t => {
         'myTokens',
         AssetKind.NAT,
         // @ts-expect-error Intentional wrong type for testing
-        'bad displayInfo',
+        'badness',
       ),
     {
-      message: /"bad displayInfo" - Must have shape of base: "copyRecord"/,
+      message:
+        /^displayInfo: "badness" - Must have shape of base: "copyRecord"$/,
     },
   );
 });

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -32,7 +32,7 @@ test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
         // @ts-expect-error Intentional wrong type for testing
         harden({ decimalPlaces: 'hello' }),
       ),
-    { message: `decimalPlaces "hello" is not a safe integer` },
+    { message: /"hello" - Must be >= -100/ },
   );
 
   t.throws(
@@ -58,13 +58,13 @@ test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
   t.throws(
     () =>
       makeIssuerKit('myTokens', AssetKind.NAT, harden({ decimalPlaces: 101 })),
-    { message: 'decimalPlaces 101 exceeds 100' },
+    { message: /101 - Must be <= 100/ },
   );
 
   t.throws(
     () =>
       makeIssuerKit('myTokens', AssetKind.NAT, harden({ decimalPlaces: -101 })),
-    { message: 'decimalPlaces -101 is less than -100' },
+    { message: /-101 - Must be >= -100/ },
   );
 });
 
@@ -81,7 +81,7 @@ test('makeIssuerKit bad displayInfo.assetKind', async t => {
       ),
     {
       message:
-        'displayInfo.assetKind was present ("something") and did not match the assetKind argument ("nat")',
+        /"something" - Must match one of \["nat","set","copySet","copyBag"\]/,
     },
   );
 });
@@ -98,8 +98,7 @@ test('makeIssuerKit bad displayInfo.whatever', async t => {
         }),
       ),
     {
-      message:
-        'key "whatever" was not one of the expected keys ["decimalPlaces","assetKind"]',
+      message: /Remainder \{"whatever":"something"\} - Must match \{\}/,
     },
   );
 });
@@ -114,8 +113,7 @@ test('makeIssuerKit malicious displayInfo', async t => {
         'bad displayInfo',
       ),
     {
-      message:
-        '"displayInfo" "bad displayInfo" must be a pass-by-copy record, not "string"',
+      message: /"bad displayInfo" - Must have shape of base: "copyRecord"/,
     },
   );
 });

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -44,8 +44,7 @@ test('bad display info', t => {
   const displayInfo = harden({ somethingUnexpected: 3 });
   // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => makeIssuerKit('fungible', AssetKind.NAT, displayInfo), {
-    message:
-      /key "somethingUnexpected" was not one of the expected keys \["decimalPlaces","assetKind"\]/,
+    message: /Remainder \{"somethingUnexpected":3\} - Must match \{\}/,
   });
 });
 

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -44,7 +44,8 @@ test('bad display info', t => {
   const displayInfo = harden({ somethingUnexpected: 3 });
   // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => makeIssuerKit('fungible', AssetKind.NAT, displayInfo), {
-    message: /Remainder \{"somethingUnexpected":3\} - Must match \{\}/,
+    message:
+      /^displayInfo: Remainder \{"somethingUnexpected":3\} - Must match \{\}$/,
   });
 });
 

--- a/packages/store/src/patterns/match-helpers.js
+++ b/packages/store/src/patterns/match-helpers.js
@@ -1,0 +1,46 @@
+import { E } from '@endo/eventual-send';
+import { isPromise } from '@endo/promise-kit';
+
+const { details: X } = assert;
+
+/**
+ * @param {Error} innerErr
+ * @param {string} label
+ * @param {ErrorConstructor=} ErrorConstructor
+ * @returns {never}
+ */
+export const throwLabeled = (innerErr, label, ErrorConstructor = undefined) => {
+  const outerErr = assert.error(
+    `${label}: ${innerErr.message}`,
+    ErrorConstructor,
+  );
+  assert.note(outerErr, X`Caused by ${innerErr}`);
+  throw outerErr;
+};
+harden(throwLabeled);
+
+/**
+ * @template A,R
+ * @param {(...args: A) => R} func
+ * @param {A} args
+ * @param {string} [label]
+ * @returns {R}
+ */
+export const applyLabelingError = (func, args, label = undefined) => {
+  if (label === undefined) {
+    return func(...args);
+  }
+  assert.typeof(label, 'string');
+  let result;
+  try {
+    result = func(...args);
+  } catch (err) {
+    throwLabeled(err, label);
+  }
+  if (isPromise(result)) {
+    return E.when(result, undefined, reason => throwLabeled(reason, label));
+  } else {
+    return result;
+  }
+};
+harden(applyLabelingError);

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -27,6 +27,7 @@ import {
   checkCopyMap,
   copyMapKeySet,
 } from '../keys/checkKey.js';
+import { applyLabelingError } from './match-helpers.js';
 
 /// <reference types="ses"/>
 
@@ -375,9 +376,10 @@ const makePatternKit = () => {
   /**
    * @param {Passable} specimen
    * @param {Pattern} patt
+   * @param {string} [label]
    */
-  const fit = (specimen, patt) => {
-    checkMatches(specimen, patt, assertChecker);
+  const fit = (specimen, patt, label = undefined) => {
+    applyLabelingError(checkMatches, [specimen, patt, assertChecker], label);
   };
 
   // /////////////////////// getRankCover //////////////////////////////////////

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -434,6 +434,7 @@
  * @param {Passable} specimen
  * @param {Pattern} pattern
  * @param {Checker=} check
+ * @returns {boolean}
  */
 
 /**
@@ -556,7 +557,7 @@
 /**
  * @typedef {object} PatternKit
  * @property {(specimen: Passable, patt: Pattern) => boolean} matches
- * @property {(specimen: Passable, patt: Pattern) => void} fit
+ * @property {(specimen: Passable, patt: Pattern, label?: string) => void} fit
  * @property {(patt: Pattern) => void} assertPattern
  * @property {(patt: Passable) => boolean} isPattern
  * @property {(patt: Pattern) => void} assertKeyPattern


### PR DESCRIPTION
The input validation of displayInfo was using its own copy of `assertPure`, copied from @endo/marshal, which was dangerously wrong. See https://github.com/endojs/endo/pull/1242

Much of the input validation can be expressed more declaratively, compactly, and reliably using our `M` pattern language. Doing so took care of many issues implicitly, including the previous use of `assertPure`.

Note to reviewers:

In replacing as much of the previous ad hoc input validation with the pattern language as I could, I sacrificed the quality of the error messages. Please let me know whether you think I went too far and should restore some of the previous logic for better error messages. The differences are well represented by differences in the test files.