### PR TITLE
feat(wallet/api): marshal contexts for wallet, board

### DIFF
--- a/packages/wallet/api/src/marshal-contexts.js
+++ b/packages/wallet/api/src/marshal-contexts.js
@@ -105,12 +105,14 @@ const initSlotVal = (table, slot, val) => {
 /**
  * Make context for exporting wallet data where brands etc. can be recognized by boardId.
  *
- * Objects should be registered before serialization:
- *   - for closely-held object, use initPurseId etc.
- *   - for published objects such as brands and issuers, use initBoardId / ensureBoardId
+ * When serializing wallet state for, there's a tension between
  *
- * Unregistered objects (such as instances in amounts) get serialized
- * with a fresh slot.
+ *  - keeping purses etc. closely held
+ *  - recognizing identity of brands also referenced in the state of contracts such as the AMM
+ *
+ * `makeMarshal()` is parameterized by the type of slots. Here we use a disjoint union of
+ *   - board ids for widely shared objects
+ *   - kind:seq ids for closely held objects; for example purse:123
  */
 export const makeExportContext = () => {
   const walletObjects = {

--- a/packages/wallet/api/src/marshal-contexts.js
+++ b/packages/wallet/api/src/marshal-contexts.js
@@ -8,8 +8,12 @@ const { details: X, quote: q } = assert;
 /**
  * Make context for exporting wallet data where brands etc. can be recognized by boardId.
  *
- * All purses, brands, etc. must be registered before serialization / unserialization.
- * Neither the serializer nor the unserializer creates new presences.
+ * Objects should be registered before serialization:
+ *   - for closely-held object, use initPurseId etc.
+ *   - for published objects such as brands and issuers, use initBoardId / ensureBoardId
+ *
+ * Unregistered objects (such as instances in amounts) get serialized
+ * with a fresh slot.
  */
 export const makeExportContext = () => {
   const toVal = {

--- a/packages/wallet/api/src/marshal-contexts.js
+++ b/packages/wallet/api/src/marshal-contexts.js
@@ -48,6 +48,8 @@ export const makeExportContext = () => {
     return val;
   };
 
+  let nonce = 0;
+
   const valToSlot = val => {
     if (sharedData.has(val)) {
       return sharedData.get(val);
@@ -58,24 +60,43 @@ export const makeExportContext = () => {
         return `${kind}:${id}`;
       }
     }
-    assert.fail(X`cannot serialize ${val}`);
+    nonce += 1;
+    const slot = `unknown:${nonce}`;
+    sharedData.init(val, slot);
+    return slot;
   };
 
   return harden({
+    /**
+     * @param {string} id
+     * @param {Purse} purse
+     */
     initPurseId: (id, purse) => {
       toVal.purse.init(id, purse);
       fromVal.purse.init(purse, id);
     },
     purseEntries: toVal.purse.entries,
+    /**
+     * @param {string} id
+     * @param {Brand} brand
+     */
     initBrandId: (id, brand) => {
       toVal.brand.init(id, brand);
       fromVal.brand.init(brand, id);
     },
     brandEntries: toVal.purse.entries,
+    /**
+     * @param {string} id
+     * @param {Issuer} issuer
+     */
     initIssuerId: (id, issuer) => {
       toVal.issuer.init(id, issuer);
       fromVal.issuer.init(issuer, id);
     },
+    /**
+     * @param {string} id
+     * @param {unknown} val
+     */
     initBoardId: (id, val) => {
       sharedData.init(val, id);
     },

--- a/packages/wallet/api/src/marshal-contexts.js
+++ b/packages/wallet/api/src/marshal-contexts.js
@@ -139,7 +139,7 @@ export const makeImportContext = () => {
      * @param {string} slot
      * @param {string} iface
      */
-    fromPart: (slot, iface) => {
+    fromMyWallet: (slot, iface) => {
       const kind = kindOf(slot);
       const key = kind ? slot.slice(kind.length + 1) : slot;
       const table = kind ? myData[kind].bySlot : sharedData;
@@ -154,7 +154,7 @@ export const makeImportContext = () => {
   };
 
   const valToSlot = {
-    fromWallet: val => {
+    fromMyWallet: val => {
       for (const kind of Object.keys(myData)) {
         if (myData[kind].byVal.has(val)) {
           const id = myData[kind].byVal.get(val);
@@ -169,7 +169,7 @@ export const makeImportContext = () => {
     fromBoard: makeMarshal(undefined, slotToVal.fromBoard, {
       marshalName: 'fromBoard',
     }),
-    fromPart: makeMarshal(valToSlot.fromWallet, slotToVal.fromPart, {
+    fromMyWallet: makeMarshal(valToSlot.fromMyWallet, slotToVal.fromMyWallet, {
       marshalName: 'fromPart',
     }),
   };
@@ -186,7 +186,7 @@ export const makeImportContext = () => {
   return harden({
     savePurseActions: makeSaver('purse', myData.purse),
     savePaymentActions: makeSaver('payment', myData.payment),
-    fromWallet: Far('wallet marshaller', { ...marshal.fromPart }),
+    fromMyWallet: Far('wallet marshaller', { ...marshal.fromMyWallet }),
     fromBoard: Far('board marshaller', { ...marshal.fromBoard }),
   });
 };

--- a/packages/wallet/api/src/marshal-contexts.js
+++ b/packages/wallet/api/src/marshal-contexts.js
@@ -15,23 +15,12 @@ export const makeExportContext = () => {
   const toVal = {
     /** @type {MapStore<string, Purse>} */
     purse: makeScalarMap(),
-    /** @type {MapStore<string, Brand>} */
-    brand: makeScalarMap(),
-    /** @type {MapStore<string, Issuer>} */
-    issuer: makeScalarMap(),
-    // TODO: 6 in total, right?
-    // offer
-    // contact
-    // dapp
+    // TODO: offer, contact, dapp
   };
   const fromVal = {
     /** @type {MapStore<Purse, string>} */
     purse: makeScalarMap(),
-    /** @type {MapStore<Brand, string>} */
-    brand: makeScalarMap(),
-    /** @type {MapStore<Issuer, string>} */
-    issuer: makeScalarMap(),
-    // TODO: 6 in total, right?
+    // TODO: offer, contact, dapp
   };
   /** @type {MapStore<unknown, string>} */
   const sharedData = makeScalarMap();
@@ -78,20 +67,10 @@ export const makeExportContext = () => {
     purseEntries: toVal.purse.entries,
     /**
      * @param {string} id
-     * @param {Brand} brand
+     * @param {unknown} val
      */
-    initBrandId: (id, brand) => {
-      toVal.brand.init(id, brand);
-      fromVal.brand.init(brand, id);
-    },
-    brandEntries: toVal.purse.entries,
-    /**
-     * @param {string} id
-     * @param {Issuer} issuer
-     */
-    initIssuerId: (id, issuer) => {
-      toVal.issuer.init(id, issuer);
-      fromVal.issuer.init(issuer, id);
+    initBoardId: (id, val) => {
+      sharedData.init(val, id);
     },
     /**
      * @param {string} id

--- a/packages/wallet/api/src/marshal-contexts.js
+++ b/packages/wallet/api/src/marshal-contexts.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { makeScalarMap } from '@agoric/store';
-import { Far, makeMarshal } from '@endo/marshal';
+import { Far, makeMarshal, Remotable } from '@endo/marshal';
+import { HandledPromise } from '@endo/eventual-send'; // TODO: convince tsc this isn't needed
 
 const { details: X, quote: q } = assert;
 
@@ -188,4 +189,38 @@ export const makeImportContext = () => {
     fromWallet: Far('wallet marshaller', { ...marshal.fromPart }),
     fromBoard: Far('board marshaller', { ...marshal.fromBoard }),
   });
+};
+
+/**
+ * @param {string} iface
+ * @param {{
+ *   applyMethod: (target: unknown, method: string | symbol, args: unknown[]) => void,
+ *   applyFunction: (target: unknown, args: unknown[]) => void,
+ * }} handler
+ */
+const makePresence = (iface, handler) => {
+  let it;
+  const hp = new HandledPromise((resolve, reject, resolveWithPresence) => {
+    it = resolveWithPresence(handler);
+  });
+  assert(it);
+  assert(hp);
+  return Remotable(iface, undefined, it);
+};
+
+/**
+ * @param {string} iface
+ * @param {(parts: unknown[]) => void} log
+ */
+export const makeLoggingPresence = (iface, log) => {
+  /** @type {any} */ // TODO: solve types puzzle
+  const it = makePresence(iface, {
+    applyMethod: (target, method, args) => {
+      log(harden(['applyMethod', target, method, args]));
+    },
+    applyFunction: (target, args) => {
+      log(harden(['applyFunction', target, args]));
+    },
+  });
+  return it;
 };

--- a/packages/wallet/api/src/marshal-contexts.js
+++ b/packages/wallet/api/src/marshal-contexts.js
@@ -80,7 +80,11 @@ export const makeExportContext = () => {
      * @param {string} id
      * @param {unknown} val
      */
-    initBoardId: (id, val) => {
+    ensureBoardId: (id, val) => {
+      if (sharedData.has(val)) {
+        assert.equal(sharedData.get(val), id);
+        return;
+      }
       sharedData.init(val, id);
     },
     issuerEntries: toVal.purse.entries,

--- a/packages/wallet/api/test/test-middleware.js
+++ b/packages/wallet/api/test/test-middleware.js
@@ -3,9 +3,23 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { E, Far } from '@endo/far';
 import {
+  makeExportContext,
   makeImportContext,
   makeLoggingPresence,
 } from '../src/marshal-contexts.js';
+
+const capData1 = {
+  body: JSON.stringify([
+    [
+      'applyMethod',
+      { '@qclass': 'slot', iface: 'Alleged: purse.actions', index: 0 },
+      'deposit',
+      [{ '@qclass': 'slot', iface: 'Alleged: payment', index: 1 }],
+    ],
+    ['applyFunction', { '@qclass': 'slot', index: 0 }, [1, 'thing']],
+  ]),
+  slots: ['purse:1', 'payment:1'],
+};
 
 test('makeLoggingPresence logs calls on purse/payment actions', async t => {
   const msgs = [];
@@ -14,29 +28,38 @@ test('makeLoggingPresence logs calls on purse/payment actions', async t => {
     actions: await makeLoggingPresence('Alleged: purse.actions', enqueue),
   };
   const myPayment = Far('payment', {});
-  await E(purse.actions).deposit(myPayment);
+  await E(purse.actions).deposit(myPayment); // promise resolves???
   await E(purse.actions)(1, 'thing');
   t.deepEqual(msgs, [
     ['applyMethod', purse.actions, 'deposit', [myPayment]],
     ['applyFunction', purse.actions, [1, 'thing']],
   ]);
 
-  const ctx = makeImportContext();
+  const ctx = makeExportContext();
   ctx.savePurseActions(purse.actions);
   ctx.savePaymentActions(myPayment);
-  const capData = ctx.fromMyWallet.serialize(harden([...msgs]));
-  t.deepEqual(capData, {
-    body: JSON.stringify([
-      [
-        'applyMethod',
-        { '@qclass': 'slot', iface: 'Alleged: purse.actions', index: 0 },
-        'deposit',
-        [{ '@qclass': 'slot', iface: 'Alleged: payment', index: 1 }],
-      ],
-      ['applyFunction', { '@qclass': 'slot', index: 0 }, [1, 'thing']],
-    ]),
-    slots: ['purse:1', 'payment:1'],
-  });
+  const capData = ctx.serialize(harden([...msgs]));
+  t.deepEqual(capData, capData1);
+});
+
+test('makeImportContext in wallet UI can unserialize messages', async t => {
+  const ctx = makeImportContext();
+
+  const stuff = ctx.fromMyWallet.unserialize(capData1);
+  t.is(stuff.length, 2);
+  t.is(stuff[0][2], 'deposit');
+  // const msgs = [];
+  // const enqueue = m => msgs.push(m);
+  // const purse = {
+  //   actions: await makeLoggingPresence('Alleged: purse.actions', enqueue),
+  // };
+  // const brandM = Far('Moola brand', {});
+  // const amt = harden({ brand: brandM, value: 123n });
+
+  // await E(purse.actions).transfer(amt, 'there'); // promise resolves???
+  // t.deepEqual(msgs, [
+  //   ['applyMethod', purse.actions, 'transfer', [amt, 'there']],
+  // ]);
 });
 
 //   {

--- a/packages/wallet/api/test/test-middleware.js
+++ b/packages/wallet/api/test/test-middleware.js
@@ -27,7 +27,9 @@ test('makeLoggingPresence logs calls on purse/payment actions', async t => {
   const purse = {
     actions: await makeLoggingPresence('Alleged: purse.actions', enqueue),
   };
-  const myPayment = Far('payment', {});
+  const myPayment = Far('payment', {
+    getAllegedBrand: () => assert.fail('mock'),
+  });
   await E(purse.actions).deposit(myPayment); // promise resolves???
   await E(purse.actions)(1, 'thing');
   t.deepEqual(msgs, [

--- a/packages/wallet/api/test/test-middleware.js
+++ b/packages/wallet/api/test/test-middleware.js
@@ -2,43 +2,10 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { E, Far } from '@endo/far';
-import { Remotable } from '@endo/marshal';
-import { HandledPromise } from '@endo/eventual-send'; // TODO: convince tsc this isn't needed
-import { makeImportContext } from '../src/marshal-contexts.js';
-
-/**
- * @param {string} iface
- * @param {{
- *   applyMethod: (target: unknown, method: string | symbol, args: unknown[]) => void,
- *   applyFunction: (target: unknown, args: unknown[]) => void,
- * }} handler
- */
-const makePresence = (iface, handler) => {
-  let it;
-  const hp = new HandledPromise((resolve, reject, resolveWithPresence) => {
-    it = resolveWithPresence(handler);
-  });
-  assert(it);
-  assert(hp);
-  return Remotable(iface, undefined, it);
-};
-
-/**
- * @param {string} iface
- * @param {(parts: unknown[]) => void} log
- */
-const makeLoggingPresence = (iface, log) => {
-  /** @type {any} */ // TODO: solve types puzzle
-  const it = makePresence(iface, {
-    applyMethod: (target, method, args) => {
-      log(harden(['applyMethod', target, method, args]));
-    },
-    applyFunction: (target, args) => {
-      log(harden(['applyFunction', target, args]));
-    },
-  });
-  return it;
-};
+import {
+  makeImportContext,
+  makeLoggingPresence,
+} from '../src/marshal-contexts.js';
 
 test('presences for actions log their work', async t => {
   const msgs = [];

--- a/packages/wallet/api/test/test-middleware.js
+++ b/packages/wallet/api/test/test-middleware.js
@@ -1,0 +1,75 @@
+// @ts-check
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { E, Far } from '@endo/far';
+import { HandledPromise } from '@endo/eventual-send'; // TODO: convince tsc this isn't needed
+
+/**
+ * @param {{
+ *   applyMethod: (target: unknown, method: string | symbol, args: unknown[]) => void,
+ *   applyFunction: (target: unknown, args: unknown[]) => void,
+ * }} handler
+ */
+const makePresence = handler => {
+  let it;
+  const hp = new HandledPromise((resolve, reject, resolveWithPresence) => {
+    it = resolveWithPresence(handler);
+  });
+  assert(it);
+  assert(hp);
+  return it;
+};
+
+/**
+ * @param {(parts: unknown[]) => void} log
+ */
+const makeLoggingPresence = log => {
+  /** @type {any} */ // TODO: solve types puzzle
+  const it = makePresence({
+    applyMethod: (target, method, args) => {
+      log(['applyMethod', target, method, args]);
+    },
+    applyFunction: (target, args) => {
+      log(['applyFunction', target, args]);
+    },
+  });
+  return it;
+};
+
+test('presences for actions log their work', async t => {
+  const msgs = [];
+  const enqueue = m => msgs.push(m);
+  const purse = {
+    actions: makeLoggingPresence(enqueue),
+  };
+  const myPayment = Far('payment', {});
+  await E(purse.actions).deposit(myPayment);
+  await E(purse.actions)(1, 'thing');
+  t.deepEqual(msgs, [
+    ['applyMethod', purse.actions, 'deposit', [myPayment]],
+    ['applyFunction', purse.actions, [1, 'thing']],
+  ]);
+});
+
+// marshalData1 = JSON.stringify({
+//     body: [
+//       'applyMethod',
+//       {"@qclass":"slot", index: 0},
+//       'deposit',
+//       [
+//         {
+//           amount: {“@qclass”:”bigint”, digits: “3000000”},
+//           brand: {"@qclass": "slot", index:1 },
+//         }
+//       ]
+//     ],
+//     slots: [[‘purse’, ["MyPurse"]], [‘brand’, ["IST"], {decimalPlaces:6}]],
+//   });
+
+//   {
+//     type: "WalletReversibleAction",
+//     spec: [{
+//       json: <bunch of data>,
+//       lang: "en-US"
+//       readable: "deposit 3 [IST] into [MyPurse] purse"
+//     }]

--- a/packages/wallet/api/test/test-middleware.js
+++ b/packages/wallet/api/test/test-middleware.js
@@ -7,7 +7,7 @@ import {
   makeLoggingPresence,
 } from '../src/marshal-contexts.js';
 
-test('presences for actions log their work', async t => {
+test('makeLoggingPresence logs calls on purse/payment actions', async t => {
   const msgs = [];
   const enqueue = m => msgs.push(m);
   const purse = {

--- a/packages/wallet/api/test/test-middleware.js
+++ b/packages/wallet/api/test/test-middleware.js
@@ -24,7 +24,7 @@ test('presences for actions log their work', async t => {
   const ctx = makeImportContext();
   ctx.savePurseActions(purse.actions);
   ctx.savePaymentActions(myPayment);
-  const capData = ctx.fromWallet.serialize(harden([...msgs]));
+  const capData = ctx.fromMyWallet.serialize(harden([...msgs]));
   t.deepEqual(capData, {
     body: JSON.stringify([
       [

--- a/packages/wallet/api/test/test-wallet-marshal.js
+++ b/packages/wallet/api/test/test-wallet-marshal.js
@@ -90,6 +90,16 @@ test('preserve identity of brands across AMM and wallet', t => {
 });
 
 test('handle unregistered identites in serialization', t => {
+test('ensureBoardId allows re-registration; initBoardId does not', t => {
+  const brand = Far('Moola brand', {});
+
+  const context = makeExportContext();
+  context.initBoardId('b1', brand);
+  t.throws(() => context.initBoardId('b1', brand));
+  context.ensureBoardId('b1', brand);
+  t.throws(() => context.ensureBoardId('b2', brand));
+});
+
   const brand = Far('Zoe invitation brand', {});
   const instance = Far('amm instance', {});
   const invitationAmount = harden({ brand, value: [{ instance }] });

--- a/packages/wallet/api/test/test-wallet-marshal.js
+++ b/packages/wallet/api/test/test-wallet-marshal.js
@@ -89,4 +89,17 @@ test('preserve identity of brands across AMM and wallet', t => {
   );
 });
 
-// TODO: test consistent deserialization of unregistered objects in fromWallet
+test('handle unregistered identites in serialization', t => {
+  const brand = Far('Zoe invitation brand', {});
+  const instance = Far('amm instance', {});
+  const invitationAmount = harden({ brand, value: [{ instance }] });
+
+  const context = makeExportContext();
+  context.initBoardId('b1', brand);
+  const actual = context.serialize(invitationAmount);
+
+  t.deepEqual(actual, {
+    body: '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe invitation brand","index":0},"value":[{"instance":{"@qclass":"slot","iface":"Alleged: amm instance","index":1}}]}',
+    slots: ['b1', 'unknown:1'],
+  });
+});

--- a/packages/wallet/api/test/test-wallet-marshal.js
+++ b/packages/wallet/api/test/test-wallet-marshal.js
@@ -1,0 +1,92 @@
+// @ts-check
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Far } from '@endo/far';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
+import {
+  makeExportContext,
+  makeImportContext,
+} from '../src/marshal-contexts.js';
+
+/**
+ * @param {ReturnType<typeof makeBoard>} board
+ */
+const makeAMM = board => {
+  const atom = Far('ATOM brand', {});
+  const pub = board.getPublishingMarshaller();
+  return harden({ getMetrics: () => pub.serialize(harden([atom])) });
+};
+
+/**
+ * @param {ReturnType<typeof makeBoard>} board
+ */
+const makeWallet = board => {
+  const context = makeExportContext();
+  let brand;
+  return harden({
+    suggestIssuer: (name, boardId) => {
+      brand = board.getValue(boardId);
+      const purse = Far(`${name} purse`, {
+        getCurrentAmount: () => harden({ brand, value: 100 }),
+      });
+      // only for private brands
+      //   context.initBrandId(boardId, brand);
+      context.initBoardId(boardId, brand);
+      context.initPurseId(name, purse); // TODO: strong id rather than name?
+    },
+    publish: () =>
+      context.serialize(
+        harden(
+          [...context.purseEntries()].map(([name, purse], id) => ({
+            meta: { id },
+            // displayInfo
+            // brandBoardId,
+            purse,
+            brand,
+            currentAmount: purse.getCurrentAmount(),
+            // actions
+            brandPetname: name,
+            pursePetname: `${name} purse`,
+          })),
+        ),
+      ),
+  });
+};
+
+test('preserve identity of brands across AMM and wallet', t => {
+  const context = makeImportContext();
+
+  const board = makeBoard(0, { prefix: 'board' });
+  const amm = makeAMM(board);
+  const ammMetricsCapData = amm.getMetrics();
+
+  t.deepEqual(ammMetricsCapData, {
+    body: '[{"@qclass":"slot","iface":"Alleged: ATOM brand","index":0}]',
+    slots: ['board011'],
+  });
+
+  /** @type {Brand[]} */
+  const [b1] = context.fromBoard.unserialize(ammMetricsCapData);
+  /** @type {Brand[]} */
+  const [b2] = context.fromBoard.unserialize(amm.getMetrics());
+  t.is(b1, b2, 'unserialization twice from same source');
+
+  const myWallet = makeWallet(board);
+  myWallet.suggestIssuer('ATOM', 'board011');
+  const walletCapData = myWallet.publish();
+  t.deepEqual(walletCapData, {
+    body: '[{"brand":{"@qclass":"slot","iface":"Alleged: ATOM brand","index":0},"brandPetname":"ATOM","currentAmount":{"brand":{"@qclass":"slot","index":0},"value":100},"meta":{"id":0},"purse":{"@qclass":"slot","iface":"Alleged: ATOM purse","index":1},"pursePetname":"ATOM purse"}]',
+    slots: ['board011', 'purse:ATOM'],
+  });
+
+  const walletState = context.fromWallet.unserialize(walletCapData);
+  t.is(walletState[0].brand, b1, 'unserialization across sources');
+
+  t.throws(
+    () => context.fromBoard.unserialize(walletCapData),
+    { message: /bad shared slot/ },
+    'AMM cannot refer to purses',
+  );
+});
+
+// TODO: test consistent deserialization of unregistered objects in fromWallet

--- a/packages/wallet/api/test/test-wallet-marshal.js
+++ b/packages/wallet/api/test/test-wallet-marshal.js
@@ -79,7 +79,7 @@ test('preserve identity of brands across AMM and wallet', t => {
     slots: ['board011', 'purse:ATOM'],
   });
 
-  const walletState = context.fromWallet.unserialize(walletCapData);
+  const walletState = context.fromMyWallet.unserialize(walletCapData);
   t.is(walletState[0].brand, b1, 'unserialization across sources');
 
   t.throws(

--- a/packages/wallet/api/test/test-wallet-marshal.js
+++ b/packages/wallet/api/test/test-wallet-marshal.js
@@ -87,13 +87,16 @@ test('makeImportContext preserves identity across AMM and wallet', t => {
 });
 
 test('ensureBoardId allows re-registration; initBoardId does not', t => {
-  const brand = Far('Moola brand', {});
+  const brandM = Far('Moola brand', {});
+  const brandS = Far('Semolean brand', {});
 
   const context = makeExportContext();
-  context.initBoardId('b1', brand);
-  t.throws(() => context.initBoardId('b1', brand));
-  context.ensureBoardId('b1', brand);
-  t.throws(() => context.ensureBoardId('b2', brand));
+  context.initBoardId('b1', brandM);
+  t.throws(() => context.initBoardId('b1', brandM));
+  context.ensureBoardId('b1', brandM);
+  t.throws(() => context.ensureBoardId('b2', brandM));
+  context.ensureBoardId('b2', brandS);
+  t.throws(() => context.initBoardId('b2', brandM));
 });
 
 test('makeExportContext.serialize handles unregistered identites', t => {
@@ -109,4 +112,15 @@ test('makeExportContext.serialize handles unregistered identites', t => {
     body: '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe invitation brand","index":0},"value":[{"instance":{"@qclass":"slot","iface":"Alleged: amm instance","index":1}}]}',
     slots: ['b1', 'unknown:1'],
   });
+
+  t.deepEqual(context.unserialize(actual), invitationAmount);
+
+  const myPayment = Far('payment', {});
+  context.savePaymentActions(myPayment);
+  const cap2 = context.serialize(myPayment);
+  t.deepEqual(cap2, {
+    body: '{"@qclass":"slot","iface":"Alleged: payment","index":0}',
+    slots: ['payment:1'],
+  });
+  t.deepEqual(context.unserialize(cap2), myPayment);
 });

--- a/packages/wallet/api/test/test-wallet-marshal.js
+++ b/packages/wallet/api/test/test-wallet-marshal.js
@@ -8,18 +8,14 @@ import {
   makeImportContext,
 } from '../src/marshal-contexts.js';
 
-/**
- * @param {ReturnType<typeof makeBoard>} board
- */
+/** @param {ReturnType<typeof makeBoard>} board */
 const makeAMM = board => {
   const atom = Far('ATOM brand', {});
   const pub = board.getPublishingMarshaller();
   return harden({ getMetrics: () => pub.serialize(harden([atom])) });
 };
 
-/**
- * @param {ReturnType<typeof makeBoard>} board
- */
+/** @param {ReturnType<typeof makeBoard>} board */
 const makeWallet = board => {
   const context = makeExportContext();
   let brand;
@@ -32,6 +28,7 @@ const makeWallet = board => {
       // only for private brands
       //   context.initBrandId(boardId, brand);
       context.initBoardId(boardId, brand);
+      // @ts-expect-error mock purse
       context.initPurseId(name, purse); // TODO: strong id rather than name?
     },
     publish: () =>
@@ -53,7 +50,7 @@ const makeWallet = board => {
   });
 };
 
-test('preserve identity of brands across AMM and wallet', t => {
+test('makeImportContext preserves identity across AMM and wallet', t => {
   const context = makeImportContext();
 
   const board = makeBoard(0, { prefix: 'board' });
@@ -89,7 +86,6 @@ test('preserve identity of brands across AMM and wallet', t => {
   );
 });
 
-test('handle unregistered identites in serialization', t => {
 test('ensureBoardId allows re-registration; initBoardId does not', t => {
   const brand = Far('Moola brand', {});
 
@@ -100,6 +96,7 @@ test('ensureBoardId allows re-registration; initBoardId does not', t => {
   t.throws(() => context.ensureBoardId('b2', brand));
 });
 
+test('makeExportContext.serialize handles unregistered identites', t => {
   const brand = Far('Zoe invitation brand', {});
   const instance = Far('amm instance', {});
   const invitationAmount = harden({ brand, value: [{ instance }] });

--- a/packages/wallet/api/test/test-wallet-marshal.js
+++ b/packages/wallet/api/test/test-wallet-marshal.js
@@ -58,7 +58,9 @@ test('makeImportContext preserves identity across AMM and wallet', t => {
   const ammMetricsCapData = amm.getMetrics();
 
   t.deepEqual(ammMetricsCapData, {
-    body: '[{"@qclass":"slot","iface":"Alleged: ATOM brand","index":0}]',
+    body: JSON.stringify([
+      { '@qclass': 'slot', iface: 'Alleged: ATOM brand', index: 0 },
+    ]),
     slots: ['board011'],
   });
 
@@ -72,7 +74,16 @@ test('makeImportContext preserves identity across AMM and wallet', t => {
   myWallet.suggestIssuer('ATOM', 'board011');
   const walletCapData = myWallet.publish();
   t.deepEqual(walletCapData, {
-    body: '[{"brand":{"@qclass":"slot","iface":"Alleged: ATOM brand","index":0},"brandPetname":"ATOM","currentAmount":{"brand":{"@qclass":"slot","index":0},"value":100},"meta":{"id":0},"purse":{"@qclass":"slot","iface":"Alleged: ATOM purse","index":1},"pursePetname":"ATOM purse"}]',
+    body: JSON.stringify([
+      {
+        brand: { '@qclass': 'slot', iface: 'Alleged: ATOM brand', index: 0 },
+        brandPetname: 'ATOM',
+        currentAmount: { brand: { '@qclass': 'slot', index: 0 }, value: 100 },
+        meta: { id: 0 },
+        purse: { '@qclass': 'slot', iface: 'Alleged: ATOM purse', index: 1 },
+        pursePetname: 'ATOM purse',
+      },
+    ]),
     slots: ['board011', 'purse:ATOM'],
   });
 
@@ -109,8 +120,23 @@ test('makeExportContext.serialize handles unregistered identites', t => {
   const actual = context.serialize(invitationAmount);
 
   t.deepEqual(actual, {
-    body: '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe invitation brand","index":0},"value":[{"instance":{"@qclass":"slot","iface":"Alleged: amm instance","index":1}}]}',
     slots: ['b1', 'unknown:1'],
+    body: JSON.stringify({
+      brand: {
+        '@qclass': 'slot',
+        iface: 'Alleged: Zoe invitation brand',
+        index: 0,
+      },
+      value: [
+        {
+          instance: {
+            '@qclass': 'slot',
+            iface: 'Alleged: amm instance',
+            index: 1,
+          },
+        },
+      ],
+    }),
   });
 
   t.deepEqual(context.unserialize(actual), invitationAmount);
@@ -119,7 +145,11 @@ test('makeExportContext.serialize handles unregistered identites', t => {
   context.savePaymentActions(myPayment);
   const cap2 = context.serialize(myPayment);
   t.deepEqual(cap2, {
-    body: '{"@qclass":"slot","iface":"Alleged: payment","index":0}',
+    body: JSON.stringify({
+      '@qclass': 'slot',
+      iface: 'Alleged: payment',
+      index: 0,
+    }),
     slots: ['payment:1'],
   });
   t.deepEqual(context.unserialize(cap2), myPayment);


### PR DESCRIPTION
refs: #4398
obsoletes #5874

## Description

When serializing wallet state for chainStorage, there's a tension between
  - keeping purses etc. closely held
  - recognizing identity of brands also referenced in the state of contracts such as the AMM

`makeMarshal` is parameterized by the type of slots. Here we use a disjoint union of
   - board ids for widely shared objects
   - `kind:seq` ids for closely held objects; for example `purse:123`

@samsiegart note that unlike #5874 , this PR doesn't include any changes to `lib-wallet.js`; I hope you can layer those changes on top of this as a form of review.

This PR includes `makeLoggingPresence`, which is some advanced work on smart wallet middleware. While the design is still in progress, test coverage of this version is good enough that I'd like to land it.

### Security Considerations

As @warner noted, there's a risk that chainStorage data from the AMM could try to refer to a purse using a slots such as `purse:123`; such a reference must fail.

### Documentation Considerations

not much; these are internal APIs.

### Testing Considerations

Test coverage is 100%.

```
agoric-sdk/packages/wallet/api$ yarn c8 ava test/test-wallet-marshal.js test/test-middleware.js
yarn run v1.22.19
$ .../.bin/c8 ava test/test-wallet-marshal.js test/test-middleware.js

  ✔ middleware › makeImportContext in wallet UI can unserialize messages
  ✔ middleware › makeLoggingPresence logs calls on purse/payment actions
  ✔ wallet-marshal › makeImportContext preserves identity across AMM and wallet
  ✔ wallet-marshal › ensureBoardId allows re-registration; initBoardId does not
  ✔ wallet-marshal › makeExportContext.serialize handles unregistered identites
  ─

  5 tests passed
---------------------|---------|----------|---------|---------|-------------------
File                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------------|---------|----------|---------|---------|-------------------
All files            |     100 |      100 |     100 |     100 |                   
 marshal-contexts.js |     100 |      100 |     100 |     100 |                   
---------------------|---------|----------|---------|---------|-------------------
Done in 0.71s.
```