### PR TITLE
Implement swingset-runner test to validate vat process failure behavior

### DIFF
--- a/packages/swingset-runner/demo/workerDeathTest/bootstrap.js
+++ b/packages/swingset-runner/demo/workerDeathTest/bootstrap.js
@@ -1,0 +1,14 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+export function buildRootObject() {
+  console.log(`bootstrap vat initializing`);
+  return Far('root', {
+    async bootstrap(vats) {
+      const howMuch = 100_000_000;
+      console.log(`bootstrap vat invokes busy vat for ${howMuch} steps`);
+      await E(vats.busy).doStuff(howMuch);
+      await E(vats.idle).doNothing();
+    },
+  });
+}

--- a/packages/swingset-runner/demo/workerDeathTest/swingset.json
+++ b/packages/swingset-runner/demo/workerDeathTest/swingset.json
@@ -1,0 +1,15 @@
+{
+  "bootstrap": "bootstrap",
+  "defaultManagerType": "xs-worker",
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "bootstrap.js"
+    },
+    "busy": {
+      "sourceSpec": "vat-busy.js"
+    },
+    "idle": {
+      "sourceSpec": "vat-idle.js"
+    }
+  }
+}

--- a/packages/swingset-runner/demo/workerDeathTest/vat-busy.js
+++ b/packages/swingset-runner/demo/workerDeathTest/vat-busy.js
@@ -1,0 +1,22 @@
+import { Far } from '@endo/marshal';
+
+export function buildRootObject(_vatPowers, _vatParameters, baggage) {
+  console.log(`busy vat initializing`);
+  baggage.init('someKey', 'hello');
+  return Far('root', {
+    doStuff(howMuch) {
+      let n = 2.0;
+      for (let i = 0; i <= howMuch; i += 1) {
+        n = Math.sqrt(n) * Math.sqrt(n); // introduce some computational drag
+        if (i % 10_000_000 === 0) {
+          let bv = 'no baggage';
+          if (baggage) {
+            bv = baggage.get('someKey');
+          }
+          console.log(`busy vat doing step ${i} of ${howMuch}, bv=${bv}`);
+        }
+      }
+      console.log(`busy vat finished ${howMuch} steps`);
+    },
+  });
+}

--- a/packages/swingset-runner/demo/workerDeathTest/vat-idle.js
+++ b/packages/swingset-runner/demo/workerDeathTest/vat-idle.js
@@ -1,0 +1,8 @@
+import { Far } from '@endo/marshal';
+
+export function buildRootObject() {
+  console.log(`idle vat initializing`);
+  return Far('root', {
+    doNothing() {},
+  });
+}

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -339,10 +339,12 @@ export async function main() {
     delete config.loopboxSenders;
     deviceEndowments.loopbox = { ...loopboxEndowments };
   }
-  if (useXS) {
-    config.defaultManagerType = 'xs-worker';
-  } else {
-    config.defaultManagerType = 'local';
+  if (!config.defaultManagerType) {
+    if (useXS) {
+      config.defaultManagerType = 'xs-worker';
+    } else {
+      config.defaultManagerType = 'local';
+    }
   }
   if (launchIndirectly) {
     config = generateIndirectConfig(config);


### PR DESCRIPTION
This PR adds a `swingset-runner` demo for testing vat process failure behavior.  This requires manual testing since it is prohibitively difficult (or, at least, more difficult than we currently care to expend resources on) to automate.

The issue to which this PR is responsive contains a detailed writeup of the use of this manual test and the conclusions drawn from it.

Closes #2958
Closes #5480