### PR TITLE
WIP: better mismatch errors

### DIFF
--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -11,7 +11,7 @@ import { DisplayInfoShape } from './typeGuards.js';
  * @returns {DisplayInfo}
  */
 export const coerceDisplayInfo = (allegedDisplayInfo, assetKind) => {
-  fit(allegedDisplayInfo, DisplayInfoShape);
+  fit(allegedDisplayInfo, DisplayInfoShape, 'displayInfo');
 
   if (allegedDisplayInfo.assetKind !== undefined) {
     assert(

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -32,7 +32,7 @@ test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
         // @ts-expect-error Intentional wrong type for testing
         harden({ decimalPlaces: 'hello' }),
       ),
-    { message: /"hello" - Must be >= -100/ },
+    { message: /^displayInfo: "hello" - Must be >= -100$/ },
   );
 
   t.throws(
@@ -58,13 +58,13 @@ test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
   t.throws(
     () =>
       makeIssuerKit('myTokens', AssetKind.NAT, harden({ decimalPlaces: 101 })),
-    { message: /101 - Must be <= 100/ },
+    { message: /^displayInfo: 101 - Must be <= 100$/ },
   );
 
   t.throws(
     () =>
       makeIssuerKit('myTokens', AssetKind.NAT, harden({ decimalPlaces: -101 })),
-    { message: /-101 - Must be >= -100/ },
+    { message: /^displayInfo: -101 - Must be >= -100$/ },
   );
 });
 
@@ -81,7 +81,7 @@ test('makeIssuerKit bad displayInfo.assetKind', async t => {
       ),
     {
       message:
-        /"something" - Must match one of \["nat","set","copySet","copyBag"\]/,
+        /^displayInfo: "something" - Must match one of \["nat","set","copySet","copyBag"\]$/,
     },
   );
 });
@@ -98,7 +98,8 @@ test('makeIssuerKit bad displayInfo.whatever', async t => {
         }),
       ),
     {
-      message: /Remainder \{"whatever":"something"\} - Must match \{\}/,
+      message:
+        /^displayInfo: Remainder \{"whatever":"something"\} - Must match \{\}$/,
     },
   );
 });
@@ -110,10 +111,11 @@ test('makeIssuerKit malicious displayInfo', async t => {
         'myTokens',
         AssetKind.NAT,
         // @ts-expect-error Intentional wrong type for testing
-        'bad displayInfo',
+        'badness',
       ),
     {
-      message: /"bad displayInfo" - Must have shape of base: "copyRecord"/,
+      message:
+        /^displayInfo: "badness" - Must have shape of base: "copyRecord"$/,
     },
   );
 });

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -44,7 +44,8 @@ test('bad display info', t => {
   const displayInfo = harden({ somethingUnexpected: 3 });
   // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => makeIssuerKit('fungible', AssetKind.NAT, displayInfo), {
-    message: /Remainder \{"somethingUnexpected":3\} - Must match \{\}/,
+    message:
+      /^displayInfo: Remainder \{"somethingUnexpected":3\} - Must match \{\}$/,
   });
 });
 

--- a/packages/store/src/patterns/match-helpers.js
+++ b/packages/store/src/patterns/match-helpers.js
@@ -1,0 +1,46 @@
+import { E } from '@endo/eventual-send';
+import { isPromise } from '@endo/promise-kit';
+
+const { details: X } = assert;
+
+/**
+ * @param {Error} innerErr
+ * @param {string} label
+ * @param {ErrorConstructor=} ErrorConstructor
+ * @returns {never}
+ */
+export const throwLabeled = (innerErr, label, ErrorConstructor = undefined) => {
+  const outerErr = assert.error(
+    `${label}: ${innerErr.message}`,
+    ErrorConstructor,
+  );
+  assert.note(outerErr, X`Caused by ${innerErr}`);
+  throw outerErr;
+};
+harden(throwLabeled);
+
+/**
+ * @template A,R
+ * @param {(...args: A) => R} func
+ * @param {A} args
+ * @param {string} [label]
+ * @returns {R}
+ */
+export const applyLabelingError = (func, args, label = undefined) => {
+  if (label === undefined) {
+    return func(...args);
+  }
+  assert.typeof(label, 'string');
+  let result;
+  try {
+    result = func(...args);
+  } catch (err) {
+    throwLabeled(err, label);
+  }
+  if (isPromise(result)) {
+    return E.when(result, undefined, reason => throwLabeled(reason, label));
+  } else {
+    return result;
+  }
+};
+harden(applyLabelingError);

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -27,6 +27,7 @@ import {
   checkCopyMap,
   copyMapKeySet,
 } from '../keys/checkKey.js';
+import { applyLabelingError } from './match-helpers.js';
 
 /// <reference types="ses"/>
 
@@ -375,9 +376,10 @@ const makePatternKit = () => {
   /**
    * @param {Passable} specimen
    * @param {Pattern} patt
+   * @param {string} [label]
    */
-  const fit = (specimen, patt) => {
-    checkMatches(specimen, patt, assertChecker);
+  const fit = (specimen, patt, label = undefined) => {
+    applyLabelingError(checkMatches, [specimen, patt, assertChecker], label);
   };
 
   // /////////////////////// getRankCover //////////////////////////////////////

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -434,6 +434,7 @@
  * @param {Passable} specimen
  * @param {Pattern} pattern
  * @param {Checker=} check
+ * @returns {boolean}
  */
 
 /**
@@ -556,7 +557,7 @@
 /**
  * @typedef {object} PatternKit
  * @property {(specimen: Passable, patt: Pattern) => boolean} matches
- * @property {(specimen: Passable, patt: Pattern) => void} fit
+ * @property {(specimen: Passable, patt: Pattern, label?: string) => void} fit
  * @property {(patt: Pattern) => void} assertPattern
  * @property {(patt: Passable) => boolean} isPattern
  * @property {(patt: Pattern) => void} assertKeyPattern


### PR DESCRIPTION
Stacked on https://github.com/Agoric/agoric-sdk/pull/5876

At https://github.com/Agoric/agoric-sdk/pull/5876#discussion_r935866850 @Chris-Hibbert observes that #5876 would make error messages worse. I would like to keep the declarative pattern-based input validation, so this PR is a first step at improving the error messages to regain some of the ground lost in #5876 