### PR TITLE
test(vaultFactory): refactor to macro

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@endo/ses-ava": "^0.2.31",
-    "ava": "^3.12.1"
+    "ava": "^4.3.1"
   },
   "files": [
     "bin/vat",

--- a/packages/inter-protocol/test/test-interest-math.js
+++ b/packages/inter-protocol/test/test-interest-math.js
@@ -6,18 +6,18 @@ import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { calculateCurrentDebt, reverseInterest } from '../src/interest-math.js';
 
-const runBrand = makeIssuerKit('run').brand;
+const brand = makeIssuerKit('foo').brand;
 
 /**
  * @param {*} t
  * @param {readonly [bigint, bigint, bigint]} input
  * @param {bigint} result
  */
-function checkDebt(t, input, result) {
+function checkDebt(t, [debt, interest, compounded], result) {
   /** @type {Amount<'nat'>} */
-  const debtSnapshot = AmountMath.make(runBrand, input[0]);
-  const interestSnapshot = makeRatio(100n + input[1], runBrand);
-  const currentCompoundedInterest = makeRatio(100n + input[2], runBrand);
+  const debtSnapshot = AmountMath.make(brand, debt);
+  const interestSnapshot = makeRatio(100n + interest, brand);
+  const currentCompoundedInterest = makeRatio(100n + compounded, brand);
   t.is(
     calculateCurrentDebt(
       debtSnapshot,
@@ -28,47 +28,39 @@ function checkDebt(t, input, result) {
   );
 }
 
-for (const [input, result] of /** @type {const} */ ([
-  // no debt
-  [[0n, 0n, 0n], 0n],
-  [[0n, 0n, 250n], 0n],
+test('no debt wo/compounding', checkDebt, [0n, 0n, 0n], 0n);
+test('no debt w/ compounding', checkDebt, [0n, 0n, 250n], 0n);
+test('some debt wo/compounding', checkDebt, [1_000_000n, 0n, 0n], 1_000_000n);
+test('some debt w/ compounding', checkDebt, [1_000_000n, 0n, 2n], 1_020_000n);
+test(
+  'previous interest wo/compounding',
+  checkDebt,
+  [1_000_000n, 2n, 2n],
+  1_000_000n,
+);
+test(
+  'previous interest w/ compounding',
+  checkDebt,
+  [1_000_000n, 2n, 4n],
+  1_019_608n,
+);
+test(
+  'previous interest, compounded down',
+  checkDebt,
+  [1_000_000n, 2n, 0n], // negative interest since snapshot
+  980_392n,
+);
 
-  // some debt
-  [[1_000_000n, 0n, 0n], 1_000_000n],
-  [[1_000_000n, 0n, 2n], 1_020_000n],
-
-  // some debt and previous interest
-  [[1_000_000n, 2n, 0n], 980_392n], // negative interest since snapshot
-  [[1_000_000n, 2n, 2n], 1_000_000n],
-  [[1_000_000n, 2n, 4n], 1_019_608n],
-])) {
-  test(
-    `calculateCurrentDebt ${input} returns ${result}`,
-    checkDebt,
-    input,
-    result,
-  );
+function checkReverse(t, [debt, interest], result) {
+  // /** @type {Amount<'nat'>} */
+  const debtSnap = AmountMath.make(brand, debt);
+  const interestApplied = makeRatio(100n + interest, brand);
+  t.deepEqual(reverseInterest(debtSnap, interestApplied).value, result);
 }
 
-function checkReverse(t, input, result) {
-  /** @type {Amount<'nat'>} */
-  const debt = AmountMath.make(runBrand, input[0]);
-  const interestApplied = makeRatio(100n + input[1], runBrand);
-  t.deepEqual(reverseInterest(debt, interestApplied).value, result);
-}
+test('none', checkReverse, [0n, 0n], 0n);
+test('none w/interest', checkReverse, [0n, 1n], 0n);
 
-for (const [input, result] of /** @type {const} */ ([
-  [[0n, 0n], 0n],
-  [[0n, 1n], 0n],
-
-  [[1_000_000n, 0n], 1_000_000n],
-  [[1_000_000n, 2n], 980_392n],
-  [[1_000_000n, 100n], 500_000n],
-])) {
-  test(
-    `reverseInterest ${input} returns ${result}`,
-    checkReverse,
-    input,
-    result,
-  );
-}
+test('some', checkReverse, [1_000_000n, 0n], 1_000_000n);
+test('some w/interest', checkReverse, [1_000_000n, 2n], 980_392n);
+test('some w/100% interest', checkReverse, [1_000_000n, 100n], 500_000n);

--- a/packages/inter-protocol/test/vaultFactory/test-storeUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storeUtils.js
@@ -1,50 +1,58 @@
 // @ts-check
 // Must be first to set up globals
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import '@endo/init/debug.js';
+// Consider ses-ava once https://github.com/endojs/endo/issues/1235 is resolved
+import test from 'ava';
 
 import { AmountMath } from '@agoric/ertp';
 import { Far } from '@endo/marshal';
 import * as StoreUtils from '../../src/vaultFactory/storeUtils.js';
 
 export const mockBrand = Far('brand');
-
-for (const [debt, collat, vaultId, expectedKey, numberOut] of [
-  [0, 100, 'vault-A', 'fc399000000000000:vault-A', 450359962737049600], // Infinity collateralized but we treat 0 as epsilon for safer serialization
-  [1, 100, 'vault-B', 'fc059000000000000:vault-B', 100.0],
-  [1000, 100, 'vault-C', 'fbfb999999999999a:vault-C', 0.1],
-  [1000, 101, 'vault-D', 'fbfb9db22d0e56042:vault-D', 0.101],
-  [
-    100,
-    Number.MAX_SAFE_INTEGER,
-    'vault-MAX-COLLATERAL',
-    'fc2d47ae147ae147a:vault-MAX-COLLATERAL',
-    90071992547409.9,
-  ],
-  [
-    Number.MAX_SAFE_INTEGER,
-    100,
-    'vault-MAX-DEBT',
-    'fbd09000000000001:vault-MAX-DEBT',
-    1.1102230246251567e-14,
-  ],
-  [
-    Number.MAX_SAFE_INTEGER,
-    Number.MAX_SAFE_INTEGER,
-    'vault-MAX-EVEN',
-    'fbff0000000000000:vault-MAX-EVEN',
-    1,
-  ],
-  [1, 0, 'vault-NOCOLLATERAL', 'f8000000000000000:vault-NOCOLLATERAL', 0],
-]) {
-  test(`vault keys: (${debt}/${collat}, ${vaultId}) => ${expectedKey} ==> ${numberOut}, ${vaultId}`, t => {
+const keysMatch = test.macro({
+  exec(t, [debt, collat, vaultId], [expectedKey, numberOut]) {
     const key = StoreUtils.toVaultKey(
       // @ts-expect-error cast to NormalizedDebt
       AmountMath.make(mockBrand, BigInt(debt)),
       AmountMath.make(mockBrand, BigInt(collat)),
       String(vaultId),
     );
-    // @ts-expect-error TODO use macros
     t.is(key, expectedKey);
     t.deepEqual(StoreUtils.fromVaultKey(key), [numberOut, vaultId]);
-  });
-}
+  },
+  title(providedTitle = '', [debt, collat, vaultId], [expectedKey, numberOut]) {
+    return `${providedTitle} (${debt}/${collat}, ${vaultId}) => ${expectedKey} ==> ${numberOut}, ${vaultId})`;
+  },
+});
+
+test(
+  'Infinity collateralized',
+  keysMatch,
+  [0, 100, 'vault-A'],
+  // treat 0 as epsilon for safer serialization
+  ['fc399000000000000:vault-A', 450359962737049600],
+);
+test(keysMatch, [1, 100, 'vault-B'], ['fc059000000000000:vault-B', 100.0]);
+test(keysMatch, [1000, 100, 'vault-C'], ['fbfb999999999999a:vault-C', 0.1]);
+test(keysMatch, [1000, 101, 'vault-D'], ['fbfb9db22d0e56042:vault-D', 0.101]);
+
+test(
+  keysMatch,
+  [100, Number.MAX_SAFE_INTEGER, 'vault-MAX-COLLATERAL'],
+  ['fc2d47ae147ae147a:vault-MAX-COLLATERAL', 90071992547409.9],
+);
+test(
+  keysMatch,
+  [Number.MAX_SAFE_INTEGER, 100, 'vault-MAX-DEBT'],
+  ['fbd09000000000001:vault-MAX-DEBT', 1.1102230246251567e-14],
+);
+test(
+  keysMatch,
+  [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER, 'vault-MAX-EVEN'],
+  ['fbff0000000000000:vault-MAX-EVEN', 1],
+);
+test(
+  keysMatch,
+  [1, 0, 'vault-NOCOLLATERAL'],
+  ['f8000000000000000:vault-NOCOLLATERAL', 0],
+);


### PR DESCRIPTION
## Description

Refactor some inter-protocol tests to use [Ava macros](https://github.com/avajs/ava/blob/main/docs/01-writing-tests.md#reusing-test-logic-through-macros)

Note that the `test.macro` introduced in Ava 4 breaks under `prepare-test-env-ava` until https://github.com/endojs/endo/issues/1235.

Also bumps the `peerDependency` in swingset-vat.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

--