### PR TITLE
fix(swingset): don't delete heap snapshot if it didn't change

### DIFF
--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -590,7 +590,7 @@ export function makeVatKeeper(
 
     const snapshotID = await manager.makeSnapshot(snapStore);
     const old = getLastSnapshot();
-    if (old) {
+    if (old && old.snapshotID !== snapshotID) {
       if (removeFromSnapshot(old.snapshotID) === 0) {
         snapStore.prepareToDelete(old.snapshotID);
       }

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -304,7 +304,10 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
       vatKeeper.transcriptSnapshotStats();
     if (snapshotInitial === totalEntries) {
       reason = { snapshotInitial };
-    } else if (totalEntries - snapshottedEntries >= snapshotInterval) {
+    } else if (
+      totalEntries > snapshotInitial &&
+      totalEntries - snapshottedEntries >= snapshotInterval
+    ) {
       reason = { snapshotInterval };
     }
     // console.log('maybeSaveSnapshot: reason:', reason);

--- a/packages/SwingSet/test/xsnap-snapshots/bootstrap-snapshots.js
+++ b/packages/SwingSet/test/xsnap-snapshots/bootstrap-snapshots.js
@@ -1,0 +1,12 @@
+import { Far } from '@endo/marshal';
+
+export const buildRootObject = () => {
+  let count = 0;
+  return Far('root', {
+    bootstrap: () => 0,
+    increment: () => {
+      count += 1;
+    },
+    read: () => count,
+  });
+};

--- a/packages/SwingSet/test/xsnap-snapshots/test-xsnap-snapshots.js
+++ b/packages/SwingSet/test/xsnap-snapshots/test-xsnap-snapshots.js
@@ -1,0 +1,134 @@
+// import lmdb early to work around SES incompatibility
+import 'lmdb';
+
+// eslint-disable-next-line import/order
+import { test } from '../../tools/prepare-test-env-ava.js';
+import tmp from 'tmp';
+
+// eslint-disable-next-line import/order
+import { assert } from '@agoric/assert';
+import { initSwingStore } from '@agoric/swing-store';
+import {
+  buildKernelBundles,
+  initializeSwingset,
+  makeSwingsetController,
+} from '../../src/index.js';
+import { bundleOpts } from '../util.js';
+
+const bfile = name => new URL(name, import.meta.url).pathname;
+test.before(async t => {
+  const kernelBundles = await buildKernelBundles();
+  t.context.data = { kernelBundles };
+});
+
+test('snapshots', async t => {
+  const swingStorePath = tmp.dirSync({ unsafeCleanup: true }).name;
+  const { commit, ...hostStorage } = initSwingStore(swingStorePath);
+  const { snapStore, kvStore } = hostStorage;
+  const config = {
+    defaultManagerType: 'xs-worker',
+    snapshotInitial: 1,
+    snapshotInterval: 1,
+    bootstrap: 'bootstrap',
+    defaultReapInterval: 'never', // disable BOYD, only startVat+deliver
+    vats: {
+      bootstrap: { sourceSpec: bfile('bootstrap-snapshots.js') },
+    },
+  };
+
+  const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
+  initOpts.addComms = false;
+  initOpts.addVattp = false;
+  initOpts.addTimer = false;
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, {}, runtimeOpts);
+  t.teardown(c.shutdown);
+  c.pinVatRoot('bootstrap');
+  await c.run();
+
+  const run = async (method, args = []) => {
+    assert(Array.isArray(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
+    await c.run();
+    const status = c.kpStatus(kpid);
+    t.is(status, 'fulfilled');
+  };
+
+  const vatID = kvStore.get('vat.name.bootstrap');
+
+  function getLatestSnapshot() {
+    const s = kvStore.get(`local.${vatID}.lastSnapshot`);
+    return JSON.parse(s)?.snapshotID;
+  }
+
+  // return 'undefined' if the snapshotID is unrecognized, or a
+  // (possibly-empty) array of vatIDs that use it
+  function getSnapshotUsers(snapshotID) {
+    const v = kvStore.get(`local.snapshot.${snapshotID}`);
+    return v ? JSON.parse(v) : v;
+  }
+
+  // the delivery of startVat and bootstrap() results in snapshot A
+  const sidA = getLatestSnapshot();
+  t.true(await snapStore.has(sidA));
+  t.deepEqual(getSnapshotUsers(sidA), [vatID]);
+
+  // increment() results in snapshot B
+  await run('increment');
+
+  const sidB = getLatestSnapshot();
+  t.not(sidA, sidB);
+  // the DB remembers 'A' as unused, so commit() will delete it, but
+  // until then we should have both
+  t.true(await snapStore.has(sidA));
+  t.true(await snapStore.has(sidB));
+  t.deepEqual(getSnapshotUsers(sidA), []);
+  t.deepEqual(getSnapshotUsers(sidB), [vatID]);
+
+  // commit() will delete the file. Ideally it would also remove the
+  // entire used-by entry, but they are in different DBs with
+  // different atomicity domains, so we currently leave the empty
+  // used-by entries around forever
+  await commit();
+
+  t.false(await snapStore.has(sidA));
+  t.true(await snapStore.has(sidB));
+  // t.deepEqual(getSnapshotUsers(sidA), undefined);
+  t.deepEqual(getSnapshotUsers(sidA), []); // not deleted
+  t.deepEqual(getSnapshotUsers(sidB), [vatID]);
+
+  // this delivery does not change the vat state, so its snapshot will
+  // be identical to the previous one (B). In bug 5901, vatKeeper
+  // erroneously marked this ID as deleted.
+  await run('read');
+
+  t.is(getLatestSnapshot(), sidB);
+  t.true(await snapStore.has(sidB));
+  t.deepEqual(getSnapshotUsers(sidA), []); // not deleted
+  t.deepEqual(getSnapshotUsers(sidB), [vatID]);
+
+  // in the buggy version, this commit() deleted B
+  await commit();
+  t.is(getLatestSnapshot(), sidB);
+  t.true(await snapStore.has(sidB)); // .. so this failed
+  t.deepEqual(getSnapshotUsers(sidA), []); // not deleted
+  t.deepEqual(getSnapshotUsers(sidB), [vatID]);
+
+  await run('increment'); // results in snapshot C
+  const sidC = getLatestSnapshot();
+  t.not(sidC, sidB);
+  t.true(await snapStore.has(sidB));
+  t.true(await snapStore.has(sidC));
+  t.deepEqual(getSnapshotUsers(sidA), []); // not deleted
+  t.deepEqual(getSnapshotUsers(sidB), []);
+  t.deepEqual(getSnapshotUsers(sidC), [vatID]);
+
+  // the commit() will delete B now that it is unused
+  await commit();
+  // in the buggy version, commit() failed because B was already deleted
+  t.false(await snapStore.has(sidB));
+  t.true(await snapStore.has(sidC));
+  t.deepEqual(getSnapshotUsers(sidA), []); // not deleted
+  t.deepEqual(getSnapshotUsers(sidB), []); // not deleted
+  t.deepEqual(getSnapshotUsers(sidC), [vatID]);
+});

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -219,6 +219,21 @@ export function makeSnapStore(
 
   /**
    * @param {string} hash
+   * @returns {Promise<boolean>}
+   */
+  function has(hash) {
+    return stat(hashPath(hash))
+      .then(_stats => true)
+      .catch(err => {
+        if (err.code === 'ENOENT') {
+          return false;
+        }
+        throw err;
+      });
+  }
+
+  /**
+   * @param {string} hash
    * @param {(fn: string) => Promise<T>} loadRaw
    * @template T
    */
@@ -268,5 +283,5 @@ export function makeSnapStore(
     }
   }
 
-  return freeze({ load, save, prepareToDelete, commitDeletes });
+  return freeze({ has, load, save, prepareToDelete, commitDeletes });
 }

--- a/packages/swing-store/test/test-snapstore.js
+++ b/packages/swing-store/test/test-snapstore.js
@@ -32,6 +32,10 @@ test('build temp file; compress to cache file', async t => {
     'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
     hash,
   );
+  t.is(await store.has(hash), true);
+  const zero =
+    '0000000000000000000000000000000000000000000000000000000000000000';
+  t.is(await store.has(zero), false);
   t.falsy(
     fs.existsSync(keepTmp),
     'temp file should have been deleted after withTempName',


### PR DESCRIPTION
Deliveries to a vat might not actually change the state of the vat, if
the action is read-only and GC is good at cleaning up any temporary
objects. When the vat runs inside an `xsnap` worker, this can result
in the following heap snapshot being identical to the previous one.

`vatKeeper.saveSnapshot()` had a bug in which it always marked the
previous snapshotID as unused, even if the new snapshotID was the same
as the old one. The snapStore handled this correctly, but vatKeeper
was telling it to `prepareToDelete` by mistake.

Snapshots and the kvStore are (unfortunately) in separate databases,
with separate commit points. To avoid losing data if the application
halts after kvStore commits but before snapStore commits, we defer
deletion of unused snapshots until the `snapStore.commit()`. The
snapStore maintains an in-RAM `Set` of unreferenced snapshot IDs to
remember what needs deletion.

The vatKeeper bug manifested as a crash after the following sequence
of events:

* 1: a delivery is made that does not change the vat state (snapshotA)
  * the bug tells snapStore to add snapshotA to the deletion list
* 2: `snapStore.commit()` runs
  * snapshotA is deleted, oops
* 3: a second delivery arrives, resulting in snapshotB
  * vatKeeper tells snapStore to delete snapshotA again
* 4: `snapStore.commit()` runs again
  * snapStore attempts to re-delete the snapshotA file
  * that results in ENOENT and a crash

We only create a snapshot for every 200 cranks, so there could be a
considerable delay between events 2 and 3, allowing the crash to
happen well after the actual problem. And until recently, xsnap was
not creating deterministic snapshots, masking the problem.

The fix is to change `vatKeeper` to not assume the new snapshot is
different than the old one: if they are the same, don't mark the old
one as unused.

closes #5901
