### PR TITLE
feat(zoe): add E(userSeat).wasWantSatisfied()

### DIFF
--- a/packages/zoe/src/contractFacet/offerSafety.js
+++ b/packages/zoe/src/contractFacet/offerSafety.js
@@ -7,20 +7,25 @@ import { AmountMath } from '@agoric/ertp';
  * allocationAmount greater than or equal to requiredAmount for every
  * keyword of giveOrWant?
  *
+ * To prepare for multiples, satisfiesWant and satisfiesGive return 0 or 1.
+ * isOfferSafe will still be boolean. When we have Multiples, satisfiesWant and
+ * satisfiesGive will tell how many times the offer was matched.
+ *
  * @param {AmountKeywordRecord} giveOrWant
  * @param {AmountKeywordRecord} allocation
+ * @returns {0|1}
  */
 const satisfiesInternal = (giveOrWant = {}, allocation) => {
   const isGTEByKeyword = ([keyword, requiredAmount]) => {
     // If there is no allocation for a keyword, we know the giveOrWant
     // is not satisfied without checking further.
     if (allocation[keyword] === undefined) {
-      return false;
+      return 0;
     }
     const allocationAmount = allocation[keyword];
-    return AmountMath.isGTE(allocationAmount, requiredAmount);
+    return AmountMath.isGTE(allocationAmount, requiredAmount) ? 1 : 0;
   };
-  return Object.entries(giveOrWant).every(isGTEByKeyword);
+  return Object.entries(giveOrWant).every(isGTEByKeyword) ? 1 : 0;
 };
 
 /**
@@ -77,8 +82,11 @@ const satisfiesGive = (proposal, allocation) =>
  */
 function isOfferSafe(proposal, allocation) {
   return (
-    satisfiesGive(proposal, allocation) || satisfiesWant(proposal, allocation)
+    satisfiesGive(proposal, allocation) > 0 ||
+    satisfiesWant(proposal, allocation) > 0
   );
 }
 
+harden(isOfferSafe);
+harden(satisfiesWant);
 export { isOfferSafe, satisfiesWant };

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -37,12 +37,14 @@ export const assertIssuerKeywords = (zcf, expected) => {
  * check; whether the allocation constitutes a refund is not
  * checked. The update is merged with currentAllocation
  * (update's values prevailing if the keywords are the same)
- * to produce the newAllocation.
+ * to produce the newAllocation. The return value is 0 for
+ * false and 1 for true. When multiples are introduced, any
+ * positive return value will mean true.
  *
  * @param {ZCF} zcf
  * @param {ZcfSeatPartial} seat
  * @param {AmountKeywordRecord} update
- * @returns {boolean}
+ * @returns {0|1}
  */
 export const satisfies = (zcf, seat, update) => {
   const currentAllocation = seat.getCurrentAllocation();

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -182,7 +182,7 @@
  * @property {() => Promise<OR>} getOfferResult
  * @property {() => void=} tryExit
  * @property {() => Promise<boolean>} hasExited
- * @property {() => Promise<0|1>} wasWantSatisfied
+ * @property {() => Promise<0|1>} numWantsSatisfied
  *
  * @property {() => Promise<Allocation>} getCurrentAllocationJig
  * Labelled "Jig" because it *should* only be used for tests, though

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -182,6 +182,7 @@
  * @property {() => Promise<OR>} getOfferResult
  * @property {() => void=} tryExit
  * @property {() => Promise<boolean>} hasExited
+ * @property {() => Promise<0|1>} wasWantSatisfied
  *
  * @property {() => Promise<Allocation>} getCurrentAllocationJig
  * Labelled "Jig" because it *should* only be used for tests, though

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -97,7 +97,7 @@ export const makeZoeSeatAdminKit = (
     getCurrentAllocationJig: async () => currentAllocation,
     getAllocationNotifierJig: async () => notifier,
 
-    wasWantSatisfied: async () => {
+    numWantsSatisfied: async () => {
       return E.when(payoutPromiseKit.promise, () =>
         satisfiesWant(proposal, currentAllocation),
       );

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -4,6 +4,7 @@ import { makePromiseKit } from '@endo/promise-kit';
 import { makeNotifierKit } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { AmountMath } from '@agoric/ertp';
 
 import { handlePKitWarning } from '../handleWarning.js';
 
@@ -95,6 +96,14 @@ export const makeZoeSeatAdminKit = (
 
     getCurrentAllocationJig: async () => currentAllocation,
     getAllocationNotifierJig: async () => notifier,
+
+    wasWantSatisfied: async () => {
+      return E.when(payoutPromiseKit.promise, () =>
+        Object.keys(proposal.want).every(kwd =>
+          AmountMath.isGTE(currentAllocation[kwd], proposal.want[kwd]),
+        ),
+      );
+    },
   });
 
   return { userSeat, zoeSeatAdmin, notifier };

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -4,9 +4,9 @@ import { makePromiseKit } from '@endo/promise-kit';
 import { makeNotifierKit } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { AmountMath } from '@agoric/ertp';
 
 import { handlePKitWarning } from '../handleWarning.js';
+import { satisfiesWant } from '../contractFacet/offerSafety.js';
 
 import '../types.js';
 import '../internal-types.js';
@@ -99,9 +99,7 @@ export const makeZoeSeatAdminKit = (
 
     wasWantSatisfied: async () => {
       return E.when(payoutPromiseKit.promise, () =>
-        Object.keys(proposal.want).every(kwd =>
-          AmountMath.isGTE(currentAllocation[kwd], proposal.want[kwd]),
-        ),
+        satisfiesWant(proposal, currentAllocation),
       );
     },
   });

--- a/packages/zoe/test/unitTests/test-offerSafety.js
+++ b/packages/zoe/test/unitTests/test-offerSafety.js
@@ -3,7 +3,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { isOfferSafe } from '../../src/contractFacet/offerSafety.js';
+import {
+  isOfferSafe,
+  satisfiesWant,
+} from '../../src/contractFacet/offerSafety.js';
 import { setup } from './setupBasicMints.js';
 
 // Potential outcomes:
@@ -34,6 +37,7 @@ test('isOfferSafe - more than want, more than give', t => {
   const amounts = harden({ A: moola(10n), B: simoleans(7n), C: bucks(8n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
+  t.is(satisfiesWant(proposal, amounts), 1);
 });
 
 // more than want, less than give -> true
@@ -47,6 +51,7 @@ test('isOfferSafe - more than want, less than give', t => {
   const amounts = harden({ A: moola(1n), B: simoleans(7n), C: bucks(8n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
+  t.is(satisfiesWant(proposal, amounts), 1);
 });
 
 // more than want, equal to give -> true
@@ -60,6 +65,7 @@ test('isOfferSafe - more than want, equal to give', t => {
   const amounts = harden({ A: moola(9n), B: simoleans(6n), C: bucks(7n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
+  t.is(satisfiesWant(proposal, amounts), 1);
 });
 
 // less than want, more than give -> true
@@ -73,6 +79,7 @@ test('isOfferSafe - less than want, more than give', t => {
   const amounts = harden({ A: moola(7n), B: simoleans(9n), C: bucks(19n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
+  t.is(satisfiesWant(proposal, amounts), 0);
 });
 
 // less than want, less than give -> false
@@ -86,6 +93,7 @@ test('isOfferSafe - less than want, less than give', t => {
   const amounts = harden({ A: moola(7n), B: simoleans(5n), C: bucks(6n) });
 
   t.falsy(isOfferSafe(proposal, amounts));
+  t.is(satisfiesWant(proposal, amounts), 0);
 });
 
 // less than want, equal to give -> true
@@ -99,6 +107,7 @@ test('isOfferSafe - less than want, equal to give', t => {
   const amounts = harden({ A: moola(1n), B: simoleans(5n), C: bucks(7n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
+  t.is(satisfiesWant(proposal, amounts), 0);
 });
 
 // equal to want, more than give -> true
@@ -112,6 +121,7 @@ test('isOfferSafe - equal to want, more than give', t => {
   const amounts = harden({ A: moola(2n), B: simoleans(6n), C: bucks(8n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
+  t.is(satisfiesWant(proposal, amounts), 1);
 });
 
 // equal to want, less than give -> true
@@ -125,6 +135,7 @@ test('isOfferSafe - equal to want, less than give', t => {
   const amounts = harden({ A: moola(0n), B: simoleans(6n), C: bucks(0n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
+  t.is(satisfiesWant(proposal, amounts), 1);
 });
 
 // equal to want, equal to give -> true
@@ -138,6 +149,7 @@ test('isOfferSafe - equal to want, equal to give', t => {
   const amounts = harden({ A: moola(1n), B: simoleans(6n), C: bucks(7n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
+  t.is(satisfiesWant(proposal, amounts), 1);
 });
 
 test('isOfferSafe - empty proposal', t => {
@@ -146,4 +158,5 @@ test('isOfferSafe - empty proposal', t => {
   const amounts = harden({ A: moola(1n), B: simoleans(6n), C: bucks(7n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
+  t.is(satisfiesWant(proposal, amounts), 1);
 });

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -933,7 +933,7 @@ test(`userSeat from zcf.makeEmptySeatKit - only these properties exist`, async t
     'tryExit',
     'getCurrentAllocationJig',
     'getAllocationNotifierJig',
-    'wasWantSatisfied',
+    'numWantsSatisfied',
   ];
   const { zcf } = await setupZCFTest();
   const { userSeat: userSeatP } = zcf.makeEmptySeatKit();
@@ -1415,7 +1415,7 @@ test(`zcf.setOfferFilter - legal lists`, async t => {
   t.is(await zcf.setOfferFilter(['fooOffer: ', 'bar Offer']), undefined);
 });
 
-test('wasWantSatisfied: no', async t => {
+test('numWantsSatisfied: no', async t => {
   const { zcf } = await setupZCFTest();
   const doubloonMint = await zcf.makeZCFMint('Doubloons');
   const yenMint = await zcf.makeZCFMint('Yen');
@@ -1441,10 +1441,10 @@ test('wasWantSatisfied: no', async t => {
   );
 
   await zcfSeat.exit();
-  t.is(await E(userSeat).wasWantSatisfied(), 0);
+  t.is(await E(userSeat).numWantsSatisfied(), 0);
 });
 
-test('wasWantSatisfied: yes', async t => {
+test('numWantsSatisfied: yes', async t => {
   const { zcf } = await setupZCFTest();
   const doubloonMint = await zcf.makeZCFMint('Doubloons');
   const { brand: doubloonBrand } = doubloonMint.getIssuerRecord();
@@ -1461,10 +1461,10 @@ test('wasWantSatisfied: yes', async t => {
   doubloonMint.mintGains(harden({ Bonus: doubloonAmount }), zcfSeat);
 
   await zcfSeat.exit();
-  t.is(await E(userSeat).wasWantSatisfied(), 1);
+  t.is(await E(userSeat).numWantsSatisfied(), 1);
 });
 
-test('wasWantSatisfied as promise', async t => {
+test('numWantsSatisfied as promise', async t => {
   const { zcf } = await setupZCFTest();
   const doubloonMint = await zcf.makeZCFMint('Doubloons');
   const { brand: doubloonBrand } = doubloonMint.getIssuerRecord();
@@ -1479,7 +1479,7 @@ test('wasWantSatisfied as promise', async t => {
     proposal,
   );
 
-  const outcome = E.when(E(userSeat).wasWantSatisfied(), result =>
+  const outcome = E.when(E(userSeat).numWantsSatisfied(), result =>
     t.is(result, 1),
   );
   doubloonMint.mintGains(harden({ Bonus: doubloonAmount }), zcfSeat);

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1440,7 +1440,7 @@ test('wasWantSatisfied: no', async t => {
   );
 
   await zcfSeat.exit();
-  t.false(await E(userSeat).wasWantSatisfied());
+  t.is(await E(userSeat).wasWantSatisfied(), 0);
 });
 
 test('wasWantSatisfied: yes', async t => {
@@ -1460,7 +1460,7 @@ test('wasWantSatisfied: yes', async t => {
   doubloonMint.mintGains(harden({ Bonus: doubloonAmount }), zcfSeat);
 
   await zcfSeat.exit();
-  t.true(await E(userSeat).wasWantSatisfied());
+  t.is(await E(userSeat).wasWantSatisfied(), 1);
 });
 
 test('wasWantSatisfied as promise', async t => {
@@ -1479,7 +1479,7 @@ test('wasWantSatisfied as promise', async t => {
   );
 
   const outcome = E.when(E(userSeat).wasWantSatisfied(), result =>
-    t.true(result),
+    t.is(result, 1),
   );
   doubloonMint.mintGains(harden({ Bonus: doubloonAmount }), zcfSeat);
 

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -933,6 +933,7 @@ test(`userSeat from zcf.makeEmptySeatKit - only these properties exist`, async t
     'tryExit',
     'getCurrentAllocationJig',
     'getAllocationNotifierJig',
+    'wasWantSatisfied',
   ];
   const { zcf } = await setupZCFTest();
   const { userSeat: userSeatP } = zcf.makeEmptySeatKit();


### PR DESCRIPTION
closes: #5818
closes: #3056
refs: #4360

## Description

Add a method on Zoe's userSeats that reveals whether the seat exited with its wants satisfied.

### Security Considerations

This doesn't reveal interim state of a seat. In fact, it doesn't reveal anything the userSeat didn't already have access to, since it only needed the payouts and the proposal. But this is a more reliable way for dApps to find out than doing the calculation themselves.

### Documentation Considerations

Needs to be added to the Zoe docs.

### Testing Considerations

Tests simple cases of satisfying and not satisfying the wants. Verifies that the promise is available before the seat exits.