### PR TITLE
fix: Better pattern mismatch diagnostics

### DIFF
--- a/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
@@ -20,7 +20,7 @@ const empty = makeCopyBag([]);
  */
 export const copyBagMathHelpers = harden({
   doCoerce: bag => {
-    fit(bag, M.bag());
+    fit(bag, M.bag(), 'bag of amount');
     return bag;
   },
   doMakeEmpty: () => empty,

--- a/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
@@ -20,7 +20,7 @@ const empty = makeCopySet([]);
  */
 export const copySetMathHelpers = harden({
   doCoerce: set => {
-    fit(set, M.set());
+    fit(set, M.set(), 'set of amount');
     return set;
   },
   doMakeEmpty: () => empty,

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -190,7 +190,7 @@ export const vivifyPaymentLedger = (
    */
   const assertAmountConsistent = (paymentBalance, optAmountShape) => {
     if (optAmountShape !== undefined) {
-      fit(paymentBalance, optAmountShape);
+      fit(paymentBalance, optAmountShape, 'amount');
     }
   };
 
@@ -372,7 +372,7 @@ export const vivifyPaymentLedger = (
    */
   const mintPayment = newAmount => {
     newAmount = coerce(newAmount);
-    fit(newAmount, amountSchema);
+    fit(newAmount, amountSchema, 'minted amount');
     const payment = makePayment();
     initPayment(payment, newAmount, undefined);
     return payment;

--- a/packages/SwingSet/src/vats/timer/timeMath.js
+++ b/packages/SwingSet/src/vats/timer/timeMath.js
@@ -124,7 +124,7 @@ const toAbs = (ts, brand = undefined) => {
   } else {
     const { timerBrand } = ts;
     agreedTimerBrand(timerBrand, brand);
-    fit(ts, TimestampShape);
+    fit(ts, TimestampShape, 'timestamp');
     return ts;
   }
 };
@@ -145,7 +145,7 @@ const toRel = (rt, brand = undefined) => {
   } else {
     const { timerBrand } = rt;
     agreedTimerBrand(timerBrand, brand);
-    fit(rt, RelativeTimeShape);
+    fit(rt, RelativeTimeShape, 'relativeTime');
     return rt;
   }
 };

--- a/packages/inter-protocol/src/stakeFactory/attestation.js
+++ b/packages/inter-protocol/src/stakeFactory/attestation.js
@@ -74,7 +74,11 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
       attestationAmount.brand === attBrand,
       X`The escrowed attestation ${attestationAmount} was not of the attestation brand ${attBrand}`,
     );
-    fit(attestationAmount.value.payload, harden([[M.string(), M.bigint()]]));
+    fit(
+      attestationAmount.value.payload,
+      harden([[M.string(), M.bigint()]]),
+      'attestationAmount',
+    );
     /** @type {[Address, bigint][]} */
     const [[address, valueReturned]] = attestationAmount.value.payload;
     const lienedAmount = AmountMath.make(stakeBrand, valueReturned);

--- a/packages/inter-protocol/src/stakeFactory/stakeFactoryManager.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactoryManager.js
@@ -207,7 +207,7 @@ const manager = {
     fit(
       attestationGiven.value,
       M.bagOf([M.string(), M.bigint()]),
-      attestationGiven,
+      'attestationGiven',
     );
     const [[_addr, valueLiened]] = getCopyBagEntries(attestationGiven.value);
     const amountLiened = AmountMath.make(brands.Stake, valueLiened);

--- a/packages/inter-protocol/src/stakeFactory/stakeFactoryManager.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactoryManager.js
@@ -204,7 +204,11 @@ const manager = {
       brands.Attestation,
       X`Invalid Attestation ${attestationGiven}. Expected brand ${brands.Attestation}`,
     );
-    fit(attestationGiven.value, M.bagOf([M.string(), M.bigint()]));
+    fit(
+      attestationGiven.value,
+      M.bagOf([M.string(), M.bigint()]),
+      attestationGiven,
+    );
     const [[_addr, valueLiened]] = getCopyBagEntries(attestationGiven.value);
     const amountLiened = AmountMath.make(brands.Stake, valueLiened);
     const maxDebt = floorMultiplyBy(amountLiened, mintingRatio);

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -320,9 +320,9 @@ const machineBehavior = {
       zcf,
     } = ephemera;
     const { collateralTypes, mintSeat, rewardPoolSeat } = state;
-    fit(collateralIssuer, M.remotable());
+    fit(collateralIssuer, M.remotable(), 'collateralIssuer');
     assertKeywordName(collateralKeyword);
-    fit(initialParamValues, vaultParamPattern);
+    fit(initialParamValues, vaultParamPattern, 'initialParamValues');
     await zcf.saveIssuer(collateralIssuer, collateralKeyword);
     const collateralBrand = zcf.getBrandForIssuer(collateralIssuer);
     // We create only one vault per collateralType.

--- a/packages/store/src/stores/scalarMapStore.js
+++ b/packages/store/src/stores/scalarMapStore.js
@@ -147,7 +147,7 @@ export const makeScalarMapStore = (
 
     assertPassable(value);
     if (valueSchema !== undefined) {
-      fit(value, valueSchema);
+      fit(value, valueSchema, 'mapStore value');
     }
   };
 
@@ -158,7 +158,7 @@ export const makeScalarMapStore = (
 
     assertScalarKey(key);
     if (keySchema !== undefined) {
-      fit(key, keySchema);
+      fit(key, keySchema, 'mapStore key');
     }
     assertKVOkToSet(key, value);
   };

--- a/packages/store/src/stores/scalarSetStore.js
+++ b/packages/store/src/stores/scalarSetStore.js
@@ -102,7 +102,7 @@ export const makeScalarSetStore = (
 
     assertScalarKey(key);
     if (keySchema !== undefined) {
-      fit(key, keySchema);
+      fit(key, keySchema, 'setStore key');
     }
   };
 

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -105,7 +105,7 @@ export const makeScalarWeakMapStore = (
 
     assertPassable(value);
     if (valueSchema !== undefined) {
-      fit(value, valueSchema);
+      fit(value, valueSchema, 'weakMapStore value');
     }
   };
 
@@ -119,7 +119,7 @@ export const makeScalarWeakMapStore = (
       X`Only remotables can be keys of scalar WeakMapStores: ${key}`,
     );
     if (keySchema !== undefined) {
-      fit(key, keySchema);
+      fit(key, keySchema, 'weakMapStore key');
     }
     assertKVOkToSet(key, value);
   };

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -87,7 +87,7 @@ export const makeScalarWeakSetStore = (
       X`Only remotables can be keys of scalar WeakStores: ${key}`,
     );
     if (keySchema !== undefined) {
-      fit(key, keySchema);
+      fit(key, keySchema, 'weakSetStore key');
     }
   };
 

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -170,7 +170,7 @@ export const cleanProposal = (proposal, getAssetKindByBrand) => {
     give: cleanedGive,
     exit,
   });
-  fit(cleanedProposal, ProposalShape);
+  fit(cleanedProposal, ProposalShape, 'proposal');
   assertExit(exit);
   assertKeywordNotInBoth(cleanedWant, cleanedGive);
   return cleanedProposal;

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -110,7 +110,7 @@ export const swapExact = (zcf, leftSeat, rightSeat) => {
  */
 export const fitProposalShape = (seat, proposalShape) =>
   // TODO remove this harden, obligating our caller to harden.
-  fit(seat.getProposal(), harden(proposalShape));
+  fit(seat.getProposal(), harden(proposalShape), 'proposal');
 
 /**
  * Check the seat's proposal against an `expected` record that says

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -60,7 +60,11 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
 
   /** @type {OfferHandler} */
   const makeOption = sellSeat => {
-    fit(sellSeat.getProposal(), M.split({ exit: { afterDeadline: M.any() } }));
+    fit(
+      sellSeat.getProposal(),
+      M.split({ exit: { afterDeadline: M.any() } }),
+      'exit afterDeadline',
+    );
     const sellSeatExitRule = sellSeat.getProposal().exit;
     assert(
       isAfterDeadlineExitRule(sellSeatExitRule),

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -74,7 +74,11 @@ const start = zcf => {
 
   /** @type {OfferHandler} */
   const makeOption = sellSeat => {
-    fit(sellSeat.getProposal(), M.split({ exit: { afterDeadline: M.any() } }));
+    fit(
+      sellSeat.getProposal(),
+      M.split({ exit: { afterDeadline: M.any() } }),
+      'exit afterDeadline',
+    );
     const sellSeatExitRule = sellSeat.getProposal().exit;
     assert(
       isAfterDeadlineExitRule(sellSeatExitRule),

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -57,7 +57,7 @@ export const makeOfferMethod = (
     const proposal = cleanProposal(uncleanProposal, getAssetKindByBrand);
     const proposalSchema = getProposalSchemaForInvitation(invitationHandle);
     if (proposalSchema !== undefined) {
-      fit(proposal, proposalSchema);
+      fit(proposal, proposalSchema, 'proposal');
     }
 
     if (offerArgs !== undefined) {


### PR DESCRIPTION
## Description

Pattern matching produces errors that are not always clear, so
https://github.com/Agoric/agoric-sdk/pull/5876 
added an optional `label` parameter to `fit` to at least identify what the error was about. This PR adds such labels to the `fit` calls outside of `test` and `demo` directories.

### Security Considerations

None

### Documentation Considerations

None

### Testing Considerations

Tests that were doing exact matches against error messages might need to be updated. Those doing unanchored regexp matching would not.