### PR TITLE
more RUN remnants

### DIFF
--- a/packages/inter-protocol/docs/governance-params.md
+++ b/packages/inter-protocol/docs/governance-params.md
@@ -48,7 +48,7 @@ In `packages/inter-protocol/src/reserve/collateralReserve.js`:
 The Inter Protocol Whitepaper v0.8 does not describe the governance parameters
 for this contract.  
 
-### RUNStake
+### stakeFactory
 
 In `packages/inter-protocol/src/stakeFactory/stakeFactory.js`:
 
@@ -60,7 +60,7 @@ In `packages/inter-protocol/src/stakeFactory/stakeFactory.js`:
 | MintingRatio       | ParamTypes.RATIO    | Yes |
 
 From Inter Protocol Whitepaper, v0.8:  
->Governance through the BLDer DAO determines the parameters for RUNstake. These include the total debt limit, the minting limit per account, and minting fees and interest rates. 
+>Governance through the BLDer DAO determines the parameters for stakeFactory. These include the total debt limit, the minting limit per account, and minting fees and interest rates. 
 
 ### Parity Stability Mechanism (PSM)
 

--- a/packages/inter-protocol/scripts/init-core.js
+++ b/packages/inter-protocol/scripts/init-core.js
@@ -4,7 +4,7 @@ import { makeHelpers } from '@agoric/deploy-script-support';
 import { objectMap } from '@agoric/vat-data';
 
 import {
-  getManifestForRunProtocol,
+  getManifestForInterProtocol,
   getManifestForEconCommittee,
   getManifestForMain,
 } from '../src/proposals/core-proposal.js';
@@ -181,7 +181,7 @@ export const defaultProposalBuilder = async (
   return harden({
     sourceSpec: '../src/proposals/core-proposal.js',
     getManifestCall: [
-      getManifestForRunProtocol.name,
+      getManifestForInterProtocol.name,
       {
         ROLE,
         vaultFactoryControllerAddress,

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -184,7 +184,7 @@ const REWARD_MANIFEST = harden({
   },
 });
 
-const RUN_STAKE_MANIFEST = harden({
+const STAKE_FACTORY_MANIFEST = harden({
   [econBehaviors.startLienBridge.name]: {
     consume: { bridgeManager: true },
     produce: { lienBridge: true },
@@ -296,13 +296,13 @@ export const getManifestForMain = (
 const roleToManifest = harden({
   chain: {
     ...REWARD_MANIFEST,
-    ...RUN_STAKE_MANIFEST,
+    ...STAKE_FACTORY_MANIFEST,
   },
   'sim-chain': SIM_CHAIN_MANIFEST,
   client: {},
 });
 
-export const getManifestForRunProtocol = (
+export const getManifestForInterProtocol = (
   { restoreRef },
   {
     ROLE = 'chain',

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -539,10 +539,10 @@ harden(grantVaultFactoryControl);
 export const configureVaultFactoryUI = async ({
   consume: { board, zoe },
   issuer: {
-    consume: { [Stable.symbol]: centralIssuerP },
+    consume: { [Stable.symbol]: stableIssuerP },
   },
   brand: {
-    consume: { [Stable.symbol]: centralBrandP },
+    consume: { [Stable.symbol]: stableBrandP },
   },
   installation: {
     consume: {
@@ -569,9 +569,9 @@ export const configureVaultFactoryUI = async ({
     amm: ammInstance,
     vaultFactory: vaultInstance,
   });
-  const [centralIssuer, centralBrand] = await Promise.all([
-    centralIssuerP,
-    centralBrandP,
+  const [stableIssuer, stableBrand] = await Promise.all([
+    stableIssuerP,
+    stableBrandP,
   ]);
 
   const invitationIssuer = await E(zoe).getInvitationIssuer();
@@ -589,8 +589,12 @@ export const configureVaultFactoryUI = async ({
   const boardIdValue = [
     ['INSTANCE_BOARD_ID', instances.vaultFactory],
     ['INSTALLATION_BOARD_ID', installs.vaultFactory],
-    ['RUN_ISSUER_BOARD_ID', centralIssuer],
-    ['RUN_BRAND_BOARD_ID', centralBrand],
+    // @deprecated
+    ['RUN_ISSUER_BOARD_ID', stableIssuer],
+    // @deprecated
+    ['RUN_BRAND_BOARD_ID', stableBrand],
+    ['STABLE_ISSUER_BOARD_ID', stableIssuer],
+    ['STABLE_BRAND_BOARD_ID', stableBrand],
     ['AMM_INSTALLATION_BOARD_ID', installs.amm],
     ['LIQ_INSTALLATION_BOARD_ID', installs.liquidate],
     ['BINARY_COUNTER_INSTALLATION_BOARD_ID', installs.binaryVoteCounter],

--- a/packages/inter-protocol/src/stakeFactory/stakeFactory.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactory.js
@@ -209,7 +209,7 @@ export const start = async (
   const publicFacet = augmentPublicFacet(
     Far('stakeFactory public', {
       makeLoanInvitation: () =>
-        zcf.makeInvitation(offerHandler, 'make RUNstake'),
+        zcf.makeInvitation(offerHandler, 'make stakeFactory'),
       makeReturnAttInvitation: att.publicFacet.makeReturnAttInvitation,
     }),
   );

--- a/packages/inter-protocol/src/stakeFactory/stakeFactoryKit.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactoryKit.js
@@ -56,7 +56,7 @@ const calculateFee = (feeCoeff, currentDebt, giveAmount, wantAmount) => {
  */
 
 /**
- * Make RUNstake kit state
+ * Make stakeFactory kit state
  *
  * @param {ZCF} zcf
  * @param {ZCFSeat} startSeat
@@ -358,7 +358,7 @@ const helperBehavior = {
     helper.assertVaultHoldsNoMinted();
     seat.exit();
 
-    return 'Your RUNstake is closed; thank you for your business.';
+    return 'Your stakeFactory is closed; thank you for your business.';
   },
 };
 
@@ -418,7 +418,7 @@ const finish = ({ facets }) => {
 };
 
 /**
- * Make RUNstake kit, subject to stakeFactory terms.
+ * Make stakeFactory kit, subject to stakeFactory terms.
  *
  * @param {ZCF} zcf
  * @param {ZCFSeat} startSeat
@@ -426,7 +426,7 @@ const finish = ({ facets }) => {
  * @throws {Error} if startSeat proposal is not consistent with governance parameters in manager
  */
 export const makeStakeFactoryKit = defineKindMulti(
-  'RUNStakeKit',
+  'stakeFactoryKit',
   initState,
   behavior,
   { finish },


### PR DESCRIPTION
## Description

Some internal references remained to RUN. This changes those.

It also adds board ids for `STABLE` as an alternative to `RUN`. Rather than removing the latter it deprecates so dapps don't break. (those that use https://github.com/search?q=org%3AAgoric+RUN_ISSUER_BOARD_ID&type=code ) 

Once those are converted to use `STABLE` we can remove the deprecated in https://github.com/Agoric/agoric-sdk/issues/5605


### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

Should not affect tests.