### PR TITLE
feat(vaultFactory)!: split numVaults to numActiveVaults and numLiquidatingVaults

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/inter-protocol/src/vaultFactory/orderedVaultStore.js
@@ -7,7 +7,7 @@ import { fromVaultKey, toVaultKey } from './storeUtils.js';
  * Designed to be replaceable by naked Collections API when composite keys are available.
  *
  * In this module debts are encoded as the inverse quotient (collateral over debt) so that
- * greater collaterization sorts after lower. (Higher debt-to-collateral come
+ * greater collateralization sorts after lower. (Higher debt-to-collateral come
  * first.)
  */
 

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -49,7 +49,9 @@ const trace = makeTracer('IV', false);
  * Constants for vault phase.
  *
  * ACTIVE       - vault is in use and can be changed
- * LIQUIDATING  - vault is being liquidated by the vault manager, and cannot be changed by the user
+ * LIQUIDATING  - vault is being liquidated by the vault manager, and cannot be changed by the user.
+ *                If liquidation fails, vaults may remain in this state. An upgrade to the contract
+ *                might be able to recover them.
  * TRANSFER     - vault is able to be transferred (payments and debits frozen until it has a new owner)
  * CLOSED       - vault was closed by the user and all assets have been paid out
  * LIQUIDATED   - vault was closed by the manager, with remaining assets paid to owner

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -23,6 +23,7 @@ import {
   makeKindHandle,
   makeScalarBigMapStore,
   pickFacet,
+  makeScalarBigSetStore,
 } from '@agoric/vat-data';
 import {
   assertProposalShape,
@@ -56,9 +57,10 @@ const trace = makeTracer('VM');
 /**
  * @typedef {object} MetricsNotification
  *
- * @property {number}         numVaults        present count of vaults
- * @property {Amount<'nat'>}  totalCollateral  present sum of collateral across all vaults
- * @property {Amount<'nat'>}  totalDebt        present sum of debt across all vaults
+ * @property {number}         numVaults          present count of vaults
+ * @property {number}         liquidatingVaults  present count of liquidating vaults
+ * @property {Amount<'nat'>}  totalCollateral    present sum of collateral across all vaults
+ * @property {Amount<'nat'>}  totalDebt          present sum of debt across all vaults
  *
  * @property {Amount<'nat'>}  totalCollateralSold       running sum of collateral sold in liquidation // totalCollateralSold
  * @property {Amount<'nat'>}  totalOverageReceived      running sum of overages, central received greater than debt
@@ -93,6 +95,7 @@ const trace = makeTracer('VM');
  * debtMint: ZCFMint<'nat'>,
  * poolIncrementSeat: ZCFSeat,
  * unsettledVaults: MapStore<string, Vault>,
+ * liquidatingVaults: SetStore<Vault>,
  * }>} ImmutableState
  */
 
@@ -202,6 +205,16 @@ const initState = (
     durable: true,
   });
 
+  /**
+   * If things are going well, the set will contain at most one Vault. Otherwise
+   * failures remain and are available to be repaired via contract upgrade.
+   *
+   * @type {SetStore<Vault>}
+   */
+  const liquidatingVaults = makeScalarBigSetStore('orderedVaultStore', {
+    durable: true,
+  });
+
   /** @type {ImmutableState} */
   const fixed = {
     collateralBrand,
@@ -209,6 +222,7 @@ const initState = (
     debtMint,
     poolIncrementSeat: zcf.makeEmptySeatKit().zcfSeat,
     unsettledVaults,
+    liquidatingVaults,
   };
 
   const compoundedInterest = makeRatio(100n, fixed.debtBrand); // starts at 1.0, no interest
@@ -357,6 +371,7 @@ const helperBehavior = {
     /** @type {MetricsNotification} */
     const payload = harden({
       numVaults: prioritizedVaults.getCount(),
+      liquidatingVaults: state.liquidatingVaults.getSize(),
       totalCollateral: state.totalCollateral,
       totalDebt: state.totalDebt,
 
@@ -504,6 +519,9 @@ const helperBehavior = {
     // Start liquidation (vaultState: LIQUIDATING)
     const liquidator = state.liquidator;
     assert(liquidator);
+    state.liquidatingVaults.add(vault);
+    prioritizedVaults.removeVault(key);
+
     return liquidate(
       zcf,
       vault,
@@ -537,7 +555,7 @@ const helperBehavior = {
           state.totalShortfallReceived,
           accounting.shortfall,
         );
-        prioritizedVaults.removeVault(key);
+        state.liquidatingVaults.delete(vault);
         trace('liquidated', state.collateralBrand);
         state.numLiquidationsCompleted += 1;
         facets.helper.updateMetrics();

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -57,8 +57,8 @@ const trace = makeTracer('VM');
 /**
  * @typedef {object} MetricsNotification
  *
- * @property {number}         numVaults          present count of vaults
- * @property {number}         liquidatingVaults  present count of liquidating vaults
+ * @property {number}         numActiveVaults          present count of vaults
+ * @property {number}         numLiquidatingVaults  present count of liquidating vaults
  * @property {Amount<'nat'>}  totalCollateral    present sum of collateral across all vaults
  * @property {Amount<'nat'>}  totalDebt          present sum of debt across all vaults
  *
@@ -211,7 +211,7 @@ const initState = (
    *
    * @type {SetStore<Vault>}
    */
-  const liquidatingVaults = makeScalarBigSetStore('orderedVaultStore', {
+  const liquidatingVaults = makeScalarBigSetStore('liquidatingVaults', {
     durable: true,
   });
 
@@ -370,8 +370,8 @@ const helperBehavior = {
 
     /** @type {MetricsNotification} */
     const payload = harden({
-      numVaults: prioritizedVaults.getCount(),
-      liquidatingVaults: state.liquidatingVaults.getSize(),
+      numActiveVaults: prioritizedVaults.getCount(),
+      numLiquidatingVaults: state.liquidatingVaults.getSize(),
       totalCollateral: state.totalCollateral,
       totalDebt: state.totalDebt,
 

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2597,6 +2597,7 @@ test('manager notifiers', async t => {
   await m.assertInitial({
     // present
     numVaults: 0,
+    liquidatingVaults: 0,
     totalCollateral: aeth.make(0n),
     totalDebt: run.make(0n),
 
@@ -2703,7 +2704,8 @@ test('manager notifiers', async t => {
   totalOverageReceived += 54n - DEBT2;
   await m.assertChange({
     numLiquidationsCompleted: 2,
-    numVaults: 1,
+    numVaults: 0,
+    liquidatingVaults: 1,
     totalCollateral: { value: AMPLE },
     totalDebt: { value: DEBT1 },
     totalOverageReceived: { value: totalOverageReceived },
@@ -2712,7 +2714,7 @@ test('manager notifiers', async t => {
   totalProceedsReceived += 473n;
   await m.assertChange({
     numLiquidationsCompleted: 3,
-    numVaults: 0,
+    liquidatingVaults: 0,
     totalCollateral: { value: 0n },
     totalDebt: { value: 0n },
     totalProceedsReceived: { value: totalProceedsReceived },
@@ -2799,7 +2801,8 @@ test('manager notifiers', async t => {
   totalProceedsReceived += nextProceeds;
   await m.assertChange({
     numLiquidationsCompleted: 5,
-    numVaults: 1,
+    numVaults: 0,
+    liquidatingVaults: 1,
     totalCollateral: { value: AMPLE },
     totalDebt: { value: DEBT1 + DEBT2 + interestAccrued - nextProceeds },
     totalProceedsReceived: { value: totalProceedsReceived },
@@ -2808,7 +2811,7 @@ test('manager notifiers', async t => {
   totalProceedsReceived += nextProceeds;
   await m.assertChange({
     numLiquidationsCompleted: 6,
-    numVaults: 0,
+    liquidatingVaults: 0,
     totalCollateral: { value: 0n },
     totalDebt: { value: 0n },
     totalProceedsReceived: { value: totalProceedsReceived },

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2596,8 +2596,8 @@ test('manager notifiers', async t => {
   trace('0. Creation');
   await m.assertInitial({
     // present
-    numVaults: 0,
-    liquidatingVaults: 0,
+    numActiveVaults: 0,
+    numLiquidatingVaults: 0,
     totalCollateral: aeth.make(0n),
     totalDebt: run.make(0n),
 
@@ -2624,7 +2624,7 @@ test('manager notifiers', async t => {
   let { vault } = await E(vaultSeat).getOfferResult();
   m.addDebt(DEBT1);
   await m.assertChange({
-    numVaults: 1,
+    numActiveVaults: 1,
     totalCollateral: { value: AMPLE },
     totalDebt: { value: DEBT1 },
   });
@@ -2649,7 +2649,7 @@ test('manager notifiers', async t => {
   let totalProceedsReceived = 474n;
   let totalOverageReceived = totalProceedsReceived - DEBT1;
   await m.assertChange({
-    numVaults: 0,
+    numActiveVaults: 0,
     totalCollateral: { value: 0n },
     totalDebt: { value: 0n },
     numLiquidationsCompleted: 1,
@@ -2672,7 +2672,7 @@ test('manager notifiers', async t => {
   );
   ({ vault } = await E(vaultSeat).getOfferResult());
   await m.assertChange({
-    numVaults: 1,
+    numActiveVaults: 1,
     totalCollateral: { value: AMPLE },
     totalDebt: { value: DEBT1 },
   });
@@ -2692,7 +2692,7 @@ test('manager notifiers', async t => {
   );
   ({ vault } = await E(vaultSeat).getOfferResult());
   await m.assertChange({
-    numVaults: 2,
+    numActiveVaults: 2,
     totalCollateral: { value: AMPLE + ENOUGH },
     totalDebt: { value: DEBT1 + DEBT2 },
   });
@@ -2704,8 +2704,8 @@ test('manager notifiers', async t => {
   totalOverageReceived += 54n - DEBT2;
   await m.assertChange({
     numLiquidationsCompleted: 2,
-    numVaults: 0,
-    liquidatingVaults: 1,
+    numActiveVaults: 0,
+    numLiquidatingVaults: 1,
     totalCollateral: { value: AMPLE },
     totalDebt: { value: DEBT1 },
     totalOverageReceived: { value: totalOverageReceived },
@@ -2714,7 +2714,7 @@ test('manager notifiers', async t => {
   totalProceedsReceived += 473n;
   await m.assertChange({
     numLiquidationsCompleted: 3,
-    liquidatingVaults: 0,
+    numLiquidatingVaults: 0,
     totalCollateral: { value: 0n },
     totalDebt: { value: 0n },
     totalProceedsReceived: { value: totalProceedsReceived },
@@ -2734,7 +2734,7 @@ test('manager notifiers', async t => {
   );
   ({ vault } = await E(vaultSeat).getOfferResult());
   await m.assertChange({
-    numVaults: 1,
+    numActiveVaults: 1,
     totalCollateral: { value: aeth.make(ENOUGH).value },
     totalDebt: { value: DEBT2 },
   });
@@ -2745,7 +2745,7 @@ test('manager notifiers', async t => {
   totalProceedsReceived += 53n;
   await m.assertChange({
     numLiquidationsCompleted: 4,
-    numVaults: 0,
+    numActiveVaults: 0,
     totalCollateral: { value: 0n },
     totalDebt: { value: 0n },
     totalProceedsReceived: { value: totalProceedsReceived },
@@ -2764,7 +2764,7 @@ test('manager notifiers', async t => {
   );
   ({ vault } = await E(vaultSeat).getOfferResult());
   await m.assertChange({
-    numVaults: 1,
+    numActiveVaults: 1,
     totalCollateral: { value: AMPLE },
     totalDebt: { value: DEBT1 },
   });
@@ -2787,7 +2787,7 @@ test('manager notifiers', async t => {
   );
   ({ vault } = await E(vaultSeat).getOfferResult());
   await m.assertChange({
-    numVaults: 2,
+    numActiveVaults: 2,
     totalCollateral: { value: AMPLE + ENOUGH },
     totalDebt: { value: DEBT1 + interestAccrued + DEBT2 },
   });
@@ -2801,8 +2801,8 @@ test('manager notifiers', async t => {
   totalProceedsReceived += nextProceeds;
   await m.assertChange({
     numLiquidationsCompleted: 5,
-    numVaults: 0,
-    liquidatingVaults: 1,
+    numActiveVaults: 0,
+    numLiquidatingVaults: 1,
     totalCollateral: { value: AMPLE },
     totalDebt: { value: DEBT1 + DEBT2 + interestAccrued - nextProceeds },
     totalProceedsReceived: { value: totalProceedsReceived },
@@ -2811,7 +2811,7 @@ test('manager notifiers', async t => {
   totalProceedsReceived += nextProceeds;
   await m.assertChange({
     numLiquidationsCompleted: 6,
-    liquidatingVaults: 0,
+    numLiquidatingVaults: 0,
     totalCollateral: { value: 0n },
     totalDebt: { value: 0n },
     totalProceedsReceived: { value: totalProceedsReceived },
@@ -2836,7 +2836,7 @@ test('manager notifiers', async t => {
   ({ vault } = await E(vaultSeat).getOfferResult());
   m.addDebt(DEBT1);
   await m.assertChange({
-    numVaults: 1,
+    numActiveVaults: 1,
     totalCollateral: { value: AMPLE },
     totalDebt: { value: DEBT1 },
   });
@@ -2877,7 +2877,7 @@ test('manager notifiers', async t => {
   );
   await E(vaultSeat).getOfferResult();
   await m.assertChange({
-    numVaults: 0,
+    numActiveVaults: 0,
     totalCollateral: { value: 0n },
     totalDebt: { value: 0n },
   });


### PR DESCRIPTION
closes: #5691 

## Description

Move vaults to a new SetStore upon entering liquidation.  The goal is to not leave them in orderedVaultStore if they get stuck, and to be able to find them again (via upgrade) if repair is necessary.

### Security Considerations

The goal is to make liquidation more robust. Without this fix, it seems possible for a failure in liquidation to leave a vault at the head of the queue and unable to make progress. This change moves it out of the head of the queue, so a failure to liquidate won't block the queue.

### Documentation Considerations

None

### Testing Considerations

I couldn't find  a cost effective way to simulate a failure in liquidation. so the recovery path is untested.
