### PR TITLE
feat(liquidation): If liquidation results in a shortfall, don't refund excess

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -74,7 +74,7 @@ const liquidate = async (
       ];
 
   const toBurn = AmountMath.min(proceeds.Minted, debt);
-  // debt is fully settled, with toBurn and shortfall
+  // debt is fully accounted for, with toBurn and shortfall
   assert(AmountMath.isEqual(debt, AmountMath.add(toBurn, shortfall)));
 
   // Manager accounting changes determined. Update the vault state.

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -61,6 +61,8 @@ const trace = makeTracer('VM');
  * @property {number}         numLiquidatingVaults  present count of liquidating vaults
  * @property {Amount<'nat'>}  totalCollateral    present sum of collateral across all vaults
  * @property {Amount<'nat'>}  totalDebt          present sum of debt across all vaults
+ * @property {Amount<'nat'>}  totalCollateralHeld collateral held as a result of not returning excess refunds
+ *                                                from AMM to owners of vaults liquidated with shortfalls
  *
  * @property {Amount<'nat'>}  totalCollateralSold       running sum of collateral sold in liquidation // totalCollateralSold
  * @property {Amount<'nat'>}  totalOverageReceived      running sum of overages, central received greater than debt
@@ -94,6 +96,7 @@ const trace = makeTracer('VM');
  * debtBrand: Brand<'nat'>,
  * debtMint: ZCFMint<'nat'>,
  * poolIncrementSeat: ZCFSeat,
+ * collateralHeldSeat: ZCFSeat,
  * unsettledVaults: MapStore<string, Vault>,
  * liquidatingVaults: SetStore<Vault>,
  * }>} ImmutableState
@@ -221,6 +224,7 @@ const initState = (
     debtBrand,
     debtMint,
     poolIncrementSeat: zcf.makeEmptySeatKit().zcfSeat,
+    collateralHeldSeat: zcf.makeEmptySeatKit().zcfSeat,
     unsettledVaults,
     liquidatingVaults,
   };
@@ -368,12 +372,16 @@ const helperBehavior = {
     );
     assert(metricsPublication && prioritizedVaults);
 
+    const totalCollateralHeld =
+      state.collateralHeldSeat.getCurrentAllocation()?.Collateral ??
+      AmountMath.makeEmpty(state.collateralBrand, 'nat');
     /** @type {MetricsNotification} */
     const payload = harden({
       numActiveVaults: prioritizedVaults.getCount(),
       numLiquidatingVaults: state.liquidatingVaults.getSize(),
       totalCollateral: state.totalCollateral,
       totalDebt: state.totalDebt,
+      totalCollateralHeld,
 
       numLiquidationsCompleted: state.numLiquidationsCompleted,
       totalCollateralSold: state.totalCollateralSold,
@@ -533,6 +541,26 @@ const helperBehavior = {
         facets.manager.burnAndRecord(accounting.toBurn, vaultSeat);
 
         // current values
+
+        // Sometimes, the AMM will sell less than all the collateral. If there
+        // was a shortfall, the investor doesn't keep the change, so we get it
+        const collateralPost = vault.getCollateralAmount();
+        if (!AmountMath.isEmpty(collateralPost)) {
+          if (!AmountMath.isEmpty(accounting.shortfall)) {
+            // XXX The borrower doesn't get any excess collateal remaining when
+            // liquidation results in a shortfall. We currently do nothing with
+            // it. We could hold it until it crosses some threshold, then sell
+            // it to the AMM, or we could transfer it to the reserve. At least
+            // it's visible in the accounting.
+            vaultSeat.decrementBy(
+              state.collateralHeldSeat.incrementBy({
+                Collateral: collateralPost,
+              }),
+            );
+            zcf.reallocate(vaultSeat, state.collateralHeldSeat);
+          }
+        }
+
         state.totalCollateral = AmountMath.subtract(
           state.totalCollateral,
           collateralPre,

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2597,7 +2597,7 @@ test('manager notifiers', async t => {
     numLiquidatingVaults: 0,
     totalCollateral: aeth.make(0n),
     totalDebt: run.make(0n),
-    totalCollateralHeld: aeth.make(0n),
+    retainedCollateral: aeth.make(0n),
 
     // running
     numLiquidationsCompleted: 0,
@@ -2811,7 +2811,7 @@ test('manager notifiers', async t => {
     numLiquidationsCompleted: 6,
     numLiquidatingVaults: 0,
     totalCollateral: { value: 0n },
-    totalCollateralHeld: { value: 5685n },
+    retainedCollateral: { value: 5685n },
     totalDebt: { value: 0n },
     totalProceedsReceived: { value: totalProceedsReceived },
     totalShortfallReceived: {

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -818,7 +818,7 @@ test('price falls precipitously', async t => {
   t.deepEqual(
     await E(vault).getCollateralAmount(),
     aeth.makeEmpty(),
-    'Excess collateral not  returned due to shortfall',
+    'Excess collateral not returned due to shortfall',
   );
 
   const finalNotification = await E(vaultNotifier).getUpdateSince();


### PR DESCRIPTION
closes: #5558

## Description

If liquidation results in a shortfall, don't refund the excess. The Vaults hold onto the excess collateral. There's currently no code to dispose of it.

When the value crosses some threshold, we could sell it to the AMM or
transfer it to the Reserve

### Security Considerations

None.

### Documentation Considerations

This is probably what people expect, so no additions. This does add to the accounting records, if that's written up anywhere.

### Testing Considerations

update some tests.