### PR TITLE
chore(swingset): Replace ioutil.ReadFile with os.ReadFile

### DIFF
--- a/.github/actions/restore-golang/action.yml
+++ b/.github/actions/restore-golang/action.yml
@@ -16,7 +16,7 @@ runs:
       with:
         clean: 'false'
         submodules: 'true'
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.go-version }}
     - uses: kenchan0130/actions-system-info@master

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,29 +14,16 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
       - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/setup-go@v3
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          go-version: '>=1.17'
+          check-latest: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # golangci-lint version and command line arguments
           version: latest
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
           args: --timeout=3m
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the all caching functionality will be complete disabled,
-          #           takes precedence over all other caching options.
-          # skip-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
+          # for pull requests, show only new issues
+          only-new-issues: true

--- a/golang/cosmos/x/swingset/client/cli/tx.go
+++ b/golang/cosmos/x/swingset/client/cli/tx.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -63,7 +63,7 @@ func GetCmdDeliver() *cobra.Command {
 						return err
 					}
 				} else {
-					jsonBytes, err := ioutil.ReadFile(fname)
+					jsonBytes, err := os.ReadFile(fname)
 					if err != nil {
 						return err
 					}
@@ -109,7 +109,7 @@ func GetCmdInstallBundle() *cobra.Command {
 						return err
 					}
 				} else {
-					jsonBytes, err := ioutil.ReadFile(fname)
+					jsonBytes, err := os.ReadFile(fname)
 					if err != nil {
 						return err
 					}
@@ -234,13 +234,13 @@ Specify at least one pair of permit.json and code.js files`,
 			evals := make([]types.CoreEval, 0, npairs)
 			for j := 0; j < npairs; j++ {
 				permitFile := args[j*2]
-				permit, err := ioutil.ReadFile(permitFile)
+				permit, err := os.ReadFile(permitFile)
 				if err != nil {
 					return errors.Wrapf(err, "failed to read permit %s", permitFile)
 				}
 
 				codeFile := args[j*2+1]
-				code, err := ioutil.ReadFile(codeFile)
+				code, err := os.ReadFile(codeFile)
 				if err != nil {
 					return errors.Wrapf(err, "failed to read code %s", codeFile)
 				}


### PR DESCRIPTION
Fixes #5920

## Description

`ioutil.ReadFile` has been deprecated in favor of `os.ReadFile` since Go 1.16:
https://pkg.go.dev/io/ioutil@go1.19#ReadFile

### Security Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

CI with the pre-PR version of golangci-lint.yml selected go1.17.13 and then go1.19 and passed, establishing that the proximate issues have been addressed.
CI with the new versions of Go-related GitHub actions should pass as well.