### PR TITLE
fix: remove uses of __allowUnsafeMonkeyPatching__

### DIFF
--- a/packages/wallet/ui/src/lockdown.js
+++ b/packages/wallet/ui/src/lockdown.js
@@ -12,7 +12,6 @@ Math.pow = (base, exp) =>
     : mathPow(base, exp);
 
 lockdown({
-  __allowUnsafeMonkeyPatching__: 'unsafe',
   errorTaming: 'unsafe',
   overrideTaming: 'severe',
   consoleTaming,

--- a/packages/web-components/demo/install-ses-lockdown.js
+++ b/packages/web-components/demo/install-ses-lockdown.js
@@ -2,7 +2,6 @@
 import '@endo/init/pre-remoting.js';
 
 lockdown({
-  __allowUnsafeMonkeyPatching__: 'unsafe',
   errorTaming: 'unsafe',
   stackFiltering: 'verbose',
   overrideTaming: 'severe',


### PR DESCRIPTION
The `__allowUnsafeMonkeyPatching__` option, as the name indicates, is an unsafe temporary hack that we did to work around what we had hoped was a temporary problem. To see if the underlying problem went away, this PR removes those vestigial uses to see what breaks.

When tried under CI, the only thing that broke is golangci-lint 
https://github.com/Agoric/agoric-sdk/runs/7754082612?check_suite_focus=true
which seems unlikely to be related. Reviewers, what else needs to be tested to see if this PR actually breaks anything?

It would be a big relief to remove uses of this unsafe hacky option.