### PR TITLE
5868 casting client coordinator for cache

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -20,13 +20,14 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agoric/store": "^0.7.2",
+    "@agoric/vat-data": "^0.3.1",
+    "@agoric/vats": "^0.10.0",
     "@endo/far": "^0.2.5",
     "@endo/marshal": "^0.6.9"
   },
   "devDependencies": {
     "ava": "^4.3.1",
     "c8": "^7.7.2",
-    "@agoric/vat-data": "^0.3.1",
     "@agoric/zoe": "^0.24.0"
   },
   "publishConfig": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -19,6 +19,7 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
+    "@agoric/casting": "^0.1.0",
     "@agoric/store": "^0.7.2",
     "@agoric/vat-data": "^0.3.1",
     "@agoric/vats": "^0.10.0",

--- a/packages/cache/src/state.js
+++ b/packages/cache/src/state.js
@@ -22,3 +22,19 @@ export const makeState = (value, priorState = GROUND_STATE) =>
     generation: priorState.generation + 1n,
     value,
   });
+
+/**
+ * Wrap a state store to have a default value using the GROUND_STATE
+ *
+ * @param {MapStore<string, import('./types').State>} stateStore
+ */
+export const withGroundState = stateStore => ({
+  ...stateStore,
+  get: key => {
+    if (!stateStore.has(key)) {
+      return GROUND_STATE;
+    }
+    return stateStore.get(key);
+  },
+});
+harden(withGroundState);

--- a/packages/cache/src/store.js
+++ b/packages/cache/src/store.js
@@ -5,7 +5,7 @@ import { matches, makeScalarMapStore } from '@agoric/store';
 
 import '@agoric/store/exported.js';
 
-import { GROUND_STATE, makeState } from './state.js';
+import { withGroundState, makeState } from './state.js';
 
 /**
  * @param {(obj: unknown) => unknown} [sanitize]
@@ -34,99 +34,140 @@ const makeKeyToString = (sanitize = obj => obj) => {
 };
 
 /**
+ * @param {string} keyStr
+ * @param {(oldValue: unknown) => unknown} txn
+ * @param {Pattern} guardPattern
+ * @param {(obj: unknown) => unknown} sanitize Process keys and values with
+ * this function before storing them
+ * @param {{
+ * get(key: string): import('./types').State;
+ * set(key: string, value: import('./types').State): void;
+ * init(key: string, value: import('./types').State): void;
+ * }} stateStore
+ * @returns {Promise<unknown>} the value of the updated state
+ */
+const applyCacheTransaction = async (
+  keyStr,
+  txn,
+  guardPattern,
+  sanitize,
+  stateStore,
+) => {
+  /**
+   * Retrieve a potential updated state from the transaction.
+   *
+   * @param {import('./types').State} basisState
+   * @returns {Promise<import('./types').State | null>} the updated state, or null if no longer applicable
+   */
+  const getUpdatedState = async basisState => {
+    const { value } = basisState;
+    if (!matches(value, guardPattern)) {
+      // value doesn't match, so don't apply the update.
+      return null;
+    }
+
+    const newValue = await sanitize(txn(value));
+    return makeState(newValue, basisState);
+  };
+
+  let basisState = stateStore.get(keyStr);
+  let updatedState = await getUpdatedState(basisState);
+
+  // AWAIT INTERLEAVING
+
+  // Loop until our updated state is fresh wrt our current state.
+  basisState = stateStore.get(keyStr);
+  while (updatedState && updatedState.generation <= basisState.generation) {
+    // eslint-disable-next-line no-await-in-loop
+    updatedState = await getUpdatedState(basisState);
+    // AWAIT INTERLEAVING
+    basisState = stateStore.get(keyStr);
+  }
+
+  if (!updatedState) {
+    // The latest store value doesn't match the guard pattern, so don't
+    // update.
+    return basisState.value;
+  }
+
+  // The guard pattern passes and the updated state is fresh, so update the
+  // store.
+  if (basisState.generation < 1n) {
+    // XXX can encapsulate this logic in the caller and eliminate `init()`
+    stateStore.init(keyStr, updatedState);
+  } else {
+    stateStore.set(keyStr, updatedState);
+  }
+
+  // Return the newly-applied value.
+  return updatedState.value;
+};
+
+/**
  * Make a cache coordinator backed by a MapStore.  This coordinator doesn't
  * currently enforce any cache eviction, but that would be a useful feature.
  *
  * @param {MapStore<string, import('./types').State>} [stateStore]
  * @param {(obj: unknown) => unknown} [sanitize] Process keys and values with
- * this function before storing them
+ * this function before storing them. Defaults to deeplyFulfilled.
  */
 export const makeScalarStoreCoordinator = (
   stateStore = makeScalarMapStore(),
   sanitize = deeplyFulfilled,
 ) => {
-  const keyToString = makeKeyToString(sanitize);
+  const serializePassable = makeKeyToString(sanitize);
 
-  const getCurrentState = keyStr => {
-    if (!stateStore.has(keyStr)) {
-      return GROUND_STATE;
-    }
-    return stateStore.get(keyStr);
-  };
-
-  /**
-   * @param {string} keyStr
-   * @param {(oldValue: unknown) => unknown} txn
-   * @param {Pattern} guardPattern
-   * @returns {Promise<unknown>} the updated state
-   */
-  const applyCacheTransaction = async (keyStr, txn, guardPattern) => {
-    /**
-     * Retrieve a potential updated state from the transaction.
-     *
-     * @param {import('./types').State} basisState
-     * @returns {Promise<import('./types').State | null>} the updated state, or null if no longer applicable
-     */
-    const getUpdatedState = async basisState => {
-      const { value } = basisState;
-      if (!matches(value, guardPattern)) {
-        // value doesn't match, so don't apply the update.
-        return null;
-      }
-
-      const newValue = await sanitize(txn(value));
-      return makeState(newValue, basisState);
-    };
-
-    let basisState = getCurrentState(keyStr);
-    let updatedState = await getUpdatedState(basisState);
-
-    // AWAIT INTERLEAVING
-
-    // Loop until our updated state is fresh wrt our current state.
-    basisState = getCurrentState(keyStr);
-    while (updatedState && updatedState.generation <= basisState.generation) {
-      // eslint-disable-next-line no-await-in-loop
-      updatedState = await getUpdatedState(basisState);
-      // AWAIT INTERLEAVING
-      basisState = getCurrentState(keyStr);
-    }
-
-    if (!updatedState) {
-      // The latest store value doesn't match the guard pattern, so don't
-      // update.
-      return basisState.value;
-    }
-
-    // The guard pattern passes and the updated state is fresh, so update the
-    // store.
-    if (basisState.generation < 1n) {
-      stateStore.init(keyStr, updatedState);
-    } else {
-      stateStore.set(keyStr, updatedState);
-    }
-
-    // Return the newly-applied value.
-    return updatedState.value;
-  };
+  const defaultStateStore = withGroundState(stateStore);
 
   /** @type {import('./types').Coordinator} */
   const coord = Far('store cache coordinator', {
     getRecentValue: async key => {
-      const keyStr = await keyToString(key);
-      return getCurrentState(keyStr).value;
+      const keyStr = await serializePassable(key);
+      return defaultStateStore.get(keyStr).value;
     },
     setCacheValue: async (key, newValue, guardPattern) => {
-      const keyStr = await keyToString(key);
-      return applyCacheTransaction(keyStr, () => newValue, guardPattern);
+      const keyStr = await serializePassable(key);
+      return applyCacheTransaction(
+        keyStr,
+        () => newValue,
+        guardPattern,
+        sanitize,
+        defaultStateStore,
+      );
     },
     updateCacheValue: async (key, updater, guardPattern) => {
-      const keyStr = await keyToString(key);
+      const keyStr = await serializePassable(key);
       return applyCacheTransaction(
         keyStr,
         oldValue => E(updater).update(oldValue),
         guardPattern,
+        sanitize,
+        defaultStateStore,
       );
+    },
+  });
+  return coord;
+};
+
+// TODO make this like the MapStore wrapper but handle async b/c
+/**
+ * Make a cache coordinator backed by a MapStore.  This coordinator doesn't
+ * currently enforce any cache eviction, but that would be a useful feature.
+ *
+ * @param {MapStore<string, import('./types').State>} [stateStore]
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
+ */
+/*
+export const makeChainStorageCoordinator = (
+  stateStore = makeScalarMapStore(),
+  storageNode,
+  marshaller,
+) => {};
+*/
+        defaultStateStore,
+      );
+      return updateStorageNode(storedValue);
     },
   });
   return coord;

--- a/packages/cache/test/test-cache-casting.js
+++ b/packages/cache/test/test-cache-casting.js
@@ -1,0 +1,62 @@
+// @ts-nocheck
+// eslint-disable-next-line import/order
+import { test } from '@agoric/casting/test/prepare-test-env-ava.js';
+
+import { delay, makeLeader, makeCastingSpec } from '@agoric/casting';
+import { startFakeServer } from '@agoric/casting/test/fake-rpc-server.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { makeFakeMarshaller } from '@agoric/notifier/tools/testSupports.js';
+import { E } from '@endo/far';
+import { makeCastingClientCoordinator } from '../src/store.js';
+
+// eslint-disable-next-line import/no-extraneous-dependencies -- XXX
+import { makeCache } from '../src/cache.js';
+
+test.before(t => {
+  t.context.cleanups = [];
+  t.context.startServer = startFakeServer;
+});
+
+test.after(t => {
+  // Populated by fake-rpc-server
+  t.context.cleanups.map(cleanup => cleanup());
+});
+
+test('cache read', async t => {
+  const initialCache = { price: 1n };
+  const marshaller = makeFakeMarshaller();
+  const PORT = await t.context.startServer(
+    t,
+    [initialCache, initialCache],
+    marshaller,
+  );
+
+  // The rest of this test is taken almost verbatim from the README.md, with
+  // some minor modifications (testLeaderOptions and deepEqual).
+  const leader = await makeLeader(`http://localhost:${PORT}/network-config`, {
+    retryCallback: null, // fail fast, no retries
+    keepPolling: () =>
+      delay(200).then(() => {
+        console.log('keepPolling cb');
+        return true;
+      }), // poll really quickly
+    jitter: null, // no jitter
+  });
+
+  const castingSpec = makeCastingSpec(':mailbox.agoric1foobarbaz');
+  const coordinator = makeCastingClientCoordinator(
+    leader,
+    castingSpec,
+    {
+      proof: 'none',
+      unserializer: marshaller,
+    },
+    t.log,
+  );
+  const cache = await makeCache(coordinator);
+
+  t.is(await cache('absent'), undefined);
+  t.is(await cache('price'), initialCache.price);
+  t.is(await cache('price'), initialCache.price);
+  // TODO update cache state
+});

--- a/packages/cache/test/test-storage.js
+++ b/packages/cache/test/test-storage.js
@@ -1,0 +1,175 @@
+// @ts-check
+// Must be first to set up globals
+// import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+// eslint-disable-next-line import/no-extraneous-dependencies -- XXX
+import '@agoric/swingset-vat/tools/prepare-test-env.js';
+
+import test from 'ava';
+import { makeChainStorageRoot } from '@agoric/vats/src/lib-chainStorage.js';
+
+// eslint-disable-next-line import/no-extraneous-dependencies -- XXX
+import { makeFakeMarshaller } from '@agoric/notifier/tools/testSupports.js';
+import { Far } from '@endo/marshal';
+import { M } from '@agoric/store';
+import { makeCache } from '../src/cache.js';
+import { makeChainStorageCoordinator } from '../src/store.js';
+
+const setup = () => {
+  const storageNodeState = {};
+  const chainStorage = makeChainStorageRoot(
+    message => {
+      assert(message.key === 'cache');
+      assert(message.method === 'set');
+      storageNodeState.cache = message.value;
+    },
+    'swingset',
+    'cache',
+  );
+  const cache = makeCache(
+    makeChainStorageCoordinator(chainStorage, makeFakeMarshaller()),
+  );
+  return { cache, storageNodeState };
+};
+
+test('makeChainStorageCoordinator with non-remote values', async t => {
+  const { cache, storageNodeState } = setup();
+
+  t.is(await cache('brandName', 'barbosa'), 'barbosa');
+  t.deepEqual(Object.keys(storageNodeState), ['cache']);
+  t.deepEqual(JSON.parse(storageNodeState.cache), {
+    '{"body":"\\"brandName\\"","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"1"},"value":"barbosa"}',
+      slots: [],
+    },
+  });
+
+  // One-time initialization (of 'frotz')
+  t.is(await cache('frotz', 'default'), 'default');
+  const afterFirstFrotz = {
+    '{"body":"\\"brandName\\"","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"1"},"value":"barbosa"}',
+      slots: [],
+    },
+    '{"body":"\\"frotz\\"","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"1"},"value":"default"}',
+      slots: [],
+    },
+  };
+  t.deepEqual(JSON.parse(storageNodeState.cache), afterFirstFrotz);
+  // no change
+  t.is(await cache('frotz', 'ignored'), 'default');
+  t.deepEqual(JSON.parse(storageNodeState.cache), afterFirstFrotz);
+
+  // cache more complex Passable
+  const complexPassable = {
+    str: 'string',
+    big: 1n,
+    num: 53,
+    arr: ['hi', 'there'],
+  };
+  t.deepEqual(
+    await cache(['complex', 'passable'], complexPassable),
+    complexPassable,
+  );
+  t.deepEqual(JSON.parse(storageNodeState.cache), {
+    ...afterFirstFrotz,
+    '{"body":"[\\"complex\\",\\"passable\\"]","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"1"},"value":{"arr":["hi","there"],"big":{"@qclass":"bigint","digits":"1"},"num":53,"str":"string"}}',
+      slots: [],
+    },
+  });
+});
+
+test('makeChainStorageCoordinator with remote values', async t => {
+  const { cache, storageNodeState } = setup();
+
+  const farThing = Far('farThing', { getAllegedName: () => 'dollaz' });
+
+  t.is(await cache('brand', farThing), farThing);
+  t.deepEqual(Object.keys(storageNodeState), ['cache']);
+  t.deepEqual(JSON.parse(storageNodeState.cache), {
+    '{"body":"\\"brand\\"","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"1"},"value":{"@qclass":"slot","iface":"Alleged: farThing","index":0}}',
+      slots: [1],
+    },
+  });
+});
+
+test('makeChainStorageCoordinator with updater', async t => {
+  const { cache, storageNodeState } = setup();
+
+  const increment = (counter = 0) => Promise.resolve(counter + 1);
+
+  // Initial
+  t.is(await cache('counter', increment), 1);
+  t.deepEqual(Object.keys(storageNodeState), ['cache']);
+  t.deepEqual(JSON.parse(storageNodeState.cache), {
+    '{"body":"\\"counter\\"","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"1"},"value":1}',
+      slots: [],
+    },
+  });
+
+  // Again without a pattern
+  t.is(await cache('counter', increment), 1);
+  t.deepEqual(Object.keys(storageNodeState), ['cache']);
+  t.deepEqual(JSON.parse(storageNodeState.cache), {
+    '{"body":"\\"counter\\"","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"1"},"value":1}',
+      slots: [],
+    },
+  });
+
+  // Again with a matching pattern
+  t.is(await cache('counter', increment, M.any()), 2);
+  t.deepEqual(Object.keys(storageNodeState), ['cache']);
+  t.deepEqual(JSON.parse(storageNodeState.cache), {
+    '{"body":"\\"counter\\"","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"2"},"value":2}',
+      slots: [],
+    },
+  });
+});
+
+test('makeChainStorageCoordinator with remote updater', async t => {
+  const { cache, storageNodeState } = setup();
+
+  let counter = 0;
+  const counterObj = Far('counterObj', {
+    increment: () => {
+      return (counter += 1);
+    },
+  });
+
+  // Initial
+  t.is(await cache('counter', counterObj.increment), 1);
+  t.deepEqual(Object.keys(storageNodeState), ['cache']);
+  t.deepEqual(JSON.parse(storageNodeState.cache), {
+    '{"body":"\\"counter\\"","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"1"},"value":1}',
+      slots: [],
+    },
+  });
+
+  // Again without a pattern, doesn't increment
+  t.is(await cache('counter', counterObj.increment), 1);
+  t.is(counter, 1);
+  t.deepEqual(Object.keys(storageNodeState), ['cache']);
+  t.deepEqual(JSON.parse(storageNodeState.cache), {
+    '{"body":"\\"counter\\"","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"1"},"value":1}',
+      slots: [],
+    },
+  });
+
+  // Again with a matching pattern
+  t.is(await cache('counter', counterObj.increment, M.any()), 2);
+  t.is(counter, 2);
+  t.deepEqual(Object.keys(storageNodeState), ['cache']);
+  t.deepEqual(JSON.parse(storageNodeState.cache), {
+    '{"body":"\\"counter\\"","slots":[]}': {
+      body: '{"generation":{"@qclass":"bigint","digits":"2"},"value":2}',
+      slots: [],
+    },
+  });
+});

--- a/packages/casting/src/casting-spec.js
+++ b/packages/casting/src/casting-spec.js
@@ -101,7 +101,9 @@ export const makeCastingSpecFromRef = async specCap => {
 };
 
 /**
- * @param {ERef<any>} sourceP
+ * Create an abstract type from a given source representation
+ *
+ * @param {ERef<unknown>} sourceP
  * @returns {Promise<import('./types').CastingSpec>}
  */
 export const makeCastingSpec = async sourceP => {

--- a/packages/casting/src/casting-spec.js
+++ b/packages/casting/src/casting-spec.js
@@ -118,3 +118,4 @@ export const makeCastingSpec = async sourceP => {
   }
   assert.fail(`CastingSpec ${spec} is not a string, object, or ref`);
 };
+/** @typedef {ReturnType<typeof makeCastingSpec>} CastingSpec */

--- a/packages/casting/src/leader-netconfig.js
+++ b/packages/casting/src/leader-netconfig.js
@@ -75,3 +75,4 @@ export const makeLeader = (bootstrap = DEFAULT_BOOTSTRAP, options) => {
   }
   return makeLeaderFromRpcAddresses([bootstrap], options);
 };
+/** @typedef {ReturnType<typeof makeLeader>} Leader */

--- a/packages/notifier/tools/testSupports.js
+++ b/packages/notifier/tools/testSupports.js
@@ -40,8 +40,17 @@ export const makeFakeStorage = (path, publication) => {
 };
 harden(makeFakeStorage);
 
-export const makeFakeMarshaller = () =>
-  makeMarshal(undefined, undefined, {
-    marshalSaveError: () => {},
+export const makeFakeMarshaller = () => {
+  const vals = [];
+  const fromVal = val => {
+    vals.push(val);
+    return vals.length;
+  };
+  const toVal = slot => vals[slot];
+  return makeMarshal(fromVal, toVal, {
+    marshalSaveError: err => {
+      throw err;
+    },
   });
+};
 harden(makeFakeMarshaller);

--- a/packages/vats/src/vat-chainStorage.js
+++ b/packages/vats/src/vat-chainStorage.js
@@ -1,7 +1,13 @@
+// @ts-check
 import { E, Far } from '@endo/far';
 import { makeChainStorageRoot } from './lib-chainStorage.js';
 
 export function buildRootObject(_vatPowers) {
+  /**
+   * @param {ERef<BridgeManager>} bridgeManager
+   * @param {string} bridgeId
+   * @param {string} rootPath must be unique (caller responsibility to ensure)
+   */
   function makeBridgedChainStorageRoot(bridgeManager, bridgeId, rootPath) {
     // Note that the uniqueness of rootPath is not validated here,
     // and is instead the responsibility of callers.

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -12,7 +12,7 @@
  */
 
 import { assert, details as X, q } from '@agoric/assert';
-import { makeScalarStoreCoordinator } from '@agoric/cache';
+import { makeScalarStoreCoordinator, withChainStorage } from '@agoric/cache';
 import { makeLegacyMap, makeScalarMap, makeScalarWeakMap } from '@agoric/store';
 import { makeScalarBigMapStore, objectMap } from '@agoric/vat-data';
 import { AmountMath } from '@agoric/ertp';
@@ -55,20 +55,22 @@ const cmp = (a, b) => {
 };
 
 /**
- * @typedef {object} MakeWalletParams
- * @property {ERef<ZoeService>} zoe
- * @property {ERef<Board>} board
- * @property {ERef<NameHub>} [agoricNames]
- * @property {ERef<NameHub>} [namesByAddress]
- * @property {ERef<MyAddressNameAdmin>} myAddressNameAdmin
- * @property {(state: any) => void} [pursesStateChangeHandler=noActionStateChangeHandler]
- * @property {(state: any) => void} [inboxStateChangeHandler=noActionStateChangeHandler]
- * @property {() => number} [dateNow]
- * @param {MakeWalletParams} param0
+ * @param {{
+ * agoricNames?: ERef<NameHub>
+ * board: ERef<Board>
+ * cacheStorageNode: ERef<StorageNode>,
+ * dateNow?: () => number,
+ * inboxStateChangeHandler?: (state: any) => void,
+ * myAddressNameAdmin: ERef<MyAddressNameAdmin>
+ * namesByAddress?: ERef<NameHub>
+ * pursesStateChangeHandler?: (state: any) => void,
+ * zoe: ERef<ZoeService>,
+ * }} opt
  */
 export function makeWalletRoot({
   zoe,
   board,
+  cacheStorageNode,
   agoricNames,
   namesByAddress,
   myAddressNameAdmin,
@@ -1058,8 +1060,9 @@ export function makeWalletRoot({
     dappsUpdater.updateState([...dappOrigins.values()]);
   };
 
-  const sharedCacheCoordinator = makeScalarStoreCoordinator(
-    makeScalarBigMapStore(`shared cache`),
+  const sharedCacheCoordinator = withChainStorage(
+    makeScalarStoreCoordinator(makeScalarBigMapStore(`shared cache`)),
+    cacheStorageNode,
   );
 
   async function waitForDappApproval(

--- a/packages/wallet/api/src/wallet.js
+++ b/packages/wallet/api/src/wallet.js
@@ -23,6 +23,7 @@ import './internal-types.js';
  * @typedef {{
  * agoricNames: ERef<NameHub>,
  * board: ERef<Board>,
+ * cacheStorageNode: ERef<StorageNode>,
  * localTimerPollInterval?: bigint,
  * localTimerService?: TimerService,
  * myAddressNameAdmin: ERef<MyAddressNameAdmin>,
@@ -102,6 +103,7 @@ export function buildRootObject(vatPowers) {
   async function startup({
     zoe,
     board,
+    cacheStorageNode,
     agoricNames,
     namesByAddress,
     myAddressNameAdmin,
@@ -127,6 +129,7 @@ export function buildRootObject(vatPowers) {
     const dateNow = await dateNowP;
     const w = makeWalletRoot({
       agoricNames,
+      cacheStorageNode,
       namesByAddress,
       myAddressNameAdmin,
       zoe,

--- a/packages/wallet/contract/src/singleWallet.js
+++ b/packages/wallet/contract/src/singleWallet.js
@@ -26,7 +26,7 @@ const { assign, entries, keys, fromEntries } = Object;
 /**
  * @param {ZCF<SmartWalletContractTerms>} zcf
  * @param {{
- *   storageNode?: ERef<StorageNode>,
+ *   storageNode: ERef<StorageNode>,
  *   marshaller?: ERef<Marshaller>,
  * }} privateArgs
  */
@@ -37,18 +37,23 @@ export const start = async (zcf, privateArgs) => {
   assert(myAddressNameAdmin, 'missing myAddressNameAdmin');
   assert(namesByAddress, 'missing namesByAddress');
   assert(agoricNames, 'missing agoricNames');
+
   const zoe = zcf.getZoeService();
+
+  const address = await E(myAddressNameAdmin).getMyAddress();
+  const { storageNode, marshaller } = privateArgs;
+  assert(storageNode, 'missing storageNode');
+
+  const cacheStorageNode = E(storageNode).getChildNode('cache');
 
   const wallet = await makeWallet(bank, {
     agoricNames,
+    cacheStorageNode,
     namesByAddress,
     myAddressNameAdmin,
     zoe,
     board,
   });
-
-  const address = await E(myAddressNameAdmin).getMyAddress();
-  const { storageNode, marshaller } = privateArgs;
 
   const myWalletStorageNode =
     storageNode && E(storageNode).getChildNode(address);

--- a/packages/wallet/contract/src/smartWallet.js
+++ b/packages/wallet/contract/src/smartWallet.js
@@ -32,8 +32,11 @@ export const makeSmartWallet = async (
   assert(myAddressNameAdmin, 'missing myAddressNameAdmin');
   assert(storageNode, 'missing storageNode');
 
+  const cacheStorageNode = E(storageNode).getChildNode('cache');
+
   const wallet = await makeWallet(bank, {
     agoricNames,
+    cacheStorageNode,
     namesByAddress,
     // ??? why do we make this instead of passing the address itself?
     myAddressNameAdmin,

--- a/packages/wallet/contract/src/support.js
+++ b/packages/wallet/contract/src/support.js
@@ -8,6 +8,7 @@ import { E } from '@endo/far';
  * @param {{
  * agoricNames: ERef<NameHub>,
  * board: ERef<Board>,
+ * cacheStorageNode: ERef<StorageNode>,
  * myAddressNameAdmin: ERef<MyAddressNameAdmin>,
  * namesByAddress: ERef<NameHub>,
  * zoe: ERef<ZoeService>,


### PR DESCRIPTION
builds on #5871 to
close: #5686 

## Description

Introduce a new CastingClientCoordinator for the cache system that allows a cache to be backed by casting. This allows RPC reads and transaction writes. 

This draft has the reads. Writes will come after https://github.com/agoric/agoric-sdk/issues/5912

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
