### PR TITLE
feat(SwingSet): evictAfterSnapshot option for periodic eviction of all vats

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -86,6 +86,18 @@ end-of-block processing for `ag-chain-cosmos` and the sim-chain.
 
 Lifetime: until we have a more consistent load testing regimen
 
+## EVICT_AFTER_SNAPSHOT
+
+Affects: cosmic-swingset
+
+Purpose: work around possible memory leaks in vat workers
+
+Description: if set to non-empty string, vats are evicted
+after each snapshot, causing them to be restarted with a
+fresh process memory allocation.
+
+Lifetime: for the life of performance issues such as https://github.com/Agoric/agoric-sdk/issues/5910
+
 ## FAKE_CURRENCIES
 
 Affects: cosmic-swingset

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -315,6 +315,8 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
       return false;
     }
     await vatKeeper.saveSnapshot(manager);
+    console.warn('EXPERIMENTAL: periodic eviction', lastVatID);
+    await evict(lastVatID);
     lastVatID = undefined;
     return true;
   }

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -113,6 +113,7 @@ async function buildSwingset(
       slogCallbacks,
       slogFile,
       slogSender,
+      warehousePolicy: { evictAfterSnapshot: !!env.EVICT_AFTER_SNAPSHOT },
     },
   );
 


### PR DESCRIPTION
Add a switch in case "turn it off and turn it on again" helps manage vat worker RAM usage.

refs: #5910 

### Documentation Considerations

`$EVICT_AFTER_SNAPSHOT` environment variable is documented.

### Testing Considerations

unit tests updated

passes a smoke test:

```
agoric-sdk/packages/cosmic-swingset$ EVICT_AFTER_SNAPSHOT=1 make scenario2-run-chain
...
2022-08-17T02:15:44.347Z SwingSet: vat: v1: agoricNamesAdmin settled; remaining: []
XS snapshot written to /home/connolly/projects/agoric-sdk/packages/cosmic-swingset/t1/n0/data/ag-cosmos-chain-state/xs-snapshots/ba667a6f910f04ec834edfb9f71b480f94b8f2fad3fe40bd0a27a4292a9d6f5d.gz : 2664962 bytes compressed, 14694111 raw
2022-08-17T02:15:45.181Z SwingSet: kernel: periodic eviction v1
```