### PR TITLE
publication record for AMM liquidityIssuer

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,6 @@
 /* eslint-env node */
 const process = require('process');
+
 const lintTypes = !!process.env.AGORIC_ESLINT_TYPES;
 
 module.exports = {
@@ -30,6 +31,8 @@ module.exports = {
     '@typescript-eslint/no-floating-promises': lintTypes ? 'warn' : 'off',
     // so that floating-promises can be explicitly permitted with void operator
     'no-void': ['error', { allowAsStatement: true }],
+    // Not severe but the default 'warning' clutters output and it's easy to fix
+    'jsdoc/check-param-names': 'error',
     'jsdoc/no-multi-asterisks': 'off',
     'jsdoc/multiline-blocks': 'off',
     // Use these rules to warn about JSDoc type problems, such as after

--- a/packages/cache/src/store.js
+++ b/packages/cache/src/store.js
@@ -168,8 +168,8 @@ export const makeScalarStoreCoordinator = (
  * Don't write any marshalled value that's older than what's already pushed
  *
  * @param {MapStore<string, import('./types').State>} stateStore
- * @param {ERef<StorageNode>} storageNode
  * @param {ERef<Marshaller>} marshaller
+ * @param {ERef<StorageNode>} storageNode
  * @returns {<T>(storedValue: T) => Promise<T>}
  */
 const makeLastWinsUpdater = (stateStore, marshaller, storageNode) => {

--- a/packages/inter-protocol/README.md
+++ b/packages/inter-protocol/README.md
@@ -52,6 +52,7 @@ The canonical keys (under `published`) are as follows. Non-terminal nodes could 
         - `metrics`
         - `governance`
         - `pool0`
+            - `init`
             - `metrics`
     - `psm`
         - `governance`

--- a/packages/inter-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/pool.js
@@ -11,6 +11,7 @@ import {
   calcValueToRemove,
 } from '@agoric/zoe/src/contractSupport/index.js';
 
+import { E } from '@endo/eventual-send';
 import { makeMetricsPublisherKit } from '../contractSupport.js';
 import { makePriceAuthority } from './priceAuthority.js';
 import { makeSinglePool } from './singlePool.js';
@@ -22,6 +23,8 @@ import { makeSinglePool } from './singlePool.js';
 export const publicPrices = prices => {
   return { amountIn: prices.swapperGives, amountOut: prices.swapperGets };
 };
+
+/** @typedef {{ liquidityIssuerRecord: IssuerRecord<'nat'> }} InitPublication */
 
 /** @typedef {{ central: Amount, secondary: Amount }} NotificationState */
 
@@ -87,7 +90,14 @@ export const definePoolKind = (baggage, ammPowers, storageNode, marshaller) => {
    * @returns {ImmutableState & MutableState}
    */
   const poolInit = (liquidityZcfMint, poolSeat, secondaryBrand) => {
-    /** @type {PublishKit<{secondary: Amount, central: Amount}>} */
+    /** @type {StoredPublishKit<InitPublication>} */
+    const { publisher: initPublisher } = makeStoredPublishKit(
+      E(storageNode).getChildNode('init'),
+      marshaller,
+    );
+    initPublisher.finish({
+      liquidityIssuerRecord: liquidityZcfMint.getIssuerRecord(),
+    });
 
     return {
       liqTokenSupply: 0n,

--- a/packages/inter-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/pool.js
@@ -3,14 +3,15 @@
 import '@agoric/zoe/exported.js';
 
 import { AmountMath, isNatValue } from '@agoric/ertp';
-import { makeStoredPublisherKit, makeStoredPublishKit } from '@agoric/notifier';
+import { makeStoredPublishKit } from '@agoric/notifier';
+import { vivifyKindMulti } from '@agoric/vat-data';
 import {
   calcLiqValueToMint,
   calcSecondaryRequired,
   calcValueToRemove,
 } from '@agoric/zoe/src/contractSupport/index.js';
-import { vivifyKindMulti } from '@agoric/vat-data';
 
+import { makeMetricsPublisherKit } from '../contractSupport.js';
 import { makePriceAuthority } from './priceAuthority.js';
 import { makeSinglePool } from './singlePool.js';
 
@@ -21,14 +22,6 @@ import { makeSinglePool } from './singlePool.js';
 export const publicPrices = prices => {
   return { amountIn: prices.swapperGives, amountOut: prices.swapperGets };
 };
-
-/**
- * @typedef {{
- *   centralAmount: Amount,
- *   secondaryAmount: Amount,
- *   liquidityTokens: Amount,
- * }} MetricsPayload
- */
 
 /** @typedef {{ central: Amount, secondary: Amount }} NotificationState */
 
@@ -81,9 +74,11 @@ export const definePoolKind = (baggage, ammPowers, storageNode, marshaller) => {
     storageNode,
     marshaller,
   );
-  /** @type {{publisher: IterationObserver<PoolMetricsNotification>,subscriber: StoredSubscription<PoolMetricsNotification>}} */
-  const { publisher: metricsPublication, subscriber: metricsSubscription } =
-    makeStoredPublisherKit(storageNode, marshaller, 'metrics');
+  /** @type {import('../contractSupport.js').MetricsPublisherKit<PoolMetricsNotification>} */
+  const { metricsPublication, metricsSubscription } = makeMetricsPublisherKit(
+    storageNode,
+    marshaller,
+  );
 
   /**
    * @param {ZCFMint} liquidityZcfMint


### PR DESCRIPTION
unblocks: https://github.com/Agoric/agoric-sdk/issues/5914

## Description

The wallet needs a way to read the liquidityIssuer for an AMM pool without a chain transaction.

This puts it on a new storage node, `init` under each pool's own storage node. `init` is chosen to convey that its set during initialization and that it will never change. (Implemented by `.finish` and not holding the publisher ref)

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

@dckc tested manually: https://github.com/Agoric/agoric-sdk/pull/5935/files#r944704134

This change still needs a CI test. That'll take a new testing ability so I'm working on that independently. 