### PR TITLE
fix(vats): avoid sending large contract bundles to Zoe.install()

### DIFF
--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -125,9 +125,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
     home: { produce: { bank: 'bank' } },
   },
   installBootContracts: {
-    vatPowers: { D: true },
-    devices: { vatAdmin: true },
-    consume: { zoe: 'zoe' },
+    consume: { zoe: 'zoe', vatAdminSvc: true },
     installation: {
       produce: {
         centralSupply: 'zoe',

--- a/packages/vats/test/devices.js
+++ b/packages/vats/test/devices.js
@@ -3,22 +3,27 @@ import bundleMintHolder from '../bundles/bundle-mintHolder.js';
 import bundleSingleWallet from '../bundles/bundle-singleWallet.js';
 import bundleWalletFactory from '../bundles/bundle-walletFactory.js';
 
+const bundles = {
+  centralSupply: bundleCentralSupply,
+  mintHolder: bundleMintHolder,
+  singleWallet: bundleSingleWallet,
+  walletFactory: bundleWalletFactory,
+};
+
 export const devices = {
   vatAdmin: {
+    getBundleCap: id => {
+      assert(id.startsWith('b1-'));
+      const name = id.replace(/^b1-/, '');
+      const bundle = bundles[name];
+      assert(bundle, `unknown bundle ${name}`);
+      return bundle;
+    },
     getNamedBundleCap: name => ({
       getBundle: () => {
-        switch (name) {
-          case 'centralSupply':
-            return bundleCentralSupply;
-          case 'mintHolder':
-            return bundleMintHolder;
-          case 'singleWallet':
-            return bundleSingleWallet;
-          case 'walletFactory':
-            return bundleWalletFactory;
-          default:
-            throw new Error(`unknown bundle ${name}`);
-        }
+        const bundle = bundles[name];
+        assert(bundle, `unknown bundle ${name}`);
+        return bundle;
       },
     }),
   },

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -103,13 +103,16 @@ const testRole = (ROLE, governanceActions) => {
       { argv: argvByRole[ROLE], governanceActions },
     );
 
-    const fakeVatAdmin = makeFakeVatAdmin(() => {}).admin;
+    const { admin: fakeVatAdmin } = makeFakeVatAdmin(() => {});
     const fakeBundleCaps = new Map(); // {} -> name
     const getNamedBundleCap = name => {
       const bundleCap = harden({});
       fakeBundleCaps.set(bundleCap, name);
       return bundleCap;
     };
+    const getBundleIDByName = name => `b1-${name}`;
+    const getBundleCap = id => devices.vatAdmin.getBundleCap(id);
+
     const createVat = (bundleCap, options) => {
       const name = fakeBundleCaps.get(bundleCap);
       assert(name);
@@ -141,7 +144,14 @@ const testRole = (ROLE, governanceActions) => {
       ...mock.vats,
       vatAdmin: /** @type { any } */ ({
         createVatAdminService: () =>
-          Far('vatAdminSvc', { getNamedBundleCap, createVat, createVatByName }),
+          Far('vatAdminSvc', {
+            getNamedBundleCap,
+            createVat,
+            createVatByName,
+            getBundleIDByName,
+            getBundleCap,
+            waitForBundleCap: getBundleCap,
+          }),
       }),
     };
     const actual = await E(root).bootstrap(vats, mock.devices);
@@ -167,6 +177,7 @@ test('evaluateInstallation is available to core eval', async t => {
       },
     };
 
+    // @ts-expect-error mock lacks getBundleIDByName
     const { zoeService } = makeZoeKit(makeFakeVatAdmin(() => {}).admin);
 
     const theBoard = boardRoot().getBoard();

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -177,7 +177,6 @@ test('evaluateInstallation is available to core eval', async t => {
       },
     };
 
-    // @ts-expect-error mock lacks getBundleIDByName
     const { zoeService } = makeZoeKit(makeFakeVatAdmin(() => {}).admin);
 
     const theBoard = boardRoot().getBoard();

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -259,6 +259,7 @@
  * @property {(id: BundleID) => ERef<BundleCap>} waitForBundleCap
  * @property {(id: BundleID) => ERef<BundleCap>} getBundleCap
  * @property {(name: string) => ERef<BundleCap>} getNamedBundleCap
+ * @property {(name: string) => BundleID} getBundleIDByName
  * @property {(bundleCap: BundleCap, options?: Record<string, any>) => ERef<RootAndAdminNode>} createVat
  */
 

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -50,7 +50,9 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // This is explicitly intended to be mutable so that
   // test-only state can be provided from contracts
   // to their tests.
+  /** @type {VatAdminSvc} */
   const admin = Far('vatAdmin', {
+    getBundleIDByName: () => assert.fail('mock. not impl'),
     getBundleCap: bundleID => {
       if (!idToBundleCap.has(bundleID)) {
         idToBundleCap.init(bundleID, bogusBundleCap());


### PR DESCRIPTION
refs: #5910, #4374

## Description

in `installBootContracts`, we were using `getNamedBundleCap` and `getBundle` resulting in a large bundle of source code sent to `E(zoe).install(bundle)`. Now that the infrastructure is available, let's use `getBundleIDByName` and `E(zoe).installBundleID(bundleID)`.

### Security Considerations

contributes to our ability to put a cap on message size

### Documentation Considerations

the type for `VatAdminSvc` was missing a method.

### Testing Considerations

unit tests needed some adjustment.
