### PR TITLE
style(xsnap): excuse test code from no-nested-await

### DIFF
--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -1,5 +1,5 @@
 /* global globalThis */
-/* eslint-disable no-await-in-loop */
+/* eslint-disable no-await-in-loop, @jessie.js/no-nested-await -- test code */
 // @ts-check
 
 /** global print */

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -8,7 +8,7 @@ Usage:
 
 // @ts-check
 
-/* eslint-disable no-await-in-loop */
+/* eslint-disable no-await-in-loop, @jessie.js/no-nested-await -- test code */
 import '@endo/init';
 import { assert, details as X, q } from '@agoric/assert';
 import { xsnap } from './xsnap.js';

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 /* global process */
+/* eslint-disable @jessie.js/no-nested-await -- test/build code */
 // @ts-check
 import * as childProcessTop from 'child_process';
 import fsTop from 'fs';

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -1,5 +1,7 @@
 /* global process */
 // @ts-check
+/* We make exceptions for test code. This is a test utility. */
+/* eslint-disable @jessie.js/no-nested-await */
 /* eslint no-await-in-loop: ["off"] */
 
 import '@endo/init';


### PR DESCRIPTION
Tidy up some of the lint warnings that show up in _every_ PR.