### PR TITLE
refactor StorageNode type

### DIFF
--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -6,7 +6,7 @@ import { AmountMath } from '@agoric/ertp';
 import '@agoric/governance/exported.js';
 import '@agoric/vats/exported.js';
 import '@agoric/vats/src/core/types.js';
-import { makeStorageNode } from '@agoric/vats/src/lib-chainStorage.js';
+import { makeStorageNodeChild } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E, Far } from '@endo/far';
 import { Stable, Stake } from '@agoric/vats/src/tokens.js';
@@ -217,7 +217,10 @@ export const setupAmm = async (
     AmountMath.make(runBrand, minInitialPoolLiquidity),
   );
 
-  const storageNode = await makeStorageNode(chainStorage, AMM_STORAGE_PATH);
+  const storageNode = await makeStorageNodeChild(
+    chainStorage,
+    AMM_STORAGE_PATH,
+  );
   const marshaller = await E(board).getPublishingMarshaller();
 
   const ammGovernorTerms = await deeplyFulfilled(
@@ -313,7 +316,7 @@ export const setupReserve = async ({
     ammInstanceWithoutReserve,
   );
 
-  const storageNode = await makeStorageNode(chainStorage, STORAGE_PATH);
+  const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
   const marshaller = await E(board).getReadonlyMarshaller();
 
   const reserveGovernorTerms = await deeplyFulfilled(
@@ -439,7 +442,7 @@ export const startVaultFactory = async (
 
   const ammPublicFacet = await E(zoe).getPublicFacet(ammInstance);
   const reservePublicFacet = await E(zoe).getPublicFacet(reserveInstance);
-  const storageNode = await makeStorageNode(chainStorage, STORAGE_PATH);
+  const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
   const marshaller = await E(board).getReadonlyMarshaller();
 
   const vaultFactoryTerms = makeGovernedTerms(
@@ -846,7 +849,7 @@ export const startStakeFactory = async (
     },
   );
 
-  const storageNode = await makeStorageNode(chainStorage, STORAGE_PATH);
+  const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
   const marshaller = await E(board).getReadonlyMarshaller();
 
   const stakeTerms = await deeplyFulfilled(

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -120,7 +120,7 @@ export const createPriceFeed = async (
   );
 
   const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
-  const marshaller = await E(board).getReadonlyMarshaller();
+  const marshaller = E(board).getReadonlyMarshaller();
 
   // Create the price feed.
   const aggregator = await E(zoe).startInstance(
@@ -128,7 +128,7 @@ export const createPriceFeed = async (
     undefined,
     terms,
     {
-      storageNode: E(storageNode).getChildNode(
+      storageNode: E(storageNode).makeChildNode(
         sanitizePathSegment(AGORIC_INSTANCE_NAME),
       ),
       marshaller,

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -1,7 +1,7 @@
 import { E } from '@endo/far';
 import { makeIssuerKit } from '@agoric/ertp';
 import {
-  makeStorageNode,
+  makeStorageNodeChild,
   sanitizePathSegment,
 } from '@agoric/vats/src/lib-chainStorage.js';
 import { deeplyFulfilled } from '@endo/marshal';
@@ -119,8 +119,8 @@ export const createPriceFeed = async (
     }),
   );
 
-  const storageNode = await makeStorageNode(chainStorage, STORAGE_PATH);
-  const marshaller = E(board).getReadonlyMarshaller();
+  const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
+  const marshaller = await E(board).getReadonlyMarshaller();
 
   // Create the price feed.
   const aggregator = await E(zoe).startInstance(

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -2,7 +2,7 @@
 
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
-import { makeStorageNode } from '@agoric/vats/src/lib-chainStorage.js';
+import { makeStorageNodeChild } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/far';
 import { Stable } from '@agoric/vats/src/tokens.js';
@@ -104,7 +104,7 @@ export const startPSM = async (
     }),
   );
 
-  const storageNode = await makeStorageNode(chainStorage, 'psm');
+  const storageNode = await makeStorageNodeChild(chainStorage, 'psm');
   const marshaller = await E(board).getPublishingMarshaller();
 
   const governorTerms = await deeplyFulfilled(

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -333,7 +333,7 @@ const machineBehavior = {
 
     const managerStorageNode =
       storageNode &&
-      E(storageNode).getChildNode(`manager${state.managerCounter}`);
+      E(storageNode).makeChildNode(`manager${state.managerCounter}`);
     state.managerCounter += 1;
 
     /** a powerful object; can modify parameters */

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -814,8 +814,8 @@ const selfBehavior = {
     const vaultId = String(state.vaultCounter);
 
     const vaultStorageNode = E(
-      E(storageNode).getChildNode(`vaults`),
-    ).getChildNode(`vault${vaultId}`);
+      E(storageNode).makeChildNode(`vaults`),
+    ).makeChildNode(`vault${vaultId}`);
 
     const vault = makeVault(
       zcf,

--- a/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -320,7 +320,7 @@ const start = async (zcf, privateArgs, baggage) => {
     return zcf.getIssuerForBrand(brand);
   };
   const poolStorageNode = await (privateArgs.storageNode &&
-    E(privateArgs.storageNode).getChildNode(
+    E(privateArgs.storageNode).makeChildNode(
       // NB: the set of pools grows monotonically
       `pool${secondaryBrandToPool.getSize()}`,
     ));

--- a/packages/inter-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/pool.js
@@ -92,7 +92,7 @@ export const definePoolKind = (baggage, ammPowers, storageNode, marshaller) => {
   const poolInit = (liquidityZcfMint, poolSeat, secondaryBrand) => {
     /** @type {StoredPublishKit<InitPublication>} */
     const { publisher: initPublisher } = makeStoredPublishKit(
-      E(storageNode).getChildNode('init'),
+      E(storageNode).makeChildNode('init'),
       marshaller,
     );
     initPublisher.finish({

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -114,7 +114,7 @@ const makeTestContext = async () => {
     privateArgs: harden({
       feeMintAccess: await feeMintAccess,
       initialPoserInvitation,
-      storageNode: makeMockChainStorageRoot().getChildNode('psm'),
+      storageNode: makeMockChainStorageRoot().makeChildNode('psm'),
       marshaller: makeBoard().getReadonlyMarshaller(),
     }),
     run: { issuer: runIssuer, brand: runBrand },

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -174,7 +174,7 @@ export const makeStoredPublisherKit = (storageNode, marshaller, childPath) => {
   const { publication, subscription } = makeSubscriptionKit();
 
   if (storageNode && childPath) {
-    storageNode = E(storageNode).getChildNode(childPath);
+    storageNode = E(storageNode).makeChildNode(childPath);
   }
 
   // wrap the subscription to tee events to storage, repeating to this `subscriber`

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -136,6 +136,7 @@ export const makeStoredSubscription = (
   }
 
   /** @type {StoredSubscription<T>} */
+  // @ts-expect-error getStoreKey invalid, deprecated type
   const storesub = Far('StoredSubscription', {
     getStoreKey: async () => {
       if (!storageNode) {

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -219,6 +219,14 @@
 /** @typedef {Pick<Marshaller, 'unserialize'>} Unserializer */
 
 /**
+ * This represents a node in an IAVL tree.
+ *
+ * The active implementation is x/vstorage, an Agoric extension of the Cosmos SDK.
+ *
+ * Vstorage is a hierarchical externally-reachable storage structure that
+ * identifies children by restricted ASCII name and is associated with arbitrary
+ * string-valued data for each node, defaulting to the empty string.
+ *
  * @typedef {object} StorageNode
  * @property {(data: string) => void} setValue publishes some data
  * @property {() => ERef<Record<string, any>>} getStoreKey get the

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -219,6 +219,15 @@
 /** @typedef {Pick<Marshaller, 'unserialize'>} Unserializer */
 
 /**
+ * Defined by vstorageStoreKey in vstorage.go
+ *
+ * @typedef VStorageKey
+ * @property {string} storeName
+ * @property {string} storeSubkey
+ * @property {string} dataPrefixBytes
+ */
+
+/**
  * This represents a node in an IAVL tree.
  *
  * The active implementation is x/vstorage, an Agoric extension of the Cosmos SDK.
@@ -229,7 +238,7 @@
  *
  * @typedef {object} StorageNode
  * @property {(data: string) => void} setValue publishes some data
- * @property {() => ERef<Record<string, any>>} getStoreKey get the
+ * @property {() => ERef<VStorageKey>} getStoreKey get the
  * externally-reachable store key for this storage item
  * @property {(subPath: string) => StorageNode} makeChildNode
  */

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -194,8 +194,6 @@
  * ```
  * The resulting `localIterable` also supports such remote use, and
  * will return access to the same representation.
- * @property {StorageNode['getStoreKey']} getStoreKey get the
- * externally-reachable store key for this subscription
  */
 
 /**
@@ -250,6 +248,7 @@
  */
 
 /**
+ * @deprecated
  * @template T
  * @typedef {Subscription<T> & StoredFacet} StoredSubscription
  */

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -231,7 +231,7 @@
  * @property {(data: string) => void} setValue publishes some data
  * @property {() => ERef<Record<string, any>>} getStoreKey get the
  * externally-reachable store key for this storage item
- * @property {(subPath: string) => StorageNode} getChildNode TODO: makeChildNode
+ * @property {(subPath: string) => StorageNode} makeChildNode
  */
 
 /**

--- a/packages/notifier/test/test-stored-subscription.js
+++ b/packages/notifier/test/test-stored-subscription.js
@@ -178,6 +178,7 @@ test('StoredPublisher', async t => {
   const { subscriber } = makeStoredPublishKit(storageNode, marshaller);
 
   t.deepEqual(await subscriber.getStoreKey(), {
+    dataPrefixBytes: '',
     storeName: 'swingset',
     storeSubkey: 'swingset/data:publish.publish.foo.bar',
   });

--- a/packages/notifier/tools/testSupports.js
+++ b/packages/notifier/tools/testSupports.js
@@ -33,7 +33,7 @@ export const makeFakeStorage = (path, publication) => {
       }
       publication.updateState(value);
     },
-    getChildNode: () => storage,
+    makeChildNode: () => storage,
     // @ts-expect-error
     countSetValueCalls: () => setValueCalls,
   };

--- a/packages/notifier/tools/testSupports.js
+++ b/packages/notifier/tools/testSupports.js
@@ -20,6 +20,7 @@ export const makeFakeStorage = (path, publication) => {
   const storeKey = harden({
     storeName: 'swingset',
     storeSubkey: `swingset/data:${fullPath}`,
+    dataPrefixBytes: '',
   });
   /** @type {StorageNode} */
   const storage = {

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -7,7 +7,7 @@ import { provide } from '@agoric/store/src/stores/store-utils.js';
 import { E, Far } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';
 
-import { makeStorageNode } from '../lib-chainStorage.js';
+import { makeStorageNodeChild } from '../lib-chainStorage.js';
 import { makeNameHubKit } from '../nameHub.js';
 import { feeIssuerConfig } from './utils.js';
 import { Stable, Stake } from '../tokens.js';
@@ -240,7 +240,7 @@ export const makeClientBanks = async ({
   const STORAGE_PATH = 'wallet';
 
   const [storageNode, bridgeManager] = await Promise.all([
-    makeStorageNode(chainStorage, STORAGE_PATH),
+    makeStorageNodeChild(chainStorage, STORAGE_PATH),
     bridgeManagerP,
   ]);
 

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -325,7 +325,7 @@ export const publishAgoricNames = async ({
     console.warn('cannot publish agoricNames without chainStorage');
     return;
   }
-  const nameStorage = E(root).getChildNode('agoricNames');
+  const nameStorage = E(root).makeChildNode('agoricNames');
   const marshaller = E(board).getPublishingMarshaller();
 
   // brand, issuer, ...
@@ -333,7 +333,7 @@ export const publishAgoricNames = async ({
     keys(agoricNamesReserved).map(async kind => {
       const kindAdmin = await E(agoricNamesAdmin).lookupAdmin(kind);
 
-      const kindNode = await E(nameStorage).getChildNode(kind);
+      const kindNode = await E(nameStorage).makeChildNode(kind);
       const { publisher } = makeStoredPublishKit(kindNode, marshaller);
       publisher.publish([]);
       kindAdmin.onUpdate(publisher.publish);

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -196,7 +196,7 @@
  *   bldIssuerKit: RemoteIssuerKit,
  *   board: Board,
  *   bridgeManager: OptionalBridgeManager,
- *   chainStorage: import('../lib-chainStorage.js').ChainStorageNode | null,
+ *   chainStorage: StorageNode | null,
  *   chainTimerService: TimerService,
  *   client: ClientManager,
  *   clientCreator: ClientCreator,

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -84,7 +84,6 @@ export function makeChainStorageRoot(
   const rootNode = makeChainStorageNode(rootPath);
   return rootNode;
 }
-/** @typedef {ReturnType<typeof makeChainStorageRoot>} ChainStorageNode */
 
 /**
  * @returns {StorageNode} an object that confirms to StorageNode API but does not store anywhere.
@@ -99,7 +98,7 @@ const makeNullStorageNode = () => {
  * falling back to an inert object with the correct interface (but incomplete
  * behavior) when that is unavailable.
  *
- * @param {ERef<ChainStorageNode?>} chainStorage
+ * @param {ERef<StorageNode?>} chainStorage
  * @param {string} [childName]
  * @returns {Promise<StorageNode>}
  */

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -99,15 +99,12 @@ const makeNullStorageNode = () => {
  * behavior) when that is unavailable.
  *
  * @param {ERef<StorageNode?>} chainStorage
- * @param {string} [childName]
+ * @param {string} childName
  * @returns {Promise<StorageNode>}
  */
-export async function makeStorageNode(chainStorage, childName) {
+export async function makeStorageNodeChild(chainStorage, childName) {
   // eslint-disable-next-line @jessie.js/no-nested-await
   const storageNode = (await chainStorage) || makeNullStorageNode();
-  if (childName) {
-    return E(storageNode).getChildNode(childName);
-  }
-  return storageNode;
+  return E(storageNode).getChildNode(childName);
 }
-harden(makeStorageNode);
+harden(makeStorageNodeChild);

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -70,9 +70,6 @@ export function makeChainStorageRoot(
         assert.typeof(value, 'string');
         handleStorageMessage({ key: path, method: 'set', value });
       },
-      clearValue() {
-        handleStorageMessage({ key: path, method: 'set', value: '' });
-      },
       // Possible extensions:
       // * getValue()
       // * getChildNames() and/or getChildNodes()

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -58,7 +58,8 @@ export function makeChainStorageRoot(
           value: '',
         });
       },
-      getChildNode(name) {
+      /** @type {(name: string) => StorageNode} */
+      makeChildNode(name) {
         assert.typeof(name, 'string');
         assert(
           pathSegmentPattern.test(name),
@@ -72,7 +73,7 @@ export function makeChainStorageRoot(
       },
       // Possible extensions:
       // * getValue()
-      // * getChildNames() and/or getChildNodes()
+      // * getChildNames() and/or makeChildNodes()
       // * getName()
       // * recursive delete
       // * batch operations
@@ -105,6 +106,6 @@ const makeNullStorageNode = () => {
 export async function makeStorageNodeChild(storageNodeRef, childName) {
   // eslint-disable-next-line @jessie.js/no-nested-await
   const storageNode = (await storageNodeRef) || makeNullStorageNode();
-  return E(storageNode).getChildNode(childName);
+  return E(storageNode).makeChildNode(childName);
 }
 harden(makeStorageNodeChild);

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -51,6 +51,7 @@ export function makeChainStorageRoot(
 
   function makeChainStorageNode(path) {
     const node = {
+      /** @type {() => VStorageKey} */
       getStoreKey() {
         return handleStorageMessage({
           key: path,
@@ -67,6 +68,7 @@ export function makeChainStorageRoot(
         );
         return makeChainStorageNode(`${path}.${name}`);
       },
+      /** @type {(value: string) => void} */
       setValue(value) {
         assert.typeof(value, 'string');
         handleStorageMessage({ key: path, method: 'set', value });

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -98,13 +98,13 @@ const makeNullStorageNode = () => {
  * falling back to an inert object with the correct interface (but incomplete
  * behavior) when that is unavailable.
  *
- * @param {ERef<StorageNode?>} chainStorage
+ * @param {ERef<StorageNode?>} storageNodeRef
  * @param {string} childName
  * @returns {Promise<StorageNode>}
  */
-export async function makeStorageNodeChild(chainStorage, childName) {
+export async function makeStorageNodeChild(storageNodeRef, childName) {
   // eslint-disable-next-line @jessie.js/no-nested-await
-  const storageNode = (await chainStorage) || makeNullStorageNode();
+  const storageNode = (await storageNodeRef) || makeNullStorageNode();
   return E(storageNode).getChildNode(childName);
 }
 harden(makeStorageNodeChild);

--- a/packages/vats/test/test-lib-chainStorage.js
+++ b/packages/vats/test/test-lib-chainStorage.js
@@ -45,13 +45,14 @@ test('makeChainStorageRoot', async t => {
   );
   for (const [label, val] of nonStrings) {
     t.throws(
+      // @ts-expect-error invalid value
       () => rootNode.setValue(val),
       undefined,
       `${label} value for root node is rejected`,
     );
   }
 
-  rootNode.clearValue();
+  rootNode.setValue('');
   rootNode.setValue('foo');
   t.deepEqual(
     messages.slice(-1),
@@ -101,12 +102,6 @@ test('makeChainStorageRoot', async t => {
       [{ key: childPath, method: 'set', value: 'foo' }],
       'non-root setValue message',
     );
-    child.clearValue();
-    t.deepEqual(
-      messages.slice(-1),
-      [{ key: childPath, method: 'set', value: '' }],
-      'non-root clearValue message',
-    );
   }
 
   // Invalid path segments are non-strings, empty, too long, or contain unacceptable characters.
@@ -126,6 +121,7 @@ test('makeChainStorageRoot', async t => {
   badSegments.set('ASCII with combining diacritical mark', 'a\u0301');
   for (const [label, val] of badSegments) {
     t.throws(
+      // @ts-expect-error invalid value
       () => rootNode.getChildNode(val),
       undefined,
       `${label} segment is rejected`,
@@ -143,6 +139,7 @@ test('makeChainStorageRoot', async t => {
   });
   for (const [label, val] of nonStrings) {
     t.throws(
+      // @ts-expect-error invalid value
       () => deepNode.setValue(val),
       undefined,
       `${label} value for non-root node is rejected`,
@@ -155,22 +152,22 @@ test('makeChainStorageRoot', async t => {
     'level-skipping setValue message',
   );
 
-  childNode.clearValue();
+  childNode.setValue('');
   t.deepEqual(
     messages.slice(-1),
     [{ key: childPath, method: 'set', value: '' }],
-    'child clearValue message',
+    'child setValue message',
   );
-  deepNode.clearValue();
+  deepNode.setValue('');
   t.deepEqual(
     messages.slice(-1),
     [{ key: deepPath, method: 'set', value: '' }],
-    'granchild clearValue message',
+    'granchild setValue message',
   );
-  childNode.clearValue();
+  childNode.setValue('');
   t.deepEqual(
     messages.slice(-1),
     [{ key: childPath, method: 'set', value: '' }],
-    'child clearValue message',
+    'child setValue message',
   );
 });

--- a/packages/vats/test/test-lib-chainStorage.js
+++ b/packages/vats/test/test-lib-chainStorage.js
@@ -89,7 +89,7 @@ test('makeChainStorageRoot', async t => {
       .repeat(Math.ceil(100 / validSegmentChars.length))
       .match(/.{1,100}/gsu) || [];
   for (const segment of extremeSegments) {
-    const child = rootNode.getChildNode(segment);
+    const child = rootNode.makeChildNode(segment);
     const childPath = `${rootPath}.${segment}`;
     t.deepEqual(
       child.getStoreKey(),
@@ -122,16 +122,16 @@ test('makeChainStorageRoot', async t => {
   for (const [label, val] of badSegments) {
     t.throws(
       // @ts-expect-error invalid value
-      () => rootNode.getChildNode(val),
+      () => rootNode.makeChildNode(val),
       undefined,
       `${label} segment is rejected`,
     );
   }
 
   // Level-skipping creation is allowed.
-  const childNode = rootNode.getChildNode('child');
+  const childNode = rootNode.makeChildNode('child');
   const childPath = `${rootPath}.child`;
-  const deepNode = childNode.getChildNode('grandchild');
+  const deepNode = childNode.makeChildNode('grandchild');
   const deepPath = `${childPath}.grandchild`;
   t.deepEqual(deepNode.getStoreKey(), {
     storeName: 'swingset',

--- a/packages/wallet/contract/src/singleWallet.js
+++ b/packages/wallet/contract/src/singleWallet.js
@@ -44,7 +44,7 @@ export const start = async (zcf, privateArgs) => {
   const { storageNode, marshaller } = privateArgs;
   assert(storageNode, 'missing storageNode');
 
-  const cacheStorageNode = E(storageNode).getChildNode('cache');
+  const cacheStorageNode = E(storageNode).makeChildNode('cache');
 
   const wallet = await makeWallet(bank, {
     agoricNames,
@@ -56,7 +56,7 @@ export const start = async (zcf, privateArgs) => {
   });
 
   const myWalletStorageNode =
-    storageNode && E(storageNode).getChildNode(address);
+    storageNode && E(storageNode).makeChildNode(address);
   const admin = E(wallet).getAdminFacet();
 
   /** @type {Record<string, ERef<Notifier<unknown>>>} */

--- a/packages/wallet/contract/src/smartWallet.js
+++ b/packages/wallet/contract/src/smartWallet.js
@@ -32,7 +32,7 @@ export const makeSmartWallet = async (
   assert(myAddressNameAdmin, 'missing myAddressNameAdmin');
   assert(storageNode, 'missing storageNode');
 
-  const cacheStorageNode = E(storageNode).getChildNode('cache');
+  const cacheStorageNode = E(storageNode).makeChildNode('cache');
 
   const wallet = await makeWallet(bank, {
     agoricNames,
@@ -69,7 +69,7 @@ export const makeSmartWallet = async (
 
   const marshaller = wallet.getMarshaller();
 
-  const myWalletStorageNode = E(storageNode).getChildNode(address);
+  const myWalletStorageNode = E(storageNode).makeChildNode(address);
   const storedSubscriber = makeStoredSubscriber(
     subscriber,
     myWalletStorageNode,

--- a/packages/wallet/contract/test/test-singleWallet.js
+++ b/packages/wallet/contract/test/test-singleWallet.js
@@ -6,7 +6,7 @@ import '@agoric/vats/src/core/types.js';
 import '@agoric/zoe/exported.js';
 
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
-import { makeStorageNode } from '@agoric/vats/src/lib-chainStorage.js';
+import { makeStorageNodeChild } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeNameHubKit } from '@agoric/vats/src/nameHub.js';
 import { E, Far } from '@endo/far';
 import path from 'path';
@@ -64,7 +64,10 @@ const makeTestContext = async t => {
   );
 
   // copied from makeClientBanks()
-  const storageNode = await makeStorageNode(consume.chainStorage, 'wallet');
+  const storageNode = await makeStorageNodeChild(
+    consume.chainStorage,
+    'wallet',
+  );
   const marshaller = E(consume.board).getPublishingMarshaller();
 
   const singleWallet = E(zoe).startInstance(

--- a/packages/wallet/contract/test/test-walletFactory.js
+++ b/packages/wallet/contract/test/test-walletFactory.js
@@ -6,7 +6,7 @@ import '@agoric/vats/src/core/types.js';
 import '@agoric/zoe/exported.js';
 
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
-import { makeStorageNode } from '@agoric/vats/src/lib-chainStorage.js';
+import { makeStorageNodeChild } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeNameHubKit } from '@agoric/vats/src/nameHub.js';
 import { E, Far } from '@endo/far';
 import path from 'path';
@@ -59,7 +59,10 @@ const makeTestContext = async t => {
   // #endregion
 
   // copied from makeClientBanks()
-  const storageNode = await makeStorageNode(consume.chainStorage, 'wallet');
+  const storageNode = await makeStorageNodeChild(
+    consume.chainStorage,
+    'wallet',
+  );
   const marshaller = E(consume.board).getPublishingMarshaller();
 
   const walletFactory = E(zoe).startInstance(

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -58,10 +58,10 @@ const aggregatorPath = `${dirname}/../../../src/contracts/priceAggregator.js`;
  *
  * @param {Promise<StoredSubscriber<unknown>>} subscriber
  */
-export const subscriptionKey = subscriber => {
+export const subscriberSubkey = subscriber => {
   return E(subscriber)
     .getStoreKey()
-    .then(storeKey => storeKey.key);
+    .then(storeKey => storeKey.storeSubkey);
 };
 
 const makePublicationChecker = async (t, aggregatorPublicFacet) => {
@@ -110,7 +110,7 @@ test.before('setup aggregator and oracles', async ot => {
   // ??? why do we need the Far here and not in VaultFactory tests?
   const marshaller = Far('fake marshaller', { ...makeFakeMarshaller() });
   const storageRoot = makeChainStorageRoot(
-    v => v,
+    m => ({ storeSubkey: `paTest:${m.key}` }),
     'swingset',
     'mockChainStorageRoot',
   );
@@ -1019,7 +1019,7 @@ test('storage keys', async t => {
   const { publicFacet } = await t.context.makeMedianAggregator(1n);
 
   t.is(
-    await subscriptionKey(E(publicFacet).getSubscriber()),
-    'mockChainStorageRoot.priceAggregator.ATOM_USD_price_feed',
+    await subscriberSubkey(E(publicFacet).getSubscriber()),
+    'paTest:mockChainStorageRoot.priceAggregator.ATOM_USD_price_feed',
   );
 });

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -154,14 +154,14 @@ test.before('setup aggregator and oracles', async ot => {
    */
   const makeMedianAggregator = async POLL_INTERVAL => {
     const timer = buildManualTimer(() => {});
-    const storageNode = E(storageRoot).getChildNode('priceAggregator');
+    const storageNode = E(storageRoot).makeChildNode('priceAggregator');
     const aggregator = await E(zoe).startInstance(
       aggregatorInstallation,
       undefined,
       { timer, POLL_INTERVAL, brandIn: atomBrand, brandOut: usdBrand },
       {
         marshaller,
-        storageNode: E(storageNode).getChildNode(
+        storageNode: E(storageNode).makeChildNode(
           sanitizePathSegment('ATOM-USD price feed'),
         ),
       },


### PR DESCRIPTION
## Description

We have ChainStorageNode and StorageNode but it seems the latter is sufficient. The only difference is the former has `clearValue`, which is the same as `setValue(undefined)`.

This removes `clearValue` and replaces `ChainStorageNode` with `StorageNode`.

It also renames the `makeStorageNode` function to distinguish its use case (making a child) and makes `childName` required.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

CI
