### PR TITLE
fix: bug in M.setOf and M.bagOf

### DIFF
--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -58,7 +58,7 @@ const SetValueShape = M.arrayOf(M.key());
  * will never be minted. That want will never be satisfied.
  * "You can't always get..."
  */
-const CopyBagValueShape = M.bagOf();
+const CopyBagValueShape = M.bag();
 
 const AmountValueShape = M.or(
   NatValueShape,

--- a/packages/inter-protocol/src/stakeFactory/stakeFactoryManager.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactoryManager.js
@@ -204,11 +204,7 @@ const manager = {
       brands.Attestation,
       X`Invalid Attestation ${attestationGiven}. Expected brand ${brands.Attestation}`,
     );
-    fit(
-      attestationGiven.value,
-      M.bagOf([M.string(), M.bigint()]),
-      'attestationGiven',
-    );
+    fit(attestationGiven.value, M.bagOf(M.string()), 'attestationGiven');
     const [[_addr, valueLiened]] = getCopyBagEntries(attestationGiven.value);
     const amountLiened = AmountMath.make(brands.Stake, valueLiened);
     const maxDebt = floorMultiplyBy(amountLiened, mintingRatio);

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -818,21 +818,27 @@ const makePatternKit = () => {
 
   /** @type {MatchHelper} */
   const matchBagOfHelper = Far('match:bagOf helper', {
-    checkMatches: (specimen, keyPatt, check = x => x) =>
+    checkMatches: (specimen, [keyPatt, countPatt], check = x => x) =>
       check(
         passStyleOf(specimen) === 'tagged' && getTag(specimen) === 'copyBag',
         X`${specimen} - Must be a a CopyBag`,
       ) &&
-      specimen.payload.every(([key, _count]) =>
-        checkMatches(key, keyPatt, check),
+      specimen.payload.every(
+        ([key, count]) =>
+          checkMatches(key, keyPatt, check) &&
+          checkMatches(count, countPatt, check),
       ),
 
-    checkIsMatcherPayload: checkPattern,
+    checkIsMatcherPayload: (entryPatt, check = x => x) =>
+      check(
+        passStyleOf(entryPatt) === 'copyArray' && entryPatt.length === 2,
+        X`${entryPatt} - Must be an pair of patterns`,
+      ) && checkPattern(entryPatt, check),
 
     getRankCover: () => getPassStyleCover('tagged'),
 
     checkKeyPattern: (_, check = x => x) =>
-      check(false, X`CopySets not yet supported as keys`),
+      check(false, X`CopyBags not yet supported as keys`),
   });
 
   /** @type {MatchHelper} */
@@ -1082,7 +1088,8 @@ const makePatternKit = () => {
     recordOf: (keyPatt = M.any(), valuePatt = M.any()) =>
       makeMatcher('match:recordOf', [keyPatt, valuePatt]),
     setOf: (keyPatt = M.any()) => makeMatcher('match:setOf', keyPatt),
-    bagOf: (keyPatt = M.any()) => makeMatcher('match:bagOf', keyPatt),
+    bagOf: (keyPatt = M.any(), countPatt = M.any()) =>
+      makeMatcher('match:bagOf', [keyPatt, countPatt]),
     mapOf: (keyPatt = M.any(), valuePatt = M.any()) =>
       makeMatcher('match:mapOf', [keyPatt, valuePatt]),
     split: (base, rest = undefined) =>

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -806,7 +806,7 @@ const makePatternKit = () => {
       check(
         passStyleOf(specimen) === 'tagged' && getTag(specimen) === 'copySet',
         X`${specimen} - Must be a a CopySet`,
-      ) && specimen.payload.every(el => checkMatches(el, keyPatt)),
+      ) && specimen.payload.every(el => checkMatches(el, keyPatt, check)),
 
     checkIsMatcherPayload: checkPattern,
 
@@ -823,7 +823,9 @@ const makePatternKit = () => {
         passStyleOf(specimen) === 'tagged' && getTag(specimen) === 'copyBag',
         X`${specimen} - Must be a a CopyBag`,
       ) &&
-      specimen.payload.every(([key, _count]) => checkMatches(key, keyPatt)),
+      specimen.payload.every(([key, _count]) =>
+        checkMatches(key, keyPatt, check),
+      ),
 
     checkIsMatcherPayload: checkPattern,
 

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -536,11 +536,12 @@
  * @property {(subPatt?: Pattern) => Matcher} arrayOf
  * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => Matcher} recordOf
  * @property {(keyPatt?: Pattern) => Matcher} setOf
- * @property {(keyPatt?: Pattern) => Matcher} bagOf
+ * @property {(keyPatt?: Pattern, countPatt?: Pattern) => Matcher} bagOf
  * Parameterized by a keyPatt that is matched against every element of the
  * abstract bag. In terms of the bag representation, it is matched against
- * the first element of each pair. No pattern is run over the cardinality
- * numbers.
+ * the first element of each pair. If the second `countPatt` is provided,
+ * it is matched against the cardinality of each element. The `countPatt`
+ * is rarely expected to be useful, but is provided to minimize surprise.
  * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => Matcher} mapOf
  * @property {(
  *   base: CopyRecord<*> | CopyArray<*>,

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -537,6 +537,10 @@
  * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => Matcher} recordOf
  * @property {(keyPatt?: Pattern) => Matcher} setOf
  * @property {(keyPatt?: Pattern) => Matcher} bagOf
+ * Parameterized by a keyPatt that is matched against every element of the
+ * abstract bag. In terms of the bag representation, it is matched against
+ * the first element of each pair. No pattern is run over the cardinality
+ * numbers.
  * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => Matcher} mapOf
  * @property {(
  *   base: CopyRecord<*> | CopyArray<*>,


### PR DESCRIPTION
In the internal pattern match logic of `M.setOf(keyPatt)` and `M.bagOf(keyPatt)`, even when called by `fit`, a mismatch could cause these to return `false` rather than throwing. This masked a bug, also fixed in this PR.

The tests that would test this fix are postponed until https://github.com/Agoric/agoric-sdk/pull/5947 , which is stacked on this one, so those tests can show the improved error messages.