### PR TITLE
copyBag types

### DIFF
--- a/packages/store/src/keys/checkKey.js
+++ b/packages/store/src/keys/checkKey.js
@@ -280,7 +280,7 @@ harden(assertCopyBag);
 /**
  * @template K
  * @param {CopyBag<K>} b
- * @returns {K[]}
+ * @returns {CopyBag<K>['payload']}
  */
 export const getCopyBagEntries = b => {
   assertCopyBag(b);

--- a/packages/store/src/keys/copyBag.js
+++ b/packages/store/src/keys/copyBag.js
@@ -102,8 +102,14 @@ export const checkBagEntries = (bagEntries, check = x => x) => {
 };
 harden(checkBagEntries);
 
-export const assertBagEntries = bagEntries =>
+// eslint-disable-next-line jsdoc/require-returns-check -- doesn't understand asserts
+/**
+ * @param {[Passable,bigint][]} bagEntries
+ * @returns {asserts bagEntries is [Passable,bigint][]}
+ */
+export const assertBagEntries = bagEntries => {
   checkBagEntries(bagEntries, assertChecker);
+};
 harden(assertBagEntries);
 
 export const coerceToBagEntries = bagEntriesList => {

--- a/packages/store/src/keys/copyBag.js
+++ b/packages/store/src/keys/copyBag.js
@@ -115,7 +115,7 @@ harden(coerceToBagEntries);
 
 /**
  * @template K
- * @param {Iterable<K>} bagEntryIter
+ * @param {Iterable<[K, bigint]>} bagEntryIter
  * @returns {CopyBag<K>}
  */
 export const makeBagOfEntries = bagEntryIter =>

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -79,9 +79,13 @@
  * @typedef {CopyTagged} CopySet
  */
 
+// TODO parameterize CopyTagged so this can include it
 /**
  * @template K
- * @typedef {CopyTagged} CopyBag
+ * @typedef {{
+ *   [Symbol.toStringTag]: string;
+ *   payload: Array<[K, bigint]>;
+ * }} CopyBag
  */
 
 /**

--- a/packages/store/test/test-copyBag.js
+++ b/packages/store/test/test-copyBag.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { makeCopyBag } from '../src/keys/checkKey.js';
+
+import '../src/types.js';
+
+test('duplicate keys', t => {
+  t.throws(
+    () =>
+      makeCopyBag([
+        ['a', 1n],
+        ['a', 1n],
+      ]),
+    { message: 'value has duplicate keys: "a"' },
+  );
+});

--- a/packages/store/test/test-copyBag.js
+++ b/packages/store/test/test-copyBag.js
@@ -5,6 +5,33 @@ import { makeCopyBag } from '../src/keys/checkKey.js';
 
 import '../src/types.js';
 
+test('ordering', t => {
+  const bag = makeCopyBag([
+    ['z', 26n],
+    ['a', 1n],
+    ['b', 2n],
+    ['c', 3n],
+  ]);
+  t.deepEqual(bag.payload, [
+    ['z', 26n],
+    ['c', 3n],
+    ['b', 2n],
+    ['a', 1n],
+  ]);
+});
+
+test('types', t => {
+  const bag = makeCopyBag([['a', 1n]]);
+
+  // @ts-expect-error should not be 'any'
+  bag.payload.foo;
+  const [str, count] = bag.payload[0];
+  str.concat; // string
+  count + 1n; // bigint
+
+  t.pass();
+});
+
 test('duplicate keys', t => {
   t.throws(
     () =>


### PR DESCRIPTION
## Description

Prompted by https://github.com/Agoric/agoric-sdk/pull/5952#discussion_r945309304 .

This corrects the types for copyBag, adds a test, and makes its assert narrow.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

--