### PR TITLE
fix(wallet/ui): change makeFollower to getUnserializer

### DIFF
--- a/packages/wallet/ui/src/service/ScopedBridge.js
+++ b/packages/wallet/ui/src/service/ScopedBridge.js
@@ -1,4 +1,3 @@
-import { makeFollower } from '@agoric/casting';
 import { Far } from '@endo/captp';
 
 export const getScopedBridge = (origin, suggestedDappPetname, bridge) => {
@@ -7,7 +6,6 @@ export const getScopedBridge = (origin, suggestedDappPetname, bridge) => {
     dappService,
     offerService,
     issuerService,
-    leader,
     unserializer,
   } = bridge;
 
@@ -82,9 +80,9 @@ export const getScopedBridge = (origin, suggestedDappPetname, bridge) => {
       // TODO: filter offers by dapp origin
       return offerService.notifier;
     },
-    async makeFollower(spec) {
+    async getUnserializer() {
       await dapp.approvedP;
-      return makeFollower(spec, leader, { unserializer });
+      return unserializer;
     },
   });
 };


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/issues/5354

Since  https://github.com/Agoric/agoric-sdk/commit/6db0f477d8a21ffceb56b5d9b0f4d5f4f87feeca (likely due to upgrading `@endo/Far`), the follower being passed over the bridge no longer works. The purpose of this was so that the dapp could share the unserializer with the wallet so brand references etc. would be identical. So, just provide the unserializer instead.