### PR TITLE
drop maxNodeModuleJsDepth

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -17,7 +17,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:eslint": "eslint .",
-    "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/SwingSet/exported.js
+++ b/packages/SwingSet/exported.js
@@ -1,1 +1,8 @@
 /// <reference types="./src/vats/timer/types"/>
+
+// XXX without this types don't resolve
+// eslint-disable-next-line import/no-extraneous-dependencies -- TODO remove
+import '@agoric/governance/exported.js';
+
+// XXX https://github.com/endojs/endo/issues/1254
+import '@endo/captp/src/types.js';

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -17,7 +17,7 @@
     "test:xs-worker": "ava test/workers/test-worker.js -m 'xs vat manager'",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "yarn lint:types&&yarn lint:eslint",
-    "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint ."
   },
   "devDependencies": {

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -3,6 +3,9 @@
 import fs from 'fs';
 import path from 'path';
 
+// XXX types resolution
+import '@endo/bundle-source/src/types.js';
+
 import { resolve as resolveModuleSpecifier } from 'import-meta-resolve';
 import { assert, details as X } from '@agoric/assert';
 import bundleSource from '@endo/bundle-source';

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -1,5 +1,9 @@
 /* eslint-disable @jessie.js/no-nested-await */
 /* global process */
+
+// XXX types resolution https://github.com/endojs/endo/issues/1254
+import '@endo/captp/src/types.js';
+
 import { Command } from 'commander';
 import path from 'path';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -12,7 +12,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint --ext .js,.ts ."
   },
   "keywords": [],

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -13,7 +13,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint --ext .js,.ts ."
   },
   "keywords": [],

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -15,7 +15,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint ."
   },
   "keywords": [],

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -13,7 +13,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint:eslint": "eslint .",
-    "lint:types": "tsc --maxNodeModuleJsDepth 5 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint": "run-s --continue-on-error lint:*"
   },
   "repository": {

--- a/packages/deploy-script-support/src/helpers.js
+++ b/packages/deploy-script-support/src/helpers.js
@@ -1,4 +1,6 @@
 // @ts-check
+import '@agoric/inter-protocol/exported.js';
+import '@endo/captp/src/types.js';
 import '@agoric/zoe/exported.js';
 import { E } from '@endo/far';
 

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:eslint": "eslint .",
-    "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:eslint": "eslint .",
-    "lint:types": "tsc --maxNodeModuleJsDepth 5 -p jsconfig.json"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/inter-protocol/src/index.js
+++ b/packages/inter-protocol/src/index.js
@@ -1,1 +1,7 @@
+// @ts-check
+/// <reference types="ses"/>
+
+// Ambient types. Needed only for dev but this does a runtime import.
+import '@agoric/notifier/exported.js';
+
 export { calculateCurrentDebt } from './interest-math.js';

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:eslint": "eslint .",
-    "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -5,16 +5,17 @@
  * @typedef {import('@endo/far').ERef<T>} ERef
  */
 
+// XXX import src/types until https://github.com/endojs/endo/issues/1254
 /**
  * @template T
- * @typedef {import('@endo/promise-kit').PromiseKit<T>} PromiseKit
+ * @typedef {import('@endo/promise-kit/src/types.js').PromiseKit<T>} PromiseKit
  */
 
 /**
  * Deprecated. Use PromiseKit instead.
  *
  * @template T
- * @typedef {import('@endo/promise-kit').PromiseRecord<T>} PromiseRecord
+ * @typedef {import('@endo/promise-kit/src/types.js').PromiseRecord<T>} PromiseRecord
  */
 
 /**

--- a/packages/pegasus/exported.js
+++ b/packages/pegasus/exported.js
@@ -1,3 +1,7 @@
+// XXX without this types don't resolve
+// eslint-disable-next-line import/no-extraneous-dependencies -- TODO remove
+import '@agoric/inter-protocol/exported.js';
+
 import './src/types.js';
 import '@agoric/notifier/exported.js';
 import '@agoric/ertp/exported.js';

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:eslint": "eslint .",
-    "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -5,7 +5,6 @@
 /**
  * @typedef {string} Denom
  * @typedef {string} DepositAddress
- * @typedef {string} Address
  */
 
 /**

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -15,7 +15,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint ."
   },
   "keywords": [],

--- a/packages/solo/src/entrypoint.js
+++ b/packages/solo/src/entrypoint.js
@@ -1,5 +1,8 @@
 #! /usr/bin/env node
 
+// XXX types resolution
+import '@agoric/swingset-vat/exported.js';
+
 import '@endo/init/pre-bundle-source.js';
 
 // import lmdb early to work around SES incompatibility

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -13,7 +13,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint ."
   },
   "repository": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -12,7 +12,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint ."
   },
   "bin": {

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -18,7 +18,7 @@
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:types": "tsc --maxNodeModuleJsDepth 5 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint ."
   },
   "keywords": [],

--- a/packages/wallet/api/exported.js
+++ b/packages/wallet/api/exported.js
@@ -1,1 +1,6 @@
+// XXX without this types don't resolve
+// eslint-disable-next-line import/no-extraneous-dependencies -- TODO remove
+import '@agoric/governance/exported.js';
+import '@agoric/zoe/exported.js';
+
 import './src/types.js';

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -10,7 +10,7 @@
     "test:xs": "exit 0",
     "lint": "run-s --continue-on-error lint:*",
     "lint-fix": "yarn lint:eslint --fix",
-    "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint ."
   },
   "devDependencies": {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -14,7 +14,7 @@
     "test:watch": "web-test-runner --watch",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
-    "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint . --ignore-path .gitignore",
     "analyze": "cem analyze --litelement",
     "start": "web-dev-server --port 8100"

--- a/packages/zoe/exported.js
+++ b/packages/zoe/exported.js
@@ -1,3 +1,7 @@
+// XXX without this types don't resolve
+// eslint-disable-next-line import/no-extraneous-dependencies -- TODO remove
+import '@agoric/inter-protocol/exported.js';
+
 import './src/contractFacet/types.js';
 import './src/zoeService/types.js';
 import './src/contractSupport/types.js';

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -21,7 +21,7 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:eslint": "eslint .",
-    "lint:types": "tsc --maxNodeModuleJsDepth 4 -p jsconfig.json"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
closes: #4560

## Description

If we get captp and promise-kit from Endo to export explicit types, then I think with this change we can drop maxNodeModulesJsDepth

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
