### PR TITLE
style: Rename variables in Go-JS plumbing code for accuracy

### DIFF
--- a/golang/cosmos/x/swingset/keeper/keeper.go
+++ b/golang/cosmos/x/swingset/keeper/keeper.go
@@ -20,6 +20,7 @@ import (
 // Top-level paths for chain storage should remain synchronized with
 // packages/vats/src/chain-storage-paths.js
 const (
+	StoragePathActionQueue  = "actionQueue"
 	StoragePathActivityhash = "activityhash"
 	StoragePathBeansOwing   = "beansOwing"
 	StoragePathEgress       = "egress"

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -324,7 +324,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     );
     const actionQueue = makeChainQueue(
       msg => chainSend(portNums.storage, msg),
-      'actionQueue.',
+      `${STORAGE_PATH.ACTION_QUEUE}.`,
     );
     function setActivityhash(activityhash) {
       const msg = stringify({
@@ -334,7 +334,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       });
       chainSend(portNums.storage, msg);
     }
-    function doOutboundBridge(dstID, obj) {
+    function doOutboundBridge(dstID, msg) {
       const portNum = portNums[dstID];
       if (portNum === undefined) {
         console.error(
@@ -345,11 +345,11 @@ export default async function main(progname, args, { env, homedir, agcc }) {
           `warning: doOutboundBridge called before AG_COSMOS_INIT gave us ${dstID}`,
         );
       }
-      const retStr = chainSend(portNum, stringify(obj));
+      const respStr = chainSend(portNum, stringify(msg));
       try {
-        return JSON.parse(retStr);
+        return JSON.parse(respStr);
       } catch (e) {
-        assert.fail(X`cannot JSON.parse(${JSON.stringify(retStr)}): ${e}`);
+        assert.fail(X`cannot JSON.parse(${JSON.stringify(respStr)}): ${e}`);
       }
     }
 

--- a/packages/vats/src/chain-storage-paths.js
+++ b/packages/vats/src/chain-storage-paths.js
@@ -4,6 +4,7 @@
  * To avoid collisions, they should remain synchronized with
  * golang/cosmos/x/swingset/keeper/keeper.go
  */
+export const ACTION_QUEUE = 'actionQueue';
 export const ACTIVITYHASH = 'activityhash';
 export const BEANSOWING = 'beansOwing';
 export const EGRESS = 'egress';


### PR DESCRIPTION
## Description

I had occasion to dive through the Go–JS plumbing, and found a number of variables with overly generic names. This cleans them up.

### Security Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a