### PR TITLE
fix: show more stacks

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -710,6 +710,7 @@ export default function buildKernel(
       // eslint-disable-next-line @jessie.js/no-nested-await
       await vatWarehouse.createDynamicVat(vatID);
     } catch (err) {
+      console.log('error during creation', err);
       const info = makeError(`${err}`);
       const results = {
         didDelivery: true, // ok, it failed, but we did spend the time

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -710,7 +710,7 @@ export default function buildKernel(
       // eslint-disable-next-line @jessie.js/no-nested-await
       await vatWarehouse.createDynamicVat(vatID);
     } catch (err) {
-      console.log('error during creation', err);
+      console.log('error during createDynamicVat', err);
       const info = makeError(`${err}`);
       const results = {
         didDelivery: true, // ok, it failed, but we did spend the time

--- a/packages/SwingSet/src/supervisors/supervisor-helper.js
+++ b/packages/SwingSet/src/supervisors/supervisor-helper.js
@@ -36,7 +36,7 @@ function makeSupervisorDispatch(dispatch) {
         () => harden(['ok', null, null]),
         err => {
           // TODO react more thoughtfully, maybe terminate the vat
-          console.log(`error [${err}] during vat dispatch() of ${delivery}`);
+          console.log(`error during vat dispatch() of ${delivery}`, err);
           return harden(['error', `${err}`, null]);
         },
       );

--- a/packages/pegasus/src/ics20.js
+++ b/packages/pegasus/src/ics20.js
@@ -122,6 +122,7 @@ export const makeICS20TransferPacketAck = async (success, error) => {
     const ack = { result: ICS20_TRANSFER_SUCCESS_RESULT };
     return JSON.stringify(ack);
   }
+  console.log('nack', error);
   const nack = { error: `${error}` };
   return JSON.stringify(nack);
 };


### PR DESCRIPTION
I was not seeing stacks that I expected to be useful. Tracking down the particular error I was seeing, by grepping for `during vat dispatch() of`, I saw that the error was simply being stringified and not otherwise reported, which looses both the stack info and all the redacted error.message info. I found two others by grepping for `${err`. This PR fixes these three to log the error to the console. Depending on what console that is, this may or may not be very useful, but it is the right thing.

No doubt there are other cases where we're only stringifying an error and not otherwise reporting it. But this PR fixes only the three I found.