### PR TITLE
5979 fix priceFeed resolution

### DIFF
--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -6,6 +6,7 @@ import {
 } from '@agoric/vats/src/lib-chainStorage.js';
 import { deeplyFulfilled } from '@endo/marshal';
 
+import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
 import { reserveThenDeposit, reserveThenGetNames } from './utils.js';
 
 /** @type {(name: string) => void} */
@@ -115,6 +116,7 @@ export const createPriceFeed = async (
     ]),
   ]);
 
+  const unitAmountIn = await unitAmount(brandIn);
   /** @type {import('@agoric/zoe/src/contracts/priceAggregator.js').PriceAggregatorContract['terms']} */
   const terms = await deeplyFulfilled(
     harden({
@@ -123,6 +125,7 @@ export const createPriceFeed = async (
       brandIn,
       brandOut,
       timer,
+      unitAmountIn,
     }),
   );
 

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -16,7 +16,6 @@
 import '@agoric/zoe/exported.js';
 
 import { AmountMath } from '@agoric/ertp';
-import { Nat } from '@agoric/nat';
 import { makeStoredPublishKit, observeNotifier } from '@agoric/notifier';
 import {
   defineDurableKindMulti,
@@ -35,6 +34,7 @@ import {
   makeRatioFromAmounts,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
+import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
 import {
   checkDebtLimit,
   makeEphemeraProvider,
@@ -919,12 +919,8 @@ const selfBehavior = {
 
     const { debtBrand } = state;
     // get a quote for one unit of the collateral
-    const displayInfo = await E(state.collateralBrand).getDisplayInfo();
-    const decimalPlaces = displayInfo.decimalPlaces || 0n;
-    return E(priceAuthority).quoteGiven(
-      AmountMath.make(state.collateralBrand, 10n ** Nat(decimalPlaces)),
-      debtBrand,
-    );
+    const collateralUnit = await unitAmount(state.collateralBrand);
+    return E(priceAuthority).quoteGiven(collateralUnit, debtBrand);
   },
 
   /** @param {MethodContext} context */

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/setup.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/setup.js
@@ -169,7 +169,7 @@ export const setupAmmServices = async (
     E(zoe).getInvitationIssuer(),
   ).getAmountOf(poserInvitationP);
 
-  /** @type {import('../../supports.js').MockChainStorageRoot} */
+  /** @type {import('@agoric/vats/tools/storage-test-utils.js').MockChainStorageRoot} */
   // @ts-expect-error cast
   const mockChainStorage = await space.consume.chainStorage;
 

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -10,15 +10,17 @@ import {
   makePromiseSpace,
 } from '@agoric/vats/src/core/utils.js';
 import { makeBoard } from '@agoric/vats/src/lib-board.js';
-import { makeFakeStorageKit } from '@agoric/vats/tools/storage-test-utils.js';
 import { Stable } from '@agoric/vats/src/tokens.js';
+import { makeMockChainStorageRoot } from '@agoric/vats/tools/storage-test-utils.js';
 import { makeZoeKit } from '@agoric/zoe';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
-import { makeLoopback, makeMarshal } from '@endo/captp';
-import { E, Far } from '@endo/far';
+import { makeLoopback } from '@endo/captp';
+import { E } from '@endo/far';
 import { makeTracer } from '../src/makeTracer.js';
+
+export { makeMockChainStorageRoot };
 
 /**
  * @param {*} t
@@ -63,35 +65,6 @@ export const setUpZoeForTest = (setJig = () => {}) => {
   };
 };
 harden(setUpZoeForTest);
-
-export const makeMockChainStorageRoot = () => {
-  const { rootNode, data } = makeFakeStorageKit('mockChainStorageRoot');
-
-  const defaultMarshaller = makeMarshal(undefined, (_slotId, iface) => ({
-    iface,
-  }));
-
-  return Far('mockChainStorage', {
-    ...rootNode,
-    /**
-     *  Defaults to deserializing pass-by-presence objects into { iface } representations.
-     * Note that this is **not** a null transformation; capdata `@qclass` and `index` properties
-     * are dropped and `iface` is _added_ for repeat references.
-     *
-     * @param {string} path
-     * @param {Marshaller} marshaller
-     * @returns {unknown}
-     */
-    getBody: (path, marshaller = defaultMarshaller) => {
-      const dataStr = data.get(path);
-      assert(dataStr, `no data at ${path}`);
-      assert.typeof(dataStr, 'string');
-      const datum = JSON.parse(dataStr);
-      return marshaller.unserialize(datum);
-    },
-  });
-};
-/** @typedef {ReturnType<typeof makeMockChainStorageRoot>} MockChainStorageRoot */
 
 /**
  *

--- a/packages/zoe/src/contractSupport/priceQuote.js
+++ b/packages/zoe/src/contractSupport/priceQuote.js
@@ -1,5 +1,9 @@
 // @ts-check
 
+import { AmountMath } from '@agoric/ertp';
+import { Nat } from '@agoric/nat';
+import { E } from '@endo/eventual-send';
+
 // PriceAuthorities return quotes as a pair of an amount and a payment, both
 // with the same value. The underlying amount wraps amountIn, amountOut, timer
 // and timestamp. The payment is issued by the quoteIssuer to support veracity
@@ -23,3 +27,12 @@ export const getAmountIn = quote => getPriceDescription(quote).amountIn;
 export const getAmountOut = quote => getPriceDescription(quote).amountOut;
 /** @type {(quote: PriceQuote) => Timestamp} */
 export const getTimestamp = quote => getPriceDescription(quote).timestamp;
+
+/** @param {Brand<'nat'>} brand */
+export const unitAmount = async brand => {
+  // Brand methods are remote
+  const displayInfo = await E(brand).getDisplayInfo();
+  const decimalPlaces = displayInfo.decimalPlaces ?? 0;
+  return AmountMath.make(brand, 10n ** Nat(decimalPlaces));
+};
+harden(unitAmount);

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -198,7 +198,6 @@ const start = async (zcf, privateArgs) => {
     });
 
   // for each new quote from the priceAuthority, publish it to off-chain storage
-  // XXX https://github.com/Agoric/agoric-sdk/issues/5853
   observeNotifier(
     priceAuthority.makeQuoteNotifier(AmountMath.make(brandIn, 1n), brandOut),
     {

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -30,7 +30,7 @@ const { add, subtract, multiply, floorDivide, ceilDivide, isGTE } = natSafeMath;
  * timeout: number,
  * minSubmissionValue: number,
  * maxSubmissionValue: number,
- * unitAmountIn: Amount,
+ * unitAmountIn?: Amount,
  * }>} zcf
  * @param {object} root0
  * @param {ERef<Mint>} [root0.quoteMint]


### PR DESCRIPTION
closes: #5979

## Description

The price feed is relayed to RPC by an observer of a QuoteNotifier. The `makeQuoteNotifier` call used `1n` as the unit amount, ignoring decimal places.

This makes it use decimal places to calculate an "integer" unit amount. It also adds unit tests of the storage output and refactors an inter-protocol test util so it can be used here.

I'm not sure about the `unitAmount()` helper function because many functions take a `unitAmountIn` parameter. I wonder if that's how this should be handled instead, perhaps making that a required argument.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

New tests but none that would have broken before this fix. I tried setting the decimalPlaces in the `$ATOM` issuer (as it must be on chain) but that broke many other test expressions. 