### PR TITLE
test: missing `await electorateOutcome`, so didn't detect paramChange

### DIFF
--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -428,8 +428,10 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
         committeeName: 'ThirtyCommittee',
         committeeSize: 5,
       };
-      const { electorateCreatorFacet: secondElectorateCreatorFacet } =
-        await startElectorate(zoe, installations, secondElectorateTerms);
+      const {
+        electorateCreatorFacet: secondElectorateCreatorFacet,
+        electorateInstance: secondElectorateInstance,
+      } = await startElectorate(zoe, installations, secondElectorateTerms);
 
       const newPoserInvitationP = E(
         secondElectorateCreatorFacet,
@@ -459,14 +461,14 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
         e => log(`vote (unexpected) rejected outcome: ${e}`),
       );
 
+      await electorateOutcome;
       await validateElectorateChange(
         zoe,
         log,
         voters1,
         details1,
         governorInstance,
-        // The electorate didn't change
-        firstElectorateInstance,
+        secondElectorateInstance,
         E(zoe).getPublicFacet(governorInstance),
       );
 

--- a/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
@@ -188,11 +188,11 @@ test.serial('changeTwoParams', async t => {
     '@@ tick:2 @@',
     '&& running a task scheduled for 2. &&',
     'vote outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: BundleInstallation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
-    'Validation complete: true',
     'params update: Electorate,MalleableNumber',
     'current value of MalleableNumber is 42',
     'updated to ({"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: BundleInstallation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}})',
     'successful outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: BundleInstallation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}} ',
+    'Validation complete: true',
   ]);
 });
 


### PR DESCRIPTION
closes: #5962

## Description

There was a missing `await electorateOutcome`, which allowed me to replace 
``` js
        // The electorate didn't change
        firstElectorateInstance,
```
with `secondElectorateInstance`, which was the intended result of the test

### Security Considerations

Where else have I allowed broken tests to slip through like this?

### Documentation Considerations

None.

### Testing Considerations

Test didn't find the result it was looking for,  and accepted the incorrect result rather than repairing the test.
