### PR TITLE
feat(wallet/ui): expose netconfig url to dapp bridge

### DIFF
--- a/packages/wallet/ui/src/components/SmartWalletConnection.jsx
+++ b/packages/wallet/ui/src/components/SmartWalletConnection.jsx
@@ -89,6 +89,7 @@ const SmartWalletConnection = ({
         context.fromBoard,
         publicAddress,
         keplrConnection,
+        href,
         backendError,
         () => setConnectionState('bridged'),
       );

--- a/packages/wallet/ui/src/service/ScopedBridge.js
+++ b/packages/wallet/ui/src/service/ScopedBridge.js
@@ -7,6 +7,7 @@ export const getScopedBridge = (origin, suggestedDappPetname, bridge) => {
     offerService,
     issuerService,
     unserializer,
+    networkConfig,
   } = bridge;
 
   const { dapps, addDapp, setDappPetname, deleteDapp, enableDapp } =
@@ -83,6 +84,10 @@ export const getScopedBridge = (origin, suggestedDappPetname, bridge) => {
     async getUnserializer() {
       await dapp.approvedP;
       return unserializer;
+    },
+    async getNetConfig() {
+      await dapp.approvedP;
+      return networkConfig;
     },
   });
 };

--- a/packages/wallet/ui/src/util/WalletBackendAdapter.js
+++ b/packages/wallet/ui/src/util/WalletBackendAdapter.js
@@ -98,6 +98,7 @@ export const makeBackendFromWalletBridge = walletBridge => {
  * @param {import('@agoric/casting').Unserializer} unserializer
  * @param {string} publicAddress
  * @param {object} keplrConnection
+ * @param {string} networkConfig
  * @param {(e: unknown) => void} [errorHandler]
  * @param {() => void} [firstCallback]
  */
@@ -107,6 +108,7 @@ export const makeWalletBridgeFromFollower = (
   unserializer,
   publicAddress,
   keplrConnection,
+  networkConfig,
   errorHandler = e => {
     // Make an unhandled rejection.
     throw e;
@@ -201,6 +203,7 @@ export const makeWalletBridgeFromFollower = (
         unserializer,
         publicAddress,
         issuerService,
+        networkConfig,
         ...getNotifierMethods,
       }),
   });


### PR DESCRIPTION
refs: https://github.com/Agoric/dapp-treasury/issues/137

The dapps use casting's `makeLeader` which defaults to connecting to `localhost`. This lets the dapps connect to the same network that the wallet is using.

See https://github.com/Agoric/dapp-amm/pull/34