### PR TITLE
fix: prepare for inherited method representation

### DIFF
--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -237,7 +237,7 @@ test('purse.getDepositFacet', async t => {
   await checkNotifier();
   await E(purse)
     .getDepositFacet()
-    .then(({ receive }) => receive(payment))
+    .then(depositFacet => depositFacet.receive(payment))
     .then(checkDeposit);
 });
 

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -2,7 +2,7 @@
 
 import { Far } from '@endo/marshal';
 import { makeStoredPublisherKit } from '@agoric/notifier';
-import { keyEQ } from '@agoric/store';
+import { getMethodNames, keyEQ } from '@agoric/store';
 import { objectMap, ignoreContext } from '@agoric/vat-data';
 import { assertElectorateMatches } from './contractGovernance/paramManager.js';
 import { makeParamManagerFromTerms } from './contractGovernance/typedParamManager.js';
@@ -140,7 +140,7 @@ const facetHelpers = (zcf, paramManager) => {
       // methods it has. There's no clean way to have contracts specify the APIs
       // without also separately providing their names.
       getGovernedApiNames: ({ facets }) =>
-        Object.keys(facets.governedApis || {}),
+        getMethodNames(facets.governedApis || {}),
     });
 
     return { governorFacet, limitedCreatorFacet };

--- a/packages/inter-protocol/src/stakeFactory/stakeFactory.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactory.js
@@ -199,8 +199,12 @@ export const start = async (
       },
       invitationMakers: Far('invitation makers', {
         AdjustBalances: () =>
-          zcf.makeInvitation(helper.adjustBalancesHook, 'AdjustBalances'),
-        CloseVault: () => zcf.makeInvitation(helper.closeHook, 'CloseVault'),
+          zcf.makeInvitation(
+            seatx => helper.adjustBalancesHook(seatx),
+            'AdjustBalances',
+          ),
+        CloseVault: () =>
+          zcf.makeInvitation(seatx => helper.closeHook(seatx), 'CloseVault'),
       }),
       vault: pot,
     });

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -693,7 +693,10 @@ const selfBehavior = {
     const { helper } = facets;
     helper.assertActive();
     const { zcf } = provideEphemera(state.idInManager);
-    return zcf.makeInvitation(helper.adjustBalancesHook, 'AdjustBalances');
+    return zcf.makeInvitation(
+      seat => helper.adjustBalancesHook(seat),
+      'AdjustBalances',
+    );
   },
 
   /**
@@ -703,7 +706,7 @@ const selfBehavior = {
     const { helper } = facets;
     helper.assertCloseable();
     const { zcf } = provideEphemera(state.idInManager);
-    return zcf.makeInvitation(helper.closeHook, 'CloseVault');
+    return zcf.makeInvitation(seat => helper.closeHook(seat), 'CloseVault');
   },
 
   /**
@@ -728,7 +731,7 @@ const selfBehavior = {
     };
     const { zcf } = provideEphemera(state.idInManager);
     return zcf.makeInvitation(
-      helper.makeTransferInvitationHook,
+      seat => helper.makeTransferInvitationHook(seat),
       'TransferVault',
       transferState,
     );

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -752,7 +752,7 @@ const collateralBehavior = {
   makeVaultInvitation: ({ state, facets: { self } }) => {
     const { zcf } = provideEphemera(state.collateralBrand);
     assert(zcf);
-    return zcf.makeInvitation(self.makeVaultKit, 'MakeVault');
+    return zcf.makeInvitation(seat => self.makeVaultKit(seat), 'MakeVault');
   },
   /** @param {MethodContext} context */
   getSubscriber: ({ state }) => {
@@ -787,8 +787,8 @@ const selfBehavior = {
   liquidateAll: async ({ state, facets: { helper } }) => {
     const { prioritizedVaults } = provideEphemera(state.collateralBrand);
     assert(prioritizedVaults);
-    const toLiquidate = Array.from(prioritizedVaults.entries()).map(
-      helper.liquidateAndRemove,
+    const toLiquidate = Array.from(prioritizedVaults.entries()).map(entry =>
+      helper.liquidateAndRemove(entry),
     );
     await Promise.all(toLiquidate);
   },
@@ -938,7 +938,7 @@ const finish = ({ state, facets: { helper } }) => {
   );
   assert(periodNotifier && prioritizedVaults && zcf);
 
-  prioritizedVaults.onHigherHighest(helper.reschedulePriceCheck);
+  prioritizedVaults.onHigherHighest(() => helper.reschedulePriceCheck());
 
   // push initial state of metrics
   helper.updateMetrics();

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -77,6 +77,7 @@ export {
 } from './stores/scalarMapStore.js';
 
 export { provide } from './stores/store-utils.js';
+export { getMethodNames, bindAllMethods } from './utils.js';
 
 // /////////////////////// Deprecated Legacy ///////////////////////////////////
 

--- a/packages/store/src/utils.js
+++ b/packages/store/src/utils.js
@@ -1,0 +1,79 @@
+// @ts-check
+
+// TODO https://github.com/Agoric/agoric-sdk/issues/5992
+// Many of the utilities accumulating in this module really have nothing
+// to do with the store package. Follow #5992 and migrate them, or perhaps
+// the entire utils.js module, to that independent sdk-internal package
+// that we will need to create.
+
+const { getPrototypeOf, create, fromEntries } = Object;
+const { ownKeys, apply } = Reflect;
+
+/** @typedef {import('@endo/marshal/src/types').Remotable} Remotable */
+
+const compareStringified = (left, right) => {
+  left = String(left);
+  right = String(right);
+  // eslint-disable-next-line no-nested-ternary
+  return left < right ? -1 : left > right ? 1 : 0;
+};
+
+/**
+ * @param {object} obj
+ * @returns {(string|symbol)[]}
+ */
+export const getMethodNames = obj => {
+  const result = [];
+  while (obj !== null && obj !== Object.prototype) {
+    const mNames = ownKeys(obj).filter(name => typeof obj[name] === 'function');
+    result.push(...mNames);
+    obj = getPrototypeOf(obj);
+  }
+  result.sort(compareStringified);
+  return harden(result);
+};
+harden(getMethodNames);
+
+/**
+ * TODO This function exists only to ease the
+ * https://github.com/Agoric/agoric-sdk/pull/5970 transition, from all methods
+ * being own properties to methods being inherited from a common prototype.
+ * This transition breaks two patterns used in prior code: autobinding,
+ * and enumerating methods by enumerating own properties. For both, the
+ * preferred repairs are
+ *    * autobinding: Replace, for example,
+ *      `foo(obj.method)` with `foo(arg => `obj.method(arg))`. IOW, stop relying
+ *      on expressions like `obj.method` to extract a method still bound to the
+ *      state of `obj` because, for virtual and durable objects,
+ *      they no longer will after #5970.
+ *    * method enumeration: Replace, for example
+ *      `Reflect.ownKeys(obj)` with `getMethodNames(obj)`.
+ *
+ * Once all problematic cases have been converted in this manner, this
+ * `bindAllMethods` hack can and TODO should be deleted. However, we currently
+ * have no reliable static way to track down and fix all autobinding sites.
+ * For those objects that have not yet been fully repaired by the above two
+ * techniques, `bindAllMethods` creates an object that acts much like the
+ * pre-#5970 objects, with all their methods as instance-bound own properties.
+ * It does this by making a new object inheriting from `obj` where the new
+ * object has bound own methods overridding all the methods it would have
+ * inherited from `obj`.
+ *
+ * @param {Remotable} obj
+ * @returns {Remotable}
+ */
+export const bindAllMethods = obj =>
+  harden(
+    create(
+      obj,
+      fromEntries(
+        getMethodNames(obj).map(name => [
+          name,
+          {
+            value: (...args) => apply(obj[name], obj, args),
+          },
+        ]),
+      ),
+    ),
+  );
+harden(bindAllMethods);

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -26,7 +26,7 @@ export const makeExitObj = (proposal, zcfSeat) => {
     // data) and presences (local proxies for objects that may have
     // methods).
     return Far('exitObj', {
-      exit: zcfSeat.exit,
+      exit: () => zcfSeat.exit(),
     });
   }
 
@@ -36,7 +36,7 @@ export const makeExitObj = (proposal, zcfSeat) => {
       .setWakeup(
         exit.afterDeadline.deadline,
         Far('wakeObj', {
-          wake: zcfSeat.exit,
+          wake: () => zcfSeat.exit(),
         }),
       )
       .catch(reason => {

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -378,7 +378,7 @@ const start = async zcf => {
     return AmountMath.make(brandIn, outputValue);
   };
 
-  const getPoolAllocation = poolSeat.getCurrentAllocation;
+  const getPoolAllocation = () => poolSeat.getCurrentAllocation();
 
   /** @type {AutoswapPublicFacet} */
   const publicFacet = Far('publicFacet', {

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -92,7 +92,7 @@ const makeZoeKit = (
   } = makeZoeStorageManager(
     createZCFVat,
     getBundleCapForID,
-    feeMint.getFeeIssuerKit,
+    feeMintAccess => feeMint.getFeeIssuerKit(feeMintAccess),
     shutdownZoeVat,
     feeMint.getFeeIssuer(),
     feeMint.getFeeBrand(),

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -60,7 +60,7 @@ test('zoe - atomicSwap', async t => {
       collectPayouts: async seat => {
         await E(seat)
           .getPayout('Asset')
-          .then(moolaPurse.deposit)
+          .then(payment => moolaPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -71,7 +71,7 @@ test('zoe - atomicSwap', async t => {
 
         await E(seat)
           .getPayout('Price')
-          .then(simoleanPurse.deposit)
+          .then(payment => simoleanPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -127,7 +127,7 @@ test('zoe - atomicSwap', async t => {
 
         const r1 = E(seat)
           .getPayout('Asset')
-          .then(moolaPurse.deposit)
+          .then(payment => moolaPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -138,7 +138,7 @@ test('zoe - atomicSwap', async t => {
 
         const r2 = E(seat)
           .getPayout('Price')
-          .then(simoleanPurse.deposit)
+          .then(payment => simoleanPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -218,7 +218,7 @@ test('zoe - non-fungible atomicSwap', async t => {
 
         seat
           .getPayout('Asset')
-          .then(ccPurse.deposit)
+          .then(payment => ccPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -229,7 +229,7 @@ test('zoe - non-fungible atomicSwap', async t => {
 
         seat
           .getPayout('Price')
-          .then(rpgPurse.deposit)
+          .then(payment => rpgPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -292,7 +292,7 @@ test('zoe - non-fungible atomicSwap', async t => {
 
         await seat
           .getPayout('Asset')
-          .then(ccPurse.deposit)
+          .then(payment => ccPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -303,7 +303,7 @@ test('zoe - non-fungible atomicSwap', async t => {
 
         await seat
           .getPayout('Price')
-          .then(rpgPurse.deposit)
+          .then(payment => rpgPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,

--- a/packages/zoe/test/unitTests/contracts/test-auction.js
+++ b/packages/zoe/test/unitTests/contracts/test-auction.js
@@ -64,7 +64,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       collectPayout: async seat => {
         await E(seat)
           .getPayout('Asset')
-          .then(moolaPurse.deposit)
+          .then(payment => moolaPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -75,7 +75,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
 
         await E(seat)
           .getPayout('Ask')
-          .then(simoleanPurse.deposit)
+          .then(payment => simoleanPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -140,14 +140,14 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       collectPayout: async seat => {
         await E(seat)
           .getPayout('Asset')
-          .then(moolaPurse.deposit)
+          .then(payment => moolaPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(amountDeposited, moola(1n), `Bob wins the auction`),
           );
 
         await E(seat)
           .getPayout('Bid')
-          .then(simoleanPurse.deposit)
+          .then(payment => simoleanPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -184,14 +184,14 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       collectPayout: async seat => {
         await E(seat)
           .getPayout('Asset')
-          .then(moolaPurse.deposit)
+          .then(payment => moolaPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(amountDeposited, moola(0n), `didn't win the auction`),
           );
 
         await E(seat)
           .getPayout('Bid')
-          .then(simoleanPurse.deposit)
+          .then(payment => simoleanPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(amountDeposited, bidAmount, `full refund`),
           );
@@ -869,7 +869,7 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
       collectPayout: async seat => {
         await E(seat)
           .getPayout('Asset')
-          .then(moolaPurse.deposit)
+          .then(payment => moolaPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -880,7 +880,7 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
 
         await E(seat)
           .getPayout('Ask')
-          .then(simoleanPurse.deposit)
+          .then(payment => simoleanPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -945,14 +945,14 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
       collectPayout: async seat => {
         await E(seat)
           .getPayout('Asset')
-          .then(moolaPurse.deposit)
+          .then(payment => moolaPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(amountDeposited, moola(1n), `Bob wins the auction`),
           );
 
         await E(seat)
           .getPayout('Bid')
-          .then(simoleanPurse.deposit)
+          .then(payment => simoleanPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -989,14 +989,14 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
       collectPayout: async seat => {
         await E(seat)
           .getPayout('Asset')
-          .then(moolaPurse.deposit)
+          .then(payment => moolaPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(amountDeposited, moola(0n), `didn't win the auction`),
           );
 
         await E(seat)
           .getPayout('Bid')
-          .then(simoleanPurse.deposit)
+          .then(payment => simoleanPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(amountDeposited, bidAmount, `full refund`),
           );

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -79,7 +79,7 @@ test('zoe - coveredCall', async t => {
       processPayouts: async seat => {
         await E(seat)
           .getPayout('Moola')
-          .then(moolaPurse.deposit)
+          .then(payment => moolaPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -90,7 +90,7 @@ test('zoe - coveredCall', async t => {
 
         await E(seat)
           .getPayout('Simoleans')
-          .then(simoleanPurse.deposit)
+          .then(payment => simoleanPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -101,7 +101,7 @@ test('zoe - coveredCall', async t => {
 
         await E(seat)
           .getPayout('Bucks')
-          .then(bucksPurse.deposit)
+          .then(payment => bucksPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -169,14 +169,14 @@ test('zoe - coveredCall', async t => {
       processPayouts: async seat => {
         await E(seat)
           .getPayout('UnderlyingAsset')
-          .then(moolaPurse.deposit)
+          .then(payment => moolaPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(amountDeposited, moola(3n), `Bob got what he wanted`),
           );
 
         await E(seat)
           .getPayout('StrikePrice1')
-          .then(simoleanPurse.deposit)
+          .then(payment => simoleanPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
@@ -187,7 +187,7 @@ test('zoe - coveredCall', async t => {
 
         await E(seat)
           .getPayout('StrikePrice2')
-          .then(bucksPurse.deposit)
+          .then(payment => bucksPurse.deposit(payment))
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -8,6 +8,7 @@ import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { passStyleOf, Far } from '@endo/marshal';
+import { getMethodNames } from '@agoric/store';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@endo/bundle-source';
@@ -110,7 +111,7 @@ test(`E(zoe).startInstance no issuerKeywordRecord, no terms`, async t => {
   isEmptyFacet(t, result.creatorFacet);
   t.deepEqual(result.creatorInvitation, undefined);
   facetHasMethods(t, result.publicFacet, ['makeInvitation']);
-  t.deepEqual(Object.getOwnPropertyNames(result.adminFacet).sort(), [
+  t.deepEqual(getMethodNames(result.adminFacet), [
     'getVatShutdownPromise',
     'restartContract',
     'upgradeContract',
@@ -137,7 +138,7 @@ test(`E(zoe).startInstance promise for installation`, async t => {
   isEmptyFacet(t, result.creatorFacet);
   t.deepEqual(result.creatorInvitation, undefined);
   facetHasMethods(t, result.publicFacet, ['makeInvitation']);
-  t.deepEqual(Object.getOwnPropertyNames(result.adminFacet).sort(), [
+  t.deepEqual(getMethodNames(result.adminFacet), [
     'getVatShutdownPromise',
     'restartContract',
     'upgradeContract',

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -5,6 +5,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { Far } from '@endo/marshal';
 import { AssetKind, AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
+import { getMethodNames } from '@agoric/store';
 import { makeOffer } from '../makeOffer.js';
 
 import { setup } from '../setupBasicMints.js';
@@ -712,7 +713,7 @@ test(`zcfSeat from zcf.makeEmptySeatKit - only these properties exist`, async t 
   const { zcf } = await setupZCFTest();
   const makeZCFSeat = () => zcf.makeEmptySeatKit().zcfSeat;
   const seat = makeZCFSeat();
-  t.deepEqual(Object.getOwnPropertyNames(seat).sort(), expectedMethods.sort());
+  t.deepEqual(getMethodNames(seat), expectedMethods.sort());
 });
 
 test(`zcfSeat.getProposal from zcf.makeEmptySeatKit`, async t => {


### PR DESCRIPTION
#5970 changes the representation of virtual and durable objects to be more class-like. This breaks autobinding (see explanation there), requiring us bind extracted methods to their receiver. Also, the methods of an object are no longer necessarily own properties. Rather, gathering all the methods requires us to ascend the inheritance chain.

This PR extracts those repairs into a prior PR that should work both before and after #5970 . Separated the PRs makes both more reviewable.