### PR TITLE
improve static typing of contract start terms

### DIFF
--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -143,6 +143,7 @@ const start = async (zcf, privateArgs) => {
   } = await E(zoe).startInstance(
     governedContractInstallation,
     governedIssuerKeywordRecord,
+    // @ts-expect-error XXX governance types
     augmentedTerms,
     privateArgs.governed,
   );

--- a/packages/governance/test/unitTests/test-committee.js
+++ b/packages/governance/test/unitTests/test-committee.js
@@ -41,7 +41,6 @@ const setupContract = async () => {
   /** @typedef {Installation<import('../../src/committee.js').start>} CommitteInstallation */
   /** @typedef {Installation<import('../../src/binaryVoteCounter.js').start>} CounterInstallation */
   /** @type {[CommitteInstallation, CounterInstallation] } */
-  // @ts-expect-error cast
   const [electorateInstallation, counterInstallation] = await Promise.all([
     E(zoe).install(electorateBundle),
     E(zoe).install(counterBundle),

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -1,10 +1,9 @@
 // @ts-check
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
+import { deeplyFulfilledObject } from '@agoric/internal';
 import { Stable } from '@agoric/vats/src/tokens.js';
 import { E } from '@endo/far';
-import { deeplyFulfilled } from '@endo/marshal';
-
 import { reserveThenGetNames } from './utils.js';
 
 export * from './startPSM.js';
@@ -218,7 +217,7 @@ export const registerScaledPriceAuthority = async (
     runBrand,
   );
 
-  const terms = await deeplyFulfilled(
+  const terms = await deeplyFulfilledObject(
     harden({
       sourcePriceAuthority,
       scaleIn,

--- a/packages/inter-protocol/src/proposals/committee-proposal.js
+++ b/packages/inter-protocol/src/proposals/committee-proposal.js
@@ -1,6 +1,6 @@
 // @ts-check
+import { deeplyFulfilledObject } from '@agoric/internal';
 import { E } from '@endo/far';
-import { deeplyFulfilled } from '@endo/marshal';
 import { reserveThenDeposit } from './utils.js';
 
 const { values } = Object;
@@ -34,7 +34,7 @@ export const inviteCommitteeMembers = async (
     E(agoricNames).lookup('installation', 'econCommitteeCharter'),
     counterP,
   ]);
-  const terms = await deeplyFulfilled(
+  const terms = await deeplyFulfilledObject(
     harden({
       binaryVoteCounterInstallation: counterInstall,
     }),

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -182,6 +182,7 @@ export const startInterchainPool = async (
     { Central: centralIssuer },
     terms,
     {
+      // @ts-expect-error XXX remotable types
       bankManager,
     },
   );

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -13,7 +13,7 @@ import {
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E, Far } from '@endo/far';
 import { Stable, Stake } from '@agoric/vats/src/tokens.js';
-import { deeplyFulfilled } from '@endo/marshal';
+import { deeplyFulfilledObject } from '@agoric/internal';
 import * as Collect from '../collect.js';
 import { makeTracer } from '../makeTracer.js';
 import { makeStakeReporter } from '../my-lien.js';
@@ -171,7 +171,7 @@ export const startInterchainPool = async (
     mgrP,
   ]);
 
-  const terms = await deeplyFulfilled(
+  const terms = await deeplyFulfilledObject(
     harden({
       minimumCentral: AmountMath.make(centralBrand, minimumCentral),
       amm,
@@ -248,7 +248,7 @@ export const setupAmm = async (
   );
   const marshaller = await E(board).getPublishingMarshaller();
 
-  const ammGovernorTerms = await deeplyFulfilled(
+  const ammGovernorTerms = await deeplyFulfilledObject(
     harden({
       timer: chainTimerService,
       electorateInstance,
@@ -344,7 +344,7 @@ export const setupReserve = async ({
   const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
   const marshaller = await E(board).getReadonlyMarshaller();
 
-  const reserveGovernorTerms = await deeplyFulfilled(
+  const reserveGovernorTerms = await deeplyFulfilledObject(
     harden({
       timer: chainTimerService,
       electorateInstance,
@@ -487,7 +487,7 @@ export const startVaultFactory = async (
     },
   );
 
-  const governorTerms = await deeplyFulfilled(
+  const governorTerms = await deeplyFulfilledObject(
     harden({
       timer: chainTimerService,
       electorateInstance: economicCommitteeInstance,
@@ -688,7 +688,7 @@ export const startRewardDistributor = async ({
 }) => {
   trace('startRewardDistributor');
   const timerService = await chainTimerService;
-  const feeDistributorTerms = await deeplyFulfilled(
+  const feeDistributorTerms = await deeplyFulfilledObject(
     harden({
       timerService,
       collectionInterval: 60n * 60n, // 1 hour
@@ -879,7 +879,7 @@ export const startStakeFactory = async (
   const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
   const marshaller = await E(board).getReadonlyMarshaller();
 
-  const stakeTerms = await deeplyFulfilled(
+  const stakeTerms = await deeplyFulfilledObject(
     harden({
       timer: chainTimerService,
       electorateInstance,

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -4,7 +4,7 @@ import {
   makeStorageNodeChild,
   assertPathSegment,
 } from '@agoric/vats/src/lib-chainStorage.js';
-import { deeplyFulfilled } from '@endo/marshal';
+import { deeplyFulfilledObject } from '@agoric/internal';
 
 import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
 import { reserveThenDeposit, reserveThenGetNames } from './utils.js';
@@ -118,7 +118,7 @@ export const createPriceFeed = async (
 
   const unitAmountIn = await unitAmount(brandIn);
   /** @type {import('@agoric/zoe/src/contracts/priceAggregator.js').PriceAggregatorContract['terms']} */
-  const terms = await deeplyFulfilled(
+  const terms = await deeplyFulfilledObject(
     harden({
       ...contractTerms,
       description: AGORIC_INSTANCE_NAME,

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -104,7 +104,7 @@ export const createPriceFeed = async (
   /**
    * Values come from economy-template.json, which at this writing had IN:ATOM, OUT:USD
    *
-   * @type {[[Brand, Brand], [Installation]]}
+   * @type {[[Brand, Brand], [Installation<import('@agoric/zoe/src/contracts/priceAggregator.js').start>]]}
    */
   const [[brandIn, brandOut], [priceAggregator]] = await Promise.all([
     reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('oracleBrand'), [
@@ -128,6 +128,7 @@ export const createPriceFeed = async (
       unitAmountIn,
     }),
   );
+  terms.absent;
 
   const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
   const marshaller = E(board).getReadonlyMarshaller();

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -6,7 +6,7 @@ import { makeStorageNodeChild } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/far';
 import { Stable } from '@agoric/vats/src/tokens.js';
-import { deeplyFulfilled } from '@endo/marshal';
+import { deeplyFulfilledObject } from '@agoric/internal';
 import { reserveThenGetNamePaths } from './utils.js';
 
 const BASIS_POINTS = 10000n;
@@ -78,7 +78,7 @@ export const startPSM = async (
     ]);
 
   const mintLimit = AmountMath.make(anchorBrand, MINT_LIMIT);
-  const terms = await deeplyFulfilled(
+  const terms = await deeplyFulfilledObject(
     harden({
       anchorBrand,
       anchorPerStable: makeRatio(100n, anchorBrand, 100n, stable),
@@ -111,7 +111,7 @@ export const startPSM = async (
 
   const marshaller = await E(board).getPublishingMarshaller();
 
-  const governorTerms = await deeplyFulfilled(
+  const governorTerms = await deeplyFulfilledObject(
     harden({
       timer: chainTimerService,
       economicCommittee,
@@ -186,7 +186,7 @@ export const makeAnchorAsset = async (
   );
 
   /** @type {import('@agoric/vats/src/mintHolder.js').AssetTerms} */
-  const terms = await deeplyFulfilled(
+  const terms = await deeplyFulfilledObject(
     harden({
       keyword,
       assetKind: AssetKind.NAT,

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -185,7 +185,6 @@ export const makeAnchorAsset = async (
     X`anchorOptions.denom must be a string, not ${denom}`,
   );
 
-  /** @type {import('@agoric/vats/src/mintHolder.js').AssetTerms} */
   const terms = await deeplyFulfilledObject(
     harden({
       keyword,

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -141,7 +141,7 @@ export const makeVoterTool = async (
 /**
  * @param {bigint} value
  * @param {{
- *   centralSupply: ERef<Installation>,
+ *   centralSupply: ERef<Installation<import('@agoric/vats/src/centralSupply.js').start>>,
  *   feeMintAccess: ERef<FeeMintAccess>,
  *   zoe: ERef<ZoeService>,
  * }} powers

--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -66,6 +66,8 @@ const makeTestContext = async () => {
     bundleCache.load(src, dest).then(b => E(zoe).install(b));
   const installation = {
     mintHolder: install(contractRoots.mintHolder, 'mintHolder'),
+    /** @type {Installation<import('@agoric/vats/src/centralSupply.js').start>} */
+    // @ts-expect-error cast
     centralSupply: E(zoe).install(centralSupplyBundle),
     econCommitteeCharter: install(
       contractRoots.econCommitteeCharter,

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@endo/eventual-send": "^0.15.5",
+    "@endo/marshal": "^0.6.9",
     "@endo/promise-kit": "^0.2.43"
   },
   "devDependencies": {

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { E } from '@endo/eventual-send';
+import { deeplyFulfilled, isObject } from '@endo/marshal';
 import { isPromise } from '@endo/promise-kit';
 
 /** @typedef {import('@endo/marshal/src/types').Remotable} Remotable */
@@ -178,3 +179,28 @@ export const bindAllMethods = obj =>
     ),
   );
 harden(bindAllMethods);
+
+/**
+ * @template {{}} T
+ * @typedef {{ [K in keyof T]: DeeplyAwaited<T[K]> }} DeeplyAwaitedObject
+ */
+
+/**
+ * Caveats:
+ * - doesn't recur within Promise results
+ * - resulting type has wrapper in its name
+ *
+ * @template T
+ * @typedef {T extends PromiseLike ? Awaited<T> : T extends {} ? DeeplyAwaitedObject<T> : Awaited<T>} DeeplyAwaited
+ */
+
+/**
+ * A more constrained version of {deeplyFulfilled} for type safety until https://github.com/endojs/endo/issues/1257
+ * Useful in starting contracts that need all terms to be fulfilled in order to be durable.
+ *
+ * @type {<T extends {}>(unfulfilledTerms: T) => DeeplyAwaited<T>}
+ */
+export const deeplyFulfilledObject = obj => {
+  assert(isObject(obj), 'param must be an object');
+  return deeplyFulfilled(obj);
+};

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -1,2 +1,3 @@
+/// <reference types="ses"/>
 export * from './vat-data-bindings.js';
 export * from './kind-utils.js';

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -22,7 +22,6 @@ export const ignoreContext =
   fn =>
   (context, ...args) =>
     fn(...args);
-// @ts-expect-error TODO statically recognize harden
 harden(ignoreContext);
 
 /**
@@ -32,7 +31,6 @@ harden(ignoreContext);
  */
 export const provideKindHandle = (baggage, kindName) =>
   provide(baggage, `${kindName}_kindHandle`, () => makeKindHandle(kindName));
-// @ts-expect-error TODO statically recognize harden
 harden(provideKindHandle);
 
 /** @type {import('./types.js').VivifyKind} */
@@ -49,7 +47,6 @@ export const vivifyKind = (
     behavior,
     options,
   );
-// @ts-expect-error TODO statically recognize harden
 harden(vivifyKind);
 
 /** @type {import('./types.js').VivifyKindMulti} */
@@ -66,7 +63,6 @@ export const vivifyKindMulti = (
     behavior,
     options,
   );
-// @ts-expect-error TODO statically recognize harden
 harden(vivifyKindMulti);
 
 /**
@@ -94,5 +90,4 @@ export const vivifySingleton = (
 
   return provide(baggage, `the_${kindName}`, () => makeSingleton());
 };
-// @ts-expect-error TODO statically recognize harden
 harden(vivifySingleton);

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -74,7 +74,6 @@ export const pickFacet =
   (maker, facetName) =>
   (...args) =>
     maker(...args)[facetName];
-// @ts-expect-error TODO statically recognize harden
 harden(pickFacet);
 
 /**
@@ -88,22 +87,18 @@ harden(pickFacet);
 export const partialAssign = (target, source) => {
   Object.assign(target, source);
 };
-// @ts-expect-error TODO statically recognize harden
 harden(partialAssign);
 
 export const provideDurableMapStore = (baggage, name) =>
   provide(baggage, name, () => makeScalarBigMapStore(name, { durable: true }));
-// @ts-expect-error TODO statically recognize harden
 harden(provideDurableMapStore);
 
 export const provideDurableWeakMapStore = (baggage, name) =>
   provide(baggage, name, () =>
     makeScalarBigWeakMapStore(name, { durable: true }),
   );
-// @ts-expect-error TODO statically recognize harden
 harden(provideDurableWeakMapStore);
 
 export const provideDurableSetStore = (baggage, name) =>
   provide(baggage, name, () => makeScalarBigSetStore(name, { durable: true }));
-// @ts-expect-error TODO statically recognize harden
 harden(provideDurableSetStore);

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@agoric/assert": "^0.4.0",
     "@agoric/ertp": "^0.14.2",
+    "@agoric/internal": "^0.1.0",
     "@agoric/governance": "^0.7.0",
     "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.4.0",

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -5,8 +5,8 @@ import { Nat } from '@agoric/nat';
 import { makeScalarMapStore } from '@agoric/store';
 import { provide } from '@agoric/store/src/stores/store-utils.js';
 import { E, Far } from '@endo/far';
-import { deeplyFulfilled } from '@endo/marshal';
 
+import { deeplyFulfilledObject } from '@agoric/internal';
 import { makeStorageNodeChild } from '../lib-chainStorage.js';
 import { makeNameHubKit } from '../nameHub.js';
 import { feeIssuerConfig } from './utils.js';
@@ -244,7 +244,7 @@ export const makeClientBanks = async ({
     bridgeManagerP,
   ]);
 
-  const terms = await deeplyFulfilled(
+  const terms = await deeplyFulfilledObject(
     harden({
       agoricNames,
       namesByAddress,

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -254,6 +254,7 @@ export const makeClientBanks = async ({
   const { creatorFacet } = await E(zoe).startInstance(
     walletFactory,
     {},
+    // @ts-expect-error FIXME 'board' types don't match
     terms,
     { storageNode, bridgeManager },
   );

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -371,7 +371,6 @@ export const addBankAssets = async ({
   const runKit = { issuer: runIssuer, brand: runBrand, payment };
 
   /** @type {{ creatorFacet: ERef<Mint>, publicFacet: ERef<Issuer> }} */
-  // @ts-expect-error cast
   const { creatorFacet: bldMint, publicFacet: bldIssuer } = E.get(
     E(zoe).startInstance(
       mintHolder,

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -172,6 +172,7 @@
  *   installation:{
  *     produce: Record<WellKnownName['installation'], Producer<Installation>>,
  *     consume: Record<WellKnownName['installation'], Promise<Installation<unknown>>> & {
+ *       interchainPool: Promise<Installation<import('@agoric/inter-protocol/src/interchainPool.js').start>>,
  *       mintHolder: Promise<Installation<import('@agoric/vats/src/mintHolder.js').start>>,
  *       singleWallet: Promise<Installation<import('@agoric/smart-wallet/src/singleWallet.js').start>>,
  *       walletFactory: Promise<Installation<import('@agoric/smart-wallet/src/walletFactory.js').start>>,

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -172,6 +172,7 @@
  *   installation:{
  *     produce: Record<WellKnownName['installation'], Producer<Installation>>,
  *     consume: Record<WellKnownName['installation'], Promise<Installation<unknown>>> & {
+ *       mintHolder: Promise<Installation<import('@agoric/vats/src/mintHolder.js').start>>,
  *       singleWallet: Promise<Installation<import('@agoric/smart-wallet/src/singleWallet.js').start>>,
  *       walletFactory: Promise<Installation<import('@agoric/smart-wallet/src/walletFactory.js').start>>,
  *     },

--- a/packages/vats/src/mintHolder.js
+++ b/packages/vats/src/mintHolder.js
@@ -8,13 +8,12 @@ import { makeIssuerKit } from '@agoric/ertp';
  * makeIssuerKit in its own contract, and hence in
  * its own vat.
  *
- * @typedef {{
+ * @template {AssetKind} K
+ * @param {ZCF<{
  *   keyword: string,
- *   assetKind: AssetKind,
+ *   assetKind: K,
  *   displayInfo: DisplayInfo,
- * }} AssetTerms
- *
- * @type {ContractStartFn<Issuer, Mint, AssetTerms>}
+ * }>} zcf
  */
 export const start = zcf => {
   const { keyword, assetKind, displayInfo } = zcf.getTerms();

--- a/packages/vats/test/test-bootstrapPayment.js
+++ b/packages/vats/test/test-bootstrapPayment.js
@@ -40,7 +40,7 @@ const setUpZoeForTest = setJig => {
  *   feeMintAccess: FeeMintAccess,
  *   issuer: Record<'IST', Issuer>,
  *   brand: Record<'IST', Brand>,
- *   installation: Record<'centralSupply', Installation<import('../src/centralSupply.js').CentralSupplyContract>>,
+ *   installation: Record<'centralSupply', Installation<import('../src/centralSupply.js').start>>,
  * }>} CentralSupplyTestContext
  */
 

--- a/packages/wallet/contract/src/singleWallet.js
+++ b/packages/wallet/contract/src/singleWallet.js
@@ -15,11 +15,11 @@ const { assign, entries, keys, fromEntries } = Object;
 
 /**
  * @typedef {{
- *   agoricNames: NameHub,
- *   bank: import('@agoric/vats/src/vat-bank').Bank,
- *   board: Board,
+ *   agoricNames: ERef<NameHub>,
+ *   bank: ERef<import('@agoric/vats/src/vat-bank').Bank>,
+ *   board: ERef<Board>,
  *   myAddressNameAdmin: ERef<MyAddressNameAdmin>,
- *   namesByAddress: NameHub,
+ *   namesByAddress: ERef<NameHub>,
  * }} SmartWalletContractTerms
  */
 

--- a/packages/wallet/contract/src/smartWallet.js
+++ b/packages/wallet/contract/src/smartWallet.js
@@ -16,9 +16,9 @@ const { assign, entries, keys, fromEntries } = Object;
  * myAddressNameAdmin: ERef<MyAddressNameAdmin>,
  * }} unique
  * @param {{
- * agoricNames: NameHub,
- * board: Board
- * namesByAddress: NameHub,
+ * agoricNames: ERef<NameHub>,
+ * board: ERef<Board>,
+ * namesByAddress: ERef<NameHub>,
  * storageNode: ERef<StorageNode>,
  * zoe: ERef<ZoeService>,
  * }} shared

--- a/packages/wallet/contract/src/walletFactory.js
+++ b/packages/wallet/contract/src/walletFactory.js
@@ -16,9 +16,9 @@ import { makeSmartWallet } from './smartWallet.js';
 
 /**
  * @typedef {{
- *   agoricNames: NameHub,
- *   board: Board,
- *   namesByAddress: NameHub,
+ *   agoricNames: ERef<NameHub>,
+ *   board: ERef<Board>,
+ *   namesByAddress: ERef<NameHub>,
  * }} SmartWalletContractTerms
  *
  * @typedef {{

--- a/packages/wallet/contract/test/test-singleWallet.js
+++ b/packages/wallet/contract/test/test-singleWallet.js
@@ -53,7 +53,6 @@ const makeTestContext = async t => {
     'singleWallet',
   );
   /** @type {Promise<Installation<import('../src/singleWallet.js').start>>} */
-  // @ts-expect-error cast
   const installation = E(zoe).install(bundle);
   // #endregion
 

--- a/packages/wallet/contract/test/test-walletFactory.js
+++ b/packages/wallet/contract/test/test-walletFactory.js
@@ -54,7 +54,6 @@ const makeTestContext = async t => {
     'walletFactory',
   );
   /** @type {Promise<Installation<import('../src/walletFactory.js').start>>} */
-  // @ts-expect-error case
   const installation = E(zoe).install(bundle);
   // #endregion
 
@@ -63,7 +62,6 @@ const makeTestContext = async t => {
     consume.chainStorage,
     'wallet',
   );
-  const marshaller = E(consume.board).getPublishingMarshaller();
 
   const walletFactory = E(zoe).startInstance(
     installation,
@@ -73,7 +71,7 @@ const makeTestContext = async t => {
       namesByAddress: consume.namesByAddress,
       board: consume.board,
     },
-    { storageNode, marshaller },
+    { storageNode },
   );
 
   return {

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -289,8 +289,8 @@
  */
 
 /**
- * @template [C=unknown] contract
- * @typedef {import('./utils').Installation<C>} Installation
+ * @template [SF=any] contract start function
+ * @typedef {import('./utils').Installation<SF>} Installation
  */
 
 /**


### PR DESCRIPTION
## Description

Work around https://github.com/endojs/endo/issues/1257 by defining a local `deeplyFulfilledObject`.

Use it in contract starts to restore type safety (see https://github.com/Agoric/agoric-sdk/pull/5930#issuecomment-1218565035 )


### Security Considerations

--

### Documentation Considerations

This may not be something we want to include in the API backwards compatibility. Once Endo has better type annotations this won't be necessary.

### Testing Considerations

No change in code. Tested types manually:
<img width="499" alt="Screen Shot 2022-08-18 at 7 32 33 AM" src="https://user-images.githubusercontent.com/21505/185421269-6973e5e1-4376-42b6-9377-bd7c2050e329.png">
<img width="710" alt="Screen Shot 2022-08-18 at 7 47 15 AM" src="https://user-images.githubusercontent.com/21505/185424705-13e8dc4d-3d91-4f6a-8650-971162aba56e.png">

