### PR TITLE
make Zoe durable

### DIFF
--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -139,6 +139,13 @@ export const DisplayInfoShape = M.splitRecord(
   },
 );
 
+export const IssuerKitShape = harden({
+  brand: BrandShape,
+  mint: MintShape,
+  issuer: IssuerShape,
+  displayInfo: DisplayInfoShape,
+});
+
 // //////////////////////// Interfaces /////////////////////////////////////////
 
 export const BrandI = M.interface('Brand', {

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -196,6 +196,7 @@ const makeParamManagerBuilder = (publisherKit, zoe) => {
       throw Fail`zoe must be provided for governed Invitations ${zoe}`;
     }
     const { instance, installation } = await E(zoe).getInvitationDetails(i);
+    // @ts-expect-error typescript thinks they're guaranteed True. I'm not sure.
     assert(instance && installation, 'must be an invitation');
   };
 

--- a/packages/governance/src/typeGuards.js
+++ b/packages/governance/src/typeGuards.js
@@ -5,6 +5,7 @@ import {
   TimerShape,
   makeHandleShape,
 } from '@agoric/zoe/src/typeGuards.js';
+import { SubscriberShape } from '@agoric/notifier';
 
 export const ChoiceMethodShape = M.or('unranked', 'order', 'plurality');
 export const QuorumRuleShape = M.or('majority', 'no_quorum', 'all');
@@ -167,7 +168,6 @@ export const PositionShape = M.or(
 export const QuestionHandleShape = makeHandleShape('question');
 
 // TODO(hibbert): add details; move to a more appropriate location
-export const SubscriberShape = M.remotable('Subscriber');
 export const InvitationShape = M.remotable('Invitation');
 
 // XXX I want to add questionHandle and counterInstance to

--- a/packages/governance/test/unitTests/test-binaryballotCount.js
+++ b/packages/governance/test/unitTests/test-binaryballotCount.js
@@ -24,6 +24,8 @@ const SIMPLE_ISSUE = harden({ text: 'Fish or cut bait?' });
 const FISH = harden({ text: 'Fish' });
 const BAIT = harden({ text: 'Cut Bait' });
 
+/** @type {PARAM_CHANGE_ISSUE} */
+// @ts-expect-error cast
 const PARAM_ISSUE = harden({
   spec: {
     paramPath: { key: 'something' },
@@ -272,7 +274,6 @@ test('binary varying share weights', async t => {
 test('binary contested', async t => {
   const questionSpec = coerceQuestionSpec({
     method: ChoiceMethod.UNRANKED,
-    // @ts-expect-error I dunno what's confusing it.
     issue: PARAM_ISSUE,
     positions: [positive, negative],
     electionType: ElectionType.PARAM_CHANGE,

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -240,6 +240,7 @@ test('change multiple params', async t => {
   const update1 = await notifier.getUpdateSince();
   // constructing the fixture to deepEqual would complicate this with insufficient benefit
   t.is(
+    // @ts-expect-error reaching into unknown values
     update1.value.current.Electorate.value.value[0].description,
     'questionPoser',
   );

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -44,15 +44,14 @@ const setUpZoeForTest = async setJig => {
    * @property {IssuerRecord} mintedIssuerRecord
    * @property {IssuerRecord} govIssuerRecord
    */
-  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
+  const { zoeService, feeMintAccessRetriever } = makeZoeKit(
     makeFakeVatAdmin(setJig, o => makeFar(o)).admin,
   );
   /** @type {ERef<ZoeService>} */
   const zoe = makeFar(zoeService);
-  const feeMintAccess = await makeFar(nonFarFeeMintAccess);
   return {
     zoe,
-    feeMintAccess,
+    feeMintAccessP: feeMintAccessRetriever.get(),
   };
 };
 
@@ -241,7 +240,6 @@ test('change multiple params', async t => {
   const update1 = await notifier.getUpdateSince();
   // constructing the fixture to deepEqual would complicate this with insufficient benefit
   t.is(
-    // @ts-expect-error reaching into unknown values
     update1.value.current.Electorate.value.value[0].description,
     'questionPoser',
   );

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -81,7 +81,7 @@ export const start = async zcf => {
     return zcf.makeInvitation(voteOnOfferFilterHandler, 'vote on offer filter');
   };
 
-  const MakerShape = M.interface('Charter InvitationMakers', {
+  const MakerI = M.interface('Charter InvitationMakers', {
     VoteOnParamChange: M.call().returns(M.promise()),
     VoteOnPauseOffers: M.call(
       InstanceHandleShape,
@@ -91,7 +91,7 @@ export const start = async zcf => {
   });
   const invitationMakers = makeHeapFarInstance(
     'Charter Invitation Makers',
-    MakerShape,
+    MakerI,
     {
       VoteOnParamChange: makeParamInvitation,
       VoteOnPauseOffers: makeOfferFilterInvitation,

--- a/packages/inter-protocol/src/proposals/demoIssuers.js
+++ b/packages/inter-protocol/src/proposals/demoIssuers.js
@@ -323,7 +323,7 @@ export const connectFaucet = async ({
 
     const faucetPaymentInfo = userPaymentRecords.flat();
 
-    const userFeePurse = await E(zoe).makeFeePurse();
+    const userFeePurse = await E(E(zoe).getFeeIssuer()).makeEmptyPurse();
 
     const faucet = Far('faucet', {
       /**

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -222,7 +222,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   };
 
   /** @param {ZCFSeat} seat */
-  const wantmintedHook = seat => {
+  const wantMintedHook = seat => {
     const {
       give: { In: given },
       want: { Out: wanted } = { Out: undefined },
@@ -254,7 +254,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     },
     makeWantMintedInvitation() {
       return zcf.makeInvitation(
-        wantmintedHook,
+        wantMintedHook,
         'wantMinted',
         undefined,
         M.splitRecord({

--- a/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -265,10 +265,6 @@ const start = async zcf => {
       { stopAfter: debt },
     );
     await Promise.all([E(liqSeat).getOfferResult(), deposited]);
-
-    // This uses getCurrentAllocationJig only to support testing, so is ok
-    const amounts = await E(liqSeat).getCurrentAllocationJig();
-    trace('offerResult', { amounts });
   }
 
   /**

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
@@ -252,7 +252,7 @@ test('amm add and remove liquidity', async t => {
   };
   await tracker.assertChange(poolLiquidity);
 
-  const alloc = await E(addLiquiditySeat).getCurrentAllocationJig();
+  const alloc = await E(addLiquiditySeat).getFinalAllocation();
   t.deepEqual(alloc, {
     Central: central(0n),
     Liquidity: AmountMath.make(liquidityBrand, 1_499_999_000n),
@@ -493,7 +493,7 @@ test('add wrong liquidity', async t => {
     }),
   );
 
-  const alloc = await E(addLiquiditySeat).getCurrentAllocationJig();
+  const alloc = await E(addLiquiditySeat).getFinalAllocation();
   t.deepEqual(alloc, {
     Central: central(0n),
     Liquidity: AmountMath.make(liquidityBrand, 1_499_999_000n),

--- a/packages/inter-protocol/test/psm/test-governedPsm.js
+++ b/packages/inter-protocol/test/psm/test-governedPsm.js
@@ -195,6 +195,5 @@ test('replace electorate of Economic Committee', async t => {
   const pf = await E(governorCreatorFacet).getPublicFacet();
   const { Electorate: newElectorate } = await E(pf).getGovernedParams();
   t.is(newElectorate.type, 'invitation');
-  // @ts-expect-error unknonwn
   t.is(newElectorate.value.value[0].instance, secondElectorateInstance);
 });

--- a/packages/inter-protocol/test/psm/test-governedPsm.js
+++ b/packages/inter-protocol/test/psm/test-governedPsm.js
@@ -195,5 +195,6 @@ test('replace electorate of Economic Committee', async t => {
   const pf = await E(governorCreatorFacet).getPublicFacet();
   const { Electorate: newElectorate } = await E(pf).getGovernedParams();
   t.is(newElectorate.type, 'invitation');
+  // @ts-expect-error unknonwn
   t.is(newElectorate.value.value[0].instance, secondElectorateInstance);
 });

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -83,7 +83,8 @@ const minusAnchorFee = (anchor, anchorPerMinted) => {
 const makeTestContext = async () => {
   const bundleCache = await unsafeMakeBundleCache('bundles/');
   const psmBundle = await bundleCache.load(psmRoot, 'psm');
-  const { zoe, feeMintAccess } = setUpZoeForTest();
+  const { zoe, feeMintAccessP } = await setUpZoeForTest();
+  const feeMintAccess = await feeMintAccessP;
 
   const mintedIssuer = await E(zoe).getFeeIssuer();
   /** @type {IssuerKit<'nat'>} */
@@ -122,7 +123,7 @@ const makeTestContext = async () => {
   return {
     bundles: { psmBundle },
     zoe: await zoe,
-    feeMintAccess: await feeMintAccess,
+    feeMintAccess,
     initialPoserInvitation,
     minted,
     anchor,
@@ -244,7 +245,7 @@ async function makePsmDriver(t, customTerms) {
       );
       await E(collectFeesSeat).getOfferResult();
       const feePayoutAmount = await E.get(
-        E(collectFeesSeat).getCurrentAllocationJig(),
+        E(collectFeesSeat).getFinalAllocation(),
       ).Fee;
       return feePayoutAmount;
     },
@@ -258,6 +259,15 @@ async function makePsmDriver(t, customTerms) {
       return E(seat).getPayouts();
     },
     swapAnchorForMintedSeat,
+
+    /**
+     * @param {Amount<'nat'>} giveAnchor
+     * @param {Amount<'nat'>} [wantMinted]
+     */
+    async swapAnchorForMintedErrors(giveAnchor, wantMinted) {
+      const seat = swapAnchorForMintedSeat(giveAnchor, wantMinted);
+      return seat;
+    },
 
     /**
      * @param {Amount<'nat'>} giveRun
@@ -321,21 +331,18 @@ test('limit', async t => {
 
   trace('test going over limit');
   const give = anchor.make(MINT_LIMIT);
-  const paymentPs = await driver.swapAnchorForMinted(give);
-  trace('gone over limit');
+  const seat = await driver.swapAnchorForMintedErrors(give);
+  await t.throwsAsync(async () => E(seat).getOfferResult());
 
+  const paymentPs = await E(seat).getPayouts();
+  trace('gone over limit');
   // We should get 0 Minted  and all our anchor back
-  // TODO should this be expecteed to be an empty Out?
   t.falsy(paymentPs.Out);
-  // const actualRun = await E(runIssuer).getAmountOf(runPayout);
-  // t.deepEqual(actualRun, AmountMath.makeEmpty(runBrand));
   const anchorReturn = await paymentPs.In;
   const actualAnchor = await E(anchor.issuer).getAmountOf(anchorReturn);
   t.deepEqual(actualAnchor, give);
   // The pool should be unchanged
   driver.assertPoolBalance(initialPool);
-  // TODO Offer result should be an error
-  // t.throwsAsync(() => await E(seat1).getOfferResult());
 });
 
 test('limit is for minted', async t => {
@@ -635,7 +642,6 @@ test('wrong give wantMintedInvitation', async t => {
     installs: { centralSupply },
   } = t.context;
   const { publicFacet } = await makePsmDriver(t);
-  console.log('publicFacet', publicFacet);
   const istValue = scale6(100);
   const giveIST = AmountMath.make(minted.brand, istValue);
   const istPayment = await mintRunPayment(istValue, {
@@ -674,7 +680,7 @@ test('extra give wantMintedInvitation', async t => {
       ),
     {
       message:
-        '"wantMinted" proposal: give: {"Extra":{"brand":"[Alleged: aUSD brand]","value":"[200000000n]"},"In":{"brand":"[Seen]","value":"[200000000n]"}} - Must not have unexpected properties: ["Extra"]',
+        /"wantMinted" proposal: .* - Must not have unexpected properties: \["Extra"\]/,
     },
   );
 });

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -43,7 +43,7 @@ const setupReserveBootstrap = async (
     /** @type { import('../../src/proposals/econ-behaviors.js').EconomyBootstrapPowers } */ (
       ammSpaces.space
     );
-  const zoe = await farZoeKit.zoe;
+  const zoe = await E.get(farZoeKit).zoe;
 
   // @ts-expect-error could be undefined
   produce.chainTimerService.resolve(timer);
@@ -82,7 +82,7 @@ export const setupReserveServices = async (
   timer = buildManualTimer(t.log),
 ) => {
   const farZoeKit = await setUpZoeForTest();
-  const { feeMintAccess, zoe } = farZoeKit;
+  const { feeMintAccessP, zoe } = farZoeKit;
 
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
@@ -90,6 +90,7 @@ export const setupReserveServices = async (
   const spaces = await setupReserveBootstrap(
     t,
     timer,
+    // @ts-expect-error confusion about awaited return types
     farZoeKit,
     runIssuer,
     electorateTerms,
@@ -102,6 +103,7 @@ export const setupReserveServices = async (
   const faucetInstallation = E(zoe).install(faucetBundle);
   brand.produce.IST.resolve(runBrand);
   issuer.produce.IST.resolve(runIssuer);
+  const feeMintAccess = await feeMintAccessP;
   produce.feeMintAccess.resolve(await feeMintAccess);
 
   const governorCreatorFacet = E.get(consume.reserveKit).governorCreatorFacet;

--- a/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
+++ b/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
@@ -87,7 +87,7 @@ test.before(async t => {
   );
   console.timeEnd('bundling');
 
-  const { zoe, feeMintAccess } = await setUpZoeForTest(() => {});
+  const { zoe, feeMintAccessP } = await setUpZoeForTest(() => {});
   const bld = makeIssuerKit('BLD', AssetKind.NAT, micro.displayInfo);
   const issuer = {
     [Stable.symbol]: await E(zoe).getFeeIssuer(),
@@ -113,7 +113,7 @@ test.before(async t => {
   t.context = await deeplyFulfilled(
     harden({
       zoe,
-      feeMintAccess,
+      feeMintAccess: feeMintAccessP,
       issuer,
       brand,
       installation,

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -41,26 +41,20 @@ harden(provideBundle);
  * Returns promises for `zoe` and the `feeMintAccess`.
  *
  * @param {() => void} setJig
- * @returns {import('./amm/vpool-xyk-amm/setup.js').FarZoeKit}
  */
-export const setUpZoeForTest = (setJig = () => {}) => {
+export const setUpZoeForTest = async (setJig = () => {}) => {
   const { makeFar } = makeLoopback('zoeTest');
 
-  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
-    makeFakeVatAdmin(setJig).admin,
-    undefined,
-    {
+  const { zoeService, feeMintAccessRetriever } = await makeFar(
+    makeZoeKit(makeFakeVatAdmin(setJig).admin, undefined, {
       name: Stable.symbol,
       assetKind: Stable.assetKind,
       displayInfo: Stable.displayInfo,
-    },
+    }),
   );
-  /** @type {ERef<ZoeService>} */
-  const zoe = makeFar(zoeService);
-  const feeMintAccess = makeFar(nonFarFeeMintAccess);
   return {
-    zoe,
-    feeMintAccess,
+    zoe: zoeService,
+    feeMintAccessP: E(feeMintAccessRetriever).get(),
   };
 };
 harden(setUpZoeForTest);

--- a/packages/inter-protocol/test/swingsetTests/governance/bootstrap.js
+++ b/packages/inter-protocol/test/swingsetTests/governance/bootstrap.js
@@ -86,13 +86,16 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
     devices.vatAdmin,
   );
-  const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
+  const { zoe, feeMintAccessRetriever } = await E(vats.zoe).buildZoe(
+    vatAdminSvc,
+  );
 
   const installations = await installContracts(zoe, cb);
   const voterCreator = E(vats.voter).build(zoe);
 
   const [testName, startingValues] = argv;
 
+  const feeMintAccess = await E(feeMintAccessRetriever).get();
   const {
     aliceP,
     governor,

--- a/packages/inter-protocol/test/swingsetTests/governance/vat-zoe.js
+++ b/packages/inter-protocol/test/swingsetTests/governance/vat-zoe.js
@@ -8,7 +8,7 @@ export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe, feeMintAccess } = makeZoeKit(
+      const { zoeService: zoe, feeMintAccessRetriever } = makeZoeKit(
         vatAdminSvc,
         shutdownZoeVat,
         {
@@ -18,7 +18,7 @@ export function buildRootObject(vatPowers) {
         },
       );
 
-      return { zoe, feeMintAccess };
+      return { zoe, feeMintAccessRetriever };
     },
   });
 }

--- a/packages/inter-protocol/test/swingsetTests/vaultFactory/bootstrap.js
+++ b/packages/inter-protocol/test/swingsetTests/vaultFactory/bootstrap.js
@@ -7,11 +7,14 @@ function makeBootstrap(argv, cb, vatPowers) {
     const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
       devices.vatAdmin,
     );
-    const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
+    const { zoe, feeMintAccessRetriever } = await E(vats.zoe).buildZoe(
+      vatAdminSvc,
+    );
 
     const installations = await installContracts(zoe, cb);
 
     const [testName, startingValues] = argv;
+    const feeMintAccess = await E(feeMintAccessRetriever).get();
     const { aliceP, vaultFactory } = await makeVats(
       vatPowers.testLog,
       vats,

--- a/packages/inter-protocol/test/swingsetTests/vaultFactory/vat-zoe.js
+++ b/packages/inter-protocol/test/swingsetTests/vaultFactory/vat-zoe.js
@@ -8,7 +8,7 @@ export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe, feeMintAccess } = makeZoeKit(
+      const { zoeService: zoe, feeMintAccessRetriever } = makeZoeKit(
         vatAdminSvc,
         shutdownZoeVat,
         {
@@ -17,7 +17,7 @@ export function buildRootObject(vatPowers) {
           displayInfo: Stable.displayInfo,
         },
       );
-      return { zoe, feeMintAccess };
+      return { zoe, feeMintAccessRetriever };
     },
   });
 }

--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -57,7 +57,7 @@ let lastProposalSequence = 0;
 
 const makeTestContext = async () => {
   const bundleCache = await makeNodeBundleCache('bundles/', s => import(s));
-  const { zoe, feeMintAccess } = await setUpZoeForTest();
+  const { zoe, feeMintAccessP } = await setUpZoeForTest();
 
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
@@ -67,7 +67,6 @@ const makeTestContext = async () => {
   const installation = {
     mintHolder: install(contractRoots.mintHolder, 'mintHolder'),
     /** @type {Installation<import('@agoric/vats/src/centralSupply.js').start>} */
-    // @ts-expect-error cast
     centralSupply: E(zoe).install(centralSupplyBundle),
     econCommitteeCharter: install(
       contractRoots.econCommitteeCharter,
@@ -103,7 +102,7 @@ const makeTestContext = async () => {
     restoreBundleID,
     cleanups: [],
     zoe: await zoe,
-    feeMintAccess: await feeMintAccess,
+    feeMintAccess: await feeMintAccessP,
     run: { issuer: runIssuer, brand: runBrand },
     installation,
   };

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -96,7 +96,7 @@ const defaultParamValues = debt =>
  * @returns {Promise<DriverContext>}
  */
 export const makeDriverContext = async () => {
-  const { zoe, feeMintAccess } = setUpZoeForTest();
+  const { zoe, feeMintAccessP } = await setUpZoeForTest();
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
   // @ts-expect-error missing mint
@@ -117,6 +117,8 @@ export const makeDriverContext = async () => {
     reserve: bundleCache.load(contractRoots.reserve, 'reserve'),
   });
   const installation = objectMap(bundles, bundle => E(zoe).install(bundle));
+
+  const feeMintAccess = await feeMintAccessP;
   const contextPs = {
     bundles,
     installation,
@@ -497,7 +499,7 @@ export const makeManagerDriver = async (
       );
       currentOfferResult = await E(currentSeat).getOfferResult();
       if (expected) {
-        const payouts = await E(currentSeat).getCurrentAllocationJig();
+        const payouts = await E(currentSeat).getFinalAllocation();
         trace(t, 'AMM payouts', payouts);
         t.like(payouts, expected);
       }

--- a/packages/inter-protocol/test/vaultFactory/test-vault-interest.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-interest.js
@@ -34,13 +34,11 @@ const setJig = jig => {
 
 const { makeFar, makeNear: makeRemote } = makeLoopback('zoeTest');
 
-const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
-  makeFakeVatAdmin(setJig, makeRemote).admin,
+const { zoeService: zoe, feeMintAccessRetriever } = await makeFar(
+  makeZoeKit(makeFakeVatAdmin(setJig, makeRemote).admin),
 );
-/** @type {ERef<ZoeService>} */
-const zoe = makeFar(zoeService);
-trace('makeZoe');
-const feeMintAccessP = makeFar(nonFarFeeMintAccess);
+
+const feeMintAccessP = E(feeMintAccessRetriever).get();
 
 /**
  * @param {ERef<ZoeService>} zoeP

--- a/packages/inter-protocol/test/vaultFactory/test-vault.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault.js
@@ -34,13 +34,11 @@ const setJig = jig => {
 
 const { makeFar, makeNear: makeRemote } = makeLoopback('zoeTest');
 
-const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
-  makeFakeVatAdmin(setJig, makeRemote).admin,
+const { zoeService: zoe, feeMintAccessRetriever } = await makeFar(
+  makeZoeKit(makeFakeVatAdmin(setJig, makeRemote).admin),
 );
-/** @type {ERef<ZoeService>} */
-const zoe = makeFar(zoeService);
 trace('makeZoe');
-const feeMintAccessP = makeFar(nonFarFeeMintAccess);
+const feeMintAccessP = E(feeMintAccessRetriever).get();
 
 /**
  * @param {ERef<ZoeService>} zoeP

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -3,6 +3,7 @@ export {
   subscribeEach,
   subscribeLatest,
   vivifyDurablePublishKit,
+  SubscriberShape,
 } from './publish-kit.js';
 export {
   makeNotifier,

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -431,3 +431,5 @@ export const vivifyDurablePublishKit = (baggage, kindName) => {
   );
 };
 harden(vivifyDurablePublishKit);
+
+export const SubscriberShape = M.remotable('Subscriber');

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -66,6 +66,7 @@ export const makeInvitationsHelper = (
       fit(spec, shape.PurseInvitationSpec);
 
       const { instance, description } = spec;
+      // @ts-expect-error TS thinks it's always true. I'm doubtful.
       assert(instance && description, 'missing instance or description');
       /** @type {Amount<'set'>} */
       const purseAmount = await E(invitationsPurse).getCurrentAmount();

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -67,15 +67,14 @@ export const subscriptionKey = subscription => {
 
 const setUpZoeForTest = async () => {
   const { makeFar } = makeLoopback('zoeTest');
-  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
-    makeFakeVatAdmin(() => {}).admin,
+  const { zoeService, feeMintAccessRetriever } = await makeFar(
+    makeZoeKit(makeFakeVatAdmin(() => {}).admin),
   );
   /** @type {import('@endo/far').ERef<ZoeService>} */
   const zoe = makeFar(zoeService);
-  const feeMintAccess = await makeFar(nonFarFeeMintAccess);
   return {
     zoe,
-    feeMintAccess,
+    feeMintAccessRetriever,
   };
 };
 harden(setUpZoeForTest);
@@ -126,8 +125,9 @@ export const makeMockTestSpace = async log => {
   const { agoricNames, spaces } = makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
 
-  const { zoe, feeMintAccess } = await setUpZoeForTest();
+  const { zoe, feeMintAccessP } = await setUpZoeForTest();
   produce.zoe.resolve(zoe);
+  const feeMintAccess = await feeMintAccessP;
   produce.feeMintAccess.resolve(feeMintAccess);
 
   const vatLoader = name => {

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -111,12 +111,13 @@ export const buildZoe = async ({
   produce: { zoe, feeMintAccess },
 }) => {
   const zcfBundleName = 'zcf'; // should match config.bundles.zcf=
-  const { zoeService, feeMintAccess: fma } = await E(
+  const { zoeService, feeMintAccessRetriever } = await E(
     E(loadCriticalVat)('zoe'),
   ).buildZoe(vatAdminSvc, feeIssuerConfig, zcfBundleName);
 
   zoe.resolve(zoeService);
 
+  const fma = await E(feeMintAccessRetriever).get();
   feeMintAccess.resolve(fma);
   return Promise.all([
     E(client).assignBundle([_addr => ({ zoe: zoeService })]),

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -6,7 +6,7 @@ export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
     buildZoe: async (adminVat, feeIssuerConfig, zcfBundleName) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
       assert(zcfBundleName, `vat-zoe requires zcfBundleName`);
-      const { zoeService, feeMintAccess } = makeZoeKit(
+      const { zoeService, feeMintAccessRetriever } = makeZoeKit(
         adminVat,
         shutdownZoeVat,
         feeIssuerConfig,
@@ -15,7 +15,7 @@ export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
       );
       return harden({
         zoeService,
-        feeMintAccess,
+        feeMintAccessRetriever,
       });
     },
   });

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -28,21 +28,16 @@ import { devices } from './devices.js';
 
 const setUpZoeForTest = async () => {
   const { makeFar } = makeLoopback('zoeTest');
-  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
-    makeFakeVatAdmin(() => {}).admin,
-    undefined,
-    {
+  const { zoeService, feeMintAccessRetriever } = await makeFar(
+    makeZoeKit(makeFakeVatAdmin(() => {}).admin, undefined, {
       name: Stable.symbol,
       assetKind: Stable.assetKind,
       displayInfo: Stable.displayInfo,
-    },
+    }),
   );
-  /** @type {ERef<ZoeService>} */
-  const zoe = makeFar(zoeService);
-  const feeMintAccess = await makeFar(nonFarFeeMintAccess);
   return {
-    zoe,
-    feeMintAccess,
+    zoe: zoeService,
+    feeMintAccessP: E(feeMintAccessRetriever).get(),
   };
 };
 harden(setUpZoeForTest);
@@ -62,8 +57,9 @@ test('connectFaucet produces payments', async t => {
   const { agoricNames, spaces } = makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
 
-  const { zoe, feeMintAccess } = await setUpZoeForTest();
+  const { zoe, feeMintAccessP } = await setUpZoeForTest();
   produce.zoe.resolve(zoe);
+  const feeMintAccess = await feeMintAccessP;
   produce.feeMintAccess.resolve(feeMintAccess);
   produce.bridgeManager.resolve(undefined);
 

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -45,7 +45,7 @@ const makeTestContext = async () => {
   const bundleCache = await unsafeMakeBundleCache('bundles/');
   const psmBundle = await bundleCache.load(psmRoot, 'psm');
   const policyBundle = await bundleCache.load(policyRoot, 'provisionPool');
-  const { zoe, feeMintAccess } = setUpZoeForTest();
+  const { zoe, feeMintAccessP } = await setUpZoeForTest();
 
   const mintedIssuer = await E(zoe).getFeeIssuer();
   /** @type {Brand<'nat'>} */
@@ -85,7 +85,7 @@ const makeTestContext = async () => {
     bundles: { psmBundle },
     storageRoot,
     zoe: await zoe,
-    feeMintAccess: await feeMintAccess,
+    feeMintAccess: await feeMintAccessP,
     committeeCreator,
     initialPoserInvitation,
     minted: { issuer: mintedIssuer, brand: mintedBrand },

--- a/packages/vats/test/test-vat-bank.js
+++ b/packages/vats/test/test-vat-bank.js
@@ -210,10 +210,11 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
   const { agoricNames, spaces } = makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
 
-  const { zoeService, feeMintAccess } = makeZoeKit(
+  const { zoeService, feeMintAccessRetriever } = makeZoeKit(
     makeFakeVatAdmin(() => {}).admin,
   );
   produce.zoe.resolve(zoeService);
+  const feeMintAccess = await feeMintAccessRetriever.get();
   produce.feeMintAccess.resolve(feeMintAccess);
   const vatPowers = {
     D: x => x,

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -593,7 +593,7 @@ export function makeWalletRoot({
    * @param {string} id
    * @param {ERef<UserSeat>} seat
    */
-  async function subscribeToNotifier(id, seat) {
+  async function subscribeToUpdates(id, seat) {
     E(E(seat).getExitSubscriber())
       .subscribeAfter()
       .then(update => updateOrResubscribe(id, seat, update));
@@ -1330,7 +1330,7 @@ export function makeWalletRoot({
         .hasExited()
         .then(exited => {
           if (!exited) {
-            subscribeToNotifier(id, seat);
+            subscribeToUpdates(id, seat);
           }
         });
 

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -175,7 +175,6 @@ export function makeWalletRoot({
 
   // Offers that the wallet knows about (the inbox).
   const idToOffer = makeScalarMap('offerId');
-  const idToNotifierP = makeScalarMap('offerId');
   /** @type {LegacyMap<string, PromiseRecord<any>>} */
   // Legacy because promise kits are not passables
   const idToOfferResultPromiseKit = makeLegacyMap('id');
@@ -572,27 +571,20 @@ export function makeWalletRoot({
     await updateAllInboxState();
   }
 
-  // handle the update, which has already resolved to a record. If the offer is
-  // 'done', mark the offer 'complete', otherwise resubscribe to the notifier.
+  // handle the update, which has already resolved to a record. The update means
+  // the offer is 'done'.
   function updateOrResubscribe(id, seat, update) {
     const { updateCount } = update;
-    if (updateCount === undefined) {
-      // TODO do we still need these?
-      idToSeat.delete(id);
+    assert(updateCount === undefined);
+    idToSeat.delete(id);
 
-      const offer = idToOffer.get(id);
-      const completedOffer = addMeta({
-        ...offer,
-        status: 'complete',
-      });
-      idToOffer.set(id, completedOffer);
-      updateInboxState(id, completedOffer);
-      idToNotifierP.delete(id);
-    } else {
-      E(idToNotifierP.get(id))
-        .getUpdateSince(updateCount)
-        .then(nextUpdate => updateOrResubscribe(id, seat, nextUpdate));
-    }
+    const offer = idToOffer.get(id);
+    const completedOffer = addMeta({
+      ...offer,
+      status: 'complete',
+    });
+    idToOffer.set(id, completedOffer);
+    updateInboxState(id, completedOffer);
   }
 
   /**
@@ -602,19 +594,9 @@ export function makeWalletRoot({
    * @param {ERef<UserSeat>} seat
    */
   async function subscribeToNotifier(id, seat) {
-    E(seat)
-      // TODO This uses getAllocationNotifierJig for production, and so
-      // is likely wrong
-      // See https://github.com/Agoric/agoric-sdk/issues/5834
-      .getAllocationNotifierJig()
-      .then(offerNotifierP => {
-        if (!idToNotifierP.has(id)) {
-          idToNotifierP.init(id, offerNotifierP);
-        }
-        E(offerNotifierP)
-          .getUpdateSince()
-          .then(update => updateOrResubscribe(id, seat, update));
-      });
+    E(E(seat).getExitSubscriber())
+      .subscribeAfter()
+      .then(update => updateOrResubscribe(id, seat, update));
   }
 
   /**

--- a/packages/zoe/docs/ZoeDataInitialization.puml
+++ b/packages/zoe/docs/ZoeDataInitialization.puml
@@ -12,7 +12,7 @@ end box
 bootstrap -> Zoe: makeZoeKit(...)
 Zoe -> ZoeStorageManager : makeZoeStorageManager()
 ZoeStorageManager -> ZoeStorageManager : provideIssuerStorage()
-ZoeStorageManager -> ZoeStorageManager : makeEscrowStorage()
+ZoeStorageManager -> ZoeStorageManager : provideEscrowStorage()
 ZoeStorageManager -> ZoeStorageManager : vivifyInvitationKit()
 ZoeStorageManager -> InstanceAdminStorage : makeInstanceAdminStorage()
 InstanceAdminStorage -> InstanceAdminStorage : instanceToInstanceAdmin

--- a/packages/zoe/docs/offers+invitations+seats.puml
+++ b/packages/zoe/docs/offers+invitations+seats.puml
@@ -46,7 +46,7 @@ ZCF -> ZCF : promise = makePromiseKit
 ZCF -> ZCF : seatHandle = makeSeatHandle()
 ZCF -> ZCF : makeZcfSeat({}, {}, seatHandle)
 ZCF -> ZCF : exitObj = makeExitObj({}, handle)
-ZCF -> ZoeInstance : makeNoEscrowSeatKit({}, {}, exitObj, seatHandle)
+ZCF -> ZoeInstance : makeNoEscrowSeat({}, {}, exitObj, seatHandle)
 ZCF -> contract : <font color=gray><size:12>{ zcfSeat, userSeat: promise }
 ZoeInstance -> ZoeInstance : { userSeat, notifier, zoeSeatAdmin } =\n  makeSeatAdminKit(alloc, proposal,\n  promises, ...)
 ZoeInstance -> ZoeInstance : store zoeSeatAdmin

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -1,6 +1,7 @@
 import { assert, details as X, q } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { vivifyFarClass, provideDurableSetStore } from '@agoric/vat-data';
+import { M, initEmpty } from '@agoric/store';
 
 import {
   isOnDemandExitRule,
@@ -8,57 +9,110 @@ import {
   isWaivedExitRule,
 } from '../typeGuards.js';
 
+const ExitObjectI = M.interface('ExitObject', { exit: M.call().returns() });
+const WakerI = M.interface('Waker', {
+  wake: M.call(M.bigint()).returns(),
+  schedule: M.call().returns(),
+});
+
 /**
- * Makes the appropriate exitObj, which runs in ZCF and allows the seat's owner
- * to request the position be exited.
+ * Makes a function that makes exitObjects. The maker is executed in ZCF. It
+ * returns an object than can be passed to Zoe when a seat is created so Zoe can
+ * inform ZCF if and when the seat's owner calls seat.exit().
  */
 
-/** @type {MakeExitObj} */
-export const makeExitObj = (proposal, zcfSeat) => {
-  const { exit } = proposal;
+export const makeMakeExiter = baggage => {
+  const activeWakers = provideDurableSetStore(baggage, 'activeWakers');
 
-  if (isOnDemandExitRule(exit)) {
-    // Allow the user to exit their seat on demand. Note: we must wrap
-    // it in an object to send it back to Zoe because our marshalling layer
-    // only allows two kinds of objects: records (no methods and only
-    // data) and presences (local proxies for objects that may have
-    // methods).
-    return Far('exitObj', {
-      exit: () => zcfSeat.exit(),
-    });
-  }
-
-  if (isAfterDeadlineExitRule(exit)) {
-    // Automatically exit the seat after deadline.
-    E(exit.afterDeadline.timer)
-      .setWakeup(
-        exit.afterDeadline.deadline,
-        Far('wakeObj', {
-          wake: () => zcfSeat.exit(),
-        }),
-      )
-      .catch(reason => {
-        console.error(
-          `The seat could not be made with the provided timer ${exit.afterDeadline.timer} and deadline ${exit.afterDeadline.deadline}`,
-        );
-        console.error(reason);
-        zcfSeat.fail(reason);
-        throw reason;
-      });
-  }
-
-  if (isWaivedExitRule(exit) || isAfterDeadlineExitRule(exit)) {
-    /** @type {ExitObj} */
-    return Far('exitObj', {
-      exit: () => {
-        // if exitKind is 'waived' the user has no ability to exit their seat
-        // on demand
+  const makeExitable = vivifyFarClass(
+    baggage,
+    'ExitObject',
+    ExitObjectI,
+    zcfSeat => ({ zcfSeat }),
+    {
+      exit() {
+        const { state } = this;
+        state.zcfSeat.exit();
+      },
+    },
+  );
+  const makeWaived = vivifyFarClass(
+    baggage,
+    'ExitWaived',
+    ExitObjectI,
+    initEmpty,
+    {
+      exit() {
+        // in this case the user has no ability to exit their seat on demand
         throw Error(
           `Only seats with the exit rule "onDemand" can exit at will`,
         );
       },
-    });
+    },
+  );
+  const makeWaker = vivifyFarClass(
+    baggage,
+    'Waker',
+    WakerI,
+    (zcfSeat, afterDeadline) => ({ zcfSeat, afterDeadline }),
+    {
+      wake(_when) {
+        const { state, self } = this;
+
+        activeWakers.delete(self);
+        state.zcfSeat.exit();
+      },
+      schedule() {
+        const { state, self } = this;
+
+        E(state.afterDeadline.timer)
+          .setWakeup(state.afterDeadline.deadline, self)
+          .catch(reason => {
+            console.error(
+              `The seat could not be made with the provided timer ${state.afterDeadline.timer} and deadline ${state.afterDeadline.deadline}`,
+            );
+            console.error(reason);
+            state.zcfSeat.fail(reason);
+            throw reason;
+          });
+      },
+    },
+  );
+
+  // On revival, reschedule all the active wakers.
+  for (const waker of activeWakers.values()) {
+    waker.schedule();
   }
 
-  assert.fail(X`exit kind was not recognized: ${q(exit)}`);
+  /**
+   * Makes the appropriate exitObj, which runs in ZCF and allows the seat's owner
+   * to request the position be exited.
+   *
+   * @type {MakeExitObj}
+   */
+  return (proposal, zcfSeat) => {
+    const { exit } = proposal;
+
+    if (isOnDemandExitRule(exit)) {
+      // Allow the user to exit their seat on demand. Note: we must wrap
+      // it in an object to send it back to Zoe because our marshalling layer
+      // only allows two kinds of objects: records (no methods and only
+      // data) and presences (local proxies for objects that may have
+      // methods).
+      return makeExitable(zcfSeat);
+    }
+
+    if (isAfterDeadlineExitRule(exit)) {
+      const waker = makeWaker(zcfSeat, exit.afterDeadline);
+      activeWakers.add(waker);
+      // Automatically exit the seat after deadline.
+      waker.schedule();
+    }
+
+    if (isWaivedExitRule(exit) || isAfterDeadlineExitRule(exit)) {
+      return makeWaived();
+    }
+
+    assert.fail(X`exit kind was not recognized: ${q(exit)}`);
+  };
 };

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -33,7 +33,6 @@
  * @property {MakeInvitation} makeInvitation
  * @property {(completion: Completion) => void} shutdown
  * @property {ShutdownWithFailure} shutdownWithFailure
- * @property {Assert} assert
  * @property {() => ERef<ZoeService>} getZoeService
  * @property {() => Issuer<'set'>} getInvitationIssuer
  * @property {() => StandardTerms & CT} getTerms
@@ -46,6 +45,7 @@
  * @property {SetTestJig} setTestJig
  * @property {() => Promise<void>} stopAcceptingOffers
  * @property {(strings: Array<string>) => void} setOfferFilter
+ * @property {() => Promise<Array<string>>} getOfferFilter
  * @property {() => Instance} getInstance
  */
 
@@ -188,7 +188,7 @@
  * @typedef {object} ZCFSeat
  * @property {() => void} exit
  * @property {ZCFSeatFail} fail
- * @property {() => Promise<Notifier<Allocation>>} getNotifier
+ * @property {() => Promise<Subscriber<Allocation>>} getSubscriber
  * @property {() => boolean} hasExited
  * @property {() => ProposalRecord} getProposal
  * @property {ZCFGetAmountAllocated} getAmountAllocated

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -16,14 +16,12 @@ import './types.js';
 
 const { details: X } = assert;
 
-// helpers for the code shared between MakeZCFMint and RegisterZCFMint
-
 export const makeZCFMintFactory = async (
   zcfBaggage,
   recordIssuer,
   getAssetKindByBrand,
   makeEmptySeatKit,
-  reallocateForZCFMint,
+  reallocator,
 ) => {
   // The set of baggages for zcfMints
   const zcfMintBaggageSet = provideDurableSetStore(zcfBaggage, 'baggageSet');
@@ -90,12 +88,12 @@ export const makeZCFMintFactory = async (
               X`The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`,
             );
           // No effects above, apart from incrementBy. Note COMMIT POINT within
-          // reallocateForZCFMint. The following two steps *should* be
+          // reallocator.reallocate(). The following two steps *should* be
           // committed atomically, but it is not a disaster if they are
           // not. If we minted only, no one would ever get those
           // invisibly-minted assets.
           E(zoeMint).mintAndEscrow(totalToMint);
-          reallocateForZCFMint(zcfSeat, allocationPlusGains);
+          reallocator.reallocate(zcfSeat, allocationPlusGains);
           return zcfSeat;
         },
         burnLosses: (losses, zcfSeat) => {
@@ -123,11 +121,11 @@ export const makeZCFMintFactory = async (
           }
 
           // No effects above, apart from decrementBy. Note COMMIT POINT within
-          // reallocateForZCFMint. The following two steps *should* be
+          // reallocator.reallocate(). The following two steps *should* be
           // committed atomically, but it is not a disaster if they are
           // not. If we only commit the allocationMinusLosses no one would
           // ever get the unburned assets.
-          reallocateForZCFMint(zcfSeat, allocationMinusLosses);
+          reallocator.reallocate(zcfSeat, allocationMinusLosses);
           E(zoeMint).withdrawAndBurn(totalToBurn);
         },
       },

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -1,19 +1,27 @@
 import {
-  provideDurableWeakMapStore,
-  provideDurableMapStore,
   makeScalarBigMapStore,
-  vivifyKind,
   makeScalarBigWeakMapStore,
+  provideDurableMapStore,
+  provideDurableWeakMapStore,
+  vivifyFarClassKit,
+  vivifyKind,
+  provide,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
+import { initEmpty, M } from '@agoric/store';
 
 import { isOfferSafe } from './offerSafety.js';
 import { assertRightsConserved } from './rightsConservation.js';
 import { addToAllocation, subtractFromAllocation } from './allocationMath.js';
 import { coerceAmountKeywordRecord } from '../cleanProposal.js';
+import {
+  AmountKeywordRecordShape,
+  ProposalShape,
+  SeatShape,
+} from '../typeGuards.js';
 
-const { details: X } = assert;
+const { details: X, Fail } = assert;
 
 /** @type {CreateSeatManager} */
 export const createSeatManager = (
@@ -44,7 +52,7 @@ export const createSeatManager = (
    * @returns {void}
    */
   const assertActive = zcfSeat => {
-    assert(activeZCFSeats.has(zcfSeat), 'seat has been exited');
+    activeZCFSeats.has(zcfSeat) || Fail`seat has been exited`;
   };
 
   /**
@@ -118,111 +126,6 @@ export const createSeatManager = (
     }
   };
 
-  /**
-   * Unlike the zcf.reallocate method, this one does not check conservation,
-   * and so can be used internally for reallocations that violate
-   * conservation.
-   *
-   * @type {ReallocateForZCFMint}
-   */
-  const reallocateForZCFMint = (zcfSeat, newAllocation) => {
-    try {
-      // COMMIT POINT
-      // All the effects below must succeed "atomically". Scare quotes because
-      // the eventual send at the bottom is part of this "atomicity" even
-      // though its effects happen later. The send occurs in the order of
-      // updates from zcf to zoe, its effects must occur immediately in zoe
-      // on reception, and must not fail.
-      //
-      // Commit the newAllocation and inform Zoe of the
-      // newAllocation.
-
-      activeZCFSeats.set(zcfSeat, newAllocation);
-
-      const seatHandleAllocations = [
-        {
-          seatHandle: zcfSeatToSeatHandle.get(zcfSeat),
-          allocation: newAllocation,
-        },
-      ];
-
-      E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
-    } catch (err) {
-      shutdownWithFailure(err);
-      throw err;
-    }
-  };
-
-  const reallocate = (/** @type {ZCFSeat[]} */ ...seats) => {
-    // We may want to handle this with static checking instead.
-    // Discussion at: https://github.com/Agoric/agoric-sdk/issues/1017
-    assert(
-      seats.length >= 2,
-      'reallocating must be done over two or more seats',
-    );
-
-    seats.forEach(assertActive);
-    seats.forEach(assertStagedAllocation);
-
-    // Ensure that rights are conserved overall.
-    const flattenAllocations = allocations =>
-      allocations.flatMap(Object.values);
-
-    const previousAllocations = seats.map(seat => seat.getCurrentAllocation());
-    const previousAmounts = flattenAllocations(previousAllocations);
-
-    const newAllocations = seats.map(seat => seat.getStagedAllocation());
-    const newAmounts = flattenAllocations(newAllocations);
-
-    assertRightsConserved(previousAmounts, newAmounts);
-
-    // Ensure that offer safety holds.
-    seats.forEach(seat => {
-      isOfferSafe(seat.getProposal(), seat.getStagedAllocation()) ||
-        assert.fail(
-          X`Offer safety was violated by the proposed allocation: ${seat.getStagedAllocation()}. Proposal was ${seat.getProposal()}`,
-        );
-    });
-
-    // Keep track of seats used so far in this call, to prevent aliasing.
-    const zcfSeatsSoFar = new Set();
-
-    seats.forEach(seat => {
-      zcfSeatToSeatHandle.has(seat) ||
-        assert.fail(X`The seat ${seat} was not recognized`);
-      !zcfSeatsSoFar.has(seat) ||
-        assert.fail(X`Seat (${seat}) was already an argument to reallocate`);
-      zcfSeatsSoFar.add(seat);
-    });
-
-    try {
-      // No side effects above. All conditions checked which could have
-      // caused us to reject this reallocation.
-      // COMMIT POINT
-      // All the effects below must succeed "atomically". Scare quotes because
-      // the eventual send at the bottom is part of this "atomicity" even
-      // though its effects happen later. The send occurs in the order of
-      // updates from zcf to zoe, its effects must occur immediately in zoe
-      // on reception, and must not fail.
-      //
-      // Commit the staged allocations (currentAllocation is replaced
-      // for each of the seats) and inform Zoe of the
-      // newAllocation.
-
-      seats.forEach(commitStagedAllocation);
-
-      const seatHandleAllocations = seats.map(seat => {
-        const seatHandle = zcfSeatToSeatHandle.get(seat);
-        return { seatHandle, allocation: seat.getCurrentAllocation() };
-      });
-
-      E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
-    } catch (err) {
-      shutdownWithFailure(err);
-      throw err;
-    }
-  };
-
   /** @param {ZCFSeat} zcfSeat */
   const assertNoStagedAllocation = zcfSeat => {
     if (hasStagedAllocation(zcfSeat)) {
@@ -239,8 +142,11 @@ export const createSeatManager = (
     'zcfSeat',
     proposal => ({ proposal }),
     {
-      getNotifier: ({ self }) =>
-        E(zoeInstanceAdmin).getSeatNotifier(zcfSeatToSeatHandle.get(self)),
+      getSubscriber: ({ self }) => {
+        return E(zoeInstanceAdmin).getExitSubscriber(
+          zcfSeatToSeatHandle.get(self),
+        );
+      },
       getProposal: ({ state }) => state.proposal,
       exit: ({ self }, completion) => {
         assertActive(self);
@@ -332,12 +238,6 @@ export const createSeatManager = (
       hasStagedAllocation: ({ self }) => hasStagedAllocation(self),
     },
   );
-  const makeZCFSeat = ({ proposal, initialAllocation, seatHandle }) => {
-    const zcfSeat = makeZCFSeatInternal(proposal);
-    activeZCFSeats.init(zcfSeat, initialAllocation);
-    zcfSeatToSeatHandle.init(zcfSeat, seatHandle);
-    return zcfSeat;
-  };
 
   const replaceDurableWeakMapStore = (baggage, key) => {
     const mapStore = makeScalarBigWeakMapStore(key, { durable: true });
@@ -345,19 +245,145 @@ export const createSeatManager = (
     return mapStore;
   };
 
-  /** @type {DropAllReferences} */
-  const dropAllReferences = () => {
-    activeZCFSeats = replaceDurableWeakMapStore(zcfBaggage, 'activeZCFSeats');
-    zcfSeatToSeatHandle = replaceDurableWeakMapStore(
-      zcfBaggage,
-      'zcfSeatToSeatHandle',
-    );
-  };
-
-  return harden({
-    makeZCFSeat,
-    reallocate,
-    reallocateForZCFMint,
-    dropAllReferences,
+  const ZcfSeatManagerIKit = harden({
+    seatManager: M.interface('ZcfSeatManager', {
+      makeZCFSeat: M.call(
+        M.partial({
+          proposal: ProposalShape,
+          initialAllocation: AmountKeywordRecordShape,
+          seatHandle: SeatShape,
+          offerArgs: M.any(),
+        }),
+      ).returns(M.remotable('zcfSeat')),
+      reallocate: M.call(M.remotable('zcfSeat'), M.remotable('zcfSeat'))
+        .rest(M.arrayOf(M.remotable('zcfSeat')))
+        .returns(),
+      dropAllReferences: M.call().returns(),
+    }),
+    zcfMintReallocator: M.interface('MintReallocator', {
+      reallocate: M.call(SeatShape, AmountKeywordRecordShape).returns(),
+    }),
   });
+
+  const makeSeatManagerKit = vivifyFarClassKit(
+    zcfBaggage,
+    'ZcfSeatManager',
+    ZcfSeatManagerIKit,
+    initEmpty,
+    {
+      seatManager: {
+        makeZCFSeat({ proposal, initialAllocation, seatHandle }) {
+          const zcfSeat = makeZCFSeatInternal(proposal);
+          activeZCFSeats.init(zcfSeat, initialAllocation);
+          zcfSeatToSeatHandle.init(zcfSeat, seatHandle);
+          return zcfSeat;
+        },
+
+        reallocate(/** @type {ZCFSeat[]} */ ...seats) {
+          seats.forEach(assertActive);
+          seats.forEach(assertStagedAllocation);
+
+          // Ensure that rights are conserved overall.
+          const flattenAllocations = allocations =>
+            allocations.flatMap(Object.values);
+          const previousAllocations = seats.map(seat =>
+            seat.getCurrentAllocation(),
+          );
+          const previousAmounts = flattenAllocations(previousAllocations);
+          const newAllocations = seats.map(seat => seat.getStagedAllocation());
+          const newAmounts = flattenAllocations(newAllocations);
+
+          assertRightsConserved(previousAmounts, newAmounts);
+
+          // Ensure that offer safety holds.
+          for (const seat of seats) {
+            isOfferSafe(seat.getProposal(), seat.getStagedAllocation()) ||
+              Fail`Offer safety was violated by the proposed allocation: ${seat.getStagedAllocation()}. Proposal was ${seat.getProposal()}`;
+          }
+
+          // Keep track of seats used so far in this call, to prevent aliasing.
+          const zcfSeatsSoFar = new Set();
+
+          for (const seat of seats) {
+            zcfSeatToSeatHandle.has(seat) ||
+              Fail`The seat ${seat} was not recognized`;
+            !zcfSeatsSoFar.has(seat) ||
+              Fail`Seat (${seat}) was already an argument to reallocate`;
+            zcfSeatsSoFar.add(seat);
+          }
+
+          try {
+            // No side effects above. All conditions checked which could have
+            // caused us to reject this reallocation.
+            // COMMIT POINT
+            // All the effects below must succeed "atomically". Scare quotes because
+            // the eventual send at the bottom is part of this "atomicity" even
+            // though its effects happen later. The send occurs in the order of
+            // updates from zcf to zoe, its effects must occur immediately in zoe
+            // on reception, and must not fail.
+            //
+            // Commit the staged allocations (currentAllocation is replaced
+            // for each of the seats) and inform Zoe of the
+            // newAllocation.
+
+            seats.forEach(commitStagedAllocation);
+
+            const seatHandleAllocations = seats.map(seat => {
+              const seatHandle = zcfSeatToSeatHandle.get(seat);
+              return { seatHandle, allocation: seat.getCurrentAllocation() };
+            });
+
+            E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
+          } catch (err) {
+            shutdownWithFailure(err);
+            throw err;
+          }
+        },
+        dropAllReferences() {
+          activeZCFSeats = replaceDurableWeakMapStore(
+            zcfBaggage,
+            'activeZCFSeats',
+          );
+          zcfSeatToSeatHandle = replaceDurableWeakMapStore(
+            zcfBaggage,
+            'zcfSeatToSeatHandle',
+          );
+        },
+      },
+      zcfMintReallocator: {
+        // Unlike the zcf.reallocate method, this one does not check
+        // conservation, and so can be used internally for reallocations that
+        // violate conservation.
+        reallocate(zcfSeat, newAllocation) {
+          try {
+            // COMMIT POINT
+            // All the effects below must succeed "atomically". Scare quotes
+            // because the eventual send at the bottom is part of this
+            // "atomicity" even though its effects happen later. The send occurs
+            // in the order of updates from zcf to zoe, its effects must occur
+            // immediately in zoe on reception, and must not fail.
+            //
+            // Commit the newAllocation and inform Zoe of the
+            // newAllocation.
+
+            activeZCFSeats.set(zcfSeat, newAllocation);
+
+            const seatHandleAllocations = [
+              {
+                seatHandle: zcfSeatToSeatHandle.get(zcfSeat),
+                allocation: newAllocation,
+              },
+            ];
+
+            E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
+          } catch (err) {
+            shutdownWithFailure(err);
+            throw err;
+          }
+        },
+      },
+    },
+  );
+
+  return provide(zcfBaggage, 'theSeatManagerKit', () => makeSeatManagerKit());
 };

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -1,18 +1,20 @@
 import { E } from '@endo/eventual-send';
-import { Far, Remotable, passStyleOf } from '@endo/marshal';
+import { passStyleOf, Remotable } from '@endo/marshal';
 import { AssetKind } from '@agoric/ertp';
 import { makePromiseKit } from '@endo/promise-kit';
-import { assertPattern, initEmpty } from '@agoric/store';
+import { assertPattern } from '@agoric/store';
 import {
+  canBeDurable,
+  M,
   makeScalarBigMapStore,
   provideDurableMapStore,
-  canBeDurable,
+  vivifyFarInstance,
   vivifyKind,
 } from '@agoric/vat-data';
 
 import { cleanProposal } from '../cleanProposal.js';
 import { evalContractBundle } from './evalContractCode.js';
-import { makeExitObj } from './exit.js';
+import { makeMakeExiter } from './exit.js';
 import { defineDurableHandle } from '../makeHandle.js';
 import { provideIssuerStorage } from '../issuerStorage.js';
 import { createSeatManager } from './zcfSeat.js';
@@ -24,7 +26,10 @@ import { makeZCFMintFactory } from './zcfMint.js';
 import '../internal-types.js';
 import './internal-types.js';
 
-const { details: X, makeAssert } = assert;
+import '@agoric/swingset-vat/src/types-ambient.js';
+import { InvitationHandleShape } from '../typeGuards.js';
+
+const { details: X } = assert;
 
 /**
  * Make the ZCF vat in zygote-usable form. First, a generic ZCF is
@@ -48,9 +53,10 @@ export const makeZCFZygote = async (
   zcfBaggage = makeScalarBigMapStore('zcfBaggage', { durable: true }),
 ) => {
   const makeSeatHandle = defineDurableHandle(zcfBaggage, 'Seat');
-  /** @type {PromiseRecord<ZoeInstanceAdmin>} */
-  const zoeInstanceAdminPromiseKit = makePromiseKit();
-  const zoeInstanceAdmin = zoeInstanceAdminPromiseKit.promise;
+  /** @type {ERef<ZoeInstanceAdmin>} */
+  let zoeInstanceAdmin;
+  let seatManager;
+  const makeExiter = makeMakeExiter(zcfBaggage);
 
   const {
     storeIssuerRecord,
@@ -63,19 +69,10 @@ export const makeZCFZygote = async (
   /** @type {ShutdownWithFailure} */
   const shutdownWithFailure = reason => {
     E(zoeInstanceAdmin).failAllSeats(reason);
-    // eslint-disable-next-line no-use-before-define
-    dropAllReferences();
+    seatManager.dropAllReferences();
     // https://github.com/Agoric/agoric-sdk/issues/3239
     powers.exitVatWithFailure(reason);
   };
-
-  const { makeZCFSeat, reallocate, reallocateForZCFMint, dropAllReferences } =
-    createSeatManager(
-      zoeInstanceAdmin,
-      getAssetKindByBrand,
-      shutdownWithFailure,
-      zcfBaggage,
-    );
 
   const { storeOfferHandler, takeOfferHandler } =
     makeOfferHandlerStorage(zcfBaggage);
@@ -106,24 +103,17 @@ export const makeZCFZygote = async (
       initialAllocation,
       seatHandle,
     });
-    const zcfSeat = makeZCFSeat(seatData);
+    const zcfSeat = seatManager.makeZCFSeat(seatData);
 
-    const exitObj = makeExitObj(seatData.proposal, zcfSeat);
-
+    const exiter = makeExiter(seatData.proposal, zcfSeat);
     E(zoeInstanceAdmin)
-      .makeNoEscrowSeatKit(initialAllocation, proposal, exitObj, seatHandle)
+      .makeNoEscrowSeat(initialAllocation, proposal, exiter, seatHandle)
       .then(({ userSeat }) => userSeatPromiseKit.resolve(userSeat));
 
     return { zcfSeat, userSeat: userSeatPromiseKit.promise };
   };
 
-  const zcfMintFactory = await makeZCFMintFactory(
-    zcfBaggage,
-    recordIssuer,
-    getAssetKindByBrand,
-    makeEmptySeatKit,
-    reallocateForZCFMint,
-  );
+  let zcfMintFactory;
 
   /**
    * @template {AssetKind} [K='nat']
@@ -145,7 +135,6 @@ export const makeZCFZygote = async (
       assetKind,
       displayInfo,
     );
-    // @ts-expect-error could be instantiated with a different subtype
     return zcfMintFactory.makeZCFMintInternal(keyword, zoeMint);
   };
 
@@ -157,16 +146,16 @@ export const makeZCFZygote = async (
       keyword,
       feeMintAccess,
     );
-    // @ts-expect-error could be instantiated with a different subtype
     return zcfMintFactory.makeZCFMintInternal(keyword, zoeMint);
   };
 
   /** @type {ZCF} */
+  // Using Remotable rather than Far because there are too many complications
+  // imposing checking wrappers: makeInvitation() and setJig() want to
+  // accept raw functions. assert cannot be a valid passable! (It's a function
+  // and has members.)
   const zcf = Remotable('Alleged: zcf', undefined, {
-    // Using Remotable rather than Far because too many complications
-    // imposing checking wrappers: makeInvitation and setJig want to
-    // accept raw functions. assert cannot be a valid passable!
-    reallocate,
+    reallocate: (...seats) => seatManager.reallocate(...seats),
     assertUniqueKeyword,
     saveIssuer: async (issuerP, keyword) => {
       // TODO: The checks of the keyword for uniqueness are
@@ -179,8 +168,7 @@ export const makeZCFZygote = async (
       return record;
     },
     makeInvitation: (
-      // @ts-expect-error xxx arbitrary subtype
-      offerHandler = Far('default offer handler', () => {}),
+      offerHandler,
       description,
       customProperties = harden({}),
       proposalShape = undefined,
@@ -190,6 +178,9 @@ export const makeZCFZygote = async (
         'string',
         X`invitations must have a description string: ${description}`,
       );
+
+      offerHandler || assert(offerHandler, `offerHandler must be provided`);
+
       if (proposalShape !== undefined) {
         assertPattern(proposalShape);
       }
@@ -206,11 +197,10 @@ export const makeZCFZygote = async (
     // Shutdown the entire vat and give payouts
     shutdown: completion => {
       E(zoeInstanceAdmin).exitAllSeats(completion);
-      dropAllReferences();
+      seatManager.dropAllReferences();
       powers.exitVat(completion);
     },
     shutdownWithFailure,
-    assert: makeAssert(shutdownWithFailure),
     stopAcceptingOffers: () => E(zoeInstanceAdmin).stopAcceptingOffers(),
     makeZCFMint,
     registerFeeMint,
@@ -231,20 +221,24 @@ export const makeZCFZygote = async (
     },
     getInstance: () => getInstanceRecord().instance,
     setOfferFilter: strings => E(zoeInstanceAdmin).setOfferFilter(strings),
+    getOfferFilter: () => E(zoeInstanceAdmin).getOfferFilter(),
   });
+
+  const HandleOfferShape = M.remotable('HandleOffer');
 
   // handleOfferObject gives Zoe the ability to notify ZCF when a new seat is
   // added in offer(). ZCF responds with the exitObj and offerResult.
   const makeHandleOfferObj = vivifyKind(
     zcfBaggage,
     'handleOfferObj',
-    initEmpty,
+    offerHandlerTaker => ({ offerHandlerTaker }),
     {
-      handleOffer: (_context, invitationHandle, seatData) => {
-        const zcfSeat = makeZCFSeat(seatData);
+      handleOffer: ({ state }, invitationHandle, seatData) => {
+        const zcfSeat = seatManager.makeZCFSeat(seatData);
         // TODO: provide a details that's a better diagnostic for the
         // ephemeral offerHandler that did not survive upgrade.
-        const offerHandler = takeOfferHandler(invitationHandle);
+
+        const offerHandler = state.offerHandlerTaker.take(invitationHandle);
         const offerResultP =
           typeof offerHandler === 'function'
             ? E(offerHandler)(zcfSeat, seatData.offerArgs)
@@ -259,13 +253,24 @@ export const makeZCFZygote = async (
           }
           throw zcfSeat.fail(reason);
         });
-        const exitObj = makeExitObj(seatData.proposal, zcfSeat);
+        const exiter = makeExiter(seatData.proposal, zcfSeat);
         /** @type {HandleOfferResult} */
-        return harden({ offerResultPromise, exitObj });
+        return harden({ offerResultPromise, exitObj: exiter });
       },
     },
   );
-  const handleOfferObj = makeHandleOfferObj();
+
+  const HandleOfferFunctionShape = M.remotable('HandleOfferFunction');
+  const OfferHandlerShape = M.or(HandleOfferShape, HandleOfferFunctionShape);
+  const TakerI = M.interface('offer handler taker', {
+    take: M.call(InvitationHandleShape)
+      .optional(M.string())
+      .returns(OfferHandlerShape),
+  });
+  const taker = vivifyFarInstance(zcfBaggage, 'offer handler taker', TakerI, {
+    take: takeOfferHandler,
+  });
+  const handleOfferObj = makeHandleOfferObj(taker);
 
   const evaluateContract = () => {
     let bundle;
@@ -299,6 +304,24 @@ export const makeZCFZygote = async (
 
   const contractBaggage = provideDurableMapStore(zcfBaggage, 'contractBaggage');
 
+  const initSeatMgrAndMintFactory = async () => {
+    let zcfMintReallocator;
+    ({ seatManager, zcfMintReallocator } = createSeatManager(
+      zoeInstanceAdmin,
+      getAssetKindByBrand,
+      shutdownWithFailure,
+      zcfBaggage,
+    ));
+
+    zcfMintFactory = await makeZCFMintFactory(
+      zcfBaggage,
+      recordIssuer,
+      getAssetKindByBrand,
+      makeEmptySeatKit,
+      zcfMintReallocator,
+    );
+  };
+
   /**
    * A zygote is a pre-image of a vat that can quickly be instantiated because
    * the code has already been evaluated. SwingSet doesn't support zygotes yet.
@@ -318,8 +341,10 @@ export const makeZCFZygote = async (
       issuerStorageFromZoe,
       privateArgs = undefined,
     ) => {
-      zoeInstanceAdminPromiseKit.resolve(instanceAdminFromZoe);
-      zcfBaggage.init('instanceAdmin', instanceAdminFromZoe);
+      zoeInstanceAdmin = instanceAdminFromZoe;
+      initSeatMgrAndMintFactory();
+
+      zcfBaggage.init('zcfInstanceAdmin', instanceAdminFromZoe);
       instantiateInstanceRecordStorage(instanceRecordFromZoe);
       instantiateIssuerStorage(issuerStorageFromZoe);
 
@@ -354,9 +379,10 @@ export const makeZCFZygote = async (
     },
 
     restartContract: async (privateArgs = undefined) => {
-      const instanceAdmin = zcfBaggage.get('instanceAdmin');
-      zoeInstanceAdminPromiseKit.resolve(instanceAdmin);
+      const instanceAdmin = zcfBaggage.get('zcfInstanceAdmin');
+      zoeInstanceAdmin = instanceAdmin;
       assert(vivify, 'vivify must be defined to upgrade a contract');
+      initSeatMgrAndMintFactory();
 
       // restart an upgradeable contract
       return E.when(

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -29,7 +29,7 @@ import './internal-types.js';
 import '@agoric/swingset-vat/src/types-ambient.js';
 import { InvitationHandleShape } from '../typeGuards.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 /**
  * Make the ZCF vat in zygote-usable form. First, a generic ZCF is
@@ -108,7 +108,7 @@ export const makeZCFZygote = async (
     const exiter = makeExiter(seatData.proposal, zcfSeat);
     E(zoeInstanceAdmin)
       .makeNoEscrowSeat(initialAllocation, proposal, exiter, seatHandle)
-      .then(({ userSeat }) => userSeatPromiseKit.resolve(userSeat));
+      .then(userSeat => userSeatPromiseKit.resolve(userSeat));
 
     return { zcfSeat, userSeat: userSeatPromiseKit.promise };
   };
@@ -173,13 +173,10 @@ export const makeZCFZygote = async (
       customProperties = harden({}),
       proposalShape = undefined,
     ) => {
-      assert.typeof(
-        description,
-        'string',
-        X`invitations must have a description string: ${description}`,
-      );
+      typeof description === 'string' ||
+        Fail`invitations must have a description string: ${description}`;
 
-      offerHandler || assert(offerHandler, `offerHandler must be provided`);
+      offerHandler || Fail`offerHandler must be provided`;
 
       if (proposalShape !== undefined) {
         assertPattern(proposalShape);
@@ -287,16 +284,13 @@ export const makeZCFZygote = async (
   const { start, buildRootObject, vivify } = await evaluateContract();
 
   if (start === undefined && vivify === undefined) {
-    assert(
-      buildRootObject === undefined,
-      'Did you provide a vat bundle instead of a contract bundle?',
-    );
-    assert.fail('unrecognized contract exports');
+    buildRootObject === undefined ||
+      Fail`Did you provide a vat bundle instead of a contract bundle?`;
+    Fail`unrecognized contract exports`;
   }
-  assert(
-    !start || !vivify,
-    'contract must provide exactly one of "start" and "vivify"',
-  );
+  !start ||
+    !vivify ||
+    Fail`contract must provide exactly one of "start" and "vivify"`;
 
   // snapshot zygote here //////////////////
   // the zygote object below will be created now, but its methods won't be
@@ -381,7 +375,7 @@ export const makeZCFZygote = async (
     restartContract: async (privateArgs = undefined) => {
       const instanceAdmin = zcfBaggage.get('zcfInstanceAdmin');
       zoeInstanceAdmin = instanceAdmin;
-      assert(vivify, 'vivify must be defined to upgrade a contract');
+      vivify || Fail`vivify must be defined to upgrade a contract`;
       initSeatMgrAndMintFactory();
 
       // restart an upgradeable contract
@@ -396,12 +390,10 @@ export const makeZCFZygote = async (
           const priorPublicFacet = zcfBaggage.get('publicFacet');
           const priorCreatorInvitation = zcfBaggage.get('creatorInvitation');
 
-          assert(
-            priorCreatorFacet === creatorFacet &&
-              priorPublicFacet === publicFacet &&
-              priorCreatorInvitation === creatorInvitation,
-            'restartContract failed: facets returned by contract changed identity',
-          );
+          (priorCreatorFacet === creatorFacet &&
+            priorPublicFacet === publicFacet &&
+            priorCreatorInvitation === creatorInvitation) ||
+            Fail`restartContract failed: facets returned by contract changed identity`;
           return harden({
             creatorFacet,
             publicFacet,

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -1,7 +1,11 @@
 import { Far } from '@endo/marshal';
 import { Nat } from '@agoric/nat';
 import { AmountMath } from '@agoric/ertp';
-import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
+import {
+  makeNotifierKit,
+  observeIteration,
+  subscribeLatest,
+} from '@agoric/notifier';
 import {
   assertIssuerKeywords,
   defaultAcceptanceMsg,
@@ -48,8 +52,8 @@ const start = zcf => {
   const sell = seat => {
     sellerSeat = seat;
 
-    observeNotifier(
-      sellerSeat.getNotifier(),
+    observeIteration(
+      subscribeLatest(sellerSeat.getSubscriber()),
       harden({
         updateState: sellerSeatAllocation =>
           availableItemsUpdater.updateState(
@@ -63,6 +67,7 @@ const start = zcf => {
         fail: reason => availableItemsUpdater.fail(reason),
       }),
     );
+    availableItemsUpdater.updateState(sellerSeat.getCurrentAllocation().Items);
     return defaultAcceptanceMsg;
   };
 
@@ -115,7 +120,12 @@ const start = zcf => {
 
     if (AmountMath.isEmpty(getAvailableItems())) {
       zcf.shutdown('All items sold.');
+    } else {
+      availableItemsUpdater.updateState(
+        sellerSeat.getCurrentAllocation().Items,
+      );
     }
+
     return defaultAcceptanceMsg;
   };
 

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -166,7 +166,7 @@
  * @param {ProposalRecord} proposal
  * @param {ExitObj} exitObj
  * @param {SeatHandle} seatHandle
- * @returns {{userSeat: UserSeat}}
+ * @returns {UserSeat}
  */
 
 /**
@@ -237,7 +237,7 @@
  */
 
 /**
- * @typedef RootAndAdminNode
+ * @typedef {object} RootAndAdminNode
  * @property {object} root
  * @property {AdminNode} adminNode
  */

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -15,20 +15,31 @@
  */
 
 /**
+ * @typedef WithdrawFacet
+ * @property {(allocation:Allocation) => PaymentPKeywordRecord} withdrawPayments
+ */
+
+/**
+ * @typedef {object} InstanceAdminHelper
+ * @property {(zoeSeatAdmin: ZoeSeatAdmin) => void} exitZoeSeatAdmin
+ * @property {(zoeSeatAdmin: ZoeSeatAdmin) => boolean} hasExited
+ */
+
+/**
  * @typedef {object} ZoeSeatAdminKit
  * @property {UserSeat} userSeat
  * @property {ZoeSeatAdmin} zoeSeatAdmin
- * @property {Notifier<Allocation>} notifier
- *
- * @callback MakeZoeSeatAdminKit
+ */
+
+/** @callback MakeZoeSeatAdminKit
  * Make the Zoe seat admin, user seat and a notifier
  * @param {Allocation} initialAllocation
- * @param {(zoeSeatAdmin: ZoeSeatAdmin) => void} exitZoeSeatAdmin
- * @param {(zoeSeatAdmin: ZoeSeatAdmin) => boolean} hasExited
+ * @param {InstanceAdminHelper} instanceAdminHelper
  * @param {ProposalRecord} proposal
- * @param {WithdrawPayments} withdrawPayments
+ * @param {WithdrawFacet} withdrawFacet
  * @param {ERef<ExitObj>} exitObj
  * @param {ERef<unknown>} [offerResult]
+ * @param {import('@agoric/vat-data').Baggage} baggage
  * @returns {ZoeSeatAdminKit}
  */
 
@@ -69,7 +80,7 @@
  *     proposal: ProposalRecord,
  *     offerArgs?: object,
  * ) => UserSeat } makeUserSeat
- * @property {MakeNoEscrowSeatKit} makeNoEscrowSeatKit
+ * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {() => Instance} getInstance
  * @property {() => object} getPublicFacet
  * @property {() => IssuerKeywordRecord} getIssuers
@@ -81,6 +92,8 @@
  * @property {ShutdownWithFailure} failAllSeats
  * @property {() => void} stopAcceptingOffers
  * @property {(string: string) => boolean} isBlocked
+ * @property {(handleOfferObj: HandleOfferObj, publicFacet: unknown) => void} initDelayedState
+ * @property {(strings: string[]) => void} setOfferFilter
  */
 
 /**
@@ -111,15 +124,16 @@
  *            ) => Promise<IssuerRecord>} saveIssuer
  * @property {MakeZoeMint} makeZoeMint
  * @property {RegisterFeeMint} registerFeeMint
- * @property {MakeNoEscrowSeatKit} makeNoEscrowSeatKit
+ * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {ReplaceAllocations} replaceAllocations
  * @property {(completion: Completion) => void} exitAllSeats
  * @property {ShutdownWithFailure} failAllSeats
  * @property {(seatHandle: SeatHandle, completion: Completion) => void} exitSeat
  * @property {(seatHandle: SeatHandle, reason: Error) => void} failSeat
- * @property {(seatHandle: SeatHandle) => Promise<Notifier<Allocation>>} getSeatNotifier
  * @property {() => void} stopAcceptingOffers
  * @property {(strings: Array<string>) => void} setOfferFilter
+ * @property {() => Promise<Array<string>>} getOfferFilter
+ * @property {(seatHandle: SeatHandle) => Subscriber<any>} getExitSubscriber
  */
 
 /**
@@ -147,12 +161,12 @@
  */
 
 /**
- * @callback MakeNoEscrowSeatKit
+ * @callback MakeNoEscrowSeat
  * @param {Allocation} initialAllocation
  * @param {ProposalRecord} proposal
  * @param {ExitObj} exitObj
  * @param {SeatHandle} seatHandle
- * @returns {{userSeat: UserSeat, notifier: Notifier<Allocation>}}
+ * @returns {{userSeat: UserSeat}}
  */
 
 /**
@@ -272,14 +286,18 @@
  */
 
 /**
- * @callback ReallocateForZCFMint
- * @param {ZCFSeat} zcfSeat
- * @param {Allocation} newAllocation
- * @returns {void}
+ * @typedef {object} ZcfSeatManager
+ * @property {MakeZCFSeat} makeZCFSeat
+ * @property {Reallocate} reallocate
+ * @property {DropAllReferences} dropAllReferences
  */
 
 /**
- *
+ * @typedef {object} ZcfMintReallocator
+ * @property {(zcfSeat: ZCFSeat, newAllocation: Allocation) => void} reallocate
+ */
+
+/**
  * @callback CreateSeatManager
  *
  * The SeatManager holds the active zcfSeats and can reallocate and
@@ -289,10 +307,7 @@
  * @param {GetAssetKindByBrand} getAssetKindByBrand
  * @param {ShutdownWithFailure} shutdownWithFailure
  * @param {import('@agoric/vat-data').Baggage} zcfBaggage
- * @returns {{ makeZCFSeat: MakeZCFSeat,
-    reallocate: Reallocate,
-    reallocateForZCFMint: ReallocateForZCFMint,
-    dropAllReferences: DropAllReferences }}
+ * @returns {{ seatManager: ZcfSeatManager, zcfMintReallocator: ZcfMintReallocator }}
  */
 
 /**

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,11 +1,10 @@
 import { assert } from '@agoric/assert';
 import { initEmpty, makeHeapFarInstance } from '@agoric/store';
-import {
-  provide,
-  defineDurableFarClass,
-  makeKindHandle,
-} from '@agoric/vat-data';
+import { vivifyFarClass } from '@agoric/vat-data';
+
 import { HandleI } from './typeGuards.js';
+
+const { Fail } = assert;
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -16,14 +15,10 @@ import { HandleI } from './typeGuards.js';
  * @returns {H extends 'Instance' ? () => Instance : () => Handle<H>}
  */
 export const defineDurableHandle = (baggage, handleType) => {
-  assert.typeof(handleType, 'string', 'handleType must be a string');
-  const durableHandleKindHandle = provide(
+  typeof handleType === 'string' || Fail`handleType must be a string`;
+  const makeHandle = vivifyFarClass(
     baggage,
-    `${handleType}KindHandle`,
-    () => makeKindHandle(`${handleType}Handle`),
-  );
-  const makeHandle = defineDurableFarClass(
-    durableHandleKindHandle,
+    `${handleType}Handle`,
     HandleI,
     initEmpty,
     {},
@@ -41,7 +36,7 @@ harden(defineDurableHandle);
  * @returns {H extends 'Instance' ? Instance : Handle<H>}
  */
 export const makeHandle = handleType => {
-  assert.typeof(handleType, 'string', 'handleType must be a string');
+  typeof handleType === 'string' || Fail`handleType must be a string`;
   // Return the intersection type (really just an empty object).
   // @ts-expect-error Bit by our own opaque types.
   return /** @type {Handle<H>} */ (

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -231,11 +231,10 @@ export const SourceBundleShape = M.recordOf(
   M.string(),
   M.string({ stringLengthLimit: Infinity }),
 );
-export const ModuleFormatBundleShape = M.splitRecord(
-  harden({}),
-  harden({ moduleFormat: M.any() }),
+export const BundleShape = M.and(
+  M.partial({ moduleFormat: M.string() }),
+  M.recordOf(M.string(), M.string()),
 );
-export const BundleShape = M.or(ModuleFormatBundleShape, SourceBundleShape);
 
 export const ZoeStorageManagerIKit = harden({
   zoeServiceDataAccess: M.interface('ZoeService dataAccess', {

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -196,7 +196,11 @@ export const InstanceStorageManagerIKit = harden({
 
     saveIssuer: M.call(IssuerShape, KeywordShape).returns(M.promise()),
     makeZoeMint: M.call(KeywordShape)
-      .optional(AssetKindShape, DisplayInfoShape, M.pattern())
+      .optional(
+        AssetKindShape,
+        DisplayInfoShape,
+        M.splitRecord(harden({}), harden({ elementShape: M.pattern() })),
+      )
       .returns(M.eref(ZoeMintShape)),
     registerFeeMint: M.call(KeywordShape, M.remotable('feeMintAccess')).returns(
       M.remotable('feeMint'),

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -218,6 +218,15 @@ export const InstanceStorageManagerIKit = harden({
 });
 
 export const BundleCapShape = M.remotable('bundleCap');
+export const SourceBundleShape = M.recordOf(
+  M.string(),
+  M.string({ stringLengthLimit: Infinity }),
+);
+export const ModuleFormatBundleShape = M.splitRecord(
+  harden({}),
+  harden({ moduleFormat: M.any() }),
+);
+export const BundleShape = M.or(ModuleFormatBundleShape, SourceBundleShape);
 
 export const ZoeStorageManagerIKit = harden({
   zoeServiceDataAccess: M.interface('ZoeService dataAccess', {
@@ -234,7 +243,9 @@ export const ZoeStorageManagerIKit = harden({
     getBundleIDFromInstallation: M.call(InstallationShape).returns(
       M.eref(M.string()),
     ),
-    installBundle: M.call(InstanceHandleShape).returns(M.promise()),
+    installBundle: M.call(M.or(InstanceHandleShape, SourceBundleShape)).returns(
+      M.promise(),
+    ),
     installBundleID: M.call(M.string()).returns(M.promise()),
 
     getPublicFacet: M.call(InstanceHandleShape).returns(
@@ -268,8 +279,8 @@ export const ZoeStorageManagerIKit = harden({
       InstallationShape,
       M.any(),
       IssuerPKeywordRecordShape,
-      InstanceHandleShape,
-      BundleCapShape,
+      M.or(InstanceHandleShape, SourceBundleShape),
+      M.or(BundleCapShape, BundleShape),
     ).returns(M.promise()),
     unwrapInstallation: M.callWhen(M.eref(InstallationShape)).returns(M.any()),
   }),

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -231,10 +231,10 @@ export const SourceBundleShape = M.recordOf(
   M.string(),
   M.string({ stringLengthLimit: Infinity }),
 );
-export const BundleShape = M.and(
-  M.partial({ moduleFormat: M.string() }),
-  M.recordOf(M.string(), M.string()),
+export const ModuleFormatBundleShape = M.splitRecord(
+  harden({ moduleFormat: M.any() }),
 );
+export const BundleShape = M.and(ModuleFormatBundleShape, SourceBundleShape);
 
 export const ZoeStorageManagerIKit = harden({
   zoeServiceDataAccess: M.interface('ZoeService dataAccess', {

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -1,6 +1,18 @@
-import { AmountShape } from '@agoric/ertp';
+import {
+  AmountShape,
+  AssetKindShape,
+  DisplayInfoShape,
+  IssuerShape,
+  IssuerKitShape,
+  BrandShape,
+  PaymentShape,
+} from '@agoric/ertp';
 import { M } from '@agoric/store';
 import { TimestampValueShape } from '@agoric/swingset-vat/src/vats/timer/typeGuards.js';
+import { SubscriberShape } from '@agoric/notifier';
+
+// keywords have an initial cap
+export const KeywordShape = M.string();
 
 export const InvitationHandleShape = M.remotable('InvitationHandle');
 export const InvitationShape = M.remotable('Invitation');
@@ -8,11 +20,42 @@ export const InstanceHandleShape = M.remotable('InstanceHandle');
 export const InstallationShape = M.remotable('Installation');
 export const SeatShape = M.remotable('Seat');
 
-export const AmountKeywordRecordShape = M.recordOf(M.string(), AmountShape);
+export const AmountKeywordRecordShape = M.recordOf(KeywordShape, AmountShape);
 export const AmountPatternKeywordRecordShape = M.recordOf(
-  M.string(),
+  KeywordShape,
   M.pattern(),
 );
+export const PaymentKeywordRecordShape = M.recordOf(KeywordShape, PaymentShape);
+export const PaymentPKeywordRecordShape = M.recordOf(
+  KeywordShape,
+  M.eref(PaymentShape),
+);
+export const IssuerKeywordRecordShape = M.recordOf(KeywordShape, IssuerShape);
+export const IssuerPKeywordRecordShape = M.recordOf(
+  KeywordShape,
+  M.eref(IssuerShape),
+);
+export const BrandKeywordRecordShape = M.recordOf(KeywordShape, BrandShape);
+
+export const IssuerRecordShape = M.splitRecord(
+  {
+    brand: BrandShape,
+    issuer: IssuerShape,
+    assetKind: AssetKindShape,
+  },
+  { displayInfo: DisplayInfoShape },
+);
+
+export const TermsShape = harden({
+  issuers: IssuerKeywordRecordShape,
+  brands: BrandKeywordRecordShape,
+});
+
+export const InstanceRecordShape = harden({
+  installation: InstallationShape,
+  instance: InstanceHandleShape,
+  terms: M.split(TermsShape, M.record()),
+});
 
 export const HandleI = M.interface('Handle', {});
 
@@ -47,7 +90,7 @@ export const FullProposalShape = harden({
 export const ProposalShape = M.splitRecord({}, FullProposalShape, {});
 
 export const isOnDemandExitRule = exit => {
-  const [exitKey] = Object.getOwnPropertyNames(exit);
+  const [exitKey] = Object.keys(exit);
   return exitKey === 'onDemand';
 };
 
@@ -56,7 +99,7 @@ export const isOnDemandExitRule = exit => {
  * @returns {exit is WaivedExitRule}
  */
 export const isWaivedExitRule = exit => {
-  const [exitKey] = Object.getOwnPropertyNames(exit);
+  const [exitKey] = Object.keys(exit);
   return exitKey === 'waived';
 };
 
@@ -65,7 +108,7 @@ export const isWaivedExitRule = exit => {
  * @returns {exit is AfterDeadlineExitRule}
  */
 export const isAfterDeadlineExitRule = exit => {
-  const [exitKey] = Object.getOwnPropertyNames(exit);
+  const [exitKey] = Object.keys(exit);
   return exitKey === 'afterDeadline';
 };
 
@@ -78,4 +121,225 @@ export const InvitationElementShape = M.splitRecord({
 
 export const OfferHandlerI = M.interface('OfferHandler', {
   handle: M.call(SeatShape).optional(M.any()).returns(M.string()),
+});
+
+export const SeatHandleAllocations = M.arrayOf(
+  harden({
+    seatHandle: SeatShape,
+    allocation: AmountKeywordRecordShape,
+  }),
+);
+
+export const ZoeMintI = M.interface('ZoeMint', {
+  getIssuerRecord: M.call().returns(IssuerRecordShape),
+  mintAndEscrow: M.call(AmountShape).returns(),
+  withdrawAndBurn: M.call(AmountShape).returns(),
+});
+
+export const ZcfMintI = M.interface('ZcfMint', {
+  getIssuerRecord: M.call().returns(IssuerRecordShape),
+  mintGains: M.call(AmountKeywordRecordShape, M.remotable('zcfSeat')).returns(),
+  burnLosses: M.call(
+    AmountKeywordRecordShape,
+    M.remotable('zcfSeat'),
+  ).returns(),
+});
+
+export const ExitObjectI = M.interface('Exit Object', {
+  exit: M.call().returns(),
+});
+
+export const InstanceAdminShape = M.remotable('InstanceAdmin');
+export const InstanceAdminI = M.interface('InstanceAdmin', {
+  makeInvitation: M.call(InvitationHandleShape, M.string())
+    .optional(M.any(), M.pattern())
+    .returns(M.promise()),
+  saveIssuer: M.callWhen(M.await(IssuerShape), M.string()).returns(
+    IssuerRecordShape,
+  ),
+  isBlocked: M.call(M.string()).returns(M.boolean()),
+  makeZoeMint: M.call(KeywordShape)
+    .optional(AssetKindShape, DisplayInfoShape, M.pattern())
+    .returns(M.remotable('zoeMint')),
+  registerFeeMint: M.call(KeywordShape, M.remotable('feeMintAccess')).returns(
+    M.remotable('feeMint'),
+  ),
+  makeNoEscrowSeat: M.call(
+    AmountKeywordRecordShape,
+    ProposalShape,
+    M.remotable('ExitObj'),
+    SeatShape,
+  ).returns({ userSeat: SeatShape }),
+  replaceAllocations: M.call(SeatHandleAllocations).returns(),
+  exitAllSeats: M.call(M.any()).returns(),
+  failAllSeats: M.call(M.any()).returns(),
+  exitSeat: M.call(SeatShape, M.any()).returns(),
+  failSeat: M.call(SeatShape, M.any()).returns(),
+  stopAcceptingOffers: M.call().returns(),
+  setOfferFilter: M.call(M.arrayOf(M.string())).returns(),
+  getOfferFilter: M.call().returns(M.arrayOf(M.string())),
+  getExitSubscriber: M.call(SeatShape).returns(SubscriberShape),
+});
+
+export const InstanceStorageManagerI = M.interface('InstanceStorageManager', {
+  getTerms: M.call().returns(M.split(TermsShape, M.record())),
+  getIssuers: M.call().returns(IssuerKeywordRecordShape),
+  getBrands: M.call().returns(BrandKeywordRecordShape),
+  getInstallationForInstance: M.call().returns(InstallationShape),
+  getInvitationIssuer: M.call().returns(IssuerShape),
+
+  saveIssuer: M.call(IssuerShape, M.string()).returns(M.promise()),
+  makeZoeMint: M.call(KeywordShape)
+    .optional(AssetKindShape, DisplayInfoShape, M.pattern())
+    .returns(M.or(ZoeMintI, M.remotable('zoeMint'), M.promise())),
+  registerFeeMint: M.call(KeywordShape, M.remotable('feeMintAccess')).returns(
+    IssuerKitShape,
+  ),
+  getInstanceRecord: M.call().returns(InstanceRecordShape),
+  getIssuerRecords: M.call().returns(M.arrayOf(IssuerRecordShape)),
+  getWithdrawPayments: M.call().returns(M.remotable('WithdrawFacet')),
+  initInstanceAdmin: M.call(
+    InstanceHandleShape,
+    M.remotable('instanceAdmin'),
+  ).returns(M.promise()),
+  deleteInstanceAdmin: M.call(InstanceAdminI).returns(),
+  makeInvitation: M.call(InvitationHandleShape, M.string())
+    .optional(M.any(), M.pattern())
+    .returns(M.promise()),
+  getRoot: M.call().returns(M.promise()),
+  getAdminNode: M.call().returns(M.remotable('adminNode')),
+});
+
+// In `SwingSet/src/types-external.js`, it's typed as `*`.
+const BundleCapShape = M.any();
+
+export const ZoeStorageManagerIKit = harden({
+  zoeServiceDataAccess: M.interface('ZoeService dataAccess', {
+    getTerms: M.call(InstanceHandleShape).returns(
+      M.split(TermsShape, M.record()),
+    ),
+    getIssuers: M.call(InstanceHandleShape).returns(IssuerKeywordRecordShape),
+    getBrands: M.call(InstanceHandleShape).returns(BrandKeywordRecordShape),
+    getInstallationForInstance: M.call(InstanceHandleShape).returns(
+      M.or(M.promise(), M.remotable('Installation')),
+    ),
+    getInvitationIssuer: M.call().returns(IssuerShape),
+
+    getBundleIDFromInstallation: M.call(M.any()).returns(M.promise()),
+    installBundle: M.call(M.any()).returns(M.promise()),
+    installBundleID: M.call(M.string()).returns(M.promise()),
+
+    getPublicFacet: M.call(InstanceHandleShape).returns(
+      M.or(M.promise(), M.remotable('PublicFacet')),
+    ),
+    getOfferFilter: M.call(InstanceHandleShape).returns(M.arrayOf(M.string())),
+    setOfferFilter: M.call(
+      InstanceHandleShape,
+      M.arrayOf(M.string()),
+    ).returns(),
+    getProposalShapeForInvitation: M.call(InvitationHandleShape).returns(
+      M.or(M.pattern(), M.undefined()),
+    ),
+  }),
+  makeOfferAccess: M.interface('ZoeStorage makeOffer access', {
+    getAssetKindByBrand: M.call(BrandShape).returns(AssetKindShape),
+    installBundle: M.call(InstanceHandleShape).returns(),
+    getInstanceAdmin: M.call(InstanceHandleShape).returns(
+      M.remotable('instanceAdmin'),
+    ),
+    getProposalShapeForInvitation: M.call(InvitationHandleShape).returns(
+      M.or(M.pattern(), M.undefined()),
+    ),
+    getInvitationIssuer: M.call().returns(IssuerShape),
+    depositPayments: M.call(ProposalShape, PaymentPKeywordRecordShape).returns(
+      M.promise(),
+    ),
+  }),
+  startInstanceAccess: M.interface('ZoeStorage startInstance access', {
+    makeZoeInstanceStorageManager: M.call(
+      M.any(),
+      InstallationShape,
+      M.any(),
+      IssuerPKeywordRecordShape,
+      InstanceHandleShape,
+      BundleCapShape,
+    ).returns(M.promise()),
+    unwrapInstallation: M.callWhen(M.eref(InstallationShape)).returns(M.any()),
+  }),
+  invitationIssuerAccess: M.interface('ZoeStorage invitationIssuer', {
+    getInvitationIssuer: M.call().returns(IssuerShape),
+  }),
+});
+
+export const ZoeServiceIKit = harden({
+  zoeService: M.interface('ZoeService', {
+    install: M.call(M.any()).returns(M.promise()),
+    installBundleID: M.call(M.string()).returns(M.promise()),
+    startInstance: M.call(M.eref(InstallationShape))
+      .optional(IssuerPKeywordRecordShape, M.any(), M.any())
+      .returns(M.promise()),
+    offer: M.call(M.eref(InvitationShape))
+      .optional(ProposalShape, PaymentPKeywordRecordShape, M.any())
+      .returns(M.promise()),
+
+    getPublicFacet: M.callWhen(M.await(InstanceHandleShape)).returns(
+      M.or(M.promise(), M.remotable('PublicFacet')),
+    ),
+    getBrands: M.callWhen(M.await(InstanceHandleShape)).returns(
+      M.or(M.promise(), BrandKeywordRecordShape),
+    ),
+    getIssuers: M.callWhen(M.await(InstanceHandleShape)).returns(
+      M.or(M.promise(), IssuerKeywordRecordShape),
+    ),
+    getOfferFilter: M.callWhen(M.await(InstanceHandleShape)).returns(
+      M.arrayOf(M.string()),
+    ),
+    setOfferFilter: M.call(
+      InstanceHandleShape,
+      M.arrayOf(M.string()),
+    ).returns(),
+    getTerms: M.callWhen(M.await(InstanceHandleShape)).returns(M.any()),
+    getInstallationForInstance: M.callWhen(
+      M.await(InstanceHandleShape),
+    ).returns(M.or(M.promise(), M.remotable('Installation'))),
+    getInvitationIssuer: M.call().returns(M.promise()),
+    getBundleIDFromInstallation: M.call(M.any()).returns(M.promise()),
+
+    getFeeIssuer: M.call().returns(M.promise()),
+    getInstance: M.call(M.eref(InvitationShape)).returns(M.promise()),
+    getInstallation: M.call(M.eref(InvitationShape)).returns(M.promise()),
+    getInvitationDetails: M.call(M.eref(InvitationShape)).returns(M.any()),
+    getConfiguration: M.call().returns({
+      feeIssuerConfig: {
+        name: M.string(),
+        assetKind: 'nat',
+        displayInfo: M.any(),
+      },
+    }),
+    getProposalShapeForInvitation: M.call(InvitationHandleShape).returns(
+      M.or(ProposalShape, M.undefined()),
+    ),
+  }),
+  feeMintAccessRetriever: M.interface('FeeMintAccessRetriever', {
+    get: M.call().returns(M.any()),
+  }),
+});
+
+export const AdminFacetI = M.interface('ZcfAdminFacet', {
+  getVatShutdownPromise: M.call().returns(M.promise()),
+  restartContract: M.call().optional(M.any()).returns(M.promise()),
+  upgradeContract: M.call(M.string()).optional(M.any()).returns(M.promise()),
+});
+
+export const SeatDataShape = harden({
+  proposal: ProposalShape,
+  initialAllocation: AmountKeywordRecordShape,
+  seatHandle: SeatShape,
+});
+
+export const HandleOfferI = M.interface('HandleOffer', {
+  handleOffer: M.call(InvitationHandleShape, SeatDataShape).returns({
+    offerResultPromise: M.promise(),
+    exitObj: ExitObjectI,
+  }),
 });

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -330,7 +330,7 @@ export const ZoeServiceIKit = harden({
       M.await(InstanceHandleShape),
     ).returns(M.eref(M.remotable('Installation'))),
     getBundleIDFromInstallation: M.call(InstallationShape).returns(
-      M.eref(M.string),
+      M.eref(M.string()),
     ),
 
     getInstallation: M.call(M.eref(InvitationShape)).returns(M.promise()),

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -239,7 +239,7 @@ export const ZoeStorageManagerIKit = harden({
     getIssuers: M.call(InstanceHandleShape).returns(IssuerKeywordRecordShape),
     getBrands: M.call(InstanceHandleShape).returns(BrandKeywordRecordShape),
     getInstallationForInstance: M.call(InstanceHandleShape).returns(
-      M.or(M.promise(), M.remotable('Installation')),
+      M.eref(M.remotable('Installation')),
     ),
     getInvitationIssuer: M.call().returns(IssuerShape),
 
@@ -252,7 +252,7 @@ export const ZoeStorageManagerIKit = harden({
     installBundleID: M.call(M.string()).returns(M.promise()),
 
     getPublicFacet: M.call(InstanceHandleShape).returns(
-      M.or(M.promise(), M.remotable('PublicFacet')),
+      M.eref(M.remotable('PublicFacet')),
     ),
     getOfferFilter: M.call(InstanceHandleShape).returns(M.arrayOf(M.string())),
     setOfferFilter: M.call(
@@ -313,10 +313,10 @@ export const ZoeServiceIKit = harden({
     getInvitationIssuer: M.call().returns(M.promise()),
     getFeeIssuer: M.call().returns(M.promise()),
     getBrands: M.callWhen(M.await(InstanceHandleShape)).returns(
-      M.or(M.promise(), BrandKeywordRecordShape),
+      BrandKeywordRecordShape,
     ),
     getIssuers: M.callWhen(M.await(InstanceHandleShape)).returns(
-      M.or(M.promise(), IssuerKeywordRecordShape),
+      IssuerKeywordRecordShape,
     ),
     getPublicFacet: M.callWhen(M.await(InstanceHandleShape)).returns(
       M.remotable('PublicFacet'),
@@ -324,7 +324,7 @@ export const ZoeServiceIKit = harden({
     getTerms: M.callWhen(M.await(InstanceHandleShape)).returns(M.any()),
     getInstallationForInstance: M.callWhen(
       M.await(InstanceHandleShape),
-    ).returns(M.or(M.promise(), M.remotable('Installation'))),
+    ).returns(M.eref(M.remotable('Installation'))),
     getBundleIDFromInstallation: M.call(InstallationShape).returns(
       M.eref(M.string),
     ),

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -260,7 +260,7 @@ export const ZoeStorageManagerIKit = harden({
       M.arrayOf(M.string()),
     ).returns(),
     getProposalShapeForInvitation: M.call(InvitationHandleShape).returns(
-      M.or(M.pattern(), M.undefined()),
+      M.opt(M.pattern()),
     ),
   }),
   makeOfferAccess: M.interface('ZoeStorage makeOffer access', {
@@ -269,7 +269,7 @@ export const ZoeStorageManagerIKit = harden({
       M.remotable('instanceAdmin'),
     ),
     getProposalShapeForInvitation: M.call(InvitationHandleShape).returns(
-      M.or(M.pattern(), M.undefined()),
+      M.opt(M.pattern()),
     ),
     getInvitationIssuer: M.call().returns(IssuerShape),
     depositPayments: M.call(ProposalShape, PaymentPKeywordRecordShape).returns(

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -227,14 +227,10 @@ export const InstanceStorageManagerIKit = harden({
 });
 
 export const BundleCapShape = M.remotable('bundleCap');
-export const SourceBundleShape = M.recordOf(
-  M.string(),
-  M.string({ stringLengthLimit: Infinity }),
+export const BundleShape = M.and(
+  M.splitRecord({ moduleFormat: M.any() }),
+  M.recordOf(M.string(), M.string({ stringLengthLimit: Infinity })),
 );
-export const ModuleFormatBundleShape = M.splitRecord(
-  harden({ moduleFormat: M.any() }),
-);
-export const BundleShape = M.and(ModuleFormatBundleShape, SourceBundleShape);
 
 export const ZoeStorageManagerIKit = harden({
   zoeServiceDataAccess: M.interface('ZoeService dataAccess', {
@@ -249,7 +245,7 @@ export const ZoeStorageManagerIKit = harden({
     getBundleIDFromInstallation: M.call(InstallationShape).returns(
       M.eref(M.string()),
     ),
-    installBundle: M.call(M.or(InstanceHandleShape, SourceBundleShape)).returns(
+    installBundle: M.call(M.or(InstanceHandleShape, BundleShape)).returns(
       M.promise(),
     ),
     installBundleID: M.call(M.string()).returns(M.promise()),
@@ -285,7 +281,7 @@ export const ZoeStorageManagerIKit = harden({
       InstallationShape,
       M.any(),
       IssuerPKeywordRecordShape,
-      M.or(InstanceHandleShape, SourceBundleShape),
+      M.or(InstanceHandleShape, BundleShape),
       M.or(BundleCapShape, BundleShape),
     ).returns(M.promise()),
     unwrapInstallation: M.callWhen(M.eref(InstallationShape)).returns(M.any()),

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -3,7 +3,6 @@ import {
   AssetKindShape,
   DisplayInfoShape,
   IssuerShape,
-  IssuerKitShape,
   BrandShape,
   PaymentShape,
 } from '@agoric/ertp';
@@ -54,7 +53,7 @@ export const TermsShape = harden({
 export const InstanceRecordShape = harden({
   installation: InstallationShape,
   instance: InstanceHandleShape,
-  terms: M.split(TermsShape, M.record()),
+  terms: M.splitRecord(TermsShape),
 });
 
 export const HandleI = M.interface('Handle', {});
@@ -123,7 +122,7 @@ export const OfferHandlerI = M.interface('OfferHandler', {
   handle: M.call(SeatShape).optional(M.any()).returns(M.string()),
 });
 
-export const SeatHandleAllocations = M.arrayOf(
+export const SeatHandleAllocationsShape = M.arrayOf(
   harden({
     seatHandle: SeatShape,
     allocation: AmountKeywordRecordShape,
@@ -149,69 +148,76 @@ export const ExitObjectI = M.interface('Exit Object', {
   exit: M.call().returns(),
 });
 
+const ExitObjectShape = M.remotable('ExitObj');
 export const InstanceAdminShape = M.remotable('InstanceAdmin');
 export const InstanceAdminI = M.interface('InstanceAdmin', {
   makeInvitation: M.call(InvitationHandleShape, M.string())
-    .optional(M.any(), M.pattern())
+    .optional(M.record(), M.pattern())
     .returns(M.promise()),
   saveIssuer: M.callWhen(M.await(IssuerShape), M.string()).returns(
     IssuerRecordShape,
   ),
-  isBlocked: M.call(M.string()).returns(M.boolean()),
+  makeNoEscrowSeat: M.call(
+    AmountKeywordRecordShape,
+    ProposalShape,
+    ExitObjectShape,
+    SeatShape,
+  ).returns(SeatShape),
+  exitAllSeats: M.call(M.any()).returns(),
+  failAllSeats: M.call(M.any()).returns(),
+  exitSeat: M.call(SeatShape, M.any()).returns(),
+  failSeat: M.call(SeatShape, M.any()).returns(),
   makeZoeMint: M.call(KeywordShape)
     .optional(AssetKindShape, DisplayInfoShape, M.pattern())
     .returns(M.remotable('zoeMint')),
   registerFeeMint: M.call(KeywordShape, M.remotable('feeMintAccess')).returns(
     M.remotable('feeMint'),
   ),
-  makeNoEscrowSeat: M.call(
-    AmountKeywordRecordShape,
-    ProposalShape,
-    M.remotable('ExitObj'),
-    SeatShape,
-  ).returns({ userSeat: SeatShape }),
-  replaceAllocations: M.call(SeatHandleAllocations).returns(),
-  exitAllSeats: M.call(M.any()).returns(),
-  failAllSeats: M.call(M.any()).returns(),
-  exitSeat: M.call(SeatShape, M.any()).returns(),
-  failSeat: M.call(SeatShape, M.any()).returns(),
+  replaceAllocations: M.call(SeatHandleAllocationsShape).returns(),
   stopAcceptingOffers: M.call().returns(),
   setOfferFilter: M.call(M.arrayOf(M.string())).returns(),
   getOfferFilter: M.call().returns(M.arrayOf(M.string())),
   getExitSubscriber: M.call(SeatShape).returns(SubscriberShape),
+  isBlocked: M.call(M.string()).returns(M.boolean()),
 });
 
-export const InstanceStorageManagerI = M.interface('InstanceStorageManager', {
-  getTerms: M.call().returns(M.split(TermsShape, M.record())),
-  getIssuers: M.call().returns(IssuerKeywordRecordShape),
-  getBrands: M.call().returns(BrandKeywordRecordShape),
-  getInstallationForInstance: M.call().returns(InstallationShape),
-  getInvitationIssuer: M.call().returns(IssuerShape),
+export const InstanceStorageManagerIKit = harden({
+  instanceStorageManager: M.interface('InstanceStorageManager', {
+    getTerms: M.call().returns(M.split(TermsShape, M.record())),
+    getIssuers: M.call().returns(IssuerKeywordRecordShape),
+    getBrands: M.call().returns(BrandKeywordRecordShape),
+    getInstallationForInstance: M.call().returns(InstallationShape),
+    getInvitationIssuer: M.call().returns(IssuerShape),
 
-  saveIssuer: M.call(IssuerShape, M.string()).returns(M.promise()),
-  makeZoeMint: M.call(KeywordShape)
-    .optional(AssetKindShape, DisplayInfoShape, M.pattern())
-    .returns(M.or(ZoeMintI, M.remotable('zoeMint'), M.promise())),
-  registerFeeMint: M.call(KeywordShape, M.remotable('feeMintAccess')).returns(
-    IssuerKitShape,
-  ),
-  getInstanceRecord: M.call().returns(InstanceRecordShape),
-  getIssuerRecords: M.call().returns(M.arrayOf(IssuerRecordShape)),
-  getWithdrawPayments: M.call().returns(M.remotable('WithdrawFacet')),
-  initInstanceAdmin: M.call(
-    InstanceHandleShape,
-    M.remotable('instanceAdmin'),
-  ).returns(M.promise()),
-  deleteInstanceAdmin: M.call(InstanceAdminI).returns(),
-  makeInvitation: M.call(InvitationHandleShape, M.string())
-    .optional(M.any(), M.pattern())
-    .returns(M.promise()),
-  getRoot: M.call().returns(M.promise()),
-  getAdminNode: M.call().returns(M.remotable('adminNode')),
+    saveIssuer: M.call(IssuerShape, M.string()).returns(M.promise()),
+    makeZoeMint: M.call(KeywordShape)
+      .optional(AssetKindShape, DisplayInfoShape, M.pattern())
+      .returns(M.or(ZoeMintI, M.remotable('zoeMint'), M.promise())),
+    registerFeeMint: M.call(KeywordShape, M.remotable('feeMintAccess')).returns(
+      M.remotable('feeMint'),
+    ),
+    getInstanceRecord: M.call().returns(InstanceRecordShape),
+    getIssuerRecords: M.call().returns(M.arrayOf(IssuerRecordShape)),
+    getWithdrawFacet: M.call().returns(M.remotable('WithdrawFacet')),
+    initInstanceAdmin: M.call(
+      InstanceHandleShape,
+      M.remotable('instanceAdmin'),
+    ).returns(M.promise()),
+    deleteInstanceAdmin: M.call(InstanceAdminI).returns(),
+    makeInvitation: M.call(InvitationHandleShape, M.string())
+      .optional(M.any(), M.pattern())
+      .returns(M.promise()),
+    getRoot: M.call().returns(M.any()),
+    getAdminNode: M.call().returns(M.remotable('adminNode')),
+  }),
+  withdrawFacet: M.interface('WithdrawFacet', {
+    withdrawPayments: M.call(AmountKeywordRecordShape).returns(
+      PaymentPKeywordRecordShape,
+    ),
+  }),
 });
 
-// In `SwingSet/src/types-external.js`, it's typed as `*`.
-const BundleCapShape = M.any();
+export const BundleCapShape = M.remotable('bundleCap');
 
 export const ZoeStorageManagerIKit = harden({
   zoeServiceDataAccess: M.interface('ZoeService dataAccess', {
@@ -225,8 +231,10 @@ export const ZoeStorageManagerIKit = harden({
     ),
     getInvitationIssuer: M.call().returns(IssuerShape),
 
-    getBundleIDFromInstallation: M.call(M.any()).returns(M.promise()),
-    installBundle: M.call(M.any()).returns(M.promise()),
+    getBundleIDFromInstallation: M.call(InstallationShape).returns(
+      M.eref(M.string()),
+    ),
+    installBundle: M.call(InstanceHandleShape).returns(M.promise()),
     installBundleID: M.call(M.string()).returns(M.promise()),
 
     getPublicFacet: M.call(InstanceHandleShape).returns(
@@ -243,7 +251,6 @@ export const ZoeStorageManagerIKit = harden({
   }),
   makeOfferAccess: M.interface('ZoeStorage makeOffer access', {
     getAssetKindByBrand: M.call(BrandShape).returns(AssetKindShape),
-    installBundle: M.call(InstanceHandleShape).returns(),
     getInstanceAdmin: M.call(InstanceHandleShape).returns(
       M.remotable('instanceAdmin'),
     ),
@@ -281,43 +288,43 @@ export const ZoeServiceIKit = harden({
     offer: M.call(M.eref(InvitationShape))
       .optional(ProposalShape, PaymentPKeywordRecordShape, M.any())
       .returns(M.promise()),
+    setOfferFilter: M.call(
+      InstanceHandleShape,
+      M.arrayOf(M.string()),
+    ).returns(),
 
-    getPublicFacet: M.callWhen(M.await(InstanceHandleShape)).returns(
-      M.or(M.promise(), M.remotable('PublicFacet')),
+    getOfferFilter: M.callWhen(M.await(InstanceHandleShape)).returns(
+      M.arrayOf(M.string()),
     ),
+    getInvitationIssuer: M.call().returns(M.promise()),
+    getFeeIssuer: M.call().returns(M.promise()),
     getBrands: M.callWhen(M.await(InstanceHandleShape)).returns(
       M.or(M.promise(), BrandKeywordRecordShape),
     ),
     getIssuers: M.callWhen(M.await(InstanceHandleShape)).returns(
       M.or(M.promise(), IssuerKeywordRecordShape),
     ),
-    getOfferFilter: M.callWhen(M.await(InstanceHandleShape)).returns(
-      M.arrayOf(M.string()),
+    getPublicFacet: M.callWhen(M.await(InstanceHandleShape)).returns(
+      M.remotable('PublicFacet'),
     ),
-    setOfferFilter: M.call(
-      InstanceHandleShape,
-      M.arrayOf(M.string()),
-    ).returns(),
     getTerms: M.callWhen(M.await(InstanceHandleShape)).returns(M.any()),
     getInstallationForInstance: M.callWhen(
       M.await(InstanceHandleShape),
     ).returns(M.or(M.promise(), M.remotable('Installation'))),
-    getInvitationIssuer: M.call().returns(M.promise()),
     getBundleIDFromInstallation: M.call(M.any()).returns(M.promise()),
 
-    getFeeIssuer: M.call().returns(M.promise()),
-    getInstance: M.call(M.eref(InvitationShape)).returns(M.promise()),
     getInstallation: M.call(M.eref(InvitationShape)).returns(M.promise()),
-    getInvitationDetails: M.call(M.eref(InvitationShape)).returns(M.any()),
+    getInstance: M.call(M.eref(InvitationShape)).returns(M.promise()),
     getConfiguration: M.call().returns({
       feeIssuerConfig: {
         name: M.string(),
         assetKind: 'nat',
-        displayInfo: M.any(),
+        displayInfo: DisplayInfoShape,
       },
     }),
+    getInvitationDetails: M.call(M.eref(InvitationShape)).returns(M.any()),
     getProposalShapeForInvitation: M.call(InvitationHandleShape).returns(
-      M.or(ProposalShape, M.undefined()),
+      M.opt(ProposalShape),
     ),
   }),
   feeMintAccessRetriever: M.interface('FeeMintAccessRetriever', {

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -2,7 +2,7 @@
 
 /**
  * @template {string} H - the name of the handle
- * @typedef {H & {}} Handle A type constructor for an opaque type
+ * @typedef {H & import("@endo/marshal").Remotable} Handle A type constructor for an opaque type
  * identified by the H string. This uses an intersection type
  * ('MyHandle' & {}) to tag the handle's type even though the actual
  * value is just an empty object.

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -16,7 +16,7 @@ import { arrayToObj } from '../objArrayConversion.js';
  *
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
-export const makeEscrowStorage = baggage => {
+export const provideEscrowStorage = baggage => {
   /** @type {WeakStore<Brand, ERef<Purse>>} */
   const brandToPurse = provideDurableWeakMapStore(baggage, 'brandToPurse');
 
@@ -41,9 +41,9 @@ export const makeEscrowStorage = baggage => {
   };
 
   /**
-   * @type {MakeLocalPurse}
+   * @type {ProvideLocalPurse}
    */
-  const makeLocalPurse = (issuer, brand) => {
+  const provideLocalPurse = (issuer, brand) => {
     if (brandToPurse.has(brand)) {
       return /** @type {Purse} */ (brandToPurse.get(brand));
     } else {
@@ -132,7 +132,7 @@ export const makeEscrowStorage = baggage => {
 
   return {
     createPurse, // createPurse does not return a purse
-    makeLocalPurse,
+    provideLocalPurse,
     withdrawPayments,
     depositPayments,
   };

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -1,6 +1,10 @@
 import { makeDurableIssuerKit, AssetKind } from '@agoric/ertp';
 import { initEmpty } from '@agoric/store';
-import { vivifyKindMulti, provideDurableMapStore } from '@agoric/vat-data';
+import {
+  vivifyKindMulti,
+  provideDurableMapStore,
+  provide,
+} from '@agoric/vat-data';
 
 const FEE_MINT_KIT = 'FeeMintKit';
 
@@ -16,12 +20,6 @@ export const defaultFeeIssuerConfig = harden(
  * @param {import('@agoric/vat-data').Baggage} zoeBaggage
  * @param {FeeIssuerConfig} feeIssuerConfig
  * @param {ShutdownWithFailure} shutdownZoeVat
- * @returns {{
- *    getFeeMintAccess: () => FeeMintAccess,
- *    getFeeIssuerKit: GetFeeIssuerKit,
- *    getFeeIssuer: () => Issuer<'nat'>,
- *    getFeeBrand: () => Brand<'nat'>,
- * }}
  */
 const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   const mintBaggage = provideDurableMapStore(zoeBaggage, 'mintBaggage');
@@ -48,7 +46,6 @@ const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   const makeFeeMintKit = vivifyKindMulti(mintBaggage, 'FeeMint', initEmpty, {
     feeMint: {
       getFeeIssuerKit,
-      getFeeMintAccess: ({ facets }) => facets.feeMintAccess,
       getFeeIssuer: () => mintBaggage.get(FEE_MINT_KIT).issuer,
       getFeeBrand: () => mintBaggage.get(FEE_MINT_KIT).brand,
     },
@@ -57,8 +54,7 @@ const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
     feeMintAccess: {},
   });
 
-  const { feeMint } = makeFeeMintKit();
-  return feeMint;
+  return provide(zoeBaggage, 'theFeeMint', () => makeFeeMintKit());
 };
 
 export { vivifyFeeMint };

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -10,7 +10,7 @@ import { initEmpty } from '@agoric/store';
 import {
   InstallationShape,
   BundleCapShape,
-  SourceBundleShape,
+  BundleShape,
   InstanceHandleShape,
 } from '../typeGuards.js';
 
@@ -80,7 +80,7 @@ export const makeInstallationStorage = (
       installation: InstallationShape,
     }),
     harden({
-      bundle: SourceBundleShape,
+      bundle: BundleShape,
       bundleCap: BundleCapShape,
       bundleID: M.string(),
     }),
@@ -88,7 +88,7 @@ export const makeInstallationStorage = (
   );
 
   const InstallationStorageI = M.interface('InstallationStorage', {
-    installBundle: M.call(M.or(InstanceHandleShape, SourceBundleShape)).returns(
+    installBundle: M.call(M.or(InstanceHandleShape, BundleShape)).returns(
       M.promise(),
     ),
     installBundleID: M.call(M.string()).returns(M.promise()),

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -7,20 +7,18 @@ import {
   vivifyKind,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
-import { InstallationShape, BundleCapShape } from '../typeGuards.js';
+import {
+  InstallationShape,
+  BundleCapShape,
+  SourceBundleShape,
+  InstanceHandleShape,
+} from '../typeGuards.js';
 
 const { Fail } = assert;
 
 /** @typedef { import('@agoric/swingset-vat').BundleCap} BundleCap */
 /** @typedef { import('@agoric/swingset-vat').BundleID} BundleID */
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
-
-export const SourceBundleShape = M.recordOf(M.string(), M.string());
-export const ModuleFormatBundleShape = M.splitRecord(
-  harden({}),
-  harden({ moduleFormat: M.any() }),
-);
-export const BundleShape = M.or(ModuleFormatBundleShape, SourceBundleShape);
 
 /**
  * @param {GetBundleCapForID} getBundleCapForID
@@ -90,7 +88,9 @@ export const makeInstallationStorage = (
   );
 
   const InstallationStorageI = M.interface('InstallationStorage', {
-    installBundle: M.call(BundleShape).returns(M.promise()),
+    installBundle: M.call(M.or(InstanceHandleShape, SourceBundleShape)).returns(
+      M.promise(),
+    ),
     installBundleID: M.call(M.string()).returns(M.promise()),
     unwrapInstallation: M.callWhen(M.await(InstallationShape)).returns(
       UnwrappedInstallationShape,

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -139,8 +139,6 @@ export const makeInstallationStorage = (
         );
         return installation;
       },
-      // XXX is there a better way to declare that the final else throws?
-      // eslint-disable-next-line consistent-return
       unwrapInstallation(installation) {
         if (installationsBundleCap.has(installation)) {
           const { bundleCap, bundleID } =
@@ -150,7 +148,7 @@ export const makeInstallationStorage = (
           const bundle = installationsBundle.get(installation);
           return { bundle, installation };
         } else {
-          Fail`${installation} was not a valid installation`;
+          throw Fail`${installation} was not a valid installation`;
         }
       },
       async getBundleIDFromInstallation(allegedInstallation) {

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -1,19 +1,30 @@
 import { assert, details as X } from '@agoric/assert';
-import { E } from '@endo/eventual-send';
 import {
+  M,
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
+  vivifyFarInstance,
   vivifyKind,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
+import { InstallationShape } from '../typeGuards.js';
+
+const { Fail } = assert;
 
 /** @typedef { import('@agoric/swingset-vat').BundleCap} BundleCap */
 /** @typedef { import('@agoric/swingset-vat').BundleID} BundleID */
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
+export const SourceBundleShape = M.recordOf(M.string(), M.string());
+export const ModuleFormatBundleShape = M.splitRecord(
+  harden({}),
+  harden({ moduleFormat: M.any() }),
+);
+export const BundleShape = M.or(ModuleFormatBundleShape, SourceBundleShape);
+
 /**
  * @param {GetBundleCapForID} getBundleCapForID
- * @param {Baggage} [zoeBaggage]
+ * @param {Baggage} [zoeBaggage] optional only so it can be omitted in tests
  */
 export const makeInstallationStorage = (
   getBundleCapForID,
@@ -54,80 +65,88 @@ export const makeInstallationStorage = (
    * an instance is started.
    */
 
-  /** @type {InstallBundleID} */
-  const installBundleID = async bundleID => {
-    assert.typeof(bundleID, 'string', `a bundle ID must be provided`);
-    // this waits until someone tells the host application to store the
-    // bundle into the kernel, with controller.validateAndInstallBundle()
-    const bundleCap = await getBundleCapForID(bundleID);
-    // AWAIT
-
-    /** @type {Installation} */
-    // @ts-expect-error cast
-    const installation = makeBundleIDInstallation();
-    installationsBundleCap.init(installation, harden({ bundleCap, bundleID }));
-    return installation;
-  };
-
   /** @type {InstallBundle} */
   const installSourceBundle = async bundle => {
-    assert.typeof(bundle, 'object', 'a bundle must be provided');
+    typeof bundle === 'object' || Fail`a bundle must be provided`;
+    /** @type {Installation} */
+    bundle || Fail`a bundle must be provided`;
     /** @type {Installation} */
     // @ts-expect-error cast
     const installation = makeBundleInstallation(bundle);
-    assert(bundle, 'a bundle must be provided');
     installationsBundle.init(installation, bundle);
     return installation;
   };
 
-  /** @type {InstallBundle} */
-  const installBundle = async allegedBundle => {
-    // Bundle is a very open-ended type and we must decide here
-    // whether to treat it as either a HashBundle or SourceBundle.
-    // So, we cast it down and inspect it.
-    const bundle = /** @type {unknown} */ (harden(allegedBundle));
-    assert.typeof(bundle, 'object', 'a bundle must be provided');
-    assert(bundle !== null, 'a bundle must be provided');
-    const { moduleFormat } = bundle;
-    if (moduleFormat === 'endoZipBase64Sha512') {
-      const { endoZipBase64Sha512 } = bundle;
-      assert.typeof(
-        endoZipBase64Sha512,
-        'string',
-        `bundle endoZipBase64Sha512 must be a string, got ${endoZipBase64Sha512}`,
-      );
-      return installBundleID(`b1-${endoZipBase64Sha512}`);
-    }
-    return installSourceBundle(bundle);
-  };
-
-  /** @type {UnwrapInstallation} */
-  const unwrapInstallation = installationP => {
-    return E.when(installationP, installation => {
-      if (installationsBundleCap.has(installation)) {
-        const { bundleCap, bundleID } =
-          installationsBundleCap.get(installation);
-        return { bundleCap, bundleID, installation };
-      } else if (installationsBundle.has(installation)) {
-        const bundle = installationsBundle.get(installation);
-        return { bundle, installation };
-      } else {
-        assert.fail(X`${installation} was not a valid installation`);
-      }
-    });
-  };
-
-  const getBundleIDFromInstallation = async allegedInstallationP => {
-    const { bundleID } = await unwrapInstallation(allegedInstallationP);
-    // AWAIT
-    assert(bundleID, 'installation does not have a bundle ID');
-    return bundleID;
-  };
-
-  return harden({
-    installBundle,
-    installBundleID,
-    unwrapInstallation,
-    getBundleIDFromInstallation,
+  const InstallationStorageI = M.interface('InstallationStorage', {
+    installBundle: M.call(BundleShape).returns(M.promise()),
+    installBundleID: M.call(M.string()).returns(M.promise()),
+    unwrapInstallation: M.callWhen(M.await(InstallationShape)).returns(M.any()),
+    getBundleIDFromInstallation: M.call(InstallationShape).returns(M.promise()),
   });
+
+  const installationStorage = vivifyFarInstance(
+    zoeBaggage,
+    'InstallationStorage',
+    InstallationStorageI,
+    {
+      async installBundle(allegedBundle) {
+        // Bundle is a very open-ended type and we must decide here whether to
+        // treat it as either a HashBundle or SourceBundle. So we have to
+        // inspect it.
+        typeof allegedBundle === 'object' || Fail`a bundle must be provided`;
+        allegedBundle !== null || Fail`a bundle must be provided`;
+        const { moduleFormat } = allegedBundle;
+        if (moduleFormat === 'endoZipBase64Sha512') {
+          const { endoZipBase64Sha512 } = allegedBundle;
+          assert.typeof(
+            endoZipBase64Sha512,
+            'string',
+            `bundle endoZipBase64Sha512 must be a string, got ${endoZipBase64Sha512}`,
+          );
+          return this.installBundleID(`b1-${endoZipBase64Sha512}`);
+        }
+        return installSourceBundle(allegedBundle);
+      },
+      async installBundleID(bundleID) {
+        typeof bundleID === 'string' || Fail`a bundle ID must be provided`;
+        // this waits until someone tells the host application to store the
+        // bundle into the kernel, with controller.validateAndInstallBundle()
+        const bundleCap = await getBundleCapForID(bundleID);
+        // AWAIT
+
+        /** @type {Installation} */
+        // @ts-expect-error cast
+        const installation = makeBundleIDInstallation();
+        installationsBundleCap.init(
+          installation,
+          harden({ bundleCap, bundleID }),
+        );
+        return installation;
+      },
+      unwrapInstallation(installation) {
+        if (installationsBundleCap.has(installation)) {
+          const { bundleCap, bundleID } =
+            installationsBundleCap.get(installation);
+          return { bundleCap, bundleID, installation };
+        } else if (installationsBundle.has(installation)) {
+          const bundle = installationsBundle.get(installation);
+          return { bundle, installation };
+        } else {
+          assert.fail(X`${installation} was not a valid installation`);
+        }
+      },
+      async getBundleIDFromInstallation(allegedInstallationP) {
+        // @ts-expect-error TS doesn't understand context
+        const { self } = this;
+        const { bundleID } = await self.unwrapInstallation(
+          allegedInstallationP,
+        );
+        // AWAIT
+        bundleID || Fail`installation does not have a bundle ID`;
+        return bundleID;
+      },
+    },
+  );
+
+  return installationStorage;
 };

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -10,7 +10,6 @@ import { initEmpty } from '@agoric/store';
 import {
   InstallationShape,
   BundleCapShape,
-  BundleShape,
   InstanceHandleShape,
 } from '../typeGuards.js';
 
@@ -80,7 +79,7 @@ export const makeInstallationStorage = (
       installation: InstallationShape,
     }),
     harden({
-      bundle: BundleShape,
+      bundle: M.recordOf(M.string(), M.string({ stringLengthLimit: Infinity })),
       bundleCap: BundleCapShape,
       bundleID: M.string(),
     }),
@@ -88,9 +87,12 @@ export const makeInstallationStorage = (
   );
 
   const InstallationStorageI = M.interface('InstallationStorage', {
-    installBundle: M.call(M.or(InstanceHandleShape, BundleShape)).returns(
-      M.promise(),
-    ),
+    installBundle: M.call(
+      M.or(
+        InstanceHandleShape,
+        M.recordOf(M.string(), M.string({ stringLengthLimit: Infinity })),
+      ),
+    ).returns(M.promise()),
     installBundleID: M.call(M.string()).returns(M.promise()),
     unwrapInstallation: M.callWhen(M.await(InstallationShape)).returns(
       UnwrappedInstallationShape,

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -208,7 +208,7 @@ const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
 
       state.zoeSeatAdmins.add(zoeSeatAdmin);
       state.seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
-      return { userSeat };
+      return userSeat;
     },
     getOfferFilter: ({ state }) => state.offerFilterStrings,
     setOfferFilter: ({ state }, strings) => {

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -1,49 +1,303 @@
 import { E } from '@endo/eventual-send';
-import { makeWeakStore } from '@agoric/store';
+import {
+  canBeDurable,
+  makeScalarBigSetStore,
+  provideDurableWeakMapStore,
+  vivifyKindMulti,
+  vivifyFarClassKit,
+  M,
+  provide,
+} from '@agoric/vat-data';
+import { makeZoeSeatAdminFactory } from './zoeSeat.js';
+import { defineDurableHandle } from '../makeHandle.js';
+import {
+  BrandKeywordRecordShape,
+  InstanceAdminShape,
+  InstanceHandleShape,
+  IssuerKeywordRecordShape,
+} from '../typeGuards.js';
+
+const { quote: q, Fail } = assert;
 
 /**
- *
+ * @file Two objects are defined here, both called InstanceAdminSomething.
+ * InstanceAdminStorage is a container for individual InstanceAdmins. Each
+ * InstanceAdmin is associated with a particular contract instance, and is used
+ * by both Zoe and ZCF to record and access the instance state. startInstance
+ * also defines zoeInstanceAdmin, which is a facet that is passed to startZcf()
+ * that wraps access to a zoeInstanceAdmin and other stores.
  */
-export const makeInstanceAdminStorage = () => {
-  /** @type {WeakStore<Instance,InstanceAdmin>} */
-  const instanceToInstanceAdmin = makeWeakStore('instance');
 
-  /** @type {import('./utils.js').GetPublicFacet} */
-  const getPublicFacet = async instanceP =>
-    E.when(instanceP, instance =>
-      instanceToInstanceAdmin.get(instance).getPublicFacet(),
-    );
+const InstanceAdminStorageIKit = harden({
+  accessor: M.interface('InstanceAdminStorage', {
+    getPublicFacet: M.callWhen(M.await(InstanceHandleShape)).returns(
+      M.remotable(),
+    ),
+    getBrands: M.call(InstanceHandleShape).returns(BrandKeywordRecordShape),
+    getIssuers: M.call(InstanceHandleShape).returns(IssuerKeywordRecordShape),
+    getTerms: M.call(InstanceHandleShape).returns(M.record()),
+    getOfferFilter: M.call(InstanceHandleShape).returns(M.arrayOf(M.string())),
+    getInstallationForInstance: M.call(InstanceHandleShape).returns(
+      M.remotable(),
+    ),
+    getInstanceAdmin: M.call(InstanceHandleShape).returns(InstanceAdminShape),
+  }),
+  updater: M.interface('InstanceAdmin updater', {
+    initInstanceAdmin: M.call(InstanceHandleShape, InstanceAdminShape).returns(
+      M.promise(),
+    ),
+    deleteInstanceAdmin: M.call(InstanceHandleShape).returns(),
+  }),
+});
 
-  /** @type {GetBrands} */
-  const getBrands = async instance =>
-    instanceToInstanceAdmin.get(instance).getBrands();
+/** @param {import('@agoric/vat-data').Baggage} baggage */
+export const makeInstanceAdminStorage = baggage => {
+  const makeIAS = vivifyFarClassKit(
+    baggage,
+    'InstanceAdmin',
+    InstanceAdminStorageIKit,
+    () => ({
+      instanceToInstanceAdmin: provideDurableWeakMapStore(
+        baggage,
+        'instanceToInstanceAdmin',
+      ),
+    }),
+    {
+      // ZoeStorageManager uses the accessor facet to get info about instances
+      accessor: {
+        getPublicFacet(instance) {
+          const { state } = this;
+          const ia = state.instanceToInstanceAdmin.get(instance);
+          return ia.getPublicFacet();
+        },
+        getBrands(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.get(instance).getBrands();
+        },
+        getIssuers(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.get(instance).getIssuers();
+        },
+        getTerms(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.get(instance).getTerms();
+        },
+        getOfferFilter(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.get(instance).getOfferFilter();
+        },
+        getInstallationForInstance(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin
+            .get(instance)
+            .getInstallationForInstance();
+        },
+        getInstanceAdmin(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.get(instance);
+        },
+      },
+      // The updater facet is only used inside the instanceStorageManager
+      updater: {
+        async initInstanceAdmin(instance, instanceAdmin) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.init(instance, instanceAdmin);
+        },
+        deleteInstanceAdmin(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.delete(instance);
+        },
+      },
+    },
+  );
+  return provide(baggage, 'theInstanceAdminStorage', () => makeIAS());
+};
+harden(makeInstanceAdminStorage);
 
-  /** @type {GetIssuers} */
-  const getIssuers = async instance =>
-    instanceToInstanceAdmin.get(instance).getIssuers();
-
-  /** @type {GetTerms} */
-  const getTerms = instance => instanceToInstanceAdmin.get(instance).getTerms();
-
-  /** @type {GetOfferFilter} */
-  const getOfferFilter = async instanceP =>
-    E.when(instanceP, instance =>
-      instanceToInstanceAdmin.get(instance).getOfferFilter(),
-    );
-
-  /** @type {GetInstallationForInstance} */
-  const getInstallationForInstance = async instance =>
-    instanceToInstanceAdmin.get(instance).getInstallationForInstance();
+const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
+  const makeSeatHandle = defineDurableHandle(zoeBaggage, 'Seat');
 
   return harden({
-    getPublicFacet,
-    getBrands,
-    getIssuers,
-    getTerms,
-    getOfferFilter,
-    getInstallationForInstance,
-    getInstanceAdmin: instanceToInstanceAdmin.get,
-    initInstanceAdmin: instanceToInstanceAdmin.init,
-    deleteInstanceAdmin: instanceToInstanceAdmin.delete,
+    getPublicFacet: ({ state }) => state.publicFacet,
+    getTerms: ({ state }) => state.zoeInstanceStorageManager.getTerms(),
+    getIssuers: ({ state }) => state.zoeInstanceStorageManager.getIssuers(),
+    getBrands: ({ state }) => state.zoeInstanceStorageManager.getBrands(),
+
+    // instanceAdmin is created early in startInstance. initDelayedState is
+    // called after startZcf, but before the contract facets are made available.
+    initDelayedState: ({ state }, handleOfferObj, publicFacet) => {
+      state.handleOfferObj = handleOfferObj;
+      canBeDurable(publicFacet) || Fail`publicFacet must be durable`;
+      state.publicFacet = publicFacet;
+    },
+    getInstallationForInstance: ({ state }) =>
+      state.zoeInstanceStorageManager.getInstallationForInstance(),
+    getInstance: ({ state }) => state.instanceHandle,
+    assertAcceptingOffers: ({ state }) => {
+      assert(state.acceptingOffers, `No further offers are accepted`);
+    },
+    exitAllSeats: ({ state }, completion) => {
+      state.acceptingOffers = false;
+      Array.from(state.zoeSeatAdmins.keys()).forEach(zoeSeatAdmin =>
+        zoeSeatAdmin.exit(completion),
+      );
+    },
+    failAllSeats: ({ state }, reason) => {
+      state.acceptingOffers = false;
+      Array.from(state.zoeSeatAdmins.keys()).forEach(zoeSeatAdmin =>
+        zoeSeatAdmin.fail(reason),
+      );
+    },
+    stopAcceptingOffers: ({ state }) => {
+      state.acceptingOffers = false;
+    },
+    makeUserSeat: (
+      { state, facets: { helper } },
+      invitationHandle,
+      initialAllocation,
+      proposal,
+      offerArgs = undefined,
+    ) => {
+      const { userSeat, zoeSeatAdmin } = makeZoeSeatAdminKit(
+        initialAllocation,
+        proposal,
+        helper,
+        state.zoeInstanceStorageManager.getWithdrawFacet(),
+      );
+
+      const seatHandle = makeSeatHandle();
+      state.seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
+
+      const seatData = harden({
+        proposal,
+        initialAllocation,
+        seatHandle,
+        offerArgs,
+      });
+
+      state.zoeSeatAdmins.add(zoeSeatAdmin);
+      state.handleOfferObj || Fail`incomplete setup of zoe seat`;
+      E.when(
+        E(state.handleOfferObj).handleOffer(invitationHandle, seatData),
+        ({ offerResultPromise, exitObj }) =>
+          zoeSeatAdmin.resolveExitAndResult(offerResultPromise, exitObj),
+        err => {
+          state.adminNode.terminateWithFailure(err);
+          throw err;
+        },
+      );
+
+      // return the userSeat before the offerHandler is called
+      return userSeat;
+    },
+    makeNoEscrowSeat: (
+      { state, facets: { helper } },
+      initialAllocation,
+      proposal,
+      exitObj,
+      seatHandle,
+    ) => {
+      const { userSeat, zoeSeatAdmin } = makeZoeSeatAdminKit(
+        initialAllocation,
+        proposal,
+        helper,
+        state.zoeInstanceStorageManager.getWithdrawFacet(),
+        exitObj,
+        true,
+      );
+
+      state.zoeSeatAdmins.add(zoeSeatAdmin);
+      state.seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
+      return { userSeat };
+    },
+    getOfferFilter: ({ state }) => state.offerFilterStrings,
+    setOfferFilter: ({ state }, strings) => {
+      Array.isArray(strings) || Fail`${q(strings)} must be an Array`;
+      const proposedStrings = harden([...strings]);
+      proposedStrings.every(s => typeof s === 'string') ||
+        Fail`Blocked strings (${q(
+          proposedStrings,
+        )}) must be an Array of strings.`;
+
+      state.offerFilterStrings = proposedStrings;
+    },
+    // If any offer filter string matches the input string, don't process the
+    // invitation. Offer filter strings that end in ':' match if they are a
+    // prefix of the input string; others must match it exactly.
+    isBlocked: ({ state }, string) => {
+      return state.offerFilterStrings.some(filterString => {
+        return (
+          filterString === string ||
+          (filterString.endsWith(':') && string.startsWith(filterString))
+        );
+      });
+    },
   });
 };
+
+const helperBehavior = {
+  exitZoeSeatAdmin: ({ state }, zoeSeatAdmin) =>
+    state.zoeSeatAdmins.delete(zoeSeatAdmin),
+  hasExited: ({ state }, zoeSeatAdmin) =>
+    !state.zoeSeatAdmins.has(zoeSeatAdmin),
+};
+
+/**
+ * @typedef {Readonly<{
+ *   publicFacet: unknown,
+ *   handlerOfferObj: unknown,
+ * }>} ImmutableState
+ * @typedef {{
+ *   offerFilterStrings: string[],
+ * }} MutableState
+ * @typedef {MutableState & ImmutableState} State
+ * @typedef {{
+ *   state: State,
+ * }} MethodContext
+ */
+
+/**
+ * @param {import('@agoric/vat-data').Baggage} zoeBaggage
+ * @param {WeakStore<SeatHandle, ZoeSeatAdmin>} seatHandleToZoeSeatAdmin
+ */
+export const makeInstanceAdminMaker = (
+  zoeBaggage,
+  seatHandleToZoeSeatAdmin,
+) => {
+  const makeZoeSeatAdminKit = makeZoeSeatAdminFactory(zoeBaggage);
+  const makeInstanceAdminMulti = vivifyKindMulti(
+    zoeBaggage,
+    'instanceAdmin',
+    (instanceHandle, zoeInstanceStorageManager, adminNode) => {
+      const retVal = {
+        offerFilterStrings: harden([]),
+        publicFacet: undefined,
+        handleOfferObj: undefined,
+        zoeInstanceStorageManager,
+        seatHandleToZoeSeatAdmin,
+        instanceHandle,
+        acceptingOffers: true,
+        zoeSeatAdmins: makeScalarBigSetStore('zoeSeatAdmins', {
+          durable: true,
+        }),
+        adminNode,
+      };
+      return retVal;
+    },
+    {
+      instanceAdmin: makeInstanceAdminBehavior(zoeBaggage, makeZoeSeatAdminKit),
+      helper: helperBehavior,
+    },
+  );
+
+  return (instanceHandle, zoeInstanceStorageManager, adminNode) => {
+    const instanceAdmin = makeInstanceAdminMulti(
+      instanceHandle,
+      zoeInstanceStorageManager,
+      adminNode,
+    ).instanceAdmin;
+    return instanceAdmin;
+  };
+};
+
+harden(makeInstanceAdminMaker);

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -14,7 +14,7 @@
  * before with `feeMintAccess`. In that case, we do not create a new
  * purse, but reuse the existing purse.
  *
- * @callback MakeLocalPurse
+ * @callback ProvideLocalPurse
  * @param {Issuer} issuer
  * @param {Brand} brand
  * @returns {Purse}
@@ -86,9 +86,9 @@
  * @property {InitInstanceAdmin} initInstanceAdmin
  * @property {DeleteInstanceAdmin} deleteInstanceAdmin
  * @property {ZoeInstanceAdminMakeInvitation} makeInvitation
- * @property {Issuer} invitationIssuer
- * @property {object} root of a RootAndAdminNode
- * @property {AdminNode} adminNode of a RootAndAdminNode
+ * @property {() => Issuer} getInvitationIssuer
+ * @property {() => object} getRoot of a RootAndAdminNode
+ * @property {() => AdminNode} getAdminNode of a RootAndAdminNode
  */
 
 /**
@@ -133,6 +133,7 @@
  * @property {GetIssuers} getIssuers
  * @property {GetTerms} getTerms
  * @property {GetOfferFilter} getOfferFilter
+ * @property {SetOfferFilter} setOfferFilter
  * @property {GetInstallationForInstance} getInstallationForInstance
  * @property {GetInstanceAdmin} getInstanceAdmin
  * @property {UnwrapInstallation} unwrapInstallation

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -1,5 +1,6 @@
 import { passStyleOf } from '@endo/marshal';
 import { fit } from '@agoric/store';
+import { E } from '@endo/eventual-send';
 
 import { cleanProposal } from '../../cleanProposal.js';
 import { burnInvitation } from './burnInvitation.js';
@@ -9,23 +10,9 @@ import '@agoric/ertp/exported.js';
 import '@agoric/store/exported.js';
 import '../internal-types.js';
 
-const { details: X, quote: q } = assert;
+const { details: X, quote: q, Fail } = assert;
 
-/**
- * @param {Issuer} invitationIssuer
- * @param {GetInstanceAdmin} getInstanceAdmin
- * @param {DepositPayments} depositPayments
- * @param {GetAssetKindByBrand} getAssetKindByBrand
- * @param {GetProposalShapeForInvitation} getProposalShapeForInvitation
- * @returns {Offer}
- */
-export const makeOfferMethod = (
-  invitationIssuer,
-  getInstanceAdmin,
-  depositPayments,
-  getAssetKindByBrand,
-  getProposalShapeForInvitation,
-) => {
+export const makeOfferMethod = offerDataAccess => {
   /** @type {Offer} */
   const offer = async (
     invitation,
@@ -33,15 +20,17 @@ export const makeOfferMethod = (
     paymentKeywordRecord = harden({}),
     offerArgs = undefined,
   ) => {
+    const invitationIssuer = offerDataAccess.getInvitationIssuer();
     const query = makeInvitationQueryFns(invitationIssuer);
     const { instance, description } = await query.getInvitationDetails(
       invitation,
     );
     // AWAIT ///
 
-    const instanceAdmin = getInstanceAdmin(instance);
+    const instanceAdmin = await offerDataAccess.getInstanceAdmin(instance);
+    // AWAIT ///
     !instanceAdmin.isBlocked(description) ||
-      assert.fail(X`not accepting offer with description ${q(description)}`);
+      Fail`not accepting offer with description ${q(description)}`;
     const { invitationHandle } = await burnInvitation(
       invitationIssuer,
       invitation,
@@ -50,8 +39,13 @@ export const makeOfferMethod = (
 
     instanceAdmin.assertAcceptingOffers();
 
+    const getAssetKindByBrand = brand => {
+      return offerDataAccess.getAssetKindByBrand(brand);
+    };
+
     const proposal = cleanProposal(uncleanProposal, getAssetKindByBrand);
-    const proposalShape = getProposalShapeForInvitation(invitationHandle);
+    const proposalShape =
+      offerDataAccess.getProposalShapeForInvitation(invitationHandle);
     if (proposalShape !== undefined) {
       fit(proposal, proposalShape, `${q(description)} proposal`);
     }
@@ -66,22 +60,17 @@ export const makeOfferMethod = (
       );
     }
 
-    const initialAllocation = await depositPayments(
-      proposal,
-      paymentKeywordRecord,
+    return E.when(
+      offerDataAccess.depositPayments(proposal, paymentKeywordRecord),
+      initialAllocation =>
+        instanceAdmin.makeUserSeat(
+          invitationHandle,
+          initialAllocation,
+          proposal,
+          offerArgs,
+        ),
     );
-    // AWAIT ///
-
-    // This triggers the offerHandler in ZCF
-    const userSeat = await instanceAdmin.makeUserSeat(
-      invitationHandle,
-      initialAllocation,
-      proposal,
-      offerArgs,
-    );
-    // AWAIT ///
-    // @ts-expect-error cast
-    return userSeat;
   };
+
   return offer;
 };

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -1,35 +1,198 @@
 import { E } from '@endo/eventual-send';
-import { makePromiseKit } from '@endo/promise-kit';
-import { Far, passStyleOf } from '@endo/marshal';
-import { makeWeakStore } from '@agoric/store';
-import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { passStyleOf } from '@endo/marshal';
+import {
+  M,
+  makeScalarBigMapStore,
+  provideDurableWeakMapStore,
+  vivifyFarClass,
+} from '@agoric/vat-data';
+import { initEmpty } from '@agoric/store';
 
-import { makeZoeSeatAdminKit } from './zoeSeat.js';
 import { defineDurableHandle } from '../makeHandle.js';
-import { handlePKitWarning } from '../handleWarning.js';
+import { makeInstanceAdminMaker } from './instanceAdminStorage.js';
+import { AdminFacetI, InstanceAdminI } from '../typeGuards.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 /** @typedef { import('@agoric/swingset-vat').BundleCap} BundleCap */
 
 const { details: X, quote: q } = assert;
 
+const instanceAdminBehavior = {
+  makeInvitation(handle, desc, customProps, proposalShape) {
+    const { state } = this;
+    return state.instanceStorage.makeInvitation(
+      handle,
+      desc,
+      customProps,
+      proposalShape,
+    );
+  },
+  // checks of keyword done on zcf side
+  saveIssuer(issuer, keyword) {
+    const { state } = this;
+    return state.instanceStorage.saveIssuer(issuer, keyword);
+  },
+  // A Seat requested by the contract without any payments to escrow
+  makeNoEscrowSeat(initialAllocations, proposal, exitObj, seatHandle) {
+    const { state } = this;
+    return state.instanceAdmin.makeNoEscrowSeat(
+      initialAllocations,
+      proposal,
+      exitObj,
+      seatHandle,
+    );
+  },
+  exitAllSeats(completion) {
+    const { state } = this;
+    state.instanceAdmin.exitAllSeats(completion);
+  },
+  failAllSeats(reason) {
+    const { state } = this;
+    return state.instanceAdmin.failAllSeats(reason);
+  },
+  exitSeat(seatHandle, completion) {
+    const { state } = this;
+    state.seatHandleToSeatAdmin.get(seatHandle).exit(completion);
+  },
+  failSeat(seatHandle, reason) {
+    const { state } = this;
+    state.seatHandleToSeatAdmin.get(seatHandle).fail(reason);
+  },
+  makeZoeMint(keyword, assetKind, displayInfo, pattern) {
+    const { state } = this;
+    return state.instanceStorage.makeZoeMint(
+      keyword,
+      assetKind,
+      displayInfo,
+      pattern,
+    );
+  },
+  registerFeeMint(keyword, feeMintAccess) {
+    const { state } = this;
+    return state.instanceStorage.registerFeeMint(keyword, feeMintAccess);
+  },
+  replaceAllocations(seatHandleAllocations) {
+    const { state } = this;
+    try {
+      seatHandleAllocations.forEach(({ seatHandle, allocation }) => {
+        const zoeSeatAdmin = state.seatHandleToSeatAdmin.get(seatHandle);
+        zoeSeatAdmin.replaceAllocation(allocation);
+      });
+    } catch (err) {
+      state.adminNode.terminateWithFailure(err);
+      throw err;
+    }
+  },
+  stopAcceptingOffers() {
+    const { state } = this;
+    return state.instanceAdmin.stopAcceptingOffers();
+  },
+  setOfferFilter(strings) {
+    const { state } = this;
+    state.instanceAdmin.setOfferFilter(strings);
+  },
+  getOfferFilter() {
+    const { state } = this;
+    return state.instanceAdmin.getOfferFilter();
+  },
+  getExitSubscriber(seatHandle) {
+    const { state } = this;
+    return state.seatHandleToSeatAdmin.get(seatHandle).getExitSubscriber();
+  },
+  isBlocked(string) {
+    const { state } = this;
+    return state.instanceAdmin.isBlocked(string);
+  },
+};
+
 /**
- * @param {MakeZoeInstanceStorageManager} makeZoeInstanceStorageManager
- * @param {UnwrapInstallation} unwrapInstallation
+ * @param {any} startInstanceAccess
  * @param {ERef<BundleCap>} zcfBundleCapP
  * @param {(id: string) => BundleCap} getBundleCapByIdNow
  * @param {Baggage} [zoeBaggage]
- * @returns {import('./utils.js').StartInstance}
+ * @returns {import('./utils').StartInstance}
  */
 export const makeStartInstance = (
-  makeZoeInstanceStorageManager,
-  unwrapInstallation,
+  startInstanceAccess,
   zcfBundleCapP,
   getBundleCapByIdNow,
   zoeBaggage = makeScalarBigMapStore('zoe baggage', { durable: true }),
 ) => {
   const makeInstanceHandle = defineDurableHandle(zoeBaggage, 'Instance');
-  const makeSeatHandle = defineDurableHandle(zoeBaggage, 'Seat');
+
+  /** @type {WeakStore<SeatHandle, ZoeSeatAdmin>} */
+  const seatHandleToZoeSeatAdmin = provideDurableWeakMapStore(
+    zoeBaggage,
+    'seatHandleToZoeSeatAdmin',
+  );
+
+  const instanceAdminMaker = makeInstanceAdminMaker(
+    zoeBaggage,
+    seatHandleToZoeSeatAdmin,
+  );
+
+  const makeZoeInstanceAdmin = vivifyFarClass(
+    zoeBaggage,
+    'zoeInstanceAdmin',
+    InstanceAdminI,
+    (instanceStorage, instanceAdmin, seatHandleToSeatAdmin, adminNode) => ({
+      instanceStorage,
+      instanceAdmin,
+      seatHandleToSeatAdmin,
+      adminNode,
+    }),
+    instanceAdminBehavior,
+  );
+
+  const vivifyEmptyFacet = facetName =>
+    vivifyFarClass(
+      zoeBaggage,
+      facetName,
+      M.interface(facetName, {}),
+      initEmpty,
+      {},
+    );
+  const makeEmptyCreatorFacet = vivifyEmptyFacet('emptyCreatorFacet');
+  const makeEmptyPublicFacet = vivifyEmptyFacet('emptyPublicFacet');
+
+  const makeAdminFacet = vivifyFarClass(
+    zoeBaggage,
+    'adminFacet',
+    AdminFacetI,
+    (adminNode, zcfBundleCap, contractBundleCap) => ({
+      adminNode,
+      zcfBundleCap,
+      contractBundleCap,
+    }),
+    {
+      getVatShutdownPromise() {
+        const { state } = this;
+
+        return E(state.adminNode).done();
+      },
+      restartContract(_newPrivateArgs) {
+        const { state } = this;
+
+        const vatParameters = { contractBundleCap: state.contractBundleCap };
+        return E(state.adminNode).upgrade(state.zcfBundleCap.value, {
+          vatParameters,
+        });
+      },
+      async upgradeContract(contractBundleId, newPrivateArgs) {
+        const { state } = this;
+        const newContractBundleCap = await getBundleCapByIdNow(
+          contractBundleId,
+        );
+        const vatParameters = {
+          contractBundleCap: newContractBundleCap,
+          privateArgs: newPrivateArgs,
+        };
+        return E(state.adminNode).upgrade(state.zcfBundleCap.value, {
+          vatParameters,
+        });
+      },
+    },
+  );
 
   const startInstance = async (
     installationP,
@@ -37,15 +200,9 @@ export const makeStartInstance = (
     customTerms = harden({}),
     privateArgs = undefined,
   ) => {
-    /** @type {WeakStore<SeatHandle, ZoeSeatAdmin>} */
-    const seatHandleToZoeSeatAdmin = makeWeakStore('seatHandle');
-    const instanceBaggage = makeScalarBigMapStore('instanceBaggage', {
-      durable: true,
-    });
-
-    const { installation, bundle, bundleCap } = await unwrapInstallation(
-      installationP,
-    );
+    const { installation, bundle, bundleCap } = await E(
+      startInstanceAccess,
+    ).unwrapInstallation(installationP);
     // AWAIT ///
 
     const contractBundleCap = bundle || bundleCap;
@@ -61,210 +218,58 @@ export const makeStartInstance = (
       );
     }
 
-    const instance = makeInstanceHandle();
+    const instanceHandle = makeInstanceHandle();
 
-    // Invitations whose descriptions match any of the strings will be blocked
-    /** @type {Readonly<string[]>} */
-    let offerFilterStrings = [];
-    // if any string in the list matches, don't process the invitation. Strings
-    // that end in ':' may be prefix matches, others must match exactly.
-    const isBlocked = string => {
-      return offerFilterStrings.some(s => {
-        return string === s || (s.slice(-1) === ':' && string.startsWith(s));
-      });
-    };
+    const instanceBaggage = makeScalarBigMapStore('instanceBaggage', {
+      durable: true,
+    });
 
-    const setOfferFilter = strings => {
-      assert(Array.isArray(strings), X`${q(strings)} must be an Array`);
-      const proposedStrings = harden([...strings]);
-      proposedStrings.every(s => typeof s === 'string') ||
-        assert.fail(
-          X`Blocked strings (${q(
-            proposedStrings,
-          )}) must be an Array of strings.`,
-        );
-
-      offerFilterStrings = proposedStrings;
-    };
-
-    const zoeInstanceStorageManager = await makeZoeInstanceStorageManager(
+    const zoeInstanceStorageManager = await E(
+      startInstanceAccess,
+    ).makeZoeInstanceStorageManager(
       instanceBaggage,
       installation,
       customTerms,
       uncleanIssuerKeywordRecord,
-      instance,
+      instanceHandle,
       contractBundleCap,
     );
     // AWAIT ///
 
-    const { adminNode, root } = zoeInstanceStorageManager;
+    const adminNode = zoeInstanceStorageManager.getAdminNode();
     /** @type {ZCFRoot} */
-    const zcfRoot = root;
+    const zcfRoot = zoeInstanceStorageManager.getRoot();
 
-    /** @type {PromiseRecord<HandleOfferObj>} */
-    const handleOfferObjPromiseKit = makePromiseKit();
-    handlePKitWarning(handleOfferObjPromiseKit);
-    const publicFacetPromiseKit = makePromiseKit();
-    handlePKitWarning(publicFacetPromiseKit);
-
-    const makeInstanceAdmin = () => {
-      /** @type {Set<ZoeSeatAdmin>} */
-      const zoeSeatAdmins = new Set();
-      let acceptingOffers = true;
-
-      const exitZoeSeatAdmin = zoeSeatAdmin =>
-        zoeSeatAdmins.delete(zoeSeatAdmin);
-      const hasExited = zoeSeatAdmin => !zoeSeatAdmins.has(zoeSeatAdmin);
-
-      /** @type {InstanceAdmin} */
-      const instanceAdmin = Far('instanceAdmin', {
-        getPublicFacet: () => publicFacetPromiseKit.promise,
-        getTerms: zoeInstanceStorageManager.getTerms,
-        getIssuers: zoeInstanceStorageManager.getIssuers,
-        getBrands: zoeInstanceStorageManager.getBrands,
-        getOfferFilter: () => harden([...offerFilterStrings]),
-        getInstallationForInstance:
-          zoeInstanceStorageManager.getInstallationForInstance,
-        getInstance: () => instance,
-        assertAcceptingOffers: () => {
-          assert(acceptingOffers, `No further offers are accepted`);
-        },
-        exitAllSeats: completion => {
-          acceptingOffers = false;
-          zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.exit(completion));
-        },
-        failAllSeats: reason => {
-          acceptingOffers = false;
-          zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.fail(reason));
-        },
-        stopAcceptingOffers: () => {
-          acceptingOffers = false;
-        },
-        makeUserSeat: (
-          invitationHandle,
-          initialAllocation,
-          proposal,
-          offerArgs = undefined,
-        ) => {
-          const offerResultPromiseKit = makePromiseKit();
-          handlePKitWarning(offerResultPromiseKit);
-          const exitObjPromiseKit = makePromiseKit();
-          handlePKitWarning(exitObjPromiseKit);
-          const seatHandle = makeSeatHandle();
-
-          const { userSeat, zoeSeatAdmin } = makeZoeSeatAdminKit(
-            initialAllocation,
-            exitZoeSeatAdmin,
-            hasExited,
-            proposal,
-            zoeInstanceStorageManager.withdrawPayments,
-            exitObjPromiseKit.promise,
-            offerResultPromiseKit.promise,
-          );
-
-          seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
-
-          const seatData = harden({
-            proposal,
-            initialAllocation,
-            seatHandle,
-            offerArgs,
-          });
-
-          zoeSeatAdmins.add(zoeSeatAdmin);
-
-          E.when(
-            E(handleOfferObjPromiseKit.promise).handleOffer(
-              invitationHandle,
-              seatData,
-            ),
-            ({ offerResultPromise, exitObj }) => {
-              offerResultPromiseKit.resolve(offerResultPromise);
-              exitObjPromiseKit.resolve(exitObj);
-            },
-            err => {
-              adminNode.terminateWithFailure(err);
-              throw err;
-            },
-          );
-
-          // return the userSeat before the offerHandler is called
-          return userSeat;
-        },
-        makeNoEscrowSeatKit: (
-          initialAllocation,
-          proposal,
-          exitObj,
-          seatHandle,
-        ) => {
-          const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
-            initialAllocation,
-            exitZoeSeatAdmin,
-            hasExited,
-            proposal,
-            zoeInstanceStorageManager.withdrawPayments,
-            exitObj,
-          );
-          zoeSeatAdmins.add(zoeSeatAdmin);
-          seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
-          return { userSeat, notifier };
-        },
-        isBlocked,
-      });
-      return instanceAdmin;
-    };
-
-    const instanceAdmin = makeInstanceAdmin();
-    zoeInstanceStorageManager.initInstanceAdmin(instance, instanceAdmin);
+    /** @type {InstanceAdmin} */
+    const instanceAdmin = instanceAdminMaker(
+      instanceHandle,
+      zoeInstanceStorageManager,
+      adminNode,
+    );
+    zoeInstanceStorageManager.initInstanceAdmin(instanceHandle, instanceAdmin);
 
     E(adminNode)
       .done()
       .then(
-        completion => instanceAdmin.exitAllSeats(completion),
+        completion => {
+          instanceAdmin.exitAllSeats(completion);
+        },
         reason => instanceAdmin.failAllSeats(reason),
       );
 
     /** @type {ZoeInstanceAdmin} */
-    const zoeInstanceAdminForZcf = Far('zoeInstanceAdminForZcf', {
-      makeInvitation: zoeInstanceStorageManager.makeInvitation,
-      // checks of keyword done on zcf side
-      saveIssuer: zoeInstanceStorageManager.saveIssuer,
-      // A Seat requested by the contract without any payments to escrow
-      makeNoEscrowSeatKit: instanceAdmin.makeNoEscrowSeatKit,
-      exitAllSeats: completion => instanceAdmin.exitAllSeats(completion),
-      failAllSeats: reason => instanceAdmin.failAllSeats(reason),
-      exitSeat: (seatHandle, completion) => {
-        seatHandleToZoeSeatAdmin.get(seatHandle).exit(completion);
-      },
-      failSeat: (seatHandle, reason) => {
-        seatHandleToZoeSeatAdmin.get(seatHandle).fail(reason);
-      },
-      getSeatNotifier: seatHandle =>
-        seatHandleToZoeSeatAdmin.get(seatHandle).getNotifier(),
-      makeZoeMint: zoeInstanceStorageManager.makeZoeMint,
-      registerFeeMint: zoeInstanceStorageManager.registerFeeMint,
-      replaceAllocations: seatHandleAllocations => {
-        try {
-          seatHandleAllocations.forEach(({ seatHandle, allocation }) => {
-            const zoeSeatAdmin = seatHandleToZoeSeatAdmin.get(seatHandle);
-            zoeSeatAdmin.replaceAllocation(allocation);
-          });
-        } catch (err) {
-          adminNode.terminateWithFailure(err);
-          throw err;
-        }
-      },
-      stopAcceptingOffers: () => instanceAdmin.stopAcceptingOffers(),
-      setOfferFilter,
-      getOfferFilter: () => harden([...offerFilterStrings]),
-    });
+    const zoeInstanceAdminForZcf = makeZoeInstanceAdmin(
+      zoeInstanceStorageManager,
+      instanceAdmin,
+      seatHandleToZoeSeatAdmin,
+      adminNode,
+    );
 
-    // At this point, the contract will start executing. All must be
-    // ready
+    // At this point, the contract will start executing. All must be ready
 
     const {
-      creatorFacet = Far('emptyCreatorFacet', {}),
-      publicFacet = Far('emptyPublicFacet', {}),
+      creatorFacet = makeEmptyCreatorFacet(),
+      publicFacet = makeEmptyPublicFacet(),
       creatorInvitation: creatorInvitationP,
       handleOfferObj,
     } = await E(zcfRoot).startZcf(
@@ -274,14 +279,15 @@ export const makeStartInstance = (
       privateArgs,
     );
 
-    handleOfferObjPromiseKit.resolve(handleOfferObj);
-    publicFacetPromiseKit.resolve(publicFacet);
+    instanceAdmin.initDelayedState(handleOfferObj, publicFacet);
 
     // creatorInvitation can be undefined, but if it is defined,
     // let's make sure it is an invitation.
     return Promise.allSettled([
       creatorInvitationP,
-      zoeInstanceStorageManager.invitationIssuer.isLive(creatorInvitationP),
+      zoeInstanceStorageManager
+        .getInvitationIssuer()
+        .isLive(creatorInvitationP),
       zcfBundleCapP,
     ]).then(([invitationResult, isLiveResult, zcfBundleCapResult]) => {
       let creatorInvitation;
@@ -300,27 +306,11 @@ export const makeStartInstance = (
           'the budnle cap was broken',
         );
       }
-      const adminFacet = Far('adminFacet', {
-        getVatShutdownPromise: () => E(adminNode).done(),
-        restartContract: _newPrivateArgs => {
-          const vatParameters = { contractBundleCap };
-          return E(adminNode).upgrade(zcfBundleCapResult.value, {
-            vatParameters,
-          });
-        },
-        upgradeContract: async (contractBundleId, newPrivateArgs) => {
-          const newContractBundleCap = await getBundleCapByIdNow(
-            contractBundleId,
-          );
-          const vatParameters = {
-            contractBundleCap: newContractBundleCap,
-            privateArgs: newPrivateArgs,
-          };
-          return E(adminNode).upgrade(zcfBundleCapResult.value, {
-            vatParameters,
-          });
-        },
-      });
+      const adminFacet = makeAdminFacet(
+        adminNode,
+        harden(zcfBundleCapResult),
+        contractBundleCap,
+      );
 
       // Actually returned to the user.
       return {
@@ -328,7 +318,7 @@ export const makeStartInstance = (
 
         // TODO (#5775) deprecate this return value from contracts.
         creatorInvitation,
-        instance,
+        instance: instanceHandle,
         publicFacet,
         adminFacet,
       };

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -15,95 +15,7 @@ import { AdminFacetI, InstanceAdminI } from '../typeGuards.js';
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 /** @typedef { import('@agoric/swingset-vat').BundleCap} BundleCap */
 
-const { details: X, quote: q } = assert;
-
-const instanceAdminBehavior = {
-  makeInvitation(handle, desc, customProps, proposalShape) {
-    const { state } = this;
-    return state.instanceStorage.makeInvitation(
-      handle,
-      desc,
-      customProps,
-      proposalShape,
-    );
-  },
-  // checks of keyword done on zcf side
-  saveIssuer(issuer, keyword) {
-    const { state } = this;
-    return state.instanceStorage.saveIssuer(issuer, keyword);
-  },
-  // A Seat requested by the contract without any payments to escrow
-  makeNoEscrowSeat(initialAllocations, proposal, exitObj, seatHandle) {
-    const { state } = this;
-    return state.instanceAdmin.makeNoEscrowSeat(
-      initialAllocations,
-      proposal,
-      exitObj,
-      seatHandle,
-    );
-  },
-  exitAllSeats(completion) {
-    const { state } = this;
-    state.instanceAdmin.exitAllSeats(completion);
-  },
-  failAllSeats(reason) {
-    const { state } = this;
-    return state.instanceAdmin.failAllSeats(reason);
-  },
-  exitSeat(seatHandle, completion) {
-    const { state } = this;
-    state.seatHandleToSeatAdmin.get(seatHandle).exit(completion);
-  },
-  failSeat(seatHandle, reason) {
-    const { state } = this;
-    state.seatHandleToSeatAdmin.get(seatHandle).fail(reason);
-  },
-  makeZoeMint(keyword, assetKind, displayInfo, pattern) {
-    const { state } = this;
-    return state.instanceStorage.makeZoeMint(
-      keyword,
-      assetKind,
-      displayInfo,
-      pattern,
-    );
-  },
-  registerFeeMint(keyword, feeMintAccess) {
-    const { state } = this;
-    return state.instanceStorage.registerFeeMint(keyword, feeMintAccess);
-  },
-  replaceAllocations(seatHandleAllocations) {
-    const { state } = this;
-    try {
-      seatHandleAllocations.forEach(({ seatHandle, allocation }) => {
-        const zoeSeatAdmin = state.seatHandleToSeatAdmin.get(seatHandle);
-        zoeSeatAdmin.replaceAllocation(allocation);
-      });
-    } catch (err) {
-      state.adminNode.terminateWithFailure(err);
-      throw err;
-    }
-  },
-  stopAcceptingOffers() {
-    const { state } = this;
-    return state.instanceAdmin.stopAcceptingOffers();
-  },
-  setOfferFilter(strings) {
-    const { state } = this;
-    state.instanceAdmin.setOfferFilter(strings);
-  },
-  getOfferFilter() {
-    const { state } = this;
-    return state.instanceAdmin.getOfferFilter();
-  },
-  getExitSubscriber(seatHandle) {
-    const { state } = this;
-    return state.seatHandleToSeatAdmin.get(seatHandle).getExitSubscriber();
-  },
-  isBlocked(string) {
-    const { state } = this;
-    return state.instanceAdmin.isBlocked(string);
-  },
-};
+const { Fail, quote: q } = assert;
 
 /**
  * @param {any} startInstanceAccess
@@ -141,7 +53,93 @@ export const makeStartInstance = (
       seatHandleToSeatAdmin,
       adminNode,
     }),
-    instanceAdminBehavior,
+    {
+      makeInvitation(handle, desc, customProps, proposalShape) {
+        const { state } = this;
+        return state.instanceStorage.makeInvitation(
+          handle,
+          desc,
+          customProps,
+          proposalShape,
+        );
+      },
+      // checks of keyword done on zcf side
+      saveIssuer(issuer, keyword) {
+        const { state } = this;
+        return state.instanceStorage.saveIssuer(issuer, keyword);
+      },
+      // A Seat requested by the contract without any payments to escrow
+      makeNoEscrowSeat(initialAllocations, proposal, exitObj, seatHandle) {
+        const { state } = this;
+        return state.instanceAdmin.makeNoEscrowSeat(
+          initialAllocations,
+          proposal,
+          exitObj,
+          seatHandle,
+        );
+      },
+      exitAllSeats(completion) {
+        const { state } = this;
+        state.instanceAdmin.exitAllSeats(completion);
+      },
+      failAllSeats(reason) {
+        const { state } = this;
+        return state.instanceAdmin.failAllSeats(reason);
+      },
+      exitSeat(seatHandle, completion) {
+        const { state } = this;
+        state.seatHandleToSeatAdmin.get(seatHandle).exit(completion);
+      },
+      failSeat(seatHandle, reason) {
+        const { state } = this;
+        state.seatHandleToSeatAdmin.get(seatHandle).fail(reason);
+      },
+      makeZoeMint(keyword, assetKind, displayInfo, pattern) {
+        const { state } = this;
+        return state.instanceStorage.makeZoeMint(
+          keyword,
+          assetKind,
+          displayInfo,
+          pattern,
+        );
+      },
+      registerFeeMint(keyword, feeMintAccess) {
+        const { state } = this;
+        return state.instanceStorage.registerFeeMint(keyword, feeMintAccess);
+      },
+      replaceAllocations(seatHandleAllocations) {
+        const { state } = this;
+        try {
+          seatHandleAllocations.forEach(({ seatHandle, allocation }) => {
+            const zoeSeatAdmin = state.seatHandleToSeatAdmin.get(seatHandle);
+            zoeSeatAdmin.replaceAllocation(allocation);
+          });
+        } catch (err) {
+          state.adminNode.terminateWithFailure(err);
+          throw err;
+        }
+      },
+      stopAcceptingOffers() {
+        const { state } = this;
+        return state.instanceAdmin.stopAcceptingOffers();
+      },
+      setOfferFilter(strings) {
+        const { state } = this;
+        state.instanceAdmin.setOfferFilter(strings);
+      },
+      getOfferFilter() {
+        const { state } = this;
+        return state.instanceAdmin.getOfferFilter();
+      },
+      getExitSubscriber(seatHandle) {
+        const { state } = this;
+        return state.seatHandleToSeatAdmin.get(seatHandle).getExitSubscriber();
+      },
+      isBlocked(string) {
+        const { state } = this;
+        return state.instanceAdmin.isBlocked(string);
+      },
+    },
   );
 
   const vivifyEmptyFacet = facetName =>
@@ -170,7 +168,7 @@ export const makeStartInstance = (
 
         return E(state.adminNode).done();
       },
-      restartContract(_newPrivateArgs) {
+      restartContract(_newPrivateArgs = undefined) {
         const { state } = this;
 
         const vatParameters = { contractBundleCap: state.contractBundleCap };
@@ -178,7 +176,7 @@ export const makeStartInstance = (
           vatParameters,
         });
       },
-      async upgradeContract(contractBundleId, newPrivateArgs) {
+      async upgradeContract(contractBundleId, newPrivateArgs = undefined) {
         const { state } = this;
         const newContractBundleCap = await getBundleCapByIdNow(
           contractBundleId,
@@ -210,12 +208,10 @@ export const makeStartInstance = (
 
     if (privateArgs !== undefined) {
       const passStyle = passStyleOf(privateArgs);
-      assert(
-        passStyle === 'copyRecord',
-        X`privateArgs must be a pass-by-copy record, but instead was a ${q(
+      passStyle === 'copyRecord' ||
+        Fail`privateArgs must be a pass-by-copy record, but instead was a ${q(
           passStyle,
-        )}: ${privateArgs}`,
-      );
+        )}: ${privateArgs}`;
     }
 
     const instanceHandle = makeInstanceHandle();
@@ -295,16 +291,13 @@ export const makeStartInstance = (
         creatorInvitation = invitationResult.value;
       }
       if (creatorInvitation !== undefined) {
-        assert(
-          isLiveResult.status === 'fulfilled' && isLiveResult.value,
-          'The contract did not correctly return a creatorInvitation',
-        );
+        (isLiveResult.status === 'fulfilled' && isLiveResult.value) ||
+          Fail`The contract did not correctly return a creatorInvitation`;
       }
       if (zcfBundleCapResult !== undefined) {
-        assert(
-          zcfBundleCapResult.status === 'fulfilled' && zcfBundleCapResult.value,
-          'the budnle cap was broken',
-        );
+        (zcfBundleCapResult.status === 'fulfilled' &&
+          zcfBundleCapResult.value) ||
+          Fail`the bundle cap was broken`;
       }
       const adminFacet = makeAdminFacet(
         adminNode,

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -143,7 +143,7 @@
 /**
  * @callback GetBundleIDFromInstallation
  *
- * Verify that an alleged Invitation is real, and return the Bundle ID it
+ * Verify that an alleged Installation is real, and return the Bundle ID it
  * will use for contract code.
  *
  * @param {ERef<Installation>} allegedInstallation

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -33,6 +33,7 @@
  * @property {GetBrands} getBrands
  * @property {GetTerms} getTerms
  * @property {GetOfferFilter} getOfferFilter
+ * @property {SetOfferFilter} setOfferFilter
  * @property {GetInstallationForInstance} getInstallationForInstance
  * @property {GetInstance} getInstance
  * @property {GetInstallation} getInstallation
@@ -40,12 +41,6 @@
  * Return an object with the instance, installation, description, invitation
  * handle, and any custom properties specific to the contract.
  * @property {GetFeeIssuer} getFeeIssuer
- * @property {() => Promise<Purse>} makeFeePurse
- * Deprecated. Does nothing useful but provided during transition so less old
- * code breaks.
- * @property {(defaultFeePurse: ERef<Purse>) => ZoeService} bindDefaultFeePurse
- * Deprecated. Does nothing useful but provided during transition so less old
- * code breaks.
  * @property {GetConfiguration} getConfiguration
  * @property {GetBundleIDFromInstallation} getBundleIDFromInstallation
  * @property {(invitationHandle: InvitationHandle) => Pattern | undefined} getProposalShapeForInvitation
@@ -90,6 +85,12 @@
  * @callback GetOfferFilter
  * @param {import('./utils').Instance<any>} instance
  * @returns {string[]}
+ */
+
+/**
+ * @callback SetOfferFilter
+ * @param {Instance} instance
+ * @param {string[]} strings
  */
 
 /**
@@ -197,7 +198,11 @@
  * @typedef {object} UserSeat
  * @property {() => Promise<ProposalRecord>} getProposal
  * @property {() => Promise<PaymentPKeywordRecord>} getPayouts
+ * returns a promise for a KeywordPaymentRecord containing all the payouts from
+ * this seat. The promise will resolve after the seat has exited.
  * @property {(keyword: Keyword) => Promise<Payment<any>>} getPayout
+ * returns a promise for the Payment corresponding to the indicated keyword.
+ * The promise will resolve after the seat has exited.
  * @property {() => Promise<OR>} getOfferResult
  * @property {() => void} [tryExit]
  * Note: Only works if the seat's `proposal` has an `OnDemand` `exit` clause. Zoe's
@@ -208,17 +213,16 @@
  * interact with the contract.
  * @property {() => Promise<boolean>} hasExited
  * Returns true if the seat has exited, false if it is still active.
- * @property {() => Promise<0|1>} numWantsSatisfied
- *
- * @property {() => Promise<Allocation>} getCurrentAllocationJig
- * Labelled "Jig" because it *should* only be used for tests, though
- * nothing prevents it from being used otherwise.
- * @property {() => Promise<Notifier<Allocation>>} getAllocationNotifierJig
- * Labelled "Jig" because it *should* only be used for tests, though
- * nothing prevents it from being used otherwise.
+ * @property {() => Promise<0|1>} numWantsSatisfied returns 1 if the proposal's
+ * want clause was satisfied by the final allocation, otherwise 0. This is
+ * numeric to support a planned enhancement called "multiples" which will allow
+ * the return value to be any non-negative number. The promise will resolve
+ * after the seat has exited.
  * @property {() => Promise<Allocation>} getFinalAllocation
- * return a promise for the final allocation. If called after the seat has
- * exited, it will promptly resolve to an Allocation.
+ * return a promise for the final allocation. The promise will resolve after the
+ * seat has exited.
+ * @property {() => Subscriber<any>} getExitSubscriber returns a subscriber that
+ * will be notified when the seat has exited or failed.
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -127,13 +127,17 @@ const makeZoeKit = (
         },
         startInstance,
         offer,
-        getPublicFacet(instance) {
+        setOfferFilter(instance, filters) {
           const { state } = this;
-          return state.dataAccess.getPublicFacet(instance);
+          state.dataAccess.setOfferFilter(instance, filters);
         },
 
         // The functions below are getters only and have no impact on
         // state within Zoe
+        getOfferFilter(instance) {
+          const { state } = this;
+          return state.dataAccess.getOfferFilter(instance);
+        },
         async getInvitationIssuer() {
           const { state } = this;
           return state.dataAccess.getInvitationIssuer();
@@ -150,33 +154,29 @@ const makeZoeKit = (
           const { state } = this;
           return state.dataAccess.getIssuers(instance);
         },
+        getPublicFacet(instance) {
+          const { state } = this;
+          return state.dataAccess.getPublicFacet(instance);
+        },
         getTerms(instance) {
           const { state } = this;
           return state.dataAccess.getTerms(instance);
-        },
-        getOfferFilter(instance) {
-          const { state } = this;
-          return state.dataAccess.getOfferFilter(instance);
-        },
-        setOfferFilter(instance, filters) {
-          const { state } = this;
-          state.dataAccess.setOfferFilter(instance, filters);
         },
         getInstallationForInstance(instance) {
           const { state } = this;
           return state.dataAccess.getInstallationForInstance(instance);
         },
-
-        getInstance(invitation) {
-          return getInstance(invitation);
-        },
-        getInstallation,
-        getInvitationDetails,
-        getConfiguration,
         getBundleIDFromInstallation(installation) {
           const { state } = this;
           return state.dataAccess.getBundleIDFromInstallation(installation);
         },
+        getInstallation,
+
+        getInstance(invitation) {
+          return getInstance(invitation);
+        },
+        getConfiguration,
+        getInvitationDetails,
         getProposalShapeForInvitation(invitation) {
           const { state } = this;
           return state.dataAccess.getProposalShapeForInvitation(invitation);

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -10,6 +10,7 @@ import '../internal-types.js';
 import {
   AmountKeywordRecordShape,
   KeywordShape,
+  ExitObjectShape,
   PaymentPKeywordRecordShape,
 } from '../typeGuards.js';
 
@@ -18,7 +19,7 @@ const ZoeSeatIKit = harden({
     replaceAllocation: M.call(AmountKeywordRecordShape).returns(),
     exit: M.call(M.any()).returns(),
     fail: M.call(M.any()).returns(),
-    resolveExitAndResult: M.call(M.promise(), M.remotable('exitObj')).returns(),
+    resolveExitAndResult: M.call(M.promise(), ExitObjectShape).returns(),
     getExitSubscriber: M.call().returns(SubscriberShape),
     // The return promise is empty, but doExit relies on settlement as a signal
     // that the payouts have settled. The exit publisher is notified after that.

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -1,108 +1,293 @@
-import { makePromiseKit } from '@endo/promise-kit';
-import { makeNotifierKit } from '@agoric/notifier';
+import { vivifyDurablePublishKit, SubscriberShape } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { M, vivifyFarClassKit, canBeDurable } from '@agoric/vat-data';
+import { deeplyFulfilled } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
 
-import { handlePKitWarning } from '../handleWarning.js';
 import { satisfiesWant } from '../contractFacet/offerSafety.js';
-
 import '../types.js';
 import '../internal-types.js';
+import {
+  AmountKeywordRecordShape,
+  KeywordShape,
+  PaymentPKeywordRecordShape,
+} from '../typeGuards.js';
+
+const ZoeSeatIKit = harden({
+  zoeSeatAdmin: M.interface('ZoeSeatAdmin', {
+    replaceAllocation: M.call(AmountKeywordRecordShape).returns(),
+    exit: M.call(M.any()).returns(),
+    fail: M.call(M.any()).returns(),
+    resolveExitAndResult: M.call(M.promise(), M.remotable('exitObj')).returns(),
+    getExitSubscriber: M.call().returns(SubscriberShape),
+    finalPayouts: M.call(M.eref(PaymentPKeywordRecordShape)).returns(
+      M.promise(),
+    ),
+  }),
+  userSeat: M.interface('UserSeat', {
+    getProposal: M.call().returns(M.promise()),
+    getPayouts: M.call().returns(M.promise()),
+    getPayout: M.call(KeywordShape).returns(M.promise()),
+    getOfferResult: M.call().returns(M.promise()),
+    hasExited: M.call().returns(M.promise()),
+    tryExit: M.call().returns(M.promise()),
+    numWantsSatisfied: M.call().returns(M.promise()),
+    getFinalAllocation: M.call().returns(M.promise()),
+    getExitSubscriber: M.call().returns(M.any()),
+  }),
+});
+
+const assertHasNotExited = (c, msg) => {
+  !c.state.instanceAdminHelper.hasExited(c.facets.zoeSeatAdmin) ||
+    assert(!c.state.instanceAdminHelper.hasExited(c.facets.zoeSeatAdmin), msg);
+};
 
 /**
- * makeZoeSeatAdminKit makes an object that manages the state of a seat
- * participating in a Zoe contract and return its two facets.
+ * makeZoeSeatAdminFactory returns a maker for an object that manages the state
+ * of a seat participating in a Zoe contract and return its two facets.
  *
- * The UserSeat
- * is suitable to be handed to an agent outside zoe and the contract and allows
- * them to query or monitor the current state, access the payouts and result,
- * and call exit() if that's allowed for this seat.
+ * The UserSeat is suitable to be handed to an agent outside zoe and the
+ * contract and allows them to query or monitor the current state, access the
+ * payouts and result, and call exit() if that's allowed for this seat.
  *
  * The zoeSeatAdmin is passed by Zoe to the ContractFacet (zcf), to allow zcf to
  * query or update the allocation or exit the seat cleanly.
+ *
+ * @param {import('@agoric/vat-data').Baggage} baggage
  */
-/** @type {MakeZoeSeatAdminKit} */
-export const makeZoeSeatAdminKit = (
-  initialAllocation,
-  exitZoeSeatAdmin,
-  hasExited,
-  proposal,
-  withdrawPayments,
-  exitObj,
-  offerResult,
-) => {
-  const payoutPromiseKit = makePromiseKit();
-  handlePKitWarning(payoutPromiseKit);
-  const { notifier, updater } = makeNotifierKit();
+export const makeZoeSeatAdminFactory = baggage => {
+  const makeDurablePublishKit = vivifyDurablePublishKit(
+    baggage,
+    'zoe Seat publisher',
+  );
 
-  // Prime the notifier with the initial allocation.
-  updater.updateState(initialAllocation);
-
-  let currentAllocation = initialAllocation;
-
-  const doExit = zoeSeatAdmin => {
-    exitZoeSeatAdmin(zoeSeatAdmin);
-
+  const doExit = (
+    zoeSeatAdmin,
+    currentAllocation,
+    withdrawFacet,
+    instanceAdminHelper,
+  ) => {
     /** @type {PaymentPKeywordRecord} */
-    const payout = withdrawPayments(currentAllocation);
-    payoutPromiseKit.resolve(payout);
+    const payouts = withdrawFacet.withdrawPayments(currentAllocation);
+    return E.when(
+      zoeSeatAdmin.finalPayouts(payouts),
+      () => instanceAdminHelper.exitZoeSeatAdmin(zoeSeatAdmin),
+      () => instanceAdminHelper.exitZoeSeatAdmin(zoeSeatAdmin),
+    );
   };
 
-  /** @type {ZoeSeatAdmin} */
-  const zoeSeatAdmin = Far('zoeSeatAdmin', {
-    replaceAllocation: replacementAllocation => {
-      assert(
-        !hasExited(zoeSeatAdmin),
-        'Cannot replace allocation. Seat has already exited',
-      );
-      harden(replacementAllocation);
-      // Merging happens in ZCF, so replacementAllocation can
-      // replace the old allocation entirely.
-      updater.updateState(replacementAllocation);
-      currentAllocation = replacementAllocation;
-    },
-    exit: reason => {
-      assert(
-        !hasExited(zoeSeatAdmin),
-        'Cannot exit seat. Seat has already exited',
-      );
-      updater.finish(reason);
-      doExit(zoeSeatAdmin);
-    },
-    fail: reason => {
-      assert(
-        !hasExited(zoeSeatAdmin),
-        'Cannot fail seat. Seat has already exited',
-      );
-      updater.fail(reason);
-      doExit(zoeSeatAdmin);
-    },
-    getNotifier: () => Promise.resolve(notifier),
-  });
+  // There is a race between resolveExitAndResult() and getOfferResult() that
+  // can be limited to when the adminFactory is paged in. If state.offerResult
+  // is defined, getOfferResult will return it. If it's not defined when
+  // getOfferResult is called, create a promiseKit, return the promise and store
+  // the kit here. When resolveExitAndResult() is called, it saves
+  // state.offerResult and resolves the promise if it exists, then removes the
+  // table entry.
+  const ephemeralOfferResultStore = new Map();
 
-  /** @type {UserSeat} */
-  const userSeat = Far('userSeat', {
-    getProposal: async () => proposal,
-    getPayouts: async () => payoutPromiseKit.promise,
-    getPayout: async keyword => {
-      assert(keyword, 'A keyword must be provided');
-      return E.get(payoutPromiseKit.promise)[keyword];
+  return vivifyFarClassKit(
+    baggage,
+    'ZoeSeatKit',
+    ZoeSeatIKit,
+    (
+      initialAllocation,
+      proposal,
+      instanceAdminHelper,
+      withdrawFacet,
+      exitObj = undefined,
+      // emptySeatKits start with offerResult validly undefined; others can set
+      // it to anything (including undefined) in resolveExitAndResult()
+      offerResultIsUndefined = false,
+    ) => {
+      const { publisher, subscriber } = makeDurablePublishKit();
+      return {
+        currentAllocation: initialAllocation,
+        proposal,
+        exitObj,
+        offerResult: undefined,
+        offerResultValid: offerResultIsUndefined,
+        instanceAdminHelper,
+        withdrawFacet,
+        publisher,
+        subscriber,
+        payouts: undefined,
+        exiting: false,
+      };
     },
-    getOfferResult: async () => offerResult,
-    hasExited: async () => hasExited(zoeSeatAdmin),
-    tryExit: async () => E(exitObj).exit(),
+    {
+      zoeSeatAdmin: {
+        replaceAllocation(replacementAllocation) {
+          const { state } = this;
+          assertHasNotExited(
+            this,
+            'Cannot replace allocation. Seat has already exited',
+          );
+          harden(replacementAllocation);
+          // Merging happens in ZCF, so replacementAllocation can
+          // replace the old allocation entirely.
 
-    getCurrentAllocationJig: async () => currentAllocation,
-    getAllocationNotifierJig: async () => notifier,
-    getFinalAllocation: () =>
-      E.when(payoutPromiseKit.promise, () => currentAllocation),
+          state.currentAllocation = replacementAllocation;
+        },
+        exit(reason) {
+          const { state, facets } = this;
+          // Since this method doesn't wait, we could re-enter via exitAllSeats.
+          // If that happens, we shouldn't re-do any of the work.
+          if (state.exiting) {
+            return;
+          }
+          assertHasNotExited(this, 'Cannot exit seat. Seat has already exited');
 
-    numWantsSatisfied: async () => {
-      return E.when(payoutPromiseKit.promise, () =>
-        satisfiesWant(proposal, currentAllocation),
-      );
+          state.exiting = true;
+          E.when(
+            doExit(
+              facets.zoeSeatAdmin,
+              state.currentAllocation,
+              state.withdrawFacet,
+              state.instanceAdminHelper,
+            ),
+            () => state.publisher.finish(reason),
+          );
+        },
+        fail(reason) {
+          const { state, facets } = this;
+          // Since this method doesn't wait, we could re-enter via failAllSeats.
+          // If that happens, we shouldn't re-do any of the work.
+          if (state.exiting) {
+            return;
+          }
+
+          assertHasNotExited(this, 'Cannot fail seat. Seat has already exited');
+
+          state.exiting = true;
+          E.when(
+            doExit(
+              facets.zoeSeatAdmin,
+              state.currentAllocation,
+              state.withdrawFacet,
+              state.instanceAdminHelper,
+            ),
+            () => state.publisher.fail(reason),
+            () => state.publisher.fail(reason),
+          );
+        },
+        // called only for seats resulting from offers.
+        resolveExitAndResult(offerResultPromise, exitObj) {
+          const { state, facets } = this;
+
+          if (ephemeralOfferResultStore.has(facets.userSeat)) {
+            const pKit = ephemeralOfferResultStore.get(facets.userSeat);
+            E.when(
+              offerResultPromise,
+              offerResult => {
+                pKit.resolve(offerResult);
+                state.offerResult = offerResult;
+                state.offerResultValid = true;
+                ephemeralOfferResultStore.delete(facets.userSeat);
+              },
+              e => {
+                pKit.reject(e);
+                state.offerResult = pKit.promise;
+                state.offerResultValid = true;
+                ephemeralOfferResultStore.delete(facets.userSeat);
+              },
+            );
+          } else if (canBeDurable(offerResultPromise)) {
+            state.offerResult = offerResultPromise;
+            state.offerResultValid = true;
+          } else {
+            const kit = makePromiseKit();
+            kit.resolve(offerResultPromise);
+            ephemeralOfferResultStore.set(facets.userSeat, kit);
+            state.offerResultValid = false;
+          }
+
+          state.exitObj = exitObj;
+        },
+        getExitSubscriber() {
+          const { state } = this;
+          return state.subscriber;
+        },
+        async finalPayouts(payments) {
+          const { state } = this;
+
+          const settledPayouts = await deeplyFulfilled(payments);
+          state.payouts = settledPayouts;
+        },
+      },
+      userSeat: {
+        async getProposal() {
+          const { state } = this;
+          return state.proposal;
+        },
+        async getPayouts() {
+          const { state } = this;
+
+          return E.when(
+            state.subscriber.subscribeAfter(),
+            () => deeplyFulfilled(state.payouts),
+            () => deeplyFulfilled(state.payouts),
+          );
+        },
+        async getPayout(keyword) {
+          const { state } = this;
+
+          return E.when(
+            state.subscriber.subscribeAfter(),
+            // @ts-expect-error subscribeAfter guarantees it won't be undefined
+            () => state.payouts[keyword],
+            // @ts-expect-error subscribeAfter guarantees it won't be undefined
+            () => state.payouts[keyword],
+          );
+        },
+        async getOfferResult() {
+          const { state, facets } = this;
+
+          if (state.offerResultValid) {
+            return state.offerResult;
+          } else if (ephemeralOfferResultStore.has(facets.userSeat)) {
+            return ephemeralOfferResultStore.get(facets.userSeat).promise;
+          }
+
+          const kit = makePromiseKit();
+          ephemeralOfferResultStore.set(facets.userSeat, kit);
+          return kit.promise;
+        },
+        async hasExited() {
+          const { state, facets } = this;
+
+          return (
+            state.exiting ||
+            state.instanceAdminHelper.hasExited(facets.zoeSeatAdmin)
+          );
+        },
+        async tryExit() {
+          const { state } = this;
+          assert(state.exitObj, 'exitObj must be initialized before use');
+          assertHasNotExited(this, 'Cannot exit; seat has already exited');
+
+          return E(state.exitObj).exit();
+        },
+        async numWantsSatisfied() {
+          const { state } = this;
+          return E.when(
+            state.subscriber.subscribeAfter(),
+            () => satisfiesWant(state.proposal, state.currentAllocation),
+            () => satisfiesWant(state.proposal, state.currentAllocation),
+          );
+        },
+        getExitSubscriber() {
+          const { state } = this;
+          return state.subscriber;
+        },
+        getFinalAllocation() {
+          const { state } = this;
+          return E.when(
+            state.subscriber.subscribeAfter(),
+            () => state.currentAllocation,
+            () => state.currentAllocation,
+          );
+        },
+      },
     },
-  });
-
-  return { userSeat, zoeSeatAdmin, notifier };
+  );
 };

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -20,7 +20,7 @@ const ZoeSeatIKit = harden({
     fail: M.call(M.any()).returns(),
     resolveExitAndResult: M.call(M.promise(), M.remotable('exitObj')).returns(),
     getExitSubscriber: M.call().returns(SubscriberShape),
-    // The return promise is empty, but doExit relies on resolution as a signal
+    // The return promise is empty, but doExit relies on settlement as a signal
     // that the payouts have settled. The exit publisher is notified after that.
     finalPayouts: M.call(M.eref(PaymentPKeywordRecordShape)).returns(
       M.promise(),

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -344,10 +344,6 @@ export const makeZoeStorageManager = (
     return makeInstanceStorageManager().instanceStorageManager;
   };
 
-  const installBundle = bundleID => {
-    return installationStorage.installBundle(bundleID);
-  };
-
   const getInvitationIssuer = () => invitationIssuer;
 
   const makeStorageManager = vivifyFarClassKit(
@@ -392,7 +388,9 @@ export const makeZoeStorageManager = (
           return state.instanceAdmins.getInstallationForInstance(instance);
         },
         getProposalShapeForInvitation,
-        installBundle,
+        installBundle: allegedBundle => {
+          return installationStorage.installBundle(allegedBundle);
+        },
         installBundleID(bundleID) {
           return installationStorage.installBundleID(bundleID);
         },

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -19,7 +19,7 @@ import { makeInstallationStorage } from './installationStorage.js';
 import './types.js';
 import './internal-types.js';
 import {
-  InstanceStorageManagerI,
+  InstanceStorageManagerIKit,
   ZoeMintI,
   ZoeStorageManagerIKit,
 } from '../typeGuards.js';
@@ -234,7 +234,7 @@ export const makeZoeStorageManager = (
     const makeInstanceStorageManager = vivifyFarClassKit(
       instanceBaggage,
       'InstanceStorageManager',
-      InstanceStorageManagerI,
+      InstanceStorageManagerIKit,
       initEmpty,
       {
         instanceStorageManager: {
@@ -302,16 +302,21 @@ export const makeZoeStorageManager = (
               ),
             );
           },
-          initInstanceAdmin(i, instanceAdmin) {
+          initInstanceAdmin(instanceHandle, instanceAdmin) {
             return instanceAdminStorage.updater.initInstanceAdmin(
-              i,
+              instanceHandle,
               instanceAdmin,
             );
           },
           deleteInstanceAdmin(i) {
             instanceAdminStorage.updater.deleteInstanceAdmin(i);
           },
-          makeInvitation(handle, desc, customProps, proposalShape) {
+          makeInvitation(
+            handle,
+            desc,
+            customProps = undefined,
+            proposalShape = undefined,
+          ) {
             return makeInvitationImpl(handle, desc, customProps, proposalShape);
           },
           getInvitationIssuer() {
@@ -393,8 +398,7 @@ export const makeZoeStorageManager = (
         },
       },
       makeOfferAccess: {
-        getAssetKindByBrand: issuerStorage.getAssetKindByBrand /* o */,
-        installBundle,
+        getAssetKindByBrand: issuerStorage.getAssetKindByBrand,
         getInstanceAdmin(instance) {
           const { state } = this;
           return state.instanceAdmins.getInstanceAdmin(instance);

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -1,20 +1,28 @@
-import { AssetKind, makeIssuerKit } from '@agoric/ertp';
-import { Far } from '@endo/marshal';
+import { AssetKind, makeDurableIssuerKit } from '@agoric/ertp';
 import {
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
+  vivifyFarClassKit,
+  vivifyFarClass,
+  provideDurableSetStore,
 } from '@agoric/vat-data';
+import { initEmpty } from '@agoric/store';
 
 import { provideIssuerStorage } from '../issuerStorage.js';
 import { makeAndStoreInstanceRecord } from '../instanceRecordStorage.js';
 import { makeIssuerRecord } from '../issuerRecord.js';
-import { makeEscrowStorage } from './escrowStorage.js';
+import { provideEscrowStorage } from './escrowStorage.js';
 import { vivifyInvitationKit } from './makeInvitation.js';
 import { makeInstanceAdminStorage } from './instanceAdminStorage.js';
 import { makeInstallationStorage } from './installationStorage.js';
 
 import './types.js';
 import './internal-types.js';
+import {
+  InstanceStorageManagerI,
+  ZoeMintI,
+  ZoeStorageManagerIKit,
+} from '../typeGuards.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -31,20 +39,19 @@ import './internal-types.js';
  * @param {CreateZCFVat} createZCFVat - the ability to create a new
  * ZCF Vat
  * @param {GetBundleCapForID} getBundleCapForID
- * @param {GetFeeIssuerKit} getFeeIssuerKit
  * @param {ShutdownWithFailure} shutdownZoeVat
- * @param {Issuer} feeIssuer
- * @param {Brand} feeBrand
+ * @param {{
+ *    getFeeIssuerKit: GetFeeIssuerKit,
+ *    getFeeIssuer: () => Issuer,
+ *    getFeeBrand: () => Brand,
+ * }} feeMint
  * @param {Baggage} [zoeBaggage]
- * @returns {ZoeStorageManager}
  */
 export const makeZoeStorageManager = (
   createZCFVat,
   getBundleCapForID,
-  getFeeIssuerKit,
   shutdownZoeVat,
-  feeIssuer,
-  feeBrand,
+  feeMint,
   zoeBaggage = makeScalarBigMapStore('zoe baggage', { durable: true }),
 ) => {
   // issuerStorage contains the issuers that the ZoeService knows
@@ -56,7 +63,7 @@ export const makeZoeStorageManager = (
   // EscrowStorage holds the purses that Zoe uses for escrow. This
   // object should be closely held and tracked: all of the digital
   // assets that users escrow are contained within these purses.
-  const escrowStorage = makeEscrowStorage(zoeBaggage);
+  const escrowStorage = provideEscrowStorage(zoeBaggage);
 
   // Add a purse for escrowing user funds (not for fees). Create the
   // local, non-remote escrow purse for the fee mint immediately.
@@ -64,7 +71,11 @@ export const makeZoeStorageManager = (
   // would treat the feeIssuer as if it is remote, creating a promise
   // for a purse with E(issuer).makeEmptyPurse(). We need a local
   // purse, so we cannot allow that to happen.
-  escrowStorage.makeLocalPurse(feeIssuer, feeBrand);
+
+  escrowStorage.provideLocalPurse(
+    feeMint.getFeeIssuer(),
+    feeMint.getFeeBrand(),
+  );
 
   // In order to participate in a contract, users must have
   // invitations, which are ERTP payments made by Zoe. This code
@@ -78,27 +89,14 @@ export const makeZoeStorageManager = (
   // "zoeInstanceAdmin" - an admin facet within the Zoe Service for
   // that particular instance. This code manages the storage of those
   // instanceAdmins
-  const {
-    getPublicFacet,
-    getBrands,
-    getIssuers,
-    getTerms,
-    getOfferFilter,
-    getInstallationForInstance,
-    getInstanceAdmin,
-    initInstanceAdmin,
-    deleteInstanceAdmin,
-  } = makeInstanceAdminStorage();
+  const instanceAdminStorage = makeInstanceAdminStorage(zoeBaggage);
 
   // Zoe stores "installations" - identifiable bundles of contract
-  // code that can be reused again and again to create new contract
-  // instances
-  const {
-    installBundle,
-    installBundleID,
-    unwrapInstallation,
-    getBundleIDFromInstallation,
-  } = makeInstallationStorage(getBundleCapForID, zoeBaggage);
+  // code that can be reused to create new contract instances
+  const installationStorage = makeInstallationStorage(
+    getBundleCapForID,
+    zoeBaggage,
+  );
 
   const proposalShapes = provideDurableWeakMapStore(
     zoeBaggage,
@@ -112,7 +110,51 @@ export const makeZoeStorageManager = (
     return undefined;
   };
 
-  /** @type {MakeZoeInstanceStorageManager} */
+  const zoeMintBaggageSet = provideDurableSetStore(
+    zoeBaggage,
+    'zoeMintBaggageSet',
+  );
+  for (const issuerBaggage of zoeMintBaggageSet.values()) {
+    zoeMintBaggageSet(issuerBaggage);
+  }
+
+  const makeZoeMint = vivifyFarClass(
+    zoeBaggage,
+    'ZoeMint',
+    ZoeMintI,
+    (localMint, localPooledPurse, adminNode, localIssuerRecord) => ({
+      localMint,
+      localPooledPurse,
+      adminNode,
+      localIssuerRecord,
+    }),
+    {
+      getIssuerRecord() {
+        const { state } = this;
+        return state.localIssuerRecord;
+      },
+      mintAndEscrow(totalToMint) {
+        const { state } = this;
+        const payment = state.localMint.mintPayment(totalToMint);
+        // Note COMMIT POINT within deposit.
+        state.localPooledPurse.deposit(payment, totalToMint);
+      },
+      withdrawAndBurn(totalToBurn) {
+        const { state } = this;
+        try {
+          // COMMIT POINT
+          const payment = state.localPooledPurse.withdraw(totalToBurn);
+          // Note redundant COMMIT POINT within burn.
+          state.localIssuerRecord.issuer.burn(payment, totalToBurn);
+        } catch (err) {
+          // eslint-disable-next-line no-use-before-define
+          state.adminNode.terminateWithFailure(err);
+          throw err;
+        }
+      },
+    },
+  );
+
   const makeZoeInstanceStorageManager = async (
     instanceBaggage,
     installation,
@@ -150,16 +192,7 @@ export const makeZoeStorageManager = (
       brands,
     );
 
-    /** @type {SaveIssuer} */
-    const saveIssuer = async (issuerP, keyword) => {
-      const issuerRecord = await issuerStorage.storeIssuer(issuerP);
-      await escrowStorage.createPurse(issuerRecord.issuer, issuerRecord.brand);
-      instanceRecordManager.addIssuerToInstanceRecord(keyword, issuerRecord);
-      return issuerRecord;
-    };
-
-    /** @type {WrapIssuerKitWithZoeMint} */
-    const wrapIssuerKitWithZoeMint = (keyword, localIssuerKit) => {
+    const wrapIssuerKitWithZoeMint = (keyword, localIssuerKit, adminNode) => {
       const {
         mint: localMint,
         issuer: localIssuer,
@@ -173,7 +206,7 @@ export const makeZoeStorageManager = (
         localDisplayInfo,
       );
       issuerStorage.storeIssuerRecord(localIssuerRecord);
-      const localPooledPurse = escrowStorage.makeLocalPurse(
+      const localPooledPurse = escrowStorage.provideLocalPurse(
         localIssuerRecord.issuer,
         localIssuerRecord.brand,
       );
@@ -182,69 +215,15 @@ export const makeZoeStorageManager = (
         localIssuerRecord,
       );
       /** @type {ZoeMint} */
-      const zoeMint = Far('ZoeMint', {
-        getIssuerRecord: () => {
-          return localIssuerRecord;
-        },
-        mintAndEscrow: totalToMint => {
-          const payment = localMint.mintPayment(totalToMint);
-          // Note COMMIT POINT within deposit.
-          localPooledPurse.deposit(payment, totalToMint);
-        },
-        withdrawAndBurn: totalToBurn => {
-          // eslint-disable-next-line no-use-before-define
-          try {
-            // COMMIT POINT
-            const payment = localPooledPurse.withdraw(totalToBurn);
-            // Note redundant COMMIT POINT within burn.
-            localIssuer.burn(payment, totalToBurn);
-          } catch (err) {
-            // eslint-disable-next-line no-use-before-define
-            adminNode.terminateWithFailure(err);
-            throw err;
-          }
-        },
-      });
-      return zoeMint;
-    };
-
-    /** @type {MakeZoeMint} */
-    const makeZoeMint = (
-      keyword,
-      assetKind = AssetKind.NAT,
-      displayInfo,
-      { elementShape = undefined } = {},
-    ) => {
-      // Local indicates one that zoe itself makes from vetted code,
-      // and so can be assumed correct and fresh by zoe.
-      const localIssuerKit = makeIssuerKit(
-        keyword,
-        assetKind,
-        displayInfo,
-        // eslint-disable-next-line no-use-before-define
-        adminNode.terminateWithFailure,
-        { elementShape },
+      return makeZoeMint(
+        localMint,
+        localPooledPurse,
+        adminNode,
+        localIssuerRecord,
       );
-      return wrapIssuerKitWithZoeMint(keyword, localIssuerKit);
     };
 
-    /** @type {RegisterFeeMint} */
-    const registerFeeMint = (keyword, allegedFeeMintAccess) => {
-      const feeIssuerKit = getFeeIssuerKit(allegedFeeMintAccess);
-      return wrapIssuerKitWithZoeMint(keyword, feeIssuerKit);
-    };
-
-    /** @type {GetIssuerRecords} */
-    const getIssuerRecords = () =>
-      issuerStorage.getIssuerRecords(
-        // the issuerStorage is a weakStore, so we cannot iterate over
-        // it directly. Additionally, we only want to export the
-        // issuers used in this contract instance specifically, not
-        // all issuers.
-        Object.values(instanceRecordManager.getInstanceRecord().terms.issuers),
-      );
-
-    const makeInvitation = setupMakeInvitation(
+    const makeInvitationImpl = setupMakeInvitation(
       instance,
       installation,
       proposalShapes,
@@ -252,43 +231,191 @@ export const makeZoeStorageManager = (
 
     const { root, adminNode } = await createZCFVat(contractBundleCap);
 
-    return harden({
-      getTerms: instanceRecordManager.getTerms,
-      getIssuers: instanceRecordManager.getIssuers,
-      getBrands: instanceRecordManager.getBrands,
-      getInstallationForInstance:
-        instanceRecordManager.getInstallationForInstance,
-      saveIssuer,
-      makeZoeMint,
-      registerFeeMint,
-      getInstanceRecord: instanceRecordManager.getInstanceRecord,
-      getIssuerRecords,
-      withdrawPayments: escrowStorage.withdrawPayments,
-      initInstanceAdmin,
-      deleteInstanceAdmin,
-      makeInvitation,
-      invitationIssuer,
-      root,
-      adminNode,
-    });
+    const makeInstanceStorageManager = vivifyFarClassKit(
+      instanceBaggage,
+      'InstanceStorageManager',
+      InstanceStorageManagerI,
+      initEmpty,
+      {
+        instanceStorageManager: {
+          getTerms() {
+            return instanceRecordManager.getTerms();
+          },
+          getIssuers() {
+            return instanceRecordManager.getIssuers();
+          },
+          getBrands() {
+            return instanceRecordManager.getBrands();
+          },
+          getInstallationForInstance() {
+            return instanceRecordManager.getInstallationForInstance();
+          },
+          async saveIssuer(issuerP, keyword) {
+            const issuerRecord = await issuerStorage.storeIssuer(issuerP);
+            await escrowStorage.createPurse(
+              issuerRecord.issuer,
+              issuerRecord.brand,
+            );
+            instanceRecordManager.addIssuerToInstanceRecord(
+              keyword,
+              issuerRecord,
+            );
+            return issuerRecord;
+          },
+          makeZoeMint(
+            keyword,
+            assetKind = AssetKind.NAT,
+            displayInfo,
+            { elementShape = undefined } = {},
+          ) {
+            // Local indicates one that zoe itself makes from vetted code,
+            // and so can be assumed correct and fresh by zoe.
+            const issuerBaggage = makeScalarBigMapStore('IssuerBaggage', {
+              durable: true,
+            });
+            const localIssuerKit = makeDurableIssuerKit(
+              issuerBaggage,
+              keyword,
+              assetKind,
+              displayInfo,
+              adminNode.terminateWithFailure,
+              { elementShape },
+            );
+            zoeMintBaggageSet.add(issuerBaggage);
+            return wrapIssuerKitWithZoeMint(keyword, localIssuerKit, adminNode);
+          },
+          registerFeeMint(keyword, allegedFeeMintAccess) {
+            const feeIssuerKit = feeMint.getFeeIssuerKit(allegedFeeMintAccess);
+            return wrapIssuerKitWithZoeMint(keyword, feeIssuerKit, adminNode);
+          },
+          getInstanceRecord() {
+            return instanceRecordManager.getInstanceRecord();
+          },
+          getIssuerRecords() {
+            return issuerStorage.getIssuerRecords(
+              // the issuerStorage is a weakStore, so we cannot iterate over
+              // it directly. Additionally, we only want to export the
+              // issuers used in this contract instance specifically, not
+              // all issuers.
+              Object.values(
+                instanceRecordManager.getInstanceRecord().terms.issuers,
+              ),
+            );
+          },
+          initInstanceAdmin(i, instanceAdmin) {
+            return instanceAdminStorage.updater.initInstanceAdmin(
+              i,
+              instanceAdmin,
+            );
+          },
+          deleteInstanceAdmin(i) {
+            instanceAdminStorage.updater.deleteInstanceAdmin(i);
+          },
+          makeInvitation(handle, desc, customProps, proposalShape) {
+            return makeInvitationImpl(handle, desc, customProps, proposalShape);
+          },
+          getInvitationIssuer() {
+            return invitationIssuer;
+          },
+          getRoot() {
+            return root;
+          },
+          getWithdrawFacet() {
+            const { facets } = this;
+            return facets.withdrawFacet;
+          },
+          getAdminNode() {
+            return adminNode;
+          },
+        },
+        // Goes to the Zoe seat, which isn't restricted in how much to withdraw
+        withdrawFacet: {
+          withdrawPayments(amounts) {
+            return escrowStorage.withdrawPayments(amounts);
+          },
+        },
+      },
+    );
+    return makeInstanceStorageManager().instanceStorageManager;
   };
 
-  return {
-    makeZoeInstanceStorageManager,
-    getAssetKindByBrand: issuerStorage.getAssetKindByBrand,
-    depositPayments: escrowStorage.depositPayments,
-    invitationIssuer,
-    installBundle,
-    installBundleID,
-    getBundleIDFromInstallation,
-    getPublicFacet,
-    getBrands,
-    getIssuers,
-    getOfferFilter,
-    getTerms,
-    getInstallationForInstance,
-    getInstanceAdmin,
-    unwrapInstallation,
-    getProposalShapeForInvitation,
+  const installBundle = bundleID => {
+    return installationStorage.installBundle(bundleID);
   };
+
+  const getInvitationIssuer = () => invitationIssuer;
+
+  const makeStorageManager = vivifyFarClassKit(
+    zoeBaggage,
+    'ZoeStorageManager',
+    ZoeStorageManagerIKit,
+    instanceAdmins => ({ instanceAdmins }),
+    {
+      zoeServiceDataAccess: {
+        getInvitationIssuer,
+        getBundleIDFromInstallation(allegedInstallation) {
+          return installationStorage.getBundleIDFromInstallation(
+            allegedInstallation,
+          );
+        },
+        getPublicFacet(instance) {
+          const { state } = this;
+          return state.instanceAdmins.getPublicFacet(instance);
+        },
+        getBrands(instance) {
+          const { state } = this;
+          return state.instanceAdmins.getBrands(instance);
+        },
+        getIssuers(instance) {
+          const { state } = this;
+          return state.instanceAdmins.getIssuers(instance);
+        },
+        getOfferFilter(instance) {
+          const { state } = this;
+          return state.instanceAdmins.getOfferFilter(instance);
+        },
+        setOfferFilter(instance, filters) {
+          const { state } = this;
+          state.instanceAdmins.setOfferFilter(instance, filters);
+        },
+        getTerms(instance) {
+          const { state } = this;
+          return state.instanceAdmins.getTerms(instance);
+        },
+        getInstallationForInstance(instance) {
+          const { state } = this;
+          return state.instanceAdmins.getInstallationForInstance(instance);
+        },
+        getProposalShapeForInvitation,
+        installBundle,
+        installBundleID(bundleID) {
+          return installationStorage.installBundleID(bundleID);
+        },
+      },
+      makeOfferAccess: {
+        getAssetKindByBrand: issuerStorage.getAssetKindByBrand /* o */,
+        installBundle,
+        getInstanceAdmin(instance) {
+          const { state } = this;
+          return state.instanceAdmins.getInstanceAdmin(instance);
+        },
+        getProposalShapeForInvitation,
+        getInvitationIssuer,
+        depositPayments(proposal, payments) {
+          return escrowStorage.depositPayments(proposal, payments);
+        },
+      },
+      startInstanceAccess: {
+        makeZoeInstanceStorageManager,
+        unwrapInstallation(installation) {
+          return installationStorage.unwrapInstallation(installation);
+        },
+      },
+      invitationIssuerAccess: {
+        getInvitationIssuer,
+      },
+    },
+  );
+
+  return makeStorageManager(instanceAdminStorage.accessor);
 };

--- a/packages/zoe/test/swingsetTests/runMint/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/runMint/bootstrap.js
@@ -8,7 +8,9 @@ export function buildRootObject(vatPowers, vatParameters) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
-      const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const { zoe, feeMintAccessRetriever } = await E(vats.zoe).buildZoe(
+        vatAdminSvc,
+      );
       const installations = {};
       const installedPs = vatParameters.contractNames.map(name =>
         E(vatAdminSvc)
@@ -20,6 +22,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       );
       await Promise.all(installedPs);
 
+      const feeMintAccess = await E(feeMintAccessRetriever).get();
       const aliceP = E(vats.alice).build(zoe, installations, feeMintAccess);
       await E(aliceP).runMintTest();
     },

--- a/packages/zoe/test/swingsetTests/runMint/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/runMint/vat-alice.js
@@ -13,9 +13,9 @@ const build = async (log, zoe, installations, feeMintAccess) => {
       log('starting runMintTest');
       const { instance } = await E(zoe).startInstance(
         installations.offerArgsUsageContract,
-        {
+        harden({
           RUN: E(zoe).getFeeIssuer(),
-        },
+        }),
         undefined,
       );
       const issuers = await E(zoe).getIssuers(instance);

--- a/packages/zoe/test/swingsetTests/runMint/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/runMint/vat-zoe.js
@@ -6,11 +6,12 @@ export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: async vatAdminSvc => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe, feeMintAccess } = makeZoeKit(
+      const { zoeService: zoe, feeMintAccessRetriever } = makeZoeKit(
         vatAdminSvc,
         shutdownZoeVat,
       );
-      return harden({ zoe, feeMintAccess });
+
+      return harden({ zoe, feeMintAccessRetriever });
     },
   });
 }

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -8,9 +8,8 @@ import '../../../../exported.js';
 
 import { E } from '@endo/eventual-send';
 import bundleSource from '@endo/bundle-source';
-import { AmountMath } from '@agoric/ertp';
+import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 
-import { setup } from '../../setupBasicMints.js';
 import { setupZCFTest } from '../../zcf/setupZcfTest.js';
 import { makeRatio } from '../../../../src/contractSupport/index.js';
 import { assertAmountsEqual } from '../../../zoeTestHelpers.js';
@@ -95,7 +94,8 @@ export const checkPayouts = async (
 };
 
 export const setupLoanUnitTest = async terms => {
-  const { moolaKit: collateralKit, simoleanKit: loanKit } = setup();
+  const collateralKit = makeIssuerKit('moola');
+  const loanKit = makeIssuerKit('simoleans');
 
   if (!terms) {
     terms = harden({

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -35,11 +35,12 @@ const setupBorrow = async (
   timer = buildManualTimer(console.log, 0n, { eventLoopIteration }),
 ) => {
   const setup = await setupLoanUnitTest();
-  const { zcf, loanKit, collateralKit, zoe, vatAdminState } = setup;
+  const { zcf: loanZcf, loanKit, collateralKit, zoe, vatAdminState } = setup;
   // Set up the lender seat
   const maxLoan = AmountMath.make(loanKit.brand, maxLoanValue);
+
   const { zcfSeat: lenderSeat, userSeat: lenderUserSeat } = await makeSeatKit(
-    zcf,
+    loanZcf,
     { give: { Loan: maxLoan } },
     { Loan: loanKit.mint.mintPayment(maxLoan) },
   );
@@ -88,7 +89,7 @@ const setupBorrow = async (
     loanBrand: loanKit.brand,
     collateralBrand: collateralKit.brand,
   };
-  const borrowInvitation = makeBorrowInvitation(zcf, config);
+  const borrowInvitation = makeBorrowInvitation(loanZcf, config);
   return {
     ...setup,
     borrowInvitation,

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -348,7 +348,7 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
   await E(aliceSeat).getOfferResult();
 
   await t.throwsAsync(() => E(aliceSeat).tryExit(), {
-    message: /seat has been exited/,
+    message: /seat has already exited/,
   });
 
   const moolaPayout = await aliceSeat.getPayout('ContributionA');

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
@@ -6,7 +6,7 @@ import path from 'path';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
 import { M, fit, keyEQ } from '@agoric/store';
-import { AmountMath, AssetKind } from '@agoric/ertp';
+import { AmountMath, AssetKind, BrandShape } from '@agoric/ertp';
 
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { setup } from '../setupBasicMints.js';
@@ -200,7 +200,7 @@ test('zoe - coveredCall with swap for invitation', async t => {
   fit(optionAmount, optionAmountPattern1);
 
   const optionAmountPattern2 = harden({
-    brand: M.remotable(),
+    brand: BrandShape,
     value: [
       M.split({
         installation: coveredCallInstallation,

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -67,7 +67,7 @@ test.before(
   },
 );
 
-test('pay bounty', async t => {
+test.serial('pay bounty', async t => {
   const { zoe, oracleInstallation, bountyInstallation } = t.context;
   // The timer is not build in test.before(), because each test needs its own.
   const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });
@@ -152,7 +152,7 @@ test('pay bounty', async t => {
   await Promise.all([promise1, promise2, promise3, promise4]);
 });
 
-test('pay no bounty', async t => {
+test.serial('pay no bounty', async t => {
   const { zoe, oracleInstallation, bountyInstallation } = t.context;
   // The timer is not build in test.before(), because each test needs its own.
   const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -5,7 +5,6 @@ import path from 'path';
 
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
-import { makePromiseKit } from '@endo/promise-kit';
 import { passStyleOf, Far } from '@endo/marshal';
 import { getMethodNames } from '@agoric/internal';
 
@@ -21,8 +20,7 @@ const dirname = path.dirname(filename);
 test(`zoe.getInvitationIssuer`, async t => {
   const { zoe, zcf } = await setupZCFTest();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  // @ts-expect-error
-  const invitation = zcf.makeInvitation(undefined, 'invite');
+  const invitation = zcf.makeInvitation(() => {}, 'invite');
 
   // A few basic tests that the invitation issuer acts like an issuer.
   // Not exhaustive.
@@ -38,7 +36,8 @@ test(`E(zoe).install bad bundle`, async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).install(), {
-    message: 'a bundle must be provided',
+    message:
+      'In "install" method of (ZoeService zoeService): Expected at least 1 arguments: []',
   });
 });
 
@@ -54,7 +53,8 @@ test(`E(zoe).installBundleID bad id`, async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).installBundleID(), {
-    message: 'a bundle ID must be provided',
+    message:
+      'In "installBundleID" method of (ZoeService zoeService): Expected at least 1 arguments: []',
   });
 });
 
@@ -77,12 +77,7 @@ test(`E(zoe).startInstance bad installation`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).startInstance(), {
     message:
-      // Should be able to use more informative error once SES double
-      // disclosure bug is fixed. See
-      // https://github.com/endojs/endo/pull/640
-      //
-      // /"\[undefined\]" was not a valid installation/,
-      /.* was not a valid installation/,
+      'In "startInstance" method of (ZoeService zoeService): Expected at least 1 arguments: []',
   });
 });
 
@@ -97,10 +92,9 @@ function facetHasMethods(t, facet, names) {
 }
 
 test(`E(zoe).startInstance no issuerKeywordRecord, no terms`, async t => {
-  const { zoe, installation } = await setupZCFTest();
-  const result = await E(zoe).startInstance(installation);
+  const result = await setupZCFTest();
   // Note that deepEqual treats all empty objects (handles) as interchangeable.
-  t.deepEqual(Object.getOwnPropertyNames(result).sort(), [
+  t.deepEqual(Object.getOwnPropertyNames(result.startInstanceResult).sort(), [
     'adminFacet',
     'creatorFacet',
     'creatorInvitation',
@@ -109,23 +103,16 @@ test(`E(zoe).startInstance no issuerKeywordRecord, no terms`, async t => {
   ]);
   isEmptyFacet(t, result.creatorFacet);
   t.deepEqual(result.creatorInvitation, undefined);
-  facetHasMethods(t, result.publicFacet, ['makeInvitation']);
-  t.deepEqual(getMethodNames(result.adminFacet), [
-    'getVatShutdownPromise',
-    'restartContract',
-    'upgradeContract',
+  facetHasMethods(t, result.startInstanceResult.publicFacet, [
+    'makeInvitation',
   ]);
+  isEmptyFacet(t, result.startInstanceResult.adminFacet);
 });
 
 test(`E(zoe).startInstance promise for installation`, async t => {
-  const { zoe, installation } = await setupZCFTest();
-  const { promise: installationP, resolve: installationPResolve } =
-    makePromiseKit();
+  const { startInstanceResult } = await setupZCFTest();
 
-  const resultP = E(zoe).startInstance(installationP);
-  installationPResolve(installation);
-
-  const result = await resultP;
+  const result = await startInstanceResult;
   // Note that deepEqual treats all empty objects (handles) as interchangeable.
   t.deepEqual(Object.getOwnPropertyNames(result).sort(), [
     'adminFacet',
@@ -145,7 +132,8 @@ test(`E(zoe).startInstance promise for installation`, async t => {
 });
 
 test(`E(zoe).startInstance - terms, issuerKeywordRecord switched`, async t => {
-  const { zoe, installation } = await setupZCFTest();
+  const { zoe } = setup();
+  const installation = await E(zoe).installBundleID('b1-contract');
   const { moolaKit } = setup();
   await t.throwsAsync(
     () =>
@@ -156,18 +144,14 @@ test(`E(zoe).startInstance - terms, issuerKeywordRecord switched`, async t => {
       ),
     {
       message:
-        // Should be able to use more informative error once SES double
-        // disclosure bug is fixed. See
-        // https://github.com/endojs/endo/pull/640
-        //
-        // /keyword "something" must be an ascii identifier starting with upper case./
-        /keyword .* must be an ascii identifier starting with upper case./,
+        'In "startInstance" method of (ZoeService zoeService): arg 1?: something: [1]: 2 - Must match one of ["[match:remotable]","[match:kind]"]',
     },
   );
 });
 
 test(`E(zoe).startInstance - bad issuer, makeEmptyPurse throws`, async t => {
-  const { zoe, installation } = await setupZCFTest();
+  const { zoe } = setup();
+  const installation = await E(zoe).installBundleID('b1-contract');
   const brand = Far('brand', {
     // eslint-disable-next-line no-use-before-define
     isMyIssuer: i => i === badIssuer,
@@ -195,14 +179,6 @@ test(`E(zoe).offer`, async t => {
   t.is(await E(userSeat).getOfferResult(), 'result');
 });
 
-test(`E(zoe).offer - no invitation`, async t => {
-  const { zoe } = await setupZCFTest();
-  // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).offer(), {
-    message: /A Zoe invitation is required, not "\[undefined\]"/,
-  });
-});
-
 test(`E(zoe).offer - payment instead of paymentKeywordRecord`, async t => {
   const { zoe, zcf } = await setupZCFTest();
   const { mint, brand, issuer } = makeIssuerKit('Token');
@@ -214,7 +190,7 @@ test(`E(zoe).offer - payment instead of paymentKeywordRecord`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).offer(invitation, proposal, payment), {
     message:
-      '"keywordRecord" "[Alleged: Token payment]" must be a pass-by-copy record, not "remotable"',
+      'In "offer" method of (ZoeService zoeService): arg 2?: remotable "[Alleged: Token payment]" - Must be a copyRecord',
   });
 });
 
@@ -256,12 +232,7 @@ test(`E(zoe).getPublicFacet - no instance`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getPublicFacet(), {
     message:
-      // Should be able to use more informative error once SES double
-      // disclosure bug is fixed. See
-      // https://github.com/endojs/endo/pull/640
-      //
-      // /"instance" not found: "\[undefined\]"/,
-      /.* not found: "\[undefined\]"/,
+      'In "getPublicFacet" method of (ZoeService zoeService): arg 0: undefined "[undefined]" - Must be a remotable (InstanceHandle)',
   });
 });
 
@@ -292,12 +263,7 @@ test(`zoe.getIssuers - no instance`, async t => {
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getIssuers(), {
     message:
-      // Should be able to use more informative error once SES double
-      // disclosure bug is fixed. See
-      // https://github.com/endojs/endo/pull/640
-      //
-      // /"instance" not found: "\[undefined\]"/,
-      /.* not found: "\[undefined\]"/,
+      'In "getIssuers" method of (ZoeService zoeService): arg 0: undefined "[undefined]" - Must be a remotable (InstanceHandle)',
   });
 });
 
@@ -328,12 +294,7 @@ test(`zoe.getBrands - no instance`, async t => {
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getBrands(), {
     message:
-      // Should be able to use more informative error once SES double
-      // disclosure bug is fixed. See
-      // https://github.com/endojs/endo/pull/640
-      //
-      // /"instance" not found: "\[undefined\]"/,
-      /.* not found: "\[undefined\]"/,
+      'In "getBrands" method of (ZoeService zoeService): arg 0: undefined "[undefined]" - Must be a remotable (InstanceHandle)',
   });
 });
 
@@ -386,12 +347,7 @@ test(`zoe.getTerms - no instance`, async t => {
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getTerms(), {
     message:
-      // Should be able to use more informative error once SES double
-      // disclosure bug is fixed. See
-      // https://github.com/endojs/endo/pull/640
-      //
-      // /"instance" not found: "\[undefined\]"/,
-      /.* not found: "\[undefined\]"/,
+      'In "getTerms" method of (ZoeService zoeService): arg 0: undefined "[undefined]" - Must be a remotable (InstanceHandle)',
   });
 });
 
@@ -419,24 +375,22 @@ test(`zoe.getInstallationForInstance`, async t => {
 
 test(`zoe.getInstance`, async t => {
   const { zoe, zcf, instance } = await setupZCFTest();
-  // @ts-expect-error
-  const invitation = await E(zcf).makeInvitation(undefined, 'invitation');
+  const invitation = await E(zcf).makeInvitation(() => {}, 'invitation');
   const actualInstance = await E(zoe).getInstance(invitation);
   t.is(actualInstance, instance);
 });
 
 test(`zoe.getInstance - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
-  // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInstance(), {
-    message: 'A Zoe invitation is required, not "[undefined]"',
+    message:
+      'In "getInstance" method of (ZoeService zoeService): Expected at least 1 arguments: []',
   });
 });
 
 test(`zoe.getInstallation`, async t => {
   const { zoe, zcf, installation } = await setupZCFTest();
-  // @ts-expect-error
-  const invitation = await E(zcf).makeInvitation(undefined, 'invitation');
+  const invitation = await E(zcf).makeInvitation(() => {}, 'invitation');
   const actualInstallation = await E(zoe).getInstallation(invitation);
   t.is(actualInstallation, installation);
 });
@@ -445,20 +399,16 @@ test(`zoe.getInstallation - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInstallation(), {
-    message: 'A Zoe invitation is required, not "[undefined]"',
+    message:
+      'In "getInstallation" method of (ZoeService zoeService): Expected at least 1 arguments: []',
   });
 });
 
 test(`zoe.getInvitationDetails`, async t => {
-  const { zoe, zcf, installation, instance } = await setupZCFTest();
+  const { zcf } = await setupZCFTest();
   // @ts-expect-error
-  const invitation = await E(zcf).makeInvitation(undefined, 'invitation');
-  const details = await E(zoe).getInvitationDetails(invitation);
-  t.deepEqual(details, {
-    description: 'invitation',
-    handle: details.handle,
-    installation,
-    instance,
+  await t.throwsAsync(() => E(zcf).makeInvitation(undefined, 'invitation'), {
+    message: 'offerHandler must be provided',
   });
 });
 
@@ -466,30 +416,12 @@ test(`zoe.getInvitationDetails - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInvitationDetails(), {
-    message: 'A Zoe invitation is required, not "[undefined]"',
+    message:
+      'In "getInvitationDetails" method of (ZoeService zoeService): Expected at least 1 arguments: []',
   });
 });
 
-test(`zcf.registerFeeMint twice`, async t => {
-  const { zoe, zcf: zcf1, zcf2, feeMintAccess } = await setupZCFTest();
-  const feeIssuer = E(zoe).getFeeIssuer();
-  const feeBrand = await E(feeIssuer).getBrand();
-
-  const fee1000 = AmountMath.make(feeBrand, 1000n);
-
-  const zcfMint1 = await zcf1.registerFeeMint('RUN', feeMintAccess);
-  const zcfMint2 = await zcf2.registerFeeMint('RUN', feeMintAccess);
-
-  const zcfSeat1 = zcfMint1.mintGains(harden({ Fee: fee1000 }));
-  const zcfSeat2 = zcfMint2.mintGains(harden({ Fee: fee1000 }));
-
-  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    Fee: fee1000,
-  });
-  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    Fee: fee1000,
-  });
-});
+test.todo(`zcf.registerFeeMint twice in different contracts`);
 
 test(`zoe.getConfiguration`, async t => {
   const { zoe } = await setupZCFTest();

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -22,36 +22,17 @@ const contractRoot = `${dirname}/zcfTesterContract.js`;
 export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   /** @type {ZCF<T>} */
   let zcf;
-  /** @type {ZCF<T>} */
-  let zcf2;
 
-  // We would like to start two contract instances in order to get two
-  // different `zcfs`. However, we only pass in one `setTestJig`, so
-  // here, we set the first `zcf` if it has not been set before, and
-  // if it has, we set the second `zcf`.
-  const setZCF = jig => {
-    if (zcf === undefined) {
-      zcf = jig.zcf;
-    } else {
-      zcf2 = jig.zcf;
-    }
-  };
+  const setZCF = jig => (zcf = jig.zcf);
   // The contract provides the `zcf` via `setTestJig` upon `start`.
   const fakeVatAdmin = makeFakeVatAdmin(setZCF);
-  const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin.admin);
+  const { zoeService: zoe, feeMintAccessRetriever } = makeZoeKit(
+    fakeVatAdmin.admin,
+  );
   const bundle = await bundleSource(contractRoot);
   fakeVatAdmin.vatAdminState.installBundle('b1-contract', bundle);
   const installation = await E(zoe).installBundleID('b1-contract');
-  const { creatorFacet, instance } = await E(zoe).startInstance(
-    installation,
-    issuerKeywordRecord,
-    // @ts-expect-error generics mismatch
-    terms,
-  );
-  // In case a second zcf is needed
-  const { creatorFacet: creatorFacet2, instance: instance2 } = await E(
-    zoe,
-  ).startInstance(
+  const startInstanceResult = await E(zoe).startInstance(
     installation,
     issuerKeywordRecord,
     // @ts-expect-error generics mismatch
@@ -63,16 +44,11 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   return {
     zoe,
     zcf,
-    instance,
+    instance: startInstanceResult.instance,
     installation,
-    creatorFacet,
+    creatorFacet: startInstanceResult.creatorFacet,
     vatAdminState,
-    feeMintAccess,
-
-    // Additional ZCF
-    // @ts-expect-error zcf2 is accessible before it is set
-    zcf2,
-    creatorFacet2,
-    instance2,
+    feeMintAccessRetriever,
+    startInstanceResult,
   };
 };

--- a/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
+++ b/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
@@ -19,10 +19,11 @@ const contractRoot = `${dirname}/registerFeeMintContract.js`;
 
 test(`feeMintAccess`, async t => {
   const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
-  const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe, feeMintAccessRetriever } = makeZoeKit(fakeVatAdmin);
   const bundle = await bundleSource(contractRoot);
   vatAdminState.installBundle('b1-registerfee', bundle);
   const installation = await E(zoe).installBundleID('b1-registerfee');
+  const feeMintAccess = await E(feeMintAccessRetriever).get();
   const { creatorFacet } = await E(zoe).startInstance(
     installation,
     undefined,

--- a/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
@@ -44,10 +44,7 @@ test(`zcf.reallocate undefined`, async t => {
 
   // @ts-expect-error Deliberate wrong type for testing
   t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2, undefined), {
-    message:
-      // TODO: Improve error message if something other than a seat is
-      // passed.
-      'seat has been exited',
+    message: / - Must be a remotable/,
   });
 });
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -76,7 +76,7 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
     message: 'second seat failed',
   });
   await t.throwsAsync(() => E(userSeat1).tryExit(), {
-    message: 'seat has been exited',
+    message: 'Cannot exit; seat has already exited',
   });
   t.falsy(vatAdminState.getHasExited());
 });

--- a/packages/zoe/test/unitTests/zoe/test-escrowStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-escrowStorage.js
@@ -4,15 +4,17 @@ import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 
 import { E } from '@endo/eventual-send';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
-import { makeEscrowStorage } from '../../../src/zoeService/escrowStorage.js';
+import { provideEscrowStorage } from '../../../src/zoeService/escrowStorage.js';
 import {
   assertAmountsEqual,
   assertPayoutAmount,
 } from '../../zoeTestHelpers.js';
 
-test('makeEscrowStorage', async t => {
-  const { createPurse, makeLocalPurse, withdrawPayments, depositPayments } =
-    makeEscrowStorage(makeScalarBigMapStore('zoe baggage', { durable: true }));
+test('provideEscrowStorage', async t => {
+  const { createPurse, provideLocalPurse, withdrawPayments, depositPayments } =
+    provideEscrowStorage(
+      makeScalarBigMapStore('zoe baggage', { durable: true }),
+    );
 
   const currencyKit = makeIssuerKit(
     'currency',
@@ -25,7 +27,7 @@ test('makeEscrowStorage', async t => {
   await createPurse(currencyKit.issuer, currencyKit.brand);
 
   // Normally only used for ZCFMint issuers
-  makeLocalPurse(ticketKit.issuer, ticketKit.brand);
+  provideLocalPurse(ticketKit.issuer, ticketKit.brand);
 
   const gameTicketAmount = AmountMath.make(
     ticketKit.brand,
@@ -131,7 +133,7 @@ const setupPurses = async createPurse => {
 };
 
 test('payments without matching give keywords', async t => {
-  const { createPurse, depositPayments } = makeEscrowStorage(
+  const { createPurse, depositPayments } = provideEscrowStorage(
     makeScalarBigMapStore('zoe baggage', { durable: true }),
   );
 
@@ -168,7 +170,7 @@ test('payments without matching give keywords', async t => {
 });
 
 test(`give keywords without matching payments`, async t => {
-  const { createPurse, depositPayments } = makeEscrowStorage(
+  const { createPurse, depositPayments } = provideEscrowStorage(
     makeScalarBigMapStore('zoe baggage', { durable: true }),
   );
 

--- a/packages/zoe/test/unitTests/zoe/test-installationStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-installationStorage.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
@@ -7,11 +5,12 @@ import { makeHandle } from '../../../src/makeHandle.js';
 import { makeInstallationStorage } from '../../../src/zoeService/installationStorage.js';
 
 test('install, unwrap installations', async t => {
-  const { installBundle, unwrapInstallation } = makeInstallationStorage();
+  // @ts-expect-error omitting required param during tests
+  const installationStorage = makeInstallationStorage();
   const fakeBundle = {};
 
-  const installation = await installBundle(fakeBundle);
-  const unwrapped = await unwrapInstallation(installation);
+  const installation = await installationStorage.installBundle(fakeBundle);
+  const unwrapped = await installationStorage.unwrapInstallation(installation);
   t.is(unwrapped.installation, installation);
   t.deepEqual(unwrapped.bundle, fakeBundle);
 });
@@ -20,38 +19,45 @@ test('install, unwrap installation of bundlecap', async t => {
   const bundleCaps = { id: makeHandle('BundleCap') };
   const getBundleCapFromID = id => bundleCaps[id];
 
-  const { installBundleID, unwrapInstallation } =
-    makeInstallationStorage(getBundleCapFromID);
+  const installationStorage = makeInstallationStorage(getBundleCapFromID);
 
-  const installation = await installBundleID('id');
-  const unwrapped = await unwrapInstallation(installation);
+  const installation = await installationStorage.installBundleID('id');
+  const unwrapped = await installationStorage.unwrapInstallation(installation);
   t.is(unwrapped.installation, installation);
   t.is(unwrapped.bundleID, 'id');
   t.is(unwrapped.bundleCap, bundleCaps.id);
 });
 
 test('unwrap promise for installation', async t => {
-  const { installBundle, unwrapInstallation } = makeInstallationStorage();
+  // @ts-expect-error omitting required param during tests
+  const installationStorage = makeInstallationStorage();
   const fakeBundle = {};
 
-  const installation = await installBundle(fakeBundle);
-  const unwrapped = await unwrapInstallation(Promise.resolve(installation));
+  const installation = await installationStorage.installBundle(fakeBundle);
+  const unwrapped = await installationStorage.unwrapInstallation(
+    harden(Promise.resolve(installation)),
+  );
   t.is(unwrapped.installation, installation);
   t.deepEqual(unwrapped.bundle, fakeBundle);
 });
 
 test('install several', async t => {
-  const { installBundle, unwrapInstallation } = makeInstallationStorage();
+  // @ts-expect-error omitting required param during tests
+  const installationStorage = makeInstallationStorage();
   const fakeBundle1 = {};
   const fakeBundle2 = {};
 
-  const installation1 = await installBundle(fakeBundle1);
-  const unwrapped1 = await unwrapInstallation(installation1);
+  const installation1 = await installationStorage.installBundle(fakeBundle1);
+  const unwrapped1 = await installationStorage.unwrapInstallation(
+    installation1,
+  );
   t.is(unwrapped1.installation, installation1);
   t.deepEqual(unwrapped1.bundle, fakeBundle1);
 
-  const installation2 = await installBundle(fakeBundle2);
-  const unwrapped2 = await unwrapInstallation(installation2);
+  const installation2 = await installationStorage.installBundle(fakeBundle2);
+  const unwrapped2 = await installationStorage.unwrapInstallation(
+    installation2,
+  );
   t.is(unwrapped2.installation, installation2);
   t.deepEqual(unwrapped2.bundle, fakeBundle2);
 });
@@ -59,33 +65,40 @@ test('install several', async t => {
 test('install same twice', async t => {
   const bundleCaps = { id: makeHandle('BundleCap') };
   const getBundleCapFromID = id => bundleCaps[id];
-  const { installBundle, installBundleID, unwrapInstallation } =
-    makeInstallationStorage(getBundleCapFromID);
+  const installationStorage = makeInstallationStorage(getBundleCapFromID);
   const fakeBundle1 = {};
 
-  const installation1 = await installBundle(fakeBundle1);
-  const unwrapped1 = await unwrapInstallation(installation1);
+  const installation1 = await installationStorage.installBundle(fakeBundle1);
+  const unwrapped1 = await installationStorage.unwrapInstallation(
+    installation1,
+  );
   t.is(unwrapped1.installation, installation1);
   t.deepEqual(unwrapped1.bundle, fakeBundle1);
 
   // If the same bundle is installed twice, the bundle is the same,
   // but the installation is different. Zoe does not currently care about
   // duplicate bundles.
-  const installation2 = await installBundle(fakeBundle1);
-  const unwrapped2 = await unwrapInstallation(installation2);
+  const installation2 = await installationStorage.installBundle(fakeBundle1);
+  const unwrapped2 = await installationStorage.unwrapInstallation(
+    installation2,
+  );
   t.is(unwrapped2.installation, installation2);
   t.not(installation2, installation1);
   t.deepEqual(unwrapped2.bundle, fakeBundle1);
 
   // same for bundleIDs
-  const installation3 = await installBundleID('id');
-  const installation4 = await installBundleID('id');
+  const installation3 = await installationStorage.installBundleID('id');
+  const installation4 = await installationStorage.installBundleID('id');
   t.not(installation3, installation4);
-  const unwrapped3 = await unwrapInstallation(installation3);
+  const unwrapped3 = await installationStorage.unwrapInstallation(
+    installation3,
+  );
   t.is(unwrapped3.installation, installation3);
   t.is(unwrapped3.bundleID, 'id');
   t.is(unwrapped3.bundleCap, bundleCaps.id);
-  const unwrapped4 = await unwrapInstallation(installation4);
+  const unwrapped4 = await installationStorage.unwrapInstallation(
+    installation4,
+  );
   t.is(unwrapped4.installation, installation4);
   t.is(unwrapped4.bundleID, 'id');
   t.is(unwrapped4.bundleCap, bundleCaps.id);

--- a/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
@@ -2,88 +2,72 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { Far } from '@endo/marshal';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 import { makeInstanceAdminStorage } from '../../../src/zoeService/instanceAdminStorage.js';
+import { setup } from '../setupBasicMints.js';
 
 test('makeInstanceAdminStorage', async t => {
-  const {
-    getPublicFacet,
-    getBrands,
-    getIssuers,
-    getTerms,
-    getInstallationForInstance,
-    getInstanceAdmin,
-    initInstanceAdmin,
-    deleteInstanceAdmin,
-  } = makeInstanceAdminStorage();
+  const ias = makeInstanceAdminStorage(
+    makeScalarBigMapStore('zoe baggage', { durable: true }),
+  );
 
-  const mockInstance1 = Far('mockInstance1', {});
-  const mockInstance2 = Far('mockInstance2', {});
-  const mockInstanceAdmin1 = Far('mockInstanceAdmin1', {
-    getPublicFacet: () => 'publicFacet1',
-    getBrands: () => 'brands1',
-    getIssuers: () => 'issuers1',
-    getTerms: () => 'terms1',
-    getInstallationForInstance: () => 'installation1',
-  });
-  const mockInstanceAdmin2 = Far('mockInstanceAdmin2', {
-    getPublicFacet: () => 'publicFacet2',
-    getBrands: () => 'brands2',
-    getIssuers: () => 'issuers2',
-    getTerms: () => 'terms2',
-    getInstallationForInstance: () => 'installation2',
+  const { moolaKit } = setup();
+  const mockInstallation1 = Far('mockInstallation', {});
+  const mockInstance1 = Far('mockInstance', {});
+  const mockBrandRecord = harden({ M: moolaKit.brand });
+  const mockIssuerRecord = harden({ M: moolaKit.issuer });
+  const mockTerms = harden({ something: 'anything' });
+  const mockFacet = harden(
+    Far('mock', {
+      identity: a => a,
+    }),
+  );
+  const mockInstanceAdmin = Far('mockInstanceAdmin', {
+    getInstallationForInstance: () => mockInstallation1,
+    getBrands: () => mockBrandRecord,
+    getPublicFacet: () => mockFacet,
+    getIssuers: () => mockIssuerRecord,
+    getTerms: () => mockTerms,
+    getOfferFilter: () => ['filter'],
   });
 
-  // @ts-expect-error instance is mocked
-  initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
-
-  // @ts-expect-error instance is mocked
-  initInstanceAdmin(mockInstance2, mockInstanceAdmin2);
-
-  // @ts-expect-error instance is mocked
-  t.is(getInstanceAdmin(mockInstance1), mockInstanceAdmin1);
-
-  // @ts-expect-error instance is mocked
-  t.is(await getPublicFacet(mockInstance1), 'publicFacet1');
-
-  // @ts-expect-error instance is mocked
-  t.is(await getBrands(mockInstance2), 'brands2');
-
-  // @ts-expect-error instance is mocked
-  t.is(await getIssuers(mockInstance1), 'issuers1');
-
-  // @ts-expect-error instance is mocked
-  t.is(await getTerms(mockInstance1), 'terms1');
-
-  // @ts-expect-error instance is mocked
-  t.is(await getInstallationForInstance(mockInstance1), 'installation1');
-
-  // @ts-expect-error instance is mocked
-  deleteInstanceAdmin(mockInstance2);
-
-  // @ts-expect-error instance is mocked
-  t.throws(() => getInstanceAdmin(mockInstance2), {
-    message: '"instance" not found: "[Alleged: mockInstance2]"',
-  });
-
-  // @ts-expect-error instance is mocked
-  await t.throwsAsync(() => getPublicFacet(mockInstance2), {
-    message: '"instance" not found: "[Alleged: mockInstance2]"',
-  });
+  ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin);
+  t.is(
+    await ias.accessor.getInstallationForInstance(mockInstance1),
+    mockInstallation1,
+  );
+  t.is(await ias.accessor.getBrands(mockInstance1), mockBrandRecord);
+  t.is(await ias.accessor.getPublicFacet(mockInstance1), mockFacet);
+  t.is(await ias.accessor.getIssuers(mockInstance1), mockIssuerRecord);
+  t.is(await ias.accessor.getTerms(mockInstance1), mockTerms);
 });
 
 test('add another instance admin for same instance', async t => {
-  const { initInstanceAdmin } = makeInstanceAdminStorage();
+  const ias = makeInstanceAdminStorage(
+    makeScalarBigMapStore('zoe baggage', { durable: true }),
+  );
 
-  const mockInstance1 = Far('mockInstance1', {});
-  const mockInstanceAdmin1 = Far('mockInstanceAdmin1', {});
-  const mockInstanceAdmin2 = Far('mockInstanceAdmin2', {});
-
-  // @ts-expect-error instance is mocked
-  initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
-
-  // @ts-expect-error instance is mocked
-  t.throws(() => initInstanceAdmin(mockInstance1, mockInstanceAdmin2), {
-    message: '"instance" already registered: "[Alleged: mockInstance1]"',
+  const mockInstallation1 = Far('mockInstallation', {});
+  const mockInstance1 = Far('mockInstance', {});
+  const mockInstanceAdmin1 = Far('mockInstanceAdmin', {
+    getInstallationForInstance: () => mockInstallation1,
+    getBrands: () => 'brands',
+    getPublicFacet: () => 'publicFacet',
+    getIssuers: () => 'issuers',
+    getTerms: () => 'terms',
+    getOfferFilter: () => 'filter',
   });
+
+  ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
+  t.is(
+    await ias.accessor.getInstallationForInstance(mockInstance1),
+    mockInstallation1,
+  );
+
+  const mockInstanceAdmin2 = Far('mockInstanceAdmin', {});
+  await t.throwsAsync(
+    () => ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin2),
+    { message: /"\[Alleged: mockInstance\]" already registered/ },
+  );
 });

--- a/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
+++ b/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
@@ -21,7 +21,7 @@ test('vivifyInvitationKit', async t => {
   const mockInstallation = Far('mockInstallation', {});
 
   const makeInvitation = setupMakeInvitation(
-    // @ts-expect-error mockInstance is mocked
+    // @ts-expect-error mockInstallation is mocked
     mockInstance,
     mockInstallation,
     proposalShapes,
@@ -69,7 +69,7 @@ test('description is omitted, wrongly', async t => {
   const mockInstallation = Far('mockInstallation', {});
 
   const makeInvitation = setupMakeInvitation(
-    // @ts-expect-error mockInstance is mocked
+    // @ts-expect-error mockInstallation is mocked
     mockInstance,
     mockInstallation,
     proposalShapes,
@@ -84,7 +84,7 @@ test('description is omitted, wrongly', async t => {
   await t.throwsAsync(
     async () =>
       makeInvitation(
-        // @ts-expect-error mockInvitationHandle is mocked
+        // @ts-expect-error intentional incorrect argument
         mockInvitationHandle,
         description,
         customProperties,
@@ -102,7 +102,7 @@ test('customProperties ok to omit', async t => {
   const mockInstallation = Far('mockInstallation', {});
 
   const makeInvitation = setupMakeInvitation(
-    // @ts-expect-error mockInstance is mocked
+    // @ts-expect-error mockInstallation is mocked
     mockInstance,
     mockInstallation,
     proposalShapes,
@@ -111,11 +111,8 @@ test('customProperties ok to omit', async t => {
   const mockInvitationHandle = Far('mockInvitationHandle', {});
   const description = 'myInvitation';
 
-  const invitation = makeInvitation(
-    // @ts-expect-error mockInvitationHandle is mocked
-    mockInvitationHandle,
-    description,
-  );
+  // @ts-expect-error type exception for testing
+  const invitation = makeInvitation(mockInvitationHandle, description);
 
   const amount = await E(invitationIssuer).getAmountOf(invitation);
   const invitationBrand = await E(invitationIssuer).getBrand();


### PR DESCRIPTION
closes: #4383
refs: #6502

## Description

Make Zoe durable.

The prior version passed around many bundles of functions. Those had to be converted to durable facets to be passable.

### Security Considerations

Pervasive

### Documentation Considerations

seat notifiers (which notified on interim allocations) have been dropped and replaced with a subscriber that only notifies when the seat exits.

The way feeMintAccess is obtained changed.

The methods that allowed requests for internal allocation state (`getCurrentAllocationJig`) has been dropped.  Many of the clients can use `getFinalAllocation()` instead.

`zoe.bindDefaultFeePurse`, `zoe.makeFeePurse`, and `zcf.assert()` were  dropped.

### Testing Considerations

Test timing changed in some cases, since Promises can no longer be used.
