### PR TITLE
chore: Update links

### DIFF
--- a/packages/ERTP/README.md
+++ b/packages/ERTP/README.md
@@ -9,4 +9,4 @@ ways, with exactly the same security properties.
 
 Learn more about [ERTP fundamentals like mints, issuers, purses and payments](https://agoric.com/documentation/ertp/guide/).
 
-Looking for Zoe, our smart contract framework? Zoe has been moved into its own [npm package (`@agoric/zoe`)](https://www.npmjs.com/package/@agoric/zoe) and the code can be found at [`packages/zoe`](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe#zoe).
+Looking for Zoe, our smart contract framework? Zoe has been moved into its own [npm package (`@agoric/zoe`)](https://www.npmjs.com/package/@agoric/zoe) and the code can be found at [`packages/zoe`](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe#zoe).

--- a/packages/SwingSet/docs/delivery.md
+++ b/packages/SwingSet/docs/delivery.md
@@ -282,7 +282,7 @@ be recycled, but it seems less confusing to simply retire the number.
 We use the term `CapData` to describe a piece of data that can include
 capability references. Each reference is known as a `CapSlot`. The data is
 serialized into into our
-[augmented form of JSON](https://github.com/endojs/endo/tree/master/packages/marshal),
+[augmented form of JSON](https://github.com/endojs/endo/tree/HEAD/packages/marshal),
 which uses special `@qclass` keys to represent things not normally expressible
 by JSON (such as `NaN`, `Infinity`, `undefined`, BigInts, and `CapSlot`
 references) or not preserved by normal serialization/deserialization (such as

--- a/packages/SwingSet/docs/garbage-collection.md
+++ b/packages/SwingSet/docs/garbage-collection.md
@@ -507,7 +507,7 @@ Comms vats send three kinds of messages to each other:
 * `remote.retireExport`
 * `remote.retireImport`
 
-The comms protocol is [obsequiously polite](https://github.com/Agoric/agoric-sdk/blob/master/packages/SwingSet/docs/comms.md#over-the-wire-slot-types), and always formats messages for the convenience of the recipient. The comms GC protocol is the same. When a `dropExport` message arrives, it means the recipient of the message was exporting something to the sender, and now the sending side no longer needs it. When kernel A tells comms A to `dispatch.dropExport`, comms A will tell comms B to `remote.dropExport`.
+The comms protocol is [obsequiously polite](https://github.com/Agoric/agoric-sdk/blob/HEAD/packages/SwingSet/docs/comms.md#over-the-wire-slot-types), and always formats messages for the convenience of the recipient. The comms GC protocol is the same. When a `dropExport` message arrives, it means the recipient of the message was exporting something to the sender, and now the sending side no longer needs it. When kernel A tells comms A to `dispatch.dropExport`, comms A will tell comms B to `remote.dropExport`.
 
 For reference, the following diagram shows the set of object references involved in a downstream vat-3 (inside "machine 3") holding a Presence, which represents the import an object which is ultimately provided by a Remotable exported by vat-1 inside "machine 1".
 

--- a/packages/SwingSet/misc-tools/monitor-slog-block-time.py
+++ b/packages/SwingSet/misc-tools/monitor-slog-block-time.py
@@ -47,7 +47,7 @@ import subprocess
 #
 # [sigs2/3/tot]: The number of signatures on the block, of type 2 ("COMMIT")
 #                or type 3 ("NIL"), and the total of both. Tendermint docs at
-#                https://docs.tendermint.com/master/spec/core/data_structures.html#blockidflag
+#                https://github.com/tendermint/tendermint/blob/HEAD/spec/core/data_structures.md#blockidflag
 #                might provide an interpretation of these flags. If the
 #                number of signatures drops, it might indicate that
 #                validators are falling behind and were unable to deliver

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -12,7 +12,7 @@
 // this module must be considered a resource module.
 
 // The assertions re-exported here are defined in
-// https://github.com/endojs/endo/blob/master/packages/ses/src/error/assert.js
+// https://github.com/endojs/endo/blob/HEAD/packages/ses/src/error/assert.js
 
 // At https://github.com/Agoric/agoric-sdk/issues/2774
 // is a record of a failed attempt to remove '.types'.

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -2,7 +2,7 @@
 /// <reference types="ses"/>
 
 // Based on
-// https://github.com/Agoric/SES-shim/blob/master/packages/ses/src/error/types.js
+// https://github.com/Agoric/SES-shim/blob/HEAD/packages/ses/src/error/types.js
 // Coordinate edits until we refactor to avoid this duplication
 // At https://github.com/Agoric/agoric-sdk/issues/2774
 // is a record of a failed attempt to remove this duplication.

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -5,7 +5,7 @@
   "keywords": [],
   "author": "Agoric",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/Agoric/agoric-sdk/tree/master/packages/cosmic-proto#readme",
+  "homepage": "https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/cosmic-proto#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Agoric/agoric-sdk.git"

--- a/packages/cosmic-swingset/README-bridge.md
+++ b/packages/cosmic-swingset/README-bridge.md
@@ -1,4 +1,4 @@
-https://github.com/Agoric/agoric-sdk/tree/master/packages/cosmic-swingset
+https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/cosmic-swingset
 README-bridge.md
 
 ## ERTP Transfer between two virtual purses

--- a/packages/cosmic-swingset/README-bridge.md
+++ b/packages/cosmic-swingset/README-bridge.md
@@ -1,6 +1,3 @@
-https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/cosmic-swingset
-README-bridge.md
-
 ## ERTP Transfer between two virtual purses
 
 ```mermaid

--- a/packages/cosmic-swingset/README.md
+++ b/packages/cosmic-swingset/README.md
@@ -23,8 +23,6 @@ In any case, for now, you will be needing to build the solo node from the source
 
 To build and install from sources, first follow the instructions at [Before Using Agoric Software](https://agoric.com/documentation/getting-started/before-using-agoric.html) to install the Agoric SDK and its prerequisites.
 
-- **Warning:** There are some [known issues](https://github.com/Agoric/cosmic-swingset/issues/71) installing cosmic-swingset with [snap-based version of node.js on Ubuntu](https://github.com/nodesource/distributions/blob/master/README.md#snap). **We recommend** using a non-snap version
-
 You'll then need to install the following additional software:
 - [Golang](https://golang.org/doc/install) (you need at least version 1.17)
 - (scenarios 1 and 0) [Python3](https://www.python.org/downloads/)

--- a/packages/cosmic-swingset/bin/ag-nchainz
+++ b/packages/cosmic-swingset/bin/ag-nchainz
@@ -2,7 +2,7 @@
 # ag-nchainz - Agoric-specific nchainz scripts
 #
 # First run at least two Agoric chains:
-# (https://github.com/iqlusioninc/relayer/tree/master/scripts/nchainz)
+# (https://github.com/cosmos/relayer/blob/d59c98adb368822a25328fe74db433f8aae78a1d/scripts/nchainz)
 #
 #   nchainz init agoric agoric
 #   ag-nchainz start-solos

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -28,7 +28,7 @@ import './types-ambient.js';
  * The purpose of building on the notifier protocol is to have a lossy
  * adaptor, where intermediate results can be missed in favor of more recent
  * results which are therefore less stale. See
- * https://github.com/Agoric/documentation/blob/master/main/distributed-programming.md#notifiers
+ * https://github.com/Agoric/documentation/blob/HEAD/main/guides/js-programming/notifiers.md
  *
  * @template T
  * @param {ERef<BaseNotifier<T>>} notifierP

--- a/packages/pegasus/src/ics20.js
+++ b/packages/pegasus/src/ics20.js
@@ -5,7 +5,7 @@ import { assert, details as X, Fail } from '@agoric/assert';
 
 /**
  * @typedef {object} ICS20TransferPacket Packet shape defined at:
- * https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer#data-structures
+ * https://github.com/cosmos/ibc/tree/HEAD/spec/app/ics-020-fungible-token-transfer#data-structures
  * @property {string} amount The extent of the amount
  * @property {Denom} denom The denomination of the amount
  * @property {string} sender The sender address
@@ -116,7 +116,7 @@ export const assertICS20TransferPacketAck = async ack => {
 
 /**
  * Create results of the transfer.  Acknowledgement shape defined at:
- * https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer#data-structures
+ * https://github.com/cosmos/ibc/tree/HEAD/spec/app/ics-020-fungible-token-transfer#data-structures
  *
  * @param {boolean} success
  * @param {any} error

--- a/packages/vats/test/test-dump.js
+++ b/packages/vats/test/test-dump.js
@@ -4,7 +4,7 @@ import test from 'ava';
 
 import { dump } from '../src/repl.js';
 
-// Taken from https://github.com/endojs/endo/blob/HEAD/packages/ses/test/error/test-assert-log.js#L414
+// Taken from https://github.com/endojs/endo/blob/43b796232634b54c9e7de1c0a2349d22c29fc384/packages/ses/test/error/test-assert-log.js#L414
 test('dump: the @erights challenge', async t => {
   const superTagged = { [Symbol.toStringTag]: 'Tagged' };
   const subTagged = { __proto__: superTagged };
@@ -25,10 +25,11 @@ test('dump: the @erights challenge', async t => {
     },
     2 ** 54,
     { superTagged, subTagged, subTaggedNonEmpty },
+    { __proto__: null },
   ];
   t.is(
     dump(challenges),
-    '[[Promise],[Function foo],"[hilbert]",undefined,"undefined",[URIError: wut?],[33n,Symbol(foo),Symbol(bar),Symbol(Symbol.asyncIterator)],{"NaN":NaN,"Infinity":Infinity,"neg":-Infinity},18014398509481984,{"superTagged":{[Symbol(Symbol.toStringTag)]:"Tagged"},"subTagged":[Object Tagged]{},"subTaggedNonEmpty":[Object Tagged]{"foo":"x"}}]',
+    '[[Promise],[Function foo],"[hilbert]",undefined,"undefined",[URIError: wut?],[33n,Symbol(foo),Symbol(bar),Symbol(Symbol.asyncIterator)],{"NaN":NaN,"Infinity":Infinity,"neg":-Infinity},18014398509481984,{"superTagged":{[Symbol(Symbol.toStringTag)]:"Tagged"},"subTagged":[Object Tagged]{},"subTaggedNonEmpty":[Object Tagged]{"foo":"x"}},{}]',
   );
   t.is(
     dump(challenges, 2),
@@ -60,7 +61,8 @@ test('dump: the @erights challenge', async t => {
     "subTaggedNonEmpty": [Object Tagged] {
       "foo": "x"
     }
-  }
+  },
+  {}
 ]`,
   );
 });

--- a/packages/vats/test/test-dump.js
+++ b/packages/vats/test/test-dump.js
@@ -4,7 +4,7 @@ import test from 'ava';
 
 import { dump } from '../src/repl.js';
 
-// Taken from https://github.com/endojs/endo/tree/main/packages/ses/test/error/test-assert-log.js#L414
+// Taken from https://github.com/endojs/endo/blob/HEAD/packages/ses/test/error/test-assert-log.js#L414
 test('dump: the @erights challenge', async t => {
   const superTagged = { [Symbol.toStringTag]: 'Tagged' };
   const subTagged = { __proto__: superTagged };

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -19,7 +19,7 @@ to use Web Components is ReactJS, for which we provide a [React-specific wrapper
 
 You will need to ensure your app first installs and locks down the JS
 environment using
-[SES](https://github.com/endojs/endo/tree/master/packages/ses#readme).
+[SES](https://github.com/endojs/endo/tree/HEAD/packages/ses#readme).
 
 You can create an `install-ses-lockdown.js` module that does all the setup
 needed by your app:

--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -187,7 +187,7 @@ function checkExpectation(exc, expectation) {
 /**
  * Emulate ava assertion API
  *
- * ref https://github.com/avajs/ava/blob/main/docs/03-assertions.md
+ * ref https://github.com/avajs/ava/blob/HEAD/docs/03-assertions.md
  *
  * @param {Harness} htest
  * @param {TapFormat} out

--- a/packages/zoe/CONTRIBUTING.md
+++ b/packages/zoe/CONTRIBUTING.md
@@ -62,4 +62,4 @@ To test that that the Zoe update works (in the most basic sense) with cosmic-swi
 
 
 To test that the update works with agoric-cli, follow the instructions
-for [Developing Agoric CLI](https://github.com/Agoric/agoric-sdk/tree/master/packages/agoric-cli#developing-agoric-cli).
+for [Developing Agoric CLI](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/agoric-cli#developing-agoric-cli).


### PR DESCRIPTION
## Description

* Use "HEAD" rather than "master" for github.com links, to survive renaming of the main branch.
* Address some broken links, particularly relating to docs.tendermint.com churn.

### Security Considerations

n/a

### Documentation Considerations

https://github.com/Agoric/documentation may need similar updates.

### Testing Considerations

n/a