### PR TITLE
fix: align issuer declaration order

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -466,6 +466,12 @@ export const vivifyPaymentLedger = (
   );
 
   const issuer = vivifySingleton(issuerBaggage, `${name} issuer`, {
+    getBrand: () => brand,
+    getAllegedName: () => name,
+    getAssetKind: () => assetKind,
+    getDisplayInfo: () => displayInfo,
+    makeEmptyPurse,
+
     isLive,
     getAmountOf,
     burn,
@@ -473,11 +479,6 @@ export const vivifyPaymentLedger = (
     combine,
     split,
     splitMany,
-    getBrand: () => brand,
-    getAllegedName: () => name,
-    getAssetKind: () => assetKind,
-    getDisplayInfo: () => displayInfo,
-    makeEmptyPurse,
   });
 
   const mint = vivifySingleton(issuerBaggage, `${name} mint`, {

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -115,6 +115,34 @@
  * @property {() => Pattern} getAmountSchema
  */
 
+// /////////////////////////// Issuer //////////////////////////////////////////
+
+/**
+ * @callback IssuerIsLive
+ *
+ * Return true if the payment continues to exist.
+ *
+ * If the payment is a promise, the operation will proceed upon
+ * resolution.
+ *
+ * @param {ERef<Payment>} payment
+ * @returns {Promise<boolean>}
+ */
+/**
+ * @template {AssetKind} [K=AssetKind]
+ * @callback IssuerGetAmountOf
+ *
+ * Get the amount of digital assets in the payment. Because the
+ * payment is not trusted, we cannot call a method on it directly, and
+ * must use the issuer instead.
+ *
+ * If the payment is a promise, the operation will proceed upon
+ * resolution.
+ *
+ * @param {ERef<Payment>} payment
+ * @returns {Promise<Amount<K>>}
+ */
+
 /**
  * @callback IssuerBurn
  *
@@ -147,33 +175,6 @@
  * @param {ERef<Payment>} payment
  * @param {Pattern=} optAmountShape
  * @returns {Promise<Payment>}
- */
-
-/**
- * @callback IssuerIsLive
- *
- * Return true if the payment continues to exist.
- *
- * If the payment is a promise, the operation will proceed upon
- * resolution.
- *
- * @param {ERef<Payment>} payment
- * @returns {Promise<boolean>}
- */
-
-/**
- * @template {AssetKind} [K=AssetKind]
- * @callback IssuerGetAmountOf
- *
- * Get the amount of digital assets in the payment. Because the
- * payment is not trusted, we cannot call a method on it directly, and
- * must use the issuer instead.
- *
- * If the payment is a promise, the operation will proceed upon
- * resolution.
- *
- * @param {ERef<Payment>} payment
- * @returns {Promise<Amount<K>>}
  */
 
 /**


### PR DESCRIPTION
Purely a semantics-free declaration reordering. No text was changed within the reordered pieces.

There are three places where we encounter a sequence that is per issuer methods.
   * The property declarations in the `Issuer` type
   * The preceding declarations of the method types
   * The implementation

https://github.com/Agoric/agoric-sdk/pull/5960 adds a fourth one. To do this, I had to repeatedly look at all three representations method by method. For my sanity I arranged them all to follow the `Issuer` type's order of property declarations. But this creates diff noise in an already busy PR. Hence I'm pulling out the semantics-free reordering by itself, so that once #5960 is rebased on this one, the diff noise will go await as well.