### PR TITLE
4968 psm econ data

### DIFF
--- a/packages/inter-protocol/README.md
+++ b/packages/inter-protocol/README.md
@@ -56,7 +56,7 @@ The canonical keys (under `published`) are as follows. Non-terminal nodes could 
             - `metrics`
     - `psm`
         - `governance`
-        - ~~`metrics`~~ TODO
+        - `metrics`
     - `stakeFactory`
         - `governance`
 

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -1,7 +1,8 @@
 // @ts-check
 import { AmountMath } from '@agoric/ertp';
-import { makeStoredPublisherKit } from '@agoric/notifier';
+import { makeStoredPublisherKit, makeStoredPublishKit } from '@agoric/notifier';
 import { M } from '@agoric/store';
+import { E } from '@endo/eventual-send';
 
 const { details: X, quote: q } = assert;
 
@@ -84,6 +85,7 @@ export const checkDebtLimit = (debtLimit, totalDebt, toMint) => {
 };
 
 /**
+ * @deprecated use makeMetricsPublishKit
  * @template T
  * @param {ERef<StorageNode>} storageNode
  * @param {ERef<Marshaller>} marshaller
@@ -109,6 +111,34 @@ harden(makeMetricsPublisherKit);
  * @property {IterationObserver<T>} metricsPublication
  * @property {StoredSubscription<T>} metricsSubscription
  */
+
+/**
+ * @template T
+ * @typedef {object} MetricsPublishKit<T>
+ * @property {Publisher<T>} metricsPublisher
+ * @property {StoredSubscriber<T>} metricsSubscriber
+ */
+
+/**
+ * @template T
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
+ * @returns {MetricsPublishKit<T>}
+ */
+export const makeMetricsPublishKit = (storageNode, marshaller) => {
+  assert(
+    storageNode && marshaller,
+    'makeMetricsPublisherKit missing storageNode or marshaller',
+  );
+  const metricsNode = E(storageNode).makeChildNode('metrics');
+  /** @type {StoredPublishKit<T>} */
+  const kit = makeStoredPublishKit(metricsNode, marshaller);
+  return {
+    metricsPublisher: kit.publisher,
+    metricsSubscriber: kit.subscriber,
+  };
+};
+harden(makeMetricsPublishKit);
 
 /**
  * @template K Key

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -105,9 +105,9 @@ export const startPSM = async (
   );
 
   const psmStorageNode = await makeStorageNodeChild(chainStorage, 'psm');
-  const storageNode = psmStorageNode
-    .makeChildNode(Stable.symbol)
-    .makeChildNode(keyword);
+  const storageNode = E(
+    E(psmStorageNode).makeChildNode(Stable.symbol),
+  ).makeChildNode(keyword);
 
   const marshaller = await E(board).getPublishingMarshaller();
 

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -22,10 +22,10 @@ const nonalphanumeric = /[^A-Za-z0-9]/g;
  * @typedef {object} MetricsNotification
  *
  * @property {AmountKeywordRecord} allocations
- * @property {Amount<'nat'>} shortfallBalance shortfall from liquiditation that
+ * @property {Amount<'nat'>} shortfallBalance shortfall from liquidation that
+ *   has not yet been compensated.
  * @property {Amount<'nat'>} totalFeeMinted total Fee tokens minted to date
  * @property {Amount<'nat'>} totalFeeBurned total Fee tokens burned to date
- *   has not yet been compensated.
  */
 
 /**

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -75,15 +75,10 @@ const minusAnchorFee = (anchor, anchorPerStable) => {
   );
 };
 
-// let testJig;
-const setJig = _jig => {
-  // testJig = jig;
-};
-
 const makeTestContext = async () => {
   const bundleCache = await unsafeMakeBundleCache('bundles/');
   const psmBundle = await bundleCache.load(psmRoot, 'psm');
-  const { zoe, feeMintAccess } = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = setUpZoeForTest();
 
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
@@ -147,62 +142,104 @@ test.before(async t => {
   t.context = await makeTestContext();
 });
 
-test('simple trades', async t => {
+async function makePsmDriver(t, customTerms) {
   const {
     zoe,
     privateArgs,
     terms,
     installs: { psmInstall },
-    run,
-    anchorKit: { brand: anchorBrand, issuer: anchorIssuer, mint: anchorMint },
+    anchorKit: { issuer: anchorIssuer, mint: anchorMint },
   } = t.context;
-  const { publicFacet, creatorFacet } = await E(zoe).startInstance(
+  const { creatorFacet, publicFacet } = await E(zoe).startInstance(
     psmInstall,
     harden({ AUSD: anchorIssuer }),
-    terms,
+    { ...terms, ...customTerms },
     privateArgs,
   );
+
+  return {
+    publicFacet,
+
+    /** @param {Amount<'nat'>} expected */
+    async assertPoolBalance(expected) {
+      const balance = await E(publicFacet).getPoolBalance();
+      t.deepEqual(balance, expected);
+    },
+
+    async getFeePayout() {
+      const limitedCreatorFacet = E(creatorFacet).getLimitedCreatorFacet();
+      const collectFeesSeat = await E(zoe).offer(
+        E(limitedCreatorFacet).makeCollectFeesInvitation(),
+      );
+      await E(collectFeesSeat).getOfferResult();
+      const feePayoutAmount = await E.get(
+        E(collectFeesSeat).getCurrentAllocationJig(),
+      ).Fee;
+      return feePayoutAmount;
+    },
+
+    /** @param {Amount<'nat'>} giveAnchor */
+    swapAnchorForRun(giveAnchor) {
+      const seat = E(zoe).offer(
+        E(publicFacet).makeSwapInvitation(),
+        harden({ give: { In: giveAnchor } }),
+        harden({ In: anchorMint.mintPayment(giveAnchor) }),
+      );
+      return E(seat).getPayouts();
+    },
+
+    /**
+     * @param {Amount<'nat'>} giveRun
+     * @param {Payment<'nat'>} runPayment
+     */
+    swapRunForAnchor(giveRun, runPayment) {
+      const seat = E(zoe).offer(
+        E(publicFacet).makeSwapInvitation(),
+        harden({ give: { In: giveRun } }),
+        harden({ In: runPayment }),
+      );
+      return E(seat).getPayouts();
+    },
+  };
+}
+
+test('simple trades', async t => {
+  const {
+    terms,
+    run,
+    anchorKit: { brand: anchorBrand, issuer: anchorIssuer },
+  } = t.context;
+  const driver = await makePsmDriver(t);
+
   const giveAnchor = AmountMath.make(anchorBrand, 200n * 1_000_000n);
-  const seat1 = await E(zoe).offer(
-    E(publicFacet).makeSwapInvitation(),
-    harden({ give: { In: giveAnchor } }),
-    harden({ In: anchorMint.mintPayment(giveAnchor) }),
-  );
-  const runPayout = await E(seat1).getPayout('Out');
+
+  const runPayouts = await driver.swapAnchorForRun(giveAnchor);
   const expectedRun = minusAnchorFee(giveAnchor, terms.anchorPerStable);
-  const actualRun = await E(run.issuer).getAmountOf(runPayout);
+  const actualRun = await E(run.issuer).getAmountOf(runPayouts.Out);
   t.deepEqual(actualRun, expectedRun);
-  const liq = await E(publicFacet).getPoolBalance();
-  t.true(AmountMath.isEqual(liq, giveAnchor));
+  await driver.assertPoolBalance(giveAnchor);
+
   const giveRun = AmountMath.make(run.brand, 100n * 1_000_000n);
-  trace('get stable', { giveRun, expectedRun, actualRun, liq });
-  const [runPayment, _moreRun] = await E(run.issuer).split(runPayout, giveRun);
-  const seat2 = await E(zoe).offer(
-    E(publicFacet).makeSwapInvitation(),
-    harden({ give: { In: giveRun } }),
-    harden({ In: runPayment }),
+  trace('get stable', { giveRun, expectedRun, actualRun });
+  const [runPayment, _moreRun] = await E(run.issuer).split(
+    runPayouts.Out,
+    giveRun,
   );
-  const anchorPayout = await E(seat2).getPayout('Out');
-  const actualAnchor = await E(anchorIssuer).getAmountOf(anchorPayout);
+  const anchorPayouts = await driver.swapRunForAnchor(giveRun, runPayment);
+  const actualAnchor = await E(anchorIssuer).getAmountOf(anchorPayouts.Out);
   const expectedAnchor = AmountMath.make(
     anchorBrand,
     minusStableFee(giveRun).value,
   );
   t.deepEqual(actualAnchor, expectedAnchor);
-  const liq2 = await E(publicFacet).getPoolBalance();
-  t.deepEqual(AmountMath.subtract(giveAnchor, expectedAnchor), liq2);
-  trace('get anchor', { runGive: giveRun, expectedRun, actualAnchor, liq2 });
+  await driver.assertPoolBalance(
+    AmountMath.subtract(giveAnchor, expectedAnchor),
+  );
+  trace('get anchor', { runGive: giveRun, expectedRun, actualAnchor });
 
   // Check the fees
   // 1BP per anchor = 30000n plus 3BP per stable = 20000n
-  const limitedCreatorFacet = E(creatorFacet).getLimitedCreatorFacet();
-  const collectFeesSeat = await E(zoe).offer(
-    E(limitedCreatorFacet).makeCollectFeesInvitation(),
-  );
-  await E(collectFeesSeat).getOfferResult();
-  const feePayoutAmount = await E.get(
-    E(collectFeesSeat).getCurrentAllocationJig(),
-  ).Fee;
+  const feePayoutAmount = await driver.getFeePayout();
   const expectedFee = AmountMath.make(run.brand, 50000n);
   trace('Reward Fee', { feePayoutAmount, expectedFee });
   t.truthy(AmountMath.isEqual(feePayoutAmount, expectedFee));
@@ -210,39 +247,21 @@ test('simple trades', async t => {
 
 test('limit', async t => {
   const {
-    zoe,
-    privateArgs,
-    terms,
     mintLimit,
-    installs: { psmInstall },
-    anchorKit: { brand: anchorBrand, issuer: anchorIssuer, mint: anchorMint },
+    anchorKit: { brand: anchorBrand, issuer: anchorIssuer },
   } = t.context;
 
-  const { publicFacet } = await E(zoe).startInstance(
-    psmInstall,
-    harden({ AUSD: anchorIssuer }),
-    terms,
-    privateArgs,
-  );
+  const driver = await makePsmDriver(t);
+
   const initialPool = AmountMath.make(anchorBrand, 1n);
-  await E(zoe).offer(
-    E(publicFacet).makeSwapInvitation(),
-    harden({ give: { In: initialPool } }),
-    harden({ In: anchorMint.mintPayment(initialPool) }),
-  );
-  t.assert(
-    AmountMath.isEqual(await E(publicFacet).getPoolBalance(), initialPool),
-  );
+  await driver.swapAnchorForRun(initialPool);
+  await driver.assertPoolBalance(initialPool);
+
   trace('test going over limit');
   const give = mintLimit;
-  const seat1 = await E(zoe).offer(
-    E(publicFacet).makeSwapInvitation(),
-    harden({ give: { In: give } }),
-    harden({ In: anchorMint.mintPayment(give) }),
-  );
+  const paymentPs = await driver.swapAnchorForRun(give);
   trace('gone over limit');
 
-  const paymentPs = await E(seat1).getPayouts();
   // We should get 0 Stable  and all our anchor back
   // TODO should this be expecteed to be an empty Out?
   t.falsy(paymentPs.Out);
@@ -252,78 +271,47 @@ test('limit', async t => {
   const actualAnchor = await E(anchorIssuer).getAmountOf(anchorReturn);
   t.deepEqual(actualAnchor, give);
   // The pool should be unchanged
-  t.assert(
-    AmountMath.isEqual(await E(publicFacet).getPoolBalance(), initialPool),
-  );
+  driver.assertPoolBalance(initialPool);
   // TODO Offer result should be an error
   // t.throwsAsync(() => await E(seat1).getOfferResult());
 });
 
 test('anchor is 2x stable', async t => {
   const {
-    zoe,
-    privateArgs,
-    terms,
-    installs: { psmInstall },
     run,
-    anchorKit: { brand: anchorBrand, issuer: anchorIssuer, mint: anchorMint },
+    anchorKit: { brand: anchorBrand, issuer: anchorIssuer },
   } = t.context;
   const anchorPerStable = makeRatio(200n, anchorBrand, 100n, run.brand);
-  const { publicFacet } = await E(zoe).startInstance(
-    psmInstall,
-    harden({ AUSD: anchorIssuer }),
-    { ...terms, anchorPerStable },
-    privateArgs,
-  );
+  const driver = await makePsmDriver(t, { anchorPerStable });
+
   const giveAnchor = AmountMath.make(anchorBrand, 400n * 1_000_000n);
-  const seat1 = await E(zoe).offer(
-    E(publicFacet).makeSwapInvitation(),
-    harden({ give: { In: giveAnchor } }),
-    harden({ In: anchorMint.mintPayment(giveAnchor) }),
-  );
-  const runPayout = await E(seat1).getPayout('Out');
+  const runPayouts = await driver.swapAnchorForRun(giveAnchor);
+
   const expectedRun = minusAnchorFee(giveAnchor, anchorPerStable);
-  const actualRun = await E(run.issuer).getAmountOf(runPayout);
+  const actualRun = await E(run.issuer).getAmountOf(runPayouts.Out);
   t.deepEqual(actualRun, expectedRun);
-  const liq = await E(publicFacet).getPoolBalance();
-  t.true(AmountMath.isEqual(liq, giveAnchor));
+
+  driver.assertPoolBalance(giveAnchor);
+
   const giveRun = AmountMath.make(run.brand, 100n * 1_000_000n);
-  trace('get stable ratio', { giveRun, expectedRun, actualRun, liq });
-  const [runPayment, _moreRun] = await E(run.issuer).split(runPayout, giveRun);
-  const seat2 = await E(zoe).offer(
-    E(publicFacet).makeSwapInvitation(),
-    harden({ give: { In: giveRun } }),
-    harden({ In: runPayment }),
+  trace('get stable ratio', { giveRun, expectedRun, actualRun });
+  const [runPayment, _moreRun] = await E(run.issuer).split(
+    runPayouts.Out,
+    giveRun,
   );
-  const anchorPayout = await E(seat2).getPayout('Out');
-  const actualAnchor = await E(anchorIssuer).getAmountOf(anchorPayout);
+  const anchorPayouts = await driver.swapRunForAnchor(giveRun, runPayment);
+  const actualAnchor = await E(anchorIssuer).getAmountOf(anchorPayouts.Out);
   const expectedAnchor = floorMultiplyBy(
     minusStableFee(giveRun),
     anchorPerStable,
   );
   t.deepEqual(actualAnchor, expectedAnchor);
-  const liq2 = await E(publicFacet).getPoolBalance();
-  t.deepEqual(AmountMath.subtract(giveAnchor, expectedAnchor), liq2);
-  trace('get anchor', { runGive: giveRun, expectedRun, actualAnchor, liq2 });
+  driver.assertPoolBalance(AmountMath.subtract(giveAnchor, expectedAnchor));
+  trace('get anchor', { runGive: giveRun, expectedRun, actualAnchor });
 });
 
-// NB: most 'storage keys' tests integrate bootstrap config, but this uses startInstance directly
-// because there are as yet no startPSM tests.
 test('storage keys', async t => {
-  const {
-    zoe,
-    privateArgs,
-    terms,
-    installs: { psmInstall },
-    anchorKit: { issuer: anchorIssuer },
-  } = t.context;
-  /** @type {Awaited<ReturnType<typeof import('../../src/psm/psm.js').start>>} */
-  const { publicFacet } = await E(zoe).startInstance(
-    psmInstall,
-    harden({ AUSD: anchorIssuer }),
-    terms,
-    privateArgs,
-  );
+  const { publicFacet } = await makePsmDriver(t);
 
   t.is(
     await subscriptionKey(E(publicFacet).getSubscription()),

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -104,6 +104,7 @@ const makeTestContext = async () => {
   );
 
   const mockChainStorage = makeMockChainStorageRoot();
+  const childkey = 'IST-aUSD';
 
   return {
     bundles: { psmBundle },
@@ -112,7 +113,9 @@ const makeTestContext = async () => {
     privateArgs: harden({
       feeMintAccess: await feeMintAccess,
       initialPoserInvitation,
-      storageNode: mockChainStorage.makeChildNode('psm'),
+      storageNode: mockChainStorage
+        .makeChildNode('psm')
+        .makeChildNode(childkey),
       marshaller: makeBoard().getReadonlyMarshaller(),
     }),
     stable: { issuer: stableIssuer, brand: stableBrand },
@@ -318,17 +321,20 @@ test('psm.governance', async t => {
   const { publicFacet } = await makePsmDriver(t);
   t.is(
     await subscriptionKey(E(publicFacet).getSubscription()),
-    'mockChainStorageRoot.psm.governance',
+    'mockChainStorageRoot.psm.IST-aUSD.governance',
   );
 
   const { mockChainStorage } = t.context;
-  t.like(mockChainStorage.getBody('mockChainStorageRoot.psm.governance'), {
-    current: {
-      Electorate: { type: 'invitation' },
-      GiveStableFee: { type: 'ratio' },
-      MintLimit: { type: 'amount' },
-      WantStableFee: { type: 'ratio' },
+  t.like(
+    mockChainStorage.getBody('mockChainStorageRoot.psm.IST-aUSD.governance'),
+    {
+      current: {
+        Electorate: { type: 'invitation' },
+        GiveStableFee: { type: 'ratio' },
+        MintLimit: { type: 'amount' },
+        WantStableFee: { type: 'ratio' },
+      },
     },
-  });
+  );
 });
 });

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -199,7 +199,7 @@ export const withAmountUtils = kit => {
 
 /**
  *
- * @param {Promise<StoredSubscription<unknown>> | StoredSubscriber<unknown>} subscription
+ * @param {ERef<StoredSubscription<unknown> | StoredSubscriber<unknown>>} subscription
  */
 export const subscriptionKey = subscription => {
   return E(subscription)

--- a/packages/inter-protocol/test/vaultFactory/test-liquidator.js
+++ b/packages/inter-protocol/test/vaultFactory/test-liquidator.js
@@ -20,7 +20,7 @@ import {
 /** @type {import('ava').TestFn<Context>} */
 const test = unknownTest;
 
-const trace = makeTracer('TestLiq');
+const trace = makeTracer('TestLiq', false);
 
 test.before(async t => {
   t.context = await makeDriverContext();

--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -14,7 +14,7 @@ import { makeDriverContext, makeManagerDriver } from './driver.js';
 /** @type {import('ava').TestFn<Context>} */
 const test = unknownTest;
 
-const trace = makeTracer('TestLiq');
+const trace = makeTracer('TestLiq', false);
 
 test.before(async t => {
   t.context = await makeDriverContext();

--- a/packages/inter-protocol/test/vaultFactory/test-vault-interest.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-interest.js
@@ -16,7 +16,7 @@ import { assert } from '@agoric/assert';
 import { makeTracer } from '../../src/makeTracer.js';
 
 const vaultRoot = './vault-contract-wrapper.js';
-const trace = makeTracer('TestVaultInterest');
+const trace = makeTracer('TestVaultInterest', false);
 
 /**
  * The properties will be asssigned by `setTestJig` in the contract.

--- a/packages/inter-protocol/test/vaultFactory/test-vault.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault.js
@@ -16,7 +16,7 @@ import { assert } from '@agoric/assert';
 import { makeTracer } from '../../src/makeTracer.js';
 
 const vaultRoot = './vault-contract-wrapper.js';
-const trace = makeTracer('TestVault');
+const trace = makeTracer('TestVault', false);
 
 /**
  * The properties will be asssigned by `setTestJig` in the contract.

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -75,7 +75,7 @@ const contractRoots = {
 
 /** @typedef {import('../../src/vaultFactory/vaultFactory').VaultFactoryContract} VFC */
 
-const trace = makeTracer('TestST');
+const trace = makeTracer('TestST', false);
 
 const BASIS_POINTS = 10000n;
 const SECONDS_PER_DAY = SECONDS_PER_YEAR / 365n;


### PR DESCRIPTION
closes: #4968 

## Description

See curated commit history.


### Security Considerations

--

### Documentation Considerations

Updated README

### Testing Considerations

Added unit tests. To cover `startPSM` I also tested manually with cosmic-swingset chain,

```
❯ make scenario2-setup scenario2-run-chain-economy

❯ agd query vstorage keys published.psm.IST.AUSD
children:
- governance
- metrics
pagination: null

❯ agoric follow :published.psm.IST.AUSD.metrics
SES Lockdown using options from environment variables "LOCKDOWN_ERROR_TAMING"
{
  anchorPoolBalance: {
    brand: slot(0,"Alleged: AUSD brand"),
    value: 0n,
  },
  feePoolBalance: {
    brand: slot(1,"Alleged: IST brand"),
    value: 0n,
  },
  totalAnchorProvided: {
    brand: slot(0),
    value: 0n,
  },
  totalStableProvided: {
    brand: slot(1),
    value: 0n,
  },
}