### PR TITLE
fix: make nested awaits somewhat safer

### DIFF
--- a/packages/SwingSet/src/devices/plugin/device-plugin.js
+++ b/packages/SwingSet/src/devices/plugin/device-plugin.js
@@ -55,7 +55,8 @@ export function buildRootDeviceNode(tools) {
    */
   async function createConnection(mod, index, epoch) {
     try {
-      const modNS = await endowments.import(mod);
+      const modNS = // eslint-disable-next-line @jessie.js/no-nested-await
+        await (async () => endowments.import(mod))();
       const receiver = obj => {
         // console.info('receiver', index, obj);
 

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -168,15 +168,15 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
     // instantiate all static vats
     for (const [name, vatID] of kernelKeeper.getStaticVats()) {
       logStartup(`provideVatKeeper for vat ${name} as vat ${vatID}`);
-      // eslint-disable-next-line no-await-in-loop
-      await ensureVatOnline(vatID, recreate);
+      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+      await (async () => ensureVatOnline(vatID, recreate))();
     }
 
     // instantiate all dynamic vats
     for (const vatID of kernelKeeper.getDynamicVats()) {
       logStartup(`provideVatKeeper for dynamic vat ${vatID}`);
-      // eslint-disable-next-line no-await-in-loop
-      await ensureVatOnline(vatID, recreate);
+      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+      await (async () => ensureVatOnline(vatID, recreate))();
     }
   }
 
@@ -379,7 +379,8 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
     // worker may or may not be online
     if (ephemeral.vats.has(vatID)) {
       try {
-        await evict(vatID);
+        // eslint-disable-next-line @jessie.js/no-nested-await
+        await (async () => evict(vatID))();
       } catch (err) {
         console.debug('vat termination was already reported; ignoring:', err);
       }

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -239,11 +239,9 @@ export function makeNetworkProtocol(protocolHandler) {
     // Check if we are underspecified (ends in slash)
     if (localAddr.endsWith(ENDPOINT_SEPARATOR)) {
       for (;;) {
-        // eslint-disable-next-line no-await-in-loop
-        const portID = await E(protocolHandler).generatePortID(
-          localAddr,
-          protocolHandler,
-        );
+        // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+        const portID = await (async () =>
+          E(protocolHandler).generatePortID(localAddr, protocolHandler))();
         const newAddr = `${localAddr}${portID}`;
         if (!boundPorts.has(newAddr)) {
           localAddr = newAddr;
@@ -386,10 +384,11 @@ export function makeNetworkProtocol(protocolHandler) {
         let localAddr;
         try {
           // See if our protocol is willing to receive this connection.
-          // eslint-disable-next-line no-await-in-loop
-          const localInstance = await E(protocolHandler)
-            .onInstantiate(port, listenPrefix, remoteAddr, protocolHandler)
-            .catch(rethrowUnlessMissing);
+          // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+          const localInstance = await (async () =>
+            E(protocolHandler)
+              .onInstantiate(port, listenPrefix, remoteAddr, protocolHandler)
+              .catch(rethrowUnlessMissing))();
           localAddr = localInstance
             ? `${listenAddr}/${localInstance}`
             : listenAddr;
@@ -467,10 +466,9 @@ export function makeNetworkProtocol(protocolHandler) {
       let lastFailure;
       try {
         // Attempt the loopback connection.
-        const attempt = await protocolImpl.inbound(
-          remoteAddr,
-          initialLocalAddr,
-        );
+        // eslint-disable-next-line @jessie.js/no-nested-await
+        const attempt = await (async () =>
+          protocolImpl.inbound(remoteAddr, initialLocalAddr))();
         return attempt.accept({ handler: lchandler });
       } catch (e) {
         lastFailure = e;

--- a/packages/cache/src/store.js
+++ b/packages/cache/src/store.js
@@ -78,8 +78,8 @@ const applyCacheTransaction = async (
   // Loop until our updated state is fresh wrt our current state.
   basisState = stateStore.get(keyStr);
   while (updatedState && updatedState.generation <= basisState.generation) {
-    // eslint-disable-next-line no-await-in-loop
-    updatedState = await getUpdatedState(basisState);
+    // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+    updatedState = await (async () => getUpdatedState(basisState))();
     // AWAIT INTERLEAVING
     basisState = stateStore.get(keyStr);
   }

--- a/packages/deploy-script-support/src/installInPieces.js
+++ b/packages/deploy-script-support/src/installInPieces.js
@@ -38,7 +38,8 @@ export const installInPieces = async (
       log(
         `waiting for ${inFlightAdditions.length} (~${approxBytesInFlight}B) additions...`,
       );
-      await Promise.all(inFlightAdditions);
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await (async () => Promise.all(inFlightAdditions))();
       approxBytesInFlight = 0;
       inFlightAdditions = [];
     }

--- a/packages/deploy-script-support/src/startInstance.js
+++ b/packages/deploy-script-support/src/startInstance.js
@@ -99,9 +99,9 @@ export const makeStartInstance = (
         `creatorInvitation must be defined to be deposited`,
       );
       console.log(`-- Adding Invitation for: ${instancePetname}`);
-      const invitationAmount = await E(zoeInvitationPurse).deposit(
-        creatorInvitation,
-      );
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      const invitationAmount = await (async () =>
+        E(zoeInvitationPurse).deposit(creatorInvitation))();
       console.log(`- Created Contract Instance: ${instancePetname}`);
 
       const creatorInvitationDetails = invitationAmount.value[0];

--- a/packages/deploy-script-support/src/writeCoreProposal.js
+++ b/packages/deploy-script-support/src/writeCoreProposal.js
@@ -63,11 +63,15 @@ export const makeWriteCoreProposal = (
       let bundle;
       if (bundlePath) {
         const bundleCache = pathResolve(bundlePath);
-        await createBundles([[pathResolve(entrypoint), bundleCache]]);
-        const ns = await import(bundleCache);
+        // eslint-disable-next-line @jessie.js/no-nested-await
+        await (async () =>
+          createBundles([[pathResolve(entrypoint), bundleCache]]))();
+        const ns = // eslint-disable-next-line @jessie.js/no-nested-await
+          await (async () => import(bundleCache))();
         bundle = ns.default;
       } else {
-        bundle = await bundleSource(pathResolve(entrypoint));
+        bundle = // eslint-disable-next-line @jessie.js/no-nested-await
+          await (async () => bundleSource(pathResolve(entrypoint)))();
       }
 
       // Serialise the installations.

--- a/packages/inter-protocol/src/proposals/demoIssuers.js
+++ b/packages/inter-protocol/src/proposals/demoIssuers.js
@@ -624,6 +624,9 @@ export const fundAMM = async ({
       let fromCentral;
 
       if (brandsWithPriceAuthorities.includes(brand)) {
+        // @ts-expect-error TS only started complaining about this
+        // after we wrapped the expression in an immediately-executed
+        // async function.
         // eslint-disable-next-line @jessie.js/no-nested-await
         ({ toCentral, fromCentral } = await (async () =>
           E(ammPublicFacet)

--- a/packages/inter-protocol/src/proposals/demoIssuers.js
+++ b/packages/inter-protocol/src/proposals/demoIssuers.js
@@ -288,10 +288,9 @@ export const connectFaucet = async ({
             case Stake.symbol:
               return bldIssuerKit;
             default: {
-              const { mint, issuer, brand } = await provideCoin(
-                name,
-                vats.mints,
-              );
+              // eslint-disable-next-line @jessie.js/no-nested-await
+              const { mint, issuer, brand } = await (async () =>
+                provideCoin(name, vats.mints))();
               return { issuer, brand, mint };
             }
           }
@@ -306,7 +305,8 @@ export const connectFaucet = async ({
         // Use the bank layer for BLD, IST.
         if (issuerName === Stake.symbol || issuerName === Stable.symbol) {
           const purse = E(bank).getPurse(brand);
-          await E(purse).deposit(payment);
+          // eslint-disable-next-line @jessie.js/no-nested-await
+          await (async () => E(purse).deposit(payment))();
         } else {
           toFaucet = [
             {
@@ -493,10 +493,9 @@ export const fundAMM = async ({
       async issuerName => {
         switch (issuerName) {
           case Stable.symbol: {
-            const [issuer, brand] = await Promise.all([
-              centralIssuer,
-              centralBrand,
-            ]);
+            // eslint-disable-next-line @jessie.js/no-nested-await
+            const [issuer, brand] = await (async () =>
+              Promise.all([centralIssuer, centralBrand]))();
             return { mint: undefined, issuer, brand };
           }
           case 'BLD':
@@ -625,12 +624,14 @@ export const fundAMM = async ({
       let fromCentral;
 
       if (brandsWithPriceAuthorities.includes(brand)) {
-        ({ toCentral, fromCentral } = await E(ammPublicFacet)
-          .getPriceAuthorities(brand)
-          .catch(_e => {
-            // console.warn('could not get AMM priceAuthorities', _e);
-            return { toCentral: undefined, fromCentral: undefined };
-          }));
+        // eslint-disable-next-line @jessie.js/no-nested-await
+        ({ toCentral, fromCentral } = await (async () =>
+          E(ammPublicFacet)
+            .getPriceAuthorities(brand)
+            .catch(_e => {
+              // console.warn('could not get AMM priceAuthorities', _e);
+              return { toCentral: undefined, fromCentral: undefined };
+            })))();
       }
 
       if (!fromCentral && tradesGivenCentral) {

--- a/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -197,12 +197,13 @@ const start = async zcf => {
         trace('exiting processTranches loop');
         return;
       }
-      await oncePerBlock();
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await (async () => oncePerBlock())();
 
       // Determine the max allowed tranche size
-      const { Secondary: poolCollateral, Central: poolCentral } = await E(
-        amm,
-      ).getPoolAllocation(toSell.brand);
+      const { Secondary: poolCollateral, Central: poolCentral } =
+        // eslint-disable-next-line @jessie.js/no-nested-await
+        await (async () => E(amm).getPoolAllocation(toSell.brand))();
       const maxAllowedTranche = maxTrancheWithFees(
         poolCollateral,
         MaxImpactBP,
@@ -224,10 +225,9 @@ const start = async zcf => {
 
       // this could use a unit rather than the tranche size to run concurrently
       /** @type PriceQuote */
-      const oracleQuote = await E(priceAuthority).quoteGiven(
-        tranche,
-        debtBrand,
-      );
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      const oracleQuote = await await (async () =>
+        E(priceAuthority).quoteGiven(tranche, debtBrand))();
       const oracleLimit = computeOracleLimit(oracleQuote, OracleTolerance);
 
       trace('Tranche', { debt, tranche, minAmmProceeds, oracleLimit });
@@ -303,7 +303,9 @@ const start = async zcf => {
       const collateralBefore = debtorSeat.getAmountAllocated('In');
       const proceedsBefore = debtorSeat.getAmountAllocated('Out');
 
-      await sellTranche(debtorSeat, collateral, debt, oracleLimit);
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await (async () =>
+        sellTranche(debtorSeat, collateral, debt, oracleLimit))();
 
       const proceedsAfter = debtorSeat.getAmountAllocated('Out');
       if (AmountMath.isEqual(proceedsBefore, proceedsAfter)) {

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -467,7 +467,8 @@ const helperBehavior = {
         // The rest of this method will not happen until after a quote is received.
         // This may not happen until much later, when the market changes.
         // eslint-disable-next-line no-await-in-loop
-        const quote = await E(ephemera.outstandingQuote).getPromise();
+        const quote = // eslint-disable-next-line @jessie.js/no-nested-await, no-await-in-loop
+          await (async () => E(ephemera.outstandingQuote).getPromise())();
         ephemera.outstandingQuote = null;
         // When we receive a quote, we check whether the vault with the highest
         // ratio of debt to collateral is below the liquidationMargin, and if so,
@@ -488,7 +489,8 @@ const helperBehavior = {
       }
     }
     for await (const next of eventualLiquidations()) {
-      await facets.helper.liquidateAndRemove(next);
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await (async () => facets.helper.liquidateAndRemove(next))();
       trace('price check liq', state.collateralBrand, next && next[0]);
     }
   },

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -467,7 +467,11 @@ const helperBehavior = {
         // The rest of this method will not happen until after a quote is received.
         // This may not happen until much later, when the market changes.
         // eslint-disable-next-line no-await-in-loop
-        const quote = // eslint-disable-next-line @jessie.js/no-nested-await, no-await-in-loop
+        const quote =
+          // @ts-expect-error TS only started complaining about this
+          // after we wrapped the expression in an immediately-executed
+          // async function.
+          // eslint-disable-next-line @jessie.js/no-nested-await, no-await-in-loop
           await (async () => E(ephemera.outstandingQuote).getPromise())();
         ephemera.outstandingQuote = null;
         // When we receive a quote, we check whether the vault with the highest

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -94,10 +94,12 @@ export function makeSnapStore(
     });
     let result;
     try {
-      result = await thunk(name);
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      result = await (async () => thunk(name))();
     } finally {
       try {
-        await unlink(name);
+        // eslint-disable-next-line @jessie.js/no-nested-await
+        await (async () => unlink(name))();
       } catch (ignore) {
         // ignore
       }
@@ -115,14 +117,18 @@ export function makeSnapStore(
     const tmp = await ptmpName({ tmpdir: root, template: 'atomic-XXXXXX' });
     let result;
     try {
-      await thunk(tmp);
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await (async () => thunk(tmp))();
       const target = resolve(root, dest);
-      await rename(tmp, target);
-      const stats = await stat(target);
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await (async () => rename(tmp, target))();
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      const stats = await (async () => stat(target))();
       result = { filename: target, size: stats.size };
     } finally {
       try {
-        await unlink(tmp);
+        // eslint-disable-next-line @jessie.js/no-nested-await
+        await (async () => unlink(tmp))();
       } catch (ignore) {
         // ignore
       }
@@ -151,16 +157,21 @@ export function makeSnapStore(
       autoClose: false,
     });
     try {
-      await Promise.all([
-        fsStreamReady(sourceStream),
-        fsStreamReady(destinationStream),
-      ]);
-      await pipe(sourceStream, f, destinationStream);
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await (async () =>
+        Promise.all([
+          fsStreamReady(sourceStream),
+          fsStreamReady(destinationStream),
+        ]))();
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await (async () => pipe(sourceStream, f, destinationStream))();
       if (flush) {
-        await destination.sync();
+        // eslint-disable-next-line @jessie.js/no-nested-await
+        await (async () => destination.sync())();
       }
     } finally {
-      await Promise.all([destination.close(), source.close()]);
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await (async () => Promise.all([destination.close(), source.close()]))();
     }
   }
 
@@ -265,7 +276,8 @@ export function makeSnapStore(
         const fullPath = hashPath(hash);
         try {
           if (keepSnapshots !== true) {
-            await unlink(fullPath);
+            // eslint-disable-next-line @jessie.js/no-nested-await
+            await (async () => unlink(fullPath))();
           }
           toDelete.delete(hash);
         } catch (error) {

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -14,10 +14,12 @@ const main = async () => {
   }
 
   for await (const file of files) {
-    const { readCircBuf } = await makeMemoryMappedCircularBuffer({
-      circularBufferFilename: file,
-      circularBufferSize: null,
-    });
+    // eslint-disable-next-line @jessie.js/no-nested-await
+    const { readCircBuf } = await (async () =>
+      makeMemoryMappedCircularBuffer({
+        circularBufferFilename: file,
+        circularBufferSize: null,
+      }))();
 
     let offset = 0;
     for (;;) {
@@ -50,8 +52,9 @@ const main = async () => {
       }
 
       // If the buffer is full, wait for stdout to drain.
-      // eslint-disable-next-line no-await-in-loop
-      await new Promise(resolve => process.stdout.once('drain', resolve));
+      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+      await (async () =>
+        new Promise(resolve => process.stdout.once('drain', resolve)))();
     }
   }
 };

--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -93,7 +93,8 @@ async function run() {
       lineCount % LINE_COUNT_TO_FLUSH === 0
     ) {
       lastTime = now;
-      await stats(update);
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await (async () => stats(update))();
     }
 
     if (!update) {
@@ -107,7 +108,8 @@ async function run() {
       const delayMS = PROCESSING_PERIOD - (now - startOfLastPeriod);
       maybeWait = new Promise(resolve => setTimeout(resolve, delayMS));
     }
-    await maybeWait;
+    // eslint-disable-next-line @jessie.js/no-nested-await
+    await (async () => maybeWait)();
     now = Date.now();
 
     if (now - startOfLastPeriod >= PROCESSING_PERIOD) {

--- a/packages/web-components/src/admin-websocket-connector.js
+++ b/packages/web-components/src/admin-websocket-connector.js
@@ -10,8 +10,8 @@ export const waitForBootstrap = async getBootstrap => {
   let update = await getLoadingUpdate();
   while (update.value.includes('wallet')) {
     console.log('waiting for wallet');
-    // eslint-disable-next-line no-await-in-loop
-    update = await getLoadingUpdate(update.updateCount);
+    // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+    update = await (async () => (getLoadingUpdate(update.updateCount)))();
   }
 
   return getBootstrap();

--- a/packages/web-components/src/admin-websocket-connector.js
+++ b/packages/web-components/src/admin-websocket-connector.js
@@ -10,8 +10,8 @@ export const waitForBootstrap = async getBootstrap => {
   let update = await getLoadingUpdate();
   while (update.value.includes('wallet')) {
     console.log('waiting for wallet');
-    // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
-    update = await (async () => (getLoadingUpdate(update.updateCount)))();
+    // eslint-disable-next-line no-await-in-loop
+    update = await getLoadingUpdate(update.updateCount);
   }
 
   return getBootstrap();

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -219,15 +219,15 @@ export async function replayXSnap(
       const seq = parseInt(digits, 10);
       console.log(folder, seq, kind);
       if (running && !['command', 'reply'].includes(kind)) {
-        // eslint-disable-next-line no-await-in-loop
+        // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
         await running;
         running = undefined;
       }
       const file = rd.file(step);
       switch (kind) {
         case 'isReady':
-          // eslint-disable-next-line no-await-in-loop
-          await it.isReady();
+          // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+          await (async () => it.isReady())();
           break;
         case 'evaluate':
           running = it.evaluate(file.getText());
@@ -247,8 +247,8 @@ export async function replayXSnap(
             return;
           } else {
             try {
-              // eslint-disable-next-line no-await-in-loop
-              await it.snapshot(file.getText());
+              // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+              await (async () => it.snapshot(file.getText()))();
             } catch (err) {
               console.warn(err, 'while taking snapshot:', err);
             }
@@ -270,7 +270,8 @@ export async function replayXSnap(
       const storedOpts = JSON.parse(rd.file(optionsFn).getText());
       console.log(folder, optionsFn, 'already spawned; ignoring:', storedOpts);
     }
-    await runSteps(rd, steps);
+    // eslint-disable-next-line @jessie.js/no-nested-await
+    await (async () => runSteps(rd, steps))();
   }
 
   await it.close();

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -163,7 +163,8 @@ export function xsnap(options) {
    */
   async function runToIdle() {
     for (;;) {
-      const iteration = await messagesFromXsnap.next(undefined);
+      const iteration = // eslint-disable-next-line @jessie.js/no-nested-await
+        await (async () => messagesFromXsnap.next(undefined))();
       if (iteration.done) {
         xsnapProcess.kill();
         return vatCancelled;
@@ -200,7 +201,10 @@ export function xsnap(options) {
           )}`,
         );
       } else if (message[0] === QUERY) {
-        await messagesToXsnap.next(await handleCommand(message.subarray(1)));
+        const newLocal = // eslint-disable-next-line @jessie.js/no-nested-await
+          await (async () => handleCommand(message.subarray(1)))();
+        // eslint-disable-next-line @jessie.js/no-nested-await
+        await (async () => messagesToXsnap.next(newLocal))();
       }
     }
   }

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -328,7 +328,8 @@ export function makeOnewayPriceAuthorityKit(opts) {
               // We don't wait for the quote to be authenticated; resolve
               // immediately.
               quotePK.resolve(quoteP);
-              await quotePK.promise;
+              // eslint-disable-next-line @jessie.js/no-nested-await
+              await (async () => quotePK.promise)();
             } catch (e) {
               quotePK.reject(e);
             }

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -101,10 +101,11 @@ const start = zcf => {
     const option = payoffHandler.makeOptionInvitation(position);
     const invitationIssuer = zcf.getInvitationIssuer();
     const payment = harden({ Option: option });
-    const spreadAmount = harden({
-      Option: await E(invitationIssuer).getAmountOf(option),
-    });
+    const Option = await E(invitationIssuer).getAmountOf(option);
     // AWAIT ////
+    const spreadAmount = harden({
+      Option,
+    });
 
     await depositToSeat(zcf, collateralSeat, spreadAmount, payment);
     // AWAIT ////

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -67,7 +67,11 @@ const start = async zcf => {
       try {
         assert(!revoked, revokedMsg);
         const noFee = AmountMath.makeEmpty(feeBrand);
-        const { requiredFee, reply } = await E(handler).onQuery(query, noFee);
+        const {
+          requiredFee,
+          reply,
+        } = // eslint-disable-next-line @jessie.js/no-nested-await
+          await (async () => E(handler).onQuery(query, noFee))();
         assert(
           !requiredFee || AmountMath.isGTE(noFee, requiredFee),
           X`Oracle required a fee but the query had none`,
@@ -83,7 +87,11 @@ const start = async zcf => {
       const doQuery = async querySeat => {
         try {
           const fee = querySeat.getAmountAllocated('Fee', feeBrand);
-          const { requiredFee, reply } = await E(handler).onQuery(query, fee);
+          const {
+            requiredFee,
+            reply,
+          } = // eslint-disable-next-line @jessie.js/no-nested-await
+            await (async () => E(handler).onQuery(query, fee))();
           if (requiredFee) {
             feeSeat.incrementBy(
               querySeat.decrementBy(harden({ Fee: requiredFee })),


### PR DESCRIPTION
for many unsafe nested await expressions like 
```js
await expr;
```
change to
```js
// eslint-disable-next-line @jessie.js/no-nested-await
await (async () => (expr))();
```
making it safer against some of the hazards of `await`
   * if `expr` throws, it'll still be a turn boundary before the `await` turns it back into a throw. When the nature of the unsafety was only that it was within a try block, this change actually makes that use safe. The catch, finally, and code after try will always happen in another turn.
   * make the semantic cost visible locally, and make the semantic cost carry a syntactic cost locally
   * leave the global lint warning in place, without habituating us to ignoring it.

Note: These are *not* semantics preserving changes. They may very well break something. This PR needs to be reviewed carefully before merging. Ideally with the author of each `await` reviewing the changes I made to their code.

Note: Not all packages done yet. In fact, at the moment I've only reduced the global await warnings from 191 to 136 :(
