### PR TITLE
WIP: make many multiline asserts into ifs

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -222,10 +222,11 @@ const AmountMath = {
     assertRemotable(brand, 'brand');
     assertRecord(allegedAmount, 'amount');
     const { brand: allegedBrand, value: allegedValue } = allegedAmount;
-    assert(
-      brand === allegedBrand,
-      X`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the specified brand ${brand}.`,
-    );
+    if (!(brand === allegedBrand)) {
+      assert.fail(
+        X`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the specified brand ${brand}.`,
+      );
+    }
     // Will throw on inappropriate value
     return AmountMath.make(brand, allegedValue);
   },

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -14,18 +14,20 @@ export const coerceDisplayInfo = (allegedDisplayInfo, assetKind) => {
   fit(allegedDisplayInfo, DisplayInfoShape, 'displayInfo');
 
   if (allegedDisplayInfo.assetKind !== undefined) {
-    assert(
-      allegedDisplayInfo.assetKind === assetKind,
-      X`displayInfo.assetKind was present (${allegedDisplayInfo.assetKind}) and did not match the assetKind argument (${assetKind})`,
-    );
+    if (!(allegedDisplayInfo.assetKind === assetKind)) {
+      assert.fail(
+        X`displayInfo.assetKind was present (${allegedDisplayInfo.assetKind}) and did not match the assetKind argument (${assetKind})`,
+      );
+    }
   }
   const displayInfo = harden({ ...allegedDisplayInfo, assetKind });
 
   if (displayInfo.decimalPlaces !== undefined) {
-    assert(
-      Number.isSafeInteger(displayInfo.decimalPlaces),
-      X`decimalPlaces ${displayInfo.decimalPlaces} is not a safe integer`,
-    );
+    if (!Number.isSafeInteger(displayInfo.decimalPlaces)) {
+      assert.fail(
+        X`decimalPlaces ${displayInfo.decimalPlaces} is not a safe integer`,
+      );
+    }
   }
 
   return displayInfo;

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -21,10 +21,11 @@ const amountSchemaFromElementSchema = (brand, assetKind, elementSchema) => {
   switch (assetKind) {
     case 'nat': {
       valueSchema = M.nat();
-      assert(
-        elementSchema === undefined,
-        X`Fungible assets cannot have an elementSchema: ${q(elementSchema)}`,
-      );
+      if (!(elementSchema === undefined)) {
+        assert.fail(
+          X`Fungible assets cannot have an elementSchema: ${q(elementSchema)}`,
+        );
+      }
       break;
     }
     case 'set': {
@@ -199,10 +200,11 @@ export const vivifyPaymentLedger = (
    * @returns {void}
    */
   const assertLivePayment = payment => {
-    assert(
-      paymentLedger.has(payment),
-      X`${payment} was not a live payment for brand ${brand}. It could be a used-up payment, a payment for another brand, or it might not be a payment at all.`,
-    );
+    if (!paymentLedger.has(payment)) {
+      assert.fail(
+        X`${payment} was not a live payment for brand ${brand}. It could be a used-up payment, a payment for another brand, or it might not be a payment at all.`,
+      );
+    }
   };
 
   /**
@@ -233,10 +235,9 @@ export const vivifyPaymentLedger = (
     if (payments.length > 1) {
       const antiAliasingStore = new Set();
       payments.forEach(payment => {
-        assert(
-          !antiAliasingStore.has(payment),
-          X`same payment ${payment} seen twice`,
-        );
+        if (antiAliasingStore.has(payment)) {
+          assert.fail(X`same payment ${payment} seen twice`);
+        }
         antiAliasingStore.add(payment);
       });
     }
@@ -246,10 +247,9 @@ export const vivifyPaymentLedger = (
     const newTotal = newPaymentBalances.reduce(add, emptyAmount);
 
     // Invariant check
-    assert(
-      isEqual(total, newTotal),
-      X`rights were not conserved: ${total} vs ${newTotal}`,
-    );
+    if (!isEqual(total, newTotal)) {
+      assert.fail(X`rights were not conserved: ${total} vs ${newTotal}`);
+    }
 
     let newPayments;
     try {
@@ -435,10 +435,11 @@ export const vivifyPaymentLedger = (
     recoverySet,
   ) => {
     amount = coerce(amount);
-    assert(
-      AmountMath.isGTE(currentBalance, amount),
-      X`Withdrawal of ${amount} failed because the purse only contained ${currentBalance}`,
-    );
+    if (!AmountMath.isGTE(currentBalance, amount)) {
+      assert.fail(
+        X`Withdrawal of ${amount} failed because the purse only contained ${currentBalance}`,
+      );
+    }
     const newPurseBalance = subtract(currentBalance, amount);
 
     const payment = makePayment();

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -91,10 +91,11 @@ export const vivifyPurseKind = (
             const delta = facets.purse.deposit(payment);
             amount = AmountMath.add(amount, delta, brand);
           }
-          assert(
-            state.recoverySet.getSize() === 0,
-            X`internal: Remaining unrecovered payments: ${facets.purse.getRecoverySet()}`,
-          );
+          if (!(state.recoverySet.getSize() === 0)) {
+            assert.fail(
+              X`internal: Remaining unrecovered payments: ${facets.purse.getRecoverySet()}`,
+            );
+          }
           return amount;
         },
       },

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -143,10 +143,9 @@ export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
     const worker = doXSnap({ handleCommand, name, ...meterOpts, ...xsnapOpts });
 
     for (const bundle of bundles) {
-      assert(
-        bundle.moduleFormat === 'getExport',
-        X`unexpected: ${bundle.moduleFormat}`,
-      );
+      if (!(bundle.moduleFormat === 'getExport')) {
+        assert.fail(X`unexpected: ${bundle.moduleFormat}`);
+      }
       // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       await worker.evaluate(`(${bundle.source}\n)()`.trim());
     }

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -238,10 +238,11 @@ export async function loadSwingsetConfigFile(configPath) {
     await normalizeConfigDescriptor(config.bundles, referrer, false);
     // await normalizeConfigDescriptor(config.devices, referrer, true); // TODO: represent devices
     assert(config.bootstrap, X`no designated bootstrap vat in ${configPath}`);
-    assert(
-      config.vats && config.vats[config.bootstrap],
-      X`bootstrap vat ${config.bootstrap} not found in ${configPath}`,
-    );
+    if (!(config.vats && config.vats[config.bootstrap])) {
+      assert.fail(
+        X`bootstrap vat ${config.bootstrap} not found in ${configPath}`,
+      );
+    }
     return config;
   } catch (e) {
     if (e.code === 'ENOENT') {
@@ -295,10 +296,9 @@ export async function initializeSwingset(
   const kvStore = hostStorage.kvStore;
   insistStorageAPI(kvStore);
 
-  assert(
-    !swingsetIsInitialized(hostStorage),
-    X`kernel store already initialized`,
-  );
+  if (swingsetIsInitialized(hostStorage)) {
+    assert.fail(X`kernel store already initialized`);
+  }
 
   // copy config so we can safely mess with it even if it's shared or hardened
   config = JSON.parse(JSON.stringify(config));

--- a/packages/SwingSet/src/devices/lib/deviceTools.js
+++ b/packages/SwingSet/src/devices/lib/deviceTools.js
@@ -50,10 +50,9 @@ export function buildSerializationTools(syscall, deviceName) {
       assert(!allocatedByVat, X`devices cannot yet allocate objects ${slot}`);
       return presenceForSlot(slot);
     } else if (type === 'device') {
-      assert(
-        allocatedByVat,
-        X`devices should yet not be given other devices '${slot}'`,
-      );
+      if (!allocatedByVat) {
+        assert.fail(X`devices should yet not be given other devices '${slot}'`);
+      }
       return deviceNodeForSlot(slot);
     } else if (type === 'promise') {
       assert.fail(X`devices should not yet be given promises '${slot}'`);

--- a/packages/SwingSet/src/devices/loopbox/loopbox.js
+++ b/packages/SwingSet/src/devices/loopbox/loopbox.js
@@ -17,10 +17,9 @@ import { assert, details as X } from '@agoric/assert';
  */
 
 export function buildLoopbox(deliverMode) {
-  assert(
-    deliverMode === 'immediate' || deliverMode === 'queued',
-    X`deliverMode=${deliverMode}, must be 'immediate' or 'queued'`,
-  );
+  if (!(deliverMode === 'immediate' || deliverMode === 'queued')) {
+    assert.fail(X`deliverMode=${deliverMode}, must be 'immediate' or 'queued'`);
+  }
   const loopboxSrcPath = new URL('device-loopbox.js', import.meta.url).pathname;
 
   let loopboxPassOneMessage;

--- a/packages/SwingSet/src/devices/mailbox/device-mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox/device-mailbox.js
@@ -35,10 +35,9 @@ export function buildRootDeviceNode(tools) {
 
   // console.debug(`device-mailbox build: inboundHandler is`, inboundHandler);
   deliverInboundMessages = (peer, newMessages) => {
-    assert(
-      inboundHandler,
-      X`deliverInboundMessages before registerInboundHandler`,
-    );
+    if (!inboundHandler) {
+      assert.fail(X`deliverInboundMessages before registerInboundHandler`);
+    }
     try {
       SO(inboundHandler).deliverInboundMessages(peer, newMessages);
     } catch (e) {

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -241,10 +241,11 @@ export function buildRootDeviceNode(tools) {
   }
 
   function updateTime(time) {
-    assert(
-      time >= lastPolled,
-      X`Time is monotonic. ${time} cannot be less than ${lastPolled}`,
-    );
+    if (!(time >= lastPolled)) {
+      assert.fail(
+        X`Time is monotonic. ${time} cannot be less than ${lastPolled}`,
+      );
+    }
     lastPolled = time;
     saveState();
   }

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -139,10 +139,9 @@ export function makeDeviceSlots(
 
     assert(!outstandingProxies.has(x), X`SO(SO(x)) is invalid`);
     const slot = valToSlot.get(x);
-    assert(
-      slot && parseVatSlot(slot).type === 'object',
-      X`SO(x) must be called on a Presence, not ${x}`,
-    );
+    if (!(slot && parseVatSlot(slot).type === 'object')) {
+      assert.fail(X`SO(x) must be called on a Presence, not ${x}`);
+    }
     const handler = PresenceHandler(slot);
     const p = harden(new Proxy({}, handler));
     outstandingProxies.add(p);

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -998,10 +998,9 @@ export default function buildKernel(
   function routeSendEvent(message) {
     const { target, msg } = message;
     const { type } = parseKernelSlot(target);
-    assert(
-      ['object', 'promise'].includes(type),
-      X`unable to send() to slot.type ${type}`,
-    );
+    if (!['object', 'promise'].includes(type)) {
+      assert.fail(X`unable to send() to slot.type ${type}`);
+    }
 
     function splat(error) {
       if (msg.result) {

--- a/packages/SwingSet/src/kernel/parseKernelSlots.js
+++ b/packages/SwingSet/src/kernel/parseKernelSlots.js
@@ -78,8 +78,7 @@ export function makeKernelSlot(type, id) {
  * @returns {void}
  */
 export function insistKernelType(type, kernelSlot) {
-  assert(
-    type === parseKernelSlot(kernelSlot).type,
-    X`kernelSlot ${kernelSlot} is not of type ${type}`,
-  );
+  if (!(type === parseKernelSlot(kernelSlot).type)) {
+    assert.fail(X`kernelSlot ${kernelSlot} is not of type ${type}`);
+  }
 }

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -686,10 +686,11 @@ export default function makeKernelKeeper(
     const p = getKernelPromise(kpid);
     assert(p.state === 'unresolved', X`${kpid} was already resolved`);
     if (expectedDecider) {
-      assert(
-        p.decider === expectedDecider,
-        X`${kpid} is decided by ${p.decider}, not ${expectedDecider}`,
-      );
+      if (!(p.decider === expectedDecider)) {
+        assert.fail(
+          X`${kpid} is decided by ${p.decider}, not ${expectedDecider}`,
+        );
+      }
     } else {
       assert(!p.decider, X`${kpid} is decided by ${p.decider}, not the kernel`);
     }
@@ -913,10 +914,9 @@ export default function makeKernelKeeper(
     // there is some kernel queue holding the message and its content.
 
     const p = getKernelPromise(kernelSlot);
-    assert(
-      p.state === 'unresolved',
-      X`${kernelSlot} is '${p.state}', not 'unresolved'`,
-    );
+    if (!(p.state === 'unresolved')) {
+      assert.fail(X`${kernelSlot} is '${p.state}', not 'unresolved'`);
+    }
     const nkey = `${kernelSlot}.queue.nextID`;
     const nextID = Nat(BigInt(getRequired(nkey)));
     kvStore.set(nkey, `${nextID + 1n}`);

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -523,10 +523,9 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
   function translateSubscribe(vpid) {
     const kpid = mapVatSlotToKernelSlot(vpid);
     kdebug(`syscall[${vatID}].subscribe(${vpid}/${kpid})`);
-    assert(
-      kernelKeeper.hasKernelPromise(kpid),
-      X`unknown kernelPromise id '${kpid}'`,
-    );
+    if (!kernelKeeper.hasKernelPromise(kpid)) {
+      assert.fail(X`unknown kernelPromise id '${kpid}'`);
+    }
     /** @type { KernelSyscallSubscribe } */
     const ks = harden(['subscribe', vatID, kpid]);
     return ks;

--- a/packages/SwingSet/src/lib/capdata.js
+++ b/packages/SwingSet/src/lib/capdata.js
@@ -17,10 +17,9 @@ export function insistCapData(capdata) {
     'string',
     X`capdata has non-string .body ${capdata.body}`,
   );
-  assert(
-    Array.isArray(capdata.slots),
-    X`capdata has non-Array slots ${capdata.slots}`,
-  );
+  if (!Array.isArray(capdata.slots)) {
+    assert.fail(X`capdata has non-Array slots ${capdata.slots}`);
+  }
   // TODO check that the .slots array elements are actually strings
 }
 

--- a/packages/SwingSet/src/lib/netstring.js
+++ b/packages/SwingSet/src/lib/netstring.js
@@ -55,18 +55,16 @@ export function decode(data, optMaxChunkSize) {
       assert.fail(X`unparsable size ${sizeString}, should be integer`);
     }
     if (optMaxChunkSize) {
-      assert(
-        size <= optMaxChunkSize,
-        X`size ${size} exceeds limit of ${optMaxChunkSize}`,
-      );
+      if (!(size <= optMaxChunkSize)) {
+        assert.fail(X`size ${size} exceeds limit of ${optMaxChunkSize}`);
+      }
     }
     if (data.length < colon + 1 + size + 1) {
       break; // still waiting for `${DATA}.`
     }
-    assert(
-      data[colon + 1 + size] === COMMA,
-      X`malformed netstring: not terminated by comma`,
-    );
+    if (!(data[colon + 1 + size] === COMMA)) {
+      assert.fail(X`malformed netstring: not terminated by comma`);
+    }
     payloads.push(data.subarray(colon + 1, colon + 1 + size));
     start = colon + 1 + size + 1;
   }

--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -331,10 +331,9 @@ export function makeCollectionManager(
     }
 
     function get(key) {
-      assert(
-        matches(key, keySchema),
-        X`invalid key type for collection ${q(label)}`,
-      );
+      if (!matches(key, keySchema)) {
+        assert.fail(X`invalid key type for collection ${q(label)}`);
+      }
       const result = syscall.vatstoreGet(keyToDBKey(key));
       if (result) {
         return unserialize(JSON.parse(result));
@@ -362,10 +361,9 @@ export function makeCollectionManager(
         X`key ${key} already registered in collection ${q(label)}`,
       );
       if (valueSchema) {
-        assert(
-          matches(value, valueSchema),
-          X`invalid value type for collection ${q(label)}`,
-        );
+        if (!matches(value, valueSchema)) {
+          assert.fail(X`invalid value type for collection ${q(label)}`);
+        }
       }
       currentGenerationNumber += 1;
       const serializedValue = serialize(value);
@@ -380,10 +378,9 @@ export function makeCollectionManager(
       if (passStyleOf(key) === 'remotable') {
         const vref = convertValToSlot(key);
         if (durable) {
-          assert(
-            vrm.isDurable(vref),
-            X`key (${key}) is not durable in ${value}`,
-          );
+          if (!vrm.isDurable(vref)) {
+            assert.fail(X`key (${key}) is not durable in ${value}`);
+          }
         }
         generateOrdinal(key);
         if (hasWeakKeys) {
@@ -398,15 +395,13 @@ export function makeCollectionManager(
     }
 
     function set(key, value) {
-      assert(
-        matches(key, keySchema),
-        X`invalid key type for collection ${q(label)}`,
-      );
+      if (!matches(key, keySchema)) {
+        assert.fail(X`invalid key type for collection ${q(label)}`);
+      }
       if (valueSchema) {
-        assert(
-          matches(value, valueSchema),
-          X`invalid value type for collection ${q(label)}`,
-        );
+        if (!matches(value, valueSchema)) {
+          assert.fail(X`invalid value type for collection ${q(label)}`);
+        }
       }
       const after = serialize(harden(value));
       assertAcceptableSyscallCapdataSize([after]);
@@ -426,10 +421,9 @@ export function makeCollectionManager(
     }
 
     function deleteInternal(key) {
-      assert(
-        matches(key, keySchema),
-        X`invalid key type for collection ${q(label)}`,
-      );
+      if (!matches(key, keySchema)) {
+        assert.fail(X`invalid key type for collection ${q(label)}`);
+      }
       const dbKey = keyToDBKey(key);
       const rawValue = syscall.vatstoreGet(dbKey);
       assert(rawValue, X`key ${key} not found in collection ${q(label)}`);
@@ -475,10 +469,9 @@ export function makeCollectionManager(
       function* iter() {
         const generationAtStart = currentGenerationNumber;
         while (priorDBKey !== undefined) {
-          assert(
-            generationAtStart === currentGenerationNumber,
-            X`keys in store cannot be added to during iteration`,
-          );
+          if (!(generationAtStart === currentGenerationNumber)) {
+            assert.fail(X`keys in store cannot be added to during iteration`);
+          }
           const [dbKey, dbValue] = syscall.vatstoreGetAfter(
             priorDBKey,
             start,

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -810,10 +810,9 @@ function build(
     meterControl.assertNotMetered();
     const { type } = parseVatSlot(slot);
     assert(type === 'promise', X`revivePromise called on non-promise ${slot}`);
-    assert(
-      !getValForSlot(slot),
-      X`revivePromise called on pre-existing ${slot}`,
-    );
+    if (getValForSlot(slot)) {
+      assert.fail(X`revivePromise called on pre-existing ${slot}`);
+    }
     const pRec = makePipelinablePromise(slot);
     importedVPIDs.set(slot, pRec);
     const p = pRec.promise;
@@ -985,10 +984,9 @@ function build(
 
   function forbidPromises(serArgs) {
     for (const slot of serArgs.slots) {
-      assert(
-        parseVatSlot(slot).type !== 'promise',
-        X`D() arguments cannot include a Promise`,
-      );
+      if (!(parseVatSlot(slot).type !== 'promise')) {
+        assert.fail(X`D() arguments cannot include a Promise`);
+      }
     }
   }
 
@@ -1425,10 +1423,11 @@ function build(
       'remotable',
       X`buildRootObject() for vat ${forVatID} returned ${rootObject}, which is not Far`,
     );
-    assert(
-      getInterfaceOf(rootObject) !== undefined,
-      X`buildRootObject() for vat ${forVatID} returned ${rootObject} with no interface`,
-    );
+    if (!(getInterfaceOf(rootObject) !== undefined)) {
+      assert.fail(
+        X`buildRootObject() for vat ${forVatID} returned ${rootObject} with no interface`,
+      );
+    }
     // Need to load watched promises *after* buildRootObject() so that handler kindIDs
     // have a chance to be reassociated with their handlers.
     watchedPromiseManager.loadWatchedPromiseTable();

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -670,10 +670,9 @@ export function makeVirtualObjectManager(
     harden(behaviorTemplate);
 
     function makeRepresentative(innerSelf, initializing) {
-      assert(
-        innerSelf.repCount === 0,
-        X`${innerSelf.baseRef} already has a representative`,
-      );
+      if (!(innerSelf.repCount === 0)) {
+        assert.fail(X`${innerSelf.baseRef} already has a representative`);
+      }
       innerSelf.repCount += 1;
 
       function ensureState() {

--- a/packages/SwingSet/src/vats/comms/clist-inbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-inbound.js
@@ -23,10 +23,11 @@ export function makeInbound(state) {
     const lpid = remote.mapFromRemote(rpid);
     assert(lpid, X`unknown remote ${remoteID} promise ${rpid}`);
     const { subscribers } = state.getPromiseSubscribers(lpid);
-    assert(
-      subscribers.indexOf(remoteID) === -1,
-      X`attempt to retire remote ${remoteID} subscribed promise ${rpid}`,
-    );
+    if (!(subscribers.indexOf(remoteID) === -1)) {
+      assert.fail(
+        X`attempt to retire remote ${remoteID} subscribed promise ${rpid}`,
+      );
+    }
     remote.deleteRemoteMapping(lpid);
     cdebug(`comms delete mapping r<->k ${remoteID} ${rpid}<=>${lpid}`);
   }

--- a/packages/SwingSet/src/vats/comms/clist-kernel.js
+++ b/packages/SwingSet/src/vats/comms/clist-kernel.js
@@ -90,10 +90,9 @@ export function makeKernel(state, syscall) {
     assert(lpid, X`unknown kernel promise ${kfpid}`);
     assert(state.mapToKernel(lpid), X`unmapped local promise ${lpid}`);
     const { kernelIsSubscribed } = state.getPromiseSubscribers(lpid);
-    assert(
-      !kernelIsSubscribed,
-      X`attempt to retire subscribed promise ${kfpid}`,
-    );
+    if (kernelIsSubscribed) {
+      assert.fail(X`attempt to retire subscribed promise ${kfpid}`);
+    }
     state.deleteKernelMapping(lpid);
     cdebug(`comms delete mapping l<->k ${kfpid}<=>${lpid}`);
   }
@@ -105,10 +104,9 @@ export function makeKernel(state, syscall) {
     assert(lref, X`${kfref} must already be mapped to a local ID`);
     if (parseVatSlot(kfref).type === 'object') {
       // comms export, kernel import, it must be reachable
-      assert(
-        isReachable(lref),
-        X`kernel sending to unreachable import ${lref}`,
-      );
+      if (!isReachable(lref)) {
+        assert.fail(X`kernel sending to unreachable import ${lref}`);
+      }
     }
     return lref;
   }

--- a/packages/SwingSet/src/vats/comms/controller.js
+++ b/packages/SwingSet/src/vats/comms/controller.js
@@ -77,10 +77,9 @@ export function deliverToController(
     const remoteID = state.getRemoteIDForName(remoteName);
     assert(remoteID, X`unknown remote name ${remoteName}`);
     const remoteRefID = args[1];
-    assert(
-      args[2]['@qclass'] === 'slot' && args[2].index === 0,
-      X`unexpected args for addEgress(): ${methargs.body}`,
-    );
+    if (!(args[2]['@qclass'] === 'slot' && args[2].index === 0)) {
+      assert.fail(X`unexpected args for addEgress(): ${methargs.body}`);
+    }
     const localRef = provideLocalForKernel(slots[args[2].index]);
     addEgress(remoteID, remoteRefID, localRef);
     syscall.resolve([[result, false, UNDEFINED]]);

--- a/packages/SwingSet/src/vats/comms/delivery.js
+++ b/packages/SwingSet/src/vats/comms/delivery.js
@@ -61,10 +61,9 @@ export function makeDeliveryKit(
   function sendFromKernel(ktarget, kmethargs, kresult) {
     const target = getLocalForKernel(ktarget);
     const methargs = mapDataFromKernel(kmethargs, null);
-    assert(
-      state.getObject(target) || state.getPromiseStatus(target),
-      X`unknown message target ${target}/${ktarget}`,
-    );
+    if (!(state.getObject(target) || state.getPromiseStatus(target))) {
+      assert.fail(X`unknown message target ${target}/${ktarget}`);
+    }
     const result = provideLocalForKernelResult(kresult);
     const localDelivery = harden({ target, methargs, result });
     handleSend(localDelivery);
@@ -139,16 +138,14 @@ export function makeDeliveryKit(
     const seqNum = message.substring(0, delim1);
     const remote = state.getRemote(remoteID);
     const recvSeqNum = remote.advanceReceivedSeqNum();
-    assert(
-      seqNum === '' || seqNum === `${recvSeqNum}`,
-      X`unexpected recv seqNum ${seqNum}`,
-    );
+    if (!(seqNum === '' || seqNum === `${recvSeqNum}`)) {
+      assert.fail(X`unexpected recv seqNum ${seqNum}`);
+    }
 
     const delim2 = message.indexOf(':', delim1 + 1);
-    assert(
-      delim2 >= 0,
-      X`received message ${message} lacks ackSeqNum delimiter`,
-    );
+    if (!(delim2 >= 0)) {
+      assert.fail(X`received message ${message} lacks ackSeqNum delimiter`);
+    }
     const ackSeqNum = parseInt(message.substring(delim1 + 1, delim2), 10);
     handleAckFromRemote(remoteID, ackSeqNum);
 

--- a/packages/SwingSet/src/vats/comms/parseLocalSlots.js
+++ b/packages/SwingSet/src/vats/comms/parseLocalSlots.js
@@ -68,8 +68,7 @@ export function makeLocalSlot(type, id) {
  * @returns {void}
  */
 export function insistLocalType(type, localSlot) {
-  assert(
-    type === parseLocalSlot(localSlot).type,
-    X`localSlot ${localSlot} is not of type ${type}`,
-  );
+  if (!(type === parseLocalSlot(localSlot).type)) {
+    assert.fail(X`localSlot ${localSlot} is not of type ${type}`);
+  }
 }

--- a/packages/SwingSet/src/vats/comms/parseRemoteSlot.js
+++ b/packages/SwingSet/src/vats/comms/parseRemoteSlot.js
@@ -57,10 +57,9 @@ export function makeRemoteSlot(type, allocatedByRecipient, id) {
 }
 
 export function insistRemoteType(type, remoteSlot) {
-  assert(
-    type === parseRemoteSlot(remoteSlot).type,
-    X`remoteSlot ${remoteSlot} is not of type ${type}`,
-  );
+  if (!(type === parseRemoteSlot(remoteSlot).type)) {
+    assert.fail(X`remoteSlot ${remoteSlot} is not of type ${type}`);
+  }
 }
 
 // The clist for each remote-machine has two sides: fromRemote (used to

--- a/packages/SwingSet/src/vats/comms/remote.js
+++ b/packages/SwingSet/src/vats/comms/remote.js
@@ -18,10 +18,9 @@ export function initializeRemoteState(
   name,
   transmitterID,
 ) {
-  assert(
-    !store.get(`${remoteID}.initialized`),
-    X`remote ${remoteID} already exists`,
-  );
+  if (store.get(`${remoteID}.initialized`)) {
+    assert.fail(X`remote ${remoteID} already exists`);
+  }
   store.set(`${remoteID}.sendSeq`, '1');
   store.set(`${remoteID}.recvSeq`, '0');
   store.set(`${remoteID}.o.nextID`, `${identifierBase + 20}`);

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -308,10 +308,9 @@ export function makeNetworkProtocol(protocolHandler) {
       },
       async removeListener(listenHandler) {
         assert(listening.has(localAddr), X`Port ${localAddr} is not listening`);
-        assert(
-          listening.get(localAddr)[1] === listenHandler,
-          X`Port ${localAddr} handler to remove is not listening`,
-        );
+        if (!(listening.get(localAddr)[1] === listenHandler)) {
+          assert.fail(X`Port ${localAddr} handler to remove is not listening`);
+        }
         listening.delete(localAddr);
         await E(protocolHandler).onListenRemove(
           port,
@@ -339,10 +338,9 @@ export function makeNetworkProtocol(protocolHandler) {
         return conn;
       },
       async revoke() {
-        assert(
-          revoked !== RevokeState.REVOKED,
-          X`Port ${localAddr} is already revoked`,
-        );
+        if (!(revoked !== RevokeState.REVOKED)) {
+          assert.fail(X`Port ${localAddr} is already revoked`);
+        }
         revoked = RevokeState.REVOKING;
         await E(protocolHandler).onRevoke(port, localAddr, protocolHandler);
         revoked = RevokeState.REVOKED;
@@ -605,10 +603,9 @@ export function makeLoopbackProtocolHandler(
     async onListenRemove(port, localAddr, listenHandler, _protocolHandler) {
       const [lport, lhandler] = listeners.get(localAddr);
       assert(lport === port, X`Port does not match listener on ${localAddr}`);
-      assert(
-        lhandler === listenHandler,
-        X`Listen handler does not match listener on ${localAddr}`,
-      );
+      if (!(lhandler === listenHandler)) {
+        assert.fail(X`Listen handler does not match listener on ${localAddr}`);
+      }
       listeners.delete(localAddr);
     },
     async onRevoke(_port, _localAddr, _protocolHandler) {

--- a/packages/SwingSet/src/vats/vattp/vat-vattp.js
+++ b/packages/SwingSet/src/vats/vattp/vat-vattp.js
@@ -185,10 +185,9 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
     () => 0n,
   );
   const initNetworkHostState = (allegedName, comms, console) => {
-    assert(
-      !networkHostNames.has(allegedName),
-      X`already have host for ${allegedName}`,
-    );
+    if (networkHostNames.has(allegedName)) {
+      assert.fail(X`already have host for ${allegedName}`);
+    }
     networkHostNames.add(allegedName);
     networkHostCounter += 1n;
     baggage.set(networkHostCounterBaggageKey, networkHostCounter);

--- a/packages/SwingSet/test/commsVatDriver.js
+++ b/packages/SwingSet/test/commsVatDriver.js
@@ -185,10 +185,9 @@ function loggingSyscall(log) {
  * @returns {string} the ref embedded within `scriptRef`
  */
 function refOf(scriptRef) {
-  assert(
-    scriptRef[0] === '@',
-    X`expected reference ${scriptRef} to start with '@'`,
-  );
+  if (!(scriptRef[0] === '@')) {
+    assert.fail(X`expected reference ${scriptRef} to start with '@'`);
+  }
   const delim = scriptRef.indexOf(':');
   let ref;
   if (delim < 0) {

--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -66,10 +66,11 @@ const assertHttpConnectionSpec = connectionSpec => {
     'number',
     X`Expected "port" number on "http" type connectionSpec, ${connectionSpec}`,
   );
-  assert(
-    Number.isInteger(port),
-    X`Expected integer "port" on "http" type connectionSpec, ${connectionSpec}`,
-  );
+  if (!Number.isInteger(port)) {
+    assert.fail(
+      X`Expected integer "port" on "http" type connectionSpec, ${connectionSpec}`,
+    );
+  }
 };
 
 // eslint-disable-next-line jsdoc/require-returns-check

--- a/packages/agoric-cli/src/set-defaults.js
+++ b/packages/agoric-cli/src/set-defaults.js
@@ -12,10 +12,9 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
 
   const [prog, configDir] = rawArgs.slice(1);
 
-  assert(
-    prog === 'ag-chain-cosmos',
-    X`<prog> must currently be 'ag-chain-cosmos'`,
-  );
+  if (!(prog === 'ag-chain-cosmos')) {
+    assert.fail(X`<prog> must currently be 'ag-chain-cosmos'`);
+  }
 
   const { exportMetrics, enableCors } = opts;
 

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -30,18 +30,16 @@ const TELEMETRY_SERVICE_NAME = 'agd-cosmos';
 
 const toNumber = specimen => {
   const number = parseInt(specimen, 10);
-  assert(
-    String(number) === String(specimen),
-    X`Could not parse ${JSON.stringify(specimen)} as a number`,
-  );
+  if (!(String(number) === String(specimen))) {
+    assert.fail(X`Could not parse ${JSON.stringify(specimen)} as a number`);
+  }
   return number;
 };
 
 const makeChainStorage = (call, prefix = '', options = {}) => {
-  assert(
-    prefix === '' || prefix.endsWith('.'),
-    X`prefix ${prefix} must end with a dot`,
-  );
+  if (!(prefix === '' || prefix.endsWith('.'))) {
+    assert.fail(X`prefix ${prefix} must end with a dot`);
+  }
 
   const { fromChainShape, toChainShape } = options;
 

--- a/packages/cosmic-swingset/src/params.js
+++ b/packages/cosmic-swingset/src/params.js
@@ -18,10 +18,9 @@ export const stringToNat = s => {
 export const parseParams = params => {
   const { beans_per_unit: rawBeansPerUnit, fee_unit_price: rawFeeUnitPrice } =
     params;
-  assert(
-    Array.isArray(rawBeansPerUnit),
-    X`beansPerUnit must be an array, not ${rawBeansPerUnit}`,
-  );
+  if (!Array.isArray(rawBeansPerUnit)) {
+    assert.fail(X`beansPerUnit must be an array, not ${rawBeansPerUnit}`);
+  }
   const beansPerUnit = Object.fromEntries(
     rawBeansPerUnit.map(({ key, beans }) => {
       assert.typeof(key, 'string', X`Key ${key} must be a string`);
@@ -29,10 +28,9 @@ export const parseParams = params => {
     }),
   );
 
-  assert(
-    Array.isArray(rawFeeUnitPrice),
-    X`feeUnitPrice ${rawFeeUnitPrice} must be an array`,
-  );
+  if (!Array.isArray(rawFeeUnitPrice)) {
+    assert.fail(X`feeUnitPrice ${rawFeeUnitPrice} must be an array`);
+  }
   const feeUnitPrice = rawFeeUnitPrice.map(({ denom, amount }) => {
     assert.typeof(denom, 'string', X`denom ${denom} must be a string`);
     assert(denom, X`denom ${denom} must be non-empty`);

--- a/packages/deploy-script-support/src/assertOfferResult.js
+++ b/packages/deploy-script-support/src/assertOfferResult.js
@@ -5,8 +5,9 @@ import { E } from '@endo/far';
 /** @type {AssertOfferResult} */
 export const assertOfferResult = async (seat, expectedOfferResult) => {
   const actualOfferResult = await E(seat).getOfferResult();
-  assert(
-    actualOfferResult === expectedOfferResult,
-    X`offerResult (${actualOfferResult}) did not equal expected: ${expectedOfferResult}`,
-  );
+  if (!(actualOfferResult === expectedOfferResult)) {
+    assert.fail(
+      X`offerResult (${actualOfferResult}) did not equal expected: ${expectedOfferResult}`,
+    );
+  }
 };

--- a/packages/deploy-script-support/src/extract-proposal.js
+++ b/packages/deploy-script-support/src/extract-proposal.js
@@ -129,10 +129,9 @@ export const extractCoreProposalBundles = async (
       };
       const publishRef = async handleP => {
         const handle = await handleP;
-        assert(
-          bundleHandleToAbsolutePaths.has(handle),
-          X`${handle} not in installed bundles`,
-        );
+        if (!bundleHandleToAbsolutePaths.has(handle)) {
+          assert.fail(X`${handle} not in installed bundles`);
+        }
         return handle;
       };
       const proposal = await ns[entrypoint]({ publishRef, install }, ...args);

--- a/packages/deployment/src/init.js
+++ b/packages/deployment/src/init.js
@@ -513,10 +513,9 @@ const doInit =
       config.OFFSETS[PLACEMENT] = offset;
     }
 
-    assert(
-      Object.values(ROLE_INSTANCE).some(i => i > 0),
-      X`Aborting due to no nodes configured!`,
-    );
+    if (!Object.values(ROLE_INSTANCE).some(i => i > 0)) {
+      assert.fail(X`Aborting due to no nodes configured!`);
+    }
 
     await wr.createFile(
       `vars.tf`,

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -284,10 +284,9 @@ show-config      display the client connection parameters
           break;
 
         default:
-          assert(
-            versionKind.match(/^[1-9]/),
-            X`${versionKind} is not one of "epoch", or NNN`,
-          );
+          if (!versionKind.match(/^[1-9]/)) {
+            assert.fail(X`${versionKind} is not one of "epoch", or NNN`);
+          }
       }
 
       let vstr = `${epoch}`;
@@ -801,10 +800,9 @@ ${chalk.yellow.bold(`ag-setup-solo --netconfig='${dwebHost}/network-config'`)}
         const ID = String(raw);
 
         assert(ID, X`${idPath} must contain a node ${ID}`);
-        assert(
-          ID.match(/^[a-f0-9]+/),
-          X`${idPath} contains an invalid ID ${ID}`,
-        );
+        if (!ID.match(/^[a-f0-9]+/)) {
+          assert.fail(X`${idPath} contains an invalid ID ${ID}`);
+        }
         if (cmd.endsWith('-ids')) {
           ret += `${sep}${ID}`;
         } else {
@@ -970,10 +968,9 @@ ${node}:${roleParams}
     case 'play': {
       const [pb, ...pbargs] = args.slice(1);
       assert(pb, X`Need: [playbook name]`);
-      assert(
-        pb.match(/^\w[-\w]*$/),
-        X`[playbook] ${JSON.stringify(pb)} must be a word`,
-      );
+      if (!pb.match(/^\w[-\w]*$/)) {
+        assert.fail(X`[playbook] ${JSON.stringify(pb)} must be a word`);
+      }
       await inited();
       return doRun(setup.playbook(pb, ...pbargs));
     }

--- a/packages/deployment/src/run.js
+++ b/packages/deployment/src/run.js
@@ -50,10 +50,11 @@ export const running = (process, { exec, spawn }) => {
 
     needBacktick: async cmd => {
       const ret = await it.getStdout(cmd);
-      assert(
-        ret.code === 0,
-        X`Unexpected ${JSON.stringify(cmd)} exit code: ${ret.code}`,
-      );
+      if (!(ret.code === 0)) {
+        assert.fail(
+          X`Unexpected ${JSON.stringify(cmd)} exit code: ${ret.code}`,
+        );
+      }
       return ret.stdout;
     },
     cwd: () => process.cwd(),

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -30,10 +30,11 @@ const validateBinaryQuestionSpec = questionSpec => {
   coerceQuestionSpec(questionSpec);
 
   const positions = questionSpec.positions;
-  assert(
-    positions.length === 2,
-    X`Binary questions must have exactly two positions. had ${positions.length}: ${positions}`,
-  );
+  if (!(positions.length === 2)) {
+    assert.fail(
+      X`Binary questions must have exactly two positions. had ${positions.length}: ${positions}`,
+    );
+  }
 
   assert(
     questionSpec.maxChoices === 1,
@@ -81,10 +82,11 @@ const makeBinaryVoteCounter = (questionSpec, threshold, instance) => {
   const submitVote = (voterHandle, chosenPositions, shares = 1n) => {
     assert(chosenPositions.length === 1, 'only 1 position allowed');
     const [position] = chosenPositions;
-    assert(
-      positionIncluded(positions, position),
-      X`The specified choice is not a legal position: ${position}.`,
-    );
+    if (!positionIncluded(positions, position)) {
+      assert.fail(
+        X`The specified choice is not a legal position: ${position}.`,
+      );
+    }
 
     // CRUCIAL: If the voter cast a valid ballot, we'll record it, but we need
     // to make sure that each voter's vote is recorded only once.

--- a/packages/governance/src/contractGovernance/assertions.js
+++ b/packages/governance/src/contractGovernance/assertions.js
@@ -8,10 +8,9 @@ const { details: X } = assert;
 const makeLooksLikeBrand = name => {
   /** @param {Brand} brand */
   return brand => {
-    assert(
-      isRemotable(brand),
-      X`value for ${name} must be a brand, was ${brand}`,
-    );
+    if (!isRemotable(brand)) {
+      assert.fail(X`value for ${name} must be a brand, was ${brand}`);
+    }
   };
 };
 harden(makeLooksLikeBrand);
@@ -19,10 +18,11 @@ harden(makeLooksLikeBrand);
 const makeAssertInstallation = name => {
   return installation => {
     // TODO(3344): add a better assertion once Zoe validates installations
-    assert(
-      typeof installation === 'object',
-      X`value for ${name} must be an Installation, was ${installation}`,
-    );
+    if (!(typeof installation === 'object')) {
+      assert.fail(
+        X`value for ${name} must be an Installation, was ${installation}`,
+      );
+    }
   };
 };
 harden(makeAssertInstallation);
@@ -30,10 +30,9 @@ harden(makeAssertInstallation);
 const makeAssertInstance = name => {
   return instance => {
     // TODO(3344): add a better assertion once Zoe validates instances
-    assert(
-      typeof instance === 'object',
-      X`value for ${name} must be an Instance, was ${instance}`,
-    );
+    if (!(typeof instance === 'object')) {
+      assert.fail(X`value for ${name} must be an Instance, was ${instance}`);
+    }
   };
 };
 harden(makeAssertInstance);

--- a/packages/governance/src/contractGovernance/governApi.js
+++ b/packages/governance/src/contractGovernance/governApi.js
@@ -56,10 +56,9 @@ const setupApiGovernance = async (
     voteCounterInstallation,
     deadline,
   ) => {
-    assert(
-      governedNames.includes(apiMethodName),
-      X`${apiMethodName} is not a governed API.`,
-    );
+    if (!governedNames.includes(apiMethodName)) {
+      assert.fail(X`${apiMethodName} is not a governed API.`);
+    }
 
     const { positive, negative } = makeApiInvocationPositions(
       apiMethodName,

--- a/packages/governance/src/contractGovernance/governParam.js
+++ b/packages/governance/src/contractGovernance/governParam.js
@@ -72,15 +72,17 @@ const assertBallotConcernsParam = (paramSpec, questionSpec) => {
   // XXX doesn't fully test this requirement
   assert(issue, 'must be a param change issue');
 
-  assert(
-    issue.spec.changes[parameterName],
-    X`Question (${issue.spec.changes}) does not concern ${parameterName}`,
-  );
+  if (!issue.spec.changes[parameterName]) {
+    assert.fail(
+      X`Question (${issue.spec.changes}) does not concern ${parameterName}`,
+    );
+  }
 
-  assert(
-    keyEQ(issue.spec.paramPath, paramPath),
-    X`Question path (${issue.spec.paramPath}) doesn't match request (${paramPath})`,
-  );
+  if (!keyEQ(issue.spec.paramPath, paramPath)) {
+    assert.fail(
+      X`Question path (${issue.spec.paramPath}) doesn't match request (${paramPath})`,
+    );
+  }
 };
 
 /** @type {SetupGovernance} */

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -126,10 +126,11 @@ const start = async (zcf, privateArgs) => {
     },
   } = zcf.getTerms();
 
-  assert(
-    contractTerms.governedParams[CONTRACT_ELECTORATE],
-    X`Contract must declare ${CONTRACT_ELECTORATE} as a governed parameter`,
-  );
+  if (!contractTerms.governedParams[CONTRACT_ELECTORATE]) {
+    assert.fail(
+      X`Contract must declare ${CONTRACT_ELECTORATE} as a governed parameter`,
+    );
+  }
 
   const augmentedTerms = harden({
     ...contractTerms,

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -48,10 +48,9 @@ const QuorumRule = /** @type {const} */ ({
 
 const assertSimpleIssue = issue => {
   assert.typeof(issue, 'object', X`Issue ("${issue}") must be a record`);
-  assert(
-    issue && typeof issue.text === 'string',
-    X`Issue ("${issue}") must be a record with text: aString`,
-  );
+  if (!(issue && typeof issue.text === 'string')) {
+    assert.fail(X`Issue ("${issue}") must be a record with text: aString`);
+  }
 };
 
 /**
@@ -82,10 +81,11 @@ const assertParamChangeIssue = issue => {
 
 const assertApiInvocation = issue => {
   assert.typeof(issue, 'object', X`Issue ("${issue}") must be a record`);
-  assert(
-    issue && typeof issue.apiMethodName === 'string',
-    X`Issue ("${issue}") must be a record with apiMethodName: aString`,
-  );
+  if (!(issue && typeof issue.apiMethodName === 'string')) {
+    assert.fail(
+      X`Issue ("${issue}") must be a record with apiMethodName: aString`,
+    );
+  }
 };
 
 /**
@@ -95,10 +95,9 @@ const assertApiInvocation = issue => {
  */
 
 const assertIssueForType = (electionType, issue) => {
-  assert(
-    passStyleOf(issue) === 'copyRecord',
-    X`A question can only be a pass-by-copy record: ${issue}`,
-  );
+  if (!(passStyleOf(issue) === 'copyRecord')) {
+    assert.fail(X`A question can only be a pass-by-copy record: ${issue}`);
+  }
 
   switch (electionType) {
     case ElectionType.SURVEY:
@@ -168,10 +167,9 @@ const coerceQuestionSpec = ({
       'positions must be records',
     ),
   );
-  assert(
-    positionIncluded(positions, tieOutcome),
-    X`tieOutcome must be a legal position: ${q(tieOutcome)}`,
-  );
+  if (!positionIncluded(positions, tieOutcome)) {
+    assert.fail(X`tieOutcome must be a legal position: ${q(tieOutcome)}`);
+  }
   assertEnumIncludes(QuorumRule, quorumRule, 'QuorumRule');
   assertEnumIncludes(ElectionType, electionType, 'ElectionType');
   assertEnumIncludes(ChoiceMethod, method, 'ChoiceMethod');

--- a/packages/governance/src/validators.js
+++ b/packages/governance/src/validators.js
@@ -60,10 +60,11 @@ const assertContractElectorate = async (
   const allegedGovernorPF = E(zoe).getPublicFacet(allegedGovernor);
   const electorate = await E(allegedGovernorPF).getElectorate();
 
-  assert(
-    electorate === allegedElectorate,
-    X`The allegedElectorate didn't match the actual ${q(electorate)}`,
-  );
+  if (!(electorate === allegedElectorate)) {
+    assert.fail(
+      X`The allegedElectorate didn't match the actual ${q(electorate)}`,
+    );
+  }
 
   return true;
 };

--- a/packages/inter-protocol/src/interchainPool.js
+++ b/packages/inter-protocol/src/interchainPool.js
@@ -56,10 +56,11 @@ export const start = (zcf, { bankManager }) => {
     const {
       give: { Central: centralAmt },
     } = seat.getProposal();
-    assert(
-      AmountMath.isGTE(centralAmt, minimumCentral),
-      X`at least ${q(minimumCentral)} required; only ${q(centralAmt)} given`,
-    );
+    if (!AmountMath.isGTE(centralAmt, minimumCentral)) {
+      assert.fail(
+        X`at least ${q(minimumCentral)} required; only ${q(centralAmt)} given`,
+      );
+    }
 
     const interAsset = makeIssuerKit(
       denom,

--- a/packages/inter-protocol/src/interest.js
+++ b/packages/inter-protocol/src/interest.js
@@ -134,10 +134,11 @@ export const calculateCompoundedInterest = (
 const validatedBrand = (mint, debt) => {
   const { brand: debtBrand } = debt;
   const { brand: issuerBrand } = mint.getIssuerRecord();
-  assert(
-    debtBrand === issuerBrand,
-    X`Debt and issuer brands differ: ${debtBrand} != ${issuerBrand}`,
-  );
+  if (!(debtBrand === issuerBrand)) {
+    assert.fail(
+      X`Debt and issuer brands differ: ${debtBrand} != ${issuerBrand}`,
+    );
+  }
   return issuerBrand;
 };
 

--- a/packages/inter-protocol/src/my-lien.js
+++ b/packages/inter-protocol/src/my-lien.js
@@ -57,10 +57,11 @@ export const makeStakeReporter = (bridgeManager, brand, denom = 'ubld') => {
       return changeLiened(address, delta);
     },
     getAccountState: async (address, wantedBrand) => {
-      assert(
-        wantedBrand === brand,
-        X`Cannot getAccountState for ${wantedBrand}. Expected ${brand}.`,
-      );
+      if (!(wantedBrand === brand)) {
+        assert.fail(
+          X`Cannot getAccountState for ${wantedBrand}. Expected ${brand}.`,
+        );
+      }
       /** @type { AccountState<string> } */
       const { currentTime, bonded, liened, locked, total, unbonding } = await E(
         bridgeManager,

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -105,10 +105,9 @@ export const start = async (zcf, privateArgs, baggage) => {
       anchorPool.getAmountAllocated('Anchor', anchorBrand),
       given,
     );
-    assert(
-      AmountMath.isGTE(params.getMintLimit(), anchorAfterTrade),
-      X`Request would exceed mint limit`,
-    );
+    if (!AmountMath.isGTE(params.getMintLimit(), anchorAfterTrade)) {
+      assert.fail(X`Request would exceed mint limit`);
+    }
   };
 
   /**
@@ -121,10 +120,9 @@ export const start = async (zcf, privateArgs, baggage) => {
     const afterFee = AmountMath.subtract(given, fee);
     const maxAnchor = floorMultiplyBy(afterFee, anchorPerStable);
     // TODO this prevents the reallocate from failing. Can this be tested otherwise?
-    assert(
-      AmountMath.isGTE(maxAnchor, wanted),
-      X`wanted ${wanted} is more then ${given} minus fees ${fee}`,
-    );
+    if (!AmountMath.isGTE(maxAnchor, wanted)) {
+      assert.fail(X`wanted ${wanted} is more then ${given} minus fees ${fee}`);
+    }
     stageTransfer(seat, stage, { In: afterFee }, { Stable: afterFee });
     stageTransfer(seat, feePool, { In: fee }, { Stable: fee });
     stageTransfer(anchorPool, seat, { Anchor: maxAnchor }, { Out: maxAnchor });
@@ -142,10 +140,9 @@ export const start = async (zcf, privateArgs, baggage) => {
     const asStable = floorDivideBy(given, anchorPerStable);
     const fee = ceilMultiplyBy(asStable, params.getWantStableFee());
     const afterFee = AmountMath.subtract(asStable, fee);
-    assert(
-      AmountMath.isGTE(afterFee, wanted),
-      X`wanted ${wanted} is more then ${given} minus fees ${fee}`,
-    );
+    if (!AmountMath.isGTE(afterFee, wanted)) {
+      assert.fail(X`wanted ${wanted} is more then ${given} minus fees ${fee}`);
+    }
     stableMint.mintGains({ Stable: asStable }, stage);
     stageTransfer(seat, anchorPool, { In: given }, { Anchor: given });
     stageTransfer(stage, seat, { Stable: afterFee }, { Out: afterFee });

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -234,10 +234,11 @@ const start = async (zcf, privateArgs, baggage) => {
   };
 
   const getKeywordForBrand = brand => {
-    assert(
-      keywordForBrand.has(brand),
-      X`Issuer not defined for brand ${q(brand)}; first call addIssuer()`,
-    );
+    if (!keywordForBrand.has(brand)) {
+      assert.fail(
+        X`Issuer not defined for brand ${q(brand)}; first call addIssuer()`,
+      );
+    }
     return keywordForBrand.get(brand);
   };
 

--- a/packages/inter-protocol/src/stakeFactory/attestation.js
+++ b/packages/inter-protocol/src/stakeFactory/attestation.js
@@ -70,10 +70,11 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
 
   /** @param {Amount<'copyBag'>} attestationAmount */
   const unwrapLienedAmount = attestationAmount => {
-    assert(
-      attestationAmount.brand === attBrand,
-      X`The escrowed attestation ${attestationAmount} was not of the attestation brand ${attBrand}`,
-    );
+    if (!(attestationAmount.brand === attBrand)) {
+      assert.fail(
+        X`The escrowed attestation ${attestationAmount} was not of the attestation brand ${attBrand}`,
+      );
+    }
     fit(
       attestationAmount.value.payload,
       harden([[M.string(), M.bigint()]]),

--- a/packages/inter-protocol/src/stakeFactory/stakeFactoryKit.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactoryKit.js
@@ -82,10 +82,11 @@ const initState = (zcf, startSeat, manager) => {
     } = startSeat.getProposal();
 
     const { maxDebt } = manager.maxDebtForLien(attestationGiven);
-    assert(
-      AmountMath.isGTE(maxDebt, runWanted),
-      X`wanted ${runWanted}, more than max debt (${maxDebt}) for ${attestationGiven}`,
-    );
+    if (!AmountMath.isGTE(maxDebt, runWanted)) {
+      assert.fail(
+        X`wanted ${runWanted}, more than max debt (${maxDebt}) for ${attestationGiven}`,
+      );
+    }
 
     const { newDebt, fee, toMint } = calculateFee(
       manager.getLoanFee(),
@@ -93,10 +94,11 @@ const initState = (zcf, startSeat, manager) => {
       emptyDebt,
       runWanted,
     );
-    assert(
-      !AmountMath.isEmpty(fee),
-      X`loan requested (${runWanted}) is too small; cannot accrue interest`,
-    );
+    if (AmountMath.isEmpty(fee)) {
+      assert.fail(
+        X`loan requested (${runWanted}) is too small; cannot accrue interest`,
+      );
+    }
     assert(AmountMath.isEqual(newDebt, toMint), X`loan fee mismatch`);
     trace('init', { runWanted, fee, attestationGiven });
 
@@ -235,10 +237,9 @@ const helperBehavior = {
   assertVaultHoldsNoMinted: ({ state, facets }) => {
     const { vaultSeat } = state;
     const { helper } = facets;
-    assert(
-      AmountMath.isEmpty(helper.getMintedAllocated(vaultSeat)),
-      X`Vault should be empty of debt`,
-    );
+    if (!AmountMath.isEmpty(helper.getMintedAllocated(vaultSeat))) {
+      assert.fail(X`Vault should be empty of debt`);
+    }
   },
 
   /**
@@ -338,10 +339,11 @@ const helperBehavior = {
     const {
       give: { [KW.Debt]: runOffered },
     } = seat.getProposal();
-    assert(
-      AmountMath.isGTE(runOffered, currentDebt),
-      X`Offer ${runOffered} is not sufficient to pay off debt ${currentDebt}`,
-    );
+    if (!AmountMath.isGTE(runOffered, currentDebt)) {
+      assert.fail(
+        X`Offer ${runOffered} is not sufficient to pay off debt ${currentDebt}`,
+      );
+    }
     vaultSeat.incrementBy(seat.decrementBy(harden({ [KW.Debt]: currentDebt })));
     seat.incrementBy(
       vaultSeat.decrementBy(

--- a/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -284,10 +284,9 @@ const start = async zcf => {
     assertProposalShape(debtorSeat, {
       give: { In: null },
     });
-    assert(
-      originalDebt.brand === debtBrand,
-      X`Cannot liquidate to ${originalDebt.brand}`,
-    );
+    if (!(originalDebt.brand === debtBrand)) {
+      assert.fail(X`Cannot liquidate to ${originalDebt.brand}`);
+    }
     const penalty = ceilMultiplyBy(originalDebt, penaltyRate);
     const debtWithPenalty = AmountMath.add(originalDebt, penalty);
     trace('LIQ', { originalDebt, debtWithPenalty });

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -230,10 +230,11 @@ const helperBehavior = {
   assignPhase: ({ state }, newPhase) => {
     const { phase } = state;
     const validNewPhases = validTransitions[phase];
-    assert(
-      validNewPhases.includes(newPhase),
-      X`Vault cannot transition from ${q(phase)} to ${q(newPhase)}`,
-    );
+    if (!validNewPhases.includes(newPhase)) {
+      assert.fail(
+        X`Vault cannot transition from ${q(phase)} to ${q(newPhase)}`,
+      );
+    }
     state.phase = newPhase;
   },
 
@@ -244,10 +245,11 @@ const helperBehavior = {
 
   assertCloseable: ({ state }) => {
     const { phase } = state;
-    assert(
-      phase === Phase.ACTIVE || phase === Phase.LIQUIDATED,
-      X`to be closed a vault must be active or liquidated, not ${phase}`,
-    );
+    if (!(phase === Phase.ACTIVE || phase === Phase.LIQUIDATED)) {
+      assert.fail(
+        X`to be closed a vault must be active or liquidated, not ${phase}`,
+      );
+    }
   },
   // #endregion
 
@@ -303,10 +305,9 @@ const helperBehavior = {
 
   assertVaultHoldsNoMinted: ({ state, facets }) => {
     const { vaultSeat } = state;
-    assert(
-      AmountMath.isEmpty(facets.helper.getMintedAllocated(vaultSeat)),
-      X`Vault should be empty of Minted`,
-    );
+    if (!AmountMath.isEmpty(facets.helper.getMintedAllocated(vaultSeat))) {
+      assert.fail(X`Vault should be empty of Minted`);
+    }
   },
 
   /**
@@ -404,10 +405,11 @@ const helperBehavior = {
 
       // you must pay off the entire remainder but if you offer too much, we won't
       // take more than you owe
-      assert(
-        AmountMath.isGTE(given, debt),
-        X`Offer ${given} is not sufficient to pay off debt ${debt}`,
-      );
+      if (!AmountMath.isGTE(given, debt)) {
+        assert.fail(
+          X`Offer ${given} is not sufficient to pay off debt ${debt}`,
+        );
+      }
 
       // Return any overpayment
       seat.incrementBy(vaultSeat.decrementBy(vaultSeat.getCurrentAllocation()));
@@ -492,10 +494,9 @@ const helperBehavior = {
     const newCollateralPre = addSubtract(collateralPre, giveColl, wantColl);
     // max debt supported by current Collateral as modified by proposal
     const maxDebtPre = await state.manager.maxDebtFor(newCollateralPre);
-    assert(
-      updaterPre === ephemera.outerUpdater,
-      X`Transfer during vault adjustment`,
-    );
+    if (!(updaterPre === ephemera.outerUpdater)) {
+      assert.fail(X`Transfer during vault adjustment`);
+    }
     helper.assertActive();
 
     // After the `await`, we retrieve the vault's allocations again,
@@ -626,10 +627,11 @@ const selfBehavior = {
       fee,
       toMint,
     } = helper.loanFee(actualDebtPre, helper.emptyDebt(), wantMinted);
-    assert(
-      !AmountMath.isEmpty(fee),
-      X`loan requested (${wantMinted}) is too small; cannot accrue interest`,
-    );
+    if (AmountMath.isEmpty(fee)) {
+      assert.fail(
+        X`loan requested (${wantMinted}) is too small; cannot accrue interest`,
+      );
+    }
     assert(AmountMath.isEqual(newDebtPre, toMint), X`fee mismatch for vault`);
     trace(
       'initVault',

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -217,10 +217,9 @@ const makeVaultInvitation = ({ state }) => {
       want: { Minted: requestedAmount },
     } = seat.getProposal();
     const { brand: brandIn } = collateralAmount;
-    assert(
-      collateralTypes.has(brandIn),
-      X`Not a supported collateral type ${brandIn}`,
-    );
+    if (!collateralTypes.has(brandIn)) {
+      assert.fail(X`Not a supported collateral type ${brandIn}`);
+    }
 
     assert(
       AmountMath.isGTE(
@@ -326,10 +325,11 @@ const machineBehavior = {
     await zcf.saveIssuer(collateralIssuer, collateralKeyword);
     const collateralBrand = zcf.getBrandForIssuer(collateralIssuer);
     // We create only one vault per collateralType.
-    assert(
-      !collateralTypes.has(collateralBrand),
-      X`Collateral brand ${q(collateralBrand)} has already been added`,
-    );
+    if (collateralTypes.has(collateralBrand)) {
+      assert.fail(
+        X`Collateral brand ${q(collateralBrand)} has already been added`,
+      );
+    }
 
     const managerStorageNode =
       storageNode &&
@@ -489,10 +489,9 @@ const publicBehavior = {
    */
   getCollateralManager: ({ state }, brandIn) => {
     const { collateralTypes } = state;
-    assert(
-      collateralTypes.has(brandIn),
-      X`Not a supported collateral type ${brandIn}`,
-    );
+    if (!collateralTypes.has(brandIn)) {
+      assert.fail(X`Not a supported collateral type ${brandIn}`);
+    }
     /** @type {VaultManager} */
     return collateralTypes.get(brandIn).getPublicFacet();
   },

--- a/packages/inter-protocol/src/vpool-xyk-amm/addLiquidity.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/addLiquidity.js
@@ -30,10 +30,9 @@ const makeMakeAddLiquidityInvitation = (zcf, getPool) => {
     const pool = getPool(secondaryBrand);
     const liquidityIssuer = pool.getLiquidityIssuer();
     const liquidityBrand = zcf.getBrandForIssuer(liquidityIssuer);
-    assert(
-      seat.getProposal().want.Liquidity.brand === liquidityBrand,
-      X`liquidity brand must be ${q(liquidityBrand)}`,
-    );
+    if (!(seat.getProposal().want.Liquidity.brand === liquidityBrand)) {
+      assert.fail(X`liquidity brand must be ${q(liquidityBrand)}`);
+    }
 
     return pool.addLiquidity(seat);
   };

--- a/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
@@ -39,17 +39,15 @@ export const makeAddIssuer = (
     ]);
     // AWAIT ///////////////
 
-    assert(
-      secondaryAssetKind === AssetKind.NAT,
-      X`${keyword} asset not fungible (must use NAT math)`,
-    );
+    if (!(secondaryAssetKind === AssetKind.NAT)) {
+      assert.fail(X`${keyword} asset not fungible (must use NAT math)`);
+    }
 
     /** @type {(brand: Brand) => Promise<ZCFMint>} */
     const makeLiquidityMint = brand => {
-      assert(
-        !isInSecondaries(brand),
-        X`issuer ${secondaryIssuer} already has a pool`,
-      );
+      if (isInSecondaries(brand)) {
+        assert.fail(X`issuer ${secondaryIssuer} already has a pool`);
+      }
 
       const liquidityKeyword = `${keyword}Liquidity`;
       zcf.assertUniqueKeyword(liquidityKeyword);
@@ -152,16 +150,18 @@ export const makeAddPoolInvitation = (
         centralAboveMinimum,
       );
 
-      assert(
-        AmountMath.isGTE(funderLiquidityAmount, wantLiquidityAmount),
-        X`Requested too many liquidity tokens (${wantLiquidityAmount}, max: ${funderLiquidityAmount}`,
-      );
+      if (!AmountMath.isGTE(funderLiquidityAmount, wantLiquidityAmount)) {
+        assert.fail(
+          X`Requested too many liquidity tokens (${wantLiquidityAmount}, max: ${funderLiquidityAmount}`,
+        );
+      }
     }
 
-    assert(
-      AmountMath.isGTE(centralAmount, minPoolLiquidity),
-      X`The minimum initial liquidity is ${minPoolLiquidity}, rejecting ${centralAmount}`,
-    );
+    if (!AmountMath.isGTE(centralAmount, minPoolLiquidity)) {
+      assert.fail(
+        X`The minimum initial liquidity is ${minPoolLiquidity}, rejecting ${centralAmount}`,
+      );
+    }
     const minLiqAmount = AmountMath.make(
       liquidityBrand,
       minPoolLiquidity.value,

--- a/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/calcFees.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/calcFees.js
@@ -41,10 +41,11 @@ const amountGT = (left, right) =>
  * @returns {Amount}
  */
 const calcFee = ({ amountIn, amountOut }, feeRatio) => {
-  assert(
-    feeRatio.numerator.brand === feeRatio.denominator.brand,
-    X`feeRatio numerator and denominator must use the same brand ${feeRatio}`,
-  );
+  if (!(feeRatio.numerator.brand === feeRatio.denominator.brand)) {
+    assert.fail(
+      X`feeRatio numerator and denominator must use the same brand ${feeRatio}`,
+    );
+  }
 
   let sameBrandAmount;
   if (amountIn.brand === feeRatio.numerator.brand) {
@@ -62,10 +63,9 @@ const calcFee = ({ amountIn, amountOut }, feeRatio) => {
   const fee = ceilMultiplyBy(sameBrandAmount, feeRatio);
 
   // Fee cannot exceed the amount on which it is levied
-  assert(
-    AmountMath.isGTE(sameBrandAmount, fee),
-    X`The feeRatio can't be greater than 1 ${feeRatio}`,
-  );
+  if (!AmountMath.isGTE(sameBrandAmount, fee)) {
+    assert.fail(X`The feeRatio can't be greater than 1 ${feeRatio}`);
+  }
 
   return fee;
 };

--- a/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/core.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/core.js
@@ -9,10 +9,11 @@ import { getXY } from './getXY.js';
 const { details: X } = assert;
 
 const assertSingleBrand = ratio => {
-  assert(
-    ratio.numerator.brand === ratio.denominator.brand,
-    X`Ratio was expected to have same brand in numerator ${ratio.numerator.brand} and denominator ${ratio.denominator.brand}`,
-  );
+  if (!(ratio.numerator.brand === ratio.denominator.brand)) {
+    assert.fail(
+      X`Ratio was expected to have same brand in numerator ${ratio.numerator.brand} and denominator ${ratio.denominator.brand}`,
+    );
+  }
 };
 
 /**
@@ -108,10 +109,11 @@ const swapInReduced = ({ x, y, deltaX: offeredAmountIn }) => {
   const amountOut = calcDeltaYSellingX(x, y, offeredAmountIn);
   const reducedAmountIn = calcDeltaXSellingX(x, y, amountOut);
 
-  assert(
-    AmountMath.isGTE(offeredAmountIn, reducedAmountIn),
-    X`The trade would have required ${reducedAmountIn} more than was offered ${offeredAmountIn}`,
-  );
+  if (!AmountMath.isGTE(offeredAmountIn, reducedAmountIn)) {
+    assert.fail(
+      X`The trade would have required ${reducedAmountIn} more than was offered ${offeredAmountIn}`,
+    );
+  }
 
   return harden({
     amountIn: reducedAmountIn,
@@ -131,10 +133,11 @@ const swapOutImproved = ({ x, y, deltaY: wantedAmountOut }) => {
   const amountIn = calcDeltaXSellingX(x, y, wantedAmountOut);
   const improvedAmountOut = calcDeltaYSellingX(x, y, amountIn);
 
-  assert(
-    AmountMath.isGTE(improvedAmountOut, wantedAmountOut),
-    X`The trade would have returned ${improvedAmountOut} less than was wanted ${wantedAmountOut}`,
-  );
+  if (!AmountMath.isGTE(improvedAmountOut, wantedAmountOut)) {
+    assert.fail(
+      X`The trade would have returned ${improvedAmountOut} less than was wanted ${wantedAmountOut}`,
+    );
+  }
 
   return harden({
     amountIn,

--- a/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/getXY.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/getXY.js
@@ -21,10 +21,11 @@ export const getXY = ({ amountGiven, poolAllocation, amountWanted }) => {
   const yBrand = amountWanted && amountWanted.brand;
   const secondaryBrand = poolAllocation.Secondary.brand;
   const centralBrand = poolAllocation.Central.brand;
-  assert(
-    amountGiven || amountWanted,
-    X`At least one of ${amountGiven} and ${amountWanted} must be specified`,
-  );
+  if (!(amountGiven || amountWanted)) {
+    assert.fail(
+      X`At least one of ${amountGiven} and ${amountWanted} must be specified`,
+    );
+  }
 
   const deltas = {
     deltaX: amountGiven,

--- a/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/swap.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/swap.js
@@ -95,10 +95,9 @@ const isGreaterThanZero = amount => {
 };
 
 const assertGreaterThanZero = (amount, name) => {
-  assert(
-    amount && isGreaterThanZero(amount),
-    X`${name} must be greater than 0: ${amount}`,
-  );
+  if (!(amount && isGreaterThanZero(amount))) {
+    assert.fail(X`${name} must be greater than 0: ${amount}`);
+  }
 };
 
 const isWantedAvailable = (poolAllocation, amountWanted) => {

--- a/packages/inter-protocol/src/vpool-xyk-amm/doublePool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/doublePool.js
@@ -50,10 +50,11 @@ export const makeDoublePool = (
 
   const centralBrand = inCentral.brand;
   const emptyCentralAmount = AmountMath.makeEmpty(centralBrand);
-  assert(
-    centralBrand === outCentral.brand,
-    X`The central brands on the two pools must match: ${centralBrand}, ${outCentral.brand}`,
-  );
+  if (!(centralBrand === outCentral.brand)) {
+    assert.fail(
+      X`The central brands on the two pools must match: ${centralBrand}, ${outCentral.brand}`,
+    );
+  }
 
   const allocateGainsAndLosses = (seat, prices) => {
     const inPoolSeat = collateralInPool.getPoolSeat();

--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -90,10 +90,9 @@ const makeTestContext = async () => {
 
   const registerBundleHandles = bundleHandleMap => {
     for (const [{ bundleID }, paths] of bundleHandleMap.entries()) {
-      assert(
-        !bundleIDToAbsolutePaths.has(bundleID),
-        X`bundleID ${bundleID} already registered`,
-      );
+      if (bundleIDToAbsolutePaths.has(bundleID)) {
+        assert.fail(X`bundleID ${bundleID} already registered`);
+      }
       bundleIDToAbsolutePaths.set(bundleID, paths);
     }
   };

--- a/packages/sharing-service/src/sharedMap.js
+++ b/packages/sharing-service/src/sharedMap.js
@@ -16,10 +16,9 @@ function makeSharedMap(name) {
       return namedEntries.get(propertyName)[0];
     },
     addEntry(key, value) {
-      assert(
-        !namedEntries.has(key),
-        X`SharedMap ${name} already has an entry for ${key}.`,
-      );
+      if (namedEntries.has(key)) {
+        assert.fail(X`SharedMap ${name} already has an entry for ${key}.`);
+      }
       orderedEntries.push([key, value]);
       namedEntries.set(key, [value, orderedEntries.length]);
       return orderedEntries.length;

--- a/packages/sharing-service/src/sharing.js
+++ b/packages/sharing-service/src/sharing.js
@@ -16,30 +16,27 @@ function makeSharingService() {
       if (!sharedMaps.has(key)) {
         return undefined;
       }
-      assert(
-        sharedMaps.get(key) !== tombstone,
-        X`Entry for ${key} has already been collected.`,
-      );
+      if (!(sharedMaps.get(key) !== tombstone)) {
+        assert.fail(X`Entry for ${key} has already been collected.`);
+      }
       const result = sharedMaps.get(key);
       // these are single-use entries. Leave a tombstone to prevent MITM.
       sharedMaps.set(key, tombstone);
       return result;
     },
     createSharedMap(preferredName) {
-      assert(
-        !sharedMaps.has(preferredName),
-        X`Entry already exists: ${preferredName}`,
-      );
+      if (sharedMaps.has(preferredName)) {
+        assert.fail(X`Entry already exists: ${preferredName}`);
+      }
       const sharedMap = makeSharedMap(preferredName);
       sharedMaps.set(preferredName, sharedMap);
       brand.add(sharedMap);
       return sharedMap;
     },
     validate(allegedSharedMap) {
-      assert(
-        brand.has(allegedSharedMap),
-        X`Unrecognized sharedMap: ${allegedSharedMap}`,
-      );
+      if (!brand.has(allegedSharedMap)) {
+        assert.fail(X`Unrecognized sharedMap: ${allegedSharedMap}`);
+      }
       return allegedSharedMap;
     },
     // We don't need remove, since grabSharedMap can be used for that.

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -130,10 +130,9 @@ const buildSwingset = async (
   const importPlugin = async mod => {
     // Ensure they can't traverse out of the plugins prefix.
     const pluginFile = path.resolve(pluginsPrefix, mod);
-    assert(
-      pluginFile.startsWith(pluginsPrefix),
-      X`Cannot load ${pluginFile} plugin; outside of ${pluginDir}`,
-    );
+    if (!pluginFile.startsWith(pluginsPrefix)) {
+      assert.fail(X`Cannot load ${pluginFile} plugin; outside of ${pluginDir}`);
+    }
 
     // TODO: Detect the module type and use the appropriate loader, just like
     // `agoric deploy`.

--- a/packages/stat-logger/src/statGraph.js
+++ b/packages/stat-logger/src/statGraph.js
@@ -158,10 +158,9 @@ export async function renderGraph(spec, outputPath, type = 'png') {
   } else if (spec.marks.length === 0) {
     throw new Error('graph spec has no graphs defined');
   }
-  assert(
-    type === 'png' || type === 'pdf',
-    X`invalid output type ${type}, valid types are png or pdf`,
-  );
+  if (!(type === 'png' || type === 'pdf')) {
+    assert.fail(X`invalid output type ${type}, valid types are png or pdf`);
+  }
 
   let loadDir = '.';
   let out = process.stdout;

--- a/packages/store/src/keys/merge-bag-operators.js
+++ b/packages/store/src/keys/merge-bag-operators.js
@@ -232,10 +232,9 @@ const bagIterCompare = xyi => {
   } else if (loneY) {
     return -1;
   } else {
-    assert(
-      !loneX && !loneY,
-      X`Internal: Unexpected lone pair ${q([loneX, loneY])}`,
-    );
+    if (!(!loneX && !loneY)) {
+      assert.fail(X`Internal: Unexpected lone pair ${q([loneX, loneY])}`);
+    }
     return 0;
   }
 };

--- a/packages/store/src/keys/merge-set-operators.js
+++ b/packages/store/src/keys/merge-set-operators.js
@@ -208,10 +208,9 @@ const iterCompare = xyi => {
   } else if (loneY) {
     return -1;
   } else {
-    assert(
-      !loneX && !loneY,
-      X`Internal: Unexpected lone pair ${q([loneX, loneY])}`,
-    );
+    if (!(!loneX && !loneY)) {
+      assert.fail(X`Internal: Unexpected lone pair ${q([loneX, loneY])}`);
+    }
     return 0;
   }
 };

--- a/packages/store/src/patterns/encodePassable.js
+++ b/packages/store/src/patterns/encodePassable.js
@@ -128,10 +128,9 @@ const encodeBigInt = n => {
 const decodeBigInt = encoded => {
   const typePrefix = encoded[0];
   let rem = encoded.slice(1);
-  assert(
-    typePrefix === 'p' || typePrefix === 'n',
-    X`Encoded bigint expected: ${encoded}`,
-  );
+  if (!(typePrefix === 'p' || typePrefix === 'n')) {
+    assert.fail(X`Encoded bigint expected: ${encoded}`);
+  }
 
   const lDigits = rem.search(/[0-9]/) + 1;
   assert(lDigits >= 1, X`Digit count expected: ${encoded}`);
@@ -141,10 +140,9 @@ const decodeBigInt = encoded => {
   const snDigits = rem.slice(0, lDigits);
   rem = rem.slice(lDigits);
 
-  assert(
-    /^[0-9]+$/.test(snDigits),
-    X`Decimal digit count expected: ${encoded}`,
-  );
+  if (!/^[0-9]+$/.test(snDigits)) {
+    assert.fail(X`Decimal digit count expected: ${encoded}`);
+  }
   let nDigits = parseInt(snDigits, 10);
   if (typePrefix === 'n') {
     // TODO Assert to reject forbidden encodings
@@ -155,10 +153,9 @@ const decodeBigInt = encoded => {
   assert(rem.startsWith(':'), X`Separator expected: ${encoded}`);
   rem = rem.slice(1);
 
-  assert(
-    rem.length === nDigits,
-    X`Fixed-length digit sequence expected: ${encoded}`,
-  );
+  if (!(rem.length === nDigits)) {
+    assert.fail(X`Fixed-length digit sequence expected: ${encoded}`);
+  }
   let n = BigInt(rem);
   if (typePrefix === 'n') {
     // TODO Assert to reject forbidden encodings
@@ -203,10 +200,9 @@ const decodeArray = (encoded, decodePassable) => {
       i += 1;
       assert(i < encoded.length, X`unexpected end of encoding ${encoded}`);
       const c2 = encoded[i];
-      assert(
-        c2 === '\u0000' || c2 === '\u0001',
-        X`Unexpected character after u0001 escape: ${c2}`,
-      );
+      if (!(c2 === '\u0000' || c2 === '\u0001')) {
+        assert.fail(X`Unexpected character after u0001 escape: ${c2}`);
+      }
       elemChars.push(c2);
     } else {
       elemChars.push(c);
@@ -247,10 +243,9 @@ const decodeTagged = (encoded, decodePassable) => {
   const tagpayload = decodeArray(encoded.substring(1), decodePassable);
   assert(tagpayload.length === 2, X`expected tag,payload pair: ${encoded}`);
   const [tag, payload] = tagpayload;
-  assert(
-    passStyleOf(tag) === 'string',
-    X`not a valid tagged encoding: ${encoded}`,
-  );
+  if (!(passStyleOf(tag) === 'string')) {
+    assert.fail(X`not a valid tagged encoding: ${encoded}`);
+  }
   return makeTagged(tag, payload);
 };
 
@@ -297,26 +292,29 @@ export const makeEncodePassable = ({
       }
       case 'remotable': {
         const result = encodeRemotable(passable);
-        assert(
-          result.startsWith('r'),
-          X`internal: Remotable encoding must start with "r": ${result}`,
-        );
+        if (!result.startsWith('r')) {
+          assert.fail(
+            X`internal: Remotable encoding must start with "r": ${result}`,
+          );
+        }
         return result;
       }
       case 'error': {
         const result = encodeError(passable);
-        assert(
-          result.startsWith('!'),
-          X`internal: Error encoding must start with "!": ${result}`,
-        );
+        if (!result.startsWith('!')) {
+          assert.fail(
+            X`internal: Error encoding must start with "!": ${result}`,
+          );
+        }
         return result;
       }
       case 'promise': {
         const result = encodePromise(passable);
-        assert(
-          result.startsWith('?'),
-          X`internal: Promise encoding must start with "p": ${result}`,
-        );
+        if (!result.startsWith('?')) {
+          assert.fail(
+            X`internal: Promise encoding must start with "p": ${result}`,
+          );
+        }
         return result;
       }
       case 'symbol': {

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -112,10 +112,11 @@ const makePatternKit = () => {
             // are non-key patterns, general support is both hard and not
             // currently needed. Currently, we only need a copySet of a single
             // non-key pattern element.
-            assert(
-              patt.payload.length === 1,
-              X`Non-singleton copySets with matcher not yet implemented: ${patt}`,
-            );
+            if (!(patt.payload.length === 1)) {
+              assert.fail(
+                X`Non-singleton copySets with matcher not yet implemented: ${patt}`,
+              );
+            }
             return checkPattern(patt.payload[0], check);
           }
           case 'copyBag': {
@@ -367,10 +368,11 @@ const makePatternKit = () => {
             // Should already be validated by checkPattern. But because this
             // is a check that may loosen over time, we also assert everywhere
             // we still rely on the restriction.
-            assert(
-              patt.payload.length === 1,
-              X`Non-singleton copySets with matcher not yet implemented: ${patt}`,
-            );
+            if (!(patt.payload.length === 1)) {
+              assert.fail(
+                X`Non-singleton copySets with matcher not yet implemented: ${patt}`,
+              );
+            }
             return checkMatches(specPayload[0], pattPayload[0], check, 0);
           }
           case 'copyMap': {

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -114,10 +114,11 @@ export const makeScalarWeakMapStore = (
     // See https://github.com/Agoric/agoric-sdk/issues/3606
     harden(key);
 
-    assert(
-      passStyleOf(key) === 'remotable',
-      X`Only remotables can be keys of scalar WeakMapStores: ${key}`,
-    );
+    if (!(passStyleOf(key) === 'remotable')) {
+      assert.fail(
+        X`Only remotables can be keys of scalar WeakMapStores: ${key}`,
+      );
+    }
     if (keySchema !== undefined) {
       fit(key, keySchema, 'weakMapStore key');
     }

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -82,10 +82,9 @@ export const makeScalarWeakSetStore = (
     // See https://github.com/Agoric/agoric-sdk/issues/3606
     harden(key);
 
-    assert(
-      passStyleOf(key) === 'remotable',
-      X`Only remotables can be keys of scalar WeakStores: ${key}`,
-    );
+    if (!(passStyleOf(key) === 'remotable')) {
+      assert.fail(X`Only remotables can be keys of scalar WeakStores: ${key}`);
+    }
     if (keySchema !== undefined) {
       fit(key, keySchema, 'weakSetStore key');
     }

--- a/packages/swing-store/src/ephemeralSwingStore.js
+++ b/packages/swing-store/src/ephemeralSwingStore.js
@@ -126,10 +126,9 @@ export function initEphemeralSwingStore() {
 
   function insistStreamName(streamName) {
     assert.typeof(streamName, 'string');
-    assert(
-      streamName.match(/^[-\w]+$/),
-      X`invalid stream name ${q(streamName)}`,
-    );
+    if (!streamName.match(/^[-\w]+$/)) {
+      assert.fail(X`invalid stream name ${q(streamName)}`);
+    }
   }
 
   function insistStreamPosition(position) {
@@ -159,10 +158,11 @@ export function initEphemeralSwingStore() {
   function readStream(streamName, startPosition, endPosition) {
     insistStreamName(streamName);
     const stream = streams.get(streamName) || [];
-    assert(
-      !streamStatus.get(streamName),
-      X`can't read stream ${q(streamName)} because it's already in use`,
-    );
+    if (streamStatus.get(streamName)) {
+      assert.fail(
+        X`can't read stream ${q(streamName)} because it's already in use`,
+      );
+    }
     insistStreamPosition(startPosition);
     insistStreamPosition(endPosition);
     assert(startPosition.itemCount <= endPosition.itemCount);
@@ -177,18 +177,18 @@ export function initEphemeralSwingStore() {
       let pos = startPosition.itemCount;
       function* reader() {
         while (pos < stream.length) {
-          assert(
-            streamStatus.get(streamName) === readStatus,
-            X`can't read stream ${q(streamName)}, it's been closed`,
-          );
+          if (!(streamStatus.get(streamName) === readStatus)) {
+            assert.fail(
+              X`can't read stream ${q(streamName)}, it's been closed`,
+            );
+          }
           const result = stream[pos];
           pos += 1;
           yield result;
         }
-        assert(
-          streamStatus.get(streamName) === readStatus,
-          X`can't read stream ${q(streamName)}, it's been closed`,
-        );
+        if (!(streamStatus.get(streamName) === readStatus)) {
+          assert.fail(X`can't read stream ${q(streamName)}, it's been closed`);
+        }
         streamStatus.delete(streamName);
       }
       return reader();
@@ -211,9 +211,8 @@ export function initEphemeralSwingStore() {
     if (!stream) {
       stream = [];
       streams.set(streamName, stream);
-    } else {
-      assert(
-        !streamStatus.get(streamName),
+    } else if (streamStatus.get(streamName)) {
+      assert.fail(
         X`can't write stream ${q(streamName)} because it's already in use`,
       );
     }

--- a/packages/swing-store/src/sqlStreamStore.js
+++ b/packages/swing-store/src/sqlStreamStore.js
@@ -63,16 +63,18 @@ export function sqlStreamStore(dbDir, io) {
    */
   function readStream(streamName, startPosition, endPosition) {
     insistStreamName(streamName);
-    assert(
-      !streamStatus.get(streamName),
-      X`can't read stream ${q(streamName)} because it's already in use`,
-    );
+    if (streamStatus.get(streamName)) {
+      assert.fail(
+        X`can't read stream ${q(streamName)} because it's already in use`,
+      );
+    }
     insistStreamPosition(startPosition);
     insistStreamPosition(endPosition);
-    assert(
-      startPosition.itemCount <= endPosition.itemCount,
-      X`${q(startPosition.itemCount)} <= ${q(endPosition.itemCount)}}`,
-    );
+    if (!(startPosition.itemCount <= endPosition.itemCount)) {
+      assert.fail(
+        X`${q(startPosition.itemCount)} <= ${q(endPosition.itemCount)}}`,
+      );
+    }
 
     function* reader() {
       const query = db.prepare(`
@@ -86,19 +88,19 @@ export function sqlStreamStore(dbDir, io) {
         startPosition.itemCount,
         endPosition.itemCount,
       )) {
-        assert(
-          streamStatus.get(streamName) === 'reading',
-          X`can't read stream ${q(streamName)}, it's been closed`,
-        );
+        if (!(streamStatus.get(streamName) === 'reading')) {
+          assert.fail(X`can't read stream ${q(streamName)}, it's been closed`);
+        }
         yield item;
       }
       streamStatus.delete(streamName);
     }
 
-    assert(
-      !streamStatus.has(streamName),
-      X`can't read stream ${q(streamName)} because it's already in use`,
-    );
+    if (streamStatus.has(streamName)) {
+      assert.fail(
+        X`can't read stream ${q(streamName)} because it's already in use`,
+      );
+    }
 
     if (startPosition.itemCount === endPosition.itemCount) {
       return empty();
@@ -118,10 +120,11 @@ export function sqlStreamStore(dbDir, io) {
     insistStreamName(streamName);
     insistStreamPosition(position);
 
-    assert(
-      !streamStatus.get(streamName),
-      X`can't write stream ${q(streamName)} because it's already in use`,
-    );
+    if (streamStatus.get(streamName)) {
+      assert.fail(
+        X`can't write stream ${q(streamName)} because it's already in use`,
+      );
+    }
 
     db.prepare(
       `

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -25,10 +25,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       // Bob ensures it's the contract he expects
-      assert(
-        installations.automaticRefund === installation,
-        X`should be the expected automaticRefund`,
-      );
+      if (!(installations.automaticRefund === installation)) {
+        assert.fail(X`should be the expected automaticRefund`);
+      }
 
       assert(
         issuerKeywordRecord.Contribution1 === moolaIssuer,
@@ -84,10 +83,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
       assert(installation === installations.coveredCall, X`wrong installation`);
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      if (!(optionValue[0].description === 'exerciseOption')) {
+        assert.fail(X`wrong invitation`);
+      }
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
@@ -150,10 +148,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const optionValue = optionAmounts.value;
 
       assert(installation === installations.coveredCall, X`wrong installation`);
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      if (!(optionValue[0].description === 'exerciseOption')) {
+        assert.fail(X`wrong invitation`);
+      }
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
@@ -228,10 +225,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
 
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      if (!(installation === installations.secondPriceAuction)) {
+        assert.fail(X`wrong installation`);
+      }
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -25,10 +25,9 @@ const build = async (log, zoe, issuers, payments, installations) => {
         invitation,
       );
 
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      if (!(installation === installations.secondPriceAuction)) {
+        assert.fail(X`wrong installation`);
+      }
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -26,10 +26,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
 
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      if (!(installation === installations.secondPriceAuction)) {
+        assert.fail(X`wrong installation`);
+      }
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
@@ -100,16 +99,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       // Dave expects that Bob has already made an offer in the swap
       // with the following rules:
-      assert(
-        keyEQ(invitationValue[0].asset, optionAmounts),
-        X`asset is the option`,
-      );
+      if (!keyEQ(invitationValue[0].asset, optionAmounts)) {
+        assert.fail(X`asset is the option`);
+      }
       assert(keyEQ(invitationValue[0].price, bucks(1n)), X`price is 1 buck`);
       const optionValue = optionAmounts.value;
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      if (!(optionValue[0].description === 'exerciseOption')) {
+        assert.fail(X`wrong invitation`);
+      }
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -117,10 +117,9 @@ export const makeMemoryMappedCircularBuffer = async ({
    * @returns {IteratorResult<Uint8Array, void>}
    */
   const readCircBuf = (outbuf, offset = 0) => {
-    assert(
-      offset + outbuf.byteLength <= arenaSize,
-      X`Reading past end of circular buffer`,
-    );
+    if (!(offset + outbuf.byteLength <= arenaSize)) {
+      assert.fail(X`Reading past end of circular buffer`);
+    }
 
     // Read the data to the end of the arena.
     let firstReadLength = outbuf.byteLength;

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -76,10 +76,9 @@ export function makeBridgeManager(E, D, bridgeDevice) {
       srcHandlers.init(srcID, handler);
     },
     unregister(srcID, handler) {
-      assert(
-        srcHandlers.get(srcID) === handler,
-        X`Handler was not registered for ${srcID}`,
-      );
+      if (!(srcHandlers.get(srcID) === handler)) {
+        assert.fail(X`Handler was not registered for ${srcID}`);
+      }
       srcHandlers.delete(srcID);
     },
   });

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -233,10 +233,9 @@ export const extract = (template, specimen) => {
     return new Proxy(target, {
       get: (t, propName) => {
         if (typeof propName !== 'symbol') {
-          assert(
-            propName in t,
-            X`${propName} not permitted, only ${keys(template)}`,
-          );
+          if (!(propName in t)) {
+            assert.fail(X`${propName} not permitted, only ${keys(template)}`);
+          }
         }
         return t[propName];
       },

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -473,10 +473,9 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
         case 'channelOpenConfirm': {
           const { portID, channelID } = obj;
           const channelKey = `${channelID}:${portID}`;
-          assert(
-            channelKeyToAttemptP.has(channelKey),
-            X`${channelKey}: did not expect channelOpenConfirm`,
-          );
+          if (!channelKeyToAttemptP.has(channelKey)) {
+            assert.fail(X`${channelKey}: did not expect channelOpenConfirm`);
+          }
           const attemptP = channelKeyToAttemptP.get(channelKey);
           channelKeyToAttemptP.delete(channelKey);
 

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -107,10 +107,11 @@ function makeBoard(
       assert.typeof(id, 'string', X`id must be string: ${id}`);
       assert(id.startsWith(prefix), X`id must start with ${prefix}: ${id}`);
       const digits = id.slice(prefix.length);
-      assert(
-        digits.match(DIGITS_REGEXP),
-        X`id must end in at least ${q(crcDigits + 1)} digits: ${id}`,
-      );
+      if (!digits.match(DIGITS_REGEXP)) {
+        assert.fail(
+          X`id must end in at least ${q(crcDigits + 1)} digits: ${id}`,
+        );
+      }
       const seq = digits.slice(crcDigits);
       const allegedCrc = digits.slice(0, crcDigits);
       const crcInput = `${prefix}${seq}`;

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -12,10 +12,11 @@ const pathSegmentPattern = /^[a-zA-Z0-9_-]{1,100}$/;
 
 /** @type {(name: string) => void} */
 export const assertPathSegment = name => {
-  assert(
-    pathSegmentPattern.test(name),
-    X`Path segment names must consist of 1 to 100 characters limited to ASCII alphanumerics, underscores, and/or dashes: ${name}`,
-  );
+  if (!pathSegmentPattern.test(name)) {
+    assert.fail(
+      X`Path segment names must consist of 1 to 100 characters limited to ASCII alphanumerics, underscores, and/or dashes: ${name}`,
+    );
+  }
 };
 harden(assertPathSegment);
 

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -111,10 +111,9 @@ export const makeNameHubKit = () => {
       if (keyToRecord.has(key)) {
         record = keyToRecord.get(key);
       }
-      assert(
-        record && !record.promise,
-        X`key ${key} is not already initialized`,
-      );
+      if (!(record && !record.promise)) {
+        assert.fail(X`key ${key} is not already initialized`);
+      }
       nameAdmin.update(key, newValue, adminValue);
     },
     onUpdate: fn => {

--- a/packages/wallet/api/src/findOrMakeInvitation.js
+++ b/packages/wallet/api/src/findOrMakeInvitation.js
@@ -14,10 +14,9 @@ const assertFirstCapASCII = str => {
       str,
     )} must be an ascii identifier starting with upper case.`,
   );
-  assert(
-    str !== 'NaN' && str !== 'Infinity',
-    X`keyword ${q(str)} must not be a number's name`,
-  );
+  if (!(str !== 'NaN' && str !== 'Infinity')) {
+    assert.fail(X`keyword ${q(str)} must not be a number's name`);
+  }
 };
 
 /**
@@ -33,10 +32,9 @@ const findByBoardId = async (invitationPurseBalance, { board, boardId }) => {
   const invitationHandle = await E(board).getValue(boardId);
   const match = element => element.handle === invitationHandle;
   const matchingValue = invitationPurseBalance.value.find(match);
-  assert(
-    matchingValue,
-    X`Cannot find invitation corresponding to ${q(boardId)}`,
-  );
+  if (!matchingValue) {
+    assert.fail(X`Cannot find invitation corresponding to ${q(boardId)}`);
+  }
 
   return harden([matchingValue]);
 };

--- a/packages/wallet/api/src/lib-dehydrate.js
+++ b/packages/wallet/api/src/lib-dehydrate.js
@@ -48,10 +48,11 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
    * @returns {string | Path}
    */
   const explode = data => {
-    assert(
-      data.startsWith(IMPLODE_PREFIX),
-      X`exploded string ${data} must start with ${q(IMPLODE_PREFIX)}`,
-    );
+    if (!data.startsWith(IMPLODE_PREFIX)) {
+      assert.fail(
+        X`exploded string ${data} must start with ${q(IMPLODE_PREFIX)}`,
+      );
+    }
     const strongname = JSON.parse(data.slice(IMPLODE_PREFIX.length));
     if (!isPath(strongname)) {
       return strongname;
@@ -206,10 +207,9 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
       if (petnameToVal.has(petname) && petnameToVal.get(petname) === val) {
         return;
       }
-      assert(
-        !petnameToVal.has(petname),
-        X`petname ${petname} is already in use`,
-      );
+      if (petnameToVal.has(petname)) {
+        assert.fail(X`petname ${petname} is already in use`);
+      }
       assert(!valToPetname.has(val), X`val ${val} already has a petname`);
       petnameToVal.init(petname, val);
       valToPetname.init(val, petname);

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -633,10 +633,9 @@ export function makeWalletRoot({
     const keywordPaymentPs = Object.entries(proposal.give || harden({})).map(
       async ([keyword, { type, ...amount }]) => {
         const purse = purseKeywordRecord[keyword];
-        assert(
-          purse !== undefined,
-          X`purse was not found for keyword ${q(keyword)}`,
-        );
+        if (!(purse !== undefined)) {
+          assert.fail(X`purse was not found for keyword ${q(keyword)}`);
+        }
 
         if (type === 'Attestation') {
           const payment = await E(attMakerPK.promise).makeAttestation(amount);
@@ -1938,10 +1937,9 @@ export function makeWalletRoot({
       return E(agoricNames).lookup(...path);
     },
     getNamesByAddress(...path) {
-      assert(
-        namesByAddress,
-        X`namesByAddress was not supplied to the wallet maker`,
-      );
+      if (!namesByAddress) {
+        assert.fail(X`namesByAddress was not supplied to the wallet maker`);
+      }
       return E(namesByAddress).lookup(...path);
     },
   });

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -283,23 +283,20 @@ async function avaConfig(args, options, { glob, readFile }) {
   if (typeof exclude === 'string') {
     exclude = [exclude];
   }
-  assert(
-    !exclude || Array.isArray(exclude),
-    X`ava-xs.exclude: expected array or string: ${q(exclude)}`,
-  );
+  if (!(!exclude || Array.isArray(exclude))) {
+    assert.fail(X`ava-xs.exclude: expected array or string: ${q(exclude)}`);
+  }
 
   if (!files.length) {
-    assert(
-      Array.isArray(filePatterns),
-      X`ava.files: expected Array: ${q(filePatterns)}`,
-    );
+    if (!Array.isArray(filePatterns)) {
+      assert.fail(X`ava.files: expected Array: ${q(filePatterns)}`);
+    }
     files = (await Promise.all(filePatterns.map(globFiles))).flat();
   }
 
-  assert(
-    Array.isArray(require),
-    X`ava.requires: expected Array: ${q(require)}`,
-  );
+  if (!Array.isArray(require)) {
+    assert.fail(X`ava.requires: expected Array: ${q(require)}`);
+  }
   const config = { files, require, exclude, debug, verbose, titleMatch };
   return config;
 }

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -27,20 +27,20 @@ const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
 // lookup a keyword-named property no matter what `i` is.
 export const assertKeywordName = keyword => {
   assert.typeof(keyword, 'string');
-  assert(
-    keyword.length <= MAX_KEYWORD_LENGTH,
-    X`keyword ${keyword} exceeded maximum length ${MAX_KEYWORD_LENGTH} characters; got ${keyword.length}`,
-  );
+  if (!(keyword.length <= MAX_KEYWORD_LENGTH)) {
+    assert.fail(
+      X`keyword ${keyword} exceeded maximum length ${MAX_KEYWORD_LENGTH} characters; got ${keyword.length}`,
+    );
+  }
   assert(
     firstCapASCII.test(keyword),
     X`keyword ${q(
       keyword,
     )} must be an ascii identifier starting with upper case.`,
   );
-  assert(
-    keyword !== 'NaN' && keyword !== 'Infinity',
-    X`keyword ${q(keyword)} must not be a number's name`,
-  );
+  if (!(keyword !== 'NaN' && keyword !== 'Infinity')) {
+    assert.fail(X`keyword ${q(keyword)} must not be a number's name`);
+  }
 };
 
 /**
@@ -74,10 +74,11 @@ export const coerceAmountPatternKeywordRecord = (
       const assetKind = getAssetKind(amount);
       // TODO: replace this assertion with a check of the assetKind
       // property on the brand, when that exists.
-      assert(
-        assetKind === brandAssetKind,
-        X`The amount ${amount} did not have the assetKind of the brand ${brandAssetKind}`,
-      );
+      if (!(assetKind === brandAssetKind)) {
+        assert.fail(
+          X`The amount ${amount} did not have the assetKind of the brand ${brandAssetKind}`,
+        );
+      }
       return AmountMath.coerce(amount.brand, amount);
     } else {
       assertPattern(amount);
@@ -122,10 +123,9 @@ const assertKeywordNotInBoth = (want, give) => {
   const giveKeywords = ownKeys(give);
 
   giveKeywords.forEach(keyword => {
-    assert(
-      !wantKeywordSet.has(keyword),
-      X`a keyword cannot be in both 'want' and 'give'`,
-    );
+    if (wantKeywordSet.has(keyword)) {
+      assert.fail(X`a keyword cannot be in both 'want' and 'give'`);
+    }
   });
 };
 
@@ -154,10 +154,11 @@ export const cleanProposal = (proposal, getAssetKindByBrand) => {
     exit = harden({ onDemand: null }),
     ...rest
   } = proposal;
-  assert(
-    ownKeys(rest).length === 0,
-    X`${proposal} - Must only have want:, give:, exit: properties: ${rest}`,
-  );
+  if (!(ownKeys(rest).length === 0)) {
+    assert.fail(
+      X`${proposal} - Must only have want:, give:, exit: properties: ${rest}`,
+    );
+  }
 
   const cleanedWant = coerceAmountPatternKeywordRecord(
     want,

--- a/packages/zoe/src/contractFacet/rightsConservation.js
+++ b/packages/zoe/src/contractFacet/rightsConservation.js
@@ -77,10 +77,11 @@ const assertEqualPerBrand = (leftSumsByBrand, rightSumsByBrand) => {
 
   allBrands.forEach(brand => {
     const { leftSum, rightSum } = getSums(brand);
-    assert(
-      AmountMath.isEqual(leftSum, rightSum),
-      X`rights were not conserved for brand ${brand} ${leftSum.value} != ${rightSum.value}`,
-    );
+    if (!AmountMath.isEqual(leftSum, rightSum)) {
+      assert.fail(
+        X`rights were not conserved for brand ${brand} ${leftSum.value} != ${rightSum.value}`,
+      );
+    }
   });
 };
 

--- a/packages/zoe/src/contractFacet/vatRoot.js
+++ b/packages/zoe/src/contractFacet/vatRoot.js
@@ -30,10 +30,9 @@ export async function buildRootObject(powers, vatParameters, baggage) {
   // `zcfZygote.startContract` should exposed separately.
   const { testJigSetter } = powers;
   const { contractBundleCap } = vatParameters;
-  assert(
-    contractBundleCap,
-    X`expected vatParameters.contractBundleCap ${vatParameters}`,
-  );
+  if (!contractBundleCap) {
+    assert.fail(X`expected vatParameters.contractBundleCap ${vatParameters}`);
+  }
   let { zoeService, invitationIssuer } = vatParameters;
   const firstTime = !baggage.has('DidStart');
   if (firstTime) {

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -90,10 +90,11 @@ export const makeZCFMintFactory = async (
           // we are adding assets. However, we keep this check so that
           // all reallocations are covered by offer safety checks, and
           // that any bug within Zoe that may affect this is caught.
-          assert(
-            zcfSeat.isOfferSafe(allocationPlusGains),
-            X`The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`,
-          );
+          if (!zcfSeat.isOfferSafe(allocationPlusGains)) {
+            assert.fail(
+              X`The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`,
+            );
+          }
           // No effects above, apart from incrementBy. Note COMMIT POINT within
           // reallocateForZCFMint. The following two steps *should* be
           // committed atomically, but it is not a disaster if they are
@@ -116,10 +117,11 @@ export const makeZCFMintFactory = async (
           );
 
           // verifies offer safety
-          assert(
-            zcfSeat.isOfferSafe(allocationMinusLosses),
-            X`The allocation after burning losses ${allocationMinusLosses} for the zcfSeat was not offer safe`,
-          );
+          if (!zcfSeat.isOfferSafe(allocationMinusLosses)) {
+            assert.fail(
+              X`The allocation after burning losses ${allocationMinusLosses} for the zcfSeat was not offer safe`,
+            );
+          }
 
           // Decrement the stagedAllocation if it exists so that the
           // stagedAllocation is kept up to the currentAllocation

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -185,10 +185,11 @@ export const createSeatManager = (
 
     // Ensure that offer safety holds.
     seats.forEach(seat => {
-      assert(
-        isOfferSafe(seat.getProposal(), seat.getStagedAllocation()),
-        X`Offer safety was violated by the proposed allocation: ${seat.getStagedAllocation()}. Proposal was ${seat.getProposal()}`,
-      );
+      if (!isOfferSafe(seat.getProposal(), seat.getStagedAllocation())) {
+        assert.fail(
+          X`Offer safety was violated by the proposed allocation: ${seat.getStagedAllocation()}. Proposal was ${seat.getProposal()}`,
+        );
+      }
     });
 
     // Keep track of seats used so far in this call, to prevent aliasing.

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -43,10 +43,9 @@ export const getInputPrice = (
   outputReserve = Nat(outputReserve);
   assert(inputValue > 0n, X`inputValue ${inputValue} must be positive`);
   assert(inputReserve > 0n, X`inputReserve ${inputReserve} must be positive`);
-  assert(
-    outputReserve > 0n,
-    X`outputReserve ${outputReserve} must be positive`,
-  );
+  if (!(outputReserve > 0n)) {
+    assert.fail(X`outputReserve ${outputReserve} must be positive`);
+  }
 
   const oneMinusFeeScaled = subtract(BASIS_POINTS, feeBasisPoints);
   const inputWithFee = multiply(inputValue, oneMinusFeeScaled);

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -298,10 +298,11 @@ export function makeOnewayPriceAuthorityKit(opts) {
         const amountIn = calcAmountIn(amountOut);
         const actualAmountOut = calcAmountOut(amountIn);
 
-        assert(
-          AmountMath.isGTE(actualAmountOut, amountOut),
-          X`Calculation of ${actualAmountOut} didn't cover expected ${amountOut}`,
-        );
+        if (!AmountMath.isGTE(actualAmountOut, amountOut)) {
+          assert.fail(
+            X`Calculation of ${actualAmountOut} didn't cover expected ${amountOut}`,
+          );
+        }
         return { amountIn, amountOut };
       });
       assert(quote);

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -45,10 +45,11 @@ export const assertIsRatio = ratio => {
   const keys = Object.keys(ratio);
   assert(keys.length === 2, X`Ratio ${ratio} must be a record with 2 fields.`);
   for (const name of keys) {
-    assert(
-      ratioPropertyNames.includes(name),
-      X`Parameter must be a Ratio record, but ${ratio} has ${q(name)}`,
-    );
+    if (!ratioPropertyNames.includes(name)) {
+      assert.fail(
+        X`Parameter must be a Ratio record, but ${ratio} has ${q(name)}`,
+      );
+    }
   }
   const numeratorValue = ratio.numerator.value;
   const denominatorValue = ratio.denominator.value;
@@ -75,10 +76,11 @@ export const makeRatio = (
   denominator = PERCENT,
   denominatorBrand = numeratorBrand,
 ) => {
-  assert(
-    denominator > 0n,
-    X`No infinite ratios! Denominator was 0/${q(denominatorBrand)}`,
-  );
+  if (!(denominator > 0n)) {
+    assert.fail(
+      X`No infinite ratios! Denominator was 0/${q(denominatorBrand)}`,
+    );
+  }
 
   return harden({
     numerator: AmountMath.make(numeratorBrand, numerator),

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -19,10 +19,9 @@ export const assertIssuerKeywords = (zcf, expected) => {
   const actual = getKeysSorted(issuers);
   expected = [...expected]; // in case hardened
   expected.sort();
-  assert(
-    keyEQ(actual, harden(expected)),
-    X`keywords: ${actual} were not as expected: ${expected}`,
-  );
+  if (!keyEQ(actual, harden(expected))) {
+    assert.fail(X`keywords: ${actual} were not as expected: ${expected}`);
+  }
 };
 
 /**
@@ -149,10 +148,9 @@ export const assertProposalShape = (seat, expected) => {
   const actual = seat.getProposal();
   const assertKeys = (a, e) => {
     if (e !== undefined) {
-      assert(
-        keyEQ(getKeysSorted(a), getKeysSorted(e)),
-        X`actual ${a} did not match expected ${e}`,
-      );
+      if (!keyEQ(getKeysSorted(a), getKeysSorted(e))) {
+        assert.fail(X`actual ${a} did not match expected ${e}`);
+      }
     }
   };
   assertKeys(actual.give, expected.give);

--- a/packages/zoe/src/contracts/auction/assertBidSeat.js
+++ b/packages/zoe/src/contracts/auction/assertBidSeat.js
@@ -6,14 +6,14 @@ import { AmountMath } from '@agoric/ertp';
 export const assertBidSeat = (zcf, sellSeat, bidSeat) => {
   const minBid = sellSeat.getProposal().want.Ask;
   const bid = bidSeat.getAmountAllocated('Bid', minBid.brand);
-  assert(
-    AmountMath.isGTE(bid, minBid),
-    X`bid ${bid} is under the minimum bid ${minBid}`,
-  );
+  if (!AmountMath.isGTE(bid, minBid)) {
+    assert.fail(X`bid ${bid} is under the minimum bid ${minBid}`);
+  }
   const assetAtAuction = sellSeat.getProposal().give.Asset;
   const assetWanted = bidSeat.getAmountAllocated('Asset', assetAtAuction.brand);
-  assert(
-    AmountMath.isGTE(assetAtAuction, assetWanted),
-    X`more assets were wanted ${assetWanted} than were available ${assetAtAuction}`,
-  );
+  if (!AmountMath.isGTE(assetAtAuction, assetWanted)) {
+    assert.fail(
+      X`more assets were wanted ${assetWanted} than were available ${assetAtAuction}`,
+    );
+  }
 };

--- a/packages/zoe/src/contracts/auction/index.js
+++ b/packages/zoe/src/contracts/auction/index.js
@@ -50,10 +50,11 @@ const start = zcf => {
   } = zcf.getTerms();
 
   assert.typeof(bidDuration, 'bigint');
-  assert(
-    winnerPriceOption === FIRST_PRICE || winnerPriceOption === SECOND_PRICE,
-    X`Only first and second price auctions are supported`,
-  );
+  if (
+    !(winnerPriceOption === FIRST_PRICE || winnerPriceOption === SECOND_PRICE)
+  ) {
+    assert.fail(X`Only first and second price auctions are supported`);
+  }
 
   let sellSeat;
   let isTimerStarted = false;

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -123,10 +123,9 @@ const start = zcf => {
       } = depositSeat.getProposal();
 
       // assert that the allocation includes the amount of collateral required
-      assert(
-        AmountMath.isEqual(newCollateral, deposit),
-        X`Collateral required: ${deposit.value}`,
-      );
+      if (!AmountMath.isEqual(newCollateral, deposit)) {
+        assert.fail(X`Collateral required: ${deposit.value}`);
+      }
 
       // assert that the requested option was the right one.
       assert(

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -66,10 +66,11 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
       'exit afterDeadline',
     );
     const sellSeatExitRule = sellSeat.getProposal().exit;
-    assert(
-      isAfterDeadlineExitRule(sellSeatExitRule),
-      X`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`,
-    );
+    if (!isAfterDeadlineExitRule(sellSeatExitRule)) {
+      assert.fail(
+        X`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`,
+      );
+    }
 
     const exerciseOption = makeExerciser(sellSeat);
     const customProps = harden({

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -55,10 +55,11 @@ export const makeBorrowInvitation = (zcf, config) => {
 
     // Assert the required collateral was escrowed.
     const requiredMargin = ceilMultiplyBy(loanWanted, mmr);
-    assert(
-      AmountMath.isGTE(collateralPriceInLoanBrand, requiredMargin),
-      X`The required margin is ${requiredMargin.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`,
-    );
+    if (!AmountMath.isGTE(collateralPriceInLoanBrand, requiredMargin)) {
+      assert.fail(
+        X`The required margin is ${requiredMargin.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`,
+      );
+    }
 
     const timestamp = getTimestamp(quote);
 
@@ -72,10 +73,11 @@ export const makeBorrowInvitation = (zcf, config) => {
     );
 
     // Assert that loanWanted <= maxLoan
-    assert(
-      AmountMath.isGTE(maxLoan, loanWanted),
-      X`The wanted loan ${loanWanted} must be below or equal to the maximum possible loan ${maxLoan}`,
-    );
+    if (!AmountMath.isGTE(maxLoan, loanWanted)) {
+      assert.fail(
+        X`The wanted loan ${loanWanted} must be below or equal to the maximum possible loan ${maxLoan}`,
+      );
+    }
 
     const { zcfSeat: collateralSeat } = zcf.makeEmptySeatKit();
 

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -33,10 +33,11 @@ export const makeCloseLoanInvitation = (zcf, config) => {
     const debt = getDebt();
 
     // All debt must be repaid.
-    assert(
-      AmountMath.isGTE(repaid, debt),
-      X`Not enough Loan assets have been repaid.  ${debt} is required, but only ${repaid} was repaid.`,
-    );
+    if (!AmountMath.isGTE(repaid, debt)) {
+      assert.fail(
+        X`Not enough Loan assets have been repaid.  ${debt} is required, but only ${repaid} was repaid.`,
+      );
+    }
 
     // Transfer the collateral to the repaySeat and remove the
     // required Loan amount. Any excess Loan amount is kept by the repaySeat.

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -68,10 +68,9 @@ const start = async zcf => {
         assert(!revoked, revokedMsg);
         const noFee = AmountMath.makeEmpty(feeBrand);
         const { requiredFee, reply } = await E(handler).onQuery(query, noFee);
-        assert(
-          !requiredFee || AmountMath.isGTE(noFee, requiredFee),
-          X`Oracle required a fee but the query had none`,
-        );
+        if (!(!requiredFee || AmountMath.isGTE(noFee, requiredFee))) {
+          assert.fail(X`Oracle required a fee but the query had none`);
+        }
         return reply;
       } catch (e) {
         E(handler).onError(query, e);

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -101,10 +101,9 @@ const start = zcf => {
     );
 
     // Check that the money provided to pay for the items is greater than the totalCost.
-    assert(
-      AmountMath.isGTE(providedMoney, totalCost),
-      X`More money (${totalCost}) is required to buy these items`,
-    );
+    if (!AmountMath.isGTE(providedMoney, totalCost)) {
+      assert.fail(X`More money (${totalCost}) is required to buy these items`);
+    }
 
     // Reallocate.
     sellerSeat.incrementBy(

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -36,10 +36,9 @@ export const makeInstanceRecordStorage = baggage => {
     );
 
   const addIssuerToInstanceRecord = (keyword, issuerRecord) => {
-    assert(
-      !(keyword in issuerRecord),
-      X`conflicting definition of ${q(keyword)}`,
-    );
+    if (keyword in issuerRecord) {
+      assert.fail(X`conflicting definition of ${q(keyword)}`);
+    }
 
     assertInstantiated();
     const instanceRecord = baggage.get('instanceRecord');
@@ -86,10 +85,11 @@ export const makeInstanceRecordStorage = baggage => {
   const assertUniqueKeyword = keyword => {
     assertInstantiated();
     assertKeywordName(keyword);
-    assert(
-      !ownKeys(baggage.get('instanceRecord').terms.issuers).includes(keyword),
-      X`keyword ${q(keyword)} must be unique`,
-    );
+    if (
+      ownKeys(baggage.get('instanceRecord').terms.issuers).includes(keyword)
+    ) {
+      assert.fail(X`keyword ${q(keyword)} must be unique`);
+    }
   };
 
   const instantiate = startingInstanceRecord => {

--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -14,10 +14,9 @@ import { assert, details as X, q } from '@agoric/assert';
  * @param {U[]} keys
  */
 export const arrayToObj = (array, keys) => {
-  assert(
-    array.length === keys.length,
-    X`array and keys must be of equal length`,
-  );
+  if (!(array.length === keys.length)) {
+    assert.fail(X`array and keys must be of equal length`);
+  }
   const obj =
     /** @type {Record<U, T>} */
     ({});
@@ -34,9 +33,10 @@ export const arrayToObj = (array, keys) => {
 export const assertSubset = (whole, part) => {
   part.forEach(key => {
     assert.typeof(key, 'string');
-    assert(
-      whole.includes(key),
-      X`key ${q(key)} was not one of the expected keys ${q(whole)}`,
-    );
+    if (!whole.includes(key)) {
+      assert.fail(
+        X`key ${q(key)} was not one of the expected keys ${q(whole)}`,
+      );
+    }
   });
 };

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -42,10 +42,9 @@ export const makeOfferMethod = (
     // AWAIT ///
 
     const instanceAdmin = getInstanceAdmin(instance);
-    assert(
-      !instanceAdmin.isBlocked(description),
-      X`not accepting offer with description ${q(description)}`,
-    );
+    if (instanceAdmin.isBlocked(description)) {
+      assert.fail(X`not accepting offer with description ${q(description)}`);
+    }
     const { invitationHandle } = await burnInvitation(
       invitationIssuer,
       invitation,

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -78,10 +78,13 @@ export const makeStartInstance = (
     const setOfferFilter = strings => {
       assert(Array.isArray(strings), X`${q(strings)} must be an Array`);
       const proposedStrings = harden([...strings]);
-      assert(
-        proposedStrings.every(s => typeof s === 'string'),
-        X`Blocked strings (${q(proposedStrings)}) must be an Array of strings.`,
-      );
+      if (!proposedStrings.every(s => typeof s === 'string')) {
+        assert.fail(
+          X`Blocked strings (${q(
+            proposedStrings,
+          )}) must be an Array of strings.`,
+        );
+      }
 
       offerFilterStrings = proposedStrings;
     };

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/bootstrap-coveredCall-service-upgrade.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/bootstrap-coveredCall-service-upgrade.js
@@ -52,10 +52,11 @@ const depositPayout = (seat, keyword, purse, expectedAmount) => {
       return E(purse).deposit(payout);
     })
     .then(depositAmount => {
-      assert(
-        AmountMath.isEqual(depositAmount, expectedAmount),
-        X`amounts don't match: ${q(depositAmount)}, ${q(expectedAmount)}`,
-      );
+      if (!AmountMath.isEqual(depositAmount, expectedAmount)) {
+        assert.fail(
+          X`amounts don't match: ${q(depositAmount)}, ${q(expectedAmount)}`,
+        );
+      }
     });
 };
 

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -58,10 +58,11 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
   const makeOption = sellSeat => {
     fit(sellSeat.getProposal(), M.split({ exit: { afterDeadline: M.any() } }));
     const sellSeatExitRule = sellSeat.getProposal().exit;
-    assert(
-      isAfterDeadlineExitRule(sellSeatExitRule),
-      X`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`,
-    );
+    if (!isAfterDeadlineExitRule(sellSeatExitRule)) {
+      assert.fail(
+        X`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`,
+      );
+    }
 
     const exerciseOption = makeExerciser(sellSeat);
     const customProps = harden({

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -26,10 +26,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       // Bob ensures it's the contract he expects
-      assert(
-        installations.automaticRefund === installation,
-        X`should be the expected automaticRefund`,
-      );
+      if (!(installations.automaticRefund === installation)) {
+        assert.fail(X`should be the expected automaticRefund`);
+      }
 
       assert(
         issuerKeywordRecord.Contribution1 === moolaIssuer,
@@ -85,10 +84,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
       assert(installation === installations.coveredCall, X`wrong installation`);
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      if (!(optionValue[0].description === 'exerciseOption')) {
+        assert.fail(X`wrong invitation`);
+      }
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
@@ -151,10 +149,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const optionValue = optionAmounts.value;
 
       assert(installation === installations.coveredCall, X`wrong installation`);
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      if (!(optionValue[0].description === 'exerciseOption')) {
+        assert.fail(X`wrong invitation`);
+      }
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
@@ -229,10 +226,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
 
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      if (!(installation === installations.secondPriceAuction)) {
+        assert.fail(X`wrong installation`);
+      }
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -25,10 +25,9 @@ const build = async (log, zoe, issuers, payments, installations) => {
         invitation,
       );
 
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      if (!(installation === installations.secondPriceAuction)) {
+        assert.fail(X`wrong installation`);
+      }
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -26,10 +26,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
 
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      if (!(installation === installations.secondPriceAuction)) {
+        assert.fail(X`wrong installation`);
+      }
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
@@ -93,16 +92,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       // Dave expects that Bob has already made an offer in the swap
       // with the following rules:
-      assert(
-        keyEQ(invitationValue[0].asset, optionAmounts),
-        X`asset is the option`,
-      );
+      if (!keyEQ(invitationValue[0].asset, optionAmounts)) {
+        assert.fail(X`asset is the option`);
+      }
       assert(keyEQ(invitationValue[0].price, bucks(1n)), X`price is 1 buck`);
       const optionValue = optionAmounts.value;
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      if (!(optionValue[0].description === 'exerciseOption')) {
+        assert.fail(X`wrong invitation`);
+      }
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -56,10 +56,9 @@ const start = async zcf => {
       });
       assertProposalShape(bountySeat, feeProposal);
       const feeAmount = bountySeat.getCurrentAllocation().Fee;
-      assert(
-        AmountMath.isGTE(feeAmount, fee),
-        X`Fee was required to be at least ${fee}`,
-      );
+      if (!AmountMath.isGTE(feeAmount, fee)) {
+        assert.fail(X`Fee was required to be at least ${fee}`);
+      }
 
       // The funder gets the fee regardless of the outcome.
       funderSeat.incrementBy(

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -40,10 +40,9 @@ const start = zcf => {
 
   // We assume the only valid responses are 'YES' and 'NO'
   const assertResponse = response => {
-    assert(
-      response === 'NO' || response === 'YES',
-      X`the answer ${q(response)} was not 'YES' or 'NO'`,
-    );
+    if (!(response === 'NO' || response === 'YES')) {
+      assert.fail(X`the answer ${q(response)} was not 'YES' or 'NO'`);
+    }
     // Throw an error if the response is not valid, but do not
     // exit the seat. We should allow the voter to recast their vote.
   };

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -65,10 +65,9 @@ test.before(
           let requiredFee;
           if (query.kind === 'Paid') {
             requiredFee = feeAmount;
-            assert(
-              AmountMath.isGTE(fee, requiredFee),
-              X`Minimum fee of ${feeAmount} not met; have ${fee}`,
-            );
+            if (!AmountMath.isGTE(fee, requiredFee)) {
+              assert.fail(X`Minimum fee of ${feeAmount} not met; have ${fee}`);
+            }
           }
           const reply = { pong: query };
           return harden({ reply, requiredFee });

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -46,10 +46,11 @@ const start = zcf => {
         assert(amountToColor);
         // Ensure that the amount of pixels that we want to color is
         // covered by what is actually escrowed.
-        assert(
-          AmountMath.isGTE(escrowedAmount, amountToColor),
-          X`The pixels to color were not all escrowed. Currently escrowed: ${escrowedAmount}, amount to color: ${amountToColor}`,
-        );
+        if (!AmountMath.isGTE(escrowedAmount, amountToColor)) {
+          assert.fail(
+            X`The pixels to color were not all escrowed. Currently escrowed: ${escrowedAmount}, amount to color: ${amountToColor}`,
+          );
+        }
 
         // Pretend to color
         return `successfully colored ${amountToColor.value} pixels ${color}`;


### PR DESCRIPTION
When tracing code in the debugger, I'm always surprised about how many steps it takes to walk through an assert is I single step all the way. For multiline `assert(` calls, the `if` form with an `assert.fail(` is about the same number of lines, sometimes a bit more, sometimes a bit less. (Altogether, the PR is a net reduction in lines of code.) It is *less* readable than the simple `assert(` because of the inversion of the condition. But it does skip all the 
```js
X`...${q(expr)}...`
```
in the success case, which is the only case where we might care about performance. Would it make a significant difference? A difference big enough to pay the cost of reduced readability? We won't know until we measure. Hence this WIP draft PR.