### PR TITLE
feat: PSM-only bootstrap

### DIFF
--- a/packages/SwingSet/src/devices/mailbox/device-mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox/device-mailbox.js
@@ -63,6 +63,10 @@ export function buildRootDeviceNode(tools) {
       setDeviceState(harden({ inboundHandler }));
     },
 
+    unregisterInboundHander() {
+      inboundHandler = undefined;
+    },
+
     add(peer, msgnum, body) {
       try {
         endowments.add(`${peer}`, Nat(msgnum), `${body}`);

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -144,6 +144,11 @@ scenario2-run-chain-economy: t1/decentral-economy-config.json
 		OTEL_EXPORTER_PROMETHEUS_PORT=$(OTEL_EXPORTER_PROMETHEUS_PORT) \
 		$(AGC) --home=t1/n0 start --log_level=warn $(AGC_START_ARGS)
 
+scenario2-run-chain-psm: ../vats/decentral-psm-config.json
+	CHAIN_BOOTSTRAP_VAT_CONFIG="$$PWD/../vats/decentral-psm-config.json" \
+		OTEL_EXPORTER_PROMETHEUS_PORT=$(OTEL_EXPORTER_PROMETHEUS_PORT) \
+		$(AGC) --home=t1/n0 start --log_level=warn $(AGC_START_ARGS)
+
 scenario2-run-chain:
 	OTEL_EXPORTER_PROMETHEUS_PORT=$(OTEL_EXPORTER_PROMETHEUS_PORT) \
 		$(AGC) --home=t1/n0 start --log_level=warn $(AGC_START_ARGS)

--- a/packages/inter-protocol/scripts/build-bundles.js
+++ b/packages/inter-protocol/scripts/build-bundles.js
@@ -1,6 +1,9 @@
 #! /usr/bin/env node
 import '@endo/init';
-import { extractProposalBundles } from '@agoric/deploy-script-support';
+import {
+  createBundles,
+  extractProposalBundles,
+} from '@agoric/deploy-script-support';
 import url from 'url';
 import process from 'process';
 
@@ -16,5 +19,10 @@ await extractProposalBundles(
     ['.', defaultProposalBuilder],
     ['.', collateralProposalBuilder],
   ],
+  dirname,
+);
+
+await createBundles(
+  [['../src/psm/psm.js', '../bundles/bundle-psm.js']],
   dirname,
 );

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -9,7 +9,7 @@ export * from './sim-behaviors.js';
 // named 'EconomyBootstrapPowers'.
 export * from './startPSM.js';
 
-const ECON_COMMITTEE_MANIFEST = harden({
+export const ECON_COMMITTEE_MANIFEST = harden({
   [econBehaviors.startEconomicCommittee.name]: {
     consume: {
       board: true,

--- a/packages/vats/decentral-psm-config.json
+++ b/packages/vats/decentral-psm-config.json
@@ -1,0 +1,56 @@
+{
+  "bootstrap": "bootstrap",
+  "defaultReapInterval": 1000,
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "@agoric/vats/src/core/boot-psm.js",
+      "parameters": {
+        "anchorAssets": [
+          {
+            "denom": "ibc/usdc1234"
+          }
+        ],
+        "economicCommitteeAddresses": []
+      }
+    }
+  },
+  "bundles": {
+    "walletFactory": {
+      "sourceSpec": "@agoric/wallet/contract/src/walletFactory.js"
+    },
+    "committee": {
+      "sourceSpec": "@agoric/governance/src/committee.js"
+    },
+    "contractGovernor": {
+      "sourceSpec": "@agoric/governance/src/contractGovernor.js"
+    },
+    "binaryVoteCounter": {
+      "sourceSpec": "@agoric/governance/src/binaryVoteCounter.js"
+    },
+    "psm": {
+      "sourceSpec": "@agoric/inter-protocol/src/psm/psm.js"
+    },
+    "bank": {
+      "sourceSpec": "@agoric/vats/src/vat-bank.js"
+    },
+    "centralSupply": {
+      "sourceSpec": "@agoric/vats/src/centralSupply.js"
+    },
+    "mintHolder": {
+      "sourceSpec": "@agoric/vats/src/mintHolder.js"
+    },
+    "board": {
+      "sourceSpec": "@agoric/vats/src/vat-board.js"
+    },
+    "chainStorage": {
+      "sourceSpec": "@agoric/vats/src/vat-chainStorage.js"
+    },
+    "zcf": {
+      "sourceSpec": "@agoric/zoe/contractFacet.js"
+    },
+    "zoe": {
+      "sourceSpec": "@agoric/vats/src/vat-zoe.js"
+    }
+  },
+  "defaultManagerType": "xs-worker"
+}

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -21,6 +21,8 @@ const RESERVE_ADDRESS = 'agoric1ae0lmtzlgrcnla9xjkpaarq5d5dfez63h3nucl';
 /**
  * non-exhaustive list of powerFlags
  * REMOTE_WALLET is currently a default.
+ *
+ * See also MsgProvision in golang/cosmos/proto/agoric/swingset/msgs.proto
  */
 export const PowerFlags = /** @type {const} */ ({
   SMART_WALLET: 'SMART_WALLET',

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -1,0 +1,223 @@
+// @ts-check
+import { Far } from '@endo/far';
+import {
+  installGovAndPSMContracts,
+  makeAnchorAsset,
+  startPSM,
+  PSM_MANIFEST,
+} from '@agoric/inter-protocol/src/proposals/startPSM.js';
+// TODO: factor startEconomicCommittee out of econ-behaviors.js
+import { startEconomicCommittee } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
+import { ECON_COMMITTEE_MANIFEST } from '@agoric/inter-protocol/src/proposals/core-proposal.js';
+import { makeAgoricNamesAccess, makePromiseSpace } from './utils.js';
+import { Stable, Stake } from '../tokens.js';
+import {
+  addBankAssets,
+  buildZoe,
+  installBootContracts,
+  makeAddressNameHubs,
+  makeBoard,
+  makeVatsFromBundles,
+  mintInitialSupply,
+} from './basic-behaviors.js';
+import * as utils from './utils.js';
+import {
+  bridgeCoreEval,
+  makeBridgeManager,
+  makeChainStorage,
+  publishAgoricNames,
+  startTimerService,
+} from './chain-behaviors.js';
+import { CHAIN_BOOTSTRAP_MANIFEST } from './manifest.js';
+import {
+  startWalletFactory,
+  WALLET_FACTORY_MANIFEST,
+} from './startWalletFactory.js';
+
+/** @typedef {import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace} EconomyBootstrapSpace */
+
+/**
+ * PSM and gov contracts are available as
+ * named swingset bundles only in
+ * decentral-psm-config.json
+ */
+const PSM_GOV_INSTALL_MANIFEST = {
+  [installGovAndPSMContracts.name]: {
+    vatPowers: { D: true },
+    devices: { vatAdmin: true },
+    consume: { zoe: 'zoe' },
+    installation: {
+      produce: {
+        contractGovernor: 'zoe',
+        committee: 'zoe',
+        binaryVoteCounter: 'zoe',
+        psm: 'zoe',
+      },
+    },
+  },
+};
+
+/**
+ * We reserve these keys in name hubs.
+ */
+export const agoricNamesReserved = harden(
+  /** @type {const} */ ({
+    issuer: {
+      [Stake.symbol]: Stake.proposedName,
+      [Stable.symbol]: Stable.proposedName,
+      AUSD: 'Agoric bridged USDC',
+    },
+    brand: {
+      [Stake.symbol]: Stake.proposedName,
+      [Stable.symbol]: Stable.proposedName,
+      AUSD: 'Agoric bridged USDC',
+    },
+    installation: {
+      centralSupply: 'central supply',
+      mintHolder: 'mint holder',
+      walletFactory: 'multitenant smart wallet',
+      contractGovernor: 'contract governor',
+      committee: 'committee electorate',
+      binaryVoteCounter: 'binary vote counter',
+      psm: 'Parity Stability Module',
+    },
+    instance: {
+      economicCommittee: 'Economic Committee',
+      psm: 'Parity Stability Module',
+      psmGovernor: 'PSM Governor',
+    },
+  }),
+);
+
+/**
+ * Build root object of the PSM-only bootstrap vat.
+ *
+ * @param {{
+ *   D: DProxy
+ * }} vatPowers
+ * @param {{
+ *     economicCommitteeAddresses: string[],
+ *     anchorAssets: { denom: string }[],
+ * }} vatParameters
+ */
+export const buildRootObject = (vatPowers, vatParameters) => {
+  // @ts-expect-error no TS defs for rickety test scaffolding
+  const log = vatPowers.logger || console.info;
+
+  const {
+    anchorAssets: [{ denom: anchorDenom }], // TODO: handle >1?
+    economicCommitteeAddresses,
+  } = vatParameters;
+
+  const { produce, consume } = makePromiseSpace(log);
+  const { agoricNames, agoricNamesAdmin, spaces } = makeAgoricNamesAccess(
+    log,
+    agoricNamesReserved,
+  );
+  produce.agoricNames.resolve(agoricNames);
+  produce.agoricNamesAdmin.resolve(agoricNamesAdmin);
+
+  const runBootstrapParts = async (vats, devices) => {
+    /** TODO: BootstrapPowers type puzzle */
+    /** @type { any } */
+    const allPowers = harden({
+      vatPowers,
+      vatParameters,
+      vats,
+      devices,
+      produce,
+      consume,
+      ...spaces,
+      // ISSUE: needed? runBehaviors,
+      // These module namespaces might be useful for core eval governance.
+      modules: {
+        utils: { ...utils },
+      },
+    });
+    const manifest = {
+      ...CHAIN_BOOTSTRAP_MANIFEST,
+      ...WALLET_FACTORY_MANIFEST,
+      ...PSM_GOV_INSTALL_MANIFEST,
+      ...ECON_COMMITTEE_MANIFEST,
+      ...PSM_MANIFEST,
+    };
+    const powersFor = name => {
+      const permit = manifest[name];
+      assert(permit, `missing permit for ${name}`);
+      return utils.extractPowers(permit, allPowers);
+    };
+
+    await Promise.all([
+      makeVatsFromBundles(powersFor('makeVatsFromBundles')),
+      buildZoe(powersFor('buildZoe')),
+      makeBoard(powersFor('makeBoard')),
+      makeBridgeManager(powersFor('makeBridgeManager')),
+      makeChainStorage(powersFor('makeChainStorage')),
+      makeAddressNameHubs(powersFor('makeAddressNameHubs')),
+      publishAgoricNames(powersFor('publishAgoricNames'), {
+        options: {
+          agoricNamesOptions: { topLevel: Object.keys(agoricNamesReserved) },
+        },
+      }),
+      startWalletFactory(powersFor('startWalletFactory')),
+      mintInitialSupply(powersFor('mintInitialSupply')),
+      addBankAssets(powersFor('addBankAssets')),
+      startTimerService(powersFor('startTimerService')),
+      // centralSupply, mintHolder, walletFactory
+      installBootContracts(powersFor('installBootContracts')),
+      installGovAndPSMContracts(powersFor('installGovAndPSMContracts')),
+      startEconomicCommittee(powersFor('startEconomicCommittee'), {
+        options: {
+          econCommitteeOptions: {
+            committeeSize: economicCommitteeAddresses.length,
+          },
+        },
+      }),
+      makeAnchorAsset(powersFor('makeAnchorAsset'), {
+        options: { anchorOptions: { denom: anchorDenom } },
+      }),
+      startPSM(powersFor('startPSM'), {
+        options: { anchorOptions: { denom: anchorDenom } },
+      }),
+      // Finally, allow bootstrap powers to be granted
+      // by governance to code to be executed after initial bootstrap.
+      bridgeCoreEval(powersFor('bridgeCoreEval')),
+    ]);
+  };
+
+  return Far('bootstrap', {
+    bootstrap: (vats, devices) => {
+      const { D } = vatPowers;
+      D(devices.mailbox).registerInboundHandler(
+        Far('dummyInboundHandler', { deliverInboundMessages: () => {} }),
+      );
+
+      runBootstrapParts(vats, devices).catch(e => {
+        console.error('BOOTSTRAP FAILED:', e);
+        throw e;
+      });
+    },
+    /**
+     * Allow kernel to provide things to CORE_EVAL.
+     *
+     * @param {string} name
+     * @param {unknown} resolution
+     */
+    produceItem: (name, resolution) => {
+      assert.typeof(name, 'string');
+      produce[name].resolve(resolution);
+    },
+    // expose reset in case we need to do-over
+    resetItem: name => {
+      assert.typeof(name, 'string');
+      produce[name].reset();
+    },
+    // expose consume mostly for testing
+    consumeItem: name => {
+      assert.typeof(name, 'string');
+      return consume[name];
+    },
+  });
+};
+
+harden({ buildRootObject });

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -180,8 +180,8 @@ export const buildRootObject = (vatPowers, vatParameters) => {
           options: { anchorOptions: { denom, keyword } },
         }),
       ),
-      // Finally, allow bootstrap powers to be granted
-      // by governance to code to be executed after initial bootstrap.
+      // Allow bootstrap powers to be granted by governance
+      // to code to be evaluated after initial bootstrap.
       bridgeCoreEval(powersFor('bridgeCoreEval')),
     ]);
   };

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -317,10 +317,16 @@ export const makeChainStorage = async ({
   chainStorageP.resolve(rootNodeP);
 };
 
-/** @param {BootstrapPowers} powers */
-export const publishAgoricNames = async ({
-  consume: { agoricNamesAdmin, board, chainStorage: rootP },
-}) => {
+/**
+ * @param {BootstrapPowers} powers
+ * @param {{ options?: {agoricNamesOptions?: {
+ *   topLevel?: string[]
+ * }}}} config
+ */
+export const publishAgoricNames = async (
+  { consume: { agoricNamesAdmin, board, chainStorage: rootP } },
+  { options: { agoricNamesOptions } = {} } = {},
+) => {
   const root = await rootP;
   if (!root) {
     console.warn('cannot publish agoricNames without chainStorage');
@@ -330,8 +336,9 @@ export const publishAgoricNames = async ({
   const marshaller = E(board).getPublishingMarshaller();
 
   // brand, issuer, ...
+  const { topLevel = keys(agoricNamesReserved) } = agoricNamesOptions || {};
   await Promise.all(
-    keys(agoricNamesReserved).map(async kind => {
+    topLevel.map(async kind => {
       const kindAdmin = await E(agoricNamesAdmin).lookupAdmin(kind);
 
       const kindNode = await E(nameStorage).makeChildNode(kind);

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -1,0 +1,135 @@
+// @ts-check
+import { E, Far } from '@endo/far';
+import { deeplyFulfilled } from '@endo/marshal';
+
+import * as BRIDGE_ID from '../bridge-ids.js';
+import { makeStorageNodeChild } from '../lib-chainStorage.js';
+import { makeMyAddressNameAdmin, PowerFlags } from './basic-behaviors.js';
+
+const { details: X } = assert;
+
+/**
+ * @param {ERef<ZoeService>} zoe
+ * @param {Installation<import('@agoric/smart-wallet/src/walletFactory').start>} inst
+ * @typedef {Awaited<ReturnType<typeof startFactoryInstance>>} WalletFactoryStartResult
+ */
+// eslint-disable-next-line no-unused-vars
+const startFactoryInstance = (zoe, inst) => E(zoe).startInstance(inst);
+
+/**
+ * Register for PLEASE_PROVISION bridge messages and handle
+ * them by providing a smart wallet from the wallet factory.
+ *
+ * @param {BootstrapPowers} param0
+ */
+export const startWalletFactory = async ({
+  consume: {
+    agoricNames,
+    bankManager,
+    board,
+    bridgeManager: bridgeManagerP,
+    chainStorage,
+    namesByAddress,
+    namesByAddressAdmin: namesByAddressAdminP,
+    zoe,
+  },
+  produce: { client, walletFactoryStartResult },
+  installation: {
+    consume: { walletFactory },
+  },
+}) => {
+  const STORAGE_PATH = 'wallet';
+
+  const [storageNode, bridgeManager, namesByAddressAdmin] = await Promise.all([
+    makeStorageNodeChild(chainStorage, STORAGE_PATH),
+    bridgeManagerP,
+    namesByAddressAdminP,
+  ]);
+
+  const terms = await deeplyFulfilled(
+    harden({
+      agoricNames,
+      namesByAddress,
+      board,
+    }),
+  );
+  /** @type {WalletFactoryStartResult} */
+  const x = await E(zoe).startInstance(walletFactory, {}, terms, {
+    storageNode,
+    bridgeManager,
+  });
+  walletFactoryStartResult.resolve(x);
+  const { creatorFacet } = x;
+
+  /** @param {string} address */
+  const tryLookup = async address =>
+    E(namesByAddress)
+      .lookup(address)
+      .catch(_notFound => undefined);
+
+  const handler = Far('provisioningHandler', {
+    fromBridge: async (_srcID, obj) => {
+      assert.equal(
+        obj.type,
+        'PLEASE_PROVISION',
+        X`Unrecognized request ${obj.type}`,
+      );
+      const { address, powerFlags } = obj;
+      console.info('PLEASE_PROVISION', address, powerFlags);
+
+      const hubBefore = await tryLookup(address);
+      assert(!hubBefore, 'already provisioned');
+
+      if (!powerFlags.includes(PowerFlags.SMART_WALLET)) {
+        return;
+      }
+      const myAddressNameAdmin = makeMyAddressNameAdmin(
+        namesByAddressAdmin,
+        address,
+      );
+
+      const bank = E(bankManager).getBankForAddress(address);
+      await E(creatorFacet).provideSmartWallet(
+        address,
+        bank,
+        myAddressNameAdmin,
+      );
+      console.info('provisioned', address, powerFlags);
+    },
+  });
+  if (!bridgeManager) {
+    console.warn('missing bridgeManager in startWalletFactory');
+  }
+  await (bridgeManager &&
+    E(bridgeManager).register(BRIDGE_ID.PROVISION, handler));
+
+  client.resolve(
+    Far('dummy client', {
+      assignBundle: (propertyMakers = []) => {
+        console.warn('ignoring', propertyMakers.length, 'propertyMakers');
+      },
+    }),
+  );
+};
+
+export const WALLET_FACTORY_MANIFEST = {
+  [startWalletFactory.name]: {
+    consume: {
+      agoricNames: true,
+      bankManager: 'bank',
+      board: 'board',
+      bridgeManager: true,
+      chainStorage: 'chainStorage',
+      namesByAddress: true,
+      namesByAddressAdmin: true,
+      zoe: 'zoe',
+    },
+    produce: {
+      client: true, // dummy client in this configuration
+      walletFactoryStartResult: true,
+    },
+    installation: {
+      consume: { walletFactory: 'zoe' },
+    },
+  },
+};

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -215,6 +215,7 @@
  *   priceAuthority: PriceAuthority,
  *   priceAuthorityAdmin: PriceAuthorityRegistryAdmin,
  *   provisioning: Awaited<ProvisioningVat>,
+ *   walletFactoryStartResult: import('./startWalletFactory').WalletFactoryStartResult,
  *   zoe: ZoeService,
  * }>} ChainBootstrapSpace
  *

--- a/packages/vats/test/devices.js
+++ b/packages/vats/test/devices.js
@@ -1,24 +1,31 @@
+import bundleCommittee from '@agoric/governance/bundles/bundle-committee.js';
+import bundleContractGovernor from '@agoric/governance/bundles/bundle-contractGovernor.js';
+import bundleBinaryVoteCounter from '@agoric/governance/bundles/bundle-binaryVoteCounter.js';
+import bundlePSM from '@agoric/inter-protocol/bundles/bundle-psm.js';
+
 import bundleCentralSupply from '../bundles/bundle-centralSupply.js';
 import bundleMintHolder from '../bundles/bundle-mintHolder.js';
 import bundleSingleWallet from '../bundles/bundle-singleWallet.js';
 import bundleWalletFactory from '../bundles/bundle-walletFactory.js';
 
+const bundles = {
+  centralSupply: bundleCentralSupply,
+  mintHolder: bundleMintHolder,
+  singleWallet: bundleSingleWallet,
+  walletFactory: bundleWalletFactory,
+  committee: bundleCommittee,
+  contractGovernor: bundleContractGovernor,
+  binaryVoteCounter: bundleBinaryVoteCounter,
+  psm: bundlePSM,
+};
+
 export const devices = {
   vatAdmin: {
     getNamedBundleCap: name => ({
       getBundle: () => {
-        switch (name) {
-          case 'centralSupply':
-            return bundleCentralSupply;
-          case 'mintHolder':
-            return bundleMintHolder;
-          case 'singleWallet':
-            return bundleSingleWallet;
-          case 'walletFactory':
-            return bundleWalletFactory;
-          default:
-            throw new Error(`unknown bundle ${name}`);
-        }
+        const bundle = bundles[name];
+        assert(bundle, `unknown bundle ${name}`);
+        return bundle;
       },
     }),
   },

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -1,7 +1,7 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import { E, Far } from '@endo/far';
+import { E, Far, passStyleOf } from '@endo/far';
 import bundleSource from '@endo/bundle-source';
 import {
   makeFakeVatAdmin,
@@ -11,6 +11,7 @@ import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 
 import { makeZoeKit } from '@agoric/zoe';
 import { buildRootObject } from '../src/core/boot.js';
+import { buildRootObject as buildPSMRootObject } from '../src/core/boot-psm.js';
 import { bridgeCoreEval } from '../src/core/chain-behaviors.js';
 import { makePromiseSpace } from '../src/core/utils.js';
 import { buildRootObject as bankRoot } from '../src/vat-bank.js';
@@ -78,6 +79,52 @@ const makeMock = t =>
       }),
     },
   });
+
+const mockSwingsetVats = mock => {
+  const { admin: fakeVatAdmin } = makeFakeVatAdmin(() => {});
+  const fakeBundleCaps = new Map(); // {} -> name
+  const getNamedBundleCap = name => {
+    const bundleCap = harden({});
+    fakeBundleCaps.set(bundleCap, name);
+    return bundleCap;
+  };
+
+  const createVat = (bundleCap, options) => {
+    const name = fakeBundleCaps.get(bundleCap);
+    assert(name);
+    switch (name) {
+      case 'zcf':
+        return fakeVatAdmin.createVat(zcfBundleCap, options);
+      default: {
+        const buildRoot = vatRoots[name];
+        if (!buildRoot) {
+          throw Error(`TODO: load vat ${name}`);
+        }
+        const vatParameters = { ...options?.vatParameters };
+        if (name === 'zoe') {
+          // basic-behaviors.js:buildZoe() provides hard-coded zcf BundleName
+          // and vat-zoe.js ignores vatParameters, but this would be the
+          // preferred way to pass the name.
+          vatParameters.zcfBundleName = 'zcf';
+        }
+        return { root: buildRoot({}, vatParameters), admin: {} };
+      }
+    }
+  };
+  const createVatByName = name => {
+    const bundleCap = getNamedBundleCap(name);
+    return createVat(bundleCap);
+  };
+
+  const vats = {
+    ...mock.vats,
+    vatAdmin: /** @type { any } */ ({
+      createVatAdminService: () =>
+        Far('vatAdminSvc', { getNamedBundleCap, createVat, createVatByName }),
+    }),
+  };
+  return vats;
+};
 
 const argvByRole = {
   chain: {
@@ -222,6 +269,45 @@ test('bootstrap provides a way to pass items to CORE_EVAL', async t => {
     // @ts-expect-error Device<T> is a little goofy
     { D: d => d, logger: t.log },
     { argv: argvByRole.chain, governanceActions: false },
+  );
+
+  await E(root).produceItem('swissArmyKnife', [1, 2, 3]);
+  t.deepEqual(await E(root).consumeItem('swissArmyKnife'), [1, 2, 3]);
+  await E(root).resetItem('swissArmyKnife');
+  await E(root).produceItem('swissArmyKnife', 4);
+  t.deepEqual(await E(root).consumeItem('swissArmyKnife'), 4);
+});
+
+const psmParams = {
+  anchorAssets: [{ denom: 'ibc/toyusdc' }],
+  economicCommitteeAddresses: [],
+  argv: { bootMsg: {} },
+};
+
+test(`PSM-only bootstrap`, async t => {
+  const mock = makeMock(t);
+  const root = buildPSMRootObject(
+    // @ts-expect-error Device<T> is a little goofy
+    { D: d => d, logger: t.log },
+    psmParams,
+  );
+
+  const vats = mockSwingsetVats(mock);
+  const actual = await E(root).bootstrap(vats, mock.devices);
+  t.deepEqual(actual, undefined);
+
+  const agoricNames = /** @type {Promise<NameHub>} */ (
+    E(root).consumeItem('agoricNames')
+  );
+  const instance = await E(agoricNames).lookup('instance', 'psm');
+  t.is(passStyleOf(instance), 'remotable');
+});
+
+test('PSM-only bootstrap provides a way to pass items to CORE_EVAL', async t => {
+  const root = buildPSMRootObject(
+    // @ts-expect-error Device<T> is a little goofy
+    { D: d => d, logger: t.log },
+    psmParams,
   );
 
   await E(root).produceItem('swissArmyKnife', [1, 2, 3]);


### PR DESCRIPTION
closes: #6009

## Description

`boot-psm.js` is an alternative to `packages/vats/src/core/boot.js` that runs all and only the bootstrap behaviors necessary to start the PSM, along with the smart wallet.

 - [x] TODO: `decentral-psm-config.json`

### Security Considerations

In order to simplify security review, where `boot.js` does dynamic function name lookup from `manifest.js` and simulates CORE_EVAL proposals, `boot-psm.js` makes statically-evident imports and function calls.

 - [x] TODO: attenuate `allPowers` on a per-call basis
 - [x] TODO: factor startEconomicCommittee out of econ-behaviors.js

### Documentation Considerations

?

`decentral-psm-config.json` should provide one form of documentation.

 - [ ] TODO: manifest visualization
 - visualization of slogfile
    - [x]  from running bootstrap
    - [ ] doing a trade

### Testing Considerations

 - [x] minimal unit testing
 - [x] integration testing with `local-chain` (`make scenario2-run-chain-psm`) and smart wallet (`psm-tool.js`)
 - [ ] test that important parts of `CORE_EVAL` were not left out somehow
