### PR TITLE
fix(swingset): don't un-expose 'gc', to stop intermittent test failures

### DIFF
--- a/packages/SwingSet/src/lib-nodejs/engine-gc.js
+++ b/packages/SwingSet/src/lib-nodejs/engine-gc.js
@@ -7,8 +7,13 @@ if (typeof bestGC !== 'function') {
   // Node.js v8 wizardry.
   v8.setFlagsFromString('--expose_gc');
   bestGC = vm.runInNewContext('gc');
-  // Hide the gc global from new contexts/workers.
-  v8.setFlagsFromString('--no-expose_gc');
+  // We leave --expose_gc turned on, otherwise AVA's shared workers
+  // may race and disable it before we manage to extract the
+  // binding. This won't cause 'gc' to be visible to new Compartments
+  // because SES strips out everything it doesn't recognize.
+
+  // // Hide the gc global from new contexts/workers.
+  // v8.setFlagsFromString('--no-expose_gc');
 }
 
 // Export a const.


### PR DESCRIPTION
engine-gc.js acquires the `gc()` function (to force garbage
collection) on Node.js by turning on the (global) `--expose_gc` V8
flag, then evaluating code within a new context (because the original
one might not have had `--expose_gc` turned on), stashing the `gc`
global, then uses `--no-expose_gc` to hide it again.

It seems that AVA's worker-based parallelism approach causes multiple
calls to this routine within the same process, sharing a V8
instance. So there's a race between one worker doing
enable/stash/disable and another. If they interleave, a "stash" might
happen while the symbol is disabled, causing a Reference Error and a
crash.

closes #6028
