### PR TITLE
ci(mergify): don't rely on local-npm integration to pass

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,15 +12,16 @@ queue_rules:
       - or:
           - label=bypass:integration
           - check-skipped=getting-started
-          - and:
-              - or:
-                  - check-success=getting-started (link-cli)
-                  - check-neutral=getting-started (link-cli)
-                  - check-skipped=getting-started (link-cli)
-              - or:
-                  - check-success=getting-started (local-npm)
-                  - check-neutral=getting-started (local-npm)
-                  - check-skipped=getting-started (local-npm)
+          - check-success=getting-started (link-cli)
+          - check-neutral=getting-started (link-cli)
+          - check-skipped=getting-started (link-cli)
+      # FIXME: Enable this section to validate NPM deploys...
+      #- or:
+      #    - label=bypass:integration
+      #    - check-skipped=getting-started
+      #    - check-success=getting-started (local-npm)
+      #    - check-neutral=getting-started (local-npm)
+      #    - check-skipped=getting-started (local-npm)
 
 pull_request_rules:
   - name: merge to master


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

Refs: #5970

## Description

At least until we have made our NPM release story more coherent, tolerate failures of the `local-npm` integration test so that they don't stall Mergify.

We don't recommend using `bypass:integration` for many of these cases since that bypasses valuable deployment and `link-cli` integration testing.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
