### PR TITLE
store econ committee questions off-chain

### DIFF
--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -324,3 +324,35 @@ changes to contract parameters. There should also be managers that
   passes.
 * manage a plebiscite among stake holders to allow participants to express
   opinions about the future of the chain.
+
+## Reading data off-chain
+
+Governed contracts publish along with the contract they're governing. See [../inter-protocol/README.md].
+
+Committee contracts also publish the questions posed. These can then be followed off-chain like so,
+```js
+  const key = `published.committee.questions`; // or whatever the stream of interest is
+  const leader = makeDefaultLeader();
+  const follower = makeFollower(storeKey, leader);
+  for await (const { value } of iterateLatest(follower)) {
+    console.log(`here's a value`, value);
+  }
+```
+
+### Demo
+
+Start the chain in one terminal:
+```sh
+cd packages/cosmic-swingset
+make scenario2-setup scenario2-run-chain-economy
+```
+Once you see a string like `block 17 commit` then the chain is available. In another terminal,
+```sh
+# shows keys of the committees node
+agd query vstorage keys 'published.committees'
+# shows keys of the initial economic committee node
+agd query vstorage keys 'published.committees.Initial_Economic_Committee'
+# follow questions
+agoric follow :published.committees.Initial_Economic_Committee.latestQuestion
+```
+Note that there won't be `'published.committees.Initial_Economic_Committee.latestQuestion` until some `.addQuestion()` call executes.

--- a/packages/governance/docs/coreArchitecture.puml
+++ b/packages/governance/docs/coreArchitecture.puml
@@ -25,7 +25,7 @@ package "Electorate Vat" <<Rectangle>>  {
         terms: committeeSize, committeeName
         --
         Questions[]
-        +getQuestionSubscription()
+        +getQuestionSubscriber()
         +getOpenQuestions()
         +getQuestion(questionHandle)
         #getVoterInvitation(): (via some mechanism)

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -36,6 +36,7 @@
     "@agoric/notifier": "^0.4.0",
     "@agoric/store": "^0.7.2",
     "@agoric/vat-data": "^0.3.1",
+    "@agoric/vats": "^0.10.0",
     "@agoric/zoe": "^0.24.0",
     "@endo/captp": "^2.0.9",
     "@endo/eventual-send": "^0.15.5",

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -44,8 +44,6 @@ const start = (zcf, privateArgs) => {
       E(privateArgs.storageNode).makeChildNode('latestQuestion'),
       privateArgs.marshaller,
     );
-  // @ts-expect-error at first, no latest question but every other call must provide QuestionDetails
-  questionsPublisher.publish(undefined);
 
   const makeCommitteeVoterInvitation = index => {
     /** @type {OfferHandler} */

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -2,7 +2,7 @@
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeSubscriptionKit } from '@agoric/notifier';
+import { makePublishKit } from '@agoric/notifier';
 import { makeStore } from '@agoric/store';
 import { natSafeMath } from '@agoric/zoe/src/contractSupport/index.js';
 
@@ -34,7 +34,7 @@ const { ceilDivide } = natSafeMath;
 const start = zcf => {
   /** @type {Store<Handle<'Question'>, QuestionRecord>} */
   const allQuestions = makeStore('Question');
-  const { subscription, publication } = makeSubscriptionKit();
+  const { subscriber, publisher } = makePublishKit();
 
   const makeCommitteeVoterInvitation = index => {
     /** @type {OfferHandler} */
@@ -88,13 +88,13 @@ const start = zcf => {
       quorumThreshold(questionSpec.quorumRule),
       voteCounter,
       allQuestions,
-      publication,
+      publisher,
     );
   };
 
   /** @type {CommitteeElectoratePublic} */
   const publicFacet = Far('publicFacet', {
-    getQuestionSubscription: () => subscription,
+    getQuestionSubscriber: () => subscriber,
     getOpenQuestions: () => getOpenQuestions(allQuestions),
     getName: () => committeeName,
     getInstance: zcf.getInstance,
@@ -106,7 +106,7 @@ const start = zcf => {
     getPoserInvitation: () => getPoserInvitation(zcf, addQuestion),
     addQuestion,
     getVoterInvitations: () => invitations,
-    getQuestionSubscription: () => subscription,
+    getQuestionSubscriber: () => subscriber,
     getPublicFacet: () => publicFacet,
   });
 

--- a/packages/governance/src/electorateTools.js
+++ b/packages/governance/src/electorateTools.js
@@ -14,7 +14,7 @@ const startCounter = async (
   quorumThreshold,
   voteCounter,
   questionStore,
-  publication,
+  publisher,
 ) => {
   const voteCounterTerms = {
     questionSpec,
@@ -29,7 +29,7 @@ const startCounter = async (
   ).startInstance(voteCounter, {}, voteCounterTerms);
   const details = await E(publicFacet).getDetails();
   const { deadline } = questionSpec.closingRule;
-  publication.updateState(details);
+  publisher.publish(details);
   const questionHandle = details.questionHandle;
 
   const voteCounterFacets = { voteCap: creatorFacet, publicFacet, deadline };

--- a/packages/governance/src/internalTypes.js
+++ b/packages/governance/src/internalTypes.js
@@ -12,6 +12,6 @@
  * @param {unknown} quorumThreshold
  * @param {ERef<Installation>} voteCounter
  * @param {Store<Handle<'Question'>, QuestionRecord>} questionStore
- * @param {IterationObserver<unknown>} publication
+ * @param {Publisher<unknown>} publisher
  * @returns {AddQuestionReturn}
  */

--- a/packages/governance/src/noActionElectorate.js
+++ b/packages/governance/src/noActionElectorate.js
@@ -1,7 +1,7 @@
 // @ts-check
 
+import { makePublishKit } from '@agoric/notifier';
 import { Far } from '@endo/marshal';
-import { makeSubscriptionKit } from '@agoric/notifier';
 import { makePromiseKit } from '@endo/promise-kit';
 
 /**
@@ -11,10 +11,10 @@ import { makePromiseKit } from '@endo/promise-kit';
  *  @type {ContractStartFn<ElectoratePublic, ElectorateCreatorFacet>}
  */
 const start = zcf => {
-  const { subscription } = makeSubscriptionKit();
+  const { subscriber } = makePublishKit();
 
   const publicFacet = Far('publicFacet', {
-    getQuestionSubscription: () => subscription,
+    getQuestionSubscriber: () => subscriber,
     getOpenQuestions: () => {
       /** @type {Handle<'Question'>[]} */
       const noQuestions = [];
@@ -40,7 +40,7 @@ const start = zcf => {
     getVoterInvitations: () => {
       throw Error(`No Action Electorate doesn't have invitations.`);
     },
-    getQuestionSubscription: () => subscription,
+    getQuestionSubscriber: () => subscriber,
     getPublicFacet: () => publicFacet,
   });
 

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -233,7 +233,7 @@
 
 /**
  * @typedef {object} ElectoratePublic
- * @property {() => Subscription<QuestionDetails>} getQuestionSubscription
+ * @property {() => Subscriber<QuestionDetails>} getQuestionSubscriber
  * @property {GetOpenQuestions} getOpenQuestions,
  * @property {() => Instance} getInstance
  * @property {GetQuestion} getQuestion
@@ -255,7 +255,7 @@
  *  reassurance. When someone needs to connect addQuestion to the Electorate
  *  instance, getPoserInvitation() lets them get addQuestion with assurance.
  * @property {() => Promise<Invitation>} getPoserInvitation
- * @property {() => Subscription<QuestionDetails>} getQuestionSubscription
+ * @property {() => Subscriber<QuestionDetails>} getQuestionSubscriber
  * @property {() => ElectoratePublic} getPublicFacet
  */
 

--- a/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
@@ -2,6 +2,8 @@
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
+import { makeMockChainStorageRoot } from '@agoric/vats/tools/storage-test-utils.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 
 import {
@@ -56,7 +58,10 @@ const committeeBinaryStart = async (
 ) => {
   const electorateTerms = { committeeName: 'TheCommittee', committeeSize: 5 };
   const { creatorFacet: electorateFacet, instance: electorateInstance } =
-    await E(zoe).startInstance(installations.committee, {}, electorateTerms);
+    await E(zoe).startInstance(installations.committee, {}, electorateTerms, {
+      storageNode: makeMockChainStorageRoot().makeChildNode('thisElectorate'),
+      marshaller: makeBoard().getReadonlyMarshaller(),
+    });
 
   const choose = { text: 'Choose' };
   const electionType = ElectionType.SURVEY;
@@ -116,7 +121,10 @@ const committeeBinaryTwoQuestions = async (
 
   const electorateTerms = { committeeName: 'TheCommittee', committeeSize: 5 };
   const { creatorFacet: electorateFacet, instance: electorateInstance } =
-    await E(zoe).startInstance(installations.committee, {}, electorateTerms);
+    await E(zoe).startInstance(installations.committee, {}, electorateTerms, {
+      storageNode: makeMockChainStorageRoot().makeChildNode('thisElectorate'),
+      marshaller: makeBoard().getReadonlyMarshaller(),
+    });
 
   const invitations = await E(electorateFacet).getVoterInvitations();
   const details2 = await E(zoe).getInvitationDetails(invitations[2]);

--- a/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
@@ -65,65 +65,65 @@ async function main(t, argv) {
   return controller.dump();
 }
 
-const expectedCommitteeBinaryStartLog = [
-  '=> voter vat is set up',
-  '@@ schedule task for:3, currently: 0 @@',
-  'invitation details check: true Voter2',
-  'Alice voted for {"text":"Eeny"}',
-  'Bob voted for {"text":"Meeny"}',
-  'Carol voted for {"text":"Eeny"}',
-  'Dave voted for {"text":"Eeny"}',
-  'Emma voted for {"text":"Meeny"}',
-  'Seat Alice has exited',
-  'Seat Bob has exited',
-  'Seat Carol has exited',
-  'Seat Dave has exited',
-  'Seat Emma has exited',
-  'verify question from instance: {"text":"Choose"}, [{"text":"Eeny"},{"text":"Meeny"}], unranked',
-  'Verify: q: {"text":"Choose"}, max: 1, committee: TheCommittee',
-  'Verify instances: electorate: true, counter: true',
-  '@@ tick:1 @@',
-  '@@ tick:2 @@',
-  '@@ tick:3 @@',
-  'vote outcome: {"text":"Eeny"}',
-];
-
 test.serial('zoe - committee binary vote - valid inputs', async t => {
   const dump = await main(t, ['committeeBinaryStart']);
-  t.deepEqual(dump.log, expectedCommitteeBinaryStartLog);
-});
+  const expected = [
+    '=> voter vat is set up',
+    '@@ schedule task for:3, currently: 0 @@',
+    'invitation details check: true Voter2',
+    'Alice voted for {"text":"Eeny"}',
+    'Bob voted for {"text":"Meeny"}',
+    'Carol voted for {"text":"Eeny"}',
+    'Dave voted for {"text":"Eeny"}',
+    'Emma voted for {"text":"Meeny"}',
+    'Seat Alice has exited',
+    'Seat Bob has exited',
+    'Seat Carol has exited',
+    'Seat Dave has exited',
+    'Seat Emma has exited',
+    'verify question from instance: {"text":"Choose"}, [{"text":"Eeny"},{"text":"Meeny"}], unranked',
+    'Verify: q: {"text":"Choose"}, max: 1, committee: TheCommittee',
+    'Verify instances: electorate: true, counter: true',
+    '@@ tick:1 @@',
+    '@@ tick:2 @@',
+    '@@ tick:3 @@',
+    'vote outcome: {"text":"Eeny"}',
+  ];
 
-const expectedCommitteeBinaryTwoQuestionsLog = [
-  '=> voter vat is set up',
-  'starting TWO questions test',
-  'invitation details check: true Voter2',
-  '@@ schedule task for:3, currently: 0 @@',
-  'Alice voted on {"text":"Choose"} for {"text":"One Potato"}',
-  'Bob voted on {"text":"Choose"} for {"text":"One Potato"}',
-  'Carol voted on {"text":"Choose"} for {"text":"Two Potato"}',
-  'Dave voted on {"text":"Choose"} for {"text":"One Potato"}',
-  'Emma voted on {"text":"Choose"} for {"text":"One Potato"}',
-  '@@ schedule task for:4, currently: 0 @@',
-  'Alice voted on {"text":"How high?"} for {"text":"1 foot"}',
-  'Bob voted on {"text":"How high?"} for {"text":"2 feet"}',
-  'Carol voted on {"text":"How high?"} for {"text":"1 foot"}',
-  'Dave voted on {"text":"How high?"} for {"text":"1 foot"}',
-  'Emma voted on {"text":"How high?"} for {"text":"2 feet"}',
-  'verify question from instance: {"text":"Choose"}, [{"text":"One Potato"},{"text":"Two Potato"}], unranked',
-  'Verify: q: {"text":"Choose"}, max: 1, committee: TheCommittee',
-  'Verify instances: electorate: true, counter: true',
-  'verify question from instance: {"text":"How high?"}, [{"text":"1 foot"},{"text":"2 feet"}], unranked',
-  'Verify: q: {"text":"How high?"}, max: 1, committee: TheCommittee',
-  'Verify instances: electorate: true, counter: true',
-  '@@ tick:1 @@',
-  '@@ tick:2 @@',
-  '@@ tick:3 @@',
-  '@@ tick:4 @@',
-  'vote outcome: {"text":"One Potato"}',
-  'vote outcome: {"text":"1 foot"}',
-];
+  t.deepEqual(dump.log, expected, 'was:\n'.concat(dump.log.join(',\n')));
+});
 
 test.serial('zoe - committee binary vote - TwoQuestions', async t => {
   const dump = await main(t, ['committeeBinaryTwoQuestions']);
-  t.deepEqual(dump.log, expectedCommitteeBinaryTwoQuestionsLog);
+  const expected = [
+    '=> voter vat is set up',
+    'starting TWO questions test',
+    'invitation details check: true Voter2',
+    '@@ schedule task for:3, currently: 0 @@',
+    'Alice voted on {"text":"Choose"} for {"text":"One Potato"}',
+    'Bob voted on {"text":"Choose"} for {"text":"One Potato"}',
+    'Carol voted on {"text":"Choose"} for {"text":"Two Potato"}',
+    'Dave voted on {"text":"Choose"} for {"text":"One Potato"}',
+    'Emma voted on {"text":"Choose"} for {"text":"One Potato"}',
+    '@@ schedule task for:4, currently: 0 @@',
+    'Alice voted on {"text":"How high?"} for {"text":"1 foot"}',
+    'Bob voted on {"text":"How high?"} for {"text":"2 feet"}',
+    'Carol voted on {"text":"How high?"} for {"text":"1 foot"}',
+    'Dave voted on {"text":"How high?"} for {"text":"1 foot"}',
+    'Emma voted on {"text":"How high?"} for {"text":"2 feet"}',
+    'verify question from instance: {"text":"Choose"}, [{"text":"One Potato"},{"text":"Two Potato"}], unranked',
+    'Verify: q: {"text":"Choose"}, max: 1, committee: TheCommittee',
+    'Verify instances: electorate: true, counter: true',
+    'verify question from instance: {"text":"How high?"}, [{"text":"1 foot"},{"text":"2 feet"}], unranked',
+    'Verify: q: {"text":"How high?"}, max: 1, committee: TheCommittee',
+    'Verify instances: electorate: true, counter: true',
+    '@@ tick:1 @@',
+    '@@ tick:2 @@',
+    '@@ tick:3 @@',
+    '@@ tick:4 @@',
+    'vote outcome: {"text":"One Potato"}',
+    'vote outcome: {"text":"1 foot"}',
+  ];
+
+  t.deepEqual(dump.log, expected, 'was:\n'.concat(dump.log.join(',\n')));
 });

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -4,6 +4,8 @@ import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { observeIteration } from '@agoric/notifier';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
+import { makeMockChainStorageRoot } from '@agoric/vats/tools/storage-test-utils.js';
 
 import { makeTerms, MALLEABLE_NUMBER } from './governedContract.js';
 import { CONTRACT_ELECTORATE, assertContractElectorate } from '../../../src';
@@ -74,7 +76,10 @@ const installContracts = async (zoe, cb) => {
  */
 const startElectorate = async (zoe, installations, electorateTerms) => {
   const { creatorFacet: electorateCreatorFacet, instance: electorateInstance } =
-    await E(zoe).startInstance(installations.committee, {}, electorateTerms);
+    await E(zoe).startInstance(installations.committee, {}, electorateTerms, {
+      storageNode: makeMockChainStorageRoot().makeChildNode('thisElectorate'),
+      marshaller: makeBoard().getReadonlyMarshaller(),
+    });
   return { electorateCreatorFacet, electorateInstance };
 };
 

--- a/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
@@ -111,6 +111,7 @@ const build = async (log, zoe) => {
  * @typedef {ReturnType<Awaited<ReturnType<typeof build>>['createVoter']>} EVatVoter
  */
 
+/** @type {BuildRootObjectForTestVat} */
 export const buildRootObject = vatPowers =>
   Far('root', {
     build: (...args) => build(vatPowers.testLog, ...args),

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -9,6 +9,8 @@ import bundleSource from '@endo/bundle-source';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { E } from '@endo/eventual-send';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
+import { makeMockChainStorageRoot } from '@agoric/vats/tools/storage-test-utils.js';
 
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { MALLEABLE_NUMBER } from '../swingsetTests/contractGovernor/governedContract.js';
@@ -79,7 +81,10 @@ const setUpGovernedContract = async (zoe, electorateTerms, timer) => {
   const installs = { governor, electorate, counter, governed };
 
   const { creatorFacet: committeeCreator, instance: electorateInstance } =
-    await E(zoe).startInstance(electorate, harden({}), electorateTerms);
+    await E(zoe).startInstance(electorate, harden({}), electorateTerms, {
+      storageNode: makeMockChainStorageRoot().makeChildNode('thisElectorate'),
+      marshaller: makeBoard().getReadonlyMarshaller(),
+    });
 
   const poserInvitation = await E(committeeCreator).getPoserInvitation();
   const invitationAmount = await E(E(zoe).getInvitationIssuer()).getAmountOf(

--- a/packages/inter-protocol/README.md
+++ b/packages/inter-protocol/README.md
@@ -59,6 +59,9 @@ The canonical keys (under `published`) are as follows. Non-terminal nodes could 
         - `metrics`
     - `stakeFactory`
         - `governance`
+    - `committees`
+        - `Initial_Economic_Committee`
+          - `latestQuestion`
 
 ### Demo
 

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -12,6 +12,8 @@ export * from './startPSM.js';
 const ECON_COMMITTEE_MANIFEST = harden({
   [econBehaviors.startEconomicCommittee.name]: {
     consume: {
+      board: true,
+      chainStorage: true,
       zoe: true,
     },
     produce: { economicCommitteeCreatorFacet: 'economicCommittee' },

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -6,7 +6,10 @@ import { AmountMath } from '@agoric/ertp';
 import '@agoric/governance/exported.js';
 import '@agoric/vats/exported.js';
 import '@agoric/vats/src/core/types.js';
-import { makeStorageNodeChild } from '@agoric/vats/src/lib-chainStorage.js';
+import {
+  assertPathSegment,
+  makeStorageNodeChild,
+} from '@agoric/vats/src/lib-chainStorage.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E, Far } from '@endo/far';
 import { Stable, Stake } from '@agoric/vats/src/tokens.js';
@@ -29,6 +32,13 @@ const SECONDS_PER_DAY = 24n * SECONDS_PER_HOUR;
 
 const BASIS_POINTS = 10_000n;
 const MILLI = 1_000_000n;
+
+/** @type {(name: string) => string} */
+const sanitizePathSegment = name => {
+  const candidate = name.replace(/[ ,]/g, '_');
+  assertPathSegment(candidate);
+  return candidate;
+};
 
 /**
  * @typedef {GovernedCreatorFacet<import('../stakeFactory/stakeFactory.js').StakeFactoryCreator>} StakeFactoryCreator
@@ -84,7 +94,7 @@ const MILLI = 1_000_000n;
  */
 export const startEconomicCommittee = async (
   {
-    consume: { zoe },
+    consume: { board, chainStorage, zoe },
     produce: { economicCommitteeCreatorFacet },
     installation: {
       consume: { committee },
@@ -95,16 +105,31 @@ export const startEconomicCommittee = async (
   },
   { options: { econCommitteeOptions = {} } = {} },
 ) => {
+  const COMMITTEES_ROOT = 'committees';
   trace('startEconomicCommittee');
   const {
     committeeName = 'Initial Economic Committee',
     committeeSize = 3,
     ...rest
   } = econCommitteeOptions;
+
+  const committeesNode = await makeStorageNodeChild(
+    chainStorage,
+    COMMITTEES_ROOT,
+  );
+  const storageNode = await E(committeesNode).makeChildNode(
+    sanitizePathSegment(committeeName),
+  );
+  const marshaller = await E(board).getReadonlyMarshaller();
+
   const { creatorFacet, instance } = await E(zoe).startInstance(
     committee,
     {},
     { committeeName, committeeSize, ...rest },
+    {
+      storageNode,
+      marshaller,
+    },
   );
 
   economicCommitteeCreatorFacet.resolve(creatorFacet);

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -92,12 +92,18 @@ const makeTestContext = async () => {
   const psmInstall = await E(zoe).install(psmBundle);
   const mintLimit = AmountMath.make(anchor.brand, MINT_LIMIT);
 
+  const marshaller = makeBoard().getReadonlyMarshaller();
+
   const { creatorFacet: committeeCreator } = await E(zoe).startInstance(
     committeeInstall,
     harden({}),
     {
       committeeName: 'Demos',
       committeeSize: 1,
+    },
+    {
+      storageNode: makeMockChainStorageRoot().makeChildNode('thisCommittee'),
+      marshaller,
     },
   );
 
@@ -115,6 +121,7 @@ const makeTestContext = async () => {
     anchor,
     installs: { committeeInstall, psmInstall },
     mintLimit,
+    marshaller,
     terms: {
       anchorBrand: anchor.brand,
       anchorPerStable: makeRatio(100n, anchor.brand, 100n, stableBrand),
@@ -156,6 +163,7 @@ async function makePsmDriver(t, customTerms) {
     anchor,
   } = t.context;
 
+  // Each driver needs its own to avoid state pollution between tests
   const mockChainStorage = makeMockChainStorageRoot();
 
   /** @type {Awaited<ReturnType<import('../../src/psm/psm.js').start>>} */

--- a/packages/inter-protocol/test/swingsetTests/governance/vat-voter.js
+++ b/packages/inter-protocol/test/swingsetTests/governance/vat-voter.js
@@ -109,6 +109,7 @@ const build = async (log, zoe) => {
  * @typedef {ReturnType<Awaited<ReturnType<typeof build>>['createVoter']>} EVatVoter
  */
 
+/** @type {BuildRootObjectForTestVat} */
 export const buildRootObject = vatPowers =>
   Far('root', {
     build: (...args) => build(vatPowers.testLog, ...args),


### PR DESCRIPTION
## Description

Publish committee questions to chain storage.


### Security Considerations

Gives contracts a Marshaller from the board. It is read-only.

### Documentation Considerations

It's a feature of `@agoric/governance` contracts but also `@agoric/inter-protocol`. Documented in both READMEs.

### Testing Considerations

Unit and swingset tests pass, but they don't cover `startEconomicCommittee`. So I did a chain test per the "Demo" section of the README. The contract publishes 'undefined' as the first question so the key is present:
```
❯ agd query vstorage keys 'published.committees'
children:
- Initial_Economic_Committee
pagination: null
❯ agd query vstorage keys 'published.committees.Initial_Economic_Committee'
children:
- latestQuestion
pagination: null
❯ agoric follow :published.committees.Initial_Economic_Committee.latestQuestion
SES Lockdown using options from environment variables "LOCKDOWN_ERROR_TAMING"
undefined
```
