### PR TITLE
fix(agoric-cli): Reliable publishBundle client

### DIFF
--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -23,14 +23,14 @@
   "devDependencies": {
     "@agoric/swingset-vat": "^0.28.0",
     "ava": "^4.3.1",
-    "c8": "^7.11.0",
-    "tmp": "^0.2.1"
+    "c8": "^7.11.0"
   },
   "dependencies": {
     "@agoric/access-token": "^0.4.18",
     "@agoric/assert": "^0.4.0",
     "@agoric/cache": "^0.1.0",
     "@agoric/casting": "^0.1.0",
+    "@agoric/cosmic-proto": "^0.1.0",
     "@agoric/nat": "^4.1.0",
     "@endo/bundle-source": "^2.2.6",
     "@endo/captp": "^2.0.13",
@@ -38,6 +38,13 @@
     "@endo/init": "^0.5.47",
     "@endo/marshal": "^0.7.3",
     "@endo/promise-kit": "^0.2.47",
+    "@cosmjs/encoding": "0.28.13",
+    "@cosmjs/crypto": "0.28.13",
+    "@cosmjs/math": "0.28.13",
+    "@cosmjs/proto-signing": "0.28.13",
+    "@cosmjs/stargate": "0.28.13",
+    "@cosmjs/tendermint-rpc": "0.28.13",
+    "@endo/far": "^0.2.9",
     "@iarna/toml": "^2.2.3",
     "anylogger": "^0.21.0",
     "chalk": "^2.4.2",

--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -1,6 +1,48 @@
 // @ts-check
 /// <reference types="ses"/>
 
+import { E } from '@endo/far';
+
+import {
+  iterateEach,
+  makeFollower,
+  makeLeaderFromRpcAddresses,
+  makeCastingSpec,
+} from '@agoric/casting';
+import { DirectSecp256k1HdWallet, Registry } from '@cosmjs/proto-signing';
+import { defaultRegistryTypes } from '@cosmjs/stargate';
+import { stringToPath } from '@cosmjs/crypto';
+import { Decimal } from '@cosmjs/math';
+import { Bech32 } from '@cosmjs/encoding';
+
+import { MsgInstallBundle } from '@agoric/cosmic-proto/swingset/msgs.js';
+
+// https://github.com/Agoric/agoric-sdk/blob/master/golang/cosmos/daemon/main.go
+const Agoric = {
+  Bech32MainPrefix: 'agoric',
+  CoinType: 564,
+  proto: {
+    swingset: {
+      InstallBundle: {
+        // matches package agoric.swingset in swingset/msgs.go
+        typeUrl: '/agoric.swingset.MsgInstallBundle',
+      },
+    },
+  },
+  // arbitrary fee for installing a bundle
+  fee: { amount: [], gas: '50000000' },
+  // Agoric chain does not use cosmos gas (yet?)
+  gasPrice: { denom: 'uist', amount: Decimal.fromUserInput('50000000', 0) },
+};
+
+const hdPath = (coinType = 118, account = 0) =>
+  stringToPath(`m/44'/${coinType}'/${account}'/0/0`);
+
+const registry = new Registry([
+  ...defaultRegistryTypes,
+  [Agoric.proto.swingset.InstallBundle.typeUrl, MsgInstallBundle],
+]);
+
 /**
  * @typedef {object} JsonHttpRequest
  * @property {string} hostname
@@ -187,19 +229,15 @@ const urlForRpcAddress = address => {
 
 /**
  * @param {object} args
- * @param {ReturnType<import('./helpers.js').makePspawn>} args.pspawn
- * @param {string} args.cosmosHelper
  * @param {typeof import('path').resolve} args.pathResolve
- * @param {typeof import('fs').promises.writeFile} args.writeFile
- * @param {typeof import('tmp').dirSync} args.tmpDirSync
+ * @param {typeof import('fs').promises.readFile} args.readFile
+ * @param {typeof import('@cosmjs/stargate').SigningStargateClient.connectWithSigner} args.connectWithSigner
  * @param {() => number} args.random - a random number in the interval [0, 1)
  */
 export const makeCosmosBundlePublisher = ({
-  pspawn,
-  cosmosHelper,
   pathResolve,
-  writeFile,
-  tmpDirSync,
+  readFile,
+  connectWithSigner,
   random,
 }) => {
   /**
@@ -207,41 +245,89 @@ export const makeCosmosBundlePublisher = ({
    * @param {CosmosConnectionSpec} connectionSpec
    */
   const publishBundleCosmos = async (bundle, connectionSpec) => {
-    const { chainID = 'agoric', homeDirectory, rpcAddresses } = connectionSpec;
+    const { homeDirectory, rpcAddresses } = connectionSpec;
 
-    const rpcAddress = choose(rpcAddresses, random());
+    assert.typeof(bundle, 'object', 'Bundles must be objects');
+    assert(bundle !== null, 'Bundles must be objects');
+    const { endoZipBase64Sha512: expectedEndoZipBase64Sha512 } = bundle;
 
-    const { name: tempDirPath, removeCallback } = tmpDirSync({
-      unsafeCleanup: true,
-      prefix: 'agoric-cli-bundle-',
+    const leader = makeLeaderFromRpcAddresses(rpcAddresses);
+
+    // AWAIT
+    const mnemonic = (
+      await readFile(pathResolve(homeDirectory, 'ag-solo-mnemonic'), 'ascii')
+    ).trim();
+
+    const wallet = await DirectSecp256k1HdWallet.fromMnemonic(mnemonic, {
+      prefix: Agoric.Bech32MainPrefix,
+      hdPaths: [hdPath(Agoric.CoinType, 0), hdPath(Agoric.CoinType, 1)],
     });
-    try {
-      const tempFilePath = pathResolve(tempDirPath, 'bundle.json');
-      await writeFile(tempFilePath, `${JSON.stringify(bundle)}\n`);
-      const args = [
-        'tx',
-        'swingset',
-        'install-bundle',
-        '--gas',
-        'auto',
-        '--gas-adjustment',
-        '1.2',
-        '--home',
-        pathResolve(homeDirectory, 'ag-cosmos-helper-statedir'),
-        '--node',
-        urlForRpcAddress(rpcAddress),
-        '--keyring-backend',
-        'test',
-        '--from',
-        'ag-solo',
-        '--chain-id',
-        chainID,
-        '--yes',
-        `@${tempFilePath}`,
-      ];
-      await pspawn(cosmosHelper, args);
-    } finally {
-      removeCallback();
+
+    const [from] = await wallet.getAccounts();
+
+    const installBundleMsg = {
+      bundle: JSON.stringify(bundle),
+      submitter: Bech32.decode(from.address).data,
+    };
+
+    /** @type {Array<import('@cosmjs/proto-signing').EncodeObject>} */
+    const encodeObjects = [
+      {
+        typeUrl: Agoric.proto.swingset.InstallBundle.typeUrl,
+        value: installBundleMsg,
+      },
+    ];
+
+    let height;
+    for (let attempt = 0; ; attempt += 1) {
+      const rpcAddress = choose(rpcAddresses, random());
+
+      // TODO round-robin rpcAddress, create client proxy that rotates through clients
+      // or push round-robin down to a Tendermint34Client concern (where it ought to be)
+      const endpoint = urlForRpcAddress(rpcAddress);
+
+      // AWAIT
+      // eslint-disable-next-line no-await-in-loop,@jessie.js/no-nested-await
+      const stargateClient = await connectWithSigner(endpoint, wallet, {
+        prefix: Agoric.Bech32MainPrefix,
+        gasPrice: Agoric.gasPrice,
+        registry,
+      });
+
+      // AWAIT
+      // eslint-disable-next-line no-await-in-loop,@jessie.js/no-nested-await
+      const result = await stargateClient
+        .signAndBroadcast(from.address, encodeObjects, Agoric.fee)
+        .catch(error => {
+          console.error(error);
+          return null;
+        });
+      if (result !== null) {
+        let code;
+        ({ code, height } = result);
+        if (code === 0) {
+          break;
+        }
+      }
+
+      // AWAIT
+      // eslint-disable-next-line no-await-in-loop,@jessie.js/no-nested-await
+      await E(leader).jitter('agoric CLI deploy');
+    }
+
+    const castingSpec = makeCastingSpec(':bundles');
+    const follower = makeFollower(castingSpec, leader);
+
+    for await (const envelope of iterateEach(follower, { height })) {
+      const { value } = envelope;
+      const { endoZipBase64Sha512, installed, error } = value;
+      if (endoZipBase64Sha512 === expectedEndoZipBase64Sha512) {
+        if (!installed) {
+          throw error;
+        } else {
+          return;
+        }
+      }
     }
   };
 


### PR DESCRIPTION

closes: #5460

## Description

Change #5541 causes Cosmic Swingset to report the results of InstallBundle messages. This change improves the reliability of `publishBundle` in deploy scripts by:

1. Instead of shelling out to `agd` to send an InstallBundle message to the chain, uses CosmJs. Consequently, gets the block height the message was submitted against, so the lowest height that we can look for a response in the IAVL tree synced to RPC nodes.
2. Retries around submitting an InstallBundle message.
3. Follows the `:published.installation` vstorage topic broadcast by the Agoric chain to observe whether the InstallBundle message resulted in successful or unsuccessful installation.

This necessitated a bug fix, and so inspired a refactor, of `@agoric/casting` such that it does not retain I/O handles between yielding a value and the holder requesting the next value. The resulting async iterators should more closely conform to the intended semantics of medial-lossy and medial-lossless subscriptions without needing to poll and observe every block over the lifetime of a subscription, as is now possible with Richard’s refactor of storage cells.

### Security Considerations

Clients should not rely on the shapes of storage cells.

### Documentation Considerations

My intention is to follow-up on this change with improved deploy-script helpers and integration of those helpers in example dapps such that `publishBundle` is abstracted away from the attention of end-users. The fungible-faucet scaffold dapp then serves as the documentation for the proper way to publish a contract.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

For manual verification, in `dapp-fungible-faucet`:

```sh
# tab 1
agoric start local-chain --reset

# tab 2
agoric start local-solo --reset

# tab 3
agoric follow :published.installation

# tab 4
agoric deploy contract/deploy.js --need=agoric
```

Otherwise, the tests in `casting` cover the refactor, though these could no-doubt be elaborated to cover more of the new behavior.