### PR TITLE
test(xsnap): disable timestamp test until it tolerates fast CI hosts

### DIFF
--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -1,4 +1,4 @@
-/* global globalThis performance */
+/* global performance */
 // @ts-check
 
 import '@endo/init/debug.js';
@@ -66,7 +66,11 @@ test('meter details', async t => {
   t.is(meterType, 'xs-meter-16');
 });
 
-(globalThis.performance ? test : test.skip)('meter timestamps', async t => {
+// test disabled until rewritten to tolerate fast CI hosts getting
+// multiple events within the same microsecond, #5951
+// (globalThis.performance ? test : test.skip)('meter timestamps', async t => {
+
+test.skip('meter timestamps', async t => {
   const kernelTimes = [];
   function addTimestamp(name) {
     // xsnap-worker.c uses `gettimeofday()`, so this isn't exactly the


### PR DESCRIPTION
This test gets a false failure if the host is fast enough to cause two
events to occur within the same microsecond. The ticket describes a
weaker ordering assertion to apply that would confirm we get
timestamps and they they appear in mostly the right order, while not
failing if the CI host is too fast. I'm disabling this test until I
get around to implementing that scheme.

refs #5951
