### PR TITLE
fix(swing-store): use sqlite transactions for streamStore operations

### DIFF
--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@endo/init": "^0.5.43",
+    "@types/better-sqlite3": "^7.5.0",
     "ava": "^4.3.1",
     "c8": "^7.7.2"
   },

--- a/packages/swing-store/src/sqlStreamStore.js
+++ b/packages/swing-store/src/sqlStreamStore.js
@@ -67,10 +67,8 @@ export function sqlStreamStore(dbDir, io) {
   // https://sqlite.org/lang_transaction.html , especially section 2.2
 
   function ensureTransaction() {
-    // @ts-expect-error Database really does have .inTransaction:boolean
     if (!db.inTransaction) {
       db.prepare('BEGIN IMMEDIATE TRANSACTION').run();
-      // @ts-expect-error Database really does have .inTransaction:boolean
       assert(db.inTransaction);
     }
   }
@@ -163,7 +161,6 @@ export function sqlStreamStore(dbDir, io) {
   };
 
   const commit = () => {
-    // @ts-expect-error Database really does have .inTransaction:boolean
     if (db.inTransaction) {
       db.prepare('COMMIT').run();
     }

--- a/packages/swing-store/src/sqlStreamStore.js
+++ b/packages/swing-store/src/sqlStreamStore.js
@@ -54,6 +54,27 @@ export function sqlStreamStore(dbDir, io) {
     )
   `);
 
+  // We use explicit transactions to 1: not commit writes until the
+  // host application calls commit() and 2: avoid expensive fsyncs
+  // until the appropriate commit point. All API methods should call
+  // this first, otherwise sqlite will automatically start a
+  // transaction for us, but it will commit/fsync at the end of the DB
+  // run(). We use IMMEDIATE because the kernel is supposed to be the
+  // sole writer of the DB, and if some other process is holding a
+  // write lock, I'd like to find out earlier rather than later. We do
+  // not use EXCLUSIVE because we should allow external *readers*, and
+  // we might decide to use WAL mode some day. Read all of
+  // https://sqlite.org/lang_transaction.html , especially section 2.2
+
+  function ensureTransaction() {
+    // @ts-expect-error Database really does have .inTransaction:boolean
+    if (!db.inTransaction) {
+      db.prepare('BEGIN IMMEDIATE TRANSACTION').run();
+      // @ts-expect-error Database really does have .inTransaction:boolean
+      assert(db.inTransaction);
+    }
+  }
+
   const streamStatus = new Map();
 
   /**
@@ -75,6 +96,7 @@ export function sqlStreamStore(dbDir, io) {
     );
 
     function* reader() {
+      ensureTransaction();
       const query = db.prepare(`
         SELECT item
         FROM streamItem
@@ -123,6 +145,7 @@ export function sqlStreamStore(dbDir, io) {
       X`can't write stream ${q(streamName)} because it's already in use`,
     );
 
+    ensureTransaction();
     db.prepare(
       `
       INSERT INTO streamItem (streamName, item, position)
@@ -140,10 +163,15 @@ export function sqlStreamStore(dbDir, io) {
   };
 
   const commit = () => {
-    // We use the sqlite3 auto-commit API: every command automatically starts
-    // a new transaction if one is not already in effect, and every
-    // automatically-started transaction is committed when the last SQL
-    // statement finishes. https://sqlite.org/lang_transaction.html
+    // @ts-expect-error Database really does have .inTransaction:boolean
+    if (db.inTransaction) {
+      db.prepare('COMMIT').run();
+    }
+  };
+
+  const close = () => {
+    // close without commit is abort
+    db.close();
   };
 
   return harden({
@@ -151,6 +179,7 @@ export function sqlStreamStore(dbDir, io) {
     readStream,
     closeStream,
     commit,
+    close,
     STREAM_START,
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3945,6 +3945,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/better-sqlite3@^7.5.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.6.0.tgz#603d1c7a72527dd946e2bf641ed4c0b74a547423"
+  integrity sha512-rnSP9vY+fVsF3iJja5yRGBJV63PNBiezJlYrCkqUmQWFoB16cxAHwOkjsAYEu317miOfKaJpa65cbp0P4XJ/jw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/body-parser@*":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.1.tgz#0c0174c42a7d017b818303d4b5d969cb0b75929c"


### PR DESCRIPTION
The 'streamStore' component of swing-store is used to hold the
append-only delivery transcript for each vat. It stores each record in
a SQLite table.

Previously, streamStore used SQLite's auto-commit API: every write was
committed immediately. This causes a significant performance hit,
especially on slower disks, because a DB commit must do 3-ish
`fsync()` calls. SSDs are fast, but we observed 12.8ms stalls on the
standard disks of a popular cloud CPU provider, for each call to
writeStreamItem().

For the SwingSet client, each vat delivery triggered this stall, and a
full chain block could have hundreds of deliveries, leading to
multiple seconds of delay.

This patch changes streamStore to create an explicit DB transaction
instead of relying on automatic ones. SQLite will not commit these
transactions automatically, so the patch also introduces internal
`streamStore.commit()` and `.close()` methods.

Clients should continue to use `swingStore.commit()` and
`swingStore.close()` as usual; they will invoke the internal
streamStore methods as appropriate. The three patterns are:

* `commit()`: commit changes, keep using the DB
* `commit(); close();`: commit changes, close the DB
* `close();`: abandon the changes, close the DB

The streamStore is committed before the kvStore (LMDB) commit. As
before, we rely upon clients recording the startPos/endPos of the
stream into the kvStore, to safely tolerate a crash just after the
streamStore.commit but before the kvStore.commit. The next restart
after the crash will contain the spurious stream item in streamStore,
but the old startPos/endPos in kvStore, so clients will effectively
ignore the leftover item.

closes #6056
