### PR TITLE
Fix process-integration-results.sh

### DIFF
--- a/scripts/process-integration-swingstore-traces.sh
+++ b/scripts/process-integration-swingstore-traces.sh
@@ -9,15 +9,15 @@ RESULTSDIR=${RESULTSDIR-"$NETWORK_NAME/results"}
 [ $# -gt 0 ] && RESULTSDIR="$1"
 
 get_trace_len() {
-  grep -n commit-tx $1 | tail -1 | cut -d : -f 1 || echo 0
+  grep -n commit-tx $1 | tail -1 | cut -d : -f 1 || cat $1 | wc -l || echo 0
 }
 
 get_vats_from_diff() {
-  grep 'set local\.v' $1 | cut -d . -f 2 | sort | uniq
+  grep 'set local\.v' $1 | cut -d . -f 2 | sort | uniq || true
 }
 
 get_snapshots_from_diff() {
-  grep 'set local\.snapshot\.' $1 | cut -d ' ' -f 2 | cut -d . -f 3 | sort | uniq
+  grep 'set local\.snapshot\.' $1 | cut -d ' ' -f 2 | cut -d . -f 3 | sort | uniq || true
 }
 
 val0len=$(get_trace_len $RESULTSDIR/validator0-swingstore-trace)

--- a/scripts/process-integration-swingstore-traces.sh
+++ b/scripts/process-integration-swingstore-traces.sh
@@ -46,7 +46,7 @@ if [ -f $RESULTSDIR/chain-stage-0-swingstore-trace ] ; then
   diffs="$diffs $RESULTSDIR/monitor-vs-validator-swingstore-trace.diff"
 fi
 
-[ $val_diff_ret -eq 0 -a $chain_diff_ret -eq 0 ] && exit 0
+# [ $val_diff_ret -eq 0 -a $chain_diff_ret -eq 0 ] && exit 0
 
 get_snapshots_from_diff <(cat $diffs) > $RESULTSDIR/divergent_snapshots
 get_vats_from_diff <(cat $diffs) > $RESULTSDIR/divergent_snapshot_vats


### PR DESCRIPTION
refs: #6022 

## Description

Updates the processing script to handle some more cases:
- Run without error if no snapshot were found to diverge
- Remove new time/stats fields from slog for diffing
- Generate an artifact when xsnap traces are found to diverge (to diagnose issues like in #6022)

### Security Considerations

None, manual debug scripts

### Documentation Considerations

There should be some

### Testing Considerations

Generated artifacts for these divergences in #6011 tests and on a local run of the same branch.
