### PR TITLE
ci(Mergify): remove check failed rules for integration tests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,23 +5,15 @@ queue_rules:
       - base=master
       # Require integration tests before merging only
       - or:
-          - and:
-              - '-check-failure=deployment-test'
-              - or:
-                  - '#commits-behind>0'
-                  - queue-position<0
+          - '#commits-behind>0'
+          - queue-position<0
           - label=bypass:integration
           - check-success=deployment-test
           - check-neutral=deployment-test
           - check-skipped=deployment-test
       - or:
-          - and:
-              - '-check-failure=getting-started'
-              - '-check-failure=getting-started (link-cli)'
-              - '-check-failure=getting-started (local-npm)'
-              - or:
-                  - '#commits-behind>0'
-                  - queue-position<0
+          - '#commits-behind>0'
+          - queue-position<0
           - label=bypass:integration
           - check-skipped=getting-started
           - and:


### PR DESCRIPTION
Apparently the change in https://github.com/Agoric/agoric-sdk/pull/5405 to bypass integration tests unless the PR is up to date at the top of the merge queue may be causing issues. The goal in including the check failed rule was in particular to disembark the PR if the check failed. However it may have ended up counter-productive since we're seeing merge queue stalls.