### PR TITLE
fix(vats): chainStorage vat writes directly to device

### DIFF
--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -290,16 +290,16 @@ export const makeBridgeManager = async ({
 harden(makeBridgeManager);
 
 /**
- * @param {BootstrapPowers & {
+ * @param {BootDevices<ChainDevices> & BootstrapSpace & {
  *   consume: { loadVat: ERef<VatLoader<ChainStorageVat>> }
  * }} powers
  */
 export const makeChainStorage = async ({
-  consume: { bridgeManager: bridgeManagerP, loadVat },
+  devices: { bridge },
+  consume: { loadVat },
   produce: { chainStorage: chainStorageP },
 }) => {
-  const bridgeManager = await bridgeManagerP;
-  if (!bridgeManager) {
+  if (!bridge) {
     console.warn('Cannot support chainStorage without an actual chain.');
     chainStorageP.resolve(null);
     return;
@@ -309,7 +309,7 @@ export const makeChainStorage = async ({
 
   const vat = E(loadVat)('chainStorage');
   const rootNodeP = E(vat).makeBridgedChainStorageRoot(
-    bridgeManager,
+    bridge,
     BRIDGE_ID.STORAGE,
     ROOT_PATH,
     { sequence: true },

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -94,10 +94,8 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
     home: { produce: { chainTimerService: 'timer' } },
   },
   makeChainStorage: {
-    consume: {
-      bridgeManager: true,
-      loadVat: true,
-    },
+    devices: { bridge: 'kernel' },
+    consume: { loadVat: true },
     produce: {
       chainStorage: 'chainStorage',
     },

--- a/packages/vats/src/vat-chainStorage.js
+++ b/packages/vats/src/vat-chainStorage.js
@@ -1,23 +1,19 @@
 // @ts-check
-import { E, Far } from '@endo/far';
+import { Far } from '@endo/far';
 import { makeChainStorageRoot } from './lib-chainStorage.js';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(vatPowers) {
   /**
-   * @param {ERef<BridgeManager>} bridgeManager
+   * @param {BridgeDevice} bridge
    * @param {string} bridgeId
    * @param {string} rootPath must be unique (caller responsibility to ensure)
    * @param {object} [options]
    */
-  function makeBridgedChainStorageRoot(
-    bridgeManager,
-    bridgeId,
-    rootPath,
-    options,
-  ) {
+  function makeBridgedChainStorageRoot(bridge, bridgeId, rootPath, options) {
+    const { D } = vatPowers;
     // Note that the uniqueness of rootPath is not validated here,
     // and is instead the responsibility of callers.
-    const toStorage = message => E(bridgeManager).toBridge(bridgeId, message);
+    const toStorage = message => D(bridge).callOutbound(bridgeId, message);
     const rootNode = makeChainStorageRoot(
       toStorage,
       'swingset',


### PR DESCRIPTION
closes: #6053

### Security Considerations

Device access is a power that the chainStorage vat didn't previously have. I believe granting it is entirely appropriate.

### Documentation Considerations

`manifest.js` is updated with the required bootstrap powers.

### Testing Considerations

Tested manually; resulting before and after sequence diagrams are below.