### PR TITLE
refactor(store)!: move from Shape to Schema terminology

### DIFF
--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -3,7 +3,7 @@
 import { assert, details as X } from '@agoric/assert';
 import { fit } from '@agoric/store';
 
-import { DisplayInfoShape } from './typeGuards.js';
+import { DisplayInfoSchema } from './typeGuards.js';
 
 /**
  * @param {AdditionalDisplayInfo} allegedDisplayInfo
@@ -11,7 +11,7 @@ import { DisplayInfoShape } from './typeGuards.js';
  * @returns {DisplayInfo}
  */
 export const coerceDisplayInfo = (allegedDisplayInfo, assetKind) => {
-  fit(allegedDisplayInfo, DisplayInfoShape, 'displayInfo');
+  fit(allegedDisplayInfo, DisplayInfoSchema, 'displayInfo');
 
   if (allegedDisplayInfo.assetKind !== undefined) {
     assert(

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -178,19 +178,19 @@ export const vivifyPaymentLedger = (
 
   /**
    * Methods like deposit() have an optional second parameter
-   * `optAmountShape`
+   * `optAmountSchema`
    * which, if present, is supposed to match the balance of the
    * payment. This helper function does that check.
    *
-   * Note: `optAmountShape` is user-supplied with no previous validation.
+   * Note: `optAmountSchema` is user-supplied with no previous validation.
    *
    * @param {Amount} paymentBalance
-   * @param {Pattern=} optAmountShape
+   * @param {Pattern=} optAmountSchema
    * @returns {void}
    */
-  const assertAmountConsistent = (paymentBalance, optAmountShape) => {
-    if (optAmountShape !== undefined) {
-      fit(paymentBalance, optAmountShape, 'amount');
+  const assertAmountConsistent = (paymentBalance, optAmountSchema) => {
+    if (optAmountSchema !== undefined) {
+      fit(paymentBalance, optAmountSchema, 'amount');
     }
   };
 
@@ -284,11 +284,11 @@ export const vivifyPaymentLedger = (
   };
 
   /** @type {IssuerBurn} */
-  const burn = (paymentP, optAmountShape = undefined) => {
+  const burn = (paymentP, optAmountSchema = undefined) => {
     return E.when(paymentP, payment => {
       assertLivePayment(payment);
       const paymentBalance = paymentLedger.get(payment);
-      assertAmountConsistent(paymentBalance, optAmountShape);
+      assertAmountConsistent(paymentBalance, optAmountSchema);
       try {
         // COMMIT POINT.
         deletePayment(payment);
@@ -301,11 +301,11 @@ export const vivifyPaymentLedger = (
   };
 
   /** @type {IssuerClaim} */
-  const claim = (paymentP, optAmountShape = undefined) => {
+  const claim = (paymentP, optAmountSchema = undefined) => {
     return E.when(paymentP, srcPayment => {
       assertLivePayment(srcPayment);
       const srcPaymentBalance = paymentLedger.get(srcPayment);
-      assertAmountConsistent(srcPaymentBalance, optAmountShape);
+      assertAmountConsistent(srcPaymentBalance, optAmountSchema);
       // Note COMMIT POINT within moveAssets.
       const [payment] = moveAssets(
         harden([srcPayment]),
@@ -386,14 +386,14 @@ export const vivifyPaymentLedger = (
    * @param {(newPurseBalance: Amount) => void} updatePurseBalance -
    * commit the purse balance
    * @param {Payment} srcPayment
-   * @param {Pattern=} optAmountShape
+   * @param {Pattern=} optAmountSchema
    * @returns {Amount}
    */
   const depositInternal = (
     currentBalance,
     updatePurseBalance,
     srcPayment,
-    optAmountShape = undefined,
+    optAmountSchema = undefined,
   ) => {
     assert(
       !isPromise(srcPayment),
@@ -402,7 +402,7 @@ export const vivifyPaymentLedger = (
     );
     assertLivePayment(srcPayment);
     const srcPaymentBalance = paymentLedger.get(srcPayment);
-    assertAmountConsistent(srcPaymentBalance, optAmountShape);
+    assertAmountConsistent(srcPaymentBalance, optAmountSchema);
     const newPurseBalance = add(srcPaymentBalance, currentBalance);
     try {
       // COMMIT POINT

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -53,7 +53,7 @@ export const vivifyPurseKind = (
         deposit: (
           { state, facets: { purse } },
           srcPayment,
-          optAmountShape = undefined,
+          optAmountSchema = undefined,
         ) => {
           // Note COMMIT POINT within deposit.
           return depositInternal(
@@ -61,7 +61,7 @@ export const vivifyPurseKind = (
             newPurseBalance =>
               updatePurseBalance(state, newPurseBalance, purse),
             srcPayment,
-            optAmountShape,
+            optAmountSchema,
             state.recoverySet,
           );
         },

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,16 +1,16 @@
 import { M, matches } from '@agoric/store';
 
 /**
- * When the AmountValue of an Amount fits the NatValueShape, i.e., when it is
+ * When the AmountValue of an Amount fits the NatValueSchema, i.e., when it is
  * a non-negative bigint, then it represents that many units of the
  * fungible asset represented by that amount. The brand of that amount
  * should indeed represent a kind of asset consisting of a countable
  * set of fungible units.
  */
-const NatValueShape = M.nat();
+const NatValueSchema = M.nat();
 
 /**
- * When the AmountValue of an Amount fits the CopySetValueShape, i.e., when it
+ * When the AmountValue of an Amount fits the CopySetValueSchema, i.e., when it
  * is a CopySet, then it represents the set of those
  * keys, where each key represents some individual non-fungible
  * item, like a concert ticket, from the non-fungible asset class
@@ -27,19 +27,19 @@ const NatValueShape = M.nat();
  * will never be minted. That want will never be satisfied.
  * "You can't always get..."
  */
-const CopySetValueShape = M.set();
+const CopySetValueSchema = M.set();
 
 /**
- * When the AmountValue of an Amount fits the SetValueShape, i.e., when it
+ * When the AmountValue of an Amount fits the SetValueSchema, i.e., when it
  * is a CopyArray of passable Keys. This representation is deprecated.
  *
  * @deprecated Please change from using array-based SetValues to CopySet-based
  * CopySetValues.
  */
-const SetValueShape = M.arrayOf(M.key());
+const SetValueSchema = M.arrayOf(M.key());
 
 /**
- * When the AmountValue of an Amount fits the CopyBagValueShape, i.e., when it
+ * When the AmountValue of an Amount fits the CopyBagValueSchema, i.e., when it
  * is a CopyBag, then it represents the bag (multiset) of those
  * keys, where each key represents some individual semi-fungible
  * item, like a concert ticket, from the semi-fungible asset class
@@ -58,18 +58,18 @@ const SetValueShape = M.arrayOf(M.key());
  * will never be minted. That want will never be satisfied.
  * "You can't always get..."
  */
-const CopyBagValueShape = M.bag();
+const CopyBagValueSchema = M.bag();
 
-const AmountValueShape = M.or(
-  NatValueShape,
-  CopySetValueShape,
-  SetValueShape,
-  CopyBagValueShape,
+const AmountValueSchema = M.or(
+  NatValueSchema,
+  CopySetValueSchema,
+  SetValueSchema,
+  CopyBagValueSchema,
 );
 
-export const AmountShape = harden({
+export const AmountSchema = harden({
   brand: M.remotable(),
-  value: AmountValueShape,
+  value: AmountValueSchema,
 });
 
 /**
@@ -78,7 +78,7 @@ export const AmountShape = harden({
  * @param {AmountValue} value
  * @returns {value is NatValue}
  */
-export const isNatValue = value => matches(value, NatValueShape);
+export const isNatValue = value => matches(value, NatValueSchema);
 harden(isNatValue);
 
 /**
@@ -87,7 +87,7 @@ harden(isNatValue);
  * @param {AmountValue} value
  * @returns {value is CopySetValue}
  */
-export const isCopySetValue = value => matches(value, CopySetValueShape);
+export const isCopySetValue = value => matches(value, CopySetValueSchema);
 harden(isCopySetValue);
 
 /**
@@ -99,7 +99,7 @@ harden(isCopySetValue);
  * @param {AmountValue} value
  * @returns {value is SetValue}
  */
-export const isSetValue = value => matches(value, SetValueShape);
+export const isSetValue = value => matches(value, SetValueSchema);
 harden(isSetValue);
 
 /**
@@ -108,21 +108,21 @@ harden(isSetValue);
  * @param {AmountValue} value
  * @returns {value is CopyBagValue}
  */
-export const isCopyBagValue = value => matches(value, CopyBagValueShape);
+export const isCopyBagValue = value => matches(value, CopyBagValueSchema);
 harden(isCopyBagValue);
 
 // One GOOGOLth should be enough decimal places for anybody.
 export const MAX_ABSOLUTE_DECIMAL_PLACES = 100;
 
-export const AssetValueShape = M.or('nat', 'set', 'copySet', 'copyBag');
+export const AssetKindSchema = M.or('nat', 'set', 'copySet', 'copyBag');
 
-export const DisplayInfoShape = M.partial(
+export const DisplayInfoSchema = M.partial(
   harden({
     decimalPlaces: M.and(
       M.gte(-MAX_ABSOLUTE_DECIMAL_PLACES),
       M.lte(MAX_ABSOLUTE_DECIMAL_PLACES),
     ),
-    assetKind: AssetValueShape,
+    assetKind: AssetKindSchema,
   }),
   harden({
     // Including this empty `rest` ensures that there are no other

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -156,7 +156,7 @@
  * resolution.
  *
  * @param {ERef<Payment>} payment
- * @param {Pattern=} optAmountShape
+ * @param {Pattern=} optAmountSchema
  * @returns {Promise<Amount>}
  */
 
@@ -173,7 +173,7 @@
  * resolution.
  *
  * @param {ERef<Payment>} payment
- * @param {Pattern=} optAmountShape
+ * @param {Pattern=} optAmountSchema
  * @returns {Promise<Payment>}
  */
 
@@ -309,7 +309,7 @@
 /**
  * @callback DepositFacetReceive
  * @param {Payment} payment
- * @param {Pattern=} optAmountShape
+ * @param {Pattern=} optAmountSchema
  * @returns {Amount}
  */
 
@@ -326,7 +326,7 @@
 /**
  * @callback PurseDeposit
  * @param {Payment} payment
- * @param {Pattern=} optAmountShape
+ * @param {Pattern=} optAmountSchema
  * @returns {Amount}
  */
 

--- a/packages/SwingSet/src/vats/timer/timeMath.js
+++ b/packages/SwingSet/src/vats/timer/timeMath.js
@@ -5,7 +5,7 @@
 import { Nat } from '@agoric/nat';
 import { fit } from '@agoric/store';
 
-import { RelativeTimeShape, TimestampShape } from './typeGuards.js';
+import { RelativeTimeSchema, TimestampSchema } from './typeGuards.js';
 
 const { details: X, quote: q } = assert;
 
@@ -124,7 +124,7 @@ const toAbs = (ts, brand = undefined) => {
   } else {
     const { timerBrand } = ts;
     agreedTimerBrand(timerBrand, brand);
-    fit(ts, TimestampShape, 'timestamp');
+    fit(ts, TimestampSchema, 'timestamp');
     return ts;
   }
 };
@@ -145,7 +145,7 @@ const toRel = (rt, brand = undefined) => {
   } else {
     const { timerBrand } = rt;
     agreedTimerBrand(timerBrand, brand);
-    fit(rt, RelativeTimeShape, 'relativeTime');
+    fit(rt, RelativeTimeSchema, 'relativeTime');
     return rt;
   }
 };

--- a/packages/SwingSet/src/vats/timer/typeGuards.js
+++ b/packages/SwingSet/src/vats/timer/typeGuards.js
@@ -1,21 +1,24 @@
 import { M } from '@agoric/store';
 
-export const TimerBrandShape = M.remotable();
-export const TimestampValueShape = M.nat();
-export const RelativeTimeValueShape = M.nat(); // Should we allow negatives?
+export const TimerBrandSchema = M.remotable();
+export const TimestampValueSchema = M.nat();
+export const RelativeTimeValueSchema = M.nat(); // Should we allow negatives?
 
-export const TimestampRecordShape = harden({
-  timerBrand: TimerBrandShape,
-  absValue: TimestampValueShape,
+export const TimestampRecordSchema = harden({
+  timerBrand: TimerBrandSchema,
+  absValue: TimestampValueSchema,
 });
 
-export const RelativeTimeRecordShape = harden({
-  timerBrand: TimerBrandShape,
-  relValue: RelativeTimeValueShape,
+export const RelativeTimeRecordSchema = harden({
+  timerBrand: TimerBrandSchema,
+  relValue: RelativeTimeValueSchema,
 });
 
-export const TimestampShape = M.or(TimestampRecordShape, TimestampValueShape);
-export const RelativeTimeShape = M.or(
-  RelativeTimeRecordShape,
-  RelativeTimeValueShape,
+export const TimestampSchema = M.or(
+  TimestampRecordSchema,
+  TimestampValueSchema,
+);
+export const RelativeTimeSchema = M.or(
+  RelativeTimeRecordSchema,
+  RelativeTimeValueSchema,
 );

--- a/packages/inter-protocol/src/stakeFactory/attestation.js
+++ b/packages/inter-protocol/src/stakeFactory/attestation.js
@@ -166,7 +166,10 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
 
   /** @param {ZCFSeat} seat */
   const returnAttestation = async seat => {
-    assertProposalShape(seat, { give: { [KW.Attestation]: null }, want: {} });
+    assertProposalShape(seat, {
+      give: { [KW.Attestation]: null },
+      want: {},
+    });
 
     const {
       give: { [KW.Attestation]: attestationAmount },

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -1080,52 +1080,52 @@ const makePatternKit = () => {
 
   const makeKindMatcher = kind => makeMatcher('match:kind', kind);
 
-  const AnyShape = makeMatcher('match:any', undefined);
-  const ScalarShape = makeMatcher('match:scalar', undefined);
-  const KeyShape = makeMatcher('match:key', undefined);
-  const PatternShape = makeMatcher('match:pattern', undefined);
-  const BooleanShape = makeKindMatcher('boolean');
-  const NumberShape = makeKindMatcher('number');
-  const BigintShape = makeKindMatcher('bigint');
-  const NatShape = makeMatcher('match:gte', 0n);
-  const StringShape = makeKindMatcher('string');
-  const SymbolShape = makeKindMatcher('symbol');
-  const RecordShape = makeKindMatcher('copyRecord');
-  const ArrayShape = makeKindMatcher('copyArray');
-  const SetShape = makeKindMatcher('copySet');
-  const BagShape = makeKindMatcher('copyBag');
-  const MapShape = makeKindMatcher('copyMap');
-  const RemotableShape = makeKindMatcher('remotable');
-  const ErrorShape = makeKindMatcher('error');
-  const PromiseShape = makeKindMatcher('promise');
-  const UndefinedShape = makeKindMatcher('undefined');
+  const AnySchema = makeMatcher('match:any', undefined);
+  const ScalarSchema = makeMatcher('match:scalar', undefined);
+  const KeySchema = makeMatcher('match:key', undefined);
+  const PatternSchema = makeMatcher('match:pattern', undefined);
+  const BooleanSchema = makeKindMatcher('boolean');
+  const NumberSchema = makeKindMatcher('number');
+  const BigintSchema = makeKindMatcher('bigint');
+  const NatSchema = makeMatcher('match:gte', 0n);
+  const StringSchema = makeKindMatcher('string');
+  const SymbolSchema = makeKindMatcher('symbol');
+  const RecordSchema = makeKindMatcher('copyRecord');
+  const ArraySchema = makeKindMatcher('copyArray');
+  const SetSchema = makeKindMatcher('copySet');
+  const BagSchema = makeKindMatcher('copyBag');
+  const MapSchema = makeKindMatcher('copyMap');
+  const RemotableSchema = makeKindMatcher('remotable');
+  const ErrorSchema = makeKindMatcher('error');
+  const PromiseSchema = makeKindMatcher('promise');
+  const UndefinedSchema = makeKindMatcher('undefined');
 
   /** @type {MatcherNamespace} */
   const M = harden({
-    any: () => AnyShape,
+    any: () => AnySchema,
     and: (...patts) => makeMatcher('match:and', patts),
     or: (...patts) => makeMatcher('match:or', patts),
     not: subPatt => makeMatcher('match:not', subPatt),
 
-    scalar: () => ScalarShape,
-    key: () => KeyShape,
-    pattern: () => PatternShape,
+    scalar: () => ScalarSchema,
+    key: () => KeySchema,
+    pattern: () => PatternSchema,
     kind: makeKindMatcher,
-    boolean: () => BooleanShape,
-    number: () => NumberShape,
-    bigint: () => BigintShape,
-    nat: () => NatShape,
-    string: () => StringShape,
-    symbol: () => SymbolShape,
-    record: () => RecordShape,
-    array: () => ArrayShape,
-    set: () => SetShape,
-    bag: () => BagShape,
-    map: () => MapShape,
-    remotable: () => RemotableShape,
-    error: () => ErrorShape,
-    promise: () => PromiseShape,
-    undefined: () => UndefinedShape,
+    boolean: () => BooleanSchema,
+    number: () => NumberSchema,
+    bigint: () => BigintSchema,
+    nat: () => NatSchema,
+    string: () => StringSchema,
+    symbol: () => SymbolSchema,
+    record: () => RecordSchema,
+    array: () => ArraySchema,
+    set: () => SetSchema,
+    bag: () => BagSchema,
+    map: () => MapSchema,
+    remotable: () => RemotableSchema,
+    error: () => ErrorSchema,
+    promise: () => PromiseSchema,
+    undefined: () => UndefinedSchema,
     null: () => null,
 
     lt: rightOperand => makeMatcher('match:lt', rightOperand),

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -55,22 +55,22 @@
  *
  * Patterns are often used in a type-like manner, to represent the category
  * of passables that are intended* to match that pattern. To keep this
- * distinction clear, we often use the suffix "Shape" rather than "Pattern"
+ * distinction clear, we often use the suffix "Schema" rather than "Pattern"
  * to avoid the levels confusion when the pattern itself represents
- * some category of pattern. For example, an "AmountShape" represents the
- * category of Amounts. And "AmountPatternShape" represents the
+ * some category of pattern. For example, an "AmountSchema" represents the
+ * category of Amounts. And "AmountPatternSchema" represents the
  * category of patterns over Amounts.
  *
  * * I say "intended" above because Patterns, in order to be declarative
  * and passable, cannot have the generality of predicates written in a
  * Turing-universal programming language. Rather, to represent the category of
- * things intended to be a Foo, a FooShape should reliably
- * accept all Foos and reject only non-Foos. However, a FooShape may also accept
+ * things intended to be a Foo, a FooSchema should reliably accept
+ * all Foos and reject only non-Foos. However, a FooSchema may also accept
  * non-Foos that "look like" or have "the same shape as" genuine Foos. To write
- * as accurate predicate, for use, for example, for input validation, would
+ * an accurate predicate for use, for example, for input validation, would
  * need to supplement the pattern check with code to check for the residual
  * cases.
- * We hope the "Shape" metaphor helps remind us of this type-like imprecision
+ * We hope the "Schema" metaphor helps remind us of this type-like imprecision
  * of patterns.
  */
 

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -4,7 +4,7 @@ import { assert, details as X, q } from '@agoric/assert';
 import { AmountMath, getAssetKind } from '@agoric/ertp';
 import { assertRecord } from '@endo/marshal';
 import { assertKey, assertPattern, fit, isKey } from '@agoric/store';
-import { ProposalShape } from './typeGuards.js';
+import { ProposalSchema } from './typeGuards.js';
 import { arrayToObj } from './objArrayConversion.js';
 
 import '../exported.js';
@@ -102,7 +102,7 @@ export const coerceAmountKeywordRecord = (
 };
 
 /**
- * Just checks residual issues after matching ProposalShape.
+ * Just checks residual issues after matching ProposalSchema.
  * Only known residual issue is verifying that it only has one of the
  * optional properties.
  *
@@ -170,7 +170,7 @@ export const cleanProposal = (proposal, getAssetKindByBrand) => {
     give: cleanedGive,
     exit,
   });
-  fit(cleanedProposal, ProposalShape, 'proposal');
+  fit(cleanedProposal, ProposalSchema, 'proposal');
   assertExit(exit);
   assertKeywordNotInBoth(cleanedWant, cleanedGive);
   return cleanedProposal;

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -26,7 +26,7 @@ export * from './statistics.js';
 export {
   defaultAcceptanceMsg,
   swap,
-  fitProposalShape,
+  fitProposalSchema,
   assertProposalShape,
   assertIssuerKeywords,
   satisfies,

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -103,16 +103,16 @@ export const swapExact = (zcf, leftSeat, rightSeat) => {
  */
 
 /**
- * Check the seat's proposal against `proposalShape`.
+ * Check the seat's proposal against `proposalSchema`.
  * If the client submits an offer which does not match
  * these expectations, the seat will be exited (and payments refunded).
  *
  * @param {ZCFSeat} seat
- * @param {Pattern} proposalShape
+ * @param {Pattern} proposalSchema
  */
-export const fitProposalShape = (seat, proposalShape) =>
+export const fitProposalSchema = (seat, proposalSchema) =>
   // TODO remove this harden, obligating our caller to harden.
-  fit(seat.getProposal(), harden(proposalShape), 'proposal');
+  fit(seat.getProposal(), harden(proposalSchema), 'proposal');
 
 /**
  * Check the seat's proposal against an `expected` record that says
@@ -123,6 +123,8 @@ export const fitProposalShape = (seat, proposalShape) =>
  * null contents. If the client submits an offer which does not match
  * these expectations, the seat will be exited (and payments refunded).
  *
+ * @deprecated Use optional `proposalSchema` argument to `makeInvitation` with
+ * a genuine pattern.
  * @param {ZCFSeat} seat
  * @param {ExpectedRecord} expected
  */

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -1,11 +1,11 @@
 // @ts-check
 
-import { AmountShape } from '@agoric/ertp';
+import { AmountSchema } from '@agoric/ertp';
 import { M } from '@agoric/store';
-import { TimestampValueShape } from '@agoric/swingset-vat/src/vats/timer/typeGuards.js';
+import { TimestampValueSchema } from '@agoric/swingset-vat/src/vats/timer/typeGuards.js';
 
-export const AmountKeywordRecordShape = M.recordOf(M.string(), AmountShape);
-export const AmountPatternKeywordRecordShape = M.recordOf(
+export const AmountKeywordRecordSchema = M.recordOf(M.string(), AmountSchema);
+export const AmountPatternKeywordRecordSchema = M.recordOf(
   M.string(),
   M.pattern(),
 );
@@ -13,9 +13,9 @@ export const AmountPatternKeywordRecordShape = M.recordOf(
 /**
  * After defaults are filled in
  */
-export const ProposalShape = harden({
-  want: AmountPatternKeywordRecordShape,
-  give: AmountKeywordRecordShape,
+export const ProposalSchema = harden({
+  want: AmountPatternKeywordRecordSchema,
+  give: AmountKeywordRecordSchema,
   // To accept only one, we could use M.or rather than M.partial,
   // but the error messages would have been worse. Rather,
   // cleanProposal's assertExit checks that there's exactly one.
@@ -25,7 +25,7 @@ export const ProposalShape = harden({
       waived: null,
       afterDeadline: {
         timer: M.remotable(),
-        deadline: TimestampValueShape,
+        deadline: TimestampValueSchema,
       },
     },
     {},
@@ -55,7 +55,7 @@ export const isAfterDeadlineExitRule = exit => {
   return exitKey === 'afterDeadline';
 };
 
-export const InvitationElementShape = M.split({
+export const InvitationElementSchema = M.split({
   description: M.string(),
   handle: M.remotable(), // invitationHandle
   instance: M.remotable(),

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { AmountMath, makeDurableIssuerKit, AssetKind } from '@agoric/ertp';
-import { InvitationElementShape } from '../typeGuards.js';
+import { InvitationElementSchema } from '../typeGuards.js';
 
 /**
  * @param {import('@agoric/vat-data').Baggage} baggage
@@ -14,7 +14,7 @@ export const vivifyInvitationKit = (baggage, shutdownZoeVat = undefined) => {
     AssetKind.SET,
     undefined,
     shutdownZoeVat,
-    { elementSchema: InvitationElementShape },
+    { elementSchema: InvitationElementSchema },
   );
 
   /**


### PR DESCRIPTION
As explained in https://github.com/Agoric/agoric-sdk/blob/master/packages/store/src/types.js#L56-L74 , when talking about patterns, we need an additional suffix besides "Pattern". But we only need one. Before this PR we fell into using two: "Schema" and "Shape". Either one is a decent choice. This PR switches all those uses to "Schema". The old `assertProposalShape` was not using patterns, but rather an ad-hoc specialized pattern-like encoding that we wish to deprecate, so it is *not* renamed to `assertProposalSchema`.