### PR TITLE
refactor(store)!: fix bad check defaults

### DIFF
--- a/packages/store/src/keys/checkKey.js
+++ b/packages/store/src/keys/checkKey.js
@@ -26,10 +26,10 @@ const { ownKeys } = Reflect;
 
 /**
  * @param {Passable} val
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-const checkPrimitiveKey = (val, check = x => x) => {
+const checkPrimitiveKey = (val, check) => {
   if (isObject(val)) {
     return check(false, X`A ${q(typeof val)} cannot be a primitive: ${val}`);
   }
@@ -43,7 +43,7 @@ const checkPrimitiveKey = (val, check = x => x) => {
  * @param {Passable} val
  * @returns {boolean}
  */
-export const isPrimitiveKey = val => checkPrimitiveKey(val);
+export const isPrimitiveKey = val => checkPrimitiveKey(val, x => x);
 harden(isPrimitiveKey);
 
 /**
@@ -57,10 +57,10 @@ harden(assertPrimitiveKey);
 
 /**
  * @param {Passable} val
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-export const checkScalarKey = (val, check = x => x) => {
+export const checkScalarKey = (val, check) => {
   if (isPrimitiveKey(val)) {
     return true;
   }
@@ -75,7 +75,7 @@ export const checkScalarKey = (val, check = x => x) => {
  * @param {Passable} val
  * @returns {boolean}
  */
-export const isScalarKey = val => checkScalarKey(val);
+export const isScalarKey = val => checkScalarKey(val, x => x);
 harden(isScalarKey);
 
 /**
@@ -94,10 +94,10 @@ const keyMemo = new WeakSet();
 
 /**
  * @param {Passable} val
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-export const checkKey = (val, check = x => x) => {
+export const checkKey = (val, check) => {
   if (isPrimitiveKey(val)) {
     return true;
   }
@@ -127,7 +127,7 @@ harden(checkKey);
  * @param {Passable} val
  * @returns {boolean}
  */
-export const isKey = val => checkKey(val);
+export const isKey = val => checkKey(val, x => x);
 harden(isKey);
 
 /**
@@ -148,10 +148,10 @@ const copySetMemo = new WeakSet();
 
 /**
  * @param {Passable} s
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-export const checkCopySet = (s, check = x => x) => {
+export const checkCopySet = (s, check) => {
   if (copySetMemo.has(s)) {
     return true;
   }
@@ -161,7 +161,7 @@ export const checkCopySet = (s, check = x => x) => {
       X`Not a copySet: ${s}`,
     ) &&
     checkElements(s.payload, check) &&
-    checkKey(s.payload);
+    checkKey(s.payload, check);
   if (result) {
     copySetMemo.add(s);
   }
@@ -176,7 +176,7 @@ harden(checkCopySet);
  */
 
 /** @type {IsCopySet} */
-export const isCopySet = s => checkCopySet(s);
+export const isCopySet = s => checkCopySet(s, x => x);
 harden(isCopySet);
 
 /**
@@ -234,10 +234,10 @@ const copyBagMemo = new WeakSet();
 
 /**
  * @param {Passable} b
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-export const checkCopyBag = (b, check = x => x) => {
+export const checkCopyBag = (b, check) => {
   if (copyBagMemo.has(b)) {
     return true;
   }
@@ -247,7 +247,7 @@ export const checkCopyBag = (b, check = x => x) => {
       X`Not a copyBag: ${b}`,
     ) &&
     checkBagEntries(b.payload, check) &&
-    checkKey(b.payload);
+    checkKey(b.payload, check);
   if (result) {
     copyBagMemo.add(b);
   }
@@ -262,7 +262,7 @@ harden(checkCopyBag);
  */
 
 /** @type {IsCopyBag} */
-export const isCopyBag = b => checkCopyBag(b);
+export const isCopyBag = b => checkCopyBag(b, x => x);
 harden(isCopyBag);
 
 /**
@@ -345,10 +345,10 @@ const copyMapMemo = new WeakSet();
 
 /**
  * @param {Passable} m
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-export const checkCopyMap = (m, check = x => x) => {
+export const checkCopyMap = (m, check) => {
   if (copyMapMemo.has(m)) {
     return true;
   }
@@ -366,6 +366,7 @@ export const checkCopyMap = (m, check = x => x) => {
       X`A copyMap's payload must only have .keys and .values: ${m}`,
     ) &&
     checkElements(keys, check) &&
+    checkKey(keys, check) &&
     check(
       passStyleOf(values) === 'copyArray',
       X`A copyMap's .values must be a copyArray: ${m}`,
@@ -388,7 +389,7 @@ harden(checkCopyMap);
  */
 
 /** @type {IsCopyMap} */
-export const isCopyMap = m => checkCopyMap(m);
+export const isCopyMap = m => checkCopyMap(m, x => x);
 harden(isCopyMap);
 
 /**
@@ -515,10 +516,10 @@ harden(makeCopyMap);
 
 /**
  * @param {Passable} val
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-const checkKeyInternal = (val, check = x => x) => {
+const checkKeyInternal = (val, check) => {
   const checkIt = child => checkKey(child, check);
 
   const passStyle = passStyleOf(val);

--- a/packages/store/src/keys/copyBag.js
+++ b/packages/store/src/keys/copyBag.js
@@ -15,7 +15,7 @@ const { details: X } = assert;
 /**
  * @template T
  * @param {[T,bigint][]} bagEntries
- * @param {FullCompare=} fullCompare If provided and `bagEntries` is already
+ * @param {FullCompare | undefined} fullCompare If provided and `bagEntries` is already
  * known to be sorted by this `fullCompare`, then we should get a memo hit
  * rather than a resorting. However, currently, we still enumerate the entire
  * array each time.
@@ -23,14 +23,10 @@ const { details: X } = assert;
  * TODO: If doing this reduntantly turns out to be expensive, we
  * could memoize this no-duplicate-keys finding as well, independent
  * of the `fullOrder` use to reach this finding.
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-const checkNoDuplicateKeys = (
-  bagEntries,
-  fullCompare = undefined,
-  check = x => x,
-) => {
+const checkNoDuplicateKeys = (bagEntries, fullCompare, check) => {
   // This fullOrder contains history dependent state. It is specific
   // to this one call and does not survive it.
   // TODO Once all our tooling is ready for `&&=`, the following
@@ -64,10 +60,10 @@ export const assertNoDuplicateKeys = (bagEntries, fullCompare = undefined) => {
 
 /**
  * @param {[Passable,bigint][]} bagEntries
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-export const checkBagEntries = (bagEntries, check = x => x) => {
+export const checkBagEntries = (bagEntries, check) => {
   if (passStyleOf(bagEntries) !== 'copyArray') {
     return check(
       false,

--- a/packages/store/src/keys/copySet.js
+++ b/packages/store/src/keys/copySet.js
@@ -15,7 +15,7 @@ const { details: X } = assert;
 /**
  * @template T
  * @param {T[]} elements
- * @param {FullCompare=} fullCompare If provided and `elements` is already known
+ * @param {FullCompare | undefined} fullCompare If provided and `elements` is already known
  * to be sorted by this `fullCompare`, then we should get a memo hit rather
  * than a resorting. However, currently, we still enumerate the entire array
  * each time.
@@ -23,14 +23,10 @@ const { details: X } = assert;
  * TODO: If doing this reduntantly turns out to be expensive, we
  * could memoize this no-duplicate finding as well, independent
  * of the `fullOrder` use to reach this finding.
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-const checkNoDuplicates = (
-  elements,
-  fullCompare = undefined,
-  check = x => x,
-) => {
+const checkNoDuplicates = (elements, fullCompare, check) => {
   // This fullOrder contains history dependent state. It is specific
   // to this one call and does not survive it.
   // TODO Once all our tooling is ready for `&&=`, the following
@@ -61,10 +57,10 @@ export const assertNoDuplicates = (elements, fullCompare = undefined) => {
 
 /**
  * @param {Passable[]} elements
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
-export const checkElements = (elements, check = x => x) => {
+export const checkElements = (elements, check) => {
   if (passStyleOf(elements) !== 'copyArray') {
     return check(
       false,
@@ -81,8 +77,9 @@ export const checkElements = (elements, check = x => x) => {
 };
 harden(checkElements);
 
-export const assertElements = elements =>
+export const assertElements = elements => {
   checkElements(elements, assertChecker);
+};
 harden(assertElements);
 
 export const coerceToElements = elementsList => {

--- a/packages/store/src/patterns/internal-types.js
+++ b/packages/store/src/patterns/internal-types.js
@@ -16,14 +16,14 @@
 //  * enforced by the common calling logic.
 //  *
 //  * @property {(allegedPayload: Passable,
-//  *             check?: Checker
+//  *             check: Checker
 //  * ) => boolean} checkIsMatcherPayload
 //  * Assumes this is the payload of a CopyTagged with the corresponding
 //  * matchTag. Is this a valid payload for a Matcher with that tag?
 //  *
 //  * @property {(specimen: Passable,
 //  *             matcherPayload: Passable,
-//  *             check?: Checker
+//  *             check: Checker
 //  * ) => boolean} checkMatches
 //  * Assuming a valid Matcher of this type with `matcherPayload` as its
 //  * payload, does this specimen match that Matcher?

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -438,14 +438,14 @@
 /**
  * @callback CheckPattern
  * @param {Passable} allegedPattern
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
 
 /**
  * @callback CheckKeyPattern
  * @param {Passable} allegedPattern
- * @param {Checker=} check
+ * @param {Checker} check
  * @returns {boolean}
  */
 
@@ -585,14 +585,14 @@
  * enforced by the common calling logic.
  *
  * @property {(allegedPayload: Passable,
- *             check?: Checker
+ *             check: Checker
  * ) => boolean} checkIsMatcherPayload
  * Assumes this is the payload of a CopyTagged with the corresponding
  * matchTag. Is this a valid payload for a Matcher with that tag?
  *
  * @property {(specimen: Passable,
  *             matcherPayload: Passable,
- *             check?: Checker,
+ *             check: Checker,
  * ) => boolean} checkMatches
  * Assuming a valid Matcher of this type with `matcherPayload` as its
  * payload, does this specimen match that Matcher?
@@ -609,7 +609,7 @@
  * rank as any possible matching specimen.
  *
  * @property {(allegedPattern: Passable,
- *             check?: Checker
+ *             check: Checker
  * ) => boolean} checkKeyPattern
  * Assumes this is the payload of a CopyTagged with the corresponding
  * matchTag. Is this a valid pattern for use as a query key or key schema?

--- a/packages/store/test/test-patterns.js
+++ b/packages/store/test/test-patterns.js
@@ -2,6 +2,7 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { makeTagged } from '@endo/marshal';
 import { makeCopyBag, makeCopyMap, makeCopySet } from '../src/keys/checkKey.js';
 import { fit, matches, M } from '../src/patterns/patternMatchers.js';
 import '../src/types.js';
@@ -280,4 +281,22 @@ test('test simple matches', t => {
       t.false(matches(specimen, noPattern), `${noPattern}`);
     }
   }
+});
+
+test('masking match failure', t => {
+  const nonSet = makeTagged('copySet', harden([M.string()]));
+  const nonBag = makeTagged('copyBag', harden([[M.string(), 8n]]));
+  const nonMap = makeTagged(
+    'copyMap',
+    harden({ keys: [M.string()], values: ['x'] }),
+  );
+  t.throws(() => fit(nonSet, M.set()), {
+    message: 'A passable tagged "match:kind" is not a key: "[match:kind]"',
+  });
+  t.throws(() => fit(nonBag, M.bag()), {
+    message: 'A passable tagged "match:kind" is not a key: "[match:kind]"',
+  });
+  t.throws(() => fit(nonMap, M.map()), {
+    message: 'A passable tagged "match:kind" is not a key: "[match:kind]"',
+  });
 });


### PR DESCRIPTION
There were a few places where I was calling `checkKey` with one argument when I should have been calling it with two. This bug survived because it was being another problems, which this PR fixes:

My practice of the isFoo/assertFoo/checkFoo pattern was to have the `check` parameter of the `checkFoo` functions be optional, and to default to `x => x`. This means that my failure to call it with two arguments when I should have turned into the equivalent of calling it with a `x => x`, turning the call from acting like an assert into acting like a predicate.

Another problem noticed and fixed in the process: When an `assertFoo` function calls a `checkFoo` function with `assertChecker`, then the `checkFoo` function will either return true or throw. However, the `assertFoo` function should either return silently or throw. But some of these `assertFoo` functions forgot to put the call to `checkFoo` in curly braces.

See also https://github.com/endojs/endo/pull/1274

Although these are similar PRs against both our repos, there is no dependence between them. Whew!

---

Separately, prior to this PR `checkKey` could be mislead by a tagged record that obeyed the marshal-level invariants of Tagged but, for example for a tag of `copySet`, did not obey the store-level invariants of CopySet. This led `checkKey` to thinking that a non-CopySet was a valid key, which it is not. The hazard was the use of `keyOf` to get the indicator without the invariant check.

Removes `keyOf`. Enhances `checkKey` to call the necessary invariant checkers itself.