### PR TITLE
fix: ALWAYS default to safe

### DIFF
--- a/packages/wallet/ui/src/lockdown.js
+++ b/packages/wallet/ui/src/lockdown.js
@@ -1,7 +1,9 @@
 // Allow the React dev environment to extend the console for debugging
 // features.
 // eslint-disable-next-line no-constant-condition
-const consoleTaming = '%NODE_ENV%' === 'production' ? 'safe' : 'unsafe';
+const consoleTaming = '%NODE_ENV%' === 'development' ? 'unsafe' : 'safe';
+// eslint-disable-next-line no-constant-condition
+const errorTaming = '%NODE_ENV%' === 'development' ? 'unsafe' : 'safe';
 
 // eslint-disable-next-line no-restricted-properties
 const { pow: mathPow } = Math;
@@ -12,7 +14,7 @@ Math.pow = (base, exp) =>
     : mathPow(base, exp);
 
 lockdown({
-  errorTaming: 'unsafe',
+  errorTaming,
   overrideTaming: 'severe',
   consoleTaming,
 });

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -45,7 +45,7 @@ environment that `agoric-wallet-connection` uses:
 
 ```js
 // Ensure this is imported before anything else in your project.
-import './install-ses-lockdown.js';
+import './install-demo-ses-lockdown.js';
 ```
 
 Or, in your `index.html`:
@@ -112,7 +112,7 @@ This is an example of how to use the wallet connection in plain HTML:
 <button>Connect to Wallet</button>
 
 <script type="module">
-  import './install-ses-lockdown.js';
+  import './install-demo-ses-lockdown.js';
   import '@agoric/wallet-connection/agoric-wallet-connection.js';
 
   // Set up event handlers.

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -33,7 +33,7 @@ import '@endo/eventual-send/shim.js'; // adds support needed by E
 // can still access powerful globals, but this start compartment can use `new Compartment(...)`
 // to evaluate code with stricter confinement.
 lockdown({
-  errorTaming: 'unsafe',
+  errorTaming: 'unsafe', // Should use 'safe' in production mode.
   overrideTaming: 'severe',
 });
 
@@ -45,7 +45,7 @@ environment that `agoric-wallet-connection` uses:
 
 ```js
 // Ensure this is imported before anything else in your project.
-import './install-demo-ses-lockdown.js';
+import './install-ses-lockdown.js';
 ```
 
 Or, in your `index.html`:
@@ -112,7 +112,7 @@ This is an example of how to use the wallet connection in plain HTML:
 <button>Connect to Wallet</button>
 
 <script type="module">
-  import './install-demo-ses-lockdown.js';
+  import './install-ses-lockdown.js';
   import '@agoric/wallet-connection/agoric-wallet-connection.js';
 
   // Set up event handlers.
@@ -154,12 +154,13 @@ requires `consoleTaming` should be set to `unsafe` to make dev-mode work:
 <script>
   // Allow the React dev environment to extend the console for debugging
   // features.
-  const consoleTaming = '%NODE_ENV%' === 'production' ? 'safe' : 'unsafe';
+  const consoleTaming = '%NODE_ENV%' === 'development' ? 'unsafe' : 'safe';
+  const errorTaming = '%NODE_ENV%' === 'development' ? 'unsafe' : 'safe';
 
   lockdown({
-    errorTaming: 'unsafe',
+    consoleTaming,
+    errorTaming,
     overrideTaming: 'severe',
-    consoleTaming: consoleTaming,
   });
 </script>
 ```

--- a/packages/web-components/demo/index.html
+++ b/packages/web-components/demo/index.html
@@ -14,7 +14,7 @@
   <div id="demo"></div>
 
   <script type="module">
-    import './install-ses-lockdown.js';
+    import './install-demo-ses-lockdown.js';
 
     import { E } from '@endo/eventual-send';
     import { html, render } from 'lit';

--- a/packages/web-components/demo/install-demo-ses-lockdown.js
+++ b/packages/web-components/demo/install-demo-ses-lockdown.js
@@ -2,7 +2,7 @@
 import '@endo/init/pre-remoting.js';
 
 lockdown({
-  errorTaming: 'unsafe', // TODO Wen safe?
+  errorTaming: 'unsafe', // Only used for demo mode, so unsafe ok
   stackFiltering: 'verbose',
   overrideTaming: 'severe',
 });

--- a/packages/web-components/demo/install-ses-lockdown.js
+++ b/packages/web-components/demo/install-ses-lockdown.js
@@ -2,7 +2,7 @@
 import '@endo/init/pre-remoting.js';
 
 lockdown({
-  errorTaming: 'unsafe',
+  errorTaming: 'unsafe', // TODO Wen safe?
   stackFiltering: 'verbose',
   overrideTaming: 'severe',
 });

--- a/packages/web-components/test/agoric-wallet-connection.test.js
+++ b/packages/web-components/test/agoric-wallet-connection.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle,import/no-extraneous-dependencies */
-import '../demo/install-ses-lockdown.js';
+import '../demo/install-demo-ses-lockdown.js';
 import { E } from '@endo/eventual-send';
 import { html } from 'lit';
 import { fixture, expect } from '@open-wc/testing';


### PR DESCRIPTION
Configuration options should ***ALWAYS*** default to a safe setting, and require an explicit override to be unsafe.

See https://github.com/Agoric/agoric-sdk/pull/5875/files?diff=split&w=1#r944032788

This PR only fixes one of the two cases I found of `NODE_ENV`. I commented the other, to not lose it. Please advise on how best to fix the commented one. Thanks.

See https://github.com/Agoric/dapp-card-store/pull/58 and https://github.com/Agoric/dapp-fungible-faucet/pull/52