### PR TITLE
refactor(store)!: split `provide` into collision vs no-collision variants

### DIFF
--- a/packages/ERTP/src/transientNotifier.js
+++ b/packages/ERTP/src/transientNotifier.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { makeScalarBigWeakMapStore } from '@agoric/vat-data';
-import { provide } from '@agoric/store';
+import { provideLazy } from '@agoric/store';
 import { makeNotifierKit } from '@agoric/notifier';
 
 // Note: Virtual for high cardinality, but *not* durable, and so
@@ -13,7 +13,7 @@ export const makeTransientNotifierKit = () => {
   );
 
   const provideNotifierKit = key =>
-    provide(transientNotiferKits, key, () =>
+    provideLazy(transientNotiferKits, key, () =>
       makeNotifierKit(key.getCurrentAmount()),
     );
 

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -10,8 +10,8 @@ import { makeNotifierKit } from '@agoric/notifier';
 import { Far, passStyleOf } from '@endo/marshal';
 import { E } from '@endo/eventual-send';
 import { Nat, isNat } from '@agoric/nat';
-import { provide } from '@agoric/store';
 import {
+  provide,
   makeScalarBigMapStore,
   makeScalarBigSetStore,
   vivifyKind,

--- a/packages/SwingSet/src/vats/vattp/vat-vattp.js
+++ b/packages/SwingSet/src/vats/vattp/vat-vattp.js
@@ -1,6 +1,6 @@
 import { assert, details as X } from '@agoric/assert';
-import { provide } from '@agoric/store';
 import {
+  provide,
   defineDurableKindMulti,
   makeScalarBigMapStore,
   provideDurableMapStore,

--- a/packages/SwingSet/test/vo-test-harness/vat-dvo-test-test.js
+++ b/packages/SwingSet/test/vo-test-harness/vat-dvo-test-test.js
@@ -1,7 +1,10 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { provide } from '@agoric/store';
-import { provideKindHandle, defineDurableKind } from '@agoric/vat-data';
+import {
+  provide,
+  provideKindHandle,
+  defineDurableKind,
+} from '@agoric/vat-data';
 
 export function buildRootObject(_vatPowers, vatParameters, baggage) {
   let other;

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -10,7 +10,6 @@
 /**
  * @callback BaseAssert
  * The `assert` function itself.
- *
  * @param {*} flag The truthy/falsy value
  * @param {Details=} optDetails The details to throw
  * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
@@ -74,43 +73,36 @@
  * @param {'bigint'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is bigint}
- *
  * @callback AssertTypeofBoolean
  * @param {any} specimen
  * @param {'boolean'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is boolean}
- *
  * @callback AssertTypeofFunction
  * @param {any} specimen
  * @param {'function'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is Function}
- *
  * @callback AssertTypeofNumber
  * @param {any} specimen
  * @param {'number'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is number}
- *
  * @callback AssertTypeofObject
  * @param {any} specimen
  * @param {'object'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is Record<any, any> | null}
- *
  * @callback AssertTypeofString
  * @param {any} specimen
  * @param {'string'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is string}
- *
  * @callback AssertTypeofSymbol
  * @param {any} specimen
  * @param {'symbol'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is symbol}
- *
  * @callback AssertTypeofUndefined
  * @param {any} specimen
  * @param {'undefined'} typename
@@ -143,7 +135,6 @@
  * Annotate this error with these details, potentially to be used by an
  * augmented console, like the causal console of `console.js`, to
  * provide extra information associated with logged errors.
- *
  * @param {Error} error
  * @param {Details} detailsNote
  * @returns {void}
@@ -217,7 +208,6 @@
  * callback, where that callback actually performs that larger termination.
  * If possible, the callback should also report its `reason` parameter as
  * the alleged reason for the termination.
- *
  * @param {Error} reason
  */
 
@@ -237,7 +227,6 @@
  * that prevents execution from reaching the following throw. However, if
  * `optRaise` returns normally, which would be unusual, the throw following
  * `optRaise(reason)` would still happen.
- *
  * @param {Raise=} optRaise
  * @param {boolean=} unredacted
  * @returns {Assert}

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -73,36 +73,57 @@
  * @param {'bigint'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is bigint}
+ */
+
+/**
  * @callback AssertTypeofBoolean
  * @param {any} specimen
  * @param {'boolean'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is boolean}
+ */
+
+/**
  * @callback AssertTypeofFunction
  * @param {any} specimen
  * @param {'function'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is Function}
+ */
+
+/**
  * @callback AssertTypeofNumber
  * @param {any} specimen
  * @param {'number'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is number}
+ */
+
+/**
  * @callback AssertTypeofObject
  * @param {any} specimen
  * @param {'object'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is Record<any, any> | null}
+ */
+
+/**
  * @callback AssertTypeofString
  * @param {any} specimen
  * @param {'string'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is string}
+ */
+
+/**
  * @callback AssertTypeofSymbol
  * @param {any} specimen
  * @param {'symbol'} typename
  * @param {Details=} optDetails
  * @returns {asserts specimen is symbol}
+ */
+
+/**
  * @callback AssertTypeofUndefined
  * @param {any} specimen
  * @param {'undefined'} typename

--- a/packages/inter-protocol/scripts/deploy-contracts.js
+++ b/packages/inter-protocol/scripts/deploy-contracts.js
@@ -23,7 +23,7 @@ const contractRoots = contractRefs.map(ref =>
 );
 
 /** @type {<T>(store: any, key: string, make: () => T) => Promise<T>} */
-const provide = async (store, key, make) => {
+const provideWhen = async (store, key, make) => {
   const found = await E(store).get(key);
   if (found) {
     return found;
@@ -47,7 +47,9 @@ export default async (homeP, endowments) => {
 
   console.log('getting installCache...');
   /** @type {CopyMap<string, {installation: Installation, boardId: string, path?: string}>} */
-  const initial = await provide(scratch, 'installCache', () => makeCopyMap([]));
+  const initial = await provideWhen(scratch, 'installCache', () =>
+    makeCopyMap([]),
+  );
   console.log('initially:', initial.payload.keys.length, 'entries');
 
   // ISSUE: getCopyMapEntries of CopyMap<K, V> loses K, V.

--- a/packages/inter-protocol/src/proposals/utils.js
+++ b/packages/inter-protocol/src/proposals/utils.js
@@ -68,7 +68,7 @@ export const reserveThenDeposit = async (
 };
 
 /** @type {<T>(store: ERef<MapStore>, key: string, make: () => T) => Promise<T>} */
-const provide = async (store, key, make) => {
+const provideWhen = async (store, key, make) => {
   const found = await E(store).get(key);
   if (found) {
     return found;
@@ -90,7 +90,7 @@ export const makeInstallCache = async (
   { installCacheKey = 'installCache', loadBundle },
 ) => {
   /** @type {CopyMap<string, {installation: Installation, boardId: string, path?: string}>} */
-  const initial = await provide(E.get(homeP).scratch, installCacheKey, () =>
+  const initial = await provideWhen(E.get(homeP).scratch, installCacheKey, () =>
     makeCopyMap([]),
   );
   // ISSUE: getCopyMapEntries of CopyMap<K, V> loses K, V.
@@ -111,7 +111,7 @@ export const makeInstallCache = async (
     const { endoZipBase64Sha512: sha512 } = await loadBundle(bPath).then(
       m => m.default,
     );
-    const detail = await provide(working, sha512, () =>
+    const detail = await provideWhen(working, sha512, () =>
       install(mPath, bPath, opts).then(installation => ({
         installation,
         sha512,

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -11,9 +11,8 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { Far } from '@endo/marshal';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
-import { vivifyKindMulti, M } from '@agoric/vat-data';
+import { provide, vivifyKindMulti, M } from '@agoric/vat-data';
 import { AmountMath } from '@agoric/ertp';
-import { provide } from '@agoric/store';
 
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import { makeMetricsPublishKit } from '../contractSupport.js';

--- a/packages/inter-protocol/src/stakeFactory/attestation.js
+++ b/packages/inter-protocol/src/stakeFactory/attestation.js
@@ -3,7 +3,7 @@
 
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { E, Far } from '@endo/far';
-import { fit, M, makeCopyBag, makeStore, provide } from '@agoric/store';
+import { fit, M, makeCopyBag, makeStore, provideLazy } from '@agoric/store';
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 import { AttKW as KW } from './constants.js';
 import { makeAttestationTool } from './attestationTool.js';
@@ -254,7 +254,7 @@ export const makeAttestationFacets = async (zcf, stakeBrand, lienBridge) => {
        */
       provideAttestationTool: address => {
         assert.typeof(address, 'string');
-        return provide(attMakerByAddress, address, () =>
+        return provideLazy(attMakerByAddress, address, () =>
           makeAttestationTool(address, lienMint, stakeBrand, zcf),
         );
       },

--- a/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -4,10 +4,7 @@ import '@agoric/zoe/exported.js';
 
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { handleParamGovernance, ParamTypes } from '@agoric/governance';
-import {
-  makeAtomicProvider,
-  provide,
-} from '@agoric/store/src/stores/store-utils.js';
+import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import {
   assertIssuerKeywords,
   offerTo,
@@ -17,6 +14,7 @@ import { Far } from '@endo/marshal';
 import {
   provideDurableMapStore,
   provideDurableWeakMapStore,
+  provide,
   vivifyKindMulti,
 } from '@agoric/vat-data';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -76,7 +76,7 @@ export {
   makeScalarMapStore as makeStore, // Deprecated legacy
 } from './stores/scalarMapStore.js';
 
-export { provide } from './stores/store-utils.js';
+export { provideLazy } from './stores/store-utils.js';
 
 // /////////////////////// Deprecated Legacy ///////////////////////////////////
 

--- a/packages/store/src/stores/store-utils.js
+++ b/packages/store/src/stores/store-utils.js
@@ -88,7 +88,7 @@ export const makeCurrentKeysKit = (
 harden(makeCurrentKeysKit);
 
 /**
- * Call `provide` to get or make the value associated with the key.
+ * Call `provideLazy` to get or make the value associated with the key.
  * If there already is one, return that. Otherwise,
  * call `makeValue(key)`, remember it as the value for
  * that key, and return it.
@@ -99,16 +99,17 @@ harden(makeCurrentKeysKit);
  * @param {(key: K) => V} makeValue
  * @returns {V}
  */
-export const provide = (mapStore, key, makeValue) => {
+export const provideLazy = (mapStore, key, makeValue) => {
   if (!mapStore.has(key)) {
     mapStore.init(key, makeValue(key));
   }
   return mapStore.get(key);
 };
-harden(provide);
+harden(provideLazy);
 
 /**
- * Helper for use cases in which the maker function is async. For two provide
+ * Helper for use cases in which the maker function is async. For two
+ * provideLazy
  * calls with the same key, one may be making when the other call starts and it
  * would make again. (Then there'd be a collision when the second tries to store
  * the key.) This prevents that race condition by immediately storing a Promise

--- a/packages/store/src/stores/store-utils.js
+++ b/packages/store/src/stores/store-utils.js
@@ -108,10 +108,10 @@ export const provideLazy = (mapStore, key, makeValue) => {
 harden(provideLazy);
 
 /**
- * Helper for use cases in which the maker function is async. For two
- * provideLazy
- * calls with the same key, one may be making when the other call starts and it
- * would make again. (Then there'd be a collision when the second tries to store
+ * Helper for use cases in which the maker function is async.
+ * For two provideLazy calls with the same key, one may be making when the
+ * other call starts and it would make again.
+ * (Then there'd be a collision when the second tries to store
  * the key.) This prevents that race condition by immediately storing a Promise
  * for the maker in an ephemeral store.
  *
@@ -135,8 +135,10 @@ export const makeAtomicProvider = store => {
    * that key, and return it.
    *
    * @param {K} key
-   * @param {(key: K) => Promise<V>} makeValue make the value for the store if it hasn't been made yet or the last make failed
-   * @param {(key: K, value: V) => Promise<void>} [finishValue] runs exactly once after a new value is added to the store
+   * @param {(key: K) => Promise<V>} makeValue make the value for the store
+   * if it hasn't been made yet or the last make failed
+   * @param {(key: K, value: V) => Promise<void>} [finishValue] runs exactly
+   * once after a new value is added to the store
    * @returns {Promise<V>}
    */
   const provideAsync = (key, makeValue, finishValue) => {

--- a/packages/store/test/test-store.js
+++ b/packages/store/test/test-store.js
@@ -9,7 +9,7 @@ import { makeLegacyWeakMap } from '../src/legacy/legacyWeakMap.js';
 import { makeScalarMapStore } from '../src/stores/scalarMapStore.js';
 import { makeScalarSetStore } from '../src/stores/scalarSetStore.js';
 import { makeScalarWeakMapStore } from '../src/stores/scalarWeakMapStore.js';
-import { provide } from '../src/stores/store-utils.js';
+import { provideLazy } from '../src/stores/store-utils.js';
 
 import '../src/types.js';
 
@@ -212,12 +212,12 @@ test('iteration succeeds with concurrent deletion', t => {
   t.deepEqual(seenValues, [0, 1, 2, 3, 5]);
 });
 
-test('provide for mapStores', t => {
+test('provideLazy for mapStores', t => {
   const m = makeScalarMapStore('provider');
   let i = 1;
   const makeValue = k => `${k} ${(i += 1)}`;
-  t.is(provide(m, 'a', makeValue), 'a 2');
-  t.is(provide(m, 'b', makeValue), 'b 3');
-  t.is(provide(m, 'a', makeValue), 'a 2');
-  t.is(provide(m, 'b', makeValue), 'b 3');
+  t.is(provideLazy(m, 'a', makeValue), 'a 2');
+  t.is(provideLazy(m, 'b', makeValue), 'b 3');
+  t.is(provideLazy(m, 'a', makeValue), 'a 2');
+  t.is(provideLazy(m, 'b', makeValue), 'b 3');
 });

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -1,6 +1,6 @@
 import { objectMap } from '@agoric/internal';
-import { provide } from '@agoric/store';
 import {
+  provide,
   defineDurableKind,
   defineDurableKindMulti,
   makeKindHandle,

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -119,10 +119,7 @@ harden(partialAssign);
  * @param {(key?: string) => any} makeValue
  * @returns {any}
  */
-export const provide = (baggage, key, makeValue) => {
-  return provideLazy(baggage, key, makeValue);
-};
-harden(provide);
+export const provide = provideLazy;
 
 export const provideDurableMapStore = (baggage, name) =>
   provide(baggage, name, () => makeScalarBigMapStore(name, { durable: true }));

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -114,10 +114,11 @@ harden(partialAssign);
  * than one in the same vat incarnation with the same
  * baggage,key pair.
  *
+ * @template K,V
  * @param {import('./types.js').Baggage} baggage
- * @param {string} key
- * @param {(key?: string) => any} makeValue
- * @returns {any}
+ * @param {K} key
+ * @param {(key: K) => V} makeValue
+ * @returns {V}
  */
 export const provide = provideLazy;
 

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -7,7 +7,7 @@ import {
   makeScalarWeakMapStore,
   makeScalarSetStore,
   makeScalarWeakSetStore,
-  provide,
+  provideLazy,
 } from '@agoric/store';
 
 export {
@@ -88,6 +88,41 @@ export const partialAssign = (target, source) => {
   Object.assign(target, source);
 };
 harden(partialAssign);
+
+/**
+ * Unlike `provideLazy`, `provide` should be called at most once
+ * within any vat incarnation with a given `baggage`,`key` pair.
+ *
+ * `provide` should only to be used to populate baggage,
+ * where the total number of calls to `provide` must be
+ * low cardinality, since we keep the bookkeeping to detect collisions
+ * in normal language-heap memory. All the other baggage-oriented
+ * `provide*` and `vivify*` functions call `provide`,
+ * and so impose the same constraints. This is consistent with
+ * our expected durability patterns: What we store in baggage are
+ *    * kindHandles, which are per kind, which must be low cardinality
+ *    * data "variables" for reestablishing the lexical scope, especially
+ *      of singletons
+ *    * named non-baggage collections at the leaves of the baggage tree.
+ *
+ * What is expected to be high cardinality are the instances of the kinds,
+ * and the members of the non-bagggage collections.
+ *
+ * TODO https://github.com/Agoric/agoric-sdk/pull/5875 :
+ * Implement development-time instrumentation to detect when
+ * `provide` violates the above prescription, and is called more
+ * than one in the same vat incarnation with the same
+ * baggage,key pair.
+ *
+ * @param {import('./types.js').Baggage} baggage
+ * @param {string} key
+ * @param {(key?: string) => any} makeValue
+ * @returns {any}
+ */
+export const provide = (baggage, key, makeValue) => {
+  return provideLazy(baggage, key, makeValue);
+};
+harden(provide);
 
 export const provideDurableMapStore = (baggage, name) =>
   provide(baggage, name, () => makeScalarBigMapStore(name, { durable: true }));

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -3,7 +3,7 @@
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { Nat } from '@agoric/nat';
 import { makeScalarMapStore } from '@agoric/store';
-import { provide } from '@agoric/store/src/stores/store-utils.js';
+import { provideLazy } from '@agoric/store/src/stores/store-utils.js';
 import { E, Far } from '@endo/far';
 
 import { deeplyFulfilledObject } from '@agoric/internal';
@@ -77,7 +77,7 @@ export const makeVatsFromBundles = ({
   vatStore.resolve(store);
 
   loadVat.resolve(bundleName => {
-    return provide(store, bundleName, _k => {
+    return provideLazy(store, bundleName, _k => {
       console.info(`createVatByName(${bundleName})`);
       /** @type { Promise<VatInfo> } */
       const vatInfo = E(svc).createVatByName(bundleName, { name: bundleName });

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { provide } from '@agoric/store';
+import { provide } from '@agoric/vat-data';
 import { assertKeywordName } from './cleanProposal.js';
 
 const { ownKeys } = Reflect;

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,8 +1,7 @@
 // @ts-check
 
 import { assert } from '@agoric/assert';
-import { provide } from '@agoric/store';
-import { defineDurableKind, makeKindHandle } from '@agoric/vat-data';
+import { provide, defineDurableKind, makeKindHandle } from '@agoric/vat-data';
 import { Far } from '@endo/marshal';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */


### PR DESCRIPTION
#5875 would enable us to diagnose provide collisions, once we have support for turning on this instrumentation only during development. (The instrumentation provides an unsafe global communications channel, and so cannot be on in production.)

In order to do so, it must distinguish between `provide` calls on baggage that should obey the no-collision rule vs other uses on baggage or any map, for example for lazy initialization, where a no-collision rule would be inappropriate. With this PR, the lazy initialization use is supported by `provideLazy`. The stricter `provide`, being meaningful only wrt baggage, is moved from `@agoric/store` to `@agoric/vat-data`. Because we're moving it up the dependency graph, we cannot easily leave behind an adapter in `@agoric/store` that forwards to the new one, so this PR pays the compat cost instead.

Even without that instrumentation, this separation of intent is useful, so this PR extracts that portion so it can be merged first.

Completely separately, assert/src/type.js comment whitespace has been a perpetual annoyance, as `yarn lint-fix` collapses newlines between separate `@callbacks` needed for readability. This PR changes the comments to be resistant to disruption by `yarn lint-fix`.