### PR TITLE
fix: patch to emulate endo #1275

### DIFF
--- a/patches/@endo+marshal+0.7.3.patch
+++ b/patches/@endo+marshal+0.7.3.patch
@@ -1,0 +1,72 @@
+diff --git a/node_modules/@endo/marshal/src/helpers/safe-promise.js b/node_modules/@endo/marshal/src/helpers/safe-promise.js
+index f22b245..c075f03 100644
+--- a/node_modules/@endo/marshal/src/helpers/safe-promise.js
++++ b/node_modules/@endo/marshal/src/helpers/safe-promise.js
+@@ -23,25 +23,52 @@ const checkPromiseOwnKeys = (pr, check = x => x) => {
+     key => typeof key !== 'symbol' || !hasOwnPropertyOf(Promise.prototype, key),
+   );
+ 
++  const checkSafeEnoughKey = key => {
++    const val = pr[key];
++    if (val === undefined || typeof val === 'number') {
++      return true;
++    }
++    if (
++      typeof val === 'object' &&
++      val !== null &&
++      isFrozen(val) &&
++      getPrototypeOf(val) === Object.prototype
++    ) {
++      const subKeys = ownKeys(val);
++      if (subKeys.length === 0) {
++        return true;
++      }
++
++      // At the time of this writing, Node's async_hooks contains the
++      // following code, which we can also safely tolerate
++      //
++      // function destroyTracking(promise, parent) {
++      // trackPromise(promise, parent);
++      //   const asyncId = promise[async_id_symbol];
++      //   const destroyed = { destroyed: false };
++      //   promise[destroyedSymbol] = destroyed;
++      //   registerDestroyHook(promise, asyncId, destroyed);
++      // }
++
++      if (
++        subKeys.length === 1 &&
++        subKeys[0] === 'destroyed' &&
++        val.destroyed === false
++      ) {
++        return true;
++      }
++    }
++    return check(
++      false,
++      X`Unexpected promise own property value: ${pr}.${q(key)} is ${val}`,
++    );
++  };
++
+   return (
+     check(
+       unknownKeys.length === 0,
+       X`${pr} - Must not have any own properties: ${q(unknownKeys)}`,
+-    ) &&
+-    check(
+-      keys.filter(key => {
+-        const val = pr[key];
+-        return !(
+-          val === undefined ||
+-          typeof val === 'number' ||
+-          (typeof val === 'object' &&
+-            isFrozen(val) &&
+-            getPrototypeOf(val) === Object.prototype &&
+-            ownKeys(val).length === 0)
+-        );
+-      }).length === 0,
+-      X`${pr} - async_hooks own keys have unexpected values`,
+-    )
++    ) && keys.every(checkSafeEnoughKey)
+   );
+ };
+ 


### PR DESCRIPTION
Our attempt to safely tolerate Node async_hooks was safe, but missed a case we could handle safely and which is provoked at least by the vscode debugger.

This patch emulates https://github.com/endojs/endo/pull/1275 so that, for example, our experience debugging our code under vscode stops encountering this problem.

From recent experience, we know that we can't really depend on endo patches to smooth over agoric-sdk dependence on unreleased endo features. But AFAIK, we (including our users) only encounter this condition during development, and our previous problem with patches happened only under CI, which has never been known to provoke the case handled here.