### PR TITLE
feat: charter for the PSM, enabling governance

### DIFF
--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -521,6 +521,7 @@
  * @typedef {object} GovernedContractFacetAccess
  * @property {VoteOnParamChanges} voteOnParamChanges
  * @property {VoteOnApiInvocation} voteOnApiInvocation
+ * @property {VoteOnOfferFilter} voteOnOfferFilter
  * @property {() => Promise<LimitedCreatorFacet<CF>>} getCreatorFacet - creator
  *   facet of the governed contract, without the tightly held ability to change
  *   param values.

--- a/packages/inter-protocol/src/psm/psmCharter.js
+++ b/packages/inter-protocol/src/psm/psmCharter.js
@@ -66,9 +66,15 @@ export const start = async (zcf, privateArgs) => {
     VoteOnPauseOffers: makeOfferFilterInvitation,
   });
 
-  const publicFacet = Far('votingAPI', {
-    invitationMakers,
+  const charterMemberHandler = seat => {
+    seat.exit();
+    return invitationMakers;
+  };
+
+  const creatorFacet = Far('psm charter creator', {
+    makeCharterMemberInvitation: () =>
+      zcf.makeInvitation(charterMemberHandler, 'PSM charter member invitation'),
   });
 
-  return harden({ publicFacet });
+  return harden({ creatorFacet });
 };

--- a/packages/inter-protocol/src/psm/psmCharter.js
+++ b/packages/inter-protocol/src/psm/psmCharter.js
@@ -1,0 +1,74 @@
+// @ts-check
+
+import '@agoric/governance/src/exported.js';
+import '@agoric/zoe/exported.js';
+import '@agoric/zoe/src/contracts/exported.js';
+
+import { E, Far } from '@endo/far';
+
+/**
+ * @file
+ *
+ * This contract makes it possible for those who govern the PSM to call for
+ * votes on changes. A more complete implementation would validate parameters,
+ * constrain deadlines and possibly split the ability to call for votes into
+ * separate capabilities for finer grain encapsulation.
+ */
+
+/**
+ * @param {ZCF<{binaryVoteCounterInstallation:Installation}>} zcf
+ * @param {{psm:GovernedContractFacetAccess<{},{}>}} privateArgs
+ */
+export const start = async (zcf, privateArgs) => {
+  const { binaryVoteCounterInstallation: counter } = zcf.getTerms();
+  const { psm } = privateArgs;
+
+  const makeParamInvitaion = () => {
+    /**
+     * @param {Record<string, unknown>} params
+     * @param {bigint} deadline
+     * @param {{paramPath: { key: string }}} [path]
+     */
+    const voteOnParamChanges = (
+      params,
+      deadline,
+      path = { paramPath: { key: 'governedApi' } },
+    ) => {
+      return E(psm).voteOnParamChanges(counter, deadline, {
+        ...path,
+        changes: params,
+      });
+    };
+
+    return zcf.makeInvitation(
+      () => Far('param change hook', { voteOnParamChanges }),
+      'vote on param changes',
+    );
+  };
+
+  const makeOfferFilterInvitation = () => {
+    /**
+     * @param {string[]} strings
+     * @param {bigint} deadline
+     */
+    const voteOnOfferFilter = (strings, deadline) => {
+      return E(psm).voteOnOfferFilter(counter, deadline, strings);
+    };
+
+    return zcf.makeInvitation(
+      () => Far('offer filter hook', { voteOnOfferFilter }),
+      'vote on offer filter',
+    );
+  };
+
+  const invitationMakers = Far('PSM Invitation Makers', {
+    VoteOnParamChange: makeParamInvitaion,
+    VoteOnPauseOffers: makeOfferFilterInvitation,
+  });
+
+  const publicFacet = Far('votingAPI', {
+    invitationMakers,
+  });
+
+  return harden({ publicFacet });
+};

--- a/packages/inter-protocol/test/psm/test-governedPsm.js
+++ b/packages/inter-protocol/test/psm/test-governedPsm.js
@@ -24,7 +24,6 @@ test('psm block offers w/Governance', async t => {
   const invitations = await E(committeeCreator).getVoterInvitations();
   const { governorCreatorFacet } = governor;
 
-  // @ts-expect-error undeclared type?
   const { details } = await E(governorCreatorFacet).voteOnOfferFilter(
     installs.counter,
     2n,


### PR DESCRIPTION
closes: #6089

## Description

A `Charter` for the PSM to allow the econ committee to govern it.

### Security Considerations

This bundles the ability to vote in the same facet as the ability to call for votes. For the initial release we want both of these to be in the hands of the econ committee.

### Documentation Considerations

None

### Testing Considerations

No tests are included.  I don't know how this would get hooked into the bootstrap space, so I'm not sure how invoke it in a test environment.
