### PR TITLE
feat: add a continuing invitation to the voter facet

### DIFF
--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -60,6 +60,18 @@ const start = (zcf, privateArgs) => {
           const { voteCap } = allQuestions.get(questionHandle);
           return E(voteCap).submitVote(voterHandle, positions, 1n);
         },
+        getInvitationMaker: () =>
+          Far('invitation maker', {
+            makeVoteInvitation: questionHandle => {
+              const continuingVoteHandler = (_seat, { positions }) => {
+                _seat.exit();
+                const { voteCap } = allQuestions.get(questionHandle);
+                return E(voteCap).submitVote(voterHandle, positions, 1n);
+              };
+
+              return zcf.makeInvitation(continuingVoteHandler, 'vote');
+            },
+          }),
       });
     };
 

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
@@ -46,7 +46,7 @@ const build = async (log, zoe) => {
       /** @type {Promise<CommitteeElectoratePublic>} electoratePublicFacet */
       const electoratePublicFacet = E(zoe).getPublicFacet(electorateInstance);
       const seat = E(zoe).offer(invitation);
-      const voteFacet = E(seat).getOfferResult();
+      const { voter: voteFacet } = E.get(E(seat).getOfferResult());
       void E.when(E(seat).getPayouts(), async () => {
         void E.when(E(seat).hasExited(), exited => {
           log(`Seat ${name} ${exited ? 'has exited' : 'is open'}`);
@@ -75,7 +75,7 @@ const build = async (log, zoe) => {
       /** @type {Promise<CommitteeElectoratePublic>} electoratePublicFacet */
       const electoratePublicFacet = E(zoe).getPublicFacet(electorateInstance);
       const seat = E(zoe).offer(invitation);
-      const voteFacet = E(seat).getOfferResult();
+      const { voter: voteFacet } = E.get(E(seat).getOfferResult());
 
       const voteMap = new Map();
       choices.forEach(entry => {

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
@@ -46,7 +46,7 @@ const build = async (log, zoe) => {
       /** @type {Promise<CommitteeElectoratePublic>} electoratePublicFacet */
       const electoratePublicFacet = E(zoe).getPublicFacet(electorateInstance);
       const seat = E(zoe).offer(invitation);
-      const { voter: voteFacet } = E.get(E(seat).getOfferResult());
+      const { voter } = E.get(E(seat).getOfferResult());
       void E.when(E(seat).getPayouts(), async () => {
         void E.when(E(seat).hasExited(), exited => {
           log(`Seat ${name} ${exited ? 'has exited' : 'is open'}`);
@@ -56,7 +56,7 @@ const build = async (log, zoe) => {
       const votingObserver = Far('voting observer', {
         updateState: details => {
           log(`${name} voted for ${q(choice)}`);
-          return E(voteFacet).castBallotFor(details.questionHandle, [choice]);
+          return E(voter).castBallotFor(details.questionHandle, [choice]);
         },
       });
       const subscriber = E(electoratePublicFacet).getQuestionSubscriber();
@@ -75,7 +75,7 @@ const build = async (log, zoe) => {
       /** @type {Promise<CommitteeElectoratePublic>} electoratePublicFacet */
       const electoratePublicFacet = E(zoe).getPublicFacet(electorateInstance);
       const seat = E(zoe).offer(invitation);
-      const { voter: voteFacet } = E.get(E(seat).getOfferResult());
+      const { voter } = E.get(E(seat).getOfferResult());
 
       const voteMap = new Map();
       choices.forEach(entry => {
@@ -86,7 +86,7 @@ const build = async (log, zoe) => {
         updateState: details => {
           const choice = voteMap.get(details.issue.text);
           log(`${name} voted on ${q(details.issue)} for ${q(choice)}`);
-          return E(voteFacet).castBallotFor(details.questionHandle, [choice]);
+          return E(voter).castBallotFor(details.questionHandle, [choice]);
         },
       });
       const subscriber = E(electoratePublicFacet).getQuestionSubscriber();

--- a/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
@@ -18,7 +18,7 @@ const build = async (log, zoe) => {
   return Far('voter', {
     createVoter: async (name, invitation) => {
       const seat = E(zoe).offer(invitation);
-      const voteFacet = E(seat).getOfferResult();
+      const { voter: voteFacet } = E.get(E(seat).getOfferResult());
 
       return Far(`Voter ${name}`, {
         castBallotFor: async (questionHandle, choice) => {

--- a/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/vat-voter.js
@@ -18,12 +18,12 @@ const build = async (log, zoe) => {
   return Far('voter', {
     createVoter: async (name, invitation) => {
       const seat = E(zoe).offer(invitation);
-      const { voter: voteFacet } = E.get(E(seat).getOfferResult());
+      const { voter } = E.get(E(seat).getOfferResult());
 
       return Far(`Voter ${name}`, {
         castBallotFor: async (questionHandle, choice) => {
           log(`Voter ${name} voted for ${q(choice)}`);
-          return E(voteFacet).castBallotFor(questionHandle, [choice]);
+          return E(voter).castBallotFor(questionHandle, [choice]);
         },
         /**
          *

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -133,7 +133,7 @@ const setUpVoterAndVote = async (committeeCreator, zoe, qHandle, choice) => {
   const invitations = await E(committeeCreator).getVoterInvitations();
 
   const seat = E(zoe).offer(invitations[0]);
-  const voteFacet = E(seat).getOfferResult();
+  const voteFacet = E.get(E(seat).getOfferResult()).voter;
   return E(voteFacet).castBallotFor(qHandle, [choice]);
 };
 
@@ -414,9 +414,8 @@ test('change param continuing invitation', async t => {
   const invitations = await E(committeeCreator).getVoterInvitations();
 
   const seat = E(zoe).offer(invitations[0]);
-  const voteFacet = E(seat).getOfferResult();
-  const continuingInvitation = E(voteFacet).getInvitationMaker();
-  const voteInvitation = E(continuingInvitation).makeVoteInvitation(
+  const { invitationMakers } = E.get(E(seat).getOfferResult());
+  const voteInvitation = E(invitationMakers).makeVoteInvitation(
     details.questionHandle,
   );
   await E(zoe).offer(voteInvitation, {}, {}, { positions: [positive] });

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -133,8 +133,8 @@ const setUpVoterAndVote = async (committeeCreator, zoe, qHandle, choice) => {
   const invitations = await E(committeeCreator).getVoterInvitations();
 
   const seat = E(zoe).offer(invitations[0]);
-  const voteFacet = E.get(E(seat).getOfferResult()).voter;
-  return E(voteFacet).castBallotFor(qHandle, [choice]);
+  const { voter } = E.get(E(seat).getOfferResult());
+  return E(voter).castBallotFor(qHandle, [choice]);
 };
 
 test('governParam no votes', async t => {

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/test-amm-governance.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/test-amm-governance.js
@@ -88,8 +88,8 @@ test('amm change param via Governance', async t => {
 
   const exerciseAndVote = invitation => {
     const seat = E(zoe).offer(invitation);
-    const voteFacet = E(seat).getOfferResult();
-    return E(voteFacet).castBallotFor(questionHandle, [positions[0]]);
+    const { voter } = E.get(E(seat).getOfferResult());
+    return E(voter).castBallotFor(questionHandle, [positions[0]]);
   };
   await Promise.all(invitations.map(exerciseAndVote));
 
@@ -194,8 +194,8 @@ test('price check after Governance param change', async t => {
 
   const exerciseAndVote = invitation => {
     const seat = E(zoe).offer(invitation);
-    const voteFacet = E(seat).getOfferResult();
-    return E(voteFacet).castBallotFor(questionHandle, [positions[0]]);
+    const { voter } = E.get(E(seat).getOfferResult());
+    return E(voter).castBallotFor(questionHandle, [positions[0]]);
   };
   await Promise.all(invitations.map(exerciseAndVote));
 

--- a/packages/inter-protocol/test/psm/test-governedPsm.js
+++ b/packages/inter-protocol/test/psm/test-governedPsm.js
@@ -34,8 +34,8 @@ test('psm block offers w/Governance', async t => {
 
   const exerciseAndVote = invitation => {
     const seat = E(zoe).offer(invitation);
-    const voteFacet = E(seat).getOfferResult();
-    return E(voteFacet).castBallotFor(questionHandle, [positions[0]]);
+    const { voter } = E.get(E(seat).getOfferResult());
+    return E(voter).castBallotFor(questionHandle, [positions[0]]);
   };
   await Promise.all(invitations.map(exerciseAndVote));
 

--- a/packages/inter-protocol/test/reserve/test-reserve.js
+++ b/packages/inter-protocol/test/reserve/test-reserve.js
@@ -197,7 +197,7 @@ test('governance add Liquidity to the AMM', async t => {
     space.consume.economicCommitteeCreatorFacet,
   ).getVoterInvitations();
 
-  const voterFacet = await E(E(zoe).offer(voterInvitation)).getOfferResult();
+  const { voter } = await E(E(zoe).offer(voterInvitation)).getOfferResult();
 
   const params = harden([moola(90_000n), AmountMath.make(runBrand, 80_000n)]);
   const { details: detailsP } = await E(
@@ -210,9 +210,7 @@ test('governance add Liquidity to the AMM', async t => {
   );
   const details = await detailsP;
 
-  await E(voterFacet).castBallotFor(details.questionHandle, [
-    details.positions[0],
-  ]);
+  await E(voter).castBallotFor(details.questionHandle, [details.positions[0]]);
   await timer.tick();
   await timer.tick();
   await eventLoopIteration();
@@ -285,7 +283,7 @@ test('request more collateral than available', async t => {
     space.consume.economicCommitteeCreatorFacet,
   ).getVoterInvitations();
 
-  const voterFacet = await E(E(zoe).offer(voterInvitation)).getOfferResult();
+  const { voter } = await E(E(zoe).offer(voterInvitation)).getOfferResult();
 
   const params = harden([moola(90_000n), AmountMath.make(runBrand, 80_000n)]);
   const { details: detailsP, outcomeOfUpdate } = await E(
@@ -298,9 +296,7 @@ test('request more collateral than available', async t => {
   );
   const details = await detailsP;
 
-  await E(voterFacet).castBallotFor(details.questionHandle, [
-    details.positions[0],
-  ]);
+  await E(voter).castBallotFor(details.questionHandle, [details.positions[0]]);
   await timer.tick();
   await timer.tick();
 
@@ -438,7 +434,7 @@ test('reserve burn IST', async t => {
     space.consume.economicCommitteeCreatorFacet,
   ).getVoterInvitations();
 
-  const voterFacet = await E(E(zoe).offer(voterInvitation)).getOfferResult();
+  const { voter } = await E(E(zoe).offer(voterInvitation)).getOfferResult();
 
   const params = harden([oneKRun]);
   const { details: detailsP } = await E(
@@ -450,9 +446,7 @@ test('reserve burn IST', async t => {
     TimeMath.addAbsRel(timer.getCurrentTimestamp(), 2n),
   );
   const details = await detailsP;
-  await E(voterFacet).castBallotFor(details.questionHandle, [
-    details.positions[0],
-  ]);
+  await E(voter).castBallotFor(details.questionHandle, [details.positions[0]]);
   await timer.tick();
   await timer.tick();
 

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -122,7 +122,7 @@ export const makeVoterTool = async (
   const [invitation] = await E(electorateCreator).getVoterInvitations();
   await stakeFactoryGovernorCreatorFacet;
   const seat = E(zoe).offer(invitation);
-  const voteFacet = E(seat).getOfferResult();
+  const { voter } = E.get(E(seat).getOfferResult());
   return harden({
     changeParam: async (paramsSpec, deadline) => {
       /** @type { ContractGovernanceVoteResult } */
@@ -130,7 +130,7 @@ export const makeVoterTool = async (
         stakeFactoryGovernorCreatorFacet,
       ).voteOnParamChanges(counter, deadline, paramsSpec);
       const { questionHandle, positions } = await details;
-      const cast = E(voteFacet).castBallotFor(questionHandle, [positions[0]]);
+      const cast = E(voter).castBallotFor(questionHandle, [positions[0]]);
       const count = E(zoe).getPublicFacet(instance);
       const outcome = E(count).getOutcome();
       return { cast, outcome };

--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -572,9 +572,9 @@ test('Committee can raise debt limit', async t => {
       t.log({ inv });
       const seat = await E(zoe).offer(inv);
       t.log({ seat });
-      const voteFacet = await E(seat).getOfferResult();
-      t.log({ voteFacet });
-      return E(voteFacet).castBallotFor(questionHandle, [positions[0]]);
+      const { voter } = await E(seat).getOfferResult();
+      t.log({ voter });
+      return E(voter).castBallotFor(questionHandle, [positions[0]]);
     }),
   );
 


### PR DESCRIPTION
closes: #6091

## Description

Add a continuing invitation to the voter facet to be used via the SmartWallet.

### Security Considerations

The new method on the voter facet enforces the same attenuation as the previous. While the underlying capability can specify any weight, the facet provided to the user can only vote the owner's actual share.

### Documentation Considerations

None. Only relevant to the wallet developer.

### Testing Considerations

Added a test that grabs the voting capability, but doesn't try to use it as a continuing invitation.