### PR TITLE
feat: hold onto adminFacets in bootstrap

### DIFF
--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -244,7 +244,7 @@ export const registerScaledPriceAuthority = async (
  */
 export const addAssetToVault = async (
   {
-    consume: { vaultFactoryFacets, agoricNamesAdmin },
+    consume: { vaultFactoryKit, agoricNamesAdmin },
     brand: {
       consume: { [Stable.symbol]: stableP },
     },
@@ -260,7 +260,7 @@ export const addAssetToVault = async (
   );
 
   const stable = await stableP;
-  const vaultFactoryCreator = E.get(vaultFactoryFacets).creatorFacet;
+  const vaultFactoryCreator = E.get(vaultFactoryKit).creatorFacet;
   await E(vaultFactoryCreator).addVaultType(interchainIssuer, oracleBrand, {
     debtLimit: AmountMath.make(stable, 0n),
     // the rest of these are arbitrary, TBD by gov cttee
@@ -320,7 +320,7 @@ export const getManifestForAddAssetToVault = (
       },
       [addAssetToVault.name]: {
         consume: {
-          vaultFactoryFacets: true,
+          vaultFactoryKit: true,
           agoricNamesAdmin: true,
         },
         brand: {

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -244,7 +244,7 @@ export const registerScaledPriceAuthority = async (
  */
 export const addAssetToVault = async (
   {
-    consume: { vaultFactoryCreator, agoricNamesAdmin },
+    consume: { vaultFactoryFacets, agoricNamesAdmin },
     brand: {
       consume: { [Stable.symbol]: stableP },
     },
@@ -260,6 +260,7 @@ export const addAssetToVault = async (
   );
 
   const stable = await stableP;
+  const vaultFactoryCreator = E.get(vaultFactoryFacets).creatorFacet;
   await E(vaultFactoryCreator).addVaultType(interchainIssuer, oracleBrand, {
     debtLimit: AmountMath.make(stable, 0n),
     // the rest of these are arbitrary, TBD by gov cttee
@@ -319,9 +320,7 @@ export const getManifestForAddAssetToVault = (
       },
       [addAssetToVault.name]: {
         consume: {
-          vaultFactoryCreator: true,
-          ammCreatorFacet: true,
-          reserveCreatorFacet: true,
+          vaultFactoryFacets: true,
           agoricNamesAdmin: true,
         },
         brand: {

--- a/packages/inter-protocol/src/proposals/committee-proposal.js
+++ b/packages/inter-protocol/src/proposals/committee-proposal.js
@@ -46,7 +46,7 @@ harden(inviteCommitteeMembers);
  */
 export const startEconCharter = async ({
   consume: { zoe },
-  produce: { econCharterFacets },
+  produce: { econCharterKit },
   installation: {
     consume: { binaryVoteCounter: counterP, econCommitteeCharter: installP },
   },
@@ -67,7 +67,7 @@ export const startEconCharter = async ({
   /** @type {Promise<import('./econ-behaviors').EconCharterStartResult>} */
   const startResult = E(zoe).startInstance(charterInstall, undefined, terms);
   instanceP.resolve(E.get(startResult).instance);
-  econCharterFacets.resolve(startResult);
+  econCharterKit.resolve(startResult);
 };
 harden(startEconCharter);
 
@@ -75,21 +75,21 @@ harden(startEconCharter);
  * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
  */
 export const addGovernorsToEconCharter = async ({
-  consume: { reserveFacets, ammFacets, vaultFactoryFacets, econCharterFacets },
+  consume: { reserveKit, ammKit, vaultFactoryKit, econCharterKit },
   instance: {
     consume: { amm, reserve, VaultFactory },
   },
 }) => {
-  const { creatorFacet } = E.get(econCharterFacets);
+  const { creatorFacet } = E.get(econCharterKit);
 
   // Introduce charter to governed creator facets.
   await Promise.all(
     [
-      { instanceP: amm, facetP: E.get(ammFacets).governorCreatorFacet },
-      { instanceP: reserve, facetP: E.get(reserveFacets).governorCreatorFacet },
+      { instanceP: amm, facetP: E.get(ammKit).governorCreatorFacet },
+      { instanceP: reserve, facetP: E.get(reserveKit).governorCreatorFacet },
       {
         instanceP: VaultFactory,
-        facetP: E.get(vaultFactoryFacets).governorCreatorFacet,
+        facetP: E.get(vaultFactoryKit).governorCreatorFacet,
       },
     ].map(async ({ instanceP, facetP }) => {
       const [instance, govFacet] = await Promise.all([instanceP, facetP]);
@@ -106,10 +106,10 @@ harden(addGovernorsToEconCharter);
  * @param {{ options: { voterAddresses: Record<string, string> }}} param1
  */
 export const inviteToEconCharter = async (
-  { consume: { namesByAddressAdmin, econCharterFacets } },
+  { consume: { namesByAddressAdmin, econCharterKit } },
   { options: { voterAddresses } },
 ) => {
-  const { creatorFacet } = E.get(econCharterFacets);
+  const { creatorFacet } = E.get(econCharterKit);
 
   await Promise.all(
     values(voterAddresses).map(async addr =>
@@ -137,7 +137,7 @@ export const getManifestForInviteCommittee = async (
       },
       [startEconCharter.name]: {
         consume: { zoe: t },
-        produce: { econCharterFacets: t },
+        produce: { econCharterKit: t },
         installation: {
           consume: { binaryVoteCounter: t, econCommitteeCharter: t },
         },
@@ -150,14 +150,14 @@ export const getManifestForInviteCommittee = async (
           reserveGovernorCreatorFacet: t,
           ammGovernorCreatorFacet: t,
           vaultFactoryGovernorCreator: t,
-          econCharterFacets: t,
+          econCharterKit: t,
           zoe: t,
           agoricNames: t,
           namesByAddressAdmin: t,
           economicCommitteeCreatorFacet: t,
-          reserveFacets: t,
-          ammFacets: t,
-          vaultFactoryFacets: t,
+          reserveKit: t,
+          ammKit: t,
+          vaultFactoryKit: t,
         },
         installation: {
           consume: { binaryVoteCounter: t },
@@ -167,7 +167,7 @@ export const getManifestForInviteCommittee = async (
         },
       },
       [inviteToEconCharter.name]: {
-        consume: { namesByAddressAdmin: t, econCharterFacets: t },
+        consume: { namesByAddressAdmin: t, econCharterKit: t },
       },
     },
     installations: {

--- a/packages/inter-protocol/src/proposals/committee-proposal.js
+++ b/packages/inter-protocol/src/proposals/committee-proposal.js
@@ -46,7 +46,7 @@ harden(inviteCommitteeMembers);
  */
 export const startEconCharter = async ({
   consume: { zoe },
-  produce: { econCharterStartResult },
+  produce: { econCharterFacets },
   installation: {
     consume: { binaryVoteCounter: counterP, econCommitteeCharter: installP },
   },
@@ -66,8 +66,8 @@ export const startEconCharter = async ({
 
   /** @type {Promise<import('./econ-behaviors').EconCharterStartResult>} */
   const startResult = E(zoe).startInstance(charterInstall, undefined, terms);
-  econCharterStartResult.resolve(startResult);
   instanceP.resolve(E.get(startResult).instance);
+  econCharterFacets.resolve(startResult);
 };
 harden(startEconCharter);
 
@@ -75,17 +75,12 @@ harden(startEconCharter);
  * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers
  */
 export const addGovernorsToEconCharter = async ({
-  consume: {
-    reserveFacets,
-    ammFacets,
-    vaultFactoryFacets,
-    econCharterStartResult,
-  },
+  consume: { reserveFacets, ammFacets, vaultFactoryFacets, econCharterFacets },
   instance: {
     consume: { amm, reserve, VaultFactory },
   },
 }) => {
-  const { creatorFacet } = E.get(econCharterStartResult);
+  const { creatorFacet } = E.get(econCharterFacets);
 
   // Introduce charter to governed creator facets.
   await Promise.all(
@@ -111,10 +106,10 @@ harden(addGovernorsToEconCharter);
  * @param {{ options: { voterAddresses: Record<string, string> }}} param1
  */
 export const inviteToEconCharter = async (
-  { consume: { namesByAddressAdmin, econCharterStartResult } },
+  { consume: { namesByAddressAdmin, econCharterFacets } },
   { options: { voterAddresses } },
 ) => {
-  const { creatorFacet } = E.get(econCharterStartResult);
+  const { creatorFacet } = E.get(econCharterFacets);
 
   await Promise.all(
     values(voterAddresses).map(async addr =>
@@ -142,7 +137,7 @@ export const getManifestForInviteCommittee = async (
       },
       [startEconCharter.name]: {
         consume: { zoe: t },
-        produce: { econCharterStartResult: t },
+        produce: { econCharterFacets: t },
         installation: {
           consume: { binaryVoteCounter: t, econCommitteeCharter: t },
         },
@@ -155,7 +150,7 @@ export const getManifestForInviteCommittee = async (
           reserveGovernorCreatorFacet: t,
           ammGovernorCreatorFacet: t,
           vaultFactoryGovernorCreator: t,
-          econCharterStartResult: t,
+          econCharterFacets: t,
           zoe: t,
           agoricNames: t,
           namesByAddressAdmin: t,
@@ -172,7 +167,7 @@ export const getManifestForInviteCommittee = async (
         },
       },
       [inviteToEconCharter.name]: {
-        consume: { namesByAddressAdmin: t, econCharterStartResult: t },
+        consume: { namesByAddressAdmin: t, econCharterFacets: t },
       },
     },
     installations: {

--- a/packages/inter-protocol/src/proposals/committee-proposal.js
+++ b/packages/inter-protocol/src/proposals/committee-proposal.js
@@ -76,9 +76,9 @@ harden(startEconCharter);
  */
 export const addGovernorsToEconCharter = async ({
   consume: {
-    reserveGovernorCreatorFacet,
-    ammGovernorCreatorFacet,
-    vaultFactoryGovernorCreator,
+    reserveFacets,
+    ammFacets,
+    vaultFactoryFacets,
     econCharterStartResult,
   },
   instance: {
@@ -90,11 +90,11 @@ export const addGovernorsToEconCharter = async ({
   // Introduce charter to governed creator facets.
   await Promise.all(
     [
-      { instanceP: amm, facetP: ammGovernorCreatorFacet },
-      { instanceP: reserve, facetP: reserveGovernorCreatorFacet },
+      { instanceP: amm, facetP: E.get(ammFacets).governorCreatorFacet },
+      { instanceP: reserve, facetP: E.get(reserveFacets).governorCreatorFacet },
       {
         instanceP: VaultFactory,
-        facetP: vaultFactoryGovernorCreator,
+        facetP: E.get(vaultFactoryFacets).governorCreatorFacet,
       },
     ].map(async ({ instanceP, facetP }) => {
       const [instance, govFacet] = await Promise.all([instanceP, facetP]);
@@ -156,6 +156,16 @@ export const getManifestForInviteCommittee = async (
           ammGovernorCreatorFacet: t,
           vaultFactoryGovernorCreator: t,
           econCharterStartResult: t,
+          zoe: t,
+          agoricNames: t,
+          namesByAddressAdmin: t,
+          economicCommitteeCreatorFacet: t,
+          reserveFacets: t,
+          ammFacets: t,
+          vaultFactoryFacets: t,
+        },
+        installation: {
+          consume: { binaryVoteCounter: t },
         },
         instance: {
           consume: { amm: t, reserve: t, VaultFactory: t },

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -21,7 +21,7 @@ const SHARED_MAIN_MANIFEST = harden({
       zoe: 'zoe',
       economicCommitteeCreatorFacet: 'economicCommittee',
     },
-    produce: { ammFacets: 'amm' },
+    produce: { ammKit: 'amm' },
     issuer: { consume: { [Stable.symbol]: 'zoe' } },
     brand: { consume: { [Stable.symbol]: 'zoe' } },
     installation: {
@@ -56,9 +56,9 @@ const SHARED_MAIN_MANIFEST = harden({
       zoe: 'zoe',
       priceAuthority: 'priceAuthority',
       economicCommitteeCreatorFacet: 'economicCommittee',
-      reserveFacets: 'reserve',
+      reserveKit: 'reserve',
     },
-    produce: { vaultFactoryFacets: 'VaultFactory' },
+    produce: { vaultFactoryKit: 'VaultFactory' },
     brand: { consume: { [Stable.symbol]: 'zoe' } },
     oracleBrand: { consume: { USD: true } },
     installation: {
@@ -84,13 +84,13 @@ const SHARED_MAIN_MANIFEST = harden({
     consume: {
       client: 'provisioning',
       priceAuthorityAdmin: 'priceAuthority',
-      vaultFactoryFacets: 'VaultFactory',
+      vaultFactoryKit: 'VaultFactory',
     },
   },
 
   [econBehaviors.setupReserve.name]: {
     consume: {
-      ammFacets: 'amm',
+      ammKit: 'amm',
       board: 'board',
       chainStorage: true,
       feeMintAccess: 'zoe',
@@ -98,7 +98,7 @@ const SHARED_MAIN_MANIFEST = harden({
       zoe: 'zoe',
       economicCommitteeCreatorFacet: 'economicCommittee',
     },
-    produce: { reserveFacets: 'reserve' },
+    produce: { reserveKit: 'reserve' },
     issuer: { consume: { [Stable.symbol]: 'zoe' } },
     brand: { consume: { [Stable.symbol]: 'zoe' } },
     installation: {
@@ -142,14 +142,14 @@ const REWARD_MANIFEST = harden({
     consume: {
       chainTimerService: true,
       bankManager: true,
-      vaultFactoryFacets: true,
+      vaultFactoryKit: true,
       periodicFeeCollectors: true,
-      ammFacets: true,
-      stakeFactoryFacets: true,
-      reserveFacets: true,
+      ammKit: true,
+      stakeFactoryKit: true,
+      reserveKit: true,
       zoe: true,
     },
-    produce: { feeDistributorFacets: true, periodicFeeCollectors: true },
+    produce: { feeDistributorKit: true, periodicFeeCollectors: true },
     instance: { produce: { feeDistributor: true } },
     installation: { consume: { feeDistributor: true } },
     issuer: { consume: { [Stable.symbol]: 'zoe' } },
@@ -177,7 +177,7 @@ const STAKE_FACTORY_MANIFEST = harden({
       economicCommitteeCreatorFacet: 'economicCommittee',
     },
     produce: {
-      stakeFactoryFacets: 'stakeFactory',
+      stakeFactoryKit: 'stakeFactory',
     },
     installation: {
       consume: { contractGovernor: 'zoe', stakeFactory: 'zoe' },
@@ -208,7 +208,7 @@ export const SIM_CHAIN_MANIFEST = harden({
       mints: 'mints',
       priceAuthorityVat: 'priceAuthority',
       priceAuthorityAdmin: 'priceAuthority',
-      vaultFactoryFacets: 'VaultFactory',
+      vaultFactoryKit: 'VaultFactory',
       zoe: true,
     },
     installation: {

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -21,11 +21,7 @@ const SHARED_MAIN_MANIFEST = harden({
       zoe: 'zoe',
       economicCommitteeCreatorFacet: 'economicCommittee',
     },
-    produce: {
-      ammCreatorFacet: 'amm',
-      ammInstanceWithoutReserve: 'amm',
-      ammGovernorCreatorFacet: 'amm',
-    },
+    produce: { ammFacets: 'amm' },
     issuer: { consume: { [Stable.symbol]: 'zoe' } },
     brand: { consume: { [Stable.symbol]: 'zoe' } },
     installation: {
@@ -60,13 +56,9 @@ const SHARED_MAIN_MANIFEST = harden({
       zoe: 'zoe',
       priceAuthority: 'priceAuthority',
       economicCommitteeCreatorFacet: 'economicCommittee',
-      reserveCreatorFacet: 'reserve',
+      reserveFacets: 'reserve',
     },
-    produce: {
-      vaultFactoryCreator: 'VaultFactory',
-      vaultFactoryGovernorCreator: 'VaultFactory',
-      vaultFactoryVoteCreator: 'VaultFactory',
-    },
+    produce: { vaultFactoryFacets: 'VaultFactory' },
     brand: { consume: { [Stable.symbol]: 'zoe' } },
     oracleBrand: { consume: { USD: true } },
     installation: {
@@ -92,14 +84,13 @@ const SHARED_MAIN_MANIFEST = harden({
     consume: {
       client: 'provisioning',
       priceAuthorityAdmin: 'priceAuthority',
-      vaultFactoryCreator: 'VaultFactory',
+      vaultFactoryFacets: 'VaultFactory',
     },
   },
 
   [econBehaviors.setupReserve.name]: {
     consume: {
-      ammCreatorFacet: 'amm',
-      ammInstanceWithoutReserve: 'amm',
+      ammFacets: 'amm',
       board: 'board',
       chainStorage: true,
       feeMintAccess: 'zoe',
@@ -107,11 +98,7 @@ const SHARED_MAIN_MANIFEST = harden({
       zoe: 'zoe',
       economicCommitteeCreatorFacet: 'economicCommittee',
     },
-    produce: {
-      reserveCreatorFacet: 'reserve',
-      reserveGovernorCreatorFacet: 'reserve',
-      reservePublicFacet: 'reserve',
-    },
+    produce: { reserveFacets: 'reserve' },
     issuer: { consume: { [Stable.symbol]: 'zoe' } },
     brand: { consume: { [Stable.symbol]: 'zoe' } },
     installation: {
@@ -155,14 +142,14 @@ const REWARD_MANIFEST = harden({
     consume: {
       chainTimerService: true,
       bankManager: true,
-      vaultFactoryCreator: true,
+      vaultFactoryFacets: true,
       periodicFeeCollectors: true,
-      ammCreatorFacet: true,
-      stakeFactoryCreatorFacet: true,
-      reservePublicFacet: true,
+      ammFacets: true,
+      stakeFactoryFacets: true,
+      reserveFacets: true,
       zoe: true,
     },
-    produce: { feeDistributorCreatorFacet: true, periodicFeeCollectors: true },
+    produce: { feeDistributorFacets: true, periodicFeeCollectors: true },
     instance: { produce: { feeDistributor: true } },
     installation: { consume: { feeDistributor: true } },
     issuer: { consume: { [Stable.symbol]: 'zoe' } },
@@ -190,8 +177,7 @@ const STAKE_FACTORY_MANIFEST = harden({
       economicCommitteeCreatorFacet: 'economicCommittee',
     },
     produce: {
-      stakeFactoryCreatorFacet: 'stakeFactory',
-      stakeFactoryGovernorCreatorFacet: 'stakeFactory',
+      stakeFactoryFacets: 'stakeFactory',
     },
     installation: {
       consume: { contractGovernor: 'zoe', stakeFactory: 'zoe' },
@@ -222,7 +208,7 @@ export const SIM_CHAIN_MANIFEST = harden({
       mints: 'mints',
       priceAuthorityVat: 'priceAuthority',
       priceAuthorityAdmin: 'priceAuthority',
-      vaultFactoryCreator: 'VaultFactory',
+      vaultFactoryFacets: 'VaultFactory',
       zoe: true,
     },
     installation: {

--- a/packages/inter-protocol/src/proposals/demoIssuers.js
+++ b/packages/inter-protocol/src/proposals/demoIssuers.js
@@ -464,7 +464,7 @@ export const fundAMM = async ({
     mints,
     priceAuthorityVat,
     priceAuthorityAdmin,
-    vaultFactoryCreator,
+    vaultFactoryFacets,
     zoe,
   },
   installation: {
@@ -576,7 +576,7 @@ export const fundAMM = async ({
         );
 
         const issuerPresence = await kit.issuer;
-        return E(vaultFactoryCreator).addVaultType(
+        return E(E.get(vaultFactoryFacets).creatorFacet).addVaultType(
           issuerPresence,
           issuerName,
           rates,

--- a/packages/inter-protocol/src/proposals/demoIssuers.js
+++ b/packages/inter-protocol/src/proposals/demoIssuers.js
@@ -464,7 +464,7 @@ export const fundAMM = async ({
     mints,
     priceAuthorityVat,
     priceAuthorityAdmin,
-    vaultFactoryFacets,
+    vaultFactoryKit,
     zoe,
   },
   installation: {
@@ -576,7 +576,7 @@ export const fundAMM = async ({
         );
 
         const issuerPresence = await kit.issuer;
-        return E(E.get(vaultFactoryFacets).creatorFacet).addVaultType(
+        return E(E.get(vaultFactoryKit).creatorFacet).addVaultType(
           issuerPresence,
           issuerName,
           rates,

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -64,10 +64,7 @@ const MILLI = 1_000_000n;
  *   periodicFeeCollectors: import('../feeDistributor.js').PeriodicFeeCollector[],
  *   bankMints: Mint[],
  *   psmFacets: MapStore<Brand, PSMFacets>,
- *   econCharterFacets: {
- *     creatorFacet: EconCharterStartResult,
- *     adminFacet: AdminFacet,
- *   },
+ *   econCharterFacets: EconCharterStartResult,
  *   reserveFacets: {
  *     publicFacet: import('../reserve/assetReserve.js').AssetReservePublicFacet,
  *     creatorFacet: import('../reserve/assetReserve.js').AssetReserveLimitedCreatorFacet,

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -38,13 +38,13 @@ export const startPSM = async (
       zoe,
       feeMintAccess: feeMintAccessP,
       economicCommitteeCreatorFacet,
-      econCharterFacets,
+      econCharterKit,
       provisionPoolStartResult,
       chainStorage,
       chainTimerService,
-      psmFacets,
+      psmKit,
     },
-    produce: { psmFacets: producePsmFacets },
+    produce: { psmKit: producepsmKit },
     installation: {
       consume: { contractGovernor, psm: psmInstall },
     },
@@ -162,9 +162,9 @@ export const startPSM = async (
     E(governorFacets.creatorFacet).getAdminFacet(),
   ]);
 
-  /** @typedef {import('./econ-behaviors.js').PSMFacets} PSMFacets */
-  /** @type {PSMFacets} */
-  const newPsmFacets = {
+  /** @typedef {import('./econ-behaviors.js').PSMKit} psmKit */
+  /** @type {psmKit} */
+  const newpsmKit = {
     psm,
     psmGovernor: governorFacets.instance,
     psmCreatorFacet,
@@ -173,18 +173,18 @@ export const startPSM = async (
   };
 
   // Provide pattern with a promise.
-  producePsmFacets.resolve(makeScalarMapStore());
+  producepsmKit.resolve(makeScalarMapStore());
 
-  /** @type {MapStore<Brand,PSMFacets>} */
-  const psmFacetsMap = await psmFacets;
+  /** @type {MapStore<Brand,psmKit>} */
+  const psmKitMap = await psmKit;
 
-  psmFacetsMap.init(anchorBrand, newPsmFacets);
+  psmKitMap.init(anchorBrand, newpsmKit);
   const instanceKey = `psm-${Stable.symbol}-${keyword}`;
   const instanceAdmin = E(agoricNamesAdmin).lookupAdmin('instance');
 
   await Promise.all([
-    E(instanceAdmin).update(instanceKey, newPsmFacets.psm),
-    E(E.get(econCharterFacets).creatorFacet).addInstance(
+    E(instanceAdmin).update(instanceKey, newpsmKit.psm),
+    E(E.get(econCharterKit).creatorFacet).addInstance(
       psm,
       governorFacets.creatorFacet,
       instanceKey,
@@ -192,7 +192,7 @@ export const startPSM = async (
     // @ts-expect-error TODO type for provisionPoolStartResult
     E(E.get(provisionPoolStartResult).creatorFacet).initPSM(
       anchorBrand,
-      newPsmFacets.psm,
+      newpsmKit.psm,
     ),
   ]);
 };
@@ -278,7 +278,7 @@ export const installGovAndPSMContracts = async ({
   vatPowers: { D },
   devices: { vatAdmin },
   consume: { zoe },
-  produce: { psmFacets },
+  produce: { psmKit },
   installation: {
     produce: {
       contractGovernor,
@@ -293,7 +293,7 @@ export const installGovAndPSMContracts = async ({
   // indexed by the brand. Since each name in the BootstrapSpace can only be
   // produced  once, we produce an empty store here, and each time a PSM is
   // started up, the details are added to the store.
-  psmFacets.resolve(makeScalarMapStore());
+  psmKit.resolve(makeScalarMapStore());
 
   return Promise.all(
     Object.entries({
@@ -324,7 +324,7 @@ export const PSM_GOV_MANIFEST = {
     vatPowers: { D: true },
     devices: { vatAdmin: true },
     consume: { zoe: 'zoe' },
-    produce: { psmFacets: 'true' },
+    produce: { psmKit: 'true' },
     installation: {
       produce: {
         contractGovernor: 'zoe',
@@ -338,7 +338,7 @@ export const PSM_GOV_MANIFEST = {
   [startEconCharter.name]: {
     consume: { zoe: 'zoe', agoricNames: true },
     produce: {
-      econCharterFacets: 'econCommitteeCharter',
+      econCharterKit: 'econCommitteeCharter',
     },
     installation: {
       consume: { binaryVoteCounter: 'zoe', econCommitteeCharter: 'zoe' },
@@ -356,13 +356,13 @@ export const INVITE_PSM_COMMITTEE_MANIFEST = harden(
       consume: {
         namesByAddressAdmin: true,
         economicCommitteeCreatorFacet: true,
-        econCharterFacets: true,
+        econCharterKit: true,
       },
     },
     [inviteToEconCharter.name]: {
       consume: {
         namesByAddressAdmin: true,
-        econCharterFacets: true,
+        econCharterKit: true,
       },
     },
   }),
@@ -385,11 +385,11 @@ export const PSM_MANIFEST = harden({
       feeMintAccess: 'zoe',
       economicCommitteeCreatorFacet: 'economicCommittee',
       provisionPoolStartResult: true,
-      econCharterFacets: 'econCommitteeCharter',
+      econCharterKit: 'econCommitteeCharter',
       chainTimerService: 'timer',
-      psmFacets: true,
+      psmKit: true,
     },
-    produce: { psmFacets: 'true' },
+    produce: { psmKit: 'true' },
     installation: {
       consume: { contractGovernor: 'zoe', psm: 'zoe' },
     },

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -313,29 +313,6 @@ export const installGovAndPSMContracts = async ({
 };
 
 /**
- * @deprecated the PSM charter has been merged with the econ charter
- * @param {EconomyBootstrapPowers} powers
- */
-export const startPSMCharter = async ({
-  consume: { zoe },
-  produce: { econCharterFacets },
-  installation: {
-    consume: { binaryVoteCounter, econCommitteeCharter: installP },
-  },
-  instance: {
-    produce: { econCommitteeCharter: instanceP },
-  },
-}) => {
-  const [charterR, counterR] = await Promise.all([installP, binaryVoteCounter]);
-
-  const terms = { binaryVoteCounterInstallation: counterR };
-  const facets = await E(zoe).startInstance(charterR, {}, terms);
-
-  instanceP.resolve(facets.instance);
-  econCharterFacets.resolve(harden(facets));
-};
-
-/**
  * PSM and gov contracts are available as
  * named swingset bundles only in
  * decentral-psm-config.json

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -332,13 +332,7 @@ export const startPSMCharter = async ({
   const facets = await E(zoe).startInstance(charterR, {}, terms);
 
   instanceP.resolve(facets.instance);
-  econCharterFacets.resolve(
-    harden({
-      creatorFacet: facets.creatorFacet,
-      adminFacet: facets.adminFacet,
-      instance: facets.instance,
-    }),
-  );
+  econCharterFacets.resolve(harden(facets));
 };
 
 /**
@@ -391,7 +385,7 @@ export const INVITE_PSM_COMMITTEE_MANIFEST = harden(
     [inviteToEconCharter.name]: {
       consume: {
         namesByAddressAdmin: true,
-        econCharterStartResult: true,
+        econCharterFacets: true,
       },
     },
   }),

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/setup.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/setup.js
@@ -142,7 +142,7 @@ export const setupAmmServices = async (
     counter: installation.consume.binaryVoteCounter,
   });
 
-  const governorCreatorFacet = consume.ammGovernorCreatorFacet;
+  const governorCreatorFacet = E.get(consume.ammFacets).governorCreatorFacet;
   const governorInstance = await instance.consume.ammGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
   const g = {
@@ -155,7 +155,7 @@ export const setupAmmServices = async (
   /** @type { GovernedPublicFacet<XYKAMMPublicFacet> } */
   const ammPublicFacet = await E(governorCreatorFacet).getPublicFacet();
   const amm = {
-    ammCreatorFacet: await consume.ammCreatorFacet,
+    ammCreatorFacet: await E.get(consume.ammFacets).creatorFacet,
     ammPublicFacet,
     instance: governedInstance,
   };

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/setup.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/setup.js
@@ -142,7 +142,7 @@ export const setupAmmServices = async (
     counter: installation.consume.binaryVoteCounter,
   });
 
-  const governorCreatorFacet = E.get(consume.ammFacets).governorCreatorFacet;
+  const governorCreatorFacet = E.get(consume.ammKit).governorCreatorFacet;
   const governorInstance = await instance.consume.ammGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
   const g = {
@@ -155,7 +155,7 @@ export const setupAmmServices = async (
   /** @type { GovernedPublicFacet<XYKAMMPublicFacet> } */
   const ammPublicFacet = await E(governorCreatorFacet).getPublicFacet();
   const amm = {
-    ammCreatorFacet: await E.get(consume.ammFacets).creatorFacet,
+    ammCreatorFacet: await E.get(consume.ammKit).creatorFacet,
     ammPublicFacet,
     instance: governedInstance,
   };

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
@@ -380,7 +380,7 @@ test('MinInitialPoolLiquidity to reserve', async t => {
     { committeeName: 'EnBancPanel', committeeSize: 3 },
     centralR,
   );
-  const { reserveFacets } = space.consume;
+  const { reserveKit } = space.consume;
 
   const liquidityIssuer = await E(amm.ammPublicFacet).addIssuer(
     moolaKit.issuer,
@@ -413,7 +413,7 @@ test('MinInitialPoolLiquidity to reserve', async t => {
     `Added Moola and Central Liquidity`,
   );
 
-  const reserveCreatorFacet = E.get(reserveFacets).creatorFacet;
+  const reserveCreatorFacet = E.get(reserveKit).creatorFacet;
   const reserveAllocations = await E(reserveCreatorFacet).getAllocations();
   t.deepEqual(reserveAllocations, {
     RmoolaLiquidity: AmountMath.make(liquidityBrand, 1000n),

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
@@ -380,7 +380,7 @@ test('MinInitialPoolLiquidity to reserve', async t => {
     { committeeName: 'EnBancPanel', committeeSize: 3 },
     centralR,
   );
-  const { reserveCreatorFacet } = space.consume;
+  const { reserveFacets } = space.consume;
 
   const liquidityIssuer = await E(amm.ammPublicFacet).addIssuer(
     moolaKit.issuer,
@@ -413,6 +413,7 @@ test('MinInitialPoolLiquidity to reserve', async t => {
     `Added Moola and Central Liquidity`,
   );
 
+  const reserveCreatorFacet = E.get(reserveFacets).creatorFacet;
   const reserveAllocations = await E(reserveCreatorFacet).getAllocations();
   t.deepEqual(reserveAllocations, {
     RmoolaLiquidity: AmountMath.make(liquidityBrand, 1000n),

--- a/packages/inter-protocol/test/psm/gov-add-psm-permit.json
+++ b/packages/inter-protocol/test/psm/gov-add-psm-permit.json
@@ -7,8 +7,7 @@
     "zoe": "zoe",
     "feeMintAccess": "zoe",
     "economicCommitteeCreatorFacet": "economicCommittee",
-    "econCharterStartResult": true,
-    "econCharterFacets": "econCharter",
+    "econCharterFacets": true,
     "provisionPoolStartResult": true,
     "psmFacets": true,
     "chainTimerService": "timer"

--- a/packages/inter-protocol/test/psm/gov-add-psm-permit.json
+++ b/packages/inter-protocol/test/psm/gov-add-psm-permit.json
@@ -8,6 +8,7 @@
     "feeMintAccess": "zoe",
     "economicCommitteeCreatorFacet": "economicCommittee",
     "econCharterStartResult": true,
+    "econCharterFacets": "econCharter",
     "provisionPoolStartResult": true,
     "psmFacets": true,
     "chainTimerService": "timer"

--- a/packages/inter-protocol/test/psm/gov-add-psm-permit.json
+++ b/packages/inter-protocol/test/psm/gov-add-psm-permit.json
@@ -7,9 +7,9 @@
     "zoe": "zoe",
     "feeMintAccess": "zoe",
     "economicCommitteeCreatorFacet": "economicCommittee",
-    "econCharterFacets": true,
+    "econCharterKit": true,
     "provisionPoolStartResult": true,
-    "psmFacets": true,
+    "psmKit": true,
     "chainTimerService": "timer"
   },
   "produce": {

--- a/packages/inter-protocol/test/psm/gov-replace-committee.js
+++ b/packages/inter-protocol/test/psm/gov-replace-committee.js
@@ -80,7 +80,7 @@ const invitePSMCommitteeMembers = async (
     consume: {
       namesByAddressAdmin,
       economicCommitteeCreatorFacet,
-      econCharterStartResult,
+      econCharterFacets,
     },
   },
   { options: { voterAddresses = {} } },
@@ -99,7 +99,7 @@ const invitePSMCommitteeMembers = async (
         const [voterInvitation, charterMemberInvitation] = await Promise.all([
           invitationP,
           E(
-            E.get(econCharterStartResult).creatorFacet,
+            E.get(econCharterFacets).creatorFacet,
           ).makeCharterMemberInvitation(),
         ]);
         console.log('sending charter, voting invitations to', addr);

--- a/packages/inter-protocol/test/psm/gov-replace-committee.js
+++ b/packages/inter-protocol/test/psm/gov-replace-committee.js
@@ -80,7 +80,7 @@ const invitePSMCommitteeMembers = async (
     consume: {
       namesByAddressAdmin,
       economicCommitteeCreatorFacet,
-      econCharterFacets,
+      econCharterKit,
     },
   },
   { options: { voterAddresses = {} } },
@@ -98,9 +98,7 @@ const invitePSMCommitteeMembers = async (
       addrInvitations.map(async ([addr, invitationP]) => {
         const [voterInvitation, charterMemberInvitation] = await Promise.all([
           invitationP,
-          E(
-            E.get(econCharterFacets).creatorFacet,
-          ).makeCharterMemberInvitation(),
+          E(E.get(econCharterKit).creatorFacet).makeCharterMemberInvitation(),
         ]);
         console.log('sending charter, voting invitations to', addr);
         await reserveThenDeposit(
@@ -209,10 +207,10 @@ const main = async permittedPowers => {
   /*
    * tell all the PSM contracts about it
    */
-  const psmFacetsMap = await permittedPowers.consume.psmFacets;
+  const psmKitMap = await permittedPowers.consume.psmKit;
   // TODO make sure new PSMs get this committee (using ".reset" in the space?)
-  const replacements = [...psmFacetsMap.values()].map(psmFacets =>
-    E(psmFacets.psmGovernorCreatorFacet).replaceElectorate(newElectoratePoser),
+  const replacements = [...psmKitMap.values()].map(psmKit =>
+    E(psmKit.psmGovernorCreatorFacet).replaceElectorate(newElectoratePoser),
   );
   await Promise.all(replacements);
 

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -122,7 +122,7 @@ export const setupPsm = async (
   brand.produce.AUSD.resolve(knut.brand);
   issuer.produce.AUSD.resolve(knut.issuer);
 
-  space.produce.psmFacets.resolve(makeScalarMapStore());
+  space.produce.psmKit.resolve(makeScalarMapStore());
   const istIssuer = await E(zoe).getFeeIssuer();
   const istBrand = await E(istIssuer).getBrand();
 
@@ -162,10 +162,10 @@ export const setupPsm = async (
     counter: installation.consume.binaryVoteCounter,
   });
 
-  const allPsms = await consume.psmFacets;
-  const psmFacets = allPsms.get(knut.brand);
-  const governorCreatorFacet = psmFacets.psmGovernorCreatorFacet;
-  const governorInstance = psmFacets.psmGovernor;
+  const allPsms = await consume.psmKit;
+  const psmKit = allPsms.get(knut.brand);
+  const governorCreatorFacet = psmKit.psmGovernorCreatorFacet;
+  const governorInstance = psmKit.psmGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
   const g = {
     governorInstance,
@@ -177,7 +177,7 @@ export const setupPsm = async (
   /** @type { GovernedPublicFacet<import('../../src/psm/psm.js').PsmPublicFacet> } */
   const psmPublicFacet = await E(governorCreatorFacet).getPublicFacet();
   const psm = {
-    psmCreatorFacet: psmFacets.psmCreatorFacet,
+    psmCreatorFacet: psmKit.psmCreatorFacet,
     psmPublicFacet,
     instance: governedInstance,
   };
@@ -185,7 +185,7 @@ export const setupPsm = async (
   const committeeCreator = await consume.economicCommitteeCreatorFacet;
   const electorateInstance = await instance.consume.economicCommittee;
   const { creatorFacet: econCharterCreatorFacet } = await E.get(
-    consume.econCharterFacets,
+    consume.econCharterKit,
   );
 
   const poserInvitationP = E(committeeCreator).getPoserInvitation();

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -184,8 +184,9 @@ export const setupPsm = async (
 
   const committeeCreator = await consume.economicCommitteeCreatorFacet;
   const electorateInstance = await instance.consume.economicCommittee;
-  const { creatorFacet: econCharterCreatorFacet } =
-    await consume.econCharterStartResult;
+  const { creatorFacet: econCharterCreatorFacet } = await E.get(
+    consume.econCharterFacets,
+  );
 
   const poserInvitationP = E(committeeCreator).getPoserInvitation();
   const poserInvitationAmount = await E(

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -52,7 +52,7 @@ const setupReserveBootstrap = async (
   const newAmm = {
     ammCreatorFacet: ammSpaces.amm.ammCreatorFacet,
     ammPublicFacet: ammSpaces.amm.ammPublicFacet,
-    instance: ammSpaces.amm.governedInstance,
+    instance: ammSpaces.amm.instance,
   };
 
   return {
@@ -104,7 +104,9 @@ export const setupReserveServices = async (
   issuer.produce.IST.resolve(runIssuer);
   produce.feeMintAccess.resolve(await feeMintAccess);
 
-  const governorCreatorFacet = consume.reserveGovernorCreatorFacet;
+  const governorCreatorFacet = E.get(
+    consume.reserveFacets,
+  ).governorCreatorFacet;
   const governorInstance = await instance.consume.reserveGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
   const g = {
@@ -119,7 +121,7 @@ export const setupReserveServices = async (
 
   /** @type {ReserveKit} */
   const reserve = {
-    reserveCreatorFacet: await consume.reserveCreatorFacet,
+    reserveCreatorFacet: await E.get(consume.reserveFacets).creatorFacet,
     reservePublicFacet,
     instance: governedInstance,
   };

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -104,9 +104,7 @@ export const setupReserveServices = async (
   issuer.produce.IST.resolve(runIssuer);
   produce.feeMintAccess.resolve(await feeMintAccess);
 
-  const governorCreatorFacet = E.get(
-    consume.reserveFacets,
-  ).governorCreatorFacet;
+  const governorCreatorFacet = E.get(consume.reserveKit).governorCreatorFacet;
   const governorInstance = await instance.consume.reserveGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
   const g = {
@@ -121,7 +119,7 @@ export const setupReserveServices = async (
 
   /** @type {ReserveKit} */
   const reserve = {
-    reserveCreatorFacet: await E.get(consume.reserveFacets).creatorFacet,
+    reserveCreatorFacet: await E.get(consume.reserveKit).creatorFacet,
     reservePublicFacet,
     instance: governedInstance,
   };

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -173,9 +173,9 @@ test('want stable', async t => {
 
 test('govern offerFilter', async t => {
   const { anchor, invitationBrand } = t.context;
-  const { agoricNames, psmFacets, zoe } = await E.get(t.context.consume);
+  const { agoricNames, psmKit, zoe } = await E.get(t.context.consume);
 
-  const { psm: psmInstance } = await E(psmFacets).get(anchor.brand);
+  const { psm: psmInstance } = await E(psmKit).get(anchor.brand);
 
   const wallet = await t.context.simpleProvideWallet(committeeAddress);
   const computedState = coalesceUpdates(E(wallet).getUpdatesSubscriber());

--- a/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
+++ b/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
@@ -296,9 +296,9 @@ test('wrap liened amount', async t => {
 
   const { chain, space } = await bootstrapStakeFactory(t, timer);
   const { consume, instance } = space;
-  const { zoe, stakeFactoryFacets } = consume;
+  const { zoe, stakeFactoryKit } = consume;
   const { stakeFactory: stakeFactoryinstance } = instance.consume;
-  const walletMaker = makeWalletMaker(E.get(stakeFactoryFacets).creatorFacet);
+  const walletMaker = makeWalletMaker(E.get(stakeFactoryKit).creatorFacet);
   const bob = chain.provisionAccount('Bob', 'addr1b');
 
   // Bob introduces himself to the Agoric JS VM.
@@ -324,9 +324,9 @@ test('unwrap liened amount', async t => {
 
   const { chain, space } = await bootstrapStakeFactory(t, timer);
   const { consume, instance } = space;
-  const { zoe, stakeFactoryFacets } = consume;
+  const { zoe, stakeFactoryKit } = consume;
   const { stakeFactory: stakeFactoryinstance } = instance.consume;
-  const walletMaker = makeWalletMaker(E.get(stakeFactoryFacets).creatorFacet);
+  const walletMaker = makeWalletMaker(E.get(stakeFactoryKit).creatorFacet);
   const bob = chain.provisionAccount('Bob', 'addr1b');
 
   // Bob introduces himself to the Agoric JS VM.
@@ -357,7 +357,7 @@ test('stakeFactory API usage', async t => {
 
   const { chain, space } = await bootstrapStakeFactory(t, timer);
   const { consume } = space;
-  const { zoe, stakeFactoryFacets } = consume;
+  const { zoe, stakeFactoryKit } = consume;
   const runBrand = await space.brand.consume.IST;
   const bldBrand = await space.brand.consume.BLD;
   const runIssuer = await space.issuer.consume.IST;
@@ -370,7 +370,7 @@ test('stakeFactory API usage', async t => {
   founder.sendTo('addr1b', 5_000n * micro.unit);
   bob.stake(3_000n * micro.unit);
 
-  const walletMaker = makeWalletMaker(E.get(stakeFactoryFacets).creatorFacet);
+  const walletMaker = makeWalletMaker(E.get(stakeFactoryKit).creatorFacet);
 
   // Bob introduces himself to the Agoric JS VM.
   const bobWallet = walletMaker(bob.getAddress());
@@ -406,7 +406,7 @@ test('extra offer keywords are rejected', async t => {
 
   const { chain, space } = await bootstrapStakeFactory(t, timer);
   const { consume } = space;
-  const { zoe, stakeFactoryFacets } = consume;
+  const { zoe, stakeFactoryKit } = consume;
   const runBrand = await space.brand.consume.IST;
   const bldBrand = await space.brand.consume.BLD;
   const publicFacet = E(zoe).getPublicFacet(
@@ -418,7 +418,7 @@ test('extra offer keywords are rejected', async t => {
   founder.sendTo('addr1b', 5_000n * micro.unit);
   bob.stake(3_000n * micro.unit);
 
-  const walletMaker = makeWalletMaker(E.get(stakeFactoryFacets).creatorFacet);
+  const walletMaker = makeWalletMaker(E.get(stakeFactoryKit).creatorFacet);
 
   // Bob introduces himself to the Agoric JS VM.
   const bobWallet = walletMaker(bob.getAddress());
@@ -516,7 +516,7 @@ const makeWorld = async t => {
   const { chain, space } = await bootstrapStakeFactory(t, timer);
   const { consume } = space;
 
-  const { zoe, stakeFactoryFacets, lienBridge } = consume;
+  const { zoe, stakeFactoryKit, lienBridge } = consume;
   const { IST: runIssuer } = space.issuer.consume;
   const [bldBrand, runBrand] = await Promise.all([
     space.brand.consume.BLD,
@@ -526,14 +526,14 @@ const makeWorld = async t => {
   const stakeFactory = {
     instance: stakeFactoryinstance,
     publicFacet: E(zoe).getPublicFacet(stakeFactoryinstance),
-    creatorFacet: E.get(stakeFactoryFacets).creatorFacet,
+    creatorFacet: E.get(stakeFactoryKit).creatorFacet,
   };
 
   const counter = await space.installation.consume.binaryVoteCounter;
   const committee = makeVoterTool(
     zoe,
     space.consume.economicCommitteeCreatorFacet,
-    E.get(space.consume.stakeFactoryFacets).governorCreatorFacet,
+    E.get(space.consume.stakeFactoryKit).governorCreatorFacet,
     counter,
   );
 

--- a/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
+++ b/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
@@ -296,9 +296,9 @@ test('wrap liened amount', async t => {
 
   const { chain, space } = await bootstrapStakeFactory(t, timer);
   const { consume, instance } = space;
-  const { zoe, stakeFactoryCreatorFacet: creatorFacet } = consume;
+  const { zoe, stakeFactoryFacets } = consume;
   const { stakeFactory: stakeFactoryinstance } = instance.consume;
-  const walletMaker = makeWalletMaker(creatorFacet);
+  const walletMaker = makeWalletMaker(E.get(stakeFactoryFacets).creatorFacet);
   const bob = chain.provisionAccount('Bob', 'addr1b');
 
   // Bob introduces himself to the Agoric JS VM.
@@ -324,9 +324,9 @@ test('unwrap liened amount', async t => {
 
   const { chain, space } = await bootstrapStakeFactory(t, timer);
   const { consume, instance } = space;
-  const { zoe, stakeFactoryCreatorFacet: creatorFacet } = consume;
+  const { zoe, stakeFactoryFacets } = consume;
   const { stakeFactory: stakeFactoryinstance } = instance.consume;
-  const walletMaker = makeWalletMaker(creatorFacet);
+  const walletMaker = makeWalletMaker(E.get(stakeFactoryFacets).creatorFacet);
   const bob = chain.provisionAccount('Bob', 'addr1b');
 
   // Bob introduces himself to the Agoric JS VM.
@@ -357,7 +357,7 @@ test('stakeFactory API usage', async t => {
 
   const { chain, space } = await bootstrapStakeFactory(t, timer);
   const { consume } = space;
-  const { zoe, stakeFactoryCreatorFacet: creatorFacet } = consume;
+  const { zoe, stakeFactoryFacets } = consume;
   const runBrand = await space.brand.consume.IST;
   const bldBrand = await space.brand.consume.BLD;
   const runIssuer = await space.issuer.consume.IST;
@@ -370,7 +370,7 @@ test('stakeFactory API usage', async t => {
   founder.sendTo('addr1b', 5_000n * micro.unit);
   bob.stake(3_000n * micro.unit);
 
-  const walletMaker = makeWalletMaker(creatorFacet);
+  const walletMaker = makeWalletMaker(E.get(stakeFactoryFacets).creatorFacet);
 
   // Bob introduces himself to the Agoric JS VM.
   const bobWallet = walletMaker(bob.getAddress());
@@ -406,7 +406,7 @@ test('extra offer keywords are rejected', async t => {
 
   const { chain, space } = await bootstrapStakeFactory(t, timer);
   const { consume } = space;
-  const { zoe, stakeFactoryCreatorFacet: creatorFacet } = consume;
+  const { zoe, stakeFactoryFacets } = consume;
   const runBrand = await space.brand.consume.IST;
   const bldBrand = await space.brand.consume.BLD;
   const publicFacet = E(zoe).getPublicFacet(
@@ -418,7 +418,7 @@ test('extra offer keywords are rejected', async t => {
   founder.sendTo('addr1b', 5_000n * micro.unit);
   bob.stake(3_000n * micro.unit);
 
-  const walletMaker = makeWalletMaker(creatorFacet);
+  const walletMaker = makeWalletMaker(E.get(stakeFactoryFacets).creatorFacet);
 
   // Bob introduces himself to the Agoric JS VM.
   const bobWallet = walletMaker(bob.getAddress());
@@ -516,7 +516,7 @@ const makeWorld = async t => {
   const { chain, space } = await bootstrapStakeFactory(t, timer);
   const { consume } = space;
 
-  const { zoe, stakeFactoryCreatorFacet, lienBridge } = consume;
+  const { zoe, stakeFactoryFacets, lienBridge } = consume;
   const { IST: runIssuer } = space.issuer.consume;
   const [bldBrand, runBrand] = await Promise.all([
     space.brand.consume.BLD,
@@ -526,15 +526,14 @@ const makeWorld = async t => {
   const stakeFactory = {
     instance: stakeFactoryinstance,
     publicFacet: E(zoe).getPublicFacet(stakeFactoryinstance),
-    creatorFacet: stakeFactoryCreatorFacet,
+    creatorFacet: E.get(stakeFactoryFacets).creatorFacet,
   };
 
   const counter = await space.installation.consume.binaryVoteCounter;
   const committee = makeVoterTool(
     zoe,
     space.consume.economicCommitteeCreatorFacet,
-    // @ts-expect-error TODO: add stakeFactoryGovernorCreatorFacet to vats/src/types.js
-    space.consume.stakeFactoryGovernorCreatorFacet,
+    E.get(space.consume.stakeFactoryFacets).governorCreatorFacet,
     counter,
   );
 

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -162,7 +162,7 @@ const setupAmmAndElectorate = async (t, aethLiquidity, runLiquidity) => {
   });
   await setupReserve(space);
 
-  const governorCreatorFacet = E.get(consume.ammFacets).governorCreatorFacet;
+  const governorCreatorFacet = E.get(consume.ammKit).governorCreatorFacet;
   const governorInstance = await instance.consume.ammGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
   const governedInstance = E(governorPublicFacet).getGovernedContract();
@@ -171,7 +171,7 @@ const setupAmmAndElectorate = async (t, aethLiquidity, runLiquidity) => {
   t.context.committee = makeVoterTool(
     zoe,
     space.consume.economicCommitteeCreatorFacet,
-    E.get(space.consume.vaultFactoryFacets).governorCreatorFacet,
+    E.get(space.consume.vaultFactoryKit).governorCreatorFacet,
     counter,
   );
 
@@ -204,7 +204,7 @@ const setupAmmAndElectorate = async (t, aethLiquidity, runLiquidity) => {
 
   // TODO get the creator directly
   const newAmm = {
-    ammCreatorFacet: await E.get(consume.ammFacets).creatorFacet,
+    ammCreatorFacet: await E.get(consume.ammKit).creatorFacet,
     ammPublicFacet,
     instance: governedInstance,
     ammLiquidity: E(ammLiquiditySeat).getPayout('Liquidity'),
@@ -281,13 +281,13 @@ const setupServices = async (
     proposal: aethInitialLiquidity,
     payment: aeth.mint.mintPayment(aethInitialLiquidity),
   };
-  const { amm: ammFacets, space } = await setupAmmAndElectorate(
+  const { amm: ammKit, space } = await setupAmmAndElectorate(
     t,
     aethLiquidity,
     runLiquidity,
   );
   const { consume, produce } = space;
-  trace(t, 'amm', { ammFacets });
+  trace(t, 'amm', { ammKit });
 
   // Cheesy hack for easy use of manual price authority
   const priceAuthority = makeManualPriceAuthority({
@@ -302,15 +302,13 @@ const setupServices = async (
   const {
     installation: { produce: iProduce },
   } = space;
-  t.context.reserveCreatorFacet = E.get(
-    space.consume.reserveFacets,
-  ).creatorFacet;
+  t.context.reserveCreatorFacet = E.get(space.consume.reserveKit).creatorFacet;
   iProduce.VaultFactory.resolve(t.context.installation.VaultFactory);
   iProduce.liquidate.resolve(t.context.installation.liquidate);
   await startVaultFactory(space, { loanParams: loanTiming }, minInitialDebt);
 
   const governorCreatorFacet = E.get(
-    consume.vaultFactoryFacets,
+    consume.vaultFactoryKit,
   ).governorCreatorFacet;
   /** @type {Promise<VaultFactoryCreatorFacet & LimitedCreatorFacet<any>>} */
   const vaultFactoryCreatorFacet = /** @type { any } */ (
@@ -348,7 +346,7 @@ const setupServices = async (
       lender,
       aethVaultManager,
     },
-    ammFacets,
+    ammKit,
     priceAuthority,
   };
 };
@@ -485,7 +483,7 @@ export const makeManagerDriver = async (
     },
     sellOnAMM: async (give, want, optStopAfter, expected) => {
       const swapInvitation = E(
-        services.ammFacets.ammPublicFacet,
+        services.ammKit.ammPublicFacet,
       ).makeSwapInvitation();
       trace(t, 'AMM sell', { give, want, optStopAfter });
       const offerArgs = optStopAfter
@@ -538,7 +536,7 @@ export const makeManagerDriver = async (
       const reserveAllocations = await E(reserveCreatorFacet).getAllocations();
 
       const liquidityIssuer = await E(
-        services.ammFacets.ammPublicFacet,
+        services.ammKit.ammPublicFacet,
       ).getLiquidityIssuer(aeth.brand);
       const liquidityBrand = await E(liquidityIssuer).getBrand();
 

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -162,7 +162,7 @@ const setupAmmAndElectorate = async (t, aethLiquidity, runLiquidity) => {
   });
   await setupReserve(space);
 
-  const governorCreatorFacet = consume.ammGovernorCreatorFacet;
+  const governorCreatorFacet = E.get(consume.ammFacets).governorCreatorFacet;
   const governorInstance = await instance.consume.ammGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
   const governedInstance = E(governorPublicFacet).getGovernedContract();
@@ -171,7 +171,7 @@ const setupAmmAndElectorate = async (t, aethLiquidity, runLiquidity) => {
   t.context.committee = makeVoterTool(
     zoe,
     space.consume.economicCommitteeCreatorFacet,
-    space.consume.vaultFactoryGovernorCreator,
+    E.get(space.consume.vaultFactoryFacets).governorCreatorFacet,
     counter,
   );
 
@@ -204,7 +204,7 @@ const setupAmmAndElectorate = async (t, aethLiquidity, runLiquidity) => {
 
   // TODO get the creator directly
   const newAmm = {
-    ammCreatorFacet: await consume.ammCreatorFacet,
+    ammCreatorFacet: await E.get(consume.ammFacets).creatorFacet,
     ammPublicFacet,
     instance: governedInstance,
     ammLiquidity: E(ammLiquiditySeat).getPayout('Liquidity'),
@@ -302,12 +302,16 @@ const setupServices = async (
   const {
     installation: { produce: iProduce },
   } = space;
-  t.context.reserveCreatorFacet = space.consume.reserveCreatorFacet;
+  t.context.reserveCreatorFacet = E.get(
+    space.consume.reserveFacets,
+  ).creatorFacet;
   iProduce.VaultFactory.resolve(t.context.installation.VaultFactory);
   iProduce.liquidate.resolve(t.context.installation.liquidate);
   await startVaultFactory(space, { loanParams: loanTiming }, minInitialDebt);
 
-  const governorCreatorFacet = consume.vaultFactoryGovernorCreator;
+  const governorCreatorFacet = E.get(
+    consume.vaultFactoryFacets,
+  ).governorCreatorFacet;
   /** @type {Promise<VaultFactoryCreatorFacet & LimitedCreatorFacet<any>>} */
   const vaultFactoryCreatorFacet = /** @type { any } */ (
     E(governorCreatorFacet).getCreatorFacet()

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -180,7 +180,7 @@ const setupAmmAndElectorateAndReserve = async (
   // AMM needs the reserve in order to function
   await setupReserve(space);
 
-  const governorCreatorFacet = E.get(consume.ammFacets).governorCreatorFacet;
+  const governorCreatorFacet = E.get(consume.ammKit).governorCreatorFacet;
   const governorInstance = await instance.consume.ammGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
   const governedInstance = E(governorPublicFacet).getGovernedContract();
@@ -214,7 +214,7 @@ const setupAmmAndElectorateAndReserve = async (
 
   // TODO get the creator directly
   const newAmm = {
-    ammCreatorFacet: await E.get(consume.ammFacets).creatorFacet,
+    ammCreatorFacet: await E.get(consume.ammKit).creatorFacet,
     ammPublicFacet,
     instance: governedInstance,
     ammLiquidity: E(ammLiquiditySeat).getPayout('Liquidity'),
@@ -320,14 +320,14 @@ const setupServices = async (
     proposal: aethInitialLiquidity,
     payment: aeth.mint.mintPayment(aethInitialLiquidity),
   };
-  const { amm: ammFacets, space } = await setupAmmAndElectorateAndReserve(
+  const { amm: ammKit, space } = await setupAmmAndElectorateAndReserve(
     t,
     aethLiquidity,
     runLiquidity,
   );
 
   const { consume, produce } = space;
-  trace(t, 'amm', { ammFacets });
+  trace(t, 'amm', { ammKit });
 
   const quoteIssuerKit = makeIssuerKit('quote', AssetKind.SET);
   // Cheesy hack for easy use of manual price authority
@@ -358,14 +358,12 @@ const setupServices = async (
   await startVaultFactory(space, { loanParams: loanTiming }, minInitialDebt);
 
   const governorCreatorFacet = E.get(
-    consume.vaultFactoryFacets,
+    consume.vaultFactoryKit,
   ).governorCreatorFacet;
   /** @type {Promise<VaultFactoryCreatorFacet & LimitedCreatorFacet<VaultFactoryCreatorFacet>>} */
-  const vaultFactoryCreatorFacetP = E.get(
-    consume.vaultFactoryFacets,
-  ).creatorFacet;
-  const reserveCreatorFacet = E.get(consume.reserveFacets).creatorFacet;
-  const reserveFacets = { reserveCreatorFacet };
+  const vaultFactoryCreatorFacetP = E.get(consume.vaultFactoryKit).creatorFacet;
+  const reserveCreatorFacet = E.get(consume.reserveKit).creatorFacet;
+  const reserveKit = { reserveCreatorFacet };
 
   // Add a vault that will lend on aeth collateral
   /** @type {Promise<VaultManager>} */
@@ -384,7 +382,7 @@ const setupServices = async (
   ] = await Promise.all([
     E(consume.agoricNames).lookup('instance', 'VaultFactoryGovernor'),
     vaultFactoryCreatorFacetP,
-    E.get(consume.vaultFactoryFacets).publicFacet,
+    E.get(consume.vaultFactoryKit).publicFacet,
     aethVaultManagerP,
     pa,
   ]);
@@ -412,13 +410,13 @@ const setupServices = async (
     zoe,
     governor: g,
     vaultFactory: v,
-    ammFacets,
+    ammKit,
     runKit: { issuer: run.issuer, brand: run.brand },
     priceAuthority,
-    reserveFacets,
+    reserveKit,
     /** @param {Brand<'nat'>} baseBrand */
     getLiquidityBrand: baseBrand =>
-      E(ammFacets.ammPublicFacet)
+      E(ammKit.ammPublicFacet)
         .getLiquidityIssuer(baseBrand)
         .then(liqIssuer => E(liqIssuer).getBrand()),
   };
@@ -566,7 +564,7 @@ test('price drop', async t => {
   const {
     vaultFactory: { vaultFactory, lender },
     priceAuthority,
-    reserveFacets: { reserveCreatorFacet },
+    reserveKit: { reserveCreatorFacet },
   } = services;
 
   // Create a loan for 270 Minted with 400 aeth collateral
@@ -719,7 +717,7 @@ test('price falls precipitously', async t => {
 
   const { vaultFactory, lender } = services.vaultFactory;
 
-  const { reserveCreatorFacet } = services.reserveFacets;
+  const { reserveCreatorFacet } = services.reserveKit;
   // Create a loan for 370 Minted with 400 aeth collateral
   const collateralAmount = aeth.make(400n);
   const loanAmount = run.make(370n);
@@ -757,9 +755,7 @@ test('price falls precipitously', async t => {
   );
 
   // Sell some Eth to drive the value down
-  const swapInvitation = E(
-    services.ammFacets.ammPublicFacet,
-  ).makeSwapInvitation();
+  const swapInvitation = E(services.ammKit.ammPublicFacet).makeSwapInvitation();
   const proposal = harden({
     give: { In: aeth.make(200n) },
     want: { Out: run.makeEmpty() },
@@ -1764,7 +1760,7 @@ test('mutable liquidity triggers and interest', async t => {
   const {
     vaultFactory: { lender },
     priceAuthority,
-    reserveFacets: { reserveCreatorFacet },
+    reserveKit: { reserveCreatorFacet },
   } = services;
 
   const metricsSub = await E(reserveCreatorFacet).getMetrics();
@@ -2038,7 +2034,7 @@ test('collect fees from loan and AMM', async t => {
     Minted: run.make(24n),
   });
 
-  const amm = services.ammFacets.ammPublicFacet;
+  const amm = services.ammKit.ammPublicFacet;
   const swapAmount = aeth.make(60000n);
   const swapSeat = await E(zoe).offer(
     E(amm).makeSwapInInvitation(),

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -180,7 +180,7 @@ const setupAmmAndElectorateAndReserve = async (
   // AMM needs the reserve in order to function
   await setupReserve(space);
 
-  const governorCreatorFacet = consume.ammGovernorCreatorFacet;
+  const governorCreatorFacet = E.get(consume.ammFacets).governorCreatorFacet;
   const governorInstance = await instance.consume.ammGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
   const governedInstance = E(governorPublicFacet).getGovernedContract();
@@ -214,7 +214,7 @@ const setupAmmAndElectorateAndReserve = async (
 
   // TODO get the creator directly
   const newAmm = {
-    ammCreatorFacet: await consume.ammCreatorFacet,
+    ammCreatorFacet: await E.get(consume.ammFacets).creatorFacet,
     ammPublicFacet,
     instance: governedInstance,
     ammLiquidity: E(ammLiquiditySeat).getPayout('Liquidity'),
@@ -357,11 +357,14 @@ const setupServices = async (
   iProduce.liquidate.resolve(t.context.installation.liquidate);
   await startVaultFactory(space, { loanParams: loanTiming }, minInitialDebt);
 
-  const governorCreatorFacet = consume.vaultFactoryGovernorCreator;
+  const governorCreatorFacet = E.get(
+    consume.vaultFactoryFacets,
+  ).governorCreatorFacet;
   /** @type {Promise<VaultFactoryCreatorFacet & LimitedCreatorFacet<VaultFactoryCreatorFacet>>} */
-  // @ts-expect-error TypeScript is confused
-  const vaultFactoryCreatorFacetP = E(governorCreatorFacet).getCreatorFacet();
-  const reserveCreatorFacet = consume.reserveCreatorFacet;
+  const vaultFactoryCreatorFacetP = E.get(
+    consume.vaultFactoryFacets,
+  ).creatorFacet;
+  const reserveCreatorFacet = E.get(consume.reserveFacets).creatorFacet;
   const reserveFacets = { reserveCreatorFacet };
 
   // Add a vault that will lend on aeth collateral
@@ -372,7 +375,6 @@ const setupServices = async (
     rates,
   );
   /** @type {[any, VaultFactoryCreatorFacet, VFC['publicFacet'], VaultManager, PriceAuthority]} */
-  // @ts-expect-error cast
   const [
     governorInstance,
     vaultFactory, // creator
@@ -382,7 +384,7 @@ const setupServices = async (
   ] = await Promise.all([
     E(consume.agoricNames).lookup('instance', 'VaultFactoryGovernor'),
     vaultFactoryCreatorFacetP,
-    E(governorCreatorFacet).getPublicFacet(),
+    E.get(consume.vaultFactoryFacets).publicFacet,
     aethVaultManagerP,
     pa,
   ]);

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -146,7 +146,12 @@ export const startWalletFactory = async (
       consume: { [Stable.symbol]: feeIssuerP },
     },
   },
-  { options: { perAccountInitialValue = (StableUnit * 25n) / 100n } = {} } = {},
+  {
+    options: {
+      perAccountInitialValue = (StableUnit * 25n) / 100n,
+      walletBridgeId = BRIDGE_ID.PROVISION_SMART_WALLET,
+    } = {},
+  } = {},
 ) => {
   const WALLET_STORAGE_PATH = 'wallet';
   const POOL_STORAGE_PATH = 'provisionPool';
@@ -236,7 +241,7 @@ export const startWalletFactory = async (
   });
 
   await Promise.all([
-    E(bridgeManager).register(BRIDGE_ID.PROVISION, handler),
+    E(bridgeManager).register(walletBridgeId, handler),
     E(E.get(econCharterFacets).creatorFacet).addInstance(
       ppFacets.instance,
       ppFacets.creatorFacet,

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -146,12 +146,7 @@ export const startWalletFactory = async (
       consume: { [Stable.symbol]: feeIssuerP },
     },
   },
-  {
-    options: {
-      perAccountInitialValue = (StableUnit * 25n) / 100n,
-      walletBridgeId = BRIDGE_ID.PROVISION_SMART_WALLET,
-    } = {},
-  } = {},
+  { options: { perAccountInitialValue = (StableUnit * 25n) / 100n } = {} } = {},
 ) => {
   const WALLET_STORAGE_PATH = 'wallet';
   const POOL_STORAGE_PATH = 'provisionPool';

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -107,7 +107,10 @@ const startGovernedInstance = async (
  *
  * @param {BootstrapPowers & PromiseSpaceOf<{
  *   economicCommitteeCreatorFacet: import('@agoric/governance/src/committee.js').CommitteeElectorateCreatorFacet
- *   econCharterStartResult: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconCharterStartResult,
+ *   econCharterFacets: {
+ *     creatorFacet: Awaited<ReturnType<import('@agoric/inter-protocol/src/econCommitteeCharter.js').start>>['creatorFacet'],
+ *     adminFacet: AdminFacet,
+ *   } ,
  * }>} powers
  * @param {{
  *   options?: {
@@ -129,7 +132,7 @@ export const startWalletFactory = async (
       zoe,
       chainTimerService,
       economicCommitteeCreatorFacet,
-      econCharterStartResult,
+      econCharterFacets,
     },
     produce: { client, walletFactoryStartResult, provisionPoolStartResult },
     installation: {
@@ -238,8 +241,8 @@ export const startWalletFactory = async (
   });
 
   await Promise.all([
-    E(bridgeManager).register(walletBridgeId, handler),
-    E(E.get(econCharterStartResult).creatorFacet).addInstance(
+    E(bridgeManager).register(BRIDGE_ID.PROVISION, handler),
+    E(E.get(econCharterFacets).creatorFacet).addInstance(
       ppFacets.instance,
       ppFacets.creatorFacet,
       'provisionPool',
@@ -273,7 +276,7 @@ export const WALLET_FACTORY_MANIFEST = {
       zoe: 'zoe',
       chainTimerService: 'timer',
       economicCommitteeCreatorFacet: 'economicCommittee',
-      econCharterStartResult: true,
+      econCharterFacets: 'psmCharter',
     },
     produce: {
       client: true, // dummy client in this configuration

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -107,7 +107,7 @@ const startGovernedInstance = async (
  *
  * @param {BootstrapPowers & PromiseSpaceOf<{
  *   economicCommitteeCreatorFacet: import('@agoric/governance/src/committee.js').CommitteeElectorateCreatorFacet
- *   econCharterFacets: {
+ *   econCharterKit: {
  *     creatorFacet: Awaited<ReturnType<import('@agoric/inter-protocol/src/econCommitteeCharter.js').start>>['creatorFacet'],
  *     adminFacet: AdminFacet,
  *   } ,
@@ -132,7 +132,7 @@ export const startWalletFactory = async (
       zoe,
       chainTimerService,
       economicCommitteeCreatorFacet,
-      econCharterFacets,
+      econCharterKit,
     },
     produce: { client, walletFactoryStartResult, provisionPoolStartResult },
     installation: {
@@ -242,7 +242,7 @@ export const startWalletFactory = async (
 
   await Promise.all([
     E(bridgeManager).register(walletBridgeId, handler),
-    E(E.get(econCharterFacets).creatorFacet).addInstance(
+    E(E.get(econCharterKit).creatorFacet).addInstance(
       ppFacets.instance,
       ppFacets.creatorFacet,
       'provisionPool',
@@ -276,7 +276,7 @@ export const WALLET_FACTORY_MANIFEST = {
       zoe: 'zoe',
       chainTimerService: 'timer',
       economicCommitteeCreatorFacet: 'economicCommittee',
-      econCharterFacets: 'psmCharter',
+      econCharterKit: 'psmCharter',
     },
     produce: {
       client: true, // dummy client in this configuration


### PR DESCRIPTION
closes: #6034

## Description

Save the AdminFacets from the core economy contracts during bootstrap.

This saves them in spaces, so they can be used by big-hammer scripts.

This makes all the contracts started in bootstrap use a consistent format for saving their public, private, governance and admin facets. Rather than all being top level names, each contract has a single top-level name, like `ammFacets`, which contains `{ creatorFacet, governorCreatorFacet, adminFacet, publicFacet }`, and sometimes an `instance`.

`feeDistributor` and `psmCharter` are not governed, so they don't have `adminFacet`s, and `psmCharter` has no `publicFacet`.

### Security Considerations

Wouldn't want to misplace these.

### Documentation Considerations

None.

### Testing Considerations

Untested.