### PR TITLE
feat: save PSM adminFacet in bootstrap

### DIFF
--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -163,6 +163,7 @@ const start = async (zcf, privateArgs) => {
     creatorFacet: governedCF,
     instance: governedInstance,
     publicFacet: governedPF,
+    adminFacet,
   } = await E(zoe).startInstance(
     governedContractInstallation,
     governedIssuerKeywordRecord,
@@ -281,6 +282,7 @@ const start = async (zcf, privateArgs) => {
     voteOnApiInvocation,
     voteOnOfferFilter: voteOnFilter,
     getCreatorFacet: () => limitedCreatorFacet,
+    getAdminFacet: () => adminFacet,
     getInstance: () => governedInstance,
     getPublicFacet: () => governedPF,
   });

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -41,15 +41,6 @@ const sanitizePathSegment = name => {
 };
 
 /**
- * There's an obsolete version in utils.d.ts
- *
- * @typedef {object} AdminFacet
- * @property {() => PromiseLike} getVatShutdownPromise
- * @property {(contractBundleId: string, newPrivateArgs: any) => void} upgradeContract
- * @property {(newPrivateArgs:any) => void} restartContract
- */
-
-/**
  * @typedef {GovernedCreatorFacet<import('../stakeFactory/stakeFactory.js').StakeFactoryCreator>} StakeFactoryCreator
  * @typedef {import('../stakeFactory/stakeFactory.js').StakeFactoryPublic} StakeFactoryPublic
  * @typedef {import('../reserve/assetReserve.js').GovernedAssetReserveFacetAccess} GovernedAssetReserveFacetAccess

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -41,6 +41,15 @@ const sanitizePathSegment = name => {
 };
 
 /**
+ * There's an obsolete version in utils.d.ts
+ *
+ * @typedef {object} AdminFacet
+ * @property {() => PromiseLike} getVatShutdownPromise
+ * @property {(contractBundleId: string, newPrivateArgs: any) => void} upgradeContract
+ * @property {(newPrivateArgs:any) => void} restartContract
+ */
+
+/**
  * @typedef {GovernedCreatorFacet<import('../stakeFactory/stakeFactory.js').StakeFactoryCreator>} StakeFactoryCreator
  * @typedef {import('../stakeFactory/stakeFactory.js').StakeFactoryPublic} StakeFactoryPublic
  * @typedef {import('../reserve/assetReserve.js').GovernedAssetReserveFacetAccess} GovernedAssetReserveFacetAccess
@@ -60,6 +69,7 @@ const sanitizePathSegment = name => {
  *   bankMints: Mint[],
  *   psmCreatorFacet: unknown,
  *   psmGovernorCreatorFacet: GovernedContractFacetAccess<{},{}>,
+ *   psmAdminFacet: AdminFacet,
  *   reservePublicFacet: import('../reserve/assetReserve.js').AssetReservePublicFacet,
  *   reserveCreatorFacet: import('../reserve/assetReserve.js').AssetReserveLimitedCreatorFacet,
  *   reserveGovernorCreatorFacet: GovernedAssetReserveFacetAccess,

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -34,7 +34,7 @@ export const startPSM = async (
       chainStorage,
       chainTimerService,
     },
-    produce: { psmCreatorFacet, psmGovernorCreatorFacet },
+    produce: { psmCreatorFacet, psmGovernorCreatorFacet, psmAdminFacet },
     installation: {
       consume: { contractGovernor, psm: psmInstall },
     },
@@ -138,14 +138,11 @@ export const startPSM = async (
     }),
   );
 
-  const governedInstance = await E(governorFacets.creatorFacet).getInstance();
-  const creatorFacet = E(governorFacets.creatorFacet).getCreatorFacet();
-
-  psmInstanceR.resolve(governedInstance);
+  psmInstanceR.resolve(await E(governorFacets.creatorFacet).getInstance());
   psmGovernorR.resolve(governorFacets.instance);
-  psmCreatorFacet.resolve(creatorFacet);
+  psmCreatorFacet.resolve(E(governorFacets.creatorFacet).getCreatorFacet());
+  psmAdminFacet.resolve(E(governorFacets.creatorFacet).getAdminFacet());
   psmGovernorCreatorFacet.resolve(governorFacets.creatorFacet);
-  psmInstanceR.resolve(governedInstance);
 };
 harden(startPSM);
 

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -259,7 +259,11 @@ export const PSM_MANIFEST = harden({
       economicCommitteeCreatorFacet: 'economicCommittee',
       chainTimerService: 'timer',
     },
-    produce: { psmCreatorFacet: 'psm', psmGovernorCreatorFacet: 'psmGovernor' },
+    produce: {
+      psmCreatorFacet: 'psm',
+      psmAdminFacet: 'psm',
+      psmGovernorCreatorFacet: 'psmGovernor',
+    },
     installation: {
       consume: { contractGovernor: 'zoe', psm: 'zoe' },
     },

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -243,3 +243,7 @@
  * @template S
  * @typedef {import('../zoeService/utils').ContractOf<S>} ContractOf
  */
+
+/**
+ * @typedef {import('../zoeService/utils').AdminFacet} AdminFacet
+ */

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -13,8 +13,11 @@ type ContractFacet<T extends {} = {}> = {
   readonly [P in keyof T]: T[P] extends Callable ? T[P] : never;
 };
 
-type AdminFacet = {
-  getVatShutdownPromise: () => Promise<any>; // Completion, which is currently any
+export type AdminFacet = {
+  // Completion, which is currently any
+  getVatShutdownPromise: () => Promise<any>;
+  upgradeContract: (contractBundleId: string, newPrivateArgs: any) => void;
+  restartContract: (newPrivateArgs: any) => void;
 };
 
 /**


### PR DESCRIPTION
closes: #6100

## Description

Save the PSM adminFacet from bootstrap. Also, the contractGovernor will now make the adminFacet available when other contracts need it.

### Security Considerations

The admin facet is very powerful. The bootstrap environment is considered a secure context in which to hold powerful facets for the Econ Committee's use.

### Documentation Considerations

None.

### Testing Considerations

deferred to #6099.
