### PR TITLE
fix(inter-protocol): ensure PSM availability after staging failure

### DIFF
--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -155,7 +155,6 @@ export const start = async (zcf, privateArgs, baggage) => {
     const fee = ceilMultiplyBy(given, params.getGiveStableFee());
     const afterFee = AmountMath.subtract(given, fee);
     const maxAnchor = floorMultiplyBy(afterFee, anchorPerStable);
-    // TODO this prevents the reallocate from failing. Can this be tested otherwise?
     assert(
       AmountMath.isGTE(maxAnchor, wanted),
       X`wanted ${wanted} is more then ${given} minus fees ${fee}`,
@@ -175,7 +174,7 @@ export const start = async (zcf, privateArgs, baggage) => {
       stage.clear();
       anchorPool.clear();
       feePool.clear();
-      // NOTE someday, reallocate should guarantee that this case cannot happen
+      // TODO(#6116) someday, reallocate should guarantee that this case cannot happen
       throw e;
     }
     totalAnchorProvided = AmountMath.add(totalAnchorProvided, maxAnchor);
@@ -205,7 +204,7 @@ export const start = async (zcf, privateArgs, baggage) => {
       stage.clear();
       anchorPool.clear();
       feePool.clear();
-      // NOTE someday, reallocate should guarantee that this case cannot happen
+      // TODO(#6116) someday, reallocate should guarantee that this case cannot happen
       stableMint.burnLosses({ Stable: asStable }, stage);
       throw e;
     }

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -16,6 +16,7 @@ import {
   makeRatio,
   natSafeMath as NatMath,
 } from '@agoric/zoe/src/contractSupport/index.js';
+import centralSupplyBundle from '@agoric/vats/bundles/bundle-centralSupply.js';
 import { E } from '@endo/eventual-send';
 import { NonNullish } from '@agoric/assert';
 import path from 'path';
@@ -23,6 +24,7 @@ import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { makeTracer } from '../../src/makeTracer.js';
 import {
   makeMockChainStorageRoot,
+  mintRunPayment,
   setUpZoeForTest,
   subscriptionKey,
   withAmountUtils,
@@ -90,6 +92,8 @@ const makeTestContext = async () => {
 
   const committeeInstall = await E(zoe).install(committeeBundle);
   const psmInstall = await E(zoe).install(psmBundle);
+  const centralSupply = await E(zoe).install(centralSupplyBundle);
+
   const mintLimit = AmountMath.make(anchor.brand, MINT_LIMIT);
 
   const marshaller = makeBoard().getReadonlyMarshaller();
@@ -119,7 +123,7 @@ const makeTestContext = async () => {
     initialPoserInvitation,
     stable: { issuer: stableIssuer, brand: stableBrand },
     anchor,
-    installs: { committeeInstall, psmInstall },
+    installs: { committeeInstall, psmInstall, centralSupply },
     mintLimit,
     marshaller,
     terms: {
@@ -209,29 +213,49 @@ async function makePsmDriver(t, customTerms) {
       return feePayoutAmount;
     },
 
-    /** @param {Amount<'nat'>} giveAnchor */
-    async swapAnchorForStable(giveAnchor) {
+    /**
+     * @param {Amount<'nat'>} giveAnchor
+     * @param {Amount<'nat'>} [wantStable]
+     * @param {*} [out]
+     */
+    async swapAnchorForStable(giveAnchor, wantStable, out) {
       const seat = E(zoe).offer(
         E(publicFacet).makeWantStableInvitation(),
-        harden({ give: { In: giveAnchor } }),
+        harden({
+          give: { In: giveAnchor },
+          ...(wantStable ? { want: { Out: wantStable } } : {}),
+        }),
         // @ts-expect-error known defined
         harden({ In: anchor.mint.mintPayment(giveAnchor) }),
       );
       await eventLoopIteration();
+      if (out) {
+        out.seat = seat;
+        out.offerResult = E(seat).getOfferResult();
+      }
       return E(seat).getPayouts();
     },
 
     /**
      * @param {Amount<'nat'>} giveRun
      * @param {Payment<'nat'>} runPayment
+     * @param {Amount<'nat'>} [wantAnchor]
+     * @param {*} [out]
      */
-    async swapStableForAnchor(giveRun, runPayment) {
+    async swapStableForAnchor(giveRun, runPayment, wantAnchor, out) {
       const seat = E(zoe).offer(
         E(publicFacet).makeGiveStableInvitation(),
-        harden({ give: { In: giveRun } }),
+        harden({
+          give: { In: giveRun },
+          ...(wantAnchor ? { want: { Out: wantAnchor } } : {}),
+        }),
         harden({ In: runPayment }),
       );
       await eventLoopIteration();
+      if (out) {
+        out.seat = seat;
+        out.offerResult = E(seat).getOfferResult();
+      }
       return E(seat).getPayouts();
     },
   };
@@ -303,6 +327,112 @@ test('limit', async t => {
   driver.assertPoolBalance(initialPool);
   // TODO Offer result should be an error
   // t.throwsAsync(() => await E(seat1).getOfferResult());
+});
+
+/** @type {[kind: 'want' | 'give', give: number, want: number, result: number | false][]} */
+const trades = [
+  ['give', 200, 190, false],
+  ['want', 101, 100, 1],
+  ['give', 50, 50, false],
+  ['give', 51, 50, 1],
+];
+
+test('mix of trades: failures do not prevent later service', async t => {
+  const {
+    terms,
+    stable,
+    anchor,
+    feeMintAccess,
+    zoe,
+    installs: { centralSupply },
+  } = t.context;
+  const driver = await makePsmDriver(t);
+
+  const ist100 = await mintRunPayment(500n * 1_000_000n, {
+    centralSupply,
+    feeMintAccess,
+    zoe,
+  });
+
+  assert(anchor.issuer);
+  const anchorPurse = await E(anchor.issuer).makeEmptyPurse();
+  const stablePurse = await E(stable.issuer).makeEmptyPurse();
+  await E(stablePurse).deposit(ist100);
+
+  const scale6 = x => BigInt(Math.round(x * 1_000_000));
+
+  const wantStable = async (ix, give, want, result) => {
+    t.log('wantStable', ix, give, want, result);
+    const giveAnchor = AmountMath.make(anchor.brand, scale6(give));
+    const wantAmt = AmountMath.make(stable.brand, scale6(want));
+    const out = {};
+    const runPayouts = await driver.swapAnchorForStable(
+      giveAnchor,
+      wantAmt,
+      out,
+    );
+    if (result === false) {
+      await t.throwsAsync(out.offerResult);
+      return;
+    } else {
+      await out.offerResult;
+    }
+    t.is(await E(out.seat).numWantsSatisfied(), result);
+    if (result === 0) {
+      return;
+    }
+    const expectedRun = minusAnchorFee(giveAnchor, terms.anchorPerStable);
+    const actualRun = await E(stablePurse).deposit(await runPayouts.Out);
+    t.deepEqual(actualRun, expectedRun);
+  };
+
+  const giveStable = async (ix, give, want, result) => {
+    t.log('giveStable', ix, give, want, result);
+    const giveRun = AmountMath.make(stable.brand, scale6(give));
+    const runPayment = await E(stablePurse).withdraw(giveRun);
+    const wantAmt = AmountMath.make(anchor.brand, scale6(want));
+    const out = {};
+    const anchorPayouts = await driver.swapStableForAnchor(
+      giveRun,
+      runPayment,
+      wantAmt,
+      out,
+    );
+    if (result === false) {
+      await t.throwsAsync(out.offerResult);
+      return;
+    } else {
+      await out.offerResult;
+    }
+    t.is(await E(out.seat).numWantsSatisfied(), result);
+    if (result === 0) {
+      return;
+    }
+    const actualAnchor = await E(anchorPurse).deposit(await anchorPayouts.Out);
+    const expectedAnchor = AmountMath.make(
+      anchor.brand,
+      minusStableFee(giveRun).value,
+    );
+    t.deepEqual(actualAnchor, expectedAnchor);
+  };
+
+  let ix = 0;
+  for (const [kind, give, want, result] of trades) {
+    switch (kind) {
+      case 'give':
+        await giveStable(ix, give, want, result);
+        break;
+      case 'want':
+        await wantStable(ix, give, want, result);
+        break;
+      default:
+        assert.fail(kind);
+    }
+    if (kind === 'give') {
+      // eslint-disable-next-line no-await-in-loop
+    }
+    ix += 1;
+  }
 });
 
 test('anchor is 2x stable', async t => {

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -337,7 +337,7 @@ export const createSeatManager = (
         );
         return amountKeywordRecord;
       },
-      clear: ignoreContext(clear),
+      clear: ({ self }) => clear(self),
       hasStagedAllocation: ({ self }) => hasStagedAllocation(self),
     },
   );

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -114,7 +114,9 @@ export const createSeatManager = (
   };
 
   const clear = zcfSeat => {
-    zcfSeatToStagedAllocations.delete(zcfSeat);
+    if (zcfSeatToStagedAllocations.has(zcfSeat)) {
+      zcfSeatToStagedAllocations.delete(zcfSeat);
+    }
   };
 
   const setStagedAllocation = (zcfSeat, newStagedAllocation) => {

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -5,7 +5,6 @@ import {
   provideDurableMapStore,
   makeScalarBigMapStore,
   vivifyKind,
-  ignoreContext,
   makeScalarBigWeakMapStore,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
@@ -111,12 +110,6 @@ export const createSeatManager = (
       hasStagedAllocation(zcfSeat),
       'Reallocate failed because a seat had no staged allocation. Please add or subtract from the seat and then reallocate.',
     );
-  };
-
-  const clear = zcfSeat => {
-    if (zcfSeatToStagedAllocations.has(zcfSeat)) {
-      zcfSeatToStagedAllocations.delete(zcfSeat);
-    }
   };
 
   const setStagedAllocation = (zcfSeat, newStagedAllocation) => {
@@ -337,7 +330,11 @@ export const createSeatManager = (
         );
         return amountKeywordRecord;
       },
-      clear: ({ self }) => clear(self),
+      clear: ({ self }) => {
+        if (zcfSeatToStagedAllocations.has(self)) {
+          zcfSeatToStagedAllocations.delete(self);
+        }
+      },
       hasStagedAllocation: ({ self }) => hasStagedAllocation(self),
     },
   );


### PR DESCRIPTION
closes: #6096

## Description

When an attempt to trade IST for anchor/reference token fails due to lack of anchor funds in the PSM, seat stagings were left in an inconsistent state, preventing further service. This fix clears the seat stagings on failure.

@erights @Chris-Hibbert this also includes a couple zoe tweaks that @dtribble helped me with.

### Security Considerations

availability is good :)

### Testing Considerations

added a reasonably thorough unit test
