### PR TITLE
feat(agoric-cli): follow options for lossy and block height prefixes

### DIFF
--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -223,6 +223,18 @@ const main = async (progname, rawArgs, powers) => {
       },
       'justin',
     )
+    .option(
+      '-l, --lossy',
+      'show only the most recent value for each sample interval',
+    )
+    .option(
+      '-b, --block-height',
+      'show first block height when each value was stored',
+    )
+    .option(
+      '-c, --current-block-height',
+      'show current block height when each value is reported',
+    )
     .option('-B, --bootstrap <config>', 'network bootstrap configuration')
     .action(async (pathSpecs, cmd) => {
       const opts = { ...program.opts(), ...cmd.opts() };


### PR DESCRIPTION

refs: #5460

## Description

Following #6103, `agoric follow` became useful for ad hoc tests of each and latest casting iterators during `agoric deploy` commands. This change adds `--lossy`, `--block-height`, and `--current-block-height` options. `--lossy` suggests use of getLatestIterator instead of getEachIterator, `--block-height` adds a prefix to each log with the self-reported height of the block that published the value, and `--current-block-height` adds a prefix to each log with the current block height at the time the log was emitted.

### Security Considerations


### Documentation Considerations

These flags as described above are mentioned in command-line usage. A document covering uses of the `agoric` command might also mention them, or how-to guides might make use of them in the context of solving a problem or demonstrating how storage cells work. For example, these two flags block height are useful for confirming that stream cells report the height of the block that they’re published into, not the height of the chain at the time they were published.

### Testing Considerations

Manual. I would not say that the behavior is adequately tested in `casting`, but that `casting` is the right package to test the behavior revealed by the CLI.