### PR TITLE
fix(vat-data)!: deprecate kinds in favor of Far Classes

### DIFF
--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -29,7 +29,10 @@ export const provideKindHandle = (baggage, kindName) =>
   provide(baggage, `${kindName}_kindHandle`, () => makeKindHandle(kindName));
 harden(provideKindHandle);
 
-/** @type {import('./types.js').VivifyKind} */
+/**
+ * @deprecated Use vivifyFarClass instead
+ * @type {import('./types.js').VivifyKind}
+ */
 export const vivifyKind = (
   baggage,
   kindName,
@@ -45,7 +48,10 @@ export const vivifyKind = (
   );
 harden(vivifyKind);
 
-/** @type {import('./types.js').VivifyKindMulti} */
+/**
+ * @deprecated Use vivifyFarClassKit instead
+ * @type {import('./types.js').VivifyKindMulti}
+ */
 export const vivifyKindMulti = (
   baggage,
   kindName,

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -96,12 +96,15 @@ type DefineKindOptions<C> = {
 
 export type VatData = {
   // virtual kinds
+  /** @deprecated Use defineVirtualFarClass instead */
   defineKind: <P, S, F>(
     tag: string,
     init: (...args: P) => S,
     facet: F,
     options?: DefineKindOptions<KindContext<S, F>>,
   ) => (...args: P) => KindFacet<F>;
+
+  /** @deprecated Use defineVirtualFarClassKit instead */
   defineKindMulti: <P, S, B>(
     tag: string,
     init: (...args: P) => S,
@@ -111,12 +114,16 @@ export type VatData = {
 
   // durable kinds
   makeKindHandle: (descriptionTag: string) => DurableKindHandle;
+
+  /** @deprecated Use defineDurableFarClass instead */
   defineDurableKind: <P, S, F>(
     kindHandle: DurableKindHandle,
     init: (...args: P) => S,
     facet: F,
     options?: DefineKindOptions<KindContext<S, F>>,
   ) => (...args: P) => KindFacet<F>;
+
+  /** @deprecated Use defineDurableFarClassKit instead */
   defineDurableKindMulti: <P, S, B>(
     kindHandle: DurableKindHandle,
     init: (...args: P) => S,
@@ -166,6 +173,7 @@ interface PickFacet {
   ): (...args: Parameters<M>) => ReturnType<M>[F];
 }
 
+/** @deprecated Use vivifyFarClass instead */
 type VivifyKind = <P, S, F>(
   baggage: Baggage,
   tag: string,
@@ -174,6 +182,7 @@ type VivifyKind = <P, S, F>(
   options?: DefineKindOptions<KindContext<S, F>>,
 ) => (...args: P) => KindFacet<F>;
 
+/** @deprecated Use vivifyFarClassKit instead */
 type VivifyKindMulti = <P, S, B>(
   baggage: Baggage,
   tag: string,

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -44,11 +44,17 @@ if ('VatData' in globalThis) {
   };
 }
 
+/**
+ * @deprecated Use FarClasses/FarInstances instead of kinds
+ */
 export const {
   defineKind,
   defineKindMulti,
   defineDurableKind,
   defineDurableKindMulti,
+} = VatDataGlobal;
+
+export const {
   makeKindHandle,
   providePromiseWatcher,
   watchPromise,

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,9 +1,13 @@
 // @ts-check
 
 import { assert } from '@agoric/assert';
-import { initEmpty } from '@agoric/store';
-import { provide, defineDurableKind, makeKindHandle } from '@agoric/vat-data';
-import { Far } from '@endo/marshal';
+import { initEmpty, makeHeapFarInstance } from '@agoric/store';
+import {
+  provide,
+  defineDurableFarClass,
+  makeKindHandle,
+} from '@agoric/vat-data';
+import { HandleI } from './typeGuards.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -20,7 +24,13 @@ export const defineDurableHandle = (baggage, handleType) => {
     `${handleType}KindHandle`,
     () => makeKindHandle(`${handleType}Handle`),
   );
-  const makeHandle = defineDurableKind(durableHandleKindHandle, initEmpty, {});
+  const makeHandle = defineDurableFarClass(
+    durableHandleKindHandle,
+    HandleI,
+    initEmpty,
+    {},
+  );
+  // @ts-expect-error Bit by our own opaque types.
   return /** @type {() => Handle<H>} */ (makeHandle);
 };
 harden(defineDurableHandle);
@@ -35,6 +45,9 @@ harden(defineDurableHandle);
 export const makeHandle = handleType => {
   assert.typeof(handleType, 'string', 'handleType must be a string');
   // Return the intersection type (really just an empty object).
-  return /** @type {Handle<H>} */ (Far(`${handleType}Handle`));
+  // @ts-expect-error Bit by our own opaque types.
+  return /** @type {Handle<H>} */ (
+    makeHeapFarInstance(`${handleType}Handle`, HandleI, {})
+  );
 };
 harden(makeHandle);

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -16,6 +16,8 @@ export const AmountPatternKeywordRecordShape = M.recordOf(
   M.pattern(),
 );
 
+export const HandleI = M.interface('Handle', {});
+
 export const makeHandleShape = name => M.remotable(`${name}Handle`);
 export const TimerShape = makeHandleShape('timer');
 


### PR DESCRIPTION
I believe we've now had enough experience with FarClasses, etc, to deprecate the virtual/durable kind APIs and unconditionally recommend FarClasses, etc, instead.
