### PR TITLE
fix: heap far classes

### DIFF
--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -55,7 +55,15 @@ export {
   matches,
   fit,
 } from './patterns/patternMatchers.js';
-export { defendPrototype, initEmpty } from './patterns/interface-tools.js';
+
+export {
+  defendPrototype,
+  initEmpty,
+  defineHeapFarClass,
+  defineHeapFarClassKit,
+  makeHeapFarInstance,
+} from './patterns/interface-tools.js';
+
 export { compareRank, isRankSorted, sortByRank } from './patterns/rankOrder.js';
 export {
   makeDecodePassable,

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -377,7 +377,7 @@ harden(defineHeapFarClassKit);
  * @param {object} [options]
  * @returns {T & RemotableBrand<{}, T>}
  */
-export const defineHeapFarInstance = (
+export const makeHeapFarInstance = (
   tag,
   interfaceGuard,
   methods,
@@ -392,4 +392,4 @@ export const defineHeapFarInstance = (
   );
   return makeInstance();
 };
-harden(defineHeapFarInstance);
+harden(makeHeapFarInstance);

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -1,0 +1,107 @@
+// @ts-check
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import {
+  defineHeapFarClass,
+  defineHeapFarClassKit,
+  defineHeapFarInstance,
+} from '../src/patterns/interface-tools.js';
+import { M } from '../src/patterns/patternMatchers.js';
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+test('test defineHeapFarClass', t => {
+  const makeUpCounter = defineHeapFarClass(
+    'UpCounter',
+    UpCounterI,
+    (x = 0) => ({ x }),
+    {
+      incr(y = 1) {
+        // @ts-expect-error TS doesn't know that `this` is a `Context`
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+    },
+  );
+  const upCounter = makeUpCounter(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(upCounter.incr(1), 9);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (UpCounter) arg 0: -3 - Must be >= 0',
+  });
+  t.throws(() => upCounter.incr('foo'), {
+    message:
+      'In "incr" method of (UpCounter) arg 0: string "foo" - Must be a number',
+  });
+});
+
+test('test defineHeapFarClassKit', t => {
+  const makeCounterKit = defineHeapFarClassKit(
+    'Counter',
+    harden({ up: UpCounterI, down: DownCounterI }),
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(downCounter.decr(), 7);
+  t.is(upCounter.incr(3), 10);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (Counter up) arg 0: -3 - Must be >= 0',
+  });
+  // @ts-expect-error the type violation is what we're testing
+  t.throws(() => downCounter.decr('foo'), {
+    message:
+      'In "decr" method of (Counter down) arg 0: string "foo" - Must be a number',
+  });
+  t.throws(() => upCounter.decr(3), {
+    message: 'upCounter.decr is not a function',
+  });
+});
+
+test('test defineHeapFarInstance', t => {
+  let x = 3;
+  const upCounter = defineHeapFarInstance('upCounter', UpCounterI, {
+    incr(y = 1) {
+      x += y;
+      return x;
+    },
+  });
+  t.is(upCounter.incr(5), 8);
+  t.is(upCounter.incr(1), 9);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (upCounter) arg 0: -3 - Must be >= 0',
+  });
+  t.throws(() => upCounter.incr('foo'), {
+    message:
+      'In "incr" method of (upCounter) arg 0: string "foo" - Must be a number',
+  });
+});

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -4,7 +4,7 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import {
   defineHeapFarClass,
   defineHeapFarClassKit,
-  defineHeapFarInstance,
+  makeHeapFarInstance,
 } from '../src/patterns/interface-tools.js';
 import { M } from '../src/patterns/patternMatchers.js';
 
@@ -87,9 +87,9 @@ test('test defineHeapFarClassKit', t => {
   });
 });
 
-test('test defineHeapFarInstance', t => {
+test('test makeHeapFarInstance', t => {
   let x = 3;
-  const upCounter = defineHeapFarInstance('upCounter', UpCounterI, {
+  const upCounter = makeHeapFarInstance('upCounter', UpCounterI, {
     incr(y = 1) {
       x += y;
       return x;

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -51,7 +51,7 @@ test('test defineHeapFarClass', t => {
 test('test defineHeapFarClassKit', t => {
   const makeCounterKit = defineHeapFarClassKit(
     'Counter',
-    harden({ up: UpCounterI, down: DownCounterI }),
+    { up: UpCounterI, down: DownCounterI },
     (x = 0) => ({ x }),
     {
       up: {

--- a/packages/vat-data/test/test-durable-classes.js
+++ b/packages/vat-data/test/test-durable-classes.js
@@ -46,7 +46,7 @@ test('test defineDurableFarClass', t => {
   t.throws(() => upCounter.incr(-3), {
     message: 'In "incr" method of (UpCounter) arg 0: -3 - Must be >= 0',
   });
-  // @ts-expect-error TS doesn't know that `this` is a `Context`
+  // @ts-expect-error the type violation is what we're testing
   t.throws(() => upCounter.incr('foo'), {
     message:
       'In "incr" method of (UpCounter) arg 0: string "foo" - Must be a number',
@@ -58,7 +58,7 @@ test('test defineDurableFarClassKit', t => {
 
   const makeCounterKit = defineDurableFarClassKit(
     counterKindHandle,
-    harden({ up: UpCounterI, down: DownCounterI }),
+    { up: UpCounterI, down: DownCounterI },
     (x = 0) => ({ x }),
     {
       up: {

--- a/packages/vat-data/test/test-durable-classes.js
+++ b/packages/vat-data/test/test-durable-classes.js
@@ -93,3 +93,5 @@ test('test defineDurableFarClassKit', t => {
     message: 'upCounter.decr is not a function',
   });
 });
+
+test.todo('Add tests for durability');

--- a/packages/vat-data/test/test-durable-classes.js
+++ b/packages/vat-data/test/test-durable-classes.js
@@ -1,0 +1,95 @@
+// @ts-check
+
+// Modeled on test-heap-classes.js
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { M } from '@agoric/store';
+import {
+  defineDurableFarClass,
+  defineDurableFarClassKit,
+} from '../src/far-class-utils.js';
+import { makeKindHandle } from '../src/vat-data-bindings.js';
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+test('test defineDurableFarClass', t => {
+  const upCounterKind = makeKindHandle('UpCounter');
+
+  const makeUpCounter = defineDurableFarClass(
+    upCounterKind,
+    UpCounterI,
+    (x = 0) => ({ x }),
+    {
+      incr(y = 1) {
+        // @ts-expect-error TS doesn't know that `this` is a `Context`
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+    },
+  );
+  const upCounter = makeUpCounter(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(upCounter.incr(1), 9);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (UpCounter) arg 0: -3 - Must be >= 0',
+  });
+  // @ts-expect-error TS doesn't know that `this` is a `Context`
+  t.throws(() => upCounter.incr('foo'), {
+    message:
+      'In "incr" method of (UpCounter) arg 0: string "foo" - Must be a number',
+  });
+});
+
+test('test defineDurableFarClassKit', t => {
+  const counterKindHandle = makeKindHandle('Counter');
+
+  const makeCounterKit = defineDurableFarClassKit(
+    counterKindHandle,
+    harden({ up: UpCounterI, down: DownCounterI }),
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(downCounter.decr(), 7);
+  t.is(upCounter.incr(3), 10);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (Counter up) arg 0: -3 - Must be >= 0',
+  });
+  // @ts-expect-error the type violation is what we're testing
+  t.throws(() => downCounter.decr('foo'), {
+    message:
+      'In "decr" method of (Counter down) arg 0: string "foo" - Must be a number',
+  });
+  t.throws(() => upCounter.decr(3), {
+    message: 'upCounter.decr is not a function',
+  });
+});

--- a/packages/vat-data/test/test-virtual-classes.js
+++ b/packages/vat-data/test/test-virtual-classes.js
@@ -43,7 +43,7 @@ test('test defineVirtualFarClass', t => {
   t.throws(() => upCounter.incr(-3), {
     message: 'In "incr" method of (UpCounter) arg 0: -3 - Must be >= 0',
   });
-  // @ts-expect-error TS doesn't know that `this` is a `Context`
+  // @ts-expect-error the type violation is what we're testing
   t.throws(() => upCounter.incr('foo'), {
     message:
       'In "incr" method of (UpCounter) arg 0: string "foo" - Must be a number',
@@ -53,7 +53,7 @@ test('test defineVirtualFarClass', t => {
 test('test defineVirtualFarClassKit', t => {
   const makeCounterKit = defineVirtualFarClassKit(
     'Counter',
-    harden({ up: UpCounterI, down: DownCounterI }),
+    { up: UpCounterI, down: DownCounterI },
     (x = 0) => ({ x }),
     {
       up: {

--- a/packages/vat-data/test/test-virtual-classes.js
+++ b/packages/vat-data/test/test-virtual-classes.js
@@ -1,0 +1,90 @@
+// @ts-check
+
+// Modeled on test-heap-classes.js
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { M } from '@agoric/store';
+import {
+  defineVirtualFarClass,
+  defineVirtualFarClassKit,
+} from '../src/far-class-utils.js';
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+test('test defineVirtualFarClass', t => {
+  const makeUpCounter = defineVirtualFarClass(
+    'UpCounter',
+    UpCounterI,
+    (x = 0) => ({ x }),
+    {
+      incr(y = 1) {
+        // @ts-expect-error TS doesn't know that `this` is a `Context`
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+    },
+  );
+  const upCounter = makeUpCounter(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(upCounter.incr(1), 9);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (UpCounter) arg 0: -3 - Must be >= 0',
+  });
+  // @ts-expect-error TS doesn't know that `this` is a `Context`
+  t.throws(() => upCounter.incr('foo'), {
+    message:
+      'In "incr" method of (UpCounter) arg 0: string "foo" - Must be a number',
+  });
+});
+
+test('test defineVirtualFarClassKit', t => {
+  const makeCounterKit = defineVirtualFarClassKit(
+    'Counter',
+    harden({ up: UpCounterI, down: DownCounterI }),
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(downCounter.decr(), 7);
+  t.is(upCounter.incr(3), 10);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (Counter up) arg 0: -3 - Must be >= 0',
+  });
+  // @ts-expect-error the type violation is what we're testing
+  t.throws(() => downCounter.decr('foo'), {
+    message:
+      'In "decr" method of (Counter down) arg 0: string "foo" - Must be a number',
+  });
+  t.throws(() => upCounter.decr(3), {
+    message: 'upCounter.decr is not a function',
+  });
+});

--- a/packages/vat-data/test/test-vivify.js
+++ b/packages/vat-data/test/test-vivify.js
@@ -117,3 +117,5 @@ test('test vivifyFarInstance', t => {
       'In "incr" method of (upCounter) arg 0: string "foo" - Must be a number',
   });
 });
+
+test.todo('Demonstrate that the baggage can be used to revive objects.');

--- a/packages/vat-data/test/test-vivify.js
+++ b/packages/vat-data/test/test-vivify.js
@@ -1,0 +1,119 @@
+// @ts-check
+
+// Modeled on test-heap-classes.js
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { M } from '@agoric/store';
+import {
+  vivifyFarClass,
+  vivifyFarClassKit,
+  vivifyFarInstance,
+} from '../src/far-class-utils.js';
+import { makeScalarBigMapStore } from '../src/vat-data-bindings.js';
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+test('test vivifyFarClass', t => {
+  const baggage = makeScalarBigMapStore('baggage', { durable: true });
+
+  const makeUpCounter = vivifyFarClass(
+    baggage,
+    'UpCounter',
+    UpCounterI,
+    (x = 0) => ({ x }),
+    {
+      incr(y = 1) {
+        // @ts-expect-error TS doesn't know that `this` is a `Context`
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+    },
+  );
+  const upCounter = makeUpCounter(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(upCounter.incr(1), 9);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (UpCounter) arg 0: -3 - Must be >= 0',
+  });
+  // @ts-expect-error TS doesn't know that `this` is a `Context`
+  t.throws(() => upCounter.incr('foo'), {
+    message:
+      'In "incr" method of (UpCounter) arg 0: string "foo" - Must be a number',
+  });
+});
+
+test('test vivifyFarClassKit', t => {
+  const baggage = makeScalarBigMapStore('baggage', { durable: true });
+
+  const makeCounterKit = vivifyFarClassKit(
+    baggage,
+    'Counter',
+    harden({ up: UpCounterI, down: DownCounterI }),
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(downCounter.decr(), 7);
+  t.is(upCounter.incr(3), 10);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (Counter up) arg 0: -3 - Must be >= 0',
+  });
+  // @ts-expect-error the type violation is what we're testing
+  t.throws(() => downCounter.decr('foo'), {
+    message:
+      'In "decr" method of (Counter down) arg 0: string "foo" - Must be a number',
+  });
+  t.throws(() => upCounter.decr(3), {
+    message: 'upCounter.decr is not a function',
+  });
+});
+
+test('test vivifyFarInstance', t => {
+  const baggage = makeScalarBigMapStore('baggage', { durable: true });
+
+  let x = 3;
+  const upCounter = vivifyFarInstance(baggage, 'upCounter', UpCounterI, {
+    incr(y = 1) {
+      x += y;
+      return x;
+    },
+  });
+  t.is(upCounter.incr(5), 8);
+  t.is(upCounter.incr(1), 9);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (upCounter) arg 0: -3 - Must be >= 0',
+  });
+  t.throws(() => upCounter.incr('foo'), {
+    message:
+      'In "incr" method of (upCounter) arg 0: string "foo" - Must be a number',
+  });
+});

--- a/packages/vat-data/test/test-vivify.js
+++ b/packages/vat-data/test/test-vivify.js
@@ -48,7 +48,7 @@ test('test vivifyFarClass', t => {
   t.throws(() => upCounter.incr(-3), {
     message: 'In "incr" method of (UpCounter) arg 0: -3 - Must be >= 0',
   });
-  // @ts-expect-error TS doesn't know that `this` is a `Context`
+  // @ts-expect-error the type violation is what we're testing
   t.throws(() => upCounter.incr('foo'), {
     message:
       'In "incr" method of (UpCounter) arg 0: string "foo" - Must be a number',
@@ -61,7 +61,7 @@ test('test vivifyFarClassKit', t => {
   const makeCounterKit = vivifyFarClassKit(
     baggage,
     'Counter',
-    harden({ up: UpCounterI, down: DownCounterI }),
+    { up: UpCounterI, down: DownCounterI },
     (x = 0) => ({ x }),
     {
       up: {


### PR DESCRIPTION
Prior to this PR, our menagerie of far class definer apis is

(FarClass, FarClassKit, FarInstance) x (Virtual, Durable, vivify)

The hole this leaves is the normal case of objects living in the programming language's heap. This was covered by `Far` until we introduced defensive interface guards. So this PR adds a fourth setting to the second dimension above, making it

(FarClass, FarClassKit, FarInstance) x (Heap, Virtual, Durable, vivify)

In practice I expect almost all uses to be of the Heap and vivify variants. In the Kind system, the unnamed case was the Vrtual case, when we didn't yet understand what our dominant pattern of use will be. An open question: Should we drop the "Heap" from the heap far class definers, making that the unnamed case. If so, then common cases will be
   * defineFarClass
   * defineFarClassKit
   * makeFarInstance
   * vivifyFarClass
   * vivifyFarClassKit
   * vivifyFarInstance

If https://github.com/Agoric/agoric-sdk/pull/6118 passes, then it would be
   * defineExoClass
   * defineExoClassKit
   * makeExo
   * vivifyExoClass
   * vivifyExoClassKit
   * vivifyExo
