### PR TITLE
refactor: method schemas in Governance contracts

### DIFF
--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -35,6 +35,7 @@
     "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.4.0",
     "@agoric/store": "^0.7.2",
+    "@agoric/swingset-vat": "^0.28.0",
     "@agoric/vat-data": "^0.3.1",
     "@agoric/vats": "^0.10.0",
     "@agoric/zoe": "^0.24.0",

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -2,15 +2,21 @@
 
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
-import { keyEQ, makeStore } from '@agoric/store';
+import {
+  defineHeapFarClassKit,
+  initEmpty,
+  keyEQ,
+  makeStore,
+} from '@agoric/store';
 
 import {
-  ChoiceMethod,
   buildUnrankedQuestion,
-  positionIncluded,
+  ChoiceMethod,
   coerceQuestionSpec,
+  positionIncluded,
 } from './question.js';
 import { scheduleClose } from './closingRule.js';
+import { BinaryVoteCounterIKit } from './typeGuards.js';
 
 const { details: X } = assert;
 
@@ -77,24 +83,6 @@ const makeBinaryVoteCounter = (questionSpec, threshold, instance) => {
   /** @type {Store<Handle<'Voter'>,RecordedBallot> } */
   const allBallots = makeStore('voterHandle');
 
-  /** @type {SubmitVote} */
-  const submitVote = (voterHandle, chosenPositions, shares = 1n) => {
-    assert(chosenPositions.length === 1, 'only 1 position allowed');
-    const [position] = chosenPositions;
-    assert(
-      positionIncluded(positions, position),
-      X`The specified choice is not a legal position: ${position}.`,
-    );
-
-    // CRUCIAL: If the voter cast a valid ballot, we'll record it, but we need
-    // to make sure that each voter's vote is recorded only once.
-    const completedBallot = harden({ chosen: position, shares });
-    allBallots.has(voterHandle)
-      ? allBallots.set(voterHandle, completedBallot)
-      : allBallots.init(voterHandle, completedBallot);
-    return completedBallot;
-  };
-
   const countVotes = () => {
     assert(!isOpen, X`can't count votes while the election is open`);
 
@@ -143,29 +131,58 @@ const makeBinaryVoteCounter = (questionSpec, threshold, instance) => {
     }
   };
 
-  const closeVoting = () => {
-    isOpen = false;
-    countVotes();
-  };
+  const makeBinaryVoteCounterKit = defineHeapFarClassKit(
+    'Binary VoteCounter',
+    BinaryVoteCounterIKit,
+    initEmpty,
+    {
+      closeFacet: {
+        closeVoting() {
+          isOpen = false;
+          countVotes();
+        },
+      },
+      creatorFacet: {
+        submitVote(voterHandle, chosenPositions, shares = 1n) {
+          assert(chosenPositions.length === 1, 'only 1 position allowed');
+          const [position] = chosenPositions;
+          assert(
+            positionIncluded(positions, position),
+            X`The specified choice is not a legal position: ${position}.`,
+          );
 
-  // exposed for testing. In contracts, shouldn't be released.
-  /** @type {VoteCounterCloseFacet} */
-  const closeFacet = Far('closeFacet', { closeVoting });
-
-  /** @type {VoteCounterCreatorFacet} */
-  const creatorFacet = Far('VoteCounter vote Cap', {
-    submitVote,
-  });
-
-  /** @type {VoteCounterPublicFacet} */
-  const publicFacet = Far('preliminaryPublicFacet', {
-    getQuestion: () => question,
-    isOpen: () => isOpen,
-    getOutcome: () => outcomePromise.promise,
-    getStats: () => tallyPromise.promise,
-    getDetails: () => details,
-  });
-  return { publicFacet, creatorFacet, closeFacet };
+          // CRUCIAL: If the voter cast a valid ballot, we'll record it, but we need
+          // to make sure that each voter's vote is recorded only once.
+          const completedBallot = harden({ chosen: position, shares });
+          allBallots.has(voterHandle)
+            ? allBallots.set(voterHandle, completedBallot)
+            : allBallots.init(voterHandle, completedBallot);
+          return completedBallot;
+        },
+      },
+      publicFacet: {
+        getQuestion() {
+          return question;
+        },
+        isOpen() {
+          return isOpen;
+        },
+        getOutcome() {
+          return outcomePromise.promise;
+        },
+        getStats() {
+          return tallyPromise.promise;
+        },
+        getDetails() {
+          return details;
+        },
+        getInstance() {
+          return instance;
+        },
+      },
+    },
+  );
+  return makeBinaryVoteCounterKit();
 };
 
 // The contract wrapper extracts the terms and runs makeBinaryVoteCounter().
@@ -189,13 +206,9 @@ const start = zcf => {
     zcf.getInstance(),
   );
 
-  scheduleClose(questionSpec.closingRule, closeFacet.closeVoting);
+  scheduleClose(questionSpec.closingRule, () => closeFacet.closeVoting());
 
-  const publicFacetWithGetInstance = Far('publicFacet', {
-    ...publicFacet,
-    getInstance: zcf.getInstance,
-  });
-  return { publicFacet: publicFacetWithGetInstance, creatorFacet };
+  return { publicFacet, creatorFacet };
 };
 
 harden(start);

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -93,7 +93,7 @@ const start = (zcf, privateArgs) => {
     [...Array(committeeSize).keys()].map(makeCommitteeVoterInvitation),
   );
 
-  const makeCommitteeFacets = defineHeapFarClassKit(
+  const makeCommitteeKit = defineHeapFarClassKit(
     'Committee Facets',
     CommitteeIKit,
     initEmpty,
@@ -180,8 +180,7 @@ const start = (zcf, privateArgs) => {
     },
   );
 
-  // @ts-expect-error How to type farClasses?
-  return makeCommitteeFacets();
+  return makeCommitteeKit();
 };
 
 harden(start);

--- a/packages/governance/src/contractGovernance/governParam.js
+++ b/packages/governance/src/contractGovernance/governParam.js
@@ -10,7 +10,7 @@ import {
   ElectionType,
   QuorumRule,
 } from '../question.js';
-import { ParamChangesQuestionSpecShape } from '../typeGuards.js';
+import { ParamChangesQuestionDetailsShape } from '../typeGuards.js';
 
 const { details: X } = assert;
 
@@ -43,7 +43,7 @@ const makeParamChangePositions = changes => {
  * @param {QuestionSpec<ParamChangeIssue<unknown>>} questionSpec
  */
 const assertBallotConcernsParam = (paramSpec, questionSpec) => {
-  fit(questionSpec, ParamChangesQuestionSpecShape);
+  fit(questionSpec, ParamChangesQuestionDetailsShape);
 
   const { parameterName, paramPath } = paramSpec;
   const { issue } = questionSpec;

--- a/packages/governance/src/contractGovernance/governParam.js
+++ b/packages/governance/src/contractGovernance/governParam.js
@@ -1,8 +1,8 @@
 // @ts-check
 
 import { E } from '@endo/eventual-send';
-import { Far, deeplyFulfilled } from '@endo/marshal';
-import { keyEQ } from '@agoric/store';
+import { deeplyFulfilled, Far } from '@endo/marshal';
+import { fit, keyEQ } from '@agoric/store';
 
 import {
   ChoiceMethod,
@@ -10,6 +10,7 @@ import {
   ElectionType,
   QuorumRule,
 } from '../question.js';
+import { ParamChangesQuestionSpecShape } from '../typeGuards.js';
 
 const { details: X } = assert;
 
@@ -34,30 +35,6 @@ const makeParamChangePositions = changes => {
   return harden({ positive, negative });
 };
 
-/** @type {ValidateParamChangeQuestion} */
-const validateParamChangeQuestion = details => {
-  assert(
-    details.method === ChoiceMethod.UNRANKED,
-    X`ChoiceMethod must be UNRANKED, not ${details.method}`,
-  );
-  assert(
-    details.electionType === ElectionType.PARAM_CHANGE,
-    X`ElectionType must be PARAM_CHANGE, not ${details.electionType}`,
-  );
-  assert(
-    details.maxChoices === 1,
-    X`maxChoices must be 1, not ${details.maxChoices}`,
-  );
-  assert(
-    details.quorumRule === QuorumRule.MAJORITY,
-    X`QuorumRule must be MAJORITY, not ${details.quorumRule}`,
-  );
-  assert(
-    details.tieOutcome.noChange,
-    X`tieOutcome must be noChange, not ${details.tieOutcome}`,
-  );
-};
-
 /**
  * assert that the parameter described by paramSpec is proposed to be changed in
  * the question described by questionSpec.
@@ -66,11 +43,10 @@ const validateParamChangeQuestion = details => {
  * @param {QuestionSpec<ParamChangeIssue<unknown>>} questionSpec
  */
 const assertBallotConcernsParam = (paramSpec, questionSpec) => {
+  fit(questionSpec, ParamChangesQuestionSpecShape);
+
   const { parameterName, paramPath } = paramSpec;
   const { issue } = questionSpec;
-
-  // XXX doesn't fully test this requirement
-  assert(issue, 'must be a param change issue');
 
   assert(
     issue.spec.changes[parameterName],
@@ -174,12 +150,10 @@ const setupParamGovernance = async (
 
 harden(setupParamGovernance);
 harden(makeParamChangePositions);
-harden(validateParamChangeQuestion);
 harden(assertBallotConcernsParam);
 export {
   setupParamGovernance,
   makeParamChangePositions,
-  validateParamChangeQuestion,
   assertBallotConcernsParam,
   CONTRACT_ELECTORATE,
 };

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -10,7 +10,7 @@ import {
 } from './contractGovernance/governParam.js';
 import { setupApiGovernance } from './contractGovernance/governApi.js';
 import { setupFilterGovernance } from './contractGovernance/governFilter.js';
-import { ParamChangesQuestionSpecShape } from './typeGuards.js';
+import { ParamChangesQuestionDetailsShape } from './typeGuards.js';
 
 const { details: X } = assert;
 
@@ -28,7 +28,7 @@ const validateQuestionDetails = async (zoe, electorate, details) => {
     counterInstance,
     issue: { contract: governedInstance },
   } = details;
-  fit(details, ParamChangesQuestionSpecShape);
+  fit(details, ParamChangesQuestionDetailsShape);
 
   const governorInstance = await E.get(E(zoe).getTerms(governedInstance))
     .electionManager;

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -2,14 +2,15 @@
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { fit } from '@agoric/store';
 
 import {
-  setupParamGovernance,
-  validateParamChangeQuestion,
   CONTRACT_ELECTORATE,
+  setupParamGovernance,
 } from './contractGovernance/governParam.js';
 import { setupApiGovernance } from './contractGovernance/governApi.js';
 import { setupFilterGovernance } from './contractGovernance/governFilter.js';
+import { ParamChangesQuestionSpecShape } from './typeGuards.js';
 
 const { details: X } = assert;
 
@@ -27,7 +28,7 @@ const validateQuestionDetails = async (zoe, electorate, details) => {
     counterInstance,
     issue: { contract: governedInstance },
   } = details;
-  validateParamChangeQuestion(details);
+  fit(details, ParamChangesQuestionSpecShape);
 
   const governorInstance = await E.get(E(zoe).getTerms(governedInstance))
     .electionManager;

--- a/packages/governance/src/index.js
+++ b/packages/governance/src/index.js
@@ -8,7 +8,6 @@ export {
   QuorumRule,
   coerceQuestionSpec,
   positionIncluded,
-  assertIssueForType,
   buildUnrankedQuestion,
 } from './question.js';
 
@@ -23,7 +22,6 @@ export {
   assertBallotConcernsParam,
   makeParamChangePositions,
   setupParamGovernance,
-  validateParamChangeQuestion,
   CONTRACT_ELECTORATE,
 } from './contractGovernance/governParam.js';
 

--- a/packages/governance/src/noActionElectorate.js
+++ b/packages/governance/src/noActionElectorate.js
@@ -32,7 +32,7 @@ const start = zcf => {
     getInstance() {
       return zcf.getInstance();
     },
-    getQuestion() {
+    getQuestion(_instance, _question) {
       throw Error(`noActionElectorate doesn't have questions.`);
     },
   });
@@ -42,7 +42,7 @@ const start = zcf => {
       return zcf.makeInvitation(() => {},
       `noActionElectorate doesn't allow posing questions`);
     },
-    addQuestion() {
+    addQuestion(_instance, _question) {
       throw Error(`noActionElectorate doesn't add questions.`);
     },
     getVoterInvitations() {

--- a/packages/governance/src/noActionElectorate.js
+++ b/packages/governance/src/noActionElectorate.js
@@ -1,8 +1,10 @@
 // @ts-check
 
 import { makePublishKit } from '@agoric/notifier';
-import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
+import { makeHeapFarInstance } from '@agoric/store';
+
+import { ElectoratePublicI, ElectorateCreatorI } from './typeGuards.js';
 
 /**
  * This Electorate visibly has no members, takes no votes, and approves no
@@ -13,35 +15,45 @@ import { makePromiseKit } from '@endo/promise-kit';
 const start = zcf => {
   const { subscriber } = makePublishKit();
 
-  const publicFacet = Far('publicFacet', {
-    getQuestionSubscriber: () => subscriber,
-    getOpenQuestions: () => {
+  const publicFacet = makeHeapFarInstance('publicFacet', ElectoratePublicI, {
+    getQuestionSubscriber() {
+      return subscriber;
+    },
+    getOpenQuestions() {
       /** @type {Handle<'Question'>[]} */
       const noQuestions = [];
       const questionsPromise = makePromiseKit();
       questionsPromise.resolve(noQuestions);
       return questionsPromise.promise;
     },
-    getName: () => 'no Action electorate',
-    getInstance: zcf.getInstance,
-    getQuestion: () => {
+    getName() {
+      return 'no Action electorate';
+    },
+    getInstance() {
+      return zcf.getInstance();
+    },
+    getQuestion() {
       throw Error(`noActionElectorate doesn't have questions.`);
     },
   });
 
-  const creatorFacet = Far('creatorFacet', {
-    getPoserInvitation: () => {
+  const creatorFacet = makeHeapFarInstance('creatorFacet', ElectorateCreatorI, {
+    getPoserInvitation() {
       return zcf.makeInvitation(() => {},
       `noActionElectorate doesn't allow posing questions`);
     },
     addQuestion() {
       throw Error(`noActionElectorate doesn't add questions.`);
     },
-    getVoterInvitations: () => {
+    getVoterInvitations() {
       throw Error(`No Action Electorate doesn't have invitations.`);
     },
-    getQuestionSubscriber: () => subscriber,
-    getPublicFacet: () => publicFacet,
+    getQuestionSubscriber() {
+      return subscriber;
+    },
+    getPublicFacet() {
+      return publicFacet;
+    },
   });
 
   return { publicFacet, creatorFacet };

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -1,10 +1,9 @@
 // @ts-check
 
-import { Far } from '@endo/marshal';
-import { keyEQ, fit, M } from '@agoric/store';
+import { makeHeapFarInstance, fit, keyEQ, M } from '@agoric/store';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 
-import { QuestionSpecShape } from './typeGuards.js';
+import { QuestionDetailI, QuestionSpecShape } from './typeGuards.js';
 
 // Topics being voted on are 'Questions'. Before a Question is known to a
 // electorate, the parameters can be described with a QuestionSpec. Once the
@@ -82,17 +81,18 @@ const coerceQuestionSpec = ({
 const buildUnrankedQuestion = (questionSpec, counterInstance) => {
   const questionHandle = makeHandle('Question');
 
-  const getDetails = () =>
-    harden({
-      ...questionSpec,
-      questionHandle,
-      counterInstance,
-    });
-
   /** @type {Question} */
-  return Far('question details', {
-    getVoteCounter: () => counterInstance,
-    getDetails,
+  return makeHeapFarInstance('question details', QuestionDetailI, {
+    getVoteCounter() {
+      return counterInstance;
+    },
+    getDetails() {
+      return harden({
+        ...questionSpec,
+        questionHandle,
+        counterInstance,
+      });
+    },
   });
 };
 

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -3,7 +3,7 @@
 import { makeHeapFarInstance, fit, keyEQ, M } from '@agoric/store';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 
-import { QuestionDetailI, QuestionSpecShape } from './typeGuards.js';
+import { QuestionI, QuestionSpecShape } from './typeGuards.js';
 
 // Topics being voted on are 'Questions'. Before a Question is known to a
 // electorate, the parameters can be described with a QuestionSpec. Once the
@@ -82,7 +82,7 @@ const buildUnrankedQuestion = (questionSpec, counterInstance) => {
   const questionHandle = makeHandle('Question');
 
   /** @type {Question} */
-  return makeHeapFarInstance('question details', QuestionDetailI, {
+  return makeHeapFarInstance('question details', QuestionI, {
     getVoteCounter() {
       return counterInstance;
     },

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -1,14 +1,10 @@
 // @ts-check
 
-import { Far, passStyleOf } from '@endo/marshal';
-import { keyEQ, fit } from '@agoric/store';
+import { Far } from '@endo/marshal';
+import { keyEQ, fit, M } from '@agoric/store';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
-import { Nat } from '@agoric/nat';
-import { M } from '@agoric/vat-data';
 
-import { makeAssertInstance } from './contractGovernance/assertions.js';
-
-const { details: X, quote: q } = assert;
+import { QuestionSpecShape } from './typeGuards.js';
 
 // Topics being voted on are 'Questions'. Before a Question is known to a
 // electorate, the parameters can be described with a QuestionSpec. Once the
@@ -43,123 +39,8 @@ const QuorumRule = /** @type {const} */ ({
   ALL: 'all',
 });
 
-/**
- * @param {unknown} issue
- * @returns {asserts issue is SimpleIssue}
- */
-
-const assertSimpleIssue = issue => {
-  assert.typeof(issue, 'object', X`Issue ("${issue}") must be a record`);
-  assert(
-    issue && typeof issue.text === 'string',
-    X`Issue ("${issue}") must be a record with text: aString`,
-  );
-};
-
-/**
- * @param {unknown} issue
- * @returns {asserts issue is ParamChangeIssue<unknown>}
- */
-
-const assertParamChangeIssue = issue => {
-  assert(issue, 'argument to assertParamChangeIssue cannot be null');
-  assert.typeof(issue, 'object', X`Issue ("${issue}") must be a record`);
-  assert(issue?.spec?.paramPath, X`Issue ("${issue}") must have a paramPath`);
-  assert(issue?.spec?.changes, X`Issue ("${issue}") must have changes`);
-
-  assert.typeof(
-    issue.spec.changes,
-    'object',
-    X`changes ("${issue.changes}") must be a record`,
-  );
-
-  const assertInstance = makeAssertInstance('contract');
-  assertInstance(issue.contract);
-};
-
-/**
- * @param {unknown} issue
- * @returns {asserts issue is ApiInvocationIssue}
- */
-
-const assertApiInvocation = issue => {
-  assert.typeof(issue, 'object', X`Issue ("${issue}") must be a record`);
-  assert(
-    issue && typeof issue.apiMethodName === 'string',
-    X`Issue ("${issue}") must be a record with apiMethodName: aString`,
-  );
-};
-
-/**
- * @param {unknown} issue
- * @returns {asserts issue is OfferFilterIssue}
- */
-
-const assertOfferFilter = issue => {
-  assert.typeof(issue, 'object', X`Issue ("${issue}") must be a record`);
-  fit(issue?.strings, M.arrayOf(M.string()), 'strings');
-};
-
-/**
- * @param {ElectionType} electionType
- * @param {unknown} issue
- * @returns {asserts issue is Issue}
- */
-
-const assertIssueForType = (electionType, issue) => {
-  assert(
-    passStyleOf(issue) === 'copyRecord',
-    X`A question can only be a pass-by-copy record: ${issue}`,
-  );
-
-  switch (electionType) {
-    case ElectionType.SURVEY:
-    case ElectionType.ELECTION:
-      assertSimpleIssue(issue);
-      break;
-    case ElectionType.PARAM_CHANGE:
-      assertParamChangeIssue(issue);
-      break;
-    case ElectionType.API_INVOCATION:
-      assertApiInvocation(issue);
-      break;
-    case ElectionType.OFFER_FILTER:
-      assertOfferFilter(issue);
-      break;
-    default:
-      throw Error(`Election type unrecognized`);
-  }
-};
-
 /** @type {PositionIncluded} */
 const positionIncluded = (positions, p) => positions.some(e => keyEQ(e, p));
-
-// QuestionSpec contains the subset of QuestionDetails that can be specified before
-/**
- * @param {unknown} closingRule
- * @returns {asserts closingRule is ClosingRule}
- */
-
-function assertClosingRule(closingRule) {
-  assert(closingRule, 'argument to assertClosingRule cannot be null');
-  assert.typeof(
-    closingRule,
-    'object',
-    X`ClosingRule ("${closingRule}") must be a record`,
-  );
-  Nat(closingRule?.deadline);
-  const timer = closingRule?.timer;
-  assert(passStyleOf(timer) === 'remotable', X`Timer must be a timer ${timer}`);
-}
-
-const assertEnumIncludes = (enumeration, value, name) => {
-  assert(
-    Object.keys(enumeration)
-      .map(k => enumeration[k])
-      .includes(value),
-    X`Illegal ${name}: ${value}`,
-  );
-};
 
 /**
  * @param {QuestionSpec} allegedQuestionSpec
@@ -175,27 +56,7 @@ const coerceQuestionSpec = ({
   quorumRule,
   tieOutcome,
 }) => {
-  assertIssueForType(electionType, issue);
-
-  assert(
-    positions.every(
-      p => passStyleOf(p) === 'copyRecord',
-      'positions must be records',
-    ),
-  );
-  assert(
-    positionIncluded(positions, tieOutcome),
-    X`tieOutcome must be a legal position: ${q(tieOutcome)}`,
-  );
-  assertEnumIncludes(QuorumRule, quorumRule, 'QuorumRule');
-  assertEnumIncludes(ElectionType, electionType, 'ElectionType');
-  assertEnumIncludes(ChoiceMethod, method, 'ChoiceMethod');
-  assert(maxChoices > 0, X`maxChoices must be positive: ${maxChoices}`);
-  assert(maxChoices <= positions.length, 'Choices must not exceed length');
-
-  assertClosingRule(closingRule);
-
-  return harden({
+  const question = harden({
     method,
     issue,
     positions,
@@ -205,6 +66,16 @@ const coerceQuestionSpec = ({
     quorumRule,
     tieOutcome,
   });
+
+  fit(question, QuestionSpecShape);
+
+  // XXX It would be nice to enforce this using parameterized types, but that
+  // seems to only enforce type constraints, (i.e. the tieOutcome will be the
+  // same type as any of the positions) unless you can provide the concrete
+  // value at pattern creation time.
+  fit(question.tieOutcome, M.or(...question.positions));
+
+  return question;
 };
 
 /** @type {BuildUnrankedQuestion} */
@@ -228,7 +99,6 @@ const buildUnrankedQuestion = (questionSpec, counterInstance) => {
 harden(buildUnrankedQuestion);
 harden(ChoiceMethod);
 harden(ElectionType);
-harden(assertIssueForType);
 harden(coerceQuestionSpec);
 harden(positionIncluded);
 harden(QuorumRule);
@@ -237,7 +107,6 @@ export {
   buildUnrankedQuestion,
   ChoiceMethod,
   ElectionType,
-  assertIssueForType,
   coerceQuestionSpec,
   positionIncluded,
   QuorumRule,

--- a/packages/governance/src/typeGuards.js
+++ b/packages/governance/src/typeGuards.js
@@ -227,7 +227,7 @@ export const BinaryVoteCounterAdminI = M.interface(
   {
     submitVote: M.call(VoterHandle, M.arrayOf(PositionShape))
       .optional(M.nat())
-      .returns(),
+      .returns({ chosen: PositionShape, shares: M.nat() }),
   },
 );
 

--- a/packages/governance/src/typeGuards.js
+++ b/packages/governance/src/typeGuards.js
@@ -243,14 +243,21 @@ export const QuestionStatsShape = harden({
   results: M.arrayOf({ position: PositionShape, total: M.nat() }),
 });
 
+export const QuestionDetailI = M.interface('Question details', {
+  getVoteCounter: M.call().returns(InstanceShape),
+  getDetails: M.call().returns(QuestionDetailsShape),
+});
+
 export const BinaryVoteCounterPublicI = M.interface(
   'BinaryVoteCounter PublicFacet',
   {
-    getQuestion: M.call().returns(QuestionSpecShape),
+    // XXX I expected M.call().returns(QuestionDetailI)
+    getQuestion: M.call().returns(M.remotable()),
     isOpen: M.call().returns(M.boolean()),
     getOutcome: M.call().returns(M.eref(PositionShape)),
     getStats: M.call().returns(QuestionStatsShape),
     getDetails: M.call().returns(QuestionDetailsShape),
+    getInstance: M.call().returns(InstanceShape),
   },
 );
 
@@ -259,7 +266,7 @@ export const BinaryVoteCounterAdminI = M.interface(
   'BinaryVoteCounter AdminFacet',
   {
     submitVote: M.call(VoterHandle, M.arrayOf(PositionShape))
-      .optional(M.nat)
+      .optional(M.nat())
       .returns(),
   },
 );
@@ -272,7 +279,7 @@ export const BinaryVoteCounterCloseI = M.interface(
 );
 
 export const BinaryVoteCounterIKit = harden({
-  BinaryVoteCounterPublicI,
-  BinaryVoteCounterAdminI,
-  BinaryVoteCounterCloseI,
+  publicFacet: BinaryVoteCounterPublicI,
+  creatorFacet: BinaryVoteCounterAdminI,
+  closeFacet: BinaryVoteCounterCloseI,
 });

--- a/packages/governance/src/typeGuards.js
+++ b/packages/governance/src/typeGuards.js
@@ -216,7 +216,7 @@ export const QuestionDetailsShape = M.or(
   SimpleQuestionDetailsShape,
 );
 
-export const CommitteePublicI = M.interface('Committee PublicFacet', {
+export const ElectoratePublicI = M.interface('Committee PublicFacet', {
   getQuestionSubscriber: M.call().returns(SubscriberShape),
   getOpenQuestions: M.call().returns(M.promise()),
   getName: M.call().returns(M.string()),
@@ -224,17 +224,17 @@ export const CommitteePublicI = M.interface('Committee PublicFacet', {
   getQuestion: M.call(QuestionHandleShape).returns(M.promise()),
 });
 
-export const CommitteeAdminI = M.interface('Committee AdminFacet', {
+export const ElectorateCreatorI = M.interface('Committee AdminFacet', {
   getPoserInvitation: M.call().returns(M.promise()),
   addQuestion: M.call(InstanceShape, QuestionSpecShape).returns(M.promise()),
   getVoterInvitations: M.call().returns(M.arrayOf(M.promise())),
   getQuestionSubscriber: M.call().returns(SubscriberShape),
-  getPublicFacet: M.call().returns(CommitteePublicI),
+  getPublicFacet: M.call().returns(ElectoratePublicI),
 });
 
 export const CommitteeIKit = harden({
-  publicFacet: CommitteePublicI,
-  creatorFacet: CommitteeAdminI,
+  publicFacet: ElectoratePublicI,
+  creatorFacet: ElectorateCreatorI,
 });
 
 export const QuestionStatsShape = harden({

--- a/packages/governance/src/typeGuards.js
+++ b/packages/governance/src/typeGuards.js
@@ -48,14 +48,7 @@ export const OfferFilterQuestionSpecShape = harden({
   tieOutcome: NoOfferFilterPositionShape,
 });
 export const OfferFilterQuestionDetailsShape = harden({
-  method: ChoiceMethodShape,
-  issue: OfferFilterIssueShape,
-  positions: OfferFilterPositionsShape,
-  electionType: 'offer_filter',
-  maxChoices: 1,
-  closingRule: ClosingRuleShape,
-  quorumRule: QuorumRuleShape,
-  tieOutcome: NoOfferFilterPositionShape,
+  ...OfferFilterQuestionSpecShape,
   questionHandle: makeHandleShape('Question'),
   counterInstance: InstanceHandleShape,
 });
@@ -92,14 +85,7 @@ export const ParamChangesQuestionSpecShape = harden({
 });
 
 export const ParamChangesQuestionDetailsShape = harden({
-  method: 'unranked',
-  issue: ParamChangesIssueShape,
-  positions: ParamChangesPositionsShape,
-  electionType: 'param_change',
-  maxChoices: 1,
-  closingRule: ClosingRuleShape,
-  quorumRule: 'majority',
-  tieOutcome: NoParamChangesPositionShape,
+  ...ParamChangesQuestionSpecShape,
   questionHandle: makeHandleShape('Question'),
   counterInstance: InstanceHandleShape,
 });
@@ -127,14 +113,7 @@ export const ApiInvocationQuestionSpecShape = harden({
   tieOutcome: NoApiInvocationPositionShape,
 });
 export const ApiInvocationQuestionDetailsShape = harden({
-  method: 'unranked',
-  issue: ApiInvocationSpecShape,
-  positions: ApiInvocationPositionsShape,
-  electionType: 'api_invocation',
-  maxChoices: 1,
-  closingRule: ClosingRuleShape,
-  quorumRule: QuorumRuleShape,
-  tieOutcome: NoApiInvocationPositionShape,
+  ...ApiInvocationQuestionSpecShape,
   questionHandle: makeHandleShape('Question'),
   counterInstance: InstanceHandleShape,
 });
@@ -160,14 +139,7 @@ export const SimpleQuestionSpecShape = harden({
   tieOutcome: NoSimplePositionShape,
 });
 export const SimpleQuestionDetailsShape = harden({
-  method: ChoiceMethodShape,
-  issue: SimpleIssueShape,
-  positions: SimplePositionsShape,
-  electionType: M.or('election', 'survey'),
-  maxChoices: M.gte(1),
-  closingRule: ClosingRuleShape,
-  quorumRule: QuorumRuleShape,
-  tieOutcome: NoSimplePositionShape,
+  ...SimpleQuestionSpecShape,
   questionHandle: makeHandleShape('Question'),
   counterInstance: InstanceHandleShape,
 });
@@ -223,11 +195,6 @@ export const ElectorateCreatorI = M.interface('Committee AdminFacet', {
   getVoterInvitations: M.call().returns(M.arrayOf(M.promise())),
   getQuestionSubscriber: M.call().returns(SubscriberShape),
   getPublicFacet: M.call().returns(ElectoratePublicShape),
-});
-
-export const CommitteeIKit = harden({
-  publicFacet: ElectoratePublicI,
-  creatorFacet: ElectorateCreatorI,
 });
 
 export const QuestionStatsShape = harden({

--- a/packages/governance/src/typeGuards.js
+++ b/packages/governance/src/typeGuards.js
@@ -1,0 +1,141 @@
+// @ts-check
+
+import { M } from '@agoric/store';
+import { TimestampShape } from '@agoric/swingset-vat/src/vats/timer/typeGuards.js';
+
+export const ChoiceMethodShape = M.or('unranked', 'order');
+export const QuorumRuleShape = M.or('majority', 'no_quorum', 'all');
+export const ElectionTypeShape = M.or(
+  'param_change',
+  'election',
+  'survey',
+  'api_invocation',
+  'offer_filter',
+);
+
+const makeHandleShape = name => M.remotable(`${name}Handle`);
+
+export const TimerShape = makeHandleShape('timer');
+export const InstanceShape = makeHandleShape('instance');
+
+export const ClosingRuleShape = harden({
+  timer: M.eref(TimerShape),
+  deadline: TimestampShape,
+});
+
+// all the strings that will be in the filter after passing
+export const YesOfferFilterPositionShape = harden({
+  strings: M.arrayOf(M.string()),
+});
+export const NoOfferFilterPositionShape = harden({
+  dontUpdate: M.arrayOf(M.string()),
+});
+export const OfferFilterPositionsShape = [
+  YesOfferFilterPositionShape,
+  NoOfferFilterPositionShape,
+];
+export const OfferFilterIssueShape = harden({
+  strings: M.arrayOf(M.string()),
+});
+export const OfferFilterQuestionSpecShape = harden({
+  method: ChoiceMethodShape,
+  issue: OfferFilterIssueShape,
+  positions: OfferFilterPositionsShape,
+  electionType: 'offer_filter',
+  maxChoices: M.eq(1),
+  closingRule: ClosingRuleShape,
+  quorumRule: QuorumRuleShape,
+  tieOutcome: NoOfferFilterPositionShape,
+});
+
+// keys are parameter names, values are proposed values
+export const ParamChangesSpecShape = M.recordOf(M.string(), M.any());
+export const YesParamChangesPositionShape = ParamChangesSpecShape;
+export const NoParamChangesPositionShape = harden({
+  noChange: M.arrayOf(M.string()),
+});
+export const ParamChangesPositionsShape = [
+  YesParamChangesPositionShape,
+  NoParamChangesPositionShape,
+];
+export const ParamPathShape = harden({
+  key: M.any(),
+});
+export const ParamChangesIssueShape = harden({
+  spec: {
+    paramPath: ParamPathShape,
+    changes: ParamChangesSpecShape,
+  },
+  contract: InstanceShape,
+});
+export const ParamChangesQuestionSpecShape = harden({
+  method: 'unranked',
+  issue: ParamChangesIssueShape,
+  positions: ParamChangesPositionsShape,
+  electionType: 'param_change',
+  maxChoices: M.eq(1),
+  closingRule: ClosingRuleShape,
+  quorumRule: 'majority',
+  tieOutcome: NoParamChangesPositionShape,
+});
+
+const ApiInvocationSpecShape = harden({
+  apiMethodName: M.string(),
+  methodArgs: M.arrayOf(M.any()),
+});
+export const YesApiInvocationPositionShape = ApiInvocationSpecShape;
+export const NoApiInvocationPositionShape = harden({
+  dontInvoke: M.string(),
+});
+export const ApiInvocationPositionsShape = [
+  YesApiInvocationPositionShape,
+  NoApiInvocationPositionShape,
+];
+export const ApiInvocationQuestionSpecShape = harden({
+  method: 'unranked',
+  issue: ApiInvocationSpecShape,
+  positions: ApiInvocationPositionsShape,
+  electionType: 'api_invocation',
+  maxChoices: M.eq(1),
+  closingRule: ClosingRuleShape,
+  quorumRule: QuorumRuleShape,
+  tieOutcome: NoApiInvocationPositionShape,
+});
+
+const SimpleSpecShape = harden({
+  text: M.string(),
+});
+export const YesSimplePositionShape = harden({ text: M.string() });
+export const NoSimplePositionShape = harden({ text: M.string() });
+export const SimplePositionsShape = [
+  YesSimplePositionShape,
+  NoSimplePositionShape,
+];
+export const SimpleIssueShape = SimpleSpecShape;
+export const SimpleQuestionSpecShape = harden({
+  method: ChoiceMethodShape,
+  issue: SimpleIssueShape,
+  positions: SimplePositionsShape,
+  electionType: M.or('election', 'survey'),
+  maxChoices: M.gte(1),
+  closingRule: ClosingRuleShape,
+  quorumRule: QuorumRuleShape,
+  tieOutcome: NoSimplePositionShape,
+});
+
+export const SimplePositionsShapeA = [
+  harden({ text: 'yes' }),
+  harden({ text: 'no' }),
+];
+
+export const SimpleQuestionSpecShapeA = harden({
+  positions: SimplePositionsShape,
+  tieOutcome: NoSimplePositionShape,
+});
+
+export const QuestionSpecShape = M.or(
+  ApiInvocationQuestionSpecShape,
+  OfferFilterQuestionSpecShape,
+  ParamChangesQuestionSpecShape,
+  SimpleQuestionSpecShape,
+);

--- a/packages/governance/src/typeGuards.js
+++ b/packages/governance/src/typeGuards.js
@@ -2,6 +2,11 @@
 
 import { M } from '@agoric/store';
 import { TimestampShape } from '@agoric/swingset-vat/src/vats/timer/typeGuards.js';
+import {
+  InstanceHandleShape,
+  TimerShape,
+  makeHandleShape,
+} from '@agoric/zoe/src/typeGuards.js';
 
 export const ChoiceMethodShape = M.or('unranked', 'order');
 export const QuorumRuleShape = M.or('majority', 'no_quorum', 'all');
@@ -12,11 +17,6 @@ export const ElectionTypeShape = M.or(
   'api_invocation',
   'offer_filter',
 );
-
-const makeHandleShape = name => M.remotable(`${name}Handle`);
-
-export const TimerShape = makeHandleShape('timer');
-export const InstanceShape = makeHandleShape('instance');
 
 export const ClosingRuleShape = harden({
   timer: M.eref(TimerShape),
@@ -30,10 +30,10 @@ export const YesOfferFilterPositionShape = harden({
 export const NoOfferFilterPositionShape = harden({
   dontUpdate: M.arrayOf(M.string()),
 });
-export const OfferFilterPositionsShape = [
+export const OfferFilterPositionsShape = harden([
   YesOfferFilterPositionShape,
   NoOfferFilterPositionShape,
-];
+]);
 export const OfferFilterIssueShape = harden({
   strings: M.arrayOf(M.string()),
 });
@@ -42,7 +42,7 @@ export const OfferFilterQuestionSpecShape = harden({
   issue: OfferFilterIssueShape,
   positions: OfferFilterPositionsShape,
   electionType: 'offer_filter',
-  maxChoices: M.eq(1),
+  maxChoices: 1,
   closingRule: ClosingRuleShape,
   quorumRule: QuorumRuleShape,
   tieOutcome: NoOfferFilterPositionShape,
@@ -52,12 +52,12 @@ export const OfferFilterQuestionDetailsShape = harden({
   issue: OfferFilterIssueShape,
   positions: OfferFilterPositionsShape,
   electionType: 'offer_filter',
-  maxChoices: M.eq(1),
+  maxChoices: 1,
   closingRule: ClosingRuleShape,
   quorumRule: QuorumRuleShape,
   tieOutcome: NoOfferFilterPositionShape,
   questionHandle: makeHandleShape('Question'),
-  counterInstance: InstanceShape,
+  counterInstance: InstanceHandleShape,
 });
 
 // keys are parameter names, values are proposed values
@@ -66,10 +66,10 @@ export const YesParamChangesPositionShape = ParamChangesSpecShape;
 export const NoParamChangesPositionShape = harden({
   noChange: M.arrayOf(M.string()),
 });
-export const ParamChangesPositionsShape = [
+export const ParamChangesPositionsShape = harden([
   YesParamChangesPositionShape,
   NoParamChangesPositionShape,
-];
+]);
 export const ParamPathShape = harden({
   key: M.any(),
 });
@@ -78,14 +78,14 @@ export const ParamChangesIssueShape = harden({
     paramPath: ParamPathShape,
     changes: ParamChangesSpecShape,
   },
-  contract: InstanceShape,
+  contract: InstanceHandleShape,
 });
 export const ParamChangesQuestionSpecShape = harden({
   method: 'unranked',
   issue: ParamChangesIssueShape,
   positions: ParamChangesPositionsShape,
   electionType: 'param_change',
-  maxChoices: M.eq(1),
+  maxChoices: 1,
   closingRule: ClosingRuleShape,
   quorumRule: 'majority',
   tieOutcome: NoParamChangesPositionShape,
@@ -96,12 +96,12 @@ export const ParamChangesQuestionDetailsShape = harden({
   issue: ParamChangesIssueShape,
   positions: ParamChangesPositionsShape,
   electionType: 'param_change',
-  maxChoices: M.eq(1),
+  maxChoices: 1,
   closingRule: ClosingRuleShape,
   quorumRule: 'majority',
   tieOutcome: NoParamChangesPositionShape,
   questionHandle: makeHandleShape('Question'),
-  counterInstance: InstanceShape,
+  counterInstance: InstanceHandleShape,
 });
 
 const ApiInvocationSpecShape = harden({
@@ -112,16 +112,16 @@ export const YesApiInvocationPositionShape = ApiInvocationSpecShape;
 export const NoApiInvocationPositionShape = harden({
   dontInvoke: M.string(),
 });
-export const ApiInvocationPositionsShape = [
+export const ApiInvocationPositionsShape = harden([
   YesApiInvocationPositionShape,
   NoApiInvocationPositionShape,
-];
+]);
 export const ApiInvocationQuestionSpecShape = harden({
   method: 'unranked',
   issue: ApiInvocationSpecShape,
   positions: ApiInvocationPositionsShape,
   electionType: 'api_invocation',
-  maxChoices: M.eq(1),
+  maxChoices: 1,
   closingRule: ClosingRuleShape,
   quorumRule: QuorumRuleShape,
   tieOutcome: NoApiInvocationPositionShape,
@@ -131,12 +131,12 @@ export const ApiInvocationQuestionDetailsShape = harden({
   issue: ApiInvocationSpecShape,
   positions: ApiInvocationPositionsShape,
   electionType: 'api_invocation',
-  maxChoices: M.eq(1),
+  maxChoices: 1,
   closingRule: ClosingRuleShape,
   quorumRule: QuorumRuleShape,
   tieOutcome: NoApiInvocationPositionShape,
   questionHandle: makeHandleShape('Question'),
-  counterInstance: InstanceShape,
+  counterInstance: InstanceHandleShape,
 });
 
 const SimpleSpecShape = harden({
@@ -144,10 +144,10 @@ const SimpleSpecShape = harden({
 });
 export const YesSimplePositionShape = harden({ text: M.string() });
 export const NoSimplePositionShape = harden({ text: M.string() });
-export const SimplePositionsShape = [
+export const SimplePositionsShape = harden([
   YesSimplePositionShape,
   NoSimplePositionShape,
-];
+]);
 export const SimpleIssueShape = SimpleSpecShape;
 export const SimpleQuestionSpecShape = harden({
   method: ChoiceMethodShape,
@@ -169,17 +169,7 @@ export const SimpleQuestionDetailsShape = harden({
   quorumRule: QuorumRuleShape,
   tieOutcome: NoSimplePositionShape,
   questionHandle: makeHandleShape('Question'),
-  counterInstance: InstanceShape,
-});
-
-export const SimplePositionsShapeA = [
-  harden({ text: 'yes' }),
-  harden({ text: 'no' }),
-];
-
-export const SimpleQuestionSpecShapeA = harden({
-  positions: SimplePositionsShape,
-  tieOutcome: NoSimplePositionShape,
+  counterInstance: InstanceHandleShape,
 });
 
 export const QuestionSpecShape = M.or(
@@ -220,16 +210,19 @@ export const ElectoratePublicI = M.interface('Committee PublicFacet', {
   getQuestionSubscriber: M.call().returns(SubscriberShape),
   getOpenQuestions: M.call().returns(M.promise()),
   getName: M.call().returns(M.string()),
-  getInstance: M.call().returns(InstanceShape),
+  getInstance: M.call().returns(InstanceHandleShape),
   getQuestion: M.call(QuestionHandleShape).returns(M.promise()),
 });
+const ElectoratePublicShape = M.remotable('ElectoratePublic');
 
 export const ElectorateCreatorI = M.interface('Committee AdminFacet', {
   getPoserInvitation: M.call().returns(M.promise()),
-  addQuestion: M.call(InstanceShape, QuestionSpecShape).returns(M.promise()),
+  addQuestion: M.call(InstanceHandleShape, QuestionSpecShape).returns(
+    M.promise(),
+  ),
   getVoterInvitations: M.call().returns(M.arrayOf(M.promise())),
   getQuestionSubscriber: M.call().returns(SubscriberShape),
-  getPublicFacet: M.call().returns(ElectoratePublicI),
+  getPublicFacet: M.call().returns(ElectoratePublicShape),
 });
 
 export const CommitteeIKit = harden({
@@ -243,21 +236,21 @@ export const QuestionStatsShape = harden({
   results: M.arrayOf({ position: PositionShape, total: M.nat() }),
 });
 
-export const QuestionDetailI = M.interface('Question details', {
-  getVoteCounter: M.call().returns(InstanceShape),
+export const QuestionI = M.interface('Question', {
+  getVoteCounter: M.call().returns(InstanceHandleShape),
   getDetails: M.call().returns(QuestionDetailsShape),
 });
+const QuestionShape = M.remotable('Question');
 
 export const BinaryVoteCounterPublicI = M.interface(
   'BinaryVoteCounter PublicFacet',
   {
-    // XXX I expected M.call().returns(QuestionDetailI)
-    getQuestion: M.call().returns(M.remotable()),
+    getQuestion: M.call().returns(QuestionShape),
     isOpen: M.call().returns(M.boolean()),
-    getOutcome: M.call().returns(M.eref(PositionShape)),
-    getStats: M.call().returns(QuestionStatsShape),
+    getOutcome: M.call().returns(M.eref(M.promise())),
+    getStats: M.call().returns(M.promise()),
     getDetails: M.call().returns(QuestionDetailsShape),
-    getInstance: M.call().returns(InstanceShape),
+    getInstance: M.call().returns(InstanceHandleShape),
   },
 );
 
@@ -277,9 +270,3 @@ export const BinaryVoteCounterCloseI = M.interface(
     closeVoting: M.call().returns(),
   },
 );
-
-export const BinaryVoteCounterIKit = harden({
-  publicFacet: BinaryVoteCounterPublicI,
-  creatorFacet: BinaryVoteCounterAdminI,
-  closeFacet: BinaryVoteCounterCloseI,
-});

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -688,12 +688,3 @@
  * @param {Instance} allegedGovernor
  * @param {Instance} allegedElectorate
  */
-
-/**
- * @callback ValidateParamChangeQuestion
- *
- * Validate that the details are appropriate for an election concerning a
- * parameter change for a governed contract.
- *
- * @param {ParamChangeIssueDetails} details
- */

--- a/packages/governance/test/unitTests/test-ballotBuilder.js
+++ b/packages/governance/test/unitTests/test-ballotBuilder.js
@@ -23,7 +23,7 @@ test('good QuestionSpec', t => {
         issue,
         positions,
         electionType: ElectionType.SURVEY,
-        maxChoices: 2,
+        maxChoices: 1,
         closingRule,
         quorumRule: QuorumRule.MAJORITY,
         tieOutcome: positions[1],
@@ -32,7 +32,7 @@ test('good QuestionSpec', t => {
   );
 });
 
-test('bad Question', t => {
+test('bad Issue', t => {
   t.throws(
     () =>
       coerceQuestionSpec(
@@ -49,7 +49,7 @@ test('bad Question', t => {
         }),
       ),
     {
-      message: 'A question can only be a pass-by-copy record: "will it blend?"',
+      message: / - Must match one of /,
     },
   );
 });
@@ -70,7 +70,7 @@ test('bad timer', t => {
           tieOutcome: positions[1],
         }),
       ),
-    { message: 'Timer must be a timer 37' },
+    { message: / - Must match one of / },
   );
 });
 
@@ -90,7 +90,7 @@ test('bad method', t => {
           tieOutcome: positions[1],
         }),
       ),
-    { message: 'Illegal "ChoiceMethod": "choose"' },
+    { message: / - Must match one of / },
   );
 });
 
@@ -104,13 +104,13 @@ test('bad Quorum', t => {
           issue,
           positions,
           electionType: ElectionType.SURVEY,
-          maxChoices: 2,
+          maxChoices: 1,
           closingRule,
           quorumRule: 0.5,
           tieOutcome: positions[1],
         }),
       ),
-    { message: 'Illegal "QuorumRule": 0.5' },
+    { message: / - Must match one of / },
   );
 });
 
@@ -118,19 +118,21 @@ test('bad tieOutcome', t => {
   t.throws(
     () =>
       coerceQuestionSpec(
-        // @ts-expect-error Illegal tieOutcome
         harden({
           method: ChoiceMethod.ORDER,
           issue,
           positions,
           electionType: ElectionType.SURVEY,
-          maxChoices: 2,
+          maxChoices: 1,
           closingRule,
           quorumRule: QuorumRule.NO_QUORUM,
-          tieOutcome: 'try again',
+          tieOutcome: { text: 'try again' },
         }),
       ),
-    { message: 'tieOutcome must be a legal position: "try again"' },
+    {
+      message:
+        '{"text":"try again"} - Must match one of [{"text":"yes"},{"text":"no"}]',
+    },
   );
 });
 
@@ -139,7 +141,7 @@ test('bad maxChoices', t => {
     () =>
       coerceQuestionSpec(
         harden({
-          method: ChoiceMethod.ORDER,
+          method: ChoiceMethod.UNRANKED,
           issue,
           positions,
           electionType: ElectionType.SURVEY,
@@ -149,7 +151,7 @@ test('bad maxChoices', t => {
           tieOutcome: positions[1],
         }),
       ),
-    { message: 'maxChoices must be positive: 0' },
+    { message: / - Must match one of / },
   );
 });
 
@@ -159,7 +161,8 @@ test('bad positions', t => {
       coerceQuestionSpec({
         method: ChoiceMethod.ORDER,
         issue,
-        positions: [{ text: 'yes' }, { text: 'no' }],
+        // @ts-expect-error intentionally erroneous
+        positions: [{ text: 'yes' }, { verbiage: 'no' }],
         electionType: ElectionType.SURVEY,
         maxChoices: 1,
         closingRule,
@@ -167,8 +170,7 @@ test('bad positions', t => {
         tieOutcome: positions[1],
       }),
     {
-      message:
-        'Cannot pass non-frozen objects like {"text":"yes"}. Use harden()',
+      message: / - Must match one of /,
     },
   );
 });

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -16,9 +16,10 @@ export const AmountPatternKeywordRecordShape = M.recordOf(
   M.pattern(),
 );
 
-/**
- * After defaults are filled in
- */
+export const makeHandleShape = name => M.remotable(`${name}Handle`);
+export const TimerShape = makeHandleShape('timer');
+
+/** After defaults are filled in */
 export const ProposalShape = harden({
   want: AmountPatternKeywordRecordShape,
   give: AmountKeywordRecordShape,
@@ -30,7 +31,7 @@ export const ProposalShape = harden({
       onDemand: null,
       waived: null,
       afterDeadline: {
-        timer: M.remotable(),
+        timer: M.eref(TimerShape),
         deadline: TimestampValueShape,
       },
     },

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -240,7 +240,7 @@ test('cleanProposal - other wrong stuff', t => {
     t,
     { exit: { afterDeadline: { timer: 'foo', deadline: 3n } } },
     'nat',
-    'proposal: exit: optional-parts: afterDeadline: timer: string "foo" - Must be a remotable',
+    'proposal: exit: optional-parts: afterDeadline: timer: "foo" - Must match one of ["[match:remotable]","[match:kind]"]',
   );
   proposeBad(
     t,


### PR DESCRIPTION
closes: #6060

## Description

Convert Governance contracts to use method schemas

Can be reviewed as separate commits:

commit 0: basic governance types
commit 1: committee as heapFarClass
commit 2: binaryVoteCounter and questionDetails as heapFarClasses

### Security Considerations

This uses method schemas to enforce types in the APIs.

### Documentation Considerations

No changes in behavior.

### Testing Considerations

Existing tests pass.  I didn't add tests for out-of-range parameters.