### PR TITLE
feat(deploy-script-helpers): Publish bundle

### DIFF
--- a/packages/deploy-script-support/src/helpers.js
+++ b/packages/deploy-script-support/src/helpers.js
@@ -22,7 +22,7 @@ const ZOE_INVITE_PURSE_PETNAME = 'Default Zoe invite purse';
 export const makeHelpers = async (homePromise, endowments) => {
   const { zoe, wallet, scratch, board } = E.get(homePromise);
 
-  const { lookup } = endowments;
+  const { lookup, publishBundle, pathResolve } = endowments;
 
   const walletAdmin = E(wallet).getAdminFacet();
   const installationManager = E(walletAdmin).getInstallationManager();
@@ -35,7 +35,14 @@ export const makeHelpers = async (homePromise, endowments) => {
 
   // Create the methods
 
-  const install = makeInstall(bundleSource, zoe, installationManager, board);
+  const install = makeInstall(
+    bundleSource,
+    zoe,
+    installationManager,
+    board,
+    publishBundle,
+    pathResolve,
+  );
 
   const startInstance = makeStartInstance(
     issuerManager,

--- a/packages/deploy-script-support/src/helpers.js
+++ b/packages/deploy-script-support/src/helpers.js
@@ -1,5 +1,6 @@
 import '@agoric/zoe/exported.js';
 import { E } from '@endo/far';
+import bundleSource from '@endo/bundle-source';
 
 import { makeInstall } from './install.js';
 import { makeOfferAndFindInvitationAmount } from './offer.js';
@@ -21,7 +22,7 @@ const ZOE_INVITE_PURSE_PETNAME = 'Default Zoe invite purse';
 export const makeHelpers = async (homePromise, endowments) => {
   const { zoe, wallet, scratch, board } = E.get(homePromise);
 
-  const { bundleSource, lookup } = endowments;
+  const { lookup } = endowments;
 
   const walletAdmin = E(wallet).getAdminFacet();
   const installationManager = E(walletAdmin).getInstallationManager();

--- a/packages/deploy-script-support/src/install.js
+++ b/packages/deploy-script-support/src/install.js
@@ -19,25 +19,53 @@ import { E } from '@endo/far';
  * @param {ERef<ZoeService>} zoe
  * @param {ERef<import('./startInstance.js').InstallationManager>} installationManager
  * @param {ERef<any>} board
+ * @param {(bundle: any) => any} [publishBundle]
+ * @param {(path: string) => string} [pathResolve]
  */
-export const makeInstall = (bundleSource, zoe, installationManager, board) => {
+export const makeInstall = (
+  bundleSource,
+  zoe,
+  installationManager,
+  board,
+  publishBundle,
+  pathResolve,
+) => {
   /**
-   * @param {string} resolvedPath
+   * @param {string} contractPath
    * @param {Petname} contractPetname
    * @returns {Promise<{ installation: Installation, id: string}>}
-   * */
-  const install = async (resolvedPath, contractPetname) => {
-    console.log(`- Installing Contract Name: ${contractPetname}`);
+   */
+  const install = async (contractPath, contractPetname) => {
+    const resolvedPath = pathResolve ? pathResolve(contractPath) : contractPath;
 
     const bundle = await bundleSource(resolvedPath);
-    const installation = await E(zoe).install(bundle);
-
+    console.log(`- Publishing Contract Name: ${contractPetname}`);
+    const hashedBundle = await (publishBundle ? publishBundle(bundle) : bundle);
+    console.log(`- Installing Contract Name: ${contractPetname}`);
+    const installation = await E(zoe).install(hashedBundle);
+    console.log(
+      `- Adding contract to installation manager: ${contractPetname}`,
+    );
     await E(installationManager).add(contractPetname, installation);
 
-    console.log(`- Installed Contract Name: ${contractPetname}`);
-
+    // Let's share this installation with other people, so that
+    // they can run our contract code by making a contract
+    // instance (see the api deploy script in this repo to see an
+    // example of how to use the installation to make a new contract
+    // instance.)
+    // To share the installation, we're going to put it in the
+    // board. The board is a shared, on-chain object that maps
+    // strings to objects.
     const id = await E(board).getId(installation);
-    return { installation, id };
+
+    console.log('- SUCCESS! contract code installed on Zoe');
+    console.log(`-- Contract Name: ${contractPetname}`);
+    console.log(`-- Installation Board Id: ${id}`);
+
+    return {
+      installation,
+      id,
+    };
   };
   return install;
 };


### PR DESCRIPTION
- fix(deploy-script-support): Use versioned bundleSource
- feat(deploy-script-support): Publish bundles to chain if possible

closes: #5618

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

If a deploy script receives a publishBundle power from the `agoric deploy` command, it can now publish the code to a chain and submit the hash in a delivery transaction to Zoe.  This will allow us to reduce the transaction size limits for these separate lanes: publishing and delivering messages.

This changes the deploy script helpers to take advantage of publishBundle if it's available.

### Security Considerations



### Documentation Considerations

This change should expressly reduce the burden on documentation, as opposed to having this behavior visible in all deployment scripts.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

The Dapp Fungible Faucet (our template for new dapps) does not currently use the helpers.
https://github.com/Agoric/dapp-fungible-faucet/pull/53 recruits the dapp fungible faucet integration test to exercise publishBundle.
I've verified these changes locally with a scenario2 fake chain.

dapp-fungible-faucet-branch: 4564-helpers
