### PR TITLE
refactor(store)!: Rename from FarClass to ExoClass, etc

### DIFF
--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -1,5 +1,5 @@
 import { initEmpty } from '@agoric/store';
-import { vivifyFarClass } from '@agoric/vat-data';
+import { vivifyExoClass } from '@agoric/vat-data';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -12,7 +12,7 @@ import { vivifyFarClass } from '@agoric/vat-data';
  * @returns {() => Payment<K>}
  */
 export const vivifyPaymentKind = (issuerBaggage, name, brand, PaymentI) => {
-  const makePayment = vivifyFarClass(
+  const makePayment = vivifyExoClass(
     issuerBaggage,
     `${name} payment`,
     PaymentI,

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -2,10 +2,7 @@
 import { isPromise } from '@endo/promise-kit';
 import { assertCopyArray } from '@endo/marshal';
 import { fit, M } from '@agoric/store';
-import {
-  provideDurableWeakMapStore,
-  vivifyFarInstance,
-} from '@agoric/vat-data';
+import { provideDurableWeakMapStore, vivifyExo } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { vivifyPaymentKind } from './payment.js';
 import { vivifyPurseKind } from './purse.js';
@@ -86,7 +83,7 @@ export const vivifyPaymentLedger = (
   optShutdownWithFailure = undefined,
 ) => {
   /** @type {Brand} */
-  const brand = vivifyFarInstance(issuerBaggage, `${name} brand`, BrandI, {
+  const brand = vivifyExo(issuerBaggage, `${name} brand`, BrandI, {
     isMyIssuer(allegedIssuer) {
       // BrandI delays calling this method until `allegedIssuer` is a Remotable
       return allegedIssuer === issuer;
@@ -385,7 +382,7 @@ export const vivifyPaymentLedger = (
   );
 
   /** @type {Issuer} */
-  const issuer = vivifyFarInstance(issuerBaggage, `${name} issuer`, IssuerI, {
+  const issuer = vivifyExo(issuerBaggage, `${name} issuer`, IssuerI, {
     getBrand() {
       return brand;
     },
@@ -483,7 +480,7 @@ export const vivifyPaymentLedger = (
   });
 
   /** @type {Mint} */
-  const mint = vivifyFarInstance(issuerBaggage, `${name} mint`, MintI, {
+  const mint = vivifyExo(issuerBaggage, `${name} mint`, MintI, {
     getIssuer() {
       return issuer;
     },

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -1,4 +1,4 @@
-import { vivifyFarClassKit, makeScalarBigSetStore } from '@agoric/vat-data';
+import { vivifyExoClassKit, makeScalarBigSetStore } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { makeTransientNotifierKit } from './transientNotifier.js';
 
@@ -28,7 +28,7 @@ export const vivifyPurseKind = (
   //   that created depositFacet as needed. But this approach ensures a constant
   //   identity for the facet and exercises the multi-faceted object style.
   const { depositInternal, withdrawInternal } = purseMethods;
-  const makePurseKit = vivifyFarClassKit(
+  const makePurseKit = vivifyExoClassKit(
     issuerBaggage,
     `${name} Purse`,
     PurseIKit,

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -2,7 +2,7 @@
 
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeHeapFarInstance, keyEQ, makeStore } from '@agoric/store';
+import { makeHeapExo, keyEQ, makeStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 
 import {
@@ -149,7 +149,7 @@ const makeBinaryVoteCounter = (
     });
   };
 
-  const closeFacet = makeHeapFarInstance(
+  const closeFacet = makeHeapExo(
     'BinaryVoteCounter close',
     BinaryVoteCounterCloseI,
     {
@@ -160,7 +160,7 @@ const makeBinaryVoteCounter = (
     },
   );
 
-  const creatorFacet = makeHeapFarInstance(
+  const creatorFacet = makeHeapExo(
     'BinaryVoteCounter creator',
     BinaryVoteCounterAdminI,
     {
@@ -183,7 +183,7 @@ const makeBinaryVoteCounter = (
     },
   );
 
-  const publicFacet = makeHeapFarInstance(
+  const publicFacet = makeHeapExo(
     'BinaryVoteCounter public',
     BinaryVoteCounterPublicI,
     {

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { makeStoredPublishKit } from '@agoric/notifier';
-import { makeStore, makeHeapFarInstance, M } from '@agoric/store';
+import { makeStore, makeHeapExo, M } from '@agoric/store';
 import { natSafeMath } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 
@@ -81,27 +81,23 @@ const start = (zcf, privateArgs) => {
       // Ensure that the voter can't get access to the unwrapped voteCap, and
       // has no control over the voteHandle or weight
       return harden({
-        voter: makeHeapFarInstance(`voter${index}`, VoterI, {
+        voter: makeHeapExo(`voter${index}`, VoterI, {
           castBallotFor(questionHandle, positions) {
             const { voteCap } = allQuestions.get(questionHandle);
             return E(voteCap).submitVote(voterHandle, positions, 1n);
           },
         }),
-        invitationMakers: makeHeapFarInstance(
-          'invitation makers',
-          InvitationMakerI,
-          {
-            makeVoteInvitation(positions, questionHandle) {
-              const continuingVoteHandler = cSeat => {
-                cSeat.exit();
-                const { voteCap } = allQuestions.get(questionHandle);
-                return E(voteCap).submitVote(voterHandle, positions, 1n);
-              };
+        invitationMakers: makeHeapExo('invitation makers', InvitationMakerI, {
+          makeVoteInvitation(positions, questionHandle) {
+            const continuingVoteHandler = cSeat => {
+              cSeat.exit();
+              const { voteCap } = allQuestions.get(questionHandle);
+              return E(voteCap).submitVote(voterHandle, positions, 1n);
+            };
 
-              return zcf.makeInvitation(continuingVoteHandler, 'vote');
-            },
+            return zcf.makeInvitation(continuingVoteHandler, 'vote');
           },
-        ),
+        }),
       });
     };
 
@@ -118,29 +114,25 @@ const start = (zcf, privateArgs) => {
     [...Array(committeeSize).keys()].map(makeCommitteeVoterInvitation),
   );
 
-  const publicFacet = makeHeapFarInstance(
-    'Committee publicFacet',
-    ElectoratePublicI,
-    {
-      getQuestionSubscriber() {
-        return questionsSubscriber;
-      },
-      getOpenQuestions() {
-        return getOpenQuestions(allQuestions);
-      },
-      getName() {
-        return committeeName;
-      },
-      getInstance() {
-        return zcf.getInstance();
-      },
-      getQuestion(handleP) {
-        return getQuestion(handleP, allQuestions);
-      },
+  const publicFacet = makeHeapExo('Committee publicFacet', ElectoratePublicI, {
+    getQuestionSubscriber() {
+      return questionsSubscriber;
     },
-  );
+    getOpenQuestions() {
+      return getOpenQuestions(allQuestions);
+    },
+    getName() {
+      return committeeName;
+    },
+    getInstance() {
+      return zcf.getInstance();
+    },
+    getQuestion(handleP) {
+      return getQuestion(handleP, allQuestions);
+    },
+  });
 
-  const creatorFacet = makeHeapFarInstance(
+  const creatorFacet = makeHeapExo(
     'Committee creatorFacet',
     ElectorateCreatorI,
     {

--- a/packages/governance/src/noActionElectorate.js
+++ b/packages/governance/src/noActionElectorate.js
@@ -2,7 +2,7 @@
 
 import { makePublishKit } from '@agoric/notifier';
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeHeapFarInstance } from '@agoric/store';
+import { makeHeapExo } from '@agoric/store';
 
 import { ElectoratePublicI, ElectorateCreatorI } from './typeGuards.js';
 
@@ -15,7 +15,7 @@ import { ElectoratePublicI, ElectorateCreatorI } from './typeGuards.js';
 const start = zcf => {
   const { subscriber } = makePublishKit();
 
-  const publicFacet = makeHeapFarInstance('publicFacet', ElectoratePublicI, {
+  const publicFacet = makeHeapExo('publicFacet', ElectoratePublicI, {
     getQuestionSubscriber() {
       return subscriber;
     },
@@ -37,7 +37,7 @@ const start = zcf => {
     },
   });
 
-  const creatorFacet = makeHeapFarInstance('creatorFacet', ElectorateCreatorI, {
+  const creatorFacet = makeHeapExo('creatorFacet', ElectorateCreatorI, {
     getPoserInvitation() {
       return zcf.makeInvitation(() => {},
       `noActionElectorate doesn't allow posing questions`);

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { makeHeapFarInstance, fit, keyEQ, M } from '@agoric/store';
+import { makeHeapExo, fit, keyEQ, M } from '@agoric/store';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 
 import { QuestionI, QuestionSpecShape } from './typeGuards.js';
@@ -82,7 +82,7 @@ const buildUnrankedQuestion = (questionSpec, counterInstance) => {
   const questionHandle = makeHandle('Question');
 
   /** @type {Question} */
-  return makeHeapFarInstance('question details', QuestionI, {
+  return makeHeapExo('question details', QuestionI, {
     getVoteCounter() {
       return counterInstance;
     },

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -15,7 +15,7 @@ import {
   ParamTypes,
   publicMixinAPI,
 } from '@agoric/governance';
-import { M, provide, vivifyFarInstance } from '@agoric/vat-data';
+import { M, provide, vivifyExo } from '@agoric/vat-data';
 import { AmountMath } from '@agoric/ertp';
 
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
@@ -296,7 +296,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     },
     ...publicMixin,
   };
-  const publicFacet = vivifyFarInstance(
+  const publicFacet = vivifyExo(
     baggage,
     'Parity Stability Module',
     PSMI,

--- a/packages/inter-protocol/src/psm/psmCharter.js
+++ b/packages/inter-protocol/src/psm/psmCharter.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import '@agoric/governance/src/exported.js';
-import { makeScalarMapStore, M, makeHeapFarInstance, fit } from '@agoric/store';
+import { makeScalarMapStore, M, makeHeapExo, fit } from '@agoric/store';
 import '@agoric/zoe/exported.js';
 import '@agoric/zoe/src/contracts/exported.js';
 import { InstanceHandleShape } from '@agoric/zoe/src/typeGuards.js';
@@ -90,14 +90,10 @@ export const start = async zcf => {
       TimestampShape,
     ).returns(M.promise()),
   });
-  const invitationMakers = makeHeapFarInstance(
-    'PSM Invitation Makers',
-    MakerShape,
-    {
-      VoteOnParamChange: makeParamInvitation,
-      VoteOnPauseOffers: makeOfferFilterInvitation,
-    },
-  );
+  const invitationMakers = makeHeapExo('PSM Invitation Makers', MakerShape, {
+    VoteOnParamChange: makeParamInvitation,
+    VoteOnPauseOffers: makeOfferFilterInvitation,
+  });
 
   const charterMemberHandler = seat => {
     seat.exit();
@@ -111,7 +107,7 @@ export const start = async zcf => {
     makeCharterMemberInvitation: M.call().returns(M.promise()),
   });
 
-  const creatorFacet = makeHeapFarInstance(
+  const creatorFacet = makeHeapExo(
     'PSM Charter creatorFacet',
     psmCharterCreatorI,
     {

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -13,7 +13,7 @@ import {
 } from '@agoric/notifier';
 import { fit, M, makeScalarMapStore } from '@agoric/store';
 import {
-  defineVirtualFarClassKit,
+  defineVirtualExoClassKit,
   makeScalarBigMapStore,
   pickFacet,
 } from '@agoric/vat-data';
@@ -538,7 +538,7 @@ const finish = ({ state, facets }) => {
   });
 };
 
-const SmartWalletKit = defineVirtualFarClassKit(
+const SmartWalletKit = defineVirtualExoClassKit(
   'SmartWallet',
   behaviorGuards,
   initState,

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -6,7 +6,7 @@
  */
 
 import { BridgeId, WalletName } from '@agoric/internal';
-import { fit, M, makeHeapFarInstance } from '@agoric/store';
+import { fit, M, makeHeapExo } from '@agoric/store';
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeMyAddressNameAdminKit } from '@agoric/vats/src/core/basic-behaviors.js';
@@ -75,7 +75,7 @@ export const start = async (zcf, privateArgs) => {
   const walletsByAddress = makeScalarBigMapStore('walletsByAddress');
   const provider = makeAtomicProvider(walletsByAddress);
 
-  const handleWalletAction = makeHeapFarInstance(
+  const handleWalletAction = makeHeapExo(
     'walletActionHandler',
     M.interface('walletActionHandlerI', {
       fromBridge: M.call(M.string(), shape.WalletBridgeMsg).returns(
@@ -131,7 +131,7 @@ export const start = async (zcf, privateArgs) => {
     zoe,
   });
 
-  const creatorFacet = makeHeapFarInstance(
+  const creatorFacet = makeHeapExo(
     'walletFactoryCreator',
     M.interface('walletFactoryCreatorI', {
       provideSmartWallet: M.callWhen(

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -59,9 +59,9 @@ export {
 export {
   defendPrototype,
   initEmpty,
-  defineHeapFarClass,
-  defineHeapFarClassKit,
-  makeHeapFarInstance,
+  defineHeapExoClass,
+  defineHeapExoClassKit,
+  makeHeapExo,
 } from './patterns/interface-tools.js';
 
 export { compareRank, isRankSorted, sortByRank } from './patterns/rankOrder.js';

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -264,7 +264,7 @@ const emptyRecord = harden({});
 /**
  * When calling `defineDurableKind` and
  * its siblings, used as the `init` function argument to indicate that the
- * state record of the (virtual/durable) instances of the kind/farClass
+ * state record of the (virtual/durable) instances of the kind/exoClass
  * should be empty, and that the returned maker function should have zero
  * parameters.
  *
@@ -291,7 +291,7 @@ export const initEmpty = () => emptyRecord;
  * @param {object} [options]
  * @returns {(...args: A[]) => (T & import('@endo/eventual-send').RemotableBrand<{}, T>)}
  */
-export const defineHeapFarClass = (
+export const defineHeapExoClass = (
   tag,
   interfaceGuard,
   init,
@@ -328,7 +328,7 @@ export const defineHeapFarClass = (
   // @ts-expect-error could be instantiated with different subtype
   return harden(makeInstance);
 };
-harden(defineHeapFarClass);
+harden(defineHeapExoClass);
 
 /**
  * @template A
@@ -341,7 +341,7 @@ harden(defineHeapFarClass);
  * @param {object} [options]
  * @returns {(...args: A[]) => F}
  */
-export const defineHeapFarClassKit = (
+export const defineHeapExoClassKit = (
   tag,
   interfaceGuardKit,
   init,
@@ -398,7 +398,7 @@ export const defineHeapFarClassKit = (
   // @ts-ignore xxx
   return harden(makeInstanceKit);
 };
-harden(defineHeapFarClassKit);
+harden(defineHeapExoClassKit);
 
 /**
  * @template {Record<string, Method>} T
@@ -408,13 +408,13 @@ harden(defineHeapFarClassKit);
  * @param {object} [options]
  * @returns {T & import('@endo/eventual-send').RemotableBrand<{}, T>}
  */
-export const makeHeapFarInstance = (
+export const makeHeapExo = (
   tag,
   interfaceGuard,
   methods,
   options = undefined,
 ) => {
-  const makeInstance = defineHeapFarClass(
+  const makeInstance = defineHeapExoClass(
     tag,
     interfaceGuard,
     initEmpty,
@@ -423,4 +423,4 @@ export const makeHeapFarInstance = (
   );
   return makeInstance();
 };
-harden(makeHeapFarInstance);
+harden(makeHeapExo);

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -2,9 +2,9 @@
 
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import {
-  defineHeapFarClass,
-  defineHeapFarClassKit,
-  makeHeapFarInstance,
+  defineHeapExoClass,
+  defineHeapExoClassKit,
+  makeHeapExo,
 } from '../src/patterns/interface-tools.js';
 import { M } from '../src/patterns/patternMatchers.js';
 
@@ -22,8 +22,8 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineHeapFarClass', t => {
-  const makeUpCounter = defineHeapFarClass(
+test('test defineHeapExoClass', t => {
+  const makeUpCounter = defineHeapExoClass(
     'UpCounter',
     UpCounterI,
     (x = 0) => ({ x }),
@@ -49,8 +49,8 @@ test('test defineHeapFarClass', t => {
   });
 });
 
-test('test defineHeapFarClassKit', t => {
-  const makeCounterKit = defineHeapFarClassKit(
+test('test defineHeapExoClassKit', t => {
+  const makeCounterKit = defineHeapExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
     (x = 0) => ({ x }),
@@ -91,9 +91,9 @@ test('test defineHeapFarClassKit', t => {
   });
 });
 
-test('test makeHeapFarInstance', t => {
+test('test makeHeapExo', t => {
   let x = 3;
-  const upCounter = makeHeapFarInstance('upCounter', UpCounterI, {
+  const upCounter = makeHeapExo('upCounter', UpCounterI, {
     incr(y = 1) {
       x += y;
       return x;
@@ -113,7 +113,7 @@ test('test makeHeapFarInstance', t => {
 // needn't run. we just don't have a better place to write these.
 test.skip('types', () => {
   // any methods can be defined if there's no interface
-  const unguarded = makeHeapFarInstance('upCounter', undefined, {
+  const unguarded = makeHeapExo('upCounter', undefined, {
     /** @param {number} val */
     incr(val) {
       return val;
@@ -129,7 +129,7 @@ test.skip('types', () => {
   unguarded.notInBehavior;
 
   // TODO when there is an interface, error if a method is missing from it
-  const guarded = makeHeapFarInstance('upCounter', UpCounterI, {
+  const guarded = makeHeapExo('upCounter', UpCounterI, {
     /** @param {number} val */
     incr(val) {
       return val;

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -27,7 +27,7 @@ import {
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
-export const defineVirtualFarClass = (
+export const defineVirtualExoClass = (
   tag,
   interfaceGuard,
   init,
@@ -41,7 +41,7 @@ export const defineVirtualFarClass = (
     thisfulMethods: true,
     interfaceGuard,
   });
-harden(defineVirtualFarClass);
+harden(defineVirtualExoClass);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -53,7 +53,7 @@ harden(defineVirtualFarClass);
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
-export const defineVirtualFarClassKit = (
+export const defineVirtualExoClassKit = (
   tag,
   interfaceGuardKit,
   init,
@@ -67,7 +67,7 @@ export const defineVirtualFarClassKit = (
     thisfulMethods: true,
     interfaceGuard: interfaceGuardKit,
   });
-harden(defineVirtualFarClassKit);
+harden(defineVirtualExoClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -79,7 +79,7 @@ harden(defineVirtualFarClassKit);
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
-export const defineDurableFarClass = (
+export const defineDurableExoClass = (
   kindHandle,
   interfaceGuard,
   init,
@@ -93,7 +93,7 @@ export const defineDurableFarClass = (
     thisfulMethods: true,
     interfaceGuard,
   });
-harden(defineDurableFarClass);
+harden(defineDurableExoClass);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -105,7 +105,7 @@ harden(defineDurableFarClass);
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
-export const defineDurableFarClassKit = (
+export const defineDurableExoClassKit = (
   kindHandle,
   interfaceGuardKit,
   init,
@@ -119,7 +119,7 @@ export const defineDurableFarClassKit = (
     thisfulMethods: true,
     interfaceGuard: interfaceGuardKit,
   });
-harden(defineDurableFarClassKit);
+harden(defineDurableExoClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -132,7 +132,7 @@ harden(defineDurableFarClassKit);
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
-export const vivifyFarClass = (
+export const vivifyExoClass = (
   baggage,
   kindName,
   interfaceGuard,
@@ -140,14 +140,14 @@ export const vivifyFarClass = (
   methods,
   options = undefined,
 ) =>
-  defineDurableFarClass(
+  defineDurableExoClass(
     provideKindHandle(baggage, kindName),
     interfaceGuard,
     init,
     methods,
     options,
   );
-harden(vivifyFarClass);
+harden(vivifyExoClass);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -160,7 +160,7 @@ harden(vivifyFarClass);
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
-export const vivifyFarClassKit = (
+export const vivifyExoClassKit = (
   baggage,
   kindName,
   interfaceGuardKit,
@@ -168,14 +168,14 @@ export const vivifyFarClassKit = (
   facets,
   options = undefined,
 ) =>
-  defineDurableFarClassKit(
+  defineDurableExoClassKit(
     provideKindHandle(baggage, kindName),
     interfaceGuardKit,
     init,
     facets,
     options,
   );
-harden(vivifyFarClassKit);
+harden(vivifyExoClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -187,14 +187,14 @@ harden(vivifyFarClassKit);
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {T & RemotableBrand<{}, T>}
  */
-export const vivifyFarInstance = (
+export const vivifyExo = (
   baggage,
   kindName,
   interfaceGuard,
   methods,
   options = undefined,
 ) => {
-  const makeSingleton = vivifyFarClass(
+  const makeSingleton = vivifyExoClass(
     baggage,
     kindName,
     interfaceGuard,
@@ -207,10 +207,10 @@ export const vivifyFarInstance = (
   // @ts-ignore could be instantiated with an arbitrary type
   return provide(baggage, `the_${kindName}`, () => makeSingleton());
 };
-harden(vivifyFarInstance);
+harden(vivifyExo);
 
 /**
- * @deprecated Use vivifyFarInstance instead.
+ * @deprecated Use vivifyExo instead.
  * @template T
  * @param {Baggage} baggage
  * @param {string} kindName
@@ -223,5 +223,5 @@ export const vivifySingleton = (
   kindName,
   methods,
   options = undefined,
-) => vivifyFarInstance(baggage, kindName, undefined, methods, options);
+) => vivifyExo(baggage, kindName, undefined, methods, options);
 harden(vivifySingleton);

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -2,14 +2,14 @@
 export * from './vat-data-bindings.js';
 export * from './kind-utils.js';
 export {
-  defineVirtualFarClass,
-  defineVirtualFarClassKit,
-  defineDurableFarClass,
-  defineDurableFarClassKit,
-  vivifyFarClass,
-  vivifyFarClassKit,
-  vivifyFarInstance,
+  defineVirtualExoClass,
+  defineVirtualExoClassKit,
+  defineDurableExoClass,
+  defineDurableExoClassKit,
+  vivifyExoClass,
+  vivifyExoClassKit,
+  vivifyExo,
   vivifySingleton,
-} from './far-class-utils.js';
+} from './exo-utils.js';
 
 /** @template T @typedef {import('./types.js').DefineKindOptions<T>} DefineKindOptions */

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -75,7 +75,7 @@ type DefineKindOptions<C> = {
    * argument or as their `this` binding? For `defineDurableKind` and its
    * siblings (including `vivifySingleton`), this defaults to off, meaning that
    * their behavior methods receive `context` as their first argument.
-   * `vivifyFarClass` and its siblings (including `vivifyFarInstance`) use
+   * `vivifyExoClass` and its siblings (including `vivifyExo`) use
    * this flag internally to indicate that their methods receive `context`
    * as their `this` binding.
    */
@@ -88,7 +88,7 @@ type DefineKindOptions<C> = {
    * pattern is satisfied before calling the raw method.
    *
    * In `defineDurableKind` and its siblings, this defaults to off.
-   * `vivifyFarClass` use this internally to protect their raw class methods
+   * `vivifyExoClass` use this internally to protect their raw class methods
    * using the provided interface.
    */
   interfaceGuard?: InterfaceGuard<unknown>;

--- a/packages/vat-data/test/test-durable-classes.js
+++ b/packages/vat-data/test/test-durable-classes.js
@@ -3,9 +3,9 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  defineDurableFarClass,
-  defineDurableFarClassKit,
-} from '../src/far-class-utils.js';
+  defineDurableExoClass,
+  defineDurableExoClassKit,
+} from '../src/exo-utils.js';
 import { makeKindHandle } from '../src/vat-data-bindings.js';
 
 const UpCounterI = M.interface('UpCounter', {
@@ -22,10 +22,10 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineDurableFarClass', t => {
+test('test defineDurableExoClass', t => {
   const upCounterKind = makeKindHandle('UpCounter');
 
-  const makeUpCounter = defineDurableFarClass(
+  const makeUpCounter = defineDurableExoClass(
     upCounterKind,
     UpCounterI,
     (x = 0) => ({ x }),
@@ -51,10 +51,10 @@ test('test defineDurableFarClass', t => {
   });
 });
 
-test('test defineDurableFarClassKit', t => {
+test('test defineDurableExoClassKit', t => {
   const counterKindHandle = makeKindHandle('Counter');
 
-  const makeCounterKit = defineDurableFarClassKit(
+  const makeCounterKit = defineDurableExoClassKit(
     counterKindHandle,
     { up: UpCounterI, down: DownCounterI },
     (x = 0) => ({ x }),

--- a/packages/vat-data/test/test-virtual-classes.js
+++ b/packages/vat-data/test/test-virtual-classes.js
@@ -3,9 +3,9 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  defineVirtualFarClass,
-  defineVirtualFarClassKit,
-} from '../src/far-class-utils.js';
+  defineVirtualExoClass,
+  defineVirtualExoClassKit,
+} from '../src/exo-utils.js';
 
 const UpCounterI = M.interface('UpCounter', {
   incr: M.call()
@@ -21,8 +21,8 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineVirtualFarClass', t => {
-  const makeUpCounter = defineVirtualFarClass(
+test('test defineVirtualExoClass', t => {
+  const makeUpCounter = defineVirtualExoClass(
     'UpCounter',
     UpCounterI,
     (x = 0) => ({ x }),
@@ -48,8 +48,8 @@ test('test defineVirtualFarClass', t => {
   });
 });
 
-test('test defineVirtualFarClassKit', t => {
-  const makeCounterKit = defineVirtualFarClassKit(
+test('test defineVirtualExoClassKit', t => {
+  const makeCounterKit = defineVirtualExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
     (x = 0) => ({ x }),

--- a/packages/vat-data/test/test-vivify.js
+++ b/packages/vat-data/test/test-vivify.js
@@ -3,10 +3,10 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  vivifyFarClass,
-  vivifyFarClassKit,
-  vivifyFarInstance,
-} from '../src/far-class-utils.js';
+  vivifyExoClass,
+  vivifyExoClassKit,
+  vivifyExo,
+} from '../src/exo-utils.js';
 import { makeScalarBigMapStore } from '../src/vat-data-bindings.js';
 
 const UpCounterI = M.interface('UpCounter', {
@@ -23,10 +23,10 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test vivifyFarClass', t => {
+test('test vivifyExoClass', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
-  const makeUpCounter = vivifyFarClass(
+  const makeUpCounter = vivifyExoClass(
     baggage,
     'UpCounter',
     UpCounterI,
@@ -53,10 +53,10 @@ test('test vivifyFarClass', t => {
   });
 });
 
-test('test vivifyFarClassKit', t => {
+test('test vivifyExoClassKit', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
-  const makeCounterKit = vivifyFarClassKit(
+  const makeCounterKit = vivifyExoClassKit(
     baggage,
     'Counter',
     { up: UpCounterI, down: DownCounterI },
@@ -95,11 +95,11 @@ test('test vivifyFarClassKit', t => {
   });
 });
 
-test('test vivifyFarInstance', t => {
+test('test vivifyExo', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
   let x = 3;
-  const upCounter = vivifyFarInstance(baggage, 'upCounter', UpCounterI, {
+  const upCounter = vivifyExo(baggage, 'upCounter', UpCounterI, {
     incr(y = 1) {
       x += y;
       return x;

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -3,7 +3,7 @@
 import { M, fit } from '@agoric/store';
 import '../../../exported.js';
 
-import { vivifyFarClass, vivifyFarInstance } from '@agoric/vat-data';
+import { vivifyExoClass, vivifyExo } from '@agoric/vat-data';
 import { swapExact } from '../../../src/contractSupport/index.js';
 import {
   InvitationShape,
@@ -36,7 +36,7 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
   // TODO the exerciseOption offer handler that this makes is an object rather
   // than a function for now only because we do not yet support durable
   // functions.
-  const makeExerciser = vivifyFarClass(
+  const makeExerciser = vivifyExoClass(
     instanceBaggage,
     'makeExerciserKindHandle',
     OfferHandlerI,
@@ -86,7 +86,7 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
     makeInvitation: M.call().returns(M.eref(InvitationShape)),
   });
 
-  const creatorFacet = vivifyFarInstance(
+  const creatorFacet = vivifyExo(
     instanceBaggage,
     'creatorFacet',
     CCallCreatorI,


### PR DESCRIPTION
Staged on https://github.com/Agoric/agoric-sdk/pull/6107

Addresses https://github.com/endojs/endo/issues/1193 , but more narrowly

@dtribble and I were brainstorming name alternatives to `FarClass` (which we both hate for somewhat different reasons). There are three salient differences from normal object programming, where `FarClass` only suggests the first and third. 
   * It is a remotable, meaning it is exposed to messages from outside the vat (hence "Far")
   * Related, it is protected by an interfaceGuard that does the first phase type-like phase of input validation
   * It is programmed in a class-like manner, with inline methods in the concise-method syntax, accepting their instance-specific access via their `this` binding (hence "Class")

We also need to name the instance case, and `FarInstance` is way too awkward. The instance case has the first two features but not the third.

New aha: "Exo" does double duty. 
   * As a prefix meaning "outside", it suggests the remotable meaning. That was why I suggested Exo in the first place.
   * It lets us introduce the metaphor of the [ExoSkeleton](https://en.wikipedia.org/wiki/Exoskeleton) without being confused with the exoskeleton itself. "An exo is a creature with an exoskeleton" is a memorable explanation, even if there is no RL noun "Exo".

Also
   * It is short, so for the class case "ExoSkeleton" still works.
   * It is distinct from our current "Far" and so the "Instance" qualifier isn't needed for the protective instance case.

But this last bullet (distinct from "Far") means that it isn't an answer to our first search for a term, since it doesn't cover remotable objects without a protective exoskeleton (currently, "Far objects" and "remote presences"). Oh well. I think the rename is still worth it. 

---

Reviewers, I look forward to your impressions in the review comments.

If this PR meets with your approval soon, we could merge it into https://github.com/Agoric/agoric-sdk/pull/5960 before merging https://github.com/Agoric/agoric-sdk/pull/5960 into master, skipping a phase where we're using the wrong names on master.