### PR TITLE
WIP experiment to distinguish method, kind methods, and objects

### DIFF
--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -463,12 +463,12 @@
  * @property {CreateQuestion} createQuestion
  */
 
-/** @typedef {{ [methodName: string]: (...args: any) => unknown }} GovernedApis */
+/** @typedef {{ [methodName: string]: (...args: any) => unknown }} GovernedMethods */
 
 /**
  * @template {{}} CF
  * @typedef {GovernedCreatorFacet<CF> & {
- * getGovernedApis: () => ERef<GovernedApis>;
+ * getGovernedApis: () => ERef<GovernedMethods>;
  * getGovernedApiNames: () => (string | symbol)[];
  * setOfferFilter: (strings: string[]) => void;
  * }} GovernorFacet

--- a/packages/governance/test/swingsetTests/contractGovernor/governedContract.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/governedContract.js
@@ -37,8 +37,12 @@ const start = async (zcf, privateArgs) => {
   const governanceApi = () => (governanceAPICalled += 1);
   return {
     publicFacet: augmentPublicFacet({
-      getNum: () => params.getMalleableNumber(),
-      getApiCalled: () => governanceAPICalled,
+      getNum() {
+        return params.getMalleableNumber();
+      },
+      getApiCalled() {
+        return governanceAPICalled;
+      },
     }),
     creatorFacet: makeGovernorFacet({}, { governanceApi }),
   };

--- a/packages/inter-protocol/src/collectFees.js
+++ b/packages/inter-protocol/src/collectFees.js
@@ -23,7 +23,7 @@ export const makeMakeCollectFeesInvitation = (
     return `paid out ${amount.value}`;
   };
 
-  const makeCollectFeesInvitation = () =>
+  const makeCollectFeesInvitation = _context =>
     zcf.makeInvitation(collectFees, 'collect fees');
 
   return { makeCollectFeesInvitation };

--- a/packages/inter-protocol/src/stakeFactory/stakeFactory.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactory.js
@@ -211,7 +211,7 @@ export const start = async (
   };
 
   const publicFacet = augmentPublicFacet(
-    Far('stakeFactory public', {
+    harden({
       makeLoanInvitation: () =>
         zcf.makeInvitation(offerHandler, 'make stakeFactory'),
       makeReturnAttInvitation: att.publicFacet.makeReturnAttInvitation,


### PR DESCRIPTION
Staged on https://github.com/Agoric/agoric-sdk/pull/6129 which is supposed to be https://github.com/Agoric/agoric-sdk/pull/6119

THIS PR IS NOT INTENDED TO EVER BE A CANDIDATE FOR MERGING.

An old Far object, the kind made with the `Kind` constructor, can serve double duty: It can serve as an object with methods to be invoked, and it serve as a record of methods to compose with other such records using `...`.

Both kinds and far classes move to an inheritance-based implementation in which this pun no longer works. Instead, https://github.com/Agoric/agoric-sdk/pull/6119 is experimenting with a style where non-instance-specific methods are composed together into the set of methods to give to the kind/farClass definer. In trying to review https://github.com/Agoric/agoric-sdk/pull/6119 I tried to figure out when it was doing which. This is not a question I know how to ask the type system, so in this PR I'm doing a name-based (aka "Hungarian notation") manual type check, just to trace this through for my understanding. Along the way, I see cases where `Far` is used to hold a record of methods that is *only* a record of methods. These should use `harden` rather than `Far`. I'm fixing these as I see them.

I don't intend to follow this through to completion; but rather to adequate understanding to review https://github.com/Agoric/agoric-sdk/pull/6119