### PR TITLE
fix: record-of-methods only for static composition should not be Far

### DIFF
--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -101,7 +101,7 @@ const facetHelpers = (zcf, paramManager) => {
    * @returns {LimitedCreatorFacet<CF>}
    */
   const makeLimitedCreatorFacet = originalCreatorFacet => {
-    return Far('governedContract creator facet', {
+    return harden({
       ...originalCreatorFacet,
       getContractGovernor: () => electionManager,
     });
@@ -164,7 +164,7 @@ const facetHelpers = (zcf, paramManager) => {
     const limitedCreatorFacet = makeLimitedCreatorFacet(originalCreatorFacet);
 
     /** @type {import('@agoric/vat-data/src/types.js').FunctionsPlusContext<unknown, GovernorFacet<originalCreatorFacet>>} */
-    const governorFacet = Far('governorFacet', {
+    const governorFacet = harden({
       getParamMgrRetriever: () =>
         Far('paramRetriever', { get: () => paramManager }),
       getInvitation: (_context, name) =>

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -101,7 +101,7 @@ const facetHelpers = (zcf, paramManager) => {
    * @returns {LimitedCreatorFacet<CF>}
    */
   const makeLimitedCreatorFacet = originalCreatorFacet => {
-    return harden({
+    return Far('governedContract creator facet', {
       ...originalCreatorFacet,
       getContractGovernor: () => electionManager,
     });

--- a/packages/inter-protocol/src/stakeFactory/stakeFactory.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactory.js
@@ -211,7 +211,7 @@ export const start = async (
   };
 
   const publicFacet = augmentPublicFacet(
-    Far('stakeFactory public', {
+    harden({
       makeLoanInvitation: () =>
         zcf.makeInvitation(offerHandler, 'make stakeFactory'),
       makeReturnAttInvitation: att.publicFacet.makeReturnAttInvitation,

--- a/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -466,8 +466,7 @@ const start = async (zcf, privateArgs, baggage) => {
   );
 
   const { governorFacet, limitedCreatorFacet } = makeVirtualGovernorFacet(
-    // @ts-expect-error TS is confused.
-    Far('AMM Fee Collector facet', {
+    harden({
       makeCollectFeesInvitation,
       /**
        * Must be called before adding pools. Not provided at contract start time


### PR DESCRIPTION
Failed exercise #6130 did identify some `Far` declarations around a record of methods that were *only* used to be composed with other methods to form an overall behavior. `Far` is appropriate for defining a behavioral object with methods that are callable on that object.

Staged on #6119 because that PR uses compositions between such collection of methods for "static" behavior composition, i.e., where the composition is shared by all the instances dynamically created from that composition.

Prior to kinds and far classes, `Far` objects supported a pun --- a Far object is both an object with callable methods and a record of methods can be be extracted and composed with other to form other objects. With kinds and Far classes, the methods are no longer instance specific, and are no longer own properties of a meaningful behavioral object anyway. Records of methods used only for such static composition should stabilized with `harden` rather than `Far`.

This PR can be taken as suggestions for #6119, to be merged into #6119 if approved early. Or it can be taken as an independent PR to be merged into master after #6119 is.