### PR TITLE
fix(SwingSet): liveslots and supervisor errors to console.warn

### DIFF
--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -587,9 +587,9 @@ function build(
     // See https://github.com/Agoric/agoric-sdk/issues/2780
     errorIdNum: 70000,
     marshalSaveError: err =>
-      // By sending this to `console.info`, under cosmic-swingset this is
+      // By sending this to `console.warn`, under cosmic-swingset this is
       // controlled by the `console` option given to makeLiveSlots.
-      console.info('Logging sent error stack', err),
+      console.warn('Logging sent error stack', err),
   });
   const unmeteredUnserialize = meterControl.unmetered(m.unserialize);
   // eslint-disable-next-line no-use-before-define
@@ -1353,12 +1353,12 @@ function build(
         if (isNat(value)) {
           vom.setCacheSize(value);
         } else {
-          console.log(`WARNING: invalid virtualObjectCacheSize value`, value);
+          console.warn(`WARNING: invalid virtualObjectCacheSize value`, value);
         }
         break;
       }
       default:
-        console.log(`WARNING setVatOption unknown option ${option}`);
+        console.warn(`WARNING setVatOption unknown option ${option}`);
     }
   }
 
@@ -1555,8 +1555,7 @@ function build(
         vreffedObjectRegistry,
       });
     } catch (e) {
-      console.log(`-- error during stopVat()`);
-      console.log(e);
+      console.warn(`-- error during stopVat()`, e);
       throw e;
     }
   }

--- a/packages/SwingSet/src/supervisors/supervisor-helper.js
+++ b/packages/SwingSet/src/supervisors/supervisor-helper.js
@@ -36,7 +36,7 @@ function makeSupervisorDispatch(dispatch) {
         () => harden(['ok', null, null]),
         err => {
           // TODO react more thoughtfully, maybe terminate the vat
-          console.log(`error during vat dispatch() of ${delivery}`, err);
+          console.warn(`error during vat dispatch() of ${delivery}`, err);
           return harden(['error', `${err}`, null]);
         },
       );
@@ -70,7 +70,7 @@ function makeSupervisorSyscall(syscallToManager, workerCanBlock) {
     try {
       r = syscallToManager(vso);
     } catch (err) {
-      console.log(`worker got error during syscall:`, err);
+      console.warn(`worker got error during syscall:`, err);
       throw err;
     }
     if (!workerCanBlock) {


### PR DESCRIPTION
## Description

A recent durable error in CI was hard to diagnose because liveslots errors which are the only one containing the local vat's stack trace were being printed to `stdout` and the [test in question](https://github.com/Agoric/agoric-sdk/blob/246a0ce1ffd862ef610ceeaf6343a0de2613e204/packages/cosmic-swingset/test/test-make.js#L30) discards stdout.

This PR changes the liveslots and supervisor treatment of such console logging to use the `warn` level instead, which ends up in `stderr`.

Drive by update of a couple similar cases.

### Security Considerations

None

### Documentation Considerations

None

### Testing Considerations

Visually confirmed locally that `yarn test` with this changes output all the necessary stacks while keeping the overall output quiet-ish.
