### PR TITLE
fix(scripts): Remove a typo

### DIFF
--- a/scripts/get-flattened-publication.sh
+++ b/scripts/get-flattened-publication.sh
@@ -41,7 +41,7 @@ jq --version | awk '
 resp="$(
   # Avoid the GET interface in case interpretation of `path` as JSON is ever fixed.
   # https://github.com/tendermint/tendermint/issues/9164
-  # curl -sS "${URL_PREFIX%/}/abci_query?path=%22/custom/vstorage/data/$STORAGE_KEY%22" | \
+  # curl -sS "${URL_PREFIX%/}/abci_query?path=%22/custom/vstorage/data/$STORAGE_KEY%22"
   curl -sS "$URL_PREFIX" --request POST --header 'Content-Type: application/json' --data "$(
     jq -n --arg key "$STORAGE_KEY" --arg height "$QUERY_HEIGHT" '{
       jsonrpc: "2.0",


### PR DESCRIPTION
## Description

`\` can apparently extend a comment onto the next line in some versions of bash.

### Security Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

Testing against multiple versions of bash does not seem like a good use of time.