### PR TITLE
fix(vats): avoid importing sim-behaviors into boot-psm.js

### DIFF
--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { Stable } from '@agoric/vats/src/tokens.js';
 import * as econBehaviors from './econ-behaviors.js';
+import { ECON_COMMITTEE_MANIFEST } from './startEconCommittee';
 import * as simBehaviors from './sim-behaviors.js';
 
 export * from './econ-behaviors.js';
@@ -8,23 +9,6 @@ export * from './sim-behaviors.js';
 // @ts-expect-error Module './econ-behaviors.js' has already exported a member
 // named 'EconomyBootstrapPowers'.
 export * from './startPSM.js';
-
-export const ECON_COMMITTEE_MANIFEST = harden({
-  [econBehaviors.startEconomicCommittee.name]: {
-    consume: {
-      board: true,
-      chainStorage: true,
-      zoe: true,
-    },
-    produce: { economicCommitteeCreatorFacet: 'economicCommittee' },
-    installation: {
-      consume: { committee: 'zoe' },
-    },
-    instance: {
-      produce: { economicCommittee: 'economicCommittee' },
-    },
-  },
-});
 
 const SHARED_MAIN_MANIFEST = harden({
   [econBehaviors.setupAmm.name]: {

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { Stable } from '@agoric/vats/src/tokens.js';
 import * as econBehaviors from './econ-behaviors.js';
-import { ECON_COMMITTEE_MANIFEST } from './startEconCommittee';
+import { ECON_COMMITTEE_MANIFEST } from './startEconCommittee.js';
 import * as simBehaviors from './sim-behaviors.js';
 
 export * from './econ-behaviors.js';

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -6,10 +6,7 @@ import { AmountMath } from '@agoric/ertp';
 import '@agoric/governance/exported.js';
 import '@agoric/vats/exported.js';
 import '@agoric/vats/src/core/types.js';
-import {
-  assertPathSegment,
-  makeStorageNodeChild,
-} from '@agoric/vats/src/lib-chainStorage.js';
+import { makeStorageNodeChild } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E, Far } from '@endo/far';
 import { Stable, Stake } from '@agoric/vats/src/tokens.js';
@@ -32,13 +29,6 @@ const SECONDS_PER_DAY = 24n * SECONDS_PER_HOUR;
 
 const BASIS_POINTS = 10_000n;
 const MILLI = 1_000_000n;
-
-/** @type {(name: string) => string} */
-const sanitizePathSegment = name => {
-  const candidate = name.replace(/[ ,]/g, '_');
-  assertPathSegment(candidate);
-  return candidate;
-};
 
 /**
  * @typedef {GovernedCreatorFacet<import('../stakeFactory/stakeFactory.js').StakeFactoryCreator>} StakeFactoryCreator
@@ -80,63 +70,6 @@ const sanitizePathSegment = name => {
  *
  * In production called by @agoric/vats to bootstrap.
  */
-
-/**
- * @typedef {object} EconCommitteeOptions
- * @property {string} [committeeName]
- * @property {number} [committeeSize]
- */
-
-/**
- * @param {EconomyBootstrapPowers} powers
- * @param {object} [config]
- * @param {object} [config.options]
- * @param {EconCommitteeOptions} [config.options.econCommitteeOptions]
- */
-export const startEconomicCommittee = async (
-  {
-    consume: { board, chainStorage, zoe },
-    produce: { economicCommitteeCreatorFacet },
-    installation: {
-      consume: { committee },
-    },
-    instance: {
-      produce: { economicCommittee },
-    },
-  },
-  { options: { econCommitteeOptions = {} } = {} },
-) => {
-  const COMMITTEES_ROOT = 'committees';
-  trace('startEconomicCommittee');
-  const {
-    committeeName = 'Initial Economic Committee',
-    committeeSize = 3,
-    ...rest
-  } = econCommitteeOptions;
-
-  const committeesNode = await makeStorageNodeChild(
-    chainStorage,
-    COMMITTEES_ROOT,
-  );
-  const storageNode = await E(committeesNode).makeChildNode(
-    sanitizePathSegment(committeeName),
-  );
-  const marshaller = await E(board).getReadonlyMarshaller();
-
-  const { creatorFacet, instance } = await E(zoe).startInstance(
-    committee,
-    {},
-    { committeeName, committeeSize, ...rest },
-    {
-      storageNode,
-      marshaller,
-    },
-  );
-
-  economicCommitteeCreatorFacet.resolve(creatorFacet);
-  economicCommittee.resolve(instance);
-};
-harden(startEconomicCommittee);
 
 /**
  * @param {EconomyBootstrapPowers} powers

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -7,8 +7,10 @@ import {
   PSM_MANIFEST,
 } from '@agoric/inter-protocol/src/proposals/startPSM.js';
 // TODO: factor startEconomicCommittee out of econ-behaviors.js
-import { startEconomicCommittee } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
-import { ECON_COMMITTEE_MANIFEST } from '@agoric/inter-protocol/src/proposals/core-proposal.js';
+import {
+  ECON_COMMITTEE_MANIFEST,
+  startEconomicCommittee,
+} from '@agoric/inter-protocol/src/proposals/startEconCommittee.js';
 import { makeAgoricNamesAccess, makePromiseSpace } from './utils.js';
 import { Stable, Stake } from '../tokens.js';
 import {


### PR DESCRIPTION
refs: #6009 

## Description

`boot-psm.js` was importing `core-proposal.js` just to get `ECON_COMMITTEE_MANIFEST`. Unfortunately, that dragged in `sim-behaviors.js` including a couple things that are permitted to have `feeMintAccess`.

Following the precedent of `startPSM.js`, this factors out `startEconCommittee.js`.

### Security Considerations

Clarifies that `fundAMM` and `connectFaucet`, which get `feeMintAccess` in demo/sim mode, are not in the production PSM configuration.

### Testing Considerations

I did some integration testing while working on #6067 . We'll see what the CI bots say...

cc @dtribble 