### PR TITLE
feat: make PSM bootstrap support multiple brands

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -71,7 +71,7 @@
     "files": [
       "test/**/test-*.js"
     ],
-    "timeout": "2m"
+    "timeout": "5m"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -47,6 +47,15 @@ const sanitizePathSegment = name => {
  */
 
 /**
+ * @typedef {object} PSMFacets
+ * @property {Instance} psm
+ * @property {Instance} psmGovernor
+ * @property {Awaited<ReturnType<import('../psm/psm.js').start>>['creatorFacet']} psmCreatorFacet
+ * @property {GovernedContractFacetAccess<{},{}>} psmGovernorCreatorFacet
+ * @property {AdminFacet} psmAdminFacet
+ */
+
+/**
  * @typedef { WellKnownSpaces & ChainBootstrapSpace & EconomyBootstrapSpace
  * } EconomyBootstrapPowers
  * @typedef {PromiseSpaceOf<{
@@ -58,9 +67,7 @@ const sanitizePathSegment = name => {
  *   feeDistributorPublicFacet: import('../feeDistributor.js').FeeDistributorPublicFacet,
  *   periodicFeeCollectors: import('../feeDistributor.js').PeriodicFeeCollector[],
  *   bankMints: Mint[],
- *   psmCreatorFacet: Awaited<ReturnType<import('../psm/psm.js').start>>['creatorFacet'],
- *   psmGovernorCreatorFacet: GovernedContractFacetAccess<{},{}>,
- *   psmAdminFacet: AdminFacet,
+ *   psmFacets: MapStore<Brand, PSMFacets>,
  *   reservePublicFacet: import('../reserve/assetReserve.js').AssetReservePublicFacet,
  *   reserveCreatorFacet: import('../reserve/assetReserve.js').AssetReserveLimitedCreatorFacet,
  *   reserveGovernorCreatorFacet: GovernedAssetReserveFacetAccess,

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -8,6 +8,8 @@ import { E } from '@endo/far';
 import { Stable } from '@agoric/vats/src/tokens.js';
 import { deeplyFulfilledObject } from '@agoric/internal';
 import { assert } from '@agoric/assert';
+import { makeScalarMapStore } from '@agoric/vat-data';
+
 import { reserveThenGetNamePaths } from './utils.js';
 
 const BASIS_POINTS = 10000n;
@@ -33,14 +35,13 @@ export const startPSM = async (
       economicCommitteeCreatorFacet,
       chainStorage,
       chainTimerService,
+      psmFacets,
     },
-    produce: { psmCreatorFacet, psmGovernorCreatorFacet, psmAdminFacet },
     installation: {
       consume: { contractGovernor, psm: psmInstall },
     },
     instance: {
       consume: { economicCommittee },
-      produce: { psm: psmInstanceR, psmGovernor: psmGovernorR },
     },
     brand: {
       consume: { [Stable.symbol]: stableP },
@@ -138,11 +139,20 @@ export const startPSM = async (
     }),
   );
 
-  psmInstanceR.resolve(await E(governorFacets.creatorFacet).getInstance());
-  psmGovernorR.resolve(governorFacets.instance);
-  psmCreatorFacet.resolve(E(governorFacets.creatorFacet).getCreatorFacet());
-  psmAdminFacet.resolve(E(governorFacets.creatorFacet).getAdminFacet());
-  psmGovernorCreatorFacet.resolve(governorFacets.creatorFacet);
+  /** @typedef {import('./econ-behaviors.js').PSMFacets} PSMFacets */
+  /** @type {PSMFacets} */
+  const newPsmFacets = {
+    psm: E(governorFacets.creatorFacet).getInstance(),
+    psmGovernor: governorFacets.instance,
+    psmCreatorFacet: E(governorFacets.creatorFacet).getCreatorFacet(),
+    psmAdminFacet: E(governorFacets.creatorFacet).getAdminFacet(),
+    psmGovernorCreatorFacet: governorFacets.creatorFacet,
+  };
+
+  /** @type {MapStore<Brand,PSMFacets>} */
+  const psmFacetsMap = await psmFacets;
+
+  psmFacetsMap.init(anchorBrand, newPsmFacets);
 };
 harden(startPSM);
 
@@ -217,15 +227,21 @@ export const makeAnchorAsset = async (
 };
 harden(makeAnchorAsset);
 
-/** @param {BootstrapSpace & { devices: { vatAdmin: any }, vatPowers: { D: DProxy }, }} powers */
+/** @typedef {import('./econ-behaviors.js').EconomyBootstrapSpace} EconomyBootstrapSpace */
+
+/** @param {BootstrapSpace & EconomyBootstrapSpace & { devices: { vatAdmin: any }, vatPowers: { D: DProxy }, }} powers */
+// /** @param {BootstrapSpace & { devices: { vatAdmin: any }, vatPowers: { D: DProxy }, }} powers */
 export const installGovAndPSMContracts = async ({
   vatPowers: { D },
   devices: { vatAdmin },
   consume: { zoe },
+  produce: { psmFacets },
   installation: {
     produce: { contractGovernor, committee, binaryVoteCounter, psm },
   },
 }) => {
+  psmFacets.resolve(makeScalarMapStore());
+
   return Promise.all(
     Object.entries({
       contractGovernor,
@@ -263,18 +279,13 @@ export const PSM_MANIFEST = harden({
       feeMintAccess: 'zoe',
       economicCommitteeCreatorFacet: 'economicCommittee',
       chainTimerService: 'timer',
-    },
-    produce: {
-      psmCreatorFacet: 'psm',
-      psmAdminFacet: 'psm',
-      psmGovernorCreatorFacet: 'psmGovernor',
+      psmFacets: 'psm',
     },
     installation: {
       consume: { contractGovernor: 'zoe', psm: 'zoe' },
     },
     instance: {
       consume: { economicCommittee: 'economicCommittee' },
-      produce: { psm: 'psm', psmGovernor: 'psm' },
     },
     brand: {
       consume: { AUSD: 'bank', IST: 'zoe' },

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -139,13 +139,19 @@ export const startPSM = async (
     }),
   );
 
+  const [psm, psmCreatorFacet, psmAdminFacet] = await Promise.all([
+    E(governorFacets.creatorFacet).getInstance(),
+    E(governorFacets.creatorFacet).getCreatorFacet(),
+    E(governorFacets.creatorFacet).getAdminFacet(),
+  ]);
+
   /** @typedef {import('./econ-behaviors.js').PSMFacets} PSMFacets */
   /** @type {PSMFacets} */
   const newPsmFacets = {
-    psm: E(governorFacets.creatorFacet).getInstance(),
+    psm,
     psmGovernor: governorFacets.instance,
-    psmCreatorFacet: E(governorFacets.creatorFacet).getCreatorFacet(),
-    psmAdminFacet: E(governorFacets.creatorFacet).getAdminFacet(),
+    psmCreatorFacet,
+    psmAdminFacet,
     psmGovernorCreatorFacet: governorFacets.creatorFacet,
   };
 
@@ -233,7 +239,6 @@ harden(makeAnchorAsset);
 /** @typedef {import('./econ-behaviors.js').EconomyBootstrapSpace} EconomyBootstrapSpace */
 
 /** @param {BootstrapSpace & EconomyBootstrapSpace & { devices: { vatAdmin: any }, vatPowers: { D: DProxy }, }} powers */
-// /** @param {BootstrapSpace & { devices: { vatAdmin: any }, vatPowers: { D: DProxy }, }} powers */
 export const installGovAndPSMContracts = async ({
   vatPowers: { D },
   devices: { vatAdmin },
@@ -243,6 +248,10 @@ export const installGovAndPSMContracts = async ({
     produce: { contractGovernor, committee, binaryVoteCounter, psm },
   },
 }) => {
+  // In order to support multiple instances of the PSM, we store all the facets
+  // indexed by the brand. Since each name in the BootstrapSpace can only be
+  // produced  once, we produce an empty store here, and each time a PSM is
+  // started up, the details are added to the store.
   psmFacets.resolve(makeScalarMapStore());
 
   return Promise.all(

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -153,6 +153,9 @@ export const startPSM = async (
   const psmFacetsMap = await psmFacets;
 
   psmFacetsMap.init(anchorBrand, newPsmFacets);
+  const instanceKey = `psm.${Stable.symbol}.${keyword}`;
+  const instanceAdmin = E(agoricNamesAdmin).lookupAdmin('instance');
+  await E(instanceAdmin).update(instanceKey, newPsmFacets.psm);
 };
 harden(startPSM);
 

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -9,6 +9,7 @@ import {
 } from '@agoric/vats/src/core/utils.js';
 import { makeBoard } from '@agoric/vats/src/lib-board.js';
 import { Stable } from '@agoric/vats/src/tokens.js';
+import { makeScalarMapStore } from '@agoric/vat-data';
 import { makeZoeKit } from '@agoric/zoe';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
@@ -109,6 +110,7 @@ export const setupPsm = async (
   brand.produce.AUSD.resolve(knutIssuer.brand);
   issuer.produce.AUSD.resolve(knutIssuer.issuer);
 
+  space.produce.psmFacets.resolve(makeScalarMapStore());
   const istIssuer = await E(zoe).getFeeIssuer();
   const istBrand = await E(istIssuer).getBrand();
 
@@ -138,8 +140,10 @@ export const setupPsm = async (
     counter: installation.consume.binaryVoteCounter,
   });
 
-  const governorCreatorFacet = consume.psmGovernorCreatorFacet;
-  const governorInstance = await instance.consume.psmGovernor;
+  const allPsms = await consume.psmFacets;
+  const psmFacets = allPsms.get(knutIssuer.brand);
+  const governorCreatorFacet = psmFacets.psmGovernorCreatorFacet;
+  const governorInstance = psmFacets.psmGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
   const g = {
     governorInstance,
@@ -151,7 +155,7 @@ export const setupPsm = async (
   /** @type { GovernedPublicFacet<PSM> } */
   const psmPublicFacet = await E(governorCreatorFacet).getPublicFacet();
   const psm = {
-    psmCreatorFacet: await consume.psmCreatorFacet,
+    psmCreatorFacet: psmFacets.psmCreatorFacet,
     psmPublicFacet,
     instance: governedInstance,
   };

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -46,6 +46,7 @@ const PSM_GOV_INSTALL_MANIFEST = {
     vatPowers: { D: true },
     devices: { vatAdmin: true },
     consume: { zoe: 'zoe' },
+    produce: { psmFacets: 'psm' },
     installation: {
       produce: {
         contractGovernor: 'zoe',

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -84,8 +84,7 @@ export const agoricNamesReserved = harden(
     },
     instance: {
       economicCommittee: 'Economic Committee',
-      psm: 'Parity Stability Module',
-      psmGovernor: 'PSM Governor',
+      'psm.IST.AUSD': 'Parity Stability Module: IST:AUSD',
     },
   }),
 );

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -195,7 +195,7 @@ test(`PSM-only bootstrap`, async t => {
   const agoricNames = /** @type {Promise<NameHub>} */ (
     E(root).consumeItem('agoricNames')
   );
-  const instance = await E(agoricNames).lookup('instance', 'psm');
+  const instance = await E(agoricNames).lookup('instance', 'psm.IST.AUSD');
   t.is(passStyleOf(instance), 'remotable');
 });
 


### PR DESCRIPTION
refs: #6142
refs: #6139

## Description

Make PSM bootstrap support multiple brands

This helps with #6142, but might be merged into that or #6139.

### Security Considerations

The PSM facets are available throughout PSM. That seems acceptable.

### Documentation Considerations

None

### Testing Considerations

Existing tests continue to pass. Since some are using PSM bootstrap, we can tell that it successfully stored one PSM and retrieved it. I presume two wouldn't be harder, but haven't written tests.