### PR TITLE
feat(agoric-cli): Add agoric publish subcommand

### DIFF
--- a/packages/agoric-cli/src/json.js
+++ b/packages/agoric-cli/src/json.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+/**
+ * Parses JSON and, if necessary, throws exceptions that include the location
+ * of the offending file.
+ *
+ * @param {string} source
+ * @param {string} location
+ */
+export const parseLocatedJson = (source, location) => {
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new SyntaxError(`Cannot parse JSON from ${location}, ${error}`);
+    }
+    throw error;
+  }
+};

--- a/packages/agoric-cli/src/main-publish.js
+++ b/packages/agoric-cli/src/main-publish.js
@@ -1,0 +1,64 @@
+/* global process */
+// @ts-check
+
+import path from 'path';
+
+import { SigningStargateClient } from '@cosmjs/stargate';
+
+import { parseLocatedJson } from './json.js';
+
+import { makeBundlePublisher, makeCosmosBundlePublisher } from './publish.js';
+
+const publishMain = async (progname, rawArgs, powers, opts) => {
+  const { fs } = powers;
+
+  const { node: rpcAddress, home: homeDirectory, chainID = 'agoric' } = opts;
+
+  if (typeof rpcAddress !== 'string') {
+    throw new Error(
+      `Required flag for agoric publish: -n, --node <rpcAddress>`,
+    );
+  }
+  if (typeof homeDirectory !== 'string') {
+    throw new Error(
+      `Required flag for agoric publish: -h, --home <directory>, containing ag-solo-mnemonic`,
+    );
+  }
+
+  /** @type {import('./publish.js').CosmosConnectionSpec} */
+  const connectionSpec = {
+    type: 'chain-cosmos-sdk',
+    rpcAddresses: [rpcAddress],
+    homeDirectory,
+    chainID,
+  };
+
+  for (const bundlePath of rawArgs.slice(1)) {
+    // AWAIT
+    // eslint-disable-next-line no-await-in-loop,@jessie.js/no-nested-await
+    const bundleText = await fs.readFile(bundlePath, 'utf-8');
+    const bundle = parseLocatedJson(bundleText, bundlePath);
+
+    const publishBundleCosmos = makeCosmosBundlePublisher({
+      connectWithSigner: SigningStargateClient.connectWithSigner,
+      pathResolve: path.resolve,
+      readFile: fs.readFile,
+      random: Math.random,
+    });
+    const publishBundle = makeBundlePublisher({
+      getDefaultConnection() {
+        throw new Error(
+          'Invariant: publishBundle will never call getDefaultConnection because we provide an explicit connectionSpec',
+        );
+      },
+      publishBundleCosmos,
+    });
+
+    // AWAIT
+    // eslint-disable-next-line no-await-in-loop,@jessie.js/no-nested-await
+    const hashedBundle = await publishBundle(bundle, connectionSpec);
+    process.stdout.write(`${JSON.stringify(hashedBundle)}\n`);
+  }
+};
+
+export default publishMain;

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -9,6 +9,7 @@ import {
 } from '@agoric/casting';
 import cosmosMain from './cosmos.js';
 import deployMain from './deploy.js';
+import publishMain from './main-publish.js';
 import initMain from './init.js';
 import installMain from './install.js';
 import setDefaultsMain from './set-defaults.js';
@@ -289,6 +290,27 @@ const main = async (progname, rawArgs, powers) => {
   ).action(async (scripts, cmd) => {
     const opts = { ...program.opts(), ...cmd.opts() };
     return subMain(deployMain, ['deploy', ...scripts], opts);
+  });
+
+  addRunOptions(
+    program
+      .command('publish [bundle...]')
+      .option(
+        '-n, --node <rpcAddress>',
+        '[required] A bare IPv4 address or fully qualified URL of an RPC node',
+      )
+      .option(
+        '-h, --home <directory>',
+        "[required] Path to the directory containing ag-solo-mnemonic, for the publisher's wallet mnemonic",
+      )
+      .option(
+        '-c, --chain-id <chainID>',
+        'The ID of the destination chain, if not simply "agoric"',
+      )
+      .description('publish a bundle to a Cosmos chain'),
+  ).action(async (bundles, cmd) => {
+    const opts = { ...program.opts(), ...cmd.opts() };
+    return subMain(publishMain, ['publish', ...bundles], opts);
   });
 
   program.addCommand(await makeWalletCommand());


### PR DESCRIPTION

closes: #6087

## Description

This is an `agoric publish` command that can post directly to the chain and return a hash bundle JSON blob, suitable for passing to `zoe~.install`.

### Security Considerations

### Documentation Considerations

This will be useful for documenting governance https://github.com/Agoric/agoric-sdk/issues/6086

### Testing Considerations

Works on my machine. To make work on your machine:

In cosmic-swingset:

```
make scenario2-run-chain
```

In another cosmic-swingset, use an ag-solo to provision an account. You may then turn off the ag-solo: it is not needed, and later commands must not depend on it.

```
make scenario2-run-client
```

In `dapp-fungible-faucet`, prepare a bundle.json:

```
yarn bundle-source --to bundles contract/src/contract.js contract
```

By whatever string-carving you prefer, convert the generated `bundles/bundle-contract.js` to `bundles/bundle-contract.json`. A small Node script that imports the JS and writes out JSON will suffice, or just removing the `export default ` prefix and `;` suffix in an editor will work too.

Continue:

```
agoric publish bundles/bundle-contract.json --node localhost:26657 --home ~/agoric-sdk/packages/cosmic-swingset/t1/8000/ 2>/dev/null
```

You can verify the publish with agoric follow: (the flags just provide block height published, block height observed, and ensure one line per publish).

```
agoric follow :bundles -bco jsonlines
```

You can also confirm with agd:

```
watch agd query vstorage data bundles
```