### PR TITLE
fix(xsnap): Fix timestamps

### DIFF
--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -179,7 +179,7 @@ export function xsnap(options) {
         const meterSeparator = message.indexOf(OK_SEPARATOR, 1);
         if (meterSeparator >= 0) {
           // The message is `.meterdata\1reply`.
-          const meterData = message.slice(1, meterSeparator);
+          const meterData = message.subarray(1, meterSeparator);
           // We parse the meter data as JSON
           meterInfo = JSON.parse(decoder.decode(meterData));
           // assert(typeof meterInfo === 'object');


### PR DESCRIPTION
Use xsnap-pub https://github.com/agoric-labs/xsnap-pub/pull/31 with fixed and more syscall timestamps, as well as less copies of buffers.

Remove a copy on the `xsnap.js` side too.

Update description of where time is spent.
