### PR TITLE
fix(smart-wallet): invitation issuer is remote

### DIFF
--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -78,7 +78,7 @@ export const start = async (zcf, privateArgs) => {
 
   // Each wallet has `zoe` it can use to look them up, but pass these in to save that work.
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const invitationBrand = await invitationIssuer.getBrand();
+  const invitationBrand = await E(invitationIssuer).getBrand();
 
   const shared = {
     agoricNames,


### PR DESCRIPTION
refs: #6084

## Description

Dan and I were trying to make progress on voting based on top of #6084, and ran into two issues, but the PR merged before we could suggestion this correction.

missing E() around an invitationIssuer

(I originally included updating decentral-psm-config to use smartwallet, but that's maybe not for master).

### Security Considerations

None

### Documentation Considerations

None

### Testing Considerations

None