### PR TITLE
provide starter IST to newly provisoned accounts

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -174,6 +174,7 @@ var (
 		ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
 		vbank.ModuleName:               {authtypes.Minter, authtypes.Burner},
 		vbanktypes.ReservePoolName:     nil,
+		vbanktypes.ProvisionPoolName:   nil,
 		vbanktypes.GiveawayPoolName:    nil,
 	}
 )
@@ -348,7 +349,7 @@ func NewAgoricApp(
 		keys[banktypes.StoreKey],
 		app.AccountKeeper,
 		app.GetSubspace(banktypes.ModuleName),
-		app.ModuleAccountAddrs(),
+		app.BlockedAddrs(),
 	)
 	app.AuthzKeeper = authzkeeper.NewKeeper(
 		keys[authzkeeper.StoreKey],
@@ -829,6 +830,21 @@ func (app *GaiaApp) LoadHeight(height int64) error {
 func (app *GaiaApp) ModuleAccountAddrs() map[string]bool {
 	modAccAddrs := make(map[string]bool)
 	for acc := range maccPerms {
+		modAccAddrs[authtypes.NewModuleAddress(acc).String()] = true
+	}
+
+	return modAccAddrs
+}
+
+// BlockedAddrs returns the app's module account addresses that
+// are blocked from receiving funds.
+func (app *GaiaApp) BlockedAddrs() map[string]bool {
+	modAccAddrs := make(map[string]bool)
+	for acc := range maccPerms {
+		// The provision pool is not blocked from receiving funds.
+		if acc == vbanktypes.ProvisionPoolName {
+			continue
+		}
 		modAccAddrs[authtypes.NewModuleAddress(acc).String()] = true
 	}
 

--- a/golang/cosmos/x/vbank/types/key.go
+++ b/golang/cosmos/x/vbank/types/key.go
@@ -9,4 +9,5 @@ const (
 
 	ReservePoolName  = "vbank/reserve"
 	GiveawayPoolName = "vbank/giveaway"
+	ProvisionPoolName  = "vbank/provision"
 )

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -221,7 +221,7 @@ fund-acct: wait-for-cosmos
 provision-acct: wait-for-cosmos
 	$(AGCH) --chain-id=$(CHAIN_ID) \
 	  --home=t1/bootstrap --keyring-backend=test --from=bootstrap \
-	  tx swingset provision-one t1/$(BASE_PORT) $(ACCT_ADDR) $(AGORIC_POWERS) \
+	  tx swingset provision-one t1/$(BASE_PORT) $(ACCT_ADDR) SMART_WALLET \
 	  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes
 
 FROM_KEY=bootstrap

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -125,7 +125,6 @@ export const startInterchainPool = async (
     { Central: centralIssuer },
     terms,
     {
-      // @ts-expect-error XXX remotable types
       bankManager,
     },
   );

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -173,6 +173,7 @@ export const startPSM = async (
       anchorBrand,
       stable,
     ),
+    // @ts-expect-error TODO type for provisionPoolStartResult
     E(E.get(provisionPoolStartResult).creatorFacet).initPSM(
       anchorBrand,
       newPsmFacets.psm,

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -35,6 +35,7 @@ export const startPSM = async (
       feeMintAccess: feeMintAccessP,
       economicCommitteeCreatorFacet,
       psmCharterCreatorFacet,
+      provisionPoolStartResult,
       chainStorage,
       chainTimerService,
       psmFacets,
@@ -163,13 +164,20 @@ export const startPSM = async (
   psmFacetsMap.init(anchorBrand, newPsmFacets);
   const instanceKey = `psm-${Stable.symbol}-${keyword}`;
   const instanceAdmin = E(agoricNamesAdmin).lookupAdmin('instance');
-  await E(instanceAdmin).update(instanceKey, newPsmFacets.psm);
-  await E(psmCharterCreatorFacet).addInstance(
-    psm,
-    psmCreatorFacet,
-    anchorBrand,
-    stable,
-  );
+
+  await Promise.all([
+    E(instanceAdmin).update(instanceKey, newPsmFacets.psm),
+    E(psmCharterCreatorFacet).addInstance(
+      psm,
+      psmCreatorFacet,
+      anchorBrand,
+      stable,
+    ),
+    E(E.get(provisionPoolStartResult).creatorFacet).initPSM(
+      anchorBrand,
+      newPsmFacets.psm,
+    ),
+  ]);
 };
 harden(startPSM);
 
@@ -422,6 +430,7 @@ export const PSM_MANIFEST = harden({
       zoe: 'zoe',
       feeMintAccess: 'zoe',
       economicCommitteeCreatorFacet: 'economicCommittee',
+      provisionPoolStartResult: true,
       psmCharterCreatorFacet: 'psmCharter',
       chainTimerService: 'timer',
       psmFacets: true,

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { makeLoopback } from '@endo/captp';
+import { Far, makeLoopback } from '@endo/captp';
 import { E } from '@endo/eventual-send';
 
 import {
@@ -119,6 +119,14 @@ export const setupPsm = async (
 
   brand.produce.IST.resolve(istBrand);
   issuer.produce.IST.resolve(istIssuer);
+
+  space.produce.provisionPoolStartResult.resolve({
+    creatorFacet: Far('dummy', {
+      initPSM: () => {
+        t.log('dummy provisionPool.initPSM');
+      },
+    }),
+  });
 
   await Promise.all([
     startEconomicCommittee(space, {

--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -149,7 +149,7 @@ const makeScenario = async (t, { env = process.env } = {}) => {
     space.produce.bridgeManager.resolve(undefined);
     space.produce.lienBridge.resolve(undefined);
 
-    /** @type {Awaited<BankManager>} */
+    /** @type {BankManager} */
     const bankManager = Far('mock BankManager', {
       getAssetSubscription: () => assert.fail('not impl'),
       getModuleAccountAddress: () => assert.fail('not impl'),

--- a/packages/inter-protocol/test/test-interchainPool.js
+++ b/packages/inter-protocol/test/test-interchainPool.js
@@ -63,7 +63,7 @@ test('make interchain pool', async t => {
     /** @type {PromiseKit<{ mint: ERef<Mint>, issuer: ERef<Issuer>, brand: Brand}>} */
     const ibcKitP = makePromiseKit();
 
-    /** @type {Awaited<BankManager>} */
+    /** @type {BankManager} */
     const bankManager = Far('mock BankManager', {
       getAssetSubscription: () => assert.fail('not impl'),
       getModuleAccountAddress: () => assert.fail('not impl'),

--- a/packages/smart-wallet/test/devices.js
+++ b/packages/smart-wallet/test/devices.js
@@ -1,6 +1,7 @@
 import bundleCentralSupply from '@agoric/vats/bundles/bundle-centralSupply.js';
 import bundleMintHolder from '@agoric/vats/bundles/bundle-mintHolder.js';
 import bundleWalletFactory from '@agoric/vats/bundles/bundle-legacy-walletFactory.js';
+import bundleProvisionPool from '@agoric/vats/bundles/bundle-provisionPool.js';
 
 export const devices = {
   vatAdmin: {
@@ -14,6 +15,8 @@ export const devices = {
           // TODO(PS0) replace this bundle with the non-legacy smart-wallet
           case 'walletFactory':
             return bundleWalletFactory;
+          case 'provisionPool':
+            return bundleProvisionPool;
           default:
             throw new Error(`unknown bundle ${name}`);
         }

--- a/packages/vats/decentral-core-config.json
+++ b/packages/vats/decentral-core-config.json
@@ -40,6 +40,9 @@
     "priceAuthority": {
       "sourceSpec": "@agoric/vats/src/vat-priceAuthority.js"
     },
+    "provisionPool": {
+      "sourceSpec": "@agoric/vats/src/provisionPool.js"
+    },
     "provisioning": {
       "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
     },

--- a/packages/vats/decentral-demo-config.json
+++ b/packages/vats/decentral-demo-config.json
@@ -50,6 +50,9 @@
     "provisioning": {
       "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
     },
+    "provisionPool": {
+      "sourceSpec": "@agoric/vats/src/provisionPool.js"
+    },
     "sharing": {
       "sourceSpec": "@agoric/vats/src/vat-sharing.js"
     },

--- a/packages/vats/decentral-psm-config.json
+++ b/packages/vats/decentral-psm-config.json
@@ -21,6 +21,9 @@
     "walletFactory": {
       "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
     },
+    "provisionPool": {
+      "sourceSpec": "@agoric/vats/src/provisionPool.js"
+    },
     "committee": {
       "sourceSpec": "@agoric/governance/src/committee.js"
     },

--- a/packages/vats/scripts/build-bundles.js
+++ b/packages/vats/scripts/build-bundles.js
@@ -8,6 +8,7 @@ const dirname = url.fileURLToPath(new URL('.', import.meta.url));
 const sourceToBundle = [
   [`../src/centralSupply.js`, `../bundles/bundle-centralSupply.js`],
   [`../src/mintHolder.js`, `../bundles/bundle-mintHolder.js`],
+  [`../src/provisionPool.js`, `../bundles/bundle-provisionPool.js`],
   [
     `@agoric/wallet/contract/src/singleWallet.js`,
     `../bundles/bundle-singleWallet.js`,

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -230,7 +230,7 @@ export const makeAddressNameHubs = async ({
   produce.namesByAddressAdmin.resolve(namesByAddressAdmin);
 
   const perAddress = address => {
-    const myAddressNameAdmin = makeMyAddressNameAdmin(address);
+    const { myAddressNameAdmin } = makeMyAddressNameAdmin(address);
     return { agoricNames, namesByAddress, myAddressNameAdmin };
   };
 

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -308,13 +308,14 @@ export const installBootContracts = async ({
   devices: { vatAdmin },
   consume: { zoe },
   installation: {
-    produce: { centralSupply, mintHolder, walletFactory },
+    produce: { centralSupply, mintHolder, walletFactory, provisionPool },
   },
 }) => {
   for (const [name, producer] of Object.entries({
     centralSupply,
     mintHolder,
     walletFactory,
+    provisionPool,
   })) {
     // This really wants to be E(vatAdminSvc).getBundleIDByName, but it's
     // good enough to do D(vatAdmin).getBundleIDByName

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -186,13 +186,11 @@ export const makeBoard = async ({
 harden(makeBoard);
 
 /**
- * @param {NameAdmin} namesByAddressAdmin
  * @param {string} address
  */
-export const makeMyAddressNameAdmin = (namesByAddressAdmin, address) => {
+export const makeMyAddressNameAdmin = address => {
   // Create a name hub for this address.
-  const { nameHub: myAddressNameHub, nameAdmin: rawMyAddressNameAdmin } =
-    makeNameHubKit();
+  const { nameHub, nameAdmin: rawMyAddressNameAdmin } = makeNameHubKit();
 
   /** @type {MyAddressNameAdmin} */
   const myAddressNameAdmin = Far('myAddressNameAdmin', {
@@ -200,11 +198,9 @@ export const makeMyAddressNameAdmin = (namesByAddressAdmin, address) => {
     getMyAddress: () => address,
   });
   // reserve space for deposit facet
-  myAddressNameAdmin.reserve(WalletName.depositFacet);
-  // Register it with the namesByAddress hub.
-  namesByAddressAdmin.update(address, myAddressNameHub, myAddressNameAdmin);
+  myAddressNameAdmin.reserve('depositFacet');
 
-  return myAddressNameAdmin;
+  return { nameHub, myAddressNameAdmin };
 };
 
 /**
@@ -234,10 +230,7 @@ export const makeAddressNameHubs = async ({
   produce.namesByAddressAdmin.resolve(namesByAddressAdmin);
 
   const perAddress = address => {
-    const myAddressNameAdmin = makeMyAddressNameAdmin(
-      namesByAddressAdmin,
-      address,
-    );
+    const myAddressNameAdmin = makeMyAddressNameAdmin(address);
     return { agoricNames, namesByAddress, myAddressNameAdmin };
   };
 

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -188,7 +188,7 @@ harden(makeBoard);
 /**
  * @param {string} address
  */
-export const makeMyAddressNameAdmin = address => {
+export const makeMyAddressNameAdminKit = address => {
   // Create a name hub for this address.
   const { nameHub, nameAdmin: rawMyAddressNameAdmin } = makeNameHubKit();
 
@@ -230,7 +230,7 @@ export const makeAddressNameHubs = async ({
   produce.namesByAddressAdmin.resolve(namesByAddressAdmin);
 
   const perAddress = address => {
-    const { myAddressNameAdmin } = makeMyAddressNameAdmin(address);
+    const { myAddressNameAdmin } = makeMyAddressNameAdminKit(address);
     return { agoricNames, namesByAddress, myAddressNameAdmin };
   };
 

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -198,7 +198,7 @@ export const makeMyAddressNameAdmin = address => {
     getMyAddress: () => address,
   });
   // reserve space for deposit facet
-  myAddressNameAdmin.reserve('depositFacet');
+  myAddressNameAdmin.reserve(WalletName.depositFacet);
 
   return { nameHub, myAddressNameAdmin };
 };

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -109,8 +109,12 @@ export const buildRootObject = (vatPowers, vatParameters) => {
   const log = vatPowers.logger || console.info;
 
   const { anchorAssets, economicCommitteeAddresses } = vatParameters;
-  fit(harden(anchorAssets), M.arrayOf(AnchorOptionsShape));
-  fit(harden(economicCommitteeAddresses), M.recordOf(M.string(), M.string()));
+  fit(harden(anchorAssets), M.arrayOf(AnchorOptionsShape), 'anchorAssets');
+  fit(
+    harden(economicCommitteeAddresses),
+    M.recordOf(M.string(), M.string()),
+    'economicCommitteeAddresses',
+  );
 
   const { produce, consume } = makePromiseSpace(log);
   const { agoricNames, agoricNamesAdmin, spaces } = makeAgoricNamesAccess(

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -132,6 +132,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
         centralSupply: 'zoe',
         mintHolder: 'zoe',
         walletFactory: 'zoe',
+        provisionPool: 'zoe',
       },
     },
   },

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -107,6 +107,7 @@ export const startWalletFactory = async (
   provisionPoolStartResult.resolve(ppFacets);
 
   const handler = await E(ppFacets.creatorFacet).makeHandler({
+    // @ts-expect-error XXX what is going on here???
     bankManager,
     namesByAddressAdmin,
     walletFactory: wfFacets.creatorFacet,

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -107,7 +107,6 @@ export const startWalletFactory = async (
   provisionPoolStartResult.resolve(ppFacets);
 
   const handler = await E(ppFacets.creatorFacet).makeHandler({
-    // @ts-expect-error XXX what is going on here???
     bankManager,
     namesByAddressAdmin,
     walletFactory: wfFacets.creatorFacet,

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -121,7 +121,11 @@ export const startWalletFactory = async (
   client.resolve(
     Far('dummy client', {
       assignBundle: (propertyMakers = []) => {
-        console.warn('ignoring', propertyMakers.length, 'propertyMakers');
+        console.warn(
+          'dummy mailbox client home: ignoring',
+          propertyMakers.length,
+          'propertyMakers',
+        );
       },
     }),
   );

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -84,10 +84,8 @@ export const startWalletFactory = async ({
       if (!powerFlags.includes(PowerFlags.SMART_WALLET)) {
         return;
       }
-      const myAddressNameAdmin = makeMyAddressNameAdmin(
-        namesByAddressAdmin,
-        address,
-      );
+      const { nameHub, myAddressNameAdmin } = makeMyAddressNameAdmin(address);
+      namesByAddressAdmin.update(address, nameHub, myAddressNameAdmin);
 
       const bank = E(bankManager).getBankForAddress(address);
       await E(creatorFacet).provideSmartWallet(

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -138,7 +138,8 @@
  *   issuer: |
  *     TokenKeyword | 'Attestation' | 'AUSD',
  *   installation: |
- *     'centralSupply' | 'mintHolder' | 'singleWallet' | 'walletFactory' |
+ *     'centralSupply' | 'mintHolder' |
+ *     'singleWallet' | 'walletFactory' | 'provisionPool' |
  *     'feeDistributor' |
  *     'contractGovernor' | 'committee' | 'noActionElectorate' | 'binaryVoteCounter' |
  *     'amm' | 'VaultFactory' | 'liquidate' | 'stakeFactory' |
@@ -217,6 +218,7 @@
  *   provisioning: Awaited<ProvisioningVat>,
  *   testFirstAnchorKit: import('../vat-bank.js').AssetIssuerKit,
  *   walletFactoryStartResult: import('./startWalletFactory').WalletFactoryStartResult,
+ *   provisionPoolStartResult: unknown,
  *   zoe: ZoeService,
  * }>} ChainBootstrapSpace
  *

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -195,7 +195,7 @@
  *   agoricNames: NameHub,
  *   agoricNamesAdmin: NameAdmin,
  *   aggregators: Map<unknown, { aggregator: PriceAuthority, deleter: import('@agoric/zoe/tools/priceAuthorityRegistry').Deleter }>,
- *   bankManager: Awaited<BankManager>,
+ *   bankManager: BankManager,
  *   bldIssuerKit: RemoteIssuerKit,
  *   board: Board,
  *   bridgeManager: OptionalBridgeManager,
@@ -249,7 +249,7 @@
  *   }}
  * } BootstrapSpace
  * @typedef {{ mint: ERef<Mint>, issuer: ERef<Issuer>, brand: Brand }} RemoteIssuerKit
- * @typedef {ReturnType<Awaited<BankVat>['makeBankManager']>} BankManager
+ * @typedef {Awaited<ReturnType<Awaited<BankVat>['makeBankManager']>>} BankManager
  * @typedef {ERef<ReturnType<import('../vat-bank.js').buildRootObject>>} BankVat
  * @typedef {ERef<ReturnType<import('../vat-chainStorage.js').buildRootObject>>} ChainStorageVat
  * @typedef {ERef<ReturnType<import('../vat-provisioning.js').buildRootObject>>} ProvisioningVat

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -36,6 +36,7 @@ export const agoricNamesReserved = harden({
     mintHolder: 'mint holder',
     singleWallet: 'single smart wallet',
     walletFactory: 'multitenant smart wallet',
+    provisionPool: 'provision accounts with initial IST',
     contractGovernor: 'contract governor',
     committee: 'committee electorate',
     noActionElectorate: 'no action electorate',

--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -14,7 +14,7 @@ import {
 
 const { details: X, quote: q } = assert;
 
-const privateShape = harden({
+const privateArgsShape = harden({
   poolBank: M.eref(M.remotable('bank')),
 });
 
@@ -82,7 +82,7 @@ const makeBridgeProvisionTool = sendInitialPayment => {
 export const start = (zcf, privateArgs) => {
   // TODO: make initial amount governed
   const { perAccountInitialAmount } = zcf.getTerms();
-  fit(privateArgs, privateShape, 'provisionPool privateArgs');
+  fit(privateArgs, privateArgsShape, 'provisionPool privateArgs');
   const { poolBank } = privateArgs;
   fit(perAccountInitialAmount, AmountShape, 'perAccountInitialAmount');
   const { brand: poolBrand } = perAccountInitialAmount;

--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -82,6 +82,8 @@ export const start = (zcf, privateArgs) => {
   const { poolBank } = privateArgs;
   fit(perAccountInitialAmount, AmountShape, 'perAccountInitialAmount');
   const { brand: poolBrand } = perAccountInitialAmount;
+  /** @type {ERef<Purse>} */
+  // @ts-expect-error vbank purse is close enough for our use.
   const fundPurse = E(poolBank).getPurse(poolBrand);
 
   const zoe = zcf.getZoeService();
@@ -101,6 +103,8 @@ export const start = (zcf, privateArgs) => {
     updateState: async desc => {
       console.log('provisionPool notified of new asset', desc.brand);
       await zcf.saveIssuer(desc.issuer, desc.issuerName);
+      /** @type {ERef<Purse>} */
+      // @ts-expect-error vbank purse is close enough for our use.
       const exchangePurse = E(poolBank).getPurse(desc.brand);
       observeNotifier(E(exchangePurse).getCurrentAmountNotifier(), {
         updateState: async amount => {

--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -7,7 +7,10 @@ import { E, Far } from '@endo/far';
 import { observeIteration, observeNotifier } from '@agoric/notifier';
 import { AmountMath, AmountShape } from '@agoric/ertp';
 import { WalletName } from '@agoric/internal';
-import { makeMyAddressNameAdmin, PowerFlags } from './core/basic-behaviors.js';
+import {
+  makeMyAddressNameAdminKit,
+  PowerFlags,
+} from './core/basic-behaviors.js';
 
 const { details: X, quote: q } = assert;
 
@@ -45,7 +48,8 @@ const makeBridgeProvisionTool = sendInitialPayment => {
           return;
         }
 
-        const { nameHub, myAddressNameAdmin } = makeMyAddressNameAdmin(address);
+        const { nameHub, myAddressNameAdmin } =
+          makeMyAddressNameAdminKit(address);
 
         const bank = E(bankManager).getBankForAddress(address);
         await Promise.all([

--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -1,0 +1,151 @@
+// @jessie-check
+// @ts-check
+
+import { fit, M, makeScalarMapStore } from '@agoric/store';
+import { E, Far } from '@endo/far';
+// TODO: move to narrower package?
+import { observeIteration, observeNotifier } from '@agoric/notifier';
+import { AmountMath, AmountShape } from '@agoric/ertp';
+import { makeMyAddressNameAdmin, PowerFlags } from './core/basic-behaviors.js';
+
+const { details: X, quote: q } = assert;
+
+const privateShape = harden({
+  poolBank: M.eref(M.remotable('bank')),
+});
+
+/**
+ * Given attenuated access to the funding purse,
+ * handle requests to provision smart wallets.
+ *
+ * @param {(address: string, depositFacet: ERef<DepositFacet>) => Promise<void>} sendInitialPayment
+ */
+const makeBridgeProvisionTool = sendInitialPayment => {
+  /**
+   * @param {{
+   *   bankManager: ERef<BankManager>,
+   *   namesByAddressAdmin: ERef<NameAdmin>,
+   *   walletFactory: ERef<import('@agoric/vats/src/core/startWalletFactory').WalletFactoryStartResult['creatorFacet']>
+   * }} io
+   */
+  const makeHandler = ({ bankManager, namesByAddressAdmin, walletFactory }) =>
+    Far('provisioningHandler', {
+      fromBridge: async (_srcID, obj) => {
+        assert.equal(
+          obj.type,
+          'PLEASE_PROVISION',
+          X`Unrecognized request ${obj.type}`,
+        );
+        const { address, powerFlags } = obj;
+        console.info('PLEASE_PROVISION', address, powerFlags);
+
+        if (!powerFlags.includes(PowerFlags.SMART_WALLET)) {
+          return;
+        }
+
+        const { nameHub, myAddressNameAdmin } = makeMyAddressNameAdmin(address);
+        await E(namesByAddressAdmin).update(address, nameHub);
+        const depositFacet = nameHub.lookup('depositFacet');
+
+        // don't wait for this here, since their deposit facet
+        // might not be there yet
+        void sendInitialPayment(address, depositFacet);
+
+        const bank = E(bankManager).getBankForAddress(address);
+        await E(walletFactory).provideSmartWallet(
+          address,
+          bank,
+          myAddressNameAdmin,
+        );
+        console.info('provisioned', address, powerFlags);
+      },
+    });
+  return makeHandler;
+};
+
+/**
+ * @typedef {StandardTerms & {
+ *   perAccountInitialAmount: Amount<'nat'>,
+ * }} ProvisionTerms
+ *
+ * @typedef {{
+ *   poolBank: import('@endo/far').FarRef<import('./vat-bank.js').Bank>,
+ * }} ProvisionPrivate
+ * TODO: ERef<GovernedCreatorFacet<ProvisionCreator>>
+ *
+ * @type {ContractStartFn<unknown, unknown,
+ *                        ProvisionTerms, ProvisionPrivate>}
+ */
+export const start = (zcf, privateArgs) => {
+  // TODO: make initial amount governed
+  const { perAccountInitialAmount } = zcf.getTerms();
+  fit(privateArgs, privateShape, 'provisionPool privateArgs');
+  const { poolBank } = privateArgs;
+  fit(perAccountInitialAmount, AmountShape, 'perAccountInitialAmount');
+  const fundPurse = E(poolBank).getPurse(perAccountInitialAmount.brand);
+
+  const zoe = zcf.getZoeService();
+  const swap = async (payIn, amount, instance) => {
+    const psmPub = E(zoe).getPublicFacet(instance);
+    const proposal = harden({ give: { In: amount } });
+    const invitation = E(psmPub).makeWantMintedInvitation();
+    const seat = E(zoe).offer(invitation, proposal, { In: payIn });
+    const payout = await E(seat).getPayout('Out');
+    return E(fundPurse).deposit(payout);
+  };
+
+  /** @type {MapStore<Brand, Instance>} */
+  const brandToPSM = makeScalarMapStore();
+
+  observeIteration(E(poolBank).getAssetSubscription(), {
+    updateState: async desc => {
+      console.log('provisionPool notified of new asset', desc.brand);
+      await zcf.saveIssuer(desc.issuer, desc.issuerName);
+      const exchangePurse = E(poolBank).getPurse(desc.brand);
+      observeNotifier(E(exchangePurse).getCurrentAmountNotifier(), {
+        updateState: async amount => {
+          console.log('provisionPool balance update', amount);
+          if (AmountMath.isEmpty(amount)) {
+            return;
+          }
+          if (!brandToPSM.has(desc.brand)) {
+            console.error('funds arrived but no PSM instance', desc.brand);
+            return;
+          }
+          const instance = brandToPSM.get(desc.brand);
+          const payment = E(exchangePurse).withdraw(amount);
+          await swap(payment, amount, instance).catch(async reason => {
+            console.error(X`swap failed: ${reason}`);
+            const resolvedPayment = await payment;
+            E(exchangePurse).deposit(resolvedPayment);
+          });
+        },
+        fail: reason => console.error(reason),
+      });
+    },
+  });
+
+  const sendInitialPayment = async (address, depositFacet) => {
+    const initialPmt = await E(fundPurse).withdraw(perAccountInitialAmount);
+
+    return E(depositFacet)
+      .receive(initialPmt)
+      .catch(e => {
+        console.error(X`initial deposit for ${q(address)} failed: ${q(e)}`);
+        E(fundPurse).deposit(initialPmt);
+      });
+  };
+
+  const creatorFacet = Far('Provisioning Pool creator', {
+    makeHandler: makeBridgeProvisionTool(sendInitialPayment),
+    initPSM: (brand, instance) => {
+      fit(brand, M.remotable('brand'));
+      fit(instance, M.remotable('instance'));
+      brandToPSM.init(brand, instance);
+    },
+  });
+
+  return { creatorFacet };
+};
+
+harden(start);

--- a/packages/vats/test/devices.js
+++ b/packages/vats/test/devices.js
@@ -8,6 +8,7 @@ import bundleCentralSupply from '../bundles/bundle-centralSupply.js';
 import bundleMintHolder from '../bundles/bundle-mintHolder.js';
 import bundleSingleWallet from '../bundles/bundle-singleWallet.js';
 import bundleWalletFactory from '../bundles/bundle-legacy-walletFactory.js';
+import bundleProvisionPool from '../bundles/bundle-provisionPool.js';
 
 const bundles = {
   centralSupply: bundleCentralSupply,
@@ -19,6 +20,7 @@ const bundles = {
   binaryVoteCounter: bundleBinaryVoteCounter,
   psm: bundlePSM,
   psmCharter: bundlePSMCharter,
+  provisionPool: bundleProvisionPool,
 };
 
 export const devices = {

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -1,0 +1,212 @@
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test as unknownTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import path from 'path';
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+import {
+  makeMockChainStorageRoot,
+  setUpZoeForTest,
+  withAmountUtils,
+} from '@agoric/inter-protocol/test/supports.js';
+import committeeBundle from '@agoric/governance/bundles/bundle-committee.js';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { E, Far } from '@endo/far';
+import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
+import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
+import { makeScalarMap } from '@agoric/store';
+import { makeSubscriptionKit, observeNotifier } from '@agoric/notifier';
+import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
+import { makeBoard } from '../src/lib-board.js';
+import centralSupplyBundle from '../bundles/bundle-centralSupply.js';
+
+const pathname = new URL(import.meta.url).pathname;
+const dirname = path.dirname(pathname);
+
+const psmRoot = `${dirname}/../../inter-protocol/src/psm/psm.js`;
+const policyRoot = `${dirname}/../src/provisionPool.js`;
+
+const scale6 = x => BigInt(Math.round(x * 1_000_000));
+
+const BASIS_POINTS = 10000n;
+const WantMintedFeeBP = 1n;
+const GiveMintedFeeBP = 3n;
+const MINT_LIMIT = scale6(20_000_000);
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
+const test = unknownTest;
+
+const makeTestContext = async () => {
+  const bundleCache = await unsafeMakeBundleCache('bundles/');
+  const psmBundle = await bundleCache.load(psmRoot, 'psm');
+  const policyBundle = await bundleCache.load(policyRoot, 'provisionPool');
+  const { zoe, feeMintAccess } = setUpZoeForTest();
+
+  const mintedIssuer = await E(zoe).getFeeIssuer();
+  /** @type {Brand<'nat'>} */
+  const mintedBrand = await E(mintedIssuer).getBrand();
+  const anchor = withAmountUtils(makeIssuerKit('aUSD'));
+
+  const committeeInstall = await E(zoe).install(committeeBundle);
+  const psmInstall = await E(zoe).install(psmBundle);
+  const centralSupply = await E(zoe).install(centralSupplyBundle);
+  const policyInstall = await E(zoe).install(policyBundle);
+
+  const mintLimit = AmountMath.make(anchor.brand, MINT_LIMIT);
+
+  const marshaller = makeBoard().getReadonlyMarshaller();
+
+  const { creatorFacet: committeeCreator } = await E(zoe).startInstance(
+    committeeInstall,
+    harden({}),
+    {
+      committeeName: 'Demos',
+      committeeSize: 1,
+    },
+    {
+      storageNode: makeMockChainStorageRoot().makeChildNode('thisCommittee'),
+      marshaller,
+    },
+  );
+
+  const initialPoserInvitation = await E(committeeCreator).getPoserInvitation();
+  const invitationAmount = await E(E(zoe).getInvitationIssuer()).getAmountOf(
+    initialPoserInvitation,
+  );
+
+  return {
+    bundles: { psmBundle },
+    zoe: await zoe,
+    feeMintAccess: await feeMintAccess,
+    initialPoserInvitation,
+    minted: { issuer: mintedIssuer, brand: mintedBrand },
+    anchor,
+    installs: {
+      committeeInstall,
+      psmInstall,
+      centralSupply,
+      provisionPool: policyInstall,
+    },
+    mintLimit,
+    marshaller,
+    terms: {
+      anchorBrand: anchor.brand,
+      anchorPerMinted: makeRatio(100n, anchor.brand, 100n, mintedBrand),
+      governedParams: {
+        [CONTRACT_ELECTORATE]: {
+          type: ParamTypes.INVITATION,
+          value: invitationAmount,
+        },
+        GiveMintedFee: {
+          type: ParamTypes.RATIO,
+          value: makeRatio(GiveMintedFeeBP, mintedBrand, BASIS_POINTS),
+        },
+        MintLimit: { type: ParamTypes.AMOUNT, value: mintLimit },
+        WantMintedFee: {
+          type: ParamTypes.RATIO,
+          value: makeRatio(WantMintedFeeBP, mintedBrand, BASIS_POINTS),
+        },
+      },
+    },
+  };
+};
+
+test.before(async t => {
+  t.context = await makeTestContext();
+});
+
+/** @param {Awaited<ReturnType<typeof makeTestContext>>} context */
+const tools = context => {
+  const { zoe, anchor, installs } = context;
+  const minted = withAmountUtils(context.minted);
+  const makeBank = () => {
+    const issuers = makeScalarMap();
+    [minted, anchor].forEach(kit => issuers.init(kit.brand, kit.issuer));
+    const purses = makeScalarMap();
+    [minted, anchor].forEach(kit => {
+      assert(kit.issuer);
+      purses.init(kit.brand, E(kit.issuer).makeEmptyPurse());
+    });
+
+    /** @type {SubscriptionRecord<import('../src/vat-bank.js').AssetDescriptor>} */
+    const { subscription, publication } = makeSubscriptionKit();
+
+    /** @type {import('../src/vat-bank.js').Bank} */
+    const bank = Far('mock bank', {
+      /** @param {Brand} brand */
+      getPurse: brand => purses.get(brand),
+      getAssetSubscription: () => subscription,
+    });
+
+    return { assetPublication: publication, bank };
+  };
+  const { assetPublication, bank: poolBank } = makeBank();
+
+  // Each driver needs its own to avoid state pollution between tests
+  const mockChainStorage = makeMockChainStorageRoot();
+  const { feeMintAccess, initialPoserInvitation } = context;
+  const startPSM = name => {
+    return E(zoe).startInstance(
+      installs.psmInstall,
+      harden({ AUSD: anchor.issuer }),
+      context.terms,
+      {
+        feeMintAccess,
+        initialPoserInvitation,
+        storageNode: mockChainStorage.makeChildNode(name),
+        marshaller: makeBoard().getReadonlyMarshaller(),
+      },
+    );
+  };
+
+  const publishAnchorAsset = async () => {
+    assetPublication.updateState({
+      brand: anchor.brand,
+      issuer: anchor.issuer || assert.fail(),
+      issuerName: 'USDref',
+      denom: 'ibc/toyusdc',
+      proposedName: 'toy USDC',
+    });
+  };
+  return { minted, poolBank, startPSM, publishAnchorAsset };
+};
+
+test('provisionPool trades provided assets for IST', async t => {
+  const { zoe, anchor, installs } = t.context;
+
+  const { minted, poolBank, startPSM, publishAnchorAsset } = tools(t.context);
+
+  t.log('prepare anchor purse with 100 aUSD');
+  const anchorPurse = E(poolBank).getPurse(anchor.brand);
+  assert(anchor.mint);
+  await E(anchorPurse).deposit(
+    await E(anchor.mint).mintPayment(anchor.make(scale6(100))),
+  );
+
+  t.log('startInstance(provisionPool)');
+  const perAccountInitialAmount = minted.make(scale6(0.25));
+  const facets = await E(zoe).startInstance(
+    installs.provisionPool,
+    {},
+    { perAccountInitialAmount },
+    { poolBank },
+  );
+
+  t.log('introduce PSM instance to provisionPool');
+  const psm = await startPSM('IST-AUSD');
+  await E(facets.creatorFacet).initPSM(anchor.brand, psm.instance);
+
+  t.log('publish anchor asset to initiate trading');
+  await publishAnchorAsset();
+  await eventLoopIteration(); // wait for trade
+
+  const mintedPurse = E(poolBank).getPurse(minted.brand);
+  const poolBalanceAfter = await E(mintedPurse).getCurrentAmount();
+  t.log('post-trade pool balance:', poolBalanceAfter);
+  t.deepEqual(
+    poolBalanceAfter,
+    minted.make(scale6(100) - WantMintedFeeBP * BASIS_POINTS),
+  );
+  const anchorBalanceAfter = await E(anchorPurse).getCurrentAmount();
+  t.log('post-trade anchor balance:', anchorBalanceAfter);
+  t.deepEqual(anchorBalanceAfter, anchor.makeEmpty());
+});

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -14,7 +14,7 @@ import { E, Far } from '@endo/far';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
 import { makeScalarMap } from '@agoric/store';
-import { makeSubscriptionKit, observeNotifier } from '@agoric/notifier';
+import { makeSubscriptionKit } from '@agoric/notifier';
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { makeBoard } from '../src/lib-board.js';
 import centralSupplyBundle from '../bundles/bundle-centralSupply.js';

--- a/packages/wallet/contract/test/devices.js
+++ b/packages/wallet/contract/test/devices.js
@@ -2,6 +2,7 @@ import bundleCentralSupply from '@agoric/vats/bundles/bundle-centralSupply.js';
 import bundleMintHolder from '@agoric/vats/bundles/bundle-mintHolder.js';
 import bundleSingleWallet from '@agoric/vats/bundles/bundle-singleWallet.js';
 import bundleWalletFactory from '@agoric/vats/bundles/bundle-legacy-walletFactory.js';
+import bundleProvisionPool from '@agoric/vats/bundles/bundle-provisionPool.js';
 
 export const devices = {
   vatAdmin: {
@@ -16,6 +17,8 @@ export const devices = {
             return bundleSingleWallet;
           case 'walletFactory':
             return bundleWalletFactory;
+          case 'provisionPool':
+            return bundleProvisionPool;
           default:
             throw new Error(`unknown bundle ${name}`);
         }


### PR DESCRIPTION
refs: #6067

## Description

 - add `provisionPool` contract; wire it up to the walletFactory as well as each PSM
 - add module account, `vbank/provision`, to hold IST as well as assets to sell on the/a PSM

TODO:
 - [ ] make initial amount governed (I prefer to do this in a follow-on PR)

### Security Considerations

In the contract: `makeBridgeProvisionTool` is factored out of the contract `start` function to keep the bridge handling stuff mostly separate from the asset-handling stuff.

Elsewhere, the use of bootstrap powers merits careful review.

### Documentation Considerations

We should provide end users with docs on the "pay 10 BLD to the community pool; get 0.25 IST for initial fees" model.

### Testing Considerations

Trading on the PSM is unit-tested.

The flow resulting in 0.25 IST going to the user was only tested manually. (Results are documented [below](https://github.com/Agoric/agoric-sdk/pull/6157#issuecomment-1241481631).)