### PR TITLE
fix: Make pattern matching faster

### DIFF
--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,5 +1,13 @@
 import { M, matches } from '@agoric/store';
 
+export const BrandShape = M.remotable('Brand');
+export const IssuerShape = M.remotable('Issuer');
+export const PaymentShape = M.remotable('Payment');
+export const PurseShape = M.remotable('Purse');
+export const DepositFacetShape = M.remotable('DepositFacet');
+const NotifierShape = M.remotable('Notifier');
+export const MintShape = M.remotable('Mint');
+
 /**
  * When the AmountValue of an Amount fits the NatValueShape, i.e., when it is
  * a non-negative bigint, then it represents that many units of the
@@ -68,7 +76,7 @@ const AmountValueShape = M.or(
 );
 
 export const AmountShape = harden({
-  brand: M.remotable(),
+  brand: BrandShape,
   value: AmountValueShape,
 });
 
@@ -131,14 +139,6 @@ export const DisplayInfoShape = M.partial(
 );
 
 // //////////////////////// Interfaces /////////////////////////////////////////
-
-export const BrandShape = M.remotable('Brand');
-export const IssuerShape = M.remotable('Issuer');
-export const PaymentShape = M.remotable('Payment');
-export const PurseShape = M.remotable('Purse');
-export const DepositFacetShape = M.remotable('DepositFacet');
-const NotifierShape = M.remotable('Notifier');
-export const MintShape = M.remotable('Mint');
 
 export const BrandI = M.interface('Brand', {
   isMyIssuer: M.callWhen(M.await(IssuerShape)).returns(M.boolean()),

--- a/packages/store/src/keys/checkKey.js
+++ b/packages/store/src/keys/checkKey.js
@@ -33,7 +33,10 @@ const { ownKeys } = Reflect;
  */
 const checkPrimitiveKey = (val, check) => {
   if (isObject(val)) {
-    return check(false, X`A ${q(typeof val)} cannot be a primitive: ${val}`);
+    return (
+      check !== identChecker &&
+      check(false, X`A ${q(typeof val)} cannot be a primitive: ${val}`)
+    );
   }
   // TODO There is not yet a checkPassable, but perhaps there should be.
   // If that happens, we should call it here instead.
@@ -67,10 +70,10 @@ export const checkScalarKey = (val, check) => {
     return true;
   }
   const passStyle = passStyleOf(val);
-  return check(
-    passStyle === 'remotable',
-    X`A ${q(passStyle)} cannot be a scalar key: ${val}`,
-  );
+  if (passStyle === 'remotable') {
+    return true;
+  }
+  return check(false, X`A ${q(passStyle)} cannot be a scalar key: ${val}`);
 };
 
 /**
@@ -100,9 +103,6 @@ const keyMemo = new WeakSet();
  * @returns {boolean}
  */
 export const checkKey = (val, check) => {
-  if (isPrimitiveKey(val)) {
-    return true;
-  }
   if (!isObject(val)) {
     // TODO There is not yet a checkPassable, but perhaps there should be.
     // If that happens, we should call it here instead.
@@ -553,9 +553,9 @@ const checkKeyInternal = (val, check) => {
           );
         }
         default: {
-          return check(
-            false,
-            X`A passable tagged ${q(tag)} is not a key: ${val}`,
+          return (
+            check !== identChecker &&
+            check(false, X`A passable tagged ${q(tag)} is not a key: ${val}`)
           );
         }
       }

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -157,7 +157,7 @@ const bindMethod = (
     const context = contextMap.get(self);
     assert(
       context,
-      X`${q(methodTag)} may only be applied to a valid instance: ${this}`,
+      X`${q(methodTag)} may only be applied to a valid instance: ${self}`,
     );
     return context;
   };

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-use-before-define */
 // @ts-check
 
 import {
@@ -43,6 +42,9 @@ const { ownKeys } = Reflect;
 const patternMemo = new WeakSet();
 
 // /////////////////////// Match Helpers Helpers /////////////////////////////
+
+/** For forward references to `M` */
+let MM;
 
 /**
  * The actual default values here are, at the present time, fairly
@@ -103,6 +105,7 @@ const checkIsWellFormedWithLimit = (
   }
   const limits = payload[mainLength];
   payload = harden(payload.slice(0, mainLength));
+  // eslint-disable-next-line no-use-before-define
   if (!checkMatches(payload, mainPayloadShape, check, label)) {
     return false;
   }
@@ -151,6 +154,107 @@ const makePatternKit = () => {
     // eslint-disable-next-line no-use-before-define
     HelpersByMatchTag[tag];
 
+  /**
+   * @typedef {string} Kind
+   * It is either a PassStyle other than 'tagged', or, if the underlying
+   * PassStyle is 'tagged', then the `getTag` value.
+   *
+   * We cannot further restrict this to only possible passStyles
+   * or known tags, because we wish to allow matching of tags that we
+   * don't know ahead of time. Do we need to separate the namespaces?
+   * TODO are we asking for trouble by lumping passStyles and tags
+   * together into kinds?
+   */
+
+  const kindMemo = new WeakMap();
+
+  /**
+   * Checks only recognized tags, and only if the tagged
+   * passes the invariants associated with that recognition.
+   *
+   * @param {Passable} tagged
+   * @param {Kind} tag
+   * @param {Checker} check
+   * @returns {boolean}
+   */
+  const checkTagged = (tagged, tag, check) => {
+    const matchHelper = maybeMatchHelper(tag);
+    if (matchHelper) {
+      // Buried here is the important case, where we process
+      // the various patternNodes
+      return matchHelper.checkIsWellFormed(tagged.payload, check);
+    }
+    switch (tag) {
+      case 'copySet': {
+        return checkCopySet(tagged, check);
+      }
+      case 'copyBag': {
+        return checkCopyBag(tagged, check);
+      }
+      case 'copyMap': {
+        return checkCopyMap(tagged, check);
+      }
+      default: {
+        return check(
+          false,
+          X`cannot check unrecognized tag ${q(tag)}: ${tagged}`,
+        );
+      }
+    }
+  };
+
+  /**
+   * Returns only a recognized kind, and only if the specimen passes the
+   * invariants associated with that recognition.
+   * Otherwise, `check(false, ...)` and returns undefined
+   *
+   * @param {Passable} specimen
+   * @param {Checker} [check]
+   * @returns {Kind | undefined}
+   */
+  const kindOf = (specimen, check = identChecker) => {
+    const passStyle = passStyleOf(specimen);
+    if (passStyle !== 'tagged') {
+      return passStyle;
+    }
+    // At this point we know that specimen is a well formed tagged record
+    if (kindMemo.has(specimen)) {
+      return kindMemo.get(specimen);
+    }
+    const tag = getTag(specimen);
+    if (checkTagged(specimen, tag, check)) {
+      kindMemo.set(specimen, tag);
+      return tag;
+    }
+    if (check !== identChecker) {
+      check(false, X`cannot check unrecognized tag ${q(tag)}`);
+    }
+    return undefined;
+  };
+  harden(kindOf);
+
+  /**
+   * Checks only recognized kinds, and only if the specimen
+   * passes the invariants associated with that recognition.
+   *
+   * @param {Passable} specimen
+   * @param {Kind} kind
+   * @param {Checker} check
+   * @returns {boolean}
+   */
+  const checkKind = (specimen, kind, check) => {
+    const realKind = kindOf(specimen, check);
+    if (kind === realKind) {
+      return true;
+    }
+    if (check !== identChecker) {
+      // quoting without quotes
+      const details = X([`${realKind} `, ` - Must be a ${kind}`], specimen);
+      check(false, details);
+    }
+    return false;
+  };
+
   // /////////////////////// isPattern /////////////////////////////////////////
 
   /** @type {CheckPattern} */
@@ -162,6 +266,9 @@ const makePatternKit = () => {
       // is only concerned with non-key patterns.
       return true;
     }
+    if (patternMemo.has(patt)) {
+      return true;
+    }
     // eslint-disable-next-line no-use-before-define
     const result = checkPatternInternal(patt, check);
     if (result) {
@@ -171,7 +278,8 @@ const makePatternKit = () => {
   };
 
   /**
-   * @param {Passable} patt
+   * @param {Passable} patt - known not to be a key, and therefore known
+   * not to be primitive.
    * @param {Checker} check
    * @returns {boolean}
    */
@@ -181,8 +289,11 @@ const makePatternKit = () => {
     // essentially identical.
     const checkIt = child => checkPattern(child, check);
 
-    const passStyle = passStyleOf(patt);
-    switch (passStyle) {
+    const kind = kindOf(patt, check);
+    switch (kind) {
+      case undefined: {
+        return false;
+      }
       case 'copyRecord': {
         // A copyRecord is a pattern iff all its children are
         // patterns
@@ -193,56 +304,24 @@ const makePatternKit = () => {
         // patterns
         return patt.every(checkIt);
       }
-      case 'tagged': {
-        const tag = getTag(patt);
-        const matchHelper = maybeMatchHelper(tag);
-        if (matchHelper !== undefined) {
-          // This check guarantees the payload invariants assumed by the other
-          // matchHelper methods.
-          return matchHelper.checkIsWellFormed(patt.payload, check);
-        }
-        switch (tag) {
-          case 'copySet':
-          case 'copyBag': {
-            assert(
-              !isKey(patt),
-              X`internal: The key case should have been dealt with earlier: ${patt}`,
-            );
-            return check(
-              false,
-              X`A ${q(tag)} - Must be a Key but was not: ${patt}`,
-            );
-          }
-          case 'copyMap': {
-            return (
-              checkCopyMap(patt, check) &&
-              // For a copyMap to be a pattern, all its keys and values must
-              // be patterns. For value patterns, we support full pattern
-              // matching. For key patterns, only support
-              // the same limited matching as with copySet elements.
-
-              // Check keys as a copySet
-              checkPattern(copyMapKeySet(patt), check) &&
-              // Check values as a copyMap
-              checkPattern(patt.values, check)
-            );
-          }
-          default: {
-            return check(
-              false,
-              X`A passable tagged ${q(tag)} is not a pattern: ${patt}`,
-            );
-          }
-        }
+      case 'copyMap': {
+        // A copyMap's keys are keys and therefore already known to be
+        // patterns.
+        // A copyMap is a pattern if its values are patterns.
+        return checkPattern(patt.values, check);
       }
       case 'error':
       case 'promise': {
-        return check(false, X`A ${q(passStyle)} cannot be a pattern`);
+        return check(false, X`A ${q(kind)} cannot be a pattern`);
       }
       default: {
-        // Unexpected tags are just non-patterns, but an unexpected passStyle
-        // is always an error.
-        assert.fail(X`unexpected passStyle ${q(passStyle)}: ${patt}`);
+        if (maybeMatchHelper(kind) !== undefined) {
+          return true;
+        }
+        return check(
+          false,
+          X`A passable of kind ${q(kind)} is not a pattern: ${patt}`,
+        );
       }
     }
   };
@@ -354,17 +433,42 @@ const makePatternKit = () => {
    * @returns {boolean}
    */
   const checkMatchesInternal = (specimen, patt, check) => {
-    if (isKey(patt)) {
-      // Takes care of all patterns which are keys, so the rest of this
-      // logic can assume patterns that are not key.
-      return check(keyEQ(specimen, patt), X`${specimen} - Must be: ${patt}`);
-    }
-    assertPattern(patt);
-    const specimenStyle = passStyleOf(specimen);
-    const pattStyle = passStyleOf(patt);
-    switch (pattStyle) {
+    // Worth being a bit verbose and repetitive in order to optimize
+    const patternKind = kindOf(patt, check);
+    const specimenKind = kindOf(specimen); // may be undefined
+    switch (patternKind) {
+      case undefined: {
+        return assert.fail(X`pattern expected: ${patt}`);
+      }
+      case 'promise': {
+        return assert.fail(X`promises cannot be patterns: ${patt}`);
+      }
+      case 'error': {
+        return assert.fail(X`errors cannot be patterns: ${patt}`);
+      }
+      case 'undefined':
+      case 'null':
+      case 'boolean':
+      case 'number':
+      case 'bigint':
+      case 'string':
+      case 'symbol':
+      case 'copySet':
+      case 'copyBag':
+      case 'remotable': {
+        // These kinds are necessarily keys
+        return check(keyEQ(specimen, patt), X`${specimen} - Must be: ${patt}`);
+      }
       case 'copyArray': {
-        if (specimenStyle !== 'copyArray') {
+        if (isKey(patt)) {
+          // Takes care of patterns which are keys, so the rest of this
+          // logic can assume patterns that are not keys.
+          return check(
+            keyEQ(specimen, patt),
+            X`${specimen} - Must be: ${patt}`,
+          );
+        }
+        if (specimenKind !== 'copyArray') {
           return check(
             false,
             X`${specimen} - Must be a copyArray to match a copyArray pattern: ${patt}`,
@@ -380,7 +484,15 @@ const makePatternKit = () => {
         return patt.every((p, i) => checkMatches(specimen[i], p, check, i));
       }
       case 'copyRecord': {
-        if (specimenStyle !== 'copyRecord') {
+        if (isKey(patt)) {
+          // Takes care of patterns which are keys, so the rest of this
+          // logic can assume patterns that are not keys.
+          return check(
+            keyEQ(specimen, patt),
+            X`${specimen} - Must be: ${patt}`,
+          );
+        }
+        if (specimenKind !== 'copyRecord') {
           return check(
             false,
             X`${specimen} - Must be a copyRecord to match a copyRecord pattern: ${patt}`,
@@ -408,55 +520,40 @@ const makePatternKit = () => {
           checkMatches(specimenValues[i], pattValues[i], check, label),
         );
       }
-      case 'tagged': {
-        const pattTag = getTag(patt);
-        const matchHelper = maybeMatchHelper(pattTag);
-        if (matchHelper) {
-          return matchHelper.checkMatches(specimen, patt.payload, check);
+      case 'copyMap': {
+        if (isKey(patt)) {
+          // Takes care of patterns which are keys, so the rest of this
+          // logic can assume patterns that are not keys.
+          return check(
+            keyEQ(specimen, patt),
+            X`${specimen} - Must be: ${patt}`,
+          );
         }
-        const specimenTag =
-          specimenStyle === 'tagged' ? getTag(specimen) : undefined;
-        if (specimenStyle !== 'tagged' || specimenTag !== pattTag) {
+        if (specimenKind !== 'copyMap') {
           return check(
             false,
-            X`${specimen} - Must be tagged as a ${pattTag}: ${specimenTag}`,
+            X`${specimen} - Must be a copyMap to match a copyMap pattern: ${patt}`,
           );
         }
         const { payload: pattPayload } = patt;
         const { payload: specimenPayload } = specimen;
-        switch (pattTag) {
-          case 'copySet':
-          case 'copyBag': {
-            assert(
-              !isKey(patt),
-              X`internal: The key case should have been dealt with earlier: ${patt}`,
-            );
-            assert.fail(
-              X`internal: A ${q(pattTag)} must be a Key but was not: ${patt}`,
-            );
-          }
-          case 'copyMap': {
-            if (!checkCopySet(specimen, check)) {
-              return false;
-            }
-            const pattKeySet = copyMapKeySet(pattPayload);
-            const specimenKeySet = copyMapKeySet(specimenPayload);
-            // Compare keys as copySets
-            if (checkMatches(specimenKeySet, pattKeySet, check)) {
-              return false;
-            }
-            const pattValues = pattPayload.values;
-            const specimenValues = specimenPayload.values;
-            // compare values as copyArrays
-            return checkMatches(specimenValues, pattValues, check);
-          }
-          default: {
-            assert.fail(X`Unexpected tag ${q(pattTag)}`);
-          }
+        const pattKeySet = copyMapKeySet(pattPayload);
+        const specimenKeySet = copyMapKeySet(specimenPayload);
+        // Compare keys as copySets
+        if (!checkMatches(specimenKeySet, pattKeySet, check)) {
+          return false;
         }
+        const pattValues = pattPayload.values;
+        const specimenValues = specimenPayload.values;
+        // compare values as copyArrays
+        return checkMatches(specimenValues, pattValues, check);
       }
       default: {
-        assert.fail(X`unexpected passStyle ${q(pattStyle)}: ${patt}`);
+        const matchHelper = maybeMatchHelper(patternKind);
+        if (matchHelper) {
+          return matchHelper.checkMatches(specimen, patt.payload, check);
+        }
+        assert.fail(X`internal: should have recognized ${q(patternKind)} `);
       }
     }
   };
@@ -478,7 +575,12 @@ const makePatternKit = () => {
    * @param {string|number} [label]
    */
   const fit = (specimen, patt, label = undefined) => {
+    if (checkMatches(specimen, patt, identChecker, label)) {
+      return;
+    }
+    // should only throw
     checkMatches(specimen, patt, assertChecker, label);
+    assert.fail(X`internal: ${label}: inconsistent pattern match: ${q(patt)}`);
   };
 
   // /////////////////////// getRankCover //////////////////////////////////////
@@ -591,70 +693,6 @@ const makePatternKit = () => {
       }
     }
     return getPassStyleCover(passStyle);
-  };
-
-  /**
-   * @typedef {string} Kind
-   * It is either a PassStyle other than 'tagged', or, if the underlying
-   * PassStyle is 'tagged', then the `getTag` value.
-   *
-   * We cannot further restrict this to only possible passStyles
-   * or known tags, because we wish to allow matching of tags that we
-   * don't know ahead of time. Do we need to separate the namespaces?
-   * TODO are we asking for trouble by lumping passStyles and tags
-   * together into kinds?
-   */
-
-  /**
-   * Checks only recognized kinds, and only if the specimen
-   * passes the invariants associated with that recognition.
-   * If the kind is unrecognized, then we must conservatively assume
-   * that it does not satisfy invariants we cannot validate.
-   *
-   * @param {Passable} specimen
-   * @param {Kind} kind
-   * @param {Checker} check
-   */
-  const checkKind = (specimen, kind, check) => {
-    assert(
-      kind !== 'tagged',
-      X`"tagged" is used as a kind escape and cannot be used as a kind`,
-    );
-    /** @type {Kind} */
-    let specimenKind = passStyleOf(specimen);
-    if (specimenKind !== 'tagged') {
-      if (specimenKind === kind) {
-        // passStyleOf already did all the invariant checking.
-        return true;
-      }
-    } else {
-      specimenKind = getTag(specimen);
-      if (specimenKind === kind) {
-        const matchHelper = maybeMatchHelper(kind);
-        if (matchHelper) {
-          // Buried here is the important case, where we process
-          // the various patternNodes
-          return matchHelper.checkIsWellFormed(specimen.payload, check);
-        }
-        switch (kind) {
-          case 'copySet': {
-            return checkCopySet(specimen, check);
-          }
-          case 'copyBag': {
-            return checkCopyBag(specimen, check);
-          }
-          case 'copyMap': {
-            return checkCopyMap(specimen, check);
-          }
-          default: {
-            return check(false, X`cannot check unrecognized tag ${q(kind)}`);
-          }
-        }
-      }
-    }
-    // quoting without quotes
-    const details = X([`${specimenKind} `, ` - Must be a ${kind}`], specimen);
-    return check(false, details);
   };
 
   const arrayEveryMatchPattern = (array, patt, check, labelPrefix = '') => {
@@ -830,10 +868,12 @@ const makePatternKit = () => {
         case 'string':
         case 'symbol':
         case 'remotable':
-        case 'undefined':
+        case 'undefined': {
           return true;
-        default:
+        }
+        default: {
           return check(false, X`${kind} keys are not supported`);
+        }
       }
     },
   });
@@ -957,6 +997,9 @@ const makePatternKit = () => {
       if (checkKind(specimen, 'remotable', identChecker)) {
         return true;
       }
+      if (check === identChecker) {
+        return false;
+      }
       let specimenKind = passStyleOf(specimen);
       if (specimenKind === 'tagged') {
         specimenKind = getTag(specimen);
@@ -974,7 +1017,7 @@ const makePatternKit = () => {
     checkIsWellFormed: (allegedRemotableDesc, check) =>
       checkMatches(
         allegedRemotableDesc,
-        harden({ label: M.string() }),
+        harden({ label: MM.string() }),
         check,
         'match:remotable payload',
       ),
@@ -1112,7 +1155,7 @@ const makePatternKit = () => {
     checkIsWellFormed: (payload, check) =>
       checkIsWellFormedWithLimit(
         payload,
-        harden([M.pattern(), M.pattern()]),
+        harden([MM.pattern(), MM.pattern()]),
         check,
         'match:recordOf payload',
       ),
@@ -1140,7 +1183,7 @@ const makePatternKit = () => {
     checkIsWellFormed: (payload, check) =>
       checkIsWellFormedWithLimit(
         payload,
-        harden([M.pattern()]),
+        harden([MM.pattern()]),
         check,
         'match:arrayOf payload',
       ),
@@ -1170,7 +1213,7 @@ const makePatternKit = () => {
     checkIsWellFormed: (payload, check) =>
       checkIsWellFormedWithLimit(
         payload,
-        harden([M.pattern()]),
+        harden([MM.pattern()]),
         check,
         'match:setOf payload',
       ),
@@ -1213,7 +1256,7 @@ const makePatternKit = () => {
     checkIsWellFormed: (payload, check) =>
       checkIsWellFormedWithLimit(
         payload,
-        harden([M.pattern(), M.pattern()]),
+        harden([MM.pattern(), MM.pattern()]),
         check,
         'match:bagOf payload',
       ),
@@ -1258,7 +1301,7 @@ const makePatternKit = () => {
     checkIsWellFormed: (payload, check) =>
       checkIsWellFormedWithLimit(
         payload,
-        harden([M.pattern(), M.pattern()]),
+        harden([MM.pattern(), MM.pattern()]),
         check,
         'match:mapOf payload',
       ),
@@ -1443,6 +1486,15 @@ const makePatternKit = () => {
   const PatternShape = makeMatcher('match:pattern', undefined);
   const BooleanShape = makeKindMatcher('boolean');
   const NumberShape = makeKindMatcher('number');
+  const BigIntShape = makeTagged('match:bigint', []);
+  const NatShape = makeTagged('match:nat', []);
+  const StringShape = makeTagged('match:string', []);
+  const SymbolShape = makeTagged('match:symbol', []);
+  const RecordShape = makeTagged('match:recordOf', [AnyShape, AnyShape]);
+  const ArrayShape = makeTagged('match:arrayOf', [AnyShape]);
+  const SetShape = makeTagged('match:setOf', [AnyShape]);
+  const BagShape = makeTagged('match:bagOf', [AnyShape, AnyShape]);
+  const MapShape = makeTagged('match:mapOf', [AnyShape, AnyShape]);
   const RemotableShape = makeKindMatcher('remotable');
   const ErrorShape = makeKindMatcher('error');
   const PromiseShape = makeKindMatcher('promise');
@@ -1534,15 +1586,23 @@ const makePatternKit = () => {
     kind: makeKindMatcher,
     boolean: () => BooleanShape,
     number: () => NumberShape,
-    bigint: (limits = undefined) => makeLimitsMatcher('match:bigint', [limits]),
-    nat: (limits = undefined) => makeLimitsMatcher('match:nat', [limits]),
-    string: (limits = undefined) => makeLimitsMatcher('match:string', [limits]),
-    symbol: (limits = undefined) => makeLimitsMatcher('match:symbol', [limits]),
-    record: (limits = undefined) => M.recordOf(M.any(), M.any(), limits),
-    array: (limits = undefined) => M.arrayOf(M.any(), limits),
-    set: (limits = undefined) => M.setOf(M.any(), limits),
-    bag: (limits = undefined) => M.bagOf(M.any(), M.any(), limits),
-    map: (limits = undefined) => M.mapOf(M.any(), M.any(), limits),
+    bigint: (limits = undefined) =>
+      limits ? makeLimitsMatcher('match:bigint', [limits]) : BigIntShape,
+    nat: (limits = undefined) =>
+      limits ? makeLimitsMatcher('match:nat', [limits]) : NatShape,
+    string: (limits = undefined) =>
+      limits ? makeLimitsMatcher('match:string', [limits]) : StringShape,
+    symbol: (limits = undefined) =>
+      limits ? makeLimitsMatcher('match:symbol', [limits]) : SymbolShape,
+    record: (limits = undefined) =>
+      limits ? M.recordOf(M.any(), M.any(), limits) : RecordShape,
+    array: (limits = undefined) =>
+      limits ? M.arrayOf(M.any(), limits) : ArrayShape,
+    set: (limits = undefined) => (limits ? M.setOf(M.any(), limits) : SetShape),
+    bag: (limits = undefined) =>
+      limits ? M.bagOf(M.any(), M.any(), limits) : BagShape,
+    map: (limits = undefined) =>
+      limits ? M.mapOf(M.any(), M.any(), limits) : MapShape,
     remotable: makeRemotableMatcher,
     error: () => ErrorShape,
     promise: () => PromiseShape,
@@ -1627,3 +1687,5 @@ export const {
   getRankCover,
   M,
 } = makePatternKit();
+
+MM = M;

--- a/packages/store/test/borrow-guards.js
+++ b/packages/store/test/borrow-guards.js
@@ -1,0 +1,45 @@
+// @ts-check
+import { M } from '../src/patterns/patternMatchers.js';
+
+// The purpose of this module is to provide snapshotted (and possibly stale)
+// copies of various patterns and guards from packages that this package
+// does not depend on, except for performance testing. Besides avoiding
+// dependencies that are otherwise unnecessary, this lets these copies be
+// updated on a schedule independent of the actual, based on our tradeoffs
+// of measurement fidelity wrt the actual vs measurement comparison against
+// previous measurements.
+
+export const BrandShape = M.remotable('Brand');
+export const PaymentShape = M.remotable('Payment');
+const TimerShape = M.remotable('timerHandle');
+
+const AmountValueShape = M.or(M.nat(), M.set(), M.arrayOf(M.key()), M.bag());
+
+export const AmountShape = harden({
+  brand: BrandShape,
+  value: AmountValueShape,
+});
+
+const AmountKeywordRecordShape = M.recordOf(M.string(), AmountShape);
+const AmountPatternKeywordRecordShape = M.recordOf(M.string(), M.pattern());
+
+export const FullProposalShape = harden({
+  want: AmountPatternKeywordRecordShape,
+  give: AmountKeywordRecordShape,
+  // To accept only one, we could use M.or rather than M.partial,
+  // but the error messages would have been worse. Rather,
+  // cleanProposal's assertExit checks that there's exactly one.
+  exit: M.partial(
+    {
+      onDemand: null,
+      waived: null,
+      afterDeadline: {
+        timer: M.eref(TimerShape),
+        deadline: M.nat(),
+      },
+    },
+    {},
+  ),
+});
+
+export const ProposalShape = M.partial(FullProposalShape);

--- a/packages/store/test/perf-patterns.js
+++ b/packages/store/test/perf-patterns.js
@@ -1,0 +1,262 @@
+// @ts-check
+import '@agoric/swingset-vat/tools/prepare-test-env.js';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Far, makeTagged } from '@endo/marshal';
+import engineGC from '@agoric/swingset-vat/src/lib-nodejs/engine-gc.js';
+import { makeGcAndFinalize } from '@agoric/swingset-vat/src/lib-nodejs/gc-and-finalize.js';
+
+import { makeCopyBag, makeCopyMap, makeCopySet } from '../src/keys/checkKey.js';
+import { matches, M } from '../src/patterns/patternMatchers.js';
+import {
+  AmountShape,
+  BrandShape,
+  FullProposalShape,
+  PaymentShape,
+  ProposalShape,
+} from './borrow-guards.js';
+import '../src/types.js';
+
+const gcAndFinalize = makeGcAndFinalize(engineGC);
+
+const measurements = [];
+/**
+ * @typedef MatchTest
+ * @property {Passable} specimen
+ * @property {Pattern[]} yesPatterns
+ */
+
+/** @type {MatchTest[]} */
+const matchTests = harden([
+  {
+    specimen: 3,
+    yesPatterns: [
+      3,
+      M.any(),
+      M.not(4),
+      M.kind('number'),
+      M.number(),
+      M.lte(7),
+      M.gte(2),
+      M.and(3, 3),
+      M.or(3, 4),
+      M.and(),
+
+      M.scalar(),
+      M.key(),
+      M.pattern(),
+    ],
+  },
+  {
+    specimen: [3, 4],
+    yesPatterns: [
+      [3, 4],
+      [M.number(), M.any()],
+      [M.lte(3), M.gte(3)],
+      // Arrays compare lexicographically
+      M.gte([3, 3]),
+      M.lte([4, 4]),
+      M.gte([3]),
+      M.lte([3, 4, 1]),
+
+      M.split([3], [4]),
+      M.split([3]),
+      M.split([3], M.array()),
+      M.split([3, 4], []),
+      M.split([], [3, 4]),
+
+      M.partial([3], [4]),
+      M.partial([3, 4, 5, 6]),
+      M.partial([3, 4, 5, 6], []),
+
+      M.array(),
+      M.key(),
+      M.pattern(),
+      M.arrayOf(M.number()),
+    ],
+  },
+  {
+    specimen: { foo: 3, bar: 4 },
+    yesPatterns: [
+      { foo: 3, bar: 4 },
+      { foo: M.number(), bar: M.any() },
+      { foo: M.lte(3), bar: M.gte(3) },
+      // Records compare pareto
+      M.gte({ foo: 3, bar: 3 }),
+      M.lte({ foo: 4, bar: 4 }),
+
+      M.split(
+        { foo: M.number() },
+        M.and(M.partial({ bar: M.number() }), M.partial({ baz: M.number() })),
+      ),
+
+      M.split(
+        { foo: M.number() },
+        M.partial({ bar: M.number(), baz: M.number() }),
+      ),
+
+      M.split({ foo: 3 }, { bar: 4 }),
+      M.split({ bar: 4 }, { foo: 3 }),
+      M.split({ foo: 3 }),
+      M.split({ foo: 3 }, M.record()),
+      M.split({}, { foo: 3, bar: 4 }),
+      M.split({ foo: 3, bar: 4 }, {}),
+
+      M.partial({ zip: 5, zap: 6 }),
+      M.partial({ zip: 5, zap: 6 }, { foo: 3, bar: 4 }),
+      M.partial({ foo: 3, zip: 5 }, { bar: 4 }),
+
+      M.record(),
+      M.key(),
+      M.pattern(),
+      M.recordOf(M.string(), M.number()),
+    ],
+  },
+  {
+    specimen: makeCopySet([3, 4]),
+    yesPatterns: [
+      makeCopySet([4, 3]),
+      M.gte(makeCopySet([])),
+      M.lte(makeCopySet([3, 4, 5])),
+      M.set(),
+      M.setOf(M.number()),
+    ],
+  },
+  {
+    specimen: makeCopyBag([
+      ['a', 2n],
+      ['b', 3n],
+    ]),
+    yesPatterns: [
+      M.gt(makeCopyBag([])),
+      M.gt(makeCopyBag([['a', 2n]])),
+      M.gt(
+        makeCopyBag([
+          ['a', 1n],
+          ['b', 3n],
+        ]),
+      ),
+      M.bag(),
+      M.bagOf(M.string()),
+      M.bagOf(M.string(), M.lt(5n)),
+    ],
+  },
+  {
+    specimen: makeCopyMap([
+      [{}, 'a'],
+      [{ foo: 3 }, 'b'],
+    ]),
+    yesPatterns: [
+      // M.gt(makeCopyMap([])), Map comparison not yet implemented
+      M.map(),
+      M.mapOf(M.record(), M.string()),
+    ],
+  },
+  {
+    specimen: makeTagged('mysteryTag', 88),
+    yesPatterns: [M.any(), M.not(M.pattern())],
+  },
+  {
+    specimen: makeTagged('match:any', undefined),
+    yesPatterns: [M.any(), M.pattern()],
+  },
+  {
+    specimen: makeTagged('match:any', 88),
+    yesPatterns: [M.any(), M.not(M.pattern())],
+    noPatterns: [[M.pattern(), 'match:any payload: 88 - Must be undefined']],
+  },
+  {
+    specimen: makeTagged('match:remotable', 88),
+    yesPatterns: [M.any(), M.not(M.pattern())],
+  },
+  {
+    specimen: makeTagged('match:remotable', harden({ label: 88 })),
+    yesPatterns: [M.any(), M.not(M.pattern())],
+  },
+  {
+    specimen: makeTagged('match:recordOf', harden([M.string(), M.nat()])),
+    yesPatterns: [M.pattern()],
+  },
+  {
+    specimen: makeTagged(
+      'match:recordOf',
+      harden([M.string(), Promise.resolve(null)]),
+    ),
+    yesPatterns: [M.any(), M.not(M.pattern())],
+  },
+]);
+
+const makeBatch = testCases => {
+  const specimens = [];
+  const patterns = [];
+  for (const { specimen, yesPatterns } of testCases) {
+    for (const yesPattern of yesPatterns) {
+      specimens.push(specimen);
+      patterns.push(yesPattern);
+    }
+  }
+  return harden({ specimens, patterns });
+};
+
+const repetitions = 200;
+
+// export NODE_OPTIONS="--jitless --cpu-prof --heap-prof --expose-gc"
+// NODE_OPTIONS="--jitless" node --cpu-prof --prof test/perf-patterns.js
+// node --prof-process isolate-0x140008000-36726-v8.log > processed.txt
+// node --prof test/perf-patterns.js
+// node --prof-process isolate-0x130008000-37133-v8.log > processed.txt
+
+const measure = async (title, specimen, yesPattern, factor = 1) => {
+  const times = factor * repetitions;
+  await gcAndFinalize();
+  const startAt = Date.now();
+  for (let j = 0; j < times; j += 1) {
+    // fit(specimen, yesPattern);
+    assert(matches(specimen, yesPattern), title);
+  }
+  const totalTime = Date.now() - startAt;
+  const perStep = totalTime / times;
+  measurements.push([title, perStep, Math.round(1000 / perStep)]);
+  console.log(
+    `test '${title}': ${times} repetitions took ${totalTime}ms;  each: ${perStep}ms`,
+  );
+};
+
+const brand = Far('fungible brand', {});
+const amount1000 = harden({
+  brand,
+  value: 1000n,
+});
+const payment1000 = Far('fungible payment', {});
+
+const proposal = harden({
+  give: { In: amount1000 },
+  want: { Out: amount1000 },
+  exit: { onDemand: null },
+});
+const smallArray = harden([1, 2, 3]);
+const bigArray = harden([...Array(10000).keys()]);
+
+const allMeasures = async () => {
+  await measure('amount', amount1000, AmountShape, 100);
+  await measure('array big', bigArray, M.array(), 400);
+  await measure('array big ANY', bigArray, M.any(), 2000);
+  await measure('array small', smallArray, M.array(), 500);
+  await measure('brand', brand, BrandShape, 2000);
+  await measure('empty', true, true, 1000);
+  await measure('payment', payment1000, PaymentShape, 2000);
+  await measure('full proposal', proposal, FullProposalShape, 10);
+  await measure('partial proposal', proposal, ProposalShape, 10);
+  const { specimens, patterns } = makeBatch(matchTests);
+  await measure('z base patterns', specimens, patterns, 1);
+
+  const results = measurements.sort((a, b) => (a[0] <= b[0] ? -1 : 1));
+  results.unshift(['name', 'ms', 'ops/s']);
+  console.log();
+  for (const [name, ms, ops] of results) {
+    console.log(`${name}, ${ms}, ${ops}`);
+  }
+  console.log();
+};
+
+await allMeasures();

--- a/packages/store/test/test-patterns.js
+++ b/packages/store/test/test-patterns.js
@@ -370,7 +370,7 @@ const runTests = (successCase, failCase) => {
     failCase(
       specimen,
       M.pattern(),
-      'A passable tagged "mysteryTag" is not a pattern: "[mysteryTag]"',
+      'cannot check unrecognized tag "mysteryTag": "[mysteryTag]"',
     );
   }
   {


### PR DESCRIPTION
Except for slight differences in the text of error messages, and timing of course, this PR should have no observable effect on code outside the module.

Some comparative figures from part way through development. ops/sec, so higher is better.

On the left was our pattern matching speed before we added limits. In the middle is after we added limits, causing a slowdown we found alarming. On the right is from a slightly earlier version of this PR. My current number are now slightly better than this.

As a performance oriented PR, I should note that we are not trying to do ambitious optimization. That day will come. This one is just trying to pick up some low hanging fruit in order to be good enough for now.

<img width="983" alt="image" src="https://user-images.githubusercontent.com/273868/189079709-e6dc5c09-3c32-411c-981d-ac2a2f463348.png">
