### PR TITLE
fix(vats): Mark bootstrap vats as critical

### DIFF
--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -125,6 +125,7 @@ const makeScenario = async (t, { env = process.env } = {}) => {
   const loadVat = name =>
     import(`@agoric/vats/src/vat-${name}.js`).then(ns => ns.buildRootObject());
   space.produce.loadVat.resolve(loadVat);
+  space.produce.loadCriticalVat.resolve(loadVat);
 
   const emptyRunPayment = async () => {
     const {

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -120,7 +120,7 @@ const makeFakeBridgeManager = () => {
 export const makeMockTestSpace = async log => {
   const space = /** @type {any} */ (makePromiseSpace(log));
   const { consume, produce } =
-    /** @type { BootstrapPowers & { consume: { loadVat: (n: 'mints') => MintsVat }} } */ (
+    /** @type { BootstrapPowers & { consume: { loadVat: (n: 'mints') => MintsVat, loadCriticalVat: (n: 'mints') => MintsVat }} } */ (
       space
     );
   const { agoricNames, spaces } = makeAgoricNamesAccess();
@@ -130,7 +130,7 @@ export const makeMockTestSpace = async log => {
   produce.zoe.resolve(zoe);
   produce.feeMintAccess.resolve(feeMintAccess);
 
-  produce.loadVat.resolve(name => {
+  const vatLoader = name => {
     switch (name) {
       case 'mints':
         return mintsRoot();
@@ -139,7 +139,9 @@ export const makeMockTestSpace = async log => {
       default:
         throw Error('unknown loadVat name');
     }
-  });
+  };
+  produce.loadVat.resolve(vatLoader);
+  produce.loadCriticalVat.resolve(vatLoader);
 
   const bldKit = makeIssuerKit('BLD');
   produce.bldIssuerKit.resolve(bldKit);

--- a/packages/vats/decentral-core-config.json
+++ b/packages/vats/decentral-core-config.json
@@ -3,7 +3,10 @@
   "defaultReapInterval": 1000,
   "vats": {
     "bootstrap": {
-      "sourceSpec": "@agoric/vats/src/core/boot.js"
+      "sourceSpec": "@agoric/vats/src/core/boot.js",
+      "creationOptions": {
+        "critical": true
+      }
     }
   },
   "bundles": {

--- a/packages/vats/decentral-demo-config.json
+++ b/packages/vats/decentral-demo-config.json
@@ -10,6 +10,9 @@
       "sourceSpec": "@agoric/vats/src/core/boot.js",
       "parameters": {
         "governanceActions": true
+      },
+      "creationOptions": {
+        "critical": true
       }
     }
   },

--- a/packages/vats/decentral-psm-config.json
+++ b/packages/vats/decentral-psm-config.json
@@ -11,6 +11,9 @@
           }
         ],
         "economicCommitteeAddresses": []
+      },
+      "creationOptions": {
+        "critical": true
       }
     }
   },

--- a/packages/vats/src/authorityViz.js
+++ b/packages/vats/src/authorityViz.js
@@ -109,6 +109,7 @@ const manifest2graph = manifest => {
         if (
           [
             'loadVat',
+            'loadCriticalVat',
             'client',
             'agoricNames',
             'nameHubs',

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -101,18 +101,18 @@ harden(makeVatsFromBundles);
 
 /**
  * @param { BootstrapPowers & {
- *   consume: { loadVat: ERef<VatLoader<ZoeVat>> }
+ *   consume: { loadCriticalVat: ERef<VatLoader<ZoeVat>> }
  * }} powers
  *
  * @typedef {ERef<ReturnType<import('../vat-zoe.js').buildRootObject>>} ZoeVat
  */
 export const buildZoe = async ({
-  consume: { vatAdminSvc, loadVat, client },
+  consume: { vatAdminSvc, loadCriticalVat, client },
   produce: { zoe, feeMintAccess },
 }) => {
   const zcfBundleName = 'zcf'; // should match config.bundles.zcf=
   const { zoeService, feeMintAccess: fma } = await E(
-    E(loadVat)('zoe'),
+    E(loadCriticalVat)('zoe'),
   ).buildZoe(vatAdminSvc, feeIssuerConfig, zcfBundleName);
 
   zoe.resolve(zoeService);
@@ -126,16 +126,16 @@ harden(buildZoe);
 
 /**
  * @param {BootstrapPowers & {
- *   consume: { loadVat: ERef<VatLoader<PriceAuthorityVat>>},
+ *   consume: { loadCriticalVat: ERef<VatLoader<PriceAuthorityVat>>},
  * }} powers
  *
  * @typedef {ERef<ReturnType<import('../vat-priceAuthority.js').buildRootObject>>} PriceAuthorityVat
  */
 export const startPriceAuthority = async ({
-  consume: { loadVat, client },
+  consume: { loadCriticalVat, client },
   produce,
 }) => {
-  const vats = { priceAuthority: E(loadVat)('priceAuthority') };
+  const vats = { priceAuthority: E(loadCriticalVat)('priceAuthority') };
   const { priceAuthority, adminFacet } = await E(
     vats.priceAuthority,
   ).makePriceAuthorityRegistry();
@@ -169,17 +169,17 @@ harden(makeOracleBrands);
  * TODO: rename this to getBoard?
  *
  * @param {BootstrapPowers & {
- *   consume: { loadVat: ERef<VatLoader<BoardVat>>
+ *   consume: { loadCriticalVat: ERef<VatLoader<BoardVat>>
  * }}} powers
  * @typedef {ERef<ReturnType<import('../vat-board.js').buildRootObject>>} BoardVat
  */
 export const makeBoard = async ({
-  consume: { loadVat, client },
+  consume: { loadCriticalVat, client },
   produce: {
     board: { resolve: resolveBoard },
   },
 }) => {
-  const board = await E(E(loadVat)('board')).getBoard();
+  const board = await E(E(loadCriticalVat)('board')).getBoard();
   resolveBoard(board);
   return E(client).assignBundle([_addr => ({ board })]);
 };
@@ -376,11 +376,11 @@ harden(mintInitialSupply);
  * Add IST (with initialSupply payment), BLD (with mint) to BankManager.
  *
  * @param { BootstrapSpace & {
- *   consume: { loadVat: ERef<VatLoader<BankVat>> },
+ *   consume: { loadCriticalVat: ERef<VatLoader<BankVat>> },
  * }} powers
  */
 export const addBankAssets = async ({
-  consume: { initialSupply, bridgeManager, loadVat, zoe },
+  consume: { initialSupply, bridgeManager, loadCriticalVat, zoe },
   produce: { bankManager, bldIssuerKit },
   installation: {
     consume: { mintHolder },
@@ -411,7 +411,9 @@ export const addBankAssets = async ({
   const bldKit = { mint: bldMint, issuer: bldIssuer, brand: bldBrand };
   bldIssuerKit.resolve(bldKit);
 
-  const bankMgr = await E(E(loadVat)('bank')).makeBankManager(bridgeManager);
+  const bankMgr = await E(E(loadCriticalVat)('bank')).makeBankManager(
+    bridgeManager,
+  );
   bankManager.resolve(bankMgr);
 
   // Sanity check: the bank manager should have a reserve module account.

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -117,15 +117,15 @@ harden(bridgeCoreEval);
 
 /**
  * @param {BootstrapPowers & {
- *   consume: { loadVat: ERef<VatLoader<ProvisioningVat>> }
+ *   consume: { loadCriticalVat: ERef<VatLoader<ProvisioningVat>> }
  * }} powers
  */
 export const makeProvisioner = async ({
-  consume: { clientCreator, loadVat },
+  consume: { clientCreator, loadCriticalVat },
   vats: { comms, vattp },
   produce: { provisioning },
 }) => {
-  const provisionerVat = await E(loadVat)('provisioning');
+  const provisionerVat = await E(loadCriticalVat)('provisioning');
   await E(provisionerVat).register(clientCreator, comms, vattp);
   provisioning.resolve(provisionerVat);
 };
@@ -290,12 +290,12 @@ harden(makeBridgeManager);
 
 /**
  * @param {BootDevices<ChainDevices> & BootstrapSpace & {
- *   consume: { loadVat: ERef<VatLoader<ChainStorageVat>> }
+ *   consume: { loadCriticalVat: ERef<VatLoader<ChainStorageVat>> }
  * }} powers
  */
 export const makeChainStorage = async ({
   devices: { bridge },
-  consume: { loadVat },
+  consume: { loadCriticalVat },
   produce: { chainStorage: chainStorageP },
 }) => {
   if (!bridge) {
@@ -306,7 +306,7 @@ export const makeChainStorage = async ({
 
   const ROOT_PATH = STORAGE_PATH.CUSTOM;
 
-  const vat = E(loadVat)('chainStorage');
+  const vat = E(loadCriticalVat)('chainStorage');
   const rootNodeP = E(vat).makeBridgedChainStorageRoot(
     bridge,
     BRIDGE_ID.STORAGE,
@@ -418,7 +418,7 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
 
 /**
  * @param { BootstrapPowers & {
- *   consume: { loadVat: VatLoader<any> }
+ *   consume: { loadCriticalVat: VatLoader<any> }
  *   produce: { networkVat: Producer<any> }
  * }} powers
  *
@@ -429,16 +429,16 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
  * @typedef {{ network: NetworkVat, ibc: IBCVat, provisioning: ProvisioningVat}} NetVats
  */
 export const setupNetworkProtocols = async ({
-  consume: { client, loadVat, bridgeManager, provisioning },
+  consume: { client, loadCriticalVat, bridgeManager, provisioning },
   produce: { networkVat },
 }) => {
   /** @type { NetVats } */
   const vats = {
-    network: E(loadVat)('network'),
-    ibc: E(loadVat)('ibc'),
+    network: E(loadCriticalVat)('network'),
+    ibc: E(loadCriticalVat)('ibc'),
     provisioning,
   };
-  // don't proceed if loadVat fails
+  // don't proceed if loadCriticalVat fails
   await Promise.all(Object.values(vats));
 
   networkVat.reset();

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -39,6 +39,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
     produce: {
       vatAdminSvc: 'vatAdmin',
       loadVat: true,
+      loadCriticalVat: true,
       vatStore: true,
     },
   },
@@ -227,6 +228,7 @@ export const CLIENT_BOOTSTRAP_MANIFEST = harden({
     produce: {
       vatAdminSvc: 'vatAdmin',
       loadVat: true,
+      loadCriticalVat: true,
       vatStore: true,
     },
   },

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -22,7 +22,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
     },
   },
   startPriceAuthority: {
-    consume: { loadVat: true, client: true },
+    consume: { loadCriticalVat: true, client: true },
     produce: {
       priceAuthorityVat: 'priceAuthority',
       priceAuthority: 'priceAuthority',
@@ -46,7 +46,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
   buildZoe: {
     consume: {
       vatAdminSvc: true,
-      loadVat: true,
+      loadCriticalVat: true,
       client: true,
     },
     produce: {
@@ -56,7 +56,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
   },
   makeBoard: {
     consume: {
-      loadVat: true,
+      loadCriticalVat: true,
       client: true,
     },
     produce: {
@@ -96,7 +96,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
   },
   makeChainStorage: {
     devices: { bridge: 'kernel' },
-    consume: { loadVat: true },
+    consume: { loadCriticalVat: true },
     produce: {
       chainStorage: 'chainStorage',
     },
@@ -154,8 +154,8 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
     consume: {
       initialSupply: true,
       bridgeManager: true,
-      // TODO: re-org loadVat to be subject to permits
-      loadVat: true,
+      // TODO: re-org loadCriticalVat to be subject to permits
+      loadCriticalVat: true,
       zoe: true,
     },
     produce: {
@@ -170,7 +170,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
   },
   makeProvisioner: {
     consume: {
-      loadVat: true,
+      loadCriticalVat: true,
       clientCreator: true,
     },
     produce: {
@@ -196,7 +196,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
   setupNetworkProtocols: {
     consume: {
       client: true,
-      loadVat: true,
+      loadCriticalVat: true,
       bridgeManager: true,
       zoe: true,
       provisioning: true,

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -243,6 +243,7 @@
  *     vatAdminSvc: VatAdminSvc,
  *   }> & { produce: {
  *     loadVat: Producer<VatLoader<unknown>>,
+ *     loadCriticalVat: Producer<VatLoader<unknown>>,
  *   }}
  * } BootstrapSpace
  * @typedef {{ mint: ERef<Mint>, issuer: ERef<Issuer>, brand: Brand }} RemoteIssuerKit

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -83,9 +83,11 @@ const testRole = (ROLE, governanceActions) => {
       return createVat(bundleCap);
     };
 
+    const criticalVatKey = harden({});
     const vats = {
       ...mock.vats,
       vatAdmin: /** @type { any } */ ({
+        getCriticalVatKey: () => criticalVatKey,
         createVatAdminService: () =>
           Far('vatAdminSvc', { getNamedBundleCap, createVat, createVatByName }),
       }),

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -56,7 +56,9 @@ harden(setUpZoeForTest);
 test('connectFaucet produces payments', async t => {
   const space = /** @type {any} */ (makePromiseSpace(t.log));
   const { consume, produce } =
-    /** @type { BootstrapPowers & { consume: { loadVat: LoadVat }} } */ (space);
+    /** @type { BootstrapPowers & { consume: { loadVat: LoadVat, loadCriticalVat: LoadVat }} } */ (
+      space
+    );
   const { agoricNames, spaces } = makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
 
@@ -65,7 +67,7 @@ test('connectFaucet produces payments', async t => {
   produce.feeMintAccess.resolve(feeMintAccess);
   produce.bridgeManager.resolve(undefined);
 
-  produce.loadVat.resolve(name => {
+  const vatLoader = name => {
     switch (name) {
       case 'mints':
         return mintsRoot();
@@ -74,7 +76,9 @@ test('connectFaucet produces payments', async t => {
       default:
         throw Error('unknown loadVat name');
     }
-  });
+  };
+  produce.loadVat.resolve(vatLoader);
+  produce.loadCriticalVat.resolve(vatLoader);
 
   t.plan(4); // be sure bank.deposit() gets called
 

--- a/packages/vats/test/test-vat-bank.js
+++ b/packages/vats/test/test-vat-bank.js
@@ -201,7 +201,7 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
   // Supply bootstrap prerequisites.
   const space = /** @type { any } */ (makePromiseSpace(t.log));
   const { produce, consume } =
-    /** @type { BootstrapPowers & { consume: { loadVat: VatLoader<any> }}} */ (
+    /** @type { BootstrapPowers & { consume: { loadCriticalVat: VatLoader<any> }}} */ (
       space
     );
   const { agoricNames, spaces } = makeAgoricNamesAccess();

--- a/packages/vats/test/test-vat-bank.js
+++ b/packages/vats/test/test-vat-bank.js
@@ -265,11 +265,11 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
     'initialSupply of 50 RUN',
   );
 
-  const loadVat = async name => {
+  const loadCriticalVat = async name => {
     assert.equal(name, 'bank');
     return E(buildRootObject)();
   };
-  produce.loadVat.resolve(loadVat);
+  produce.loadCriticalVat.resolve(loadCriticalVat);
   produce.bridgeManager.resolve(undefined);
 
   await addBankAssets({ consume, produce, ...spaces });

--- a/packages/vats/tools/boot-test-utils.js
+++ b/packages/vats/tools/boot-test-utils.js
@@ -111,9 +111,11 @@ export const mockSwingsetVats = mock => {
     return createVat(bundleCap);
   };
 
+  const criticalVatKey = harden({});
   const vats = {
     ...mock.vats,
     vatAdmin: /** @type { any } */ ({
+      getCriticalVatKey: () => criticalVatKey,
       createVatAdminService: () =>
         Far('vatAdminSvc', { getNamedBundleCap, createVat, createVatByName }),
     }),

--- a/packages/wallet/contract/test/supports.js
+++ b/packages/wallet/contract/test/supports.js
@@ -85,7 +85,7 @@ harden(setUpZoeForTest);
 export const makeTestSpace = async log => {
   const space = /** @type {any} */ (makePromiseSpace(log));
   const { consume, produce } =
-    /** @type { BootstrapPowers & { consume: { loadVat: (n: 'mints') => MintsVat }} } */ (
+    /** @type { BootstrapPowers & { consume: { loadVat: (n: 'mints') => MintsVat, loadCriticalVat: (n: 'mints') => MintsVat }} } */ (
       space
     );
   const { agoricNames, spaces } = makeAgoricNamesAccess();
@@ -95,7 +95,7 @@ export const makeTestSpace = async log => {
   produce.zoe.resolve(zoe);
   produce.feeMintAccess.resolve(feeMintAccess);
 
-  produce.loadVat.resolve(name => {
+  const vatLoader = name => {
     switch (name) {
       case 'mints':
         return mintsRoot();
@@ -104,7 +104,9 @@ export const makeTestSpace = async log => {
       default:
         throw Error('unknown loadVat name');
     }
-  });
+  };
+  produce.loadVat.resolve(vatLoader);
+  produce.loadCriticalVat.resolve(vatLoader);
 
   const bldKit = makeIssuerKit('BLD');
   produce.bldIssuerKit.resolve(bldKit);


### PR DESCRIPTION
closes: #6051

## Description
* Update bootstrap vats to launch as critical.
* Define a new `loadCriticalVat` variant of `loadVat`.
* Update current dynamic vats to be launched with the new variant.

### Security Considerations

`loadCriticalVat` is inherently more powerful than `loadVat`, but that power is managed by being a distinct deniable value produced by makeVatsFromBundles.

### Documentation Considerations

https://github.com/Agoric/agoric-sdk/blob/master/packages/SwingSet/docs/dynamic-vats.md mentions `createVat` but not `loadVat`, has it gone stale?

### Testing Considerations

Help wanted!