### PR TITLE
feat: ensure voting via PSMCharter works with a unit test

### DIFF
--- a/packages/cosmic-swingset/economy-template.json
+++ b/packages/cosmic-swingset/economy-template.json
@@ -70,10 +70,7 @@
     "entrypoint": "defaultProposalBuilder",
     "args": [
       {
-        "voterAddresses": [
-          "@FIRST_SOLO_ADDRESS@"
-        ]
-      }
+        "voterAddresses": { "someone": "@FIRST_SOLO_ADDRESS@" }      }
     ]
   }
 ]

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -63,7 +63,10 @@ const start = (zcf, privateArgs) => {
         ).returns(M.promise()),
       });
       const InvitationMakerI = M.interface('invitationMaker', {
-        makeVoteInvitation: M.call(QuestionHandleShape).returns(M.promise()),
+        makeVoteInvitation: M.call(
+          M.arrayOf(PositionShape),
+          QuestionHandleShape,
+        ).returns(M.promise()),
       });
 
       // CRUCIAL: voteCap carries the ability to cast votes for any voter at
@@ -82,8 +85,8 @@ const start = (zcf, privateArgs) => {
           'invitation makers',
           InvitationMakerI,
           {
-            makeVoteInvitation(questionHandle) {
-              const continuingVoteHandler = (cSeat, { positions }) => {
+            makeVoteInvitation(positions, questionHandle) {
+              const continuingVoteHandler = cSeat => {
                 cSeat.exit();
                 const { voteCap } = allQuestions.get(questionHandle);
                 return E(voteCap).submitVote(voterHandle, positions, 1n);

--- a/packages/governance/src/contractGovernance/governFilter.js
+++ b/packages/governance/src/contractGovernance/governFilter.js
@@ -96,11 +96,11 @@ const setupFilterGovernance = async (
         },
       );
 
-    return {
+    return harden({
       outcomeOfUpdate,
       instance: voteCounter,
       details: E(counterPublicFacet).getDetails(),
-    };
+    });
   };
 
   return Far('filterGovernor', {

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -419,9 +419,10 @@ test('change param continuing invitation', async t => {
   const seat = E(zoe).offer(invitations[0]);
   const { invitationMakers } = E.get(E(seat).getOfferResult());
   const voteInvitation = E(invitationMakers).makeVoteInvitation(
+    [positive],
     details.questionHandle,
   );
-  await E(zoe).offer(voteInvitation, {}, {}, { positions: [positive] });
+  await E(zoe).offer(voteInvitation);
 
   await E(timer).tick();
   await E(timer).tick();

--- a/packages/inter-protocol/scripts/init-core.js
+++ b/packages/inter-protocol/scripts/init-core.js
@@ -159,7 +159,7 @@ export const defaultProposalBuilder = async (
       anchorProposedName = anchorKeyword,
     } = {},
     econCommitteeOptions: {
-      committeeSize: econCommitteeSize = env.ECON_COMMITTEE_SIZE || '1',
+      committeeSize: econCommitteeSize = env.ECON_COMMITTEE_SIZE || '3',
     } = {},
   } = options;
 

--- a/packages/inter-protocol/scripts/init-core.js
+++ b/packages/inter-protocol/scripts/init-core.js
@@ -159,7 +159,7 @@ export const defaultProposalBuilder = async (
       anchorProposedName = anchorKeyword,
     } = {},
     econCommitteeOptions: {
-      committeeSize: econCommitteeSize = env.ECON_COMMITTEE_SIZE || '3',
+      committeeSize: econCommitteeSize = env.ECON_COMMITTEE_SIZE || '1',
     } = {},
   } = options;
 

--- a/packages/inter-protocol/src/proposals/startEconCommittee.js
+++ b/packages/inter-protocol/src/proposals/startEconCommittee.js
@@ -55,7 +55,9 @@ export const startEconomicCommittee = async (
   const storageNode = await E(committeesNode).makeChildNode(
     sanitizePathSegment(committeeName),
   );
-  const marshaller = await E(board).getReadonlyMarshaller();
+
+  // NB: committee must only publish what it intended to be public
+  const marshaller = await E(board).getPublishingMarshaller();
 
   const { creatorFacet, instance } = await E(zoe).startInstance(
     committee,

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -366,7 +366,7 @@ export const invitePSMCommitteeMembers = async (
       psmCharterCreatorFacet,
     },
   },
-  { options: { voterAddresses } },
+  { options: { voterAddresses = {} } },
 ) => {
   const invitations = await E(
     economicCommitteeCreatorFacet,
@@ -398,6 +398,16 @@ export const invitePSMCommitteeMembers = async (
   await distributeInvitations(zip(values(voterAddresses), invitations));
 };
 harden(invitePSMCommitteeMembers);
+
+export const INVITE_PSM_COMMITTEE_MANIFEST = harden({
+  [invitePSMCommitteeMembers.name]: {
+    consume: {
+      namesByAddressAdmin: true,
+      economicCommitteeCreatorFacet: true,
+      psmCharterCreatorFacet: true,
+    },
+  },
+});
 
 export const PSM_MANIFEST = harden({
   [makeAnchorAsset.name]: {
@@ -435,18 +445,6 @@ export const PSM_MANIFEST = harden({
     },
     issuer: {
       consume: { AUSD: 'bank' },
-    },
-  },
-  [invitePSMCommitteeMembers.name]: {
-    consume: {
-      zoe: true,
-      namesByAddressAdmin: true,
-      economicCommitteeCreatorFacet: true,
-      psmFacets: true,
-      psmCharterCreatorFacet: true,
-    },
-    installation: {
-      consume: { binaryVoteCounter: true },
     },
   },
 });

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -169,7 +169,7 @@ export const startPSM = async (
     E(instanceAdmin).update(instanceKey, newPsmFacets.psm),
     E(psmCharterCreatorFacet).addInstance(
       psm,
-      psmCreatorFacet,
+      governorFacets.creatorFacet,
       anchorBrand,
       stable,
     ),
@@ -306,8 +306,10 @@ export const startPSMCharter = async ({
   },
 }) => {
   const [charterR, counterR] = await Promise.all([installP, binaryVoteCounter]);
+
   const terms = { binaryVoteCounterInstallation: counterR };
-  const facets = await E.get(E(zoe).startInstance(charterR, {}, terms));
+  const facets = await E(zoe).startInstance(charterR, {}, terms);
+
   instanceP.resolve(facets.instance);
   psmCharterCreatorFacet.resolve(facets.creatorFacet);
   psmCharterAdminFacet.resolve(facets.adminFacet);
@@ -358,28 +360,14 @@ const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
  */
 export const invitePSMCommitteeMembers = async (
   {
-    consume: { zoe, namesByAddressAdmin, economicCommitteeCreatorFacet },
-    installation: {
-      consume: { binaryVoteCounter: counterP, psmCharter: psmCharterP },
+    consume: {
+      namesByAddressAdmin,
+      economicCommitteeCreatorFacet,
+      psmCharterCreatorFacet,
     },
   },
   { options: { voterAddresses } },
 ) => {
-  /** @type {[Installation, Installation]} */
-  const [charterInstall, counterInstall] = await Promise.all([
-    psmCharterP,
-    counterP,
-  ]);
-  const terms = await deeplyFulfilledObject(
-    harden({
-      binaryVoteCounterInstallation: counterInstall,
-    }),
-  );
-
-  const { creatorFacet } = E.get(
-    E(zoe).startInstance(charterInstall, undefined, terms),
-  );
-
   const invitations = await E(
     economicCommitteeCreatorFacet,
   ).getVoterInvitations();
@@ -393,7 +381,7 @@ export const invitePSMCommitteeMembers = async (
       addrInvitations.map(async ([addr, invitationP]) => {
         const [voterInvitation, charterMemberInvitation] = await Promise.all([
           invitationP,
-          E(creatorFacet).makeCharterMemberInvitation(),
+          E(psmCharterCreatorFacet).makeCharterMemberInvitation(),
         ]);
         console.log('sending charter, voting invitations to', addr);
         await reserveThenDeposit(
@@ -455,9 +443,10 @@ export const PSM_MANIFEST = harden({
       namesByAddressAdmin: true,
       economicCommitteeCreatorFacet: true,
       psmFacets: true,
+      psmCharterCreatorFacet: true,
     },
     installation: {
-      consume: { binaryVoteCounter: true, psmCharter: true },
+      consume: { binaryVoteCounter: true },
     },
   },
 });

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -312,7 +312,6 @@ export const start = async (zcf, privateArgs, baggage) => {
   const governorFacet = makeFarGovernorFacet(limitedCreatorFacet);
   return harden({
     creatorFacet: governorFacet,
-    limitedCreatorFacet,
     publicFacet,
   });
 };

--- a/packages/inter-protocol/src/psm/psmCharter.js
+++ b/packages/inter-protocol/src/psm/psmCharter.js
@@ -18,7 +18,7 @@ import { E } from '@endo/far';
  * separate capabilities for finer grain encapsulation.
  */
 
-const paramChangesOfferArgsShape = harden({
+const ParamChangesOfferArgsShape = harden({
   instance: InstanceHandleShape,
   deadline: TimestampShape,
   params: M.recordOf(M.string(), M.any()),
@@ -43,7 +43,7 @@ export const start = async zcf => {
      * @param {bigint} args.deadline
      */
     const voteOnParamChanges = (seat, args) => {
-      fit(args, paramChangesOfferArgsShape);
+      fit(args, ParamChangesOfferArgsShape);
       seat.exit();
 
       const {
@@ -73,7 +73,7 @@ export const start = async zcf => {
     return zcf.makeInvitation(voteOnOfferFilterHandler, 'vote on offer filter');
   };
 
-  const makerShape = M.interface('PSM Charter InvitationMakers', {
+  const MakerShape = M.interface('PSM Charter InvitationMakers', {
     VoteOnParamChange: M.call().returns(M.promise()),
     VoteOnPauseOffers: M.call(
       InstanceHandleShape,
@@ -83,7 +83,7 @@ export const start = async zcf => {
   });
   const invitationMakers = makeHeapFarInstance(
     'PSM Invitation Makers',
-    makerShape,
+    MakerShape,
     {
       VoteOnParamChange: makeParamInvitation,
       VoteOnPauseOffers: makeOfferFilterInvitation,
@@ -129,3 +129,5 @@ export const start = async zcf => {
 
   return harden({ creatorFacet });
 };
+
+export const INVITATION_MAKERS_DESC = 'PSM charter member invitation';

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -16,7 +16,11 @@ import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { makeMockChainStorageRoot } from '@agoric/vats/tools/storage-test-utils.js';
 import { makeIssuerKit } from '@agoric/ertp';
 
-import { installGovernance, provideBundle } from '../supports.js';
+import {
+  installGovernance,
+  provideBundle,
+  withAmountUtils,
+} from '../supports.js';
 import { startEconomicCommittee } from '../../src/proposals/startEconCommittee.js';
 import { startPSM, startPSMCharter } from '../../src/proposals/startPSM.js';
 import { allValues } from '../../src/collect.js';
@@ -99,7 +103,8 @@ export const setupPsm = async (
     farZoeKit = await setUpZoeForTest();
   }
 
-  const knutIssuerKit = makeIssuerKit('KNUT');
+  const knut = withAmountUtils(makeIssuerKit('KNUT'));
+
   const { feeMintAccess, zoe } = farZoeKit;
   const space = await setupPsmBootstrap(timer, farZoeKit);
   space.produce.zoe.resolve(farZoeKit.zoe);
@@ -110,8 +115,8 @@ export const setupPsm = async (
   const psmCharterBundle = await provideBundle(t, psmCharterRoot, 'psmCharter');
   installation.produce.psmCharter.resolve(E(zoe).install(psmCharterBundle));
 
-  brand.produce.AUSD.resolve(knutIssuerKit.brand);
-  issuer.produce.AUSD.resolve(knutIssuerKit.issuer);
+  brand.produce.AUSD.resolve(knut.brand);
+  issuer.produce.AUSD.resolve(knut.issuer);
 
   space.produce.psmFacets.resolve(makeScalarMapStore());
   const istIssuer = await E(zoe).getFeeIssuer();
@@ -154,7 +159,7 @@ export const setupPsm = async (
   });
 
   const allPsms = await consume.psmFacets;
-  const psmFacets = allPsms.get(knutIssuerKit.brand);
+  const psmFacets = allPsms.get(knut.brand);
   const governorCreatorFacet = psmFacets.psmGovernorCreatorFacet;
   const governorInstance = psmFacets.psmGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
@@ -194,7 +199,7 @@ export const setupPsm = async (
     invitationAmount: poserInvitationAmount,
     mockChainStorage: space.mockChainStorage,
     space,
-    knutIssuerKit,
+    knut,
   };
 };
 harden(setupPsm);

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -99,7 +99,7 @@ export const setupPsm = async (
     farZoeKit = await setUpZoeForTest();
   }
 
-  const knutIssuer = makeIssuerKit('KNUT');
+  const knutIssuerKit = makeIssuerKit('KNUT');
   const { feeMintAccess, zoe } = farZoeKit;
   const space = await setupPsmBootstrap(timer, farZoeKit);
   space.produce.zoe.resolve(farZoeKit.zoe);
@@ -110,8 +110,8 @@ export const setupPsm = async (
   const psmCharterBundle = await provideBundle(t, psmCharterRoot, 'psmCharter');
   installation.produce.psmCharter.resolve(E(zoe).install(psmCharterBundle));
 
-  brand.produce.AUSD.resolve(knutIssuer.brand);
-  issuer.produce.AUSD.resolve(knutIssuer.issuer);
+  brand.produce.AUSD.resolve(knutIssuerKit.brand);
+  issuer.produce.AUSD.resolve(knutIssuerKit.issuer);
 
   space.produce.psmFacets.resolve(makeScalarMapStore());
   const istIssuer = await E(zoe).getFeeIssuer();
@@ -154,7 +154,7 @@ export const setupPsm = async (
   });
 
   const allPsms = await consume.psmFacets;
-  const psmFacets = allPsms.get(knutIssuer.brand);
+  const psmFacets = allPsms.get(knutIssuerKit.brand);
   const governorCreatorFacet = psmFacets.psmGovernorCreatorFacet;
   const governorInstance = psmFacets.psmGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
@@ -175,6 +175,7 @@ export const setupPsm = async (
 
   const committeeCreator = await consume.economicCommitteeCreatorFacet;
   const electorateInstance = await instance.consume.economicCommittee;
+  const psmCharterCreatorFacet = await consume.psmCharterCreatorFacet;
 
   const poserInvitationP = E(committeeCreator).getPoserInvitation();
   const poserInvitationAmount = await E(
@@ -189,10 +190,11 @@ export const setupPsm = async (
     electorateInstance,
     governor: g,
     psm,
+    psmCharterCreatorFacet,
     invitationAmount: poserInvitationAmount,
     mockChainStorage: space.mockChainStorage,
     space,
-    knutIssuer,
+    knutIssuerKit,
   };
 };
 harden(setupPsm);

--- a/packages/inter-protocol/test/psm/test-governedPsm.js
+++ b/packages/inter-protocol/test/psm/test-governedPsm.js
@@ -71,9 +71,9 @@ test('psm block offers w/charter', async t => {
   ).makeCharterMemberInvitation();
 
   const cmSeat = E(zoe).offer(cmInvitation);
-  const result = await E(cmSeat).getOfferResult();
+  const { invitationMakers } = await E(cmSeat).getOfferResult();
 
-  const proposeInvitation = await E(result.invitationMakers).VoteOnPauseOffers(
+  const proposeInvitation = await E(invitationMakers).VoteOnPauseOffers(
     await psm.instance,
     ['wantMinted'],
     2n,
@@ -141,8 +141,8 @@ test('psm block offers w/charter via invitationMakers', async t => {
 
   const exerciseAndVote = async invitation => {
     const seat = E(zoe).offer(invitation);
-    const voteFacet = await E.get(E(seat).getOfferResult());
-    E(voteFacet.voter).castBallotFor(questionHandle, [positions[0]]);
+    const { voter } = await E.get(E(seat).getOfferResult());
+    E(voter).castBallotFor(questionHandle, [positions[0]]);
   };
   await Promise.all(invitations.map(exerciseAndVote));
 

--- a/packages/inter-protocol/test/psm/test-governedPsm.js
+++ b/packages/inter-protocol/test/psm/test-governedPsm.js
@@ -1,8 +1,6 @@
 // @ts-check
 
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-
-import { AmountMath } from '@agoric/ertp';
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
@@ -18,7 +16,7 @@ test('psm block offers w/Governance', async t => {
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
   const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });
 
-  const { knutIssuerKit, zoe, psm, committeeCreator, governor, installs } =
+  const { knut, zoe, psm, committeeCreator, governor, installs } =
     await setupPsm(t, electorateTerms, timer);
 
   const invitations = await E(committeeCreator).getVoterInvitations();
@@ -44,14 +42,14 @@ test('psm block offers w/Governance', async t => {
 
   t.deepEqual(['wantMinted'], await E(zoe).getOfferFilter(psm.instance));
 
-  const giveCentral = AmountMath.make(knutIssuerKit.brand, 1_000_000n);
+  const giveCentral = knut.make(1_000_000n);
 
   await t.throwsAsync(
     () =>
       E(zoe).offer(
         E(psm.psmPublicFacet).makeWantMintedInvitation(),
         harden({ give: { In: giveCentral } }),
-        harden({ In: knutIssuerKit.mint.mintPayment(giveCentral) }),
+        harden({ In: knut.mint.mintPayment(giveCentral) }),
       ),
     { message: 'not accepting offer with description "wantMinted"' },
   );
@@ -61,10 +59,8 @@ test('psm block offers w/charter', async t => {
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
   const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });
 
-  const { knutIssuerKit, zoe, psm, committeeCreator, psmCharterCreatorFacet } =
+  const { knut, zoe, psm, committeeCreator, psmCharterCreatorFacet } =
     await setupPsm(t, electorateTerms, timer);
-
-  const knutBrand = knutIssuerKit.brand;
 
   // onchain, the invitations get sent to the committee member via their
   // registered deposit facets. We'll skip that here.
@@ -102,14 +98,13 @@ test('psm block offers w/charter', async t => {
 
   t.deepEqual(['wantMinted'], await E(zoe).getOfferFilter(psm.instance));
 
-  const giveCentral = AmountMath.make(knutBrand, 1_000_000n);
-
+  const giveCentral = knut.make(1_000_000n);
   await t.throwsAsync(
     () =>
       E(zoe).offer(
         E(psm.psmPublicFacet).makeWantMintedInvitation(),
         harden({ give: { In: giveCentral } }),
-        harden({ In: knutIssuerKit.mint.mintPayment(giveCentral) }),
+        harden({ In: knut.mint.mintPayment(giveCentral) }),
       ),
     { message: 'not accepting offer with description "wantMinted"' },
   );
@@ -119,10 +114,8 @@ test('psm block offers w/charter via invitationMakers', async t => {
   const electorateTerms = { committeeName: 'EnBancPanel', committeeSize: 3 };
   const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });
 
-  const { knutIssuerKit, zoe, psm, committeeCreator, psmCharterCreatorFacet } =
+  const { knut, zoe, psm, committeeCreator, psmCharterCreatorFacet } =
     await setupPsm(t, electorateTerms, timer);
-
-  const knutBrand = knutIssuerKit.brand;
 
   // onchain, the invitations get sent to the committee member via their
   // registered deposit facets. We'll skip that here.
@@ -159,14 +152,13 @@ test('psm block offers w/charter via invitationMakers', async t => {
 
   t.deepEqual(['wantMinted'], await E(zoe).getOfferFilter(psm.instance));
 
-  const giveCentral = AmountMath.make(knutBrand, 1_000_000n);
-
+  const giveCentral = knut.make(1_000_000n);
   await t.throwsAsync(
     () =>
       E(zoe).offer(
         E(psm.psmPublicFacet).makeWantMintedInvitation(),
         harden({ give: { In: giveCentral } }),
-        harden({ In: knutIssuerKit.mint.mintPayment(giveCentral) }),
+        harden({ In: knut.mint.mintPayment(giveCentral) }),
       ),
     { message: 'not accepting offer with description "wantMinted"' },
   );

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -74,7 +74,7 @@ export const makeInvitationsHelper = (
         details =>
           details.description === description && details.instance === instance,
       );
-      assert(match, `invitation not found: ${description}`);
+      assert(match, `no matching invitation for ${description}`);
       const toWithDraw = AmountMath.make(invitationBrand, harden([match]));
       console.log('.... ', { toWithDraw });
 

--- a/packages/smart-wallet/test/test-psm-integration.js
+++ b/packages/smart-wallet/test/test-psm-integration.js
@@ -181,7 +181,7 @@ test('govern offerFilter', async t => {
    * @param {string} desc
    * @param {number} len
    * @param {any} balances XXX please improve this
-   * @returns {Promise<{description: string, instance: Instance}>}
+   * @returns {Promise<[{description: string, instance: Instance}]>}
    */
   const getInvitationFor = async (desc, len, balances) =>
     // @ts-expect-error TS can't tell that it's going to satisfy the @returns.

--- a/packages/vats/decentral-demo-config.json
+++ b/packages/vats/decentral-demo-config.json
@@ -9,7 +9,8 @@
     "bootstrap": {
       "sourceSpec": "@agoric/vats/src/core/boot.js",
       "parameters": {
-        "governanceActions": true
+        "governanceActions": true,
+        "economicCommitteeAddresses": { "voter":  "agoric1Ersatz" }
       },
       "creationOptions": {
         "critical": true

--- a/packages/vats/decentral-psm-config.json
+++ b/packages/vats/decentral-psm-config.json
@@ -10,7 +10,7 @@
             "denom": "ibc/usdc1234"
           }
         ],
-        "economicCommitteeAddresses": {}
+        "economicCommitteeAddresses": { "voter":  "agoric1ersatz"}
       },
       "creationOptions": {
         "critical": true

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -8,6 +8,7 @@ import {
   PSM_MANIFEST,
   PSM_GOV_MANIFEST,
   startPSMCharter,
+  INVITE_PSM_COMMITTEE_MANIFEST,
 } from '@agoric/inter-protocol/src/proposals/startPSM.js';
 import * as startPSMmod from '@agoric/inter-protocol/src/proposals/startPSM.js';
 import * as ERTPmod from '@agoric/ertp';
@@ -150,6 +151,7 @@ export const buildRootObject = (vatPowers, vatParameters) => {
       ...PSM_GOV_MANIFEST,
       ...ECON_COMMITTEE_MANIFEST,
       ...PSM_MANIFEST,
+      ...INVITE_PSM_COMMITTEE_MANIFEST,
     };
     /** @param {string} name */
     const powersFor = name => {

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -72,6 +72,7 @@ export const agoricNamesReserved = harden(
     instance: {
       economicCommittee: 'Economic Committee',
       'psm-IST-AUSD': 'Parity Stability Module: IST:AUSD',
+      psmCharter: 'Charter for the PSM',
     },
   }),
 );


### PR DESCRIPTION
refs: #6110

## Description

On the path to end-to-end test of PSM voting by committee members, this unit test demonstrates (and makes it be the case) that votes can be instigated and carried out through the PSM Charter.

### Security Considerations

The Charter will be accessible to committee members, who will use it to start up votes.

### Documentation Considerations

Yes

### Testing Considerations

This shows, via unit test, that the Charter can be used to start votes.
