### PR TITLE
feat(smartWallet): defer deposits until purse available

### DIFF
--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { AmountShape, PaymentShape } from '@agoric/ertp';
+import { AmountMath, AmountShape, PaymentShape } from '@agoric/ertp';
 import { isNat } from '@agoric/nat';
 import {
   makeStoredPublishKit,
@@ -284,7 +284,7 @@ const behavior = {
      * If the purse doesn't exist, we hold the payment until it does.
      *
      * @param {import('@endo/far').FarRef<Payment>} payment
-     * @returns {Promise<Amount | 'deferred'>}
+     * @returns {Promise<Amount>} amounts for deferred deposits will be empty
      */
     async receive(payment) {
       /** @type {State} */
@@ -297,7 +297,7 @@ const behavior = {
         } else {
           queues.init(brand, [payment]);
         }
-        return 'deferred';
+        return AmountMath.makeEmpty(brand);
       }
 
       // @ts-expect-error deposit does take a FarRef<Payment>
@@ -322,7 +322,7 @@ const behavior = {
      * @throws if any parts of the offer can be determined synchronously to be invalid
      */
     async executeOffer(offerSpec) {
-      const { state } = this;
+      const { facets, state } = this;
       const {
         zoe,
         brandPurses,
@@ -335,6 +335,7 @@ const behavior = {
 
       const executor = makeOfferExecutor({
         zoe,
+        depositFacet: facets.deposit,
         powers: {
           invitationFromSpec: makeInvitationsHelper(
             zoe,

--- a/packages/smart-wallet/test/test-psm-integration.js
+++ b/packages/smart-wallet/test/test-psm-integration.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { AmountMath } from '@agoric/ertp';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { buildRootObject as buildPSMRootObject } from '@agoric/vats/src/core/boot-psm.js';
 import '@agoric/vats/src/core/types.js';
 import { Stable } from '@agoric/vats/src/tokens.js';
@@ -14,6 +14,7 @@ import { E } from '@endo/far';
 import { NonNullish } from '@agoric/assert';
 import { coalesceUpdates } from '../src/utils.js';
 import { makeDefaultTestContext } from './contexts.js';
+import { withAmountUtils } from './supports.js';
 
 /**
  * @type {import('ava').TestFn<Awaited<ReturnType<makeDefaultTestContext>>
@@ -256,6 +257,18 @@ test.skip('govern offerFilter', async t => {
     id: 44,
     result: { chosen: { strings: ['wantStable'] }, shares: 1n },
   });
+});
+
+test('deposit unknown brand', async t => {
+  const rial = withAmountUtils(makeIssuerKit('rial'));
+  assert(rial.mint);
+
+  const wallet = await t.context.simpleProvideWallet('agoric1queue');
+
+  const payment = rial.mint.mintPayment(rial.make(1_000n));
+  const result = await wallet.getDepositFacet().receive(harden(payment));
+  // successful request but not deposited
+  t.deepEqual(result, { brand: rial.brand, value: 0n });
 });
 
 test.todo('bad offer schema');


### PR DESCRIPTION
supporting #6157 

## Description

Some brands aren't available when a payments to the deposit facet. In this case we now hold the payments in a queue and when the purse is available we deposit all of them.

The payouts handler now uses the deposit facet to get the same feature. It also attempts each payout separately instead of the previous behavior of blocking until all payments were available.

### Security Considerations

Deposits are unpermissioned so queuing them opens an attack to grow the queue unbounded. The collections are durable which should mitigate RAM consumption. If there are more problems in practice the queue size can be capped. I considered doing that in this PR but considered a worse vulnerability is for an attacker to fill the queue of a wallet and prevent legitimate deposits.


### Documentation Considerations

--
### Testing Considerations

--