### PR TITLE
fix: alt syntax for positive but faster assertions

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -25,11 +25,12 @@ const AssetKind = harden({
 const assetKindNames = harden(Object.values(AssetKind).sort());
 
 /** @type {AssertAssetKind} */
-const assertAssetKind = allegedAK =>
-  assert(
-    assetKindNames.includes(allegedAK),
-    X`The assetKind ${allegedAK} must be one of ${q(assetKindNames)}`,
-  );
+const assertAssetKind = allegedAK => {
+  assetKindNames.includes(allegedAK) ||
+    assert.fail(
+      X`The assetKind ${allegedAK} must be one of ${q(assetKindNames)}`,
+    );
+};
 harden(assertAssetKind);
 
 /**
@@ -222,10 +223,10 @@ const AmountMath = {
     assertRemotable(brand, 'brand');
     assertRecord(allegedAmount, 'amount');
     const { brand: allegedBrand, value: allegedValue } = allegedAmount;
-    assert(
-      brand === allegedBrand,
-      X`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the specified brand ${brand}.`,
-    );
+    brand === allegedBrand ||
+      assert.fail(
+        X`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the specified brand ${brand}.`,
+      );
     // Will throw on inappropriate value
     return AmountMath.make(brand, allegedValue);
   },

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -14,18 +14,18 @@ export const coerceDisplayInfo = (allegedDisplayInfo, assetKind) => {
   fit(allegedDisplayInfo, DisplayInfoShape, 'displayInfo');
 
   if (allegedDisplayInfo.assetKind !== undefined) {
-    assert(
-      allegedDisplayInfo.assetKind === assetKind,
-      X`displayInfo.assetKind was present (${allegedDisplayInfo.assetKind}) and did not match the assetKind argument (${assetKind})`,
-    );
+    allegedDisplayInfo.assetKind === assetKind ||
+      assert.fail(
+        X`displayInfo.assetKind was present (${allegedDisplayInfo.assetKind}) and did not match the assetKind argument (${assetKind})`,
+      );
   }
   const displayInfo = harden({ ...allegedDisplayInfo, assetKind });
 
   if (displayInfo.decimalPlaces !== undefined) {
-    assert(
-      Number.isSafeInteger(displayInfo.decimalPlaces),
-      X`decimalPlaces ${displayInfo.decimalPlaces} is not a safe integer`,
-    );
+    Number.isSafeInteger(displayInfo.decimalPlaces) ||
+      assert.fail(
+        X`decimalPlaces ${displayInfo.decimalPlaces} is not a safe integer`,
+      );
   }
 
   return displayInfo;

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -24,10 +24,10 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
   switch (assetKind) {
     case 'nat': {
       valueShape = M.nat();
-      assert(
-        elementShape === undefined,
-        X`Fungible assets cannot have an elementShape: ${q(elementShape)}`,
-      );
+      elementShape === undefined ||
+        assert.fail(
+          X`Fungible assets cannot have an elementShape: ${q(elementShape)}`,
+        );
       break;
     }
     case 'set': {
@@ -231,10 +231,10 @@ export const vivifyPaymentLedger = (
    * @returns {void}
    */
   const assertLivePayment = payment => {
-    assert(
-      paymentLedger.has(payment),
-      X`${payment} was not a live payment for brand ${brand}. It could be a used-up payment, a payment for another brand, or it might not be a payment at all.`,
-    );
+    paymentLedger.has(payment) ||
+      assert.fail(
+        X`${payment} was not a live payment for brand ${brand}. It could be a used-up payment, a payment for another brand, or it might not be a payment at all.`,
+      );
   };
 
   /**
@@ -265,10 +265,8 @@ export const vivifyPaymentLedger = (
     if (payments.length > 1) {
       const antiAliasingStore = new Set();
       payments.forEach(payment => {
-        assert(
-          !antiAliasingStore.has(payment),
-          X`same payment ${payment} seen twice`,
-        );
+        !antiAliasingStore.has(payment) ||
+          assert.fail(X`same payment ${payment} seen twice`);
         antiAliasingStore.add(payment);
       });
     }
@@ -278,10 +276,8 @@ export const vivifyPaymentLedger = (
     const newTotal = newPaymentBalances.reduce(add, emptyAmount);
 
     // Invariant check
-    assert(
-      isEqual(total, newTotal),
-      X`rights were not conserved: ${total} vs ${newTotal}`,
-    );
+    isEqual(total, newTotal) ||
+      assert.fail(X`rights were not conserved: ${total} vs ${newTotal}`);
 
     let newPayments;
     try {
@@ -357,10 +353,10 @@ export const vivifyPaymentLedger = (
     recoverySet,
   ) => {
     amount = coerce(amount);
-    assert(
-      AmountMath.isGTE(currentBalance, amount),
-      X`Withdrawal of ${amount} failed because the purse only contained ${currentBalance}`,
-    );
+    AmountMath.isGTE(currentBalance, amount) ||
+      assert.fail(
+        X`Withdrawal of ${amount} failed because the purse only contained ${currentBalance}`,
+      );
     const newPurseBalance = subtract(currentBalance, amount);
 
     const payment = makePayment();

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -98,10 +98,10 @@ export const vivifyPurseKind = (
             const delta = facets.purse.deposit(payment);
             amount = AmountMath.add(amount, delta, brand);
           }
-          assert(
-            state.recoverySet.getSize() === 0,
-            X`internal: Remaining unrecovered payments: ${facets.purse.getRecoverySet()}`,
-          );
+          state.recoverySet.getSize() === 0 ||
+            assert.fail(
+              X`internal: Remaining unrecovered payments: ${facets.purse.getRecoverySet()}`,
+            );
           return amount;
         },
       },

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -143,10 +143,8 @@ export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
     const worker = doXSnap({ handleCommand, name, ...meterOpts, ...xsnapOpts });
 
     for (const bundle of bundles) {
-      assert(
-        bundle.moduleFormat === 'getExport',
-        X`unexpected: ${bundle.moduleFormat}`,
-      );
+      bundle.moduleFormat === 'getExport' ||
+        assert.fail(X`unexpected: ${bundle.moduleFormat}`);
       // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       await worker.evaluate(`(${bundle.source}\n)()`.trim());
     }

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -238,10 +238,10 @@ export async function loadSwingsetConfigFile(configPath) {
     await normalizeConfigDescriptor(config.bundles, referrer, false);
     // await normalizeConfigDescriptor(config.devices, referrer, true); // TODO: represent devices
     assert(config.bootstrap, X`no designated bootstrap vat in ${configPath}`);
-    assert(
-      config.vats && config.vats[config.bootstrap],
-      X`bootstrap vat ${config.bootstrap} not found in ${configPath}`,
-    );
+    (config.vats && config.vats[config.bootstrap]) ||
+      assert.fail(
+        X`bootstrap vat ${config.bootstrap} not found in ${configPath}`,
+      );
     return config;
   } catch (e) {
     if (e.code === 'ENOENT') {
@@ -294,11 +294,8 @@ export async function initializeSwingset(
 ) {
   const kvStore = hostStorage.kvStore;
   insistStorageAPI(kvStore);
-
-  assert(
-    !swingsetIsInitialized(hostStorage),
-    X`kernel store already initialized`,
-  );
+  !swingsetIsInitialized(hostStorage) ||
+    assert.fail(X`kernel store already initialized`);
 
   // copy config so we can safely mess with it even if it's shared or hardened
   config = JSON.parse(JSON.stringify(config));

--- a/packages/SwingSet/src/devices/lib/deviceTools.js
+++ b/packages/SwingSet/src/devices/lib/deviceTools.js
@@ -50,10 +50,8 @@ export function buildSerializationTools(syscall, deviceName) {
       assert(!allocatedByVat, X`devices cannot yet allocate objects ${slot}`);
       return presenceForSlot(slot);
     } else if (type === 'device') {
-      assert(
-        allocatedByVat,
-        X`devices should yet not be given other devices '${slot}'`,
-      );
+      allocatedByVat ||
+        assert.fail(X`devices should yet not be given other devices '${slot}'`);
       return deviceNodeForSlot(slot);
     } else if (type === 'promise') {
       assert.fail(X`devices should not yet be given promises '${slot}'`);

--- a/packages/SwingSet/src/devices/loopbox/loopbox.js
+++ b/packages/SwingSet/src/devices/loopbox/loopbox.js
@@ -17,10 +17,9 @@ import { assert, details as X } from '@agoric/assert';
  */
 
 export function buildLoopbox(deliverMode) {
-  assert(
-    deliverMode === 'immediate' || deliverMode === 'queued',
-    X`deliverMode=${deliverMode}, must be 'immediate' or 'queued'`,
-  );
+  deliverMode === 'immediate' ||
+    deliverMode === 'queued' ||
+    assert.fail(X`deliverMode=${deliverMode}, must be 'immediate' or 'queued'`);
   const loopboxSrcPath = new URL('device-loopbox.js', import.meta.url).pathname;
 
   let loopboxPassOneMessage;

--- a/packages/SwingSet/src/devices/mailbox/device-mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox/device-mailbox.js
@@ -35,10 +35,8 @@ export function buildRootDeviceNode(tools) {
 
   // console.debug(`device-mailbox build: inboundHandler is`, inboundHandler);
   deliverInboundMessages = (peer, newMessages) => {
-    assert(
-      inboundHandler,
-      X`deliverInboundMessages before registerInboundHandler`,
-    );
+    inboundHandler ||
+      assert.fail(X`deliverInboundMessages before registerInboundHandler`);
     try {
       SO(inboundHandler).deliverInboundMessages(peer, newMessages);
     } catch (e) {

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -241,10 +241,10 @@ export function buildRootDeviceNode(tools) {
   }
 
   function updateTime(time) {
-    assert(
-      time >= lastPolled,
-      X`Time is monotonic. ${time} cannot be less than ${lastPolled}`,
-    );
+    time >= lastPolled ||
+      assert.fail(
+        X`Time is monotonic. ${time} cannot be less than ${lastPolled}`,
+      );
     lastPolled = time;
     saveState();
   }

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -139,10 +139,8 @@ export function makeDeviceSlots(
 
     assert(!outstandingProxies.has(x), X`SO(SO(x)) is invalid`);
     const slot = valToSlot.get(x);
-    assert(
-      slot && parseVatSlot(slot).type === 'object',
-      X`SO(x) must be called on a Presence, not ${x}`,
-    );
+    (slot && parseVatSlot(slot).type === 'object') ||
+      assert.fail(X`SO(x) must be called on a Presence, not ${x}`);
     const handler = PresenceHandler(slot);
     const p = harden(new Proxy({}, handler));
     outstandingProxies.add(p);

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -998,10 +998,8 @@ export default function buildKernel(
   function routeSendEvent(message) {
     const { target, msg } = message;
     const { type } = parseKernelSlot(target);
-    assert(
-      ['object', 'promise'].includes(type),
-      X`unable to send() to slot.type ${type}`,
-    );
+    ['object', 'promise'].includes(type) ||
+      assert.fail(X`unable to send() to slot.type ${type}`);
 
     function splat(error) {
       if (msg.result) {

--- a/packages/SwingSet/src/kernel/parseKernelSlots.js
+++ b/packages/SwingSet/src/kernel/parseKernelSlots.js
@@ -78,8 +78,6 @@ export function makeKernelSlot(type, id) {
  * @returns {void}
  */
 export function insistKernelType(type, kernelSlot) {
-  assert(
-    type === parseKernelSlot(kernelSlot).type,
-    X`kernelSlot ${kernelSlot} is not of type ${type}`,
-  );
+  type === parseKernelSlot(kernelSlot).type ||
+    assert.fail(X`kernelSlot ${kernelSlot} is not of type ${type}`);
 }

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -686,10 +686,10 @@ export default function makeKernelKeeper(
     const p = getKernelPromise(kpid);
     assert(p.state === 'unresolved', X`${kpid} was already resolved`);
     if (expectedDecider) {
-      assert(
-        p.decider === expectedDecider,
-        X`${kpid} is decided by ${p.decider}, not ${expectedDecider}`,
-      );
+      p.decider === expectedDecider ||
+        assert.fail(
+          X`${kpid} is decided by ${p.decider}, not ${expectedDecider}`,
+        );
     } else {
       assert(!p.decider, X`${kpid} is decided by ${p.decider}, not the kernel`);
     }
@@ -913,10 +913,8 @@ export default function makeKernelKeeper(
     // there is some kernel queue holding the message and its content.
 
     const p = getKernelPromise(kernelSlot);
-    assert(
-      p.state === 'unresolved',
-      X`${kernelSlot} is '${p.state}', not 'unresolved'`,
-    );
+    p.state === 'unresolved' ||
+      assert.fail(X`${kernelSlot} is '${p.state}', not 'unresolved'`);
     const nkey = `${kernelSlot}.queue.nextID`;
     const nextID = Nat(BigInt(getRequired(nkey)));
     kvStore.set(nkey, `${nextID + 1n}`);

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -44,14 +44,10 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     if (msg.result) {
       insistKernelType('promise', msg.result);
       const p = kernelKeeper.getKernelPromise(msg.result);
-      assert(
-        p.state === 'unresolved',
-        X`result ${msg.result} already resolved`,
-      );
-      assert(
-        !p.decider,
-        X`result ${msg.result} already has decider ${p.decider}`,
-      );
+      p.state === 'unresolved' ||
+        assert.fail(X`result ${msg.result} already resolved`);
+      !p.decider ||
+        assert.fail(X`result ${msg.result} already has decider ${p.decider}`);
       resultSlot = vatKeeper.mapKernelSlotToVatSlot(msg.result);
       insistVatType('promise', resultSlot);
       kernelKeeper.setDecider(msg.result, vatID);
@@ -301,14 +297,12 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       // In the case of non-pipelining vats these checks are redundant since
       // we're guaranteed to have a promise newly allocated by the vat.
       const p = kernelKeeper.getKernelPromise(result);
-      assert(
-        p.state === 'unresolved',
-        X`send() result ${result} is already resolved`,
-      );
-      assert(
-        p.decider === vatID,
-        X`send() result ${result} is decided by ${p.decider} not ${vatID}`,
-      );
+      p.state === 'unresolved' ||
+        assert.fail(X`send() result ${result} is already resolved`);
+      p.decider === vatID ||
+        assert.fail(
+          X`send() result ${result} is decided by ${p.decider} not ${vatID}`,
+        );
       kernelKeeper.clearDecider(result);
       // resolution authority now held by run-queue
     }
@@ -523,10 +517,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
   function translateSubscribe(vpid) {
     const kpid = mapVatSlotToKernelSlot(vpid);
     kdebug(`syscall[${vatID}].subscribe(${vpid}/${kpid})`);
-    assert(
-      kernelKeeper.hasKernelPromise(kpid),
-      X`unknown kernelPromise id '${kpid}'`,
-    );
+    kernelKeeper.hasKernelPromise(kpid) ||
+      assert.fail(X`unknown kernelPromise id '${kpid}'`);
     /** @type { KernelSyscallSubscribe } */
     const ks = harden(['subscribe', vatID, kpid]);
     return ks;

--- a/packages/SwingSet/src/lib/capdata.js
+++ b/packages/SwingSet/src/lib/capdata.js
@@ -17,10 +17,8 @@ export function insistCapData(capdata) {
     'string',
     X`capdata has non-string .body ${capdata.body}`,
   );
-  assert(
-    Array.isArray(capdata.slots),
-    X`capdata has non-Array slots ${capdata.slots}`,
-  );
+  Array.isArray(capdata.slots) ||
+    assert.fail(X`capdata has non-Array slots ${capdata.slots}`);
   // TODO check that the .slots array elements are actually strings
 }
 

--- a/packages/SwingSet/src/lib/netstring.js
+++ b/packages/SwingSet/src/lib/netstring.js
@@ -55,18 +55,14 @@ export function decode(data, optMaxChunkSize) {
       assert.fail(X`unparsable size ${sizeString}, should be integer`);
     }
     if (optMaxChunkSize) {
-      assert(
-        size <= optMaxChunkSize,
-        X`size ${size} exceeds limit of ${optMaxChunkSize}`,
-      );
+      size <= optMaxChunkSize ||
+        assert.fail(X`size ${size} exceeds limit of ${optMaxChunkSize}`);
     }
     if (data.length < colon + 1 + size + 1) {
       break; // still waiting for `${DATA}.`
     }
-    assert(
-      data[colon + 1 + size] === COMMA,
-      X`malformed netstring: not terminated by comma`,
-    );
+    data[colon + 1 + size] === COMMA ||
+      assert.fail(X`malformed netstring: not terminated by comma`);
     payloads.push(data.subarray(colon + 1, colon + 1 + size));
     start = colon + 1 + size + 1;
   }

--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -331,10 +331,8 @@ export function makeCollectionManager(
     }
 
     function get(key) {
-      assert(
-        matches(key, keyShape),
-        X`invalid key type for collection ${q(label)}`,
-      );
+      matches(key, keyShape) ||
+        assert.fail(X`invalid key type for collection ${q(label)}`);
       const result = syscall.vatstoreGet(keyToDBKey(key));
       if (result) {
         return unserialize(JSON.parse(result));
@@ -353,19 +351,13 @@ export function makeCollectionManager(
     }
 
     function init(key, value) {
-      assert(
-        matches(key, keyShape),
-        X`invalid key type for collection ${q(label)}`,
-      );
-      assert(
-        !has(key),
-        X`key ${key} already registered in collection ${q(label)}`,
-      );
+      matches(key, keyShape) ||
+        assert.fail(X`invalid key type for collection ${q(label)}`);
+      !has(key) ||
+        assert.fail(X`key ${key} already registered in collection ${q(label)}`);
       if (valueShape) {
-        assert(
-          matches(value, valueShape),
-          X`invalid value type for collection ${q(label)}`,
-        );
+        matches(value, valueShape) ||
+          assert.fail(X`invalid value type for collection ${q(label)}`);
       }
       currentGenerationNumber += 1;
       const serializedValue = serialize(value);
@@ -380,10 +372,8 @@ export function makeCollectionManager(
       if (passStyleOf(key) === 'remotable') {
         const vref = convertValToSlot(key);
         if (durable) {
-          assert(
-            vrm.isDurable(vref),
-            X`key (${key}) is not durable in ${value}`,
-          );
+          vrm.isDurable(vref) ||
+            assert.fail(X`key (${key}) is not durable in ${value}`);
         }
         generateOrdinal(key);
         if (hasWeakKeys) {
@@ -398,15 +388,11 @@ export function makeCollectionManager(
     }
 
     function set(key, value) {
-      assert(
-        matches(key, keyShape),
-        X`invalid key type for collection ${q(label)}`,
-      );
+      matches(key, keyShape) ||
+        assert.fail(X`invalid key type for collection ${q(label)}`);
       if (valueShape) {
-        assert(
-          matches(value, valueShape),
-          X`invalid value type for collection ${q(label)}`,
-        );
+        matches(value, valueShape) ||
+          assert.fail(X`invalid value type for collection ${q(label)}`);
       }
       const after = serialize(harden(value));
       assertAcceptableSyscallCapdataSize([after]);
@@ -426,10 +412,8 @@ export function makeCollectionManager(
     }
 
     function deleteInternal(key) {
-      assert(
-        matches(key, keyShape),
-        X`invalid key type for collection ${q(label)}`,
-      );
+      matches(key, keyShape) ||
+        assert.fail(X`invalid key type for collection ${q(label)}`);
       const dbKey = keyToDBKey(key);
       const rawValue = syscall.vatstoreGet(dbKey);
       assert(rawValue, X`key ${key} not found in collection ${q(label)}`);
@@ -475,10 +459,8 @@ export function makeCollectionManager(
       function* iter() {
         const generationAtStart = currentGenerationNumber;
         while (priorDBKey !== undefined) {
-          assert(
-            generationAtStart === currentGenerationNumber,
-            X`keys in store cannot be added to during iteration`,
-          );
+          generationAtStart === currentGenerationNumber ||
+            assert.fail(X`keys in store cannot be added to during iteration`);
           const [dbKey, dbValue] = syscall.vatstoreGetAfter(
             priorDBKey,
             start,

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -810,10 +810,8 @@ function build(
     meterControl.assertNotMetered();
     const { type } = parseVatSlot(slot);
     assert(type === 'promise', X`revivePromise called on non-promise ${slot}`);
-    assert(
-      !getValForSlot(slot),
-      X`revivePromise called on pre-existing ${slot}`,
-    );
+    !getValForSlot(slot) ||
+      assert.fail(X`revivePromise called on pre-existing ${slot}`);
     const pRec = makePipelinablePromise(slot);
     importedVPIDs.set(slot, pRec);
     const p = pRec.promise;
@@ -985,10 +983,8 @@ function build(
 
   function forbidPromises(serArgs) {
     for (const slot of serArgs.slots) {
-      assert(
-        parseVatSlot(slot).type !== 'promise',
-        X`D() arguments cannot include a Promise`,
-      );
+      parseVatSlot(slot).type !== 'promise' ||
+        assert.fail(X`D() arguments cannot include a Promise`);
     }
   }
 
@@ -1425,10 +1421,10 @@ function build(
       'remotable',
       X`buildRootObject() for vat ${forVatID} returned ${rootObject}, which is not Far`,
     );
-    assert(
-      getInterfaceOf(rootObject) !== undefined,
-      X`buildRootObject() for vat ${forVatID} returned ${rootObject} with no interface`,
-    );
+    getInterfaceOf(rootObject) !== undefined ||
+      assert.fail(
+        X`buildRootObject() for vat ${forVatID} returned ${rootObject} with no interface`,
+      );
     // Need to load watched promises *after* buildRootObject() so that handler kindIDs
     // have a chance to be reassociated with their handlers.
     watchedPromiseManager.loadWatchedPromiseTable();

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -675,10 +675,8 @@ export function makeVirtualObjectManager(
     harden(prototypeTemplate);
 
     function makeRepresentative(innerSelf, initializing) {
-      assert(
-        innerSelf.repCount === 0,
-        X`${innerSelf.baseRef} already has a representative`,
-      );
+      innerSelf.repCount === 0 ||
+        assert.fail(X`${innerSelf.baseRef} already has a representative`);
       innerSelf.repCount += 1;
 
       function ensureState() {

--- a/packages/SwingSet/src/vats/comms/clist-inbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-inbound.js
@@ -23,10 +23,10 @@ export function makeInbound(state) {
     const lpid = remote.mapFromRemote(rpid);
     assert(lpid, X`unknown remote ${remoteID} promise ${rpid}`);
     const { subscribers } = state.getPromiseSubscribers(lpid);
-    assert(
-      subscribers.indexOf(remoteID) === -1,
-      X`attempt to retire remote ${remoteID} subscribed promise ${rpid}`,
-    );
+    subscribers.indexOf(remoteID) === -1 ||
+      assert.fail(
+        X`attempt to retire remote ${remoteID} subscribed promise ${rpid}`,
+      );
     remote.deleteRemoteMapping(lpid);
     cdebug(`comms delete mapping r<->k ${remoteID} ${rpid}<=>${lpid}`);
   }

--- a/packages/SwingSet/src/vats/comms/clist-kernel.js
+++ b/packages/SwingSet/src/vats/comms/clist-kernel.js
@@ -90,10 +90,8 @@ export function makeKernel(state, syscall) {
     assert(lpid, X`unknown kernel promise ${kfpid}`);
     assert(state.mapToKernel(lpid), X`unmapped local promise ${lpid}`);
     const { kernelIsSubscribed } = state.getPromiseSubscribers(lpid);
-    assert(
-      !kernelIsSubscribed,
-      X`attempt to retire subscribed promise ${kfpid}`,
-    );
+    !kernelIsSubscribed ||
+      assert.fail(X`attempt to retire subscribed promise ${kfpid}`);
     state.deleteKernelMapping(lpid);
     cdebug(`comms delete mapping l<->k ${kfpid}<=>${lpid}`);
   }
@@ -105,10 +103,8 @@ export function makeKernel(state, syscall) {
     assert(lref, X`${kfref} must already be mapped to a local ID`);
     if (parseVatSlot(kfref).type === 'object') {
       // comms export, kernel import, it must be reachable
-      assert(
-        isReachable(lref),
-        X`kernel sending to unreachable import ${lref}`,
-      );
+      isReachable(lref) ||
+        assert.fail(X`kernel sending to unreachable import ${lref}`);
     }
     return lref;
   }

--- a/packages/SwingSet/src/vats/comms/controller.js
+++ b/packages/SwingSet/src/vats/comms/controller.js
@@ -45,14 +45,10 @@ export function deliverToController(
 
     const name = args[0];
     assert.typeof(name, 'string', X`bad addRemote name ${name}`);
-    assert(
-      args[1]['@qclass'] === 'slot' && args[1].index === 0,
-      X`unexpected args for addRemote(): ${methargs.body}`,
-    );
-    assert(
-      args[2]['@qclass'] === 'slot' && args[2].index === 1,
-      X`unexpected args for addRemote(): ${methargs.body}`,
-    );
+    (args[1]['@qclass'] === 'slot' && args[1].index === 0) ||
+      assert.fail(X`unexpected args for addRemote(): ${methargs.body}`);
+    (args[2]['@qclass'] === 'slot' && args[2].index === 1) ||
+      assert.fail(X`unexpected args for addRemote(): ${methargs.body}`);
     const transmitterID = slots[args[1].index];
     const setReceiverID = slots[args[2].index];
 
@@ -77,10 +73,8 @@ export function deliverToController(
     const remoteID = state.getRemoteIDForName(remoteName);
     assert(remoteID, X`unknown remote name ${remoteName}`);
     const remoteRefID = args[1];
-    assert(
-      args[2]['@qclass'] === 'slot' && args[2].index === 0,
-      X`unexpected args for addEgress(): ${methargs.body}`,
-    );
+    (args[2]['@qclass'] === 'slot' && args[2].index === 0) ||
+      assert.fail(X`unexpected args for addEgress(): ${methargs.body}`);
     const localRef = provideLocalForKernel(slots[args[2].index]);
     addEgress(remoteID, remoteRefID, localRef);
     syscall.resolve([[result, false, UNDEFINED]]);

--- a/packages/SwingSet/src/vats/comms/delivery.js
+++ b/packages/SwingSet/src/vats/comms/delivery.js
@@ -61,10 +61,9 @@ export function makeDeliveryKit(
   function sendFromKernel(ktarget, kmethargs, kresult) {
     const target = getLocalForKernel(ktarget);
     const methargs = mapDataFromKernel(kmethargs, null);
-    assert(
-      state.getObject(target) || state.getPromiseStatus(target),
-      X`unknown message target ${target}/${ktarget}`,
-    );
+    state.getObject(target) ||
+      state.getPromiseStatus(target) ||
+      assert.fail(X`unknown message target ${target}/${ktarget}`);
     const result = provideLocalForKernelResult(kresult);
     const localDelivery = harden({ target, methargs, result });
     handleSend(localDelivery);
@@ -139,16 +138,13 @@ export function makeDeliveryKit(
     const seqNum = message.substring(0, delim1);
     const remote = state.getRemote(remoteID);
     const recvSeqNum = remote.advanceReceivedSeqNum();
-    assert(
-      seqNum === '' || seqNum === `${recvSeqNum}`,
-      X`unexpected recv seqNum ${seqNum}`,
-    );
+    seqNum === '' ||
+      seqNum === `${recvSeqNum}` ||
+      assert.fail(X`unexpected recv seqNum ${seqNum}`);
 
     const delim2 = message.indexOf(':', delim1 + 1);
-    assert(
-      delim2 >= 0,
-      X`received message ${message} lacks ackSeqNum delimiter`,
-    );
+    delim2 >= 0 ||
+      assert.fail(X`received message ${message} lacks ackSeqNum delimiter`);
     const ackSeqNum = parseInt(message.substring(delim1 + 1, delim2), 10);
     handleAckFromRemote(remoteID, ackSeqNum);
 

--- a/packages/SwingSet/src/vats/comms/parseLocalSlots.js
+++ b/packages/SwingSet/src/vats/comms/parseLocalSlots.js
@@ -68,8 +68,6 @@ export function makeLocalSlot(type, id) {
  * @returns {void}
  */
 export function insistLocalType(type, localSlot) {
-  assert(
-    type === parseLocalSlot(localSlot).type,
-    X`localSlot ${localSlot} is not of type ${type}`,
-  );
+  type === parseLocalSlot(localSlot).type ||
+    assert.fail(X`localSlot ${localSlot} is not of type ${type}`);
 }

--- a/packages/SwingSet/src/vats/comms/parseRemoteSlot.js
+++ b/packages/SwingSet/src/vats/comms/parseRemoteSlot.js
@@ -57,10 +57,8 @@ export function makeRemoteSlot(type, allocatedByRecipient, id) {
 }
 
 export function insistRemoteType(type, remoteSlot) {
-  assert(
-    type === parseRemoteSlot(remoteSlot).type,
-    X`remoteSlot ${remoteSlot} is not of type ${type}`,
-  );
+  type === parseRemoteSlot(remoteSlot).type ||
+    assert.fail(X`remoteSlot ${remoteSlot} is not of type ${type}`);
 }
 
 // The clist for each remote-machine has two sides: fromRemote (used to

--- a/packages/SwingSet/src/vats/comms/remote.js
+++ b/packages/SwingSet/src/vats/comms/remote.js
@@ -18,10 +18,8 @@ export function initializeRemoteState(
   name,
   transmitterID,
 ) {
-  assert(
-    !store.get(`${remoteID}.initialized`),
-    X`remote ${remoteID} already exists`,
-  );
+  !store.get(`${remoteID}.initialized`) ||
+    assert.fail(X`remote ${remoteID} already exists`);
   store.set(`${remoteID}.sendSeq`, '1');
   store.set(`${remoteID}.recvSeq`, '0');
   store.set(`${remoteID}.o.nextID`, `${identifierBase + 20}`);

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -308,10 +308,8 @@ export function makeNetworkProtocol(protocolHandler) {
       },
       async removeListener(listenHandler) {
         assert(listening.has(localAddr), X`Port ${localAddr} is not listening`);
-        assert(
-          listening.get(localAddr)[1] === listenHandler,
-          X`Port ${localAddr} handler to remove is not listening`,
-        );
+        listening.get(localAddr)[1] === listenHandler ||
+          assert.fail(X`Port ${localAddr} handler to remove is not listening`);
         listening.delete(localAddr);
         await E(protocolHandler).onListenRemove(
           port,
@@ -339,10 +337,8 @@ export function makeNetworkProtocol(protocolHandler) {
         return conn;
       },
       async revoke() {
-        assert(
-          revoked !== RevokeState.REVOKED,
-          X`Port ${localAddr} is already revoked`,
-        );
+        revoked !== RevokeState.REVOKED ||
+          assert.fail(X`Port ${localAddr} is already revoked`);
         revoked = RevokeState.REVOKING;
         await E(protocolHandler).onRevoke(port, localAddr, protocolHandler);
         revoked = RevokeState.REVOKED;
@@ -605,10 +601,8 @@ export function makeLoopbackProtocolHandler(
     async onListenRemove(port, localAddr, listenHandler, _protocolHandler) {
       const [lport, lhandler] = listeners.get(localAddr);
       assert(lport === port, X`Port does not match listener on ${localAddr}`);
-      assert(
-        lhandler === listenHandler,
-        X`Listen handler does not match listener on ${localAddr}`,
-      );
+      lhandler === listenHandler ||
+        assert.fail(X`Listen handler does not match listener on ${localAddr}`);
       listeners.delete(localAddr);
     },
     async onRevoke(_port, _localAddr, _protocolHandler) {

--- a/packages/SwingSet/src/vats/vattp/vat-vattp.js
+++ b/packages/SwingSet/src/vats/vattp/vat-vattp.js
@@ -185,10 +185,8 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
     () => 0n,
   );
   const initNetworkHostState = (allegedName, comms, console) => {
-    assert(
-      !networkHostNames.has(allegedName),
-      X`already have host for ${allegedName}`,
-    );
+    !networkHostNames.has(allegedName) ||
+      assert.fail(X`already have host for ${allegedName}`);
     networkHostNames.add(allegedName);
     networkHostCounter += 1n;
     baggage.set(networkHostCounterBaggageKey, networkHostCounter);

--- a/packages/SwingSet/test/commsVatDriver.js
+++ b/packages/SwingSet/test/commsVatDriver.js
@@ -185,10 +185,8 @@ function loggingSyscall(log) {
  * @returns {string} the ref embedded within `scriptRef`
  */
 function refOf(scriptRef) {
-  assert(
-    scriptRef[0] === '@',
-    X`expected reference ${scriptRef} to start with '@'`,
-  );
+  scriptRef[0] === '@' ||
+    assert.fail(X`expected reference ${scriptRef} to start with '@'`);
   const delim = scriptRef.indexOf(':');
   let ref;
   if (delim < 0) {

--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -120,10 +120,10 @@ const assertHttpConnectionSpec = connectionSpec => {
     'number',
     X`Expected "port" number on "http" type connectionSpec, ${connectionSpec}`,
   );
-  assert(
-    Number.isInteger(port),
-    X`Expected integer "port" on "http" type connectionSpec, ${connectionSpec}`,
-  );
+  Number.isInteger(port) ||
+    assert.fail(
+      X`Expected integer "port" on "http" type connectionSpec, ${connectionSpec}`,
+    );
 };
 
 // eslint-disable-next-line jsdoc/require-returns-check

--- a/packages/agoric-cli/src/set-defaults.js
+++ b/packages/agoric-cli/src/set-defaults.js
@@ -11,11 +11,8 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
   const log = anylogger('agoric:set-defaults');
 
   const [prog, configDir] = rawArgs.slice(1);
-
-  assert(
-    prog === 'ag-chain-cosmos',
-    X`<prog> must currently be 'ag-chain-cosmos'`,
-  );
+  prog === 'ag-chain-cosmos' ||
+    assert.fail(X`<prog> must currently be 'ag-chain-cosmos'`);
 
   const { exportMetrics, enableCors } = opts;
 

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -33,18 +33,15 @@ const TELEMETRY_SERVICE_NAME = 'agd-cosmos';
 
 const toNumber = specimen => {
   const number = parseInt(specimen, 10);
-  assert(
-    String(number) === String(specimen),
-    X`Could not parse ${JSON.stringify(specimen)} as a number`,
-  );
+  String(number) === String(specimen) ||
+    assert.fail(X`Could not parse ${JSON.stringify(specimen)} as a number`);
   return number;
 };
 
 const makeChainStorage = (call, prefix = '', options = {}) => {
-  assert(
-    prefix === '' || prefix.endsWith('.'),
-    X`prefix ${prefix} must end with a dot`,
-  );
+  prefix === '' ||
+    prefix.endsWith('.') ||
+    assert.fail(X`prefix ${prefix} must end with a dot`);
 
   const { fromChainShape, toChainShape } = options;
 

--- a/packages/cosmic-swingset/src/params.js
+++ b/packages/cosmic-swingset/src/params.js
@@ -18,21 +18,16 @@ export const stringToNat = s => {
 export const parseParams = params => {
   const { beans_per_unit: rawBeansPerUnit, fee_unit_price: rawFeeUnitPrice } =
     params;
-  assert(
-    Array.isArray(rawBeansPerUnit),
-    X`beansPerUnit must be an array, not ${rawBeansPerUnit}`,
-  );
+  Array.isArray(rawBeansPerUnit) ||
+    assert.fail(X`beansPerUnit must be an array, not ${rawBeansPerUnit}`);
   const beansPerUnit = Object.fromEntries(
     rawBeansPerUnit.map(({ key, beans }) => {
       assert.typeof(key, 'string', X`Key ${key} must be a string`);
       return [key, stringToNat(beans)];
     }),
   );
-
-  assert(
-    Array.isArray(rawFeeUnitPrice),
-    X`feeUnitPrice ${rawFeeUnitPrice} must be an array`,
-  );
+  Array.isArray(rawFeeUnitPrice) ||
+    assert.fail(X`feeUnitPrice ${rawFeeUnitPrice} must be an array`);
   const feeUnitPrice = rawFeeUnitPrice.map(({ denom, amount }) => {
     assert.typeof(denom, 'string', X`denom ${denom} must be a string`);
     assert(denom, X`denom ${denom} must be non-empty`);

--- a/packages/deploy-script-support/src/assertOfferResult.js
+++ b/packages/deploy-script-support/src/assertOfferResult.js
@@ -5,8 +5,8 @@ import { E } from '@endo/far';
 /** @type {AssertOfferResult} */
 export const assertOfferResult = async (seat, expectedOfferResult) => {
   const actualOfferResult = await E(seat).getOfferResult();
-  assert(
-    actualOfferResult === expectedOfferResult,
-    X`offerResult (${actualOfferResult}) did not equal expected: ${expectedOfferResult}`,
-  );
+  actualOfferResult === expectedOfferResult ||
+    assert.fail(
+      X`offerResult (${actualOfferResult}) did not equal expected: ${expectedOfferResult}`,
+    );
 };

--- a/packages/deploy-script-support/src/extract-proposal.js
+++ b/packages/deploy-script-support/src/extract-proposal.js
@@ -129,10 +129,8 @@ export const extractCoreProposalBundles = async (
       };
       const publishRef = async handleP => {
         const handle = await handleP;
-        assert(
-          bundleHandleToAbsolutePaths.has(handle),
-          X`${handle} not in installed bundles`,
-        );
+        bundleHandleToAbsolutePaths.has(handle) ||
+          assert.fail(X`${handle} not in installed bundles`);
         return handle;
       };
       const proposal = await ns[entrypoint]({ publishRef, install }, ...args);

--- a/packages/deployment/src/init.js
+++ b/packages/deployment/src/init.js
@@ -512,11 +512,8 @@ const doInit =
       ROLE_INSTANCE[config.ROLES[PLACEMENT]] = instance;
       config.OFFSETS[PLACEMENT] = offset;
     }
-
-    assert(
-      Object.values(ROLE_INSTANCE).some(i => i > 0),
-      X`Aborting due to no nodes configured!`,
-    );
+    Object.values(ROLE_INSTANCE).some(i => i > 0) ||
+      assert.fail(X`Aborting due to no nodes configured!`);
 
     await wr.createFile(
       `vars.tf`,

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -284,10 +284,8 @@ show-config      display the client connection parameters
           break;
 
         default:
-          assert(
-            versionKind.match(/^[1-9]/),
-            X`${versionKind} is not one of "epoch", or NNN`,
-          );
+          versionKind.match(/^[1-9]/) ||
+            assert.fail(X`${versionKind} is not one of "epoch", or NNN`);
       }
 
       let vstr = `${epoch}`;
@@ -801,10 +799,8 @@ ${chalk.yellow.bold(`ag-setup-solo --netconfig='${dwebHost}/network-config'`)}
         const ID = String(raw);
 
         assert(ID, X`${idPath} must contain a node ${ID}`);
-        assert(
-          ID.match(/^[a-f0-9]+/),
-          X`${idPath} contains an invalid ID ${ID}`,
-        );
+        ID.match(/^[a-f0-9]+/) ||
+          assert.fail(X`${idPath} contains an invalid ID ${ID}`);
         if (cmd.endsWith('-ids')) {
           ret += `${sep}${ID}`;
         } else {
@@ -970,10 +966,8 @@ ${node}:${roleParams}
     case 'play': {
       const [pb, ...pbargs] = args.slice(1);
       assert(pb, X`Need: [playbook name]`);
-      assert(
-        pb.match(/^\w[-\w]*$/),
-        X`[playbook] ${JSON.stringify(pb)} must be a word`,
-      );
+      pb.match(/^\w[-\w]*$/) ||
+        assert.fail(X`[playbook] ${JSON.stringify(pb)} must be a word`);
       await inited();
       return doRun(setup.playbook(pb, ...pbargs));
     }

--- a/packages/deployment/src/run.js
+++ b/packages/deployment/src/run.js
@@ -50,10 +50,10 @@ export const running = (process, { exec, spawn }) => {
 
     needBacktick: async cmd => {
       const ret = await it.getStdout(cmd);
-      assert(
-        ret.code === 0,
-        X`Unexpected ${JSON.stringify(cmd)} exit code: ${ret.code}`,
-      );
+      ret.code === 0 ||
+        assert.fail(
+          X`Unexpected ${JSON.stringify(cmd)} exit code: ${ret.code}`,
+        );
       return ret.stdout;
     },
     cwd: () => process.cwd(),

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -35,19 +35,14 @@ const validateBinaryQuestionSpec = questionSpec => {
   coerceQuestionSpec(questionSpec);
 
   const positions = questionSpec.positions;
-  assert(
-    positions.length === 2,
-    X`Binary questions must have exactly two positions. had ${positions.length}: ${positions}`,
-  );
-
-  assert(
-    questionSpec.maxChoices === 1,
-    X`Can only choose 1 item on a binary question`,
-  );
-  assert(
-    questionSpec.method === ChoiceMethod.UNRANKED,
-    X`${questionSpec.method} must be UNRANKED`,
-  );
+  positions.length === 2 ||
+    assert.fail(
+      X`Binary questions must have exactly two positions. had ${positions.length}: ${positions}`,
+    );
+  questionSpec.maxChoices === 1 ||
+    assert.fail(X`Can only choose 1 item on a binary question`);
+  questionSpec.method === ChoiceMethod.UNRANKED ||
+    assert.fail(X`${questionSpec.method} must be UNRANKED`);
   // We don't check the quorumRule or quorumThreshold here. The quorumThreshold
   // is provided by the Electorate that creates this voteCounter, since only it
   // can translate the quorumRule to a required number of votes.
@@ -148,10 +143,10 @@ const makeBinaryVoteCounter = (questionSpec, threshold, instance) => {
       submitVote(voterHandle, chosenPositions, shares = 1n) {
         assert(chosenPositions.length === 1, 'only 1 position allowed');
         const [position] = chosenPositions;
-        assert(
-          positionIncluded(positions, position),
-          X`The specified choice is not a legal position: ${position}.`,
-        );
+        positionIncluded(positions, position) ||
+          assert.fail(
+            X`The specified choice is not a legal position: ${position}.`,
+          );
 
         // CRUCIAL: If the voter cast a valid ballot, we'll record it, but we need
         // to make sure that each voter's vote is recorded only once.

--- a/packages/governance/src/contractGovernance/assertions.js
+++ b/packages/governance/src/contractGovernance/assertions.js
@@ -8,10 +8,8 @@ const { details: X } = assert;
 const makeLooksLikeBrand = name => {
   /** @param {Brand} brand */
   return brand => {
-    assert(
-      isRemotable(brand),
-      X`value for ${name} must be a brand, was ${brand}`,
-    );
+    isRemotable(brand) ||
+      assert.fail(X`value for ${name} must be a brand, was ${brand}`);
   };
 };
 harden(makeLooksLikeBrand);
@@ -19,10 +17,10 @@ harden(makeLooksLikeBrand);
 const makeAssertInstallation = name => {
   return installation => {
     // TODO(3344): add a better assertion once Zoe validates installations
-    assert(
-      typeof installation === 'object',
-      X`value for ${name} must be an Installation, was ${installation}`,
-    );
+    typeof installation === 'object' ||
+      assert.fail(
+        X`value for ${name} must be an Installation, was ${installation}`,
+      );
   };
 };
 harden(makeAssertInstallation);
@@ -30,10 +28,8 @@ harden(makeAssertInstallation);
 const makeAssertInstance = name => {
   return instance => {
     // TODO(3344): add a better assertion once Zoe validates instances
-    assert(
-      typeof instance === 'object',
-      X`value for ${name} must be an Instance, was ${instance}`,
-    );
+    typeof instance === 'object' ||
+      assert.fail(X`value for ${name} must be an Instance, was ${instance}`);
   };
 };
 harden(makeAssertInstance);
@@ -41,14 +37,14 @@ harden(makeAssertInstance);
 const makeAssertBrandedRatio = (name, modelRatio) => {
   return ratio => {
     assertIsRatio(ratio);
-    assert(
-      ratio.numerator.brand === modelRatio.numerator.brand,
-      X`Numerator brand for ${name} must be ${modelRatio.numerator.brand}`,
-    );
-    assert(
-      ratio.denominator.brand === modelRatio.denominator.brand,
-      X`Denominator brand for ${name} must be ${modelRatio.denominator.brand}`,
-    );
+    ratio.numerator.brand === modelRatio.numerator.brand ||
+      assert.fail(
+        X`Numerator brand for ${name} must be ${modelRatio.numerator.brand}`,
+      );
+    ratio.denominator.brand === modelRatio.denominator.brand ||
+      assert.fail(
+        X`Denominator brand for ${name} must be ${modelRatio.denominator.brand}`,
+      );
     return true;
   };
 };

--- a/packages/governance/src/contractGovernance/governApi.js
+++ b/packages/governance/src/contractGovernance/governApi.js
@@ -56,10 +56,8 @@ const setupApiGovernance = async (
     voteCounterInstallation,
     deadline,
   ) => {
-    assert(
-      governedNames.includes(apiMethodName),
-      X`${apiMethodName} is not a governed API.`,
-    );
+    governedNames.includes(apiMethodName) ||
+      assert.fail(X`${apiMethodName} is not a governed API.`);
 
     const { positive, negative } = makeApiInvocationPositions(
       apiMethodName,

--- a/packages/governance/src/contractGovernance/governParam.js
+++ b/packages/governance/src/contractGovernance/governParam.js
@@ -47,16 +47,14 @@ const assertBallotConcernsParam = (paramSpec, questionSpec) => {
 
   const { parameterName, paramPath } = paramSpec;
   const { issue } = questionSpec;
-
-  assert(
-    issue.spec.changes[parameterName],
-    X`Question (${issue.spec.changes}) does not concern ${parameterName}`,
-  );
-
-  assert(
-    keyEQ(issue.spec.paramPath, paramPath),
-    X`Question path (${issue.spec.paramPath}) doesn't match request (${paramPath})`,
-  );
+  issue.spec.changes[parameterName] ||
+    assert.fail(
+      X`Question (${issue.spec.changes}) does not concern ${parameterName}`,
+    );
+  keyEQ(issue.spec.paramPath, paramPath) ||
+    assert.fail(
+      X`Question path (${issue.spec.paramPath}) doesn't match request (${paramPath})`,
+    );
 };
 
 /** @type {SetupGovernance} */

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -28,14 +28,14 @@ const assertElectorateMatches = (paramManager, governedParams) => {
   const {
     [CONTRACT_ELECTORATE]: { value: paramElectorate },
   } = governedParams;
-  assert(
-    paramElectorate,
-    X`Missing ${q(CONTRACT_ELECTORATE)} term in ${q(governedParams)}`,
-  );
-  assert(
-    keyEQ(managerElectorate, paramElectorate),
-    X`Electorate in manager (${managerElectorate})} incompatible with terms (${paramElectorate}`,
-  );
+  paramElectorate ||
+    assert.fail(
+      X`Missing ${q(CONTRACT_ELECTORATE)} term in ${q(governedParams)}`,
+    );
+  keyEQ(managerElectorate, paramElectorate) ||
+    assert.fail(
+      X`Electorate in manager (${managerElectorate})} incompatible with terms (${paramElectorate}`,
+    );
 };
 
 /**

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -149,11 +149,10 @@ const start = async (zcf, privateArgs) => {
       terms: contractTerms,
     },
   } = zcf.getTerms();
-
-  assert(
-    contractTerms.governedParams[CONTRACT_ELECTORATE],
-    X`Contract must declare ${CONTRACT_ELECTORATE} as a governed parameter`,
-  );
+  contractTerms.governedParams[CONTRACT_ELECTORATE] ||
+    assert.fail(
+      X`Contract must declare ${CONTRACT_ELECTORATE} as a governed parameter`,
+    );
 
   const augmentedTerms = harden({
     ...contractTerms,

--- a/packages/governance/src/validators.js
+++ b/packages/governance/src/validators.js
@@ -59,11 +59,10 @@ const assertContractElectorate = async (
 ) => {
   const allegedGovernorPF = E(zoe).getPublicFacet(allegedGovernor);
   const electorate = await E(allegedGovernorPF).getElectorate();
-
-  assert(
-    electorate === allegedElectorate,
-    X`The allegedElectorate didn't match the actual ${q(electorate)}`,
-  );
+  electorate === allegedElectorate ||
+    assert.fail(
+      X`The allegedElectorate didn't match the actual ${q(electorate)}`,
+    );
 
   return true;
 };

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -37,14 +37,10 @@ export const assertOnlyKeys = (proposal, keys) => {
   /** @param {AmountKeywordRecord} clause */
   const onlyKeys = clause =>
     Object.getOwnPropertyNames(clause).every(c => keys.includes(c));
-  assert(
-    onlyKeys(proposal.give),
-    X`extraneous terms in give: ${proposal.give}`,
-  );
-  assert(
-    onlyKeys(proposal.want),
-    X`extraneous terms in want: ${proposal.want}`,
-  );
+  onlyKeys(proposal.give) ||
+    assert.fail(X`extraneous terms in give: ${proposal.give}`);
+  onlyKeys(proposal.want) ||
+    assert.fail(X`extraneous terms in want: ${proposal.want}`);
 };
 
 /**

--- a/packages/inter-protocol/src/interchainPool.js
+++ b/packages/inter-protocol/src/interchainPool.js
@@ -56,10 +56,10 @@ export const start = (zcf, { bankManager }) => {
     const {
       give: { Central: centralAmt },
     } = seat.getProposal();
-    assert(
-      AmountMath.isGTE(centralAmt, minimumCentral),
-      X`at least ${q(minimumCentral)} required; only ${q(centralAmt)} given`,
-    );
+    AmountMath.isGTE(centralAmt, minimumCentral) ||
+      assert.fail(
+        X`at least ${q(minimumCentral)} required; only ${q(centralAmt)} given`,
+      );
 
     const interAsset = makeIssuerKit(
       denom,

--- a/packages/inter-protocol/src/interest.js
+++ b/packages/inter-protocol/src/interest.js
@@ -134,10 +134,10 @@ export const calculateCompoundedInterest = (
 const validatedBrand = (mint, debt) => {
   const { brand: debtBrand } = debt;
   const { brand: issuerBrand } = mint.getIssuerRecord();
-  assert(
-    debtBrand === issuerBrand,
-    X`Debt and issuer brands differ: ${debtBrand} != ${issuerBrand}`,
-  );
+  debtBrand === issuerBrand ||
+    assert.fail(
+      X`Debt and issuer brands differ: ${debtBrand} != ${issuerBrand}`,
+    );
   return issuerBrand;
 };
 

--- a/packages/inter-protocol/src/my-lien.js
+++ b/packages/inter-protocol/src/my-lien.js
@@ -57,10 +57,10 @@ export const makeStakeReporter = (bridgeManager, brand, denom = 'ubld') => {
       return changeLiened(address, delta);
     },
     getAccountState: async (address, wantedBrand) => {
-      assert(
-        wantedBrand === brand,
-        X`Cannot getAccountState for ${wantedBrand}. Expected ${brand}.`,
-      );
+      wantedBrand === brand ||
+        assert.fail(
+          X`Cannot getAccountState for ${wantedBrand}. Expected ${brand}.`,
+        );
       /** @type { AccountState<string> } */
       const { currentTime, bonded, liened, locked, total, unbonding } = await E(
         bridgeManager,

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -150,10 +150,8 @@ export const start = async (zcf, privateArgs, baggage) => {
       anchorPool.getAmountAllocated('Anchor', anchorBrand),
       given,
     );
-    assert(
-      AmountMath.isGTE(params.getMintLimit(), anchorAfterTrade),
-      X`Request would exceed mint limit`,
-    );
+    AmountMath.isGTE(params.getMintLimit(), anchorAfterTrade) ||
+      assert.fail(X`Request would exceed mint limit`);
   };
 
   /**
@@ -165,10 +163,8 @@ export const start = async (zcf, privateArgs, baggage) => {
     const fee = ceilMultiplyBy(given, params.getGiveMintedFee());
     const afterFee = AmountMath.subtract(given, fee);
     const maxAnchor = floorMultiplyBy(afterFee, anchorPerMinted);
-    assert(
-      AmountMath.isGTE(maxAnchor, wanted),
-      X`wanted ${wanted} is more than ${given} minus fees ${fee}`,
-    );
+    AmountMath.isGTE(maxAnchor, wanted) ||
+      assert.fail(X`wanted ${wanted} is more than ${given} minus fees ${fee}`);
     try {
       stageTransfer(seat, stage, { In: afterFee }, { Minted: afterFee });
       stageTransfer(seat, feePool, { In: fee }, { Minted: fee });
@@ -200,10 +196,8 @@ export const start = async (zcf, privateArgs, baggage) => {
     const asStable = floorDivideBy(given, anchorPerMinted);
     const fee = ceilMultiplyBy(asStable, params.getWantMintedFee());
     const afterFee = AmountMath.subtract(asStable, fee);
-    assert(
-      AmountMath.isGTE(afterFee, wanted),
-      X`wanted ${wanted} is more than ${given} minus fees ${fee}`,
-    );
+    AmountMath.isGTE(afterFee, wanted) ||
+      assert.fail(X`wanted ${wanted} is more than ${given} minus fees ${fee}`);
     stableMint.mintGains({ Minted: asStable }, stage);
     try {
       stageTransfer(seat, anchorPool, { In: given }, { Anchor: given });

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -234,10 +234,10 @@ const start = async (zcf, privateArgs, baggage) => {
   };
 
   const getKeywordForBrand = brand => {
-    assert(
-      keywordForBrand.has(brand),
-      X`Issuer not defined for brand ${q(brand)}; first call addIssuer()`,
-    );
+    keywordForBrand.has(brand) ||
+      assert.fail(
+        X`Issuer not defined for brand ${q(brand)}; first call addIssuer()`,
+      );
     return keywordForBrand.get(brand);
   };
 

--- a/packages/inter-protocol/src/stakeFactory/attestation.js
+++ b/packages/inter-protocol/src/stakeFactory/attestation.js
@@ -70,10 +70,10 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
 
   /** @param {Amount<'copyBag'>} attestationAmount */
   const unwrapLienedAmount = attestationAmount => {
-    assert(
-      attestationAmount.brand === attBrand,
-      X`The escrowed attestation ${attestationAmount} was not of the attestation brand ${attBrand}`,
-    );
+    attestationAmount.brand === attBrand ||
+      assert.fail(
+        X`The escrowed attestation ${attestationAmount} was not of the attestation brand ${attBrand}`,
+      );
     fit(
       attestationAmount.value.payload,
       harden([[M.string(), M.bigint()]]),

--- a/packages/inter-protocol/src/stakeFactory/stakeFactoryKit.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactoryKit.js
@@ -83,10 +83,10 @@ const initState = (zcf, startSeat, manager) => {
     } = startSeat.getProposal();
 
     const { maxDebt } = manager.maxDebtForLien(attestationGiven);
-    assert(
-      AmountMath.isGTE(maxDebt, runWanted),
-      X`wanted ${runWanted}, more than max debt (${maxDebt}) for ${attestationGiven}`,
-    );
+    AmountMath.isGTE(maxDebt, runWanted) ||
+      assert.fail(
+        X`wanted ${runWanted}, more than max debt (${maxDebt}) for ${attestationGiven}`,
+      );
 
     const { newDebt, fee, toMint } = calculateFee(
       manager.getLoanFee(),
@@ -94,10 +94,10 @@ const initState = (zcf, startSeat, manager) => {
       emptyDebt,
       runWanted,
     );
-    assert(
-      !AmountMath.isEmpty(fee),
-      X`loan requested (${runWanted}) is too small; cannot accrue interest`,
-    );
+    !AmountMath.isEmpty(fee) ||
+      assert.fail(
+        X`loan requested (${runWanted}) is too small; cannot accrue interest`,
+      );
     assert(AmountMath.isEqual(newDebt, toMint), X`loan fee mismatch`);
     trace('init', { runWanted, fee, attestationGiven });
 
@@ -236,10 +236,8 @@ const helperBehavior = {
   assertVaultHoldsNoMinted: ({ state, facets }) => {
     const { vaultSeat } = state;
     const { helper } = facets;
-    assert(
-      AmountMath.isEmpty(helper.getMintedAllocated(vaultSeat)),
-      X`Vault should be empty of debt`,
-    );
+    AmountMath.isEmpty(helper.getMintedAllocated(vaultSeat)) ||
+      assert.fail(X`Vault should be empty of debt`);
   },
 
   /**
@@ -339,10 +337,10 @@ const helperBehavior = {
     const {
       give: { [KW.Debt]: runOffered },
     } = seat.getProposal();
-    assert(
-      AmountMath.isGTE(runOffered, currentDebt),
-      X`Offer ${runOffered} is not sufficient to pay off debt ${currentDebt}`,
-    );
+    AmountMath.isGTE(runOffered, currentDebt) ||
+      assert.fail(
+        X`Offer ${runOffered} is not sufficient to pay off debt ${currentDebt}`,
+      );
     vaultSeat.incrementBy(seat.decrementBy(harden({ [KW.Debt]: currentDebt })));
     seat.incrementBy(
       vaultSeat.decrementBy(

--- a/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -284,10 +284,8 @@ const start = async zcf => {
     assertProposalShape(debtorSeat, {
       give: { In: null },
     });
-    assert(
-      originalDebt.brand === debtBrand,
-      X`Cannot liquidate to ${originalDebt.brand}`,
-    );
+    originalDebt.brand === debtBrand ||
+      assert.fail(X`Cannot liquidate to ${originalDebt.brand}`);
     const penalty = ceilMultiplyBy(originalDebt, penaltyRate);
     const debtWithPenalty = AmountMath.add(originalDebt, penalty);
     trace('LIQ', { originalDebt, debtWithPenalty });

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -230,10 +230,10 @@ const helperBehavior = {
   assignPhase: ({ state }, newPhase) => {
     const { phase } = state;
     const validNewPhases = validTransitions[phase];
-    assert(
-      validNewPhases.includes(newPhase),
-      X`Vault cannot transition from ${q(phase)} to ${q(newPhase)}`,
-    );
+    validNewPhases.includes(newPhase) ||
+      assert.fail(
+        X`Vault cannot transition from ${q(phase)} to ${q(newPhase)}`,
+      );
     state.phase = newPhase;
   },
 
@@ -244,10 +244,11 @@ const helperBehavior = {
 
   assertCloseable: ({ state }) => {
     const { phase } = state;
-    assert(
-      phase === Phase.ACTIVE || phase === Phase.LIQUIDATED,
-      X`to be closed a vault must be active or liquidated, not ${phase}`,
-    );
+    phase === Phase.ACTIVE ||
+      phase === Phase.LIQUIDATED ||
+      assert.fail(
+        X`to be closed a vault must be active or liquidated, not ${phase}`,
+      );
   },
   // #endregion
 
@@ -303,10 +304,8 @@ const helperBehavior = {
 
   assertVaultHoldsNoMinted: ({ state, facets }) => {
     const { vaultSeat } = state;
-    assert(
-      AmountMath.isEmpty(facets.helper.getMintedAllocated(vaultSeat)),
-      X`Vault should be empty of Minted`,
-    );
+    AmountMath.isEmpty(facets.helper.getMintedAllocated(vaultSeat)) ||
+      assert.fail(X`Vault should be empty of Minted`);
   },
 
   /**
@@ -404,10 +403,10 @@ const helperBehavior = {
 
       // you must pay off the entire remainder but if you offer too much, we won't
       // take more than you owe
-      assert(
-        AmountMath.isGTE(given, debt),
-        X`Offer ${given} is not sufficient to pay off debt ${debt}`,
-      );
+      AmountMath.isGTE(given, debt) ||
+        assert.fail(
+          X`Offer ${given} is not sufficient to pay off debt ${debt}`,
+        );
 
       // Return any overpayment
       seat.incrementBy(vaultSeat.decrementBy(vaultSeat.getCurrentAllocation()));
@@ -492,10 +491,8 @@ const helperBehavior = {
     const newCollateralPre = addSubtract(collateralPre, giveColl, wantColl);
     // max debt supported by current Collateral as modified by proposal
     const maxDebtPre = await state.manager.maxDebtFor(newCollateralPre);
-    assert(
-      updaterPre === ephemera.outerUpdater,
-      X`Transfer during vault adjustment`,
-    );
+    updaterPre === ephemera.outerUpdater ||
+      assert.fail(X`Transfer during vault adjustment`);
     helper.assertActive();
 
     // After the `await`, we retrieve the vault's allocations again,
@@ -626,10 +623,10 @@ const selfBehavior = {
       fee,
       toMint,
     } = helper.loanFee(actualDebtPre, helper.emptyDebt(), wantMinted);
-    assert(
-      !AmountMath.isEmpty(fee),
-      X`loan requested (${wantMinted}) is too small; cannot accrue interest`,
-    );
+    !AmountMath.isEmpty(fee) ||
+      assert.fail(
+        X`loan requested (${wantMinted}) is too small; cannot accrue interest`,
+      );
     assert(AmountMath.isEqual(newDebtPre, toMint), X`fee mismatch for vault`);
     trace(
       'initVault',

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -217,10 +217,8 @@ const makeVaultInvitation = ({ state }) => {
       want: { Minted: requestedAmount },
     } = seat.getProposal();
     const { brand: brandIn } = collateralAmount;
-    assert(
-      collateralTypes.has(brandIn),
-      X`Not a supported collateral type ${brandIn}`,
-    );
+    collateralTypes.has(brandIn) ||
+      assert.fail(X`Not a supported collateral type ${brandIn}`);
 
     assert(
       AmountMath.isGTE(
@@ -326,10 +324,10 @@ const machineBehavior = {
     await zcf.saveIssuer(collateralIssuer, collateralKeyword);
     const collateralBrand = zcf.getBrandForIssuer(collateralIssuer);
     // We create only one vault per collateralType.
-    assert(
-      !collateralTypes.has(collateralBrand),
-      X`Collateral brand ${q(collateralBrand)} has already been added`,
-    );
+    !collateralTypes.has(collateralBrand) ||
+      assert.fail(
+        X`Collateral brand ${q(collateralBrand)} has already been added`,
+      );
 
     const managerStorageNode =
       storageNode &&
@@ -489,10 +487,8 @@ const publicBehavior = {
    */
   getCollateralManager: ({ state }, brandIn) => {
     const { collateralTypes } = state;
-    assert(
-      collateralTypes.has(brandIn),
-      X`Not a supported collateral type ${brandIn}`,
-    );
+    collateralTypes.has(brandIn) ||
+      assert.fail(X`Not a supported collateral type ${brandIn}`);
     /** @type {VaultManager} */
     return collateralTypes.get(brandIn).getPublicFacet();
   },

--- a/packages/inter-protocol/src/vpool-xyk-amm/addLiquidity.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/addLiquidity.js
@@ -30,10 +30,8 @@ const makeMakeAddLiquidityInvitation = (zcf, getPool) => {
     const pool = getPool(secondaryBrand);
     const liquidityIssuer = pool.getLiquidityIssuer();
     const liquidityBrand = zcf.getBrandForIssuer(liquidityIssuer);
-    assert(
-      seat.getProposal().want.Liquidity.brand === liquidityBrand,
-      X`liquidity brand must be ${q(liquidityBrand)}`,
-    );
+    seat.getProposal().want.Liquidity.brand === liquidityBrand ||
+      assert.fail(X`liquidity brand must be ${q(liquidityBrand)}`);
 
     return pool.addLiquidity(seat);
   };

--- a/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
@@ -38,18 +38,13 @@ export const makeAddIssuer = (
       E(secondaryIssuer).getBrand(),
     ]);
     // AWAIT ///////////////
-
-    assert(
-      secondaryAssetKind === AssetKind.NAT,
-      X`${keyword} asset not fungible (must use NAT math)`,
-    );
+    secondaryAssetKind === AssetKind.NAT ||
+      assert.fail(X`${keyword} asset not fungible (must use NAT math)`);
 
     /** @type {(brand: Brand) => Promise<ZCFMint>} */
     const makeLiquidityMint = brand => {
-      assert(
-        !isInSecondaries(brand),
-        X`issuer ${secondaryIssuer} already has a pool`,
-      );
+      !isInSecondaries(brand) ||
+        assert.fail(X`issuer ${secondaryIssuer} already has a pool`);
 
       const liquidityKeyword = `${keyword}Liquidity`;
       zcf.assertUniqueKeyword(liquidityKeyword);
@@ -151,17 +146,15 @@ export const makeAddPoolInvitation = (
         liquidityBrand,
         centralAboveMinimum,
       );
-
-      assert(
-        AmountMath.isGTE(funderLiquidityAmount, wantLiquidityAmount),
-        X`Requested too many liquidity tokens (${wantLiquidityAmount}, max: ${funderLiquidityAmount}`,
-      );
+      AmountMath.isGTE(funderLiquidityAmount, wantLiquidityAmount) ||
+        assert.fail(
+          X`Requested too many liquidity tokens (${wantLiquidityAmount}, max: ${funderLiquidityAmount}`,
+        );
     }
-
-    assert(
-      AmountMath.isGTE(centralAmount, minPoolLiquidity),
-      X`The minimum initial liquidity is ${minPoolLiquidity}, rejecting ${centralAmount}`,
-    );
+    AmountMath.isGTE(centralAmount, minPoolLiquidity) ||
+      assert.fail(
+        X`The minimum initial liquidity is ${minPoolLiquidity}, rejecting ${centralAmount}`,
+      );
     const minLiqAmount = AmountMath.make(
       liquidityBrand,
       minPoolLiquidity.value,

--- a/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/calcFees.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/calcFees.js
@@ -41,10 +41,10 @@ const amountGT = (left, right) =>
  * @returns {Amount}
  */
 const calcFee = ({ amountIn, amountOut }, feeRatio) => {
-  assert(
-    feeRatio.numerator.brand === feeRatio.denominator.brand,
-    X`feeRatio numerator and denominator must use the same brand ${feeRatio}`,
-  );
+  feeRatio.numerator.brand === feeRatio.denominator.brand ||
+    assert.fail(
+      X`feeRatio numerator and denominator must use the same brand ${feeRatio}`,
+    );
 
   let sameBrandAmount;
   if (amountIn.brand === feeRatio.numerator.brand) {
@@ -52,8 +52,7 @@ const calcFee = ({ amountIn, amountOut }, feeRatio) => {
   } else if (amountOut.brand === feeRatio.numerator.brand) {
     sameBrandAmount = amountOut;
   } else {
-    assert(
-      false,
+    assert.fail(
       X`feeRatio's brand (${feeRatio.numerator.brand}) must match one of the amounts [${amountIn}, ${amountOut}].`,
     );
   }
@@ -62,10 +61,8 @@ const calcFee = ({ amountIn, amountOut }, feeRatio) => {
   const fee = ceilMultiplyBy(sameBrandAmount, feeRatio);
 
   // Fee cannot exceed the amount on which it is levied
-  assert(
-    AmountMath.isGTE(sameBrandAmount, fee),
-    X`The feeRatio can't be greater than 1 ${feeRatio}`,
-  );
+  AmountMath.isGTE(sameBrandAmount, fee) ||
+    assert.fail(X`The feeRatio can't be greater than 1 ${feeRatio}`);
 
   return fee;
 };

--- a/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/core.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/core.js
@@ -9,10 +9,10 @@ import { getXY } from './getXY.js';
 const { details: X } = assert;
 
 const assertSingleBrand = ratio => {
-  assert(
-    ratio.numerator.brand === ratio.denominator.brand,
-    X`Ratio was expected to have same brand in numerator ${ratio.numerator.brand} and denominator ${ratio.denominator.brand}`,
-  );
+  ratio.numerator.brand === ratio.denominator.brand ||
+    assert.fail(
+      X`Ratio was expected to have same brand in numerator ${ratio.numerator.brand} and denominator ${ratio.denominator.brand}`,
+    );
 };
 
 /**
@@ -107,11 +107,10 @@ export const calcDeltaXSellingX = (x, y, deltaY) => {
 const swapInReduced = ({ x, y, deltaX: offeredAmountIn }) => {
   const amountOut = calcDeltaYSellingX(x, y, offeredAmountIn);
   const reducedAmountIn = calcDeltaXSellingX(x, y, amountOut);
-
-  assert(
-    AmountMath.isGTE(offeredAmountIn, reducedAmountIn),
-    X`The trade would have required ${reducedAmountIn} more than was offered ${offeredAmountIn}`,
-  );
+  AmountMath.isGTE(offeredAmountIn, reducedAmountIn) ||
+    assert.fail(
+      X`The trade would have required ${reducedAmountIn} more than was offered ${offeredAmountIn}`,
+    );
 
   return harden({
     amountIn: reducedAmountIn,
@@ -130,11 +129,10 @@ const swapInReduced = ({ x, y, deltaX: offeredAmountIn }) => {
 const swapOutImproved = ({ x, y, deltaY: wantedAmountOut }) => {
   const amountIn = calcDeltaXSellingX(x, y, wantedAmountOut);
   const improvedAmountOut = calcDeltaYSellingX(x, y, amountIn);
-
-  assert(
-    AmountMath.isGTE(improvedAmountOut, wantedAmountOut),
-    X`The trade would have returned ${improvedAmountOut} less than was wanted ${wantedAmountOut}`,
-  );
+  AmountMath.isGTE(improvedAmountOut, wantedAmountOut) ||
+    assert.fail(
+      X`The trade would have returned ${improvedAmountOut} less than was wanted ${wantedAmountOut}`,
+    );
 
   return harden({
     amountIn,

--- a/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/getXY.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/getXY.js
@@ -21,10 +21,11 @@ export const getXY = ({ amountGiven, poolAllocation, amountWanted }) => {
   const yBrand = amountWanted && amountWanted.brand;
   const secondaryBrand = poolAllocation.Secondary.brand;
   const centralBrand = poolAllocation.Central.brand;
-  assert(
-    amountGiven || amountWanted,
-    X`At least one of ${amountGiven} and ${amountWanted} must be specified`,
-  );
+  amountGiven ||
+    amountWanted ||
+    assert.fail(
+      X`At least one of ${amountGiven} and ${amountWanted} must be specified`,
+    );
 
   const deltas = {
     deltaX: amountGiven,

--- a/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/swap.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/swap.js
@@ -95,10 +95,8 @@ const isGreaterThanZero = amount => {
 };
 
 const assertGreaterThanZero = (amount, name) => {
-  assert(
-    amount && isGreaterThanZero(amount),
-    X`${name} must be greater than 0: ${amount}`,
-  );
+  (amount && isGreaterThanZero(amount)) ||
+    assert.fail(X`${name} must be greater than 0: ${amount}`);
 };
 
 const isWantedAvailable = (poolAllocation, amountWanted) => {

--- a/packages/inter-protocol/src/vpool-xyk-amm/doublePool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/doublePool.js
@@ -50,10 +50,10 @@ export const makeDoublePool = (
 
   const centralBrand = inCentral.brand;
   const emptyCentralAmount = AmountMath.makeEmpty(centralBrand);
-  assert(
-    centralBrand === outCentral.brand,
-    X`The central brands on the two pools must match: ${centralBrand}, ${outCentral.brand}`,
-  );
+  centralBrand === outCentral.brand ||
+    assert.fail(
+      X`The central brands on the two pools must match: ${centralBrand}, ${outCentral.brand}`,
+    );
 
   const allocateGainsAndLosses = (seat, prices) => {
     const inPoolSeat = collateralInPool.getPoolSeat();

--- a/packages/inter-protocol/test/swingsetTests/governance/vat-voter.js
+++ b/packages/inter-protocol/test/swingsetTests/governance/vat-voter.js
@@ -83,22 +83,14 @@ const build = async (log, zoe) => {
             E(zoe).getInstallationForInstance(electorateInstance),
             E(zoe).getInstallationForInstance(governedInstance),
           ]);
-          assert(
-            counterInstallation === installations.counter,
-            X`counterInstallation should match`,
-          );
-          assert(
-            governorInstallation === installations.governor,
-            X`governor Installation should match`,
-          );
-          assert(
-            electorateInstallation === installations.electorate,
-            X`electorate Installation should match`,
-          );
-          assert(
-            governedInstallation === installations.vaultFactory,
-            X`vaultFactory Installation should match`,
-          );
+          counterInstallation === installations.counter ||
+            assert.fail(X`counterInstallation should match`);
+          governorInstallation === installations.governor ||
+            assert.fail(X`governor Installation should match`);
+          electorateInstallation === installations.electorate ||
+            assert.fail(X`electorate Installation should match`);
+          governedInstallation === installations.vaultFactory ||
+            assert.fail(X`vaultFactory Installation should match`);
         },
       });
     },

--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -92,10 +92,8 @@ const makeTestContext = async () => {
 
   const registerBundleHandles = bundleHandleMap => {
     for (const [{ bundleID }, paths] of bundleHandleMap.entries()) {
-      assert(
-        !bundleIDToAbsolutePaths.has(bundleID),
-        X`bundleID ${bundleID} already registered`,
-      );
+      !bundleIDToAbsolutePaths.has(bundleID) ||
+        assert.fail(X`bundleID ${bundleID} already registered`);
       bundleIDToAbsolutePaths.set(bundleID, paths);
     }
   };

--- a/packages/sharing-service/src/sharedMap.js
+++ b/packages/sharing-service/src/sharedMap.js
@@ -16,10 +16,8 @@ function makeSharedMap(name) {
       return namedEntries.get(propertyName)[0];
     },
     addEntry(key, value) {
-      assert(
-        !namedEntries.has(key),
-        X`SharedMap ${name} already has an entry for ${key}.`,
-      );
+      !namedEntries.has(key) ||
+        assert.fail(X`SharedMap ${name} already has an entry for ${key}.`);
       orderedEntries.push([key, value]);
       namedEntries.set(key, [value, orderedEntries.length]);
       return orderedEntries.length;

--- a/packages/sharing-service/src/sharing.js
+++ b/packages/sharing-service/src/sharing.js
@@ -16,30 +16,24 @@ function makeSharingService() {
       if (!sharedMaps.has(key)) {
         return undefined;
       }
-      assert(
-        sharedMaps.get(key) !== tombstone,
-        X`Entry for ${key} has already been collected.`,
-      );
+      sharedMaps.get(key) !== tombstone ||
+        assert.fail(X`Entry for ${key} has already been collected.`);
       const result = sharedMaps.get(key);
       // these are single-use entries. Leave a tombstone to prevent MITM.
       sharedMaps.set(key, tombstone);
       return result;
     },
     createSharedMap(preferredName) {
-      assert(
-        !sharedMaps.has(preferredName),
-        X`Entry already exists: ${preferredName}`,
-      );
+      !sharedMaps.has(preferredName) ||
+        assert.fail(X`Entry already exists: ${preferredName}`);
       const sharedMap = makeSharedMap(preferredName);
       sharedMaps.set(preferredName, sharedMap);
       brand.add(sharedMap);
       return sharedMap;
     },
     validate(allegedSharedMap) {
-      assert(
-        brand.has(allegedSharedMap),
-        X`Unrecognized sharedMap: ${allegedSharedMap}`,
-      );
+      brand.has(allegedSharedMap) ||
+        assert.fail(X`Unrecognized sharedMap: ${allegedSharedMap}`);
       return allegedSharedMap;
     },
     // We don't need remove, since grabSharedMap can be used for that.

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -130,10 +130,8 @@ const buildSwingset = async (
   const importPlugin = async mod => {
     // Ensure they can't traverse out of the plugins prefix.
     const pluginFile = path.resolve(pluginsPrefix, mod);
-    assert(
-      pluginFile.startsWith(pluginsPrefix),
-      X`Cannot load ${pluginFile} plugin; outside of ${pluginDir}`,
-    );
+    pluginFile.startsWith(pluginsPrefix) ||
+      assert.fail(X`Cannot load ${pluginFile} plugin; outside of ${pluginDir}`);
 
     // TODO: Detect the module type and use the appropriate loader, just like
     // `agoric deploy`.

--- a/packages/stat-logger/src/statGraph.js
+++ b/packages/stat-logger/src/statGraph.js
@@ -158,10 +158,9 @@ export async function renderGraph(spec, outputPath, type = 'png') {
   } else if (spec.marks.length === 0) {
     throw new Error('graph spec has no graphs defined');
   }
-  assert(
-    type === 'png' || type === 'pdf',
-    X`invalid output type ${type}, valid types are png or pdf`,
-  );
+  type === 'png' ||
+    type === 'pdf' ||
+    assert.fail(X`invalid output type ${type}, valid types are png or pdf`);
 
   let loadDir = '.';
   let out = process.stdout;

--- a/packages/store/src/keys/checkKey.js
+++ b/packages/store/src/keys/checkKey.js
@@ -158,10 +158,8 @@ export const checkCopySet = (s, check) => {
     return true;
   }
   const result =
-    check(
-      passStyleOf(s) === 'tagged' && getTag(s) === 'copySet',
-      X`Not a copySet: ${s}`,
-    ) &&
+    ((passStyleOf(s) === 'tagged' && getTag(s) === 'copySet') ||
+      check(false, X`Not a copySet: ${s}`)) &&
     checkElements(s.payload, check) &&
     checkKey(s.payload, check);
   if (result) {
@@ -244,10 +242,8 @@ export const checkCopyBag = (b, check) => {
     return true;
   }
   const result =
-    check(
-      passStyleOf(b) === 'tagged' && getTag(b) === 'copyBag',
-      X`Not a copyBag: ${b}`,
-    ) &&
+    ((passStyleOf(b) === 'tagged' && getTag(b) === 'copyBag') ||
+      check(false, X`Not a copyBag: ${b}`)) &&
     checkBagEntries(b.payload, check) &&
     checkKey(b.payload, check);
   if (result) {
@@ -363,20 +359,20 @@ export const checkCopyMap = (m, check) => {
   }
   const { keys, values, ...rest } = payload;
   const result =
-    check(
-      ownKeys(rest).length === 0,
-      X`A copyMap's payload must only have .keys and .values: ${m}`,
-    ) &&
+    (ownKeys(rest).length === 0 ||
+      check(
+        false,
+        X`A copyMap's payload must only have .keys and .values: ${m}`,
+      )) &&
     checkElements(keys, check) &&
     checkKey(keys, check) &&
-    check(
-      passStyleOf(values) === 'copyArray',
-      X`A copyMap's .values must be a copyArray: ${m}`,
-    ) &&
-    check(
-      keys.length === values.length,
-      X`A copyMap must have the same number of keys and values: ${m}`,
-    );
+    (passStyleOf(values) === 'copyArray' ||
+      check(false, X`A copyMap's .values must be a copyArray: ${m}`)) &&
+    (keys.length === values.length ||
+      check(
+        false,
+        X`A copyMap must have the same number of keys and values: ${m}`,
+      ));
   if (result) {
     copyMapMemo.add(m);
   }

--- a/packages/store/src/keys/merge-bag-operators.js
+++ b/packages/store/src/keys/merge-bag-operators.js
@@ -232,10 +232,8 @@ const bagIterCompare = xyi => {
   } else if (loneY) {
     return -1;
   } else {
-    assert(
-      !loneX && !loneY,
-      X`Internal: Unexpected lone pair ${q([loneX, loneY])}`,
-    );
+    (!loneX && !loneY) ||
+      assert.fail(X`Internal: Unexpected lone pair ${q([loneX, loneY])}`);
     return 0;
   }
 };

--- a/packages/store/src/keys/merge-set-operators.js
+++ b/packages/store/src/keys/merge-set-operators.js
@@ -208,10 +208,8 @@ const iterCompare = xyi => {
   } else if (loneY) {
     return -1;
   } else {
-    assert(
-      !loneX && !loneY,
-      X`Internal: Unexpected lone pair ${q([loneX, loneY])}`,
-    );
+    (!loneX && !loneY) ||
+      assert.fail(X`Internal: Unexpected lone pair ${q([loneX, loneY])}`);
     return 0;
   }
 };

--- a/packages/store/src/patterns/encodePassable.js
+++ b/packages/store/src/patterns/encodePassable.js
@@ -128,10 +128,9 @@ const encodeBigInt = n => {
 const decodeBigInt = encoded => {
   const typePrefix = encoded[0];
   let rem = encoded.slice(1);
-  assert(
-    typePrefix === 'p' || typePrefix === 'n',
-    X`Encoded bigint expected: ${encoded}`,
-  );
+  typePrefix === 'p' ||
+    typePrefix === 'n' ||
+    assert.fail(X`Encoded bigint expected: ${encoded}`);
 
   const lDigits = rem.search(/[0-9]/) + 1;
   assert(lDigits >= 1, X`Digit count expected: ${encoded}`);
@@ -140,11 +139,8 @@ const decodeBigInt = encoded => {
   assert(rem.length >= lDigits, X`Complete digit count expected: ${encoded}`);
   const snDigits = rem.slice(0, lDigits);
   rem = rem.slice(lDigits);
-
-  assert(
-    /^[0-9]+$/.test(snDigits),
-    X`Decimal digit count expected: ${encoded}`,
-  );
+  /^[0-9]+$/.test(snDigits) ||
+    assert.fail(X`Decimal digit count expected: ${encoded}`);
   let nDigits = parseInt(snDigits, 10);
   if (typePrefix === 'n') {
     // TODO Assert to reject forbidden encodings
@@ -154,11 +150,8 @@ const decodeBigInt = encoded => {
 
   assert(rem.startsWith(':'), X`Separator expected: ${encoded}`);
   rem = rem.slice(1);
-
-  assert(
-    rem.length === nDigits,
-    X`Fixed-length digit sequence expected: ${encoded}`,
-  );
+  rem.length === nDigits ||
+    assert.fail(X`Fixed-length digit sequence expected: ${encoded}`);
   let n = BigInt(rem);
   if (typePrefix === 'n') {
     // TODO Assert to reject forbidden encodings
@@ -203,10 +196,9 @@ const decodeArray = (encoded, decodePassable) => {
       i += 1;
       assert(i < encoded.length, X`unexpected end of encoding ${encoded}`);
       const c2 = encoded[i];
-      assert(
-        c2 === '\u0000' || c2 === '\u0001',
-        X`Unexpected character after u0001 escape: ${c2}`,
-      );
+      c2 === '\u0000' ||
+        c2 === '\u0001' ||
+        assert.fail(X`Unexpected character after u0001 escape: ${c2}`);
       elemChars.push(c2);
     } else {
       elemChars.push(c);
@@ -247,10 +239,8 @@ const decodeTagged = (encoded, decodePassable) => {
   const tagpayload = decodeArray(encoded.substring(1), decodePassable);
   assert(tagpayload.length === 2, X`expected tag,payload pair: ${encoded}`);
   const [tag, payload] = tagpayload;
-  assert(
-    passStyleOf(tag) === 'string',
-    X`not a valid tagged encoding: ${encoded}`,
-  );
+  passStyleOf(tag) === 'string' ||
+    assert.fail(X`not a valid tagged encoding: ${encoded}`);
   return makeTagged(tag, payload);
 };
 
@@ -297,26 +287,26 @@ export const makeEncodePassable = ({
       }
       case 'remotable': {
         const result = encodeRemotable(passable);
-        assert(
-          result.startsWith('r'),
-          X`internal: Remotable encoding must start with "r": ${result}`,
-        );
+        result.startsWith('r') ||
+          assert.fail(
+            X`internal: Remotable encoding must start with "r": ${result}`,
+          );
         return result;
       }
       case 'error': {
         const result = encodeError(passable);
-        assert(
-          result.startsWith('!'),
-          X`internal: Error encoding must start with "!": ${result}`,
-        );
+        result.startsWith('!') ||
+          assert.fail(
+            X`internal: Error encoding must start with "!": ${result}`,
+          );
         return result;
       }
       case 'promise': {
         const result = encodePromise(passable);
-        assert(
-          result.startsWith('?'),
-          X`internal: Promise encoding must start with "p": ${result}`,
-        );
+        result.startsWith('?') ||
+          assert.fail(
+            X`internal: Promise encoding must start with "p": ${result}`,
+          );
         return result;
       }
       case 'symbol': {

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -70,10 +70,8 @@ const isAwaitArgGuard = argGuard =>
 
 const desync = methodGuard => {
   const { argGuards, optionalArgGuards = [], restArgGuard } = methodGuard;
-  assert(
-    !isAwaitArgGuard(restArgGuard),
-    X`Rest args may not be awaited: ${restArgGuard}`,
-  );
+  !isAwaitArgGuard(restArgGuard) ||
+    assert.fail(X`Rest args may not be awaited: ${restArgGuard}`);
   const rawArgGuards = [...argGuards, ...optionalArgGuards];
 
   const awaitIndexes = [];
@@ -155,10 +153,10 @@ const bindMethod = (
 
   const getContext = self => {
     const context = contextMap.get(self);
-    assert(
-      context,
-      X`${q(methodTag)} may only be applied to a valid instance: ${self}`,
-    );
+    context ||
+      assert.fail(
+        X`${q(methodTag)} may only be applied to a valid instance: ${self}`,
+      );
     return context;
   };
 
@@ -233,16 +231,16 @@ export const defendPrototype = (
     {
       const methodGuardNames = ownKeys(methodGuards);
       const unimplemented = listDifference(methodGuardNames, methodNames);
-      assert(
-        unimplemented.length === 0,
-        X`methods ${q(unimplemented)} not implemented by ${q(tag)}`,
-      );
+      unimplemented.length === 0 ||
+        assert.fail(
+          X`methods ${q(unimplemented)} not implemented by ${q(tag)}`,
+        );
       if (!sloppy) {
         const unguarded = listDifference(methodNames, methodGuardNames);
-        assert(
-          unguarded.length === 0,
-          X`methods ${q(unguarded)} not guarded by ${q(interfaceName)}`,
-        );
+        unguarded.length === 0 ||
+          assert.fail(
+            X`methods ${q(unguarded)} not guarded by ${q(interfaceName)}`,
+          );
       }
     }
   }
@@ -353,15 +351,15 @@ export const defineHeapFarClassKit = (
   const facetNames = ownKeys(methodsKit);
   const interfaceNames = ownKeys(interfaceGuardKit);
   const extraInterfaceNames = listDifference(facetNames, interfaceNames);
-  assert(
-    extraInterfaceNames.length === 0,
-    X`Interfaces ${q(extraInterfaceNames)} not implemented by ${q(tag)}`,
-  );
+  extraInterfaceNames.length === 0 ||
+    assert.fail(
+      X`Interfaces ${q(extraInterfaceNames)} not implemented by ${q(tag)}`,
+    );
   const extraFacetNames = listDifference(interfaceNames, facetNames);
-  assert(
-    extraFacetNames.length === 0,
-    X`Facets ${q(extraFacetNames)} of ${q(tag)} not guarded by interfaces`,
-  );
+  extraFacetNames.length === 0 ||
+    assert.fail(
+      X`Facets ${q(extraFacetNames)} of ${q(tag)} not guarded by interfaces`,
+    );
 
   const contextMapKit = objectMap(methodsKit, () => new WeakMap());
   const prototypeKit = objectMap(methodsKit, (methods, facetName) =>

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -113,11 +113,10 @@ export const makeScalarWeakMapStore = (
     // TODO: Just a transition kludge. Remove when possible.
     // See https://github.com/Agoric/agoric-sdk/issues/3606
     harden(key);
-
-    assert(
-      passStyleOf(key) === 'remotable',
-      X`Only remotables can be keys of scalar WeakMapStores: ${key}`,
-    );
+    passStyleOf(key) === 'remotable' ||
+      assert.fail(
+        X`Only remotables can be keys of scalar WeakMapStores: ${key}`,
+      );
     if (keyShape !== undefined) {
       fit(key, keyShape, 'weakMapStore key');
     }

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -81,11 +81,8 @@ export const makeScalarWeakSetStore = (
     // TODO: Just a transition kludge. Remove when possible.
     // See https://github.com/Agoric/agoric-sdk/issues/3606
     harden(key);
-
-    assert(
-      passStyleOf(key) === 'remotable',
-      X`Only remotables can be keys of scalar WeakStores: ${key}`,
-    );
+    passStyleOf(key) === 'remotable' ||
+      assert.fail(X`Only remotables can be keys of scalar WeakStores: ${key}`);
     if (keyShape !== undefined) {
       fit(key, keyShape, 'weakSetStore key');
     }

--- a/packages/swing-store/src/ephemeralSwingStore.js
+++ b/packages/swing-store/src/ephemeralSwingStore.js
@@ -126,10 +126,8 @@ export function initEphemeralSwingStore() {
 
   function insistStreamName(streamName) {
     assert.typeof(streamName, 'string');
-    assert(
-      streamName.match(/^[-\w]+$/),
-      X`invalid stream name ${q(streamName)}`,
-    );
+    streamName.match(/^[-\w]+$/) ||
+      assert.fail(X`invalid stream name ${q(streamName)}`);
   }
 
   function insistStreamPosition(position) {
@@ -159,10 +157,10 @@ export function initEphemeralSwingStore() {
   function readStream(streamName, startPosition, endPosition) {
     insistStreamName(streamName);
     const stream = streams.get(streamName) || [];
-    assert(
-      !streamStatus.get(streamName),
-      X`can't read stream ${q(streamName)} because it's already in use`,
-    );
+    !streamStatus.get(streamName) ||
+      assert.fail(
+        X`can't read stream ${q(streamName)} because it's already in use`,
+      );
     insistStreamPosition(startPosition);
     insistStreamPosition(endPosition);
     assert(startPosition.itemCount <= endPosition.itemCount);
@@ -177,18 +175,16 @@ export function initEphemeralSwingStore() {
       let pos = startPosition.itemCount;
       function* reader() {
         while (pos < stream.length) {
-          assert(
-            streamStatus.get(streamName) === readStatus,
-            X`can't read stream ${q(streamName)}, it's been closed`,
-          );
+          streamStatus.get(streamName) === readStatus ||
+            assert.fail(
+              X`can't read stream ${q(streamName)}, it's been closed`,
+            );
           const result = stream[pos];
           pos += 1;
           yield result;
         }
-        assert(
-          streamStatus.get(streamName) === readStatus,
-          X`can't read stream ${q(streamName)}, it's been closed`,
-        );
+        streamStatus.get(streamName) === readStatus ||
+          assert.fail(X`can't read stream ${q(streamName)}, it's been closed`);
         streamStatus.delete(streamName);
       }
       return reader();
@@ -212,10 +208,10 @@ export function initEphemeralSwingStore() {
       stream = [];
       streams.set(streamName, stream);
     } else {
-      assert(
-        !streamStatus.get(streamName),
-        X`can't write stream ${q(streamName)} because it's already in use`,
-      );
+      !streamStatus.get(streamName) ||
+        assert.fail(
+          X`can't write stream ${q(streamName)} because it's already in use`,
+        );
     }
     stream[position.itemCount] = item;
     return harden({ itemCount: position.itemCount + 1 });

--- a/packages/swing-store/src/sqlStreamStore.js
+++ b/packages/swing-store/src/sqlStreamStore.js
@@ -82,16 +82,16 @@ export function sqlStreamStore(dbDir, io) {
    */
   function readStream(streamName, startPosition, endPosition) {
     insistStreamName(streamName);
-    assert(
-      !streamStatus.get(streamName),
-      X`can't read stream ${q(streamName)} because it's already in use`,
-    );
+    !streamStatus.get(streamName) ||
+      assert.fail(
+        X`can't read stream ${q(streamName)} because it's already in use`,
+      );
     insistStreamPosition(startPosition);
     insistStreamPosition(endPosition);
-    assert(
-      startPosition.itemCount <= endPosition.itemCount,
-      X`${q(startPosition.itemCount)} <= ${q(endPosition.itemCount)}}`,
-    );
+    startPosition.itemCount <= endPosition.itemCount ||
+      assert.fail(
+        X`${q(startPosition.itemCount)} <= ${q(endPosition.itemCount)}}`,
+      );
 
     function* reader() {
       ensureTransaction();
@@ -106,19 +106,16 @@ export function sqlStreamStore(dbDir, io) {
         startPosition.itemCount,
         endPosition.itemCount,
       )) {
-        assert(
-          streamStatus.get(streamName) === 'reading',
-          X`can't read stream ${q(streamName)}, it's been closed`,
-        );
+        streamStatus.get(streamName) === 'reading' ||
+          assert.fail(X`can't read stream ${q(streamName)}, it's been closed`);
         yield item;
       }
       streamStatus.delete(streamName);
     }
-
-    assert(
-      !streamStatus.has(streamName),
-      X`can't read stream ${q(streamName)} because it's already in use`,
-    );
+    !streamStatus.has(streamName) ||
+      assert.fail(
+        X`can't read stream ${q(streamName)} because it's already in use`,
+      );
 
     if (startPosition.itemCount === endPosition.itemCount) {
       return empty();
@@ -137,11 +134,10 @@ export function sqlStreamStore(dbDir, io) {
   const writeStreamItem = (streamName, item, position) => {
     insistStreamName(streamName);
     insistStreamPosition(position);
-
-    assert(
-      !streamStatus.get(streamName),
-      X`can't write stream ${q(streamName)} because it's already in use`,
-    );
+    !streamStatus.get(streamName) ||
+      assert.fail(
+        X`can't write stream ${q(streamName)} because it's already in use`,
+      );
 
     ensureTransaction();
     db.prepare(

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -25,19 +25,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       // Bob ensures it's the contract he expects
-      assert(
-        installations.automaticRefund === installation,
-        X`should be the expected automaticRefund`,
-      );
-
-      assert(
-        issuerKeywordRecord.Contribution1 === moolaIssuer,
-        X`The first issuer should be the moola issuer`,
-      );
-      assert(
-        issuerKeywordRecord.Contribution2 === simoleanIssuer,
-        X`The second issuer should be the simolean issuer`,
-      );
+      installations.automaticRefund === installation ||
+        assert.fail(X`should be the expected automaticRefund`);
+      issuerKeywordRecord.Contribution1 === moolaIssuer ||
+        assert.fail(X`The first issuer should be the moola issuer`);
+      issuerKeywordRecord.Contribution2 === simoleanIssuer ||
+        assert.fail(X`The second issuer should be the simolean issuer`);
 
       // 1. Bob escrows his offer
       const bobProposal = harden({
@@ -84,10 +77,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
       assert(installation === installations.coveredCall, X`wrong installation`);
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      optionValue[0].description === 'exerciseOption' ||
+        assert.fail(X`wrong invitation`);
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
@@ -103,15 +94,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(optionValue[0].expirationDate === 1n, X`wrong expirationDate`);
       assert(optionValue[0].timeAuthority === timer, 'wrong timer');
       const { UnderlyingAsset, StrikePrice } = issuerKeywordRecord;
-
-      assert(
-        UnderlyingAsset === moolaIssuer,
-        X`The underlying asset issuer should be the moola issuer`,
-      );
-      assert(
-        StrikePrice === simoleanIssuer,
-        X`The strike price issuer should be the simolean issuer`,
-      );
+      UnderlyingAsset === moolaIssuer ||
+        assert.fail(X`The underlying asset issuer should be the moola issuer`);
+      StrikePrice === simoleanIssuer ||
+        assert.fail(X`The strike price issuer should be the simolean issuer`);
 
       const bobPayments = { StrikePrice: simoleanPayment };
       // Bob escrows
@@ -150,10 +136,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const optionValue = optionAmounts.value;
 
       assert(installation === installations.coveredCall, X`wrong installation`);
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      optionValue[0].description === 'exerciseOption' ||
+        assert.fail(X`wrong invitation`);
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
@@ -170,14 +154,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
       assert(optionValue[0].expirationDate === 100n, X`wrong expiration date`);
       assert(optionValue[0].timeAuthority === timer, X`wrong timer`);
-      assert(
-        UnderlyingAsset === moolaIssuer,
-        X`The underlyingAsset issuer should be the moola issuer`,
-      );
-      assert(
-        StrikePrice === simoleanIssuer,
-        X`The strikePrice issuer should be the simolean issuer`,
-      );
+      UnderlyingAsset === moolaIssuer ||
+        assert.fail(X`The underlyingAsset issuer should be the moola issuer`);
+      StrikePrice === simoleanIssuer ||
+        assert.fail(X`The strikePrice issuer should be the simolean issuer`);
 
       // Let's imagine that Bob wants to create a swap to trade this
       // invitation for bucks. He wants to invitation Dave as the
@@ -227,11 +207,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
-
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      installation === installations.secondPriceAuction ||
+        assert.fail(X`wrong installation`);
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
@@ -282,15 +259,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         ),
         X`issuers were not as expected`,
       );
-
-      assert(
-        keyEQ(invitationValue[0].asset, moola(3)),
-        X`Alice made a different offer than expected`,
-      );
-      assert(
-        keyEQ(invitationValue[0].price, simoleans(7)),
-        X`Alice made a different offer than expected`,
-      );
+      keyEQ(invitationValue[0].asset, moola(3)) ||
+        assert.fail(X`Alice made a different offer than expected`);
+      keyEQ(invitationValue[0].price, simoleans(7)) ||
+        assert.fail(X`Alice made a different offer than expected`);
 
       const proposal = harden({
         want: { Asset: moola(3) },
@@ -321,19 +293,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const installation = await E(zoe).getInstallation(invitation);
       const exclInvitation = await E(invitationIssuer).claim(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-
-      assert(
-        installation === installations.simpleExchange,
-        X`wrong installation`,
-      );
-      assert(
-        issuerKeywordRecord.Asset === moolaIssuer,
-        X`The first issuer should be the moola issuer`,
-      );
-      assert(
-        issuerKeywordRecord.Price === simoleanIssuer,
-        X`The second issuer should be the simolean issuer`,
-      );
+      installation === installations.simpleExchange ||
+        assert.fail(X`wrong installation`);
+      issuerKeywordRecord.Asset === moolaIssuer ||
+        assert.fail(X`The first issuer should be the moola issuer`);
+      issuerKeywordRecord.Price === simoleanIssuer ||
+        assert.fail(X`The second issuer should be the simolean issuer`);
 
       const bobBuyOrderProposal = harden({
         want: { Asset: moola(3) },
@@ -364,19 +329,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-
-      assert(
-        installation === installations.simpleExchange,
-        X`wrong installation`,
-      );
-      assert(
-        issuerKeywordRecord.Asset === moolaIssuer,
-        X`The first issuer should be the moola issuer`,
-      );
-      assert(
-        issuerKeywordRecord.Price === simoleanIssuer,
-        X`The second issuer should be the simolean issuer`,
-      );
+      installation === installations.simpleExchange ||
+        assert.fail(X`wrong installation`);
+      issuerKeywordRecord.Asset === moolaIssuer ||
+        assert.fail(X`The first issuer should be the moola issuer`);
+      issuerKeywordRecord.Price === simoleanIssuer ||
+        assert.fail(X`The second issuer should be the simolean issuer`);
       const bobBuyOrderProposal = harden({
         want: { Asset: moola(m) },
         give: { Price: simoleans(s) },

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -24,11 +24,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         invitation,
       );
-
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      installation === installations.secondPriceAuction ||
+        assert.fail(X`wrong installation`);
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -25,11 +25,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
-
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      installation === installations.secondPriceAuction ||
+        assert.fail(X`wrong installation`);
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
@@ -77,18 +74,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
       const { source } = await E(installation).getBundle();
       // pick some arbitrary code points as a signature.
-      assert(
-        source.includes('asset: give.Asset,'),
-        X`source bundle didn't match at "asset: give.Asset,"`,
-      );
-      assert(
-        source.includes('swap(zcf, firstSeat, matchingSeat)'),
-        X`source bundle didn't match at "swap(zcf, firstSeat, matchingSeat)"`,
-      );
-      assert(
-        source.includes('makeMatchingInvitation'),
-        X`source bundle didn't match at "makeMatchingInvitation"`,
-      );
+      source.includes('asset: give.Asset,') ||
+        assert.fail(X`source bundle didn't match at "asset: give.Asset,"`);
+      source.includes('swap(zcf, firstSeat, matchingSeat)') ||
+        assert.fail(
+          X`source bundle didn't match at "swap(zcf, firstSeat, matchingSeat)"`,
+        );
+      source.includes('makeMatchingInvitation') ||
+        assert.fail(X`source bundle didn't match at "makeMatchingInvitation"`);
       assert(installation === installations.atomicSwap, X`wrong installation`);
       assert(
         keyEQ(
@@ -100,16 +93,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       // Dave expects that Bob has already made an offer in the swap
       // with the following rules:
-      assert(
-        keyEQ(invitationValue[0].asset, optionAmounts),
-        X`asset is the option`,
-      );
+      keyEQ(invitationValue[0].asset, optionAmounts) ||
+        assert.fail(X`asset is the option`);
       assert(keyEQ(invitationValue[0].price, bucks(1n)), X`price is 1 buck`);
       const optionValue = optionAmounts.value;
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      optionValue[0].description === 'exerciseOption' ||
+        assert.fail(X`wrong invitation`);
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -117,10 +117,8 @@ export const makeMemoryMappedCircularBuffer = async ({
    * @returns {IteratorResult<Uint8Array, void>}
    */
   const readCircBuf = (outbuf, offset = 0) => {
-    assert(
-      offset + outbuf.byteLength <= arenaSize,
-      X`Reading past end of circular buffer`,
-    );
+    offset + outbuf.byteLength <= arenaSize ||
+      assert.fail(X`Reading past end of circular buffer`);
 
     // Read the data to the end of the arena.
     let firstReadLength = outbuf.byteLength;

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -76,10 +76,8 @@ export function makeBridgeManager(E, D, bridgeDevice) {
       srcHandlers.init(srcID, handler);
     },
     unregister(srcID, handler) {
-      assert(
-        srcHandlers.get(srcID) === handler,
-        X`Handler was not registered for ${srcID}`,
-      );
+      srcHandlers.get(srcID) === handler ||
+        assert.fail(X`Handler was not registered for ${srcID}`);
       srcHandlers.delete(srcID);
     },
   });

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -234,10 +234,8 @@ export const extract = (template, specimen) => {
     return new Proxy(target, {
       get: (t, propName) => {
         if (typeof propName !== 'symbol') {
-          assert(
-            propName in t,
-            X`${propName} not permitted, only ${keys(template)}`,
-          );
+          propName in t ||
+            assert.fail(X`${propName} not permitted, only ${keys(template)}`);
         }
         return t[propName];
       },

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -473,10 +473,8 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
         case 'channelOpenConfirm': {
           const { portID, channelID } = obj;
           const channelKey = `${channelID}:${portID}`;
-          assert(
-            channelKeyToAttemptP.has(channelKey),
-            X`${channelKey}: did not expect channelOpenConfirm`,
-          );
+          channelKeyToAttemptP.has(channelKey) ||
+            assert.fail(X`${channelKey}: did not expect channelOpenConfirm`);
           const attemptP = channelKeyToAttemptP.get(channelKey);
           channelKeyToAttemptP.delete(channelKey);
 

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -107,10 +107,10 @@ function makeBoard(
       assert.typeof(id, 'string', X`id must be string: ${id}`);
       assert(id.startsWith(prefix), X`id must start with ${prefix}: ${id}`);
       const digits = id.slice(prefix.length);
-      assert(
-        digits.match(DIGITS_REGEXP),
-        X`id must end in at least ${q(crcDigits + 1)} digits: ${id}`,
-      );
+      digits.match(DIGITS_REGEXP) ||
+        assert.fail(
+          X`id must end in at least ${q(crcDigits + 1)} digits: ${id}`,
+        );
       const seq = digits.slice(crcDigits);
       const allegedCrc = digits.slice(0, crcDigits);
       const crcInput = `${prefix}${seq}`;

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -12,10 +12,10 @@ const pathSegmentPattern = /^[a-zA-Z0-9_-]{1,100}$/;
 
 /** @type {(name: string) => void} */
 export const assertPathSegment = name => {
-  assert(
-    pathSegmentPattern.test(name),
-    X`Path segment names must consist of 1 to 100 characters limited to ASCII alphanumerics, underscores, and/or dashes: ${name}`,
-  );
+  pathSegmentPattern.test(name) ||
+    assert.fail(
+      X`Path segment names must consist of 1 to 100 characters limited to ASCII alphanumerics, underscores, and/or dashes: ${name}`,
+    );
 };
 harden(assertPathSegment);
 

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -111,10 +111,8 @@ export const makeNameHubKit = () => {
       if (keyToRecord.has(key)) {
         record = keyToRecord.get(key);
       }
-      assert(
-        record && !record.promise,
-        X`key ${key} is not already initialized`,
-      );
+      (record && !record.promise) ||
+        assert.fail(X`key ${key} is not already initialized`);
       nameAdmin.update(key, newValue, adminValue);
     },
     onUpdate: fn => {

--- a/packages/wallet/api/src/findOrMakeInvitation.js
+++ b/packages/wallet/api/src/findOrMakeInvitation.js
@@ -14,10 +14,8 @@ const assertFirstCapASCII = str => {
       str,
     )} must be an ascii identifier starting with upper case.`,
   );
-  assert(
-    str !== 'NaN' && str !== 'Infinity',
-    X`keyword ${q(str)} must not be a number's name`,
-  );
+  (str !== 'NaN' && str !== 'Infinity') ||
+    assert.fail(X`keyword ${q(str)} must not be a number's name`);
 };
 
 /**
@@ -33,10 +31,8 @@ const findByBoardId = async (invitationPurseBalance, { board, boardId }) => {
   const invitationHandle = await E(board).getValue(boardId);
   const match = element => element.handle === invitationHandle;
   const matchingValue = invitationPurseBalance.value.find(match);
-  assert(
-    matchingValue,
-    X`Cannot find invitation corresponding to ${q(boardId)}`,
-  );
+  matchingValue ||
+    assert.fail(X`Cannot find invitation corresponding to ${q(boardId)}`);
 
   return harden([matchingValue]);
 };

--- a/packages/wallet/api/src/lib-dehydrate.js
+++ b/packages/wallet/api/src/lib-dehydrate.js
@@ -48,10 +48,10 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
    * @returns {string | Path}
    */
   const explode = data => {
-    assert(
-      data.startsWith(IMPLODE_PREFIX),
-      X`exploded string ${data} must start with ${q(IMPLODE_PREFIX)}`,
-    );
+    data.startsWith(IMPLODE_PREFIX) ||
+      assert.fail(
+        X`exploded string ${data} must start with ${q(IMPLODE_PREFIX)}`,
+      );
     const strongname = JSON.parse(data.slice(IMPLODE_PREFIX.length));
     if (!isPath(strongname)) {
       return strongname;
@@ -206,10 +206,8 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
       if (petnameToVal.has(petname) && petnameToVal.get(petname) === val) {
         return;
       }
-      assert(
-        !petnameToVal.has(petname),
-        X`petname ${petname} is already in use`,
-      );
+      !petnameToVal.has(petname) ||
+        assert.fail(X`petname ${petname} is already in use`);
       assert(!valToPetname.has(val), X`val ${val} already has a petname`);
       petnameToVal.init(petname, val);
       valToPetname.init(val, petname);
@@ -220,14 +218,12 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
     };
 
     const renamePetname = (petname, val) => {
-      assert(
-        valToPetname.has(val),
-        X`val ${val} has not been previously named, would you like to add it instead?`,
-      );
-      assert(
-        !petnameToVal.has(petname),
-        X`petname ${petname} is already in use`,
-      );
+      valToPetname.has(val) ||
+        assert.fail(
+          X`val ${val} has not been previously named, would you like to add it instead?`,
+        );
+      !petnameToVal.has(petname) ||
+        assert.fail(X`petname ${petname} is already in use`);
       // Delete the old mappings.
       const oldPetname = valToPetname.get(val);
       petnameToVal.delete(oldPetname);

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -667,10 +667,8 @@ export function makeWalletRoot({
     const keywordPaymentPs = Object.entries(proposal.give || harden({})).map(
       async ([keyword, { type, ...amount }]) => {
         const purse = purseKeywordRecord[keyword];
-        assert(
-          purse !== undefined,
-          X`purse was not found for keyword ${q(keyword)}`,
-        );
+        purse !== undefined ||
+          assert.fail(X`purse was not found for keyword ${q(keyword)}`);
 
         if (type === 'Attestation') {
           const payment = await E(attMakerPK.promise).makeAttestation(amount);
@@ -1734,14 +1732,12 @@ export function makeWalletRoot({
     );
 
     const { publicSubscribers } = offerResult;
-    assert(
-      publicSubscribers,
-      X`offerResult ${offerResult} does not have publicSubscribers`,
-    );
-    assert(
-      passStyleOf(publicSubscribers) === 'copyRecord',
-      X`publicSubscribers ${publicSubscribers} must be a record`,
-    );
+    publicSubscribers ||
+      assert.fail(
+        X`offerResult ${offerResult} does not have publicSubscribers`,
+      );
+    passStyleOf(publicSubscribers) === 'copyRecord' ||
+      assert.fail(X`publicSubscribers ${publicSubscribers} must be a record`);
 
     return publicSubscribers;
   }
@@ -1975,10 +1971,11 @@ export function makeWalletRoot({
       return E(agoricNames).lookup(...path);
     },
     getNamesByAddress(...path) {
-      assert(
-        namesByAddress,
-        X`namesByAddress was not supplied to the wallet maker`,
-      );
+      if (namesByAddress === undefined) {
+        // TypeScript confused about `||` control flow so use `if` instead
+        // https://github.com/microsoft/TypeScript/issues/50739
+        assert.fail(X`namesByAddress was not supplied to the wallet maker`);
+      }
       return E(namesByAddress).lookup(...path);
     },
   });

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -283,23 +283,17 @@ async function avaConfig(args, options, { glob, readFile }) {
   if (typeof exclude === 'string') {
     exclude = [exclude];
   }
-  assert(
-    !exclude || Array.isArray(exclude),
-    X`ava-xs.exclude: expected array or string: ${q(exclude)}`,
-  );
+  !exclude ||
+    Array.isArray(exclude) ||
+    assert.fail(X`ava-xs.exclude: expected array or string: ${q(exclude)}`);
 
   if (!files.length) {
-    assert(
-      Array.isArray(filePatterns),
-      X`ava.files: expected Array: ${q(filePatterns)}`,
-    );
+    Array.isArray(filePatterns) ||
+      assert.fail(X`ava.files: expected Array: ${q(filePatterns)}`);
     files = (await Promise.all(filePatterns.map(globFiles))).flat();
   }
-
-  assert(
-    Array.isArray(require),
-    X`ava.requires: expected Array: ${q(require)}`,
-  );
+  Array.isArray(require) ||
+    assert.fail(X`ava.requires: expected Array: ${q(require)}`);
   const config = { files, require, exclude, debug, verbose, titleMatch };
   return config;
 }

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -27,20 +27,18 @@ const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
 // lookup a keyword-named property no matter what `i` is.
 export const assertKeywordName = keyword => {
   assert.typeof(keyword, 'string');
-  assert(
-    keyword.length <= MAX_KEYWORD_LENGTH,
-    X`keyword ${keyword} exceeded maximum length ${MAX_KEYWORD_LENGTH} characters; got ${keyword.length}`,
-  );
+  keyword.length <= MAX_KEYWORD_LENGTH ||
+    assert.fail(
+      X`keyword ${keyword} exceeded maximum length ${MAX_KEYWORD_LENGTH} characters; got ${keyword.length}`,
+    );
   assert(
     firstCapASCII.test(keyword),
     X`keyword ${q(
       keyword,
     )} must be an ascii identifier starting with upper case.`,
   );
-  assert(
-    keyword !== 'NaN' && keyword !== 'Infinity',
-    X`keyword ${q(keyword)} must not be a number's name`,
-  );
+  (keyword !== 'NaN' && keyword !== 'Infinity') ||
+    assert.fail(X`keyword ${q(keyword)} must not be a number's name`);
 };
 
 /**
@@ -74,10 +72,10 @@ export const coerceAmountPatternKeywordRecord = (
       const assetKind = getAssetKind(amount);
       // TODO: replace this assertion with a check of the assetKind
       // property on the brand, when that exists.
-      assert(
-        assetKind === brandAssetKind,
-        X`The amount ${amount} did not have the assetKind of the brand ${brandAssetKind}`,
-      );
+      assetKind === brandAssetKind ||
+        assert.fail(
+          X`The amount ${amount} did not have the assetKind of the brand ${brandAssetKind}`,
+        );
       return AmountMath.coerce(amount.brand, amount);
     } else {
       assertPattern(amount);
@@ -122,10 +120,8 @@ const assertKeywordNotInBoth = (want, give) => {
   const giveKeywords = ownKeys(give);
 
   giveKeywords.forEach(keyword => {
-    assert(
-      !wantKeywordSet.has(keyword),
-      X`a keyword cannot be in both 'want' and 'give'`,
-    );
+    !wantKeywordSet.has(keyword) ||
+      assert.fail(X`a keyword cannot be in both 'want' and 'give'`);
   });
 };
 
@@ -154,10 +150,10 @@ export const cleanProposal = (proposal, getAssetKindByBrand) => {
     exit = harden({ onDemand: null }),
     ...rest
   } = proposal;
-  assert(
-    ownKeys(rest).length === 0,
-    X`${proposal} - Must only have want:, give:, exit: properties: ${rest}`,
-  );
+  ownKeys(rest).length === 0 ||
+    assert.fail(
+      X`${proposal} - Must only have want:, give:, exit: properties: ${rest}`,
+    );
 
   const cleanedWant = coerceAmountPatternKeywordRecord(
     want,

--- a/packages/zoe/src/contractFacet/allocationMath.js
+++ b/packages/zoe/src/contractFacet/allocationMath.js
@@ -61,14 +61,17 @@ const subtract = (amount, amountToSubtract, keyword) => {
     // amount is undefined, it is filtered out in doOperation.
     return /** @type {Amount} */ (amount);
   } else {
-    assert(
-      amount !== undefined,
-      X`The amount could not be subtracted from the allocation because the allocation did not have an amount under the keyword ${keyword}.`,
-    );
-    assert(
-      AmountMath.isGTE(amount, amountToSubtract),
-      X`The amount to be subtracted ${amountToSubtract} was greater than the allocation's amount ${amount} for the keyword ${keyword}`,
-    );
+    if (amount === undefined) {
+      // TypeScript confused about `||` control flow so use `if` instead
+      // https://github.com/microsoft/TypeScript/issues/50739
+      assert.fail(
+        X`The amount could not be subtracted from the allocation because the allocation did not have an amount under the keyword ${keyword}.`,
+      );
+    }
+    AmountMath.isGTE(amount, amountToSubtract) ||
+      assert.fail(
+        X`The amount to be subtracted ${amountToSubtract} was greater than the allocation's amount ${amount} for the keyword ${keyword}`,
+      );
     return AmountMath.subtract(amount, amountToSubtract);
   }
 };

--- a/packages/zoe/src/contractFacet/rightsConservation.js
+++ b/packages/zoe/src/contractFacet/rightsConservation.js
@@ -77,10 +77,10 @@ const assertEqualPerBrand = (leftSumsByBrand, rightSumsByBrand) => {
 
   allBrands.forEach(brand => {
     const { leftSum, rightSum } = getSums(brand);
-    assert(
-      AmountMath.isEqual(leftSum, rightSum),
-      X`rights were not conserved for brand ${brand} ${leftSum.value} != ${rightSum.value}`,
-    );
+    AmountMath.isEqual(leftSum, rightSum) ||
+      assert.fail(
+        X`rights were not conserved for brand ${brand} ${leftSum.value} != ${rightSum.value}`,
+      );
   });
 };
 

--- a/packages/zoe/src/contractFacet/vatRoot.js
+++ b/packages/zoe/src/contractFacet/vatRoot.js
@@ -30,10 +30,8 @@ export async function buildRootObject(powers, vatParameters, baggage) {
   // `zcfZygote.startContract` should exposed separately.
   const { testJigSetter } = powers;
   const { contractBundleCap } = vatParameters;
-  assert(
-    contractBundleCap,
-    X`expected vatParameters.contractBundleCap ${vatParameters}`,
-  );
+  contractBundleCap ||
+    assert.fail(X`expected vatParameters.contractBundleCap ${vatParameters}`);
   let { zoeService, invitationIssuer } = vatParameters;
   const firstTime = !baggage.has('DidStart');
   if (firstTime) {

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -90,10 +90,10 @@ export const makeZCFMintFactory = async (
           // we are adding assets. However, we keep this check so that
           // all reallocations are covered by offer safety checks, and
           // that any bug within Zoe that may affect this is caught.
-          assert(
-            zcfSeat.isOfferSafe(allocationPlusGains),
-            X`The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`,
-          );
+          zcfSeat.isOfferSafe(allocationPlusGains) ||
+            assert.fail(
+              X`The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`,
+            );
           // No effects above, apart from incrementBy. Note COMMIT POINT within
           // reallocateForZCFMint. The following two steps *should* be
           // committed atomically, but it is not a disaster if they are
@@ -116,10 +116,10 @@ export const makeZCFMintFactory = async (
           );
 
           // verifies offer safety
-          assert(
-            zcfSeat.isOfferSafe(allocationMinusLosses),
-            X`The allocation after burning losses ${allocationMinusLosses} for the zcfSeat was not offer safe`,
-          );
+          zcfSeat.isOfferSafe(allocationMinusLosses) ||
+            assert.fail(
+              X`The allocation after burning losses ${allocationMinusLosses} for the zcfSeat was not offer safe`,
+            );
 
           // Decrement the stagedAllocation if it exists so that the
           // stagedAllocation is kept up to the currentAllocation

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -180,24 +180,20 @@ export const createSeatManager = (
 
     // Ensure that offer safety holds.
     seats.forEach(seat => {
-      assert(
-        isOfferSafe(seat.getProposal(), seat.getStagedAllocation()),
-        X`Offer safety was violated by the proposed allocation: ${seat.getStagedAllocation()}. Proposal was ${seat.getProposal()}`,
-      );
+      isOfferSafe(seat.getProposal(), seat.getStagedAllocation()) ||
+        assert.fail(
+          X`Offer safety was violated by the proposed allocation: ${seat.getStagedAllocation()}. Proposal was ${seat.getProposal()}`,
+        );
     });
 
     // Keep track of seats used so far in this call, to prevent aliasing.
     const zcfSeatsSoFar = new Set();
 
     seats.forEach(seat => {
-      assert(
-        zcfSeatToSeatHandle.has(seat),
-        X`The seat ${seat} was not recognized`,
-      );
-      assert(
-        !zcfSeatsSoFar.has(seat),
-        X`Seat (${seat}) was already an argument to reallocate`,
-      );
+      zcfSeatToSeatHandle.has(seat) ||
+        assert.fail(X`The seat ${seat} was not recognized`);
+      !zcfSeatsSoFar.has(seat) ||
+        assert.fail(X`Seat (${seat}) was already an argument to reallocate`);
       zcfSeatsSoFar.add(seat);
     });
 

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -43,10 +43,8 @@ export const getInputPrice = (
   outputReserve = Nat(outputReserve);
   assert(inputValue > 0n, X`inputValue ${inputValue} must be positive`);
   assert(inputReserve > 0n, X`inputReserve ${inputReserve} must be positive`);
-  assert(
-    outputReserve > 0n,
-    X`outputReserve ${outputReserve} must be positive`,
-  );
+  outputReserve > 0n ||
+    assert.fail(X`outputReserve ${outputReserve} must be positive`);
 
   const oneMinusFeeScaled = subtract(BASIS_POINTS, feeBasisPoints);
   const inputWithFee = multiply(inputValue, oneMinusFeeScaled);
@@ -85,14 +83,12 @@ export const getOutputPrice = (
   outputReserve = Nat(outputReserve);
 
   assert(inputReserve > 0n, X`inputReserve ${inputReserve} must be positive`);
-  assert(
-    outputReserve > 0n,
-    X`outputReserve ${outputReserve} must be positive`,
-  );
-  assert(
-    outputReserve > outputValue,
-    X`outputReserve ${outputReserve} must be greater than outputValue ${outputValue}`,
-  );
+  outputReserve > 0n ||
+    assert.fail(X`outputReserve ${outputReserve} must be positive`);
+  outputReserve > outputValue ||
+    assert.fail(
+      X`outputReserve ${outputReserve} must be greater than outputValue ${outputValue}`,
+    );
 
   const oneMinusFeeScaled = subtract(BASIS_POINTS, feeBasisPoints);
   const numerator = multiply(multiply(outputValue, inputReserve), BASIS_POINTS);

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -297,11 +297,10 @@ export function makeOnewayPriceAuthorityKit(opts) {
         // We need to determine an amountIn that guarantees at least the amountOut.
         const amountIn = calcAmountIn(amountOut);
         const actualAmountOut = calcAmountOut(amountIn);
-
-        assert(
-          AmountMath.isGTE(actualAmountOut, amountOut),
-          X`Calculation of ${actualAmountOut} didn't cover expected ${amountOut}`,
-        );
+        AmountMath.isGTE(actualAmountOut, amountOut) ||
+          assert.fail(
+            X`Calculation of ${actualAmountOut} didn't cover expected ${amountOut}`,
+          );
         return { amountIn, amountOut };
       });
       assert(quote);

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -45,21 +45,21 @@ export const assertIsRatio = ratio => {
   const keys = Object.keys(ratio);
   assert(keys.length === 2, X`Ratio ${ratio} must be a record with 2 fields.`);
   for (const name of keys) {
-    assert(
-      ratioPropertyNames.includes(name),
-      X`Parameter must be a Ratio record, but ${ratio} has ${q(name)}`,
-    );
+    ratioPropertyNames.includes(name) ||
+      assert.fail(
+        X`Parameter must be a Ratio record, but ${ratio} has ${q(name)}`,
+      );
   }
   const numeratorValue = ratio.numerator.value;
   const denominatorValue = ratio.denominator.value;
-  assert(
-    isNat(numeratorValue),
-    X`The numerator value must be a NatValue, not ${numeratorValue}`,
-  );
-  assert(
-    isNat(denominatorValue),
-    X`The denominator value must be a NatValue, not ${denominatorValue}`,
-  );
+  isNat(numeratorValue) ||
+    assert.fail(
+      X`The numerator value must be a NatValue, not ${numeratorValue}`,
+    );
+  isNat(denominatorValue) ||
+    assert.fail(
+      X`The denominator value must be a NatValue, not ${denominatorValue}`,
+    );
 };
 
 /**
@@ -75,10 +75,10 @@ export const makeRatio = (
   denominator = PERCENT,
   denominatorBrand = numeratorBrand,
 ) => {
-  assert(
-    denominator > 0n,
-    X`No infinite ratios! Denominator was 0/${q(denominatorBrand)}`,
-  );
+  denominator > 0n ||
+    assert.fail(
+      X`No infinite ratios! Denominator was 0/${q(denominatorBrand)}`,
+    );
 
   return harden({
     numerator: AmountMath.make(numeratorBrand, numerator),
@@ -295,14 +295,14 @@ export const multiplyRatios = (left, right) => {
  */
 export const oneMinus = ratio => {
   assertIsRatio(ratio);
-  assert(
-    ratio.numerator.brand === ratio.denominator.brand,
-    X`oneMinus only supports ratios with a single brand, but ${ratio.numerator.brand} doesn't match ${ratio.denominator.brand}`,
-  );
-  assert(
-    ratio.numerator.value <= ratio.denominator.value,
-    X`Parameter must be less than or equal to 1: ${ratio.numerator.value}/${ratio.denominator.value}`,
-  );
+  ratio.numerator.brand === ratio.denominator.brand ||
+    assert.fail(
+      X`oneMinus only supports ratios with a single brand, but ${ratio.numerator.brand} doesn't match ${ratio.denominator.brand}`,
+    );
+  ratio.numerator.value <= ratio.denominator.value ||
+    assert.fail(
+      X`Parameter must be less than or equal to 1: ${ratio.numerator.value}/${ratio.denominator.value}`,
+    );
   return makeRatio(
     subtract(ratio.denominator.value, ratio.numerator.value),
     ratio.numerator.brand,

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -19,10 +19,8 @@ export const assertIssuerKeywords = (zcf, expected) => {
   const actual = getKeysSorted(issuers);
   expected = [...expected]; // in case hardened
   expected.sort();
-  assert(
-    keyEQ(actual, harden(expected)),
-    X`keywords: ${actual} were not as expected: ${expected}`,
-  );
+  keyEQ(actual, harden(expected)) ||
+    assert.fail(X`keywords: ${actual} were not as expected: ${expected}`);
 };
 
 /**
@@ -157,10 +155,8 @@ export const assertProposalShape = (seat, expected) => {
   const actual = seat.getProposal();
   const assertKeys = (a, e) => {
     if (e !== undefined) {
-      assert(
-        keyEQ(getKeysSorted(a), getKeysSorted(e)),
-        X`actual ${a} did not match expected ${e}`,
-      );
+      keyEQ(getKeysSorted(a), getKeysSorted(e)) ||
+        assert.fail(X`actual ${a} did not match expected ${e}`);
     }
   };
   assertKeys(actual.give, expected.give);

--- a/packages/zoe/src/contracts/auction/assertBidSeat.js
+++ b/packages/zoe/src/contracts/auction/assertBidSeat.js
@@ -6,14 +6,12 @@ import { AmountMath } from '@agoric/ertp';
 export const assertBidSeat = (zcf, sellSeat, bidSeat) => {
   const minBid = sellSeat.getProposal().want.Ask;
   const bid = bidSeat.getAmountAllocated('Bid', minBid.brand);
-  assert(
-    AmountMath.isGTE(bid, minBid),
-    X`bid ${bid} is under the minimum bid ${minBid}`,
-  );
+  AmountMath.isGTE(bid, minBid) ||
+    assert.fail(X`bid ${bid} is under the minimum bid ${minBid}`);
   const assetAtAuction = sellSeat.getProposal().give.Asset;
   const assetWanted = bidSeat.getAmountAllocated('Asset', assetAtAuction.brand);
-  assert(
-    AmountMath.isGTE(assetAtAuction, assetWanted),
-    X`more assets were wanted ${assetWanted} than were available ${assetAtAuction}`,
-  );
+  AmountMath.isGTE(assetAtAuction, assetWanted) ||
+    assert.fail(
+      X`more assets were wanted ${assetWanted} than were available ${assetAtAuction}`,
+    );
 };

--- a/packages/zoe/src/contracts/auction/index.js
+++ b/packages/zoe/src/contracts/auction/index.js
@@ -50,10 +50,9 @@ const start = zcf => {
   } = zcf.getTerms();
 
   assert.typeof(bidDuration, 'bigint');
-  assert(
-    winnerPriceOption === FIRST_PRICE || winnerPriceOption === SECOND_PRICE,
-    X`Only first and second price auctions are supported`,
-  );
+  winnerPriceOption === FIRST_PRICE ||
+    winnerPriceOption === SECOND_PRICE ||
+    assert.fail(X`Only first and second price auctions are supported`);
 
   let sellSeat;
   let isTimerStarted = false;

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -123,10 +123,8 @@ const start = zcf => {
       } = depositSeat.getProposal();
 
       // assert that the allocation includes the amount of collateral required
-      assert(
-        AmountMath.isEqual(newCollateral, deposit),
-        X`Collateral required: ${deposit.value}`,
-      );
+      AmountMath.isEqual(newCollateral, deposit) ||
+        assert.fail(X`Collateral required: ${deposit.value}`);
 
       // assert that the requested option was the right one.
       assert(

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -66,10 +66,13 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
       'exit afterDeadline',
     );
     const sellSeatExitRule = sellSeat.getProposal().exit;
-    assert(
-      isAfterDeadlineExitRule(sellSeatExitRule),
-      X`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`,
-    );
+    if (!isAfterDeadlineExitRule(sellSeatExitRule)) {
+      // TypeScript confused about `||` control flow so use `if` instead
+      // https://github.com/microsoft/TypeScript/issues/50739
+      assert.fail(
+        X`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`,
+      );
+    }
 
     const exerciseOption = makeExerciser(sellSeat);
     const customProps = harden({

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -55,10 +55,10 @@ export const makeBorrowInvitation = (zcf, config) => {
 
     // Assert the required collateral was escrowed.
     const requiredMargin = ceilMultiplyBy(loanWanted, mmr);
-    assert(
-      AmountMath.isGTE(collateralPriceInLoanBrand, requiredMargin),
-      X`The required margin is ${requiredMargin.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`,
-    );
+    AmountMath.isGTE(collateralPriceInLoanBrand, requiredMargin) ||
+      assert.fail(
+        X`The required margin is ${requiredMargin.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`,
+      );
 
     const timestamp = getTimestamp(quote);
 
@@ -72,10 +72,10 @@ export const makeBorrowInvitation = (zcf, config) => {
     );
 
     // Assert that loanWanted <= maxLoan
-    assert(
-      AmountMath.isGTE(maxLoan, loanWanted),
-      X`The wanted loan ${loanWanted} must be below or equal to the maximum possible loan ${maxLoan}`,
-    );
+    AmountMath.isGTE(maxLoan, loanWanted) ||
+      assert.fail(
+        X`The wanted loan ${loanWanted} must be below or equal to the maximum possible loan ${maxLoan}`,
+      );
 
     const { zcfSeat: collateralSeat } = zcf.makeEmptySeatKit();
 

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -33,10 +33,10 @@ export const makeCloseLoanInvitation = (zcf, config) => {
     const debt = getDebt();
 
     // All debt must be repaid.
-    assert(
-      AmountMath.isGTE(repaid, debt),
-      X`Not enough Loan assets have been repaid.  ${debt} is required, but only ${repaid} was repaid.`,
-    );
+    AmountMath.isGTE(repaid, debt) ||
+      assert.fail(
+        X`Not enough Loan assets have been repaid.  ${debt} is required, but only ${repaid} was repaid.`,
+      );
 
     // Transfer the collateral to the repaySeat and remove the
     // required Loan amount. Any excess Loan amount is kept by the repaySeat.

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -68,10 +68,9 @@ const start = async zcf => {
         assert(!revoked, revokedMsg);
         const noFee = AmountMath.makeEmpty(feeBrand);
         const { requiredFee, reply } = await E(handler).onQuery(query, noFee);
-        assert(
-          !requiredFee || AmountMath.isGTE(noFee, requiredFee),
-          X`Oracle required a fee but the query had none`,
-        );
+        !requiredFee ||
+          AmountMath.isGTE(noFee, requiredFee) ||
+          assert.fail(X`Oracle required a fee but the query had none`);
         return reply;
       } catch (e) {
         E(handler).onError(query, e);

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -101,10 +101,8 @@ const start = zcf => {
     );
 
     // Check that the money provided to pay for the items is greater than the totalCost.
-    assert(
-      AmountMath.isGTE(providedMoney, totalCost),
-      X`More money (${totalCost}) is required to buy these items`,
-    );
+    AmountMath.isGTE(providedMoney, totalCost) ||
+      assert.fail(X`More money (${totalCost}) is required to buy these items`);
 
     // Reallocate.
     sellerSeat.incrementBy(

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -36,10 +36,8 @@ export const makeInstanceRecordStorage = baggage => {
     );
 
   const addIssuerToInstanceRecord = (keyword, issuerRecord) => {
-    assert(
-      !(keyword in issuerRecord),
-      X`conflicting definition of ${q(keyword)}`,
-    );
+    !(keyword in issuerRecord) ||
+      assert.fail(X`conflicting definition of ${q(keyword)}`);
 
     assertInstantiated();
     const instanceRecord = baggage.get('instanceRecord');
@@ -86,10 +84,8 @@ export const makeInstanceRecordStorage = baggage => {
   const assertUniqueKeyword = keyword => {
     assertInstantiated();
     assertKeywordName(keyword);
-    assert(
-      !ownKeys(baggage.get('instanceRecord').terms.issuers).includes(keyword),
-      X`keyword ${q(keyword)} must be unique`,
-    );
+    !ownKeys(baggage.get('instanceRecord').terms.issuers).includes(keyword) ||
+      assert.fail(X`keyword ${q(keyword)} must be unique`);
   };
 
   const instantiate = startingInstanceRecord => {

--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -14,10 +14,8 @@ import { assert, details as X, q } from '@agoric/assert';
  * @param {U[]} keys
  */
 export const arrayToObj = (array, keys) => {
-  assert(
-    array.length === keys.length,
-    X`array and keys must be of equal length`,
-  );
+  array.length === keys.length ||
+    assert.fail(X`array and keys must be of equal length`);
   const obj =
     /** @type {Record<U, T>} */
     ({});
@@ -34,9 +32,9 @@ export const arrayToObj = (array, keys) => {
 export const assertSubset = (whole, part) => {
   part.forEach(key => {
     assert.typeof(key, 'string');
-    assert(
-      whole.includes(key),
-      X`key ${q(key)} was not one of the expected keys ${q(whole)}`,
-    );
+    whole.includes(key) ||
+      assert.fail(
+        X`key ${q(key)} was not one of the expected keys ${q(whole)}`,
+      );
   });
 };

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -42,10 +42,8 @@ export const makeOfferMethod = (
     // AWAIT ///
 
     const instanceAdmin = getInstanceAdmin(instance);
-    assert(
-      !instanceAdmin.isBlocked(description),
-      X`not accepting offer with description ${q(description)}`,
-    );
+    !instanceAdmin.isBlocked(description) ||
+      assert.fail(X`not accepting offer with description ${q(description)}`);
     const { invitationHandle } = await burnInvitation(
       invitationIssuer,
       invitation,

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -78,10 +78,12 @@ export const makeStartInstance = (
     const setOfferFilter = strings => {
       assert(Array.isArray(strings), X`${q(strings)} must be an Array`);
       const proposedStrings = harden([...strings]);
-      assert(
-        proposedStrings.every(s => typeof s === 'string'),
-        X`Blocked strings (${q(proposedStrings)}) must be an Array of strings.`,
-      );
+      proposedStrings.every(s => typeof s === 'string') ||
+        assert.fail(
+          X`Blocked strings (${q(
+            proposedStrings,
+          )}) must be an Array of strings.`,
+        );
 
       offerFilterStrings = proposedStrings;
     };

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/bootstrap-coveredCall-service-upgrade.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/bootstrap-coveredCall-service-upgrade.js
@@ -52,10 +52,10 @@ const depositPayout = (seat, keyword, purse, expectedAmount) => {
       return E(purse).deposit(payout);
     })
     .then(depositAmount => {
-      assert(
-        AmountMath.isEqual(depositAmount, expectedAmount),
-        X`amounts don't match: ${q(depositAmount)}, ${q(expectedAmount)}`,
-      );
+      AmountMath.isEqual(depositAmount, expectedAmount) ||
+        assert.fail(
+          X`amounts don't match: ${q(depositAmount)}, ${q(expectedAmount)}`,
+        );
     });
 };
 

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -65,11 +65,13 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
   const makeOption = sellSeat => {
     fit(sellSeat.getProposal(), M.split({ exit: { afterDeadline: M.any() } }));
     const sellSeatExitRule = sellSeat.getProposal().exit;
-    assert(
-      isAfterDeadlineExitRule(sellSeatExitRule),
-      X`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`,
-    );
-
+    if (!isAfterDeadlineExitRule(sellSeatExitRule)) {
+      // TypeScript confused about `||` control flow so use `if` instead
+      // https://github.com/microsoft/TypeScript/issues/50739
+      assert.fail(
+        X`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`,
+      );
+    }
     const exerciseOption = makeExerciser(sellSeat);
     const customProps = harden({
       expirationDate: sellSeatExitRule.afterDeadline.deadline,

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -26,19 +26,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       // Bob ensures it's the contract he expects
-      assert(
-        installations.automaticRefund === installation,
-        X`should be the expected automaticRefund`,
-      );
-
-      assert(
-        issuerKeywordRecord.Contribution1 === moolaIssuer,
-        X`The first issuer should be the moola issuer`,
-      );
-      assert(
-        issuerKeywordRecord.Contribution2 === simoleanIssuer,
-        X`The second issuer should be the simolean issuer`,
-      );
+      installations.automaticRefund === installation ||
+        assert.fail(X`should be the expected automaticRefund`);
+      issuerKeywordRecord.Contribution1 === moolaIssuer ||
+        assert.fail(X`The first issuer should be the moola issuer`);
+      issuerKeywordRecord.Contribution2 === simoleanIssuer ||
+        assert.fail(X`The second issuer should be the simolean issuer`);
 
       // 1. Bob escrows his offer
       const bobProposal = harden({
@@ -85,10 +78,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
       assert(installation === installations.coveredCall, X`wrong installation`);
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      optionValue[0].description === 'exerciseOption' ||
+        assert.fail(X`wrong invitation`);
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
@@ -104,15 +95,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(optionValue[0].expirationDate === 1n, X`wrong expirationDate`);
       assert(optionValue[0].timeAuthority === timer, 'wrong timer');
       const { UnderlyingAsset, StrikePrice } = issuerKeywordRecord;
-
-      assert(
-        UnderlyingAsset === moolaIssuer,
-        X`The underlying asset issuer should be the moola issuer`,
-      );
-      assert(
-        StrikePrice === simoleanIssuer,
-        X`The strike price issuer should be the simolean issuer`,
-      );
+      UnderlyingAsset === moolaIssuer ||
+        assert.fail(X`The underlying asset issuer should be the moola issuer`);
+      StrikePrice === simoleanIssuer ||
+        assert.fail(X`The strike price issuer should be the simolean issuer`);
 
       const bobPayments = { StrikePrice: simoleanPayment };
       // Bob escrows
@@ -151,10 +137,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const optionValue = optionAmounts.value;
 
       assert(installation === installations.coveredCall, X`wrong installation`);
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      optionValue[0].description === 'exerciseOption' ||
+        assert.fail(X`wrong invitation`);
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
@@ -171,14 +155,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
       assert(optionValue[0].expirationDate === 100n, X`wrong expiration date`);
       assert(optionValue[0].timeAuthority === timer, X`wrong timer`);
-      assert(
-        UnderlyingAsset === moolaIssuer,
-        X`The underlyingAsset issuer should be the moola issuer`,
-      );
-      assert(
-        StrikePrice === simoleanIssuer,
-        X`The strikePrice issuer should be the simolean issuer`,
-      );
+      UnderlyingAsset === moolaIssuer ||
+        assert.fail(X`The underlyingAsset issuer should be the moola issuer`);
+      StrikePrice === simoleanIssuer ||
+        assert.fail(X`The strikePrice issuer should be the simolean issuer`);
 
       // Let's imagine that Bob wants to create a swap to trade this
       // invitation for bucks. He wants to invitation Dave as the
@@ -228,11 +208,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
-
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      installation === installations.secondPriceAuction ||
+        assert.fail(X`wrong installation`);
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
@@ -283,15 +260,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         ),
         X`issuers were not as expected`,
       );
-
-      assert(
-        keyEQ(invitationValue[0].asset, moola(3n)),
-        X`Alice made a different offer than expected`,
-      );
-      assert(
-        keyEQ(invitationValue[0].price, simoleans(7n)),
-        X`Alice made a different offer than expected`,
-      );
+      keyEQ(invitationValue[0].asset, moola(3n)) ||
+        assert.fail(X`Alice made a different offer than expected`);
+      keyEQ(invitationValue[0].price, simoleans(7n)) ||
+        assert.fail(X`Alice made a different offer than expected`);
 
       const proposal = harden({
         want: { Asset: moola(3n) },
@@ -322,19 +294,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const installation = await E(zoe).getInstallation(invitation);
       const exclInvitation = await E(invitationIssuer).claim(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-
-      assert(
-        installation === installations.simpleExchange,
-        X`wrong installation`,
-      );
-      assert(
-        issuerKeywordRecord.Asset === moolaIssuer,
-        X`The first issuer should be the moola issuer`,
-      );
-      assert(
-        issuerKeywordRecord.Price === simoleanIssuer,
-        X`The second issuer should be the simolean issuer`,
-      );
+      installation === installations.simpleExchange ||
+        assert.fail(X`wrong installation`);
+      issuerKeywordRecord.Asset === moolaIssuer ||
+        assert.fail(X`The first issuer should be the moola issuer`);
+      issuerKeywordRecord.Price === simoleanIssuer ||
+        assert.fail(X`The second issuer should be the simolean issuer`);
 
       const bobBuyOrderProposal = harden({
         want: { Asset: moola(3n) },
@@ -365,19 +330,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-
-      assert(
-        installation === installations.simpleExchange,
-        X`wrong installation`,
-      );
-      assert(
-        issuerKeywordRecord.Asset === moolaIssuer,
-        X`The first issuer should be the moola issuer`,
-      );
-      assert(
-        issuerKeywordRecord.Price === simoleanIssuer,
-        X`The second issuer should be the simolean issuer`,
-      );
+      installation === installations.simpleExchange ||
+        assert.fail(X`wrong installation`);
+      issuerKeywordRecord.Asset === moolaIssuer ||
+        assert.fail(X`The first issuer should be the moola issuer`);
+      issuerKeywordRecord.Price === simoleanIssuer ||
+        assert.fail(X`The second issuer should be the simolean issuer`);
       const bobBuyOrderProposal = harden({
         want: { Asset: moola(m) },
         give: { Price: simoleans(s) },

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -24,11 +24,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         invitation,
       );
-
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      installation === installations.secondPriceAuction ||
+        assert.fail(X`wrong installation`);
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -25,11 +25,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
-
-      assert(
-        installation === installations.secondPriceAuction,
-        X`wrong installation`,
-      );
+      installation === installations.secondPriceAuction ||
+        assert.fail(X`wrong installation`);
       assert(
         keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
@@ -93,16 +90,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       // Dave expects that Bob has already made an offer in the swap
       // with the following rules:
-      assert(
-        keyEQ(invitationValue[0].asset, optionAmounts),
-        X`asset is the option`,
-      );
+      keyEQ(invitationValue[0].asset, optionAmounts) ||
+        assert.fail(X`asset is the option`);
       assert(keyEQ(invitationValue[0].price, bucks(1n)), X`price is 1 buck`);
       const optionValue = optionAmounts.value;
-      assert(
-        optionValue[0].description === 'exerciseOption',
-        X`wrong invitation`,
-      );
+      optionValue[0].description === 'exerciseOption' ||
+        assert.fail(X`wrong invitation`);
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -56,10 +56,8 @@ const start = async zcf => {
       });
       assertProposalShape(bountySeat, feeProposal);
       const feeAmount = bountySeat.getCurrentAllocation().Fee;
-      assert(
-        AmountMath.isGTE(feeAmount, fee),
-        X`Fee was required to be at least ${fee}`,
-      );
+      AmountMath.isGTE(feeAmount, fee) ||
+        assert.fail(X`Fee was required to be at least ${fee}`);
 
       // The funder gets the fee regardless of the outcome.
       funderSeat.incrementBy(

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -40,10 +40,9 @@ const start = zcf => {
 
   // We assume the only valid responses are 'YES' and 'NO'
   const assertResponse = response => {
-    assert(
-      response === 'NO' || response === 'YES',
-      X`the answer ${q(response)} was not 'YES' or 'NO'`,
-    );
+    response === 'NO' ||
+      response === 'YES' ||
+      assert.fail(X`the answer ${q(response)} was not 'YES' or 'NO'`);
     // Throw an error if the response is not valid, but do not
     // exit the seat. We should allow the voter to recast their vote.
   };

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -65,10 +65,8 @@ test.before(
           let requiredFee;
           if (query.kind === 'Paid') {
             requiredFee = feeAmount;
-            assert(
-              AmountMath.isGTE(fee, requiredFee),
-              X`Minimum fee of ${feeAmount} not met; have ${fee}`,
-            );
+            AmountMath.isGTE(fee, requiredFee) ||
+              assert.fail(X`Minimum fee of ${feeAmount} not met; have ${fee}`);
           }
           const reply = { pong: query };
           return harden({ reply, requiredFee });

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -46,10 +46,10 @@ const start = zcf => {
         assert(amountToColor);
         // Ensure that the amount of pixels that we want to color is
         // covered by what is actually escrowed.
-        assert(
-          AmountMath.isGTE(escrowedAmount, amountToColor),
-          X`The pixels to color were not all escrowed. Currently escrowed: ${escrowedAmount}, amount to color: ${amountToColor}`,
-        );
+        AmountMath.isGTE(escrowedAmount, amountToColor) ||
+          assert.fail(
+            X`The pixels to color were not all escrowed. Currently escrowed: ${escrowedAmount}, amount to color: ${amountToColor}`,
+          );
 
         // Pretend to color
         return `successfully colored ${amountToColor.value} pixels ${color}`;


### PR DESCRIPTION
Like https://github.com/endojs/endo/pull/1280

Replace some occurrences of
```js
assert(..condExpr.., X`..detailsString..`);
```
with
```js
..condExpr.. || assert.fail(X`..detailsString..`);
```

I only made the changes that I was easily able to do via regexp search and replace in vscode
```
^\s*assert\(\n\s*(.*?),\n\s*X`(.*?)`,\n\s*\);
($1) || assert.fail(X`$2`);
```
and similar, followed by a global `yarn lint-fix` and then repair until everything tested green again. No doubt there are more cases that I missed. But from @dtribble 's measurements, these are already enough to show significant perf improvements.
