### PR TITLE
build(docker): delimit sha in snapshot tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
             | jq '(.commit.committer.date | fromdate)')
           TIMESTAMP=`date +%Y%m%d%H%M%S --date="@${COMMIT_TIME}"`
           SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-6)
-          SNAPSHOT_TAG="${TIMESTAMP}${SHORT_SHA}"
+          SNAPSHOT_TAG="${TIMESTAMP}-${SHORT_SHA}"
           echo "::set-output name=tag::$SNAPSHOT_TAG"
 
   docker-sdk:


### PR DESCRIPTION
## Description

Finding the SDK version in in here wasn't obvious to me,
```
image: agoric/agoric-sdk:${SDK_TAG:-20220908203246d46b60-linux_amd64}
```

This adds the delimiter to separate it from the timestamp.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

--