### PR TITLE
feat(patterns): improve the measurement tools

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,7 +14,10 @@
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc --maxNodeModuleJsDepth 3 -p jsconfig.json",
-    "lint:eslint": "eslint ."
+    "lint:eslint": "eslint .",
+    "perf:build": "rollup --config test/rollup.config.js",
+    "perf:node": "NODE_OPTIONS='--jitless' node dist/bundle-perf-patterns.mjs",
+    "perf:xs": "../xsnap/moddable/build/bin/mac/release/xst -m dist/bundle-perf-patterns.mjs"
   },
   "repository": {
     "type": "git",
@@ -39,6 +42,7 @@
   "devDependencies": {
     "@agoric/swingset-vat": "^0.28.0",
     "@fast-check/ava": "^1.0.1",
+    "@rollup/plugin-node-resolve": "^6.1.0",
     "ava": "^4.3.1"
   },
   "files": [

--- a/packages/store/test/perf-setup.js
+++ b/packages/store/test/perf-setup.js
@@ -1,0 +1,28 @@
+/* global globalThis setTimeout print */
+
+globalThis.console =
+  globalThis.console ||
+  Object.fromEntries(
+    ['debug', 'log', 'info', 'warn', 'error'].map(level => [level, print]),
+  );
+
+globalThis.setImmediate = globalThis.setImmediate || (fn => setTimeout(fn, 0));
+
+export const setupGC = async () => {
+  let gc = globalThis.gc || (typeof $262 !== 'undefined' ? $262.gc : null);
+  if (!gc) {
+    try {
+      const [{ default: v8 }, { default: vm }] = await Promise.all([
+        import('v8'),
+        import('vm'),
+      ]);
+      v8.setFlagsFromString('--expose_gc');
+      gc = vm.runInNewContext('gc');
+      v8.setFlagsFromString('--no-expose_gc');
+    } catch (err) {
+      // eslint-disable-next-line no-void
+      gc = () => void Array.from({ length: 2 ** 24 }, () => Math.random());
+    }
+  }
+  globalThis.gc = gc;
+};

--- a/packages/store/test/rollup.config.js
+++ b/packages/store/test/rollup.config.js
@@ -1,0 +1,13 @@
+import resolve from '@rollup/plugin-node-resolve';
+
+export default [
+  {
+    input: 'test/perf-patterns.js',
+    output: {
+      file: `dist/bundle-perf-patterns.mjs`,
+      format: 'es',
+      name: 'perfPatterns',
+    },
+    plugins: [resolve()],
+  },
+];


### PR DESCRIPTION
closes: #6098

## Description
- Add support XS
- Build a single script that works for both node and XS
- Add platform-neutral support for forced GC
- add package scripts to build and run perf tasks

### Security Considerations

N/A

### Documentation Considerations

Byild sript instructions are in the perf-patterns file

### Testing Considerations

Currently only run manually with 
```
yarn perf:build
yarn perf:node
yarn perf:xs
```