### PR TITLE
feat(provision): use governance in provisioning

### DIFF
--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -37,7 +37,6 @@
     "@agoric/ertp": "^0.14.2",
     "@agoric/nat": "^4.1.0",
     "@agoric/smart-wallet": "^0.2.0",
-    "@agoric/vats": "^0.10.0",
     "@agoric/zoe": "^0.24.0",
     "@endo/bundle-source": "^2.2.6",
     "@endo/captp": "^2.0.13",

--- a/packages/agoric-cli/src/commands/wallet.js
+++ b/packages/agoric-cli/src/commands/wallet.js
@@ -13,9 +13,6 @@ import { simpleOffers } from '../lib/psm.js';
 import { makeRpcUtils, networkConfig } from '../lib/rpc.js';
 import { getWalletState } from '../lib/wallet.js';
 
-// Ambient types. Needed only for dev but this does a runtime import.
-import '@agoric/vats/src/core/types.js';
-import '@agoric/vats/src/types.js';
 import { makeLeaderOptions } from '../lib/casting.js';
 import { normalizeAddress } from '../lib/keys.js';
 

--- a/packages/inter-protocol/docs/governance-params.md
+++ b/packages/inter-protocol/docs/governance-params.md
@@ -74,3 +74,11 @@ In `packages/inter-protocol/src/psm/psm.js`:
 
 The Inter Protocol Whitepaper v0.8 does not describe the governance parameters
 for this contract.
+
+### Provision Pool
+
+In `packages/vats/src/provisionPool.js`:
+
+| Governance Key          | Type    | WP? |
+| ----------------------- | :------ | --- |
+| PerAccountInitialAmount | Amount  | N/A |

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -28,6 +28,8 @@ export const getCourierPK = (key, keyToCourierPK) => {
 /**
  * Create the [send, receive] pair.
  *
+ * @typedef {import('@agoric/vats/src/nameHub.js').NameHub} NameHub
+ *
  * @typedef {object} CourierArgs
  * @property {ZCF} zcf
  * @property {ERef<BoardDepositFacet>} board

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -30,6 +30,8 @@ const TRANSFER_PROPOSAL_SHAPE = {
  * @param {ZCF} zcf the Zoe Contract Facet
  * @param {ERef<BoardDepositFacet>} board where to find depositFacets by boardID
  * @param {ERef<NameHub>} namesByAddress where to find depositFacets by bech32
+ *
+ * @typedef {import('@agoric/vats/src/nameHub.js').NameHub} NameHub
  */
 const makePegasus = (zcf, board, namesByAddress) => {
   /**

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -101,7 +101,7 @@ const { details: X, quote: q } = assert;
  * invitationPurse: Purse<'set'>,
  * }} unique
  * @param {{
- * agoricNames: ERef<NameHub>,
+ * agoricNames: ERef<import('@agoric/vats/src/nameHub.js').NameHub>,
  * invitationIssuer: ERef<Issuer<'set'>>,
  * invitationBrand: Brand<'set'>,
  * publicMarshaller: Marshaller,

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -25,6 +25,8 @@ const PrivateArgsShape = harden(
  *   agoricNames: ERef<NameHub>,
  *   board: ERef<Board>,
  * }} SmartWalletContractTerms
+ *
+ * @typedef {import('@agoric/vats/src/nameHub').NameHub} NameHub
  */
 
 // NB: even though all the wallets share this contract, they

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -30,7 +30,7 @@ import { Far } from '@endo/far';
  * Create a handler that demuxes/muxes the bridge device by its first argument.
  *
  * @param {typeof import('@endo/far').E} E The eventual sender
- * @param {DProxy} D The device sender
+ * @param {<T>(target: Device<T>) => T} D The device sender
  * @param {Device<BridgeDevice>} bridgeDevice The bridge to manage
  * @returns {BridgeManager} admin facet for this handler
  */

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -213,7 +213,7 @@ export const buildRootObject = (vatPowers, vatParameters) => {
         Far('dummyInboundHandler', { deliverInboundMessages: () => {} }),
       );
 
-      runBootstrapParts(vats, devices).catch(e => {
+      return runBootstrapParts(vats, devices).catch(e => {
         console.error('BOOTSTRAP FAILED:', e);
         throw e;
       });

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -74,6 +74,8 @@ export const agoricNamesReserved = harden(
       economicCommittee: 'Economic Committee',
       'psm-IST-AUSD': 'Parity Stability Module: IST:AUSD',
       psmCharter: 'Charter for the PSM',
+      walletFactory: 'Smart Wallet Factory',
+      provisionPool: 'Provision Pool',
     },
   }),
 );

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -129,6 +129,7 @@ export const startWalletFactory = async (
     installation: {
       consume: { walletFactory, provisionPool, contractGovernor },
     },
+    instance: { produce: instanceProduce },
     brand: {
       consume: { [Stable.symbol]: feeBrandP },
     },
@@ -189,6 +190,7 @@ export const startWalletFactory = async (
     },
   );
   walletFactoryStartResult.resolve(wfFacets);
+  instanceProduce.walletFactory.resolve(wfFacets.instance);
   const poolBank = E(bankManager).getBankForAddress(poolAddr);
 
   const ppFacets = await startGovernedInstance(
@@ -215,6 +217,7 @@ export const startWalletFactory = async (
       economicCommitteeCreatorFacet,
     },
   );
+  instanceProduce.provisionPool.resolve(ppFacets.instance);
 
   provisionPoolStartResult.resolve(ppFacets);
 
@@ -270,6 +273,12 @@ export const WALLET_FACTORY_MANIFEST = {
     },
     issuer: {
       consume: { [Stable.symbol]: 'zoe' },
+    },
+    instance: {
+      produce: {
+        provisionPool: 'provisionPool',
+        walletFactory: 'walletFactory',
+      },
     },
   },
 };

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -1,8 +1,9 @@
 // @ts-check
 import { E, Far } from '@endo/far';
 import { deeplyFulfilled } from '@endo/marshal';
-import { BridgeId as BRIDGE_ID } from '@agoric/internal';
+import { BridgeId as BRIDGE_ID, deeplyFulfilledObject } from '@agoric/internal';
 import { AmountMath } from '@agoric/ertp';
+import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
 import { makeStorageNodeChild } from '../lib-chainStorage.js';
 import { Stable } from '../tokens.js';
 
@@ -17,10 +18,93 @@ const startFactoryInstance = (zoe, inst) => E(zoe).startInstance(inst);
 const StableUnit = BigInt(10 ** Stable.displayInfo.decimalPlaces);
 
 /**
+ *
+ * @param {{
+ *   zoe: ERef<ZoeService>,
+ *   governedContractInstallation: ERef<Installation>,
+ *   issuerKeywordRecord?: IssuerKeywordRecord,
+ *   terms: Record<string, unknown>,
+ *   privateArgs: any, // TODO: connect with Installation type
+ * }} zoeArgs
+ * @param {{
+ *   governedParams: Record<string, unknown>,
+ *   timer: ERef<TimerService>,
+ *   contractGovernor: ERef<Installation>,
+ *   economicCommitteeCreatorFacet: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']['economicCommitteeCreatorFacet']
+ * }} govArgs
+ */
+const startGovernedInstance = async (
+  {
+    zoe,
+    governedContractInstallation,
+    issuerKeywordRecord,
+    terms,
+    privateArgs,
+  },
+  { governedParams, timer, contractGovernor, economicCommitteeCreatorFacet },
+) => {
+  const poserInvitationP = E(
+    economicCommitteeCreatorFacet,
+  ).getPoserInvitation();
+  const [initialPoserInvitation, electorateInvitationAmount] =
+    await Promise.all([
+      poserInvitationP,
+      E(E(zoe).getInvitationIssuer()).getAmountOf(poserInvitationP),
+    ]);
+
+  const governorTerms = await deeplyFulfilledObject(
+    harden({
+      timer,
+      governedContractInstallation,
+      governed: {
+        terms: {
+          ...terms,
+          governedParams: {
+            [CONTRACT_ELECTORATE]: {
+              type: ParamTypes.INVITATION,
+              value: electorateInvitationAmount,
+            },
+            ...governedParams,
+          },
+        },
+        issuerKeywordRecord,
+      },
+    }),
+  );
+  const governorFacets = await E(zoe).startInstance(
+    contractGovernor,
+    {},
+    governorTerms,
+    harden({
+      economicCommitteeCreatorFacet,
+      governed: {
+        ...privateArgs,
+        initialPoserInvitation,
+      },
+    }),
+  );
+  const [instance, creatorFacet, adminFacet] = await Promise.all([
+    E(governorFacets.creatorFacet).getInstance(),
+    E(governorFacets.creatorFacet).getCreatorFacet(),
+    E(governorFacets.creatorFacet).getAdminFacet(),
+  ]);
+  const facets = {
+    instance,
+    governor: governorFacets.instance,
+    creatorFacet,
+    adminFacet,
+    governorCreatorFacet: governorFacets.creatorFacet,
+  };
+  return facets;
+};
+
+/**
  * Register for PLEASE_PROVISION bridge messages and handle
  * them by providing a smart wallet from the wallet factory.
  *
- * @param {BootstrapPowers} param0
+ * @param {BootstrapPowers & PromiseSpaceOf<{
+ *   economicCommitteeCreatorFacet: CommitteeElectorateCreatorFacet
+ * }>} powers
  * @param {{
  *   options?: {
  *     perAccountInitialValue?: bigint
@@ -38,10 +122,12 @@ export const startWalletFactory = async (
       namesByAddress,
       namesByAddressAdmin: namesByAddressAdminP,
       zoe,
+      chainTimerService,
+      economicCommitteeCreatorFacet,
     },
     produce: { client, walletFactoryStartResult, provisionPoolStartResult },
     installation: {
-      consume: { walletFactory, provisionPool },
+      consume: { walletFactory, provisionPool, contractGovernor },
     },
     brand: {
       consume: { [Stable.symbol]: feeBrandP },
@@ -52,7 +138,8 @@ export const startWalletFactory = async (
   },
   { options: { perAccountInitialValue = (StableUnit * 25n) / 100n } = {} } = {},
 ) => {
-  const STORAGE_PATH = 'wallet';
+  const WALLET_STORAGE_PATH = 'wallet';
+  const POOL_STORAGE_PATH = 'provisionPool';
   const [bridgeManager, poolAddr] = await Promise.all([
     bridgeManagerP,
     E(bankManager).getModuleAccountAddress('vbank/provision'),
@@ -68,13 +155,19 @@ export const startWalletFactory = async (
     );
     return;
   }
-  const [storageNode, namesByAddressAdmin, feeBrand, feeIssuer] =
-    await Promise.all([
-      makeStorageNodeChild(chainStorage, STORAGE_PATH),
-      namesByAddressAdminP,
-      feeBrandP,
-      feeIssuerP,
-    ]);
+  const [
+    walletStorageNode,
+    poolStorageNode,
+    namesByAddressAdmin,
+    feeBrand,
+    feeIssuer,
+  ] = await Promise.all([
+    makeStorageNodeChild(chainStorage, WALLET_STORAGE_PATH),
+    makeStorageNodeChild(chainStorage, POOL_STORAGE_PATH),
+    namesByAddressAdminP,
+    feeBrandP,
+    feeIssuerP,
+  ]);
 
   const terms = await deeplyFulfilled(
     harden({
@@ -89,7 +182,7 @@ export const startWalletFactory = async (
     { Fee: feeIssuer },
     terms,
     {
-      storageNode,
+      storageNode: walletStorageNode,
       // POLA contract only needs to register for srcId='wallet'
       // TODO consider a scoped attenuation of this bridge manager to just 'wallet'
       bridgeManager,
@@ -97,17 +190,32 @@ export const startWalletFactory = async (
   );
   walletFactoryStartResult.resolve(wfFacets);
   const poolBank = E(bankManager).getBankForAddress(poolAddr);
-  const ppTerms = harden({
-    perAccountInitialAmount: AmountMath.make(feeBrand, perAccountInitialValue),
-  });
 
-  /** @type {Awaited<ReturnType<typeof import('../provisionPool').start>>} */
-  const ppFacets = await E(zoe).startInstance(
-    provisionPool,
-    undefined,
-    ppTerms,
-    harden({ poolBank }),
+  const ppFacets = await startGovernedInstance(
+    // zoe.startInstance() args
+    {
+      zoe,
+      governedContractInstallation: provisionPool,
+      terms: {},
+      privateArgs: harden({
+        poolBank,
+        storageNode: poolStorageNode,
+        marshaller: E(board).getPublishingMarshaller(),
+      }),
+    },
+    {
+      governedParams: {
+        PerAccountInitialAmount: {
+          type: ParamTypes.AMOUNT,
+          value: AmountMath.make(feeBrand, perAccountInitialValue),
+        },
+      },
+      timer: chainTimerService,
+      contractGovernor,
+      economicCommitteeCreatorFacet,
+    },
   );
+
   provisionPoolStartResult.resolve(ppFacets);
 
   const handler = await E(ppFacets.creatorFacet).makeHandler({
@@ -142,6 +250,8 @@ export const WALLET_FACTORY_MANIFEST = {
       namesByAddress: true,
       namesByAddressAdmin: true,
       zoe: 'zoe',
+      chainTimerService: 'timer',
+      economicCommitteeCreatorFacet: 'economicCommittee',
     },
     produce: {
       client: true, // dummy client in this configuration
@@ -149,7 +259,11 @@ export const WALLET_FACTORY_MANIFEST = {
       provisionPoolStartResult: true,
     },
     installation: {
-      consume: { walletFactory: 'zoe', provisionPool: 'zoe' },
+      consume: {
+        walletFactory: 'zoe',
+        provisionPool: 'zoe',
+        contractGovernor: 'zoe',
+      },
     },
     brand: {
       consume: { [Stable.symbol]: 'zoe' },

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -223,6 +223,7 @@
  *   zoe: ZoeService,
  * }>} ChainBootstrapSpace
  *
+ * @typedef {import('../nameHub').NameHub} NameHub
  * IDEA/TODO: make types of demo stuff invisible in production behaviors
  * @typedef {{
  *   argv: {

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -149,6 +149,7 @@
  *     'amm' | 'ammGovernor' | 'VaultFactory' | 'VaultFactoryGovernor' |
  *     'stakeFactory' | 'stakeFactoryGovernor' |
  *     'psmCharter' | 'interchainPool' |
+ *     'walletFactory' | 'provisionPool' |
  *     'Treasury' | 'reserve' | 'reserveGovernor' | 'Pegasus',
  *   oracleBrand:
  *     'USD',

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -67,6 +67,8 @@ export const agoricNamesReserved = harden({
     reserveGovernor: 'ReserveGovernor',
     psmCharter: 'Charter for PSM Governance questions',
     interchainPool: 'interchainPool',
+    provisionPool: 'Account Provision Pool',
+    walletFactory: 'Smart Wallet Factory',
   },
   oracleBrand: {
     USD: 'US Dollar',

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -11,6 +11,57 @@ import './types.js';
 const { details: X } = assert;
 
 /**
+ * @typedef {object} NameHub read-only access to a node in a name hierarchy
+ *
+ * NOTE: We need to return arrays, not iterables, because even if marshal could
+ * allow passing a remote iterable, there would be an inordinate number of round
+ * trips for the contents of even the simplest nameHub.
+ *
+ * @property {(...path: Array<string>) => Promise<any>} lookup Look up a
+ * path of keys starting from the current NameHub.  Wait on any reserved
+ * promises.
+ * @property {() => [string, unknown][]} entries get all the entries
+ * available in the current NameHub
+ * @property {() => string[]} keys get all names available in the
+ * current NameHub
+ * @property {() => unknown[]} values get all values available in the
+ * current NameHub
+ */
+
+/**
+ * @typedef {object} NameAdmin write access to a node in a name hierarchy
+ *
+ * @property {(key: string) => void} reserve Mark a key as reserved; will
+ * return a promise that is fulfilled when the key is updated (or rejected when
+ * deleted).
+ * @property {( key: string, newValue: unknown, newAdmin?: unknown) =>
+ *   any } default Update if not already updated.  Return
+ *   existing value, or newValue if not existing.
+ * @property {(
+ *   key: string, newValue: unknown, newAdmin?: unknown) => void
+ * } set Update only if already initialized. Reject if not.
+ * @property {(
+ *   key: string, newValue: unknown, newAdmin?: unknown) => void
+ * } update Fulfill an outstanding reserved promise (if any) to the newValue and
+ * set the key to the newValue.  If newAdmin is provided, set that to return via
+ * lookupAdmin.
+ * @property {(...path: Array<string>) => Promise<any>} lookupAdmin Look up the
+ * `newAdmin` from the path of keys starting from the current NameAdmin.  Wait
+ * on any reserved promises.
+ * @property {(key: string) => void} delete Delete a value and reject an
+ * outstanding reserved promise (if any).
+ * @property {() => NameHub} readonly get the NameHub corresponding to the
+ * current NameAdmin
+ * @property {(fn: undefined | ((entries: [string, unknown][]) => void)) => void} onUpdate
+ */
+
+/**
+ * @typedef {object} NameHubKit a node in a name hierarchy
+ * @property {NameHub} nameHub read access
+ * @property {NameAdmin} nameAdmin write access
+ */
+
+/**
  * Make two facets of a node in a name hierarchy: the nameHub
  * is read access and the nameAdmin is write access.
  *

--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -27,7 +27,7 @@ const privateArgsShape = harden({
  * Metrics naming scheme is that nouns are present values and past-participles
  * are accumulative.
  *
- * @property {bigint} provisionedCount  count of new wallets provisioned
+ * @property {bigint} walletsProvisioned  count of new wallets provisioned
  * @property {Amount<'nat'>} totalMintedProvided  running sum of Minted provided to new wallets
  * @property {Amount<'nat'>} totalMintedConverted  running sum of Minted
  * ever received by the contract from PSM
@@ -135,10 +135,10 @@ export const start = async (zcf, privateArgs) => {
     privateArgs.storageNode,
     privateArgs.marshaller,
   );
-  const updateMetrics = provisionedCount => {
+  const updateMetrics = walletsProvisioned => {
     metricsPublisher.publish(
       harden({
-        provisionedCount,
+        walletsProvisioned,
         totalMintedProvided,
         totalMintedConverted,
       }),

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -10,56 +10,6 @@
  */
 
 /**
- * @typedef {object} NameHub read-only access to a node in a name hierarchy
- *
- * NOTE: We need to return arrays, not iterables, because even if marshal could
- * allow passing a remote iterable, there would be an inordinate number of round
- * trips for the contents of even the simplest nameHub.
- *
- * @property {(...path: Array<string>) => Promise<any>} lookup Look up a
- * path of keys starting from the current NameHub.  Wait on any reserved
- * promises.
- * @property {() => [string, unknown][]} entries get all the entries
- * available in the current NameHub
- * @property {() => string[]} keys get all names available in the
- * current NameHub
- * @property {() => unknown[]} values get all values available in the
- * current NameHub
- */
-
-/**
- * @typedef {object} NameAdmin write access to a node in a name hierarchy
- *
- * @property {(key: string) => void} reserve Mark a key as reserved; will
- * return a promise that is fulfilled when the key is updated (or rejected when
- * deleted).
- * @property {( key: string, newValue: unknown, newAdmin?: unknown) =>
- *   any } default Update if not already updated.  Return
- *   existing value, or newValue if not existing.
- * @property {(
- *   key: string, newValue: unknown, newAdmin?: unknown) => void
- * } set Update only if already initialized. Reject if not.
- * @property {(
- *   key: string, newValue: unknown, newAdmin?: unknown) => void
- * } update Fulfill an outstanding reserved promise (if any) to the newValue and
- * set the key to the newValue.  If newAdmin is provided, set that to return via
- * lookupAdmin.
- * @property {(...path: Array<string>) => Promise<any>} lookupAdmin Look up the
- * `newAdmin` from the path of keys starting from the current NameAdmin.  Wait
- * on any reserved promises.
- * @property {(key: string) => void} delete Delete a value and reject an
- * outstanding reserved promise (if any).
- * @property {() => NameHub} readonly get the NameHub corresponding to the
- * current NameAdmin
- * @property {(fn: undefined | ((entries: [string, unknown][]) => void)) => void} onUpdate
- */
-
-/**
+ * @typedef {import('./nameHub.js').NameAdmin} NameAdmin
  * @typedef {NameAdmin & { getMyAddress(): string }} MyAddressNameAdmin
- */
-
-/**
- * @typedef {object} NameHubKit a node in a name hierarchy
- * @property {NameHub} nameHub read access
- * @property {NameAdmin} nameAdmin write access
  */

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -9,6 +9,7 @@ import bundleSource from '@endo/bundle-source';
 import { E, Far, passStyleOf } from '@endo/far';
 
 import { makeZoeKit } from '@agoric/zoe';
+import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { buildRootObject as buildPSMRootObject } from '../src/core/boot-psm.js';
 import { buildRootObject } from '../src/core/boot.js';
 import { bridgeCoreEval } from '../src/core/chain-behaviors.js';
@@ -191,8 +192,8 @@ const psmParams = {
 test(`PSM-only bootstrap`, async t => {
   const root = buildPSMRootObject({ D: mockDProxy, logger: t.log }, psmParams);
 
-  const returnVal = await E(root).bootstrap(...mockPsmBootstrapArgs(t.log));
-  t.is(returnVal, undefined);
+  void E(root).bootstrap(...mockPsmBootstrapArgs(t.log));
+  await eventLoopIteration();
 
   const agoricNames =
     /** @type {Promise<import('../src/nameHub.js').NameHub>} */ (

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -194,9 +194,10 @@ test(`PSM-only bootstrap`, async t => {
   const returnVal = await E(root).bootstrap(...mockPsmBootstrapArgs(t.log));
   t.is(returnVal, undefined);
 
-  const agoricNames = /** @type {Promise<NameHub>} */ (
-    E(root).consumeItem('agoricNames')
-  );
+  const agoricNames =
+    /** @type {Promise<import('../src/nameHub.js').NameHub>} */ (
+      E(root).consumeItem('agoricNames')
+    );
   const instance = await E(agoricNames).lookup('instance', 'psm-IST-AUSD');
   t.is(passStyleOf(instance), 'remotable');
 });

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -67,6 +67,8 @@ const cmp = (a, b) => {
  * pursesStateChangeHandler?: (state: any) => void,
  * zoe: ERef<ZoeService>,
  * }} opt
+ *
+ * @typedef {import('@agoric/vats/src/nameHub').NameHub} NameHub
  */
 export function makeWalletRoot({
   zoe,

--- a/packages/wallet/api/src/wallet.js
+++ b/packages/wallet/api/src/wallet.js
@@ -32,6 +32,8 @@ import './internal-types.js';
  * timerDeviceScale?: number,
  * zoe: ERef<ZoeService>,
  * }} StartupTerms
+ *
+ * @typedef {import('@agoric/vats/src/nameHub').NameHub} NameHub
  */
 
 export function buildRootObject(vatPowers) {

--- a/packages/wallet/contract/src/singleWallet.js
+++ b/packages/wallet/contract/src/singleWallet.js
@@ -21,6 +21,8 @@ const { assign, entries, keys, fromEntries } = Object;
  *   myAddressNameAdmin: ERef<MyAddressNameAdmin>,
  *   namesByAddress: ERef<NameHub>,
  * }} SmartWalletContractTerms
+ *
+ * @typedef {import('@agoric/vats/src/nameHub').NameHub} NameHub
  */
 
 /**

--- a/packages/wallet/contract/src/smartWallet.js
+++ b/packages/wallet/contract/src/smartWallet.js
@@ -22,6 +22,8 @@ const { assign, entries, keys, fromEntries } = Object;
  * storageNode: ERef<StorageNode>,
  * zoe: ERef<ZoeService>,
  * }} shared
+ *
+ * @typedef {import('@agoric/vats/src/nameHub').NameHub} NameHub
  */
 export const makeSmartWallet = async (
   { address, bank, myAddressNameAdmin },

--- a/packages/wallet/contract/src/support.js
+++ b/packages/wallet/contract/src/support.js
@@ -13,6 +13,7 @@ import { E } from '@endo/far';
  * namesByAddress: ERef<NameHub>,
  * zoe: ERef<ZoeService>,
  * }} terms
+ * @typedef {import('@agoric/vats/src/nameHub').NameHub} NameHub
  */
 export async function makeWallet(bank, terms) {
   const legacyRootObject = buildRootObject();

--- a/packages/wallet/contract/src/walletFactory.js
+++ b/packages/wallet/contract/src/walletFactory.js
@@ -21,6 +21,8 @@ import { makeSmartWallet } from './smartWallet.js';
  *   namesByAddress: ERef<NameHub>,
  * }} SmartWalletContractTerms
  *
+ * @typedef {import('@agoric/vats/src/nameHub').NameHub} NameHub
+ *
  * @typedef {{
  * 	 type: 'WALLET_ACTION',
  *   owner: string,


### PR DESCRIPTION
closes: #6067

## Description

- [x] move initialAmount term to governance
- [x] add subscription for
  - provisionedCount: 1n,
  - totalMintedConverted
  - totalMintedProvided
- [x] connect provisionPool to psmCharter so econ committee can govern it
- drive by: propagate error from PSM bootstrap

The difference between totalMintedConverted and totalMintedProvided is the pool balance.

## Docs

added initial amount to inter-protocol/docs/governance-params.md

## Testing

I (@dckc) tested the metrics manually end-to-end.

I have not tested the ability to change the initial amount via governance; I expect we'll do that as we validate the rest of committee governance end-to-end.

