### PR TITLE
fix(smart-wallet): not yet durable-able

### DIFF
--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -13,8 +13,7 @@ import {
 } from '@agoric/notifier';
 import { fit, M, makeScalarMapStore } from '@agoric/store';
 import {
-  defineDurableFarClassKit,
-  makeKindHandle,
+  defineVirtualFarClassKit,
   makeScalarBigMapStore,
   pickFacet,
 } from '@agoric/vat-data';
@@ -457,8 +456,8 @@ const finish = ({ state, facets }) => {
   });
 };
 
-const SmartWalletKit = defineDurableFarClassKit(
-  makeKindHandle('SmartWallet'),
+const SmartWalletKit = defineVirtualFarClassKit(
+  'SmartWallet',
   behaviorGuards,
   initState,
   behavior,

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -48,9 +48,7 @@ export const start = async (zcf, privateArgs) => {
   const { storageNode, bridgeManager } = privateArgs;
 
   /** @type {MapStore<string, import('./smartWallet').SmartWallet>} */
-  const walletsByAddress = makeScalarBigMapStore('walletsByAddress', {
-    durable: true,
-  });
+  const walletsByAddress = makeScalarBigMapStore('walletsByAddress');
   const provider = makeAtomicProvider(walletsByAddress);
 
   const handleWalletAction = makeHeapFarInstance(


### PR DESCRIPTION
## Description

#6178 made the wallet factory durable and relied on the chain deployment test to check that the object graph was compatible. Unfortunately we don't yet have wallets in the deployment test (see https://github.com/Agoric/agoric-sdk/issues/6171 ) so it didn't detect this exception on smart wallet construction,
```
Error: value for "bank" is not durable
```

Revert for now to get master working.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

Needs a regression test. Forthcoming.
