### PR TITLE
test: withAmountUtils expects IssuerKit

### DIFF
--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -196,7 +196,6 @@ async function makePsmDriver(t, customTerms) {
         give: { In: giveAnchor },
         ...(wantMinted ? { want: { Out: wantMinted } } : {}),
       }),
-      // @ts-expect-error known defined
       harden({ In: anchor.mint.mintPayment(giveAnchor) }),
     );
     await eventLoopIteration();
@@ -292,7 +291,6 @@ test('simple trades', async t => {
     giveRun,
   );
   const anchorPayouts = await driver.swapMintedForAnchor(giveRun, runPayment);
-  // @ts-expect-error known non-null
   const actualAnchor = await E(anchor.issuer).getAmountOf(anchorPayouts.Out);
   const expectedAnchor = AmountMath.make(
     anchor.brand,
@@ -332,7 +330,6 @@ test('limit', async t => {
   // const actualRun = await E(runIssuer).getAmountOf(runPayout);
   // t.deepEqual(actualRun, AmountMath.makeEmpty(runBrand));
   const anchorReturn = await paymentPs.In;
-  // @ts-expect-error known non-null
   const actualAnchor = await E(anchor.issuer).getAmountOf(anchorReturn);
   t.deepEqual(actualAnchor, give);
   // The pool should be unchanged
@@ -462,7 +459,6 @@ test('anchor is 2x minted', async t => {
     giveRun,
   );
   const anchorPayouts = await driver.swapMintedForAnchor(giveRun, runPayment);
-  // @ts-expect-error known non-null
   const actualAnchor = await E(anchor.issuer).getAmountOf(anchorPayouts.Out);
   const expectedAnchor = floorMultiplyBy(
     minusMintedFee(giveRun),

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -175,10 +175,7 @@ export const produceInstallations = (space, installations) => {
 };
 
 /**
- * @param {object} kit
- * @param {Brand<'nat'>} kit.brand
- * @param {Issuer<'nat'>} [kit.issuer]
- * @param {Mint<'nat'>} [kit.mint]
+ * @param {Pick<IssuerKit<'nat'>, 'brand' | 'issuer' | 'mint'>} kit
  */
 export const withAmountUtils = kit => {
   return {

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -101,6 +101,7 @@ export const makeDriverContext = async () => {
   const { zoe, feeMintAccess } = setUpZoeForTest();
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
+  // @ts-expect-error missing mint
   const run = withAmountUtils({ issuer: runIssuer, brand: runBrand });
   const aeth = withAmountUtils(makeIssuerKit('aEth'));
   const bundleCache = await unsafeMakeBundleCache('./bundles/'); // package-relative

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -113,6 +113,7 @@ test.before(async t => {
   const { zoe, feeMintAccess } = setUpZoeForTest();
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
+  // @ts-expect-error missing mint
   const run = withAmountUtils({ issuer: runIssuer, brand: runBrand });
   const aeth = withAmountUtils(makeIssuerKit('aEth'));
 

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -117,6 +117,7 @@ test.before(async t => {
 /** @param {Awaited<ReturnType<typeof makeTestContext>>} context */
 const tools = context => {
   const { zoe, anchor, installs } = context;
+  // @ts-expect-error missing mint
   const minted = withAmountUtils(context.minted);
   const makeBank = () => {
     const issuers = makeScalarMap();


### PR DESCRIPTION
## Description

While some `withAmountUtils` are made with `run` that doesn't have a `mint` available, almost always it's made with a full issuer kit so make the type assume it was and suppress error on construction as necessary. Since these are unit tests, if `.mint` is accessed when not defined, the test will fail so the type doesn't need to be so cautious.

### Security Considerations

--
### Documentation Considerations

--

### Testing Considerations

--