### PR TITLE
fix: increase snapshot interval from 200 to 1,000

### DIFF
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -308,7 +308,7 @@ export default function makeKernelKeeper(
       defaultReapInterval = 1,
       relaxDurabilityRules = false,
       snapshotInitial = 2,
-      snapshotInterval = 200,
+      snapshotInterval = 1_000,
     } = kernelOptions;
 
     kvStore.set('vat.names', '[]');


### PR DESCRIPTION
fixes #6196

### Description

snapshots seem to take a lot of time; with this change, we do it 5x less often

### Testing Considerations

untested