### PR TITLE
test(vats): match decentral-psm-config.json against a pattern

### DIFF
--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -97,6 +97,11 @@ const AnchorOptionsShape = M.split(
   }),
 );
 
+export const ParametersShape = harden({
+  anchorAssets: M.arrayOf(AnchorOptionsShape),
+  economicCommitteeAddresses: M.recordOf(M.string(), M.string()),
+});
+
 /**
  * Build root object of the PSM-only bootstrap vat.
  *
@@ -112,13 +117,8 @@ const AnchorOptionsShape = M.split(
 export const buildRootObject = (vatPowers, vatParameters) => {
   const log = vatPowers.logger || console.info;
 
+  fit(harden(vatParameters), ParametersShape, 'boot-psm params');
   const { anchorAssets, economicCommitteeAddresses } = vatParameters;
-  fit(harden(anchorAssets), M.arrayOf(AnchorOptionsShape), 'anchorAssets');
-  fit(
-    harden(economicCommitteeAddresses),
-    M.recordOf(M.string(), M.string()),
-    'economicCommitteeAddresses',
-  );
 
   const { produce, consume } = makePromiseSpace(log);
   const { agoricNames, agoricNamesAdmin, spaces } = makeAgoricNamesAccess(

--- a/packages/vats/test/test-boot-config.js
+++ b/packages/vats/test/test-boot-config.js
@@ -1,0 +1,61 @@
+// @ts-check
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { promises as fsPromises } from 'fs';
+import path from 'path';
+
+import { fit, M } from '@agoric/store';
+import { ParametersShape as BootParametersShape } from '../src/core/boot-psm.js';
+
+const pathname = new URL(import.meta.url).pathname;
+const dirname = path.dirname(pathname);
+const asset = (...ps) =>
+  fsPromises.readFile(path.join(dirname, ...ps), 'utf-8');
+
+/**
+ * NOTE: this pattern suffices for PSM bootstrap,
+ * but does not cover the whole SwingSet config syntax.
+ *
+ * {@link packages/SwingSet/docs/configuration.md}
+ * TODO: move this to swingset?
+ *
+ * @see SwingSetConfig
+ * in packages/SwingSet/src/types-external.js
+ */
+const shape = (() => {
+  const ManagerType = M.or('xs-worker', 'local'); // TODO: others
+
+  const Bundle = M.split({ moduleType: M.string() }, M.partial({}));
+
+  const p1 = M.and(
+    M.partial({ creationOptions: M.partial({ critial: M.boolean() }) }),
+    M.partial({ parameters: M.recordOf(M.string(), M.any()) }),
+  );
+  const SwingSetConfigProperties = M.or(
+    M.split({ sourceSpec: M.string() }, p1),
+    M.split({ bundleSpec: M.string() }, p1),
+    M.split({ bundle: Bundle }, p1),
+  );
+  const SwingSetConfigDescriptor = M.recordOf(
+    M.string(),
+    SwingSetConfigProperties,
+  );
+
+  const SwingSetConfig = M.and(
+    M.partial({ defaultManagerType: ManagerType }),
+    M.partial({ includeDevDependencies: M.boolean() }),
+    M.partial({ defaultReapInterval: M.number() }), // not in swingset decl
+    M.partial({ vats: SwingSetConfigDescriptor }),
+    M.partial({ bootstrap: M.string() }),
+    M.partial({ bundles: SwingSetConfigDescriptor }),
+  );
+
+  return { ManagerType, SwingSetConfig };
+})();
+
+test('PSM config file is valid', async t => {
+  const txt = await asset('..', 'decentral-psm-config.json');
+  const config = harden(JSON.parse(txt));
+  t.notThrows(() => fit(config, shape.SwingSetConfig));
+  t.notThrows(() => fit(config.vats.bootstrap.parameters, BootParametersShape));
+});


### PR DESCRIPTION
refs: #6009 

## Description

catch things like `[]` vs `{}` in `economicCommitteeAddresses`.

### Security Considerations

input validation is a security best practice

### Documentation Considerations

perhaps the bootstrap parameters for `boot-psm.js` could use more documentation.

### Testing Considerations

yup.
