### PR TITLE
test: make it possible to label representatives during debugging

### DIFF
--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -18,6 +18,9 @@ import { parseVatSlot } from '../lib/parseVatSlots.js';
 // later regenerated.
 const unweakable = new WeakSet();
 
+// label representatives to simplify identification during debugging
+const LABEL_REPRESENTATIVES = false;
+
 /**
  * Make a simple LRU cache of virtual object inner selves.
  *
@@ -732,7 +735,10 @@ export function makeVirtualObjectManager(
         // `context` does not need a linkToCohort because it holds the
         // facets (which hold the cohort)
         unweakable.add(context);
-        const self = harden({ __proto__: prototypeTemplate });
+        const self = harden({
+          __proto__: prototypeTemplate,
+          ...(LABEL_REPRESENTATIVES ? { [innerSelf.baseRef]: () => {} } : {}),
+        });
         context.self = self;
         contextMapTemplate.set(self, context);
         toHold = self;

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -752,6 +752,9 @@ export function makeVirtualObjectManager(
         for (const name of facetNames) {
           const facet = harden({
             __proto__: prototypeTemplate[name],
+            ...(LABEL_REPRESENTATIVES
+              ? { [`${innerSelf.baseRef}|${name}`]: () => {} }
+              : {}),
           });
           contextMapTemplate[name].set(facet, context);
           facets[name] = facet;


### PR DESCRIPTION
## Description

I've been looking for a way to distinguish different opaque representatives during debugging. @warner showed me how. I've added a flag to make it simple to turn this on when needed.

### Security Considerations

In production, logs shouldn't contain this detail. During debugging, it's fine.

### Documentation Considerations

We don't tend to write this kind of thing up.

### Testing Considerations

This made it far easier for me to debug while working on #6167.  I've wanted the same ability several times before.