### PR TITLE
fix: triage await safety

### DIFF
--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -4,30 +4,13 @@ import path from 'path';
 
 import { resolve as resolveModuleSpecifier } from 'import-meta-resolve';
 import { assert, details as X } from '@agoric/assert';
+import { allValues } from '@agoric/internal';
 import bundleSource from '@endo/bundle-source';
 
 import '../types-ambient.js';
 import { insistStorageAPI } from '../lib/storageAPI.js';
 import { initializeKernel } from './initializeKernel.js';
 import { kdebugEnable } from '../lib/kdebug.js';
-
-/**
- * @param {X[]} xs
- * @param {Y[]} ys
- * @returns {[X, Y][]}
- * @template X, Y
- */
-const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
-const { keys, values, fromEntries } = Object;
-/**
- * @param {Record<string, Promise<V>>} obj
- * @returns {Promise<Record<string, V>>}
- * @template V
- */
-const allValues = async obj => {
-  const vals = await Promise.all(values(obj));
-  return fromEntries(zip(keys(obj), vals));
-};
 
 const bundleRelative = rel =>
   bundleSource(new URL(rel, import.meta.url).pathname);

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -24,8 +24,10 @@ const { keys, values, fromEntries } = Object;
  * @returns {Promise<Record<string, V>>}
  * @template V
  */
-const allValues = async obj =>
-  fromEntries(zip(keys(obj), await Promise.all(values(obj))));
+const allValues = async obj => {
+  const vals = await Promise.all(values(obj));
+  return fromEntries(zip(keys(obj), vals));
+};
 
 const bundleRelative = rel =>
   bundleSource(new URL(rel, import.meta.url).pathname);
@@ -172,7 +174,14 @@ export function loadBasedir(basedir, options = {}) {
  */
 async function resolveSpecFromConfig(referrer, specPath) {
   try {
-    return new URL(await resolveModuleSpecifier(specPath, referrer)).pathname;
+    // This nested await is safe because "terminal-control-flow".
+    //
+    // Some code does execute after this one, synchronously or asynchronously.
+    // That would normally be unsafe, but all that code is clearly not stateful.
+    // Its correctness is independent on timing.
+    // eslint-disable-next-line @jessie.js/no-nested-await
+    const base = await resolveModuleSpecifier(specPath, referrer);
+    return new URL(base).pathname;
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND' && e.code !== 'ERR_MODULE_NOT_FOUND') {
       throw e;
@@ -235,7 +244,21 @@ export async function loadSwingsetConfigFile(configPath) {
       configPath,
       `file:///${process.cwd()}/`,
     ).toString();
+    // This nested await is safe because "not-my-problem".
+    //
+    // It does occur nested with a control flow branch. But it is at top
+    // level within that branch, followed by another await also at
+    // top level within that branch. Therefore, this await introduces
+    // no unsafety beyond that potentially caused by the next await.
+    // eslint-disable-next-line @jessie.js/no-nested-await
     await normalizeConfigDescriptor(config.vats, referrer, true);
+    // This nested await is safe because "synchonous-throw-impossible".
+    //
+    // normalizeConfigDescriptor is an async function. The only argument
+    // expression that might in theory throw is `config.bundles`, which we
+    // are confident could not actually throw. Even if it could, we'd still
+    // be safe because "terminal-control-flow". The catch body is not stateful.
+    // eslint-disable-next-line @jessie.js/no-nested-await
     await normalizeConfigDescriptor(config.bundles, referrer, false);
     // await normalizeConfigDescriptor(config.devices, referrer, true); // TODO: represent devices
     assert(config.bootstrap, X`no designated bootstrap vat in ${configPath}`);

--- a/packages/SwingSet/src/devices/plugin/device-plugin.js
+++ b/packages/SwingSet/src/devices/plugin/device-plugin.js
@@ -53,6 +53,15 @@ export function buildRootDeviceNode(tools) {
    */
   async function createConnection(mod, index, epoch) {
     try {
+      // This nested await is safe because "terminal-throw-control-flow".
+      //
+      // This statement appears at the top level of a top level try block,
+      // and so is executed
+      // unconditionally. If it throws, we do nothing significantly stateful
+      // before exiting. (We do not consider `console.log` to be stateful
+      // for these purposes.) Otherwise, it will always cause a turn boundary
+      // before control flow continues.
+      // eslint-disable-next-line @jessie.js/no-nested-await
       const modNS = await endowments.import(mod);
       const receiver = obj => {
         // console.info('receiver', index, obj);

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -237,7 +237,28 @@ export function makeNetworkProtocol(protocolHandler) {
     // Check if we are underspecified (ends in slash)
     if (localAddr.endsWith(ENDPOINT_SEPARATOR)) {
       for (;;) {
-        // eslint-disable-next-line no-await-in-loop
+        // This nested await is safe because "terminal-throw-control-flow" +
+        // "synchronous-throw-impossible" + "not-my-problem".
+        //
+        // We assume `E` cannot synchronously throw, and all the argument
+        // expressions are simple variables. If the await expression throws
+        // we exit the function immediately. Thus, there is a reliable
+        // turn boundary before each iteration of the loop. There remains
+        // the issue of zero iterations of the loop, which in this case is
+        // impossible because of the absence of a condition in the head.
+        //
+        // Finally, there remains the issue of the unbalances `if`. The
+        // then case will always take at least one turn boundary before
+        // proceeding. But the else case will proceed synchronously to
+        // the subsequent code. Fortunately, the next interesting statement
+        // is a top level await, so this await does not introduce any
+        // unsafety beyond that caused by the other await.
+        // Hence "not-my-problem". That await is manifestly safe because it
+        // is at top level of the function and always forces a turn boundary.
+        // The awaited expression is another `E` message send expression in
+        // which all the argument expressions are only variables, so it will
+        // not cause anything stateful prior to that turn boundary.
+        // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
         const portID = await E(protocolHandler).generatePortID(
           localAddr,
           protocolHandler,
@@ -358,6 +379,8 @@ export function makeNetworkProtocol(protocolHandler) {
       },
     });
 
+    // The safety of the `await` in the loop above depends on this `await`
+    // remaining in place.
     await E(protocolHandler).onBind(port, localAddr, protocolHandler);
     boundPorts.init(localAddr, port);
     currentConnections.init(port, new Set());
@@ -379,6 +402,10 @@ export function makeNetworkProtocol(protocolHandler) {
         const [port, listener] = listening.get(listenPrefix);
         let localAddr;
         try {
+          // TODO FIXME This code should be refactored to make this
+          // await checkably safe, or to remove it, or to record here
+          // why it is actually safe.
+          //
           // See if our protocol is willing to receive this connection.
           // eslint-disable-next-line no-await-in-loop
           const localInstance = await E(protocolHandler)
@@ -460,6 +487,10 @@ export function makeNetworkProtocol(protocolHandler) {
 
       let lastFailure;
       try {
+        // TODO FIXME This code should be refactored to make this
+        // await checkably safe, or to remove it, or to record here
+        // why it is actually safe.
+        //
         // Attempt the loopback connection.
         const attempt = await protocolImpl.inbound(
           remoteAddr,

--- a/packages/agoric-cli/src/cosmos.js
+++ b/packages/agoric-cli/src/cosmos.js
@@ -85,6 +85,8 @@ export default async function cosmosMain(progname, rawArgs, powers, opts) {
   }
 
   if (popts.pull) {
+    // This await is safe because "terminal-control-flow"
+    // eslint-disable-next-line @jessie.js/no-nested-await
     const exitStatus = await pspawn('docker', ['pull', IMAGE]);
     if (exitStatus) {
       return exitStatus;

--- a/packages/agoric-cli/src/deploy.js
+++ b/packages/agoric-cli/src/deploy.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the agoric-cli package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 /* global process setTimeout setInterval clearInterval */
 /* eslint-disable no-await-in-loop */
 

--- a/packages/agoric-cli/src/init.js
+++ b/packages/agoric-cli/src/init.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the agoric-cli package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 import chalk from 'chalk';
 import { makePspawn } from './helpers.js';
 

--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the agoric-cli package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 /* global process AggregateError Buffer */
 import path from 'path';
 import chalk from 'chalk';

--- a/packages/agoric-cli/src/open.js
+++ b/packages/agoric-cli/src/open.js
@@ -55,6 +55,9 @@ export default async function walletMain(progname, rawArgs, powers, opts) {
   process.stdout.write(`${walletUrl}\n`);
   if (opts.browser) {
     const browser = opener(walletUrl);
+    // This await is safe because terminal-control-flow.
+    //
+    // eslint-disable-next-line @jessie.js/no-nested-await
     await new Promise(resolve => browser.on('exit', resolve));
   }
 }

--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the agoric-cli package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 // @ts-check
 /// <reference types="ses"/>
 

--- a/packages/agoric-cli/src/set-defaults.js
+++ b/packages/agoric-cli/src/set-defaults.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the agoric-cli package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 import { basename } from 'path';
 import { assert, details as X } from '@agoric/assert';
 import {

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the agoric-cli package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 /* global process setTimeout */
 import chalk from 'chalk';
 import { createHash } from 'crypto';

--- a/packages/cache/src/store.js
+++ b/packages/cache/src/store.js
@@ -77,6 +77,14 @@ const applyCacheTransaction = async (
   // Loop until our updated state is fresh wrt our current state.
   basisState = stateStore.get(keyStr);
   while (updatedState && updatedState.generation <= basisState.generation) {
+    // TODO FIXME This code should be refactored to make this
+    // await checkably safe, or to remove it, or to record here
+    // why it is actually safe.
+    //
+    // If we knew that this loop is guaranteed to execute at least once,
+    // then this await would be safe because "terminal-throw-control-flow".
+    // But if it might execute zero times, then the stateful code after
+    // this loop might execute synchronously or asynchronously.
     // eslint-disable-next-line no-await-in-loop
     updatedState = await getUpdatedState(basisState);
     // AWAIT INTERLEAVING

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -98,6 +98,14 @@ async function buildSwingset(
 
     // Find the entrypoints for all the core proposals.
     if (config.coreProposals) {
+      // TODO FIXME This code should be refactored to make this
+      // await checkably safe, or to remove it, or to record here
+      // why it is actually safe.
+      //
+      // `initializeSwingset` is stateful and is called synchronously
+      // or asynchronously, depending on which branch of the conditional
+      // is taken. If it were verified to be insensitive to this,
+      // then this await would be safe because "terminal-control-flow"
       const { bundles, code } = await extractCoreProposalBundles(
         config.coreProposals,
         vatconfig,
@@ -654,6 +662,11 @@ export async function launch({
           blockHeight,
           runNum,
         });
+        // This nested await is safe because "terminal-control-flow".
+        //
+        // It occurs at the top level of a case of an unbalanced,
+        // but top level terminal switch. Nothing happens after the switch.
+        // eslint-disable-next-line @jessie.js/no-nested-await
         await processAction(action.type, bootstrapBlock);
         controller.writeSlogObject({
           type: 'cosmic-swingset-run-finish',
@@ -685,6 +698,9 @@ export async function launch({
 
         // Save the kernel's computed state just before the chain commits.
         const start2 = Date.now();
+        // This nested await is safe because "terminal-control-flow".
+        //
+        // eslint-disable-next-line @jessie.js/no-nested-await
         await saveOutsideState(savedHeight, blockTime);
         const saveTime = Date.now() - start2;
         controller.writeSlogObject({
@@ -756,6 +772,14 @@ export async function launch({
 
           provideInstallationPublisher();
 
+          // This nested await is safe because "terminal-control-flow".
+          //
+          // It occurs at the top level of a branch of an unbalanced
+          // but terminal if, that is top level and terminal within a case
+          // of a top level unbalanced but terminal and top level switch.
+          // Thus, nothing happens after completion of the immeiately
+          // enclosing if.
+          // eslint-disable-next-line @jessie.js/no-nested-await
           await processAction(action.type, async () =>
             runKernel(
               blockHeight,
@@ -767,6 +791,9 @@ export async function launch({
 
           // We write out our on-chain state as a number of chainSends.
           const start = Date.now();
+          // This nested await is safe because "terminal-control-flow".
+          //
+          // eslint-disable-next-line @jessie.js/no-nested-await
           await saveChainState();
           chainTime = Date.now() - start;
 

--- a/packages/deploy-script-support/src/installInPieces.js
+++ b/packages/deploy-script-support/src/installInPieces.js
@@ -37,6 +37,21 @@ export const installInPieces = async (
       log(
         `waiting for ${inFlightAdditions.length} (~${approxBytesInFlight}B) additions...`,
       );
+      // This await is safe both because "initial-control-flow"
+      // and "terminal-control-flow"
+      //
+      // "initial-control-flow" is the time reversal of
+      // "terminal-control-flow". There is always a turn boundary before each
+      // iteration of a for-await-of loop. This await occurs in one branch
+      // of an unbalanced if within the loop body. But it happens before
+      // anything stateful executes within this iteration, so all subsequent
+      // code in the loop body only executes after a turn boundary.
+      // It is also safe because "terminal-control-flow" because non of the
+      // code in the remainder of the loop body is potentially stateful.
+      // The for-await-of loop protects all code after the loop anyway,
+      // because even in the zero iteration case it will always take a
+      // turn boundary.
+      // eslint-disable-next-line @jessie.js/no-nested-await
       await Promise.all(inFlightAdditions);
       approxBytesInFlight = 0;
       inFlightAdditions = [];

--- a/packages/deploy-script-support/src/startInstance.js
+++ b/packages/deploy-script-support/src/startInstance.js
@@ -97,6 +97,12 @@ export const makeStartInstance = (
         `creatorInvitation must be defined to be deposited`,
       );
       console.log(`-- Adding Invitation for: ${instancePetname}`);
+      // This nested await is safe bacause "terminal-control-flow".
+      //
+      // Nothing potentially stateful happens in this function after the
+      // await. For these purposes, `console.log` is not considered
+      // significantly stateful.
+      // eslint-disable-next-line @jessie.js/no-nested-await
       const invitationAmount = await E(zoeInvitationPurse).deposit(
         creatorInvitation,
       );

--- a/packages/deploy-script-support/src/writeCoreProposal.js
+++ b/packages/deploy-script-support/src/writeCoreProposal.js
@@ -1,3 +1,9 @@
+// IIUC the purpose of the deploy-script-support package,
+// we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 import fs from 'fs';
 import { E } from '@endo/far';
 

--- a/packages/inter-protocol/src/collect.js
+++ b/packages/inter-protocol/src/collect.js
@@ -1,11 +1,1 @@
-const { fromEntries, keys, values } = Object;
-
-/** @type { <X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
-export const zip = (xs, ys) => harden(xs.map((x, i) => [x, ys[+i]]));
-
-/** @type { <K extends string, V>(obj: Record<K, ERef<V>>) => Promise<Record<K, V>> } */
-export const allValues = async obj => {
-  const resolved = await Promise.all(values(obj));
-  // @ts-expect-error cast
-  return harden(fromEntries(zip(keys(obj), resolved)));
-};
+export { allValues, zip } from '@agoric/internal';

--- a/packages/inter-protocol/src/proposals/committee-proposal.js
+++ b/packages/inter-protocol/src/proposals/committee-proposal.js
@@ -1,11 +1,8 @@
-import { deeplyFulfilledObject } from '@agoric/internal';
+import { deeplyFulfilledObject, zip } from '@agoric/internal';
 import { E } from '@endo/far';
 import { reserveThenDeposit } from './utils.js';
 
 const { values } = Object;
-
-/** @type { <X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
-const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
 
 /**
  * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers

--- a/packages/inter-protocol/src/proposals/demoIssuers.js
+++ b/packages/inter-protocol/src/proposals/demoIssuers.js
@@ -286,6 +286,11 @@ export const connectFaucet = async ({
             case Stake.symbol:
               return bldIssuerKit;
             default: {
+              // This nested await is safe because "terminal-control-flow".
+              //
+              // This switch is the last statement within the enclosing
+              // function.
+              // eslint-disable-next-line @jessie.js/no-nested-await
               const { mint, issuer, brand } = await provideCoin(
                 name,
                 vats.mints,
@@ -304,6 +309,8 @@ export const connectFaucet = async ({
         // Use the bank layer for BLD, IST.
         if (issuerName === Stake.symbol || issuerName === Stable.symbol) {
           const purse = E(bank).getPurse(brand);
+          // This nested await is safe because "terminal-control-flow"
+          // eslint-disable-next-line @jessie.js/no-nested-await
           await E(purse).deposit(payment);
         } else {
           toFaucet = [
@@ -491,6 +498,8 @@ export const fundAMM = async ({
       async issuerName => {
         switch (issuerName) {
           case Stable.symbol: {
+            // This nested await is safe because "terminal-control-flow"
+            // eslint-disable-next-line @jessie.js/no-nested-await
             const [issuer, brand] = await Promise.all([
               centralIssuer,
               centralBrand,
@@ -625,6 +634,9 @@ export const fundAMM = async ({
       let fromCentral;
 
       if (brandsWithPriceAuthorities.includes(brand)) {
+        // TODO FIXME This code should be refactored to make this
+        // await checkably safe, or to remove it, or to record here
+        // why it is actually safe.
         ({ toCentral, fromCentral } = await E(ammPublicFacet)
           .getPriceAuthorities(brand)
           .catch(_e => {

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -4,7 +4,7 @@ import { makeStorageNodeChild } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/far';
 import { Stable } from '@agoric/vats/src/tokens.js';
-import { deeplyFulfilledObject } from '@agoric/internal';
+import { deeplyFulfilledObject, zip } from '@agoric/internal';
 import { makeScalarMapStore } from '@agoric/vat-data';
 
 import { reserveThenDeposit, reserveThenGetNamePaths } from './utils.js';
@@ -361,9 +361,6 @@ export const PSM_GOV_MANIFEST = {
     },
   },
 };
-
-/** @type { <X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
-const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
 
 /**
  * @param {import('./econ-behaviors').EconomyBootstrapPowers} powers

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -465,7 +465,16 @@ const helperBehavior = {
 
         // The rest of this method will not happen until after a quote is received.
         // This may not happen until much later, when the market changes.
-        // eslint-disable-next-line no-await-in-loop
+        //
+        // This nested await is safe because "terminal-control-flow"
+        //
+        // It occurs at top level of the body of a top level terminal
+        // while. But do note that the enclosing function is an asynchronous
+        // generator function and that there is a `yield` within the loop.
+        // I don't think that causes any additional worries, but I have not
+        // thought about it enough.
+        //
+        // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
         const quote = await E(ephemera.outstandingQuote).getPromise();
         ephemera.outstandingQuote = null;
         // When we receive a quote, we check whether the vault with the highest
@@ -486,7 +495,10 @@ const helperBehavior = {
         }
       }
     }
+
     for await (const next of eventualLiquidations()) {
+      // This nested await is safe because "top-of-for-await"
+      // eslint-disable-next-line @jessie.js/no-nested-await
       await facets.helper.liquidateAndRemove(next);
       trace('price check liq', state.collateralBrand, next && next[0]);
     }

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -352,3 +352,13 @@ export const fsStreamReady = stream =>
     stream.on('ready', onReady);
     stream.on('error', onError);
   });
+
+/** @type { <X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
+export const zip = (xs, ys) => harden(xs.map((x, i) => [x, ys[+i]]));
+
+/** @type { <K extends string, V>(obj: Record<K, V | PromiseLike<V>>) => Promise<Record<K, V>> } */
+export const allValues = async obj => {
+  const resolved = await Promise.all(Object.values(obj));
+  // @ts-expect-error cast
+  return harden(fromEntries(zip(Object.keys(obj), resolved)));
+};

--- a/packages/solo/src/add-chain.js
+++ b/packages/solo/src/add-chain.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the solo package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 /* global process */
 import fetch from 'node-fetch';
 import crypto from 'crypto';

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the solo package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 /* global setTimeout Buffer */
 import path from 'path';
 import fs from 'fs';

--- a/packages/solo/src/main.js
+++ b/packages/solo/src/main.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the solo package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 import fs from 'fs';
 import path from 'path';
 import parseArgs from 'minimist';

--- a/packages/solo/src/pipe-entrypoint.js
+++ b/packages/solo/src/pipe-entrypoint.js
@@ -37,6 +37,9 @@ const main = async () => {
   switch (method) {
     case 'connectToFakeChain': {
       const [basedir, GCI, delay] = margs;
+      // This nested await is safe because "terminal-control-flow".
+      //
+      // eslint-disable-next-line @jessie.js/no-nested-await
       deliverator = await connectToFakeChain(
         basedir,
         GCI,

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the solo package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 // @ts-check
 /* global process setTimeout */
 import fs from 'fs';

--- a/packages/solo/src/vat-http.js
+++ b/packages/solo/src/vat-http.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the solo package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 import { makeNotifierKit } from '@agoric/notifier';
 import { makeCache } from '@agoric/cache';
 import { E } from '@endo/eventual-send';

--- a/packages/solo/src/web.js
+++ b/packages/solo/src/web.js
@@ -1,3 +1,8 @@
+// IIUC the purpose of the solo package, we do not need to worry
+// about await safety for any of the code in this package.
+// TODO someone who understands this package better should verify this.
+/* eslint-disable @jessie.js/no-nested-await */
+
 /* global setTimeout clearTimeout setInterval clearInterval process */
 // Start a network service
 import path from 'path';

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -14,6 +14,7 @@ const main = async () => {
   }
 
   for await (const file of files) {
+    // This nested await is safe because "top-level-of-for-await".
     // eslint-disable-next-line @jessie.js/no-nested-await
     const { readCircBuf } = await makeMemoryMappedCircularBuffer({
       circularBufferFilename: file,
@@ -51,7 +52,9 @@ const main = async () => {
       }
 
       // If the buffer is full, wait for stdout to drain.
-      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+      //
+      // This nested await is safe because "synchronous-throw-impossible".
+      // eslint-disable-next-line @jessie.js/no-nested-await, no-await-in-loop
       await new Promise(resolve => process.stdout.once('drain', resolve));
     }
   }

--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -95,6 +95,14 @@ async function run() {
       lineCount % LINE_COUNT_TO_FLUSH === 0
     ) {
       lastTime = now;
+      // TODO FIXME This code should be refactored to make this
+      // await checkably safe, or to remove it, or to record here
+      // why it is actually safe.
+      //
+      // It is nested in a conditional with no
+      // balancing await on the other branch. Likely this is low risk
+      // because it is only in telemetry. The integrity of critical computation
+      // should not be endangered by a bug in telemetry in any case.
       // eslint-disable-next-line @jessie.js/no-nested-await
       await stats(update);
     }
@@ -110,6 +118,7 @@ async function run() {
       const delayMS = PROCESSING_PERIOD - (now - startOfLastPeriod);
       maybeWait = new Promise(resolve => setTimeout(resolve, delayMS));
     }
+    // This nested await is safe because "top-of-for-await".
     // eslint-disable-next-line @jessie.js/no-nested-await
     await maybeWait;
     now = Date.now();

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -385,6 +385,12 @@ export const registerNetworkProtocols = async (vats, dibcBridgeManager) => {
         });
       },
     });
+    // This nested await is safe because "terminal-control-flow".
+    //
+    // It occurs at the top level of one branch of an unbalanced non-top-level
+    // if. However, immediately after the if is another await expression
+    // that has no effects prior to the turn boundary.
+    // eslint-disable-next-line @jessie.js/no-nested-await
     const ibcHandler = await E(vats.ibc).createInstance(callbacks);
     dibcBridgeManager.register(BRIDGE_ID.DIBC, ibcHandler);
     ps.push(

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -381,6 +381,13 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
           const attemptP = E(protocolImpl).inbound(localAddr, remoteAddr);
 
           // Tell what version string we negotiated.
+          //
+          // This nested await is safe because "terminal-control-flow".
+          //
+          // It occurs at the top level of one branch of an unbalanced, but
+          // top level and terminal switch statement. Nothing happens after
+          // the switch.
+          // eslint-disable-next-line @jessie.js/no-nested-await
           const attemptedLocal = await E(attemptP).getLocalAddress();
           const match = attemptedLocal.match(
             // Match:  ... /ORDER/VERSION ...
@@ -493,6 +500,9 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
             rPortID,
             order,
           );
+          // This nested await is safe because "terminal-control-flow".
+          //
+          // eslint-disable-next-line @jessie.js/no-nested-await
           const localAddr = await E(attemptP).getLocalAddress();
           E(attemptP).accept({
             localAddress: `${localAddr}/ibc-channel/${channelID}`,
@@ -512,6 +522,9 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
           const connP = channelKeyToConnP.get(channelKey);
           const data = base64ToBytes(data64);
 
+          // This nested await is safe because "terminal-control-flow".
+          //
+          // eslint-disable-next-line @jessie.js/no-nested-await
           await E(connP)
             .send(data)
             .then(ack => {

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -43,7 +43,9 @@ const makePurseController = (
       let updateRecord = await balanceNotifier.getUpdateSince();
       while (updateRecord.updateCount) {
         yield updateRecord.value;
-        // eslint-disable-next-line no-await-in-loop
+        // This nested await is safe because "terminal-control-flow".
+        //
+        // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
         updateRecord = await balanceNotifier.getUpdateSince(
           updateRecord.updateCount,
         );

--- a/packages/web-components/src/admin-websocket-connector.js
+++ b/packages/web-components/src/admin-websocket-connector.js
@@ -10,7 +10,16 @@ export const waitForBootstrap = async getBootstrap => {
   let update = await getLoadingUpdate();
   while (update.value.includes('wallet')) {
     console.log('waiting for wallet');
-    // eslint-disable-next-line no-await-in-loop
+    // This await is safe because "terminal-combined-control-flow".
+    //
+    // It occurs at the top level of the loop body of a non-terminal top
+    // level loop, so we need to consider the zero-vs-non-zero iteration
+    // cases wrt the potentially stateful `getBootstrap()`. However, there is
+    // a turn boundary immediately prior to the loop, with no
+    // potentially stateful execution between that turn boundary and the loop.
+    // So, considering the loop and that previous await together,
+    // `getBootstrap()` in always called in a new turn.
+    // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
     update = await getLoadingUpdate(update.updateCount);
   }
 

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -325,6 +325,15 @@ export function makeOnewayPriceAuthorityKit(opts) {
               // We don't wait for the quote to be authenticated; resolve
               // immediately.
               quotePK.resolve(quoteP);
+              // This nested await is safe because
+              // "synchronous-throw-impossible" + "terminal-control-flow".
+              //
+              // The expression `quotePK.promise` might be a rejected promise,
+              // but (we assume) this expression cannot throw. Thus, if we
+              // reach here, we would only proceed to the stateful catch
+              // body after a turn boundary. The try-catch statement is
+              // top-level and terminal within the wake method.
+              // eslint-disable-next-line @jessie.js/no-nested-await
               await quotePK.promise;
             } catch (e) {
               quotePK.reject(e);

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -98,8 +98,9 @@ const start = zcf => {
     const option = payoffHandler.makeOptionInvitation(position);
     const invitationIssuer = zcf.getInvitationIssuer();
     const payment = harden({ Option: option });
+    const Option = await E(invitationIssuer).getAmountOf(option);
     const spreadAmount = harden({
-      Option: await E(invitationIssuer).getAmountOf(option),
+      Option,
     });
     // AWAIT ////
 

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -64,6 +64,15 @@ const start = async zcf => {
       try {
         assert(!revoked, revokedMsg);
         const noFee = AmountMath.makeEmpty(feeBrand);
+        // This nested await is safe because "synchronous-throw-impossible" +
+        // "terminal-control-flow".
+        //
+        // Assuming `E` does its job, the awaited expression cannot throw.
+        // If it returns a rejected promise, that will cause the stateful
+        // catch clause to execute, but only after a turn boundary.
+        // The await is at top level of a top level terminal try block, and so
+        // executes unconditionally unless something earlier threw.
+        // eslint-disable-next-line @jessie.js/no-nested-await
         const { requiredFee, reply } = await E(handler).onQuery(query, noFee);
         !requiredFee ||
           AmountMath.isGTE(noFee, requiredFee) ||
@@ -80,6 +89,11 @@ const start = async zcf => {
       const doQuery = async querySeat => {
         try {
           const fee = querySeat.getAmountAllocated('Fee', feeBrand);
+          // This nested await is safe because "synchronous-throw-impossible" +
+          // "terminal-control-flow".
+          //
+          // Same reasons as above.
+          // eslint-disable-next-line @jessie.js/no-nested-await
           const { requiredFee, reply } = await E(handler).onQuery(query, fee);
           if (requiredFee) {
             feeSeat.incrementBy(


### PR DESCRIPTION
Jessie warns of violations of https://github.com/Agoric/agoric-sdk/wiki/No-Nested-Await . Before this PR, a `yarn lint` of agoric-sdk generated 188 of these warnings. This PR triages those warnings. 10 remain warnings and should be fixed subsequent to this PR, preferably by someone who better understands the code these occur in.

For each warning, I either
   * for the 10 that still need to be fixed, I added a TODO FIXME comment and filed one of the issues listed below.
   * turned the rule off wholesale for modules in packages that likely don't need to be assert-safe.
   * fixed the code so that it obeys the No-Nested-Await rule
   * fixed the code so it is actually safe for reasons I explain, even though it still violates No-Nested-Await.
   * realized the code was already safe, sometimes for subtle reasons I explain, even though it violates the No-Nested-Await rule.

For each explanation I inserted, I tried to state the principle I found myself using to figure out that the code is safe. For each of these, I coined a term for this principle, such as "terminal-control-flow", and explain it well the first time I encounter it. Other times, I use the name of the principle, explaining only why it applies to that individual case.

Of my fixes, if they were about correctness, I have filed one of "Fixes" issues listed below that also raises the possibility of cherry picking that fix, so that it could go in ahead of the rest of this PR.

Reviewers, after this PR goes through its first sanity check by you, based on your feedback I will then collect an explanation of the surviving principles and put them someplace more reusable, like our wiki.

Everyone, *please* look at my changes to the code you're most familiar with to see if I broke anything. I tried to be very careful not to, but... . Also, please see if my explanations of why your code was safe, or with my mods is now safe, make sense to you. Even better if you could send me less convoluted replacements than mine for your current code, for example code in which we no longer need to suppress the Jessie await warning.

---

Does not yet fix https://github.com/Agoric/agoric-sdk/issues/6220 , but I expect to include it before merging if it has not already been fixed.

Still needing analysis, but could be addressed in separate PRs:
https://github.com/Agoric/agoric-sdk/issues/6226
https://github.com/Agoric/agoric-sdk/issues/6227
https://github.com/Agoric/agoric-sdk/issues/6228
https://github.com/Agoric/agoric-sdk/issues/6229
https://github.com/Agoric/agoric-sdk/issues/6230
https://github.com/Agoric/agoric-sdk/issues/6231
https://github.com/Agoric/agoric-sdk/issues/6232
https://github.com/Agoric/agoric-sdk/issues/6233
https://github.com/Agoric/agoric-sdk/issues/6234
https://github.com/Agoric/agoric-sdk/issues/6235

This PR would fix, if not already fixed by cherry picking from this PR:
Fixes https://github.com/Agoric/agoric-sdk/issues/6237
Fixes https://github.com/Agoric/agoric-sdk/issues/6239
Fixes https://github.com/Agoric/agoric-sdk/issues/6240
Fixes https://github.com/Agoric/agoric-sdk/issues/6242
Fixes https://github.com/Agoric/agoric-sdk/issues/6243
Fixes https://github.com/Agoric/agoric-sdk/issues/6244