### PR TITLE
feat(cosmic-swingset): Depth first scheduling

### DIFF
--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -24,6 +24,7 @@ import { BridgeId as BRIDGE_ID } from '@agoric/internal';
 import stringify from './json-stable-stringify.js';
 import { launch } from './launch-chain.js';
 import { getTelemetryProviders } from './kernel-stats.js';
+import { makeQueue } from './make-queue.js';
 
 // eslint-disable-next-line no-unused-vars
 let whenHellFreezesOver = null;
@@ -112,81 +113,6 @@ const makeChainStorage = (call, prefix = '', options = {}) => {
     onAbort: resetCache,
   });
   return { ...buffered, commit, abort };
-};
-
-/**
- * Create a queue backed by chain storage.
- *
- * The queue uses the following storage layout, prefixed by `prefix`, such as
- * `actionQueue.`:
- * - `<prefix>head`: the index of the first entry of the queue.
- * - `<prefix>tail`: the index *past* the last entry in the queue.
- * - `<prefix><index>`: the contents of the queue at the given index.
- *
- * For the `actionQueue`, the Cosmos side of the queue will push into the queue,
- * updating `<prefix>tail` and `<prefix><index>`.  The JS side will shift the
- * queue, updating `<prefix>head` and reading and deleting `<prefix><index>`.
- *
- * Parallel access is not supported, only a single outstanding operation at a
- * time.
- *
- * @param {(obj: any) => any} call send a message to the chain's storage API and
- * receive a reply
- * @param {string} [prefix] string to prepend to the queue's storage keys
- */
-const makeChainQueue = (call, prefix = '') => {
-  const storage = makeChainStorage(call, prefix);
-  const queue = {
-    push: obj => {
-      const tail = storage.get('tail') || 0;
-      storage.set('tail', tail + 1);
-      storage.set(`${tail}`, obj);
-      storage.commit();
-    },
-    /** @type {Iterable<unknown>} */
-    consumeAll: () => ({
-      [Symbol.iterator]: () => {
-        let done = false;
-        let head = storage.get('head') || 0;
-        const tail = storage.get('tail') || 0;
-        return {
-          next: () => {
-            if (done) return { done };
-            if (head < tail) {
-              // Still within the queue.
-              const headKey = `${head}`;
-              const value = storage.get(headKey);
-              storage.delete(headKey);
-              head += 1;
-              return { value, done };
-            }
-            // Reached the end, so clean up our indices.
-            storage.delete('head');
-            storage.delete('tail');
-            storage.commit();
-            done = true;
-            return { done };
-          },
-          return: () => {
-            if (done) return { done };
-            // We're done consuming, so save our state.
-            storage.set('head', head);
-            storage.commit();
-            done = true;
-            return { done };
-          },
-          throw: err => {
-            if (done) return { done };
-            // Don't change our state.
-            storage.abort();
-            done = true;
-            throw err;
-          },
-        };
-      },
-    }),
-  };
-  return queue;
 };
 
 export default async function main(progname, args, { env, homedir, agcc }) {
@@ -323,9 +249,11 @@ export default async function main(progname, args, { env, homedir, agcc }) {
         toChainShape: exportMailbox,
       },
     );
-    const actionQueue = makeChainQueue(
-      msg => chainSend(portNums.storage, msg),
-      `${STORAGE_PATH.ACTION_QUEUE}.`,
+    const actionQueue = makeQueue(
+      makeChainStorage(
+        msg => chainSend(portNums.storage, msg),
+        `${STORAGE_PATH.ACTION_QUEUE}.`,
+      ),
     );
     function setActivityhash(activityhash) {
       const msg = stringify({

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -513,7 +513,7 @@ export async function launch({
         verboseBlocks && blockManagerConsole.info('block bootstrap');
         if (computedHeight !== 0) {
           throw Error(
-            `Cannot run a bootstrap block at height ${action.blockHeight}`,
+            `Cannot run a bootstrap block at height ${computedHeight}`,
           );
         }
         await processAction(action);

--- a/packages/cosmic-swingset/src/make-queue.js
+++ b/packages/cosmic-swingset/src/make-queue.js
@@ -1,0 +1,81 @@
+/**
+ * @typedef {object} QueueStorage
+ * @property {() => void} commit
+ * @property {() => void} abort
+ * @property {(key: string) => unknown} get
+ * @property {(key: string, value: unknown) => void} set
+ * @property {(key: string) => void} delete
+ */
+
+/**
+ * Create a queue backed by some sort of scoped storage.
+ *
+ * The queue writes the following bare keys, and expect any prefixing/scoping
+ * to be handled by the storage:
+ * - `head`: the index of the first entry of the queue.
+ * - `tail`: the index *past* the last entry in the queue.
+ * - `<index>`: the contents of the queue at the given index.
+ *
+ * For the `actionQueue`, the Cosmos side of the queue will push into the queue,
+ * updating `<prefix>tail` and `<prefix><index>`.  The JS side will shift the
+ * queue, updating `<prefix>head` and reading and deleting `<prefix><index>`.
+ *
+ * Parallel access is not supported, only a single outstanding operation at a
+ * time.
+ *
+ * @param {QueueStorage} storage a scoped queue storage
+ */
+export const makeQueue = storage => {
+  const queue = {
+    push: obj => {
+      const tail = storage.get('tail') || 0;
+      storage.set('tail', tail + 1);
+      storage.set(`${tail}`, obj);
+      storage.commit();
+    },
+    /** @type {Iterable<unknown>} */
+    consumeAll: () => ({
+      [Symbol.iterator]: () => {
+        let done = false;
+        let head = storage.get('head') || 0;
+        const tail = storage.get('tail') || 0;
+        return {
+          next: () => {
+            if (done) return { done };
+            if (head < tail) {
+              // Still within the queue.
+              const headKey = `${head}`;
+              const value = storage.get(headKey);
+              storage.delete(headKey);
+              head += 1;
+              return { value, done };
+            }
+            // Reached the end, so clean up our indices.
+            storage.delete('head');
+            storage.delete('tail');
+            storage.commit();
+            done = true;
+            return { done };
+          },
+          return: () => {
+            if (done) return { done };
+            // We're done consuming, so save our state.
+            storage.set('head', head);
+            storage.commit();
+            done = true;
+            return { done };
+          },
+          throw: err => {
+            if (done) return { done };
+            // Don't change our state.
+            storage.abort();
+            done = true;
+            throw err;
+          },
+        };
+      },
+    }),
+  };
+  return queue;
+};
+harden(makeQueue);

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -606,8 +606,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
 
         // TODO: Move the encompassing `block` root span to cosmos
         spans.push(`block ${slogAttrs.blockHeight}`);
-        spans.start(`begin-block`, spans.top());
-        spans.end(`begin-block`);
+        spans.top().addEvent(`begin-block-action`, cleanAttrs(slogAttrs), now);
         break;
       }
       case 'cosmic-swingset-commit-block-start': {
@@ -637,11 +636,20 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         break;
       }
       case 'cosmic-swingset-end-block-start': {
-        spans.push(`end-block`);
+        // Add `end-block` as an event onto the emcompassing `block` span
+        spans.top().addEvent('end-block-action', cleanAttrs(slogAttrs), now);
         break;
       }
       case 'cosmic-swingset-end-block-finish': {
-        spans.pop('end-block');
+        // Don't record finish
+        break;
+      }
+      case 'cosmic-swingset-run-start': {
+        spans.push(`swingset-run`);
+        break;
+      }
+      case 'cosmic-swingset-run-finish': {
+        spans.pop(`swingset-run`);
         break;
       }
       case 'heap-snapshot-save': {

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -571,6 +571,14 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         }
         break;
       }
+      case 'bundle-kernel-start': {
+        spans.push(`bundle-kernel`);
+        break;
+      }
+      case 'bundle-kernel-finish': {
+        spans.pop('bundle-kernel');
+        break;
+      }
       case 'cosmic-swingset-bootstrap-block-start': {
         dbTransactionManager.begin();
         spans.push(`bootstrap-block`);
@@ -636,29 +644,13 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         spans.pop('end-block');
         break;
       }
-      case 'cosmic-swingset-save-chain-start': {
-        spans.push(`save-chain`);
+      case 'heap-snapshot-save': {
+        // Add an event to whatever the top span is for now (likely crank)
+        spans.top()?.addEvent('snapshot-save', cleanAttrs(slogAttrs), now);
         break;
       }
-      case 'cosmic-swingset-save-chain-finish': {
-        spans.pop('save-chain');
-        break;
-      }
-      case 'cosmic-swingset-save-external-start': {
-        spans.push(`save-external`);
-        break;
-      }
-      case 'cosmic-swingset-save-external-finish': {
-        spans.pop('save-external');
-        spans.pop(); // 'block ...'
-        break;
-      }
-      case 'solo-process-kernel-start': {
-        spans.push(`solo-process-kernel`);
-        break;
-      }
-      case 'solo-process-kernel-finish': {
-        spans.pop(`solo-process-kernel`);
+      case 'heap-snapshot-load': {
+        // Ignore
         break;
       }
       case 'crank-start': {


### PR DESCRIPTION
closes: #6210

## Description

This PR further refactors cosmic-swingset and add an `inboundQueue` which buffers the cosmos inbound actions on the JS side, processing them one by one by running swingset to quiescence after delivering each action.

### Security Considerations

This approach is not safe against infinite message loops, which would cause a Denial Of Service. However the current contracts are trusted to not behave like that.

### Testing Considerations

Tested locally with the loadgen. Load testing in progress on ollinet.
