### PR TITLE
fix(psm): "mint" limits for IST rather than anchor

### DIFF
--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -51,7 +51,7 @@ export const startPSM = async (
     options: { anchorOptions = {} } = {},
     WantMintedFeeBP = 1n,
     GiveMintedFeeBP = 3n,
-    MINT_LIMIT = 20_000_000n * 1_000_000n,
+    MINT_LIMIT = 1_000n * 1_000_000n,
   } = {},
 ) => {
   const { denom, keyword = 'AUSD' } = anchorOptions;
@@ -79,7 +79,7 @@ export const startPSM = async (
       E(E(zoe).getInvitationIssuer()).getAmountOf(poserInvitationP),
     ]);
 
-  const mintLimit = AmountMath.make(anchorBrand, MINT_LIMIT);
+  const mintLimit = AmountMath.make(stable, MINT_LIMIT);
   const terms = await deeplyFulfilledObject(
     harden({
       anchorBrand,

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -525,13 +525,17 @@ test('metrics', async t => {
   t.deepEqual(Object.keys(driver.getStorageChildBody('metrics')), [
     'anchorPoolBalance',
     'feePoolBalance',
-
+    'mintedPoolBalance',
     'totalAnchorProvided',
     'totalMintedProvided',
   ]);
   t.like(driver.getStorageChildBody('metrics'), {
     anchorPoolBalance: { brand: { iface: 'Alleged: aUSD brand' }, value: 0n },
     feePoolBalance: { brand: { iface: 'Alleged: IST brand' }, value: 0n },
+    mintedPoolBalance: {
+      brand: { iface: 'Alleged: IST brand' },
+      value: 0n,
+    },
     totalAnchorProvided: {
       brand: { iface: 'Alleged: aUSD brand' },
       value: 0n,
@@ -550,6 +554,10 @@ test('metrics', async t => {
       value: giveAnchor.value,
     },
     feePoolBalance: { value: 20_000n },
+    mintedPoolBalance: {
+      brand: { iface: 'Alleged: IST brand' },
+      value: giveAnchor.value,
+    },
     totalAnchorProvided: {
       value: 0n,
     },
@@ -565,6 +573,10 @@ test('metrics', async t => {
       value: giveAnchor.value,
     },
     feePoolBalance: { value: 20_000n },
+    mintedPoolBalance: {
+      brand: { iface: 'Alleged: IST brand' },
+      value: giveAnchor.value,
+    },
     totalAnchorProvided: {
       value: 0n,
     },
@@ -586,6 +598,10 @@ test('metrics', async t => {
       value: giveMinted.value + fee,
     },
     feePoolBalance: { value: 50_000n },
+    mintedPoolBalance: {
+      brand: { iface: 'Alleged: IST brand' },
+      value: giveAnchor.value - giveMinted.value + fee,
+    },
     totalAnchorProvided: {
       value: giveMinted.value - fee,
     },

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -51,7 +51,7 @@ const makeTestContext = async () => {
   const centralSupply = await E(zoe).install(centralSupplyBundle);
   const policyInstall = await E(zoe).install(policyBundle);
 
-  const mintLimit = AmountMath.make(anchor.brand, MINT_LIMIT);
+  const mintLimit = AmountMath.make(mintedBrand, MINT_LIMIT);
 
   const marshaller = makeBoard().getReadonlyMarshaller();
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #6223

## Description

The MintingLimit parameter was specified in terms of the anchor brand. That makes the MintingLimit incomparable with among minting sources, including other PSMs.

Incidentally reduce the default MINT_LIMIT to a small value for testing. Governance is required to raise it to a higher amount.

### Security Considerations

The minting limits are an important tool for managing risk in IST. While the minting limit using the anchor amounts coudl be managed, using different brands for different PSM or other minting sources would make it so that we were not minting against a standard limit.

### Documentation Considerations

Documenting minting limits as expressed in IST will be much clearer.

### Testing Considerations

A test was added to confirm that it mints against the minted brand rather than the anchor brand.
