### PR TITLE
fix(cosmic-swingset): Fix consensus failure on bundle parse errors

### DIFF
--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -340,7 +340,13 @@ export async function launch({
   }
 
   async function installBundle(bundleSource) {
-    const bundle = JSON.parse(bundleSource);
+    let bundle;
+    try {
+      bundle = JSON.parse(bundleSource);
+    } catch (e) {
+      blockManagerConsole.warn('INSTALL_BUNDLE warn:', e);
+      return;
+    }
     harden(bundle);
 
     const error = await controller.validateAndInstallBundle(bundle).then(


### PR DESCRIPTION
Fixes #6169

## Description

Submitting a non-JSON bundle would previously produce a consensus failure.

### Documentation Considerations

None.

### Testing Considerations

Manually verified under cosmic-swingset `scenario2` with this trigger:

```
agd --home t1/bootstrap tx swingset install-bundle @hi.txt --keyring-backend test --from bootstrap --chain-id agoric
```

Where `hi.txt` contains `hi`.
