### PR TITLE
fix(cosmic-swingset): add inboundQueue metrics

### DIFF
--- a/packages/cosmic-swingset/src/make-queue.js
+++ b/packages/cosmic-swingset/src/make-queue.js
@@ -27,6 +27,11 @@
  */
 export const makeQueue = storage => {
   const queue = {
+    size: () => {
+      const tail = storage.get('tail') || 0;
+      const head = storage.get('head') || 0;
+      return tail - head;
+    },
     push: obj => {
       const tail = storage.get('tail') || 0;
       storage.set('tail', tail + 1);


### PR DESCRIPTION
This adds a few keys to the stats that we report to e.g. Prometheus, to report on the size/add/remove counters for the new `inboundQueue`.

closes #6245
