### PR TITLE
Telemetry enhancement

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -225,6 +225,8 @@ export async function makeSwingsetController(
   // see https://github.com/Agoric/SES-shim/issues/292 for details
   harden(console);
 
+  writeSlogObject({ type: 'kernel-init-start' });
+
   writeSlogObject({ type: 'bundle-kernel-start' });
   // eslint-disable-next-line @jessie.js/no-nested-await
   const { kernelBundle = await buildKernelBundle() } = runtimeOptions;
@@ -507,6 +509,8 @@ export async function makeSwingsetController(
       );
     },
   });
+
+  writeSlogObject({ type: 'kernel-init-finish' });
 
   return controller;
 }

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1300,6 +1300,10 @@ export default function buildKernel(
     const crankNum = kernelKeeper.getCrankNumber();
     kernelKeeper.incrementCrankNumber();
     const { crankhash, activityhash } = kernelKeeper.commitCrank();
+    // kernelSlog.write({
+    //   type: 'kernel-stats',
+    //   stats: kernelKeeper.getStats(),
+    // });
     kernelSlog.write({
       type: 'crank-finish',
       crankNum,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -475,6 +475,10 @@ export async function launch({
       await crankScheduler(runPolicy);
       const remainingBeans = runPolicy.remainingBeans();
       controller.writeSlogObject({
+        type: 'kernel-stats',
+        stats: controller.getStats(),
+      });
+      controller.writeSlogObject({
         type: 'cosmic-swingset-run-finish',
         blockHeight,
         runNum,

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -26,6 +26,7 @@
     "@agoric/store": "^0.8.0",
     "@agoric/swing-store": "^0.8.0",
     "@agoric/swingset-vat": "^0.29.0",
+    "@agoric/telemetry": "^0.3.0",
     "@agoric/vat-data": "^0.4.0",
     "@agoric/zoe": "^0.25.0",
     "@endo/bundle-source": "^2.3.1",

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -610,6 +610,11 @@ export async function main() {
     if (verbose) {
       log('==> running block');
     }
+    controller.writeSlogObject({
+      type: 'cosmic-swingset-end-block-start',
+      blockHeight: blockNumber,
+      blockTime: blockStartTime,
+    });
     while (requestedSteps > 0) {
       requestedSteps -= 1;
       try {
@@ -642,6 +647,15 @@ export async function main() {
       await swingStore.commit();
     }
     const blockEndTime = readClock();
+    controller.writeSlogObject({
+      type: 'kernel-stats',
+      stats: controller.getStats(),
+    });
+    controller.writeSlogObject({
+      type: 'cosmic-swingset-end-block-finish',
+      blockHeight: blockNumber,
+      blockTime: blockEndTime,
+    });
     if (forceGC) {
       engineGC();
     }

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -14,6 +14,7 @@ const main = async () => {
   }
 
   for await (const file of files) {
+    // eslint-disable-next-line @jessie.js/no-nested-await
     const { readCircBuf } = await makeMemoryMappedCircularBuffer({
       circularBufferFilename: file,
       circularBufferSize: null,
@@ -50,7 +51,7 @@ const main = async () => {
       }
 
       // If the buffer is full, wait for stdout to drain.
-      // eslint-disable-next-line no-await-in-loop
+      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       await new Promise(resolve => process.stdout.once('drain', resolve));
     }
   }

--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -69,7 +69,7 @@ async function run() {
   let lineCount = 0;
 
   const stats = async flush => {
-    console.log(`${lineCount} lines, about ${byteCount} bytes`);
+    // console.log(`${lineCount} lines, about ${byteCount} bytes`);
     if (!flush) {
       return;
     }
@@ -83,7 +83,7 @@ async function run() {
   for await (const line of lines) {
     lineCount += 1;
     const obj = harden(JSON.parse(line));
-    update ||= obj.time >= progress.lastSlogTime;
+    update ||= obj.time > progress.lastSlogTime;
     if (update) {
       progress.lastSlogTime = obj.time;
     }
@@ -94,6 +94,7 @@ async function run() {
       lineCount % LINE_COUNT_TO_FLUSH === 0
     ) {
       lastTime = now;
+      // eslint-disable-next-line @jessie.js/no-nested-await
       await stats(update);
     }
 
@@ -108,6 +109,7 @@ async function run() {
       const delayMS = PROCESSING_PERIOD - (now - startOfLastPeriod);
       maybeWait = new Promise(resolve => setTimeout(resolve, delayMS));
     }
+    // eslint-disable-next-line @jessie.js/no-nested-await
     await maybeWait;
     now = Date.now();
 
@@ -131,7 +133,7 @@ async function run() {
     }
   }
 
-  await stats();
+  await stats(true);
   console.log(
     `done parsing`,
     slogFileName,

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -82,7 +82,9 @@ export const makeSlogSender = async (opts = {}) => {
       console.warn(`Unknown SLOGSENDER_AGENT=${SLOGSENDER_AGENT}`);
   }
 
-  console.warn('Loading slog sender modules:', ...slogSenderModules);
+  if (SLOGSENDER) {
+    console.warn('Loading slog sender modules:', ...slogSenderModules);
+  }
 
   const makersInfo = await Promise.all(
     slogSenderModules.map(async moduleIdentifier =>


### PR DESCRIPTION
Various telemetry related improvements in support of #4585 

- The slog-to-otel converter has been extensively cleaned up and supports the latest version of slog output we are producing
- Kernel stats are output as slog entries as part of finishing up each block
- The slogulator tool has been updated to account for the many and various changes and enhancements to slog output since the last time it was worked on
- The swingset-runner tool can now produce an Open Telemetry feed of its slog if so requested
