### PR TITLE
refactor(swing-store): Use the same stream-based approach for loading snapshots as saving them

### DIFF
--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -331,9 +331,9 @@ export function makeSnapStore(
     };
 
     const results = await Promise.allSettled([...toDelete].map(deleteHash));
-    const errors = results.flatMap(({ status, reason }) =>
-      status === 'rejected' ? [reason] : [],
-    );
+    const errors = /** @type {PromiseRejectedResult[]} */ (
+      results.filter(({ status }) => status === 'rejected')
+    ).map(({ reason }) => reason);
     if (errors.length) {
       throw Error(JSON.stringify(errors));
     }


### PR DESCRIPTION
## Description

Copies the `const cleanup = []; return aggregateTryFinally(…)` pattern and removes consequently-unused helpers.

We could try abstracting that pattern itself into a helper, but I don't think it would save much because the particulars are different.

### Security Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a
