### PR TITLE
feat(zoe): expose keywords in error messages

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -233,7 +233,9 @@ export const vivifyPaymentLedger = (
   const assertLivePayment = payment => {
     paymentLedger.has(payment) ||
       assert.fail(
-        X`${payment} was not a live payment for brand ${brand}. It could be a used-up payment, a payment for another brand, or it might not be a payment at all.`,
+        X`${payment} was not a live payment for brand ${q(
+          brand,
+        )}. It could be a used-up payment, a payment for another brand, or it might not be a payment at all.`,
       );
   };
 

--- a/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
@@ -6,7 +6,7 @@ import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 
 import { definePoolKind } from './pool.js';
 
-const { details: X } = assert;
+const { details: X, quote: q } = assert;
 
 const DISPLAY_INFO = harden({ decimalPlaces: 6 });
 
@@ -39,7 +39,7 @@ export const makeAddIssuer = (
     ]);
     // AWAIT ///////////////
     secondaryAssetKind === AssetKind.NAT ||
-      assert.fail(X`${keyword} asset not fungible (must use NAT math)`);
+      assert.fail(X`${q(keyword)} asset not fungible (must use NAT math)`);
 
     /** @type {(brand: Brand) => Promise<ZCFMint>} */
     const makeLiquidityMint = brand => {

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -29,7 +29,11 @@ export const assertKeywordName = keyword => {
   assert.typeof(keyword, 'string');
   keyword.length <= MAX_KEYWORD_LENGTH ||
     assert.fail(
-      X`keyword ${keyword} exceeded maximum length ${MAX_KEYWORD_LENGTH} characters; got ${keyword.length}`,
+      X`keyword ${q(
+        keyword,
+      )} exceeded maximum length ${MAX_KEYWORD_LENGTH} characters; got ${
+        keyword.length
+      }`,
     );
   assert(
     firstCapASCII.test(keyword),

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -29,11 +29,9 @@ export const assertKeywordName = keyword => {
   assert.typeof(keyword, 'string');
   keyword.length <= MAX_KEYWORD_LENGTH ||
     assert.fail(
-      X`keyword ${q(
-        keyword,
-      )} exceeded maximum length ${MAX_KEYWORD_LENGTH} characters; got ${
-        keyword.length
-      }`,
+      X`keyword ${q(keyword)} exceeded maximum length ${q(
+        MAX_KEYWORD_LENGTH,
+      )} characters; got ${keyword.length}`,
     );
   assert(
     firstCapASCII.test(keyword),

--- a/packages/zoe/src/contractFacet/allocationMath.js
+++ b/packages/zoe/src/contractFacet/allocationMath.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { AmountMath } from '@agoric/ertp';
 
-const { details: X } = assert;
+const { details: X, quote: q } = assert;
 
 /**
  * @callback Operation
@@ -65,12 +65,16 @@ const subtract = (amount, amountToSubtract, keyword) => {
       // TypeScript confused about `||` control flow so use `if` instead
       // https://github.com/microsoft/TypeScript/issues/50739
       assert.fail(
-        X`The amount could not be subtracted from the allocation because the allocation did not have an amount under the keyword ${keyword}.`,
+        X`The amount could not be subtracted from the allocation because the allocation did not have an amount under the keyword ${q(
+          keyword,
+        )}.`,
       );
     }
     AmountMath.isGTE(amount, amountToSubtract) ||
       assert.fail(
-        X`The amount to be subtracted ${amountToSubtract} was greater than the allocation's amount ${amount} for the keyword ${keyword}`,
+        X`The amount to be subtracted ${amountToSubtract} was greater than the allocation's amount ${amount} for the keyword ${q(
+          keyword,
+        )}`,
       );
     return AmountMath.subtract(amount, amountToSubtract);
   }


### PR DESCRIPTION
## Description

@erights by way of @dckc ,
> Amounts should not be quoted. Keywords, brands, etc, relatively static info that does not reveal actual quantities, should be quoted.

### Security Considerations

Keywords are safe to expose. They're part of the contract code.

### Documentation Considerations

--
### Testing Considerations

--