### PR TITLE
fix device timer remove()

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:c8": "c8 --all $C8_OPTIONS ava",
     "test:xs": "SWINGSET_WORKER_TYPE=xs-worker ava",
     "test:xs-worker": "ava test/workers -m 'xsnap vat manager'",
     "lint-fix": "yarn lint:eslint --fix",

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -147,8 +147,8 @@ function makeTimerMap(state = undefined) {
   // We don't expect this to be called often, so we don't optimize for it.
   /**
    *
-   * @param {Waker} target
-   * @returns {bigint[]}
+   * @param {Waker} targetHandler
+   * @returns {bigint[]} times that have been removed (may contain duplicates)
    */
   function remove(targetHandler) {
     /** @type {bigint[]} */
@@ -164,6 +164,7 @@ function makeTimerMap(state = undefined) {
         }
       }
       if (handlers.length === 0) {
+        // Splice out this element, preserving `i` so we visit any successor.
         schedule.splice(i, 1);
       } else {
         i += 1;
@@ -285,7 +286,10 @@ export function buildRootDeviceNode(tools) {
       saveState();
       return baseTime;
     },
-    /** @param {Waker} handler */
+    /**
+     * @param {Waker} handler
+     * @returns {bigint[]} times that have been removed (may contain duplicates)
+     */
     removeWakeup(handler) {
       const times = deadlines.remove(handler);
       saveState();

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -86,6 +86,7 @@ function makeTimerMap(state = undefined) {
     return copyState(schedule);
   }
 
+  /** @param {bigint} time */
   function eventsFor(time) {
     assert.typeof(time, 'bigint');
     for (let i = 0; i < schedule.length && schedule[i].time <= time; i += 1) {
@@ -101,8 +102,16 @@ function makeTimerMap(state = undefined) {
   // There's some question as to whether it's important to invoke the handlers
   // in the order of their deadlines. If so, we should probably ensure that the
   // recorded deadlines don't have finer granularity than the turns.
+  /**
+   *
+   * @param {bigint} time
+   * @param {Waker} handler
+   * @param {number} [repeater]
+   * @returns {bigint}
+   */
   function add(time, handler, repeater = undefined) {
     assert.typeof(time, 'bigint');
+    /** @type {IndexedHandler} */
     const handlerRecord =
       typeof repeater === 'number' ? { handler, index: repeater } : { handler };
     const { handlers: records } = eventsFor(time);
@@ -111,7 +120,11 @@ function makeTimerMap(state = undefined) {
     return time;
   }
 
-  // Remove and return all pairs indexed by numbers up to target
+  /**
+   * Remove and return all pairs indexed by numbers up to target
+   *
+   * @param {bigint} target
+   */
   function removeEventsThrough(target) {
     assert.typeof(target, 'bigint');
     const returnValues = [];
@@ -132,7 +145,13 @@ function makeTimerMap(state = undefined) {
   }
 
   // We don't expect this to be called often, so we don't optimize for it.
+  /**
+   *
+   * @param {Waker} targetHandler
+   * @returns {bigint[]}
+   */
   function remove(targetHandler) {
+    /** @type {bigint[]} */
     const droppedTimes = [];
     let i = 0;
     while (i < schedule.length) {
@@ -277,6 +296,7 @@ export function buildRootDeviceNode(tools) {
       saveState();
       return baseTime;
     },
+    /** @param {Waker} handler */
     removeWakeup(handler) {
       const times = deadlines.remove(handler);
       saveState();
@@ -304,6 +324,10 @@ export function buildRootDeviceNode(tools) {
       saveState();
       return index;
     },
+    /**
+     * @param {number} index
+     * @param {Waker} handler
+     */
     schedule(index, handler) {
       const nextTime = nextScheduleTime(index, repeaters, lastPolled);
       deadlines.add(nextTime, handler, index);

--- a/packages/SwingSet/test/timer-device.test.js
+++ b/packages/SwingSet/test/timer-device.test.js
@@ -256,7 +256,7 @@ test('multiMap initialize with state', t => {
   ]);
 });
 
-test.failing('multiMap remove edge cases', t => {
+test('multiMap remove edge cases', t => {
   const mm = makeTimerMap();
   const handlerA = makeHandler();
   const handlerB = makeHandler();

--- a/packages/SwingSet/tools/manual-timer.js
+++ b/packages/SwingSet/tools/manual-timer.js
@@ -8,7 +8,7 @@ import { buildRootObject } from '../src/vats/timer/vat-timer.js';
 /**
  * @import {Timestamp} from '@agoric/time'
  * @import {TimerService} from '@agoric/time'
- * @import {Waker} from '../src/devices/timer/device-timer.js'
+ * @import {TimerDevice, Waker} from '../src/devices/timer/device-timer.js'
  *
  * @typedef {object} ManualTimerCallbacks
  * @property {(newTime: bigint, msg?: string) => void} [advanceTo]
@@ -34,8 +34,7 @@ const setup = callbacks => {
     currentWakeup: undefined,
     currentHandler: undefined,
   };
-  /** @type {any} */
-  const deviceMarker = harden({});
+  const deviceMarker = /** @type {TimerDevice} */ (harden({}));
   const timerDeviceFuncs = harden({
     getLastPolled: () => state.now,
     setWakeup: (when, handler) => {


### PR DESCRIPTION
## Description

Working on https://github.com/Agoric/agoric-sdk/pull/6256 I noticed the condition in the loop was looking for a value that couldn't be in the array. I think this resulted in a bug in `TimerMap.remove` and thus `DeviceTimer.removeWakeup`.

### Security Considerations

Without this, wake handlers aren't removed from the map. PSMO uses timers for voting so this creates a resource exhaustion risk, proportional to the number of questions posed.

### Documentation Considerations

--
### Testing Considerations

No tests failed. What would a good regression test be?