### PR TITLE
fix wallet show latest

### DIFF
--- a/packages/agoric-cli/src/commands/wallet.js
+++ b/packages/agoric-cli/src/commands/wallet.js
@@ -8,8 +8,11 @@ import {
   makeLeaderFromRpcAddresses,
 } from '@agoric/casting';
 import { Command } from 'commander';
-import { fmtRecordOfLines, simplePurseBalances } from '../lib/format.js';
-import { simpleOffers } from '../lib/psm.js';
+import {
+  fmtRecordOfLines,
+  offerStatusTuples,
+  purseBalanceTuples,
+} from '../lib/format.js';
 import { makeRpcUtils, networkConfig } from '../lib/rpc.js';
 import { getWalletState } from '../lib/wallet.js';
 
@@ -107,8 +110,8 @@ export const makeWalletCommand = async () => {
       console.warn('got state', state);
       const { brands, balances } = state;
       const summary = {
-        balances: simplePurseBalances([...balances.values()], brands),
-        offers: simpleOffers(state, agoricNames),
+        balances: purseBalanceTuples([...balances.values()], brands),
+        offers: offerStatusTuples(state, agoricNames),
       };
       process.stdout.write(fmtRecordOfLines(summary));
     });

--- a/packages/agoric-cli/src/commands/wallet.js
+++ b/packages/agoric-cli/src/commands/wallet.js
@@ -110,7 +110,11 @@ export const makeWalletCommand = async () => {
       console.warn('got state', state);
       const { brands, balances } = state;
       const summary = {
-        balances: purseBalanceTuples([...balances.values()], brands),
+        balances: purseBalanceTuples(
+          [...balances.values()],
+          // @ts-expect-error xxx RpcRemote
+          [...brands.values()],
+        ),
         offers: offerStatusTuples(state, agoricNames),
       };
       process.stdout.write(fmtRecordOfLines(summary));

--- a/packages/agoric-cli/src/lib/psm.js
+++ b/packages/agoric-cli/src/lib/psm.js
@@ -1,8 +1,6 @@
 // @ts-check
 
-import { COSMOS_UNIT, makeAmountFormatter } from './format.js';
-// eslint-disable-next-line no-unused-vars -- typeof below
-import { makeAgoricNames } from './rpc.js';
+import { COSMOS_UNIT } from './format.js';
 
 // Ambient types. Needed only for dev but this does a runtime import.
 import '@agoric/zoe/src/zoeService/types.js';
@@ -10,46 +8,6 @@ import '@agoric/zoe/src/zoeService/types.js';
 /** @typedef {import('@agoric/smart-wallet/src/offers').OfferSpec} OfferSpec */
 /** @typedef {import('@agoric/smart-wallet/src/offers').OfferStatus} OfferStatus */
 /** @typedef {import('@agoric/smart-wallet/src/smartWallet').BridgeAction} BridgeAction */
-
-/**
- * @param {{ brands: import('./format').AssetDescriptor[], offers: Map<number, OfferStatus>}} state
- * @param {Awaited<ReturnType<typeof makeAgoricNames>>} agoricNames
- */
-export const simpleOffers = (state, agoricNames) => {
-  const { brands, offers } = state;
-  const fmt = makeAmountFormatter(brands);
-  const fmtRecord = r =>
-    Object.fromEntries(
-      Object.entries(r).map(([kw, amount]) => [kw, fmt(amount)]),
-    );
-  return [...offers.keys()].sort().map(id => {
-    const o = offers.get(id);
-    assert(o);
-    assert(o.invitationSpec.source === 'contract');
-    const {
-      invitationSpec: { instance, publicInvitationMaker },
-      proposal: { give, want },
-      payouts,
-    } = o;
-    const entry = Object.entries(agoricNames.instance).find(
-      // @ts-expect-error xxx RpcRemote
-      ([_name, candidate]) => candidate === instance,
-    );
-    const instanceName = entry ? entry[0] : '???';
-    return [
-      instanceName,
-      new Date(id).toISOString(),
-      id,
-      publicInvitationMaker,
-      o.numWantsSatisfied,
-      {
-        give: fmtRecord(give),
-        want: fmtRecord(want),
-        ...(payouts ? { payouts: fmtRecord(payouts) } : {}),
-      },
-    ];
-  });
-};
 
 /**
  * @param {Record<string, Brand>} brands

--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { makeWalletStateCoalescer } from '@agoric/smart-wallet/src/utils.js';
 import { boardSlottingMarshaller, storageHelper } from './rpc.js';
 
 /**
@@ -6,49 +7,21 @@ import { boardSlottingMarshaller, storageHelper } from './rpc.js';
  * @param {import('./rpc').IdMap} ctx
  * @param {object} io
  * @param {import('./rpc.js').VStorage} io.vstorage
+ * @returns {Promise<import('@agoric/smart-wallet/src/utils.js').CoalescedWalletState>}
  */
 export const getWalletState = async (addr, ctx, { vstorage }) => {
   const capDataStrings = await vstorage.readAll(`published.wallet.${addr}`);
   assert(capDataStrings?.length, 'readAll returned empty');
   const capDatas = storageHelper.parseMany(capDataStrings);
 
-  // XXX very similar to `coalesceUpdates` util
+  const coalescer = makeWalletStateCoalescer();
 
-  /** @type {Map<number, import('./psm').OfferSpec>} */
-  const offers = new Map();
-  /** @type {Map<Brand, Amount>} */
-  const balances = new Map();
-  /** @type {import('./format').AssetDescriptor[]} */
-  const brands = [];
   const mm = boardSlottingMarshaller(ctx.convertSlotToVal);
   for (const capData of capDatas) {
     /** @type import('@agoric/smart-wallet/src/smartWallet').UpdateRecord */
-    const update = mm.unserialize(capData);
-    console.warn('wallet update', update);
-    assert(update.updated, 'missing key: updated');
-    switch (update.updated) {
-      case 'offerStatus': {
-        const { status } = update;
-        const lastStatus = offers.get(status.id);
-        // merge records
-        offers.set(status.id, { ...lastStatus, ...status });
-        break;
-      }
-      case 'balance': {
-        const { currentAmount } = update;
-        // last record wins
-        balances.set(currentAmount.brand, currentAmount);
-        break;
-      }
-      case 'brand': {
-        // @ts-expect-error cast for unserialization hack
-        brands.push(update.descriptor);
-        break;
-      }
-      default:
-        // @ts-expect-error
-        throw Error(`unsupported update ${update.updated}`);
-    }
+    const updateRecord = mm.unserialize(capData);
+    console.warn('wallet update', updateRecord);
+    coalescer.include(updateRecord);
   }
-  return { balances, brands, offers };
+  return coalescer.state;
 };

--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -21,7 +21,7 @@ export const getWalletState = async (addr, ctx, { vstorage }) => {
   /** @type {import('./format').AssetDescriptor[]} */
   const brands = [];
   const mm = boardSlottingMarshaller(ctx.convertSlotToVal);
-  capDatas.forEach(capData => {
+  for (const capData of capDatas) {
     /** @type import('@agoric/smart-wallet/src/smartWallet').UpdateRecord */
     const update = mm.unserialize(capData);
     console.warn('wallet update', update);
@@ -29,16 +29,15 @@ export const getWalletState = async (addr, ctx, { vstorage }) => {
     switch (update.updated) {
       case 'offerStatus': {
         const { status } = update;
-        if (!offers.has(status.id)) {
-          offers.set(status.id, status);
-        }
+        const lastStatus = offers.get(status.id);
+        // merge records
+        offers.set(status.id, { ...lastStatus, ...status });
         break;
       }
       case 'balance': {
         const { currentAmount } = update;
-        if (!balances.has(currentAmount.brand)) {
-          balances.set(currentAmount.brand, currentAmount);
-        }
+        // last record wins
+        balances.set(currentAmount.brand, currentAmount);
         break;
       }
       case 'brand': {
@@ -50,6 +49,6 @@ export const getWalletState = async (addr, ctx, { vstorage }) => {
         // @ts-expect-error
         throw Error(`unsupported update ${update.updated}`);
     }
-  });
+  }
   return { balances, brands, offers };
 };


### PR DESCRIPTION
## Description

`agoric wallet show` offer summaries showed the first update record, ignoring subsequent. This the records merge.

For purse balances it also let first win. This changes to last wins.

### Security Considerations

--
### Documentation Considerations

--
### Testing Considerations

Now that  `makeWalletStateCoalescer` is used in CLI and smart-wallet, the smart-wallet PSM integration tests provide some coverage.
