### PR TITLE
fix(xsnap): upgrade to xsnap-native with exit on unknown command

### DIFF
--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -207,6 +207,11 @@ export function xsnap(options) {
       } else if (message[0] === QUERY) {
         const commandResult = await handleCommand(message.subarray(1));
         await messagesToXsnap.next([QUERY_RESPONSE_BUF, commandResult]);
+      } else {
+        // unrecognized responses also kill the process
+        xsnapProcess.kill();
+        const m = decoder.decode(message);
+        throw new Error(`xsnap protocol error: received unknown message <<${m}>>`);
       }
     }
   }


### PR DESCRIPTION
This updates agoric-sdk to use the newest xsnap with the fix that makes it exit (with error) on unknown commands.
