### PR TITLE
Typescript 4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lerna": "^3.22.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",
-    "typescript": "~4.7.4"
+    "typescript": "~4.8.3"
   },
   "engines": {
     "node": ">=14.15.0"

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -88,8 +88,8 @@ export const fsStreamReady = stream =>
  *   tmpName: typeof import('tmp').tmpName,
  *   unlink: typeof import('fs').promises.unlink,
  * }} io
- * @param {object} [options]
- * @param {boolean | undefined} [options.keepSnapshots]
+ * @param {object} options
+ * @param {boolean} [options.keepSnapshots]
  * @returns {SnapStore}
  */
 export function makeSnapStore(
@@ -149,7 +149,7 @@ export function makeSnapStore(
    * @param {string} srcPath
    * @param {NodeJS.ReadWriteStream} transform
    * @param {string} destPath
-   * @param {object} [options]
+   * @param {object} options
    * @param {boolean} [options.flush]
    */
   async function filter(srcPath, transform, destPath, { flush = false } = {}) {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "react": "^16.14.0",
     "react-dom": "^16.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~4.8.3"
   },
   "ava": {
     "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -17472,10 +17472,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.2, typescript@~4.7.4:
+typescript@^4.3.2:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@~4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description

Upgrade TypeScript 4.7 to 4.8.

https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/

- [ ] make Endo compatible with 4.8 (or [stop using maxNodeModuleJsDepth](https://github.com/Agoric/agoric-sdk/issues/4560) )

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
