### PR TITLE
test(smart-wallet): local chain launch script

### DIFF
--- a/packages/agoric-cli/test/agops-governance-smoketest.sh
+++ b/packages/agoric-cli/test/agops-governance-smoketest.sh
@@ -10,20 +10,8 @@ if [ -z "$AGORIC_NET" ]; then
 cd agoric-sdk
 yarn install && yarn build
 
-# (new tab)
-# Start the chain
-cd packages/cosmic-swingset
-make scenario2-setup scenario2-run-chain-psm
-
-# (new tab)
-cd packages/cosmic-swingset
-# Fund the pool
-make fund-provision-pool
-# Provision your wallet
-agoric wallet provision --account <key-name>
-# verify
-agoric wallet list
-agoric wallet show --from <key-name>
+# local chain running with wallet provisioned
+packages/smart-wallet/scripts/start-local-chain.sh YOUR_ACCOUNT_KEY
 "
     exit 1
 fi

--- a/packages/agoric-cli/test/agops-perf-smoketest.sh
+++ b/packages/agoric-cli/test/agops-perf-smoketest.sh
@@ -10,26 +10,8 @@ if [ -z "$AGORIC_NET" ]; then
 cd agoric-sdk
 yarn install && yarn build
 
-# (new tab)
-# Start the chain
-cd packages/cosmic-swingset
-make scenario2-setup scenario2-run-chain-psm
-
-# (new tab)
-cd packages/cosmic-swingset
-# Fund the pool
-make fund-provision-pool
-# Fund your wallet
-export ACCT_ADDR=<key-bech32>
-# with 100 BLD for provisioning wallet and 100 USDC for psm trading
-make ACCT_ADDR=$ACCT_ADDR SOLO_COINS=100000000ubld,100000000ibc/usdc1234 fund-acct
-agd query bank balances $ACCT_ADDR
-
-# Provision your wallet
-agoric wallet provision --spend --account <key-name>
-# verify
-agoric wallet list
-agoric wallet show --from <key-name>
+# local chain running with wallet provisioned
+packages/smart-wallet/scripts/start-local-chain.sh YOUR_ACCOUNT_KEY
 "
   exit 1
 fi

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -219,13 +219,13 @@ fund-provision-pool:
 # provisioned, so make room for 400 accounts with 100 USDC which mints 100 IST.
 	$(MAKE) ACCT_ADDR=agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 FUNDS=1000000000ibc/usdc1234 fund-acct
 
-fund-acct: wait-for-cosmos
+fund-acct:
 	$(AGCH) \
 	  --home=t1/bootstrap --keyring-backend=test --from=bootstrap \
 	  tx bank send bootstrap $(ACCT_ADDR) $(FUNDS) \
 	  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID)
 
-provision-acct: wait-for-cosmos
+provision-acct:
 	$(AGCH) --chain-id=$(CHAIN_ID) \
 	  --home=t1/bootstrap --keyring-backend=test --from=bootstrap \
 	  tx swingset provision-one t1/$(BASE_PORT) $(ACCT_ADDR) SMART_WALLET \

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -214,12 +214,15 @@ t1-provision-one-with-powers: wait-for-cosmos
 
 # Send some USDC to the vbank/provision module account where it can be traded for IST.
 fund-provision-pool:
-	$(MAKE) ACCT_ADDR=agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 SOLO_COINS=1234000000ibc/usdc1234 fund-acct
+# The agoric1megzy… address is the account of the provisioning pool.
+# The mint limit is 1000 IST and each wallet gets 0.25 IST when
+# provisioned, so make room for 400 accounts with 100 USDC which mints 100 IST.
+	$(MAKE) ACCT_ADDR=agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 FUNDS=1000000000ibc/usdc1234 fund-acct
 
 fund-acct: wait-for-cosmos
 	$(AGCH) \
 	  --home=t1/bootstrap --keyring-backend=test --from=bootstrap \
-	  tx bank send bootstrap $(ACCT_ADDR) $(SOLO_COINS) \
+	  tx bank send bootstrap $(ACCT_ADDR) $(FUNDS) \
 	  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID)
 
 provision-acct: wait-for-cosmos

--- a/packages/smart-wallet/scripts/start-local-chain.sh
+++ b/packages/smart-wallet/scripts/start-local-chain.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# TODO make cross-platform https://stackoverflow.com/questions/52670836/standard-log-locations-for-a-cross-platform-application
+mkdir -p ~/Library/Logs/Agoric
+CHAIN_LOG=~/Library/Logs/Agoric/local-chain.log
+touch "$CHAIN_LOG" || exit 1
+open -a /System/Applications/Utilities/Console.app $CHAIN_LOG
+
+# ugly way to get SDK path regardless of cwd
+SDK=$(readlink -f "$(dirname -- "$(readlink -f -- "$0")")/../../..")
+
+WALLET=$1
+
+if [ -z "$WALLET" ]; then
+    echo "USAGE: $0 wallet-key"
+    echo "You can reference by name: agd keys list"
+    exit 1
+fi
+
+WALLET_BECH32=$(agd keys show "$WALLET" --output json | jq -r .address)
+
+echo CHAIN_LOG $CHAIN_LOG
+echo SDK "$SDK"
+echo WALLET "$WALLET"
+echo WALLET_BECH32 "$WALLET_BECH32"
+
+# TODO detect it's already running, indicate when it started and offer to restart
+# e.g. killall node xsnap-worker
+echo "Starting the chain..."
+cd "$SDK"/packages/cosmic-swingset || exit 1
+make scenario2-setup scenario2-run-chain-psm >>$CHAIN_LOG 2>&1 &
+echo "Logs written to $CHAIN_LOG"
+
+echo "Funding the pool..."
+make fund-provision-pool
+
+echo "Funding your wallet account..."
+# After `fund-provision-pool` there is 900 IST remaining for other account funding.
+# A wallet can be tested with 20 BLD for provisioning wallet and 20 USDC for psm trading
+make ACCT_ADDR="$WALLET_BECH32" FUNDS=20000000ubld,20000000ibc/usdc1234 fund-acct
+agd query bank balances "$WALLET_BECH32" | grep ubld || exit 1
+
+echo "Provisioning your smart wallet..."
+agoric wallet provision --spend --account "$WALLET"
+echo "waiting for blocks"
+sleep 5
+# verify
+agoric wallet list
+agoric wallet show --from "$WALLET"

--- a/packages/smart-wallet/scripts/start-local-chain.sh
+++ b/packages/smart-wallet/scripts/start-local-chain.sh
@@ -30,6 +30,7 @@ echo "Starting the chain..."
 cd "$SDK"/packages/cosmic-swingset || exit 1
 make scenario2-setup scenario2-run-chain-psm >>$CHAIN_LOG 2>&1 &
 echo "Logs written to $CHAIN_LOG"
+make wait-for-cosmos
 
 echo "Funding the pool..."
 make fund-provision-pool

--- a/packages/wallet/ui/README.md
+++ b/packages/wallet/ui/README.md
@@ -7,28 +7,14 @@ The UI deps and scripts were bootstrapped with [Create React App](https://github
 To run it,
 
 ```sh
+# freshen sdk
 cd agoric-sdk
-yarn && yarn build
+yarn install && yarn build
 
-# Start the chain
-cd packages/cosmic-swingset
-make scenario2-setup scenario2-run-chain-psm
+# local chain running with wallet provisioned
+packages/smart-wallet/scripts/start-local-chain.sh YOUR_ACCOUNT_KEY
 
-# (new tab) chain setup
-cd packages/cosmic-swingset
-# Fund the pool
-make fund-provision-pool
-# Fund your wallet
-export ACCT_ADDR=<key-bech32>
-# with 100 BLD for provisioning wallet and 100 USDC for psm trading
-make ACCT_ADDR=$ACCT_ADDR SOLO_COINS=10000000ubld,10000000ibc/usdc1234 fund-acct
-agd query bank balances $ACCT_ADDR
-
-# Provision your smart wallet
-agoric wallet provision --account <key-name>
-# now refresh the wallet UI and purses should load
-
-# Start a wallet UI, new shell
+# Start a wallet UI
 cd packages/wallet/ui && yarn start
 # NB: trailing slash
 open http://localhost:3000/wallet/ 


### PR DESCRIPTION
## Description

We increasingly need a working smart wallet available locally and we have three files that repeat the steps to do it.

This creates a new single file they can each reference and tries to do it in a way that it can be run as one command on the CLI. So far it only works on MacOS but it still has value on Linux as a consolidation.

### Security Considerations

local

### Documentation Considerations

Simplifies

### Testing Considerations

Manually