### PR TITLE
fix: arb passable tools

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -34,7 +34,8 @@
     "@agoric/internal": "^0.2.1",
     "@endo/eventual-send": "^0.16.5",
     "@endo/marshal": "^0.7.5",
-    "@endo/promise-kit": "^0.2.49"
+    "@endo/promise-kit": "^0.2.49",
+    "@fast-check/ava": "^1.0.1"
   },
   "devDependencies": {
     "@agoric/swingset-vat": "^0.30.2",

--- a/packages/store/tools/arb-passable.js
+++ b/packages/store/tools/arb-passable.js
@@ -1,0 +1,106 @@
+// @ts-check
+import { Far, makeTagged } from '@endo/marshal';
+import { fc } from '@fast-check/ava';
+import '../src/types.js';
+
+/**
+ * The only elements with identity. Everything else should be equal
+ * by contents.
+ */
+export const exampleAlice = Far('alice', {});
+export const exampleBob = Far('bob', {});
+export const exampleCarol = Far('carol', {});
+
+export const arbString = fc.oneof(fc.string(), fc.fullUnicodeString());
+
+export const arbLeaf = fc.oneof(
+  fc.constantFrom(null, undefined, false, true),
+  arbString,
+  arbString.map(s => Symbol.for(s)),
+  // primordial symbols and registered lookalikes
+  fc.constantFrom(
+    ...Object.getOwnPropertyNames(Symbol).flatMap(k => {
+      const v = Symbol[k];
+      if (typeof v !== 'symbol') return [];
+      return [v, Symbol.for(k), Symbol.for(`@@${k}`)];
+    }),
+  ),
+  fc.bigInt(),
+  fc.integer(),
+  fc.constantFrom(-0, NaN, Infinity, -Infinity),
+  fc.record({}),
+  fc.constantFrom(exampleAlice, exampleBob, exampleCarol),
+  arbString.map(s => new Error(s)),
+  // unresolved promise
+  fc.constant(new Promise(() => {})),
+);
+
+const { arbDag } = fc.letrec(tie => {
+  return {
+    arbDag: fc.oneof(
+      { withCrossShrink: true },
+      arbLeaf,
+      tie('arbDag').map(v => Promise.resolve(v)),
+      fc.array(tie('arbDag')),
+      fc.dictionary(
+        arbString.filter(s => s !== 'then'),
+        tie('arbDag'),
+      ),
+      // A tagged value, either of arbitrary type with arbitrary payload
+      // or of known type with arbitrary or explicitly valid payload.
+      // Ordered by increasing complexity.
+      fc
+        .oneof(
+          fc.record({ type: arbString, payload: tie('arbDag') }),
+          fc.record({
+            type: fc.constantFrom('copySet'),
+            payload: fc.oneof(
+              tie('arbDag'),
+              // copySet valid payload is an array of unique passables.
+              // TODO: it must be a reverse sorted array, so we should
+              // generate some of those
+              fc.uniqueArray(tie('arbDag')),
+            ),
+          }),
+          fc.record({
+            type: fc.constantFrom('copyBag'),
+            payload: fc.oneof(
+              tie('arbDag'),
+              // copyBag valid payload is an array of [passable, count] tuples
+              // in which each passable is unique.
+              // TODO: it must be a reverse sorted array, so we should
+              // generate some of those
+              fc.uniqueArray(fc.tuple(tie('arbDag'), fc.bigInt()), {
+                selector: entry => entry[0],
+              }),
+            ),
+          }),
+          fc.record({
+            type: fc.constantFrom('copyMap'),
+            payload: fc.oneof(
+              tie('arbDag'),
+              // copyMap valid payload is a {keys: Array<Passable>, values: Array<Passable>} record
+              // in which keys are unique and both arrays have the same length.
+              // TODO: keys must be a reverse sorted array, so we should
+              // generate some of those
+              fc
+                .uniqueArray(
+                  fc.record({ key: tie('arbDag'), value: tie('arbDag') }),
+                  { selector: entry => entry.key },
+                )
+                .map(entries => ({
+                  keys: entries.map(({ key }) => key),
+                  values: entries.map(({ value }) => value),
+                })),
+            ),
+          }),
+        )
+        .map(({ type, payload }) => makeTagged(type, payload)),
+    ),
+  };
+});
+
+/**
+ * A factory for arbitrary passables
+ */
+export const arbPassable = arbDag.map(x => harden(x));

--- a/packages/store/tools/arb-passable.js
+++ b/packages/store/tools/arb-passable.js
@@ -57,8 +57,8 @@ const { arbDag } = fc.letrec(tie => {
             payload: fc.oneof(
               tie('arbDag'),
               // copySet valid payload is an array of unique passables.
-              // TODO: it must be a reverse sorted array, so we should
-              // generate some of those
+              // TODO: A valid copySet payload must be a reverse sorted array,
+              // so we should generate some of those as well.
               fc.uniqueArray(tie('arbDag')),
             ),
           }),
@@ -68,8 +68,8 @@ const { arbDag } = fc.letrec(tie => {
               tie('arbDag'),
               // copyBag valid payload is an array of [passable, count] tuples
               // in which each passable is unique.
-              // TODO: it must be a reverse sorted array, so we should
-              // generate some of those
+              // TODO: A valid copyBag payload must be a reverse sorted array,
+              // so we should generate some of those as well.
               fc.uniqueArray(fc.tuple(tie('arbDag'), fc.bigInt()), {
                 selector: entry => entry[0],
               }),
@@ -79,10 +79,13 @@ const { arbDag } = fc.letrec(tie => {
             type: fc.constantFrom('copyMap'),
             payload: fc.oneof(
               tie('arbDag'),
-              // copyMap valid payload is a {keys: Array<Passable>, values: Array<Passable>} record
-              // in which keys are unique and both arrays have the same length.
-              // TODO: keys must be a reverse sorted array, so we should
-              // generate some of those
+              // copyMap valid payload is a
+              // `{ keys: Passable[], values: Passable[]}`
+              // record in which keys are unique and both arrays have the
+              // same length.
+              // TODO: In a valid copyMap payload, the keys must be a
+              // reverse sorted array, so we should generate some of
+              // those as well.
               fc
                 .uniqueArray(
                   fc.record({ key: tie('arbDag'), value: tie('arbDag') }),


### PR DESCRIPTION
Move the generation of fast-check arb passables into a separate module in a new store/tools directory. This establishes a pattern of putting arb generators into tools/ directories, where they are still only to support testing, can be exported and reused by other packages for their own testing purposes.
