### PR TITLE
feat(agoric-cli): support --home, --keyring-backend

### DIFF
--- a/packages/agoric-cli/src/commands/wallet.js
+++ b/packages/agoric-cli/src/commands/wallet.js
@@ -42,7 +42,6 @@ export const makeWalletCommand = async () => {
       '--keyring-backend [os|file|test]',
       'keyring\'s backend (os|file|test) (default "os")',
     )
-    .option('--dry-run', 'spit out the command instead of running it')
     .option('--nickname [string]', 'nickname to use', 'my-wallet')
     .action(function () {
       const {
@@ -50,12 +49,11 @@ export const makeWalletCommand = async () => {
         nickname,
         spend,
         home,
-        dryRun,
         keyringBackend: backend,
       } = this.opts();
+      const tx = `provision-one ${nickname} ${account} SMART_WALLET`;
       if (spend) {
-        const tx = `provision-one ${nickname} ${account} SMART_WALLET`;
-        execSwingsetTransaction(tx, networkConfig, account, dryRun, {
+        execSwingsetTransaction(tx, networkConfig, account, false, {
           home,
           backend,
         });
@@ -71,9 +69,11 @@ export const makeWalletCommand = async () => {
           .map(f => `${nf.format(Number(f.amount))} ${f.denom}`)
           .join(' + ');
         process.stdout.write(`Provisioning a wallet costs ${costs}\n`);
-        process.stdout.write(
-          `To really provision, repeat this command with --spend\n`,
-        );
+        process.stdout.write(`To really provision, rerun with --spend or...\n`);
+        execSwingsetTransaction(tx, networkConfig, account, true, {
+          home,
+          backend,
+        });
       }
     });
 

--- a/packages/agoric-cli/src/commands/wallet.js
+++ b/packages/agoric-cli/src/commands/wallet.js
@@ -37,12 +37,28 @@ export const makeWalletCommand = async () => {
       normalizeAddress,
     )
     .option('--spend', 'confirm you want to spend')
+    .option('--home [dir]', 'agd application home directory')
+    .option(
+      '--keyring-backend [os|file|test]',
+      'keyring\'s backend (os|file|test) (default "os")',
+    )
+    .option('--dry-run', 'spit out the command instead of running it')
     .option('--nickname [string]', 'nickname to use', 'my-wallet')
     .action(function () {
-      const { account, nickname, spend } = this.opts();
+      const {
+        account,
+        nickname,
+        spend,
+        home,
+        dryRun,
+        keyringBackend: backend,
+      } = this.opts();
       if (spend) {
         const tx = `provision-one ${nickname} ${account} SMART_WALLET`;
-        execSwingsetTransaction(tx, networkConfig, account);
+        execSwingsetTransaction(tx, networkConfig, account, dryRun, {
+          home,
+          backend,
+        });
       } else {
         const params = fetchSwingsetParams(networkConfig);
         assert(
@@ -70,15 +86,27 @@ export const makeWalletCommand = async () => {
       normalizeAddress,
     )
     .requiredOption('--offer [filename]', 'path to file with prepared offer')
+    .option('--home [dir]', 'agd application home directory')
+    .option(
+      '--keyring-backend [os|file|test]',
+      'keyring\'s backend (os|file|test) (default "os")',
+    )
     .option('--dry-run', 'spit out the command instead of running it')
     .action(function () {
-      const { dryRun, from, offer } = this.opts();
+      const {
+        dryRun,
+        from,
+        offer,
+        home,
+        keyringBackend: backend,
+      } = this.opts();
 
       execSwingsetTransaction(
         `wallet-action --allow-spend "$(cat ${offer})"`,
         networkConfig,
         from,
         dryRun,
+        { home, backend },
       );
     });
 

--- a/packages/agoric-cli/src/lib/chain.js
+++ b/packages/agoric-cli/src/lib/chain.js
@@ -21,16 +21,22 @@ harden(normalizeAddress);
  * @param {import('./rpc').MinimalNetworkConfig} net
  * @param {string} from
  * @param {boolean} [dryRun]
+ * @param {{home: string, backend: string}} [keyring]
  */
 export const execSwingsetTransaction = (
   swingsetArgs,
   net,
   from,
   dryRun = false,
+  keyring = undefined,
 ) => {
   const { chainName, rpcAddrs } = net;
 
-  const cmd = `agd --node=${rpcAddrs[0]} --chain-id=${chainName} --from=${from} tx swingset ${swingsetArgs}`;
+  const homeOpt = keyring?.home ? `--home=${keyring.home}` : '';
+  const backendOpt = keyring?.backend
+    ? `--keyring-backend=${keyring.backend}`
+    : '';
+  const cmd = `agd --node=${rpcAddrs[0]} --chain-id=${chainName} ${homeOpt} ${backendOpt} --from=${from} tx swingset ${swingsetArgs}`;
 
   if (dryRun) {
     process.stdout.write('Run this interactive command in shell:\n\n');


### PR DESCRIPTION
for `agoric wallet provision` and `agoric wallet send`

closes: #6315
refs: #6211

### Security Considerations

Key management for `--keyring-backend=test` is considerably less secure than other options, but presumably folks who ask for it know what they're asking for.

### Documentation Considerations

`--help` stuff added

### Testing Considerations

manually tested
