### PR TITLE
BREAKING CHANGE: rename from FarClass to ExoClass, etc

### DIFF
--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -1,5 +1,5 @@
 import { initEmpty } from '@agoric/store';
-import { prepareFarClass } from '@agoric/vat-data';
+import { prepareExoClass } from '@agoric/vat-data';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -12,7 +12,7 @@ import { prepareFarClass } from '@agoric/vat-data';
  * @returns {() => Payment<K>}
  */
 export const preparePaymentKind = (issuerBaggage, name, brand, PaymentI) => {
-  const makePayment = prepareFarClass(
+  const makePayment = prepareExoClass(
     issuerBaggage,
     `${name} payment`,
     PaymentI,

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -2,10 +2,7 @@
 import { isPromise } from '@endo/promise-kit';
 import { assertCopyArray } from '@endo/marshal';
 import { fit, M } from '@agoric/store';
-import {
-  provideDurableWeakMapStore,
-  prepareFarInstance,
-} from '@agoric/vat-data';
+import { provideDurableWeakMapStore, prepareExo } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { preparePaymentKind } from './payment.js';
 import { preparePurseKind } from './purse.js';
@@ -84,7 +81,7 @@ export const preparePaymentLedger = (
   optShutdownWithFailure = undefined,
 ) => {
   /** @type {Brand<K>} */
-  const brand = prepareFarInstance(issuerBaggage, `${name} brand`, BrandI, {
+  const brand = prepareExo(issuerBaggage, `${name} brand`, BrandI, {
     isMyIssuer(allegedIssuer) {
       // BrandI delays calling this method until `allegedIssuer` is a Remotable
       return allegedIssuer === issuer;
@@ -379,7 +376,7 @@ export const preparePaymentLedger = (
   );
 
   /** @type {Issuer<K>} */
-  const issuer = prepareFarInstance(issuerBaggage, `${name} issuer`, IssuerI, {
+  const issuer = prepareExo(issuerBaggage, `${name} issuer`, IssuerI, {
     getBrand() {
       return brand;
     },
@@ -477,7 +474,7 @@ export const preparePaymentLedger = (
   });
 
   /** @type {Mint<K>} */
-  const mint = prepareFarInstance(issuerBaggage, `${name} mint`, MintI, {
+  const mint = prepareExo(issuerBaggage, `${name} mint`, MintI, {
     getIssuer() {
       return issuer;
     },

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -1,4 +1,4 @@
-import { prepareFarClassKit, makeScalarBigSetStore } from '@agoric/vat-data';
+import { prepareExoClassKit, makeScalarBigSetStore } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { makeTransientNotifierKit } from './transientNotifier.js';
 
@@ -28,7 +28,7 @@ export const preparePurseKind = (
   //   that created depositFacet as needed. But this approach ensures a constant
   //   identity for the facet and exercises the multi-faceted object style.
   const { depositInternal, withdrawInternal } = purseMethods;
-  const makePurseKit = prepareFarClassKit(
+  const makePurseKit = prepareExoClassKit(
     issuerBaggage,
     `${name} Purse`,
     PurseIKit,

--- a/packages/SwingSet/test/vat-durable-singleton.js
+++ b/packages/SwingSet/test/vat-durable-singleton.js
@@ -1,6 +1,6 @@
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';
-import { provide, prepareFarClassKit } from '@agoric/vat-data';
+import { provide, prepareExoClassKit } from '@agoric/vat-data';
 
 export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const { version } = vatParameters;
@@ -9,7 +9,7 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const emptyFacetI = M.interface('Facet', {});
   const iKit = harden({ facet1: emptyFacetI, facet2: emptyFacetI });
   const initState = () => ({});
-  const makeInstance = prepareFarClassKit(
+  const makeInstance = prepareExoClassKit(
     baggage,
     'ClassKit',
     iKit,

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -1,5 +1,5 @@
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeHeapFarInstance, keyEQ, makeStore } from '@agoric/store';
+import { makeHeapExo, keyEQ, makeStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 
 import {
@@ -133,7 +133,7 @@ const makeBinaryVoteCounter = (
     });
   };
 
-  const closeFacet = makeHeapFarInstance(
+  const closeFacet = makeHeapExo(
     'BinaryVoteCounter close',
     BinaryVoteCounterCloseI,
     {
@@ -144,7 +144,7 @@ const makeBinaryVoteCounter = (
     },
   );
 
-  const creatorFacet = makeHeapFarInstance(
+  const creatorFacet = makeHeapExo(
     'BinaryVoteCounter creator',
     BinaryVoteCounterAdminI,
     {
@@ -165,7 +165,7 @@ const makeBinaryVoteCounter = (
     },
   );
 
-  const publicFacet = makeHeapFarInstance(
+  const publicFacet = makeHeapExo(
     'BinaryVoteCounter public',
     BinaryVoteCounterPublicI,
     {

--- a/packages/governance/src/multiCandidateVoteCounter.js
+++ b/packages/governance/src/multiCandidateVoteCounter.js
@@ -1,4 +1,4 @@
-import { keyEQ, makeHeapFarInstance, makeStore } from '@agoric/store';
+import { keyEQ, makeHeapExo, makeStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import {
@@ -150,7 +150,7 @@ const makeMultiCandidateVoteCounter = (
     });
   };
 
-  const closeFacet = makeHeapFarInstance(
+  const closeFacet = makeHeapExo(
     'MultiCandidateVoteCounter close',
     VoteCounterCloseI,
     {
@@ -161,7 +161,7 @@ const makeMultiCandidateVoteCounter = (
     },
   );
 
-  const creatorFacet = makeHeapFarInstance(
+  const creatorFacet = makeHeapExo(
     'MultiCandidateVoteCounter creator',
     VoteCounterAdminI,
     {
@@ -184,7 +184,7 @@ const makeMultiCandidateVoteCounter = (
     },
   );
 
-  const publicFacet = makeHeapFarInstance(
+  const publicFacet = makeHeapExo(
     'MultiCandidateVoteCounter public',
     VoteCounterPublicI,
     {

--- a/packages/governance/src/noActionElectorate.js
+++ b/packages/governance/src/noActionElectorate.js
@@ -1,6 +1,6 @@
 import { makePublishKit } from '@agoric/notifier';
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeHeapFarInstance } from '@agoric/store';
+import { makeHeapExo } from '@agoric/store';
 
 import { ElectoratePublicI, ElectorateCreatorI } from './typeGuards.js';
 
@@ -13,7 +13,7 @@ import { ElectoratePublicI, ElectorateCreatorI } from './typeGuards.js';
 const start = zcf => {
   const { subscriber } = makePublishKit();
 
-  const publicFacet = makeHeapFarInstance('publicFacet', ElectoratePublicI, {
+  const publicFacet = makeHeapExo('publicFacet', ElectoratePublicI, {
     getQuestionSubscriber() {
       return subscriber;
     },
@@ -35,7 +35,7 @@ const start = zcf => {
     },
   });
 
-  const creatorFacet = makeHeapFarInstance('creatorFacet', ElectorateCreatorI, {
+  const creatorFacet = makeHeapExo('creatorFacet', ElectorateCreatorI, {
     getPoserInvitation() {
       return zcf.makeInvitation(() => {},
       `noActionElectorate doesn't allow posing questions`);

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -1,4 +1,4 @@
-import { makeHeapFarInstance, fit, keyEQ, M } from '@agoric/store';
+import { makeHeapExo, fit, keyEQ, M } from '@agoric/store';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 
 import { QuestionI, QuestionSpecShape } from './typeGuards.js';
@@ -83,7 +83,7 @@ const buildQuestion = (questionSpec, counterInstance) => {
   const questionHandle = makeHandle('Question');
 
   /** @type {Question} */
-  return makeHeapFarInstance('question details', QuestionI, {
+  return makeHeapExo('question details', QuestionI, {
     getVoteCounter() {
       return counterInstance;
     },

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -1,5 +1,5 @@
 import '@agoric/governance/exported.js';
-import { makeScalarMapStore, M, makeHeapFarInstance, fit } from '@agoric/store';
+import { makeScalarMapStore, M, makeHeapExo, fit } from '@agoric/store';
 import '@agoric/zoe/exported.js';
 import '@agoric/zoe/src/contracts/exported.js';
 import { InstanceHandleShape } from '@agoric/zoe/src/typeGuards.js';
@@ -89,14 +89,10 @@ export const start = async zcf => {
       TimestampShape,
     ).returns(M.promise()),
   });
-  const invitationMakers = makeHeapFarInstance(
-    'Charter Invitation Makers',
-    MakerI,
-    {
-      VoteOnParamChange: makeParamInvitation,
-      VoteOnPauseOffers: makeOfferFilterInvitation,
-    },
-  );
+  const invitationMakers = makeHeapExo('Charter Invitation Makers', MakerI, {
+    VoteOnParamChange: makeParamInvitation,
+    VoteOnPauseOffers: makeOfferFilterInvitation,
+  });
 
   const charterMemberHandler = seat => {
     seat.exit();
@@ -110,23 +106,19 @@ export const start = async zcf => {
     makeCharterMemberInvitation: M.call().returns(M.promise()),
   });
 
-  const creatorFacet = makeHeapFarInstance(
-    'Charter creatorFacet',
-    charterCreatorI,
-    {
-      /**
-       * @param {Instance} governedInstance
-       * @param {GovernedContractFacetAccess<{},{}>} governorFacet
-       * @param {string} [label] for diagnostic use only
-       */
-      addInstance: (governedInstance, governorFacet, label) => {
-        console.log('charter: adding instance', label);
-        instanceToGovernor.init(governedInstance, governorFacet);
-      },
-      makeCharterMemberInvitation: () =>
-        zcf.makeInvitation(charterMemberHandler, INVITATION_MAKERS_DESC),
+  const creatorFacet = makeHeapExo('Charter creatorFacet', charterCreatorI, {
+    /**
+     * @param {Instance} governedInstance
+     * @param {GovernedContractFacetAccess<{},{}>} governorFacet
+     * @param {string} [label] for diagnostic use only
+     */
+    addInstance: (governedInstance, governorFacet, label) => {
+      console.log('charter: adding instance', label);
+      instanceToGovernor.init(governedInstance, governorFacet);
     },
-  );
+    makeCharterMemberInvitation: () =>
+      zcf.makeInvitation(charterMemberHandler, INVITATION_MAKERS_DESC),
+  });
 
   return harden({ creatorFacet });
 };

--- a/packages/inter-protocol/src/price/priceOracleAdmin.js
+++ b/packages/inter-protocol/src/price/priceOracleAdmin.js
@@ -1,4 +1,4 @@
-import { defineDurableFarClass, M, makeKindHandle } from '@agoric/vat-data';
+import { defineDurableExoClass, M, makeKindHandle } from '@agoric/vat-data';
 
 export const INVITATION_MAKERS_DESC = 'oracle invitation';
 
@@ -52,7 +52,7 @@ const OracleAdminI = M.interface('OracleAdmin', {
   getStatus: M.call().returns(M.record()),
 });
 
-export const makeOracleAdmin = defineDurableFarClass(
+export const makeOracleAdmin = defineDurableExoClass(
   oracleAdminKind,
   OracleAdminI,
   initState,

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -3,7 +3,7 @@ import { AmountMath } from '@agoric/ertp';
 import { isNat, Nat } from '@agoric/nat';
 import { TimeMath } from '@agoric/swingset-vat/src/vats/timer/timeMath.js';
 import {
-  defineDurableFarClassKit,
+  defineDurableExoClassKit,
   M,
   makeKindHandle,
   makeScalarBigMapStore,
@@ -94,7 +94,7 @@ const validRoundId = roundId => {
  */
 /** @typedef {ImmutableState & MutableState} State */
 
-export const makeRoundsManagerKit = defineDurableFarClassKit(
+export const makeRoundsManagerKit = defineDurableExoClassKit(
   roundsManagerKind,
   {
     helper: UnguardedHelperI,

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -15,7 +15,7 @@ import {
   ParamTypes,
   publicMixinAPI,
 } from '@agoric/governance';
-import { M, provide, prepareFarInstance } from '@agoric/vat-data';
+import { M, provide, prepareExo } from '@agoric/vat-data';
 import { AmountMath } from '@agoric/ertp';
 
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
@@ -275,7 +275,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     },
     ...publicMixin,
   };
-  const publicFacet = prepareFarInstance(
+  const publicFacet = prepareExo(
     baggage,
     'Parity Stability Module',
     PSMI,

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -1,7 +1,7 @@
 import { AmountMath, AmountShape } from '@agoric/ertp';
 import { makeTracer } from '@agoric/internal';
 import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
-import { M, prepareFarClassKit } from '@agoric/vat-data';
+import { M, prepareExoClassKit } from '@agoric/vat-data';
 import {
   assertProposalShape,
   atomicTransfer,
@@ -218,8 +218,8 @@ export const prepareVault = baggage => {
   trace('prepareVault');
   const makeVaultKit = prepareVaultKit(baggage);
 
-  // TODO find a way to not have to indent a level deeper than defineDurableFarClassKit does
-  const maker = prepareFarClassKit(
+  // TODO find a way to not have to indent a level deeper than defineDurableExoClassKit does
+  const maker = prepareExoClassKit(
     baggage,
     'Vault',
     {

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -22,7 +22,7 @@ import {
   prepareDurablePublishKit,
 } from '@agoric/notifier';
 import {
-  defineDurableFarClassKit,
+  defineDurableExoClassKit,
   makeKindHandle,
   makeScalarBigMapStore,
 } from '@agoric/vat-data';
@@ -276,7 +276,7 @@ const finish = async ({ state }) => {
  * @param {import('@agoric/governance/src/contractGovernance/typedParamManager').TypedParamManager<import('./params.js').VaultDirectorParams>} directorParamManager
  * @param {ZCFMint<"nat">} debtMint
  */
-const makeVaultDirector = defineDurableFarClassKit(
+const makeVaultDirector = defineDurableExoClassKit(
   makeKindHandle('VaultDirector'),
   {
     creator: M.interface('creator', {

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -7,7 +7,7 @@ import {
   SubscriberShape,
   prepareDurablePublishKit,
 } from '@agoric/notifier';
-import { M, prepareFarClassKit } from '@agoric/vat-data';
+import { M, prepareExoClassKit } from '@agoric/vat-data';
 import { makeEphemeraProvider } from '../contractSupport.js';
 import { UnguardedHelperI } from '../typeGuards.js';
 
@@ -49,7 +49,7 @@ export const prepareVaultHolder = baggage => {
     'Vault Holder publish kit',
   );
 
-  const makeVaultHolderKit = prepareFarClassKit(
+  const makeVaultHolderKit = prepareExoClassKit(
     baggage,
     'Vault Holder',
     {

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -26,7 +26,7 @@ import {
   M,
   makeScalarBigMapStore,
   makeScalarBigSetStore,
-  prepareFarClassKit,
+  prepareExoClassKit,
 } from '@agoric/vat-data';
 import {
   assertProposalShape,
@@ -332,8 +332,8 @@ export const prepareVaultManagerKit = baggage => {
     return state;
   };
 
-  // TODO find a way to not have to indent a level deeper than defineDurableFarClassKit does
-  return prepareFarClassKit(
+  // TODO find a way to not have to indent a level deeper than defineDurableExoClassKit does
+  return prepareExoClassKit(
     baggage,
     'VaultManagerKit',
     {

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -4,7 +4,7 @@ import { HandledPromise, E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';
-import { canBeDurable, prepareFarClassKit } from '@agoric/vat-data';
+import { canBeDurable, prepareExoClassKit } from '@agoric/vat-data';
 
 import './types-ambient.js';
 
@@ -385,7 +385,7 @@ export const prepareDurablePublishKit = (baggage, kindName) => {
   /**
    * @returns {() => PublishKit<*>}
    */
-  return prepareFarClassKit(
+  return prepareExoClassKit(
     baggage,
     kindName,
     publishKitIKit,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -10,7 +10,7 @@ import {
 import { makeStoredPublishKit, observeNotifier } from '@agoric/notifier';
 import { fit, M, makeScalarMapStore } from '@agoric/store';
 import {
-  defineVirtualFarClassKit,
+  defineVirtualExoClassKit,
   makeScalarBigMapStore,
   pickFacet,
 } from '@agoric/vat-data';
@@ -247,7 +247,7 @@ const behaviorGuards = {
   }),
 };
 
-const SmartWalletKit = defineVirtualFarClassKit(
+const SmartWalletKit = defineVirtualExoClassKit(
   'SmartWallet',
   behaviorGuards,
   initState,

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -5,7 +5,7 @@
  */
 
 import { WalletName } from '@agoric/internal';
-import { fit, M, makeHeapFarInstance, makeScalarMapStore } from '@agoric/store';
+import { fit, M, makeHeapExo, makeScalarMapStore } from '@agoric/store';
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeMyAddressNameAdminKit } from '@agoric/vats/src/core/basic-behaviors.js';
@@ -139,7 +139,7 @@ export const start = async (zcf, privateArgs) => {
   const walletsByAddress = makeScalarBigMapStore('walletsByAddress');
   const provider = makeAtomicProvider(walletsByAddress);
 
-  const handleWalletAction = makeHeapFarInstance(
+  const handleWalletAction = makeHeapExo(
     'walletActionHandler',
     M.interface('walletActionHandlerI', {
       fromBridge: M.call(shape.WalletBridgeMsg).returns(M.promise()),
@@ -201,7 +201,7 @@ export const start = async (zcf, privateArgs) => {
     zoe,
   });
 
-  const creatorFacet = makeHeapFarInstance(
+  const creatorFacet = makeHeapExo(
     'walletFactoryCreator',
     M.interface('walletFactoryCreatorI', {
       provideSmartWallet: M.callWhen(

--- a/packages/store/docs/exo-taxonomy.md
+++ b/packages/store/docs/exo-taxonomy.md
@@ -1,0 +1,38 @@
+# A Taxonomy of Exo-making Functions
+
+An Exo is a Far object protected by an interface guard. We chose the term "exo" both because
+* "exo" means "outside". An exo object is reachable from outside the vat. Other vats can hold a reference (a capability) to an exo, and anyone with a reference to an exo can send it messages. Put another way, the exo objects are the objects in a vat that are outward facing, and so must be fully defensive against receiving bad messages.
+* Alludes to "ExoSkeleton", a protective outside layer that is an effective first defense against many threats. Likewise, an exo's interface guard is a great first layer of type-like (pattern-based) input validation. The programmers remaining burden to make the outward facing exo objects fully defensive thus becomes easier.
+
+"Exo" forms a nice pairing with Endo, our distributed Hardened JavaScript platform.
+
+## Make instance vs Define class vs Define class kit
+
+* ***`make*Exo`*** <br>
+Makes a new fresh Exo instance.
+* ***`define*ExoClass`*** <br>
+Each call defines a class-like category of Exo instances, where the arguments of the `define*ExoClass` call describe what all instances of that category have in common. Each call makes and returns a new fresh `make*` function that makes new instances of that category. The arguments of that returned `make*` function describe what is specific to the instance it makes.
+* ***`define*ExoClassKit`*** <br>
+We often call a record of named entangled Xs an "XKit", as it a "toolkit" is a collection of closely related tools. Each call to `define*ExoClassKit` defines a kit of entangled Exo classes. Each call makes and return a single new fresh `make*Kit` function for making a corresponding kit of Exo instances. Each of these instances is considered to be a "facet" of that kit. All facets of the same kit share a common encapsulated state.
+
+## Heap vs Virtual vs Durable
+
+* ***`*HeapExo*`*** <br>
+Like the small stores, the "heap" exo objects live in JavaScript's heap. Therefore, the total number of such HeapExo objects in a given vat must be able to fit into the JavaScript heap of that vat, and will occupy room in that vat's snapshot. We say the total number of instances is *low cardinality* when we expect the total number to remain low enough that this heap representation is not a problem.
+* ***`*VirtualExo*`*** <br>
+Like the big stores, the virtual exo objects are written to external storage outside the JavaScript heap. But these are ephemeral -- they do not survive upgrade. Their only purpose is for high cardinality, so we do not provide a convenience for directly making exo instances. IOW, there is no `makeVirtualExo`, only `defineVirtualExoClass` and `defineVirtualExoClassKit`.
+* ***`*DurableExo*`*** <br>
+The durable exo objects are also written to external storage. These can also survive upgrade, and so can be passed in baggage to a successor vat-incarnation.
+
+Note that the total number of exo classes must still low cardinality, even if they are virtual or durable. Being virtual or durable only enables the instances to be high cardinality.
+
+## Make/Define vs Prepare (Durable only)
+
+"prepare" is like "provide" in that it defines something that should be in the baggage, using the one that is there if found, but otherwise making a new one and registering it, so that the successor vat-invocation will find it at the same place in the baggage. Unlike "provide", for each exo behavior already in the baggage, one must call "prepare" immediately --- during the first crank of the vat incarnation. What is passed in baggage is only the state of the durable objects. Only the `prepare*` calls associate that state with code, giving it behavior. All these objects must be prepared early, so they know how to react when they receive messages.
+
+* ***`prepareExo`*** <br>
+Like `makeHeapExo` but for a durable exo in baggage.
+* ***`prepareExoClass`*** <br>
+Like `defineHeapExoClass` but for a durable exo in baggage.
+* ***`prepareExoClassKit`*** <br>
+Like `defineHeapExoClassKit` but for a durable exo in baggage.

--- a/packages/store/docs/store-taxonomy.md
+++ b/packages/store/docs/store-taxonomy.md
@@ -1,6 +1,8 @@
-# A Taxonomy of Stores
+# A Taxonomy of Store-making Functions
 
-Some dimensions on which our Stores differ. For each of these dimensions, in the headings below we indicate the dominant default choice with an asterisk (*). A given Store maker should document which non-default points in this design space it supports. For example, the `makeScalarMapStore` function makes stores that are Strong and Ephemeral and have Scalar keys.  The name is explicit only about the dimensions in which it differs from the defaults.
+Some dimensions on which our Stores differ. For each of these dimensions, in the headings below we indicate the dominant default choice with a plus (+). A given Store maker should document which non-default points in this design space it supports. For example, the `makeScalarMapStore` function makes stores that are Strong and Ephemeral and have Scalar keys and Passable values.  The name is explicit only about the dimensions in which it differs from the defaults.
+
+This package establishes the naming scheme, but only populates some of the choices below. It is left to higher layer packages, such as `@agoric/vat-data`, to provide some of the other choices explained below.
 
 All stores are Far objects (a kind of remotable) that may be snapshotted to (or restored from) a corresponding pass-by-copy objects. MapStores snapshot into CopyMaps. SetStores snapshot into CopySets.
 
@@ -8,13 +10,21 @@ All stores are Far objects (a kind of remotable) that may be snapshotted to (or 
 
 ## SetStores vs MapStores
 
-* SetStores store only keys (of type Key), where each key is key-unique, i.e., it is not keyEQ to any other key in the set.
-* MapStores store key value associations, where the keys are key-unique Keys, as with sets, and the associated values are Passable.
+Neither MapStore nor SetStore have an unnamed default. Rather, both choices must be explicitly named. Thus, when speaking *about* stores, the term *store* refers to both SetStores and MapStores.
 
-## Weak vs Strong*
+* ***`make*SetStore`*** <br>
+SetStores store only keys (of type Key), where each key is key-unique, i.e., it is not keyEQ to any other key in the set.
+* ***`make*MapStore`*** <br>
+MapStores store key value associations, where the keys are key-unique Keys, as with sets, and the associated values are Passable.
 
-* A weak store does not enable its contents to be iterated. Only with the key of a given entry will a weak store reveal anything about the entry. This sometimes enables gc of entries that the collector knows can never be mentioned. But, unlike JavaScript WeakSets and WeakMaps, a weak store *may* allow other values as keys, such as numbers, that can be synthesized at will. Entries indexed by such synthesizable keys can never be collected.
-* A strong store does enable iteration of its contents, and so must retain those contents as long as the strong store itself exists.
+## Weak vs Strong+
+
+There is no "Strong" qualifier in the names. A non-weak store is implicitly a strong store.
+
+* ***`make*Weak*Store`*** <br>
+A weak store does not enable its contents to be iterated. Only with the key of a given entry will a weak store reveal anything about the entry. This sometimes enables gc of entries that the collector knows can never be mentioned. But, unlike JavaScript WeakSets and WeakMaps, a weak store *may* allow other values as keys, such as numbers, that can be synthesized at will. Entries indexed by such synthesizable keys can never be collected.
+* ***`make*Store`*** <br>
+ A strong store does enable iteration of its contents, and so must retain those contents as long as the strong store itself exists.
 
 Methods on stores can be grouped into four categories:
 
@@ -23,33 +33,74 @@ Methods on stores can be grouped into four categories:
 * query -- `keys`, `values`, `entries`, `getSize`
 * query-update -- `clear`
 
-Both strong and weak stores have lookup and update methods, whereas only strong stores have query and query-update methods.  The latter are denied to weak stores since the operations entail iterability.
+Both strong and weak stores have lookup and update methods, whereas only strong stores have query and query-update methods. Weak stores do not have the query-update methods since they require iterability.
 
 # Storage and Representation Differences
 
-## Scalar Keys Only vs Composite Keys Allowed*
+## Scalar Keys Only vs Composite Keys Allowed+
 
-* Scalars are primitives or remotables, those keys that can be compared without looking inside objects. This directly reflects the semantics of JavaScript's Maps and Sets, which only index by scalar keys.
-* Composite keys are things like copyArrays, copyRecords, copySets, or copyMaps, that compare by structural key equality.
+There is no qualifier for the composite case. Rather, a non-scalar store allows composite keys.
 
-## Long* vs Short Expected Lifetime (WeakStores only)
+* ***`make*Scalar*Store`*** <br>
+Scalars are primitives or remotables, those keys that can be compared without looking inside objects. This directly reflects the semantics of JavaScript's Maps and Sets, which only index by scalar keys.
+* ***`make*Store`*** <br>
+Composite keys are things like copyArrays, copyRecords, copySets, or copyMaps, that compare by structural key equality. (Composite-key stores are not yet implemented, so currently all stores are only scalar stores and so must explicitly use the `*Scalar*` qualifier.)
 
-The expected lifetime of a weak store helps us optimize its representation.
-* If we expect a weak store to outlive most of its keys, we may internally use a JavaScript WeakMap.
-* If we expect the keys in a weak store to outlive the store, we may internally use a JavaScript Map, to avoid the costs often associated indexing a key for JavaScript WeakMaps that are no longer alive. Though keep in mind that this representation denies the garbage collector the opportunity to collect those keys while these expected-to-be-short-lived stores are still alive.
+## Long+ vs Short Expected Lifetime (WeakStores only)
 
-## Heap* vs Virtual
+The expected lifetime of a weak store helps us optimize its representation. The default is to use the representation suitable for long lived weak maps.
 
-* Like JavaScript Maps and Sets, heap stores live in the JavaScript language heap, limited by the size of heap memory and occupying room in vat snapshots.
-* Virtual collections potentially live outside the heap (i.e., on disk). A virtual store serializes (marshals) its contents to store it, and unserializes (unmarshals) its contents to retrieve it. Virtual objects (a kind of far object) that are accessible *only* from virtual stores can completely disappear from the heap, to be restored if any serialized reference to it is restored. A virtual store is itself a virtual object.
+* ***`make*Weak*Store(...)`*** <br>
+If we expect a weak store to outlive most of its keys, we consider it long lived. The implementation may internally use a JavaScript WeakMap.
+* ***`make*Weak*Store(..., { ..., longLived: false })`*** <br>
+ If we expect the keys in a weak store to outlive the store, we should use the `longLived: false` option. The implementation may internally use a JavaScript Map, to avoid the costs often associated indexing a key for JavaScript WeakMaps that are no longer alive. Though keep in mind that this representation denies the garbage collector the opportunity to collect those keys while these expected-to-be-short-lived stores are still alive.
 
-## Ephemeral* vs Durable (Heap is always Ephemeral)
+## Small+ vs Big
 
-Stores only exist in one vat at a time, giving us free transactional integrity. All heap stores are ephemeral. Virtual stores can be ephemeral or durable. Ephemeral and durable virtual stores are collectively referred to as "big", since they are able to grow to a large number of elements -- "Big" is an ergonomically friendlier alternative to "Virtual" in the names of the associated maker functions.
-* Ephemeral stores only exist in the vat that initially created them, dying when that vat dies. The content of virtual ephemeral stores can include references to ephemeral non-virtual remotables or promises.
-* A durable store can be part of a vat's "estate", to be transferred to that vat's heir/successor on the death of its current vat. A durable store can only contain keys and values that are still meaningful across such traumas, such as
-    * durable objects (a kind of virtual object)
-    * Remotes, a kind of remotable designating a far object in another vat
-    * Promises, perhaps. These are tempting because they can be restored into a well-defined severed state, the rejected promise.
+There is no qualifier for small. Non-big stores are always small. The `@agoric/store` package implements only small stores. Big stores are provided by the `@agoric/vat-data` package.
 
-    A durable store may not store a reference to a local non-durable far object. A durable store is itself a durable object.
+* ***`make*Store`*** <br>
+A small store is one that is expected to fit into a normal JavaScript object using JavaScript's normal heap memory and occupying room in vat snapshots.
+* ***`make*Big*Store`*** <br>
+A big store uses external memory, such as database tables.
+
+A big store serializes (marshals) its contents to store it, and unserializes (unmarshals) its contents to retrieve it. Since stores in general store only Passable objects, it should be relatively painless for a refactor to switch between small stores and big stores without changing the meaning of the program.
+
+Virtual objects (a kind of far object) that are accessible *only* from big stores can completely disappear from the heap, to be restored if any serialized reference to it is restored. A big store is itself a virtual object.
+
+## Ephemeral+ vs Durable (Only big stores can be durable)
+
+Durable objects are those that can survive upgrade, to be passed forward from one vat incarnation to the next. All the data needed for the successor vat to resume operation should be durable. All small stores are ephemeral. Big stores can be ephemeral or durable. Big stores are ephemeral by default, but can be made durable by explicit use of the `durable: true` option.
+
+* ***`make*Store(...)`*** <br>
+Ephemeral stores only exist in the vat that initially created them, dying when that vat dies. The content of virtual ephemeral stores can include references to ephemeral non-virtual remotables or promises.
+* ***`make*Big*Store(..., { ..., durable: true })`*** <br>
+A durable store can be part of a vat's "estate", to be transferred to that vat's heir/successor on the death of its current vat. A durable store can only contain keys and values that are still meaningful across upgrades, such as
+    * durable objects
+    * remote presences, a kind of remotable designating a far object in another vat
+
+    A durable store may not store a reference to a local ephemeral far object. A durable store is itself a durable object.
+
+# Origin Differences
+
+## Make+ vs Provide (Durable only)
+
+For durable objects to be communicated across upgrade, from one vat incarnation to the next, they must be reachable from *baggage*. Baggage is rooted in a distinct durable map store, and consists of a tree of durable map stores reachable from that root. The code of the successor vat should generally be written so that it can be a successor to a previous incarnation, restoring itself from baggage that has been filled by that predecesor, but also so that it can be instantiated directly, with empty baggage, as the first vat-incarnation of a new vat.
+
+To write code that can be used either way, we use the *provide* pattern, supported by a small number of functions specialized for this purpose. Where a `make*` function always makes a new something each time it is called, a `provide*` function uses the one it finds, if there is one there, but otherwise creates a new one while placing it in the baggage at the same place, so that its successor will find it.
+
+* ***`make*(...)`*** <br>
+Makes a fresh new something each time it is called.
+* ***`provide(baggage, key, () => make*(...))`*** <br>
+The `provide` function only be called at most once for any `baggage`,`key` pair during any given vat incarnation. This is the general case for providing anything that can be made.
+
+With specific conveniences for the following common cases:
+
+* ***`provideDurableMapStore(baggage, key)`*** <br>
+Provides (from that baggage at that key) a scalar big durable strong map store.
+* ***`provideDurableWeakMapStore(baggage, key)`*** <br>
+Provides (from that baggage at that key) a scalar big durable weak map store.
+* ***`provideDurableSetStore(baggage, key)`*** <br>
+Provides (from that baggage at that key) a scalar big durable strong set store.
+
+We may add more such conveniences over time as we encounter the need.

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -58,9 +58,9 @@ export {
   defendPrototype,
   defendPrototypeKit,
   initEmpty,
-  defineHeapFarClass,
-  defineHeapFarClassKit,
-  makeHeapFarInstance,
+  defineHeapExoClass,
+  defineHeapExoClassKit,
+  makeHeapExo,
 } from './patterns/interface-tools.js';
 
 export { makeScalarWeakSetStore } from './stores/scalarWeakSetStore.js';

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -279,7 +279,7 @@ const emptyRecord = harden({});
 /**
  * When calling `defineDurableKind` and
  * its siblings, used as the `init` function argument to indicate that the
- * state record of the (virtual/durable) instances of the kind/farClass
+ * state record of the (virtual/durable) instances of the kind/exoClass
  * should be empty, and that the returned maker function should have zero
  * parameters.
  *
@@ -306,7 +306,7 @@ export const initEmpty = () => emptyRecord;
  * @param {object} [options]
  * @returns {(...args: A[]) => (T & import('@endo/eventual-send').RemotableBrand<{}, T>)}
  */
-export const defineHeapFarClass = (
+export const defineHeapExoClass = (
   tag,
   interfaceGuard,
   init,
@@ -343,7 +343,7 @@ export const defineHeapFarClass = (
   // @ts-expect-error could be instantiated with different subtype
   return harden(makeInstance);
 };
-harden(defineHeapFarClass);
+harden(defineHeapExoClass);
 
 /**
  * @template A args to init
@@ -356,7 +356,7 @@ harden(defineHeapFarClass);
  * @param {object} [options]
  * @returns {(...args: A[]) => F}
  */
-export const defineHeapFarClassKit = (
+export const defineHeapExoClassKit = (
   tag,
   interfaceGuardKit,
   init,
@@ -396,7 +396,7 @@ export const defineHeapFarClassKit = (
   // @ts-ignore xxx
   return harden(makeInstanceKit);
 };
-harden(defineHeapFarClassKit);
+harden(defineHeapExoClassKit);
 
 /**
  * @template {Record<string, Method>} T
@@ -406,13 +406,13 @@ harden(defineHeapFarClassKit);
  * @param {object} [options]
  * @returns {T & import('@endo/eventual-send').RemotableBrand<{}, T>}
  */
-export const makeHeapFarInstance = (
+export const makeHeapExo = (
   tag,
   interfaceGuard,
   methods,
   options = undefined,
 ) => {
-  const makeInstance = defineHeapFarClass(
+  const makeInstance = defineHeapExoClass(
     tag,
     interfaceGuard,
     initEmpty,
@@ -421,4 +421,4 @@ export const makeHeapFarInstance = (
   );
   return makeInstance();
 };
-harden(makeHeapFarInstance);
+harden(makeHeapExo);

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -1,8 +1,8 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import {
-  defineHeapFarClass,
-  defineHeapFarClassKit,
-  makeHeapFarInstance,
+  defineHeapExoClass,
+  defineHeapExoClassKit,
+  makeHeapExo,
 } from '../src/patterns/interface-tools.js';
 import { M } from '../src/patterns/patternMatchers.js';
 
@@ -20,8 +20,8 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineHeapFarClass', t => {
-  const makeUpCounter = defineHeapFarClass(
+test('test defineHeapExoClass', t => {
+  const makeUpCounter = defineHeapExoClass(
     'UpCounter',
     UpCounterI,
     /** @param {number} x */
@@ -47,8 +47,8 @@ test('test defineHeapFarClass', t => {
   });
 });
 
-test('test defineHeapFarClassKit', t => {
-  const makeCounterKit = defineHeapFarClassKit(
+test('test defineHeapExoClassKit', t => {
+  const makeCounterKit = defineHeapExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
     /** @param {number} x */
@@ -93,9 +93,9 @@ test('test defineHeapFarClassKit', t => {
   });
 });
 
-test('test makeHeapFarInstance', t => {
+test('test makeHeapExo', t => {
   let x = 3;
-  const upCounter = makeHeapFarInstance('upCounter', UpCounterI, {
+  const upCounter = makeHeapExo('upCounter', UpCounterI, {
     incr(y = 1) {
       x += y;
       return x;
@@ -115,13 +115,13 @@ test('test makeHeapFarInstance', t => {
 // For code sharing with defineKind which does not support an interface
 test('missing interface', t => {
   t.notThrows(() =>
-    makeHeapFarInstance('greeter', undefined, {
+    makeHeapExo('greeter', undefined, {
       sayHello() {
         return 'hello';
       },
     }),
   );
-  const greeterMaker = makeHeapFarInstance('greeterMaker', undefined, {
+  const greeterMaker = makeHeapExo('greeterMaker', undefined, {
     makeSayHello() {
       return () => 'hello';
     },
@@ -134,7 +134,7 @@ test('missing interface', t => {
 
 test('sloppy option', t => {
   const emptyBehavior = {};
-  const greeter = makeHeapFarInstance(
+  const greeter = makeHeapExo(
     'greeter',
     M.interface('greeter', emptyBehavior, { sloppy: true }),
     {
@@ -147,7 +147,7 @@ test('sloppy option', t => {
 
   t.throws(
     () =>
-      makeHeapFarInstance(
+      makeHeapExo(
         'greeter',
         M.interface('greeter', emptyBehavior, { sloppy: false }),
         {
@@ -161,7 +161,7 @@ test('sloppy option', t => {
 });
 
 test('naked function call', t => {
-  const greeter = makeHeapFarInstance(
+  const greeter = makeHeapExo(
     'greeter',
     M.interface('greeter', { sayHello: M.call().returns('hello') }),
     {
@@ -183,7 +183,7 @@ test('naked function call', t => {
 // needn't run. we just don't have a better place to write these.
 test.skip('types', () => {
   // any methods can be defined if there's no interface
-  const unguarded = makeHeapFarInstance('upCounter', undefined, {
+  const unguarded = makeHeapExo('upCounter', undefined, {
     /** @param {number} val */
     incr(val) {
       return val;
@@ -199,7 +199,7 @@ test.skip('types', () => {
   unguarded.notInBehavior;
 
   // TODO when there is an interface, error if a method is missing from it
-  const guarded = makeHeapFarInstance('upCounter', UpCounterI, {
+  const guarded = makeHeapExo('upCounter', UpCounterI, {
     /** @param {number} val */
     incr(val) {
       return val;

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -28,7 +28,7 @@ import {
  * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const defineVirtualFarClass = (
+export const defineVirtualExoClass = (
   tag,
   interfaceGuard,
   init,
@@ -42,7 +42,7 @@ export const defineVirtualFarClass = (
     thisfulMethods: true,
     interfaceGuard,
   });
-harden(defineVirtualFarClass);
+harden(defineVirtualExoClass);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -55,7 +55,7 @@ harden(defineVirtualFarClass);
  * @param {DefineKindOptions<{ facets: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const defineVirtualFarClassKit = (
+export const defineVirtualExoClassKit = (
   tag,
   interfaceGuardKit,
   init,
@@ -69,7 +69,7 @@ export const defineVirtualFarClassKit = (
     thisfulMethods: true,
     interfaceGuard: interfaceGuardKit,
   });
-harden(defineVirtualFarClassKit);
+harden(defineVirtualExoClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -82,7 +82,7 @@ harden(defineVirtualFarClassKit);
  * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const defineDurableFarClass = (
+export const defineDurableExoClass = (
   kindHandle,
   interfaceGuard,
   init,
@@ -96,7 +96,7 @@ export const defineDurableFarClass = (
     thisfulMethods: true,
     interfaceGuard,
   });
-harden(defineDurableFarClass);
+harden(defineDurableExoClass);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -109,7 +109,7 @@ harden(defineDurableFarClass);
  * @param {DefineKindOptions<{ facets: T, state: ReturnType<I>}>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const defineDurableFarClassKit = (
+export const defineDurableExoClassKit = (
   kindHandle,
   interfaceGuardKit,
   init,
@@ -123,7 +123,7 @@ export const defineDurableFarClassKit = (
     thisfulMethods: true,
     interfaceGuard: interfaceGuardKit,
   });
-harden(defineDurableFarClassKit);
+harden(defineDurableExoClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -137,7 +137,7 @@ harden(defineDurableFarClassKit);
  * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const prepareFarClass = (
+export const prepareExoClass = (
   baggage,
   kindName,
   interfaceGuard,
@@ -145,14 +145,14 @@ export const prepareFarClass = (
   methods,
   options = undefined,
 ) =>
-  defineDurableFarClass(
+  defineDurableExoClass(
     provideKindHandle(baggage, kindName),
     interfaceGuard,
     init,
     methods,
     options,
   );
-harden(prepareFarClass);
+harden(prepareExoClass);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -166,7 +166,7 @@ harden(prepareFarClass);
  * @param {DefineKindOptions<{ facets: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const prepareFarClassKit = (
+export const prepareExoClassKit = (
   baggage,
   kindName,
   interfaceGuardKit,
@@ -174,14 +174,14 @@ export const prepareFarClassKit = (
   facets,
   options = undefined,
 ) =>
-  defineDurableFarClassKit(
+  defineDurableExoClassKit(
     provideKindHandle(baggage, kindName),
     interfaceGuardKit,
     init,
     facets,
     options,
   );
-harden(prepareFarClassKit);
+harden(prepareExoClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -194,14 +194,14 @@ harden(prepareFarClassKit);
  * @param {DefineKindOptions<{ self: M }>} [options]
  * @returns {T & RemotableBrand<{}, T>}
  */
-export const prepareFarInstance = (
+export const prepareExo = (
   baggage,
   kindName,
   interfaceGuard,
   methods,
   options = undefined,
 ) => {
-  const makeSingleton = prepareFarClass(
+  const makeSingleton = prepareExoClass(
     baggage,
     kindName,
     interfaceGuard,
@@ -214,11 +214,11 @@ export const prepareFarInstance = (
   // @ts-ignore could be instantiated with an arbitrary type
   return provide(baggage, `the_${kindName}`, () => makeSingleton());
 };
-harden(prepareFarInstance);
+harden(prepareExo);
 
 /**
- * @deprecated Use prepareFarInstance instead.
  * @template {Record<string | symbol, CallableFunction>} T methods
+ * @deprecated Use prepareExo instead.
  * @param {Baggage} baggage
  * @param {string} kindName
  * @param {T} methods
@@ -230,5 +230,5 @@ export const prepareSingleton = (
   kindName,
   methods,
   options = undefined,
-) => prepareFarInstance(baggage, kindName, undefined, methods, options);
+) => prepareExo(baggage, kindName, undefined, methods, options);
 harden(prepareSingleton);

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -2,14 +2,14 @@
 export * from './vat-data-bindings.js';
 export * from './kind-utils.js';
 export {
-  defineVirtualFarClass,
-  defineVirtualFarClassKit,
-  defineDurableFarClass,
-  defineDurableFarClassKit,
-  prepareFarClass,
-  prepareFarClassKit,
-  prepareFarInstance,
+  defineVirtualExoClass,
+  defineVirtualExoClassKit,
+  defineDurableExoClass,
+  defineDurableExoClassKit,
+  prepareExoClass,
+  prepareExoClassKit,
+  prepareExo,
   prepareSingleton,
-} from './far-class-utils.js';
+} from './exo-utils.js';
 
 /** @template T @typedef {import('./types.js').DefineKindOptions<T>} DefineKindOptions */

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -30,7 +30,7 @@ export const provideKindHandle = (baggage, kindName) =>
 harden(provideKindHandle);
 
 /**
- * @deprecated Use prepareFarClass instead
+ * @deprecated Use prepareExoClass instead
  * @type {import('./types.js').PrepareKind}
  */
 export const prepareKind = (
@@ -49,7 +49,7 @@ export const prepareKind = (
 harden(prepareKind);
 
 /**
- * @deprecated Use prepareFarClassKit instead
+ * @deprecated Use prepareExoClassKit instead
  * @type {import('./types.js').PrepareKindMulti}
  */
 export const prepareKindMulti = (

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -75,7 +75,7 @@ type DefineKindOptions<C> = {
    * argument or as their `this` binding? For `defineDurableKind` and its
    * siblings (including `prepareSingleton`), this defaults to off, meaning that
    * their behavior methods receive `context` as their first argument.
-   * `prepareFarClass` and its siblings (including `prepareFarInstance`) use
+   * `prepareExoClass` and its siblings (including `prepareExo`) use
    * this flag internally to indicate that their methods receive `context`
    * as their `this` binding.
    */
@@ -88,7 +88,7 @@ type DefineKindOptions<C> = {
    * pattern is satisfied before calling the raw method.
    *
    * In `defineDurableKind` and its siblings, this defaults to off.
-   * `prepareFarClass` use this internally to protect their raw class methods
+   * `prepareExoClass` use this internally to protect their raw class methods
    * using the provided interface.
    */
   interfaceGuard?: InterfaceGuard<unknown>;
@@ -96,7 +96,7 @@ type DefineKindOptions<C> = {
 
 export type VatData = {
   // virtual kinds
-  /** @deprecated Use defineVirtualFarClass instead */
+  /** @deprecated Use defineVirtualExoClass instead */
   defineKind: <P, S, F>(
     tag: string,
     init: (...args: P) => S,
@@ -104,7 +104,7 @@ export type VatData = {
     options?: DefineKindOptions<KindContext<S, F>>,
   ) => (...args: P) => KindFacet<F>;
 
-  /** @deprecated Use defineVirtualFarClassKit instead */
+  /** @deprecated Use defineVirtualExoClassKit instead */
   defineKindMulti: <P, S, B>(
     tag: string,
     init: (...args: P) => S,
@@ -115,7 +115,7 @@ export type VatData = {
   // durable kinds
   makeKindHandle: (descriptionTag: string) => DurableKindHandle;
 
-  /** @deprecated Use defineDurableFarClass instead */
+  /** @deprecated Use defineDurableExoClass instead */
   defineDurableKind: <P, S, F>(
     kindHandle: DurableKindHandle,
     init: (...args: P) => S,
@@ -123,7 +123,7 @@ export type VatData = {
     options?: DefineKindOptions<KindContext<S, F>>,
   ) => (...args: P) => KindFacet<F>;
 
-  /** @deprecated Use defineDurableFarClassKit instead */
+  /** @deprecated Use defineDurableExoClassKit instead */
   defineDurableKindMulti: <P, S, B>(
     kindHandle: DurableKindHandle,
     init: (...args: P) => S,
@@ -173,7 +173,7 @@ interface PickFacet {
   ): (...args: Parameters<M>) => ReturnType<M>[F];
 }
 
-/** @deprecated Use prepareFarClass instead */
+/** @deprecated Use prepareExoClass instead */
 type PrepareKind = <P, S, F>(
   baggage: Baggage,
   tag: string,
@@ -182,7 +182,7 @@ type PrepareKind = <P, S, F>(
   options?: DefineKindOptions<KindContext<S, F>>,
 ) => (...args: P) => KindFacet<F>;
 
-/** @deprecated Use prepareFarClassKit instead */
+/** @deprecated Use prepareExoClassKit instead */
 type PrepareKindMulti = <P, S, B>(
   baggage: Baggage,
   tag: string,

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -45,7 +45,7 @@ if ('VatData' in globalThis) {
 }
 
 /**
- * @deprecated Use FarClasses/FarInstances instead of kinds
+ * @deprecated Use Exos/ExoClasses instead of kinds
  */
 export const {
   defineKind,

--- a/packages/vat-data/test/test-durable-classes.js
+++ b/packages/vat-data/test/test-durable-classes.js
@@ -3,13 +3,13 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  defineDurableFarClass,
-  defineDurableFarClassKit,
-} from '../src/far-class-utils.js';
-import {
   makeKindHandle,
   makeScalarBigMapStore,
 } from '../src/vat-data-bindings.js';
+import {
+  defineDurableExoClass,
+  defineDurableExoClassKit,
+} from '../src/exo-utils.js';
 
 const UpCounterI = M.interface('UpCounter', {
   incr: M.call()
@@ -25,10 +25,10 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineDurableFarClass', t => {
+test('test defineDurableExoClass', t => {
   const upCounterKind = makeKindHandle('UpCounter');
 
-  const makeUpCounter = defineDurableFarClass(
+  const makeUpCounter = defineDurableExoClass(
     upCounterKind,
     UpCounterI,
     /** @param {number} x */
@@ -61,10 +61,10 @@ test('test defineDurableFarClass', t => {
   makeUpCounter('str');
 });
 
-test('test defineDurableFarClassKit', t => {
+test('test defineDurableExoClassKit', t => {
   const counterKindHandle = makeKindHandle('Counter');
 
-  const makeCounterKit = defineDurableFarClassKit(
+  const makeCounterKit = defineDurableExoClassKit(
     counterKindHandle,
     { up: UpCounterI, down: DownCounterI },
     /** @param {number} x */
@@ -117,7 +117,7 @@ test('finish option', t => {
     counterRegistry.init(state.name, self);
   };
 
-  const makeUpCounter = defineDurableFarClass(
+  const makeUpCounter = defineDurableExoClass(
     upCounterKind,
     UpCounterI,
     /**

--- a/packages/vat-data/test/test-prepare.js
+++ b/packages/vat-data/test/test-prepare.js
@@ -3,10 +3,10 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  prepareFarClass,
-  prepareFarClassKit,
-  prepareFarInstance,
-} from '../src/far-class-utils.js';
+  prepareExoClass,
+  prepareExoClassKit,
+  prepareExo,
+} from '../src/exo-utils.js';
 import { makeScalarBigMapStore } from '../src/vat-data-bindings.js';
 
 const UpCounterI = M.interface('UpCounter', {
@@ -23,10 +23,10 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test prepareFarClass', t => {
+test('test prepareExoClass', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
-  const makeUpCounter = prepareFarClass(
+  const makeUpCounter = prepareExoClass(
     baggage,
     'UpCounter',
     UpCounterI,
@@ -57,10 +57,10 @@ test('test prepareFarClass', t => {
   makeUpCounter('str');
 });
 
-test('test prepareFarClassKit', t => {
+test('test prepareExoClassKit', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
-  const makeCounterKit = prepareFarClassKit(
+  const makeCounterKit = prepareExoClassKit(
     baggage,
     'Counter',
     { up: UpCounterI, down: DownCounterI },
@@ -105,11 +105,11 @@ test('test prepareFarClassKit', t => {
   makeCounterKit('str');
 });
 
-test('test prepareFarInstance', t => {
+test('test prepareExo', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
   let x = 3;
-  const upCounter = prepareFarInstance(baggage, 'upCounter', UpCounterI, {
+  const upCounter = prepareExo(baggage, 'upCounter', UpCounterI, {
     incr(y = 1) {
       x += y;
       return x;

--- a/packages/vat-data/test/test-virtual-classes.js
+++ b/packages/vat-data/test/test-virtual-classes.js
@@ -3,9 +3,9 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  defineVirtualFarClass,
-  defineVirtualFarClassKit,
-} from '../src/far-class-utils.js';
+  defineVirtualExoClass,
+  defineVirtualExoClassKit,
+} from '../src/exo-utils.js';
 
 const UpCounterI = M.interface('UpCounter', {
   incr: M.call()
@@ -21,8 +21,8 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineVirtualFarClass', t => {
-  const makeUpCounter = defineVirtualFarClass(
+test('test defineVirtualExoClass', t => {
+  const makeUpCounter = defineVirtualExoClass(
     'UpCounter',
     UpCounterI,
     /** @param {number} x */
@@ -52,8 +52,8 @@ test('test defineVirtualFarClass', t => {
   makeUpCounter('str');
 });
 
-test('test defineVirtualFarClassKit', t => {
-  const makeCounterKit = defineVirtualFarClassKit(
+test('test defineVirtualExoClassKit', t => {
+  const makeCounterKit = defineVirtualExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
     /** @param {number} x */

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -1,6 +1,6 @@
 import { Fail, q } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
-import { prepareFarClass, provideDurableSetStore } from '@agoric/vat-data';
+import { prepareExoClass, provideDurableSetStore } from '@agoric/vat-data';
 import { M, initEmpty } from '@agoric/store';
 
 import {
@@ -24,7 +24,7 @@ const WakerI = M.interface('Waker', {
 export const makeMakeExiter = baggage => {
   const activeWakers = provideDurableSetStore(baggage, 'activeWakers');
 
-  const makeExitable = prepareFarClass(
+  const makeExitable = prepareExoClass(
     baggage,
     'ExitObject',
     ExitObjectI,
@@ -36,7 +36,7 @@ export const makeMakeExiter = baggage => {
       },
     },
   );
-  const makeWaived = prepareFarClass(
+  const makeWaived = prepareExoClass(
     baggage,
     'ExitWaived',
     ExitObjectI,
@@ -50,7 +50,7 @@ export const makeMakeExiter = baggage => {
       },
     },
   );
-  const makeWaker = prepareFarClass(
+  const makeWaker = prepareExoClass(
     baggage,
     'Waker',
     WakerI,

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -3,7 +3,7 @@ import {
   makeScalarBigWeakMapStore,
   provideDurableMapStore,
   provideDurableWeakMapStore,
-  prepareFarClassKit,
+  prepareExoClassKit,
   prepareKind,
   provide,
 } from '@agoric/vat-data';
@@ -263,7 +263,7 @@ export const createSeatManager = (
     }),
   });
 
-  const makeSeatManagerKit = prepareFarClassKit(
+  const makeSeatManagerKit = prepareExoClassKit(
     zcfBaggage,
     'ZcfSeatManager',
     ZcfSeatManagerIKit,

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -8,7 +8,7 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableMapStore,
-  prepareFarInstance,
+  prepareExo,
   prepareKind,
 } from '@agoric/vat-data';
 
@@ -193,7 +193,7 @@ export const makeZCFZygote = async (
       .optional(M.string())
       .returns(OfferHandlerShape),
   });
-  const taker = prepareFarInstance(zcfBaggage, 'offer handler taker', TakerI, {
+  const taker = prepareExo(zcfBaggage, 'offer handler taker', TakerI, {
     take: takeOfferHandler,
   });
   const handleOfferObj = makeHandleOfferObj(taker);

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -1,4 +1,4 @@
-import { provide, prepareFarClass, M } from '@agoric/vat-data';
+import { provide, prepareExoClass, M } from '@agoric/vat-data';
 import { assertKeywordName } from './cleanProposal.js';
 import {
   BrandKeywordRecordShape,
@@ -47,7 +47,7 @@ export const makeInstanceRecordStorage = baggage => {
     assertUniqueKeyword: M.call(KeywordShape).returns(),
   });
 
-  const makeInstanceRecord = prepareFarClass(
+  const makeInstanceRecord = prepareExoClass(
     baggage,
     'InstanceRecord',
     InstanceRecordI,

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,6 +1,6 @@
 import { assert } from '@agoric/assert';
-import { initEmpty, makeHeapFarInstance } from '@agoric/store';
-import { prepareFarClass } from '@agoric/vat-data';
+import { initEmpty, makeHeapExo } from '@agoric/store';
+import { prepareExoClass } from '@agoric/vat-data';
 
 import { HandleI } from './typeGuards.js';
 
@@ -16,7 +16,7 @@ const { Fail } = assert;
  */
 export const defineDurableHandle = (baggage, handleType) => {
   typeof handleType === 'string' || Fail`handleType must be a string`;
-  const makeHandle = prepareFarClass(
+  const makeHandle = prepareExoClass(
     baggage,
     `${handleType}Handle`,
     HandleI,
@@ -40,7 +40,7 @@ export const makeHandle = handleType => {
   // Return the intersection type (really just an empty object).
   // @ts-expect-error Bit by our own opaque types.
   return /** @type {Handle<H>} */ (
-    makeHeapFarInstance(`${handleType}Handle`, HandleI, {})
+    makeHeapExo(`${handleType}Handle`, HandleI, {})
   );
 };
 harden(makeHandle);

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -3,7 +3,7 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  prepareFarInstance,
+  prepareExo,
   prepareKind,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
@@ -102,7 +102,7 @@ export const makeInstallationStorage = (
     ),
   });
 
-  const installationStorage = prepareFarInstance(
+  const installationStorage = prepareExo(
     zoeBaggage,
     'InstallationStorage',
     InstallationStorageI,

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -1,11 +1,11 @@
 import {
   canBeDurable,
-  M,
   makeScalarBigSetStore,
-  provide,
   provideDurableWeakMapStore,
-  prepareFarClassKit,
   prepareKindMulti,
+  prepareExoClassKit,
+  M,
+  provide,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
 import { defineDurableHandle } from '../makeHandle.js';
@@ -50,7 +50,7 @@ const InstanceAdminStorageIKit = harden({
 
 /** @param {import('@agoric/vat-data').Baggage} baggage */
 export const makeInstanceAdminStorage = baggage => {
-  const makeIAS = prepareFarClassKit(
+  const makeIAS = prepareExoClassKit(
     baggage,
     'InstanceAdmin',
     InstanceAdminStorageIKit,

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -4,7 +4,7 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  prepareFarClass,
+  prepareExoClass,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
 
@@ -43,7 +43,7 @@ export const makeStartInstance = (
     seatHandleToZoeSeatAdmin,
   );
 
-  const makeZoeInstanceAdmin = prepareFarClass(
+  const makeZoeInstanceAdmin = prepareExoClass(
     zoeBaggage,
     'zoeInstanceAdmin',
     InstanceAdminI,
@@ -143,7 +143,7 @@ export const makeStartInstance = (
   );
 
   const prepareEmptyFacet = facetName =>
-    prepareFarClass(
+    prepareExoClass(
       zoeBaggage,
       facetName,
       M.interface(facetName, {}),
@@ -153,7 +153,7 @@ export const makeStartInstance = (
   const makeEmptyCreatorFacet = prepareEmptyFacet('emptyCreatorFacet');
   const makeEmptyPublicFacet = prepareEmptyFacet('emptyPublicFacet');
 
-  const makeAdminFacet = prepareFarClass(
+  const makeAdminFacet = prepareExoClass(
     zoeBaggage,
     'adminFacet',
     AdminFacetI,

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -16,7 +16,7 @@ import '../internal-types.js';
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeScalarBigMapStore, prepareFarInstance } from '@agoric/vat-data';
+import { makeScalarBigMapStore, prepareExo } from '@agoric/vat-data';
 
 import { makeZoeStorageManager } from './zoeStorageManager.js';
 import { makeStartInstance } from './startInstance.js';
@@ -160,7 +160,7 @@ const makeZoeKit = (
   };
 
   /** @type {ZoeService} */
-  const zoeService = prepareFarInstance(zoeBaggage, 'ZoeService', ZoeServiceI, {
+  const zoeService = prepareExo(zoeBaggage, 'ZoeService', ZoeServiceI, {
     install(bundleId) {
       return dataAccess.installBundle(bundleId);
     },

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -1,6 +1,6 @@
 import { prepareDurablePublishKit, SubscriberShape } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
-import { M, prepareFarClassKit } from '@agoric/vat-data';
+import { M, prepareExoClassKit } from '@agoric/vat-data';
 import { deeplyFulfilled } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
 
@@ -88,7 +88,7 @@ export const makeZoeSeatAdminFactory = baggage => {
   // table entry.
   const ephemeralOfferResultStore = new Map();
 
-  return prepareFarClassKit(
+  return prepareExoClassKit(
     baggage,
     'ZoeSeatKit',
     ZoeSeatIKit,

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -2,8 +2,8 @@ import { AssetKind, makeDurableIssuerKit, AmountMath } from '@agoric/ertp';
 import {
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  prepareFarClassKit,
-  prepareFarClass,
+  prepareExoClassKit,
+  prepareExoClass,
   provideDurableSetStore,
 } from '@agoric/vat-data';
 
@@ -117,7 +117,7 @@ export const makeZoeStorageManager = (
     zoeMintBaggageSet(issuerBaggage);
   }
 
-  const makeZoeMint = prepareFarClass(
+  const makeZoeMint = prepareExoClass(
     zoeBaggage,
     'ZoeMint',
     ZoeMintI,
@@ -154,7 +154,7 @@ export const makeZoeStorageManager = (
     },
   );
 
-  const makeInstanceStorageManager = prepareFarClassKit(
+  const makeInstanceStorageManager = prepareExoClassKit(
     zoeBaggage,
     'InstanceStorageManager',
     InstanceStorageManagerIKit,
@@ -390,7 +390,7 @@ export const makeZoeStorageManager = (
 
   const getInvitationIssuer = () => invitationIssuer;
 
-  const makeStorageManager = prepareFarClassKit(
+  const makeStorageManager = prepareExoClassKit(
     zoeBaggage,
     'ZoeStorageManager',
     ZoeStorageManagerIKit,

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -1,5 +1,7 @@
 import { M, fit } from '@agoric/store';
-import { prepareFarClass, prepareFarInstance } from '@agoric/vat-data';
+import '../../../exported.js';
+
+import { prepareExoClass, prepareExo } from '@agoric/vat-data';
 import { swapExact } from '../../../src/contractSupport/index.js';
 import {
   InvitationShape,
@@ -32,7 +34,7 @@ const prepare = async (zcf, _privateArgs, instanceBaggage) => {
   // TODO the exerciseOption offer handler that this makes is an object rather
   // than a function for now only because we do not yet support durable
   // functions.
-  const makeExerciser = prepareFarClass(
+  const makeExerciser = prepareExoClass(
     instanceBaggage,
     'makeExerciserKindHandle',
     OfferHandlerI,
@@ -81,7 +83,7 @@ const prepare = async (zcf, _privateArgs, instanceBaggage) => {
     makeInvitation: M.call().returns(M.eref(InvitationShape)),
   });
 
-  const creatorFacet = prepareFarInstance(
+  const creatorFacet = prepareExo(
     instanceBaggage,
     'creatorFacet',
     CCallCreatorI,


### PR DESCRIPTION
Fixes https://github.com/endojs/endo/issues/1193 .

@dtribble and I were brainstorming name alternatives to `FarClass` (which we both hate for somewhat different reasons). There are three salient differences from normal object programming, where `FarClass` only suggests the first and third. 
   * It is a remotable, meaning it is exposed to messages from outside the vat (hence "Far")
   * Related, it is protected by an interfaceGuard that does the first type-like phase of input validation
   * It is programmed in a class-like manner, with inline methods in the concise-method syntax, accepting their instance-specific access via their `this` binding (hence "Class")

We also need to name the instance case, and `FarInstance` is way too awkward. The instance case has the first two features but not the third.

New aha: "Exo" does double duty. 
   * As a prefix meaning "outside", it suggests the remotable meaning. That was why I suggested Exo in the first place.
   * It lets us introduce the metaphor of the [ExoSkeleton](https://en.wikipedia.org/wiki/Exoskeleton) without being confused with the exoskeleton itself. "An exo is a creature with an exoskeleton" is a memorable explanation, even if there is no RL noun "Exo".

Also
   * It is short, so for the class case "ExoClass" still works.
   * It is distinct from our current "Far" and so the "Instance" qualifier isn't needed for the protective instance case.

But this last bullet (distinct from "Far") means that it isn't an answer to our first search for a term, since it doesn't cover remotable objects without a protective exoskeleton (currently, "Far objects" and "remote presences"). Oh well. I think the rename is still worth it. 
