### PR TITLE
Deterministic xsnap bundles

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -147,6 +147,7 @@ export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
 
     for (const bundle of bundles) {
       bundle.moduleFormat === 'getExport' ||
+        bundle.moduleFormat === 'nestedEvaluate' ||
         assert.fail(X`unexpected: ${bundle.moduleFormat}`);
       // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       await worker.evaluate(`(${bundle.source}\n)()`.trim());

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -30,8 +30,10 @@ const allValues = async obj =>
 
 const bundleRelative = rel =>
   bundleSource(new URL(rel, import.meta.url).pathname);
-const bundleRelativeGE = rel =>
-  bundleSource(new URL(rel, import.meta.url).pathname, { format: 'getExport' });
+const bundleRelativeCallable = rel =>
+  bundleSource(new URL(rel, import.meta.url).pathname, {
+    format: 'nestedEvaluate',
+  });
 
 /**
  * Build the source bundles for the kernel. makeSwingsetController()
@@ -56,10 +58,10 @@ export async function buildVatAndDeviceBundles() {
     vattp: bundleRelative('../vats/vattp/vat-vattp.js'),
     timer: bundleRelative('../vats/timer/vat-timer.js'),
 
-    lockdown: bundleRelativeGE(
+    lockdown: bundleRelativeCallable(
       '../supervisors/subprocess-xsnap/lockdown-subprocess-xsnap.js',
     ),
-    supervisor: bundleRelativeGE(
+    supervisor: bundleRelativeCallable(
       '../supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js',
     ),
   });

--- a/patches/@endo+bundle-source+2.3.1.patch
+++ b/patches/@endo+bundle-source+2.3.1.patch
@@ -1,0 +1,111 @@
+diff --git a/node_modules/@endo/bundle-source/src/index.js b/node_modules/@endo/bundle-source/src/index.js
+index 9eb89aa..f3960c4 100644
+--- a/node_modules/@endo/bundle-source/src/index.js
++++ b/node_modules/@endo/bundle-source/src/index.js
+@@ -32,6 +32,23 @@ const textEncoder = new TextEncoder();
+ const textDecoder = new TextDecoder();
+ const readPowers = makeReadPowers({ fs, url, crypto });
+ 
++// Find the longest common prefix of an array of strings.
++function longestCommonPrefix(strings) {
++  if (strings.length === 0) {
++    return '';
++  }
++  const first = strings[0];
++  const rest = strings.slice(1);
++  let i = 0;
++  for (; i < first.length; i += 1) {
++    const c = first[i];
++    if (rest.some(s => s[i] !== c)) {
++      break;
++    }
++  }
++  return first.slice(0, i);
++}
++
+ function rewriteComment(node, unmapLoc) {
+   node.type = 'CommentBlock';
+   // Within comments...
+@@ -192,6 +209,17 @@ async function bundleNestedEvaluateAndGetExports(
+   });
+   // console.log(output);
+ 
++  // Find the longest common prefix of all the source file names.
++  // We shorten the fileNames to make the bundle output deterministic.
++  const fileNameToUrlPath = fileName =>
++    readPowers.pathToFileURL(pathResolve(startFilename, fileName)).pathname;
++  const pathnames = output.map(({ fileName }) => fileNameToUrlPath(fileName));
++  const longestPrefix = longestCommonPrefix(pathnames);
++
++  // Ensure the prefix ends with a slash.
++  const pathnameEndPos = longestPrefix.lastIndexOf('/');
++  const pathnamePrefix = longestPrefix.slice(0, pathnameEndPos + 1);
++
+   // Create a source bundle.
+   const unsortedSourceBundle = {};
+   let entrypoint;
+@@ -201,8 +229,12 @@ async function bundleNestedEvaluateAndGetExports(
+         throw Error(`unprepared for assets: ${chunk.fileName}`);
+       }
+       const { code, fileName, isEntry } = chunk;
++      const pathname = fileNameToUrlPath(fileName);
++      const shortName = pathname.startsWith(pathnamePrefix)
++        ? pathname.slice(pathnamePrefix.length)
++        : fileName;
+       if (isEntry) {
+-        entrypoint = fileName;
++        entrypoint = shortName;
+       }
+ 
+       const useLocationUnmap =
+@@ -212,7 +244,7 @@ async function bundleNestedEvaluateAndGetExports(
+         sourceMap: chunk.map,
+         useLocationUnmap,
+       });
+-      unsortedSourceBundle[fileName] = transformedCode;
++      unsortedSourceBundle[shortName] = transformedCode;
+ 
+       // console.log(`==== sourceBundle[${fileName}]\n${sourceBundle[fileName]}\n====`);
+     }),
+@@ -250,7 +282,7 @@ async function bundleNestedEvaluateAndGetExports(
+   let sourceMap;
+   let source;
+   if (moduleFormat === 'getExport') {
+-    sourceMap = `//# sourceURL=${resolvedPath}\n`;
++    sourceMap = `//# sourceURL=${DEFAULT_FILE_PREFIX}/${entrypoint}\n`;
+ 
+     if (Object.keys(sourceBundle).length !== 1) {
+       throw Error('unprepared for more than one chunk');
+@@ -292,11 +324,8 @@ ${sourceMap}`;
+     // This function's source code is inlined in the output bundle.
+     // It figures out the exports from a given module filename.
+     const nsBundle = {};
+-    const nestedEvaluate = _src => {
+-      throw Error('need to override nestedEvaluate');
+-    };
+     function computeExports(filename, exportPowers, exports) {
+-      const { require: systemRequire, _log } = exportPowers;
++      const { require: systemRequire, systemEval, _log } = exportPowers;
+       // This captures the endowed require.
+       const match = filename.match(/^(.*)\/[^/]+$/);
+       const thisdir = match ? match[1] : '.';
+@@ -366,7 +395,8 @@ ${sourceMap}`;
+       }
+ 
+       // log('evaluating', code);
+-      return nestedEvaluate(code)(contextRequire, exports);
++      // eslint-disable-next-line no-eval
++      return (systemEval || eval)(code)(contextRequire, exports);
+     }
+ 
+     source = `\
+@@ -387,7 +417,8 @@ function getExportWithNestedEvaluate(filePrefix) {
+ 
+   // Evaluate the entrypoint recursively, seeding the exports.
+   const systemRequire = typeof require === 'undefined' ? undefined : require;
+-  return computeExports(entrypoint, { require: systemRequire }, {});
++  const systemEval = typeof nestedEvaluate === 'undefined' ? undefined : nestedEvaluate;
++  return computeExports(entrypoint, { require: systemRequire, systemEval }, {});
+ }
+ ${sourceMap}`;
+   }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #6298
refs: endojs/endo#1294

## Description

Adopts the changes from endojs/endo#1296 as a patch to the SDK, and enables the use of the improved `nestedEvaluate` to make xsnap lockdown and supervisor bundles not leak local path information.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Reduces an unnecessary information leak of where the bundle was created.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

Backwards compatible.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

We need to test as part of the loadgen or instagoric to see if xsnap snapshots are truly deterministic after this change even if the SDK is built in different locations.
