### PR TITLE
feat(telemetry): concentrate slog handling in separate process

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -194,10 +194,11 @@ Affects: cosmic-swingset
 
 Purpose: intercept the SwingSet LOG file in realtime
 
-Description: when nonempty, use the value as a module specifier.  The module
-will be loaded by `@agoric/telemetry/src/make-slog-sender.js`, via
-`import(moduleSpec)`, and then the exported `makeSlogSender` function creates a
-`slogSender`.  Then, every time a SLOG object is written by SwingSet,
+Description: when nonempty, use the value as a list of module specifiers
+separated by commas `,`.  The modules will be loaded by
+`@agoric/telemetry/src/make-slog-sender.js`, via `import(moduleSpec)`, and
+their exported `makeSlogSender` function called to create an aggregate
+`slogSender`. Every time a SLOG object is written by SwingSet, each module's
 `slogSender(slogObject)` will be called.
 
 The default is `'@agoric/telemetry/src/flight-recorder.js'`, which writes to an

--- a/docs/env.md
+++ b/docs/env.md
@@ -204,6 +204,18 @@ their exported `makeSlogSender` function called to create an aggregate
 The default is `'@agoric/telemetry/src/flight-recorder.js'`, which writes to an
 mmap'ed circular buffer.
 
+## SLOGSENDER_AGENT
+
+Affects: cosmic-swingset
+
+Purpose: selects the agent type used to handle the SwingSet LOG
+
+Description: if empty or `'self'` slog senders are loaded in the same process
+and thread as the SwingSet kernel. If `'process'`, slog senders are loaded in a
+sub-process which receives all SLOG events over an IPC connection.
+
+The default is `'self'`.
+
 ## SWINGSET_WORKER_TYPE
 
 Affects: solo

--- a/packages/SwingSet/test/vat-admin/test-create-vat.js
+++ b/packages/SwingSet/test/vat-admin/test-create-vat.js
@@ -61,13 +61,15 @@ async function doTestSetup(t, doVatAdminRestart = false, enableSlog = false) {
     brokenHang: { bundle: bundles.brokenHangVatBundle },
   };
   let doSlog = false;
-  function slogSender(_, s) {
+  function slogSender(slogObj) {
     if (!doSlog) return;
-    const o = JSON.parse(s);
-    delete o.time;
-    delete o.replay;
-    delete o.crankNum;
-    delete o.deliveryNum;
+    const {
+      time: _1,
+      replay: _2,
+      crankNum: _3,
+      deliveryNum: _4,
+      ...o
+    } = slogObj;
     if (['crank-start', 'deliver', 'syscall'].includes(o.type)) {
       console.log(JSON.stringify(o));
     }

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -392,6 +392,10 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       }
       lastCommitTime = t0;
 
+      await slogSender.forceFlush?.().catch(err => {
+        console.warn('Failed to flush slog sender', err);
+      });
+
       return {
         memoryUsage,
         heapStats,

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -13,7 +13,7 @@ import {
 import { makeBufferedStorage } from '@agoric/swingset-vat/src/lib/storageAPI.js';
 
 import { assert, details as X } from '@agoric/assert';
-import { makeSlogSenderFromModule } from '@agoric/telemetry';
+import { makeSlogSender } from '@agoric/telemetry';
 
 import { makeChainStorageRoot } from '@agoric/vats/src/lib-chainStorage.js';
 import { makeMarshal } from '@endo/marshal';
@@ -318,14 +318,12 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     });
 
     const {
-      SLOGFILE,
-      SLOGSENDER,
       LMDB_MAP_SIZE,
       SWING_STORE_TRACE,
       XSNAP_KEEP_SNAPSHOTS,
       NODE_HEAP_SNAPSHOTS = -1,
     } = env;
-    const slogSender = await makeSlogSenderFromModule(SLOGSENDER, {
+    const slogSender = await makeSlogSender({
       stateDir: stateDBDir,
       env,
       serviceName: TELEMETRY_SERVICE_NAME,
@@ -421,7 +419,6 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       env,
       verboseBlocks: true,
       metricsProvider,
-      slogFile: SLOGFILE,
       slogSender,
       mapSize,
       swingStoreTraceFile,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -52,7 +52,7 @@ async function buildSwingset(
   vatconfig,
   argv,
   env,
-  { debugName = undefined, slogCallbacks, slogFile, slogSender },
+  { debugName = undefined, slogCallbacks, slogSender },
 ) {
   // FIXME: Find a better way to propagate the role.
   process.env.ROLE = argv.ROLE;
@@ -118,7 +118,6 @@ async function buildSwingset(
     {
       env,
       slogCallbacks,
-      slogFile,
       slogSender,
     },
   );
@@ -213,7 +212,6 @@ export async function launch({
   debugName = undefined,
   verboseBlocks = false,
   metricsProvider = DEFAULT_METER_PROVIDER,
-  slogFile = undefined,
   slogSender,
   mapSize = DEFAULT_LMDB_MAP_SIZE,
   swingStoreTraceFile,
@@ -272,7 +270,6 @@ export async function launch({
     {
       debugName,
       slogCallbacks,
-      slogFile,
       slogSender,
     },
   );

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -9,7 +9,7 @@ import {
 
 import anylogger from 'anylogger';
 
-import { makeSlogSenderFromModule } from '@agoric/telemetry';
+import { makeSlogSender } from '@agoric/telemetry';
 
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { assert, details as X } from '@agoric/assert';
@@ -91,9 +91,9 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     serviceName: TELEMETRY_SERVICE_NAME,
   });
 
-  const { SLOGFILE, SLOGSENDER, LMDB_MAP_SIZE } = process.env;
+  const { LMDB_MAP_SIZE } = env;
   const mapSize = (LMDB_MAP_SIZE && parseInt(LMDB_MAP_SIZE, 10)) || undefined;
-  const slogSender = await makeSlogSenderFromModule(SLOGSENDER, {
+  const slogSender = await makeSlogSender({
     stateDir: stateDBdir,
     serviceName: TELEMETRY_SERVICE_NAME,
     env,
@@ -119,7 +119,6 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     argv,
     debugName: GCI,
     metricsProvider,
-    slogFile: SLOGFILE,
     slogSender,
     mapSize,
   });

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -36,6 +36,7 @@ DOCKER_VOLUMES="$AGORIC_SDK_PATH:/usr/src/agoric-sdk" \
 
 # Go ahead and bootstrap with detailed debug logging.
 SLOGSENDER=@agoric/telemetry/src/flight-recorder.js,@agoric/telemetry/src/otel-trace.js \
+SLOGSENDER_AGENT=process \
 AG_COSMOS_START_ARGS="--log_level=info --trace-store=.ag-chain-cosmos/data/kvstore-trace" \
 VAULT_FACTORY_CONTROLLER_ADDR="$SOLO_ADDR" \
 CHAIN_BOOTSTRAP_VAT_CONFIG="$VAT_CONFIG" \

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -35,7 +35,7 @@ DOCKER_VOLUMES="$AGORIC_SDK_PATH:/usr/src/agoric-sdk" \
 "$thisdir/setup.sh" init --noninteractive
 
 # Go ahead and bootstrap with detailed debug logging.
-SLOGSENDER=@agoric/telemetry/src/otel-and-flight-recorder.js \
+SLOGSENDER=@agoric/telemetry/src/flight-recorder.js,@agoric/telemetry/src/otel-trace.js \
 AG_COSMOS_START_ARGS="--log_level=info --trace-store=.ag-chain-cosmos/data/kvstore-trace" \
 VAULT_FACTORY_CONTROLLER_ADDR="$SOLO_ADDR" \
 CHAIN_BOOTSTRAP_VAT_CONFIG="$VAT_CONFIG" \

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -468,6 +468,7 @@ show-config      display the client connection parameters
         'VAULT_FACTORY_CONTROLLER_ADDR',
         'CHAIN_BOOTSTRAP_VAT_CONFIG',
         'SLOGSENDER',
+        'SLOGSENDER_AGENT',
         'XSNAP_TEST_RECORD',
         'SWING_STORE_TRACE',
         'XSNAP_KEEP_SNAPSHOTS',

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -17,10 +17,7 @@ import anylogger from 'anylogger';
 // import djson from 'deterministic-json';
 
 import { assert, details as X } from '@agoric/assert';
-import {
-  makeSlogSenderFromModule,
-  getTelemetryProviders,
-} from '@agoric/telemetry';
+import { makeSlogSender, getTelemetryProviders } from '@agoric/telemetry';
 import {
   loadSwingsetConfigFile,
   buildCommand,
@@ -177,16 +174,10 @@ const buildSwingset = async (
   const { metricsProvider = DEFAULT_METER_PROVIDER } = getTelemetryProviders({
     console,
     env,
-    serviceName: 'solo',
+    serviceName: TELEMETRY_SERVICE_NAME,
   });
 
-  const {
-    SLOGFILE: slogFile,
-    SLOGSENDER,
-    LMDB_MAP_SIZE,
-    SWING_STORE_TRACE,
-    XSNAP_KEEP_SNAPSHOTS,
-  } = env;
+  const { LMDB_MAP_SIZE, SWING_STORE_TRACE, XSNAP_KEEP_SNAPSHOTS } = env;
   const mapSize = (LMDB_MAP_SIZE && parseInt(LMDB_MAP_SIZE, 10)) || undefined;
 
   const defaultTraceFile = path.resolve(kernelStateDBDir, 'store-trace.log');
@@ -230,7 +221,7 @@ const buildSwingset = async (
     }
     await initializeSwingset(config, argv, hostStorage);
   }
-  const slogSender = await makeSlogSenderFromModule(SLOGSENDER, {
+  const slogSender = await makeSlogSender({
     stateDir: kernelStateDBDir,
     serviceName: TELEMETRY_SERVICE_NAME,
     env,
@@ -238,7 +229,7 @@ const buildSwingset = async (
   const controller = await makeSwingsetController(
     hostStorage,
     deviceEndowments,
-    { env, slogCallbacks, slogFile, slogSender },
+    { env, slogCallbacks, slogSender },
   );
 
   const { crankScheduler } = exportKernelStats({

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -22,6 +22,7 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
+    "@agoric/internal": "^0.2.0",
     "@agoric/store": "^0.8.0",
     "@endo/init": "^0.5.48",
     "@opentelemetry/api": "^1.0.0",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -25,6 +25,7 @@
     "@agoric/internal": "^0.2.0",
     "@agoric/store": "^0.8.0",
     "@endo/init": "^0.5.48",
+    "@endo/stream": "^0.3.17",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/exporter-prometheus": "^0.27.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.27.0",

--- a/packages/telemetry/src/all.js
+++ b/packages/telemetry/src/all.js
@@ -1,24 +1,3 @@
 // @ts-check
-import { makeSlogSender as makeFlightRecorderSlogSender } from './flight-recorder.js';
-import { makeSlogSender as makeOtelSlogSender } from './otel-trace.js';
 
-export const makeSlogSender = async opts => {
-  const senders = await Promise.all([
-    makeFlightRecorderSlogSender(opts),
-    makeOtelSlogSender(opts),
-  ]);
-
-  const filteredSenders = senders.filter(Boolean);
-  if (!filteredSenders.length) {
-    return undefined;
-  }
-  const slogSender = (...args) => {
-    for (const sender of filteredSenders) {
-      sender?.(...args);
-    }
-  };
-  return Object.assign(slogSender, {
-    forceFlush: () =>
-      Promise.all(filteredSenders.map(sender => sender?.forceFlush?.())),
-  });
-};
+export { makeSlogSender } from './otel-and-flight-recorder.js';

--- a/packages/telemetry/src/index.js
+++ b/packages/telemetry/src/index.js
@@ -7,6 +7,20 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 export * from './make-slog-sender.js';
 
+/**
+ * @typedef {((obj: {}, jsonObj?: string | undefined) => void) & {
+ *  usesJsonObject?: boolean;
+ *  forceFlush?: () => Promise<void>;
+ * }} SlogSender
+ */
+/**
+ * @typedef {MakeSlogSenderCommonOptions & Record<string, unknown>} MakeSlogSenderOptions
+ * @typedef {object} MakeSlogSenderCommonOptions
+ * @property {Record<string, string | undefined>} [env]
+ * @property {string} [stateDir]
+ * @property {string} [serviceName]
+ */
+
 export const getResourceAttributes = ({
   env = process.env,
   serviceName = '',

--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -7,7 +7,7 @@ import zlib from 'zlib';
 import readline from 'readline';
 import process from 'process';
 
-import { makeSlogSenderFromModule } from './make-slog-sender.js';
+import { makeSlogSender } from './make-slog-sender.js';
 
 const LINE_COUNT_TO_FLUSH = 10000;
 const ELAPSED_MS_TO_FLUSH = 3000;
@@ -22,7 +22,7 @@ async function run() {
 
   if (!SLOGSENDER) {
     console.log(
-      `SLOGSENDER=@agoric/telemetry/src/all.js ingest-slog [SLOGFILE[.gz]]`,
+      `SLOGSENDER=@agoric/telemetry/src/otel-trace.js ingest-slog [SLOGFILE[.gz]]`,
     );
     console.log(` - sends slogfile via telemetry`);
     process.exitCode = 1;
@@ -30,9 +30,10 @@ async function run() {
   }
 
   const [slogFile] = args;
-  const slogSender = await makeSlogSenderFromModule(SLOGSENDER, {
+  const slogSender = await makeSlogSender({
     serviceName,
     stateDir: '.',
+    env: process.env,
   });
 
   if (!slogSender) {
@@ -123,10 +124,10 @@ async function run() {
         time: virtualTime,
         actualTime: obj.time,
       };
-      slogSender(virtualTimeObj, JSON.stringify(virtualTimeObj));
+      slogSender(virtualTimeObj);
     } else {
       // Use the original.
-      slogSender(obj, line);
+      slogSender(obj);
     }
   }
 

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -1,32 +1,128 @@
 // @ts-check
 import path from 'path';
 import tmp from 'tmp';
+import { PromiseAllOrErrors } from '@agoric/internal';
+import { serializeSlogObj } from './serialize-slog-obj.js';
 
-export const DEFAULT_SLOG_SENDER_MODULE =
+export const DEFAULT_SLOGSENDER_MODULE =
   '@agoric/telemetry/src/flight-recorder.js';
+export const SLOGFILE_SENDER_MODULE = '@agoric/telemetry/src/slog-file.js';
 
-export const makeSlogSenderFromModule = async (
-  slogSenderModule = DEFAULT_SLOG_SENDER_MODULE,
-  makerOpts = {},
-) => {
-  if (!slogSenderModule) {
+/** @typedef {import('./index.js').SlogSender} SlogSender */
+
+/**
+ *
+ * @param {import('./index.js').MakeSlogSenderOptions} opts
+ */
+export const makeSlogSender = async (opts = {}) => {
+  const { env = {}, stateDir: stateDirOption, ...otherOpts } = opts;
+  const { SLOGSENDER = DEFAULT_SLOGSENDER_MODULE, ...otherEnv } = env;
+
+  const slogSenderModules = SLOGSENDER.split(',').map(modulePath =>
+    modulePath.startsWith('.')
+      ? // Resolve relative to the current working directory.
+        path.resolve(modulePath)
+      : modulePath,
+  );
+  if (
+    otherEnv.SLOGFILE &&
+    !slogSenderModules.includes(SLOGFILE_SENDER_MODULE)
+  ) {
+    slogSenderModules.push(SLOGFILE_SENDER_MODULE);
+  }
+
+  if (!slogSenderModules.length) {
     return undefined;
   }
 
-  if (slogSenderModule.startsWith('.')) {
-    // Resolve relative to the current working directory.
-    slogSenderModule = path.resolve(slogSenderModule);
+  console.warn('Loading slog sender modules:', ...slogSenderModules);
+
+  const makersInfo = await Promise.all(
+    slogSenderModules.map(async moduleIdentifier =>
+      import(moduleIdentifier)
+        .then(
+          /** @param {{makeSlogSender: (opts: {}) => Promise<SlogSender | undefined>}} module */ ({
+            makeSlogSender: maker,
+          }) =>
+            typeof maker === 'function'
+              ? { maker, moduleIdentifier }
+              : Promise.reject(
+                  new Error(`No 'makeSlogSender' function exported by module`),
+                ),
+        )
+        .catch(err => {
+          console.warn(
+            `Failed to load slog sender from ${moduleIdentifier}.`,
+            err,
+          );
+          return undefined;
+        }),
+    ),
+  );
+
+  if (!makersInfo.filter(Boolean).length) {
+    return undefined;
   }
 
-  console.warn(`Loading makeSlogSender from ${slogSenderModule}`);
-  const { makeSlogSender: maker } = await import(slogSenderModule);
-  if (typeof maker !== 'function') {
-    throw Error(`${slogSenderModule} did not export a makeSlogSender function`);
-  }
+  let stateDir = stateDirOption;
 
-  const { stateDir = tmp.dirSync().name } = makerOpts;
-  if (stateDir !== makerOpts.stateDir) {
+  if (stateDir === undefined) {
+    stateDir = tmp.dirSync().name;
     console.warn(`Using ${stateDir} for stateDir`);
   }
-  return maker({ ...makerOpts, stateDir });
+
+  const senders = await Promise.all(
+    makersInfo.map(async makerInfo => {
+      if (!makerInfo || makerInfo.maker === makeSlogSender) {
+        return undefined;
+      }
+      const { maker, moduleIdentifier } = makerInfo;
+      return maker({
+        ...otherOpts,
+        stateDir,
+        env: { SLOGSENDER: moduleIdentifier, ...otherEnv },
+      });
+    }),
+  ).then(
+    potentialSenders =>
+      /** @type {SlogSender[]} */ (potentialSenders.filter(Boolean)),
+  );
+
+  if (!senders.length) {
+    return undefined;
+  } else if (senders.length === 1) {
+    const sender = senders[0];
+    const { usesJsonObject = true } = sender;
+    return !usesJsonObject
+      ? sender
+      : Object.assign(
+          (slogObj, jsonObj = serializeSlogObj(slogObj)) =>
+            sender(slogObj, jsonObj),
+          sender,
+        );
+  } else {
+    // Optimize creating a JSON serialization only if needed
+    // by any of the sender modules
+    const hasSenderUsingJsonObj = senders.some(
+      ({ usesJsonObject = true }) => usesJsonObject,
+    );
+    const getJsonObj = hasSenderUsingJsonObj
+      ? serializeSlogObj
+      : () => undefined;
+    /** @type {SlogSender} */
+    const slogSender = (slogObj, jsonObj = getJsonObj(slogObj)) => {
+      for (const sender of senders) {
+        try {
+          sender(slogObj, jsonObj);
+        } catch (err) {
+          console.error('WARNING: slog sender error', err);
+        }
+      }
+    };
+    return Object.assign(slogSender, {
+      forceFlush: async () =>
+        PromiseAllOrErrors(senders.map(sender => sender.forceFlush?.())),
+      usesJsonObject: hasSenderUsingJsonObj,
+    });
+  }
 };

--- a/packages/telemetry/src/otel-and-flight-recorder.js
+++ b/packages/telemetry/src/otel-and-flight-recorder.js
@@ -1,13 +1,18 @@
-import { makeSlogSender as makeFlightRecorderSlogSender } from './flight-recorder.js';
-import { makeSlogSender as makeOtelSlogSender } from './otel-trace.js';
+import { makeSlogSender as makeSlogSenderFromEnv } from './make-slog-sender.js';
 
 export const makeSlogSender = async opts => {
-  const [flightRecorderSlogSender, otelSlogSender] = await Promise.all([
-    makeFlightRecorderSlogSender(opts),
-    makeOtelSlogSender(opts),
-  ]);
-  return obj => {
-    flightRecorderSlogSender(obj);
-    otelSlogSender(obj);
-  };
+  const { SLOGFILE: _1, SLOGSENDER: _2, ...otherEnv } = opts.env || {};
+
+  console.warn(
+    'Deprecated slog sender, please use SLOGSENDER=@agoric/telemetry/src/flight-recorder.js,@agoric/telemetry/src/otel-trace.js',
+  );
+
+  const senderModules = ['./otel-trace.js', './flight-recorder.js']
+    .map(identifier => import.meta.resolve(identifier))
+    .join(',');
+
+  return makeSlogSenderFromEnv({
+    ...opts,
+    env: { ...otherEnv, SLOGSENDER: senderModules },
+  });
 };

--- a/packages/telemetry/src/otel-trace.js
+++ b/packages/telemetry/src/otel-trace.js
@@ -65,5 +65,6 @@ export const makeSlogSender = async opts => {
 
   return Object.assign(slogSender, {
     forceFlush: () => tracingProvider.forceFlush(),
+    usesJsonObject: false,
   });
 };

--- a/packages/telemetry/src/serialize-slog-obj.js
+++ b/packages/telemetry/src/serialize-slog-obj.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+export const serializeSlogObj = slogObj =>
+  JSON.stringify(slogObj, (_, arg) =>
+    typeof arg === 'bigint' ? Number(arg) : arg,
+  );

--- a/packages/telemetry/src/slog-file.js
+++ b/packages/telemetry/src/slog-file.js
@@ -1,0 +1,63 @@
+import { createWriteStream } from 'fs';
+import { open } from 'fs/promises';
+import { fsStreamReady, makeAggregateError } from '@agoric/internal';
+import { serializeSlogObj } from './serialize-slog-obj.js';
+
+const noPath = /** @type {import('fs').PathLike} */ (
+  /** @type {unknown} */ (undefined)
+);
+
+// @ts-check
+/** @param {import('./index.js').MakeSlogSenderOptions} opts */
+export const makeSlogSender = async ({ env: { SLOGFILE } = {} } = {}) => {
+  if (!SLOGFILE) {
+    return undefined;
+  }
+
+  const handle = await open(SLOGFILE, 'a');
+
+  const stream = createWriteStream(noPath, { fd: handle.fd });
+  await fsStreamReady(stream);
+
+  let flushed = Promise.resolve();
+
+  const writeNewLine = () => {
+    const written = new Promise((resolve, reject) => {
+      stream.write('\n', err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+    flushed = flushed.then(
+      () => written,
+      async err =>
+        Promise.reject(
+          written.then(
+            () => err,
+            writtenError => makeAggregateError([err, writtenError]),
+          ),
+        ),
+    );
+  };
+
+  const slogSender = (slogObj, jsonObj = serializeSlogObj(slogObj)) => {
+    stream.write(jsonObj);
+    writeNewLine();
+  };
+
+  return Object.assign(slogSender, {
+    forceFlush: async () => {
+      await flushed;
+      await handle.sync().catch(err => {
+        if (err.code === 'EINVAL') {
+          return;
+        }
+        throw err;
+      });
+    },
+    usesJsonObject: true,
+  });
+};

--- a/packages/telemetry/src/slog-sender-pipe-entrypoint.js
+++ b/packages/telemetry/src/slog-sender-pipe-entrypoint.js
@@ -1,0 +1,116 @@
+/* global process */
+// @ts-check
+import '@endo/init';
+
+import anylogger from 'anylogger';
+import { makeShutdown } from './shutdown.js';
+
+import { makeSlogSender } from './make-slog-sender.js';
+
+const logger = anylogger('slog-sender-pipe-entrypoint');
+
+/** @type {(msg: import('./slog-sender-pipe.js').SlogSenderPipeWaitReplies) => void} */
+const send = Function.prototype.bind.call(process.send, process);
+
+/**
+ * @typedef {object} InitMessage
+ * @property {'init'} type
+ * @property {import('./index.js').MakeSlogSenderOptions} options
+ */
+/**
+ * @typedef {object} SendMessage
+ * @property {'send'} type
+ * @property {object} obj
+ */
+/**
+ * @typedef {object} FlushMessage
+ * @property {'flush'} type
+ */
+/** @typedef {InitMessage | FlushMessage} SlogSenderPipeWaitMessages */
+/** @typedef {SlogSenderPipeWaitMessages | SendMessage } SlogSenderPipeMessages */
+
+const main = async () => {
+  /** @type {import('./index.js').SlogSender | undefined} */
+  let slogSender;
+
+  const { registerShutdown } = makeShutdown(false);
+
+  registerShutdown(async () => {
+    await slogSender?.forceFlush?.();
+    process.disconnect?.();
+  });
+
+  /** @param {import('./index.js').MakeSlogSenderOptions} opts */
+  const init = async ({ env, ...otherOpts } = {}) => {
+    if (slogSender) {
+      assert.fail('Already initialized');
+    }
+
+    slogSender = await makeSlogSender({
+      ...otherOpts,
+      env: Object.assign(Object.create(process.env), env),
+    });
+
+    return !!slogSender;
+  };
+
+  const flush = async () => {
+    if (!slogSender) {
+      assert.fail('No sender available');
+    }
+
+    await slogSender.forceFlush?.();
+  };
+
+  process.on(
+    'message',
+    /** @param {SlogSenderPipeMessages} msg */ msg => {
+      if (!msg || typeof msg !== 'object') {
+        logger.warn('received invalid message', msg);
+        return;
+      }
+
+      switch (msg.type) {
+        case 'init': {
+          void init(msg.options).then(
+            hasSender => {
+              send({ type: 'initReply', hasSender });
+            },
+            error => {
+              send({ type: 'initReply', hasSender: false, error });
+            },
+          );
+          break;
+        }
+        case 'flush': {
+          void flush().then(
+            () => {
+              send({ type: 'flushReply' });
+            },
+            error => {
+              send({ type: 'flushReply', error });
+            },
+          );
+          break;
+        }
+        case 'send': {
+          if (!slogSender) {
+            logger.warn('received send with no sender available');
+          } else {
+            slogSender(msg.obj);
+          }
+          break;
+        }
+        default: {
+          // @ts-expect-error exhaustive type check
+          logger.warn('received unknown message type', msg.type);
+        }
+      }
+    },
+  );
+};
+
+main().catch(e => {
+  logger.error(e);
+  process.exitCode = 1;
+});

--- a/packages/telemetry/src/slog-sender-pipe.js
+++ b/packages/telemetry/src/slog-sender-pipe.js
@@ -1,0 +1,186 @@
+// @ts-check
+import { fork } from 'child_process';
+import path from 'path';
+import anylogger from 'anylogger';
+
+import { makeQueue } from '@endo/stream';
+
+import { makeShutdown } from './shutdown.js';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const logger = anylogger('slog-sender-pipe');
+
+/**
+ * @template {any[]} T
+ * @template R
+ * @param {(...args: T) => Promise<R>} operation
+ */
+const withMutex = operation => {
+  /** @type {import('@endo/stream').AsyncQueue<void>} */
+  const mutex = makeQueue();
+  mutex.put(Promise.resolve());
+  /** @param {T} args */
+  return async (...args) => {
+    await mutex.get();
+    const result = operation(...args);
+    mutex.put(result.then(() => {}));
+    return result;
+  };
+};
+
+/**
+ * @typedef {object} SlogSenderInitReply
+ * @property {'initReply'} type
+ * @property {boolean} hasSender
+ * @property {Error} [error]
+ */
+/**
+ * @typedef {object} SlogSenderFlushReply
+ * @property {'flushReply'} type
+ * @property {Error} [error]
+ */
+/** @typedef {SlogSenderInitReply | SlogSenderFlushReply} SlogSenderPipeWaitReplies */
+
+/** @param {import('.').MakeSlogSenderOptions} opts */
+export const makeSlogSender = async opts => {
+  const { registerShutdown } = makeShutdown();
+  const cp = fork(path.join(dirname, 'slog-sender-pipe-entrypoint.js'), [], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+    serialization: 'advanced',
+  });
+  // logger.log('done fork');
+
+  const pipeSend = withMutex(
+    /**
+     * @template {{type: string}} T
+     * @param {T} msg
+     */
+    msg =>
+      /** @type {Promise<void>} */ (
+        new Promise((resolve, reject) => {
+          cp.send(msg, err => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          });
+        })
+      ),
+  );
+
+  /**
+   * @typedef {{
+   *   init: {
+   *     message: import('./slog-sender-pipe-entrypoint').InitMessage;
+   *     reply: SlogSenderInitReply;
+   *   };
+   *   flush: {
+   *     message: import('./slog-sender-pipe-entrypoint').FlushMessage;
+   *     reply: SlogSenderFlushReply;
+   *   };
+   * }} SlogSenderWaitMessagesAndReplies
+   */
+
+  /** @typedef {keyof SlogSenderWaitMessagesAndReplies} SendWaitCommands */
+  /**
+   * @template {SlogSenderPipeWaitReplies} T
+   * @typedef {Omit<T, 'type' | 'error'>} ReplyPayload
+   */
+
+  /** @type {import('@endo/stream').AsyncQueue<SlogSenderPipeWaitReplies>} */
+  const sendWaitQueue = makeQueue();
+  /** @type {SendWaitCommands | undefined} */
+  let sendWaitType;
+
+  const sendWaitReply = withMutex(
+    /**
+     * @template {SendWaitCommands} T
+     * @param {T} type
+     * @param {Omit<SlogSenderWaitMessagesAndReplies[T]["message"], 'type'>} payload
+     * @returns {Promise<ReplyPayload<SlogSenderWaitMessagesAndReplies[T]["reply"]>>}
+     */
+    async (type, payload) => {
+      !sendWaitType || assert.fail('Invalid mutex state');
+
+      const msg = { ...payload, type };
+
+      sendWaitType = type;
+      return pipeSend(msg)
+        .then(async () => sendWaitQueue.get())
+        .then(
+          /** @param {SlogSenderWaitMessagesAndReplies[T]["reply"]} reply */ ({
+            type: replyType,
+            error,
+            ...rest
+          }) => {
+            replyType === `${type}Reply` ||
+              assert.fail(`Unexpected reply ${replyType}`);
+            if (error) {
+              throw error;
+            }
+            return rest;
+          },
+        )
+        .finally(() => {
+          sendWaitType = undefined;
+        });
+    },
+  );
+
+  cp.on(
+    'message',
+    /** @param { SlogSenderPipeWaitReplies } msg */
+    msg => {
+      // logger.log('received', msg);
+      if (
+        !msg ||
+        typeof msg !== 'object' ||
+        msg.type !== `${sendWaitType}Reply`
+      ) {
+        logger.warn('Received unexpected message', msg);
+        return;
+      }
+
+      sendWaitQueue.put(msg);
+    },
+  );
+
+  const flush = async () => sendWaitReply('flush', {});
+  /** @param {import('./index.js').MakeSlogSenderOptions} options */
+  const init = async options => sendWaitReply('init', { options });
+
+  const send = obj => {
+    void pipeSend({ type: 'send', obj });
+  };
+
+  registerShutdown(async () => {
+    // logger.log('shutdown');
+    if (!cp.connected) {
+      return;
+    }
+
+    await flush();
+    cp.disconnect();
+  });
+
+  const { hasSender } = await init(opts).catch(err => {
+    cp.disconnect();
+    throw err;
+  });
+
+  if (!hasSender) {
+    cp.disconnect();
+    return undefined;
+  }
+
+  const slogSender = send;
+  return Object.assign(slogSender, {
+    forceFlush: async () => {
+      await flush();
+    },
+    usesJsonObject: false,
+  });
+};


### PR DESCRIPTION
closes: #6304

## Description

This change consolidates all slog event handling in the `telemetry` package, including serialization and slog file writing. It also adds a new option to perform slog event processing in a sub-process, leaving only the slog object creation and a minimal serialization (using v8 structured cloning) in the main kernel process.

Added forced flushing support to the slog file "sender", with a trigger after commiting every block to make sure the slog data is not lost in case of unclean termination.

### Security Considerations

None I can think of

### Documentation Considerations

Updated the `env.md` describing the new `SLOGSENDER_AGENT` option, and the change to the existing `SLOGSENDER` option.

### Testing Considerations

Updated the integration deployment test to use the new sub-process processing. Tested locally with the loadgen.
