### PR TITLE
fix(agoric-cli): don't crash on non-contract offers

### DIFF
--- a/packages/agoric-cli/src/lib/format.js
+++ b/packages/agoric-cli/src/lib/format.js
@@ -100,38 +100,49 @@ export const offerStatusTuples = (state, agoricNames) => {
     [...brands.values()],
   );
   const fmtRecord = r =>
-    Object.fromEntries(
-      Object.entries(r).map(([kw, amount]) => [kw, fmt(amount)]),
-    );
+    r
+      ? Object.fromEntries(
+          Object.entries(r).map(([kw, amount]) => [kw, fmt(amount)]),
+        )
+      : undefined;
   return Array.from(offerStatuses.values()).map(o => {
     assert(o);
-    assert(o.invitationSpec.source === 'contract');
-    const {
-      invitationSpec: { instance, publicInvitationMaker },
-      proposal: { give, want },
-      payouts,
-    } = o;
-    const entry = Object.entries(agoricNames.instance).find(
-      ([_name, candidate]) => candidate === instance,
-    );
-    const instanceName = entry ? entry[0] : '???';
     let when = '??';
     try {
       when = new Date(o.id).toISOString();
     } catch {
       console.debug('offer id', o.id, 'not a timestamp');
     }
-    return [
-      instanceName,
-      o.id,
-      when,
-      publicInvitationMaker,
-      o.numWantsSatisfied,
-      {
-        give: fmtRecord(give),
-        want: fmtRecord(want),
-        ...(payouts ? { payouts: fmtRecord(payouts) } : {}),
-      },
-    ];
+    const {
+      proposal: { give, want },
+      payouts,
+    } = o;
+    const amounts = {
+      give: fmtRecord(give),
+      want: fmtRecord(want),
+      payouts: fmtRecord(payouts),
+    };
+    switch (o.invitationSpec.source) {
+      case 'contract': {
+        const {
+          invitationSpec: { instance, publicInvitationMaker },
+        } = o;
+        const entry = Object.entries(agoricNames.instance).find(
+          // @ts-expect-error minimarshal types are off by a bit
+          ([_name, candidate]) => candidate === instance,
+        );
+        const instanceName = entry ? entry[0] : '???';
+        return [
+          instanceName,
+          o.id,
+          when,
+          publicInvitationMaker,
+          o.numWantsSatisfied,
+          amounts,
+        ];
+      }
+      default:
+        return ['?', o.id, when, '?', o.numWantsSatisfied, amounts];
+    }
   });
 };

--- a/packages/agoric-cli/src/lib/format.js
+++ b/packages/agoric-cli/src/lib/format.js
@@ -128,7 +128,7 @@ export const offerStatusTuples = (state, agoricNames) => {
           invitationSpec: { instance, publicInvitationMaker },
         } = o;
         const entry = Object.entries(agoricNames.instance).find(
-          // @ts-expect-error minimarshal types are off by a bit
+          // @ts-ignore minimarshal types are off by a bit
           ([_name, candidate]) => candidate === instance,
         );
         const instanceName = entry ? entry[0] : '???';


### PR DESCRIPTION
closes: #6329

### Testing Considerations

tested manually:

```
$ AGORIC_NET=loadtest,agoricloadtest-31 agoric wallet show --from agoric1pd5xgjnkp5ls6jnfq85qm60lc2glu3wdv4nf45
...
{
  "balances": [

  ],
  "offers": [
    ["?",1664235240949,"2022-09-26T23:34:00.949Z","?",null,{}]
  ]
}
```

