### PR TITLE
feat: run CI and mergify on release-pismo

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -3,7 +3,10 @@
 #  Require branches to be up to date before merging
 on:
   push:
-    branches: [master] # $default-branch
+    branches:
+      # $default-branch
+      - master
+      - release-pismo
 
 jobs:
   build:

--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -52,10 +52,17 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: check credentials
         run: npm whoami
-      - name: publish to NPM dev tag
+      - name: publish to NPM tag
         run: |
+          if [ "${{ github.ref_name }}" = "release-pismo" ]; then
+            # A pismo dev release.
+            TAG=pismo-dev
+          else
+            # Just a dev release.
+            TAG=dev
+          fi
           yarn lerna publish --conventional-prerelease --canary --exact \
-            --dist-tag=dev --preid=dev-$(git rev-parse --short=7 HEAD) \
+            --dist-tag=$TAG --preid=$TAG-$(git rev-parse --short=7 HEAD) \
             --no-push --no-verify-access --yes
       - name: notify on failure
         if: failure()

--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -5,7 +5,10 @@ name: ag-solo on xs
 
 on:
   push:
-    branches: [master] # $default-branch
+    branches:
+      # $default-branch
+      - master
+      - release-pismo
 
 jobs:
   xs-build:

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - release-pismo
       - beta
     tags:
       - '@agoric/sdk@*'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,10 @@ name: Build release Docker Images
 
 on:
   push:
-    branches: [master] # $default-branch
+    branches:
+      # $default-branch
+      - master
+      - release-pismo
     tags:
       - '@agoric/sdk@*'
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,11 +61,17 @@ jobs:
           SDK_TAG=$(echo "${{ github.ref_name }}" | sed -ne 's!^@agoric/sdk@!!p')
           case $SDK_TAG in
             "")
-              # Just a dev release.
-              DOCKER_TAGS=dev
+              if [ "${{ github.ref_name }}" = "release-pismo" ]; then
+                # A pismo dev release.
+                DOCKER_TAGS=pismo-dev
+              else
+                # Just a dev release.
+                DOCKER_TAGS=dev
+              fi
               ;;
             *)
               # A tagged SDK release.
+              # The commit may or may not be a descendant of the current master branch
               DOCKER_TAGS="latest $SDK_TAG"
               ;;
           esac

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -3,7 +3,10 @@ on:
   push:
     tags:
       - v*
-    branches: [master] # $default-branch
+    branches:
+      # $default-branch
+      - master
+      - release-pismo
   pull_request:
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - release-pismo
       - beta
   pull_request:
     types:

--- a/.github/workflows/pre-check-integration.yml
+++ b/.github/workflows/pre-check-integration.yml
@@ -13,7 +13,11 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'force:integration') || (
-        (github.event.pull_request.base.ref == 'master' || github.event.pull_request.base.ref == 'beta') &&
+        (
+          github.event.pull_request.base.ref == 'master' ||
+          github.event.pull_request.base.ref == 'release-pismo' ||
+          github.event.pull_request.base.ref == 'beta'
+        ) &&
         github.event.pull_request.draft == false &&
         (
           contains(github.event.pull_request.labels.*.name, 'automerge:squash') || 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -22,10 +22,33 @@ queue_rules:
       #    - check-success=getting-started (local-npm)
       #    - check-neutral=getting-started (local-npm)
       #    - check-skipped=getting-started (local-npm)
+  - name: pismo
+    conditions:
+      - base=release-pismo
+      # Require integration tests before merging only
+      - or:
+          - label=bypass:integration
+          - check-success=deployment-test
+          - check-neutral=deployment-test
+          - check-skipped=deployment-test
+      - or:
+          - label=bypass:integration
+          - check-skipped=getting-started
+          - check-success=getting-started (link-cli)
+          - check-neutral=getting-started (link-cli)
+          - check-skipped=getting-started (link-cli)
+      # FIXME: Enable this section to validate NPM deploys...
+      #- or:
+      #    - label=bypass:integration
+      #    - check-skipped=getting-started
+      #    - check-success=getting-started (local-npm)
+      #    - check-neutral=getting-started (local-npm)
+      #    - check-skipped=getting-started (local-npm)
 
 pull_request_rules:
   - name: merge to master
     conditions:
+      - base=master
       - label=automerge:merge
       - or:
           - check-success=wait-integration-pre-checks
@@ -43,6 +66,7 @@ pull_request_rules:
         method: merge
   - name: rebase updates then merge to master
     conditions:
+      - base=master
       - label=automerge:rebase
       - or:
           - check-success=wait-integration-pre-checks
@@ -61,6 +85,7 @@ pull_request_rules:
         update_method: rebase
   - name: squash to master
     conditions:
+      - base=master
       - label=automerge:squash
       - or:
           - check-success=wait-integration-pre-checks
@@ -75,4 +100,59 @@ pull_request_rules:
     actions:
       queue:
         name: main
+        method: squash
+  - name: merge to release-pismo
+    conditions:
+      - base=release-pismo
+      - label=automerge:merge
+      - or:
+          - check-success=wait-integration-pre-checks
+          - label=bypass:integration
+      - or:
+          - and: # breakage succeeds like we thought
+              - check-success=breakage
+              - -label=proto:expect-breakage
+          - and: # breakage fails like we thought
+              - check-failure=breakage
+              - label=proto:expect-breakage
+    actions:
+      queue:
+        name: pismo
+        method: merge
+  - name: rebase updates then merge to release-pismo
+    conditions:
+      - base=release-pismo
+      - label=automerge:rebase
+      - or:
+          - check-success=wait-integration-pre-checks
+          - label=bypass:integration
+      - or:
+          - and: # breakage succeeds like we thought
+              - check-success=breakage
+              - -label=proto:expect-breakage
+          - and: # breakage fails like we thought
+              - check-failure=breakage
+              - label=proto:expect-breakage
+    actions:
+      queue:
+        name: pismo
+        method: merge
+        update_method: rebase
+  - name: squash to release-pismo
+    conditions:
+      - base=release-pismo
+      - label=automerge:squash
+      - or:
+          - check-success=wait-integration-pre-checks
+          - label=bypass:integration
+      - or:
+          - and: # breakage succeeds like we thought
+              - check-success=breakage
+              - -label=proto:expect-breakage
+          - and: # breakage fails like we thought
+              - check-failure=breakage
+              - label=proto:expect-breakage
+    actions:
+      queue:
+        name: pismo
         method: squash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-The current `master` branch is supported with security updates.
+The current `master` and `release-pismo` branches are supported with security updates.
 
 ## Coordinated Vulnerability Disclosure
 

--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -4,6 +4,7 @@ NAME := $(shell sed -ne 's/.*"name": "\([^"]*\)".*/\1/p' package.json)
 VERSION := $(shell sed -ne 's/.*"version": "\([^"]*\)".*/\1/p' package.json)
 GIT_COMMIT = $(shell hash=`git rev-parse --short HEAD 2>/dev/null`; if test -n "$$hash"; then echo $$hash`git diff --quiet || echo -dirty`; else cat git-revision.txt; fi)
 PR_TARGET_REPO = ../../.git
+# TODO: figure out how to handle other branches like pismo-release
 PR_TARGET_BRANCH = master
 
 default: all


### PR DESCRIPTION
This should allow up to run the same CI, integration tests and mergify automerge on `release-pismo` as we currently have on `master`
