### PR TITLE
fix: vbank updates for new zero balance

### DIFF
--- a/golang/cosmos/x/vbank/vbank.go
+++ b/golang/cosmos/x/vbank/vbank.go
@@ -74,8 +74,8 @@ type vbankBalanceUpdate struct {
 // getBalanceUpdate returns a bridge message containing the current bank balance
 // for the given addresses each for the specified denominations. Coins are used
 // only to track the set of denoms, not for the particular nonzero amounts.
-func getBalanceUpdate(ctx sdk.Context, keeper Keeper, addressToBalance map[string]sdk.Coins) vm.Jsonable {
-	nentries := len(addressToBalance)
+func getBalanceUpdate(ctx sdk.Context, keeper Keeper, addressToUpdate map[string]sdk.Coins) vm.Jsonable {
+	nentries := len(addressToUpdate)
 	if nentries == 0 {
 		return nil
 	}
@@ -89,7 +89,7 @@ func getBalanceUpdate(ctx sdk.Context, keeper Keeper, addressToBalance map[strin
 
 	// Note that Golang randomises the order of iteration, so we have to sort
 	// below to be deterministic.
-	for address, coins := range addressToBalance {
+	for address, coins := range addressToUpdate {
 		account, err := sdk.AccAddressFromBech32(address)
 		if err != nil {
 			stdlog.Println("Cannot parse address for vbank update", address)

--- a/golang/cosmos/x/vbank/vbank_test.go
+++ b/golang/cosmos/x/vbank/vbank_test.go
@@ -529,18 +529,26 @@ func Test_EndBlock_Events(t *testing.T) {
 
 	events := []abci.Event{
 		{
-			Type: "transfer",
+			Type: "coin_received",
 			Attributes: []abci.EventAttribute{
-				{Key: []byte("recipient"), Value: []byte(addr1)},
-				{Key: []byte("sender"), Value: []byte(addr2)},
+				{Key: []byte("receiver"), Value: []byte(addr1)},
+				{Key: []byte("amount"), Value: []byte("500ubld,600urun,700ushmoo")},
+			},
+		},
+		{
+			Type: "coin_spent",
+			Attributes: []abci.EventAttribute{
+				{Key: []byte("spender"), Value: []byte(addr2)},
 				{Key: []byte("amount"), Value: []byte("500ubld,600urun,700ushmoo")},
 				{Key: []byte("other"), Value: []byte(addr3)},
 			},
 		},
 		{
-			Type: "not a transfer",
+			Type: "something_else",
 			Attributes: []abci.EventAttribute{
-				{Key: []byte("sender"), Value: []byte(addr4)},
+				{Key: []byte("receiver"), Value: []byte(addr4)},
+				{Key: []byte("spender"), Value: []byte(addr4)},
+				{Key: []byte("amount"), Value: []byte("500ubld,600urun,700ushmoo")},
 			},
 		},
 	}
@@ -552,15 +560,22 @@ func Test_EndBlock_Events(t *testing.T) {
 		t.Errorf("EndBlock() got %+v, want empty", updates)
 	}
 
-	wantCalls := []string{
+	wantCalls1 := []string{
 		"GetBalance " + addr1 + " ubld",
 		"GetBalance " + addr1 + " urun",
 		"GetBalance " + addr1 + " ushmoo",
+	}
+	wantCalls2 := []string{
 		"GetBalance " + addr2 + " ubld",
 		"GetBalance " + addr2 + " urun",
 		"GetBalance " + addr2 + " ushmoo",
 	}
-	// TODO: make comparison order-insensitive
+	var wantCalls []string
+	if addr1 < addr2 {
+		wantCalls = append(wantCalls1, wantCalls2...)
+	} else {
+		wantCalls = append(wantCalls2, wantCalls1...)
+	}
 	if !reflect.DeepEqual(bank.calls, wantCalls) {
 		t.Errorf("got calls %v, want {%s}", bank.calls, wantCalls)
 	}

--- a/golang/cosmos/x/vbank/vbank_test.go
+++ b/golang/cosmos/x/vbank/vbank_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/Agoric/agoric-sdk/golang/cosmos/app/params"
@@ -560,22 +561,17 @@ func Test_EndBlock_Events(t *testing.T) {
 		t.Errorf("EndBlock() got %+v, want empty", updates)
 	}
 
-	wantCalls1 := []string{
+	wantCalls := []string{
 		"GetBalance " + addr1 + " ubld",
 		"GetBalance " + addr1 + " urun",
 		"GetBalance " + addr1 + " ushmoo",
-	}
-	wantCalls2 := []string{
 		"GetBalance " + addr2 + " ubld",
 		"GetBalance " + addr2 + " urun",
 		"GetBalance " + addr2 + " ushmoo",
 	}
-	var wantCalls []string
-	if addr1 < addr2 {
-		wantCalls = append(wantCalls1, wantCalls2...)
-	} else {
-		wantCalls = append(wantCalls2, wantCalls1...)
-	}
+	sort.Strings(wantCalls)
+	sort.Strings(bank.calls)
+
 	if !reflect.DeepEqual(bank.calls, wantCalls) {
 		t.Errorf("got calls %v, want {%s}", bank.calls, wantCalls)
 	}

--- a/golang/cosmos/x/vbank/vbank_test.go
+++ b/golang/cosmos/x/vbank/vbank_test.go
@@ -105,8 +105,15 @@ func decodeBalances(encoded []byte) (balances, uint64, error) {
 }
 
 func Test_marshalBalanceUpdate(t *testing.T) {
-	bank := &mockBank{balance: map[string]sdk.Coin{
-		addr1: sdk.NewInt64Coin("moola", 392),
+	bank := &mockBank{balances: map[string]sdk.Coins{
+		addr1: sdk.NewCoins(
+			sdk.NewInt64Coin("foocoin", 123),
+			sdk.NewInt64Coin("barcoin", 456),
+			sdk.NewInt64Coin("moola", 789),
+		),
+		addr2: sdk.NewCoins(
+			sdk.NewInt64Coin("foocoin", 456),
+		),
 	}}
 	keeper, ctx := makeTestKit(nil, bank)
 
@@ -124,17 +131,17 @@ func Test_marshalBalanceUpdate(t *testing.T) {
 		{
 			name: "simple",
 			addressToBalance: map[string]sdk.Coins{
-				addr1: {sdk.NewInt64Coin("foocoin", 123)},
+				addr1: sdk.NewCoins(sdk.NewInt64Coin("foocoin", 1)),
 			},
 			want: newBalances(account(addr1, coin("foocoin", "123"))),
 		},
 		{
 			name: "multi-denom",
 			addressToBalance: map[string]sdk.Coins{
-				addr1: {
-					sdk.NewInt64Coin("foocoin", 123),
-					sdk.NewInt64Coin("barcoin", 456),
-				},
+				addr1: sdk.NewCoins(
+					sdk.NewInt64Coin("foocoin", 1),
+					sdk.NewInt64Coin("barcoin", 2),
+				),
 			},
 			want: newBalances(
 				account(addr1,
@@ -144,12 +151,18 @@ func Test_marshalBalanceUpdate(t *testing.T) {
 		{
 			name: "multi-acct",
 			addressToBalance: map[string]sdk.Coins{
-				addr1: {sdk.NewInt64Coin("foocoin", 123)},
-				addr2: {sdk.NewInt64Coin("barcoin", 456)},
+				addr1: sdk.NewCoins(
+					sdk.NewInt64Coin("foocoin", 4),
+					sdk.NewInt64Coin("moola", 45),
+				),
+				addr2: sdk.NewCoins(
+					sdk.NewInt64Coin("foocoin", 17),
+					sdk.NewInt64Coin("moola", 45),
+				),
 			},
 			want: newBalances(
-				account(addr1, coin("foocoin", "123")),
-				account(addr2, coin("barcoin", "456")),
+				account(addr1, coin("foocoin", "123"), coin("moola", "789")),
+				account(addr2, coin("foocoin", "456"), coin("moola", "0")),
 			),
 		},
 	}
@@ -178,10 +191,8 @@ func Test_marshalBalanceUpdate(t *testing.T) {
 type mockBank struct {
 	// Record of all calls to the bank.
 	calls []string
-	// Value to return from GetAllBalances().
-	allBalances map[string]sdk.Coins
-	// Value to return from GetBalance().
-	balance map[string]sdk.Coin
+	// balances for each address
+	balances map[string]sdk.Coins
 }
 
 var _ types.BankKeeper = (*mockBank)(nil)
@@ -197,12 +208,20 @@ func (b *mockBank) BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) 
 
 func (b *mockBank) GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
 	b.record(fmt.Sprintf("GetAllBalances %s", addr))
-	return b.allBalances[addr.String()]
+	balances, ok := b.balances[addr.String()]
+	if !ok {
+		return sdk.NewCoins()
+	}
+	return balances
 }
 
 func (b *mockBank) GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin {
 	b.record(fmt.Sprintf("GetBalance %s %s", addr, denom))
-	return b.balance[addr.String()]
+	amount := sdk.ZeroInt()
+	if balances, ok := b.balances[addr.String()]; ok {
+		amount = balances.AmountOf(denom)
+	}
+	return sdk.NewCoin(denom, amount)
 }
 
 func (b *mockBank) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error {
@@ -258,8 +277,8 @@ func makeTestKit(account types.AccountKeeper, bank types.BankKeeper) (Keeper, sd
 }
 
 func Test_Receive_GetBalance(t *testing.T) {
-	bank := &mockBank{balance: map[string]sdk.Coin{
-		addr1: sdk.NewInt64Coin("quatloos", 123),
+	bank := &mockBank{balances: map[string]sdk.Coins{
+		addr1: sdk.NewCoins(sdk.NewInt64Coin("quatloos", 123)),
 	}}
 	keeper, ctx := makeTestKit(nil, bank)
 	ch := NewPortHandler(AppModule{}, keeper)
@@ -286,8 +305,8 @@ func Test_Receive_GetBalance(t *testing.T) {
 }
 
 func Test_Receive_Give(t *testing.T) {
-	bank := &mockBank{balance: map[string]sdk.Coin{
-		addr1: sdk.NewInt64Coin("urun", 1000),
+	bank := &mockBank{balances: map[string]sdk.Coins{
+		addr1: sdk.NewCoins(sdk.NewInt64Coin("urun", 1000)),
 	}}
 	keeper, ctx := makeTestKit(nil, bank)
 	ch := NewPortHandler(AppModule{}, keeper)
@@ -448,8 +467,8 @@ func Test_Receive_GiveToRewardDistributor(t *testing.T) {
 }
 
 func Test_Receive_Grab(t *testing.T) {
-	bank := &mockBank{balance: map[string]sdk.Coin{
-		addr1: sdk.NewInt64Coin("ubld", 1000),
+	bank := &mockBank{balances: map[string]sdk.Coins{
+		addr1: sdk.NewCoins(sdk.NewInt64Coin("ubld", 1000)),
 	}}
 	keeper, ctx := makeTestKit(nil, bank)
 	ch := NewPortHandler(AppModule{}, keeper)
@@ -487,12 +506,12 @@ func Test_Receive_Grab(t *testing.T) {
 }
 
 func Test_EndBlock_Events(t *testing.T) {
-	bank := &mockBank{allBalances: map[string]sdk.Coins{
-		addr1: {sdk.NewInt64Coin("ubld", 1000)},
-		addr2: {
+	bank := &mockBank{balances: map[string]sdk.Coins{
+		addr1: sdk.NewCoins(sdk.NewInt64Coin("ubld", 1000)),
+		addr2: sdk.NewCoins(
 			sdk.NewInt64Coin("urun", 4000),
 			sdk.NewInt64Coin("arcadeTokens", 7),
-		},
+		),
 	}}
 	keeper, ctx := makeTestKit(nil, bank)
 	// Turn off rewards.
@@ -514,7 +533,7 @@ func Test_EndBlock_Events(t *testing.T) {
 			Attributes: []abci.EventAttribute{
 				{Key: []byte("recipient"), Value: []byte(addr1)},
 				{Key: []byte("sender"), Value: []byte(addr2)},
-				{Key: []byte("amount"), Value: []byte("quite a lot")},
+				{Key: []byte("amount"), Value: []byte("500ubld,600urun,700ushmoo")},
 				{Key: []byte("other"), Value: []byte(addr3)},
 			},
 		},
@@ -534,8 +553,12 @@ func Test_EndBlock_Events(t *testing.T) {
 	}
 
 	wantCalls := []string{
-		"GetAllBalances " + addr1,
-		"GetAllBalances " + addr2,
+		"GetBalance " + addr1 + " ubld",
+		"GetBalance " + addr1 + " urun",
+		"GetBalance " + addr1 + " ushmoo",
+		"GetBalance " + addr2 + " ubld",
+		"GetBalance " + addr2 + " urun",
+		"GetBalance " + addr2 + " ushmoo",
 	}
 	// TODO: make comparison order-insensitive
 	if !reflect.DeepEqual(bank.calls, wantCalls) {
@@ -544,7 +567,11 @@ func Test_EndBlock_Events(t *testing.T) {
 
 	wantMsg := newBalances(
 		account(addr1, coin("ubld", "1000")),
-		account(addr2, coin("urun", "4000"), coin("arcadeTokens", "7")),
+		account(addr1, coin("urun", "0")),
+		account(addr1, coin("ushmoo", "0")),
+		account(addr2, coin("ubld", "0")),
+		account(addr2, coin("urun", "4000")),
+		account(addr2, coin("ushmoo", "0")),
 	)
 	if len(msgsSent) != 1 {
 		t.Errorf("got msgs = %v, want one message", msgsSent)
@@ -566,12 +593,12 @@ func Test_EndBlock_Events(t *testing.T) {
 
 func Test_EndBlock_Rewards(t *testing.T) {
 	bank := &mockBank{
-		allBalances: map[string]sdk.Coins{
-			ModuleName: {
+		balances: map[string]sdk.Coins{
+			ModuleName: sdk.NewCoins(
 				sdk.NewInt64Coin("urun", 1000),
 				sdk.NewInt64Coin("stickers", 10),
 				sdk.NewInt64Coin("puppies", 0),
-			},
+			),
 		},
 	}
 	keeper, ctx := makeTestKit(nil, bank)


### PR DESCRIPTION
closes: #6321

## Description

Issue #6321 arose from an impedance mismatch between the swingset world which typically works a denom at a time, and the Cosmos world which handles collections of arbitrary denoms as a unit, representing only those with a nonzero quantity. To give balance updates for denoms which have dropped to zero quantity, we need to extract from an event the set of denoms that it might have affected, then at the end of a block we send updates for the whole set of such denoms, including those for which the current balance is zero.

This PR also changes which events we monitor to notice balance changes. The "transfer" events are only generated for `MsgSend` and for the output addresses of `MsgMultiSend`. By monitoring the lower-level "coin_spent/received" events, we still handle `MsgSend`, but now handle all participants of `MsgMultiSend` as well as delegation, undelegation, minting, and burning for both user and module accounts.

### Security Considerations

Missing notifications is not a good user experience, but does not lead to any integrity issues.

### Documentation Considerations

None.

### Testing Considerations

None.
