### PR TITLE
fix(telemetry): handle misbehaving slog senders

### DIFF
--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -392,7 +392,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       }
       lastCommitTime = t0;
 
-      await slogSender.forceFlush?.().catch(err => {
+      await Promise.resolve(slogSender.forceFlush?.()).catch(err => {
         console.warn('Failed to flush slog sender', err);
       });
 

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -237,7 +237,7 @@ export const makeMemoryMappedCircularBuffer = async ({
 export const makeSlogSender = async opts => {
   const { writeJSON } = await makeMemoryMappedCircularBuffer(opts);
   return Object.assign(writeJSON, {
-    forceFlush: () => {},
+    forceFlush: async () => {},
     usesJsonObject: true,
   });
 };

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -120,16 +120,6 @@ export const makeSlogSender = async (opts = {}) => {
 
   if (!senders.length) {
     return undefined;
-  } else if (senders.length === 1) {
-    const sender = senders[0];
-    const { usesJsonObject = true } = sender;
-    return !usesJsonObject
-      ? sender
-      : Object.assign(
-          (slogObj, jsonObj = serializeSlogObj(slogObj)) =>
-            sender(slogObj, jsonObj),
-          sender,
-        );
   } else {
     // Optimize creating a JSON serialization only if needed
     // by any of the sender modules

--- a/packages/telemetry/src/null.js
+++ b/packages/telemetry/src/null.js
@@ -1,4 +1,4 @@
 // @ts-check
 export const makeSlogSender = async _opts => {
-  return Object.assign(() => {}, { forceFlush: () => {} });
+  return Object.assign(() => {}, { forceFlush: async () => {} });
 };

--- a/packages/telemetry/src/otel-trace.js
+++ b/packages/telemetry/src/otel-trace.js
@@ -64,7 +64,7 @@ export const makeSlogSender = async opts => {
   });
 
   return Object.assign(slogSender, {
-    forceFlush: () => tracingProvider.forceFlush(),
+    forceFlush: async () => tracingProvider.forceFlush(),
     usesJsonObject: false,
   });
 };


### PR DESCRIPTION
## Description

#6325 introduced a change that highlighted an existing bug in the slog senders: `flight-recorder.js` had a `forceFlush` which didn't return a Promise, and `chain-main.js` had un unconditional `.catch` on the return value of `forceFlush`. I'm not exactly sure how we never triggered this before given that the default slog sender should have been flight recorder, but the fix is easy enough.

Drive-by change to make sure slogSender calls never throw back into swingset, as discussed in https://github.com/Agoric/agoric-sdk/pull/6247#discussion_r981845593 (cc @warner)