### PR TITLE
fix: cheap auxdata

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -107,6 +107,9 @@ export const preparePaymentLedger = (
     getAmountShape() {
       return amountShape;
     },
+    aux() {
+      return brandAuxData;
+    },
   });
 
   const amountShape = amountShapeFromElementShape(
@@ -114,6 +117,13 @@ export const preparePaymentLedger = (
     assetKind,
     elementShape,
   );
+
+  const brandAuxData = harden({
+    name,
+    assetKind,
+    displayInfo,
+    amountShape,
+  });
 
   const { IssuerI, MintI, PaymentI, PurseIKit } = makeIssuerInterfaces(
     brand,

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -156,11 +156,19 @@ export const IssuerKitShape = harden({
 
 // //////////////////////// Interfaces /////////////////////////////////////////
 
+export const BrandAuxDataShape = harden({
+  name: M.string(),
+  assetKind: AssetKindShape,
+  displayInfo: DisplayInfoShape,
+  amountShape: M.pattern(),
+});
+
 export const BrandI = M.interface('Brand', {
   isMyIssuer: M.callWhen(M.await(IssuerShape)).returns(M.boolean()),
   getAllegedName: M.call().returns(M.string()),
   getDisplayInfo: M.call().returns(DisplayInfoShape),
   getAmountShape: M.call().returns(M.pattern()),
+  aux: M.call().returns(BrandAuxDataShape),
 });
 
 /**

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -86,6 +86,14 @@
  */
 
 /**
+ * @typedef {object} BrandAuxData
+ * @property {string} name
+ * @property {AssetKind} assetKind
+ * @property {DisplayInfo} displayInfo
+ * @property {Pattern} amountShape
+ */
+
+/**
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} Brand
  * The brand identifies the kind of issuer, and has a function to get the
@@ -104,6 +112,7 @@
  * @property {() => DisplayInfo<K>} getDisplayInfo
  * Give information to UI on how to display the amount.
  * @property {() => Pattern} getAmountShape
+ * @property {() => BrandAuxData} aux
  */
 
 // /////////////////////////// Issuer //////////////////////////////////////////

--- a/packages/ERTP/test/unitTests/mathHelpers/mockBrand.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/mockBrand.js
@@ -1,13 +1,19 @@
 import { Far } from '@endo/marshal';
+import { M } from '@agoric/store';
 import { AssetKind } from '../../../src/index.js';
+
+const mockAuxData = harden({
+  name: 'mock',
+  assetKind: AssetKind.NAT,
+  displayInfo: { assetKind: AssetKind.NAT },
+  amountShape: M.any(),
+});
 
 /** @type {Brand<AssetKind>} */
 export const mockBrand = Far('brand', {
-  // eslint-disable-next-line no-unused-vars
-  isMyIssuer: async allegedIssuer => false,
-  getAllegedName: () => 'mock',
-  getAmountShape: () => {},
-  getDisplayInfo: () => ({
-    assetKind: AssetKind.NAT,
-  }),
+  getAllegedName: () => mockAuxData.name,
+  isMyIssuer: async _allegedIssuer => false,
+  getDisplayInfo: () => mockAuxData.displayInfo,
+  getAmountShape: () => mockAuxData.amountShape,
+  aux: () => mockAuxData,
 });

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -10,6 +10,21 @@ import { mockBrand } from './mockBrand.js';
 // AmountMath so that we can test that any duplication is handled
 // correctly.
 
+const otherAuxData = harden({
+  name: 'somename',
+  assetKind: AssetKind.NAT,
+  displayInfo: { assetKind: AssetKind.NAT },
+  amountShape: M.any(),
+});
+
+const otherBrand = Far('otherBrand', {
+  getAllegedName: () => otherAuxData.name,
+  isMyIssuer: async _allegedIssuer => false,
+  getDisplayInfo: () => otherAuxData.displayInfo,
+  getAmountShape: () => otherAuxData.amountShape,
+  aux: () => otherAuxData,
+});
+
 test('natMathHelpers make', t => {
   t.deepEqual(m.make(mockBrand, 4n), { brand: mockBrand, value: 4n });
   // @ts-expect-error deliberate invalid arguments for testing
@@ -62,12 +77,7 @@ test('natMathHelpers coerce', t => {
       m.coerce(
         mockBrand,
         harden({
-          brand: Far('otherBrand', {
-            getAllegedName: () => 'somename',
-            isMyIssuer: async () => false,
-            getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
-            getAmountShape: () => M.any(),
-          }),
+          brand: otherBrand,
           value: 4n,
         }),
       ),
@@ -186,39 +196,14 @@ test('natMathHelpers isGTE', t => {
 });
 
 test('natMathHelpers isGTE mixed brands', t => {
-  t.throws(
-    () =>
-      m.isGTE(
-        m.make(
-          Far('otherBrand', {
-            getAllegedName: () => 'somename',
-            isMyIssuer: async () => false,
-            getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
-            getAmountShape: () => M.any(),
-          }),
-          5n,
-        ),
-        m.make(mockBrand, 3n),
-      ),
-    {
-      message: /Brands in left .* and right .* should match but do not/,
-    },
-  );
+  t.throws(() => m.isGTE(m.make(otherBrand, 5n), m.make(mockBrand, 3n)), {
+    message: /Brands in left .* and right .* should match but do not/,
+  });
 });
 
 test(`natMathHelpers isGTE - brands don't match objective brand`, t => {
   t.throws(
-    () =>
-      m.isGTE(
-        m.make(mockBrand, 5n),
-        m.make(mockBrand, 3n),
-        Far('otherBrand', {
-          getAllegedName: () => 'somename',
-          isMyIssuer: async () => false,
-          getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
-          getAmountShape: () => M.any(),
-        }),
-      ),
+    () => m.isGTE(m.make(mockBrand, 5n), m.make(mockBrand, 3n), otherBrand),
     {
       message: /amount's brand .* did not match expected brand .*/,
     },
@@ -237,39 +222,14 @@ test('natMathHelpers isEqual', t => {
 });
 
 test('natMathHelpers isEqual mixed brands', t => {
-  t.throws(
-    () =>
-      m.isEqual(
-        m.make(
-          Far('otherBrand', {
-            getAllegedName: () => 'somename',
-            isMyIssuer: async () => false,
-            getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
-            getAmountShape: () => M.any(),
-          }),
-          4n,
-        ),
-        m.make(mockBrand, 4n),
-      ),
-    {
-      message: /Brands in left .* and right .* should match but do not/,
-    },
-  );
+  t.throws(() => m.isEqual(m.make(otherBrand, 4n), m.make(mockBrand, 4n)), {
+    message: /Brands in left .* and right .* should match but do not/,
+  });
 });
 
 test(`natMathHelpers isEqual - brands don't match objective brand`, t => {
   t.throws(
-    () =>
-      m.isEqual(
-        m.make(mockBrand, 4n),
-        m.make(mockBrand, 4n),
-        Far('otherBrand', {
-          getAllegedName: () => 'somename',
-          isMyIssuer: async () => false,
-          getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
-          getAmountShape: () => M.any(),
-        }),
-      ),
+    () => m.isEqual(m.make(mockBrand, 4n), m.make(mockBrand, 4n), otherBrand),
     {
       message: /amount's brand .* did not match expected brand .*/,
     },
@@ -285,39 +245,14 @@ test('natMathHelpers add', t => {
 });
 
 test('natMathHelpers add mixed brands', t => {
-  t.throws(
-    () =>
-      m.add(
-        m.make(
-          Far('otherBrand', {
-            getAllegedName: () => 'somename',
-            isMyIssuer: async () => false,
-            getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
-            getAmountShape: () => M.any(),
-          }),
-          5n,
-        ),
-        m.make(mockBrand, 9n),
-      ),
-    {
-      message: /Brands in left .* and right .* should match but do not/,
-    },
-  );
+  t.throws(() => m.add(m.make(otherBrand, 5n), m.make(mockBrand, 9n)), {
+    message: /Brands in left .* and right .* should match but do not/,
+  });
 });
 
 test(`natMathHelpers add - brands don't match objective brand`, t => {
   t.throws(
-    () =>
-      m.add(
-        m.make(mockBrand, 5n),
-        m.make(mockBrand, 9n),
-        Far('otherBrand', {
-          getAllegedName: () => 'somename',
-          isMyIssuer: async () => false,
-          getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
-          getAmountShape: () => M.any(),
-        }),
-      ),
+    () => m.add(m.make(mockBrand, 5n), m.make(mockBrand, 9n), otherBrand),
     {
       message: /amount's brand .* did not match expected brand .*/,
     },
@@ -333,39 +268,14 @@ test('natMathHelpers subtract', t => {
 });
 
 test('natMathHelpers subtract mixed brands', t => {
-  t.throws(
-    () =>
-      m.subtract(
-        m.make(
-          Far('otherBrand', {
-            getAllegedName: () => 'somename',
-            isMyIssuer: async () => false,
-            getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
-            getAmountShape: () => M.any(),
-          }),
-          6n,
-        ),
-        m.make(mockBrand, 1n),
-      ),
-    {
-      message: /Brands in left .* and right .* should match but do not/,
-    },
-  );
+  t.throws(() => m.subtract(m.make(otherBrand, 6n), m.make(mockBrand, 1n)), {
+    message: /Brands in left .* and right .* should match but do not/,
+  });
 });
 
 test(`natMathHelpers subtract brands don't match brand`, t => {
   t.throws(
-    () =>
-      m.subtract(
-        m.make(mockBrand, 6n),
-        m.make(mockBrand, 1n),
-        Far('otherBrand', {
-          getAllegedName: () => 'somename',
-          isMyIssuer: async () => false,
-          getDisplayInfo: () => ({ assetKind: AssetKind.NAT }),
-          getAmountShape: () => M.any(),
-        }),
-      ),
+    () => m.subtract(m.make(mockBrand, 6n), m.make(mockBrand, 1n), otherBrand),
     {
       message: /amount's brand .* did not match expected brand .*/,
     },

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -20,6 +20,54 @@ const SYSCALL_CAPDATA_BODY_SIZE_LIMIT = 10_000_000;
 const SYSCALL_CAPDATA_SLOTS_LENGTH_LIMIT = 10_000;
 
 const { details: X } = assert;
+// TODO Move someplace more reusable; perhaps even @endo/marshal
+const makeRemotePresence = (iface, fulfilledHandler) => {
+  let remotePresence;
+  const p = new HandledPromise((_res, _rej, resolveWithPresence) => {
+    remotePresence = resolveWithPresence(fulfilledHandler);
+    let auxData;
+    let hasAuxData = false;
+
+    /**
+     * A remote presence has an `aux()` method that either returns a promise
+     * or a non-promise. The first time it is called, it does an eventual-send
+     * of an `aux()` message to the far object it designates, remembers that
+     * promise as its auxdata, and returns that. It also watches that promise
+     * to react to its fulfillment. Until that reaction, every time its
+     * `aux()` is called, it will return that same promise. Once it reacts
+     * to the promise being fulfilled, if that ever happens, then the
+     * fulfillment becomes its new auxdata which gets returned from then on.
+     *
+     * @template T
+     * @returns {ERef<T>}
+     */
+    const aux = () => {
+      if (hasAuxData) {
+        return auxData;
+      }
+      auxData = E(remotePresence).aux();
+      hasAuxData = true;
+      // TODO Also watch for a rejection. If rejected with the special
+      // value indicating the promise was broken by upgrade, then ask again.
+      // To keep the return promise valid across that upgrade-polling
+      // requires more bookkeeping, to keep the returned promise distinct
+      // from the promise for the result of the send.
+      E.when(auxData, value => (auxData = value));
+      return auxData;
+    };
+    defineProperty(remotePresence, 'aux', {
+      value: aux,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+    // Use Remotable rather than Far to make a remote from a presence
+    Remotable(iface, undefined, remotePresence);
+  });
+
+  harden(p);
+  return remotePresence;
+};
 
 // 'makeLiveSlots' is a dispatcher which uses javascript Maps to keep track
 // of local objects which have been exported. These cannot be persisted
@@ -392,22 +440,17 @@ function build(
       },
     };
 
-    let remotePresence;
-    const p = new HandledPromise((_res, _rej, resolveWithPresence) => {
-      // Use Remotable rather than Far to make a remote from a presence
-      remotePresence = Remotable(
-        iface,
-        undefined,
-        resolveWithPresence(fulfilledHandler),
-      );
-      // remote === presence, actually
+    const remotePresence = makeRemotePresence(iface, fulfilledHandler);
 
-      // todo: mfig says resolveWithPresence
-      // gives us a Presence, Remotable gives us a Remote. I think that
-      // implies we have a lot of renaming to do, 'makeRemote' instead of
-      // 'makeImportedPresence', etc. I'd like to defer that for a later
-      // cleanup/renaming pass.
-    }); // no unfulfilledHandler
+    // remote === presence, actually
+
+    // todo: mfig says resolveWithPresence
+    // gives us a Presence, Remotable gives us a Remote. I think that
+    // implies we have a lot of renaming to do, 'makeRemote' instead of
+    // 'makeImportedPresence', etc. I'd like to defer that for a later
+    // cleanup/renaming pass.
+
+    // no unfulfilledHandler
 
     // The call to resolveWithPresence performs the forwarding logic
     // immediately, so by the time we reach here, E(presence).foo() will use
@@ -419,8 +462,6 @@ function build(
     // `HandledPromise.resolve(presence)`. So we must harden it now, for
     // safety, to prevent it from being used as a communication channel
     // between isolated objects that share a reference to the Presence.
-    void harden(p);
-
     // Up at the application level, presence~.foo(args) starts by doing
     // HandledPromise.resolve(presence), which retrieves it, and then does
     // p.eventualSend('foo', [args]), which uses the fulfilledHandler.

--- a/packages/zoe/src/issuerStorage.js
+++ b/packages/zoe/src/issuerStorage.js
@@ -90,15 +90,16 @@ export const provideIssuerStorage = zcfBaggage => {
     assertInstantiated();
     const brandP = E(issuerP).getBrand();
     const brandIssuerMatchP = E(brandP).isMyIssuer(issuerP);
-    const displayInfoP = E(brandP).getDisplayInfo();
-    /** @type {[Issuer,Brand,boolean,DisplayInfo]} */
-    const [issuer, brand, brandIssuerMatch, displayInfo] = await Promise.all([
+    const brandAuxDataP = E(brandP).aux();
+    /** @type {[Issuer,Brand,boolean,BrandAuxData]} */
+    const [issuer, brand, brandIssuerMatch, brandAuxData] = await Promise.all([
       issuerP,
       brandP,
       brandIssuerMatchP,
-      displayInfoP,
+      brandAuxDataP,
     ]);
     // AWAIT /////
+    const { displayInfo } = brandAuxData;
 
     if (issuerToIssuerRecord.has(issuer)) {
       return issuerToIssuerRecord.get(issuer);

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -7,6 +7,7 @@ import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { passStyleOf, Far } from '@endo/marshal';
 import { getMethodNames } from '@agoric/internal';
+import { M } from '@agoric/store';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@endo/bundle-source';
@@ -156,6 +157,13 @@ test(`E(zoe).startInstance - bad issuer, makeEmptyPurse throws`, async t => {
     // eslint-disable-next-line no-use-before-define
     isMyIssuer: i => i === badIssuer,
     getDisplayInfo: () => ({ decimalPlaces: 6, assetKind: AssetKind.NAT }),
+    aux: () =>
+      harden({
+        name: 'bogusBrand',
+        assetKind: AssetKind.NAT,
+        displayInfo: { decimalPlaces: 6, assetKind: AssetKind.NAT },
+        amountShape: M.any(),
+      }),
   });
   const badIssuer = Far('issuer', {
     makeEmptyPurse: async () => {

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -5,8 +5,9 @@ import { Far } from '@endo/marshal';
 import { AssetKind, AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { getMethodNames } from '@agoric/internal';
-import { makeOffer } from '../makeOffer.js';
+import { M } from '@agoric/store';
 
+import { makeOffer } from '../makeOffer.js';
 import { setup } from '../setupBasicMints.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 
@@ -204,6 +205,13 @@ test(`zcf.saveIssuer - bad issuer, makeEmptyPurse throws`, async t => {
     // eslint-disable-next-line no-use-before-define
     isMyIssuer: i => i === badIssuer,
     getDisplayInfo: () => ({ decimalPlaces: 6, assetKind: AssetKind.NAT }),
+    aux: () =>
+      harden({
+        name: 'bogusBrand',
+        assetKind: AssetKind.NAT,
+        displayInfo: { decimalPlaces: 6, assetKind: AssetKind.NAT },
+        amountShape: M.any(),
+      }),
   });
   const badIssuer = Far('issuer', {
     makeEmptyPurse: async () => {


### PR DESCRIPTION
Liveslots adds to all remote presences an `aux()` method.

A remote presence has an `aux()` method that either returns a promise or a non-promise. The first time it is called, it does an eventual-send of an `aux()` message to the far object it designates, remembers that promise as its auxdata, and returns that. It also watches that promise to react to its fulfillment. Until that reaction, every time its `aux()` is called, it will return that same promise. Once it reacts to the promise being fulfilled, if that ever happens, then the fulfillment becomes its new auxdata which gets returned from then on.

Initially only liveslots does this. But the mechanism is in a reusable `makeRemotePresence` function that should probably move to `@endo/marshal` so that other things that make remote presences can use it.

A good first test will be for ERTP brands to provide an auxdata object with the things that you can currently ask a brand for that are stable, and that zoe needs to cache before it can register the brand. Zoe's caching logic should then become much simpler as it need only delay registration until a local call to the brand's `aux()` returns a non-promise. After that, the remote presence's `aux()` method must always immediately return the same non-promise.

(Some brands are co-located with Zoe, in which case their `aux()` method may not be similarly stable. But that would be a misbehaving brand. The only brands co-located with the Zoe service are made by Zoe and relied on not to misbehave.)

***Back in draft pending needed redesign to play well with virtual and durable storage.***

If we believe this approach is adequate for our auxdata needs, then
Fixes: https://github.com/Agoric/agoric-sdk/issues/2069

@Chris-Hibbert @warner @FUDCo @michaelfig @mhofman when this is ready, I'll ask you to review. Until then, please ignore. @Chris-Hibbert I'm leaving you listed since you already commented.