### PR TITLE
fix: make it possible to set decimalPlaces when calling startPSM (#6348)

### DIFF
--- a/packages/agoric-cli/src/lib/psm.js
+++ b/packages/agoric-cli/src/lib/psm.js
@@ -96,6 +96,8 @@ export const makePSMSpendAction = (instance, brands, opts) => {
     brands,
     opts,
     opts.feePct ? opts.feePct / 100 : undefined,
+    // @ts-expect-error please update types. Not sure where pair goees.
+    opts.pair[1],
   );
 
   console.warn('psm spend give', proposal.give);

--- a/packages/inter-protocol/test/psm/gov-add-psm-permit.json
+++ b/packages/inter-protocol/test/psm/gov-add-psm-permit.json
@@ -8,6 +8,7 @@
     "feeMintAccess": "zoe",
     "economicCommitteeCreatorFacet": "economicCommittee",
     "psmCharterCreatorFacet": "psmCharter",
+    "provisionPoolStartResult": true,
     "psmFacets": true,
     "chainTimerService": "timer"
   },

--- a/packages/inter-protocol/test/psm/gov-add-psm.js
+++ b/packages/inter-protocol/test/psm/gov-add-psm.js
@@ -20,8 +20,8 @@ const DAI = {
 
 const config = {
   options: { anchorOptions: DAI },
-  WantStableFeeBP: 1n,
-  GiveStableFeeBP: 3n,
+  WantMintedFeeBP: 1n,
+  GiveMintedFeeBP: 3n,
   MINT_LIMIT: 0n,
 };
 


### PR DESCRIPTION
## Description

Merge #6348 (allow setting decimalPlaces when starting PSM) into `release-pismo`.

