### PR TITLE
deterministic xsnap bundles on release-pismo

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -147,6 +147,7 @@ export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
 
     for (const bundle of bundles) {
       bundle.moduleFormat === 'getExport' ||
+        bundle.moduleFormat === 'nestedEvaluate' ||
         assert.fail(X`unexpected: ${bundle.moduleFormat}`);
       // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       await worker.evaluate(`(${bundle.source}\n)()`.trim());

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -30,8 +30,10 @@ const allValues = async obj =>
 
 const bundleRelative = rel =>
   bundleSource(new URL(rel, import.meta.url).pathname);
-const bundleRelativeGE = rel =>
-  bundleSource(new URL(rel, import.meta.url).pathname, { format: 'getExport' });
+const bundleRelativeCallable = rel =>
+  bundleSource(new URL(rel, import.meta.url).pathname, {
+    format: 'nestedEvaluate',
+  });
 
 /**
  * Build the source bundles for the kernel. makeSwingsetController()
@@ -56,10 +58,10 @@ export async function buildVatAndDeviceBundles() {
     vattp: bundleRelative('../vats/vattp/vat-vattp.js'),
     timer: bundleRelative('../vats/timer/vat-timer.js'),
 
-    lockdown: bundleRelativeGE(
+    lockdown: bundleRelativeCallable(
       '../supervisors/subprocess-xsnap/lockdown-subprocess-xsnap.js',
     ),
-    supervisor: bundleRelativeGE(
+    supervisor: bundleRelativeCallable(
       '../supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js',
     ),
   });

--- a/patches/@endo+bundle-source+2.3.0.patch
+++ b/patches/@endo+bundle-source+2.3.0.patch
@@ -1,0 +1,111 @@
+diff --git a/node_modules/@endo/bundle-source/src/index.js b/node_modules/@endo/bundle-source/src/index.js
+index 9eb89aa..f3960c4 100644
+--- a/node_modules/@endo/bundle-source/src/index.js
++++ b/node_modules/@endo/bundle-source/src/index.js
+@@ -32,6 +32,23 @@ const textEncoder = new TextEncoder();
+ const textDecoder = new TextDecoder();
+ const readPowers = makeReadPowers({ fs, url, crypto });
+ 
++// Find the longest common prefix of an array of strings.
++function longestCommonPrefix(strings) {
++  if (strings.length === 0) {
++    return '';
++  }
++  const first = strings[0];
++  const rest = strings.slice(1);
++  let i = 0;
++  for (; i < first.length; i += 1) {
++    const c = first[i];
++    if (rest.some(s => s[i] !== c)) {
++      break;
++    }
++  }
++  return first.slice(0, i);
++}
++
+ function rewriteComment(node, unmapLoc) {
+   node.type = 'CommentBlock';
+   // Within comments...
+@@ -192,6 +209,17 @@ async function bundleNestedEvaluateAndGetExports(
+   });
+   // console.log(output);
+ 
++  // Find the longest common prefix of all the source file names.
++  // We shorten the fileNames to make the bundle output deterministic.
++  const fileNameToUrlPath = fileName =>
++    readPowers.pathToFileURL(pathResolve(startFilename, fileName)).pathname;
++  const pathnames = output.map(({ fileName }) => fileNameToUrlPath(fileName));
++  const longestPrefix = longestCommonPrefix(pathnames);
++
++  // Ensure the prefix ends with a slash.
++  const pathnameEndPos = longestPrefix.lastIndexOf('/');
++  const pathnamePrefix = longestPrefix.slice(0, pathnameEndPos + 1);
++
+   // Create a source bundle.
+   const unsortedSourceBundle = {};
+   let entrypoint;
+@@ -201,8 +229,12 @@ async function bundleNestedEvaluateAndGetExports(
+         throw Error(`unprepared for assets: ${chunk.fileName}`);
+       }
+       const { code, fileName, isEntry } = chunk;
++      const pathname = fileNameToUrlPath(fileName);
++      const shortName = pathname.startsWith(pathnamePrefix)
++        ? pathname.slice(pathnamePrefix.length)
++        : fileName;
+       if (isEntry) {
+-        entrypoint = fileName;
++        entrypoint = shortName;
+       }
+ 
+       const useLocationUnmap =
+@@ -212,7 +244,7 @@ async function bundleNestedEvaluateAndGetExports(
+         sourceMap: chunk.map,
+         useLocationUnmap,
+       });
+-      unsortedSourceBundle[fileName] = transformedCode;
++      unsortedSourceBundle[shortName] = transformedCode;
+ 
+       // console.log(`==== sourceBundle[${fileName}]\n${sourceBundle[fileName]}\n====`);
+     }),
+@@ -250,7 +282,7 @@ async function bundleNestedEvaluateAndGetExports(
+   let sourceMap;
+   let source;
+   if (moduleFormat === 'getExport') {
+-    sourceMap = `//# sourceURL=${resolvedPath}\n`;
++    sourceMap = `//# sourceURL=${DEFAULT_FILE_PREFIX}/${entrypoint}\n`;
+ 
+     if (Object.keys(sourceBundle).length !== 1) {
+       throw Error('unprepared for more than one chunk');
+@@ -292,11 +324,8 @@ ${sourceMap}`;
+     // This function's source code is inlined in the output bundle.
+     // It figures out the exports from a given module filename.
+     const nsBundle = {};
+-    const nestedEvaluate = _src => {
+-      throw Error('need to override nestedEvaluate');
+-    };
+     function computeExports(filename, exportPowers, exports) {
+-      const { require: systemRequire, _log } = exportPowers;
++      const { require: systemRequire, systemEval, _log } = exportPowers;
+       // This captures the endowed require.
+       const match = filename.match(/^(.*)\/[^/]+$/);
+       const thisdir = match ? match[1] : '.';
+@@ -366,7 +395,8 @@ ${sourceMap}`;
+       }
+ 
+       // log('evaluating', code);
+-      return nestedEvaluate(code)(contextRequire, exports);
++      // eslint-disable-next-line no-eval
++      return (systemEval || eval)(code)(contextRequire, exports);
+     }
+ 
+     source = `\
+@@ -387,7 +417,8 @@ function getExportWithNestedEvaluate(filePrefix) {
+ 
+   // Evaluate the entrypoint recursively, seeding the exports.
+   const systemRequire = typeof require === 'undefined' ? undefined : require;
+-  return computeExports(entrypoint, { require: systemRequire }, {});
++  const systemEval = typeof nestedEvaluate === 'undefined' ? undefined : nestedEvaluate;
++  return computeExports(entrypoint, { require: systemRequire, systemEval }, {});
+ }
+ ${sourceMap}`;
+   }


### PR DESCRIPTION
This cherry-picks the #6298 fixes (from PR #6324) onto `release-pismo`. With this change, the SES and supervisor bundles we create should no longer embed the directory name where the source tree was checked out. Before this, if one validator did a `git clone https://github.com/Agoric/agoric-sdk` into `/home/alice/agoric-sdk`, and a different one used `/home/bob/agoric-sdk`, then their bundle contents would differ, which caused a consensus failure on the very first block. Validators dealt with this by agreeing to use a specific directory (I think `/usr/src/agoric`). This change should remove that requirement.

refs #6298 
