### PR TITLE
fix(wallet-ui): detect unprovisioned wallet

### DIFF
--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -2,6 +2,7 @@
 // @ts-check
 import { iterateReverse } from '@agoric/casting';
 import { observeIteration, subscribeEach } from '@agoric/notifier';
+import { E } from '@endo/far';
 
 export const NO_SMART_WALLET_ERROR = 'no smart wallet';
 
@@ -113,18 +114,17 @@ export const coalesceUpdates = updates => {
 /**
  *
  * @param {import('@agoric/casting').Follower<any>} follower
- * @returns {Promise<number>}
  * @throws if there is no first height
  */
-export const getFirstHeight = async follower => {
-  /** @type {number=} */
-  let firstHeight = undefined;
-  for await (const { blockHeight } of iterateReverse(follower)) {
-    // TODO: Only set firstHeight and break if the value contains all our state.
-    firstHeight = blockHeight;
+export const assertHasData = async follower => {
+  const eachIterable = E(follower).getReverseIterable();
+  const iterator = await E(eachIterable)[Symbol.asyncIterator]();
+  const el = await iterator.next();
+
+  // done before we started
+  if (el.done && !el.value) {
+    assert.fail(NO_SMART_WALLET_ERROR);
   }
-  assert(firstHeight, NO_SMART_WALLET_ERROR);
-  return firstHeight;
 };
 
 /**

--- a/packages/wallet/ui/src/contexts/Provider.jsx
+++ b/packages/wallet/ui/src/contexts/Provider.jsx
@@ -20,7 +20,7 @@ import {
 import { onLoadP } from '../util/onLoad';
 
 const useDebugLogging = (state, watch) => {
-  useEffect(() => console.debug({ state }), watch);
+  useEffect(() => console.debug('useDebugLogging', { state }), watch);
 };
 
 const cmp = (a, b) => {

--- a/packages/wallet/ui/src/util/WalletBackendAdapter.js
+++ b/packages/wallet/ui/src/util/WalletBackendAdapter.js
@@ -5,7 +5,10 @@ import {
   makeAsyncIterableFromNotifier,
   makeNotifierKit,
 } from '@agoric/notifier';
-import { NO_SMART_WALLET_ERROR } from '@agoric/smart-wallet/src/utils.js';
+import {
+  assertHasData,
+  NO_SMART_WALLET_ERROR,
+} from '@agoric/smart-wallet/src/utils.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { getDappService } from '../service/Dapps.js';
@@ -181,6 +184,7 @@ export const makeWalletBridgeFromFollowers = (
   };
 
   const fetchCurrent = async () => {
+    await assertHasData(currentFollower);
     const latestIterable = await E(currentFollower).getLatestIterable();
     const iterator = latestIterable[Symbol.asyncIterator]();
     const latest = await iterator.next();


### PR DESCRIPTION
_no ticket_

## Description

#6359 broke the detection of a missing smart wallet in the Wallet UI so that it stopped prompting to provision one. I had removed `getFirstHeight` to save that traversal, but we do need one request to find out whether the data is available. This has a simpler `assertHasData` that doesn't continue iterating for the first height and just fails if there isn't any height to traverse.

### Security Considerations

--
### Documentation Considerations

--
### Testing Considerations

Tested manually with a provisioned account (shows purses) and an unprovisioned (shows dialog).