### PR TITLE
fix: protect zoe from keyword collision

### DIFF
--- a/packages/internal/test/test-utils.js
+++ b/packages/internal/test/test-utils.js
@@ -1,7 +1,41 @@
 import test from 'ava';
 import '@endo/init';
 
-import { objectMap, makeMeasureSeconds } from '../src/utils.js';
+import {
+  fromUniqueEntries,
+  objectMap,
+  makeMeasureSeconds,
+} from '../src/utils.js';
+
+test('fromUniqueEntries', t => {
+  const goodEntries = [
+    ['a', 7],
+    ['b', 8],
+    [Symbol.hasInstance, 9],
+  ];
+  const goodObj1 = Object.fromEntries(goodEntries);
+  t.deepEqual(goodObj1, {
+    a: 7,
+    b: 8,
+    [Symbol.hasInstance]: 9,
+  });
+  const goodObj2 = fromUniqueEntries(goodEntries);
+  t.deepEqual(goodObj2, goodObj1);
+
+  const badEntries = [
+    ['a', 7],
+    ['a', 8],
+    [Symbol.hasInstance, 9],
+  ];
+  const badObj = Object.fromEntries(badEntries);
+  t.deepEqual(badObj, {
+    a: 8,
+    [Symbol.hasInstance]: 9,
+  });
+  t.throws(() => fromUniqueEntries(badEntries), {
+    message: /^collision on property name "a": .*$/,
+  });
+});
 
 test('objectMap', t => {
   // @ts-expect-error

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -5,6 +5,7 @@ import { keyEQ, fit } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { AssetKind } from '@agoric/ertp';
+import { fromUniqueEntries } from '@agoric/internal';
 import { satisfiesWant } from '../contractFacet/offerSafety.js';
 
 export const defaultAcceptanceMsg = `The offer has been accepted. Once the contract has been completed, please check your payout`;
@@ -265,7 +266,7 @@ export async function saveAllIssuers(zcf, issuerKeywordRecord = harden({})) {
 /** @type {MapKeywords} */
 export const mapKeywords = (keywordRecord = {}, keywordMapping) => {
   return harden(
-    Object.fromEntries(
+    fromUniqueEntries(
       Object.entries(keywordRecord).map(([keyword, value]) => {
         if (keywordMapping[keyword] === undefined) {
           return [keyword, value];
@@ -278,7 +279,7 @@ export const mapKeywords = (keywordRecord = {}, keywordMapping) => {
 /** @type {Reverse} */
 const reverse = (keywordRecord = {}) => {
   return harden(
-    Object.fromEntries(
+    fromUniqueEntries(
       Object.entries(keywordRecord).map(([key, value]) => [value, key]),
     ),
   );


### PR DESCRIPTION
Zoe makes two uses of `fromEntries` to construct a keyword record from user-provided data, where there might be a keyword collision, causing some entries to overwrite others.

This PR protects Zoe from that by providing a `fromUniqueEntries` that throws if there is a collision and otherwise acts like the built-in one. We place that in the `@agoric/internal` package so it can be widely reused anywhere in agoric-sdk where a similar hazard arises. However, it will need to move or be copied to use outside of agoric-sdk.

Found when reviewing https://github.com/Agoric/agoric-sdk/pull/6362 , though it does not change our vulnerability to this flaw.

See also https://github.com/endojs/endo/pull/1306