### PR TITLE
fix: pattern based compression

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -34,6 +34,7 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
       if (elementShape === undefined) {
         valueShape = M.arrayOf(M.key());
       } else {
+        // M.and compresses only according to its last conjunct
         valueShape = M.arrayOf(M.and(M.key(), elementShape));
       }
       break;
@@ -139,6 +140,7 @@ export const vivifyPaymentLedger = (
   const paymentLedger = provideDurableWeakMapStore(
     issuerBaggage,
     'paymentLedger',
+    { valueShape: amountShape },
   );
 
   /**

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -1,3 +1,4 @@
+import { M } from '@agoric/store';
 import { vivifyFarClassKit, makeScalarBigSetStore } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { makeTransientNotifierKit } from './transientNotifier.js';
@@ -12,6 +13,8 @@ export const vivifyPurseKind = (
   PurseIKit,
   purseMethods,
 ) => {
+  const amountShape = brand.getAmountShape();
+
   // Note: Virtual for high cardinality, but *not* durable, and so
   // broken across an upgrade.
   const { provideNotifier, update: updateBalance } = makeTransientNotifierKit();
@@ -109,6 +112,12 @@ export const vivifyPurseKind = (
         receive(...args) {
           return this.facets.purse.deposit(...args);
         },
+      },
+    },
+    {
+      stateShape: {
+        currentBalance: amountShape,
+        recoverySet: M.remotable('recoverySet'),
       },
     },
   );

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -1,12 +1,19 @@
 // @ts-check
-/* eslint-disable no-use-before-define, jsdoc/require-returns-type */
+/* eslint-disable no-use-before-define */
 
-import { assert, details as X, q } from '@agoric/assert';
-import { defendPrototype } from '@agoric/store';
-import { Far } from '@endo/marshal';
+import {
+  assertPattern,
+  decompress,
+  defendPrototype,
+  mustCompress,
+} from '@agoric/store';
+import { Far, hasOwnPropertyOf, passStyleOf } from '@endo/marshal';
 import { parseVatSlot } from '../lib/parseVatSlots.js';
 
 /** @template T @typedef {import('@agoric/vat-data').DefineKindOptions<T>} DefineKindOptions */
+
+const { ownKeys } = Reflect;
+const { details: X, quote: q } = assert;
 
 // import { kdebug } from './kdebug.js';
 
@@ -28,7 +35,7 @@ const unweakable = new WeakSet();
  * @param {(baseRef: string, rawState: object) => void} store  Function to
  *   store raw object state by its baseRef
  *
- * @returns An LRU cache of (up to) the given size
+ * @returns {object} An LRU cache of (up to) the given size
  *
  * This cache is part of the virtual object manager and is not intended to be
  * used independently; it is exported only for the benefit of test code.
@@ -146,24 +153,28 @@ export function makeCache(size, fetch, store) {
 /**
  * Create a new virtual object manager.  There is one of these for each vat.
  *
- * @param {*} syscall  Vat's syscall object, used to access the vatstore operations.
- * @param {*} vrm  Virtual reference manager, to handle reference counting and GC
- *   of virtual references.
- * @param {() => number} allocateExportID  Function to allocate the next object
- *   export ID for the enclosing vat.
- * @param {(val: object) => string} _getSlotForVal  A function that returns the
- *   object ID (vref) for a given object, if any.  their corresponding export
- *   IDs
- * @param {*} registerValue  Function to register a new slot+value in liveSlot's
- *   various tables
- * @param {import('@endo/marshal').Serialize<unknown>} serialize  Serializer for this vat
- * @param {import('@endo/marshal').Unserialize<unknown>} unserialize  Unserializer for this vat
- * @param {number} cacheSize  How many virtual objects this manager should cache
- *   in memory.
- * @param {*} assertAcceptableSyscallCapdataSize  Function to check for oversized
- *   syscall params
+ * @param {*} syscall
+ * Vat's syscall object, used to access the vatstore operations.
+ * @param {*} vrm
+ * Virtual reference manager, to handle reference counting and GC
+ * of virtual references.
+ * @param {() => number} allocateExportID
+ * Function to allocate the next object export ID for the enclosing vat.
+ * @param {(val: object) => string} _getSlotForVal
+ * A function that returns the object ID (vref) for a given object, if any.
+ * their corresponding export IDs
+ * @param {*} registerValue
+ * Function to register a new slot+value in liveSlot's various tables
+ * @param {import('@endo/marshal').Serialize<unknown>} serialize
+ * Serializer for this vat
+ * @param {import('@endo/marshal').Unserialize<unknown>} unserialize
+ * Unserializer for this vat
+ * @param {number} cacheSize
+ * How many virtual objects this manager should cache in memory.
+ * @param {*} assertAcceptableSyscallCapdataSize
+ * Function to check for oversized syscall params
  *
- * @returns a new virtual object manager.
+ * @returns {object} a new virtual object manager.
  *
  * The virtual object manager allows the creation of persistent objects that do
  * not need to occupy memory when they are not in use.  It provides five
@@ -585,12 +596,45 @@ export function makeVirtualObjectManager(
   ) {
     const {
       finish,
+      stateShape = undefined,
       thisfulMethods = false,
       interfaceGuard = undefined,
     } = options;
     let facetNames;
     let contextMapTemplate;
     let prototypeTemplate;
+
+    harden(stateShape);
+    stateShape === undefined ||
+      passStyleOf(stateShape) === 'copyRecord' ||
+      assert.fail(X`A stateShape must be a copyRecord: ${q(stateShape)}`);
+    assertPattern(stateShape);
+
+    const serializeSlot = (slotState, prop) => {
+      if (stateShape === undefined) {
+        return serialize(slotState);
+      }
+      hasOwnPropertyOf(stateShape, prop) ||
+        assert.fail(
+          X`State must only have fields described by stateShape: ${q(
+            ownKeys(stateShape),
+          )}`,
+        );
+      return serialize(mustCompress(slotState, stateShape[prop], prop));
+    };
+
+    const unserializeSlot = (slotData, prop) => {
+      if (stateShape === undefined) {
+        return unserialize(slotData);
+      }
+      hasOwnPropertyOf(stateShape, prop) ||
+        assert.fail(
+          X`State only has fields described by stateShape: ${q(
+            ownKeys(stateShape),
+          )}`,
+        );
+      return decompress(unserialize(slotData), stateShape[prop]);
+    };
 
     const facetiousness = assessFacetiousness(behavior);
     switch (facetiousness) {
@@ -695,12 +739,12 @@ export function makeVirtualObjectManager(
         Object.defineProperty(state, prop, {
           get: () => {
             ensureState();
-            return unserialize(innerSelf.rawState[prop]);
+            return unserializeSlot(innerSelf.rawState[prop], prop);
           },
           set: value => {
             ensureState();
             const before = innerSelf.rawState[prop];
-            const after = serialize(value);
+            const after = serializeSlot(value, prop);
             assertAcceptableSyscallCapdataSize([after]);
             if (isDurable) {
               after.slots.forEach((vref, index) => {
@@ -793,11 +837,12 @@ export function makeVirtualObjectManager(
       const initialData = init ? init(...args) : {};
       const rawState = {};
       for (const prop of Object.getOwnPropertyNames(initialData)) {
-        const data = serialize(initialData[prop]);
+        const data = serializeSlot(initialData[prop], prop);
         assertAcceptableSyscallCapdataSize([data]);
         if (isDurable) {
           data.slots.forEach(vref => {
-            assert(vrm.isDurable(vref), X`value for ${q(prop)} is not durable`);
+            vrm.isDurable(vref) ||
+              assert.fail(X`value for ${q(prop)} is not durable`);
           });
         }
         data.slots.forEach(vrm.addReachableVref);

--- a/packages/SwingSet/test/stores/test-collections.js
+++ b/packages/SwingSet/test/stores/test-collections.js
@@ -174,7 +174,9 @@ test('constrain map key shape', t => {
   t.is(stringsOnly.get('skey'), 'this should work');
   t.throws(
     () => stringsOnly.init(29, 'this should not work'),
-    m('invalid key type for collection "map key strings only"'),
+    m(
+      'invalid key type for collection "map key strings only": number 29 - Must be a string',
+    ),
   );
 
   const noStrings = makeScalarBigMapStore('map key no strings', {
@@ -184,27 +186,31 @@ test('constrain map key shape', t => {
   noStrings.init(true, 'boolean ok');
   t.throws(
     () => noStrings.init('foo', 'string not ok?'),
-    m('invalid key type for collection "map key no strings"'),
+    m(
+      'invalid key type for collection "map key no strings": "foo" - Must fail negated pattern: "[match:string]"',
+    ),
   );
   t.is(noStrings.get(47), 'number ok');
   t.is(noStrings.get(true), 'boolean ok');
   t.falsy(noStrings.has('foo'));
   t.throws(
     () => noStrings.get('foo'),
-    m('invalid key type for collection "map key no strings"'),
+    m(
+      'invalid key type for collection "map key no strings": "foo" - Must fail negated pattern: "[match:string]"',
+    ),
   );
 
   const only47 = makeScalarBigMapStore('map key only 47', { keyShape: 47 });
   only47.init(47, 'this number ok');
   t.throws(
     () => only47.init(29, 'this number not ok?'),
-    m('invalid key type for collection "map key only 47"'),
+    m('invalid key type for collection "map key only 47": 29 - Must be: 47'),
   );
   t.is(only47.get(47), 'this number ok');
   t.falsy(only47.has(29));
   t.throws(
     () => only47.get(29),
-    m('invalid key type for collection "map key only 47"'),
+    m('invalid key type for collection "map key only 47": 29 - Must be: 47'),
   );
 
   const lt47 = makeScalarBigMapStore('map key less than 47', {
@@ -213,13 +219,17 @@ test('constrain map key shape', t => {
   lt47.init(29, 'this number ok');
   t.throws(
     () => lt47.init(53, 'this number not ok?'),
-    m('invalid key type for collection "map key less than 47"'),
+    m(
+      'invalid key type for collection "map key less than 47": 53 - Must be < 47',
+    ),
   );
   t.is(lt47.get(29), 'this number ok');
   t.falsy(lt47.has(53));
   t.throws(
     () => lt47.get(53),
-    m('invalid key type for collection "map key less than 47"'),
+    m(
+      'invalid key type for collection "map key less than 47": 53 - Must be < 47',
+    ),
   );
   lt47.init(11, 'lower value');
   lt47.init(46, 'higher value');
@@ -235,7 +245,9 @@ test('constrain map value shape', t => {
   t.is(stringsOnly.get('sval'), 'string value');
   t.throws(
     () => stringsOnly.init('nval', 29),
-    m('invalid value type for collection "map value strings only"'),
+    m(
+      'invalid value type for collection "map value strings only": number 29 - Must be a string',
+    ),
   );
 
   const noStrings = makeScalarBigMapStore('map value no strings', {
@@ -245,7 +257,9 @@ test('constrain map value shape', t => {
   noStrings.init('bkey', true);
   t.throws(
     () => noStrings.init('skey', 'string not ok?'),
-    m('invalid value type for collection "map value no strings"'),
+    m(
+      'invalid value type for collection "map value no strings": "string not ok?" - Must fail negated pattern: "[match:string]"',
+    ),
   );
   t.is(noStrings.get('nkey'), 47);
   t.is(noStrings.get('bkey'), true);
@@ -257,7 +271,9 @@ test('constrain map value shape', t => {
   only47.init('47key', 47);
   t.throws(
     () => only47.init('29key', 29),
-    m('invalid value type for collection "map value only 47"'),
+    m(
+      'invalid value type for collection "map value only 47": 29 - Must be: 47',
+    ),
   );
   t.is(only47.get('47key'), 47);
   t.falsy(only47.has('29key'));
@@ -268,7 +284,9 @@ test('constrain map value shape', t => {
   lt47.init('29key', 29);
   t.throws(
     () => lt47.init('53key', 53),
-    m('invalid value type for collection "map value less than 47"'),
+    m(
+      'invalid value type for collection "map value less than 47": 53 - Must be < 47',
+    ),
   );
   t.is(lt47.get('29key'), 29);
   t.falsy(lt47.has('53key'));
@@ -288,7 +306,9 @@ test('constrain set key shape', t => {
   t.truthy(stringsOnly.has('skey'));
   t.throws(
     () => stringsOnly.add(29),
-    m('invalid key type for collection "strings only set"'),
+    m(
+      'invalid key type for collection "strings only set": number 29 - Must be a string',
+    ),
   );
 
   const noStrings = makeScalarBigSetStore('no strings set', {
@@ -298,7 +318,9 @@ test('constrain set key shape', t => {
   noStrings.add(true);
   t.throws(
     () => noStrings.add('foo?'),
-    m('invalid key type for collection "no strings set"'),
+    m(
+      'invalid key type for collection "no strings set": "foo?" - Must fail negated pattern: "[match:string]"',
+    ),
   );
   t.truthy(noStrings.has(47));
   t.truthy(noStrings.has(true));
@@ -311,7 +333,7 @@ test('constrain set key shape', t => {
   t.falsy(only47.has(29));
   t.throws(
     () => only47.add(29),
-    m('invalid key type for collection "only 47 set"'),
+    m('invalid key type for collection "only 47 set": 29 - Must be: 47'),
   );
 
   const lt47 = makeScalarBigSetStore('less than 47 set', {
@@ -320,7 +342,7 @@ test('constrain set key shape', t => {
   lt47.add(29);
   t.throws(
     () => lt47.add(53),
-    m('invalid key type for collection "less than 47 set"'),
+    m('invalid key type for collection "less than 47 set": 53 - Must be < 47'),
   );
   t.truthy(lt47.has(29));
   t.falsy(lt47.has(53));

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -56,6 +56,8 @@ export {
   fit,
 } from './patterns/patternMatchers.js';
 
+export { compress, mustCompress, decompress } from './patterns/compress.js';
+
 export {
   defendPrototype,
   initEmpty,

--- a/packages/store/src/patterns/compress.js
+++ b/packages/store/src/patterns/compress.js
@@ -1,0 +1,250 @@
+// @ts-check
+import { assertChecker, makeTagged, passStyleOf } from '@endo/marshal';
+
+import { recordParts } from './rankOrder.js';
+import {
+  kindOf,
+  assertPattern,
+  maybeMatchHelper,
+  matches,
+  checkMatches,
+} from './patternMatchers.js';
+import { isKey } from '../keys/checkKey.js';
+import { keyEQ } from '../keys/compareKeys.js';
+
+const { fromEntries } = Object;
+const { details: X, quote: q } = assert;
+
+/**
+ * When, for example, all the specimens in a given store match a
+ * specific pattern, then each of those specimens must contain the same
+ * literal superstructure as their one shared pattern. Therefore, storing
+ * that literal superstructure would be redumdant. If `specimen` does
+ * match `pattern`, then `compress(specimen, pattern)` will return a bindings
+ * array which is hopefully more compact than `specimen` as a whole, but
+ * carries all the information from specimen that cannot be derived just
+ * from knowledge that it matches this `pattern`.
+ *
+ * @type {Compress}
+ */
+export const compress = (specimen, pattern) => {
+  // Not yet frozen! Used to accumulate bindings
+  const bindings = [];
+  const emitBinding = binding => {
+    bindings.push(binding);
+  };
+  harden(emitBinding);
+
+  /**
+   * @param {Passable} innerSpecimen
+   * @param {Pattern} innerPattern
+   * @returns {boolean}
+   */
+  const compressRecur = (innerSpecimen, innerPattern) => {
+    assertPattern(innerPattern);
+    if (isKey(innerPattern)) {
+      return keyEQ(innerSpecimen, innerPattern);
+    }
+    const patternKind = kindOf(innerPattern);
+    const specimenKind = kindOf(innerSpecimen);
+    switch (patternKind) {
+      case undefined: {
+        return false;
+      }
+      case 'copyArray': {
+        if (
+          specimenKind !== 'copyArray' ||
+          innerSpecimen.length !== innerPattern.length
+        ) {
+          return false;
+        }
+        return innerPattern.every((p, i) => compressRecur(innerSpecimen[i], p));
+      }
+      case 'copyRecord': {
+        if (specimenKind !== 'copyRecord') {
+          return false;
+        }
+        const [specimenNames, specimenValues] = recordParts(innerSpecimen);
+        const [pattNames, pattValues] = recordParts(innerPattern);
+        if (specimenNames.length !== pattNames.length) {
+          return false;
+        }
+        return pattNames.every(
+          (name, i) =>
+            specimenNames[i] === name &&
+            compressRecur(specimenValues[i], pattValues[i]),
+        );
+      }
+      case 'copyMap': {
+        if (specimenKind !== 'copyMap') {
+          return false;
+        }
+        const {
+          payload: { keys: pattKeys, values: valuePatts },
+        } = innerPattern;
+        const {
+          payload: { keys: specimenKeys, values: specimenValues },
+        } = innerSpecimen;
+        // TODO BUG: this assumes that the keys appear in the
+        // same order, so we can compare values in that order.
+        // However, we're only guaranteed that they appear in
+        // the same rankOrder. Thus we must search one of these
+        // in the other's rankOrder.
+        if (!keyEQ(specimenKeys, pattKeys)) {
+          return false;
+        }
+        return compressRecur(specimenValues, valuePatts);
+      }
+      default:
+        {
+          const matchHelper = maybeMatchHelper(patternKind);
+          if (matchHelper) {
+            if (matchHelper.compress) {
+              const subBindings = matchHelper.compress(
+                innerSpecimen,
+                innerPattern.payload,
+                compress,
+              );
+              if (subBindings === undefined) {
+                return false;
+              } else {
+                // Note that we're not flattening the subBindings
+                // Note that as long as we allow this kind of nested compression,
+                // we cannot feasibly preserve sort order anyway.
+                emitBinding(subBindings);
+                return true;
+              }
+            } else if (matches(innerSpecimen, innerPattern)) {
+              emitBinding(innerSpecimen);
+              return true;
+            } else {
+              return false;
+            }
+          }
+        }
+        assert.fail(X`unrecognized kind: ${q(patternKind)}`);
+    }
+  };
+
+  if (compressRecur(specimen, pattern)) {
+    return harden(bindings);
+  } else {
+    return undefined;
+  }
+};
+harden(compress);
+
+/**
+ * `mustCompress` is to `compress` approximately as `fit` is to `matches`.
+ * Where `compress` indicates pattern match failure by returning `undefined`,
+ * `mustCompress` indicates pattern match failure by throwing an error
+ * with a good pattern-match-failure diagnostic. Thus, like `fit`,
+ * `mustCompress` has an additional optional `label` parameter to be used on
+ * the outside of that diagnostic if needed. If `mustCompress` does return
+ * normally, then the pattern match succeeded and `mustCompress` returns a
+ * valid bindings array.
+ *
+ * @type {MustCompress}
+ */
+export const mustCompress = (specimen, pattern, label = undefined) => {
+  const bindings = compress(specimen, pattern);
+  if (bindings !== undefined) {
+    return bindings;
+  }
+  // should only throw
+  checkMatches(specimen, pattern, assertChecker, label);
+  assert.fail(X`internal: ${label}: inconsistent pattern match: ${q(pattern)}`);
+};
+harden(mustCompress);
+
+/**
+ * `decompress` reverses the compression performed by `compress`
+ * or `mustCompress`, in order to recover the equivalent
+ * of the original specimen from the `bindings` array and the `pattern`.
+ *
+ * @type {Decompress}
+ */
+export const decompress = (bindings, pattern) => {
+  passStyleOf(bindings) === 'copyArray' ||
+    assert.fail(X`Pattern ${pattern} expected bindings array: ${bindings}`);
+  let i = 0;
+  const takeBinding = () => {
+    i < bindings.length ||
+      assert.fail(
+        X`Pattern  ${q(pattern)} expects more than ${q(
+          bindings.length,
+        )} bindings: ${bindings}`,
+      );
+    const binding = bindings[i];
+    i += 1;
+    return binding;
+  };
+  harden(takeBinding);
+
+  const decompressRecur = innerPattern => {
+    assertPattern(innerPattern);
+    if (isKey(innerPattern)) {
+      return innerPattern;
+    }
+    const patternKind = kindOf(innerPattern);
+    switch (patternKind) {
+      case undefined: {
+        assert.fail(X`decompress expected a pattern: ${q(innerPattern)}`);
+      }
+      case 'copyArray': {
+        return harden(innerPattern.map(p => decompressRecur(p)));
+      }
+      case 'copyRecord': {
+        const [pattNames, pattValues] = recordParts(innerPattern);
+        const entries = pattNames.map((name, j) => [
+          name,
+          decompressRecur(pattValues[j]),
+        ]);
+        // Reverse so printed form looks less surprising,
+        // with ascenting rather than descending property names.
+        return harden(fromEntries(entries.reverse()));
+      }
+      case 'copyMap': {
+        const {
+          payload: { keys: pattKeys, values: valuePatts },
+        } = innerPattern;
+        return makeTagged(
+          'copyMap',
+          harden({
+            keys: pattKeys,
+            values: valuePatts.map(p => decompressRecur(p)),
+          }),
+        );
+      }
+      default:
+        {
+          const matchHelper = maybeMatchHelper(patternKind);
+          if (matchHelper) {
+            if (matchHelper.decompress) {
+              const subBindings = takeBinding();
+              passStyleOf(subBindings) === 'copyArray' ||
+                assert.fail(
+                  X`Pattern ${q(
+                    innerPattern,
+                  )} expected nested bindings array: ${subBindings}`,
+                );
+
+              return matchHelper.decompress(
+                subBindings,
+                innerPattern.payload,
+                decompress,
+              );
+            } else {
+              return takeBinding();
+            }
+          }
+        }
+        assert.fail(
+          X`unrecognized pattern kind: ${q(patternKind)} ${q(innerPattern)}`,
+        );
+    }
+  };
+
+  return decompressRecur(pattern);
+};
+harden(decompress);

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -8,6 +8,7 @@
 /** @template T @typedef {import('@endo/marshal').CopyRecord<T>} CopyRecord */
 /** @template T @typedef {import('@endo/marshal').CopyArray<T>} CopyArray */
 /** @typedef {import('@endo/marshal').Checker} Checker */
+/** @typedef {import('./patterns/patternMatchers').Kind} Kind */
 
 /**
  * @typedef {Passable} Key
@@ -626,10 +627,34 @@
  * @property {(patt: Pattern) => void} assertKeyPattern
  * @property {(patt: Passable) => boolean} isKeyPattern
  * @property {GetRankCover} getRankCover
+ * @property {(passable: Passable, check?: Checker) => (Kind | undefined)} kindOf
+ * @property {(tag: string) => (MatchHelper | undefined)} maybeMatchHelper
  * @property {MatcherNamespace} M
  */
 
 // /////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @callback Compress
+ * @param {Passable} specimen
+ * @param {Pattern} pattern
+ * @returns {Passable[] | undefined}
+ */
+
+/**
+ * @callback MustCompress
+ * @param {Passable} specimen
+ * @param {Pattern} pattern
+ * @param {string|number} [label]
+ * @returns {Passable[]}
+ */
+
+/**
+ * @callback Decompress
+ * @param {Passable[]} bindings
+ * @param {Pattern} pattern
+ * @returns {Passable}
+ */
 
 // TODO
 // The following type should be in internal-types.js, since the
@@ -656,6 +681,27 @@
  * ) => boolean} checkMatches
  * Assuming a valid Matcher of this type with `matcherPayload` as its
  * payload, does this specimen match that Matcher?
+ *
+ * @property {(specimen: Passable,
+ *             matcherPayload: Passable,
+ *             compress: Compress
+ * ) => (Passable[] | undefined)} [compress]
+ * Assuming a valid Matcher of this type with `matcherPayload` as its
+ * payload, if this specimen matches this matcher, then return a
+ * "bindings" array of passables that represents this specimen,
+ * perhaps more compactly, given the knowledge that it matches this matcher.
+ * If the specimen does not match the matcher, return undefined.
+ * If this matcher has a `compress` method, then it must have a matching
+ * `decompress` method.
+ *
+ * @property {(bindings: Passable[],
+ *             matcherPayload: Passable,
+ *             decompress: Decompress
+ * ) => Passable} [decompress]
+ * If `bindings` is the result of a successful `compress` with this matcher,
+ * then `decompress` must return a Passable equivalent to the original specimen.
+ * If this matcher has an `decompress` method, then it must have a matching
+ * `compress` method.
  *
  * @property {(
  *   payload: Passable,

--- a/packages/store/test/test-compress.js
+++ b/packages/store/test/test-compress.js
@@ -1,0 +1,166 @@
+// @ts-check
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { Far } from '@endo/marshal';
+import {
+  makeCopyBagFromElements,
+  makeCopyMap,
+  makeCopySet,
+} from '../src/keys/checkKey.js';
+import {
+  compress,
+  decompress,
+  mustCompress,
+} from '../src/patterns/compress.js';
+import { M } from '../src/patterns/patternMatchers.js';
+
+const runTests = testTriple => {
+  const brand = Far('simoleans', {});
+  const moolaBrand = Far('moola', {});
+  const timer = Far('timer', {});
+
+  testTriple({ brand, value: 37n }, { brand, value: M.bigint() }, [37n]);
+  testTriple(
+    { brand, value: 37n },
+    { brand: M.remotable(), value: M.bigint() },
+    [37n, brand],
+  );
+  testTriple(
+    { brand, value: 37n },
+    { brand: M.bigint(), value: M.bigint() },
+    undefined,
+    'test mustCompress: brand: remotable "[Alleged: simoleans]" - Must be a bigint',
+  );
+  testTriple({ brand, value: 37n }, M.any(), [{ brand, value: 37n }]);
+  testTriple({ brand, value: 37n }, M.recordOf(M.string(), M.scalar()), [
+    { brand, value: 37n },
+  ]);
+  testTriple(
+    [{ foo: 'a' }, { foo: 'b' }, { foo: 'c' }],
+    M.arrayOf(harden({ foo: M.string() })),
+    [[['a'], ['b'], ['c']]],
+  );
+  testTriple(
+    makeCopySet([{ foo: 'a' }, { foo: 'b' }, { foo: 'c' }]),
+    M.setOf(harden({ foo: M.string() })),
+    [[['c'], ['b'], ['a']]],
+  );
+  testTriple(
+    makeCopyBagFromElements([{ foo: 'a' }, { foo: 'a' }, { foo: 'c' }]),
+    M.bagOf(harden({ foo: M.string() })),
+    [
+      [
+        ['c', 1n],
+        ['a', 2n],
+      ],
+    ],
+  );
+  testTriple(
+    makeCopyMap([
+      [{ foo: 'a' }, { bar: 1 }],
+      [{ foo: 'b' }, { bar: 2 }],
+      [{ foo: 'c' }, { bar: 3 }],
+    ]),
+    M.mapOf(harden({ foo: M.string() }), harden({ bar: M.number() })),
+    [
+      [
+        [['c'], ['b'], ['a']],
+        [[3], [2], [1]],
+      ],
+    ],
+  );
+  testTriple(
+    makeCopyMap([
+      [{ foo: 'c' }, { bar: 3 }],
+      [{ foo: 'b' }, { bar: 2 }],
+      [{ foo: 'a' }, { bar: 1 }],
+    ]),
+    // TODO Add a test case where the keys are in the same rankOrder but not
+    // the same order.
+    makeCopyMap([
+      [{ foo: 'c' }, M.any()],
+      // @ts-expect-error The array need not be generic
+      [{ foo: 'b' }, { bar: M.number() }],
+      [{ foo: 'a' }, { bar: 1 }],
+    ]),
+    [{ bar: 3 }, 2],
+  );
+  testTriple(
+    {
+      want: { Winnings: { brand: moolaBrand, value: ['x', 'y'] } },
+      give: { Bid: { brand, value: 37n } },
+      exit: { afterDeadline: { deadline: 11n, timer } },
+    },
+    {
+      want: { Winnings: { brand: moolaBrand, value: M.array() } },
+      give: { Bid: { brand, value: M.nat() } },
+      exit: { afterDeadline: { deadline: M.gte(10n), timer } },
+    },
+    [['x', 'y'], 37n, 11n],
+  );
+  testTriple(
+    'orange',
+    M.or('red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'),
+    [[1]],
+  );
+  testTriple(
+    { x: 3, y: 5 },
+    M.or(harden({ x: M.number(), y: M.number() }), M.bigint(), M.record()),
+    [[0, 5, 3]],
+  );
+  testTriple(
+    [5n],
+    M.or(harden({ x: M.number(), y: M.number() }), [M.bigint()], M.record()),
+    [[1, 5n]],
+  );
+  testTriple(
+    { x: 3, y: 5, z: 9 },
+    M.or(harden({ x: M.number(), y: M.number() }), M.bigint(), M.record()),
+    [[2, { x: 3, y: 5, z: 9 }]],
+  );
+  testTriple(
+    {
+      brand,
+      value: [{ bar: 2 }, { bar: 1 }],
+    },
+    {
+      brand,
+      value: M.arrayOf(M.and(M.key(), { bar: M.number() })),
+    },
+    [[[[2]], [[1]]]],
+  );
+};
+
+test('compression', t => {
+  const testCompress = (specimen, pattern, bindings) =>
+    t.deepEqual(compress(harden(specimen), harden(pattern)), harden(bindings));
+  runTests(testCompress);
+});
+
+test('test mustCompress', t => {
+  const testCompress = (specimen, pattern, bindings, message) => {
+    if (bindings === undefined) {
+      t.throws(
+        () =>
+          mustCompress(harden(specimen), harden(pattern), 'test mustCompress'),
+        { message },
+      );
+    } else {
+      t.deepEqual(
+        mustCompress(harden(specimen), harden(pattern), 'test mustCompress'),
+        harden(bindings),
+      );
+    }
+  };
+  runTests(testCompress);
+});
+
+test('decompression', t => {
+  const testDecompress = (specimen, pattern, bindings) =>
+    bindings === undefined ||
+    t.deepEqual(
+      decompress(harden(bindings), harden(pattern)),
+      harden(specimen),
+    );
+  runTests(testDecompress);
+});

--- a/packages/store/test/test-patterns.js
+++ b/packages/store/test/test-patterns.js
@@ -41,7 +41,7 @@ const runTests = (successCase, failCase) => {
     failCase(specimen, M.gte('x'), '3 - Must be >= "x"');
     failCase(specimen, M.and(3, 4), '3 - Must be: 4');
     failCase(specimen, M.or(4, 4), '3 - Must match one of [4,4]');
-    failCase(specimen, M.or(), '3 - no pattern disjuncts to match: []');
+    failCase(specimen, M.or(), '3 - Must fail negated pattern: "[match:any]"');
   }
   {
     const specimen = [3, 4];

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -70,6 +70,12 @@ type DefineKindOptions<C> = {
   durable?: boolean;
 
   /**
+   * If provided, it describes the shape of all state records of instances
+   * of this kind.
+   */
+  stateShape?: { [name: string]: Pattern };
+
+  /**
    * Intended for internal use only.
    * Should the raw methods receive their `context` argument as their first
    * argument or as their `this` binding? For `defineDurableKind` and its

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -122,16 +122,20 @@ harden(partialAssign);
  */
 export const provide = provideLazy;
 
-export const provideDurableMapStore = (baggage, name) =>
-  provide(baggage, name, () => makeScalarBigMapStore(name, { durable: true }));
+export const provideDurableMapStore = (baggage, name, options = {}) =>
+  provide(baggage, name, () =>
+    makeScalarBigMapStore(name, { durable: true, ...options }),
+  );
 harden(provideDurableMapStore);
 
-export const provideDurableWeakMapStore = (baggage, name) =>
+export const provideDurableWeakMapStore = (baggage, name, options = {}) =>
   provide(baggage, name, () =>
-    makeScalarBigWeakMapStore(name, { durable: true }),
+    makeScalarBigWeakMapStore(name, { durable: true, ...options }),
   );
 harden(provideDurableWeakMapStore);
 
-export const provideDurableSetStore = (baggage, name) =>
-  provide(baggage, name, () => makeScalarBigSetStore(name, { durable: true }));
+export const provideDurableSetStore = (baggage, name, options = {}) =>
+  provide(baggage, name, () =>
+    makeScalarBigSetStore(name, { durable: true, ...options }),
+  );
 harden(provideDurableSetStore);


### PR DESCRIPTION
When the only specimens you store are those that match a pattern, store only the information which is not literally the same as the pattern.

Added to the store module
   * `compress(specimen, pattern)` - returns bindings array, or `undefined` to indicate match failure
   * `mustCompress(specimen, pattern, label)` - indicates failure with diagnostic including `label`
   * `decompress(bindings, pattern)` - undoes the others.

Modified SwingSet's virtual mapStores so that if they have a `valueShape` option, they also use it for compression.

Modified ERTP's paymentLedger to provide the `amountShape` as the `valueShape` option for the durable ledger mapStore.

Verified in the debugger that we now only store a singleton array around the value itself, dropping the enclosing amount structure and the brand which is always the same for a given ledger mapStore. IOW, instead of storing the serialization of
```js
{
   brand: moolaBrand,
   value: 2n,
}
```
for every live payment, with this PR we store the serialization of
```js
[2n]
```
for every live payment. This is not just a savings because it is smaller. We also avoid needing to adjust the refcount of their common `moolaBrand`.

Once we've switched to smallcaps, the serialization of `[2n]` is tiny.