### PR TITLE
refactor(ertp): improve vivify factoring

### DIFF
--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -26,8 +26,8 @@ import './types.js';
  * @template {AssetKind} K
  * @param {IssuerRecord<K>} issuerRecord
  * @param {Baggage} issuerBaggage
- * @param {ShutdownWithFailure=} optShutdownWithFailure If this issuer fails
- * in the middle of an atomic action (which btw should never happen), it
+ * @param {ShutdownWithFailure | undefined} optShutdownWithFailure If this issuer
+ * fails in the middle of an atomic action (which btw should never happen), it
  * potentially leaves its ledger in a corrupted state. If this function was
  * provided, then the failed atomic action will call it, so that some
  * larger unit of computation, like the enclosing vat, can be shutdown

--- a/packages/ERTP/test/swingsetTests/ertpService/vat-ertp-service.js
+++ b/packages/ERTP/test/swingsetTests/ertpService/vat-ertp-service.js
@@ -34,7 +34,7 @@ export const vivifyErtpService = (baggage, exitVatWithFailure) => {
   });
 
   for (const issuerBaggage of issuerBaggageSet.values()) {
-    vivifyIssuerKit(issuerBaggage);
+    vivifyIssuerKit(issuerBaggage, exitVatWithFailure);
   }
 
   return ertpService;

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -11,7 +11,7 @@ test('makeIssuerKit bad allegedName', async t => {
   t.throws(() => makeIssuerKit(harden({})), { message: `{} must be a string` });
   // @ts-expect-error Intentional wrong type for testing
   t.throws(() => makeIssuerKit({}), {
-    message: `Cannot pass non-frozen objects like {}. Use harden()`,
+    message: `{} must be a string`,
   });
 });
 

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -7,15 +7,10 @@ import {
   ceilMultiplyBy,
   floorMultiplyBy,
 } from '@agoric/zoe/src/contractSupport/index.js';
-import { AmountMath } from '@agoric/ertp';
-import {
-  defineDurableKindMulti,
-  makeKindHandle,
-  pickFacet,
-} from '@agoric/vat-data';
+import { AmountMath, IssuerShape, PaymentShape } from '@agoric/ertp';
+import { M, pickFacet, vivifyFarClassKit } from '@agoric/vat-data';
 import { makeTracer } from '../makeTracer.js';
 import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
-import { makeVaultKit } from './vaultKit.js';
 import {
   addSubtract,
   assertOnlyKeys,
@@ -141,668 +136,687 @@ const validTransitions = {
 // @ts-expect-error not yet defined
 const provideEphemera = makeEphemeraProvider(() => ({}));
 
-/**
- * @param {ZCF} zcf
- * @param {VaultManager} manager
- * @param {VaultId} idInManager
- * @param {ERef<StorageNode>} storageNode
- * @param {ERef<Marshaller>} marshaller
- */
-const initState = (zcf, manager, idInManager, storageNode, marshaller) => {
-  const ephemera = provideEphemera(idInManager);
-  ephemera.storageNode = storageNode;
-  ephemera.marshaller = marshaller;
-  ephemera.zcf = zcf;
+// TODO what do we call facets that are for children pointing at their internal parent?
 
-  /**
-   * @type {ImmutableState & MutableState}
-   */
-  return harden({
-    idInManager,
-    manager,
-    outerUpdater: null,
-    phase: Phase.ACTIVE,
-
-    // vaultSeat will hold the collateral until the loan is retired. The
-    // payout from it will be handed to the user: if the vault dies early
-    // (because the vaultFactory vat died), they'll get all their
-    // collateral back. If that happens, the issuer for the Minted will be dead,
-    // so their loan will be worthless.
-    vaultSeat: zcf.makeEmptySeatKit().zcfSeat,
-
-    // Two values from the same moment
-    interestSnapshot: manager.getCompoundedInterest(),
-    debtSnapshot: AmountMath.makeEmpty(manager.getDebtBrand()),
-  });
-};
-
-/**
- * Check whether we can proceed with an `adjustBalances`.
- *
- * @param {Amount} newCollateralPre
- * @param {Amount} maxDebtPre
- * @param {Amount} newCollateral
- * @param {Amount} newDebt
- * @returns {boolean}
- */
-const checkRestart = (newCollateralPre, maxDebtPre, newCollateral, newDebt) => {
-  if (AmountMath.isGTE(newCollateralPre, newCollateral)) {
-    // The collateral did not go up. If the collateral decreased, we pro-rate maxDebt.
-    // We can pro-rate maxDebt because the quote is either linear (price is
-    // unchanging) or super-linear (also called "convex"). Super-linear is from
-    // AMMs: selling less collateral would mean an even smaller price impact, so
-    // this is a conservative choice.
-    const debtPerCollateral = makeRatioFromAmounts(
-      maxDebtPre,
-      newCollateralPre,
-    );
-    // `floorMultiply` because the debt ceiling should be tight
-    const maxDebtAfter = floorMultiplyBy(newCollateral, debtPerCollateral);
-    assert(
-      AmountMath.isGTE(maxDebtAfter, newDebt),
-      X`The requested debt ${q(
-        newDebt,
-      )} is more than the collateralization ratio allows: ${q(maxDebtAfter)}`,
-    );
-    // The `collateralAfter` can still cover the `newDebt`, so don't restart.
-    return false;
-  }
-  // The collateral went up. Restart if the debt *also* went up because
-  // the price quote might not apply at the higher numbers.
-  return !AmountMath.isGTE(maxDebtPre, newDebt);
-};
-
-const helperBehavior = {
+export const vivifayVaultFactory = (baggage, zcf, manager) => {
   // #region Computed constants
-  collateralBrand: ({ state }) => state.manager.getCollateralBrand(),
-  debtBrand: ({ state }) => state.manager.getDebtBrand(),
-
-  emptyCollateral: ({ facets }) =>
-    AmountMath.makeEmpty(facets.helper.collateralBrand()),
-  emptyDebt: ({ facets }) => AmountMath.makeEmpty(facets.helper.debtBrand()),
-  // #endregion
-
-  // #region Phase logic
-  /**
-   * @param {MethodContext} context
-   * @param {VaultPhase} newPhase
-   */
-  assignPhase: ({ state }, newPhase) => {
-    const { phase } = state;
-    const validNewPhases = validTransitions[phase];
-    validNewPhases.includes(newPhase) ||
-      assert.fail(
-        X`Vault cannot transition from ${q(phase)} to ${q(newPhase)}`,
-      );
-    state.phase = newPhase;
-  },
-
-  assertActive: ({ state }) => {
-    const { phase } = state;
-    assert(phase === Phase.ACTIVE);
-  },
-
-  assertCloseable: ({ state }) => {
-    const { phase } = state;
-    phase === Phase.ACTIVE ||
-      phase === Phase.LIQUIDATED ||
-      assert.fail(
-        X`to be closed a vault must be active or liquidated, not ${phase}`,
-      );
-  },
+  const emptyCollateral = AmountMath.makeEmpty(manager.collateralBrand());
+  const emptyMinted = AmountMath.makeEmpty(manager.debtBrand());
   // #endregion
 
   /**
-   * Called whenever the debt is paid or created through a transaction,
-   * but not for interest accrual.
    *
-   * @param {MethodContext} context
-   * @param {Amount} newDebt - principal and all accrued interest
-   */
-  updateDebtSnapshot: ({ state }, newDebt) => {
-    // update local state
-    state.debtSnapshot = newDebt;
-    state.interestSnapshot = state.manager.getCompoundedInterest();
-  },
-
-  /**
-   * Update the debt balance and propagate upwards to
-   * maintain aggregate debt and liquidation order.
-   *
-   * @param {MethodContext} context
-   * @param {NormalizedDebt} oldDebtNormalized - prior principal and all accrued interest, normalized to the launch of the vaultManager
-   * @param {Amount<'nat'>} oldCollateral - actual collateral
-   * @param {Amount<'nat'>} newDebtActual - actual principal and all accrued interest
-   */
-  updateDebtAccounting: (
-    { state, facets },
-    oldDebtNormalized,
-    oldCollateral,
-    newDebtActual,
-  ) => {
-    const { helper } = facets;
-    helper.updateDebtSnapshot(newDebtActual);
-    // notify manager so it can notify and clean up as appropriate
-    state.manager.handleBalanceChange(
-      oldDebtNormalized,
-      oldCollateral,
-      state.idInManager,
-      state.phase,
-      facets.self,
-    );
-  },
-
-  /**
-   *
-   * @param {MethodContext} context
    * @param {ZCFSeat} seat
    */
-  getCollateralAllocated: ({ facets }, seat) =>
-    seat.getAmountAllocated('Collateral', facets.helper.collateralBrand()),
-  getMintedAllocated: ({ facets }, seat) =>
-    seat.getAmountAllocated('Minted', facets.helper.debtBrand()),
+  const getCollateralAllocated = seat =>
+    seat.getAmountAllocated('Collateral', manager.collateralBrand());
+  const getMintedAllocated = seat =>
+    seat.getAmountAllocated('Minted', manager.debtBrand());
 
-  assertVaultHoldsNoMinted: ({ state, facets }) => {
-    const { vaultSeat } = state;
-    AmountMath.isEmpty(facets.helper.getMintedAllocated(vaultSeat)) ||
-      assert.fail(X`Vault should be empty of Minted`);
-  },
+  // const [anchorAmountShape, stableAmountShape] = await Promise.all([
+  //   E(anchorBrand).getAmountShape(),
+  //   E(stableBrand).getAmountShape(),
+  // ]);
+  // TODO add accessors for the shapes on the vault manager
+
+  const VaultI = M.interface('Vault', {
+    getIssuer: M.call().returns(IssuerShape),
+    mintPayment: M.call(manager.getCollateralShape()).returns(PaymentShape),
+  });
+  const HelperI = M.interface('DepositFacet', {
+    // receive: ,
+  });
+
+  const VaultIKit = harden({
+    helpers: HelperI,
+    vault: VaultI,
+  });
 
   /**
    *
-   * @param {MethodContext} context
    * @param {Amount<'nat'>} collateralAmount
    * @param {Amount<'nat'>} proposedRunDebt
    */
-  assertSufficientCollateral: async (
-    { state, facets },
+  const assertSufficientCollateral = async (
     collateralAmount,
     proposedRunDebt,
   ) => {
-    const maxRun = await state.manager.maxDebtFor(collateralAmount);
+    const maxRun = await manager.maxDebtFor(collateralAmount);
     assert(
-      AmountMath.isGTE(maxRun, proposedRunDebt, facets.helper.debtBrand()),
+      AmountMath.isGTE(maxRun, proposedRunDebt, manager.debtBrand()),
       X`Requested ${q(proposedRunDebt)} exceeds max ${q(maxRun)} for ${q(
         collateralAmount,
       )} collateral`,
     );
-  },
+  };
 
   /**
-   *
-   * @param {MethodContext} context
-   * @param {HolderPhase} newPhase
-   */
-  getStateSnapshot: ({ state, facets }, newPhase) => {
-    const { debtSnapshot: debt, interestSnapshot: interest } = state;
-    /** @type {VaultNotification} */
-    return harden({
-      debtSnapshot: { debt, interest },
-      locked: facets.self.getCollateralAmount(),
-      // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
-      // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
-      vaultState: newPhase,
-    });
-  },
-
-  /**
-   * call this whenever anything changes!
-   *
-   * @param {MethodContext} context
-   */
-  updateUiState: ({ state, facets }) => {
-    const ephemera = provideEphemera(state.idInManager);
-    const { outerUpdater } = ephemera;
-    if (!outerUpdater) {
-      // It's not an error to change to liquidating during transfer
-      return;
-    }
-    const { phase } = state;
-    const uiState = facets.helper.getStateSnapshot(phase);
-    trace('updateUiState', state.idInManager, uiState);
-
-    switch (phase) {
-      case Phase.ACTIVE:
-      case Phase.LIQUIDATING:
-      case Phase.LIQUIDATED:
-        outerUpdater.publish(uiState);
-        break;
-      case Phase.CLOSED:
-        outerUpdater.finish(uiState);
-        ephemera.outerUpdater = null;
-        break;
-      default:
-        throw Error(`unreachable vault phase: ${phase}`);
-    }
-  },
-
-  /**
-   * @param {MethodContext} context
-   * @param {ZCFSeat} seat
-   */
-  closeHook: async ({ state, facets }, seat) => {
-    const { self, helper } = facets;
-    helper.assertCloseable();
-    const { phase, vaultSeat } = state;
-    const { zcf } = provideEphemera(state.idInManager);
-
-    // Held as keys for cleanup in the manager
-    const oldDebtNormalized = self.getNormalizedDebt();
-    const oldCollateral = self.getCollateralAmount();
-
-    if (phase === Phase.ACTIVE) {
-      assertProposalShape(seat, {
-        give: { Minted: null },
-      });
-
-      // you're paying off the debt, you get everything back.
-      const debt = self.getCurrentDebt();
-      const {
-        give: { Minted: given },
-      } = seat.getProposal();
-
-      // you must pay off the entire remainder but if you offer too much, we won't
-      // take more than you owe
-      AmountMath.isGTE(given, debt) ||
-        assert.fail(
-          X`Offer ${given} is not sufficient to pay off debt ${debt}`,
-        );
-
-      // Return any overpayment
-      seat.incrementBy(vaultSeat.decrementBy(vaultSeat.getCurrentAllocation()));
-      zcf.reallocate(seat, vaultSeat);
-      state.manager.burnAndRecord(debt, seat);
-    } else if (phase === Phase.LIQUIDATED) {
-      // Simply reallocate vault assets to the offer seat.
-      // Don't take anything from the offer, even if vault is underwater.
-      // TODO verify that returning Minted here doesn't mess up debt limits
-      seat.incrementBy(vaultSeat.decrementBy(vaultSeat.getCurrentAllocation()));
-      zcf.reallocate(seat, vaultSeat);
-    } else {
-      throw new Error('only active and liquidated vaults can be closed');
-    }
-
-    seat.exit();
-    helper.assignPhase(Phase.CLOSED);
-    helper.updateDebtSnapshot(helper.emptyDebt());
-    helper.updateUiState();
-
-    helper.assertVaultHoldsNoMinted();
-    vaultSeat.exit();
-
-    state.manager.handleBalanceChange(
-      oldDebtNormalized,
-      oldCollateral,
-      state.idInManager,
-      state.phase,
-      facets.self,
-    );
-
-    return 'your loan is closed, thank you for your business';
-  },
-
-  /**
-   * Calculate the fee, the amount to mint and the resulting debt.
-   * The give and the want together reflect a delta, where typically
-   * one is zero because they come from the gave/want of an offer
-   * proposal. If the `want` is zero, the `fee` will also be zero,
-   * so the simple math works.
-   *
-   * @param {MethodContext} context
-   * @param {Amount} currentDebt
-   * @param {Amount} giveAmount
-   * @param {Amount} wantAmount
-   */
-  loanFee: ({ state }, currentDebt, giveAmount, wantAmount) => {
-    const fee = ceilMultiplyBy(
-      wantAmount,
-      state.manager.getGovernedParams().getLoanFee(),
-    );
-    const toMint = AmountMath.add(wantAmount, fee);
-    const newDebt = addSubtract(currentDebt, toMint, giveAmount);
-    return { newDebt, toMint, fee };
-  },
-
-  /**
-   * Adjust principal and collateral (atomically for offer safety)
-   *
-   * @param {MethodContext} context
-   * @param {ZCFSeat} clientSeat
-   * @returns {Promise<string>} success message
-   */
-  adjustBalancesHook: async ({ state, facets }, clientSeat) => {
-    const { self, helper } = facets;
-    const ephemera = provideEphemera(state.idInManager);
-    const { outerUpdater: updaterPre } = ephemera;
-    const { vaultSeat } = state;
-    const proposal = clientSeat.getProposal();
-    assertOnlyKeys(proposal, ['Collateral', 'Minted']);
-
-    const allEmpty = amounts => {
-      return amounts.every(a => AmountMath.isEmpty(a));
-    };
-
-    const normalizedDebtPre = self.getNormalizedDebt();
-    const collateralPre = helper.getCollateralAllocated(vaultSeat);
-
-    const giveColl = proposal.give.Collateral || helper.emptyCollateral();
-    const wantColl = proposal.want.Collateral || helper.emptyCollateral();
-
-    const newCollateralPre = addSubtract(collateralPre, giveColl, wantColl);
-    // max debt supported by current Collateral as modified by proposal
-    const maxDebtPre = await state.manager.maxDebtFor(newCollateralPre);
-    updaterPre === ephemera.outerUpdater ||
-      assert.fail(X`Transfer during vault adjustment`);
-    helper.assertActive();
-
-    // After the `await`, we retrieve the vault's allocations again,
-    // so we can compare to the debt limit based on the new values.
-    const collateral = helper.getCollateralAllocated(vaultSeat);
-    const newCollateral = addSubtract(collateral, giveColl, wantColl);
-
-    const debt = self.getCurrentDebt();
-    const giveMinted = AmountMath.min(
-      proposal.give.Minted || helper.emptyDebt(),
-      debt,
-    );
-    const wantMinted = proposal.want.Minted || helper.emptyDebt();
-    if (allEmpty([giveColl, giveMinted, wantColl, wantMinted])) {
-      clientSeat.exit();
-      return 'no transaction, as requested';
-    }
-
-    // Calculate the fee, the amount to mint and the resulting debt. We'll
-    // verify that the target debt doesn't violate the collateralization ratio,
-    // then mint, reallocate, and burn.
-    const { newDebt, fee, toMint } = helper.loanFee(
-      debt,
-      giveMinted,
-      wantMinted,
-    );
-
-    trace('adjustBalancesHook', state.idInManager, {
-      newCollateralPre,
-      newCollateral,
-      fee,
-      toMint,
-      newDebt,
-    });
-
-    if (checkRestart(newCollateralPre, maxDebtPre, newCollateral, newDebt)) {
-      return helper.adjustBalancesHook(clientSeat);
-    }
-
-    stageDelta(clientSeat, vaultSeat, giveColl, wantColl, 'Collateral');
-    // `wantMinted` is allocated in the reallocate and mint operation, and so not here
-    stageDelta(clientSeat, vaultSeat, giveMinted, helper.emptyDebt(), 'Minted');
-
-    /** @type {Array<ZCFSeat>} */
-    const vaultSeatOpt = allEmpty([giveColl, giveMinted, wantColl])
-      ? []
-      : [vaultSeat];
-    state.manager.mintAndReallocate(toMint, fee, clientSeat, ...vaultSeatOpt);
-
-    // parent needs to know about the change in debt
-    helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebt);
-    state.manager.burnAndRecord(giveMinted, vaultSeat);
-    helper.assertVaultHoldsNoMinted();
-
-    helper.updateUiState();
-    clientSeat.exit();
-    return 'We have adjusted your balances, thank you for your business';
-  },
-
-  /**
-   *
-   * @param {MethodContext} context
-   * @param {ZCFSeat} seat
-   * @returns {VaultKit}
-   */
-  makeTransferInvitationHook: ({ state, facets }, seat) => {
-    const { self, helper } = facets;
-    helper.assertCloseable();
-    seat.exit();
-
-    const ephemera = provideEphemera(state.idInManager);
-
-    // eslint-disable-next-line no-use-before-define
-    const vaultKit = makeVaultKit(
-      self,
-      ephemera.storageNode,
-      ephemera.marshaller,
-      state.manager.getAssetSubscriber(),
-    );
-    ephemera.outerUpdater = vaultKit.vaultUpdater;
-    helper.updateUiState();
-
-    return vaultKit;
-  },
-};
-
-const selfBehavior = {
-  /**
-   * @param {MethodContext} context
-   */
-  getVaultSeat: ({ state }) => state.vaultSeat,
-
-  /**
-   * @param {MethodContext} context
-   * @param {ZCFSeat} seat
+   * @param {ZCF} zcf
+   * @param {VaultManager} manager
+   * @param {VaultId} idInManager
    * @param {ERef<StorageNode>} storageNode
    * @param {ERef<Marshaller>} marshaller
    */
-  initVaultKit: async ({ state, facets }, seat, storageNode, marshaller) => {
-    assert(seat && storageNode && marshaller, 'initVaultKit missing argument');
-    const ephemera = provideEphemera(state.idInManager);
 
-    const { self, helper } = facets;
-
-    const normalizedDebtPre = self.getNormalizedDebt();
-    const actualDebtPre = self.getCurrentDebt();
-    assert(
-      AmountMath.isEmpty(normalizedDebtPre) &&
-        AmountMath.isEmpty(actualDebtPre),
-      X`vault must be empty initially`,
-    );
-
-    const collateralPre = self.getCollateralAmount();
-    trace('initVaultKit start: collateral', state.idInManager, {
-      actualDebtPre,
-      collateralPre,
-    });
-
-    // get the payout to provide access to the collateral if the
-    // contract abandons
-    const {
-      give: { Collateral: giveCollateral },
-      want: { Minted: wantMinted },
-    } = seat.getProposal();
-
-    const {
-      newDebt: newDebtPre,
-      fee,
-      toMint,
-    } = helper.loanFee(actualDebtPre, helper.emptyDebt(), wantMinted);
-    !AmountMath.isEmpty(fee) ||
-      assert.fail(
-        X`loan requested (${wantMinted}) is too small; cannot accrue interest`,
+  /**
+   * Check whether we can proceed with an `adjustBalances`.
+   *
+   * @param {Amount} newCollateralPre
+   * @param {Amount} maxDebtPre
+   * @param {Amount} newCollateral
+   * @param {Amount} newDebt
+   * @returns {boolean}
+   */
+  const checkRestart = (
+    newCollateralPre,
+    maxDebtPre,
+    newCollateral,
+    newDebt,
+  ) => {
+    if (AmountMath.isGTE(newCollateralPre, newCollateral)) {
+      // The collateral did not go up. If the collateral decreased, we pro-rate maxDebt.
+      // We can pro-rate maxDebt because the quote is either linear (price is
+      // unchanging) or super-linear (also called "convex"). Super-linear is from
+      // AMMs: selling less collateral would mean an even smaller price impact, so
+      // this is a conservative choice.
+      const debtPerCollateral = makeRatioFromAmounts(
+        maxDebtPre,
+        newCollateralPre,
       );
-    assert(AmountMath.isEqual(newDebtPre, toMint), X`fee mismatch for vault`);
-    trace(
-      'initVault',
-      state.idInManager,
-      { wantedRun: wantMinted, fee },
-      self.getCollateralAmount(),
-    );
-
-    await helper.assertSufficientCollateral(giveCollateral, newDebtPre);
-
-    const { vaultSeat } = state;
-    vaultSeat.incrementBy(
-      seat.decrementBy(harden({ Collateral: giveCollateral })),
-    );
-    state.manager.mintAndReallocate(toMint, fee, seat, vaultSeat);
-    helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebtPre);
-
-    const vaultKit = makeVaultKit(
-      self,
-      storageNode,
-      marshaller,
-      state.manager.getAssetSubscriber(),
-    );
-    ephemera.outerUpdater = vaultKit.vaultUpdater;
-    helper.updateUiState();
-    return vaultKit;
-  },
-
-  /**
-   * Called by manager at start of liquidation.
-   *
-   * @param {MethodContext} context
-   */
-  liquidating: ({ facets }) => {
-    const { helper } = facets;
-    helper.assignPhase(Phase.LIQUIDATING);
-    helper.updateUiState();
-  },
-
-  /**
-   * Called by manager at end of liquidation, at which point all debts have been
-   * covered.
-   *
-   * @param {MethodContext} context
-   */
-  liquidated: ({ facets }) => {
-    const { helper } = facets;
-    helper.updateDebtSnapshot(
-      // liquidated vaults retain no debt
-      AmountMath.makeEmpty(helper.debtBrand()),
-    );
-
-    helper.assignPhase(Phase.LIQUIDATED);
-    helper.updateUiState();
-  },
-
-  /**
-   * @param {MethodContext} context
-   */
-  makeAdjustBalancesInvitation: ({ state, facets }) => {
-    const { helper } = facets;
-    helper.assertActive();
-    const { zcf } = provideEphemera(state.idInManager);
-    return zcf.makeInvitation(
-      seat => helper.adjustBalancesHook(seat),
-      'AdjustBalances',
-    );
-  },
-
-  /**
-   * @param {MethodContext} context
-   */
-  makeCloseInvitation: ({ state, facets }) => {
-    const { helper } = facets;
-    helper.assertCloseable();
-    const { zcf } = provideEphemera(state.idInManager);
-    return zcf.makeInvitation(seat => helper.closeHook(seat), 'CloseVault');
-  },
-
-  /**
-   * @param {MethodContext} context
-   * @returns {Promise<Invitation>}
-   */
-  makeTransferInvitation: ({ state, facets }) => {
-    const ephemera = provideEphemera(state.idInManager);
-    const { outerUpdater } = ephemera;
-    const { self, helper } = facets;
-    // Bring the debt snapshot current for the final report before transfer
-    helper.updateDebtSnapshot(self.getCurrentDebt());
-    const { debtSnapshot: debt, interestSnapshot: interest, phase } = state;
-    if (outerUpdater) {
-      outerUpdater.finish(helper.getStateSnapshot(Phase.TRANSFER));
-      ephemera.outerUpdater = null;
+      // `floorMultiply` because the debt ceiling should be tight
+      const maxDebtAfter = floorMultiplyBy(newCollateral, debtPerCollateral);
+      assert(
+        AmountMath.isGTE(maxDebtAfter, newDebt),
+        X`The requested debt ${q(
+          newDebt,
+        )} is more than the collateralization ratio allows: ${q(maxDebtAfter)}`,
+      );
+      // The `collateralAfter` can still cover the `newDebt`, so don't restart.
+      return false;
     }
-    const transferState = {
-      debtSnapshot: { debt, interest },
-      locked: self.getCollateralAmount(),
-      vaultState: phase,
-    };
-    const { zcf } = provideEphemera(state.idInManager);
-    return zcf.makeInvitation(
-      seat => helper.makeTransferInvitationHook(seat),
-      'TransferVault',
-      transferState,
-    );
-  },
+    // The collateral went up. Restart if the debt *also* went up because
+    // the price quote might not apply at the higher numbers.
+    return !AmountMath.isGTE(maxDebtPre, newDebt);
+  };
 
-  // for status/debugging
+  const helperBehavior = {
+    // #region Phase logic
+    /**
+     * @param {VaultPhase} newPhase
+     */
+    assignPhase(newPhase) {
+      const { state } = this;
+      const { phase } = state;
+      const validNewPhases = validTransitions[phase];
+      validNewPhases.includes(newPhase) ||
+        assert.fail(
+          X`Vault cannot transition from ${q(phase)} to ${q(newPhase)}`,
+        );
+      state.phase = newPhase;
+    },
 
+    assertActive() {
+      const { phase } = this.state;
+      assert(phase === Phase.ACTIVE);
+    },
+
+    assertCloseable() {
+      const { phase } = this.state;
+      phase === Phase.ACTIVE ||
+        phase === Phase.LIQUIDATED ||
+        assert.fail(
+          X`to be closed a vault must be active or liquidated, not ${phase}`,
+        );
+    },
+    // #endregion
+
+    /**
+     * Called whenever the debt is paid or created through a transaction,
+     * but not for interest accrual.
+     *
+     * @param {Amount} newDebt - principal and all accrued interest
+     */
+    updateDebtSnapshot(newDebt) {
+      // update local state
+      const { state } = this;
+      state.debtSnapshot = newDebt;
+      state.interestSnapshot = manager.getCompoundedInterest();
+    },
+
+    /**
+     * Update the debt balance and propagate upwards to
+     * maintain aggregate debt and liquidation order.
+     *
+     * @param {NormalizedDebt} oldDebtNormalized - prior principal and all accrued interest, normalized to the launch of the vaultManager
+     * @param {Amount<'nat'>} oldCollateral - actual collateral
+     * @param {Amount<'nat'>} newDebtActual - actual principal and all accrued interest
+     */
+    updateDebtAccounting(oldDebtNormalized, oldCollateral, newDebtActual) {
+      const { state, facets } = this;
+      const { helper } = facets;
+      helper.updateDebtSnapshot(newDebtActual);
+      // notify manager so it can notify and clean up as appropriate
+      manager.handleBalanceChange(
+        oldDebtNormalized,
+        oldCollateral,
+        state.idInManager,
+        state.phase,
+        facets.self,
+      );
+    },
+
+    assertVaultHoldsNoMinted() {
+      const { state } = this;
+      const { vaultSeat } = state;
+      AmountMath.isEmpty(getMintedAllocated(vaultSeat)) ||
+        assert.fail(X`Vault should be empty of Minted`);
+    },
+
+    /**
+     *
+     * @param {HolderPhase} newPhase
+     */
+    getStateSnapshot(newPhase) {
+      const { state, facets } = this;
+      const { debtSnapshot: debt, interestSnapshot: interest } = state;
+      /** @type {VaultNotification} */
+      return harden({
+        debtSnapshot: { debt, interest },
+        locked: facets.self.getCollateralAmount(),
+        // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
+        // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
+        vaultState: newPhase,
+      });
+    },
+
+    /**
+     * call this whenever anything changes!
+     *
+     */
+    updateUiState() {
+      const { state, facets } = this;
+      const ephemera = provideEphemera(state.idInManager);
+      const { outerUpdater } = ephemera;
+      if (!outerUpdater) {
+        // It's not an error to change to liquidating during transfer
+        return;
+      }
+      const { phase } = state;
+      const uiState = facets.helper.getStateSnapshot(phase);
+      trace('updateUiState', state.idInManager, uiState);
+
+      switch (phase) {
+        case Phase.ACTIVE:
+        case Phase.LIQUIDATING:
+        case Phase.LIQUIDATED:
+          outerUpdater.publish(uiState);
+          break;
+        case Phase.CLOSED:
+          outerUpdater.finish(uiState);
+          ephemera.outerUpdater = null;
+          break;
+        default:
+          throw Error(`unreachable vault phase: ${phase}`);
+      }
+    },
+
+    /**
+     * @param {ZCFSeat} seat
+     */
+    async closeHook(seat) {
+      const { state, facets } = this;
+      const { self, helper } = facets;
+      helper.assertCloseable();
+      const { phase, vaultSeat } = state;
+
+      // Held as keys for cleanup in the manager
+      const oldDebtNormalized = self.getNormalizedDebt();
+      const oldCollateral = self.getCollateralAmount();
+
+      if (phase === Phase.ACTIVE) {
+        assertProposalShape(seat, {
+          give: { Minted: null },
+        });
+
+        // you're paying off the debt, you get everything back.
+        const debt = self.getCurrentDebt();
+        const {
+          give: { Minted: given },
+        } = seat.getProposal();
+
+        // you must pay off the entire remainder but if you offer too much, we won't
+        // take more than you owe
+        AmountMath.isGTE(given, debt) ||
+          assert.fail(
+            X`Offer ${given} is not sufficient to pay off debt ${debt}`,
+          );
+
+        // Return any overpayment
+        seat.incrementBy(
+          vaultSeat.decrementBy(vaultSeat.getCurrentAllocation()),
+        );
+        zcf.reallocate(seat, vaultSeat);
+        manager.burnAndRecord(debt, seat);
+      } else if (phase === Phase.LIQUIDATED) {
+        // Simply reallocate vault assets to the offer seat.
+        // Don't take anything from the offer, even if vault is underwater.
+        // TODO verify that returning Minted here doesn't mess up debt limits
+        seat.incrementBy(
+          vaultSeat.decrementBy(vaultSeat.getCurrentAllocation()),
+        );
+        zcf.reallocate(seat, vaultSeat);
+      } else {
+        throw new Error('only active and liquidated vaults can be closed');
+      }
+
+      seat.exit();
+      helper.assignPhase(Phase.CLOSED);
+      helper.updateDebtSnapshot(emptyCollateral);
+      helper.updateUiState();
+
+      helper.assertVaultHoldsNoMinted();
+      vaultSeat.exit();
+
+      manager.handleBalanceChange(
+        oldDebtNormalized,
+        oldCollateral,
+        state.idInManager,
+        state.phase,
+        facets.self,
+      );
+
+      return 'your loan is closed, thank you for your business';
+    },
+
+    /**
+     * Calculate the fee, the amount to mint and the resulting debt.
+     * The give and the want together reflect a delta, where typically
+     * one is zero because they come from the gave/want of an offer
+     * proposal. If the `want` is zero, the `fee` will also be zero,
+     * so the simple math works.
+     *
+     * @param {Amount} currentDebt
+     * @param {Amount} giveAmount
+     * @param {Amount} wantAmount
+     */
+    loanFee(currentDebt, giveAmount, wantAmount) {
+      const { state } = this;
+      const fee = ceilMultiplyBy(
+        wantAmount,
+        manager.getGovernedParams().getLoanFee(),
+      );
+      const toMint = AmountMath.add(wantAmount, fee);
+      const newDebt = addSubtract(currentDebt, toMint, giveAmount);
+      return { newDebt, toMint, fee };
+    },
+
+    /**
+     * Adjust principal and collateral (atomically for offer safety)
+     *
+     * @param {ZCFSeat} clientSeat
+     * @returns {Promise<string>} success message
+     */
+    async adjustBalancesHook(clientSeat) {
+      const { state, facets } = this;
+      const { self, helper } = facets;
+      const ephemera = provideEphemera(state.idInManager);
+      const { outerUpdater: updaterPre } = ephemera;
+      const { vaultSeat } = state;
+      const proposal = clientSeat.getProposal();
+      assertOnlyKeys(proposal, ['Collateral', 'Minted']);
+
+      const allEmpty = amounts => {
+        return amounts.every(a => AmountMath.isEmpty(a));
+      };
+
+      const normalizedDebtPre = self.getNormalizedDebt();
+      const collateralPre = getCollateralAllocated(vaultSeat);
+
+      const giveColl = proposal.give.Collateral || emptyCollateral;
+      const wantColl = proposal.want.Collateral || emptyCollateral;
+
+      const newCollateralPre = addSubtract(collateralPre, giveColl, wantColl);
+      // max debt supported by current Collateral as modified by proposal
+      const maxDebtPre = await manager.maxDebtFor(newCollateralPre);
+      updaterPre === ephemera.outerUpdater ||
+        assert.fail(X`Transfer during vault adjustment`);
+      helper.assertActive();
+
+      // After the `await`, we retrieve the vault's allocations again,
+      // so we can compare to the debt limit based on the new values.
+      const collateral = getCollateralAllocated(vaultSeat);
+      const newCollateral = addSubtract(collateral, giveColl, wantColl);
+
+      const debt = self.getCurrentDebt();
+      const giveMinted = AmountMath.min(
+        proposal.give.Minted || emptyMinted,
+        debt,
+      );
+      const wantMinted = proposal.want.Minted || emptyMinted;
+      if (allEmpty([giveColl, giveMinted, wantColl, wantMinted])) {
+        clientSeat.exit();
+        return 'no transaction, as requested';
+      }
+
+      // Calculate the fee, the amount to mint and the resulting debt. We'll
+      // verify that the target debt doesn't violate the collateralization ratio,
+      // then mint, reallocate, and burn.
+      const { newDebt, fee, toMint } = helper.loanFee(
+        debt,
+        giveMinted,
+        wantMinted,
+      );
+
+      trace('adjustBalancesHook', state.idInManager, {
+        newCollateralPre,
+        newCollateral,
+        fee,
+        toMint,
+        newDebt,
+      });
+
+      if (checkRestart(newCollateralPre, maxDebtPre, newCollateral, newDebt)) {
+        return helper.adjustBalancesHook(clientSeat);
+      }
+
+      stageDelta(clientSeat, vaultSeat, giveColl, wantColl, 'Collateral');
+      // `wantMinted` is allocated in the reallocate and mint operation, and so not here
+      stageDelta(clientSeat, vaultSeat, giveMinted, emptyMinted, 'Minted');
+
+      /** @type {Array<ZCFSeat>} */
+      const vaultSeatOpt = allEmpty([giveColl, giveMinted, wantColl])
+        ? []
+        : [vaultSeat];
+      manager.mintAndReallocate(toMint, fee, clientSeat, ...vaultSeatOpt);
+
+      // parent needs to know about the change in debt
+      helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebt);
+      manager.burnAndRecord(giveMinted, vaultSeat);
+      helper.assertVaultHoldsNoMinted();
+
+      helper.updateUiState();
+      clientSeat.exit();
+      return 'We have adjusted your balances, thank you for your business';
+    },
+
+    /**
+     *
+     * @param {ZCFSeat} seat
+     * @returns {VaultKit}
+     */
+    makeTransferInvitationHook(seat) {
+      const { state, facets } = this;
+      const { self, helper } = facets;
+      helper.assertCloseable();
+      seat.exit();
+
+      const ephemera = provideEphemera(state.idInManager);
+
+      // eslint-disable-next-line no-use-before-define
+      const vaultKit = makeVaultKit(
+        self,
+        ephemera.storageNode,
+        ephemera.marshaller,
+        manager.getAssetSubscriber(),
+      );
+      ephemera.outerUpdater = vaultKit.vaultUpdater;
+      helper.updateUiState();
+
+      return vaultKit;
+    },
+  };
+
+  const selfBehavior = {
+    /**
+     */
+    getVaultSeat() {
+      const { state } = this;
+      return state.vaultSeat;
+    },
+
+    /**
+     * @param {ZCFSeat} seat
+     * @param {ERef<StorageNode>} storageNode
+     * @param {ERef<Marshaller>} marshaller
+     */
+    async initVaultKit(seat, storageNode, marshaller) {
+      const { state, facets } = this;
+      assert(
+        seat && storageNode && marshaller,
+        'initVaultKit missing argument',
+      );
+      const ephemera = provideEphemera(state.idInManager);
+
+      const { self, helper } = facets;
+
+      const normalizedDebtPre = self.getNormalizedDebt();
+      const actualDebtPre = self.getCurrentDebt();
+      assert(
+        AmountMath.isEmpty(normalizedDebtPre) &&
+          AmountMath.isEmpty(actualDebtPre),
+        X`vault must be empty initially`,
+      );
+
+      const collateralPre = self.getCollateralAmount();
+      trace('initVaultKit start: collateral', state.idInManager, {
+        actualDebtPre,
+        collateralPre,
+      });
+
+      // get the payout to provide access to the collateral if the
+      // contract abandons
+      const {
+        give: { Collateral: giveCollateral },
+        want: { Minted: wantMinted },
+      } = seat.getProposal();
+
+      const {
+        newDebt: newDebtPre,
+        fee,
+        toMint,
+      } = helper.loanFee(actualDebtPre, emptyMinted, wantMinted);
+      !AmountMath.isEmpty(fee) ||
+        assert.fail(
+          X`loan requested (${wantMinted}) is too small; cannot accrue interest`,
+        );
+      assert(AmountMath.isEqual(newDebtPre, toMint), X`fee mismatch for vault`);
+      trace(
+        'initVault',
+        state.idInManager,
+        { wantedRun: wantMinted, fee },
+        self.getCollateralAmount(),
+      );
+
+      await assertSufficientCollateral(giveCollateral, newDebtPre);
+
+      const { vaultSeat } = state;
+      vaultSeat.incrementBy(
+        seat.decrementBy(harden({ Collateral: giveCollateral })),
+      );
+      manager.mintAndReallocate(toMint, fee, seat, vaultSeat);
+      helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebtPre);
+
+      const vaultKit = makeVaultKit(
+        self,
+        storageNode,
+        marshaller,
+        manager.getAssetSubscriber(),
+      );
+      ephemera.outerUpdater = vaultKit.vaultUpdater;
+      helper.updateUiState();
+      return vaultKit;
+    },
+
+    /**
+     * Called by manager at start of liquidation.
+     *
+     */
+    liquidating() {
+      const { helper } = this.facets;
+      helper.assignPhase(Phase.LIQUIDATING);
+      helper.updateUiState();
+    },
+
+    /**
+     * Called by manager at end of liquidation, at which point all debts have been
+     * covered.
+     *
+     */
+    liquidated() {
+      const { helper } = this.facets;
+      helper.updateDebtSnapshot(
+        // liquidated vaults retain no debt
+        AmountMath.makeEmpty(helper.debtBrand()),
+      );
+
+      helper.assignPhase(Phase.LIQUIDATED);
+      helper.updateUiState();
+    },
+
+    /**
+     */
+    makeAdjustBalancesInvitation() {
+      const { facets } = this;
+      const { helper } = facets;
+      helper.assertActive();
+      return zcf.makeInvitation(
+        seat => helper.adjustBalancesHook(seat),
+        'AdjustBalances',
+      );
+    },
+
+    /**
+     */
+    makeCloseInvitation() {
+      const { facets } = this;
+      const { helper } = facets;
+      helper.assertCloseable();
+      return zcf.makeInvitation(seat => helper.closeHook(seat), 'CloseVault');
+    },
+
+    /**
+     * @returns {Promise<Invitation>}
+     */
+    makeTransferInvitation() {
+      const { state, facets } = this;
+      const ephemera = provideEphemera(state.idInManager);
+      const { outerUpdater } = ephemera;
+      const { self, helper } = facets;
+      // Bring the debt snapshot current for the final report before transfer
+      helper.updateDebtSnapshot(self.getCurrentDebt());
+      const { debtSnapshot: debt, interestSnapshot: interest, phase } = state;
+      if (outerUpdater) {
+        outerUpdater.finish(helper.getStateSnapshot(Phase.TRANSFER));
+        ephemera.outerUpdater = null;
+      }
+      const transferState = {
+        debtSnapshot: { debt, interest },
+        locked: self.getCollateralAmount(),
+        vaultState: phase,
+      };
+      return zcf.makeInvitation(
+        seat => helper.makeTransferInvitationHook(seat),
+        'TransferVault',
+        transferState,
+      );
+    },
+
+    // for status/debugging
+
+    /**
+     *
+     * @returns {Amount<'nat'>}
+     */
+    getCollateralAmount() {
+      const { state } = this;
+      const { vaultSeat } = state;
+      // getCollateralAllocated would return final allocations
+      return vaultSeat.hasExited()
+        ? emptyCollateral
+        : getCollateralAllocated(vaultSeat);
+    },
+
+    /**
+     * The actual current debt, including accrued interest.
+     *
+     * This looks like a simple getter but it does a lot of the heavy lifting for
+     * interest accrual. Rather than updating all records when interest accrues,
+     * the vault manager updates just its rolling compounded interest. Here we
+     * calculate what the current debt is given what's recorded in this vault and
+     * what interest has compounded since this vault record was written.
+     *
+     * @see getNormalizedDebt
+     *
+     * @returns {Amount<'nat'>}
+     */
+    getCurrentDebt() {
+      const { state } = this;
+      return calculateCurrentDebt(
+        state.debtSnapshot,
+        state.interestSnapshot,
+        manager.getCompoundedInterest(),
+      );
+    },
+
+    /**
+     * The normalization puts all debts on a common time-independent scale since
+     * the launch of this vault manager. This allows the manager to order vaults
+     * by their debt-to-collateral ratios without having to mutate the debts as
+     * the interest accrues.
+     *
+     * @see getActualDebAmount
+     *
+     * @returns {import('./storeUtils.js').NormalizedDebt} as if the vault was open at the launch of this manager, before any interest accrued
+     */
+    getNormalizedDebt() {
+      const { state } = this;
+      // @ts-expect-error cast
+      return reverseInterest(state.debtSnapshot, state.interestSnapshot);
+    },
+  };
+
+  const makeVaultBase = vivifyFarClassKit(
+    baggage,
+    `Vault`,
+    VaultIKit,
+    (idInManager, storageNode, marshaller) => {
+      const ephemera = provideEphemera(idInManager);
+      ephemera.storageNode = storageNode;
+      ephemera.marshaller = marshaller;
+
+      /**
+       * @type {ImmutableState & MutableState}
+       */
+      return harden({
+        idInManager,
+        outerUpdater: null,
+        phase: Phase.ACTIVE,
+
+        // vaultSeat will hold the collateral until the loan is retired. The
+        // payout from it will be handed to the user: if the vault dies early
+        // (because the vaultFactory vat died), they'll get all their
+        // collateral back. If that happens, the issuer for the Minted will be dead,
+        // so their loan will be worthless.
+        vaultSeat: zcf.makeEmptySeatKit().zcfSeat,
+
+        // Two values from the same moment
+        interestSnapshot: manager.getCompoundedInterest(),
+        debtSnapshot: AmountMath.makeEmpty(manager.getDebtBrand()),
+      });
+    },
+    {
+      self: selfBehavior,
+      helper: helperBehavior,
+    },
+  );
   /**
-   *
-   * @param {MethodContext} context
-   * @returns {Amount<'nat'>}
+   * @param {ZCF} zcf
+   * @param {VaultManager} manager
+   * @param {VaultId} idInManager
    */
-  getCollateralAmount: ({ state, facets }) => {
-    const { vaultSeat } = state;
-    const { helper } = facets;
-    // getCollateralAllocated would return final allocations
-    return vaultSeat.hasExited()
-      ? helper.emptyCollateral()
-      : helper.getCollateralAllocated(vaultSeat);
-  },
-
-  /**
-   * The actual current debt, including accrued interest.
-   *
-   * This looks like a simple getter but it does a lot of the heavy lifting for
-   * interest accrual. Rather than updating all records when interest accrues,
-   * the vault manager updates just its rolling compounded interest. Here we
-   * calculate what the current debt is given what's recorded in this vault and
-   * what interest has compounded since this vault record was written.
-   *
-   * @see getNormalizedDebt
-   *
-   * @param {MethodContext} context
-   * @returns {Amount<'nat'>}
-   */
-  getCurrentDebt: ({ state }) => {
-    return calculateCurrentDebt(
-      state.debtSnapshot,
-      state.interestSnapshot,
-      state.manager.getCompoundedInterest(),
-    );
-  },
-
-  /**
-   * The normalization puts all debts on a common time-independent scale since
-   * the launch of this vault manager. This allows the manager to order vaults
-   * by their debt-to-collateral ratios without having to mutate the debts as
-   * the interest accrues.
-   *
-   * @see getActualDebAmount
-   *
-   * @param {MethodContext} context
-   * @returns {import('./storeUtils.js').NormalizedDebt} as if the vault was open at the launch of this manager, before any interest accrued
-   */
-  getNormalizedDebt: ({ state }) => {
-    // @ts-expect-error cast
-    return reverseInterest(state.debtSnapshot, state.interestSnapshot);
-  },
+  const makeVault = pickFacet(makeVaultBase, 'self');
+  return makeVault;
 };
+harden(vivifyVaultFactory);
 
-const makeVaultBase = defineDurableKindMulti(
-  makeKindHandle('Vault'),
-  initState,
-  {
-    self: selfBehavior,
-    helper: helperBehavior,
-  },
-);
-
-/**
- * @param {ZCF} zcf
- * @param {VaultManager} manager
- * @param {VaultId} idInManager
- */
-export const makeVault = pickFacet(makeVaultBase, 'self');
-
-/** @typedef {ReturnType<typeof makeVault>} Vault */
+/** @typedef {ReturnType<typeof vivifyVaultFactory>} Vault */

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -5,15 +5,40 @@
 import '@agoric/zoe/exported.js';
 
 import { makeStoredPublishKit } from '@agoric/notifier';
-import { defineDurableKindMulti, makeKindHandle } from '@agoric/vat-data';
+import {
+  defineDurableKindMulti,
+  M,
+  makeKindHandle,
+  vivifyFarClass,
+} from '@agoric/vat-data';
+import { AmountShape } from '@agoric/ertp';
 import { makeEphemeraProvider } from '../contractSupport.js';
 
 const { details: X } = assert;
 
+const SubscriberShape = M.remotable('Subscriber');
+const InvitationShape = M.remotable('Invitation');
+
+// TODO share interface with vaults
+const VaultHolderI = M.interface('VaultHolder', {
+  getSubscriber: M.call().returns(SubscriberShape),
+  makeAdjustBalancesInvitation: M.call().returns(InvitationShape),
+  makeCloseInvitation: M.call().returns(InvitationShape),
+  makeTransferInvitation: M.call().returns(InvitationShape),
+  getCollateralAmount: M.call().returns(AmountShape),
+  getCurrentDebt: M.call().returns(AmountShape),
+  getNormalizedDebt: M.call().returns(AmountShape),
+});
+
 // XXX durable key to an ephemeral object
 // UNTIL https://github.com/Agoric/agoric-sdk/issues/4567
 let holderId = 0n;
-
+/**
+ * @typedef {{
+ * holderId: bigint,
+ * vault: Vault | null,
+ * }} State
+ */
 /**
  * @type {(key: bigint) => {
  * publisher: StoredPublishKit<VaultNotification>['publisher'],
@@ -23,19 +48,73 @@ let holderId = 0n;
 const provideEphemera = makeEphemeraProvider(() => ({}));
 
 /**
- * @typedef {{
- * holderId: bigint,
- * vault: Vault | null,
- * }} State
- * @typedef {Readonly<{
- *   state: State,
- *   facets: {
- *     helper: import('@agoric/vat-data/src/types').KindFacet<typeof helper>,
- *     self: import('@agoric/vat-data/src/types').KindFacet<typeof holder>,
- *   },
- * }>} MethodContext
+ * @param context
+ * @param context.state
+ * @param context.state.vault
+ * @throws if this holder no longer owns the vault
  */
+const owned = ({ state: { vault } }) => {
+  assert(vault, X`Using vault holder after transfer`);
+  return vault;
+};
 
+const vivifyVaultHolder = baggage => {
+  const makeHolder = vivifyFarClass(
+    baggage,
+    `VaultHolder`,
+    VaultHolderI,
+    (vault, subscriber) => {
+      holderId += 1n;
+      const ephemera = provideEphemera(holderId);
+      // UNTIL https://github.com/Agoric/agoric-sdk/issues/4567
+      Object.assign(ephemera, { subscriber });
+
+      return { holderId, vault };
+    },
+    {
+      getSubscriber() {
+        return provideEphemera(this.state.holderId).subscriber;
+      },
+      makeAdjustBalancesInvitation() {
+        return owned(this).makeAdjustBalancesInvitation();
+      },
+      makeCloseInvitation() {
+        return owned(this).makeCloseInvitation();
+      },
+      /**
+       * Starting a transfer revokes the vault holder. The associated updater will
+       * get a special notification that the vault is being transferred.
+       *
+       */
+      makeTransferInvitation() {
+        const { state } = this;
+        const vault = owned(this);
+        state.vault = null;
+        return vault.makeTransferInvitation();
+      },
+      // for status/debugging
+      getCollateralAmount() {
+        return owned(this).getCollateralAmount();
+      },
+      getCurrentDebt() {
+        return owned(this).getCurrentDebt();
+      },
+      getNormalizedDebt() {
+        return owned(this).getNormalizedDebt();
+      },
+    },
+  );
+  const makeVaultHolder = (vault, storageNode, marshaller) => {
+    /** @type {StoredPublishKit<VaultNotification>} */
+    const { subscriber, publisher } = makeStoredPublishKit(
+      storageNode,
+      marshaller,
+    );
+    const holder = makeHolder(vault, subscriber);
+    return harden({ holder, updater: publisher });
+  };
+  return makeVaultHolder;
+};
 /**
  *
  * @param {Vault} vault
@@ -43,66 +122,6 @@ const provideEphemera = makeEphemeraProvider(() => ({}));
  * @param {ERef<Marshaller>} marshaller
  * @returns {State}
  */
-const initState = (vault, storageNode, marshaller) => {
-  /** @type {StoredPublishKit<VaultNotification>} */
-  const { subscriber, publisher } = makeStoredPublishKit(
-    storageNode,
-    marshaller,
-  );
-
-  holderId += 1n;
-  const ephemera = provideEphemera(holderId);
-  // UNTIL https://github.com/Agoric/agoric-sdk/issues/4567
-  Object.assign(ephemera, { subscriber, publisher });
-
-  return { holderId, vault };
-};
-
-const helper = {
-  /**
-   * @param {MethodContext} context
-   * @throws if this holder no longer owns the vault
-   */
-  owned: ({ state }) => {
-    const { vault } = state;
-    assert(vault, X`Using vault holder after transfer`);
-    return vault;
-  },
-  /** @param {MethodContext} context */
-  getUpdater: ({ state }) => provideEphemera(state.holderId).publisher,
-};
-
-const holder = {
-  /** @param {MethodContext} context */
-  getSubscriber: ({ state }) => provideEphemera(state.holderId).subscriber,
-  /** @param {MethodContext} context */
-  makeAdjustBalancesInvitation: ({ facets }) =>
-    facets.helper.owned().makeAdjustBalancesInvitation(),
-  /** @param {MethodContext} context */
-  makeCloseInvitation: ({ facets }) =>
-    facets.helper.owned().makeCloseInvitation(),
-  /**
-   * Starting a transfer revokes the vault holder. The associated updater will
-   * get a special notification that the vault is being transferred.
-   *
-   * @param {MethodContext} context
-   */
-  makeTransferInvitation: ({ state, facets }) => {
-    const vault = facets.helper.owned();
-    state.vault = null;
-    return vault.makeTransferInvitation();
-  },
-  // for status/debugging
-  /** @param {MethodContext} context */
-  getCollateralAmount: ({ facets }) =>
-    facets.helper.owned().getCollateralAmount(),
-  /** @param {MethodContext} context */
-  getCurrentDebt: ({ facets }) => facets.helper.owned().getCurrentDebt(),
-  /** @param {MethodContext} context */
-  getNormalizedDebt: ({ facets }) => facets.helper.owned().getNormalizedDebt(),
-};
-
-const behavior = { helper, holder };
 
 export const makeVaultHolder = defineDurableKindMulti(
   makeKindHandle('VaultHolder'),

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -17,7 +17,7 @@ export const makeVaultKit = (
   marshaller,
   assetSubscriber,
 ) => {
-  const { holder, helper } = makeVaultHolder(vault, storageNode, marshaller);
+  const { holder, updater } = makeVaultHolder(vault, storageNode, marshaller);
   const vaultKit = harden({
     publicSubscribers: {
       // XXX should come from manager directly https://github.com/Agoric/agoric-sdk/issues/5814
@@ -30,7 +30,7 @@ export const makeVaultKit = (
       TransferVault: holder.makeTransferInvitation,
     }),
     vault: holder,
-    vaultUpdater: helper.getUpdater(),
+    vaultUpdater: updater,
   });
   return vaultKit;
 };


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description

Construct new issuers without storing then revivifying them.

This also changes the information abotu the issuer the baggage to being a single record rather than multiple individual fields.

### Security Considerations
This provides a cleaner factoring for sharing code between creation and revivification, primarily for singletons.

### Documentation Considerations
This should be an easier-to-document pattern.

### Testing Considerations

Existing tests should cover this refactor.