### PR TITLE
Slog sender improvements

### DIFF
--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -392,7 +392,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       }
       lastCommitTime = t0;
 
-      await Promise.resolve(slogSender.forceFlush?.()).catch(err => {
+      await Promise.resolve(slogSender?.forceFlush?.()).catch(err => {
         console.warn('Failed to flush slog sender', err);
       });
 

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -13,6 +13,13 @@ export const DEFAULT_SLOGSENDER_AGENT = 'self';
 /** @typedef {import('./index.js').SlogSender} SlogSender */
 
 /**
+ * @template T
+ * @param {readonly T[]} arr
+ * @returns {(T extends null | undefined | '' | false | 0 ? never : T)[]}
+ */
+const filterTruthy = arr => /** @type {any[]} */ (arr.filter(Boolean));
+
+/**
  *
  * @param {import('./index.js').MakeSlogSenderOptions} opts
  */
@@ -24,18 +31,19 @@ export const makeSlogSender = async (opts = {}) => {
     ...otherEnv
   } = env;
 
-  const slogSenderModules = SLOGSENDER.split(',').map(modulePath =>
-    modulePath.startsWith('.')
-      ? // Resolve relative to the current working directory.
-        path.resolve(modulePath)
-      : modulePath,
-  );
-  if (
-    otherEnv.SLOGFILE &&
-    !slogSenderModules.includes(SLOGFILE_SENDER_MODULE)
-  ) {
-    slogSenderModules.push(SLOGFILE_SENDER_MODULE);
-  }
+  const slogSenderModules = [
+    ...new Set([
+      ...(otherEnv.SLOGFILE ? [SLOGFILE_SENDER_MODULE] : []),
+      ...SLOGSENDER.split(',')
+        .filter(Boolean)
+        .map(modulePath =>
+          modulePath.startsWith('.')
+            ? // Resolve relative to the current working directory.
+              path.resolve(modulePath)
+            : modulePath,
+        ),
+    ]),
+  ];
 
   if (!slogSenderModules.length) {
     return undefined;
@@ -73,12 +81,21 @@ export const makeSlogSender = async (opts = {}) => {
         .then(
           /** @param {{makeSlogSender: (opts: {}) => Promise<SlogSender | undefined>}} module */ ({
             makeSlogSender: maker,
-          }) =>
-            typeof maker === 'function'
-              ? { maker, moduleIdentifier }
-              : Promise.reject(
-                  new Error(`No 'makeSlogSender' function exported by module`),
+          }) => {
+            if (typeof maker !== 'function') {
+              return Promise.reject(
+                new Error(`No 'makeSlogSender' function exported by module`),
+              );
+            } else if (maker === makeSlogSender) {
+              return Promise.reject(
+                new Error(
+                  `Cannot recursively load 'makeSlogSender' aggregator`,
                 ),
+              );
+            }
+
+            return /** @type {const} */ ([maker, moduleIdentifier]);
+          },
         )
         .catch(err => {
           console.warn(
@@ -88,9 +105,9 @@ export const makeSlogSender = async (opts = {}) => {
           return undefined;
         }),
     ),
-  );
+  ).then(makerEntries => [...new Map(filterTruthy(makerEntries)).entries()]);
 
-  if (!makersInfo.filter(Boolean).length) {
+  if (!makersInfo.length) {
     return undefined;
   }
 
@@ -102,21 +119,14 @@ export const makeSlogSender = async (opts = {}) => {
   }
 
   const senders = await Promise.all(
-    makersInfo.map(async makerInfo => {
-      if (!makerInfo || makerInfo.maker === makeSlogSender) {
-        return undefined;
-      }
-      const { maker, moduleIdentifier } = makerInfo;
-      return maker({
+    makersInfo.map(async ([maker, moduleIdentifier]) =>
+      maker({
         ...otherOpts,
         stateDir,
         env: { SLOGSENDER: moduleIdentifier, ...otherEnv },
-      });
-    }),
-  ).then(
-    potentialSenders =>
-      /** @type {SlogSender[]} */ (potentialSenders.filter(Boolean)),
-  );
+      }),
+    ),
+  ).then(filterTruthy);
 
   if (!senders.length) {
     return undefined;


### PR DESCRIPTION
## Description

- Fixes the `makeSlogSender` aggregator to prevent using the same sender module multiple times.
- Fixes cosmic-swingset to correctly handle when no slogSender exists.
- Add the ability to override/set env variables specific to slog senders. This for example would allow disabling tracers for the sub-process.
