### PR TITLE
fix: swingset amino codec / Ledger support

### DIFF
--- a/golang/cosmos/x/swingset/alias.go
+++ b/golang/cosmos/x/swingset/alias.go
@@ -17,7 +17,6 @@ var (
 	NewMsgDeliverInbound = types.NewMsgDeliverInbound
 	NewMsgProvision      = types.NewMsgProvision
 	NewMailbox           = types.NewMailbox
-	ModuleCdc            = types.ModuleCdc
 	RegisterCodec        = types.RegisterCodec
 )
 

--- a/golang/cosmos/x/swingset/types/codec.go
+++ b/golang/cosmos/x/swingset/types/codec.go
@@ -12,13 +12,13 @@ import (
 var (
 	amino = codec.NewLegacyAmino()
 
-	// ModuleCdc references the global x/deployment module codec. Note, the codec should
+	// ModuleCdc references the global x/swingset module codec. Note, the codec should
 	// ONLY be used in certain instances of tests and for JSON encoding as Amino is
 	// still used for that purpose.
 	//
 	// The actual codec used for serialization should be provided to x/swingset and
 	// defined at the application level.
-	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
+	ModuleAminoCdc = codec.NewAminoCodec(amino)
 )
 
 func init() {

--- a/golang/cosmos/x/swingset/types/msgs.go
+++ b/golang/cosmos/x/swingset/types/msgs.go
@@ -94,7 +94,7 @@ func (msg MsgDeliverInbound) GetSignBytes() []byte {
 	if msg.Nums == nil {
 		msg.Nums = []uint64{}
 	}
-	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleAminoCdc.MustMarshalJSON(&msg))
 }
 
 // GetSigners defines whose signature is required
@@ -125,7 +125,7 @@ func (msg MsgWalletAction) GetSigners() []sdk.AccAddress {
 
 // GetSignBytes encodes the message for signing
 func (msg MsgWalletAction) GetSignBytes() []byte {
-	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleAminoCdc.MustMarshalJSON(&msg))
 }
 
 // Route should return the name of the module
@@ -142,7 +142,7 @@ func (msg MsgWalletSpendAction) Type() string { return "wallet_spend_action" }
 
 // GetSignBytes encodes the message for signing
 func (msg MsgWalletSpendAction) GetSignBytes() []byte {
-	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleAminoCdc.MustMarshalJSON(&msg))
 }
 
 // ValidateBasic runs stateless checks on the message
@@ -228,7 +228,7 @@ func (msg MsgProvision) GetSignBytes() []byte {
 	if msg.PowerFlags == nil {
 		msg.PowerFlags = []string{}
 	}
-	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleAminoCdc.MustMarshalJSON(&msg))
 }
 
 // GetSigners defines whose signature is required

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -34,7 +34,7 @@ const PROVISION_COINS = [
 ].join(',');
 const DELEGATE0_COINS = `50000000${STAKING_DENOM}`;
 const SOLO_COINS = `13000000${STAKING_DENOM},500000000${CENTRAL_DENOM}`;
-const CHAIN_ID = 'agoric';
+const CHAIN_ID = 'agoriclocal';
 
 const FAKE_CHAIN_DELAY =
   process.env.FAKE_CHAIN_DELAY === undefined

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -4,7 +4,7 @@
 # don't want.
 
 REPOSITORY = agoric/cosmic-swingset
-CHAIN_ID = agoric
+CHAIN_ID = agoriclocal
 INITIAL_HEIGHT = 17
 GENESIS_TIME = $(shell TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)
 VOTING_PERIOD = 45s

--- a/packages/wallet/ui/public/network-config
+++ b/packages/wallet/ui/public/network-config
@@ -1,4 +1,4 @@
 {
-  "chainName": "agoric",
+  "chainName": "agoriclocal",
   "rpcAddrs": ["http://localhost:26657"]
 }

--- a/packages/wallet/ui/src/util/keyManagement.js
+++ b/packages/wallet/ui/src/util/keyManagement.js
@@ -79,12 +79,13 @@ const CosmosMessages = /** @type {const} */ ({
 });
 
 /**
- * `/agoric.swingset.XXX` matches package agoric.swingset in swingset/msgs.go
+ * `/agoric.swingset.XXX` matches package agoric.swingset in swingset/msgs.proto
+ * aminoType taken from Type() in golang/cosmos/x/swingset/types/msgs.go
  */
 export const SwingsetMsgs = /** @type {const} */ ({
   MsgProvision: {
     typeUrl: '/agoric.swingset.MsgProvision',
-    aminoType: 'swingset/MsgProvision',
+    aminoType: 'swingset/Provision',
   },
   MsgWalletAction: {
     typeUrl: '/agoric.swingset.MsgWalletAction',
@@ -92,7 +93,7 @@ export const SwingsetMsgs = /** @type {const} */ ({
   },
   MsgWalletSpendAction: {
     typeUrl: '/agoric.swingset.MsgWalletSpendAction',
-    aminoType: 'swingset/WalletAction',
+    aminoType: 'swingset/WalletSpendAction',
   },
 });
 
@@ -138,18 +139,43 @@ export const zeroFee = () => {
   return fee;
 };
 
+const dbg = label => x => {
+  console.log(label, x);
+  return x;
+};
+
 /** @type {import('@cosmjs/stargate').AminoConverters} */
 const SwingsetConverters = {
   [SwingsetMsgs.MsgProvision.typeUrl]: {
     aminoType: SwingsetMsgs.MsgProvision.aminoType,
-    toAmino: ({ action, owner }) => ({
-      action,
-      owner: toBech32(bech32Config.bech32PrefixAccAddr, fromBase64(owner)),
-    }),
-    fromAmino: ({ action, owner }) => ({
-      action,
-      owner: toBase64(toAccAddress(owner)),
-    }),
+    toAmino: protoVal => {
+      const { nickname, address, powerFlags, submitter } = dbg(
+        'provision toAmino protoVal',
+      )(protoVal);
+      return {
+        address: toBech32(
+          bech32Config.bech32PrefixAccAddr,
+          fromBase64(address),
+        ),
+        nickname,
+        powerFlags,
+        submitter: toBech32(
+          bech32Config.bech32PrefixAccAddr,
+          fromBase64(submitter),
+        ),
+      };
+    },
+    fromAmino: aminoVal => {
+      const { nickname, address, powerFlags, submitter } = dbg(
+        'provision fromAmino aminoVal',
+      )(aminoVal);
+      return {
+        address: toBase64(toAccAddress(address)),
+        nickname,
+        powerFlags,
+        submitter: toBase64(toAccAddress(submitter)),
+      };
+    },
   },
   [SwingsetMsgs.MsgWalletAction.typeUrl]: {
     aminoType: SwingsetMsgs.MsgWalletAction.aminoType,
@@ -163,7 +189,7 @@ const SwingsetConverters = {
     }),
   },
   [SwingsetMsgs.MsgWalletSpendAction.typeUrl]: {
-    aminoType: SwingsetMsgs.MsgWalletAction.aminoType,
+    aminoType: SwingsetMsgs.MsgWalletSpendAction.aminoType,
     toAmino: ({ spendAction, owner }) => ({
       spendAction,
       owner: toBech32(bech32Config.bech32PrefixAccAddr, fromBase64(owner)),


### PR DESCRIPTION
closes: #6347
refs: #3628

## Description

Fix amino codec details both in `x/swingset` and `wallet/ui`.

Also, avoid collisions with `agoric` chain name in Keplr.

### Security Considerations

Being able to use a Ledger is a pretty big security feature :)

### Documentation Considerations

@rowgraus I guess this should go in the user docs?

Big thanks to the Keplr folks for diagnosing the problem!

### Testing Considerations

@michaelfig tested `agd` and the wallet UI; I also tested the wallet UI.

![image](https://user-images.githubusercontent.com/150986/193914432-4c5684b2-d934-48dd-9764-4cb8d0050ed6.png)



@turadg wondered about integration testing with [zemu](https://github.com/Zondax/zemu). I'm inclined to leave that out of scope.