### PR TITLE
support corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "packages/wallet/api"
   ],
   "type": "module",
+  "packageManager": "yarn@1.22.19",
   "devDependencies": {
     "@endo/eslint-config": "^0.5.1",
     "@jessie.js/eslint-plugin": "^0.3.0",


### PR DESCRIPTION
## Description

[Yarn install docs](https://yarnpkg.com/getting-started/install) recommend using [Corepack](https://nodejs.org/api/corepack.html) which is available in 16.10+. We can't set the minimum engine to that because we support Node v14. It's also available in 14.19+ but setting that as minimum engine could create problems for 15.0-16.9.

So this just adds the property for use in Node installs that have Corepack enabled, but leaves the `.yarn/releases` for installs that don't. (Though it removes an old release.)

Eventually we can drop the `.yarn` folder and use Corepack, reduceing maintenance work and building on the Node ecosystem.

### Security Considerations

--

### Documentation Considerations

--
### Testing Considerations

--