### PR TITLE
build: Use larger, auto-scaling runners for our GitHub workflows

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     if: ${{ github.repository_owner == 'agoric' }}
-    runs-on: ubuntu-latest
+    runs-on: NewAutoScaled
     strategy:
       matrix:
         node-version: ['14.x', '16.x']
@@ -33,7 +33,7 @@ jobs:
 
   dev-canary:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: NewAutoScaled
     strategy:
       matrix:
         # note: only use one node-version
@@ -74,7 +74,7 @@ jobs:
 
   coverage:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: NewAutoScaled
     strategy:
       matrix:
         # note: only use one node-version
@@ -118,7 +118,7 @@ jobs:
 
   benchmark:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: NewAutoScaled
     strategy:
       matrix:
         # note: only use one node-version

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -27,7 +27,7 @@ jobs:
   deployment-test:
     needs: pre_check
     if: needs.pre_check.outputs.should_run == 'true'
-    runs-on: ubuntu-18.04 # trusty
+    runs-on: NewAutoScaled
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   snapshot:
     if: ${{ github.repository_owner == 'agoric' }}
-    runs-on: ubuntu-latest
+    runs-on: NewAutoScaled
     outputs:
       tag: '${{ steps.snapshot-tag.outputs.tag }}'
     steps:
@@ -32,7 +32,7 @@ jobs:
 
   docker-sdk:
     needs: snapshot
-    runs-on: ubuntu-latest
+    runs-on: NewAutoScaled
     strategy:
       matrix:
         platform:
@@ -163,7 +163,7 @@ jobs:
   # It just runs agoric/agoric-sdk with a "single-node" argument.
   docker-ibc-alpha:
     needs: [docker-sdk, snapshot]
-    runs-on: ubuntu-latest
+    runs-on: NewAutoScaled
     if: ${{ needs.docker-sdk.outputs.tag }} != dev
     steps:
       - uses: actions/checkout@v2
@@ -208,7 +208,7 @@ jobs:
 
   docker-solo:
     needs: [docker-sdk, snapshot]
-    runs-on: ubuntu-latest
+    runs-on: NewAutoScaled
     steps:
       - uses: actions/checkout@v2
       - name: Save SDK_TAG


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #6410
refs: #XXXX

## Description

Use this new runner: 
![image](https://user-images.githubusercontent.com/554601/194389836-d9cf07ab-bab2-411f-951c-4cd5c1940a5a.png)


### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
