### PR TITLE
fix: implement upgrade handler

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -740,21 +740,21 @@ func NewAgoricApp(
 			}
 
 			// Set bean count
-			currentSwingset := app.SwingSetKeeper.GetParams(ctx)
-			ctx.Logger().Info("pre-swingset upgrade", "subspace", swingset.ModuleName, "params", currentSwingset)
+			currentSwingsetParams := app.SwingSetKeeper.GetParams(ctx)
+			ctx.Logger().Info("pre-swingset upgrade", "subspace", swingset.ModuleName, "params", currentSwingsetParams)
 
-			for i := 0; i < len(currentSwingset.BeansPerUnit); i++ {
-				if currentSwingset.BeansPerUnit[i].Key == swingsettypes.BeansPerBlockComputeLimit {
-					currentSwingset.BeansPerUnit[i] = swingsettypes.NewStringBeans(swingsettypes.BeansPerBlockComputeLimit, sdk.NewUint(6500000000))
+			for i := 0; i < len(currentSwingsetParams.BeansPerUnit); i++ {
+				if currentSwingsetParams.BeansPerUnit[i].Key == swingsettypes.BeansPerBlockComputeLimit {
+					currentSwingsetParams.BeansPerUnit[i].Beans = sdk.NewUint(6500000000)
 				}
 			}
 
 			// Set bootstrap
 
-			currentSwingset.BootstrapVatConfig = "@agoric/vats/decentral-prod-config.json"
-			ctx.Logger().Info("post-swingset upgrade", "subspace", swingset.ModuleName, "params", currentSwingset)
+			currentSwingsetParams.BootstrapVatConfig = "@agoric/vats/decentral-prod-config.json"
+			ctx.Logger().Info("post-swingset upgrade", "subspace", swingset.ModuleName, "params", currentSwingsetParams)
 
-			app.SwingSetKeeper.SetParams(ctx, currentSwingset)
+			app.SwingSetKeeper.SetParams(ctx, currentSwingsetParams)
 
 			return vm, err
 		},

--- a/packages/vats/decentral-prod-config.json
+++ b/packages/vats/decentral-prod-config.json
@@ -1,0 +1,68 @@
+{
+  "bootstrap": "bootstrap",
+  "defaultReapInterval": 1000,
+  "snapshotInterval": 1000,
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "@agoric/vats/src/core/boot-psm.js",
+      "parameters": {
+        "anchorAssets": [
+          {
+            "denom": "ibc/usdc1234"
+          }
+        ],
+        "economicCommitteeAddresses": {
+          "voter": "agoric1ersatz"
+        }
+      },
+      "creationOptions": {
+        "critical": true
+      }
+    }
+  },
+  "bundles": {
+    "walletFactory": {
+      "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
+    },
+    "provisionPool": {
+      "sourceSpec": "@agoric/vats/src/provisionPool.js"
+    },
+    "committee": {
+      "sourceSpec": "@agoric/governance/src/committee.js"
+    },
+    "contractGovernor": {
+      "sourceSpec": "@agoric/governance/src/contractGovernor.js"
+    },
+    "binaryVoteCounter": {
+      "sourceSpec": "@agoric/governance/src/binaryVoteCounter.js"
+    },
+    "psm": {
+      "sourceSpec": "@agoric/inter-protocol/src/psm/psm.js"
+    },
+    "psmCharter": {
+      "sourceSpec": "@agoric/inter-protocol/src/psm/psmCharter.js"
+    },
+    "bank": {
+      "sourceSpec": "@agoric/vats/src/vat-bank.js"
+    },
+    "centralSupply": {
+      "sourceSpec": "@agoric/vats/src/centralSupply.js"
+    },
+    "mintHolder": {
+      "sourceSpec": "@agoric/vats/src/mintHolder.js"
+    },
+    "board": {
+      "sourceSpec": "@agoric/vats/src/vat-board.js"
+    },
+    "chainStorage": {
+      "sourceSpec": "@agoric/vats/src/vat-chainStorage.js"
+    },
+    "zcf": {
+      "sourceSpec": "@agoric/zoe/contractFacet.js"
+    },
+    "zoe": {
+      "sourceSpec": "@agoric/vats/src/vat-zoe.js"
+    }
+  },
+  "defaultManagerType": "xs-worker"
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #6285
refs: #XXXX

## Description

Turns out since we're not starting from genesis, we need to tickle the InitGenesis on each of the newly added modules.  This change implements the upgrade handler.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
I tested this locally with a stock agoric-upgrade-7 local chain with no issues at the cosmos layer.   
Testing Scripts: https://github.com/Agoric/upgrade-test

```
11:52AM INF ABCI Replay Blocks appHeight=7 module=consensus stateHeight=7 storeHeight=8
11:52AM INF Replay last block using real app module=consensus
11:52AM INF applying upgrade "agoric-upgrade-8" at height: 8
11:52AM INF adding a new module: lien
2022/10/07 11:52:41 Running SwingSet until bootstrap is ready
Loading slog sender modules: @agoric/telemetry/src/flight-recorder.js
2022-10-07T18:52:41.327Z launch-chain: Launching SwingSet kernel
2022-10-07T18:52:54.474Z launch-chain: Expected SwingSet kernel statistic cosmic_swingset_inbound_queue_length not found
2022-10-07T18:52:54.474Z launch-chain: Expected SwingSet kernel statistic cosmic_swingset_inbound_queue_add not found
2022-10-07T18:52:54.474Z launch-chain: Expected SwingSet kernel statistic cosmic_swingset_inbound_queue_remove not found
2022-10-07T18:52:54.475Z block-manager: block bootstrap
11:53AM INF created new capability module=ibc name=ports/echo
11:53AM INF port binded module=x/ibc/port port=echo
11:53AM INF claimed capability capability=3 module=vibc name=ports/echo
11:53AM INF adding a new module: swingset
11:53AM INF adding a new module: vbank
11:53AM INF adding a new module: vibc
11:53AM INF adding a new module: vstorage
11:53AM INF pre-swingset upgrade params={"beans_per_unit":[{"beans":"800000000","key":"blockComputeLimit"},{"beans":"1000000000000","key":"feeUnit"},{"beans":"10000000000","key":"inboundTx"},{"beans":"1000000000","key":"message"},{"beans":"20000000","key":"messageByte"},{"beans":"200000000000","key":"minFeeDebit"},{"beans":"30000000","key":"vatCreation"},{"beans":"100","key":"xsnapComputron"}],"bootstrap_vat_config":"@agoric/vats/decentral-core-config.json","fee_unit_price":[{"amount":"1000000","denom":"uist"}],"power_flag_fees":[{"fee":[{"amount":"10000000","denom":"ubld"}],"power_flag":"SMART_WALLET"}],"queue_max":[{"key":"inbound","size":1000}]} subspace=swingset
11:53AM INF post-swingset upgrade params={"beans_per_unit":[{"beans":"6500000000","key":"blockComputeLimit"},{"beans":"1000000000000","key":"feeUnit"},{"beans":"10000000000","key":"inboundTx"},{"beans":"1000000000","key":"message"},{"beans":"20000000","key":"messageByte"},{"beans":"200000000000","key":"minFeeDebit"},{"beans":"30000000","key":"vatCreation"},{"beans":"100","key":"xsnapComputron"}],"bootstrap_vat_config":"@agoric/vats/decentral-prod-config.json","fee_unit_price":[{"amount":"1000000","denom":"uist"}],"power_flag_fees":[{"fee":[{"amount":"10000000","denom":"ubld"}],"power_flag":"SMART_WALLET"}],"queue_max":[{"key":"inbound","size":1000}]} subspace=swingset
11:53AM INF minted coins from module account amount=205stake from=mint module=x/bank
2022-10-07T18:53:05.091Z block-manager: block 8 begin
11:53AM INF executed block height=8 module=consensus num_invalid_txs=0 num_valid_txs=0
2022-10-07T18:53:05.116Z block-manager: block 8 commit
11:53AM INF commit synced commit=436F6D6D697449447B5B3135302037322035203234372032313520323239203137302031313420323335203138322036203134332038312036372031382036382032313420313937203131372032323020313831203220323030203230382037372031382031343020323620323520313534203631203138395D3A387D
11:53AM INF committed state app_hash=964805F7D7E5AA72EBB6068F51431244D6C575DCB502C8D04D128C1A199A3DBD height=8 module=consensus num_txs=0
11:53AM INF Completed ABCI Handshake - Tendermint and App are synced appHash="���\x00�<��\x17#��F�\\��c\u05eb��#�\\��>�yg�" appHeight=7 module=consensus
11:53AM INF Version info block=11 p2p=8 tendermint_version=0.34.19
11:53AM INF This node is a validator addr=2C1AB235A74EC6ACD7C287491A8857B95C82EAEB module=consensus pubKey=IwquZv0Eah0mnZgbEQx9yAbyXt2RQRqkUXpG+XTbz1I=
11:53AM INF indexed block height=8 module=txindex
11:53AM INF P2P Node ID ID=e2d0a862c4a6df88d153d66247c1506b40eea221 file=netstate/config/node_key.json module=p2p
11:53AM INF Adding persistent peers addrs=[] module=p2p
11:53AM INF Adding unconditional peer ids ids=[] module=p2p
11:53AM INF Add our address to book addr={"id":"e2d0a862c4a6df88d153d66247c1506b40eea221","ip":"0.0.0.0","port":26656} book=netstate/config/addrbook.json module=p2p
11:53AM INF Starting Node service impl=Node
11:53AM INF Starting pprof server laddr=localhost:6060
11:53AM INF Starting RPC HTTP server on 127.0.0.1:26657 module=rpc-server
11:53AM INF Starting P2P Switch service impl="P2P Switch" module=p2p
11:53AM INF Starting PEX service impl=PEX module=pex
11:53AM INF Starting AddrBook service book=netstate/config/addrbook.json impl=AddrBook module=p2p
11:53AM INF Starting Mempool service impl=Mempool module=mempool
11:53AM INF Starting BlockchainReactor service impl=BlockchainReactor module=blockchain
11:53AM INF Starting Consensus service impl=ConsensusReactor module=consensus
11:53AM INF Reactor  module=consensus waitSync=false
11:53AM INF Starting State service impl=ConsensusState module=consensus
11:53AM INF Ensure peers module=pex numDialing=0 numInPeers=0 numOutPeers=0 numToDial=10
11:53AM INF No addresses to dial. Falling back to seeds module=pex
11:53AM INF Starting baseWAL service impl=baseWAL module=consensus wal=netstate/data/cs.wal/wal
11:53AM INF Starting Group service impl=Group module=consensus wal=netstate/data/cs.wal/wal
11:53AM INF Starting TimeoutTicker service impl=TimeoutTicker module=consensus
11:53AM INF Searching for height height=9 max=0 min=0 module=consensus wal=netstate/data/cs.wal/wal
11:53AM INF Searching for height height=8 max=0 min=0 module=consensus wal=netstate/data/cs.wal/wal
11:53AM INF Found height=8 index=0 module=consensus wal=netstate/data/cs.wal/wal
11:53AM INF Catchup by replaying consensus messages height=9 module=consensus
11:53AM INF Replay: Done module=consensus
11:53AM INF Starting Evidence service impl=Evidence module=evidence
11:53AM INF Starting StateSync service impl=StateSync module=statesync
11:53AM INF Saving AddrBook to file book=netstate/config/addrbook.json module=p2p size=0
11:53AM INF Timed out dur=4998.431 height=9 module=consensus round=0 step=1
11:53AM INF received proposal module=consensus proposal={"Type":32,"block_id":{"hash":"492A4F3054B20A8AA0E3C798BE07463604A2FB73D86531D1AC125F69425F6B93","parts":{"hash":"6FC5DAD0F32DFDE4BD9B948C57CCEF89903BCA27FCF0314C4F0A60D201A352A9","total":1}},"height":9,"pol_round":-1,"round":0,"signature":"/EqpdZqoOp054CTmZSH1vCMkL31PA42NcuO08dFzlz5jsXWWHYeVfZB+J2Fkx/WWurmfps2M/4RfHX7Lq8QaAw==","timestamp":"2022-10-07T18:53:10.297537Z"}
11:53AM INF received complete proposal block hash=492A4F3054B20A8AA0E3C798BE07463604A2FB73D86531D1AC125F69425F6B93 height=9 module=consensus
11:53AM INF finalizing commit of block hash=492A4F3054B20A8AA0E3C798BE07463604A2FB73D86531D1AC125F69425F6B93 height=9 module=consensus num_txs=0 root=964805F7D7E5AA72EBB6068F51431244D6C575DCB502C8D04D128C1A199A3DBD
11:53AM INF minted coins from module account amount=205stake from=mint module=x/bank
2022-10-07T18:53:10.472Z block-manager: block 9 begin
11:53AM INF executed block height=9 module=state num_invalid_txs=0 num_valid_txs=0
2022-10-07T18:53:10.496Z block-manager: block 9 commit
11:53AM INF commit synced commit=436F6D6D697449447B5B313931203233322038342031343420313839203634203439203234382031353220313536203833203234332033382039332031332032313320323136203232342032353220383320323039203130382031393720323133203234372031342032343620323032203233342032303320323335203233385D3A397D
11:53AM INF committed state app_hash=BFE85490BD4031F8989C53F3265D0DD5D8E0FC53D16CC5D5F70EF6CAEACBEBEE height=9 module=state num_txs=0

```
