### PR TITLE
fix: strike "Initial" from Economic Committee

### DIFF
--- a/packages/agoric-cli/src/commands/psm.js
+++ b/packages/agoric-cli/src/commands/psm.js
@@ -369,7 +369,7 @@ export const makePsmCommand = async logger => {
       const opts = this.opts();
 
       const questionHandleCapDataStr = await vstorage.readLatest(
-        'published.committees.Initial_Economic_Committee.latestQuestion',
+        'published.committees.Economic_Committee.latestQuestion',
       );
       const questionDescriptions = storageHelper.unserializeTxt(
         questionHandleCapDataStr,

--- a/packages/agoric-cli/test/agops-governance-smoketest.sh
+++ b/packages/agoric-cli/test/agops-governance-smoketest.sh
@@ -83,9 +83,9 @@ jq ".body | fromjson" <"$PROPOSAL_OFFER"
 agoric wallet send --from "$KEY" --offer "$PROPOSAL_OFFER"
 
 # to verify that the question was proposed, you can use
-# agoric follow published.committees.Initial_Economic_Committee.latestQuestion
+# agoric follow published.committees.Economic_Committee.latestQuestion
 # for a local net or
-# agoric -B $networkConfig follow published.committees.Initial_Economic_Committee.latestQuestion
+# agoric -B $networkConfig follow published.committees.Economic_Committee.latestQuestion
 
 # vote on the question that was made
 VOTE_OFFER=$(mktemp -t agops.XXX)

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -366,9 +366,9 @@ Once you see a string like `block 17 commit` then the chain is available. In ano
 ```sh
 # shows keys of the committees node
 agd query vstorage keys 'published.committees'
-# shows keys of the initial economic committee node
-agd query vstorage keys 'published.committees.Initial_Economic_Committee'
+# shows keys of the economic committee node
+agd query vstorage keys 'published.committees.Economic_Committee'
 # follow questions
-agoric follow :published.committees.Initial_Economic_Committee.latestQuestion
+agoric follow :published.committees.Economic_Committee.latestQuestion
 ```
-Note that there won't be `'published.committees.Initial_Economic_Committee.latestQuestion` until some `.addQuestion()` call executes.
+Note that there won't be `'published.committees.Economic_Committee.latestQuestion` until some `.addQuestion()` call executes.

--- a/packages/inter-protocol/README.md
+++ b/packages/inter-protocol/README.md
@@ -62,7 +62,7 @@ The canonical keys (under `published`) are as follows. Non-terminal nodes could 
     - `stakeFactory`
         - `governance`
     - `committees`
-        - `Initial_Economic_Committee`
+        - `Economic_Committee`
           - `latestQuestion`
 
 ### Demo

--- a/packages/inter-protocol/src/proposals/startEconCommittee.js
+++ b/packages/inter-protocol/src/proposals/startEconCommittee.js
@@ -43,7 +43,8 @@ export const startEconomicCommittee = async (
   const COMMITTEES_ROOT = 'committees';
   trace('startEconomicCommittee');
   const {
-    committeeName = 'Initial Economic Committee',
+    // NB: the electorate (and size) of the committee may change, but the name must not
+    committeeName = 'Economic Committee',
     committeeSize = 3,
     ...rest
   } = econCommitteeOptions;


### PR DESCRIPTION
refs: #6111 

## Description

The "Initial Economic Committee" is a misnomer because the named entity is a persistent institution, not a particular set of people. We've called what they do Economic Governance. In the code, when we change the set of people who do the economic governing we replace one "committee" with another. But the named entity "Economic Committee" endures.

There may be a better name yet than "Economic Committee" to avoid this confusion. Meanwhile we should at least strike "Initial" as what is being named is an enduring mutable body, not an actual set of members.

### Security Considerations

none

### Documentation Considerations

It would be good to have something like an ER diagram of:
- storage nodes
- commiteee
- electorate
- accounts
- humans

### Testing Considerations

Requires similar change to dapp-econ-gov. Since that tool is used so rarely and changes are cheap, I'll push that change once this is deployed. Alternately I can make it support both URLs until we're sure we can kill the older.