### PR TITLE
feat(wallet/ui): show JSON in keplr signer even without Ledger

### DIFF
--- a/packages/wallet/ui/src/util/keyManagement.js
+++ b/packages/wallet/ui/src/util/keyManagement.js
@@ -380,7 +380,9 @@ export const makeInteractiveSigner = async (
 
   const key = await keplr.getKey(chainId);
 
-  const offlineSigner = await keplr.getOfflineSignerAuto(chainId);
+  // Until we have SIGN_MODE_TEXTUAL,
+  // Use Amino because Direct results in ugly protobuf in the keplr UI.
+  const offlineSigner = await keplr.getOfflineSignerOnlyAmino(chainId);
   console.log('InteractiveSigner', { offlineSigner });
 
   // Currently, Keplr extension manages only one address/public key pair.


### PR DESCRIPTION
fixes: #6424

## Description

Rendering of our custom messages (MsgSpendAction, MsgProvision) in the keplr signer isn't great, but with a Ledger, the amino encoding meant that it's at least about as readable as JSON, as opposed to cosmos "direct" signing, where keplr displayed hex encoded protobuf gobbledygook.

It turns out that the amino encoding works fine even without a Ledger, so we might as well use it all the time to get the nicer UX.

### Security Considerations

Being able to confirm transaction details in the signer window provides a large step up in wallet security.

### Documentation Considerations

re-take some screenshots, @otoole-brendan ?

### Testing Considerations

tested manually:

![image](https://user-images.githubusercontent.com/150986/194678525-90a409e2-6424-42fb-9567-b3e7c1d31fef.png)