### PR TITLE
feat: main, test config: anchor IBC denoms, encon committee addresses

### DIFF
--- a/packages/vats/decentral-devnet-config.json
+++ b/packages/vats/decentral-devnet-config.json
@@ -9,9 +9,33 @@
         "anchorAssets": [
           {
             "keyword": "AUSD",
-            "proposedName": "AUSD",
+            "proposedName": "Anchor USD",
+            "decimalPlaces": 6,
+            "denom": "ibc/toyellie"
+          },
+          {
+            "keyword": "USDC_axl",
+            "proposedName": "USD Coin",
             "decimalPlaces": 6,
             "denom": "ibc/usdc1234"
+          },
+          {
+            "keyword": "USDC_grv",
+            "proposedName": "USD Coin",
+            "decimalPlaces": 6,
+            "denom": "ibc/usdc5678"
+          },
+          {
+            "keyword": "USDT_axl",
+            "proposedName": "Tether USD",
+            "decimalPlaces": 6,
+            "denom": "ibc/usdt1234"
+          },
+          {
+            "keyword": "USDT_grv",
+            "proposedName": "Tether USD",
+            "decimalPlaces": 6,
+            "denom": "ibc/usdt5678"
           }
         ],
         "economicCommitteeAddresses": {

--- a/packages/vats/decentral-devnet-config.json
+++ b/packages/vats/decentral-devnet-config.json
@@ -8,12 +8,6 @@
       "parameters": {
         "anchorAssets": [
           {
-            "keyword": "AUSD",
-            "proposedName": "Anchor USD",
-            "decimalPlaces": 6,
-            "denom": "ibc/toyellie"
-          },
-          {
             "keyword": "USDC_axl",
             "proposedName": "USD Coin",
             "decimalPlaces": 6,
@@ -36,6 +30,12 @@
             "proposedName": "Tether USD",
             "decimalPlaces": 6,
             "denom": "ibc/usdt5678"
+          },
+          {
+            "keyword": "AUSD",
+            "proposedName": "Anchor USD",
+            "decimalPlaces": 6,
+            "denom": "ibc/toyellie"
           }
         ],
         "economicCommitteeAddresses": {

--- a/packages/vats/decentral-main-psm-config.json
+++ b/packages/vats/decentral-main-psm-config.json
@@ -33,7 +33,12 @@
           }
         ],
         "economicCommitteeAddresses": {
-          "voter": "agoric1ersatz"
+          "Jason Potts": "agoric1gx9uu7y6c90rqruhesae2t7c2vlw4uyyxlqxrx",
+          "Chloe White": "agoric1d4228cvelf8tj65f4h7n2td90sscavln2283h5",
+          "Thibault Schrepel": "agoric14543m33dr28x7qhwc558hzlj9szwhzwzpcmw6a",
+          "Chris Berg": "agoric13p9adwk0na5npfq64g22l6xucvqdmu3xqe70wq",
+          "Youssef Amrani": "agoric1el6zqs8ggctj5vwyukyk4fh50wcpdpwgugd5l5",
+          "Joe Clark": "agoric1zayxg4e9vd0es9c9jlpt36qtth255txjp6a8yc"
         }
       },
       "creationOptions": {

--- a/packages/vats/decentral-main-psm-config.json
+++ b/packages/vats/decentral-main-psm-config.json
@@ -8,7 +8,28 @@
       "parameters": {
         "anchorAssets": [
           {
-            "denom": "ibc/usdc1234"
+            "keyword": "USDC_axl",
+            "proposedName": "USD Coin",
+            "decimalPlaces": 6,
+            "denom": "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+          },
+          {
+            "keyword": "USDC_grv",
+            "proposedName": "USD Coin",
+            "decimalPlaces": 6,
+            "denom": "ibc/6831292903487E58BF9A195FDDC8A2E626B3DF39B88F4E7F41C935CADBAF54AC"
+          },
+          {
+            "keyword": "USDT_axl",
+            "proposedName": "Tether USD",
+            "decimalPlaces": 6,
+            "denom": "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045"
+          },
+          {
+            "keyword": "USDT_grv",
+            "proposedName": "Tether USD",
+            "decimalPlaces": 6,
+            "denom": "ibc/386D09AE31DA7C0C93091BB45D08CB7A0730B1F697CD813F06A5446DCF02EEB2"
           }
         ],
         "economicCommitteeAddresses": {

--- a/packages/vats/decentral-psm-config.json
+++ b/packages/vats/decentral-psm-config.json
@@ -8,7 +8,16 @@
       "parameters": {
         "anchorAssets": [
           {
+            "keyword": "USDC_axl",
+            "proposedName": "USD Coin",
+            "decimalPlaces": 6,
             "denom": "ibc/usdc1234"
+          },
+          {
+            "keyword": "AUSD",
+            "proposedName": "Anchor USD",
+            "decimalPlaces": 6,
+            "denom": "ibc/toyellie"
           }
         ],
         "economicCommitteeAddresses": {

--- a/packages/vats/decentral-test-psm-config.json
+++ b/packages/vats/decentral-test-psm-config.json
@@ -8,6 +8,9 @@
       "parameters": {
         "anchorAssets": [
           {
+            "keyword": "ToyUSD",
+            "proposedName": "Toy USD",
+            "decimalPlaces": 6,
             "denom": "ibc/usdc1234"
           }
         ],


### PR DESCRIPTION
closes: #6284
refs: #6435

## Description

 - [x] Econ committee addresses for `main` net
 - [x] PSM anchorAssets configurations
   - [x] local testing: `decentral-psm-config.json`
     - Keep AUSD for compatibility with ad-hoc integration test scripts in agoric-cli
     - [x] add `USDC_axl` to test multiple coins, token icons, etc.
   - [x] devnet, ollinet anchorAssets
     - Keep AUSD for compatibility
     - [x] use {USDC,USDT}_{axl,grv} look-alikes for ephemeral nets, without relayer-based denoms
   - [x] test (emerynet) denoms
     - [x] Toy USD to start with
     - Don't use up keywords such as `USDC_axl`; vote them in as relayers become available
   - [x] `main` denoms
     - [x] USDC_axl
     - [x] USDC_grv
     - [x] USDT_axl
     - [x] USDT_grv

### Security Considerations

 - anchor assets designated by these denoms rely on availability of relayers
 - the usual cosmos wallet key management risks apply to econ committee addresses

### Documentation Considerations

Perhaps the [Validator Guide](https://github.com/Agoric/agoric-sdk/wiki/Validator-Guide) should say something about choosing between `main-psm` and `test-psm` configs?

### Testing Considerations

For the anchor assets:
 - IBC denoms are the results of actual transactions
   - see [10 Oct Axelar notes](https://github.com/Agoric/agoric-sdk/issues/6284#issuecomment-1273899065)
 - booting a local chain with this `anchorAssets` configuration has been tested (though not trading and such)

We plan to continue to use test gov addresses for emerynet.

