### PR TITLE
fix(swingset): only preload maxVatsOnline/2 vats

### DIFF
--- a/packages/SwingSet/test/vat-warehouse/test-preload.js
+++ b/packages/SwingSet/test/vat-warehouse/test-preload.js
@@ -1,0 +1,126 @@
+// eslint-disable-next-line import/order
+import { test } from '../../tools/prepare-test-env-ava.js';
+
+// import * as proc from 'child_process';
+import tmp from 'tmp';
+import { makeSnapStore, makeSnapStoreIO } from '@agoric/swing-store';
+import { provideHostStorage } from '../../src/controller/hostStorage.js';
+import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
+
+test('only preload maxVatsOnline vats', async t => {
+  const bpath = new URL('vat-preload-bootstrap.js', import.meta.url).pathname;
+  const tpath = new URL('vat-preload-extra.js', import.meta.url).pathname;
+  // this combination of config and initOpts means we have only two
+  // initial vats: v1-bootstrap and v2-vatAdmin
+  const config = {
+    defaultManagerType: 'xs-worker',
+    defaultReapInterval: 'never',
+    bootstrap: 'bootstrap',
+    vats: {
+      bootstrap: {
+        sourceSpec: bpath,
+      },
+    },
+    bundles: { extra: { sourceSpec: tpath } },
+  };
+  const initOpts = {
+    addComms: false,
+    addVattp: false,
+    addTimer: false,
+  };
+  const argv = [];
+
+  const snapstorePath = tmp.dirSync({ unsafeCleanup: true }).name;
+  const snapStore = makeSnapStore(snapstorePath, makeSnapStoreIO());
+  const hostStorage = { snapStore, ...provideHostStorage() };
+
+  await initializeSwingset(config, argv, hostStorage, initOpts);
+
+  /* we use vat-warehouse's built-in instrumentation, but I'll leave
+   * this alternative here in case it's ever useful
+  // this lets us snoop on which workers are still alive
+  const workers = new Map();
+  function spawn(...args) {
+    const worker = proc.spawn(...args);
+    const name = args[1][0]; // e.g. 'v1:bootstrap'
+    workers.set(name, worker);
+    return worker;
+  }
+  const isAlive = name =>
+    workers.has(name) && workers.get(name).exitCode === null;
+  */
+
+  // we'll create a 'canary' vat, and ten extras
+  const all = ['bootstrap', 'vatAdmin', 'canary'];
+  for (let count = 0; count < 10; count += 1) {
+    all.push(`extra-${count}`);
+  }
+
+  function areLiving(c, ...expected) {
+    expected = new Set(expected);
+    const living = c.getStatus().activeVats.map(info => info.options.name);
+    for (const name of all) {
+      t.is(living.indexOf(name) !== -1, expected.has(name), name);
+    }
+  }
+
+  const maxVatsOnline = 10;
+  const warehousePolicy = { maxVatsOnline };
+  const runtimeOptions = { warehousePolicy /* , spawn */ };
+
+  const c1 = await makeSwingsetController(hostStorage, null, runtimeOptions);
+  c1.pinVatRoot('bootstrap');
+  await c1.run();
+  areLiving(c1, 'bootstrap', 'vatAdmin');
+
+  // launch v3-canary
+  c1.queueToVatRoot('bootstrap', 'launchCanary', []);
+  await c1.run();
+  areLiving(c1, 'bootstrap', 'vatAdmin', 'canary');
+
+  // then launch v4-extra-0 through v13-extra-9, which knocks the
+  // v3-canary and v4/v5 workers offline
+  c1.queueToVatRoot('bootstrap', 'launchExtra', []);
+  await c1.run();
+  areLiving(
+    c1,
+    'bootstrap',
+    'vatAdmin',
+    // 'canary', -- evicted
+    // 'extra-0', -- evicted
+    // 'extra-1', -- evicted
+    'extra-2',
+    'extra-3',
+    'extra-4',
+    'extra-5',
+    'extra-6',
+    'extra-7',
+    'extra-8',
+    'extra-9',
+  );
+
+  // shut down that controller, then start a new one
+  await c1.shutdown();
+  const c2 = await makeSwingsetController(hostStorage, null, runtimeOptions);
+
+  // we only preload maxVatsOnline/2 vats: the static vats in
+  // lexicographic order (e.g. 1,10,11,2,3,4, except here we only have
+  // v1 and v2 as static vats), and the dynamic vats in creation order
+  areLiving(c2, 'bootstrap', 'vatAdmin', 'canary', 'extra-0', 'extra-1');
+
+  // send a message to an offline extra vat, assert it came online
+  c2.queueToVatRoot('bootstrap', 'ping', ['extra-6']);
+  await c2.run();
+
+  areLiving(
+    c2,
+    'bootstrap',
+    'vatAdmin',
+    'canary',
+    'extra-0',
+    'extra-1',
+    'extra-6', // now online
+  );
+
+  await c2.shutdown();
+});

--- a/packages/SwingSet/test/vat-warehouse/test-warehouse.js
+++ b/packages/SwingSet/test/vat-warehouse/test-warehouse.js
@@ -10,16 +10,26 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 import fs from 'fs';
 import tmp from 'tmp';
 import { initSwingStore } from '@agoric/swing-store';
-import { loadBasedir, buildVatController } from '../../src/index.js';
+import { buildVatController } from '../../src/index.js';
 import { makeLRU } from '../../src/kernel/vat-warehouse.js';
 
 async function makeController(managerType, runtimeOptions, snapshotInterval) {
-  const config = await loadBasedir(new URL('./', import.meta.url).pathname);
-  if (snapshotInterval) {
-    config.snapshotInterval = snapshotInterval;
-  }
-  assert(config.vats);
-  config.vats.target.creationOptions = { managerType, enableDisavow: true };
+  const bpath = new URL('bootstrap.js', import.meta.url).pathname;
+  const tpath = new URL('vat-target.js', import.meta.url).pathname;
+  const config = {
+    snapshotInterval,
+    bootstrap: 'bootstrap',
+    vats: {
+      bootstrap: {
+        sourceSpec: bpath,
+      },
+      target: {
+        creationOptions: { managerType },
+        sourceSpec: tpath,
+      },
+    },
+  };
+
   config.vats.target2 = config.vats.target;
   config.vats.target3 = config.vats.target;
   config.vats.target4 = config.vats.target;

--- a/packages/SwingSet/test/vat-warehouse/vat-preload-bootstrap.js
+++ b/packages/SwingSet/test/vat-warehouse/vat-preload-bootstrap.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-await-in-loop */
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+export function buildRootObject() {
+  const extras = new Map(); // count -> root
+  let vatAdminSvc;
+  let bcap;
+
+  async function start(name) {
+    const opts = { name, vatParameters: { name } };
+    const { root } = await E(vatAdminSvc).createVat(bcap, opts);
+    return root;
+  }
+
+  return Far('root', {
+    async bootstrap(vats, devices) {
+      vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+      );
+      bcap = await E(vatAdminSvc).getNamedBundleCap('extra');
+    },
+
+    async launchCanary() {
+      const canary = await start('canary');
+      extras.set('canary', canary);
+    },
+
+    async launchExtra() {
+      for (let count = 0; count < 10; count += 1) {
+        const name = `extra-${count}`;
+        const root = await start(name);
+        extras.set(name, root);
+      }
+    },
+
+    ping(which) {
+      console.log(`ping ${which}`);
+      return E(extras.get(which)).ping();
+    },
+  });
+}

--- a/packages/SwingSet/test/vat-warehouse/vat-preload-extra.js
+++ b/packages/SwingSet/test/vat-warehouse/vat-preload-extra.js
@@ -1,0 +1,8 @@
+import { Far } from '@endo/marshal';
+
+export function buildRootObject(_vatPowers, _vatParameters) {
+  // console.log(`extra: ${vatParameters.name}`);
+  return Far('root', {
+    ping() {},
+  });
+}


### PR DESCRIPTION
`runtimeOptions.warehousePolicy.maxVatsOnline` is an option which limits the number of xsnap workers the kernel is willing to run at the same time. It defaults to 50, which means when a message is sent to the 51st vat, some other worker (the least-recently used one) is evicted/killed (aka "paged out") to make room for the worker being started ("paged in"). This limits the amount of RAM and processes we consume from the host OS (usually Linux).

Previously, when the kernel starts, it would preload all vats, even if there were more than `maxVatsOnline`, which had the pathological behavior of 1: paging vats in only to page them back out again before ever talking to them, and 2: leaving the most recent *defined* vats online, rather than the most likely to be *used* vats.

In the Agoric PSM chain, we'll create a new vat for each governance vote, and those vote vats don't get any traffic once the governance issue is complete, but for various reasons we don't terminate them. After 30-ish votes, there will be enough dynamic vats for the early static vats (like bootstrap and zoe) to be evicted during kernel startup, which wastes time and increases latency at some unpredictable point in the future when new Zoe/contract messages arrive.

This changes the preload process to only load `maxVatsOnline / 2` vats, not all of them. It starts with the static vats (in lexicographic order, unfortunately, not numberic), and then goes through all the dynamic vats (in creation order), stopping after we hit the limit. This should avoid loading the useless done-but-not-terminated voting vats, and should leave room in the LRU queue so the next message that arrives to a still-offline worker won't evict a useful one right away.

In the long run, we might want to persist the LRU order across a reboot, so any evictions that *do* happen are less likely to hit a vat which is probably going to get paged in again soon. We might preload everything in the LRU (restoring the same set of workers that the earlier incarnation had running), or only a subset at the top (under the assumption that the bottom is unlikely to be paged in again any time soon, and it's better to save time/memory by not loading them).

closes #6433
