### PR TITLE
Convert SwingSet to use smallcaps encoding for serialized data

### DIFF
--- a/packages/SwingSet/misc-tools/measure-metering/measure.js
+++ b/packages/SwingSet/misc-tools/measure-metering/measure.js
@@ -9,6 +9,7 @@ import { xsnap } from '@agoric/xsnap';
 import * as proc from 'child_process';
 import * as os from 'os';
 import { buildVatController } from '../../src/index.js';
+import { kunser } from '../../src/lib/kmarshal.js';
 
 function countingPolicy() {
   let computrons = 0n;
@@ -81,7 +82,7 @@ async function run() {
     const kp = c.queueToVatRoot('bootstrap', 'measure', [mode]);
     await c.run();
     const cd = c.kpResolution(kp);
-    const used = JSON.parse(cd.body);
+    const used = kunser(cd);
     assert.typeof(used, 'number');
     return used;
   }

--- a/packages/SwingSet/src/devices/lib/deviceTools.js
+++ b/packages/SwingSet/src/devices/lib/deviceTools.js
@@ -74,6 +74,7 @@ export function buildSerializationTools(syscall, deviceName) {
 
   const m = makeMarshal(convertValToSlot, convertSlotToVal, {
     marshalName: `device:${deviceName}`,
+    serializeBodyFormat: 'smallcaps',
     // TODO Temporary hack.
     // See https://github.com/Agoric/agoric-sdk/issues/2780
     errorIdNum: 60000,

--- a/packages/SwingSet/src/devices/vat-admin/device-vat-admin.js
+++ b/packages/SwingSet/src/devices/vat-admin/device-vat-admin.js
@@ -2,6 +2,7 @@ import { Nat } from '@agoric/nat';
 import { assert } from '@agoric/assert';
 import { buildSerializationTools } from '../lib/deviceTools.js';
 import { insistVatID } from '../../lib/id.js';
+import { kunser } from '../../lib/kmarshal.js';
 
 /*
 
@@ -202,7 +203,7 @@ export function buildDevice(tools, endowments) {
         // D(devices.vatAdmin).createByBundle(bundle, options) -> vatID
         if (method === 'createByBundle') {
           const res = syscall.callKernelHook('createByBundle', argsCapdata);
-          const vatID = JSON.parse(res.body);
+          const vatID = kunser(res);
           assert.typeof(vatID, 'string', `createByBundle gave non-VatID`);
           return returnFromInvoke(vatID);
         }
@@ -210,14 +211,14 @@ export function buildDevice(tools, endowments) {
         // D(devices.vatAdmin).createByBundleID(bundleID, options) -> vatID
         if (method === 'createByBundleID') {
           const res = syscall.callKernelHook('createByID', argsCapdata);
-          const vatID = JSON.parse(res.body);
+          const vatID = kunser(res);
           assert.typeof(vatID, 'string', `createByID gave non-VatID`);
           return returnFromInvoke(vatID);
         }
 
         // D(devices.vatAdmin).upgradeVat(vatID, bundleID, vatParameters, upgradeMessage) -> upgradeID
         if (method === 'upgradeVat') {
-          const args = JSON.parse(argsCapdata.body);
+          const args = kunser(argsCapdata);
           assert(Array.isArray(args), 'upgradeVat() args array');
           assert.equal(args.length, 4, `upgradeVat() args length`);
           const [vatID, bundleID, _vatParameters, upgradeMessage] = args;
@@ -230,14 +231,14 @@ export function buildDevice(tools, endowments) {
           );
 
           const res = syscall.callKernelHook('upgrade', argsCapdata);
-          const upgradeID = JSON.parse(res.body);
+          const upgradeID = kunser(res);
           assert.typeof(upgradeID, 'string', 'upgradeVat gave non-upgradeID');
           return returnFromInvoke(upgradeID);
         }
 
         // D(devices.vatAdmin).terminateWithFailure(vatID, reason)
         if (method === 'terminateWithFailure') {
-          const args = JSON.parse(argsCapdata.body);
+          const args = kunser(argsCapdata);
           assert(Array.isArray(args), 'terminateWithFailure() args array');
           assert.equal(args.length, 2, `terminateWithFailure() args length`);
           const [vatID, _reason] = args;
@@ -249,7 +250,7 @@ export function buildDevice(tools, endowments) {
 
         // D(devices.vatAdmin).changeOptions(vatID, options)
         if (method === 'changeOptions') {
-          const args = JSON.parse(argsCapdata.body);
+          const args = kunser(argsCapdata);
           assert(Array.isArray(args), 'changeOptions() args array');
           assert.equal(args.length, 2, `changeOptions() args length`);
           const [vatID, _reason] = args;

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -103,6 +103,7 @@ export function makeDeviceSlots(
 
   const m = makeMarshal(convertValToSlot, convertSlotToVal, {
     marshalName: `device:${forDeviceName}`,
+    serializeBodyFormat: 'smallcaps',
     // TODO Temporary hack.
     // See https://github.com/Agoric/agoric-sdk/issues/2780
     errorIdNum: 50000,

--- a/packages/SwingSet/src/kernel/kernelQueue.js
+++ b/packages/SwingSet/src/kernel/kernelQueue.js
@@ -2,6 +2,7 @@ import { insistKernelType, parseKernelSlot } from './parseKernelSlots.js';
 import { insistCapData } from '../lib/capdata.js';
 import { insistMessage } from '../lib/message.js';
 import { insistVatID } from '../lib/id.js';
+import { kser } from '../lib/kmarshal.js';
 
 /**
  * @param {object} tools
@@ -85,7 +86,8 @@ export function makeKernelQueueHandler(tools) {
    * by some other vat. This requires a kref as a target.
    *
    * @param {string} kref  Target of the message
-   * @param {*} methargs  The method and arguments
+   * @param {string} method  The method name
+   * @param {any[]} args  The arguments array
    * @param {ResolutionPolicy=} policy How the kernel should handle an eventual
    *    resolution or rejection of the message's result promise. Should be
    *    one of 'none' (don't even create a result promise), 'ignore' (do
@@ -94,10 +96,10 @@ export function makeKernelQueueHandler(tools) {
    *    rejection).
    * @returns {string | undefined} the kpid of the sent message's result promise, if any
    */
-  function queueToKref(kref, methargs, policy = 'ignore') {
+  function queueToKref(kref, method, args, policy = 'ignore') {
     // queue a message on the end of the queue, with 'absolute' krefs.
     // Use 'step' or 'run' to execute it
-    insistCapData(methargs);
+    const methargs = kser([method, args]);
     methargs.slots.forEach(s => parseKernelSlot(s));
     let resultKPID;
     if (policy !== 'none') {

--- a/packages/SwingSet/src/kernel/notifyTermination.js
+++ b/packages/SwingSet/src/kernel/notifyTermination.js
@@ -1,11 +1,12 @@
 import { insistCapData } from '../lib/capdata.js';
+import { kunser } from '../lib/kmarshal.js';
 
 /**
  * @param {string} vatID
  * @param {string} vatAdminRootKref
  * @param {boolean} shouldReject
  * @param {import('@endo/marshal').CapData<unknown>} info
- * @param {(kref: string, methargs: unknown, policy?: string) => void} queueToKref
+ * @param {(kref: string, method: string, args: unknown[], policy?: string) => void} queueToKref
  */
 export function notifyTermination(
   vatID,
@@ -16,16 +17,11 @@ export function notifyTermination(
 ) {
   insistCapData(info);
 
-  // Embedding the info capdata into the arguments list, taking advantage of
-  // the fact that neither vatID (which is a string) nor shouldReject (which
-  // is a boolean) can contain any slots.
-  const methargs = {
-    body: JSON.stringify([
-      'vatTerminated',
-      [vatID, shouldReject, JSON.parse(info.body)],
-    ]),
-    slots: info.slots,
-  };
-
-  queueToKref(vatAdminRootKref, methargs, 'logFailure');
+  // Embed the info capdata into the arguments list
+  queueToKref(
+    vatAdminRootKref,
+    'vatTerminated',
+    [vatID, shouldReject, kunser(info)],
+    'logFailure',
+  );
 }

--- a/packages/SwingSet/src/kernel/vat-admin-hooks.js
+++ b/packages/SwingSet/src/kernel/vat-admin-hooks.js
@@ -1,24 +1,18 @@
 import { assert } from '@agoric/assert';
-import { stringify, parse } from '@endo/marshal';
 import { insistVatID } from '../lib/id.js';
+import { kser, kunser } from '../lib/kmarshal.js';
 
 export function makeVatAdminHooks(tools) {
   const { kernelKeeper, terminateVat } = tools;
   return {
     createByBundle(argsCapData) {
       // first, split off vatParameters
-      const argsJSON = JSON.parse(argsCapData.body);
-      const [bundle, { vatParameters: vpJSON, ...dynamicOptionsJSON }] =
-        argsJSON;
+      const args = kunser(argsCapData);
+      const [bundle, { vatParameters, ...dynamicOptions }] = args;
       // assemble the vatParameters capdata
-      const vatParameters = {
-        body: JSON.stringify(vpJSON),
-        slots: argsCapData.slots,
-      };
-      // then re-parse the rest with marshal
-      const dynamicOptions = parse(JSON.stringify(dynamicOptionsJSON));
+      const marshalledVatParameters = kser(vatParameters);
       // incref slots while create-vat is on run-queue
-      for (const kref of vatParameters.slots) {
+      for (const kref of marshalledVatParameters.slots) {
         kernelKeeper.incrementRefCount(kref, 'create-vat-event');
       }
       const source = { bundle };
@@ -27,38 +21,29 @@ export function makeVatAdminHooks(tools) {
         type: 'create-vat',
         vatID,
         source,
-        vatParameters,
+        vatParameters: marshalledVatParameters,
         dynamicOptions,
       };
       kernelKeeper.addToAcceptanceQueue(harden(event));
       // the device gets the new vatID immediately, and will be notified
       // later when it is created and a root object is available
-      const vatIDCapData = { body: JSON.stringify(vatID), slots: [] };
-      return harden(vatIDCapData);
+      return harden(kser(vatID));
     },
 
     createByID(argsCapData) {
-      // argsCapData is marshal([bundleID, options]), and options is {
-      // vatParameters, ...rest }, and 'rest' is JSON-serializable (no
-      // slots or bigints or undefined). We get the intermediate marshal
-      // representation (with @qclass nodes), carve off vatParameters,
-      // then reassemble the rest. All slots will be associated with
-      // vatParameters.
+      // `argsCapData` is marshal([bundleID, options]), and `options` is {
+      // vatParameters, ...rest }, and `rest` is checked by vat-vat-admin.js to
+      // contain only known keys and types, none of which allow slots.  So any
+      // slots in `argsCapData` will be associated with `vatParameters`.
 
       // first, split off vatParameters
-      const argsJSON = JSON.parse(argsCapData.body);
-      const [bundleID, { vatParameters: vpJSON, ...dynamicOptionsJSON }] =
-        argsJSON;
+      const args = kunser(argsCapData);
+      const [bundleID, { vatParameters, ...dynamicOptions }] = args;
       assert(kernelKeeper.hasBundle(bundleID), bundleID);
-      // assemble the vatParameters capdata
-      const vatParameters = {
-        body: JSON.stringify(vpJSON),
-        slots: argsCapData.slots,
-      };
-      // then re-parse the rest with marshal
-      const dynamicOptions = parse(JSON.stringify(dynamicOptionsJSON));
+      // assemble the marshalled vatParameters
+      const marshalledVatParameters = kser(vatParameters);
       // incref slots while create-vat is on run-queue
-      for (const kref of vatParameters.slots) {
+      for (const kref of marshalledVatParameters.slots) {
         kernelKeeper.incrementRefCount(kref, 'create-vat-event');
       }
       const source = { bundleID };
@@ -67,25 +52,24 @@ export function makeVatAdminHooks(tools) {
         type: 'create-vat',
         vatID,
         source,
-        vatParameters,
+        vatParameters: marshalledVatParameters,
         dynamicOptions,
       };
       kernelKeeper.addToAcceptanceQueue(harden(event));
       // the device gets the new vatID immediately, and will be notified
       // later when it is created and a root object is available
-      const vatIDCapData = { body: JSON.stringify(vatID), slots: [] };
-      return harden(vatIDCapData);
+      return harden(kser(vatID));
     },
 
     upgrade(argsCapData) {
       // marshal([vatID, bundleID, vatParameters]) -> upgradeID
-      const argsJSON = JSON.parse(argsCapData.body);
-      const [vatID, bundleID, vpJSON, upgradeMessage] = argsJSON;
+      const args = kunser(argsCapData);
+      const [vatID, bundleID, vatParameters, upgradeMessage] = args;
       insistVatID(vatID);
       assert.typeof(bundleID, 'string');
       assert.typeof(upgradeMessage, 'string');
-      const vpCD = { body: JSON.stringify(vpJSON), slots: argsCapData.slots };
-      for (const kref of vpCD.slots) {
+      const marshalledVatParameters = kser(vatParameters);
+      for (const kref of marshalledVatParameters.slots) {
         kernelKeeper.incrementRefCount(kref, 'upgrade-vat-event');
       }
       const upgradeID = kernelKeeper.allocateUpgradeID();
@@ -94,34 +78,33 @@ export function makeVatAdminHooks(tools) {
         vatID,
         upgradeID,
         bundleID,
-        vatParameters: vpCD,
+        vatParameters: marshalledVatParameters,
         upgradeMessage,
       };
       kernelKeeper.addToAcceptanceQueue(harden(ev));
-      const upgradeIDCD = { body: JSON.stringify(upgradeID), slots: [] };
-      return harden(upgradeIDCD);
+      return harden(kser(upgradeID));
     },
 
-    terminate(argsCD) {
+    terminate(argsCapData) {
       // marshal([vatID, reason]) -> null
-      const argsJSON = JSON.parse(argsCD.body);
-      const [vatID, reasonJSON] = argsJSON;
+      const args = kunser(argsCapData);
+      const [vatID, reason] = args;
       insistVatID(vatID);
-      const reasonCD = { ...argsCD, body: JSON.stringify(reasonJSON) };
+      const marshalledReason = kser(reason);
       // we don't need to incrementRefCount because if terminateVat sends
       // 'reason' to vat-admin, it uses notifyTermination / queueToKref /
       // doSend, and doSend() does its own incref
-      void terminateVat(vatID, true, reasonCD);
+      void terminateVat(vatID, true, marshalledReason);
       // TODO: terminateVat is async, result doesn't fire until worker
       // is dead. To fix this we'll probably need to move termination
       // to a run-queue ['terminate-vat', vatID] event, like createVat
-      return harden({ body: stringify(undefined), slots: [] });
+      return harden(kser(undefined));
     },
 
     changeOptions(argsCapData) {
       // marshal([vatID, options]) -> null
       assert(argsCapData.slots.length === 0);
-      const args = JSON.parse(argsCapData.body);
+      const args = kunser(argsCapData);
       const [vatID, options] = args;
       insistVatID(vatID);
       const ev = {
@@ -130,7 +113,7 @@ export function makeVatAdminHooks(tools) {
         options,
       };
       kernelKeeper.addToAcceptanceQueue(harden(ev));
-      return harden({ body: stringify(undefined), slots: [] });
+      return harden(kser(undefined));
     },
   };
 }

--- a/packages/SwingSet/src/lib/capdata.js
+++ b/packages/SwingSet/src/lib/capdata.js
@@ -1,4 +1,6 @@
 import { assert, details as X } from '@agoric/assert';
+import { passStyleOf } from '@endo/marshal';
+import { kunser, krefOf } from './kmarshal.js';
 
 /* eslint-disable jsdoc/require-returns-check */
 /**
@@ -29,16 +31,10 @@ export function insistCapData(capdata) {
  * @param {import('@endo/marshal').CapData<string>} data
  */
 export function extractSingleSlot(data) {
-  const body = JSON.parse(data.body);
-  if (
-    body &&
-    typeof body === 'object' &&
-    body['@qclass'] === 'slot' &&
-    body.index === 0
-  ) {
-    if (data.slots.length === 1) {
-      return data.slots[0];
-    }
+  const value = kunser(data);
+  const style = passStyleOf(value);
+  if (style === 'remotable' || style === 'promise') {
+    return krefOf(value);
   }
   return null;
 }

--- a/packages/SwingSet/src/lib/kmarshal.js
+++ b/packages/SwingSet/src/lib/kmarshal.js
@@ -1,0 +1,79 @@
+import { Far, makeMarshal, passStyleOf } from '@endo/marshal';
+import { assert } from '@agoric/assert';
+
+// Simple wrapper for serializing and unserializing marshalled values inside the
+// kernel, where we don't actually want to use clists nor actually allocate real
+// objects, but instead to stay entirely within the domain of krefs.  This is
+// used to enable syntactic manipulation of serialized values while remaining
+// agnostic about the internal details of the serialization encoding.
+
+const refMap = new WeakMap();
+
+export const kslot = (kref, iface) => {
+  assert.typeof(kref, 'string');
+  if (iface && iface.startsWith('Alleged: ')) {
+    // Encoder prepends "Alleged: " to iface string, but the decoder doesn't strip it
+    // Unclear whether it's the decoder or me who is wrong
+    iface = iface.slice(9);
+  }
+  if (
+    kref.startsWith('p') ||
+    kref.startsWith('kp') ||
+    kref.startsWith('lp') ||
+    kref.startsWith('rp')
+  ) {
+    // TODO: temporary hack because smallcaps encodes promise references
+    // differently from remotable object references, and the current version of
+    // the smallcaps decoder annoyingly insists that if the encoded body string
+    // says a slot is a promise, then convertSlotToVal had better by damn return
+    // an actual Promise, even if, as in the intended use case here, we neither
+    // want nor need a promise, nor the overhead of a map to keep track of it
+    // with.  This behavior is in service of defense against a hypothesized
+    // security issue whose exact nature has largely been forgotton in the
+    // months since it was first encountered.  MarkM is currently researching
+    // what the problem was thought to have been, to see if it is real and to
+    // understand it if so.  This will eventually result in either changes to
+    // the smallcaps encoding or to the marshal setup API to support the purely
+    // manipulative use case.  In the meantime, this ugliness...
+    const p = new Promise(() => undefined);
+    refMap.set(p, kref);
+    return harden(p);
+  } else {
+    const o = Far(iface, {
+      iface: () => iface,
+      getKref: () => `${kref}`,
+    });
+    return o;
+  }
+};
+
+export const krefOf = obj => {
+  const fromMap = refMap.get(obj);
+  if (fromMap) {
+    return fromMap;
+  }
+  // When krefOf() is called as part of kmarshal.serialize, marshal
+  // will only give it things that are 'remotable' (Promises and the
+  // Far objects created by kslot()).  When krefOf() is called by
+  // kernel code (as part of extractSingleSlot() or the vat-comms
+  // equivalent), it ought to throw if 'obj' is not one of the Far
+  // objects created by our kslot().
+  assert.equal(passStyleOf(obj), 'remotable', obj);
+  const getKref = obj.getKref;
+  assert.typeof(getKref, 'function');
+  return getKref();
+};
+
+const kmarshal = makeMarshal(krefOf, kslot, {
+  serializeBodyFormat: 'smallcaps',
+  errorTagging: 'off',
+});
+
+export const kser = value => kmarshal.serialize(harden(value));
+
+export const kunser = serializedValue => kmarshal.unserialize(serializedValue);
+
+export function makeError(message) {
+  assert.typeof(message, 'string');
+  return kser(Error(message));
+}

--- a/packages/SwingSet/src/lib/makeUndeliverableError.js
+++ b/packages/SwingSet/src/lib/makeUndeliverableError.js
@@ -11,14 +11,9 @@
 // "data is not callable" error is kind of unique to the way swingset handles
 // references, so we create a distinct error message.
 
-const QCLASS = '@';
+import { kunser, kser } from './kmarshal.js';
 
 export function makeUndeliverableError(methargs) {
-  const method = JSON.parse(methargs.body)[0];
-  const s = {
-    [QCLASS]: 'error',
-    name: 'TypeError',
-    message: `data is not callable, has no method ${method}`,
-  };
-  return harden({ body: JSON.stringify(s), slots: [] });
+  const method = kunser(methargs)[0];
+  return kser(TypeError(`data is not callable, has no method ${method}`));
 }

--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -14,7 +14,6 @@ import {
   makeCopyMap,
 } from '@agoric/store';
 import { Far, passStyleOf } from '@endo/marshal';
-import { decodeToJustin } from '@endo/marshal/src/marshal-justin.js';
 import { parseVatSlot } from '../lib/parseVatSlots.js';
 
 // The maximum length of an LMDB key used to be 511 bytes which corresponded to
@@ -71,32 +70,9 @@ function matchAny(patt) {
 }
 
 function throwNotDurable(value, slotIndex, serializedValue) {
-  const body = JSON.parse(serializedValue.body);
-  let encodedValue;
-  try {
-    encodedValue = decodeToJustin(
-      {
-        body,
-        slots: serializedValue.slots,
-      },
-      true,
-    );
-  } catch (justinError) {
-    const err = assert.error(
-      X`value is not durable: ${value} at slot ${q(
-        slotIndex,
-      )} of ${serializedValue}`,
-    );
-    assert.note(
-      err,
-      X`decodeToJustin(${serializedValue}) threw ${justinError} `,
-    );
-    throw err;
-  }
   assert.fail(
-    X`value is not durable: ${value} at slot ${q(
-      slotIndex,
-    )} of ${encodedValue}`,
+    // prettier-ignore
+    X`value is not durable: ${value} at slot ${q(slotIndex)} of ${serializedValue.body}`,
   );
 }
 

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -584,6 +584,7 @@ function build(
   // eslint-disable-next-line no-use-before-define
   const m = makeMarshal(convertValToSlot, convertSlotToVal, {
     marshalName: `liveSlots:${forVatID}`,
+    serializeBodyFormat: 'smallcaps',
     // TODO Temporary hack.
     // See https://github.com/Agoric/agoric-sdk/issues/2780
     errorIdNum: 70000,

--- a/packages/SwingSet/src/vats/comms/controller.js
+++ b/packages/SwingSet/src/vats/comms/controller.js
@@ -1,10 +1,6 @@
 import { Nat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';
-
-const UNDEFINED = harden({
-  body: JSON.stringify({ '@qclass': 'undefined' }),
-  slots: [],
-});
+import { kser, kunser, kslot, krefOf } from '../../lib/kmarshal.js';
 
 // deliverToController() is used for local vats which want to talk to us as a
 // vat, rather than as a conduit to talk to remote vats. The bootstrap
@@ -29,41 +25,27 @@ export function deliverToController(
     provideLocalForKernel,
   } = clistKit;
 
-  const methargsdata = JSON.parse(methargs.body);
+  const methargsdata = kunser(methargs);
   const [method, args] = methargsdata;
-  const { slots } = methargs;
-
-  // We use a degenerate form of deserialization, just enough to handle the
-  // handful of methods implemented by the commsController. 'args.body' can
-  // normally have arbitrary {'@qclass': whatever} objects, but we only
-  // handle {'@qclass':'slot', index} objects, which point into the
-  // 'args.slots' array.
 
   function doAddRemote() {
     // comms!addRemote(name, tx, setRx)
     //  we then do setRx!setReceiver(rx)
 
     const name = args[0];
-    assert.typeof(name, 'string', X`bad addRemote name ${name}`);
-    (args[1]['@qclass'] === 'slot' && args[1].index === 0) ||
-      assert.fail(X`unexpected args for addRemote(): ${methargs.body}`);
-    (args[2]['@qclass'] === 'slot' && args[2].index === 1) ||
-      assert.fail(X`unexpected args for addRemote(): ${methargs.body}`);
-    const transmitterID = slots[args[1].index];
-    const setReceiverID = slots[args[2].index];
+    const transmitterID = krefOf(args[1]);
+    assert(transmitterID, 'bad "transmitter" arg for addRemote()');
+    const setReceiverID = krefOf(args[2]);
+    assert(setReceiverID, 'bad "setReceiver" arg for addRemote()');
 
     const { receiverID } = state.addRemote(name, transmitterID);
 
-    const rxArg = { '@qclass': 'slot', index: 0 };
-    const setReceiverMethargs = harden({
-      body: JSON.stringify(['setReceiver', [rxArg]]),
-      slots: [receiverID],
-    });
+    const setReceiverMethargs = kser(['setReceiver', [kslot(receiverID)]]);
     syscall.send(setReceiverID, setReceiverMethargs);
     // todo: consider, this leaves one message (setReceiver) on the queue,
     // rather than giving the caller of comms!addRemote() something to
     // synchronize upon. I don't think it hurts, but might affect debugging.
-    syscall.resolve([[result, false, UNDEFINED]]);
+    syscall.resolve([[result, false, kser(undefined)]]);
   }
 
   function doAddEgress() {
@@ -73,11 +55,11 @@ export function deliverToController(
     const remoteID = state.getRemoteIDForName(remoteName);
     assert(remoteID, X`unknown remote name ${remoteName}`);
     const remoteRefID = args[1];
-    (args[2]['@qclass'] === 'slot' && args[2].index === 0) ||
-      assert.fail(X`unexpected args for addEgress(): ${methargs.body}`);
-    const localRef = provideLocalForKernel(slots[args[2].index]);
+    const kernelRefID = krefOf(args[2]);
+    assert(kernelRefID, 'bad "obj0" arg for addEgress()');
+    const localRef = provideLocalForKernel(kernelRefID);
     addEgress(remoteID, remoteRefID, localRef);
-    syscall.resolve([[result, false, UNDEFINED]]);
+    syscall.resolve([[result, false, kser(undefined)]]);
   }
 
   function doAddIngress() {
@@ -88,14 +70,11 @@ export function deliverToController(
     assert(remoteID, X`unknown remote name ${remoteName}`);
     const remoteRefID = Nat(args[1]);
     const iface = args[2];
-    const localRef = addIngress(remoteID, remoteRefID);
-    const data = {
-      body: '{"@qclass":"slot","index":0}',
-      slots: [provideKernelForLocal(localRef)],
-    };
     if (iface) {
-      data.body = `{"@qclass":"slot","iface":"${iface}","index":0}`;
+      assert.typeof(iface, 'string', 'unexpected iface type in addIngress()');
     }
+    const localRef = addIngress(remoteID, remoteRefID);
+    const data = kser(kslot(provideKernelForLocal(localRef), iface));
     syscall.resolve([[result, false, data]]);
   }
 

--- a/packages/SwingSet/src/vats/comms/delivery.js
+++ b/packages/SwingSet/src/vats/comms/delivery.js
@@ -6,11 +6,7 @@ import { makeUndeliverableError } from '../../lib/makeUndeliverableError.js';
 import { extractSingleSlot, insistCapData } from '../../lib/capdata.js';
 import { insistRemoteType } from './parseRemoteSlot.js';
 import { insistRemoteID } from './remote.js';
-
-const UNDEFINED = harden({
-  body: JSON.stringify({ '@qclass': 'undefined' }),
-  slots: [],
-});
+import { kser } from '../../lib/kmarshal.js';
 
 export function makeDeliveryKit(
   state,
@@ -126,7 +122,7 @@ export function makeDeliveryKit(
       // TODO: eventually, the vattp vat will be changed to send the 'receive'
       // message as a one-way message.  When that happens, this code should be
       // changed to assert here that the result parameter is null or undefined.
-      syscall.resolve([[result, false, UNDEFINED]]);
+      syscall.resolve([[result, false, kser(undefined)]]);
     }
     // The message is preceded by an optional sequence number followed by the
     // sequence number that the remote end had most recently received from us as

--- a/packages/SwingSet/test/bundling/test-bundles.js
+++ b/packages/SwingSet/test/bundling/test-bundles.js
@@ -5,9 +5,9 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 import fs from 'fs';
 import bundleSource from '@endo/bundle-source';
 import { assert } from '@agoric/assert';
-import { parse } from '@endo/marshal';
 import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
+import { kunser, krefOf } from '../../src/lib/kmarshal.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
@@ -95,19 +95,17 @@ test('bundles', async t => {
     const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
-    const capdata = c.kpResolution(kpid);
-    return [status, capdata];
+    const result = c.kpResolution(kpid);
+    return [status, kunser(result)];
   }
 
   async function check(name, args, expectedResult) {
-    const [status, capdata] = await run(name, args);
-    const result = parse(capdata.body);
+    const [status, result] = await run(name, args);
     t.deepEqual([status, result], ['fulfilled', expectedResult]);
   }
 
   async function checkRejects(name, args, expectedResult) {
-    const [status, capdata] = await run(name, args);
-    const result = parse(capdata.body);
+    const [status, result] = await run(name, args);
     t.deepEqual([status, result], ['rejected', expectedResult]);
   }
 
@@ -172,13 +170,9 @@ test('bundles', async t => {
 
   // check the shape of the waitForBundleCap bundlecap
   const d1 = c.kpResolution(waitKPID);
-  const res1 = JSON.parse(d1.body);
-  const dev1 = { '@qclass': 'slot', iface: 'Alleged: device node', index: 0 };
-  t.deepEqual(res1, dev1);
-  const slots1 = d1.slots;
-  const dev1slot = slots1[0];
+  const res1 = kunser(d1);
+  const dev1slot = krefOf(res1);
   t.regex(dev1slot, /^kd\d+$/);
-  t.is(slots1[0], dev1slot);
 
   // and make sure we can load it by ID
   await check('vatFromID', [bid1, 'runtime'], ['installed']);
@@ -193,13 +187,8 @@ test('bundles', async t => {
   // check the shape of the getBundleCap bundlecap
   const [s2, d2] = await run('getBundleCap', [bid2]);
   t.is(s2, 'fulfilled');
-  const res2 = JSON.parse(d2.body);
-  const dev2 = { '@qclass': 'slot', iface: 'Alleged: device node', index: 0 };
-  t.deepEqual(res2, dev2);
-  const slots2 = d2.slots;
-  const dev2slot = slots2[0];
+  const dev2slot = krefOf(d2);
   t.regex(dev2slot, /^kd\d+$/);
-  t.is(slots2[0], dev2slot);
 
   // and the shape of the bundle
   const [s3, d3] = await run('getBundle', [bid2]);
@@ -207,7 +196,6 @@ test('bundles', async t => {
   // but importBundle() requires an object, with moduleFormat: and
   // endoZipBase64:
   t.is(s3, 'fulfilled');
-  const res3 = parse(d3.body);
-  t.is(res3.moduleFormat, 'endoZipBase64');
-  t.is(typeof res3.endoZipBase64, 'string');
+  t.is(d3.moduleFormat, 'endoZipBase64');
+  t.is(typeof d3.endoZipBase64, 'string');
 });

--- a/packages/SwingSet/test/change-parameters/test-change-parameters.js
+++ b/packages/SwingSet/test/change-parameters/test-change-parameters.js
@@ -3,11 +3,10 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import { assert } from '@agoric/assert';
-import { parse } from '@endo/marshal';
-// eslint-disable-next-line import/order
 import { getAllState } from '@agoric/swing-store';
 import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
+import { kunser } from '../../src/lib/kmarshal.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
@@ -63,8 +62,8 @@ async function testChangeParameters(t) {
     const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
-    const capdata = c.kpResolution(kpid);
-    return [status, parse(capdata.body)];
+    const result = c.kpResolution(kpid);
+    return [status, kunser(result)];
   }
 
   // setup target vat

--- a/packages/SwingSet/test/definition/test-vat-definition.js
+++ b/packages/SwingSet/test/definition/test-vat-definition.js
@@ -1,16 +1,7 @@
 import { test } from '../../tools/prepare-test-env-ava.js';
 
 import { buildVatController } from '../../src/index.js';
-
-const mUndefined = { '@qclass': 'undefined' };
-
-function capdata(body, slots = []) {
-  return harden({ body, slots });
-}
-
-function capargs(args, slots = []) {
-  return capdata(JSON.stringify(args), slots);
-}
+import { kser } from '../../src/lib/kmarshal.js';
 
 test('create with setup and buildRootObject', async t => {
   const config = {
@@ -29,29 +20,29 @@ test('create with setup and buildRootObject', async t => {
   c.pinVatRoot('liveslots');
   let r = c.queueToVatRoot('setup', 'increment', [], 'panic');
   await c.run();
-  t.deepEqual(c.kpResolution(r), capargs(mUndefined), 'setup incr');
+  t.deepEqual(c.kpResolution(r), kser(undefined), 'setup incr');
   r = c.queueToVatRoot('setup', 'read', [], 'panic');
   await c.run();
-  t.deepEqual(c.kpResolution(r), capargs(1), 'setup read');
+  t.deepEqual(c.kpResolution(r), kser(1), 'setup read');
   r = c.queueToVatRoot('setup', 'remotable', [], 'panic');
   await c.run();
   t.deepEqual(
     c.kpResolution(r),
-    capargs('Alleged: iface1'),
+    kser('Alleged: iface1'),
     'setup Remotable/getInterfaceOf',
   );
 
   r = c.queueToVatRoot('liveslots', 'increment', [], 'panic');
   await c.run();
-  t.deepEqual(c.kpResolution(r), capargs(mUndefined), 'ls incr');
+  t.deepEqual(c.kpResolution(r), kser(undefined), 'ls incr');
   r = c.queueToVatRoot('liveslots', 'read', [], 'panic');
   await c.run();
-  t.deepEqual(c.kpResolution(r), capargs(1), 'ls read');
+  t.deepEqual(c.kpResolution(r), kser(1), 'ls read');
   r = c.queueToVatRoot('liveslots', 'remotable', [], 'panic');
   await c.run();
   t.deepEqual(
     c.kpResolution(r),
-    capargs('Alleged: iface1'),
+    kser('Alleged: iface1'),
     'ls Remotable/getInterfaceOf',
   );
 });

--- a/packages/SwingSet/test/device-mailbox/test-device-mailbox.js
+++ b/packages/SwingSet/test/device-mailbox/test-device-mailbox.js
@@ -14,6 +14,7 @@ import {
   buildMailbox,
 } from '../../src/devices/mailbox/mailbox.js';
 import { bundleOpts } from '../util.js';
+import { kunser } from '../../src/lib/kmarshal.js';
 
 test.before(async t => {
   const kernelBundles = await buildKernelBundles();
@@ -187,14 +188,14 @@ test('mailbox determinism', async t => {
   t.deepEqual(c1a.dump().log, ['comms receive msg1']);
   const kp1 = c1a.queueToVatRoot('bootstrap', 'getNumReceived', []);
   await c1a.run();
-  t.deepEqual(JSON.parse(c1a.kpResolution(kp1).body), 1);
+  t.is(kunser(c1a.kpResolution(kp1)), 1);
 
   t.true(mb2.deliverInbound('peer1', msg1, 0));
   await c2.run();
   t.deepEqual(c2.dump().log, ['comms receive msg1']);
   const kp2 = c2.queueToVatRoot('bootstrap', 'getNumReceived', []);
   await c2.run();
-  t.deepEqual(JSON.parse(c2.kpResolution(kp2).body), 1);
+  t.is(kunser(c2.kpResolution(kp2)), 1);
 
   // both should have the same number of cranks
   t.is(
@@ -219,7 +220,7 @@ test('mailbox determinism', async t => {
   // but vattp dedups, so only one message should be delivered to comms
   const kp3 = c1b.queueToVatRoot('bootstrap', 'getNumReceived', []);
   await c1b.run();
-  t.deepEqual(JSON.parse(c1b.kpResolution(kp3).body), 1);
+  t.is(kunser(c1b.kpResolution(kp3)), 1);
 
   t.true(mb2.deliverInbound('peer1', msg1, 0));
   await c2.run();
@@ -228,7 +229,7 @@ test('mailbox determinism', async t => {
   t.deepEqual(c2.dump().log, ['comms receive msg1']);
   const kp4 = c2.queueToVatRoot('bootstrap', 'getNumReceived', []);
   await c2.run();
-  t.deepEqual(JSON.parse(c2.kpResolution(kp4).body), 1);
+  t.is(kunser(c2.kpResolution(kp4)), 1);
 
   // Both should *still* have the same number of cranks. This is what bug
   // #3471 exposed.

--- a/packages/SwingSet/test/devices/bootstrap-0.js
+++ b/packages/SwingSet/test/devices/bootstrap-0.js
@@ -4,8 +4,7 @@ export default function setup(syscall, state, _helpers, vatPowers) {
   function dispatch(vatDeliverObject) {
     if (vatDeliverObject[0] === 'message') {
       const { args } = extractMessage(vatDeliverObject);
-      vatPowers.testLog(args.body);
-      vatPowers.testLog(JSON.stringify(args.slots));
+      vatPowers.testLog(JSON.stringify(args));
     }
   }
   return dispatch;

--- a/packages/SwingSet/test/devices/bootstrap-1.js
+++ b/packages/SwingSet/test/devices/bootstrap-1.js
@@ -1,5 +1,6 @@
 import { assert, details as X } from '@agoric/assert';
 import { extractMessage } from '../vat-util.js';
+import { kser, kunser, krefOf } from '../../src/lib/kmarshal.js';
 
 export default function setup(syscall, state, _helpers, vatPowers) {
   const { testLog } = vatPowers;
@@ -8,13 +9,12 @@ export default function setup(syscall, state, _helpers, vatPowers) {
     if (vatDeliverObject[0] === 'message') {
       const { method, args } = extractMessage(vatDeliverObject);
       if (method === 'bootstrap') {
-        const argb = JSON.parse(args.body);
-        const deviceIndex = argb[1].d1.index;
-        deviceRef = args.slots[deviceIndex];
+        const [_vats, devices] = kunser(args);
+        deviceRef = krefOf(devices.d1);
         assert(deviceRef === 'd-70', X`bad deviceRef ${deviceRef}`);
       } else if (method === 'step1') {
         testLog(`callNow`);
-        const setArgs = harden({ body: JSON.stringify([1, 2]), slots: [] });
+        const setArgs = kser([1, 2]);
         const ret = syscall.callNow(deviceRef, 'set', setArgs);
         testLog(JSON.stringify(ret));
       }

--- a/packages/SwingSet/test/devices/bootstrap-4.js
+++ b/packages/SwingSet/test/devices/bootstrap-4.js
@@ -1,46 +1,32 @@
-import { assert } from '@agoric/assert';
-import { QCLASS } from '@endo/marshal';
 import { insistVatType } from '../../src/lib/parseVatSlots.js';
 import { extractMessage } from '../vat-util.js';
+import { kunser, kser, kslot, krefOf } from '../../src/lib/kmarshal.js';
 
 // to exercise the error we get when syscall.callNow() is given a promise
 // identifier, we must bypass liveslots, which would otherwise protect us
 // against the vat-fatal mistake
 
-function capdata(body, slots = []) {
-  return harden({ body, slots });
-}
-
-function capargs(args, slots = []) {
-  return capdata(JSON.stringify(args), slots);
-}
-
 export default function setup(syscall, state, _helpers, vatPowers) {
   const { callNow } = syscall;
   const { testLog } = vatPowers;
-  let slot;
+  let d0;
   function dispatch(vatDeliverObject) {
     if (vatDeliverObject[0] === 'message') {
       const { method, args, result } = extractMessage(vatDeliverObject);
       if (method === 'bootstrap') {
         // find and stash the device slot
-        const [_vats, devices] = JSON.parse(args.body);
-        const qnode = devices.d0;
-        assert.equal(qnode[QCLASS], 'slot');
-        slot = args.slots[qnode.index];
-        insistVatType('device', slot);
+        const [_vats, devices] = kunser(args);
+        d0 = devices.d0;
+        insistVatType('device', krefOf(d0));
         // resolve the bootstrap() promise now, so it won't be rejected later
         // when we're terminated
-        syscall.resolve([[result, false, capargs(0, [])]]);
+        syscall.resolve([[result, false, kser(0)]]);
       } else if (method === 'doBadCallNow') {
         const vpid = 'p+1'; // pretend we're exporting a promise
-        const pnode = { [QCLASS]: 'slot', index: 0 };
-        const callNowArgs = capargs([pnode], [vpid]);
-
         testLog('sending Promise');
         try {
           // this will throw an exception, but is also (eventually) vat-fatal
-          callNow(slot, 'send', callNowArgs);
+          callNow(krefOf(d0), 'send', kser([kslot(vpid)]));
           testLog('oops: survived sending Promise');
         } catch (e) {
           testLog('good: callNow failed');

--- a/packages/SwingSet/test/devices/test-raw-device.js
+++ b/packages/SwingSet/test/devices/test-raw-device.js
@@ -3,8 +3,8 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import bundleSource from '@endo/bundle-source';
-import { parse } from '@endo/marshal';
 import { provideHostStorage } from '../../src/controller/hostStorage.js';
+import { kunser } from '../../src/lib/kmarshal.js';
 
 import {
   initializeSwingset,
@@ -59,7 +59,7 @@ test('d1', async t => {
   // first, exercise plain arguments and return values
   const r1 = c.queueToVatRoot('bootstrap', 'step1', []);
   await c.run();
-  t.deepEqual(JSON.parse(c.kpResolution(r1).body), { a: 4, b: [5, 6] });
+  t.deepEqual(kunser(c.kpResolution(r1)), { a: 4, b: [5, 6] });
   t.deepEqual(sharedArray, ['pushed']);
   sharedArray.length = 0;
 
@@ -68,7 +68,7 @@ test('d1', async t => {
   const r2 = c.queueToVatRoot('bootstrap', 'step2', []);
   await c.run();
   const expected2 = ['got', true, 'hi ping1', true, 'hi ping2', true];
-  t.deepEqual(JSON.parse(c.kpResolution(r2).body), expected2);
+  t.deepEqual(kunser(c.kpResolution(r2)), expected2);
 
   // create and pass around new device nodes
   const r3 = c.queueToVatRoot('bootstrap', 'step3', []);
@@ -77,7 +77,7 @@ test('d1', async t => {
     ['dn1', 21, true, true],
     ['dn2', 22, true, true],
   ];
-  t.deepEqual(JSON.parse(c.kpResolution(r3).body), expected3);
+  t.deepEqual(kunser(c.kpResolution(r3)), expected3);
 
   // check that devices can manage state through vatstore
   const r4 = c.queueToVatRoot('bootstrap', 'step4', []);
@@ -87,23 +87,21 @@ test('d1', async t => {
     ['value1', undefined],
     [undefined, undefined],
   ];
-  t.deepEqual(parse(c.kpResolution(r4).body), expected4);
+  t.deepEqual(kunser(c.kpResolution(r4)), expected4);
 
   // check that device exceptions do not kill the device, calling vat, or kernel
   const r5 = c.queueToVatRoot('bootstrap', 'step5', []);
   await c.run();
-  // body: '{"@qclass":"error","errorId":"error:liveSlots:v1#70001","message":"syscall.callNow failed: device.invoke failed, see logs for details","name":"Error"}',
   const expected5 = Error(
     'syscall.callNow failed: device.invoke failed, see logs for details',
   );
-  t.deepEqual(parse(c.kpResolution(r5).body), expected5);
+  t.deepEqual(kunser(c.kpResolution(r5)), expected5);
 
   // and raw devices can return an error result
   const r6 = c.queueToVatRoot('bootstrap', 'step6', []);
   await c.run();
-  // body: '{"@qclass":"error","errorId":"error:liveSlots:v1#70001","message":"syscall.callNow failed: device.invoke failed, see logs for details","name":"Error"}',
   const expected6 = Error(
     'syscall.callNow failed: deliberate raw-device result error',
   );
-  t.deepEqual(parse(c.kpResolution(r6).body), expected6);
+  t.deepEqual(kunser(c.kpResolution(r6)), expected6);
 });

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -6,13 +6,13 @@ import { makeGcAndFinalize } from '../src/lib-nodejs/gc-and-finalize.js';
 import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
 import { makeLiveSlots } from '../src/liveslots/liveslots.js';
 import {
-  capargs,
   makeMessage,
   makeDropExports,
   makeRetireImports,
   makeRetireExports,
   makeBringOutYourDead,
 } from './util.js';
+import { kser } from '../src/lib/kmarshal.js';
 
 /**
  * @param {boolean} [skipLogging = false]
@@ -145,7 +145,7 @@ export async function makeDispatch(
       return { buildRootObject: build };
     },
   );
-  await startVat(capargs());
+  await startVat(kser());
   if (returnTestHooks) {
     returnTestHooks[0] = testHooks;
   }
@@ -179,9 +179,9 @@ export async function setupTestLiveslots(
   );
   const [testHooks] = th;
 
-  async function dispatchMessage(message, args = [], slots = []) {
+  async function dispatchMessage(message, ...args) {
     const rp = nextRP();
-    await dispatch(makeMessage('o+0', message, args, slots, rp));
+    await dispatch(makeMessage('o+0', message, args, rp));
     if (forceGC) {
       // XXX TERRIBLE HACK WARNING XXX The following GC call is terrible but
       // apparently sometimes necessary.  Without it, certain tests in some
@@ -279,5 +279,5 @@ export function validateDone(v) {
 }
 
 export function validateReturned(v, rp) {
-  validate(v, matchResolveOne(rp, capargs({ '@qclass': 'undefined' })));
+  validate(v, matchResolveOne(rp, kser(undefined)));
 }

--- a/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
@@ -3,14 +3,7 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import { buildVatController } from '../../src/index.js';
-
-function capdata(body, slots = []) {
-  return harden({ body, slots });
-}
-
-function capargs(args, slots = []) {
-  return capdata(JSON.stringify(args), slots);
-}
+import { kunser } from '../../src/lib/kmarshal.js';
 
 // Dynamic vats are created without metering by default
 
@@ -39,15 +32,15 @@ test('unmetered dynamic vat', async t => {
   // 'createVat' will import the bundle
   const kp1 = c.queueToVatRoot('bootstrap', 'createVat', ['dynamic'], 'panic');
   await c.run();
-  const res1 = c.kpResolution(kp1);
-  t.is(JSON.parse(res1.body)[0], 'created', res1.body);
+  const res1 = kunser(c.kpResolution(kp1));
+  t.is(res1[0], 'created');
   // const doneKPID = res1.slots[0];
 
   // Now send a message to the dynamic vat that runs normally
   const kp2 = c.queueToVatRoot('bootstrap', 'run', [], 'panic');
   await c.run();
   t.is(c.kpStatus(kp2), 'fulfilled');
-  t.deepEqual(c.kpResolution(kp2), capargs(42));
+  t.deepEqual(kunser(c.kpResolution(kp2)), 42);
 
   // TODO: find a way to prove that the xsnap child process does not have a
   // per-crank meter imposed upon it. Previously, this test only exercised

--- a/packages/SwingSet/test/promise-watcher/test-promise-watcher.js
+++ b/packages/SwingSet/test/promise-watcher/test-promise-watcher.js
@@ -55,8 +55,8 @@ async function testPromiseWatcher(t) {
     const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
-    const capdata = c.kpResolution(kpid);
-    return [status, capdata];
+    const result = c.kpResolution(kpid);
+    return [status, result];
   }
 
   // create initial version
@@ -89,7 +89,7 @@ async function testPromiseWatcher(t) {
   const [v2status /* , v2capdata */] = await run('upgradeV2', []);
   t.is(v2status, 'fulfilled');
   const doString =
-    '{"name":"vatUpgraded","upgradeMessage":"test upgrade","incarnationNumber":1}';
+    '{"incarnationNumber":1,"name":"vatUpgraded","upgradeMessage":"test upgrade"}';
   t.deepEqual(c.dump().log, [
     ...beforeReference,
     `lp3-pw rejected ${doString} version v2 via watcher []`,

--- a/packages/SwingSet/test/stores/test-storeGC/test-lifecycle.js
+++ b/packages/SwingSet/test/stores/test-storeGC/test-lifecycle.js
@@ -6,7 +6,6 @@ import {
   buildRootObject,
   mainHeldIdx,
   mapRef,
-  mapRefArg,
   NONE,
   validateDropExports,
   validateDropExportsWithGCAndRetire,
@@ -23,6 +22,7 @@ import {
   validateRetireExports,
   validateStoreHeld,
 } from '../../gc-helpers.js';
+import { kslot } from '../../../src/lib/kmarshal.js';
 
 // These tests follow the model described in
 // ../virtualObjects/test-virtualObjectGC.js
@@ -98,8 +98,7 @@ test.serial('store lifecycle 2', async t => {
   validateDropHeld(v, rp, '1', 'r');
 
   // lERV -> LERV  Reintroduce the in-memory reference via message
-  const [marg, mslot] = mapRefArg(mainHeldIdx);
-  rp = await dispatchMessage('importAndHold', [marg], [mslot]);
+  rp = await dispatchMessage('importAndHold', kslot(mapRef(mainHeldIdx)));
   validateImportAndHold(v, rp, mainHeldIdx);
 
   // LERV -> lERV  Drop in-memory reference
@@ -282,8 +281,7 @@ test.serial('store lifecycle 7', async t => {
   validateDropHeld(v, rp, NONE, 'r');
 
   // lERv -> LERv  Reintroduce the in-memory reference via message
-  const [marg, mslot] = mapRefArg(mainHeldIdx);
-  rp = await dispatchMessage('importAndHold', [marg], [mslot]);
+  rp = await dispatchMessage('importAndHold', kslot(mapRef(mainHeldIdx)));
   validateImportAndHold(v, rp, mainHeldIdx);
 
   // LERv -> lERv  Drop in-memory reference again, still no GC because exported

--- a/packages/SwingSet/test/stores/test-storeGC/test-weak-key.js
+++ b/packages/SwingSet/test/stores/test-storeGC/test-weak-key.js
@@ -19,10 +19,7 @@ import {
   mainHeldIdx,
   mapRef,
   NONE,
-  nullValString,
   refValString,
-  stringValString,
-  thingArg,
   validateCreateStore,
   validateDeleteMetadataOnly,
   validateInit,
@@ -31,6 +28,8 @@ import {
   validateUpdate,
   validateWeakCheckEmpty,
 } from '../../gc-helpers.js';
+import { kslot } from '../../../src/lib/kmarshal.js';
+import { vstr } from '../../util.js';
 
 // These tests follow the model described in
 // ../virtualObjects/test-virtualObjectGC.js
@@ -68,7 +67,7 @@ test.serial('verify store weak key GC', async t => {
   validate(v, matchVatstoreGet(`vc.${mapID}.|${mapRef(keyID)}`, '1'));
   validate(
     v,
-    matchVatstoreSet(`vc.${mapID}.${ordinalKey}`, stringValString('arbitrary')),
+    matchVatstoreSet(`vc.${mapID}.${ordinalKey}`, vstr('arbitrary')),
   );
 
   validate(v, matchVatstoreGet(`vc.${setID}.|${mapRef(keyID)}`, NONE));
@@ -77,7 +76,7 @@ test.serial('verify store weak key GC', async t => {
   validate(v, matchVatstoreSet(`vc.${setID}.|nextOrdinal`, '2'));
   validate(v, matchVatstoreSet(`vom.ir.${mapRef(keyID)}|${setID}`, '1'));
   validate(v, matchVatstoreGet(`vc.${setID}.|${mapRef(keyID)}`, '1'));
-  validate(v, matchVatstoreSet(`vc.${setID}.${ordinalKey}`, nullValString));
+  validate(v, matchVatstoreSet(`vc.${setID}.${ordinalKey}`, vstr(null)));
   validateReturned(v, rp);
   validate(v, matchVatstoreSet('idCounters'));
   validateDone(v);
@@ -92,7 +91,7 @@ test.serial('verify store weak key GC', async t => {
     v,
     matchVatstoreGetAfter('', `vc.${mapID}.`, `vc.${mapID}.{`, [
       `vc.${mapID}.${ordinalKey}`,
-      stringValString('arbitrary'),
+      vstr('arbitrary'),
     ]),
   );
   validate(
@@ -104,7 +103,7 @@ test.serial('verify store weak key GC', async t => {
     v,
     matchVatstoreGetAfter('', `vc.${setID}.`, `vc.${setID}.{`, [
       `vc.${setID}.${ordinalKey}`,
-      nullValString,
+      vstr(null),
     ]),
   );
   validate(
@@ -122,13 +121,13 @@ test.serial('verify store weak key GC', async t => {
   validate(v, matchVatstoreDelete(`${prefix}${mapID}`));
   validate(v, matchVatstoreGet(`vc.${mapID}.|${mapRef(keyID)}`, '1'));
   validate(v, matchVatstoreDelete(`vc.${mapID}.|${mapRef(keyID)}`));
-  validate(v, matchVatstoreGet(`vc.${mapID}.${ordinalKey}`, stringValString('arbitrary')));
+  validate(v, matchVatstoreGet(`vc.${mapID}.${ordinalKey}`, vstr('arbitrary')));
   validate(v, matchVatstoreDelete(`vc.${mapID}.${ordinalKey}`));
   validate(v, matchVatstoreGetAfter(`${prefix}${mapID}`, prefix, NONE, [`${prefix}${setID}`, '1']));
   validate(v, matchVatstoreDelete(`${prefix}${setID}`));
   validate(v, matchVatstoreGet(`vc.${setID}.|${mapRef(keyID)}`, '1'));
   validate(v, matchVatstoreDelete(`vc.${setID}.|${mapRef(keyID)}`));
-  validate(v, matchVatstoreGet(`vc.${setID}.${ordinalKey}`, nullValString));
+  validate(v, matchVatstoreGet(`vc.${setID}.${ordinalKey}`, vstr(null)));
   validate(v, matchVatstoreDelete(`vc.${setID}.${ordinalKey}`));
   validate(v, matchVatstoreGetAfter(`${prefix}${setID}`, prefix, NONE, [NONE, NONE]));
 
@@ -202,10 +201,10 @@ test.serial('verify presence weak key GC', async t => {
     await setupTestLiveslots(t, buildRootObject, 'bob', true);
 
   const presenceRef = 'o-5';
+  const presence = kslot(presenceRef, 'thing');
 
   // Import a presence to use as a key and hold onto it weakly
-  const [targ, tslot] = thingArg(presenceRef);
-  let rp = await dispatchMessage('importAndHoldAndKey', [targ], [tslot]);
+  let rp = await dispatchMessage('importAndHoldAndKey', presence);
   validateInit(v);
   const mapID = mainHeldIdx;
   validateCreateStore(v, mapID, true); // map
@@ -222,7 +221,7 @@ test.serial('verify presence weak key GC', async t => {
   validate(v, matchVatstoreGet(`vc.${mapID}.|${presenceRef}`, '1'));
   validate(
     v,
-    matchVatstoreSet(`vc.${mapID}.${ordinalKey}`, stringValString('arbitrary')),
+    matchVatstoreSet(`vc.${mapID}.${ordinalKey}`, vstr('arbitrary')),
   );
 
   validate(v, matchVatstoreGet(`vc.${setID}.|${presenceRef}`, NONE));
@@ -231,7 +230,7 @@ test.serial('verify presence weak key GC', async t => {
   validate(v, matchVatstoreSet(`vc.${setID}.|nextOrdinal`, '2'));
   validate(v, matchVatstoreSet(`vom.ir.${presenceRef}|${setID}`, '1'));
   validate(v, matchVatstoreGet(`vc.${setID}.|${presenceRef}`, '1'));
-  validate(v, matchVatstoreSet(`vc.${setID}.${ordinalKey}`, nullValString));
+  validate(v, matchVatstoreSet(`vc.${setID}.${ordinalKey}`, vstr(null)));
   validateReturned(v, rp);
   validate(v, matchVatstoreSet('idCounters'));
 
@@ -245,7 +244,7 @@ test.serial('verify presence weak key GC', async t => {
     v,
     matchVatstoreGetAfter('', `vc.${mapID}.`, `vc.${mapID}.{`, [
       `vc.${mapID}.${ordinalKey}`,
-      stringValString('arbitrary'),
+      vstr('arbitrary'),
     ]),
   );
   validate(
@@ -257,7 +256,7 @@ test.serial('verify presence weak key GC', async t => {
     v,
     matchVatstoreGetAfter('', `vc.${setID}.`, `vc.${setID}.{`, [
       `vc.${setID}.${ordinalKey}`,
-      nullValString,
+      vstr(null),
     ]),
   );
   validate(
@@ -280,7 +279,7 @@ test.serial('verify presence weak key GC', async t => {
     v,
     matchVatstoreGetAfter('', `vc.${mapID}.`, `vc.${mapID}.{`, [
       `vc.${mapID}.${ordinalKey}`,
-      stringValString('arbitrary'),
+      vstr('arbitrary'),
     ]),
   );
   validate(
@@ -292,7 +291,7 @@ test.serial('verify presence weak key GC', async t => {
     v,
     matchVatstoreGetAfter('', `vc.${setID}.`, `vc.${setID}.{`, [
       `vc.${setID}.${ordinalKey}`,
-      nullValString,
+      vstr(null),
     ]),
   );
   validate(
@@ -306,13 +305,13 @@ test.serial('verify presence weak key GC', async t => {
   validate(v, matchVatstoreDelete(`${prefix}${mapID}`));
   validate(v, matchVatstoreGet(`vc.${mapID}.|${presenceRef}`, '1'));
   validate(v, matchVatstoreDelete(`vc.${mapID}.|${presenceRef}`));
-  validate(v, matchVatstoreGet(`vc.${mapID}.${ordinalKey}`, stringValString('arbitrary')));
+  validate(v, matchVatstoreGet(`vc.${mapID}.${ordinalKey}`, vstr('arbitrary')));
   validate(v, matchVatstoreDelete(`vc.${mapID}.${ordinalKey}`));
   validate(v, matchVatstoreGetAfter(`${prefix}${mapID}`, prefix, NONE, [`${prefix}${setID}`, '1']));
   validate(v, matchVatstoreDelete(`${prefix}${setID}`));
   validate(v, matchVatstoreGet(`vc.${setID}.|${presenceRef}`, '1'));
   validate(v, matchVatstoreDelete(`vc.${setID}.|${presenceRef}`));
-  validate(v, matchVatstoreGet(`vc.${setID}.${ordinalKey}`, nullValString));
+  validate(v, matchVatstoreGet(`vc.${setID}.${ordinalKey}`, vstr(null)));
   validate(v, matchVatstoreDelete(`vc.${setID}.${ordinalKey}`));
   validate(v, matchVatstoreGetAfter(`${prefix}${setID}`, prefix, NONE, [NONE, NONE]));
   validateRefCountCheck(v, presenceRef, NONE);

--- a/packages/SwingSet/test/test-baggage.js
+++ b/packages/SwingSet/test/test-baggage.js
@@ -12,6 +12,7 @@ import {
   validateReturned,
 } from './liveslots-helpers.js';
 import { validateCreateBuiltInTables } from './gc-helpers.js';
+import { vstr } from './util.js';
 
 function buildRootObject(vatPowers, vatParameters, baggage) {
   baggage.has('outside');
@@ -25,13 +26,6 @@ function buildRootObject(vatPowers, vatParameters, baggage) {
 }
 
 const NONE = undefined; // mostly just shorter, to maintain legibility while making prettier shut up
-
-function stringVal(str) {
-  return JSON.stringify({
-    body: JSON.stringify(str),
-    slots: [],
-  });
-}
 
 function validateSetup(v) {
   validate(v, matchVatstoreGet('idCounters', NONE));
@@ -58,7 +52,7 @@ test.serial('exercise baggage', async t => {
   validateSetup(v);
   validate(v, matchVatstoreGet('vc.1.soutside', NONE));
   validate(v, matchVatstoreGet('vc.1.soutside', NONE));
-  validate(v, matchVatstoreSet('vc.1.soutside', stringVal('outer val')));
+  validate(v, matchVatstoreSet('vc.1.soutside', vstr('outer val')));
   validate(v, matchVatstoreGet('vc.1.|entryCount', '0'));
   validate(v, matchVatstoreSet('vc.1.|entryCount', '1'));
   validate(v, matchVatstoreGet('deadPromises', NONE));
@@ -66,9 +60,9 @@ test.serial('exercise baggage', async t => {
   validateDone(v);
 
   const rp = await dispatchMessage('doSomething', []);
-  validate(v, matchVatstoreGet('vc.1.soutside', stringVal('outer val')));
+  validate(v, matchVatstoreGet('vc.1.soutside', vstr('outer val')));
   validate(v, matchVatstoreGet('vc.1.sinside', NONE));
-  validate(v, matchVatstoreSet('vc.1.sinside', stringVal('inner val')));
+  validate(v, matchVatstoreSet('vc.1.sinside', vstr('inner val')));
   validate(v, matchVatstoreGet('vc.1.|entryCount', '1'));
   validate(v, matchVatstoreSet('vc.1.|entryCount', '2'));
   validateReturned(v, rp);

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -7,6 +7,7 @@ import { makePromiseKit } from '@endo/promise-kit';
 
 import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
 import { makeMarshaller } from '../src/liveslots/liveslots.js';
+import { kser, makeError } from '../src/lib/kmarshal.js';
 
 const gcTools = harden({
   WeakRef,
@@ -33,16 +34,16 @@ test('serialize exports', t => {
     },
   });
   t.deepEqual(ser(o1), {
-    body: '{"@qclass":"slot","iface":"Alleged: o1","index":0}',
+    body: '#"$0.Alleged: o1"',
     slots: ['o+1'],
   });
   // m now remembers that o1 is exported as 1
   t.deepEqual(ser(harden([o1, o1])), {
-    body: '[{"@qclass":"slot","iface":"Alleged: o1","index":0},{"@qclass":"slot","index":0}]',
+    body: '#["$0.Alleged: o1","$0"]',
     slots: ['o+1'],
   });
   t.deepEqual(ser(harden([o2, o1])), {
-    body: '[{"@qclass":"slot","iface":"Alleged: o2","index":0},{"@qclass":"slot","iface":"Alleged: o1","index":1}]',
+    body: '#["$0.Alleged: o2","$1.Alleged: o1"]',
     slots: ['o+2', 'o+1'],
   });
 });
@@ -50,7 +51,7 @@ test('serialize exports', t => {
 test('deserialize imports', async t => {
   const { unmeteredUnserialize } = makeUnmeteredMarshaller(undefined);
   const a = unmeteredUnserialize({
-    body: '{"@qclass":"slot","index":0}',
+    body: '#"$0"',
     slots: ['o-1'],
   });
   // a should be a proxy/presence. For now these are obvious.
@@ -59,14 +60,14 @@ test('deserialize imports', async t => {
 
   // m now remembers the proxy
   const b = unmeteredUnserialize({
-    body: '{"@qclass":"slot","index":0}',
+    body: '#"$0"',
     slots: ['o-1'],
   });
   t.is(a, b);
 
   // the slotid is what matters, not the index
   const c = unmeteredUnserialize({
-    body: '{"@qclass":"slot","index":2}',
+    body: '#"$2"',
     slots: ['x', 'x', 'o-1'],
   });
   t.is(a, c);
@@ -80,7 +81,7 @@ test('deserialize exports', t => {
   const o1 = Far('o1', {});
   m.serialize(o1); // allocates slot=1
   const a = unmeteredUnserialize({
-    body: '{"@qclass":"slot","index":0}',
+    body: '#"$0"',
     slots: ['o+1'],
   });
   t.is(a, o1);
@@ -89,11 +90,11 @@ test('deserialize exports', t => {
 test('serialize imports', async t => {
   const { m, unmeteredUnserialize } = makeUnmeteredMarshaller(undefined);
   const a = unmeteredUnserialize({
-    body: '{"@qclass":"slot","index":0}',
+    body: '#"$0"',
     slots: ['o-1'],
   });
   t.deepEqual(m.serialize(a), {
-    body: '{"@qclass":"slot","iface":"Alleged: presence o-1","index":0}',
+    body: '#"$0.Alleged: presence o-1"',
     slots: ['o-1'],
   });
 });
@@ -106,19 +107,19 @@ test('serialize promise', async t => {
   const { m, unmeteredUnserialize } = makeUnmeteredMarshaller(syscall);
   const { promise } = makePromiseKit();
   t.deepEqual(m.serialize(promise), {
-    body: '{"@qclass":"slot","index":0}',
+    body: '#"&0"',
     slots: ['p+5'],
   });
   // serializer should remember the promise
   t.deepEqual(m.serialize(harden(['other stuff', promise])), {
-    body: '["other stuff",{"@qclass":"slot","index":0}]',
+    body: '#["other stuff","&0"]',
     slots: ['p+5'],
   });
 
   // inbound should recognize it and return the promise
   t.deepEqual(
     unmeteredUnserialize({
-      body: '{"@qclass":"slot","index":0}',
+      body: '#"&0"',
       slots: ['p+5'],
     }),
     promise,
@@ -136,9 +137,25 @@ test('unserialize promise', async t => {
   const { m } = makeMarshaller(syscall, gcTools);
   const unserialize = gcTools.meterControl.unmetered(m.unserialize);
   const p = unserialize({
-    body: '{"@qclass":"slot","index":0}',
+    body: '#"&0"',
     slots: ['p-1'],
   });
   t.deepEqual(log, ['subscribe-p-1']);
   t.truthy(p instanceof Promise);
+});
+
+test('kernel serialzation of errors', async t => {
+  // The kernel synthesizes e.g. `Error('vat-upgrade failure')`, so we
+  // need kmarshal to serialize those errors in a deterministic
+  // way. This test checks that we don't get surprising things like
+  // `errorId` or stack traces.
+  const e1 = kser(Error('fake error'));
+  const ref = {
+    body: '#{"#error":"fake error","name":"Error"}',
+    slots: [],
+  };
+  t.deepEqual(e1, ref);
+
+  const e2 = makeError('fake error');
+  t.deepEqual(e2, ref);
 });

--- a/packages/SwingSet/test/test-promises.js
+++ b/packages/SwingSet/test/test-promises.js
@@ -6,7 +6,7 @@ import {
   loadBasedir,
   buildKernelBundles,
 } from '../src/index.js';
-import { capargs } from './util.js';
+import { kser, kslot } from '../src/lib/kmarshal.js';
 
 test.before(async t => {
   const kernelBundles = await buildKernelBundles();
@@ -164,28 +164,19 @@ test('circular promise resolution data', async t => {
       id: 'kp40',
       state: 'fulfilled',
       refCount: 1,
-      data: {
-        body: '{"@qclass":"undefined"}',
-        slots: [],
-      },
+      data: kser(undefined),
     },
     {
       id: 'kp42',
       state: 'fulfilled',
       refCount: 1,
-      data: {
-        body: '[{"@qclass":"slot","index":0}]',
-        slots: ['kp44'],
-      },
+      data: kser([kslot('kp44')]),
     },
     {
       id: 'kp44',
       state: 'fulfilled',
       refCount: 1,
-      data: {
-        body: '[{"@qclass":"slot","index":0}]',
-        slots: ['kp42'],
-      },
+      data: kser([kslot('kp42')]),
     },
   ];
   t.deepEqual(c.dump().promises, expectedPromises);
@@ -219,5 +210,5 @@ test('refcount while queued', async t => {
   // will be delivered, with a new promise that is promptly resolved to '3'.
   const kpid4 = c.queueToVatRoot('right', 'three', [], 'ignore');
   await c.run();
-  t.deepEqual(c.kpResolution(kpid4), capargs([true, 3]));
+  t.deepEqual(c.kpResolution(kpid4), kser([true, 3]));
 });

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -7,7 +7,7 @@ import bundleSource from '@endo/bundle-source';
 
 import { makeXsSubprocessFactory } from '../src/kernel/vat-loader/manager-subprocess-xsnap.js';
 import { makeStartXSnap } from '../src/controller/controller.js';
-import { capargs } from './util.js';
+import { kser } from '../src/lib/kmarshal.js';
 
 test('child termination distinguished from meter exhaustion', async t => {
   const makeb = rel =>
@@ -68,9 +68,9 @@ test('child termination distinguished from meter exhaustion', async t => {
     schandler,
   );
 
-  await m.deliver(['startVat', capargs()]);
+  await m.deliver(['startVat', kser()]);
 
-  const msg = { methargs: capargs(['hang', []]) };
+  const msg = { methargs: kser(['hang', []]) };
   /** @type { VatDeliveryObject } */
   const delivery = ['message', 'o+0', msg];
 

--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
@@ -212,7 +212,11 @@ export const buildRootObject = () => {
       const vatParameters = { youAre: 'v2', marker, handler, explode };
       // vp.handler causes v2 to handler~.ping(), but that gets unwound
       const p = E(ulrikAdmin).upgrade(bcap, { vatParameters }); // throws
-      await p.catch(e => events.push(e));
+      await p.catch(e => {
+        events.push(e);
+        events.push(e instanceof Error);
+        events.push(/vat-upgrade failure/.test(e.message));
+      });
       await E(ulrikRoot).pingback(handler); // goes to post-rewind v1
       return events;
     },

--- a/packages/SwingSet/test/upgrade/test-upgrade-replay.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade-replay.js
@@ -9,7 +9,8 @@ import {
   initializeSwingset,
   makeSwingsetController,
 } from '../../src/index.js';
-import { capargs, bundleOpts } from '../util.js';
+import { bundleOpts } from '../util.js';
+import { kser } from '../../src/lib/kmarshal.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
@@ -24,8 +25,8 @@ async function run(c, method, args = []) {
   const kpid = c.queueToVatRoot('bootstrap', method, args);
   await c.run();
   const status = c.kpStatus(kpid);
-  const capdata = c.kpResolution(kpid);
-  return [status, capdata];
+  const result = c.kpResolution(kpid);
+  return [status, result];
 }
 
 test.before(async t => {
@@ -56,13 +57,13 @@ test('replay after upgrade', async t => {
     // create initial version
     const [v1status, v1data] = await run(c1, 'buildV1');
     t.is(v1status, 'fulfilled');
-    t.deepEqual(v1data, capargs(1));
+    t.deepEqual(v1data, kser(1));
 
     // now perform the upgrade
     const [v2status, v2data] = await run(c1, 'upgradeV2');
     t.is(v2status, 'fulfilled');
     // upgrade restart loses RAM state, hence adding 20 yields 20 rather than 21
-    t.deepEqual(v2data, capargs(20));
+    t.deepEqual(v2data, kser(20));
   }
 
   // copy the store just to be sure
@@ -80,6 +81,6 @@ test('replay after upgrade', async t => {
     t.is(rstatus, 'fulfilled');
 
     // replay retains RAM state of post-upgrade vat, hence adding 300 yields 320
-    t.deepEqual(rdata, capargs(320));
+    t.deepEqual(rdata, kser(320));
   }
 });

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -6,9 +6,10 @@ import bundleSource from '@endo/bundle-source';
 import { waitUntilQuiescent } from '../src/lib-nodejs/waitUntilQuiescent.js';
 import { provideHostStorage } from '../src/controller/hostStorage.js';
 import { createSHA256 } from '../src/lib-nodejs/hasher.js';
-import { extractMessage, capdata, capargs, ignore } from './vat-util.js';
+import { extractMessage, ignore, vstr } from './vat-util.js';
+import { kser } from '../src/lib/kmarshal.js';
 
-export { extractMessage, capdata, capargs, ignore };
+export { extractMessage, ignore, vstr };
 
 function compareArraysOfStrings(a, b) {
   a = a.join(' ');
@@ -89,58 +90,14 @@ export function buildDispatch(onDispatchCallback) {
 }
 
 /**
- * @param {number} index
- * @param {string} [iface]
- */
-export function capSlot(index, iface = 'export') {
-  iface = iface ? `Alleged: ${iface}` : undefined;
-  return { '@qclass': 'slot', iface, index };
-}
-
-/**
- * @param {string} method
- * @param {string} slot
- * @param {string} [iface]
- */
-export function methargsOneSlot(method, slot, iface = 'export') {
-  iface = iface ? `Alleged: ${iface}` : undefined;
-  return capargs([method, [{ '@qclass': 'slot', iface, index: 0 }]], [slot]);
-}
-
-/**
- * @param {string} slot
- * @param {string} [iface]
- */
-export function capdataOneSlot(slot, iface = 'export') {
-  iface = iface ? `Alleged: ${iface}` : undefined;
-  return capargs({ '@qclass': 'slot', iface, index: 0 }, [slot]);
-}
-
-/**
- * @param {string} slot
- * @param {string} [iface]
- */
-export function capargsOneSlot(slot, iface = 'export') {
-  iface = iface ? `Alleged: ${iface}` : undefined;
-  return capargs([{ '@qclass': 'slot', iface, index: 0 }], [slot]);
-}
-
-/**
  *
  * @param {unknown} target
  * @param {string} method
  * @param {any[]} args
- * @param {any[]} slots
  * @param {unknown} result
  */
-export function makeMessage(
-  target,
-  method,
-  args = [],
-  slots = [],
-  result = null,
-) {
-  const methargs = capargs([method, args], slots);
+export function makeMessage(target, method, args = [], result = null) {
+  const methargs = kser([method, args]);
   const msg = { methargs, result };
   const vatDeliverObject = harden(['message', target, msg]);
   return vatDeliverObject;

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate-replay.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate-replay.js
@@ -9,7 +9,7 @@ import {
   loadSwingsetConfigFile,
   buildKernelBundles,
 } from '../../../src/index.js';
-import { capargs } from '../../util.js';
+import { kser } from '../../../src/lib/kmarshal.js';
 
 test.before(async t => {
   const kernelBundles = await buildKernelBundles();
@@ -28,7 +28,7 @@ test.serial('replay does not resurrect dead vat', async t => {
       kernelBundles: t.context.data.kernelBundles,
     });
     await c1.run();
-    t.deepEqual(c1.kpResolution(c1.bootstrapResult), capargs('bootstrap done'));
+    t.deepEqual(c1.kpResolution(c1.bootstrapResult), kser('bootstrap done'));
     // this comes from the dynamic vat...
     t.deepEqual(c1.dump().log, [`w: I ate'nt dead`]);
   }

--- a/packages/SwingSet/test/vat-admin/test-replay.js
+++ b/packages/SwingSet/test/vat-admin/test-replay.js
@@ -4,7 +4,7 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 import { getAllState, setAllState } from '@agoric/swing-store';
 import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import { buildKernelBundles, buildVatController } from '../../src/index.js';
-import { capargs } from '../util.js';
+import { kser } from '../../src/lib/kmarshal.js';
 
 function copy(data) {
   return JSON.parse(JSON.stringify(data));
@@ -42,7 +42,7 @@ test.serial('replay dynamic vat', async t => {
     c1.pinVatRoot('bootstrap');
     const r1 = c1.queueToVatRoot('bootstrap', 'createVat', [], 'panic');
     await c1.run();
-    t.deepEqual(c1.kpResolution(r1), capargs('created'));
+    t.deepEqual(c1.kpResolution(r1), kser('created'));
   }
 
   // Now we abandon that swingset and start a new one, with the same state.
@@ -59,6 +59,6 @@ test.serial('replay dynamic vat', async t => {
     t.teardown(c2.shutdown);
     const r2 = c2.queueToVatRoot('bootstrap', 'check', [], 'panic');
     await c2.run();
-    t.deepEqual(c2.kpResolution(r2), capargs('ok'));
+    t.deepEqual(c2.kpResolution(r2), kser('ok'));
   }
 });

--- a/packages/SwingSet/test/vat-syscall-failure.js
+++ b/packages/SwingSet/test/vat-syscall-failure.js
@@ -1,12 +1,5 @@
 import { extractMessage } from './vat-util.js';
-
-function capdata(body, slots = []) {
-  return harden({ body, slots });
-}
-
-function capargs(args, slots = []) {
-  return capdata(JSON.stringify(args), slots);
-}
+import { kser } from '../src/lib/kmarshal.js';
 
 export default function setup(syscall, _state, _helpers, vatPowers) {
   function dispatch(vatDeliverObject) {
@@ -16,7 +9,7 @@ export default function setup(syscall, _state, _helpers, vatPowers) {
     const { method, args } = extractMessage(vatDeliverObject);
     vatPowers.testLog(`${method}`);
     const thing = method === 'begood' ? args.slots[0] : 'o-3414159';
-    syscall.send(thing, capargs(['pretendToBeAThing', [method]]));
+    syscall.send(thing, kser(['pretendToBeAThing', [method]]));
   }
   return dispatch;
 }

--- a/packages/SwingSet/test/vat-util.js
+++ b/packages/SwingSet/test/vat-util.js
@@ -2,35 +2,16 @@
 // modules
 
 import { assert } from '@agoric/assert';
-import { QCLASS } from '@endo/marshal';
+import { kser, kunser } from '../src/lib/kmarshal.js';
 
 export function extractMessage(vatDeliverObject) {
   const [type, ...vdoargs] = vatDeliverObject;
   assert.equal(type, 'message', `util.js .extractMessage got type ${type}`);
   const [facetID, msg] = vdoargs;
   const { methargs, result } = msg;
-  const methargsdata = JSON.parse(methargs.body);
-  const [method, argsdata] = methargsdata;
-  const args = { body: JSON.stringify(argsdata), slots: methargs.slots };
+  const [method, argsdata] = kunser(methargs);
+  const args = kser(argsdata);
   return { facetID, method, args, result };
-}
-
-export function capdata(body, slots = []) {
-  return harden({ body, slots });
-}
-
-function replacer(_, arg) {
-  if (typeof arg === 'bigint') {
-    return { [QCLASS]: 'bigint', digits: String(arg) };
-  }
-  if (arg === undefined) {
-    return { [QCLASS]: 'undefined' };
-  }
-  return arg;
-}
-
-export function capargs(args, slots = []) {
-  return capdata(JSON.stringify(args, replacer), slots);
 }
 
 export function ignore(p) {
@@ -39,3 +20,5 @@ export function ignore(p) {
     () => 0,
   );
 }
+
+export const vstr = v => JSON.stringify(kser(v));

--- a/packages/SwingSet/test/virtualObjects/collection-slots/test-collection-slots.js
+++ b/packages/SwingSet/test/virtualObjects/collection-slots/test-collection-slots.js
@@ -10,17 +10,14 @@ import {
   makeSwingsetController,
 } from '../../../src/index.js';
 
+import { kunser, krefOf } from '../../../src/lib/kmarshal.js';
+
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
 }
 
 function getImportSensorKref(impcapdata, i) {
-  const body = JSON.parse(impcapdata.body);
-  const value = body[i];
-  if (typeof value === 'object' && value['@qclass'] === 'slot') {
-    return ['slot', impcapdata.slots[value.index]];
-  }
-  return value;
+  return ['slot', krefOf(kunser(impcapdata)[i])];
 }
 
 test('collection entry slots trigger doMoreGC', async t => {
@@ -55,8 +52,8 @@ test('collection entry slots trigger doMoreGC', async t => {
     const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
-    const capdata = c.kpResolution(kpid);
-    return [status, capdata];
+    const result = c.kpResolution(kpid);
+    return [status, result];
   }
 
   function has(kref) {
@@ -68,9 +65,9 @@ test('collection entry slots trigger doMoreGC', async t => {
   // fetch the "importSensor": exported by bootstrap, imported by the
   // other vat. We'll determine its kref and later query the other vat
   // to see if it's still importing one or not
-  const [impstatus, impcapdata] = await run('getImportSensors', []);
+  const [impstatus, impresult] = await run('getImportSensors', []);
   t.is(impstatus, 'fulfilled');
-  const imp1kref = getImportSensorKref(impcapdata, 0)[1];
+  const imp1kref = getImportSensorKref(impresult, 0)[1];
 
   // at this point, vat-target has not yet seen the sensors
   t.is(has(imp1kref), undefined);

--- a/packages/SwingSet/test/virtualObjects/delete-stored-vo/test-delete-stored-vo.js
+++ b/packages/SwingSet/test/virtualObjects/delete-stored-vo/test-delete-stored-vo.js
@@ -9,18 +9,14 @@ import {
   initializeSwingset,
   makeSwingsetController,
 } from '../../../src/index.js';
+import { kunser, krefOf } from '../../../src/lib/kmarshal.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
 }
 
 function getImportSensorKref(impcapdata, i) {
-  const body = JSON.parse(impcapdata.body);
-  const value = body[i];
-  if (typeof value === 'object' && value['@qclass'] === 'slot') {
-    return ['slot', impcapdata.slots[value.index]];
-  }
-  return value;
+  return ['slot', krefOf(kunser(impcapdata)[i])];
 }
 
 test('VO property deletion is not short-circuited', async t => {
@@ -55,8 +51,8 @@ test('VO property deletion is not short-circuited', async t => {
     const kpid = c.queueToVatRoot('bootstrap', method, args);
     await c.run();
     const status = c.kpStatus(kpid);
-    const capdata = c.kpResolution(kpid);
-    return [status, capdata];
+    const result = c.kpResolution(kpid);
+    return [status, result];
   }
 
   function has(kref) {

--- a/packages/SwingSet/test/virtualObjects/test-weakcollections.js
+++ b/packages/SwingSet/test/virtualObjects/test-weakcollections.js
@@ -6,14 +6,7 @@ import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
 import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualSupport.js';
 import makeNextLog from '../make-nextlog.js';
-
-function capdata(body, slots = []) {
-  return harden({ body, slots });
-}
-
-function capargs(args, slots = []) {
-  return capdata(JSON.stringify(args), slots);
-}
+import { kser } from '../../src/lib/kmarshal.js';
 
 test('weakMap in vat', async t => {
   const config = {
@@ -40,7 +33,7 @@ test('weakMap in vat', async t => {
   const nextLog = makeNextLog(c);
 
   await c.run();
-  t.deepEqual(c.kpResolution(bootstrapResult), capargs('bootstrap done'));
+  t.deepEqual(c.kpResolution(bootstrapResult), kser('bootstrap done'));
 
   async function doSimple(method) {
     const r = c.queueToVatRoot('bootstrap', method, []);
@@ -50,7 +43,7 @@ test('weakMap in vat', async t => {
   }
 
   const preGCResult = await doSimple('runProbes');
-  t.deepEqual(preGCResult, capargs('probes done'));
+  t.deepEqual(preGCResult, kser('probes done'));
   t.deepEqual(nextLog(), [
     'probe of sample-object returns imported item #0',
     'probe of [object Promise] returns imported item #1',
@@ -64,7 +57,7 @@ test('weakMap in vat', async t => {
   await doSimple('betweenProbes');
   engineGC();
   const postGCResult = await doSimple('runProbes');
-  t.deepEqual(postGCResult, capargs('probes done'));
+  t.deepEqual(postGCResult, kser('probes done'));
   t.deepEqual(nextLog(), [
     'probe of sample-object returns imported item #0',
     'probe of [object Promise] returns undefined',

--- a/packages/SwingSet/test/virtualObjects/vdata-promises/test-vdata-promises.js
+++ b/packages/SwingSet/test/virtualObjects/vdata-promises/test-vdata-promises.js
@@ -8,7 +8,7 @@ import {
   initializeSwingset,
   makeSwingsetController,
 } from '../../../src/index.js';
-import { capargs } from '../../util.js';
+import { kunser } from '../../../src/lib/kmarshal.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
@@ -46,12 +46,9 @@ test('imported promises in vdata', async t => {
   t.is(c.kpStatus(kpid1), 'fulfilled');
   const res1 = c.kpResolution(kpid1);
   // console.log(res1); // [p1, p2, p3]
-  t.deepEqual(JSON.parse(res1.body), [
-    { '@qclass': 'slot', index: 0 },
-    { '@qclass': 'slot', index: 1 },
-    { '@qclass': 'slot', index: 2 },
-  ]);
-  const [p1kref, p2kref, p3kref] = res1.slots;
+  const res1Val = kunser(res1);
+  t.is(res1Val.length, 3);
+  const [p1kref, p2kref, p3kref] = res1Val;
 
   c.queueToVatRoot('bootstrap', 'doImportTest2', [], 'panic');
   await c.run();
@@ -60,7 +57,8 @@ test('imported promises in vdata', async t => {
   await c.run();
   t.is(c.kpStatus(kpid2), 'fulfilled');
   const res2 = c.kpResolution(kpid2);
-  t.deepEqual(res2, capargs([1, 2, 2, 3, 3]));
+  const res2Val = kunser(res2);
+  t.deepEqual(res2Val, [1, 2, 2, 3, 3]);
 
   // check clist for promise retirement
 
@@ -69,9 +67,9 @@ test('imported promises in vdata', async t => {
     // returns undefined, or { vatSlot, isReachable }
     return s && parseReachableAndVatSlot(s);
   }
-  t.falsy(has(p1kref));
-  t.falsy(has(p2kref));
-  t.falsy(has(p3kref));
+  t.falsy(has(`${p1kref}`));
+  t.falsy(has(`${p2kref}`));
+  t.falsy(has(`${p3kref}`));
 });
 
 test('result promises in vdata', async t => {
@@ -90,12 +88,9 @@ test('result promises in vdata', async t => {
   t.is(c.kpStatus(kpid1), 'fulfilled');
   const res1 = c.kpResolution(kpid1);
   // console.log(res1); // [p4, p5, p6]
-  t.deepEqual(JSON.parse(res1.body), [
-    { '@qclass': 'slot', index: 0 },
-    { '@qclass': 'slot', index: 1 },
-    { '@qclass': 'slot', index: 2 },
-  ]);
-  const [p4kref, p5kref, p6kref] = res1.slots;
+  const res1Val = kunser(res1);
+  t.is(res1Val.length, 3);
+  const [p4kref, p5kref, p6kref] = res1Val;
 
   c.queueToVatRoot('bootstrap', 'doResultTest2', [], 'panic');
   await c.run();
@@ -104,7 +99,8 @@ test('result promises in vdata', async t => {
   await c.run();
   t.is(c.kpStatus(kpid2), 'fulfilled');
   const res2 = c.kpResolution(kpid2);
-  t.deepEqual(res2, capargs([4, 5, 5, 6, 6]));
+  const res2Val = kunser(res2);
+  t.deepEqual(res2Val, [4, 5, 5, 6, 6]);
 
   // check clist for promise retirement
 
@@ -113,9 +109,9 @@ test('result promises in vdata', async t => {
     // returns undefined, or { vatSlot, isReachable }
     return s && parseReachableAndVatSlot(s);
   }
-  t.falsy(has(p4kref));
-  t.falsy(has(p5kref));
-  t.falsy(has(p6kref));
+  t.falsy(has(`${p4kref}`));
+  t.falsy(has(`${p5kref}`));
+  t.falsy(has(`${p6kref}`));
 });
 
 test('exported promises in vdata', async t => {
@@ -134,14 +130,15 @@ test('exported promises in vdata', async t => {
   t.is(c.kpStatus(kpid1), 'fulfilled');
   const res1 = c.kpResolution(kpid1);
   // console.log(res1); // { data, resolutions }
-  t.deepEqual(JSON.parse(res1.body).data.is, {
+  const res1Val = kunser(res1);
+  t.deepEqual(res1Val.data.is, {
     p7is: true,
     p8is: true,
     p9is: true,
     p10is: true,
     p14is: true,
   });
-  t.deepEqual(JSON.parse(res1.body).resolutions, {
+  t.deepEqual(res1Val.resolutions, {
     p9: 9,
     p10: 10,
     p11: 11,
@@ -158,12 +155,8 @@ test('exported promises in vdata', async t => {
 
   // all these promises should be resolved by now, and retired from
   // the clist
-  const promises = JSON.parse(res1.body).data.ret;
+  const promises = res1Val.data.ret;
   for (const pname of Object.keys(promises)) {
-    const obj = promises[pname];
-    t.is(obj['@qclass'], 'slot');
-    const slot = obj.index;
-    const kref = res1.slots[slot];
-    t.falsy(has(kref));
+    t.falsy(has(`${promises[pname]}`));
   }
 });

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -1,6 +1,7 @@
 import { test } from '../../tools/prepare-test-env-ava.js';
 
 import { loadBasedir, buildVatController } from '../../src/index.js';
+import { kunser } from '../../src/lib/kmarshal.js';
 
 function canBlock(managerType) {
   // nodeworker cannot block: the thread-to-thread port it uses provides a
@@ -41,7 +42,7 @@ test('local vat manager', async t => {
   await c.run();
   t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
   t.deepEqual(c.dump().log, ['testLog works']);
-  t.deepEqual(JSON.parse(c.kpResolution(c.bootstrapResult).body), expected);
+  t.deepEqual(kunser(c.kpResolution(c.bootstrapResult)), expected);
 });
 
 test('xs vat manager', async t => {
@@ -51,7 +52,7 @@ test('xs vat manager', async t => {
   await c.run();
   t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
   t.deepEqual(c.dump().log, ['testLog works']);
-  t.deepEqual(JSON.parse(c.kpResolution(c.bootstrapResult).body), expected);
+  t.deepEqual(kunser(c.kpResolution(c.bootstrapResult)), expected);
 });
 
 test.skip('nodeWorker vat manager', async t => {
@@ -61,7 +62,7 @@ test.skip('nodeWorker vat manager', async t => {
   await c.run();
   t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
   t.deepEqual(c.dump().log, ['testLog works']);
-  t.deepEqual(JSON.parse(c.kpResolution(c.bootstrapResult).body), expected);
+  t.deepEqual(kunser(c.kpResolution(c.bootstrapResult)), expected);
 });
 
 test.skip('node-subprocess vat manager', async t => {
@@ -71,5 +72,5 @@ test.skip('node-subprocess vat manager', async t => {
   await c.run();
   t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
   t.deepEqual(c.dump().log, ['testLog works']);
-  t.deepEqual(JSON.parse(c.kpResolution(c.bootstrapResult).body), expected);
+  t.deepEqual(kunser(c.kpResolution(c.bootstrapResult)), expected);
 });

--- a/packages/SwingSet/test/zcf-ish-upgrade/test-zcf-ish-upgrade.js
+++ b/packages/SwingSet/test/zcf-ish-upgrade/test-zcf-ish-upgrade.js
@@ -36,8 +36,8 @@ test('zcf-ish upgrade', async t => {
     const kpid = c.queueToVatRoot('bootstrap', name, args);
     await c.run();
     const status = c.kpStatus(kpid);
-    const capdata = c.kpResolution(kpid);
-    return [status, capdata];
+    const result = c.kpResolution(kpid);
+    return [status, result];
   };
 
   // create initial version

--- a/packages/SwingSet/tools/fakeVirtualSupport.js
+++ b/packages/SwingSet/tools/fakeVirtualSupport.js
@@ -203,7 +203,9 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     return val;
   }
 
-  const marshal = makeMarshal(convertValToSlot, convertSlotToVal);
+  const marshal = makeMarshal(convertValToSlot, convertSlotToVal, {
+    serializeBodyFormat: 'smallcaps',
+  });
 
   function registerEntry(baseRef, val, valIsCohort) {
     setValForSlot(baseRef, val);

--- a/packages/SwingSet/tools/vo-test-harness.js
+++ b/packages/SwingSet/tools/vo-test-harness.js
@@ -149,11 +149,11 @@ export async function runVOTest(t, prepare, makeTestObject, testTestObject) {
   );
 
   await dispatchMessage('makeAndHold');
-  await dispatchMessage('testHeld', ['before']);
+  await dispatchMessage('testHeld', 'before');
   await dispatchMessage('storeHeld');
   await dispatchMessage('dropHeld');
   await dispatchMessage('fetchAndHold');
-  await dispatchMessage('testHeld', ['after']);
+  await dispatchMessage('testHeld', 'after');
 }
 
 function bfile(name) {
@@ -163,6 +163,9 @@ function bfile(name) {
 const stupidM = makeMarshal(
   () => undefined,
   slot => `@${slot}`,
+  {
+    serializeBodyFormat: 'smallcaps',
+  },
 );
 const extractLog = capdata => stupidM.unserialize(capdata);
 

--- a/packages/swingset-runner/demo/vatFailure/vat-bad.js
+++ b/packages/swingset-runner/demo/vatFailure/vat-bad.js
@@ -1,17 +1,10 @@
 import { assert } from '@agoric/assert';
-
-function capdata(body, slots = []) {
-  return harden({ body, slots });
-}
-
-function capargs(args, slots = []) {
-  return capdata(JSON.stringify(args), slots);
-}
+import { kser } from '@agoric/swingset-vat/src/lib/kmarshal.js';
 
 export default function setup(syscall, _state, _helpers, _vatPowers) {
   function deliver(target, method, args) {
     const thing = method === 'begood' ? args.slots[0] : 'o-3414159';
-    syscall.send(thing, 'pretendToBeAThing', capargs([method]));
+    syscall.send(thing, 'pretendToBeAThing', kser([method]));
   }
   function dispatch(vatDeliveryObject) {
     const [type, ...args] = vatDeliveryObject;


### PR DESCRIPTION
These changes adapt SwingSet to use the new 'smallcaps' encoding format (instead of the prior 'capdata' format) for messages and stored data.

Prior to this PR, a large number of SwingSet tests would inspect and/or generate 'capdata' formatted messages and data fragments by directly constructing or examining their 'capdata' representations.  In addition, various places in the kernel would originate or transform messages by manually generating or manipulating 'capdata' formatted objects -- the kernel did not use `marshal` directly since the serializers and deserializers all closed over vat-specific reference mapping tables.  Nearly all of this has been replaced by a new kernel module `lib/kmarshal.js` that uses the actual `marshal` package to provide a set of serialization and unserialization tools that allow messages to be worked with without engaging with the details of the underlying encoding format.  (There does remain a small number of specialized bits of code which work with the underlying representation directly, mostly for purposes of validating the serialization machinery itself).  The net result of all of this is code (especially in the tests) that is considerably cleaner and simpler, that more clearly and directly expresses what it wants to do, and is significantly less brittle as well. The cost is that this PR has a very large number of individual code changes and touches a lot of files, so review will be tedious.

Note: This will not pass CI until https://github.com/endojs/endo/issues/1309 is addressed, which requires a change to Endo and/or XS. The requisite fix to Endo is https://github.com/endojs/endo/pull/1325 which is still pending release at the time this PR is being created.

Fixes #6326
