### PR TITLE
Patch bug in `stack-utils` npm package

### DIFF
--- a/patches/stack-utils+2.0.5.patch
+++ b/patches/stack-utils+2.0.5.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/stack-utils/index.js b/node_modules/stack-utils/index.js
+index ed14bd3..ad9eeb1 100644
+--- a/node_modules/stack-utils/index.js
++++ b/node_modules/stack-utils/index.js
+@@ -161,7 +161,7 @@ class StackUtils {
+     setFile(res, site.getFileName(), this._cwd);
+ 
+     if (site.isConstructor()) {
+-      res.constructor = true;
++      Object.defineProperty(res, 'constructor', { value: true });
+     }
+ 
+     if (site.isEval()) {
+@@ -260,7 +260,7 @@ class StackUtils {
+     setFile(res, file, this._cwd);
+ 
+     if (ctor) {
+-      res.constructor = true;
++      Object.defineProperty(res, 'constructor', { value: true });
+     }
+ 
+     if (evalOrigin) {


### PR DESCRIPTION
Lockdown breaks Ava under certain versions of NodeJS.  It turns out to be due to a bug in the `stack-utils` npm package which trips over the override mistake. I've filed an issue with the maintainer of that package, but in the meantime this patch deals with the problem.

It is unclear which version of Node starts manifesting the problem, but at least v16.16.0 has it.  The problem manifests as Ava test failures being reported unhelpfully -- whereas one should get a stack backtrace from the point in the test file where the failure happened, usually along with a nice diff between expected and actual result values from things like `t.deepEqual`, instead you get an "Unable to serialize error" exception with a stack trace from somewhere deep in the bowels of Ava.  The problem was the `stack-utils` npm package (which Ava uses) failing a property assignment to `Object.prototype` (which should have been a simple property assignment to an ordinary property of an ordinary object but wasn't because of the override mistake) in an environment where `Object.prototype` is frozen because of lockdown.

Without this patch (or, the eventual hoped for fix to the `stack-utils` npm package itself), debugging Ava test failures is grossly inhibited if you are using one of the newer versions of Node that manifest the problem.

See https://github.com/tapjs/stack-utils/issues/70
