### PR TITLE
chore: set default PSM fees to 0%

### DIFF
--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -49,8 +49,8 @@ export const startPSM = async (
   },
   {
     options: { anchorOptions = {} } = {},
-    WantMintedFeeBP = 1n,
-    GiveMintedFeeBP = 3n,
+    WantMintedFeeBP = 0n,
+    GiveMintedFeeBP = 0n,
     MINT_LIMIT = 1_000n * 1_000_000n,
   } = {},
 ) => {

--- a/packages/smart-wallet/test/test-psm-integration.js
+++ b/packages/smart-wallet/test/test-psm-integration.js
@@ -171,7 +171,7 @@ test('want stable', async t => {
   await offersFacet.executeOffer(offerSpec);
   await eventLoopIteration();
   t.is(purseBalance(computedState, anchor.brand), 0n);
-  t.is(purseBalance(computedState, stableBrand), swapSize - 1n);
+  t.is(purseBalance(computedState, stableBrand), swapSize); // assume 0% fee
 
   const currentState = await headValue(currentSub);
   t.like(currentState, { lastOfferId: 1 });


### PR DESCRIPTION
refs: inter xfn meeting yesterday

## Description

Default PSM fees are supposed to be 0 per @rowgraus , @btulloh , @dtribble 

### Security Considerations

none

### Documentation Considerations

@otoole-brendan I suppose this affects screenshots and such

### Testing Considerations

@arirubinstein noted that we have yet to test starting with this configuration.
