### PR TITLE
fix(vats): Toy USDC denom in test config

### DIFF
--- a/packages/vats/decentral-test-psm-config.json
+++ b/packages/vats/decentral-test-psm-config.json
@@ -11,7 +11,7 @@
             "keyword": "ToyUSD",
             "proposedName": "Toy USD",
             "decimalPlaces": 6,
-            "denom": "ibc/usdc1234"
+            "denom": "ibc/toyusdc"
           }
         ],
         "economicCommitteeAddresses": {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: 6284

## Description

emerynet has `ibc/toyusdc` , not `ibc/usdc1234`

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

 - add other denoms while we're at it? (no)
 - add `ibc/toyusdc` to faucet

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
