### PR TITLE
fix: better proposal mismatch errors

### DIFF
--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -624,7 +624,7 @@ test('wrong give giveMintedInvitation', async t => {
       ),
     {
       message:
-        'proposal: required-parts: give: In: brand: "[Alleged: aUSD brand]" - Must be: "[Alleged: IST brand]"',
+        '"giveMinted" proposal: required-parts: give: In: brand: "[Alleged: aUSD brand]" - Must be: "[Alleged: IST brand]"',
     },
   );
 });
@@ -654,7 +654,7 @@ test('wrong give wantMintedInvitation', async t => {
       ),
     {
       message:
-        'proposal: required-parts: give: In: brand: "[Alleged: IST brand]" - Must be: "[Alleged: aUSD brand]"',
+        '"wantMinted" proposal: required-parts: give: In: brand: "[Alleged: IST brand]" - Must be: "[Alleged: aUSD brand]"',
     },
   );
 });
@@ -676,7 +676,7 @@ test('extra give wantMintedInvitation', async t => {
       ),
     {
       message:
-        'proposal: required-parts: give: {"Extra":{"brand":"[Alleged: aUSD brand]","value":"[200000000n]"},"In":{"brand":"[Seen]","value":"[200000000n]"}} - Must not have unexpected properties: ["Extra"]',
+        '"wantMinted" proposal: required-parts: give: {"Extra":{"brand":"[Alleged: aUSD brand]","value":"[200000000n]"},"In":{"brand":"[Seen]","value":"[200000000n]"}} - Must not have unexpected properties: ["Extra"]',
     },
   );
 });

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -55,7 +55,7 @@ export const makeOfferMethod = (
     const proposal = cleanProposal(uncleanProposal, getAssetKindByBrand);
     const proposalShape = getProposalShapeForInvitation(invitationHandle);
     if (proposalShape !== undefined) {
-      fit(proposal, proposalShape, 'proposal');
+      fit(proposal, proposalShape, `${q(description)} proposal`);
     }
 
     if (offerArgs !== undefined) {


### PR DESCRIPTION
Use the description string in the proposal mismatch error, to tell which invitation was involved.