### PR TITLE
fix: simplify unnecessary promise

### DIFF
--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -180,7 +180,7 @@ export const setupAmm = async (
 
   const ammTerms = makeAmmTerms(
     chainTimerService,
-    E(E(zoe).getInvitationIssuer()).getAmountOf(poserInvitationP),
+    E(E(zoe).getInvitationIssuer()).getAmountOf(poserInvitation),
     AmountMath.make(runBrand, minInitialPoolLiquidity),
   );
 


### PR DESCRIPTION
We already happen to have the resolved reference due to an earlier `await` so may as well use that.

Noticed while working on https://github.com/Agoric/agoric-sdk/pull/6475