### PR TITLE
omit superfluous 'SEVERED: ' from wallet spend proposal

### DIFF
--- a/packages/wallet/ui/src/components/SmartWalletConnection.jsx
+++ b/packages/wallet/ui/src/components/SmartWalletConnection.jsx
@@ -2,6 +2,7 @@ import { makeFollower, makeLeader } from '@agoric/casting';
 import { observeIterator } from '@agoric/notifier';
 import { NO_SMART_WALLET_ERROR } from '@agoric/smart-wallet/src/utils';
 import { makeImportContext } from '@agoric/wallet/api/src/marshal-contexts';
+import { Far } from '@endo/marshal';
 import MuiAlert from '@mui/material/Alert';
 import Snackbar from '@mui/material/Snackbar';
 import React, { useEffect, useState, useMemo } from 'react';
@@ -23,6 +24,14 @@ const Alert = React.forwardRef(function Alert({ children, ...props }, ref) {
     </MuiAlert>
   );
 });
+
+/**
+ * Wallet UI doesn't use objects as presences, only as identities.
+ * Use this to override the defaultMakePresence of makeImportContext.
+ *
+ * @param {string} iface
+ */
+const inertPresence = iface => Far(iface.replace(/^Alleged: /, ''), {});
 
 const SmartWalletConnection = ({
   connectionConfig,
@@ -77,7 +86,7 @@ const SmartWalletConnection = ({
   };
 
   const [context, leader] = useMemo(
-    () => [makeImportContext(), makeLeader(href)],
+    () => [makeImportContext(inertPresence), makeLeader(href)],
     [connectionConfig, keplrConnection],
   );
 

--- a/packages/wallet/ui/src/contexts/Provider.jsx
+++ b/packages/wallet/ui/src/contexts/Provider.jsx
@@ -19,6 +19,13 @@ import {
 } from '../util/keyManagement';
 import { onLoadP } from '../util/onLoad';
 
+/**
+ * @typedef KeplrUtils
+ * @property {string} address
+ * @property {{ interactiveSigner: import('../util/keyManagement').InteractiveSigner, backgroundSigner: import('../util/keyManagement').BackgroundSigner}} signers
+ * @property {string} chainId,
+ */
+
 const useDebugLogging = (state, watch) => {
   useEffect(() => console.debug('useDebugLogging', { state }), watch);
 };

--- a/packages/wallet/ui/src/service/Offers.js
+++ b/packages/wallet/ui/src/service/Offers.js
@@ -33,6 +33,7 @@ export const getOfferService = (
   chainOffersNotifier,
   boardIdMarshaller,
 ) => {
+  /** @type {Map<number, Offer>} */
   const offers = new Map();
   const { notifier, updater } = makeNotifierKit();
   const broadcastUpdates = () => updater.updateState([...offers.values()]);
@@ -106,16 +107,17 @@ export const getOfferService = (
     broadcastUpdates();
   };
 
-  const declineOffer = (/** @type {string} */ id) => {
+  const declineOffer = (/** @type {number} */ id) => {
     const offer = offers.get(id);
     assert(offer, `Tried to decline undefined offer ${id}`);
     upsertOffer({ ...offer, status: OfferUIStatus.declined });
     broadcastUpdates();
   };
 
-  const acceptOffer = async (/** @type {string} */ id) => {
+  const acceptOffer = async (/** @type {number} */ id) => {
     const offer = offers.get(id);
     assert(offer, `Tried to accept undefined offer ${id}`);
+    assert(offer.spendAction, 'Missing spendAction');
     return signSpendAction(offer.spendAction);
   };
 
@@ -137,6 +139,7 @@ export const getOfferService = (
             ...oldOffer,
             id: status.id,
             status: OfferUIStatus.rejected,
+            // @ts-expect-error xxx types debt
             error: `${status.error}`,
           });
           remove(smartWalletKey, status.id);

--- a/packages/wallet/ui/src/util/WalletBackendAdapter.js
+++ b/packages/wallet/ui/src/util/WalletBackendAdapter.js
@@ -110,7 +110,7 @@ export const makeBackendFromWalletBridge = (
  * @param {ReturnType<import('@endo/marshal').makeMarshal>} marshaller
  * @param {import('@agoric/casting').ValueFollower<import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord>} currentFollower
  * @param {import('@agoric/casting').ValueFollower<import('@agoric/smart-wallet/src/smartWallet').UpdateRecord>} updateFollower
- * @param {object} keplrConnection
+ * @param {import('../contexts/Provider.jsx').KeplrUtils} keplrConnection
  * @param {(e: unknown) => void} [errorHandler]
  * @param {() => void} [firstCallback]
  */
@@ -169,6 +169,7 @@ export const makeWalletBridgeFromFollowers = (
     notifierKits.purses.updater.updateState(harden(purses));
   };
 
+  /** @param {string} data */
   const signSpendAction = async data => {
     const {
       signers: { interactiveSigner },

--- a/packages/wallet/ui/src/util/keyManagement.js
+++ b/packages/wallet/ui/src/util/keyManagement.js
@@ -272,7 +272,7 @@ export const makeBackgroundSigner = async ({ localStorage, csprng }) => {
     queryGrants,
   });
 };
-
+/** @typedef {Awaited<ReturnType<typeof makeBackgroundSigner>>} BackgroundSigner */
 /**
  * @param {string} granter bech32 address
  * @param {string} grantee bech32 address
@@ -520,3 +520,4 @@ export const makeInteractiveSigner = async (
     },
   });
 };
+/** @typedef {Awaited<ReturnType<typeof makeInteractiveSigner>>} InteractiveSigner */


### PR DESCRIPTION
## Description

The SEVERED warning pertains to presences but we're sending the offer marshalled so it's distracting to the user. This removes it when the offer is being sent.


### Security Considerations

It doesn't remove it any earlier because there are no guarantees that other consumers would expect it to be a valid presence.

### Documentation Considerations

The code comment suffices because the distinction is relevant to Wallet UI users.

### Testing Considerations

Manually tested.