### PR TITLE
fix(telemetry): fix otel-slog converter

### DIFF
--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -83,6 +83,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
   let currentAttrs = {};
 
   let isReplaying = false;
+  let currentBlockHeight = -1;
 
   const cleanAttrs = attrs => ({
     ...serializeInto(attrs, 'agoric'),
@@ -379,13 +380,13 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
   let finished = false;
   const finish = () => {
     finished = true;
-    spans.endAll(now);
     let top = spans.top();
     while (top) {
       top.end(now);
       spans.pop();
       top = spans.top();
     }
+    spans.endAll(now);
   };
 
   const getCrankKey = create => {
@@ -414,11 +415,14 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
     // console.log('slogging', obj);
     switch (slogType) {
       case 'kernel-init-start': {
+        assert(!spans.top());
+        dbTransactionManager.begin();
         spans.push('init');
         break;
       }
       case 'kernel-init-finish': {
         spans.pop('init');
+        dbTransactionManager.end();
         break;
       }
       case 'bundle-kernel-start': {
@@ -813,12 +817,16 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         break;
       }
       case 'cosmic-swingset-begin-block': {
-        dbTransactionManager.begin();
         if (spans.topKind() === 'intra-block') {
           spans.pop('intra-block');
           spans.pop('block');
         }
+        if (currentBlockHeight > 0) {
+          dbTransactionManager.end();
+        }
         assert(!spans.top());
+        dbTransactionManager.begin();
+        currentBlockHeight = slogAttrs.blockHeight;
 
         // TODO: Move the encompassing `block` root span to cosmos
         spans.push(['block', slogAttrs.blockHeight]);
@@ -837,8 +845,12 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
       }
       case 'cosmic-swingset-after-commit-block': {
         // Add the event to whatever the current top span is (most likely intra-block)
+        // TODO: add as a span of the block
         spans.top()?.addEvent('after-commit', cleanAttrs(slogAttrs), now);
-        dbTransactionManager.end();
+        if (currentBlockHeight === slogAttrs.blockHeight) {
+          dbTransactionManager.end();
+          currentBlockHeight = -1;
+        }
         break;
       }
       case 'cosmic-swingset-deliver-inbound': {


### PR DESCRIPTION
closes: #XXXX
closes: #6469

## Description

This PR fixes some otel converter processing issues which prevented it from making new spans once some edge cases were encountered. It also include more robust logic to hard reset the expected state of the otel tracing at block boundaries, to limit the blast radius of similar issues in the future.

This fixes an issue discovered when trying to get otel telemetry from the mainnet archival node, the previously reported #6469, and a DB transaction issue discovered locally when working on other telemetry improvements.

### Security Considerations

None

### Testing Considerations

Tested locally on the mainnet slog, and slog from #6469. I will double check the integration output as well.