### PR TITLE
fix: include swingset/* file for export

### DIFF
--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -37,7 +37,8 @@
   },
   "files": [
     "build",
-    "LICENSE*"
+    "LICENSE*",
+    "swingset/*"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Description

The files in `exports` weren't all included in the published package. In particular, https://github.com/Agoric/agoric-sdk/blob/6bfb278a695963e96f0bf1d37f3181a91286b065/packages/cosmic-proto/package.json#L18-L19

This puts them in `files` to be available.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

I ran into this problem when importing `@agoric/cosmic-proto` in another repo. I confirmed this fixes it by using `yarn link`.