### PR TITLE
fix: cosmic-proto exports

### DIFF
--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -15,8 +15,8 @@
   },
   "type": "module",
   "exports": {
-    "./swingset/msgs.js": "./swingset/msgs.js",
-    "./swingset/msgs.ts": "./swingset/msgs.ts",
+    "./swingset/msgs.js": "./gen/agoric/swingset/msgs.js",
+    "./swingset/msgs.ts": "./gen/agoric/swingset/msgs.ts",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -38,7 +38,8 @@
   "files": [
     "build",
     "LICENSE*",
-    "swingset/*"
+    "swingset",
+    "gen"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Description

https://www.npmjs.com/package/@agoric/cosmic-proto doesn’t have any code. I thought https://github.com/Agoric/agoric-sdk/pull/6510 would solve that, but [a build of agoric-sdk with it ](https://www.npmjs.com/package/@agoric/cosmic-proto/v/0.2.2-dev-0534694.0) still doesn’t have them. 

I tried removing the `swingset/*` symlinks but it broke consumers that don't understand package.json `exports`.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

CI. I see this is covered (transitively) by `test-publish-bundle.js`.