### PR TITLE
test: fix start-local-chain-boot script

### DIFF
--- a/packages/inter-protocol/scripts/start-local-chain-boot.js
+++ b/packages/inter-protocol/scripts/start-local-chain-boot.js
@@ -54,13 +54,7 @@ export const buildRootObject = (vatPowers, vatParameters) => {
 
   const { demoOracleAddresses } = vatParameters;
 
-  // const { spaces } = makeAgoricNamesAccess(log, agoricNamesReserved);
-
   const runBootstrapParts = async (vats, devices) => {
-    await psmRootObject.bootstrap(vats, devices);
-
-    /** TODO: BootstrapPowers type puzzle */
-    /** @type { any } */
     const allPowers = harden({
       vatPowers,
       vatParameters,


### PR DESCRIPTION
## Description

In the last revisions of https://github.com/Agoric/agoric-sdk/pull/6499/ there was a redundant bootstrap call which didn't get detected before merge. (It shows up after some other apparent success.)

This fixes `start-local-chain-boot.js` so that it only calls `psmRootObject.bootstrap(vats, devices)` once (within the Promise.all).

### Security Considerations

--
### Documentation Considerations

--

### Testing Considerations

It might be worth putting this into a CI job. I don't think so given that developers can usually fix what they encounter and if they're not encountering it it's not so much a problem.