### PR TITLE
feat(cosmic-proto): query swingset params etc.

### DIFF
--- a/packages/cosmic-proto/gen/agoric/swingset/query.js
+++ b/packages/cosmic-proto/gen/agoric/swingset/query.js
@@ -1,0 +1,336 @@
+/* eslint-disable */
+import { Params, Egress } from './swingset.js';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal.js';
+export const protobufPackage = 'agoric.swingset';
+function createBaseQueryParamsRequest() {
+  return {};
+}
+export const QueryParamsRequest = {
+  encode(_, writer = _m0.Writer.create()) {
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryParamsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(_) {
+    return {};
+  },
+  toJSON(_) {
+    const obj = {};
+    return obj;
+  },
+  fromPartial(_) {
+    const message = createBaseQueryParamsRequest();
+    return message;
+  },
+};
+function createBaseQueryParamsResponse() {
+  return { params: undefined };
+}
+export const QueryParamsResponse = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.params !== undefined) {
+      Params.encode(message.params, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryParamsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.params = Params.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      params: isSet(object.params) ? Params.fromJSON(object.params) : undefined,
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.params !== undefined &&
+      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryParamsResponse();
+    message.params =
+      object.params !== undefined && object.params !== null
+        ? Params.fromPartial(object.params)
+        : undefined;
+    return message;
+  },
+};
+function createBaseQueryEgressRequest() {
+  return { peer: new Uint8Array() };
+}
+export const QueryEgressRequest = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.peer.length !== 0) {
+      writer.uint32(10).bytes(message.peer);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryEgressRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.peer = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      peer: isSet(object.peer)
+        ? bytesFromBase64(object.peer)
+        : new Uint8Array(),
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.peer !== undefined &&
+      (obj.peer = base64FromBytes(
+        message.peer !== undefined ? message.peer : new Uint8Array(),
+      ));
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryEgressRequest();
+    message.peer = object.peer ?? new Uint8Array();
+    return message;
+  },
+};
+function createBaseQueryEgressResponse() {
+  return { egress: undefined };
+}
+export const QueryEgressResponse = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.egress !== undefined) {
+      Egress.encode(message.egress, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryEgressResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.egress = Egress.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      egress: isSet(object.egress) ? Egress.fromJSON(object.egress) : undefined,
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.egress !== undefined &&
+      (obj.egress = message.egress ? Egress.toJSON(message.egress) : undefined);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryEgressResponse();
+    message.egress =
+      object.egress !== undefined && object.egress !== null
+        ? Egress.fromPartial(object.egress)
+        : undefined;
+    return message;
+  },
+};
+function createBaseQueryMailboxRequest() {
+  return { peer: new Uint8Array() };
+}
+export const QueryMailboxRequest = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.peer.length !== 0) {
+      writer.uint32(10).bytes(message.peer);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryMailboxRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.peer = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      peer: isSet(object.peer)
+        ? bytesFromBase64(object.peer)
+        : new Uint8Array(),
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.peer !== undefined &&
+      (obj.peer = base64FromBytes(
+        message.peer !== undefined ? message.peer : new Uint8Array(),
+      ));
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryMailboxRequest();
+    message.peer = object.peer ?? new Uint8Array();
+    return message;
+  },
+};
+function createBaseQueryMailboxResponse() {
+  return { value: '' };
+}
+export const QueryMailboxResponse = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.value !== '') {
+      writer.uint32(10).string(message.value);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryMailboxResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.value = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.value !== undefined && (obj.value = message.value);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryMailboxResponse();
+    message.value = object.value ?? '';
+    return message;
+  },
+};
+export class QueryClientImpl {
+  rpc;
+  constructor(rpc) {
+    this.rpc = rpc;
+    this.Params = this.Params.bind(this);
+    this.Egress = this.Egress.bind(this);
+    this.Mailbox = this.Mailbox.bind(this);
+  }
+  Params(request) {
+    const data = QueryParamsRequest.encode(request).finish();
+    const promise = this.rpc.request('agoric.swingset.Query', 'Params', data);
+    return promise.then((data) =>
+      QueryParamsResponse.decode(new _m0.Reader(data)),
+    );
+  }
+  Egress(request) {
+    const data = QueryEgressRequest.encode(request).finish();
+    const promise = this.rpc.request('agoric.swingset.Query', 'Egress', data);
+    return promise.then((data) =>
+      QueryEgressResponse.decode(new _m0.Reader(data)),
+    );
+  }
+  Mailbox(request) {
+    const data = QueryMailboxRequest.encode(request).finish();
+    const promise = this.rpc.request('agoric.swingset.Query', 'Mailbox', data);
+    return promise.then((data) =>
+      QueryMailboxResponse.decode(new _m0.Reader(data)),
+    );
+  }
+}
+var globalThis = (() => {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
+})();
+const atob =
+  globalThis.atob ||
+  ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
+function bytesFromBase64(b64) {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+const btoa =
+  globalThis.btoa ||
+  ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
+function base64FromBytes(arr) {
+  const bin = [];
+  arr.forEach((byte) => {
+    bin.push(String.fromCharCode(byte));
+  });
+  return btoa(bin.join(''));
+}
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long;
+  _m0.configure();
+}
+function isSet(value) {
+  return value !== null && value !== undefined;
+}

--- a/packages/cosmic-proto/gen/agoric/swingset/query.ts
+++ b/packages/cosmic-proto/gen/agoric/swingset/query.ts
@@ -1,0 +1,493 @@
+/* eslint-disable */
+import { Params, Egress } from './swingset.js';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal.js';
+
+export const protobufPackage = 'agoric.swingset';
+
+/** QueryParamsRequest is the request type for the Query/Params RPC method. */
+export interface QueryParamsRequest {}
+
+/** QueryParamsResponse is the response type for the Query/Params RPC method. */
+export interface QueryParamsResponse {
+  /** params defines the parameters of the module. */
+  params?: Params;
+}
+
+/** QueryEgressRequest is the request type for the Query/Egress RPC method */
+export interface QueryEgressRequest {
+  peer: Uint8Array;
+}
+
+/** QueryEgressResponse is the egress response. */
+export interface QueryEgressResponse {
+  egress?: Egress;
+}
+
+/** QueryMailboxRequest is the mailbox query. */
+export interface QueryMailboxRequest {
+  peer: Uint8Array;
+}
+
+/** QueryMailboxResponse is the mailbox response. */
+export interface QueryMailboxResponse {
+  value: string;
+}
+
+function createBaseQueryParamsRequest(): QueryParamsRequest {
+  return {};
+}
+
+export const QueryParamsRequest = {
+  encode(
+    _: QueryParamsRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryParamsRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryParamsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): QueryParamsRequest {
+    return {};
+  },
+
+  toJSON(_: QueryParamsRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryParamsRequest>, I>>(
+    _: I,
+  ): QueryParamsRequest {
+    const message = createBaseQueryParamsRequest();
+    return message;
+  },
+};
+
+function createBaseQueryParamsResponse(): QueryParamsResponse {
+  return { params: undefined };
+}
+
+export const QueryParamsResponse = {
+  encode(
+    message: QueryParamsResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.params !== undefined) {
+      Params.encode(message.params, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryParamsResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryParamsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.params = Params.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryParamsResponse {
+    return {
+      params: isSet(object.params) ? Params.fromJSON(object.params) : undefined,
+    };
+  },
+
+  toJSON(message: QueryParamsResponse): unknown {
+    const obj: any = {};
+    message.params !== undefined &&
+      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryParamsResponse>, I>>(
+    object: I,
+  ): QueryParamsResponse {
+    const message = createBaseQueryParamsResponse();
+    message.params =
+      object.params !== undefined && object.params !== null
+        ? Params.fromPartial(object.params)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseQueryEgressRequest(): QueryEgressRequest {
+  return { peer: new Uint8Array() };
+}
+
+export const QueryEgressRequest = {
+  encode(
+    message: QueryEgressRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.peer.length !== 0) {
+      writer.uint32(10).bytes(message.peer);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryEgressRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryEgressRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.peer = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryEgressRequest {
+    return {
+      peer: isSet(object.peer)
+        ? bytesFromBase64(object.peer)
+        : new Uint8Array(),
+    };
+  },
+
+  toJSON(message: QueryEgressRequest): unknown {
+    const obj: any = {};
+    message.peer !== undefined &&
+      (obj.peer = base64FromBytes(
+        message.peer !== undefined ? message.peer : new Uint8Array(),
+      ));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryEgressRequest>, I>>(
+    object: I,
+  ): QueryEgressRequest {
+    const message = createBaseQueryEgressRequest();
+    message.peer = object.peer ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseQueryEgressResponse(): QueryEgressResponse {
+  return { egress: undefined };
+}
+
+export const QueryEgressResponse = {
+  encode(
+    message: QueryEgressResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.egress !== undefined) {
+      Egress.encode(message.egress, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryEgressResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryEgressResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.egress = Egress.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryEgressResponse {
+    return {
+      egress: isSet(object.egress) ? Egress.fromJSON(object.egress) : undefined,
+    };
+  },
+
+  toJSON(message: QueryEgressResponse): unknown {
+    const obj: any = {};
+    message.egress !== undefined &&
+      (obj.egress = message.egress ? Egress.toJSON(message.egress) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryEgressResponse>, I>>(
+    object: I,
+  ): QueryEgressResponse {
+    const message = createBaseQueryEgressResponse();
+    message.egress =
+      object.egress !== undefined && object.egress !== null
+        ? Egress.fromPartial(object.egress)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseQueryMailboxRequest(): QueryMailboxRequest {
+  return { peer: new Uint8Array() };
+}
+
+export const QueryMailboxRequest = {
+  encode(
+    message: QueryMailboxRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.peer.length !== 0) {
+      writer.uint32(10).bytes(message.peer);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryMailboxRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryMailboxRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.peer = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryMailboxRequest {
+    return {
+      peer: isSet(object.peer)
+        ? bytesFromBase64(object.peer)
+        : new Uint8Array(),
+    };
+  },
+
+  toJSON(message: QueryMailboxRequest): unknown {
+    const obj: any = {};
+    message.peer !== undefined &&
+      (obj.peer = base64FromBytes(
+        message.peer !== undefined ? message.peer : new Uint8Array(),
+      ));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryMailboxRequest>, I>>(
+    object: I,
+  ): QueryMailboxRequest {
+    const message = createBaseQueryMailboxRequest();
+    message.peer = object.peer ?? new Uint8Array();
+    return message;
+  },
+};
+
+function createBaseQueryMailboxResponse(): QueryMailboxResponse {
+  return { value: '' };
+}
+
+export const QueryMailboxResponse = {
+  encode(
+    message: QueryMailboxResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.value !== '') {
+      writer.uint32(10).string(message.value);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryMailboxResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryMailboxResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.value = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryMailboxResponse {
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
+  },
+
+  toJSON(message: QueryMailboxResponse): unknown {
+    const obj: any = {};
+    message.value !== undefined && (obj.value = message.value);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryMailboxResponse>, I>>(
+    object: I,
+  ): QueryMailboxResponse {
+    const message = createBaseQueryMailboxResponse();
+    message.value = object.value ?? '';
+    return message;
+  },
+};
+
+/** Query provides defines the gRPC querier service */
+export interface Query {
+  /** Params queries params of the swingset module. */
+  Params(request: QueryParamsRequest): Promise<QueryParamsResponse>;
+  /** Egress queries a provisioned egress. */
+  Egress(request: QueryEgressRequest): Promise<QueryEgressResponse>;
+  /** Return the contents of a peer's outbound mailbox. */
+  Mailbox(request: QueryMailboxRequest): Promise<QueryMailboxResponse>;
+}
+
+export class QueryClientImpl implements Query {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.Params = this.Params.bind(this);
+    this.Egress = this.Egress.bind(this);
+    this.Mailbox = this.Mailbox.bind(this);
+  }
+  Params(request: QueryParamsRequest): Promise<QueryParamsResponse> {
+    const data = QueryParamsRequest.encode(request).finish();
+    const promise = this.rpc.request('agoric.swingset.Query', 'Params', data);
+    return promise.then((data) =>
+      QueryParamsResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  Egress(request: QueryEgressRequest): Promise<QueryEgressResponse> {
+    const data = QueryEgressRequest.encode(request).finish();
+    const promise = this.rpc.request('agoric.swingset.Query', 'Egress', data);
+    return promise.then((data) =>
+      QueryEgressResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  Mailbox(request: QueryMailboxRequest): Promise<QueryMailboxResponse> {
+    const data = QueryMailboxRequest.encode(request).finish();
+    const promise = this.rpc.request('agoric.swingset.Query', 'Mailbox', data);
+    return promise.then((data) =>
+      QueryMailboxResponse.decode(new _m0.Reader(data)),
+    );
+  }
+}
+
+interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array,
+  ): Promise<Uint8Array>;
+}
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var globalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
+})();
+
+const atob: (b64: string) => string =
+  globalThis.atob ||
+  ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
+function bytesFromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+
+const btoa: (bin: string) => string =
+  globalThis.btoa ||
+  ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
+function base64FromBytes(arr: Uint8Array): string {
+  const bin: string[] = [];
+  arr.forEach((byte) => {
+    bin.push(String.fromCharCode(byte));
+  });
+  return btoa(bin.join(''));
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P>>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/cosmic-proto/gen/agoric/swingset/swingset.js
+++ b/packages/cosmic-proto/gen/agoric/swingset/swingset.js
@@ -1,0 +1,577 @@
+/* eslint-disable */
+import Long from 'long';
+import { Coin } from '../../cosmos/base/v1beta1/coin.js';
+import _m0 from 'protobufjs/minimal.js';
+export const protobufPackage = 'agoric.swingset';
+function createBaseCoreEvalProposal() {
+  return { title: '', description: '', evals: [] };
+}
+export const CoreEvalProposal = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.title !== '') {
+      writer.uint32(10).string(message.title);
+    }
+    if (message.description !== '') {
+      writer.uint32(18).string(message.description);
+    }
+    for (const v of message.evals) {
+      CoreEval.encode(v, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCoreEvalProposal();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.title = reader.string();
+          break;
+        case 2:
+          message.description = reader.string();
+          break;
+        case 3:
+          message.evals.push(CoreEval.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      title: isSet(object.title) ? String(object.title) : '',
+      description: isSet(object.description) ? String(object.description) : '',
+      evals: Array.isArray(object?.evals)
+        ? object.evals.map((e) => CoreEval.fromJSON(e))
+        : [],
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.title !== undefined && (obj.title = message.title);
+    message.description !== undefined &&
+      (obj.description = message.description);
+    if (message.evals) {
+      obj.evals = message.evals.map((e) =>
+        e ? CoreEval.toJSON(e) : undefined,
+      );
+    } else {
+      obj.evals = [];
+    }
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseCoreEvalProposal();
+    message.title = object.title ?? '';
+    message.description = object.description ?? '';
+    message.evals = object.evals?.map((e) => CoreEval.fromPartial(e)) || [];
+    return message;
+  },
+};
+function createBaseCoreEval() {
+  return { jsonPermits: '', jsCode: '' };
+}
+export const CoreEval = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.jsonPermits !== '') {
+      writer.uint32(10).string(message.jsonPermits);
+    }
+    if (message.jsCode !== '') {
+      writer.uint32(18).string(message.jsCode);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCoreEval();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.jsonPermits = reader.string();
+          break;
+        case 2:
+          message.jsCode = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      jsonPermits: isSet(object.jsonPermits) ? String(object.jsonPermits) : '',
+      jsCode: isSet(object.jsCode) ? String(object.jsCode) : '',
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.jsonPermits !== undefined &&
+      (obj.jsonPermits = message.jsonPermits);
+    message.jsCode !== undefined && (obj.jsCode = message.jsCode);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseCoreEval();
+    message.jsonPermits = object.jsonPermits ?? '';
+    message.jsCode = object.jsCode ?? '';
+    return message;
+  },
+};
+function createBaseParams() {
+  return {
+    beansPerUnit: [],
+    feeUnitPrice: [],
+    bootstrapVatConfig: '',
+    powerFlagFees: [],
+    queueMax: [],
+  };
+}
+export const Params = {
+  encode(message, writer = _m0.Writer.create()) {
+    for (const v of message.beansPerUnit) {
+      StringBeans.encode(v, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.feeUnitPrice) {
+      Coin.encode(v, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.bootstrapVatConfig !== '') {
+      writer.uint32(26).string(message.bootstrapVatConfig);
+    }
+    for (const v of message.powerFlagFees) {
+      PowerFlagFee.encode(v, writer.uint32(34).fork()).ldelim();
+    }
+    for (const v of message.queueMax) {
+      QueueSize.encode(v, writer.uint32(42).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseParams();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.beansPerUnit.push(
+            StringBeans.decode(reader, reader.uint32()),
+          );
+          break;
+        case 2:
+          message.feeUnitPrice.push(Coin.decode(reader, reader.uint32()));
+          break;
+        case 3:
+          message.bootstrapVatConfig = reader.string();
+          break;
+        case 4:
+          message.powerFlagFees.push(
+            PowerFlagFee.decode(reader, reader.uint32()),
+          );
+          break;
+        case 5:
+          message.queueMax.push(QueueSize.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      beansPerUnit: Array.isArray(object?.beansPerUnit)
+        ? object.beansPerUnit.map((e) => StringBeans.fromJSON(e))
+        : [],
+      feeUnitPrice: Array.isArray(object?.feeUnitPrice)
+        ? object.feeUnitPrice.map((e) => Coin.fromJSON(e))
+        : [],
+      bootstrapVatConfig: isSet(object.bootstrapVatConfig)
+        ? String(object.bootstrapVatConfig)
+        : '',
+      powerFlagFees: Array.isArray(object?.powerFlagFees)
+        ? object.powerFlagFees.map((e) => PowerFlagFee.fromJSON(e))
+        : [],
+      queueMax: Array.isArray(object?.queueMax)
+        ? object.queueMax.map((e) => QueueSize.fromJSON(e))
+        : [],
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    if (message.beansPerUnit) {
+      obj.beansPerUnit = message.beansPerUnit.map((e) =>
+        e ? StringBeans.toJSON(e) : undefined,
+      );
+    } else {
+      obj.beansPerUnit = [];
+    }
+    if (message.feeUnitPrice) {
+      obj.feeUnitPrice = message.feeUnitPrice.map((e) =>
+        e ? Coin.toJSON(e) : undefined,
+      );
+    } else {
+      obj.feeUnitPrice = [];
+    }
+    message.bootstrapVatConfig !== undefined &&
+      (obj.bootstrapVatConfig = message.bootstrapVatConfig);
+    if (message.powerFlagFees) {
+      obj.powerFlagFees = message.powerFlagFees.map((e) =>
+        e ? PowerFlagFee.toJSON(e) : undefined,
+      );
+    } else {
+      obj.powerFlagFees = [];
+    }
+    if (message.queueMax) {
+      obj.queueMax = message.queueMax.map((e) =>
+        e ? QueueSize.toJSON(e) : undefined,
+      );
+    } else {
+      obj.queueMax = [];
+    }
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseParams();
+    message.beansPerUnit =
+      object.beansPerUnit?.map((e) => StringBeans.fromPartial(e)) || [];
+    message.feeUnitPrice =
+      object.feeUnitPrice?.map((e) => Coin.fromPartial(e)) || [];
+    message.bootstrapVatConfig = object.bootstrapVatConfig ?? '';
+    message.powerFlagFees =
+      object.powerFlagFees?.map((e) => PowerFlagFee.fromPartial(e)) || [];
+    message.queueMax =
+      object.queueMax?.map((e) => QueueSize.fromPartial(e)) || [];
+    return message;
+  },
+};
+function createBaseState() {
+  return { queueAllowed: [] };
+}
+export const State = {
+  encode(message, writer = _m0.Writer.create()) {
+    for (const v of message.queueAllowed) {
+      QueueSize.encode(v, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseState();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.queueAllowed.push(QueueSize.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      queueAllowed: Array.isArray(object?.queueAllowed)
+        ? object.queueAllowed.map((e) => QueueSize.fromJSON(e))
+        : [],
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    if (message.queueAllowed) {
+      obj.queueAllowed = message.queueAllowed.map((e) =>
+        e ? QueueSize.toJSON(e) : undefined,
+      );
+    } else {
+      obj.queueAllowed = [];
+    }
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseState();
+    message.queueAllowed =
+      object.queueAllowed?.map((e) => QueueSize.fromPartial(e)) || [];
+    return message;
+  },
+};
+function createBaseStringBeans() {
+  return { key: '', beans: '' };
+}
+export const StringBeans = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.key !== '') {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.beans !== '') {
+      writer.uint32(18).string(message.beans);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStringBeans();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.string();
+          break;
+        case 2:
+          message.beans = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      beans: isSet(object.beans) ? String(object.beans) : '',
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.key !== undefined && (obj.key = message.key);
+    message.beans !== undefined && (obj.beans = message.beans);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseStringBeans();
+    message.key = object.key ?? '';
+    message.beans = object.beans ?? '';
+    return message;
+  },
+};
+function createBasePowerFlagFee() {
+  return { powerFlag: '', fee: [] };
+}
+export const PowerFlagFee = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.powerFlag !== '') {
+      writer.uint32(10).string(message.powerFlag);
+    }
+    for (const v of message.fee) {
+      Coin.encode(v, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePowerFlagFee();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.powerFlag = reader.string();
+          break;
+        case 2:
+          message.fee.push(Coin.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      powerFlag: isSet(object.powerFlag) ? String(object.powerFlag) : '',
+      fee: Array.isArray(object?.fee)
+        ? object.fee.map((e) => Coin.fromJSON(e))
+        : [],
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.powerFlag !== undefined && (obj.powerFlag = message.powerFlag);
+    if (message.fee) {
+      obj.fee = message.fee.map((e) => (e ? Coin.toJSON(e) : undefined));
+    } else {
+      obj.fee = [];
+    }
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBasePowerFlagFee();
+    message.powerFlag = object.powerFlag ?? '';
+    message.fee = object.fee?.map((e) => Coin.fromPartial(e)) || [];
+    return message;
+  },
+};
+function createBaseQueueSize() {
+  return { key: '', size: 0 };
+}
+export const QueueSize = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.key !== '') {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.size !== 0) {
+      writer.uint32(16).int32(message.size);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueueSize();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.string();
+          break;
+        case 2:
+          message.size = reader.int32();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      size: isSet(object.size) ? Number(object.size) : 0,
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.key !== undefined && (obj.key = message.key);
+    message.size !== undefined && (obj.size = Math.round(message.size));
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueueSize();
+    message.key = object.key ?? '';
+    message.size = object.size ?? 0;
+    return message;
+  },
+};
+function createBaseEgress() {
+  return { nickname: '', peer: new Uint8Array(), powerFlags: [] };
+}
+export const Egress = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.nickname !== '') {
+      writer.uint32(10).string(message.nickname);
+    }
+    if (message.peer.length !== 0) {
+      writer.uint32(18).bytes(message.peer);
+    }
+    for (const v of message.powerFlags) {
+      writer.uint32(26).string(v);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEgress();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.nickname = reader.string();
+          break;
+        case 2:
+          message.peer = reader.bytes();
+          break;
+        case 3:
+          message.powerFlags.push(reader.string());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      nickname: isSet(object.nickname) ? String(object.nickname) : '',
+      peer: isSet(object.peer)
+        ? bytesFromBase64(object.peer)
+        : new Uint8Array(),
+      powerFlags: Array.isArray(object?.powerFlags)
+        ? object.powerFlags.map((e) => String(e))
+        : [],
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.nickname !== undefined && (obj.nickname = message.nickname);
+    message.peer !== undefined &&
+      (obj.peer = base64FromBytes(
+        message.peer !== undefined ? message.peer : new Uint8Array(),
+      ));
+    if (message.powerFlags) {
+      obj.powerFlags = message.powerFlags.map((e) => e);
+    } else {
+      obj.powerFlags = [];
+    }
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseEgress();
+    message.nickname = object.nickname ?? '';
+    message.peer = object.peer ?? new Uint8Array();
+    message.powerFlags = object.powerFlags?.map((e) => e) || [];
+    return message;
+  },
+};
+var globalThis = (() => {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
+})();
+const atob =
+  globalThis.atob ||
+  ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
+function bytesFromBase64(b64) {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+const btoa =
+  globalThis.btoa ||
+  ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
+function base64FromBytes(arr) {
+  const bin = [];
+  arr.forEach((byte) => {
+    bin.push(String.fromCharCode(byte));
+  });
+  return btoa(bin.join(''));
+}
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long;
+  _m0.configure();
+}
+function isSet(value) {
+  return value !== null && value !== undefined;
+}

--- a/packages/cosmic-proto/gen/agoric/swingset/swingset.ts
+++ b/packages/cosmic-proto/gen/agoric/swingset/swingset.ts
@@ -1,0 +1,809 @@
+/* eslint-disable */
+import Long from 'long';
+import { Coin } from '../../cosmos/base/v1beta1/coin.js';
+import _m0 from 'protobufjs/minimal.js';
+
+export const protobufPackage = 'agoric.swingset';
+
+/**
+ * CoreEvalProposal is a gov Content type for evaluating code in the SwingSet
+ * core.
+ * See `agoric-sdk/packages/vats/src/core/eval.js`.
+ */
+export interface CoreEvalProposal {
+  title: string;
+  description: string;
+  /**
+   * Although evals are sequential, they may run concurrently, since they each
+   * can return a Promise.
+   */
+  evals: CoreEval[];
+}
+
+/**
+ * CoreEval defines an individual SwingSet core evaluation, for use in
+ * CoreEvalProposal.
+ */
+export interface CoreEval {
+  /**
+   * Grant these JSON-stringified core bootstrap permits to the jsCode, as the
+   * `powers` endowment.
+   */
+  jsonPermits: string;
+  /**
+   * Evaluate this JavaScript code in a Compartment endowed with `powers` as
+   * well as some powerless helpers.
+   */
+  jsCode: string;
+}
+
+/** Params are the swingset configuration/governance parameters. */
+export interface Params {
+  /**
+   * Map from unit name to a value in SwingSet "beans".
+   * Must not be negative.
+   *
+   * These values are used by SwingSet to normalize named per-resource charges
+   * (maybe rent) in a single Nat usage unit, the "bean".
+   *
+   * There is no required order to this list of entries, but all the chain
+   * nodes must all serialize and deserialize the existing order without
+   * permuting it.
+   */
+  beansPerUnit: StringBeans[];
+  /**
+   * The price in Coins per the unit named "fee".  This value is used by
+   * cosmic-swingset JS code to decide how many tokens to charge.
+   *
+   * cost = beans_used * fee_unit_price / beans_per_unit["fee"]
+   */
+  feeUnitPrice: Coin[];
+  /**
+   * The SwingSet bootstrap vat configuration file.  Not usefully modifiable
+   * via governance as it is only referenced by the chain's initial
+   * construction.
+   */
+  bootstrapVatConfig: string;
+  /**
+   * If the provision submitter doesn't hold a provisionpass, their requested
+   * power flags are looked up in this fee menu (first match wins) and the sum
+   * is charged.  If any power flag is not found in this menu, the request is
+   * rejected.
+   */
+  powerFlagFees: PowerFlagFee[];
+  /**
+   * Maximum sizes for queues.
+   * These values are used by SwingSet to compute how many messages should be
+   * accepted in a block.
+   *
+   * There is no required order to this list of entries, but all the chain
+   * nodes must all serialize and deserialize the existing order without
+   * permuting it.
+   */
+  queueMax: QueueSize[];
+}
+
+/** The current state of the module. */
+export interface State {
+  /**
+   * The allowed number of items to add to queues, as determined by SwingSet.
+   * Transactions which attempt to enqueue more should be rejected.
+   */
+  queueAllowed: QueueSize[];
+}
+
+/** Map element of a string key to a Nat bean count. */
+export interface StringBeans {
+  /** What the beans are for. */
+  key: string;
+  /** The actual bean value. */
+  beans: string;
+}
+
+/** Map a provisioning power flag to its corresponding fee. */
+export interface PowerFlagFee {
+  powerFlag: string;
+  fee: Coin[];
+}
+
+/** Map element of a string key to a size. */
+export interface QueueSize {
+  /** What the size is for. */
+  key: string;
+  /** The actual size value. */
+  size: number;
+}
+
+/** Egress is the format for a swingset egress. */
+export interface Egress {
+  nickname: string;
+  peer: Uint8Array;
+  /** TODO: Remove these power flags as they are deprecated and have no effect. */
+  powerFlags: string[];
+}
+
+function createBaseCoreEvalProposal(): CoreEvalProposal {
+  return { title: '', description: '', evals: [] };
+}
+
+export const CoreEvalProposal = {
+  encode(
+    message: CoreEvalProposal,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.title !== '') {
+      writer.uint32(10).string(message.title);
+    }
+    if (message.description !== '') {
+      writer.uint32(18).string(message.description);
+    }
+    for (const v of message.evals) {
+      CoreEval.encode(v!, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): CoreEvalProposal {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCoreEvalProposal();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.title = reader.string();
+          break;
+        case 2:
+          message.description = reader.string();
+          break;
+        case 3:
+          message.evals.push(CoreEval.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CoreEvalProposal {
+    return {
+      title: isSet(object.title) ? String(object.title) : '',
+      description: isSet(object.description) ? String(object.description) : '',
+      evals: Array.isArray(object?.evals)
+        ? object.evals.map((e: any) => CoreEval.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: CoreEvalProposal): unknown {
+    const obj: any = {};
+    message.title !== undefined && (obj.title = message.title);
+    message.description !== undefined &&
+      (obj.description = message.description);
+    if (message.evals) {
+      obj.evals = message.evals.map((e) =>
+        e ? CoreEval.toJSON(e) : undefined,
+      );
+    } else {
+      obj.evals = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<CoreEvalProposal>, I>>(
+    object: I,
+  ): CoreEvalProposal {
+    const message = createBaseCoreEvalProposal();
+    message.title = object.title ?? '';
+    message.description = object.description ?? '';
+    message.evals = object.evals?.map((e) => CoreEval.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseCoreEval(): CoreEval {
+  return { jsonPermits: '', jsCode: '' };
+}
+
+export const CoreEval = {
+  encode(
+    message: CoreEval,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.jsonPermits !== '') {
+      writer.uint32(10).string(message.jsonPermits);
+    }
+    if (message.jsCode !== '') {
+      writer.uint32(18).string(message.jsCode);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): CoreEval {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCoreEval();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.jsonPermits = reader.string();
+          break;
+        case 2:
+          message.jsCode = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CoreEval {
+    return {
+      jsonPermits: isSet(object.jsonPermits) ? String(object.jsonPermits) : '',
+      jsCode: isSet(object.jsCode) ? String(object.jsCode) : '',
+    };
+  },
+
+  toJSON(message: CoreEval): unknown {
+    const obj: any = {};
+    message.jsonPermits !== undefined &&
+      (obj.jsonPermits = message.jsonPermits);
+    message.jsCode !== undefined && (obj.jsCode = message.jsCode);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<CoreEval>, I>>(object: I): CoreEval {
+    const message = createBaseCoreEval();
+    message.jsonPermits = object.jsonPermits ?? '';
+    message.jsCode = object.jsCode ?? '';
+    return message;
+  },
+};
+
+function createBaseParams(): Params {
+  return {
+    beansPerUnit: [],
+    feeUnitPrice: [],
+    bootstrapVatConfig: '',
+    powerFlagFees: [],
+    queueMax: [],
+  };
+}
+
+export const Params = {
+  encode(
+    message: Params,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    for (const v of message.beansPerUnit) {
+      StringBeans.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.feeUnitPrice) {
+      Coin.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.bootstrapVatConfig !== '') {
+      writer.uint32(26).string(message.bootstrapVatConfig);
+    }
+    for (const v of message.powerFlagFees) {
+      PowerFlagFee.encode(v!, writer.uint32(34).fork()).ldelim();
+    }
+    for (const v of message.queueMax) {
+      QueueSize.encode(v!, writer.uint32(42).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Params {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseParams();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.beansPerUnit.push(
+            StringBeans.decode(reader, reader.uint32()),
+          );
+          break;
+        case 2:
+          message.feeUnitPrice.push(Coin.decode(reader, reader.uint32()));
+          break;
+        case 3:
+          message.bootstrapVatConfig = reader.string();
+          break;
+        case 4:
+          message.powerFlagFees.push(
+            PowerFlagFee.decode(reader, reader.uint32()),
+          );
+          break;
+        case 5:
+          message.queueMax.push(QueueSize.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Params {
+    return {
+      beansPerUnit: Array.isArray(object?.beansPerUnit)
+        ? object.beansPerUnit.map((e: any) => StringBeans.fromJSON(e))
+        : [],
+      feeUnitPrice: Array.isArray(object?.feeUnitPrice)
+        ? object.feeUnitPrice.map((e: any) => Coin.fromJSON(e))
+        : [],
+      bootstrapVatConfig: isSet(object.bootstrapVatConfig)
+        ? String(object.bootstrapVatConfig)
+        : '',
+      powerFlagFees: Array.isArray(object?.powerFlagFees)
+        ? object.powerFlagFees.map((e: any) => PowerFlagFee.fromJSON(e))
+        : [],
+      queueMax: Array.isArray(object?.queueMax)
+        ? object.queueMax.map((e: any) => QueueSize.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: Params): unknown {
+    const obj: any = {};
+    if (message.beansPerUnit) {
+      obj.beansPerUnit = message.beansPerUnit.map((e) =>
+        e ? StringBeans.toJSON(e) : undefined,
+      );
+    } else {
+      obj.beansPerUnit = [];
+    }
+    if (message.feeUnitPrice) {
+      obj.feeUnitPrice = message.feeUnitPrice.map((e) =>
+        e ? Coin.toJSON(e) : undefined,
+      );
+    } else {
+      obj.feeUnitPrice = [];
+    }
+    message.bootstrapVatConfig !== undefined &&
+      (obj.bootstrapVatConfig = message.bootstrapVatConfig);
+    if (message.powerFlagFees) {
+      obj.powerFlagFees = message.powerFlagFees.map((e) =>
+        e ? PowerFlagFee.toJSON(e) : undefined,
+      );
+    } else {
+      obj.powerFlagFees = [];
+    }
+    if (message.queueMax) {
+      obj.queueMax = message.queueMax.map((e) =>
+        e ? QueueSize.toJSON(e) : undefined,
+      );
+    } else {
+      obj.queueMax = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Params>, I>>(object: I): Params {
+    const message = createBaseParams();
+    message.beansPerUnit =
+      object.beansPerUnit?.map((e) => StringBeans.fromPartial(e)) || [];
+    message.feeUnitPrice =
+      object.feeUnitPrice?.map((e) => Coin.fromPartial(e)) || [];
+    message.bootstrapVatConfig = object.bootstrapVatConfig ?? '';
+    message.powerFlagFees =
+      object.powerFlagFees?.map((e) => PowerFlagFee.fromPartial(e)) || [];
+    message.queueMax =
+      object.queueMax?.map((e) => QueueSize.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseState(): State {
+  return { queueAllowed: [] };
+}
+
+export const State = {
+  encode(message: State, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.queueAllowed) {
+      QueueSize.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): State {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseState();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.queueAllowed.push(QueueSize.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): State {
+    return {
+      queueAllowed: Array.isArray(object?.queueAllowed)
+        ? object.queueAllowed.map((e: any) => QueueSize.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: State): unknown {
+    const obj: any = {};
+    if (message.queueAllowed) {
+      obj.queueAllowed = message.queueAllowed.map((e) =>
+        e ? QueueSize.toJSON(e) : undefined,
+      );
+    } else {
+      obj.queueAllowed = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<State>, I>>(object: I): State {
+    const message = createBaseState();
+    message.queueAllowed =
+      object.queueAllowed?.map((e) => QueueSize.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseStringBeans(): StringBeans {
+  return { key: '', beans: '' };
+}
+
+export const StringBeans = {
+  encode(
+    message: StringBeans,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.key !== '') {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.beans !== '') {
+      writer.uint32(18).string(message.beans);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StringBeans {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStringBeans();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.string();
+          break;
+        case 2:
+          message.beans = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StringBeans {
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      beans: isSet(object.beans) ? String(object.beans) : '',
+    };
+  },
+
+  toJSON(message: StringBeans): unknown {
+    const obj: any = {};
+    message.key !== undefined && (obj.key = message.key);
+    message.beans !== undefined && (obj.beans = message.beans);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<StringBeans>, I>>(
+    object: I,
+  ): StringBeans {
+    const message = createBaseStringBeans();
+    message.key = object.key ?? '';
+    message.beans = object.beans ?? '';
+    return message;
+  },
+};
+
+function createBasePowerFlagFee(): PowerFlagFee {
+  return { powerFlag: '', fee: [] };
+}
+
+export const PowerFlagFee = {
+  encode(
+    message: PowerFlagFee,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.powerFlag !== '') {
+      writer.uint32(10).string(message.powerFlag);
+    }
+    for (const v of message.fee) {
+      Coin.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): PowerFlagFee {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePowerFlagFee();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.powerFlag = reader.string();
+          break;
+        case 2:
+          message.fee.push(Coin.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PowerFlagFee {
+    return {
+      powerFlag: isSet(object.powerFlag) ? String(object.powerFlag) : '',
+      fee: Array.isArray(object?.fee)
+        ? object.fee.map((e: any) => Coin.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: PowerFlagFee): unknown {
+    const obj: any = {};
+    message.powerFlag !== undefined && (obj.powerFlag = message.powerFlag);
+    if (message.fee) {
+      obj.fee = message.fee.map((e) => (e ? Coin.toJSON(e) : undefined));
+    } else {
+      obj.fee = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<PowerFlagFee>, I>>(
+    object: I,
+  ): PowerFlagFee {
+    const message = createBasePowerFlagFee();
+    message.powerFlag = object.powerFlag ?? '';
+    message.fee = object.fee?.map((e) => Coin.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseQueueSize(): QueueSize {
+  return { key: '', size: 0 };
+}
+
+export const QueueSize = {
+  encode(
+    message: QueueSize,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.key !== '') {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.size !== 0) {
+      writer.uint32(16).int32(message.size);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueueSize {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueueSize();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.string();
+          break;
+        case 2:
+          message.size = reader.int32();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueueSize {
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      size: isSet(object.size) ? Number(object.size) : 0,
+    };
+  },
+
+  toJSON(message: QueueSize): unknown {
+    const obj: any = {};
+    message.key !== undefined && (obj.key = message.key);
+    message.size !== undefined && (obj.size = Math.round(message.size));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueueSize>, I>>(
+    object: I,
+  ): QueueSize {
+    const message = createBaseQueueSize();
+    message.key = object.key ?? '';
+    message.size = object.size ?? 0;
+    return message;
+  },
+};
+
+function createBaseEgress(): Egress {
+  return { nickname: '', peer: new Uint8Array(), powerFlags: [] };
+}
+
+export const Egress = {
+  encode(
+    message: Egress,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.nickname !== '') {
+      writer.uint32(10).string(message.nickname);
+    }
+    if (message.peer.length !== 0) {
+      writer.uint32(18).bytes(message.peer);
+    }
+    for (const v of message.powerFlags) {
+      writer.uint32(26).string(v!);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Egress {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEgress();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.nickname = reader.string();
+          break;
+        case 2:
+          message.peer = reader.bytes();
+          break;
+        case 3:
+          message.powerFlags.push(reader.string());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Egress {
+    return {
+      nickname: isSet(object.nickname) ? String(object.nickname) : '',
+      peer: isSet(object.peer)
+        ? bytesFromBase64(object.peer)
+        : new Uint8Array(),
+      powerFlags: Array.isArray(object?.powerFlags)
+        ? object.powerFlags.map((e: any) => String(e))
+        : [],
+    };
+  },
+
+  toJSON(message: Egress): unknown {
+    const obj: any = {};
+    message.nickname !== undefined && (obj.nickname = message.nickname);
+    message.peer !== undefined &&
+      (obj.peer = base64FromBytes(
+        message.peer !== undefined ? message.peer : new Uint8Array(),
+      ));
+    if (message.powerFlags) {
+      obj.powerFlags = message.powerFlags.map((e) => e);
+    } else {
+      obj.powerFlags = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Egress>, I>>(object: I): Egress {
+    const message = createBaseEgress();
+    message.nickname = object.nickname ?? '';
+    message.peer = object.peer ?? new Uint8Array();
+    message.powerFlags = object.powerFlags?.map((e) => e) || [];
+    return message;
+  },
+};
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var globalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
+})();
+
+const atob: (b64: string) => string =
+  globalThis.atob ||
+  ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
+function bytesFromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+
+const btoa: (bin: string) => string =
+  globalThis.btoa ||
+  ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
+function base64FromBytes(arr: Uint8Array): string {
+  const bin: string[] = [];
+  arr.forEach((byte) => {
+    bin.push(String.fromCharCode(byte));
+  });
+  return btoa(bin.join(''));
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P>>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/cosmic-proto/gen/cosmos/base/v1beta1/coin.js
+++ b/packages/cosmic-proto/gen/cosmos/base/v1beta1/coin.js
@@ -1,0 +1,201 @@
+/* eslint-disable */
+import Long from 'long';
+import _m0 from 'protobufjs/minimal.js';
+export const protobufPackage = 'cosmos.base.v1beta1';
+function createBaseCoin() {
+  return { denom: '', amount: '' };
+}
+export const Coin = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.denom !== '') {
+      writer.uint32(10).string(message.denom);
+    }
+    if (message.amount !== '') {
+      writer.uint32(18).string(message.amount);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCoin();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.denom = reader.string();
+          break;
+        case 2:
+          message.amount = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      denom: isSet(object.denom) ? String(object.denom) : '',
+      amount: isSet(object.amount) ? String(object.amount) : '',
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.denom !== undefined && (obj.denom = message.denom);
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseCoin();
+    message.denom = object.denom ?? '';
+    message.amount = object.amount ?? '';
+    return message;
+  },
+};
+function createBaseDecCoin() {
+  return { denom: '', amount: '' };
+}
+export const DecCoin = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.denom !== '') {
+      writer.uint32(10).string(message.denom);
+    }
+    if (message.amount !== '') {
+      writer.uint32(18).string(message.amount);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDecCoin();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.denom = reader.string();
+          break;
+        case 2:
+          message.amount = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      denom: isSet(object.denom) ? String(object.denom) : '',
+      amount: isSet(object.amount) ? String(object.amount) : '',
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.denom !== undefined && (obj.denom = message.denom);
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseDecCoin();
+    message.denom = object.denom ?? '';
+    message.amount = object.amount ?? '';
+    return message;
+  },
+};
+function createBaseIntProto() {
+  return { int: '' };
+}
+export const IntProto = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.int !== '') {
+      writer.uint32(10).string(message.int);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseIntProto();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.int = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      int: isSet(object.int) ? String(object.int) : '',
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.int !== undefined && (obj.int = message.int);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseIntProto();
+    message.int = object.int ?? '';
+    return message;
+  },
+};
+function createBaseDecProto() {
+  return { dec: '' };
+}
+export const DecProto = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.dec !== '') {
+      writer.uint32(10).string(message.dec);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDecProto();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.dec = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      dec: isSet(object.dec) ? String(object.dec) : '',
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.dec !== undefined && (obj.dec = message.dec);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseDecProto();
+    message.dec = object.dec ?? '';
+    return message;
+  },
+};
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long;
+  _m0.configure();
+}
+function isSet(value) {
+  return value !== null && value !== undefined;
+}

--- a/packages/cosmic-proto/gen/cosmos/base/v1beta1/coin.ts
+++ b/packages/cosmic-proto/gen/cosmos/base/v1beta1/coin.ts
@@ -1,0 +1,298 @@
+/* eslint-disable */
+import Long from 'long';
+import _m0 from 'protobufjs/minimal.js';
+
+export const protobufPackage = 'cosmos.base.v1beta1';
+
+/**
+ * Coin defines a token with a denomination and an amount.
+ *
+ * NOTE: The amount field is an Int which implements the custom method
+ * signatures required by gogoproto.
+ */
+export interface Coin {
+  denom: string;
+  amount: string;
+}
+
+/**
+ * DecCoin defines a token with a denomination and a decimal amount.
+ *
+ * NOTE: The amount field is an Dec which implements the custom method
+ * signatures required by gogoproto.
+ */
+export interface DecCoin {
+  denom: string;
+  amount: string;
+}
+
+/** IntProto defines a Protobuf wrapper around an Int object. */
+export interface IntProto {
+  int: string;
+}
+
+/** DecProto defines a Protobuf wrapper around a Dec object. */
+export interface DecProto {
+  dec: string;
+}
+
+function createBaseCoin(): Coin {
+  return { denom: '', amount: '' };
+}
+
+export const Coin = {
+  encode(message: Coin, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.denom !== '') {
+      writer.uint32(10).string(message.denom);
+    }
+    if (message.amount !== '') {
+      writer.uint32(18).string(message.amount);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Coin {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCoin();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.denom = reader.string();
+          break;
+        case 2:
+          message.amount = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Coin {
+    return {
+      denom: isSet(object.denom) ? String(object.denom) : '',
+      amount: isSet(object.amount) ? String(object.amount) : '',
+    };
+  },
+
+  toJSON(message: Coin): unknown {
+    const obj: any = {};
+    message.denom !== undefined && (obj.denom = message.denom);
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Coin>, I>>(object: I): Coin {
+    const message = createBaseCoin();
+    message.denom = object.denom ?? '';
+    message.amount = object.amount ?? '';
+    return message;
+  },
+};
+
+function createBaseDecCoin(): DecCoin {
+  return { denom: '', amount: '' };
+}
+
+export const DecCoin = {
+  encode(
+    message: DecCoin,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.denom !== '') {
+      writer.uint32(10).string(message.denom);
+    }
+    if (message.amount !== '') {
+      writer.uint32(18).string(message.amount);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): DecCoin {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDecCoin();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.denom = reader.string();
+          break;
+        case 2:
+          message.amount = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DecCoin {
+    return {
+      denom: isSet(object.denom) ? String(object.denom) : '',
+      amount: isSet(object.amount) ? String(object.amount) : '',
+    };
+  },
+
+  toJSON(message: DecCoin): unknown {
+    const obj: any = {};
+    message.denom !== undefined && (obj.denom = message.denom);
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DecCoin>, I>>(object: I): DecCoin {
+    const message = createBaseDecCoin();
+    message.denom = object.denom ?? '';
+    message.amount = object.amount ?? '';
+    return message;
+  },
+};
+
+function createBaseIntProto(): IntProto {
+  return { int: '' };
+}
+
+export const IntProto = {
+  encode(
+    message: IntProto,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.int !== '') {
+      writer.uint32(10).string(message.int);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): IntProto {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseIntProto();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.int = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): IntProto {
+    return {
+      int: isSet(object.int) ? String(object.int) : '',
+    };
+  },
+
+  toJSON(message: IntProto): unknown {
+    const obj: any = {};
+    message.int !== undefined && (obj.int = message.int);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<IntProto>, I>>(object: I): IntProto {
+    const message = createBaseIntProto();
+    message.int = object.int ?? '';
+    return message;
+  },
+};
+
+function createBaseDecProto(): DecProto {
+  return { dec: '' };
+}
+
+export const DecProto = {
+  encode(
+    message: DecProto,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.dec !== '') {
+      writer.uint32(10).string(message.dec);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): DecProto {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDecProto();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.dec = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DecProto {
+    return {
+      dec: isSet(object.dec) ? String(object.dec) : '',
+    };
+  },
+
+  toJSON(message: DecProto): unknown {
+    const obj: any = {};
+    message.dec !== undefined && (obj.dec = message.dec);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DecProto>, I>>(object: I): DecProto {
+    const message = createBaseDecProto();
+    message.dec = object.dec ?? '';
+    return message;
+  },
+};
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P>>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -17,12 +17,16 @@
   "exports": {
     "./swingset/msgs.js": "./gen/agoric/swingset/msgs.js",
     "./swingset/msgs.ts": "./gen/agoric/swingset/msgs.ts",
+    "./swingset/query.js": "./gen/agoric/swingset/query.js",
+    "./swingset/query.ts": "./gen/agoric/swingset/query.ts",
+    "./swingset/swingset.js": "./gen/agoric/swingset/swingset.js",
+    "./swingset/swingset.ts": "./gen/agoric/swingset/swingset.ts",
     "./package.json": "./package.json"
   },
   "scripts": {
     "build": "echo Use yarn rebuild",
     "rebuild": "rm -rf gen && mkdir -p gen && yarn build:ts && yarn build:js && prettier -w .",
-    "build:ts": "protoc --plugin=node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt='esModuleInterop=true,forceLong=long,useOptionals=true' --ts_proto_out=./gen --ts_proto_opt=importSuffix=.js ./proto/agoric/swingset/msgs.proto -I./proto",
+    "build:ts": "protoc --plugin=node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt='esModuleInterop=true,forceLong=long,useOptionals=true' --ts_proto_out=./gen --ts_proto_opt=importSuffix=.js ./proto/agoric/swingset/msgs.proto ./proto/agoric/swingset/query.proto -I./proto",
     "build:js": "tsc --build jsconfig.json",
     "test": "node test/sanity-test.js",
     "test:xs": "exit 0",

--- a/packages/cosmic-proto/proto/cosmos
+++ b/packages/cosmic-proto/proto/cosmos
@@ -1,0 +1,1 @@
+../../../golang/cosmos/third_party/proto/cosmos

--- a/packages/cosmic-proto/swingset/query.js
+++ b/packages/cosmic-proto/swingset/query.js
@@ -1,0 +1,1 @@
+../gen/agoric/swingset/query.js

--- a/packages/cosmic-proto/swingset/query.ts
+++ b/packages/cosmic-proto/swingset/query.ts
@@ -1,0 +1,1 @@
+../gen/agoric/swingset/query.ts

--- a/packages/cosmic-proto/swingset/swingset.js
+++ b/packages/cosmic-proto/swingset/swingset.js
@@ -1,0 +1,1 @@
+../gen/agoric/swingset/swingset.js

--- a/packages/cosmic-proto/swingset/swingset.ts
+++ b/packages/cosmic-proto/swingset/swingset.ts
@@ -1,0 +1,1 @@
+../gen/agoric/swingset/swingset.ts

--- a/packages/cosmic-proto/test/query-swingset-params.js
+++ b/packages/cosmic-proto/test/query-swingset-params.js
@@ -1,0 +1,33 @@
+// @ts-check
+import { QueryClient, createProtobufRpcClient } from '@cosmjs/stargate';
+import { QueryClientImpl } from '@agoric/cosmic-proto/swingset/query.js';
+
+import { HttpClient, Tendermint34Client } from '@cosmjs/tendermint-rpc';
+
+/**
+ * Query swingset params
+ *
+ * For example, minFeeThingy@@@
+ *
+ * @param {import('@cosmjs/tendermint-rpc').Tendermint34Client} rpcClient
+ * @returns {Promise<import('@agoric/cosmic-proto/swingset/query.js').QueryParamsResponse>}
+ */
+const querySwingsetParams = async (rpcClient) => {
+  const base = QueryClient.withExtensions(rpcClient);
+  const rpc = createProtobufRpcClient(base);
+  const queryService = new QueryClientImpl(rpc);
+  console.log('query swingset params');
+  const result = await queryService.Params({});
+
+  return result;
+};
+
+const testMain = async () => {
+  const endPoint = 'https://emerynet.rpc.agoric.net:443';
+  const rpc = new HttpClient(endPoint);
+  const trpc = await Tendermint34Client.create(rpc);
+  const params = await querySwingsetParams(trpc);
+  console.log(JSON.stringify(params, null, 2));
+};
+
+testMain().catch((err) => console.error(err));

--- a/packages/cosmic-proto/test/sanity-test.js
+++ b/packages/cosmic-proto/test/sanity-test.js
@@ -1,1 +1,2 @@
 import '@agoric/cosmic-proto/swingset/msgs.js';
+import '@agoric/cosmic-proto/swingset/query.js';


### PR DESCRIPTION
## Description

In support of showing swingset execution fee batch size (#6525), generate client stubs for `proto/agoric/swingset/query.proto` to go with `msgs.proto`.

## Security considerations

The generated stubs have been only lightly reviewed; we presume they use the same code patterns we have looked at more closely for other stubs.

## Documentation considerations

We seem to rely on the .proto files as documentation. :-/

## Testing considerations

 - sanity test is extended to import `query.js`
 - an integration test (not run in ci) shows how to use `query.js`
