### PR TITLE
fix: error details use

### DIFF
--- a/packages/SwingSet/src/devices/lib/deviceTools.js
+++ b/packages/SwingSet/src/devices/lib/deviceTools.js
@@ -69,7 +69,7 @@ export function buildSerializationTools(syscall, deviceName) {
     if (devnodeSlot) {
       return devnodeSlot;
     }
-    throw Error(X`unable to convert value ${val}`);
+    assert.fail(X`unable to convert value ${val}`);
   }
 
   const m = makeMarshal(convertValToSlot, convertSlotToVal, {


### PR DESCRIPTION
Noticed when looking at https://github.com/Agoric/agoric-sdk/pull/6537/files?file-filters%5B%5D=.cjs&file-filters%5B%5D=.js&file-filters%5B%5D=.patch&show-deleted-files=true&show-viewed-files=true&w=1#diff-17b9421ee446248e751293c3062d91a159b91855b47f125fcef41de09acbf0a4 adding a strange error suppression. The error being suppressed here was actually symptomatic of a genuine problem:

```js
    // @ts-expect-error DetailsToken not a string
    throw Error(X`unable to convert value ${val}`);
```

The `Error` constructor doesn't know anything about `assert.details`, aka `X`. The unredacted value of `val` is likely lost. This `throw Error` should be an `assert.fail`, as it correctly is for similar cases elsewhere in this file.