### PR TITLE
checkJs swingset-vat

### DIFF
--- a/packages/SwingSet/jsconfig.json
+++ b/packages/SwingSet/jsconfig.json
@@ -3,25 +3,17 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
+    "checkJs": true,
     "noEmit": true,
-/*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
   "include": [
     "exported.js",
-    "demo/**/*.js", 
-    "lib/**/*.js", 
-    "src/**/*.js", 
+    "lib/**/*.js",
+    "src/**/*.js",
     "src/**/*.ts",
-    "misc-tools/**/*.js", 
-    "test/**/*.js", 
-    "tools/**/*.js", 
+    // "test",
+    "tools",
   ],
 }

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -21,6 +21,7 @@
     "lint:eslint": "eslint ."
   },
   "devDependencies": {
+    "@types/microtime": "^2.1.0",
     "@types/tmp": "^0.2.0",
     "tmp": "^0.2.1"
   },

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -1,4 +1,3 @@
-// @ts-check
 /* global globalThis, WeakRef, FinalizationRegistry */
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error -- https://github.com/Agoric/agoric-sdk/issues/4620 */
 

--- a/packages/SwingSet/src/controller/hostStorage.js
+++ b/packages/SwingSet/src/controller/hostStorage.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { initSwingStore } from '@agoric/swing-store';
 
 /*

--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -147,7 +147,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
   if (config.bootstrap) {
     const bootstrapVatID = kernelKeeper.getVatIDForName(config.bootstrap);
     logStartup(`=> queueing bootstrap()`);
-    bootstrapResultKpid = enqueueBootstrap(bootstrapVatID, kernelKeeper);
+    bootstrapResultKpid = enqueueBootstrap(bootstrapVatID);
     if (config.pinBootstrapRoot) {
       const kref = exportRootObject(kernelKeeper, bootstrapVatID);
       kernelKeeper.pinObject(kref);

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -1,5 +1,4 @@
 /* global process */
-// @ts-check
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/SwingSet/src/devices/bridge/device-bridge.js
+++ b/packages/SwingSet/src/devices/bridge/device-bridge.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@endo/marshal';
 

--- a/packages/SwingSet/src/devices/plugin/device-plugin.js
+++ b/packages/SwingSet/src/devices/plugin/device-plugin.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { makeCapTP } from '@endo/captp';
 import { Far } from '@endo/marshal';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -147,7 +147,9 @@ function makeTimerMap(state = undefined) {
       } else {
         // Nothing prevents a particular handler from appearing more than once
         for (const { handler } of handlers) {
+          // @ts-expect-error xxx Waker vs IndexedHandler
           if (handler === targetHandler && handlers.indexOf(handler) !== -1) {
+            // @ts-expect-error xxx Waker vs IndexedHandler
             handlers.splice(handlers.indexOf(handler), 1);
             droppedTimes.push(time);
           }

--- a/packages/SwingSet/src/devices/vat-admin/device-vat-admin.js
+++ b/packages/SwingSet/src/devices/vat-admin/device-vat-admin.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { Nat } from '@agoric/nat';
 import { assert } from '@agoric/assert';
 import { buildSerializationTools } from '../lib/deviceTools.js';

--- a/packages/SwingSet/src/kernel/deviceManager.js
+++ b/packages/SwingSet/src/kernel/deviceManager.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert } from '@agoric/assert';
 import { makeDeviceSlots } from './deviceSlots.js';
 import { insistCapData } from '../lib/capdata.js';

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { Remotable, passStyleOf, makeMarshal } from '@endo/marshal';
 import { assert, details as X } from '@agoric/assert';
 import {

--- a/packages/SwingSet/src/kernel/deviceTranslator.js
+++ b/packages/SwingSet/src/kernel/deviceTranslator.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { assert, details as X } from '@agoric/assert';
 import { insistMessage } from '../lib/message.js';
 import { insistKernelType } from './parseKernelSlots.js';

--- a/packages/SwingSet/src/kernel/dummyMeterControl.js
+++ b/packages/SwingSet/src/kernel/dummyMeterControl.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert } from '@agoric/assert';
 
 export function makeDummyMeterControl() {

--- a/packages/SwingSet/src/kernel/gc-actions.js
+++ b/packages/SwingSet/src/kernel/gc-actions.js
@@ -44,6 +44,7 @@ export function processNextGCAction(kernelKeeper) {
     const hasCList = vatKeeper.hasCListEntry(kref);
     const isReachable = hasCList ? vatKeeper.getReachableFlag(kref) : undefined;
     const exists = kernelKeeper.kernelObjectExists(kref);
+    // @ts-expect-error xxx
     const { reachable, recognizable } = exists
       ? kernelKeeper.getObjectRefCount(kref)
       : {};

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { isNat } from '@agoric/nat';
 import { importBundle } from '@endo/import-bundle';

--- a/packages/SwingSet/src/kernel/kernelQueue.js
+++ b/packages/SwingSet/src/kernel/kernelQueue.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { insistKernelType, parseKernelSlot } from './parseKernelSlots.js';
 import { insistCapData } from '../lib/capdata.js';
 import { insistMessage } from '../lib/message.js';

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -1,4 +1,3 @@
-// @ts-check
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error -- https://github.com/Agoric/agoric-sdk/issues/4620 */
 
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/src/kernel/metrics.js
+++ b/packages/SwingSet/src/kernel/metrics.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 // All the kernel metrics we are prepared for.
 export const KERNEL_STATS_SUM_METRICS = /** @type {const} */ ([
   {

--- a/packages/SwingSet/src/kernel/notifyTermination.js
+++ b/packages/SwingSet/src/kernel/notifyTermination.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { insistCapData } from '../lib/capdata.js';
 
 /**

--- a/packages/SwingSet/src/kernel/parseKernelSlots.js
+++ b/packages/SwingSet/src/kernel/parseKernelSlots.js
@@ -19,12 +19,13 @@ import { assert, details as X } from '@agoric/assert';
  *
  * @param {unknown} s  The string to be parsed, as described above.
  *
- * @returns {{type: 'object' | 'device' | 'promise', id: number}} a kernel slot object corresponding to the parameter.
+ * @returns {{type: 'object' | 'device' | 'promise', id: bigint}} a kernel slot object corresponding to the parameter.
  *
  * @throws {Error} if the given string is syntactically incorrect.
  */
 export function parseKernelSlot(s) {
   assert.typeof(s, 'string');
+  /** @type {'object' | 'device' | 'promise' | undefined} */
   let type;
   let idSuffix;
   if (s.startsWith('ko')) {

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -98,6 +98,7 @@ export function makeDummySlogger(slogCallbacks, dummyConsole) {
     write: () => 0,
   });
   doneRegistering(`Unrecognized makeDummySlogger slogCallbacks names:`);
+  // @ts-expect-error xxx
   return dummySlogger;
 }
 
@@ -281,5 +282,6 @@ export function makeSlogger(slogCallbacks, writeObj) {
     write,
   });
   doneRegistering(`Unrecognized makeSlogger slogCallbacks names:`);
+  // @ts-expect-error xxx
   return slogger;
 }

--- a/packages/SwingSet/src/kernel/state/deviceKeeper.js
+++ b/packages/SwingSet/src/kernel/state/deviceKeeper.js
@@ -31,15 +31,15 @@ export function initializeDeviceState(kvStore, deviceID) {
  *
  * @param {*} kvStore  The storage in which the persistent state will be kept
  * @param {string} deviceID  The device ID string of the device in question
- * @param { addKernelDeviceNode: (deviceID: string) => string,
+ * @param {{ addKernelDeviceNode: (deviceID: string) => string,
  *          incrementRefCount: (kernelSlot: string,
  *                              tag: string?,
  *                              options: {
- *                                isExport: boolean?,
- *                                onlyRecognizable: boolean?,
+ *                                isExport?: boolean,
+ *                                onlyRecognizable?: boolean,
  *                              },
- *                             ) => undefined),
- *         } tools
+ *                             ) => void,
+ *         }} tools
  * @returns {*} an object to hold and access the kernel's state for the given device
  */
 export function makeDeviceKeeper(kvStore, deviceID, tools) {
@@ -185,6 +185,7 @@ export function makeDeviceKeeper(kvStore, deviceID, tools) {
    * @returns {Array<[string, string, string]>} an array of this device's state information
    */
   function dumpState() {
+    /** @type {Array<[string, string, string]>} */
     const res = [];
     const prefix = `${deviceID}.c.`;
     for (const k of kvStore.getKeys(prefix, `${deviceID}.c/`)) {

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -1,4 +1,3 @@
-// @ts-check
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error -- https://github.com/Agoric/agoric-sdk/issues/4620 */
 import { Nat, isNat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/src/kernel/state/reachable.js
+++ b/packages/SwingSet/src/kernel/state/reachable.js
@@ -14,6 +14,7 @@ export function parseReachableAndVatSlot(value) {
   } else {
     assert(`flag (${flag}) must be 'R' or '_'`);
   }
+  // @ts-expect-error xxx TS doesn't know isReachable is assigned b/c assert() throws
   return { isReachable, vatSlot };
 }
 harden(parseReachableAndVatSlot);

--- a/packages/SwingSet/src/kernel/state/reachable.js
+++ b/packages/SwingSet/src/kernel/state/reachable.js
@@ -12,9 +12,8 @@ export function parseReachableAndVatSlot(value) {
   } else if (flag === '_') {
     isReachable = false;
   } else {
-    assert(`flag (${flag}) must be 'R' or '_'`);
+    assert.fail(`flag (${flag}) must be 'R' or '_'`);
   }
-  // @ts-expect-error xxx TS doesn't know isReachable is assigned b/c assert() throws
   return { isReachable, vatSlot };
 }
 harden(parseReachableAndVatSlot);

--- a/packages/SwingSet/src/kernel/state/stats.js
+++ b/packages/SwingSet/src/kernel/state/stats.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 /** @typedef {'counter' | 'gauge'} KernelStatsMetricType */
 /**
  * @template {KernelStatsMetricType} [T=KernelStatsMetricType]

--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { assert } from '@agoric/assert';
 import { insistStorageAPI, makeBufferedStorage } from '../../lib/storageAPI.js';
 

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -1,7 +1,6 @@
 /**
  * Kernel's keeper of persistent state for a vat.
  */
-// @ts-check
 import { Nat, isNat } from '@agoric/nat';
 import { assert, details as X, q } from '@agoric/assert';
 import { parseKernelSlot } from '../parseKernelSlots.js';

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert } from '@agoric/assert';
 import '../../types-ambient.js';
 import { insistVatDeliveryResult } from '../../lib/message.js';

--- a/packages/SwingSet/src/kernel/vat-loader/manager-local.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-local.js
@@ -1,4 +1,3 @@
-// @ts-check
 /* global globalThis */
 
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
@@ -1,4 +1,3 @@
-// @ts-check
 // import { Worker } from 'worker_threads'; // not from a Compartment
 import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
@@ -81,7 +81,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       } else if (type === 'dispatchReady') {
         parentLog(`dispatch() ready`);
         // wait10ms().then(dispatchIsReady); // stall to let logs get printed
-        dispatchIsReady(undefined);
+        dispatchIsReady();
       } else if (type === 'syscall') {
         parentLog(`syscall`, args);
         const [vatSyscallObject] = args;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
@@ -67,6 +67,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       void workerP.then(worker => worker.postMessage(msg));
     }
 
+    /** @type {PromiseKit<void>} */
     const { promise: dispatchReadyP, resolve: dispatchIsReady } =
       makePromiseKit();
     let waiting;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -78,7 +78,7 @@ export function makeNodeSubprocessFactory(tools) {
       } else if (type === 'dispatchReady') {
         parentLog(`dispatch() ready`);
         // wait10ms().then(dispatchIsReady); // stall to let logs get printed
-        dispatchIsReady();
+        dispatchIsReady(undefined);
       } else if (type === 'syscall') {
         parentLog(`syscall`, args);
         const [vatSyscallObject] = args;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert, details as X, q } from '@agoric/assert';
 import { ExitCode } from '@agoric/xsnap/api.js';
 import { makeManagerKit } from './manager-helper.js';

--- a/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
+++ b/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { assertKnownOptions } from '../../lib/assertOptions.js';
 import { makeVatSlot } from '../../lib/parseVatSlots.js';

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-await-in-loop,@jessie.js/no-nested-await */
-// @ts-check
 import { assert, details as X, quote as q } from '@agoric/assert';
 import { isNat } from '@agoric/nat';
 import { makeVatTranslators } from './vatTranslator.js';

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { insistMessage } from '../lib/message.js';
 import { insistKernelType, parseKernelSlot } from './parseKernelSlots.js';

--- a/packages/SwingSet/src/lib-nodejs/engine-gc.js
+++ b/packages/SwingSet/src/lib-nodejs/engine-gc.js
@@ -7,6 +7,7 @@ if (typeof bestGC !== 'function') {
   // Node.js v8 wizardry.
   v8.setFlagsFromString('--expose_gc');
   bestGC = vm.runInNewContext('gc');
+  assert(bestGC);
   // We leave --expose_gc turned on, otherwise AVA's shared workers
   // may race and disable it before we manage to extract the
   // binding. This won't cause 'gc' to be visible to new Compartments

--- a/packages/SwingSet/src/lib-nodejs/spawnSubprocessWorker.js
+++ b/packages/SwingSet/src/lib-nodejs/spawnSubprocessWorker.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // this file is loaded by the controller, in the start compartment
 import { spawn } from 'child_process';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/SwingSet/src/lib-nodejs/waitUntilQuiescent.js
+++ b/packages/SwingSet/src/lib-nodejs/waitUntilQuiescent.js
@@ -11,6 +11,7 @@ export function waitUntilQuiescent() {
   // lower-priority than the Promise queue on browsers and Node 11, but on
   // Node 10 it is higher. So this trick requires Node 11.
   // https://jsblog.insiderattack.net/new-changes-to-timers-and-microtasks-from-node-v11-0-0-and-above-68d112743eb3
+  /** @type {PromiseKit<void>} */
   const { promise: queueEmptyP, resolve } = makePromiseKit();
   setImmediate(() => resolve());
   return queueEmptyP;

--- a/packages/SwingSet/src/lib-nodejs/worker-protocol.js
+++ b/packages/SwingSet/src/lib-nodejs/worker-protocol.js
@@ -28,14 +28,19 @@ export function arrayEncoderStream() {
 }
 
 export function arrayDecoderStream() {
+  /**
+   *
+   * @param {Buffer} buf
+   * @param {BufferEncoding} encoding
+   * @param {*} callback
+   */
   function transform(buf, encoding, callback) {
     let err;
     try {
       if (!Buffer.isBuffer(buf)) {
         throw Error('stream expects Buffers');
       }
-      // @ts-expect-error Buffer not assignable to string
-      this.push(JSON.parse(buf));
+      this.push(JSON.parse(buf.toString()));
     } catch (e) {
       err = e;
     }

--- a/packages/SwingSet/src/lib-nodejs/worker-protocol.js
+++ b/packages/SwingSet/src/lib-nodejs/worker-protocol.js
@@ -5,6 +5,12 @@ import { Transform } from 'stream';
 // data into Buffers suitable for netstring conversion.
 
 export function arrayEncoderStream() {
+  /**
+   *
+   * @param {*} object
+   * @param {BufferEncoding} encoding
+   * @param {*} callback
+   */
   function transform(object, encoding, callback) {
     if (!Array.isArray(object)) {
       throw Error('stream requires Arrays');
@@ -28,6 +34,7 @@ export function arrayDecoderStream() {
       if (!Buffer.isBuffer(buf)) {
         throw Error('stream expects Buffers');
       }
+      // @ts-expect-error Buffer not assignable to string
       this.push(JSON.parse(buf));
     } catch (e) {
       err = e;

--- a/packages/SwingSet/src/lib/capdata.js
+++ b/packages/SwingSet/src/lib/capdata.js
@@ -9,7 +9,7 @@ import { assert, details as X } from '@agoric/assert';
  * @param {any} capdata  The object to be tested
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
- * @returns {asserts capdata is import('@endo/marshal').CapData<unknown>}
+ * @returns {asserts capdata is import('@endo/marshal').CapData<string>}
  */
 export function insistCapData(capdata) {
   assert.typeof(
@@ -26,8 +26,7 @@ export function insistCapData(capdata) {
  * Returns the slot of a presence if the provided capdata is composed
  * of a single presence, `null` otherwise
  *
- * @param {import('@endo/marshal').CapData<unknown>} data
- * @returns {string | undefined}
+ * @param {import('@endo/marshal').CapData<string>} data
  */
 export function extractSingleSlot(data) {
   const body = JSON.parse(data.body);

--- a/packages/SwingSet/src/lib/id.js
+++ b/packages/SwingSet/src/lib/id.js
@@ -79,7 +79,7 @@ export function makeDeviceID(index) {
  *
  * @param {string} s  The string to be parsed.
  *
- * @returns {{ type: 'vat' | 'device', id: number}} an object: {
+ * @returns {{ type: 'vat' | 'device', id: bigint}} an object: {
  *    type: STRING, // 'vat' or 'device', accordingly
  *    id: Nat       // the index
  *  }
@@ -93,6 +93,7 @@ export function parseVatOrDeviceID(s) {
     X`${s} is not a string, so cannot be a VatID/DeviceID`,
   );
   s = `${s}`;
+  /** @type {'vat' | 'device' | undefined} */
   let type;
   let idSuffix;
   if (s.startsWith('v')) {

--- a/packages/SwingSet/src/lib/message.js
+++ b/packages/SwingSet/src/lib/message.js
@@ -7,7 +7,7 @@ import { insistCapData } from './capdata.js';
  * string, a .args property that's a capdata object, and optionally a .result
  * property that, if present, must be a string.
  *
- * @param {unknown} message  The object to be tested
+ * @param {any} message  The object to be tested
  *
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.

--- a/packages/SwingSet/src/lib/netstring.js
+++ b/packages/SwingSet/src/lib/netstring.js
@@ -7,7 +7,11 @@ import { Transform } from 'stream';
 const COLON = 58;
 const COMMA = 44;
 
-// input is a Buffer, output is a netstring-wrapped Buffer
+/**
+ *
+ * @param {Buffer} data
+ * @returns {Buffer} netstring-wrapped
+ */
 export function encode(data) {
   const prefix = Buffer.from(`${data.length}:`);
   const suffix = Buffer.from(',');
@@ -16,6 +20,12 @@ export function encode(data) {
 
 // input is a sequence of strings, output is a byte pipe
 export function netstringEncoderStream() {
+  /**
+   *
+   * @param {Buffer} chunk
+   * @param {BufferEncoding} encoding
+   * @param {*} callback
+   */
   function transform(chunk, encoding, callback) {
     if (!Buffer.isBuffer(chunk)) {
       throw Error('stream requires Buffers');
@@ -74,7 +84,12 @@ export function decode(data, optMaxChunkSize) {
 // input is a byte pipe, output is a sequence of Buffers
 export function netstringDecoderStream(optMaxChunkSize) {
   let buffered = Buffer.from('');
-
+  /**
+   *
+   * @param {Buffer} chunk
+   * @param {BufferEncoding} encoding
+   * @param {*} callback
+   */
   function transform(chunk, encoding, callback) {
     if (!Buffer.isBuffer(chunk)) {
       throw Error('stream requires Buffers');

--- a/packages/SwingSet/src/lib/runPolicies.js
+++ b/packages/SwingSet/src/lib/runPolicies.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { assert } from '@agoric/assert';
 
 export function foreverPolicy() {

--- a/packages/SwingSet/src/lib/storageAPI.js
+++ b/packages/SwingSet/src/lib/storageAPI.js
@@ -137,7 +137,7 @@ function* mergeUtf16SortedIterators(it1, it2) {
  *   onPendingDelete?: (key: string) => void, // a callback invoked after a new uncommitted delete
  *   onCommit?: () => void, // a callback invoked after pending operations have been committed
  *   onAbort?: () => void, // a callback invoked after pending operations have been aborted
- * }?} listeners  Optional callbacks to be invoked when respective events occur
+ * }} listeners  Optional callbacks to be invoked when respective events occur
  *
  * @returns {{kvStore: KVStore, commit: () => void, abort: () => void}}
  */
@@ -163,6 +163,7 @@ export function makeBufferedStorage(kvStore, listeners = {}) {
       if (additions.has(key)) return additions.get(key);
       if (deletions.has(key)) return undefined;
       const value = kvStore.get(key);
+      // @ts-expect-error value may be undefined
       if (onGet !== undefined) onGet(key, value);
       return value;
     },

--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert, details as X, q } from '@agoric/assert';
 import {
   getRankCover,

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -41,7 +41,7 @@ const SYSCALL_CAPDATA_SLOTS_LENGTH_LIMIT = 10_000;
  * @param {LiveSlotsOptions} liveSlotsOptions
  * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent, gcAndFinalize,
  *                      meterControl }
- * @param {Console} console
+ * @param {Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>} console
  * @param {*} buildVatNamespace
  *
  * @returns {*} { dispatch }
@@ -1285,7 +1285,6 @@ function build(
     }
   }
 
-  /** @type {ExitVatWithFailure} */
   function exitVatWithFailure(reason) {
     meterControl.assertIsMetered(); // else userspace getters could escape
     const args = m.serialize(harden(reason));
@@ -1496,6 +1495,7 @@ function build(
     vom.flushCache();
     await gcTools.gcAndFinalize();
     const doMore = await scanForDeadObjects();
+    // @ts-expect-error FIXME doMore is void
     if (doMore) {
       return bringOutYourDead();
     }
@@ -1657,7 +1657,7 @@ function build(
  * @param {LiveSlotsOptions} liveSlotsOptions
  * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent }
  * @param {Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>} [liveSlotsConsole]
- * @param {*} buildVatNamespace
+ * @param {*} [buildVatNamespace]
  *
  * @returns {*} { vatGlobals, inescapableGlobalProperties, dispatch }
  *
@@ -1712,6 +1712,7 @@ export function makeLiveSlots(
 
 // for tests
 export function makeMarshaller(syscall, gcTools, vatID = 'forVatID') {
+  // @ts-expect-error missing buildVatNamespace param
   const { m } = build(syscall, vatID, {}, {}, gcTools, console);
   return { m };
 }

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -7,6 +7,7 @@ import {
 import { assert, details as X } from '@agoric/assert';
 import { isNat } from '@agoric/nat';
 import { isPromise } from '@endo/promise-kit';
+import { HandledPromise } from '@endo/eventual-send';
 import {
   insistVatType,
   makeVatSlot,

--- a/packages/SwingSet/src/liveslots/stop-vat.js
+++ b/packages/SwingSet/src/liveslots/stop-vat.js
@@ -230,6 +230,7 @@ function deleteVirtualObjectsWithDecref({ syscall, vrm }) {
   // single decrefs)
   const durableBaserefs = Array.from(durableDecrefs.keys()).sort();
   for (const baseRef of durableBaserefs) {
+    // @ts-expect-error FIXME .get does not exist on array
     vrm.decRefCount(baseRef, durableBaserefs.get(baseRef));
   }
 
@@ -286,6 +287,7 @@ function deleteCollectionsWithDecref({ syscall, vrm }) {
   }
   const durableBaserefs = Array.from(durableDecrefs.keys()).sort();
   for (const baseRef of durableBaserefs) {
+    // @ts-expect-error FIXME .get does not exist on array
     vrm.decRefCount(baseRef, durableBaserefs.get(baseRef));
   }
 

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -1,4 +1,3 @@
-// @ts-check
 /* eslint-disable no-use-before-define, jsdoc/require-returns-type */
 
 import { assert, details as X, q } from '@agoric/assert';

--- a/packages/SwingSet/src/liveslots/virtualReferences.js
+++ b/packages/SwingSet/src/liveslots/virtualReferences.js
@@ -1,4 +1,3 @@
-// @ts-check
 /* eslint-disable no-use-before-define, jsdoc/require-returns-type */
 
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/src/liveslots/watchedPromises.js
+++ b/packages/SwingSet/src/liveslots/watchedPromises.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 // no-lonely-if is a stupid rule that really should be disabled globally
 /* eslint-disable no-lonely-if */
 

--- a/packages/SwingSet/src/supervisors/nodeworker/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/supervisors/nodeworker/supervisor-nodeworker.js
@@ -1,4 +1,3 @@
-// @ts-check
 /* global WeakRef, FinalizationRegistry */
 // this file is loaded at the start of a new Worker, which makes it a new JS
 // environment (with it's own Realm), so we must install-ses too.

--- a/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
@@ -1,4 +1,3 @@
-// @ts-check
 /* global WeakRef, FinalizationRegistry */
 
 // this file is loaded at the start of a new subprocess

--- a/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
@@ -1,5 +1,4 @@
 /* global globalThis WeakRef FinalizationRegistry */
-// @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@endo/import-bundle';
 import { makeMarshal } from '@endo/marshal';

--- a/packages/SwingSet/src/supervisors/supervisor-helper.js
+++ b/packages/SwingSet/src/supervisors/supervisor-helper.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { assert } from '@agoric/assert';
 import {
   insistVatSyscallObject,

--- a/packages/SwingSet/src/typeGuards.js
+++ b/packages/SwingSet/src/typeGuards.js
@@ -1,4 +1,3 @@
-// @ts-check
 // @jessie-check
 import { M } from '@agoric/store';
 

--- a/packages/SwingSet/src/types-ambient.js
+++ b/packages/SwingSet/src/types-ambient.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 /**
  * @typedef { import('./types-external.js').BundleFormat } BundleFormat
  */

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 export {};
 
 /* This file defines types that part of the external API of swingset. That

--- a/packages/SwingSet/src/types-internal.js
+++ b/packages/SwingSet/src/types-internal.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 export {};
 
 /**

--- a/packages/SwingSet/src/vats/comms/delivery.js
+++ b/packages/SwingSet/src/vats/comms/delivery.js
@@ -1,4 +1,3 @@
-// @ts-check
 /* eslint-disable no-use-before-define */
 
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/src/vats/comms/parseLocalSlots.js
+++ b/packages/SwingSet/src/vats/comms/parseLocalSlots.js
@@ -15,12 +15,13 @@ import { assert, details as X } from '@agoric/assert';
  *
  * @param {unknown} s  The string to be parsed, as described above.
  *
- * @returns {{type: 'object' | 'promise', id: number}} a local slot object corresponding to the parameter.
+ * @returns {{type: 'object' | 'promise', id: bigint}} a local slot object corresponding to the parameter.
  *
  * @throws {Error} if the given string is syntactically incorrect.
  */
 export function parseLocalSlot(s) {
   assert.typeof(s, 'string');
+  /** @type {'object' | 'promise' | undefined} */
   let type;
   let idSuffix;
   if (s.startsWith('lo')) {
@@ -40,7 +41,7 @@ export function parseLocalSlot(s) {
  * Generate a local slot reference string given a type and id.
  *
  * @param {'object' | 'promise'} type  The type
- * @param {number} id    The id, a Nat.
+ * @param {bigint} id    The id, a Nat.
  *
  * @returns {string} the corresponding local slot reference string.
  *

--- a/packages/SwingSet/src/vats/network/bytes.js
+++ b/packages/SwingSet/src/vats/network/bytes.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import './types.js';
 import { encodeBase64, decodeBase64 } from '@endo/base64';
 

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { makeScalarMap, makeLegacyMap } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';

--- a/packages/SwingSet/src/vats/network/router.js
+++ b/packages/SwingSet/src/vats/network/router.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { E as defaultE } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makeStore } from '@agoric/store';

--- a/packages/SwingSet/src/vats/network/types.js
+++ b/packages/SwingSet/src/vats/network/types.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 /**
  * @typedef {string|Buffer|ArrayBuffer} Data
  * @typedef {string} Bytes

--- a/packages/SwingSet/src/vats/plugin-manager.js
+++ b/packages/SwingSet/src/vats/plugin-manager.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { makeStore } from '@agoric/store';
 import { makeCapTP } from '@endo/captp';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/SwingSet/src/vats/timer/timeMath.js
+++ b/packages/SwingSet/src/vats/timer/timeMath.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 // TODO Move this module somewhere more pleasantly reusable
 
 import { Nat } from '@agoric/nat';

--- a/packages/SwingSet/src/vats/timer/timed-iteration.js
+++ b/packages/SwingSet/src/vats/timer/timed-iteration.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { TimeMath } from './timeMath.js';

--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-use-before-define */
-// @ts-check
 
 import { E } from '@endo/eventual-send';
 import { Far, passStyleOf } from '@endo/marshal';

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -24,7 +24,7 @@ const managerTypes = ['local', 'nodeWorker', 'node-subprocess', 'xs-worker'];
 
 function producePRR() {
   const { promise, resolve, reject } = makePromiseKit();
-  return [promise, { resolve, reject }];
+  return /** @type {const} */ ([promise, { resolve, reject }]);
 }
 
 export function buildRootObject(vatPowers, _vatParameters, baggage) {
@@ -531,7 +531,7 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
   /**
    * the kernel queues this to us when a vat upgrade completes or fails
    *
-   * @param {UpgradeID} upgradeID
+   * @param {import('../../devices/vat-admin/device-vat-admin.js').UpgradeID} upgradeID
    * @param {boolean} success
    * @param {Error | undefined} error
    * @param {number} incarnationNumber

--- a/packages/SwingSet/src/vats/vattp/vat-vattp.js
+++ b/packages/SwingSet/src/vats/vattp/vat-vattp.js
@@ -141,6 +141,7 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
       // TODO: Stop silently creating mailboxes.
       // https://github.com/Agoric/agoric-sdk/issues/5824
       const { inbound } = provideMailbox(name);
+      // @ts-expect-error bad typedef
       inbound.deliverMessages(newMessages);
     },
 
@@ -148,6 +149,7 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
       // TODO: Stop silently creating mailboxes.
       // https://github.com/Agoric/agoric-sdk/issues/5824
       const { inbound } = provideMailbox(name);
+      // @ts-expect-error bad typedef
       inbound.deliverAck(ack);
     },
   };

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -125,7 +125,7 @@ export async function makeDispatch(
   build,
   vatID = 'vatA',
   liveSlotsOptions = {},
-  returnTestHooks = undefined,
+  returnTestHooks,
 ) {
   const gcTools = harden({
     WeakRef,

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -85,26 +85,51 @@ export function buildDispatch(onDispatchCallback = undefined) {
   return { log, dispatch };
 }
 
+/**
+ * @param {number} index
+ * @param {string} [iface]
+ */
 export function capSlot(index, iface = 'export') {
   iface = iface ? `Alleged: ${iface}` : undefined;
   return { '@qclass': 'slot', iface, index };
 }
 
+/**
+ * @param {string} method
+ * @param {string} slot
+ * @param {string} [iface]
+ */
 export function methargsOneSlot(method, slot, iface = 'export') {
   iface = iface ? `Alleged: ${iface}` : undefined;
   return capargs([method, [{ '@qclass': 'slot', iface, index: 0 }]], [slot]);
 }
 
+/**
+ * @param {string} slot
+ * @param {string} [iface]
+ */
 export function capdataOneSlot(slot, iface = 'export') {
   iface = iface ? `Alleged: ${iface}` : undefined;
   return capargs({ '@qclass': 'slot', iface, index: 0 }, [slot]);
 }
 
+/**
+ * @param {string} slot
+ * @param {string} [iface]
+ */
 export function capargsOneSlot(slot, iface = 'export') {
   iface = iface ? `Alleged: ${iface}` : undefined;
   return capargs([{ '@qclass': 'slot', iface, index: 0 }], [slot]);
 }
 
+/**
+ *
+ * @param {unknown} target
+ * @param {string} method
+ * @param {any[]} args
+ * @param {any[]} slots
+ * @param {unknown} result
+ */
 export function makeMessage(
   target,
   method,

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -45,7 +45,10 @@ export function dumpKT(kernel) {
   }
 }
 
-export function buildDispatch(onDispatchCallback = undefined) {
+/**
+ * @param {(d: unknown) => void} [onDispatchCallback ]
+ */
+export function buildDispatch(onDispatchCallback) {
   const log = [];
 
   const GC = ['dropExports', 'retireExports', 'retireImports'];

--- a/packages/SwingSet/tools/manual-timer.js
+++ b/packages/SwingSet/tools/manual-timer.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { Far } from '@endo/marshal';
 import { makeScalarMapStore } from '@agoric/store';
 import { bindAllMethods } from '@agoric/internal';

--- a/packages/SwingSet/tools/prepare-test-env-ava.js
+++ b/packages/SwingSet/tools/prepare-test-env-ava.js
@@ -14,6 +14,8 @@ import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';
 
 /** @type {typeof rawTest} */
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore XXX https://github.com/endojs/endo/issues/1235
 export const test = wrapTest(rawTest);
 
 // Does not import from a module because we're testing the global env

--- a/packages/SwingSet/tools/vat.js
+++ b/packages/SwingSet/tools/vat.js
@@ -27,10 +27,12 @@ async function main() {
     argv[0] === '--' || argv[0] === undefined ? '.' : argv.shift();
   const vatArgv = argv[0] === '--' ? argv.slice(1) : argv;
 
+  assert(basedir);
   const config = await loadBasedir(basedir);
   const { loopboxSrcPath, loopboxEndowments } = buildLoopbox('immediate');
   config.devices = [['loopbox', loopboxSrcPath, loopboxEndowments]];
 
+  // @ts-expect-error expects string[], not boolean, in second position
   const controller = await buildVatController(config, withSES, vatArgv);
   if (command === 'run') {
     await controller.run();

--- a/patches/@endo+import-bundle+0.2.55.patch
+++ b/patches/@endo+import-bundle+0.2.55.patch
@@ -1,0 +1,9 @@
+diff --git a/node_modules/@endo/import-bundle/src/index.js b/node_modules/@endo/import-bundle/src/index.js
+index dbb87c8..abe69f7 100644
+--- a/node_modules/@endo/import-bundle/src/index.js
++++ b/node_modules/@endo/import-bundle/src/index.js
+@@ -1,3 +1,4 @@
++// @ts-nocheck
+ /* global globalThis */
+ /// <reference types="ses"/>
+ 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3147,6 +3147,11 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
+"@types/microtime@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/microtime/-/microtime-2.1.0.tgz#adbd99f501a85c88695eb1efd3515810f2563932"
+  integrity sha512-4mUXDZ9ISb7vpu7Q5cR9Itl2ncbYzn7nVgplTLBHoM4M3Mt85dK12CXIMGn+F8ZD0CMiWhjBajJyDY5yxijC0Q==
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
@@ -3254,6 +3259,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
+"@types/semver@^7.3.12":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
@@ -3334,6 +3344,14 @@
     "@typescript-eslint/types" "5.33.0"
     "@typescript-eslint/visitor-keys" "5.33.0"
 
+"@typescript-eslint/scope-manager@5.42.0":
+  version "5.42.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.42.0.tgz#e1f2bb26d3b2a508421ee2e3ceea5396b192f5ef"
+  integrity sha512-l5/3IBHLH0Bv04y+H+zlcLiEMEMjWGaCX6WyHE5Uk2YkSGAMlgdUPsT/ywTSKgu9D1dmmKMYgYZijObfA39Wow==
+  dependencies:
+    "@typescript-eslint/types" "5.42.0"
+    "@typescript-eslint/visitor-keys" "5.42.0"
+
 "@typescript-eslint/type-utils@5.33.0":
   version "5.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz#92ad1fba973c078d23767ce2d8d5a601baaa9338"
@@ -3348,6 +3366,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.33.0.tgz#d41c584831805554b063791338b0220b613a275b"
   integrity sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==
 
+"@typescript-eslint/types@5.42.0":
+  version "5.42.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.42.0.tgz#5aeff9b5eced48f27d5b8139339bf1ef805bad7a"
+  integrity sha512-t4lzO9ZOAUcHY6bXQYRuu+3SSYdD9TS8ooApZft4WARt4/f2Cj/YpvbTe8A4GuhT4bNW72goDMOy7SW71mZwGw==
+
 "@typescript-eslint/typescript-estree@5.33.0":
   version "5.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz#02d9c9ade6f4897c09e3508c27de53ad6bfa54cf"
@@ -3361,7 +3384,20 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.33.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.10.2":
+"@typescript-eslint/typescript-estree@5.42.0":
+  version "5.42.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.0.tgz#2592d24bb5f89bf54a63384ff3494870f95b3fd8"
+  integrity sha512-2O3vSq794x3kZGtV7i4SCWZWCwjEtkWfVqX4m5fbUBomOsEOyd6OAD1qU2lbvV5S8tgy/luJnOYluNyYVeOTTg==
+  dependencies:
+    "@typescript-eslint/types" "5.42.0"
+    "@typescript-eslint/visitor-keys" "5.42.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.33.0", "@typescript-eslint/utils@^5.10.2":
   version "5.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.33.0.tgz#46797461ce3146e21c095d79518cc0f8ec574038"
   integrity sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==
@@ -3373,12 +3409,34 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/utils@^5.10.0":
+  version "5.42.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.42.0.tgz#f06bd43b9a9a06ed8f29600273240e84a53f2f15"
+  integrity sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.42.0"
+    "@typescript-eslint/types" "5.42.0"
+    "@typescript-eslint/typescript-estree" "5.42.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+    semver "^7.3.7"
+
 "@typescript-eslint/visitor-keys@5.33.0":
   version "5.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz#fbcbb074e460c11046e067bc3384b5d66b555484"
   integrity sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==
   dependencies:
     "@typescript-eslint/types" "5.33.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.42.0":
+  version "5.42.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.0.tgz#ee8d62d486f41cfe646632fab790fbf0c1db5bb0"
+  integrity sha512-QHbu5Hf/2lOEOwy+IUw0GoSCuAzByTAWWrOTKzTzsotiUnWFpuKnXcAhC9YztAf2EElQ0VvIK+pHJUPkM0q7jg==
+  dependencies:
+    "@typescript-eslint/types" "5.42.0"
     eslint-visitor-keys "^3.3.0"
 
 "@web/browser-logs@^0.2.1", "@web/browser-logs@^0.2.2":
@@ -6124,9 +6182,9 @@ eslint-plugin-import@^2.18.2, eslint-plugin-import@^2.25.3:
     tsconfig-paths "^3.12.0"
 
 eslint-plugin-jest@^25.3.0, eslint-plugin-jest@^26.0.0:
-  version "26.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.0.0.tgz#f83a25a23ab90ce5b375b1d44389b8c391be5ce8"
-  integrity sha512-Fvs0YgJ/nw9FTrnqTuMGVrkozkd07jkQzWm0ajqyHlfcsdkxGfAuv30fgfWHOnHiCr9+1YQ365CcDX7vrNhqQg==
+  version "26.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.9.0.tgz#7931c31000b1c19e57dbfb71bbf71b817d1bf949"
+  integrity sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/issues/4885 (progress)

## Description

Extracted from https://github.com/Agoric/agoric-sdk/pull/6537

Changes isolated by commit to make review easier.

Note that this omits `test` from tsconfig so that `checkJs` can be enabled. Only one test file has `ts-check` so it's not much loss. To add `test` back in with `checkJs` would require fixing the "Found 938 errors in 76 files" or adding `@ts-nocheck` in files that aren't deemed worthy to fix (e.g. 161 errors in `test-liveslots.js`).

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

CI