### PR TITLE
chore(deps): update `source-map@^0.7.3` to 0.7.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11931,9 +11931,9 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 sourcemap-codec@^1.4.4:
   version "1.4.6"


### PR DESCRIPTION
Refs: #6489 

## Description

The `source-map@0.7.4` update is important for enabling Node.js v18 compatibility. Older versions use a `typeof fetch === 'function'` check to enable browser-specific behavior. With this release however, the browser check is moved to whether `window` is defined and matches `this` value at check time. Node.js 18 has a `fetch` function, so older `source-map` versions incorrectly flag it as 'browser'. None of Node.js versions have a `this === window` situation going on.

This is a change on the path to Node.js 18 compatibility route, in anticipation of #6489 offering official support down the line.

Refs: mozilla/source-map@48f90d548f7e94ee6331e1862ca7ea2673ae9e57 

### Security Considerations

Assuming existing dependency ranges are assumed to be secure, this is not applicable.

### Documentation Considerations

N/A. No changes to user are expected, as the internal update is a semver patch.

### Testing Considerations

Existing regression testing cases apply here, as no new functionality is being introduced.
