### PR TITLE
fix npm prepack

### DIFF
--- a/packages/ERTP/jsconfig.json
+++ b/packages/ERTP/jsconfig.json
@@ -12,8 +12,6 @@
     ]
   },
   "include": [
-    "*.js",
-    "*.ts",
     "src/**/*.js",
     "src/**/*.ts",
     "test"

--- a/packages/SwingSet/jsconfig.json
+++ b/packages/SwingSet/jsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "node",
   },
   "include": [
-    "exported.js",
     "lib/**/*.js",
     "src/**/*.js",
     "src/**/*.ts",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -59,6 +59,7 @@
   "files": [
     "bin/vat",
     "src/**/*.js",
+    "src/**/*.d.ts",
     "exported.js",
     "tools"
   ],

--- a/packages/SwingSet/src/vats/timer/types.js
+++ b/packages/SwingSet/src/vats/timer/types.js
@@ -1,0 +1,2 @@
+// Empty JS file to correspond with types.d.ts
+export {};

--- a/packages/access-token/jsconfig.json
+++ b/packages/access-token/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -16,7 +15,6 @@
     "moduleResolution": "node",
   },
   "include": [
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js"
   ]

--- a/packages/assert/jsconfig.json
+++ b/packages/assert/jsconfig.json
@@ -15,5 +15,7 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js"],
+  "include": [
+    "src/**/*.js",
+  ],
 }

--- a/packages/cosmic-swingset/jsconfig.json
+++ b/packages/cosmic-swingset/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -17,7 +16,6 @@
   },
   "include": [
     "calc-*.js",
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js",
   ],

--- a/packages/deployment/jsconfig.json
+++ b/packages/deployment/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -16,7 +15,6 @@
     "moduleResolution": "node",
   },
   "include": [
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js"
   ]

--- a/packages/governance/jsconfig.build.json
+++ b/packages/governance/jsconfig.build.json
@@ -7,6 +7,7 @@
         "declarationMap": true
     },
     "exclude": [
-        "test/"
+        "scripts",
+        "test/",
     ]
 }

--- a/packages/governance/src/index.js
+++ b/packages/governance/src/index.js
@@ -1,5 +1,9 @@
+// Ambient types. https://github.com/Agoric/agoric-sdk/issues/6512
+import '@agoric/swingset-vat/src/vats/network/types.js';
+import '@agoric/ertp/exported.js';
+import '@agoric/zoe/exported.js';
+
 import './types.js';
-import '@agoric/vats/src/core/types.js';
 
 export {
   ChoiceMethod,

--- a/packages/inter-protocol/jsconfig.json
+++ b/packages/inter-protocol/jsconfig.json
@@ -10,7 +10,6 @@
     "moduleResolution": "node",
   },
   "include": [
-    "exported.js",
     "globals.d.ts",
     "scripts/**/*.js",
     "src/**/*.js",

--- a/packages/notifier/jsconfig.json
+++ b/packages/notifier/jsconfig.json
@@ -10,8 +10,6 @@
     "moduleResolution": "node",
   },
   "include": [
-    "exports.js",
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js",
     "tools/**/*.js",

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -445,6 +445,7 @@ const behavior = {
      *
      * @param {import('@endo/marshal').CapData<string>} actionCapData of type BridgeAction
      * @param {boolean} [canSpend=false]
+     * @returns {Promise<void>}
      */
     handleBridgeAction(actionCapData, canSpend = false) {
       const { publicMarshaller } = this.state;
@@ -472,11 +473,11 @@ const behavior = {
     getOffersFacet() {
       return this.facets.offers;
     },
-
+    /** @returns {StoredSubscriber<CurrentWalletRecord>} */
     getCurrentSubscriber() {
       return this.state.currentPublishKit.subscriber;
     },
-
+    /** @returns {StoredSubscriber<UpdateRecord>} */
     getUpdatesSubscriber() {
       /** @type {{state: State}} */
       // @ts-expect-error

--- a/packages/solo/jsconfig.json
+++ b/packages/solo/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -16,7 +15,6 @@
     "moduleResolution": "node",
   },
   "include": [
-    "exported.js",
     "public/**/*.js",
     "src/**/*.js",
     "test/**/*.js",

--- a/packages/sparse-ints/jsconfig.json
+++ b/packages/sparse-ints/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -16,7 +15,6 @@
     "moduleResolution": "node",
   },
   "include": [
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js"
   ]

--- a/packages/stat-logger/jsconfig.json
+++ b/packages/stat-logger/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -16,7 +15,6 @@
     "moduleResolution": "node",
   },
   "include": [
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js"
   ]

--- a/packages/store/jsconfig.json
+++ b/packages/store/jsconfig.json
@@ -10,7 +10,6 @@
     "moduleResolution": "node",
   },
   "include": [
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js",
   ],

--- a/packages/swing-store/jsconfig.json
+++ b/packages/swing-store/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -15,7 +14,6 @@
     "moduleResolution": "node",
   },
   "include": [
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js",
   ],

--- a/packages/ui-components/jsconfig.json
+++ b/packages/ui-components/jsconfig.json
@@ -16,5 +16,9 @@
     "moduleResolution": "node",
     "jsx": "react",
   },
-  "include": ["src/**/*.js", "src/**/*.jsx", "test/**/*.js", "exported.js"],
+  "include": [
+    "src/**/*.js",
+    "src/**/*.jsx",
+    "test/**/*.js",
+  ],
 }

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -7,6 +7,9 @@ import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
 import { makeStorageNodeChild } from '../lib-chainStorage.js';
 import { Stable } from '../tokens.js';
 
+// Ambient types (globals)
+import '@agoric/swingset-vat/src/vats/timer/types.js';
+
 /**
  * @param {ERef<ZoeService>} zoe
  * @param {Installation<import('@agoric/smart-wallet/src/walletFactory').start>} inst

--- a/packages/web-components/jsconfig.json
+++ b/packages/web-components/jsconfig.json
@@ -17,7 +17,6 @@
   },
   "include": [
     "*.js",
-    "exported.js",
     "src/**/*.js",
     "test/**/*.js",
   ],

--- a/packages/zoe/jsconfig.json
+++ b/packages/zoe/jsconfig.json
@@ -10,7 +10,6 @@
   },
   "include": [
     "contractFacet.js",
-    "exported.js",
     "scripts/**/*.js",
     "src/**/*.js",
     "src/**/*.ts",

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -5,7 +5,6 @@ import { assertKey, assertPattern, fit, isKey } from '@agoric/store';
 import { FullProposalShape } from './typeGuards.js';
 import { arrayToObj } from './objArrayConversion.js';
 
-import '../exported.js';
 import './internal-types.js';
 
 const { ownKeys } = Reflect;

--- a/packages/zoe/src/contractFacet/rightsConservation.js
+++ b/packages/zoe/src/contractFacet/rightsConservation.js
@@ -2,7 +2,6 @@ import { makeStore } from '@agoric/store';
 import { assert, details as X } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 
-import '../../exported.js';
 import '../internal-types.js';
 
 /**

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -81,7 +81,7 @@
  *
  * @param {ERef<Issuer>} issuerP Promise for issuer
  * @param {Keyword} keyword Keyword for added issuer
- * @returns {Promise<IssuerRecord<K>>} Issuer is added and ready
+ * @returns {Promise<IssuerRecord<*>>} Issuer is added and ready
  */
 
 /**

--- a/packages/zoe/src/contractFacet/vatRoot.js
+++ b/packages/zoe/src/contractFacet/vatRoot.js
@@ -8,7 +8,6 @@
 import { Far } from '@endo/marshal';
 import { E } from '@endo/far';
 
-import '../../exported.js';
 import '../internal-types.js';
 
 import { makeZCFZygote } from './zcfZygote.js';

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -10,7 +10,6 @@ import { coerceAmountKeywordRecord } from '../cleanProposal.js';
 import { makeIssuerRecord } from '../issuerRecord.js';
 import { addToAllocation, subtractFromAllocation } from './allocationMath.js';
 
-import '../../exported.js';
 import '../internal-types.js';
 import './internal-types.js';
 import './types.js';

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -21,7 +21,6 @@ import { handlePKitWarning } from '../handleWarning.js';
 import { makeOfferHandlerStorage } from './offerHandlerStorage.js';
 import { makeZCFMintFactory } from './zcfMint.js';
 
-import '../../exported.js';
 import '../internal-types.js';
 import './internal-types.js';
 

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -7,8 +7,6 @@ import { makePromiseKit } from '@endo/promise-kit';
 import { AmountMath } from '@agoric/ertp';
 import { makeNotifier } from '@agoric/notifier';
 
-import '../../exported.js';
-
 /**
  * @callback CompareAmount
  * @param {Amount} amount

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -1,5 +1,3 @@
-import '../../exported.js';
-
 import { fit, keyEQ } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -5,8 +5,6 @@ import {
   assertProposalShape,
 } from '../contractSupport/index.js';
 
-import '../../exported.js';
-
 /**
  * Trade one item for another.
  * https://agoric.com/documentation/zoe/guide/contracts/atomic-swap.html

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -1,7 +1,5 @@
 import { Far } from '@endo/marshal';
 
-import '../../exported.js';
-
 /**
  * This is a very trivial contract to explain and test Zoe.
  * AutomaticRefund just gives you back what you put in.

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -13,8 +13,6 @@ import {
   calcSecondaryRequired,
 } from '../contractSupport/index.js';
 
-import '../../exported.js';
-
 /**
  * Autoswap is a rewrite of Uniswap. Please see the documentation for
  * more https://agoric.com/documentation/zoe/guide/contracts/autoswap.html

--- a/packages/zoe/src/contracts/barterExchange.js
+++ b/packages/zoe/src/contracts/barterExchange.js
@@ -1,7 +1,5 @@
 import { Far } from '@endo/marshal';
 import { makeLegacyMap } from '@agoric/store';
-import '../../exported.js';
-
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import { satisfies } from '../contractSupport/index.js';
 

--- a/packages/zoe/src/contracts/callSpread/calculateShares.js
+++ b/packages/zoe/src/contracts/callSpread/calculateShares.js
@@ -1,4 +1,3 @@
-import '../../../exported.js';
 import './types.js';
 
 import { AmountMath, isNatValue } from '@agoric/ertp';

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -1,4 +1,3 @@
-import '../../../exported.js';
 import './types.js';
 
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -1,4 +1,3 @@
-import '../../../exported.js';
 import './types.js';
 
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -1,4 +1,3 @@
-import '../../../exported.js';
 import './types.js';
 
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -1,6 +1,4 @@
 import { fit, M } from '@agoric/store';
-import '../../exported.js';
-
 import { vivifyKind, vivifySingleton } from '@agoric/vat-data';
 import { swapExact } from '../contractSupport/index.js';
 import { isAfterDeadlineExitRule } from '../typeGuards.js';

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -1,6 +1,4 @@
 import { M, fit } from '@agoric/store';
-import '../../exported.js';
-
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import { swapExact } from '../contractSupport/index.js';
 import { isAfterDeadlineExitRule } from '../typeGuards.js';

--- a/packages/zoe/src/contracts/loan/addCollateral.js
+++ b/packages/zoe/src/contracts/loan/addCollateral.js
@@ -1,5 +1,3 @@
-import '../../../exported.js';
-
 import { assertProposalShape } from '../../contractSupport/index.js';
 
 import { scheduleLiquidation } from './scheduleLiquidation.js';

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -1,5 +1,3 @@
-import '../../../exported.js';
-
 import { assert, details as X } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';

--- a/packages/zoe/src/contracts/loan/index.js
+++ b/packages/zoe/src/contracts/loan/index.js
@@ -1,5 +1,3 @@
-import '../../../exported.js';
-
 import { Nat } from '@agoric/nat';
 
 import {

--- a/packages/zoe/src/contracts/loan/lend.js
+++ b/packages/zoe/src/contracts/loan/lend.js
@@ -1,5 +1,3 @@
-import '../../../exported.js';
-
 import { assertProposalShape } from '../../contractSupport/index.js';
 import { makeBorrowInvitation } from './borrow.js';
 

--- a/packages/zoe/src/contracts/loan/liquidate.js
+++ b/packages/zoe/src/contracts/loan/liquidate.js
@@ -1,5 +1,3 @@
-import '../../../exported.js';
-
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
 

--- a/packages/zoe/src/contracts/loan/scheduleLiquidation.js
+++ b/packages/zoe/src/contracts/loan/scheduleLiquidation.js
@@ -1,5 +1,3 @@
-import '../../../exported.js';
-
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
 

--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -1,4 +1,3 @@
-import '../../../exported.js';
 import { Far } from '@endo/marshal';
 import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -2,7 +2,6 @@ import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 
-import '../../exported.js';
 import { assert } from '@agoric/assert';
 
 /**

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -1,8 +1,6 @@
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 
-import '../../exported.js';
-
 /**
  * This is a very simple contract that creates a new issuer and mints payments
  * from it, in order to give an example of how that can be done.  This contract

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -2,8 +2,6 @@ import { assert, details as X } from '@agoric/assert';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 
-import '../../exported.js';
-
 import { E } from '@endo/eventual-send';
 
 /**

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -7,8 +7,6 @@ import {
   assertProposalShape,
 } from '../contractSupport/index.js';
 
-import '../../exported.js';
-
 /**
  * This contract is inspired by the description of an OTC Desk smart
  * contract in this article:

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -9,8 +9,6 @@ import {
   assertNatAssetKind,
 } from '../contractSupport/index.js';
 
-import '../../exported.js';
-
 const { details: X } = assert;
 
 /**

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -1,7 +1,6 @@
 import { makeNotifierKit } from '@agoric/notifier';
 import { Far } from '@endo/marshal';
 
-import '../../exported.js';
 import {
   swap,
   satisfies,

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -7,7 +7,6 @@ import { makeInvitationQueryFns } from '../invitationQueries.js';
 
 import '@agoric/ertp/exported.js';
 import '@agoric/store/exported.js';
-import '../../../exported.js';
 import '../internal-types.js';
 
 const { details: X, quote: q } = assert;

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -71,7 +71,7 @@
 /**
  * @callback GetPublicFacet
  * @param {ERef<Instance>} instanceP
- * @returns {Promise<object>}
+ * @returns {Promise<any>}
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -12,7 +12,6 @@ import '@agoric/ertp/exported.js';
 import '@agoric/store/exported.js';
 import '@agoric/vats/exported.js';
 
-import '../../exported.js';
 import '../internal-types.js';
 
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -6,8 +6,6 @@ import {
   assertProposalShape,
 } from '../../../src/contractSupport/index.js';
 
-import '../../../exported.js';
-
 /**
  * This is an atomic swap contract to test Zoe handling contract failures.
  *

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -1,6 +1,4 @@
 import { M, fit } from '@agoric/store';
-import '../../../exported.js';
-
 import { vivifyFarClass, vivifyFarInstance } from '@agoric/vat-data';
 import { swapExact } from '../../../src/contractSupport/index.js';
 import {

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -10,8 +10,6 @@ import {
   assertNatAssetKind,
 } from '../../../src/contractSupport/index.js';
 
-import '../../../exported.js';
-
 const { details: X, quote: q } = assert;
 
 /**

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -12,8 +12,6 @@ import {
   scaleForAddLiquidity,
   updatePoolState,
 } from '../../autoswapJig.js';
-import '../../../exported.js';
-
 import { setup } from '../setupBasicMints.js';
 import { installationPFromSource } from '../installFromSource.js';
 import { assertOfferResult, assertPayoutAmount } from '../../zoeTestHelpers.js';

--- a/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import '../../../exported.js';
-
 import { setup } from '../setupBasicMints.js';
 import { calculateShares } from '../../../src/contracts/callSpread/calculateShares.js';
 import {

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -4,7 +4,6 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import path from 'path';
 
 import { E } from '@endo/eventual-send';
-import '../../../exported.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { eventLoopIteration } from '../../../tools/eventLoopIteration.js';
 

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -13,7 +13,6 @@ import { E } from '@endo/eventual-send';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
-import '../../../exported.js';
 import '../../../src/contracts/exported.js';
 
 /**

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -20,7 +20,6 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { eventLoopIteration } from '../../../tools/eventLoopIteration.js';
 
-import '../../../exported.js';
 import '../../../src/contracts/exported.js';
 import {
   addRatios,

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -14,7 +14,6 @@ import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 
-import '../../../exported.js';
 import '../../../src/contracts/exported.js';
 
 /** @type {import('ava').TestFn<any>} */

--- a/packages/zoe/test/unitTests/contracts/test-scaledPriceAuthority.js
+++ b/packages/zoe/test/unitTests/contracts/test-scaledPriceAuthority.js
@@ -14,7 +14,6 @@ import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { makeManualPriceAuthority } from '../../../tools/manualPriceAuthority.js';
 
-import '../../../exported.js';
 import '../../../src/contracts/exported.js';
 
 /**

--- a/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
@@ -1,5 +1,3 @@
-import '../../../exported.js';
-
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import { Far } from '@endo/marshal';
 

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -12,7 +12,6 @@ import { assert } from '@agoric/assert';
 import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
 
-import '../../exported.js';
 import '../../src/contracts/exported.js';
 import buildManualTimer from '../../tools/manualTimer.js';
 import { eventLoopIteration } from '../../tools/eventLoopIteration.js';

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
@@ -11,8 +11,6 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
-import '../../../exported.js';
-
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -10,8 +10,6 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
-import '../../../exported.js';
-
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
 

--- a/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
@@ -1,4 +1,3 @@
-import '../../../exported.js';
 import { Far } from '@endo/far';
 
 /**

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -1,6 +1,5 @@
 import { E } from '@endo/eventual-send';
 
-import '../exported.js';
 import { AmountMath, assertValueGetHelpers } from '@agoric/ertp';
 
 import { q } from '@agoric/assert';

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -11,7 +11,6 @@ import { TimeMath } from '@agoric/swingset-vat/src/vats/timer/timeMath.js';
 import { natSafeMath } from '../src/contractSupport/index.js';
 
 import './types.js';
-import '../exported.js';
 
 const { details: X } = assert;
 


### PR DESCRIPTION
## Description

Now that packages do `tsc --build` in their `prepack`, [governance is failing to pack and publish](https://github.com/Agoric/agoric-sdk/actions/runs/3464380814/jobs/5785901498). 

The problem is that some builds were making `exported.d.ts` which prevents the propagation of ambient types. This PR stops tsc builds from creating `exported.d.ts` by omitting it from configs _and_ hunting down transitive imports.


### Security Considerations

n/a

### Documentation Considerations

Some tribal knowledge in ensuring that `exported.d.ts` aren't built. Maybe this git blame to this PR suffices.

### Testing Considerations

Only master builds do the publish step that was failing, so I tested locally by running `yarn prepack` in each of these packages in the order they are in the failing CI job:

1. `internal`
2. `ertp`
3. `zoe`
4. `governance`
