### PR TITLE
fix: use atomicTransfers rather than stagings.

### DIFF
--- a/packages/inter-protocol/src/collectFees.js
+++ b/packages/inter-protocol/src/collectFees.js
@@ -1,3 +1,5 @@
+import { atomicTransfer } from '@agoric/zoe/src/contractSupport';
+
 /**
  * Provide shared support for providing access to fees from a service contract.
  *
@@ -14,9 +16,10 @@ export const makeMakeCollectFeesInvitation = (
 ) => {
   const collectFees = seat => {
     const amount = feeSeat.getAmountAllocated(keyword, feeBrand);
-    feeSeat.decrementBy(harden({ [keyword]: amount }));
-    seat.incrementBy(harden({ Fee: amount }));
-    zcf.reallocate(seat, feeSeat);
+    atomicTransfer(
+      zcf,
+      harden([[feeSeat, seat, { [keyword]: amount }, { Fee: amount }]]),
+    );
 
     seat.exit();
     return `paid out ${amount.value}`;

--- a/packages/inter-protocol/src/collectFees.js
+++ b/packages/inter-protocol/src/collectFees.js
@@ -16,10 +16,7 @@ export const makeMakeCollectFeesInvitation = (
 ) => {
   const collectFees = seat => {
     const amount = feeSeat.getAmountAllocated(keyword, feeBrand);
-    atomicTransfer(
-      zcf,
-      harden([[feeSeat, seat, { [keyword]: amount }, { Fee: amount }]]),
-    );
+    atomicTransfer(zcf, feeSeat, seat, { [keyword]: amount }, { Fee: amount });
 
     seat.exit();
     return `paid out ${amount.value}`;

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -46,7 +46,7 @@ export const assertOnlyKeys = (proposal, keys) => {
  * the gain and a loss on the `fromSeat`. The gain/loss are typically from the
  * give/want respectively of a proposal. The `key` is the allocation keyword.
  *
- * @deprecated Use atomicTransfer instead
+ * @deprecated Use atomicRearrange instead
  * @param {ZCFSeat} fromSeat
  * @param {ZCFSeat} toSeat
  * @param {Amount} fromLoses

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -46,6 +46,7 @@ export const assertOnlyKeys = (proposal, keys) => {
  * the gain and a loss on the `fromSeat`. The gain/loss are typically from the
  * give/want respectively of a proposal. The `key` is the allocation keyword.
  *
+ * @deprecated Use atomicTransfer instead
  * @param {ZCFSeat} fromSeat
  * @param {ZCFSeat} toSeat
  * @param {Amount} fromLoses

--- a/packages/inter-protocol/src/interchainPool.js
+++ b/packages/inter-protocol/src/interchainPool.js
@@ -90,7 +90,7 @@ export const start = (zcf, { bankManager }) => {
         },
       });
 
-      atomicTransfer(zcf, harden([[seat, seat2, { Central: centralAmt }]]));
+      atomicTransfer(zcf, seat, seat2, { Central: centralAmt });
 
       const invitation = await E(ammPub).addPoolInvitation();
       const { userSeatPromise, deposited } = await offerTo(

--- a/packages/inter-protocol/src/interchainPool.js
+++ b/packages/inter-protocol/src/interchainPool.js
@@ -1,6 +1,9 @@
 import { E, Far } from '@endo/far';
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
-import { offerTo } from '@agoric/zoe/src/contractSupport/index.js';
+import {
+  offerTo,
+  atomicTransfer,
+} from '@agoric/zoe/src/contractSupport/index.js';
 import { MIN_INITIAL_POOL_LIQUIDITY_KEY } from './vpool-xyk-amm/params.js';
 
 const { Fail, quote: q } = assert;
@@ -87,8 +90,7 @@ export const start = (zcf, { bankManager }) => {
         },
       });
 
-      seat2.incrementBy(seat.decrementBy(harden({ Central: centralAmt })));
-      zcf.reallocate(seat, seat2);
+      atomicTransfer(zcf, harden([[seat, seat2, { Central: centralAmt }]]));
 
       const invitation = await E(ammPub).addPoolInvitation();
       const { userSeatPromise, deposited } = await offerTo(

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -7,7 +7,7 @@ import {
   ceilMultiplyBy,
   floorDivideBy,
   floorMultiplyBy,
-  atomicTransfer,
+  atomicRearrange,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { Far } from '@endo/marshal';
 import {
@@ -163,7 +163,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     const maxAnchor = floorMultiplyBy(afterFee, anchorPerMinted);
     AmountMath.isGTE(maxAnchor, wanted) ||
       Fail`wanted ${wanted} is more than ${given} minus fees ${fee}`;
-    atomicTransfer(
+    atomicRearrange(
       zcf,
       harden([
         [seat, stage, { In: afterFee }, { Minted: afterFee }],
@@ -173,7 +173,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     );
     // The treatment of `burnMinted` here is different than the
     // one immediately below. This `burnMinted`
-    // happen only if the `atomicTransfer` does *not* throw.
+    // happen only if the `atomicRearrange` does *not* throw.
     burnMinted(afterFee);
     totalAnchorProvided = AmountMath.add(totalAnchorProvided, maxAnchor);
   };
@@ -192,7 +192,7 @@ export const start = async (zcf, privateArgs, baggage) => {
       Fail`wanted ${wanted} is more than ${given} minus fees ${fee}`;
     mintMinted(asStable);
     try {
-      atomicTransfer(
+      atomicRearrange(
         zcf,
         harden([
           [seat, anchorPool, { In: given }, { Anchor: given }],
@@ -203,7 +203,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     } catch (e) {
       // The treatment of `burnMinted` here is different than the
       // one immediately above. This `burnMinted`
-      // happens only if the `atomicTransfer` *does* throw.
+      // happens only if the `atomicRearrange` *does* throw.
       burnMinted(asStable);
       throw e;
     }

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -259,14 +259,10 @@ const start = async (zcf, privateArgs, baggage) => {
 
     atomicTransfer(
       zcf,
-      harden([
-        [
-          seat,
-          collateralSeat,
-          { Collateral: amountIn },
-          { [collateralKeyword]: amountIn },
-        ],
-      ]),
+      seat,
+      collateralSeat,
+      { Collateral: amountIn },
+      { [collateralKeyword]: amountIn },
     );
     seat.exit();
 
@@ -344,12 +340,9 @@ const start = async (zcf, privateArgs, baggage) => {
     const offerToSeat = feeMint.mintGains(harden({ Fee: fee }));
     state.totalFeeMinted = AmountMath.add(state.totalFeeMinted, fee);
 
-    atomicTransfer(
-      zcf,
-      harden([
-        [collateralSeat, offerToSeat, { [collateralKeyword]: collateral }],
-      ]),
-    );
+    atomicTransfer(zcf, collateralSeat, offerToSeat, {
+      [collateralKeyword]: collateral,
+    });
 
     // Add Fee tokens and collateral to the AMM
     const invitation = await E(
@@ -379,14 +372,10 @@ const start = async (zcf, privateArgs, baggage) => {
 
     atomicTransfer(
       zcf,
-      harden([
-        [
-          offerToSeat,
-          collateralSeat,
-          { Liquidity: liquidityAmount.Liquidity },
-          { [liquidityKeyword]: liquidityAmount.Liquidity },
-        ],
-      ]),
+      offerToSeat,
+      collateralSeat,
+      { Liquidity: liquidityAmount.Liquidity },
+      { [liquidityKeyword]: liquidityAmount.Liquidity },
     );
     updateMetrics({ state });
   };

--- a/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -322,10 +322,7 @@ const start = async zcf => {
     const penaltyPaid = AmountMath.min(penalty, debtPaid);
 
     // Allocate penalty portion of proceeds to a seat that will hold it for transfer to reserve
-    atomicTransfer(
-      zcf,
-      harden([[debtorSeat, penaltyPoolSeat, { Out: penaltyPaid }]]),
-    );
+    atomicTransfer(zcf, debtorSeat, penaltyPoolSeat, { Out: penaltyPaid });
 
     debtorSeat.exit();
     trace('exit seat');

--- a/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -7,6 +7,7 @@ import {
   natSafeMath as NatMath,
   ceilMultiplyBy,
   oneMinus,
+  atomicTransfer,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { AmountMath } from '@agoric/ertp';
 import { Far } from '@endo/marshal';
@@ -321,10 +322,10 @@ const start = async zcf => {
     const penaltyPaid = AmountMath.min(penalty, debtPaid);
 
     // Allocate penalty portion of proceeds to a seat that will hold it for transfer to reserve
-    penaltyPoolSeat.incrementBy(
-      debtorSeat.decrementBy(harden({ Out: penaltyPaid })),
+    atomicTransfer(
+      zcf,
+      harden([[debtorSeat, penaltyPoolSeat, { Out: penaltyPaid }]]),
     );
-    zcf.reallocate(penaltyPoolSeat, debtorSeat);
 
     debtorSeat.exit();
     trace('exit seat');

--- a/packages/inter-protocol/src/vaultFactory/liquidateMinimum.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateMinimum.js
@@ -2,6 +2,7 @@ import { E } from '@endo/eventual-send';
 import {
   ceilMultiplyBy,
   offerTo,
+  atomicTransfer,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { AmountMath } from '@agoric/ertp';
 import { Far } from '@endo/marshal';
@@ -73,10 +74,10 @@ const start = async zcf => {
     const penaltyPaid = AmountMath.min(penalty, debtPaid);
 
     // Allocate penalty portion of proceeds to a seat that will hold it for transfer to reserve
-    penaltyPoolSeat.incrementBy(
-      debtorSeat.decrementBy(harden({ Out: penaltyPaid })),
+    atomicTransfer(
+      zcf,
+      harden([[debtorSeat, penaltyPoolSeat, { Out: penaltyPaid }]]),
     );
-    zcf.reallocate(penaltyPoolSeat, debtorSeat);
 
     debtorSeat.exit();
   };

--- a/packages/inter-protocol/src/vaultFactory/liquidateMinimum.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateMinimum.js
@@ -74,10 +74,7 @@ const start = async zcf => {
     const penaltyPaid = AmountMath.min(penalty, debtPaid);
 
     // Allocate penalty portion of proceeds to a seat that will hold it for transfer to reserve
-    atomicTransfer(
-      zcf,
-      harden([[debtorSeat, penaltyPoolSeat, { Out: penaltyPaid }]]),
-    );
+    atomicTransfer(zcf, debtorSeat, penaltyPoolSeat, { Out: penaltyPaid });
 
     debtorSeat.exit();
   };

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -399,10 +399,7 @@ const helperBehavior = {
         Fail`Offer ${given} is not sufficient to pay off debt ${debt}`;
 
       // Return any overpayment
-      atomicTransfer(
-        zcf,
-        harden([[vaultSeat, seat, vaultSeat.getCurrentAllocation()]]),
-      );
+      atomicTransfer(zcf, vaultSeat, seat, vaultSeat.getCurrentAllocation());
 
       state.manager.burnAndRecord(debt, seat);
     } else if (phase === Phase.LIQUIDATED) {
@@ -410,10 +407,7 @@ const helperBehavior = {
       // Don't take anything from the offer, even if vault is underwater.
       // TODO verify that returning Minted here doesn't mess up debt limits
 
-      atomicTransfer(
-        zcf,
-        harden([[vaultSeat, seat, vaultSeat.getCurrentAllocation()]]),
-      );
+      atomicTransfer(zcf, vaultSeat, seat, vaultSeat.getCurrentAllocation());
     } else {
       throw new Error('only active and liquidated vaults can be closed');
     }

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -538,16 +538,9 @@ const helperBehavior = {
           // it. We could hold it until it crosses some threshold, then sell it
           // to the AMM, or we could transfer it to the reserve. At least it's
           // visible in the accounting.
-          atomicTransfer(
-            zcf,
-            harden([
-              [
-                vaultSeat,
-                state.retainedCollateralSeat,
-                { Collateral: collateralPost },
-              ],
-            ]),
-          );
+          atomicTransfer(zcf, vaultSeat, state.retainedCollateralSeat, {
+            Collateral: collateralPost,
+          });
         }
 
         // Reduce totalCollateral by collateralPre, since all the collateral was

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -31,6 +31,7 @@ import {
   getAmountOut,
   makeRatio,
   makeRatioFromAmounts,
+  atomicTransfer,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
@@ -537,12 +538,16 @@ const helperBehavior = {
           // it. We could hold it until it crosses some threshold, then sell it
           // to the AMM, or we could transfer it to the reserve. At least it's
           // visible in the accounting.
-          vaultSeat.decrementBy(
-            state.retainedCollateralSeat.incrementBy({
-              Collateral: collateralPost,
-            }),
+          atomicTransfer(
+            zcf,
+            harden([
+              [
+                vaultSeat,
+                state.retainedCollateralSeat,
+                { Collateral: collateralPost },
+              ],
+            ]),
           );
-          zcf.reallocate(vaultSeat, state.retainedCollateralSeat);
         }
 
         // Reduce totalCollateral by collateralPre, since all the collateral was

--- a/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
@@ -1,6 +1,9 @@
 import { E } from '@endo/eventual-send';
 import { AmountMath, AssetKind } from '@agoric/ertp';
-import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
+import {
+  assertProposalShape,
+  atomicTransfer,
+} from '@agoric/zoe/src/contractSupport/index.js';
 
 import { definePoolKind } from './pool.js';
 
@@ -173,10 +176,19 @@ export const makeAddPoolInvitation = (
     // transfer minPoolLiquidity in tokens from the funder to the reserve.
     helper.addLiquidityInternal(seat, secondaryAmount, centralAmount);
 
-    seat.decrementBy({ Liquidity: minLiqAmount });
     const { zcfSeat: reserveLiquidityTokenSeat } = zcf.makeEmptySeatKit();
-    reserveLiquidityTokenSeat.incrementBy({ [liquidityKeyword]: minLiqAmount });
-    zcf.reallocate(reserveLiquidityTokenSeat, seat);
+    atomicTransfer(
+      zcf,
+      harden([
+        [
+          seat,
+          reserveLiquidityTokenSeat,
+          { Liquidity: minLiqAmount },
+          { [liquidityKeyword]: minLiqAmount },
+        ],
+      ]),
+    );
+
     seat.exit();
     pool.updateState();
 

--- a/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
@@ -179,14 +179,10 @@ export const makeAddPoolInvitation = (
     const { zcfSeat: reserveLiquidityTokenSeat } = zcf.makeEmptySeatKit();
     atomicTransfer(
       zcf,
-      harden([
-        [
-          seat,
-          reserveLiquidityTokenSeat,
-          { Liquidity: minLiqAmount },
-          { [liquidityKeyword]: minLiqAmount },
-        ],
-      ]),
+      seat,
+      reserveLiquidityTokenSeat,
+      { Liquidity: minLiqAmount },
+      { [liquidityKeyword]: minLiqAmount },
     );
 
     seat.exit();

--- a/packages/inter-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/pool.js
@@ -7,7 +7,7 @@ import {
   calcLiqValueToMint,
   calcSecondaryRequired,
   calcValueToRemove,
-  atomicTransfer,
+  atomicRearrange,
 } from '@agoric/zoe/src/contractSupport/index.js';
 
 import { E } from '@endo/eventual-send';
@@ -253,7 +253,7 @@ export const definePoolKind = (baggage, ammPowers, storageNode, marshaller) => {
         ),
       );
 
-      atomicTransfer(
+      atomicRearrange(
         ammPowers.zcf,
         harden([
           [userSeat, poolSeat, { Liquidity: liquidityIn }],

--- a/packages/inter-protocol/src/vpool-xyk-amm/singlePool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/singlePool.js
@@ -24,7 +24,7 @@ export const makeSinglePool = ammPowers => ({
     const { zcf, protocolSeat } = ammPowers;
     const inBrand = prices.swapperGives.brand;
 
-    /** @type {import('@agoric/zoe/src/contractSupport/atomicTransfer.js').TransferArgs[]} */
+    /** @type {import('@agoric/zoe/src/contractSupport/atomicTransfer.js').TransferPart[]} */
     const xfer = harden(
       inBrand === getSecondaryBrand(pool)
         ? [

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -404,37 +404,3 @@ export const assertAllDefined = obj => {
     Fail`missing ${q(missing)}`;
   }
 };
-
-/**
- * @template T
- * @typedef {object} ListAccumulator
- * @property {(value: T) => void} push
- * @property {() => void} clear
- * @property {() => T[]} snapshot
- * @property {() => T[]} takeSnapshot
- */
-
-/**
- * @template {any} T
- * @param {(x: T) => T} coerce
- * @returns {ListAccumulator<T>}
- */
-export const makeListAccumulator = (coerce = x => x) => {
-  /** @type {T[]} */
-  let list = [];
-  return harden({
-    push: value => {
-      list.push(coerce(value));
-    },
-    clear: () => {
-      list = [];
-    },
-    snapshot: () => harden([...list]),
-    takeSnapshot: () => {
-      const result = harden(list);
-      list = [];
-      return result;
-    },
-  });
-};
-harden(makeListAccumulator);

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -404,3 +404,37 @@ export const assertAllDefined = obj => {
     Fail`missing ${q(missing)}`;
   }
 };
+
+/**
+ * @template T
+ * @typedef {object} ListAccumulator
+ * @property {(value: T) => void} push
+ * @property {() => void} clear
+ * @property {() => T[]} snapshot
+ * @property {() => T[]} takeSnapshot
+ */
+
+/**
+ * @template {any} T
+ * @param {(x: T) => T} coerce
+ * @returns {ListAccumulator<T>}
+ */
+export const makeListAccumulator = (coerce = x => x) => {
+  /** @type {T[]} */
+  let list = [];
+  return harden({
+    push: value => {
+      list.push(coerce(value));
+    },
+    clear: () => {
+      list = [];
+    },
+    snapshot: () => harden([...list]),
+    takeSnapshot: () => {
+      const result = harden(list);
+      list = [];
+      return result;
+    },
+  });
+};
+harden(makeListAccumulator);

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -252,14 +252,10 @@ const makePegasus = (zcf, board, namesByAddress) => {
           // Transfer the amount to our backing seat.
           atomicTransfer(
             zcf,
-            harden([
-              [
-                loser,
-                winner,
-                { [loserKeyword]: amount },
-                { [winnerKeyword]: amount },
-              ],
-            ]),
+            loser,
+            winner,
+            { [loserKeyword]: amount },
+            { [winnerKeyword]: amount },
           );
         };
 

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -3,7 +3,10 @@
 import { assert, details as X, Fail } from '@agoric/assert';
 import { makeLegacyWeakMap, makeLegacyMap } from '@agoric/store';
 import { E, Far } from '@endo/far';
-import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
+import {
+  assertProposalShape,
+  atomicTransfer,
+} from '@agoric/zoe/src/contractSupport/index.js';
 import { makeSubscriptionKit } from '@agoric/notifier';
 
 import '@agoric/vats/exported.js';
@@ -247,9 +250,17 @@ const makePegasus = (zcf, board, namesByAddress) => {
           winner,
         ) => {
           // Transfer the amount to our backing seat.
-          loser.decrementBy(harden({ [loserKeyword]: amount }));
-          winner.incrementBy(harden({ [winnerKeyword]: amount }));
-          zcf.reallocate(loser, winner);
+          atomicTransfer(
+            zcf,
+            harden([
+              [
+                loser,
+                winner,
+                { [loserKeyword]: amount },
+                { [winnerKeyword]: amount },
+              ],
+            ]),
+          );
         };
 
         // Describe how to retain/redeem real local erights.

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -1,4 +1,5 @@
 import { Far, assertPassable, passStyleOf } from '@endo/marshal';
+import { getCopyMapEntries, isCopyMap } from '../keys/checkKey.js';
 import { fit, assertPattern } from '../patterns/patternMatchers.js';
 
 const { quote: q, Fail } = assert;
@@ -57,6 +58,9 @@ export const makeWeakMapStoreMethods = (
     },
 
     addAll: entries => {
+      if (isCopyMap(entries)) {
+        entries = getCopyMapEntries(entries);
+      }
       for (const [key, value] of entries) {
         // Don't assert that the key either does or does not exist.
         assertKVOkToAdd(key, value);

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -1,4 +1,5 @@
 import { Far, passStyleOf } from '@endo/marshal';
+import { getCopySetKeys, isCopySet } from '../keys/checkKey.js';
 import { fit, assertPattern } from '../patterns/patternMatchers.js';
 
 const { quote: q, Fail } = assert;
@@ -41,6 +42,9 @@ export const makeWeakSetStoreMethods = (
     },
 
     addAll: keys => {
+      if (isCopySet(keys)) {
+        keys = getCopySetKeys(keys);
+      }
       for (const key of keys) {
         assertKeyOkToAdd(key);
         jsset.add(key);

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -147,7 +147,7 @@
  * allows primitives and remotables.
  * @property {(key: K) => void} delete
  * Remove the key. Throws if not found.
- * @property {(keys: Iterable<K>) => void} addAll
+ * @property {(keys: CopySet<K> | Iterable<K>) => void} addAll
  */
 
 /**
@@ -163,7 +163,7 @@
  * allows primitives and remotables.
  * @property {(key: K) => void} delete
  * Remove the key. Throws if not found.
- * @property {(keys: Iterable<K>) => void} addAll
+ * @property {(keys: CopySet<K> | Iterable<K>) => void} addAll
  * @property {(keyPatt?: Pattern) => Iterable<K>} keys
  * @property {(keyPatt?: Pattern) => Iterable<K>} values
  * @property {(keyPatt?: Pattern) => CopySet<K>} snapshot
@@ -187,7 +187,7 @@
  * Set the key. Throws if not found.
  * @property {(key: K) => void} delete
  * Remove the key. Throws if not found.
- * @property {(entries: Iterable<[K,V]>) => void} addAll
+ * @property {(entries: CopyMap<K,V> | Iterable<[K,V]>) => void} addAll
  */
 
 /**
@@ -206,7 +206,7 @@
  * Set the key. Throws if not found.
  * @property {(key: K) => void} delete
  * Remove the key. Throws if not found.
- * @property {(entries: Iterable<[K,V]>) => void} addAll
+ * @property {(entries: CopyMap<K,V> | Iterable<[K,V]>) => void} addAll
  * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => Iterable<K>} keys
  * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => Iterable<V>} values
  * @property {(

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -22,7 +22,8 @@
  * synchronously from within the contract, and usually is referred to
  * in code as zcf.
  *
- * @property {Reallocate} reallocate - reallocate amounts among seats
+ * @property {Reallocate} reallocate - reallocate amounts among seats.
+ * Deprecated: Use atomicTransfer instead.
  * @property {(keyword: Keyword) => void} assertUniqueKeyword - check
  * whether a keyword is valid and unique and could be added in
  * `saveIssuer`
@@ -193,11 +194,16 @@
  * @property {ZCFGetAmountAllocated} getAmountAllocated
  * @property {() => Allocation} getCurrentAllocation
  * @property {() => Allocation} getStagedAllocation
+ * Deprecated: Use atomicTransfer instead
  * @property {() => boolean} hasStagedAllocation
+ * Deprecated: Use atomicTransfer instead
  * @property {(newAllocation: Allocation) => boolean} isOfferSafe
  * @property {(amountKeywordRecord: AmountKeywordRecord) => AmountKeywordRecord} incrementBy
+ * Deprecated: Use atomicTransfer instead
  * @property {(amountKeywordRecord: AmountKeywordRecord) => AmountKeywordRecord} decrementBy
+ * Deprecated: Use atomicTransfer instead
  * @property {() => void} clear
+ * Deprecated: Use atomicTransfer instead
  */
 
 /**

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -23,7 +23,7 @@
  * in code as zcf.
  *
  * @property {Reallocate} reallocate - reallocate amounts among seats.
- * Deprecated: Use atomicTransfer instead.
+ * Deprecated: Use atomicRearrange instead.
  * @property {(keyword: Keyword) => void} assertUniqueKeyword - check
  * whether a keyword is valid and unique and could be added in
  * `saveIssuer`
@@ -194,16 +194,16 @@
  * @property {ZCFGetAmountAllocated} getAmountAllocated
  * @property {() => Allocation} getCurrentAllocation
  * @property {() => Allocation} getStagedAllocation
- * Deprecated: Use atomicTransfer instead
+ * Deprecated: Use atomicRearrange instead
  * @property {() => boolean} hasStagedAllocation
- * Deprecated: Use atomicTransfer instead
+ * Deprecated: Use atomicRearrange instead
  * @property {(newAllocation: Allocation) => boolean} isOfferSafe
  * @property {(amountKeywordRecord: AmountKeywordRecord) => AmountKeywordRecord} incrementBy
- * Deprecated: Use atomicTransfer instead
+ * Deprecated: Use atomicRearrange instead
  * @property {(amountKeywordRecord: AmountKeywordRecord) => AmountKeywordRecord} decrementBy
- * Deprecated: Use atomicTransfer instead
+ * Deprecated: Use atomicRearrange instead
  * @property {() => void} clear
- * Deprecated: Use atomicTransfer instead
+ * Deprecated: Use atomicRearrange instead
  */
 
 /**

--- a/packages/zoe/src/contractSupport/atomicTransfer.js
+++ b/packages/zoe/src/contractSupport/atomicTransfer.js
@@ -1,0 +1,79 @@
+const { details: X, quote: q } = assert;
+
+/**
+ * @typedef {[
+ *   fromSeat?: ZCFSeat,
+ *   toSeat?: ZCFSeat,
+ *   subtrahend?: AmountKeywordRecord,
+ *   addend?: AmountKeywordRecord
+ * ]} TransferArgs
+ */
+
+/**
+ * TODO Refactor from being a helper into being zcf's replacement for
+ * reallocate. Is currently a helper during the transition, to avoid
+ * interference with progress on Zoe durability.
+ *
+ * @param {ZCF} zcf
+ * @param {TransferArgs[]} transfers
+ */
+export const atomicTransfer = (zcf, transfers) => {
+  const uniqueSeatSet = new Set();
+  for (const [
+    fromSeat = undefined,
+    toSeat = undefined,
+    _subtrahend,
+    _addend,
+  ] of transfers) {
+    fromSeat && uniqueSeatSet.add(fromSeat);
+    toSeat && uniqueSeatSet.add(toSeat);
+  }
+  const uniqueSeats = harden([...uniqueSeatSet.keys()]);
+  for (const seat of uniqueSeats) {
+    !seat.hasStagedAllocation() ||
+      assert.fail(X`Cannot mix atomicTransfer with seat stagings: ${seat}`);
+  }
+
+  try {
+    for (const [
+      fromSeat = undefined,
+      toSeat = undefined,
+      subtrahend = undefined,
+      addend = subtrahend,
+    ] of transfers) {
+      if (fromSeat || subtrahend) {
+        if (!fromSeat) {
+          assert.fail(X`Transfer ${subtrahend} from ? must have a fromSeat`);
+        }
+        if (!subtrahend) {
+          assert.fail(X`Transfer ? from ${fromSeat} must say how much`);
+        }
+        fromSeat.decrementBy(subtrahend);
+      }
+      if (toSeat || addend) {
+        if (!toSeat) {
+          assert.fail(X`Transfer ${addend} into ? must have a toSeat`);
+        }
+        if (!addend) {
+          assert.fail(X`Transfer ? into ${toSeat} must say how much`);
+        }
+        toSeat.incrementBy(addend);
+      }
+    }
+
+    // Perhaps deprecate this >= 2 restriction?
+    uniqueSeats.length >= 2 ||
+      assert.fail(
+        X`Can only commit a reallocation among at least 2 seats: ${q(
+          uniqueSeats.length,
+        )}`,
+      );
+    // Take it apart and put it back together to satisfy the type checker
+    const [seat0, seat1, ...restSeats] = uniqueSeats;
+    zcf.reallocate(seat0, seat1, ...restSeats);
+  } finally {
+    for (const seat of uniqueSeats) {
+      seat.clear();
+    }
+  }
+};

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -21,7 +21,12 @@ export { makeStateMachine } from './stateMachine.js';
 
 export * from './statistics.js';
 
-export { atomicTransfer } from './atomicTransfer.js';
+export {
+  atomicRearrange,
+  atomicTransfer,
+  fromOnly,
+  toOnly,
+} from './atomicTransfer.js';
 
 export {
   defaultAcceptanceMsg,

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -21,6 +21,8 @@ export { makeStateMachine } from './stateMachine.js';
 
 export * from './statistics.js';
 
+export { atomicTransfer } from './atomicTransfer.js';
+
 export {
   defaultAcceptanceMsg,
   swap,
@@ -34,7 +36,6 @@ export {
   withdrawFromSeat,
   saveAllIssuers,
   offerTo,
-  checkZCF,
 } from './zoeHelpers.js';
 
 export {

--- a/packages/zoe/src/contracts/auction/firstPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/firstPriceLogic.js
@@ -1,5 +1,5 @@
 import { AmountMath } from '@agoric/ertp';
-import { atomicTransfer } from '../../contractSupport/index.js';
+import { atomicRearrange } from '../../contractSupport/index.js';
 
 /**
  * @param {ZCF} zcf
@@ -44,7 +44,7 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   }
 
   // Everyone else gets a refund so their values remain the same.
-  atomicTransfer(
+  atomicRearrange(
     zcf,
     harden([
       [highestBidSeat, sellSeat, { Bid: highestBid }, { Ask: highestBid }],

--- a/packages/zoe/src/contracts/auction/secondPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/secondPriceLogic.js
@@ -1,5 +1,5 @@
 import { AmountMath } from '@agoric/ertp';
-import { atomicTransfer } from '../../contractSupport/index.js';
+import { atomicRearrange } from '../../contractSupport/index.js';
 
 /**
  * @param {ZCF} zcf
@@ -50,7 +50,7 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   }
 
   // Everyone else gets a refund so their values remain the same.
-  atomicTransfer(
+  atomicRearrange(
     zcf,
     harden([
       [

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -11,7 +11,7 @@ import {
   assertProposalShape,
   assertNatAssetKind,
   calcSecondaryRequired,
-  atomicTransfer,
+  atomicRearrange,
 } from '../contractSupport/index.js';
 
 /**
@@ -88,7 +88,7 @@ const start = async zcf => {
   };
 
   function consummate(tradeAmountIn, tradeAmountOut, swapSeat) {
-    atomicTransfer(
+    atomicRearrange(
       zcf,
       harden([
         [
@@ -204,7 +204,7 @@ const start = async zcf => {
       Central: AmountMath.make(brands.Central, centralIn),
       Secondary: secondaryAmount,
     };
-    atomicTransfer(
+    atomicRearrange(
       zcf,
       harden([
         [seat, poolSeat, liquidityDeposited],
@@ -307,7 +307,7 @@ const start = async zcf => {
       Secondary: newUserSecondaryAmount,
     };
 
-    atomicTransfer(
+    atomicRearrange(
       zcf,
       harden([
         [removeLiqSeat, poolSeat, { Liquidity: userAllocation.Liquidity }],

--- a/packages/zoe/src/contracts/barterExchange.js
+++ b/packages/zoe/src/contracts/barterExchange.js
@@ -1,7 +1,7 @@
 import { Far } from '@endo/marshal';
 import { makeLegacyMap } from '@agoric/store';
 // Eventually will be importable from '@agoric/zoe-contract-support'
-import { satisfies, atomicTransfer } from '../contractSupport/index.js';
+import { satisfies, atomicRearrange } from '../contractSupport/index.js';
 
 /**
  * This Barter Exchange accepts offers to trade arbitrary goods for other
@@ -63,7 +63,7 @@ const start = zcf => {
     const matchingTrade = findMatchingTrade(offerDetails, orders);
     if (matchingTrade) {
       // reallocate by giving each side what it wants
-      atomicTransfer(
+      atomicRearrange(
         zcf,
         harden([
           [

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -7,7 +7,7 @@ import {
   assertProposalShape,
   depositToSeat,
   assertNatAssetKind,
-  atomicTransfer,
+  atomicRearrange,
 } from '../../contractSupport/index.js';
 import { makePayoffHandler } from './payoffHandler.js';
 import { Position } from './position.js';
@@ -112,7 +112,7 @@ const start = async zcf => {
         give: { Collateral: null },
         want: { LongOption: null, ShortOption: null },
       });
-      atomicTransfer(
+      atomicRearrange(
         zcf,
         harden([
           [creatorSeat, collateralSeat, { Collateral: settlementAmount }],

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -7,6 +7,7 @@ import {
   assertProposalShape,
   depositToSeat,
   assertNatAssetKind,
+  atomicTransfer,
 } from '../../contractSupport/index.js';
 import { makePayoffHandler } from './payoffHandler.js';
 import { Position } from './position.js';
@@ -111,18 +112,20 @@ const start = async zcf => {
         give: { Collateral: null },
         want: { LongOption: null, ShortOption: null },
       });
-      collateralSeat.incrementBy(
-        creatorSeat.decrementBy(harden({ Collateral: settlementAmount })),
+      atomicTransfer(
+        zcf,
+        harden([
+          [creatorSeat, collateralSeat, { Collateral: settlementAmount }],
+          [
+            collateralSeat,
+            creatorSeat,
+            {
+              LongOption: longAmount,
+              ShortOption: shortAmount,
+            },
+          ],
+        ]),
       );
-      creatorSeat.incrementBy(
-        collateralSeat.decrementBy(
-          harden({
-            LongOption: longAmount,
-            ShortOption: shortAmount,
-          }),
-        ),
-      );
-      zcf.reallocate(collateralSeat, creatorSeat);
       payoffHandler.schedulePayoffs();
       creatorSeat.exit();
     };

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -2,7 +2,11 @@ import './types.js';
 
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
-import { getAmountOut, ceilMultiplyBy } from '../../contractSupport/index.js';
+import {
+  getAmountOut,
+  ceilMultiplyBy,
+  atomicTransfer,
+} from '../../contractSupport/index.js';
 import { Position } from './position.js';
 import { calculateShares } from './calculateShares.js';
 
@@ -36,10 +40,10 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
 
   function reallocateToSeat(seatPromise, seatPortion) {
     seatPromise.then(seat => {
-      seat.incrementBy(
-        collateralSeat.decrementBy(harden({ Collateral: seatPortion })),
+      atomicTransfer(
+        zcf,
+        harden([[collateralSeat, seat, { Collateral: seatPortion }]]),
       );
-      zcf.reallocate(seat, collateralSeat);
       seat.exit();
       seatsExited += 1;
       const remainder = collateralSeat.getAmountAllocated('Collateral');

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -40,10 +40,7 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
 
   function reallocateToSeat(seatPromise, seatPortion) {
     seatPromise.then(seat => {
-      atomicTransfer(
-        zcf,
-        harden([[collateralSeat, seat, { Collateral: seatPortion }]]),
-      );
+      atomicTransfer(zcf, collateralSeat, seat, { Collateral: seatPortion });
       seat.exit();
       seatsExited += 1;
       const remainder = collateralSeat.getAmountAllocated('Collateral');

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -10,6 +10,7 @@ import {
   assertNatAssetKind,
   makeRatio,
   ceilMultiplyBy,
+  atomicTransfer,
 } from '../../contractSupport/index.js';
 import { makePayoffHandler } from './payoffHandler.js';
 import { Position } from './position.js';
@@ -130,12 +131,13 @@ const start = zcf => {
         'wanted option not a match',
       );
 
-      depositSeat.incrementBy(collateralSeat.decrementBy(harden(spreadAmount)));
-      collateralSeat.incrementBy(
-        depositSeat.decrementBy(harden({ Collateral: newCollateral })),
+      atomicTransfer(
+        zcf,
+        harden([
+          [collateralSeat, depositSeat, spreadAmount],
+          [depositSeat, collateralSeat, { Collateral: newCollateral }],
+        ]),
       );
-
-      zcf.reallocate(collateralSeat, depositSeat);
       depositSeat.exit();
     };
 

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -10,7 +10,7 @@ import {
   assertNatAssetKind,
   makeRatio,
   ceilMultiplyBy,
-  atomicTransfer,
+  atomicRearrange,
 } from '../../contractSupport/index.js';
 import { makePayoffHandler } from './payoffHandler.js';
 import { Position } from './position.js';
@@ -131,7 +131,7 @@ const start = zcf => {
         'wanted option not a match',
       );
 
-      atomicTransfer(
+      atomicRearrange(
         zcf,
         harden([
           [collateralSeat, depositSeat, spreadAmount],

--- a/packages/zoe/src/contracts/loan/addCollateral.js
+++ b/packages/zoe/src/contracts/loan/addCollateral.js
@@ -1,4 +1,7 @@
-import { assertProposalShape } from '../../contractSupport/index.js';
+import {
+  assertProposalShape,
+  atomicTransfer,
+} from '../../contractSupport/index.js';
 
 import { scheduleLiquidation } from './scheduleLiquidation.js';
 
@@ -16,15 +19,17 @@ export const makeAddCollateralInvitation = (zcf, config) => {
       want: {},
     });
 
-    collateralSeat.incrementBy(
-      addCollateralSeat.decrementBy(
-        harden({
-          Collateral: addCollateralSeat.getAmountAllocated('Collateral'),
-        }),
-      ),
+    atomicTransfer(
+      zcf,
+      harden([
+        [
+          addCollateralSeat,
+          collateralSeat,
+          { Collateral: addCollateralSeat.getAmountAllocated('Collateral') },
+        ],
+      ]),
     );
 
-    zcf.reallocate(collateralSeat, addCollateralSeat);
     addCollateralSeat.exit();
 
     // Schedule the new liquidation trigger. The old one will have an

--- a/packages/zoe/src/contracts/loan/addCollateral.js
+++ b/packages/zoe/src/contracts/loan/addCollateral.js
@@ -19,16 +19,9 @@ export const makeAddCollateralInvitation = (zcf, config) => {
       want: {},
     });
 
-    atomicTransfer(
-      zcf,
-      harden([
-        [
-          addCollateralSeat,
-          collateralSeat,
-          { Collateral: addCollateralSeat.getAmountAllocated('Collateral') },
-        ],
-      ]),
-    );
+    atomicTransfer(zcf, addCollateralSeat, collateralSeat, {
+      Collateral: addCollateralSeat.getAmountAllocated('Collateral'),
+    });
 
     addCollateralSeat.exit();
 

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -9,7 +9,7 @@ import {
   getAmountOut,
   ceilMultiplyBy,
   getTimestamp,
-  atomicTransfer,
+  atomicRearrange,
 } from '../../contractSupport/index.js';
 
 import { scheduleLiquidation } from './scheduleLiquidation.js';
@@ -76,7 +76,7 @@ export const makeBorrowInvitation = (zcf, config) => {
 
     const { zcfSeat: collateralSeat } = zcf.makeEmptySeatKit();
 
-    atomicTransfer(
+    atomicRearrange(
       zcf,
       harden([
         // Transfer the wanted Loan amount to the borrower

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -5,7 +5,7 @@ import { AmountMath } from '@agoric/ertp';
 
 import {
   assertProposalShape,
-  atomicTransfer,
+  atomicRearrange,
 } from '../../contractSupport/index.js';
 
 // The debt, the amount which must be repaid, is just the amount
@@ -42,7 +42,7 @@ export const makeCloseLoanInvitation = (zcf, config) => {
     // Transfer the collateral to the repaySeat and remove the
     // required Loan amount. Any excess Loan amount is kept by the repaySeat.
     // Transfer the repaid loan amount to the lender
-    atomicTransfer(
+    atomicRearrange(
       zcf,
       harden([
         [

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -42,19 +42,14 @@ export const makeCloseLoanInvitation = (zcf, config) => {
     // Transfer the collateral to the repaySeat and remove the
     // required Loan amount. Any excess Loan amount is kept by the repaySeat.
     // Transfer the repaid loan amount to the lender
+    const collateralAmount = collateralSeat.getAmountAllocated(
+      'Collateral',
+      collateralBrand,
+    );
     atomicRearrange(
       zcf,
       harden([
-        [
-          collateralSeat,
-          repaySeat,
-          {
-            Collateral: collateralSeat.getAmountAllocated(
-              'Collateral',
-              collateralBrand,
-            ),
-          },
-        ],
+        [collateralSeat, repaySeat, { Collateral: collateralAmount }],
         [repaySeat, lenderSeat, { Loan: debt }],
       ]),
     );

--- a/packages/zoe/src/contracts/loan/scheduleLiquidation.js
+++ b/packages/zoe/src/contracts/loan/scheduleLiquidation.js
@@ -55,10 +55,9 @@ export const scheduleLiquidation = (zcf, configWithBorrower) => {
       // collateral is on the collateral seat. If an error occurs, we
       // reallocate the collateral to the lender and shutdown the
       // contract, kicking out any remaining seats.
-      atomicTransfer(
-        zcf,
-        harden([[collateralSeat, lenderSeat, { Collateral: allCollateral }]]),
-      );
+      atomicTransfer(zcf, collateralSeat, lenderSeat, {
+        Collateral: allCollateral,
+      });
 
       zcf.shutdownWithFailure(err);
       throw err;

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -30,7 +30,7 @@ const start = async zcf => {
           ? feeSeat.getCurrentAllocation()
           : seat.getProposal().want;
 
-        atomicTransfer(zcf, harden([[feeSeat, seat, gains]]));
+        atomicTransfer(zcf, feeSeat, seat, gains);
 
         seat.exit();
         return 'Successfully withdrawn';
@@ -42,10 +42,7 @@ const start = async zcf => {
     makeShutdownInvitation: () => {
       const shutdown = seat => {
         revoked = true;
-        atomicTransfer(
-          zcf,
-          harden([[feeSeat, seat, feeSeat.getCurrentAllocation()]]),
-        );
+        atomicTransfer(zcf, feeSeat, seat, feeSeat.getCurrentAllocation());
 
         zcf.shutdown(revokedMsg);
       };
@@ -84,10 +81,7 @@ const start = async zcf => {
           const fee = querySeat.getAmountAllocated('Fee', feeBrand);
           const { requiredFee, reply } = await E(handler).onQuery(query, fee);
           if (requiredFee) {
-            atomicTransfer(
-              zcf,
-              harden([[querySeat, feeSeat, { Fee: requiredFee }]]),
-            );
+            atomicTransfer(zcf, querySeat, feeSeat, { Fee: requiredFee });
           }
           querySeat.exit();
           E(handler).onReply(query, reply, requiredFee);

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -5,6 +5,7 @@ import {
   offerTo,
   saveAllIssuers,
   assertProposalShape,
+  atomicTransfer,
 } from '../contractSupport/index.js';
 
 /**
@@ -96,10 +97,11 @@ const start = zcf => {
   const addInventory = seat => {
     assertProposalShape(seat, { want: {} });
     // Take everything in this seat and add it to the marketMakerSeat
-    marketMakerSeat.incrementBy(
-      seat.decrementBy(harden(seat.getCurrentAllocation())),
+    atomicTransfer(
+      zcf,
+      harden([[seat, marketMakerSeat, seat.getCurrentAllocation()]]),
     );
-    zcf.reallocate(marketMakerSeat, seat);
+
     seat.exit();
     return 'Inventory added';
   };
@@ -107,8 +109,8 @@ const start = zcf => {
   const removeInventory = seat => {
     assertProposalShape(seat, { give: {} });
     const { want } = seat.getProposal();
-    seat.incrementBy(marketMakerSeat.decrementBy(harden(want)));
-    zcf.reallocate(marketMakerSeat, seat);
+    atomicTransfer(zcf, harden([[marketMakerSeat, seat, want]]));
+
     seat.exit();
     return 'Inventory removed';
   };

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -97,10 +97,7 @@ const start = zcf => {
   const addInventory = seat => {
     assertProposalShape(seat, { want: {} });
     // Take everything in this seat and add it to the marketMakerSeat
-    atomicTransfer(
-      zcf,
-      harden([[seat, marketMakerSeat, seat.getCurrentAllocation()]]),
-    );
+    atomicTransfer(zcf, seat, marketMakerSeat, seat.getCurrentAllocation());
 
     seat.exit();
     return 'Inventory added';
@@ -109,7 +106,7 @@ const start = zcf => {
   const removeInventory = seat => {
     assertProposalShape(seat, { give: {} });
     const { want } = seat.getProposal();
-    atomicTransfer(zcf, harden([[marketMakerSeat, seat, want]]));
+    atomicTransfer(zcf, marketMakerSeat, seat, want);
 
     seat.exit();
     return 'Inventory removed';

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -7,6 +7,7 @@ import {
   defaultAcceptanceMsg,
   assertProposalShape,
   assertNatAssetKind,
+  atomicTransfer,
 } from '../contractSupport/index.js';
 
 const { details: X } = assert;
@@ -101,13 +102,13 @@ const start = zcf => {
       assert.fail(X`More money (${totalCost}) is required to buy these items`);
 
     // Reallocate.
-    sellerSeat.incrementBy(
-      buyerSeat.decrementBy(harden({ Money: providedMoney })),
+    atomicTransfer(
+      zcf,
+      harden([
+        [buyerSeat, sellerSeat, { Money: providedMoney }],
+        [sellerSeat, buyerSeat, { Items: wantedItems }],
+      ]),
     );
-    buyerSeat.incrementBy(
-      sellerSeat.decrementBy(harden({ Items: wantedItems })),
-    );
-    zcf.reallocate(buyerSeat, sellerSeat);
 
     // The buyer's offer has been processed.
     buyerSeat.exit();

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -7,7 +7,7 @@ import {
   defaultAcceptanceMsg,
   assertProposalShape,
   assertNatAssetKind,
-  atomicTransfer,
+  atomicRearrange,
 } from '../contractSupport/index.js';
 
 const { details: X } = assert;
@@ -102,7 +102,7 @@ const start = zcf => {
       assert.fail(X`More money (${totalCost}) is required to buy these items`);
 
     // Reallocate.
-    atomicTransfer(
+    atomicRearrange(
       zcf,
       harden([
         [buyerSeat, sellerSeat, { Money: providedMoney }],


### PR DESCRIPTION
Fixes #3850
Fixes #6116 

Alternative to https://github.com/Agoric/agoric-sdk/pull/4327

Based on https://github.com/Agoric/agoric-sdk/pull/6102#discussion_r960760639

Revisiting the example from #3850, current code like

```js
  brandOutPoolSeat.decrementBy(harden({ Secondary: amountOut }));
  seat.incrementBy(harden({ Out: amountOut }));

  brandOutPoolSeat.incrementBy(
    brandInPoolSeat.decrementBy(harden({ Central: reducedCentralAmount })));

  seat.decrementBy(harden({ In: reducedAmountIn }));
  brandInPoolSeat.incrementBy(harden({ Secondary: reducedAmountIn }));

  zcf.reallocate(brandOutPoolSeat, brandInPoolSeat, seat);
```

becomes

```js
  atomicTransfer(
    zcf,
    harden([
      [brandOutPoolSeat, seat, { Secondary: amountOut }, { Out: amountOut }],
      [brandInPoolSeat, brandOutPoolSeat, { Central: reducedCentralAmount }],
      [seat, brandInPoolSeat, { In: reducedAmountIn }, { Secondary: reducedAmountIn }],
    ]),
  );
```

No matter whether the `atomicTransfer` succeeds or fails, there are none of the stateful hazards associated with the previous staging approach.

In exchange for `atomicTransfer`, this PR deprecates the `zcf` method `reallocate, and deprecates the `zcfSeat` methods `incrementBy`, `decrementBy`, `clear`, `getStagedAllocation`, and `hasStagedAllocation`.

Currently `atomicTransfer` is a helper, to avoid collisions with ongoing work on Zoe durability. Once we're past that, I expect we'll redefine it as a replacement for `zcf.reallocate`, so the above example becomes

```js
  zcf.transfer(harden([
    [brandOutPoolSeat, seat, { Secondary: amountOut }, { Out: amountOut }],
    [brandInPoolSeat, brandOutPoolSeat, { Central: reducedCentralAmount }],
    [seat, brandInPoolSeat, { In: reducedAmountIn }, { Secondary: reducedAmountIn }],
  ]));
```
