### PR TITLE
types for `this` in far classes

### DIFF
--- a/packages/ERTP/jsconfig.json
+++ b/packages/ERTP/jsconfig.json
@@ -6,6 +6,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
     "types": [
       "node"

--- a/packages/SwingSet/jsconfig.json
+++ b/packages/SwingSet/jsconfig.json
@@ -6,6 +6,7 @@
     "checkJs": true,
     "noEmit": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/SwingSet/src/lib-nodejs/worker-protocol.js
+++ b/packages/SwingSet/src/lib-nodejs/worker-protocol.js
@@ -7,6 +7,7 @@ import { Transform } from 'stream';
 export function arrayEncoderStream() {
   /**
    *
+   * @this {{ push: (b: Buffer) => void }}
    * @param {*} object
    * @param {BufferEncoding} encoding
    * @param {*} callback
@@ -30,6 +31,7 @@ export function arrayEncoderStream() {
 export function arrayDecoderStream() {
   /**
    *
+   * @this {{ push: (b: Buffer) => void }}
    * @param {Buffer} buf
    * @param {BufferEncoding} encoding
    * @param {*} callback

--- a/packages/SwingSet/src/lib/netstring.js
+++ b/packages/SwingSet/src/lib/netstring.js
@@ -22,6 +22,7 @@ export function encode(data) {
 export function netstringEncoderStream() {
   /**
    *
+   * @this {{ push: (b: Buffer) => void }}
    * @param {Buffer} chunk
    * @param {BufferEncoding} encoding
    * @param {*} callback
@@ -86,6 +87,7 @@ export function netstringDecoderStream(optMaxChunkSize) {
   let buffered = Buffer.from('');
   /**
    *
+   * @this {{ push: (b: Buffer) => void }}
    * @param {Buffer} chunk
    * @param {BufferEncoding} encoding
    * @param {*} callback

--- a/packages/access-token/jsconfig.json
+++ b/packages/access-token/jsconfig.json
@@ -12,6 +12,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/agoric-cli/jsconfig.json
+++ b/packages/agoric-cli/jsconfig.json
@@ -13,6 +13,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -69,6 +69,7 @@ export const makeOracleCommand = async logger => {
     )
     .option('--offerId [number]', 'Offer id', Number, Date.now())
     .action(async function () {
+      // @ts-expect-error this implicit any
       const opts = this.opts();
 
       const instance = lookupPriceAggregatorInstance(opts.pair);
@@ -104,6 +105,7 @@ export const makeOracleCommand = async logger => {
     )
     .requiredOption('--price [number]', 'price (format TODO)', String)
     .action(async function () {
+      // @ts-expect-error this implicit any
       const opts = this.opts();
 
       /** @type {import('../lib/psm.js').OfferSpec} */
@@ -136,6 +138,7 @@ export const makeOracleCommand = async logger => {
       ['ATOM', 'USD'],
     )
     .action(async function () {
+      // @ts-expect-error this implicit any
       const { pair } = this.opts();
 
       const capDataStr = await vstorage.readLatest(

--- a/packages/agoric-cli/src/commands/perf.js
+++ b/packages/agoric-cli/src/commands/perf.js
@@ -45,6 +45,7 @@ export const makePerfCommand = async logger => {
     )
     .option('--home [string]', 'directory for config and data')
     .action(async function () {
+      // @ts-expect-error this implicit any
       const opts = this.opts();
       logger.warn({ opts });
       const payloadStr = await fs.readFileSync(opts.executeOffer).toString();

--- a/packages/agoric-cli/src/commands/psm.js
+++ b/packages/agoric-cli/src/commands/psm.js
@@ -126,6 +126,7 @@ export const makePsmCommand = async logger => {
       ['IST', 'AUSD'],
     )
     .action(async function () {
+      // @ts-expect-error this implicit any
       const { pair } = this.opts();
       const { governance } = await getGovernanceState(pair);
       console.log('psm governance params', Object.keys(governance));
@@ -159,6 +160,7 @@ export const makePsmCommand = async logger => {
     .option('--feePct [%]', 'Gas fee percentage', Number)
     .option('--offerId [number]', 'Offer id', Number, Date.now())
     .action(async function () {
+      // @ts-expect-error this implicit any
       const opts = this.opts();
       console.warn('running with options', opts);
       const instance = await lookupPsmInstance(opts.pair);
@@ -172,6 +174,7 @@ export const makePsmCommand = async logger => {
     .description('join the economic committee')
     .option('--offerId [number]', 'Offer id', Number, Date.now())
     .action(async function () {
+      // @ts-expect-error this implicit any
       const opts = this.opts();
 
       const { economicCommittee } = agoricNames.instance;
@@ -202,6 +205,7 @@ export const makePsmCommand = async logger => {
     .description('prepare an offer to accept the charter invitation')
     .option('--offerId [number]', 'Offer id', Number, Date.now())
     .action(async function () {
+      // @ts-expect-error this implicit any
       const opts = this.opts();
 
       const { psmCharter } = agoricNames.instance;
@@ -255,6 +259,7 @@ export const makePsmCommand = async logger => {
       1,
     )
     .action(async function () {
+      // @ts-expect-error this implicit any
       const opts = this.opts();
 
       const psmInstance = lookupPsmInstance(opts.pair);
@@ -312,6 +317,7 @@ export const makePsmCommand = async logger => {
       1,
     )
     .action(async function () {
+      // @ts-expect-error this implicit any
       const opts = this.opts();
 
       const psmInstance = lookupPsmInstance(opts.pair);
@@ -366,6 +372,7 @@ export const makePsmCommand = async logger => {
       Number,
     )
     .action(async function () {
+      // @ts-expect-error this implicit any
       const opts = this.opts();
 
       const questionHandleCapDataStr = await vstorage.readLatest(

--- a/packages/agoric-cli/src/commands/wallet.js
+++ b/packages/agoric-cli/src/commands/wallet.js
@@ -53,6 +53,7 @@ export const makeWalletCommand = async () => {
         spend,
         home,
         keyringBackend: backend,
+        // @ts-expect-error this implicit any
       } = this.opts();
       const tx = `provision-one ${nickname} ${account} SMART_WALLET`;
       if (spend) {
@@ -102,6 +103,7 @@ export const makeWalletCommand = async () => {
         offer,
         home,
         keyringBackend: backend,
+        // @ts-expect-error this implicit any
       } = this.opts();
 
       execSwingsetTransaction(
@@ -131,6 +133,7 @@ export const makeWalletCommand = async () => {
       normalizeAddress,
     )
     .action(async function () {
+      // @ts-expect-error this implicit any
       const opts = this.opts();
 
       const { agoricNames, fromBoard, vstorage } = await makeRpcUtils({
@@ -176,6 +179,7 @@ export const makeWalletCommand = async () => {
       normalizeAddress,
     )
     .action(async function () {
+      // @ts-expect-error this implicit any
       const { from } = this.opts();
       const spec = `:published.wallet.${from}`;
 

--- a/packages/assert/jsconfig.json
+++ b/packages/assert/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -13,6 +12,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/cache/jsconfig.json
+++ b/packages/cache/jsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/casting/jsconfig.json
+++ b/packages/casting/jsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/cosmic-proto/tsconfig.json
+++ b/packages/cosmic-proto/tsconfig.json
@@ -7,6 +7,7 @@
     "allowSyntheticDefaultImports": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
     "outDir": "dist"
   },

--- a/packages/cosmic-swingset/jsconfig.json
+++ b/packages/cosmic-swingset/jsconfig.json
@@ -12,6 +12,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/deploy-script-support/jsconfig.json
+++ b/packages/deploy-script-support/jsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/deployment/jsconfig.json
+++ b/packages/deployment/jsconfig.json
@@ -12,6 +12,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/governance/jsconfig.json
+++ b/packages/governance/jsconfig.json
@@ -6,6 +6,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/inter-protocol/jsconfig.json
+++ b/packages/inter-protocol/jsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/internal/jsconfig.json
+++ b/packages/internal/jsconfig.json
@@ -7,6 +7,7 @@
     "downlevelIteration": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
     "types": [
       "node"

--- a/packages/notifier/jsconfig.json
+++ b/packages/notifier/jsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/pegasus/jsconfig.json
+++ b/packages/pegasus/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -13,6 +12,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/smart-wallet/jsconfig.json
+++ b/packages/smart-wallet/jsconfig.json
@@ -3,10 +3,10 @@
     "target": "esnext",
     "module": "esnext",
     "checkJs": true,
-    "noImplicitThis": true,
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/smart-wallet/jsconfig.json
+++ b/packages/smart-wallet/jsconfig.json
@@ -3,6 +3,7 @@
     "target": "esnext",
     "module": "esnext",
     "checkJs": true,
+    "noImplicitThis": true,
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,

--- a/packages/solo/jsconfig.json
+++ b/packages/solo/jsconfig.json
@@ -12,6 +12,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/sparse-ints/jsconfig.json
+++ b/packages/sparse-ints/jsconfig.json
@@ -12,6 +12,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/stat-logger/jsconfig.json
+++ b/packages/stat-logger/jsconfig.json
@@ -12,6 +12,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/store/jsconfig.json
+++ b/packages/store/jsconfig.json
@@ -4,10 +4,10 @@
     "target": "esnext",
     "module": "esnext",
     "checkJs": true,
-    "noImplicitThis": true,
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/store/jsconfig.json
+++ b/packages/store/jsconfig.json
@@ -4,6 +4,7 @@
     "target": "esnext",
     "module": "esnext",
     "checkJs": true,
+    "noImplicitThis": true,
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -137,7 +137,7 @@ const defendMethod = (method, methodGuard, label) => {
  *
  * @param {string} methodTag
  * @param {WeakMap} contextMap
- * @param {Method} behaviorMethod
+ * @param {CallableFunction} behaviorMethod
  * @param {boolean} [thisfulMethods]
  * @param {MethodGuard} [methodGuard]
  */
@@ -195,7 +195,7 @@ const bindMethod = (
 };
 
 /**
- * @template {Record<string | symbol, Method>} T
+ * @template {Record<string | symbol, CallableFunction>} T
  * @param {string} tag
  * @param {WeakMap} contextMap
  * @param {T} behaviorMethods
@@ -280,13 +280,13 @@ export const initEmpty = () => emptyRecord;
  */
 
 /**
- * @template A
- * @template S
- * @template {{}} T
+ * @template A args to init
+ * @template S state from init
+ * @template {Record<string | symbol, CallableFunction>} T methods
  * @param {string} tag
  * @param {any} interfaceGuard
  * @param {(...args: A[]) => S} init
- * @param {T} methods
+ * @param {T & ThisType<T & { state: S }>} methods
  * @param {object} [options]
  * @returns {(...args: A[]) => (T & import('@endo/eventual-send').RemotableBrand<{}, T>)}
  */
@@ -330,13 +330,13 @@ export const defineHeapFarClass = (
 harden(defineHeapFarClass);
 
 /**
- * @template A
- * @template S
- * @template {Record<string, any>} F
+ * @template A args to init
+ * @template S state from init
+ * @template {Record<string, Record<string | symbol, CallableFunction>>} F methods
  * @param {string} tag
  * @param {any} interfaceGuardKit
  * @param {(...args: A[]) => S} init
- * @param {F} methodsKit
+ * @param {F & { [K in keyof F]: ThisType<F[K] & { state: S }> }} methodsKit
  * @param {object} [options]
  * @returns {(...args: A[]) => F}
  */

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -24,10 +24,10 @@ test('test defineHeapFarClass', t => {
   const makeUpCounter = defineHeapFarClass(
     'UpCounter',
     UpCounterI,
+    /** @param {number} x */
     (x = 0) => ({ x }),
     {
       incr(y = 1) {
-        // @ts-expect-error TS doesn't know that `this` is a `Context`
         const { state } = this;
         state.x += y;
         return state.x;
@@ -51,11 +51,11 @@ test('test defineHeapFarClassKit', t => {
   const makeCounterKit = defineHeapFarClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
     (x = 0) => ({ x }),
     {
       up: {
         incr(y = 1) {
-          // @ts-expect-error xxx this.state
           const { state } = this;
           state.x += y;
           return state.x;
@@ -63,7 +63,6 @@ test('test defineHeapFarClassKit', t => {
       },
       down: {
         decr(y = 1) {
-          // @ts-expect-error xxx this.state
           const { state } = this;
           state.x -= y;
           return state.x;

--- a/packages/swing-store/jsconfig.json
+++ b/packages/swing-store/jsconfig.json
@@ -11,6 +11,7 @@
     "emitDeclarationOnly": true,
 */
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/swingset-runner/jsconfig.json
+++ b/packages/swingset-runner/jsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/telemetry/jsconfig.json
+++ b/packages/telemetry/jsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/ui-components/jsconfig.json
+++ b/packages/ui-components/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -13,6 +12,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
     "jsx": "react",
   },

--- a/packages/vat-data/src/far-class-utils.js
+++ b/packages/vat-data/src/far-class-utils.js
@@ -45,11 +45,13 @@ harden(defineVirtualFarClass);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
- * @template A,S,T
+ * @template A args to init
+ * @template S state from init
+ * @template {Record<string, Record<string | symbol, CallableFunction>>} T facets
  * @param {string} tag
  * @param {any} interfaceGuardKit
  * @param {(...args: A[]) => S} init
- * @param {T} facets
+ * @param {T & { [K in keyof T]: ThisType<T[K] & { facets: T, state: S }> }} facets
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
@@ -71,11 +73,13 @@ harden(defineVirtualFarClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
- * @template A,S,T
+ * @template A args to init
+ * @template S state from init
+ * @template {Record<string | symbol, CallableFunction>} T methods
  * @param {DurableKindHandle} kindHandle
  * @param {any} interfaceGuard
  * @param {(...args: A[]) => S} init
- * @param {T} methods
+ * @param {T & ThisType<T & { state: S }>} methods
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
@@ -97,11 +101,13 @@ harden(defineDurableFarClass);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
- * @template A,S,T
+ * @template A args to init
+ * @template S state from init
+ * @template {Record<string, Record<string | symbol, CallableFunction>>} T facets
  * @param {DurableKindHandle} kindHandle
  * @param {any} interfaceGuardKit
  * @param {(...args: A[]) => S} init
- * @param {T} facets
+ * @param {T & { [K in keyof T]: ThisType<T[K] & { facets: T, state: S }> }} facets
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
@@ -123,12 +129,14 @@ harden(defineDurableFarClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
- * @template A,S,T
+ * @template A args to init
+ * @template S state from init
+ * @template {Record<string | symbol, CallableFunction>} T methods
  * @param {Baggage} baggage
  * @param {string} kindName
  * @param {any} interfaceGuard
  * @param {(...args: A[]) => S} init
- * @param {T} methods
+ * @param {T & ThisType<T & { state: S }>} methods
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
@@ -151,12 +159,14 @@ harden(vivifyFarClass);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
- * @template A,S,T
+ * @template A args to init
+ * @template S state from init
+ * @template {Record<string, Record<string | symbol, CallableFunction>>} T facets
  * @param {Baggage} baggage
  * @param {string} kindName
  * @param {any} interfaceGuardKit
  * @param {(...args: A[]) => S} init
- * @param {T} facets
+ * @param {T & { [K in keyof T]: ThisType<T[K] & { facets: T, state: S }> }} facets
  * @param {DefineKindOptions<unknown>} [options]
  * @returns {(...args: A[]) => (T & RemotableBrand<{}, T>)}
  */
@@ -179,7 +189,8 @@ harden(vivifyFarClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
- * @template T,M
+ * @template T
+ * @template {Record<string | symbol, CallableFunction>} M methods
  * @param {Baggage} baggage
  * @param {string} kindName
  * @param {any} interfaceGuard
@@ -211,7 +222,7 @@ harden(vivifyFarInstance);
 
 /**
  * @deprecated Use vivifyFarInstance instead.
- * @template T
+ * @template {Record<string | symbol, CallableFunction>} T methods
  * @param {Baggage} baggage
  * @param {string} kindName
  * @param {T} methods

--- a/packages/vat-data/test/test-durable-classes.js
+++ b/packages/vat-data/test/test-durable-classes.js
@@ -28,10 +28,10 @@ test('test defineDurableFarClass', t => {
   const makeUpCounter = defineDurableFarClass(
     upCounterKind,
     UpCounterI,
+    /** @param {number} x */
     (x = 0) => ({ x }),
     {
       incr(y = 1) {
-        // @ts-expect-error TS doesn't know that `this` is a `Context`
         const { state } = this;
         state.x += y;
         return state.x;
@@ -87,6 +87,7 @@ test('test defineDurableFarClassKit', t => {
     message:
       'In "decr" method of (Counter down) arg 0: string "foo" - Must be a number',
   });
+  // @ts-expect-error the type violation is what we're testing
   t.throws(() => upCounter.decr(3), {
     message: 'upCounter.decr is not a function',
   });

--- a/packages/vat-data/test/test-virtual-classes.js
+++ b/packages/vat-data/test/test-virtual-classes.js
@@ -82,6 +82,7 @@ test('test defineVirtualFarClassKit', t => {
     message:
       'In "decr" method of (Counter down) arg 0: string "foo" - Must be a number',
   });
+  // @ts-expect-error the type violation is what we're testing
   t.throws(() => upCounter.decr(3), {
     message: 'upCounter.decr is not a function',
   });

--- a/packages/vat-data/test/test-vivify.js
+++ b/packages/vat-data/test/test-vivify.js
@@ -33,7 +33,6 @@ test('test vivifyFarClass', t => {
     (x = 0) => ({ x }),
     {
       incr(y = 1) {
-        // @ts-expect-error TS doesn't know that `this` is a `Context`
         const { state } = this;
         state.x += y;
         return state.x;
@@ -90,6 +89,7 @@ test('test vivifyFarClassKit', t => {
     message:
       'In "decr" method of (Counter down) arg 0: string "foo" - Must be a number',
   });
+  // @ts-expect-error the type violation is what we're testing
   t.throws(() => upCounter.decr(3), {
     message: 'upCounter.decr is not a function',
   });

--- a/packages/vats/jsconfig.json
+++ b/packages/vats/jsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/wallet/api/jsconfig.json
+++ b/packages/wallet/api/jsconfig.json
@@ -3,16 +3,10 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/web-components/jsconfig.json
+++ b/packages/web-components/jsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
+    /*
     // The following flags are for creating .d.ts files:
     "noEmit": false,
     "declaration": true,
@@ -13,6 +12,7 @@
 */
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/zoe/jsconfig.json
+++ b/packages/zoe/jsconfig.json
@@ -6,6 +6,7 @@
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitThis": true,
     "moduleResolution": "node",
   },
   "include": [

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -39,7 +39,6 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
     sellSeat => ({ sellSeat }),
     {
       handle(buySeat) {
-        // @ts-expect-error TS doesn't understand context
         const { state } = this;
         assert(!state.sellSeat.hasExited(), sellSeatExpiredMsg);
         try {


### PR DESCRIPTION
## Description

Far classes put `state` and `facets` on `this` but we never got the types there. This was allowed by our TS config because `this` was implicitly `any`. 

This PR makes `this` inferred in behaviors passed to the Far class makers. 

It also enables `noImplicitThis` across the repo to catch such type coverage loss in the future (and because the `ThisType` utility that enables the above requires it.)

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

CI