### PR TITLE
fix: cosmic-proto exports through npm

### DIFF
--- a/packages/cosmic-proto/MAINTAINERS.md
+++ b/packages/cosmic-proto/MAINTAINERS.md
@@ -1,4 +1,4 @@
-This package is updated rarely and so the build is checked into SCM. That is, part of `dist` is copied to root so they can be imported in consumers that don't yet support ESM. We also have symlink `./swingset` to the `dist/agoric/swingset` for local requires. (Note [NPM won't publish symlinks](https://github.com/npm/npm/issues/3310)).
+This package is updated rarely and so the build is checked into SCM. That is, part of `dist` is copied to root so they can be imported in consumers that don't yet support ESM. We used to have a symlink `./swingset` to the `dist/agoric/swingset` for local requires but [NPM won't publish symlinks](https://github.com/npm/npm/issues/3310)). So now we have modules there that import from `dist/`.
 
  We used to check in `gen` but they're redundant with `dist` output and include `.ts` which creates problems for downstream consumers using TypeScript ([ref](https://github.com/microsoft/TypeScript/issues/47387#issuecomment-1168711813)).
 

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -17,16 +17,16 @@
   "exports": {
     "./package.json": "./package.json",
     "./swingset/msgs.js": {
-      "types": "./swingset/msgs.d.ts",
-      "default": "./swingset/msgs.js"
+      "types": "./dist/agoric/swingset/msgs.d.ts",
+      "default": "./dist/agoric/swingset/msgs.js"
     },
     "./swingset/query.js": {
-      "types": "./swingset/query.d.ts",
-      "default": "./swingset/query.js"
+      "types": "./dist/agoric/swingset/query.d.ts",
+      "default": "./dist/agoric/swingset/query.js"
     },
     "./swingset/swingset.js": {
-      "types": "./swingset/swingset.d.ts",
-      "default": "./swingset/swingset.js"
+      "types": "./dist/agoric/swingset/swingset.d.ts",
+      "default": "./dist/agoric/swingset/swingset.js"
     }
   },
   "scripts": {

--- a/packages/cosmic-proto/swingset
+++ b/packages/cosmic-proto/swingset
@@ -1,1 +1,0 @@
-dist/agoric/swingset/

--- a/packages/cosmic-proto/swingset/msgs.js
+++ b/packages/cosmic-proto/swingset/msgs.js
@@ -1,0 +1,2 @@
+/** @file for backwards compatibility */
+export * from '../dist/agoric/swingset/msgs.js';

--- a/packages/cosmic-proto/swingset/query.js
+++ b/packages/cosmic-proto/swingset/query.js
@@ -1,0 +1,2 @@
+/** @file for backwards compatibility */
+export * from '../dist/agoric/swingset/query.js';

--- a/packages/cosmic-proto/swingset/swingset.js
+++ b/packages/cosmic-proto/swingset/swingset.js
@@ -1,0 +1,2 @@
+/** @file for backwards compatibility */
+export * from '../dist/agoric/swingset/swingset.js';


### PR DESCRIPTION
## Description

 https://github.com/Agoric/agoric-sdk/pull/6540 didn't solve for NPM consumers that don't support export maps.

This puts files in `swingset` instead of symlinks, so they go through `npm pack`. It re-exports instead of copying because the source code needs to be able to reference `../cosmos` and having that in the second path would require copying that directory too.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

```
❯ npm pack
npm notice
npm notice 📦  @agoric/cosmic-proto@0.2.1
npm notice === Tarball Contents ===
npm notice 11.4kB LICENSE
npm notice 352B   README.md
npm notice 18.0kB dist/agoric/swingset/msgs.d.ts
npm notice 17.9kB dist/agoric/swingset/msgs.js
npm notice 14.0kB dist/agoric/swingset/query.d.ts
npm notice 9.6kB  dist/agoric/swingset/query.js
npm notice 16.3kB dist/agoric/swingset/swingset.d.ts
npm notice 17.0kB dist/agoric/swingset/swingset.js
npm notice 3.3kB  dist/cosmos/base/v1beta1/coin.d.ts
npm notice 6.1kB  dist/cosmos/base/v1beta1/coin.js
npm notice 1.8kB  package.json
npm notice 90B    swingset/msgs.js
npm notice 91B    swingset/query.js
npm notice 94B    swingset/swingset.js
npm notice === Tarball Details ===
npm notice name:          @agoric/cosmic-proto
npm notice version:       0.2.1
npm notice filename:      @agoric/cosmic-proto-0.2.1.tgz
npm notice package size:  16.6 kB
npm notice unpacked size: 116.1 kB
npm notice shasum:        a5ccc3df532c938d4bfe06e1b870117e4c436465
npm notice integrity:     sha512-nphByyltyAeaQ[...]tQCs/SLkD0rQg==
npm notice total files:   14
```
(The `swingset` files are there)