### PR TITLE
test: Add Node.js 18.x to workflows

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        node-version: ['14.x', '16.x', '18.x']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -38,7 +38,7 @@ jobs:
           go-version: 1.17
       - uses: ./.github/actions/restore-node
         with:
-          node-version: 18.x
+          node-version: 16.x
           # Forces xsnap to initialize all memory to random data, which increases
           # the chances the content of snapshots may deviate between validators
           # TODO: key the node built cache on this env

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -38,7 +38,7 @@ jobs:
           go-version: 1.17
       - uses: ./.github/actions/restore-node
         with:
-          node-version: 16.x
+          node-version: 18.x
           # Forces xsnap to initialize all memory to random data, which increases
           # the chances the content of snapshots may deviate between validators
           # TODO: key the node built cache on this env

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x']
+        node-version: ['14.x', '16.x', '18.x']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: '16.x'
+          node-version: '18.x'
 
       # first job also does repo-level linting
       - name: lint repo format
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-node
         with:
-          node-version: '16.x'
+          node-version: '18.x'
 
       - name: yarn lint rest
         run: ./scripts/lint-with-types.sh rest
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['14.x', '16.x', 'xs']
+        engine: ['14.x', '16.x', '18.x', 'xs']
     steps:
       - name: set vars
         id: vars
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['14.x', '16.x', 'xs']
+        engine: ['14.x', '16.x', '18.x', 'xs']
     steps:
       - name: set vars
         id: vars
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['14.x', '16.x', 'xs']
+        engine: ['14.x', '16.x', '18.x', 'xs']
     steps:
       - name: set vars
         id: vars
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['14.x', '16.x', 'xs']
+        engine: ['14.x', '16.x', '18.x', 'xs']
     steps:
       - name: set vars
         id: vars
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['14.x', '16.x', 'xs']
+        engine: ['14.x', '16.x', '18.x', 'xs']
     steps:
       - name: set vars
         id: vars
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['14.x', '16.x', 'xs']
+        engine: ['14.x', '16.x', '18.x', 'xs']
     steps:
       - name: set vars
         id: vars
@@ -280,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['14.x', '16.x', 'xs']
+        engine: ['14.x', '16.x', '18.x', 'xs']
     steps:
       - name: set vars
         id: vars
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['14.x', '16.x', 'xs']
+        engine: ['14.x', '16.x', '18.x', 'xs']
     steps:
       - name: set vars
         id: vars
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['14.x', '16.x', 'xs']
+        engine: ['14.x', '16.x', '18.x', 'xs']
     steps:
       - name: set vars
         id: vars
@@ -347,7 +347,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['14.x', '16.x', 'xs']
+        engine: ['14.x', '16.x', '18.x', 'xs']
     steps:
       - name: set vars
         id: vars

--- a/packages/solo/test/captp-fixture.js
+++ b/packages/solo/test/captp-fixture.js
@@ -44,7 +44,7 @@ export async function makeFixture(PORT, noisy = false) {
       /** @type {() => void} */
       let abortCapTP;
       ws = new WebSocket(
-        `ws://localhost:${PORT}/private/captp?accessToken=${accessToken}`,
+        `ws://127.0.0.1:${PORT}/private/captp?accessToken=${accessToken}`,
         {
           origin: `http://localhost:${PORT}`,
         },


### PR DESCRIPTION
refs: #6489

## Description

Node.js 14.x is retained as the default, just as it was before, considering it is Maintenance LTS set to EOL next year (2023-04-30).

This change adds Node.js 18.x in all the places where workflows previously were building with Node.js 16.x - either as addition to it where multiple version are provided, or as an upgrade where only one version is used.

This finishes up the bulk of #6489, however manual testing of compatibility should be conducted further before that.

### Security Considerations

N/A. This is a change to test scenarios, to support the Current LTS of Node.js.

### Documentation Considerations

Backwards compatibility should not be affected. As result of manual testing in #6489, it may be decided to inform users that Node.js 18.x is now officially supported. Upgrade of Node.js versions is breaking for compiled blobs, in which case users need to rebuild project when upgrading from Node.js 16.x to 18.x, similar to how they would do when upgrading from 14.x to 16.x.

### Testing Considerations

The test suite is expanded to support Node.js 18.x. Additional manual testing is out of scope for this PR and can be evaluated/discussed in #6489.