### PR TITLE
fix: don't ignore protobuf stubs in docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,6 @@ packages/stat-logger
 **/deployment.json
 **/vars.tf
 **/*.log
-**/dist
 **/build
 **/__pycache__
 **/*.egg-info


### PR DESCRIPTION
fixes #6600

### Documentation Considerations

The knowledge of how `packages/cosmic-proto` interacts with `packages/deployment` is pretty scattered. But I don't see a cost-effective way to address it.

### Testing Considerations

Manually tested:

```
agoric-sdk/packages/deployment$ make docker-build-sdk
...
Successfully built 12b3487fed42
docker tag agoric/agoric-sdk:undefined agoric/agoric-sdk:latest

agoric-sdk/packages/deployment$ docker run --rm -ti --entrypoint /bin/bash agoric/agoric-sdk:latest
root@941eb040792f:~# agoric
Usage: agoric [options] [command]
```
