### PR TITLE
6384 casting queryAbci

### DIFF
--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -544,7 +544,7 @@ export const makeCosmjsFollower = (
   }
 
   /**
-   * @param {number} cursorBlockHeight
+   * @param {number} [cursorBlockHeight]
    * @yields {ValueFollowerElement<T>}
    */
   async function* getReverseIterableAtHeight(cursorBlockHeight) {
@@ -552,8 +552,10 @@ export const makeCosmjsFollower = (
     // cursorBlockHeight) so we know not to emit duplicates
     // of that cell.
     let cursorData;
-    while (cursorBlockHeight > 0) {
-      cursorData = (await getDataAtHeight(cursorBlockHeight)).value;
+    while (cursorBlockHeight === undefined || cursorBlockHeight > 0) {
+      ({ value: cursorData, height: cursorBlockHeight } = await getDataAtHeight(
+        cursorBlockHeight,
+      ));
       if (cursorData.length === 0) {
         // No data at the cursor height, so signal beginning of stream.
         return;
@@ -573,9 +575,6 @@ export const makeCosmjsFollower = (
       return getEachIterableAtHeight(height);
     },
     async getReverseIterable({ height = undefined } = {}) {
-      if (height === undefined) {
-        height = await getBlockHeight();
-      }
       return getReverseIterableAtHeight(height);
     },
   });


### PR DESCRIPTION
closes: #6384

## Description

Whenever fetching data at the latest height, Casting was first making a query for height. In some loops it was repeated.

This uses Tendermint RPC's `abciQuery` to fetch data at the same time as height. To do this, many of the helper functions had to be refactored to return the height along with the data. It no longer uses the Stargate abstraction, but to align with it the `QueryAbciResponse` type is copied and used.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

I tested some agoric-cli commands which use Casting. 