### PR TITLE
6384 single fetch for data and block height

### DIFF
--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -61,6 +61,22 @@ const arrayEqual = (a, b) => {
 const defaultDataPrefixBytes = new Uint8Array();
 
 /**
+ * @param {Uint8Array} prefixedData
+ * @param {Uint8Array} prefix
+ */
+const stripPrefix = (prefixedData, prefix) => {
+  assert(
+    prefixedData.length >= prefix.length,
+    X`result too short for data prefix ${prefix}`,
+  );
+  assert(
+    arrayEqual(prefixedData.subarray(0, prefix.length), prefix),
+    X`${prefixedData} doesn't start with data prefix ${prefix}`,
+  );
+  return prefixedData.slice(prefix.length);
+};
+
+/**
  * @template T
  * @param {Iterable<T>} values
  * @returns {T}
@@ -211,17 +227,7 @@ export const makeCosmjsFollower = (
       // No data.
       return result;
     }
-
-    // Handle the data prefix if any.
-    assert(
-      result.length >= dataPrefixBytes.length,
-      X`result too short for data prefix ${dataPrefixBytes}`,
-    );
-    assert(
-      arrayEqual(result.subarray(0, dataPrefixBytes.length), dataPrefixBytes),
-      X`${result} doesn't start with data prefix ${dataPrefixBytes}`,
-    );
-    return result.slice(dataPrefixBytes.length);
+    return stripPrefix(result, dataPrefixBytes);
   };
 
   /**

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-await-in-loop, no-continue, @jessie.js/no-nested-await */
 
 import { E, Far } from '@endo/far';
-import * as tendermintRpcStar from '@cosmjs/tendermint-rpc';
+import * as tendermint34 from '@cosmjs/tendermint-rpc';
 import * as stargateStar from '@cosmjs/stargate';
 
 import { MAKE_DEFAULT_DECODER, MAKE_DEFAULT_UNSERIALIZER } from './defaults.js';
@@ -10,11 +10,22 @@ import { makeCastingSpec } from './casting-spec.js';
 import { makeLeader as defaultMakeLeader } from './leader-netconfig.js';
 
 const { QueryClient } = stargateStar;
-const { Tendermint34Client } = tendermintRpcStar;
+const { Tendermint34Client } = tendermint34;
 const { details: X, quote: q } = assert;
 const textDecoder = new TextDecoder();
 
 /** @template T @typedef {import('./types.js').Follower<import('./types.js').ValueFollowerElement<T>>} ValueFollower */
+
+// Copied from https://github.com/cosmos/cosmjs/pull/1328/files until release
+/**
+ * @typedef {{
+ *   readonly value: Uint8Array;
+ *   readonly height: number;
+ * }} QueryAbciResponse
+ * The response of an ABCI query to Tendermint.
+ * This is a subset of `tendermint34.AbciQueryResponse` in order
+ * to abstract away Tendermint versions.
+ */
 
 /**
  * This is an imperfect heuristic to navigate the migration from value cells to
@@ -116,7 +127,7 @@ export const makeCosmjsFollower = (
   const tendermintClientPs = new Map();
   /**
    * @param {string} endpoint
-   * @returns {tendermintRpcStar.Tendermint34Client}
+   * @returns {tendermint34.Tendermint34Client}
    */
   const provideTendermintClient = endpoint => {
     let clientP = tendermintClientPs.get(endpoint);

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -598,7 +598,7 @@ export const makeCosmjsFollower = (
   }
 
   /**
-   * @param {number} cursorBlockHeight
+   * @param {number} [cursorBlockHeight]
    * @yields {ValueFollowerElement<T>}
    */
   async function* getReverseIterableAtHeight(cursorBlockHeight) {
@@ -606,8 +606,10 @@ export const makeCosmjsFollower = (
     // cursorBlockHeight) so we know not to emit duplicates
     // of that cell.
     let cursorData;
-    while (cursorBlockHeight > 0) {
-      cursorData = (await getDataAtHeight(cursorBlockHeight)).value;
+    while (cursorBlockHeight === undefined || cursorBlockHeight > 0) {
+      ({ value: cursorData, height: cursorBlockHeight } = await getDataAtHeight(
+        cursorBlockHeight,
+      ));
       if (cursorData.length === 0) {
         // No data at the cursor height, so signal beginning of stream.
         return;
@@ -627,9 +629,6 @@ export const makeCosmjsFollower = (
       return getEachIterableAtHeight(height);
     },
     async getReverseIterable({ height = undefined } = {}) {
-      if (height === undefined) {
-        height = await getBlockHeight();
-      }
       return getReverseIterableAtHeight(height);
     },
   });


### PR DESCRIPTION
closes: #6384

A fresh try at https://github.com/Agoric/agoric-sdk/pull/6603 with fewer changes.

## Description

Whenever fetching data at the latest height, Casting was first making a query for height. In some loops it was repeated.

This uses Tendermint RPC's `abciQuery` to fetch data at the same time as height. To do this, many of the helper functions had to be refactored to return the height along with the data (using the `QueryAbciResponse` type from  https://github.com/cosmos/cosmjs/pull/1328/ )

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

I tested some agoric-cli commands which use Casting. 