### PR TITLE
4383 debugging fee mint access

### DIFF
--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -138,6 +138,13 @@ export const DisplayInfoShape = M.partial(
   }),
 );
 
+export const IssuerKitShape = harden({
+  brand: BrandShape,
+  mint: MintShape,
+  issuer: IssuerShape,
+  displayInfo: DisplayInfoShape,
+});
+
 // //////////////////////// Interfaces /////////////////////////////////////////
 
 export const BrandI = M.interface('Brand', {

--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -18,6 +18,9 @@ import { parseVatSlot } from '../lib/parseVatSlots.js';
 // later regenerated.
 const unweakable = new WeakSet();
 
+// label representatives to simplify identification during debugging
+const LABEL_REPRESENTATIVES = true;
+
 /**
  * Make a simple LRU cache of virtual object inner selves.
  *
@@ -732,7 +735,10 @@ export function makeVirtualObjectManager(
         // `context` does not need a linkToCohort because it holds the
         // facets (which hold the cohort)
         unweakable.add(context);
-        const self = harden({ __proto__: prototypeTemplate });
+        const self = harden({
+          __proto__: prototypeTemplate,
+          ...(LABEL_REPRESENTATIVES ? { [innerSelf.baseRef]: () => {} } : {}),
+        });
         context.self = self;
         contextMapTemplate.set(self, context);
         toHold = self;
@@ -746,6 +752,9 @@ export function makeVirtualObjectManager(
         for (const name of facetNames) {
           const facet = harden({
             __proto__: prototypeTemplate[name],
+            ...(LABEL_REPRESENTATIVES
+              ? { [`${innerSelf.baseRef}|${name}`]: () => {} }
+              : {}),
           });
           contextMapTemplate[name].set(facet, context);
           facets[name] = facet;

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -159,6 +159,7 @@ const start = async (zcf, privateArgs) => {
     electionManager: zcf.getInstance(),
   });
 
+  console.log(`CG  START `, privateArgs.governed.feeMintAccess);
   const {
     creatorFacet: governedCF,
     instance: governedInstance,

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -46,15 +46,14 @@ const setUpZoeForTest = async setJig => {
    * @property {IssuerRecord} mintedIssuerRecord
    * @property {IssuerRecord} govIssuerRecord
    */
-  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
+  const { zoeService, feeMintAccessRetriever } = makeZoeKit(
     makeFakeVatAdmin(setJig, o => makeFar(o)).admin,
   );
   /** @type {ERef<ZoeService>} */
   const zoe = makeFar(zoeService);
-  const feeMintAccess = await makeFar(nonFarFeeMintAccess);
   return {
     zoe,
-    feeMintAccess,
+    feeMintAccessP: feeMintAccessRetriever.get(),
   };
 };
 

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -789,6 +789,8 @@ export const startStakeFactory = async (
       feeMintAccessP,
     ]);
 
+  console.log(`EB  p.all`, feeMintAccess);
+
   const stakeFactoryTerms = makeStakeFactoryTerms(
     {
       timerService: chainTimerService,

--- a/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -265,10 +265,6 @@ const start = async zcf => {
       { stopAfter: debt },
     );
     await Promise.all([E(liqSeat).getOfferResult(), deposited]);
-
-    // This uses getCurrentAllocationJig only to support testing, so is ok
-    const amounts = await E(liqSeat).getCurrentAllocationJig();
-    trace('offerResult', { amounts });
   }
 
   /**

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/test-liquidity.js
@@ -5,7 +5,7 @@ import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { setup } from '@agoric/zoe/test/unitTests/setupBasicMints.js';
-import { assertPayoutAmount } from '@agoric/zoe/test/zoeTestHelpers.js';
+import { assertGetPayoutAmount } from '@agoric/zoe/test/zoeTestHelpers.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { subscriptionTracker } from '../../metrics.js';
@@ -117,7 +117,7 @@ const makeAssertPayouts = (
     sExpected,
   ) => {
     const lAmount = AmountMath.make(liquidityBrand, lExpected);
-    await assertPayoutAmount(
+    await assertGetPayoutAmount(
       t,
       moolaLiquidityIssuer,
       lPayment,
@@ -125,7 +125,7 @@ const makeAssertPayouts = (
       'Liquidity payout',
     );
     const cAmount = AmountMath.make(centralR.brand, cExpected);
-    await assertPayoutAmount(
+    await assertGetPayoutAmount(
       t,
       centralR.issuer,
       cPayment,
@@ -133,7 +133,7 @@ const makeAssertPayouts = (
       'central payout',
     );
     const sAmount = AmountMath.make(moolaKit.brand, sExpected);
-    await assertPayoutAmount(
+    await assertGetPayoutAmount(
       t,
       moolaKit.issuer,
       sPayment,

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -19,7 +19,7 @@ import {
 } from '@agoric/zoe/test/autoswapJig.js';
 import {
   assertAmountsEqual,
-  assertPayoutAmount,
+  assertGetPayoutAmount,
 } from '@agoric/zoe/test/zoeTestHelpers.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
@@ -603,9 +603,13 @@ test('amm doubleSwap', async t => {
     undefined,
   );
 
-  const payout = await E(collectFeesSeat).getPayout('Fee');
-
-  await assertPayoutAmount(t, centralR.issuer, payout, runningFees);
+  await assertGetPayoutAmount(
+    t,
+    centralR.issuer,
+    collectFeesSeat,
+    'Fee',
+    runningFees,
+  );
 
   t.deepEqual(await E(amm.ammPublicFacet).getProtocolPoolBalance(), {
     Fee: AmountMath.makeEmpty(centralR.brand),
@@ -813,12 +817,11 @@ test('amm jig - swapOut uneven', async t => {
     undefined,
   );
 
-  const payout = await E(collectFeesSeat).getPayout('Fee');
-
-  await assertPayoutAmount(
+  await assertGetPayoutAmount(
     t,
     centralR.issuer,
-    payout,
+    collectFeesSeat,
+    'Fee',
     AmountMath.make(centralR.brand, expectedPoolBalance),
     'payout of collectFeesSeat',
   );
@@ -944,14 +947,14 @@ test('zoe allow empty reallocations', async t => {
     undefined,
   );
 
-  const payout = await E(collectFeesSeat2).getPayout('Fee');
   const result = await E(collectFeesSeat2).getOfferResult();
 
   t.deepEqual(result, 'paid out 0');
-  await assertPayoutAmount(
+  await assertGetPayoutAmount(
     t,
     centralR.issuer,
-    payout,
+    collectFeesSeat2,
+    'Fee',
     AmountMath.makeEmpty(centralR.brand),
   );
 });

--- a/packages/inter-protocol/test/psm/test-governedPsm.js
+++ b/packages/inter-protocol/test/psm/test-governedPsm.js
@@ -196,6 +196,5 @@ test('replace electorate of Economic Committee', async t => {
   const pf = await E(governorCreatorFacet).getPublicFacet();
   const { Electorate: newElectorate } = await E(pf).getGovernedParams();
   t.is(newElectorate.type, 'invitation');
-  // @ts-expect-error unknonwn
   t.is(newElectorate.value.value[0].instance, secondElectorateInstance);
 });

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -85,7 +85,7 @@ const minusAnchorFee = (anchor, anchorPerMinted) => {
 const makeTestContext = async () => {
   const bundleCache = await unsafeMakeBundleCache('bundles/');
   const psmBundle = await bundleCache.load(psmRoot, 'psm');
-  const { zoe, feeMintAccess } = setUpZoeForTest();
+  const { zoe, feeMintAccessP } = setUpZoeForTest();
 
   const mintedIssuer = await E(zoe).getFeeIssuer();
   /** @type {IssuerKit} */
@@ -124,7 +124,7 @@ const makeTestContext = async () => {
   return {
     bundles: { psmBundle },
     zoe: await zoe,
-    feeMintAccess: await feeMintAccess,
+    feeMintAccess: await feeMintAccessP,
     initialPoserInvitation,
     minted,
     anchor,

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -82,7 +82,7 @@ export const setupReserveServices = async (
   timer = buildManualTimer(t.log),
 ) => {
   const farZoeKit = await setUpZoeForTest();
-  const { feeMintAccess, zoe } = farZoeKit;
+  const { feeMintAccessP, zoe } = farZoeKit;
 
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
@@ -102,6 +102,7 @@ export const setupReserveServices = async (
   const faucetInstallation = E(zoe).install(faucetBundle);
   brand.produce.IST.resolve(runBrand);
   issuer.produce.IST.resolve(runIssuer);
+  const feeMintAccess = await feeMintAccessP;
   produce.feeMintAccess.resolve(await feeMintAccess);
 
   const governorCreatorFacet = consume.reserveGovernorCreatorFacet;

--- a/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
+++ b/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
@@ -88,7 +88,7 @@ test.before(async t => {
   );
   console.timeEnd('bundling');
 
-  const { zoe, feeMintAccess } = await setUpZoeForTest(() => {});
+  const { zoe, feeMintAccessP } = await setUpZoeForTest(() => {});
   const bld = makeIssuerKit('BLD', AssetKind.NAT, micro.displayInfo);
   const issuer = {
     [Stable.symbol]: await E(zoe).getFeeIssuer(),
@@ -114,7 +114,7 @@ test.before(async t => {
   t.context = await deeplyFulfilled(
     harden({
       zoe,
-      feeMintAccess,
+      feeMintAccess: feeMintAccessP,
       issuer,
       brand,
       installation,

--- a/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
+++ b/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
@@ -934,7 +934,7 @@ test('Add collateral - more BLD required (FAIL)', async t => {
   await d.checkBLDLiened(800n);
 });
 
-test('Lower collateral', async t => {
+test.only('Lower collateral', async t => {
   const d = await makeWorld(t);
   await d.buyBLD(1000n);
   await d.stakeBLD(1000n);

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -58,9 +58,10 @@ export const setUpZoeForTest = (setJig = () => {}) => {
   );
   /** @type {ERef<ZoeService>} */
   const zoe = makeFar(zoeService);
+  console.log(`SUPP  setup`, feeMintAccessRetriever);
   return {
     zoe,
-    feeMintAccessP: feeMintAccessRetriever.get(),
+    feeMintAccessP: E(feeMintAccessRetriever).get(),
   };
 };
 harden(setUpZoeForTest);

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -47,7 +47,7 @@ harden(provideBundle);
 export const setUpZoeForTest = (setJig = () => {}) => {
   const { makeFar } = makeLoopback('zoeTest');
 
-  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
+  const { zoeService, feeMintAccessRetriever } = makeZoeKit(
     makeFakeVatAdmin(setJig).admin,
     undefined,
     {
@@ -58,10 +58,9 @@ export const setUpZoeForTest = (setJig = () => {}) => {
   );
   /** @type {ERef<ZoeService>} */
   const zoe = makeFar(zoeService);
-  const feeMintAccess = makeFar(nonFarFeeMintAccess);
   return {
     zoe,
-    feeMintAccess,
+    feeMintAccessP: feeMintAccessRetriever.get(),
   };
 };
 harden(setUpZoeForTest);

--- a/packages/inter-protocol/test/swingsetTests/governance/bootstrap.js
+++ b/packages/inter-protocol/test/swingsetTests/governance/bootstrap.js
@@ -88,13 +88,16 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
     devices.vatAdmin,
   );
-  const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
+  const { zoe, feeMintAccessRetriever } = await E(vats.zoe).buildZoe(
+    vatAdminSvc,
+  );
 
   const installations = await installContracts(zoe, cb);
   const voterCreator = E(vats.voter).build(zoe);
 
   const [testName, startingValues] = argv;
 
+  const feeMintAccess = await E(feeMintAccessRetriever).get();
   const {
     aliceP,
     governor,

--- a/packages/inter-protocol/test/swingsetTests/governance/vat-zoe.js
+++ b/packages/inter-protocol/test/swingsetTests/governance/vat-zoe.js
@@ -10,7 +10,7 @@ export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe, feeMintAccess } = makeZoeKit(
+      const { zoeService: zoe, feeMintAccessRetriever } = makeZoeKit(
         vatAdminSvc,
         shutdownZoeVat,
         {
@@ -20,7 +20,7 @@ export function buildRootObject(vatPowers) {
         },
       );
 
-      return { zoe, feeMintAccess };
+      return { zoe, feeMintAccessRetriever };
     },
   });
 }

--- a/packages/inter-protocol/test/swingsetTests/vaultFactory/bootstrap.js
+++ b/packages/inter-protocol/test/swingsetTests/vaultFactory/bootstrap.js
@@ -9,11 +9,14 @@ function makeBootstrap(argv, cb, vatPowers) {
     const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
       devices.vatAdmin,
     );
-    const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
+    const { zoe, feeMintAccessRetriever } = await E(vats.zoe).buildZoe(
+      vatAdminSvc,
+    );
 
     const installations = await installContracts(zoe, cb);
 
     const [testName, startingValues] = argv;
+    const feeMintAccess = await E(feeMintAccessRetriever).get();
     const { aliceP, vaultFactory } = await makeVats(
       vatPowers.testLog,
       vats,

--- a/packages/inter-protocol/test/swingsetTests/vaultFactory/vat-zoe.js
+++ b/packages/inter-protocol/test/swingsetTests/vaultFactory/vat-zoe.js
@@ -10,7 +10,7 @@ export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe, feeMintAccess } = makeZoeKit(
+      const { zoeService: zoe, feeMintAccessRetriever } = makeZoeKit(
         vatAdminSvc,
         shutdownZoeVat,
         {
@@ -19,7 +19,7 @@ export function buildRootObject(vatPowers) {
           displayInfo: Stable.displayInfo,
         },
       );
-      return { zoe, feeMintAccess };
+      return { zoe, feeMintAccessRetriever };
     },
   });
 }

--- a/packages/inter-protocol/test/test-feeDistributor.js
+++ b/packages/inter-protocol/test/test-feeDistributor.js
@@ -7,7 +7,7 @@ import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { setup } from '@agoric/zoe/test/unitTests/setupBasicMints.js';
 
-import { assertPayoutAmount } from '@agoric/zoe/test/zoeTestHelpers.js';
+import { assertGetPayoutAmount } from '@agoric/zoe/test/zoeTestHelpers.js';
 import { E, Far } from '@endo/far';
 import { makeFeeDistributor } from '../src/feeDistributor.js';
 
@@ -61,7 +61,7 @@ const assertPaymentArray = async (
   for (let i = 0; i < count; i += 1) {
     // XXX https://github.com/Agoric/agoric-sdk/issues/5527
     // eslint-disable-next-line no-await-in-loop
-    await assertPayoutAmount(
+    await assertGetPayoutAmount(
       t,
       issuer,
       payments[i],

--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -57,7 +57,7 @@ let lastProposalSequence = 0;
 
 const makeTestContext = async () => {
   const bundleCache = await makeNodeBundleCache('bundles/', s => import(s));
-  const { zoe, feeMintAccess } = await setUpZoeForTest();
+  const { zoe, feeMintAccessP } = await setUpZoeForTest();
 
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
@@ -103,7 +103,7 @@ const makeTestContext = async () => {
     restoreBundleID,
     cleanups: [],
     zoe: await zoe,
-    feeMintAccess: await feeMintAccess,
+    feeMintAccess: await feeMintAccessP,
     run: { issuer: runIssuer, brand: runBrand },
     installation,
   };

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -98,7 +98,7 @@ const defaultParamValues = debt =>
  * @returns {Promise<DriverContext>}
  */
 export const makeDriverContext = async () => {
-  const { zoe, feeMintAccessRetriever } = setUpZoeForTest();
+  const { zoe, feeMintAccessP } = setUpZoeForTest();
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
   // @ts-expect-error missing mint
@@ -119,7 +119,8 @@ export const makeDriverContext = async () => {
     reserve: bundleCache.load(contractRoots.reserve, 'reserve'),
   });
   const installation = objectMap(bundles, bundle => E(zoe).install(bundle));
-  const feeMintAccess = await E(feeMintAccessRetriever).get();
+
+  const feeMintAccess = await feeMintAccessP;
   const contextPs = {
     bundles,
     installation,

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -98,7 +98,7 @@ const defaultParamValues = debt =>
  * @returns {Promise<DriverContext>}
  */
 export const makeDriverContext = async () => {
-  const { zoe, feeMintAccess } = setUpZoeForTest();
+  const { zoe, feeMintAccessRetriever } = setUpZoeForTest();
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
   // @ts-expect-error missing mint
@@ -119,6 +119,7 @@ export const makeDriverContext = async () => {
     reserve: bundleCache.load(contractRoots.reserve, 'reserve'),
   });
   const installation = objectMap(bundles, bundle => E(zoe).install(bundle));
+  const feeMintAccess = await E(feeMintAccessRetriever).get();
   const contextPs = {
     bundles,
     installation,

--- a/packages/inter-protocol/test/vaultFactory/test-vault-interest.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-interest.js
@@ -36,13 +36,14 @@ const setJig = jig => {
 
 const { makeFar, makeNear: makeRemote } = makeLoopback('zoeTest');
 
-const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
+const { zoeService, feeMintAccessRetriever } = makeZoeKit(
   makeFakeVatAdmin(setJig, makeRemote).admin,
 );
+
 /** @type {ERef<ZoeService>} */
 const zoe = makeFar(zoeService);
 trace('makeZoe');
-const feeMintAccessP = makeFar(nonFarFeeMintAccess);
+const feeMintAccessP = feeMintAccessRetriever.get();
 
 /**
  * @param {ERef<ZoeService>} zoeP

--- a/packages/inter-protocol/test/vaultFactory/test-vault.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault.js
@@ -36,13 +36,13 @@ const setJig = jig => {
 
 const { makeFar, makeNear: makeRemote } = makeLoopback('zoeTest');
 
-const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
+const { zoeService, feeMintAccessRetriever } = makeZoeKit(
   makeFakeVatAdmin(setJig, makeRemote).admin,
 );
 /** @type {ERef<ZoeService>} */
 const zoe = makeFar(zoeService);
 trace('makeZoe');
-const feeMintAccessP = makeFar(nonFarFeeMintAccess);
+const feeMintAccessP = feeMintAccessRetriever.get();
 
 /**
  * @param {ERef<ZoeService>} zoeP

--- a/packages/inter-protocol/test/vaultFactory/test-vault.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault.js
@@ -40,7 +40,8 @@ const { zoeService, feeMintAccessRetriever } = makeZoeKit(
   makeFakeVatAdmin(setJig, makeRemote).admin,
 );
 /** @type {ERef<ZoeService>} */
-const zoe = makeFar(zoeService);
+const zoe = zoeService;
+// const zoe = makeFar(zoeService);
 trace('makeZoe');
 const feeMintAccessP = feeMintAccessRetriever.get();
 
@@ -67,6 +68,7 @@ async function launch(zoeP, sourceRoot) {
     collateralKit: { mint: collateralMint, brand: collateralBrand },
   } = testJig;
   const { brand: runBrand } = runMint.getIssuerRecord();
+  console.log(`TV  launch   brand`, runBrand);
 
   const collateral50 = AmountMath.make(collateralBrand, 50n);
   const proposal = harden({
@@ -86,7 +88,7 @@ async function launch(zoeP, sourceRoot) {
 
 const helperContract = launch(zoe, vaultRoot);
 
-test('first', async t => {
+test.only('first', async t => {
   const { creatorSeat, creatorFacet } = await helperContract;
 
   // Our wrapper gives us a Vault which holds 50 Collateral, has lent out 70

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -110,7 +110,7 @@ const defaultParamValues = debtBrand =>
   });
 
 test.before(async t => {
-  const { zoe, feeMintAccess } = setUpZoeForTest();
+  const { zoe, feeMintAccessRetriever } = setUpZoeForTest();
   const runIssuer = await E(zoe).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
   // @ts-expect-error missing mint
@@ -128,6 +128,7 @@ test.before(async t => {
   });
   const installation = objectMap(bundles, bundle => E(zoe).install(bundle));
 
+  const feeMintAccess = await E(feeMintAccessRetriever).get();
   const contextPs = {
     zoe,
     feeMintAccess,

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -70,15 +70,14 @@ export const subscriptionKey = subscription => {
 
 const setUpZoeForTest = async () => {
   const { makeFar } = makeLoopback('zoeTest');
-  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
+  const { zoeService, feeMintAccessRetriever } = makeZoeKit(
     makeFakeVatAdmin(() => {}).admin,
   );
   /** @type {import('@endo/far').ERef<ZoeService>} */
   const zoe = makeFar(zoeService);
-  const feeMintAccess = await makeFar(nonFarFeeMintAccess);
   return {
     zoe,
-    feeMintAccess,
+    feeMintAccessRetriever,
   };
 };
 harden(setUpZoeForTest);
@@ -126,9 +125,9 @@ export const makeMockTestSpace = async log => {
   const { agoricNames, spaces } = makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
 
-  const { zoe, feeMintAccess } = await setUpZoeForTest();
+  const { zoe, feeMintAccessRetriever } = await setUpZoeForTest();
   produce.zoe.resolve(zoe);
-  produce.feeMintAccess.resolve(feeMintAccess);
+  produce.feeMintAccess.resolve(feeMintAccessRetriever.get());
 
   const vatLoader = name => {
     switch (name) {

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -1636,7 +1636,7 @@ const makePatternKit = () => {
     interface: (interfaceName, methodGuards, { sloppy = false } = {}) => {
       for (const [_, methodGuard] of entries(methodGuards)) {
         methodGuard.klass === 'methodGuard' ||
-          assert.fail(X`unrecognize method guard ${methodGuard}`);
+          assert.fail(X`unrecognized method guard ${methodGuard}`);
       }
       return harden({
         klass: 'Interface',

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -112,12 +112,13 @@ export const buildZoe = async ({
   produce: { zoe, feeMintAccess },
 }) => {
   const zcfBundleName = 'zcf'; // should match config.bundles.zcf=
-  const { zoeService, feeMintAccess: fma } = await E(
+  const { zoeService, feeMintAccessRetriever } = await E(
     E(loadCriticalVat)('zoe'),
   ).buildZoe(vatAdminSvc, feeIssuerConfig, zcfBundleName);
 
   zoe.resolve(zoeService);
 
+  const fma = await feeMintAccessRetriever.get();
   feeMintAccess.resolve(fma);
   return Promise.all([
     E(client).assignBundle([_addr => ({ zoe: zoeService })]),

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -6,7 +6,7 @@ export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
     buildZoe: async (adminVat, feeIssuerConfig, zcfBundleName) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
       assert(zcfBundleName, `vat-zoe requires zcfBundleName`);
-      const { zoeService, feeMintAccess } = makeZoeKit(
+      const { zoeService, feeMintAccessRetriever } = makeZoeKit(
         adminVat,
         shutdownZoeVat,
         feeIssuerConfig,

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -15,7 +15,7 @@ export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
       );
       return harden({
         zoeService,
-        feeMintAccess,
+        feeMintAccessRetriever,
       });
     },
   });

--- a/packages/vats/test/test-bootstrapPayment.js
+++ b/packages/vats/test/test-bootstrapPayment.js
@@ -15,7 +15,7 @@ import { Stable } from '../src/tokens.js';
 
 const setUpZoeForTest = setJig => {
   const { makeFar } = makeLoopback('zoeTest');
-  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
+  const { zoeService, feeMintAccessRetriever } = makeZoeKit(
     makeFakeVatAdmin(setJig).admin,
     undefined,
     {
@@ -26,10 +26,9 @@ const setUpZoeForTest = setJig => {
   );
   /** @type {ERef<ZoeService>} */
   const zoe = makeFar(zoeService);
-  const feeMintAccess = makeFar(nonFarFeeMintAccess);
   return {
     zoe,
-    feeMintAccess,
+    feeMintAccessRetriever,
   };
 };
 
@@ -45,7 +44,7 @@ const setUpZoeForTest = setJig => {
  */
 
 test.before(async (/** @type {CentralSupplyTestContext} */ t) => {
-  const { zoe, feeMintAccess } = await setUpZoeForTest(() => {});
+  const { zoe, feeMintAccessRetriever } = await setUpZoeForTest(() => {});
   const issuer = {
     IST: E(zoe).getFeeIssuer(),
   };
@@ -60,7 +59,7 @@ test.before(async (/** @type {CentralSupplyTestContext} */ t) => {
   t.context = await deeplyFulfilled(
     harden({
       zoe,
-      feeMintAccess,
+      feeMintAccess: E(feeMintAccessRetriever).get(),
       issuer,
       brand,
       installation,

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -28,7 +28,7 @@ import { devices } from './devices.js';
 
 const setUpZoeForTest = async () => {
   const { makeFar } = makeLoopback('zoeTest');
-  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
+  const { zoeService, feeMintAccessRetriever } = makeZoeKit(
     makeFakeVatAdmin(() => {}).admin,
     undefined,
     {
@@ -39,10 +39,9 @@ const setUpZoeForTest = async () => {
   );
   /** @type {ERef<ZoeService>} */
   const zoe = makeFar(zoeService);
-  const feeMintAccess = await makeFar(nonFarFeeMintAccess);
   return {
     zoe,
-    feeMintAccess,
+    feeMintAccessRetriever,
   };
 };
 harden(setUpZoeForTest);
@@ -62,8 +61,9 @@ test('connectFaucet produces payments', async t => {
   const { agoricNames, spaces } = makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
 
-  const { zoe, feeMintAccess } = await setUpZoeForTest();
+  const { zoe, feeMintAccessRetriever } = await setUpZoeForTest();
   produce.zoe.resolve(zoe);
+  const feeMintAccess = await feeMintAccessRetriever.get();
   produce.feeMintAccess.resolve(feeMintAccess);
   produce.bridgeManager.resolve(undefined);
 

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -45,7 +45,7 @@ const makeTestContext = async () => {
   const bundleCache = await unsafeMakeBundleCache('bundles/');
   const psmBundle = await bundleCache.load(psmRoot, 'psm');
   const policyBundle = await bundleCache.load(policyRoot, 'provisionPool');
-  const { zoe, feeMintAccess } = setUpZoeForTest();
+  const { zoe, feeMintAccessP } = setUpZoeForTest();
 
   const mintedIssuer = await E(zoe).getFeeIssuer();
   /** @type {Brand<'nat'>} */
@@ -85,7 +85,7 @@ const makeTestContext = async () => {
     bundles: { psmBundle },
     storageRoot,
     zoe: await zoe,
-    feeMintAccess: await feeMintAccess,
+    feeMintAccess: await feeMintAccessP,
     committeeCreator,
     initialPoserInvitation,
     minted: { issuer: mintedIssuer, brand: mintedBrand },

--- a/packages/vats/test/test-vat-bank.js
+++ b/packages/vats/test/test-vat-bank.js
@@ -207,10 +207,11 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
   const { agoricNames, spaces } = makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
 
-  const { zoeService, feeMintAccess } = makeZoeKit(
+  const { zoeService, feeMintAccessRetriever } = makeZoeKit(
     makeFakeVatAdmin(() => {}).admin,
   );
   produce.zoe.resolve(zoeService);
+  const feeMintAccess = await feeMintAccessRetriever.get();
   produce.feeMintAccess.resolve(feeMintAccess);
   const vatPowers = {
     D: x => x,

--- a/packages/zoe/docs/ZoeDataInitialization.puml
+++ b/packages/zoe/docs/ZoeDataInitialization.puml
@@ -12,7 +12,7 @@ end box
 bootstrap -> Zoe: makeZoeKit(...)
 Zoe -> ZoeStorageManager : makeZoeStorageManager()
 ZoeStorageManager -> ZoeStorageManager : provideIssuerStorage()
-ZoeStorageManager -> ZoeStorageManager : makeEscrowStorage()
+ZoeStorageManager -> ZoeStorageManager : provideEscrowStorage()
 ZoeStorageManager -> ZoeStorageManager : vivifyInvitationKit()
 ZoeStorageManager -> InstanceAdminStorage : makeInstanceAdminStorage()
 InstanceAdminStorage -> InstanceAdminStorage : instanceToInstanceAdmin

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -2,7 +2,8 @@
 
 import { assert, details as X, q } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { vivifyFarClass, provideDurableSetStore } from '@agoric/vat-data';
+import { M, initEmpty } from '@agoric/store';
 
 import {
   isOnDemandExitRule,
@@ -10,57 +11,107 @@ import {
   isWaivedExitRule,
 } from '../typeGuards.js';
 
-/**
- * Makes the appropriate exitObj, which runs in ZCF and allows the seat's owner
- * to request the position be exited.
- */
+const ExitObjectGuard = M.interface('ExitObject', { exit: M.call().returns() });
+const WakerInterfaceGuard = M.interface('Waker', {
+  wake: M.call(M.bigint()).returns(),
+  schedule: M.call().returns(),
+});
 
-/** @type {MakeExitObj} */
-export const makeExitObj = (proposal, zcfSeat) => {
-  const { exit } = proposal;
+export const makeMakeExiter = baggage => {
+  const activeWakers = provideDurableSetStore(baggage, 'activeWakers');
 
-  if (isOnDemandExitRule(exit)) {
-    // Allow the user to exit their seat on demand. Note: we must wrap
-    // it in an object to send it back to Zoe because our marshalling layer
-    // only allows two kinds of objects: records (no methods and only
-    // data) and presences (local proxies for objects that may have
-    // methods).
-    return Far('exitObj', {
-      exit: () => zcfSeat.exit(),
-    });
-  }
-
-  if (isAfterDeadlineExitRule(exit)) {
-    // Automatically exit the seat after deadline.
-    E(exit.afterDeadline.timer)
-      .setWakeup(
-        exit.afterDeadline.deadline,
-        Far('wakeObj', {
-          wake: () => zcfSeat.exit(),
-        }),
-      )
-      .catch(reason => {
-        console.error(
-          `The seat could not be made with the provided timer ${exit.afterDeadline.timer} and deadline ${exit.afterDeadline.deadline}`,
-        );
-        console.error(reason);
-        zcfSeat.fail(reason);
-        throw reason;
-      });
-  }
-
-  if (isWaivedExitRule(exit) || isAfterDeadlineExitRule(exit)) {
-    /** @type {ExitObj} */
-    return Far('exitObj', {
-      exit: () => {
-        // if exitKind is 'waived' the user has no ability to exit their seat
-        // on demand
+  const makeExitable = vivifyFarClass(
+    baggage,
+    'ExitObject',
+    ExitObjectGuard,
+    zcfSeat => ({ zcfSeat }),
+    {
+      exit() {
+        // @ts-expect-error context isn't known yet.
+        const { state } = this;
+        state.zcfSeat.exit();
+      },
+    },
+  );
+  const makeWaived = vivifyFarClass(
+    baggage,
+    'ExitWaived',
+    ExitObjectGuard,
+    initEmpty,
+    {
+      exit() {
+        // in this case the user has no ability to exit their seat on demand
         throw Error(
           `Only seats with the exit rule "onDemand" can exit at will`,
         );
       },
-    });
+    },
+  );
+  const makeWaker = vivifyFarClass(
+    baggage,
+    'Waker',
+    WakerInterfaceGuard,
+    (zcfSeat, afterDeadline) => ({ zcfSeat, afterDeadline }),
+    {
+      wake(_when) {
+        // @ts-expect-error context isn't known yet.
+        const { state, self } = this;
+
+        activeWakers.delete(self);
+        state.zcfSeat.exit();
+      },
+      schedule() {
+        // @ts-expect-error context isn't known yet.
+        const { state, self } = this;
+
+        E(state.afterDeadline.timer)
+          .setWakeup(state.afterDeadline.deadline, self)
+          .catch(reason => {
+            console.error(
+              `The seat could not be made with the provided timer ${state.afterDeadline.timer} and deadline ${state.afterDeadline.deadline}`,
+            );
+            console.error(reason);
+            state.zcfSeat.fail(reason);
+            throw reason;
+          });
+      },
+    },
+  );
+
+  // On revival, reschedule all the active wakers.
+  for (const waker of activeWakers.values()) {
+    waker.schedule();
   }
 
-  assert.fail(X`exit kind was not recognized: ${q(exit)}`);
+  /**
+   * Makes the appropriate exitObj, which runs in ZCF and allows the seat's owner
+   * to request the position be exited.
+   *
+   * @type {MakeExitObj}
+   */
+  return (proposal, zcfSeat) => {
+    const { exit } = proposal;
+
+    if (isOnDemandExitRule(exit)) {
+      // Allow the user to exit their seat on demand. Note: we must wrap
+      // it in an object to send it back to Zoe because our marshalling layer
+      // only allows two kinds of objects: records (no methods and only
+      // data) and presences (local proxies for objects that may have
+      // methods).
+      return makeExitable(zcfSeat);
+    }
+
+    if (isAfterDeadlineExitRule(exit)) {
+      const waker = makeWaker(zcfSeat, exit.afterDeadline);
+      activeWakers.add(waker);
+      // Automatically exit the seat after deadline.
+      waker.schedule();
+    }
+
+    if (isWaivedExitRule(exit) || isAfterDeadlineExitRule(exit)) {
+      return makeWaived();
+    }
+
+    assert.fail(X`exit kind was not recognized: ${q(exit)}`);
+  };
 };

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -45,6 +45,7 @@
  * @property {SetTestJig} setTestJig
  * @property {() => Promise<void>} stopAcceptingOffers
  * @property {(strings: Array<string>) => void} setOfferFilter
+ * @property {() => Promise<Array<string>>} getOfferFilter
  * @property {() => Instance} getInstance
  */
 
@@ -187,7 +188,7 @@
  * @typedef {object} ZCFSeat
  * @property {() => void} exit
  * @property {ZCFSeatFail} fail
- * @property {() => Promise<Notifier<Allocation>>} getNotifier
+ * @property {() => Promise<Subscriber<Allocation>>} getSubscriber
  * @property {() => boolean} hasExited
  * @property {() => ProposalRecord} getProposal
  * @property {ZCFGetAmountAllocated} getAmountAllocated

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -93,12 +93,12 @@ export const makeZCFMintFactory = async (
               X`The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`,
             );
           // No effects above, apart from incrementBy. Note COMMIT POINT within
-          // reallocateForZCFMint. The following two steps *should* be
+          // reallocator.reallocate(). The following two steps *should* be
           // committed atomically, but it is not a disaster if they are
           // not. If we minted only, no one would ever get those
           // invisibly-minted assets.
           E(zoeMint).mintAndEscrow(totalToMint);
-          reallocateForZCFMint(zcfSeat, allocationPlusGains);
+          reallocator.reallocate(zcfSeat, allocationPlusGains);
           return zcfSeat;
         },
         burnLosses: (losses, zcfSeat) => {

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -21,14 +21,12 @@ import '@agoric/swingset-vat/src/types-ambient.js';
 
 const { details: X } = assert;
 
-// helpers for the code shared between MakeZCFMint and RegisterZCFMint
-
 export const makeZCFMintFactory = async (
   zcfBaggage,
   recordIssuer,
   getAssetKindByBrand,
   makeEmptySeatKit,
-  reallocateForZCFMint,
+  reallocator,
 ) => {
   // The set of baggages for zcfMints
   const zcfMintBaggageSet = provideDurableSetStore(zcfBaggage, 'baggageSet');
@@ -132,7 +130,7 @@ export const makeZCFMintFactory = async (
           // committed atomically, but it is not a disaster if they are
           // not. If we only commit the allocationMinusLosses no one would
           // ever get the unburned assets.
-          reallocateForZCFMint(zcfSeat, allocationMinusLosses);
+          reallocator.reallocate(zcfSeat, allocationMinusLosses);
           E(zoeMint).withdrawAndBurn(totalToBurn);
         },
       },

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -7,6 +7,7 @@ import {
   provideDurableWeakMapStore,
   vivifyFarClassKit,
   vivifyKind,
+  provide,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
@@ -143,8 +144,12 @@ export const createSeatManager = (
     'zcfSeat',
     proposal => ({ proposal }),
     {
-      getNotifier: ({ self }) =>
-        E(zoeInstanceAdmin).getSeatNotifier(zcfSeatToSeatHandle.get(self)),
+      getSubscriber: context => {
+        const { self } = context;
+        return E(zoeInstanceAdmin).getExitSubscriber(
+          zcfSeatToSeatHandle.get(self),
+        );
+      },
       getProposal: ({ state }) => state.proposal,
       exit: ({ self }, completion) => {
         assertActive(self);
@@ -389,5 +394,5 @@ export const createSeatManager = (
     },
   );
 
-  return makeSeatManagerKit();
+  return provide(zcfBaggage, 'theSeatManagerKit', () => makeSeatManagerKit());
 };

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -3,7 +3,11 @@
 import { Far } from '@endo/marshal';
 import { Nat } from '@agoric/nat';
 import { AmountMath } from '@agoric/ertp';
-import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
+import {
+  makeNotifierKit,
+  observeIteration,
+  subscribeLatest,
+} from '@agoric/notifier';
 import {
   assertIssuerKeywords,
   defaultAcceptanceMsg,
@@ -51,8 +55,8 @@ const start = zcf => {
   const sell = seat => {
     sellerSeat = seat;
 
-    observeNotifier(
-      sellerSeat.getNotifier(),
+    observeIteration(
+      subscribeLatest(sellerSeat.getSubscriber()),
       harden({
         updateState: sellerSeatAllocation =>
           availableItemsUpdater.updateState(
@@ -66,6 +70,7 @@ const start = zcf => {
         fail: reason => availableItemsUpdater.fail(reason),
       }),
     );
+    availableItemsUpdater.updateState(sellerSeat.getCurrentAllocation().Items);
     return defaultAcceptanceMsg;
   };
 
@@ -118,7 +123,12 @@ const start = zcf => {
 
     if (AmountMath.isEmpty(getAvailableItems())) {
       zcf.shutdown('All items sold.');
+    } else {
+      availableItemsUpdater.updateState(
+        sellerSeat.getCurrentAllocation().Items,
+      );
     }
+
     return defaultAcceptanceMsg;
   };
 

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -16,20 +16,31 @@
  */
 
 /**
+ * @typedef WithdrawFacet
+ * @property {(allocation:Allocation) => PaymentPKeywordRecord} withdrawPayments
+ */
+
+/**
+ * @typedef {object} InstanceAdminHelper
+ * @property {(zoeSeatAdmin: ZoeSeatAdmin) => void} exitZoeSeatAdmin
+ * @property {(zoeSeatAdmin: ZoeSeatAdmin) => boolean} hasExited
+ */
+
+/**
  * @typedef {object} ZoeSeatAdminKit
  * @property {UserSeat} userSeat
  * @property {ZoeSeatAdmin} zoeSeatAdmin
- * @property {Notifier<Allocation>} notifier
- *
- * @callback MakeZoeSeatAdminKit
+ */
+
+/** @callback MakeZoeSeatAdminKit
  * Make the Zoe seat admin, user seat and a notifier
  * @param {Allocation} initialAllocation
- * @param {(zoeSeatAdmin: ZoeSeatAdmin) => void} exitZoeSeatAdmin
- * @param {(zoeSeatAdmin: ZoeSeatAdmin) => boolean} hasExited
+ * @param {InstanceAdminHelper} instanceAdminHelper
  * @param {ProposalRecord} proposal
- * @param {WithdrawPayments} withdrawPayments
+ * @param {WithdrawFacet} withdrawFacet
  * @param {ERef<ExitObj>} exitObj
  * @param {ERef<unknown>} [offerResult]
+ * @param {import('@agoric/vat-data').Baggage} baggage
  * @returns {ZoeSeatAdminKit}
  */
 
@@ -82,6 +93,8 @@
  * @property {ShutdownWithFailure} failAllSeats
  * @property {() => void} stopAcceptingOffers
  * @property {(string: string) => boolean} isBlocked
+ * @property {(handleOfferObj: HandleOfferObj, publicFacet: unknown) => void} initDelayedState
+ * @property {(strings: string[]) => void} setOfferFilter
  */
 
 /**
@@ -153,7 +166,7 @@
  * @param {ProposalRecord} proposal
  * @param {ExitObj} exitObj
  * @param {SeatHandle} seatHandle
- * @returns {{userSeat: UserSeat, notifier: Notifier<Allocation>}}
+ * @returns {{userSeat: UserSeat}}
  */
 
 /**
@@ -273,14 +286,18 @@
  */
 
 /**
- * @callback ReallocateForZCFMint
- * @param {ZCFSeat} zcfSeat
- * @param {Allocation} newAllocation
- * @returns {void}
+ * @typedef {object} ZcfSeatManager
+ * @property {MakeZCFSeat} makeZCFSeat
+ * @property {Reallocate} reallocate
+ * @property {DropAllReferences} dropAllReferences
  */
 
 /**
- *
+ * @typedef {object} ZcfMintReallocator
+ * @property {(zcfSeat: ZCFSeat, newAllocation: Allocation) => void} reallocate
+ */
+
+/**
  * @callback CreateSeatManager
  *
  * The SeatManager holds the active zcfSeats and can reallocate and
@@ -290,10 +307,7 @@
  * @param {GetAssetKindByBrand} getAssetKindByBrand
  * @param {ShutdownWithFailure} shutdownWithFailure
  * @param {import('@agoric/vat-data').Baggage} zcfBaggage
- * @returns {{ makeZCFSeat: MakeZCFSeat,
-    reallocate: Reallocate,
-    reallocateForZCFMint: ReallocateForZCFMint,
-    dropAllReferences: DropAllReferences }}
+ * @returns {{ seatManager: ZcfSeatManager, zcfMintReallocator: ZcfMintReallocator }}
  */
 
 /**

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -88,13 +88,13 @@
  * @property {() => BrandKeywordRecord} getBrands
  * @property {() => object} getTerms
  * @property {() => string[]} getOfferFilter
+ * @property {(strings: string[]) => void} setOfferFilter
  * @property {() => Installation} getInstallationForInstance
  * @property {(completion: Completion) => void} exitAllSeats
  * @property {ShutdownWithFailure} failAllSeats
  * @property {() => void} stopAcceptingOffers
  * @property {(string: string) => boolean} isBlocked
  * @property {(handleOfferObj: HandleOfferObj, publicFacet: unknown) => void} initDelayedState
- * @property {(strings: string[]) => void} setOfferFilter
  */
 
 /**
@@ -131,9 +131,10 @@
  * @property {ShutdownWithFailure} failAllSeats
  * @property {(seatHandle: SeatHandle, completion: Completion) => void} exitSeat
  * @property {(seatHandle: SeatHandle, reason: Error) => void} failSeat
- * @property {(seatHandle: SeatHandle) => Promise<Notifier<Allocation>>} getSeatNotifier
  * @property {() => void} stopAcceptingOffers
  * @property {(strings: Array<string>) => void} setOfferFilter
+ * @property {() => Promise<Array<string>>} getOfferFilter
+ * @property {(seatHandle: SeatHandle) => Subscriber<any>} getExitSubscriber
  */
 
 /**

--- a/packages/zoe/src/issuerStorage.js
+++ b/packages/zoe/src/issuerStorage.js
@@ -68,6 +68,8 @@ export const provideIssuerStorage = zcfBaggage => {
       return issuerToIssuerRecord.get(issuer);
     }
 
+    console.log(`ISS  store`, brand);
+
     brandToIssuerRecord.init(brand, issuerRecord);
     issuerToIssuerRecord.init(issuer, issuerRecord);
     return issuerToIssuerRecord.get(issuer);
@@ -75,6 +77,9 @@ export const provideIssuerStorage = zcfBaggage => {
 
   const getByBrand = brand => {
     assertInstantiated();
+
+    console.log(`Iss get`, brand);
+
     return brandToIssuerRecord.get(brand);
   };
 

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,9 +1,9 @@
 // @ts-check
 
-import { assert } from '@agoric/assert';
 import { initEmpty } from '@agoric/store';
-import { provide, defineDurableKind, makeKindHandle } from '@agoric/vat-data';
+import { vivifyFarClass } from '@agoric/vat-data';
 import { Far } from '@endo/marshal';
+import { HandleI } from './typeGuards.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -15,12 +15,13 @@ import { Far } from '@endo/marshal';
  */
 export const defineDurableHandle = (baggage, handleType) => {
   assert.typeof(handleType, 'string', 'handleType must be a string');
-  const durableHandleKindHandle = provide(
+  const makeHandle = vivifyFarClass(
     baggage,
-    `${handleType}KindHandle`,
-    () => makeKindHandle(`${handleType}Handle`),
+    `${handleType}Handle`,
+    HandleI,
+    initEmpty,
+    {},
   );
-  const makeHandle = defineDurableKind(durableHandleKindHandle, initEmpty, {});
   return /** @type {() => Handle<H>} */ (makeHandle);
 };
 harden(defineDurableHandle);

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -1,8 +1,22 @@
 // @ts-check
 
-import { AmountShape } from '@agoric/ertp';
+import {
+  AmountShape,
+  AssetKindShape,
+  DisplayInfoShape,
+  IssuerShape,
+  IssuerKitShape,
+  BrandShape,
+  PaymentShape,
+} from '@agoric/ertp';
 import { M } from '@agoric/store';
 import { TimestampValueShape } from '@agoric/swingset-vat/src/vats/timer/typeGuards.js';
+
+// keywords have an initial cap
+export const KeywordShape = M.string();
+
+// TODO should be exported from Notifiers.
+export const NotifierShape = M.any();
 
 export const InvitationHandleShape = M.remotable('InvitationHandle');
 export const InvitationShape = M.remotable('Invitation');
@@ -10,11 +24,38 @@ export const InstanceHandleShape = M.remotable('InstanceHandle');
 export const InstallationShape = M.remotable('Installation');
 export const SeatShape = M.remotable('Seat');
 
-export const AmountKeywordRecordShape = M.recordOf(M.string(), AmountShape);
+export const AmountKeywordRecordShape = M.recordOf(KeywordShape, AmountShape);
 export const AmountPatternKeywordRecordShape = M.recordOf(
-  M.string(),
+  KeywordShape,
   M.pattern(),
 );
+export const PaymentKeywordRecordShape = M.recordOf(KeywordShape, PaymentShape);
+export const PaymentPKeywordRecordShape = M.recordOf(
+  KeywordShape,
+  M.eref(PaymentShape),
+);
+export const IssuerKeywordRecordShape = M.recordOf(KeywordShape, IssuerShape);
+export const BrandKeywordRecordShape = M.recordOf(KeywordShape, BrandShape);
+
+export const IssuerRecordShape = M.split(
+  {
+    brand: BrandShape,
+    issuer: IssuerShape,
+    assetKind: AssetKindShape,
+  },
+  { displayInfo: DisplayInfoShape },
+);
+
+export const TermsShape = harden({
+  issuers: IssuerKeywordRecordShape,
+  brands: BrandKeywordRecordShape,
+});
+
+export const InstanceRecordShape = harden({
+  installation: InstallationShape,
+  instance: InstanceHandleShape,
+  terms: M.split(TermsShape, M.record()),
+});
 
 export const makeHandleShape = name => M.remotable(`${name}Handle`);
 export const TimerShape = makeHandleShape('timer');
@@ -77,4 +118,194 @@ export const InvitationElementShape = M.split({
 
 export const OfferHandlerI = M.interface('OfferHandler', {
   handle: M.call(SeatShape).optional(M.any()).returns(M.string()),
+});
+
+export const SeatHandleAllocations = M.arrayOf(
+  harden({
+    seatHandle: SeatShape,
+    allocation: AmountKeywordRecordShape,
+  }),
+);
+
+export const ZoeMintShape = M.interface('ZoeMint', {
+  getIssuerRecord: M.call().returns(IssuerRecordShape),
+  mintAndEscrow: M.call(AmountShape).returns(),
+  withdrawAndBurn: M.call(AmountShape).returns(),
+});
+
+export const ExitObjectShape = M.interface('Exit Object', {
+  exit: M.call().returns(),
+});
+
+export const InstanceAdminShape = M.interface('InstanceAdmin', {
+  makeInvitation: M.call(InvitationHandleShape, M.string())
+    .optional(M.any(), ProposalShape)
+    .returns(M.promise()),
+  saveIssuer: M.call(M.eref(IssuerShape), M.string()).returns(M.promise()),
+  makeZoeMint: M.call(KeywordShape)
+    .optional(AssetKindShape, DisplayInfoShape, M.pattern)
+    .returns(M.remotable()),
+  registerFeeMint: M.call(KeywordShape, M.remotable()).returns(M.remotable()),
+  makeNoEscrowSeatKit: M.call(
+    AmountKeywordRecordShape,
+    ProposalShape,
+    M.remotable(),
+    SeatShape,
+  ).returns({ userSeat: SeatShape }),
+  replaceAllocations: M.call(SeatHandleAllocations).returns(),
+  exitAllSeats: M.call(M.any()).returns(),
+  failAllSeats: M.call(M.any()).returns(),
+  exitSeat: M.call(SeatShape, M.any()).returns(),
+  failSeat: M.call(SeatShape, M.any()).returns(),
+  stopAcceptingOffers: M.call().returns(),
+  setOfferFilter: M.call(M.arrayOf(M.string())).returns(),
+  getOfferFilter: M.call().returns(M.string()),
+});
+
+export const InstanceStorageManagerGuard = M.interface(
+  'InstanceStorageManager',
+  {
+    getTerms: M.call().returns(M.split(TermsShape, M.record())),
+    getIssuers: M.call().returns(IssuerKeywordRecordShape),
+    getBrands: M.call().returns(BrandKeywordRecordShape),
+    getInstallationForInstance: M.call().returns(InstallationShape),
+    getInvitationIssuer: M.call().returns(IssuerShape),
+
+    saveIssuer: M.call(IssuerShape, M.string()).returns(M.promise()),
+    makeZoeMint: M.call(KeywordShape)
+      .optional(AssetKindShape, DisplayInfoShape, M.pattern)
+      .returns(M.or(ZoeMintShape, M.remotable(), M.promise())),
+    registerFeeMint: M.call(KeywordShape, M.remotable()).returns(
+      IssuerKitShape,
+    ),
+    getInstanceRecord: M.call().returns(InstanceRecordShape),
+    getIssuerRecords: M.call().returns(M.arrayOf(IssuerRecordShape)),
+    getWithdrawPayments: M.call().returns(
+      M.interface('WithdrawFacet', {
+        withdrawPayments: M.call(AmountKeywordRecordShape).returns(
+          PaymentKeywordRecordShape,
+        ),
+      }),
+    ),
+    initInstanceAdmin: M.call(InstanceHandleShape, M.remotable()).returns(
+      M.promise(),
+    ),
+    deleteInstanceAdmin: M.call(InstanceAdminShape).returns(),
+    makeInvitation: M.call(InvitationHandleShape, M.string())
+      .optional(M.any(), ProposalShape)
+      .returns(M.promise()),
+    getRoot: M.call().returns(M.promise()),
+    getAdminNode: M.call().returns(M.remotable()),
+  },
+);
+
+const BundleCapShape = M.any();
+
+export const ZoeStorageMangerInterface = {
+  zoeServiceDataAccess: M.interface('ZoeService dataAccess', {
+    getTerms: M.call(InstanceHandleShape).returns(
+      M.split(TermsShape, M.record()),
+    ),
+    getIssuers: M.call(InstanceHandleShape).returns(M.promise()),
+    getBrands: M.call(InstanceHandleShape).returns(M.promise()),
+    getInstallationForInstance: M.call(InstanceHandleShape).returns(
+      M.promise(),
+    ),
+    getInvitationIssuer: M.call().returns(IssuerShape),
+
+    getBundleIDFromInstallation: M.call(M.any()).returns(M.promise()),
+    // TODO(cth) what should BundleID look like?
+    installBundle: M.call(M.any()).returns(M.promise()),
+    installBundleID: M.call(M.string()).returns(M.promise()),
+
+    getPublicFacet: M.call(M.eref(InstanceHandleShape)).returns(M.promise()),
+    getOfferFilter: M.call(InstanceHandleShape).returns(M.promise()),
+    setOfferFilter: M.call(
+      InstanceHandleShape,
+      M.arrayOf(M.string()),
+    ).returns(),
+    getProposalShapeForInvitation: M.call(InvitationHandleShape).returns(
+      M.or(ProposalShape, M.undefined()),
+    ),
+  }),
+  makeOfferAccess: M.interface('ZoeStorage makeOffer access', {
+    getAssetKindByBrand: M.call(BrandShape).returns(AssetKindShape),
+    installBundle: M.call(InstanceHandleShape).returns(),
+    getInstanceAdmin: M.call(InstanceHandleShape).returns(M.remotable()),
+    getProposalShapeForInvitation: M.call(InvitationHandleShape).returns(
+      M.or(ProposalShape, M.undefined()),
+    ),
+    getInvitationIssuer: M.call().returns(IssuerShape),
+    depositPayments: M.call(ProposalShape, PaymentPKeywordRecordShape).returns(
+      M.promise(),
+    ),
+  }),
+  startInstanceAccess: M.interface('ZoeStorage startInstance access', {
+    makeZoeInstanceStorageManager: M.call(
+      M.any(),
+      InstallationShape,
+      M.any(),
+      IssuerKeywordRecordShape,
+      InstanceHandleShape,
+      BundleCapShape,
+    ).returns(M.promise()),
+    unwrapInstallation: M.callWhen(M.eref(InstallationShape)).returns(M.any()),
+  }),
+  invitationIssuerAccess: M.interface('ZoeStorage invitationIssuer', {
+    getInvitationIssuer: M.call().returns(IssuerShape),
+  }),
+};
+
+export const ZoeServiceInterface = {
+  zoeService: M.interface('ZoeService', {
+    // TODO(cth) what should bundleID look like?
+    install: M.call(M.any()).returns(M.promise()),
+    installBundleID: M.call(M.any()).returns(M.promise()),
+    // TODO(CTH) The rest is optional.  How do I say that?
+    startInstance: M.call(M.eref(InstallationShape))
+      .optional(IssuerKeywordRecordShape, M.any(), M.any())
+      .returns(M.promise()),
+    offer: M.call(M.eref(InvitationShape))
+      .optional(ProposalShape, PaymentPKeywordRecordShape, M.any())
+      .returns(M.promise()),
+
+    getPublicFacet: M.call(M.eref(InstanceHandleShape)).returns(M.promise()),
+    getBrands: M.call(InstanceHandleShape).returns(M.promise()),
+    getIssuers: M.call(InstanceHandleShape).returns(M.promise()),
+    getOfferFilter: M.call(InstanceHandleShape).returns(M.promise()),
+    setOfferFilter: M.call(
+      InstanceHandleShape,
+      M.arrayOf(M.string()),
+    ).returns(),
+    getTerms: M.call(InstanceHandleShape).returns(M.any()),
+    getInstallationForInstance: M.call(InstanceHandleShape).returns(
+      M.promise(),
+    ),
+    getInvitationIssuer: M.call().returns(M.promise()),
+    getBundleIDFromInstallation: M.call(M.any()).returns(M.promise()),
+
+    getFeeIssuer: M.call().returns(M.promise()),
+    getInstance: M.call(M.eref(InvitationShape)).returns(M.promise()),
+    getInstallation: M.call(M.eref(InvitationShape)).returns(M.promise()),
+    getInvitationDetails: M.call(M.eref(InvitationShape)).returns(M.any()),
+    getConfiguration: M.call().returns({
+      feeIssuerConfig: {
+        name: M.string(),
+        assetKind: 'nat',
+        displayInfo: M.any(),
+      },
+    }),
+    getProposalShapeForInvitation: M.call(InvitationHandleShape).returns(
+      M.or(ProposalShape, M.undefined()),
+    ),
+  }),
+  feeMintAccessRetriever: M.interface('FeeMintAccessRetriever', {
+    get: M.call().returns(M.any()),
+  }),
+};
+
+export const AdminFacetGuard = M.interface('ZcfAdminFacet', {
+  getVatShutdownPromise: M.call().returns(),
+  restartContract: M.call().returns(),
+  upgradeContract: M.call().returns(),
 });

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -2,7 +2,7 @@
 
 /**
  * @template {string} H - the name of the handle
- * @typedef {H & {}} Handle A type constructor for an opaque type
+ * @typedef {H & Remotable} Handle A type constructor for an opaque type
  * identified by the H string. This uses an intersection type
  * ('MyHandle' & {}) to tag the handle's type even though the actual
  * value is just an empty object.

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -18,7 +18,7 @@ import { arrayToObj } from '../objArrayConversion.js';
  *
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
-export const makeEscrowStorage = baggage => {
+export const provideEscrowStorage = baggage => {
   /** @type {WeakStore<Brand, ERef<Purse>>} */
   const brandToPurse = provideDurableWeakMapStore(baggage, 'brandToPurse');
 
@@ -43,9 +43,9 @@ export const makeEscrowStorage = baggage => {
   };
 
   /**
-   * @type {MakeLocalPurse}
+   * @type {ProvideLocalPurse}
    */
-  const makeLocalPurse = (issuer, brand) => {
+  const provideLocalPurse = (issuer, brand) => {
     if (brandToPurse.has(brand)) {
       return /** @type {Purse} */ (brandToPurse.get(brand));
     } else {
@@ -134,7 +134,7 @@ export const makeEscrowStorage = baggage => {
 
   return {
     createPurse, // createPurse does not return a purse
-    makeLocalPurse,
+    provideLocalPurse,
     withdrawPayments,
     depositPayments,
   };

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -19,7 +19,7 @@ export const defaultFeeIssuerConfig = harden(
  * @param {FeeIssuerConfig} feeIssuerConfig
  * @param {ShutdownWithFailure} shutdownZoeVat
  * @returns {{
- *    getFeeMintAccess: () => FeeMintAccess,
+ *    getFeeMintAccessToken: () => FeeMintAccess,
  *    getFeeIssuerKit: GetFeeIssuerKit,
  *    getFeeIssuer: () => Issuer,
  *    getFeeBrand: () => Brand,
@@ -50,7 +50,7 @@ const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   const makeFeeMintKit = vivifyKindMulti(mintBaggage, 'FeeMint', initEmpty, {
     feeMint: {
       getFeeIssuerKit,
-      getFeeMintAccess: ({ facets }) => facets.feeMintAccess,
+      getFeeMintAccessToken: ({ facets }) => facets.feeMintAccess,
       getFeeIssuer: () => mintBaggage.get(FEE_MINT_KIT).issuer,
       getFeeBrand: () => mintBaggage.get(FEE_MINT_KIT).brand,
     },

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -134,7 +134,7 @@ export const makeInstallationStorage = (
         });
       },
       async getBundleIDFromInstallation(allegedInstallationP) {
-        // TODO(cth) need a declaration of this that inlcudes state
+        // @ts-expect-error TS doesn't understand context
         const { self } = this;
         const { bundleID } = await self.unwrapInstallation(
           allegedInstallationP,

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -3,14 +3,21 @@
 import { assert, details as X } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
 import {
+  M,
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
+  vivifyFarInstance,
   vivifyKind,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
+import { InstallationShape } from '../typeGuards.js';
 
 /** @typedef { import('@agoric/swingset-vat').BundleID} BundleID */
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
+
+export const SourceBundleShape = M.recordOf(M.string(), M.string());
+export const ModuleFormatBundleShape = M.partial({ moduleFormat: M.any() });
+export const BundleShape = M.or(ModuleFormatBundleShape, SourceBundleShape);
 
 /**
  * @param {GetBundleCapForID} getBundleCapForID
@@ -55,21 +62,6 @@ export const makeInstallationStorage = (
    * an instance is started.
    */
 
-  /** @type {InstallBundleID} */
-  const installBundleID = async bundleID => {
-    assert.typeof(bundleID, 'string', `a bundle ID must be provided`);
-    // this waits until someone tells the host application to store the
-    // bundle into the kernel, with controller.validateAndInstallBundle()
-    const bundleCap = await getBundleCapForID(bundleID);
-    // AWAIT
-
-    /** @type {Installation} */
-    // @ts-expect-error cast
-    const installation = makeBundleIDInstallation();
-    installationsBundleCap.init(installation, harden({ bundleCap, bundleID }));
-    return installation;
-  };
-
   /** @type {InstallBundle} */
   const installSourceBundle = async bundle => {
     assert.typeof(bundle, 'object', 'a bundle must be provided');
@@ -80,54 +72,79 @@ export const makeInstallationStorage = (
     return installation;
   };
 
-  /** @type {InstallBundle} */
-  const installBundle = async allegedBundle => {
-    // Bundle is a very open-ended type and we must decide here
-    // whether to treat it as either a HashBundle or SourceBundle.
-    // So, we cast it down and inspect it.
-    const bundle = /** @type {unknown} */ (harden(allegedBundle));
-    assert.typeof(bundle, 'object', 'a bundle must be provided');
-    assert(bundle !== null, 'a bundle must be provided');
-    const { moduleFormat } = bundle;
-    if (moduleFormat === 'endoZipBase64Sha512') {
-      const { endoZipBase64Sha512 } = bundle;
-      assert.typeof(
-        endoZipBase64Sha512,
-        'string',
-        `bundle endoZipBase64Sha512 must be a string, got ${endoZipBase64Sha512}`,
-      );
-      return installBundleID(`b1-${endoZipBase64Sha512}`);
-    }
-    return installSourceBundle(bundle);
-  };
-
-  /** @type {UnwrapInstallation} */
-  const unwrapInstallation = installationP => {
-    return E.when(installationP, installation => {
-      if (installationsBundleCap.has(installation)) {
-        const { bundleCap, bundleID } =
-          installationsBundleCap.get(installation);
-        return { bundleCap, bundleID, installation };
-      } else if (installationsBundle.has(installation)) {
-        const bundle = installationsBundle.get(installation);
-        return { bundle, installation };
-      } else {
-        assert.fail(X`${installation} was not a valid installation`);
-      }
-    });
-  };
-
-  const getBundleIDFromInstallation = async allegedInstallationP => {
-    const { bundleID } = await unwrapInstallation(allegedInstallationP);
-    // AWAIT
-    assert(bundleID, 'installation does not have a bundle ID');
-    return bundleID;
-  };
-
-  return harden({
-    installBundle,
-    installBundleID,
-    unwrapInstallation,
-    getBundleIDFromInstallation,
+  const InstallationStorage = M.interface('InstallationStorage', {
+    installBundle: M.call(BundleShape).returns(M.promise()),
+    installBundleID: M.call(M.string()).returns(M.promise()),
+    unwrapInstallation: M.callWhen(M.eref(InstallationShape)).returns(M.any()),
+    getBundleIDFromInstallation: M.call(InstallationShape).returns(M.promise()),
   });
+
+  const installationStorage = vivifyFarInstance(
+    zoeBaggage,
+    'InstallationStorage',
+    InstallationStorage,
+    {
+      async installBundle(allegedBundle) {
+        // Bundle is a very open-ended type and we must decide here
+        // whether to treat it as either a HashBundle or SourceBundle.
+        // So, we cast it down and inspect it.
+        const bundle = /** @type {unknown} */ (harden(allegedBundle));
+        assert.typeof(bundle, 'object', 'a bundle must be provided');
+        assert(bundle !== null, 'a bundle must be provided');
+        const { moduleFormat } = bundle;
+        if (moduleFormat === 'endoZipBase64Sha512') {
+          const { endoZipBase64Sha512 } = bundle;
+          assert.typeof(
+            endoZipBase64Sha512,
+            'string',
+            `bundle endoZipBase64Sha512 must be a string, got ${endoZipBase64Sha512}`,
+          );
+          return this.installBundleID(`b1-${endoZipBase64Sha512}`);
+        }
+        return installSourceBundle(bundle);
+      },
+      async installBundleID(bundleID) {
+        assert.typeof(bundleID, 'string', `a bundle ID must be provided`);
+        // this waits until someone tells the host application to store the
+        // bundle into the kernel, with controller.validateAndInstallBundle()
+        const bundleCap = await getBundleCapForID(bundleID);
+        // AWAIT
+
+        /** @type {Installation} */
+        // @ts-expect-error cast
+        const installation = makeBundleIDInstallation();
+        installationsBundleCap.init(
+          installation,
+          harden({ bundleCap, bundleID }),
+        );
+        return installation;
+      },
+      unwrapInstallation(installationP) {
+        return E.when(installationP, installation => {
+          if (installationsBundleCap.has(installation)) {
+            const { bundleCap, bundleID } =
+              installationsBundleCap.get(installation);
+            return { bundleCap, bundleID, installation };
+          } else if (installationsBundle.has(installation)) {
+            const bundle = installationsBundle.get(installation);
+            return { bundle, installation };
+          } else {
+            assert.fail(X`${installation} was not a valid installation`);
+          }
+        });
+      },
+      async getBundleIDFromInstallation(allegedInstallationP) {
+        // TODO(cth) need a declaration of this that inlcudes state
+        const { self } = this;
+        const { bundleID } = await self.unwrapInstallation(
+          allegedInstallationP,
+        );
+        // AWAIT
+        assert(bundleID, 'installation does not have a bundle ID');
+        return bundleID;
+      },
+    },
+  );
+
+  return installationStorage;
 };

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -8,6 +8,7 @@ import {
   vivifyKindMulti,
   vivifyFarClassKit,
   M,
+  provide,
 } from '@agoric/vat-data';
 import { makeZoeSeatAdminFactory } from './zoeSeat.js';
 import { defineDurableHandle } from '../makeHandle.js';
@@ -90,7 +91,7 @@ export const makeInstanceAdminStorage = baggage => {
       },
     },
   );
-  return makeIAS();
+  return provide(baggage, 'theInstanceAdminStorage', () => makeIAS());
 };
 harden(makeInstanceAdminStorage);
 
@@ -135,8 +136,6 @@ const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
       proposal,
       offerArgs = undefined,
     ) => {
-      debugger;
-
       const { userSeat, zoeSeatAdmin } = makeZoeSeatAdminKit(
         initialAllocation,
         proposal,
@@ -182,6 +181,7 @@ const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
         helper,
         state.zoeInstanceStorageManager.getWithdrawFacet(),
         exitObj,
+        true,
       );
 
       state.zoeSeatAdmins.add(zoeSeatAdmin);
@@ -212,9 +212,8 @@ const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
 const helperBehavior = {
   exitZoeSeatAdmin: ({ state }, zoeSeatAdmin) =>
     state.zoeSeatAdmins.delete(zoeSeatAdmin),
-  hasExited: ({ state }, zoeSeatAdmin) => {
-    return !state.zoeSeatAdmins.has(zoeSeatAdmin);
-  },
+  hasExited: ({ state }, zoeSeatAdmin) =>
+    !state.zoeSeatAdmins.has(zoeSeatAdmin),
 };
 
 /**
@@ -239,6 +238,7 @@ export const makeInstanceAdminMaker = (
   zoeBaggage,
   seatHandleToZoeSeatAdmin,
 ) => {
+  const makeZoeSeatAdminKit = makeZoeSeatAdminFactory(zoeBaggage);
   const makeInstanceAdminMulti = vivifyKindMulti(
     zoeBaggage,
     'instanceAdmin',

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -1,51 +1,277 @@
 // @ts-check
 
 import { E } from '@endo/eventual-send';
-import { makeWeakStore } from '@agoric/store';
+import {
+  canBeDurable,
+  makeScalarBigSetStore,
+  provideDurableWeakMapStore,
+  vivifyKindMulti,
+  vivifyFarClassKit,
+  M,
+} from '@agoric/vat-data';
+import { makeZoeSeatAdminFactory } from './zoeSeat.js';
+import { defineDurableHandle } from '../makeHandle.js';
+import { InstanceAdminShape, InstanceHandleShape } from '../typeGuards.js';
 
-/**
- *
- */
-export const makeInstanceAdminStorage = () => {
-  /** @type {WeakStore<Instance,InstanceAdmin>} */
-  const instanceToInstanceAdmin = makeWeakStore('instance');
+const { quote: q, details: X } = assert;
 
-  /** @type {GetPublicFacet} */
-  const getPublicFacet = async instanceP =>
-    E.when(instanceP, instance =>
-      instanceToInstanceAdmin.get(instance).getPublicFacet(),
-    );
+const InstanceAdminStorageShape = M.interface('InstanceAdminStorage', {
+  getPublicFacet: M.call(M.eref(InstanceHandleShape)).returns(M.promise()),
+  getBrands: M.call(InstanceHandleShape).returns(M.promise()),
+  getIssuers: M.call(InstanceHandleShape).returns(M.promise()),
+  getTerms: M.call(InstanceHandleShape).returns(M.promise()),
+  getOfferFilter: M.call(M.eref(InstanceHandleShape)).returns(M.promise()),
+  setOfferFilter: M.call(M.eref(InstanceHandleShape)).returns(),
+  getInstallationForInstance: M.call(InstanceHandleShape).returns(M.promise()),
+  getInstanceAdmin: M.call(InstanceHandleShape).returns(InstanceAdminShape),
+  initInstanceAdmin: M.call(InstanceHandleShape).returns(M.promise()),
+  deleteInstanceAdmin: M.call(InstanceHandleShape).returns(M.promise()),
+});
 
-  /** @type {GetBrands} */
-  const getBrands = async instance =>
-    instanceToInstanceAdmin.get(instance).getBrands();
+/** @param {import('@agoric/vat-data').Baggage} baggage */
+export const makeInstanceAdminStorage = baggage => {
+  const makeIAS = vivifyFarClassKit(
+    baggage,
+    'InstanceAdmin',
+    InstanceAdminStorageShape,
+    () => ({
+      instanceToInstanceAdmin: provideDurableWeakMapStore(
+        baggage,
+        'instanceToInstanceAdmin',
+      ),
+    }),
+    {
+      accessor: {
+        async getPublicFacet(instanceP) {
+          const { state } = this;
+          return E.when(instanceP, async instance => {
+            const ia = state.instanceToInstanceAdmin.get(instance);
+            return ia.getPublicFacet();
+          });
+        },
+        async getBrands(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.get(instance).getBrands();
+        },
+        async getIssuers(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.get(instance).getIssuers();
+        },
+        getTerms(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.get(instance).getTerms();
+        },
+        async getOfferFilter(instanceP) {
+          const { state } = this;
+          return E.when(instanceP, instance =>
+            state.instanceToInstanceAdmin.get(instance).getOfferFilter(),
+          );
+        },
+        async getInstallationForInstance(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin
+            .get(instance)
+            .getInstallationForInstance();
+        },
+        getInstanceAdmin(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.get(instance);
+        },
+      },
+      updater: {
+        async initInstanceAdmin(instance, instanceAdmin) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.init(instance, instanceAdmin);
+        },
+        deleteInstanceAdmin(instance) {
+          const { state } = this;
+          return state.instanceToInstanceAdmin.delete(instance);
+        },
+      },
+    },
+  );
+  return makeIAS();
+};
+harden(makeInstanceAdminStorage);
 
-  /** @type {GetIssuers} */
-  const getIssuers = async instance =>
-    instanceToInstanceAdmin.get(instance).getIssuers();
-
-  /** @type {GetTerms} */
-  const getTerms = instance => instanceToInstanceAdmin.get(instance).getTerms();
-
-  /** @type {GetOfferFilter} */
-  const getOfferFilter = async instanceP =>
-    E.when(instanceP, instance =>
-      instanceToInstanceAdmin.get(instance).getOfferFilter(),
-    );
-
-  /** @type {GetInstallationForInstance} */
-  const getInstallationForInstance = async instance =>
-    instanceToInstanceAdmin.get(instance).getInstallationForInstance();
+const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
+  const makeSeatHandle = defineDurableHandle(zoeBaggage, 'Seat');
 
   return harden({
-    getPublicFacet,
-    getBrands,
-    getIssuers,
-    getTerms,
-    getOfferFilter,
-    getInstallationForInstance,
-    getInstanceAdmin: instanceToInstanceAdmin.get,
-    initInstanceAdmin: instanceToInstanceAdmin.init,
-    deleteInstanceAdmin: instanceToInstanceAdmin.delete,
+    getPublicFacet: ({ state }) => state.publicFacet,
+    getTerms: ({ state }) => state.zoeInstanceStorageManager.getTerms(),
+    getIssuers: ({ state }) => state.zoeInstanceStorageManager.getIssuers(),
+    getBrands: ({ state }) => state.zoeInstanceStorageManager.getBrands(),
+    initDelayedState: ({ state }, handleOfferObj, publicFacet) => {
+      state.handleOfferObj = handleOfferObj;
+      assert(canBeDurable(publicFacet), 'publicFacet must be durable');
+      state.publicFacet = publicFacet;
+    },
+    getInstallationForInstance: ({ state }) =>
+      state.zoeInstanceStorageManager.getInstallationForInstance(),
+    getInstance: ({ state }) => state.instanceHandle,
+    assertAcceptingOffers: ({ state }) => {
+      assert(state.acceptingOffers, `No further offers are accepted`);
+    },
+    exitAllSeats: ({ state }, completion) => {
+      state.acceptingOffers = false;
+      Array.from(state.zoeSeatAdmins.keys()).forEach(zoeSeatAdmin =>
+        zoeSeatAdmin.exit(completion),
+      );
+    },
+    failAllSeats: ({ state }, reason) => {
+      state.acceptingOffers = false;
+      Array.from(state.zoeSeatAdmins.keys()).forEach(zoeSeatAdmin =>
+        zoeSeatAdmin.fail(reason),
+      );
+    },
+    stopAcceptingOffers: ({ state }) => {
+      state.acceptingOffers = false;
+    },
+    makeUserSeat: (
+      { state, facets: { helper } },
+      invitationHandle,
+      initialAllocation,
+      proposal,
+      offerArgs = undefined,
+    ) => {
+      debugger;
+
+      const { userSeat, zoeSeatAdmin } = makeZoeSeatAdminKit(
+        initialAllocation,
+        proposal,
+        helper,
+        state.zoeInstanceStorageManager.getWithdrawFacet(),
+      );
+
+      const seatHandle = makeSeatHandle();
+      state.seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
+
+      const seatData = harden({
+        proposal,
+        initialAllocation,
+        seatHandle,
+        offerArgs,
+      });
+
+      state.zoeSeatAdmins.add(zoeSeatAdmin);
+      assert(state.handleOfferObj, 'incomplete setup of zoe seat');
+      E.when(
+        E(state.handleOfferObj).handleOffer(invitationHandle, seatData),
+        ({ offerResultPromise, exitObj }) =>
+          zoeSeatAdmin.resolveExitAndResult(offerResultPromise, exitObj),
+        err => {
+          state.adminNode.terminateWithFailure(err);
+          throw err;
+        },
+      );
+
+      // return the userSeat before the offerHandler is called
+      return userSeat;
+    },
+    makeNoEscrowSeatKit: (
+      { state, facets: { helper } },
+      initialAllocation,
+      proposal,
+      exitObj,
+      seatHandle,
+    ) => {
+      const { userSeat, zoeSeatAdmin } = makeZoeSeatAdminKit(
+        initialAllocation,
+        proposal,
+        helper,
+        state.zoeInstanceStorageManager.getWithdrawFacet(),
+        exitObj,
+      );
+
+      state.zoeSeatAdmins.add(zoeSeatAdmin);
+      state.seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
+      return { userSeat };
+    },
+    getOfferFilter: ({ state }) => state.offerFilterStrings,
+    setOfferFilter: ({ state }, strings) => {
+      assert(Array.isArray(strings), X`${q(strings)} must be an Array`);
+      const proposedStrings = harden([...strings]);
+      assert(
+        proposedStrings.every(s => typeof s === 'string'),
+        X`Blocked strings (${q(proposedStrings)}) must be an Array of strings.`,
+      );
+
+      state.offerFilterStrings = proposedStrings;
+    },
+    // if any string in the list matches, don't process the invitation. Strings
+    // that end in ':' may be prefix matches, others must match exactly.
+    isBlocked: ({ state }, string) => {
+      return state.offerFilterStrings.some(s => {
+        return string === s || (s.slice(-1) === ':' && string.startsWith(s));
+      });
+    },
   });
 };
+
+const helperBehavior = {
+  exitZoeSeatAdmin: ({ state }, zoeSeatAdmin) =>
+    state.zoeSeatAdmins.delete(zoeSeatAdmin),
+  hasExited: ({ state }, zoeSeatAdmin) => {
+    return !state.zoeSeatAdmins.has(zoeSeatAdmin);
+  },
+};
+
+/**
+ * @typedef {Readonly<{
+ *   publicFacet: unknown,
+ *   handlerOfferObj: unknown,
+ * }>} ImmutableState
+ * @typedef {{
+ *   offerFilterStrings: string[],
+ * }} MutableState
+ * @typedef {MutableState & ImmutableState} State
+ * @typedef {{
+ *   state: State,
+ * }} MethodContext
+ */
+
+/**
+ * @param {import('@agoric/vat-data').Baggage} zoeBaggage
+ * @param {WeakStore<SeatHandle, ZoeSeatAdmin>} seatHandleToZoeSeatAdmin
+ */
+export const makeInstanceAdminMaker = (
+  zoeBaggage,
+  seatHandleToZoeSeatAdmin,
+) => {
+  const makeInstanceAdminMulti = vivifyKindMulti(
+    zoeBaggage,
+    'instanceAdmin',
+    (instanceHandle, zoeInstanceStorageManager, adminNode) => {
+      const retVal = {
+        offerFilterStrings: harden([]),
+        publicFacet: undefined,
+        handleOfferObj: undefined,
+        zoeInstanceStorageManager,
+        seatHandleToZoeSeatAdmin,
+        instanceHandle,
+        acceptingOffers: true,
+        zoeSeatAdmins: makeScalarBigSetStore('zoeSeatAdmins', {
+          durable: true,
+        }),
+        adminNode,
+      };
+      return retVal;
+    },
+    {
+      instanceAdmin: makeInstanceAdminBehavior(zoeBaggage, makeZoeSeatAdminKit),
+      helper: helperBehavior,
+    },
+  );
+
+  return (instanceHandle, zoeInstanceStorageManager, adminNode) => {
+    const instanceAdmin = makeInstanceAdminMulti(
+      instanceHandle,
+      zoeInstanceStorageManager,
+      adminNode,
+    ).instanceAdmin;
+    return instanceAdmin;
+  };
+};
+
+harden(makeInstanceAdminMaker);

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -88,9 +88,9 @@
  * @property {InitInstanceAdmin} initInstanceAdmin
  * @property {DeleteInstanceAdmin} deleteInstanceAdmin
  * @property {ZoeInstanceAdminMakeInvitation} makeInvitation
- * @property {Issuer} invitationIssuer
- * @property {object} root of a RootAndAdminNode
- * @property {AdminNode} adminNode of a RootAndAdminNode
+ * @property {() => Issuer} getInvitationIssuer
+ * @property {() => object} getRoot of a RootAndAdminNode
+ * @property {() => AdminNode} getAdminNode of a RootAndAdminNode
  */
 
 /**
@@ -135,6 +135,7 @@
  * @property {GetIssuers} getIssuers
  * @property {GetTerms} getTerms
  * @property {GetOfferFilter} getOfferFilter
+ * @property {SetOfferFilter} setOfferFilter
  * @property {GetInstallationForInstance} getInstallationForInstance
  * @property {GetInstanceAdmin} getInstanceAdmin
  * @property {UnwrapInstallation} unwrapInstallation

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -16,7 +16,7 @@
  * before with `feeMintAccess`. In that case, we do not create a new
  * purse, but reuse the existing purse.
  *
- * @callback MakeLocalPurse
+ * @callback ProvideLocalPurse
  * @param {Issuer} issuer
  * @param {Brand} brand
  * @returns {Purse}

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -13,21 +13,7 @@ import '../internal-types.js';
 
 const { details: X, quote: q } = assert;
 
-/**
- * @param {Issuer} invitationIssuer
- * @param {GetInstanceAdmin} getInstanceAdmin
- * @param {DepositPayments} depositPayments
- * @param {GetAssetKindByBrand} getAssetKindByBrand
- * @param {GetProposalShapeForInvitation} getProposalShapeForInvitation
- * @returns {Offer}
- */
-export const makeOfferMethod = (
-  invitationIssuer,
-  getInstanceAdmin,
-  depositPayments,
-  getAssetKindByBrand,
-  getProposalShapeForInvitation,
-) => {
+export const makeOfferMethod = offerDataAccess => {
   /** @type {Offer} */
   const offer = async (
     invitation,
@@ -35,13 +21,14 @@ export const makeOfferMethod = (
     paymentKeywordRecord = harden({}),
     offerArgs = undefined,
   ) => {
+    const invitationIssuer = offerDataAccess.getInvitationIssuer();
     const query = makeInvitationQueryFns(invitationIssuer);
     const { instance, description } = await query.getInvitationDetails(
       invitation,
     );
     // AWAIT ///
 
-    const instanceAdmin = getInstanceAdmin(instance);
+    const instanceAdmin = offerDataAccess.getInstanceAdmin(instance);
     !instanceAdmin.isBlocked(description) ||
       assert.fail(X`not accepting offer with description ${q(description)}`);
     const { invitationHandle } = await burnInvitation(
@@ -52,8 +39,13 @@ export const makeOfferMethod = (
 
     instanceAdmin.assertAcceptingOffers();
 
+    const getAssetKindByBrand = brand => {
+      return offerDataAccess.getAssetKindByBrand(brand);
+    };
+
     const proposal = cleanProposal(uncleanProposal, getAssetKindByBrand);
-    const proposalShape = getProposalShapeForInvitation(invitationHandle);
+    const proposalShape =
+      offerDataAccess.getProposalShapeForInvitation(invitationHandle);
     if (proposalShape !== undefined) {
       fit(proposal, proposalShape, `${q(description)} proposal`);
     }
@@ -68,7 +60,7 @@ export const makeOfferMethod = (
       );
     }
 
-    const initialAllocation = await depositPayments(
+    const initialAllocation = await offerDataAccess.depositPayments(
       proposal,
       paymentKeywordRecord,
     );
@@ -82,7 +74,7 @@ export const makeOfferMethod = (
       offerArgs,
     );
     // AWAIT ///
-    // @ts-expect-error cast
+
     return userSeat;
   };
   return offer;

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 import { E } from '@endo/eventual-send';
-import { makePromiseKit } from '@endo/promise-kit';
 import { passStyleOf } from '@endo/marshal';
 import {
   M,
@@ -12,9 +11,8 @@ import {
 import { initEmpty } from '@agoric/store';
 
 import { defineDurableHandle } from '../makeHandle.js';
-import { handlePKitWarning } from '../handleWarning.js';
 import { makeInstanceAdminMaker } from './instanceAdminStorage.js';
-import { InstanceAdminShape, AdminFacetGuard } from '../typeGuards.js';
+import { AdminFacetGuard, InstanceAdminShape } from '../typeGuards.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -97,6 +95,10 @@ const instanceAdminBehavior = {
   getOfferFilter() {
     const { state } = this;
     return state.instanceAdmin.getOfferFilter();
+  },
+  getExitSubscriber(seatHandle) {
+    const { state } = this;
+    return state.seatHandleToAdmin.get(seatHandle).getExitSubscriber();
   },
 };
 
@@ -238,10 +240,6 @@ export const makeStartInstance = (
     /** @type {ZCFRoot} */
     const zcfRoot = zoeInstanceStorageManager.getRoot();
 
-    /** @type {PromiseRecord<HandleOfferObj>} */
-    const handleOfferObjPromiseKit = makePromiseKit();
-    handlePKitWarning(handleOfferObjPromiseKit);
-
     /** @type {InstanceAdmin} */
     const instanceAdmin = instanceAdminMaker(
       instanceHandle,
@@ -260,7 +258,6 @@ export const makeStartInstance = (
       );
 
     /** @type {ZoeInstanceAdmin} */
-    // @ts-expect-error CTH Temp for notifiers
     const zoeInstanceAdminForZcf = makeZoeInstanceAdmin(
       zoeInstanceStorageManager,
       instanceAdmin,

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -94,6 +94,12 @@
  */
 
 /**
+ * @callback SetOfferFilter
+ * @param {Instance} instance
+ * @param {string[]} strings
+ */
+
+/**
  * @callback GetInstallationForInstance
  * @param {Instance} instance
  * @returns {Promise<Installation>}
@@ -198,7 +204,12 @@
  * @typedef {object} UserSeat
  * @property {() => Promise<ProposalRecord>} getProposal
  * @property {() => Promise<PaymentPKeywordRecord>} getPayouts
+ * returns a KeywordPaymentRecord containing all the payouts from this seat. If
+ * called before the seat has exited, (check using getExitSubscriber()) it will
+ * throw an error.
  * @property {(keyword: Keyword) => Promise<Payment>} getPayout
+ * returns the Payment corresponding to the indicated keyword. If called before
+ * the seat has exited, (check using getExitSubscriber()) it will throw an error.
  * @property {() => Promise<OR>} getOfferResult
  * @property {() => void} [tryExit]
  * Note: Only works if the seat's `proposal` has an `OnDemand` `exit` clause. Zoe's
@@ -209,17 +220,18 @@
  * interact with the contract.
  * @property {() => Promise<boolean>} hasExited
  * Returns true if the seat has exited, false if it is still active.
- * @property {() => Promise<0|1>} numWantsSatisfied
- *
- * @property {() => Promise<Allocation>} getCurrentAllocationJig
- * Labelled "Jig" because it *should* only be used for tests, though
- * nothing prevents it from being used otherwise.
- * @property {() => Promise<Notifier<Allocation>>} getAllocationNotifierJig
- * Labelled "Jig" because it *should* only be used for tests, though
- * nothing prevents it from being used otherwise.
+ * @property {() => Promise<0|1>} numWantsSatisfied returns 1 if the proposal's
+ * want clause was satisfied by the final allocation, otherwise 0. This is
+ * numeric to support a planned enhancement called "multiples" which will allow
+ * the return value to be any non-negative number.  If called before the seat has
+ * exited, (check using getExitSubscriber()) it will throw an error.
  * @property {() => Promise<Allocation>} getFinalAllocation
- * return a promise for the final allocation. If called after the seat has
- * exited, it will promptly resolve to an Allocation.
+ * return the final allocation. If called before the seat has exited, (check
+ * using getExitSubscriber()) it will throw an error.
+ * @property {() => Subscriber<any>} getExitSubscriber returns a subscriber that
+ * will be notified when the seat has exited or failed. This subscriber should
+ * be used to find out when it is safe to call getFinalAllocation(),
+ * numWantsSatisfied(), getPayout(), or getPayouts().
  */
 
 /**

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -33,6 +33,7 @@
  * @property {GetBrands} getBrands
  * @property {GetTerms} getTerms
  * @property {GetOfferFilter} getOfferFilter
+ * @property {SetOfferFilter} setOfferFilter
  * @property {GetInstallationForInstance} getInstallationForInstance
  * @property {GetInstance} getInstance
  * @property {GetInstallation} getInstallation
@@ -40,12 +41,6 @@
  * Return an object with the instance, installation, description, invitation
  * handle, and any custom properties specific to the contract.
  * @property {GetFeeIssuer} getFeeIssuer
- * @property {() => Promise<Purse>} makeFeePurse
- * Deprecated. Does nothing useful but provided during transition so less old
- * code breaks.
- * @property {(defaultFeePurse: ERef<Purse>) => ZoeService} bindDefaultFeePurse
- * Deprecated. Does nothing useful but provided during transition so less old
- * code breaks.
  * @property {GetConfiguration} getConfiguration
  * @property {GetBundleIDFromInstallation} getBundleIDFromInstallation
  * @property {(invitationHandle: InvitationHandle) => Pattern | undefined} getProposalShapeForInvitation

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -16,7 +16,11 @@ import '../../exported.js';
 import '../internal-types.js';
 
 import { E } from '@endo/eventual-send';
-import { makeScalarBigMapStore, vivifyFarClassKit } from '@agoric/vat-data';
+import {
+  makeScalarBigMapStore,
+  vivifyFarClassKit,
+  provide,
+} from '@agoric/vat-data';
 
 import { makeZoeStorageManager } from './zoeStorageManager.js';
 import { makeStartInstance } from './startInstance.js';
@@ -49,7 +53,7 @@ const makeZoeKit = (
 ) => {
   let zoeService;
 
-  const feeMint = vivifyFeeMint(zoeBaggage, feeIssuerConfig, shutdownZoeVat);
+  const feeMintKit = vivifyFeeMint(zoeBaggage, feeIssuerConfig, shutdownZoeVat);
 
   /** @type {GetBundleCapForID} */
   const getBundleCapForID = bundleID =>
@@ -79,7 +83,7 @@ const makeZoeKit = (
     createZCFVat,
     getBundleCapForID,
     shutdownZoeVat,
-    feeMint,
+    feeMintKit.feeMint,
     zoeBaggage,
   );
 
@@ -136,7 +140,7 @@ const makeZoeKit = (
           return state.dataAccess.getInvitationIssuer();
         },
         async getFeeIssuer() {
-          return feeMint.getFeeIssuer();
+          return feeMintKit.feeMint.getFeeIssuer();
         },
 
         getBrands(instance) {
@@ -181,13 +185,16 @@ const makeZoeKit = (
       },
       feeMintAccessRetriever: {
         get() {
-          return feeMint.getFeeMintAccessToken();
+          console.log(`ZOE  fMAR`, feeMintKit.feeMintAccess);
+          return feeMintKit.feeMintAccess;
         },
       },
     },
   );
 
-  const zoeServices = makeZoeService(zoeServiceDataAccess);
+  const zoeServices = provide(zoeBaggage, 'zoe', () =>
+    makeZoeService(zoeServiceDataAccess),
+  );
   zoeService = zoeServices.zoeService;
   return zoeServices;
 };

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -16,15 +16,15 @@ import '../../exported.js';
 import '../internal-types.js';
 
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
-import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { makeScalarBigMapStore, vivifyFarClassKit } from '@agoric/vat-data';
 
 import { makeZoeStorageManager } from './zoeStorageManager.js';
 import { makeStartInstance } from './startInstance.js';
 import { makeOfferMethod } from './offer/offer.js';
 import { makeInvitationQueryFns } from './invitationQueries.js';
 import { getZcfBundleCap, setupCreateZCFVat } from './createZCFVat.js';
-import { vivifyFeeMint, defaultFeeIssuerConfig } from './feeMint.js';
+import { defaultFeeIssuerConfig, vivifyFeeMint } from './feeMint.js';
+import { ZoeServiceInterface } from '../typeGuards.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -39,10 +39,6 @@ import { vivifyFeeMint, defaultFeeIssuerConfig } from './feeMint.js';
  * @param {FeeIssuerConfig} feeIssuerConfig
  * @param {ZCFSpec} [zcfSpec] - Pointer to the contract facet bundle.
  * @param {Baggage} [zoeBaggage]
- * @returns {{
- *   zoeService: ZoeService,
- *   feeMintAccess: FeeMintAccess,
- * }}
  */
 const makeZoeKit = (
   vatAdminSvc,
@@ -51,6 +47,8 @@ const makeZoeKit = (
   zcfSpec = { name: 'zcf' },
   zoeBaggage = makeScalarBigMapStore('zoe baggage', { durable: true }),
 ) => {
+  let zoeService;
+
   const feeMint = vivifyFeeMint(zoeBaggage, feeIssuerConfig, shutdownZoeVat);
 
   /** @type {GetBundleCapForID} */
@@ -65,8 +63,7 @@ const makeZoeKit = (
     vatAdminSvc,
     zcfBundleCap,
     // eslint-disable-next-line no-use-before-define
-    () => invitationIssuer,
-    // eslint-disable-next-line no-use-before-define
+    () => invitationIssuerAccess.getInvitationIssuer(),
     () => zoeService,
   );
   const getBundleCapByIdNow = id => E(vatAdminSvc).getBundleCap(id);
@@ -74,51 +71,33 @@ const makeZoeKit = (
   // The ZoeStorageManager composes and consolidates capabilities
   // needed by Zoe according to POLA.
   const {
-    depositPayments,
-    getAssetKindByBrand,
-    makeZoeInstanceStorageManager,
-    installBundle,
-    installBundleID,
-    unwrapInstallation,
-    getBundleIDFromInstallation,
-    getPublicFacet,
-    getBrands,
-    getIssuers,
-    getTerms,
-    getOfferFilter,
-    getInstallationForInstance,
-    getInstanceAdmin,
-    invitationIssuer,
-    getProposalShapeForInvitation,
+    zoeServiceDataAccess,
+    makeOfferAccess,
+    startInstanceAccess,
+    invitationIssuerAccess,
   } = makeZoeStorageManager(
     createZCFVat,
     getBundleCapForID,
-    feeMintAccess => feeMint.getFeeIssuerKit(feeMintAccess),
     shutdownZoeVat,
-    feeMint.getFeeIssuer(),
-    feeMint.getFeeBrand(),
+    feeMint,
     zoeBaggage,
   );
 
   // Pass the capabilities necessary to create E(zoe).startInstance
   const startInstance = makeStartInstance(
-    makeZoeInstanceStorageManager,
-    unwrapInstallation,
+    startInstanceAccess,
     zcfBundleCap,
     getBundleCapByIdNow,
+    zoeBaggage,
   );
 
   // Pass the capabilities necessary to create E(zoe).offer
-  const offer = makeOfferMethod(
-    invitationIssuer,
-    getInstanceAdmin,
-    depositPayments,
-    getAssetKindByBrand,
-    getProposalShapeForInvitation,
-  );
+  const offer = makeOfferMethod(makeOfferAccess);
 
   // Make the methods that allow users to easily and credibly get
   // information about their invitations.
+
+  const invitationIssuer = invitationIssuerAccess.getInvitationIssuer();
   const { getInstance, getInstallation, getInvitationDetails } =
     makeInvitationQueryFns(invitationIssuer);
 
@@ -128,46 +107,89 @@ const makeZoeKit = (
     });
   };
 
-  /** @type {ZoeService} */
-  const zoeService = Far('zoeService', {
-    install: installBundle,
-    installBundleID,
-    startInstance,
-    offer,
-    /**
-     * @deprecated Useless but provided during transition to keep old
-     * code from breaking.
-     */
-    makeFeePurse: async () => feeMint.getFeeIssuer().makeEmptyPurse(),
-    /**
-     * @deprecated Useless but provided during transition to keep old
-     * code from breaking.
-     * @param {ERef<Purse>} _defaultFeePurse
-     */
-    bindDefaultFeePurse: _defaultFeePurse => zoeService,
-    getPublicFacet,
+  const makeZoeService = vivifyFarClassKit(
+    zoeBaggage,
+    'ZoeService',
+    ZoeServiceInterface,
+    dataAccess => ({ dataAccess }),
+    {
+      zoeService: {
+        install(bundleId) {
+          const { state } = this;
+          return state.dataAccess.installBundle(bundleId);
+        },
+        installBundleID(bundleId) {
+          const { state } = this;
+          return state.dataAccess.installBundleID(bundleId);
+        },
+        startInstance,
+        offer,
+        getPublicFacet(instance) {
+          const { state } = this;
+          return state.dataAccess.getPublicFacet(instance);
+        },
 
-    // The functions below are getters only and have no impact on
-    // state within Zoe
-    getInvitationIssuer: async () => invitationIssuer,
-    getFeeIssuer: async () => feeMint.getFeeIssuer(),
-    getBrands,
-    getIssuers,
-    getTerms,
-    getOfferFilter,
-    getInstallationForInstance,
-    getInstance,
-    getInstallation,
-    getInvitationDetails,
-    getConfiguration,
-    getBundleIDFromInstallation,
-    getProposalShapeForInvitation,
-  });
+        // The functions below are getters only and have no impact on
+        // state within Zoe
+        async getInvitationIssuer() {
+          const { state } = this;
+          return state.dataAccess.getInvitationIssuer();
+        },
+        async getFeeIssuer() {
+          return feeMint.getFeeIssuer();
+        },
 
-  return harden({
-    zoeService,
-    feeMintAccess: feeMint.getFeeMintAccess(),
-  });
+        getBrands(instance) {
+          const { state } = this;
+          return state.dataAccess.getBrands(instance);
+        },
+        getIssuers(instance) {
+          const { state } = this;
+          return state.dataAccess.getIssuers(instance);
+        },
+        getTerms(instance) {
+          const { state } = this;
+          return state.dataAccess.getTerms(instance);
+        },
+        getOfferFilter(instance) {
+          const { state } = this;
+          return state.dataAccess.getOfferFilter(instance);
+        },
+        setOfferFilter(instance, filters) {
+          const { state } = this;
+          state.dataAccess.setOfferFilter(instance, filters);
+        },
+        getInstallationForInstance(instance) {
+          const { state } = this;
+          return state.dataAccess.getInstallationForInstance(instance);
+        },
+
+        getInstance(invitation) {
+          return getInstance(invitation);
+        },
+        getInstallation,
+        getInvitationDetails,
+        getConfiguration,
+        getBundleIDFromInstallation(installation) {
+          const { state } = this;
+          return state.dataAccess.getBundleIDFromInstallation(installation);
+        },
+        getProposalShapeForInvitation(invitation) {
+          const { state } = this;
+          return state.dataAccess.getProposalShapeForInvitation(invitation);
+        },
+      },
+      feeMintAccessRetriever: {
+        get() {
+          return feeMint.getFeeMintAccessToken();
+        },
+      },
+    },
+  );
+
+  const zoeServices = makeZoeService(zoeServiceDataAccess);
+  zoeService = zoeServices.zoeService;
+  return zoeServices;
 };
 
 export { makeZoeKit };

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -3,108 +3,232 @@
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeNotifierKit } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { vivifyFarClassKit, M } from '@agoric/vat-data';
 
-import { handlePKitWarning } from '../handleWarning.js';
 import { satisfiesWant } from '../contractFacet/offerSafety.js';
 
 import '../types.js';
 import '../internal-types.js';
+import {
+  AmountKeywordRecordShape,
+  KeywordShape,
+  NotifierShape,
+} from '../typeGuards.js';
+
+const ZoeSeatGuard = {
+  zoeSeatAdmin: M.interface('ZoeSeatAdmin', {
+    replaceAllocation: M.call(AmountKeywordRecordShape).returns(),
+    exit: M.call(M.any()).returns(),
+    fail: M.call(M.any()).returns(),
+    getNotifier: M.call().returns(NotifierShape),
+    resolveExitAndResult: M.call(M.promise(), M.remotable()).returns(),
+  }),
+  userSeat: M.interface('UserSeat', {
+    getProposal: M.call().returns(M.promise()),
+    getPayouts: M.call().returns(M.promise()),
+    getPayout: M.call(KeywordShape).returns(M.promise()),
+    getOfferResult: M.call().returns(M.promise()),
+    hasExited: M.call().returns(M.promise()),
+    tryExit: M.call().returns(M.promise()),
+    numWantsSatisfied: M.call().returns(M.promise()),
+    // deprecated. See
+    // https://github.com/Agoric/agoric-sdk/issues/5833 and
+    // https://github.com/Agoric/agoric-sdk/issues/5834
+    getCurrentAllocationJig: M.call().returns(M.promise()),
+    getAllocationNotifierJig: M.call().returns(M.promise()),
+    getFinalAllocation: M.call().returns(M.promise()),
+  }),
+};
 
 /**
- * makeZoeSeatAdminKit makes an object that manages the state of a seat
- * participating in a Zoe contract and return its two facets.
+ * makeZoeSeatAdminFactory returns a maker for an object that manages the state
+ * of a seat participating in a Zoe contract and return its two facets.
  *
- * The UserSeat
- * is suitable to be handed to an agent outside zoe and the contract and allows
- * them to query or monitor the current state, access the payouts and result,
- * and call exit() if that's allowed for this seat.
+ * The UserSeat is suitable to be handed to an agent outside zoe and the
+ * contract and allows them to query or monitor the current state, access the
+ * payouts and result, and call exit() if that's allowed for this seat.
  *
  * The zoeSeatAdmin is passed by Zoe to the ContractFacet (zcf), to allow zcf to
  * query or update the allocation or exit the seat cleanly.
+ *
+ * @param {import('@agoric/vat-data').Baggage} baggage
  */
-/** @type {MakeZoeSeatAdminKit} */
-export const makeZoeSeatAdminKit = (
-  initialAllocation,
-  exitZoeSeatAdmin,
-  hasExited,
-  proposal,
-  withdrawPayments,
-  exitObj,
-  offerResult,
-) => {
-  const payoutPromiseKit = makePromiseKit();
-  handlePKitWarning(payoutPromiseKit);
-  const { notifier, updater } = makeNotifierKit();
+export const makeZoeSeatAdminFactory = baggage => {
+  let notifier;
+  let updater;
+  let payoutPromiseKit;
 
-  // Prime the notifier with the initial allocation.
-  updater.updateState(initialAllocation);
-
-  let currentAllocation = initialAllocation;
-
-  const doExit = zoeSeatAdmin => {
-    exitZoeSeatAdmin(zoeSeatAdmin);
-
-    /** @type {PaymentPKeywordRecord} */
-    const payout = withdrawPayments(currentAllocation);
-    payoutPromiseKit.resolve(payout);
+  // TODO(cth) these need to be moved to the seat scope
+  const getNotifier = () => {
+    if (!notifier) {
+      ({ notifier, updater } = makeNotifierKit());
+    }
+    return notifier;
+  };
+  const getUpdater = () => {
+    if (!notifier) {
+      ({ notifier, updater } = makeNotifierKit());
+    }
+    return updater;
   };
 
-  /** @type {ZoeSeatAdmin} */
-  const zoeSeatAdmin = Far('zoeSeatAdmin', {
-    replaceAllocation: replacementAllocation => {
-      assert(
-        !hasExited(zoeSeatAdmin),
-        'Cannot replace allocation. Seat has already exited',
-      );
-      harden(replacementAllocation);
-      // Merging happens in ZCF, so replacementAllocation can
-      // replace the old allocation entirely.
-      updater.updateState(replacementAllocation);
-      currentAllocation = replacementAllocation;
-    },
-    exit: reason => {
-      assert(
-        !hasExited(zoeSeatAdmin),
-        'Cannot exit seat. Seat has already exited',
-      );
-      updater.finish(reason);
-      doExit(zoeSeatAdmin);
-    },
-    fail: reason => {
-      assert(
-        !hasExited(zoeSeatAdmin),
-        'Cannot fail seat. Seat has already exited',
-      );
-      updater.fail(reason);
-      doExit(zoeSeatAdmin);
-    },
-    getNotifier: () => Promise.resolve(notifier),
-  });
+  // TODO(cth) convert to Notifier and move to the seat scope
+  const getPayoutPromiseKit = () => {
+    if (!payoutPromiseKit) {
+      payoutPromiseKit = makePromiseKit();
+    }
+    return payoutPromiseKit;
+  };
 
-  /** @type {UserSeat} */
-  const userSeat = Far('userSeat', {
-    getProposal: async () => proposal,
-    getPayouts: async () => payoutPromiseKit.promise,
-    getPayout: async keyword => {
-      assert(keyword, 'A keyword must be provided');
-      return E.get(payoutPromiseKit.promise)[keyword];
+  const doExit = (
+    zoeSeatAdmin,
+    currentAllocation,
+    withdrawFacet,
+    instanceAdminHelper,
+  ) => {
+    instanceAdminHelper.exitZoeSeatAdmin(zoeSeatAdmin);
+
+    /** @type {PaymentPKeywordRecord} */
+    const payout = withdrawFacet.withdrawPayments(currentAllocation);
+    getPayoutPromiseKit().resolve(payout);
+  };
+
+  return vivifyFarClassKit(
+    baggage,
+    'ZoeSeatKit',
+    ZoeSeatGuard,
+    (
+      initialAllocation,
+      proposal,
+      instanceAdminHelper,
+      withdrawFacet,
+      exitObj = undefined,
+    ) => ({
+      currentAllocation: initialAllocation,
+      proposal,
+      exitObj,
+      offerResult: undefined,
+      instanceAdminHelper,
+      withdrawFacet,
+    }),
+    {
+      zoeSeatAdmin: {
+        replaceAllocation(replacementAllocation) {
+          const { state, facets } = this;
+          assert(
+            !state.instanceAdminHelper.hasExited(facets.zoeSeatAdmin),
+            'Cannot replace allocation. Seat has already exited',
+          );
+          harden(replacementAllocation);
+          // Merging happens in ZCF, so replacementAllocation can
+          // replace the old allocation entirely.
+
+          // TODO (cth) notifiers
+          // getUpdater().updateState(replacementAllocation);
+
+          state.currentAllocation = replacementAllocation;
+        },
+        exit(reason) {
+          const { state, facets } = this;
+          assert(
+            !state.instanceAdminHelper.hasExited(facets.zoeSeatAdmin),
+            'Cannot exit seat. Seat has already exited',
+          );
+
+          // TODO (cth) notifiers
+          // getUpdater().finish(reason);
+
+          doExit(
+            facets.zoeSeatAdmin,
+            state.currentAllocation,
+            state.withdrawFacet,
+            state.instanceAdminHelper,
+          );
+        },
+        fail(reason) {
+          const { state, facets } = this;
+          assert(
+            !state.instanceAdminHelper.hasExited(facets.zoeSeatAdmin),
+            'Cannot fail seat. Seat has already exited',
+          );
+          getUpdater().fail(reason);
+          doExit(
+            facets.zoeSeatAdmin,
+            state.currentAllocation,
+            state.withdrawFacet,
+            state.instanceAdminHelper,
+          );
+        },
+        getNotifier() {
+          return Promise.resolve(getNotifier());
+        },
+        // called only for seats resulting from offers.
+        resolveExitAndResult(offerResultPromise, exitObj) {
+          const { state } = this;
+
+          state.offerResult = offerResultPromise;
+          state.exitObj = exitObj;
+        },
+      },
+      userSeat: {
+        async getProposal() {
+          const { state } = this;
+          return state.proposal;
+        },
+        async getPayouts() {
+          const { state } = this;
+          console.log(`ZSeat  getPayouts`, state.proposal);
+
+          debugger;
+
+          return getPayoutPromiseKit().promise;
+        },
+        async getPayout(keyword) {
+          return E.get(getPayoutPromiseKit().promise)[keyword];
+        },
+        async getOfferResult() {
+          const { state } = this;
+          return state.offerResult;
+        },
+        async hasExited() {
+          const { state, facets } = this;
+          return state.instanceAdminHelper.hasExited(facets.zoeSeatAdmin);
+        },
+        async tryExit() {
+          const { state } = this;
+          assert(state.exitObj, 'exitObj must be initialized before use');
+
+          return E(state.exitObj).exit();
+        },
+        async numWantsSatisfied() {
+          const { state } = this;
+          return E.when(getPayoutPromiseKit().promise, () =>
+            satisfiesWant(state.proposal, state.currentAllocation),
+          );
+        },
+        async getCurrentAllocationJig() {
+          const { state } = this;
+          return state.currentAllocation;
+        },
+        async getAllocationNotifierJig() {
+          return getNotifier();
+        },
+        getFinalAllocation() {
+          const { state } = this;
+          return E.when(
+            payoutPromiseKit.promise,
+            () => state.currentAllocation,
+          );
+        },
+      },
     },
-    getOfferResult: async () => offerResult,
-    hasExited: async () => hasExited(zoeSeatAdmin),
-    tryExit: async () => E(exitObj).exit(),
+    {
+      finish: ({ state }) => {
+        // TODO (cth) notifiers
+        // getUpdater().updateState(state.currentAllocation);
 
-    getCurrentAllocationJig: async () => currentAllocation,
-    getAllocationNotifierJig: async () => notifier,
-    getFinalAllocation: () =>
-      E.when(payoutPromiseKit.promise, () => currentAllocation),
-
-    numWantsSatisfied: async () => {
-      return E.when(payoutPromiseKit.promise, () =>
-        satisfiesWant(proposal, currentAllocation),
-      );
+        console.log(`ZoeSeat  finish`);
+      },
     },
-  });
-
-  return { userSeat, zoeSeatAdmin, notifier };
+  );
 };

--- a/packages/zoe/test/swingsetTests/runMint/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/runMint/bootstrap.js
@@ -8,7 +8,9 @@ export function buildRootObject(vatPowers, vatParameters) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
-      const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const { zoe, feeMintAccessRetriever } = await E(vats.zoe).buildZoe(
+        vatAdminSvc,
+      );
       const installations = {};
       const installedPs = vatParameters.contractNames.map(name =>
         E(vatAdminSvc)
@@ -20,6 +22,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       );
       await Promise.all(installedPs);
 
+      const feeMintAccess = await E(feeMintAccessRetriever).get();
       const aliceP = E(vats.alice).build(zoe, installations, feeMintAccess);
       await E(aliceP).runMintTest();
     },

--- a/packages/zoe/test/swingsetTests/runMint/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/runMint/vat-alice.js
@@ -13,9 +13,9 @@ const build = async (log, zoe, installations, feeMintAccess) => {
       log('starting runMintTest');
       const { instance } = await E(zoe).startInstance(
         installations.offerArgsUsageContract,
-        {
+        harden({
           RUN: E(zoe).getFeeIssuer(),
-        },
+        }),
         undefined,
       );
       const issuers = await E(zoe).getIssuers(instance);

--- a/packages/zoe/test/swingsetTests/runMint/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/runMint/vat-zoe.js
@@ -8,11 +8,12 @@ export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: async vatAdminSvc => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe, feeMintAccess } = makeZoeKit(
+      const { zoeService: zoe, feeMintAccessRetriever } = makeZoeKit(
         vatAdminSvc,
         shutdownZoeVat,
       );
-      return harden({ zoe, feeMintAccess });
+
+      return harden({ zoe, feeMintAccessRetriever });
     },
   });
 }

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -8,9 +8,8 @@ import '../../../../exported.js';
 
 import { E } from '@endo/eventual-send';
 import bundleSource from '@endo/bundle-source';
-import { AmountMath } from '@agoric/ertp';
+import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 
-import { setup } from '../../setupBasicMints.js';
 import { setupZCFTest } from '../../zcf/setupZcfTest.js';
 import { makeRatio } from '../../../../src/contractSupport/index.js';
 import { assertAmountsEqual } from '../../../zoeTestHelpers.js';
@@ -95,7 +94,8 @@ export const checkPayouts = async (
 };
 
 export const setupLoanUnitTest = async terms => {
-  const { moolaKit: collateralKit, simoleanKit: loanKit } = setup();
+  const collateralKit = makeIssuerKit('moola');
+  const loanKit = makeIssuerKit('simoleans');
 
   if (!terms) {
     terms = harden({

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -35,11 +35,12 @@ const setupBorrow = async (
   timer = buildManualTimer(console.log, 0n, { eventLoopIteration }),
 ) => {
   const setup = await setupLoanUnitTest();
-  const { zcf, loanKit, collateralKit, zoe, vatAdminState } = setup;
+  const { zcf: loanZcf, loanKit, collateralKit, zoe, vatAdminState } = setup;
   // Set up the lender seat
   const maxLoan = AmountMath.make(loanKit.brand, maxLoanValue);
+
   const { zcfSeat: lenderSeat, userSeat: lenderUserSeat } = await makeSeatKit(
-    zcf,
+    loanZcf,
     { give: { Loan: maxLoan } },
     { Loan: loanKit.mint.mintPayment(maxLoan) },
   );
@@ -88,7 +89,7 @@ const setupBorrow = async (
     loanBrand: loanKit.brand,
     collateralBrand: collateralKit.brand,
   };
-  const borrowInvitation = makeBorrowInvitation(zcf, config);
+  const borrowInvitation = makeBorrowInvitation(loanZcf, config);
   return {
     ...setup,
     borrowInvitation,

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -350,7 +350,7 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
   await E(aliceSeat).getOfferResult();
 
   await t.throwsAsync(() => E(aliceSeat).tryExit(), {
-    message: /seat has been exited/,
+    message: /seat has already exited/,
   });
 
   const moolaPayout = await aliceSeat.getPayout('ContributionA');

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -12,8 +12,9 @@ import { eventLoopIteration } from '../../../tools/eventLoopIteration.js';
 import { setup } from '../setupBasicMints.js';
 import { installationPFromSource } from '../installFromSource.js';
 import {
-  assertPayoutDeposit,
+  assertGetPayoutAndDeposit,
   assertPayoutAmount,
+  assertPayoutDeposit,
 } from '../../zoeTestHelpers.js';
 import { makeFakePriceAuthority } from '../../../tools/fakePriceAuthority.js';
 
@@ -426,14 +427,15 @@ test('fundedCallSpread, late exercise', async t => {
   await E(manualTimer).tick();
 
   const carolOptionSeat = await E(zoe).offer(carolShortOption);
-  const carolPayout = await carolOptionSeat.getPayout('Collateral');
-  const carolDepositAmount = await E(carolBucksPurse).deposit(carolPayout);
-  await t.deepEqual(
-    carolDepositAmount,
+  const carolDeposit = assertGetPayoutAndDeposit(
+    t,
+    carolOptionSeat,
+    'Collateral',
+    carolBucksPurse,
     bucks(75n),
-    `payout was ${carolDepositAmount.value}, expected 75`,
   );
-  await Promise.all([bobDeposit]);
+
+  await Promise.all([bobDeposit, carolDeposit]);
 });
 
 test('fundedCallSpread, sell options', async t => {
@@ -700,10 +702,10 @@ test('pricedCallSpread, mid-strike', async t => {
   const bobOption = await bobFundingSeat.getPayout('Option');
   const bobOptionSeat = await E(zoe).offer(bobOption);
 
-  const bobPayout = bobOptionSeat.getPayout('Collateral');
-  const bobDeposit = assertPayoutDeposit(
+  const bobDeposit = assertGetPayoutAndDeposit(
     t,
-    bobPayout,
+    bobOptionSeat,
+    'Collateral',
     bobBucksPurse,
     bucks(225n),
   );
@@ -728,10 +730,10 @@ test('pricedCallSpread, mid-strike', async t => {
   const carolOption = await carolFundingSeat.getPayout('Option');
   const carolOptionSeat = await E(zoe).offer(carolOption);
 
-  const carolPayout = carolOptionSeat.getPayout('Collateral');
-  const carolDeposit = assertPayoutDeposit(
+  const carolDeposit = assertGetPayoutAndDeposit(
     t,
-    carolPayout,
+    carolOptionSeat,
+    'Collateral',
     carolBucksPurse,
     bucks(75n),
   );

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -545,6 +545,7 @@ test('zoe - coveredCall with swap for invitation', async t => {
   const daveCoveredCallPayments = harden({
     StrikePrice: daveSimoleanPayment,
   });
+
   const daveCoveredCallSeat = await E(zoe).offer(
     daveOption,
     daveCoveredCallProposal,

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -16,6 +16,7 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 import '../../../exported.js';
 import '../../../src/contracts/exported.js';
+import { assertGetPayoutAmount } from '../../zoeTestHelpers.js';
 
 /**
  * @typedef {object} TestContext
@@ -172,8 +173,11 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
   t.deepEqual(await E(offer3).getOfferResult(), {
     pong: { kind: 'Paid', data: 'baz' },
   });
-  t.deepEqual(
-    await link.issuer.getAmountOf(E(offer3).getPayout('Fee')),
+  await assertGetPayoutAmount(
+    t,
+    link.issuer,
+    offer3,
+    'Fee',
     AmountMath.subtract(overAmount, feeAmount),
   );
 
@@ -192,10 +196,7 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
 
   await t.throwsAsync(() => E(offer2).getOfferResult(), { instanceOf: Error });
   await t.throwsAsync(() => E(offer4).getOfferResult(), { instanceOf: Error });
-  t.deepEqual(
-    await link.issuer.getAmountOf(E(offer4).getPayout('Fee')),
-    underAmount,
-  );
+  await assertGetPayoutAmount(t, link.issuer, offer4, 'Fee', underAmount);
 
   const withdrawSome = E(pingCreator).makeWithdrawInvitation();
   const withdrawOffer = E(zoe).offer(
@@ -239,8 +240,11 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
     message: `Oracle revoked`,
   });
 
-  t.deepEqual(
-    await link.issuer.getAmountOf(E(withdrawOffer).getPayout('Fee')),
+  await assertGetPayoutAmount(
+    t,
+    link.issuer,
+    withdrawOffer,
+    'Fee',
     AmountMath.make(link.brand, 201n),
   );
 });

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -11,7 +11,7 @@ import { Far } from '@endo/marshal';
 
 import { setup } from '../setupBasicMints.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
-import { assertPayoutAmount } from '../../zoeTestHelpers.js';
+import { assertGetPayoutAmount } from '../../zoeTestHelpers.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -159,17 +159,19 @@ const makeBob = (
         'The option was exercised. Please collect the assets in your payout.',
       );
 
-      await assertPayoutAmount(
+      await assertGetPayoutAmount(
         t,
         moolaIssuer,
-        E(seat).getPayout('Whatever2'),
+        seat,
+        'Whatever2',
         moola(3n),
         'bob moola',
       );
-      await assertPayoutAmount(
+      await assertGetPayoutAmount(
         t,
         simoleanIssuer,
-        E(seat).getPayout('Whatever1'),
+        seat,
+        'Whatever1',
         simoleans(0n),
         'bob simolean',
       );
@@ -213,17 +215,19 @@ const makeBob = (
         message: 'The covered call option is expired.',
       });
 
-      await assertPayoutAmount(
+      await assertGetPayoutAmount(
         t,
         moolaIssuer,
-        E(offerExpiredSeat).getPayout('Whatever2'),
+        offerExpiredSeat,
+        'Whatever2',
         moola(0n),
         'bob moola',
       );
-      await assertPayoutAmount(
+      await assertGetPayoutAmount(
         t,
         simoleanIssuer,
-        E(offerExpiredSeat).getPayout('Whatever1'),
+        offerExpiredSeat,
+        'Whatever1',
         simoleans(4n),
         'bob simolean',
       );
@@ -268,24 +272,27 @@ const makeBob = (
           'rights were not conserved for brand "[Alleged: simoleans brand]" "[15n]" != "[16n]"',
       });
 
-      await assertPayoutAmount(
+      await assertGetPayoutAmount(
         t,
         bucksIssuer,
-        E(seat).getPayout('Whatever1'),
+        seat,
+        'Whatever1',
         bucks(500n),
         'bob bucks',
       );
-      await assertPayoutAmount(
+      await assertGetPayoutAmount(
         t,
         moolaIssuer,
-        E(seat).getPayout('Whatever2'),
+        seat,
+        'Whatever2',
         moola(35n),
         'bob moola',
       );
-      await assertPayoutAmount(
+      await assertGetPayoutAmount(
         t,
         simoleanIssuer,
-        E(seat).getPayout('Whatever3'),
+        seat,
+        'Whatever3',
         simoleans(0n),
         'bob simolean',
       );
@@ -336,24 +343,27 @@ const makeBob = (
 
       t.is(await E(publicFacet).getRating(), '66%');
 
-      await assertPayoutAmount(
+      await assertGetPayoutAmount(
         t,
         bucksIssuer,
-        E(seat).getPayout('Whatever1'),
+        seat,
+        'Whatever1',
         bucks(500n),
         'bob bucks',
       );
-      await assertPayoutAmount(
+      await assertGetPayoutAmount(
         t,
         moolaIssuer,
-        E(seat).getPayout('Whatever2'),
+        seat,
+        'Whatever2',
         moola(35n),
         'bob moola',
       );
-      await assertPayoutAmount(
+      await assertGetPayoutAmount(
         t,
         simoleanIssuer,
-        E(seat).getPayout('Whatever3'),
+        seat,
+        'Whatever3',
         simoleans(0n),
         'bob simolean',
       );

--- a/packages/zoe/test/unitTests/test-blockedOffers.js
+++ b/packages/zoe/test/unitTests/test-blockedOffers.js
@@ -14,7 +14,7 @@ import {
   depositToSeat,
   withdrawFromSeat,
 } from '../../src/contractSupport/index.js';
-import { assertPayoutAmount } from '../zoeTestHelpers.js';
+import { assertAmountsEqual } from '../zoeTestHelpers.js';
 import { makeOffer } from './makeOffer.js';
 
 const filename = new URL(import.meta.url).pathname;
@@ -106,7 +106,9 @@ test(`blockedOffers - allow empty`, async t => {
   await depositToSeat(zcf, zcfSeat, { C: bucks(2n) }, { C: newBucks });
   const promises = await withdrawFromSeat(zcf, zcfSeat, { C: bucks(2n) });
 
-  await assertPayoutAmount(t, bucksIssuer, promises.C, bucks(2n), 'C is 2');
+  await E.when(E(bucksIssuer).getAmountOf(promises.C), amount =>
+    assertAmountsEqual(t, amount, bucks(2n), 'C is 2'),
+  );
 });
 
 test(`blockedOffers - allow`, async t => {
@@ -127,7 +129,9 @@ test(`blockedOffers - allow`, async t => {
   await depositToSeat(zcf, zcfSeat, { C: bucks(2n) }, { C: newBucks });
   const promises = await withdrawFromSeat(zcf, zcfSeat, { C: bucks(2n) });
 
-  await assertPayoutAmount(t, bucksIssuer, promises.C, bucks(2n), 'C is 2');
+  await E.when(E(bucksIssuer).getAmountOf(promises.C), amount =>
+    assertAmountsEqual(t, amount, bucks(2n), 'C is 2'),
+  );
 });
 
 test(`blockedOffers - allow not blocked by incomplete prefix`, async t => {
@@ -148,5 +152,7 @@ test(`blockedOffers - allow not blocked by incomplete prefix`, async t => {
   await depositToSeat(zcf, zcfSeat, { C: bucks(2n) }, { C: newBucks });
   const promises = await withdrawFromSeat(zcf, zcfSeat, { C: bucks(2n) });
 
-  await assertPayoutAmount(t, bucksIssuer, promises.C, bucks(2n), 'C is 2');
+  await E.when(E(bucksIssuer).getAmountOf(promises.C), amount =>
+    assertAmountsEqual(t, amount, bucks(2n), 'C is 2'),
+  );
 });

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -68,7 +68,7 @@ test.before(
   },
 );
 
-test('pay bounty', async t => {
+test.serial('pay bounty', async t => {
   const { zoe, oracleInstallation, bountyInstallation } = t.context;
   // The timer is not build in test.before(), because each test needs its own.
   const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });
@@ -153,7 +153,7 @@ test('pay bounty', async t => {
   await Promise.all([promise1, promise2, promise3, promise4]);
 });
 
-test('pay no bounty', async t => {
+test.serial('pay no bounty', async t => {
   const { zoe, oracleInstallation, bountyInstallation } = t.context;
   // The timer is not build in test.before(), because each test needs its own.
   const timer = buildManualTimer(t.log, 0n, { eventLoopIteration });

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -17,7 +17,7 @@ import '../../src/contracts/exported.js';
 import buildManualTimer from '../../tools/manualTimer.js';
 import { eventLoopIteration } from '../../tools/eventLoopIteration.js';
 import { setup } from './setupBasicMints.js';
-import { assertPayoutAmount } from '../zoeTestHelpers.js';
+import { assertGetPayoutAmount } from '../zoeTestHelpers.js';
 import { makeScriptedOracle } from '../../tools/scriptedOracle.js';
 
 // This test shows how to set up a fake oracle and use it in a contract.
@@ -109,16 +109,18 @@ test.serial('pay bounty', async t => {
     }),
   );
   const bountyInvitation = await funderSeat.getOfferResult();
-  const promise1 = assertPayoutAmount(
+  const promise1 = assertGetPayoutAmount(
     t,
     moolaIssuer,
-    funderSeat.getPayout('Fee'),
+    funderSeat,
+    'Fee',
     moola(50n),
   );
-  const promise2 = assertPayoutAmount(
+  const promise2 = assertGetPayoutAmount(
     t,
     moolaIssuer,
-    funderSeat.getPayout('Bounty'),
+    funderSeat,
+    'Bounty',
     moola(0n),
   );
 
@@ -133,16 +135,18 @@ test.serial('pay bounty', async t => {
       Fee: moolaMint.mintPayment(moola(50n)),
     }),
   );
-  const promise3 = assertPayoutAmount(
+  const promise3 = assertGetPayoutAmount(
     t,
     moolaIssuer,
-    bountySeat.getPayout('Fee'),
+    bountySeat,
+    'Fee',
     moola(0n),
   );
-  const promise4 = assertPayoutAmount(
+  const promise4 = assertGetPayoutAmount(
     t,
     moolaIssuer,
-    bountySeat.getPayout('Bounty'),
+    bountySeat,
+    'Bounty',
     moola(200n),
   );
 
@@ -194,17 +198,19 @@ test.serial('pay no bounty', async t => {
     }),
   );
   const bountyInvitation = await funderSeat.getOfferResult();
-  const p1 = assertPayoutAmount(
+  const p1 = assertGetPayoutAmount(
     t,
     moolaIssuer,
-    funderSeat.getPayout('Fee'),
+    funderSeat,
+    'Fee',
     moola(50n),
   );
   // Alice gets the funds back.
-  const p2 = assertPayoutAmount(
+  const p2 = assertGetPayoutAmount(
     t,
     moolaIssuer,
-    funderSeat.getPayout('Bounty'),
+    funderSeat,
+    'Bounty',
     moola(200n),
   );
 
@@ -219,17 +225,19 @@ test.serial('pay no bounty', async t => {
       Fee: moolaMint.mintPayment(moola(50n)),
     }),
   );
-  const p3 = assertPayoutAmount(
+  const p3 = assertGetPayoutAmount(
     t,
     moolaIssuer,
-    bountySeat.getPayout('Fee'),
+    bountySeat,
+    'Fee',
     moola(0n),
   );
   // Bob doesn't receive the bounty
-  const p4 = assertPayoutAmount(
+  const p4 = assertGetPayoutAmount(
     t,
     moolaIssuer,
-    bountySeat.getPayout('Bounty'),
+    bountySeat,
+    'Bounty',
     moola(0n),
   );
 

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -21,8 +21,7 @@ const dirname = path.dirname(filename);
 test(`zoe.getInvitationIssuer`, async t => {
   const { zoe, zcf } = await setupZCFTest();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  // @ts-expect-error
-  const invitation = zcf.makeInvitation(undefined, 'invite');
+  const invitation = zcf.makeInvitation(() => {}, 'invite');
 
   // A few basic tests that the invitation issuer acts like an issuer.
   // Not exhaustive.
@@ -105,10 +104,7 @@ test(`E(zoe).startInstance no issuerKeywordRecord, no terms`, async t => {
   facetHasMethods(t, result.startInstanceResult.publicFacet, [
     'makeInvitation',
   ]);
-  t.deepEqual(
-    Object.getOwnPropertyNames(result.startInstanceResult.adminFacet).sort(),
-    ['getVatShutdownPromise', 'restartContract', 'upgradeContract'],
-  );
+  isEmptyFacet(t, result.startInstanceResult.adminFacet);
 });
 
 test(`E(zoe).startInstance promise for installation`, async t => {
@@ -146,7 +142,7 @@ test(`E(zoe).startInstance - terms, issuerKeywordRecord switched`, async t => {
       ),
     {
       message:
-        /In "startInstance" method of \(ZoeService zoeService\) arg 1: something: \[1\]: number 2/,
+        /In "startInstance" method of \(ZoeService zoeService\) arg 1: something: \[1\]: 2/,
     },
   );
 });
@@ -373,8 +369,7 @@ test(`zoe.getInstallationForInstance`, async t => {
 
 test(`zoe.getInstance`, async t => {
   const { zoe, zcf, instance } = await setupZCFTest();
-  // @ts-expect-error
-  const invitation = await E(zcf).makeInvitation(undefined, 'invitation');
+  const invitation = await E(zcf).makeInvitation(() => {}, 'invitation');
   const actualInstance = await E(zoe).getInstance(invitation);
   t.is(actualInstance, instance);
 });
@@ -388,8 +383,7 @@ test(`zoe.getInstance - no invitation`, async t => {
 
 test(`zoe.getInstallation`, async t => {
   const { zoe, zcf, installation } = await setupZCFTest();
-  // @ts-expect-error
-  const invitation = await E(zcf).makeInvitation(undefined, 'invitation');
+  const invitation = await E(zcf).makeInvitation(() => {}, 'invitation');
   const actualInstallation = await E(zoe).getInstallation(invitation);
   t.is(actualInstallation, installation);
 });
@@ -403,15 +397,10 @@ test(`zoe.getInstallation - no invitation`, async t => {
 });
 
 test(`zoe.getInvitationDetails`, async t => {
-  const { zoe, zcf, installation, instance } = await setupZCFTest();
+  const { zcf } = await setupZCFTest();
   // @ts-expect-error
-  const invitation = await E(zcf).makeInvitation(undefined, 'invitation');
-  const details = await E(zoe).getInvitationDetails(invitation);
-  t.deepEqual(details, {
-    description: 'invitation',
-    handle: details.handle,
-    installation,
-    instance,
+  await t.throwsAsync(() => E(zcf).makeInvitation(undefined, 'invitation'), {
+    message: 'offerHandler must be provided',
   });
 });
 

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -6,7 +6,6 @@ import path from 'path';
 
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
-import { makePromiseKit } from '@endo/promise-kit';
 import { passStyleOf, Far } from '@endo/marshal';
 import { getMethodNames } from '@agoric/internal';
 
@@ -39,7 +38,7 @@ test(`E(zoe).install bad bundle`, async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).install(), {
-    message: 'a bundle must be provided',
+    message: /expected 1 arguments/,
   });
 });
 
@@ -55,7 +54,7 @@ test(`E(zoe).installBundleID bad id`, async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).installBundleID(), {
-    message: 'a bundle ID must be provided',
+    message: /expected 1 arguments/,
   });
 });
 
@@ -77,13 +76,7 @@ test(`E(zoe).startInstance bad installation`, async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).startInstance(), {
-    message:
-      // Should be able to use more informative error once SES double
-      // disclosure bug is fixed. See
-      // https://github.com/endojs/endo/pull/640
-      //
-      // /"\[undefined\]" was not a valid installation/,
-      /.* was not a valid installation/,
+    message: /expected 1 arguments/,
   });
 });
 
@@ -98,10 +91,9 @@ function facetHasMethods(t, facet, names) {
 }
 
 test(`E(zoe).startInstance no issuerKeywordRecord, no terms`, async t => {
-  const { zoe, installation } = await setupZCFTest();
-  const result = await E(zoe).startInstance(installation);
+  const result = await setupZCFTest();
   // Note that deepEqual treats all empty objects (handles) as interchangeable.
-  t.deepEqual(Object.getOwnPropertyNames(result).sort(), [
+  t.deepEqual(Object.getOwnPropertyNames(result.startInstanceResult).sort(), [
     'adminFacet',
     'creatorFacet',
     'creatorInvitation',
@@ -110,23 +102,19 @@ test(`E(zoe).startInstance no issuerKeywordRecord, no terms`, async t => {
   ]);
   isEmptyFacet(t, result.creatorFacet);
   t.deepEqual(result.creatorInvitation, undefined);
-  facetHasMethods(t, result.publicFacet, ['makeInvitation']);
-  t.deepEqual(getMethodNames(result.adminFacet), [
-    'getVatShutdownPromise',
-    'restartContract',
-    'upgradeContract',
+  facetHasMethods(t, result.startInstanceResult.publicFacet, [
+    'makeInvitation',
   ]);
+  t.deepEqual(
+    Object.getOwnPropertyNames(result.startInstanceResult.adminFacet).sort(),
+    ['getVatShutdownPromise', 'restartContract', 'upgradeContract'],
+  );
 });
 
 test(`E(zoe).startInstance promise for installation`, async t => {
-  const { zoe, installation } = await setupZCFTest();
-  const { promise: installationP, resolve: installationPResolve } =
-    makePromiseKit();
+  const { startInstanceResult } = await setupZCFTest();
 
-  const resultP = E(zoe).startInstance(installationP);
-  installationPResolve(installation);
-
-  const result = await resultP;
+  const result = await startInstanceResult;
   // Note that deepEqual treats all empty objects (handles) as interchangeable.
   t.deepEqual(Object.getOwnPropertyNames(result).sort(), [
     'adminFacet',
@@ -146,7 +134,8 @@ test(`E(zoe).startInstance promise for installation`, async t => {
 });
 
 test(`E(zoe).startInstance - terms, issuerKeywordRecord switched`, async t => {
-  const { zoe, installation } = await setupZCFTest();
+  const { zoe } = setup();
+  const installation = await E(zoe).installBundleID('b1-contract');
   const { moolaKit } = setup();
   await t.throwsAsync(
     () =>
@@ -157,18 +146,14 @@ test(`E(zoe).startInstance - terms, issuerKeywordRecord switched`, async t => {
       ),
     {
       message:
-        // Should be able to use more informative error once SES double
-        // disclosure bug is fixed. See
-        // https://github.com/endojs/endo/pull/640
-        //
-        // /keyword "something" must be an ascii identifier starting with upper case./
-        /keyword .* must be an ascii identifier starting with upper case./,
+        /In "startInstance" method of \(ZoeService zoeService\) arg 1: something: \[1\]: number 2/,
     },
   );
 });
 
 test(`E(zoe).startInstance - bad issuer, makeEmptyPurse throws`, async t => {
-  const { zoe, installation } = await setupZCFTest();
+  const { zoe } = setup();
+  const installation = await E(zoe).installBundleID('b1-contract');
   const brand = Far('brand', {
     // eslint-disable-next-line no-use-before-define
     isMyIssuer: i => i === badIssuer,
@@ -196,14 +181,6 @@ test(`E(zoe).offer`, async t => {
   t.is(await E(userSeat).getOfferResult(), 'result');
 });
 
-test(`E(zoe).offer - no invitation`, async t => {
-  const { zoe } = await setupZCFTest();
-  // @ts-expect-error deliberate invalid arguments for testing
-  await t.throwsAsync(() => E(zoe).offer(), {
-    message: /A Zoe invitation is required, not "\[undefined\]"/,
-  });
-});
-
 test(`E(zoe).offer - payment instead of paymentKeywordRecord`, async t => {
   const { zoe, zcf } = await setupZCFTest();
   const { mint, brand, issuer } = makeIssuerKit('Token');
@@ -215,7 +192,7 @@ test(`E(zoe).offer - payment instead of paymentKeywordRecord`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).offer(invitation, proposal, payment), {
     message:
-      '"keywordRecord" "[Alleged: Token payment]" must be a pass-by-copy record, not "remotable"',
+      'In "offer" method of (ZoeService zoeService) arg 2: remotable "[Alleged: Token payment]" - Must be a copyRecord',
   });
 });
 
@@ -256,13 +233,7 @@ test(`E(zoe).getPublicFacet - no instance`, async t => {
   const { zoe } = setup();
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getPublicFacet(), {
-    message:
-      // Should be able to use more informative error once SES double
-      // disclosure bug is fixed. See
-      // https://github.com/endojs/endo/pull/640
-      //
-      // /"instance" not found: "\[undefined\]"/,
-      /.* not found: "\[undefined\]"/,
+    message: /expected 1 arguments/,
   });
 });
 
@@ -292,13 +263,7 @@ test(`zoe.getIssuers - no instance`, async t => {
   const { zoe } = setup();
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getIssuers(), {
-    message:
-      // Should be able to use more informative error once SES double
-      // disclosure bug is fixed. See
-      // https://github.com/endojs/endo/pull/640
-      //
-      // /"instance" not found: "\[undefined\]"/,
-      /.* not found: "\[undefined\]"/,
+    message: /expected 1 arguments/,
   });
 });
 
@@ -328,13 +293,7 @@ test(`zoe.getBrands - no instance`, async t => {
   const { zoe } = setup();
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getBrands(), {
-    message:
-      // Should be able to use more informative error once SES double
-      // disclosure bug is fixed. See
-      // https://github.com/endojs/endo/pull/640
-      //
-      // /"instance" not found: "\[undefined\]"/,
-      /.* not found: "\[undefined\]"/,
+    message: /expected 1 arguments/,
   });
 });
 
@@ -386,13 +345,7 @@ test(`zoe.getTerms - no instance`, async t => {
   const { zoe } = setup();
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getTerms(), {
-    message:
-      // Should be able to use more informative error once SES double
-      // disclosure bug is fixed. See
-      // https://github.com/endojs/endo/pull/640
-      //
-      // /"instance" not found: "\[undefined\]"/,
-      /.* not found: "\[undefined\]"/,
+    message: /expected 1 arguments/,
   });
 });
 
@@ -428,9 +381,8 @@ test(`zoe.getInstance`, async t => {
 
 test(`zoe.getInstance - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
-  // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInstance(), {
-    message: 'A Zoe invitation is required, not "[undefined]"',
+    message: /expected 1 arguments/,
   });
 });
 
@@ -446,7 +398,7 @@ test(`zoe.getInstallation - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInstallation(), {
-    message: 'A Zoe invitation is required, not "[undefined]"',
+    message: /expected 1 arguments/,
   });
 });
 
@@ -467,30 +419,11 @@ test(`zoe.getInvitationDetails - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInvitationDetails(), {
-    message: 'A Zoe invitation is required, not "[undefined]"',
+    message: /expected 1 arguments/,
   });
 });
 
-test(`zcf.registerFeeMint twice`, async t => {
-  const { zoe, zcf: zcf1, zcf2, feeMintAccess } = await setupZCFTest();
-  const feeIssuer = E(zoe).getFeeIssuer();
-  const feeBrand = await E(feeIssuer).getBrand();
-
-  const fee1000 = AmountMath.make(feeBrand, 1000n);
-
-  const zcfMint1 = await zcf1.registerFeeMint('RUN', feeMintAccess);
-  const zcfMint2 = await zcf2.registerFeeMint('RUN', feeMintAccess);
-
-  const zcfSeat1 = zcfMint1.mintGains(harden({ Fee: fee1000 }));
-  const zcfSeat2 = zcfMint2.mintGains(harden({ Fee: fee1000 }));
-
-  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    Fee: fee1000,
-  });
-  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    Fee: fee1000,
-  });
-});
+test.todo(`zcf.registerFeeMint twice in different contracts`);
 
 test(`zoe.getConfiguration`, async t => {
   const { zoe } = await setupZCFTest();

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -24,36 +24,17 @@ const contractRoot = `${dirname}/zcfTesterContract.js`;
 export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   /** @type {ZCF<T>} */
   let zcf;
-  /** @type {ZCF<T>} */
-  let zcf2;
 
-  // We would like to start two contract instances in order to get two
-  // different `zcfs`. However, we only pass in one `setTestJig`, so
-  // here, we set the first `zcf` if it has not been set before, and
-  // if it has, we set the second `zcf`.
-  const setZCF = jig => {
-    if (zcf === undefined) {
-      zcf = jig.zcf;
-    } else {
-      zcf2 = jig.zcf;
-    }
-  };
+  const setZCF = jig => (zcf = jig.zcf);
   // The contract provides the `zcf` via `setTestJig` upon `start`.
   const fakeVatAdmin = makeFakeVatAdmin(setZCF);
-  const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin.admin);
+  const { zoeService: zoe, feeMintAccessRetriever } = makeZoeKit(
+    fakeVatAdmin.admin,
+  );
   const bundle = await bundleSource(contractRoot);
   fakeVatAdmin.vatAdminState.installBundle('b1-contract', bundle);
   const installation = await E(zoe).installBundleID('b1-contract');
-  const { creatorFacet, instance } = await E(zoe).startInstance(
-    installation,
-    issuerKeywordRecord,
-    // @ts-expect-error generics mismatch
-    terms,
-  );
-  // In case a second zcf is needed
-  const { creatorFacet: creatorFacet2, instance: instance2 } = await E(
-    zoe,
-  ).startInstance(
+  const startInstanceResult = await E(zoe).startInstance(
     installation,
     issuerKeywordRecord,
     // @ts-expect-error generics mismatch
@@ -65,16 +46,11 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   return {
     zoe,
     zcf,
-    instance,
+    instance: startInstanceResult.instance,
     installation,
-    creatorFacet,
+    creatorFacet: startInstanceResult.creatorFacet,
     vatAdminState,
-    feeMintAccess,
-
-    // Additional ZCF
-    // @ts-expect-error zcf2 is accessible before it is set
-    zcf2,
-    creatorFacet2,
-    instance2,
+    feeMintAccessRetriever,
+    startInstanceResult,
   };
 };

--- a/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
+++ b/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
@@ -20,10 +20,11 @@ const contractRoot = `${dirname}/registerFeeMintContract.js`;
 
 test(`feeMintAccess`, async t => {
   const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
-  const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe, feeMintAccessRetriever } = makeZoeKit(fakeVatAdmin);
   const bundle = await bundleSource(contractRoot);
   vatAdminState.installBundle('b1-registerfee', bundle);
   const installation = await E(zoe).installBundleID('b1-registerfee');
+  const feeMintAccess = await E(feeMintAccessRetriever).get();
   const { creatorFacet } = await E(zoe).startInstance(
     installation,
     undefined,

--- a/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
@@ -45,10 +45,7 @@ test(`zcf.reallocate undefined`, async t => {
 
   // @ts-expect-error Deliberate wrong type for testing
   t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2, undefined), {
-    message:
-      // TODO: Improve error message if something other than a seat is
-      // passed.
-      'seat has been exited',
+    message: / - Must be a remotable/,
   });
 });
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -79,7 +79,7 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
     message: 'second seat failed',
   });
   await t.throwsAsync(() => E(userSeat1).tryExit(), {
-    message: 'seat has been exited',
+    message: 'Cannot exit; seat has already exited',
   });
   t.falsy(vatAdminState.getHasExited());
 });

--- a/packages/zoe/test/unitTests/zoe/test-escrowStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-escrowStorage.js
@@ -6,15 +6,17 @@ import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 
 import { E } from '@endo/eventual-send';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
-import { makeEscrowStorage } from '../../../src/zoeService/escrowStorage.js';
+import { provideEscrowStorage } from '../../../src/zoeService/escrowStorage.js';
 import {
   assertAmountsEqual,
   assertPayoutAmount,
 } from '../../zoeTestHelpers.js';
 
-test('makeEscrowStorage', async t => {
-  const { createPurse, makeLocalPurse, withdrawPayments, depositPayments } =
-    makeEscrowStorage(makeScalarBigMapStore('zoe baggage', { durable: true }));
+test('provideEscrowStorage', async t => {
+  const { createPurse, provideLocalPurse, withdrawPayments, depositPayments } =
+    provideEscrowStorage(
+      makeScalarBigMapStore('zoe baggage', { durable: true }),
+    );
 
   const currencyKit = makeIssuerKit(
     'currency',
@@ -27,7 +29,7 @@ test('makeEscrowStorage', async t => {
   await createPurse(currencyKit.issuer, currencyKit.brand);
 
   // Normally only used for ZCFMint issuers
-  makeLocalPurse(ticketKit.issuer, ticketKit.brand);
+  provideLocalPurse(ticketKit.issuer, ticketKit.brand);
 
   const gameTicketAmount = AmountMath.make(
     ticketKit.brand,
@@ -133,7 +135,7 @@ const setupPurses = async createPurse => {
 };
 
 test('payments without matching give keywords', async t => {
-  const { createPurse, depositPayments } = makeEscrowStorage(
+  const { createPurse, depositPayments } = provideEscrowStorage(
     makeScalarBigMapStore('zoe baggage', { durable: true }),
   );
 
@@ -170,7 +172,7 @@ test('payments without matching give keywords', async t => {
 });
 
 test(`give keywords without matching payments`, async t => {
-  const { createPurse, depositPayments } = makeEscrowStorage(
+  const { createPurse, depositPayments } = provideEscrowStorage(
     makeScalarBigMapStore('zoe baggage', { durable: true }),
   );
 

--- a/packages/zoe/test/unitTests/zoe/test-installationStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-installationStorage.js
@@ -7,11 +7,11 @@ import { makeHandle } from '../../../src/makeHandle.js';
 import { makeInstallationStorage } from '../../../src/zoeService/installationStorage.js';
 
 test('install, unwrap installations', async t => {
-  const { installBundle, unwrapInstallation } = makeInstallationStorage();
+  const installationStorage = makeInstallationStorage();
   const fakeBundle = {};
 
-  const installation = await installBundle(fakeBundle);
-  const unwrapped = await unwrapInstallation(installation);
+  const installation = await installationStorage.installBundle(fakeBundle);
+  const unwrapped = await installationStorage.unwrapInstallation(installation);
   t.is(unwrapped.installation, installation);
   t.deepEqual(unwrapped.bundle, fakeBundle);
 });
@@ -20,38 +20,43 @@ test('install, unwrap installation of bundlecap', async t => {
   const bundleCaps = { id: makeHandle('BundleCap') };
   const getBundleCapFromID = id => bundleCaps[id];
 
-  const { installBundleID, unwrapInstallation } =
-    makeInstallationStorage(getBundleCapFromID);
+  const installationStorage = makeInstallationStorage(getBundleCapFromID);
 
-  const installation = await installBundleID('id');
-  const unwrapped = await unwrapInstallation(installation);
+  const installation = await installationStorage.installBundleID('id');
+  const unwrapped = await installationStorage.unwrapInstallation(installation);
   t.is(unwrapped.installation, installation);
   t.is(unwrapped.bundleID, 'id');
   t.is(unwrapped.bundleCap, bundleCaps.id);
 });
 
 test('unwrap promise for installation', async t => {
-  const { installBundle, unwrapInstallation } = makeInstallationStorage();
+  const installationStorage = makeInstallationStorage();
   const fakeBundle = {};
 
-  const installation = await installBundle(fakeBundle);
-  const unwrapped = await unwrapInstallation(Promise.resolve(installation));
+  const installation = await installationStorage.installBundle(fakeBundle);
+  const unwrapped = await installationStorage.unwrapInstallation(
+    harden(Promise.resolve(installation)),
+  );
   t.is(unwrapped.installation, installation);
   t.deepEqual(unwrapped.bundle, fakeBundle);
 });
 
 test('install several', async t => {
-  const { installBundle, unwrapInstallation } = makeInstallationStorage();
+  const installationStorage = makeInstallationStorage();
   const fakeBundle1 = {};
   const fakeBundle2 = {};
 
-  const installation1 = await installBundle(fakeBundle1);
-  const unwrapped1 = await unwrapInstallation(installation1);
+  const installation1 = await installationStorage.installBundle(fakeBundle1);
+  const unwrapped1 = await installationStorage.unwrapInstallation(
+    installation1,
+  );
   t.is(unwrapped1.installation, installation1);
   t.deepEqual(unwrapped1.bundle, fakeBundle1);
 
-  const installation2 = await installBundle(fakeBundle2);
-  const unwrapped2 = await unwrapInstallation(installation2);
+  const installation2 = await installationStorage.installBundle(fakeBundle2);
+  const unwrapped2 = await installationStorage.unwrapInstallation(
+    installation2,
+  );
   t.is(unwrapped2.installation, installation2);
   t.deepEqual(unwrapped2.bundle, fakeBundle2);
 });
@@ -59,33 +64,40 @@ test('install several', async t => {
 test('install same twice', async t => {
   const bundleCaps = { id: makeHandle('BundleCap') };
   const getBundleCapFromID = id => bundleCaps[id];
-  const { installBundle, installBundleID, unwrapInstallation } =
-    makeInstallationStorage(getBundleCapFromID);
+  const installationStorage = makeInstallationStorage(getBundleCapFromID);
   const fakeBundle1 = {};
 
-  const installation1 = await installBundle(fakeBundle1);
-  const unwrapped1 = await unwrapInstallation(installation1);
+  const installation1 = await installationStorage.installBundle(fakeBundle1);
+  const unwrapped1 = await installationStorage.unwrapInstallation(
+    installation1,
+  );
   t.is(unwrapped1.installation, installation1);
   t.deepEqual(unwrapped1.bundle, fakeBundle1);
 
   // If the same bundle is installed twice, the bundle is the same,
   // but the installation is different. Zoe does not currently care about
   // duplicate bundles.
-  const installation2 = await installBundle(fakeBundle1);
-  const unwrapped2 = await unwrapInstallation(installation2);
+  const installation2 = await installationStorage.installBundle(fakeBundle1);
+  const unwrapped2 = await installationStorage.unwrapInstallation(
+    installation2,
+  );
   t.is(unwrapped2.installation, installation2);
   t.not(installation2, installation1);
   t.deepEqual(unwrapped2.bundle, fakeBundle1);
 
   // same for bundleIDs
-  const installation3 = await installBundleID('id');
-  const installation4 = await installBundleID('id');
+  const installation3 = await installationStorage.installBundleID('id');
+  const installation4 = await installationStorage.installBundleID('id');
   t.not(installation3, installation4);
-  const unwrapped3 = await unwrapInstallation(installation3);
+  const unwrapped3 = await installationStorage.unwrapInstallation(
+    installation3,
+  );
   t.is(unwrapped3.installation, installation3);
   t.is(unwrapped3.bundleID, 'id');
   t.is(unwrapped3.bundleCap, bundleCaps.id);
-  const unwrapped4 = await unwrapInstallation(installation4);
+  const unwrapped4 = await installationStorage.unwrapInstallation(
+    installation4,
+  );
   t.is(unwrapped4.installation, installation4);
   t.is(unwrapped4.bundleID, 'id');
   t.is(unwrapped4.bundleCap, bundleCaps.id);

--- a/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
@@ -4,88 +4,62 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { Far } from '@endo/marshal';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 import { makeInstanceAdminStorage } from '../../../src/zoeService/instanceAdminStorage.js';
 
 test('makeInstanceAdminStorage', async t => {
-  const {
-    getPublicFacet,
-    getBrands,
-    getIssuers,
-    getTerms,
-    getInstallationForInstance,
-    getInstanceAdmin,
-    initInstanceAdmin,
-    deleteInstanceAdmin,
-  } = makeInstanceAdminStorage();
+  const ias = makeInstanceAdminStorage(
+    makeScalarBigMapStore('zoe baggage', { durable: true }),
+  );
 
-  const mockInstance1 = Far('mockInstance1', {});
-  const mockInstance2 = Far('mockInstance2', {});
-  const mockInstanceAdmin1 = Far('mockInstanceAdmin1', {
-    getPublicFacet: () => 'publicFacet1',
-    getBrands: () => 'brands1',
-    getIssuers: () => 'issuers1',
-    getTerms: () => 'terms1',
-    getInstallationForInstance: () => 'installation1',
-  });
-  const mockInstanceAdmin2 = Far('mockInstanceAdmin2', {
-    getPublicFacet: () => 'publicFacet2',
-    getBrands: () => 'brands2',
-    getIssuers: () => 'issuers2',
-    getTerms: () => 'terms2',
-    getInstallationForInstance: () => 'installation2',
+  const mockInstallation1 = Far('mockInstallation', {});
+  const mockInstance1 = Far('mockInstance', {});
+  const mockInstanceAdmin = Far('mockInstanceAdmin', {
+    getInstallationForInstance: () => mockInstallation1,
+    getBrands: () => 'brands',
+    getPublicFacet: () => 'publicFacet',
+    getIssuers: () => 'issuers',
+    getTerms: () => 'terms',
+    getOfferFilter: () => 'filter',
   });
 
-  // @ts-expect-error instance is mocked
-  initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
-
-  // @ts-expect-error instance is mocked
-  initInstanceAdmin(mockInstance2, mockInstanceAdmin2);
-
-  // @ts-expect-error instance is mocked
-  t.is(getInstanceAdmin(mockInstance1), mockInstanceAdmin1);
-
-  // @ts-expect-error instance is mocked
-  t.is(await getPublicFacet(mockInstance1), 'publicFacet1');
-
-  // @ts-expect-error instance is mocked
-  t.is(await getBrands(mockInstance2), 'brands2');
-
-  // @ts-expect-error instance is mocked
-  t.is(await getIssuers(mockInstance1), 'issuers1');
-
-  // @ts-expect-error instance is mocked
-  t.is(await getTerms(mockInstance1), 'terms1');
-
-  // @ts-expect-error instance is mocked
-  t.is(await getInstallationForInstance(mockInstance1), 'installation1');
-
-  // @ts-expect-error instance is mocked
-  deleteInstanceAdmin(mockInstance2);
-
-  // @ts-expect-error instance is mocked
-  t.throws(() => getInstanceAdmin(mockInstance2), {
-    message: '"instance" not found: "[Alleged: mockInstance2]"',
-  });
-
-  // @ts-expect-error instance is mocked
-  await t.throwsAsync(() => getPublicFacet(mockInstance2), {
-    message: '"instance" not found: "[Alleged: mockInstance2]"',
-  });
+  ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin);
+  t.is(
+    await ias.accessor.getInstallationForInstance(mockInstance1),
+    mockInstallation1,
+  );
+  t.is(await ias.accessor.getBrands(mockInstance1), 'brands');
+  t.is(await ias.accessor.getPublicFacet(mockInstance1), 'publicFacet');
+  t.is(await ias.accessor.getIssuers(mockInstance1), 'issuers');
+  t.is(await ias.accessor.getTerms(mockInstance1), 'terms');
 });
 
 test('add another instance admin for same instance', async t => {
-  const { initInstanceAdmin } = makeInstanceAdminStorage();
+  const ias = makeInstanceAdminStorage(
+    makeScalarBigMapStore('zoe baggage', { durable: true }),
+  );
 
-  const mockInstance1 = Far('mockInstance1', {});
-  const mockInstanceAdmin1 = Far('mockInstanceAdmin1', {});
-  const mockInstanceAdmin2 = Far('mockInstanceAdmin2', {});
-
-  // @ts-expect-error instance is mocked
-  initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
-
-  // @ts-expect-error instance is mocked
-  t.throws(() => initInstanceAdmin(mockInstance1, mockInstanceAdmin2), {
-    message: '"instance" already registered: "[Alleged: mockInstance1]"',
+  const mockInstallation1 = Far('mockInstallation', {});
+  const mockInstance1 = Far('mockInstance', {});
+  const mockInstanceAdmin1 = Far('mockInstanceAdmin', {
+    getInstallationForInstance: () => mockInstallation1,
+    getBrands: () => 'brands',
+    getPublicFacet: () => 'publicFacet',
+    getIssuers: () => 'issuers',
+    getTerms: () => 'terms',
+    getOfferFilter: () => 'filter',
   });
+
+  ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
+  t.is(
+    await ias.accessor.getInstallationForInstance(mockInstance1),
+    mockInstallation1,
+  );
+
+  const mockInstanceAdmin2 = Far('mockInstanceAdmin', {});
+  await t.throwsAsync(
+    () => ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin2),
+    { message: /"\[Alleged: mockInstance\]" already registered/ },
+  );
 });

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -36,15 +36,26 @@ export const assertAmountsEqual = (t, amount, expected, label = '') => {
   }
 };
 
-export const assertPayoutAmount = async (
+export const assertPayoutAmount = (t, issuer, payout, expectedAmount, label) =>
+  E.when(E(issuer).getAmountOf(payout), amount =>
+    assertAmountsEqual(t, amount, expectedAmount, label),
+  );
+
+export const assertGetPayoutAmount = async (
   t,
   issuer,
-  payout,
+  seat,
+  keyword,
   expectedAmount,
   label = '',
 ) => {
-  const amount = await E(issuer).getAmountOf(payout);
-  assertAmountsEqual(t, amount, expectedAmount, label);
+  assertPayoutAmount(
+    t,
+    issuer,
+    E(seat).getPayout(keyword),
+    expectedAmount,
+    label,
+  );
 };
 
 // Returns a promise that can be awaited in tests to ensure the check completes.
@@ -61,6 +72,29 @@ export const assertPayoutDeposit = (t, payout, purse, amount) => {
         ),
       );
   });
+};
+
+// Returns a promise that can be awaited in tests to ensure the check completes.
+export const assertGetPayoutAndDeposit = (
+  t,
+  seat,
+  keyword,
+  purse,
+  amount,
+  msg,
+) => {
+  const assertDeposit = payment => {
+    return E.when(E(purse).deposit(payment), payoutAmount =>
+      assertAmountsEqual(
+        t,
+        payoutAmount,
+        amount,
+        msg || `payout was ${payoutAmount.value}, expected ${amount}.value`,
+      ),
+    );
+  };
+
+  return E.when(E(seat).getPayout(keyword), payout => assertDeposit(payout));
 };
 
 export const assertOfferResult = (t, seat, expected, msg = expected) => {


### PR DESCRIPTION
An INTERMEDIATE state for debugging

Most tests pass. Much is working about Zoe durability.

One major sticking point is that the feeMintAccess token isn't being
robustly delivered to contracts that need it.  It appears that the
loopback mechanism from endo may be at fault.

I've turned on tracing for object IDs as built in
https://github.com/Agoric/agoric-sdk/pull/6218
This makes it possible to identify individual objects as they are
passed around.

For example, when the  'Lower Collateral' test in test-stakeFactory is
run, we get

    The object representing access to the fee brand mint was not provided

And a detailed trace using #6218 shows that the correct object was
held in econ-behavior, but when the contractGovernor is called, it
appears to have a different object.

```
EB  p.all Object [Alleged: FeeMint feeMintAccess] {
  'o+15/1|feeMintAccess': [Function: o+15/1|feeMintAccess]
}
CG  START  Object [Alleged: FeeMint feeMintAccess] {}
FeeMint Object [Alleged: FeeMint feeMintAccess] {
  'o+15/1|feeMintAccess': [Function: o+15/1|feeMintAccess]
} Object [Alleged: FeeMint feeMintAccess] {}
Temporary logging of sent error (Error#1)
Error#1: The object representing access to the fee brand mint was not provided
```

replacing `const zoe = makeFar(zoeService);` with `const zoe =
zoeService;` allows the test to pass, so removing the loopback
circumvents the problem.
### Security Considerations

None

### Documentation Considerations

None

### Testing Considerations

this is about testing