### PR TITLE
feat(assert): export assert.Fail from endo

### DIFF
--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -40,6 +40,7 @@ const missing = [
   'string',
   'note',
   'details',
+  'Fail',
   'quote',
   'makeAssert',
 ].filter(name => globalAssert[name] === undefined);
@@ -51,13 +52,9 @@ if (missing.length > 0) {
   );
 }
 
-const { details, quote, makeAssert } = globalAssert;
+const { details, Fail, quote, makeAssert } = globalAssert;
 
-export { globalAssert as assert, details, quote };
-
-export { quote as q };
-
-export { makeAssert };
+export { globalAssert as assert, details, Fail, quote, quote as q, makeAssert };
 
 /**
  * @template T

--- a/packages/assert/test/test-assert.js
+++ b/packages/assert/test/test-assert.js
@@ -2,7 +2,7 @@ import '@endo/init';
 // eslint-disable-next-line import/no-unresolved -- lint error not worth solving; test passes
 import test from 'ava';
 
-import { NonNullish } from '../src/assert.js';
+import { NonNullish, Fail } from '../src/assert.js';
 
 test('NonNullish', t => {
   assert.equal(NonNullish('defined'), 'defined');
@@ -11,5 +11,12 @@ test('NonNullish', t => {
   });
   t.throws(() => NonNullish(undefined), {
     message: 'unexpected "[undefined]"',
+  });
+});
+
+test('Fail', t => {
+  t.notThrows(() => true || Fail`Should not be thrown`);
+  t.throws(() => false || Fail`Should be thrown`, {
+    message: 'Should be thrown',
   });
 });


### PR DESCRIPTION
Now that agoric-sdk has been upgraded to depend on https://github.com/endojs/endo/pull/1334 , the `@agoric/assert` module should export `Fail` directly. Also, types.js needs to track the addition of `Fail`. See https://github.com/endojs/endo/pull/1384