### PR TITLE
refactor(types): EconCharterStartResult without runtime

### DIFF
--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -28,9 +28,9 @@ const validateQuestionDetails = async (zoe, electorate, details) => {
   } = details;
   fit(details, ParamChangesQuestionDetailsShape);
 
+  /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<typeof start>} */
   const governorInstance = await E.get(E(zoe).getTerms(governedInstance))
     .electionManager;
-  /** @type {Promise<GovernorPublic>} */
   const governorPublic = E(zoe).getPublicFacet(governorInstance);
 
   return Promise.all([

--- a/packages/governance/src/types-ambient.js
+++ b/packages/governance/src/types-ambient.js
@@ -337,7 +337,7 @@
  * @typedef {object} AddQuestionReturn
  * @property {VoteCounterPublicFacet} publicFacet
  * @property {VoteCounterCreatorFacet} creatorFacet
- * @property {Instance} instance
+ * @property {import('@agoric/zoe/src/zoeService/utils.js').Instance<typeof import('./binaryVoteCounter.js').start>} instance
  * @property {Timestamp} deadline
  * @property {Handle<'Question'>} questionHandle
  */

--- a/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
@@ -19,6 +19,13 @@ const makeVoterVat = async (log, vats, zoe) => {
   return voterCreator;
 };
 
+/**
+ *
+ * @param {Pick<QuestionDetails, 'issue' | 'positions' | 'electionType'>} qDetails
+ * @param {TimestampValue} closingTime
+ * @param {{ electorateFacet: import('../../../src/committee.js').CommitteeElectorateCreatorFacet, installations: Record<string, Installation>, timer: TimerService }} tools
+ * @param {*} quorumRule
+ */
 const createQuestion = async (qDetails, closingTime, tools, quorumRule) => {
   const { electorateFacet, installations } = tools;
   const { issue, positions, electionType } = qDetails;

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
@@ -40,8 +40,8 @@ const verify = async (log, issue, electoratePublicFacet, instances) => {
 const build = async (log, zoe) => {
   return Far('voter', {
     createVoter: async (name, invitation, choice) => {
+      /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<typeof import('@agoric/governance/src/committee').start>} */
       const electorateInstance = await E(zoe).getInstance(invitation);
-      /** @type {Promise<CommitteeElectoratePublic>} electoratePublicFacet */
       const electoratePublicFacet = E(zoe).getPublicFacet(electorateInstance);
       const seat = E(zoe).offer(invitation);
       const { voter } = E.get(E(seat).getOfferResult());

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -68,13 +68,7 @@ const MILLI = 1_000_000n;
  * }>} EconomyBootstrapSpace
  */
 
-/**
- * @param {ERef<ZoeService>} zoe
- * @param {Installation<import('../econCommitteeCharter').start>} inst
- * @typedef {Awaited<ReturnType<typeof startCharterInstance>>} EconCharterStartResult
- */
-// eslint-disable-next-line no-unused-vars
-const startCharterInstance = (zoe, inst) => E(zoe).startInstance(inst);
+/** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('../econCommitteeCharter').start>} EconCharterStartResult */
 
 /**
  * @file A collection of productions, each of which declares inputs and outputs.

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -13,7 +13,7 @@ import { HandleI } from './typeGuards.js';
  * @template {string} H
  * @param {Baggage} baggage
  * @param {H} handleType
- * @returns {() => Handle<H>}
+ * @returns {H extends 'Instance' ? () => Instance : () => Handle<H>}
  */
 export const defineDurableHandle = (baggage, handleType) => {
   assert.typeof(handleType, 'string', 'handleType must be a string');
@@ -38,7 +38,7 @@ harden(defineDurableHandle);
  *
  * @template {string} H
  * @param {H} handleType the string literal type of the handle
- * @returns {Handle<H>}
+ * @returns {H extends 'Instance' ? Instance : Handle<H>}
  */
 export const makeHandle = handleType => {
   assert.typeof(handleType, 'string', 'handleType must be a string');

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -27,7 +27,7 @@
  *
  * @typedef {object} InstanceRecord
  * @property {Installation} installation
- * @property {Instance} instance
+ * @property {import("./zoeService/utils.js").Instance<any>} instance
  * @property {AnyTerms} terms - contract parameters
  */
 

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -8,7 +8,7 @@ export const makeInstanceAdminStorage = () => {
   /** @type {WeakStore<Instance,InstanceAdmin>} */
   const instanceToInstanceAdmin = makeWeakStore('instance');
 
-  /** @type {GetPublicFacet} */
+  /** @type {import('./utils.js').GetPublicFacet} */
   const getPublicFacet = async instanceP =>
     E.when(instanceP, instance =>
       instanceToInstanceAdmin.get(instance).getPublicFacet(),

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -128,7 +128,7 @@
  * @property {InstallBundle} installBundle
  * @property {InstallBundleID} installBundleID
  * @property {GetBundleIDFromInstallation} getBundleIDFromInstallation
- * @property {GetPublicFacet} getPublicFacet
+ * @property {import('./utils.js').GetPublicFacet} getPublicFacet
  * @property {GetBrands} getBrands
  * @property {GetIssuers} getIssuers
  * @property {GetTerms} getTerms

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -28,7 +28,7 @@
  * @property {InstallBundleID} installBundleID
  * @property {import('./utils').StartInstance} startInstance
  * @property {Offer} offer
- * @property {GetPublicFacet} getPublicFacet
+ * @property {import('./utils').GetPublicFacet} getPublicFacet
  * @property {GetIssuers} getIssuers
  * @property {GetBrands} getBrands
  * @property {GetTerms} getTerms
@@ -69,45 +69,39 @@
  */
 
 /**
- * @callback GetPublicFacet
- * @param {ERef<Instance>} instanceP
- * @returns {Promise<any>}
- */
-
-/**
  * @callback GetIssuers
- * @param {Instance} instance
+ * @param {import('./utils').Instance<any>} instance
  * @returns {Promise<IssuerKeywordRecord>}
  */
 
 /**
  * @callback GetBrands
- * @param {Instance} instance
+ * @param {import('./utils').Instance<any>} instance
  * @returns {Promise<BrandKeywordRecord>}
  */
 
 /**
  * @callback GetTerms
- * @param {Instance} instance
+ * @param {import('./utils').Instance<any>} instance
  * @returns {Promise<AnyTerms>}
  */
 
 /**
  * @callback GetOfferFilter
- * @param {Instance} instance
+ * @param {import('./utils').Instance<any>} instance
  * @returns {string[]}
  */
 
 /**
  * @callback GetInstallationForInstance
- * @param {Instance} instance
+ * @param {import('./utils').Instance<any>} instance
  * @returns {Promise<Installation>}
  */
 
 /**
  * @callback GetInstance
  * @param {ERef<Invitation>} invitation
- * @returns {Promise<Instance>}
+ * @returns {Promise<import('./utils').Instance<any>>}
  */
 
 /**
@@ -286,7 +280,7 @@
  */
 
 /**
- * @typedef {Handle<'Instance'>} Instance
+ * @typedef {import('./utils').Instance<any>} Instance
  */
 
 /**
@@ -314,7 +308,7 @@
 /**
  * @typedef {object} StandardInvitationDetails
  * @property {Installation} installation
- * @property {Instance} instance
+ * @property {import('./utils').Instance<any>} instance
  * @property {InvitationHandle} handle
  * @property {string} description
  */

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -1,6 +1,6 @@
 import { Callable } from '@agoric/eventual-send';
 
-import type { Instance, IssuerKeywordRecord, Payment } from './types.js';
+import type { IssuerKeywordRecord, Payment } from './types.js';
 
 // XXX https://github.com/Agoric/agoric-sdk/issues/4565
 type SourceBundle = Record<string, any>;
@@ -22,6 +22,10 @@ export type AdminFacet = {
 declare const StartFunction: unique symbol;
 export type Installation<SF> = {
   getBundle: () => SourceBundle;
+  // because TS is structural, without this the generic is ignored
+  [StartFunction]: SF;
+};
+export type Instance<SF> = Handle<'Instance'> & {
   // because TS is structural, without this the generic is ignored
   [StartFunction]: SF;
 };
@@ -94,3 +98,7 @@ export type StartInstance = <SF>(
   terms?: Omit<StartParams<SF>['terms'], 'brands' | 'issuers'>,
   privateArgs?: StartParams<SF>['privateArgs'],
 ) => Promise<StartedInstanceKit<SF>>;
+
+export type GetPublicFacet = <SF>(
+  instance: Instance<SF> | PromiseLike<Instance<SF>>,
+) => Promise<StartResult<SF>['publicFacet']>;

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -65,6 +65,12 @@ type StartContractInstance<C> = (
   adminFacet: AdminFacet;
 }>;
 
+/** The result of `startInstance` */
+export type StartedInstanceKit<SF> = {
+  instance: Instance;
+  adminFacet: AdminFacet;
+} & Awaited<ReturnType<SF>>;
+
 /**
  * Zoe is long-lived. We can use Zoe to create smart contract
  * instances by specifying a particular contract installation to use,
@@ -87,9 +93,4 @@ export type StartInstance = <SF>(
   // 'brands' and 'issuers' need not be passed in; Zoe provides them as StandardTerms
   terms?: Omit<StartParams<SF>['terms'], 'brands' | 'issuers'>,
   privateArgs?: StartParams<SF>['privateArgs'],
-) => Promise<
-  {
-    instance: Instance;
-    adminFacet: AdminFacet;
-  } & Awaited<ReturnType<SF>>
->;
+) => Promise<StartedInstanceKit<SF>>;


### PR DESCRIPTION
## Description

This defines the `EconCharterStartResult` without executing code and requiring lint suppressions.

### Security Considerations

--

### Documentation Considerations

New type, has a doc string.

### Testing Considerations

CI