### PR TITLE
make Chainlink the canonical priceAggregator

### DIFF
--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -96,7 +96,7 @@ export const makeOracleCommand = async logger => {
 
   oracle
     .command('pushPrice')
-    .description('add a current price sample')
+    .description('add a current price sample to a priceAggregator')
     .option('--offerId [number]', 'Offer id', Number, Date.now())
     .requiredOption(
       '--oracleAdminAcceptOfferId [number]',
@@ -128,6 +128,40 @@ export const makeOracleCommand = async logger => {
       console.warn('Now execute the prepared offer');
     });
 
+  oracle
+    .command('pushPriceRound')
+    .description('add a price for a round to a priceAggregatorChainlink')
+    .option('--offerId [number]', 'Offer id', Number, Date.now())
+    .requiredOption(
+      '--oracleAdminAcceptOfferId [number]',
+      'offer that had continuing invitation result',
+      Number,
+    )
+    .requiredOption('--price [number]', 'price (format TODO)', String)
+    .requiredOption('--roundId [number]', 'round', Number)
+    .action(async function () {
+      // @ts-expect-error this implicit any
+      const opts = this.opts();
+
+      /** @type {import('../lib/psm.js').OfferSpec} */
+      const offer = {
+        id: Number(opts.offerId),
+        invitationSpec: {
+          source: 'continuing',
+          previousOffer: opts.oracleAdminAcceptOfferId,
+          invitationMakerName: 'makePushPriceInvitation',
+          invitationArgs: harden([{ data: opts.price, roundId: opts.roundId }]),
+        },
+        proposal: {},
+      };
+
+      outputAction({
+        method: 'executeOffer',
+        offer,
+      });
+
+      console.warn('Now execute the prepared offer');
+    });
   oracle
     .command('query')
     .description('return current aggregated (median) price')

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -137,7 +137,7 @@ export const makeOracleCommand = async logger => {
       'offer that had continuing invitation result',
       Number,
     )
-    .requiredOption('--price [number]', 'price (format TODO)', String)
+    .requiredOption('--price [number]', 'price (per unitAmount)', BigInt)
     .requiredOption('--roundId [number]', 'round', Number)
     .action(async function () {
       // @ts-expect-error this implicit any
@@ -150,7 +150,9 @@ export const makeOracleCommand = async logger => {
           source: 'continuing',
           previousOffer: opts.oracleAdminAcceptOfferId,
           invitationMakerName: 'makePushPriceInvitation',
-          invitationArgs: harden([{ data: opts.price, roundId: opts.roundId }]),
+          invitationArgs: harden([
+            { unitPrice: opts.price, roundId: opts.roundId },
+          ]),
         },
         proposal: {},
       };

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -114,7 +114,7 @@ export const makeOracleCommand = async logger => {
         invitationSpec: {
           source: 'continuing',
           previousOffer: opts.oracleAdminAcceptOfferId,
-          invitationMakerName: 'makePushPriceInvitation',
+          invitationMakerName: 'PushPrice',
           invitationArgs: harden([opts.price]),
         },
         proposal: {},
@@ -149,7 +149,7 @@ export const makeOracleCommand = async logger => {
         invitationSpec: {
           source: 'continuing',
           previousOffer: opts.oracleAdminAcceptOfferId,
-          invitationMakerName: 'makePushPriceInvitation',
+          invitationMakerName: 'PushPrice',
           invitationArgs: harden([
             { unitPrice: opts.price, roundId: opts.roundId },
           ]),

--- a/packages/agoric-cli/test/agops-oracle-smoketest.sh
+++ b/packages/agoric-cli/test/agops-oracle-smoketest.sh
@@ -45,5 +45,5 @@ agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
 echo "Offer $ORACLE_OFFER_ID should have numWantsSatisfied: 1"
 agoric wallet show --from "$WALLET"
 
-# see new price
-agoric follow :published.priceFeed.ATOM-USD_price_feed
+# verify that the round started
+agoric follow :published.priceFeed.ATOM-USD_price_feed.latestRound

--- a/packages/agoric-cli/test/agops-oracle-smoketest.sh
+++ b/packages/agoric-cli/test/agops-oracle-smoketest.sh
@@ -24,6 +24,11 @@ if [ -z "$WALLET" ]; then
 fi
 set -x
 
+# this is in economy-template.json in the oracleAddresses list (agoric1dy0yegdsev4xvce3dx7zrz2ad9pesf5svzud6y)
+# to use it run `agd keys oracle2 --interactive` and enter this mnenomic:
+# dizzy scale gentle good play scene certain acquire approve alarm retreat recycle inch journey fitness grass minimum learn funny way unlock what buzz upon
+WALLET2=oracle2
+
 # Accept invitation to admin an oracle
 ORACLE_OFFER=$(mktemp -t agops.XXX)
 bin/agops oracle accept >|"$ORACLE_OFFER"
@@ -33,7 +38,14 @@ agoric wallet send --from "$WALLET" --offer "$ORACLE_OFFER"
 agoric wallet show --from "$WALLET"
 ORACLE_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
 
-### Now we have the continuing invitationMakers saved in the wallet
+# repeat for oracle2
+ORACLE_OFFER=$(mktemp -t agops.XXX)
+bin/agops oracle accept >|"$ORACLE_OFFER"
+jq ".body | fromjson" <"$ORACLE_OFFER"
+agoric wallet send --from "$WALLET2" --offer "$ORACLE_OFFER"
+ORACLE2_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
+
+### Now we have the continuing invitationMakers saved in the wallets
 
 # Use invitation result, with continuing invitationMakers to propose a vote
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
@@ -47,3 +59,18 @@ agoric wallet show --from "$WALLET"
 
 # verify that the round started
 agoric follow :published.priceFeed.ATOM-USD_price_feed.latestRound
+
+# submit another price in the round from the second oracle
+PROPOSAL_OFFER=$(mktemp -t agops.XXX)
+bin/agops oracle pushPriceRound --price 2.01 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
+jq ".body | fromjson" <"$PROPOSAL_OFFER"
+agoric wallet send --from "$WALLET2" --offer "$PROPOSAL_OFFER"
+
+# second round, first oracle
+PROPOSAL_OFFER=$(mktemp -t agops.XXX)
+bin/agops oracle pushPriceRound --price 1.02 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
+agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
+# second round, second oracle
+PROPOSAL_OFFER=$(mktemp -t agops.XXX)
+bin/agops oracle pushPriceRound --price 2.01 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
+agoric wallet send --from "$WALLET2" --offer "$PROPOSAL_OFFER"

--- a/packages/agoric-cli/test/agops-oracle-smoketest.sh
+++ b/packages/agoric-cli/test/agops-oracle-smoketest.sh
@@ -49,7 +49,7 @@ ORACLE2_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
 
 # Use invitation result, with continuing invitationMakers to propose a vote
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPriceRound --price 1.01 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
+bin/agops oracle pushPriceRound --price 101 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
 jq ".body | fromjson" <"$PROPOSAL_OFFER"
 agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
 
@@ -65,17 +65,17 @@ agoric follow :published.priceFeed.ATOM-USD_price_feed.latestRound
 
 # submit another price in the round from the second oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPriceRound --price 2.01 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
+bin/agops oracle pushPriceRound --price 201 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
 jq ".body | fromjson" <"$PROPOSAL_OFFER"
 agoric wallet send --from "$WALLET2" --offer "$PROPOSAL_OFFER"
 
 # second round, first oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPriceRound --price 11.02 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
+bin/agops oracle pushPriceRound --price 1102 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
 agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
 # second round, second oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPriceRound --price 12.02 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
+bin/agops oracle pushPriceRound --price 1202 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
 agoric wallet send --from "$WALLET2" --offer "$PROPOSAL_OFFER"
 
 # see new price

--- a/packages/agoric-cli/test/agops-oracle-smoketest.sh
+++ b/packages/agoric-cli/test/agops-oracle-smoketest.sh
@@ -57,6 +57,9 @@ agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
 echo "Offer $ORACLE_OFFER_ID should have numWantsSatisfied: 1"
 agoric wallet show --from "$WALLET"
 
+# verify feed publishing
+agd query vstorage keys published.priceFeed
+
 # verify that the round started
 agoric follow :published.priceFeed.ATOM-USD_price_feed.latestRound
 
@@ -68,9 +71,12 @@ agoric wallet send --from "$WALLET2" --offer "$PROPOSAL_OFFER"
 
 # second round, first oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPriceRound --price 1.02 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
+bin/agops oracle pushPriceRound --price 11.02 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
 agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
 # second round, second oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPriceRound --price 2.01 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
+bin/agops oracle pushPriceRound --price 12.02 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
 agoric wallet send --from "$WALLET2" --offer "$PROPOSAL_OFFER"
+
+# see new price
+agoric follow :published.priceFeed.ATOM-USD_price_feed

--- a/packages/agoric-cli/test/agops-oracle-smoketest.sh
+++ b/packages/agoric-cli/test/agops-oracle-smoketest.sh
@@ -37,7 +37,7 @@ ORACLE_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
 
 # Use invitation result, with continuing invitationMakers to propose a vote
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPrice --price 1.01 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
+bin/agops oracle pushPriceRound --price 1.01 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
 jq ".body | fromjson" <"$PROPOSAL_OFFER"
 agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
 

--- a/packages/cosmic-swingset/economy-template.json
+++ b/packages/cosmic-swingset/economy-template.json
@@ -110,7 +110,8 @@
       {
         "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
         "oracleAddresses": [
-          "@PRIMARY_ADDRESS@"
+          "@PRIMARY_ADDRESS@",
+          "agoric1dy0yegdsev4xvce3dx7zrz2ad9pesf5svzud6y"
         ],
         "IN_BRAND_LOOKUP": [
           "agoricNames",

--- a/packages/inter-protocol/scripts/price-feed-core.js
+++ b/packages/inter-protocol/scripts/price-feed-core.js
@@ -57,8 +57,8 @@ export const defaultProposalBuilder = async (
         brandOutRef: brandOut && publishRef(brandOut),
         priceAggregatorRef: publishRef(
           install(
-            '@agoric/zoe/src/contracts/priceAggregator.js',
-            '../bundles/bundle-priceAggregator.js',
+            '@agoric/zoe/src/contracts/priceAggregatorChainlink.js',
+            '../bundles/bundle-priceAggregatorChainlink.js',
           ),
         ),
       },

--- a/packages/inter-protocol/scripts/start-local-chain.sh
+++ b/packages/inter-protocol/scripts/start-local-chain.sh
@@ -65,3 +65,12 @@ sleep 15
 # verify
 agoric wallet list
 agoric wallet show --from "$WALLET"
+
+echo "Repeating for oracle2 account..."
+# this is in economy-template.json in the oracleAddresses list (agoric1dy0yegdsev4xvce3dx7zrz2ad9pesf5svzud6y)
+# to use it run `agd keys oracle2 --interactive` and enter this mnenomic:
+# dizzy scale gentle good play scene certain acquire approve alarm retreat recycle inch journey fitness grass minimum learn funny way unlock what buzz upon
+WALLET2=oracle2
+WALLET2_BECH32=$(agd keys show "$WALLET2" --output json | jq -r .address)
+make ACCT_ADDR="$WALLET2_BECH32" FUNDS=20000000ubld,20000000ibc/usdc1234 fund-acct
+agoric wallet provision --spend --account "$WALLET2"

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -187,11 +187,11 @@ export const createPriceFeed = async (
     .then(deleter => E(aggregators).set(terms, { aggregator, deleter }));
 
   /**
-   * Send an invitation to one of the oracles.
+   * Initialize a new oracle and send an invitation to administer it.
    *
    * @param {string} addr
    */
-  const distributeInvitation = async addr => {
+  const addOracle = async addr => {
     const invitation = await E(aggregator.creatorFacet).makeOracleInvitation(
       addr,
     );
@@ -204,7 +204,7 @@ export const createPriceFeed = async (
   };
 
   trace('distributing invitations', oracleAddresses);
-  await Promise.all(oracleAddresses.map(distributeInvitation));
+  await Promise.all(oracleAddresses.map(addOracle));
   trace('createPriceFeed complete');
 };
 

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -87,7 +87,7 @@ export const ensureOracleBrands = async (
 
 /**
  * @param {ChainBootstrapSpace} powers
- * @param {{options: {priceFeedOptions: {AGORIC_INSTANCE_NAME: string, oracleAddresses: string[], contractTerms: unknown, IN_BRAND_NAME: string, OUT_BRAND_NAME: string}}}} config
+ * @param {{options: {priceFeedOptions: {AGORIC_INSTANCE_NAME: string, oracleAddresses: string[], contractTerms: import('@agoric/zoe/src/contracts/priceAggregatorChainlink.js').ChainlinkConfig, IN_BRAND_NAME: string, OUT_BRAND_NAME: string}}}} config
  */
 export const createPriceFeed = async (
   {
@@ -129,7 +129,7 @@ export const createPriceFeed = async (
   /**
    * Values come from economy-template.json, which at this writing had IN:ATOM, OUT:USD
    *
-   * @type {[[Brand<'nat'>, Brand<'nat'>], [Installation<import('@agoric/zoe/src/contracts/priceAggregator.js').start>]]}
+   * @type {[[Brand<'nat'>, Brand<'nat'>], [Installation<import('@agoric/zoe/src/contracts/priceAggregatorChainlink.js').start>]]}
    */
   const [[brandIn, brandOut], [priceAggregator]] = await Promise.all([
     reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('oracleBrand'), [
@@ -142,7 +142,6 @@ export const createPriceFeed = async (
   ]);
 
   const unitAmountIn = await unitAmount(brandIn);
-  /** @type {import('@agoric/zoe/src/contracts/priceAggregator.js').PriceAggregatorContract['terms']} */
   const terms = await deeplyFulfilledObject(
     harden({
       ...contractTerms,
@@ -306,7 +305,12 @@ export const startPriceFeeds = async (
         priceFeedOptions: {
           AGORIC_INSTANCE_NAME: `${inBrandName}-${outBrandName} price feed`,
           contractTerms: {
-            POLL_INTERVAL: 1n,
+            minSubmissionCount: 2,
+            minSubmissionValue: 1,
+            maxSubmissionCount: 5,
+            maxSubmissionValue: 99999,
+            restartDelay: 1n,
+            timeout: 10,
           },
           oracleAddresses: demoOracleAddresses,
           IN_BRAND_NAME: inBrandName,

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -73,10 +73,10 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
       'installation',
     );
     const paBundle = await bundleCache.load(
-      '../zoe/src/contracts/priceAggregator.js',
+      '../zoe/src/contracts/priceAggregatorChainlink.js',
       'priceAggregator',
     );
-    /** @type {Promise<Installation<import('@agoric/zoe/src/contracts/priceAggregator.js').start>>} */
+    /** @type {Promise<Installation<import('@agoric/zoe/src/contracts/priceAggregatorChainlink.js').start>>} */
     const paInstallation = E(zoe).install(paBundle);
     await E(installAdmin).update('priceAggregator', paInstallation);
 
@@ -87,7 +87,12 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
           priceFeedOptions: {
             AGORIC_INSTANCE_NAME: `${inBrandName}-${outBrandName} price feed`,
             contractTerms: {
-              POLL_INTERVAL: 1n,
+              minSubmissionCount: 2,
+              minSubmissionValue: 1,
+              maxSubmissionCount: 5,
+              maxSubmissionValue: 99999,
+              restartDelay: 1n,
+              timeout: 10,
             },
             oracleAddresses,
             IN_BRAND_NAME: inBrandName,

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -156,7 +156,7 @@ test('admin price', async t => {
   // Push a new price result /////////////////////////
 
   /** @type {import('@agoric/zoe/src/contracts/priceAggregatorChainlink.js').PriceRound} */
-  const result = { roundId: 1, data: '123' };
+  const result = { roundId: 1, unitPrice: 123n };
 
   /** @type {import('@agoric/smart-wallet/src/invitations.js').ContinuingInvitationSpec} */
   const proposeInvitationSpec = {

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -162,7 +162,7 @@ test('admin price', async t => {
   const proposeInvitationSpec = {
     source: 'continuing',
     previousOffer: 44,
-    invitationMakerName: 'makePushPriceInvitation',
+    invitationMakerName: 'PushPrice',
     invitationArgs: harden([result]),
   };
 

--- a/packages/zoe/scripts/build-bundles.js
+++ b/packages/zoe/scripts/build-bundles.js
@@ -11,6 +11,10 @@ const sourceToBundle = [
     '../src/contracts/priceAggregator.js',
     '../bundles/bundle-priceAggregator.js',
   ],
+  [
+    '../src/contracts/priceAggregatorChainlink.js',
+    '../bundles/bundle-priceAggregatorChainlink.js',
+  ],
 ];
 
 await createBundles(sourceToBundle, dirname);

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -256,7 +256,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
             amountIn,
             amountOut: calcAmountOut(amountIn),
           }));
-          assert(quote);
+          assert(quote, 'createQuote returned falsey');
 
           const value = await quote;
           return harden({

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -55,6 +55,9 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
  * }} privateArgs
  */
 const start = async (zcf, privateArgs) => {
+  // brands come from named terms instead of `brands` key because the latter is
+  // a StandardTerm that Zoe creates from the `issuerKeywordRecord` argument and
+  // Oracle brands are inert (without issuers or mints).
   const { timer, POLL_INTERVAL, brandIn, brandOut, unitAmountIn } =
     zcf.getTerms();
   assertAllDefined({ brandIn, brandOut, POLL_INTERVAL, timer, unitAmountIn });

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -35,6 +35,8 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
 /** @typedef {ParsableNumber | Ratio} Price */
 
 /**
+ * @deprecated use priceAggregatorChainlink
+ *
  * This contract aggregates price values from a set of oracles and provides a
  * PriceAuthority for their median. This naive method is game-able and so this module
  * is a stub until we complete what is now in `priceAggregatorChainlink.js`.

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -35,6 +35,9 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
 
 /** @typedef {ParsableNumber | Ratio} Price */
 
+/** @type {(quote: PriceQuote) => PriceDescription} */
+export const priceDescriptionFromQuote = quote => quote.quoteAmount.value[0];
+
 /**
  * @deprecated use priceAggregatorChainlink
  *
@@ -220,7 +223,7 @@ const start = async (zcf, privateArgs) => {
 
   // for each new quote from the priceAuthority, publish it to off-chain storage
   observeNotifier(priceAuthority.makeQuoteNotifier(unitAmountIn, brandOut), {
-    updateState: quote => publisher.publish(quote),
+    updateState: quote => publisher.publish(priceDescriptionFromQuote(quote)),
     fail: reason => {
       throw Error(`priceAuthority observer failed: ${reason}`);
     },

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -1,33 +1,34 @@
 /// <reference path="../../../SwingSet/src/vats/timer/types.d.ts" />
 
-import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
+import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { assertAllDefined } from '@agoric/internal';
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
 import {
   makeNotifierKit,
   makeStoredPublishKit,
   observeNotifier,
 } from '@agoric/notifier';
 import { makeLegacyMap } from '@agoric/store';
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+import '../../tools/types.js';
 import {
   calculateMedian,
   makeOnewayPriceAuthorityKit,
 } from '../contractSupport/index.js';
 import {
+  addRatios,
+  assertParsableNumber,
+  ceilDivideBy,
+  floorMultiplyBy,
   makeRatio,
   makeRatioFromAmounts,
-  parseRatio,
-  addRatios,
-  ratioGTE,
-  floorMultiplyBy,
-  ceilDivideBy,
   multiplyRatios,
+  parseRatio,
+  ratioGTE,
   ratiosSame,
-  assertParsableNumber,
 } from '../contractSupport/ratio.js';
 
-import '../../tools/types.js';
 import '@agoric/ertp/src/types-ambient.js';
 
 export const INVITATION_MAKERS_DESC = 'oracle invitation';

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -434,7 +434,7 @@ const start = async (zcf, privateArgs) => {
        * @param {object} param1
        * @param {Notifier<OraclePriceSubmission>} [param1.notifier] optional notifier that produces oracle price submissions
        * @param {number} [param1.scaleValueOut]
-       * @returns {Promise<{admin: OracleAdmin<Price>, invitationMakers: {makePushPriceInvitation: (price: ParsableNumber) => Promise<Invitation<void>>} }>}
+       * @returns {Promise<{admin: OracleAdmin<Price>, invitationMakers: {PushPrice: (price: ParsableNumber) => Promise<Invitation<void>>} }>}
        */
       const offerHandler = async (
         seat,
@@ -443,7 +443,7 @@ const start = async (zcf, privateArgs) => {
         const admin = await creatorFacet.initOracle(oracleKey);
         const invitationMakers = Far('invitation makers', {
           /** @param {ParsableNumber} price */
-          makePushPriceInvitation(price) {
+          PushPrice(price) {
             assertParsableNumber(price);
             return zcf.makeInvitation(cSeat => {
               cSeat.exit();

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -32,7 +32,7 @@ import '@agoric/ertp/src/types-ambient.js';
 
 export const INVITATION_MAKERS_DESC = 'oracle invitation';
 
-/** @typedef {ParsableNumber | Ratio} Result */
+/** @typedef {ParsableNumber | Ratio} Price */
 
 /**
  * This contract aggregates price values from a set of oracles and provides a
@@ -425,7 +425,7 @@ const start = async (zcf, privateArgs) => {
        * @param {object} param1
        * @param {Notifier<OraclePriceSubmission>} [param1.notifier] optional notifier that produces oracle price submissions
        * @param {number} [param1.scaleValueOut]
-       * @returns {Promise<{admin: OracleAdmin<Result>, invitationMakers: {makePushPriceInvitation: (price: ParsableNumber) => Promise<Invitation<void>>} }>}
+       * @returns {Promise<{admin: OracleAdmin<Price>, invitationMakers: {makePushPriceInvitation: (price: ParsableNumber) => Promise<Invitation<void>>} }>}
        */
       const offerHandler = async (
         seat,
@@ -483,7 +483,7 @@ const start = async (zcf, privateArgs) => {
     /**
      * @param {Instance | string} [oracleInstance]
      * @param {OracleQuery} [query]
-     * @returns {Promise<OracleAdmin<Result>>}
+     * @returns {Promise<OracleAdmin<Price>>}
      */
     initOracle: async (oracleInstance, query) => {
       /** @type {OracleKey} */
@@ -526,7 +526,7 @@ const start = async (zcf, privateArgs) => {
         record.lastSample = ratio;
       };
 
-      /** @type {OracleAdmin<Result>} */
+      /** @type {OracleAdmin<Price>} */
       const oracleAdmin = Far('OracleAdmin', {
         async delete() {
           assert(records.has(record), 'Oracle record is already deleted');

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -61,6 +61,9 @@ const start = async (
   zcf,
   { quoteMint = makeIssuerKit('quote', AssetKind.SET).mint } = {},
 ) => {
+  // brands come from named terms instead of `brands` key because the latter is
+  // a StandardTerm that Zoe creates from the `issuerKeywordRecord` argument and
+  // Oracle brands are inert (without issuers or mints).
   const {
     timer,
     brandIn,

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -849,17 +849,7 @@ const start = async (zcf, privateArgs) => {
             keyToRecords.delete(oracleAddr);
           }
         },
-        async pushResult({
-          roundId: roundIdRaw = undefined,
-          unitPrice: submissionRaw,
-        }) {
-          // Sample of NaN, 0, or negative numbers get culled in
-          // the median calculation.
-          pushResult({
-            roundId: roundIdRaw,
-            unitPrice: submissionRaw,
-          }).catch(console.error);
-        },
+        pushResult,
       });
 
       return harden(oracleAdmin);

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -559,7 +559,7 @@ const start = async (zcf, privateArgs) => {
    * @param {string} oracleAddr
    * @param {bigint} roundId
    * @param {Timestamp} blockTimestamp
-   * @returns {string} error message or '' if no error
+   * @returns {string?} error message, if there is one
    */
   const validateOracleRound = (oracleAddr, roundId, blockTimestamp) => {
     // cache storage reads
@@ -585,8 +585,7 @@ const start = async (zcf, privateArgs) => {
       return 'invalid round to report';
     if (roundId !== 1n && !canSupersede)
       return 'previous round not supersedable';
-    // XXX return a more obvious 'no errors' value, e.g. null
-    return '';
+    return null;
   };
 
   /**
@@ -639,7 +638,7 @@ const start = async (zcf, privateArgs) => {
     }
 
     const error = validateOracleRound(oracleAddr, roundId, blockTimestamp);
-    if (error.length !== 0) {
+    if (error !== null) {
       eligibleToSubmit = false;
     }
 
@@ -669,9 +668,9 @@ const start = async (zcf, privateArgs) => {
       blockTimestamp,
     );
     if (TimeMath.absValue(rounds.get(queriedRoundId).startedAt) > 0n) {
-      return acceptingSubmissions(queriedRoundId) && error.length === 0;
+      return acceptingSubmissions(queriedRoundId) && error === null;
     } else {
-      return delayed(oracleAddr, queriedRoundId) && error.length === 0;
+      return delayed(oracleAddr, queriedRoundId) && error === null;
     }
   };
 
@@ -811,7 +810,7 @@ const start = async (zcf, privateArgs) => {
           return;
         }
 
-        if (!(error.length === 0)) {
+        if (!(error === null)) {
           console.error(error);
           return;
         }

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -717,13 +717,13 @@ const start = async (zcf, privateArgs) => {
        * reported data.
        *
        * @param {ZCFSeat} seat
-       * @returns {Promise<{admin: OracleAdmin<PriceRound>, invitationMakers: {makePushPriceInvitation: (result: PriceRound) => Promise<Invitation<void>>} }>}
+       * @returns {Promise<{admin: OracleAdmin<PriceRound>, invitationMakers: {PushPrice: (result: PriceRound) => Promise<Invitation<void>>} }>}
        */
       const offerHandler = async seat => {
         const admin = await creatorFacet.initOracle(oracleAddr);
         const invitationMakers = Far('invitation makers', {
           /** @param {PriceRound} result */
-          makePushPriceInvitation(result) {
+          PushPrice(result) {
             assertParsableNumber(result.unitPrice);
             return zcf.makeInvitation(cSeat => {
               cSeat.exit();

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -1,3 +1,7 @@
+/** @file
+ * Adaptation of Chainlink algorithm to the Agoric platform.
+ * Modeled on https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/FluxAggregator.sol (version?)
+ */
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
@@ -26,6 +30,7 @@ import {
 
 export { INVITATION_MAKERS_DESC };
 
+// FIXME is MAX_SAFE_INTEGER sufficient? why encoded as string?
 /**
  * @typedef {{ roundId: number | undefined, data: string }} PriceRound
  * `data` is a string encoded integer (Number.MAX_SAFE_INTEGER)

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -38,7 +38,7 @@ const { add, subtract, multiply, floorDivide, ceilDivide, isGTE } = natSafeMath;
  * maxSubmissionValue: number,
  * brandIn: Brand<'nat'>,
  * brandOut: Brand<'nat'>,
- * unitAmountIn: Amount<'nat'>,
+ * unitAmountIn?: Amount<'nat'>,
  * }>} zcf
  * @param {object} root0
  * @param {ERef<Mint<'set'>>} [root0.quoteMint]

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -10,9 +10,9 @@ import {
   calculateMedian,
   natSafeMath,
   makeOnewayPriceAuthorityKit,
-} from '../contractSupport';
+} from '../contractSupport/index.js';
 
-import '../../tools/types';
+import '../../tools/types.js';
 
 /**
  * @typedef {{ roundId: number | undefined, data: string }} Result

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -691,13 +691,6 @@ const start = async (zcf, privateArgs) => {
     return add(currentRound, 1);
   };
 
-  /**
-   * @type {Omit<import('./priceAggregator').PriceAggregatorContract['creatorFacet'], 'initOracle'> & {
-   *   initOracle: (instance) => Promise<OracleAdmin<PriceRound>>,
-   *   getRoundData(roundId: bigint | number): Promise<RoundData>,
-   *   oracleRoundState(oracleAddr: string, queriedRoundId: BigInt): Promise<any>
-   * }}
-   */
   const creatorFacet = Far('PriceAggregatorChainlinkCreatorFacet', {
     /**
      * An "oracle invitation" is an invitation to be able to submit data to
@@ -707,7 +700,7 @@ const start = async (zcf, privateArgs) => {
      * directly to manage the price submissions as well as to terminate the
      * relationship.
      *
-     * @param {string} oracleAddr
+     * @param {string} oracleAddr Bech32 of oracle operator smart wallet
      */
     makeOracleInvitation: async oracleAddr => {
       /**
@@ -756,8 +749,12 @@ const start = async (zcf, privateArgs) => {
     },
 
     // unlike the median case, no query argument is passed, since polling behavior is undesired
-    /** @param {string} oracleAddr */
+    /**
+     * @param {string} oracleAddr Bech32 of oracle operator smart wallet
+     * @returns {Promise<OracleAdmin<PriceRound>>}
+     */
     async initOracle(oracleAddr) {
+      assert.typeof(oracleAddr, 'string');
       /** @type {OracleRecord} */
       const record = { querier: undefined, lastSample: 0 };
 
@@ -885,7 +882,7 @@ const start = async (zcf, privateArgs) => {
      * a method to provide all current info oracleStatuses need. Intended only
      * only to be callable by oracleStatuses. Not for use by contracts to read state.
      *
-     * @param {string} oracleAddr
+     * @param {string} oracleAddr Bech32 of oracle operator smart wallet
      * @param {bigint} queriedRoundId
      */
     async oracleRoundState(oracleAddr, queriedRoundId) {

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -24,6 +24,20 @@ import { INVITATION_MAKERS_DESC } from './priceAggregator';
 const { add, subtract, multiply, floorDivide, ceilDivide, isGTE } = natSafeMath;
 
 /**
+ * @typedef {object} RoundData
+ * @property {bigint} roundId  the round ID for which data was retrieved
+ * @property {number} answer the answer for the given round
+ * @property {Timestamp} startedAt the timestamp when the round was started. This is 0
+ * if the round hasn't been started yet.
+ * @property {Timestamp} updatedAt the timestamp when the round last was updated (i.e.
+ * answer was last computed)
+ * @property {bigint} answeredInRound the round ID of the round in which the answer
+ * was computed. answeredInRound may be smaller than roundId when the round
+ * timed out. answeredInRound is equal to roundId when the round didn't time out
+ * and was completed regularly.
+ */
+
+/**
  * PriceAuthority for their median. Unlike the simpler `priceAggregator.js`, this approximates
  * the *Node Operator Aggregation* logic of [Chainlink price
  * feeds](https://blog.chain.link/levels-of-data-aggregation-in-chainlink-price-feeds/).
@@ -604,7 +618,7 @@ const start = async (
   /**
    * @type {Omit<import('./priceAggregator').PriceAggregatorContract['creatorFacet'], 'initOracle'> & {
    *   initOracle: (instance) => Promise<OracleAdmin<PriceRound>>,
-   *   getRoundData(_roundId: bigint | number): Promise<any>,
+   *   getRoundData(_roundId: bigint | number): Promise<RoundData>,
    *   oracleRoundState(_oracle: OracleKey, _queriedRoundId: BigInt): Promise<any>
    * }}
    */
@@ -780,19 +794,9 @@ const start = async (
      * consumers are encouraged to check
      * that they're receiving fresh data by inspecting the updatedAt and
      * answeredInRound return values.
-     * return is: [roundId, answer, startedAt, updatedAt, answeredInRound], where
-     * roundId is the round ID for which data was retrieved
-     * answer is the answer for the given round
-     * startedAt is the timestamp when the round was started. This is 0
-     * if the round hasn't been started yet.
-     * updatedAt is the timestamp when the round last was updated (i.e.
-     * answer was last computed)
-     * answeredInRound is the round ID of the round in which the answer
-     * was computed. answeredInRound may be smaller than roundId when the round
-     * timed out. answeredInRound is equal to roundId when the round didn't time out
-     * and was completed regularly.
      *
      * @param {bigint | number} _roundIdRaw
+     * @returns {Promise<RoundData>}
      */
     async getRoundData(_roundIdRaw) {
       const roundId = Nat(_roundIdRaw);

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -604,7 +604,7 @@ const start = async (
   /**
    * @type {Omit<import('./priceAggregator').PriceAggregatorContract['creatorFacet'], 'initOracle'> & {
    *   initOracle: (instance) => Promise<OracleAdmin<PriceRound>>,
-   *   getRoundData(_roundId: BigInt): Promise<any>,
+   *   getRoundData(_roundId: bigint | number): Promise<any>,
    *   oracleRoundState(_oracle: OracleKey, _queriedRoundId: BigInt): Promise<any>
    * }}
    */
@@ -792,7 +792,7 @@ const start = async (
      * timed out. answeredInRound is equal to roundId when the round didn't time out
      * and was completed regularly.
      *
-     * @param {bigint} _roundIdRaw
+     * @param {bigint | number} _roundIdRaw
      */
     async getRoundData(_roundIdRaw) {
       const roundId = Nat(_roundIdRaw);

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -89,9 +89,8 @@ const makePublicationChecker = async (t, aggregatorPublicFacet) => {
     /** @param {{timestamp: bigint, amountOut: any}} spec */
     async nextMatches({ timestamp, amountOut }) {
       const { value } = await E(publications).next();
-      const quoteValue = value.quoteAmount.value[0];
-      t.is(quoteValue.timestamp, timestamp, 'wrong timestamp');
-      t.is(quoteValue.amountOut.value, amountOut, 'wrong amountOut value');
+      t.is(value.timestamp, timestamp, 'wrong timestamp');
+      t.is(value.amountOut.value, amountOut, 'wrong amountOut value');
     },
   };
 };
@@ -1096,21 +1095,13 @@ test('storage', async t => {
       'mockChainStorageRoot.priceAggregator.ATOM-USD_price_feed',
     ),
     {
-      quoteAmount: {
-        brand: { iface: 'Alleged: quote brand' },
-        value: [
-          {
-            amountIn: { brand: { iface: 'Alleged: $ATOM brand' }, value: 1n },
-            amountOut: {
-              brand: { iface: 'Alleged: $USD brand' },
-              value: 1020n,
-            },
-            timer: { iface: 'Alleged: ManualTimer' },
-            timestamp: 1n,
-          },
-        ],
+      amountIn: { brand: { iface: 'Alleged: $ATOM brand' }, value: 1n },
+      amountOut: {
+        brand: { iface: 'Alleged: $USD brand' },
+        value: 1020n,
       },
-      quotePayment: { iface: 'Alleged: quote payment' },
+      timer: { iface: 'Alleged: ManualTimer' },
+      timestamp: 1n,
     },
   );
 });

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -559,7 +559,7 @@ test('oracle continuing invitation', async t => {
   const or1 = E(zoe).offer(inv1, undefined, undefined, { notifier: oracle1 });
   const oracleAdmin1 = E(or1).getOfferResult();
   const invitationMakers = await E.get(oracleAdmin1).invitationMakers;
-  t.true('makePushPriceInvitation' in invitationMakers);
+  t.true('PushPrice' in invitationMakers);
 
   const amountIn = AmountMath.make(brandIn, 1000000n);
   const makeQuoteValue = (timestamp, valueOut) => [
@@ -575,7 +575,7 @@ test('oracle continuing invitation', async t => {
     E(aggregator.publicFacet).getPriceAuthority(),
   ).makeQuoteNotifier(amountIn, brandOut);
 
-  const invPrice = await E(invitationMakers).makePushPriceInvitation('1234');
+  const invPrice = await E(invitationMakers).PushPrice('1234');
   const invPriceResult = await E(zoe).offer(invPrice);
   t.deepEqual(await E(invPriceResult).numWantsSatisfied(), 1);
 

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -35,6 +35,17 @@ const defaultConfig = {
   minSubmissionValue: 100,
   maxSubmissionValue: 10000,
 };
+
+/**
+ *
+ * @param {Promise<StoredSubscriber<unknown>>} subscriber
+ */
+export const subscriberSubkey = subscriber => {
+  return E(subscriber)
+    .getStoreKey()
+    .then(storeKey => storeKey.storeSubkey);
+};
+
 const makeContext = async () => {
   // Outside of tests, we should use the long-lived Zoe on the
   // testnet. In this test, we must create a new Zoe.
@@ -745,4 +756,15 @@ test('notifications', async t => {
     roundId: 3n,
     startedAt: 1n,
   });
+});
+
+test('storage keys', async t => {
+  const { publicFacet } = await t.context.makeChainlinkAggregator(
+    defaultConfig,
+  );
+
+  t.is(
+    await subscriberSubkey(E(publicFacet).getSubscriber()),
+    'fake:mockChainStorageRoot.priceAggregator.LINK-USD_price_feed',
+  );
 });

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -15,7 +15,7 @@ import buildManualTimer from '../../../tools/manualTimer.js';
 
 import '../../../src/contracts/exported.js';
 
-/** @type {import('ava').TestFn<any>} */
+/** @type {import('ava').TestFn<TestContext>} */
 const test = unknownTest;
 
 /**
@@ -28,6 +28,7 @@ const test = unknownTest;
 /**
  * @typedef {object} TestContext
  * @property {ZoeService} zoe
+ * @property {(...args) => } makeChainlinkAggregator
  * @property {MakeFakePriceOracle} makeFakePriceOracle
  * @property {(POLL_INTERVAL: bigint) => Promise<PriceAggregatorKit & { instance: Instance }>} makeMedianAggregator
  * @property {Amount} feeAmount
@@ -64,6 +65,7 @@ test.before(
     /** @type {Installation<import('../../../src/contracts/oracle.js').OracleStart>} */
     const oracleInstallation = await E(zoe).installBundleID('b1-oracle');
     vatAdminState.installBundle('b1-aggregator', aggregatorBundle);
+    /** @type {Installation<import('../../../src/contracts/priceAggregatorChainlink.js').start>} */
     const aggregatorInstallation = await E(zoe).installBundleID(
       'b1-aggregator',
     );
@@ -110,7 +112,6 @@ test.before(
       minSubmissionCount,
       restartDelay,
       timeout,
-      description,
       minSubmissionValue,
       maxSubmissionValue,
     ) => {
@@ -118,18 +119,15 @@ test.before(
 
       const aggregator = await E(zoe).startInstance(
         aggregatorInstallation,
-        // TODO back to this way of specifying brands
-        // { In: link.issuer, Out: usd.issuer },
         undefined,
         {
-          brandIn: link.issuer,
-          brandOut: usd.issuer,
           timer,
+          brandIn: link.brand,
+          brandOut: usd.brand,
           maxSubmissionCount,
           minSubmissionCount,
           restartDelay,
           timeout,
-          description,
           minSubmissionValue,
           maxSubmissionValue,
         },
@@ -149,7 +147,6 @@ test('basic', async t => {
   const minSubmissionCount = 2;
   const restartDelay = 5;
   const timeout = 10;
-  const description = 'Chainlink oracles';
   const minSubmissionValue = 100;
   const maxSubmissionValue = 10000;
 
@@ -158,7 +155,6 @@ test('basic', async t => {
     minSubmissionCount,
     restartDelay,
     timeout,
-    description,
     minSubmissionValue,
     maxSubmissionValue,
   );
@@ -226,7 +222,6 @@ test('timeout', async t => {
   const minSubmissionCount = 2;
   const restartDelay = 2;
   const timeout = 5;
-  const description = 'Chainlink oracles';
   const minSubmissionValue = 100;
   const maxSubmissionValue = 10000;
 
@@ -235,7 +230,6 @@ test('timeout', async t => {
     minSubmissionCount,
     restartDelay,
     timeout,
-    description,
     minSubmissionValue,
     maxSubmissionValue,
   );
@@ -296,7 +290,6 @@ test('issue check', async t => {
   const minSubmissionCount = 2;
   const restartDelay = 2;
   const timeout = 5;
-  const description = 'Chainlink oracles';
   const minSubmissionValue = 100;
   const maxSubmissionValue = 10000;
 
@@ -305,7 +298,6 @@ test('issue check', async t => {
     minSubmissionCount,
     restartDelay,
     timeout,
-    description,
     minSubmissionValue,
     maxSubmissionValue,
   );
@@ -354,7 +346,6 @@ test('supersede', async t => {
   const minSubmissionCount = 2;
   const restartDelay = 1;
   const timeout = 5;
-  const description = 'Chainlink oracles';
   const minSubmissionValue = 100;
   const maxSubmissionValue = 10000;
 
@@ -363,7 +354,6 @@ test('supersede', async t => {
     minSubmissionCount,
     restartDelay,
     timeout,
-    description,
     minSubmissionValue,
     maxSubmissionValue,
   );
@@ -420,7 +410,6 @@ test('interleaved', async t => {
   const minSubmissionCount = 3; // requires ALL the oracles for consensus in this case
   const restartDelay = 1;
   const timeout = 5;
-  const description = 'Chainlink oracles';
   const minSubmissionValue = 100;
   const maxSubmissionValue = 10000;
 
@@ -429,7 +418,6 @@ test('interleaved', async t => {
     minSubmissionCount,
     restartDelay,
     timeout,
-    description,
     minSubmissionValue,
     maxSubmissionValue,
   );
@@ -558,7 +546,6 @@ test('larger', async t => {
   const minSubmissionCount = 3;
   const restartDelay = 1;
   const timeout = 5;
-  const description = 'Chainlink oracles';
   const minSubmissionValue = 100;
   const maxSubmissionValue = 10000;
 
@@ -567,7 +554,6 @@ test('larger', async t => {
     minSubmissionCount,
     restartDelay,
     timeout,
-    description,
     minSubmissionValue,
     maxSubmissionValue,
   );
@@ -641,7 +627,6 @@ test('suggest', async t => {
   const minSubmissionCount = 3;
   const restartDelay = 1;
   const timeout = 5;
-  const description = 'Chainlink oracles';
   const minSubmissionValue = 100;
   const maxSubmissionValue = 10000;
 
@@ -650,7 +635,6 @@ test('suggest', async t => {
     minSubmissionCount,
     restartDelay,
     timeout,
-    description,
     minSubmissionValue,
     maxSubmissionValue,
   );

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -118,8 +118,12 @@ test.before(
 
       const aggregator = await E(zoe).startInstance(
         aggregatorInstallation,
-        { In: link.issuer, Out: usd.issuer },
+        // TODO back to this way of specifying brands
+        // { In: link.issuer, Out: usd.issuer },
+        undefined,
         {
+          brandIn: link.issuer,
+          brandOut: usd.issuer,
           timer,
           maxSubmissionCount,
           minSubmissionCount,

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -139,6 +139,8 @@ test('basic', async t => {
     minSubmissionValue,
     maxSubmissionValue,
   );
+  /** @type {{ timer: ManualTimer }} */
+  // @ts-expect-error cast
   const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
 
   const priceOracleA = await makeFakePriceOracle();
@@ -214,6 +216,8 @@ test('timeout', async t => {
     minSubmissionValue,
     maxSubmissionValue,
   );
+  /** @type {{ timer: ManualTimer }} */
+  // @ts-expect-error cast
   const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
 
   const priceOracleA = await makeFakePriceOracle();
@@ -282,6 +286,8 @@ test('issue check', async t => {
     minSubmissionValue,
     maxSubmissionValue,
   );
+  /** @type {{ timer: ManualTimer }} */
+  // @ts-expect-error cast
   const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
 
   const priceOracleA = await makeFakePriceOracle();
@@ -338,6 +344,8 @@ test('supersede', async t => {
     minSubmissionValue,
     maxSubmissionValue,
   );
+  /** @type {{ timer: ManualTimer }} */
+  // @ts-expect-error cast
   const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
 
   const priceOracleA = await makeFakePriceOracle();
@@ -402,6 +410,8 @@ test('interleaved', async t => {
     minSubmissionValue,
     maxSubmissionValue,
   );
+  /** @type {{ timer: ManualTimer }} */
+  // @ts-expect-error cast
   const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
 
   const priceOracleA = await makeFakePriceOracle();
@@ -538,6 +548,8 @@ test('larger', async t => {
     minSubmissionValue,
     maxSubmissionValue,
   );
+  /** @type {{ timer: ManualTimer }} */
+  // @ts-expect-error cast
   const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
 
   const priceOracleA = await makeFakePriceOracle();
@@ -619,6 +631,8 @@ test('suggest', async t => {
     minSubmissionValue,
     maxSubmissionValue,
   );
+  /** @type {{ timer: ManualTimer }} */
+  // @ts-expect-error cast
   const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
 
   const priceOracleA = await makeFakePriceOracle();

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -705,29 +705,6 @@ test('notifications', async t => {
     roundId: 1n,
     startedAt: 1n,
   });
-  // t.deepEqual(
-  //   aggregator.mockStorageRoot.getBody(
-  //     'mockChainStorageRoot.priceAggregator.LINK-USD_price_feed',
-  //   ),
-  //   {
-  //     quoteAmount: {
-  //       brand: { iface: 'Alleged: quote brand' },
-  //       value: [
-  //         {
-  //           amountIn: { brand: { iface: 'Alleged: $LINK brand' }, value: 1n },
-  //           amountOut: {
-  //             brand: { iface: 'Alleged: $USD brand' },
-  //             value: 1020n,
-  //           },
-  //           timer: { iface: 'Alleged: ManualTimer' },
-  //           timestamp: 1n,
-  //         },
-  //       ],
-  //     },
-  //     quotePayment: { iface: 'Alleged: quote payment' },
-  //   },
-  // );
-
   await E(pricePushAdminB).pushResult({ roundId: 1, data: '200' });
 
   await E(pricePushAdminA).pushResult({ roundId: 2, data: '1000' });
@@ -749,6 +726,13 @@ test('notifications', async t => {
   });
   // A joins in
   await E(pricePushAdminA).pushResult({ roundId: 2, data: '1000' });
+  // writes to storage
+  t.deepEqual(
+    aggregator.mockStorageRoot.getBody(
+      'mockChainStorageRoot.priceAggregator.LINK-USD_price_feed.latestRound',
+    ),
+    { roundId: 2n, startedAt: 1n },
+  );
 
   // A can start again
   await E(pricePushAdminA).pushResult({ roundId: 3, data: '1000' });
@@ -756,6 +740,28 @@ test('notifications', async t => {
     roundId: 3n,
     startedAt: 1n,
   });
+  t.deepEqual(
+    aggregator.mockStorageRoot.getBody(
+      'mockChainStorageRoot.priceAggregator.LINK-USD_price_feed',
+    ),
+    {
+      quoteAmount: {
+        brand: { iface: 'Alleged: quote brand' },
+        value: [
+          {
+            amountIn: { brand: { iface: 'Alleged: $LINK brand' }, value: 1n },
+            amountOut: {
+              brand: { iface: 'Alleged: $USD brand' },
+              value: 1020n,
+            },
+            timer: { iface: 'Alleged: ManualTimer' },
+            timestamp: 1n,
+          },
+        ],
+      },
+      quotePayment: { iface: 'Alleged: quote payment' },
+    },
+  );
 });
 
 test('storage keys', async t => {

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -181,9 +181,9 @@ test('basic', async t => {
 
   // ----- round 1: basic consensus
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, data: '100' });
-  await E(pricePushAdminB).pushResult({ roundId: 1, data: '200' });
-  await E(pricePushAdminC).pushResult({ roundId: 1, data: '300' });
+  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
+  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 300n });
   await oracleTimer.tick();
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -195,9 +195,9 @@ test('basic', async t => {
   // the restartDelay, which means its submission will be IGNORED. this means the median
   // should ONLY be between the OracleB and C values, which is why it is 25000
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 2, data: '1000' });
-  await E(pricePushAdminB).pushResult({ roundId: 2, data: '2000' });
-  await E(pricePushAdminC).pushResult({ roundId: 2, data: '3000' });
+  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 2000n });
+  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 3000n });
   await oracleTimer.tick();
 
   const round1Attempt2 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -209,9 +209,9 @@ test('basic', async t => {
   // unlike the previous test, if C initializes, all submissions should be recorded,
   // which means the median will be the expected 5000 here
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 3, data: '5000' });
-  await E(pricePushAdminA).pushResult({ roundId: 3, data: '4000' });
-  await E(pricePushAdminB).pushResult({ roundId: 3, data: '6000' });
+  await E(pricePushAdminC).pushResult({ roundId: 3, unitPrice: 5000n });
+  await E(pricePushAdminA).pushResult({ roundId: 3, unitPrice: 4000n });
+  await E(pricePushAdminB).pushResult({ roundId: 3, unitPrice: 6000n });
   await oracleTimer.tick();
 
   const round1Attempt3 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -248,11 +248,11 @@ test('timeout', async t => {
 
   // ----- round 1: basic consensus w/ ticking: should work EXACTLY the same
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, data: '100' });
+  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 1, data: '200' });
+  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 1, data: '300' });
+  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 300n });
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
   t.deepEqual(round1Attempt1.roundId, 1n);
@@ -262,15 +262,15 @@ test('timeout', async t => {
   // timeout behavior is, if more ticks pass than the timeout param (5 here), the round is
   // considered "timedOut," at which point, the values are simply copied from the previous round
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, data: '2000' });
+  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 2000n });
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick(); // --- should time out here
-  await E(pricePushAdminC).pushResult({ roundId: 3, data: '1000' });
-  await E(pricePushAdminA).pushResult({ roundId: 3, data: '3000' });
+  await E(pricePushAdminC).pushResult({ roundId: 3, unitPrice: 1000n });
+  await E(pricePushAdminA).pushResult({ roundId: 3, unitPrice: 3000n });
 
   const round1Attempt2 = await E(aggregator.creatorFacet).getRoundData(1);
   t.deepEqual(round1Attempt2.answer, 200n);
@@ -307,20 +307,20 @@ test('issue check', async t => {
 
   // ----- round 1: ignore too low values
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, data: '50' }); // should be IGNORED
+  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 50n }); // should be IGNORED
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 1, data: '200' });
+  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 1, data: '300' });
+  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 300n });
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
   t.deepEqual(round1Attempt1.answer, 250n);
 
   // ----- round 2: ignore too high values
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, data: '20000' });
-  await E(pricePushAdminC).pushResult({ roundId: 2, data: '1000' });
-  await E(pricePushAdminA).pushResult({ roundId: 2, data: '3000' });
+  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 20000n });
+  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 3000n });
   await oracleTimer.tick();
 
   const round2Attempt1 = await E(aggregator.creatorFacet).getRoundData(2);
@@ -354,9 +354,9 @@ test('supersede', async t => {
 
   // ----- round 1: round 1 is NOT supersedable when 3 submits, meaning it will be ignored
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, data: '100' });
-  await E(pricePushAdminC).pushResult({ roundId: 2, data: '300' });
-  await E(pricePushAdminB).pushResult({ roundId: 1, data: '200' });
+  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 300n });
+  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -364,8 +364,8 @@ test('supersede', async t => {
 
   // ----- round 2: oracle C's value from before should have been IGNORED
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, data: '2000' });
-  await E(pricePushAdminA).pushResult({ roundId: 2, data: '1000' });
+  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 2000n });
+  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 1000n });
   await oracleTimer.tick();
 
   const round2Attempt1 = await E(aggregator.creatorFacet).getRoundData(2);
@@ -373,7 +373,7 @@ test('supersede', async t => {
 
   // ----- round 3: oracle C should NOT be able to supersede round 3
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 4, data: '1000' });
+  await E(pricePushAdminC).pushResult({ roundId: 4, unitPrice: 1000n });
 
   try {
     await E(aggregator.creatorFacet).getRoundData(4);
@@ -412,9 +412,9 @@ test('interleaved', async t => {
 
   // ----- round 1: we now need unanimous submission for a round for it to have consensus
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, data: '100' });
-  await E(pricePushAdminC).pushResult({ roundId: 2, data: '300' });
-  await E(pricePushAdminB).pushResult({ roundId: 1, data: '200' });
+  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 300n });
+  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
 
   try {
@@ -425,17 +425,17 @@ test('interleaved', async t => {
 
   // ----- round 2: interleaved round submission -- just making sure this works
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 1, data: '300' });
+  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 300n });
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, data: '2000' });
-  await E(pricePushAdminA).pushResult({ roundId: 2, data: '1000' });
+  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 2000n });
+  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 1000n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 3, data: '9000' });
+  await E(pricePushAdminC).pushResult({ roundId: 3, unitPrice: 9000n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 2, data: '3000' }); // assumes oracle C is going for a resubmission
+  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 3000n }); // assumes oracle C is going for a resubmission
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 3, data: '5000' });
+  await E(pricePushAdminA).pushResult({ roundId: 3, unitPrice: 5000n });
   await oracleTimer.tick();
 
   const round1Attempt2 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -458,9 +458,9 @@ test('interleaved', async t => {
   await oracleTimer.tick();
   await oracleTimer.tick();
   // round 3 is NOT yet supersedeable (since no value present and not yet timed out), so these should fail
-  await E(pricePushAdminA).pushResult({ roundId: 4, data: '4000' });
-  await E(pricePushAdminB).pushResult({ roundId: 4, data: '5000' });
-  await E(pricePushAdminC).pushResult({ roundId: 4, data: '6000' });
+  await E(pricePushAdminA).pushResult({ roundId: 4, unitPrice: 4000n });
+  await E(pricePushAdminB).pushResult({ roundId: 4, unitPrice: 5000n });
+  await E(pricePushAdminC).pushResult({ roundId: 4, unitPrice: 6000n });
   await oracleTimer.tick(); // --- round 3 has NOW timed out, meaning it is now supersedable
 
   try {
@@ -476,9 +476,9 @@ test('interleaved', async t => {
   }
 
   // so NOW we should be able to submit round 4, and round 3 should just be copied from round 2
-  await E(pricePushAdminA).pushResult({ roundId: 4, data: '4000' });
-  await E(pricePushAdminB).pushResult({ roundId: 4, data: '5000' });
-  await E(pricePushAdminC).pushResult({ roundId: 4, data: '6000' });
+  await E(pricePushAdminA).pushResult({ roundId: 4, unitPrice: 4000n });
+  await E(pricePushAdminB).pushResult({ roundId: 4, unitPrice: 5000n });
+  await E(pricePushAdminC).pushResult({ roundId: 4, unitPrice: 6000n });
   await oracleTimer.tick();
 
   const round3Attempt3 = await E(aggregator.creatorFacet).getRoundData(3);
@@ -488,7 +488,7 @@ test('interleaved', async t => {
   t.deepEqual(round4Attempt2.answer, 5000n);
 
   // ----- round 5: ping-ponging should be possible (although this is an unlikely pernicious case)
-  await E(pricePushAdminC).pushResult({ roundId: 5, data: '1000' });
+  await E(pricePushAdminC).pushResult({ roundId: 5, unitPrice: 1000n });
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
@@ -496,14 +496,14 @@ test('interleaved', async t => {
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 6, data: '1000' });
+  await E(pricePushAdminA).pushResult({ roundId: 6, unitPrice: 1000n });
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 7, data: '1000' });
+  await E(pricePushAdminC).pushResult({ roundId: 7, unitPrice: 1000n });
 
   const round5Attempt1 = await E(aggregator.creatorFacet).getRoundData(5);
   const round6Attempt1 = await E(aggregator.creatorFacet).getRoundData(6);
@@ -549,36 +549,36 @@ test('larger', async t => {
 
   // ----- round 1: usual case
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, data: '100' });
-  await E(pricePushAdminB).pushResult({ roundId: 1, data: '200' });
+  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 2, data: '1000' });
+  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 1000n });
   await oracleTimer.tick();
-  await E(pricePushAdminD).pushResult({ roundId: 3, data: '3000' });
+  await E(pricePushAdminD).pushResult({ roundId: 3, unitPrice: 3000n });
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminE).pushResult({ roundId: 1, data: '300' });
+  await E(pricePushAdminE).pushResult({ roundId: 1, unitPrice: 300n });
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
   t.deepEqual(round1Attempt1.answer, 200n);
 
   // ----- round 2: ignore late arrival
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, data: '600' });
+  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 600n });
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 2, data: '500' });
+  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 500n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 3, data: '1000' });
+  await E(pricePushAdminC).pushResult({ roundId: 3, unitPrice: 1000n });
   await oracleTimer.tick();
-  await E(pricePushAdminD).pushResult({ roundId: 1, data: '500' });
+  await E(pricePushAdminD).pushResult({ roundId: 1, unitPrice: 500n });
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 2, data: '1000' });
+  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 1000n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 1, data: '700' }); // this should be IGNORED since oracle C has already sent round 2
+  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 700n }); // this should be IGNORED since oracle C has already sent round 2
 
   const round1Attempt2 = await E(aggregator.creatorFacet).getRoundData(1);
   const round2Attempt1 = await E(aggregator.creatorFacet).getRoundData(2);
@@ -615,9 +615,9 @@ test('suggest', async t => {
 
   // ----- round 1: basic consensus
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, data: '100' });
-  await E(pricePushAdminB).pushResult({ roundId: 1, data: '200' });
-  await E(pricePushAdminC).pushResult({ roundId: 1, data: '300' });
+  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
+  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 300n });
   await oracleTimer.tick();
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -626,7 +626,7 @@ test('suggest', async t => {
 
   // ----- round 2: add a new oracle and confirm the suggested round is correct
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, data: '1000' });
+  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 1000n });
   const oracleCSuggestion = await E(aggregator.creatorFacet).oracleRoundState(
     priceOracleC.instance,
     1n,
@@ -646,10 +646,10 @@ test('suggest', async t => {
   t.deepEqual(oracleBSuggestion.oracleCount, 3);
 
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 2, data: '2000' });
+  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 2000n });
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 2, data: '3000' });
+  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 3000n });
 
   const oracleASuggestion = await E(aggregator.creatorFacet).oracleRoundState(
     priceOracleA.instance,
@@ -661,12 +661,12 @@ test('suggest', async t => {
   t.deepEqual(oracleASuggestion.startedAt, 0n); // round 3 hasn't yet started, so it should be zeroed
 
   // ----- round 3: try using suggested round
-  await E(pricePushAdminC).pushResult({ roundId: 3, data: '100' });
+  await E(pricePushAdminC).pushResult({ roundId: 3, unitPrice: 100n });
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: undefined, data: '200' });
+  await E(pricePushAdminA).pushResult({ roundId: undefined, unitPrice: 200n });
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: undefined, data: '300' });
+  await E(pricePushAdminB).pushResult({ roundId: undefined, unitPrice: 300n });
 
   const round3Attempt1 = await E(aggregator.creatorFacet).getRoundData(3);
   t.deepEqual(round3Attempt1.roundId, 3n);
@@ -703,12 +703,12 @@ test('notifications', async t => {
   ]();
 
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, data: '100' });
+  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
   t.deepEqual((await eachLatestRound.next()).value, {
     roundId: 1n,
     startedAt: 1n,
   });
-  await E(pricePushAdminB).pushResult({ roundId: 1, data: '200' });
+  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
 
   await eventLoopIteration();
   t.deepEqual(
@@ -726,7 +726,7 @@ test('notifications', async t => {
     },
   );
 
-  await E(pricePushAdminA).pushResult({ roundId: 2, data: '1000' });
+  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 1000n });
   // A started last round so fails to start next round
   t.deepEqual(
     // subscribe fresh because the iterator won't advance yet
@@ -737,14 +737,14 @@ test('notifications', async t => {
     },
   );
   // B gets to start it
-  await E(pricePushAdminB).pushResult({ roundId: 2, data: '1000' });
+  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 1000n });
   // now it's roundId=2
   t.deepEqual((await eachLatestRound.next()).value, {
     roundId: 2n,
     startedAt: 1n,
   });
   // A joins in
-  await E(pricePushAdminA).pushResult({ roundId: 2, data: '1000' });
+  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 1000n });
   // writes to storage
   t.deepEqual(
     aggregator.mockStorageRoot.getBody(
@@ -770,7 +770,7 @@ test('notifications', async t => {
   );
 
   // A can start again
-  await E(pricePushAdminA).pushResult({ roundId: 3, data: '1000' });
+  await E(pricePushAdminA).pushResult({ roundId: 3, unitPrice: 1000n });
   t.deepEqual((await eachLatestRound.next()).value, {
     roundId: 3n,
     startedAt: 1n,


### PR DESCRIPTION
closes: #6628
part of https://github.com/Agoric/agoric-sdk/issues/6571

## Description

Make `priceAggregatorChainlink` the price aggregator contract. Updates CLI command and smoketest script to use the new result struct.

Updates the contract itself for code quality and compatibility with the Smart Wallet (using continuing invitation pattern and keying oracles by wallet address).

### Security Considerations

Increases security by implementing round constraints on oracle price pushes. No new privileges.

### Documentation Considerations

This changes the `priceAggregator` to be Chainlink style, which is different than https://github.com/Agoric/dapp-oracle/ expects. OTOH it's already broken and serves mostly an illustration instead of a functioning dapp.

### Testing Considerations

Tested manually with https://github.com/Agoric/agoric-sdk/blob/6ff21e34936bdaad17ecd3d0e40dc7493a75cac3/packages/agoric-cli/test/agops-oracle-smoketest.sh