### PR TITLE
feat: integrate JSON.stringify/parse in board marshallers

### DIFF
--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -221,13 +221,15 @@ harden(makeStorageNodeChild);
 // TODO find a better module for this
 /**
  * @param {import('@endo/far').ERef<StorageNode>} storageNode
- * @param {import('@endo/far').ERef<Marshaller>} marshaller
+ * @param {import('@endo/far').ERef<Marshaller & {
+ *   serializeAndStringify: (value: unknown) => string
+ * }>} marshaller
  * @returns {(value: unknown) => Promise<void>}
  */
 export const makeSerializeToStorage = (storageNode, marshaller) => {
   return async value => {
-    const marshalled = await E(marshaller).toCapData(value);
-    const serialized = JSON.stringify(marshalled);
-    return E(storageNode).setValue(serialized);
+    const serializedP = E(marshaller).serializeAndStringify(value);
+    // @ts-expect-error M.callWhen
+    return E(storageNode).setValue(serializedP);
   };
 };

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -36,7 +36,7 @@ const { Fail } = assert;
  */
 
 const ChainStorageNodeI = M.interface('StorageNode', {
-  setValue: M.callWhen(M.string()).returns(),
+  setValue: M.callWhen(M.await(M.string())).returns(),
   getPath: M.call().returns(M.string()),
   getStoreKey: M.callWhen().returns(M.record()),
   makeChildNode: M.call(M.string())
@@ -228,8 +228,7 @@ harden(makeStorageNodeChild);
  */
 export const makeSerializeToStorage = (storageNode, marshaller) => {
   return async value => {
-    const serializedP = E(marshaller).serializeAndStringify(value);
-    // @ts-expect-error M.callWhen
-    return E(storageNode).setValue(serializedP);
+    const serialized = await E(marshaller).serializeAndStringify(value);
+    return E(storageNode).setValue(serialized);
   };
 };

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -23,6 +23,7 @@ const MarshalI = M.interface('Marshaller', {
   fromCapData: M.call(CapDataShape).returns(M.any()),
   serializeAndStringify: M.callWhen(M.any()).returns(M.string()),
   unserialize: M.call(CapDataShape).returns(M.any()),
+  parseAndDecode: M.callWhen(M.string()).returns(M.any()),
 });
 
 const IdShape = M.string();
@@ -348,6 +349,11 @@ export const prepareBoardKit = baggage => {
           const readonly = makeReadonlyMarshaller(this.state);
           return JSON.stringify(readonly.serialize(val));
         },
+        parseAndDecode(str) {
+          const data = JSON.parse(str);
+          const readonly = makeReadonlyMarshaller(this.state);
+          return readonly.unserialize(data);
+        },
       },
       publishingMarshaller: {
         toCapData(val) {
@@ -367,6 +373,11 @@ export const prepareBoardKit = baggage => {
         serializeAndStringify(val) {
           const publishing = makePublishingMarshaller(this.state);
           return JSON.stringify(publishing.serialize(val));
+        },
+        parseAndDecode(str) {
+          const data = JSON.parse(str);
+          const publishing = makePublishingMarshaller(this.state);
+          return publishing.unserialize(data);
         },
       },
     },

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -16,12 +16,12 @@ export const DEFAULT_CRC_DIGITS = 2;
 export const DEFAULT_PREFIX = 'board0';
 
 //#region Interface Guards
-// TODO import from Endo
 const CapDataShape = { body: M.string(), slots: M.array() };
 const MarshalI = M.interface('Marshaller', {
   toCapData: M.call(M.any()).returns(CapDataShape),
   serialize: M.call(M.any()).returns(CapDataShape),
   fromCapData: M.call(CapDataShape).returns(M.any()),
+  serializeAndStringify: M.callWhen(M.any()).returns(M.string()),
   unserialize: M.call(CapDataShape).returns(M.any()),
 });
 
@@ -344,6 +344,10 @@ export const prepareBoardKit = baggage => {
         unserialize(data) {
           return this.facets.readonlyMarshaller.fromCapData(data);
         },
+        serializeAndStringify(val) {
+          const readonly = makeReadonlyMarshaller(this.state);
+          return JSON.stringify(readonly.serialize(val));
+        },
       },
       publishingMarshaller: {
         toCapData(val) {
@@ -359,6 +363,10 @@ export const prepareBoardKit = baggage => {
         },
         unserialize(data) {
           return this.facets.publishingMarshaller.fromCapData(data);
+        },
+        serializeAndStringify(val) {
+          const publishing = makePublishingMarshaller(this.state);
+          return JSON.stringify(publishing.serialize(val));
         },
       },
     },

--- a/packages/vats/test/test-lib-board.js
+++ b/packages/vats/test/test-lib-board.js
@@ -133,3 +133,12 @@ test('serialize and stringify to save a round trip', async t => {
   const s = await E(marshaller).serializeAndStringify(obj2);
   t.is(s, '{"body":"#\\"$0.Alleged: obj2\\"","slots":["board0371"]}');
 });
+
+test('parse and decode', async t => {
+  const board = makeBoard();
+  const marshaller = board.getPublishingMarshaller();
+  const obj2 = Far('obj2', {});
+  const s = await E(marshaller).serializeAndStringify(obj2);
+  const actual = await E(marshaller).parseAndDecode(s);
+  t.is(actual, obj2);
+});

--- a/packages/vats/test/test-lib-board.js
+++ b/packages/vats/test/test-lib-board.js
@@ -125,3 +125,11 @@ test(`getReadonlyMarshaller doesn't leak unpublished objects`, async t => {
   const marshaller = board.getReadonlyMarshaller();
   await testBoardMarshaller(t, board, marshaller, false);
 });
+
+test('serialize and stringify to save a round trip', async t => {
+  const board = makeBoard();
+  const marshaller = board.getPublishingMarshaller();
+  const obj2 = Far('obj2', {});
+  const s = await E(marshaller).serializeAndStringify(obj2);
+  t.is(s, '{"body":"#\\"$0.Alleged: obj2\\"","slots":["board0371"]}');
+});

--- a/packages/zoe/src/contractSupport/recorder.js
+++ b/packages/zoe/src/contractSupport/recorder.js
@@ -101,9 +101,8 @@ export const prepareRecorder = (baggage, marshaller) => {
         const { closed, publisher, storageNode, valueShape } = this.state;
         !closed || Fail`cannot write to closed recorder`;
         mustMatch(value, valueShape);
-        const encoded = await E(marshaller).toCapData(value);
-        const serialized = JSON.stringify(encoded);
-        await E(storageNode).setValue(serialized);
+        const serializedP = await E(marshaller).serializeAndStringify(value);
+        await E(storageNode).setValue(serializedP);
 
         // below here differs from writeFinal()
         return publisher.publish(value);
@@ -118,9 +117,8 @@ export const prepareRecorder = (baggage, marshaller) => {
         const { closed, publisher, storageNode, valueShape } = this.state;
         !closed || Fail`cannot write to closed recorder`;
         mustMatch(value, valueShape);
-        const encoded = await E(marshaller).toCapData(value);
-        const serialized = JSON.stringify(encoded);
-        await E(storageNode).setValue(serialized);
+        const serializedP = await E(marshaller).serializeAndStringify(value);
+        await E(storageNode).setValue(serializedP);
 
         // below here differs from writeFinal()
         this.state.closed = true;


### PR DESCRIPTION
refs: #6625, #6038

based on feedback, plan is to add support for this in endo, starting with
 - [x] https://github.com/endojs/endo/issues/1248
   - https://github.com/endojs/endo/pull/1402

## Description

In #6625, @warner writes:

> I think we're seeing the same "long time to serialize" problem ...

That reminded me of the [two round trips in each wallet state update](https://github.com/Agoric/agoric-sdk/issues/6038#issuecomment-1242631519) - one for `serialize` and one for `setValue`:

![image](https://user-images.githubusercontent.com/150986/206278955-75d00191-3ec1-417c-8a6e-b40f1acb7257.png)

by changing `E(marshaller).serialize(value).then(x => E(storageNode).setValue(JSON.stringify(x))` to `E(storageNode).setValue(E(marshaller).serializeAndStringify(x))` we can save a round trip for each:

![image](https://user-images.githubusercontent.com/150986/206280017-ef9745c9-d11d-4ce3-9168-7a624348c12a.png)

[gist with before and after .svg diagrams](https://gist.github.com/dckc/942e8b7467827ea9ef6fe53937abdb09)

### Drawbacks

 - [ ] we were using `serialize` from the marshal API. `serializeAndStringify` means a distinct interface/type threaded through all the places that use storage nodes.
   - It's a little awkward, but saving a round trip is worth it, yes?

### Security Considerations

 - [ ] `setValue()` takes a promise now. Using pattern guards in `makeChainStorageRoot` would let us use `callAfter` as well as the usual security benefits 

### Documentation Considerations

?

### Testing Considerations

 - [x] `serializeAndStringify` unit test in `test-lib-board.js`
