### PR TITLE
fix(swingset): workaround XS garbage collection bugs

### DIFF
--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -103,7 +103,7 @@ import { makeTranscriptManager } from './transcript.js';
  * @param {KernelSlog} kernelSlog
  * @param {(vso: VatSyscallObject) => VatSyscallResult} vatSyscallHandler
  * @param {boolean} workerCanBlock
- * @param {(vatID: any, originalSyscall: any, newSyscall: any) => Error | undefined} [compareSyscalls]
+ * @param {(vatID: any, originalSyscall: any, newSyscall: any) => import('./transcript.js').CompareSyscallsResult} [compareSyscalls]
  * @param {boolean} [useTranscript]
  * @returns {ManagerKit}
  */
@@ -247,7 +247,9 @@ function makeManagerKit(
       // but if the puppy deviates one inch from previous twitches, explode
       kernelSlog.syscall(vatID, undefined, vso);
       const vres = transcriptManager.simulateSyscall(vso);
-      return vres;
+      if (vres) {
+        return vres;
+      }
     }
 
     const vres = vatSyscallHandler(vso);
@@ -256,7 +258,7 @@ function makeManagerKit(
     if (successFlag === 'ok' && data && !workerCanBlock) {
       console.log(`warning: syscall returns data, but worker cannot get it`);
     }
-    if (transcriptManager) {
+    if (transcriptManager && !transcriptManager.inReplay()) {
       transcriptManager.addSyscall(vso, vres);
     }
     return vres;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -2,6 +2,7 @@
 import { assert, details as X, q } from '@agoric/assert';
 import { ExitCode } from '@agoric/xsnap/api.js';
 import { makeManagerKit } from './manager-helper.js';
+import { requireIdenticalExceptStableVCSyscalls } from './transcript.js';
 
 import {
   insistVatSyscallObject,
@@ -55,7 +56,7 @@ export function makeXsSubprocessFactory({
     const {
       name: vatName,
       metered,
-      compareSyscalls,
+      compareSyscalls = requireIdenticalExceptStableVCSyscalls,
       useTranscript,
       sourcedConsole,
     } = managerOptions;

--- a/packages/SwingSet/src/kernel/vat-loader/transcript.js
+++ b/packages/SwingSet/src/kernel/vat-loader/transcript.js
@@ -1,5 +1,21 @@
 import djson from '../../lib/djson.js';
 
+// Indicate that a syscall is missing from the transcript but is safe to
+// perform during replay
+const missingSyscall = Symbol('missing transcript syscall');
+
+// Indicate that a syscall is recorded in the transcript but can be safely
+// ignored / skipped during replay.
+const extraSyscall = Symbol('extra transcript syscall');
+
+/** @typedef {typeof missingSyscall | typeof extraSyscall | Error | undefined} CompareSyscallsResult */
+
+/**
+ * @param {any} vatID
+ * @param {object} originalSyscall
+ * @param {object} newSyscall
+ * @returns {CompareSyscallsResult}
+ */
 export function requireIdentical(vatID, originalSyscall, newSyscall) {
   if (djson.stringify(originalSyscall) !== djson.stringify(newSyscall)) {
     console.error(`anachrophobia strikes vat ${vatID}`);
@@ -8,6 +24,67 @@ export function requireIdentical(vatID, originalSyscall, newSyscall) {
     return new Error(`historical inaccuracy in replay of ${vatID}`);
   }
   return undefined;
+}
+
+const vcSyscallRE = /^vc\.\d+\.\|(?:schemata|label)$/;
+
+/**
+ * Liveslots currently has a deficiency which results in [virtual collections
+ * being sensitive to organic GC](https://github.com/Agoric/agoric-sdk/issues/6360).
+ *
+ * XS also has multiple issues causing memory to not be collected identically
+ * depending on the load from snapshot schedule. This results in organic GC
+ * triggering at different times based on which snapshot the worker was created
+ * from.
+ *
+ * Combined together, these bugs cause syscalls being emitted by liveslots at
+ * different times whether the execution occurred in a worker created from a
+ * more or less recent snapshot. With a strict check during transcript replay,
+ * this can cause [anachrophobia errors when restarting SwingSet](https://github.com/Agoric/agoric-sdk/issues/6588),
+ * or potentially when reloading a vat that was paged out.
+ *
+ * Thankfully the syscalls issued by liveslots for these virtual collection
+ * objects are both easily identifiable and stable over time. That means their
+ * response is always the same regardless when the syscall is made.
+ *
+ * This method enhances the basic identical check and returns sentinel values
+ * (unique symbols), indicating whether a syscall during replay requires to
+ * skip an entry from the transcript or perform the actual syscall because the
+ * entry is missing in the transcript. This works in conjunction with
+ * `simulateSyscall` which then performs the appropriate action.
+ *
+ * @param {any} vatID
+ * @param {object} originalSyscall
+ * @param {object} newSyscall
+ * @returns {CompareSyscallsResult}
+ */
+export function requireIdenticalExceptStableVCSyscalls(
+  vatID,
+  originalSyscall,
+  newSyscall,
+) {
+  const error = requireIdentical(vatID, originalSyscall, newSyscall);
+
+  if (error) {
+    if (
+      originalSyscall[0] === 'vatstoreGet' &&
+      vcSyscallRE.test(originalSyscall[1])
+    ) {
+      // The syscall recorded in the transcript is for a virtual collection
+      // metadata get. It can be safely skipped.
+      console.warn(`  mitigation: ignoring extra vc syscall`);
+      return extraSyscall;
+    }
+
+    if (newSyscall[0] === 'vatstoreGet' && vcSyscallRE.test(newSyscall[1])) {
+      // The syscall performed by the vat is for a virtual collection metadata
+      // get. It can be safely performed during replay.
+      console.warn(`  mitigation: falling through to syscall handler`);
+      return missingSyscall;
+    }
+  }
+
+  return error;
 }
 
 export function makeTranscriptManager(
@@ -59,13 +136,44 @@ export function makeTranscriptManager(
   let replayError;
 
   function simulateSyscall(newSyscall) {
-    const s = playbackSyscalls.shift();
-    const newReplayError = compareSyscalls(vatID, s.d, newSyscall);
-    if (newReplayError) {
-      replayError = newReplayError;
-      throw replayError;
+    while (playbackSyscalls.length) {
+      const compareError = compareSyscalls(
+        vatID,
+        playbackSyscalls[0].d,
+        newSyscall,
+      );
+
+      if (compareError === missingSyscall) {
+        // return `undefined` to indicate that this syscall cannot be simulated
+        // and needs to be performed (virtual collection metadata get)
+        return undefined;
+      }
+
+      const s = playbackSyscalls.shift();
+
+      if (!compareError) {
+        return s.response;
+      } else if (compareError !== extraSyscall) {
+        replayError = compareError;
+        break;
+      }
+
+      // Check the next transcript entry, skipping any extra syscalls recorded
+      // in the transcript (virtual collection metadata get)
     }
-    return s.response;
+
+    if (!replayError) {
+      // Error if the vat performs a syscall for which we don't have a
+      // corresponding entry in the transcript.
+
+      // Note that if a vat performed an "allowed" vc metadata get syscall after
+      // we reach the end of the transcript, we would error instead of
+      // falling through and performing the syscall. However liveslots does not
+      // perform vc metadata get syscalls unless it needs to provide an entry
+      // to the program, which always results in subsequent syscalls.
+      replayError = new Error(`historical inaccuracy in replay of ${vatID}`);
+    }
+    throw replayError;
   }
 
   function finishReplayDelivery(dnum) {


### PR DESCRIPTION
refs: #6588 

## Description

This changes how the transcript replay logic handles syscalls so that virtual collection metadata `vatstoreGet` syscalls can happen at different times than when it was originally recorded.

### Security Considerations

This ability to skip, and more importantly, fall-through syscalls should be limited to idempotent syscalls. In this case `vatstoreGet` of vc metadata will always return the same result as the data never changes, and a "get" does not perform any changes. By collocating the compare function definition and the usage, we avoid this capability being exposed inadvertently to the embedder.

### Documentation Considerations

How to apply this change:
In `agoric-sdk`:
```sh
curl https://patch-diff.githubusercontent.com/raw/Agoric/agoric-sdk/pull/6664.diff | patch -p1
```

### Testing Considerations

Tested against `stake2me`'s `agoric_2012-12-11.tar` snapshot which contains an arachnophobia issue for vat6:

```
2022-12-13T00:07:49.608Z launch-chain: Launching SwingSet kernel
2022-12-13T00:07:59.792Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:07:59.793Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.12.|schemata","length":2}
2022-12-13T00:07:59.793Z SwingSet: kernel: got     : {"0":"vatstoreSet","1":"vom.dkind.11","2":"{\"kindID\":\"11\",\"tag\":\"IST payment\",\"nextInstanceID\":5909,\"unfaceted\":true}","length":3}
2022-12-13T00:07:59.794Z SwingSet: kernel:   mitigation: ignoring extra vc syscall
2022-12-13T00:07:59.794Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:07:59.794Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.12.|label","length":2}
2022-12-13T00:07:59.794Z SwingSet: kernel: got     : {"0":"vatstoreSet","1":"vom.dkind.11","2":"{\"kindID\":\"11\",\"tag\":\"IST payment\",\"nextInstanceID\":5909,\"unfaceted\":true}","length":3}
2022-12-13T00:07:59.794Z SwingSet: kernel:   mitigation: ignoring extra vc syscall
2022-12-13T00:07:59.819Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:07:59.819Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.12.|schemata","length":2}
2022-12-13T00:07:59.819Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.7.|o+11/5908","length":2}
2022-12-13T00:07:59.819Z SwingSet: kernel:   mitigation: ignoring extra vc syscall
2022-12-13T00:07:59.819Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:07:59.819Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.12.|label","length":2}
2022-12-13T00:07:59.819Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.7.|o+11/5908","length":2}
2022-12-13T00:07:59.820Z SwingSet: kernel:   mitigation: ignoring extra vc syscall
2022-12-13T00:08:00.382Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:00.382Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.29.|schemata","length":2}
2022-12-13T00:08:00.382Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.7.|o+11/5915","length":2}
2022-12-13T00:08:00.382Z SwingSet: kernel:   mitigation: ignoring extra vc syscall
2022-12-13T00:08:00.382Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:00.383Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.29.|label","length":2}
2022-12-13T00:08:00.383Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.7.|o+11/5915","length":2}
2022-12-13T00:08:00.383Z SwingSet: kernel:   mitigation: ignoring extra vc syscall
2022-12-13T00:08:00.460Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:00.460Z SwingSet: kernel: expected: {"0":"vatstoreSet","1":"vom.dkind.11","2":"{\"kindID\":\"11\",\"tag\":\"IST payment\",\"nextInstanceID\":5918,\"unfaceted\":true}","length":3}
2022-12-13T00:08:00.460Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.12.|schemata","length":2}
2022-12-13T00:08:00.460Z SwingSet: kernel:   mitigation: falling through to syscall handler
2022-12-13T00:08:00.462Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:00.462Z SwingSet: kernel: expected: {"0":"vatstoreSet","1":"vom.dkind.11","2":"{\"kindID\":\"11\",\"tag\":\"IST payment\",\"nextInstanceID\":5918,\"unfaceted\":true}","length":3}
2022-12-13T00:08:00.462Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.12.|label","length":2}
2022-12-13T00:08:00.462Z SwingSet: kernel:   mitigation: falling through to syscall handler
2022-12-13T00:08:00.782Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:00.783Z SwingSet: kernel: expected: {"0":"vatstoreSet","1":"vom.dkind.11","2":"{\"kindID\":\"11\",\"tag\":\"IST payment\",\"nextInstanceID\":5923,\"unfaceted\":true}","length":3}
2022-12-13T00:08:00.783Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.393.|schemata","length":2}
2022-12-13T00:08:00.783Z SwingSet: kernel:   mitigation: falling through to syscall handler
2022-12-13T00:08:00.785Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:00.785Z SwingSet: kernel: expected: {"0":"vatstoreSet","1":"vom.dkind.11","2":"{\"kindID\":\"11\",\"tag\":\"IST payment\",\"nextInstanceID\":5923,\"unfaceted\":true}","length":3}
2022-12-13T00:08:00.785Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.393.|label","length":2}
2022-12-13T00:08:00.786Z SwingSet: kernel:   mitigation: falling through to syscall handler
2022-12-13T00:08:00.897Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:00.897Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.7.|o+11/5924","length":2}
2022-12-13T00:08:00.897Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.12.|schemata","length":2}
2022-12-13T00:08:00.897Z SwingSet: kernel:   mitigation: falling through to syscall handler
2022-12-13T00:08:00.898Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:00.898Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.7.|o+11/5924","length":2}
2022-12-13T00:08:00.898Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.12.|label","length":2}
2022-12-13T00:08:00.898Z SwingSet: kernel:   mitigation: falling through to syscall handler
2022-12-13T00:08:02.148Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:02.148Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.7.|o+11/5940","length":2}
2022-12-13T00:08:02.148Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.12.|schemata","length":2}
2022-12-13T00:08:02.148Z SwingSet: kernel:   mitigation: falling through to syscall handler
2022-12-13T00:08:02.149Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:02.149Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.7.|o+11/5940","length":2}
2022-12-13T00:08:02.149Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.12.|label","length":2}
2022-12-13T00:08:02.149Z SwingSet: kernel:   mitigation: falling through to syscall handler
2022-12-13T00:08:02.522Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:02.523Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.12.|schemata","length":2}
2022-12-13T00:08:02.523Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.7.|o+11/5946","length":2}
2022-12-13T00:08:02.523Z SwingSet: kernel:   mitigation: ignoring extra vc syscall
2022-12-13T00:08:02.523Z SwingSet: kernel: anachrophobia strikes vat v6
2022-12-13T00:08:02.523Z SwingSet: kernel: expected: {"0":"vatstoreGet","1":"vc.12.|label","length":2}
2022-12-13T00:08:02.523Z SwingSet: kernel: got     : {"0":"vatstoreGet","1":"vc.7.|o+11/5946","length":2}
2022-12-13T00:08:02.523Z SwingSet: kernel:   mitigation: ignoring extra vc syscall
```

Confirmed working on our own archival node.