### PR TITLE
fix: Factor out `defendPrototypeKit` with consolidated error checking

### DIFF
--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-use-before-define, jsdoc/require-returns-type */
 
 import { assert, Fail, q } from '@agoric/assert';
-import { defendPrototype } from '@agoric/store';
+import { objectMap } from '@agoric/internal';
+import { defendPrototype, defendPrototypeKit } from '@agoric/store';
 import { Far } from '@endo/marshal';
 import { parseVatSlot } from '../lib/parseVatSlots.js';
 
@@ -609,25 +610,14 @@ export function makeVirtualObjectManager(
       case 'many': {
         assert(multifaceted);
         facetNames = Object.getOwnPropertyNames(behavior).sort();
-        assert(
-          facetNames.length > 1,
-          'a multi-facet object must have multiple facets',
+        contextMapTemplate = objectMap(behavior, () => new WeakMap());
+        prototypeTemplate = defendPrototypeKit(
+          tag,
+          contextMapTemplate,
+          behavior,
+          thisfulMethods,
+          interfaceGuard,
         );
-        contextMapTemplate = {};
-        prototypeTemplate = {};
-        for (const name of facetNames) {
-          const contextMap = new WeakMap();
-          contextMapTemplate[name] = contextMap;
-          const prototype = defendPrototype(
-            `${tag} ${name}`,
-            contextMap,
-            behavior[name],
-            thisfulMethods,
-            // TODO some tool does not yet understand the `?.[` syntax
-            interfaceGuard && interfaceGuard[name],
-          );
-          prototypeTemplate[name] = prototype;
-        }
         break;
       }
       case 'not': {

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -56,6 +56,7 @@ export {
 
 export {
   defendPrototype,
+  defendPrototypeKit,
   initEmpty,
   defineHeapFarClass,
   defineHeapFarClassKit,

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -226,6 +226,49 @@ export const defendPrototype = (
 };
 harden(defendPrototype);
 
+/**
+ * @param {string} tag
+ * @param {Record<string, WeakMap>} contextMapKit
+ * @param {Record<string, Record<string | symbol, CallableFunction>>} behaviorMethodsKit
+ * @param {boolean} [thisfulMethods]
+ * @param {Record<string, InterfaceGuard>} [interfaceGuardKit]
+ */
+export const defendPrototypeKit = (
+  tag,
+  contextMapKit,
+  behaviorMethodsKit,
+  thisfulMethods = false,
+  interfaceGuardKit = undefined,
+) => {
+  const facetNames = ownKeys(behaviorMethodsKit).sort();
+  facetNames.length > 1 || Fail`A multi-facet object must have multiple facets`;
+  if (interfaceGuardKit) {
+    const interfaceNames = ownKeys(interfaceGuardKit);
+    const extraInterfaceNames = listDifference(facetNames, interfaceNames);
+    extraInterfaceNames.length === 0 ||
+      Fail`Interfaces ${q(extraInterfaceNames)} not implemented by ${q(tag)}`;
+    const extraFacetNames = listDifference(interfaceNames, facetNames);
+    extraFacetNames.length === 0 ||
+      Fail`Facets ${q(extraFacetNames)} of ${q(tag)} not guarded by interfaces`;
+  }
+  const contextMapNames = ownKeys(contextMapKit);
+  const extraContextNames = listDifference(facetNames, contextMapNames);
+  extraContextNames.length === 0 ||
+    Fail`Contexts ${q(extraContextNames)} not implemented by ${q(tag)}`;
+  const extraFacetNames = listDifference(contextMapNames, facetNames);
+  extraFacetNames.length === 0 ||
+    Fail`Facets ${q(extraFacetNames)} of ${q(tag)} missing contexts`;
+  return objectMap(behaviorMethodsKit, (behaviorMethods, facetName) =>
+    defendPrototype(
+      `${tag} ${facetName}`,
+      contextMapKit[facetName],
+      behaviorMethods,
+      thisfulMethods,
+      interfaceGuardKit && interfaceGuardKit[facetName],
+    ),
+  );
+};
+
 const emptyRecord = harden({});
 
 /**
@@ -315,26 +358,13 @@ export const defineHeapFarClassKit = (
   methodsKit,
   options = undefined,
 ) => {
-  const facetNames = ownKeys(methodsKit);
-  const interfaceNames = ownKeys(interfaceGuardKit);
-  const extraInterfaceNames = listDifference(facetNames, interfaceNames);
-  extraInterfaceNames.length === 0 ||
-    Fail`Interfaces ${q(extraInterfaceNames)} not implemented by ${q(tag)}`;
-  const extraFacetNames = listDifference(interfaceNames, facetNames);
-  extraFacetNames.length === 0 ||
-    Fail`Facets ${q(extraFacetNames)} of ${q(tag)} not guarded by interfaces`;
-
   const contextMapKit = objectMap(methodsKit, () => new WeakMap());
-  const prototypeKit = objectMap(methodsKit, (methods, facetName) =>
-    defendPrototype(
-      // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- different per package https://github.com/Agoric/agoric-sdk/issues/4620
-      // @ts-ignore could be symbol
-      `${tag} ${facetName}`,
-      contextMapKit[facetName],
-      methods,
-      true,
-      interfaceGuardKit[facetName],
-    ),
+  const prototypeKit = defendPrototypeKit(
+    tag,
+    contextMapKit,
+    methodsKit,
+    true,
+    interfaceGuardKit,
   );
   const makeInstanceKit = (...args) => {
     // Be careful not to freeze the state record


### PR DESCRIPTION
closes: #6656 
refs: #5997

https://github.com/Agoric/agoric-sdk/pull/6672 needs to go first, in order to fix the bug that this PR reveals. Until then, this PR fails in PR on this pre-existing but previously unknown bug. I'm declaring this Ready for Review anyway, assuming that #6672 has happened.

There is some redundant logic between the code of, for example, `defineHeapFarClass` and `defineVirtualFarClass`. But at some of that common logic had already been factored out into their shared `defendPrototype`, exported by the store package.

Similarly, there is some redundant logic between the code of, for example `defineHeapFarClassKit` and `defineVirtualFarClassKit`. Prior to the PR, that additional "kit" handling logic was not factored out. The error checks in the two locations diverged, with each one making checks not made in the others. #6656 was due to weak error checking in the `defineVirtualFarClassKit` pathway that was already adequately checked in `defineHeapFarClassKit`.

This PR factors out the additional common "kit" handling logic above `defendPrototype` into a shared `defendPrototypeKit`, consolidating the error checks to be a union of the errors checked from the original two locations. These consolidated error checks should close out #6656 .