### PR TITLE
fix: add missing facet interface

### DIFF
--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -2,7 +2,9 @@ import {
   AmountMath,
   AmountShape,
   BrandShape,
+  IssuerShape,
   PaymentShape,
+  PurseShape,
 } from '@agoric/ertp';
 import {
   makeStoredPublishKit,
@@ -205,18 +207,18 @@ export const initState = (unique, shared) => {
 };
 
 const behaviorGuards = {
-  // xxx updateBalance string not really optional. not exposed so okay to skip guards.
-  // helper: M.interface('helperFacetI', {
-  //   addBrand: M.call(
-  //     {
-  //       brand: BrandShape,
-  //       issuer: IssuerShape,
-  //       petname: M.string(),
-  //     },
-  //     PurseShape,
-  //   ).returns(M.promise()),
-  //   updateBalance: M.call(PurseShape, AmountShape, M.opt(M.string())).returns(),
-  // }),
+  helper: M.interface('helperFacetI', {
+    updateBalance: M.call(PurseShape, AmountShape).optional('init').returns(),
+    publishCurrentState: M.call().returns(),
+    addBrand: M.call(
+      {
+        brand: BrandShape,
+        issuer: M.eref(IssuerShape),
+        petname: M.string(),
+      },
+      PurseShape,
+    ).returns(M.promise()),
+  }),
   deposit: M.interface('depositFacetI', {
     receive: M.callWhen(M.await(M.eref(PaymentShape))).returns(AmountShape),
   }),


### PR DESCRIPTION
Fixes https://github.com/Agoric/agoric-sdk/issues/6675

Extracted from https://github.com/Agoric/agoric-sdk/pull/6670 . #6668 improves the error checking of *FarClassKit, which revealed a bug in SmartWallet -- a missing facet interface for the facet `helper`. #6670 fixes that bug on top of #6668 to see if the error report goes away. It is still in CI, but seems good so far. This PR is just that bug fix without #6668, since #6668 is not yet merged.

Blocks #6668 , since otherwise #6668 fails under CI, preventing its merge.