### PR TITLE
fix: replace unsafe then with E.when

### DIFF
--- a/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
@@ -1,5 +1,6 @@
 // import { Worker } from 'worker_threads'; // not from a Compartment
 import { assert, Fail } from '@agoric/assert';
+import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeManagerKit } from './manager-helper.js';
 
@@ -64,7 +65,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
 
     function sendToWorker(msg) {
       assert(msg instanceof Array);
-      void workerP.then(worker => worker.postMessage(msg));
+      E.when(workerP, worker => worker.postMessage(msg));
     }
 
     /** @type {PromiseKit<void>} */

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -1,6 +1,7 @@
 // import { spawn } from 'child_process'; // not from Compartment
 
 import { assert, Fail } from '@agoric/assert';
+import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeManagerKit } from './manager-helper.js';
 
@@ -105,7 +106,7 @@ export function makeNodeSubprocessFactory(tools) {
 
     function shutdown() {
       terminate();
-      return done.then(_ => undefined);
+      return E.when(done, _ => undefined);
     }
     const manager = mk.getManager(shutdown);
     return dispatchReadyP.then(() => manager);

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -7,7 +7,7 @@ import {
 import { assert, details as X, Fail } from '@agoric/assert';
 import { isNat } from '@agoric/nat';
 import { isPromise } from '@endo/promise-kit';
-import { HandledPromise } from '@endo/eventual-send';
+import { E, HandledPromise } from '@endo/eventual-send';
 import {
   insistVatType,
   makeVatSlot,
@@ -452,7 +452,7 @@ function build(
           Fail`mIPromise handler called after resolution`;
         }
         // FIXME: Actually pipeline.
-        return p.then(o => o[prop]);
+        return E.when(p, o => o[prop]);
       },
     };
 
@@ -1168,7 +1168,8 @@ function build(
       exportedVPIDs.delete(vpid);
     }
 
-    p.then(
+    E.when(
+      p,
       value => handle(false, value),
       value => handle(true, value),
     );

--- a/packages/SwingSet/src/liveslots/watchedPromises.js
+++ b/packages/SwingSet/src/liveslots/watchedPromises.js
@@ -3,6 +3,7 @@
 
 import { assert } from '@agoric/assert';
 import { initEmpty, M } from '@agoric/store';
+import { E } from '@endo/eventual-send';
 import { parseVatSlot } from '../lib/parseVatSlots.js';
 
 /**

--- a/packages/SwingSet/src/liveslots/watchedPromises.js
+++ b/packages/SwingSet/src/liveslots/watchedPromises.js
@@ -96,7 +96,8 @@ export function makeWatchedPromiseManager(
       }
     }
 
-    p.then(
+    E.when(
+      p,
       res => settle(res, true),
       rej => settle(rej, false),
     );

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -330,7 +330,7 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
     noteRunningVat(vatID);
 
     const adminNode = makeAdminNode(vatID);
-    return pendingP.then(root => {
+    return E.when(pendingP, root => {
       return { adminNode, root };
     });
   }

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -4,6 +4,7 @@ import process from 'node:process';
 import fs from 'node:fs';
 import { performance } from 'perf_hooks';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
+import { E } from '@endo/far';
 import engineGC from '@agoric/swingset-vat/src/lib-nodejs/engine-gc.js';
 import { waitUntilQuiescent } from '@agoric/swingset-vat/src/lib-nodejs/waitUntilQuiescent.js';
 import {
@@ -174,7 +175,8 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     }
     const action = JSON.parse(str);
     const p = Promise.resolve(handler(action));
-    p.then(
+    E.when(
+      p,
       res => {
         // console.error(`Replying in Node to ${str} with`, res);
         replier.resolve(stringify(res !== undefined ? res : null));

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -2,6 +2,7 @@
 /* eslint-disable @jessie.js/no-nested-await */
 import anylogger from 'anylogger';
 
+import { E } from '@endo/far';
 import {
   buildMailbox,
   buildMailboxStateMap,
@@ -580,7 +581,7 @@ export async function launch({
     const p = fn();
     // Just attach some callbacks, but don't use the resulting neutered result
     // promise.
-    p.then(finish, e => {
+    E.when(p, finish, e => {
       // None of these must fail, and if they do, log them verbosely before
       // returning to the chain.
       blockManagerConsole.error(type, 'error:', e);

--- a/packages/deploy-script-support/src/offer.js
+++ b/packages/deploy-script-support/src/offer.js
@@ -77,13 +77,13 @@ export const makeOfferAndFindInvitationAmount = (
       const allDepositedP = Promise.all(
         Object.entries(paymentsP).map(([keyword, paymentP]) => {
           const depositInPurse = makeDepositInPurse(keyword);
-          return paymentP.then(depositInPurse);
+          return E.when(paymentP, depositInPurse);
         }),
       );
       return allDepositedP;
     };
     const paymentsPP = E(seat).getPayouts();
-    return paymentsPP.then(handlePayments);
+    return E.when(paymentsPP, handlePayments);
   };
 
   /** @type {OfferHelper} */

--- a/packages/deploy-script-support/src/writeCoreProposal.js
+++ b/packages/deploy-script-support/src/writeCoreProposal.js
@@ -70,7 +70,7 @@ export const makeWriteCoreProposal = (
       }
 
       // Serialise the installations.
-      mutex = mutex.then(() => {
+      mutex = E.when(mutex, () => {
         console.log('installing', { filePrefix, entrypoint, bundlePath });
 
         return installInPieces(bundle, bundler, opts);

--- a/packages/inter-protocol/src/interchainPool.js
+++ b/packages/inter-protocol/src/interchainPool.js
@@ -100,7 +100,7 @@ export const start = (zcf, { bankManager }) => {
         proposal,
         seat2,
       );
-      return deposited.then(_ => {
+      return E.when(deposited, _ => {
         seat.exit();
         seat2.exit();
 

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -25,6 +25,7 @@
     "@agoric/assert": "^0.5.1",
     "@agoric/internal": "^0.2.1",
     "@agoric/store": "^0.8.1",
+    "@endo/eventual-send": "^0.16.8",
     "@endo/init": "^0.5.52",
     "@endo/stream": "^0.3.21",
     "@opentelemetry/api": "^1.0.0",

--- a/packages/telemetry/src/slog-file.js
+++ b/packages/telemetry/src/slog-file.js
@@ -1,5 +1,6 @@
 import { createWriteStream } from 'fs';
 import { open } from 'fs/promises';
+import { E } from '@endo/eventual-send';
 import { fsStreamReady, makeAggregateError } from '@agoric/internal';
 import { serializeSlogObj } from './serialize-slog-obj.js';
 
@@ -31,7 +32,8 @@ export const makeSlogSender = async ({ env: { SLOGFILE } = {} } = {}) => {
         }
       });
     });
-    flushed = flushed.then(
+    flushed = E.when(
+      flushed,
       () => written,
       async err =>
         Promise.reject(

--- a/packages/telemetry/src/slog-sender-pipe.js
+++ b/packages/telemetry/src/slog-sender-pipe.js
@@ -2,6 +2,7 @@ import { fork } from 'child_process';
 import path from 'path';
 import anylogger from 'anylogger';
 
+import { E } from '@endo/eventual-send';
 import { makeQueue } from '@endo/stream';
 
 import { makeShutdown } from './shutdown.js';
@@ -24,7 +25,7 @@ const withMutex = operation => {
   return async (...args) => {
     await mutex.get();
     const result = operation(...args);
-    mutex.put(result.then(() => {}));
+    mutex.put(E.when(result, () => {}));
     return result;
   };
 };

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -88,7 +88,7 @@ export const makeVatsFromBundles = async ({
         });
         return vatInfo;
       });
-      return vatInfoP.then(vatInfo => vatInfo.root);
+      return E.when(vatInfoP, vatInfo => vatInfo.root);
     };
   };
 

--- a/packages/vats/src/repl.js
+++ b/packages/vats/src/repl.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { isPromise } from '@endo/promise-kit';
-import { Far } from '@endo/far';
+import { E, Far } from '@endo/far';
 import * as farExports from '@endo/far';
 
 import { Nat } from '@agoric/nat';
@@ -253,7 +253,8 @@ export function getReplHandler(replObjects, send) {
 
       if (isPromise(r)) {
         display[histnum] = `unresolved Promise`;
-        r.then(
+        E.when(
+          r,
           res => {
             history[histnum] = res;
             display[histnum] = dump(res);

--- a/packages/vats/src/vat-provisioning.js
+++ b/packages/vats/src/vat-provisioning.js
@@ -50,7 +50,7 @@ export function buildRootObject() {
         );
         // Update the notifier when the chainBundle resolves.
         const { notifier, updater } = makeNotifierKit();
-        chainBundle.then(clientHome => {
+        E.when(chainBundle, clientHome => {
           updater.updateState(harden({ clientHome, clientAddress: address }));
         });
         return Far('emulatedClientFacet', {

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -120,7 +120,7 @@ function makeVirtualPurse(vpc, kit) {
     async receive(payment, optAmountShape = undefined) {
       if (isPromise(payment)) {
         throw TypeError(
-          `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: paymentPromise.then(actualPayment => deposit(actualPayment))`,
+          `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: E.when(paymentPromise, actualPayment => deposit(actualPayment))`,
         );
       }
 

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -474,7 +474,7 @@ export function makeWalletRoot({
         return;
       case 'accept':
         assert(idToOfferResultPromiseKit.has(id));
-        void idToOfferResultPromiseKit.get(id).promise.then(result => {
+        void E.when(idToOfferResultPromiseKit.get(id).promise, result => {
           const style = passStyleOf(result);
           const active =
             style === 'remotable' ||
@@ -845,7 +845,7 @@ export function makeWalletRoot({
       } else {
         p = Promise.resolve();
       }
-      return p.then(_ => petnameForBrand);
+      return E.when(p, _ => petnameForBrand);
     };
     return addBrandPetname().then(async brandName => {
       await updateAllIssuersState();

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -39,7 +39,7 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
   }
 
   function reallocateToSeat(seatPromise, seatPortion) {
-    seatPromise.then(seat => {
+    E.when(seatPromise, seat => {
       atomicTransfer(zcf, collateralSeat, seat, { Collateral: seatPortion });
       seat.exit();
       seatsExited += 1;


### PR DESCRIPTION
See https://github.com/endojs/endo/pull/1407

`val.then(` can be vulnerable to reentrancy by a "bad" `then` method, either because `val` is not a promise, or because it is a promise with an own `then` method overriding the `Promise.prototype.then` method.

`E.when` provides several advantages
   * it provides some protection against such reentrancy. (This protection is not perfect because of the `constructor` attack. With possible future changes to the language or platform, we may be able to address this, in which case we will upgrade `E.when` to provide this extra protection.)
   * It works even when `val` is properly described by the type `ERef<T>` rather than just `Promise<T>`. Thus, it is more equivalent to `Promise.resolve(val).then(`, but less verbose.
   * If we introduce non-thenable promise-likes, `E.when` will be generalized to work with those.

Alternatively, we're considering just generalizing the `E` function call behavior so that `E(val)` returns a safe non-promise thenable, in which case we'd replace all our `E.when(val, ...)` with `E(val).then(...)`. I agree this looks much prettier and we should switch to it. But switching to `E.when` in the meantime at least gives us a clearly marked starting point. (cc @mhofman that invented this prettier form)