### PR TITLE
fix(types): type assertion for assertAllDefined

### DIFF
--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -384,13 +384,18 @@ export const fsStreamReady = stream =>
   });
 
 /**
+ * @template {Record<string, unknown>} T
+ * @typedef {{[P in keyof T]: Exclude<T[P], undefined>;}} AllDefined
+ */
+
+/**
  * Concise way to check values are available from object literal shorthand.
  * Throws error message to specify the missing values.
  *
  * @template {Record<string, unknown>} T
  * @param {T} obj
  * @throws if any value in the object entries is not defined
- * @returns {asserts obj is Required<T>}
+ * @returns {asserts obj is AllDefined<T>}
  */
 
 export const assertAllDefined = obj => {

--- a/packages/internal/test/test-utils.js
+++ b/packages/internal/test/test-utils.js
@@ -68,13 +68,27 @@ test('makeMeasureSeconds', async t => {
 });
 
 test('assertAllDefined', t => {
-  /** @type {{s: string, m?: string | undefined}} */
+  /** @type {{ s: string, m: string | undefined, u?: string}} */
   const obj = { s: 'defined', m: 'maybe' };
   assertAllDefined(obj);
   // typecheck
   obj.m.length;
+  t.throws(
+    () =>
+      // @ts-expect-error key presence not checked
+      obj.u.length,
+  );
 
   t.throws(() => assertAllDefined({ u: undefined, v: undefined }), {
     message: 'missing ["u","v"]',
   });
+
+  /** @type {{ prop?: number }} */
+  const foo = {};
+  assertAllDefined(foo);
+  t.throws(
+    () =>
+      // @ts-expect-error key presence not checked
+      foo.prop.toFixed,
+  );
 });


### PR DESCRIPTION
## Description

@mhofman pointed out this problem:
```js
/** @type {{prop?: number}} */
const foo = {};

assertAllDefined(foo); // does not throw

assert(typeof foo.prop === 'number'); // throws but TS would claim it doesn't
```

The type assertion wasn't really necessary so this removes it.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

Updated unit test.
