### PR TITLE
refactor(agoric-cli): clarify flow of inputs to outputs in start.js (WIP)

### DIFF
--- a/packages/access-token/src/access-token.js
+++ b/packages/access-token/src/access-token.js
@@ -1,3 +1,4 @@
+// @ts-check
 import fs from 'fs';
 import crypto from 'crypto';
 import os from 'os';
@@ -5,13 +6,20 @@ import path from 'path';
 
 import { openJSONStore } from './json-store.js';
 
+const { freeze: harden } = Object; // IOU
+
 // Adapted from https://stackoverflow.com/a/43866992/14073862
-export function generateAccessToken({
-  stringBase = 'base64url',
-  byteLength = 48,
-} = {}) {
+export function generateAccessToken(
+  {
+    stringBase = /** @type {const} */ ('base64url'),
+    byteLength = 48,
+    randomBytes,
+  } = {
+    randomBytes: crypto.randomBytes,
+  },
+) {
   return new Promise((resolve, reject) =>
-    crypto.randomBytes(byteLength, (err, buffer) => {
+    randomBytes(byteLength, (err, buffer) => {
       if (err) {
         reject(err);
       } else if (stringBase === 'base64url') {
@@ -26,26 +34,61 @@ export function generateAccessToken({
   );
 }
 
+/**
+ * @param {string=} sharedStateDir
+ * @param {object} io
+ * @param {typeof fs} io.fs
+ */
+export const makeMyAgoricDir = (
+  sharedStateDir = path.join(os.homedir(), '.agoric'),
+  { fs: fsSync } = { fs },
+) => {
+  const {
+    promises: { mkdir },
+  } = fsSync;
+  return harden({
+    /**
+     * @param {string | number} port
+     * @param {object} io
+     * @param {typeof import('crypto').randomBytes} io.randomBytes
+     */
+    getAccessToken: async (
+      port,
+      { randomBytes } = { randomBytes: crypto.randomBytes },
+    ) => {
+      if (typeof port === 'string') {
+        const match = port.match(/^(.*:)?(\d+)$/);
+        if (match) {
+          port = match[2];
+        }
+      }
+
+      // Ensure we're protected with a unique accessToken for this basedir.
+      await mkdir(sharedStateDir, { mode: 0o700, recursive: true });
+
+      // TODO: pass fsSync IO access explicitly to makeJSONStore
+      // Ensure an access token exists.
+      const { storage, commit, close } = openJSONStore(sharedStateDir);
+      const accessTokenKey = `accessToken/${port}`;
+      const stored = storage.has(accessTokenKey);
+      const accessToken = await (stored
+        ? storage.get(accessTokenKey)
+        : generateAccessToken({ randomBytes }));
+      await (stored ||
+        (async () => {
+          storage.set(accessTokenKey, accessToken);
+          await commit();
+        })());
+      await close();
+      return accessToken;
+    },
+  });
+};
+
+/**
+ * @param {number|string} port
+ * @deprecated use makeMyAgoricDir for OCap Discipline
+ */
 export async function getAccessToken(port) {
-  if (typeof port === 'string') {
-    const match = port.match(/^(.*:)?(\d+)$/);
-    if (match) {
-      port = match[2];
-    }
-  }
-
-  // Ensure we're protected with a unique accessToken for this basedir.
-  const sharedStateDir = path.join(os.homedir(), '.agoric');
-  await fs.promises.mkdir(sharedStateDir, { mode: 0o700, recursive: true });
-
-  // Ensure an access token exists.
-  const { storage, commit, close } = openJSONStore(sharedStateDir);
-  const accessTokenKey = `accessToken/${port}`;
-  if (!storage.has(accessTokenKey)) {
-    storage.set(accessTokenKey, await generateAccessToken());
-    await commit();
-  }
-  const accessToken = storage.get(accessTokenKey);
-  await close();
-  return accessToken;
+  return makeMyAgoricDir().getAccessToken(port);
 }

--- a/packages/agoric-cli/src/entrypoint.js
+++ b/packages/agoric-cli/src/entrypoint.js
@@ -33,6 +33,7 @@ main(progname, rawArgs, {
   makeWebSocket,
   fs,
   fsSync: rawFs,
+  path,
   now: Date.now,
   os,
   process,

--- a/packages/agoric-cli/src/entrypoint.js
+++ b/packages/agoric-cli/src/entrypoint.js
@@ -32,6 +32,7 @@ main(progname, rawArgs, {
   stdout,
   makeWebSocket,
   fs,
+  fsSync: rawFs,
   now: Date.now,
   os,
   process,

--- a/packages/agoric-cli/src/init.js
+++ b/packages/agoric-cli/src/init.js
@@ -6,7 +6,9 @@ import { makePspawn } from './helpers.js';
 import '@endo/captp/src/types.js';
 import '@agoric/swingset-vat/exported.js';
 import '@agoric/swingset-vat/src/vats/network/types.js';
-import { Command } from 'commander';
+import commander from 'commander';
+
+const { Command } = commander;
 
 const DEFAULT_DAPP_TEMPLATE = 'dapp-fungible-faucet';
 const DEFAULT_DAPP_URL_BASE = 'https://github.com/Agoric/';
@@ -24,8 +26,8 @@ const gitURL = (relativeOrAbsoluteURL, base) => {
 
 export const makeInitCommand = () =>
   new Command('init')
-    .argument('<project>')
     .description('create a new Dapp directory named <project>')
+    .arguments('<project>')
     .option(
       '--dapp-template <name>',
       'use the template specified by <name>',

--- a/packages/agoric-cli/src/init.js
+++ b/packages/agoric-cli/src/init.js
@@ -6,6 +6,11 @@ import { makePspawn } from './helpers.js';
 import '@endo/captp/src/types.js';
 import '@agoric/swingset-vat/exported.js';
 import '@agoric/swingset-vat/src/vats/network/types.js';
+import { Command } from 'commander';
+
+const DEFAULT_DAPP_TEMPLATE = 'dapp-fungible-faucet';
+const DEFAULT_DAPP_URL_BASE = 'https://github.com/Agoric/';
+const DEFAULT_DAPP_BRANCH = undefined;
 
 // Use either an absolute template URL, or find it relative to DAPP_URL_BASE.
 const gitURL = (relativeOrAbsoluteURL, base) => {
@@ -16,6 +21,26 @@ const gitURL = (relativeOrAbsoluteURL, base) => {
   }
   return url.href;
 };
+
+export const makeInitCommand = () =>
+  new Command('init')
+    .argument('<project>')
+    .description('create a new Dapp directory named <project>')
+    .option(
+      '--dapp-template <name>',
+      'use the template specified by <name>',
+      DEFAULT_DAPP_TEMPLATE,
+    )
+    .option(
+      '--dapp-base <base-url>',
+      'find the template relative to <base-url>',
+      DEFAULT_DAPP_URL_BASE,
+    )
+    .option(
+      '--dapp-branch <branch>',
+      'use this branch instead of the repository HEAD',
+      DEFAULT_DAPP_BRANCH,
+    );
 
 export default async function initMain(_progname, rawArgs, priv, opts) {
   const { anylogger, spawn, fs } = priv;

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -15,17 +15,13 @@ import { makeMyAgoricDir } from '@agoric/access-token';
 import cosmosMain from './cosmos.js';
 import deployMain from './deploy.js';
 import publishMain from './main-publish.js';
-import initMain from './init.js';
+import initMain, { makeInitCommand } from './init.js';
 import installMain from './install.js';
 import setDefaultsMain from './set-defaults.js';
 import startMain from './start.js';
 import followMain from './follow.js';
 import { makeOpenCommand, makeTUI } from './open.js';
 import { makeWalletCommand } from './commands/wallet.js';
-
-const DEFAULT_DAPP_TEMPLATE = 'dapp-fungible-faucet';
-const DEFAULT_DAPP_URL_BASE = 'https://github.com/Agoric/';
-const DEFAULT_DAPP_BRANCH = undefined;
 
 const STAMP = '_agstate';
 
@@ -98,28 +94,12 @@ const main = async (progname, rawArgs, powers) => {
   );
   program.addCommand(makeOpenCommand({ opener, baseDir, tui, randomBytes }));
 
-  program
-    .command('init <project>')
-    .description('create a new Dapp directory named <project>')
-    .option(
-      '--dapp-template <name>',
-      'use the template specified by <name>',
-      DEFAULT_DAPP_TEMPLATE,
-    )
-    .option(
-      '--dapp-base <base-url>',
-      'find the template relative to <base-url>',
-      DEFAULT_DAPP_URL_BASE,
-    )
-    .option(
-      '--dapp-branch <branch>',
-      'use this branch instead of the repository HEAD',
-      DEFAULT_DAPP_BRANCH,
-    )
-    .action(async (project, cmd) => {
+  program.addComman(
+    makeInitCommand().action(async (project, cmd) => {
       const opts = { ...program.opts(), ...cmd.opts() };
       return initMain(progname, ['init', project], powers, opts).then(procExit);
-    });
+    }),
+  );
 
   program
     .command('set-defaults <program> <config-dir>')

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -57,12 +57,8 @@ const main = async (progname, rawArgs, powers) => {
     return true;
   }
 
-  function subMain(fn, args, options) {
-    return fn(progname, args, powers, options).then(
-      // This seems to be the only way to propagate the exit code.
-      code => process.exit(code || 0),
-    );
-  }
+  // This seems to be the only way to propagate the exit code.
+  const procExit = code => process.exit(code || 0);
 
   program.storeOptionsAsProperties(false);
 
@@ -87,7 +83,9 @@ const main = async (progname, rawArgs, powers) => {
     .description('client for an Agoric Cosmos chain')
     .action(async (command, cmd) => {
       const opts = { ...program.opts(), ...cmd.opts() };
-      return subMain(cosmosMain, ['cosmos', ...command], opts);
+      return cosmosMain(progname, ['cosmos', ...command], powers, opts).then(
+        procExit,
+      );
     });
 
   const { randomBytes } = crypto;
@@ -120,7 +118,7 @@ const main = async (progname, rawArgs, powers) => {
     )
     .action(async (project, cmd) => {
       const opts = { ...program.opts(), ...cmd.opts() };
-      return subMain(initMain, ['init', project], opts);
+      return initMain(progname, ['init', project], powers, opts).then(procExit);
     });
 
   program
@@ -153,7 +151,12 @@ const main = async (progname, rawArgs, powers) => {
     )
     .action(async (prog, configDir, cmd) => {
       const opts = { ...program.opts(), ...cmd.opts() };
-      return subMain(setDefaultsMain, ['set-defaults', prog, configDir], opts);
+      return setDefaultsMain(
+        progname,
+        ['set-defaults', prog, configDir],
+        powers,
+        opts,
+      ).then(procExit);
     });
 
   program
@@ -162,7 +165,12 @@ const main = async (progname, rawArgs, powers) => {
     .action(async (forceSdkVersion, cmd) => {
       await isNotBasedir();
       const opts = { ...program.opts(), ...cmd.opts() };
-      return subMain(installMain, ['install', forceSdkVersion], opts);
+      return installMain(
+        progname,
+        ['install', forceSdkVersion],
+        powers,
+        opts,
+      ).then(procExit);
     });
 
   program
@@ -236,7 +244,9 @@ const main = async (progname, rawArgs, powers) => {
     .option('-B, --bootstrap <config>', 'network bootstrap configuration')
     .action(async (pathSpecs, cmd) => {
       const opts = { ...program.opts(), ...cmd.opts() };
-      return subMain(followMain, ['follow', ...pathSpecs], opts);
+      return followMain(progname, ['follow', ...pathSpecs], powers, opts).then(
+        procExit,
+      );
     });
 
   const addRunOptions = cmd =>
@@ -270,7 +280,7 @@ const main = async (progname, rawArgs, powers) => {
       ),
   ).action(async (script, scriptArgs, cmd) => {
     const opts = { ...program.opts(), ...cmd.opts(), scriptArgs };
-    return subMain(deployMain, ['run', script], opts);
+    return deployMain(progname, ['run', script], powers, opts).then(procExit);
   });
 
   addRunOptions(
@@ -286,7 +296,9 @@ const main = async (progname, rawArgs, powers) => {
       ),
   ).action(async (scripts, cmd) => {
     const opts = { ...program.opts(), ...cmd.opts() };
-    return subMain(deployMain, ['deploy', ...scripts], opts);
+    return deployMain(progname, ['deploy', ...scripts], powers, opts).then(
+      procExit,
+    );
   });
 
   addRunOptions(
@@ -307,7 +319,9 @@ const main = async (progname, rawArgs, powers) => {
       .description('publish a bundle to a Cosmos chain'),
   ).action(async (bundles, cmd) => {
     const opts = { ...program.opts(), ...cmd.opts() };
-    return subMain(publishMain, ['publish', ...bundles], opts);
+    return publishMain(progname, ['publish', ...bundles], powers, opts).then(
+      procExit,
+    );
   });
 
   program.addCommand(await makeWalletCommand());
@@ -349,7 +363,12 @@ agoric start local-solo [portNum] [provisionPowers] - local solo VM
     .action(async (profile, args, cmd) => {
       await isNotBasedir();
       const opts = { ...program.opts(), ...cmd.opts() };
-      return subMain(startMain, ['start', profile, ...args], opts);
+      return startMain(
+        progname,
+        ['start', profile, ...args],
+        powers,
+        opts,
+      ).then(procExit);
     });
 
   // Throw an error instead of exiting directly.

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -30,6 +30,7 @@ const dirname = path.dirname(filename);
  * @param {typeof import('anylogger').default} powers.anylogger
  * @param {typeof import('fs/promises')} powers.fs
  * @param {typeof import('fs')} powers.fsSync
+ * @param {typeof import('path')} powers.path
  */
 const main = async (progname, rawArgs, powers) => {
   const { anylogger, fs, fsSync } = powers;

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -17,7 +17,7 @@ import deployMain from './deploy.js';
 import publishMain from './main-publish.js';
 import initMain, { makeInitCommand } from './init.js';
 import installMain from './install.js';
-import setDefaultsMain from './set-defaults.js';
+import setDefaultsMain, { makeSetDefaultsCommand } from './set-defaults.js';
 import startMain from './start.js';
 import followMain from './follow.js';
 import { makeOpenCommand, makeTUI } from './open.js';
@@ -94,42 +94,15 @@ const main = async (progname, rawArgs, powers) => {
   );
   program.addCommand(makeOpenCommand({ opener, baseDir, tui, randomBytes }));
 
-  program.addComman(
+  program.addCommand(
     makeInitCommand().action(async (project, cmd) => {
       const opts = { ...program.opts(), ...cmd.opts() };
       return initMain(progname, ['init', project], powers, opts).then(procExit);
     }),
   );
 
-  program
-    .command('set-defaults <program> <config-dir>')
-    .description('update the configuration files for <program> in <config-dir>')
-    .option(
-      '--enable-cors',
-      'open RPC and API endpoints to all cross-origin requests',
-      false,
-    )
-    .option(
-      '--export-metrics',
-      'open ports to export Prometheus metrics',
-      false,
-    )
-    .option(
-      '--import-from <dir>',
-      'import the exported configuration from <dir>',
-    )
-    .option(
-      '--persistent-peers <addrs>',
-      'set the config.toml p2p.persistent_peers value',
-      '',
-    )
-    .option('--seeds <addrs>', 'set the config.toml p2p.seeds value', '')
-    .option(
-      '--unconditional-peer-ids <ids>',
-      'set the config.toml p2p.unconditional_peer_ids value',
-      '',
-    )
-    .action(async (prog, configDir, cmd) => {
+  program.addCommand(
+    makeSetDefaultsCommand().action(async (prog, configDir, cmd) => {
       const opts = { ...program.opts(), ...cmd.opts() };
       return setDefaultsMain(
         progname,
@@ -137,7 +110,8 @@ const main = async (progname, rawArgs, powers) => {
         powers,
         opts,
       ).then(procExit);
-    });
+    }),
+  );
 
   program
     .command('install [force-sdk-version]')

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -208,41 +208,8 @@ const main = async (progname, rawArgs, powers) => {
 
   program.addCommand(await makeWalletCommand());
 
-  program
-    .command('start [profile] [args...]')
-    .description(
-      `\
-start an Agoric VM
-
-agoric start - runs the default profile (dev)
-agoric start dev -- [initArgs] - simulated chain and solo VM
-agoric start local-chain [portNum] -- [initArgs] - local chain
-agoric start local-solo [portNum] [provisionPowers] - local solo VM
-`,
-    )
-    .option('-d, --debug', 'run in JS debugger mode')
-    .option('--reset', 'clear all VM state before starting')
-    .option('--no-restart', 'do not actually start the VM')
-    .option('--pull', 'for Docker-based VM, pull the image before running')
-    .option('--rebuild', 'rebuild VM dependencies before running')
-    .option(
-      '--delay [seconds]',
-      'delay for simulated chain to process messages',
-    )
-    .option(
-      '--inspect [host[:port]]',
-      'activate inspector on host:port (default: "127.0.0.1:9229")',
-    )
-    .option(
-      '--inspect-brk [host[:port]]',
-      'activate inspector on host:port and break at start of script (default: "127.0.0.1:9229")',
-    )
-    .option(
-      '--wallet <package>',
-      'install the wallet from NPM package <package>',
-      '@agoric/wallet-frontend',
-    )
-    .action(async (profile, args, cmd) => {
+  program.addComman(
+    createStartCommand().action(async (profile, args, cmd) => {
       await isNotBasedir();
       const opts = { ...program.opts(), ...cmd.opts() };
       return startMain(
@@ -251,7 +218,8 @@ agoric start local-solo [portNum] [provisionPowers] - local solo VM
         powers,
         opts,
       ).then(procExit);
-    });
+    }),
+  );
 
   // Throw an error instead of exiting directly.
   program.exitOverride();

--- a/packages/agoric-cli/src/open.js
+++ b/packages/agoric-cli/src/open.js
@@ -1,23 +1,71 @@
-/* global process setInterval clearInterval */
-import opener from 'opener';
-
-import { getAccessToken } from '@agoric/access-token';
-
+// @ts-check
 import { assert, details as X } from '@agoric/assert';
+import { Command } from 'commander';
 
-export default async function walletMain(progname, rawArgs, powers, opts) {
-  const { anylogger, fs } = powers;
-  const console = anylogger('agoric:wallet');
+/**
+ * @typedef {{
+ *   repl: boolean | 'only',
+ *   browser: boolean,
+ *   hostport: string,
+ * }} OpenOpts
+ *
+ * @typedef {{
+ *   setInterval: typeof setInterval,
+ *   clearInterval: typeof clearInterval,
+ * }} Timer
+ *
+ * @typedef {ReturnType<typeof import('@agoric/access-token').makeMyAgoricDir>} MyAgoricDir
+ */
 
+/**
+ * @param {{
+ *   stdout: typeof process.stdout,
+ *   stderr: typeof process.stderr,
+ * }} stdio
+ * @param {Timer} timer
+ */
+export const makeTUI = ({ stdout, stderr }, { setInterval, clearInterval }) => {
+  return harden({
+    write: s => stdout.write(s),
+    writeErr: s => stderr.write(s),
+    /**
+     * @template T
+     *
+     * @param {string} msg
+     * @param {Promise<T>} job
+     * @param {number=} interval
+     */
+    progress: async (msg, job, interval = 1000) => {
+      stderr.write(msg);
+      const progressDot = '.';
+      const progressTimer = setInterval(
+        () => stderr.write(progressDot),
+        interval,
+      );
+
+      const result = await job;
+
+      clearInterval(progressTimer);
+      stderr.write('\n');
+      return result;
+    },
+  });
+};
+
+/**
+ * @param {OpenOpts} opts
+ * @param {object} io
+ * @param {ReturnType<typeof makeTUI>} io.tui
+ * @param {MyAgoricDir} io.baseDir
+ * @param {typeof import('opener')} io.opener
+ * @param {typeof import('crypto').randomBytes} io.randomBytes
+ */
+const open = async (opts, { tui, baseDir, opener, randomBytes }) => {
   let suffix;
   switch (opts.repl) {
-    case 'yes':
-    case 'true':
     case true:
       suffix = '';
       break;
-    case 'no':
-    case 'false':
     case false:
     case undefined:
       suffix = '/wallet/';
@@ -32,29 +80,57 @@ export default async function walletMain(progname, rawArgs, powers, opts) {
       );
   }
 
-  process.stderr.write(`Launching wallet...`);
-  const progressDot = '.';
-  const progressTimer = setInterval(
-    () => process.stderr.write(progressDot),
-    1000,
+  const walletAccessToken = await tui.progress(
+    `Launching wallet...`,
+    baseDir
+      .getAccessToken(opts.hostport, { randomBytes })
+      .catch(e => console.error(`Trying to fetch access token:`, e)),
   );
-
-  const walletAccessToken = await getAccessToken(opts.hostport, {
-    console,
-    fs,
-  }).catch(e => console.error(`Trying to fetch access token:`, e));
-
-  clearInterval(progressTimer);
-  process.stderr.write('\n');
 
   // Write out the URL and launch the web browser.
   const walletUrl = `http://${
     opts.hostport
   }${suffix}#accessToken=${encodeURIComponent(walletAccessToken)}`;
 
-  process.stdout.write(`${walletUrl}\n`);
+  tui.write(`${walletUrl}\n`);
   if (opts.browser) {
     const browser = opener(walletUrl);
+    // safe: terminal-control-flow
+    // eslint-disable-next-line @jessie.js/no-nested-await
     await new Promise(resolve => browser.on('exit', resolve));
   }
-}
+};
+
+/**
+ * @param {object} io
+ * @param {ReturnType<makeTUI>} io.tui
+ * @param {MyAgoricDir} io.baseDir
+ * @param {typeof import('opener')} io.opener
+ * @param {typeof import('crypto').randomBytes} io.randomBytes
+ */
+export const makeOpenCommand = ({ tui, baseDir, opener, randomBytes }) =>
+  new Command('open')
+    .description('launch the Agoric UI')
+    .option(
+      '--hostport <host:port>',
+      'host and port to connect to VM',
+      '127.0.0.1:8000',
+    )
+    .option('--no-browser', `just display the URL, don't open a browser`)
+    .option(
+      '--repl [yes | only | no]',
+      'whether to show the Read-eval-print loop [yes]',
+      value => {
+        /** @type { boolean | 'only' } */
+        const x = { yes: true, no: false, only: 'only' }[value];
+        assert(
+          x !== undefined,
+          X`--repl must be one of 'yes', 'no', or 'only'`,
+          TypeError,
+        );
+        return value;
+      },
+    )
+    .action((/** @type {OpenOpts} */ opts) =>
+      open(opts, { tui, opener, baseDir, randomBytes }),
+    );

--- a/packages/agoric-cli/src/set-defaults.js
+++ b/packages/agoric-cli/src/set-defaults.js
@@ -1,10 +1,43 @@
 import { basename } from 'path';
 import { Fail } from '@agoric/assert';
+import commander from 'commander';
 import {
   finishCosmosApp,
   finishTendermintConfig,
   finishCosmosGenesis,
 } from './chain-config.js';
+
+const { Command } = commander;
+
+export const makeSetDefaultsCommand = () =>
+  new Command('set-defaults')
+    .description('update the configuration files for <program> in <config-dir>')
+    .arguments('<program> <config-dir>')
+    .option(
+      '--enable-cors',
+      'open RPC and API endpoints to all cross-origin requests',
+      false,
+    )
+    .option(
+      '--export-metrics',
+      'open ports to export Prometheus metrics',
+      false,
+    )
+    .option(
+      '--import-from <dir>',
+      'import the exported configuration from <dir>',
+    )
+    .option(
+      '--persistent-peers <addrs>',
+      'set the config.toml p2p.persistent_peers value',
+      '',
+    )
+    .option('--seeds <addrs>', 'set the config.toml p2p.seeds value', '')
+    .option(
+      '--unconditional-peer-ids <ids>',
+      'set the config.toml p2p.unconditional_peer_ids value',
+      '',
+    );
 
 export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
   const { anylogger, fs } = powers;

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -1,3 +1,4 @@
+/* eslint-disable @jessie.js/no-nested-await */
 /* global process setTimeout */
 import chalk from 'chalk';
 import { createHash } from 'crypto';

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import { createHash } from 'crypto';
 import path from 'path';
 import { createRequire } from 'module';
+import { Command } from 'commander';
 
 import { Nat, isNat } from '@agoric/nat';
 
@@ -50,6 +51,41 @@ const CHAIN_PORT = process.env.CHAIN_PORT || 26657;
 const DEFAULT_NETCONFIG = 'https://testnet.agoric.net/network-config';
 
 const GAS_ADJUSTMENT = '1.2';
+
+export const createStartCommand = () =>
+  new Command('start [profile] [args...]')
+    .description(
+      `\
+start an Agoric VM
+
+agoric start - runs the default profile (dev)
+agoric start dev -- [initArgs] - simulated chain and solo VM
+agoric start local-chain [portNum] -- [initArgs] - local chain
+agoric start local-solo [portNum] [provisionPowers] - local solo VM
+`,
+    )
+    .option('-d, --debug', 'run in JS debugger mode')
+    .option('--reset', 'clear all VM state before starting')
+    .option('--no-restart', 'do not actually start the VM')
+    .option('--pull', 'for Docker-based VM, pull the image before running')
+    .option('--rebuild', 'rebuild VM dependencies before running')
+    .option(
+      '--delay [seconds]',
+      'delay for simulated chain to process messages',
+    )
+    .option(
+      '--inspect [host[:port]]',
+      'activate inspector on host:port (default: "127.0.0.1:9229")',
+    )
+    .option(
+      '--inspect-brk [host[:port]]',
+      'activate inspector on host:port and break at start of script (default: "127.0.0.1:9229")',
+    )
+    .option(
+      '--wallet <package>',
+      'install the wallet from NPM package <package>',
+      '@agoric/wallet-frontend',
+    );
 
 /**
  * Resolve after a delay in milliseconds.

--- a/packages/agoric-cli/test/test-start.js
+++ b/packages/agoric-cli/test/test-start.js
@@ -1,0 +1,126 @@
+/* eslint-disable no-await-in-loop */
+// @ts-check
+import '@endo/init/pre.js';
+import 'esm';
+import '@endo/init/debug.js';
+import anyTest from 'ava';
+
+import startMain from '../src/start.js';
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
+const test = anyTest;
+
+const makeTestContext = () => {
+  // eslint-disable-next-line no-undef
+  return { setTimeout };
+};
+
+test.before(async t => {
+  t.context = makeTestContext();
+});
+
+const setDefault = (m, k, d) => {
+  if (m.has(k)) return m.get(k);
+  m.set(k, d);
+  return d;
+};
+
+const makeDelay = setTimeout => ms =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
+const makeScenario = t => {
+  const logged = [];
+  const save =
+    level =>
+    (msg, ...args) => {
+      logged.push({ level, msg, args });
+    };
+  /** @type {typeof import('anylogger').default} */
+  // @ts-expect-error cast
+  const anylogger = name => {
+    const log = save('log');
+    Object.assign(log, {
+      log,
+      info: save('info'),
+      error: save('error'),
+      warn: save('warn'),
+    });
+    return log;
+  };
+
+  const myFiles = new Map(
+    Object.entries({
+      'node_modules/@agoric/solo': {},
+    }),
+  );
+
+  const anyStats = /** @type {any} */ ({});
+  /** @type {typeof import('fs/promises')} */
+  // @ts-expect-error cast
+  const fs = {
+    stat: async file =>
+      myFiles.has(file) ? anyStats : assert.fail('no such file'),
+  };
+
+  const running = new Map();
+  let topPid = 0;
+  /** @type {typeof import('child_process').spawn}  */
+  // @ts-expect-error cast
+  const spawn = (cmd, args, opts) => {
+    const cp = {
+      pid: (topPid += 1),
+      handlers: new Map(),
+      on: (eventName, handler) => {
+        t.log('on', eventName, cp.pid);
+        setDefault(cp.handlers, eventName, []).push(handler);
+      },
+    };
+    running.set(cp.pid, cp);
+    t.log('spawn', cp.pid, cmd, args);
+    return cp;
+  };
+  const runChildren = async (delay, dur = 250) => {
+    for (;;) {
+      await delay(dur);
+      // t.log('runChildren', running.size);
+      const { done, value: pid } = running.keys().next();
+      // eslint-disable-next-line no-continue
+      if (done) continue;
+      const cp = running.get(pid);
+      running.delete(pid);
+      for (const h of cp.handlers.get('exit')) {
+        t.log('exit', pid, h);
+        h(0);
+      }
+    }
+  };
+
+  /** @type {typeof import('process')} */
+  // @ts-expect-error cast
+  const process = {
+    on: (ev, h) => {
+      t.log('process.on', ev, h);
+      return process;
+    },
+  };
+
+  return { anylogger, logged, fs, myFiles, spawn, runChildren, process };
+};
+
+test('refactor1', async t => {
+  const progName = 'agoric';
+  const agoricOpts = { sdk: true, verbose: 0 };
+  const world = makeScenario(t);
+  const done = startMain(progName, [], world, { ...agoricOpts, restart: true });
+  world.runChildren(makeDelay(t.context.setTimeout), 50);
+  await done;
+  const expected = [
+    'initializing dev',
+    ' init dev ',
+    'setting sim chain',
+    'set-fake-chain',
+    'start',
+  ];
+  t.is(world.logged.length, expected.length);
+  expected.forEach((s, ix) => t.true(world.logged[ix].msg.includes(s)));
+});


### PR DESCRIPTION
This is very rough; I'm not sure how far I'll pursue it. Early feedback is welcome.

refs: #6687, #2160

## Description

While trying to remove `sim-behaviors.js` from `boot.js` (#6687), I re-discovered `argv.ROLE`. In trying to figure out whether we still use it, I struggled to read `packages/agoric-cli/src/start.js`. This is an attempt to take the one 700+ line function and refactor it to make clear what inputs are used where.

### Security Considerations

The result should obey ocap discipline (#2160).

### Documentation Considerations

It's not intended to have any user-visible impact.

### Testing Considerations

I started adding unit tests to confirm that the refactor preserves all relevant functionality.
