### PR TITLE
Zoe checks start args shapes

### DIFF
--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -4,7 +4,7 @@
  * Contract to make smart wallets.
  */
 
-import { assertAllDefined, BridgeId, WalletName } from '@agoric/internal';
+import { BridgeId, WalletName } from '@agoric/internal';
 import { fit, M, makeHeapFarInstance } from '@agoric/store';
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
@@ -22,6 +22,11 @@ export const privateArgsShape = harden(
     { bridgeManager: M.eref(M.any()) },
   ),
 );
+
+export const customTermsShape = harden({
+  agoricNames: M.not(M.undefined()),
+  board: M.not(M.undefined()),
+});
 
 /**
  * Provide a NameHub for this address and insert depositFacet only if not
@@ -73,7 +78,6 @@ export const publishDepositFacet = async (
  */
 export const start = async (zcf, privateArgs) => {
   const { agoricNames, board } = zcf.getTerms();
-  assertAllDefined({ agoricNames, board });
 
   const zoe = zcf.getZoeService();
   const { storageNode, bridgeManager } = privateArgs;

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -16,7 +16,7 @@ import { shape } from './typeGuards.js';
 // Ambient types. Needed only for dev but this does a runtime import.
 import '@agoric/vats/exported.js';
 
-const PrivateArgsShape = harden(
+export const privateArgsShape = harden(
   M.splitRecord(
     { storageNode: M.eref(M.any()) },
     { bridgeManager: M.eref(M.any()) },
@@ -72,7 +72,6 @@ export const publishDepositFacet = async (
  * }} privateArgs
  */
 export const start = async (zcf, privateArgs) => {
-  fit(harden(privateArgs), PrivateArgsShape);
   const { agoricNames, board } = zcf.getTerms();
   assertAllDefined({ agoricNames, board });
 

--- a/packages/smart-wallet/test/test-startWalletFactory.js
+++ b/packages/smart-wallet/test/test-startWalletFactory.js
@@ -1,0 +1,117 @@
+/* eslint-disable no-await-in-loop */
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+import { makeStorageNodeChild } from '@agoric/vats/src/lib-chainStorage.js';
+import { E } from '@endo/far';
+import path from 'path';
+import { makeMockTestSpace } from './supports.js';
+
+import '@agoric/vats/src/core/types.js';
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
+const test = anyTest;
+
+const makeTestContext = async () => {
+  // To debug, pass t.log instead of null logger
+  const log = () => null;
+  const { consume } = await makeMockTestSpace(log);
+  const { zoe } = consume;
+
+  // #region Installs
+  const pathname = new URL(import.meta.url).pathname;
+  const dirname = path.dirname(pathname);
+
+  const bundleCache = await unsafeMakeBundleCache('bundles/');
+  const bundle = await bundleCache.load(
+    `${dirname}/../src/walletFactory.js`,
+    'walletFactory',
+  );
+  /** @type {Promise<Installation<import('../src/walletFactory.js').start>>} */
+  const installation = E(zoe).install(bundle);
+  // #endregion
+
+  // copied from makeClientBanks()
+  const storageNode = await makeStorageNodeChild(
+    consume.chainStorage,
+    'wallet',
+  );
+
+  const bridgeManager = await consume.bridgeManager;
+
+  return {
+    consume,
+    bridgeManager,
+    installation,
+    storageNode,
+  };
+};
+
+test.before(async t => {
+  t.context = await makeTestContext();
+});
+
+test('customTermsShape', async t => {
+  const { consume, bridgeManager, installation, storageNode } = t.context;
+  const { agoricNames, board, zoe } = consume;
+  const privateArgs = { bridgeManager, storageNode };
+
+  // extra term
+  await t.throwsAsync(
+    E(zoe).startInstance(
+      installation,
+      {},
+      {
+        agoricNames,
+        board,
+        //   @ts-expect-error extra term
+        extra: board,
+      },
+      privateArgs,
+    ),
+    {
+      message:
+        '{"agoricNames":"[Promise]","board":"[Promise]","extra":"[Seen]"} - Must not have unexpected properties: ["extra"]',
+    },
+  );
+
+  // missing a term
+  await t.throwsAsync(
+    E(zoe).startInstance(
+      installation,
+      {},
+      //   @ts-expect-error missing 'board'
+      {
+        agoricNames,
+      },
+      privateArgs,
+    ),
+    {
+      message:
+        '{"agoricNames":"[Promise]"} - Must have missing properties ["board"]',
+    },
+  );
+});
+
+test('privateArgsShape', async t => {
+  const { consume, bridgeManager, installation } = t.context;
+  const { agoricNames, board, zoe } = consume;
+  const terms = {
+    agoricNames,
+    board,
+  };
+
+  // missing an arg
+  await t.throwsAsync(
+    E(zoe).startInstance(
+      installation,
+      {},
+      terms,
+      // @ts-expect-error bridgeManager optional but storageNode required
+      { bridgeManager },
+    ),
+    {
+      message: '{} - Must have missing properties ["storageNode"]',
+    },
+  );
+});

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -127,7 +127,6 @@ export const startWalletFactory = async (
       board,
       bridgeManager: bridgeManagerP,
       chainStorage,
-      namesByAddress,
       namesByAddressAdmin: namesByAddressAdminP,
       zoe,
       chainTimerService,
@@ -187,7 +186,6 @@ export const startWalletFactory = async (
   const terms = await deeplyFulfilled(
     harden({
       agoricNames,
-      namesByAddress,
       board,
     }),
   );
@@ -271,7 +269,6 @@ export const WALLET_FACTORY_MANIFEST = {
       board: 'board',
       bridgeManager: true,
       chainStorage: 'chainStorage',
-      namesByAddress: true,
       namesByAddressAdmin: true,
       zoe: 'zoe',
       chainTimerService: 'timer',

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -149,78 +149,6 @@ export const makeZCFZygote = async (
     return zcfMintFactory.makeZCFMintInternal(keyword, zoeMint);
   };
 
-  /** @type {ZCF} */
-  // Using Remotable rather than Far because there are too many complications
-  // imposing checking wrappers: makeInvitation() and setJig() want to
-  // accept raw functions. assert cannot be a valid passable! (It's a function
-  // and has members.)
-  const zcf = Remotable('Alleged: zcf', undefined, {
-    reallocate: (...seats) => seatManager.reallocate(...seats),
-    assertUniqueKeyword,
-    saveIssuer: async (issuerP, keyword) => {
-      // TODO: The checks of the keyword for uniqueness are
-      // duplicated. Assess how waiting on promises to resolve might
-      // affect those checks and see if one can be removed.
-      assertUniqueKeyword(keyword);
-      const record = await E(zoeInstanceAdmin).saveIssuer(issuerP, keyword);
-      // AWAIT ///
-      recordIssuer(keyword, record);
-      return record;
-    },
-    makeInvitation: (
-      offerHandler,
-      description,
-      customProperties = harden({}),
-      proposalShape = undefined,
-    ) => {
-      typeof description === 'string' ||
-        Fail`invitations must have a description string: ${description}`;
-
-      offerHandler || Fail`offerHandler must be provided`;
-
-      if (proposalShape !== undefined) {
-        assertPattern(proposalShape);
-      }
-
-      const invitationHandle = storeOfferHandler(offerHandler);
-      const invitationP = E(zoeInstanceAdmin).makeInvitation(
-        invitationHandle,
-        description,
-        customProperties,
-        proposalShape,
-      );
-      return invitationP;
-    },
-    // Shutdown the entire vat and give payouts
-    shutdown: completion => {
-      E(zoeInstanceAdmin).exitAllSeats(completion);
-      seatManager.dropAllReferences();
-      powers.exitVat(completion);
-    },
-    shutdownWithFailure,
-    stopAcceptingOffers: () => E(zoeInstanceAdmin).stopAcceptingOffers(),
-    makeZCFMint,
-    registerFeeMint,
-    makeEmptySeatKit,
-
-    // The methods below are pure and have no side-effects //
-    getZoeService: () => zoeService,
-    getInvitationIssuer: () => invitationIssuer,
-    getTerms,
-    getBrandForIssuer,
-    getIssuerForBrand,
-    getAssetKind: getAssetKindByBrand,
-    /** @type {SetTestJig} */
-    setTestJig: (testFn = () => ({})) => {
-      if (testJigSetter) {
-        testJigSetter({ ...testFn(), zcf });
-      }
-    },
-    getInstance: () => getInstanceRecord().instance,
-    setOfferFilter: strings => E(zoeInstanceAdmin).setOfferFilter(strings),
-    getOfferFilter: () => E(zoeInstanceAdmin).getOfferFilter(),
-  });
-
   const HandleOfferShape = M.remotable('HandleOffer');
 
   // handleOfferObject gives Zoe the ability to notify ZCF when a new seat is
@@ -292,6 +220,78 @@ export const makeZCFZygote = async (
   !start ||
     !vivify ||
     Fail`contract must provide exactly one of "start" and "vivify"`;
+
+  /** @type {ZCF} */
+  // Using Remotable rather than Far because there are too many complications
+  // imposing checking wrappers: makeInvitation() and setJig() want to
+  // accept raw functions. assert cannot be a valid passable! (It's a function
+  // and has members.)
+  const zcf = Remotable('Alleged: zcf', undefined, {
+    reallocate: (...seats) => seatManager.reallocate(...seats),
+    assertUniqueKeyword,
+    saveIssuer: async (issuerP, keyword) => {
+      // TODO: The checks of the keyword for uniqueness are
+      // duplicated. Assess how waiting on promises to resolve might
+      // affect those checks and see if one can be removed.
+      assertUniqueKeyword(keyword);
+      const record = await E(zoeInstanceAdmin).saveIssuer(issuerP, keyword);
+      // AWAIT ///
+      recordIssuer(keyword, record);
+      return record;
+    },
+    makeInvitation: (
+      offerHandler,
+      description,
+      customProperties = harden({}),
+      proposalShape = undefined,
+    ) => {
+      typeof description === 'string' ||
+        Fail`invitations must have a description string: ${description}`;
+
+      offerHandler || Fail`offerHandler must be provided`;
+
+      if (proposalShape !== undefined) {
+        assertPattern(proposalShape);
+      }
+
+      const invitationHandle = storeOfferHandler(offerHandler);
+      const invitationP = E(zoeInstanceAdmin).makeInvitation(
+        invitationHandle,
+        description,
+        customProperties,
+        proposalShape,
+      );
+      return invitationP;
+    },
+    // Shutdown the entire vat and give payouts
+    shutdown: completion => {
+      E(zoeInstanceAdmin).exitAllSeats(completion);
+      seatManager.dropAllReferences();
+      powers.exitVat(completion);
+    },
+    shutdownWithFailure,
+    stopAcceptingOffers: () => E(zoeInstanceAdmin).stopAcceptingOffers(),
+    makeZCFMint,
+    registerFeeMint,
+    makeEmptySeatKit,
+
+    // The methods below are pure and have no side-effects //
+    getZoeService: () => zoeService,
+    getInvitationIssuer: () => invitationIssuer,
+    getTerms,
+    getBrandForIssuer,
+    getIssuerForBrand,
+    getAssetKind: getAssetKindByBrand,
+    /** @type {SetTestJig} */
+    setTestJig: (testFn = () => ({})) => {
+      if (testJigSetter) {
+        testJigSetter({ ...testFn(), zcf });
+      }
+    },
+    getInstance: () => getInstanceRecord().instance,
+    setOfferFilter: strings => E(zoeInstanceAdmin).setOfferFilter(strings),
+    getOfferFilter: () => E(zoeInstanceAdmin).getOfferFilter(),
+  });
 
   // snapshot zygote here //////////////////
   // the zygote object below will be created now, but its methods won't be

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -2,7 +2,7 @@ import { E } from '@endo/eventual-send';
 import { passStyleOf, Remotable } from '@endo/marshal';
 import { AssetKind } from '@agoric/ertp';
 import { makePromiseKit } from '@endo/promise-kit';
-import { assertPattern } from '@agoric/store';
+import { assertPattern, fit } from '@agoric/store';
 import {
   canBeDurable,
   M,
@@ -281,7 +281,8 @@ export const makeZCFZygote = async (
     return evalContractBundle(bundle);
   };
   // evaluate the contract (either the first version, or an upgrade)
-  const { start, buildRootObject, vivify } = await evaluateContract();
+  const { start, buildRootObject, privateArgsShape, customTermsShape, vivify } =
+    await evaluateContract();
 
   if (start === undefined && vivify === undefined) {
     buildRootObject === undefined ||
@@ -343,6 +344,9 @@ export const makeZCFZygote = async (
       instantiateIssuerStorage(issuerStorageFromZoe);
 
       const startFn = start || vivify;
+      if (privateArgsShape) {
+        fit(privateArgs, privateArgsShape);
+      }
       // start a contract for the first time
       return E.when(
         startFn(zcf, privateArgs, contractBaggage),


### PR DESCRIPTION
## Description

When configuring contract manifests, it helps to have diagnostics on missing or invalid parameters. https://github.com/Agoric/agoric-sdk/pull/6651 was a light improvement for that.

This PR makes it part of Zoe to validate parameters before calling the `start` (or `vivify`) function.


### Security Considerations

Improves boundary checking

### Documentation Considerations

https://github.com/Agoric/documentation/issues/743

### Testing Considerations

CI, new tests