### PR TITLE
feat(vats): publish vbank asset list with agoricNames

### DIFF
--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -355,7 +355,13 @@ harden(mintInitialSupply);
  * }} powers
  */
 export const addBankAssets = async ({
-  consume: { initialSupply, bridgeManager, loadCriticalVat, zoe },
+  consume: {
+    agoricNamesAdmin,
+    initialSupply,
+    bridgeManager,
+    loadCriticalVat,
+    zoe,
+  },
   produce: { bankManager, bldIssuerKit },
   installation: {
     consume: { mintHolder },
@@ -385,8 +391,13 @@ export const addBankAssets = async ({
   const bldKit = { mint: bldMint, issuer: bldIssuer, brand: bldBrand };
   bldIssuerKit.resolve(bldKit);
 
+  const assetAdmin = E(agoricNamesAdmin).lookupAdmin('vbankAsset');
+  const nameUpdater = Far('AssetHub', {
+    update: (name, val) => E(assetAdmin).update(name, val),
+  });
   const bankMgr = await E(E(loadCriticalVat)('bank')).makeBankManager(
     bridgeManager,
+    nameUpdater,
   );
   bankManager.resolve(bankMgr);
 

--- a/packages/vats/src/core/boot-psm.js
+++ b/packages/vats/src/core/boot-psm.js
@@ -63,6 +63,10 @@ export const agoricNamesReserved = harden(
       [Stable.symbol]: Stable.proposedName,
       AUSD: 'Agoric bridged USDC',
     },
+    vbankAsset: {
+      [Stake.symbol]: Stake.proposedName,
+      [Stable.symbol]: Stable.proposedName,
+    },
     oracleBrand: {
       USD: 'US Dollar',
     },

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -184,6 +184,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
   },
   [addBankAssets.name]: {
     consume: {
+      agoricNamesAdmin: true,
       initialSupply: true,
       bridgeManager: true,
       // TODO: re-org loadCriticalVat to be subject to permits

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -31,6 +31,10 @@ export const agoricNamesReserved = harden({
     Attestation: 'Agoric lien attestation',
     AUSD: 'Agoric bridged USDC',
   },
+  vbankAsset: {
+    [Stake.denom]: Stake.proposedName,
+    [Stable.denom]: Stable.proposedName,
+  },
   installation: {
     centralSupply: 'central supply',
     mintHolder: 'mint holder',


### PR DESCRIPTION
closes: #5762
refs: https://github.com/Agoric/dapp-inter/issues/9

## Description

 - add a `vbankAsset` entry in `agoricNames`
 - add an entry under it for each `addAsset()` call that maps `denom` to  `{ brand, issuer, issuerName, denom, proposedName, displayInfo }`
   - provided the optional `nameAdmin` arg to `makeBankManager()` is present

### Security Considerations

claim for review: the only objects we're publishing here are brands and issuers.

### Documentation Considerations

our docs on chainStorage keys / paths are kinda scattered. _I suppose we can consider that in scope of #6111 rather than here._

### Testing Considerations

tested manually with `make scenario2-run-chain`, and that before adding `displayInfo` support.

```
$ agoric follow :published.agoricNames.vbankAsset
...
[
  [
    "ubld",
    {
      brand: slot(0,"Alleged: BLD brand"),
      issuer: slot(1,"Alleged: BLD issuer"),
      issuerName: "BLD",
      proposedName: "Agoric staking token",
    },
  ],
  [
    "uist",
    {
      brand: slot(2,"Alleged: IST brand"),
      issuer: slot(3,"Alleged: IST issuer"),
      issuerName: "IST",
      proposedName: "Agoric stable local currency",
    },
  ],
]
```
