### PR TITLE
fix(types): ZoeService

### DIFF
--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -66,7 +66,7 @@ const makeTestContext = async () => {
     bundleCache.load(src, dest).then(b => E(zoe).install(b));
   const installation = {
     mintHolder: install(contractRoots.mintHolder, 'mintHolder'),
-    /** @type {Installation<import('@agoric/vats/src/centralSupply.js').start>} */
+    /** @type {Promise<Installation<import('@agoric/vats/src/centralSupply.js').start>>} */
     centralSupply: E(zoe).install(centralSupplyBundle),
     econCommitteeCharter: install(
       contractRoots.econCommitteeCharter,

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -12,7 +12,7 @@ import { Far } from '@endo/marshal';
  * anything in `give` and `want`. The amount in `give` will be returned, and
  * `want` will be ignored.
  *
- * @param {ZCF} zcf
+ * @param {ZCF<{}>} zcf
  */
 const start = zcf => {
   let offersCount = 0n;

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -49,7 +49,7 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
  * @param {{
  * marshaller: Marshaller,
  * quoteMint?: ERef<Mint<'set'>>,
- * storageNode: StorageNode,
+ * storageNode: ERef<StorageNode>,
  * }} privateArgs
  */
 const start = async (zcf, privateArgs) => {

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -71,7 +71,7 @@ type StartContractInstance<C> = (
 
 /** The result of `startInstance` */
 export type StartedInstanceKit<SF> = {
-  instance: Instance;
+  instance: Instance<SF>;
   adminFacet: AdminFacet;
 } & Awaited<ReturnType<SF>>;
 

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -116,6 +116,7 @@ const makeZoeKit = (
     ZoeServiceIKit,
     dataAccess => ({ dataAccess }),
     {
+      /** @type {ZoeService} */
       zoeService: {
         install(bundleId) {
           const { state } = this;

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -118,6 +118,7 @@ test.before('setup aggregator and oracles', async t => {
   /** @type {Installation<import('../../../src/contracts/oracle.js').OracleStart>} */
   const oracleInstallation = await E(zoe).installBundleID('b1-oracle');
   vatAdminState.installBundle('b1-aggregator', aggregatorBundle);
+  /** @type {Installation<import('../../../src/contracts/priceAggregator.js').start>} */
   const aggregatorInstallation = await E(zoe).installBundleID('b1-aggregator');
 
   const link = makeIssuerKit('$ATOM');
@@ -185,8 +186,7 @@ test.before('setup aggregator and oracles', async t => {
         storageNode: E(storageNode).makeChildNode('ATOM-USD_price_feed'),
       },
     );
-    aggregator.mockStorageRoot = storageRoot;
-    return aggregator;
+    return { ...aggregator, mockStorageRoot: storageRoot };
   };
   t.context.zoe = zoe;
   t.context.makeFakePriceOracle = makeFakePriceOracle;

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
@@ -77,6 +76,8 @@ test.before(
       /** @type {OracleHandler} */
       const oracleHandler = Far('OracleHandler', {
         async onQuery({ increment }, _fee) {
+          assert(valueOut);
+          assert(increment);
           valueOut += increment;
           return harden({
             reply: `${valueOut}`,

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -25,26 +25,6 @@ export const setup = () => {
   /** @type {<K extends AssetKind>(brand: Brand<K>) => (value: any) => Amount<K>} */
   const makeSimpleMake = brand => value => AmountMath.make(brand, value);
 
-  /**
-   * @typedef {object} BasicMints
-   * @property {Issuer<'nat'>} moolaIssuer
-   * @property {Mint<'nat'>} moolaMint
-   * @property {IssuerKit<'nat'>} moolaKit
-   * @property {Issuer<'nat'>} simoleanIssuer
-   * @property {Mint<'nat'>} simoleanMint
-   * @property {IssuerKit<'nat'>} simoleanKit
-   * @property {Issuer<'nat'>} bucksIssuer
-   * @property {Mint<'nat'>} bucksMint
-   * @property {IssuerKit<'nat'>} bucksKit
-   * @property {Store<string, Brand<'nat'>>} brands
-   * @property {(value: NatValue) => Amount<'nat'>} moola
-   * @property {(value: NatValue) => Amount<'nat'>} simoleans
-   * @property {(value: NatValue) => Amount<'nat'>} bucks
-   * @property {ZoeService} zoe
-   * @property {*} vatAdminState
-   */
-
-  /** @type {BasicMints} */
   const result = {
     moolaIssuer: moolaKit.issuer,
     moolaMint: moolaKit.mint,

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -199,8 +199,13 @@ test(`E(zoe).getPublicFacet`, async t => {
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
   vatAdminState.installBundle('b1-refund', bundle);
+  /** @type {Installation<import('@agoric/zoe/src/contracts/automaticRefund').start>} */
   const installation = await E(zoe).installBundleID('b1-refund');
   const { publicFacet, instance } = await E(zoe).startInstance(installation);
+  t.throwsAsync(() =>
+    // @ts-expect-error not on public facet
+    E(publicFacet).missingMethod(),
+  );
   const offersCount = await E(publicFacet).getOffersCount();
   t.is(offersCount, 0n);
   t.is(await E(zoe).getPublicFacet(instance), publicFacet);
@@ -316,6 +321,7 @@ test(`zoe.getTerms`, async t => {
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
   vatAdminState.installBundle('b1-refund', bundle);
+  /** @type {Installation<import('@agoric/zoe/src/contracts/automaticRefund').start>} */
   const installation = await E(zoe).installBundleID('b1-refund');
   const { instance } = await E(zoe).startInstance(
     installation,
@@ -328,6 +334,8 @@ test(`zoe.getTerms`, async t => {
   );
 
   const zoeTerms = await E(zoe).getTerms(instance);
+  // @ts-expect-error not a term of the contract
+  t.is(zoeTerms.invalid, undefined);
 
   const expected = {
     issuers: {
@@ -382,6 +390,7 @@ test(`zoe.getInstance`, async t => {
 
 test(`zoe.getInstance - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
+  // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInstance(), {
     message:
       'In "getInstance" method of (ZoeService zoeService): Expected at least 1 arguments: []',


### PR DESCRIPTION
## Description

https://github.com/Agoric/agoric-sdk/pull/5997 refactored the `zoe` service construction in a way that lost the `ZoeService` type annotation. This was hidden in part because the unit tests had their own `ZoeService` annotation.

This PR refactors the annotation so tests get it from the application code. It also adds more test cases to cover the type info being present by explicitly expecting type errors that will throw if the type regresses to `any`.

### Security Considerations

n/a
### Documentation Considerations

n/a

### Testing Considerations

CI