### PR TITLE
refactor: use Fail template tag in ERTP and zoe

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -6,7 +6,7 @@ import { setMathHelpers } from './mathHelpers/setMathHelpers.js';
 import { copySetMathHelpers } from './mathHelpers/copySetMathHelpers.js';
 import { copyBagMathHelpers } from './mathHelpers/copyBagMathHelpers.js';
 
-const { details: X, quote: q } = assert;
+const { quote: q, Fail } = assert;
 
 /**
  * Constants for the kinds of assets we support.
@@ -27,9 +27,7 @@ const assetKindNames = harden(Object.values(AssetKind).sort());
  */
 const assertAssetKind = allegedAK => {
   assetKindNames.includes(allegedAK) ||
-    assert.fail(
-      X`The assetKind ${allegedAK} must be one of ${q(assetKindNames)}`,
-    );
+    Fail`The assetKind ${allegedAK} must be one of ${q(assetKindNames)}`;
 };
 harden(assertAssetKind);
 
@@ -101,14 +99,14 @@ const assertValueGetAssetKind = value => {
     // @ts-expect-error cast
     return 'copyBag';
   }
-  assert.fail(
-    // TODO This isn't quite the right error message, in case valuePassStyle
-    // is 'tagged'. We would need to distinguish what kind of tagged
-    // object it is.
-    // Also, this kind of manual listing is a maintenance hazard we
-    // (TODO) will encounter when we extend the math helpers further.
-    X`value ${value} must be a bigint, copySet, copyBag, or an array, not ${passStyle}`,
-  );
+  // TODO This isn't quite the right error message, in case valuePassStyle
+  // is 'tagged'. We would need to distinguish what kind of tagged
+  // object it is.
+  // Also, this kind of manual listing is a maintenance hazard we
+  // (TODO) will encounter when we extend the math helpers further.
+  throw Fail`value ${value} must be a bigint, copySet, copyBag, or an array, not ${q(
+    passStyle,
+  )}`;
 };
 
 /**
@@ -129,11 +127,10 @@ export const assertValueGetHelpers = value =>
 const optionalBrandCheck = (allegedBrand, brand) => {
   if (brand !== undefined) {
     assertRemotable(brand, 'brand');
-    assert.equal(
-      allegedBrand,
-      brand,
-      X`amount's brand ${allegedBrand} did not match expected brand ${brand}`,
-    );
+    allegedBrand === brand ||
+      Fail`amount's brand ${q(allegedBrand)} did not match expected brand ${q(
+        brand,
+      )}`;
   }
 };
 
@@ -153,18 +150,14 @@ const checkLRAndGetHelpers = (leftAmount, rightAmount, brand = undefined) => {
   assertRemotable(rightBrand, 'rightBrand');
   optionalBrandCheck(leftBrand, brand);
   optionalBrandCheck(rightBrand, brand);
-  assert.equal(
-    leftBrand,
-    rightBrand,
-    X`Brands in left ${leftBrand} and right ${rightBrand} should match but do not`,
-  );
+  leftBrand === rightBrand ||
+    Fail`Brands in left ${q(leftBrand)} and right ${q(
+      rightBrand,
+    )} should match but do not`;
   const leftHelpers = assertValueGetHelpers(leftValue);
   const rightHelpers = assertValueGetHelpers(rightValue);
-  assert.equal(
-    leftHelpers,
-    rightHelpers,
-    X`The left ${leftAmount} and right amount ${rightAmount} had different assetKinds`,
-  );
+  leftHelpers === rightHelpers ||
+    Fail`The left ${leftAmount} and right amount ${rightAmount} had different assetKinds`;
   return leftHelpers;
 };
 
@@ -219,9 +212,7 @@ const AmountMath = {
     assertRecord(allegedAmount, 'amount');
     const { brand: allegedBrand, value: allegedValue } = allegedAmount;
     brand === allegedBrand ||
-      assert.fail(
-        X`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the specified brand ${brand}.`,
-      );
+      Fail`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the specified brand ${brand}.`;
     // Will throw on inappropriate value
     return AmountMath.make(brand, allegedValue);
   },

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -1,4 +1,4 @@
-import { assert, details as X } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import { fit } from '@agoric/store';
 
 import { DisplayInfoShape } from './typeGuards.js';
@@ -13,17 +13,13 @@ export const coerceDisplayInfo = (allegedDisplayInfo, assetKind) => {
 
   if (allegedDisplayInfo.assetKind !== undefined) {
     allegedDisplayInfo.assetKind === assetKind ||
-      assert.fail(
-        X`displayInfo.assetKind was present (${allegedDisplayInfo.assetKind}) and did not match the assetKind argument (${assetKind})`,
-      );
+      Fail`displayInfo.assetKind was present (${allegedDisplayInfo.assetKind}) and did not match the assetKind argument (${assetKind})`;
   }
   const displayInfo = harden({ ...allegedDisplayInfo, assetKind });
 
   if (displayInfo.decimalPlaces !== undefined) {
     Number.isSafeInteger(displayInfo.decimalPlaces) ||
-      assert.fail(
-        X`decimalPlaces ${displayInfo.decimalPlaces} is not a safe integer`,
-      );
+      Fail`decimalPlaces ${displayInfo.decimalPlaces} is not a safe integer`;
   }
 
   return displayInfo;

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -2,7 +2,7 @@ import { Nat, isNat } from '@agoric/nat';
 
 import '../types-ambient.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 const empty = 0n;
 
 /**
@@ -21,7 +21,7 @@ export const natMathHelpers = harden({
   doCoerce: nat => {
     // TODO: tighten the definition of Nat in @agoric/nat to throw on `number`
     assert.typeof(nat, 'bigint');
-    assert(isNat(nat), X`value ${nat} must be a natural number`);
+    isNat(nat) || Fail`value ${nat} must be a natural number`;
     return Nat(nat);
   },
   doMakeEmpty: () => empty,

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -15,7 +15,7 @@ import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
-const { details: X, quote: q } = assert;
+const { details: X, quote: q, Fail } = assert;
 
 const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
   let valueShape;
@@ -23,9 +23,7 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
     case 'nat': {
       valueShape = M.nat();
       elementShape === undefined ||
-        assert.fail(
-          X`Fungible assets cannot have an elementShape: ${q(elementShape)}`,
-        );
+        Fail`Fungible assets cannot have an elementShape: ${q(elementShape)}`;
       break;
     }
     case 'set': {
@@ -53,7 +51,7 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
       break;
     }
     default: {
-      assert.fail(X`unexpected asset kind ${q(assetKind)}`);
+      Fail`unexpected asset kind ${q(assetKind)}`;
     }
   }
 
@@ -230,11 +228,9 @@ export const vivifyPaymentLedger = (
    */
   const assertLivePayment = payment => {
     paymentLedger.has(payment) ||
-      assert.fail(
-        X`${payment} was not a live payment for brand ${q(
-          brand,
-        )}. It could be a used-up payment, a payment for another brand, or it might not be a payment at all.`,
-      );
+      Fail`${payment} was not a live payment for brand ${q(
+        brand,
+      )}. It could be a used-up payment, a payment for another brand, or it might not be a payment at all.`;
   };
 
   /**
@@ -266,7 +262,7 @@ export const vivifyPaymentLedger = (
       const antiAliasingStore = new Set();
       payments.forEach(payment => {
         !antiAliasingStore.has(payment) ||
-          assert.fail(X`same payment ${payment} seen twice`);
+          Fail`same payment ${payment} seen twice`;
         antiAliasingStore.add(payment);
       });
     }
@@ -277,7 +273,7 @@ export const vivifyPaymentLedger = (
 
     // Invariant check
     isEqual(total, newTotal) ||
-      assert.fail(X`rights were not conserved: ${total} vs ${newTotal}`);
+      Fail`rights were not conserved: ${total} vs ${newTotal}`;
 
     let newPayments;
     try {
@@ -354,9 +350,7 @@ export const vivifyPaymentLedger = (
   ) => {
     amount = coerce(amount);
     AmountMath.isGTE(currentBalance, amount) ||
-      assert.fail(
-        X`Withdrawal of ${amount} failed because the purse only contained ${currentBalance}`,
-      );
+      Fail`Withdrawal of ${amount} failed because the purse only contained ${currentBalance}`;
     const newPurseBalance = subtract(currentBalance, amount);
 
     const payment = makePayment();

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -2,7 +2,7 @@ import { vivifyFarClassKit, makeScalarBigSetStore } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { makeTransientNotifierKit } from './transientNotifier.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 export const vivifyPurseKind = (
   issuerBaggage,
@@ -99,9 +99,7 @@ export const vivifyPurseKind = (
             amount = AmountMath.add(amount, delta, brand);
           }
           state.recoverySet.getSize() === 0 ||
-            assert.fail(
-              X`internal: Remaining unrecovered payments: ${facets.purse.getRecoverySet()}`,
-            );
+            Fail`internal: Remaining unrecovered payments: ${facets.purse.getRecoverySet()}`;
           return amount;
         },
       },

--- a/packages/inter-protocol/test/amm/constantProduct/test-calcDeltaX.js
+++ b/packages/inter-protocol/test/amm/constantProduct/test-calcDeltaX.js
@@ -16,7 +16,7 @@ const doTest = (t, x, y, deltaY, expectedDeltaX) => {
 
 test('0, 0, 0, 0', t => {
   t.throws(() => doTest(t, 0n, 0n, 0n, 0n), {
-    message: 'No infinite ratios! Denominator was 0/"[Alleged: BLD brand]"',
+    message: 'No infinite ratios! Denominator was 0 "[Alleged: BLD brand]"',
   });
 });
 
@@ -28,7 +28,7 @@ test('0, 0, 1, 0', t => {
 
 test('1, 0, 0, 0', t => {
   t.throws(() => doTest(t, 1n, 0n, 0n, 0n), {
-    message: 'No infinite ratios! Denominator was 0/"[Alleged: BLD brand]"',
+    message: 'No infinite ratios! Denominator was 0 "[Alleged: BLD brand]"',
   });
 });
 
@@ -42,7 +42,7 @@ test('1, 1, 0, 0', t => {
 
 test('1, 1, 1, 0', t => {
   t.throws(() => doTest(t, 1n, 1n, 1n, 0n), {
-    message: 'No infinite ratios! Denominator was 0/"[Alleged: BLD brand]"',
+    message: 'No infinite ratios! Denominator was 0 "[Alleged: BLD brand]"',
   });
 });
 

--- a/packages/inter-protocol/test/amm/constantProduct/test-calcDeltaY.js
+++ b/packages/inter-protocol/test/amm/constantProduct/test-calcDeltaY.js
@@ -17,7 +17,7 @@ const doTest = (t, x, y, deltaX, expectedDeltaY) => {
 // deltaXPlusX is 0
 test('0, 0, 0, 0', t => {
   t.throws(() => doTest(t, 0n, 0n, 0n, 0n), {
-    message: 'No infinite ratios! Denominator was 0/"[Alleged: RUN brand]"',
+    message: 'No infinite ratios! Denominator was 0 "[Alleged: RUN brand]"',
   });
 });
 
@@ -32,7 +32,7 @@ test('1, 0, 0, 0', t => {
 // deltaXPlusX is 0
 test('0, 1, 0, 0', t => {
   t.throws(() => doTest(t, 0n, 1n, 0n, 0n), {
-    message: 'No infinite ratios! Denominator was 0/"[Alleged: RUN brand]"',
+    message: 'No infinite ratios! Denominator was 0 "[Alleged: RUN brand]"',
   });
 });
 

--- a/packages/ui-components/src/ratio.js
+++ b/packages/ui-components/src/ratio.js
@@ -25,7 +25,7 @@ export const makeRatio = (
   denominatorBrand = numeratorBrand,
 ) => {
   denominator > 0n ||
-    Fail`No infinite ratios! Denominator was 0/${q(denominatorBrand)}`;
+    Fail`No infinite ratios! Denominator was 0 ${q(denominatorBrand)}`;
 
   // @ts-expect-error cast to return type because make() ensures
   return harden({

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -1,4 +1,4 @@
-import { assert, details as X, q } from '@agoric/assert';
+import { assert, q, Fail } from '@agoric/assert';
 import { AmountMath, getAssetKind } from '@agoric/ertp';
 import { assertRecord } from '@endo/marshal';
 import { assertKey, assertPattern, fit, isKey } from '@agoric/store';
@@ -25,19 +25,15 @@ const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
 export const assertKeywordName = keyword => {
   assert.typeof(keyword, 'string');
   keyword.length <= MAX_KEYWORD_LENGTH ||
-    assert.fail(
-      X`keyword ${q(keyword)} exceeded maximum length ${q(
-        MAX_KEYWORD_LENGTH,
-      )} characters; got ${keyword.length}`,
-    );
-  assert(
-    firstCapASCII.test(keyword),
-    X`keyword ${q(
+    Fail`keyword ${q(keyword)} exceeded maximum length ${q(
+      MAX_KEYWORD_LENGTH,
+    )} characters; got ${keyword.length}`;
+  firstCapASCII.test(keyword) ||
+    Fail`keyword ${q(
       keyword,
-    )} must be an ascii identifier starting with upper case.`,
-  );
+    )} must be an ascii identifier starting with upper case.`;
   (keyword !== 'NaN' && keyword !== 'Infinity') ||
-    assert.fail(X`keyword ${q(keyword)} must not be a number's name`);
+    Fail`keyword ${q(keyword)} must not be a number's name`;
 };
 
 /**
@@ -72,9 +68,7 @@ export const coerceAmountPatternKeywordRecord = (
       // TODO: replace this assertion with a check of the assetKind
       // property on the brand, when that exists.
       assetKind === brandAssetKind ||
-        assert.fail(
-          X`The amount ${amount} did not have the assetKind of the brand ${brandAssetKind}`,
-        );
+        Fail`The amount ${amount} did not have the assetKind of the brand ${brandAssetKind}`;
       return AmountMath.coerce(amount.brand, amount);
     } else {
       assertPattern(amount);
@@ -106,7 +100,7 @@ export const coerceAmountKeywordRecord = (
  * @param {ExitRule} exit
  */
 const assertExit = exit =>
-  assert(ownKeys(exit).length === 1, X`exit ${exit} should only have one key`);
+  ownKeys(exit).length === 1 || Fail`exit ${exit} should only have one key`;
 
 /**
  * check that keyword is not in both 'want' and 'give'.
@@ -120,7 +114,7 @@ const assertKeywordNotInBoth = (want, give) => {
 
   giveKeywords.forEach(keyword => {
     !wantKeywordSet.has(keyword) ||
-      assert.fail(X`a keyword cannot be in both 'want' and 'give'`);
+      Fail`a keyword cannot be in both 'want' and 'give'`;
   });
 };
 
@@ -150,9 +144,7 @@ export const cleanProposal = (proposal, getAssetKindByBrand) => {
     ...rest
   } = proposal;
   ownKeys(rest).length === 0 ||
-    assert.fail(
-      X`${proposal} - Must only have want:, give:, exit: properties: ${rest}`,
-    );
+    Fail`${proposal} - Must only have want:, give:, exit: properties: ${rest}`;
 
   const cleanedWant = coerceAmountPatternKeywordRecord(
     want,

--- a/packages/zoe/src/contractFacet/allocationMath.js
+++ b/packages/zoe/src/contractFacet/allocationMath.js
@@ -1,6 +1,6 @@
 import { AmountMath } from '@agoric/ertp';
 
-const { details: X, quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 /**
  * @callback Operation
@@ -63,18 +63,14 @@ const subtract = (amount, amountToSubtract, keyword) => {
     if (amount === undefined) {
       // TypeScript confused about `||` control flow so use `if` instead
       // https://github.com/microsoft/TypeScript/issues/50739
-      assert.fail(
-        X`The amount could not be subtracted from the allocation because the allocation did not have an amount under the keyword ${q(
-          keyword,
-        )}.`,
-      );
+      throw Fail`The amount could not be subtracted from the allocation because the allocation did not have an amount under the keyword ${q(
+        keyword,
+      )}.`;
     }
     AmountMath.isGTE(amount, amountToSubtract) ||
-      assert.fail(
-        X`The amount to be subtracted ${amountToSubtract} was greater than the allocation's amount ${amount} for the keyword ${q(
-          keyword,
-        )}`,
-      );
+      Fail`The amount to be subtracted ${amountToSubtract} was greater than the allocation's amount ${amount} for the keyword ${q(
+        keyword,
+      )}`;
     return AmountMath.subtract(amount, amountToSubtract);
   }
 };

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -1,4 +1,4 @@
-import { assert, details as X, q } from '@agoric/assert';
+import { Fail, q } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
 import { vivifyFarClass, provideDurableSetStore } from '@agoric/vat-data';
 import { M, initEmpty } from '@agoric/store';
@@ -113,6 +113,6 @@ export const makeMakeExiter = baggage => {
       return makeWaived();
     }
 
-    assert.fail(X`exit kind was not recognized: ${q(exit)}`);
+    throw Fail`exit kind was not recognized: ${q(exit)}`;
   };
 };

--- a/packages/zoe/src/contractFacet/rightsConservation.js
+++ b/packages/zoe/src/contractFacet/rightsConservation.js
@@ -1,5 +1,5 @@
 import { makeStore } from '@agoric/store';
-import { assert, details as X } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 
 import '../internal-types.js';
@@ -75,9 +75,7 @@ const assertEqualPerBrand = (leftSumsByBrand, rightSumsByBrand) => {
   allBrands.forEach(brand => {
     const { leftSum, rightSum } = getSums(brand);
     AmountMath.isEqual(leftSum, rightSum) ||
-      assert.fail(
-        X`rights were not conserved for brand ${brand} ${leftSum.value} != ${rightSum.value}`,
-      );
+      Fail`rights were not conserved for brand ${brand} ${leftSum.value} != ${rightSum.value}`;
   });
 };
 

--- a/packages/zoe/src/contractFacet/vatRoot.js
+++ b/packages/zoe/src/contractFacet/vatRoot.js
@@ -12,7 +12,7 @@ import '../internal-types.js';
 
 import { makeZCFZygote } from './zcfZygote.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 /**
  * @param {VatPowers & { testJigSetter: TestJigSetter }} powers
@@ -28,7 +28,7 @@ export async function buildRootObject(powers, vatParameters, baggage) {
   const { testJigSetter } = powers;
   const { contractBundleCap } = vatParameters;
   contractBundleCap ||
-    assert.fail(X`expected vatParameters.contractBundleCap ${vatParameters}`);
+    Fail`expected vatParameters.contractBundleCap ${vatParameters}`;
   let { zoeService, invitationIssuer } = vatParameters;
   const firstTime = !baggage.has('DidStart');
   if (firstTime) {

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -14,7 +14,7 @@ import '../internal-types.js';
 import './internal-types.js';
 import './types.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 export const makeZCFMintFactory = async (
   zcfBaggage,
@@ -84,9 +84,7 @@ export const makeZCFMintFactory = async (
           // all reallocations are covered by offer safety checks, and
           // that any bug within Zoe that may affect this is caught.
           zcfSeat.isOfferSafe(allocationPlusGains) ||
-            assert.fail(
-              X`The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`,
-            );
+            Fail`The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`;
           // No effects above, apart from incrementBy. Note COMMIT POINT within
           // reallocator.reallocate(). The following two steps *should* be
           // committed atomically, but it is not a disaster if they are
@@ -110,9 +108,7 @@ export const makeZCFMintFactory = async (
 
           // verifies offer safety
           zcfSeat.isOfferSafe(allocationMinusLosses) ||
-            assert.fail(
-              X`The allocation after burning losses ${allocationMinusLosses} for the zcfSeat was not offer safe`,
-            );
+            Fail`The allocation after burning losses ${allocationMinusLosses} for the zcfSeat was not offer safe`;
 
           // Decrement the stagedAllocation if it exists so that the
           // stagedAllocation is kept up to the currentAllocation

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -21,7 +21,7 @@ import {
   SeatShape,
 } from '../typeGuards.js';
 
-const { details: X, Fail } = assert;
+const { Fail } = assert;
 
 /** @type {CreateSeatManager} */
 export const createSeatManager = (
@@ -129,11 +129,9 @@ export const createSeatManager = (
   /** @param {ZCFSeat} zcfSeat */
   const assertNoStagedAllocation = zcfSeat => {
     if (hasStagedAllocation(zcfSeat)) {
-      assert.fail(
-        X`The seat could not be exited with a staged but uncommitted allocation: ${getStagedAllocation(
-          zcfSeat,
-        )}. Please reallocate over this seat or clear the staged allocation.`,
-      );
+      Fail`The seat could not be exited with a staged but uncommitted allocation: ${getStagedAllocation(
+        zcfSeat,
+      )}. Please reallocate over this seat or clear the staged allocation.`;
     }
   };
 

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -2,7 +2,7 @@ import { Nat } from '@agoric/nat';
 import { natSafeMath } from './safeMath.js';
 
 const { subtract, add, multiply, floorDivide } = natSafeMath;
-const { details: X } = assert;
+const { Fail } = assert;
 
 const BASIS_POINTS = 10000n; // TODO change to 10_000n once tooling copes.
 
@@ -39,10 +39,9 @@ export const getInputPrice = (
   inputValue = Nat(inputValue);
   inputReserve = Nat(inputReserve);
   outputReserve = Nat(outputReserve);
-  assert(inputValue > 0n, X`inputValue ${inputValue} must be positive`);
-  assert(inputReserve > 0n, X`inputReserve ${inputReserve} must be positive`);
-  outputReserve > 0n ||
-    assert.fail(X`outputReserve ${outputReserve} must be positive`);
+  inputValue > 0n || Fail`inputValue ${inputValue} must be positive`;
+  inputReserve > 0n || Fail`inputReserve ${inputReserve} must be positive`;
+  outputReserve > 0n || Fail`outputReserve ${outputReserve} must be positive`;
 
   const oneMinusFeeScaled = subtract(BASIS_POINTS, feeBasisPoints);
   const inputWithFee = multiply(inputValue, oneMinusFeeScaled);
@@ -80,13 +79,10 @@ export const getOutputPrice = (
   inputReserve = Nat(inputReserve);
   outputReserve = Nat(outputReserve);
 
-  assert(inputReserve > 0n, X`inputReserve ${inputReserve} must be positive`);
-  outputReserve > 0n ||
-    assert.fail(X`outputReserve ${outputReserve} must be positive`);
+  inputReserve > 0n || Fail`inputReserve ${inputReserve} must be positive`;
+  outputReserve > 0n || Fail`outputReserve ${outputReserve} must be positive`;
   outputReserve > outputValue ||
-    assert.fail(
-      X`outputReserve ${outputReserve} must be greater than outputValue ${outputValue}`,
-    );
+    Fail`outputReserve ${outputReserve} must be greater than outputValue ${outputValue}`;
 
   const oneMinusFeeScaled = subtract(BASIS_POINTS, feeBasisPoints);
   const numerator = multiply(multiply(outputValue, inputReserve), BASIS_POINTS);

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -2,7 +2,7 @@
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { assert, details as X } from '@agoric/assert';
+import { assert, q, Fail } from '@agoric/assert';
 import { makePromiseKit } from '@endo/promise-kit';
 import { AmountMath } from '@agoric/ertp';
 import { makeNotifier } from '@agoric/notifier';
@@ -219,16 +219,10 @@ export function makeOnewayPriceAuthorityKit(opts) {
    * @param {Brand} brandOut
    */
   const assertBrands = (brandIn, brandOut) => {
-    assert.equal(
-      brandIn,
-      actualBrandIn,
-      X`Desired brandIn ${brandIn} must match ${actualBrandIn}`,
-    );
-    assert.equal(
-      brandOut,
-      actualBrandOut,
-      X`Desired brandOut ${brandOut} must match ${actualBrandOut}`,
-    );
+    brandIn === actualBrandIn ||
+      Fail`Desired brandIn ${q(brandIn)} must match ${q(actualBrandIn)}`;
+    brandOut === actualBrandOut ||
+      Fail`Desired brandOut ${q(brandOut)} must match ${q(actualBrandOut)}`;
   };
 
   /** @type {PriceAuthority} */
@@ -296,9 +290,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
         const amountIn = calcAmountIn(amountOut);
         const actualAmountOut = calcAmountOut(amountIn);
         AmountMath.isGTE(actualAmountOut, amountOut) ||
-          assert.fail(
-            X`Calculation of ${actualAmountOut} didn't cover expected ${amountOut}`,
-          );
+          Fail`Calculation of ${actualAmountOut} didn't cover expected ${amountOut}`;
         return { amountIn, amountOut };
       });
       assert(quote);

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -1,5 +1,5 @@
 import './types.js';
-import { assert, details as X, q } from '@agoric/assert';
+import { assert, details as X, q, Fail } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 import { assertRecord } from '@endo/marshal';
 import { isNat } from '@agoric/nat';
@@ -44,20 +44,14 @@ export const assertIsRatio = ratio => {
   assert(keys.length === 2, X`Ratio ${ratio} must be a record with 2 fields.`);
   for (const name of keys) {
     ratioPropertyNames.includes(name) ||
-      assert.fail(
-        X`Parameter must be a Ratio record, but ${ratio} has ${q(name)}`,
-      );
+      Fail`Parameter must be a Ratio record, but ${ratio} has ${q(name)}`;
   }
   const numeratorValue = ratio.numerator.value;
   const denominatorValue = ratio.denominator.value;
   isNat(numeratorValue) ||
-    assert.fail(
-      X`The numerator value must be a NatValue, not ${numeratorValue}`,
-    );
+    Fail`The numerator value must be a NatValue, not ${numeratorValue}`;
   isNat(denominatorValue) ||
-    assert.fail(
-      X`The denominator value must be a NatValue, not ${denominatorValue}`,
-    );
+    Fail`The denominator value must be a NatValue, not ${denominatorValue}`;
 };
 
 /**
@@ -74,9 +68,7 @@ export const makeRatio = (
   denominatorBrand = numeratorBrand,
 ) => {
   denominator > 0n ||
-    assert.fail(
-      X`No infinite ratios! Denominator was 0/${q(denominatorBrand)}`,
-    );
+    Fail`No infinite ratios! Denominator was 0 ${q(denominatorBrand)}`;
 
   // @ts-expect-error cast to return type because make() ensures
   return harden({
@@ -286,7 +278,7 @@ export const multiplyRatios = (left, right) => {
     if (left.numerator.brand === left.denominator.brand) {
       return [right.numerator.brand, right.denominator.brand];
     }
-    assert.fail(X`at least one brand must cancel out: ${q(left)} ${q(right)}`);
+    throw Fail`at least one brand must cancel out: ${q(left)} ${q(right)}`;
   };
 
   const [numeratorBrand, denominatorBrand] = getRemainingBrands();
@@ -307,13 +299,9 @@ export const multiplyRatios = (left, right) => {
 export const oneMinus = ratio => {
   assertIsRatio(ratio);
   ratio.numerator.brand === ratio.denominator.brand ||
-    assert.fail(
-      X`oneMinus only supports ratios with a single brand, but ${ratio.numerator.brand} doesn't match ${ratio.denominator.brand}`,
-    );
+    Fail`oneMinus only supports ratios with a single brand, but ${ratio.numerator.brand} doesn't match ${ratio.denominator.brand}`;
   ratio.numerator.value <= ratio.denominator.value ||
-    assert.fail(
-      X`Parameter must be less than or equal to 1: ${ratio.numerator.value}/${ratio.denominator.value}`,
-    );
+    Fail`Parameter must be less than or equal to 1: ${ratio.numerator.value}/${ratio.denominator.value}`;
   return makeRatio(
     subtract(ratio.denominator.value, ratio.numerator.value),
     ratio.numerator.brand,

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -13,7 +13,7 @@ import {
 
 export const defaultAcceptanceMsg = `The offer has been accepted. Once the contract has been completed, please check your payout`;
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 const getKeysSorted = obj => harden(Reflect.ownKeys(obj || {}).sort());
 
@@ -23,7 +23,7 @@ export const assertIssuerKeywords = (zcf, expected) => {
   expected = [...expected]; // in case hardened
   expected.sort();
   keyEQ(actual, harden(expected)) ||
-    assert.fail(X`keywords: ${actual} were not as expected: ${expected}`);
+    Fail`keywords: ${actual} were not as expected: ${expected}`;
 };
 
 /**
@@ -143,11 +143,10 @@ export const assertProposalShape = (seat, expected) => {
   assert(!Array.isArray(expected), 'Expected must be an non-array object');
   const assertValuesNull = e => {
     if (e !== undefined) {
-      Object.values(e).forEach(value =>
-        assert(
-          value === null,
-          X`The value of the expected record must be null but was ${value}`,
-        ),
+      Object.values(e).forEach(
+        value =>
+          value === null ||
+          Fail`The value of the expected record must be null but was ${value}`,
       );
     }
   };
@@ -162,7 +161,7 @@ export const assertProposalShape = (seat, expected) => {
   const assertKeys = (a, e) => {
     if (e !== undefined) {
       keyEQ(getKeysSorted(a), getKeysSorted(e)) ||
-        assert.fail(X`actual ${a} did not match expected ${e}`);
+        Fail`actual ${a} did not match expected ${e}`;
     }
   };
   assertKeys(actual.give, expected.give);

--- a/packages/zoe/src/contracts/auction/assertBidSeat.js
+++ b/packages/zoe/src/contracts/auction/assertBidSeat.js
@@ -1,15 +1,13 @@
-import { assert, details as X } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 
 export const assertBidSeat = (zcf, sellSeat, bidSeat) => {
   const minBid = sellSeat.getProposal().want.Ask;
   const bid = bidSeat.getAmountAllocated('Bid', minBid.brand);
   AmountMath.isGTE(bid, minBid) ||
-    assert.fail(X`bid ${bid} is under the minimum bid ${minBid}`);
+    Fail`bid ${bid} is under the minimum bid ${minBid}`;
   const assetAtAuction = sellSeat.getProposal().give.Asset;
   const assetWanted = bidSeat.getAmountAllocated('Asset', assetAtAuction.brand);
   AmountMath.isGTE(assetAtAuction, assetWanted) ||
-    assert.fail(
-      X`more assets were wanted ${assetWanted} than were available ${assetAtAuction}`,
-    );
+    Fail`more assets were wanted ${assetWanted} than were available ${assetAtAuction}`;
 };

--- a/packages/zoe/src/contracts/auction/index.js
+++ b/packages/zoe/src/contracts/auction/index.js
@@ -12,7 +12,7 @@ import * as secondPriceLogic from './secondPriceLogic.js';
 import * as firstPriceLogic from './firstPriceLogic.js';
 import { assertBidSeat } from './assertBidSeat.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 const FIRST_PRICE = 'first-price';
 const SECOND_PRICE = 'second-price';
@@ -50,7 +50,7 @@ const start = zcf => {
   assert.typeof(bidDuration, 'bigint');
   winnerPriceOption === FIRST_PRICE ||
     winnerPriceOption === SECOND_PRICE ||
-    assert.fail(X`Only first and second price auctions are supported`);
+    Fail`Only first and second price auctions are supported`;
 
   let sellSeat;
   let isTimerStarted = false;

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -15,7 +15,7 @@ import {
 import { makePayoffHandler } from './payoffHandler.js';
 import { Position } from './position.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 const PERCENT_BASE = 100n;
 const BASIS_POINTS = 10000n;
@@ -122,7 +122,7 @@ const start = zcf => {
 
       // assert that the allocation includes the amount of collateral required
       AmountMath.isEqual(newCollateral, deposit) ||
-        assert.fail(X`Collateral required: ${deposit.value}`);
+        Fail`Collateral required: ${deposit.value}`;
 
       // assert that the requested option was the right one.
       assert(

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -3,7 +3,7 @@ import { vivifyKind, vivifySingleton } from '@agoric/vat-data';
 import { swapExact } from '../contractSupport/index.js';
 import { isAfterDeadlineExitRule } from '../typeGuards.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 const sellSeatExpiredMsg = 'The covered call option is expired.';
 
@@ -65,9 +65,7 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
     if (!isAfterDeadlineExitRule(sellSeatExitRule)) {
       // TypeScript confused about `||` control flow so use `if` instead
       // https://github.com/microsoft/TypeScript/issues/50739
-      assert.fail(
-        X`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`,
-      );
+      throw Fail`the seller must have an afterDeadline exitRule, but instead had ${sellSeatExitRule}`;
     }
 
     const exerciseOption = makeExerciser(sellSeat);

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -3,7 +3,7 @@ import { M, fit } from '@agoric/store';
 import { swapExact } from '../contractSupport/index.js';
 import { isAfterDeadlineExitRule } from '../typeGuards.js';
 
-const { details: X, quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 /**
  * A call option is the right (but not the obligation) to buy digital
@@ -76,12 +76,11 @@ const start = zcf => {
       'exit afterDeadline',
     );
     const sellSeatExitRule = sellSeat.getProposal().exit;
-    assert(
-      isAfterDeadlineExitRule(sellSeatExitRule),
-      X`the seller must have an afterDeadline exitRule, but instead had ${q(
+    if (!isAfterDeadlineExitRule(sellSeatExitRule)) {
+      throw Fail`the seller must have an afterDeadline exitRule, but instead had ${q(
         sellSeatExitRule,
-      )}`,
-    );
+      )}`;
+    }
 
     const exerciseOption = buySeat => {
       assert(!sellSeat.hasExited(), sellSeatExpiredMsg);

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -1,4 +1,4 @@
-import { assert, details as X } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
@@ -53,9 +53,7 @@ export const makeBorrowInvitation = (zcf, config) => {
     // Assert the required collateral was escrowed.
     const requiredMargin = ceilMultiplyBy(loanWanted, mmr);
     AmountMath.isGTE(collateralPriceInLoanBrand, requiredMargin) ||
-      assert.fail(
-        X`The required margin is ${requiredMargin.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`,
-      );
+      Fail`The required margin is ${requiredMargin.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`;
 
     const timestamp = getTimestamp(quote);
 
@@ -70,9 +68,7 @@ export const makeBorrowInvitation = (zcf, config) => {
 
     // Assert that loanWanted <= maxLoan
     AmountMath.isGTE(maxLoan, loanWanted) ||
-      assert.fail(
-        X`The wanted loan ${loanWanted} must be below or equal to the maximum possible loan ${maxLoan}`,
-      );
+      Fail`The wanted loan ${loanWanted} must be below or equal to the maximum possible loan ${maxLoan}`;
 
     const { zcfSeat: collateralSeat } = zcf.makeEmptySeatKit();
 

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -1,6 +1,6 @@
 import './types.js';
 
-import { assert, details as X } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 
 import {
@@ -35,9 +35,7 @@ export const makeCloseLoanInvitation = (zcf, config) => {
 
     // All debt must be repaid.
     AmountMath.isGTE(repaid, debt) ||
-      assert.fail(
-        X`Not enough Loan assets have been repaid.  ${debt} is required, but only ${repaid} was repaid.`,
-      );
+      Fail`Not enough Loan assets have been repaid.  ${debt} is required, but only ${repaid} was repaid.`;
 
     // Transfer the collateral to the repaySeat and remove the
     // required Loan amount. Any excess Loan amount is kept by the repaySeat.

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -1,4 +1,4 @@
-import { assert, details as X } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 
@@ -66,7 +66,7 @@ const start = async zcf => {
         const { requiredFee, reply } = await E(handler).onQuery(query, noFee);
         !requiredFee ||
           AmountMath.isGTE(noFee, requiredFee) ||
-          assert.fail(X`Oracle required a fee but the query had none`);
+          Fail`Oracle required a fee but the query had none`;
         return reply;
       } catch (e) {
         E(handler).onError(query, e);

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -1,5 +1,6 @@
 /// <reference path="../../../SwingSet/src/vats/timer/types.d.ts" />
 
+import { Fail, q } from '@agoric/assert';
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { assertAllDefined } from '@agoric/internal';
 import {
@@ -387,8 +388,9 @@ const start = async (zcf, privateArgs) => {
           result = makeScaledRatioFromData(value);
           break;
         }
-        case 'undefined':
-          assert.fail('undefined value in OraclePriceSubmission');
+        case 'undefined': {
+          throw Fail`undefined value in OraclePriceSubmission`;
+        }
         case 'object': {
           if ('data' in value) {
             result = makeScaledRatioFromData(value.data);
@@ -399,10 +401,11 @@ const start = async (zcf, privateArgs) => {
             result = value;
             break;
           }
-          assert.fail(`unknown value object`);
+          throw Fail`unknown value object`;
         }
-        default:
-          assert.fail(`unknown value type {typeof value}`);
+        default: {
+          throw Fail`unknown value type ${q(typeof value)}`;
+        }
       }
 
       pushResult(result).catch(console.error);

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -14,7 +14,7 @@ import {
   atomicRearrange,
 } from '../contractSupport/index.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 /**
  * Sell items in exchange for money. Items may be fungible or
@@ -104,7 +104,7 @@ const start = zcf => {
 
     // Check that the money provided to pay for the items is greater than the totalCost.
     AmountMath.isGTE(providedMoney, totalCost) ||
-      assert.fail(X`More money (${totalCost}) is required to buy these items`);
+      Fail`More money (${totalCost}) is required to buy these items`;
 
     // Reallocate.
     atomicRearrange(

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -3,7 +3,7 @@ import { assertKeywordName } from './cleanProposal.js';
 
 const { ownKeys } = Reflect;
 
-const { details: X, quote: q } = assert;
+const { details: X, quote: q, Fail } = assert;
 
 /**
  * The InstanceRecord stores the installation, customTerms, issuers,
@@ -34,8 +34,7 @@ export const makeInstanceRecordStorage = baggage => {
     );
 
   const addIssuerToInstanceRecord = (keyword, issuerRecord) => {
-    !(keyword in issuerRecord) ||
-      assert.fail(X`conflicting definition of ${q(keyword)}`);
+    !(keyword in issuerRecord) || Fail`conflicting definition of ${q(keyword)}`;
 
     assertInstantiated();
     const instanceRecord = baggage.get('instanceRecord');
@@ -83,7 +82,7 @@ export const makeInstanceRecordStorage = baggage => {
     assertInstantiated();
     assertKeywordName(keyword);
     !ownKeys(baggage.get('instanceRecord').terms.issuers).includes(keyword) ||
-      assert.fail(X`keyword ${q(keyword)} must be unique`);
+      Fail`keyword ${q(keyword)} must be unique`;
   };
 
   const instantiate = startingInstanceRecord => {

--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -1,4 +1,4 @@
-import { assert, details as X, q } from '@agoric/assert';
+import { assert, Fail, q } from '@agoric/assert';
 
 /**
  * @typedef {bigint|boolean|null|number|string|symbol|undefined} Primitive
@@ -12,8 +12,7 @@ import { assert, details as X, q } from '@agoric/assert';
  * @param {U[]} keys
  */
 export const arrayToObj = (array, keys) => {
-  array.length === keys.length ||
-    assert.fail(X`array and keys must be of equal length`);
+  array.length === keys.length || Fail`array and keys must be of equal length`;
   const obj =
     /** @type {Record<U, T>} */
     ({});
@@ -31,8 +30,6 @@ export const assertSubset = (whole, part) => {
   part.forEach(key => {
     assert.typeof(key, 'string');
     whole.includes(key) ||
-      assert.fail(
-        X`key ${q(key)} was not one of the expected keys ${q(whole)}`,
-      );
+      Fail`key ${q(key)} was not one of the expected keys ${q(whole)}`;
   });
 };

--- a/packages/zoe/src/zoeService/createZCFVat.js
+++ b/packages/zoe/src/zoeService/createZCFVat.js
@@ -1,5 +1,7 @@
 import { E } from '@endo/eventual-send';
 
+const { Fail, quote: q } = assert;
+
 export const getZcfBundleCap = (zcfSpec, vatAdminSvc) => {
   let zcfBundleCapP;
   if (zcfSpec.bundleCap) {
@@ -10,7 +12,7 @@ export const getZcfBundleCap = (zcfSpec, vatAdminSvc) => {
     zcfBundleCapP = E(vatAdminSvc).getBundleCap(zcfSpec.id);
   } else {
     const keys = Object.keys(zcfSpec).join(',');
-    assert.fail(`setupCreateZCFVat: bad zcfSpec, has keys '${keys}'`);
+    Fail`setupCreateZCFVat: bad zcfSpec, has keys '${q(keys)}'`;
   }
 
   return zcfBundleCapP;

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -1,6 +1,6 @@
 import { AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
-import { assert, details as X, q } from '@agoric/assert';
+import { q, Fail } from '@agoric/assert';
 import { objectMap } from '@agoric/internal';
 import { provideDurableWeakMapStore } from '@agoric/vat-data';
 
@@ -34,9 +34,7 @@ export const provideEscrowStorage = baggage => {
         }
       },
       err =>
-        assert.fail(
-          X`A purse could not be created for brand ${brand} because: ${err}`,
-        ),
+        Fail`A purse could not be created for brand ${brand} because: ${err}`,
     );
   };
 
@@ -85,14 +83,12 @@ export const provideEscrowStorage = baggage => {
     // keywords. Proposal.give keywords that do not have matching payments will
     // be caught in the deposit step.
     paymentKeywords.forEach(keyword => {
-      assert(
-        giveKeywords.includes(keyword),
-        X`The ${q(
+      giveKeywords.includes(keyword) ||
+        Fail`The ${q(
           keyword,
         )} keyword in the paymentKeywordRecord was not a keyword in proposal.give, which had keywords: ${q(
           giveKeywords,
-        )}`,
-      );
+        )}`;
     });
 
     const proposalKeywords = harden([...giveKeywords, ...wantKeywords]);
@@ -106,14 +102,12 @@ export const provideEscrowStorage = baggage => {
     // https://github.com/Agoric/agoric-sdk/issues/1271
     const amountsDeposited = await Promise.all(
       giveKeywords.map(keyword => {
-        assert(
-          payments[keyword] !== undefined,
-          X`The ${q(
+        payments[keyword] !== undefined ||
+          Fail`The ${q(
             keyword,
           )} keyword in proposal.give did not have an associated payment in the paymentKeywordRecord, which had keywords: ${q(
             paymentKeywords,
-          )}`,
-        );
+          )}`;
         return doDepositPayment(payments[keyword], give[keyword]);
       }),
     );

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -1,4 +1,4 @@
-import { assert, details as X } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 import { AmountMath, makeDurableIssuerKit, AssetKind } from '@agoric/ertp';
 import { InvitationElementShape } from '../typeGuards.js';
 
@@ -34,11 +34,8 @@ export const vivifyInvitationKit = (baggage, shutdownZoeVat = undefined) => {
       proposalShape = undefined,
     ) => {
       assert.typeof(invitationHandle, 'object');
-      assert.typeof(
-        description,
-        'string',
-        X`The description ${description} must be a string`,
-      );
+      typeof description === 'string' ||
+        Fail`The description ${description} must be a string`;
 
       // If the contract-provided customProperties include the
       // properties 'description', 'handle', 'instance',

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -10,7 +10,7 @@ import '@agoric/ertp/exported.js';
 import '@agoric/store/exported.js';
 import '../internal-types.js';
 
-const { details: X, quote: q, Fail } = assert;
+const { quote: q, Fail } = assert;
 
 export const makeOfferMethod = offerDataAccess => {
   /** @type {Offer} */
@@ -52,12 +52,10 @@ export const makeOfferMethod = offerDataAccess => {
 
     if (offerArgs !== undefined) {
       const passStyle = passStyleOf(offerArgs);
-      assert(
-        passStyle === 'copyRecord',
-        X`offerArgs must be a pass-by-copy record, but instead was a ${q(
+      passStyle === 'copyRecord' ||
+        Fail`offerArgs must be a pass-by-copy record, but instead was a ${q(
           passStyle,
-        )}: ${offerArgs}`,
-      );
+        )}: ${offerArgs}`;
     }
 
     return E.when(

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -269,13 +269,13 @@ test('ratio bad inputs', t => {
     message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
   t.throws(() => makeRatio(3n, brand, 0n), {
-    message: /No infinite ratios! Denominator was 0/,
+    message: /No infinite ratios! Denominator was 0 ,
   });
   t.throws(() => makeRatioFromAmounts(moe(37n), moe(0n)), {
-    message: /No infinite ratios! Denominator was 0/,
+    message: /No infinite ratios! Denominator was 0 ,
   });
   t.throws(() => makeRatioFromAmounts(moe(37n), moe(0n)), {
-    message: /No infinite ratios! Denominator was 0/,
+    message: /No infinite ratios! Denominator was 0 ,
   });
 });
 
@@ -284,13 +284,13 @@ test('ratio bad inputs w/brand names', t => {
   /** @param {bigint} value */
   const moe = value => AmountMath.make(brand, value);
   t.throws(() => makeRatio(3n, brand, 0n), {
-    message: 'No infinite ratios! Denominator was 0/"[Alleged: moe brand]"',
+    message: 'No infinite ratios! Denominator was 0 "[Alleged: moe brand]"',
   });
   t.throws(() => makeRatioFromAmounts(moe(37n), moe(0n)), {
-    message: 'No infinite ratios! Denominator was 0/"[Alleged: moe brand]"',
+    message: 'No infinite ratios! Denominator was 0 "[Alleged: moe brand]"',
   });
   t.throws(() => makeRatioFromAmounts(moe(37n), moe(0n)), {
-    message: 'No infinite ratios! Denominator was 0/"[Alleged: moe brand]"',
+    message: 'No infinite ratios! Denominator was 0 "[Alleged: moe brand]"',
   });
 });
 

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -269,13 +269,13 @@ test('ratio bad inputs', t => {
     message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
   t.throws(() => makeRatio(3n, brand, 0n), {
-    message: /No infinite ratios! Denominator was 0 ,
+    message: /No infinite ratios! Denominator was 0/,
   });
   t.throws(() => makeRatioFromAmounts(moe(37n), moe(0n)), {
-    message: /No infinite ratios! Denominator was 0 ,
+    message: /No infinite ratios! Denominator was 0/,
   });
   t.throws(() => makeRatioFromAmounts(moe(37n), moe(0n)), {
-    message: /No infinite ratios! Denominator was 0 ,
+    message: /No infinite ratios! Denominator was 0/,
   });
 });
 

--- a/packages/zoe/tools/priceAuthorityRegistry.js
+++ b/packages/zoe/tools/priceAuthorityRegistry.js
@@ -1,6 +1,6 @@
 import { E } from '@endo/eventual-send';
 import { makeStore } from '@agoric/store';
-import { assert, details as X } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import { Far } from '@endo/marshal';
 
 /**
@@ -159,11 +159,8 @@ export const makePriceAuthorityRegistry = () => {
 
       return Far('deleter', {
         delete() {
-          assert.equal(
-            priceStore.has(brandOut) && priceStore.get(brandOut),
-            record,
-            X`Price authority already dropped`,
-          );
+          (priceStore.has(brandOut) && priceStore.get(brandOut) === record) ||
+            Fail`Price authority already dropped`;
           priceStore.delete(brandOut);
         },
       });


### PR DESCRIPTION
Replaces #6622 

Only the ERTP and zoe portions of #6482 

See https://github.com/endojs/endo/pull/1334