### PR TITLE
move priceAggregatorChainlink to inter-protocol

### DIFF
--- a/packages/inter-protocol/scripts/build-bundles.js
+++ b/packages/inter-protocol/scripts/build-bundles.js
@@ -29,6 +29,10 @@ await createBundles(
       '../src/econCommitteeCharter.js',
       '../bundles/bundle-econCommitteeCharter.js',
     ],
+    [
+      '../src/priceAggregatorChainlink.js',
+      '../bundles/bundle-priceAggregatorChainlink.js',
+    ],
   ],
   dirname,
 );

--- a/packages/inter-protocol/scripts/price-feed-core.js
+++ b/packages/inter-protocol/scripts/price-feed-core.js
@@ -57,7 +57,7 @@ export const defaultProposalBuilder = async (
         brandOutRef: brandOut && publishRef(brandOut),
         priceAggregatorRef: publishRef(
           install(
-            '@agoric/zoe/src/contracts/priceAggregatorChainlink.js',
+            '@agoric/inter-protocol/src/priceAggregatorChainlink.js',
             '../bundles/bundle-priceAggregatorChainlink.js',
           ),
         ),

--- a/packages/inter-protocol/src/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/priceAggregatorChainlink.js
@@ -714,7 +714,7 @@ const start = async (zcf, privateArgs) => {
           PushPrice(result) {
             return zcf.makeInvitation(cSeat => {
               cSeat.exit();
-              admin.pushResult(result);
+              admin.pushPrice(result);
             }, 'PushPrice');
           },
         });
@@ -796,7 +796,7 @@ const start = async (zcf, privateArgs) => {
          *
          * @param {PriceRound} result
          */
-        async pushResult({
+        async pushPrice({
           roundId: roundIdRaw = undefined,
           unitPrice: valueRaw,
         }) {

--- a/packages/inter-protocol/src/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/priceAggregatorChainlink.js
@@ -19,16 +19,15 @@ import {
   calculateMedian,
   natSafeMath,
   makeOnewayPriceAuthorityKit,
-} from '../contractSupport/index.js';
+} from '@agoric/zoe/src/contractSupport/index.js';
 
-import '../../tools/types.js';
-import { assertParsableNumber } from '../contractSupport/ratio.js';
-import {
-  INVITATION_MAKERS_DESC,
-  priceDescriptionFromQuote,
-} from './priceAggregator.js';
+import '@agoric/zoe/tools/types.js';
+import { assertParsableNumber } from '@agoric/zoe/src/contractSupport/ratio.js';
 
-export { INVITATION_MAKERS_DESC };
+export const INVITATION_MAKERS_DESC = 'oracle invitation';
+
+/** @type {(quote: PriceQuote) => PriceDescription} */
+const priceDescriptionFromQuote = quote => quote.quoteAmount.value[0];
 
 /**
  * @typedef {{ roundId: number | undefined, unitPrice: NatValue }} PriceRound

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -87,7 +87,7 @@ export const ensureOracleBrands = async (
 
 /**
  * @param {ChainBootstrapSpace} powers
- * @param {{options: {priceFeedOptions: {AGORIC_INSTANCE_NAME: string, oracleAddresses: string[], contractTerms: import('@agoric/zoe/src/contracts/priceAggregatorChainlink.js').ChainlinkConfig, IN_BRAND_NAME: string, OUT_BRAND_NAME: string}}}} config
+ * @param {{options: {priceFeedOptions: {AGORIC_INSTANCE_NAME: string, oracleAddresses: string[], contractTerms: import('@agoric/inter-protocol/src/priceAggregatorChainlink.js').ChainlinkConfig, IN_BRAND_NAME: string, OUT_BRAND_NAME: string}}}} config
  */
 export const createPriceFeed = async (
   {
@@ -129,7 +129,7 @@ export const createPriceFeed = async (
   /**
    * Values come from economy-template.json, which at this writing had IN:ATOM, OUT:USD
    *
-   * @type {[[Brand<'nat'>, Brand<'nat'>], [Installation<import('@agoric/zoe/src/contracts/priceAggregatorChainlink.js').start>]]}
+   * @type {[[Brand<'nat'>, Brand<'nat'>], [Installation<import('@agoric/inter-protocol/src/priceAggregatorChainlink.js').start>]]}
    */
   const [[brandIn, brandOut], [priceAggregator]] = await Promise.all([
     reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('oracleBrand'), [

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -73,10 +73,10 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
       'installation',
     );
     const paBundle = await bundleCache.load(
-      '../zoe/src/contracts/priceAggregatorChainlink.js',
+      '../inter-protocol/src/priceAggregatorChainlink.js',
       'priceAggregator',
     );
-    /** @type {Promise<Installation<import('@agoric/zoe/src/contracts/priceAggregatorChainlink.js').start>>} */
+    /** @type {Promise<Installation<import('@agoric/inter-protocol/src/priceAggregatorChainlink.js').start>>} */
     const paInstallation = E(zoe).install(paBundle);
     await E(installAdmin).update('priceAggregator', paInstallation);
 

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -11,7 +11,7 @@ import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { E } from '@endo/far';
 
 import { coalesceUpdates } from '@agoric/smart-wallet/src/utils.js';
-import { INVITATION_MAKERS_DESC } from '@agoric/zoe/src/contracts/priceAggregatorChainlink.js';
+import { INVITATION_MAKERS_DESC } from '@agoric/inter-protocol/src/priceAggregatorChainlink.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { ensureOracleBrands } from '../../src/proposals/price-feed-proposal.js';
 import { headValue } from '../supports.js';
@@ -89,7 +89,7 @@ test('admin price', async t => {
 
   const offersFacet = wallet.getOffersFacet();
 
-  /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<import('@agoric/zoe/src/contracts/priceAggregatorChainlink.js').start>} */
+  /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<import('@agoric/inter-protocol/src/priceAggregatorChainlink.js').start>} */
   const priceAggregator = await E(agoricNames).lookup(
     'instance',
     'ATOM-USD price feed',
@@ -155,7 +155,7 @@ test('admin price', async t => {
 
   // Push a new price result /////////////////////////
 
-  /** @type {import('@agoric/zoe/src/contracts/priceAggregatorChainlink.js').PriceRound} */
+  /** @type {import('@agoric/inter-protocol/src/priceAggregatorChainlink.js').PriceRound} */
   const result = { roundId: 1, unitPrice: 123n };
 
   /** @type {import('@agoric/smart-wallet/src/invitations.js').ContinuingInvitationSpec} */

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -11,8 +11,8 @@ import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { E } from '@endo/far';
 
 import { coalesceUpdates } from '@agoric/smart-wallet/src/utils.js';
-import { INVITATION_MAKERS_DESC } from '@agoric/inter-protocol/src/priceAggregatorChainlink.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { INVITATION_MAKERS_DESC } from '../../src/priceAggregatorChainlink.js';
 import { ensureOracleBrands } from '../../src/proposals/price-feed-proposal.js';
 import { headValue } from '../supports.js';
 import { makeDefaultTestContext } from './contexts.js';

--- a/packages/inter-protocol/test/test-priceAggregatorChainlink.js
+++ b/packages/inter-protocol/test/test-priceAggregatorChainlink.js
@@ -133,9 +133,9 @@ test('basic', async t => {
 
   // ----- round 1: basic consensus
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
-  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
-  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 300n });
+  await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
+  await E(pricePushAdminC).pushPrice({ roundId: 1, unitPrice: 300n });
   await oracleTimer.tick();
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -147,9 +147,9 @@ test('basic', async t => {
   // the restartDelay, which means its submission will be IGNORED. this means the median
   // should ONLY be between the OracleB and C values, which is why it is 25000
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 1000n });
-  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 2000n });
-  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 3000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 2000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 3000n });
   await oracleTimer.tick();
 
   const round1Attempt2 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -161,9 +161,9 @@ test('basic', async t => {
   // unlike the previous test, if C initializes, all submissions should be recorded,
   // which means the median will be the expected 5000 here
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 3, unitPrice: 5000n });
-  await E(pricePushAdminA).pushResult({ roundId: 3, unitPrice: 4000n });
-  await E(pricePushAdminB).pushResult({ roundId: 3, unitPrice: 6000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 3, unitPrice: 5000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 3, unitPrice: 4000n });
+  await E(pricePushAdminB).pushPrice({ roundId: 3, unitPrice: 6000n });
   await oracleTimer.tick();
 
   const round1Attempt3 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -196,11 +196,11 @@ test('timeout', async t => {
 
   // ----- round 1: basic consensus w/ ticking: should work EXACTLY the same
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 100n });
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
+  await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 300n });
+  await E(pricePushAdminC).pushPrice({ roundId: 1, unitPrice: 300n });
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
   t.deepEqual(round1Attempt1.roundId, 1n);
@@ -210,15 +210,15 @@ test('timeout', async t => {
   // timeout behavior is, if more ticks pass than the timeout param (5 here), the round is
   // considered "timedOut," at which point, the values are simply copied from the previous round
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 2000n });
+  await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 2000n });
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick(); // --- should time out here
-  await E(pricePushAdminC).pushResult({ roundId: 3, unitPrice: 1000n });
-  await E(pricePushAdminA).pushResult({ roundId: 3, unitPrice: 3000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 3, unitPrice: 1000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 3, unitPrice: 3000n });
 
   const round1Attempt2 = await E(aggregator.creatorFacet).getRoundData(1);
   t.deepEqual(round1Attempt2.answer, 200n);
@@ -251,20 +251,20 @@ test('issue check', async t => {
 
   // ----- round 1: ignore too low values
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 50n }); // should be IGNORED
+  await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 50n }); // should be IGNORED
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
+  await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 300n });
+  await E(pricePushAdminC).pushPrice({ roundId: 1, unitPrice: 300n });
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
   t.deepEqual(round1Attempt1.answer, 250n);
 
   // ----- round 2: ignore too high values
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 20000n });
-  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 1000n });
-  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 3000n });
+  await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 20000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 3000n });
   await oracleTimer.tick();
 
   const round2Attempt1 = await E(aggregator.creatorFacet).getRoundData(2);
@@ -294,9 +294,9 @@ test('supersede', async t => {
 
   // ----- round 1: round 1 is NOT supersedable when 3 submits, meaning it will be ignored
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
-  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 300n });
-  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
+  await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 300n });
+  await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -304,8 +304,8 @@ test('supersede', async t => {
 
   // ----- round 2: oracle C's value from before should have been IGNORED
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 2000n });
-  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 2000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 1000n });
   await oracleTimer.tick();
 
   const round2Attempt1 = await E(aggregator.creatorFacet).getRoundData(2);
@@ -313,7 +313,7 @@ test('supersede', async t => {
 
   // ----- round 3: oracle C should NOT be able to supersede round 3
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 4, unitPrice: 1000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 4, unitPrice: 1000n });
 
   try {
     await E(aggregator.creatorFacet).getRoundData(4);
@@ -348,9 +348,9 @@ test('interleaved', async t => {
 
   // ----- round 1: we now need unanimous submission for a round for it to have consensus
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
-  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 300n });
-  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
+  await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 300n });
+  await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
 
   try {
@@ -361,17 +361,17 @@ test('interleaved', async t => {
 
   // ----- round 2: interleaved round submission -- just making sure this works
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 300n });
+  await E(pricePushAdminC).pushPrice({ roundId: 1, unitPrice: 300n });
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 2000n });
-  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 2000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 1000n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 3, unitPrice: 9000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 3, unitPrice: 9000n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 3000n }); // assumes oracle C is going for a resubmission
+  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 3000n }); // assumes oracle C is going for a resubmission
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 3, unitPrice: 5000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 3, unitPrice: 5000n });
   await oracleTimer.tick();
 
   const round1Attempt2 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -394,9 +394,9 @@ test('interleaved', async t => {
   await oracleTimer.tick();
   await oracleTimer.tick();
   // round 3 is NOT yet supersedeable (since no value present and not yet timed out), so these should fail
-  await E(pricePushAdminA).pushResult({ roundId: 4, unitPrice: 4000n });
-  await E(pricePushAdminB).pushResult({ roundId: 4, unitPrice: 5000n });
-  await E(pricePushAdminC).pushResult({ roundId: 4, unitPrice: 6000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 4, unitPrice: 4000n });
+  await E(pricePushAdminB).pushPrice({ roundId: 4, unitPrice: 5000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 4, unitPrice: 6000n });
   await oracleTimer.tick(); // --- round 3 has NOW timed out, meaning it is now supersedable
 
   try {
@@ -412,9 +412,9 @@ test('interleaved', async t => {
   }
 
   // so NOW we should be able to submit round 4, and round 3 should just be copied from round 2
-  await E(pricePushAdminA).pushResult({ roundId: 4, unitPrice: 4000n });
-  await E(pricePushAdminB).pushResult({ roundId: 4, unitPrice: 5000n });
-  await E(pricePushAdminC).pushResult({ roundId: 4, unitPrice: 6000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 4, unitPrice: 4000n });
+  await E(pricePushAdminB).pushPrice({ roundId: 4, unitPrice: 5000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 4, unitPrice: 6000n });
   await oracleTimer.tick();
 
   const round3Attempt3 = await E(aggregator.creatorFacet).getRoundData(3);
@@ -424,7 +424,7 @@ test('interleaved', async t => {
   t.deepEqual(round4Attempt2.answer, 5000n);
 
   // ----- round 5: ping-ponging should be possible (although this is an unlikely pernicious case)
-  await E(pricePushAdminC).pushResult({ roundId: 5, unitPrice: 1000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 5, unitPrice: 1000n });
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
@@ -432,14 +432,14 @@ test('interleaved', async t => {
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 6, unitPrice: 1000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 6, unitPrice: 1000n });
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 7, unitPrice: 1000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 7, unitPrice: 1000n });
 
   const round5Attempt1 = await E(aggregator.creatorFacet).getRoundData(5);
   const round6Attempt1 = await E(aggregator.creatorFacet).getRoundData(6);
@@ -479,36 +479,36 @@ test('larger', async t => {
 
   // ----- round 1: usual case
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
-  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
+  await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 1000n });
   await oracleTimer.tick();
-  await E(pricePushAdminD).pushResult({ roundId: 3, unitPrice: 3000n });
+  await E(pricePushAdminD).pushPrice({ roundId: 3, unitPrice: 3000n });
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminE).pushResult({ roundId: 1, unitPrice: 300n });
+  await E(pricePushAdminE).pushPrice({ roundId: 1, unitPrice: 300n });
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
   t.deepEqual(round1Attempt1.answer, 200n);
 
   // ----- round 2: ignore late arrival
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 600n });
+  await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 600n });
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 500n });
+  await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 500n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 3, unitPrice: 1000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 3, unitPrice: 1000n });
   await oracleTimer.tick();
-  await E(pricePushAdminD).pushResult({ roundId: 1, unitPrice: 500n });
+  await E(pricePushAdminD).pushPrice({ roundId: 1, unitPrice: 500n });
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 1000n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 700n }); // this should be IGNORED since oracle C has already sent round 2
+  await E(pricePushAdminC).pushPrice({ roundId: 1, unitPrice: 700n }); // this should be IGNORED since oracle C has already sent round 2
 
   const round1Attempt2 = await E(aggregator.creatorFacet).getRoundData(1);
   const round2Attempt1 = await E(aggregator.creatorFacet).getRoundData(2);
@@ -541,9 +541,9 @@ test('suggest', async t => {
 
   // ----- round 1: basic consensus
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
-  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
-  await E(pricePushAdminC).pushResult({ roundId: 1, unitPrice: 300n });
+  await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
+  await E(pricePushAdminC).pushPrice({ roundId: 1, unitPrice: 300n });
   await oracleTimer.tick();
 
   const round1Attempt1 = await E(aggregator.creatorFacet).getRoundData(1);
@@ -552,7 +552,7 @@ test('suggest', async t => {
 
   // ----- round 2: add a new oracle and confirm the suggested round is correct
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 1000n });
   const oracleCSuggestion = await E(aggregator.creatorFacet).oracleRoundState(
     'agorice1priceOracleC',
     1n,
@@ -572,10 +572,10 @@ test('suggest', async t => {
   t.deepEqual(oracleBSuggestion.oracleCount, 3);
 
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 2000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 2000n });
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushResult({ roundId: 2, unitPrice: 3000n });
+  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 3000n });
 
   const oracleASuggestion = await E(aggregator.creatorFacet).oracleRoundState(
     'agorice1priceOracleA',
@@ -587,12 +587,12 @@ test('suggest', async t => {
   t.deepEqual(oracleASuggestion.startedAt, 0n); // round 3 hasn't yet started, so it should be zeroed
 
   // ----- round 3: try using suggested round
-  await E(pricePushAdminC).pushResult({ roundId: 3, unitPrice: 100n });
+  await E(pricePushAdminC).pushPrice({ roundId: 3, unitPrice: 100n });
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: undefined, unitPrice: 200n });
+  await E(pricePushAdminA).pushPrice({ roundId: undefined, unitPrice: 200n });
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushResult({ roundId: undefined, unitPrice: 300n });
+  await E(pricePushAdminB).pushPrice({ roundId: undefined, unitPrice: 300n });
 
   const round3Attempt1 = await E(aggregator.creatorFacet).getRoundData(3);
   t.deepEqual(round3Attempt1.roundId, 3n);
@@ -626,12 +626,12 @@ test('notifications', async t => {
   ]();
 
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushResult({ roundId: 1, unitPrice: 100n });
+  await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 100n });
   t.deepEqual((await eachLatestRound.next()).value, {
     roundId: 1n,
     startedAt: 1n,
   });
-  await E(pricePushAdminB).pushResult({ roundId: 1, unitPrice: 200n });
+  await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
 
   await eventLoopIteration();
   t.deepEqual(
@@ -649,7 +649,7 @@ test('notifications', async t => {
     },
   );
 
-  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 1000n });
   // A started last round so fails to start next round
   t.deepEqual(
     // subscribe fresh because the iterator won't advance yet
@@ -660,14 +660,14 @@ test('notifications', async t => {
     },
   );
   // B gets to start it
-  await E(pricePushAdminB).pushResult({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 1000n });
   // now it's roundId=2
   t.deepEqual((await eachLatestRound.next()).value, {
     roundId: 2n,
     startedAt: 1n,
   });
   // A joins in
-  await E(pricePushAdminA).pushResult({ roundId: 2, unitPrice: 1000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 1000n });
   // writes to storage
   t.deepEqual(
     aggregator.mockStorageRoot.getBody(
@@ -693,7 +693,7 @@ test('notifications', async t => {
   );
 
   // A can start again
-  await E(pricePushAdminA).pushResult({ roundId: 3, unitPrice: 1000n });
+  await E(pricePushAdminA).pushPrice({ roundId: 3, unitPrice: 1000n });
   t.deepEqual((await eachLatestRound.next()).value, {
     roundId: 3n,
     startedAt: 1n,

--- a/packages/inter-protocol/test/test-priceAggregatorChainlink.js
+++ b/packages/inter-protocol/test/test-priceAggregatorChainlink.js
@@ -15,11 +15,9 @@ import {
 } from '@agoric/notifier/tools/testSupports.js';
 import { makeMockChainStorageRoot } from '@agoric/vats/tools/storage-test-utils.js';
 import { subscribeEach } from '@agoric/notifier';
-import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
-import { makeZoeKit } from '../../../src/zoeService/zoe.js';
-import buildManualTimer from '../../../tools/manualTimer.js';
-
-import '../../../src/contracts/exported.js';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { makeZoeKit } from '@agoric/zoe/src/zoeService/zoe.js';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 
 /** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeContext>>>} */
 const test = unknownTest;
@@ -27,8 +25,7 @@ const test = unknownTest;
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
 
-const oraclePath = `${dirname}/../../../src/contracts/oracle.js`;
-const aggregatorPath = `${dirname}/../../../src/contracts/priceAggregatorChainlink.js`;
+const aggregatorPath = `${dirname}/../src/priceAggregatorChainlink.js`;
 
 const defaultConfig = {
   maxSubmissionCount: 1000,
@@ -56,7 +53,6 @@ const makeContext = async () => {
   const { zoeService: zoe } = makeZoeKit(admin);
 
   // Pack the contracts.
-  const oracleBundle = await bundleSource(oraclePath);
   const aggregatorBundle = await bundleSource(aggregatorPath);
 
   // Install the contract on Zoe, getting an installation. We can
@@ -64,9 +60,8 @@ const makeContext = async () => {
   // of tests, we can also send the installation to someone
   // else, and they can use it to create a new contract instance
   // using the same code.
-  vatAdminState.installBundle('b1-oracle', oracleBundle);
   vatAdminState.installBundle('b1-aggregator', aggregatorBundle);
-  /** @type {Installation<import('../../../src/contracts/priceAggregatorChainlink.js').start>} */
+  /** @type {Installation<import('../src/priceAggregatorChainlink.js').start>} */
   const aggregatorInstallation = await E(zoe).installBundleID('b1-aggregator');
 
   const link = makeIssuerKit('$LINK', AssetKind.NAT);

--- a/packages/zoe/scripts/build-bundles.js
+++ b/packages/zoe/scripts/build-bundles.js
@@ -7,14 +7,6 @@ const dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 const sourceToBundle = [
   ['../src/contractFacet/vatRoot.js', '../bundles/bundle-contractFacet.js'],
-  [
-    '../src/contracts/priceAggregator.js',
-    '../bundles/bundle-priceAggregator.js',
-  ],
-  [
-    '../src/contracts/priceAggregatorChainlink.js',
-    '../bundles/bundle-priceAggregatorChainlink.js',
-  ],
 ];
 
 await createBundles(sourceToBundle, dirname);

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -375,6 +375,7 @@ export const quantize = (ratio, newDen) => {
 };
 
 const NUMERIC_RE = /^(\d\d*)(?:\.(\d*))?$/;
+/** @typedef {bigint | number | string} ParsableNumber */
 
 /**
  * Create a ratio from a given numeric value.

--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -1,4 +1,3 @@
 import './types.js';
 import './loan/types.js';
-import './priceAggregatorTypes.js';
 import './callSpread/types.js';

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -32,6 +32,11 @@ import {
 
 import '@agoric/ertp/src/types-ambient.js';
 
+/** @typedef {bigint | number | string} ParsableNumber */
+/**
+ * @typedef {Readonly<ParsableNumber | { data: ParsableNumber }>} OraclePriceSubmission
+ */
+
 /** @typedef {ParsableNumber | Ratio} Price */
 
 /** @type {(quote: PriceQuote) => PriceDescription} */

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -32,12 +32,10 @@ import {
 
 import '@agoric/ertp/src/types-ambient.js';
 
-export const INVITATION_MAKERS_DESC = 'oracle invitation';
-
 /** @typedef {ParsableNumber | Ratio} Price */
 
 /** @type {(quote: PriceQuote) => PriceDescription} */
-export const priceDescriptionFromQuote = quote => quote.quoteAmount.value[0];
+const priceDescriptionFromQuote = quote => quote.quoteAmount.value[0];
 
 /**
  * @deprecated use priceAggregatorChainlink
@@ -477,7 +475,7 @@ const start = async (zcf, privateArgs) => {
         });
       };
 
-      return zcf.makeInvitation(offerHandler, INVITATION_MAKERS_DESC);
+      return zcf.makeInvitation(offerHandler, 'oracle invitation');
     },
     /** @param {OracleKey} oracleKey */
     deleteOracle: async oracleKey => {

--- a/packages/zoe/src/contracts/priceAggregatorTypes.js
+++ b/packages/zoe/src/contracts/priceAggregatorTypes.js
@@ -16,11 +16,6 @@
  */
 
 /**
- * @typedef {bigint | number | string} ParsableNumber
- * @typedef {Readonly<ParsableNumber | { data: ParsableNumber }>} OraclePriceSubmission
- */
-
-/**
  * @typedef {Record<string, unknown> & {
  * kind?: string,
  * increment?: bigint,


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/issues/6571

## Description

An alternative to https://github.com/Agoric/agoric-sdk/pull/6712.

This leaves Zoe's example contracts alone (until https://github.com/Agoric/agoric-sdk/issues/1656). Instead, it moves the production priceAggregatorChainlink to inter-protocol. While it's more general than the Inter Protocol, in Vaults launch the only instances will be governed by Inter's economic committee. When there are other instances, we can refactor again.

Doing this frees the production contract from coupling to the example contract, letting it evolve in ways more suited to its production usage. Unlike #6712 this leaves the contract name alone, since residing in a different package suffices suffices to avoid confusion over how they relate.

### Security Considerations

None.

### Documentation Considerations

https://docs.agoric.com/guides/chainlink-integration.html may need updating, though I think that was already the case as this contract has changed significantly since the bounty.

### Testing Considerations

CI