### PR TITLE
6571 throw errors

### DIFF
--- a/packages/inter-protocol/src/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/priceAggregatorChainlink.js
@@ -429,9 +429,7 @@ const start = async (zcf, privateArgs) => {
    * @param {string} oracleId
    */
   const recordSubmission = (submission, roundId, oracleId) => {
-    if (!acceptingSubmissions(roundId)) {
-      assert.fail('round not accepting submissions');
-    }
+    acceptingSubmissions(roundId) || Fail`round not accepting submissions`;
 
     const lastRoundDetails = details.get(roundId);
     details.set(roundId, {
@@ -731,13 +729,11 @@ const start = async (zcf, privateArgs) => {
           unitPrice: valueRaw,
         }) {
           const value = Nat(valueRaw);
-          if (!(value >= minSubmissionValue)) {
-            Fail`value below minSubmissionValue ${q(minSubmissionValue)}`;
-          }
 
-          if (!(value <= maxSubmissionValue)) {
+          value >= minSubmissionValue ||
+            Fail`value below minSubmissionValue ${q(minSubmissionValue)}`;
+          value <= maxSubmissionValue ||
             Fail`value above maxSubmissionValue ${q(maxSubmissionValue)}`;
-          }
 
           const blockTimestamp = await E(timer).getCurrentTimestamp();
 

--- a/packages/inter-protocol/src/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/priceAggregatorChainlink.js
@@ -430,8 +430,7 @@ const start = async (zcf, privateArgs) => {
    */
   const recordSubmission = (submission, roundId, oracleId) => {
     if (!acceptingSubmissions(roundId)) {
-      console.error('round not accepting submissions');
-      return false;
+      assert.fail('round not accepting submissions');
     }
 
     const lastRoundDetails = details.get(roundId);
@@ -445,7 +444,6 @@ const start = async (zcf, privateArgs) => {
       lastReportedRound: roundId,
       latestSubmission: submission,
     });
-    return true;
   };
 
   /**
@@ -772,10 +770,7 @@ const start = async (zcf, privateArgs) => {
           }
 
           proposeNewRound(roundId, oracleId, blockTimestamp);
-          const recorded = recordSubmission(value, roundId, oracleId);
-          if (!recorded) {
-            return;
-          }
+          recordSubmission(value, roundId, oracleId);
 
           updateRoundAnswer(roundId, blockTimestamp);
           deleteRoundDetails(roundId);

--- a/packages/inter-protocol/src/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/priceAggregatorChainlink.js
@@ -721,11 +721,6 @@ const start = async (zcf, privateArgs) => {
       );
 
       const oracleAdmin = Far('OracleAdmin', {
-        /** Remove the oracle from the aggregator */
-        async delete() {
-          // The actual deletion is synchronous.
-          oracleStatuses.delete(oracleId);
-        },
         /**
          * push a unitPrice result from this oracle
          *

--- a/packages/inter-protocol/src/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/priceAggregatorChainlink.js
@@ -12,7 +12,7 @@ import {
 } from '@agoric/notifier';
 import { Nat, isNat } from '@agoric/nat';
 import { TimeMath } from '@agoric/swingset-vat/src/vats/timer/timeMath.js';
-import { Fail } from '@agoric/assert';
+import { Fail, q } from '@agoric/assert';
 import { assertAllDefined } from '@agoric/internal';
 import {
   calculateMedian,
@@ -738,6 +738,14 @@ const start = async (zcf, privateArgs) => {
           unitPrice: valueRaw,
         }) {
           const value = Nat(valueRaw);
+          if (!(value >= minSubmissionValue)) {
+            Fail`value below minSubmissionValue ${q(minSubmissionValue)}`;
+          }
+
+          if (!(value <= maxSubmissionValue)) {
+            Fail`value above maxSubmissionValue ${q(maxSubmissionValue)}`;
+          }
+
           const blockTimestamp = await E(timer).getCurrentTimestamp();
 
           let roundId;
@@ -753,20 +761,14 @@ const start = async (zcf, privateArgs) => {
             roundId = Nat(roundIdRaw);
           }
 
-          const error = validateOracleRound(oracleId, roundId, blockTimestamp);
-          if (!(value >= minSubmissionValue)) {
-            console.error('value below minSubmissionValue', minSubmissionValue);
-            return;
-          }
+          const errorMsg = validateOracleRound(
+            oracleId,
+            roundId,
+            blockTimestamp,
+          );
 
-          if (!(value <= maxSubmissionValue)) {
-            console.error('value above maxSubmissionValue');
-            return;
-          }
-
-          if (!(error === null)) {
-            console.error(error);
-            return;
+          if (!(errorMsg === null)) {
+            assert.fail(errorMsg);
           }
 
           proposeNewRound(roundId, oracleId, blockTimestamp);

--- a/packages/inter-protocol/test/test-priceAggregatorChainlink.js
+++ b/packages/inter-protocol/test/test-priceAggregatorChainlink.js
@@ -251,7 +251,12 @@ test('issue check', async t => {
 
   // ----- round 1: ignore too low values
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 50n }); // should be IGNORED
+  await t.throwsAsync(
+    E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 50n }),
+    {
+      message: 'value below minSubmissionValue 100',
+    },
+  );
   await oracleTimer.tick();
   await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
@@ -262,7 +267,10 @@ test('issue check', async t => {
 
   // ----- round 2: ignore too high values
   await oracleTimer.tick();
-  await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 20000n });
+  await t.throwsAsync(
+    E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 20000n }),
+    { message: 'value above maxSubmissionValue 10000' },
+  );
   await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 1000n });
   await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 3000n });
   await oracleTimer.tick();
@@ -295,7 +303,12 @@ test('supersede', async t => {
   // ----- round 1: round 1 is NOT supersedable when 3 submits, meaning it will be ignored
   await oracleTimer.tick();
   await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 100n });
-  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 300n });
+  await t.throwsAsync(
+    E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 300n }),
+    {
+      message: 'previous round not supersedable',
+    },
+  );
   await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
 
@@ -313,7 +326,10 @@ test('supersede', async t => {
 
   // ----- round 3: oracle C should NOT be able to supersede round 3
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushPrice({ roundId: 4, unitPrice: 1000n });
+  await t.throwsAsync(
+    E(pricePushAdminC).pushPrice({ roundId: 4, unitPrice: 1000n }),
+    { message: 'invalid round to report' },
+  );
 
   try {
     await E(aggregator.creatorFacet).getRoundData(4);
@@ -349,7 +365,12 @@ test('interleaved', async t => {
   // ----- round 1: we now need unanimous submission for a round for it to have consensus
   await oracleTimer.tick();
   await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 100n });
-  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 300n });
+  await t.throwsAsync(
+    E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 300n }),
+    {
+      message: 'previous round not supersedable',
+    },
+  );
   await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
 
@@ -366,7 +387,10 @@ test('interleaved', async t => {
   await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 2000n });
   await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 1000n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushPrice({ roundId: 3, unitPrice: 9000n });
+  await t.throwsAsync(
+    E(pricePushAdminC).pushPrice({ roundId: 3, unitPrice: 9000n }),
+    { message: 'previous round not supersedable' },
+  );
   await oracleTimer.tick();
   await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 3000n }); // assumes oracle C is going for a resubmission
   await oracleTimer.tick();
@@ -413,8 +437,14 @@ test('interleaved', async t => {
 
   // so NOW we should be able to submit round 4, and round 3 should just be copied from round 2
   await E(pricePushAdminA).pushPrice({ roundId: 4, unitPrice: 4000n });
-  await E(pricePushAdminB).pushPrice({ roundId: 4, unitPrice: 5000n });
-  await E(pricePushAdminC).pushPrice({ roundId: 4, unitPrice: 6000n });
+  await t.throwsAsync(
+    E(pricePushAdminB).pushPrice({ roundId: 4, unitPrice: 5000n }),
+    { message: /cannot report on previous rounds/ },
+  );
+  await t.throwsAsync(
+    E(pricePushAdminC).pushPrice({ roundId: 4, unitPrice: 6000n }),
+    { message: /cannot report on previous rounds/ },
+  );
   await oracleTimer.tick();
 
   const round3Attempt3 = await E(aggregator.creatorFacet).getRoundData(3);
@@ -483,9 +513,15 @@ test('larger', async t => {
   await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
   await oracleTimer.tick();
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 1000n });
+  await t.throwsAsync(
+    E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 1000n }),
+    { message: 'previous round not supersedable' },
+  );
   await oracleTimer.tick();
-  await E(pricePushAdminD).pushPrice({ roundId: 3, unitPrice: 3000n });
+  await t.throwsAsync(
+    E(pricePushAdminD).pushPrice({ roundId: 3, unitPrice: 3000n }),
+    { message: 'invalid round to report' },
+  );
   await oracleTimer.tick();
   await oracleTimer.tick();
   await oracleTimer.tick();
@@ -500,7 +536,10 @@ test('larger', async t => {
   await oracleTimer.tick();
   await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 500n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushPrice({ roundId: 3, unitPrice: 1000n });
+  await t.throwsAsync(
+    E(pricePushAdminC).pushPrice({ roundId: 3, unitPrice: 1000n }),
+    { message: 'previous round not supersedable' },
+  );
   await oracleTimer.tick();
   await E(pricePushAdminD).pushPrice({ roundId: 1, unitPrice: 500n });
   await oracleTimer.tick();
@@ -508,7 +547,11 @@ test('larger', async t => {
   await oracleTimer.tick();
   await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 1000n });
   await oracleTimer.tick();
-  await E(pricePushAdminC).pushPrice({ roundId: 1, unitPrice: 700n }); // this should be IGNORED since oracle C has already sent round 2
+  await t.throwsAsync(
+    E(pricePushAdminC).pushPrice({ roundId: 1, unitPrice: 700n }),
+    // oracle C has already sent round 2
+    { message: 'cannot report on previous rounds' },
+  );
 
   const round1Attempt2 = await E(aggregator.creatorFacet).getRoundData(1);
   const round2Attempt1 = await E(aggregator.creatorFacet).getRoundData(2);

--- a/packages/inter-protocol/test/test-priceAggregatorChainlink.js
+++ b/packages/inter-protocol/test/test-priceAggregatorChainlink.js
@@ -147,7 +147,10 @@ test('basic', async t => {
   // the restartDelay, which means its submission will be IGNORED. this means the median
   // should ONLY be between the OracleB and C values, which is why it is 25000
   await oracleTimer.tick();
-  await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 1000n });
+  await t.throwsAsync(
+    E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 1000n }),
+    { message: 'round not accepting submissions' },
+  );
   await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 2000n });
   await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 3000n });
   await oracleTimer.tick();
@@ -418,7 +421,10 @@ test('interleaved', async t => {
   await oracleTimer.tick();
   await oracleTimer.tick();
   // round 3 is NOT yet supersedeable (since no value present and not yet timed out), so these should fail
-  await E(pricePushAdminA).pushPrice({ roundId: 4, unitPrice: 4000n });
+  await t.throwsAsync(
+    E(pricePushAdminA).pushPrice({ roundId: 4, unitPrice: 4000n }),
+    { message: 'round not accepting submissions' },
+  );
   await E(pricePushAdminB).pushPrice({ roundId: 4, unitPrice: 5000n });
   await E(pricePushAdminC).pushPrice({ roundId: 4, unitPrice: 6000n });
   await oracleTimer.tick(); // --- round 3 has NOW timed out, meaning it is now supersedable
@@ -692,7 +698,10 @@ test('notifications', async t => {
     },
   );
 
-  await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 1000n });
+  await t.throwsAsync(
+    E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 1000n }),
+    { message: 'round not accepting submissions' },
+  );
   // A started last round so fails to start next round
   t.deepEqual(
     // subscribe fresh because the iterator won't advance yet


### PR DESCRIPTION
refs: #6571

## Description

- refactor: oracleID not necessarly addr
- feat: durable oracleStatuses, rounds, details
- refactor(priceAggregator): rm unused keyToRecords
- feat: throw pushPrice errors
- feat: throw recordSubmission errors
- chore: oracleAdmin cannot delete() itself

The latter three are breaking changes to the API, but only of the unreleased code, so there's no "BREAKING CHANGE" conventional commit needed to version bump.

### Security Considerations

none

### Documentation Considerations

none

### Testing Considerations

CI