### PR TITLE
fix(swing-store): move getAllState/setAllState onto a debug object

### DIFF
--- a/packages/SwingSet/test/change-parameters/test-change-parameters.js
+++ b/packages/SwingSet/test/change-parameters/test-change-parameters.js
@@ -3,23 +3,12 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import { assert } from '@agoric/assert';
-import { initSwingStore, getAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
 import { kunser } from '../../src/lib/kmarshal.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
-}
-
-// eslint-disable-next-line no-unused-vars
-function dumpState(kernelStorage, vatID) {
-  const s = getAllState(kernelStorage).kvStuff;
-  const keys = Array.from(Object.keys(s)).sort();
-  for (const k of keys) {
-    if (k.startsWith(`${vatID}.vs.`)) {
-      console.log(k, s[k]);
-    }
-  }
 }
 
 async function testChangeParameters(t) {

--- a/packages/SwingSet/test/devices/test-devices.js
+++ b/packages/SwingSet/test/devices/test-devices.js
@@ -2,7 +2,7 @@
 import { test } from '../../tools/prepare-test-env-ava.js';
 
 import bundleSource from '@endo/bundle-source';
-import { initSwingStore, getAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 import { parse } from '@endo/marshal';
 
 import {
@@ -211,7 +211,7 @@ test.serial('d2.5', async t => {
 });
 
 test.serial('device state', async t => {
-  const kernelStorage = initSwingStore().kernelStorage;
+  const { kernelStorage, debug } = initSwingStore();
   const config = {
     bootstrap: 'bootstrap',
     vats: {
@@ -236,7 +236,7 @@ test.serial('device state', async t => {
   const d3 = c1.deviceNameToID('d3');
   await c1.run();
   t.deepEqual(c1.dump().log, ['undefined', 'w+r', 'called', 'got {"s":"new"}']);
-  const s = getAllState(kernelStorage).kvStuff;
+  const s = debug.getAllState().kvStuff;
   t.deepEqual(JSON.parse(s[`${d3}.deviceState`]), kser({ s: 'new' }));
   t.deepEqual(JSON.parse(s[`${d3}.o.nextID`]), 10);
 });

--- a/packages/SwingSet/test/promise-watcher/test-promise-watcher.js
+++ b/packages/SwingSet/test/promise-watcher/test-promise-watcher.js
@@ -8,22 +8,11 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
 import { assert } from '@agoric/assert';
 // eslint-disable-next-line import/order
-import { initSwingStore, getAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
 
 function bfile(name) {
   return new URL(name, import.meta.url).pathname;
-}
-
-// eslint-disable-next-line no-unused-vars
-function dumpState(kernelStorage, vatID) {
-  const s = getAllState(kernelStorage).kvStuff;
-  const keys = Array.from(Object.keys(s)).sort();
-  for (const k of keys) {
-    if (k.startsWith(`${vatID}.vs.`)) {
-      console.log(k, s[k]);
-    }
-  }
 }
 
 async function testPromiseWatcher(t) {

--- a/packages/SwingSet/test/test-activityhash-vs-start.js
+++ b/packages/SwingSet/test/test-activityhash-vs-start.js
@@ -2,7 +2,7 @@
 import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { initSwingStore, getAllState, setAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 import { initializeSwingset, makeSwingsetController } from '../src/index.js';
 import { buildTimer } from '../src/devices/timer/timer.js';
 
@@ -38,7 +38,7 @@ test.serial('restarting kernel does not change activityhash', async t => {
   const deviceEndowments1 = {
     timer: { ...timer1.endowments },
   };
-  const ks1 = initSwingStore().kernelStorage;
+  const { kernelStorage: ks1, debug: debug1 } = initSwingStore();
   // console.log(`--c1 build`);
   await initializeSwingset(config, [], ks1);
   const c1 = await makeSwingsetController(ks1, deviceEndowments1);
@@ -49,7 +49,7 @@ test.serial('restarting kernel does not change activityhash', async t => {
   await c1.run();
 
   // console.log(`--c1 getAllState`);
-  const state = getAllState(ks1);
+  const state = debug1.getAllState();
   // console.log(`ah: ${c1.getActivityhash()}`);
 
   // console.log(`--c1 poll1`);
@@ -70,8 +70,8 @@ test.serial('restarting kernel does not change activityhash', async t => {
   const deviceEndowments2 = {
     timer: { ...timer2.endowments },
   };
-  const ks2 = initSwingStore().kernelStorage;
-  setAllState(ks2, state);
+  const { kernelStorage: ks2, debug: debug2 } = initSwingStore();
+  debug2.setAllState(state);
   // console.log(`--c2 build`);
   const c2 = await makeSwingsetController(ks2, deviceEndowments2);
   // console.log(`ah: ${c2.getActivityhash()}`);
@@ -102,14 +102,14 @@ test.serial('comms initialize is deterministic', async t => {
   const config = {};
   config.bootstrap = 'bootstrap';
   config.vats = { bootstrap: { sourceSpec } };
-  const ks1 = initSwingStore().kernelStorage;
+  const { kernelStorage: ks1, debug: debug1 } = initSwingStore();
   await initializeSwingset(config, [], ks1);
   const c1 = await makeSwingsetController(ks1, {});
   c1.pinVatRoot('bootstrap');
   // the bootstrap message will cause comms to initialize itself
   await c1.run();
 
-  const state = getAllState(ks1);
+  const state = debug1.getAllState();
 
   // but the second message should not
   c1.queueToVatRoot('bootstrap', 'addRemote', ['remote2']);
@@ -118,8 +118,8 @@ test.serial('comms initialize is deterministic', async t => {
   await c1.shutdown();
 
   // a kernel restart is loading a new kernel from the same state
-  const ks2 = initSwingStore().kernelStorage;
-  setAllState(ks2, state);
+  const { kernelStorage: ks2, debug: debug2 } = initSwingStore();
+  debug2.setAllState(state);
   const c2 = await makeSwingsetController(ks2, {});
 
   // the "am I already initialized?" check must be identical to the

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -3,7 +3,7 @@
 import { test } from '../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
 import { createHash } from 'crypto';
-import { initSwingStore, getAllState, setAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 import makeKernelKeeper from '../src/kernel/state/kernelKeeper.js';
 import { makeKernelStats } from '../src/kernel/state/stats.js';
 import { KERNEL_STATS_METRICS } from '../src/kernel/metrics.js';
@@ -70,17 +70,17 @@ async function testStorage(t, s, getState, commit) {
 }
 
 test('storageInMemory', async t => {
-  const kernelStorage = initSwingStore(null).kernelStorage;
+  const { kernelStorage, debug } = initSwingStore(null);
   await testStorage(
     t,
     kernelStorage.kvStore,
-    () => getAllState(kernelStorage).kvStuff,
+    () => debug.getAllState().kvStuff,
     null,
   );
 });
 
 test('storage helpers', t => {
-  const kernelStorage = initSwingStore(null).kernelStorage;
+  const { kernelStorage, debug } = initSwingStore(null);
   const kv = kernelStorage.kvStore;
 
   kv.set('foo.0', 'f0');
@@ -89,7 +89,7 @@ test('storage helpers', t => {
   kv.set('foo.3', 'f3');
   // omit foo.4
   kv.set('foo.5', 'f5');
-  checkState(t, () => getAllState(kernelStorage).kvStuff, [
+  checkState(t, () => debug.getAllState().kvStuff, [
     ['foo.0', 'f0'],
     ['foo.1', 'f1'],
     ['foo.2', 'f2'],
@@ -114,20 +114,20 @@ test('storage helpers', t => {
   // zero, so if there is a gap in the key sequence (e.g., 'foo.4' in the
   // above), they stop counting when they hit it
   t.truthy(kv.has('foo.5'));
-  checkState(t, () => getAllState(kernelStorage).kvStuff, [['foo.5', 'f5']]);
+  checkState(t, () => debug.getAllState().kvStuff, [['foo.5', 'f5']]);
 });
 
 function buildKeeperStorageInMemory() {
-  const kernelStorage = initSwingStore(null).kernelStorage;
+  const { kernelStorage, debug } = initSwingStore(null);
   return {
-    getState: () => getAllState(kernelStorage).kvStuff,
+    getState: () => debug.getAllState().kvStuff,
     ...kernelStorage,
   };
 }
 
 function duplicateKeeper(getState) {
-  const kernelStorage = initSwingStore(null).kernelStorage;
-  setAllState(kernelStorage, { kvStuff: getState(), streamStuff: new Map() });
+  const { kernelStorage, debug } = initSwingStore(null);
+  debug.setAllState({ kvStuff: getState(), streamStuff: new Map() });
   const kernelKeeper = makeKernelKeeper(kernelStorage, null);
   kernelKeeper.loadStats();
   return kernelKeeper;

--- a/packages/SwingSet/test/test-transcript-light.js
+++ b/packages/SwingSet/test/test-transcript-light.js
@@ -1,35 +1,35 @@
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
-import { initSwingStore, getAllState, setAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 import { buildVatController, loadBasedir } from '../src/index.js';
 
 test('transcript-light load', async t => {
   const config = await loadBasedir(
     new URL('basedir-transcript', import.meta.url).pathname,
   );
-  const kernelStorage = initSwingStore().kernelStorage;
+  const { kernelStorage, debug } = initSwingStore();
   const c = await buildVatController(config, ['one'], { kernelStorage });
   t.teardown(c.shutdown);
-  const state0 = getAllState(kernelStorage);
+  const state0 = debug.getAllState();
   t.is(state0.kvStuff.initialized, 'true');
   t.is(state0.kvStuff.runQueue, '[1,1]');
   t.not(state0.kvStuff.acceptanceQueue, '[]');
 
   await c.step();
-  const state1 = getAllState(kernelStorage);
+  const state1 = debug.getAllState();
 
   await c.step();
-  const state2 = getAllState(kernelStorage);
+  const state2 = debug.getAllState();
 
   await c.step();
-  const state3 = getAllState(kernelStorage);
+  const state3 = debug.getAllState();
 
   await c.step();
-  const state4 = getAllState(kernelStorage);
+  const state4 = debug.getAllState();
 
   await c.step();
-  const state5 = getAllState(kernelStorage);
+  const state5 = debug.getAllState();
 
   // build from loaded state
   // Step 0
@@ -37,74 +37,74 @@ test('transcript-light load', async t => {
   const cfg0 = await loadBasedir(
     new URL('basedir-transcript', import.meta.url).pathname,
   );
-  const kernelStorage0 = initSwingStore().kernelStorage;
-  setAllState(kernelStorage0, state0);
+  const { kernelStorage: kernelStorage0, debug: debug0 } = initSwingStore();
+  debug0.setAllState(state0);
   const c0 = await buildVatController(cfg0, ['one'], {
     kernelStorage: kernelStorage0,
   });
   t.teardown(c0.shutdown);
 
   await c0.step();
-  t.deepEqual(state1, getAllState(kernelStorage0), `p1`);
+  t.deepEqual(state1, debug0.getAllState(), `p1`);
 
   await c0.step();
-  t.deepEqual(state2, getAllState(kernelStorage0), `p2`);
+  t.deepEqual(state2, debug0.getAllState(), `p2`);
 
   await c0.step();
-  t.deepEqual(state3, getAllState(kernelStorage0), `p3`);
+  t.deepEqual(state3, debug0.getAllState(), `p3`);
 
   await c0.step();
-  t.deepEqual(state4, getAllState(kernelStorage0), `p4`);
+  t.deepEqual(state4, debug0.getAllState(), `p4`);
 
   await c0.step();
-  t.deepEqual(state5, getAllState(kernelStorage0), `p5`);
+  t.deepEqual(state5, debug0.getAllState(), `p5`);
 
   // Step 1
 
   const cfg1 = await loadBasedir(
     new URL('basedir-transcript', import.meta.url).pathname,
   );
-  const kernelStorage1 = initSwingStore().kernelStorage;
-  setAllState(kernelStorage1, state1);
+  const { kernelStorage: kernelStorage1, debug: debug1 } = initSwingStore();
+  debug1.setAllState(state1);
   const c1 = await buildVatController(cfg1, ['one'], {
     kernelStorage: kernelStorage1,
   });
   t.teardown(c1.shutdown);
 
-  t.deepEqual(state1, getAllState(kernelStorage1), `p6`); // actual, expected
+  t.deepEqual(state1, debug1.getAllState(), `p6`); // actual, expected
 
   await c1.step();
-  t.deepEqual(state2, getAllState(kernelStorage1), `p7`);
+  t.deepEqual(state2, debug1.getAllState(), `p7`);
 
   await c1.step();
-  t.deepEqual(state3, getAllState(kernelStorage1), `p8`);
+  t.deepEqual(state3, debug1.getAllState(), `p8`);
 
   await c1.step();
-  t.deepEqual(state4, getAllState(kernelStorage1), `p9`);
+  t.deepEqual(state4, debug1.getAllState(), `p9`);
 
   await c1.step();
-  t.deepEqual(state5, getAllState(kernelStorage1), `p10`);
+  t.deepEqual(state5, debug1.getAllState(), `p10`);
 
   // Step 2
 
   const cfg2 = await loadBasedir(
     new URL('basedir-transcript', import.meta.url).pathname,
   );
-  const kernelStorage2 = initSwingStore().kernelStorage;
-  setAllState(kernelStorage2, state2);
+  const { kernelStorage: kernelStorage2, debug: debug2 } = initSwingStore();
+  debug2.setAllState(state2);
   const c2 = await buildVatController(cfg2, ['one'], {
     kernelStorage: kernelStorage2,
   });
   t.teardown(c2.shutdown);
 
-  t.deepEqual(state2, getAllState(kernelStorage2), `p11`);
+  t.deepEqual(state2, debug2.getAllState(), `p11`);
 
   await c2.step();
-  t.deepEqual(state3, getAllState(kernelStorage2), `p12`);
+  t.deepEqual(state3, debug2.getAllState(), `p12`);
 
   await c2.step();
-  t.deepEqual(state4, getAllState(kernelStorage2), `p13`);
+  t.deepEqual(state4, debug2.getAllState(), `p13`);
 
   await c2.step();
-  t.deepEqual(state5, getAllState(kernelStorage2), `p14`);
+  t.deepEqual(state5, debug2.getAllState(), `p14`);
 });

--- a/packages/SwingSet/test/test-transcript.js
+++ b/packages/SwingSet/test/test-transcript.js
@@ -1,19 +1,19 @@
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
-import { initSwingStore, getAllState, setAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 
 // import fs from 'fs';
 import { buildVatController, loadBasedir } from '../src/index.js';
 
-async function buildTrace(c, kernelStorage) {
+async function buildTrace(c, getAllState) {
   const states = [];
   while (c.dump().runQueue.length && c.dump().gcActions.length) {
-    states.push(getAllState(kernelStorage));
+    states.push(getAllState());
     // eslint-disable-next-line no-await-in-loop
     await c.step();
   }
-  states.push(getAllState(kernelStorage));
+  states.push(getAllState());
   await c.shutdown();
   return states;
 }
@@ -22,11 +22,11 @@ test('transcript-one save', async t => {
   const config = await loadBasedir(
     new URL('basedir-transcript', import.meta.url).pathname,
   );
-  const kernelStorage = initSwingStore().kernelStorage;
+  const { kernelStorage, debug } = initSwingStore();
   const c1 = await buildVatController(config, ['one'], {
     kernelStorage,
   });
-  const states1 = await buildTrace(c1, kernelStorage);
+  const states1 = await buildTrace(c1, debug.getAllState);
   /*
   states1.forEach( (s, i) =>
     fs.writeFileSync(`kdata-${i}.json`, JSON.stringify(s))
@@ -35,11 +35,11 @@ test('transcript-one save', async t => {
   const config2 = await loadBasedir(
     new URL('basedir-transcript', import.meta.url).pathname,
   );
-  const kernelStorage2 = initSwingStore().kernelStorage;
+  const { kernelStorage: kernelStorage2, debug: debug2 } = initSwingStore();
   const c2 = await buildVatController(config2, ['one'], {
     kernelStorage: kernelStorage2,
   });
-  const states2 = await buildTrace(c2, kernelStorage2);
+  const states2 = await buildTrace(c2, debug2.getAllState);
 
   states1.forEach((s, i) => {
     // Too expensive!  If there is a difference in the 3MB data, AVA will spin
@@ -63,9 +63,9 @@ test('transcript-one load', async t => {
   const config = await loadBasedir(
     new URL('basedir-transcript', import.meta.url).pathname,
   );
-  const s0 = initSwingStore().kernelStorage;
+  const { kernelStorage: s0, debug: d0 } = initSwingStore();
   const c0 = await buildVatController(config, ['one'], { kernelStorage: s0 });
-  const states = await buildTrace(c0, s0);
+  const states = await buildTrace(c0, d0.getAllState);
   // states.forEach((s,j) =>
   //               fs.writeFileSync(`kdata-${j}.json`,
   //                                JSON.stringify(states[j])));
@@ -75,12 +75,12 @@ test('transcript-one load', async t => {
     const cfg = await loadBasedir(
       new URL('basedir-transcript', import.meta.url).pathname,
     );
-    const s = initSwingStore().kernelStorage;
-    setAllState(s, states[i]);
+    const { kernelStorage: s, debug: d } = initSwingStore();
+    d.setAllState(states[i]);
     // eslint-disable-next-line no-await-in-loop
     const c = await buildVatController(cfg, ['one'], { kernelStorage: s });
     // eslint-disable-next-line no-await-in-loop
-    const newstates = await buildTrace(c, s);
+    const newstates = await buildTrace(c, d.getAllState);
     // newstates.forEach((s,j) =>
     //                  fs.writeFileSync(`kdata-${i+j}-${i}+${j}.json`,
     //                                   JSON.stringify(newstates[j])));

--- a/packages/SwingSet/test/upgrade/test-upgrade-replay.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade-replay.js
@@ -2,7 +2,7 @@
 import { test } from '../../tools/prepare-test-env-ava.js';
 
 import { assert } from '@agoric/assert';
-import { initSwingStore, getAllState, setAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 import {
   buildKernelBundles,
   initializeSwingset,
@@ -45,7 +45,7 @@ test('replay after upgrade', async t => {
   };
   const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
 
-  const kernelStorage1 = initSwingStore().kernelStorage;
+  const { kernelStorage: kernelStorage1, debug: debug1 } = initSwingStore();
   {
     await initializeSwingset(copy(config), [], kernelStorage1, initOpts);
     const c1 = await makeSwingsetController(kernelStorage1, {}, runtimeOpts);
@@ -66,9 +66,9 @@ test('replay after upgrade', async t => {
   }
 
   // copy the store just to be sure
-  const state1 = getAllState(kernelStorage1);
-  const kernelStorage2 = initSwingStore().kernelStorage;
-  setAllState(kernelStorage2, state1);
+  const state1 = debug1.getAllState();
+  const { kernelStorage: kernelStorage2, debug: debug2 } = initSwingStore();
+  debug2.setAllState(state1);
   {
     const c2 = await makeSwingsetController(kernelStorage2, {}, runtimeOpts);
     t.teardown(c2.shutdown);

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -4,7 +4,7 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
 import { assert } from '@agoric/assert';
 import bundleSource from '@endo/bundle-source';
-import { initSwingStore, getAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 import { parseReachableAndVatSlot } from '../../src/kernel/state/reachable.js';
 import { parseVatSlot } from '../../src/lib/parseVatSlots.js';
 import { kunser, krefOf } from '../../src/lib/kmarshal.js';
@@ -24,8 +24,8 @@ test.before(async t => {
 });
 
 // eslint-disable-next-line no-unused-vars
-const dumpState = (kernelStorage, vatID) => {
-  const s = getAllState(kernelStorage).kvStuff;
+const dumpState = (debug, vatID) => {
+  const s = debug.getAllState().kvStuff;
   const keys = Array.from(Object.keys(s)).sort();
   for (const k of keys) {
     if (k.startsWith(`${vatID}.vs.`)) {
@@ -130,6 +130,7 @@ const testUpgrade = async (
     },
   };
 
+  // const { kernelStorage, debug } = initSwingStore();
   const { kernelStorage } = initSwingStore();
   const { kvStore } = kernelStorage;
   const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
@@ -195,7 +196,7 @@ const testUpgrade = async (
     return kvStore.has(`${vatID}.vs.vom.${vref}`);
   };
 
-  // dumpState(kernelStorage, vatID);
+  // dumpState(debug, vatID);
 
   // deduce exporter vrefs for all durable/virtual objects, and assert
   // that they're still in DB
@@ -261,7 +262,7 @@ const testUpgrade = async (
   t.is(c.kpStatus(v1p2Kref), 'rejected');
   t.deepEqual(kunser(c.kpResolution(v1p2Kref)), vatUpgradedError);
 
-  // dumpState(kernelStorage, vatID);
+  // dumpState(debug, vatID);
 
   // all the merely-virtual exports should be gone
   // for (let i = 1; i < NUM_SENSORS + 1; i += 1) {

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate-replay.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate-replay.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/order
 import { test } from '../../../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
-import { initSwingStore, getAllState, setAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 
 import {
   buildVatController,
@@ -20,7 +20,7 @@ test.serial('replay does not resurrect dead vat', async t => {
     .pathname;
   const config = await loadSwingsetConfigFile(configPath);
 
-  const kernelStorage1 = initSwingStore().kernelStorage;
+  const { kernelStorage: kernelStorage1, debug: debug1 } = initSwingStore();
   {
     const c1 = await buildVatController(config, [], {
       kernelStorage: kernelStorage1,
@@ -32,10 +32,10 @@ test.serial('replay does not resurrect dead vat', async t => {
     t.deepEqual(c1.dump().log, [`w: I ate'nt dead`]);
   }
 
-  const state1 = getAllState(kernelStorage1);
-  const kernelStorage2 = initSwingStore().kernelStorage;
+  const state1 = debug1.getAllState();
+  const { kernelStorage: kernelStorage2, debug: debug2 } = initSwingStore();
   // XXX TODO also copy transcripts
-  setAllState(kernelStorage2, state1);
+  debug2.setAllState(state1);
   {
     const c2 = await buildVatController(config, [], {
       kernelStorage: kernelStorage2,

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/order
 import { test } from '../../../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
-import { initSwingStore, getAllState, setAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 
 import {
   buildVatController,
@@ -389,7 +389,7 @@ test.serial('dispatches to the dead do not harm kernel', async t => {
     .pathname;
   const config = await loadSwingsetConfigFile(configPath);
 
-  const kernelStorage1 = initSwingStore().kernelStorage;
+  const { kernelStorage: kernelStorage1, debug: debug1 } = initSwingStore();
   {
     const c1 = await buildVatController(config, [], {
       kernelStorage: kernelStorage1,
@@ -407,10 +407,10 @@ test.serial('dispatches to the dead do not harm kernel', async t => {
       'done: Error: arbitrary reason',
     ]);
   }
-  const state1 = getAllState(kernelStorage1);
-  const kernelStorage2 = initSwingStore().kernelStorage;
+  const state1 = debug1.getAllState();
+  const { kernelStorage: kernelStorage2, debug: debug2 } = initSwingStore();
   // XXX TODO also copy transcripts
-  setAllState(kernelStorage2, state1);
+  debug2.setAllState(state1);
   {
     const c2 = await buildVatController(config, [], {
       kernelStorage: kernelStorage2,

--- a/packages/SwingSet/test/vat-admin/test-replay.js
+++ b/packages/SwingSet/test/vat-admin/test-replay.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/order
 import { test } from '../../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
-import { initSwingStore, getAllState, setAllState } from '@agoric/swing-store';
+import { initSwingStore } from '@agoric/swing-store';
 import { buildKernelBundles, buildVatController } from '../../src/index.js';
 import { kser } from '../../src/lib/kmarshal.js';
 
@@ -31,7 +31,7 @@ test.serial('replay dynamic vat', async t => {
   };
 
   // XXX TODO: also copy and check transcripts
-  const kernelStorage1 = initSwingStore().kernelStorage;
+  const { kernelStorage: kernelStorage1, debug: debug1 } = initSwingStore();
   {
     const c1 = await buildVatController(copy(config), [], {
       kernelStorage: kernelStorage1,
@@ -48,9 +48,9 @@ test.serial('replay dynamic vat', async t => {
   // we could re-use the Storage object, but I'll be paranoid and create a
   // new one.
 
-  const state1 = getAllState(kernelStorage1);
-  const kernelStorage2 = initSwingStore().kernelStorage;
-  setAllState(kernelStorage2, state1);
+  const state1 = debug1.getAllState();
+  const { kernelStorage: kernelStorage2, debug: debug2 } = initSwingStore();
+  debug2.setAllState(state1);
   {
     const c2 = await buildVatController(copy(config), [], {
       kernelStorage: kernelStorage2,


### PR DESCRIPTION
`getAllState` and `setAllState` are swing-store helper functions which copy (or set) all the state of a store at once, used exclusively for testing.

Previously, they were exported by swing-store, and applied to a `kernelStorage` object, but that depended upon a
`streamStore.dumpStreams` method that we'd rather not expose to normal users.

This commit adds a new `debug` object, next to `kernelStorage` and `hostStorage`, which holds `getAllState`, `setAllState`, and `dumpStreams`. The `kernelStorage.streamStore` object no longer has a `dumpStreams` method.

This also updates all the swingset unit tests which were using the helper functions.
