### PR TITLE
feat(swingset-tools): Expand replay tool for anachrophobia diagnosis

### DIFF
--- a/packages/SwingSet/misc-tools/extract-transcript-from-kerneldb.js
+++ b/packages/SwingSet/misc-tools/extract-transcript-from-kerneldb.js
@@ -54,6 +54,9 @@ if (!vatName) {
       )} ${len.padStart(10)} deliveries`,
     );
   }
+} else if (/(supervisor|lockdown)(B|-b)undle/.test(vatName)) {
+  const bundle = kvStore.get(vatName.replace('-bundle', 'Bundle'));
+  fs.writeFileSync(vatName.replace('Bundle', '-bundle'), bundle);
 } else {
   let vatID = vatName;
   if (allVatNames.indexOf(vatName) !== -1) {

--- a/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
+++ b/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
@@ -47,7 +47,6 @@ async function run() {
           vatParameters,
           vatSourceBundle,
         };
-        transcriptNum += 1;
         // first line of transcript is the source bundle
         fs.writeSync(fd, JSON.stringify(t));
         fs.writeSync(fd, '\n');
@@ -72,8 +71,8 @@ async function run() {
       }
       case 'deliver-result': {
         console.log(` -- deliver-result`);
-        const entry = { transcriptNum, d: delivery, syscalls };
         transcriptNum += 1;
+        const entry = { transcriptNum, d: delivery, syscalls };
         fs.writeSync(fd, JSON.stringify(entry));
         fs.writeSync(fd, '\n');
         break;
@@ -82,7 +81,6 @@ async function run() {
         console.log(' -- heap-snapshot-save');
         const { type, snapshotID } = e;
         const t = { transcriptNum, type, vatID, snapshotID };
-        transcriptNum += 1;
         fs.writeSync(fd, JSON.stringify(t));
         fs.writeSync(fd, '\n');
         break;

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -46,10 +46,11 @@ const IGNORE_SNAPSHOT_HASH_DIFFERENCES = true;
 
 const FORCED_SNAPSHOT_INITIAL = 2;
 const FORCED_SNAPSHOT_INTERVAL = 1000;
-const FORCED_RELOAD_FROM_SNAPSHOT = false;
-const KEEP_WORKER_RECENT = 0;
+const FORCED_RELOAD_FROM_SNAPSHOT = true;
+const KEEP_WORKER_RECENT = 10;
 const KEEP_WORKER_INITIAL = 2;
-const KEEP_WORKER_INTERVAL = 1;
+const KEEP_WORKER_INTERVAL = 10;
+const KEEP_WORKER_TRANSACTION_NUMS = [];
 
 const SKIP_EXTRA_SYSCALLS = true;
 const SIMULATE_VC_SYSCALLS = true;
@@ -374,7 +375,7 @@ async function replay(transcriptFile) {
 
       if (error) {
         console.error(
-          `during transcript num= ${lastTranscriptNum} for worker PID ${workerData.xsnapPID}`,
+          `during transcript num= ${lastTranscriptNum} for worker PID ${workerData.xsnapPID} (start delivery ${workerData.firstTranscriptNum})`,
         );
 
         if (error === extraSyscall && !SKIP_EXTRA_SYSCALLS) {
@@ -462,11 +463,15 @@ async function replay(transcriptFile) {
             firstTranscriptNum != null &&
             !(
               (KEEP_WORKER_INTERVAL &&
-                Math.floor(firstTranscriptNum / FORCED_SNAPSHOT_INTERVAL) %
+                Math.floor(
+                  (firstTranscriptNum - startTranscriptNum) /
+                    FORCED_SNAPSHOT_INTERVAL,
+                ) %
                   KEEP_WORKER_INTERVAL ===
                   0) ||
               idx < KEEP_WORKER_INITIAL ||
-              idx >= workers.length - KEEP_WORKER_RECENT
+              idx >= workers.length - KEEP_WORKER_RECENT ||
+              KEEP_WORKER_TRANSACTION_NUMS.includes(firstTranscriptNum)
             ),
         )
         .map(async workerData => {
@@ -482,7 +487,7 @@ async function replay(transcriptFile) {
           // eslint-disable-next-line no-await-in-loop
           await manager.shutdown();
           console.log(
-            `Shutdown worker PID ${xsnapPID} (first transcript num ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
+            `Shutdown worker PID ${xsnapPID} (start delivery ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
               Math.round(deliveryTimeSinceLastSnapshot) / 1000
             }s. Delivery time total ${
               Math.round(deliveryTimeTotal) / 1000
@@ -583,7 +588,7 @@ async function replay(transcriptFile) {
       saveSnapshotID = data.snapshotID;
       await Promise.all(
         workers.map(async workerData => {
-          const { manager, xsnapPID } = workerData;
+          const { manager, xsnapPID, firstTranscriptNum } = workerData;
           if (!manager.makeSnapshot) return;
           const { hash, rawSaveSeconds } = await manager.makeSnapshot(
             snapStore,
@@ -602,16 +607,15 @@ async function replay(transcriptFile) {
             })}\n`,
           );
           if (hash !== saveSnapshotID) {
-            const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID} for worker PID ${xsnapPID}`;
+            const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID} for worker PID ${xsnapPID} (start delivery ${firstTranscriptNum})`;
             if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
               console.warn(errorMessage);
             } else {
               throw new Error(errorMessage);
             }
           } else {
-            console.log(`made snapshot ${hash} of worker PID ${xsnapPID}`);
             console.log(
-              `made snapshot ${hash} of worker PID ${xsnapPID}.\n    Save time = ${
+              `made snapshot ${hash} of worker PID ${xsnapPID} (start delivery ${firstTranscriptNum}).\n    Save time = ${
                 Math.round(rawSaveSeconds * 1000) / 1000
               }s. Delivery time since last snapshot ${
                 Math.round(workerData.deliveryTimeSinceLastSnapshot) / 1000
@@ -631,7 +635,7 @@ async function replay(transcriptFile) {
       const { transcriptNum, d: delivery, syscalls } = data;
       lastTranscriptNum = transcriptNum;
       if (startTranscriptNum == null) {
-        startTranscriptNum = transcriptNum;
+        startTranscriptNum = transcriptNum - 1;
       }
       const makeSnapshot =
         FORCED_SNAPSHOT_INTERVAL &&
@@ -680,7 +684,9 @@ async function replay(transcriptFile) {
               })}\n`,
             );
             console.log(
-              `made snapshot ${snapshotID} after delivery ${transcriptNum} to worker PID ${xsnapPID}.\n    Save time = ${
+              `made snapshot ${snapshotID} after delivery ${transcriptNum} to worker PID ${xsnapPID} (start delivery ${
+                workerData.firstTranscriptNum
+              }).\n    Save time = ${
                 Math.round(rawSaveSeconds * 1000) / 1000
               }s. Delivery time since last snapshot ${
                 Math.round(workerData.deliveryTimeSinceLastSnapshot) / 1000
@@ -735,7 +741,7 @@ async function replay(transcriptFile) {
       }) => {
         await manager.shutdown();
         console.log(
-          `Shutdown worker PID ${xsnapPID} (first transcript num ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
+          `Shutdown worker PID ${xsnapPID} (start delivery ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
             Math.round(deliveryTimeSinceLastSnapshot) / 1000
           }s. Delivery time total ${
             Math.round(deliveryTimeTotal) / 1000

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -51,6 +51,8 @@ const USE_CUSTOM_SNAP_STORE = true;
 // Enable to output xsnap debug traces corresponding to the transcript replay
 const RECORD_XSNAP_TRACE = false;
 
+const USE_XSNAP_DEBUG = false;
+
 const pipe = promisify(pipeline);
 
 /** @type {(filename: string) => Promise<string>} */
@@ -193,6 +195,9 @@ async function replay(transcriptFile) {
     const env = /** @type {Record<string, string>} */ ({});
     if (RECORD_XSNAP_TRACE) {
       env.XSNAP_TEST_RECORD = process.cwd();
+    }
+    if (USE_XSNAP_DEBUG) {
+      env.XSNAP_DEBUG = 'true';
     }
 
     const capturePIDSpawn = /** @type {typeof spawn} */ (

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -281,6 +281,7 @@ async function replay(transcriptFile) {
         `manager created from bundle source, worker PID: ${xsnapPID}`,
       );
     } else if (data.type === 'heap-snapshot-save') {
+      if (!manager.makeSnapshot) continue; // eslint-disable-line no-continue
       saveSnapshotID = data.snapshotID;
       const h = await manager.makeSnapshot(snapStore);
       snapshotOverrideMap.set(saveSnapshotID, h);
@@ -317,7 +318,7 @@ async function replay(transcriptFile) {
       // console.log(`dr`, dr);
 
       // enable this to write periodic snapshots, for #5975 leak
-      if (false && deliveryNum % 10 === 8) {
+      if (false && deliveryNum % 10 === 8 && manager.makeSnapshot) {
         console.log(`-- writing snapshot`, xsnapPID);
         const fn = 'snapshot.xss';
         const snapstore = {

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -137,9 +137,10 @@ async function replay(transcriptFile) {
         async save(saveRaw) {
           const snapFile = `${saveSnapshotID || 'unknown'}.xss`;
           await saveRaw(snapFile);
-          const h = await fileHash(snapFile);
-          await fs.promises.rename(snapFile, `${h}.xss`);
-          return h;
+          const hash = await fileHash(snapFile);
+          const filePath = `${hash}.xss`;
+          await fs.promises.rename(snapFile, filePath);
+          return { hash, filePath };
         },
         async load(hash, loadRaw) {
           const snapFile = `${hash}.xss`;
@@ -283,17 +284,17 @@ async function replay(transcriptFile) {
     } else if (data.type === 'heap-snapshot-save') {
       if (!manager.makeSnapshot) continue; // eslint-disable-line no-continue
       saveSnapshotID = data.snapshotID;
-      const h = await manager.makeSnapshot(snapStore);
-      snapshotOverrideMap.set(saveSnapshotID, h);
-      if (h !== saveSnapshotID) {
-        const errorMessage = `Snapshot hash does not match. ${h} !== ${saveSnapshotID}`;
+      const { hash } = await manager.makeSnapshot(snapStore);
+      snapshotOverrideMap.set(saveSnapshotID, hash);
+      if (hash !== saveSnapshotID) {
+        const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID}`;
         if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
           console.warn(errorMessage);
         } else {
           throw new Error(errorMessage);
         }
       } else {
-        console.log(`made snapshot ${h}`);
+        console.log(`made snapshot ${hash}`);
       }
       saveSnapshotID = null;
     } else {

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -141,6 +141,9 @@ const argv = yargsParser(process.argv.slice(2), {
     recordXsnapTrace: false,
     useXsnapDebug: false,
   },
+  config: {
+    config: true,
+  },
   configuration: {
     'duplicate-arguments-array': false,
     'flatten-duplicate-arrays': false,
@@ -977,6 +980,23 @@ async function replay(transcriptFile) {
               argv.keepWorkerHashDifference && divergent,
             );
           }
+        }
+
+        const loadSnapshots = [].concat(
+          argv.loadSnapshots?.[transcriptNum] || [],
+        );
+        for (const snapshotID of loadSnapshots) {
+          // eslint-disable-next-line no-await-in-loop
+          await loadSnapshot(
+            {
+              snapshotID,
+              vatID,
+            },
+            argv.keepWorkerExplicitLoad ||
+              (argv.keepWorkerHashDifference &&
+                (loadSnapshots.length > 1 ||
+                  !uniqueSnapshotIDs.includes(snapshotID))),
+          );
         }
       }
     }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -48,8 +48,10 @@ const FORCED_SNAPSHOT_INITIAL = 2;
 const FORCED_SNAPSHOT_INTERVAL = 1000;
 const FORCED_RELOAD_FROM_SNAPSHOT = true;
 const KEEP_WORKER_RECENT = 10;
-const KEEP_WORKER_INITIAL = 2;
+const KEEP_WORKER_INITIAL = 0;
 const KEEP_WORKER_INTERVAL = 10;
+const KEEP_WORKER_EXPLICIT_LOAD = true;
+const KEEP_WORKER_DIVERGENT_SNAPSHOTS = true;
 const KEEP_WORKER_TRANSACTION_NUMS = [];
 
 const SKIP_EXTRA_SYSCALLS = true;
@@ -190,6 +192,7 @@ async function replay(transcriptFile) {
    *  deliveryTimeTotal: number;
    *  deliveryTimeSinceLastSnapshot: number;
    *  loadSnapshotID: string | undefined;
+   *  keep: boolean;
    *  firstTranscriptNum: number | null;
    * }} WorkerData
    */
@@ -417,7 +420,8 @@ async function replay(transcriptFile) {
   let vatParameters;
   let vatSourceBundle;
 
-  const createManager = async () => {
+  /** @param {boolean} keep */
+  const createManager = async keep => {
     /** @type {WorkerData} */
     const workerData = {
       manager: /** @type {WorkerData['manager']} */ (
@@ -427,6 +431,7 @@ async function replay(transcriptFile) {
       deliveryTimeTotal: 0,
       deliveryTimeSinceLastSnapshot: 0,
       loadSnapshotID,
+      keep,
       firstTranscriptNum: null,
     };
     workers.push(workerData);
@@ -450,7 +455,7 @@ async function replay(transcriptFile) {
   };
 
   let loadLock = Promise.resolve();
-  const loadSnapshot = async data => {
+  const loadSnapshot = async (data, keep = false) => {
     if (worker !== 'xs-worker') {
       return;
     }
@@ -459,9 +464,10 @@ async function replay(transcriptFile) {
     await Promise.all(
       workers
         .filter(
-          ({ firstTranscriptNum }, idx) =>
+          ({ firstTranscriptNum, keep: keepRequested }, idx) =>
             firstTranscriptNum != null &&
             !(
+              keepRequested ||
               (KEEP_WORKER_INTERVAL &&
                 Math.floor(
                   (firstTranscriptNum - startTranscriptNum) /
@@ -510,9 +516,11 @@ async function replay(transcriptFile) {
       if (snapshotOverrideMap.has(loadSnapshotID)) {
         loadSnapshotID = snapshotOverrideMap.get(loadSnapshotID);
       }
-      if (
-        workers.find(workerData => workerData.loadSnapshotID === loadSnapshotID)
-      ) {
+      const existingWorkerData = workers.find(
+        workerData => workerData.loadSnapshotID === loadSnapshotID,
+      );
+      if (existingWorkerData) {
+        existingWorkerData.keep ||= !!keep;
         console.log(
           `found an existing manager for snapshot ${loadSnapshotID}, skipping duplicate creation`,
         );
@@ -521,7 +529,7 @@ async function replay(transcriptFile) {
       if (data.vatID) {
         vatID = data.vatID;
       }
-      const { xsnapPID } = await createManager();
+      const { xsnapPID } = await createManager(keep);
       console.log(
         `created manager from snapshot ${loadSnapshotID}, worker PID: ${xsnapPID}`,
       );
@@ -557,7 +565,7 @@ async function replay(transcriptFile) {
     const data = JSON.parse(line);
     if (data.type === 'heap-snapshot-load') {
       if (worker === 'xs-worker') {
-        await loadSnapshot(data);
+        await loadSnapshot(data, KEEP_WORKER_EXPLICIT_LOAD);
       } else if (!workers.length) {
         throw Error(
           `Cannot replay transcript in ${worker} starting with a heap snapshot load.`,
@@ -571,7 +579,7 @@ async function replay(transcriptFile) {
       }
       ({ vatParameters, vatSourceBundle } = data);
       vatID = data.vatID;
-      const { xsnapPID } = await createManager();
+      const { xsnapPID } = await createManager(KEEP_WORKER_EXPLICIT_LOAD);
       console.log(
         `manager created from bundle source, worker PID: ${xsnapPID}`,
       );
@@ -586,50 +594,76 @@ async function replay(transcriptFile) {
       );
     } else if (data.type === 'heap-snapshot-save') {
       saveSnapshotID = data.snapshotID;
-      await Promise.all(
-        workers.map(async workerData => {
-          const { manager, xsnapPID, firstTranscriptNum } = workerData;
-          if (!manager.makeSnapshot) return;
-          const { hash, rawSaveSeconds } = await manager.makeSnapshot(
-            snapStore,
-          );
-          snapshotOverrideMap.set(saveSnapshotID, hash);
-          fs.writeSync(
-            snapshotActivityFd,
-            `${JSON.stringify({
-              transcriptFile,
-              type: 'save',
-              xsnapPID,
-              vatID,
-              transcriptNum: lastTranscriptNum,
-              snapshotID: hash,
-              saveSnapshotID,
-            })}\n`,
-          );
-          if (hash !== saveSnapshotID) {
-            const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID} for worker PID ${xsnapPID} (start delivery ${firstTranscriptNum})`;
-            if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
-              console.warn(errorMessage);
-            } else {
-              throw new Error(errorMessage);
-            }
+
+      /** @param {WorkerData} workerData */
+      const doWorkerSnapshot = async workerData => {
+        const { manager, xsnapPID, firstTranscriptNum } = workerData;
+        if (!manager.makeSnapshot) return null;
+        const { hash, rawSaveSeconds } = await manager.makeSnapshot(snapStore);
+        fs.writeSync(
+          snapshotActivityFd,
+          `${JSON.stringify({
+            transcriptFile,
+            type: 'save',
+            xsnapPID,
+            vatID,
+            transcriptNum: lastTranscriptNum,
+            snapshotID: hash,
+            saveSnapshotID,
+          })}\n`,
+        );
+        if (hash !== saveSnapshotID) {
+          const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID} for worker PID ${xsnapPID} (start delivery ${firstTranscriptNum})`;
+          if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
+            console.warn(errorMessage);
           } else {
-            console.log(
-              `made snapshot ${hash} of worker PID ${xsnapPID} (start delivery ${firstTranscriptNum}).\n    Save time = ${
-                Math.round(rawSaveSeconds * 1000) / 1000
-              }s. Delivery time since last snapshot ${
-                Math.round(workerData.deliveryTimeSinceLastSnapshot) / 1000
-              }s. Up ${
-                lastTranscriptNum - (workerData.firstTranscriptNum ?? NaN)
-              } deliveries.`,
-            );
+            throw new Error(errorMessage);
           }
-          workerData.deliveryTimeSinceLastSnapshot = 0;
-        }),
-      );
+        } else {
+          console.log(
+            `made snapshot ${hash} of worker PID ${xsnapPID} (start delivery ${firstTranscriptNum}).\n    Save time = ${
+              Math.round(rawSaveSeconds * 1000) / 1000
+            }s. Delivery time since last snapshot ${
+              Math.round(workerData.deliveryTimeSinceLastSnapshot) / 1000
+            }s. Up ${
+              lastTranscriptNum - (workerData.firstTranscriptNum ?? NaN)
+            } deliveries.`,
+          );
+        }
+        workerData.deliveryTimeSinceLastSnapshot = 0;
+        return hash;
+      };
+      const savedSnapshots = await (USE_CUSTOM_SNAP_STORE
+        ? workers.reduce(
+            async (hashes, workerData) => [
+              ...(await hashes),
+              await doWorkerSnapshot(workerData),
+            ],
+            Promise.resolve(/** @type {string[]} */ ([])),
+          )
+        : Promise.all(workers.map(doWorkerSnapshot)));
       saveSnapshotID = null;
+
+      const uniqueSnapshotIDs = new Set(savedSnapshots);
+      let divergent = uniqueSnapshotIDs.size > 1;
+      if (
+        !uniqueSnapshotIDs.has(data.snapshotID) &&
+        (divergent || savedSnapshots[0] !== null)
+      ) {
+        divergent = true;
+        snapshotOverrideMap.set(
+          data.snapshotID,
+          /** @type {string} */ (savedSnapshots[0]),
+        );
+      }
       if (FORCED_RELOAD_FROM_SNAPSHOT) {
-        await loadSnapshot(data);
+        for (const snapshotID of uniqueSnapshotIDs) {
+          // eslint-disable-next-line no-await-in-loop
+          await loadSnapshot(
+            { ...data, snapshotID },
+            KEEP_WORKER_DIVERGENT_SNAPSHOTS && divergent,
+          );
+        }
       }
     } else {
       const { transcriptNum, d: delivery, syscalls } = data;
@@ -705,7 +739,9 @@ async function replay(transcriptFile) {
         snapshotID => snapshotID != null,
       );
 
-      if (makeSnapshot && uniqueSnapshotIDs.length !== 1) {
+      const divergent = uniqueSnapshotIDs.length !== 1;
+
+      if (makeSnapshot && divergent) {
         const errorMessage = `Snapshot hashes do not match each other: ${uniqueSnapshotIDs.join(
           ', ',
         )}`;
@@ -719,10 +755,13 @@ async function replay(transcriptFile) {
       if (FORCED_RELOAD_FROM_SNAPSHOT) {
         for (const snapshotID of uniqueSnapshotIDs) {
           // eslint-disable-next-line no-await-in-loop
-          await loadSnapshot({
-            snapshotID,
-            vatID,
-          });
+          await loadSnapshot(
+            {
+              snapshotID,
+              vatID,
+            },
+            KEEP_WORKER_DIVERGENT_SNAPSHOTS && divergent,
+          );
         }
       }
     }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -192,6 +192,7 @@ async function replay(transcriptFile) {
    *  deliveryTimeTotal: number;
    *  deliveryTimeSinceLastSnapshot: number;
    *  loadSnapshotID: string | undefined;
+   *  timeOfLastCommand: number;
    *  keep: boolean;
    *  firstTranscriptNum: number | null;
    * }} WorkerData
@@ -342,6 +343,13 @@ async function replay(transcriptFile) {
     );
   }
 
+  const updateDeliveryTime = workerData => {
+    const deliveryTime = performance.now() - workerData.timeOfLastCommand;
+    workerData.timeOfLastCommand = NaN;
+    workerData.deliveryTimeTotal += deliveryTime;
+    workerData.deliveryTimeSinceLastSnapshot += deliveryTime;
+  };
+
   /** @type {Map<string, VatSyscallResult | undefined>} */
   const knownVCSyscalls = new Map();
 
@@ -366,8 +374,13 @@ async function replay(transcriptFile) {
    * @param {WorkerData} workerData
    * @returns {import('../src/kernel/vat-loader/transcript.js').CompareSyscalls}
    */
-  const makeCompareSyscalls =
-    workerData => (_vatID, originalSyscall, newSyscall, originalResponse) => {
+  const makeCompareSyscalls = workerData => {
+    const doCompare = (
+      _vatID,
+      originalSyscall,
+      newSyscall,
+      originalResponse,
+    ) => {
       const error = bestRequireIdentical(vatID, originalSyscall, newSyscall);
       if (
         error &&
@@ -416,6 +429,24 @@ async function replay(transcriptFile) {
 
       return error;
     };
+    const compareSyscalls = (
+      _vatID,
+      originalSyscall,
+      newSyscall,
+      originalResponse,
+    ) => {
+      updateDeliveryTime(workerData);
+      const result = doCompare(
+        _vatID,
+        originalSyscall,
+        newSyscall,
+        originalResponse,
+      );
+      workerData.timeOfLastCommand = performance.now();
+      return result;
+    };
+    return compareSyscalls;
+  };
 
   let vatParameters;
   let vatSourceBundle;
@@ -430,6 +461,7 @@ async function replay(transcriptFile) {
       xsnapPID: NaN,
       deliveryTimeTotal: 0,
       deliveryTimeSinceLastSnapshot: 0,
+      timeOfLastCommand: NaN,
       loadSnapshotID,
       keep,
       firstTranscriptNum: null,
@@ -690,14 +722,12 @@ async function replay(transcriptFile) {
       //     JSON.stringify(s.response[1]).slice(0, 200),
       //   );
       // }
-      const start = performance.now();
       const snapshotIDs = await Promise.all(
         workers.map(async workerData => {
           const { manager, xsnapPID } = workerData;
+          workerData.timeOfLastCommand = performance.now();
           await manager.replayOneDelivery(delivery, syscalls, transcriptNum);
-          const deliveryTime = performance.now() - start;
-          workerData.deliveryTimeTotal += deliveryTime;
-          workerData.deliveryTimeSinceLastSnapshot += deliveryTime;
+          updateDeliveryTime(workerData);
           workerData.firstTranscriptNum ??= transcriptNum - 1;
 
           // console.log(`dr`, dr);

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -47,6 +47,7 @@ const IGNORE_SNAPSHOT_HASH_DIFFERENCES = false;
 const FORCED_SNAPSHOT_INITIAL = 2;
 const FORCED_SNAPSHOT_INTERVAL = 1000;
 const FORCED_RELOAD_FROM_SNAPSHOT = false;
+const MAX_CONCURRENT_WORKERS = 1;
 
 const SKIP_EXTRA_SYSCALLS = true;
 const SIMULATE_VC_SYSCALLS = false;
@@ -178,7 +179,14 @@ async function replay(transcriptFile) {
         testLog,
       })
     );
-  let xsnapPID;
+  /**
+   * @typedef {{
+   *  manager: import('../src/types-external.js').VatManager;
+   *  xsnapPID: number | undefined;
+   * }} WorkerData
+   */
+  /** @type {WorkerData[]} */
+  const workers = [];
 
   if (worker === 'xs-worker') {
     // eslint-disable-next-line no-constant-condition
@@ -203,7 +211,7 @@ async function replay(transcriptFile) {
       /** @param  {Parameters<typeof spawn>} args */
       (...args) => {
         const child = spawn(...args);
-        xsnapPID = child.pid;
+        workers[workers.length - 1].xsnapPID = child.pid;
         return child;
       }
     );
@@ -344,10 +352,11 @@ async function replay(transcriptFile) {
   };
 
   /**
+   * @param {WorkerData} workerData
    * @returns {import('../src/kernel/vat-loader/transcript.js').CompareSyscalls}
    */
   const makeCompareSyscalls =
-    () => (_vatID, originalSyscall, newSyscall, originalResponse) => {
+    workerData => (_vatID, originalSyscall, newSyscall, originalResponse) => {
       const error = bestRequireIdentical(vatID, originalSyscall, newSyscall);
       if (
         error &&
@@ -357,7 +366,9 @@ async function replay(transcriptFile) {
       }
 
       if (error) {
-        console.error(`during transcript num= ${lastTranscriptNum}`);
+        console.error(
+          `during transcript num= ${lastTranscriptNum} for worker PID ${workerData.xsnapPID}`,
+        );
 
         if (error === extraSyscall && !SKIP_EXTRA_SYSCALLS) {
           return new Error('Extra syscall disallowed');
@@ -397,35 +408,47 @@ async function replay(transcriptFile) {
 
   let vatParameters;
   let vatSourceBundle;
-  /** @type {import('../src/types-external.js').VatManager | undefined} */
-  let manager;
 
   const createManager = async () => {
+    /** @type {WorkerData} */
+    const workerData = {
+      manager: /** @type {WorkerData['manager']} */ (
+        /** @type {unknown} */ (undefined)
+      ),
+      xsnapPID: NaN,
+    };
+    workers.push(workerData);
     const managerOptions =
       /** @type {import('../src/types-external.js').ManagerOptions} */ (
         /** @type {Partial<import('../src/types-external.js').ManagerOptions>} */ ({
           sourcedConsole: console,
           vatParameters,
-          compareSyscalls: makeCompareSyscalls(),
+          compareSyscalls: makeCompareSyscalls(workerData),
           useTranscript: true,
         })
       );
-    manager = await factory.createFromBundle(
+    workerData.manager = await factory.createFromBundle(
       vatID,
       vatSourceBundle,
       managerOptions,
       {},
       vatSyscallHandler,
     );
+    return workerData;
   };
 
   const loadSnapshot = async data => {
     if (worker !== 'xs-worker') {
       return;
     }
-    if (manager) {
+    while (workers.length >= MAX_CONCURRENT_WORKERS) {
+      // Keep the first ever worker, unless we're allowed one max
+      const { manager, xsnapPID } = /** @type {WorkerData} */ (
+        MAX_CONCURRENT_WORKERS > 1 ? workers.splice(1, 1)[0] : workers.pop()
+      );
+      // eslint-disable-next-line no-await-in-loop
       await manager.shutdown();
-      manager = undefined;
+      console.log(`Shutdown worker PID ${xsnapPID}`);
     }
     loadSnapshotID = data.snapshotID;
     if (snapshotOverrideMap.has(loadSnapshotID)) {
@@ -434,7 +457,7 @@ async function replay(transcriptFile) {
     if (data.vatID) {
       vatID = data.vatID;
     }
-    await createManager();
+    const { xsnapPID } = await createManager();
     console.log(
       `created manager from snapshot ${loadSnapshotID}, worker PID: ${xsnapPID}`,
     );
@@ -468,12 +491,12 @@ async function replay(transcriptFile) {
     if (data.type === 'heap-snapshot-load') {
       if (worker === 'xs-worker') {
         await loadSnapshot(data);
-      } else if (!manager) {
+      } else if (!workers.length) {
         throw Error(
           `Cannot replay transcript in ${worker} starting with a heap snapshot load.`,
         );
       }
-    } else if (!manager) {
+    } else if (!workers.length) {
       if (data.type !== 'create-vat') {
         throw Error(
           `first line of transcript was not a create-vat or heap-snapshot-load`,
@@ -481,7 +504,7 @@ async function replay(transcriptFile) {
       }
       ({ vatParameters, vatSourceBundle } = data);
       vatID = data.vatID;
-      await createManager();
+      const { xsnapPID } = await createManager();
       console.log(
         `manager created from bundle source, worker PID: ${xsnapPID}`,
       );
@@ -495,32 +518,36 @@ async function replay(transcriptFile) {
         })}\n`,
       );
     } else if (data.type === 'heap-snapshot-save') {
-      if (!manager.makeSnapshot) continue; // eslint-disable-line no-continue
       saveSnapshotID = data.snapshotID;
-      const { hash } = await manager.makeSnapshot(snapStore);
-      snapshotOverrideMap.set(saveSnapshotID, hash);
-      fs.writeSync(
-        snapshotActivityFd,
-        `${JSON.stringify({
-          transcriptFile,
-          type: 'save',
-          xsnapPID,
-          vatID,
-          transcriptNum: lastTranscriptNum,
-          snapshotID: hash,
-          saveSnapshotID,
-        })}\n`,
+      await Promise.all(
+        workers.map(async ({ manager, xsnapPID }) => {
+          if (!manager.makeSnapshot) return;
+          const { hash } = await manager.makeSnapshot(snapStore);
+          snapshotOverrideMap.set(saveSnapshotID, hash);
+          fs.writeSync(
+            snapshotActivityFd,
+            `${JSON.stringify({
+              transcriptFile,
+              type: 'save',
+              xsnapPID,
+              vatID,
+              transcriptNum: lastTranscriptNum,
+              snapshotID: hash,
+              saveSnapshotID,
+            })}\n`,
+          );
+          if (hash !== saveSnapshotID) {
+            const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID} for worker PID ${xsnapPID}`;
+            if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
+              console.warn(errorMessage);
+            } else {
+              throw new Error(errorMessage);
+            }
+          } else {
+            console.log(`made snapshot ${hash} of worker PID ${xsnapPID}`);
+          }
+        }),
       );
-      if (hash !== saveSnapshotID) {
-        const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID}`;
-        if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
-          console.warn(errorMessage);
-        } else {
-          throw new Error(errorMessage);
-        }
-      } else {
-        console.log(`made snapshot ${hash}`);
-      }
       saveSnapshotID = null;
       if (FORCED_RELOAD_FROM_SNAPSHOT) {
         await loadSnapshot(data);
@@ -528,6 +555,10 @@ async function replay(transcriptFile) {
     } else {
       const { transcriptNum, d: delivery, syscalls } = data;
       lastTranscriptNum = transcriptNum;
+      const makeSnapshot =
+        FORCED_SNAPSHOT_INTERVAL &&
+        (transcriptNum - FORCED_SNAPSHOT_INITIAL) % FORCED_SNAPSHOT_INTERVAL ===
+          0;
       // syscalls = [{ d, response }, ..]
       // console.log(`replaying:`);
       // console.log(
@@ -543,44 +574,61 @@ async function replay(transcriptFile) {
       //     JSON.stringify(s.response[1]).slice(0, 200),
       //   );
       // }
-      await manager.replayOneDelivery(delivery, syscalls, transcriptNum);
-      // console.log(`dr`, dr);
+      const snapshotIDs = await Promise.all(
+        workers.map(async ({ manager, xsnapPID }) => {
+          await manager.replayOneDelivery(delivery, syscalls, transcriptNum);
 
-      // enable this to write periodic snapshots, for #5975 leak
-      if (
-        manager.makeSnapshot &&
-        FORCED_SNAPSHOT_INTERVAL &&
-        (transcriptNum - FORCED_SNAPSHOT_INITIAL) % FORCED_SNAPSHOT_INTERVAL ===
-          0
-      ) {
-        const { hash } = await manager.makeSnapshot(snapStore);
-        fs.writeSync(
-          snapshotActivityFd,
-          `${JSON.stringify({
-            transcriptFile,
-            type: 'save',
-            xsnapPID,
-            vatID,
-            transcriptNum,
-            snapshotID: hash,
-          })}\n`,
-        );
-        console.log(`made snapshot ${hash} for delivery ${transcriptNum}`);
-        if (FORCED_RELOAD_FROM_SNAPSHOT) {
-          await loadSnapshot({
-            snapshotID: hash,
-            vatID,
-          });
+          // console.log(`dr`, dr);
+
+          // enable this to write periodic snapshots, for #5975 leak
+          if (makeSnapshot && manager.makeSnapshot) {
+            const { hash: snapshotID } = await manager.makeSnapshot(snapStore);
+            fs.writeSync(
+              snapshotActivityFd,
+              `${JSON.stringify({
+                transcriptFile,
+                type: 'save',
+                xsnapPID,
+                vatID,
+                transcriptNum,
+                snapshotID,
+              })}\n`,
+            );
+            console.log(
+              `made snapshot ${snapshotID} after delivery ${transcriptNum} to worker PID ${xsnapPID}`,
+            );
+            return snapshotID;
+          } else {
+            return null;
+          }
+        }),
+      );
+      const uniqueSnapshotIDs = [...new Set(snapshotIDs)];
+
+      if (makeSnapshot && uniqueSnapshotIDs.length !== 1) {
+        const errorMessage = `Snapshot hashes do not match each other: ${uniqueSnapshotIDs.join(
+          ', ',
+        )}`;
+        if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
+          console.warn(errorMessage);
+        } else {
+          throw new Error(errorMessage);
         }
+      }
+
+      const snapshotID = uniqueSnapshotIDs[0];
+      if (snapshotID && FORCED_RELOAD_FROM_SNAPSHOT) {
+        await loadSnapshot({
+          snapshotID,
+          vatID,
+        });
       }
     }
   }
 
   lines.close();
   fs.closeSync(snapshotActivityFd);
-  if (manager) {
-    await manager.shutdown();
-  }
+  await Promise.all(workers.map(async ({ manager }) => manager.shutdown()));
 }
 
 async function run() {

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -50,7 +50,7 @@ const FORCED_RELOAD_FROM_SNAPSHOT = false;
 
 // Use a simplified snapstore which derives the snapshot filename from the
 // transcript and doesn't compress the snapshot
-const USE_CUSTOM_SNAP_STORE = true;
+const USE_CUSTOM_SNAP_STORE = false;
 
 // Enable to output xsnap debug traces corresponding to the transcript replay
 const RECORD_XSNAP_TRACE = false;
@@ -170,7 +170,7 @@ async function replay(transcriptFile) {
           return loadRaw(snapFile);
         },
       })
-    : makeSnapStore(process.cwd(), makeSnapStoreIO());
+    : makeSnapStore(process.cwd(), makeSnapStoreIO(), { keepSnapshots: true });
   const testLog = () => {};
   const meterControl = makeDummyMeterControl();
   const gcTools = harden({
@@ -391,10 +391,10 @@ async function replay(transcriptFile) {
       lastTranscriptNum = transcriptNum;
       // syscalls = [{ d, response }, ..]
       // console.log(`replaying:`);
-      console.log(
-        `delivery ${transcriptNum} (L ${lineNumber}):`,
-        JSON.stringify(delivery).slice(0, 200),
-      );
+      // console.log(
+      //   `delivery ${transcriptNum} (L ${lineNumber}):`,
+      //   JSON.stringify(delivery).slice(0, 200),
+      // );
       // for (const s of syscalls) {
       //   // s.response = 'nope';
       //   console.log(

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -124,6 +124,7 @@ async function replay(transcriptFile) {
 
   let loadSnapshotID = null;
   let saveSnapshotID = null;
+  let lastTranscriptNum;
   const snapshotOverrideMap = new Map();
 
   const fakeKernelKeeper =
@@ -279,7 +280,6 @@ async function replay(transcriptFile) {
     transcriptF = transcriptF.pipe(zlib.createGunzip());
   }
   const lines = readline.createInterface({ input: transcriptF });
-  let deliveryNum = 0; // TODO is this aligned?
   let lineNumber = 1;
   for await (const line of lines) {
     if (lineNumber % 1000 === 0) {
@@ -305,7 +305,9 @@ async function replay(transcriptFile) {
       if (snapshotOverrideMap.has(loadSnapshotID)) {
         loadSnapshotID = snapshotOverrideMap.get(loadSnapshotID);
       }
-      vatID = data.vatID;
+      if (data.vatID) {
+        vatID = data.vatID;
+      }
       await createManager();
       console.log(
         `created manager from snapshot ${loadSnapshotID}, worker PID: ${xsnapPID}`,
@@ -340,11 +342,12 @@ async function replay(transcriptFile) {
       }
       saveSnapshotID = null;
     } else {
-      const { d: delivery, syscalls } = data;
+      const { transcriptNum, d: delivery, syscalls } = data;
+      lastTranscriptNum = transcriptNum;
       // syscalls = [{ d, response }, ..]
       // console.log(`replaying:`);
       console.log(
-        `delivery ${deliveryNum} (L ${lineNumber}):`,
+        `delivery ${transcriptNum} (L ${lineNumber}):`,
         JSON.stringify(delivery).slice(0, 200),
       );
       // for (const s of syscalls) {
@@ -356,12 +359,11 @@ async function replay(transcriptFile) {
       //     JSON.stringify(s.response[1]).slice(0, 200),
       //   );
       // }
-      await manager.replayOneDelivery(delivery, syscalls, deliveryNum);
-      deliveryNum += 1;
+      await manager.replayOneDelivery(delivery, syscalls, transcriptNum);
       // console.log(`dr`, dr);
 
       // enable this to write periodic snapshots, for #5975 leak
-      if (false && deliveryNum % 10 === 8 && manager.makeSnapshot) {
+      if (false && transcriptNum % 10 === 8 && manager.makeSnapshot) {
         console.log(`-- writing snapshot`, xsnapPID);
         const fn = 'snapshot.xss';
         const snapstore = {
@@ -386,7 +388,7 @@ async function run() {
   const args = process.argv.slice(2);
   console.log(`argv`, args);
   if (args.length < 1) {
-    console.log(`replay-one-vat.js transcript.sst`);
+    console.log(`replay-transcript.js transcript.sst`);
     return;
   }
   const [transcriptFile] = args;

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -42,12 +42,14 @@ const ABSOLUTE_SDK_PATH = null;
 const REBUILD_BUNDLES = false;
 
 // Enable to continue if snapshot hash doesn't match transcript
-const IGNORE_SNAPSHOT_HASH_DIFFERENCES = false;
+const IGNORE_SNAPSHOT_HASH_DIFFERENCES = true;
 
 const FORCED_SNAPSHOT_INITIAL = 2;
 const FORCED_SNAPSHOT_INTERVAL = 1000;
 const FORCED_RELOAD_FROM_SNAPSHOT = false;
-const MAX_CONCURRENT_WORKERS = 1;
+const KEEP_WORKER_RECENT = 0;
+const KEEP_WORKER_INITIAL = 1;
+const KEEP_WORKER_INTERVAL = 1;
 
 const SKIP_EXTRA_SYSCALLS = true;
 const SIMULATE_VC_SYSCALLS = false;
@@ -122,6 +124,7 @@ async function replay(transcriptFile) {
   let loadSnapshotID = null;
   let saveSnapshotID = null;
   let lastTranscriptNum;
+  let startTranscriptNum;
   const snapshotOverrideMap = new Map();
 
   const snapshotActivityFd = fs.openSync('snapshot-activity.jsonl', 'a');
@@ -447,27 +450,47 @@ async function replay(transcriptFile) {
     if (worker !== 'xs-worker') {
       return;
     }
-    while (workers.length >= MAX_CONCURRENT_WORKERS) {
-      // Keep the first ever worker, unless we're allowed one max
-      const {
-        manager,
-        xsnapPID,
-        deliveryTimeSinceLastSnapshot,
-        deliveryTimeTotal,
-        firstTranscriptNum,
-      } = /** @type {WorkerData} */ (
-        MAX_CONCURRENT_WORKERS > 1 ? workers.splice(1, 1)[0] : workers.pop()
-      );
-      // eslint-disable-next-line no-await-in-loop
-      await manager.shutdown();
-      console.log(
-        `Shutdown worker PID ${xsnapPID}.\n    Delivery time since last snapshot ${
-          Math.round(deliveryTimeSinceLastSnapshot) / 1000
-        }s. Delivery time total ${Math.round(deliveryTimeTotal) / 1000}s. Up ${
-          lastTranscriptNum - (firstTranscriptNum ?? NaN)
-        } deliveries.`,
-      );
-    }
+    await Promise.all(
+      workers
+        .filter(
+          ({ firstTranscriptNum }) =>
+            firstTranscriptNum != null &&
+            !(
+              (KEEP_WORKER_INTERVAL &&
+                Math.floor(firstTranscriptNum / FORCED_SNAPSHOT_INTERVAL) %
+                  KEEP_WORKER_INTERVAL ===
+                  0) ||
+              (KEEP_WORKER_RECENT > 0 &&
+                lastTranscriptNum - firstTranscriptNum <=
+                  KEEP_WORKER_RECENT * FORCED_SNAPSHOT_INTERVAL) ||
+              (KEEP_WORKER_INITIAL > 0 &&
+                firstTranscriptNum - startTranscriptNum <=
+                  KEEP_WORKER_INITIAL * FORCED_SNAPSHOT_INTERVAL)
+            ),
+        )
+        .map(async workerData => {
+          workers.splice(workers.indexOf(workerData), 1);
+
+          const {
+            manager,
+            xsnapPID,
+            deliveryTimeSinceLastSnapshot,
+            deliveryTimeTotal,
+            firstTranscriptNum,
+          } = workerData;
+          // eslint-disable-next-line no-await-in-loop
+          await manager.shutdown();
+          console.log(
+            `Shutdown worker PID ${xsnapPID} (first transcript num ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
+              Math.round(deliveryTimeSinceLastSnapshot) / 1000
+            }s. Delivery time total ${
+              Math.round(deliveryTimeTotal) / 1000
+            }s. Up ${
+              lastTranscriptNum - (firstTranscriptNum ?? NaN)
+            } deliveries.`,
+          );
+        }),
+    );
     loadSnapshotID = data.snapshotID;
     if (snapshotOverrideMap.has(loadSnapshotID)) {
       loadSnapshotID = snapshotOverrideMap.get(loadSnapshotID);
@@ -586,6 +609,9 @@ async function replay(transcriptFile) {
     } else {
       const { transcriptNum, d: delivery, syscalls } = data;
       lastTranscriptNum = transcriptNum;
+      if (startTranscriptNum == null) {
+        startTranscriptNum = transcriptNum;
+      }
       const makeSnapshot =
         FORCED_SNAPSHOT_INTERVAL &&
         (transcriptNum - FORCED_SNAPSHOT_INITIAL) % FORCED_SNAPSHOT_INTERVAL ===
@@ -648,7 +674,9 @@ async function replay(transcriptFile) {
           }
         }),
       );
-      const uniqueSnapshotIDs = [...new Set(snapshotIDs)];
+      const uniqueSnapshotIDs = [...new Set(snapshotIDs)].filter(
+        snapshotID => snapshotID != null,
+      );
 
       if (makeSnapshot && uniqueSnapshotIDs.length !== 1) {
         const errorMessage = `Snapshot hashes do not match each other: ${uniqueSnapshotIDs.join(
@@ -661,12 +689,15 @@ async function replay(transcriptFile) {
         }
       }
 
-      const snapshotID = uniqueSnapshotIDs[0];
-      if (snapshotID && FORCED_RELOAD_FROM_SNAPSHOT) {
-        await loadSnapshot({
-          snapshotID,
-          vatID,
-        });
+      if (FORCED_RELOAD_FROM_SNAPSHOT) {
+        await Promise.all(
+          uniqueSnapshotIDs.map(async snapshotID =>
+            loadSnapshot({
+              snapshotID,
+              vatID,
+            }),
+          ),
+        );
       }
     }
   }
@@ -684,7 +715,7 @@ async function replay(transcriptFile) {
       }) => {
         await manager.shutdown();
         console.log(
-          `Shutdown worker PID ${xsnapPID}.\n    Delivery time since last snapshot ${
+          `Shutdown worker PID ${xsnapPID} (first transcript num ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
             Math.round(deliveryTimeSinceLastSnapshot) / 1000
           }s. Delivery time total ${
             Math.round(deliveryTimeTotal) / 1000

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -44,6 +44,9 @@ const REBUILD_BUNDLES = false;
 // Enable to continue if snapshot hash doesn't match transcript
 const IGNORE_SNAPSHOT_HASH_DIFFERENCES = false;
 
+const FORCED_SNAPSHOT_INITIAL = 2;
+const FORCED_SNAPSHOT_INTERVAL = 1000;
+
 // Use a simplified snapstore which derives the snapshot filename from the
 // transcript and doesn't compress the snapshot
 const USE_CUSTOM_SNAP_STORE = true;
@@ -397,17 +400,25 @@ async function replay(transcriptFile) {
       // console.log(`dr`, dr);
 
       // enable this to write periodic snapshots, for #5975 leak
-      if (false && transcriptNum % 10 === 8 && manager.makeSnapshot) {
-        console.log(`-- writing snapshot`, xsnapPID);
-        const fn = 'snapshot.xss';
-        const snapstore = {
-          save(thunk) {
-            return thunk(fn);
-          },
-        };
-        // @ts-expect-error to be removed
-        await manager.makeSnapshot(snapstore);
-        // const size = fs.statSync(fn).size;
+      if (
+        manager.makeSnapshot &&
+        FORCED_SNAPSHOT_INTERVAL &&
+        (transcriptNum - FORCED_SNAPSHOT_INITIAL) % FORCED_SNAPSHOT_INTERVAL ===
+          0
+      ) {
+        const { hash } = await manager.makeSnapshot(snapStore);
+        fs.writeSync(
+          snapshotActivityFd,
+          `${JSON.stringify({
+            transcriptFile,
+            type: 'save',
+            xsnapPID,
+            vatID,
+            transcriptNum,
+            snapshotID: hash,
+          })}\n`,
+        );
+        console.log(`made snapshot ${hash} for delivery ${transcriptNum}`);
       }
     }
   }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -16,6 +16,8 @@ import { pipeline } from 'stream';
 import { performance } from 'perf_hooks';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { file as tmpFile, tmpName } from 'tmp';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import yargsParser from 'yargs-parser';
 import bundleSource from '@endo/bundle-source';
 import { makeMeasureSeconds } from '@agoric/internal';
 import { makeSnapStore } from '@agoric/swing-store';
@@ -30,44 +32,121 @@ import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
 import { makeGcAndFinalize } from '../src/lib-nodejs/gc-and-finalize.js';
 import engineGC from '../src/lib-nodejs/engine-gc.js';
 
-// Set the absolute path of the SDK to use for bundling
-// This can help if there are symlinks in the path that should be respected
-// to match the path of the SDK that produced the initial transcript
-// For e.g. set to '/src' if replaying a docker based loadgen transcript
-const ABSOLUTE_SDK_PATH = null;
-
-// Rebuild the bundles when starting the replay.
-// Disable if bundles were previously extracted form a Kernel DB, or
-// to save a few seconds and rely upon previously built versions instead
-const REBUILD_BUNDLES = false;
-
-// Enable to continue if snapshot hash doesn't match transcript
-const IGNORE_SNAPSHOT_HASH_DIFFERENCES = true;
-const IGNORE_CONCURRENT_WORKER_DIVERGENCES = true;
-
-const FORCED_SNAPSHOT_INITIAL = 2;
-const FORCED_SNAPSHOT_INTERVAL = 1000;
-const FORCED_RELOAD_FROM_SNAPSHOT = true;
-const KEEP_WORKER_RECENT = 10;
-const KEEP_WORKER_INITIAL = 0;
-const KEEP_WORKER_INTERVAL = 10;
-const KEEP_WORKER_EXPLICIT_LOAD = true;
-const KEEP_WORKER_DIVERGENT_SNAPSHOTS = true;
-const KEEP_WORKER_TRANSACTION_NUMS = [];
-
-const SKIP_EXTRA_SYSCALLS = true;
-const SIMULATE_VC_SYSCALLS = true;
-
-// Use a simplified snapstore which derives the snapshot filename from the
-// transcript and doesn't compress the snapshot
-const USE_CUSTOM_SNAP_STORE = false;
-
-// Enable to output xsnap debug traces corresponding to the transcript replay
-const RECORD_XSNAP_TRACE = false;
-
-const USE_XSNAP_DEBUG = false;
-
 const pipe = promisify(pipeline);
+
+// TODO: switch to full yargs for documenting output
+const argv = yargsParser(process.argv.slice(2), {
+  string: [
+    // Set the absolute path of the SDK to use for bundling
+    // This can help if there are symlinks in the path that should be respected
+    // to match the path of the SDK that produced the initial transcript
+    // For e.g. set to '/src' if replaying a docker based loadgen transcript
+    'absoluteSdkPath',
+  ],
+
+  boolean: [
+    // Rebuild the bundles when starting the replay.
+    // Disable if bundles were previously extracted form a Kernel DB, or to
+    // save a few seconds and rely upon previously built versions instead.
+    'rebuildBundles',
+
+    // Enable to continue if snapshot hash doesn't match hash in transcript's
+    // 'save', or when the hash of the concurrent workers snapshots don't all
+    // match each other.
+    'ignoreSnapshotHashDifference',
+
+    // Enable to continue if concurrent workers do not produce the exact same
+    // set of syscalls for a delivery. With special virtual collection syscall
+    // handling (see below), all workers would normally have to diverge from
+    // the transcript in the same way for the delivery to be considered valid.
+    'ignoreConcurrentWorkerDivergences',
+
+    // If a snapshot of a worker is taken, create a new worker from that
+    // snapshot, even if no explicit snapshot load instruction is found in the
+    // input transcript.
+    'forcedReloadFromSnapshot',
+
+    // Mark workers loaded from an explicit transcript load instruction as
+    // being ineligible from being reaped.
+    'keepWorkerExplicitLoad',
+
+    // When `forcedReloadFromSnapshot` is enabled, if the hash of the/ snapshot
+    // had differences (see `ignoreSnapshotHashDifference`), mark the worker(s)
+    // created for this/these snapshot(s) as being ineligible from being reaped.
+    'keepWorkerHashDifference',
+
+    // Ignore Virtual Collection metadata syscalls that were recorded in the
+    // transcript but which are not performed by the worker.
+    'skipExtraVcSyscalls',
+
+    // Simulate Virtual Collection metadata syscalls which were not recorded in
+    // the transcript but which are performed by the worker. This only works if
+    // previous syscalls for the same metadata were recorded.
+    'simulateVcSyscalls',
+
+    // Use a simplified snapstore which derives the snapshot filename from the
+    // transcript and doesn't compress the snapshot
+    'useCustomSnapStore',
+
+    // Enable to output xsnap debug traces corresponding to the transcript replay
+    'recordXsnapTrace',
+
+    // Use the debug version of the xsnap worker
+    'useXsnapDebug',
+  ],
+  number: [
+    // Force making a snapshot after the "initial" deliveryNum, and every
+    // "interval" delivery after. The default Swingset config is after delivery
+    // 2 and every 1000 deliveries after (1002, 2002, etc.)
+    'forcedSnapshotInitial',
+    'forcedSnapshotInterval',
+
+    // Do not reap the first n "initial" and m "recent" workers.
+    // This may keep less workers than the first n or m * forcedSnapshotInterval
+    // if there are snapshots with different hashes taken for the same delivery
+    'keepWorkerInitial',
+    'keepWorkerRecent',
+
+    // Keep all workers which are made at deliveryNum which are a multiple of
+    // n * forcedSnapshotInterval from the first transcript delivery replayed.
+    // For example if the value of this option is 10, the snapshot interval is
+    // the default of 1000, and the first transcript loaded is 52002, then all
+    // workers loaded from delivery 62002, 72002, etc. won't be reaped.
+    'keepWorkerInterval',
+  ],
+  array: [
+    {
+      // Keep all workers which are made at the explicitly provided deliveryNum
+      key: 'keepWorkerTransactionNums',
+      number: true,
+    },
+  ],
+  default: {
+    absoluteSdkPath: '',
+    rebuildBundles: false,
+    ignoreSnapshotHashDifference: true,
+    ignoreConcurrentWorkerDivergences: true,
+    forcedSnapshotInitial: 2,
+    forcedSnapshotInterval: 1000,
+    forcedReloadFromSnapshot: true,
+    keepWorkerInitial: 0,
+    keepWorkerRecent: 10,
+    keepWorkerInterval: 10,
+    keepWorkerExplicitLoad: true,
+    keepWorkerHashDifference: true,
+    keepWorkerTransactionNums: [],
+    skipExtraVcSyscalls: true,
+    simulateVcSyscalls: true,
+    useCustomSnapStore: false,
+    recordXsnapTrace: false,
+    useXsnapDebug: false,
+  },
+  configuration: {
+    'duplicate-arguments-array': false,
+    'flatten-duplicate-arrays': false,
+    'greedy-arrays': true,
+  },
+});
 
 /** @type {(filename: string) => Promise<string>} */
 async function fileHash(filename) {
@@ -96,7 +175,7 @@ function makeSnapStoreIO() {
 async function makeBundles() {
   const controllerUrl = new URL(
     `${
-      ABSOLUTE_SDK_PATH ? `${ABSOLUTE_SDK_PATH}/packages/SwingSet` : '..'
+      argv.absoluteSdkPath ? `${argv.absoluteSdkPath}/packages/SwingSet` : '..'
     }/src/controller/initializeSwingset.js`,
     import.meta.url,
   );
@@ -155,7 +234,7 @@ async function replay(transcriptFile) {
       })
     );
 
-  const snapStore = USE_CUSTOM_SNAP_STORE
+  const snapStore = argv.useCustomSnapStore
     ? /** @type {SnapStore} */ ({
         async save(saveRaw) {
           const snapFile = `${saveSnapshotID || 'unknown'}.xss`;
@@ -205,7 +284,7 @@ async function replay(transcriptFile) {
 
   if (worker === 'xs-worker') {
     // eslint-disable-next-line no-constant-condition
-    if (REBUILD_BUNDLES) {
+    if (argv.rebuildBundles) {
       console.log(`creating xsnap helper bundles`);
       await makeBundles();
       console.log(`xsnap helper bundles created`);
@@ -215,10 +294,10 @@ async function replay(transcriptFile) {
       JSON.parse(fs.readFileSync('supervisor-bundle', 'utf-8')),
     ];
     const env = /** @type {Record<string, string>} */ ({});
-    if (RECORD_XSNAP_TRACE) {
+    if (argv.recordXsnapTrace) {
       env.XSNAP_TEST_RECORD = process.cwd();
     }
-    if (USE_XSNAP_DEBUG) {
+    if (argv.useXsnapDebug) {
       env.XSNAP_DEBUG = 'true';
     }
 
@@ -338,7 +417,7 @@ async function replay(transcriptFile) {
   })();
 
   if (
-    (SIMULATE_VC_SYSCALLS || SKIP_EXTRA_SYSCALLS) &&
+    (argv.simulateVcSyscalls || argv.skipExtraVcSyscalls) &&
     !supportsRelaxedSyscalls
   ) {
     console.warn(
@@ -403,7 +482,7 @@ async function replay(transcriptFile) {
       }
     }
     syscallResults = {};
-    if (divergent && !IGNORE_CONCURRENT_WORKER_DIVERGENCES) {
+    if (divergent && !argv.ignoreConcurrentWorkerDivergences) {
       throw new Error('Divergent execution between workers');
     }
   };
@@ -482,19 +561,19 @@ async function replay(transcriptFile) {
           `during transcript num= ${lastTranscriptNum} for worker PID ${workerData.xsnapPID} (start delivery ${workerData.firstTranscriptNum})`,
         );
 
-        if (error === extraSyscall && !SKIP_EXTRA_SYSCALLS) {
+        if (error === extraSyscall && !argv.skipExtraVcSyscalls) {
           return new Error('Extra syscall disallowed');
         }
       }
 
       const newSyscallKind = newSyscall[0];
 
-      if (error === missingSyscall && !SIMULATE_VC_SYSCALLS) {
+      if (error === missingSyscall && !argv.simulateVcSyscalls) {
         return new Error('Missing syscall disallowed');
       }
 
       if (
-        SIMULATE_VC_SYSCALLS &&
+        argv.simulateVcSyscalls &&
         supportsRelaxedSyscalls &&
         !error &&
         (newSyscallKind === 'vatstoreGet' ||
@@ -598,16 +677,16 @@ async function replay(transcriptFile) {
             firstTranscriptNum != null &&
             !(
               keepRequested ||
-              (KEEP_WORKER_INTERVAL &&
+              (argv.keepWorkerInterval &&
                 Math.floor(
                   (firstTranscriptNum - startTranscriptNum) /
-                    FORCED_SNAPSHOT_INTERVAL,
+                    argv.forcedSnapshotInterval,
                 ) %
-                  KEEP_WORKER_INTERVAL ===
+                  argv.keepWorkerInterval ===
                   0) ||
-              idx < KEEP_WORKER_INITIAL ||
-              idx >= workers.length - KEEP_WORKER_RECENT ||
-              KEEP_WORKER_TRANSACTION_NUMS.includes(firstTranscriptNum)
+              idx < argv.keepWorkerInitial ||
+              idx >= workers.length - argv.keepWorkerRecent ||
+              argv.keepWorkerTransactionNums.includes(firstTranscriptNum)
             ),
         )
         .map(async workerData => {
@@ -697,7 +776,7 @@ async function replay(transcriptFile) {
       const data = JSON.parse(line);
       if (data.type === 'heap-snapshot-load') {
         if (worker === 'xs-worker') {
-          await loadSnapshot(data, KEEP_WORKER_EXPLICIT_LOAD);
+          await loadSnapshot(data, argv.keepWorkerExplicitLoad);
         } else if (!workers.length) {
           throw Error(
             `Cannot replay transcript in ${worker} starting with a heap snapshot load.`,
@@ -711,7 +790,7 @@ async function replay(transcriptFile) {
         }
         ({ vatParameters, vatSourceBundle } = data);
         vatID = data.vatID;
-        const { xsnapPID } = await createManager(KEEP_WORKER_EXPLICIT_LOAD);
+        const { xsnapPID } = await createManager(argv.keepWorkerExplicitLoad);
         console.log(
           `manager created from bundle source, worker PID: ${xsnapPID}`,
         );
@@ -748,7 +827,7 @@ async function replay(transcriptFile) {
           );
           if (hash !== saveSnapshotID) {
             const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID} for worker PID ${xsnapPID} (start delivery ${firstTranscriptNum})`;
-            if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
+            if (argv.ignoreSnapshotHashDifference) {
               console.warn(errorMessage);
             } else {
               throw new Error(errorMessage);
@@ -767,7 +846,7 @@ async function replay(transcriptFile) {
           workerData.deliveryTimeSinceLastSnapshot = 0;
           return hash;
         };
-        const savedSnapshots = await (USE_CUSTOM_SNAP_STORE
+        const savedSnapshots = await (argv.useCustomSnapStore
           ? workers.reduce(
               async (hashes, workerData) => [
                 ...(await hashes),
@@ -790,12 +869,12 @@ async function replay(transcriptFile) {
             /** @type {string} */ (savedSnapshots[0]),
           );
         }
-        if (FORCED_RELOAD_FROM_SNAPSHOT) {
+        if (argv.forcedReloadFromSnapshot) {
           for (const snapshotID of uniqueSnapshotIDs) {
             // eslint-disable-next-line no-await-in-loop
             await loadSnapshot(
               { ...data, snapshotID },
-              KEEP_WORKER_DIVERGENT_SNAPSHOTS && divergent,
+              argv.keepWorkerHashDifference && divergent,
             );
           }
         }
@@ -806,9 +885,9 @@ async function replay(transcriptFile) {
           startTranscriptNum = transcriptNum - 1;
         }
         const makeSnapshot =
-          FORCED_SNAPSHOT_INTERVAL &&
-          (transcriptNum - FORCED_SNAPSHOT_INITIAL) %
-            FORCED_SNAPSHOT_INTERVAL ===
+          argv.forcedSnapshotInterval &&
+          (transcriptNum - argv.forcedSnapshotInitial) %
+            argv.forcedSnapshotInterval ===
             0;
         // syscalls = [{ d, response }, ..]
         // console.log(`replaying:`);
@@ -880,14 +959,14 @@ async function replay(transcriptFile) {
           const errorMessage = `Snapshot hashes do not match each other: ${uniqueSnapshotIDs.join(
             ', ',
           )}`;
-          if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
+          if (argv.ignoreSnapshotHashDifference) {
             console.warn(errorMessage);
           } else {
             throw new Error(errorMessage);
           }
         }
 
-        if (FORCED_RELOAD_FROM_SNAPSHOT) {
+        if (argv.forcedReloadFromSnapshot) {
           for (const snapshotID of uniqueSnapshotIDs) {
             // eslint-disable-next-line no-await-in-loop
             await loadSnapshot(
@@ -895,7 +974,7 @@ async function replay(transcriptFile) {
                 snapshotID,
                 vatID,
               },
-              KEEP_WORKER_DIVERGENT_SNAPSHOTS && divergent,
+              argv.keepWorkerHashDifference && divergent,
             );
           }
         }
@@ -930,13 +1009,12 @@ async function replay(transcriptFile) {
 }
 
 async function run() {
-  const args = process.argv.slice(2);
-  console.log(`argv`, args);
-  if (args.length < 1) {
+  console.dir(argv, { depth: null });
+  if (argv._.length < 1) {
     console.log(`replay-transcript.js transcript.sst`);
     return;
   }
-  const [transcriptFile] = args;
+  const [transcriptFile] = argv._;
   console.log(`using transcript ${transcriptFile}`);
   await replay(transcriptFile);
 }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -255,6 +255,15 @@ async function replay(transcriptFile) {
     lineNumber += 1;
     const data = JSON.parse(line);
     if (data.type === 'heap-snapshot-load') {
+      if (worker !== 'xs-worker') {
+        if (manager) {
+          continue; // eslint-disable-line no-continue
+        } else {
+          throw Error(
+            `Cannot replay transcript in ${worker} starting with a heap snapshot load.`,
+          );
+        }
+      }
       if (manager) {
         await manager.shutdown();
         manager = null;

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -183,6 +183,9 @@ async function replay(transcriptFile) {
    * @typedef {{
    *  manager: import('../src/types-external.js').VatManager;
    *  xsnapPID: number | undefined;
+   *  deliveryTimeTotal: number;
+   *  deliveryTimeSinceLastSnapshot: number;
+   *  firstTranscriptNum: number | null;
    * }} WorkerData
    */
   /** @type {WorkerData[]} */
@@ -416,6 +419,9 @@ async function replay(transcriptFile) {
         /** @type {unknown} */ (undefined)
       ),
       xsnapPID: NaN,
+      deliveryTimeTotal: 0,
+      deliveryTimeSinceLastSnapshot: 0,
+      firstTranscriptNum: null,
     };
     workers.push(workerData);
     const managerOptions =
@@ -443,12 +449,24 @@ async function replay(transcriptFile) {
     }
     while (workers.length >= MAX_CONCURRENT_WORKERS) {
       // Keep the first ever worker, unless we're allowed one max
-      const { manager, xsnapPID } = /** @type {WorkerData} */ (
+      const {
+        manager,
+        xsnapPID,
+        deliveryTimeSinceLastSnapshot,
+        deliveryTimeTotal,
+        firstTranscriptNum,
+      } = /** @type {WorkerData} */ (
         MAX_CONCURRENT_WORKERS > 1 ? workers.splice(1, 1)[0] : workers.pop()
       );
       // eslint-disable-next-line no-await-in-loop
       await manager.shutdown();
-      console.log(`Shutdown worker PID ${xsnapPID}`);
+      console.log(
+        `Shutdown worker PID ${xsnapPID}.\n    Delivery time since last snapshot ${
+          Math.round(deliveryTimeSinceLastSnapshot) / 1000
+        }s. Delivery time total ${Math.round(deliveryTimeTotal) / 1000}s. Up ${
+          lastTranscriptNum - (firstTranscriptNum ?? NaN)
+        } deliveries.`,
+      );
     }
     loadSnapshotID = data.snapshotID;
     if (snapshotOverrideMap.has(loadSnapshotID)) {
@@ -520,9 +538,12 @@ async function replay(transcriptFile) {
     } else if (data.type === 'heap-snapshot-save') {
       saveSnapshotID = data.snapshotID;
       await Promise.all(
-        workers.map(async ({ manager, xsnapPID }) => {
+        workers.map(async workerData => {
+          const { manager, xsnapPID } = workerData;
           if (!manager.makeSnapshot) return;
-          const { hash } = await manager.makeSnapshot(snapStore);
+          const { hash, rawSaveSeconds } = await manager.makeSnapshot(
+            snapStore,
+          );
           snapshotOverrideMap.set(saveSnapshotID, hash);
           fs.writeSync(
             snapshotActivityFd,
@@ -545,7 +566,17 @@ async function replay(transcriptFile) {
             }
           } else {
             console.log(`made snapshot ${hash} of worker PID ${xsnapPID}`);
+            console.log(
+              `made snapshot ${hash} of worker PID ${xsnapPID}.\n    Save time = ${
+                Math.round(rawSaveSeconds * 1000) / 1000
+              }s. Delivery time since last snapshot ${
+                Math.round(workerData.deliveryTimeSinceLastSnapshot) / 1000
+              }s. Up ${
+                lastTranscriptNum - (workerData.firstTranscriptNum ?? NaN)
+              } deliveries.`,
+            );
           }
+          workerData.deliveryTimeSinceLastSnapshot = 0;
         }),
       );
       saveSnapshotID = null;
@@ -574,15 +605,22 @@ async function replay(transcriptFile) {
       //     JSON.stringify(s.response[1]).slice(0, 200),
       //   );
       // }
+      const start = performance.now();
       const snapshotIDs = await Promise.all(
-        workers.map(async ({ manager, xsnapPID }) => {
+        workers.map(async workerData => {
+          const { manager, xsnapPID } = workerData;
           await manager.replayOneDelivery(delivery, syscalls, transcriptNum);
+          const deliveryTime = performance.now() - start;
+          workerData.deliveryTimeTotal += deliveryTime;
+          workerData.deliveryTimeSinceLastSnapshot += deliveryTime;
+          workerData.firstTranscriptNum ??= transcriptNum - 1;
 
           // console.log(`dr`, dr);
 
           // enable this to write periodic snapshots, for #5975 leak
           if (makeSnapshot && manager.makeSnapshot) {
-            const { hash: snapshotID } = await manager.makeSnapshot(snapStore);
+            const { hash: snapshotID, rawSaveSeconds } =
+              await manager.makeSnapshot(snapStore);
             fs.writeSync(
               snapshotActivityFd,
               `${JSON.stringify({
@@ -595,8 +633,15 @@ async function replay(transcriptFile) {
               })}\n`,
             );
             console.log(
-              `made snapshot ${snapshotID} after delivery ${transcriptNum} to worker PID ${xsnapPID}`,
+              `made snapshot ${snapshotID} after delivery ${transcriptNum} to worker PID ${xsnapPID}.\n    Save time = ${
+                Math.round(rawSaveSeconds * 1000) / 1000
+              }s. Delivery time since last snapshot ${
+                Math.round(workerData.deliveryTimeSinceLastSnapshot) / 1000
+              }s. Up ${
+                transcriptNum - workerData.firstTranscriptNum
+              } deliveries.`,
             );
+            workerData.deliveryTimeSinceLastSnapshot = 0;
             return snapshotID;
           } else {
             return null;
@@ -628,7 +673,28 @@ async function replay(transcriptFile) {
 
   lines.close();
   fs.closeSync(snapshotActivityFd);
-  await Promise.all(workers.map(async ({ manager }) => manager.shutdown()));
+  await Promise.all(
+    workers.map(
+      async ({
+        xsnapPID,
+        manager,
+        deliveryTimeSinceLastSnapshot,
+        deliveryTimeTotal,
+        firstTranscriptNum,
+      }) => {
+        await manager.shutdown();
+        console.log(
+          `Shutdown worker PID ${xsnapPID}.\n    Delivery time since last snapshot ${
+            Math.round(deliveryTimeSinceLastSnapshot) / 1000
+          }s. Delivery time total ${
+            Math.round(deliveryTimeTotal) / 1000
+          }s. Up ${
+            lastTranscriptNum - (firstTranscriptNum ?? NaN)
+          } deliveries.`,
+        );
+      },
+    ),
+  );
 }
 
 async function run() {

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -22,7 +22,8 @@
   },
   "devDependencies": {
     "@types/tmp": "^0.2.0",
-    "tmp": "^0.2.1"
+    "tmp": "^0.2.1",
+    "yargs-parser": "^21.0.0"
   },
   "dependencies": {
     "@agoric/assert": "^0.5.1",

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -103,7 +103,7 @@ import { makeTranscriptManager } from './transcript.js';
  * @param {KernelSlog} kernelSlog
  * @param {(vso: VatSyscallObject) => VatSyscallResult} vatSyscallHandler
  * @param {boolean} workerCanBlock
- * @param {(vatID: any, originalSyscall: any, newSyscall: any) => import('./transcript.js').CompareSyscallsResult} [compareSyscalls]
+ * @param {import('./transcript.js').CompareSyscalls} [compareSyscalls]
  * @param {boolean} [useTranscript]
  * @returns {ManagerKit}
  */
@@ -119,6 +119,7 @@ function makeManagerKit(
 ) {
   assert(kernelSlog);
   const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
+  /** @type {ReturnType<typeof makeTranscriptManager> | undefined} */
   let transcriptManager;
   if (useTranscript) {
     transcriptManager = makeTranscriptManager(
@@ -236,7 +237,6 @@ function makeManagerKit(
    * just direct).
    *
    * @param {VatSyscallObject} vso
-   * @returns {VatSyscallResult}
    */
   function syscallFromWorker(vso) {
     if (transcriptManager && transcriptManager.inReplay()) {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -267,7 +267,7 @@ function makeManagerKit(
   /**
    *
    * @param { () => Promise<void>} shutdown
-   * @param {(ss: SnapStore) => Promise<SnapshotInfo>} makeSnapshot
+   * @param {(ss: SnapStore) => Promise<SnapshotInfo>} [makeSnapshot]
    * @returns {VatManager}
    */
   function getManager(shutdown, makeSnapshot) {

--- a/packages/SwingSet/src/kernel/vat-loader/transcript.js
+++ b/packages/SwingSet/src/kernel/vat-loader/transcript.js
@@ -4,11 +4,11 @@ import djson from '../../lib/djson.js';
 
 // Indicate that a syscall is missing from the transcript but is safe to
 // perform during replay
-const missingSyscall = Symbol('missing transcript syscall');
+export const missingSyscall = Symbol('missing transcript syscall');
 
 // Indicate that a syscall is recorded in the transcript but can be safely
 // ignored / skipped during replay.
-const extraSyscall = Symbol('extra transcript syscall');
+export const extraSyscall = Symbol('extra transcript syscall');
 
 /** @typedef {typeof missingSyscall | typeof extraSyscall | Error | undefined} CompareSyscallsResult */
 /**
@@ -16,6 +16,7 @@ const extraSyscall = Symbol('extra transcript syscall');
  *     vatId: any,
  *     originalSyscall: VatSyscallObject,
  *     newSyscall: VatSyscallObject,
+ *     originalResponse?: VatSyscallResult,
  *   ) => CompareSyscallsResult
  * } CompareSyscalls
  */
@@ -35,7 +36,7 @@ export function requireIdentical(vatID, originalSyscall, newSyscall) {
   return undefined;
 }
 
-const vcSyscallRE = /^vc\.\d+\.\|(?:schemata|label)$/;
+export const vcSyscallRE = /^vc\.\d+\.\|(?:schemata|label)$/;
 
 /**
  * Liveslots currently has a deficiency which results in [virtual collections
@@ -156,6 +157,7 @@ export function makeTranscriptManager(
         vatID,
         playbackSyscalls[0].d,
         newSyscall,
+        playbackSyscalls[0].response,
       );
 
       if (compareError === missingSyscall) {

--- a/packages/SwingSet/src/kernel/vat-loader/transcript.js
+++ b/packages/SwingSet/src/kernel/vat-loader/transcript.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import djson from '../../lib/djson.js';
 
 // Indicate that a syscall is missing from the transcript but is safe to
@@ -9,12 +11,19 @@ const missingSyscall = Symbol('missing transcript syscall');
 const extraSyscall = Symbol('extra transcript syscall');
 
 /** @typedef {typeof missingSyscall | typeof extraSyscall | Error | undefined} CompareSyscallsResult */
+/**
+ * @typedef {(
+ *     vatId: any,
+ *     originalSyscall: VatSyscallObject,
+ *     newSyscall: VatSyscallObject,
+ *   ) => CompareSyscallsResult
+ * } CompareSyscalls
+ */
 
 /**
  * @param {any} vatID
- * @param {object} originalSyscall
- * @param {object} newSyscall
- * @returns {CompareSyscallsResult}
+ * @param {VatSyscallObject} originalSyscall
+ * @param {VatSyscallObject} newSyscall
  */
 export function requireIdentical(vatID, originalSyscall, newSyscall) {
   if (djson.stringify(originalSyscall) !== djson.stringify(newSyscall)) {
@@ -54,8 +63,8 @@ const vcSyscallRE = /^vc\.\d+\.\|(?:schemata|label)$/;
  * `simulateSyscall` which then performs the appropriate action.
  *
  * @param {any} vatID
- * @param {object} originalSyscall
- * @param {object} newSyscall
+ * @param {VatSyscallObject} originalSyscall
+ * @param {VatSyscallObject} newSyscall
  * @returns {CompareSyscallsResult}
  */
 export function requireIdenticalExceptStableVCSyscalls(
@@ -87,6 +96,11 @@ export function requireIdenticalExceptStableVCSyscalls(
   return error;
 }
 
+/**
+ * @param {*} vatKeeper
+ * @param {*} vatID
+ * @param {CompareSyscalls} compareSyscalls
+ */
 export function makeTranscriptManager(
   vatKeeper,
   vatID,
@@ -135,6 +149,7 @@ export function makeTranscriptManager(
 
   let replayError;
 
+  /** @param {VatSyscallObject} newSyscall */
   function simulateSyscall(newSyscall) {
     while (playbackSyscalls.length) {
       const compareError = compareSyscalls(
@@ -149,6 +164,7 @@ export function makeTranscriptManager(
         return undefined;
       }
 
+      /** @type {{d: VatSyscallObject; response: VatSyscallResult}} */
       const s = playbackSyscalls.shift();
 
       if (!compareError) {

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -222,8 +222,9 @@ export {};
  *                                 vatSyscallHandler: unknown) => Promise<VatManager>,
  *            } } VatManagerFactory
  * @typedef { { deliver: (delivery: VatDeliveryObject) => Promise<VatDeliveryResult>,
+ *              replayOneDelivery: (delivery: VatDeliveryObject, expectedSyscalls: VatSyscallObject[], deliveryNum: number) => Promise<VatDeliveryResult>,
  *              replayTranscript: (startPos: StreamPosition | undefined) => Promise<number?>,
- *              makeSnapshot?: (ss: SnapStore) => Promise<SnapshotInfo>,
+ *              makeSnapshot?: undefined | ((ss: SnapStore) => Promise<SnapshotInfo>),
  *              shutdown: () => Promise<void>,
  *            } } VatManager
  *

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -40,7 +40,7 @@ export {};
  *   vatParameters: Record<string, unknown>,
  *   virtualObjectCacheSize: number,
  *   name: string,
- *   compareSyscalls?: (originalSyscall: {}, newSyscall: {}) => Error | undefined,
+ *   compareSyscalls?: import('./kernel/vat-loader/transcript.js').CompareSyscalls,
  *   sourcedConsole: Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>,
  *   meterID?: string,
  * } & (HasBundle | HasSetup)} ManagerOptions


### PR DESCRIPTION
refs: #6588

This PR is targeting `release-pismo` as this is where I've done most of the work, but it should be safe to merge into master, which I plan on doing after approval.

I spent a lot of time cleaning up the changes to make the implementation cleaner and the individual commits relevant. At this point it's almost a rewrite of the `replay-transcript.js` tool, so reviewing commit-by-commit may be easier but not necessary.

## Description

In the past month I've massively expanded the capabilities of the replay tool to support my investigation of the anachrophobia issue experienced by validators on mainnet (#6588).

This PR adds the following features:
- Extract the bundles from swingstore using the same tool used to extract transcripts.
- Add a kind of "slog" file for the replay tool to track what it does regarding snapshots in a structured way
- Switch inline `const` based config to command line options, including ability to load options from a config file
- Fix errors not exiting the process
- Handle virtual collection syscall divergence based on the fix from #6664
  - that change was first implemented as part of the replay tool, and then moved to Swingset. The replay tool now uses the Swingset implementation with a couple tweaks
- Force snapshots on interval to replicate snapshot schedule of Swingset (snapshot activity is currently not recorded in the transcript)
- Execute multiple workers concurrently: when a snapshot is loaded, keep previous workers around according to configuration, and send deliveries to all workers concurrently.
  - Option to force load snapshots that are taken. Used to make divergence bisection easier
  - Option to load specific snapshots from config at given deliveryNums without requiring the load commands to be included in the transcript (used to test version compatibility)
  - Option to keep workers loaded from snapshots matching specific constraints:
    - first N, last M, or at given intervals
    - at specific deliveryNum
    - if explicitly loaded by config/transcript
    - when different snapshots exist for a given deliveryNum
  - Report (on console output) when snapshots or syscalls diverge between workers

### Security Considerations

None, this is a debug tooling.

### Documentation Considerations

The new command line options could be better documented (with CLI based documentation), but I didn't feel like dealing with the quirks of the full `yargs` at this point.

### Testing Considerations

Main features were used extensively over the last month. Refactors/rebase to clean up was quickly tested again.
