### PR TITLE
Zalgo: synchronize syscalls when replaying in concurrent workers

### DIFF
--- a/packages/SwingSet/src/kernel/vat-loader/async-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/async-helper.js
@@ -1,0 +1,46 @@
+/**
+ * @template T
+ * @typedef {T extends PromiseLike<any> ? never : T} SyncOnly
+ */
+
+/**
+ * @template {boolean} AllowAsync
+ * @template T
+ * @typedef {true extends AllowAsync ? (Promise<T> | T) : T} MaybePromiseResult
+ */
+
+/**
+ * WARNING: Do not use, this is releasing Zalgo
+ *
+ * @template T
+ * @template R
+ * @param {T} v
+ * @param {(v: Awaited<T>) => R} handle
+ * @returns {T extends PromiseLike<any> ? Promise<Awaited<R>> : R}
+ */
+export function maybeAsync(v, handle) {
+  if (typeof v === 'object' && v !== null && 'then' in v) {
+    return Promise.resolve(v).then(handle);
+  } else {
+    return handle(v);
+  }
+}
+
+/**
+ * Somewhat tames Zalgo
+ *
+ * @template {(...args: any[]) => any} T
+ * @param {T} fn
+ * @returns {(...args: Parameters<T>) => SyncOnly<ReturnType<T>>}
+ */
+export function ensureSync(fn) {
+  // eslint-disable-next-line func-names
+  return function (...args) {
+    const result = Reflect.apply(fn, this, args);
+    if (typeof result === 'object' && result !== null && 'then' in result) {
+      throw new Error('Unexpected async result');
+    } else {
+      return result;
+    }
+  };
+}

--- a/packages/SwingSet/src/kernel/vat-loader/async-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/async-helper.js
@@ -19,7 +19,7 @@
  * @returns {T extends PromiseLike<any> ? Promise<Awaited<R>> : R}
  */
 export function maybeAsync(v, handle) {
-  if (typeof v === 'object' && v !== null && 'then' in v) {
+  if (Object(v) === v && typeof v.then === 'function') {
     return Promise.resolve(v).then(handle);
   } else {
     return handle(v);
@@ -37,7 +37,7 @@ export function ensureSync(fn) {
   // eslint-disable-next-line func-names
   return function (...args) {
     const result = Reflect.apply(fn, this, args);
-    if (typeof result === 'object' && result !== null && 'then' in result) {
+    if (Object(result) === result && typeof result.then === 'function') {
       throw new Error('Unexpected async result');
     } else {
       return result;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -237,6 +237,20 @@ function makeManagerKit(
    * just direct).
    *
    * @param {VatSyscallObject} vso
+   * @returns {VatSyscallResult}
+   */
+  function doSyscallFromWorker(vso) {
+    const vres = vatSyscallHandler(vso);
+    // vres is ['error', reason] or ['ok', null] or ['ok', capdata] or ['ok', string]
+    const [successFlag, data] = vres;
+    if (successFlag === 'ok' && data && !workerCanBlock) {
+      console.log(`warning: syscall returns data, but worker cannot get it`);
+    }
+    return vres;
+  }
+
+  /**
+   * @param {VatSyscallObject} vso
    */
   function syscallFromWorker(vso) {
     if (transcriptManager && transcriptManager.inReplay()) {
@@ -246,22 +260,14 @@ function makeManagerKit(
 
       // but if the puppy deviates one inch from previous twitches, explode
       kernelSlog.syscall(vatID, undefined, vso);
-      const vres = transcriptManager.simulateSyscall(vso);
-      if (vres) {
-        return vres;
+      return transcriptManager.simulateSyscall(vso) || doSyscallFromWorker(vso);
+    } else {
+      const vres = doSyscallFromWorker(vso);
+      if (transcriptManager) {
+        transcriptManager.addSyscall(vso, vres);
       }
+      return vres;
     }
-
-    const vres = vatSyscallHandler(vso);
-    // vres is ['error', reason] or ['ok', null] or ['ok', capdata] or ['ok', string]
-    const [successFlag, data] = vres;
-    if (successFlag === 'ok' && data && !workerCanBlock) {
-      console.log(`warning: syscall returns data, but worker cannot get it`);
-    }
-    if (transcriptManager && !transcriptManager.inReplay()) {
-      transcriptManager.addSyscall(vso, vres);
-    }
-    return vres;
   }
 
   /**

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -98,11 +98,12 @@ import { makeTranscriptManager } from './transcript.js';
  * The returned getManager() function will return a VatManager suitable for
  * handing to the kernel, which can use it to send deliveries to the vat.
  *
+ * @template {'sync' | 'async-blocking' | 'async-dropping'} WorkerAsyncKind
  * @param {string} vatID
  * @param {KernelKeeper} kernelKeeper
  * @param {KernelSlog} kernelSlog
  * @param {(vso: VatSyscallObject) => VatSyscallResult} vatSyscallHandler
- * @param {boolean} workerCanBlock
+ * @param {WorkerAsyncKind} workerAsyncKind
  * @param {import('./transcript.js').CompareSyscalls} [compareSyscalls]
  * @param {boolean} [useTranscript]
  * @returns {ManagerKit}
@@ -113,7 +114,7 @@ function makeManagerKit(
   kernelSlog,
   kernelKeeper,
   vatSyscallHandler,
-  workerCanBlock,
+  workerAsyncKind,
   compareSyscalls,
   useTranscript,
 ) {
@@ -243,7 +244,7 @@ function makeManagerKit(
     const vres = vatSyscallHandler(vso);
     // vres is ['error', reason] or ['ok', null] or ['ok', capdata] or ['ok', string]
     const [successFlag, data] = vres;
-    if (successFlag === 'ok' && data && !workerCanBlock) {
+    if (successFlag === 'ok' && data && workerAsyncKind === 'async-dropping') {
       console.log(`warning: syscall returns data, but worker cannot get it`);
     }
     return vres;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-local.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-local.js
@@ -26,7 +26,7 @@ export function makeLocalVatManagerFactory(tools) {
       kernelSlog,
       kernelKeeper,
       vatSyscallHandler,
-      true,
+      'sync',
       compareSyscalls,
       useTranscript,
     );

--- a/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
@@ -85,7 +85,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       } else if (type === 'syscall') {
         parentLog(`syscall`, args);
         const [vatSyscallObject] = args;
-        mk.syscallFromWorker(vatSyscallObject);
+        void mk.syscallFromWorker(vatSyscallObject);
       } else if (type === 'testLog') {
         testLog(...args);
       } else if (type === 'deliverDone') {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
@@ -54,7 +54,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       kernelSlog,
       kernelKeeper,
       vatSyscallHandler,
-      false,
+      'async-dropping',
       compareSyscalls,
       useTranscript,
     );

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -31,7 +31,7 @@ export function makeNodeSubprocessFactory(tools) {
       kernelSlog,
       kernelKeeper,
       vatSyscallHandler,
-      false,
+      'async-dropping',
       compareSyscalls,
       useTranscript,
     );

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -82,7 +82,7 @@ export function makeNodeSubprocessFactory(tools) {
       } else if (type === 'syscall') {
         parentLog(`syscall`, args);
         const [vatSyscallObject] = args;
-        mk.syscallFromWorker(vatSyscallObject);
+        void mk.syscallFromWorker(vatSyscallObject);
       } else if (type === 'testLog') {
         testLog(...args);
       } else if (type === 'deliverDone') {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -76,8 +76,8 @@ export function makeXsSubprocessFactory({
       useTranscript,
     );
 
-    /** @type { (item: Tagged) => unknown } */
-    function handleUpstream([type, ...args]) {
+    /** @type { (item: Tagged) => Promise<unknown> } */
+    async function handleUpstream([type, ...args]) {
       parentLog(vatID, `handleUpstream`, type, args.length);
       switch (type) {
         case 'syscall': {
@@ -107,7 +107,7 @@ export function makeXsSubprocessFactory({
     /** @type { (msg: Uint8Array) => Promise<Uint8Array> } */
     async function handleCommand(msg) {
       // parentLog('handleCommand', { length: msg.byteLength });
-      const tagged = handleUpstream(JSON.parse(decoder.decode(msg)));
+      const tagged = await handleUpstream(JSON.parse(decoder.decode(msg)));
       return encoder.encode(JSON.stringify(tagged));
     }
 

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -71,7 +71,7 @@ export function makeXsSubprocessFactory({
       kernelSlog,
       kernelKeeper,
       vatSyscallHandler,
-      true,
+      'async-blocking',
       compareSyscalls,
       useTranscript,
     );

--- a/packages/SwingSet/src/kernel/vat-loader/transcript.js
+++ b/packages/SwingSet/src/kernel/vat-loader/transcript.js
@@ -150,16 +150,50 @@ export function makeTranscriptManager(
 
   let replayError;
 
+  const failReplay = error => {
+    replayError =
+      error ||
+      replayError ||
+      new Error(`historical inaccuracy in replay of ${vatID}`);
+    throw replayError;
+  };
+
+  const checkReplayError = () => {
+    if (replayError) {
+      throw replayError;
+    }
+  };
+
   /** @param {VatSyscallObject} newSyscall */
   function simulateSyscall(newSyscall) {
-    while (playbackSyscalls.length) {
-      const compareError = compareSyscalls(
-        vatID,
-        playbackSyscalls[0].d,
-        newSyscall,
-        playbackSyscalls[0].response,
-      );
+    function simulateSyscallNext() {
+      if (!playbackSyscalls.length) {
+        // Error if the vat performs a syscall for which we don't have a
+        // corresponding entry in the transcript.
 
+        // Note that if a vat performed an "allowed" vc metadata get syscall after
+        // we reach the end of the transcript, we would error instead of
+        // falling through and performing the syscall. However liveslots does not
+        // perform vc metadata get syscalls unless it needs to provide an entry
+        // to the program, which always results in subsequent syscalls.
+        return failReplay();
+      }
+
+      // eslint-disable-next-line no-use-before-define
+      return handleCompareResult(
+        compareSyscalls(
+          vatID,
+          playbackSyscalls[0].d,
+          newSyscall,
+          playbackSyscalls[0].response,
+        ),
+      );
+    }
+    /**
+     * @param {CompareSyscallsResult} compareError
+     * @returns {VatSyscallResult | undefined}
+     */
+    function handleCompareResult(compareError) {
       if (compareError === missingSyscall) {
         // return `undefined` to indicate that this syscall cannot be simulated
         // and needs to be performed (virtual collection metadata get)
@@ -172,26 +206,14 @@ export function makeTranscriptManager(
       if (!compareError) {
         return s.response;
       } else if (compareError !== extraSyscall) {
-        replayError = compareError;
-        break;
+        return failReplay(compareError);
+      } else {
+        // Check the next transcript entry, skipping any extra syscalls recorded
+        // in the transcript (virtual collection metadata get)
+        return simulateSyscallNext();
       }
-
-      // Check the next transcript entry, skipping any extra syscalls recorded
-      // in the transcript (virtual collection metadata get)
     }
-
-    if (!replayError) {
-      // Error if the vat performs a syscall for which we don't have a
-      // corresponding entry in the transcript.
-
-      // Note that if a vat performed an "allowed" vc metadata get syscall after
-      // we reach the end of the transcript, we would error instead of
-      // falling through and performing the syscall. However liveslots does not
-      // perform vc metadata get syscalls unless it needs to provide an entry
-      // to the program, which always results in subsequent syscalls.
-      replayError = new Error(`historical inaccuracy in replay of ${vatID}`);
-    }
-    throw replayError;
+    return simulateSyscallNext();
   }
 
   function finishReplayDelivery(dnum) {
@@ -203,16 +225,7 @@ export function makeTranscriptManager(
       for (const s of playbackSyscalls) {
         console.log(`expected:`, djson.stringify(s.d));
       }
-      if (!replayError) {
-        replayError = new Error(`historical inaccuracy in replay of ${vatID}`);
-      }
-      throw replayError;
-    }
-  }
-
-  function checkReplayError() {
-    if (replayError) {
-      throw replayError;
+      failReplay();
     }
   }
 


### PR DESCRIPTION
refs: #6588

Layered on top of #6723

As usual, better reviewed commit-by-commit.

## Description

These are the changes required for the replay tool to synchronize the execution of multiple concurrent workers at the granularity of syscalls. Moddable expressed interest in being able to do this since a full delivery can be complex.

This effectively releases Zalgo onto the transcript syscall replay logic but contains it within the various worker managers, in a way that should be safe.

To be more specific, the transcript replay logic will detect a promise returned by `compareSyscalls`, in which case the worker manager will return a promise from `syscallFromWorker`, but only if the worker supports async syscalls. This is the case for all workers but `local`, which if it detects a promise will throw.

It would be a mistake for the application to configure a local manager's options to try and use such a promise returning `compareSyscalls`.

I am putting this PR up as draft to discuss the possibility of merge, but would be fine if we decide to never merge this.

### Security Considerations

None I can think of.

### Documentation Considerations

Types were updated to attempt to document the effects of releasing Zalgo. Unfortunately the type of `managerOptions` and worker kind are not currently threaded through sufficiently to surface an incompatibility in options (promise returning `compareSyscalls` used with a `local` worker type).

### Testing Considerations

Manually through the replay tool's new option.
