### PR TITLE
[WIP] Initial vat attempts to wait but does not

### DIFF
--- a/packages/SwingSet/docs/configuration.md
+++ b/packages/SwingSet/docs/configuration.md
@@ -131,7 +131,7 @@ the kernel should prompt each vat (by delivering it a `bringOutYourDead`
 directive) to perform garbage collection and notify the kernel of any dropped or
 released references that result.  This should either be an integer, indicating
 the number of deliveries that should be made to the vat before reaping, or the
-string `'never'`, indicating that such activity should never happen.  If
+string `'never'`, indicating that such activity should never happen.  It
 defaults (yes, the default has a default) to 1.
 
 The `relaxDurabilityRules` property, if `true`, allows vat code running inside
@@ -181,8 +181,8 @@ passed to the vat or device as one of its creation parameters as the second
 argument to the `buildRootObject` function.  The second argument to
 `buildVatController` or `initializeSwingset` is an array of strings, nominally
 representing command line parameters such as would be given when launching a
-statically defined vat group via a command line tool such as `swingset-runner`
-or `ag-solo`.  If such command line parameters are given to one of the vat
+statically defined vat group via a command line tool such as `swingset-runner`.
+If such command line parameters are given to one of the vat
 initiation functions, they are added to the bootstrap vat's `parameters` object
 as the property `argv`.
 

--- a/packages/SwingSet/docs/timer.md
+++ b/packages/SwingSet/docs/timer.md
@@ -10,7 +10,7 @@ a timer object in order to create the timer's endowments, source code, and
 The timer service consists of a device (`device-timer`) and a helper vat (`vat-timer`). The host application must configure the device as it builds the swingset kernel, and then the bootstrap vat must finish the job by wiring the device and vat together.
 
 ```js
-import { buildTimer } from `@agoric/swingset-vat`;
+import { buildTimer } from '@agoric/swingset-vat';
 const timer = buildTimer();
 ```
 

--- a/packages/swingset-runner/demo/encouragementBot/bootstrap.js
+++ b/packages/swingset-runner/demo/encouragementBot/bootstrap.js
@@ -6,7 +6,7 @@ const log = console.log;
 log(`=> loading bootstrap.js`);
 
 export function buildRootObject() {
-  log(`=> setup called`);
+  log(`=> buildRootObject called`);
   return Far('root', {
     bootstrap(vats) {
       log('=> bootstrap() called');

--- a/packages/swingset-runner/demo/ivanHello/bootstrap.js
+++ b/packages/swingset-runner/demo/ivanHello/bootstrap.js
@@ -1,0 +1,39 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+const log = console.log;
+log(`=> loading bootstrap.js`);
+
+export function buildRootObject(vatPowers) {
+	log(`=> buildRootObject`)
+
+	const { D } = vatPowers;
+
+	return Far("root", {
+		async bootstrap(vats, devices) {
+			const timerService = await E(vats.timer).createTimerService(devices.timer);
+			assert(timerService)
+			const name = `jerky`
+
+			log(`=> in bootstrap sayHello`)
+			let helloP = E(vats.hello).sayHello(name)
+			let helloMsg = await helloP
+			log(helloMsg)
+
+			log(`=> in bootstrap sayHelloAfterWait`)
+			let helloAfterWaitP = E(vats.hello).sayHelloAfterWait(name, timerService, 1000000n)
+			helloMsg = await helloAfterWaitP
+			log(helloMsg)
+
+			// log(`=> in bootstrap getResponseAsPromise`)
+			// let resolver;
+			// const param = new Promise((theResolver, _theRejector) => {
+			// 	resolver = theResolver;
+			// });
+
+			// E(vats.hello)
+			// 	.getResponseAsPromise(param)
+			// resolver(`hello back from ${name}`)
+		},
+	})
+}

--- a/packages/swingset-runner/demo/ivanHello/vat-hello.js
+++ b/packages/swingset-runner/demo/ivanHello/vat-hello.js
@@ -1,0 +1,31 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+export function buildRootObject() {
+  return Far('root', {
+    sayHello(name) {
+      	console.log(`=> hello.sayHello got the name: ${name}`);
+      	return `Hello, ${name}. I returned immediately!`;
+    },
+    async getResponseAsPromise(response) {
+    	const msg = await response
+      	console.log(`=> hello.getResponseAsPromise got the reply: ${msg}`);
+      	return;    	
+    },
+    async sayHelloAfterWait(name, timerService, waitLength) {
+        const now = await E(timerService).getCurrentTimestamp();
+        console.log(`=> sayHelloAfterWait it is now: ${now}`)
+
+        // simple one-shot Promise-based relative delay
+        E(timerService)
+          .delay(waitLength)
+          .then(
+            r => console.log(`=> sayHelloAfterWait ${r}`),
+            err => console.log(`=> sayHelloAfterWait ${err}`),
+          );
+
+        console.log(`=> hello.sayHello got the name: ${name}`);
+        return `Hello, ${name}. I waited ${waitLength} seconds!`;
+    },
+  });
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: #XXXX

## Description
Created the ability to add a timer to vats launched with `packages/swingset-runner`.
Does not seem to wait for `timerService.delay()` to complete

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

Run as:
```shell
➜  swingset-runner git:(ivan-hello-vats) node bin/runner --usexs --timer --init batch demo/ivanHello
=> loading bootstrap.js
=> buildRootObject
=> in bootstrap sayHello
=> hello.sayHello got the name: jerky
Hello, jerky. I returned immediately!
=> in bootstrap sayHelloAfterWait
=> sayHelloAfterWait it is now: 0
=> hello.sayHello got the name: jerky
Hello, jerky. I waited 1000000 seconds!
bootstrap result fulfilled: {"body":"#\"#undefined\"","slots":[]}
runner finished 57 cranks in 1239086542 ns (21738360/crank)
```
