### PR TITLE
fix: dont reflect key back in error

### DIFF
--- a/golang/cosmos/x/vstorage/keeper/querier.go
+++ b/golang/cosmos/x/vstorage/keeper/querier.go
@@ -36,7 +36,7 @@ func NewQuerier(keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) sdk.Querier 
 func queryData(ctx sdk.Context, path string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) (res []byte, err error) {
 	value := keeper.GetData(ctx, path)
 	if value == "" {
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "could not get vstorage %+v", path)
+		return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "could not get vstorage path")
 	}
 
 	bz, err2 := codec.MarshalJSONIndent(legacyQuerierCdc, types.Data{Value: value})


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #6733 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Removes the reflected key from the error message when querying an unknown key

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Less bytes on the return message

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
