### PR TITLE
feat(cosmic-swingset): execute during voting time

### DIFF
--- a/golang/cosmos/x/swingset/types/default-params.go
+++ b/golang/cosmos/x/swingset/types/default-params.go
@@ -14,7 +14,7 @@ const (
 	BeansPerFeeUnit                = "feeUnit"
 	BeansPerInboundTx              = "inboundTx"
 	BeansPerBlockComputeLimit      = "blockComputeLimit"
-	BeansPerIntraBlockComputeLimit = "intraBlockComputeLimit"
+	BeansPerInterBlockComputeLimit = "interBlockComputeLimit"
 	BeansPerMessage                = "message"
 	BeansPerMessageByte            = "messageByte"
 	BeansPerMinFeeDebit            = "minFeeDebit"
@@ -35,7 +35,7 @@ var (
 	// about 2/3rds utilization, based on 5 sec voting time and up to 10 sec of
 	// computation.
 	DefaultBeansPerBlockComputeLimit      = sdk.NewUint(8000000).Mul(DefaultBeansPerXsnapComputron)
-	DefaultBeansPerIntraBlockComputeLimit = sdk.NewUint(24000000).Mul(DefaultBeansPerXsnapComputron)
+	DefaultBeansPerInterBlockComputeLimit = sdk.NewUint(24000000).Mul(DefaultBeansPerXsnapComputron)
 	// observed: 0.385 sec
 	DefaultBeansPerVatCreation = sdk.NewUint(300000).Mul(DefaultBeansPerXsnapComputron)
 
@@ -67,7 +67,7 @@ var (
 func DefaultBeansPerUnit() []StringBeans {
 	return []StringBeans{
 		NewStringBeans(BeansPerBlockComputeLimit, DefaultBeansPerBlockComputeLimit),
-		NewStringBeans(BeansPerIntraBlockComputeLimit, DefaultBeansPerIntraBlockComputeLimit),
+		NewStringBeans(BeansPerInterBlockComputeLimit, DefaultBeansPerInterBlockComputeLimit),
 		NewStringBeans(BeansPerFeeUnit, DefaultBeansPerFeeUnit),
 		NewStringBeans(BeansPerInboundTx, DefaultBeansPerInboundTx),
 		NewStringBeans(BeansPerMessage, DefaultBeansPerMessage),

--- a/golang/cosmos/x/swingset/types/default-params.go
+++ b/golang/cosmos/x/swingset/types/default-params.go
@@ -11,14 +11,15 @@ import (
 // experience if they don't.
 
 const (
-	BeansPerFeeUnit           = "feeUnit"
-	BeansPerInboundTx         = "inboundTx"
-	BeansPerBlockComputeLimit = "blockComputeLimit"
-	BeansPerMessage           = "message"
-	BeansPerMessageByte       = "messageByte"
-	BeansPerMinFeeDebit       = "minFeeDebit"
-	BeansPerVatCreation       = "vatCreation"
-	BeansPerXsnapComputron    = "xsnapComputron"
+	BeansPerFeeUnit                = "feeUnit"
+	BeansPerInboundTx              = "inboundTx"
+	BeansPerBlockComputeLimit      = "blockComputeLimit"
+	BeansPerIntraBlockComputeLimit = "intraBlockComputeLimit"
+	BeansPerMessage                = "message"
+	BeansPerMessageByte            = "messageByte"
+	BeansPerMinFeeDebit            = "minFeeDebit"
+	BeansPerVatCreation            = "vatCreation"
+	BeansPerXsnapComputron         = "xsnapComputron"
 
 	// QueueSize keys.
 	// Keep up-to-date with updateQueueAllowed() in packanges/cosmic-swingset/src/launch-chain.js
@@ -33,7 +34,8 @@ var (
 	// before starting a new block.  Some analysis (#3459) suggests this leads to
 	// about 2/3rds utilization, based on 5 sec voting time and up to 10 sec of
 	// computation.
-	DefaultBeansPerBlockComputeLimit = sdk.NewUint(8000000).Mul(DefaultBeansPerXsnapComputron)
+	DefaultBeansPerBlockComputeLimit      = sdk.NewUint(8000000).Mul(DefaultBeansPerXsnapComputron)
+	DefaultBeansPerIntraBlockComputeLimit = sdk.NewUint(24000000).Mul(DefaultBeansPerXsnapComputron)
 	// observed: 0.385 sec
 	DefaultBeansPerVatCreation = sdk.NewUint(300000).Mul(DefaultBeansPerXsnapComputron)
 
@@ -65,6 +67,7 @@ var (
 func DefaultBeansPerUnit() []StringBeans {
 	return []StringBeans{
 		NewStringBeans(BeansPerBlockComputeLimit, DefaultBeansPerBlockComputeLimit),
+		NewStringBeans(BeansPerIntraBlockComputeLimit, DefaultBeansPerIntraBlockComputeLimit),
 		NewStringBeans(BeansPerFeeUnit, DefaultBeansPerFeeUnit),
 		NewStringBeans(BeansPerInboundTx, DefaultBeansPerInboundTx),
 		NewStringBeans(BeansPerMessage, DefaultBeansPerMessage),

--- a/packages/SwingSet/src/devices/bridge/device-bridge.js
+++ b/packages/SwingSet/src/devices/bridge/device-bridge.js
@@ -13,8 +13,8 @@ function sanitize(data) {
 
 /**
  * @typedef {object} BridgeDevice
- * @property {(dstID: string, obj: any) => any} callOutbound
- * @property {(handler: { inbound: (srcID: string, obj: any) => void}) => void} registerInboundHandler
+ * @property {(...args: any[]) => any} callOutbound
+ * @property {(handler: { inbound: (...args: any[]) => void}) => void} registerInboundHandler
  */
 
 /**

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -42,6 +42,12 @@ function abbreviateReplacer(_, arg) {
     // truncate long strings
     return `${arg.slice(0, 15)}...${arg.slice(arg.length - 15)}`;
   }
+  if (arg === undefined) {
+    return 'undefined';
+  }
+  if (typeof arg === 'symbol') {
+    return String(arg);
+  }
   return arg;
 }
 

--- a/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
@@ -175,6 +175,12 @@ function abbreviateReplacer(_, arg) {
     // truncate long strings
     return `${arg.slice(0, 15)}...${arg.slice(arg.length - 15)}`;
   }
+  if (arg === undefined) {
+    return 'undefined';
+  }
+  if (typeof arg === 'symbol') {
+    return String(arg);
+  }
   return arg;
 }
 

--- a/packages/SwingSet/test/test-device-bridge.js
+++ b/packages/SwingSet/test/test-device-bridge.js
@@ -10,6 +10,7 @@ import {
 } from '../src/index.js';
 
 test('bridge device', async t => {
+  t.plan(6);
   const outboundLog = [];
   function outboundCallback(argv0, argv1) {
     outboundLog.push(argv0);
@@ -116,6 +117,7 @@ test('bridge device', async t => {
 });
 
 test('bridge device can return undefined', async t => {
+  t.plan(2);
   const outboundLog = [];
   function outboundCallback(argv0, argv1) {
     outboundLog.push(argv0);
@@ -153,5 +155,5 @@ test('bridge device can return undefined', async t => {
   await c.run();
 
   t.deepEqual(outboundLog, argv);
-  t.deepEqual(c.dump().log, ['outbound retval', '', 'true']);
+  t.deepEqual(c.dump().log, ['outbound retval', '"undefined"', 'true']);
 });

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -36,7 +36,7 @@
     "@endo/import-bundle": "^0.3.0",
     "@endo/init": "^0.5.52",
     "@endo/marshal": "^0.8.1",
-    "@endo/promise-kit": "^0.2.53",
+    "@endo/promise-kit": "^0.2.52",
     "@iarna/toml": "^2.2.3",
     "@opentelemetry/sdk-metrics": "^0.32.0",
     "anylogger": "^0.21.0",

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -36,6 +36,7 @@
     "@endo/import-bundle": "^0.3.0",
     "@endo/init": "^0.5.52",
     "@endo/marshal": "^0.8.1",
+    "@endo/promise-kit": "^0.2.53",
     "@iarna/toml": "^2.2.3",
     "@opentelemetry/sdk-metrics": "^0.32.0",
     "anylogger": "^0.21.0",

--- a/packages/cosmic-swingset/src/active-guard.js
+++ b/packages/cosmic-swingset/src/active-guard.js
@@ -1,0 +1,64 @@
+import { makePromiseKit } from '@endo/promise-kit';
+
+export const makeActiveGuard = () => {
+  /** @type {Promise<void> | undefined} */
+  let jobsCompleted;
+  let active = false;
+  /** @type {Array<{job: () => any, resolve: (result: any) => void}>} */
+  const pendingJobs = [];
+
+  const maybeProcessJobs = () => {
+    if (active) {
+      const jobs = pendingJobs.splice(0);
+      jobsCompleted = Promise.all([
+        jobsCompleted,
+        ...jobs.map(({ job, resolve }) => {
+          const result = Promise.resolve().then(job);
+          resolve(result);
+          return result.then(
+            () => {},
+            () => {},
+          );
+        }),
+      ]).then(() => {});
+    }
+  };
+
+  /** @param {() => any} job */
+  const whenActive = async job => {
+    const { resolve, promise } = makePromiseKit();
+    pendingJobs.push({ job, resolve });
+    maybeProcessJobs();
+    return promise;
+  };
+
+  /**
+   * @template {(...args: any[]) => any} T
+   * @template {boolean} [D=true]
+   * @param {T} fn
+   * @param {D} [dropResult=true]
+   * @returns {(...args: Parameters<T>) => (false extends D ? Promise<Awaited<ReturnType<T>>> : never) | (true extends D ? undefined : never)}
+   */
+  const whenActiveWrap =
+    (fn, dropResult = true) =>
+    (...args) => {
+      const result = whenActive(() => fn(...args));
+      if (dropResult) {
+        result.catch(err => {
+          console.warn('Unhandled rejection for active wrapped task', err);
+        });
+        return undefined;
+      } else {
+        return result;
+      }
+    };
+
+  /** @param {boolean} newValue */
+  const updateActive = async newValue => {
+    active = newValue;
+    maybeProcessJobs();
+    return jobsCompleted;
+  };
+
+  return { whenActive, whenActiveWrap, updateActive };
+};

--- a/packages/cosmic-swingset/src/active-guard.js
+++ b/packages/cosmic-swingset/src/active-guard.js
@@ -8,20 +8,22 @@ export const makeActiveGuard = () => {
   const pendingJobs = [];
 
   const maybeProcessJobs = () => {
-    if (active) {
-      const jobs = pendingJobs.splice(0);
-      jobsCompleted = Promise.all([
-        jobsCompleted,
-        ...jobs.map(({ job, resolve }) => {
-          const result = Promise.resolve().then(job);
-          resolve(result);
-          return result.then(
-            () => {},
-            () => {},
-          );
-        }),
-      ]).then(() => {});
+    if (!active) {
+      return;
     }
+
+    const jobs = pendingJobs.splice(0);
+    jobsCompleted = Promise.all([
+      jobsCompleted,
+      ...jobs.map(({ job, resolve }) => {
+        const result = Promise.resolve().then(job);
+        resolve(result);
+        return result.then(
+          () => {},
+          () => {},
+        );
+      }),
+    ]).then(() => {});
   };
 
   /** @param {() => any} job */

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -85,14 +85,14 @@ export async function buildSwingset(
     config = loadBasedir(vatconfig);
   }
 
-  const mailboxStateMap = buildMailboxStateMap(mailboxStorage);
-  const activeMailboxStateMap = {
-    add: whenActiveWrap(mailboxStateMap.add),
-    remove: whenActiveWrap(mailboxStateMap.remove),
-    setAcknum: whenActiveWrap(mailboxStateMap.setAcknum),
+  const rawMailboxStateMap = buildMailboxStateMap(mailboxStorage);
+  const mailboxStateMap = {
+    add: whenActiveWrap(rawMailboxStateMap.add),
+    remove: whenActiveWrap(rawMailboxStateMap.remove),
+    setAcknum: whenActiveWrap(rawMailboxStateMap.setAcknum),
   };
   const timer = buildTimer();
-  const mb = buildMailbox(activeMailboxStateMap);
+  const mb = buildMailbox(mailboxStateMap);
   config.devices = {
     mailbox: {
       sourceSpec: mb.srcPath,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -31,6 +31,7 @@ import {
 
 import {
   BeansPerBlockComputeLimit,
+  BeansPerIntraBlockComputeLimit,
   BeansPerVatCreation,
   BeansPerXsnapComputron,
   QueueInbound,
@@ -535,13 +536,14 @@ export async function launch({
     return p;
   }
 
-  async function runKernel(runPolicy, blockHeight) {
+  async function runKernel(runPolicy, blockHeight, phase) {
     let runNum = 0;
     async function runSwingset() {
       const initialBeans = runPolicy.remainingBeans();
       controller.writeSlogObject({
         type: 'cosmic-swingset-run-start',
         blockHeight,
+        phase,
         runNum,
         initialBeans,
       });
@@ -557,6 +559,7 @@ export async function launch({
       controller.writeSlogObject({
         type: 'cosmic-swingset-run-finish',
         blockHeight,
+        phase,
         runNum,
         remainingBeans,
         usedBeans: initialBeans - remainingBeans,
@@ -625,7 +628,7 @@ export async function launch({
       params.beansPerUnit[BeansPerBlockComputeLimit],
     );
 
-    await runKernel(runPolicy, blockHeight);
+    await runKernel(runPolicy, blockHeight, 'endBlock');
 
     if (END_BLOCK_SPIN_MS) {
       // Introduce a busy-wait to artificially put load on the chain.
@@ -700,7 +703,7 @@ export async function launch({
     throw decohered;
   }
 
-  async function afterCommit(blockHeight, blockTime) {
+  async function afterCommit(blockHeight, blockTime, params) {
     await Promise.resolve()
       .then(afterCommitCallback)
       .then((afterCommitStats = {}) => {
@@ -711,6 +714,15 @@ export async function launch({
           ...afterCommitStats,
         });
       });
+
+    const computeLimit = params.beansPerUnit[BeansPerIntraBlockComputeLimit];
+
+    if (!(computeLimit > 0n)) {
+      return;
+    }
+
+    const runPolicy = computronCounter(params.beansPerUnit, computeLimit);
+    await runKernel(runPolicy, blockHeight, 'afterCommit');
   }
 
   async function blockingSend(action) {
@@ -784,13 +796,27 @@ export async function launch({
           blockTime,
         });
 
-        blockParams = undefined;
-
         blockManagerConsole.debug(
           `wrote SwingSet checkpoint [run=${runTime}ms, chainSave=${chainTime}ms, kernelSave=${saveTime}ms]`,
         );
 
-        afterCommitWorkDone = afterCommit(blockHeight, blockTime);
+        controller.writeSlogObject({
+          type: 'cosmic-swingset-after-commit-block-start',
+          blockHeight,
+          blockTime,
+        });
+        afterCommitWorkDone = afterCommit(
+          blockHeight,
+          blockTime,
+          blockParams,
+        ).then(() => {
+          controller.writeSlogObject({
+            type: 'cosmic-swingset-after-commit-block-finish',
+            blockHeight,
+            blockTime,
+          });
+        });
+        blockParams = undefined;
 
         return undefined;
       }

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -178,26 +178,28 @@ export async function buildSwingset(
 
 /**
  * @typedef {object} BeansPerUnit
- * @property {bigint} blockComputeLimit
  * @property {bigint} vatCreation
  * @property {bigint} xsnapComputron
  */
 
 /**
  * @param {BeansPerUnit} beansPerUnit
+ * @param {bigint} computeLimit
  * @returns {ChainRunPolicy}
  */
-function computronCounter({
-  [BeansPerBlockComputeLimit]: blockComputeLimit,
-  [BeansPerVatCreation]: vatCreation,
-  [BeansPerXsnapComputron]: xsnapComputron,
-}) {
-  assert.typeof(blockComputeLimit, 'bigint');
+function computronCounter(
+  {
+    [BeansPerVatCreation]: vatCreation,
+    [BeansPerXsnapComputron]: xsnapComputron,
+  },
+  computeLimit,
+) {
+  assert.typeof(computeLimit, 'bigint');
   assert.typeof(vatCreation, 'bigint');
   assert.typeof(xsnapComputron, 'bigint');
   let totalBeans = 0n;
-  const shouldRun = () => totalBeans < blockComputeLimit;
-  const remainingBeans = () => blockComputeLimit - totalBeans;
+  const shouldRun = () => totalBeans < computeLimit;
+  const remainingBeans = () => computeLimit - totalBeans;
 
   const policy = harden({
     vatCreated() {
@@ -618,7 +620,10 @@ export async function launch({
     );
 
     // make a runPolicy that will be shared across all cycles
-    const runPolicy = computronCounter(params.beansPerUnit);
+    const runPolicy = computronCounter(
+      params.beansPerUnit,
+      params.beansPerUnit[BeansPerBlockComputeLimit],
+    );
 
     await runKernel(runPolicy, blockHeight);
 

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -31,7 +31,7 @@ import {
 
 import {
   BeansPerBlockComputeLimit,
-  BeansPerIntraBlockComputeLimit,
+  BeansPerInterBlockComputeLimit,
   BeansPerVatCreation,
   BeansPerXsnapComputron,
   QueueInbound,
@@ -715,7 +715,7 @@ export async function launch({
         });
       });
 
-    const computeLimit = params.beansPerUnit[BeansPerIntraBlockComputeLimit];
+    const computeLimit = params.beansPerUnit[BeansPerInterBlockComputeLimit];
 
     if (!(computeLimit > 0n)) {
       return;

--- a/packages/cosmic-swingset/src/sim-params.js
+++ b/packages/cosmic-swingset/src/sim-params.js
@@ -16,7 +16,7 @@ const makeQueueSize = (key, size) => ({ key, size });
 // experience if they don't.
 
 export const BeansPerBlockComputeLimit = 'blockComputeLimit';
-export const BeansPerIntraBlockComputeLimit = 'intraBockComputeLimit';
+export const BeansPerInterBlockComputeLimit = 'interBockComputeLimit';
 export const BeansPerFeeUnit = 'feeUnit';
 export const BeansPerInboundTx = 'inboundTx';
 export const BeansPerMessage = 'message';
@@ -33,7 +33,7 @@ export const defaultBeansPerXsnapComputron = 100n;
 // computation.
 export const defaultBeansPerBlockComputeLimit =
   8_000_000n * defaultBeansPerXsnapComputron;
-export const defaultBeansPerIntraBlockComputeLimit =
+export const defaultBeansPerInterBlockComputeLimit =
   24_000_000n * defaultBeansPerXsnapComputron;
 // observed: 0.385 sec
 export const defaultBeansPerVatCreation =
@@ -55,8 +55,8 @@ export const defaultBeansPerUnit = [
   makeStringBeans(BeansPerInboundTx, defaultBeansPerInboundTx),
   makeStringBeans(BeansPerBlockComputeLimit, defaultBeansPerBlockComputeLimit),
   makeStringBeans(
-    BeansPerIntraBlockComputeLimit,
-    defaultBeansPerIntraBlockComputeLimit,
+    BeansPerInterBlockComputeLimit,
+    defaultBeansPerInterBlockComputeLimit,
   ),
   makeStringBeans(BeansPerMessage, defaultBeansPerMessage),
   makeStringBeans(BeansPerMessageByte, defaultBeansPerMessageByte),

--- a/packages/cosmic-swingset/src/sim-params.js
+++ b/packages/cosmic-swingset/src/sim-params.js
@@ -16,6 +16,7 @@ const makeQueueSize = (key, size) => ({ key, size });
 // experience if they don't.
 
 export const BeansPerBlockComputeLimit = 'blockComputeLimit';
+export const BeansPerIntraBlockComputeLimit = 'intraBockComputeLimit';
 export const BeansPerFeeUnit = 'feeUnit';
 export const BeansPerInboundTx = 'inboundTx';
 export const BeansPerMessage = 'message';
@@ -32,6 +33,8 @@ export const defaultBeansPerXsnapComputron = 100n;
 // computation.
 export const defaultBeansPerBlockComputeLimit =
   8_000_000n * defaultBeansPerXsnapComputron;
+export const defaultBeansPerIntraBlockComputeLimit =
+  24_000_000n * defaultBeansPerXsnapComputron;
 // observed: 0.385 sec
 export const defaultBeansPerVatCreation =
   300_000n * defaultBeansPerXsnapComputron;
@@ -51,6 +54,10 @@ export const defaultBeansPerUnit = [
   makeStringBeans(BeansPerFeeUnit, defaultBeansPerFeeUnit),
   makeStringBeans(BeansPerInboundTx, defaultBeansPerInboundTx),
   makeStringBeans(BeansPerBlockComputeLimit, defaultBeansPerBlockComputeLimit),
+  makeStringBeans(
+    BeansPerIntraBlockComputeLimit,
+    defaultBeansPerIntraBlockComputeLimit,
+  ),
   makeStringBeans(BeansPerMessage, defaultBeansPerMessage),
   makeStringBeans(BeansPerMessageByte, defaultBeansPerMessageByte),
   makeStringBeans(BeansPerMinFeeDebit, defaultBeansPerMinFeeDebit),

--- a/packages/internal/src/config.js
+++ b/packages/internal/src/config.js
@@ -19,6 +19,7 @@ export const BridgeId = {
   PROVISION: 'provision',
   PROVISION_SMART_WALLET: 'provisionWallet',
   WALLET: 'wallet',
+  OUTBOUND_RESULT: 'outboundResult', // Synthetic source used to send results back asynchronously
 };
 harden(BridgeId);
 

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -909,8 +909,8 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         break;
       }
       case 'cosmic-swingset-begin-block': {
-        if (spans.topKind() === 'intra-block') {
-          spans.pop('intra-block');
+        if (spans.topKind() === 'inter-block') {
+          spans.pop('inter-block');
           spans.pop('block');
         }
         if (currentBlockHeight > 0) {
@@ -937,11 +937,11 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
       case 'cosmic-swingset-commit-block-finish': {
         spans.pop(['commit-block', slogAttrs.blockHeight]);
         // Push a span to capture the time between blocks from cosmic-swingset POV
-        spans.push(['intra-block', slogAttrs.blockHeight]);
+        spans.push(['inter-block', slogAttrs.blockHeight]);
         break;
       }
       case 'cosmic-swingset-after-commit-stats': {
-        // Add the event to whatever the current top span is (most likely intra-block)
+        // Add the event to whatever the current top span is (most likely inter-block)
         // TODO: add as a span of the block
         spans.top()?.addEvent('after-commit', cleanAttrs(slogAttrs), now);
         if (currentBlockHeight === slogAttrs.blockHeight) {

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -936,14 +936,22 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
       }
       case 'cosmic-swingset-commit-block-finish': {
         spans.pop(['commit-block', slogAttrs.blockHeight]);
+        break;
+      }
+      case 'cosmic-swingset-after-commit-block-start': {
+        spans.push(['after-commit', slogAttrs.blockHeight]);
+        break;
+      }
+      case 'cosmic-swingset-after-commit-block-finish': {
+        spans.pop(['after-commit', slogAttrs.blockHeight]);
         // Push a span to capture the time between blocks from cosmic-swingset POV
         spans.push(['inter-block', slogAttrs.blockHeight]);
         break;
       }
       case 'cosmic-swingset-after-commit-stats': {
-        // Add the event to whatever the current top span is (most likely inter-block)
+        // Add the event to whatever the current top span is (most likely after-commit)
         // TODO: add as a span of the block
-        spans.top()?.addEvent('after-commit', cleanAttrs(slogAttrs), now);
+        spans.top()?.addEvent('after-commit-stats', cleanAttrs(slogAttrs), now);
         if (currentBlockHeight === slogAttrs.blockHeight) {
           dbTransactionManager.end();
           currentBlockHeight = -1;

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -80,21 +80,23 @@ export function makeBridgeManager(E, D, bridgeDevice) {
   const toBridge = async (dstID, obj) => {
     bridgeDevice || Fail`bridge device not yet connected`;
     const { bpid, promise } = resultHandler.allocateResult();
-    try {
-      D(bridgeDevice).callOutbound(dstID, obj, bpid);
-    } catch (error) {
-      console.error('Synchronous error while invoking callOutbound', error);
-      resultHandler.fromBridge([
-        {
-          bpid,
-          result: {
-            status: 'rejected',
-            reason: `callOutbound failure: ${error}`,
+    return Promise.resolve()
+      .then(() => {
+        D(bridgeDevice).callOutbound(dstID, obj, bpid);
+      })
+      .catch(error => {
+        console.error('Error while invoking callOutbound', error);
+        return resultHandler.fromBridge([
+          {
+            bpid,
+            result: {
+              status: 'rejected',
+              reason: `callOutbound failure: ${error}`,
+            },
           },
-        },
-      ]);
-    }
-    return promise;
+        ]);
+      })
+      .then(() => promise);
   };
 
   // We now manage the device.

--- a/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
+++ b/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
@@ -73,7 +73,7 @@ async function main(t, argv) {
 }
 
 const expected = [
-  '{"adminFacet":{},"creatorFacet":{},"instance":{},"publicFacet":{}}',
+  '{"adminFacet":{},"creatorFacet":{},"creatorInvitation":"undefined","instance":{},"publicFacet":{}}',
 ];
 
 test.serial('defineKind swingset', async t => {


### PR DESCRIPTION
refs: #6447 

Best reviewed commit-by-commit

## Description

Building on top of #6683 and #6730, this introduces a bridge device implementation which uses asynchronous results, allowing to unlock queuing of chainSend while JS is not actively processing a `blockingSend` from golang.

With some new queueing in cosmic-swingset, this allows executing swingset during voting time.

### Security Considerations

This PR introduces guards to guarantee that Swingset activity will not cause calls into golang when not expected (outside of a `blockingSend` call).

While executing swingset during voting time (outside of `blockingSend`), the chain sends are effectively queued in memory by cosmic-swingset, which is safe since they are flushed at the beginning of the next block. Any work performed during voting time is committed as part of the next block.

### Documentation Considerations

Some code comments updated, but there is probably some docs that bit-rotted because of this change.

### Testing Considerations

The changes are mostly constrained to cosmic-swingset and related, which does not have good unit test coverage. However I ran the loadgen on this change, and it works well, having confirmed loadgen tasks now run decently faster. I need to do more analysis on the block timings to see if intra block work ever negatively impacts the following block.
