### PR TITLE
refactor: pulling up more await weeds

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -48,7 +48,6 @@
     "@endo/zip": "^0.2.28",
     "anylogger": "^0.21.0",
     "import-meta-resolve": "^1.1.1",
-    "jessie.js": "^0.3.2",
     "microtime": "^3.1.0",
     "semver": "^6.3.0"
   },

--- a/packages/SwingSet/src/devices/plugin/device-plugin.js
+++ b/packages/SwingSet/src/devices/plugin/device-plugin.js
@@ -51,8 +51,8 @@ export function buildRootDeviceNode(tools) {
    * @param {number} epoch which generation of CapTP instances this is
    * @returns {Promise<(obj: Record<string, any>) => void>} send a message to the module
    */
-  async function createConnection(mod, index, epoch) {
-    try {
+  const createConnection = async (mod, index, epoch) =>
+    (async () => {
       const modNS = await endowments.import(mod);
       const receiver = obj => {
         // console.info('receiver', index, obj);
@@ -87,11 +87,10 @@ export function buildRootDeviceNode(tools) {
       const { dispatch } = makeCapTP(mod, receiver, bootstrap, { epoch });
 
       return dispatch;
-    } catch (e) {
+    })().catch(e => {
       console.error(`Cannot connect to ${mod}:`, e);
       throw e;
-    }
-  }
+    });
 
   /**
    * Load a module and connect to it.

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -3,7 +3,7 @@ import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
 import { assert, details as X, Fail } from '@agoric/assert';
-import { asyncGenerate } from 'jessie.js';
+import { whileTrue } from '@agoric/internal';
 import { toBytes } from './bytes.js';
 
 import '@agoric/store/exported.js';
@@ -237,11 +237,7 @@ export function makeNetworkProtocol(protocolHandler) {
   const bind = async localAddr => {
     // Check if we are underspecified (ends in slash)
     const underspecified = localAddr.endsWith(ENDPOINT_SEPARATOR);
-    const whileUnderspecified = asyncGenerate(() => ({
-      done: !underspecified,
-      value: null,
-    }));
-    for await (const _ of whileUnderspecified) {
+    for await (const _ of whileTrue(() => underspecified)) {
       const portID = await E(protocolHandler).generatePortID(
         localAddr,
         protocolHandler,

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -34,6 +34,7 @@
     "@agoric/casting": "^0.3.2",
     "@agoric/cosmic-proto": "^0.2.1",
     "@agoric/ertp": "^0.15.3",
+    "@agoric/internal": "^0.2.1",
     "@agoric/nat": "^4.1.0",
     "@agoric/smart-wallet": "^0.4.2",
     "@agoric/swingset-vat": "^0.30.2",
@@ -59,7 +60,6 @@
     "deterministic-json": "^1.0.5",
     "esm": "agoric-labs/esm#Agoric-built",
     "inquirer": "^8.2.2",
-    "jessie.js": "^0.3.2",
     "opener": "^1.5.2",
     "tmp": "^0.2.1",
     "ws": "^7.2.0"

--- a/packages/agoric-cli/src/deploy.js
+++ b/packages/agoric-cli/src/deploy.js
@@ -12,7 +12,7 @@ import inquirer from 'inquirer';
 import createEsmRequire from 'esm';
 import { createRequire } from 'module';
 import { SigningStargateClient } from '@cosmjs/stargate';
-import { asyncGenerate } from 'jessie.js';
+import { whileTrue } from '@agoric/internal';
 
 import { getAccessToken } from '@agoric/access-token';
 
@@ -248,11 +248,7 @@ export default async function deployMain(progname, rawArgs, powers, opts) {
         let lastUpdateCount;
         let stillLoading = [...need].sort();
         progressDot = 'o';
-        const untilNotLoading = asyncGenerate(() => ({
-          done: !stillLoading.length,
-          value: stillLoading,
-        }));
-        for await (const _ of untilNotLoading) {
+        for await (const _ of whileTrue(() => stillLoading.length)) {
           // Wait for the notifier to report a new state.
           process.stdout.write(progressDot);
           console.debug('need:', stillLoading.join(', '));

--- a/packages/agoric-cli/src/init.js
+++ b/packages/agoric-cli/src/init.js
@@ -40,15 +40,14 @@ export default async function initMain(_progname, rawArgs, priv, opts) {
     dappBranch = ['-b', opts.dappBranch];
   }
 
-  if (
-    await pspawn(
-      'git',
-      ['clone', '--origin=upstream', dappURL, DIR, ...dappBranch],
-      {
-        stdio: 'inherit',
-      },
-    )
-  ) {
+  const exitStatus = await pspawn(
+    'git',
+    ['clone', '--origin=upstream', dappURL, DIR, ...dappBranch],
+    {
+      stdio: 'inherit',
+    },
+  );
+  if (exitStatus) {
     throw Error('cannot clone');
   }
 
@@ -57,7 +56,7 @@ export default async function initMain(_progname, rawArgs, priv, opts) {
 
   let topLevelName;
   const subdirs = ['', 'api/', 'contract/', 'ui/', '_agstate/agoric-servers/'];
-  for (const dir of subdirs) {
+  for await (const dir of subdirs) {
     const path = `${DIR}/${dir}package.json`;
     log('rewriting ', path);
 

--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -59,7 +59,7 @@ export default async function installMain(progname, rawArgs, powers, opts) {
   }
 
   const yarnInstallEachWorktree = async (phase, ...flags) => {
-    for (const workTree of workTrees) {
+    for await (const workTree of workTrees) {
       log.info(`yarn install ${phase} in ${workTree}`);
       // eslint-disable-next-line no-await-in-loop
       const yarnInstall = await pspawn(
@@ -226,15 +226,14 @@ export default async function installMain(progname, rawArgs, powers, opts) {
       }
     }
   } else {
+    const subdirMapper = async subd => {
+      const exists = await fs.stat(`${subd}/package.json`).catch(_ => false);
+      return exists && subd;
+    };
     const existingSubdirs = await Promise.all(
       ['.', '_agstate/agoric-servers', 'contract', 'api', 'ui']
         .sort()
-        .map(async subd => {
-          const exists = await fs
-            .stat(`${subd}/package.json`)
-            .catch(_ => false);
-          return exists && subd;
-        }),
+        .map(subdirMapper),
     );
     subdirs = existingSubdirs.filter(subd => subd);
   }
@@ -254,22 +253,21 @@ export default async function installMain(progname, rawArgs, powers, opts) {
       await fs.symlink(sdkRoot, sdkWorktree);
     }
 
-    await Promise.all(
-      subdirs.map(async subdir => {
-        const nm = `${subdir}/node_modules`;
-        log(chalk.bold.green(`removing ${nm} link`));
-        await fs.unlink(nm).catch(_ => {});
+    const subdirMapper = async subdir => {
+      const nm = `${subdir}/node_modules`;
+      log(chalk.bold.green(`removing ${nm} link`));
+      await fs.unlink(nm).catch(_ => {});
 
-        // Remove all the package links.
-        // This is needed to prevent yarn errors when installing new versions of
-        // linked modules (like `@agoric/zoe`).
-        await Promise.all(
-          [...sdkPackageToPath.keys()].map(async pjName =>
-            fs.unlink(`${nm}/${pjName}`).catch(_ => {}),
-          ),
-        );
-      }),
-    );
+      // Remove all the package links.
+      // This is needed to prevent yarn errors when installing new versions of
+      // linked modules (like `@agoric/zoe`).
+      await Promise.all(
+        [...sdkPackageToPath.keys()].map(async pjName =>
+          fs.unlink(`${nm}/${pjName}`).catch(_ => {}),
+        ),
+      );
+    };
+    await Promise.all(subdirs.map(subdirMapper));
   } else {
     DEFAULT_SDK_PACKAGE_NAMES.forEach(name => sdkPackageToPath.set(name, null));
   }
@@ -310,17 +308,14 @@ export default async function installMain(progname, rawArgs, powers, opts) {
   );
 
   const sdkPackages = [...sdkPackageToPath.keys()].sort();
-  for (const subdir of subdirs) {
-    // eslint-disable-next-line no-await-in-loop
+  for await (const subdir of subdirs) {
     const exists = await fs.stat(`${subdir}/package.json`).catch(_ => false);
-    if (
-      exists &&
-      // eslint-disable-next-line no-await-in-loop
-      (await pspawn('yarn', [...linkFlags, 'link', ...sdkPackages], {
+    const flag = await (exists &&
+      pspawn('yarn', [...linkFlags, 'link', ...sdkPackages], {
         stdio: 'inherit',
         cwd: subdir,
-      }))
-    ) {
+      }));
+    if (flag) {
       log.error('Cannot yarn link', ...sdkPackages);
       return 1;
     }

--- a/packages/agoric-cli/src/open.js
+++ b/packages/agoric-cli/src/open.js
@@ -53,8 +53,10 @@ export default async function walletMain(progname, rawArgs, powers, opts) {
   }${suffix}#accessToken=${encodeURIComponent(walletAccessToken)}`;
 
   process.stdout.write(`${walletUrl}\n`);
+  let p;
   if (opts.browser) {
     const browser = opener(walletUrl);
-    await new Promise(resolve => browser.on('exit', resolve));
+    p = new Promise(resolve => browser.on('exit', resolve));
   }
+  await p;
 }

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -128,17 +128,17 @@ export default async function startMain(progname, rawArgs, powers, opts) {
   }
 
   const capture = (spawner, args, show = false) => {
-    const capret = [
+    const statusOut = [
       spawner(args, { stdio: ['inherit', 'pipe', 'inherit'] }),
       '',
     ];
-    capret[0].childProcess.stdout.on('data', chunk => {
+    statusOut[0].childProcess.stdout.on('data', chunk => {
       if (show) {
         process.stdout.write(chunk);
       }
-      capret[1] += chunk.toString('utf-8');
+      statusOut[1] += chunk.toString('utf-8');
     });
-    return capret;
+    return statusOut;
   };
 
   const showKey = keyName =>
@@ -309,9 +309,9 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const addrs = {};
     for (const keyName of ['provision', 'delegate0']) {
       /* eslint-disable no-await-in-loop */
-      let capret = showKey(keyName);
-      const capretZero = await capret[0];
-      if (capretZero) {
+      let statusOut = showKey(keyName);
+      const exitStatusOut = await statusOut[0];
+      if (exitStatusOut) {
         const exitStatus = await keysSpawn([
           'keys',
           'add',
@@ -321,13 +321,13 @@ export default async function startMain(progname, rawArgs, powers, opts) {
         if (exitStatus) {
           return exitStatus;
         }
-        capret = showKey(keyName);
-        const status2 = await capret[0];
+        statusOut = showKey(keyName);
+        const status2 = await statusOut[0];
         if (status2) {
           return status2;
         }
       }
-      addrs[keyName] = capret[1].trimRight();
+      addrs[keyName] = statusOut[1].trimRight();
       /* eslint-enable no-await-in-loop */
     }
 
@@ -638,11 +638,11 @@ export default async function startMain(progname, rawArgs, powers, opts) {
             ],
           ];
           for (/* await */ const cmd of provCmds) {
-            const capret = capture(keysSpawn, cmd, true);
+            const statusOut = capture(keysSpawn, cmd, true);
             // eslint-disable-next-line no-await-in-loop
-            exitStatus = await capret[0];
+            exitStatus = await statusOut[0];
             if (!exitStatus) {
-              const json = capret[1].replace(/^gas estimate: \d+$/m, '');
+              const json = statusOut[1].replace(/^gas estimate: \d+$/m, '');
               try {
                 const ret = JSON.parse(json);
                 if (ret.code !== 0) {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -19,13 +19,13 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
+    "@agoric/internal": "^0.2.1",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/vat-data": "^0.4.3",
     "@agoric/vats": "^0.13.0",
     "@endo/far": "^0.2.14",
-    "@endo/marshal": "^0.8.1",
-    "jessie.js": "^0.3.2"
+    "@endo/marshal": "^0.8.1"
   },
   "devDependencies": {
     "@agoric/zoe": "^0.25.3",

--- a/packages/cache/src/store.js
+++ b/packages/cache/src/store.js
@@ -2,7 +2,7 @@ import { E, Far } from '@endo/far';
 import { deeplyFulfilled, makeMarshal } from '@endo/marshal';
 import { matches, makeScalarMapStore } from '@agoric/store';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
-import { asyncGenerate } from 'jessie.js';
+import { untilTrue } from '@agoric/internal';
 import { withGroundState, makeState } from './state.js';
 
 import './types.js';
@@ -77,10 +77,9 @@ const applyCacheTransaction = async (
 
   // Loop until our updated state is fresh wrt our current state.
   basisState = stateStore.get(keyStr);
-  const untilUpdateSynced = asyncGenerate(() => ({
-    value: null,
-    done: !updatedState || updatedState.generation > basisState.generation,
-  }));
+  const untilUpdateSynced = untilTrue(
+    () => !updatedState || updatedState.generation > basisState.generation,
+  );
   for await (const _ of untilUpdateSynced) {
     updatedState = await getUpdatedState(basisState);
     // AWAIT INTERLEAVING

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -38,13 +38,14 @@ async function makeMapStorage(file) {
     await fs.promises.writeFile(file, json);
   };
 
-  let obj = {};
   await (async () => {
     content = await fs.promises.readFile(file);
-    obj = JSON.parse(content);
-  })().catch(() => map);
-
-  Object.entries(obj).forEach(([k, v]) => map.set(k, importMailbox(v)));
+    return JSON.parse(content);
+  })().then(
+    obj =>
+      Object.entries(obj).forEach(([k, v]) => map.set(k, importMailbox(v))),
+    () => {},
+  );
 
   return map;
 }

--- a/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidateIncrementally.js
@@ -11,6 +11,7 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { AmountMath } from '@agoric/ertp';
 import { Far } from '@endo/marshal';
+import { forever } from '@agoric/internal';
 import { makeTracer } from '../makeTracer.js';
 
 const { Fail } = assert;
@@ -187,7 +188,7 @@ const start = async zcf => {
    * @yields {LiquidationStep}
    */
   async function* processTranches(seat, originalDebt) {
-    while (true) {
+    for await (const _ of forever) {
       const proceedsSoFar = seat.getAmountAllocated('Out');
       const toSell = seat.getAmountAllocated('In');
       if (

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@endo/eventual-send": "^0.16.8",
     "@endo/marshal": "^0.8.1",
-    "@endo/promise-kit": "^0.2.52"
+    "@endo/promise-kit": "^0.2.52",
+    "jessie.js": "^0.3.2"
   },
   "devDependencies": {
     "@endo/init": "^0.5.52",

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -2,6 +2,7 @@
 import { E } from '@endo/eventual-send';
 import { deeplyFulfilled, isObject } from '@endo/marshal';
 import { isPromise } from '@endo/promise-kit';
+import { asyncGenerate } from 'jessie.js';
 
 /** @typedef {import('@endo/marshal/src/types').Remotable} Remotable */
 
@@ -409,3 +410,32 @@ export const assertAllDefined = obj => {
     Fail`missing ${q(missing)}`;
   }
 };
+
+const neverDone = harden({ done: false, value: null });
+
+/** @type {AsyncIterable<null>} */
+export const forever = asyncGenerate(() => neverDone);
+
+/**
+ * @param {() => boolean} boolFunc
+ * @returns {AsyncIterable<null>}
+ */
+export const whileTrue = boolFunc =>
+  asyncGenerate(() =>
+    harden({
+      done: !boolFunc(),
+      value: null,
+    }),
+  );
+
+/**
+ * @param {() => boolean} boolFunc
+ * @returns {AsyncIterable<null>}
+ */
+export const untilTrue = boolFunc =>
+  asyncGenerate(() =>
+    harden({
+      done: !!boolFunc(),
+      value: null,
+    }),
+  );

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -417,7 +417,10 @@ const neverDone = harden({ done: false, value: null });
 export const forever = asyncGenerate(() => neverDone);
 
 /**
- * @param {() => boolean} boolFunc
+ * @param {() => unknown} boolFunc
+ * `boolFunc`'s return value is used for its truthiness vs falsiness.
+ * IOW, it is coerced to a boolean so the caller need not bother doing this
+ * themselves.
  * @returns {AsyncIterable<null>}
  */
 export const whileTrue = boolFunc =>
@@ -429,7 +432,10 @@ export const whileTrue = boolFunc =>
   );
 
 /**
- * @param {() => boolean} boolFunc
+ * @param {() => unknown} boolFunc
+ * `boolFunc`'s return value is used for its truthiness vs falsiness.
+ * IOW, it is coerced to a boolean so the caller need not bother doing this
+ * themselves.
  * @returns {AsyncIterable<null>}
  */
 export const untilTrue = boolFunc =>

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -86,7 +86,7 @@ export const makeOfferExecutor = ({
         });
       };
 
-      try {
+      const tryBody = async () => {
         // 1. Prepare values and validate synchronously.
         const { id, invitationSpec, proposal, offerArgs } = offerSpec;
 
@@ -177,9 +177,8 @@ export const makeOfferExecutor = ({
             }),
           handleError,
         );
-      } catch (err) {
-        handleError(err);
-      }
+      };
+      await tryBody().catch(err => handleError(err));
     },
   };
 };

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -4,6 +4,7 @@ import { AmountMath, AssetKind } from '@agoric/ertp';
 import { E, Far } from '@endo/far';
 import { makeNotifierKit, makeSubscriptionKit } from '@agoric/notifier';
 import { makeStore, makeWeakStore } from '@agoric/store';
+import { whileTrue } from '@agoric/internal';
 import { makeVirtualPurse } from './virtual-purse.js';
 
 import '@agoric/notifier/exported.js';
@@ -40,7 +41,7 @@ const makePurseController = (
     async *getBalances(b) {
       assert.equal(b, brand);
       let updateRecord = await balanceNotifier.getUpdateSince();
-      while (updateRecord.updateCount) {
+      for await (const _ of whileTrue(() => !!updateRecord.updateCount)) {
         yield updateRecord.value;
         // eslint-disable-next-line no-await-in-loop
         updateRecord = await balanceNotifier.getUpdateSince(

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -41,7 +41,7 @@ const makePurseController = (
     async *getBalances(b) {
       assert.equal(b, brand);
       let updateRecord = await balanceNotifier.getUpdateSince();
-      for await (const _ of whileTrue(() => !!updateRecord.updateCount)) {
+      for await (const _ of whileTrue(() => updateRecord.updateCount)) {
         yield updateRecord.value;
         // eslint-disable-next-line no-await-in-loop
         updateRecord = await balanceNotifier.getUpdateSince(

--- a/packages/web-components/src/admin-websocket-connector.js
+++ b/packages/web-components/src/admin-websocket-connector.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { E } from '@endo/eventual-send';
+import { whileTrue } from '@agoric/internal';
 
 const CONNECTION_TIMEOUT_MS = 5000;
 
@@ -8,7 +9,7 @@ export const waitForBootstrap = async getBootstrap => {
   const getLoadingUpdate = (...args) =>
     E(E.get(getBootstrap()).loadingNotifier).getUpdateSince(...args);
   let update = await getLoadingUpdate();
-  while (update.value.includes('wallet')) {
+  for await (const _ of whileTrue(() => update.value.includes('wallet'))) {
     console.log('waiting for wallet');
     // eslint-disable-next-line no-await-in-loop
     update = await getLoadingUpdate(update.updateCount);

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@agoric/assert": "^0.5.1",
+    "@agoric/internal": "^0.2.1",
     "@endo/bundle-source": "^2.4.2",
     "@endo/eventual-send": "^0.16.8",
     "@endo/init": "^0.5.52",

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -208,7 +208,7 @@ export async function replayXSnap(
    */
   async function runSteps(rd, steps) {
     const folder = rd.path;
-    for (const step of steps) {
+    for await (const step of steps) {
       const parts = step.match(/(\d+)-([a-zA-Z]+)\.(dat|json)$/);
       if (!parts) {
         throw Error(`expected 0001-abc.dat; got: ${step}`);
@@ -217,14 +217,12 @@ export async function replayXSnap(
       const seq = parseInt(digits, 10);
       console.log(folder, seq, kind);
       if (running && !['command', 'reply'].includes(kind)) {
-        // eslint-disable-next-line no-await-in-loop
         await running;
         running = undefined;
       }
       const file = rd.file(step);
       switch (kind) {
         case 'isReady':
-          // eslint-disable-next-line no-await-in-loop
           await it.isReady();
           break;
         case 'evaluate':
@@ -245,7 +243,6 @@ export async function replayXSnap(
             return;
           } else {
             try {
-              // eslint-disable-next-line no-await-in-loop
               await it.snapshot(file.getText());
             } catch (err) {
               console.warn(err, 'while taking snapshot:', err);

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -13,6 +13,7 @@
 import { makeNetstringReader, makeNetstringWriter } from '@endo/netstring';
 import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
 import { racePromises } from '@endo/promise-kit';
+import { forever } from '@agoric/internal';
 import { ErrorCode, ErrorSignal, ErrorMessage, METER_TYPE } from '../api.js';
 import { defer } from './defer.js';
 
@@ -166,7 +167,7 @@ export function xsnap(options) {
    * @returns {Promise<RunResult<Uint8Array>>}
    */
   async function runToIdle() {
-    for (;;) {
+    for await (const _ of forever) {
       const iteration = await messagesFromXsnap.next(undefined);
       if (iteration.done) {
         xsnapProcess.kill();
@@ -215,6 +216,7 @@ export function xsnap(options) {
         );
       }
     }
+    throw Error(`unreachable, but tools don't know that`);
   }
 
   /**

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -99,8 +99,9 @@ const start = zcf => {
     const option = payoffHandler.makeOptionInvitation(position);
     const invitationIssuer = zcf.getInvitationIssuer();
     const payment = harden({ Option: option });
+    const Option = await E(invitationIssuer).getAmountOf(option);
     const spreadAmount = harden({
-      Option: await E(invitationIssuer).getAmountOf(option),
+      Option,
     });
     // AWAIT ////
 


### PR DESCRIPTION
Inspired by https://github.com/Agoric/agoric-sdk/pull/6739 to return the favor.

If we keep pulling up the `await` weeds, we'll eventually be able to turn these warnings into errors.

Of the many PRs spawned off from https://github.com/Agoric/agoric-sdk/pull/6219 and the not-yet-written ugly await safety rules at https://github.com/endojs/Jessie/pull/93 , if we just fix 'em, we drop at least some of these kludgy and still-to-be-done workarounds. But this PR is only further incremental progress towards that goal. There are still way too many warnings.

I also refactored the `asyncGenerate` changes from #6739. None of them were interested in providing a value. All were only interested in the stopping condition. So instead `@agoric/internal` exports three convenience wrappers around `asyncGenerate`: `forever`, `whileTrue`, and `untilTrue`. 

I suggest reviewing with "Hide whitespace" on.