### PR TITLE
improve diagnostics for interface-tools

### DIFF
--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -2,7 +2,7 @@ import { Far } from '@endo/marshal';
 import { E } from '@endo/eventual-send';
 import { listDifference, objectMap } from '@agoric/internal';
 
-import { fit, M } from './patternMatchers.js';
+import { MinMethodGuard, fit, M } from './patternMatchers.js';
 
 const { quote: q, Fail } = assert;
 const { apply, ownKeys } = Reflect;
@@ -144,7 +144,6 @@ const bindMethod = (
   let { method } = thisfulMethods
     ? {
         method(...args) {
-          this || Fail`thisful method ${methodTag} called without this`;
           this ||
             Fail`thisful method ${methodTag} called without 'this' object`;
           const context = getContext(this);
@@ -159,6 +158,9 @@ const bindMethod = (
       };
   if (methodGuard) {
     method = defendMethod(method, methodGuard, methodTag);
+  } else if (thisfulMethods) {
+    // For far classes ensure that inputs and outputs are passable.
+    method = defendMethod(method, MinMethodGuard, methodTag);
   }
   defineProperties(method, {
     name: { value: methodTag },

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -144,6 +144,9 @@ const bindMethod = (
   let { method } = thisfulMethods
     ? {
         method(...args) {
+          this || Fail`thisful method ${methodTag} called without this`;
+          this ||
+            Fail`thisful method ${methodTag} called without 'this' object`;
           const context = getContext(this);
           return apply(behaviorMethod, context, args);
         },

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -1838,4 +1838,12 @@ export const {
   M,
 } = makePatternKit();
 
+/**
+ * A method guard, for inclusion in an interface guard, that enforces only that
+ * all arguments are passable and that the result is passable. (In far classes,
+ * "any" means any *passable*.) This is the least possible enforcement for a
+ * method guard, and is implied by all other method guards.
+ */
+export const MinMethodGuard = M.call().rest(M.any()).returns(M.any());
+
 MM = M;

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -481,7 +481,7 @@
  */
 
 /**
- * @typedef {object} MatcherNamespace
+ * @typedef {object} PatternMatchers
  *
  * @property {() => Matcher} any
  * Matches any passable.
@@ -695,17 +695,24 @@
  * @property {(t: Pattern) => Pattern} opt
  * Matches a value matched by the sub-pattern or the exact value
  * `undefined`.
- *
+ */
+
+/**
+ * @typedef {object} GuardMakers
  * @property {<M extends Record<any, any>>(interfaceName: string,
  *             methodGuards: M,
  *             options?: {sloppy?: boolean}
- * ) => InterfaceGuard} interface
+ * ) => InterfaceGuard} interface Guard an interface to a far object or facet
  *
- * @property {(...argGuards: ArgGuard[]) => MethodGuardMaker} call
+ * @property {(...argGuards: ArgGuard[]) => MethodGuardMaker} call Guard a synchronous call
  *
- * @property {(...argGuards: ArgGuard[]) => MethodGuardMaker} callWhen
+ * @property {(...argGuards: ArgGuard[]) => MethodGuardMaker} callWhen Guard an async call
  *
- * @property {(argGuard: ArgGuard) => ArgGuard} await
+ * @property {(argGuard: ArgGuard) => ArgGuard} await Guard an await
+ */
+
+/**
+ * @typedef {PatternMatchers & GuardMakers} MatcherNamespace
  */
 
 /** @typedef {(...args: any[]) => any} Method */

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -112,6 +112,26 @@ test('test makeHeapFarInstance', t => {
   });
 });
 
+test('naked function call', t => {
+  const greeter = makeHeapFarInstance(
+    'greeter',
+    M.interface('greeter', { sayHello: M.call().returns('hello') }),
+    {
+      sayHello() {
+        return 'hello';
+      },
+    },
+  );
+
+  const { sayHello } = greeter;
+  t.throws(() => sayHello(), {
+    message:
+      'thisful method "In \\"sayHello\\" method of (greeter)" called without \'this\' object',
+  });
+
+  t.is(sayHello.bind(greeter)(), 'hello');
+});
+
 // needn't run. we just don't have a better place to write these.
 test.skip('types', () => {
   // any methods can be defined if there's no interface

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -112,6 +112,54 @@ test('test makeHeapFarInstance', t => {
   });
 });
 
+// For code sharing with defineKind which does not support an interface
+test('missing interface', t => {
+  t.notThrows(() =>
+    makeHeapFarInstance('greeter', undefined, {
+      sayHello() {
+        return 'hello';
+      },
+    }),
+  );
+  const greeterMaker = makeHeapFarInstance('greeterMaker', undefined, {
+    makeSayHello() {
+      return () => 'hello';
+    },
+  });
+  t.throws(() => greeterMaker.makeSayHello(), {
+    message:
+      'In "makeSayHello" method of (greeterMaker): result: "[Symbol(passStyle)]" property expected: "[Function <anon>]"',
+  });
+});
+
+test('sloppy option', t => {
+  const emptyBehavior = {};
+  const greeter = makeHeapFarInstance(
+    'greeter',
+    M.interface('greeter', emptyBehavior, { sloppy: true }),
+    {
+      sayHello() {
+        return 'hello';
+      },
+    },
+  );
+  t.is(greeter.sayHello(), 'hello');
+
+  t.throws(
+    () =>
+      makeHeapFarInstance(
+        'greeter',
+        M.interface('greeter', emptyBehavior, { sloppy: false }),
+        {
+          sayHello() {
+            return 'hello';
+          },
+        },
+      ),
+    { message: 'methods ["sayHello"] not guarded by "greeter"' },
+  );
+});
+
 test('naked function call', t => {
   const greeter = makeHeapFarInstance(
     'greeter',


### PR DESCRIPTION
## Description

In the course of https://github.com/Agoric/agoric-sdk/pull/6716 I burned some time diagnosing this error message, 
> <methodTag> may only be applied to a valid instance: "undefined"

It's because in the course of converting to far class, I forgot to change the function calls from the closure onto the object. This adds a more direct diagnostic message for that case. I tried to modify the existing test in getContext but since it's used for non-thisful methods too I couldn't think of a way to diagnose this particular case. Alternative designs welcomed.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

Adds a teset to cover the error message. There still isn't one for the "may only be applied to a valid instance" message.