### PR TITLE
feat(web-components): allow custom import context

### DIFF
--- a/packages/web-components/src/keplr-connection/KeplrConnection.js
+++ b/packages/web-components/src/keplr-connection/KeplrConnection.js
@@ -11,11 +11,11 @@ const DEFAULT_NETWORK_CONFIG = 'https://main.agoric.net/network-config';
 
 export const makeAgoricKeplrConnection = async (
   networkConfig = DEFAULT_NETWORK_CONFIG,
+  context = makeImportContext(),
 ) => {
   const chainId = await getChainId(networkConfig);
   const address = await getKeplrAddress(chainId);
 
-  const context = makeImportContext();
   const leader = makeLeader(networkConfig);
   const walletNotifiers = await watchWallet(leader, address, context);
 


### PR DESCRIPTION
refs https://github.com/Agoric/dapp-inter/issues/9

The dapp will already have an import context if it starts reading the chain before connecting to keplr