### PR TITLE
feat: include oracleId in OracleStatus

### DIFF
--- a/packages/inter-protocol/src/price/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/price/priceAggregatorChainlink.js
@@ -29,7 +29,7 @@ const priceDescriptionFromQuote = quote => quote.quoteAmount.value[0];
  * @typedef {object} RoundState
  * @property {boolean} eligibleForSpecificRound
  * @property {bigint} queriedRoundId
- * @property {bigint} oracleStatus
+ * @property {bigint} latestSubmission
  * @property {Timestamp} startedAt
  * @property {number} roundTimeout
  * @property {number} oracleCount
@@ -288,7 +288,7 @@ export const start = async (zcf, privateArgs, baggage) => {
             blockTimestamp,
           ),
           queriedRoundId,
-          oracleStatus: status.latestSubmission,
+          latestSubmission: status.latestSubmission,
           startedAt: roundStatus.startedAt,
           roundTimeout: roundStatus.roundTimeout,
           oracleCount,

--- a/packages/inter-protocol/src/price/priceOracleAdmin.js
+++ b/packages/inter-protocol/src/price/priceOracleAdmin.js
@@ -4,7 +4,8 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
 
 /**
  * @typedef {{
- *   roundPowers: { handlePush: Function }
+ *   oracleId: string,
+ *   roundPowers: { handlePush: (status: OracleStatus, result: import('./roundsManager.js').PriceRound) => Promise<OracleStatus> }
  * }} HeldParams
  */
 
@@ -17,6 +18,7 @@ export const INVITATION_MAKERS_DESC = 'oracle invitation';
  * @property {bigint} lastReportedRound
  * @property {bigint} lastStartedRound
  * @property {bigint} latestSubmission
+ * @property {string} oracleId
  */
 /**
  * @typedef {Readonly<HeldParams & {
@@ -33,8 +35,9 @@ const oracleAdminKind = makeKindHandle('OracleAdmin');
  * @param {HeldParams} heldParams
  * @returns {State}
  */
-const initState = ({ roundPowers }) => {
+const initState = ({ oracleId, roundPowers }) => {
   return {
+    oracleId,
     roundPowers,
     lastReportedRound: 0n,
     lastStartedRound: 0n,
@@ -64,6 +67,7 @@ export const makeOracleAdmin = defineDurableFarClass(
       const { roundPowers } = state;
       const result = await roundPowers.handlePush(
         {
+          oracleId: state.oracleId,
           lastReportedRound: state.lastReportedRound,
           lastStartedRound: state.lastStartedRound,
           latestSubmission: state.latestSubmission,
@@ -85,6 +89,7 @@ export const makeOracleAdmin = defineDurableFarClass(
     getStatus() {
       const { state } = this;
       return {
+        oracleId: state.oracleId,
         lastReportedRound: state.lastReportedRound,
         lastStartedRound: state.lastStartedRound,
         latestSubmission: state.latestSubmission,

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -17,6 +17,8 @@ import { Far } from '@endo/marshal';
 
 const { add, subtract, multiply, floorDivide, ceilDivide, isGTE } = natSafeMath;
 
+/** @typedef {import('./priceOracleAdmin.js').OracleStatus} OracleStatus */
+
 /** @type {string} */
 const V3_NO_DATA_ERROR = 'No data present';
 
@@ -50,14 +52,6 @@ const validRoundId = roundId => {
  * was computed. answeredInRound may be smaller than roundId when the round
  * timed out. answeredInRound is equal to roundId when the round didn't time out
  * and was completed regularly.
- */
-
-/**
- * @typedef {object} OracleStatus
- * @property {bigint} lastReportedRound
- * @property {bigint} lastStartedRound
- * @property {bigint} latestSubmission
- * @property {number} index
  */
 
 /**

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -652,7 +652,7 @@ export const makeRoundsManagerKit = defineDurableFarClassKit(
         return {
           eligibleForSpecificRound: eligibleToSubmit,
           queriedRoundId: roundId,
-          oracleStatus: status.latestSubmission,
+          latestSubmission: status.latestSubmission,
           startedAt,
           roundTimeout,
         };

--- a/packages/inter-protocol/test/test-priceAggregatorChainlink.js
+++ b/packages/inter-protocol/test/test-priceAggregatorChainlink.js
@@ -602,23 +602,36 @@ test('suggest', async t => {
   // ----- round 2: add a new oracle and confirm the suggested round is correct
   await oracleTimer.tick();
   await E(pricePushAdminB).pushPrice({ roundId: 2, unitPrice: 1000n });
-  const oracleCSuggestion = await E(aggregator.creatorFacet).oracleRoundState(
-    'agorice1priceOracleC',
-    1n,
+
+  t.deepEqual(
+    await E(aggregator.creatorFacet).oracleRoundState(
+      'agorice1priceOracleC',
+      1n,
+    ),
+    {
+      eligibleForSpecificRound: false,
+      oracleCount: 3,
+      oracleStatus: 300n,
+      queriedRoundId: 1n,
+      roundTimeout: 5,
+      startedAt: 1n,
+    },
   );
 
-  t.is(oracleCSuggestion.eligibleForSpecificRound, false);
-  t.is(oracleCSuggestion.queriedRoundId, 1n);
-  t.is(oracleCSuggestion.oracleCount, 3);
-
-  const oracleBSuggestion = await E(aggregator.creatorFacet).oracleRoundState(
-    'agorice1priceOracleB',
-    0n,
+  t.deepEqual(
+    await E(aggregator.creatorFacet).oracleRoundState(
+      'agorice1priceOracleB',
+      0n,
+    ),
+    {
+      eligibleForSpecificRound: false,
+      oracleCount: 3,
+      oracleStatus: 1000n,
+      queriedRoundId: 2n,
+      roundTimeout: 5,
+      startedAt: 3n,
+    },
   );
-
-  t.is(oracleBSuggestion.eligibleForSpecificRound, false);
-  t.is(oracleBSuggestion.queriedRoundId, 2n);
-  t.is(oracleBSuggestion.oracleCount, 3);
 
   await oracleTimer.tick();
   await E(pricePushAdminA).pushPrice({ roundId: 2, unitPrice: 2000n });
@@ -626,14 +639,20 @@ test('suggest', async t => {
   await oracleTimer.tick();
   await E(pricePushAdminC).pushPrice({ roundId: 2, unitPrice: 3000n });
 
-  const oracleASuggestion = await E(aggregator.creatorFacet).oracleRoundState(
-    'agorice1priceOracleA',
-    0n,
+  t.deepEqual(
+    await E(aggregator.creatorFacet).oracleRoundState(
+      'agorice1priceOracleA',
+      0n,
+    ),
+    {
+      eligibleForSpecificRound: true,
+      oracleCount: 3,
+      oracleStatus: 2000n,
+      queriedRoundId: 3n,
+      roundTimeout: 0,
+      startedAt: 0n, // round 3 hasn't yet started, so it should be zeroed
+    },
   );
-
-  t.is(oracleASuggestion.eligibleForSpecificRound, true);
-  t.is(oracleASuggestion.queriedRoundId, 3n);
-  t.is(oracleASuggestion.startedAt, 0n); // round 3 hasn't yet started, so it should be zeroed
 
   // ----- round 3: try using suggested round
   await E(pricePushAdminC).pushPrice({ roundId: 3, unitPrice: 100n });

--- a/packages/inter-protocol/test/test-priceAggregatorChainlink.js
+++ b/packages/inter-protocol/test/test-priceAggregatorChainlink.js
@@ -611,7 +611,7 @@ test('suggest', async t => {
     {
       eligibleForSpecificRound: false,
       oracleCount: 3,
-      oracleStatus: 300n,
+      latestSubmission: 300n,
       queriedRoundId: 1n,
       roundTimeout: 5,
       startedAt: 1n,
@@ -626,7 +626,7 @@ test('suggest', async t => {
     {
       eligibleForSpecificRound: false,
       oracleCount: 3,
-      oracleStatus: 1000n,
+      latestSubmission: 1000n,
       queriedRoundId: 2n,
       roundTimeout: 5,
       startedAt: 3n,
@@ -647,7 +647,7 @@ test('suggest', async t => {
     {
       eligibleForSpecificRound: true,
       oracleCount: 3,
-      oracleStatus: 2000n,
+      latestSubmission: 2000n,
       queriedRoundId: 3n,
       roundTimeout: 0,
       startedAt: 0n, // round 3 hasn't yet started, so it should be zeroed


### PR DESCRIPTION
## Description

To support a `submittedBy` feature in https://github.com/Agoric/agoric-sdk/pull/6752

### Security Considerations

This makes `handlePush` take an `oracleId` (within the `status` arg) which could be sent from an OracleAdmin object that's responsible for a different oracleId. The reason this is acceptable is that `handlePush` is provided only to OracleAdmin objects that were created by the contract.

An alternative would be to have a separate `roundPowers` object for each OracleAdmin, with the oracleId bound, but the other state in OracleAdmin (lastReportedRound, lastStartedRound, latestSubmission) passed to `handlePush` is similarly exploitable if the OracleAdmin object can't be trusted.

### Documentation Considerations

--

### Testing Considerations

New test