### PR TITLE
chore(ERTP): AmountMath compare should be same as Key compare

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -48,11 +48,11 @@
     "@endo/far": "^0.2.18",
     "@endo/marshal": "^0.8.5",
     "@endo/nat": "^4.1.27",
-    "@endo/promise-kit": "^0.2.56"
+    "@endo/promise-kit": "^0.2.56",
+    "@fast-check/ava": "^1.1.3"
   },
   "devDependencies": {
     "@endo/bundle-source": "^2.5.1",
-    "@fast-check/ava": "^1.1.3",
     "ava": "^5.2.0",
     "tsd": "^0.28.1"
   },
@@ -67,7 +67,8 @@
       "# fast-check unsupported",
       "test/unitTests/test-amountProperties.js",
       "test/unitTests/test-inputValidation.js",
-      "test/unitTests/test-issuerObj.js"
+      "test/unitTests/test-issuerObj.js",
+      "test/unitTests/test-amount-key-arith.js"
     ]
   },
   "ava": {

--- a/packages/ERTP/test/unitTests/mathHelpers/test-copyBagMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-copyBagMathHelpers.js
@@ -6,7 +6,7 @@ import {
 } from '@agoric/store';
 
 import { AmountMath as m, AssetKind } from '../../../src/index.js';
-import { mockBrand } from './mockBrand.js';
+import { mockBrand } from '../../../tools/mockBrand.js';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled

--- a/packages/ERTP/test/unitTests/mathHelpers/test-copySetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-copySetMathHelpers.js
@@ -2,7 +2,7 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { getCopySetKeys, makeCopySet } from '@agoric/store';
 
 import { AmountMath as m, AssetKind } from '../../../src/index.js';
-import { mockBrand } from './mockBrand.js';
+import { mockBrand } from '../../../tools/mockBrand.js';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -4,7 +4,7 @@ import { M } from '@agoric/store';
 
 import { Far } from '@endo/marshal';
 import { AmountMath as m, AssetKind } from '../../../src/index.js';
-import { mockBrand } from './mockBrand.js';
+import { mockBrand } from '../../../tools/mockBrand.js';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -4,7 +4,7 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { Far } from '@endo/marshal';
 
 import { AmountMath as m, AssetKind } from '../../../src/index.js';
-import { mockBrand } from './mockBrand.js';
+import { mockBrand } from '../../../tools/mockBrand.js';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -2,7 +2,7 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { AmountMath as m, AssetKind } from '../../../src/index.js';
-import { mockBrand } from './mockBrand.js';
+import { mockBrand } from '../../../tools/mockBrand.js';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled

--- a/packages/ERTP/test/unitTests/test-amount-key-arith.js
+++ b/packages/ERTP/test/unitTests/test-amount-key-arith.js
@@ -1,0 +1,22 @@
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { fc } from '@fast-check/ava';
+import { keyEQ, keyGTE } from '@agoric/store';
+
+import { AmountMath as m } from '../../src/index.js';
+import { arbAmount } from '../../tools/arb-amount.js';
+
+test('amount equality iff key equality', async t => {
+  await fc.assert(
+    fc.property(fc.record({ x: arbAmount, y: arbAmount }), ({ x, y }) => {
+      return t.true(m.isEqual(x, y) === keyEQ(x, y));
+    }),
+  );
+});
+
+test('amount >= iff key >=', async t => {
+  await fc.assert(
+    fc.property(fc.record({ x: arbAmount, y: arbAmount }), ({ x, y }) => {
+      return t.true(m.isGTE(x, y) === keyGTE(x, y));
+    }),
+  );
+});

--- a/packages/ERTP/test/unitTests/test-amountProperties.js
+++ b/packages/ERTP/test/unitTests/test-amountProperties.js
@@ -1,29 +1,9 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import { makeCopyBag } from '@agoric/store';
 import { fc } from '@fast-check/ava';
 
 import { AmountMath as m, AssetKind } from '../../src/index.js';
-import { mockBrand } from './mathHelpers/mockBrand.js';
-
-// Perhaps makeCopyBag should coalesce duplicate labels, but for now, it does
-// not.
-const distinctLabels = pairs =>
-  new Set(pairs.map(([label, _qty]) => label)).size === pairs.length;
-const positiveCounts = pairs =>
-  pairs.filter(([_l, qty]) => qty > 0n).length === pairs.length;
-const arbBagContents = fc
-  .nat(7)
-  .chain(size =>
-    fc.array(
-      fc.tuple(fc.string(), fc.bigUint({ max: 1_000_000_000_000_000n })),
-      { minLength: size, maxLength: size },
-    ),
-  )
-  .filter(pairs => distinctLabels(pairs) && positiveCounts(pairs));
-
-const arbAmount = arbBagContents.map(contents =>
-  m.make(mockBrand, harden(makeCopyBag(contents))),
-);
+import { mockBrand } from '../../tools/mockBrand.js';
+import { arbAmount } from '../../tools/arb-amount.js';
 
 // Note: we write P => Q as !P || Q since JS has no logical => operator
 const implies = (p, q) => !p || q;

--- a/packages/ERTP/tools/arb-amount.js
+++ b/packages/ERTP/tools/arb-amount.js
@@ -1,0 +1,26 @@
+import { makeCopyBag } from '@agoric/store';
+import { fc } from '@fast-check/ava';
+
+import { AmountMath as m } from '../src/index.js';
+import { mockBrand } from './mockBrand.js';
+
+// Perhaps makeCopyBag should coalesce duplicate labels, but for now, it does
+// not.
+const distinctLabels = pairs =>
+  new Set(pairs.map(([label, _qty]) => label)).size === pairs.length;
+const positiveCounts = pairs =>
+  pairs.filter(([_l, qty]) => qty > 0n).length === pairs.length;
+const arbBagContents = fc
+  .nat(7)
+  .chain(size =>
+    fc.array(
+      fc.tuple(fc.string(), fc.bigUint({ max: 1_000_000_000_000_000n })),
+      { minLength: size, maxLength: size },
+    ),
+  )
+  .filter(pairs => distinctLabels(pairs) && positiveCounts(pairs));
+
+// TODO: should include many non-bag amounts too
+export const arbAmount = arbBagContents.map(contents =>
+  m.make(mockBrand, harden(makeCopyBag(contents))),
+);

--- a/packages/ERTP/tools/mockBrand.js
+++ b/packages/ERTP/tools/mockBrand.js
@@ -1,10 +1,10 @@
 import { Far } from '@endo/marshal';
-import { AssetKind } from '../../../src/index.js';
+import { AssetKind } from '../src/index.js';
 
 /** @type {Brand<AssetKind>} */
 export const mockBrand = Far('brand', {
   // eslint-disable-next-line no-unused-vars
-  isMyIssuer: async allegedIssuer => false,
+  isMyIssuer: async _allegedIssuer => false,
   getAllegedName: () => 'mock',
   getAmountShape: () => {},
   getDisplayInfo: () => ({


### PR DESCRIPTION
Tests that AmountMath equality and inequality match Key equality and inequality.

Moves the arbPassable abstraction into its own tools/ file so it can be shared by tests, including potentially tests outside this package. See precedent to be set by https://github.com/endojs/endo/pull/1291

While explaining the store level of abstraction to @Tyrosine22 , I mentioned that we defined the key compare on amounts to be aligned with amount compare. Then I realized that this would be a perfect subject for property-based testing. However, the current arb-amount.js is too narrow for this test to really mean anything yet. It will need to generate many more kinds of amounts.