### PR TITLE
convert vaultFactory entities to FarClass

### DIFF
--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -80,6 +80,11 @@ export const AmountShape = harden({
   value: AmountValueShape,
 });
 
+export const RatioShape = harden({
+  numerator: AmountShape,
+  denominator: AmountShape,
+});
+
 /**
  * Returns true if value is a Nat bigint.
  *

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -208,7 +208,6 @@
  * @param {ERef<Payment>} payment
  * @param {Amount[]} amounts
  * @returns {Promise<Payment[]>}
- *
  */
 
 /**

--- a/packages/SwingSet/src/devices/loopbox/loopbox.js
+++ b/packages/SwingSet/src/devices/loopbox/loopbox.js
@@ -13,7 +13,6 @@ import { Fail } from '@agoric/assert';
  * deliverMode='queued' will stall the message until the host invokes our
  * `passOneMessage()` message function. We need this to exercise bugs like
  * #1400 which are sensitive to cross-machine message delivery order.
- *
  */
 
 export function buildLoopbox(deliverMode) {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -51,7 +51,6 @@ import { makeTranscriptManager } from './transcript.js';
  *              syscallFromWorker: (vso: VatSyscallObject) => VatSyscallResult,
  *              setDeliverToWorker: (dtw: unknown) => void,
  *            } } ManagerKit
- *
  */
 
 /**

--- a/packages/SwingSet/src/supervisors/supervisor-helper.js
+++ b/packages/SwingSet/src/supervisors/supervisor-helper.js
@@ -24,7 +24,6 @@ function makeSupervisorDispatch(dispatch) {
   /**
    * @param {VatDeliveryObject} delivery
    * @returns {Promise<VatDeliveryResult>}
-   *
    */
   async function dispatchToVat(delivery) {
     // the (low-level) vat is responsible for giving up agency, but we still

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -336,7 +336,6 @@ export {};
  * @property {*} runWithoutMetering Run a callback outside metering
  * @property {*} runWithoutMeteringAsync Run an async callback outside metering
  * @property {*} unmetered Wrap a callback with runWithoutMetering
- *
  */
 
 /**

--- a/packages/SwingSet/src/types-internal.js
+++ b/packages/SwingSet/src/types-internal.js
@@ -10,5 +10,4 @@ export {};
  *
  * @typedef { DynamicVatOptionsWithoutMeter & HasMeterID } InternalDynamicVatOptions
  * @typedef { import('./types-external.js').StaticVatOptions | ( InternalDynamicVatOptions & HasMeterID ) } RecordedVatOptions
- *
  */

--- a/packages/access-token/src/json-store.js
+++ b/packages/access-token/src/json-store.js
@@ -321,7 +321,6 @@ export function setAllState(storage, stuff) {
  * @returns {boolean}
  *   If the directory is present and contains the files created by initJSONStore
  *   or openJSONStore, returns true. Else returns false.
- *
  */
 export function isJSONStore(dirPath) {
   if (`${dirPath}` !== dirPath) {

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -14,6 +14,7 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { UnguardedHelperI } from '../typeGuards.js';
 
 const { add, subtract, multiply, floorDivide, ceilDivide, isGTE } = natSafeMath;
 
@@ -96,8 +97,7 @@ const validRoundId = roundId => {
 export const makeRoundsManagerKit = defineDurableFarClassKit(
   roundsManagerKind,
   {
-    // facet used only internally, sloppy ok
-    helper: M.interface('helper', {}, { sloppy: true }),
+    helper: UnguardedHelperI,
     contract: M.interface(
       'contract',
       {

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -29,7 +29,6 @@ const { Fail } = assert;
  * thereby acts as an anchor to provide additional stability. For flexible
  * economic policies, the fee percentage for trading into and out of the stable
  * token are specified separately.
- *
  */
 
 /**

--- a/packages/inter-protocol/src/typeGuards.js
+++ b/packages/inter-protocol/src/typeGuards.js
@@ -1,0 +1,11 @@
+import { M } from '@agoric/store';
+
+/**
+ * To be used only for 'helper' facets where the calls are from trusted code.
+ */
+export const UnguardedHelperI = M.interface(
+  'helper',
+  {},
+  // not exposed so sloppy okay
+  { sloppy: true },
+);

--- a/packages/inter-protocol/src/vaultFactory/types.js
+++ b/packages/inter-protocol/src/vaultFactory/types.js
@@ -46,7 +46,6 @@
 /**
  * @typedef  {object} VaultFactoryCreatorFacet
  * @property {AddVaultType} addVaultType
- * @property {() => Promise<Array<Collateral>>} getCollaterals
  * @property {() => Allocation} getRewardAllocation
  * @property {() => Instance} getContractGovernor
  * @property {() => Promise<Invitation>} makeCollectFeesInvitation

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -364,7 +364,6 @@ const makeVaultBase = defineDurableFarClassKit(
 
       /**
        * call this whenever anything changes!
-       *
        */
       updateUiState() {
         const { state, facets } = this;
@@ -621,8 +620,6 @@ const makeVaultBase = defineDurableFarClassKit(
       },
     },
     self: {
-      /**
-       */
       getVaultSeat() {
         return this.state.vaultSeat;
       },
@@ -698,7 +695,6 @@ const makeVaultBase = defineDurableFarClassKit(
 
       /**
        * Called by manager at start of liquidation.
-       *
        */
       liquidating() {
         const { facets } = this;
@@ -711,7 +707,6 @@ const makeVaultBase = defineDurableFarClassKit(
       /**
        * Called by manager at end of liquidation, at which point all debts have been
        * covered.
-       *
        */
       liquidated() {
         const { facets } = this;
@@ -726,8 +721,6 @@ const makeVaultBase = defineDurableFarClassKit(
         helper.updateUiState();
       },
 
-      /**
-       */
       makeAdjustBalancesInvitation() {
         const { state, facets } = this;
         const { helper } = facets;
@@ -739,8 +732,6 @@ const makeVaultBase = defineDurableFarClassKit(
         );
       },
 
-      /**
-       */
       makeCloseInvitation() {
         const { state, facets } = this;
         const { helper } = facets;

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -25,6 +25,7 @@ import {
   makeEphemeraProvider,
   stageDelta,
 } from '../contractSupport.js';
+import { UnguardedHelperI } from '../typeGuards.js';
 
 const { quote: q, Fail } = assert;
 
@@ -797,13 +798,7 @@ const vaultKind = makeKindHandle('Vault');
 const makeVaultBase = defineDurableFarClassKit(
   vaultKind,
   {
-    helper: M.interface(
-      'DepositFacet',
-      {
-        // helper not exposed so guard not necessary
-      },
-      { sloppy: true },
-    ),
+    helper: UnguardedHelperI,
     self: VaultI,
   },
   initState,

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -634,7 +634,7 @@ const selfBehavior = {
     const vaultKit = makeVaultKit(
       self,
       storageNode,
-      marshaller,
+      ephemera.marshaller,
       state.manager.getAssetSubscriber(),
     );
     ephemera.outerUpdater = vaultKit.vaultUpdater;

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -202,583 +202,6 @@ const checkRestart = (newCollateralPre, maxDebtPre, newCollateral, newDebt) => {
   return !AmountMath.isGTE(maxDebtPre, newDebt);
 };
 
-const helperBehavior = {
-  // #region Computed constants
-  collateralBrand() {
-    return this.state.manager.getCollateralBrand();
-  },
-  debtBrand() {
-    return this.state.manager.getDebtBrand();
-  },
-
-  emptyCollateral() {
-    return AmountMath.makeEmpty(this.facets.helper.collateralBrand());
-  },
-  emptyDebt() {
-    return AmountMath.makeEmpty(this.facets.helper.debtBrand());
-  },
-  // #endregion
-
-  // #region Phase logic
-  /**
-   * @param {VaultPhase} newPhase
-   */
-  assignPhase(newPhase) {
-    const { state } = this;
-
-    const { phase } = state;
-    const validNewPhases = validTransitions[phase];
-    validNewPhases.includes(newPhase) ||
-      Fail`Vault cannot transition from ${q(phase)} to ${q(newPhase)}`;
-    state.phase = newPhase;
-  },
-
-  assertActive() {
-    const { phase } = this.state;
-    assert(phase === Phase.ACTIVE);
-  },
-
-  assertCloseable() {
-    const { phase } = this.state;
-    phase === Phase.ACTIVE ||
-      phase === Phase.LIQUIDATED ||
-      Fail`to be closed a vault must be active or liquidated, not ${phase}`;
-  },
-  // #endregion
-
-  /**
-   * Called whenever the debt is paid or created through a transaction,
-   * but not for interest accrual.
-   *
-   * @param {Amount<'nat'>} newDebt - principal and all accrued interest
-   */
-  updateDebtSnapshot(newDebt) {
-    const { state } = this;
-
-    // update local state
-    state.debtSnapshot = newDebt;
-    state.interestSnapshot = state.manager.getCompoundedInterest();
-  },
-
-  /**
-   * Update the debt balance and propagate upwards to
-   * maintain aggregate debt and liquidation order.
-   *
-   * @param {NormalizedDebt} oldDebtNormalized - prior principal and all accrued interest, normalized to the launch of the vaultManager
-   * @param {Amount<'nat'>} oldCollateral - actual collateral
-   * @param {Amount<'nat'>} newDebtActual - actual principal and all accrued interest
-   */
-  updateDebtAccounting(oldDebtNormalized, oldCollateral, newDebtActual) {
-    const { state, facets } = this;
-    const { helper } = facets;
-    helper.updateDebtSnapshot(newDebtActual);
-    // notify manager so it can notify and clean up as appropriate
-    state.manager.handleBalanceChange(
-      oldDebtNormalized,
-      oldCollateral,
-      state.idInManager,
-      state.phase,
-      facets.self,
-    );
-  },
-
-  /**
-   *
-   * @param {ZCFSeat} seat
-   */
-  getCollateralAllocated(seat) {
-    return seat.getAmountAllocated(
-      'Collateral',
-      this.facets.helper.collateralBrand(),
-    );
-  },
-  getMintedAllocated(seat) {
-    return seat.getAmountAllocated('Minted', this.facets.helper.debtBrand());
-  },
-
-  assertVaultHoldsNoMinted() {
-    const { state, facets } = this;
-    const { vaultSeat } = state;
-    AmountMath.isEmpty(facets.helper.getMintedAllocated(vaultSeat)) ||
-      Fail`Vault should be empty of Minted`;
-  },
-
-  /**
-   *
-   * @param {Amount<'nat'>} collateralAmount
-   * @param {Amount<'nat'>} proposedRunDebt
-   */
-  async assertSufficientCollateral(collateralAmount, proposedRunDebt) {
-    const { state, facets } = this;
-    const maxRun = await state.manager.maxDebtFor(collateralAmount);
-    AmountMath.isGTE(maxRun, proposedRunDebt, facets.helper.debtBrand()) ||
-      Fail`Requested ${q(proposedRunDebt)} exceeds max ${q(maxRun)} for ${q(
-        collateralAmount,
-      )} collateral`;
-  },
-
-  /**
-   *
-   * @param {HolderPhase} newPhase
-   */
-  getStateSnapshot(newPhase) {
-    const { state, facets } = this;
-
-    const { debtSnapshot: debt, interestSnapshot: interest } = state;
-    /** @type {VaultNotification} */
-    return harden({
-      debtSnapshot: { debt, interest },
-      locked: facets.self.getCollateralAmount(),
-      // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
-      // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
-      vaultState: newPhase,
-    });
-  },
-
-  /**
-   * call this whenever anything changes!
-   *
-   */
-  updateUiState() {
-    const { state, facets } = this;
-    const ephemera = provideEphemera(state.idInManager);
-    const { outerUpdater } = ephemera;
-    if (!outerUpdater) {
-      // It's not an error to change to liquidating during transfer
-      return;
-    }
-    const { phase } = state;
-    const uiState = facets.helper.getStateSnapshot(phase);
-    trace('updateUiState', state.idInManager, uiState);
-
-    switch (phase) {
-      case Phase.ACTIVE:
-      case Phase.LIQUIDATING:
-      case Phase.LIQUIDATED:
-        outerUpdater.publish(uiState);
-        break;
-      case Phase.CLOSED:
-        outerUpdater.finish(uiState);
-        ephemera.outerUpdater = null;
-        break;
-      default:
-        throw Error(`unreachable vault phase: ${phase}`);
-    }
-  },
-
-  /**
-   * @param {ZCFSeat} seat
-   */
-  async closeHook(seat) {
-    const { state, facets } = this;
-
-    const { self, helper } = facets;
-    helper.assertCloseable();
-    const { phase, vaultSeat } = state;
-    const { zcf } = provideEphemera(state.idInManager);
-
-    // Held as keys for cleanup in the manager
-    const oldDebtNormalized = self.getNormalizedDebt();
-    const oldCollateral = self.getCollateralAmount();
-
-    if (phase === Phase.ACTIVE) {
-      assertProposalShape(seat, {
-        give: { Minted: null },
-      });
-
-      // you're paying off the debt, you get everything back.
-      const debt = self.getCurrentDebt();
-      const {
-        give: { Minted: given },
-      } = seat.getProposal();
-
-      // you must pay off the entire remainder but if you offer too much, we won't
-      // take more than you owe
-      AmountMath.isGTE(given, debt) ||
-        Fail`Offer ${given} is not sufficient to pay off debt ${debt}`;
-
-      // Return any overpayment
-      atomicTransfer(zcf, vaultSeat, seat, vaultSeat.getCurrentAllocation());
-
-      state.manager.burnAndRecord(debt, seat);
-    } else if (phase === Phase.LIQUIDATED) {
-      // Simply reallocate vault assets to the offer seat.
-      // Don't take anything from the offer, even if vault is underwater.
-      // TODO verify that returning Minted here doesn't mess up debt limits
-
-      atomicTransfer(zcf, vaultSeat, seat, vaultSeat.getCurrentAllocation());
-    } else {
-      throw new Error('only active and liquidated vaults can be closed');
-    }
-
-    seat.exit();
-    helper.assignPhase(Phase.CLOSED);
-    helper.updateDebtSnapshot(helper.emptyDebt());
-    helper.updateUiState();
-
-    helper.assertVaultHoldsNoMinted();
-    vaultSeat.exit();
-
-    state.manager.handleBalanceChange(
-      oldDebtNormalized,
-      oldCollateral,
-      state.idInManager,
-      state.phase,
-      facets.self,
-    );
-
-    return 'your loan is closed, thank you for your business';
-  },
-
-  /**
-   * Calculate the fee, the amount to mint and the resulting debt.
-   * The give and the want together reflect a delta, where typically
-   * one is zero because they come from the gave/want of an offer
-   * proposal. If the `want` is zero, the `fee` will also be zero,
-   * so the simple math works.
-   *
-   * @param {Amount<'nat'>} currentDebt
-   * @param {Amount<'nat'>} giveAmount
-   * @param {Amount<'nat'>} wantAmount
-   */
-  loanFee(currentDebt, giveAmount, wantAmount) {
-    const { state } = this;
-
-    const fee = ceilMultiplyBy(
-      wantAmount,
-      state.manager.getGovernedParams().getLoanFee(),
-    );
-    const toMint = AmountMath.add(wantAmount, fee);
-    const newDebt = addSubtract(currentDebt, toMint, giveAmount);
-    return { newDebt, toMint, fee };
-  },
-
-  /**
-   * Adjust principal and collateral (atomically for offer safety)
-   *
-   * @param {ZCFSeat} clientSeat
-   * @returns {Promise<string>} success message
-   */
-  async adjustBalancesHook(clientSeat) {
-    const { state, facets } = this;
-
-    const { self, helper } = facets;
-    const ephemera = provideEphemera(state.idInManager);
-    const { outerUpdater: updaterPre } = ephemera;
-    const { vaultSeat } = state;
-    const proposal = clientSeat.getProposal();
-    assertOnlyKeys(proposal, ['Collateral', 'Minted']);
-
-    const allEmpty = amounts => {
-      return amounts.every(a => AmountMath.isEmpty(a));
-    };
-
-    const normalizedDebtPre = self.getNormalizedDebt();
-    const collateralPre = helper.getCollateralAllocated(vaultSeat);
-
-    const giveColl = proposal.give.Collateral || helper.emptyCollateral();
-    const wantColl = proposal.want.Collateral || helper.emptyCollateral();
-
-    const newCollateralPre = addSubtract(collateralPre, giveColl, wantColl);
-    // max debt supported by current Collateral as modified by proposal
-    const maxDebtPre = await state.manager.maxDebtFor(newCollateralPre);
-    updaterPre === ephemera.outerUpdater ||
-      Fail`Transfer during vault adjustment`;
-    helper.assertActive();
-
-    // After the `await`, we retrieve the vault's allocations again,
-    // so we can compare to the debt limit based on the new values.
-    const collateral = helper.getCollateralAllocated(vaultSeat);
-    const newCollateral = addSubtract(collateral, giveColl, wantColl);
-
-    const debt = self.getCurrentDebt();
-    const giveMinted = AmountMath.min(
-      proposal.give.Minted || helper.emptyDebt(),
-      debt,
-    );
-    const wantMinted = proposal.want.Minted || helper.emptyDebt();
-    if (allEmpty([giveColl, giveMinted, wantColl, wantMinted])) {
-      clientSeat.exit();
-      return 'no transaction, as requested';
-    }
-
-    // Calculate the fee, the amount to mint and the resulting debt. We'll
-    // verify that the target debt doesn't violate the collateralization ratio,
-    // then mint, reallocate, and burn.
-    const { newDebt, fee, toMint } = helper.loanFee(
-      debt,
-      giveMinted,
-      wantMinted,
-    );
-
-    trace('adjustBalancesHook', state.idInManager, {
-      newCollateralPre,
-      newCollateral,
-      fee,
-      toMint,
-      newDebt,
-    });
-
-    if (checkRestart(newCollateralPre, maxDebtPre, newCollateral, newDebt)) {
-      return helper.adjustBalancesHook(clientSeat);
-    }
-
-    stageDelta(clientSeat, vaultSeat, giveColl, wantColl, 'Collateral');
-    // `wantMinted` is allocated in the reallocate and mint operation, and so not here
-    stageDelta(clientSeat, vaultSeat, giveMinted, helper.emptyDebt(), 'Minted');
-
-    /** @type {Array<ZCFSeat>} */
-    const vaultSeatOpt = allEmpty([giveColl, giveMinted, wantColl])
-      ? []
-      : [vaultSeat];
-    state.manager.mintAndReallocate(toMint, fee, clientSeat, ...vaultSeatOpt);
-
-    // parent needs to know about the change in debt
-    helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebt);
-    state.manager.burnAndRecord(giveMinted, vaultSeat);
-    helper.assertVaultHoldsNoMinted();
-
-    helper.updateUiState();
-    clientSeat.exit();
-    return 'We have adjusted your balances, thank you for your business';
-  },
-
-  /**
-   *
-   * @param {ZCFSeat} seat
-   * @returns {VaultKit}
-   */
-  makeTransferInvitationHook(seat) {
-    const { state, facets } = this;
-
-    const { self, helper } = facets;
-    helper.assertCloseable();
-    seat.exit();
-
-    const ephemera = provideEphemera(state.idInManager);
-
-    // eslint-disable-next-line no-use-before-define
-    const vaultKit = makeVaultKit(
-      self,
-      ephemera.storageNode,
-      ephemera.marshaller,
-      state.manager.getAssetSubscriber(),
-    );
-    ephemera.outerUpdater = vaultKit.vaultUpdater;
-    helper.updateUiState();
-
-    return vaultKit;
-  },
-};
-
-const selfBehavior = {
-  /**
-   */
-  getVaultSeat() {
-    return this.state.vaultSeat;
-  },
-
-  /**
-   * @param {ZCFSeat} seat
-   * @param {ERef<StorageNode>} storageNode
-   */
-  async initVaultKit(seat, storageNode) {
-    const { state, facets } = this;
-
-    const ephemera = provideEphemera(state.idInManager);
-
-    const { self, helper } = facets;
-
-    const normalizedDebtPre = self.getNormalizedDebt();
-    const actualDebtPre = self.getCurrentDebt();
-    (AmountMath.isEmpty(normalizedDebtPre) &&
-      AmountMath.isEmpty(actualDebtPre)) ||
-      Fail`vault must be empty initially`;
-
-    const collateralPre = self.getCollateralAmount();
-    trace('initVaultKit start: collateral', state.idInManager, {
-      actualDebtPre,
-      collateralPre,
-    });
-
-    // get the payout to provide access to the collateral if the
-    // contract abandons
-    const {
-      give: { Collateral: giveCollateral },
-      want: { Minted: wantMinted },
-    } = seat.getProposal();
-
-    const {
-      newDebt: newDebtPre,
-      fee,
-      toMint,
-    } = helper.loanFee(actualDebtPre, helper.emptyDebt(), wantMinted);
-    !AmountMath.isEmpty(fee) ||
-      Fail`loan requested (${wantMinted}) is too small; cannot accrue interest`;
-    AmountMath.isEqual(newDebtPre, toMint) || Fail`fee mismatch for vault`;
-    trace(
-      'initVault',
-      state.idInManager,
-      { wantedRun: wantMinted, fee },
-      self.getCollateralAmount(),
-    );
-
-    await helper.assertSufficientCollateral(giveCollateral, newDebtPre);
-
-    const { vaultSeat } = state;
-    vaultSeat.incrementBy(
-      seat.decrementBy(harden({ Collateral: giveCollateral })),
-    );
-    state.manager.mintAndReallocate(toMint, fee, seat, vaultSeat);
-    helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebtPre);
-
-    const vaultKit = makeVaultKit(
-      self,
-      storageNode,
-      ephemera.marshaller,
-      state.manager.getAssetSubscriber(),
-    );
-    ephemera.outerUpdater = vaultKit.vaultUpdater;
-    helper.updateUiState();
-    return vaultKit;
-  },
-
-  /**
-   * Called by manager at start of liquidation.
-   *
-   */
-  liquidating() {
-    const { facets } = this;
-
-    const { helper } = facets;
-    helper.assignPhase(Phase.LIQUIDATING);
-    helper.updateUiState();
-  },
-
-  /**
-   * Called by manager at end of liquidation, at which point all debts have been
-   * covered.
-   *
-   */
-  liquidated() {
-    const { facets } = this;
-
-    const { helper } = facets;
-    helper.updateDebtSnapshot(
-      // liquidated vaults retain no debt
-      AmountMath.makeEmpty(helper.debtBrand()),
-    );
-
-    helper.assignPhase(Phase.LIQUIDATED);
-    helper.updateUiState();
-  },
-
-  /**
-   */
-  makeAdjustBalancesInvitation() {
-    const { state, facets } = this;
-    const { helper } = facets;
-    helper.assertActive();
-    const { zcf } = provideEphemera(state.idInManager);
-    return zcf.makeInvitation(
-      seat => helper.adjustBalancesHook(seat),
-      'AdjustBalances',
-    );
-  },
-
-  /**
-   */
-  makeCloseInvitation() {
-    const { state, facets } = this;
-    const { helper } = facets;
-    helper.assertCloseable();
-    const { zcf } = provideEphemera(state.idInManager);
-    return zcf.makeInvitation(seat => helper.closeHook(seat), 'CloseVault');
-  },
-
-  /**
-   * @returns {Promise<Invitation>}
-   */
-  makeTransferInvitation() {
-    const { state, facets } = this;
-    const ephemera = provideEphemera(state.idInManager);
-    const { outerUpdater } = ephemera;
-    const { self, helper } = facets;
-    // Bring the debt snapshot current for the final report before transfer
-    helper.updateDebtSnapshot(self.getCurrentDebt());
-    const { debtSnapshot: debt, interestSnapshot: interest, phase } = state;
-    if (outerUpdater) {
-      outerUpdater.finish(helper.getStateSnapshot(Phase.TRANSFER));
-      ephemera.outerUpdater = null;
-    }
-    const transferState = {
-      debtSnapshot: { debt, interest },
-      locked: self.getCollateralAmount(),
-      vaultState: phase,
-    };
-    const { zcf } = provideEphemera(state.idInManager);
-    return zcf.makeInvitation(
-      seat => helper.makeTransferInvitationHook(seat),
-      'TransferVault',
-      transferState,
-    );
-  },
-
-  // for status/debugging
-
-  /**
-   *
-   * @returns {Amount<'nat'>}
-   */
-  getCollateralAmount() {
-    const { state, facets } = this;
-    const { vaultSeat } = state;
-    const { helper } = facets;
-    // getCollateralAllocated would return final allocations
-    return vaultSeat.hasExited()
-      ? helper.emptyCollateral()
-      : helper.getCollateralAllocated(vaultSeat);
-  },
-
-  /**
-   * The actual current debt, including accrued interest.
-   *
-   * This looks like a simple getter but it does a lot of the heavy lifting for
-   * interest accrual. Rather than updating all records when interest accrues,
-   * the vault manager updates just its rolling compounded interest. Here we
-   * calculate what the current debt is given what's recorded in this vault and
-   * what interest has compounded since this vault record was written.
-   *
-   * @see getNormalizedDebt
-   *
-   * @returns {Amount<'nat'>}
-   */
-  getCurrentDebt() {
-    const { state } = this;
-    return calculateCurrentDebt(
-      state.debtSnapshot,
-      state.interestSnapshot,
-      state.manager.getCompoundedInterest(),
-    );
-  },
-
-  /**
-   * The normalization puts all debts on a common time-independent scale since
-   * the launch of this vault manager. This allows the manager to order vaults
-   * by their debt-to-collateral ratios without having to mutate the debts as
-   * the interest accrues.
-   *
-   * @see getActualDebAmount
-   *
-   * @returns {import('./storeUtils.js').NormalizedDebt} as if the vault was open at the launch of this manager, before any interest accrued
-   */
-  getNormalizedDebt() {
-    const { state } = this;
-    // @ts-expect-error cast
-    return reverseInterest(state.debtSnapshot, state.interestSnapshot);
-  },
-};
-
 export const VaultI = M.interface('Vault', {
   getCollateralAmount: M.call().returns(AmountShape),
   getCurrentDebt: M.call().returns(AmountShape),
@@ -802,7 +225,613 @@ const makeVaultBase = defineDurableFarClassKit(
     self: VaultI,
   },
   initState,
-  { helper: helperBehavior, self: selfBehavior },
+  {
+    helper: {
+      // #region Computed constants
+      collateralBrand() {
+        return this.state.manager.getCollateralBrand();
+      },
+      debtBrand() {
+        return this.state.manager.getDebtBrand();
+      },
+
+      emptyCollateral() {
+        return AmountMath.makeEmpty(this.facets.helper.collateralBrand());
+      },
+      emptyDebt() {
+        return AmountMath.makeEmpty(this.facets.helper.debtBrand());
+      },
+      // #endregion
+
+      // #region Phase logic
+      /**
+       * @param {VaultPhase} newPhase
+       */
+      assignPhase(newPhase) {
+        const { state } = this;
+
+        const { phase } = state;
+        const validNewPhases = validTransitions[phase];
+        validNewPhases.includes(newPhase) ||
+          Fail`Vault cannot transition from ${q(phase)} to ${q(newPhase)}`;
+        state.phase = newPhase;
+      },
+
+      assertActive() {
+        const { phase } = this.state;
+        assert(phase === Phase.ACTIVE);
+      },
+
+      assertCloseable() {
+        const { phase } = this.state;
+        phase === Phase.ACTIVE ||
+          phase === Phase.LIQUIDATED ||
+          Fail`to be closed a vault must be active or liquidated, not ${phase}`;
+      },
+      // #endregion
+
+      /**
+       * Called whenever the debt is paid or created through a transaction,
+       * but not for interest accrual.
+       *
+       * @param {Amount<'nat'>} newDebt - principal and all accrued interest
+       */
+      updateDebtSnapshot(newDebt) {
+        const { state } = this;
+
+        // update local state
+        state.debtSnapshot = newDebt;
+        state.interestSnapshot = state.manager.getCompoundedInterest();
+      },
+
+      /**
+       * Update the debt balance and propagate upwards to
+       * maintain aggregate debt and liquidation order.
+       *
+       * @param {NormalizedDebt} oldDebtNormalized - prior principal and all accrued interest, normalized to the launch of the vaultManager
+       * @param {Amount<'nat'>} oldCollateral - actual collateral
+       * @param {Amount<'nat'>} newDebtActual - actual principal and all accrued interest
+       */
+      updateDebtAccounting(oldDebtNormalized, oldCollateral, newDebtActual) {
+        const { state, facets } = this;
+        const { helper } = facets;
+        helper.updateDebtSnapshot(newDebtActual);
+        // notify manager so it can notify and clean up as appropriate
+        state.manager.handleBalanceChange(
+          oldDebtNormalized,
+          oldCollateral,
+          state.idInManager,
+          state.phase,
+          facets.self,
+        );
+      },
+
+      /**
+       *
+       * @param {ZCFSeat} seat
+       */
+      getCollateralAllocated(seat) {
+        return seat.getAmountAllocated(
+          'Collateral',
+          this.facets.helper.collateralBrand(),
+        );
+      },
+      getMintedAllocated(seat) {
+        return seat.getAmountAllocated(
+          'Minted',
+          this.facets.helper.debtBrand(),
+        );
+      },
+
+      assertVaultHoldsNoMinted() {
+        const { state, facets } = this;
+        const { vaultSeat } = state;
+        AmountMath.isEmpty(facets.helper.getMintedAllocated(vaultSeat)) ||
+          Fail`Vault should be empty of Minted`;
+      },
+
+      /**
+       *
+       * @param {Amount<'nat'>} collateralAmount
+       * @param {Amount<'nat'>} proposedRunDebt
+       */
+      async assertSufficientCollateral(collateralAmount, proposedRunDebt) {
+        const { state, facets } = this;
+        const maxRun = await state.manager.maxDebtFor(collateralAmount);
+        AmountMath.isGTE(maxRun, proposedRunDebt, facets.helper.debtBrand()) ||
+          Fail`Requested ${q(proposedRunDebt)} exceeds max ${q(maxRun)} for ${q(
+            collateralAmount,
+          )} collateral`;
+      },
+
+      /**
+       *
+       * @param {HolderPhase} newPhase
+       */
+      getStateSnapshot(newPhase) {
+        const { state, facets } = this;
+
+        const { debtSnapshot: debt, interestSnapshot: interest } = state;
+        /** @type {VaultNotification} */
+        return harden({
+          debtSnapshot: { debt, interest },
+          locked: facets.self.getCollateralAmount(),
+          // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
+          // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
+          vaultState: newPhase,
+        });
+      },
+
+      /**
+       * call this whenever anything changes!
+       *
+       */
+      updateUiState() {
+        const { state, facets } = this;
+        const ephemera = provideEphemera(state.idInManager);
+        const { outerUpdater } = ephemera;
+        if (!outerUpdater) {
+          // It's not an error to change to liquidating during transfer
+          return;
+        }
+        const { phase } = state;
+        const uiState = facets.helper.getStateSnapshot(phase);
+        trace('updateUiState', state.idInManager, uiState);
+
+        switch (phase) {
+          case Phase.ACTIVE:
+          case Phase.LIQUIDATING:
+          case Phase.LIQUIDATED:
+            outerUpdater.publish(uiState);
+            break;
+          case Phase.CLOSED:
+            outerUpdater.finish(uiState);
+            ephemera.outerUpdater = null;
+            break;
+          default:
+            throw Error(`unreachable vault phase: ${phase}`);
+        }
+      },
+
+      /**
+       * @param {ZCFSeat} seat
+       */
+      async closeHook(seat) {
+        const { state, facets } = this;
+
+        const { self, helper } = facets;
+        helper.assertCloseable();
+        const { phase, vaultSeat } = state;
+        const { zcf } = provideEphemera(state.idInManager);
+
+        // Held as keys for cleanup in the manager
+        const oldDebtNormalized = self.getNormalizedDebt();
+        const oldCollateral = self.getCollateralAmount();
+
+        if (phase === Phase.ACTIVE) {
+          assertProposalShape(seat, {
+            give: { Minted: null },
+          });
+
+          // you're paying off the debt, you get everything back.
+          const debt = self.getCurrentDebt();
+          const {
+            give: { Minted: given },
+          } = seat.getProposal();
+
+          // you must pay off the entire remainder but if you offer too much, we won't
+          // take more than you owe
+          AmountMath.isGTE(given, debt) ||
+            Fail`Offer ${given} is not sufficient to pay off debt ${debt}`;
+
+          // Return any overpayment
+          atomicTransfer(
+            zcf,
+            vaultSeat,
+            seat,
+            vaultSeat.getCurrentAllocation(),
+          );
+
+          state.manager.burnAndRecord(debt, seat);
+        } else if (phase === Phase.LIQUIDATED) {
+          // Simply reallocate vault assets to the offer seat.
+          // Don't take anything from the offer, even if vault is underwater.
+          // TODO verify that returning Minted here doesn't mess up debt limits
+
+          atomicTransfer(
+            zcf,
+            vaultSeat,
+            seat,
+            vaultSeat.getCurrentAllocation(),
+          );
+        } else {
+          throw new Error('only active and liquidated vaults can be closed');
+        }
+
+        seat.exit();
+        helper.assignPhase(Phase.CLOSED);
+        helper.updateDebtSnapshot(helper.emptyDebt());
+        helper.updateUiState();
+
+        helper.assertVaultHoldsNoMinted();
+        vaultSeat.exit();
+
+        state.manager.handleBalanceChange(
+          oldDebtNormalized,
+          oldCollateral,
+          state.idInManager,
+          state.phase,
+          facets.self,
+        );
+
+        return 'your loan is closed, thank you for your business';
+      },
+
+      /**
+       * Calculate the fee, the amount to mint and the resulting debt.
+       * The give and the want together reflect a delta, where typically
+       * one is zero because they come from the gave/want of an offer
+       * proposal. If the `want` is zero, the `fee` will also be zero,
+       * so the simple math works.
+       *
+       * @param {Amount<'nat'>} currentDebt
+       * @param {Amount<'nat'>} giveAmount
+       * @param {Amount<'nat'>} wantAmount
+       */
+      loanFee(currentDebt, giveAmount, wantAmount) {
+        const { state } = this;
+
+        const fee = ceilMultiplyBy(
+          wantAmount,
+          state.manager.getGovernedParams().getLoanFee(),
+        );
+        const toMint = AmountMath.add(wantAmount, fee);
+        const newDebt = addSubtract(currentDebt, toMint, giveAmount);
+        return { newDebt, toMint, fee };
+      },
+
+      /**
+       * Adjust principal and collateral (atomically for offer safety)
+       *
+       * @param {ZCFSeat} clientSeat
+       * @returns {Promise<string>} success message
+       */
+      async adjustBalancesHook(clientSeat) {
+        const { state, facets } = this;
+
+        const { self, helper } = facets;
+        const ephemera = provideEphemera(state.idInManager);
+        const { outerUpdater: updaterPre } = ephemera;
+        const { vaultSeat } = state;
+        const proposal = clientSeat.getProposal();
+        assertOnlyKeys(proposal, ['Collateral', 'Minted']);
+
+        const allEmpty = amounts => {
+          return amounts.every(a => AmountMath.isEmpty(a));
+        };
+
+        const normalizedDebtPre = self.getNormalizedDebt();
+        const collateralPre = helper.getCollateralAllocated(vaultSeat);
+
+        const giveColl = proposal.give.Collateral || helper.emptyCollateral();
+        const wantColl = proposal.want.Collateral || helper.emptyCollateral();
+
+        const newCollateralPre = addSubtract(collateralPre, giveColl, wantColl);
+        // max debt supported by current Collateral as modified by proposal
+        const maxDebtPre = await state.manager.maxDebtFor(newCollateralPre);
+        updaterPre === ephemera.outerUpdater ||
+          Fail`Transfer during vault adjustment`;
+        helper.assertActive();
+
+        // After the `await`, we retrieve the vault's allocations again,
+        // so we can compare to the debt limit based on the new values.
+        const collateral = helper.getCollateralAllocated(vaultSeat);
+        const newCollateral = addSubtract(collateral, giveColl, wantColl);
+
+        const debt = self.getCurrentDebt();
+        const giveMinted = AmountMath.min(
+          proposal.give.Minted || helper.emptyDebt(),
+          debt,
+        );
+        const wantMinted = proposal.want.Minted || helper.emptyDebt();
+        if (allEmpty([giveColl, giveMinted, wantColl, wantMinted])) {
+          clientSeat.exit();
+          return 'no transaction, as requested';
+        }
+
+        // Calculate the fee, the amount to mint and the resulting debt. We'll
+        // verify that the target debt doesn't violate the collateralization ratio,
+        // then mint, reallocate, and burn.
+        const { newDebt, fee, toMint } = helper.loanFee(
+          debt,
+          giveMinted,
+          wantMinted,
+        );
+
+        trace('adjustBalancesHook', state.idInManager, {
+          newCollateralPre,
+          newCollateral,
+          fee,
+          toMint,
+          newDebt,
+        });
+
+        if (
+          checkRestart(newCollateralPre, maxDebtPre, newCollateral, newDebt)
+        ) {
+          return helper.adjustBalancesHook(clientSeat);
+        }
+
+        stageDelta(clientSeat, vaultSeat, giveColl, wantColl, 'Collateral');
+        // `wantMinted` is allocated in the reallocate and mint operation, and so not here
+        stageDelta(
+          clientSeat,
+          vaultSeat,
+          giveMinted,
+          helper.emptyDebt(),
+          'Minted',
+        );
+
+        /** @type {Array<ZCFSeat>} */
+        const vaultSeatOpt = allEmpty([giveColl, giveMinted, wantColl])
+          ? []
+          : [vaultSeat];
+        state.manager.mintAndReallocate(
+          toMint,
+          fee,
+          clientSeat,
+          ...vaultSeatOpt,
+        );
+
+        // parent needs to know about the change in debt
+        helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebt);
+        state.manager.burnAndRecord(giveMinted, vaultSeat);
+        helper.assertVaultHoldsNoMinted();
+
+        helper.updateUiState();
+        clientSeat.exit();
+        return 'We have adjusted your balances, thank you for your business';
+      },
+
+      /**
+       *
+       * @param {ZCFSeat} seat
+       * @returns {VaultKit}
+       */
+      makeTransferInvitationHook(seat) {
+        const { state, facets } = this;
+
+        const { self, helper } = facets;
+        helper.assertCloseable();
+        seat.exit();
+
+        const ephemera = provideEphemera(state.idInManager);
+
+        // eslint-disable-next-line no-use-before-define
+        const vaultKit = makeVaultKit(
+          self,
+          ephemera.storageNode,
+          ephemera.marshaller,
+          state.manager.getAssetSubscriber(),
+        );
+        ephemera.outerUpdater = vaultKit.vaultUpdater;
+        helper.updateUiState();
+
+        return vaultKit;
+      },
+    },
+    self: {
+      /**
+       */
+      getVaultSeat() {
+        return this.state.vaultSeat;
+      },
+
+      /**
+       * @param {ZCFSeat} seat
+       * @param {ERef<StorageNode>} storageNode
+       */
+      async initVaultKit(seat, storageNode) {
+        const { state, facets } = this;
+
+        const ephemera = provideEphemera(state.idInManager);
+
+        const { self, helper } = facets;
+
+        const normalizedDebtPre = self.getNormalizedDebt();
+        const actualDebtPre = self.getCurrentDebt();
+        (AmountMath.isEmpty(normalizedDebtPre) &&
+          AmountMath.isEmpty(actualDebtPre)) ||
+          Fail`vault must be empty initially`;
+
+        const collateralPre = self.getCollateralAmount();
+        trace('initVaultKit start: collateral', state.idInManager, {
+          actualDebtPre,
+          collateralPre,
+        });
+
+        // get the payout to provide access to the collateral if the
+        // contract abandons
+        const {
+          give: { Collateral: giveCollateral },
+          want: { Minted: wantMinted },
+        } = seat.getProposal();
+
+        const {
+          newDebt: newDebtPre,
+          fee,
+          toMint,
+        } = helper.loanFee(actualDebtPre, helper.emptyDebt(), wantMinted);
+        !AmountMath.isEmpty(fee) ||
+          Fail`loan requested (${wantMinted}) is too small; cannot accrue interest`;
+        AmountMath.isEqual(newDebtPre, toMint) || Fail`fee mismatch for vault`;
+        trace(
+          'initVault',
+          state.idInManager,
+          { wantedRun: wantMinted, fee },
+          self.getCollateralAmount(),
+        );
+
+        await helper.assertSufficientCollateral(giveCollateral, newDebtPre);
+
+        const { vaultSeat } = state;
+        vaultSeat.incrementBy(
+          seat.decrementBy(harden({ Collateral: giveCollateral })),
+        );
+        state.manager.mintAndReallocate(toMint, fee, seat, vaultSeat);
+        helper.updateDebtAccounting(
+          normalizedDebtPre,
+          collateralPre,
+          newDebtPre,
+        );
+
+        const vaultKit = makeVaultKit(
+          self,
+          storageNode,
+          ephemera.marshaller,
+          state.manager.getAssetSubscriber(),
+        );
+        ephemera.outerUpdater = vaultKit.vaultUpdater;
+        helper.updateUiState();
+        return vaultKit;
+      },
+
+      /**
+       * Called by manager at start of liquidation.
+       *
+       */
+      liquidating() {
+        const { facets } = this;
+
+        const { helper } = facets;
+        helper.assignPhase(Phase.LIQUIDATING);
+        helper.updateUiState();
+      },
+
+      /**
+       * Called by manager at end of liquidation, at which point all debts have been
+       * covered.
+       *
+       */
+      liquidated() {
+        const { facets } = this;
+
+        const { helper } = facets;
+        helper.updateDebtSnapshot(
+          // liquidated vaults retain no debt
+          AmountMath.makeEmpty(helper.debtBrand()),
+        );
+
+        helper.assignPhase(Phase.LIQUIDATED);
+        helper.updateUiState();
+      },
+
+      /**
+       */
+      makeAdjustBalancesInvitation() {
+        const { state, facets } = this;
+        const { helper } = facets;
+        helper.assertActive();
+        const { zcf } = provideEphemera(state.idInManager);
+        return zcf.makeInvitation(
+          seat => helper.adjustBalancesHook(seat),
+          'AdjustBalances',
+        );
+      },
+
+      /**
+       */
+      makeCloseInvitation() {
+        const { state, facets } = this;
+        const { helper } = facets;
+        helper.assertCloseable();
+        const { zcf } = provideEphemera(state.idInManager);
+        return zcf.makeInvitation(seat => helper.closeHook(seat), 'CloseVault');
+      },
+
+      /**
+       * @returns {Promise<Invitation>}
+       */
+      makeTransferInvitation() {
+        const { state, facets } = this;
+        const ephemera = provideEphemera(state.idInManager);
+        const { outerUpdater } = ephemera;
+        const { self, helper } = facets;
+        // Bring the debt snapshot current for the final report before transfer
+        helper.updateDebtSnapshot(self.getCurrentDebt());
+        const { debtSnapshot: debt, interestSnapshot: interest, phase } = state;
+        if (outerUpdater) {
+          outerUpdater.finish(helper.getStateSnapshot(Phase.TRANSFER));
+          ephemera.outerUpdater = null;
+        }
+        const transferState = {
+          debtSnapshot: { debt, interest },
+          locked: self.getCollateralAmount(),
+          vaultState: phase,
+        };
+        const { zcf } = provideEphemera(state.idInManager);
+        return zcf.makeInvitation(
+          seat => helper.makeTransferInvitationHook(seat),
+          'TransferVault',
+          transferState,
+        );
+      },
+
+      // for status/debugging
+
+      /**
+       *
+       * @returns {Amount<'nat'>}
+       */
+      getCollateralAmount() {
+        const { state, facets } = this;
+        const { vaultSeat } = state;
+        const { helper } = facets;
+        // getCollateralAllocated would return final allocations
+        return vaultSeat.hasExited()
+          ? helper.emptyCollateral()
+          : helper.getCollateralAllocated(vaultSeat);
+      },
+
+      /**
+       * The actual current debt, including accrued interest.
+       *
+       * This looks like a simple getter but it does a lot of the heavy lifting for
+       * interest accrual. Rather than updating all records when interest accrues,
+       * the vault manager updates just its rolling compounded interest. Here we
+       * calculate what the current debt is given what's recorded in this vault and
+       * what interest has compounded since this vault record was written.
+       *
+       * @see getNormalizedDebt
+       *
+       * @returns {Amount<'nat'>}
+       */
+      getCurrentDebt() {
+        const { state } = this;
+        return calculateCurrentDebt(
+          state.debtSnapshot,
+          state.interestSnapshot,
+          state.manager.getCompoundedInterest(),
+        );
+      },
+
+      /**
+       * The normalization puts all debts on a common time-independent scale since
+       * the launch of this vault manager. This allows the manager to order vaults
+       * by their debt-to-collateral ratios without having to mutate the debts as
+       * the interest accrues.
+       *
+       * @see getActualDebAmount
+       *
+       * @returns {import('./storeUtils.js').NormalizedDebt} as if the vault was open at the launch of this manager, before any interest accrued
+       */
+      getNormalizedDebt() {
+        const { state } = this;
+        // @ts-expect-error cast
+        return reverseInterest(state.debtSnapshot, state.interestSnapshot);
+      },
+    },
+  },
 );
 
 /**

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -427,7 +427,6 @@ const machineBehavior = {
     facets.machine.updateMetrics();
     return vm;
   },
-  getCollaterals,
   /** @param {MethodContext} context */
   makeCollectFeesInvitation: ({ state }) => {
     const { debtMint, zcf } = ephemera;
@@ -489,13 +488,13 @@ const publicBehavior = {
     /** @type {VaultManager} */
     return collateralTypes.get(brandIn).getPublicFacet();
   },
+  getCollaterals,
   getMetrics: () => ephemera.metricsSubscription,
 
   /** @deprecated use getCollateralManager and then makeVaultInvitation instead */
   makeLoanInvitation: makeVaultInvitation,
   /** @deprecated use getCollateralManager and then makeVaultInvitation instead */
   makeVaultInvitation,
-  getCollaterals,
   getRunIssuer: () => ephemera.debtMint.getIssuerRecord().issuer,
   /**
    * subscription for the paramManager for a particular vaultManager

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -533,7 +533,6 @@ const makeVaultDirector = defineDurableFarClassKit(
        * @deprecated use getCollateralManager and then makeVaultInvitation instead
        *
        * Make a vault in the vaultManager based on the collateral type.
-       *
        */
       makeVaultInvitation() {
         const { zcf } = ephemera;

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -825,11 +825,7 @@ const selfBehavior = {
     try {
       // TODO `await` is allowed until the above ordering is fixed
       // eslint-disable-next-line @jessie.js/no-nested-await
-      const vaultKit = await vault.initVaultKit(
-        seat,
-        vaultStorageNode,
-        marshaller,
-      );
+      const vaultKit = await vault.initVaultKit(seat, vaultStorageNode);
       // initVaultKit calls back to handleBalanceChange() which will add the
       // vault to prioritizedVaults
       seat.exit();

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -548,8 +548,6 @@ const makeVaultManagerKit = defineDurableFarClassKit(
         trace('update quote', state.collateralBrand, highestDebtRatio);
       },
 
-      /**
-       */
       async processLiquidations() {
         const { state, facets } = this;
         const { prioritizedVaults, ...ephemera } = provideEphemera(
@@ -790,7 +788,6 @@ const makeVaultManagerKit = defineDurableFarClassKit(
       },
       /**
        * coefficient on existing debt to calculate new debt
-       *
        */
       getCompoundedInterest() {
         return this.state.compoundedInterest;
@@ -873,7 +870,6 @@ const makeVaultManagerKit = defineDurableFarClassKit(
       /**
        * In extreme situations, system health may require liquidating all vaults.
        * This starts the liquidations all in parallel.
-       *
        */
       async liquidateAll() {
         const {

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -274,654 +274,6 @@ const initState = (
   return state;
 };
 
-// Some of these could go in closures but are kept on a facet anticipating future durability options.
-const helperBehavior = {
-  /**
-   * @param {Timestamp} updateTime
-   * @param {ZCFSeat} poolIncrementSeat
-   */
-  async chargeAllVaults(updateTime, poolIncrementSeat) {
-    const { state, facets } = this;
-    trace('chargeAllVaults', state.collateralBrand, {
-      updateTime,
-    });
-    const { factoryPowers } = provideEphemera(state.collateralBrand);
-    assert(factoryPowers);
-
-    const interestRate = factoryPowers.getGovernedParams().getInterestRate();
-
-    // Update state with the results of charging interest
-
-    const changes = chargeInterest(
-      {
-        mint: state.debtMint,
-        mintAndReallocateWithFee: factoryPowers.mintAndReallocate,
-        poolIncrementSeat,
-        seatAllocationKeyword: 'Minted',
-      },
-      {
-        interestRate,
-        chargingPeriod: factoryPowers.getGovernedParams().getChargingPeriod(),
-        recordingPeriod: factoryPowers.getGovernedParams().getRecordingPeriod(),
-      },
-      {
-        latestInterestUpdate: state.latestInterestUpdate,
-        compoundedInterest: state.compoundedInterest,
-        totalDebt: state.totalDebt,
-      },
-      updateTime,
-    );
-
-    state.compoundedInterest = changes.compoundedInterest;
-    state.latestInterestUpdate = changes.latestInterestUpdate;
-    state.totalDebt = changes.totalDebt;
-
-    facets.helper.assetNotify();
-    trace('chargeAllVaults complete', state.collateralBrand);
-    // price to check against has changed
-    return facets.helper.reschedulePriceCheck();
-  },
-
-  assetNotify() {
-    const { state } = this;
-    const ephemera = provideEphemera(state.collateralBrand);
-    assert(ephemera.factoryPowers && ephemera.assetPublisher);
-    const interestRate = ephemera.factoryPowers
-      .getGovernedParams()
-      .getInterestRate();
-    /** @type {AssetState} */
-    const payload = harden({
-      compoundedInterest: state.compoundedInterest,
-      interestRate,
-      latestInterestUpdate: state.latestInterestUpdate,
-      // NB: the liquidator is determined by governance but the resulting
-      // instance is a concern of the manager. The param manager knows only
-      // about the installation and terms of the liqudation contract. We could
-      // have another notifier for state downstream of governance changes, but
-      // that doesn't seem to be cost-effective.
-      liquidatorInstance: state.liquidatorInstance,
-    });
-    ephemera.assetPublisher.publish(payload);
-  },
-
-  updateMetrics() {
-    const { state } = this;
-    const { metricsPublication, prioritizedVaults } = provideEphemera(
-      state.collateralBrand,
-    );
-    assert(metricsPublication && prioritizedVaults);
-
-    const retainedCollateral =
-      state.retainedCollateralSeat.getCurrentAllocation()?.Collateral ??
-      AmountMath.makeEmpty(state.collateralBrand, 'nat');
-    /** @type {MetricsNotification} */
-    const payload = harden({
-      numActiveVaults: prioritizedVaults.getCount(),
-      numLiquidatingVaults: state.liquidatingVaults.getSize(),
-      totalCollateral: state.totalCollateral,
-      totalDebt: state.totalDebt,
-      retainedCollateral,
-
-      numLiquidationsCompleted: state.numLiquidationsCompleted,
-      totalCollateralSold: state.totalCollateralSold,
-      totalOverageReceived: state.totalOverageReceived,
-      totalProceedsReceived: state.totalProceedsReceived,
-      totalShortfallReceived: state.totalShortfallReceived,
-    });
-    metricsPublication.updateState(payload);
-  },
-
-  /**
-   * When any Vault's debt ratio is higher than the current high-water level,
-   * call `reschedulePriceCheck()` to request a fresh notification from the
-   * priceAuthority. There will be extra outstanding requests since we can't
-   * cancel them. (https://github.com/Agoric/agoric-sdk/issues/2713).
-   *
-   * When the vault with the current highest debt ratio is removed or reduces
-   * its ratio, we won't reschedule the priceAuthority requests to reduce churn.
-   * Instead, when a priceQuote is received, we'll only reschedule if the
-   * high-water level when the request was made matches the current high-water
-   * level.
-   *
-   * @param {Ratio} [highestRatio]
-   * @returns {Promise<void>}
-   */
-  async reschedulePriceCheck(highestRatio) {
-    const { state, facets } = this;
-    const { prioritizedVaults, ...ephemera } = provideEphemera(
-      state.collateralBrand,
-    );
-    assert(ephemera.factoryPowers && prioritizedVaults);
-    trace('reschedulePriceCheck', state.collateralBrand, ephemera);
-    // INTERLOCK: the first time through, start the activity to wait for
-    // and process liquidations over time.
-    if (!ephemera.liquidationQueueing) {
-      ephemera.liquidationQueueing = true;
-      // eslint-disable-next-line consistent-return
-      return facets.helper
-        .processLiquidations()
-        .catch(e => console.error('Liquidator failed', e))
-        .finally(() => {
-          ephemera.liquidationQueueing = false;
-        });
-    }
-
-    if (!ephemera.outstandingQuote) {
-      // the new threshold will be picked up by the next quote request
-      return;
-    }
-
-    const highestDebtRatio = highestRatio || prioritizedVaults.highestRatio();
-    if (!highestDebtRatio) {
-      // if there aren't any open vaults, we don't need an outstanding RFQ.
-      trace('no open vaults');
-      return;
-    }
-
-    // There is already an activity processing liquidations. It may be
-    // waiting for the oracle price to cross a threshold.
-    // Update the current in-progress quote.
-    const govParams = ephemera.factoryPowers.getGovernedParams();
-    const liquidationMargin = govParams.getLiquidationMargin();
-    // Safe to call extraneously (lightweight and idempotent)
-    updateQuote(ephemera.outstandingQuote, highestDebtRatio, liquidationMargin);
-    trace('update quote', state.collateralBrand, highestDebtRatio);
-  },
-
-  /**
-   */
-  async processLiquidations() {
-    const { state, facets } = this;
-    const { prioritizedVaults, ...ephemera } = provideEphemera(
-      state.collateralBrand,
-    );
-    assert(ephemera.factoryPowers && ephemera.priceAuthority);
-    const { priceAuthority } = ephemera;
-    const govParams = ephemera.factoryPowers.getGovernedParams();
-
-    async function* eventualLiquidations() {
-      assert(prioritizedVaults);
-      while (true) {
-        const highestDebtRatio = prioritizedVaults.highestRatio();
-        if (!highestDebtRatio) {
-          return;
-        }
-        const liquidationMargin = govParams.getLiquidationMargin();
-
-        // ask to be alerted when the price level falls enough that the vault
-        // with the highest debt to collateral ratio will no longer be valued at the
-        // liquidationMargin above its debt.
-        ephemera.outstandingQuote = makeQuote(
-          priceAuthority,
-          highestDebtRatio,
-          liquidationMargin,
-        );
-        trace('posted quote request', state.collateralBrand, highestDebtRatio);
-
-        // The rest of this method will not happen until after a quote is received.
-        // This may not happen until much later, when the market changes.
-        // eslint-disable-next-line no-await-in-loop
-        const quote = await E(ephemera.outstandingQuote).getPromise();
-        ephemera.outstandingQuote = null;
-        // When we receive a quote, we check whether the vault with the highest
-        // ratio of debt to collateral is below the liquidationMargin, and if so,
-        // we liquidate it. We use ceilDivide to round up because ratios above
-        // this will be liquidated.
-        const quoteRatioPlusMargin = makeRatioFromAmounts(
-          ceilDivideBy(getAmountOut(quote), liquidationMargin),
-          getAmountIn(quote),
-        );
-        trace('quote', state.collateralBrand, quote, quoteRatioPlusMargin);
-
-        // Liquidate the head of the queue
-        const [next] =
-          prioritizedVaults.entriesPrioritizedGTE(quoteRatioPlusMargin);
-        if (next) {
-          yield next;
-        }
-      }
-    }
-    for await (const next of eventualLiquidations()) {
-      await facets.helper.liquidateAndRemove(next);
-      trace('price check liq', state.collateralBrand, next && next[0]);
-    }
-  },
-
-  /**
-   * @param {[key: string, vaultKit: Vault]} record
-   */
-  liquidateAndRemove([key, vault]) {
-    const { state, facets } = this;
-    const { factoryPowers, prioritizedVaults, zcf } = provideEphemera(
-      state.collateralBrand,
-    );
-    assert(factoryPowers && prioritizedVaults && zcf);
-    const vaultSeat = vault.getVaultSeat();
-    trace('liquidating', state.collateralBrand, vaultSeat.getProposal());
-
-    const collateralPre = vault.getCollateralAmount();
-
-    // Start liquidation (vaultState: LIQUIDATING)
-    const liquidator = state.liquidator;
-    assert(liquidator);
-    state.liquidatingVaults.add(vault);
-    prioritizedVaults.removeVault(key);
-
-    return liquidate(
-      zcf,
-      vault,
-      liquidator,
-      state.collateralBrand,
-      factoryPowers.getGovernedParams().getLiquidationPenalty(),
-    )
-      .then(accounting => {
-        facets.manager.burnAndRecord(accounting.toBurn, vaultSeat);
-
-        // current values
-
-        // Sometimes, the AMM will sell less than all the collateral. If there
-        // was a shortfall, the investor doesn't keep the change, so we get it.
-        // If there was no shortfall, the collateral is returned.
-        const collateralPost = vault.getCollateralAmount();
-        if (
-          !AmountMath.isEmpty(collateralPost) &&
-          !AmountMath.isEmpty(accounting.shortfall)
-        ) {
-          // The borrower doesn't get the excess collateral remaining when
-          // liquidation results in a shortfall. We currently do nothing with
-          // it. We could hold it until it crosses some threshold, then sell it
-          // to the AMM, or we could transfer it to the reserve. At least it's
-          // visible in the accounting.
-          atomicTransfer(zcf, vaultSeat, state.retainedCollateralSeat, {
-            Collateral: collateralPost,
-          });
-        }
-
-        // Reduce totalCollateral by collateralPre, since all the collateral was
-        // sold, returned to the vault owner, or held by the VaultManager.
-        state.totalCollateral = AmountMath.subtract(
-          state.totalCollateral,
-          collateralPre,
-        );
-        state.totalDebt = AmountMath.subtract(
-          state.totalDebt,
-          accounting.shortfall,
-        );
-
-        // cumulative values
-        state.totalProceedsReceived = AmountMath.add(
-          state.totalProceedsReceived,
-          accounting.proceeds,
-        );
-        state.totalOverageReceived = AmountMath.add(
-          state.totalOverageReceived,
-          accounting.overage,
-        );
-        state.totalShortfallReceived = AmountMath.add(
-          state.totalShortfallReceived,
-          accounting.shortfall,
-        );
-        state.liquidatingVaults.delete(vault);
-        trace('liquidated', state.collateralBrand);
-        state.numLiquidationsCompleted += 1;
-        facets.helper.updateMetrics();
-
-        if (!AmountMath.isEmpty(accounting.shortfall)) {
-          E(factoryPowers.getShortfallReporter())
-            .increaseLiquidationShortfall(accounting.shortfall)
-            .catch(reason =>
-              console.error(
-                'liquidateAndRemove failed to increaseLiquidationShortfall',
-                reason,
-              ),
-            );
-        }
-      })
-      .catch(e => {
-        // XXX should notify interested parties
-        console.error('liquidateAndRemove failed with', e);
-        throw e;
-      });
-  },
-};
-
-const managerBehavior = {
-  getGovernedParams() {
-    const { state } = this;
-    const ephemera = provideEphemera(state.collateralBrand);
-    assert(ephemera.factoryPowers);
-    return ephemera.factoryPowers.getGovernedParams();
-  },
-
-  /**
-   * @param {Amount<'nat'>} collateralAmount
-   */
-  async maxDebtFor(collateralAmount) {
-    const { state } = this;
-    const { debtBrand } = state;
-    const { priceAuthority, ...ephemera } = provideEphemera(
-      state.collateralBrand,
-    );
-    assert(ephemera.factoryPowers && priceAuthority);
-    const quoteAmount = await E(priceAuthority).quoteGiven(
-      collateralAmount,
-      debtBrand,
-    );
-    // floorDivide because we want the debt ceiling lower
-    return floorDivideBy(
-      getAmountOut(quoteAmount),
-      ephemera.factoryPowers.getGovernedParams().getLiquidationMargin(),
-    );
-  },
-  /**
-   * TODO utility method to turn a callback into non-actual one
-   * was type {MintAndReallocate}
-   *
-   * @param {Amount<'nat'>} toMint
-   * @param {Amount<'nat'>} fee
-   * @param {ZCFSeat} seat
-   * @param {...ZCFSeat} otherSeats
-   * @returns {void}
-   */
-  mintAndReallocate(toMint, fee, seat, ...otherSeats) {
-    const { state } = this;
-    const { totalDebt } = state;
-    const { factoryPowers } = provideEphemera(state.collateralBrand);
-    assert(factoryPowers);
-
-    checkDebtLimit(
-      factoryPowers.getGovernedParams().getDebtLimit(),
-      totalDebt,
-      toMint,
-    );
-    factoryPowers.mintAndReallocate(toMint, fee, seat, ...otherSeats);
-    state.totalDebt = AmountMath.add(state.totalDebt, toMint);
-  },
-  /**
-   * @param {Amount<'nat'>} toBurn
-   * @param {ZCFSeat} seat
-   */
-  burnAndRecord(toBurn, seat) {
-    const { state } = this;
-    const { factoryPowers } = provideEphemera(state.collateralBrand);
-    assert(factoryPowers);
-    trace('burnAndRecord', state.collateralBrand, {
-      toBurn,
-      totalDebt: state.totalDebt,
-    });
-    const { burnDebt } = factoryPowers;
-    burnDebt(toBurn, seat);
-    state.totalDebt = AmountMath.subtract(state.totalDebt, toBurn);
-  },
-  getAssetSubscriber() {
-    const { state } = this;
-    const { assetSubscriber } = provideEphemera(state.collateralBrand);
-    assert(assetSubscriber);
-    return assetSubscriber;
-  },
-  getCollateralBrand() {
-    return this.state.collateralBrand;
-  },
-  getDebtBrand() {
-    return this.state.debtBrand;
-  },
-  /**
-   * coefficient on existing debt to calculate new debt
-   *
-   */
-  getCompoundedInterest() {
-    return this.state.compoundedInterest;
-  },
-  /**
-   * Called by a vault when its balances change.
-   *
-   * @param {NormalizedDebt} oldDebtNormalized
-   * @param {Amount<'nat'>} oldCollateral
-   * @param {VaultId} vaultId
-   * @param {import('./vault.js').VaultPhase} vaultPhase at the end of whatever change updated balances
-   * @param {Vault} vault
-   */
-  handleBalanceChange(
-    oldDebtNormalized,
-    oldCollateral,
-    vaultId,
-    vaultPhase,
-    vault,
-  ) {
-    const { state, facets } = this;
-    const { prioritizedVaults } = provideEphemera(state.collateralBrand);
-    assert(prioritizedVaults);
-
-    // the manager holds only vaults that can accrue interest or be liquidated;
-    // i.e. vaults that have debt. The one exception is at the outset when
-    // a vault has been added to the manager but not yet accounted for.
-    const settled =
-      AmountMath.isEmpty(oldDebtNormalized) && vaultPhase !== Phase.ACTIVE;
-
-    if (settled) {
-      assert(
-        !prioritizedVaults.hasVaultByAttributes(
-          oldDebtNormalized,
-          oldCollateral,
-          vaultId,
-        ),
-        'Settled vaults must not be retained in storage',
-      );
-    } else {
-      const isNew = AmountMath.isEmpty(oldDebtNormalized);
-      if (!isNew) {
-        // its position in the queue is no longer valid
-
-        const vaultInStore = prioritizedVaults.removeVaultByAttributes(
-          oldDebtNormalized,
-          oldCollateral,
-          vaultId,
-        );
-        assert(
-          vault === vaultInStore,
-          'handleBalanceChange for two different vaults',
-        );
-      }
-
-      // replace in queue, but only if it can accrue interest or be liquidated (i.e. has debt).
-      // getCurrentDebt() would also work (0x = 0) but require more computation.
-      if (!AmountMath.isEmpty(vault.getNormalizedDebt())) {
-        prioritizedVaults.addVault(vaultId, vault);
-      }
-
-      // totalCollateral += vault's collateral delta (post — pre)
-      state.totalCollateral = AmountMath.subtract(
-        AmountMath.add(state.totalCollateral, vault.getCollateralAmount()),
-        oldCollateral,
-      );
-      // debt accounting managed through minting and burning
-      facets.helper.updateMetrics();
-    }
-  },
-};
-
-const collateralBehavior = {
-  makeVaultInvitation() {
-    const { zcf } = provideEphemera(this.state.collateralBrand);
-    assert(zcf);
-    return zcf.makeInvitation(
-      seat => this.facets.self.makeVaultKit(seat),
-      'MakeVault',
-    );
-  },
-  getSubscriber() {
-    const { state } = this;
-    const { assetSubscriber } = provideEphemera(state.collateralBrand);
-    assert(assetSubscriber);
-    return assetSubscriber;
-  },
-  getMetrics() {
-    const { state } = this;
-    const { metricsSubscription } = provideEphemera(state.collateralBrand);
-    assert(metricsSubscription);
-    return metricsSubscription;
-  },
-  getCompoundedInterest() {
-    return this.state.compoundedInterest;
-  },
-};
-
-const selfBehavior = {
-  getGovernedParams() {
-    const { state } = this;
-    const { factoryPowers } = provideEphemera(state.collateralBrand);
-    assert(factoryPowers);
-    return factoryPowers.getGovernedParams();
-  },
-
-  /**
-   * In extreme situations, system health may require liquidating all vaults.
-   * This starts the liquidations all in parallel.
-   *
-   */
-  async liquidateAll() {
-    const {
-      state,
-      facets: { helper },
-    } = this;
-    const { prioritizedVaults } = provideEphemera(state.collateralBrand);
-    assert(prioritizedVaults);
-    const toLiquidate = Array.from(prioritizedVaults.entries()).map(entry =>
-      helper.liquidateAndRemove(entry),
-    );
-    await Promise.all(toLiquidate);
-  },
-
-  /**
-   * @param {ZCFSeat} seat
-   */
-  async makeVaultKit(seat) {
-    const {
-      state,
-      facets: { manager },
-    } = this;
-    const { marshaller, prioritizedVaults, storageNode, zcf } = provideEphemera(
-      state.collateralBrand,
-    );
-    assert(marshaller, 'makeVaultKit missing marshaller');
-    assert(prioritizedVaults, 'makeVaultKit missing prioritizedVaults');
-    assert(storageNode, 'makeVaultKit missing storageNode');
-    assert(zcf, 'makeVaultKit missing zcf');
-    assertProposalShape(seat, {
-      give: { Collateral: null },
-      want: { Minted: null },
-    });
-
-    state.vaultCounter += 1;
-    const vaultId = String(state.vaultCounter);
-
-    const vaultStorageNode = E(
-      E(storageNode).makeChildNode(`vaults`),
-    ).makeChildNode(`vault${vaultId}`);
-
-    const vault = makeVault(
-      zcf,
-      manager,
-      vaultId,
-      vaultStorageNode,
-      marshaller,
-    );
-
-    try {
-      // TODO `await` is allowed until the above ordering is fixed
-      // eslint-disable-next-line @jessie.js/no-nested-await
-      const vaultKit = await vault.initVaultKit(seat, vaultStorageNode);
-      // initVaultKit calls back to handleBalanceChange() which will add the
-      // vault to prioritizedVaults
-      seat.exit();
-      return vaultKit;
-    } catch (err) {
-      // ??? do we still need this cleanup? it won't get into the store unless it has collateral,
-      // which should qualify it to be in the store. If we drop this catch then the nested await
-      // for `vault.initVaultKit()` goes away.
-
-      // remove it from the store if it got in
-      /** @type {NormalizedDebt} */
-      // @ts-expect-error cast
-      const normalizedDebt = AmountMath.makeEmpty(state.debtBrand);
-      const collateralPre = seat.getCurrentAllocation().Collateral;
-      try {
-        prioritizedVaults.removeVaultByAttributes(
-          normalizedDebt,
-          collateralPre,
-          vaultId,
-        );
-        console.error('removed vault', vaultId, 'after initVaultKit failure');
-      } catch {
-        console.error(
-          'vault',
-          vaultId,
-          'never stored during initVaultKit failure',
-        );
-      }
-      throw err;
-    }
-  },
-
-  /**
-   *
-   * @param {Installation} liquidationInstall
-   * @param {object} liquidationTerms
-   */
-  async setupLiquidator(liquidationInstall, liquidationTerms) {
-    const { state, facets } = this;
-    const { zcf } = provideEphemera(state.collateralBrand);
-    assert(zcf);
-    const { debtBrand, collateralBrand } = state;
-    const { ammPublicFacet, priceAuthority, reservePublicFacet, timerService } =
-      zcf.getTerms();
-    const zoe = zcf.getZoeService();
-    const collateralIssuer = zcf.getIssuerForBrand(collateralBrand);
-    const debtIssuer = zcf.getIssuerForBrand(debtBrand);
-    trace('setup liquidator', state.collateralBrand, {
-      debtBrand,
-      debtIssuer,
-      collateralBrand,
-      liquidationTerms,
-    });
-    const { creatorFacet, instance } = await E(zoe).startInstance(
-      liquidationInstall,
-      harden({ Minted: debtIssuer, Collateral: collateralIssuer }),
-      harden({
-        ...liquidationTerms,
-        amm: ammPublicFacet,
-        debtBrand,
-        reservePublicFacet,
-        priceAuthority,
-        timerService,
-      }),
-    );
-    trace('setup liquidator complete', state.collateralBrand, {
-      instance,
-      old: state.liquidatorInstance,
-      equal: state.liquidatorInstance === instance,
-    });
-    state.liquidatorInstance = instance;
-    state.liquidator = creatorFacet;
-    facets.helper.assetNotify();
-  },
-
-  async getCollateralQuote() {
-    const { state } = this;
-    const { priceAuthority } = provideEphemera(state.collateralBrand);
-    assert(priceAuthority);
-
-    const { debtBrand } = state;
-    // get a quote for one unit of the collateral
-    const collateralUnit = await unitAmount(state.collateralBrand);
-    return E(priceAuthority).quoteGiven(collateralUnit, debtBrand);
-  },
-
-  getPublicFacet() {
-    return this.facets.collateral;
-  },
-};
-
 // XXX type error when destructuring params
 const finish = context => {
   const {
@@ -1005,10 +357,673 @@ const makeVaultManagerKit = defineDurableFarClassKit(
   },
   initState,
   {
-    collateral: collateralBehavior,
-    helper: helperBehavior,
-    manager: managerBehavior,
-    self: selfBehavior,
+    collateral: {
+      makeVaultInvitation() {
+        const { zcf } = provideEphemera(this.state.collateralBrand);
+        assert(zcf);
+        return zcf.makeInvitation(
+          seat => this.facets.self.makeVaultKit(seat),
+          'MakeVault',
+        );
+      },
+      getSubscriber() {
+        const { state } = this;
+        const { assetSubscriber } = provideEphemera(state.collateralBrand);
+        assert(assetSubscriber);
+        return assetSubscriber;
+      },
+      getMetrics() {
+        const { state } = this;
+        const { metricsSubscription } = provideEphemera(state.collateralBrand);
+        assert(metricsSubscription);
+        return metricsSubscription;
+      },
+      getCompoundedInterest() {
+        return this.state.compoundedInterest;
+      },
+    },
+
+    // Some of these could go in closures but are kept on a facet anticipating future durability options.
+    helper: {
+      /**
+       * @param {Timestamp} updateTime
+       * @param {ZCFSeat} poolIncrementSeat
+       */
+      async chargeAllVaults(updateTime, poolIncrementSeat) {
+        const { state, facets } = this;
+        trace('chargeAllVaults', state.collateralBrand, {
+          updateTime,
+        });
+        const { factoryPowers } = provideEphemera(state.collateralBrand);
+        assert(factoryPowers);
+
+        const interestRate = factoryPowers
+          .getGovernedParams()
+          .getInterestRate();
+
+        // Update state with the results of charging interest
+
+        const changes = chargeInterest(
+          {
+            mint: state.debtMint,
+            mintAndReallocateWithFee: factoryPowers.mintAndReallocate,
+            poolIncrementSeat,
+            seatAllocationKeyword: 'Minted',
+          },
+          {
+            interestRate,
+            chargingPeriod: factoryPowers
+              .getGovernedParams()
+              .getChargingPeriod(),
+            recordingPeriod: factoryPowers
+              .getGovernedParams()
+              .getRecordingPeriod(),
+          },
+          {
+            latestInterestUpdate: state.latestInterestUpdate,
+            compoundedInterest: state.compoundedInterest,
+            totalDebt: state.totalDebt,
+          },
+          updateTime,
+        );
+
+        state.compoundedInterest = changes.compoundedInterest;
+        state.latestInterestUpdate = changes.latestInterestUpdate;
+        state.totalDebt = changes.totalDebt;
+
+        facets.helper.assetNotify();
+        trace('chargeAllVaults complete', state.collateralBrand);
+        // price to check against has changed
+        return facets.helper.reschedulePriceCheck();
+      },
+
+      assetNotify() {
+        const { state } = this;
+        const ephemera = provideEphemera(state.collateralBrand);
+        assert(ephemera.factoryPowers && ephemera.assetPublisher);
+        const interestRate = ephemera.factoryPowers
+          .getGovernedParams()
+          .getInterestRate();
+        /** @type {AssetState} */
+        const payload = harden({
+          compoundedInterest: state.compoundedInterest,
+          interestRate,
+          latestInterestUpdate: state.latestInterestUpdate,
+          // NB: the liquidator is determined by governance but the resulting
+          // instance is a concern of the manager. The param manager knows only
+          // about the installation and terms of the liqudation contract. We could
+          // have another notifier for state downstream of governance changes, but
+          // that doesn't seem to be cost-effective.
+          liquidatorInstance: state.liquidatorInstance,
+        });
+        ephemera.assetPublisher.publish(payload);
+      },
+
+      updateMetrics() {
+        const { state } = this;
+        const { metricsPublication, prioritizedVaults } = provideEphemera(
+          state.collateralBrand,
+        );
+        assert(metricsPublication && prioritizedVaults);
+
+        const retainedCollateral =
+          state.retainedCollateralSeat.getCurrentAllocation()?.Collateral ??
+          AmountMath.makeEmpty(state.collateralBrand, 'nat');
+        /** @type {MetricsNotification} */
+        const payload = harden({
+          numActiveVaults: prioritizedVaults.getCount(),
+          numLiquidatingVaults: state.liquidatingVaults.getSize(),
+          totalCollateral: state.totalCollateral,
+          totalDebt: state.totalDebt,
+          retainedCollateral,
+
+          numLiquidationsCompleted: state.numLiquidationsCompleted,
+          totalCollateralSold: state.totalCollateralSold,
+          totalOverageReceived: state.totalOverageReceived,
+          totalProceedsReceived: state.totalProceedsReceived,
+          totalShortfallReceived: state.totalShortfallReceived,
+        });
+        metricsPublication.updateState(payload);
+      },
+
+      /**
+       * When any Vault's debt ratio is higher than the current high-water level,
+       * call `reschedulePriceCheck()` to request a fresh notification from the
+       * priceAuthority. There will be extra outstanding requests since we can't
+       * cancel them. (https://github.com/Agoric/agoric-sdk/issues/2713).
+       *
+       * When the vault with the current highest debt ratio is removed or reduces
+       * its ratio, we won't reschedule the priceAuthority requests to reduce churn.
+       * Instead, when a priceQuote is received, we'll only reschedule if the
+       * high-water level when the request was made matches the current high-water
+       * level.
+       *
+       * @param {Ratio} [highestRatio]
+       * @returns {Promise<void>}
+       */
+      async reschedulePriceCheck(highestRatio) {
+        const { state, facets } = this;
+        const { prioritizedVaults, ...ephemera } = provideEphemera(
+          state.collateralBrand,
+        );
+        assert(ephemera.factoryPowers && prioritizedVaults);
+        trace('reschedulePriceCheck', state.collateralBrand, ephemera);
+        // INTERLOCK: the first time through, start the activity to wait for
+        // and process liquidations over time.
+        if (!ephemera.liquidationQueueing) {
+          ephemera.liquidationQueueing = true;
+          // eslint-disable-next-line consistent-return
+          return facets.helper
+            .processLiquidations()
+            .catch(e => console.error('Liquidator failed', e))
+            .finally(() => {
+              ephemera.liquidationQueueing = false;
+            });
+        }
+
+        if (!ephemera.outstandingQuote) {
+          // the new threshold will be picked up by the next quote request
+          return;
+        }
+
+        const highestDebtRatio =
+          highestRatio || prioritizedVaults.highestRatio();
+        if (!highestDebtRatio) {
+          // if there aren't any open vaults, we don't need an outstanding RFQ.
+          trace('no open vaults');
+          return;
+        }
+
+        // There is already an activity processing liquidations. It may be
+        // waiting for the oracle price to cross a threshold.
+        // Update the current in-progress quote.
+        const govParams = ephemera.factoryPowers.getGovernedParams();
+        const liquidationMargin = govParams.getLiquidationMargin();
+        // Safe to call extraneously (lightweight and idempotent)
+        updateQuote(
+          ephemera.outstandingQuote,
+          highestDebtRatio,
+          liquidationMargin,
+        );
+        trace('update quote', state.collateralBrand, highestDebtRatio);
+      },
+
+      /**
+       */
+      async processLiquidations() {
+        const { state, facets } = this;
+        const { prioritizedVaults, ...ephemera } = provideEphemera(
+          state.collateralBrand,
+        );
+        assert(ephemera.factoryPowers && ephemera.priceAuthority);
+        const { priceAuthority } = ephemera;
+        const govParams = ephemera.factoryPowers.getGovernedParams();
+
+        async function* eventualLiquidations() {
+          assert(prioritizedVaults);
+          while (true) {
+            const highestDebtRatio = prioritizedVaults.highestRatio();
+            if (!highestDebtRatio) {
+              return;
+            }
+            const liquidationMargin = govParams.getLiquidationMargin();
+
+            // ask to be alerted when the price level falls enough that the vault
+            // with the highest debt to collateral ratio will no longer be valued at the
+            // liquidationMargin above its debt.
+            ephemera.outstandingQuote = makeQuote(
+              priceAuthority,
+              highestDebtRatio,
+              liquidationMargin,
+            );
+            trace(
+              'posted quote request',
+              state.collateralBrand,
+              highestDebtRatio,
+            );
+
+            // The rest of this method will not happen until after a quote is received.
+            // This may not happen until much later, when the market changes.
+            // eslint-disable-next-line no-await-in-loop
+            const quote = await E(ephemera.outstandingQuote).getPromise();
+            ephemera.outstandingQuote = null;
+            // When we receive a quote, we check whether the vault with the highest
+            // ratio of debt to collateral is below the liquidationMargin, and if so,
+            // we liquidate it. We use ceilDivide to round up because ratios above
+            // this will be liquidated.
+            const quoteRatioPlusMargin = makeRatioFromAmounts(
+              ceilDivideBy(getAmountOut(quote), liquidationMargin),
+              getAmountIn(quote),
+            );
+            trace('quote', state.collateralBrand, quote, quoteRatioPlusMargin);
+
+            // Liquidate the head of the queue
+            const [next] =
+              prioritizedVaults.entriesPrioritizedGTE(quoteRatioPlusMargin);
+            if (next) {
+              yield next;
+            }
+          }
+        }
+        for await (const next of eventualLiquidations()) {
+          await facets.helper.liquidateAndRemove(next);
+          trace('price check liq', state.collateralBrand, next && next[0]);
+        }
+      },
+
+      /**
+       * @param {[key: string, vaultKit: Vault]} record
+       */
+      liquidateAndRemove([key, vault]) {
+        const { state, facets } = this;
+        const { factoryPowers, prioritizedVaults, zcf } = provideEphemera(
+          state.collateralBrand,
+        );
+        assert(factoryPowers && prioritizedVaults && zcf);
+        const vaultSeat = vault.getVaultSeat();
+        trace('liquidating', state.collateralBrand, vaultSeat.getProposal());
+
+        const collateralPre = vault.getCollateralAmount();
+
+        // Start liquidation (vaultState: LIQUIDATING)
+        const liquidator = state.liquidator;
+        assert(liquidator);
+        state.liquidatingVaults.add(vault);
+        prioritizedVaults.removeVault(key);
+
+        return liquidate(
+          zcf,
+          vault,
+          liquidator,
+          state.collateralBrand,
+          factoryPowers.getGovernedParams().getLiquidationPenalty(),
+        )
+          .then(accounting => {
+            facets.manager.burnAndRecord(accounting.toBurn, vaultSeat);
+
+            // current values
+
+            // Sometimes, the AMM will sell less than all the collateral. If there
+            // was a shortfall, the investor doesn't keep the change, so we get it.
+            // If there was no shortfall, the collateral is returned.
+            const collateralPost = vault.getCollateralAmount();
+            if (
+              !AmountMath.isEmpty(collateralPost) &&
+              !AmountMath.isEmpty(accounting.shortfall)
+            ) {
+              // The borrower doesn't get the excess collateral remaining when
+              // liquidation results in a shortfall. We currently do nothing with
+              // it. We could hold it until it crosses some threshold, then sell it
+              // to the AMM, or we could transfer it to the reserve. At least it's
+              // visible in the accounting.
+              atomicTransfer(zcf, vaultSeat, state.retainedCollateralSeat, {
+                Collateral: collateralPost,
+              });
+            }
+
+            // Reduce totalCollateral by collateralPre, since all the collateral was
+            // sold, returned to the vault owner, or held by the VaultManager.
+            state.totalCollateral = AmountMath.subtract(
+              state.totalCollateral,
+              collateralPre,
+            );
+            state.totalDebt = AmountMath.subtract(
+              state.totalDebt,
+              accounting.shortfall,
+            );
+
+            // cumulative values
+            state.totalProceedsReceived = AmountMath.add(
+              state.totalProceedsReceived,
+              accounting.proceeds,
+            );
+            state.totalOverageReceived = AmountMath.add(
+              state.totalOverageReceived,
+              accounting.overage,
+            );
+            state.totalShortfallReceived = AmountMath.add(
+              state.totalShortfallReceived,
+              accounting.shortfall,
+            );
+            state.liquidatingVaults.delete(vault);
+            trace('liquidated', state.collateralBrand);
+            state.numLiquidationsCompleted += 1;
+            facets.helper.updateMetrics();
+
+            if (!AmountMath.isEmpty(accounting.shortfall)) {
+              E(factoryPowers.getShortfallReporter())
+                .increaseLiquidationShortfall(accounting.shortfall)
+                .catch(reason =>
+                  console.error(
+                    'liquidateAndRemove failed to increaseLiquidationShortfall',
+                    reason,
+                  ),
+                );
+            }
+          })
+          .catch(e => {
+            // XXX should notify interested parties
+            console.error('liquidateAndRemove failed with', e);
+            throw e;
+          });
+      },
+    },
+    manager: {
+      getGovernedParams() {
+        const { state } = this;
+        const ephemera = provideEphemera(state.collateralBrand);
+        assert(ephemera.factoryPowers);
+        return ephemera.factoryPowers.getGovernedParams();
+      },
+
+      /**
+       * @param {Amount<'nat'>} collateralAmount
+       */
+      async maxDebtFor(collateralAmount) {
+        const { state } = this;
+        const { debtBrand } = state;
+        const { priceAuthority, ...ephemera } = provideEphemera(
+          state.collateralBrand,
+        );
+        assert(ephemera.factoryPowers && priceAuthority);
+        const quoteAmount = await E(priceAuthority).quoteGiven(
+          collateralAmount,
+          debtBrand,
+        );
+        // floorDivide because we want the debt ceiling lower
+        return floorDivideBy(
+          getAmountOut(quoteAmount),
+          ephemera.factoryPowers.getGovernedParams().getLiquidationMargin(),
+        );
+      },
+      /**
+       * TODO utility method to turn a callback into non-actual one
+       * was type {MintAndReallocate}
+       *
+       * @param {Amount<'nat'>} toMint
+       * @param {Amount<'nat'>} fee
+       * @param {ZCFSeat} seat
+       * @param {...ZCFSeat} otherSeats
+       * @returns {void}
+       */
+      mintAndReallocate(toMint, fee, seat, ...otherSeats) {
+        const { state } = this;
+        const { totalDebt } = state;
+        const { factoryPowers } = provideEphemera(state.collateralBrand);
+        assert(factoryPowers);
+
+        checkDebtLimit(
+          factoryPowers.getGovernedParams().getDebtLimit(),
+          totalDebt,
+          toMint,
+        );
+        factoryPowers.mintAndReallocate(toMint, fee, seat, ...otherSeats);
+        state.totalDebt = AmountMath.add(state.totalDebt, toMint);
+      },
+      /**
+       * @param {Amount<'nat'>} toBurn
+       * @param {ZCFSeat} seat
+       */
+      burnAndRecord(toBurn, seat) {
+        const { state } = this;
+        const { factoryPowers } = provideEphemera(state.collateralBrand);
+        assert(factoryPowers);
+        trace('burnAndRecord', state.collateralBrand, {
+          toBurn,
+          totalDebt: state.totalDebt,
+        });
+        const { burnDebt } = factoryPowers;
+        burnDebt(toBurn, seat);
+        state.totalDebt = AmountMath.subtract(state.totalDebt, toBurn);
+      },
+      getAssetSubscriber() {
+        const { state } = this;
+        const { assetSubscriber } = provideEphemera(state.collateralBrand);
+        assert(assetSubscriber);
+        return assetSubscriber;
+      },
+      getCollateralBrand() {
+        return this.state.collateralBrand;
+      },
+      getDebtBrand() {
+        return this.state.debtBrand;
+      },
+      /**
+       * coefficient on existing debt to calculate new debt
+       *
+       */
+      getCompoundedInterest() {
+        return this.state.compoundedInterest;
+      },
+      /**
+       * Called by a vault when its balances change.
+       *
+       * @param {NormalizedDebt} oldDebtNormalized
+       * @param {Amount<'nat'>} oldCollateral
+       * @param {VaultId} vaultId
+       * @param {import('./vault.js').VaultPhase} vaultPhase at the end of whatever change updated balances
+       * @param {Vault} vault
+       */
+      handleBalanceChange(
+        oldDebtNormalized,
+        oldCollateral,
+        vaultId,
+        vaultPhase,
+        vault,
+      ) {
+        const { state, facets } = this;
+        const { prioritizedVaults } = provideEphemera(state.collateralBrand);
+        assert(prioritizedVaults);
+
+        // the manager holds only vaults that can accrue interest or be liquidated;
+        // i.e. vaults that have debt. The one exception is at the outset when
+        // a vault has been added to the manager but not yet accounted for.
+        const settled =
+          AmountMath.isEmpty(oldDebtNormalized) && vaultPhase !== Phase.ACTIVE;
+
+        if (settled) {
+          assert(
+            !prioritizedVaults.hasVaultByAttributes(
+              oldDebtNormalized,
+              oldCollateral,
+              vaultId,
+            ),
+            'Settled vaults must not be retained in storage',
+          );
+        } else {
+          const isNew = AmountMath.isEmpty(oldDebtNormalized);
+          if (!isNew) {
+            // its position in the queue is no longer valid
+
+            const vaultInStore = prioritizedVaults.removeVaultByAttributes(
+              oldDebtNormalized,
+              oldCollateral,
+              vaultId,
+            );
+            assert(
+              vault === vaultInStore,
+              'handleBalanceChange for two different vaults',
+            );
+          }
+
+          // replace in queue, but only if it can accrue interest or be liquidated (i.e. has debt).
+          // getCurrentDebt() would also work (0x = 0) but require more computation.
+          if (!AmountMath.isEmpty(vault.getNormalizedDebt())) {
+            prioritizedVaults.addVault(vaultId, vault);
+          }
+
+          // totalCollateral += vault's collateral delta (post — pre)
+          state.totalCollateral = AmountMath.subtract(
+            AmountMath.add(state.totalCollateral, vault.getCollateralAmount()),
+            oldCollateral,
+          );
+          // debt accounting managed through minting and burning
+          facets.helper.updateMetrics();
+        }
+      },
+    },
+    self: {
+      getGovernedParams() {
+        const { state } = this;
+        const { factoryPowers } = provideEphemera(state.collateralBrand);
+        assert(factoryPowers);
+        return factoryPowers.getGovernedParams();
+      },
+
+      /**
+       * In extreme situations, system health may require liquidating all vaults.
+       * This starts the liquidations all in parallel.
+       *
+       */
+      async liquidateAll() {
+        const {
+          state,
+          facets: { helper },
+        } = this;
+        const { prioritizedVaults } = provideEphemera(state.collateralBrand);
+        assert(prioritizedVaults);
+        const toLiquidate = Array.from(prioritizedVaults.entries()).map(entry =>
+          helper.liquidateAndRemove(entry),
+        );
+        await Promise.all(toLiquidate);
+      },
+
+      /**
+       * @param {ZCFSeat} seat
+       */
+      async makeVaultKit(seat) {
+        const {
+          state,
+          facets: { manager },
+        } = this;
+        const { marshaller, prioritizedVaults, storageNode, zcf } =
+          provideEphemera(state.collateralBrand);
+        assert(marshaller, 'makeVaultKit missing marshaller');
+        assert(prioritizedVaults, 'makeVaultKit missing prioritizedVaults');
+        assert(storageNode, 'makeVaultKit missing storageNode');
+        assert(zcf, 'makeVaultKit missing zcf');
+        assertProposalShape(seat, {
+          give: { Collateral: null },
+          want: { Minted: null },
+        });
+
+        state.vaultCounter += 1;
+        const vaultId = String(state.vaultCounter);
+
+        const vaultStorageNode = E(
+          E(storageNode).makeChildNode(`vaults`),
+        ).makeChildNode(`vault${vaultId}`);
+
+        const vault = makeVault(
+          zcf,
+          manager,
+          vaultId,
+          vaultStorageNode,
+          marshaller,
+        );
+
+        try {
+          // TODO `await` is allowed until the above ordering is fixed
+          // eslint-disable-next-line @jessie.js/no-nested-await
+          const vaultKit = await vault.initVaultKit(seat, vaultStorageNode);
+          // initVaultKit calls back to handleBalanceChange() which will add the
+          // vault to prioritizedVaults
+          seat.exit();
+          return vaultKit;
+        } catch (err) {
+          // ??? do we still need this cleanup? it won't get into the store unless it has collateral,
+          // which should qualify it to be in the store. If we drop this catch then the nested await
+          // for `vault.initVaultKit()` goes away.
+
+          // remove it from the store if it got in
+          /** @type {NormalizedDebt} */
+          // @ts-expect-error cast
+          const normalizedDebt = AmountMath.makeEmpty(state.debtBrand);
+          const collateralPre = seat.getCurrentAllocation().Collateral;
+          try {
+            prioritizedVaults.removeVaultByAttributes(
+              normalizedDebt,
+              collateralPre,
+              vaultId,
+            );
+            console.error(
+              'removed vault',
+              vaultId,
+              'after initVaultKit failure',
+            );
+          } catch {
+            console.error(
+              'vault',
+              vaultId,
+              'never stored during initVaultKit failure',
+            );
+          }
+          throw err;
+        }
+      },
+
+      /**
+       *
+       * @param {Installation} liquidationInstall
+       * @param {object} liquidationTerms
+       */
+      async setupLiquidator(liquidationInstall, liquidationTerms) {
+        const { state, facets } = this;
+        const { zcf } = provideEphemera(state.collateralBrand);
+        assert(zcf);
+        const { debtBrand, collateralBrand } = state;
+        const {
+          ammPublicFacet,
+          priceAuthority,
+          reservePublicFacet,
+          timerService,
+        } = zcf.getTerms();
+        const zoe = zcf.getZoeService();
+        const collateralIssuer = zcf.getIssuerForBrand(collateralBrand);
+        const debtIssuer = zcf.getIssuerForBrand(debtBrand);
+        trace('setup liquidator', state.collateralBrand, {
+          debtBrand,
+          debtIssuer,
+          collateralBrand,
+          liquidationTerms,
+        });
+        const { creatorFacet, instance } = await E(zoe).startInstance(
+          liquidationInstall,
+          harden({ Minted: debtIssuer, Collateral: collateralIssuer }),
+          harden({
+            ...liquidationTerms,
+            amm: ammPublicFacet,
+            debtBrand,
+            reservePublicFacet,
+            priceAuthority,
+            timerService,
+          }),
+        );
+        trace('setup liquidator complete', state.collateralBrand, {
+          instance,
+          old: state.liquidatorInstance,
+          equal: state.liquidatorInstance === instance,
+        });
+        state.liquidatorInstance = instance;
+        state.liquidator = creatorFacet;
+        facets.helper.assetNotify();
+      },
+
+      async getCollateralQuote() {
+        const { state } = this;
+        const { priceAuthority } = provideEphemera(state.collateralBrand);
+        assert(priceAuthority);
+
+        const { debtBrand } = state;
+        // get a quote for one unit of the collateral
+        const collateralUnit = await unitAmount(state.collateralBrand);
+        return E(priceAuthority).quoteGiven(collateralUnit, debtBrand);
+      },
+
+      getPublicFacet() {
+        return this.facets.collateral;
+      },
+    },
   },
   {
     finish,

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -54,7 +54,7 @@ import { makeVault, Phase } from './vault.js';
 
 const { details: X } = assert;
 
-const trace = makeTracer('VM');
+const trace = makeTracer('VM', false);
 
 /** @typedef {import('./storeUtils.js').NormalizedDebt} NormalizedDebt */
 

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -852,8 +852,8 @@ test('vaultFactory display collateral', async t => {
     500n,
   );
 
-  const { vaultFactory } = services.vaultFactory;
-  const collaterals = await E(vaultFactory).getCollaterals();
+  const { lender } = services.vaultFactory;
+  const collaterals = await E(lender).getCollaterals();
   t.deepEqual(collaterals[0], {
     brand: aeth.brand,
     liquidationMargin: makeRatio(105n, run.brand),

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -371,19 +371,21 @@ const setupServices = async (
     'AEth',
     rates,
   );
-  /** @type {[any, VaultFactoryCreatorFacet, VFC['publicFacet'], VaultManager, PriceAuthority]} */
+  /** @type {[any, VaultFactoryCreatorFacet, VFC['publicFacet'], VaultManager, PriceAuthority, CollateralManager]} */
   const [
     governorInstance,
     vaultFactory, // creator
     lender,
     aethVaultManager,
     priceAuthority,
+    aethCollateralManager,
   ] = await Promise.all([
     E(consume.agoricNames).lookup('instance', 'VaultFactoryGovernor'),
     vaultFactoryCreatorFacetP,
     E.get(consume.vaultFactoryKit).publicFacet,
     aethVaultManagerP,
     pa,
+    E(aethVaultManagerP).getPublicFacet(),
   ]);
   trace(t, 'pa', {
     governorInstance,
@@ -402,6 +404,7 @@ const setupServices = async (
       vaultFactory,
       lender,
       aethVaultManager,
+      aethCollateralManager,
     },
   };
 
@@ -2574,7 +2577,7 @@ test('manager notifiers', async t => {
     3n * (DEBT1 + DEBT2),
   );
 
-  const { aethVaultManager, lender } = services.vaultFactory;
+  const { aethVaultManager, aethCollateralManager } = services.vaultFactory;
   const cm = await E(aethVaultManager).getPublicFacet();
 
   const m = await vaultManagerMetricsTracker(t, cm);
@@ -2599,7 +2602,7 @@ test('manager notifiers', async t => {
   trace('1. Create a loan with ample collateral');
   /** @type {UserSeat<VaultKit>} */
   let vaultSeat = await E(services.zoe).offer(
-    await E(lender).makeVaultInvitation(),
+    await E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: aeth.make(AMPLE) },
       want: { Minted: run.make(LOAN1) },
@@ -2648,7 +2651,7 @@ test('manager notifiers', async t => {
 
   trace('4. Make another LOAN1 loan');
   vaultSeat = await E(services.zoe).offer(
-    await E(lender).makeVaultInvitation(),
+    await E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: aeth.make(AMPLE) },
       want: { Minted: run.make(LOAN1) },
@@ -2668,7 +2671,7 @@ test('manager notifiers', async t => {
 
   trace('5. Make a LOAN2 loan');
   vaultSeat = await E(services.zoe).offer(
-    await E(lender).makeVaultInvitation(),
+    await E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: aeth.make(ENOUGH) },
       want: { Minted: run.make(LOAN2) },
@@ -2710,7 +2713,7 @@ test('manager notifiers', async t => {
 
   trace('7. Make another LOAN2 loan');
   vaultSeat = await E(services.zoe).offer(
-    await E(lender).makeVaultInvitation(),
+    await E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: aeth.make(ENOUGH) },
       want: { Minted: run.make(LOAN2) },
@@ -2740,7 +2743,7 @@ test('manager notifiers', async t => {
 
   trace('9. Loan interest');
   vaultSeat = await E(services.zoe).offer(
-    await E(lender).makeVaultInvitation(),
+    await E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: aeth.make(AMPLE) },
       want: { Minted: run.make(LOAN1) },
@@ -2763,7 +2766,7 @@ test('manager notifiers', async t => {
 
   trace('make another loan to trigger a publish');
   vaultSeat = await E(services.zoe).offer(
-    await E(lender).makeVaultInvitation(),
+    await E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: aeth.make(ENOUGH) },
       want: { Minted: run.make(LOAN2) },
@@ -2812,7 +2815,7 @@ test('manager notifiers', async t => {
   trace('11. Create a loan with ample collateral');
   /** @type {UserSeat<VaultKit>} */
   vaultSeat = await E(services.zoe).offer(
-    await E(lender).makeVaultInvitation(),
+    await E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: aeth.make(AMPLE) },
       want: { Minted: run.make(LOAN1) },

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -191,11 +191,7 @@ export async function start(zcf, privateArgs) {
   }));
 
   async function makeHook(seat) {
-    const vaultKit = await vault.initVaultKit(
-      seat,
-      makeFakeStorage('test'),
-      marshaller,
-    );
+    const vaultKit = await vault.initVaultKit(seat, makeFakeStorage('test'));
     return {
       vault,
       runMint,

--- a/packages/notifier/src/typeGuards.js
+++ b/packages/notifier/src/typeGuards.js
@@ -1,0 +1,3 @@
+import { M } from '@agoric/store';
+
+export const StorageNodeShape = M.remotable('StorageNode');

--- a/packages/notifier/tools/testSupports.js
+++ b/packages/notifier/tools/testSupports.js
@@ -1,7 +1,7 @@
 /* global setImmediate */
 
 // eslint-disable-next-line import/order
-import { makeMarshal } from '@endo/marshal';
+import { Far, makeMarshal } from '@endo/marshal';
 
 import '../src/types-ambient.js';
 
@@ -22,7 +22,7 @@ export const makeFakeStorage = (path, publication) => {
     dataPrefixBytes: '',
   });
   /** @type {StorageNode} */
-  const storage = {
+  const storage = Far('StorageNode', {
     getStoreKey: async () => storeKey,
     setValue: async value => {
       setValueCalls += 1;
@@ -33,9 +33,8 @@ export const makeFakeStorage = (path, publication) => {
       publication.updateState(value);
     },
     makeChildNode: () => storage,
-    // @ts-expect-error
     countSetValueCalls: () => setValueCalls,
-  };
+  });
   return storage;
 };
 harden(makeFakeStorage);

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -614,7 +614,6 @@ export function openSwingStore(dirPath, options = {}) {
  * @returns {boolean}
  *   If the directory is present and contains the files created by initSwingStore
  *   or openSwingStore, returns true. Else returns false.
- *
  */
 export function isSwingStore(dirPath) {
   assert.typeof(dirPath, 'string');

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -322,7 +322,6 @@ harden(runModuleBehaviors);
  *   agoricNamesAdmin: import('../types.js').NameAdmin,
  *   spaces: WellKnownSpaces,
  * }}
- *
  */
 export const makeAgoricNamesAccess = (
   log = () => {}, // console.debug


### PR DESCRIPTION
## Description

Part of #5285, clear out some deprecated patterns:
- define*Kind, which has been replaced by define*FarClass
- ~ephemera hack for non-durable publishers, not that we have durable publishers~ ran into some errors in chain testing and deferring this to another PR

This should make changes like https://github.com/Agoric/agoric-sdk/pull/6373/ easier to reason about and review.

I took care to segment changes to commits so I suggest reviewing by commit. When the change was just code movement I put "move" in the commit message.

### Security Considerations

No changes.

### Documentation Considerations

--

### Testing Considerations

Should work exactly as before.
