### PR TITLE
fix(smart-wallet): create purses for new assets lazily

### DIFF
--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -35,6 +35,9 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     'wallet',
   );
 
+  const assetPublisher = await E(consume.bankManager).getBankForAddress(
+    'anyAddress',
+  );
   const bridgeManager = await consume.bridgeManager;
   const walletBridgeManager = await (bridgeManager &&
     E(bridgeManager).register(BridgeId.WALLET));
@@ -44,6 +47,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     {
       agoricNames,
       board: consume.board,
+      assetPublisher,
     },
     { storageNode, walletBridgeManager },
   );

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -131,6 +131,9 @@ test('want stable', async t => {
   const stableBrand = await E(agoricNames).lookup('brand', Stable.symbol);
 
   const wallet = await t.context.simpleProvideWallet('agoric1wantstable');
+  const current = await E(E(wallet).getCurrentSubscriber())
+    .subscribeAfter()
+    .then(pub => pub.head.value);
   const computedState = coalesceUpdates(E(wallet).getUpdatesSubscriber());
 
   const offersFacet = wallet.getOffersFacet();
@@ -138,7 +141,10 @@ test('want stable', async t => {
   // let promises settle to notify brands and create purses
   await eventLoopIteration();
 
-  t.is(purseBalance(computedState, anchor.brand), 0n);
+  t.deepEqual(current.purses.find(b => b.brand === anchor.brand).balance, {
+    brand: anchor.brand,
+    value: 0n,
+  });
 
   t.log('Fund the wallet');
   assert(anchor.mint);

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -35,7 +35,7 @@ export const UNPUBLISHED_RESULT = 'UNPUBLISHED';
  * @param {object} opts.powers
  * @param {Pick<Console, 'info'| 'error'>} opts.powers.logger
  * @param {(spec: import('./invitations').InvitationSpec) => ERef<Invitation>} opts.powers.invitationFromSpec
- * @param {(brand: Brand) => import('./types').RemotePurse} opts.powers.purseForBrand
+ * @param {(brand: Brand) => Promise<import('./types').RemotePurse>} opts.powers.purseForBrand
  * @param {(status: OfferStatus) => void} opts.onStatusChange
  * @param {(offerId: OfferId, invitationAmount: Amount<'set'>, continuation: import('./types').RemoteInvitationMakers) => void} opts.onNewContinuingOffer
  */

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -66,7 +66,7 @@ export const publishDepositFacet = async (
  */
 
 // NB: even though all the wallets share this contract, they
-// 1. they should rely on that; they may be partitioned later
+// 1. they should not rely on that; they may be partitioned later
 // 2. they should never be able to detect behaviors from another wallet
 /**
  *

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -5,11 +5,12 @@
  */
 
 import { WalletName } from '@agoric/internal';
-import { fit, M, makeHeapFarInstance } from '@agoric/store';
+import { fit, M, makeHeapFarInstance, makeScalarMapStore } from '@agoric/store';
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeMyAddressNameAdminKit } from '@agoric/vats/src/core/basic-behaviors.js';
-import { E } from '@endo/far';
+import { observeIteration } from '@agoric/notifier';
+import { E, Far } from '@endo/far';
 import { makeSmartWallet } from './smartWallet.js';
 import { shape } from './typeGuards.js';
 
@@ -18,14 +19,15 @@ import '@agoric/vats/exported.js';
 
 export const privateArgsShape = harden(
   M.splitRecord(
-    { storageNode: M.eref(M.any()) },
-    { walletBridgeManager: M.eref(M.any()) },
+    { storageNode: M.eref(M.remotable('StorageNode')) },
+    { walletBridgeManager: M.eref(M.remotable('walletBridgeManager')) },
   ),
 );
 
 export const customTermsShape = harden({
-  agoricNames: M.not(M.undefined()),
-  board: M.not(M.undefined()),
+  agoricNames: M.eref(M.remotable('agoricNames')),
+  board: M.eref(M.remotable('board')),
+  assetPublisher: M.eref(M.remotable('Bank')),
 });
 
 /**
@@ -57,12 +59,63 @@ export const publishDepositFacet = async (
 };
 
 /**
+ * @param {AssetPublisher} assetPublisher
+ */
+const makeAssetRegistry = assetPublisher => {
+  /**
+   * @typedef {{
+   *   brand: Brand,
+   *   displayInfo: DisplayInfo,
+   *   issuer: Issuer,
+   *   petname: import('./types').Petname
+   * }} BrandDescriptor
+   * For use by clients to describe brands to users. Includes `displayInfo` to save a remote call.
+   */
+  /** @type {MapStore<Brand, BrandDescriptor>} */
+  const brandDescriptors = makeScalarMapStore();
+
+  // watch the bank for new issuers to make purses out of
+  void observeIteration(E(assetPublisher).getAssetSubscription(), {
+    async updateState(desc) {
+      const { brand, issuer: issuerP, issuerName: petname } = desc;
+      // await issuer identity for use in chainStorage
+      const [issuer, displayInfo] = await Promise.all([
+        issuerP,
+        E(brand).getDisplayInfo(),
+      ]);
+
+      brandDescriptors.init(desc.brand, {
+        brand,
+        issuer,
+        petname,
+        displayInfo,
+      });
+    },
+  });
+
+  // XXX marshal requires Far, but clients make sync calls
+  const registry = Far('AssetRegistry', {
+    /** @param {Brand} brand */
+    getRegisteredAsset: brand => {
+      return brandDescriptors.get(brand);
+    },
+    getRegisteredBrands: () => [...brandDescriptors.values()],
+  });
+  return registry;
+};
+
+/**
  * @typedef {{
  *   agoricNames: ERef<NameHub>,
  *   board: ERef<import('@agoric/vats').Board>,
+ *   assetPublisher: AssetPublisher,
  * }} SmartWalletContractTerms
  *
  * @typedef {import('@agoric/vats').NameHub} NameHub
+ *
+ * @typedef {{
+ *   getAssetSubscription: () => ERef<Subscription<import('@agoric/vats/src/vat-bank').AssetDescriptor>>
+ * }} AssetPublisher
  */
 
 // NB: even though all the wallets share this contract, they
@@ -77,7 +130,7 @@ export const publishDepositFacet = async (
  * }} privateArgs
  */
 export const start = async (zcf, privateArgs) => {
-  const { agoricNames, board } = zcf.getTerms();
+  const { agoricNames, board, assetPublisher } = zcf.getTerms();
 
   const zoe = zcf.getZoeService();
   const { storageNode, walletBridgeManager } = privateArgs;
@@ -122,19 +175,28 @@ export const start = async (zcf, privateArgs) => {
     E(walletBridgeManager).setHandler(handleWalletAction));
 
   // Resolve these first because the wallet maker must be synchronous
-  const getInvitationIssuer = E(zoe).getInvitationIssuer();
-  const [invitationIssuer, invitationBrand, publicMarshaller] =
-    await Promise.all([
-      getInvitationIssuer,
-      E(getInvitationIssuer).getBrand(),
-      E(board).getReadonlyMarshaller(),
-    ]);
+  const invitationIssuerP = E(zoe).getInvitationIssuer();
+  const [
+    invitationIssuer,
+    invitationBrand,
+    invitationDisplayInfo,
+    publicMarshaller,
+  ] = await Promise.all([
+    invitationIssuerP,
+    E(invitationIssuerP).getBrand(),
+    E(E(invitationIssuerP).getBrand()).getDisplayInfo(),
+    E(board).getReadonlyMarshaller(),
+  ]);
+
+  const registry = makeAssetRegistry(assetPublisher);
 
   const shared = harden({
     agoricNames,
     invitationBrand,
+    invitationDisplayInfo,
     invitationIssuer,
     publicMarshaller,
+    registry,
     storageNode,
     zoe,
   });
@@ -144,9 +206,9 @@ export const start = async (zcf, privateArgs) => {
     M.interface('walletFactoryCreatorI', {
       provideSmartWallet: M.callWhen(
         M.string(),
-        M.await(M.remotable()),
-        M.await(M.remotable()),
-      ).returns([M.remotable(), M.boolean()]),
+        M.await(M.remotable('Bank')),
+        M.await(M.remotable('namesByAddressAdmin')),
+      ).returns([M.remotable('SmartWallet'), M.boolean()]),
     }),
     {
       /**

--- a/packages/smart-wallet/test/contexts.js
+++ b/packages/smart-wallet/test/contexts.js
@@ -34,6 +34,9 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     'wallet',
   );
 
+  const assetPublisher = await E(consume.bankManager).getBankForAddress(
+    'anyAddress',
+  );
   const bridgeManager = await consume.bridgeManager;
   const walletBridgeManager = await (bridgeManager &&
     E(bridgeManager).register(BridgeId.WALLET));
@@ -43,6 +46,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     {
       agoricNames,
       board: consume.board,
+      assetPublisher,
     },
     { storageNode, walletBridgeManager },
   );

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -10,12 +10,10 @@ import { makeMockTestSpace } from './supports.js';
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeDefaultTestContext>>>} */
 const test = anyTest;
 
-const TODO = undefined;
-
 test.before(async t => {
   const withBankManager = async () => {
-    const bridge = TODO;
-    const bankManager = E(buildBankVatRoot()).makeBankManager(bridge);
+    const noBridge = undefined;
+    const bankManager = E(buildBankVatRoot()).makeBankManager(noBridge);
     const noop = () => {};
     const space0 = await makeMockTestSpace(noop);
     space0.produce.bankManager.reset();
@@ -35,7 +33,7 @@ const range = qty => [...Array(qty).keys()];
  * NOTE: this doesn't test all forms of work.
  * A better test would measure inter-vat messages or some such.
  */
-test.failing('avoid O(wallets) storage writes for a new asset', async t => {
+test('avoid O(wallets) storage writes for a new asset', async t => {
   const bankManager = t.context.consume.bankManager;
 
   let chainStorageWrites = 0;
@@ -73,8 +71,8 @@ test.failing('avoid O(wallets) storage writes for a new asset', async t => {
       addedWrites: chainStorageWrites - initialWrites,
     };
   };
-  const base = await simulate(2, 'ibc/dia1', 'DAI_axl');
-  const exp = await simulate(6, 'ibc/dia2', 'DAI_grv');
+  const base = await simulate(2, 'ibc/dai1', 'DAI_axl');
+  const exp = await simulate(6, 'ibc/dai2', 'DAI_grv');
 
   t.log({
     base: { wallets: base.qty, writes: base.addedWrites },

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -1,0 +1,87 @@
+// @ts-check
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { E } from '@endo/far';
+import { buildRootObject as buildBankVatRoot } from '@agoric/vats/src/vat-bank.js';
+import { makeIssuerKit } from '@agoric/ertp';
+import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
+import { makeDefaultTestContext } from './contexts.js';
+import { makeMockTestSpace } from './supports.js';
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeDefaultTestContext>>>} */
+const test = anyTest;
+
+const TODO = undefined;
+
+test.before(async t => {
+  const withBankManager = async () => {
+    const bridge = TODO;
+    const bankManager = E(buildBankVatRoot()).makeBankManager(bridge);
+    const noop = () => {};
+    const space0 = await makeMockTestSpace(noop);
+    space0.produce.bankManager.reset();
+    space0.produce.bankManager.resolve(bankManager);
+    return space0;
+  };
+  t.context = await makeDefaultTestContext(t, withBankManager);
+});
+
+const DEBUG = false;
+const bigIntReplacer = (_key, val) =>
+  typeof val === 'bigint' ? Number(val) : val;
+
+const range = qty => [...Array(qty).keys()];
+
+/**
+ * NOTE: this doesn't test all forms of work.
+ * A better test would measure inter-vat messages or some such.
+ */
+test.failing('avoid O(wallets) storage writes for a new asset', async t => {
+  const bankManager = t.context.consume.bankManager;
+
+  let chainStorageWrites = 0;
+
+  const startUser = async ix => {
+    const address = `agoric1u${ix}`;
+    const smartWallet = t.context.simpleProvideWallet(address);
+
+    // stick around waiting for things to happen
+    const current = await E(smartWallet).getCurrentSubscriber();
+    /** @type {bigint | undefined} */
+    let publishCount;
+    for (;;) {
+      // eslint-disable-next-line no-await-in-loop
+      const news = await E(current).subscribeAfter(publishCount);
+      publishCount = news.publishCount;
+      chainStorageWrites += 1;
+      if (DEBUG) {
+        console.log(JSON.stringify(news.head, bigIntReplacer, 2));
+      }
+    }
+  };
+
+  const simulate = async (qty, denom, name) => {
+    range(qty).forEach(startUser);
+    await eventLoopIteration();
+    const initialWrites = chainStorageWrites;
+
+    const kit = makeIssuerKit(name);
+    await E(bankManager).addAsset(denom, name, name, kit);
+    await eventLoopIteration();
+    return {
+      qty,
+      initialWrites,
+      addedWrites: chainStorageWrites - initialWrites,
+    };
+  };
+  const base = await simulate(2, 'ibc/dia1', 'DAI_axl');
+  const exp = await simulate(6, 'ibc/dia2', 'DAI_grv');
+
+  t.log({
+    base: { wallets: base.qty, writes: base.addedWrites },
+    test: { wallets: exp.qty + base.qty, writes: exp.addedWrites },
+  });
+  t.true(
+    exp.addedWrites <= (base.addedWrites * exp.qty) / base.qty / 2,
+    'actual writes should be less than half of linear growth',
+  );
+});

--- a/packages/smart-wallet/test/test-startWalletFactory.js
+++ b/packages/smart-wallet/test/test-startWalletFactory.js
@@ -64,6 +64,7 @@ test('customTermsShape', async t => {
       {
         agoricNames,
         board,
+        assetPublisher: /** @type {any} */ ({}),
         //   @ts-expect-error extra term
         extra: board,
       },
@@ -71,7 +72,7 @@ test('customTermsShape', async t => {
     ),
     {
       message:
-        '{"agoricNames":"[Promise]","board":"[Promise]","extra":"[Seen]"} - Must not have unexpected properties: ["extra"]',
+        '{"agoricNames":"[Promise]","assetPublisher":{},"board":"[Promise]","extra":"[Seen]"} - Must not have unexpected properties: ["extra"]',
     },
   );
 
@@ -88,7 +89,7 @@ test('customTermsShape', async t => {
     ),
     {
       message:
-        '{"agoricNames":"[Promise]"} - Must have missing properties ["board"]',
+        '{"agoricNames":"[Promise]"} - Must have missing properties ["board","assetPublisher"]',
     },
   );
 });
@@ -99,6 +100,7 @@ test('privateArgsShape', async t => {
   const terms = {
     agoricNames,
     board,
+    assetPublisher: /** @type {any} */ ({}),
   };
 
   // missing an arg

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -184,10 +184,14 @@ export const startWalletFactory = async (
     feeIssuerP,
   ]);
 
+  const poolBank = E(bankManager).getBankForAddress(poolAddr);
   const terms = await deeplyFulfilled(
     harden({
       agoricNames,
       board,
+      assetPublisher: Far('AssetPublisher', {
+        getAssetSubscription: () => E(poolBank).getAssetSubscription(),
+      }),
     }),
   );
   /** @type {WalletFactoryStartResult} */
@@ -202,7 +206,6 @@ export const startWalletFactory = async (
   );
   walletFactoryStartResult.resolve(wfFacets);
   instanceProduce.walletFactory.resolve(wfFacets.instance);
-  const poolBank = E(bankManager).getBankForAddress(poolAddr);
 
   const ppFacets = await startGovernedInstance(
     {


### PR DESCRIPTION
refs: #6652

## Description

 - only subscribe to new assets once, in `walletFactory.js`.
 - make purses for all vbank assets when creating a smart wallet
 - for assets added to the vbank after a smart wallet is created, create purses lazily
    - Change `purseForBrand` given to `makeOfferExecutor` to create purses lazily.

### Security Considerations

When a user executes an offer, if we don't have a purse for one of the relevant brands, we take the brand they give and "upgrade" it to an issuer, by way of info we got from the vbank, in order to make a purse. Normally we would expect the user to explicitly indicate the issuers that they trust. This isn't so much a change in the security properties of the contract - it trusted the vbank to provide issuers to make purses before - but this now happens in response to the user placing an offer rather than in response to the vbank announcing a new asset.

### Documentation Considerations

We should tell users that if a vbank asset is added after they provision their smart wallet, they won't see a purse until they execute an offer that uses it.

### Testing Considerations

I'm somewhat surprised at how little code needed to change for this in order to get `yarn test` in `packages/smart-wallet` to pass. I wonder whether those tests have good coverage of executing offers.

_p.s. tests in inter-protocol provide more coverage._