### PR TITLE
6771 pricefeed errors

### DIFF
--- a/packages/inter-protocol/src/price/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/price/priceAggregatorChainlink.js
@@ -219,10 +219,14 @@ export const start = async (zcf, privateArgs, baggage) => {
         const invitationMakers = Far('invitation makers', {
           /** @param {import('./roundsManager.js').PriceRound} result */
           PushPrice(result) {
-            return zcf.makeInvitation(cSeat => {
-              cSeat.exit();
-              admin.pushPrice(result);
-            }, 'PushPrice');
+            return zcf.makeInvitation(
+              /** @param {ZCFSeat} cSeat */
+              async cSeat => {
+                cSeat.exit();
+                await admin.pushPrice(result);
+              },
+              'PushPrice',
+            );
           },
         });
         seat.exit();

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -78,23 +78,19 @@ test.before(async t => {
   t.context = await makeDefaultTestContext(t, makeTestSpace);
 });
 
-test('admin price', async t => {
-  const { agoricNames, zoe } = t.context.consume;
+test.serial('invitations', async t => {
+  const { agoricNames } = t.context.consume;
 
   const wallet = await t.context.simpleProvideWallet(operatorAddress);
   const computedState = coalesceUpdates(E(wallet).getUpdatesSubscriber());
-  const currentSub = E(wallet).getCurrentSubscriber();
 
   await t.context.simpleCreatePriceFeed([operatorAddress], 'ATOM', 'USD');
-
-  const offersFacet = wallet.getOffersFacet();
 
   /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<import('@agoric/inter-protocol/src/price/priceAggregatorChainlink.js').start>} */
   const priceAggregator = await E(agoricNames).lookup(
     'instance',
     'ATOM-USD price feed',
   );
-  const paPublicFacet = await E(zoe).getPublicFacet(priceAggregator);
 
   /**
    * get invitation details the way a user would
@@ -125,6 +121,23 @@ test('admin price', async t => {
     proposeInvitationDetails[0].instance,
     priceAggregator,
     'priceAggregator',
+  );
+});
+
+test('admin price', async t => {
+  const { agoricNames, zoe } = t.context.consume;
+
+  const wallet = await t.context.simpleProvideWallet(operatorAddress);
+  const currentSub = E(wallet).getCurrentSubscriber();
+
+  await t.context.simpleCreatePriceFeed([operatorAddress], 'ATOM', 'USD');
+
+  const offersFacet = wallet.getOffersFacet();
+
+  /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<import('@agoric/inter-protocol/src/price/priceAggregatorChainlink.js').start>} */
+  const priceAggregator = await E(agoricNames).lookup(
+    'instance',
+    'ATOM-USD price feed',
   );
 
   // The purse has the invitation to get the makers ///////////
@@ -183,6 +196,8 @@ test('admin price', async t => {
   );
   // trigger an aggregation (POLL_INTERVAL=1n in context)
   E(manualTimer).tickN(1);
+
+  const paPublicFacet = await E(zoe).getPublicFacet(priceAggregator);
 
   const latestRoundSubscriber = await E(paPublicFacet).getRoundStartNotifier();
 


### PR DESCRIPTION
closes: #6771

## Description

When a `PushPrice` invitation executed, errors in the `pushPrice` call weren't caught or reported.

The reason is `pushPrice` was called as a floating promise. We have a way to lint floating promises but it's [too slow for CI](https://github.com/Agoric/agoric-sdk/issues/5788). Still this error should serve as a motivation to [resolve them before the next release](https://github.com/Agoric/agoric-sdk/issues/6000), to detect any other surprises.

### Security Considerations

No new boundaries.

### Documentation Considerations

Conforms better to expectation. Nothing new to document.

### Testing Considerations

New tests.