### PR TITLE
5285 durable publishkits

### DIFF
--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -84,7 +84,7 @@ export const checkDebtLimit = (debtLimit, totalDebt, toMint) => {
 };
 
 /**
- * @deprecated use makeMetricsPublishKit
+ * @deprecated incompatible with durability; instead handle vstorage ephemerally on a durable PublishKit
  * @template T
  * @param {ERef<StorageNode>} storageNode
  * @param {ERef<Marshaller>} marshaller
@@ -119,6 +119,7 @@ harden(makeMetricsPublisherKit);
  */
 
 /**
+ * @deprecated incompatible with durability; instead handle vstorage ephemerally on a durable PublishKit
  * @template T
  * @param {ERef<StorageNode>} storageNode
  * @param {ERef<Marshaller>} marshaller

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -1,31 +1,26 @@
-import '@agoric/zoe/exported.js';
-
-import {
-  assertProposalShape,
-  makeRatioFromAmounts,
-  ceilMultiplyBy,
-  floorMultiplyBy,
-  atomicTransfer,
-} from '@agoric/zoe/src/contractSupport/index.js';
 import { AmountMath, AmountShape } from '@agoric/ertp';
 import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
+import { M, vivifyFarClassKit } from '@agoric/vat-data';
 import {
-  defineDurableFarClassKit,
-  M,
-  makeKindHandle,
-  pickFacet,
-} from '@agoric/vat-data';
+  assertProposalShape,
+  atomicTransfer,
+  ceilMultiplyBy,
+  floorMultiplyBy,
+  makeRatioFromAmounts,
+} from '@agoric/zoe/src/contractSupport/index.js';
 import { SeatShape } from '@agoric/zoe/src/typeGuards.js';
-import { makeTracer } from '../makeTracer.js';
-import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
-import { makeVaultKit } from './vaultKit.js';
 import {
   addSubtract,
   assertOnlyKeys,
   makeEphemeraProvider,
   stageDelta,
 } from '../contractSupport.js';
+import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
+import { makeTracer } from '../makeTracer.js';
 import { UnguardedHelperI } from '../typeGuards.js';
+import { vivifyVaultKit } from './vaultKit.js';
+
+import '@agoric/zoe/exported.js';
 
 const { quote: q, Fail } = assert;
 
@@ -217,619 +212,638 @@ export const VaultI = M.interface('Vault', {
   makeTransferInvitation: M.call().returns(M.promise()),
 });
 
-const vaultKind = makeKindHandle('Vault');
-const makeVaultBase = defineDurableFarClassKit(
-  vaultKind,
-  {
-    helper: UnguardedHelperI,
-    self: VaultI,
-  },
-  initState,
-  {
-    helper: {
-      // #region Computed constants
-      collateralBrand() {
-        return this.state.manager.getCollateralBrand();
-      },
-      debtBrand() {
-        return this.state.manager.getDebtBrand();
-      },
+export const vivifyVault = baggage => {
+  const makeVaultKit = vivifyVaultKit(baggage);
 
-      emptyCollateral() {
-        return AmountMath.makeEmpty(this.facets.helper.collateralBrand());
-      },
-      emptyDebt() {
-        return AmountMath.makeEmpty(this.facets.helper.debtBrand());
-      },
-      // #endregion
+  // TODO find a way to not have to indent a level deeper than defineDurableFarClassKit does
+  const maker = vivifyFarClassKit(
+    baggage,
+    'Vault',
+    {
+      helper: UnguardedHelperI,
+      self: VaultI,
+    },
+    initState,
+    {
+      helper: {
+        // #region Computed constants
+        collateralBrand() {
+          return this.state.manager.getCollateralBrand();
+        },
+        debtBrand() {
+          return this.state.manager.getDebtBrand();
+        },
 
-      // #region Phase logic
-      /**
-       * @param {VaultPhase} newPhase
-       */
-      assignPhase(newPhase) {
-        const { state } = this;
+        emptyCollateral() {
+          return AmountMath.makeEmpty(this.facets.helper.collateralBrand());
+        },
+        emptyDebt() {
+          return AmountMath.makeEmpty(this.facets.helper.debtBrand());
+        },
+        // #endregion
 
-        const { phase } = state;
-        const validNewPhases = validTransitions[phase];
-        validNewPhases.includes(newPhase) ||
-          Fail`Vault cannot transition from ${q(phase)} to ${q(newPhase)}`;
-        state.phase = newPhase;
-      },
+        // #region Phase logic
+        /**
+         * @param {VaultPhase} newPhase
+         */
+        assignPhase(newPhase) {
+          const { state } = this;
 
-      assertActive() {
-        const { phase } = this.state;
-        assert(phase === Phase.ACTIVE);
-      },
+          const { phase } = state;
+          const validNewPhases = validTransitions[phase];
+          validNewPhases.includes(newPhase) ||
+            Fail`Vault cannot transition from ${q(phase)} to ${q(newPhase)}`;
+          state.phase = newPhase;
+        },
 
-      assertCloseable() {
-        const { phase } = this.state;
-        phase === Phase.ACTIVE ||
-          phase === Phase.LIQUIDATED ||
-          Fail`to be closed a vault must be active or liquidated, not ${phase}`;
-      },
-      // #endregion
+        assertActive() {
+          const { phase } = this.state;
+          assert(phase === Phase.ACTIVE);
+        },
 
-      /**
-       * Called whenever the debt is paid or created through a transaction,
-       * but not for interest accrual.
-       *
-       * @param {Amount<'nat'>} newDebt - principal and all accrued interest
-       */
-      updateDebtSnapshot(newDebt) {
-        const { state } = this;
+        assertCloseable() {
+          const { phase } = this.state;
+          phase === Phase.ACTIVE ||
+            phase === Phase.LIQUIDATED ||
+            Fail`to be closed a vault must be active or liquidated, not ${phase}`;
+        },
+        // #endregion
 
-        // update local state
-        state.debtSnapshot = newDebt;
-        state.interestSnapshot = state.manager.getCompoundedInterest();
-      },
+        /**
+         * Called whenever the debt is paid or created through a transaction,
+         * but not for interest accrual.
+         *
+         * @param {Amount<'nat'>} newDebt - principal and all accrued interest
+         */
+        updateDebtSnapshot(newDebt) {
+          const { state } = this;
 
-      /**
-       * Update the debt balance and propagate upwards to
-       * maintain aggregate debt and liquidation order.
-       *
-       * @param {NormalizedDebt} oldDebtNormalized - prior principal and all accrued interest, normalized to the launch of the vaultManager
-       * @param {Amount<'nat'>} oldCollateral - actual collateral
-       * @param {Amount<'nat'>} newDebtActual - actual principal and all accrued interest
-       */
-      updateDebtAccounting(oldDebtNormalized, oldCollateral, newDebtActual) {
-        const { state, facets } = this;
-        const { helper } = facets;
-        helper.updateDebtSnapshot(newDebtActual);
-        // notify manager so it can notify and clean up as appropriate
-        state.manager.handleBalanceChange(
-          oldDebtNormalized,
-          oldCollateral,
-          state.idInManager,
-          state.phase,
-          facets.self,
-        );
-      },
+          // update local state
+          state.debtSnapshot = newDebt;
+          state.interestSnapshot = state.manager.getCompoundedInterest();
+        },
 
-      /**
-       *
-       * @param {ZCFSeat} seat
-       */
-      getCollateralAllocated(seat) {
-        return seat.getAmountAllocated(
-          'Collateral',
-          this.facets.helper.collateralBrand(),
-        );
-      },
-      getMintedAllocated(seat) {
-        return seat.getAmountAllocated(
-          'Minted',
-          this.facets.helper.debtBrand(),
-        );
-      },
+        /**
+         * Update the debt balance and propagate upwards to
+         * maintain aggregate debt and liquidation order.
+         *
+         * @param {NormalizedDebt} oldDebtNormalized - prior principal and all accrued interest, normalized to the launch of the vaultManager
+         * @param {Amount<'nat'>} oldCollateral - actual collateral
+         * @param {Amount<'nat'>} newDebtActual - actual principal and all accrued interest
+         */
+        updateDebtAccounting(oldDebtNormalized, oldCollateral, newDebtActual) {
+          const { state, facets } = this;
+          const { helper } = facets;
+          helper.updateDebtSnapshot(newDebtActual);
+          // notify manager so it can notify and clean up as appropriate
+          state.manager.handleBalanceChange(
+            oldDebtNormalized,
+            oldCollateral,
+            state.idInManager,
+            state.phase,
+            facets.self,
+          );
+        },
 
-      assertVaultHoldsNoMinted() {
-        const { state, facets } = this;
-        const { vaultSeat } = state;
-        AmountMath.isEmpty(facets.helper.getMintedAllocated(vaultSeat)) ||
-          Fail`Vault should be empty of Minted`;
-      },
+        /**
+         *
+         * @param {ZCFSeat} seat
+         */
+        getCollateralAllocated(seat) {
+          return seat.getAmountAllocated(
+            'Collateral',
+            this.facets.helper.collateralBrand(),
+          );
+        },
+        getMintedAllocated(seat) {
+          return seat.getAmountAllocated(
+            'Minted',
+            this.facets.helper.debtBrand(),
+          );
+        },
 
-      /**
-       *
-       * @param {Amount<'nat'>} collateralAmount
-       * @param {Amount<'nat'>} proposedRunDebt
-       */
-      async assertSufficientCollateral(collateralAmount, proposedRunDebt) {
-        const { state, facets } = this;
-        const maxRun = await state.manager.maxDebtFor(collateralAmount);
-        AmountMath.isGTE(maxRun, proposedRunDebt, facets.helper.debtBrand()) ||
-          Fail`Requested ${q(proposedRunDebt)} exceeds max ${q(maxRun)} for ${q(
-            collateralAmount,
-          )} collateral`;
-      },
+        assertVaultHoldsNoMinted() {
+          const { state, facets } = this;
+          const { vaultSeat } = state;
+          AmountMath.isEmpty(facets.helper.getMintedAllocated(vaultSeat)) ||
+            Fail`Vault should be empty of Minted`;
+        },
 
-      /**
-       *
-       * @param {HolderPhase} newPhase
-       */
-      getStateSnapshot(newPhase) {
-        const { state, facets } = this;
+        /**
+         *
+         * @param {Amount<'nat'>} collateralAmount
+         * @param {Amount<'nat'>} proposedRunDebt
+         */
+        async assertSufficientCollateral(collateralAmount, proposedRunDebt) {
+          const { state, facets } = this;
+          const maxRun = await state.manager.maxDebtFor(collateralAmount);
+          AmountMath.isGTE(
+            maxRun,
+            proposedRunDebt,
+            facets.helper.debtBrand(),
+          ) ||
+            Fail`Requested ${q(proposedRunDebt)} exceeds max ${q(
+              maxRun,
+            )} for ${q(collateralAmount)} collateral`;
+        },
 
-        const { debtSnapshot: debt, interestSnapshot: interest } = state;
-        /** @type {VaultNotification} */
-        return harden({
-          debtSnapshot: { debt, interest },
-          locked: facets.self.getCollateralAmount(),
-          // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
-          // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
-          vaultState: newPhase,
-        });
-      },
+        /**
+         *
+         * @param {HolderPhase} newPhase
+         */
+        getStateSnapshot(newPhase) {
+          const { state, facets } = this;
 
-      /**
-       * call this whenever anything changes!
-       */
-      updateUiState() {
-        const { state, facets } = this;
-        const ephemera = provideEphemera(state.idInManager);
-        const { outerUpdater } = ephemera;
-        if (!outerUpdater) {
-          // It's not an error to change to liquidating during transfer
-          return;
-        }
-        const { phase } = state;
-        const uiState = facets.helper.getStateSnapshot(phase);
-        trace('updateUiState', state.idInManager, uiState);
+          const { debtSnapshot: debt, interestSnapshot: interest } = state;
+          /** @type {VaultNotification} */
+          return harden({
+            debtSnapshot: { debt, interest },
+            locked: facets.self.getCollateralAmount(),
+            // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
+            // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
+            vaultState: newPhase,
+          });
+        },
 
-        switch (phase) {
-          case Phase.ACTIVE:
-          case Phase.LIQUIDATING:
-          case Phase.LIQUIDATED:
-            outerUpdater.publish(uiState);
-            break;
-          case Phase.CLOSED:
-            outerUpdater.finish(uiState);
-            ephemera.outerUpdater = null;
-            break;
-          default:
-            throw Error(`unreachable vault phase: ${phase}`);
-        }
-      },
+        /**
+         * call this whenever anything changes!
+         */
+        updateUiState() {
+          const { state, facets } = this;
+          const ephemera = provideEphemera(state.idInManager);
+          const { outerUpdater } = ephemera;
+          if (!outerUpdater) {
+            // It's not an error to change to liquidating during transfer
+            return;
+          }
+          const { phase } = state;
+          const uiState = facets.helper.getStateSnapshot(phase);
+          trace('updateUiState', state.idInManager, uiState);
 
-      /**
-       * @param {ZCFSeat} seat
-       */
-      async closeHook(seat) {
-        const { state, facets } = this;
+          switch (phase) {
+            case Phase.ACTIVE:
+            case Phase.LIQUIDATING:
+            case Phase.LIQUIDATED:
+              outerUpdater.publish(uiState);
+              break;
+            case Phase.CLOSED:
+              outerUpdater.finish(uiState);
+              ephemera.outerUpdater = null;
+              break;
+            default:
+              throw Error(`unreachable vault phase: ${phase}`);
+          }
+        },
 
-        const { self, helper } = facets;
-        helper.assertCloseable();
-        const { phase, vaultSeat } = state;
-        const { zcf } = provideEphemera(state.idInManager);
+        /**
+         * @param {ZCFSeat} seat
+         */
+        async closeHook(seat) {
+          const { state, facets } = this;
 
-        // Held as keys for cleanup in the manager
-        const oldDebtNormalized = self.getNormalizedDebt();
-        const oldCollateral = self.getCollateralAmount();
+          const { self, helper } = facets;
+          helper.assertCloseable();
+          const { phase, vaultSeat } = state;
+          const { zcf } = provideEphemera(state.idInManager);
 
-        if (phase === Phase.ACTIVE) {
-          assertProposalShape(seat, {
-            give: { Minted: null },
+          // Held as keys for cleanup in the manager
+          const oldDebtNormalized = self.getNormalizedDebt();
+          const oldCollateral = self.getCollateralAmount();
+
+          if (phase === Phase.ACTIVE) {
+            assertProposalShape(seat, {
+              give: { Minted: null },
+            });
+
+            // you're paying off the debt, you get everything back.
+            const debt = self.getCurrentDebt();
+            const {
+              give: { Minted: given },
+            } = seat.getProposal();
+
+            // you must pay off the entire remainder but if you offer too much, we won't
+            // take more than you owe
+            AmountMath.isGTE(given, debt) ||
+              Fail`Offer ${given} is not sufficient to pay off debt ${debt}`;
+
+            // Return any overpayment
+            atomicTransfer(
+              zcf,
+              vaultSeat,
+              seat,
+              vaultSeat.getCurrentAllocation(),
+            );
+
+            state.manager.burnAndRecord(debt, seat);
+          } else if (phase === Phase.LIQUIDATED) {
+            // Simply reallocate vault assets to the offer seat.
+            // Don't take anything from the offer, even if vault is underwater.
+            // TODO verify that returning Minted here doesn't mess up debt limits
+
+            atomicTransfer(
+              zcf,
+              vaultSeat,
+              seat,
+              vaultSeat.getCurrentAllocation(),
+            );
+          } else {
+            throw new Error('only active and liquidated vaults can be closed');
+          }
+
+          seat.exit();
+          helper.assignPhase(Phase.CLOSED);
+          helper.updateDebtSnapshot(helper.emptyDebt());
+          helper.updateUiState();
+
+          helper.assertVaultHoldsNoMinted();
+          vaultSeat.exit();
+
+          state.manager.handleBalanceChange(
+            oldDebtNormalized,
+            oldCollateral,
+            state.idInManager,
+            state.phase,
+            facets.self,
+          );
+
+          return 'your loan is closed, thank you for your business';
+        },
+
+        /**
+         * Calculate the fee, the amount to mint and the resulting debt.
+         * The give and the want together reflect a delta, where typically
+         * one is zero because they come from the gave/want of an offer
+         * proposal. If the `want` is zero, the `fee` will also be zero,
+         * so the simple math works.
+         *
+         * @param {Amount<'nat'>} currentDebt
+         * @param {Amount<'nat'>} giveAmount
+         * @param {Amount<'nat'>} wantAmount
+         */
+        loanFee(currentDebt, giveAmount, wantAmount) {
+          const { state } = this;
+
+          const fee = ceilMultiplyBy(
+            wantAmount,
+            state.manager.getGovernedParams().getLoanFee(),
+          );
+          const toMint = AmountMath.add(wantAmount, fee);
+          const newDebt = addSubtract(currentDebt, toMint, giveAmount);
+          return { newDebt, toMint, fee };
+        },
+
+        /**
+         * Adjust principal and collateral (atomically for offer safety)
+         *
+         * @param {ZCFSeat} clientSeat
+         * @returns {Promise<string>} success message
+         */
+        async adjustBalancesHook(clientSeat) {
+          const { state, facets } = this;
+
+          const { self, helper } = facets;
+          const ephemera = provideEphemera(state.idInManager);
+          const { outerUpdater: updaterPre } = ephemera;
+          const { vaultSeat } = state;
+          const proposal = clientSeat.getProposal();
+          assertOnlyKeys(proposal, ['Collateral', 'Minted']);
+
+          const allEmpty = amounts => {
+            return amounts.every(a => AmountMath.isEmpty(a));
+          };
+
+          const normalizedDebtPre = self.getNormalizedDebt();
+          const collateralPre = helper.getCollateralAllocated(vaultSeat);
+
+          const giveColl = proposal.give.Collateral || helper.emptyCollateral();
+          const wantColl = proposal.want.Collateral || helper.emptyCollateral();
+
+          const newCollateralPre = addSubtract(
+            collateralPre,
+            giveColl,
+            wantColl,
+          );
+          // max debt supported by current Collateral as modified by proposal
+          const maxDebtPre = await state.manager.maxDebtFor(newCollateralPre);
+          updaterPre === ephemera.outerUpdater ||
+            Fail`Transfer during vault adjustment`;
+          helper.assertActive();
+
+          // After the `await`, we retrieve the vault's allocations again,
+          // so we can compare to the debt limit based on the new values.
+          const collateral = helper.getCollateralAllocated(vaultSeat);
+          const newCollateral = addSubtract(collateral, giveColl, wantColl);
+
+          const debt = self.getCurrentDebt();
+          const giveMinted = AmountMath.min(
+            proposal.give.Minted || helper.emptyDebt(),
+            debt,
+          );
+          const wantMinted = proposal.want.Minted || helper.emptyDebt();
+          if (allEmpty([giveColl, giveMinted, wantColl, wantMinted])) {
+            clientSeat.exit();
+            return 'no transaction, as requested';
+          }
+
+          // Calculate the fee, the amount to mint and the resulting debt. We'll
+          // verify that the target debt doesn't violate the collateralization ratio,
+          // then mint, reallocate, and burn.
+          const { newDebt, fee, toMint } = helper.loanFee(
+            debt,
+            giveMinted,
+            wantMinted,
+          );
+
+          trace('adjustBalancesHook', state.idInManager, {
+            newCollateralPre,
+            newCollateral,
+            fee,
+            toMint,
+            newDebt,
           });
 
-          // you're paying off the debt, you get everything back.
-          const debt = self.getCurrentDebt();
+          if (
+            checkRestart(newCollateralPre, maxDebtPre, newCollateral, newDebt)
+          ) {
+            return helper.adjustBalancesHook(clientSeat);
+          }
+
+          stageDelta(clientSeat, vaultSeat, giveColl, wantColl, 'Collateral');
+          // `wantMinted` is allocated in the reallocate and mint operation, and so not here
+          stageDelta(
+            clientSeat,
+            vaultSeat,
+            giveMinted,
+            helper.emptyDebt(),
+            'Minted',
+          );
+
+          /** @type {Array<ZCFSeat>} */
+          const vaultSeatOpt = allEmpty([giveColl, giveMinted, wantColl])
+            ? []
+            : [vaultSeat];
+          state.manager.mintAndReallocate(
+            toMint,
+            fee,
+            clientSeat,
+            ...vaultSeatOpt,
+          );
+
+          // parent needs to know about the change in debt
+          helper.updateDebtAccounting(
+            normalizedDebtPre,
+            collateralPre,
+            newDebt,
+          );
+          state.manager.burnAndRecord(giveMinted, vaultSeat);
+          helper.assertVaultHoldsNoMinted();
+
+          helper.updateUiState();
+          clientSeat.exit();
+          return 'We have adjusted your balances, thank you for your business';
+        },
+
+        /**
+         *
+         * @param {ZCFSeat} seat
+         * @returns {VaultKit}
+         */
+        makeTransferInvitationHook(seat) {
+          const { state, facets } = this;
+
+          const { self, helper } = facets;
+          helper.assertCloseable();
+          seat.exit();
+
+          const ephemera = provideEphemera(state.idInManager);
+
+          // eslint-disable-next-line no-use-before-define
+          const vaultKit = makeVaultKit(
+            self,
+            ephemera.storageNode,
+            ephemera.marshaller,
+            state.manager.getAssetSubscriber(),
+          );
+          ephemera.outerUpdater = vaultKit.vaultUpdater;
+          helper.updateUiState();
+
+          return vaultKit;
+        },
+      },
+      self: {
+        getVaultSeat() {
+          return this.state.vaultSeat;
+        },
+
+        /**
+         * @param {ZCFSeat} seat
+         * @param {ERef<StorageNode>} storageNode
+         */
+        async initVaultKit(seat, storageNode) {
+          const { state, facets } = this;
+
+          const ephemera = provideEphemera(state.idInManager);
+
+          const { self, helper } = facets;
+
+          const normalizedDebtPre = self.getNormalizedDebt();
+          const actualDebtPre = self.getCurrentDebt();
+          (AmountMath.isEmpty(normalizedDebtPre) &&
+            AmountMath.isEmpty(actualDebtPre)) ||
+            Fail`vault must be empty initially`;
+
+          const collateralPre = self.getCollateralAmount();
+          trace('initVaultKit start: collateral', state.idInManager, {
+            actualDebtPre,
+            collateralPre,
+          });
+
+          // get the payout to provide access to the collateral if the
+          // contract abandons
           const {
-            give: { Minted: given },
+            give: { Collateral: giveCollateral },
+            want: { Minted: wantMinted },
           } = seat.getProposal();
 
-          // you must pay off the entire remainder but if you offer too much, we won't
-          // take more than you owe
-          AmountMath.isGTE(given, debt) ||
-            Fail`Offer ${given} is not sufficient to pay off debt ${debt}`;
-
-          // Return any overpayment
-          atomicTransfer(
-            zcf,
-            vaultSeat,
-            seat,
-            vaultSeat.getCurrentAllocation(),
+          const {
+            newDebt: newDebtPre,
+            fee,
+            toMint,
+          } = helper.loanFee(actualDebtPre, helper.emptyDebt(), wantMinted);
+          !AmountMath.isEmpty(fee) ||
+            Fail`loan requested (${wantMinted}) is too small; cannot accrue interest`;
+          AmountMath.isEqual(newDebtPre, toMint) ||
+            Fail`fee mismatch for vault`;
+          trace(
+            'initVault',
+            state.idInManager,
+            { wantedRun: wantMinted, fee },
+            self.getCollateralAmount(),
           );
 
-          state.manager.burnAndRecord(debt, seat);
-        } else if (phase === Phase.LIQUIDATED) {
-          // Simply reallocate vault assets to the offer seat.
-          // Don't take anything from the offer, even if vault is underwater.
-          // TODO verify that returning Minted here doesn't mess up debt limits
+          await helper.assertSufficientCollateral(giveCollateral, newDebtPre);
 
-          atomicTransfer(
-            zcf,
-            vaultSeat,
-            seat,
-            vaultSeat.getCurrentAllocation(),
+          const { vaultSeat } = state;
+          vaultSeat.incrementBy(
+            seat.decrementBy(harden({ Collateral: giveCollateral })),
           );
-        } else {
-          throw new Error('only active and liquidated vaults can be closed');
-        }
+          state.manager.mintAndReallocate(toMint, fee, seat, vaultSeat);
+          helper.updateDebtAccounting(
+            normalizedDebtPre,
+            collateralPre,
+            newDebtPre,
+          );
 
-        seat.exit();
-        helper.assignPhase(Phase.CLOSED);
-        helper.updateDebtSnapshot(helper.emptyDebt());
-        helper.updateUiState();
+          const vaultKit = makeVaultKit(
+            self,
+            storageNode,
+            ephemera.marshaller,
+            state.manager.getAssetSubscriber(),
+          );
+          ephemera.outerUpdater = vaultKit.vaultUpdater;
+          helper.updateUiState();
+          return vaultKit;
+        },
 
-        helper.assertVaultHoldsNoMinted();
-        vaultSeat.exit();
+        /**
+         * Called by manager at start of liquidation.
+         */
+        liquidating() {
+          const { facets } = this;
 
-        state.manager.handleBalanceChange(
-          oldDebtNormalized,
-          oldCollateral,
-          state.idInManager,
-          state.phase,
-          facets.self,
-        );
+          const { helper } = facets;
+          helper.assignPhase(Phase.LIQUIDATING);
+          helper.updateUiState();
+        },
 
-        return 'your loan is closed, thank you for your business';
-      },
+        /**
+         * Called by manager at end of liquidation, at which point all debts have been
+         * covered.
+         */
+        liquidated() {
+          const { facets } = this;
 
-      /**
-       * Calculate the fee, the amount to mint and the resulting debt.
-       * The give and the want together reflect a delta, where typically
-       * one is zero because they come from the gave/want of an offer
-       * proposal. If the `want` is zero, the `fee` will also be zero,
-       * so the simple math works.
-       *
-       * @param {Amount<'nat'>} currentDebt
-       * @param {Amount<'nat'>} giveAmount
-       * @param {Amount<'nat'>} wantAmount
-       */
-      loanFee(currentDebt, giveAmount, wantAmount) {
-        const { state } = this;
+          const { helper } = facets;
+          helper.updateDebtSnapshot(
+            // liquidated vaults retain no debt
+            AmountMath.makeEmpty(helper.debtBrand()),
+          );
 
-        const fee = ceilMultiplyBy(
-          wantAmount,
-          state.manager.getGovernedParams().getLoanFee(),
-        );
-        const toMint = AmountMath.add(wantAmount, fee);
-        const newDebt = addSubtract(currentDebt, toMint, giveAmount);
-        return { newDebt, toMint, fee };
-      },
+          helper.assignPhase(Phase.LIQUIDATED);
+          helper.updateUiState();
+        },
 
-      /**
-       * Adjust principal and collateral (atomically for offer safety)
-       *
-       * @param {ZCFSeat} clientSeat
-       * @returns {Promise<string>} success message
-       */
-      async adjustBalancesHook(clientSeat) {
-        const { state, facets } = this;
+        makeAdjustBalancesInvitation() {
+          const { state, facets } = this;
+          const { helper } = facets;
+          helper.assertActive();
+          const { zcf } = provideEphemera(state.idInManager);
+          return zcf.makeInvitation(
+            seat => helper.adjustBalancesHook(seat),
+            'AdjustBalances',
+          );
+        },
 
-        const { self, helper } = facets;
-        const ephemera = provideEphemera(state.idInManager);
-        const { outerUpdater: updaterPre } = ephemera;
-        const { vaultSeat } = state;
-        const proposal = clientSeat.getProposal();
-        assertOnlyKeys(proposal, ['Collateral', 'Minted']);
+        makeCloseInvitation() {
+          const { state, facets } = this;
+          const { helper } = facets;
+          helper.assertCloseable();
+          const { zcf } = provideEphemera(state.idInManager);
+          return zcf.makeInvitation(
+            seat => helper.closeHook(seat),
+            'CloseVault',
+          );
+        },
 
-        const allEmpty = amounts => {
-          return amounts.every(a => AmountMath.isEmpty(a));
-        };
+        /**
+         * @returns {Promise<Invitation>}
+         */
+        makeTransferInvitation() {
+          const { state, facets } = this;
+          const ephemera = provideEphemera(state.idInManager);
+          const { outerUpdater } = ephemera;
+          const { self, helper } = facets;
+          // Bring the debt snapshot current for the final report before transfer
+          helper.updateDebtSnapshot(self.getCurrentDebt());
+          const {
+            debtSnapshot: debt,
+            interestSnapshot: interest,
+            phase,
+          } = state;
+          if (outerUpdater) {
+            outerUpdater.finish(helper.getStateSnapshot(Phase.TRANSFER));
+            ephemera.outerUpdater = null;
+          }
+          const transferState = {
+            debtSnapshot: { debt, interest },
+            locked: self.getCollateralAmount(),
+            vaultState: phase,
+          };
+          const { zcf } = provideEphemera(state.idInManager);
+          return zcf.makeInvitation(
+            seat => helper.makeTransferInvitationHook(seat),
+            'TransferVault',
+            transferState,
+          );
+        },
 
-        const normalizedDebtPre = self.getNormalizedDebt();
-        const collateralPre = helper.getCollateralAllocated(vaultSeat);
+        // for status/debugging
 
-        const giveColl = proposal.give.Collateral || helper.emptyCollateral();
-        const wantColl = proposal.want.Collateral || helper.emptyCollateral();
+        /**
+         *
+         * @returns {Amount<'nat'>}
+         */
+        getCollateralAmount() {
+          const { state, facets } = this;
+          const { vaultSeat } = state;
+          const { helper } = facets;
+          // getCollateralAllocated would return final allocations
+          return vaultSeat.hasExited()
+            ? helper.emptyCollateral()
+            : helper.getCollateralAllocated(vaultSeat);
+        },
 
-        const newCollateralPre = addSubtract(collateralPre, giveColl, wantColl);
-        // max debt supported by current Collateral as modified by proposal
-        const maxDebtPre = await state.manager.maxDebtFor(newCollateralPre);
-        updaterPre === ephemera.outerUpdater ||
-          Fail`Transfer during vault adjustment`;
-        helper.assertActive();
+        /**
+         * The actual current debt, including accrued interest.
+         *
+         * This looks like a simple getter but it does a lot of the heavy lifting for
+         * interest accrual. Rather than updating all records when interest accrues,
+         * the vault manager updates just its rolling compounded interest. Here we
+         * calculate what the current debt is given what's recorded in this vault and
+         * what interest has compounded since this vault record was written.
+         *
+         * @see getNormalizedDebt
+         *
+         * @returns {Amount<'nat'>}
+         */
+        getCurrentDebt() {
+          const { state } = this;
+          return calculateCurrentDebt(
+            state.debtSnapshot,
+            state.interestSnapshot,
+            state.manager.getCompoundedInterest(),
+          );
+        },
 
-        // After the `await`, we retrieve the vault's allocations again,
-        // so we can compare to the debt limit based on the new values.
-        const collateral = helper.getCollateralAllocated(vaultSeat);
-        const newCollateral = addSubtract(collateral, giveColl, wantColl);
-
-        const debt = self.getCurrentDebt();
-        const giveMinted = AmountMath.min(
-          proposal.give.Minted || helper.emptyDebt(),
-          debt,
-        );
-        const wantMinted = proposal.want.Minted || helper.emptyDebt();
-        if (allEmpty([giveColl, giveMinted, wantColl, wantMinted])) {
-          clientSeat.exit();
-          return 'no transaction, as requested';
-        }
-
-        // Calculate the fee, the amount to mint and the resulting debt. We'll
-        // verify that the target debt doesn't violate the collateralization ratio,
-        // then mint, reallocate, and burn.
-        const { newDebt, fee, toMint } = helper.loanFee(
-          debt,
-          giveMinted,
-          wantMinted,
-        );
-
-        trace('adjustBalancesHook', state.idInManager, {
-          newCollateralPre,
-          newCollateral,
-          fee,
-          toMint,
-          newDebt,
-        });
-
-        if (
-          checkRestart(newCollateralPre, maxDebtPre, newCollateral, newDebt)
-        ) {
-          return helper.adjustBalancesHook(clientSeat);
-        }
-
-        stageDelta(clientSeat, vaultSeat, giveColl, wantColl, 'Collateral');
-        // `wantMinted` is allocated in the reallocate and mint operation, and so not here
-        stageDelta(
-          clientSeat,
-          vaultSeat,
-          giveMinted,
-          helper.emptyDebt(),
-          'Minted',
-        );
-
-        /** @type {Array<ZCFSeat>} */
-        const vaultSeatOpt = allEmpty([giveColl, giveMinted, wantColl])
-          ? []
-          : [vaultSeat];
-        state.manager.mintAndReallocate(
-          toMint,
-          fee,
-          clientSeat,
-          ...vaultSeatOpt,
-        );
-
-        // parent needs to know about the change in debt
-        helper.updateDebtAccounting(normalizedDebtPre, collateralPre, newDebt);
-        state.manager.burnAndRecord(giveMinted, vaultSeat);
-        helper.assertVaultHoldsNoMinted();
-
-        helper.updateUiState();
-        clientSeat.exit();
-        return 'We have adjusted your balances, thank you for your business';
-      },
-
-      /**
-       *
-       * @param {ZCFSeat} seat
-       * @returns {VaultKit}
-       */
-      makeTransferInvitationHook(seat) {
-        const { state, facets } = this;
-
-        const { self, helper } = facets;
-        helper.assertCloseable();
-        seat.exit();
-
-        const ephemera = provideEphemera(state.idInManager);
-
-        // eslint-disable-next-line no-use-before-define
-        const vaultKit = makeVaultKit(
-          self,
-          ephemera.storageNode,
-          ephemera.marshaller,
-          state.manager.getAssetSubscriber(),
-        );
-        ephemera.outerUpdater = vaultKit.vaultUpdater;
-        helper.updateUiState();
-
-        return vaultKit;
+        /**
+         * The normalization puts all debts on a common time-independent scale since
+         * the launch of this vault manager. This allows the manager to order vaults
+         * by their debt-to-collateral ratios without having to mutate the debts as
+         * the interest accrues.
+         *
+         * @see getActualDebAmount
+         *
+         * @returns {import('./storeUtils.js').NormalizedDebt} as if the vault was open at the launch of this manager, before any interest accrued
+         */
+        getNormalizedDebt() {
+          const { state } = this;
+          // @ts-expect-error cast
+          return reverseInterest(state.debtSnapshot, state.interestSnapshot);
+        },
       },
     },
-    self: {
-      getVaultSeat() {
-        return this.state.vaultSeat;
-      },
+  );
+  return maker;
+};
 
-      /**
-       * @param {ZCFSeat} seat
-       * @param {ERef<StorageNode>} storageNode
-       */
-      async initVaultKit(seat, storageNode) {
-        const { state, facets } = this;
-
-        const ephemera = provideEphemera(state.idInManager);
-
-        const { self, helper } = facets;
-
-        const normalizedDebtPre = self.getNormalizedDebt();
-        const actualDebtPre = self.getCurrentDebt();
-        (AmountMath.isEmpty(normalizedDebtPre) &&
-          AmountMath.isEmpty(actualDebtPre)) ||
-          Fail`vault must be empty initially`;
-
-        const collateralPre = self.getCollateralAmount();
-        trace('initVaultKit start: collateral', state.idInManager, {
-          actualDebtPre,
-          collateralPre,
-        });
-
-        // get the payout to provide access to the collateral if the
-        // contract abandons
-        const {
-          give: { Collateral: giveCollateral },
-          want: { Minted: wantMinted },
-        } = seat.getProposal();
-
-        const {
-          newDebt: newDebtPre,
-          fee,
-          toMint,
-        } = helper.loanFee(actualDebtPre, helper.emptyDebt(), wantMinted);
-        !AmountMath.isEmpty(fee) ||
-          Fail`loan requested (${wantMinted}) is too small; cannot accrue interest`;
-        AmountMath.isEqual(newDebtPre, toMint) || Fail`fee mismatch for vault`;
-        trace(
-          'initVault',
-          state.idInManager,
-          { wantedRun: wantMinted, fee },
-          self.getCollateralAmount(),
-        );
-
-        await helper.assertSufficientCollateral(giveCollateral, newDebtPre);
-
-        const { vaultSeat } = state;
-        vaultSeat.incrementBy(
-          seat.decrementBy(harden({ Collateral: giveCollateral })),
-        );
-        state.manager.mintAndReallocate(toMint, fee, seat, vaultSeat);
-        helper.updateDebtAccounting(
-          normalizedDebtPre,
-          collateralPre,
-          newDebtPre,
-        );
-
-        const vaultKit = makeVaultKit(
-          self,
-          storageNode,
-          ephemera.marshaller,
-          state.manager.getAssetSubscriber(),
-        );
-        ephemera.outerUpdater = vaultKit.vaultUpdater;
-        helper.updateUiState();
-        return vaultKit;
-      },
-
-      /**
-       * Called by manager at start of liquidation.
-       */
-      liquidating() {
-        const { facets } = this;
-
-        const { helper } = facets;
-        helper.assignPhase(Phase.LIQUIDATING);
-        helper.updateUiState();
-      },
-
-      /**
-       * Called by manager at end of liquidation, at which point all debts have been
-       * covered.
-       */
-      liquidated() {
-        const { facets } = this;
-
-        const { helper } = facets;
-        helper.updateDebtSnapshot(
-          // liquidated vaults retain no debt
-          AmountMath.makeEmpty(helper.debtBrand()),
-        );
-
-        helper.assignPhase(Phase.LIQUIDATED);
-        helper.updateUiState();
-      },
-
-      makeAdjustBalancesInvitation() {
-        const { state, facets } = this;
-        const { helper } = facets;
-        helper.assertActive();
-        const { zcf } = provideEphemera(state.idInManager);
-        return zcf.makeInvitation(
-          seat => helper.adjustBalancesHook(seat),
-          'AdjustBalances',
-        );
-      },
-
-      makeCloseInvitation() {
-        const { state, facets } = this;
-        const { helper } = facets;
-        helper.assertCloseable();
-        const { zcf } = provideEphemera(state.idInManager);
-        return zcf.makeInvitation(seat => helper.closeHook(seat), 'CloseVault');
-      },
-
-      /**
-       * @returns {Promise<Invitation>}
-       */
-      makeTransferInvitation() {
-        const { state, facets } = this;
-        const ephemera = provideEphemera(state.idInManager);
-        const { outerUpdater } = ephemera;
-        const { self, helper } = facets;
-        // Bring the debt snapshot current for the final report before transfer
-        helper.updateDebtSnapshot(self.getCurrentDebt());
-        const { debtSnapshot: debt, interestSnapshot: interest, phase } = state;
-        if (outerUpdater) {
-          outerUpdater.finish(helper.getStateSnapshot(Phase.TRANSFER));
-          ephemera.outerUpdater = null;
-        }
-        const transferState = {
-          debtSnapshot: { debt, interest },
-          locked: self.getCollateralAmount(),
-          vaultState: phase,
-        };
-        const { zcf } = provideEphemera(state.idInManager);
-        return zcf.makeInvitation(
-          seat => helper.makeTransferInvitationHook(seat),
-          'TransferVault',
-          transferState,
-        );
-      },
-
-      // for status/debugging
-
-      /**
-       *
-       * @returns {Amount<'nat'>}
-       */
-      getCollateralAmount() {
-        const { state, facets } = this;
-        const { vaultSeat } = state;
-        const { helper } = facets;
-        // getCollateralAllocated would return final allocations
-        return vaultSeat.hasExited()
-          ? helper.emptyCollateral()
-          : helper.getCollateralAllocated(vaultSeat);
-      },
-
-      /**
-       * The actual current debt, including accrued interest.
-       *
-       * This looks like a simple getter but it does a lot of the heavy lifting for
-       * interest accrual. Rather than updating all records when interest accrues,
-       * the vault manager updates just its rolling compounded interest. Here we
-       * calculate what the current debt is given what's recorded in this vault and
-       * what interest has compounded since this vault record was written.
-       *
-       * @see getNormalizedDebt
-       *
-       * @returns {Amount<'nat'>}
-       */
-      getCurrentDebt() {
-        const { state } = this;
-        return calculateCurrentDebt(
-          state.debtSnapshot,
-          state.interestSnapshot,
-          state.manager.getCompoundedInterest(),
-        );
-      },
-
-      /**
-       * The normalization puts all debts on a common time-independent scale since
-       * the launch of this vault manager. This allows the manager to order vaults
-       * by their debt-to-collateral ratios without having to mutate the debts as
-       * the interest accrues.
-       *
-       * @see getActualDebAmount
-       *
-       * @returns {import('./storeUtils.js').NormalizedDebt} as if the vault was open at the launch of this manager, before any interest accrued
-       */
-      getNormalizedDebt() {
-        const { state } = this;
-        // @ts-expect-error cast
-        return reverseInterest(state.debtSnapshot, state.interestSnapshot);
-      },
-    },
-  },
-);
-
-/**
- * @param {ZCF} zcf
- * @param {VaultManager} manager
- * @param {VaultId} idInManager
- */
-export const makeVault = pickFacet(makeVaultBase, 'self');
-
-/** @typedef {ReturnType<typeof makeVault>} Vault */
+/** @typedef {ReturnType<ReturnType<typeof vivifyVault>>['self']} Vault */

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -2,119 +2,129 @@
  * @file Use-object for the owner of a vault
  */
 import { AmountShape } from '@agoric/ertp';
-import { makeStoredPublishKit, SubscriberShape } from '@agoric/notifier';
-import { defineDurableFarClassKit, M, makeKindHandle } from '@agoric/vat-data';
+import {
+  makeStoredSubscriber,
+  SubscriberShape,
+  vivifyDurablePublishKit,
+} from '@agoric/notifier';
+import { M, vivifyFarClassKit } from '@agoric/vat-data';
 import { makeEphemeraProvider } from '../contractSupport.js';
+import { UnguardedHelperI } from '../typeGuards.js';
 
 const { Fail } = assert;
 
-// XXX durable key to an ephemeral object
-// UNTIL https://github.com/Agoric/agoric-sdk/issues/4567
-let holderId = 0n;
-
 /**
- * @type {(key: bigint) => {
- * publisher: StoredPublishKit<VaultNotification>['publisher'],
- * subscriber: StoredPublishKit<VaultNotification>['subscriber'],
+ * Ephemera are the elements of state that cannot (or need not) be durable.
+ *
+ * @type {(durableSubscriber: Subscriber<VaultNotification>) => {
+ * storedSubscriber: StoredSubscriber<VaultNotification>,
  * }} */
 // @ts-expect-error not yet defined
 const provideEphemera = makeEphemeraProvider(() => ({}));
 
 /**
  * @typedef {{
- * holderId: bigint,
+ * publisher: PublishKit<VaultNotification>['publisher'],
+ * subscriber: PublishKit<VaultNotification>['subscriber'],
  * vault: Vault | null,
  * }} State
  */
 
+const HolderI = M.interface('holder', {
+  getCollateralAmount: M.call().returns(AmountShape),
+  getCurrentDebt: M.call().returns(AmountShape),
+  getNormalizedDebt: M.call().returns(AmountShape),
+  getSubscriber: M.call().returns(SubscriberShape),
+  makeAdjustBalancesInvitation: M.call().returns(M.promise()),
+  makeCloseInvitation: M.call().returns(M.promise()),
+  makeTransferInvitation: M.call().returns(M.promise()),
+});
 /**
  *
- * @param {Vault} vault
- * @param {ERef<StorageNode>} storageNode
- * @param {ERef<Marshaller>} marshaller
- * @returns {State}
+ * @param {import('@agoric/ertp').Baggage} baggage
  */
-const initState = (vault, storageNode, marshaller) => {
-  /** @type {StoredPublishKit<VaultNotification>} */
-  const { subscriber, publisher } = makeStoredPublishKit(
-    storageNode,
-    marshaller,
+export const vivifyVaultHolder = baggage => {
+  const makeVaultHolderPublishKit = vivifyDurablePublishKit(
+    baggage,
+    'Vault Holder publish kit',
   );
 
-  holderId += 1n;
-  const ephemera = provideEphemera(holderId);
-  // UNTIL https://github.com/Agoric/agoric-sdk/issues/4567
-  Object.assign(ephemera, { subscriber, publisher });
+  const makeVaultHolderKit = vivifyFarClassKit(
+    baggage,
+    'Vault Holder',
+    {
+      helper: UnguardedHelperI,
+      holder: HolderI,
+    },
+    /**
+     *
+     * @param {Vault} vault
+     * @param {ERef<StorageNode>} storageNode
+     * @param {ERef<Marshaller>} marshaller
+     * @returns {State}
+     */
+    (vault, storageNode, marshaller) => {
+      /** @type {PublishKit<VaultNotification>} */
+      const { subscriber, publisher } = makeVaultHolderPublishKit();
 
-  return { holderId, vault };
+      const ephemera = provideEphemera(subscriber);
+      ephemera.storedSubscriber = makeStoredSubscriber(
+        subscriber,
+        storageNode,
+        marshaller,
+      );
+
+      return { subscriber, publisher, vault };
+    },
+    {
+      helper: {
+        /**
+         * @throws if this holder no longer owns the vault
+         */
+        owned() {
+          const { vault } = this.state;
+          if (!vault) {
+            throw Fail`Using vault holder after transfer`;
+          }
+          return vault;
+        },
+        getUpdater() {
+          return this.state.publisher;
+        },
+      },
+      holder: {
+        /** @returns {StoredSubscriber<VaultNotification>} */
+        getSubscriber() {
+          const ephemera = provideEphemera(this.state.subscriber);
+          return ephemera.storedSubscriber;
+        },
+        makeAdjustBalancesInvitation() {
+          return this.facets.helper.owned().makeAdjustBalancesInvitation();
+        },
+        makeCloseInvitation() {
+          return this.facets.helper.owned().makeCloseInvitation();
+        },
+        /**
+         * Starting a transfer revokes the vault holder. The associated updater will
+         * get a special notification that the vault is being transferred.
+         */
+        makeTransferInvitation() {
+          const vault = this.facets.helper.owned();
+          this.state.vault = null;
+          return vault.makeTransferInvitation();
+        },
+        // for status/debugging
+        getCollateralAmount() {
+          return this.facets.helper.owned().getCollateralAmount();
+        },
+        getCurrentDebt() {
+          return this.facets.helper.owned().getCurrentDebt();
+        },
+        getNormalizedDebt() {
+          return this.facets.helper.owned().getNormalizedDebt();
+        },
+      },
+    },
+  );
+  return makeVaultHolderKit;
 };
-
-const helper = {
-  /**
-   * @throws if this holder no longer owns the vault
-   */
-  owned() {
-    const { vault } = this.state;
-    if (!vault) {
-      throw Fail`Using vault holder after transfer`;
-    }
-    return vault;
-  },
-  getUpdater() {
-    return provideEphemera(this.state.holderId).publisher;
-  },
-};
-
-const holder = {
-  getSubscriber() {
-    return provideEphemera(this.state.holderId).subscriber;
-  },
-  makeAdjustBalancesInvitation() {
-    return this.facets.helper.owned().makeAdjustBalancesInvitation();
-  },
-  makeCloseInvitation() {
-    return this.facets.helper.owned().makeCloseInvitation();
-  },
-  /**
-   * Starting a transfer revokes the vault holder. The associated updater will
-   * get a special notification that the vault is being transferred.
-   */
-  makeTransferInvitation() {
-    const vault = this.facets.helper.owned();
-    this.state.vault = null;
-    return vault.makeTransferInvitation();
-  },
-  // for status/debugging
-  getCollateralAmount() {
-    return this.facets.helper.owned().getCollateralAmount();
-  },
-  getCurrentDebt() {
-    return this.facets.helper.owned().getCurrentDebt();
-  },
-  getNormalizedDebt() {
-    return this.facets.helper.owned().getNormalizedDebt();
-  },
-};
-
-export const makeVaultHolder = defineDurableFarClassKit(
-  makeKindHandle('VaultHolder'),
-  {
-    helper: M.interface(
-      'helper',
-      // helper not exposed so guard not necessary
-      {},
-      { sloppy: true },
-    ),
-    holder: M.interface('holder', {
-      getCollateralAmount: M.call().returns(AmountShape),
-      getCurrentDebt: M.call().returns(AmountShape),
-      getNormalizedDebt: M.call().returns(AmountShape),
-      getSubscriber: M.call().returns(SubscriberShape),
-      makeAdjustBalancesInvitation: M.call().returns(M.promise()),
-      makeCloseInvitation: M.call().returns(M.promise()),
-      makeTransferInvitation: M.call().returns(M.promise()),
-    }),
-  },
-  initState,
-  { helper, holder },
-);

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -1,37 +1,36 @@
 import '@agoric/zoe/exported.js';
 import { Far } from '@endo/marshal';
-import { makeVaultHolder } from './vaultHolder.js';
+import { vivifyVaultHolder } from './vaultHolder.js';
 
-/**
- * Create a kit of utilities for use of the vault.
- *
- * @param {Vault} vault
- * @param {ERef<StorageNode>} storageNode
- * @param {ERef<Marshaller>} marshaller
- * @param {Subscriber<import('./vaultManager').AssetState>} assetSubscriber
- */
-export const makeVaultKit = (
-  vault,
-  storageNode,
-  marshaller,
-  assetSubscriber,
-) => {
-  const { holder, helper } = makeVaultHolder(vault, storageNode, marshaller);
-  const vaultKit = harden({
-    publicSubscribers: {
-      // XXX should come from manager directly https://github.com/Agoric/agoric-sdk/issues/5814
-      asset: assetSubscriber,
-      vault: holder.getSubscriber(),
-    },
-    invitationMakers: Far('invitation makers', {
-      AdjustBalances: holder.makeAdjustBalancesInvitation,
-      CloseVault: holder.makeCloseInvitation,
-      TransferVault: holder.makeTransferInvitation,
-    }),
-    vault: holder,
-    vaultUpdater: helper.getUpdater(),
-  });
-  return vaultKit;
+export const vivifyVaultKit = baggage => {
+  const makeVaultHolder = vivifyVaultHolder(baggage);
+  /**
+   * Create a kit of utilities for use of the vault.
+   *
+   * @param {Vault} vault
+   * @param {ERef<StorageNode>} storageNode
+   * @param {ERef<Marshaller>} marshaller
+   * @param {Subscriber<import('./vaultManager').AssetState>} assetSubscriber
+   */
+  const makeVaultKit = (vault, storageNode, marshaller, assetSubscriber) => {
+    const { holder, helper } = makeVaultHolder(vault, storageNode, marshaller);
+    const vaultKit = harden({
+      publicSubscribers: {
+        // XXX should come from manager directly https://github.com/Agoric/agoric-sdk/issues/5814
+        asset: assetSubscriber,
+        vault: holder.getSubscriber(),
+      },
+      invitationMakers: Far('invitation makers', {
+        AdjustBalances: holder.makeAdjustBalancesInvitation,
+        CloseVault: holder.makeCloseInvitation,
+        TransferVault: holder.makeTransferInvitation,
+      }),
+      vault: holder,
+      vaultUpdater: helper.getUpdater(),
+    });
+    return vaultKit;
+  };
+  return makeVaultKit;
 };
 
-/** @typedef {(ReturnType<typeof makeVaultKit>)} VaultKit */
+/** @typedef {(ReturnType<ReturnType<typeof vivifyVaultKit>>)} VaultKit */

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -582,7 +582,7 @@ const makeVaultManagerKit = defineDurableFarClassKit(
 
             // The rest of this method will not happen until after a quote is received.
             // This may not happen until much later, when the market changes.
-            // eslint-disable-next-line no-await-in-loop
+            // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await -- loop/nesting to yield each unconditionally
             const quote = await E(ephemera.outstandingQuote).getPromise();
             ephemera.outstandingQuote = null;
             // When we receive a quote, we check whether the vault with the highest

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -16,41 +16,36 @@ import '@agoric/zoe/exported.js';
 
 import { AmountMath, AmountShape, BrandShape, RatioShape } from '@agoric/ertp';
 import {
-  makeStoredPublishKit,
+  makeStoredSubscriber,
   observeNotifier,
   SubscriberShape,
+  vivifyDurablePublishKit,
 } from '@agoric/notifier';
 import {
-  defineDurableFarClassKit,
   M,
-  makeKindHandle,
   makeScalarBigMapStore,
   makeScalarBigSetStore,
-  pickFacet,
+  vivifyFarClassKit,
 } from '@agoric/vat-data';
 import {
   assertProposalShape,
+  atomicTransfer,
   ceilDivideBy,
   floorDivideBy,
   getAmountIn,
   getAmountOut,
   makeRatio,
   makeRatioFromAmounts,
-  atomicTransfer,
 } from '@agoric/zoe/src/contractSupport/index.js';
-import { E } from '@endo/eventual-send';
 import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
 import { InstallationShape, SeatShape } from '@agoric/zoe/src/typeGuards.js';
-import {
-  checkDebtLimit,
-  makeEphemeraProvider,
-  makeMetricsPublisherKit,
-} from '../contractSupport.js';
+import { E } from '@endo/eventual-send';
+import { checkDebtLimit, makeEphemeraProvider } from '../contractSupport.js';
 import { chargeInterest } from '../interest.js';
 import { makeTracer } from '../makeTracer.js';
 import { liquidate, makeQuote, updateQuote } from './liquidation.js';
 import { makePrioritizedVaults } from './prioritizedVaults.js';
-import { makeVault, Phase } from './vault.js';
+import { Phase, vivifyVault } from './vault.js';
 
 const { details: X } = assert;
 
@@ -97,9 +92,13 @@ const trace = makeTracer('VM', false);
 
 /**
  * @typedef {Readonly<{
+ * assetSubscriber: Subscriber<AssetState>,
+ * assetPublisher: Publisher<AssetState>,
  * collateralBrand: Brand<'nat'>,
  * debtBrand: Brand<'nat'>,
  * debtMint: ZCFMint<'nat'>,
+ * metricsPublisher: Publisher<MetricsNotification>,
+ * metricsSubscriber: Subscriber<MetricsNotification>,
  * poolIncrementSeat: ZCFSeat,
  * retainedCollateralSeat: ZCFSeat,
  * unsettledVaults: MapStore<string, Vault>,
@@ -135,8 +134,6 @@ const trace = makeTracer('VM', false);
  * using a proxy for the manager object, collateralBrand.
  *
  * @type {(collateralBrand: Brand) => Partial<{
- * assetSubscriber: Subscriber<AssetState>,
- * assetPublisher: Publisher<AssetState>,
  * factoryPowers: import('./vaultDirector.js').FactoryPowersFacet?,
  * liquidationQueueing: boolean,
  * outstandingQuote: Promise<MutableQuote>?,
@@ -144,135 +141,14 @@ const trace = makeTracer('VM', false);
  * periodNotifier: ERef<Notifier<Timestamp>>,
  * priceAuthority: ERef<PriceAuthority>,
  * prioritizedVaults: ReturnType<typeof makePrioritizedVaults>,
- * metricsPublication: IterationObserver<MetricsNotification>,
- * metricsSubscription: StoredSubscription<MetricsNotification>,
+ * storedAssetSubscriber: StoredSubscriber<AssetState>,
+ * storedMetricsSubscriber: StoredSubscriber<MetricsNotification>,
  * storageNode: ERef<StorageNode>,
  * zcf: import('./vaultFactory.js').VaultFactoryZCF,
  * }>} */
 const provideEphemera = makeEphemeraProvider(() => ({
   liquidationQueueing: false,
 }));
-
-/**
- * Create state for the Vault Manager kind
- *
- * @param {import('./vaultFactory.js').VaultFactoryZCF} zcf
- * @param {ZCFMint<'nat'>} debtMint
- * @param {Brand<'nat'>} collateralBrand
- * @param {ERef<PriceAuthority>} priceAuthority
- * @param {import('./vaultDirector.js').FactoryPowersFacet} factoryPowers
- * @param {ERef<TimerService>} timerService
- * @param {Timestamp} startTimeStamp
- * @param {ERef<StorageNode>} storageNode
- * @param {ERef<Marshaller>} marshaller
- */
-const initState = (
-  zcf,
-  debtMint,
-  collateralBrand,
-  priceAuthority,
-  factoryPowers,
-  timerService,
-  startTimeStamp,
-  storageNode,
-  marshaller,
-) => {
-  assert(
-    storageNode && marshaller,
-    'VaultManager missing storageNode or marshaller',
-  );
-
-  const periodNotifier = E(timerService).makeNotifier(
-    0n,
-    factoryPowers.getGovernedParams().getChargingPeriod(),
-  );
-
-  const debtBrand = debtMint.getIssuerRecord().brand;
-  const zeroCollateral = AmountMath.makeEmpty(collateralBrand, 'nat');
-  const zeroDebt = AmountMath.makeEmpty(debtBrand, 'nat');
-
-  const { metricsPublication, metricsSubscription } = makeMetricsPublisherKit(
-    storageNode,
-    marshaller,
-  );
-
-  /** @type {MapStore<string, Vault>} */
-  const unsettledVaults = makeScalarBigMapStore('orderedVaultStore', {
-    durable: true,
-  });
-
-  /**
-   * If things are going well, the set will contain at most one Vault. Otherwise
-   * failures remain and are available to be repaired via contract upgrade.
-   *
-   * @type {SetStore<Vault>}
-   */
-  const liquidatingVaults = makeScalarBigSetStore('liquidatingVaults', {
-    durable: true,
-  });
-
-  /** @type {ImmutableState} */
-  const fixed = {
-    collateralBrand,
-    debtBrand,
-    debtMint,
-    poolIncrementSeat: zcf.makeEmptySeatKit().zcfSeat,
-    retainedCollateralSeat: zcf.makeEmptySeatKit().zcfSeat,
-    unsettledVaults,
-    liquidatingVaults,
-  };
-
-  const compoundedInterest = makeRatio(100n, fixed.debtBrand); // starts at 1.0, no interest
-  // timestamp of most recent update to interest
-  const latestInterestUpdate = startTimeStamp;
-
-  /** @type {PublishKit<AssetState>} */
-  const { publisher: assetPublisher, subscriber: assetSubscriber } =
-    makeStoredPublishKit(storageNode, marshaller);
-
-  assetPublisher.publish(
-    harden({
-      compoundedInterest,
-      interestRate: factoryPowers.getGovernedParams().getInterestRate(),
-      latestInterestUpdate,
-    }),
-  );
-
-  const ephemera = provideEphemera(collateralBrand);
-  Object.assign(ephemera, {
-    assetSubscriber,
-    assetPublisher,
-    factoryPowers,
-    marshaller,
-    metricsPublication,
-    metricsSubscription,
-    periodNotifier,
-    priceAuthority,
-    prioritizedVaults: makePrioritizedVaults(unsettledVaults),
-    storageNode,
-    zcf,
-  });
-
-  /** @type {MutableState & ImmutableState} */
-  const state = {
-    ...fixed,
-    compoundedInterest,
-    debtBrand: fixed.debtBrand,
-    latestInterestUpdate,
-    liquidator: undefined,
-    liquidatorInstance: undefined,
-    numLiquidationsCompleted: 0,
-    totalCollateral: zeroCollateral,
-    totalDebt: zeroDebt,
-    totalOverageReceived: zeroDebt,
-    totalProceedsReceived: zeroDebt,
-    totalCollateralSold: zeroCollateral,
-    totalShortfallReceived: zeroDebt,
-    vaultCounter: 0,
-  };
-
-  return state;
-};
 
 // XXX type error when destructuring params
 const finish = context => {
@@ -310,738 +186,886 @@ const finish = context => {
   });
 };
 
-const makeVaultManagerKit = defineDurableFarClassKit(
-  makeKindHandle('VaultManagerKit'),
-  {
-    collateral: M.interface('collateral', {
-      makeVaultInvitation: M.call().returns(M.promise()),
-      getSubscriber: M.call().returns(SubscriberShape),
-      getMetrics: M.call().returns(SubscriberShape),
-      getCompoundedInterest: M.call().returns(RatioShape),
-    }),
-    helper: M.interface(
-      'helper',
-      // not exposed so sloppy okay
-      {},
-      { sloppy: true },
-    ),
-    manager: M.interface('manager', {
-      getGovernedParams: M.call().returns(M.remotable()),
-      maxDebtFor: M.call(AmountShape).returns(M.promise()),
-      mintAndReallocate: M.call(AmountShape, AmountShape, SeatShape)
-        .rest()
-        .returns(),
-      burnAndRecord: M.call(AmountShape, SeatShape).returns(),
-      getAssetSubscriber: M.call().returns(SubscriberShape),
-      getCollateralBrand: M.call().returns(BrandShape),
-      getDebtBrand: M.call().returns(BrandShape),
-      getCompoundedInterest: M.call().returns(RatioShape),
-      handleBalanceChange: M.call(
-        AmountShape,
-        AmountShape,
-        M.string(),
-        M.string(),
-        M.remotable(),
-      ).returns(),
-    }),
-    self: M.interface('self', {
-      getGovernedParams: M.call().returns(M.remotable()),
-      liquidateAll: M.call().returns(M.promise()),
-      makeVaultKit: M.call(SeatShape).returns(M.promise()),
-      setupLiquidator: M.call(InstallationShape, M.record()).returns(
-        M.promise(),
+// TODO move params of initState here because it's a singleton
+// and remove from State what doesn't need to be stored between upgrades
+export const vivifyVaultManagerKit = baggage => {
+  const makeVault = vivifyVault(baggage);
+  const makeVaultManagerMetricsPublishKit = vivifyDurablePublishKit(
+    baggage,
+    'Vault Manager metrics',
+  );
+  const makeVaultManagerAssetsPublishKit = vivifyDurablePublishKit(
+    baggage,
+    'Vault Manager assets',
+  );
+
+  /**
+   * Create state for the Vault Manager kind
+   *
+   * @param {import('./vaultFactory.js').VaultFactoryZCF} zcf
+   * @param {ZCFMint<'nat'>} debtMint
+   * @param {Brand<'nat'>} collateralBrand
+   * @param {ERef<PriceAuthority>} priceAuthority
+   * @param {import('./vaultDirector.js').FactoryPowersFacet} factoryPowers
+   * @param {ERef<TimerService>} timerService
+   * @param {Timestamp} startTimeStamp
+   * @param {ERef<StorageNode>} storageNode
+   * @param {ERef<Marshaller>} marshaller
+   */
+  const initState = (
+    zcf,
+    debtMint,
+    collateralBrand,
+    priceAuthority,
+    factoryPowers,
+    timerService,
+    startTimeStamp,
+    storageNode,
+    marshaller,
+  ) => {
+    assert(
+      storageNode && marshaller,
+      'VaultManager missing storageNode or marshaller',
+    );
+
+    const periodNotifier = E(timerService).makeNotifier(
+      0n,
+      factoryPowers.getGovernedParams().getChargingPeriod(),
+    );
+
+    const debtBrand = debtMint.getIssuerRecord().brand;
+    const zeroCollateral = AmountMath.makeEmpty(collateralBrand, 'nat');
+    const zeroDebt = AmountMath.makeEmpty(debtBrand, 'nat');
+
+    const { publisher: metricsPublisher, subscriber: metricsSubscriber } =
+      makeVaultManagerMetricsPublishKit();
+
+    /** @type {PublishKit<AssetState>} */
+    const { publisher: assetPublisher, subscriber: assetSubscriber } =
+      makeVaultManagerAssetsPublishKit();
+
+    /** @type {MapStore<string, Vault>} */
+    const unsettledVaults = makeScalarBigMapStore('orderedVaultStore', {
+      durable: true,
+    });
+
+    /**
+     * If things are going well, the set will contain at most one Vault. Otherwise
+     * failures remain and are available to be repaired via contract upgrade.
+     *
+     * @type {SetStore<Vault>}
+     */
+    const liquidatingVaults = makeScalarBigSetStore('liquidatingVaults', {
+      durable: true,
+    });
+
+    /** @type {ImmutableState} */
+    const fixed = {
+      collateralBrand,
+      debtBrand,
+      debtMint,
+      poolIncrementSeat: zcf.makeEmptySeatKit().zcfSeat,
+      retainedCollateralSeat: zcf.makeEmptySeatKit().zcfSeat,
+      unsettledVaults,
+      liquidatingVaults,
+      assetSubscriber,
+      assetPublisher,
+      metricsPublisher,
+      metricsSubscriber,
+    };
+
+    const compoundedInterest = makeRatio(100n, fixed.debtBrand); // starts at 1.0, no interest
+    // timestamp of most recent update to interest
+    const latestInterestUpdate = startTimeStamp;
+
+    assetPublisher.publish(
+      harden({
+        compoundedInterest,
+        interestRate: factoryPowers.getGovernedParams().getInterestRate(),
+        latestInterestUpdate,
+      }),
+    );
+
+    const storedMetricsSubscriber = makeStoredSubscriber(
+      metricsSubscriber,
+      E(storageNode).makeChildNode('metrics'),
+      marshaller,
+    );
+
+    const storedAssetSubscriber = makeStoredSubscriber(
+      assetSubscriber,
+      storageNode,
+      marshaller,
+    );
+
+    const ephemera = provideEphemera(collateralBrand);
+    Object.assign(ephemera, {
+      factoryPowers,
+      marshaller,
+      periodNotifier,
+      priceAuthority,
+      prioritizedVaults: makePrioritizedVaults(unsettledVaults),
+      storedAssetSubscriber,
+      storedMetricsSubscriber,
+      storageNode,
+      zcf,
+    });
+
+    /** @type {MutableState & ImmutableState} */
+    const state = {
+      ...fixed,
+      compoundedInterest,
+      debtBrand: fixed.debtBrand,
+      latestInterestUpdate,
+      liquidator: undefined,
+      liquidatorInstance: undefined,
+      numLiquidationsCompleted: 0,
+      totalCollateral: zeroCollateral,
+      totalDebt: zeroDebt,
+      totalOverageReceived: zeroDebt,
+      totalProceedsReceived: zeroDebt,
+      totalCollateralSold: zeroCollateral,
+      totalShortfallReceived: zeroDebt,
+      vaultCounter: 0,
+    };
+
+    return state;
+  };
+
+  // TODO find a way to not have to indent a level deeper than defineDurableFarClassKit does
+  return vivifyFarClassKit(
+    baggage,
+    'VaultManagerKit',
+    {
+      collateral: M.interface('collateral', {
+        makeVaultInvitation: M.call().returns(M.promise()),
+        getSubscriber: M.call().returns(SubscriberShape),
+        getMetrics: M.call().returns(SubscriberShape),
+        getCompoundedInterest: M.call().returns(RatioShape),
+      }),
+      helper: M.interface(
+        'helper',
+        // not exposed so sloppy okay
+        {},
+        { sloppy: true },
       ),
-      getCollateralQuote: M.call().returns(M.promise()),
-      getPublicFacet: M.call().returns(M.remotable()),
-    }),
-  },
-  initState,
-  {
-    collateral: {
-      makeVaultInvitation() {
-        const { zcf } = provideEphemera(this.state.collateralBrand);
-        assert(zcf);
-        return zcf.makeInvitation(
-          seat => this.facets.self.makeVaultKit(seat),
-          'MakeVault',
-        );
-      },
-      getSubscriber() {
-        const { state } = this;
-        const { assetSubscriber } = provideEphemera(state.collateralBrand);
-        assert(assetSubscriber);
-        return assetSubscriber;
-      },
-      getMetrics() {
-        const { state } = this;
-        const { metricsSubscription } = provideEphemera(state.collateralBrand);
-        assert(metricsSubscription);
-        return metricsSubscription;
-      },
-      getCompoundedInterest() {
-        return this.state.compoundedInterest;
-      },
+      manager: M.interface('manager', {
+        getGovernedParams: M.call().returns(M.remotable()),
+        maxDebtFor: M.call(AmountShape).returns(M.promise()),
+        mintAndReallocate: M.call(AmountShape, AmountShape, SeatShape)
+          .rest()
+          .returns(),
+        burnAndRecord: M.call(AmountShape, SeatShape).returns(),
+        getAssetSubscriber: M.call().returns(SubscriberShape),
+        getCollateralBrand: M.call().returns(BrandShape),
+        getDebtBrand: M.call().returns(BrandShape),
+        getCompoundedInterest: M.call().returns(RatioShape),
+        handleBalanceChange: M.call(
+          AmountShape,
+          AmountShape,
+          M.string(),
+          M.string(),
+          M.remotable(),
+        ).returns(),
+      }),
+      self: M.interface('self', {
+        getGovernedParams: M.call().returns(M.remotable()),
+        liquidateAll: M.call().returns(M.promise()),
+        makeVaultKit: M.call(SeatShape).returns(M.promise()),
+        setupLiquidator: M.call(InstallationShape, M.record()).returns(
+          M.promise(),
+        ),
+        getCollateralQuote: M.call().returns(M.promise()),
+        getPublicFacet: M.call().returns(M.remotable()),
+      }),
     },
-
-    // Some of these could go in closures but are kept on a facet anticipating future durability options.
-    helper: {
-      /**
-       * @param {Timestamp} updateTime
-       * @param {ZCFSeat} poolIncrementSeat
-       */
-      async chargeAllVaults(updateTime, poolIncrementSeat) {
-        const { state, facets } = this;
-        trace('chargeAllVaults', state.collateralBrand, {
-          updateTime,
-        });
-        const { factoryPowers } = provideEphemera(state.collateralBrand);
-        assert(factoryPowers);
-
-        const interestRate = factoryPowers
-          .getGovernedParams()
-          .getInterestRate();
-
-        // Update state with the results of charging interest
-
-        const changes = chargeInterest(
-          {
-            mint: state.debtMint,
-            mintAndReallocateWithFee: factoryPowers.mintAndReallocate,
-            poolIncrementSeat,
-            seatAllocationKeyword: 'Minted',
-          },
-          {
-            interestRate,
-            chargingPeriod: factoryPowers
-              .getGovernedParams()
-              .getChargingPeriod(),
-            recordingPeriod: factoryPowers
-              .getGovernedParams()
-              .getRecordingPeriod(),
-          },
-          {
-            latestInterestUpdate: state.latestInterestUpdate,
-            compoundedInterest: state.compoundedInterest,
-            totalDebt: state.totalDebt,
-          },
-          updateTime,
-        );
-
-        state.compoundedInterest = changes.compoundedInterest;
-        state.latestInterestUpdate = changes.latestInterestUpdate;
-        state.totalDebt = changes.totalDebt;
-
-        facets.helper.assetNotify();
-        trace('chargeAllVaults complete', state.collateralBrand);
-        // price to check against has changed
-        return facets.helper.reschedulePriceCheck();
+    initState,
+    {
+      collateral: {
+        makeVaultInvitation() {
+          const { zcf } = provideEphemera(this.state.collateralBrand);
+          assert(zcf);
+          return zcf.makeInvitation(
+            seat => this.facets.self.makeVaultKit(seat),
+            'MakeVault',
+          );
+        },
+        getSubscriber() {
+          const { storedAssetSubscriber } = provideEphemera(
+            this.state.collateralBrand,
+          );
+          assert(storedAssetSubscriber);
+          return storedAssetSubscriber;
+        },
+        getMetrics() {
+          const { storedMetricsSubscriber } = provideEphemera(
+            this.state.collateralBrand,
+          );
+          assert(storedMetricsSubscriber);
+          return storedMetricsSubscriber;
+        },
+        getCompoundedInterest() {
+          return this.state.compoundedInterest;
+        },
       },
 
-      assetNotify() {
-        const { state } = this;
-        const ephemera = provideEphemera(state.collateralBrand);
-        assert(ephemera.factoryPowers && ephemera.assetPublisher);
-        const interestRate = ephemera.factoryPowers
-          .getGovernedParams()
-          .getInterestRate();
-        /** @type {AssetState} */
-        const payload = harden({
-          compoundedInterest: state.compoundedInterest,
-          interestRate,
-          latestInterestUpdate: state.latestInterestUpdate,
-          // NB: the liquidator is determined by governance but the resulting
-          // instance is a concern of the manager. The param manager knows only
-          // about the installation and terms of the liqudation contract. We could
-          // have another notifier for state downstream of governance changes, but
-          // that doesn't seem to be cost-effective.
-          liquidatorInstance: state.liquidatorInstance,
-        });
-        ephemera.assetPublisher.publish(payload);
-      },
-
-      updateMetrics() {
-        const { state } = this;
-        const { metricsPublication, prioritizedVaults } = provideEphemera(
-          state.collateralBrand,
-        );
-        assert(metricsPublication && prioritizedVaults);
-
-        const retainedCollateral =
-          state.retainedCollateralSeat.getCurrentAllocation()?.Collateral ??
-          AmountMath.makeEmpty(state.collateralBrand, 'nat');
-        /** @type {MetricsNotification} */
-        const payload = harden({
-          numActiveVaults: prioritizedVaults.getCount(),
-          numLiquidatingVaults: state.liquidatingVaults.getSize(),
-          totalCollateral: state.totalCollateral,
-          totalDebt: state.totalDebt,
-          retainedCollateral,
-
-          numLiquidationsCompleted: state.numLiquidationsCompleted,
-          totalCollateralSold: state.totalCollateralSold,
-          totalOverageReceived: state.totalOverageReceived,
-          totalProceedsReceived: state.totalProceedsReceived,
-          totalShortfallReceived: state.totalShortfallReceived,
-        });
-        metricsPublication.updateState(payload);
-      },
-
-      /**
-       * When any Vault's debt ratio is higher than the current high-water level,
-       * call `reschedulePriceCheck()` to request a fresh notification from the
-       * priceAuthority. There will be extra outstanding requests since we can't
-       * cancel them. (https://github.com/Agoric/agoric-sdk/issues/2713).
-       *
-       * When the vault with the current highest debt ratio is removed or reduces
-       * its ratio, we won't reschedule the priceAuthority requests to reduce churn.
-       * Instead, when a priceQuote is received, we'll only reschedule if the
-       * high-water level when the request was made matches the current high-water
-       * level.
-       *
-       * @param {Ratio} [highestRatio]
-       * @returns {Promise<void>}
-       */
-      async reschedulePriceCheck(highestRatio) {
-        const { state, facets } = this;
-        const { prioritizedVaults, ...ephemera } = provideEphemera(
-          state.collateralBrand,
-        );
-        assert(ephemera.factoryPowers && prioritizedVaults);
-        trace('reschedulePriceCheck', state.collateralBrand, ephemera);
-        // INTERLOCK: the first time through, start the activity to wait for
-        // and process liquidations over time.
-        if (!ephemera.liquidationQueueing) {
-          ephemera.liquidationQueueing = true;
-          // eslint-disable-next-line consistent-return
-          return facets.helper
-            .processLiquidations()
-            .catch(e => console.error('Liquidator failed', e))
-            .finally(() => {
-              ephemera.liquidationQueueing = false;
-            });
-        }
-
-        if (!ephemera.outstandingQuote) {
-          // the new threshold will be picked up by the next quote request
-          return;
-        }
-
-        const highestDebtRatio =
-          highestRatio || prioritizedVaults.highestRatio();
-        if (!highestDebtRatio) {
-          // if there aren't any open vaults, we don't need an outstanding RFQ.
-          trace('no open vaults');
-          return;
-        }
-
-        // There is already an activity processing liquidations. It may be
-        // waiting for the oracle price to cross a threshold.
-        // Update the current in-progress quote.
-        const govParams = ephemera.factoryPowers.getGovernedParams();
-        const liquidationMargin = govParams.getLiquidationMargin();
-        // Safe to call extraneously (lightweight and idempotent)
-        updateQuote(
-          ephemera.outstandingQuote,
-          highestDebtRatio,
-          liquidationMargin,
-        );
-        trace('update quote', state.collateralBrand, highestDebtRatio);
-      },
-
-      async processLiquidations() {
-        const { state, facets } = this;
-        const { prioritizedVaults, ...ephemera } = provideEphemera(
-          state.collateralBrand,
-        );
-        assert(ephemera.factoryPowers && ephemera.priceAuthority);
-        const { priceAuthority } = ephemera;
-        const govParams = ephemera.factoryPowers.getGovernedParams();
-
-        async function* eventualLiquidations() {
-          assert(prioritizedVaults);
-          while (true) {
-            const highestDebtRatio = prioritizedVaults.highestRatio();
-            if (!highestDebtRatio) {
-              return;
-            }
-            const liquidationMargin = govParams.getLiquidationMargin();
-
-            // ask to be alerted when the price level falls enough that the vault
-            // with the highest debt to collateral ratio will no longer be valued at the
-            // liquidationMargin above its debt.
-            ephemera.outstandingQuote = makeQuote(
-              priceAuthority,
-              highestDebtRatio,
-              liquidationMargin,
-            );
-            trace(
-              'posted quote request',
-              state.collateralBrand,
-              highestDebtRatio,
-            );
-
-            // The rest of this method will not happen until after a quote is received.
-            // This may not happen until much later, when the market changes.
-            // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await -- loop/nesting to yield each unconditionally
-            const quote = await E(ephemera.outstandingQuote).getPromise();
-            ephemera.outstandingQuote = null;
-            // When we receive a quote, we check whether the vault with the highest
-            // ratio of debt to collateral is below the liquidationMargin, and if so,
-            // we liquidate it. We use ceilDivide to round up because ratios above
-            // this will be liquidated.
-            const quoteRatioPlusMargin = makeRatioFromAmounts(
-              ceilDivideBy(getAmountOut(quote), liquidationMargin),
-              getAmountIn(quote),
-            );
-            trace('quote', state.collateralBrand, quote, quoteRatioPlusMargin);
-
-            // Liquidate the head of the queue
-            const [next] =
-              prioritizedVaults.entriesPrioritizedGTE(quoteRatioPlusMargin);
-            if (next) {
-              yield next;
-            }
-          }
-        }
-        for await (const next of eventualLiquidations()) {
-          await facets.helper.liquidateAndRemove(next);
-          trace('price check liq', state.collateralBrand, next && next[0]);
-        }
-      },
-
-      /**
-       * @param {[key: string, vaultKit: Vault]} record
-       */
-      liquidateAndRemove([key, vault]) {
-        const { state, facets } = this;
-        const { factoryPowers, prioritizedVaults, zcf } = provideEphemera(
-          state.collateralBrand,
-        );
-        assert(factoryPowers && prioritizedVaults && zcf);
-        const vaultSeat = vault.getVaultSeat();
-        trace('liquidating', state.collateralBrand, vaultSeat.getProposal());
-
-        const collateralPre = vault.getCollateralAmount();
-
-        // Start liquidation (vaultState: LIQUIDATING)
-        const liquidator = state.liquidator;
-        assert(liquidator);
-        state.liquidatingVaults.add(vault);
-        prioritizedVaults.removeVault(key);
-
-        return liquidate(
-          zcf,
-          vault,
-          liquidator,
-          state.collateralBrand,
-          factoryPowers.getGovernedParams().getLiquidationPenalty(),
-        )
-          .then(accounting => {
-            facets.manager.burnAndRecord(accounting.toBurn, vaultSeat);
-
-            // current values
-
-            // Sometimes, the AMM will sell less than all the collateral. If there
-            // was a shortfall, the investor doesn't keep the change, so we get it.
-            // If there was no shortfall, the collateral is returned.
-            const collateralPost = vault.getCollateralAmount();
-            if (
-              !AmountMath.isEmpty(collateralPost) &&
-              !AmountMath.isEmpty(accounting.shortfall)
-            ) {
-              // The borrower doesn't get the excess collateral remaining when
-              // liquidation results in a shortfall. We currently do nothing with
-              // it. We could hold it until it crosses some threshold, then sell it
-              // to the AMM, or we could transfer it to the reserve. At least it's
-              // visible in the accounting.
-              atomicTransfer(zcf, vaultSeat, state.retainedCollateralSeat, {
-                Collateral: collateralPost,
-              });
-            }
-
-            // Reduce totalCollateral by collateralPre, since all the collateral was
-            // sold, returned to the vault owner, or held by the VaultManager.
-            state.totalCollateral = AmountMath.subtract(
-              state.totalCollateral,
-              collateralPre,
-            );
-            state.totalDebt = AmountMath.subtract(
-              state.totalDebt,
-              accounting.shortfall,
-            );
-
-            // cumulative values
-            state.totalProceedsReceived = AmountMath.add(
-              state.totalProceedsReceived,
-              accounting.proceeds,
-            );
-            state.totalOverageReceived = AmountMath.add(
-              state.totalOverageReceived,
-              accounting.overage,
-            );
-            state.totalShortfallReceived = AmountMath.add(
-              state.totalShortfallReceived,
-              accounting.shortfall,
-            );
-            state.liquidatingVaults.delete(vault);
-            trace('liquidated', state.collateralBrand);
-            state.numLiquidationsCompleted += 1;
-            facets.helper.updateMetrics();
-
-            if (!AmountMath.isEmpty(accounting.shortfall)) {
-              E(factoryPowers.getShortfallReporter())
-                .increaseLiquidationShortfall(accounting.shortfall)
-                .catch(reason =>
-                  console.error(
-                    'liquidateAndRemove failed to increaseLiquidationShortfall',
-                    reason,
-                  ),
-                );
-            }
-          })
-          .catch(e => {
-            // XXX should notify interested parties
-            console.error('liquidateAndRemove failed with', e);
-            throw e;
+      // Some of these could go in closures but are kept on a facet anticipating future durability options.
+      helper: {
+        /**
+         * @param {Timestamp} updateTime
+         * @param {ZCFSeat} poolIncrementSeat
+         */
+        async chargeAllVaults(updateTime, poolIncrementSeat) {
+          const { state, facets } = this;
+          trace('chargeAllVaults', state.collateralBrand, {
+            updateTime,
           });
-      },
-    },
-    manager: {
-      getGovernedParams() {
-        const { state } = this;
-        const ephemera = provideEphemera(state.collateralBrand);
-        assert(ephemera.factoryPowers);
-        return ephemera.factoryPowers.getGovernedParams();
-      },
+          const { factoryPowers } = provideEphemera(state.collateralBrand);
+          assert(factoryPowers);
 
-      /**
-       * @param {Amount<'nat'>} collateralAmount
-       */
-      async maxDebtFor(collateralAmount) {
-        const { state } = this;
-        const { debtBrand } = state;
-        const { priceAuthority, ...ephemera } = provideEphemera(
-          state.collateralBrand,
-        );
-        assert(ephemera.factoryPowers && priceAuthority);
-        const quoteAmount = await E(priceAuthority).quoteGiven(
-          collateralAmount,
-          debtBrand,
-        );
-        // floorDivide because we want the debt ceiling lower
-        return floorDivideBy(
-          getAmountOut(quoteAmount),
-          ephemera.factoryPowers.getGovernedParams().getLiquidationMargin(),
-        );
-      },
-      /**
-       * TODO utility method to turn a callback into non-actual one
-       * was type {MintAndReallocate}
-       *
-       * @param {Amount<'nat'>} toMint
-       * @param {Amount<'nat'>} fee
-       * @param {ZCFSeat} seat
-       * @param {...ZCFSeat} otherSeats
-       * @returns {void}
-       */
-      mintAndReallocate(toMint, fee, seat, ...otherSeats) {
-        const { state } = this;
-        const { totalDebt } = state;
-        const { factoryPowers } = provideEphemera(state.collateralBrand);
-        assert(factoryPowers);
+          const interestRate = factoryPowers
+            .getGovernedParams()
+            .getInterestRate();
 
-        checkDebtLimit(
-          factoryPowers.getGovernedParams().getDebtLimit(),
-          totalDebt,
-          toMint,
-        );
-        factoryPowers.mintAndReallocate(toMint, fee, seat, ...otherSeats);
-        state.totalDebt = AmountMath.add(state.totalDebt, toMint);
-      },
-      /**
-       * @param {Amount<'nat'>} toBurn
-       * @param {ZCFSeat} seat
-       */
-      burnAndRecord(toBurn, seat) {
-        const { state } = this;
-        const { factoryPowers } = provideEphemera(state.collateralBrand);
-        assert(factoryPowers);
-        trace('burnAndRecord', state.collateralBrand, {
-          toBurn,
-          totalDebt: state.totalDebt,
-        });
-        const { burnDebt } = factoryPowers;
-        burnDebt(toBurn, seat);
-        state.totalDebt = AmountMath.subtract(state.totalDebt, toBurn);
-      },
-      getAssetSubscriber() {
-        const { state } = this;
-        const { assetSubscriber } = provideEphemera(state.collateralBrand);
-        assert(assetSubscriber);
-        return assetSubscriber;
-      },
-      getCollateralBrand() {
-        return this.state.collateralBrand;
-      },
-      getDebtBrand() {
-        return this.state.debtBrand;
-      },
-      /**
-       * coefficient on existing debt to calculate new debt
-       */
-      getCompoundedInterest() {
-        return this.state.compoundedInterest;
-      },
-      /**
-       * Called by a vault when its balances change.
-       *
-       * @param {NormalizedDebt} oldDebtNormalized
-       * @param {Amount<'nat'>} oldCollateral
-       * @param {VaultId} vaultId
-       * @param {import('./vault.js').VaultPhase} vaultPhase at the end of whatever change updated balances
-       * @param {Vault} vault
-       */
-      handleBalanceChange(
-        oldDebtNormalized,
-        oldCollateral,
-        vaultId,
-        vaultPhase,
-        vault,
-      ) {
-        const { state, facets } = this;
-        const { prioritizedVaults } = provideEphemera(state.collateralBrand);
-        assert(prioritizedVaults);
+          // Update state with the results of charging interest
 
-        // the manager holds only vaults that can accrue interest or be liquidated;
-        // i.e. vaults that have debt. The one exception is at the outset when
-        // a vault has been added to the manager but not yet accounted for.
-        const settled =
-          AmountMath.isEmpty(oldDebtNormalized) && vaultPhase !== Phase.ACTIVE;
-
-        if (settled) {
-          assert(
-            !prioritizedVaults.hasVaultByAttributes(
-              oldDebtNormalized,
-              oldCollateral,
-              vaultId,
-            ),
-            'Settled vaults must not be retained in storage',
+          const changes = chargeInterest(
+            {
+              mint: state.debtMint,
+              mintAndReallocateWithFee: factoryPowers.mintAndReallocate,
+              poolIncrementSeat,
+              seatAllocationKeyword: 'Minted',
+            },
+            {
+              interestRate,
+              chargingPeriod: factoryPowers
+                .getGovernedParams()
+                .getChargingPeriod(),
+              recordingPeriod: factoryPowers
+                .getGovernedParams()
+                .getRecordingPeriod(),
+            },
+            {
+              latestInterestUpdate: state.latestInterestUpdate,
+              compoundedInterest: state.compoundedInterest,
+              totalDebt: state.totalDebt,
+            },
+            updateTime,
           );
-        } else {
-          const isNew = AmountMath.isEmpty(oldDebtNormalized);
-          if (!isNew) {
-            // its position in the queue is no longer valid
 
-            const vaultInStore = prioritizedVaults.removeVaultByAttributes(
-              oldDebtNormalized,
-              oldCollateral,
-              vaultId,
-            );
-            assert(
-              vault === vaultInStore,
-              'handleBalanceChange for two different vaults',
-            );
-          }
+          state.compoundedInterest = changes.compoundedInterest;
+          state.latestInterestUpdate = changes.latestInterestUpdate;
+          state.totalDebt = changes.totalDebt;
 
-          // replace in queue, but only if it can accrue interest or be liquidated (i.e. has debt).
-          // getCurrentDebt() would also work (0x = 0) but require more computation.
-          if (!AmountMath.isEmpty(vault.getNormalizedDebt())) {
-            prioritizedVaults.addVault(vaultId, vault);
-          }
+          facets.helper.assetNotify();
+          trace('chargeAllVaults complete', state.collateralBrand);
+          // price to check against has changed
+          return facets.helper.reschedulePriceCheck();
+        },
 
-          // totalCollateral += vault's collateral delta (post — pre)
-          state.totalCollateral = AmountMath.subtract(
-            AmountMath.add(state.totalCollateral, vault.getCollateralAmount()),
-            oldCollateral,
+        assetNotify() {
+          const { state } = this;
+          const ephemera = provideEphemera(state.collateralBrand);
+          assert(ephemera.factoryPowers);
+          const interestRate = ephemera.factoryPowers
+            .getGovernedParams()
+            .getInterestRate();
+          /** @type {AssetState} */
+          const payload = harden({
+            compoundedInterest: state.compoundedInterest,
+            interestRate,
+            latestInterestUpdate: state.latestInterestUpdate,
+            // NB: the liquidator is determined by governance but the resulting
+            // instance is a concern of the manager. The param manager knows only
+            // about the installation and terms of the liqudation contract. We could
+            // have another notifier for state downstream of governance changes, but
+            // that doesn't seem to be cost-effective.
+            liquidatorInstance: state.liquidatorInstance,
+          });
+          state.assetPublisher.publish(payload);
+        },
+
+        updateMetrics() {
+          const { state } = this;
+          const { prioritizedVaults } = provideEphemera(state.collateralBrand);
+          assert(prioritizedVaults);
+
+          const retainedCollateral =
+            state.retainedCollateralSeat.getCurrentAllocation()?.Collateral ??
+            AmountMath.makeEmpty(state.collateralBrand, 'nat');
+          /** @type {MetricsNotification} */
+          const payload = harden({
+            numActiveVaults: prioritizedVaults.getCount(),
+            numLiquidatingVaults: state.liquidatingVaults.getSize(),
+            totalCollateral: state.totalCollateral,
+            totalDebt: state.totalDebt,
+            retainedCollateral,
+
+            numLiquidationsCompleted: state.numLiquidationsCompleted,
+            totalCollateralSold: state.totalCollateralSold,
+            totalOverageReceived: state.totalOverageReceived,
+            totalProceedsReceived: state.totalProceedsReceived,
+            totalShortfallReceived: state.totalShortfallReceived,
+          });
+          state.metricsPublisher.publish(payload);
+        },
+
+        /**
+         * When any Vault's debt ratio is higher than the current high-water level,
+         * call `reschedulePriceCheck()` to request a fresh notification from the
+         * priceAuthority. There will be extra outstanding requests since we can't
+         * cancel them. (https://github.com/Agoric/agoric-sdk/issues/2713).
+         *
+         * When the vault with the current highest debt ratio is removed or reduces
+         * its ratio, we won't reschedule the priceAuthority requests to reduce churn.
+         * Instead, when a priceQuote is received, we'll only reschedule if the
+         * high-water level when the request was made matches the current high-water
+         * level.
+         *
+         * @param {Ratio} [highestRatio]
+         * @returns {Promise<void>}
+         */
+        async reschedulePriceCheck(highestRatio) {
+          const { state, facets } = this;
+          const { prioritizedVaults, ...ephemera } = provideEphemera(
+            state.collateralBrand,
           );
-          // debt accounting managed through minting and burning
-          facets.helper.updateMetrics();
-        }
-      },
-    },
-    self: {
-      getGovernedParams() {
-        const { state } = this;
-        const { factoryPowers } = provideEphemera(state.collateralBrand);
-        assert(factoryPowers);
-        return factoryPowers.getGovernedParams();
-      },
-
-      /**
-       * In extreme situations, system health may require liquidating all vaults.
-       * This starts the liquidations all in parallel.
-       */
-      async liquidateAll() {
-        const {
-          state,
-          facets: { helper },
-        } = this;
-        const { prioritizedVaults } = provideEphemera(state.collateralBrand);
-        assert(prioritizedVaults);
-        const toLiquidate = Array.from(prioritizedVaults.entries()).map(entry =>
-          helper.liquidateAndRemove(entry),
-        );
-        await Promise.all(toLiquidate);
-      },
-
-      /**
-       * @param {ZCFSeat} seat
-       */
-      async makeVaultKit(seat) {
-        const {
-          state,
-          facets: { manager },
-        } = this;
-        const { marshaller, prioritizedVaults, storageNode, zcf } =
-          provideEphemera(state.collateralBrand);
-        assert(marshaller, 'makeVaultKit missing marshaller');
-        assert(prioritizedVaults, 'makeVaultKit missing prioritizedVaults');
-        assert(storageNode, 'makeVaultKit missing storageNode');
-        assert(zcf, 'makeVaultKit missing zcf');
-        assertProposalShape(seat, {
-          give: { Collateral: null },
-          want: { Minted: null },
-        });
-
-        state.vaultCounter += 1;
-        const vaultId = String(state.vaultCounter);
-
-        const vaultStorageNode = E(
-          E(storageNode).makeChildNode(`vaults`),
-        ).makeChildNode(`vault${vaultId}`);
-
-        const vault = makeVault(
-          zcf,
-          manager,
-          vaultId,
-          vaultStorageNode,
-          marshaller,
-        );
-
-        try {
-          // TODO `await` is allowed until the above ordering is fixed
-          // eslint-disable-next-line @jessie.js/no-nested-await
-          const vaultKit = await vault.initVaultKit(seat, vaultStorageNode);
-          // initVaultKit calls back to handleBalanceChange() which will add the
-          // vault to prioritizedVaults
-          seat.exit();
-          return vaultKit;
-        } catch (err) {
-          // ??? do we still need this cleanup? it won't get into the store unless it has collateral,
-          // which should qualify it to be in the store. If we drop this catch then the nested await
-          // for `vault.initVaultKit()` goes away.
-
-          // remove it from the store if it got in
-          /** @type {NormalizedDebt} */
-          // @ts-expect-error cast
-          const normalizedDebt = AmountMath.makeEmpty(state.debtBrand);
-          const collateralPre = seat.getCurrentAllocation().Collateral;
-          try {
-            prioritizedVaults.removeVaultByAttributes(
-              normalizedDebt,
-              collateralPre,
-              vaultId,
-            );
-            console.error(
-              'removed vault',
-              vaultId,
-              'after initVaultKit failure',
-            );
-          } catch {
-            console.error(
-              'vault',
-              vaultId,
-              'never stored during initVaultKit failure',
-            );
+          assert(ephemera.factoryPowers && prioritizedVaults);
+          trace('reschedulePriceCheck', state.collateralBrand, ephemera);
+          // INTERLOCK: the first time through, start the activity to wait for
+          // and process liquidations over time.
+          if (!ephemera.liquidationQueueing) {
+            ephemera.liquidationQueueing = true;
+            // eslint-disable-next-line consistent-return
+            return facets.helper
+              .processLiquidations()
+              .catch(e => console.error('Liquidator failed', e))
+              .finally(() => {
+                ephemera.liquidationQueueing = false;
+              });
           }
-          throw err;
-        }
-      },
 
-      /**
-       *
-       * @param {Installation} liquidationInstall
-       * @param {object} liquidationTerms
-       */
-      async setupLiquidator(liquidationInstall, liquidationTerms) {
-        const { state, facets } = this;
-        const { zcf } = provideEphemera(state.collateralBrand);
-        assert(zcf);
-        const { debtBrand, collateralBrand } = state;
-        const {
-          ammPublicFacet,
-          priceAuthority,
-          reservePublicFacet,
-          timerService,
-        } = zcf.getTerms();
-        const zoe = zcf.getZoeService();
-        const collateralIssuer = zcf.getIssuerForBrand(collateralBrand);
-        const debtIssuer = zcf.getIssuerForBrand(debtBrand);
-        trace('setup liquidator', state.collateralBrand, {
-          debtBrand,
-          debtIssuer,
-          collateralBrand,
-          liquidationTerms,
-        });
-        const { creatorFacet, instance } = await E(zoe).startInstance(
-          liquidationInstall,
-          harden({ Minted: debtIssuer, Collateral: collateralIssuer }),
-          harden({
-            ...liquidationTerms,
-            amm: ammPublicFacet,
+          if (!ephemera.outstandingQuote) {
+            // the new threshold will be picked up by the next quote request
+            return;
+          }
+
+          const highestDebtRatio =
+            highestRatio || prioritizedVaults.highestRatio();
+          if (!highestDebtRatio) {
+            // if there aren't any open vaults, we don't need an outstanding RFQ.
+            trace('no open vaults');
+            return;
+          }
+
+          // There is already an activity processing liquidations. It may be
+          // waiting for the oracle price to cross a threshold.
+          // Update the current in-progress quote.
+          const govParams = ephemera.factoryPowers.getGovernedParams();
+          const liquidationMargin = govParams.getLiquidationMargin();
+          // Safe to call extraneously (lightweight and idempotent)
+          updateQuote(
+            ephemera.outstandingQuote,
+            highestDebtRatio,
+            liquidationMargin,
+          );
+          trace('update quote', state.collateralBrand, highestDebtRatio);
+        },
+
+        async processLiquidations() {
+          const { state, facets } = this;
+          const { prioritizedVaults, ...ephemera } = provideEphemera(
+            state.collateralBrand,
+          );
+          assert(ephemera.factoryPowers && ephemera.priceAuthority);
+          const { priceAuthority } = ephemera;
+          const govParams = ephemera.factoryPowers.getGovernedParams();
+
+          async function* eventualLiquidations() {
+            assert(prioritizedVaults);
+            while (true) {
+              const highestDebtRatio = prioritizedVaults.highestRatio();
+              if (!highestDebtRatio) {
+                return;
+              }
+              const liquidationMargin = govParams.getLiquidationMargin();
+
+              // ask to be alerted when the price level falls enough that the vault
+              // with the highest debt to collateral ratio will no longer be valued at the
+              // liquidationMargin above its debt.
+              ephemera.outstandingQuote = makeQuote(
+                priceAuthority,
+                highestDebtRatio,
+                liquidationMargin,
+              );
+              trace(
+                'posted quote request',
+                state.collateralBrand,
+                highestDebtRatio,
+              );
+
+              // The rest of this method will not happen until after a quote is received.
+              // This may not happen until much later, when the market changes.
+              // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await -- loop/nesting to yield each unconditionally
+              const quote = await E(ephemera.outstandingQuote).getPromise();
+              ephemera.outstandingQuote = null;
+              // When we receive a quote, we check whether the vault with the highest
+              // ratio of debt to collateral is below the liquidationMargin, and if so,
+              // we liquidate it. We use ceilDivide to round up because ratios above
+              // this will be liquidated.
+              const quoteRatioPlusMargin = makeRatioFromAmounts(
+                ceilDivideBy(getAmountOut(quote), liquidationMargin),
+                getAmountIn(quote),
+              );
+              trace(
+                'quote',
+                state.collateralBrand,
+                quote,
+                quoteRatioPlusMargin,
+              );
+
+              // Liquidate the head of the queue
+              const [next] =
+                prioritizedVaults.entriesPrioritizedGTE(quoteRatioPlusMargin);
+              if (next) {
+                yield next;
+              }
+            }
+          }
+          for await (const next of eventualLiquidations()) {
+            await facets.helper.liquidateAndRemove(next);
+            trace('price check liq', state.collateralBrand, next && next[0]);
+          }
+        },
+
+        /**
+         * @param {[key: string, vaultKit: Vault]} record
+         */
+        liquidateAndRemove([key, vault]) {
+          const { state, facets } = this;
+          const { factoryPowers, prioritizedVaults, zcf } = provideEphemera(
+            state.collateralBrand,
+          );
+          assert(factoryPowers && prioritizedVaults && zcf);
+          const vaultSeat = vault.getVaultSeat();
+          trace('liquidating', state.collateralBrand, vaultSeat.getProposal());
+
+          const collateralPre = vault.getCollateralAmount();
+
+          // Start liquidation (vaultState: LIQUIDATING)
+          const liquidator = state.liquidator;
+          assert(liquidator);
+          state.liquidatingVaults.add(vault);
+          prioritizedVaults.removeVault(key);
+
+          return liquidate(
+            zcf,
+            vault,
+            liquidator,
+            state.collateralBrand,
+            factoryPowers.getGovernedParams().getLiquidationPenalty(),
+          )
+            .then(accounting => {
+              facets.manager.burnAndRecord(accounting.toBurn, vaultSeat);
+
+              // current values
+
+              // Sometimes, the AMM will sell less than all the collateral. If there
+              // was a shortfall, the investor doesn't keep the change, so we get it.
+              // If there was no shortfall, the collateral is returned.
+              const collateralPost = vault.getCollateralAmount();
+              if (
+                !AmountMath.isEmpty(collateralPost) &&
+                !AmountMath.isEmpty(accounting.shortfall)
+              ) {
+                // The borrower doesn't get the excess collateral remaining when
+                // liquidation results in a shortfall. We currently do nothing with
+                // it. We could hold it until it crosses some threshold, then sell it
+                // to the AMM, or we could transfer it to the reserve. At least it's
+                // visible in the accounting.
+                atomicTransfer(zcf, vaultSeat, state.retainedCollateralSeat, {
+                  Collateral: collateralPost,
+                });
+              }
+
+              // Reduce totalCollateral by collateralPre, since all the collateral was
+              // sold, returned to the vault owner, or held by the VaultManager.
+              state.totalCollateral = AmountMath.subtract(
+                state.totalCollateral,
+                collateralPre,
+              );
+              state.totalDebt = AmountMath.subtract(
+                state.totalDebt,
+                accounting.shortfall,
+              );
+
+              // cumulative values
+              state.totalProceedsReceived = AmountMath.add(
+                state.totalProceedsReceived,
+                accounting.proceeds,
+              );
+              state.totalOverageReceived = AmountMath.add(
+                state.totalOverageReceived,
+                accounting.overage,
+              );
+              state.totalShortfallReceived = AmountMath.add(
+                state.totalShortfallReceived,
+                accounting.shortfall,
+              );
+              state.liquidatingVaults.delete(vault);
+              trace('liquidated', state.collateralBrand);
+              state.numLiquidationsCompleted += 1;
+              facets.helper.updateMetrics();
+
+              if (!AmountMath.isEmpty(accounting.shortfall)) {
+                E(factoryPowers.getShortfallReporter())
+                  .increaseLiquidationShortfall(accounting.shortfall)
+                  .catch(reason =>
+                    console.error(
+                      'liquidateAndRemove failed to increaseLiquidationShortfall',
+                      reason,
+                    ),
+                  );
+              }
+            })
+            .catch(e => {
+              // XXX should notify interested parties
+              console.error('liquidateAndRemove failed with', e);
+              throw e;
+            });
+        },
+      },
+      manager: {
+        getGovernedParams() {
+          const { state } = this;
+          const ephemera = provideEphemera(state.collateralBrand);
+          assert(ephemera.factoryPowers);
+          return ephemera.factoryPowers.getGovernedParams();
+        },
+
+        /**
+         * @param {Amount<'nat'>} collateralAmount
+         */
+        async maxDebtFor(collateralAmount) {
+          const { state } = this;
+          const { debtBrand } = state;
+          const { priceAuthority, ...ephemera } = provideEphemera(
+            state.collateralBrand,
+          );
+          assert(ephemera.factoryPowers && priceAuthority);
+          const quoteAmount = await E(priceAuthority).quoteGiven(
+            collateralAmount,
             debtBrand,
-            reservePublicFacet,
+          );
+          // floorDivide because we want the debt ceiling lower
+          return floorDivideBy(
+            getAmountOut(quoteAmount),
+            ephemera.factoryPowers.getGovernedParams().getLiquidationMargin(),
+          );
+        },
+        /**
+         * TODO utility method to turn a callback into non-actual one
+         * was type {MintAndReallocate}
+         *
+         * @param {Amount<'nat'>} toMint
+         * @param {Amount<'nat'>} fee
+         * @param {ZCFSeat} seat
+         * @param {...ZCFSeat} otherSeats
+         * @returns {void}
+         */
+        mintAndReallocate(toMint, fee, seat, ...otherSeats) {
+          const { state } = this;
+          const { totalDebt } = state;
+          const { factoryPowers } = provideEphemera(state.collateralBrand);
+          assert(factoryPowers);
+
+          checkDebtLimit(
+            factoryPowers.getGovernedParams().getDebtLimit(),
+            totalDebt,
+            toMint,
+          );
+          factoryPowers.mintAndReallocate(toMint, fee, seat, ...otherSeats);
+          state.totalDebt = AmountMath.add(state.totalDebt, toMint);
+        },
+        /**
+         * @param {Amount<'nat'>} toBurn
+         * @param {ZCFSeat} seat
+         */
+        burnAndRecord(toBurn, seat) {
+          const { state } = this;
+          const { factoryPowers } = provideEphemera(state.collateralBrand);
+          assert(factoryPowers);
+          trace('burnAndRecord', state.collateralBrand, {
+            toBurn,
+            totalDebt: state.totalDebt,
+          });
+          const { burnDebt } = factoryPowers;
+          burnDebt(toBurn, seat);
+          state.totalDebt = AmountMath.subtract(state.totalDebt, toBurn);
+        },
+        getAssetSubscriber() {
+          const { storedAssetSubscriber } = provideEphemera(
+            this.state.collateralBrand,
+          );
+          assert(storedAssetSubscriber);
+          return storedAssetSubscriber;
+        },
+        getCollateralBrand() {
+          return this.state.collateralBrand;
+        },
+        getDebtBrand() {
+          return this.state.debtBrand;
+        },
+        /**
+         * coefficient on existing debt to calculate new debt
+         */
+        getCompoundedInterest() {
+          return this.state.compoundedInterest;
+        },
+        /**
+         * Called by a vault when its balances change.
+         *
+         * @param {NormalizedDebt} oldDebtNormalized
+         * @param {Amount<'nat'>} oldCollateral
+         * @param {VaultId} vaultId
+         * @param {import('./vault.js').VaultPhase} vaultPhase at the end of whatever change updated balances
+         * @param {Vault} vault
+         */
+        handleBalanceChange(
+          oldDebtNormalized,
+          oldCollateral,
+          vaultId,
+          vaultPhase,
+          vault,
+        ) {
+          const { state, facets } = this;
+          const { prioritizedVaults } = provideEphemera(state.collateralBrand);
+          assert(prioritizedVaults);
+
+          // the manager holds only vaults that can accrue interest or be liquidated;
+          // i.e. vaults that have debt. The one exception is at the outset when
+          // a vault has been added to the manager but not yet accounted for.
+          const settled =
+            AmountMath.isEmpty(oldDebtNormalized) &&
+            vaultPhase !== Phase.ACTIVE;
+
+          if (settled) {
+            assert(
+              !prioritizedVaults.hasVaultByAttributes(
+                oldDebtNormalized,
+                oldCollateral,
+                vaultId,
+              ),
+              'Settled vaults must not be retained in storage',
+            );
+          } else {
+            const isNew = AmountMath.isEmpty(oldDebtNormalized);
+            if (!isNew) {
+              // its position in the queue is no longer valid
+
+              const vaultInStore = prioritizedVaults.removeVaultByAttributes(
+                oldDebtNormalized,
+                oldCollateral,
+                vaultId,
+              );
+              assert(
+                vault === vaultInStore,
+                'handleBalanceChange for two different vaults',
+              );
+            }
+
+            // replace in queue, but only if it can accrue interest or be liquidated (i.e. has debt).
+            // getCurrentDebt() would also work (0x = 0) but require more computation.
+            if (!AmountMath.isEmpty(vault.getNormalizedDebt())) {
+              prioritizedVaults.addVault(vaultId, vault);
+            }
+
+            // totalCollateral += vault's collateral delta (post — pre)
+            state.totalCollateral = AmountMath.subtract(
+              AmountMath.add(
+                state.totalCollateral,
+                vault.getCollateralAmount(),
+              ),
+              oldCollateral,
+            );
+            // debt accounting managed through minting and burning
+            facets.helper.updateMetrics();
+          }
+        },
+      },
+      self: {
+        getGovernedParams() {
+          const { state } = this;
+          const { factoryPowers } = provideEphemera(state.collateralBrand);
+          assert(factoryPowers);
+          return factoryPowers.getGovernedParams();
+        },
+
+        /**
+         * In extreme situations, system health may require liquidating all vaults.
+         * This starts the liquidations all in parallel.
+         */
+        async liquidateAll() {
+          const {
+            state,
+            facets: { helper },
+          } = this;
+          const { prioritizedVaults } = provideEphemera(state.collateralBrand);
+          assert(prioritizedVaults);
+          const toLiquidate = Array.from(prioritizedVaults.entries()).map(
+            entry => helper.liquidateAndRemove(entry),
+          );
+          await Promise.all(toLiquidate);
+        },
+
+        /**
+         * @param {ZCFSeat} seat
+         */
+        async makeVaultKit(seat) {
+          const {
+            state,
+            facets: { manager },
+          } = this;
+          const { marshaller, prioritizedVaults, storageNode, zcf } =
+            provideEphemera(state.collateralBrand);
+          assert(marshaller, 'makeVaultKit missing marshaller');
+          assert(prioritizedVaults, 'makeVaultKit missing prioritizedVaults');
+          assert(storageNode, 'makeVaultKit missing storageNode');
+          assert(zcf, 'makeVaultKit missing zcf');
+          assertProposalShape(seat, {
+            give: { Collateral: null },
+            want: { Minted: null },
+          });
+
+          state.vaultCounter += 1;
+          const vaultId = String(state.vaultCounter);
+
+          const vaultStorageNode = E(
+            E(storageNode).makeChildNode(`vaults`),
+          ).makeChildNode(`vault${vaultId}`);
+
+          const { self: vault } = makeVault(
+            zcf,
+            manager,
+            vaultId,
+            vaultStorageNode,
+            marshaller,
+          );
+
+          try {
+            // TODO `await` is allowed until the above ordering is fixed
+            // eslint-disable-next-line @jessie.js/no-nested-await
+            const vaultKit = await vault.initVaultKit(seat, vaultStorageNode);
+            // initVaultKit calls back to handleBalanceChange() which will add the
+            // vault to prioritizedVaults
+            seat.exit();
+            return vaultKit;
+          } catch (err) {
+            // ??? do we still need this cleanup? it won't get into the store unless it has collateral,
+            // which should qualify it to be in the store. If we drop this catch then the nested await
+            // for `vault.initVaultKit()` goes away.
+
+            // remove it from the store if it got in
+            /** @type {NormalizedDebt} */
+            // @ts-expect-error cast
+            const normalizedDebt = AmountMath.makeEmpty(state.debtBrand);
+            const collateralPre = seat.getCurrentAllocation().Collateral;
+            try {
+              prioritizedVaults.removeVaultByAttributes(
+                normalizedDebt,
+                collateralPre,
+                vaultId,
+              );
+              console.error(
+                'removed vault',
+                vaultId,
+                'after initVaultKit failure',
+              );
+            } catch {
+              console.error(
+                'vault',
+                vaultId,
+                'never stored during initVaultKit failure',
+              );
+            }
+            throw err;
+          }
+        },
+
+        /**
+         *
+         * @param {Installation} liquidationInstall
+         * @param {object} liquidationTerms
+         */
+        async setupLiquidator(liquidationInstall, liquidationTerms) {
+          const { state, facets } = this;
+          const { zcf } = provideEphemera(state.collateralBrand);
+          assert(zcf);
+          const { debtBrand, collateralBrand } = state;
+          const {
+            ammPublicFacet,
             priceAuthority,
+            reservePublicFacet,
             timerService,
-          }),
-        );
-        trace('setup liquidator complete', state.collateralBrand, {
-          instance,
-          old: state.liquidatorInstance,
-          equal: state.liquidatorInstance === instance,
-        });
-        state.liquidatorInstance = instance;
-        state.liquidator = creatorFacet;
-        facets.helper.assetNotify();
-      },
+          } = zcf.getTerms();
+          const zoe = zcf.getZoeService();
+          const collateralIssuer = zcf.getIssuerForBrand(collateralBrand);
+          const debtIssuer = zcf.getIssuerForBrand(debtBrand);
+          trace('setup liquidator', state.collateralBrand, {
+            debtBrand,
+            debtIssuer,
+            collateralBrand,
+            liquidationTerms,
+          });
+          const { creatorFacet, instance } = await E(zoe).startInstance(
+            liquidationInstall,
+            harden({ Minted: debtIssuer, Collateral: collateralIssuer }),
+            harden({
+              ...liquidationTerms,
+              amm: ammPublicFacet,
+              debtBrand,
+              reservePublicFacet,
+              priceAuthority,
+              timerService,
+            }),
+          );
+          trace('setup liquidator complete', state.collateralBrand, {
+            instance,
+            old: state.liquidatorInstance,
+            equal: state.liquidatorInstance === instance,
+          });
+          state.liquidatorInstance = instance;
+          state.liquidator = creatorFacet;
+          facets.helper.assetNotify();
+        },
 
-      async getCollateralQuote() {
-        const { state } = this;
-        const { priceAuthority } = provideEphemera(state.collateralBrand);
-        assert(priceAuthority);
+        async getCollateralQuote() {
+          const { state } = this;
+          const { priceAuthority } = provideEphemera(state.collateralBrand);
+          assert(priceAuthority);
 
-        const { debtBrand } = state;
-        // get a quote for one unit of the collateral
-        const collateralUnit = await unitAmount(state.collateralBrand);
-        return E(priceAuthority).quoteGiven(collateralUnit, debtBrand);
-      },
+          const { debtBrand } = state;
+          // get a quote for one unit of the collateral
+          const collateralUnit = await unitAmount(state.collateralBrand);
+          return E(priceAuthority).quoteGiven(collateralUnit, debtBrand);
+        },
 
-      getPublicFacet() {
-        return this.facets.collateral;
+        getPublicFacet() {
+          return this.facets.collateral;
+        },
       },
     },
-  },
-  {
-    finish,
-  },
-);
+    {
+      finish,
+    },
+  );
+};
 
 /**
+ * @typedef {ReturnType<ReturnType<typeof vivifyVaultManagerKit>>['self']} VaultManager
  * Each VaultManager manages a single collateral type.
  *
  * It manages some number of outstanding loans, each called a Vault, for which
  * the collateral is provided in exchange for borrowed Minted.
- *
- * @param {ZCF} zcf
- * @param {ZCFMint<'nat'>} debtMint
- * @param {Brand} collateralBrand
- * @param {ERef<PriceAuthority>} priceAuthority
- * @param {import('./vaultDirector.js').FactoryPowersFacet} factoryPowers
- * @param {ERef<TimerService>} timerService
- * @param {Timestamp} startTimeStamp
  */
-export const makeVaultManager = pickFacet(makeVaultManagerKit, 'self');
-
-/** @typedef {ReturnType<typeof makeVaultManagerKit>['manager']} VaultKitManager */
-/** @typedef {ReturnType<typeof makeVaultManager>} VaultManager */
 /** @typedef {ReturnType<VaultManager['getPublicFacet']>} CollateralManager */

--- a/packages/inter-protocol/test/metrics.js
+++ b/packages/inter-protocol/test/metrics.js
@@ -1,4 +1,4 @@
-import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
+import { makeNotifierFromAsyncIterable, subscribeEach } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
 import { diff } from 'deep-object-diff';
 
@@ -45,12 +45,12 @@ export const subscriptionTracker = async (t, subscription) => {
  * For public facets that have a `getMetrics` method.
  *
  * @param {import('ava').ExecutionContext} t
- * @param {{getMetrics?: () => ConsistentAsyncIterable<unknown>}} publicFacet
+ * @param {{getMetrics?: () => Subscriber<unknown>}} publicFacet
  * @template {object} N
  */
 export const metricsTracker = async (t, publicFacet) => {
   const metricsSub = await E(publicFacet).getMetrics();
-  return subscriptionTracker(t, metricsSub);
+  return subscriptionTracker(t, subscribeEach(metricsSub));
 };
 
 /**
@@ -60,7 +60,6 @@ export const metricsTracker = async (t, publicFacet) => {
 export const vaultManagerMetricsTracker = async (t, publicFacet) => {
   let totalDebtEver = 0n;
   /** @type {Awaited<ReturnType<typeof subscriptionTracker<import('../src/vaultFactory/vaultManager').MetricsNotification>>>} */
-  // @ts-expect-error cast
   const m = await metricsTracker(t, publicFacet);
 
   /** @returns {bigint} Proceeds - overage + shortfall */

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -20,7 +20,7 @@ import {
 import { getAmountOut } from '@agoric/zoe/src/contractSupport';
 import { E } from '@endo/eventual-send';
 import { paymentFromZCFMint } from '../../src/vaultFactory/burn.js';
-import { makeVault } from '../../src/vaultFactory/vault.js';
+import { vivifyVault } from '../../src/vaultFactory/vault.js';
 
 const BASIS_POINTS = 10000n;
 const SECONDS_PER_HOUR = 60n * 60n;
@@ -31,8 +31,9 @@ const marshaller = makeFakeMarshaller();
 /**
  * @param {ZCF} zcf
  * @param {{feeMintAccess: FeeMintAccess}} privateArgs
+ * @param {import('@agoric/ertp').Baggage} baggage
  */
-export async function start(zcf, privateArgs) {
+export async function start(zcf, privateArgs, baggage) {
   console.log(`contract started`);
   assert.typeof(privateArgs.feeMintAccess, 'object');
 
@@ -155,7 +156,9 @@ export async function start(zcf, privateArgs) {
     },
   });
 
-  const vault = await makeVault(
+  const makeVault = vivifyVault(baggage);
+
+  const { self: vault } = await makeVault(
     zcf,
     managerMock,
     // eslint-disable-next-line no-plusplus

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -164,7 +164,7 @@ harden(makeStoredSubscription);
  */
 
 /**
- * @deprecated use makeStoredPublishKit
+ * @deprecated incompatible with durability; instead handle vstorage ephemerally on a durable PublishKit
  *
  * @template [T=unknown]
  * @param {ERef<StorageNode>} [storageNode]
@@ -193,6 +193,8 @@ export const makeStoredPublisherKit = (storageNode, marshaller, childPath) => {
 };
 
 /**
+ * @deprecated incompatible with durability; instead handle vstorage ephemerally on a durable PublishKit
+ *
  * Like makePublishKit this makes a `{ publisher, subscriber }` pair for doing efficient
  * distributed pub/sub supporting both "each" and "latest" iteration
  * of published values.


### PR DESCRIPTION
## Description

On the path to #5285 but doesn't claim to finish it. 

The goal of this is to use the new durable publish kits. This required introducing baggage and vivification, which leads to some big code movement. Review is recommended to be done ignoring whitespace. I'll clean up the commits before merge. Requests on how to segment welcomed.

This introduces `provideChildBaggage` (adapted from https://github.com/Agoric/agoric-sdk/pull/6373/ ) as a pattern for making singleton children.

### Security Considerations

State now comes from baggage. Normal in revivifiable contracts.

### Documentation Considerations

None. Backwards compatible.

### Testing Considerations

Existing test coverage seemed to suffice. I had one error that wasn't appearing (on a call with @Chris-Hibbert ) but it was being hidden by another error (see 2aeee19). If you check this out locally, be sure to run-chain-economy (e.g. start-local-chain.sh) to test durability.