### PR TITLE
feat(vstorage): overhaul event emissions

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -572,8 +572,8 @@ func NewAgoricApp(
 		params.NewAppModule(app.ParamsKeeper),
 		transferModule,
 		icaModule,
-		swingset.NewAppModule(app.SwingSetKeeper),
 		vstorage.NewAppModule(app.VstorageKeeper),
+		swingset.NewAppModule(app.SwingSetKeeper),
 		vibcModule,
 		vbankModule,
 		lienModule,
@@ -605,14 +605,13 @@ func NewAgoricApp(
 		feegrant.ModuleName,
 		paramstypes.ModuleName,
 		vestingtypes.ModuleName,
-		swingset.ModuleName,
 		vstorage.ModuleName,
+		swingset.ModuleName,
 		vibc.ModuleName,
 		vbank.ModuleName,
 		lien.ModuleName,
 	)
 	app.mm.SetOrderEndBlockers(
-		vstorage.ModuleName,
 		vibc.ModuleName,
 		vbank.ModuleName,
 		lien.ModuleName,
@@ -637,6 +636,8 @@ func NewAgoricApp(
 		vestingtypes.ModuleName,
 		// SwingSet needs to be last, for it to capture all the pushed actions.
 		swingset.ModuleName,
+		// And then vstorage, to produce SwingSet-induced events.
+		vstorage.ModuleName,
 	)
 
 	// NOTE: The genutils module must occur after staking so that pools are

--- a/golang/cosmos/x/swingset/keeper/keeper.go
+++ b/golang/cosmos/x/swingset/keeper/keeper.go
@@ -327,7 +327,7 @@ func (k Keeper) SetEgress(ctx sdk.Context, egress *types.Egress) error {
 		return err
 	}
 
-	// FIXME: We need to publish this value.
+	// FIXME: We should use just SetStorageAndNotify here, but solo needs legacy for now.
 	k.vstorageKeeper.LegacySetStorageAndNotify(ctx, path, string(bz))
 
 	// Now make sure the corresponding account has been initialised.
@@ -360,6 +360,7 @@ func (k Keeper) GetMailbox(ctx sdk.Context, peer string) string {
 // SetMailbox sets the entire mailbox struct for a peer
 func (k Keeper) SetMailbox(ctx sdk.Context, peer string, mailbox string) {
 	path := StoragePathMailbox + "." + peer
+	// FIXME: We should use just SetStorageAndNotify here, but solo needs legacy for now.
 	k.vstorageKeeper.LegacySetStorageAndNotify(ctx, path, mailbox)
 }
 

--- a/golang/cosmos/x/vstorage/module.go
+++ b/golang/cosmos/x/vstorage/module.go
@@ -116,9 +116,11 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
+	am.keeper.NewChangeBatch(ctx)
 }
 
 func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.ValidatorUpdate {
+	am.keeper.FlushChangeEvents(ctx)
 	// Prevent Cosmos SDK internal errors.
 	return []abci.ValidatorUpdate{}
 }

--- a/golang/cosmos/x/vstorage/vstorage.go
+++ b/golang/cosmos/x/vstorage/vstorage.go
@@ -57,8 +57,19 @@ func (sh vstorageHandler) Receive(cctx *vm.ControllerContext, str string) (ret s
 	// Handle generic paths.
 	switch msg.Method {
 	case "set":
-		//fmt.Printf("giving Keeper.SetStorage(%s) %s\n", msg.Key, msg.Value)
 		keeper.SetStorageAndNotify(cctx.Context, msg.Path, msg.Value)
+		return "true", nil
+
+		// We sometimes need to use LegacySetStorageAndNotify, because the solo's
+		// chain-cosmos-sdk.js consumes legacy events for `mailbox.*` and `egress.*`.
+		// FIXME: Use just "set" and remove this case.
+	case "legacySet":
+		//fmt.Printf("giving Keeper.SetStorage(%s) %s\n", msg.Key, msg.Value)
+		keeper.LegacySetStorageAndNotify(cctx.Context, msg.Path, msg.Value)
+		return "true", nil
+
+	case "setWithoutNotify":
+		keeper.SetStorage(cctx.Context, msg.Path, msg.Value)
 		return "true", nil
 
 	case "append":


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

Closes: #6805

## Description

Every change to the action queue was resulting in new vstorage events for the block.  That was spamming the Cosmos event log by adding a lot of events that weren't actually useful to outside consumers.  Further investigation warranted a more rigorous approach to vstorage events..

This PR allows users of vstorage deliberately to emit (possibly legacy ag-solo-compatible) or avoid events.  Also, all events are cached within the block so that only the latest value of a path is emitted at the end of the block, in agreement with #6805.

It also updates the `state_change` event format to support upcoming changes to the `@agoric/casting` client:
- add an `anckey` (anchored key) attribute to enable event subscriptions to all children at a certain depth using only the `CONTAINS` query operator (since current Tendermint event queries do not have anything like `STARTSWITH` or `attr >= 'string1' AND attr < 'string2'` for string values)
- stop double-base64 encoding attributes
- shorten several gratuitously long key names

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
