### PR TITLE
resolve lint warnings in inter-protocol

### DIFF
--- a/packages/inter-protocol/scripts/add-initial-liquidity.js
+++ b/packages/inter-protocol/scripts/add-initial-liquidity.js
@@ -165,7 +165,7 @@ const addInitialLiquidity = async (homeP, { now = () => Date.now() }) => {
 
     const payouts = await E(seat).getPayouts();
     console.log('initialLiquidityPayouts', keys(payouts));
-    E(scratch).set('initialLiquidityPayouts', payouts);
+    await E(scratch).set('initialLiquidityPayouts', payouts);
   };
 
   console.log(

--- a/packages/inter-protocol/src/price/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/price/priceAggregatorChainlink.js
@@ -183,16 +183,19 @@ export const start = async (zcf, privateArgs, baggage) => {
   });
 
   // for each new quote from the priceAuthority, publish it to off-chain storage
-  observeNotifier(priceAuthority.makeQuoteNotifier(unitAmountIn, brandOut), {
-    updateState: quote =>
-      pricePublisher.publish(priceDescriptionFromQuote(quote)),
-    fail: reason => {
-      throw Error(`priceAuthority observer failed: ${reason}`);
+  void observeNotifier(
+    priceAuthority.makeQuoteNotifier(unitAmountIn, brandOut),
+    {
+      updateState: quote =>
+        pricePublisher.publish(priceDescriptionFromQuote(quote)),
+      fail: reason => {
+        throw Error(`priceAuthority observer failed: ${reason}`);
+      },
+      finish: done => {
+        throw Error(`priceAuthority observer died: ${done}`);
+      },
     },
-    finish: done => {
-      throw Error(`priceAuthority observer died: ${done}`);
-    },
-  });
+  );
 
   const creatorFacet = Far('PriceAggregatorChainlinkCreatorFacet', {
     /**

--- a/packages/inter-protocol/src/proposals/demoIssuers.js
+++ b/packages/inter-protocol/src/proposals/demoIssuers.js
@@ -1,3 +1,4 @@
+/* eslint-disable @jessie.js/no-nested-await -- demo file */
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { objectMap } from '@agoric/internal';
 import {

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -122,7 +122,7 @@ export const createPriceFeed = async (
 
   // Default to an empty Map and home.priceAuthority.
   produceAggregators.resolve(new Map());
-  E(client).assignBundle([_addr => ({ priceAuthority })]);
+  void E(client).assignBundle([_addr => ({ priceAuthority })]);
 
   const timer = await chainTimerService;
 
@@ -168,7 +168,7 @@ export const createPriceFeed = async (
       marshaller,
     },
   );
-  E(aggregators).set(terms, { aggregator });
+  await E(aggregators).set(terms, { aggregator });
 
   E(E(agoricNamesAdmin).lookupAdmin('instance')).update(
     AGORIC_INSTANCE_NAME,
@@ -177,7 +177,7 @@ export const createPriceFeed = async (
 
   // Publish price feed in home.priceAuthority.
   const forceReplace = true;
-  E(priceAuthorityAdmin)
+  void E(priceAuthorityAdmin)
     .registerPriceAuthority(
       E(aggregator.publicFacet).getPriceAuthority(),
       brandIn,

--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -44,7 +44,7 @@ const makeQuote = (priceAuthority, highestDebtRatio, liquidationMargin) => {
  * @param {Ratio} liquidationMargin
  */
 const updateQuote = (quote, highestDebtRatio, liquidationMargin) => {
-  E(quote).updateLevel(
+  void E(quote).updateLevel(
     highestDebtRatio.denominator, // collateral
     liquidationThreshold(highestDebtRatio, liquidationMargin),
   );

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -342,7 +342,7 @@ test('limit', async t => {
   const actualAnchor = await E(anchor.issuer).getAmountOf(anchorReturn);
   t.deepEqual(actualAnchor, give);
   // The pool should be unchanged
-  driver.assertPoolBalance(initialPool);
+  await driver.assertPoolBalance(initialPool);
 });
 
 test('limit is for minted', async t => {
@@ -354,7 +354,7 @@ test('limit is for minted', async t => {
   trace('test going over limit');
   const giveTooMuch = anchor.make(MINT_LIMIT);
   const seat1 = await driver.swapAnchorForMintedSeat(giveTooMuch);
-  t.throwsAsync(
+  await t.throwsAsync(
     () => E(seat1).getOfferResult(),
     {
       message: 'Request would exceed mint limit',
@@ -482,7 +482,7 @@ test('anchor is 2x minted', async t => {
   const actualRun = await E(minted.issuer).getAmountOf(runPayouts.Out);
   t.deepEqual(actualRun, expectedRun);
 
-  driver.assertPoolBalance(giveAnchor);
+  await driver.assertPoolBalance(giveAnchor);
 
   const giveRun = AmountMath.make(minted.brand, scale6(100));
   trace('get minted ratio', { giveRun, expectedRun, actualRun });
@@ -497,7 +497,9 @@ test('anchor is 2x minted', async t => {
     anchorPerMinted,
   );
   t.deepEqual(actualAnchor, expectedAnchor);
-  driver.assertPoolBalance(AmountMath.subtract(giveAnchor, expectedAnchor));
+  await driver.assertPoolBalance(
+    AmountMath.subtract(giveAnchor, expectedAnchor),
+  );
   trace('get anchor', { runGive: giveRun, expectedRun, actualAnchor });
 });
 

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -41,7 +41,7 @@ const makeTestSpace = async log => {
     },
     psmParams,
   );
-  psmVatRoot.bootstrap(...mockPsmBootstrapArgs(log));
+  void psmVatRoot.bootstrap(...mockPsmBootstrapArgs(log));
 
   // TODO mimic the proposals and manifest of price-feed-proposal and price-feed-core
   // calling ensureOracleBrands and createPriceFeed
@@ -237,7 +237,7 @@ test.serial('admin price', async t => {
     t.context.consume.chainTimerService
   );
   // trigger an aggregation (POLL_INTERVAL=1n in context)
-  E(manualTimer).tickN(1);
+  await E(manualTimer).tickN(1);
 
   const paPublicFacet = await E(zoe).getPublicFacet(priceAggregator);
 

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -40,7 +40,7 @@ const makePsmTestSpace = async log => {
     },
     psmParams,
   );
-  psmVatRoot.bootstrap(...mockPsmBootstrapArgs(log));
+  void psmVatRoot.bootstrap(...mockPsmBootstrapArgs(log));
 
   // @ts-expect-error cast
   return /** @type {ChainBootstrapSpace} */ (psmVatRoot.getPromiseSpace());


### PR DESCRIPTION
refs: #6000

## Description

Part of #6000 though we'll need to do this again before release.

Output of `NODE_OPTIONS='--max-old-space-size=8192' AGORIC_ESLINT_TYPES=true yarn lint` before:

```
/opt/agoric/agoric-sdk/packages/inter-protocol/scripts/add-initial-liquidity.js
  168:5  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/opt/agoric/agoric-sdk/packages/inter-protocol/src/price/priceAggregatorChainlink.js
  186:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/opt/agoric/agoric-sdk/packages/inter-protocol/src/proposals/demoIssuers.js
  289:47  warning  Unexpected `await` expression (not top of async function or `for-await-of` body)  @jessie.js/no-nested-await
  307:11  warning  Unexpected `await` expression (not top of async function or `for-await-of` body)  @jessie.js/no-nested-await
  494:37  warning  Unexpected `await` expression (not top of async function or `for-await-of` body)  @jessie.js/no-nested-await
  629:39  warning  Unexpected `await` expression (not top of async function or `for-await-of` body)  @jessie.js/no-nested-await

/opt/agoric/agoric-sdk/packages/inter-protocol/src/proposals/price-feed-proposal.js
  125:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  171:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  180:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/opt/agoric/agoric-sdk/packages/inter-protocol/src/vaultFactory/liquidation.js
  47:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/opt/agoric/agoric-sdk/packages/inter-protocol/test/psm/test-psm.js
  345:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  357:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  485:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  500:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/opt/agoric/agoric-sdk/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
   44:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  240:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/opt/agoric/agoric-sdk/packages/inter-protocol/test/smartWallet/test-psm-integration.js
  43:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

✖ 17 problems (0 errors, 17 warnings)
```

And empty after.

### Security Considerations

--
### Documentation Considerations

--
### Testing Considerations

--