### PR TITLE
resolve lint warnings in smart-wallet

### DIFF
--- a/packages/smart-wallet/src/marshal-contexts.js
+++ b/packages/smart-wallet/src/marshal-contexts.js
@@ -364,7 +364,7 @@ export const makeImportContext = (makePresence = defaultMakePresence) => {
 const makePresence = (iface, handler) => {
   let obj;
   // eslint-disable-next-line no-new
-  new HandledPromise((resolve, reject, resolveWithPresence) => {
+  void new HandledPromise((resolve, reject, resolveWithPresence) => {
     obj = resolveWithPresence(handler);
   });
   assert(obj);

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -79,7 +79,7 @@ export const makeOfferExecutor = ({
       const handleError = err => {
         logger.error('OFFER ERROR:', err);
         updateStatus({ error: err.toString() });
-        paymentsManager.tryReclaimingWithdrawnPayments().then(result => {
+        void paymentsManager.tryReclaimingWithdrawnPayments().then(result => {
           if (result) {
             updateStatus({ result });
           }
@@ -113,7 +113,7 @@ export const makeOfferExecutor = ({
         logger.info(id, 'seated');
 
         // publish 'result'
-        E.when(
+        void E.when(
           E(seatRef).getOfferResult(),
           result => {
             const passStyle = passStyleOf(result);
@@ -154,7 +154,7 @@ export const makeOfferExecutor = ({
         );
 
         // publish 'numWantsSatisfied'
-        E.when(
+        void E.when(
           E(seatRef).numWantsSatisfied(),
           numSatisfied => {
             logger.info(id, 'numSatisfied', numSatisfied);
@@ -171,7 +171,7 @@ export const makeOfferExecutor = ({
         // publish 'payouts'
         // This will block until all payouts succeed, but user will be updated
         // as each payout will trigger its corresponding purse notifier.
-        E.when(
+        void E.when(
           E(seatRef).getPayouts(),
           payouts =>
             paymentsManager.depositPayouts(payouts).then(amountsOrDeferred => {

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -441,7 +441,7 @@ const SmartWalletKit = defineVirtualExoClassKit(
               /** @type {RemotePurse} */
               // @ts-expect-error cast to RemotePurse
               const purse = E(bank).getPurse(desc.brand);
-              facets.helper.addBrand(desc, purse);
+              await facets.helper.addBrand(desc, purse);
               return purse;
             },
             logger,
@@ -470,7 +470,7 @@ const SmartWalletKit = defineVirtualExoClassKit(
             facets.helper.publishCurrentState();
           },
         });
-        executor.executeOffer(offerSpec);
+        await executor.executeOffer(offerSpec);
       },
     },
     self: {

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -318,13 +318,13 @@ const SmartWalletKit = defineVirtualExoClassKit(
 
         const { helper } = this.facets;
         // publish purse's balance and changes
-        E.when(
+        void E.when(
           E(purse).getCurrentAmount(),
           balance => helper.updateBalance(purse, balance, 'init'),
           err =>
             console.error(address, 'initial purse balance publish failed', err),
         );
-        observeNotifier(E(purse).getCurrentAmountNotifier(), {
+        void observeNotifier(E(purse).getCurrentAmountNotifier(), {
           updateState(balance) {
             helper.updateBalance(purse, balance);
           },
@@ -524,7 +524,7 @@ const SmartWalletKit = defineVirtualExoClassKit(
       } = state;
       const { helper } = facets;
       // Ensure a purse for each issuer
-      helper.addBrand(
+      void helper.addBrand(
         {
           brand: invitationBrand,
           issuer: invitationIssuer,

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -102,7 +102,7 @@ export const makeWalletStateCoalescer = () => {
 export const coalesceUpdates = updates => {
   const coalescer = makeWalletStateCoalescer();
 
-  observeIteration(subscribeEach(updates), {
+  void observeIteration(subscribeEach(updates), {
     updateState: updateRecord => {
       coalescer.update(updateRecord);
     },


### PR DESCRIPTION
refs: #6000

## Description

Part of #6000 though we'll need to do this again before release.

Output of `NODE_OPTIONS='--max-old-space-size=8192' AGORIC_ESLINT_TYPES=true yarn lint` before:

```
/opt/agoric/agoric-sdk/packages/smart-wallet/src/marshal-contexts.js
  367:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/opt/agoric/agoric-sdk/packages/smart-wallet/src/offers.js
   82:9  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  116:9  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  157:9  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  174:9  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/opt/agoric/agoric-sdk/packages/smart-wallet/src/smartWallet.js
  321:9   warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  327:9   warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  444:15  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  473:9   warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  527:7   warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/opt/agoric/agoric-sdk/packages/smart-wallet/src/utils.js
  105:3  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

✖ 11 problems (0 errors, 11 warnings)
```

And empty after.

### Security Considerations

--
### Documentation Considerations

--
### Testing Considerations

--