### PR TITLE
fix: adapt to deeplyFulfilled being async

### DIFF
--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -170,12 +170,14 @@ harden(applyLabelingError);
  */
 
 /**
- * A more constrained version of {deeplyFulfilled} for type safety until https://github.com/endojs/endo/issues/1257
- * Useful in starting contracts that need all terms to be fulfilled in order to be durable.
+ * A more constrained version of {deeplyFulfilled} for type safety until
+ * https://github.com/endojs/endo/issues/1257
+ * Useful in starting contracts that need all terms to be fulfilled
+ * in order to be durable.
  *
- * @type {<T extends {}>(unfulfilledTerms: T) => import('@endo/far').ERef<DeeplyAwaited<T>>}
+ * @type {<T extends {}>(unfulfilledTerms: T) => Promise<DeeplyAwaited<T>>}
  */
-export const deeplyFulfilledObject = obj => {
+export const deeplyFulfilledObject = async obj => {
   isObject(obj) || Fail`param must be an object`;
   return deeplyFulfilled(obj);
 };

--- a/packages/store/src/patterns/exo-tools.js
+++ b/packages/store/src/patterns/exo-tools.js
@@ -225,7 +225,16 @@ export const defendPrototype = (
       methodGuards && methodGuards[prop],
     );
   }
-  // @ts-expect-error could be instantiated with different subtype
+
+  // TODO If I leave the following line of code unmarked, then it fails
+  // locally with a type error. If I annotation it with the following line,
+  // then it fails in CI "Unused 'at-ts-expect-error' directive.".
+  // at-ts-expect-error could be instantiated with different subtype
+  // So we use at-ts-ignore instead, and then have to suppress the
+  // complaint that we should use at-ts-expect-error instead.
+  //
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore
   return Far(tag, prototype);
 };
 harden(defendPrototype);


### PR DESCRIPTION
https://github.com/endojs/endo/pull/1455 would make `deeplyFulfilled` into an async function. I've already manually inspected all calls to it in the endo and agoric-sdk repos, and this change looks harmless --- nothing will break. But it does narrow the return type, giving us an opportunity to narrow the return type of `deeplyFulfilledObject` to match.

Now makes `deeplyFulfilledObject` async as well, making moot the dependence on the endo release and agoric-sdk upgrade.