### PR TITLE
fix: rename from defineFarClass to makeExoMaker, etc

### DIFF
--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -6,7 +6,7 @@ import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 import { AssetKind, assertAssetKind } from './amountMath.js';
 import { coerceDisplayInfo } from './displayInfo.js';
-import { vivifyPaymentLedger } from './paymentLedger.js';
+import { preparePaymentLedger } from './paymentLedger.js';
 
 import './types-ambient.js';
 
@@ -24,7 +24,7 @@ import './types-ambient.js';
  * See https://github.com/Agoric/agoric-sdk/issues/3434
  * @returns {IssuerKit<K>}
  */
-export const vivifyIssuerKit = (
+export const prepareIssuerKit = (
   issuerBaggage,
   optShutdownWithFailure = undefined,
 ) => {
@@ -49,7 +49,7 @@ export const vivifyIssuerKit = (
   // Attenuate the powerful authority to mint and change balances
   /** @type {PaymentLedger<K>} */
   // @ts-expect-error could be instantiated with different subtype of AssetKind
-  const { issuer, mint, brand } = vivifyPaymentLedger(
+  const { issuer, mint, brand } = preparePaymentLedger(
     issuerBaggage,
     name,
     assetKind,
@@ -65,7 +65,7 @@ export const vivifyIssuerKit = (
     displayInfo: cleanDisplayInfo,
   });
 };
-harden(vivifyIssuerKit);
+harden(prepareIssuerKit);
 
 /**
  * @template {AssetKind} K
@@ -109,7 +109,7 @@ export const makeDurableIssuerKit = (
   issuerBaggage.init('assetKind', assetKind);
   issuerBaggage.init('displayInfo', displayInfo);
   issuerBaggage.init('elementShape', elementShape);
-  return vivifyIssuerKit(issuerBaggage, optShutdownWithFailure);
+  return prepareIssuerKit(issuerBaggage, optShutdownWithFailure);
 };
 harden(makeDurableIssuerKit);
 

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -1,5 +1,5 @@
 import { initEmpty } from '@agoric/store';
-import { defineExoFactory } from '@agoric/vat-data';
+import { prepareExoMaker } from '@agoric/vat-data';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -11,8 +11,8 @@ import { defineExoFactory } from '@agoric/vat-data';
  * @param {InterfaceGuard} PaymentI
  * @returns {() => Payment<K>}
  */
-export const vivifyPaymentKind = (issuerBaggage, name, brand, PaymentI) => {
-  const makePayment = defineExoFactory(
+export const preparePaymentKind = (issuerBaggage, name, brand, PaymentI) => {
+  const makePayment = prepareExoMaker(
     issuerBaggage,
     `${name} payment`,
     PaymentI,
@@ -25,4 +25,4 @@ export const vivifyPaymentKind = (issuerBaggage, name, brand, PaymentI) => {
   );
   return makePayment;
 };
-harden(vivifyPaymentKind);
+harden(preparePaymentKind);

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -1,5 +1,5 @@
 import { initEmpty } from '@agoric/store';
-import { vivifyFarClass } from '@agoric/vat-data';
+import { defineExoFactory } from '@agoric/vat-data';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -12,7 +12,7 @@ import { vivifyFarClass } from '@agoric/vat-data';
  * @returns {() => Payment<K>}
  */
 export const vivifyPaymentKind = (issuerBaggage, name, brand, PaymentI) => {
-  const makePayment = vivifyFarClass(
+  const makePayment = defineExoFactory(
     issuerBaggage,
     `${name} payment`,
     PaymentI,

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -2,10 +2,10 @@
 import { isPromise } from '@endo/promise-kit';
 import { assertCopyArray } from '@endo/marshal';
 import { fit, M } from '@agoric/store';
-import { provideDurableWeakMapStore, defineExo } from '@agoric/vat-data';
+import { provideDurableWeakMapStore, prepareExo } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
-import { vivifyPaymentKind } from './payment.js';
-import { vivifyPurseKind } from './purse.js';
+import { preparePaymentKind } from './payment.js';
+import { preparePurseKind } from './purse.js';
 
 import '@agoric/store/exported.js';
 import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
@@ -72,7 +72,7 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
  * @param {ShutdownWithFailure=} optShutdownWithFailure
  * @returns {PaymentLedger<K>}
  */
-export const vivifyPaymentLedger = (
+export const preparePaymentLedger = (
   issuerBaggage,
   name,
   assetKind,
@@ -81,7 +81,7 @@ export const vivifyPaymentLedger = (
   optShutdownWithFailure = undefined,
 ) => {
   /** @type {Brand<K>} */
-  const brand = defineExo(issuerBaggage, `${name} brand`, BrandI, {
+  const brand = prepareExo(issuerBaggage, `${name} brand`, BrandI, {
     isMyIssuer(allegedIssuer) {
       // BrandI delays calling this method until `allegedIssuer` is a Remotable
       return allegedIssuer === issuer;
@@ -111,7 +111,7 @@ export const vivifyPaymentLedger = (
     amountShape,
   );
 
-  const makePayment = vivifyPaymentKind(issuerBaggage, name, brand, PaymentI);
+  const makePayment = preparePaymentKind(issuerBaggage, name, brand, PaymentI);
 
   /** @type {ShutdownWithFailure} */
   const shutdownLedgerWithFailure = reason => {
@@ -363,7 +363,7 @@ export const vivifyPaymentLedger = (
     return payment;
   };
 
-  const makeEmptyPurse = vivifyPurseKind(
+  const makeEmptyPurse = preparePurseKind(
     issuerBaggage,
     name,
     assetKind,
@@ -376,7 +376,7 @@ export const vivifyPaymentLedger = (
   );
 
   /** @type {Issuer<K>} */
-  const issuer = defineExo(issuerBaggage, `${name} issuer`, IssuerI, {
+  const issuer = prepareExo(issuerBaggage, `${name} issuer`, IssuerI, {
     getBrand() {
       return brand;
     },
@@ -474,7 +474,7 @@ export const vivifyPaymentLedger = (
   });
 
   /** @type {Mint<K>} */
-  const mint = defineExo(issuerBaggage, `${name} mint`, MintI, {
+  const mint = prepareExo(issuerBaggage, `${name} mint`, MintI, {
     getIssuer() {
       return issuer;
     },
@@ -490,4 +490,4 @@ export const vivifyPaymentLedger = (
   const issuerKit = harden({ issuer, mint, brand });
   return issuerKit;
 };
-harden(vivifyPaymentLedger);
+harden(preparePaymentLedger);

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -2,10 +2,7 @@
 import { isPromise } from '@endo/promise-kit';
 import { assertCopyArray } from '@endo/marshal';
 import { fit, M } from '@agoric/store';
-import {
-  provideDurableWeakMapStore,
-  vivifyFarInstance,
-} from '@agoric/vat-data';
+import { provideDurableWeakMapStore, defineExo } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { vivifyPaymentKind } from './payment.js';
 import { vivifyPurseKind } from './purse.js';
@@ -84,7 +81,7 @@ export const vivifyPaymentLedger = (
   optShutdownWithFailure = undefined,
 ) => {
   /** @type {Brand<K>} */
-  const brand = vivifyFarInstance(issuerBaggage, `${name} brand`, BrandI, {
+  const brand = defineExo(issuerBaggage, `${name} brand`, BrandI, {
     isMyIssuer(allegedIssuer) {
       // BrandI delays calling this method until `allegedIssuer` is a Remotable
       return allegedIssuer === issuer;
@@ -379,7 +376,7 @@ export const vivifyPaymentLedger = (
   );
 
   /** @type {Issuer<K>} */
-  const issuer = vivifyFarInstance(issuerBaggage, `${name} issuer`, IssuerI, {
+  const issuer = defineExo(issuerBaggage, `${name} issuer`, IssuerI, {
     getBrand() {
       return brand;
     },
@@ -477,7 +474,7 @@ export const vivifyPaymentLedger = (
   });
 
   /** @type {Mint<K>} */
-  const mint = vivifyFarInstance(issuerBaggage, `${name} mint`, MintI, {
+  const mint = defineExo(issuerBaggage, `${name} mint`, MintI, {
     getIssuer() {
       return issuer;
     },

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -1,4 +1,4 @@
-import { vivifyFarClassKit, makeScalarBigSetStore } from '@agoric/vat-data';
+import { defineExoKitFactory, makeScalarBigSetStore } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { makeTransientNotifierKit } from './transientNotifier.js';
 
@@ -28,7 +28,7 @@ export const vivifyPurseKind = (
   //   that created depositFacet as needed. But this approach ensures a constant
   //   identity for the facet and exercises the multi-faceted object style.
   const { depositInternal, withdrawInternal } = purseMethods;
-  const makePurseKit = vivifyFarClassKit(
+  const makePurseKit = defineExoKitFactory(
     issuerBaggage,
     `${name} Purse`,
     PurseIKit,

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -1,10 +1,10 @@
-import { defineExoKitFactory, makeScalarBigSetStore } from '@agoric/vat-data';
+import { prepareExoKitMaker, makeScalarBigSetStore } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { makeTransientNotifierKit } from './transientNotifier.js';
 
 const { Fail } = assert;
 
-export const vivifyPurseKind = (
+export const preparePurseKind = (
   issuerBaggage,
   name,
   assetKind,
@@ -28,7 +28,7 @@ export const vivifyPurseKind = (
   //   that created depositFacet as needed. But this approach ensures a constant
   //   identity for the facet and exercises the multi-faceted object style.
   const { depositInternal, withdrawInternal } = purseMethods;
-  const makePurseKit = defineExoKitFactory(
+  const makePurseKit = prepareExoKitMaker(
     issuerBaggage,
     `${name} Purse`,
     PurseIKit,
@@ -112,4 +112,4 @@ export const vivifyPurseKind = (
   );
   return () => makePurseKit().purse;
 };
-harden(vivifyPurseKind);
+harden(preparePurseKind);

--- a/packages/ERTP/test/swingsetTests/ertpService/vat-ertp-service.js
+++ b/packages/ERTP/test/swingsetTests/ertpService/vat-ertp-service.js
@@ -1,15 +1,19 @@
 import { Far } from '@endo/marshal';
 import {
   makeScalarBigMapStore,
-  vivifySingleton,
+  prepareSingleton,
   provideDurableSetStore,
 } from '@agoric/vat-data';
 
-import { AssetKind, makeDurableIssuerKit, vivifyIssuerKit } from '../../../src';
+import {
+  AssetKind,
+  makeDurableIssuerKit,
+  prepareIssuerKit,
+} from '../../../src';
 
-export const vivifyErtpService = (baggage, exitVatWithFailure) => {
+export const prepareErtpService = (baggage, exitVatWithFailure) => {
   const issuerBaggageSet = provideDurableSetStore(baggage, 'BaggageSet');
-  const ertpService = vivifySingleton(baggage, 'ERTPService', {
+  const ertpService = prepareSingleton(baggage, 'ERTPService', {
     makeIssuerKit: (
       name,
       assetKind = AssetKind.NAT,
@@ -32,15 +36,15 @@ export const vivifyErtpService = (baggage, exitVatWithFailure) => {
   });
 
   for (const issuerBaggage of issuerBaggageSet.values()) {
-    vivifyIssuerKit(issuerBaggage);
+    prepareIssuerKit(issuerBaggage);
   }
 
   return ertpService;
 };
-harden(vivifyErtpService);
+harden(prepareErtpService);
 
 export const buildRootObject = async (vatPowers, _vatParams, baggage) => {
-  const ertpService = vivifyErtpService(baggage, vatPowers.exitVatWithFailure);
+  const ertpService = prepareErtpService(baggage, vatPowers.exitVatWithFailure);
   return Far('root', {
     getErtpService: () => ertpService,
   });

--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -10,8 +10,8 @@ import {
   provideDurableMapStore,
   provideDurableWeakMapStore,
   defineDurableKindMulti,
-  vivifyKind,
-  vivifySingleton,
+  prepareKind,
+  prepareSingleton,
 } from '@agoric/vat-data';
 import { makeScalarWeakMapStore } from '@agoric/store';
 import { TimeMath } from './timeMath.js';
@@ -241,7 +241,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
 
   // These Kinds are the ongoing obligations of the vat: all future
   // versions must define behaviors for these. Search for calls to
-  // 'vivifyKind', 'vivifySingleton', or 'defineDurableKindMulti'.
+  // 'prepareKind', 'prepareSingleton', or 'defineDurableKindMulti'.
   // * oneShotEvent
   // * promiseEvent
   // * repeaterEvent
@@ -397,7 +397,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
     },
   };
 
-  const makeOneShotEvent = vivifyKind(
+  const makeOneShotEvent = prepareKind(
     baggage,
     'oneShotEvent',
     initOneShotEvent,
@@ -443,7 +443,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
   /**
    * @returns { PromiseEvent }
    */
-  const makePromiseEvent = vivifyKind(
+  const makePromiseEvent = prepareKind(
     baggage,
     'promiseEvent',
     initPromiseEvent,
@@ -546,7 +546,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
     },
   };
 
-  const makeRepeaterEvent = vivifyKind(
+  const makeRepeaterEvent = prepareKind(
     baggage,
     'repeaterEvent',
     initRepeaterEvent,
@@ -740,7 +740,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
         });
     },
   };
-  const createIterator = vivifyKind(
+  const createIterator = prepareKind(
     baggage,
     'timerIterator',
     initIterator,
@@ -882,11 +882,11 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
 
   // -- now we finally build the TimerService
 
-  const wakeupHandler = vivifySingleton(baggage, 'wakeupHandler', {
+  const wakeupHandler = prepareSingleton(baggage, 'wakeupHandler', {
     wake: processAndReschedule,
   });
 
-  const timerService = vivifySingleton(baggage, 'timerService', {
+  const timerService = prepareSingleton(baggage, 'timerService', {
     getCurrentTimestamp,
     setWakeup /* one-shot with handler (absolute) */,
     wakeAt /* one-shot with Promise (absolute) */,
@@ -900,13 +900,13 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
   });
 
   // attenuated read-only facet
-  const timerClock = vivifySingleton(baggage, 'timerClock', {
+  const timerClock = prepareSingleton(baggage, 'timerClock', {
     getCurrentTimestamp,
     getTimerBrand: () => timerBrand,
   });
 
   // powerless identifier
-  const timerBrand = vivifySingleton(baggage, 'timerBrand', {
+  const timerBrand = prepareSingleton(baggage, 'timerBrand', {
     isMyTimerService: alleged => alleged === timerService,
     isMyClock: alleged => alleged === timerClock,
   });

--- a/packages/SwingSet/src/vats/vattp/vat-vattp.js
+++ b/packages/SwingSet/src/vats/vattp/vat-vattp.js
@@ -6,7 +6,7 @@ import {
   provideDurableMapStore,
   provideDurableSetStore,
   provideKindHandle,
-  vivifySingleton,
+  prepareSingleton,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
 
@@ -286,7 +286,7 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
   };
 
   // Expose a durable service singleton.
-  return vivifySingleton(baggage, serviceSingletonBaggageKey, {
+  return prepareSingleton(baggage, serviceSingletonBaggageKey, {
     ...serviceMailboxFunctions,
     ...serviceNetworkFunctions,
   });

--- a/packages/SwingSet/test/vat-durable-singleton.js
+++ b/packages/SwingSet/test/vat-durable-singleton.js
@@ -1,6 +1,6 @@
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';
-import { provide, vivifyFarClassKit } from '@agoric/vat-data';
+import { provide, defineExoKitFactory } from '@agoric/vat-data';
 
 export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const { version } = vatParameters;
@@ -9,10 +9,16 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const emptyFacetI = M.interface('Facet', {});
   const iKit = harden({ facet1: emptyFacetI, facet2: emptyFacetI });
   const initState = () => ({});
-  const makeInstance = vivifyFarClassKit(baggage, 'ClassKit', iKit, initState, {
-    facet1: {},
-    facet2: {},
-  });
+  const makeInstance = defineExoKitFactory(
+    baggage,
+    'ClassKit',
+    iKit,
+    initState,
+    {
+      facet1: {},
+      facet2: {},
+    },
+  );
   const singleton = provide(baggage, 'durableSingleton', () => makeInstance());
 
   return Far('root', {

--- a/packages/SwingSet/test/vat-durable-singleton.js
+++ b/packages/SwingSet/test/vat-durable-singleton.js
@@ -1,6 +1,6 @@
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';
-import { provide, defineExoKitFactory } from '@agoric/vat-data';
+import { provide, prepareExoKitMaker } from '@agoric/vat-data';
 
 export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const { version } = vatParameters;
@@ -9,7 +9,7 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const emptyFacetI = M.interface('Facet', {});
   const iKit = harden({ facet1: emptyFacetI, facet2: emptyFacetI });
   const initState = () => ({});
-  const makeInstance = defineExoKitFactory(
+  const makeInstance = prepareExoKitMaker(
     baggage,
     'ClassKit',
     iKit,

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -1,5 +1,5 @@
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeHeapFarInstance, keyEQ, makeStore } from '@agoric/store';
+import { makeHeapExo, keyEQ, makeStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 
 import {
@@ -133,7 +133,7 @@ const makeBinaryVoteCounter = (
     });
   };
 
-  const closeFacet = makeHeapFarInstance(
+  const closeFacet = makeHeapExo(
     'BinaryVoteCounter close',
     BinaryVoteCounterCloseI,
     {
@@ -144,7 +144,7 @@ const makeBinaryVoteCounter = (
     },
   );
 
-  const creatorFacet = makeHeapFarInstance(
+  const creatorFacet = makeHeapExo(
     'BinaryVoteCounter creator',
     BinaryVoteCounterAdminI,
     {
@@ -165,7 +165,7 @@ const makeBinaryVoteCounter = (
     },
   );
 
-  const publicFacet = makeHeapFarInstance(
+  const publicFacet = makeHeapExo(
     'BinaryVoteCounter public',
     BinaryVoteCounterPublicI,
     {

--- a/packages/governance/src/multiCandidateVoteCounter.js
+++ b/packages/governance/src/multiCandidateVoteCounter.js
@@ -1,4 +1,4 @@
-import { keyEQ, makeHeapFarInstance, makeStore } from '@agoric/store';
+import { keyEQ, makeHeapExo, makeStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import {
@@ -150,7 +150,7 @@ const makeMultiCandidateVoteCounter = (
     });
   };
 
-  const closeFacet = makeHeapFarInstance(
+  const closeFacet = makeHeapExo(
     'MultiCandidateVoteCounter close',
     VoteCounterCloseI,
     {
@@ -161,7 +161,7 @@ const makeMultiCandidateVoteCounter = (
     },
   );
 
-  const creatorFacet = makeHeapFarInstance(
+  const creatorFacet = makeHeapExo(
     'MultiCandidateVoteCounter creator',
     VoteCounterAdminI,
     {
@@ -184,7 +184,7 @@ const makeMultiCandidateVoteCounter = (
     },
   );
 
-  const publicFacet = makeHeapFarInstance(
+  const publicFacet = makeHeapExo(
     'MultiCandidateVoteCounter public',
     VoteCounterPublicI,
     {

--- a/packages/governance/src/noActionElectorate.js
+++ b/packages/governance/src/noActionElectorate.js
@@ -1,6 +1,6 @@
 import { makePublishKit } from '@agoric/notifier';
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeHeapFarInstance } from '@agoric/store';
+import { makeHeapExo } from '@agoric/store';
 
 import { ElectoratePublicI, ElectorateCreatorI } from './typeGuards.js';
 
@@ -13,7 +13,7 @@ import { ElectoratePublicI, ElectorateCreatorI } from './typeGuards.js';
 const start = zcf => {
   const { subscriber } = makePublishKit();
 
-  const publicFacet = makeHeapFarInstance('publicFacet', ElectoratePublicI, {
+  const publicFacet = makeHeapExo('publicFacet', ElectoratePublicI, {
     getQuestionSubscriber() {
       return subscriber;
     },
@@ -35,7 +35,7 @@ const start = zcf => {
     },
   });
 
-  const creatorFacet = makeHeapFarInstance('creatorFacet', ElectorateCreatorI, {
+  const creatorFacet = makeHeapExo('creatorFacet', ElectorateCreatorI, {
     getPoserInvitation() {
       return zcf.makeInvitation(() => {},
       `noActionElectorate doesn't allow posing questions`);

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -1,4 +1,4 @@
-import { makeHeapFarInstance, fit, keyEQ, M } from '@agoric/store';
+import { makeHeapExo, fit, keyEQ, M } from '@agoric/store';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 
 import { QuestionI, QuestionSpecShape } from './typeGuards.js';
@@ -83,7 +83,7 @@ const buildQuestion = (questionSpec, counterInstance) => {
   const questionHandle = makeHandle('Question');
 
   /** @type {Question} */
-  return makeHeapFarInstance('question details', QuestionI, {
+  return makeHeapExo('question details', QuestionI, {
     getVoteCounter() {
       return counterInstance;
     },

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -1,5 +1,5 @@
 import '@agoric/governance/exported.js';
-import { makeScalarMapStore, M, makeHeapFarInstance, fit } from '@agoric/store';
+import { makeScalarMapStore, M, makeHeapExo, fit } from '@agoric/store';
 import '@agoric/zoe/exported.js';
 import '@agoric/zoe/src/contracts/exported.js';
 import { InstanceHandleShape } from '@agoric/zoe/src/typeGuards.js';
@@ -89,14 +89,10 @@ export const start = async zcf => {
       TimestampShape,
     ).returns(M.promise()),
   });
-  const invitationMakers = makeHeapFarInstance(
-    'Charter Invitation Makers',
-    MakerI,
-    {
-      VoteOnParamChange: makeParamInvitation,
-      VoteOnPauseOffers: makeOfferFilterInvitation,
-    },
-  );
+  const invitationMakers = makeHeapExo('Charter Invitation Makers', MakerI, {
+    VoteOnParamChange: makeParamInvitation,
+    VoteOnPauseOffers: makeOfferFilterInvitation,
+  });
 
   const charterMemberHandler = seat => {
     seat.exit();
@@ -110,23 +106,19 @@ export const start = async zcf => {
     makeCharterMemberInvitation: M.call().returns(M.promise()),
   });
 
-  const creatorFacet = makeHeapFarInstance(
-    'Charter creatorFacet',
-    charterCreatorI,
-    {
-      /**
-       * @param {Instance} governedInstance
-       * @param {GovernedContractFacetAccess<{},{}>} governorFacet
-       * @param {string} [label] for diagnostic use only
-       */
-      addInstance: (governedInstance, governorFacet, label) => {
-        console.log('charter: adding instance', label);
-        instanceToGovernor.init(governedInstance, governorFacet);
-      },
-      makeCharterMemberInvitation: () =>
-        zcf.makeInvitation(charterMemberHandler, INVITATION_MAKERS_DESC),
+  const creatorFacet = makeHeapExo('Charter creatorFacet', charterCreatorI, {
+    /**
+     * @param {Instance} governedInstance
+     * @param {GovernedContractFacetAccess<{},{}>} governorFacet
+     * @param {string} [label] for diagnostic use only
+     */
+    addInstance: (governedInstance, governorFacet, label) => {
+      console.log('charter: adding instance', label);
+      instanceToGovernor.init(governedInstance, governorFacet);
     },
-  );
+    makeCharterMemberInvitation: () =>
+      zcf.makeInvitation(charterMemberHandler, INVITATION_MAKERS_DESC),
+  });
 
   return harden({ creatorFacet });
 };

--- a/packages/inter-protocol/src/price/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/price/priceAggregatorChainlink.js
@@ -9,7 +9,7 @@ import {
   makeStoredPublishKit,
   makeStoredSubscriber,
   observeNotifier,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
 } from '@agoric/notifier';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeOnewayPriceAuthorityKit } from '@agoric/zoe/src/contractSupport/index.js';
@@ -115,12 +115,12 @@ export const start = async (zcf, privateArgs, baggage) => {
   const { marshaller, storageNode } = privateArgs;
   assertAllDefined({ marshaller, storageNode });
 
-  const makeAnswerPublishKit = vivifyDurablePublishKit(
+  const makeAnswerPublishKit = prepareDurablePublishKit(
     baggage,
     'AnswerPublishKit',
   );
 
-  const makeLatestRoundPublishKit = vivifyDurablePublishKit(
+  const makeLatestRoundPublishKit = prepareDurablePublishKit(
     baggage,
     'LatestRoundPublishKit',
   );

--- a/packages/inter-protocol/src/price/priceOracleAdmin.js
+++ b/packages/inter-protocol/src/price/priceOracleAdmin.js
@@ -1,4 +1,4 @@
-import { makeDurableExoFactory, M, makeKindHandle } from '@agoric/vat-data';
+import { makeDurableExoMaker, M, makeKindHandle } from '@agoric/vat-data';
 
 export const INVITATION_MAKERS_DESC = 'oracle invitation';
 
@@ -52,7 +52,7 @@ const OracleAdminI = M.interface('OracleAdmin', {
   getStatus: M.call().returns(M.record()),
 });
 
-export const makeOracleAdmin = makeDurableExoFactory(
+export const makeOracleAdmin = makeDurableExoMaker(
   oracleAdminKind,
   OracleAdminI,
   initState,

--- a/packages/inter-protocol/src/price/priceOracleAdmin.js
+++ b/packages/inter-protocol/src/price/priceOracleAdmin.js
@@ -1,4 +1,4 @@
-import { defineDurableFarClass, M, makeKindHandle } from '@agoric/vat-data';
+import { makeDurableExoFactory, M, makeKindHandle } from '@agoric/vat-data';
 
 export const INVITATION_MAKERS_DESC = 'oracle invitation';
 
@@ -52,7 +52,7 @@ const OracleAdminI = M.interface('OracleAdmin', {
   getStatus: M.call().returns(M.record()),
 });
 
-export const makeOracleAdmin = defineDurableFarClass(
+export const makeOracleAdmin = makeDurableExoFactory(
   oracleAdminKind,
   OracleAdminI,
   initState,

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -3,7 +3,7 @@ import { AmountMath } from '@agoric/ertp';
 import { isNat, Nat } from '@agoric/nat';
 import { TimeMath } from '@agoric/swingset-vat/src/vats/timer/timeMath.js';
 import {
-  defineDurableFarClassKit,
+  makeDurableExoKitFactory,
   M,
   makeKindHandle,
   makeScalarBigMapStore,
@@ -94,7 +94,7 @@ const validRoundId = roundId => {
  */
 /** @typedef {ImmutableState & MutableState} State */
 
-export const makeRoundsManagerKit = defineDurableFarClassKit(
+export const makeRoundsManagerKit = makeDurableExoKitFactory(
   roundsManagerKind,
   {
     helper: UnguardedHelperI,

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -3,7 +3,7 @@ import { AmountMath } from '@agoric/ertp';
 import { isNat, Nat } from '@agoric/nat';
 import { TimeMath } from '@agoric/swingset-vat/src/vats/timer/timeMath.js';
 import {
-  makeDurableExoKitFactory,
+  makeDurableExoKitMaker,
   M,
   makeKindHandle,
   makeScalarBigMapStore,
@@ -94,7 +94,7 @@ const validRoundId = roundId => {
  */
 /** @typedef {ImmutableState & MutableState} State */
 
-export const makeRoundsManagerKit = makeDurableExoKitFactory(
+export const makeRoundsManagerKit = makeDurableExoKitMaker(
   roundsManagerKind,
   {
     helper: UnguardedHelperI,

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -15,7 +15,7 @@ import {
   ParamTypes,
   publicMixinAPI,
 } from '@agoric/governance';
-import { M, provide, vivifyFarInstance } from '@agoric/vat-data';
+import { M, provide, defineExo } from '@agoric/vat-data';
 import { AmountMath } from '@agoric/ertp';
 
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
@@ -275,7 +275,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     },
     ...publicMixin,
   };
-  const publicFacet = vivifyFarInstance(
+  const publicFacet = defineExo(
     baggage,
     'Parity Stability Module',
     PSMI,

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -15,7 +15,7 @@ import {
   ParamTypes,
   publicMixinAPI,
 } from '@agoric/governance';
-import { M, provide, defineExo } from '@agoric/vat-data';
+import { M, provide, prepareExo } from '@agoric/vat-data';
 import { AmountMath } from '@agoric/ertp';
 
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
@@ -275,7 +275,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     },
     ...publicMixin,
   };
-  const publicFacet = defineExo(
+  const publicFacet = prepareExo(
     baggage,
     'Parity Stability Module',
     PSMI,

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -5,7 +5,7 @@ import {
   offerTo,
   atomicTransfer,
 } from '@agoric/zoe/src/contractSupport/index.js';
-import { provideDurableMapStore, vivifyKindMulti } from '@agoric/vat-data';
+import { provideDurableMapStore, prepareKindMulti } from '@agoric/vat-data';
 
 import { AMM_INSTANCE } from './params.js';
 import { makeTracer } from '../makeTracer.js';
@@ -431,7 +431,7 @@ const start = async (zcf, privateArgs, baggage) => {
     }),
   );
 
-  const makeAssetReserve = vivifyKindMulti(baggage, 'assetReserve', init, {
+  const makeAssetReserve = prepareKindMulti(baggage, 'assetReserve', init, {
     publicFacet,
     creatorFacet: governorFacet,
     shortfallReportingFacet,

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -1,6 +1,6 @@
 import { AmountMath, AmountShape } from '@agoric/ertp';
 import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
-import { M, vivifyFarClassKit } from '@agoric/vat-data';
+import { M, defineExoKitFactory } from '@agoric/vat-data';
 import {
   assertProposalShape,
   atomicTransfer,
@@ -215,8 +215,8 @@ export const VaultI = M.interface('Vault', {
 export const vivifyVault = baggage => {
   const makeVaultKit = vivifyVaultKit(baggage);
 
-  // TODO find a way to not have to indent a level deeper than defineDurableFarClassKit does
-  const maker = vivifyFarClassKit(
+  // TODO find a way to not have to indent a level deeper than makeDurableExoKitFactory does
+  const maker = defineExoKitFactory(
     baggage,
     'Vault',
     {

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -1,6 +1,6 @@
 import { AmountMath, AmountShape } from '@agoric/ertp';
 import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
-import { M, defineExoKitFactory } from '@agoric/vat-data';
+import { M, prepareExoKitMaker } from '@agoric/vat-data';
 import {
   assertProposalShape,
   atomicTransfer,
@@ -18,7 +18,7 @@ import {
 import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
 import { makeTracer } from '../makeTracer.js';
 import { UnguardedHelperI } from '../typeGuards.js';
-import { vivifyVaultKit } from './vaultKit.js';
+import { prepareVaultKit } from './vaultKit.js';
 
 import '@agoric/zoe/exported.js';
 
@@ -212,11 +212,11 @@ export const VaultI = M.interface('Vault', {
   makeTransferInvitation: M.call().returns(M.promise()),
 });
 
-export const vivifyVault = baggage => {
-  const makeVaultKit = vivifyVaultKit(baggage);
+export const prepareVault = baggage => {
+  const makeVaultKit = prepareVaultKit(baggage);
 
-  // TODO find a way to not have to indent a level deeper than makeDurableExoKitFactory does
-  const maker = defineExoKitFactory(
+  // TODO find a way to not have to indent a level deeper than makeDurableExoKitMaker does
+  const maker = prepareExoKitMaker(
     baggage,
     'Vault',
     {
@@ -846,4 +846,4 @@ export const vivifyVault = baggage => {
   return maker;
 };
 
-/** @typedef {ReturnType<ReturnType<typeof vivifyVault>>['self']} Vault */
+/** @typedef {ReturnType<ReturnType<typeof prepareVault>>['self']} Vault */

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -22,7 +22,7 @@ import {
   vivifyDurablePublishKit,
 } from '@agoric/notifier';
 import {
-  defineDurableFarClassKit,
+  makeDurableExoKitFactory,
   makeKindHandle,
   makeScalarBigMapStore,
 } from '@agoric/vat-data';
@@ -276,7 +276,7 @@ const finish = async ({ state }) => {
  * @param {import('@agoric/governance/src/contractGovernance/typedParamManager').TypedParamManager<import('./params.js').VaultDirectorParams>} directorParamManager
  * @param {ZCFMint<"nat">} debtMint
  */
-const makeVaultDirector = defineDurableFarClassKit(
+const makeVaultDirector = makeDurableExoKitFactory(
   makeKindHandle('VaultDirector'),
   {
     creator: M.interface('creator', {

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -19,10 +19,10 @@ import {
   makeStoredSubscriber,
   observeIteration,
   SubscriberShape,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
 } from '@agoric/notifier';
 import {
-  makeDurableExoKitFactory,
+  makeDurableExoKitMaker,
   makeKindHandle,
   makeScalarBigMapStore,
 } from '@agoric/vat-data';
@@ -35,7 +35,7 @@ import {
   SHORTFALL_INVITATION_KEY,
   vaultParamPattern,
 } from './params.js';
-import { vivifyVaultManagerKit } from './vaultManager.js';
+import { prepareVaultManagerKit } from './vaultManager.js';
 import { provideChildBaggage } from '../contractSupport.js';
 
 const { details: X, quote: q, Fail } = assert;
@@ -152,7 +152,7 @@ const baggage = makeScalarBigMapStore('Vault Director baggage', {
   durable: true,
 });
 
-const makeVaultDirectorMetricsPublishKit = vivifyDurablePublishKit(
+const makeVaultDirectorMetricsPublishKit = prepareDurablePublishKit(
   baggage,
   'Vault Director metrics',
 );
@@ -276,7 +276,7 @@ const finish = async ({ state }) => {
  * @param {import('@agoric/governance/src/contractGovernance/typedParamManager').TypedParamManager<import('./params.js').VaultDirectorParams>} directorParamManager
  * @param {ZCFMint<"nat">} debtMint
  */
-const makeVaultDirector = makeDurableExoKitFactory(
+const makeVaultDirector = makeDurableExoKitMaker(
   makeKindHandle('VaultDirector'),
   {
     creator: M.interface('creator', {
@@ -471,7 +471,7 @@ const makeVaultDirector = makeDurableExoKitFactory(
         const brandName = await E(collateralBrand).getAllegedName();
         const makeVaultManager = managerBaggages.addChild(
           brandName,
-          vivifyVaultManagerKit,
+          prepareVaultManagerKit,
         );
 
         const { self: vm } = makeVaultManager(

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -5,9 +5,9 @@ import { AmountShape } from '@agoric/ertp';
 import {
   makeStoredSubscriber,
   SubscriberShape,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
 } from '@agoric/notifier';
-import { M, defineExoKitFactory } from '@agoric/vat-data';
+import { M, prepareExoKitMaker } from '@agoric/vat-data';
 import { makeEphemeraProvider } from '../contractSupport.js';
 import { UnguardedHelperI } from '../typeGuards.js';
 
@@ -43,13 +43,13 @@ const HolderI = M.interface('holder', {
  *
  * @param {import('@agoric/ertp').Baggage} baggage
  */
-export const vivifyVaultHolder = baggage => {
-  const makeVaultHolderPublishKit = vivifyDurablePublishKit(
+export const prepareVaultHolder = baggage => {
+  const makeVaultHolderPublishKit = prepareDurablePublishKit(
     baggage,
     'Vault Holder publish kit',
   );
 
-  const makeVaultHolderKit = defineExoKitFactory(
+  const makeVaultHolderKit = prepareExoKitMaker(
     baggage,
     'Vault Holder',
     {

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -7,7 +7,7 @@ import {
   SubscriberShape,
   vivifyDurablePublishKit,
 } from '@agoric/notifier';
-import { M, vivifyFarClassKit } from '@agoric/vat-data';
+import { M, defineExoKitFactory } from '@agoric/vat-data';
 import { makeEphemeraProvider } from '../contractSupport.js';
 import { UnguardedHelperI } from '../typeGuards.js';
 
@@ -49,7 +49,7 @@ export const vivifyVaultHolder = baggage => {
     'Vault Holder publish kit',
   );
 
-  const makeVaultHolderKit = vivifyFarClassKit(
+  const makeVaultHolderKit = defineExoKitFactory(
     baggage,
     'Vault Holder',
     {

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -1,9 +1,9 @@
 import '@agoric/zoe/exported.js';
 import { Far } from '@endo/marshal';
-import { vivifyVaultHolder } from './vaultHolder.js';
+import { prepareVaultHolder } from './vaultHolder.js';
 
-export const vivifyVaultKit = baggage => {
-  const makeVaultHolder = vivifyVaultHolder(baggage);
+export const prepareVaultKit = baggage => {
+  const makeVaultHolder = prepareVaultHolder(baggage);
   /**
    * Create a kit of utilities for use of the vault.
    *
@@ -33,4 +33,4 @@ export const vivifyVaultKit = baggage => {
   return makeVaultKit;
 };
 
-/** @typedef {(ReturnType<ReturnType<typeof vivifyVaultKit>>)} VaultKit */
+/** @typedef {(ReturnType<ReturnType<typeof prepareVaultKit>>)} VaultKit */

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -25,7 +25,7 @@ import {
   M,
   makeScalarBigMapStore,
   makeScalarBigSetStore,
-  vivifyFarClassKit,
+  defineExoKitFactory,
 } from '@agoric/vat-data';
 import {
   assertProposalShape,
@@ -332,8 +332,8 @@ export const vivifyVaultManagerKit = baggage => {
     return state;
   };
 
-  // TODO find a way to not have to indent a level deeper than defineDurableFarClassKit does
-  return vivifyFarClassKit(
+  // TODO find a way to not have to indent a level deeper than makeDurableExoKitFactory does
+  return defineExoKitFactory(
     baggage,
     'VaultManagerKit',
     {

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -19,13 +19,13 @@ import {
   makeStoredSubscriber,
   observeNotifier,
   SubscriberShape,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
 } from '@agoric/notifier';
 import {
   M,
   makeScalarBigMapStore,
   makeScalarBigSetStore,
-  defineExoKitFactory,
+  prepareExoKitMaker,
 } from '@agoric/vat-data';
 import {
   assertProposalShape,
@@ -45,7 +45,7 @@ import { chargeInterest } from '../interest.js';
 import { makeTracer } from '../makeTracer.js';
 import { liquidate, makeQuote, updateQuote } from './liquidation.js';
 import { makePrioritizedVaults } from './prioritizedVaults.js';
-import { Phase, vivifyVault } from './vault.js';
+import { Phase, prepareVault } from './vault.js';
 
 const { details: X } = assert;
 
@@ -188,13 +188,13 @@ const finish = context => {
 
 // TODO move params of initState here because it's a singleton
 // and remove from State what doesn't need to be stored between upgrades
-export const vivifyVaultManagerKit = baggage => {
-  const makeVault = vivifyVault(baggage);
-  const makeVaultManagerMetricsPublishKit = vivifyDurablePublishKit(
+export const prepareVaultManagerKit = baggage => {
+  const makeVault = prepareVault(baggage);
+  const makeVaultManagerMetricsPublishKit = prepareDurablePublishKit(
     baggage,
     'Vault Manager metrics',
   );
-  const makeVaultManagerAssetsPublishKit = vivifyDurablePublishKit(
+  const makeVaultManagerAssetsPublishKit = prepareDurablePublishKit(
     baggage,
     'Vault Manager assets',
   );
@@ -332,8 +332,8 @@ export const vivifyVaultManagerKit = baggage => {
     return state;
   };
 
-  // TODO find a way to not have to indent a level deeper than makeDurableExoKitFactory does
-  return defineExoKitFactory(
+  // TODO find a way to not have to indent a level deeper than makeDurableExoKitMaker does
+  return prepareExoKitMaker(
     baggage,
     'VaultManagerKit',
     {
@@ -1062,7 +1062,7 @@ export const vivifyVaultManagerKit = baggage => {
 };
 
 /**
- * @typedef {ReturnType<ReturnType<typeof vivifyVaultManagerKit>>['self']} VaultManager
+ * @typedef {ReturnType<ReturnType<typeof prepareVaultManagerKit>>['self']} VaultManager
  * Each VaultManager manages a single collateral type.
  *
  * It manages some number of outstanding loans, each called a Vault, for which

--- a/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -14,7 +14,7 @@ import {
   provideDurableMapStore,
   provideDurableWeakMapStore,
   provide,
-  vivifyKindMulti,
+  prepareKindMulti,
 } from '@agoric/vat-data';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import { makeMetricsPublisherKit } from '../contractSupport.js';
@@ -479,7 +479,7 @@ const start = async (zcf, privateArgs, baggage) => {
     }),
   );
 
-  const makeAMM = vivifyKindMulti(baggage, 'AMM', initEmpty, {
+  const makeAMM = prepareKindMulti(baggage, 'AMM', initEmpty, {
     publicFacet,
     creatorFacet: governorFacet,
     limitedCreatorFacet,

--- a/packages/inter-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/pool.js
@@ -2,7 +2,7 @@ import '@agoric/zoe/exported.js';
 
 import { AmountMath, isNatValue } from '@agoric/ertp';
 import { makeStoredPublishKit } from '@agoric/notifier';
-import { vivifyKindMulti } from '@agoric/vat-data';
+import { prepareKindMulti } from '@agoric/vat-data';
 import {
   calcLiqValueToMint,
   calcSecondaryRequired,
@@ -394,5 +394,5 @@ export const definePoolKind = (baggage, ammPowers, storageNode, marshaller) => {
     singlePool: makeSinglePool(ammPowers),
   });
 
-  return vivifyKindMulti(baggage, 'pool', poolInit, facets, { finish });
+  return prepareKindMulti(baggage, 'pool', poolInit, facets, { finish });
 };

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -20,7 +20,7 @@ import {
 import { getAmountOut } from '@agoric/zoe/src/contractSupport';
 import { E } from '@endo/eventual-send';
 import { paymentFromZCFMint } from '../../src/vaultFactory/burn.js';
-import { vivifyVault } from '../../src/vaultFactory/vault.js';
+import { prepareVault } from '../../src/vaultFactory/vault.js';
 
 const BASIS_POINTS = 10000n;
 const SECONDS_PER_HOUR = 60n * 60n;
@@ -156,7 +156,7 @@ export async function start(zcf, privateArgs, baggage) {
     },
   });
 
-  const makeVault = vivifyVault(baggage);
+  const makeVault = prepareVault(baggage);
 
   const { self: vault } = await makeVault(
     zcf,

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -2,7 +2,7 @@ export {
   makePublishKit,
   subscribeEach,
   subscribeLatest,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
   SubscriberShape,
 } from './publish-kit.js';
 export {

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -4,7 +4,7 @@ import { HandledPromise, E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';
-import { canBeDurable, vivifyFarClassKit } from '@agoric/vat-data';
+import { canBeDurable, defineExoKitFactory } from '@agoric/vat-data';
 
 import './types-ambient.js';
 
@@ -385,7 +385,7 @@ export const vivifyDurablePublishKit = (baggage, kindName) => {
   /**
    * @returns {() => PublishKit<*>}
    */
-  return vivifyFarClassKit(
+  return defineExoKitFactory(
     baggage,
     kindName,
     publishKitIKit,

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -4,7 +4,7 @@ import { HandledPromise, E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';
-import { canBeDurable, defineExoKitFactory } from '@agoric/vat-data';
+import { canBeDurable, prepareExoKitMaker } from '@agoric/vat-data';
 
 import './types-ambient.js';
 
@@ -381,11 +381,11 @@ const advanceDurablePublishKit = (context, done, value, rejection) => {
  * @param {import('../../vat-data/src/types.js').Baggage} baggage
  * @param {string} kindName
  */
-export const vivifyDurablePublishKit = (baggage, kindName) => {
+export const prepareDurablePublishKit = (baggage, kindName) => {
   /**
    * @returns {() => PublishKit<*>}
    */
-  return defineExoKitFactory(
+  return prepareExoKitMaker(
     baggage,
     kindName,
     publishKitIKit,
@@ -430,6 +430,6 @@ export const vivifyDurablePublishKit = (baggage, kindName) => {
     },
   );
 };
-harden(vivifyDurablePublishKit);
+harden(prepareDurablePublishKit);
 
 export const SubscriberShape = M.remotable('Subscriber');

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -16,7 +16,7 @@ import {
   makePublishKit,
   subscribeEach,
   subscribeLatest,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
 } from '../src/index.js';
 import '../src/types-ambient.js';
 import { invertPromiseSettlement } from './iterable-testing-tools.js';
@@ -32,7 +32,7 @@ const makeBaggage = () => makeScalarBigMapStore('baggage', { durable: true });
 
 const makers = {
   publishKit: makePublishKit,
-  durablePublishKit: vivifyDurablePublishKit(
+  durablePublishKit: prepareDurablePublishKit(
     makeBaggage(),
     'DurablePublishKit',
   ),
@@ -203,7 +203,7 @@ test('publish kit allows non-durable values', async t => {
   await assertTransmission(t, makePublishKit(), nonPassable, 'fail');
 });
 test('durable publish kit rejects non-durable values', async t => {
-  const makeDurablePublishKit = vivifyDurablePublishKit(
+  const makeDurablePublishKit = prepareDurablePublishKit(
     makeBaggage(),
     'DurablePublishKit',
   );
@@ -374,7 +374,7 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
 // https://github.com/Agoric/agoric-sdk/pull/6502#discussion_r1008492055
 test.skip('durable publish kit upgrade trauma', async t => {
   const baggage = makeBaggage();
-  const makeDurablePublishKit = vivifyDurablePublishKit(
+  const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,
     'DurablePublishKit',
   );

--- a/packages/notifier/test/vat-integration/vat-pubsub.js
+++ b/packages/notifier/test/vat-integration/vat-pubsub.js
@@ -1,9 +1,9 @@
 import { Far } from '@endo/marshal';
 import { provide } from '@agoric/vat-data';
-import { vivifyDurablePublishKit } from '../../src/index.js';
+import { prepareDurablePublishKit } from '../../src/index.js';
 
 export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
-  const makeDurablePublishKit = vivifyDurablePublishKit(
+  const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,
     'DurablePublishKit',
   );

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -10,7 +10,7 @@ import {
 import { makeStoredPublishKit, observeNotifier } from '@agoric/notifier';
 import { fit, M, makeScalarMapStore } from '@agoric/store';
 import {
-  defineVirtualFarClassKit,
+  makeVirtualExoKitFactory,
   makeScalarBigMapStore,
   pickFacet,
 } from '@agoric/vat-data';
@@ -239,7 +239,7 @@ const behaviorGuards = {
   }),
 };
 
-const SmartWalletKit = defineVirtualFarClassKit(
+const SmartWalletKit = makeVirtualExoKitFactory(
   'SmartWallet',
   behaviorGuards,
   initState,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -10,7 +10,7 @@ import {
 import { makeStoredPublishKit, observeNotifier } from '@agoric/notifier';
 import { fit, M, makeScalarMapStore } from '@agoric/store';
 import {
-  makeVirtualExoKitFactory,
+  makeVirtualExoKitMaker,
   makeScalarBigMapStore,
   pickFacet,
 } from '@agoric/vat-data';
@@ -239,7 +239,7 @@ const behaviorGuards = {
   }),
 };
 
-const SmartWalletKit = makeVirtualExoKitFactory(
+const SmartWalletKit = makeVirtualExoKitMaker(
   'SmartWallet',
   behaviorGuards,
   initState,

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -5,7 +5,7 @@
  */
 
 import { WalletName } from '@agoric/internal';
-import { fit, M, makeHeapFarInstance, makeScalarMapStore } from '@agoric/store';
+import { fit, M, makeHeapExo, makeScalarMapStore } from '@agoric/store';
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeMyAddressNameAdminKit } from '@agoric/vats/src/core/basic-behaviors.js';
@@ -139,7 +139,7 @@ export const start = async (zcf, privateArgs) => {
   const walletsByAddress = makeScalarBigMapStore('walletsByAddress');
   const provider = makeAtomicProvider(walletsByAddress);
 
-  const handleWalletAction = makeHeapFarInstance(
+  const handleWalletAction = makeHeapExo(
     'walletActionHandler',
     M.interface('walletActionHandlerI', {
       fromBridge: M.call(shape.WalletBridgeMsg).returns(M.promise()),
@@ -201,7 +201,7 @@ export const start = async (zcf, privateArgs) => {
     zoe,
   });
 
-  const creatorFacet = makeHeapFarInstance(
+  const creatorFacet = makeHeapExo(
     'walletFactoryCreator',
     M.interface('walletFactoryCreatorI', {
       provideSmartWallet: M.callWhen(

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -58,8 +58,8 @@ export {
   defendPrototype,
   defendPrototypeKit,
   initEmpty,
-  makeHeapExoFactory,
-  makeHeapExoKitFactory,
+  makeHeapExoMaker,
+  makeHeapExoKitMaker,
   makeHeapExo,
 } from './patterns/interface-tools.js';
 

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -58,9 +58,9 @@ export {
   defendPrototype,
   defendPrototypeKit,
   initEmpty,
-  defineHeapFarClass,
-  defineHeapFarClassKit,
-  makeHeapFarInstance,
+  makeHeapExoFactory,
+  makeHeapExoKitFactory,
+  makeHeapExo,
 } from './patterns/interface-tools.js';
 
 export { makeScalarWeakSetStore } from './stores/scalarWeakSetStore.js';

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -279,7 +279,7 @@ const emptyRecord = harden({});
 /**
  * When calling `defineDurableKind` and
  * its siblings, used as the `init` function argument to indicate that the
- * state record of the (virtual/durable) instances of the kind/farClass
+ * state record of the (virtual/durable) instances of the kind/ExoFactory
  * should be empty, and that the returned maker function should have zero
  * parameters.
  *
@@ -306,7 +306,7 @@ export const initEmpty = () => emptyRecord;
  * @param {object} [options]
  * @returns {(...args: A[]) => (T & import('@endo/eventual-send').RemotableBrand<{}, T>)}
  */
-export const defineHeapFarClass = (
+export const makeHeapExoFactory = (
   tag,
   interfaceGuard,
   init,
@@ -343,7 +343,7 @@ export const defineHeapFarClass = (
   // @ts-expect-error could be instantiated with different subtype
   return harden(makeInstance);
 };
-harden(defineHeapFarClass);
+harden(makeHeapExoFactory);
 
 /**
  * @template A args to init
@@ -356,7 +356,7 @@ harden(defineHeapFarClass);
  * @param {object} [options]
  * @returns {(...args: A[]) => F}
  */
-export const defineHeapFarClassKit = (
+export const makeHeapExoKitFactory = (
   tag,
   interfaceGuardKit,
   init,
@@ -396,7 +396,7 @@ export const defineHeapFarClassKit = (
   // @ts-ignore xxx
   return harden(makeInstanceKit);
 };
-harden(defineHeapFarClassKit);
+harden(makeHeapExoKitFactory);
 
 /**
  * @template {Record<string, Method>} T
@@ -406,13 +406,13 @@ harden(defineHeapFarClassKit);
  * @param {object} [options]
  * @returns {T & import('@endo/eventual-send').RemotableBrand<{}, T>}
  */
-export const makeHeapFarInstance = (
+export const makeHeapExo = (
   tag,
   interfaceGuard,
   methods,
   options = undefined,
 ) => {
-  const makeInstance = defineHeapFarClass(
+  const makeInstance = makeHeapExoFactory(
     tag,
     interfaceGuard,
     initEmpty,
@@ -421,4 +421,4 @@ export const makeHeapFarInstance = (
   );
   return makeInstance();
 };
-harden(makeHeapFarInstance);
+harden(makeHeapExo);

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -279,7 +279,7 @@ const emptyRecord = harden({});
 /**
  * When calling `defineDurableKind` and
  * its siblings, used as the `init` function argument to indicate that the
- * state record of the (virtual/durable) instances of the kind/ExoFactory
+ * state record of the (virtual/durable) instances of the kind/ExoMaker
  * should be empty, and that the returned maker function should have zero
  * parameters.
  *
@@ -306,7 +306,7 @@ export const initEmpty = () => emptyRecord;
  * @param {object} [options]
  * @returns {(...args: A[]) => (T & import('@endo/eventual-send').RemotableBrand<{}, T>)}
  */
-export const makeHeapExoFactory = (
+export const makeHeapExoMaker = (
   tag,
   interfaceGuard,
   init,
@@ -343,7 +343,7 @@ export const makeHeapExoFactory = (
   // @ts-expect-error could be instantiated with different subtype
   return harden(makeInstance);
 };
-harden(makeHeapExoFactory);
+harden(makeHeapExoMaker);
 
 /**
  * @template A args to init
@@ -356,7 +356,7 @@ harden(makeHeapExoFactory);
  * @param {object} [options]
  * @returns {(...args: A[]) => F}
  */
-export const makeHeapExoKitFactory = (
+export const makeHeapExoKitMaker = (
   tag,
   interfaceGuardKit,
   init,
@@ -396,7 +396,7 @@ export const makeHeapExoKitFactory = (
   // @ts-ignore xxx
   return harden(makeInstanceKit);
 };
-harden(makeHeapExoKitFactory);
+harden(makeHeapExoKitMaker);
 
 /**
  * @template {Record<string, Method>} T
@@ -412,7 +412,7 @@ export const makeHeapExo = (
   methods,
   options = undefined,
 ) => {
-  const makeInstance = makeHeapExoFactory(
+  const makeInstance = makeHeapExoMaker(
     tag,
     interfaceGuard,
     initEmpty,

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -1,8 +1,8 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import {
-  defineHeapFarClass,
-  defineHeapFarClassKit,
-  makeHeapFarInstance,
+  makeHeapExoFactory,
+  makeHeapExoKitFactory,
+  makeHeapExo,
 } from '../src/patterns/interface-tools.js';
 import { M } from '../src/patterns/patternMatchers.js';
 
@@ -20,8 +20,8 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineHeapFarClass', t => {
-  const makeUpCounter = defineHeapFarClass(
+test('test makeHeapExoFactory', t => {
+  const makeUpCounter = makeHeapExoFactory(
     'UpCounter',
     UpCounterI,
     /** @param {number} x */
@@ -47,8 +47,8 @@ test('test defineHeapFarClass', t => {
   });
 });
 
-test('test defineHeapFarClassKit', t => {
-  const makeCounterKit = defineHeapFarClassKit(
+test('test makeHeapExoKitFactory', t => {
+  const makeCounterKit = makeHeapExoKitFactory(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
     /** @param {number} x */
@@ -93,9 +93,9 @@ test('test defineHeapFarClassKit', t => {
   });
 });
 
-test('test makeHeapFarInstance', t => {
+test('test makeHeapExo', t => {
   let x = 3;
-  const upCounter = makeHeapFarInstance('upCounter', UpCounterI, {
+  const upCounter = makeHeapExo('upCounter', UpCounterI, {
     incr(y = 1) {
       x += y;
       return x;
@@ -115,13 +115,13 @@ test('test makeHeapFarInstance', t => {
 // For code sharing with defineKind which does not support an interface
 test('missing interface', t => {
   t.notThrows(() =>
-    makeHeapFarInstance('greeter', undefined, {
+    makeHeapExo('greeter', undefined, {
       sayHello() {
         return 'hello';
       },
     }),
   );
-  const greeterMaker = makeHeapFarInstance('greeterMaker', undefined, {
+  const greeterMaker = makeHeapExo('greeterMaker', undefined, {
     makeSayHello() {
       return () => 'hello';
     },
@@ -134,7 +134,7 @@ test('missing interface', t => {
 
 test('sloppy option', t => {
   const emptyBehavior = {};
-  const greeter = makeHeapFarInstance(
+  const greeter = makeHeapExo(
     'greeter',
     M.interface('greeter', emptyBehavior, { sloppy: true }),
     {
@@ -147,7 +147,7 @@ test('sloppy option', t => {
 
   t.throws(
     () =>
-      makeHeapFarInstance(
+      makeHeapExo(
         'greeter',
         M.interface('greeter', emptyBehavior, { sloppy: false }),
         {
@@ -161,7 +161,7 @@ test('sloppy option', t => {
 });
 
 test('naked function call', t => {
-  const greeter = makeHeapFarInstance(
+  const greeter = makeHeapExo(
     'greeter',
     M.interface('greeter', { sayHello: M.call().returns('hello') }),
     {
@@ -183,7 +183,7 @@ test('naked function call', t => {
 // needn't run. we just don't have a better place to write these.
 test.skip('types', () => {
   // any methods can be defined if there's no interface
-  const unguarded = makeHeapFarInstance('upCounter', undefined, {
+  const unguarded = makeHeapExo('upCounter', undefined, {
     /** @param {number} val */
     incr(val) {
       return val;
@@ -199,7 +199,7 @@ test.skip('types', () => {
   unguarded.notInBehavior;
 
   // TODO when there is an interface, error if a method is missing from it
-  const guarded = makeHeapFarInstance('upCounter', UpCounterI, {
+  const guarded = makeHeapExo('upCounter', UpCounterI, {
     /** @param {number} val */
     incr(val) {
       return val;

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -1,7 +1,7 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import {
-  makeHeapExoFactory,
-  makeHeapExoKitFactory,
+  makeHeapExoMaker,
+  makeHeapExoKitMaker,
   makeHeapExo,
 } from '../src/patterns/interface-tools.js';
 import { M } from '../src/patterns/patternMatchers.js';
@@ -20,8 +20,8 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test makeHeapExoFactory', t => {
-  const makeUpCounter = makeHeapExoFactory(
+test('test makeHeapExoMaker', t => {
+  const makeUpCounter = makeHeapExoMaker(
     'UpCounter',
     UpCounterI,
     /** @param {number} x */
@@ -47,8 +47,8 @@ test('test makeHeapExoFactory', t => {
   });
 });
 
-test('test makeHeapExoKitFactory', t => {
-  const makeCounterKit = makeHeapExoKitFactory(
+test('test makeHeapExoKitMaker', t => {
+  const makeCounterKit = makeHeapExoKitMaker(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
     /** @param {number} x */

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -28,7 +28,7 @@ import {
  * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const defineVirtualFarClass = (
+export const makeVirtualExoFactory = (
   tag,
   interfaceGuard,
   init,
@@ -42,7 +42,7 @@ export const defineVirtualFarClass = (
     thisfulMethods: true,
     interfaceGuard,
   });
-harden(defineVirtualFarClass);
+harden(makeVirtualExoFactory);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -55,7 +55,7 @@ harden(defineVirtualFarClass);
  * @param {DefineKindOptions<{ facets: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const defineVirtualFarClassKit = (
+export const makeVirtualExoKitFactory = (
   tag,
   interfaceGuardKit,
   init,
@@ -69,7 +69,7 @@ export const defineVirtualFarClassKit = (
     thisfulMethods: true,
     interfaceGuard: interfaceGuardKit,
   });
-harden(defineVirtualFarClassKit);
+harden(makeVirtualExoKitFactory);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -82,7 +82,7 @@ harden(defineVirtualFarClassKit);
  * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const defineDurableFarClass = (
+export const makeDurableExoFactory = (
   kindHandle,
   interfaceGuard,
   init,
@@ -96,7 +96,7 @@ export const defineDurableFarClass = (
     thisfulMethods: true,
     interfaceGuard,
   });
-harden(defineDurableFarClass);
+harden(makeDurableExoFactory);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -109,7 +109,7 @@ harden(defineDurableFarClass);
  * @param {DefineKindOptions<{ facets: T, state: ReturnType<I>}>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const defineDurableFarClassKit = (
+export const makeDurableExoKitFactory = (
   kindHandle,
   interfaceGuardKit,
   init,
@@ -123,7 +123,7 @@ export const defineDurableFarClassKit = (
     thisfulMethods: true,
     interfaceGuard: interfaceGuardKit,
   });
-harden(defineDurableFarClassKit);
+harden(makeDurableExoKitFactory);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -137,7 +137,7 @@ harden(defineDurableFarClassKit);
  * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const vivifyFarClass = (
+export const defineExoFactory = (
   baggage,
   kindName,
   interfaceGuard,
@@ -145,14 +145,14 @@ export const vivifyFarClass = (
   methods,
   options = undefined,
 ) =>
-  defineDurableFarClass(
+  makeDurableExoFactory(
     provideKindHandle(baggage, kindName),
     interfaceGuard,
     init,
     methods,
     options,
   );
-harden(vivifyFarClass);
+harden(defineExoFactory);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -166,7 +166,7 @@ harden(vivifyFarClass);
  * @param {DefineKindOptions<{ facets: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const vivifyFarClassKit = (
+export const defineExoKitFactory = (
   baggage,
   kindName,
   interfaceGuardKit,
@@ -174,14 +174,14 @@ export const vivifyFarClassKit = (
   facets,
   options = undefined,
 ) =>
-  defineDurableFarClassKit(
+  makeDurableExoKitFactory(
     provideKindHandle(baggage, kindName),
     interfaceGuardKit,
     init,
     facets,
     options,
   );
-harden(vivifyFarClassKit);
+harden(defineExoKitFactory);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -194,14 +194,14 @@ harden(vivifyFarClassKit);
  * @param {DefineKindOptions<{ self: M }>} [options]
  * @returns {T & RemotableBrand<{}, T>}
  */
-export const vivifyFarInstance = (
+export const defineExo = (
   baggage,
   kindName,
   interfaceGuard,
   methods,
   options = undefined,
 ) => {
-  const makeSingleton = vivifyFarClass(
+  const makeSingleton = defineExoFactory(
     baggage,
     kindName,
     interfaceGuard,
@@ -214,10 +214,10 @@ export const vivifyFarInstance = (
   // @ts-ignore could be instantiated with an arbitrary type
   return provide(baggage, `the_${kindName}`, () => makeSingleton());
 };
-harden(vivifyFarInstance);
+harden(defineExo);
 
 /**
- * @deprecated Use vivifyFarInstance instead.
+ * @deprecated Use defineExo instead.
  * @template {Record<string | symbol, CallableFunction>} T methods
  * @param {Baggage} baggage
  * @param {string} kindName
@@ -230,5 +230,5 @@ export const vivifySingleton = (
   kindName,
   methods,
   options = undefined,
-) => vivifyFarInstance(baggage, kindName, undefined, methods, options);
+) => defineExo(baggage, kindName, undefined, methods, options);
 harden(vivifySingleton);

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -28,7 +28,7 @@ import {
  * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const makeVirtualExoFactory = (
+export const makeVirtualExoMaker = (
   tag,
   interfaceGuard,
   init,
@@ -42,7 +42,7 @@ export const makeVirtualExoFactory = (
     thisfulMethods: true,
     interfaceGuard,
   });
-harden(makeVirtualExoFactory);
+harden(makeVirtualExoMaker);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -55,7 +55,7 @@ harden(makeVirtualExoFactory);
  * @param {DefineKindOptions<{ facets: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const makeVirtualExoKitFactory = (
+export const makeVirtualExoKitMaker = (
   tag,
   interfaceGuardKit,
   init,
@@ -69,7 +69,7 @@ export const makeVirtualExoKitFactory = (
     thisfulMethods: true,
     interfaceGuard: interfaceGuardKit,
   });
-harden(makeVirtualExoKitFactory);
+harden(makeVirtualExoKitMaker);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -82,7 +82,7 @@ harden(makeVirtualExoKitFactory);
  * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const makeDurableExoFactory = (
+export const makeDurableExoMaker = (
   kindHandle,
   interfaceGuard,
   init,
@@ -96,7 +96,7 @@ export const makeDurableExoFactory = (
     thisfulMethods: true,
     interfaceGuard,
   });
-harden(makeDurableExoFactory);
+harden(makeDurableExoMaker);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -109,7 +109,7 @@ harden(makeDurableExoFactory);
  * @param {DefineKindOptions<{ facets: T, state: ReturnType<I>}>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const makeDurableExoKitFactory = (
+export const makeDurableExoKitMaker = (
   kindHandle,
   interfaceGuardKit,
   init,
@@ -123,7 +123,7 @@ export const makeDurableExoKitFactory = (
     thisfulMethods: true,
     interfaceGuard: interfaceGuardKit,
   });
-harden(makeDurableExoKitFactory);
+harden(makeDurableExoKitMaker);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -137,7 +137,7 @@ harden(makeDurableExoKitFactory);
  * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const defineExoFactory = (
+export const prepareExoMaker = (
   baggage,
   kindName,
   interfaceGuard,
@@ -145,14 +145,14 @@ export const defineExoFactory = (
   methods,
   options = undefined,
 ) =>
-  makeDurableExoFactory(
+  makeDurableExoMaker(
     provideKindHandle(baggage, kindName),
     interfaceGuard,
     init,
     methods,
     options,
   );
-harden(defineExoFactory);
+harden(prepareExoMaker);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -166,7 +166,7 @@ harden(defineExoFactory);
  * @param {DefineKindOptions<{ facets: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const defineExoKitFactory = (
+export const prepareExoKitMaker = (
   baggage,
   kindName,
   interfaceGuardKit,
@@ -174,14 +174,14 @@ export const defineExoKitFactory = (
   facets,
   options = undefined,
 ) =>
-  makeDurableExoKitFactory(
+  makeDurableExoKitMaker(
     provideKindHandle(baggage, kindName),
     interfaceGuardKit,
     init,
     facets,
     options,
   );
-harden(defineExoKitFactory);
+harden(prepareExoKitMaker);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -194,14 +194,14 @@ harden(defineExoKitFactory);
  * @param {DefineKindOptions<{ self: M }>} [options]
  * @returns {T & RemotableBrand<{}, T>}
  */
-export const defineExo = (
+export const prepareExo = (
   baggage,
   kindName,
   interfaceGuard,
   methods,
   options = undefined,
 ) => {
-  const makeSingleton = defineExoFactory(
+  const makeSingleton = prepareExoMaker(
     baggage,
     kindName,
     interfaceGuard,
@@ -214,10 +214,10 @@ export const defineExo = (
   // @ts-ignore could be instantiated with an arbitrary type
   return provide(baggage, `the_${kindName}`, () => makeSingleton());
 };
-harden(defineExo);
+harden(prepareExo);
 
 /**
- * @deprecated Use defineExo instead.
+ * @deprecated Use prepareExo instead.
  * @template {Record<string | symbol, CallableFunction>} T methods
  * @param {Baggage} baggage
  * @param {string} kindName
@@ -225,10 +225,10 @@ harden(defineExo);
  * @param {DefineKindOptions<{ self: T }>} [options]
  * @returns {T & RemotableBrand<{}, T>}
  */
-export const vivifySingleton = (
+export const prepareSingleton = (
   baggage,
   kindName,
   methods,
   options = undefined,
-) => defineExo(baggage, kindName, undefined, methods, options);
-harden(vivifySingleton);
+) => prepareExo(baggage, kindName, undefined, methods, options);
+harden(prepareSingleton);

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -2,14 +2,14 @@
 export * from './vat-data-bindings.js';
 export * from './kind-utils.js';
 export {
-  makeVirtualExoFactory,
-  makeVirtualExoKitFactory,
-  makeDurableExoFactory,
-  makeDurableExoKitFactory,
-  defineExoFactory,
-  defineExoKitFactory,
-  defineExo,
-  vivifySingleton,
+  makeVirtualExoMaker,
+  makeVirtualExoKitMaker,
+  makeDurableExoMaker,
+  makeDurableExoKitMaker,
+  prepareExoMaker,
+  prepareExoKitMaker,
+  prepareExo,
+  prepareSingleton,
 } from './exo-utils.js';
 
 /** @template T @typedef {import('./types.js').DefineKindOptions<T>} DefineKindOptions */

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -2,14 +2,14 @@
 export * from './vat-data-bindings.js';
 export * from './kind-utils.js';
 export {
-  defineVirtualFarClass,
-  defineVirtualFarClassKit,
-  defineDurableFarClass,
-  defineDurableFarClassKit,
-  vivifyFarClass,
-  vivifyFarClassKit,
-  vivifyFarInstance,
+  makeVirtualExoFactory,
+  makeVirtualExoKitFactory,
+  makeDurableExoFactory,
+  makeDurableExoKitFactory,
+  defineExoFactory,
+  defineExoKitFactory,
+  defineExo,
   vivifySingleton,
-} from './far-class-utils.js';
+} from './exo-utils.js';
 
 /** @template T @typedef {import('./types.js').DefineKindOptions<T>} DefineKindOptions */

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -30,7 +30,7 @@ export const provideKindHandle = (baggage, kindName) =>
 harden(provideKindHandle);
 
 /**
- * @deprecated Use vivifyFarClass instead
+ * @deprecated Use defineExoFactory instead
  * @type {import('./types.js').VivifyKind}
  */
 export const vivifyKind = (
@@ -49,7 +49,7 @@ export const vivifyKind = (
 harden(vivifyKind);
 
 /**
- * @deprecated Use vivifyFarClassKit instead
+ * @deprecated Use defineExoKitFactory instead
  * @type {import('./types.js').VivifyKindMulti}
  */
 export const vivifyKindMulti = (

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -30,10 +30,10 @@ export const provideKindHandle = (baggage, kindName) =>
 harden(provideKindHandle);
 
 /**
- * @deprecated Use defineExoFactory instead
+ * @deprecated Use prepareExoMaker instead
  * @type {import('./types.js').VivifyKind}
  */
-export const vivifyKind = (
+export const prepareKind = (
   baggage,
   kindName,
   init,
@@ -46,13 +46,13 @@ export const vivifyKind = (
     behavior,
     options,
   );
-harden(vivifyKind);
+harden(prepareKind);
 
 /**
- * @deprecated Use defineExoKitFactory instead
+ * @deprecated Use prepareExoKitMaker instead
  * @type {import('./types.js').VivifyKindMulti}
  */
-export const vivifyKindMulti = (
+export const prepareKindMulti = (
   baggage,
   kindName,
   init,
@@ -65,4 +65,4 @@ export const vivifyKindMulti = (
     behavior,
     options,
   );
-harden(vivifyKindMulti);
+harden(prepareKindMulti);

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -73,9 +73,9 @@ type DefineKindOptions<C> = {
    * Intended for internal use only.
    * Should the raw methods receive their `context` argument as their first
    * argument or as their `this` binding? For `defineDurableKind` and its
-   * siblings (including `vivifySingleton`), this defaults to off, meaning that
+   * siblings (including `prepareSingleton`), this defaults to off, meaning that
    * their behavior methods receive `context` as their first argument.
-   * `defineExoFactory` and its siblings (including `defineExo`) use
+   * `prepareExoMaker` and its siblings (including `prepareExo`) use
    * this flag internally to indicate that their methods receive `context`
    * as their `this` binding.
    */
@@ -88,7 +88,7 @@ type DefineKindOptions<C> = {
    * pattern is satisfied before calling the raw method.
    *
    * In `defineDurableKind` and its siblings, this defaults to off.
-   * `defineExoFactory` use this internally to protect their raw class methods
+   * `prepareExoMaker` use this internally to protect their raw class methods
    * using the provided interface.
    */
   interfaceGuard?: InterfaceGuard<unknown>;
@@ -96,7 +96,7 @@ type DefineKindOptions<C> = {
 
 export type VatData = {
   // virtual kinds
-  /** @deprecated Use makeVirtualExoFactory instead */
+  /** @deprecated Use makeVirtualExoMaker instead */
   defineKind: <P, S, F>(
     tag: string,
     init: (...args: P) => S,
@@ -104,7 +104,7 @@ export type VatData = {
     options?: DefineKindOptions<KindContext<S, F>>,
   ) => (...args: P) => KindFacet<F>;
 
-  /** @deprecated Use makeVirtualExoKitFactory instead */
+  /** @deprecated Use makeVirtualExoKitMaker instead */
   defineKindMulti: <P, S, B>(
     tag: string,
     init: (...args: P) => S,
@@ -115,7 +115,7 @@ export type VatData = {
   // durable kinds
   makeKindHandle: (descriptionTag: string) => DurableKindHandle;
 
-  /** @deprecated Use makeDurableExoFactory instead */
+  /** @deprecated Use makeDurableExoMaker instead */
   defineDurableKind: <P, S, F>(
     kindHandle: DurableKindHandle,
     init: (...args: P) => S,
@@ -123,7 +123,7 @@ export type VatData = {
     options?: DefineKindOptions<KindContext<S, F>>,
   ) => (...args: P) => KindFacet<F>;
 
-  /** @deprecated Use makeDurableExoKitFactory instead */
+  /** @deprecated Use makeDurableExoKitMaker instead */
   defineDurableKindMulti: <P, S, B>(
     kindHandle: DurableKindHandle,
     init: (...args: P) => S,
@@ -173,7 +173,7 @@ interface PickFacet {
   ): (...args: Parameters<M>) => ReturnType<M>[F];
 }
 
-/** @deprecated Use defineExoFactory instead */
+/** @deprecated Use prepareExoMaker instead */
 type VivifyKind = <P, S, F>(
   baggage: Baggage,
   tag: string,
@@ -182,7 +182,7 @@ type VivifyKind = <P, S, F>(
   options?: DefineKindOptions<KindContext<S, F>>,
 ) => (...args: P) => KindFacet<F>;
 
-/** @deprecated Use defineExoKitFactory instead */
+/** @deprecated Use prepareExoKitMaker instead */
 type VivifyKindMulti = <P, S, B>(
   baggage: Baggage,
   tag: string,

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -75,7 +75,7 @@ type DefineKindOptions<C> = {
    * argument or as their `this` binding? For `defineDurableKind` and its
    * siblings (including `vivifySingleton`), this defaults to off, meaning that
    * their behavior methods receive `context` as their first argument.
-   * `vivifyFarClass` and its siblings (including `vivifyFarInstance`) use
+   * `defineExoFactory` and its siblings (including `defineExo`) use
    * this flag internally to indicate that their methods receive `context`
    * as their `this` binding.
    */
@@ -88,7 +88,7 @@ type DefineKindOptions<C> = {
    * pattern is satisfied before calling the raw method.
    *
    * In `defineDurableKind` and its siblings, this defaults to off.
-   * `vivifyFarClass` use this internally to protect their raw class methods
+   * `defineExoFactory` use this internally to protect their raw class methods
    * using the provided interface.
    */
   interfaceGuard?: InterfaceGuard<unknown>;
@@ -96,7 +96,7 @@ type DefineKindOptions<C> = {
 
 export type VatData = {
   // virtual kinds
-  /** @deprecated Use defineVirtualFarClass instead */
+  /** @deprecated Use makeVirtualExoFactory instead */
   defineKind: <P, S, F>(
     tag: string,
     init: (...args: P) => S,
@@ -104,7 +104,7 @@ export type VatData = {
     options?: DefineKindOptions<KindContext<S, F>>,
   ) => (...args: P) => KindFacet<F>;
 
-  /** @deprecated Use defineVirtualFarClassKit instead */
+  /** @deprecated Use makeVirtualExoKitFactory instead */
   defineKindMulti: <P, S, B>(
     tag: string,
     init: (...args: P) => S,
@@ -115,7 +115,7 @@ export type VatData = {
   // durable kinds
   makeKindHandle: (descriptionTag: string) => DurableKindHandle;
 
-  /** @deprecated Use defineDurableFarClass instead */
+  /** @deprecated Use makeDurableExoFactory instead */
   defineDurableKind: <P, S, F>(
     kindHandle: DurableKindHandle,
     init: (...args: P) => S,
@@ -123,7 +123,7 @@ export type VatData = {
     options?: DefineKindOptions<KindContext<S, F>>,
   ) => (...args: P) => KindFacet<F>;
 
-  /** @deprecated Use defineDurableFarClassKit instead */
+  /** @deprecated Use makeDurableExoKitFactory instead */
   defineDurableKindMulti: <P, S, B>(
     kindHandle: DurableKindHandle,
     init: (...args: P) => S,
@@ -173,7 +173,7 @@ interface PickFacet {
   ): (...args: Parameters<M>) => ReturnType<M>[F];
 }
 
-/** @deprecated Use vivifyFarClass instead */
+/** @deprecated Use defineExoFactory instead */
 type VivifyKind = <P, S, F>(
   baggage: Baggage,
   tag: string,
@@ -182,7 +182,7 @@ type VivifyKind = <P, S, F>(
   options?: DefineKindOptions<KindContext<S, F>>,
 ) => (...args: P) => KindFacet<F>;
 
-/** @deprecated Use vivifyFarClassKit instead */
+/** @deprecated Use defineExoKitFactory instead */
 type VivifyKindMulti = <P, S, B>(
   baggage: Baggage,
   tag: string,

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -45,7 +45,7 @@ if ('VatData' in globalThis) {
 }
 
 /**
- * @deprecated Use Exo/ExoFactory/ExoKitFactory instead of kinds
+ * @deprecated Use Exo/ExoMaker/ExoKitMaker instead of kinds
  */
 export const {
   defineKind,
@@ -103,7 +103,7 @@ harden(partialAssign);
  * where the total number of calls to `provide` must be
  * low cardinality, since we keep the bookkeeping to detect collisions
  * in normal language-heap memory. All the other baggage-oriented
- * `provide*` and `vivify*` functions call `provide`,
+ * `provide*` and `prepare*` functions call `provide`,
  * and so impose the same constraints. This is consistent with
  * our expected durability patterns: What we store in baggage are
  *    * kindHandles, which are per kind, which must be low cardinality

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -45,7 +45,7 @@ if ('VatData' in globalThis) {
 }
 
 /**
- * @deprecated Use FarClasses/FarInstances instead of kinds
+ * @deprecated Use Exo/ExoFactory/ExoKitFactory instead of kinds
  */
 export const {
   defineKind,

--- a/packages/vat-data/test/test-durable-classes.js
+++ b/packages/vat-data/test/test-durable-classes.js
@@ -3,8 +3,8 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  makeDurableExoFactory,
-  makeDurableExoKitFactory,
+  makeDurableExoMaker,
+  makeDurableExoKitMaker,
 } from '../src/exo-utils.js';
 import {
   makeKindHandle,
@@ -25,10 +25,10 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test makeDurableExoFactory', t => {
+test('test makeDurableExoMaker', t => {
   const upCounterKind = makeKindHandle('UpCounter');
 
-  const makeUpCounter = makeDurableExoFactory(
+  const makeUpCounter = makeDurableExoMaker(
     upCounterKind,
     UpCounterI,
     /** @param {number} x */
@@ -61,10 +61,10 @@ test('test makeDurableExoFactory', t => {
   makeUpCounter('str');
 });
 
-test('test makeDurableExoKitFactory', t => {
+test('test makeDurableExoKitMaker', t => {
   const counterKindHandle = makeKindHandle('Counter');
 
-  const makeCounterKit = makeDurableExoKitFactory(
+  const makeCounterKit = makeDurableExoKitMaker(
     counterKindHandle,
     { up: UpCounterI, down: DownCounterI },
     /** @param {number} x */
@@ -117,7 +117,7 @@ test('finish option', t => {
     counterRegistry.init(state.name, self);
   };
 
-  const makeUpCounter = makeDurableExoFactory(
+  const makeUpCounter = makeDurableExoMaker(
     upCounterKind,
     UpCounterI,
     /**

--- a/packages/vat-data/test/test-durable-classes.js
+++ b/packages/vat-data/test/test-durable-classes.js
@@ -3,9 +3,9 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  defineDurableFarClass,
-  defineDurableFarClassKit,
-} from '../src/far-class-utils.js';
+  makeDurableExoFactory,
+  makeDurableExoKitFactory,
+} from '../src/exo-utils.js';
 import {
   makeKindHandle,
   makeScalarBigMapStore,
@@ -25,10 +25,10 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineDurableFarClass', t => {
+test('test makeDurableExoFactory', t => {
   const upCounterKind = makeKindHandle('UpCounter');
 
-  const makeUpCounter = defineDurableFarClass(
+  const makeUpCounter = makeDurableExoFactory(
     upCounterKind,
     UpCounterI,
     /** @param {number} x */
@@ -61,10 +61,10 @@ test('test defineDurableFarClass', t => {
   makeUpCounter('str');
 });
 
-test('test defineDurableFarClassKit', t => {
+test('test makeDurableExoKitFactory', t => {
   const counterKindHandle = makeKindHandle('Counter');
 
-  const makeCounterKit = defineDurableFarClassKit(
+  const makeCounterKit = makeDurableExoKitFactory(
     counterKindHandle,
     { up: UpCounterI, down: DownCounterI },
     /** @param {number} x */
@@ -117,7 +117,7 @@ test('finish option', t => {
     counterRegistry.init(state.name, self);
   };
 
-  const makeUpCounter = defineDurableFarClass(
+  const makeUpCounter = makeDurableExoFactory(
     upCounterKind,
     UpCounterI,
     /**

--- a/packages/vat-data/test/test-virtual-classes.js
+++ b/packages/vat-data/test/test-virtual-classes.js
@@ -3,9 +3,9 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  defineVirtualFarClass,
-  defineVirtualFarClassKit,
-} from '../src/far-class-utils.js';
+  makeVirtualExoFactory,
+  makeVirtualExoKitFactory,
+} from '../src/exo-utils.js';
 
 const UpCounterI = M.interface('UpCounter', {
   incr: M.call()
@@ -21,8 +21,8 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineVirtualFarClass', t => {
-  const makeUpCounter = defineVirtualFarClass(
+test('test makeVirtualExoFactory', t => {
+  const makeUpCounter = makeVirtualExoFactory(
     'UpCounter',
     UpCounterI,
     /** @param {number} x */
@@ -52,8 +52,8 @@ test('test defineVirtualFarClass', t => {
   makeUpCounter('str');
 });
 
-test('test defineVirtualFarClassKit', t => {
-  const makeCounterKit = defineVirtualFarClassKit(
+test('test makeVirtualExoKitFactory', t => {
+  const makeCounterKit = makeVirtualExoKitFactory(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
     /** @param {number} x */

--- a/packages/vat-data/test/test-virtual-classes.js
+++ b/packages/vat-data/test/test-virtual-classes.js
@@ -3,8 +3,8 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  makeVirtualExoFactory,
-  makeVirtualExoKitFactory,
+  makeVirtualExoMaker,
+  makeVirtualExoKitMaker,
 } from '../src/exo-utils.js';
 
 const UpCounterI = M.interface('UpCounter', {
@@ -21,8 +21,8 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test makeVirtualExoFactory', t => {
-  const makeUpCounter = makeVirtualExoFactory(
+test('test makeVirtualExoMaker', t => {
+  const makeUpCounter = makeVirtualExoMaker(
     'UpCounter',
     UpCounterI,
     /** @param {number} x */
@@ -52,8 +52,8 @@ test('test makeVirtualExoFactory', t => {
   makeUpCounter('str');
 });
 
-test('test makeVirtualExoKitFactory', t => {
-  const makeCounterKit = makeVirtualExoKitFactory(
+test('test makeVirtualExoKitMaker', t => {
+  const makeCounterKit = makeVirtualExoKitMaker(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
     /** @param {number} x */

--- a/packages/vat-data/test/test-vivify.js
+++ b/packages/vat-data/test/test-vivify.js
@@ -3,9 +3,9 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  defineExoFactory,
-  defineExoKitFactory,
-  defineExo,
+  prepareExoMaker,
+  prepareExoKitMaker,
+  prepareExo,
 } from '../src/exo-utils.js';
 import { makeScalarBigMapStore } from '../src/vat-data-bindings.js';
 
@@ -23,10 +23,10 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineExoFactory', t => {
+test('test prepareExoMaker', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
-  const makeUpCounter = defineExoFactory(
+  const makeUpCounter = prepareExoMaker(
     baggage,
     'UpCounter',
     UpCounterI,
@@ -57,10 +57,10 @@ test('test defineExoFactory', t => {
   makeUpCounter('str');
 });
 
-test('test defineExoKitFactory', t => {
+test('test prepareExoKitMaker', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
-  const makeCounterKit = defineExoKitFactory(
+  const makeCounterKit = prepareExoKitMaker(
     baggage,
     'Counter',
     { up: UpCounterI, down: DownCounterI },
@@ -105,11 +105,11 @@ test('test defineExoKitFactory', t => {
   makeCounterKit('str');
 });
 
-test('test defineExo', t => {
+test('test prepareExo', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
   let x = 3;
-  const upCounter = defineExo(baggage, 'upCounter', UpCounterI, {
+  const upCounter = prepareExo(baggage, 'upCounter', UpCounterI, {
     incr(y = 1) {
       x += y;
       return x;

--- a/packages/vat-data/test/test-vivify.js
+++ b/packages/vat-data/test/test-vivify.js
@@ -3,10 +3,10 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  vivifyFarClass,
-  vivifyFarClassKit,
-  vivifyFarInstance,
-} from '../src/far-class-utils.js';
+  defineExoFactory,
+  defineExoKitFactory,
+  defineExo,
+} from '../src/exo-utils.js';
 import { makeScalarBigMapStore } from '../src/vat-data-bindings.js';
 
 const UpCounterI = M.interface('UpCounter', {
@@ -23,10 +23,10 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test vivifyFarClass', t => {
+test('test defineExoFactory', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
-  const makeUpCounter = vivifyFarClass(
+  const makeUpCounter = defineExoFactory(
     baggage,
     'UpCounter',
     UpCounterI,
@@ -57,10 +57,10 @@ test('test vivifyFarClass', t => {
   makeUpCounter('str');
 });
 
-test('test vivifyFarClassKit', t => {
+test('test defineExoKitFactory', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
-  const makeCounterKit = vivifyFarClassKit(
+  const makeCounterKit = defineExoKitFactory(
     baggage,
     'Counter',
     { up: UpCounterI, down: DownCounterI },
@@ -105,11 +105,11 @@ test('test vivifyFarClassKit', t => {
   makeCounterKit('str');
 });
 
-test('test vivifyFarInstance', t => {
+test('test defineExo', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
   let x = 3;
-  const upCounter = vivifyFarInstance(baggage, 'upCounter', UpCounterI, {
+  const upCounter = defineExo(baggage, 'upCounter', UpCounterI, {
     incr(y = 1) {
       x += y;
       return x;

--- a/packages/zoe/docs/ZoeDataInitialization.puml
+++ b/packages/zoe/docs/ZoeDataInitialization.puml
@@ -13,7 +13,7 @@ bootstrap -> Zoe: makeZoeKit(...)
 Zoe -> ZoeStorageManager : makeZoeStorageManager()
 ZoeStorageManager -> ZoeStorageManager : provideIssuerStorage()
 ZoeStorageManager -> ZoeStorageManager : provideEscrowStorage()
-ZoeStorageManager -> ZoeStorageManager : vivifyInvitationKit()
+ZoeStorageManager -> ZoeStorageManager : prepareInvitationKit()
 ZoeStorageManager -> InstanceAdminStorage : makeInstanceAdminStorage()
 InstanceAdminStorage -> InstanceAdminStorage : instanceToInstanceAdmin
 ZoeStorageManager /- InstanceAdminStorage : <font color=gray><size:12>getters..., \n<font color=gray><size:12>initInstanceAdmin

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -1,6 +1,6 @@
 import { Fail, q } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
-import { defineExoFactory, provideDurableSetStore } from '@agoric/vat-data';
+import { prepareExoMaker, provideDurableSetStore } from '@agoric/vat-data';
 import { M, initEmpty } from '@agoric/store';
 
 import {
@@ -24,7 +24,7 @@ const WakerI = M.interface('Waker', {
 export const makeMakeExiter = baggage => {
   const activeWakers = provideDurableSetStore(baggage, 'activeWakers');
 
-  const makeExitable = defineExoFactory(
+  const makeExitable = prepareExoMaker(
     baggage,
     'ExitObject',
     ExitObjectI,
@@ -36,7 +36,7 @@ export const makeMakeExiter = baggage => {
       },
     },
   );
-  const makeWaived = defineExoFactory(
+  const makeWaived = prepareExoMaker(
     baggage,
     'ExitWaived',
     ExitObjectI,
@@ -50,7 +50,7 @@ export const makeMakeExiter = baggage => {
       },
     },
   );
-  const makeWaker = defineExoFactory(
+  const makeWaker = prepareExoMaker(
     baggage,
     'Waker',
     WakerI,

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -1,6 +1,6 @@
 import { Fail, q } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
-import { vivifyFarClass, provideDurableSetStore } from '@agoric/vat-data';
+import { defineExoFactory, provideDurableSetStore } from '@agoric/vat-data';
 import { M, initEmpty } from '@agoric/store';
 
 import {
@@ -24,7 +24,7 @@ const WakerI = M.interface('Waker', {
 export const makeMakeExiter = baggage => {
   const activeWakers = provideDurableSetStore(baggage, 'activeWakers');
 
-  const makeExitable = vivifyFarClass(
+  const makeExitable = defineExoFactory(
     baggage,
     'ExitObject',
     ExitObjectI,
@@ -36,7 +36,7 @@ export const makeMakeExiter = baggage => {
       },
     },
   );
-  const makeWaived = vivifyFarClass(
+  const makeWaived = defineExoFactory(
     baggage,
     'ExitWaived',
     ExitObjectI,
@@ -50,7 +50,7 @@ export const makeMakeExiter = baggage => {
       },
     },
   );
-  const makeWaker = vivifyFarClass(
+  const makeWaker = defineExoFactory(
     baggage,
     'Waker',
     WakerI,

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -3,7 +3,7 @@ import { AmountMath } from '@agoric/ertp';
 import {
   provideDurableSetStore,
   makeScalarBigMapStore,
-  vivifySingleton,
+  prepareSingleton,
 } from '@agoric/vat-data';
 
 import { coerceAmountKeywordRecord } from '../cleanProposal.js';
@@ -52,7 +52,7 @@ export const makeZCFMintFactory = async (
     const add = (total, amountToAdd) =>
       AmountMath.add(total, amountToAdd, mintyBrand);
 
-    return vivifySingleton(
+    return prepareSingleton(
       zcfMintBaggage,
       'zcfMint',
       /** @type {ZCFMint} */
@@ -140,7 +140,7 @@ export const makeZCFMintFactory = async (
    * baggage for the state of the zcfMint, makes a durableZcfMint from that
    * baggage, and registers that baggage to be revived with the factory.
    */
-  const zcfMintFactory = vivifySingleton(zcfBaggage, 'zcfMintFactory', {
+  const zcfMintFactory = prepareSingleton(zcfBaggage, 'zcfMintFactory', {
     makeZCFMintInternal: async (keyword, zoeMint) => {
       const zcfMintBaggage = makeScalarBigMapStore('zcfMintBaggage', {
         durable: true,

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -3,7 +3,7 @@ import {
   makeScalarBigWeakMapStore,
   provideDurableMapStore,
   provideDurableWeakMapStore,
-  vivifyFarClassKit,
+  defineExoKitFactory,
   vivifyKind,
   provide,
 } from '@agoric/vat-data';
@@ -263,7 +263,7 @@ export const createSeatManager = (
     }),
   });
 
-  const makeSeatManagerKit = vivifyFarClassKit(
+  const makeSeatManagerKit = defineExoKitFactory(
     zcfBaggage,
     'ZcfSeatManager',
     ZcfSeatManagerIKit,

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -3,8 +3,8 @@ import {
   makeScalarBigWeakMapStore,
   provideDurableMapStore,
   provideDurableWeakMapStore,
-  defineExoKitFactory,
-  vivifyKind,
+  prepareExoKitMaker,
+  prepareKind,
   provide,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
@@ -135,7 +135,7 @@ export const createSeatManager = (
     }
   };
 
-  const makeZCFSeatInternal = vivifyKind(
+  const makeZCFSeatInternal = prepareKind(
     zcfBaggage,
     'zcfSeat',
     proposal => ({ proposal }),
@@ -263,7 +263,7 @@ export const createSeatManager = (
     }),
   });
 
-  const makeSeatManagerKit = defineExoKitFactory(
+  const makeSeatManagerKit = prepareExoKitMaker(
     zcfBaggage,
     'ZcfSeatManager',
     ZcfSeatManagerIKit,

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -8,7 +8,7 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableMapStore,
-  vivifyFarInstance,
+  defineExo,
   vivifyKind,
 } from '@agoric/vat-data';
 
@@ -193,7 +193,7 @@ export const makeZCFZygote = async (
       .optional(M.string())
       .returns(OfferHandlerShape),
   });
-  const taker = vivifyFarInstance(zcfBaggage, 'offer handler taker', TakerI, {
+  const taker = defineExo(zcfBaggage, 'offer handler taker', TakerI, {
     take: takeOfferHandler,
   });
   const handleOfferObj = makeHandleOfferObj(taker);

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -8,8 +8,8 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableMapStore,
-  defineExo,
-  vivifyKind,
+  prepareExo,
+  prepareKind,
 } from '@agoric/vat-data';
 
 import { cleanProposal } from '../cleanProposal.js';
@@ -154,7 +154,7 @@ export const makeZCFZygote = async (
 
   // handleOfferObject gives Zoe the ability to notify ZCF when a new seat is
   // added in offer(). ZCF responds with the exitObj and offerResult.
-  const makeHandleOfferObj = vivifyKind(
+  const makeHandleOfferObj = prepareKind(
     zcfBaggage,
     'handleOfferObj',
     offerHandlerTaker => ({ offerHandlerTaker }),
@@ -193,7 +193,7 @@ export const makeZCFZygote = async (
       .optional(M.string())
       .returns(OfferHandlerShape),
   });
-  const taker = defineExo(zcfBaggage, 'offer handler taker', TakerI, {
+  const taker = prepareExo(zcfBaggage, 'offer handler taker', TakerI, {
     take: takeOfferHandler,
   });
   const handleOfferObj = makeHandleOfferObj(taker);
@@ -210,17 +210,22 @@ export const makeZCFZygote = async (
     return evalContractBundle(bundle);
   };
   // evaluate the contract (either the first version, or an upgrade)
-  const { start, buildRootObject, privateArgsShape, customTermsShape, vivify } =
-    await evaluateContract();
+  const {
+    start,
+    buildRootObject,
+    privateArgsShape,
+    customTermsShape,
+    prepare,
+  } = await evaluateContract();
 
-  if (start === undefined && vivify === undefined) {
+  if (start === undefined && prepare === undefined) {
     buildRootObject === undefined ||
       Fail`Did you provide a vat bundle instead of a contract bundle?`;
     Fail`unrecognized contract exports`;
   }
   !start ||
-    !vivify ||
-    Fail`contract must provide exactly one of "start" and "vivify"`;
+    !prepare ||
+    Fail`contract must provide exactly one of "start" and "prepare"`;
 
   /** @type {ZCF} */
   // Using Remotable rather than Far because there are too many complications
@@ -354,7 +359,7 @@ export const makeZCFZygote = async (
       instanceRecHolder = makeInstanceRecord(instanceRecordFromZoe);
       instantiateIssuerStorage(issuerStorageFromZoe);
 
-      const startFn = start || vivify;
+      const startFn = start || prepare;
       if (privateArgsShape) {
         fit(privateArgs, privateArgsShape);
       }
@@ -371,7 +376,7 @@ export const makeZCFZygote = async (
             publicFacet,
             creatorInvitation,
           ].every(canBeDurable);
-          if (vivify || allDurable) {
+          if (prepare || allDurable) {
             zcfBaggage.init('creatorFacet', creatorFacet);
             zcfBaggage.init('publicFacet', publicFacet);
             zcfBaggage.init('creatorInvitation', creatorInvitation);
@@ -390,12 +395,12 @@ export const makeZCFZygote = async (
     restartContract: async (privateArgs = undefined) => {
       const instanceAdmin = zcfBaggage.get('zcfInstanceAdmin');
       zoeInstanceAdmin = instanceAdmin;
-      vivify || Fail`vivify must be defined to upgrade a contract`;
+      prepare || Fail`prepare must be defined to upgrade a contract`;
       initSeatMgrAndMintFactory();
 
       // restart an upgradeable contract
       return E.when(
-        vivify(zcf, privateArgs, contractBaggage),
+        prepare(zcf, privateArgs, contractBaggage),
         ({
           creatorFacet = undefined,
           publicFacet = undefined,

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -1,5 +1,5 @@
 import { fit, M } from '@agoric/store';
-import { vivifyKind, vivifySingleton } from '@agoric/vat-data';
+import { prepareKind, prepareSingleton } from '@agoric/vat-data';
 import { swapExact } from '../contractSupport/index.js';
 import { isAfterDeadlineExitRule } from '../typeGuards.js';
 
@@ -32,7 +32,7 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
   // XXX the exerciseOption offer handler that this makes is an object rather
   // than a function for now only because we do not yet support durable
   // functions.
-  const makeExerciser = vivifyKind(
+  const makeExerciser = prepareKind(
     instanceBaggage,
     'makeExerciserKindHandle',
     sellSeat => ({ sellSeat }),
@@ -78,7 +78,7 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
     return zcf.makeInvitation(exerciseOption, 'exerciseOption', customProps);
   };
 
-  const creatorFacet = vivifySingleton(instanceBaggage, 'creatorFacet', {
+  const creatorFacet = prepareSingleton(instanceBaggage, 'creatorFacet', {
     makeInvitation: () => zcf.makeInvitation(makeOption, 'makeCallOption'),
   });
   return harden({ creatorFacet });

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -1,4 +1,4 @@
-import { provide, defineExoFactory, M } from '@agoric/vat-data';
+import { provide, prepareExoMaker, M } from '@agoric/vat-data';
 import { assertKeywordName } from './cleanProposal.js';
 import {
   BrandKeywordRecordShape,
@@ -47,7 +47,7 @@ export const makeInstanceRecordStorage = baggage => {
     assertUniqueKeyword: M.call(KeywordShape).returns(),
   });
 
-  const makeInstanceRecord = defineExoFactory(
+  const makeInstanceRecord = prepareExoMaker(
     baggage,
     'InstanceRecord',
     InstanceRecordI,

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -1,4 +1,4 @@
-import { provide, vivifyFarClass, M } from '@agoric/vat-data';
+import { provide, defineExoFactory, M } from '@agoric/vat-data';
 import { assertKeywordName } from './cleanProposal.js';
 import {
   BrandKeywordRecordShape,
@@ -47,7 +47,7 @@ export const makeInstanceRecordStorage = baggage => {
     assertUniqueKeyword: M.call(KeywordShape).returns(),
   });
 
-  const makeInstanceRecord = vivifyFarClass(
+  const makeInstanceRecord = defineExoFactory(
     baggage,
     'InstanceRecord',
     InstanceRecordI,

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,6 +1,6 @@
 import { assert } from '@agoric/assert';
-import { initEmpty, makeHeapFarInstance } from '@agoric/store';
-import { vivifyFarClass } from '@agoric/vat-data';
+import { initEmpty, makeHeapExo } from '@agoric/store';
+import { defineExoFactory } from '@agoric/vat-data';
 
 import { HandleI } from './typeGuards.js';
 
@@ -16,7 +16,7 @@ const { Fail } = assert;
  */
 export const defineDurableHandle = (baggage, handleType) => {
   typeof handleType === 'string' || Fail`handleType must be a string`;
-  const makeHandle = vivifyFarClass(
+  const makeHandle = defineExoFactory(
     baggage,
     `${handleType}Handle`,
     HandleI,
@@ -40,7 +40,7 @@ export const makeHandle = handleType => {
   // Return the intersection type (really just an empty object).
   // @ts-expect-error Bit by our own opaque types.
   return /** @type {Handle<H>} */ (
-    makeHeapFarInstance(`${handleType}Handle`, HandleI, {})
+    makeHeapExo(`${handleType}Handle`, HandleI, {})
   );
 };
 harden(makeHandle);

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,6 +1,6 @@
 import { assert } from '@agoric/assert';
 import { initEmpty, makeHeapExo } from '@agoric/store';
-import { defineExoFactory } from '@agoric/vat-data';
+import { prepareExoMaker } from '@agoric/vat-data';
 
 import { HandleI } from './typeGuards.js';
 
@@ -16,7 +16,7 @@ const { Fail } = assert;
  */
 export const defineDurableHandle = (baggage, handleType) => {
   typeof handleType === 'string' || Fail`handleType must be a string`;
-  const makeHandle = defineExoFactory(
+  const makeHandle = prepareExoMaker(
     baggage,
     `${handleType}Handle`,
     HandleI,

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -1,7 +1,11 @@
-import { makeDurableIssuerKit, AssetKind, vivifyIssuerKit } from '@agoric/ertp';
+import {
+  makeDurableIssuerKit,
+  AssetKind,
+  prepareIssuerKit,
+} from '@agoric/ertp';
 import { initEmpty } from '@agoric/store';
 import {
-  vivifyKindMulti,
+  prepareKindMulti,
   provideDurableMapStore,
   provide,
 } from '@agoric/vat-data';
@@ -21,7 +25,7 @@ export const defaultFeeIssuerConfig = harden(
  * @param {FeeIssuerConfig} feeIssuerConfig
  * @param {ShutdownWithFailure} shutdownZoeVat
  */
-const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
+const prepareFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   const mintBaggage = provideDurableMapStore(zoeBaggage, 'mintBaggage');
   if (!mintBaggage.has(FEE_MINT_KIT)) {
     /** @type {IssuerKit} */
@@ -34,7 +38,7 @@ const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
     );
     mintBaggage.init(FEE_MINT_KIT, feeIssuerKit);
   } else {
-    vivifyIssuerKit(mintBaggage, shutdownZoeVat);
+    prepareIssuerKit(mintBaggage, shutdownZoeVat);
   }
 
   const getFeeIssuerKit = ({ facets }, allegedFeeMintAccess) => {
@@ -45,7 +49,7 @@ const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
     return mintBaggage.get(FEE_MINT_KIT);
   };
 
-  const makeFeeMintKit = vivifyKindMulti(mintBaggage, 'FeeMint', initEmpty, {
+  const makeFeeMintKit = prepareKindMulti(mintBaggage, 'FeeMint', initEmpty, {
     feeMint: {
       getFeeIssuerKit,
       getFeeIssuer: () => mintBaggage.get(FEE_MINT_KIT).issuer,
@@ -59,4 +63,4 @@ const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   return provide(zoeBaggage, 'theFeeMint', () => makeFeeMintKit());
 };
 
-export { vivifyFeeMint };
+export { prepareFeeMint };

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -3,8 +3,8 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  defineExo,
-  vivifyKind,
+  prepareExo,
+  prepareKind,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
 import {
@@ -38,14 +38,14 @@ export const makeInstallationStorage = (
     'installationsBundle',
   );
 
-  const makeBundleIDInstallation = vivifyKind(
+  const makeBundleIDInstallation = prepareKind(
     zoeBaggage,
     'BundleIDInstallation',
     initEmpty,
     { getBundle: _context => assert.fail('bundleID-based Installation') },
   );
 
-  const makeBundleInstallation = vivifyKind(
+  const makeBundleInstallation = prepareKind(
     zoeBaggage,
     'BundleInstallation',
     bundle => ({ bundle }),
@@ -102,7 +102,7 @@ export const makeInstallationStorage = (
     ),
   });
 
-  const installationStorage = defineExo(
+  const installationStorage = prepareExo(
     zoeBaggage,
     'InstallationStorage',
     InstallationStorageI,

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -3,7 +3,7 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  vivifyFarInstance,
+  defineExo,
   vivifyKind,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
@@ -102,7 +102,7 @@ export const makeInstallationStorage = (
     ),
   });
 
-  const installationStorage = vivifyFarInstance(
+  const installationStorage = defineExo(
     zoeBaggage,
     'InstallationStorage',
     InstallationStorageI,

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -4,8 +4,8 @@ import {
   makeScalarBigSetStore,
   provide,
   provideDurableWeakMapStore,
-  defineExoKitFactory,
-  vivifyKindMulti,
+  prepareExoKitMaker,
+  prepareKindMulti,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
 import { defineDurableHandle } from '../makeHandle.js';
@@ -50,7 +50,7 @@ const InstanceAdminStorageIKit = harden({
 
 /** @param {import('@agoric/vat-data').Baggage} baggage */
 export const makeInstanceAdminStorage = baggage => {
-  const makeIAS = defineExoKitFactory(
+  const makeIAS = prepareExoKitMaker(
     baggage,
     'InstanceAdmin',
     InstanceAdminStorageIKit,
@@ -265,7 +265,7 @@ export const makeInstanceAdminMaker = (
   seatHandleToZoeSeatAdmin,
 ) => {
   const makeZoeSeatAdminKit = makeZoeSeatAdminFactory(zoeBaggage);
-  const makeInstanceAdminMulti = vivifyKindMulti(
+  const makeInstanceAdminMulti = prepareKindMulti(
     zoeBaggage,
     'instanceAdmin',
     (instanceHandle, zoeInstanceStorageManager, adminNode) => {

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -4,7 +4,7 @@ import {
   makeScalarBigSetStore,
   provide,
   provideDurableWeakMapStore,
-  vivifyFarClassKit,
+  defineExoKitFactory,
   vivifyKindMulti,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
@@ -50,7 +50,7 @@ const InstanceAdminStorageIKit = harden({
 
 /** @param {import('@agoric/vat-data').Baggage} baggage */
 export const makeInstanceAdminStorage = baggage => {
-  const makeIAS = vivifyFarClassKit(
+  const makeIAS = defineExoKitFactory(
     baggage,
     'InstanceAdmin',
     InstanceAdminStorageIKit,

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -1,5 +1,9 @@
 import { provideDurableMapStore } from '@agoric/vat-data';
-import { AssetKind, makeDurableIssuerKit, vivifyIssuerKit } from '@agoric/ertp';
+import {
+  AssetKind,
+  makeDurableIssuerKit,
+  prepareIssuerKit,
+} from '@agoric/ertp';
 import { InvitationElementShape } from '../typeGuards.js';
 
 const ZOE_INVITATION_KIT = 'ZoeInvitationKit';
@@ -8,7 +12,7 @@ const ZOE_INVITATION_KIT = 'ZoeInvitationKit';
  * @param {import('@agoric/vat-data').Baggage} baggage
  * @param {ShutdownWithFailure | undefined} shutdownZoeVat
  */
-export const vivifyInvitationKit = (baggage, shutdownZoeVat = undefined) => {
+export const prepareInvitationKit = (baggage, shutdownZoeVat = undefined) => {
   let invitationKit;
 
   const invitationKitBaggage = provideDurableMapStore(
@@ -26,7 +30,7 @@ export const vivifyInvitationKit = (baggage, shutdownZoeVat = undefined) => {
     );
     invitationKitBaggage.init(ZOE_INVITATION_KIT, invitationKit);
   } else {
-    invitationKit = vivifyIssuerKit(invitationKitBaggage);
+    invitationKit = prepareIssuerKit(invitationKitBaggage);
   }
 
   return harden({

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -4,7 +4,7 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  vivifyFarClass,
+  defineExoFactory,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
 
@@ -43,7 +43,7 @@ export const makeStartInstance = (
     seatHandleToZoeSeatAdmin,
   );
 
-  const makeZoeInstanceAdmin = vivifyFarClass(
+  const makeZoeInstanceAdmin = defineExoFactory(
     zoeBaggage,
     'zoeInstanceAdmin',
     InstanceAdminI,
@@ -143,7 +143,7 @@ export const makeStartInstance = (
   );
 
   const vivifyEmptyFacet = facetName =>
-    vivifyFarClass(
+    defineExoFactory(
       zoeBaggage,
       facetName,
       M.interface(facetName, {}),
@@ -153,7 +153,7 @@ export const makeStartInstance = (
   const makeEmptyCreatorFacet = vivifyEmptyFacet('emptyCreatorFacet');
   const makeEmptyPublicFacet = vivifyEmptyFacet('emptyPublicFacet');
 
-  const makeAdminFacet = vivifyFarClass(
+  const makeAdminFacet = defineExoFactory(
     zoeBaggage,
     'adminFacet',
     AdminFacetI,

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -4,7 +4,7 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  defineExoFactory,
+  prepareExoMaker,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
 
@@ -43,7 +43,7 @@ export const makeStartInstance = (
     seatHandleToZoeSeatAdmin,
   );
 
-  const makeZoeInstanceAdmin = defineExoFactory(
+  const makeZoeInstanceAdmin = prepareExoMaker(
     zoeBaggage,
     'zoeInstanceAdmin',
     InstanceAdminI,
@@ -142,18 +142,18 @@ export const makeStartInstance = (
     },
   );
 
-  const vivifyEmptyFacet = facetName =>
-    defineExoFactory(
+  const prepareEmptyFacet = facetName =>
+    prepareExoMaker(
       zoeBaggage,
       facetName,
       M.interface(facetName, {}),
       initEmpty,
       {},
     );
-  const makeEmptyCreatorFacet = vivifyEmptyFacet('emptyCreatorFacet');
-  const makeEmptyPublicFacet = vivifyEmptyFacet('emptyPublicFacet');
+  const makeEmptyCreatorFacet = prepareEmptyFacet('emptyCreatorFacet');
+  const makeEmptyPublicFacet = prepareEmptyFacet('emptyPublicFacet');
 
-  const makeAdminFacet = defineExoFactory(
+  const makeAdminFacet = prepareExoMaker(
     zoeBaggage,
     'adminFacet',
     AdminFacetI,

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -16,7 +16,7 @@ import '../internal-types.js';
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeScalarBigMapStore, vivifyFarInstance } from '@agoric/vat-data';
+import { makeScalarBigMapStore, defineExo } from '@agoric/vat-data';
 
 import { makeZoeStorageManager } from './zoeStorageManager.js';
 import { makeStartInstance } from './startInstance.js';
@@ -156,7 +156,7 @@ const makeZoeKit = (
   };
 
   /** @type {ZoeService} */
-  const zoeService = vivifyFarInstance(zoeBaggage, 'ZoeService', ZoeServiceI, {
+  const zoeService = defineExo(zoeBaggage, 'ZoeService', ZoeServiceI, {
     install(bundleId) {
       return dataAccess.installBundle(bundleId);
     },

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -16,14 +16,14 @@ import '../internal-types.js';
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeScalarBigMapStore, defineExo } from '@agoric/vat-data';
+import { makeScalarBigMapStore, prepareExo } from '@agoric/vat-data';
 
 import { makeZoeStorageManager } from './zoeStorageManager.js';
 import { makeStartInstance } from './startInstance.js';
 import { makeOfferMethod } from './offer/offer.js';
 import { makeInvitationQueryFns } from './invitationQueries.js';
 import { getZcfBundleCap } from './createZCFVat.js';
-import { defaultFeeIssuerConfig, vivifyFeeMint } from './feeMint.js';
+import { defaultFeeIssuerConfig, prepareFeeMint } from './feeMint.js';
 import { ZoeServiceI } from '../typeGuards.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
@@ -77,7 +77,11 @@ const makeZoeKit = (
     vatAdminSvcP = zoeBaggage.get('vatAdminSvc');
   }
 
-  const feeMintKit = vivifyFeeMint(zoeBaggage, feeIssuerConfig, shutdownZoeVat);
+  const feeMintKit = prepareFeeMint(
+    zoeBaggage,
+    feeIssuerConfig,
+    shutdownZoeVat,
+  );
 
   // guarantee that vatAdminSvcP has been defined.
   const getActualVatAdminSvcP = () => {
@@ -156,7 +160,7 @@ const makeZoeKit = (
   };
 
   /** @type {ZoeService} */
-  const zoeService = defineExo(zoeBaggage, 'ZoeService', ZoeServiceI, {
+  const zoeService = prepareExo(zoeBaggage, 'ZoeService', ZoeServiceI, {
     install(bundleId) {
       return dataAccess.installBundle(bundleId);
     },

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -1,6 +1,6 @@
-import { vivifyDurablePublishKit, SubscriberShape } from '@agoric/notifier';
+import { prepareDurablePublishKit, SubscriberShape } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
-import { M, defineExoKitFactory } from '@agoric/vat-data';
+import { M, prepareExoKitMaker } from '@agoric/vat-data';
 import { deeplyFulfilled } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
 
@@ -59,7 +59,7 @@ const assertHasNotExited = (c, msg) => {
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const makeZoeSeatAdminFactory = baggage => {
-  const makeDurablePublishKit = vivifyDurablePublishKit(
+  const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,
     'zoe Seat publisher',
   );
@@ -88,7 +88,7 @@ export const makeZoeSeatAdminFactory = baggage => {
   // table entry.
   const ephemeralOfferResultStore = new Map();
 
-  return defineExoKitFactory(
+  return prepareExoKitMaker(
     baggage,
     'ZoeSeatKit',
     ZoeSeatIKit,

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -1,6 +1,6 @@
 import { vivifyDurablePublishKit, SubscriberShape } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
-import { M, vivifyFarClassKit } from '@agoric/vat-data';
+import { M, defineExoKitFactory } from '@agoric/vat-data';
 import { deeplyFulfilled } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
 
@@ -88,7 +88,7 @@ export const makeZoeSeatAdminFactory = baggage => {
   // table entry.
   const ephemeralOfferResultStore = new Map();
 
-  return vivifyFarClassKit(
+  return defineExoKitFactory(
     baggage,
     'ZoeSeatKit',
     ZoeSeatIKit,

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -2,8 +2,8 @@ import { AssetKind, makeDurableIssuerKit, AmountMath } from '@agoric/ertp';
 import {
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  vivifyFarClassKit,
-  vivifyFarClass,
+  defineExoKitFactory,
+  defineExoFactory,
   provideDurableSetStore,
 } from '@agoric/vat-data';
 
@@ -117,7 +117,7 @@ export const makeZoeStorageManager = (
     zoeMintBaggageSet(issuerBaggage);
   }
 
-  const makeZoeMint = vivifyFarClass(
+  const makeZoeMint = defineExoFactory(
     zoeBaggage,
     'ZoeMint',
     ZoeMintI,
@@ -154,7 +154,7 @@ export const makeZoeStorageManager = (
     },
   );
 
-  const makeInstanceStorageManager = vivifyFarClassKit(
+  const makeInstanceStorageManager = defineExoKitFactory(
     zoeBaggage,
     'InstanceStorageManager',
     InstanceStorageManagerIKit,
@@ -390,7 +390,7 @@ export const makeZoeStorageManager = (
 
   const getInvitationIssuer = () => invitationIssuer;
 
-  const makeStorageManager = vivifyFarClassKit(
+  const makeStorageManager = defineExoKitFactory(
     zoeBaggage,
     'ZoeStorageManager',
     ZoeStorageManagerIKit,

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -2,8 +2,8 @@ import { AssetKind, makeDurableIssuerKit, AmountMath } from '@agoric/ertp';
 import {
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  defineExoKitFactory,
-  defineExoFactory,
+  prepareExoKitMaker,
+  prepareExoMaker,
   provideDurableSetStore,
 } from '@agoric/vat-data';
 
@@ -11,7 +11,7 @@ import { provideIssuerStorage } from '../issuerStorage.js';
 import { makeInstanceRecordStorage } from '../instanceRecordStorage.js';
 import { makeIssuerRecord } from '../issuerRecord.js';
 import { provideEscrowStorage } from './escrowStorage.js';
-import { vivifyInvitationKit } from './makeInvitation.js';
+import { prepareInvitationKit } from './makeInvitation.js';
 import { makeInstanceAdminStorage } from './instanceAdminStorage.js';
 import { makeInstallationStorage } from './installationStorage.js';
 
@@ -84,7 +84,7 @@ export const makeZoeStorageManager = (
   // In order to participate in a contract, users must have invitations, which
   // are ERTP payments made by Zoe. This invitationKit must be closely held and
   // used only by the makeInvitation() method.
-  const { invitationIssuer, invitationKit } = vivifyInvitationKit(
+  const { invitationIssuer, invitationKit } = prepareInvitationKit(
     zoeBaggage,
     shutdownZoeVat,
   );
@@ -117,7 +117,7 @@ export const makeZoeStorageManager = (
     zoeMintBaggageSet(issuerBaggage);
   }
 
-  const makeZoeMint = defineExoFactory(
+  const makeZoeMint = prepareExoMaker(
     zoeBaggage,
     'ZoeMint',
     ZoeMintI,
@@ -154,7 +154,7 @@ export const makeZoeStorageManager = (
     },
   );
 
-  const makeInstanceStorageManager = defineExoKitFactory(
+  const makeInstanceStorageManager = prepareExoKitMaker(
     zoeBaggage,
     'InstanceStorageManager',
     InstanceStorageManagerIKit,
@@ -390,7 +390,7 @@ export const makeZoeStorageManager = (
 
   const getInvitationIssuer = () => invitationIssuer;
 
-  const makeStorageManager = defineExoKitFactory(
+  const makeStorageManager = prepareExoKitMaker(
     zoeBaggage,
     'ZoeStorageManager',
     ZoeStorageManagerIKit,

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -1,5 +1,5 @@
 import { M, fit } from '@agoric/store';
-import { vivifyFarClass, vivifyFarInstance } from '@agoric/vat-data';
+import { defineExoFactory, defineExo } from '@agoric/vat-data';
 import { swapExact } from '../../../src/contractSupport/index.js';
 import {
   InvitationShape,
@@ -32,7 +32,7 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
   // TODO the exerciseOption offer handler that this makes is an object rather
   // than a function for now only because we do not yet support durable
   // functions.
-  const makeExerciser = vivifyFarClass(
+  const makeExerciser = defineExoFactory(
     instanceBaggage,
     'makeExerciserKindHandle',
     OfferHandlerI,
@@ -81,7 +81,7 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
     makeInvitation: M.call().returns(M.eref(InvitationShape)),
   });
 
-  const creatorFacet = vivifyFarInstance(
+  const creatorFacet = defineExo(
     instanceBaggage,
     'creatorFacet',
     CCallCreatorI,

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -1,5 +1,5 @@
 import { M, fit } from '@agoric/store';
-import { defineExoFactory, defineExo } from '@agoric/vat-data';
+import { prepareExoMaker, prepareExo } from '@agoric/vat-data';
 import { swapExact } from '../../../src/contractSupport/index.js';
 import {
   InvitationShape,
@@ -22,7 +22,7 @@ const sellSeatExpiredMsg = 'The covered call option is expired.';
  * @param {unknown} _privateArgs
  * @param {import('@agoric/vat-data').Baggage} instanceBaggage
  */
-const vivify = async (zcf, _privateArgs, instanceBaggage) => {
+const prepare = async (zcf, _privateArgs, instanceBaggage) => {
   const firstTime = !instanceBaggage.has('DidStart');
   if (firstTime) {
     instanceBaggage.init('DidStart', true);
@@ -32,7 +32,7 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
   // TODO the exerciseOption offer handler that this makes is an object rather
   // than a function for now only because we do not yet support durable
   // functions.
-  const makeExerciser = defineExoFactory(
+  const makeExerciser = prepareExoMaker(
     instanceBaggage,
     'makeExerciserKindHandle',
     OfferHandlerI,
@@ -81,7 +81,7 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
     makeInvitation: M.call().returns(M.eref(InvitationShape)),
   });
 
-  const creatorFacet = defineExo(
+  const creatorFacet = prepareExo(
     instanceBaggage,
     'creatorFacet',
     CCallCreatorI,
@@ -94,5 +94,5 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
   return harden({ creatorFacet });
 };
 
-harden(vivify);
-export { vivify };
+harden(prepare);
+export { prepare };

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/vat-ertp-service.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/vat-ertp-service.js
@@ -1,10 +1,10 @@
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
-import { vivifyErtpService } from '@agoric/ertp/test/swingsetTests/ertpService/vat-ertp-service.js';
+import { prepareErtpService } from '@agoric/ertp/test/swingsetTests/ertpService/vat-ertp-service.js';
 
 export const buildRootObject = async (vatPowers, _vatParams, baggage) => {
   const exportableAmountMath = Far('AmountMath', { ...AmountMath });
-  const ertpService = vivifyErtpService(baggage, vatPowers.exitVatWithFailure);
+  const ertpService = prepareErtpService(baggage, vatPowers.exitVatWithFailure);
   return Far('root', {
     getErtpService: () => ertpService,
     getAmountMath: () => exportableAmountMath,


### PR DESCRIPTION
Fixes https://github.com/endojs/endo/issues/1193 . 

Same idea as https://github.com/Agoric/agoric-sdk/pull/6323 but using the names proposed in the "Rotate..." column of https://docs.google.com/spreadsheets/d/1yhKgzMOfmZOTnvP3Bh4p16H9RyYq_WhOlxZ3Qicx_Oc/edit#gid=0

# The rationale for these names

The PR comment at the top of https://github.com/Agoric/agoric-sdk/pull/6323 explains the rationale for switching from "FarClass/FarInstance" terminology to "Exo" terminology for these protected object. That part remains unchanged. The differences:

- `make*FarInstance` -> `make*Exo` <br> Makes an exo object.
- `define*FarClass`,`make*ExoFactory` -> `make*ExoMaker` <br> Although similar to classes, these are different enough that it may be more confusing than clarifying to use the term "class". What these functions return is a `make*` function for making exo instances. If we call the returned `make*` function a "maker function", then this function is one that makes such maker functions.
- `define*FarClassKit`,`make*ExoKitFactory` -> `make*ExoKitMaker` <br> It does not make a kit of maker functions. It makes a maker function that makes and returns a kit of exo objects.
- `vivify*`,`define*` -> `prepare*` <br> The notion of *preparing* something seems 
   - neutral enough between doing it when the thing to be prepared is first created vs when it is revived.
   - a nice phonetical pairing with `provide*`, helping us remember that these are similar but different
   - suggestive that it must happen early, such as in the first crank, because otherwise something that already exists might not yet be prepared.