### PR TITLE
introduce and use getPath on StorageNode

### DIFF
--- a/packages/cache/test/test-storage.js
+++ b/packages/cache/test/test-storage.js
@@ -28,15 +28,11 @@ harden(makeSimpleMarshaller);
 
 const setup = () => {
   const storageNodeState = {};
-  const chainStorage = makeChainStorageRoot(
-    message => {
-      assert(message.key === 'cache');
-      assert(message.method === 'set');
-      storageNodeState.cache = message.value;
-    },
-    'swingset',
-    'cache',
-  );
+  const chainStorage = makeChainStorageRoot(message => {
+    assert(message.key === 'cache');
+    assert(message.method === 'set');
+    storageNodeState.cache = message.value;
+  }, 'cache');
   const cache = makeCache(
     makeChainStorageCoordinator(chainStorage, makeSimpleMarshaller()),
   );

--- a/packages/casting/src/iterable.js
+++ b/packages/casting/src/iterable.js
@@ -10,7 +10,7 @@ export const makeNotifierIterable = notifier =>
   makeNotifier(E(notifier).getSharableNotifierInternals());
 
 /**
- * TODO: Remove this function when we have `makePublisherKit`.
+ * TODO: Remove this function when we have an @endo/publish-kit that suppports pull topics
  *
  * @template T
  * @param {ERef<PublicationRecord<T>>} tailP
@@ -29,7 +29,7 @@ const makeSubscriptionIterator = tailP => {
 };
 
 /**
- * TODO: Remove this function when we have `makePublisherKit`.
+ * TODO: Remove this function when we have an @endo/publish-kit that suppports pull topics
  *
  * @template T
  * @param {ERef<Subscription<T>>} subscription
@@ -60,7 +60,7 @@ export const mapAsyncIterable = (iterable, transform) => {
 };
 
 /**
- * TODO: Remove this function when we have `makePublisherKit`.
+ * TODO: Remove this function when we have an @endo/publish-kit that suppports pull topics
  *
  * @template T
  * @param {ERef<import('./types').Follower<T>>} follower
@@ -79,7 +79,7 @@ export const iterateLatest = follower =>
   });
 
 /**
- * TODO: Remove this function when we have `makePublisherKit`.
+ * TODO: Remove this function when we have an @endo/publish-kit that suppports pull topics
  *
  * @template T
  * @param {ERef<import('./types.js').Follower<T>>} follower

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -288,7 +288,6 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     const makeInstallationPublisher = () => {
       const installationStorageNode = makeChainStorageRoot(
         toStorage,
-        'swingset',
         STORAGE_PATH.BUNDLES,
         { sequence: true },
       );

--- a/packages/inter-protocol/test/test-priceAggregatorChainlink.js
+++ b/packages/inter-protocol/test/test-priceAggregatorChainlink.js
@@ -36,16 +36,6 @@ const defaultConfig = {
   maxSubmissionValue: 10000,
 };
 
-/**
- *
- * @param {Promise<StoredSubscriber<unknown>>} subscriber
- */
-export const subscriberSubkey = subscriber => {
-  return E(subscriber)
-    .getStoreKey()
-    .then(storeKey => storeKey.storeSubkey);
-};
-
 const makeContext = async () => {
   // Outside of tests, we should use the long-lived Zoe on the
   // testnet. In this test, we must create a new Zoe.
@@ -778,7 +768,7 @@ test('storage keys', async t => {
   );
 
   t.is(
-    await subscriberSubkey(E(publicFacet).getSubscriber()),
-    'fake:mockChainStorageRoot.priceAggregator.LINK-USD_price_feed',
+    await E(E(publicFacet).getSubscriber()).getPath(),
+    'mockChainStorageRoot.priceAggregator.LINK-USD_price_feed',
   );
 });

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -65,6 +65,7 @@ export const makeStoredSubscriber = (subscriber, storageNode, marshaller) => {
   /** @type {StoredSubscriber<T>} */
   const storesub = Far('StoredSubscriber', {
     subscribeAfter: publishCount => subscriber.subscribeAfter(publishCount),
+    getPath: () => E(storageNode).getPath(),
     getStoreKey: () => E(storageNode).getStoreKey(),
     getUnserializer: () => unserializer,
   });

--- a/packages/notifier/src/types-ambient.js
+++ b/packages/notifier/src/types-ambient.js
@@ -275,21 +275,25 @@
  *
  * @typedef {object} StorageNode
  * @property {(data: string) => Promise<void>} setValue publishes some data
- * @property {() => Promise<VStorageKey>} getStoreKey get the
- * externally-reachable store key for this storage item
+ * @property {() => string} getPath the chain storage path at which the node was constructed
+ * @property {() => Promise<VStorageKey>} getStoreKey DEPRECATED use getPath
  * @property {(subPath: string, options?: {sequence?: boolean}) => StorageNode} makeChildNode
  */
 
 /**
  * @typedef {object} StoredFacet
- * @property {StorageNode['getStoreKey']} getStoreKey get the externally-reachable store key
+ * @property {() => Promise<string>} getPath the chain storage path at which the node was constructed
+ * @property {StorageNode['getStoreKey']} getStoreKey DEPRECATED use getPath
  * @property {() => Unserializer} getUnserializer get the unserializer for the stored data
  */
 
 /**
- * @deprecated
+ * @deprecated use StoredSubscriber
  * @template T
- * @typedef {Subscription<T> & StoredFacet} StoredSubscription
+ * @typedef {Subscription<T> & {
+ *   getStoreKey: () => Promise<VStorageKey & { subscription: Subscription<T> }>,
+ *   getUnserializer: () => Unserializer,
+ * }} StoredSubscription
  */
 
 /**

--- a/packages/notifier/test/test-stored-subscription.js
+++ b/packages/notifier/test/test-stored-subscription.js
@@ -148,19 +148,16 @@ test('stored subscriber with setValue failure', async t => {
 
   makeStoredSubscriber(subscriber, storage, makeFakeMarshaller());
 
-  // @ts-expect-error test
   t.is(storage.countSetValueCalls(), 0);
   publisher.publish(initialValue); // fails setValue
   // should increment
   await eventLoopIteration();
-  // @ts-expect-error test
   t.is(storage.countSetValueCalls(), 1);
 
   // stops trying after a failure
   publisher.publish(initialValue); // fails setValue
   // should not increment
   await eventLoopIteration();
-  // @ts-expect-error test
   t.is(storage.countSetValueCalls(), 1);
 });
 
@@ -175,6 +172,7 @@ test('StoredPublisher', async t => {
 
   const { subscriber } = makeStoredPublishKit(storageNode, marshaller);
 
+  t.is(await subscriber.getPath(), 'publish.foo.bar');
   t.deepEqual(await subscriber.getStoreKey(), {
     dataPrefixBytes: '',
     storeName: 'swingset',

--- a/packages/notifier/tools/testSupports.js
+++ b/packages/notifier/tools/testSupports.js
@@ -21,8 +21,9 @@ export const makeFakeStorage = (path, publication) => {
     storeSubkey: `swingset/data:${fullPath}`,
     dataPrefixBytes: '',
   });
-  /** @type {StorageNode} */
+  /** @type {StorageNode & { countSetValueCalls: () => number}} */
   const storage = Far('StorageNode', {
+    getPath: () => path,
     getStoreKey: async () => storeKey,
     setValue: async value => {
       setValueCalls += 1;

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -28,22 +28,15 @@ harden(assertPathSegment);
  * Create a root storage node for a given backing function and root path.
  *
  * @param {(message: StorageMessage) => any} handleStorageMessage a function for sending a storageMessage object to the storage implementation (cf. golang/cosmos/x/vstorage/vstorage.go)
- * @param {'swingset'} storeName currently limited to "swingset"
  * @param {string} rootPath
  * @param {object} [rootOptions]
  * @param {boolean} [rootOptions.sequence] employ a wrapping structure that preserves each value set within a single block, and default child nodes to do the same
  */
 export function makeChainStorageRoot(
   handleStorageMessage,
-  storeName,
   rootPath,
   rootOptions = {},
 ) {
-  assert.equal(
-    storeName,
-    'swingset',
-    'the only currently-supported store is "swingset"',
-  );
   assert.typeof(rootPath, 'string');
 
   /**
@@ -105,7 +98,7 @@ export function makeChainStorageRoot(
  */
 const makeNullStorageNode = () => {
   // XXX re-use "ChainStorage" methods above which don't actually depend on chains
-  return makeChainStorageRoot(() => null, 'swingset', 'null');
+  return makeChainStorageRoot(() => null, 'null');
 };
 
 /**

--- a/packages/vats/src/lib-chainStorage.js
+++ b/packages/vats/src/lib-chainStorage.js
@@ -55,7 +55,13 @@ export function makeChainStorageRoot(
   function makeChainStorageNode(path, options = {}) {
     const { sequence = false } = options;
     const node = {
-      /** @type {() => Promise<VStorageKey>} */
+      getPath() {
+        return path;
+      },
+      /**
+       * @deprecated use getPath
+       * @type {() => Promise<VStorageKey>}
+       */
       async getStoreKey() {
         return handleStorageMessage({
           key: path,

--- a/packages/vats/src/vat-chainStorage.js
+++ b/packages/vats/src/vat-chainStorage.js
@@ -41,12 +41,7 @@ export function buildRootObject(vatPowers) {
 
     const toStorage = message => E(storageBridgeManager).toBridge(message);
 
-    const rootNode = makeChainStorageRoot(
-      toStorage,
-      'swingset',
-      rootPath,
-      options,
-    );
+    const rootNode = makeChainStorageRoot(toStorage, rootPath, options);
     return rootNode;
   };
 

--- a/packages/vats/test/test-lib-chainStorage.js
+++ b/packages/vats/test/test-lib-chainStorage.js
@@ -1,7 +1,6 @@
 // @ts-check
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { makeChainStorageRoot } from '../src/lib-chainStorage.js';
 import { makeFakeStorageKit } from '../tools/storage-test-utils.js';
 
 test('makeChainStorageRoot', async t => {
@@ -13,19 +12,6 @@ test('makeChainStorageRoot', async t => {
     rootStoreKey,
     { storeName: 'swingset', storeSubkey: `fake:${rootPath}` },
     'root store key matches initialization input',
-  );
-
-  t.throws(() =>
-    makeChainStorageRoot(
-      async () => {
-        t.fail(
-          'toStorage should not have been called for non-"swingset" storeName',
-        );
-      },
-      // @ts-expect-error
-      'notswingset',
-      rootPath,
-    ),
   );
 
   // Values must be strings.

--- a/packages/vats/test/test-lib-chainStorage.js
+++ b/packages/vats/test/test-lib-chainStorage.js
@@ -7,6 +7,7 @@ import { makeFakeStorageKit } from '../tools/storage-test-utils.js';
 test('makeChainStorageRoot', async t => {
   const rootPath = 'root';
   const { rootNode, messages } = makeFakeStorageKit(rootPath);
+  t.is(rootNode.getPath(), rootPath);
   const rootStoreKey = await rootNode.getStoreKey();
   t.deepEqual(
     rootStoreKey,
@@ -93,6 +94,7 @@ test('makeChainStorageRoot', async t => {
   for await (const segment of extremeSegments) {
     const child = rootNode.makeChildNode(segment);
     const childPath = `${rootPath}.${segment}`;
+    t.is(child.getPath(), childPath);
     const storeKey = await child.getStoreKey();
     t.deepEqual(
       storeKey,
@@ -136,6 +138,7 @@ test('makeChainStorageRoot', async t => {
   const childPath = `${rootPath}.child`;
   const deepNode = childNode.makeChildNode('grandchild');
   const deepPath = `${childPath}.grandchild`;
+  t.is(deepNode.getPath(), deepPath);
   t.deepEqual(await deepNode.getStoreKey(), {
     storeName: 'swingset',
     storeSubkey: `fake:${deepPath}`,

--- a/packages/vats/tools/storage-test-utils.js
+++ b/packages/vats/tools/storage-test-utils.js
@@ -59,12 +59,7 @@ export const makeFakeStorageKit = (rootPath, rootOptions) => {
         throw new Error(`unsupported method: ${message.method}`);
     }
   };
-  const rootNode = makeChainStorageRoot(
-    toStorage,
-    'swingset',
-    rootPath,
-    rootOptions,
-  );
+  const rootNode = makeChainStorageRoot(toStorage, rootPath, rootOptions);
   return { rootNode, data, messages };
 };
 harden(makeFakeStorageKit);

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -70,16 +70,6 @@ const dirname = path.dirname(filename);
 const oraclePath = `${dirname}/../../../src/contracts/oracle.js`;
 const aggregatorPath = `${dirname}/../../../src/contracts/priceAggregator.js`;
 
-/**
- *
- * @param {Promise<StoredSubscriber<unknown>>} subscriber
- */
-export const subscriberSubkey = subscriber => {
-  return E(subscriber)
-    .getStoreKey()
-    .then(storeKey => storeKey.storeSubkey);
-};
-
 const makePublicationChecker = async (t, aggregatorPublicFacet) => {
   const publications = E(
     subscribeEach(E(aggregatorPublicFacet).getSubscriber()),
@@ -1075,8 +1065,8 @@ test('storage keys', async t => {
   const { publicFacet } = await t.context.makeMedianAggregator();
 
   t.is(
-    await subscriberSubkey(E(publicFacet).getSubscriber()),
-    'fake:mockChainStorageRoot.priceAggregator.ATOM-USD_price_feed',
+    await E(E(publicFacet).getSubscriber()).getPath(),
+    'mockChainStorageRoot.priceAggregator.ATOM-USD_price_feed',
   );
 });
 


### PR DESCRIPTION
## Description

Motivated by https://github.com/Agoric/agoric-sdk/pull/6789/

This adds `getPath()` to StorageNode that a contract can use to publish the path a client can use to watch a stream of updates to that node. 

It also deprecates `getStoreKey()` which returns more info than is necessary. Since the storage context is implied by the rootStorageNode the consumer doesn't need that to be specified again.

It also removes the `storeName` param to `makeRootStorageNode` as it was never used.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

The deprecated `getStoreKey()` just says "DEPRECATED" because the `@deprecated` annotation doesn't mix well with the jsdoc.

### Testing Considerations

CI