### PR TITLE
BREAKING CHANGE: rename vivify* to prepare*

### DIFF
--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -6,7 +6,7 @@ import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 import { AssetKind, assertAssetKind } from './amountMath.js';
 import { coerceDisplayInfo } from './displayInfo.js';
-import { vivifyPaymentLedger } from './paymentLedger.js';
+import { preparePaymentLedger } from './paymentLedger.js';
 
 import './types-ambient.js';
 
@@ -24,7 +24,7 @@ import './types-ambient.js';
  * See https://github.com/Agoric/agoric-sdk/issues/3434
  * @returns {IssuerKit<K>}
  */
-export const vivifyIssuerKit = (
+export const prepareIssuerKit = (
   issuerBaggage,
   optShutdownWithFailure = undefined,
 ) => {
@@ -49,7 +49,7 @@ export const vivifyIssuerKit = (
   // Attenuate the powerful authority to mint and change balances
   /** @type {PaymentLedger<K>} */
   // @ts-expect-error could be instantiated with different subtype of AssetKind
-  const { issuer, mint, brand } = vivifyPaymentLedger(
+  const { issuer, mint, brand } = preparePaymentLedger(
     issuerBaggage,
     name,
     assetKind,
@@ -65,7 +65,7 @@ export const vivifyIssuerKit = (
     displayInfo: cleanDisplayInfo,
   });
 };
-harden(vivifyIssuerKit);
+harden(prepareIssuerKit);
 
 /**
  * @template {AssetKind} K
@@ -109,7 +109,7 @@ export const makeDurableIssuerKit = (
   issuerBaggage.init('assetKind', assetKind);
   issuerBaggage.init('displayInfo', displayInfo);
   issuerBaggage.init('elementShape', elementShape);
-  return vivifyIssuerKit(issuerBaggage, optShutdownWithFailure);
+  return prepareIssuerKit(issuerBaggage, optShutdownWithFailure);
 };
 harden(makeDurableIssuerKit);
 

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -1,5 +1,5 @@
 import { initEmpty } from '@agoric/store';
-import { vivifyFarClass } from '@agoric/vat-data';
+import { prepareFarClass } from '@agoric/vat-data';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -11,8 +11,8 @@ import { vivifyFarClass } from '@agoric/vat-data';
  * @param {InterfaceGuard} PaymentI
  * @returns {() => Payment<K>}
  */
-export const vivifyPaymentKind = (issuerBaggage, name, brand, PaymentI) => {
-  const makePayment = vivifyFarClass(
+export const preparePaymentKind = (issuerBaggage, name, brand, PaymentI) => {
+  const makePayment = prepareFarClass(
     issuerBaggage,
     `${name} payment`,
     PaymentI,
@@ -25,4 +25,4 @@ export const vivifyPaymentKind = (issuerBaggage, name, brand, PaymentI) => {
   );
   return makePayment;
 };
-harden(vivifyPaymentKind);
+harden(preparePaymentKind);

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -4,11 +4,11 @@ import { assertCopyArray } from '@endo/marshal';
 import { fit, M } from '@agoric/store';
 import {
   provideDurableWeakMapStore,
-  vivifyFarInstance,
+  prepareFarInstance,
 } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
-import { vivifyPaymentKind } from './payment.js';
-import { vivifyPurseKind } from './purse.js';
+import { preparePaymentKind } from './payment.js';
+import { preparePurseKind } from './purse.js';
 
 import '@agoric/store/exported.js';
 import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
@@ -75,7 +75,7 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
  * @param {ShutdownWithFailure=} optShutdownWithFailure
  * @returns {PaymentLedger<K>}
  */
-export const vivifyPaymentLedger = (
+export const preparePaymentLedger = (
   issuerBaggage,
   name,
   assetKind,
@@ -84,7 +84,7 @@ export const vivifyPaymentLedger = (
   optShutdownWithFailure = undefined,
 ) => {
   /** @type {Brand<K>} */
-  const brand = vivifyFarInstance(issuerBaggage, `${name} brand`, BrandI, {
+  const brand = prepareFarInstance(issuerBaggage, `${name} brand`, BrandI, {
     isMyIssuer(allegedIssuer) {
       // BrandI delays calling this method until `allegedIssuer` is a Remotable
       return allegedIssuer === issuer;
@@ -114,7 +114,7 @@ export const vivifyPaymentLedger = (
     amountShape,
   );
 
-  const makePayment = vivifyPaymentKind(issuerBaggage, name, brand, PaymentI);
+  const makePayment = preparePaymentKind(issuerBaggage, name, brand, PaymentI);
 
   /** @type {ShutdownWithFailure} */
   const shutdownLedgerWithFailure = reason => {
@@ -366,7 +366,7 @@ export const vivifyPaymentLedger = (
     return payment;
   };
 
-  const makeEmptyPurse = vivifyPurseKind(
+  const makeEmptyPurse = preparePurseKind(
     issuerBaggage,
     name,
     assetKind,
@@ -379,7 +379,7 @@ export const vivifyPaymentLedger = (
   );
 
   /** @type {Issuer<K>} */
-  const issuer = vivifyFarInstance(issuerBaggage, `${name} issuer`, IssuerI, {
+  const issuer = prepareFarInstance(issuerBaggage, `${name} issuer`, IssuerI, {
     getBrand() {
       return brand;
     },
@@ -477,7 +477,7 @@ export const vivifyPaymentLedger = (
   });
 
   /** @type {Mint<K>} */
-  const mint = vivifyFarInstance(issuerBaggage, `${name} mint`, MintI, {
+  const mint = prepareFarInstance(issuerBaggage, `${name} mint`, MintI, {
     getIssuer() {
       return issuer;
     },
@@ -493,4 +493,4 @@ export const vivifyPaymentLedger = (
   const issuerKit = harden({ issuer, mint, brand });
   return issuerKit;
 };
-harden(vivifyPaymentLedger);
+harden(preparePaymentLedger);

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -1,10 +1,10 @@
-import { vivifyFarClassKit, makeScalarBigSetStore } from '@agoric/vat-data';
+import { prepareFarClassKit, makeScalarBigSetStore } from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { makeTransientNotifierKit } from './transientNotifier.js';
 
 const { Fail } = assert;
 
-export const vivifyPurseKind = (
+export const preparePurseKind = (
   issuerBaggage,
   name,
   assetKind,
@@ -28,7 +28,7 @@ export const vivifyPurseKind = (
   //   that created depositFacet as needed. But this approach ensures a constant
   //   identity for the facet and exercises the multi-faceted object style.
   const { depositInternal, withdrawInternal } = purseMethods;
-  const makePurseKit = vivifyFarClassKit(
+  const makePurseKit = prepareFarClassKit(
     issuerBaggage,
     `${name} Purse`,
     PurseIKit,
@@ -112,4 +112,4 @@ export const vivifyPurseKind = (
   );
   return () => makePurseKit().purse;
 };
-harden(vivifyPurseKind);
+harden(preparePurseKind);

--- a/packages/ERTP/test/swingsetTests/ertpService/vat-ertp-service.js
+++ b/packages/ERTP/test/swingsetTests/ertpService/vat-ertp-service.js
@@ -1,15 +1,19 @@
 import { Far } from '@endo/marshal';
 import {
   makeScalarBigMapStore,
-  vivifySingleton,
+  prepareSingleton,
   provideDurableSetStore,
 } from '@agoric/vat-data';
 
-import { AssetKind, makeDurableIssuerKit, vivifyIssuerKit } from '../../../src';
+import {
+  AssetKind,
+  makeDurableIssuerKit,
+  prepareIssuerKit,
+} from '../../../src';
 
-export const vivifyErtpService = (baggage, exitVatWithFailure) => {
+export const prepareErtpService = (baggage, exitVatWithFailure) => {
   const issuerBaggageSet = provideDurableSetStore(baggage, 'BaggageSet');
-  const ertpService = vivifySingleton(baggage, 'ERTPService', {
+  const ertpService = prepareSingleton(baggage, 'ERTPService', {
     makeIssuerKit: (
       name,
       assetKind = AssetKind.NAT,
@@ -32,15 +36,15 @@ export const vivifyErtpService = (baggage, exitVatWithFailure) => {
   });
 
   for (const issuerBaggage of issuerBaggageSet.values()) {
-    vivifyIssuerKit(issuerBaggage);
+    prepareIssuerKit(issuerBaggage);
   }
 
   return ertpService;
 };
-harden(vivifyErtpService);
+harden(prepareErtpService);
 
 export const buildRootObject = async (vatPowers, _vatParams, baggage) => {
-  const ertpService = vivifyErtpService(baggage, vatPowers.exitVatWithFailure);
+  const ertpService = prepareErtpService(baggage, vatPowers.exitVatWithFailure);
   return Far('root', {
     getErtpService: () => ertpService,
   });

--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -10,8 +10,8 @@ import {
   provideDurableMapStore,
   provideDurableWeakMapStore,
   defineDurableKindMulti,
-  vivifyKind,
-  vivifySingleton,
+  prepareKind,
+  prepareSingleton,
 } from '@agoric/vat-data';
 import { makeScalarWeakMapStore } from '@agoric/store';
 import { TimeMath } from './timeMath.js';
@@ -241,7 +241,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
 
   // These Kinds are the ongoing obligations of the vat: all future
   // versions must define behaviors for these. Search for calls to
-  // 'vivifyKind', 'vivifySingleton', or 'defineDurableKindMulti'.
+  // 'prepareKind', 'prepareSingleton', or 'defineDurableKindMulti'.
   // * oneShotEvent
   // * promiseEvent
   // * repeaterEvent
@@ -397,7 +397,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
     },
   };
 
-  const makeOneShotEvent = vivifyKind(
+  const makeOneShotEvent = prepareKind(
     baggage,
     'oneShotEvent',
     initOneShotEvent,
@@ -443,7 +443,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
   /**
    * @returns { PromiseEvent }
    */
-  const makePromiseEvent = vivifyKind(
+  const makePromiseEvent = prepareKind(
     baggage,
     'promiseEvent',
     initPromiseEvent,
@@ -546,7 +546,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
     },
   };
 
-  const makeRepeaterEvent = vivifyKind(
+  const makeRepeaterEvent = prepareKind(
     baggage,
     'repeaterEvent',
     initRepeaterEvent,
@@ -740,7 +740,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
         });
     },
   };
-  const createIterator = vivifyKind(
+  const createIterator = prepareKind(
     baggage,
     'timerIterator',
     initIterator,
@@ -882,11 +882,11 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
 
   // -- now we finally build the TimerService
 
-  const wakeupHandler = vivifySingleton(baggage, 'wakeupHandler', {
+  const wakeupHandler = prepareSingleton(baggage, 'wakeupHandler', {
     wake: processAndReschedule,
   });
 
-  const timerService = vivifySingleton(baggage, 'timerService', {
+  const timerService = prepareSingleton(baggage, 'timerService', {
     getCurrentTimestamp,
     setWakeup /* one-shot with handler (absolute) */,
     wakeAt /* one-shot with Promise (absolute) */,
@@ -900,13 +900,13 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
   });
 
   // attenuated read-only facet
-  const timerClock = vivifySingleton(baggage, 'timerClock', {
+  const timerClock = prepareSingleton(baggage, 'timerClock', {
     getCurrentTimestamp,
     getTimerBrand: () => timerBrand,
   });
 
   // powerless identifier
-  const timerBrand = vivifySingleton(baggage, 'timerBrand', {
+  const timerBrand = prepareSingleton(baggage, 'timerBrand', {
     isMyTimerService: alleged => alleged === timerService,
     isMyClock: alleged => alleged === timerClock,
   });

--- a/packages/SwingSet/src/vats/vattp/vat-vattp.js
+++ b/packages/SwingSet/src/vats/vattp/vat-vattp.js
@@ -6,7 +6,7 @@ import {
   provideDurableMapStore,
   provideDurableSetStore,
   provideKindHandle,
-  vivifySingleton,
+  prepareSingleton,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
 
@@ -286,7 +286,7 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
   };
 
   // Expose a durable service singleton.
-  return vivifySingleton(baggage, serviceSingletonBaggageKey, {
+  return prepareSingleton(baggage, serviceSingletonBaggageKey, {
     ...serviceMailboxFunctions,
     ...serviceNetworkFunctions,
   });

--- a/packages/SwingSet/test/vat-durable-singleton.js
+++ b/packages/SwingSet/test/vat-durable-singleton.js
@@ -1,6 +1,6 @@
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';
-import { provide, vivifyFarClassKit } from '@agoric/vat-data';
+import { provide, prepareFarClassKit } from '@agoric/vat-data';
 
 export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const { version } = vatParameters;
@@ -9,10 +9,16 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const emptyFacetI = M.interface('Facet', {});
   const iKit = harden({ facet1: emptyFacetI, facet2: emptyFacetI });
   const initState = () => ({});
-  const makeInstance = vivifyFarClassKit(baggage, 'ClassKit', iKit, initState, {
-    facet1: {},
-    facet2: {},
-  });
+  const makeInstance = prepareFarClassKit(
+    baggage,
+    'ClassKit',
+    iKit,
+    initState,
+    {
+      facet1: {},
+      facet2: {},
+    },
+  );
   const singleton = provide(baggage, 'durableSingleton', () => makeInstance());
 
   return Far('root', {

--- a/packages/inter-protocol/src/price/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/price/priceAggregatorChainlink.js
@@ -9,7 +9,7 @@ import {
   makeStoredPublishKit,
   makeStoredSubscriber,
   observeNotifier,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
 } from '@agoric/notifier';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeOnewayPriceAuthorityKit } from '@agoric/zoe/src/contractSupport/index.js';
@@ -115,12 +115,12 @@ export const start = async (zcf, privateArgs, baggage) => {
   const { marshaller, storageNode } = privateArgs;
   assertAllDefined({ marshaller, storageNode });
 
-  const makeAnswerPublishKit = vivifyDurablePublishKit(
+  const makeAnswerPublishKit = prepareDurablePublishKit(
     baggage,
     'AnswerPublishKit',
   );
 
-  const makeLatestRoundPublishKit = vivifyDurablePublishKit(
+  const makeLatestRoundPublishKit = prepareDurablePublishKit(
     baggage,
     'LatestRoundPublishKit',
   );

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -15,7 +15,7 @@ import {
   ParamTypes,
   publicMixinAPI,
 } from '@agoric/governance';
-import { M, provide, vivifyFarInstance } from '@agoric/vat-data';
+import { M, provide, prepareFarInstance } from '@agoric/vat-data';
 import { AmountMath } from '@agoric/ertp';
 
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
@@ -275,7 +275,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     },
     ...publicMixin,
   };
-  const publicFacet = vivifyFarInstance(
+  const publicFacet = prepareFarInstance(
     baggage,
     'Parity Stability Module',
     PSMI,

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -5,7 +5,7 @@ import {
   offerTo,
   atomicTransfer,
 } from '@agoric/zoe/src/contractSupport/index.js';
-import { provideDurableMapStore, vivifyKindMulti } from '@agoric/vat-data';
+import { provideDurableMapStore, prepareKindMulti } from '@agoric/vat-data';
 
 import { makeTracer } from '@agoric/internal';
 import { AMM_INSTANCE } from './params.js';
@@ -431,7 +431,7 @@ const start = async (zcf, privateArgs, baggage) => {
     }),
   );
 
-  const makeAssetReserve = vivifyKindMulti(baggage, 'assetReserve', init, {
+  const makeAssetReserve = prepareKindMulti(baggage, 'assetReserve', init, {
     publicFacet,
     creatorFacet: governorFacet,
     shortfallReportingFacet,

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -1,7 +1,7 @@
 import { AmountMath, AmountShape } from '@agoric/ertp';
 import { makeTracer } from '@agoric/internal';
 import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
-import { M, vivifyFarClassKit } from '@agoric/vat-data';
+import { M, prepareFarClassKit } from '@agoric/vat-data';
 import {
   assertProposalShape,
   atomicTransfer,
@@ -18,7 +18,7 @@ import {
 } from '../contractSupport.js';
 import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
 import { UnguardedHelperI } from '../typeGuards.js';
-import { vivifyVaultKit } from './vaultKit.js';
+import { prepareVaultKit } from './vaultKit.js';
 
 import '@agoric/zoe/exported.js';
 
@@ -214,12 +214,12 @@ export const VaultI = M.interface('Vault', {
   makeTransferInvitation: M.call().returns(M.promise()),
 });
 
-export const vivifyVault = baggage => {
-  trace('vivifyVault');
-  const makeVaultKit = vivifyVaultKit(baggage);
+export const prepareVault = baggage => {
+  trace('prepareVault');
+  const makeVaultKit = prepareVaultKit(baggage);
 
   // TODO find a way to not have to indent a level deeper than defineDurableFarClassKit does
-  const maker = vivifyFarClassKit(
+  const maker = prepareFarClassKit(
     baggage,
     'Vault',
     {
@@ -846,4 +846,4 @@ export const vivifyVault = baggage => {
   return maker;
 };
 
-/** @typedef {ReturnType<ReturnType<typeof vivifyVault>>['self']} Vault */
+/** @typedef {ReturnType<ReturnType<typeof prepareVault>>['self']} Vault */

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -19,7 +19,7 @@ import {
   makeStoredSubscriber,
   observeIteration,
   SubscriberShape,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
 } from '@agoric/notifier';
 import {
   defineDurableFarClassKit,
@@ -35,7 +35,7 @@ import {
   SHORTFALL_INVITATION_KEY,
   vaultParamPattern,
 } from './params.js';
-import { vivifyVaultManagerKit } from './vaultManager.js';
+import { prepareVaultManagerKit } from './vaultManager.js';
 import { provideChildBaggage } from '../contractSupport.js';
 
 const { details: X, quote: q, Fail } = assert;
@@ -152,7 +152,7 @@ const baggage = makeScalarBigMapStore('Vault Director baggage', {
   durable: true,
 });
 
-const makeVaultDirectorMetricsPublishKit = vivifyDurablePublishKit(
+const makeVaultDirectorMetricsPublishKit = prepareDurablePublishKit(
   baggage,
   'Vault Director metrics',
 );
@@ -471,7 +471,7 @@ const makeVaultDirector = defineDurableFarClassKit(
         const brandName = await E(collateralBrand).getAllegedName();
         const makeVaultManager = managerBaggages.addChild(
           brandName,
-          vivifyVaultManagerKit,
+          prepareVaultManagerKit,
         );
 
         const { self: vm } = makeVaultManager(

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -5,9 +5,9 @@ import { AmountShape } from '@agoric/ertp';
 import {
   makeStoredSubscriber,
   SubscriberShape,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
 } from '@agoric/notifier';
-import { M, vivifyFarClassKit } from '@agoric/vat-data';
+import { M, prepareFarClassKit } from '@agoric/vat-data';
 import { makeEphemeraProvider } from '../contractSupport.js';
 import { UnguardedHelperI } from '../typeGuards.js';
 
@@ -43,13 +43,13 @@ const HolderI = M.interface('holder', {
  *
  * @param {import('@agoric/ertp').Baggage} baggage
  */
-export const vivifyVaultHolder = baggage => {
-  const makeVaultHolderPublishKit = vivifyDurablePublishKit(
+export const prepareVaultHolder = baggage => {
+  const makeVaultHolderPublishKit = prepareDurablePublishKit(
     baggage,
     'Vault Holder publish kit',
   );
 
-  const makeVaultHolderKit = vivifyFarClassKit(
+  const makeVaultHolderKit = prepareFarClassKit(
     baggage,
     'Vault Holder',
     {

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -1,14 +1,14 @@
 import { makeTracer } from '@agoric/internal';
 import '@agoric/zoe/exported.js';
 import { Far } from '@endo/marshal';
-import { vivifyVaultHolder } from './vaultHolder.js';
+import { prepareVaultHolder } from './vaultHolder.js';
 
 const trace = makeTracer('IV');
 
-export const vivifyVaultKit = baggage => {
-  trace('vivifyVaultKit', baggage);
+export const prepareVaultKit = baggage => {
+  trace('prepareVaultKit', baggage);
 
-  const makeVaultHolder = vivifyVaultHolder(baggage);
+  const makeVaultHolder = prepareVaultHolder(baggage);
   /**
    * Create a kit of utilities for use of the vault.
    *
@@ -18,7 +18,7 @@ export const vivifyVaultKit = baggage => {
    * @param {Subscriber<import('./vaultManager').AssetState>} assetSubscriber
    */
   const makeVaultKit = (vault, storageNode, marshaller, assetSubscriber) => {
-    trace('vivifyVaultKit makeVaultKit');
+    trace('prepareVaultKit makeVaultKit');
     const { holder, helper } = makeVaultHolder(vault, storageNode, marshaller);
     const vaultKit = harden({
       publicSubscribers: {
@@ -39,4 +39,4 @@ export const vivifyVaultKit = baggage => {
   return makeVaultKit;
 };
 
-/** @typedef {(ReturnType<ReturnType<typeof vivifyVaultKit>>)} VaultKit */
+/** @typedef {(ReturnType<ReturnType<typeof prepareVaultKit>>)} VaultKit */

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -20,13 +20,13 @@ import {
   makeStoredSubscriber,
   observeNotifier,
   SubscriberShape,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
 } from '@agoric/notifier';
 import {
   M,
   makeScalarBigMapStore,
   makeScalarBigSetStore,
-  vivifyFarClassKit,
+  prepareFarClassKit,
 } from '@agoric/vat-data';
 import {
   assertProposalShape,
@@ -45,7 +45,7 @@ import { checkDebtLimit, makeEphemeraProvider } from '../contractSupport.js';
 import { chargeInterest } from '../interest.js';
 import { liquidate, makeQuote, updateQuote } from './liquidation.js';
 import { makePrioritizedVaults } from './prioritizedVaults.js';
-import { Phase, vivifyVault } from './vault.js';
+import { Phase, prepareVault } from './vault.js';
 
 const { details: X } = assert;
 
@@ -188,13 +188,13 @@ const finish = context => {
 
 // TODO move params of initState here because it's a singleton
 // and remove from State what doesn't need to be stored between upgrades
-export const vivifyVaultManagerKit = baggage => {
-  const makeVault = vivifyVault(baggage);
-  const makeVaultManagerMetricsPublishKit = vivifyDurablePublishKit(
+export const prepareVaultManagerKit = baggage => {
+  const makeVault = prepareVault(baggage);
+  const makeVaultManagerMetricsPublishKit = prepareDurablePublishKit(
     baggage,
     'Vault Manager metrics',
   );
-  const makeVaultManagerAssetsPublishKit = vivifyDurablePublishKit(
+  const makeVaultManagerAssetsPublishKit = prepareDurablePublishKit(
     baggage,
     'Vault Manager assets',
   );
@@ -333,7 +333,7 @@ export const vivifyVaultManagerKit = baggage => {
   };
 
   // TODO find a way to not have to indent a level deeper than defineDurableFarClassKit does
-  return vivifyFarClassKit(
+  return prepareFarClassKit(
     baggage,
     'VaultManagerKit',
     {
@@ -1068,7 +1068,7 @@ export const vivifyVaultManagerKit = baggage => {
 };
 
 /**
- * @typedef {ReturnType<ReturnType<typeof vivifyVaultManagerKit>>['self']} VaultManager
+ * @typedef {ReturnType<ReturnType<typeof prepareVaultManagerKit>>['self']} VaultManager
  * Each VaultManager manages a single collateral type.
  *
  * It manages some number of outstanding loans, each called a Vault, for which

--- a/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -14,7 +14,7 @@ import {
   provideDurableMapStore,
   provideDurableWeakMapStore,
   provide,
-  vivifyKindMulti,
+  prepareKindMulti,
 } from '@agoric/vat-data';
 import { makeTracer } from '@agoric/internal';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
@@ -479,7 +479,7 @@ const start = async (zcf, privateArgs, baggage) => {
     }),
   );
 
-  const makeAMM = vivifyKindMulti(baggage, 'AMM', initEmpty, {
+  const makeAMM = prepareKindMulti(baggage, 'AMM', initEmpty, {
     publicFacet,
     creatorFacet: governorFacet,
     limitedCreatorFacet,

--- a/packages/inter-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/pool.js
@@ -2,7 +2,7 @@ import '@agoric/zoe/exported.js';
 
 import { AmountMath, isNatValue } from '@agoric/ertp';
 import { makeStoredPublishKit } from '@agoric/notifier';
-import { vivifyKindMulti } from '@agoric/vat-data';
+import { prepareKindMulti } from '@agoric/vat-data';
 import {
   calcLiqValueToMint,
   calcSecondaryRequired,
@@ -394,5 +394,5 @@ export const definePoolKind = (baggage, ammPowers, storageNode, marshaller) => {
     singlePool: makeSinglePool(ammPowers),
   });
 
-  return vivifyKindMulti(baggage, 'pool', poolInit, facets, { finish });
+  return prepareKindMulti(baggage, 'pool', poolInit, facets, { finish });
 };

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -20,7 +20,7 @@ import {
 import { getAmountOut } from '@agoric/zoe/src/contractSupport';
 import { E } from '@endo/eventual-send';
 import { paymentFromZCFMint } from '../../src/vaultFactory/burn.js';
-import { vivifyVault } from '../../src/vaultFactory/vault.js';
+import { prepareVault } from '../../src/vaultFactory/vault.js';
 
 const BASIS_POINTS = 10000n;
 const SECONDS_PER_HOUR = 60n * 60n;
@@ -156,7 +156,7 @@ export async function start(zcf, privateArgs, baggage) {
     },
   });
 
-  const makeVault = vivifyVault(baggage);
+  const makeVault = prepareVault(baggage);
 
   const { self: vault } = await makeVault(
     zcf,

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -2,7 +2,7 @@ export {
   makePublishKit,
   subscribeEach,
   subscribeLatest,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
   SubscriberShape,
 } from './publish-kit.js';
 export {

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -4,7 +4,7 @@ import { HandledPromise, E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';
-import { canBeDurable, vivifyFarClassKit } from '@agoric/vat-data';
+import { canBeDurable, prepareFarClassKit } from '@agoric/vat-data';
 
 import './types-ambient.js';
 
@@ -381,11 +381,11 @@ const advanceDurablePublishKit = (context, done, value, rejection) => {
  * @param {import('../../vat-data/src/types.js').Baggage} baggage
  * @param {string} kindName
  */
-export const vivifyDurablePublishKit = (baggage, kindName) => {
+export const prepareDurablePublishKit = (baggage, kindName) => {
   /**
    * @returns {() => PublishKit<*>}
    */
-  return vivifyFarClassKit(
+  return prepareFarClassKit(
     baggage,
     kindName,
     publishKitIKit,
@@ -430,6 +430,6 @@ export const vivifyDurablePublishKit = (baggage, kindName) => {
     },
   );
 };
-harden(vivifyDurablePublishKit);
+harden(prepareDurablePublishKit);
 
 export const SubscriberShape = M.remotable('Subscriber');

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -16,7 +16,7 @@ import {
   makePublishKit,
   subscribeEach,
   subscribeLatest,
-  vivifyDurablePublishKit,
+  prepareDurablePublishKit,
 } from '../src/index.js';
 import '../src/types-ambient.js';
 import { invertPromiseSettlement } from './iterable-testing-tools.js';
@@ -32,7 +32,7 @@ const makeBaggage = () => makeScalarBigMapStore('baggage', { durable: true });
 
 const makers = {
   publishKit: makePublishKit,
-  durablePublishKit: vivifyDurablePublishKit(
+  durablePublishKit: prepareDurablePublishKit(
     makeBaggage(),
     'DurablePublishKit',
   ),
@@ -203,7 +203,7 @@ test('publish kit allows non-durable values', async t => {
   await assertTransmission(t, makePublishKit(), nonPassable, 'fail');
 });
 test('durable publish kit rejects non-durable values', async t => {
-  const makeDurablePublishKit = vivifyDurablePublishKit(
+  const makeDurablePublishKit = prepareDurablePublishKit(
     makeBaggage(),
     'DurablePublishKit',
   );
@@ -374,7 +374,7 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
 // https://github.com/Agoric/agoric-sdk/pull/6502#discussion_r1008492055
 test.skip('durable publish kit upgrade trauma', async t => {
   const baggage = makeBaggage();
-  const makeDurablePublishKit = vivifyDurablePublishKit(
+  const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,
     'DurablePublishKit',
   );

--- a/packages/notifier/test/vat-integration/vat-pubsub.js
+++ b/packages/notifier/test/vat-integration/vat-pubsub.js
@@ -1,9 +1,9 @@
 import { Far } from '@endo/marshal';
 import { provide } from '@agoric/vat-data';
-import { vivifyDurablePublishKit } from '../../src/index.js';
+import { prepareDurablePublishKit } from '../../src/index.js';
 
 export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
-  const makeDurablePublishKit = vivifyDurablePublishKit(
+  const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,
     'DurablePublishKit',
   );

--- a/packages/vat-data/src/far-class-utils.js
+++ b/packages/vat-data/src/far-class-utils.js
@@ -137,7 +137,7 @@ harden(defineDurableFarClassKit);
  * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const vivifyFarClass = (
+export const prepareFarClass = (
   baggage,
   kindName,
   interfaceGuard,
@@ -152,7 +152,7 @@ export const vivifyFarClass = (
     methods,
     options,
   );
-harden(vivifyFarClass);
+harden(prepareFarClass);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -166,7 +166,7 @@ harden(vivifyFarClass);
  * @param {DefineKindOptions<{ facets: T, state: ReturnType<I> }>} [options]
  * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
  */
-export const vivifyFarClassKit = (
+export const prepareFarClassKit = (
   baggage,
   kindName,
   interfaceGuardKit,
@@ -181,7 +181,7 @@ export const vivifyFarClassKit = (
     facets,
     options,
   );
-harden(vivifyFarClassKit);
+harden(prepareFarClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
@@ -194,14 +194,14 @@ harden(vivifyFarClassKit);
  * @param {DefineKindOptions<{ self: M }>} [options]
  * @returns {T & RemotableBrand<{}, T>}
  */
-export const vivifyFarInstance = (
+export const prepareFarInstance = (
   baggage,
   kindName,
   interfaceGuard,
   methods,
   options = undefined,
 ) => {
-  const makeSingleton = vivifyFarClass(
+  const makeSingleton = prepareFarClass(
     baggage,
     kindName,
     interfaceGuard,
@@ -214,10 +214,10 @@ export const vivifyFarInstance = (
   // @ts-ignore could be instantiated with an arbitrary type
   return provide(baggage, `the_${kindName}`, () => makeSingleton());
 };
-harden(vivifyFarInstance);
+harden(prepareFarInstance);
 
 /**
- * @deprecated Use vivifyFarInstance instead.
+ * @deprecated Use prepareFarInstance instead.
  * @template {Record<string | symbol, CallableFunction>} T methods
  * @param {Baggage} baggage
  * @param {string} kindName
@@ -225,10 +225,10 @@ harden(vivifyFarInstance);
  * @param {DefineKindOptions<{ self: T }>} [options]
  * @returns {T & RemotableBrand<{}, T>}
  */
-export const vivifySingleton = (
+export const prepareSingleton = (
   baggage,
   kindName,
   methods,
   options = undefined,
-) => vivifyFarInstance(baggage, kindName, undefined, methods, options);
-harden(vivifySingleton);
+) => prepareFarInstance(baggage, kindName, undefined, methods, options);
+harden(prepareSingleton);

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -6,10 +6,10 @@ export {
   defineVirtualFarClassKit,
   defineDurableFarClass,
   defineDurableFarClassKit,
-  vivifyFarClass,
-  vivifyFarClassKit,
-  vivifyFarInstance,
-  vivifySingleton,
+  prepareFarClass,
+  prepareFarClassKit,
+  prepareFarInstance,
+  prepareSingleton,
 } from './far-class-utils.js';
 
 /** @template T @typedef {import('./types.js').DefineKindOptions<T>} DefineKindOptions */

--- a/packages/vat-data/src/kind-utils.js
+++ b/packages/vat-data/src/kind-utils.js
@@ -30,10 +30,10 @@ export const provideKindHandle = (baggage, kindName) =>
 harden(provideKindHandle);
 
 /**
- * @deprecated Use vivifyFarClass instead
- * @type {import('./types.js').VivifyKind}
+ * @deprecated Use prepareFarClass instead
+ * @type {import('./types.js').PrepareKind}
  */
-export const vivifyKind = (
+export const prepareKind = (
   baggage,
   kindName,
   init,
@@ -46,13 +46,13 @@ export const vivifyKind = (
     behavior,
     options,
   );
-harden(vivifyKind);
+harden(prepareKind);
 
 /**
- * @deprecated Use vivifyFarClassKit instead
- * @type {import('./types.js').VivifyKindMulti}
+ * @deprecated Use prepareFarClassKit instead
+ * @type {import('./types.js').PrepareKindMulti}
  */
-export const vivifyKindMulti = (
+export const prepareKindMulti = (
   baggage,
   kindName,
   init,
@@ -65,4 +65,4 @@ export const vivifyKindMulti = (
     behavior,
     options,
   );
-harden(vivifyKindMulti);
+harden(prepareKindMulti);

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -73,9 +73,9 @@ type DefineKindOptions<C> = {
    * Intended for internal use only.
    * Should the raw methods receive their `context` argument as their first
    * argument or as their `this` binding? For `defineDurableKind` and its
-   * siblings (including `vivifySingleton`), this defaults to off, meaning that
+   * siblings (including `prepareSingleton`), this defaults to off, meaning that
    * their behavior methods receive `context` as their first argument.
-   * `vivifyFarClass` and its siblings (including `vivifyFarInstance`) use
+   * `prepareFarClass` and its siblings (including `prepareFarInstance`) use
    * this flag internally to indicate that their methods receive `context`
    * as their `this` binding.
    */
@@ -88,7 +88,7 @@ type DefineKindOptions<C> = {
    * pattern is satisfied before calling the raw method.
    *
    * In `defineDurableKind` and its siblings, this defaults to off.
-   * `vivifyFarClass` use this internally to protect their raw class methods
+   * `prepareFarClass` use this internally to protect their raw class methods
    * using the provided interface.
    */
   interfaceGuard?: InterfaceGuard<unknown>;
@@ -173,8 +173,8 @@ interface PickFacet {
   ): (...args: Parameters<M>) => ReturnType<M>[F];
 }
 
-/** @deprecated Use vivifyFarClass instead */
-type VivifyKind = <P, S, F>(
+/** @deprecated Use prepareFarClass instead */
+type PrepareKind = <P, S, F>(
   baggage: Baggage,
   tag: string,
   init: (...args: P) => S,
@@ -182,8 +182,8 @@ type VivifyKind = <P, S, F>(
   options?: DefineKindOptions<KindContext<S, F>>,
 ) => (...args: P) => KindFacet<F>;
 
-/** @deprecated Use vivifyFarClassKit instead */
-type VivifyKindMulti = <P, S, B>(
+/** @deprecated Use prepareFarClassKit instead */
+type PrepareKindMulti = <P, S, B>(
   baggage: Baggage,
   tag: string,
   init: (...args: P) => S,

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -103,7 +103,7 @@ harden(partialAssign);
  * where the total number of calls to `provide` must be
  * low cardinality, since we keep the bookkeeping to detect collisions
  * in normal language-heap memory. All the other baggage-oriented
- * `provide*` and `vivify*` functions call `provide`,
+ * `provide*` and `prepare*` functions call `provide`,
  * and so impose the same constraints. This is consistent with
  * our expected durability patterns: What we store in baggage are
  *    * kindHandles, which are per kind, which must be low cardinality
@@ -117,7 +117,7 @@ harden(partialAssign);
  * TODO https://github.com/Agoric/agoric-sdk/pull/5875 :
  * Implement development-time instrumentation to detect when
  * `provide` violates the above prescription, and is called more
- * than one in the same vat incarnation with the same
+ * than once in the same vat incarnation with the same
  * baggage,key pair.
  *
  * @template K,V

--- a/packages/vat-data/test/test-prepare.js
+++ b/packages/vat-data/test/test-prepare.js
@@ -3,9 +3,9 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { M } from '@agoric/store';
 import {
-  vivifyFarClass,
-  vivifyFarClassKit,
-  vivifyFarInstance,
+  prepareFarClass,
+  prepareFarClassKit,
+  prepareFarInstance,
 } from '../src/far-class-utils.js';
 import { makeScalarBigMapStore } from '../src/vat-data-bindings.js';
 
@@ -23,10 +23,10 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test vivifyFarClass', t => {
+test('test prepareFarClass', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
-  const makeUpCounter = vivifyFarClass(
+  const makeUpCounter = prepareFarClass(
     baggage,
     'UpCounter',
     UpCounterI,
@@ -57,10 +57,10 @@ test('test vivifyFarClass', t => {
   makeUpCounter('str');
 });
 
-test('test vivifyFarClassKit', t => {
+test('test prepareFarClassKit', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
-  const makeCounterKit = vivifyFarClassKit(
+  const makeCounterKit = prepareFarClassKit(
     baggage,
     'Counter',
     { up: UpCounterI, down: DownCounterI },
@@ -105,11 +105,11 @@ test('test vivifyFarClassKit', t => {
   makeCounterKit('str');
 });
 
-test('test vivifyFarInstance', t => {
+test('test prepareFarInstance', t => {
   const baggage = makeScalarBigMapStore('baggage', { durable: true });
 
   let x = 3;
-  const upCounter = vivifyFarInstance(baggage, 'upCounter', UpCounterI, {
+  const upCounter = prepareFarInstance(baggage, 'upCounter', UpCounterI, {
     incr(y = 1) {
       x += y;
       return x;

--- a/packages/zoe/docs/ZoeDataInitialization.puml
+++ b/packages/zoe/docs/ZoeDataInitialization.puml
@@ -13,7 +13,7 @@ bootstrap -> Zoe: makeZoeKit(...)
 Zoe -> ZoeStorageManager : makeZoeStorageManager()
 ZoeStorageManager -> ZoeStorageManager : provideIssuerStorage()
 ZoeStorageManager -> ZoeStorageManager : provideEscrowStorage()
-ZoeStorageManager -> ZoeStorageManager : vivifyInvitationKit()
+ZoeStorageManager -> ZoeStorageManager : prepareInvitationKit()
 ZoeStorageManager -> InstanceAdminStorage : makeInstanceAdminStorage()
 InstanceAdminStorage -> InstanceAdminStorage : instanceToInstanceAdmin
 ZoeStorageManager /- InstanceAdminStorage : <font color=gray><size:12>getters..., \n<font color=gray><size:12>initInstanceAdmin

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -1,6 +1,6 @@
 import { Fail, q } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
-import { vivifyFarClass, provideDurableSetStore } from '@agoric/vat-data';
+import { prepareFarClass, provideDurableSetStore } from '@agoric/vat-data';
 import { M, initEmpty } from '@agoric/store';
 
 import {
@@ -24,7 +24,7 @@ const WakerI = M.interface('Waker', {
 export const makeMakeExiter = baggage => {
   const activeWakers = provideDurableSetStore(baggage, 'activeWakers');
 
-  const makeExitable = vivifyFarClass(
+  const makeExitable = prepareFarClass(
     baggage,
     'ExitObject',
     ExitObjectI,
@@ -36,7 +36,7 @@ export const makeMakeExiter = baggage => {
       },
     },
   );
-  const makeWaived = vivifyFarClass(
+  const makeWaived = prepareFarClass(
     baggage,
     'ExitWaived',
     ExitObjectI,
@@ -50,7 +50,7 @@ export const makeMakeExiter = baggage => {
       },
     },
   );
-  const makeWaker = vivifyFarClass(
+  const makeWaker = prepareFarClass(
     baggage,
     'Waker',
     WakerI,

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -3,7 +3,7 @@ import { AmountMath } from '@agoric/ertp';
 import {
   provideDurableSetStore,
   makeScalarBigMapStore,
-  vivifySingleton,
+  prepareSingleton,
 } from '@agoric/vat-data';
 
 import { coerceAmountKeywordRecord } from '../cleanProposal.js';
@@ -52,7 +52,7 @@ export const makeZCFMintFactory = async (
     const add = (total, amountToAdd) =>
       AmountMath.add(total, amountToAdd, mintyBrand);
 
-    return vivifySingleton(
+    return prepareSingleton(
       zcfMintBaggage,
       'zcfMint',
       /** @type {ZCFMint} */
@@ -140,7 +140,7 @@ export const makeZCFMintFactory = async (
    * baggage for the state of the zcfMint, makes a durableZcfMint from that
    * baggage, and registers that baggage to be revived with the factory.
    */
-  const zcfMintFactory = vivifySingleton(zcfBaggage, 'zcfMintFactory', {
+  const zcfMintFactory = prepareSingleton(zcfBaggage, 'zcfMintFactory', {
     makeZCFMintInternal: async (keyword, zoeMint) => {
       const zcfMintBaggage = makeScalarBigMapStore('zcfMintBaggage', {
         durable: true,

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -3,8 +3,8 @@ import {
   makeScalarBigWeakMapStore,
   provideDurableMapStore,
   provideDurableWeakMapStore,
-  vivifyFarClassKit,
-  vivifyKind,
+  prepareFarClassKit,
+  prepareKind,
   provide,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
@@ -135,7 +135,7 @@ export const createSeatManager = (
     }
   };
 
-  const makeZCFSeatInternal = vivifyKind(
+  const makeZCFSeatInternal = prepareKind(
     zcfBaggage,
     'zcfSeat',
     proposal => ({ proposal }),
@@ -263,7 +263,7 @@ export const createSeatManager = (
     }),
   });
 
-  const makeSeatManagerKit = vivifyFarClassKit(
+  const makeSeatManagerKit = prepareFarClassKit(
     zcfBaggage,
     'ZcfSeatManager',
     ZcfSeatManagerIKit,

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -1,5 +1,5 @@
 import { fit, M } from '@agoric/store';
-import { vivifyKind, vivifySingleton } from '@agoric/vat-data';
+import { prepareKind, prepareSingleton } from '@agoric/vat-data';
 import { swapExact } from '../contractSupport/index.js';
 import { isAfterDeadlineExitRule } from '../typeGuards.js';
 
@@ -32,7 +32,7 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
   // XXX the exerciseOption offer handler that this makes is an object rather
   // than a function for now only because we do not yet support durable
   // functions.
-  const makeExerciser = vivifyKind(
+  const makeExerciser = prepareKind(
     instanceBaggage,
     'makeExerciserKindHandle',
     sellSeat => ({ sellSeat }),
@@ -78,7 +78,7 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
     return zcf.makeInvitation(exerciseOption, 'exerciseOption', customProps);
   };
 
-  const creatorFacet = vivifySingleton(instanceBaggage, 'creatorFacet', {
+  const creatorFacet = prepareSingleton(instanceBaggage, 'creatorFacet', {
     makeInvitation: () => zcf.makeInvitation(makeOption, 'makeCallOption'),
   });
   return harden({ creatorFacet });

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -1,4 +1,4 @@
-import { provide, vivifyFarClass, M } from '@agoric/vat-data';
+import { provide, prepareFarClass, M } from '@agoric/vat-data';
 import { assertKeywordName } from './cleanProposal.js';
 import {
   BrandKeywordRecordShape,
@@ -47,7 +47,7 @@ export const makeInstanceRecordStorage = baggage => {
     assertUniqueKeyword: M.call(KeywordShape).returns(),
   });
 
-  const makeInstanceRecord = vivifyFarClass(
+  const makeInstanceRecord = prepareFarClass(
     baggage,
     'InstanceRecord',
     InstanceRecordI,

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,6 +1,6 @@
 import { assert } from '@agoric/assert';
 import { initEmpty, makeHeapFarInstance } from '@agoric/store';
-import { vivifyFarClass } from '@agoric/vat-data';
+import { prepareFarClass } from '@agoric/vat-data';
 
 import { HandleI } from './typeGuards.js';
 
@@ -16,7 +16,7 @@ const { Fail } = assert;
  */
 export const defineDurableHandle = (baggage, handleType) => {
   typeof handleType === 'string' || Fail`handleType must be a string`;
-  const makeHandle = vivifyFarClass(
+  const makeHandle = prepareFarClass(
     baggage,
     `${handleType}Handle`,
     HandleI,

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -1,7 +1,11 @@
-import { makeDurableIssuerKit, AssetKind, vivifyIssuerKit } from '@agoric/ertp';
+import {
+  makeDurableIssuerKit,
+  AssetKind,
+  prepareIssuerKit,
+} from '@agoric/ertp';
 import { initEmpty } from '@agoric/store';
 import {
-  vivifyKindMulti,
+  prepareKindMulti,
   provideDurableMapStore,
   provide,
 } from '@agoric/vat-data';
@@ -21,7 +25,7 @@ export const defaultFeeIssuerConfig = harden(
  * @param {FeeIssuerConfig} feeIssuerConfig
  * @param {ShutdownWithFailure} shutdownZoeVat
  */
-const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
+const prepareFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   const mintBaggage = provideDurableMapStore(zoeBaggage, 'mintBaggage');
   if (!mintBaggage.has(FEE_MINT_KIT)) {
     /** @type {IssuerKit} */
@@ -34,7 +38,7 @@ const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
     );
     mintBaggage.init(FEE_MINT_KIT, feeIssuerKit);
   } else {
-    vivifyIssuerKit(mintBaggage, shutdownZoeVat);
+    prepareIssuerKit(mintBaggage, shutdownZoeVat);
   }
 
   const getFeeIssuerKit = ({ facets }, allegedFeeMintAccess) => {
@@ -45,7 +49,7 @@ const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
     return mintBaggage.get(FEE_MINT_KIT);
   };
 
-  const makeFeeMintKit = vivifyKindMulti(mintBaggage, 'FeeMint', initEmpty, {
+  const makeFeeMintKit = prepareKindMulti(mintBaggage, 'FeeMint', initEmpty, {
     feeMint: {
       getFeeIssuerKit,
       getFeeIssuer: () => mintBaggage.get(FEE_MINT_KIT).issuer,
@@ -59,4 +63,4 @@ const vivifyFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
   return provide(zoeBaggage, 'theFeeMint', () => makeFeeMintKit());
 };
 
-export { vivifyFeeMint };
+export { prepareFeeMint };

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -3,8 +3,8 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  vivifyFarInstance,
-  vivifyKind,
+  prepareFarInstance,
+  prepareKind,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
 import {
@@ -38,14 +38,14 @@ export const makeInstallationStorage = (
     'installationsBundle',
   );
 
-  const makeBundleIDInstallation = vivifyKind(
+  const makeBundleIDInstallation = prepareKind(
     zoeBaggage,
     'BundleIDInstallation',
     initEmpty,
     { getBundle: _context => assert.fail('bundleID-based Installation') },
   );
 
-  const makeBundleInstallation = vivifyKind(
+  const makeBundleInstallation = prepareKind(
     zoeBaggage,
     'BundleInstallation',
     bundle => ({ bundle }),
@@ -102,7 +102,7 @@ export const makeInstallationStorage = (
     ),
   });
 
-  const installationStorage = vivifyFarInstance(
+  const installationStorage = prepareFarInstance(
     zoeBaggage,
     'InstallationStorage',
     InstallationStorageI,

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -4,8 +4,8 @@ import {
   makeScalarBigSetStore,
   provide,
   provideDurableWeakMapStore,
-  vivifyFarClassKit,
-  vivifyKindMulti,
+  prepareFarClassKit,
+  prepareKindMulti,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
 import { defineDurableHandle } from '../makeHandle.js';
@@ -50,7 +50,7 @@ const InstanceAdminStorageIKit = harden({
 
 /** @param {import('@agoric/vat-data').Baggage} baggage */
 export const makeInstanceAdminStorage = baggage => {
-  const makeIAS = vivifyFarClassKit(
+  const makeIAS = prepareFarClassKit(
     baggage,
     'InstanceAdmin',
     InstanceAdminStorageIKit,
@@ -265,7 +265,7 @@ export const makeInstanceAdminMaker = (
   seatHandleToZoeSeatAdmin,
 ) => {
   const makeZoeSeatAdminKit = makeZoeSeatAdminFactory(zoeBaggage);
-  const makeInstanceAdminMulti = vivifyKindMulti(
+  const makeInstanceAdminMulti = prepareKindMulti(
     zoeBaggage,
     'instanceAdmin',
     (instanceHandle, zoeInstanceStorageManager, adminNode) => {

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -1,5 +1,9 @@
 import { provideDurableMapStore } from '@agoric/vat-data';
-import { AssetKind, makeDurableIssuerKit, vivifyIssuerKit } from '@agoric/ertp';
+import {
+  AssetKind,
+  makeDurableIssuerKit,
+  prepareIssuerKit,
+} from '@agoric/ertp';
 import { InvitationElementShape } from '../typeGuards.js';
 
 const ZOE_INVITATION_KIT = 'ZoeInvitationKit';
@@ -8,7 +12,7 @@ const ZOE_INVITATION_KIT = 'ZoeInvitationKit';
  * @param {import('@agoric/vat-data').Baggage} baggage
  * @param {ShutdownWithFailure | undefined} shutdownZoeVat
  */
-export const vivifyInvitationKit = (baggage, shutdownZoeVat = undefined) => {
+export const prepareInvitationKit = (baggage, shutdownZoeVat = undefined) => {
   let invitationKit;
 
   const invitationKitBaggage = provideDurableMapStore(
@@ -26,7 +30,7 @@ export const vivifyInvitationKit = (baggage, shutdownZoeVat = undefined) => {
     );
     invitationKitBaggage.init(ZOE_INVITATION_KIT, invitationKit);
   } else {
-    invitationKit = vivifyIssuerKit(invitationKitBaggage);
+    invitationKit = prepareIssuerKit(invitationKitBaggage);
   }
 
   return harden({

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -4,7 +4,7 @@ import {
   M,
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  vivifyFarClass,
+  prepareFarClass,
 } from '@agoric/vat-data';
 import { initEmpty } from '@agoric/store';
 
@@ -43,7 +43,7 @@ export const makeStartInstance = (
     seatHandleToZoeSeatAdmin,
   );
 
-  const makeZoeInstanceAdmin = vivifyFarClass(
+  const makeZoeInstanceAdmin = prepareFarClass(
     zoeBaggage,
     'zoeInstanceAdmin',
     InstanceAdminI,
@@ -142,18 +142,18 @@ export const makeStartInstance = (
     },
   );
 
-  const vivifyEmptyFacet = facetName =>
-    vivifyFarClass(
+  const prepareEmptyFacet = facetName =>
+    prepareFarClass(
       zoeBaggage,
       facetName,
       M.interface(facetName, {}),
       initEmpty,
       {},
     );
-  const makeEmptyCreatorFacet = vivifyEmptyFacet('emptyCreatorFacet');
-  const makeEmptyPublicFacet = vivifyEmptyFacet('emptyPublicFacet');
+  const makeEmptyCreatorFacet = prepareEmptyFacet('emptyCreatorFacet');
+  const makeEmptyPublicFacet = prepareEmptyFacet('emptyPublicFacet');
 
-  const makeAdminFacet = vivifyFarClass(
+  const makeAdminFacet = prepareFarClass(
     zoeBaggage,
     'adminFacet',
     AdminFacetI,

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -16,14 +16,14 @@ import '../internal-types.js';
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeScalarBigMapStore, vivifyFarInstance } from '@agoric/vat-data';
+import { makeScalarBigMapStore, prepareFarInstance } from '@agoric/vat-data';
 
 import { makeZoeStorageManager } from './zoeStorageManager.js';
 import { makeStartInstance } from './startInstance.js';
 import { makeOfferMethod } from './offer/offer.js';
 import { makeInvitationQueryFns } from './invitationQueries.js';
 import { getZcfBundleCap } from './createZCFVat.js';
-import { defaultFeeIssuerConfig, vivifyFeeMint } from './feeMint.js';
+import { defaultFeeIssuerConfig, prepareFeeMint } from './feeMint.js';
 import { ZoeServiceI } from '../typeGuards.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
@@ -77,7 +77,11 @@ const makeZoeKit = (
     vatAdminSvcP = zoeBaggage.get('vatAdminSvc');
   }
 
-  const feeMintKit = vivifyFeeMint(zoeBaggage, feeIssuerConfig, shutdownZoeVat);
+  const feeMintKit = prepareFeeMint(
+    zoeBaggage,
+    feeIssuerConfig,
+    shutdownZoeVat,
+  );
 
   // guarantee that vatAdminSvcP has been defined.
   const getActualVatAdminSvcP = () => {
@@ -156,7 +160,7 @@ const makeZoeKit = (
   };
 
   /** @type {ZoeService} */
-  const zoeService = vivifyFarInstance(zoeBaggage, 'ZoeService', ZoeServiceI, {
+  const zoeService = prepareFarInstance(zoeBaggage, 'ZoeService', ZoeServiceI, {
     install(bundleId) {
       return dataAccess.installBundle(bundleId);
     },

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -1,6 +1,6 @@
-import { vivifyDurablePublishKit, SubscriberShape } from '@agoric/notifier';
+import { prepareDurablePublishKit, SubscriberShape } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
-import { M, vivifyFarClassKit } from '@agoric/vat-data';
+import { M, prepareFarClassKit } from '@agoric/vat-data';
 import { deeplyFulfilled } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
 
@@ -59,7 +59,7 @@ const assertHasNotExited = (c, msg) => {
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const makeZoeSeatAdminFactory = baggage => {
-  const makeDurablePublishKit = vivifyDurablePublishKit(
+  const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,
     'zoe Seat publisher',
   );
@@ -88,7 +88,7 @@ export const makeZoeSeatAdminFactory = baggage => {
   // table entry.
   const ephemeralOfferResultStore = new Map();
 
-  return vivifyFarClassKit(
+  return prepareFarClassKit(
     baggage,
     'ZoeSeatKit',
     ZoeSeatIKit,

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -2,8 +2,8 @@ import { AssetKind, makeDurableIssuerKit, AmountMath } from '@agoric/ertp';
 import {
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
-  vivifyFarClassKit,
-  vivifyFarClass,
+  prepareFarClassKit,
+  prepareFarClass,
   provideDurableSetStore,
 } from '@agoric/vat-data';
 
@@ -11,7 +11,7 @@ import { provideIssuerStorage } from '../issuerStorage.js';
 import { makeInstanceRecordStorage } from '../instanceRecordStorage.js';
 import { makeIssuerRecord } from '../issuerRecord.js';
 import { provideEscrowStorage } from './escrowStorage.js';
-import { vivifyInvitationKit } from './makeInvitation.js';
+import { prepareInvitationKit } from './makeInvitation.js';
 import { makeInstanceAdminStorage } from './instanceAdminStorage.js';
 import { makeInstallationStorage } from './installationStorage.js';
 
@@ -84,7 +84,7 @@ export const makeZoeStorageManager = (
   // In order to participate in a contract, users must have invitations, which
   // are ERTP payments made by Zoe. This invitationKit must be closely held and
   // used only by the makeInvitation() method.
-  const { invitationIssuer, invitationKit } = vivifyInvitationKit(
+  const { invitationIssuer, invitationKit } = prepareInvitationKit(
     zoeBaggage,
     shutdownZoeVat,
   );
@@ -117,7 +117,7 @@ export const makeZoeStorageManager = (
     zoeMintBaggageSet(issuerBaggage);
   }
 
-  const makeZoeMint = vivifyFarClass(
+  const makeZoeMint = prepareFarClass(
     zoeBaggage,
     'ZoeMint',
     ZoeMintI,
@@ -154,7 +154,7 @@ export const makeZoeStorageManager = (
     },
   );
 
-  const makeInstanceStorageManager = vivifyFarClassKit(
+  const makeInstanceStorageManager = prepareFarClassKit(
     zoeBaggage,
     'InstanceStorageManager',
     InstanceStorageManagerIKit,
@@ -390,7 +390,7 @@ export const makeZoeStorageManager = (
 
   const getInvitationIssuer = () => invitationIssuer;
 
-  const makeStorageManager = vivifyFarClassKit(
+  const makeStorageManager = prepareFarClassKit(
     zoeBaggage,
     'ZoeStorageManager',
     ZoeStorageManagerIKit,

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -1,5 +1,5 @@
 import { M, fit } from '@agoric/store';
-import { vivifyFarClass, vivifyFarInstance } from '@agoric/vat-data';
+import { prepareFarClass, prepareFarInstance } from '@agoric/vat-data';
 import { swapExact } from '../../../src/contractSupport/index.js';
 import {
   InvitationShape,
@@ -22,7 +22,7 @@ const sellSeatExpiredMsg = 'The covered call option is expired.';
  * @param {unknown} _privateArgs
  * @param {import('@agoric/vat-data').Baggage} instanceBaggage
  */
-const vivify = async (zcf, _privateArgs, instanceBaggage) => {
+const prepare = async (zcf, _privateArgs, instanceBaggage) => {
   const firstTime = !instanceBaggage.has('DidStart');
   if (firstTime) {
     instanceBaggage.init('DidStart', true);
@@ -32,7 +32,7 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
   // TODO the exerciseOption offer handler that this makes is an object rather
   // than a function for now only because we do not yet support durable
   // functions.
-  const makeExerciser = vivifyFarClass(
+  const makeExerciser = prepareFarClass(
     instanceBaggage,
     'makeExerciserKindHandle',
     OfferHandlerI,
@@ -81,7 +81,7 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
     makeInvitation: M.call().returns(M.eref(InvitationShape)),
   });
 
-  const creatorFacet = vivifyFarInstance(
+  const creatorFacet = prepareFarInstance(
     instanceBaggage,
     'creatorFacet',
     CCallCreatorI,
@@ -94,5 +94,5 @@ const vivify = async (zcf, _privateArgs, instanceBaggage) => {
   return harden({ creatorFacet });
 };
 
-harden(vivify);
-export { vivify };
+harden(prepare);
+export { prepare };

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/vat-ertp-service.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/vat-ertp-service.js
@@ -1,10 +1,10 @@
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
-import { vivifyErtpService } from '@agoric/ertp/test/swingsetTests/ertpService/vat-ertp-service.js';
+import { prepareErtpService } from '@agoric/ertp/test/swingsetTests/ertpService/vat-ertp-service.js';
 
 export const buildRootObject = async (vatPowers, _vatParams, baggage) => {
   const exportableAmountMath = Far('AmountMath', { ...AmountMath });
-  const ertpService = vivifyErtpService(baggage, vatPowers.exitVatWithFailure);
+  const ertpService = prepareErtpService(baggage, vatPowers.exitVatWithFailure);
   return Far('root', {
     getErtpService: () => ertpService,
     getAmountMath: () => exportableAmountMath,


### PR DESCRIPTION
At https://github.com/Agoric/agoric-sdk/pull/6818#pullrequestreview-1264541712 @turadg writes:

> +1 to the change of `vivify` to `prepare`. I concur with the rationale.
> [...]
> I request that the `prepare` change be pushed in a separate PR and proceed, and that the "Far" terminology get more discussion. Perhaps in a call. A product of that meeting could be the documentation I also am requesting :)

This is that separate PR.