### PR TITLE
refactor(store): stop using legacy names

### DIFF
--- a/packages/SwingSet/docs/garbage-collection.md
+++ b/packages/SwingSet/docs/garbage-collection.md
@@ -189,7 +189,7 @@ The kernel is responsible for managing these per-vat states, and reacting to sys
 
 ## Virtualized Data
 
-To move large data out of RAM and onto disk, SwingSet gives vats a handful of "virtualized data" tools. The most basic is a "virtual object", which is a SwingSet object whose state (properties) are kept on disk when not in active use. The second is a "virtual collection" (e.g. what `makeWeakStore()` returns), which is like a WeakMap except that any values keyed by a virtual object are also stored as serialized data on disk.
+To move large data out of RAM and onto disk, SwingSet gives vats a handful of "virtualized data" tools. The most basic is a "virtual object", which is a SwingSet object whose state (properties) are kept on disk when not in active use. The second is a "virtual collection" (e.g. what `makeScalarWeakMapStore()` returns), which is like a WeakMap except that any values keyed by a virtual object are also stored as serialized data on disk.
 
 Instead of Remotables, virtual objects use "Representatives" as the handle with which the object is sent, received, and manipulated. The Representative is a JS `Object`, however it goes away when userspace drops the last strong reference. But a new one might be created the next time the object is received (or retrieved from offline data), As a result, a virtual object might be defined and populated, and even reachable/recognizable by other vats (or serialized local data), even though there is no local Representative object at that moment.
 
@@ -238,7 +238,7 @@ When the kernel makes a delivery into the vat which introduces a vref for the fi
 
 ![Imported Presence](./images/gc/imported-presence.png "Imported Presence")
 
-The SwingSet object is kept "reachable" by two sources: a live Presence, and the vref being reachable from any of the vat's virtualized data (i.e. in a property of a virtual object, or as the value of a `makeWeakStore` instance). Liveslots uses the `droppedRegistry` to keep track of the former, and the virtual object manager can be queried about the state of the latter. When both sources have gone away, liveslots uses `syscall.dropImports` to inform the kernel that this vat can no longer reach the vref. If the vref is not also recognizable at that time (i.e. it is not in used as a *key* of a `WeakMap`, `WeakStore` or a `makeWeakStore` instance), liveslots also calls `syscall.retireImports` to inform the kernel that the vat can't recognize the vref either.
+The SwingSet object is kept "reachable" by two sources: a live Presence, and the vref being reachable from any of the vat's virtualized data (i.e. in a property of a virtual object, or as the value of a `makeScalarWeakMapStore` instance). Liveslots uses the `droppedRegistry` to keep track of the former, and the virtual object manager can be queried about the state of the latter. When both sources have gone away, liveslots uses `syscall.dropImports` to inform the kernel that this vat can no longer reach the vref. If the vref is not also recognizable at that time (i.e. it is not in used as a *key* of a `WeakMap`, `WeakStore` or a `makeScalarWeakMapStore` instance), liveslots also calls `syscall.retireImports` to inform the kernel that the vat can't recognize the vref either.
 
 ## Virtual Objects, Virtualized Data
 

--- a/packages/SwingSet/src/liveslots/virtualReferences.js
+++ b/packages/SwingSet/src/liveslots/virtualReferences.js
@@ -315,7 +315,7 @@ export function makeVirtualReferenceManager(
 
   /**
    * Map of all Remotables which are reachable by our virtualized data, e.g.
-   * `makeWeakStore().set(key, remotable)` or `virtualObject.state.foo =
+   * `makeScalarWeakMapStore().set(key, remotable)` or `virtualObject.state.foo =
    * remotable`. The serialization process stores the Remotable's vref to disk,
    * but doesn't actually retain the Remotable. To correctly unserialize that
    * offline data later, we must ensure the Remotable remains alive. This Map
@@ -470,7 +470,7 @@ export function makeVirtualReferenceManager(
    * A recognizer is one of:
    *   Map - the map contained within a VirtualObjectAwareWeakMap to point to its vref-keyed entries.
    *   Set - the set contained within a VirtualObjectAwareWeakSet to point to its vref-keyed entries.
-   *   deleter - a function within a WeakStore that can be called to remove an entry from that store.
+   *   deleter - a function within a WeakMapStore that can be called to remove an entry from that store.
    *
    * It is critical that each collection have exactly one recognizer that is
    * unique to that collection, because the recognizers themselves will be

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -1,4 +1,4 @@
-import { makeScalarMap, makeLegacyMap } from '@agoric/store';
+import { makeScalarMapStore, makeLegacyMap } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
@@ -222,14 +222,14 @@ export function makeNetworkProtocol(protocolHandler) {
    * Currently must be a single listenHandler.
    * TODO: Do something sensible with multiple handlers?
    *
-   * @type {Store<Endpoint, [Port, ListenHandler]>}
+   * @type {MapStore<Endpoint, [Port, ListenHandler]>}
    */
-  const listening = makeScalarMap('localAddr');
+  const listening = makeScalarMapStore('localAddr');
 
   /**
-   * @type {Store<string, Port>}
+   * @type {MapStore<string, Port>}
    */
-  const boundPorts = makeScalarMap('localAddr');
+  const boundPorts = makeScalarMapStore('localAddr');
 
   /**
    * @param {Endpoint} localAddr
@@ -554,9 +554,9 @@ export function makeLoopbackProtocolHandler(
   onInstantiate = makeNonceMaker('nonce/'),
 ) {
   /**
-   * @type {Store<string, [Port, ListenHandler]>}
+   * @type {MapStore<string, [Port, ListenHandler]>}
    */
-  const listeners = makeScalarMap('localAddr');
+  const listeners = makeScalarMapStore('localAddr');
 
   const makePortID = makeNonceMaker('port');
 

--- a/packages/SwingSet/src/vats/network/router.js
+++ b/packages/SwingSet/src/vats/network/router.js
@@ -1,6 +1,6 @@
 import { E as defaultE } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { assert, details as X } from '@agoric/assert';
 import { makeNetworkProtocol, ENDPOINT_SEPARATOR } from './network.js';
 
@@ -21,9 +21,9 @@ import './types.js';
  */
 export default function makeRouter() {
   /**
-   * @type {Store<string, any>}
+   * @type {MapStore<string, any>}
    */
-  const prefixToRoute = makeStore('prefix');
+  const prefixToRoute = makeScalarMapStore('prefix');
   return Far('Router', {
     getRoutes(addr) {
       const parts = addr.split(ENDPOINT_SEPARATOR);
@@ -76,8 +76,8 @@ export default function makeRouter() {
  */
 export function makeRouterProtocol(E = defaultE) {
   const router = makeRouter();
-  const protocols = makeStore('prefix');
-  const protocolHandlers = makeStore('prefix');
+  const protocols = makeScalarMapStore('prefix');
+  const protocolHandlers = makeScalarMapStore('prefix');
 
   function registerProtocolHandler(paths, protocolHandler) {
     const protocol = makeNetworkProtocol(protocolHandler);

--- a/packages/SwingSet/src/vats/plugin-manager.js
+++ b/packages/SwingSet/src/vats/plugin-manager.js
@@ -1,4 +1,4 @@
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { makeCapTP } from '@endo/captp';
 import { makePromiseKit } from '@endo/promise-kit';
 import { E, HandledPromise } from '@endo/eventual-send';
@@ -68,9 +68,9 @@ export function makePluginManager(pluginDevice, { D, ...vatPowers }) {
    */
 
   /**
-   * @type {Store<number, AbortDispatch>}
+   * @type {MapStore<number, AbortDispatch>}
    */
-  const modConnection = makeStore('moduleIndex');
+  const modConnection = makeScalarMapStore('moduleIndex');
 
   // Dispatch object to the right index.
   D(pluginDevice).registerReceiver(

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -1,5 +1,5 @@
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeHeapExo, keyEQ, makeStore } from '@agoric/store';
+import { makeHeapExo, keyEQ, makeScalarMapStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 
 import {
@@ -64,8 +64,8 @@ const makeBinaryVoteCounter = (
    * @property {Position} chosen
    * @property {bigint} shares
    */
-  /** @type {Store<Handle<'Voter'>,RecordedBallot> } */
-  const allBallots = makeStore('voterHandle');
+  /** @type {MapStore<Handle<'Voter'>,RecordedBallot> } */
+  const allBallots = makeScalarMapStore('voterHandle');
 
   const countVotes = () => {
     !isOpen || Fail`can't count votes while the election is open`;

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -1,5 +1,5 @@
 import { makeStoredPublishKit } from '@agoric/notifier';
-import { makeStore, makeHeapExo, M } from '@agoric/store';
+import { makeScalarMapStore, makeHeapExo, M } from '@agoric/store';
 import { natSafeMath } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 
@@ -43,8 +43,8 @@ const { ceilDivide } = natSafeMath;
  * @returns {{creatorFacet: CommitteeElectorateCreatorFacet, publicFacet: CommitteeElectoratePublic}}
  */
 const start = (zcf, privateArgs) => {
-  /** @type {Store<Handle<'Question'>, import('./electorateTools.js').QuestionRecord>} */
-  const allQuestions = makeStore('Question');
+  /** @type {MapStore<Handle<'Question'>, import('./electorateTools.js').QuestionRecord>} */
+  const allQuestions = makeScalarMapStore('Question');
   assert(privateArgs?.storageNode, 'Missing storageNode');
   assert(privateArgs?.marshaller, 'Missing marshaller');
   const questionNode = E(privateArgs.storageNode).makeChildNode(

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -2,7 +2,7 @@ import { Far, passStyleOf } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
 import { Nat } from '@agoric/nat';
-import { keyEQ, makeStore } from '@agoric/store';
+import { keyEQ, makeScalarMapStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { assertAllDefined } from '@agoric/internal';
 import { ParamTypes } from '../constants.js';
@@ -53,8 +53,8 @@ const assertElectorateMatches = (paramManager, governedParams) => {
  * @param {ERef<ZoeService>} [zoe]
  */
 const makeParamManagerBuilder = (publisherKit, zoe) => {
-  /** @type {Store<Keyword, any>} */
-  const namesToParams = makeStore('Parameter Name');
+  /** @type {MapStore<Keyword, any>} */
+  const namesToParams = makeScalarMapStore('Parameter Name');
   const { publisher, subscriber } = publisherKit;
   assertAllDefined({ publisher, subscriber });
 

--- a/packages/governance/src/electorateTools.js
+++ b/packages/governance/src/electorateTools.js
@@ -14,7 +14,7 @@ import { deeplyFulfilled, Far } from '@endo/marshal';
  * @param {QuestionSpec} questionSpec
  * @param {unknown} quorumThreshold
  * @param {ERef<Installation>} voteCounter
- * @param {Store<Handle<'Question'>, QuestionRecord>} questionStore
+ * @param {MapStore<Handle<'Question'>, QuestionRecord>} questionStore
  * @param {Publisher<unknown>} questionPublisher
  * @param {Publisher<OutcomeRecord>} outcomePublisher
  * @returns {AddQuestionReturn}
@@ -57,7 +57,7 @@ const startCounter = async (
   return { creatorFacet, publicFacet, instance, deadline, questionHandle };
 };
 
-/** @param {Store<Handle<'Question'>, QuestionRecord>} questionStore */
+/** @param {MapStore<Handle<'Question'>, QuestionRecord>} questionStore */
 const getOpenQuestions = async questionStore => {
   const isOpenPQuestions = [...questionStore.entries()].map(
     ([key, { publicFacet }]) => {
@@ -73,7 +73,7 @@ const getOpenQuestions = async questionStore => {
 
 /**
  * @param {ERef<Handle<'Question'>>} questionHandleP
- * @param {Store<Handle<'Question'>, QuestionRecord>} questionStore
+ * @param {MapStore<Handle<'Question'>, QuestionRecord>} questionStore
  */
 const getQuestion = (questionHandleP, questionStore) =>
   E.when(questionHandleP, questionHandle =>

--- a/packages/governance/src/multiCandidateVoteCounter.js
+++ b/packages/governance/src/multiCandidateVoteCounter.js
@@ -1,4 +1,4 @@
-import { keyEQ, makeHeapExo, makeStore } from '@agoric/store';
+import { keyEQ, makeHeapExo, makeScalarMapStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import {
@@ -56,8 +56,8 @@ const makeMultiCandidateVoteCounter = (
    * @property {Position[]} chosen
    * @property {bigint} shares
    */
-  /** @type {Store<Handle<'Voter'>,RecordedBallot> } */
-  const allBallots = makeStore('voterHandle');
+  /** @type {MapStore<Handle<'Voter'>,RecordedBallot> } */
+  const allBallots = makeScalarMapStore('voterHandle');
 
   const countVotes = () => {
     !isOpen || Fail`can't count votes while the election is open`;

--- a/packages/inter-protocol/src/stakeFactory/attestation.js
+++ b/packages/inter-protocol/src/stakeFactory/attestation.js
@@ -2,7 +2,13 @@
 
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { E, Far } from '@endo/far';
-import { fit, M, makeCopyBag, makeStore, provideLazy } from '@agoric/store';
+import {
+  fit,
+  M,
+  makeCopyBag,
+  makeScalarMapStore,
+  provideLazy,
+} from '@agoric/store';
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 import { AttKW as KW } from './constants.js';
 import { makeAttestationTool } from './attestationTool.js';
@@ -85,9 +91,9 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
   /**
    * Non-authoritative store of nonzero lien amounts.
    *
-   * @type {Store<Address, Amount<'nat'>>}
+   * @type {MapStore<Address, Amount<'nat'>>}
    */
-  const amountByAddress = makeStore('amount');
+  const amountByAddress = makeScalarMapStore('amount');
 
   /**
    * Get non-authoritative liened amount from the JS store, without using the lienBridge.
@@ -226,8 +232,8 @@ const makeAttestationIssuerKit = async (zcf, stakeBrand, lienBridge) => {
  * The keyword for use in returnAttestation offers is `Attestation`.
  */
 export const makeAttestationFacets = async (zcf, stakeBrand, lienBridge) => {
-  /** @type {Store<Address, AttestationTool>} */
-  const attMakerByAddress = makeStore('address');
+  /** @type {MapStore<Address, AttestationTool>} */
+  const attMakerByAddress = makeScalarMapStore('address');
 
   const { issuer, brand, lienMint } = await makeAttestationIssuerKit(
     zcf,

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -4,7 +4,7 @@ import '@agoric/zoe/src/contracts/exported.js';
 import '@agoric/governance/exported.js';
 import { E } from '@endo/eventual-send';
 
-import { fit, keyEQ, M, makeScalarMap } from '@agoric/store';
+import { fit, keyEQ, M, makeScalarMapStore } from '@agoric/store';
 import {
   assertProposalShape,
   getAmountIn,
@@ -48,7 +48,7 @@ const { details: X, quote: q, Fail } = assert;
  * shortfallReporter: import('../reserve/assetReserve.js').ShortfallReporter,
  * storedMetricsSubscriber: StoredSubscriber<MetricsNotification>,
  * storageNode: ERef<StorageNode>,
- * vaultParamManagers: Store<Brand, import('./params.js').VaultParamManager>,
+ * vaultParamManagers: MapStore<Brand, import('./params.js').VaultParamManager>,
  * zcf: import('./vaultFactory.js').VaultFactoryZCF,
  * }} Ephemera
  */
@@ -71,7 +71,7 @@ const ephemera = {};
  * }} MetricsNotification
  *
  * @typedef {Readonly<{
- * collateralTypes: Store<Brand,VaultManager>,
+ * collateralTypes: MapStore<Brand,VaultManager>,
  * metricsPublisher: Publisher<MetricsNotification>
  * metricsSubscriber: Subscriber<MetricsNotification>
  * mintSeat: ZCFSeat,
@@ -182,7 +182,7 @@ const initState = (
 
   // Non-durable map because param managers aren't durable.
   // In the event they're needed they can be reconstructed from contract terms and off-chain data.
-  const vaultParamManagers = makeScalarMap('vaultParamManagers');
+  const vaultParamManagers = makeScalarMapStore('vaultParamManagers');
 
   const { publisher: metricsPublisher, subscriber: metricsSubscriber } =
     makeVaultDirectorMetricsPublishKit();

--- a/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -185,7 +185,7 @@ const start = async (zcf, privateArgs, baggage) => {
     )}`,
   );
 
-  /** @type {Store<Brand,PoolFacets>} */
+  /** @type {MapStore<Brand,PoolFacets>} */
   const secondaryBrandToPool = provideDurableMapStore(
     baggage,
     'secondaryBrandToPool',

--- a/packages/inter-protocol/test/amm/constantProduct/test-estimator.js
+++ b/packages/inter-protocol/test/amm/constantProduct/test-estimator.js
@@ -4,7 +4,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { Far } from '@endo/marshal';
-import { makeScalarMap } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 
 import { charge, makeEstimator } from '../../../src/vpool-xyk-amm/estimate.js';
 import { withAmountUtils } from '../../supports.js';
@@ -28,8 +28,8 @@ const DEFAULT_3_POOLS = [
 
 const makePools = (issuerKits, poolValues) => {
   const centralBrand = issuerKits[0].brand;
-  const internalPools = makeScalarMap('poolBrand');
-  const uiPools = makeScalarMap('poolBrand');
+  const internalPools = makeScalarMapStore('poolBrand');
+  const uiPools = makeScalarMapStore('poolBrand');
   for (let i = 1; i < issuerKits.length; i += 1) {
     const brand = issuerKits[i].brand;
     const internalPool = Far(`pool ${brand.getAllegedName()}`, {

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -20,7 +20,7 @@ Store adds some additional functionality on top of Map.
    Map, because the Map methods are not tied to a particular
    Map instance.
 
-See `makeWeakStore` for the wrapper around JavaScript's WeakMap abstraction.
+See `makeScalarWeakMapStore` for the wrapper around JavaScript's WeakMap abstraction.
 
 # External Store
 

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -130,7 +130,7 @@
  *
  * WeakStores have the lookup and update methods but not the query
  * or query-update methods.
- * Non-weak Stores are like their corresponding WeakStore, but with the
+ * Non-weak Stores are like their corresponding WeakStores, but with the
  * additional query and query-update methods.
  */
 

--- a/packages/store/test/test-store.js
+++ b/packages/store/test/test-store.js
@@ -88,12 +88,12 @@ function check(t, mode, objMaker) {
 }
 
 test('store', t => {
-  // makeScalarMap
+  // makeScalarMapStore
   check(t, 'strong', count => count); // simple numeric keys
   check(t, 'strong', count => `${count}`); // simple strings
   check(t, 'strong', () => Far('handle', {}));
 
-  // makeScalarWeakMap
+  // makeScalarWeakMapStore
   check(t, 'weak', () => Far('handle', {}));
 });
 

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import '@agoric/store/exported.js';
 import { Fail } from '@agoric/assert';
 import { Far } from '@endo/far';
@@ -27,9 +27,9 @@ import { makeWithQueue } from './queue.js';
  */
 export function makeBridgeManager(E, D, bridgeDevice) {
   /**
-   * @type {Store<string, import('./types.js').ScopedBridgeManager>}
+   * @type {MapStore<string, import('./types.js').ScopedBridgeManager>}
    */
-  const scopedManagers = makeStore('bridgeId');
+  const scopedManagers = makeScalarMapStore('bridgeId');
 
   function bridgeInbound(srcID, obj) {
     // console.log(

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -4,7 +4,7 @@ import {
   dataToBase64,
   base64ToBytes,
 } from '@agoric/swingset-vat/src/vats/network/index.js';
-import { makeStore, makeLegacyMap } from '@agoric/store';
+import { makeScalarMapStore, makeLegacyMap } from '@agoric/store';
 import { makePromiseKit } from '@endo/promise-kit';
 import { assert, details as X, Fail } from '@agoric/assert';
 import { Far } from '@endo/far';
@@ -57,9 +57,9 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
     return rawCallIBCDevice(method, params);
   };
   /**
-   * @type {Store<string, Promise<Connection>>}
+   * @type {MapStore<string, Promise<Connection>>}
    */
-  const channelKeyToConnP = makeStore('CHANNEL:PORT');
+  const channelKeyToConnP = makeScalarMapStore('CHANNEL:PORT');
 
   /**
    * @typedef {object} Counterparty
@@ -88,14 +88,14 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
   const srcPortToOutbounds = makeLegacyMap('SRC-PORT');
 
   /**
-   * @type {Store<string, ConnectingInfo>}
+   * @type {MapStore<string, ConnectingInfo>}
    */
-  const channelKeyToInfo = makeStore('CHANNEL:PORT');
+  const channelKeyToInfo = makeScalarMapStore('CHANNEL:PORT');
 
   /**
-   * @type {Store<string, Promise<InboundAttempt>>}
+   * @type {MapStore<string, Promise<InboundAttempt>>}
    */
-  const channelKeyToAttemptP = makeStore('CHANNEL:PORT');
+  const channelKeyToAttemptP = makeScalarMapStore('CHANNEL:PORT');
 
   /**
    * @type {LegacyMap<string, LegacyMap<number, PromiseRecord<Bytes>>>}

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -3,7 +3,7 @@
 import { assert, details as X, q, Fail } from '@agoric/assert';
 import { E, Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { crc6 } from './crc.js';
 
 import './types.js';
@@ -41,8 +41,8 @@ function makeBoard(
 ) {
   const DIGITS_REGEXP = new RegExp(`^[0-9]{${crcDigits + 1},}$`);
   let lastSequence = BigInt(initSequence);
-  const idToVal = makeStore('boardId');
-  const valToId = makeStore('value');
+  const idToVal = makeScalarMapStore('boardId');
+  const valToId = makeScalarMapStore('value');
 
   const ifaceAllegedPrefix = 'Alleged: ';
   const ifaceInaccessiblePrefix = 'SEVERED: ';

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -3,7 +3,7 @@ import { assert, Fail } from '@agoric/assert';
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { E, Far } from '@endo/far';
 import { makeNotifierKit, makeSubscriptionKit } from '@agoric/notifier';
-import { makeStore, makeWeakStore } from '@agoric/store';
+import { makeScalarMapStore, makeScalarWeakMapStore } from '@agoric/store';
 import { whileTrue } from '@agoric/internal';
 import { makeVirtualPurse } from './virtual-purse.js';
 
@@ -123,11 +123,11 @@ export function buildRootObject() {
       nameAdmin = undefined,
     ) {
       const bankBridgeManager = await bankBridgeManagerP;
-      /** @type {WeakStore<Brand, AssetRecord>} */
-      const brandToAssetRecord = makeWeakStore('brand');
+      /** @type {WeakMapStore<Brand, AssetRecord>} */
+      const brandToAssetRecord = makeScalarWeakMapStore('brand');
 
-      /** @type {Store<string, Store<string, BalanceUpdater>>} */
-      const denomToAddressUpdater = makeStore('denom');
+      /** @type {MapStore<string, MapStore<string, BalanceUpdater>>} */
+      const denomToAddressUpdater = makeScalarMapStore('denom');
 
       const updateBalances = obj => {
         switch (obj && obj.type) {
@@ -182,8 +182,8 @@ export function buildRootObject() {
       const { subscription: assetSubscription, publication: assetPublication } =
         makeSubscriptionKit();
 
-      /** @type {Store<string, Bank>} */
-      const addressToBank = makeStore('address');
+      /** @type {MapStore<string, Bank>} */
+      const addressToBank = makeScalarMapStore('address');
 
       /**
        * Create a new personal bank interface for a given address.
@@ -197,8 +197,8 @@ export function buildRootObject() {
           return addressToBank.get(address);
         }
 
-        /** @type {WeakStore<Brand, VirtualPurse>} */
-        const brandToVPurse = makeWeakStore('brand');
+        /** @type {WeakMapStore<Brand, VirtualPurse>} */
+        const brandToVPurse = makeScalarWeakMapStore('brand');
 
         /** @type {Bank} */
         const bank = Far('bank', {
@@ -367,7 +367,7 @@ export function buildRootObject() {
             brand,
           });
           brandToAssetRecord.init(brand, assetRecord);
-          denomToAddressUpdater.init(denom, makeStore('address'));
+          denomToAddressUpdater.init(denom, makeScalarMapStore('address'));
           assetPublication.updateState(
             harden({
               brand,

--- a/packages/vats/src/vat-mints.js
+++ b/packages/vats/src/vat-mints.js
@@ -2,14 +2,14 @@
 import { Far } from '@endo/far';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 
 // This vat contains two starting mints for demos: moolaMint and
 // simoleanMint.
 
 export function buildRootObject() {
-  /** @type {Store<string, { mint: Mint, brand: Brand}>} */
-  const mintsAndBrands = makeStore('issuerName');
+  /** @type {MapStore<string, { mint: Mint, brand: Brand}>} */
+  const mintsAndBrands = makeScalarMapStore('issuerName');
 
   const api = Far('api', {
     getAllIssuerNames: () => [...mintsAndBrands.keys()],

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -13,7 +13,7 @@ import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { E, Far } from '@endo/far';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
-import { makeScalarMap } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { makeSubscriptionKit } from '@agoric/notifier';
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { publishDepositFacet } from '@agoric/smart-wallet/src/walletFactory.js';
@@ -130,9 +130,9 @@ const tools = context => {
   // @ts-expect-error missing mint
   const minted = withAmountUtils(context.minted);
   const makeBank = () => {
-    const issuers = makeScalarMap();
+    const issuers = makeScalarMapStore();
     [minted, anchor].forEach(kit => issuers.init(kit.brand, kit.issuer));
-    const purses = makeScalarMap();
+    const purses = makeScalarMapStore();
     [minted, anchor].forEach(kit => {
       assert(kit.issuer);
       purses.init(kit.brand, E(kit.issuer).makeEmptyPurse());

--- a/packages/wallet/api/src/internal-types.js
+++ b/packages/wallet/api/src/internal-types.js
@@ -54,11 +54,11 @@
  * @property {(petname: Petname) => string} implode
  * @property {(str: string) => Petname} explode
  * @property {LegacyWeakMap<T, Petname>} valToPetname
- * @property {WeakStore<T, string[][]>} valToPaths
+ * @property {WeakMapStore<T, string[][]>} valToPaths
  *   TODO What about when useLegacyMap is true because contact have
  *   identity? `T` would be `Contact`. Shouldn't `valToPaths` be
  *   a `LegacyWeakMap`?
- * @property {Store<Petname, T>} petnameToVal
+ * @property {MapStore<Petname, T>} petnameToVal
  * @property {(petname: Petname, val: T) => void} addPetname
  * @property {(path: string[], val: T) => void} addPath
  * @property {(petname: Petname, val: T) => void} renamePetname

--- a/packages/wallet/api/src/issuerTable.js
+++ b/packages/wallet/api/src/issuerTable.js
@@ -3,7 +3,7 @@
 import { assert } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
 
-import { makeWeakStore } from '@agoric/store';
+import { makeScalarWeakMapStore } from '@agoric/store';
 
 import '../exported.js';
 import './internal-types.js';
@@ -21,10 +21,10 @@ import './internal-types.js';
  * remote calls to get the brand and AmountMath and save them.
  */
 const makeIssuerTable = () => {
-  /** @type {WeakStore<Brand,IssuerRecord>} */
-  const brandToIssuerRecord = makeWeakStore('brand');
-  /** @type {WeakStore<Issuer,IssuerRecord>} */
-  const issuerToIssuerRecord = makeWeakStore('issuer');
+  /** @type {WeakMapStore<Brand,IssuerRecord>} */
+  const brandToIssuerRecord = makeScalarWeakMapStore('brand');
+  /** @type {WeakMapStore<Issuer,IssuerRecord>} */
+  const issuerToIssuerRecord = makeScalarWeakMapStore('issuer');
 
   /** @type {IssuerTable} */
   const issuerTable = {

--- a/packages/wallet/api/src/lib-dehydrate.js
+++ b/packages/wallet/api/src/lib-dehydrate.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { makeMarshal, mapIterable } from '@endo/marshal';
-import { makeLegacyMap, makeScalarMap } from '@agoric/store';
+import { makeLegacyMap, makeScalarMapStore } from '@agoric/store';
 import { assert, Fail, q } from '@agoric/assert';
 
 /**
@@ -40,8 +40,8 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
   // Paths are kept across all kinds.
   // TODO What about when useLegacyMap is true because contact have
   // identity?
-  /** @type {Store<any, Path[]>} */
-  const valToPaths = makeScalarMap('value');
+  /** @type {MapStore<any, Path[]>} */
+  const valToPaths = makeScalarMapStore('value');
 
   /**
    * @param {string} data
@@ -93,7 +93,7 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
    */
   const makeMapping = (kind, { useLegacyMap = false } = {}) => {
     typeof kind === 'string' || `kind ${kind} must be a string`;
-    const makeMap = useLegacyMap ? makeLegacyMap : makeScalarMap;
+    const makeMap = useLegacyMap ? makeLegacyMap : makeScalarMapStore;
     // These are actually either a LegacyMap or a MapStore depending on
     // useLegacyMap. Fortunately, the LegacyMap type is approximately the
     // intersection of these, so we can just use it.
@@ -121,9 +121,9 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
         return mapIterable(rawValToPetname.values(), val => explode(val));
       },
     };
-    /** @type {Store<string, T>} */
-    const rawPetnameToVal = makeScalarMap('petname');
-    /** @type {Store<Path | string, T>} */
+    /** @type {MapStore<string, T>} */
+    const rawPetnameToVal = makeScalarMapStore('petname');
+    /** @type {MapStore<Path | string, T>} */
     const petnameToVal = {
       ...rawPetnameToVal,
       init(key, val) {

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -14,7 +14,11 @@
 import { assert, q, Fail } from '@agoric/assert';
 import { makeScalarStoreCoordinator } from '@agoric/cache';
 import { objectMap } from '@agoric/internal';
-import { makeLegacyMap, makeScalarMap, makeScalarWeakMap } from '@agoric/store';
+import {
+  makeLegacyMap,
+  makeScalarMapStore,
+  makeScalarWeakMapStore,
+} from '@agoric/store';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
@@ -136,8 +140,8 @@ export function makeWalletRoot({
   const installationMapping = makeMapping('installation');
 
   const brandTable = makeIssuerTable();
-  /** @type {WeakStore<Issuer, string>} */
-  const issuerToBoardId = makeScalarWeakMap('issuer');
+  /** @type {WeakMapStore<Issuer, string>} */
+  const issuerToBoardId = makeScalarWeakMapStore('issuer');
 
   // Idempotently initialize the issuer's synchronous boardId mapping.
   const initIssuerToBoardId = async (issuer, brand) => {
@@ -166,21 +170,22 @@ export function makeWalletRoot({
     return issuerBoardId;
   };
 
-  /** @type {WeakStore<Purse, Brand>} */
-  const purseToBrand = makeScalarWeakMap('purse');
-  /** @type {Store<Brand, string>} */
-  const brandToDepositFacetId = makeScalarMap('brand');
-  /** @type {Store<Brand, Purse>} */
-  const brandToAutoDepositPurse = makeScalarMap('brand');
+  /** @type {WeakMapStore<Purse, Brand>} */
+  const purseToBrand = makeScalarWeakMapStore('purse');
+  /** @type {MapStore<Brand, string>} */
+  const brandToDepositFacetId = makeScalarMapStore('brand');
+  /** @type {MapStore<Brand, Purse>} */
+  const brandToAutoDepositPurse = makeScalarMapStore('brand');
 
   // Offers that the wallet knows about (the inbox).
-  const idToOffer = makeScalarMap('offerId');
+  const idToOffer = makeScalarMapStore('offerId');
   /** @type {LegacyMap<string, PromiseRecord<any>>} */
   // Legacy because promise kits are not passables
   const idToOfferResultPromiseKit = makeLegacyMap('id');
 
-  /** @type {WeakStore<Handle<'invitation'>, any>} */
-  const invitationHandleToOfferResult = makeScalarWeakMap('invitationHandle');
+  /** @type {WeakMapStore<Handle<'invitation'>, any>} */
+  const invitationHandleToOfferResult =
+    makeScalarWeakMapStore('invitationHandle');
 
   // Compiled offers (all ready to execute).
   const idToCompiledOfferP = new Map();
@@ -1072,8 +1077,8 @@ export function makeWalletRoot({
     return compiled;
   };
 
-  /** @type {Store<string, DappRecord>} */
-  const dappOrigins = makeScalarMap('dappOrigin');
+  /** @type {MapStore<string, DappRecord>} */
+  const dappOrigins = makeScalarMapStore('dappOrigin');
   const { notifier: dappsNotifier, updater: dappsUpdater } =
     /** @type {NotifierRecord<DappRecord[]>} */ (makeNotifierKit([]));
 
@@ -1367,8 +1372,8 @@ export function makeWalletRoot({
     return ret;
   }
 
-  /** @type {Store<number, PaymentRecord>} */
-  const idToPaymentRecord = makeScalarMap('paymentId');
+  /** @type {MapStore<number, PaymentRecord>} */
+  const idToPaymentRecord = makeScalarMapStore('paymentId');
   const { updater: paymentsUpdater, notifier: paymentsNotifier } =
     /** @type {NotifierRecord<PaymentRecord[]>} */ (makeNotifierKit([]));
   /**
@@ -1461,7 +1466,7 @@ export function makeWalletRoot({
     await updateAllPurseState();
   }
 
-  const pendingEnableAutoDeposits = makeScalarMap('brand');
+  const pendingEnableAutoDeposits = makeScalarMapStore('brand');
   async function doEnableAutoDeposit(pursePetname, updateState) {
     const purse = purseMapping.petnameToVal.get(pursePetname);
     const brand = purseToBrand.get(purse);

--- a/packages/wallet/api/src/marshal-contexts.js
+++ b/packages/wallet/api/src/marshal-contexts.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { makeScalarMap } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { Far, makeMarshal, Remotable } from '@endo/marshal';
 import { HandledPromise } from '@endo/eventual-send'; // TODO: convince tsc this isn't needed
 
@@ -119,25 +119,25 @@ export const makeExportContext = () => {
   const walletObjects = {
     /** @type {IdTable<number, Purse>} */
     purse: {
-      bySlot: makeScalarMap(),
-      byVal: makeScalarMap(),
+      bySlot: makeScalarMapStore(),
+      byVal: makeScalarMapStore(),
     },
     /** @type {IdTable<number, Payment>} */
     payment: {
-      bySlot: makeScalarMap(),
-      byVal: makeScalarMap(),
+      bySlot: makeScalarMapStore(),
+      byVal: makeScalarMapStore(),
     },
     // TODO: offer, contact, dapp
     /** @type {IdTable<number, unknown>} */
     unknown: {
-      bySlot: makeScalarMap(),
-      byVal: makeScalarMap(),
+      bySlot: makeScalarMapStore(),
+      byVal: makeScalarMapStore(),
     },
   };
   /** @type {IdTable<BoardId, unknown>} */
   const boardObjects = {
-    bySlot: makeScalarMap(),
-    byVal: makeScalarMap(),
+    bySlot: makeScalarMapStore(),
+    byVal: makeScalarMapStore(),
   };
 
   /**
@@ -245,24 +245,24 @@ export const makeImportContext = (makePresence = defaultMakePresence) => {
   const walletObjects = {
     /** @type {IdTable<number, unknown>} */
     purse: {
-      bySlot: makeScalarMap(),
-      byVal: makeScalarMap(),
+      bySlot: makeScalarMapStore(),
+      byVal: makeScalarMapStore(),
     },
     /** @type {IdTable<number, unknown>} */
     payment: {
-      bySlot: makeScalarMap(),
-      byVal: makeScalarMap(),
+      bySlot: makeScalarMapStore(),
+      byVal: makeScalarMapStore(),
     },
     /** @type {IdTable<number, unknown>} */
     unknown: {
-      bySlot: makeScalarMap(),
-      byVal: makeScalarMap(),
+      bySlot: makeScalarMapStore(),
+      byVal: makeScalarMapStore(),
     },
   };
   /** @type {IdTable<BoardId, unknown>} */
   const boardObjects = {
-    bySlot: makeScalarMap(),
-    byVal: makeScalarMap(),
+    bySlot: makeScalarMapStore(),
+    byVal: makeScalarMapStore(),
   };
 
   /**

--- a/packages/zoe/src/contractFacet/offerHandlerStorage.js
+++ b/packages/zoe/src/contractFacet/offerHandlerStorage.js
@@ -1,4 +1,4 @@
-import { makeWeakStore } from '@agoric/store';
+import { makeScalarWeakMapStore } from '@agoric/store';
 import { ToFarFunction } from '@endo/marshal';
 import { canBeDurable, provideDurableWeakMapStore } from '@agoric/vat-data';
 
@@ -6,17 +6,17 @@ import { defineDurableHandle } from '../makeHandle.js';
 
 export const makeOfferHandlerStorage = zcfBaggage => {
   const makeInvitationHandle = defineDurableHandle(zcfBaggage, 'Invitation');
-  /** @type {WeakStore<InvitationHandle, OfferHandler>} */
+  /** @type {WeakMapStore<InvitationHandle, OfferHandler>} */
 
   // ZCF needs to ephemerally hold on to ephemeral handlers, and durably hold
   // onto handlers that are intended to be durable. We keep two stores and store
   // each handler in the right one. When retrieving, we look for them in both.
   // If Zoe restarts, the ephemeral ones will be lost, and the durable ones will
   // survive.
-  const invitationHandleToEphemeralHandler = makeWeakStore(
+  const invitationHandleToEphemeralHandler = makeScalarWeakMapStore(
     'invitationHandleToEphemeralHandler',
   );
-  /** @type {WeakStore<InvitationHandle, OfferHandler>} */
+  /** @type {WeakMapStore<InvitationHandle, OfferHandler>} */
   const invitationHandleToDurableHandler = provideDurableWeakMapStore(
     zcfBaggage,
     'invitationHandleToDurableHandler',

--- a/packages/zoe/src/contractFacet/rightsConservation.js
+++ b/packages/zoe/src/contractFacet/rightsConservation.js
@@ -1,4 +1,4 @@
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { assert, Fail } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 
@@ -9,11 +9,11 @@ import '../internal-types.js';
  * map by brand.
  *
  * @param  {Amount[]} amounts - an array of amounts
- * @returns {Store<Brand, Amount>} sumsByBrand - a map of Brand keys and
+ * @returns {MapStore<Brand, Amount>} sumsByBrand - a map of Brand keys and
  * Amount values. The amounts are the sums.
  */
 const sumByBrand = amounts => {
-  const sumsByBrand = makeStore('brand');
+  const sumsByBrand = makeScalarMapStore('brand');
   amounts.forEach(amount => {
     const { brand } = amount;
     if (!sumsByBrand.has(brand)) {
@@ -29,8 +29,8 @@ const sumByBrand = amounts => {
 /**
  * Assert that the left sums by brand equal the right sums by brand
  *
- * @param  {Store<Brand, Amount>} leftSumsByBrand - a map of brands to sums
- * @param  {Store<Brand, Amount>} rightSumsByBrand - a map of brands to sums
+ * @param  {MapStore<Brand, Amount>} leftSumsByBrand - a map of brands to sums
+ * @param  {MapStore<Brand, Amount>} rightSumsByBrand - a map of brands to sums
  */
 const assertEqualPerBrand = (leftSumsByBrand, rightSumsByBrand) => {
   // We cannot assume that all of the brand keys present in

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -30,15 +30,15 @@ export const createSeatManager = (
   shutdownWithFailure,
   zcfBaggage = makeScalarBigMapStore('zcfBaggage', { durable: true }),
 ) => {
-  /** @type {WeakStore<ZCFSeat, Allocation>}  */
+  /** @type {WeakMapStore<ZCFSeat, Allocation>}  */
   let activeZCFSeats = provideDurableWeakMapStore(zcfBaggage, 'activeZCFSeats');
-  /** @type {Store<ZCFSeat, Allocation>} */
+  /** @type {MapStore<ZCFSeat, Allocation>} */
   const zcfSeatToStagedAllocations = provideDurableMapStore(
     zcfBaggage,
     'zcfSeatToStagedAllocations',
   );
 
-  /** @type {WeakStore<ZCFSeat, SeatHandle>} */
+  /** @type {WeakMapStore<ZCFSeat, SeatHandle>} */
   let zcfSeatToSeatHandle = provideDurableWeakMapStore(
     zcfBaggage,
     'zcfSeatToSeatHandle',

--- a/packages/zoe/src/issuerStorage.js
+++ b/packages/zoe/src/issuerStorage.js
@@ -13,12 +13,12 @@ const STORAGE_INSTANTIATED_KEY = 'IssuerStorageInstantiated';
  * @param {import('@agoric/vat-data').Baggage} zcfBaggage
  */
 export const provideIssuerStorage = zcfBaggage => {
-  /** @type {WeakStore<Brand,IssuerRecord>} */
+  /** @type {WeakMapStore<Brand,IssuerRecord>} */
   const brandToIssuerRecord = provideDurableWeakMapStore(
     zcfBaggage,
     'brandToIssuerRecord',
   );
-  /** @type {WeakStore<Issuer,IssuerRecord>} */
+  /** @type {WeakMapStore<Issuer,IssuerRecord>} */
   const issuerToIssuerRecord = provideDurableWeakMapStore(
     zcfBaggage,
     'issuerToIssuerRecord',
@@ -49,7 +49,7 @@ export const provideIssuerStorage = zcfBaggage => {
    *
    * The reason why we need the `has` check below is for the 4th case
    * above, in which we store an issuer record in ZCF that we obtained
-   * from Zoe. `WeakStore.init` errors if the key is already present,
+   * from Zoe. `WeakMapStore.init` errors if the key is already present,
    * and because an issuer can be used more than once in the same
    * contract, we need to make sure we aren't trying to `init` twice.
    * If the issuer and its record are already present, we do not need

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -17,7 +17,7 @@ import { arrayToObj } from '../objArrayConversion.js';
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const provideEscrowStorage = baggage => {
-  /** @type {WeakStore<Brand, ERef<Purse>>} */
+  /** @type {WeakMapStore<Brand, ERef<Purse>>} */
   const brandToPurse = provideDurableWeakMapStore(baggage, 'brandToPurse');
 
   /** @type {CreatePurse} */

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -27,12 +27,12 @@ export const makeInstallationStorage = (
   getBundleCapForID,
   zoeBaggage = makeScalarBigMapStore('zoe baggage', { durable: true }),
 ) => {
-  /** @type {WeakStore<Installation, { bundleCap: BundleCap, bundleID: BundleID }>} */
+  /** @type {WeakMapStore<Installation, { bundleCap: BundleCap, bundleID: BundleID }>} */
   const installationsBundleCap = provideDurableWeakMapStore(
     zoeBaggage,
     'installationsBundleCap',
   );
-  /** @type {WeakStore<Installation, SourceBundle>} */
+  /** @type {WeakMapStore<Installation, SourceBundle>} */
   const installationsBundle = provideDurableWeakMapStore(
     zoeBaggage,
     'installationsBundle',

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -258,7 +258,7 @@ const helperBehavior = {
 
 /**
  * @param {import('@agoric/vat-data').Baggage} zoeBaggage
- * @param {WeakStore<SeatHandle, ZoeSeatAdmin>} seatHandleToZoeSeatAdmin
+ * @param {WeakMapStore<SeatHandle, ZoeSeatAdmin>} seatHandleToZoeSeatAdmin
  */
 export const makeInstanceAdminMaker = (
   zoeBaggage,

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -32,7 +32,7 @@ export const makeStartInstance = (
 ) => {
   const makeInstanceHandle = defineDurableHandle(zoeBaggage, 'Instance');
 
-  /** @type {WeakStore<SeatHandle, ZoeSeatAdmin>} */
+  /** @type {WeakMapStore<SeatHandle, ZoeSeatAdmin>} */
   const seatHandleToZoeSeatAdmin = provideDurableWeakMapStore(
     zoeBaggage,
     'seatHandleToZoeSeatAdmin',

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -2,7 +2,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { Far } from '@endo/marshal';
 
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { setup } from '../setupBasicMints.js';
 
 import {
@@ -18,8 +18,8 @@ test('ZoeHelpers messages', t => {
 });
 
 function makeMockTradingZcfBuilder() {
-  const offers = makeStore('offerHandle');
-  const allocs = makeStore('offerHandle');
+  const offers = makeScalarMapStore('offerHandle');
+  const allocs = makeScalarMapStore('offerHandle');
   const reallocatedStagings = [];
 
   return Far('mockTradingZcfBuilder', {

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 
 import { Far } from '@endo/marshal';
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { AmountMath } from '@agoric/ertp';
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
@@ -34,7 +34,7 @@ const start = zcf => {
   assert.typeof(question, 'string');
   assertNatAssetKind(zcf, assetsBrand);
 
-  const seatToResponse = makeStore('seat');
+  const seatToResponse = makeScalarMapStore('seat');
 
   // We assume the only valid responses are 'YES' and 'NO'
   const assertResponse = response => {

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -1,5 +1,5 @@
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
 import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
 
@@ -12,8 +12,8 @@ export const setup = () => {
     simoleans: simoleanKit,
     bucks: bucksKit,
   };
-  /** @type {Store<string, Brand<'nat'>>} */
-  const brands = makeStore('brandName');
+  /** @type {MapStore<string, Brand<'nat'>>} */
+  const brands = makeScalarMapStore('brandName');
 
   for (const k of Object.getOwnPropertyNames(allIssuerKits)) {
     brands.init(k, allIssuerKits[k].brand);

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -1,7 +1,7 @@
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { Far } from '@endo/marshal';
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 import { evalContractBundle } from '../src/contractFacet/evalContractCode.js';
@@ -29,10 +29,10 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   let exitMessage;
   let hasExited = false;
   let exitWithFailure;
-  /** @type {Store<BundleID, BundleCap>} */
-  const idToBundleCap = makeStore('idToBundleCap');
-  /** @type {Store<BundleCap, EndoZipBase64Bundle>} */
-  const bundleCapToBundle = makeStore('bundleCapToBundle');
+  /** @type {MapStore<BundleID, BundleCap>} */
+  const idToBundleCap = makeScalarMapStore('idToBundleCap');
+  /** @type {MapStore<BundleCap, EndoZipBase64Bundle>} */
+  const bundleCapToBundle = makeScalarMapStore('bundleCapToBundle');
   const fakeVatPowers = {
     exitVatWithFailure: reason => {
       exitMessage = reason;

--- a/packages/zoe/tools/priceAuthorityRegistry.js
+++ b/packages/zoe/tools/priceAuthorityRegistry.js
@@ -1,5 +1,5 @@
 import { E } from '@endo/eventual-send';
-import { makeStore } from '@agoric/store';
+import { makeScalarMapStore } from '@agoric/store';
 import { Fail } from '@agoric/assert';
 import { Far } from '@endo/marshal';
 
@@ -37,8 +37,8 @@ export const makePriceAuthorityRegistry = () => {
    * given input and output brand pair
    */
 
-  /** @type {Store<Brand, Store<Brand, PriceAuthorityRecord>>} */
-  const assetToPriceStore = makeStore('brandIn');
+  /** @type {MapStore<Brand, MapStore<Brand, PriceAuthorityRecord>>} */
+  const assetToPriceStore = makeScalarMapStore('brandIn');
 
   /**
    * Get the registered price authority for a given input and output pair.
@@ -135,12 +135,12 @@ export const makePriceAuthorityRegistry = () => {
   /** @type {PriceAuthorityRegistryAdmin} */
   const adminFacet = Far('price authority admin facet', {
     registerPriceAuthority(pa, brandIn, brandOut, force = false) {
-      /** @type {Store<Brand, PriceAuthorityRecord>} */
+      /** @type {MapStore<Brand, PriceAuthorityRecord>} */
       let priceStore;
       if (assetToPriceStore.has(brandIn)) {
         priceStore = assetToPriceStore.get(brandIn);
       } else {
-        priceStore = makeStore('brandOut');
+        priceStore = makeScalarMapStore('brandOut');
         assetToPriceStore.init(brandIn, priceStore);
       }
 


### PR DESCRIPTION
For all legacy names exported by the store package that have non-legacy synonyms, replace uses by those non-legacy synonyms.