### PR TITLE
fix(zoe): installBundle handles HashBundle format

### DIFF
--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -108,6 +108,8 @@ export const makeInstallationStorage = (
     InstallationStorageI,
     {
       async installBundle(allegedBundle) {
+        // @ts-expect-error TS doesn't understand context
+        const { self } = this;
         // Bundle is a very open-ended type and we must decide here whether to
         // treat it as either a HashBundle or SourceBundle. So we have to
         // inspect it.
@@ -121,7 +123,7 @@ export const makeInstallationStorage = (
             'string',
             `bundle endoZipBase64Sha512 must be a string, got ${endoZipBase64Sha512}`,
           );
-          return this.installBundleID(`b1-${endoZipBase64Sha512}`);
+          return self.installBundleID(`b1-${endoZipBase64Sha512}`);
         }
         return installSourceBundle(allegedBundle);
       },

--- a/packages/zoe/test/unitTests/zoe/test-installationStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-installationStorage.js
@@ -28,6 +28,25 @@ test('install, unwrap installation of bundlecap', async t => {
   t.is(unwrapped.bundleCap, bundleCaps.id);
 });
 
+test('install HashBundle, unwrap installation of bundlecap', async t => {
+  const bundleHash = 'somehash';
+  const bundleID = `b1-${bundleHash}`;
+  const bundleCaps = { [bundleID]: makeHandle('BundleCap') };
+  const getBundleCapFromID = async id => bundleCaps[id];
+
+  const installationStorage = makeInstallationStorage(getBundleCapFromID);
+  const fakeBundle = {
+    endoZipBase64Sha512: bundleHash,
+    moduleFormat: 'endoZipBase64Sha512',
+  };
+
+  const installation = await installationStorage.installBundle(fakeBundle);
+  const unwrapped = await installationStorage.unwrapInstallation(installation);
+  t.is(unwrapped.installation, installation);
+  t.is(unwrapped.bundleID, bundleID);
+  t.is(unwrapped.bundleCap, bundleCaps[bundleID]);
+});
+
 test('unwrap promise for installation', async t => {
   // @ts-expect-error omitting required param during tests
   const installationStorage = makeInstallationStorage();


### PR DESCRIPTION
refs: https://github.com/Agoric/testnet-load-generator/pull/85

## Description

Fixes `installBundle` so the `endoZipBase64Sha512` path doesn't fail with the following message:
```
SwingSet: ls: v7: TypeError#1: ?.installBundle: no function
SwingSet: ls: v7: TypeError: ?.installBundle: no function
  at installBundle (.../zoe/src/zoeService/installationStorage.js:124)
```

(not sure why XS is truncating the method name, but given we're running an old fork, I'm not opening an issue for that)

### Testing Considerations

This was not covered by unit tests, now it is.

Loadgen will start exercising it from now on, including on this PR: 
```
#loadgen-branch: mhofman/publish-bundle
```