### PR TITLE
BREAKING CHANGE: Retire some unused deprecated names

### DIFF
--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -65,38 +65,12 @@ export {
 
 export { makeScalarWeakSetStore } from './stores/scalarWeakSetStore.js';
 export { makeScalarSetStore } from './stores/scalarSetStore.js';
-export {
-  makeScalarWeakMapStore,
-  makeScalarWeakMapStore as makeScalarWeakMap, // Deprecated legacy
-  makeScalarWeakMapStore as makeWeakStore, // Deprecated legacy
-} from './stores/scalarWeakMapStore.js';
-export {
-  makeScalarMapStore,
-  makeScalarMapStore as makeScalarMap, // Deprecated legacy
-  makeScalarMapStore as makeStore, // Deprecated legacy
-} from './stores/scalarMapStore.js';
+export { makeScalarWeakMapStore } from './stores/scalarWeakMapStore.js';
+export { makeScalarMapStore } from './stores/scalarMapStore.js';
 
 export { provideLazy } from './stores/store-utils.js';
 
 // /////////////////////// Deprecated Legacy ///////////////////////////////////
 
-// Importing these from store is deprecated. Import directly from
-// '@endo/marshal/src/rankOrder.js' instead.
-export {
-  compareRank,
-  isRankSorted,
-  sortByRank,
-} from '@endo/marshal/src/rankOrder.js';
-// Importing these from store is deprecated. Import directly from
-// '@endo/marshal/src/encodePassable.js' instead.
-export {
-  makeDecodePassable,
-  makeEncodePassable,
-  isEncodedRemotable,
-  zeroPad,
-} from '@endo/marshal/src/encodePassable.js';
-
-// export default as well as makeLegacy* only for compatibility
-// during the transition.
-export { makeLegacyMap, makeLegacyMap as default } from './legacy/legacyMap.js';
+export { makeLegacyMap } from './legacy/legacyMap.js';
 export { makeLegacyWeakMap } from './legacy/legacyWeakMap.js';

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -222,20 +222,8 @@
 
 /**
  * @template K,V
- * @typedef {WeakMapStore<K,V>} WeakStore
- * Deprecated type name `WeakStore`. Use `WeakMapStore` instead.
- */
-
-/**
- * @template K,V
- * @typedef {MapStore<K,V>} Store
- * Deprecated type name `Store`. Use `MapStore` instead.
- */
-
-/**
- * @template K,V
  * @typedef {object} LegacyWeakMap
- * LegacyWeakMap is deprecated. Use WeakMapStore instead.
+ * LegacyWeakMap is deprecated. Use WeakMapStore instead if possible.
  * @property {(key: K) => boolean} has
  * Check if a key exists
  * @property {(key: K) => V} get
@@ -252,7 +240,7 @@
 /**
  * @template K,V
  * @typedef {object} LegacyMap
- * LegacyWeakMap is deprecated. Use WeakMapStore instead.
+ * LegacyMap is deprecated. Use MapStore instead if possible.
  * @property {(key: K) => boolean} has
  * Check if a key exists
  * @property {(key: K) => V} get


### PR DESCRIPTION
#6827 stopped using some deprecated names from the store package.

At https://github.com/Agoric/agoric-sdk/pull/6827#pullrequestreview-1264671762 @turadg asks

> After this can we drop those?

This PR drops those.