### PR TITLE
clean up GitHub Actions deprecations

### DIFF
--- a/.github/actions/restore-golang/action.yml
+++ b/.github/actions/restore-golang/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: set default environment variables
       run: echo GOPATH="$HOME/go" >> $GITHUB_ENV
       shell: bash
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         clean: 'false'
         submodules: 'true'

--- a/.github/actions/restore-golang/action.yml
+++ b/.github/actions/restore-golang/action.yml
@@ -23,7 +23,7 @@ runs:
       id: system-info
     - name: cache Go modules
       id: cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ${{ env.GOPATH }}/pkg/mod
         key: ${{ runner.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-go-${{ inputs.go-version }}-built-${{ hashFiles('go.sum') }}

--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -26,7 +26,7 @@ runs:
     - uses: kenchan0130/actions-system-info@master
       id: system-info
     - name: cache node modules
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -34,7 +34,7 @@ runs:
           ${{ runner.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-yarn-
     - name: restore built files
       id: built
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: .
         key: ${{ runner.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-node-${{ inputs.node-version }}-built-${{ inputs.xsnap-random-init }}-${{ github.sha }}

--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: set default environment variables
       run: echo ESM_DISABLE_CACHE=true >> $GITHUB_ENV
       shell: bash
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         clean: 'false'
         submodules: 'true'

--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
@@ -64,7 +64,7 @@ jobs:
         working-directory: ./agoric-sdk
 
       - name: Check out dapp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Agoric/[[INSERT_DAPP_NAME]]
           path: dapp

--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -22,7 +22,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: agoric-sdk/yarn.lock
       - name: cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('agoric-sdk/yarn.lock') }}

--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         node-version: ['14.x', '16.x', '18.x']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - uses: ./.github/actions/restore-node
@@ -39,7 +39,7 @@ jobs:
         # note: only use one node-version
         node-version: ['14.x']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.node-version }}
@@ -81,7 +81,7 @@ jobs:
         node-version: ['14.x']
     if: ${{github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.node-version }}
@@ -125,7 +125,7 @@ jobs:
         node-version: ['14.x']
     if: ${{github.event_name == 'push'}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -90,7 +90,7 @@ jobs:
         run: 'yarn test:c8-all || :'
       - name: generate coverage/html reports
         run: mkdir -p coverage/tmp && yarn c8 report --reporter=html-spa --reports-dir=coverage/html --temp-directory=coverage/tmp
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: coverage
@@ -134,7 +134,7 @@ jobs:
         env:
           AUTOBENCH_METRICS_URL: ${{ secrets.AUTOBENCH_METRICS_URL }}
         run: cd packages/swingset-runner && yarn ci:autobench
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: benchmarkstats.json
           path: packages/swingset-runner/benchstats*.json

--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v1
       with:
         node-version: '14.x'

--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -21,7 +21,7 @@ jobs:
       with:
         node-version: '14.x'
     - name: cache node modules
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -107,7 +107,7 @@ jobs:
         working-directory: /usr/src/agoric-sdk
         env:
           NETWORK_NAME: chaintest
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: deployment-test-results-${{ env.NOW }}

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -29,7 +29,7 @@ jobs:
     if: needs.pre_check.outputs.should_run == 'true'
     runs-on: ubuntu-18.04 # trusty
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - run: sudo packages/deployment/scripts/install-deps.sh
@@ -66,7 +66,7 @@ jobs:
             return branch;
 
       - name: Check out loadgen
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Agoric/testnet-load-generator
           path: testnet-load-generator

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
           - linux/amd64
           - linux/arm64/v8
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Save BUILD_TAG
         run: |
           ARCH=$(echo '${{ matrix.platform }}' | tr / _)
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.docker-sdk.outputs.tag }} != dev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Save SDK_TAG
         run: echo "SDK_TAG=${{ needs.snapshot.outputs.tag }}" >> $GITHUB_ENV
       - name: Prefix tags
@@ -210,7 +210,7 @@ jobs:
     needs: [docker-sdk, snapshot]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Save SDK_TAG
         run: echo "SDK_TAG=${{ needs.snapshot.outputs.tag }}" >> $GITHUB_ENV
       - name: Prefix tags

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: '>=1.17'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,7 +32,7 @@ jobs:
         # cli: [link-cli, local-npm]
         cli: [link-cli]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Prerequisites
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           node-version: '14.x'
       - name: cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - uses: technote-space/get-diff-action@v4
@@ -27,7 +27,7 @@ jobs:
   breakage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - uses: technote-space/get-diff-action@v4

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node-version: ['14.x', '16.x', '18.x']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - uses: ./.github/actions/restore-node
@@ -41,7 +41,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: '18.x'
@@ -57,7 +57,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: '18.x'
@@ -82,7 +82,7 @@ jobs:
           echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -153,7 +153,7 @@ jobs:
           echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
           echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -210,7 +210,7 @@ jobs:
           echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -236,7 +236,7 @@ jobs:
           echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -265,7 +265,7 @@ jobs:
           echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -290,7 +290,7 @@ jobs:
           echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -320,7 +320,7 @@ jobs:
           echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
           echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -344,7 +344,7 @@ jobs:
           echo ::set-output name=node-version::${{ matrix.engine == 'xs' && '14.x' || matrix.engine }}
           echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -371,7 +371,7 @@ jobs:
           echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs-unit' || 'test:unit' }}
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
         # BEGIN-TEST-BOILERPLATE
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
@@ -398,7 +398,7 @@ jobs:
           echo ::set-output name=test::${{ matrix.engine == 'xs' && 'test:xs-worker' || 'test:swingset' }}
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
         # BEGIN-TEST-BOILERPLATE
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}

--- a/.github/workflows/test-dapp-card-store.yml.DISABLED
+++ b/.github/workflows/test-dapp-card-store.yml.DISABLED
@@ -25,7 +25,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: agoric-sdk/yarn.lock
       - name: cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('agoric-sdk/yarn.lock') }}

--- a/.github/workflows/test-dapp-card-store.yml.DISABLED
+++ b/.github/workflows/test-dapp-card-store.yml.DISABLED
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
@@ -67,7 +67,7 @@ jobs:
         working-directory: ./agoric-sdk
 
       - name: Check out dapp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Agoric/dapp-card-store
           path: dapp

--- a/.github/workflows/test-dapp-fungible-faucet.yml.DISABLED
+++ b/.github/workflows/test-dapp-fungible-faucet.yml.DISABLED
@@ -25,7 +25,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: agoric-sdk/yarn.lock
       - name: cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('agoric-sdk/yarn.lock') }}

--- a/.github/workflows/test-dapp-fungible-faucet.yml.DISABLED
+++ b/.github/workflows/test-dapp-fungible-faucet.yml.DISABLED
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
@@ -67,7 +67,7 @@ jobs:
         working-directory: ./agoric-sdk
 
       - name: Check out dapp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Agoric/dapp-fungible-faucet
           path: dapp

--- a/.github/workflows/test-dapp-otc.yml
+++ b/.github/workflows/test-dapp-otc.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: agoric-sdk/yarn.lock
       - name: cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('agoric-sdk/yarn.lock') }}

--- a/.github/workflows/test-dapp-otc.yml
+++ b/.github/workflows/test-dapp-otc.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
@@ -67,7 +67,7 @@ jobs:
         working-directory: ./agoric-sdk
 
       - name: Check out dapp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Agoric/dapp-otc
           path: dapp

--- a/.github/workflows/test-dapp-pegasus.yml
+++ b/.github/workflows/test-dapp-pegasus.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: agoric-sdk/yarn.lock
       - name: cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('agoric-sdk/yarn.lock') }}

--- a/.github/workflows/test-dapp-pegasus.yml
+++ b/.github/workflows/test-dapp-pegasus.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
@@ -67,7 +67,7 @@ jobs:
         working-directory: ./agoric-sdk
 
       - name: Check out dapp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Agoric/dapp-pegasus
           path: dapp

--- a/.github/workflows/test-dapp-simple-exchange.yml
+++ b/.github/workflows/test-dapp-simple-exchange.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
@@ -67,7 +67,7 @@ jobs:
         working-directory: ./agoric-sdk
 
       - name: Check out dapp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Agoric/dapp-simple-exchange
           path: dapp

--- a/.github/workflows/test-dapp-simple-exchange.yml
+++ b/.github/workflows/test-dapp-simple-exchange.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: agoric-sdk/yarn.lock
       - name: cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('agoric-sdk/yarn.lock') }}

--- a/.github/workflows/test-dapp-treasury.yml.DISABLED
+++ b/.github/workflows/test-dapp-treasury.yml.DISABLED
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
@@ -67,7 +67,7 @@ jobs:
         working-directory: ./agoric-sdk
 
       - name: Check out dapp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Agoric/dapp-treasury
           path: dapp

--- a/.github/workflows/test-dapp-treasury.yml.DISABLED
+++ b/.github/workflows/test-dapp-treasury.yml.DISABLED
@@ -25,7 +25,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: agoric-sdk/yarn.lock
       - name: cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('agoric-sdk/yarn.lock') }}

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -61,7 +61,7 @@ jobs:
           echo "/home/runner/bin" >> $GITHUB_PATH
 
       - name: Check out dapp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Agoric/documentation
           path: dapp

--- a/.github/workflows/test-golang.yml
+++ b/.github/workflows/test-golang.yml
@@ -11,7 +11,7 @@ jobs:
   gotest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/restore-golang
         with:
           go-version: 1.17

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -10,5 +10,5 @@ jobs:
   run-scripts-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: scripts/test/test.sh


### PR DESCRIPTION
## Description

A [recent job](https://github.com/Agoric/agoric-sdk/actions/runs/3971957504) logged 7 warnings in the action runner.
 
This resolves most of them by upgrading versions. Each commit shows the changelog.

It doesn't update https://github.com/actions/setup-node/ because I noticed we have v2 and v1, and I suspected there was some reason the v1 actions were never updated.

It also doesn't update https://github.com/actions/github-script because the latest, 6.0, is so much higher than current 0.9 that I expected some breaking change.

It doesn't update `set-output` because I tried in [6fdbe69](https://github.com/Agoric/agoric-sdk/pull/6832/commits/6fdbe690986137aa953ad237075dda20d03ae493) and 6 checks failed ([example](https://github.com/Agoric/agoric-sdk/actions/runs/3989521989/jobs/6842146385)).

### Security Considerations

--
### Scaling Considerations

--
### Documentation Considerations

--
### Testing Considerations

CI