### PR TITLE
feat(vats): share Invitation issuer/brand in agoricNames

### DIFF
--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -109,6 +109,12 @@ harden(makeVatsFromBundles);
 export const buildZoe = async ({
   consume: { vatAdminSvc, loadCriticalVat, client },
   produce: { zoe, feeMintAccess },
+  brand: {
+    produce: { Invitation: invitationBrand },
+  },
+  issuer: {
+    produce: { Invitation: invitationIssuer },
+  },
 }) => {
   const zcfBundleName = 'zcf'; // should match config.bundles.zcf=
   const { zoeService, feeMintAccess: fma } = await E(
@@ -116,6 +122,10 @@ export const buildZoe = async ({
   ).buildZoe(vatAdminSvc, feeIssuerConfig, zcfBundleName);
 
   zoe.resolve(zoeService);
+  const issuer = E(zoeService).getInvitationIssuer();
+  const brand = E(issuer).getBrand();
+  invitationIssuer.resolve(issuer);
+  invitationBrand.resolve(brand);
 
   feeMintAccess.resolve(fma);
   return Promise.all([

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -92,6 +92,8 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
       zoe: 'zoe',
       feeMintAccess: 'zoe',
     },
+    issuer: { produce: { Invitation: 'zoe' } },
+    brand: { produce: { Invitation: 'zoe' } },
   },
   [makeBoard.name]: {
     consume: {

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -134,7 +134,7 @@
  *
  * @typedef {{
  *   issuer: |
- *     TokenKeyword | 'Attestation' | 'AUSD',
+ *     TokenKeyword | 'Invitation' | 'Attestation' | 'AUSD',
  *   installation: |
  *     'centralSupply' | 'mintHolder' |
  *     'walletFactory' | 'provisionPool' |

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -23,6 +23,7 @@ export const agoricNamesReserved = harden({
     [Stake.symbol]: Stake.proposedName,
     [Stable.symbol]: Stable.proposedName,
     Attestation: 'Agoric lien attestation',
+    Invitation: 'Zoe invitation',
     AUSD: 'Agoric bridged USDC',
   },
   brand: {
@@ -30,6 +31,7 @@ export const agoricNamesReserved = harden({
     [Stable.symbol]: Stable.proposedName,
     Attestation: 'Agoric lien attestation',
     AUSD: 'Agoric bridged USDC',
+    Invitation: 'Zoe invitation',
   },
   vbankAsset: {
     [Stake.denom]: Stake.proposedName,


### PR DESCRIPTION
refs: #6807, #5762

## Description

With #5762 , we no longer need to look at an individual wallet to get vbank brands and displayInfo.
This PR does likewise for the Zoe invitation brand (and issuer).

### Documentation Considerations

Whatever docs we have for the contents of `agoricNames.brand` should get updated.

### Testing Considerations

I presume the code that depends on this will test it sufficiently.