### PR TITLE
BREAKING CHANGE: Rename *HeapExo* to *Exo*

### DIFF
--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -1,5 +1,5 @@
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeHeapExo, keyEQ, makeScalarMapStore } from '@agoric/store';
+import { makeExo, keyEQ, makeScalarMapStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 
 import {
@@ -133,7 +133,7 @@ const makeBinaryVoteCounter = (
     });
   };
 
-  const closeFacet = makeHeapExo(
+  const closeFacet = makeExo(
     'BinaryVoteCounter close',
     BinaryVoteCounterCloseI,
     {
@@ -144,7 +144,7 @@ const makeBinaryVoteCounter = (
     },
   );
 
-  const creatorFacet = makeHeapExo(
+  const creatorFacet = makeExo(
     'BinaryVoteCounter creator',
     BinaryVoteCounterAdminI,
     {
@@ -165,7 +165,7 @@ const makeBinaryVoteCounter = (
     },
   );
 
-  const publicFacet = makeHeapExo(
+  const publicFacet = makeExo(
     'BinaryVoteCounter public',
     BinaryVoteCounterPublicI,
     {

--- a/packages/governance/src/multiCandidateVoteCounter.js
+++ b/packages/governance/src/multiCandidateVoteCounter.js
@@ -1,4 +1,4 @@
-import { keyEQ, makeHeapExo, makeScalarMapStore } from '@agoric/store';
+import { keyEQ, makeExo, makeScalarMapStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import {
@@ -150,7 +150,7 @@ const makeMultiCandidateVoteCounter = (
     });
   };
 
-  const closeFacet = makeHeapExo(
+  const closeFacet = makeExo(
     'MultiCandidateVoteCounter close',
     VoteCounterCloseI,
     {
@@ -161,7 +161,7 @@ const makeMultiCandidateVoteCounter = (
     },
   );
 
-  const creatorFacet = makeHeapExo(
+  const creatorFacet = makeExo(
     'MultiCandidateVoteCounter creator',
     VoteCounterAdminI,
     {
@@ -184,7 +184,7 @@ const makeMultiCandidateVoteCounter = (
     },
   );
 
-  const publicFacet = makeHeapExo(
+  const publicFacet = makeExo(
     'MultiCandidateVoteCounter public',
     VoteCounterPublicI,
     {

--- a/packages/governance/src/noActionElectorate.js
+++ b/packages/governance/src/noActionElectorate.js
@@ -1,6 +1,6 @@
 import { makePublishKit } from '@agoric/notifier';
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeHeapExo } from '@agoric/store';
+import { makeExo } from '@agoric/store';
 
 import { ElectoratePublicI, ElectorateCreatorI } from './typeGuards.js';
 
@@ -13,7 +13,7 @@ import { ElectoratePublicI, ElectorateCreatorI } from './typeGuards.js';
 const start = zcf => {
   const { subscriber } = makePublishKit();
 
-  const publicFacet = makeHeapExo('publicFacet', ElectoratePublicI, {
+  const publicFacet = makeExo('publicFacet', ElectoratePublicI, {
     getQuestionSubscriber() {
       return subscriber;
     },
@@ -35,7 +35,7 @@ const start = zcf => {
     },
   });
 
-  const creatorFacet = makeHeapExo('creatorFacet', ElectorateCreatorI, {
+  const creatorFacet = makeExo('creatorFacet', ElectorateCreatorI, {
     getPoserInvitation() {
       return zcf.makeInvitation(() => {},
       `noActionElectorate doesn't allow posing questions`);

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -1,4 +1,4 @@
-import { makeHeapExo, fit, keyEQ, M } from '@agoric/store';
+import { makeExo, fit, keyEQ, M } from '@agoric/store';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 
 import { QuestionI, QuestionSpecShape } from './typeGuards.js';
@@ -83,7 +83,7 @@ const buildQuestion = (questionSpec, counterInstance) => {
   const questionHandle = makeHandle('Question');
 
   /** @type {Question} */
-  return makeHeapExo('question details', QuestionI, {
+  return makeExo('question details', QuestionI, {
     getVoteCounter() {
       return counterInstance;
     },

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -1,5 +1,5 @@
 import '@agoric/governance/exported.js';
-import { makeScalarMapStore, M, makeHeapExo, fit } from '@agoric/store';
+import { makeScalarMapStore, M, makeExo, fit } from '@agoric/store';
 import '@agoric/zoe/exported.js';
 import '@agoric/zoe/src/contracts/exported.js';
 import { InstanceHandleShape } from '@agoric/zoe/src/typeGuards.js';
@@ -89,7 +89,7 @@ export const start = async zcf => {
       TimestampShape,
     ).returns(M.promise()),
   });
-  const invitationMakers = makeHeapExo('Charter Invitation Makers', MakerI, {
+  const invitationMakers = makeExo('Charter Invitation Makers', MakerI, {
     VoteOnParamChange: makeParamInvitation,
     VoteOnPauseOffers: makeOfferFilterInvitation,
   });
@@ -106,7 +106,7 @@ export const start = async zcf => {
     makeCharterMemberInvitation: M.call().returns(M.promise()),
   });
 
-  const creatorFacet = makeHeapExo('Charter creatorFacet', charterCreatorI, {
+  const creatorFacet = makeExo('Charter creatorFacet', charterCreatorI, {
     /**
      * @param {Instance} governedInstance
      * @param {GovernedContractFacetAccess<{},{}>} governorFacet

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -5,7 +5,7 @@
  */
 
 import { WalletName } from '@agoric/internal';
-import { fit, M, makeHeapExo, makeScalarMapStore } from '@agoric/store';
+import { fit, M, makeExo, makeScalarMapStore } from '@agoric/store';
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeMyAddressNameAdminKit } from '@agoric/vats/src/core/basic-behaviors.js';
@@ -139,7 +139,7 @@ export const start = async (zcf, privateArgs) => {
   const walletsByAddress = makeScalarBigMapStore('walletsByAddress');
   const provider = makeAtomicProvider(walletsByAddress);
 
-  const handleWalletAction = makeHeapExo(
+  const handleWalletAction = makeExo(
     'walletActionHandler',
     M.interface('walletActionHandlerI', {
       fromBridge: M.call(shape.WalletBridgeMsg).returns(M.promise()),
@@ -201,7 +201,7 @@ export const start = async (zcf, privateArgs) => {
     zoe,
   });
 
-  const creatorFacet = makeHeapExo(
+  const creatorFacet = makeExo(
     'walletFactoryCreator',
     M.interface('walletFactoryCreatorI', {
       provideSmartWallet: M.callWhen(

--- a/packages/store/docs/exo-taxonomy.md
+++ b/packages/store/docs/exo-taxonomy.md
@@ -17,8 +17,8 @@ We often call a record of named entangled Xs an "XKit", as it a "toolkit" is a c
 
 ## Heap vs Virtual vs Durable
 
-* ***`*HeapExo*`*** <br>
-Like the small stores, the "heap" exo objects live in JavaScript's heap. Therefore, the total number of such HeapExo objects in a given vat must be able to fit into the JavaScript heap of that vat, and will occupy room in that vat's snapshot. We say the total number of instances is *low cardinality* when we expect the total number to remain low enough that this heap representation is not a problem.
+* ***`*Exo*`*** <br>
+As with stores, the default is that exo objects live in JavaScript's heap. Therefore, the total number of such Exo objects in a given vat must be able to fit into the JavaScript heap of that vat, and will occupy room in that vat's snapshot. We say the total number of instances is *low cardinality* when we expect the total number to remain low enough that this heap representation is not a problem.
 * ***`*VirtualExo*`*** <br>
 Like the big stores, the virtual exo objects are written to external storage outside the JavaScript heap. But these are ephemeral -- they do not survive upgrade. Their only purpose is for high cardinality, so we do not provide a convenience for directly making exo instances. IOW, there is no `makeVirtualExo`, only `defineVirtualExoClass` and `defineVirtualExoClassKit`.
 * ***`*DurableExo*`*** <br>
@@ -26,13 +26,21 @@ The durable exo objects are also written to external storage. These can also sur
 
 Note that the total number of exo classes must still low cardinality, even if they are virtual or durable. Being virtual or durable only enables the instances to be high cardinality.
 
+This `@endo/exo` package itself exports only the heap variants, and so only exports the names
+
+- `makeExo`
+- `defineExoClass`
+- `defineExoClassKit`
+
+The virtual and durable variants are contributed by higher layer packages that build on this one, such as `@agoric/vat-data`.
+
 ## Make/Define vs Prepare (Durable only)
 
 "prepare" is like "provide" in that it defines something that should be in the baggage, using the one that is there if found, but otherwise making a new one and registering it, so that the successor vat-invocation will find it at the same place in the baggage. Unlike "provide", for each exo behavior already in the baggage, one must call "prepare" immediately --- during the first crank of the vat incarnation. What is passed in baggage is only the state of the durable objects. Only the `prepare*` calls associate that state with code, giving it behavior. All these objects must be prepared early, so they know how to react when they receive messages.
 
-* ***`prepareExo`*** <br>
-Like `makeHeapExo` but for a durable exo in baggage.
-* ***`prepareExoClass`*** <br>
-Like `defineHeapExoClass` but for a durable exo in baggage.
-* ***`prepareExoClassKit`*** <br>
-Like `defineHeapExoClassKit` but for a durable exo in baggage.
+- **_`prepareExo`_** <br>
+  Like `makeExo` but for a durable exo in baggage.
+- **_`prepareExoClass`_** <br>
+  Like `defineExoClass` but for a durable exo in baggage.
+- **_`prepareExoClassKit`_** <br>
+  Like `defineExoClassKit` but for a durable exo in baggage.

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -58,9 +58,9 @@ export {
   defendPrototype,
   defendPrototypeKit,
   initEmpty,
-  defineHeapExoClass,
-  defineHeapExoClassKit,
-  makeHeapExo,
+  defineExoClass,
+  defineExoClassKit,
+  makeExo,
 } from './patterns/interface-tools.js';
 
 export { makeScalarWeakSetStore } from './stores/scalarWeakSetStore.js';

--- a/packages/store/src/patterns/interface-tools.js
+++ b/packages/store/src/patterns/interface-tools.js
@@ -327,7 +327,7 @@ export const initEmpty = () => emptyRecord;
  * @param {FarClassOptions<Context<S,T>>} [options]
  * @returns {(...args: A[]) => (T & import('@endo/eventual-send').RemotableBrand<{}, T>)}
  */
-export const defineHeapExoClass = (
+export const defineExoClass = (
   tag,
   interfaceGuard,
   init,
@@ -361,7 +361,7 @@ export const defineHeapExoClass = (
   // @ts-expect-error could be instantiated with different subtype
   return harden(makeInstance);
 };
-harden(defineHeapExoClass);
+harden(defineExoClass);
 
 /**
  * @template A args to init
@@ -374,7 +374,7 @@ harden(defineHeapExoClass);
  * @param {FarClassOptions<KitContext<S,F>>} [options]
  * @returns {(...args: A[]) => F}
  */
-export const defineHeapExoClassKit = (
+export const defineExoClassKit = (
   tag,
   interfaceGuardKit,
   init,
@@ -412,7 +412,7 @@ export const defineHeapExoClassKit = (
   // @ts-ignore xxx
   return harden(makeInstanceKit);
 };
-harden(defineHeapExoClassKit);
+harden(defineExoClassKit);
 
 /**
  * @template {Record<string, Method>} T
@@ -422,13 +422,8 @@ harden(defineHeapExoClassKit);
  * @param {FarClassOptions<Context<{},T>>} [options]
  * @returns {T & import('@endo/eventual-send').RemotableBrand<{}, T>}
  */
-export const makeHeapExo = (
-  tag,
-  interfaceGuard,
-  methods,
-  options = undefined,
-) => {
-  const makeInstance = defineHeapExoClass(
+export const makeExo = (tag, interfaceGuard, methods, options = undefined) => {
+  const makeInstance = defineExoClass(
     tag,
     interfaceGuard,
     initEmpty,
@@ -437,4 +432,4 @@ export const makeHeapExo = (
   );
   return makeInstance();
 };
-harden(makeHeapExo);
+harden(makeExo);

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -1,8 +1,8 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import {
-  defineHeapExoClass,
-  defineHeapExoClassKit,
-  makeHeapExo,
+  defineExoClass,
+  defineExoClassKit,
+  makeExo,
 } from '../src/patterns/interface-tools.js';
 import { M } from '../src/patterns/patternMatchers.js';
 
@@ -20,8 +20,8 @@ const DownCounterI = M.interface('DownCounter', {
     .returns(M.number()),
 });
 
-test('test defineHeapExoClass', t => {
-  const makeUpCounter = defineHeapExoClass(
+test('test defineExoClass', t => {
+  const makeUpCounter = defineExoClass(
     'UpCounter',
     UpCounterI,
     /** @param {number} x */
@@ -47,8 +47,8 @@ test('test defineHeapExoClass', t => {
   });
 });
 
-test('test defineHeapExoClassKit', t => {
-  const makeCounterKit = defineHeapExoClassKit(
+test('test defineExoClassKit', t => {
+  const makeCounterKit = defineExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
     /** @param {number} x */
@@ -93,9 +93,9 @@ test('test defineHeapExoClassKit', t => {
   });
 });
 
-test('test makeHeapExo', t => {
+test('test makeExo', t => {
   let x = 3;
-  const upCounter = makeHeapExo('upCounter', UpCounterI, {
+  const upCounter = makeExo('upCounter', UpCounterI, {
     incr(y = 1) {
       x += y;
       return x;
@@ -115,13 +115,13 @@ test('test makeHeapExo', t => {
 // For code sharing with defineKind which does not support an interface
 test('missing interface', t => {
   t.notThrows(() =>
-    makeHeapExo('greeter', undefined, {
+    makeExo('greeter', undefined, {
       sayHello() {
         return 'hello';
       },
     }),
   );
-  const greeterMaker = makeHeapExo('greeterMaker', undefined, {
+  const greeterMaker = makeExo('greeterMaker', undefined, {
     makeSayHello() {
       return () => 'hello';
     },
@@ -134,7 +134,7 @@ test('missing interface', t => {
 
 test('sloppy option', t => {
   const emptyBehavior = {};
-  const greeter = makeHeapExo(
+  const greeter = makeExo(
     'greeter',
     M.interface('greeter', emptyBehavior, { sloppy: true }),
     {
@@ -147,7 +147,7 @@ test('sloppy option', t => {
 
   t.throws(
     () =>
-      makeHeapExo(
+      makeExo(
         'greeter',
         M.interface('greeter', emptyBehavior, { sloppy: false }),
         {
@@ -161,7 +161,7 @@ test('sloppy option', t => {
 });
 
 test('naked function call', t => {
-  const greeter = makeHeapExo(
+  const greeter = makeExo(
     'greeter',
     M.interface('greeter', { sayHello: M.call().returns('hello') }),
     {
@@ -183,7 +183,7 @@ test('naked function call', t => {
 // needn't run. we just don't have a better place to write these.
 test.skip('types', () => {
   // any methods can be defined if there's no interface
-  const unguarded = makeHeapExo('upCounter', undefined, {
+  const unguarded = makeExo('upCounter', undefined, {
     /** @param {number} val */
     incr(val) {
       return val;
@@ -199,7 +199,7 @@ test.skip('types', () => {
   unguarded.notInBehavior;
 
   // TODO when there is an interface, error if a method is missing from it
-  const guarded = makeHeapExo('upCounter', UpCounterI, {
+  const guarded = makeExo('upCounter', UpCounterI, {
     /** @param {number} val */
     incr(val) {
       return val;

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,5 +1,5 @@
 import { assert } from '@agoric/assert';
-import { initEmpty, makeHeapExo } from '@agoric/store';
+import { initEmpty, makeExo } from '@agoric/store';
 import { prepareExoClass } from '@agoric/vat-data';
 
 import { HandleI } from './typeGuards.js';
@@ -39,8 +39,6 @@ export const makeHandle = handleType => {
   typeof handleType === 'string' || Fail`handleType must be a string`;
   // Return the intersection type (really just an empty object).
   // @ts-expect-error Bit by our own opaque types.
-  return /** @type {Handle<H>} */ (
-    makeHeapExo(`${handleType}Handle`, HandleI, {})
-  );
+  return /** @type {Handle<H>} */ (makeExo(`${handleType}Handle`, HandleI, {}));
 };
 harden(makeHandle);


### PR DESCRIPTION
https://github.com/endojs/endo/pull/1459 has not yet been merged into the endo monorepo, so a global rename is still not as painful as it is about to be. Now that the heap exo level will be about to stand alone in `@ando/exo`, with the virtual and durable variants to remain (at least for now) in agoric-sdk, I am increasingly unhappy with the `Heap` adjective added to those names.

So I just added a commit to the endo PR, currently at https://github.com/endojs/endo/pull/1459/commits/7fc2d06830e81eb926d0c9386cc529b023f1a192 , which does the rename. In that PR were to be merged with that state, the heap-level exo names would be simpler.

This PR does the same rename over agoric-sdk, so things will work now, and things will continue to work when agoric-sdk is upgraded to depend on https://github.com/endojs/endo/pull/1459, agoric-sdk imports these from `@endo/exo`, and the local copy of exo is deleted.