### PR TITLE
chore: drop RUN board ids

### DIFF
--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -580,10 +580,6 @@ export const configureVaultFactoryUI = async ({
   const boardIdValue = [
     ['INSTANCE_BOARD_ID', instances.vaultFactory],
     ['INSTALLATION_BOARD_ID', installs.vaultFactory],
-    // @deprecated
-    ['RUN_ISSUER_BOARD_ID', stableIssuer],
-    // @deprecated
-    ['RUN_BRAND_BOARD_ID', stableBrand],
     ['STABLE_ISSUER_BOARD_ID', stableIssuer],
     ['STABLE_BRAND_BOARD_ID', stableBrand],
     ['AMM_INSTALLATION_BOARD_ID', installs.amm],


### PR DESCRIPTION
## Description

These two deprecated `RUN` board ids should never be used and only are in dapp-treasury which is deprecated. (They don't consume board space because what they're referring to is already in board space.)

### Security Considerations

--
### Scaling Considerations

--

### Documentation Considerations

--

### Testing Considerations

Searched for instances. Only dapp-treasury uses them and that repo is archived.
https://github.com/search?q=org%3AAgoric%20RUN_ISSUER_BOARD_ID&type=code
https://github.com/search?q=org%3AAgoric%20RUN_BRAND_BOARD_ID&type=code
