### PR TITLE
6666 vault actions

### DIFF
--- a/packages/agoric-cli/src/commands/vaults.js
+++ b/packages/agoric-cli/src/commands/vaults.js
@@ -6,7 +6,12 @@
 import { Command } from 'commander';
 import { normalizeAddressWithOptions } from '../lib/chain.js';
 import { makeRpcUtils } from '../lib/rpc.js';
-import { makeOpenSpendAction } from '../lib/vaults.js';
+import {
+  lookupOfferIdForVault,
+  makeAdjustSpendAction,
+  makeCloseSpendAction,
+  makeOpenSpendAction,
+} from '../lib/vaults.js';
 import { getCurrent, outputAction } from '../lib/wallet.js';
 
 /** @typedef {import('@agoric/smart-wallet/src/offers').OfferSpec} OfferSpec */
@@ -41,10 +46,7 @@ export const makeVaultsCommand = async logger => {
       'wallet address literal or name',
       normalizeAddress,
     )
-    .action(async function () {
-      // @ts-expect-error this implicit any
-      const opts = this.opts();
-
+    .action(async function (opts) {
       const current = await getCurrent(opts.from, fromBoard, { vstorage });
 
       const vaultStoragePaths = Object.values(
@@ -60,12 +62,10 @@ export const makeVaultsCommand = async logger => {
   vaults
     .command('open')
     .description('open a new vault')
-    .option('--giveCollateral [number]', 'Collateral to give', Number, 9.0)
-    .option('--wantMinted [number]', 'Minted wants', Number, 6.0)
+    .requiredOption('--giveCollateral [number]', 'Collateral to give', Number)
+    .requiredOption('--wantMinted [number]', 'Minted wants', Number)
     .option('--offerId [number]', 'Offer id', Number, Date.now())
-    .action(async function () {
-      // @ts-expect-error this implicit any
-      const opts = this.opts();
+    .action(async function (opts) {
       logger.warn('running with options', opts);
 
       const { VaultFactory } = agoricNames.instance;
@@ -75,6 +75,35 @@ export const makeVaultsCommand = async logger => {
         VaultFactory,
         agoricNames.brand,
         opts,
+      );
+      outputAction(spendAction);
+    });
+
+  vaults
+    .command('close')
+    .description('close an existing vault')
+    .requiredOption(
+      '--from <address>',
+      'wallet address literal or name',
+      normalizeAddress,
+    )
+    .requiredOption('--giveMinted [number]', 'Minted to give back', Number)
+    .option('--offerId [number]', 'Offer id', Number, Date.now())
+    // TODO method to disambiguate between managers
+    .requiredOption('--vaultId [string]', 'Key of vault (e.g. vault1)')
+    .action(async function (opts) {
+      logger.warn('running with options', opts);
+
+      const previousOfferId = await lookupOfferIdForVault(
+        opts.vaultId,
+        getCurrent(opts.from, fromBoard, { vstorage }),
+      );
+
+      const spendAction = makeCloseSpendAction(
+        // @ts-expect-error xxx RpcRemote
+        agoricNames.brand,
+        opts,
+        previousOfferId,
       );
       outputAction(spendAction);
     });

--- a/packages/agoric-cli/src/commands/vaults.js
+++ b/packages/agoric-cli/src/commands/vaults.js
@@ -80,6 +80,38 @@ export const makeVaultsCommand = async logger => {
     });
 
   vaults
+    .command('adjust')
+    .description('adjust an existing vault')
+    .requiredOption(
+      '--from <address>',
+      'wallet address literal or name',
+      normalizeAddress,
+    )
+    .option('--giveCollateral [number]', 'More collateral to lend', Number)
+    .option('--wantCollateral [number]', 'Collateral to get back', Number)
+    .option('--giveMinted [number]', 'Minted to give back', Number)
+    .option('--wantMinted [number]', 'More minted to borrow', Number)
+    .option('--offerId [number]', 'Offer id', Number, Date.now())
+    // TODO method to disambiguate between managers
+    .requiredOption('--vaultId [string]', 'Key of vault (e.g. vault1)')
+    .action(async function (opts) {
+      logger.warn('running with options', opts);
+
+      const previousOfferId = await lookupOfferIdForVault(
+        opts.vaultId,
+        getCurrent(opts.from, fromBoard, { vstorage }),
+      );
+
+      const spendAction = makeAdjustSpendAction(
+        // @ts-expect-error xxx RpcRemote
+        agoricNames.brand,
+        opts,
+        previousOfferId,
+      );
+      outputAction(spendAction);
+    });
+
+  vaults
     .command('close')
     .description('close an existing vault')
     .requiredOption(

--- a/packages/agoric-cli/src/lib/vaults.js
+++ b/packages/agoric-cli/src/lib/vaults.js
@@ -87,6 +87,37 @@ export const makeOpenSpendAction = (instance, brands, opts) => {
 
 /**
  * @param {Record<string, Brand>} brands
+ * @param {{ offerId: string, giveCollateral?: number, wantCollateral?: number, giveMinted?: number, wantMinted?: number }} opts
+ * @param {string} previousOffer
+ * @returns {BridgeAction}
+ */
+export const makeAdjustSpendAction = (brands, opts, previousOffer) => {
+  // NB: not really a Proposal because the brands are not remotes
+  // Instead they're copyRecord like  "{"boardId":"board0257","iface":"Alleged: IST brand"}" to pass through the boardId
+  // fit(harden(proposal), ProposalShape);
+  const proposal = makeProposal(brands, opts);
+
+  /** @type {OfferSpec} */
+  const offer = {
+    id: opts.offerId,
+    invitationSpec: {
+      source: 'continuing',
+      previousOffer,
+      invitationMakerName: 'AdjustBalances',
+    },
+    proposal,
+  };
+
+  /** @type {BridgeAction} */
+  const spendAction = {
+    method: 'executeOffer',
+    offer,
+  };
+  return harden(spendAction);
+};
+
+/**
+ * @param {Record<string, Brand>} brands
  * @param {{ offerId: string, giveMinted: number }} opts
  * @param {string} previousOffer
  * @returns {BridgeAction}

--- a/packages/agoric-cli/src/lib/vaults.js
+++ b/packages/agoric-cli/src/lib/vaults.js
@@ -6,28 +6,47 @@ import { COSMOS_UNIT } from './format.js';
 /** @typedef {import('@agoric/smart-wallet/src/offers').OfferStatus} OfferStatus */
 /** @typedef {import('@agoric/smart-wallet/src/smartWallet').BridgeAction} BridgeAction */
 
+// TODO handle other collateral types
+// NB: not really a Proposal because the brands are not remotes
+// Instead they're copyRecord like  "{"boardId":"board0257","iface":"Alleged: IST brand"}" to pass through the boardId
+// fit(harden(proposal), ProposalShape);
 /**
- * Open a vault
+ * Give/want, assuming IbcATOM collateral
  *
  * @param {Record<string, Brand>} brands
- * @param {({ wantMinted: number, giveCollateral: number })} opts
+ * @param {({ giveCollateral?: number, wantCollateral?: number, giveMinted?: number, wantMinted?: number })} opts
  * @returns {Proposal}
  */
-const makeOpenProposal = (brands, opts) => {
-  return {
-    give: {
-      Collateral: {
-        brand: brands.IbcATOM,
-        value: BigInt(opts.giveCollateral * Number(COSMOS_UNIT)),
-      },
-    },
-    want: {
-      Minted: {
-        brand: brands.IST,
-        value: BigInt(opts.wantMinted * Number(COSMOS_UNIT)),
-      },
-    },
-  };
+const makeProposal = (brands, opts) => {
+  const proposal = { give: {}, want: {} };
+
+  if (opts.giveCollateral) {
+    proposal.give.Collateral = {
+      brand: brands.IbcATOM,
+      value: BigInt(opts.giveCollateral * Number(COSMOS_UNIT)),
+    };
+  }
+  if (opts.giveMinted) {
+    proposal.give.Minted = {
+      brand: brands.IST,
+      value: BigInt(opts.giveMinted * Number(COSMOS_UNIT)),
+    };
+  }
+
+  if (opts.wantCollateral) {
+    proposal.want.Collateral = {
+      brand: brands.IbcATOM,
+      value: BigInt(opts.wantCollateral * Number(COSMOS_UNIT)),
+    };
+  }
+  if (opts.wantMinted) {
+    proposal.want.Minted = {
+      brand: brands.IST,
+      value: BigInt(opts.wantMinted * Number(COSMOS_UNIT)),
+    };
+  }
+
+  return harden(proposal);
 };
 
 /**
@@ -37,7 +56,7 @@ const makeOpenProposal = (brands, opts) => {
  * @returns {BridgeAction}
  */
 export const makeOpenSpendAction = (instance, brands, opts) => {
-  const proposal = makeOpenProposal(brands, opts);
+  const proposal = makeProposal(brands, opts);
 
   console.warn('vaults open give', proposal.give);
   console.warn('vaults open want', proposal.want);

--- a/packages/agoric-cli/test/agops-oracle-smoketest.sh
+++ b/packages/agoric-cli/test/agops-oracle-smoketest.sh
@@ -36,17 +36,17 @@ WALLET2=oracle2
 ORACLE_OFFER=$(mktemp -t agops.XXX)
 bin/agops oracle accept >|"$ORACLE_OFFER"
 jq ".body | fromjson" <"$ORACLE_OFFER"
-agoric wallet send --keyring-backend="test" --from "$WALLET" --offer "$ORACLE_OFFER"
+agoric wallet send --offer "$ORACLE_OFFER" --from "$WALLET" --keyring-backend="test"
 ORACLE_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
 
 # verify the offerId is readable from chain history
-agoric wallet show --keyring-backend="test" --from "$WALLET"
+agoric wallet show --from "$WALLET" --keyring-backend="test"
 
 # repeat for oracle2
 ORACLE_OFFER=$(mktemp -t agops.XXX)
 bin/agops oracle accept >|"$ORACLE_OFFER"
 jq ".body | fromjson" <"$ORACLE_OFFER"
-agoric wallet send --keyring-backend="test" --from "$WALLET2" --offer "$ORACLE_OFFER"
+agoric wallet send --offer "$ORACLE_OFFER" --from "$WALLET2" --keyring-backend="test"
 ORACLE2_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
 
 ### Now we have the continuing invitationMakers saved in the wallets
@@ -55,11 +55,11 @@ ORACLE2_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
 bin/agops oracle pushPriceRound --price 101 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
 jq ".body | fromjson" <"$PROPOSAL_OFFER"
-agoric wallet send --keyring-backend="test" --from "$WALLET" --offer "$PROPOSAL_OFFER"
+agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET" --keyring-backend="test"
 
 # verify that the offer was satisfied
 echo "Offer $ORACLE_OFFER_ID should have numWantsSatisfied: 1"
-agoric wallet show --keyring-backend="test" --from "$WALLET"
+agoric wallet show --from "$WALLET" --keyring-backend="test"
 
 # verify feed publishing
 agd query vstorage keys published.priceFeed
@@ -71,16 +71,16 @@ agoric follow :published.priceFeed.ATOM-USD_price_feed.latestRound
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
 bin/agops oracle pushPriceRound --price 201 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
 jq ".body | fromjson" <"$PROPOSAL_OFFER"
-agoric wallet send --keyring-backend="test" --from "$WALLET2" --offer "$PROPOSAL_OFFER"
+agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET2" --keyring-backend="test"
 
 # second round, first oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
 bin/agops oracle pushPriceRound --price 1102 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
-agoric wallet send --keyring-backend="test" --from "$WALLET" --offer "$PROPOSAL_OFFER"
+agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET" --keyring-backend="test"
 # second round, second oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
 bin/agops oracle pushPriceRound --price 1202 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
-agoric wallet send --keyring-backend="test" --from "$WALLET2" --offer "$PROPOSAL_OFFER"
+agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET2" --keyring-backend="test"
 
 # see new price
 agoric follow :published.priceFeed.ATOM-USD_price_feed

--- a/packages/agoric-cli/test/agops-perf-smoketest.sh
+++ b/packages/agoric-cli/test/agops-perf-smoketest.sh
@@ -32,9 +32,9 @@ set -x
 # perf test wantMinted
 OFFER=$(mktemp -t agops.XXX)
 bin/agops psm swap --wantMinted 0.01 --feePct 0.01 --pair IST.USDC_axl >|"$OFFER"
-time bin/agops perf satisfaction --keyring-backend="test" --executeOffer "$OFFER" --from "$WALLET"
+time bin/agops perf satisfaction --executeOffer "$OFFER" --from "$WALLET" --keyring-backend="test"
 
 # perf test giveMinted
 OFFER=$(mktemp -t agops.XXX)
 bin/agops psm swap --giveMinted 0.01 --feePct 0.03 --pair IST.USDC_axl >|"$OFFER"
-time bin/agops perf satisfaction --keyring-backend="test" --executeOffer "$OFFER" --from "$WALLET"
+time bin/agops perf satisfaction --executeOffer "$OFFER" --from "$WALLET" --keyring-backend="test"

--- a/packages/agoric-cli/test/agops-vaults-smoketest.sh
+++ b/packages/agoric-cli/test/agops-vaults-smoketest.sh
@@ -33,20 +33,20 @@ set -x
 OFFER=$(mktemp -t agops.XXX)
 bin/agops vaults open --wantMinted 5.00 --giveCollateral 9.0 >|"$OFFER"
 jq ".body | fromjson" <"$OFFER"
-agoric wallet send --keyring-backend="test" --from "$WALLET" --offer "$OFFER"
+agoric wallet send --offer "$OFFER" --from "$WALLET" --keyring-backend="test"
 
 # list my vaults
-bin/agops vaults list --keyring-backend="test" --from "$WALLET"
+bin/agops vaults list --from "$WALLET" --keyring-backend="test"
 
 # adjust
 OFFER=$(mktemp -t agops.XXX)
-bin/agops vaults adjust --giveCollateral 1.0 --from "$WALLET" --vaultId vault2 >|"$OFFER"
+bin/agops vaults adjust --vaultId vault1 --giveCollateral 1.0 --from "$WALLET" --keyring-backend="test" >|"$OFFER"
 jq ".body | fromjson" <"$OFFER"
-agoric wallet send --keyring-backend="test" --from "$WALLET" --offer "$OFFER"
+agoric wallet send --from "$WALLET" --keyring-backend="test" --offer "$OFFER"
 
 # close a vault
 OFFER=$(mktemp -t agops.XXX)
 # 5.05 for 5.00 debt plus 1% fee
-bin/agops vaults close --giveMinted 5.05 --from "$WALLET" --vaultId vault1 >|"$OFFER"
+bin/agops vaults close --vaultId vault1 --giveMinted 5.05 --from "$WALLET" --keyring-backend="test" >|"$OFFER"
 jq ".body | fromjson" <"$OFFER"
-agoric wallet send --keyring-backend="test" --from "$WALLET" --offer "$OFFER"
+agoric wallet send --from "$WALLET" --keyring-backend="test" --offer "$OFFER"

--- a/packages/agoric-cli/test/agops-vaults-smoketest.sh
+++ b/packages/agoric-cli/test/agops-vaults-smoketest.sh
@@ -38,6 +38,12 @@ agoric wallet send --keyring-backend="test" --from "$WALLET" --offer "$OFFER"
 # list my vaults
 bin/agops vaults list --keyring-backend="test" --from "$WALLET"
 
+# adjust
+OFFER=$(mktemp -t agops.XXX)
+bin/agops vaults adjust --giveCollateral 1.0 --from "$WALLET" --vaultId vault2 >|"$OFFER"
+jq ".body | fromjson" <"$OFFER"
+agoric wallet send --keyring-backend="test" --from "$WALLET" --offer "$OFFER"
+
 # close a vault
 OFFER=$(mktemp -t agops.XXX)
 # 5.05 for 5.00 debt plus 1% fee

--- a/packages/agoric-cli/test/agops-vaults-smoketest.sh
+++ b/packages/agoric-cli/test/agops-vaults-smoketest.sh
@@ -31,9 +31,16 @@ set -x
 
 # open a vault
 OFFER=$(mktemp -t agops.XXX)
-bin/agops vaults open >|"$OFFER"
+bin/agops vaults open --wantMinted 5.00 --giveCollateral 9.0 >|"$OFFER"
 jq ".body | fromjson" <"$OFFER"
 agoric wallet send --keyring-backend="test" --from "$WALLET" --offer "$OFFER"
 
 # list my vaults
 bin/agops vaults list --keyring-backend="test" --from "$WALLET"
+
+# close a vault
+OFFER=$(mktemp -t agops.XXX)
+# 5.05 for 5.00 debt plus 1% fee
+bin/agops vaults close --giveMinted 5.05 --from "$WALLET" --vaultId vault1 >|"$OFFER"
+jq ".body | fromjson" <"$OFFER"
+agoric wallet send --keyring-backend="test" --from "$WALLET" --offer "$OFFER"

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -48,6 +48,14 @@ export const assertOnlyKeys = (proposal, keys) => {
 };
 
 /**
+ * @param {Amount[]} amounts
+ * @returns {boolean}
+ */
+export const allEmpty = amounts => {
+  return amounts.every(a => AmountMath.isEmpty(a));
+};
+
+/**
  * Stage a transfer between `fromSeat` and `toSeat`, specified as the delta between
  * the gain and a loss on the `fromSeat`. The gain/loss are typically from the
  * give/want respectively of a proposal. The `key` is the allocation keyword.

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -113,28 +113,6 @@ const SHARED_MAIN_MANIFEST = harden({
       },
     },
   },
-
-  [econBehaviors.configureVaultFactoryUI.name]: {
-    consume: {
-      board: true,
-      zoe: true,
-    },
-    issuer: { consume: { [Stable.symbol]: 'zoe' } },
-    brand: { consume: { [Stable.symbol]: 'zoe' } },
-    installation: {
-      consume: {
-        amm: 'zoe',
-        VaultFactory: 'zoe',
-        contractGovernor: 'zoe',
-        binaryVoteCounter: 'zoe',
-        liquidate: 'zoe',
-      },
-    },
-    instance: {
-      consume: { amm: 'amm', VaultFactory: 'VaultFactory' },
-    },
-    uiConfig: { produce: { Treasury: true, VaultFactory: true } },
-  },
 });
 
 const REWARD_MANIFEST = harden({

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -9,7 +9,6 @@ import { Stable, Stake } from '@agoric/vats/src/tokens.js';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/far';
-import * as Collect from '../collect.js';
 import { LienBridgeId, makeStakeReporter } from '../my-lien.js';
 import { makeReserveTerms } from '../reserve/params.js';
 import { makeStakeFactoryTerms } from '../stakeFactory/params.js';
@@ -525,92 +524,6 @@ export const grantVaultFactoryControl = async (
   ]);
 };
 harden(grantVaultFactoryControl);
-
-/** @param {BootstrapPowers} powers */
-export const configureVaultFactoryUI = async ({
-  consume: { board, zoe },
-  issuer: {
-    consume: { [Stable.symbol]: stableIssuerP },
-  },
-  brand: {
-    consume: { [Stable.symbol]: stableBrandP },
-  },
-  installation: {
-    consume: {
-      amm: ammInstallation,
-      VaultFactory: vaultInstallation,
-      contractGovernor,
-      binaryVoteCounter,
-      liquidate,
-    },
-  },
-  instance: {
-    consume: { amm: ammInstance, VaultFactory: vaultInstance },
-  },
-  uiConfig,
-}) => {
-  const installs = await Collect.allValues({
-    vaultFactory: vaultInstallation,
-    amm: ammInstallation,
-    contractGovernor,
-    binaryVoteCounter,
-    liquidate,
-  });
-  const instances = await Collect.allValues({
-    amm: ammInstance,
-    vaultFactory: vaultInstance,
-  });
-  const [stableIssuer, stableBrand] = await Promise.all([
-    stableIssuerP,
-    stableBrandP,
-  ]);
-
-  const invitationIssuer = await E(zoe).getInvitationIssuer();
-
-  const vaultFactoryUiDefaults = {
-    CONTRACT_NAME: 'VaultFactory',
-    AMM_NAME: 'amm',
-    BRIDGE_URL: 'http://127.0.0.1:8000',
-    // Avoid setting API_URL, so that the UI uses the same origin it came from,
-    // if it has an api server.
-    // API_URL: 'http://127.0.0.1:8000',
-  };
-
-  // Look up all the board IDs.
-  const boardIdValue = [
-    ['INSTANCE_BOARD_ID', instances.vaultFactory],
-    ['INSTALLATION_BOARD_ID', installs.vaultFactory],
-    // @deprecated
-    ['RUN_ISSUER_BOARD_ID', stableIssuer],
-    // @deprecated
-    ['RUN_BRAND_BOARD_ID', stableBrand],
-    ['STABLE_ISSUER_BOARD_ID', stableIssuer],
-    ['STABLE_BRAND_BOARD_ID', stableBrand],
-    ['AMM_INSTALLATION_BOARD_ID', installs.amm],
-    ['LIQ_INSTALLATION_BOARD_ID', installs.liquidate],
-    ['BINARY_COUNTER_INSTALLATION_BOARD_ID', installs.binaryVoteCounter],
-    ['CONTRACT_GOVERNOR_INSTALLATION_BOARD_ID', installs.contractGovernor],
-    ['AMM_INSTANCE_BOARD_ID', instances.amm],
-    ['INVITE_BRAND_BOARD_ID', E(invitationIssuer).getBrand()],
-  ];
-  await Promise.all(
-    boardIdValue.map(async ([key, valP]) => {
-      const val = await valP;
-      const boardId = await E(board).getId(val);
-      vaultFactoryUiDefaults[key] = boardId;
-    }),
-  );
-
-  // Stash the defaults where the UI can find them.
-  harden(vaultFactoryUiDefaults);
-
-  // Install the names in agoricNames.
-  uiConfig.produce[vaultFactoryUiDefaults.CONTRACT_NAME].resolve(
-    vaultFactoryUiDefaults,
-  );
-  uiConfig.produce.Treasury.resolve(vaultFactoryUiDefaults); // compatibility
-};
-harden(configureVaultFactoryUI);
 
 /**
  * Start the reward distributor.

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -12,6 +12,7 @@ import {
 import { SeatShape } from '@agoric/zoe/src/typeGuards.js';
 import {
   addSubtract,
+  allEmpty,
   assertOnlyKeys,
   makeEphemeraProvider,
   stageDelta,
@@ -506,10 +507,6 @@ export const prepareVault = baggage => {
           const { vaultSeat } = state;
           const proposal = clientSeat.getProposal();
           assertOnlyKeys(proposal, ['Collateral', 'Minted']);
-
-          const allEmpty = amounts => {
-            return amounts.every(a => AmountMath.isEmpty(a));
-          };
 
           const normalizedDebtPre = self.getNormalizedDebt();
           const collateralPre = helper.getCollateralAllocated(vaultSeat);

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -261,7 +261,7 @@ export const prepareVault = baggage => {
 
         assertActive() {
           const { phase } = this.state;
-          assert(phase === Phase.ACTIVE);
+          phase === Phase.ACTIVE || Fail`vault not active`;
         },
 
         assertCloseable() {

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -27,9 +27,9 @@ export const prepareVaultKit = baggage => {
         vault: holder.getSubscriber(),
       },
       invitationMakers: Far('invitation makers', {
-        AdjustBalances: holder.makeAdjustBalancesInvitation,
-        CloseVault: holder.makeCloseInvitation,
-        TransferVault: holder.makeTransferInvitation,
+        AdjustBalances: () => holder.makeAdjustBalancesInvitation(),
+        CloseVault: () => holder.makeCloseInvitation(),
+        TransferVault: () => holder.makeTransferInvitation(),
       }),
       vault: holder,
       vaultUpdater: helper.getUpdater(),

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -44,7 +44,7 @@ import '@agoric/zoe/exported.js';
  * @param {ERef<ZoeService>} zoe
  * @param {Brand<'set'>} invitationBrand
  * @param {Purse<'set'>} invitationsPurse
- * @param {(fromOfferId: import('./offers.js').OfferId) => import('./types').RemoteInvitationMakers} getInvitationContinuation
+ * @param {(fromOfferId: string) => import('./types').RemoteInvitationMakers} getInvitationContinuation
  */
 export const makeInvitationsHelper = (
   zoe,
@@ -104,7 +104,7 @@ export const makeInvitationsHelper = (
       fit(spec, shape.ContinuingInvitationSpec);
 
       const { previousOffer, invitationArgs = [], invitationMakerName } = spec;
-      const makers = getInvitationContinuation(previousOffer);
+      const makers = getInvitationContinuation(String(previousOffer));
       assert(
         makers,
         `invalid value stored for previous offer ${previousOffer}`,

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -37,7 +37,7 @@ export const UNPUBLISHED_RESULT = 'UNPUBLISHED';
  * @param {(spec: import('./invitations').InvitationSpec) => ERef<Invitation>} opts.powers.invitationFromSpec
  * @param {(brand: Brand) => Promise<import('./types').RemotePurse>} opts.powers.purseForBrand
  * @param {(status: OfferStatus) => void} opts.onStatusChange
- * @param {(offerId: OfferId, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers: import('./types').PublicSubscribers ) => Promise<void>} opts.onNewContinuingOffer
+ * @param {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers: import('./types').PublicSubscribers ) => Promise<void>} opts.onNewContinuingOffer
  */
 export const makeOfferExecutor = ({
   zoe,
@@ -134,7 +134,7 @@ export const makeOfferExecutor = ({
                 if ('invitationMakers' in result) {
                   // save for continuing invitation offer
                   void onNewContinuingOffer(
-                    id,
+                    String(id),
                     invitationAmount,
                     // @ts-expect-error result narrowed by passStyle
                     result.invitationMakers,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -181,17 +181,26 @@ export const initState = (unique, shared) => {
       durable: true,
     }),
     // Invitation amounts to save for persistent lookup
-    offerToUsedInvitation: makeScalarBigMapStore('invitation amounts', {
-      durable: true,
-    }),
+    offerToUsedInvitation: makeScalarBigMapStore(
+      'invitation amounts by offer',
+      {
+        durable: true,
+      },
+    ),
     // Invitation makers yielded by offer results
-    offerToInvitationMakers: makeScalarBigMapStore('invitation makers', {
-      durable: true,
-    }),
+    offerToInvitationMakers: makeScalarBigMapStore(
+      'invitation makers by offer',
+      {
+        durable: true,
+      },
+    ),
     // Public subscribers yielded by offer results
-    offerToPublicSubscriberPaths: makeScalarBigMapStore('public subscribers', {
-      durable: true,
-    }),
+    offerToPublicSubscriberPaths: makeScalarBigMapStore(
+      'public subscribers by offer',
+      {
+        durable: true,
+      },
+    ),
   };
 
   const nonpreciousState = {


### PR DESCRIPTION
closes: #6666

## Description

Primarily ads `vaults close` and `vaults adjust` actions.

Also fixes for a couple bug uncovered:
- fix(vaultHolder): invitationMakers far obj
- fix: number/string inconsistency with offer lookup

General cleanup and refactoring along the way.

Plus this drive-by that I did here since I'm manually testing the vaults so much in this PR,
- chore: remove unused configureVaultFactoryUI (per https://github.com/Agoric/agoric-sdk/pull/6841#issuecomment-1402413021 )


### Security Considerations

--

### Scaling Considerations

--

### Documentation Considerations

--

### Testing Considerations

Manually testing with the `agops-vaults-smoketest.sh` script