### PR TITLE
work around ambient issues in prepack

### DIFF
--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -196,7 +196,8 @@ const makeParamManagerBuilder = (publisherKit, zoe) => {
       throw Fail`zoe must be provided for governed Invitations ${zoe}`;
     }
     const { instance, installation } = await E(zoe).getInvitationDetails(i);
-    // @ts-expect-error typescript thinks they're guaranteed True. I'm not sure.
+    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- the build config doesn't expect an error here
+    // @ts-ignore typedefs say they're guaranteed truthy but just to be safe
     assert(instance && installation, 'must be an invitation');
   };
 

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -160,7 +160,8 @@ const start = async (zcf, privateArgs) => {
   } = await E(zoe).startInstance(
     governedContractInstallation,
     governedIssuerKeywordRecord,
-    // @ts-expect-error XXX governance types
+    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- the build config doesn't expect an error here
+    // @ts-ignore XXX governance types
     augmentedTerms,
     privateArgs.governed,
   );
@@ -217,7 +218,8 @@ const start = async (zcf, privateArgs) => {
    */
   const replaceElectorate = poserInvitation => {
     /** @type {Promise<import('./contractGovernance/typedParamManager.js').TypedParamManager<{'Electorate': 'invitation'}>>} */
-    // @ts-expect-error cast
+    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- the build config doesn't expect an error here
+    // @ts-ignore cast
     const paramMgr = E(E(governedCF).getParamMgrRetriever()).get({
       key: 'governedParams',
     });

--- a/packages/governance/tools/puppetContractGovernor.js
+++ b/packages/governance/tools/puppetContractGovernor.js
@@ -46,7 +46,8 @@ export const start = async (zcf, privateArgs) => {
   } = await E(zoe).startInstance(
     governedContractInstallation,
     governedIssuerKeywordRecord,
-    // @ts-expect-error XXX governance types
+    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- the build config doesn't expect an error here
+    // @ts-ignore XXX governance types
     augmentedTerms,
     privateArgs.governed,
   );


### PR DESCRIPTION
## Description

dev-canary starting breaking in https://github.com/Agoric/agoric-sdk/actions/runs/3992513074 due to a failing to `yarn prepack`. That was in turn due to some ts-expect-error directives. It was triggered by [changing the dependency graph](https://github.com/Agoric/agoric-sdk/pull/6823) which disrupted the careful balance of ambient types resolution.

This papers over the problem by using ts-ignore.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

PR CI doesn't cut it. Using Verdaccio I ran,
```
yarn lerna publish  --exact \
            --dist-tag=blah --preid=dev-$(git rev-parse --short=7 HEAD) \
            --no-push --no-verify-access --yes --registry "http://localhost:4873"
```
and then this to clean up the tags created,
```
git fetch origin --prune --prune-tags
```