### PR TITLE
fix(deploy-script-support): RESM compatible bundle powers

### DIFF
--- a/packages/agoric-cli/src/deploy.js
+++ b/packages/agoric-cli/src/deploy.js
@@ -326,7 +326,10 @@ export default async function deployMain(progname, rawArgs, powers, opts) {
             const fileName = paths.pop();
             try {
               return require.resolve(fileName, {
-                paths: [...paths, path.dirname(moduleFile)],
+                paths: [
+                  path.resolve(path.dirname(moduleFile), ...paths),
+                  path.dirname(moduleFile),
+                ],
               });
             } catch (e) {
               return path.resolve(path.dirname(moduleFile), ...paths, fileName);

--- a/packages/deploy-script-support/src/extract-proposal.js
+++ b/packages/deploy-script-support/src/extract-proposal.js
@@ -10,7 +10,7 @@ import {
 
 const { details: X, Fail } = assert;
 
-const require = createRequire(import.meta.url);
+const req = createRequire(import.meta.url);
 
 /**
  * @param {(ModuleSpecifier | FilePath)[]} paths
@@ -21,7 +21,7 @@ const pathResolve = (...paths) => {
   const fileName = paths.pop();
   assert(fileName, '>=1 paths required');
   try {
-    return require.resolve(fileName, {
+    return req.resolve(fileName, {
       paths,
     });
   } catch (e) {

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -53,7 +53,7 @@ then
   cd /usr/src/testnet-load-generator
   SOLO_COINS=40000000000uist \
     "$AG_SETUP_COSMOS_HOME/faucet-helper.sh" add-egress loadgen "$SOLO_ADDR"
-  SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
+  SDK_BUILD=0 MUST_USE_PUBLISH_BUNDLE=1 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
     --stage.save-storage --trace kvstore swingstore xsnap \
     --stages=3 --stage.duration=10 --stage.loadgen.cycles=4 \
     --stage.loadgen.vault.interval=12 --stage.loadgen.vault.limit=2 \

--- a/packages/internal/src/createBundles.js
+++ b/packages/internal/src/createBundles.js
@@ -3,10 +3,10 @@ import { spawnSync } from 'child_process';
 import { createRequire } from 'module';
 
 const BUNDLE_SOURCE_PROGRAM = 'bundle-source';
-const require = createRequire(import.meta.url);
+const req = createRequire(import.meta.url);
 
 export const createBundlesFromAbsolute = async sourceBundles => {
-  const prog = require.resolve(`.bin/${BUNDLE_SOURCE_PROGRAM}`);
+  const prog = req.resolve(`.bin/${BUNDLE_SOURCE_PROGRAM}`);
 
   const cacheToArgs = new Map();
   for (const [srcPath, bundlePath] of sourceBundles) {
@@ -35,7 +35,7 @@ export const createBundlesFromAbsolute = async sourceBundles => {
 
 export const createBundles = async (sourceBundles, dirname = '.') => {
   const absBundleSources = sourceBundles.map(([srcPath, bundlePath]) => [
-    require.resolve(srcPath, { paths: [dirname] }),
+    req.resolve(srcPath, { paths: [dirname] }),
     path.resolve(dirname, bundlePath),
   ]);
   return createBundlesFromAbsolute(absBundleSources);
@@ -54,7 +54,7 @@ export const extractProposalBundles = async (
       const install = async (src, bundleName) => {
         if (bundleName) {
           const bundlePath = path.resolve(home, bundleName);
-          const srcPath = require.resolve(src, { paths: [home] });
+          const srcPath = req.resolve(src, { paths: [home] });
           if (toBundle.has(bundlePath)) {
             const oldSrc = toBundle.get(bundlePath);
             assert.equal(

--- a/patches/@endo+static-module-record+0.7.15.patch
+++ b/patches/@endo+static-module-record+0.7.15.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@endo/static-module-record/src/transformSource.js b/node_modules/@endo/static-module-record/src/transformSource.js
+index cba7f8e..3a814d9 100644
+--- a/node_modules/@endo/static-module-record/src/transformSource.js
++++ b/node_modules/@endo/static-module-record/src/transformSource.js
+@@ -1,7 +1,7 @@
+ import * as babelParser from '@babel/parser';
+ import babelGenerate from '@agoric/babel-generator';
+ import babelTraverse from '@babel/traverse';
+-import babelTypes from '@babel/types';
++import * as babelTypes from '@babel/types';
+ 
+ const parseBabel = babelParser.default
+   ? babelParser.default.parse


### PR DESCRIPTION
refs: https://github.com/Agoric/testnet-load-generator/pull/85
refs: #6826 

## Description

This makes the `deploy-script-support` RESM compatible as needed for the loadgen which hasn't converted for backwards compatibility.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Manually ran the updated loadgen, against this branch
