### PR TITLE
6765 publish vaultManager's price feed

### DIFF
--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -5,7 +5,7 @@ export const IssuerShape = M.remotable('Issuer');
 export const PaymentShape = M.remotable('Payment');
 export const PurseShape = M.remotable('Purse');
 export const DepositFacetShape = M.remotable('DepositFacet');
-const NotifierShape = M.remotable('Notifier');
+export const NotifierShape = M.remotable('Notifier');
 export const MintShape = M.remotable('Mint');
 
 /**

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -184,22 +184,23 @@ harden(provideEmptySeat);
  *
  * @param {import('@agoric/vat-data').Baggage} baggage
  * @param {string} category diagnostic tag
- * @returns {import('@agoric/vat-data').Baggage}
  */
 export const provideChildBaggage = (baggage, category) => {
   const baggageSet = provideDurableSetStore(baggage, `${category}Set`);
   return Far('childBaggageManager', {
+    // TODO(types) infer args
     /**
-     * @template {(baggage: import('@agoric/ertp').Baggage) => any} M Maker function
+     * @template {(baggage: import('@agoric/ertp').Baggage, ...rest: any) => any} M Maker function
      * @param {string} childName diagnostic tag
      * @param {M} makeChild
+     * @param {...any} nonBaggageArgs
      * @returns {ReturnType<M>}
      */
-    addChild: (childName, makeChild) => {
+    addChild: (childName, makeChild, ...nonBaggageArgs) => {
       const childStore = makeScalarBigMapStore(`${childName}${category}`, {
         durable: true,
       });
-      const result = makeChild(childStore);
+      const result = makeChild(childStore, ...nonBaggageArgs);
       baggageSet.add(childStore);
       return result;
     },
@@ -207,3 +208,4 @@ export const provideChildBaggage = (baggage, category) => {
   });
 };
 harden(provideChildBaggage);
+/** @typedef {ReturnType<typeof provideChildBaggage>} ChildBaggageManager */

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -43,7 +43,7 @@ const { details: X, quote: q, Fail } = assert;
 /** @typedef {{
  * debtMint: ZCFMint<'nat'>,
  * directorParamManager: import('@agoric/governance/src/contractGovernance/typedParamManager').TypedParamManager<import('./params.js').VaultDirectorParams>,
- * managerBaggages: *,
+ * managerBaggages: import('../contractSupport.js').ChildBaggageManager,
  * marshaller: ERef<Marshaller>,
  * shortfallReporter: import('../reserve/assetReserve.js').ShortfallReporter,
  * storedMetricsSubscriber: StoredSubscriber<MetricsNotification>,
@@ -472,19 +472,16 @@ const makeVaultDirector = defineDurableExoClassKit(
         const makeVaultManager = managerBaggages.addChild(
           brandName,
           prepareVaultManagerKit,
-        );
-
-        const { self: vm } = makeVaultManager(
           zcf,
           debtMint,
           collateralBrand,
-          zcf.getTerms().priceAuthority,
           factoryPowers,
-          timerService,
           startTimeStamp,
           managerStorageNode,
-          ephemera.marshaller,
+          marshaller,
         );
+
+        const { self: vm } = makeVaultManager();
         collateralTypes.init(collateralBrand, vm);
         const { install, terms } = getLiquidationConfig(directorParamManager);
         await vm.setupLiquidator(install, terms);

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -27,6 +27,7 @@ import {
   makeScalarBigMapStore,
 } from '@agoric/vat-data';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
+import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import {
   CHARGING_PERIOD_KEY,
@@ -469,12 +470,15 @@ const makeVaultDirector = defineDurableExoClassKit(
         const { managerBaggages } = ephemera;
         // alleged okay because used only as a diagnostic tag
         const brandName = await E(collateralBrand).getAllegedName();
+        const collateralUnit = await unitAmount(collateralBrand);
+
         const makeVaultManager = managerBaggages.addChild(
           brandName,
           prepareVaultManagerKit,
           zcf,
           debtMint,
           collateralBrand,
+          collateralUnit,
           factoryPowers,
           startTimeStamp,
           managerStorageNode,

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -134,61 +134,40 @@ const trace = makeTracer('VM', false);
  * using a proxy for the manager object, collateralBrand.
  *
  * @type {(collateralBrand: Brand) => Partial<{
- * factoryPowers: import('./vaultDirector.js').FactoryPowersFacet?,
  * liquidationQueueing: boolean,
  * outstandingQuote: Promise<MutableQuote>?,
- * marshaller: ERef<Marshaller>,
  * periodNotifier: ERef<Notifier<Timestamp>>,
- * priceAuthority: ERef<PriceAuthority>,
  * prioritizedVaults: ReturnType<typeof makePrioritizedVaults>,
  * storedAssetSubscriber: StoredSubscriber<AssetState>,
  * storedMetricsSubscriber: StoredSubscriber<MetricsNotification>,
- * storageNode: ERef<StorageNode>,
- * zcf: import('./vaultFactory.js').VaultFactoryZCF,
  * }>} */
 const provideEphemera = makeEphemeraProvider(() => ({
   liquidationQueueing: false,
 }));
 
-// XXX type error when destructuring params
-const finish = context => {
-  const {
-    state,
-    facets: { helper },
-  } = context;
-  const { periodNotifier, prioritizedVaults, zcf } = provideEphemera(
-    state.collateralBrand,
-  );
-  assert(periodNotifier && prioritizedVaults && zcf);
-
-  prioritizedVaults.onHigherHighest(() => helper.reschedulePriceCheck());
-
-  // push initial state of metrics
-  helper.updateMetrics();
-
-  void observeNotifier(periodNotifier, {
-    updateState: updateTime =>
-      helper
-        .chargeAllVaults(updateTime, state.poolIncrementSeat)
-        .catch(e =>
-          console.error('🚨 vaultManager failed to charge interest', e),
-        ),
-    fail: reason => {
-      zcf.shutdownWithFailure(
-        assert.error(X`Unable to continue without a timer: ${reason}`),
-      );
-    },
-    finish: done => {
-      zcf.shutdownWithFailure(
-        assert.error(X`Unable to continue without a timer: ${done}`),
-      );
-    },
-  });
-};
-
 // TODO move params of initState here because it's a singleton
 // and remove from State what doesn't need to be stored between upgrades
-export const prepareVaultManagerKit = baggage => {
+/**
+ *
+ * @param {import('@agoric/ertp').Baggage} baggage
+ * @param {import('./vaultFactory.js').VaultFactoryZCF} zcf
+ * @param {ZCFMint<'nat'>} debtMint
+ * @param {Brand<'nat'>} collateralBrand
+ * @param {import('./vaultDirector.js').FactoryPowersFacet} factoryPowers
+ * @param {Timestamp} startTimeStamp
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
+ */
+export const prepareVaultManagerKit = (
+  baggage,
+  zcf,
+  debtMint,
+  collateralBrand,
+  factoryPowers,
+  startTimeStamp,
+  storageNode,
+  marshaller,
+) => {
   const makeVault = prepareVault(baggage);
   const makeVaultManagerMetricsPublishKit = prepareDurablePublishKit(
     baggage,
@@ -199,30 +178,9 @@ export const prepareVaultManagerKit = baggage => {
     'Vault Manager assets',
   );
 
-  /**
-   * Create state for the Vault Manager kind
-   *
-   * @param {import('./vaultFactory.js').VaultFactoryZCF} zcf
-   * @param {ZCFMint<'nat'>} debtMint
-   * @param {Brand<'nat'>} collateralBrand
-   * @param {ERef<PriceAuthority>} priceAuthority
-   * @param {import('./vaultDirector.js').FactoryPowersFacet} factoryPowers
-   * @param {ERef<TimerService>} timerService
-   * @param {Timestamp} startTimeStamp
-   * @param {ERef<StorageNode>} storageNode
-   * @param {ERef<Marshaller>} marshaller
-   */
-  const initState = (
-    zcf,
-    debtMint,
-    collateralBrand,
-    priceAuthority,
-    factoryPowers,
-    timerService,
-    startTimeStamp,
-    storageNode,
-    marshaller,
-  ) => {
+  const { priceAuthority, timerService } = zcf.getTerms();
+
+  const initState = () => {
     assert(
       storageNode && marshaller,
       'VaultManager missing storageNode or marshaller',
@@ -300,15 +258,10 @@ export const prepareVaultManagerKit = baggage => {
 
     const ephemera = provideEphemera(collateralBrand);
     Object.assign(ephemera, {
-      factoryPowers,
-      marshaller,
       periodNotifier,
-      priceAuthority,
       prioritizedVaults: makePrioritizedVaults(unsettledVaults),
       storedAssetSubscriber,
       storedMetricsSubscriber,
-      storageNode,
-      zcf,
     });
 
     /** @type {MutableState & ImmutableState} */
@@ -383,8 +336,6 @@ export const prepareVaultManagerKit = baggage => {
     {
       collateral: {
         makeVaultInvitation() {
-          const { zcf } = provideEphemera(this.state.collateralBrand);
-          assert(zcf);
           return zcf.makeInvitation(
             seat => this.facets.self.makeVaultKit(seat),
             'MakeVault',
@@ -420,8 +371,6 @@ export const prepareVaultManagerKit = baggage => {
           trace('chargeAllVaults', state.collateralBrand, {
             updateTime,
           });
-          const { factoryPowers } = provideEphemera(state.collateralBrand);
-          assert(factoryPowers);
 
           const interestRate = factoryPowers
             .getGovernedParams()
@@ -465,9 +414,7 @@ export const prepareVaultManagerKit = baggage => {
 
         assetNotify() {
           const { state } = this;
-          const ephemera = provideEphemera(state.collateralBrand);
-          assert(ephemera.factoryPowers);
-          const interestRate = ephemera.factoryPowers
+          const interestRate = factoryPowers
             .getGovernedParams()
             .getInterestRate();
           /** @type {AssetState} */
@@ -530,7 +477,7 @@ export const prepareVaultManagerKit = baggage => {
           const { prioritizedVaults, ...ephemera } = provideEphemera(
             state.collateralBrand,
           );
-          assert(ephemera.factoryPowers && prioritizedVaults);
+          assert(prioritizedVaults);
           trace('reschedulePriceCheck', state.collateralBrand, ephemera);
           // INTERLOCK: the first time through, start the activity to wait for
           // and process liquidations over time.
@@ -561,7 +508,7 @@ export const prepareVaultManagerKit = baggage => {
           // There is already an activity processing liquidations. It may be
           // waiting for the oracle price to cross a threshold.
           // Update the current in-progress quote.
-          const govParams = ephemera.factoryPowers.getGovernedParams();
+          const govParams = factoryPowers.getGovernedParams();
           const liquidationMargin = govParams.getLiquidationMargin();
           // Safe to call extraneously (lightweight and idempotent)
           updateQuote(
@@ -577,9 +524,7 @@ export const prepareVaultManagerKit = baggage => {
           const { prioritizedVaults, ...ephemera } = provideEphemera(
             state.collateralBrand,
           );
-          assert(ephemera.factoryPowers && ephemera.priceAuthority);
-          const { priceAuthority } = ephemera;
-          const govParams = ephemera.factoryPowers.getGovernedParams();
+          const govParams = factoryPowers.getGovernedParams();
 
           async function* eventualLiquidations() {
             assert(prioritizedVaults);
@@ -643,9 +588,7 @@ export const prepareVaultManagerKit = baggage => {
          */
         liquidateAndRemove([key, vault]) {
           const { state, facets } = this;
-          const { factoryPowers, prioritizedVaults, zcf } = provideEphemera(
-            state.collateralBrand,
-          );
+          const { prioritizedVaults } = provideEphemera(state.collateralBrand);
           assert(factoryPowers && prioritizedVaults && zcf);
           const vaultSeat = vault.getVaultSeat();
           trace('liquidating', state.collateralBrand, vaultSeat.getProposal());
@@ -737,10 +680,7 @@ export const prepareVaultManagerKit = baggage => {
       },
       manager: {
         getGovernedParams() {
-          const { state } = this;
-          const ephemera = provideEphemera(state.collateralBrand);
-          assert(ephemera.factoryPowers);
-          return ephemera.factoryPowers.getGovernedParams();
+          return factoryPowers.getGovernedParams();
         },
 
         /**
@@ -750,10 +690,7 @@ export const prepareVaultManagerKit = baggage => {
           trace('maxDebtFor', collateralAmount);
           const { state } = this;
           const { debtBrand } = state;
-          const { priceAuthority, ...ephemera } = provideEphemera(
-            state.collateralBrand,
-          );
-          assert(ephemera.factoryPowers && priceAuthority);
+          assert(factoryPowers && priceAuthority);
           const quoteAmount = await E(priceAuthority).quoteGiven(
             collateralAmount,
             debtBrand,
@@ -762,7 +699,7 @@ export const prepareVaultManagerKit = baggage => {
           // floorDivide because we want the debt ceiling lower
           return floorDivideBy(
             getAmountOut(quoteAmount),
-            ephemera.factoryPowers.getGovernedParams().getLiquidationMargin(),
+            factoryPowers.getGovernedParams().getLiquidationMargin(),
           );
         },
         /**
@@ -778,8 +715,6 @@ export const prepareVaultManagerKit = baggage => {
         mintAndReallocate(toMint, fee, seat, ...otherSeats) {
           const { state } = this;
           const { totalDebt } = state;
-          const { factoryPowers } = provideEphemera(state.collateralBrand);
-          assert(factoryPowers);
 
           checkDebtLimit(
             factoryPowers.getGovernedParams().getDebtLimit(),
@@ -795,8 +730,6 @@ export const prepareVaultManagerKit = baggage => {
          */
         burnAndRecord(toBurn, seat) {
           const { state } = this;
-          const { factoryPowers } = provideEphemera(state.collateralBrand);
-          assert(factoryPowers);
           trace('burnAndRecord', state.collateralBrand, {
             toBurn,
             totalDebt: state.totalDebt,
@@ -897,9 +830,6 @@ export const prepareVaultManagerKit = baggage => {
       },
       self: {
         getGovernedParams() {
-          const { state } = this;
-          const { factoryPowers } = provideEphemera(state.collateralBrand);
-          assert(factoryPowers);
           return factoryPowers.getGovernedParams();
         },
 
@@ -929,8 +859,7 @@ export const prepareVaultManagerKit = baggage => {
             state,
             facets: { manager },
           } = this;
-          const { marshaller, prioritizedVaults, storageNode, zcf } =
-            provideEphemera(state.collateralBrand);
+          const { prioritizedVaults } = provideEphemera(state.collateralBrand);
           assert(marshaller, 'makeVaultKit missing marshaller');
           assert(prioritizedVaults, 'makeVaultKit missing prioritizedVaults');
           assert(storageNode, 'makeVaultKit missing storageNode');
@@ -1005,15 +934,8 @@ export const prepareVaultManagerKit = baggage => {
          */
         async setupLiquidator(liquidationInstall, liquidationTerms) {
           const { state, facets } = this;
-          const { zcf } = provideEphemera(state.collateralBrand);
-          assert(zcf);
-          const { debtBrand, collateralBrand } = state;
-          const {
-            ammPublicFacet,
-            priceAuthority,
-            reservePublicFacet,
-            timerService,
-          } = zcf.getTerms();
+          const { debtBrand } = state;
+          const { ammPublicFacet, reservePublicFacet } = zcf.getTerms();
           const zoe = zcf.getZoeService();
           const collateralIssuer = zcf.getIssuerForBrand(collateralBrand);
           const debtIssuer = zcf.getIssuerForBrand(debtBrand);
@@ -1047,8 +969,6 @@ export const prepareVaultManagerKit = baggage => {
 
         async getCollateralQuote() {
           const { state } = this;
-          const { priceAuthority } = provideEphemera(state.collateralBrand);
-          assert(priceAuthority);
 
           const { debtBrand } = state;
           // get a quote for one unit of the collateral
@@ -1062,7 +982,41 @@ export const prepareVaultManagerKit = baggage => {
       },
     },
     {
-      finish,
+      // XXX type error when destructuring params
+      finish: context => {
+        const {
+          state,
+          facets: { helper },
+        } = context;
+        const { periodNotifier, prioritizedVaults } = provideEphemera(
+          state.collateralBrand,
+        );
+        assert(periodNotifier && prioritizedVaults && zcf);
+
+        prioritizedVaults.onHigherHighest(() => helper.reschedulePriceCheck());
+
+        // push initial state of metrics
+        helper.updateMetrics();
+
+        void observeNotifier(periodNotifier, {
+          updateState: updateTime =>
+            helper
+              .chargeAllVaults(updateTime, state.poolIncrementSeat)
+              .catch(e =>
+                console.error('🚨 vaultManager failed to charge interest', e),
+              ),
+          fail: reason => {
+            zcf.shutdownWithFailure(
+              assert.error(X`Unable to continue without a timer: ${reason}`),
+            );
+          },
+          finish: done => {
+            zcf.shutdownWithFailure(
+              assert.error(X`Unable to continue without a timer: ${done}`),
+            );
+          },
+        });
+      },
     },
   );
 };

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -38,7 +38,6 @@ import {
   makeRatio,
   makeRatioFromAmounts,
 } from '@agoric/zoe/src/contractSupport/index.js';
-import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
 import { InstallationShape, SeatShape } from '@agoric/zoe/src/typeGuards.js';
 import { E } from '@endo/eventual-send';
 import { checkDebtLimit, makeEphemeraProvider } from '../contractSupport.js';
@@ -153,6 +152,7 @@ const provideEphemera = makeEphemeraProvider(() => ({
  * @param {import('./vaultFactory.js').VaultFactoryZCF} zcf
  * @param {ZCFMint<'nat'>} debtMint
  * @param {Brand<'nat'>} collateralBrand
+ * @param {Amount<'nat'>} collateralUnit
  * @param {import('./vaultDirector.js').FactoryPowersFacet} factoryPowers
  * @param {Timestamp} startTimeStamp
  * @param {ERef<StorageNode>} storageNode
@@ -163,6 +163,7 @@ export const prepareVaultManagerKit = (
   zcf,
   debtMint,
   collateralBrand,
+  collateralUnit,
   factoryPowers,
   startTimeStamp,
   storageNode,
@@ -972,7 +973,6 @@ export const prepareVaultManagerKit = (
 
           const { debtBrand } = state;
           // get a quote for one unit of the collateral
-          const collateralUnit = await unitAmount(state.collateralBrand);
           return E(priceAuthority).quoteGiven(collateralUnit, debtBrand);
         },
 

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -503,6 +503,7 @@ export const makeManagerDriver = async (
         t.like(payouts, expected);
       }
     },
+    /** @param {Amount<'nat'>} p */
     setPrice: p => priceAuthority.setPrice(makeRatioFromAmounts(p, priceBase)),
     setGovernedParam: async (name, newValue) => {
       const deadline = 3n;

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -152,3 +152,19 @@ export async function makeStorageNodeChild(storageNodeRef, childName) {
   return E(storageNode).makeChildNode(childName);
 }
 harden(makeStorageNodeChild);
+
+/**
+ *
+ * @param {import('@endo/far').ERef<StorageNode>} storageNode
+ * @param {import('@endo/far').ERef<Marshaller>} marshaller
+ * @returns {(value: unknown) => Promise<void>}
+ */
+export const makeMarshallToStorage = (storageNode, marshaller) => {
+  return value =>
+    E(marshaller)
+      .serialize(value)
+      .then(serialized => {
+        const encoded = JSON.stringify(serialized);
+        return E(storageNode).setValue(encoded);
+      });
+};

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -23,3 +23,4 @@ export {
   makeAsyncIterableFromNotifier,
 } from './asyncIterableAdaptor.js';
 export * from './storesub.js';
+export * from './stored-notifier.js';

--- a/packages/notifier/src/stored-notifier.js
+++ b/packages/notifier/src/stored-notifier.js
@@ -1,0 +1,55 @@
+import { assertAllDefined } from '@agoric/internal';
+import { makeMarshallToStorage } from '@agoric/internal/src/lib-chainStorage.js';
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+import { observeNotifier } from './asyncIterableAdaptor.js';
+
+/**
+ * @template T
+ * @typedef {BaseNotifier<T> & Omit<StoredFacet, 'getStoreKey'>} StoredNotifier
+ */
+
+/**
+ * Begin iterating the source, storing serialized iteration values.  If the
+ * storageNode's `setValue` operation rejects, no further writes to it will
+ * be attempted (but results will remain available from the subscriber).
+ *
+ * Returns a StoredNotifier that can be used by a client to directly follow
+ * the iteration themselves, or obtain information to subscribe to the stored
+ * data out-of-band.
+ *
+ * @template T
+ * @param {ERef<Notifier<T>>} notifier
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<Marshaller>} marshaller
+ * @returns {StoredNotifier<T>}
+ */
+export const makeStoredNotifier = (notifier, storageNode, marshaller) => {
+  assertAllDefined({ notifier, storageNode, marshaller });
+
+  const marshallToStorage = makeMarshallToStorage(storageNode, marshaller);
+
+  observeNotifier(notifier, {
+    updateState(value) {
+      marshallToStorage(value).catch(reason =>
+        console.error('StoredNotifier failed to updateState', reason),
+      );
+    },
+    fail(reason) {
+      console.error('StoredNotifier failed to iterate', reason);
+    },
+  });
+
+  /** @type {Unserializer} */
+  const unserializer = Far('unserializer', {
+    unserialize: data => E(marshaller).unserialize(data),
+  });
+
+  /** @type {StoredNotifier<T>} */
+  const storedNotifier = Far('StoredNotifier', {
+    getUpdateSince: updateCount => E(notifier).getUpdateSince(updateCount),
+    getPath: () => E(storageNode).getPath(),
+    getUnserializer: () => unserializer,
+  });
+  return storedNotifier;
+};


### PR DESCRIPTION
closes: #6765

## Description

This makes the VaultManager publish changes to its price feed. The PriceAuthority returns a Notifier so this adds a `makeStoredNotifier` to pipe the prices to vstorage. I considered just having an `observeNotifier` but we have a commitment that a contract consumer can do its work without reading vstorage. So we need to continue the StoredFacet pattern that exposes a `getPath()`. I dropped `getStoreKey` though since that's deprecated.

In the course of making these changes, I need a `collateralUnit` during initState and getting it requires an await, which initState can't do. Since vaultManager is a singleton kind, it can be passed into `prepareVaultManager` and exist in closure. So this also has a refactor to move many initState params up to that prepare. cc @dtribble as it introduces arguments to `addChildBaggage`.

_Best reviewed by commit._

### Security Considerations

Similar to the scaling considerations, wrt undue load.

### Scaling Considerations

This exposes a Notifier on VaultManager ~which means that anyone can ask for a price _since_ any updateCount~. Not so, explains @michaelfig below,
> A Notifier only keeps the latest state, and all historical states are dropped. The updateCount cannot be used to index into past states, it is only used for the Notifier implementation to determine if the consumer needs to wait for the next value from the producer, or if the latest state is good enough.

### Documentation Considerations

The list of storage nodes published by VaultFactory should be updated. Deferring to https://github.com/Agoric/agoric-sdk/issues/6111

### Testing Considerations

New test. No need to test the vstorage writes per se.