### PR TITLE
feat(notifier)!: housecleaning

### DIFF
--- a/packages/SwingSet/test/metering/vat-load-dynamic.js
+++ b/packages/SwingSet/test/metering/vat-load-dynamic.js
@@ -5,6 +5,7 @@ export function buildRootObject(vatPowers) {
   const { testLog: log } = vatPowers;
   let service;
   let control;
+  const notifierToUpdateCount = new WeakMap();
 
   return Far('root', {
     async bootstrap(vats, devices) {
@@ -33,8 +34,11 @@ export function buildRootObject(vatPowers) {
 
     async whenMeterNotifiesNext(meter) {
       const notifier = await E(meter).getNotifier();
-      const initial = await E(notifier).getUpdateSince();
-      return E(notifier).getUpdateSince(initial);
+      const update = await E(notifier).getUpdateSince(
+        notifierToUpdateCount.get(notifier),
+      );
+      notifierToUpdateCount.set(notifier, update.updateCount);
+      return update;
     },
 
     async createVat(name, dynamicOptions) {

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -33,7 +33,7 @@ if (globalAssert === undefined) {
   );
 }
 
-const missing = [
+const missing = /** @type {const} */ ([
   'fail',
   'equal',
   'typeof',
@@ -43,7 +43,7 @@ const missing = [
   'Fail',
   'quote',
   'makeAssert',
-].filter(name => globalAssert[name] === undefined);
+]).filter(name => globalAssert[name] === undefined);
 if (missing.length > 0) {
   throw new Error(
     `Cannot initialize @agoric/assert, missing globalThis.assert methods ${missing.join(

--- a/packages/casting/src/follower.js
+++ b/packages/casting/src/follower.js
@@ -1,8 +1,8 @@
 import { Far } from '@endo/far';
 import {
   mapAsyncIterable,
-  makeNotifierIterable,
-  makeSubscriptionIterable,
+  subscribeEach,
+  subscribeLatest,
 } from './iterable.js';
 import { makeCosmjsFollower } from './follower-cosmjs.js';
 import { makeCastingSpec } from './casting-spec.js';
@@ -20,10 +20,10 @@ const makeSubscriptionFollower = spec => {
       const { notifier, subscription } = await spec;
       let ai;
       if (notifier) {
-        ai = makeNotifierIterable(notifier);
+        ai = subscribeLatest(notifier);
       } else {
         assert(subscription);
-        ai = makeSubscriptionIterable(subscription);
+        ai = subscribeEach(subscription);
       }
       return mapAsyncIterable(ai, transform);
     },
@@ -32,10 +32,10 @@ const makeSubscriptionFollower = spec => {
       const { notifier, subscription } = await spec;
       let ai;
       if (subscription) {
-        ai = makeSubscriptionIterable(subscription);
+        ai = subscribeEach(subscription);
       } else {
         assert(notifier);
-        ai = makeNotifierIterable(notifier);
+        ai = subscribeLatest(notifier);
       }
       return mapAsyncIterable(ai, transform);
     },

--- a/packages/casting/src/iterable.js
+++ b/packages/casting/src/iterable.js
@@ -1,47 +1,6 @@
 import { E, Far } from '@endo/far';
-import { makeNotifier } from '@agoric/notifier';
 
-/**
- * @template T
- * @param {ERef<Notifier<T>>} notifier
- * @returns {ConsistentAsyncIterable<T>}
- */
-export const makeNotifierIterable = notifier =>
-  makeNotifier(E(notifier).getSharableNotifierInternals());
-
-/**
- * TODO: Remove this function when we have an @endo/publish-kit that suppports pull topics
- *
- * @template T
- * @param {ERef<PublicationRecord<T>>} tailP
- * @returns {AsyncIterator<T>}
- */
-const makeSubscriptionIterator = tailP => {
-  // To understand the implementation, start with
-  // https://web.archive.org/web/20160404122250/http://wiki.ecmascript.org/doku.php?id=strawman:concurrency#infinite_queue
-  return Far('SubscriptionIterator', {
-    next: async () => {
-      const resultP = E.get(tailP).head;
-      tailP = E.get(tailP).tail;
-      return resultP;
-    },
-  });
-};
-
-/**
- * TODO: Remove this function when we have an @endo/publish-kit that suppports pull topics
- *
- * @template T
- * @param {ERef<Subscription<T>>} subscription
- * @returns {ConsistentAsyncIterable<T>}
- */
-export const makeSubscriptionIterable = subscription =>
-  harden({
-    [Symbol.asyncIterator]: () =>
-      makeSubscriptionIterator(
-        E(subscription).getSharableSubscriptionInternals(),
-      ),
-  });
+export { subscribeEach, subscribeLatest } from '@agoric/notifier/subscribe.js';
 
 /**
  * @template TIn

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -1,6 +1,5 @@
 import { AmountMath, AmountShape } from '@agoric/ertp';
-import { makeTracer } from '@agoric/internal';
-import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
+import { makeTracer, makeTypeGuards } from '@agoric/internal';
 import { M, prepareExoClassKit } from '@agoric/vat-data';
 import {
   assertProposalShape,
@@ -18,6 +17,8 @@ import '@agoric/zoe/exported.js';
 import { calculateLoanCosts } from './math.js';
 
 const { quote: q, Fail } = assert;
+
+const { StorageNodeShape } = makeTypeGuards(M);
 
 const trace = makeTracer('IV', false);
 

--- a/packages/inter-protocol/test/metrics.js
+++ b/packages/inter-protocol/test/metrics.js
@@ -10,9 +10,9 @@ import { makeTracer } from '@agoric/internal';
 const trace = makeTracer('TestMetrics', false);
 
 /**
- * @param {import('ava').ExecutionContext} t
- * @param {ConsistentAsyncIterable<N>} subscription
  * @template {object} N
+ * @param {import('ava').ExecutionContext} t
+ * @param {AsyncIterable<N, N>} subscription
  */
 export const subscriptionTracker = async (t, subscription) => {
   const metrics = makeNotifierFromAsyncIterable(subscription);
@@ -44,9 +44,9 @@ export const subscriptionTracker = async (t, subscription) => {
 /**
  * For public facets that have a `getMetrics` method.
  *
- * @param {import('ava').ExecutionContext} t
- * @param {ERef<{getMetrics?: () => Subscriber<unknown>}>} publicFacet
  * @template {object} N
+ * @param {import('ava').ExecutionContext} t
+ * @param {ERef<{getMetrics?: () => Subscriber<N>}>} publicFacet
  */
 export const metricsTracker = async (t, publicFacet) => {
   const metricsSub = await E(publicFacet).getMetrics();

--- a/packages/internal/src/index.js
+++ b/packages/internal/src/index.js
@@ -4,3 +4,4 @@ export * from './config.js';
 export * from './debug.js';
 export * from './utils.js';
 export * from './method-tools.js';
+export * from './typeGuards.js';

--- a/packages/internal/src/typeGuards.js
+++ b/packages/internal/src/typeGuards.js
@@ -1,0 +1,8 @@
+/**
+ * @param {typeof import('@agoric/store').M} M
+ */
+export const makeTypeGuards = M =>
+  harden({
+    StorageNodeShape: M.remotable('StorageNode'),
+  });
+harden(makeTypeGuards);

--- a/packages/notifier/exports.js
+++ b/packages/notifier/exports.js
@@ -1,5 +1,0 @@
-// TODO: Remove this file when all our clients are known to be updated.
-export * from './exported.js';
-console.warn(
-  `DEPRECATION: '@agoric/notifier/exports' is deprecated in favour of '@agoric/notifier/exported.js'`,
-);

--- a/packages/notifier/jsconfig.json
+++ b/packages/notifier/jsconfig.json
@@ -3,6 +3,7 @@
   "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.js",
+    "*.js",
     "test/**/*.js",
     "tools/**/*.js",
   ],

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -49,10 +49,16 @@
     "ava": "^5.1.0",
     "c8": "^7.12.0"
   },
+  "exports": {
+    ".": "./src/index.js",
+    "./exported.js": "./exported.js",
+    "./subscribe.js": "./subscribe.js",
+    "./tools/testSupports.js": "./tools/testSupports.js"
+  },
   "files": [
     "src/",
-    "tools",
-    "exported.js",
+    "tools/",
+    "*.js",
     "NEWS.md"
   ],
   "eslintIgnore": [

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -39,7 +39,7 @@
     "@agoric/swingset-vat": "^0.30.2",
     "@agoric/swing-store": "^0.8.1",
     "@agoric/vat-data": "^0.4.3",
-    "@endo/eventual-send": "^0.16.8",
+    "@endo/far": "^0.2.14",
     "@endo/marshal": "^0.8.1",
     "@endo/promise-kit": "^0.2.52"
   },

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -1,7 +1,6 @@
 /// <reference types="ses"/>
 
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { E, Far } from '@endo/far';
 
 import './types-ambient.js';
 

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -1,12 +1,12 @@
 /// <reference types="ses"/>
 
 import { E } from '@endo/far';
-import { subscribeLatest } from '../tools/subscribe.js';
+import { subscribeLatest } from './subscribe.js';
 
 import './types-ambient.js';
 
 /**
- * @deprecated Use `subscribeLatest` from `@agoric/notifier/tools/subscribe.js` instead.
+ * @deprecated Use `subscribeLatest` from `@agoric/notifier/subscribe.js` instead.
  *
  * Adaptor from a notifierP to an async iterable.
  * The notifierP can be any object that has an eventually invocable

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -1,10 +1,9 @@
 export {
   makePublishKit,
-  subscribeEach,
-  subscribeLatest,
   prepareDurablePublishKit,
   SubscriberShape,
 } from './publish-kit.js';
+export { subscribeEach, subscribeLatest } from '../tools/subscribe.js';
 export {
   makeNotifier,
   makeNotifierKit,
@@ -16,10 +15,7 @@ export {
   observeNotifier,
   observeIterator,
   observeIteration,
-  // deprecated. Consider not reexporting
-  updateFromIterable,
-  updateFromNotifier,
-  // Consider deprecating or not reexporting
+  // deprecated, consider removing
   makeAsyncIterableFromNotifier,
 } from './asyncIterableAdaptor.js';
 export * from './storesub.js';

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -3,7 +3,7 @@ export {
   prepareDurablePublishKit,
   SubscriberShape,
 } from './publish-kit.js';
-export { subscribeEach, subscribeLatest } from '../tools/subscribe.js';
+export { subscribeEach, subscribeLatest } from './subscribe.js';
 export {
   makeNotifier,
   makeNotifierKit,

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -5,7 +5,7 @@ import { E, Far } from '@endo/far';
 
 import './types-ambient.js';
 import { makePublishKit } from './publish-kit.js';
-import { subscribeLatest } from '../tools/subscribe.js';
+import { subscribeLatest } from './subscribe.js';
 
 /**
  * @template T

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -2,9 +2,8 @@
 
 import { assert } from '@agoric/assert';
 import { makePromiseKit } from '@endo/promise-kit';
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
 import { makeAsyncIterableFromNotifier } from './asyncIterableAdaptor.js';
+import { E, Far } from '@endo/far';
 
 import './types-ambient.js';
 

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -2,7 +2,7 @@
 
 import { HandledPromise, E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { M } from '@agoric/store';
 import { canBeDurable, prepareExoClassKit } from '@agoric/vat-data';
 

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -1,8 +1,7 @@
 /// <reference types="ses"/>
 
-import { HandledPromise, E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/far';
+import { E, Far } from '@endo/far';
 import { M } from '@agoric/store';
 import { canBeDurable, prepareExoClassKit } from '@agoric/vat-data';
 
@@ -12,116 +11,64 @@ const { Fail, quote: q } = assert;
 
 const sink = () => {};
 const makeQuietRejection = reason => {
-  const rejection = HandledPromise.reject(reason);
+  const rejection = harden(Promise.reject(reason));
   void E.when(rejection, sink, sink);
-  return harden(rejection);
+  return rejection;
 };
-
-/**
- * Asyncronously iterates over the contents of a PublicationList as they appear.
- * This iteration must drop parts of publication records that are no longer
- * needed so they can be garbage collected.
- *
- * @template T
- * @param {PublicationList<T>} pubList
- * @returns {AsyncIterator<T>}
- */
-const makeEachIterator = pubList => {
-  // To understand the implementation, start with
-  // https://web.archive.org/web/20160404122250/http://wiki.ecmascript.org/doku.php?id=strawman:concurrency#infinite_queue
-  return Far('EachIterator', {
-    next: () => {
-      const resultP = E.get(pubList).head;
-      pubList = E.get(pubList).tail;
-      // We expect the tail to be the "cannot read past end" error at the end
-      // of the happy path.
-      // Since we are wrapping that error with eventual send, we sink the
-      // rejection here too so it doesn't become an invalid unhandled rejection
-      // later.
-      void E.when(pubList, sink, sink);
-      return resultP;
-    },
-  });
-};
-
-/**
- * Given a local or remote subscriber, returns a local AsyncIterable which
- * provides "prefix lossy" iterations of the underlying PublicationList.
- * By "prefix lossy", we mean that you may miss everything published before
- * you ask the returned iterable for an iterator. But the returned iterator
- * will enumerate each thing published from that iterator's starting point.
- *
- * If the underlying PublicationList is terminated, that terminal value will be
- * reported losslessly.
- *
- * @template T
- * @param {ERef<Subscriber<T>>} subscriber
- * @returns {AsyncIterable<T>}
- */
-export const subscribeEach = subscriber => {
-  const iterable = Far('EachIterable', {
-    [Symbol.asyncIterator]: () => {
-      const pubList = E(subscriber).subscribeAfter();
-      return makeEachIterator(pubList);
-    },
-  });
-  return iterable;
-};
-harden(subscribeEach);
-
-/**
- * @template T
- * @param {ERef<Subscriber<T>>} subscriber
- * @returns {AsyncIterator<T>}
- */
-const makeLatestIterator = subscriber => {
-  let latestPublishCount;
-  return Far('LatestIterator', {
-    next: () => {
-      const pubList = E(subscriber).subscribeAfter(latestPublishCount);
-      // Without an onRejection, if pubList is a rejection, this will
-      // propagate the rejection as it should.
-      return E.when(pubList, ({ head, publishCount }) => {
-        latestPublishCount = publishCount;
-        return head;
-      });
-    },
-  });
-};
-
-/**
- * Given a local or remote subscriber, returns a local AsyncIterable which
- * provides "lossy" iterations of the underlying PublicationList.
- * By "lossy", we mean that you may miss any published state if a more
- * recent published state can be reported instead.
- *
- * If the underlying PublicationList is terminated, that terminal value will be
- * reported losslessly.
- *
- * @template T
- * @param {ERef<Subscriber<T>>} subscriber
- * @returns {AsyncIterable<T>}
- */
-export const subscribeLatest = subscriber => {
-  const iterable = Far('LatestIterable', {
-    [Symbol.asyncIterator]: () => makeLatestIterator(subscriber),
-  });
-  return iterable;
-};
-harden(subscribeLatest);
 
 export const PublisherI = M.interface('Publisher', {
   publish: M.call(M.any()).returns(),
   finish: M.call(M.any()).returns(),
   fail: M.call(M.any()).returns(),
 });
+
+// For backwards compatibility with Notifier `getUpdateSince`.
+export const UpdateCountShape = M.or(M.bigint(), M.number());
 export const SubscriberI = M.interface('Subscriber', {
   subscribeAfter: M.call().optional(M.bigint()).returns(M.promise()),
+  getUpdateSince: M.call().optional(UpdateCountShape).returns(M.promise()),
 });
 export const publishKitIKit = harden({
   publisher: PublisherI,
   subscriber: SubscriberI,
 });
+
+/**
+ * @template {object} Arg
+ * @template Ret
+ * @param {(arg: Arg) => Ret} fn
+ * @returns {(arg: Arg) => Ret}
+ */
+const weakMemoizeUnary = fn => {
+  const cache = new WeakMap();
+  return arg => {
+    /** @type {object} */
+    const oarg = arg;
+    if (cache.has(oarg)) {
+      return cache.get(oarg);
+    }
+    const result = fn(arg);
+    cache.set(oarg, result);
+    return result;
+  };
+};
+
+/**
+ * @template T
+ * @param {PublicationRecord<T>} record
+ * @returns {UpdateRecord<T>}
+ */
+const makeUpdateRecordFromPublicationRecord = record => {
+  const {
+    head: { value, done },
+    publishCount,
+  } = record;
+  if (done) {
+    // Final results have undefined updateCount.
+    return harden({ value, updateCount: undefined });
+  }
+  return harden({ value, updateCount: publishCount });
+};
 
 /**
  * Makes a `{ publisher, subscriber }` pair for doing efficient
@@ -171,6 +118,10 @@ export const makePublishKit = () => {
     }
   };
 
+  const makeMemoizedUpdateRecord = weakMemoizeUnary(
+    makeUpdateRecordFromPublicationRecord,
+  );
+
   /**
    * @template T
    * @type {Subscriber<T>}
@@ -187,6 +138,22 @@ export const makePublishKit = () => {
           'subscribeAfter argument must be a previously-issued publishCount.',
         );
       }
+    },
+    getUpdateSince: updateCount => {
+      if (updateCount === undefined) {
+        return subscriber.subscribeAfter().then(makeMemoizedUpdateRecord);
+      }
+      updateCount = BigInt(updateCount);
+      return (
+        subscriber
+          // `subscribeAfter` may resolve with the update record numbered
+          // `updateCount + 1`, even if several updates are published in the
+          // same crank...
+          .subscribeAfter(updateCount)
+          // ... so we poll the latest published update, without waiting for any
+          // further ones.
+          .then(() => subscriber.getUpdateSince())
+      );
     },
   });
 
@@ -279,7 +246,7 @@ const provideDurablePublishKitEphemeralData = (state, facets) => {
       new Error('Cannot read past end of iteration.'),
     );
     newData = {
-      currentP: HandledPromise.resolve(
+      currentP: E.resolve(
         harden({
           head: { value: state.value, done: true },
           publishCount,
@@ -294,7 +261,7 @@ const provideDurablePublishKitEphemeralData = (state, facets) => {
     void E.when(tailP, sink, sink);
     newData = {
       currentP: state.hasValue
-        ? HandledPromise.resolve(
+        ? E.resolve(
             harden({
               head: { value: state.value, done: false },
               publishCount,
@@ -381,6 +348,10 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
  * @param {string} kindName
  */
 export const prepareDurablePublishKit = (baggage, kindName) => {
+  // TODO: Once we unify with makePublishKit, we will use a Zone-compatible weak
+  // map for memoization.
+  const makeMemoizedUpdateRecord = makeUpdateRecordFromPublicationRecord;
+
   /**
    * @returns {() => PublishKit<*>}
    */
@@ -423,6 +394,25 @@ export const prepareDurablePublishKit = (baggage, kindName) => {
               'subscribeAfter argument must be a previously-issued publishCount.',
             );
           }
+        },
+        getUpdateSince(updateCount) {
+          const {
+            facets: { subscriber },
+          } = this;
+          if (updateCount === undefined) {
+            return subscriber.subscribeAfter().then(makeMemoizedUpdateRecord);
+          }
+          updateCount = BigInt(updateCount);
+          return (
+            subscriber
+              // `subscribeAfter` may resolve with the update record numbered
+              // `updateCount + 1`, even if several updates are published in the
+              // same crank...
+              .subscribeAfter(updateCount)
+              // ... so we poll the latest published update, without waiting for any
+              // further ones.
+              .then(() => subscriber.getUpdateSince())
+          );
         },
       },
     },

--- a/packages/notifier/src/stored-notifier.js
+++ b/packages/notifier/src/stored-notifier.js
@@ -1,7 +1,6 @@
 import { assertAllDefined } from '@agoric/internal';
 import { makeSerializeToStorage } from '@agoric/internal/src/lib-chainStorage.js';
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { E, Far } from '@endo/far';
 import { observeNotifier } from './asyncIterableAdaptor.js';
 
 /**

--- a/packages/notifier/src/stored-topic.js
+++ b/packages/notifier/src/stored-topic.js
@@ -1,7 +1,7 @@
 import { assertAllDefined } from '@agoric/internal';
 import { makeSerializeToStorage } from '@agoric/internal/src/lib-chainStorage.js';
 import { M } from '@agoric/store';
-import { E } from '@endo/eventual-send';
+import { E } from '@endo/far';
 import { SubscriberShape } from './publish-kit.js';
 import { forEachPublicationRecord } from './storesub.js';
 

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -1,5 +1,5 @@
-import { E } from '@endo/eventual-send';
-import { Far, makeMarshal } from '@endo/marshal';
+import { E, Far } from '@endo/far';
+import { makeMarshal } from '@endo/marshal';
 import { assertAllDefined } from '@agoric/internal';
 import { makeSerializeToStorage } from '@agoric/internal/src/lib-chainStorage.js';
 import { observeIteration } from './asyncIterableAdaptor.js';

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -5,7 +5,7 @@ import { makeSerializeToStorage } from '@agoric/internal/src/lib-chainStorage.js
 import { observeIteration } from './asyncIterableAdaptor.js';
 import { makePublishKit } from './publish-kit.js';
 import { makeSubscriptionKit } from './subscriber.js';
-import { subscribeEach } from '../tools/subscribe.js';
+import { subscribeEach } from './subscribe.js';
 
 /**
  * NB: does not yet survive upgrade https://github.com/Agoric/agoric-sdk/issues/6893

--- a/packages/notifier/src/subscribe.js
+++ b/packages/notifier/src/subscribe.js
@@ -1,0 +1,148 @@
+import { E, Far } from '@endo/far';
+
+import '../src/types-ambient.js';
+
+const sink = () => {};
+
+/**
+ * Create a near iterable that corresponds to a potentially far one.
+ *
+ * @template T
+ * @param {ERef<AsyncIterable<T>>} itP
+ * @returns {AsyncIterable<T>}
+ */
+export const subscribe = itP =>
+  Far('AsyncIterable', {
+    [Symbol.asyncIterator]: () => {
+      const it = E(itP)[Symbol.asyncIterator]();
+      return Far('AsyncIterator', {
+        next: async () => E(it).next(),
+      });
+    },
+  });
+
+/**
+ * Asyncronously iterates over the contents of a PublicationList as they appear.
+ * This iteration must drop parts of publication records that are no longer
+ * needed so they can be garbage collected.
+ *
+ * @template T
+ * @param {PublicationList<T>} pubList
+ * @returns {AsyncIterableIterator<T, T>}
+ */
+const makeEachIterator = pubList => {
+  // To understand the implementation, start with
+  // https://web.archive.org/web/20160404122250/http://wiki.ecmascript.org/doku.php?id=strawman:concurrency#infinite_queue
+  return Far('EachIterator', {
+    next: () => {
+      const resultP = E.get(pubList).head;
+      pubList = E.get(pubList).tail;
+      // We expect the tail to be the "cannot read past end" error at the end
+      // of the happy path.
+      // Since we are wrapping that error with eventual send, we sink the
+      // rejection here too so it doesn't become an invalid unhandled rejection
+      // later.
+      void E.when(pubList, sink, sink);
+      return resultP;
+    },
+    [Symbol.asyncIterator]: () => makeEachIterator(pubList),
+  });
+};
+
+/**
+ * Given a local or remote subscriber, returns a local AsyncIterable which
+ * provides "prefix lossy" iterations of the underlying PublicationList.
+ * By "prefix lossy", we mean that you may miss everything published before
+ * you ask the returned iterable for an iterator. But the returned iterator
+ * will enumerate each thing published from that iterator's starting point.
+ *
+ * If the underlying PublicationList is terminated, that terminal value will be
+ * reported losslessly.
+ *
+ * @template T
+ * @param {ERef<EachTopic<T>>} topic
+ */
+export const subscribeEach = topic => {
+  const iterable = Far('EachIterable', {
+    [Symbol.asyncIterator]: () => {
+      const pubList = E(topic).subscribeAfter();
+      return makeEachIterator(pubList);
+    },
+  });
+  return iterable;
+};
+harden(subscribeEach);
+
+/**
+ * @template T
+ * @param {ERef<LatestTopic<T>>} topic
+ * @param {bigint} [localUpdateCount]
+ * @returns {AsyncIterableIterator<T>}
+ */
+const makeLatestIterator = (topic, localUpdateCount) => {
+  let myIterationResultP;
+  return Far('LatestIterator', {
+    [Symbol.asyncIterator]: () => makeLatestIterator(topic, localUpdateCount),
+    next: () => {
+      // In this adaptor, once `next()` is called and returns an
+      // unresolved promise, `myIterationResultP`, and until
+      // `myIterationResultP` is fulfilled with an
+      // iteration result, further `next()` calls will return the same
+      // `myIterationResultP` promise again without asking the notifier
+      // for more updates. If there's already an unanswered ask in the
+      // air, all further asks should just reuse the result of that one.
+      //
+      // This reuse behavior is only needed for code that uses the async
+      // iterator protocol explicitly. When this async iterator is
+      // consumed by a for/await/of loop, `next()` will only be called
+      // after the promise for the previous iteration result has
+      // fulfilled. If it fulfills with `done: true`, the for/await/of
+      // loop will never call `next()` again.
+      //
+      // See
+      // https://2ality.com/2016/10/asynchronous-iteration.html#queuing-next()-invocations
+      // for an explicit use that sends `next()` without waiting.
+      if (myIterationResultP) {
+        return myIterationResultP;
+      }
+
+      myIterationResultP = E(topic)
+        .getUpdateSince(localUpdateCount)
+        .then(({ value, updateCount }) => {
+          localUpdateCount = updateCount;
+          const done = localUpdateCount === undefined;
+          if (!done) {
+            // Once the outstanding question has been answered, stop
+            // using that answer, so any further `next()` questions
+            // cause a new `getUpdateSince` request.
+            //
+            // But only if more answers are expected.  Once the topic
+            // is `done`, that was the last answer so reuse it forever.
+            myIterationResultP = undefined;
+          }
+          return harden({ value, done });
+        });
+      return myIterationResultP;
+    },
+  });
+};
+
+/**
+ * Given a local or remote subscriber, returns a local AsyncIterable which
+ * provides "lossy" iterations of the underlying PublicationList.
+ * By "lossy", we mean that you may miss any published state if a more
+ * recent published state can be reported instead.
+ *
+ * If the underlying PublicationList is terminated, that terminal value will be
+ * reported losslessly.
+ *
+ * @template T
+ * @param {ERef<LatestTopic<T>>} topic
+ */
+export const subscribeLatest = topic => {
+  const iterable = Far('LatestIterable', {
+    [Symbol.asyncIterator]: () => makeLatestIterator(topic),
+  });
+  return iterable;
+};
+harden(subscribeLatest);

--- a/packages/notifier/src/subscribe.js
+++ b/packages/notifier/src/subscribe.js
@@ -9,7 +9,6 @@ const sink = () => {};
  *
  * @template T
  * @param {ERef<AsyncIterable<T>>} itP
- * @returns {AsyncIterable<T>}
  */
 export const subscribe = itP =>
   Far('AsyncIterable', {
@@ -61,7 +60,6 @@ const makeEachIterator = pubList => {
  *
  * @template T
  * @param {ERef<EachTopic<T>>} topic
- * @returns {AsyncIterable<T>}
  */
 export const subscribeEach = topic => {
   const iterable = Far('EachIterable', {
@@ -168,7 +166,6 @@ const makeLatestIterator = topic => cloneLatestIterator(topic);
  *
  * @template T
  * @param {ERef<LatestTopic<T>>} topic
- * @returns {AsyncIterable<T>}
  */
 export const subscribeLatest = topic => {
   const iterable = Far('LatestIterable', {

--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -1,8 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 /// <reference types="ses"/>
 
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { E, Far } from '@endo/far';
 import { makePublishKit } from './publish-kit.js';
 
 import './types-ambient.js';

--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -1,7 +1,7 @@
 /// <reference types="ses"/>
 
 import { E, Far } from '@endo/far';
-import { subscribeEach } from '../tools/subscribe.js';
+import { subscribeEach } from './subscribe.js';
 import { makePublishKit } from './publish-kit.js';
 
 import { makePinnedHistoryTopic } from './topic.js';
@@ -34,11 +34,16 @@ harden(makeSubscription);
 export { makeSubscription };
 
 /**
- * @deprecated Producers should use `const { publisher, subscriber } =
- * makePublishKit(); const topic = makePinnedHistoryTopic(subscriber);`
+ * @deprecated Producers should use
+ * ```js
+ * const { publisher, subscriber } = makePublishKit();
+ * const topic = makePinnedHistoryTopic(subscriber);
+ * ```
  * instead, which makes it clearer that all the subscriber's history is
- * retained, preventing GC.  Potentially remote consumers use `for await (const
- * value of subscribeEach(topic)) { ... }`.
+ * retained, preventing GC.  Potentially remote consumers use
+ * ```js
+ * for await (const value of subscribeEach(topic)) { ... }
+ * ```
  *
  * Makes a `{ publication, subscription }` for doing lossless efficient
  * distributed pub/sub.

--- a/packages/notifier/src/topic.js
+++ b/packages/notifier/src/topic.js
@@ -1,0 +1,32 @@
+import { Far } from '@endo/far';
+import './types-ambient.js';
+
+/**
+ * @deprecated A pinned-history topic preserves all of its published values in
+ * memory.  Use a prefix-lossy makePublishKit instead.
+ *
+ * @template T
+ * @param {EachTopic<T> & LatestTopic<T>} topic needs to be near in order to
+ * preserve subscription timings.  TODO: drop LatestTopic<T> requirement
+ * @returns {EachTopic<T> & LatestTopic<T>}
+ */
+export const makePinnedHistoryTopic = topic => {
+  // Such losslessness inhibits GC, which is why we're moving away from it.
+
+  // We need to take an immediate snapshot of the topic's current state.
+  const pinnedPubList = topic.subscribeAfter();
+
+  return Far('PinnedHistoryTopic', {
+    subscribeAfter: async (publishCount = -1n) => {
+      if (publishCount === -1n) {
+        return pinnedPubList;
+      }
+      return topic.subscribeAfter(publishCount);
+    },
+    getUpdateSince: async (updateCount = undefined) => {
+      // TODO: Build this out of EachTopic<T>.
+      return topic.getUpdateSince(updateCount);
+    },
+  });
+};
+harden(makePinnedHistoryTopic);

--- a/packages/notifier/src/typeGuards.js
+++ b/packages/notifier/src/typeGuards.js
@@ -1,3 +1,0 @@
-import { M } from '@agoric/store';
-
-export const StorageNodeShape = M.remotable('StorageNode');

--- a/packages/notifier/subscribe.js
+++ b/packages/notifier/subscribe.js
@@ -1,0 +1,1 @@
+export * from './src/subscribe.js';

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -1,4 +1,4 @@
-import { E } from '@endo/eventual-send';
+import { E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { observeIteration, observeIterator } from '../src/index.js';
 

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -291,14 +291,14 @@ export const bob = async asyncIterableP => {
  */
 export const carol = async subscriptionP => {
   const subscriptionIteratorP = E(subscriptionP)[Symbol.asyncIterator]();
+  /** @type {PromiseKit<ForkableAsyncIterator<Passable, Passable>>} */
   const { promise: afterA, resolve: afterAResolve } = makePromiseKit();
 
   const makeObserver = log =>
     harden({
       updateState: val => {
         if (val === 'a') {
-          // @ts-expect-error
-          afterAResolve(E(subscriptionIteratorP).subscribe());
+          afterAResolve(E(subscriptionIteratorP).fork());
         }
         log.push(['non-final', val]);
       },
@@ -312,8 +312,7 @@ export const carol = async subscriptionP => {
   const observer2 = makeObserver(log2);
 
   const p1 = observeIterator(subscriptionIteratorP, observer1);
-  // afterA is an ERef<Subscription> so we use observeIteration on it.
-  const p2 = observeIteration(afterA, observer2);
+  const p2 = observeIterator(afterA, observer2);
   await Promise.all([p1, p2]);
   return [log1, log2];
 };

--- a/packages/notifier/test/test-notifier-examples.js
+++ b/packages/notifier/test/test-notifier-examples.js
@@ -1,7 +1,7 @@
 import { test } from './prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { E } from '@endo/eventual-send';
+import { E } from '@endo/far';
 import {
   observeIteration,
   makeNotifierKit,

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -131,10 +131,13 @@ const verifyPublishKit = test.macro(async (t, makePublishKit) => {
   t.false(cells.has(thirdPublishCount), 'third publishCount must be new');
   cells.set(thirdPublishCount, thirdCells[0]);
 
-  // @ts-ignore deliberate testing of invalid invocation
-  t.throws(() => subscriber.subscribeAfter(Number(secondPublishCount)), {
-    message: /bigint/,
-  });
+  t.throws(
+    // @ts-ignore deliberate testing of invalid invocation
+    () => subscriber.subscribeAfter(Number(secondPublishCount)),
+    {
+      message: /bigint/,
+    },
+  );
 
   const fourthVal = { position: 'fourth', deepPayload: [Symbol.match] };
   publisher.publish(fourthVal);

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -3,7 +3,7 @@
 
 import '@agoric/swingset-vat/tools/prepare-test-env.js';
 import test from 'ava';
-import { E } from '@endo/eventual-send';
+import { E } from '@endo/far';
 import {
   buildKernelBundles,
   initializeSwingset,

--- a/packages/notifier/test/test-stored-subscription.js
+++ b/packages/notifier/test/test-stored-subscription.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/order
 import { test } from './prepare-test-env-ava.js';
 
-import { E } from '@endo/eventual-send';
+import { E } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
 import {
   makePublishKit,

--- a/packages/notifier/test/test-subscriber-examples.js
+++ b/packages/notifier/test/test-subscriber-examples.js
@@ -1,7 +1,7 @@
 import { test } from './prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { E } from '@endo/eventual-send';
+import { E } from '@endo/far';
 import {
   observeIteration,
   makeSubscriptionKit,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -14,7 +14,7 @@ import {
   SubscriberShape,
   TopicsRecordShape,
 } from '@agoric/notifier';
-import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
+import { makeTypeGuards } from '@agoric/internal';
 import { M, mustMatch } from '@agoric/store';
 import { makeScalarBigMapStore, prepareExoClassKit } from '@agoric/vat-data';
 import { makeStorageNodePathProvider } from '@agoric/zoe/src/contractSupport/durability.js';
@@ -25,6 +25,7 @@ import { shape } from './typeGuards.js';
 import { objectMapStoragePath } from './utils.js';
 
 const { Fail, quote: q } = assert;
+const { StorageNodeShape } = makeTypeGuards(M);
 
 const ERROR_LAST_OFFER_ID = -1;
 

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -721,7 +721,7 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
    *
    * It then delivers the mailbox to inbound.  There are no optimisations.
    *
-   * @param {UpdateCount} [lastMailboxUpdate]
+   * @param {bigint} [lastMailboxUpdate]
    */
   const recurseEachMailboxUpdate = async (lastMailboxUpdate = undefined) => {
     const { updateCount, value: mailbox } = await mbNotifier.getUpdateSince(
@@ -773,7 +773,7 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
   };
 
   // This function ensures we only have one outgoing send operation at a time.
-  /** @type {(lastSendUpdate?: UpdateCount) => Promise<void>} */
+  /** @type {(lastSendUpdate?: bigint) => Promise<void>} */
   const recurseEachSend = async (lastSendUpdate = undefined) => {
     // See when there is another requested send since our last time.
     const { updateCount } = await sendNotifier.getUpdateSince(lastSendUpdate);

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -404,7 +404,7 @@ export const publishAgoricNames = async (
       const kindNode = await E(nameStorage).makeChildNode(kind);
       const { publisher } = makeStoredPublishKit(kindNode, marshaller);
       publisher.publish([]);
-      kindAdmin.onUpdate(publisher.publish);
+      kindAdmin.onUpdate(v => publisher.publish(v));
     }),
   );
 };

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -120,7 +120,7 @@
  *   `E(userBundle.bank).deposit(payment)` has to cast userBundle.bank;
  *   ideally, the cast is to some useful type. But unknown can't be cast directly to some other type;
  *   it has to be cast to any first.
- * @property {() => ConsistentAsyncIterable<Configuration>} getConfiguration
+ * @property {() => AsyncIterable<Configuration, Configuration>} getConfiguration
  *
  * @typedef {{ clientAddress: string, clientHome: Record<string, any>}} Configuration
  *

--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -428,7 +428,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
   assert(Array.isArray(invitationAmountValue2));
   const [{ handle: inviteHandle2 }] = invitationAmountValue2;
 
-  await waitForUpdate(E(zoeInvitePurse).getCurrentAmountNotifier(), () =>
+  await waitForUpdate(wallet.getPursesNotifier(), () =>
     wallet.deposit('Default Zoe invite purse', invite2),
   );
 
@@ -477,7 +477,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
           { kind: 'brand', petname: 'zoe invite' },
           { kind: 'unnamed', petname: 'unnamed-4' },
           { kind: 'unnamed', petname: 'unnamed-2' },
-          { kind: 'unnamed', petname: 'unnamed-3' },
+          { kind: 'unnamed', petname: 'unnamed-1' },
         ],
       },
       currentAmount: {
@@ -487,7 +487,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
             description: 'getRefund',
             handle: { kind: 'unnamed', petname: 'unnamed-4' },
             installation: { kind: 'unnamed', petname: 'unnamed-2' },
-            instance: { kind: 'unnamed', petname: 'unnamed-3' },
+            instance: { kind: 'unnamed', petname: 'unnamed-1' },
           },
         ],
       },
@@ -597,7 +597,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
         description: 'getRefund',
         handle: {
           kind: 'unnamed',
-          petname: 'unnamed-1',
+          petname: 'unnamed-3',
         },
         installation: {
           kind: 'installation',
@@ -735,7 +735,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
         description: 'getRefund',
         handle: {
           kind: 'unnamed',
-          petname: 'unnamed-1',
+          petname: 'unnamed-3',
         },
         installation: {
           kind: 'installation',
@@ -970,7 +970,7 @@ test('lib-wallet offer methods', async t => {
           },
           instance: {
             kind: 'unnamed',
-            petname: 'unnamed-3',
+            petname: 'unnamed-1',
           },
         },
         inviteHandleBoardId: 'board0257',
@@ -984,7 +984,7 @@ test('lib-wallet offer methods', async t => {
         },
         requestContext: { dappOrigin: 'unknown' },
         status: 'decline',
-        instancePetname: 'unnamed-3',
+        instancePetname: 'unnamed-1',
         installationPetname: 'unnamed-2',
         proposalForDisplay: {
           give: {

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -9,8 +9,6 @@ import {
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 
-/// <reference types="@agoric/notifier/src/types-ambient.js"/>
-
 /**
  * SCALE: Only for low cardinality provisioning. Every value from init() will
  * remain in the map for the lifetime of the heap. If a key object is GCed, its

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -518,6 +518,8 @@ test('oracle invitation', async t => {
   t.deepEqual(value4.quoteAmount.value, makeQuoteValue(9n, 1_234_000n));
 
   updater2.updateState('1234.567890');
+
+  await eventLoopIteration(); // pretend this is a new kernel delivery
   await E(oracleTimer).tick();
   const { value: value5, updateCount: uc5 } = await E(notifier).getUpdateSince(
     uc4,
@@ -525,6 +527,8 @@ test('oracle invitation', async t => {
   t.deepEqual(value5.quoteAmount.value, makeQuoteValue(10n, 1_234_567n));
 
   updater2.updateState(makeRatio(987_654n, brandOut, 500_000n, brandIn));
+
+  await eventLoopIteration(); // pretend this is a new kernel delivery
   await E(oracleTimer).tick();
   const { value: value6, updateCount: _uc6 } = await E(notifier).getUpdateSince(
     uc5,

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -275,7 +275,7 @@ test('median aggregator', async t => {
       increment: 8n,
     },
   );
-  // Publications can get more than one record per timestamp but tickAndQuote getUpdateSince ensures one
+  // Publications and tickAndQuote getUpdateSince ensures one record per update
   await publications.nextMatches({
     amountOut: 1169n,
     timestamp: 2n,
@@ -284,18 +284,10 @@ test('median aggregator', async t => {
   const quote2 = await tickAndQuote();
   t.deepEqual(quote2, { amountOut: 1178n, timestamp: 3n });
   await publications.nextMatches(quote2);
-  await publications.nextMatches({
-    amountOut: 1178n,
-    timestamp: 3n,
-  });
 
   const quote3 = await tickAndQuote();
   t.deepEqual(quote3, { amountOut: 1187n, timestamp: 4n });
   await publications.nextMatches(quote3);
-  await publications.nextMatches({
-    amountOut: 1187n,
-    timestamp: 4n,
-  });
 
   await E(aggregator.creatorFacet).initOracle(price800.instance, {
     increment: 17n,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #3784, endojs/endo#1035, #6883

## Description

Beginning to clean up the `@agoric/notifier` package in preparation for moving its guts to Endo.

- SwingSet metering test was using the Notifier API incorrectly (revealed by the new stricter argument checking)
- Separate subscription interfaces:
  - `EachTopic<T>` - consumable by `subscribeEach` by implementing `subscribeAfter`
  - `LatestTopic<T>` - consumable by `subscribeLatest` by implementing `getUpdateSince` (an attenuation of `subscribeAfter` with stricter GC guarantees)
- Subscribers from `makePublishKit` implements them both
- Now Notifiers can be consumed by `subscribeLatest`
- `SubscriptionIterator` is now a `ForkableIterator` so `ForkableIterator.fork()` replaces the `SubscriptionIterator.subscribe()` interface for branching an iterator
- Eliminate some deprecated code
- Replace more of the Subscription and Notifier implementations with Subscriber
- ~~Use a precursor to #6883 's Place API in order to simplify the `publish-kit.js` implementation~~ postponed

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Reduces complexity of the implementation.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

Will make producer vat's memory usage more obvious after `Subscription` and `Notifier` APIs are replaced with a new unified model of topic production and attenuation, but for now, there are no fundamental changes.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

No API changes yet, but in the future, https://docs.agoric.com/guides/js-programming/notifiers.html#distributed-operation will need to be rewritten.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
