### PR TITLE
docs: rename HEAD to master in md files

### DIFF
--- a/packages/ERTP/README.md
+++ b/packages/ERTP/README.md
@@ -5,8 +5,8 @@ ERTP is Agoric's digital asset standard.
 ERTP is a uniform way of transferring tokens and other digital
 assets in JavaScript. All kinds of digital assets can be easily
 created, but importantly, they can be transferred in exactly the same
-ways, with exactly the same security properties. 
+ways, with exactly the same security properties.
 
 Learn more about [ERTP fundamentals like mints, issuers, purses and payments](https://agoric.com/documentation/ertp/guide/).
 
-Looking for Zoe, our smart contract framework? Zoe has been moved into its own [npm package (`@agoric/zoe`)](https://www.npmjs.com/package/@agoric/zoe) and the code can be found at [`packages/zoe`](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/zoe#zoe).
+Looking for Zoe, our smart contract framework? Zoe has been moved into its own [npm package (`@agoric/zoe`)](https://www.npmjs.com/package/@agoric/zoe) and the code can be found at [`packages/zoe`](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe#zoe).

--- a/packages/SwingSet/docs/delivery.md
+++ b/packages/SwingSet/docs/delivery.md
@@ -282,7 +282,7 @@ be recycled, but it seems less confusing to simply retire the number.
 We use the term `CapData` to describe a piece of data that can include
 capability references. Each reference is known as a `CapSlot`. The data is
 serialized into into our
-[augmented form of JSON](https://github.com/endojs/endo/tree/HEAD/packages/marshal),
+[augmented form of JSON](https://github.com/endojs/endo/tree/master/packages/marshal),
 which uses special `@qclass` keys to represent things not normally expressible
 by JSON (such as `NaN`, `Infinity`, `undefined`, BigInts, and `CapSlot`
 references) or not preserved by normal serialization/deserialization (such as
@@ -511,7 +511,7 @@ trait Syscall {
     fn vatstoreDelete(key: String);
     fn dropImports(refs: &CapSlot[]);
 }
- 
+
 trait Dispatch {
     fn deliver(target: CapSlot, msg: Message);
     fn notify(resolutions: Vec<Resolution>);
@@ -1412,7 +1412,7 @@ struct CommsTables {
     next_promise_id: u32,
     promise_routes: HashMap<VatPromiseID, RemoteID>,
 }
- 
+
 ```
 
 The two routing tables (`object_routes` and `promise_routes`) are used to
@@ -1700,4 +1700,3 @@ which messages must be delivered.
 * What do we need from the relative ordering of a `dispatch.notify()` and the
   queued messages now headed to that resolution? The current design has the
   notify first, then the messages, is that ok?
-

--- a/packages/SwingSet/docs/networking.md
+++ b/packages/SwingSet/docs/networking.md
@@ -14,9 +14,9 @@ vaguely like the BSD socket API. This code can:
 The type of connection is limited by the host in which the vat is running. Chain-based machines must operate in a platonic realm of replicated consensus, so their network options are limited to protocols like IBC, which allow one gestalt chain to talk to other chain-like entities. Each such entity is defined by an evolving set of consensus rules, which typically include a current set of validator public keys and a particular history of hashed block identifiers.
 
 **CAVEAT:** IBC uses
-[Connection](https://github.com/cosmos/ibc/tree/master/spec/core/ics-003-connection-semantics/README.md)
+[Connection](https://github.com/cosmos/ibc/tree/main/spec/core/ics-003-connection-semantics/README.md)
 to mean a chain-to-chain hop, and
-[Channel](https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics/README.md)
+[Channel](https://github.com/cosmos/ibc/tree/main/spec/core/ics-004-channel-and-packet-semantics/README.md)
 to mean a Port-to-Port pathway through a series of hops.
 This is unfortunate, because IBC "Channels" correspond most precisely to
 TCP "connections", and most discussions of network APIs (including this one,

--- a/packages/SwingSet/docs/networking.md
+++ b/packages/SwingSet/docs/networking.md
@@ -14,9 +14,9 @@ vaguely like the BSD socket API. This code can:
 The type of connection is limited by the host in which the vat is running. Chain-based machines must operate in a platonic realm of replicated consensus, so their network options are limited to protocols like IBC, which allow one gestalt chain to talk to other chain-like entities. Each such entity is defined by an evolving set of consensus rules, which typically include a current set of validator public keys and a particular history of hashed block identifiers.
 
 **CAVEAT:** IBC uses
-[Connection](https://github.com/cosmos/ibc/tree/HEAD/spec/core/ics-003-connection-semantics/README.md)
+[Connection](https://github.com/cosmos/ibc/tree/master/spec/core/ics-003-connection-semantics/README.md)
 to mean a chain-to-chain hop, and
-[Channel](https://github.com/cosmos/ibc/tree/HEAD/spec/core/ics-004-channel-and-packet-semantics/README.md)
+[Channel](https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics/README.md)
 to mean a Port-to-Port pathway through a series of hops.
 This is unfortunate, because IBC "Channels" correspond most precisely to
 TCP "connections", and most discussions of network APIs (including this one,

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -19,7 +19,7 @@ to use Web Components is ReactJS, for which we provide a [React-specific wrapper
 
 You will need to ensure your app first installs and locks down the JS
 environment using
-[SES](https://github.com/endojs/endo/tree/HEAD/packages/ses#readme).
+[SES](https://github.com/endojs/endo/tree/master/packages/ses#readme).
 
 You can create an `install-ses-lockdown.js` module that does all the setup
 needed by your app:

--- a/packages/zoe/CONTRIBUTING.md
+++ b/packages/zoe/CONTRIBUTING.md
@@ -10,7 +10,7 @@ prefix to the title and Zoe tag to Zoe-related issues.
 
 ## Installing, Testing
 
-You'll need Node.js version 11 or higher. 
+You'll need Node.js version 11 or higher.
 
 * `git clone https://github.com/Agoric/agoric-sdk/`
 * `cd agoric-sdk`
@@ -62,4 +62,4 @@ To test that that the Zoe update works (in the most basic sense) with cosmic-swi
 
 
 To test that the update works with agoric-cli, follow the instructions
-for [Developing Agoric CLI](https://github.com/Agoric/agoric-sdk/tree/HEAD/packages/agoric-cli#developing-agoric-cli).
+for [Developing Agoric CLI](https://github.com/Agoric/agoric-sdk/tree/master/packages/agoric-cli#developing-agoric-cli).


### PR DESCRIPTION
At https://github.com/endojs/endo/pull/1469#discussion_r1089011161 @turadg explains advantages of docs urls using `master` rather than `HEAD`. Although he says "not worth another commit", the advantages seem compelling enough to be worth one.

Recommend reviewing with "Hide whitespace"

See https://github.com/endojs/endo/pull/1473