### PR TITLE
5894 durable smartwallet

### DIFF
--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -1,13 +1,7 @@
 import { AmountMath } from '@agoric/ertp';
 import { makeStoredPublisherKit, makeStoredPublishKit } from '@agoric/notifier';
 import { M } from '@agoric/store';
-import {
-  makeScalarBigMapStore,
-  provide,
-  provideDurableSetStore,
-} from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
 
 const { Fail, quote: q } = assert;
 
@@ -147,72 +141,3 @@ export const makeMetricsPublishKit = (storageNode, marshaller) => {
   };
 };
 harden(makeMetricsPublishKit);
-
-/**
- * @template K Key
- * @template {{}} E Ephemeral state
- * @param {() => E} init
- */
-export const makeEphemeraProvider = init => {
-  /** @type {Map<K, E>} */
-  const ephemeras = new Map();
-
-  /**
-   * Provide an object to hold state that need not (or cannot) be durable.
-   *
-   * @type {(key: K) => E}
-   */
-  return key => {
-    if (ephemeras.has(key)) {
-      // @ts-expect-error cast
-      return ephemeras.get(key);
-    }
-    const newEph = init();
-    ephemeras.set(key, newEph);
-    return newEph;
-  };
-};
-harden(makeEphemeraProvider);
-
-/**
- *
- * @param {ZCF} zcf
- * @param {import('@agoric/ertp').Baggage} baggage
- * @param {string} name
- * @returns {ZCFSeat}
- */
-export const provideEmptySeat = (zcf, baggage, name) => {
-  return provide(baggage, name, () => zcf.makeEmptySeatKit().zcfSeat);
-};
-harden(provideEmptySeat);
-
-/**
- * For making singletons, so that each baggage carries a separate kind definition (albeit of the definer)
- *
- * @param {import('@agoric/vat-data').Baggage} baggage
- * @param {string} category diagnostic tag
- */
-export const provideChildBaggage = (baggage, category) => {
-  const baggageSet = provideDurableSetStore(baggage, `${category}Set`);
-  return Far('childBaggageManager', {
-    // TODO(types) infer args
-    /**
-     * @template {(baggage: import('@agoric/ertp').Baggage, ...rest: any) => any} M Maker function
-     * @param {string} childName diagnostic tag
-     * @param {M} makeChild
-     * @param {...any} nonBaggageArgs
-     * @returns {ReturnType<M>}
-     */
-    addChild: (childName, makeChild, ...nonBaggageArgs) => {
-      const childStore = makeScalarBigMapStore(`${childName}${category}`, {
-        durable: true,
-      });
-      const result = makeChild(childStore, ...nonBaggageArgs);
-      baggageSet.add(childStore);
-      return result;
-    },
-    children: () => baggageSet.values(),
-  });
-};
-harden(provideChildBaggage);
-/** @typedef {ReturnType<typeof provideChildBaggage>} ChildBaggageManager */

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -4,11 +4,14 @@ import '@agoric/zoe/src/contracts/exported.js';
 import '@agoric/governance/exported.js';
 import { E } from '@endo/eventual-send';
 
-import { mustMatch, keyEQ, M, makeScalarMapStore } from '@agoric/store';
+import { keyEQ, M, makeScalarMapStore, mustMatch } from '@agoric/store';
 import {
   assertProposalShape,
   getAmountIn,
   getAmountOut,
+  provideChildBaggage,
+  provideEmptySeat,
+  unitAmount,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { Far } from '@endo/marshal';
@@ -18,8 +21,8 @@ import {
   makeStoredPublisherKit,
   makeStoredSubscriber,
   observeIteration,
-  SubscriberShape,
   prepareDurablePublishKit,
+  SubscriberShape,
 } from '@agoric/notifier';
 import {
   defineDurableExoClassKit,
@@ -27,7 +30,6 @@ import {
   provideDurableMapStore,
 } from '@agoric/vat-data';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
-import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import {
   CHARGING_PERIOD_KEY,
@@ -37,7 +39,6 @@ import {
   vaultParamPattern,
 } from './params.js';
 import { prepareVaultManagerKit } from './vaultManager.js';
-import { provideChildBaggage, provideEmptySeat } from '../contractSupport.js';
 
 const { details: X, quote: q, Fail } = assert;
 

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -8,7 +8,7 @@ import {
   prepareDurablePublishKit,
 } from '@agoric/notifier';
 import { M, prepareExoClassKit } from '@agoric/vat-data';
-import { makeEphemeraProvider } from '../contractSupport.js';
+import { makeEphemeraProvider } from '@agoric/zoe/src/contractSupport/index.js';
 import { UnguardedHelperI } from '../typeGuards.js';
 
 const { Fail } = assert;

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -44,10 +44,11 @@ import {
   getAmountOut,
   makeRatio,
   makeRatioFromAmounts,
+  provideEmptySeat,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { InstallationShape, SeatShape } from '@agoric/zoe/src/typeGuards.js';
 import { E } from '@endo/eventual-send';
-import { checkDebtLimit, provideEmptySeat } from '../contractSupport.js';
+import { checkDebtLimit } from '../contractSupport.js';
 import { chargeInterest } from '../interest.js';
 import { liquidate, makeQuote, updateQuote } from './liquidation.js';
 import { makePrioritizedVaults } from './prioritizedVaults.js';

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -52,6 +52,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     { storageNode, walletBridgeManager },
   );
 
+  /** @param {string} address */
   const simpleProvideWallet = async address => {
     // copied from makeClientBanks()
     const bank = E(consume.bankManager).getBankForAddress(address);

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -147,7 +147,7 @@ const pushPrice = async (wallet, adminOfferId, priceRound) => {
 // The tests are serial because they mutate shared state
 
 test.serial('invitations', async t => {
-  const operatorAddress = 'invitation test';
+  const operatorAddress = 'agoric1invitationTest';
   const wallet = await t.context.simpleProvideWallet(operatorAddress);
   const computedState = coalesceUpdates(E(wallet).getUpdatesSubscriber());
 

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -8,11 +8,10 @@ import {
   PurseShape,
 } from '@agoric/ertp';
 import { makeStoredPublishKit, observeNotifier } from '@agoric/notifier';
-import { mustMatch, M, makeScalarMapStore } from '@agoric/store';
+import { M, makeScalarMapStore, mustMatch } from '@agoric/store';
 import {
   defineVirtualExoClassKit,
   makeScalarBigMapStore,
-  pickFacet,
 } from '@agoric/vat-data';
 import { E } from '@endo/far';
 import { makeInvitationsHelper } from './invitations.js';
@@ -132,429 +131,431 @@ const mapToRecord = map => Object.fromEntries(map.entries());
  * }} MutableState
  */
 
-/**
- *
- * @param {UniqueParams} unique
- * @param {SharedParams} shared
- * @returns {State}
- */
-export const initState = (unique, shared) => {
-  // Some validation of inputs.
-  mustMatch(
-    unique,
-    harden({
-      address: M.string(),
-      bank: M.eref(M.remotable()),
-      invitationPurse: PurseShape,
-    }),
-  );
-  mustMatch(
-    shared,
-    harden({
-      agoricNames: M.eref(M.remotable('agoricNames')),
-      invitationIssuer: IssuerShape,
-      invitationBrand: BrandShape,
-      invitationDisplayInfo: DisplayInfoShape,
-      publicMarshaller: M.remotable('Marshaller'),
-      storageNode: M.eref(M.remotable('StorageNode')),
-      zoe: M.eref(M.remotable('ZoeService')),
-      registry: M.remotable('AssetRegistry'),
-    }),
-  );
+export const prepareSmartWallet = () => {
+  /**
+   *
+   * @param {UniqueParams} unique
+   * @param {SharedParams} shared
+   * @returns {State}
+   */
+  const initState = (unique, shared) => {
+    // Some validation of inputs.
+    mustMatch(
+      unique,
+      harden({
+        address: M.string(),
+        bank: M.eref(M.remotable()),
+        invitationPurse: PurseShape,
+      }),
+    );
+    mustMatch(
+      shared,
+      harden({
+        agoricNames: M.eref(M.remotable('agoricNames')),
+        invitationIssuer: IssuerShape,
+        invitationBrand: BrandShape,
+        invitationDisplayInfo: DisplayInfoShape,
+        publicMarshaller: M.remotable('Marshaller'),
+        storageNode: M.eref(M.remotable('StorageNode')),
+        zoe: M.eref(M.remotable('ZoeService')),
+        registry: M.remotable('AssetRegistry'),
+      }),
+    );
 
-  // NB: state size must not grow monotonically
-  // This is the node that UIs subscribe to for everything they need.
-  // e.g. agoric follow :published.wallet.agoric1nqxg4pye30n3trct0hf7dclcwfxz8au84hr3ht
-  const myWalletStorageNode = E(shared.storageNode).makeChildNode(
-    unique.address,
-  );
+    // NB: state size must not grow monotonically
+    // This is the node that UIs subscribe to for everything they need.
+    // e.g. agoric follow :published.wallet.agoric1nqxg4pye30n3trct0hf7dclcwfxz8au84hr3ht
+    const myWalletStorageNode = E(shared.storageNode).makeChildNode(
+      unique.address,
+    );
 
-  const myCurrentStateStorageNode =
-    E(myWalletStorageNode).makeChildNode('current');
+    const myCurrentStateStorageNode =
+      E(myWalletStorageNode).makeChildNode('current');
 
-  const preciousState = {
-    // Private purses. This assumes one purse per brand, which will be valid in MN-1 but not always.
-    brandPurses: makeScalarBigMapStore('brand purses', { durable: true }),
-    // Payments that couldn't be deposited when received.
-    // NB: vulnerable to uncapped growth by unpermissioned deposits.
-    paymentQueues: makeScalarBigMapStore('payments queues', {
-      durable: true,
-    }),
-    // Invitation amounts to save for persistent lookup
-    offerToUsedInvitation: makeScalarBigMapStore(
-      'invitation amounts by offer',
-      {
+    const preciousState = {
+      // Private purses. This assumes one purse per brand, which will be valid in MN-1 but not always.
+      brandPurses: makeScalarBigMapStore('brand purses', { durable: true }),
+      // Payments that couldn't be deposited when received.
+      // NB: vulnerable to uncapped growth by unpermissioned deposits.
+      paymentQueues: makeScalarBigMapStore('payments queues', {
         durable: true,
-      },
-    ),
-    // Invitation makers yielded by offer results
-    offerToInvitationMakers: makeScalarBigMapStore(
-      'invitation makers by offer',
-      {
-        durable: true,
-      },
-    ),
-    // Public subscribers yielded by offer results
-    offerToPublicSubscriberPaths: makeScalarBigMapStore(
-      'public subscribers by offer',
-      {
-        durable: true,
-      },
-    ),
-  };
-
-  const nonpreciousState = {
-    // What purses have reported on construction and by getCurrentAmountNotifier updates.
-    purseBalances: makeScalarMapStore(),
-    /** @type {StoredPublishKit<UpdateRecord>} */
-    updatePublishKit: harden(
-      makeStoredPublishKit(myWalletStorageNode, shared.publicMarshaller),
-    ),
-    /** @type {StoredPublishKit<CurrentWalletRecord>} */
-    currentPublishKit: harden(
-      makeStoredPublishKit(myCurrentStateStorageNode, shared.publicMarshaller),
-    ),
-  };
-
-  return {
-    ...shared,
-    ...unique,
-    ...nonpreciousState,
-    ...preciousState,
-  };
-};
-
-const behaviorGuards = {
-  helper: M.interface('helperFacetI', {
-    updateBalance: M.call(PurseShape, AmountShape).optional('init').returns(),
-    publishCurrentState: M.call().returns(),
-    addBrand: M.call(
-      {
-        brand: BrandShape,
-        issuer: M.eref(IssuerShape),
-        petname: M.string(),
-        displayInfo: DisplayInfoShape,
-      },
-      M.eref(PurseShape),
-    ).returns(M.promise()),
-  }),
-  deposit: M.interface('depositFacetI', {
-    receive: M.callWhen(M.await(M.eref(PaymentShape))).returns(AmountShape),
-  }),
-  offers: M.interface('offers facet', {
-    executeOffer: M.call(shape.OfferSpec).returns(M.promise()),
-    getLastOfferId: M.call().returns(M.number()),
-  }),
-  self: M.interface('selfFacetI', {
-    handleBridgeAction: M.call(shape.StringCapData, M.boolean()).returns(
-      M.promise(),
-    ),
-    getDepositFacet: M.call().returns(M.remotable()),
-    getOffersFacet: M.call().returns(M.remotable()),
-    getCurrentSubscriber: M.call().returns(M.remotable()),
-    getUpdatesSubscriber: M.call().returns(M.remotable()),
-  }),
-};
-
-const SmartWalletKit = defineVirtualExoClassKit(
-  'SmartWallet',
-  behaviorGuards,
-  initState,
-  {
-    helper: {
-      /**
-       * @param {RemotePurse} purse
-       * @param {Amount<any>} balance
-       * @param {'init'} [init]
-       */
-      updateBalance(purse, balance, init) {
-        const { purseBalances, updatePublishKit } = this.state;
-        if (init) {
-          purseBalances.init(purse, balance);
-        } else {
-          purseBalances.set(purse, balance);
-        }
-        updatePublishKit.publisher.publish({
-          updated: 'balance',
-          currentAmount: balance,
-        });
-        const { helper } = this.facets;
-        helper.publishCurrentState();
-      },
-
-      publishCurrentState() {
-        const {
-          currentPublishKit,
-          offerToUsedInvitation,
-          offerToPublicSubscriberPaths,
-          purseBalances,
-          registry,
-        } = this.state;
-        currentPublishKit.publisher.publish({
-          brands: registry.getRegisteredBrands(),
-          purses: [...purseBalances.values()].map(a => ({
-            brand: a.brand,
-            balance: a,
-          })),
-          offerToUsedInvitation: mapToRecord(offerToUsedInvitation),
-          offerToPublicSubscriberPaths: mapToRecord(
-            offerToPublicSubscriberPaths,
-          ),
-          // @ts-expect-error FIXME leftover from offer id string conversion
-          lastOfferId: ERROR_LAST_OFFER_ID,
-        });
-      },
-
-      /** @type {(desc: BrandDescriptor, purse: ERef<RemotePurse>) => Promise<void>} */
-      async addBrand(desc, purseRef) {
-        const { address, brandPurses, paymentQueues, updatePublishKit } =
-          this.state;
-        const pursesHas = brandPurses.has(desc.brand);
-        assert(!pursesHas, 'repeated brand from bank asset subscription');
-
-        const purse = await purseRef; // promises don't fit in durable storage
-
-        brandPurses.init(desc.brand, purse);
-
-        const { helper } = this.facets;
-        // publish purse's balance and changes
-        void E.when(
-          E(purse).getCurrentAmount(),
-          balance => helper.updateBalance(purse, balance, 'init'),
-          err =>
-            console.error(address, 'initial purse balance publish failed', err),
-        );
-        void observeNotifier(E(purse).getCurrentAmountNotifier(), {
-          updateState(balance) {
-            helper.updateBalance(purse, balance);
-          },
-          fail(reason) {
-            console.error(address, `failed updateState observer`, reason);
-          },
-        });
-
-        updatePublishKit.publisher.publish({
-          updated: 'brand',
-          descriptor: desc,
-        });
-
-        // deposit queued payments
-        const payments = paymentQueues.has(desc.brand)
-          ? paymentQueues.get(desc.brand)
-          : [];
-        // @ts-expect-error xxx with DataOnly / FarRef types
-        const deposits = payments.map(p => E(purse).deposit(p));
-        Promise.all(deposits).catch(err =>
-          console.error('ERROR depositing queued payments', err),
-        );
-      },
-    },
-    /**
-     * Similar to {DepositFacet} but async because it has to look up the purse.
-     */
-    deposit: {
-      /**
-       * Put the assets from the payment into the appropriate purse.
-       *
-       * If the purse doesn't exist, we hold the payment until it does.
-       *
-       * @param {import('@endo/far').FarRef<Payment>} payment
-       * @returns {Promise<Amount>} amounts for deferred deposits will be empty
-       */
-      async receive(payment) {
-        const { brandPurses, paymentQueues: queues } = this.state;
-        const brand = await E(payment).getAllegedBrand();
-
-        // When there is a purse deposit into it
-        if (brandPurses.has(brand)) {
-          const purse = brandPurses.get(brand);
-          // @ts-expect-error deposit does take a FarRef<Payment>
-          return E(purse).deposit(payment);
-        }
-
-        // When there is no purse, queue the payment
-        if (queues.has(brand)) {
-          queues.get(brand).push(payment);
-        } else {
-          queues.init(brand, harden([payment]));
-        }
-        return AmountMath.makeEmpty(brand);
-      },
-    },
-    offers: {
-      /**
-       * @deprecated
-       * @returns {number} an error code, for backwards compatibility with clients expecting a number
-       */
-      getLastOfferId() {
-        return ERROR_LAST_OFFER_ID;
-      },
-      /**
-       * Take an offer description provided in capData, augment it with payments and call zoe.offer()
-       *
-       * @param {import('./offers.js').OfferSpec} offerSpec
-       * @returns {Promise<void>} when the offer has been sent to Zoe; payouts go into this wallet's purses
-       * @throws if any parts of the offer can be determined synchronously to be invalid
-       */
-      async executeOffer(offerSpec) {
-        const { facets } = this;
-        const {
-          address,
-          zoe,
-          brandPurses,
-          invitationBrand,
-          invitationPurse,
-          invitationIssuer,
-          offerToInvitationMakers,
-          offerToUsedInvitation,
-          offerToPublicSubscriberPaths,
-          registry,
-          updatePublishKit,
-        } = this.state;
-
-        const logger = {
-          info: (...args) => console.info('wallet', address, ...args),
-          error: (...args) => console.log('wallet', address, ...args),
-        };
-
-        const executor = makeOfferExecutor({
-          zoe,
-          depositFacet: facets.deposit,
-          invitationIssuer,
-          powers: {
-            invitationFromSpec: makeInvitationsHelper(
-              zoe,
-              invitationBrand,
-              invitationPurse,
-              offerToInvitationMakers.get,
-            ),
-            /**
-             * @param {Brand} brand
-             * @returns {Promise<RemotePurse>}
-             */
-            purseForBrand: async brand => {
-              if (brandPurses.has(brand)) {
-                return brandPurses.get(brand);
-              }
-              const desc = registry.getRegisteredAsset(brand);
-              const { bank } = this.state;
-              /** @type {RemotePurse} */
-              // @ts-expect-error cast to RemotePurse
-              const purse = E(bank).getPurse(desc.brand);
-              await facets.helper.addBrand(desc, purse);
-              return purse;
-            },
-            logger,
-          },
-          onStatusChange: offerStatus => {
-            logger.info('offerStatus', offerStatus);
-            updatePublishKit.publisher.publish({
-              updated: 'offerStatus',
-              status: offerStatus,
-            });
-          },
-          /** @type {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers?: import('./types').PublicSubscribers) => Promise<void>} */
-          onNewContinuingOffer: async (
-            offerId,
-            invitationAmount,
-            invitationMakers,
-            publicSubscribers,
-          ) => {
-            offerToUsedInvitation.init(offerId, invitationAmount);
-            offerToInvitationMakers.init(offerId, invitationMakers);
-            const pathMap = await objectMapStoragePath(publicSubscribers);
-            if (pathMap) {
-              logger.info('recording pathMap', pathMap);
-              offerToPublicSubscriberPaths.init(offerId, pathMap);
-            }
-            facets.helper.publishCurrentState();
-          },
-        });
-        await executor.executeOffer(offerSpec);
-      },
-    },
-    self: {
-      /**
-       *
-       * @param {import('@endo/marshal').CapData<string>} actionCapData of type BridgeAction
-       * @param {boolean} [canSpend=false]
-       * @returns {Promise<void>}
-       */
-      handleBridgeAction(actionCapData, canSpend = false) {
-        const { publicMarshaller } = this.state;
-        const { offers } = this.facets;
-
-        return E.when(
-          E(publicMarshaller).unserialize(actionCapData),
-          /** @param {BridgeAction} action */
-          action => {
-            switch (action.method) {
-              case 'executeOffer': {
-                assert(canSpend, 'executeOffer requires spend authority');
-                return offers.executeOffer(action.offer);
-              }
-              default: {
-                throw Fail`invalid handle bridge action ${q(action)}`;
-              }
-            }
-          },
-        );
-      },
-      getDepositFacet() {
-        return this.facets.deposit;
-      },
-      getOffersFacet() {
-        return this.facets.offers;
-      },
-      getCurrentSubscriber() {
-        return this.state.currentPublishKit.subscriber;
-      },
-      getUpdatesSubscriber() {
-        return this.state.updatePublishKit.subscriber;
-      },
-    },
-  },
-  {
-    finish: ({ state, facets }) => {
-      const {
-        invitationBrand,
-        invitationDisplayInfo,
-        invitationIssuer,
-        invitationPurse,
-      } = state;
-      const { helper } = facets;
-      // Ensure a purse for each issuer
-      void helper.addBrand(
+      }),
+      // Invitation amounts to save for persistent lookup
+      offerToUsedInvitation: makeScalarBigMapStore(
+        'invitation amounts by offer',
         {
-          brand: invitationBrand,
-          issuer: invitationIssuer,
-          petname: 'invitations',
-          displayInfo: invitationDisplayInfo,
+          durable: true,
         },
-        // @ts-expect-error cast to RemotePurse
-        /** @type {RemotePurse} */ (invitationPurse),
-      );
+      ),
+      // Invitation makers yielded by offer results
+      offerToInvitationMakers: makeScalarBigMapStore(
+        'invitation makers by offer',
+        {
+          durable: true,
+        },
+      ),
+      // Public subscribers yielded by offer results
+      offerToPublicSubscriberPaths: makeScalarBigMapStore(
+        'public subscribers by offer',
+        {
+          durable: true,
+        },
+      ),
+    };
 
-      // Schedule creation of a purse for each registered brand.
-      state.registry.getRegisteredBrands().forEach(desc => {
-        // In this sync method, we can't await the outcome.
-        void E(state.bank)
-          .getPurse(desc.brand)
-          // @ts-expect-error cast
-          .then((/** @type {RemotePurse} */ purse) =>
-            helper.addBrand(desc, purse),
+    const nonpreciousState = {
+      // What purses have reported on construction and by getCurrentAmountNotifier updates.
+      purseBalances: makeScalarMapStore(),
+      /** @type {StoredPublishKit<UpdateRecord>} */
+      updatePublishKit: harden(
+        makeStoredPublishKit(myWalletStorageNode, shared.publicMarshaller),
+      ),
+      /** @type {StoredPublishKit<CurrentWalletRecord>} */
+      currentPublishKit: harden(
+        makeStoredPublishKit(
+          myCurrentStateStorageNode,
+          shared.publicMarshaller,
+        ),
+      ),
+    };
+
+    return {
+      ...shared,
+      ...unique,
+      ...nonpreciousState,
+      ...preciousState,
+    };
+  };
+
+  const behaviorGuards = {
+    helper: M.interface('helperFacetI', {
+      updateBalance: M.call(PurseShape, AmountShape).optional('init').returns(),
+      publishCurrentState: M.call().returns(),
+      addBrand: M.call(
+        {
+          brand: BrandShape,
+          issuer: M.eref(IssuerShape),
+          petname: M.string(),
+          displayInfo: DisplayInfoShape,
+        },
+        M.eref(PurseShape),
+      ).returns(M.promise()),
+    }),
+    deposit: M.interface('depositFacetI', {
+      receive: M.callWhen(M.await(M.eref(PaymentShape))).returns(AmountShape),
+    }),
+    offers: M.interface('offers facet', {
+      executeOffer: M.call(shape.OfferSpec).returns(M.promise()),
+      getLastOfferId: M.call().returns(M.number()),
+    }),
+    self: M.interface('selfFacetI', {
+      handleBridgeAction: M.call(shape.StringCapData, M.boolean()).returns(
+        M.promise(),
+      ),
+      getDepositFacet: M.call().returns(M.remotable()),
+      getOffersFacet: M.call().returns(M.remotable()),
+      getCurrentSubscriber: M.call().returns(M.remotable()),
+      getUpdatesSubscriber: M.call().returns(M.remotable()),
+    }),
+  };
+
+  return defineVirtualExoClassKit(
+    'SmartWallet',
+    behaviorGuards,
+    initState,
+    {
+      helper: {
+        /**
+         * @param {RemotePurse} purse
+         * @param {Amount<any>} balance
+         * @param {'init'} [init]
+         */
+        updateBalance(purse, balance, init) {
+          const { purseBalances, updatePublishKit } = this.state;
+          if (init) {
+            purseBalances.init(purse, balance);
+          } else {
+            purseBalances.set(purse, balance);
+          }
+          updatePublishKit.publisher.publish({
+            updated: 'balance',
+            currentAmount: balance,
+          });
+          const { helper } = this.facets;
+          helper.publishCurrentState();
+        },
+
+        publishCurrentState() {
+          const {
+            currentPublishKit,
+            offerToUsedInvitation,
+            offerToPublicSubscriberPaths,
+            purseBalances,
+            registry,
+          } = this.state;
+          currentPublishKit.publisher.publish({
+            brands: registry.getRegisteredBrands(),
+            purses: [...purseBalances.values()].map(a => ({
+              brand: a.brand,
+              balance: a,
+            })),
+            offerToUsedInvitation: mapToRecord(offerToUsedInvitation),
+            offerToPublicSubscriberPaths: mapToRecord(
+              offerToPublicSubscriberPaths,
+            ),
+            // @ts-expect-error FIXME leftover from offer id string conversion
+            lastOfferId: ERROR_LAST_OFFER_ID,
+          });
+        },
+
+        /** @type {(desc: BrandDescriptor, purse: ERef<RemotePurse>) => Promise<void>} */
+        async addBrand(desc, purseRef) {
+          const { address, brandPurses, paymentQueues, updatePublishKit } =
+            this.state;
+          const pursesHas = brandPurses.has(desc.brand);
+          assert(!pursesHas, 'repeated brand from bank asset subscription');
+
+          const purse = await purseRef; // promises don't fit in durable storage
+
+          brandPurses.init(desc.brand, purse);
+
+          const { helper } = this.facets;
+          // publish purse's balance and changes
+          void E.when(
+            E(purse).getCurrentAmount(),
+            balance => helper.updateBalance(purse, balance, 'init'),
+            err =>
+              console.error(
+                address,
+                'initial purse balance publish failed',
+                err,
+              ),
           );
-      });
+          void observeNotifier(E(purse).getCurrentAmountNotifier(), {
+            updateState(balance) {
+              helper.updateBalance(purse, balance);
+            },
+            fail(reason) {
+              console.error(address, `failed updateState observer`, reason);
+            },
+          });
+
+          updatePublishKit.publisher.publish({
+            updated: 'brand',
+            descriptor: desc,
+          });
+
+          // deposit queued payments
+          const payments = paymentQueues.has(desc.brand)
+            ? paymentQueues.get(desc.brand)
+            : [];
+          // @ts-expect-error xxx with DataOnly / FarRef types
+          const deposits = payments.map(p => E(purse).deposit(p));
+          Promise.all(deposits).catch(err =>
+            console.error('ERROR depositing queued payments', err),
+          );
+        },
+      },
+      /**
+       * Similar to {DepositFacet} but async because it has to look up the purse.
+       */
+      deposit: {
+        /**
+         * Put the assets from the payment into the appropriate purse.
+         *
+         * If the purse doesn't exist, we hold the payment until it does.
+         *
+         * @param {import('@endo/far').FarRef<Payment>} payment
+         * @returns {Promise<Amount>} amounts for deferred deposits will be empty
+         */
+        async receive(payment) {
+          const { brandPurses, paymentQueues: queues } = this.state;
+          const brand = await E(payment).getAllegedBrand();
+
+          // When there is a purse deposit into it
+          if (brandPurses.has(brand)) {
+            const purse = brandPurses.get(brand);
+            // @ts-expect-error deposit does take a FarRef<Payment>
+            return E(purse).deposit(payment);
+          }
+
+          // When there is no purse, queue the payment
+          if (queues.has(brand)) {
+            queues.get(brand).push(payment);
+          } else {
+            queues.init(brand, harden([payment]));
+          }
+          return AmountMath.makeEmpty(brand);
+        },
+      },
+      offers: {
+        /**
+         * @deprecated
+         * @returns {number} an error code, for backwards compatibility with clients expecting a number
+         */
+        getLastOfferId() {
+          return ERROR_LAST_OFFER_ID;
+        },
+        /**
+         * Take an offer description provided in capData, augment it with payments and call zoe.offer()
+         *
+         * @param {import('./offers.js').OfferSpec} offerSpec
+         * @returns {Promise<void>} when the offer has been sent to Zoe; payouts go into this wallet's purses
+         * @throws if any parts of the offer can be determined synchronously to be invalid
+         */
+        async executeOffer(offerSpec) {
+          const { facets } = this;
+          const {
+            address,
+            zoe,
+            brandPurses,
+            invitationBrand,
+            invitationPurse,
+            invitationIssuer,
+            offerToInvitationMakers,
+            offerToUsedInvitation,
+            offerToPublicSubscriberPaths,
+            registry,
+            updatePublishKit,
+          } = this.state;
+
+          const logger = {
+            info: (...args) => console.info('wallet', address, ...args),
+            error: (...args) => console.log('wallet', address, ...args),
+          };
+
+          const executor = makeOfferExecutor({
+            zoe,
+            depositFacet: facets.deposit,
+            invitationIssuer,
+            powers: {
+              invitationFromSpec: makeInvitationsHelper(
+                zoe,
+                invitationBrand,
+                invitationPurse,
+                offerToInvitationMakers.get,
+              ),
+              /**
+               * @param {Brand} brand
+               * @returns {Promise<RemotePurse>}
+               */
+              purseForBrand: async brand => {
+                if (brandPurses.has(brand)) {
+                  return brandPurses.get(brand);
+                }
+                const desc = registry.getRegisteredAsset(brand);
+                const { bank } = this.state;
+                /** @type {RemotePurse} */
+                // @ts-expect-error cast to RemotePurse
+                const purse = E(bank).getPurse(desc.brand);
+                await facets.helper.addBrand(desc, purse);
+                return purse;
+              },
+              logger,
+            },
+            onStatusChange: offerStatus => {
+              logger.info('offerStatus', offerStatus);
+              updatePublishKit.publisher.publish({
+                updated: 'offerStatus',
+                status: offerStatus,
+              });
+            },
+            /** @type {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers?: import('./types').PublicSubscribers) => Promise<void>} */
+            onNewContinuingOffer: async (
+              offerId,
+              invitationAmount,
+              invitationMakers,
+              publicSubscribers,
+            ) => {
+              offerToUsedInvitation.init(offerId, invitationAmount);
+              offerToInvitationMakers.init(offerId, invitationMakers);
+              const pathMap = await objectMapStoragePath(publicSubscribers);
+              if (pathMap) {
+                logger.info('recording pathMap', pathMap);
+                offerToPublicSubscriberPaths.init(offerId, pathMap);
+              }
+              facets.helper.publishCurrentState();
+            },
+          });
+          await executor.executeOffer(offerSpec);
+        },
+      },
+      self: {
+        /**
+         *
+         * @param {import('@endo/marshal').CapData<string>} actionCapData of type BridgeAction
+         * @param {boolean} [canSpend=false]
+         * @returns {Promise<void>}
+         */
+        handleBridgeAction(actionCapData, canSpend = false) {
+          const { publicMarshaller } = this.state;
+          const { offers } = this.facets;
+
+          return E.when(
+            E(publicMarshaller).unserialize(actionCapData),
+            /** @param {BridgeAction} action */
+            action => {
+              switch (action.method) {
+                case 'executeOffer': {
+                  assert(canSpend, 'executeOffer requires spend authority');
+                  return offers.executeOffer(action.offer);
+                }
+                default: {
+                  throw Fail`invalid handle bridge action ${q(action)}`;
+                }
+              }
+            },
+          );
+        },
+        getDepositFacet() {
+          return this.facets.deposit;
+        },
+        getOffersFacet() {
+          return this.facets.offers;
+        },
+        getCurrentSubscriber() {
+          return this.state.currentPublishKit.subscriber;
+        },
+        getUpdatesSubscriber() {
+          return this.state.updatePublishKit.subscriber;
+        },
+      },
     },
-  },
-);
+    {
+      finish: ({ state, facets }) => {
+        const {
+          invitationBrand,
+          invitationDisplayInfo,
+          invitationIssuer,
+          invitationPurse,
+        } = state;
+        const { helper } = facets;
+        // Ensure a purse for each issuer
+        void helper.addBrand(
+          {
+            brand: invitationBrand,
+            issuer: invitationIssuer,
+            petname: 'invitations',
+            displayInfo: invitationDisplayInfo,
+          },
+          // @ts-expect-error cast to RemotePurse
+          /** @type {RemotePurse} */ (invitationPurse),
+        );
 
-/**
- * Holders of this object:
- * - vat (transitively from holding the wallet factory)
- * - wallet-ui (which has key material; dapps use wallet-ui to propose actions)
- */
-export const makeSmartWallet = pickFacet(SmartWalletKit, 'self');
-harden(makeSmartWallet);
+        // Schedule creation of a purse for each registered brand.
+        state.registry.getRegisteredBrands().forEach(desc => {
+          // In this sync method, we can't await the outcome.
+          void E(state.bank)
+            .getPurse(desc.brand)
+            // @ts-expect-error cast
+            .then((/** @type {RemotePurse} */ purse) =>
+              helper.addBrand(desc, purse),
+            );
+        });
+      },
+    },
+  );
+};
+harden(prepareSmartWallet);
 
-/** @typedef {ReturnType<typeof makeSmartWallet>} SmartWallet */
+/** @typedef {ReturnType<ReturnType<typeof prepareSmartWallet>>['self']} SmartWallet */

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -128,8 +128,9 @@ const makeAssetRegistry = assetPublisher => {
  *   storageNode: ERef<StorageNode>,
  *   walletBridgeManager?: ERef<import('@agoric/vats').ScopedBridgeManager>,
  * }} privateArgs
+ * @param {import('@agoric/vat-data').Baggage} baggage
  */
-export const start = async (zcf, privateArgs) => {
+export const start = async (zcf, privateArgs, baggage) => {
   const { agoricNames, board, assetPublisher } = zcf.getTerms();
 
   const zoe = zcf.getZoeService();
@@ -206,7 +207,7 @@ export const start = async (zcf, privateArgs) => {
    * - vat (transitively from holding the wallet factory)
    * - wallet-ui (which has key material; dapps use wallet-ui to propose actions)
    */
-  const makeSmartWallet = prepareSmartWallet();
+  const makeSmartWallet = prepareSmartWallet(baggage, shared);
 
   const creatorFacet = makeExo(
     'walletFactoryCreator',
@@ -233,7 +234,6 @@ export const start = async (zcf, privateArgs) => {
           const invitationPurse = await E(invitationIssuer).makeEmptyPurse();
           const wallet = makeSmartWallet(
             harden({ address, bank, invitationPurse }),
-            shared,
           ).self;
 
           // An await here would deadlock with invitePSMCommitteeMembers

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -198,7 +198,6 @@ export const start = async (zcf, privateArgs, baggage) => {
     invitationIssuer,
     publicMarshaller,
     registry,
-    storageNode,
     zoe,
   });
 
@@ -232,9 +231,10 @@ export const start = async (zcf, privateArgs, baggage) => {
         /** @type {() => Promise<import('./smartWallet').SmartWallet>} */
         const maker = async () => {
           const invitationPurse = await E(invitationIssuer).makeEmptyPurse();
-          const wallet = makeSmartWallet(
-            harden({ address, bank, invitationPurse }),
-          ).self;
+          const walletStorageNode = E(storageNode).makeChildNode(address);
+          const wallet = await makeSmartWallet(
+            harden({ address, walletStorageNode, bank, invitationPurse }),
+          );
 
           // An await here would deadlock with invitePSMCommitteeMembers
           void publishDepositFacet(address, wallet, namesByAddressAdmin);

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -1,0 +1,75 @@
+import {
+  makeScalarBigMapStore,
+  provide,
+  provideDurableSetStore,
+} from '@agoric/vat-data';
+import { Far } from '@endo/marshal';
+
+/**
+ * @template K Key
+ * @template {{}} E Ephemeral state
+ * @param {() => E} init
+ */
+export const makeEphemeraProvider = init => {
+  /** @type {Map<K, E>} */
+  const ephemeras = new Map();
+
+  /**
+   * Provide an object to hold state that need not (or cannot) be durable.
+   *
+   * @type {(key: K) => E}
+   */
+  return key => {
+    if (ephemeras.has(key)) {
+      // @ts-expect-error cast
+      return ephemeras.get(key);
+    }
+    const newEph = init();
+    ephemeras.set(key, newEph);
+    return newEph;
+  };
+};
+harden(makeEphemeraProvider);
+
+/**
+ *
+ * @param {ZCF} zcf
+ * @param {import('@agoric/ertp').Baggage} baggage
+ * @param {string} name
+ * @returns {ZCFSeat}
+ */
+export const provideEmptySeat = (zcf, baggage, name) => {
+  return provide(baggage, name, () => zcf.makeEmptySeatKit().zcfSeat);
+};
+harden(provideEmptySeat);
+
+/**
+ * For making singletons, so that each baggage carries a separate kind definition (albeit of the definer)
+ *
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {string} category diagnostic tag
+ */
+export const provideChildBaggage = (baggage, category) => {
+  const baggageSet = provideDurableSetStore(baggage, `${category}Set`);
+  return Far('childBaggageManager', {
+    // TODO(types) infer args
+    /**
+     * @template {(baggage: import('@agoric/ertp').Baggage, ...rest: any) => any} M Maker function
+     * @param {string} childName diagnostic tag
+     * @param {M} makeChild
+     * @param {...any} nonBaggageArgs
+     * @returns {ReturnType<M>}
+     */
+    addChild: (childName, makeChild, ...nonBaggageArgs) => {
+      const childStore = makeScalarBigMapStore(`${childName}${category}`, {
+        durable: true,
+      });
+      const result = makeChild(childStore, ...nonBaggageArgs);
+      baggageSet.add(childStore);
+      return result;
+    },
+    children: () => baggageSet.values(),
+  });
+};
+harden(provideChildBaggage);
+/** @typedef {ReturnType<typeof provideChildBaggage>} ChildBaggageManager */

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -9,26 +9,25 @@ import { Far } from '@endo/marshal';
 /// <reference types="@agoric/notifier/src/types-ambient.js"/>
 
 /**
- * @template K Key
  * @template {{}} E Ephemeral state
  * @param {() => E} init
  */
 export const makeEphemeraProvider = init => {
-  /** @type {Map<K, E>} */
-  const ephemeras = new Map();
+  /** @type {WeakMap<any, E>} */
+  const extant = new WeakMap();
 
   /**
    * Provide an object to hold state that need not (or cannot) be durable.
    *
-   * @type {(key: K) => E}
+   * @type {(key: any) => E}
    */
   return key => {
-    if (ephemeras.has(key)) {
+    if (extant.has(key)) {
       // @ts-expect-error cast
-      return ephemeras.get(key);
+      return extant.get(key);
     }
     const newEph = init();
-    ephemeras.set(key, newEph);
+    extant.set(key, newEph);
     return newEph;
   };
 };

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -6,14 +6,11 @@ export {
   calcSecondaryRequired,
 } from './bondingCurves.js';
 
+export * from './durability.js';
+
 export * from './priceAuthority.js';
 
-export {
-  getAmountIn,
-  getAmountOut,
-  getTimestamp,
-  getPriceDescription,
-} from './priceQuote.js';
+export * from './priceQuote.js';
 
 export { natSafeMath } from './safeMath.js';
 


### PR DESCRIPTION
closes: #5894

## Description

Makes the `walletFactory` contract durable. Upgrade deferred to https://github.com/Agoric/agoric-sdk/issues/6878

In support, it moves some /inter-protocol helpers down to /zoe and adds a new `provideStoredSubscriber`. The latter will be replaced soon by TopicMeta tools (à la https://github.com/Agoric/agoric-sdk/pull/6888/ ) so this provider is designed to been drop-in replaced.

It also has a drive-by fix:
- `makeEphemeraProvider` had a strong map for its ephemeras

In this PR I had also included d072f7febc1a8bdc05ab705dd9905c6899a97b86, in the spirit of POLA, but it complicated diagnostic logging so I backed it out. Looking for feedback on whether it's worth doing (and if so I'll do in a separate PR.) @dckc may have thoughts on the ocap discipline.

### Security Considerations

No new assumptions. Improves POLA.

### Scaling Considerations

Small additional RAM for the StoredSubscriber provider.

### Documentation Considerations

--

### Testing Considerations

CI and agops-oracle-smoketest.