### PR TITLE
clean up no-continue

### DIFF
--- a/packages/SwingSet/misc-tools/extract-contract-from-transcript.js
+++ b/packages/SwingSet/misc-tools/extract-contract-from-transcript.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 import fs from 'fs';
 import zlib from 'zlib';
 import readline from 'readline';

--- a/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
+++ b/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
@@ -26,7 +26,6 @@ async function run() {
     // lineNumber += 1;
     const e = JSON.parse(line);
     if (e.vatID !== vatID) {
-      // eslint-disable-next-line no-continue
       continue; // wrong vat, or not associated with any vat
     }
     console.log(`e:`, e.type);

--- a/packages/SwingSet/misc-tools/extract-vat-from-transcript.js
+++ b/packages/SwingSet/misc-tools/extract-vat-from-transcript.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 import fs from 'fs';
 import zlib from 'zlib';
 import readline from 'readline';

--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 import { assert, details as X, q, Fail } from '@agoric/assert';
 import {
   zeroPad,

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -1,5 +1,5 @@
 /// <reference types="ses"/>
-/* eslint-disable no-await-in-loop, no-continue, @jessie.js/no-nested-await */
+/* eslint-disable no-await-in-loop, @jessie.js/no-nested-await */
 
 import { E, Far } from '@endo/far';
 import * as tendermint34 from '@cosmjs/tendermint-rpc';

--- a/packages/cosmic-swingset/src/kernel-stats.js
+++ b/packages/cosmic-swingset/src/kernel-stats.js
@@ -177,7 +177,6 @@ export function makeSlogCallbacks({ metricMeter, attributes = {} }) {
             // Add to aggregated metering stats.
             for (const [key, value] of Object.entries(meterUsage)) {
               if (key === 'meterType') {
-                // eslint-disable-next-line no-continue
                 continue;
               }
               getGroupedRecorder(`swingset_meter_usage`, group, {

--- a/packages/deployment/scripts/crunch.mjs
+++ b/packages/deployment/scripts/crunch.mjs
@@ -1,7 +1,6 @@
 #! /usr/bin/env node
 // crunch.mjs - crunch a kvstore trace file's writes into TSV
 
-/* eslint-disable no-continue */
 /* global process,Buffer */
 
 import fs from 'fs';

--- a/packages/deployment/src/init.js
+++ b/packages/deployment/src/init.js
@@ -372,7 +372,6 @@ const doInit =
         // eslint-disable-next-line no-await-in-loop
         const { PROVIDER } = await askProvider({ inquirer })(PROVIDERS);
         if (!PROVIDER) {
-          // eslint-disable-next-line no-continue
           continue;
         }
         provider = PROVIDERS[PROVIDER];
@@ -400,7 +399,6 @@ const doInit =
             myDetails,
           );
           if (CANCEL) {
-            // eslint-disable-next-line no-continue
             continue;
           }
           // Out with the old, in with the new.
@@ -504,7 +502,7 @@ const doInit =
 
       if (instance === offset) {
         // No nodes added.
-        // eslint-disable-next-line no-continue
+
         continue;
       }
 

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -736,7 +736,6 @@ ${chalk.yellow.bold(`ag-setup-solo --netconfig='${dwebHost}/network-config'`)}
       let sep = '';
       for (const CLUSTER of Object.keys(prov.public_ips.value)) {
         if (!isPublicRpc(prov.roles.value, CLUSTER)) {
-          // eslint-disable-next-line no-continue
           continue;
         }
         const ips = prov.public_ips.value[CLUSTER];
@@ -781,7 +780,6 @@ ${chalk.yellow.bold(`ag-setup-solo --netconfig='${dwebHost}/network-config'`)}
 
       for (const CLUSTER of Object.keys(prov.public_ips.value)) {
         if (!selector(CLUSTER)) {
-          // eslint-disable-next-line no-continue
           continue;
         }
         const ips = prov.public_ips.value[CLUSTER];

--- a/packages/solo/src/outbound.js
+++ b/packages/solo/src/outbound.js
@@ -28,7 +28,7 @@ export function deliver(mbs) {
   for (const target of Object.getOwnPropertyNames(data)) {
     if (!knownTargets.has(target)) {
       log.error(`eek, no delivery method for target`, target);
-      // eslint-disable-next-line no-continue
+
       continue;
     }
     const t = knownTargets.get(target);

--- a/packages/swingset-runner/src/push-metrics.js
+++ b/packages/swingset-runner/src/push-metrics.js
@@ -92,7 +92,6 @@ function gatherMetrics(kind, data, labels, specs) {
   const todo = new Set(Object.keys(data));
   for (const { key, name } of KERNEL_STATS_METRICS) {
     if (!(key in data)) {
-      // eslint-disable-next-line no-continue
       continue;
     }
     todo.delete(key);

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -46,7 +46,6 @@ const main = async () => {
         process.stdout.write(bufStr);
       }
       if (process.stdout.write('\n')) {
-        // eslint-disable-next-line no-continue
         continue;
       }
 

--- a/packages/vats/src/authorityViz.js
+++ b/packages/vats/src/authorityViz.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 // @ts-check
 import '@endo/init';
 import process from 'process';

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -56,7 +56,7 @@
   "eslintConfig": {
     "extends": [
       "@open-wc",
-      "@endo"
+      "@agoric"
     ],
     "rules": {
       "import/no-extraneous-dependencies": "off",

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -173,7 +173,6 @@ async function runTestScript(
 
     for (const name of testNames) {
       if (titleMatch && !isMatch(name, titleMatch)) {
-        // eslint-disable-next-line no-continue
         continue;
       }
       assertionStatus = { ok: 0, 'not ok': 0, SKIP: 0 };
@@ -357,7 +356,7 @@ export async function main(
   for (const filename of files) {
     if (exclude && exclude.filter(s => filename.match(s)).length > 0) {
       console.warn('# SKIP test excluded on XS', filename);
-      // eslint-disable-next-line no-continue
+
       continue;
     } else if (verbose) {
       console.log('# test script:', filename);

--- a/packages/xsnap/src/object-inspect.js
+++ b/packages/xsnap/src/object-inspect.js
@@ -497,11 +497,9 @@ function arrObjKeys(obj, inspect) {
   const syms = getOwnPropertySymbols(obj);
   for (const key of getOwnPropertyNames(obj)) {
     if (!isEnumerable.call(obj, key)) {
-      // eslint-disable-next-line no-continue
       continue;
     }
     if (isArr && String(Number(key)) === key && key < obj.length) {
-      // eslint-disable-next-line no-continue
       continue;
     }
     if ($test.call(/[^\w$]/, key)) {


### PR DESCRIPTION
## Description

https://github.com/Agoric/agoric-sdk/pull/6739 disabled the [no-continue](https://eslint.org/docs/latest/rules/no-continue). In https://github.com/Agoric/agoric-sdk/pull/6876 I had to suppress it for web-components because it extended the Endo config.

This makes that package extend Agoric config instead. It also deletes other `no-continue` suppressions.

But I think we should also disable `no-continue` in Endo. WDYT reviewers ? 
