### PR TITLE
sync getTopics

### DIFF
--- a/packages/SwingSet/src/liveslots/watchedPromises.js
+++ b/packages/SwingSet/src/liveslots/watchedPromises.js
@@ -164,6 +164,14 @@ export function makeWatchedPromiseManager(
     }
   }
 
+  /**
+   *
+   * @template {object} T
+   * @template {any[]} A args
+   * @param {Promise<T>} p
+   * @param {{onFulfilled: (T, ...A) => void, onRejected: (reason: any, ...A) => void}} watcher durable object handling resolution of the promise
+   * @param {A} args added to calls to the watcher's handlers
+   */
   function watchPromise(p, watcher, ...args) {
     // The following wrapping defers setting up the promise watcher itself to a
     // later turn so that if the promise to be watched was the return value from

--- a/packages/agoric-cli/test/agops-oracle-smoketest.sh
+++ b/packages/agoric-cli/test/agops-oracle-smoketest.sh
@@ -57,6 +57,14 @@ bin/agops oracle pushPriceRound --price 101 --roundId 1 --oracleAdminAcceptOffer
 jq ".body | fromjson" <"$PROPOSAL_OFFER"
 agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET" --keyring-backend="test"
 
+# submit another price in the round from the second oracle
+PROPOSAL_OFFER=$(mktemp -t agops.XXX)
+bin/agops oracle pushPriceRound --price 201 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
+jq ".body | fromjson" <"$PROPOSAL_OFFER"
+agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET2" --keyring-backend="test"
+
+## Additional validation
+
 # verify that the offer was satisfied
 echo "Offer $ORACLE_OFFER_ID should have numWantsSatisfied: 1"
 agoric wallet show --from "$WALLET" --keyring-backend="test"
@@ -66,12 +74,6 @@ agd query vstorage keys published.priceFeed
 
 # verify that the round started
 agoric follow :published.priceFeed.ATOM-USD_price_feed.latestRound
-
-# submit another price in the round from the second oracle
-PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPriceRound --price 201 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
-jq ".body | fromjson" <"$PROPOSAL_OFFER"
-agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET2" --keyring-backend="test"
 
 # second round, first oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -18,17 +18,16 @@ export const ratioPattern = harden({
 
 export const TopicMetaShape = M.splitRecord(
   {
-    subscriber: SubscriberShape,
+    topic: SubscriberShape,
     storagePath: M.string(),
   },
   { description: M.string() },
 );
-// TODO rename 'subscriber' field to 'topic'
 /**
  * @template {object} T topic value
  * @typedef {{
  *   description?: string,
- *   subscriber: ERef<Subscriber<T>>,
+ *   topic: ERef<Subscriber<T>>,
  *   storagePath: string,
  * }} TopicMeta
  */

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -1,9 +1,5 @@
 import { AmountMath } from '@agoric/ertp';
-import {
-  makeStoredPublisherKit,
-  makeStoredPublishKit,
-  SubscriberShape,
-} from '@agoric/notifier';
+import { makeStoredPublisherKit, makeStoredPublishKit } from '@agoric/notifier';
 import { M } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { deeplyFulfilled } from '@endo/marshal';
@@ -16,36 +12,12 @@ export const ratioPattern = harden({
   denominator: amountPattern,
 });
 
-export const TopicMetaShape = M.splitRecord(
-  {
-    topic: SubscriberShape,
-    storagePath: M.string(),
-  },
-  { description: M.string() },
-);
-/**
- * @template {object} T topic value
- * @typedef {{
- *   description?: string,
- *   topic: ERef<Subscriber<T>>,
- *   storagePath: string,
- * }} TopicMeta
- */
-
-export const TopicMetasRecordShape = M.recordOf(M.string(), TopicMetaShape);
-
-/**
- * @typedef {{
- *   [topicName: string]: TopicMeta<unknown>,
- * }} TopicMetasRecord
- */
-
 /**
  * @template {Readonly<{
- *   [subscriberKey: string]: Omit<TopicMeta<any>, 'storagePath'> & { storagePath: Promise<string>}
+ *   [subscriberKey: string]: Omit<import('@agoric/notifier').TopicMeta<any>, 'storagePath'> & { storagePath: Promise<string>}
  * }>} R
  * @param {R} unfulfilled
- * @returns {Promise<Readonly<{ [K in keyof R]: R[K]['subscriber'] extends Subscriber<infer T> ? TopicMeta<T> : never }>>}
+ * @returns {Promise<Readonly<{ [K in keyof R]: R[K]['subscriber'] extends Subscriber<infer T> ? import('@agoric/notifier').TopicMeta<T> : never }>>}
  */
 export const fulfilledTopicMetasRecord = async unfulfilled => {
   return deeplyFulfilled(harden(unfulfilled));

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -1,5 +1,9 @@
 import { AmountMath } from '@agoric/ertp';
-import { makeStoredPublisherKit, makeStoredPublishKit } from '@agoric/notifier';
+import {
+  makeStoredPublisherKit,
+  makeStoredPublishKit,
+  SubscriberShape,
+} from '@agoric/notifier';
 import { M } from '@agoric/store';
 import {
   makeScalarBigMapStore,
@@ -16,6 +20,11 @@ export const ratioPattern = harden({
   numerator: amountPattern,
   denominator: amountPattern,
 });
+
+export const SubscribersRecordShape = M.recordOf(M.string(), [
+  SubscriberShape,
+  M.string(),
+]);
 
 /**
  * Apply a delta to the `base` Amount, where the delta is represented as

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -11,7 +11,7 @@ import {
   provideDurableSetStore,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { deeplyFulfilled, Far } from '@endo/marshal';
 
 const { Fail, quote: q } = assert;
 
@@ -25,6 +25,22 @@ export const SubscribersRecordShape = M.recordOf(M.string(), [
   SubscriberShape,
   M.string(),
 ]);
+/**
+ * @typedef {{
+ *   [subscriberKey: string]: [ERef<Subscriber<unknown>>, string?]
+ * }} SubscribersRecord */
+
+/**
+ * @template {Readonly<{
+ *   [subscriberKey: string]: readonly [Subscriber<unknown>, Promise<string>?]
+ * }>} T
+ * @param {T} unfulfilled
+ * @returns {Promise<Readonly<{ [K in keyof T]: [T[K][0], Awaited<T[K][1]>] }>>}
+ */
+export const fulfilledSubscribersRecord = async unfulfilled => {
+  return deeplyFulfilled(harden(unfulfilled));
+};
+harden(fulfilledSubscribersRecord);
 
 /**
  * Apply a delta to the `base` Amount, where the delta is represented as

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -5,13 +5,8 @@ import {
   SubscriberShape,
 } from '@agoric/notifier';
 import { M } from '@agoric/store';
-import {
-  makeScalarBigMapStore,
-  provide,
-  provideDurableSetStore,
-} from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
-import { deeplyFulfilled, Far } from '@endo/marshal';
+import { deeplyFulfilled } from '@endo/marshal';
 
 const { Fail, quote: q } = assert;
 
@@ -172,72 +167,3 @@ export const makeMetricsPublishKit = (storageNode, marshaller) => {
   };
 };
 harden(makeMetricsPublishKit);
-
-/**
- * @template K Key
- * @template {{}} E Ephemeral state
- * @param {() => E} init
- */
-export const makeEphemeraProvider = init => {
-  /** @type {Map<K, E>} */
-  const ephemeras = new Map();
-
-  /**
-   * Provide an object to hold state that need not (or cannot) be durable.
-   *
-   * @type {(key: K) => E}
-   */
-  return key => {
-    if (ephemeras.has(key)) {
-      // @ts-expect-error cast
-      return ephemeras.get(key);
-    }
-    const newEph = init();
-    ephemeras.set(key, newEph);
-    return newEph;
-  };
-};
-harden(makeEphemeraProvider);
-
-/**
- *
- * @param {ZCF} zcf
- * @param {import('@agoric/ertp').Baggage} baggage
- * @param {string} name
- * @returns {ZCFSeat}
- */
-export const provideEmptySeat = (zcf, baggage, name) => {
-  return provide(baggage, name, () => zcf.makeEmptySeatKit().zcfSeat);
-};
-harden(provideEmptySeat);
-
-/**
- * For making singletons, so that each baggage carries a separate kind definition (albeit of the definer)
- *
- * @param {import('@agoric/vat-data').Baggage} baggage
- * @param {string} category diagnostic tag
- */
-export const provideChildBaggage = (baggage, category) => {
-  const baggageSet = provideDurableSetStore(baggage, `${category}Set`);
-  return Far('childBaggageManager', {
-    // TODO(types) infer args
-    /**
-     * @template {(baggage: import('@agoric/ertp').Baggage, ...rest: any) => any} M Maker function
-     * @param {string} childName diagnostic tag
-     * @param {M} makeChild
-     * @param {...any} nonBaggageArgs
-     * @returns {ReturnType<M>}
-     */
-    addChild: (childName, makeChild, ...nonBaggageArgs) => {
-      const childStore = makeScalarBigMapStore(`${childName}${category}`, {
-        durable: true,
-      });
-      const result = makeChild(childStore, ...nonBaggageArgs);
-      baggageSet.add(childStore);
-      return result;
-    },
-    children: () => baggageSet.values(),
-  });
-};
-harden(provideChildBaggage);
-/** @typedef {ReturnType<typeof provideChildBaggage>} ChildBaggageManager */

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -19,7 +19,7 @@ export const ratioPattern = harden({
 export const TopicMetaShape = M.splitRecord(
   {
     subscriber: SubscriberShape,
-    vstoragePath: M.string(),
+    storagePath: M.string(),
   },
   { description: M.string() },
 );
@@ -29,7 +29,7 @@ export const TopicMetaShape = M.splitRecord(
  * @typedef {{
  *   description?: string,
  *   subscriber: ERef<Subscriber<T>>,
- *   vstoragePath: string,
+ *   storagePath: string,
  * }} TopicMeta
  */
 
@@ -43,7 +43,7 @@ export const TopicMetasRecordShape = M.recordOf(M.string(), TopicMetaShape);
 
 /**
  * @template {Readonly<{
- *   [subscriberKey: string]: Omit<TopicMeta<any>, 'vstoragePath'> & { vstoragePath: Promise<string>}
+ *   [subscriberKey: string]: Omit<TopicMeta<any>, 'storagePath'> & { storagePath: Promise<string>}
  * }>} R
  * @param {R} unfulfilled
  * @returns {Promise<Readonly<{ [K in keyof R]: R[K]['subscriber'] extends Subscriber<infer T> ? TopicMeta<T> : never }>>}

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -16,26 +16,42 @@ export const ratioPattern = harden({
   denominator: amountPattern,
 });
 
-export const SubscribersRecordShape = M.recordOf(M.string(), [
-  SubscriberShape,
-  M.string(),
-]);
+export const TopicMetaShape = M.splitRecord(
+  {
+    subscriber: SubscriberShape,
+    vstoragePath: M.string(),
+  },
+  { description: M.string() },
+);
+// TODO rename 'subscriber' field to 'topic'
+/**
+ * @template {object} T topic value
+ * @typedef {{
+ *   description?: string,
+ *   subscriber: ERef<Subscriber<T>>,
+ *   vstoragePath: string,
+ * }} TopicMeta
+ */
+
+export const TopicMetasRecordShape = M.recordOf(M.string(), TopicMetaShape);
+
 /**
  * @typedef {{
- *   [subscriberKey: string]: [ERef<Subscriber<unknown>>, string?]
- * }} SubscribersRecord */
+ *   [topicName: string]: TopicMeta<unknown>,
+ * }} TopicMetasRecord
+ */
 
 /**
  * @template {Readonly<{
- *   [subscriberKey: string]: readonly [Subscriber<unknown>, Promise<string>?]
- * }>} T
- * @param {T} unfulfilled
- * @returns {Promise<Readonly<{ [K in keyof T]: [T[K][0], Awaited<T[K][1]>] }>>}
+ *   [subscriberKey: string]: Omit<TopicMeta<any>, 'vstoragePath'> & { vstoragePath: Promise<string>}
+ * }>} R
+ * @param {R} unfulfilled
+ * @returns {Promise<Readonly<{ [K in keyof R]: R[K]['subscriber'] extends Subscriber<infer T> ? TopicMeta<T> : never }>>}
  */
-export const fulfilledSubscribersRecord = async unfulfilled => {
+export const fulfilledTopicMetasRecord = async unfulfilled => {
   return deeplyFulfilled(harden(unfulfilled));
 };
-harden(fulfilledSubscribersRecord);
+harden(fulfilledTopicMetasRecord);
 
 /**
  * Apply a delta to the `base` Amount, where the delta is represented as

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -459,7 +459,7 @@ export { start };
  * @property {() => Allocation} getAllocations
  * @property {(issuer: Issuer) => void} addIssuer
  * @property {() => Invitation<ShortfallReporter>} makeShortfallReportingInvitation
- * @property {() => MetricsNotification} getMetrics
+ * @property {() => StoredSubscription<MetricsNotification>} getMetrics
  */
 
 /**

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -100,7 +100,7 @@ const validTransitions = {
  * @typedef {Readonly<{
  * idInManager: VaultId,
  * manager: VaultManager,
- * storageNodeKit: StorageNodeKit,
+ * storageNode: StorageNode,
  * vaultSeat: ZCFSeat,
  * }>} ImmutableState
  */
@@ -182,17 +182,17 @@ export const prepareVault = (baggage, marshaller, zcf) => {
     /**
      * @param {VaultManager} manager
      * @param {VaultId} idInManager
-     * @param {StorageNodeKit} storageNodeKit
+     * @param {StorageNode} storageNode
      * @returns {ImmutableState & MutableState}
      */
-    (manager, idInManager, storageNodeKit) => {
+    (manager, idInManager, storageNode) => {
       return harden({
         idInManager,
         manager,
         outerUpdater: null,
         phase: Phase.ACTIVE,
 
-        storageNodeKit,
+        storageNode,
 
         // vaultSeat will hold the collateral until the loan is retired. The
         // payout from it will be handed to the user: if the vault dies early
@@ -589,7 +589,7 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           // eslint-disable-next-line no-use-before-define
           const vaultKit = makeVaultKit(
             self,
-            state.storageNodeKit,
+            state.storageNode,
             state.manager.getAssetSubscriber(),
           );
           state.outerUpdater = vaultKit.vaultUpdater;
@@ -605,9 +605,9 @@ export const prepareVault = (baggage, marshaller, zcf) => {
 
         /**
          * @param {ZCFSeat} seat
-         * @param {StorageNodeKit} storageNodeKit
+         * @param {StorageNode} storageNode
          */
-        async initVaultKit(seat, storageNodeKit) {
+        async initVaultKit(seat, storageNode) {
           const { state, facets } = this;
 
           const { self, helper } = facets;
@@ -663,7 +663,7 @@ export const prepareVault = (baggage, marshaller, zcf) => {
 
           const vaultKit = makeVaultKit(
             self,
-            storageNodeKit,
+            storageNode,
             state.manager.getAssetSubscriber(),
           );
           state.outerUpdater = vaultKit.vaultUpdater;

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -496,7 +496,6 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           );
           // max debt supported by current Collateral as modified by proposal
           const maxDebtPre = await state.manager.maxDebtFor(newCollateralPre);
-          console.log('DEBUG', { updaterPre }, state);
           updaterPre === state.outerUpdater ||
             Fail`Transfer during vault adjustment`;
           helper.assertActive();

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -496,6 +496,7 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           );
           // max debt supported by current Collateral as modified by proposal
           const maxDebtPre = await state.manager.maxDebtFor(newCollateralPre);
+          console.log('DEBUG', { updaterPre }, state);
           updaterPre === state.outerUpdater ||
             Fail`Transfer during vault adjustment`;
           helper.assertActive();
@@ -577,9 +578,8 @@ export const prepareVault = (baggage, marshaller, zcf) => {
         /**
          *
          * @param {ZCFSeat} seat
-         * @returns {VaultKit}
          */
-        makeTransferInvitationHook(seat) {
+        async makeTransferInvitationHook(seat) {
           const { state, facets } = this;
 
           const { self, helper } = facets;
@@ -587,7 +587,7 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           seat.exit();
 
           // eslint-disable-next-line no-use-before-define
-          const vaultKit = makeVaultKit(
+          const vaultKit = await makeVaultKit(
             self,
             state.storageNode,
             state.manager.getAssetSubscriber(),
@@ -661,7 +661,7 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           );
           trace('initVault updateDebtAccounting fired');
 
-          const vaultKit = makeVaultKit(
+          const vaultKit = await makeVaultKit(
             self,
             storageNode,
             state.manager.getAssetSubscriber(),

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -1,5 +1,6 @@
 import { AmountMath, AmountShape } from '@agoric/ertp';
 import { makeTracer } from '@agoric/internal';
+import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
 import { M, prepareExoClassKit } from '@agoric/vat-data';
 import {
   assertProposalShape,
@@ -155,8 +156,7 @@ export const VaultI = M.interface('Vault', {
   getCurrentDebt: M.call().returns(AmountShape),
   getNormalizedDebt: M.call().returns(AmountShape),
   getVaultSeat: M.call().returns(SeatShape),
-  // FIXME m.any
-  initVaultKit: M.call(SeatShape, M.any()).returns(M.promise()),
+  initVaultKit: M.call(SeatShape, StorageNodeShape).returns(M.promise()),
   liquidated: M.call().returns(undefined),
   liquidating: M.call().returns(undefined),
   makeAdjustBalancesInvitation: M.call().returns(M.promise()),
@@ -578,7 +578,7 @@ export const prepareVault = (baggage, marshaller, zcf) => {
          *
          * @param {ZCFSeat} seat
          */
-        async makeTransferInvitationHook(seat) {
+        makeTransferInvitationHook(seat) {
           const { state, facets } = this;
 
           const { self, helper } = facets;

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -513,7 +513,7 @@ export const prepareVaultDirector = (
           return fulfilledTopicMetasRecord(
             /** @type {const} */ ({
               metrics: {
-                subscriber: metricsSubscriber,
+                topic: metricsSubscriber,
                 storagePath: storedMetricsSubscriber.getPath(),
               },
             }),

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -31,10 +31,7 @@ import {
 } from '@agoric/vat-data';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
-import {
-  fulfilledTopicMetasRecord,
-  TopicMetasRecordShape,
-} from '../contractSupport.js';
+import { fulfilledTopicMetasRecord } from '../contractSupport.js';
 import {
   CHARGING_PERIOD_KEY,
   makeVaultParamManager,

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -514,7 +514,7 @@ export const prepareVaultDirector = (
             /** @type {const} */ ({
               metrics: {
                 subscriber: metricsSubscriber,
-                vstoragePath: storedMetricsSubscriber.getPath(),
+                storagePath: storedMetricsSubscriber.getPath(),
               },
             }),
           );

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -37,7 +37,11 @@ import {
   vaultParamPattern,
 } from './params.js';
 import { prepareVaultManagerKit } from './vaultManager.js';
-import { provideChildBaggage, provideEmptySeat } from '../contractSupport.js';
+import {
+  provideChildBaggage,
+  provideEmptySeat,
+  SubscribersRecordShape,
+} from '../contractSupport.js';
 
 const { details: X, quote: q, Fail } = assert;
 
@@ -220,7 +224,7 @@ export const prepareVaultDirector = (
       public: M.interface('public', {
         getCollateralManager: M.call(BrandShape).returns(M.remotable()),
         getCollaterals: M.call().returns(M.promise()),
-        getMetrics: M.call().returns(SubscriberShape),
+        getSubscribers: M.call().returns(SubscribersRecordShape),
         makeVaultInvitation: M.call().returns(M.promise()),
         getRunIssuer: M.call().returns(IssuerShape),
         getSubscription: M.call({ collateralBrand: BrandShape }).returns(
@@ -459,9 +463,6 @@ export const prepareVaultDirector = (
             ),
           );
         },
-        getMetrics() {
-          return storedMetricsSubscriber;
-        },
         /**
          * @deprecated use getCollateralManager and then makeVaultInvitation instead
          *
@@ -500,12 +501,19 @@ export const prepareVaultDirector = (
           return debtMint.getIssuerRecord().issuer;
         },
         /**
+         * @deprecated ask the vault manager
+         *
          * subscription for the paramManager for a particular vaultManager
          *
          * @param {{ collateralBrand: Brand }} selector
          */
         getSubscription({ collateralBrand }) {
           return vaultParamManagers.get(collateralBrand).getSubscription();
+        },
+        getSubscribers() {
+          return {
+            metrics: [metricsSubscriber, storedMetricsSubscriber.getPath()],
+          };
         },
         /**
          * subscription for the paramManager for the vaultFactory's electorate

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -4,11 +4,14 @@ import '@agoric/zoe/src/contracts/exported.js';
 import '@agoric/governance/exported.js';
 import { E } from '@endo/eventual-send';
 
-import { mustMatch, keyEQ, M, makeScalarMapStore } from '@agoric/store';
+import { keyEQ, M, makeScalarMapStore, mustMatch } from '@agoric/store';
 import {
   assertProposalShape,
   getAmountIn,
   getAmountOut,
+  provideChildBaggage,
+  provideEmptySeat,
+  unitAmount,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { Far } from '@endo/marshal';
@@ -18,8 +21,8 @@ import {
   makeStoredPublisherKit,
   makeStoredSubscriber,
   observeIteration,
-  SubscriberShape,
   prepareDurablePublishKit,
+  SubscriberShape,
 } from '@agoric/notifier';
 import {
   defineDurableExoClassKit,
@@ -27,7 +30,6 @@ import {
   provideDurableMapStore,
 } from '@agoric/vat-data';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
-import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import {
   CHARGING_PERIOD_KEY,
@@ -37,11 +39,6 @@ import {
   vaultParamPattern,
 } from './params.js';
 import { prepareVaultManagerKit } from './vaultManager.js';
-import {
-  provideChildBaggage,
-  provideEmptySeat,
-  SubscribersRecordShape,
-} from '../contractSupport.js';
 
 const { details: X, quote: q, Fail } = assert;
 

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -8,7 +8,7 @@ import {
   prepareDurablePublishKit,
 } from '@agoric/notifier';
 import { M, prepareExoClassKit } from '@agoric/vat-data';
-import { makeEphemeraProvider } from '../contractSupport.js';
+import { makeEphemeraProvider } from '@agoric/zoe/src/contractSupport/index.js';
 import { UnguardedHelperI } from '../typeGuards.js';
 
 const { Fail } = assert;

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -93,10 +93,12 @@ export const prepareVaultHolder = (baggage, marshaller) => {
         },
       },
       holder: {
-        /** @returns {StoredSubscriber<VaultNotification>} */
-        getSubscriber() {
+        getSubscribers() {
+          const { subscriber } = this.state;
           const ephemera = provideEphemera(this.state.subscriber);
-          return ephemera.storedSubscriber;
+          return {
+            vault: [subscriber, ephemera.storedSubscriber.getPath()],
+          };
         },
         makeAdjustBalancesInvitation() {
           return this.facets.helper.owned().makeAdjustBalancesInvitation();

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -99,7 +99,7 @@ export const prepareVaultHolder = (baggage, marshaller) => {
           return /** @type {const} */ ({
             vault: {
               subscriber,
-              vstoragePath: storageNodeKit.path,
+              storagePath: storageNodeKit.path,
             },
           });
         },

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -26,9 +26,9 @@ export const prepareVaultKit = (baggage, marshaller) => {
     const { holder, helper } = makeVaultHolder(vault, storageNode);
     const vaultKit = harden({
       publicSubscribers: {
-        // XXX should come from manager directly https://github.com/Agoric/agoric-sdk/issues/5814
+        // @deprecated get from manager directly https://github.com/Agoric/agoric-sdk/issues/5814
         asset: assetSubscriber,
-        vault: holder.getSubscriber(),
+        vault: holder.getSubscribers().vault,
       },
       invitationMakers: Far('invitation makers', {
         AdjustBalances: () => holder.makeAdjustBalancesInvitation(),

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -18,13 +18,13 @@ export const prepareVaultKit = (baggage, marshaller) => {
    * Create a kit of utilities for use of the vault.
    *
    * @param {Vault} vault
-   * @param {ERef<StorageNode>} storageNode
+   * @param {StorageNodeKit} storageNodeKit
    * @param {Subscriber<import('./vaultManager').AssetState>} assetSubscriber
    */
-  const makeVaultKit = async (vault, storageNode, assetSubscriber) => {
+  const makeVaultKit = (vault, storageNodeKit, assetSubscriber) => {
     trace('prepareVaultKit makeVaultKit');
-    const { holder, helper } = makeVaultHolder(vault, storageNode);
-    const holderTopics = await holder.getTopics();
+    const { holder, helper } = makeVaultHolder(vault, storageNodeKit);
+    const holderTopics = holder.getTopics();
     console.log('DEBUG', { holderTopics });
     const vaultKit = harden({
       publicSubscribers: {

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -21,16 +21,15 @@ export const prepareVaultKit = (baggage, marshaller) => {
    * @param {StorageNode} storageNode
    * @param {Subscriber<import('./vaultManager').AssetState>} assetSubscriber
    */
-  // MUST BE SYNC FOR TRANSFER
   const makeVaultKit = (vault, storageNode, assetSubscriber) => {
     trace('prepareVaultKit makeVaultKit');
     const { holder, helper } = makeVaultHolder(vault, storageNode);
     const holderTopics = holder.getTopics();
-    console.log('DEBUG', { holderTopics });
     const vaultKit = harden({
       publicSubscribers: {
+        // NB this is a plain Subscriber, before the introduction of TopicMeta
         // @deprecated get from manager directly https://github.com/Agoric/agoric-sdk/issues/5814
-        asset: { topic: assetSubscriber },
+        asset: assetSubscriber,
         vault: holderTopics.vault,
       },
       invitationMakers: Far('invitation makers', {

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -21,14 +21,16 @@ export const prepareVaultKit = (baggage, marshaller) => {
    * @param {ERef<StorageNode>} storageNode
    * @param {Subscriber<import('./vaultManager').AssetState>} assetSubscriber
    */
-  const makeVaultKit = (vault, storageNode, assetSubscriber) => {
+  const makeVaultKit = async (vault, storageNode, assetSubscriber) => {
     trace('prepareVaultKit makeVaultKit');
     const { holder, helper } = makeVaultHolder(vault, storageNode);
+    const holderTopics = await holder.getTopics();
+    console.log('DEBUG', { holderTopics });
     const vaultKit = harden({
       publicSubscribers: {
         // @deprecated get from manager directly https://github.com/Agoric/agoric-sdk/issues/5814
-        asset: assetSubscriber,
-        vault: holder.getSubscribers().vault,
+        asset: { subscriber: assetSubscriber },
+        vault: holderTopics.vault,
       },
       invitationMakers: Far('invitation makers', {
         AdjustBalances: () => holder.makeAdjustBalancesInvitation(),
@@ -43,4 +45,4 @@ export const prepareVaultKit = (baggage, marshaller) => {
   return makeVaultKit;
 };
 
-/** @typedef {(ReturnType<ReturnType<typeof prepareVaultKit>>)} VaultKit */
+/** @typedef {Awaited<ReturnType<ReturnType<typeof prepareVaultKit>>>} VaultKit */

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -18,22 +18,20 @@ export const prepareVaultKit = (baggage, marshaller) => {
    * Create a kit of utilities for use of the vault.
    *
    * @param {Vault} vault
-   * @param {StorageNodeKit} storageNodeKit
+   * @param {StorageNode} storageNode
    * @param {Subscriber<import('./vaultManager').AssetState>} assetSubscriber
    */
-  const makeVaultKit = (vault, storageNodeKit, assetSubscriber) => {
+  // MUST BE SYNC FOR TRANSFER
+  const makeVaultKit = (vault, storageNode, assetSubscriber) => {
     trace('prepareVaultKit makeVaultKit');
-    const { holder, helper } = makeVaultHolder(vault, storageNodeKit);
+    const { holder, helper } = makeVaultHolder(vault, storageNode);
     const holderTopics = holder.getTopics();
     console.log('DEBUG', { holderTopics });
     const vaultKit = harden({
       publicSubscribers: {
         // @deprecated get from manager directly https://github.com/Agoric/agoric-sdk/issues/5814
-        asset: { subscriber: assetSubscriber },
+        asset: { topic: assetSubscriber },
         vault: holderTopics.vault,
-      },
-      publicPaths: {
-        vault: '',
       },
       invitationMakers: Far('invitation makers', {
         AdjustBalances: () => holder.makeAdjustBalancesInvitation(),

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -32,6 +32,9 @@ export const prepareVaultKit = (baggage, marshaller) => {
         asset: { subscriber: assetSubscriber },
         vault: holderTopics.vault,
       },
+      publicPaths: {
+        vault: '',
+      },
       invitationMakers: Far('invitation makers', {
         AdjustBalances: () => holder.makeAdjustBalancesInvitation(),
         CloseVault: () => holder.makeCloseInvitation(),

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -44,10 +44,11 @@ import {
   getAmountOut,
   makeRatio,
   makeRatioFromAmounts,
+  provideEmptySeat,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { InstallationShape, SeatShape } from '@agoric/zoe/src/typeGuards.js';
 import { E } from '@endo/eventual-send';
-import { checkDebtLimit, provideEmptySeat } from '../contractSupport.js';
+import { checkDebtLimit } from '../contractSupport.js';
 import { chargeInterest } from '../interest.js';
 import { liquidate, makeQuote, updateQuote } from './liquidation.js';
 import { makePrioritizedVaults } from './prioritizedVaults.js';

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -792,17 +792,17 @@ export const prepareVaultManagerKit = (
           const vaultId = String(state.vaultCounter);
 
           // must be a presence to be stored in vault state
-          const vaultNode = await E(
+          const vaultStorageNode = await E(
             E(storageNode).makeChildNode(`vaults`),
           ).makeChildNode(`vault${vaultId}`);
 
-          const { self: vault } = makeVault(manager, vaultId, vaultNode);
+          const { self: vault } = makeVault(manager, vaultId, vaultStorageNode);
           trace('makevaultKit made vault', vault);
 
           try {
             // TODO `await` is allowed until the above ordering is fixed
             // eslint-disable-next-line @jessie.js/no-nested-await
-            const vaultKit = await vault.initVaultKit(seat, vaultNode);
+            const vaultKit = await vault.initVaultKit(seat, vaultStorageNode);
             // initVaultKit calls back to handleBalanceChange() which will add the
             // vault to prioritizedVaults
             seat.exit();

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -301,11 +301,11 @@ export const prepareVaultManagerKit = (
           return fulfilledTopicMetasRecord(
             /** @type {const} */ ({
               asset: {
-                subscriber: assetSubscriber,
+                topic: assetSubscriber,
                 storagePath: storedAssetSubscriber.getPath(),
               },
               metrics: {
-                subscriber: metricsSubscriber,
+                topic: metricsSubscriber,
                 storagePath: storedMetricsSubscriber.getPath(),
               },
             }),

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -302,11 +302,11 @@ export const prepareVaultManagerKit = (
             /** @type {const} */ ({
               asset: {
                 subscriber: assetSubscriber,
-                vstoragePath: storedAssetSubscriber.getPath(),
+                storagePath: storedAssetSubscriber.getPath(),
               },
               metrics: {
                 subscriber: metricsSubscriber,
-                vstoragePath: storedMetricsSubscriber.getPath(),
+                storagePath: storedMetricsSubscriber.getPath(),
               },
             }),
           );

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -51,7 +51,6 @@ import { E } from '@endo/eventual-send';
 import {
   checkDebtLimit,
   fulfilledTopicMetasRecord,
-  TopicMetasRecordShape,
 } from '../contractSupport.js';
 import { chargeInterest } from '../interest.js';
 import { liquidate, makeQuote, updateQuote } from './liquidation.js';
@@ -798,17 +797,17 @@ export const prepareVaultManagerKit = (
           const vaultId = String(state.vaultCounter);
 
           // must be a presence to be stored in vault state
-          const vaultStorageNode = await E(
+          const vaultNodeKit = await E(
             E(storageNode).makeChildNode(`vaults`),
-          ).makeChildNode(`vault${vaultId}`);
+          ).makeChildNodeKit(`vault${vaultId}`);
 
-          const { self: vault } = makeVault(manager, vaultId, vaultStorageNode);
+          const { self: vault } = makeVault(manager, vaultId, vaultNodeKit);
           trace('makevaultKit made vault', vault);
 
           try {
             // TODO `await` is allowed until the above ordering is fixed
             // eslint-disable-next-line @jessie.js/no-nested-await
-            const vaultKit = await vault.initVaultKit(seat, vaultStorageNode);
+            const vaultKit = await vault.initVaultKit(seat, vaultNodeKit);
             // initVaultKit calls back to handleBalanceChange() which will add the
             // vault to prioritizedVaults
             seat.exit();

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -245,7 +245,6 @@ export const prepareVaultManagerKit = (
       collateral: M.interface('collateral', {
         makeVaultInvitation: M.call().returns(M.promise()),
         getSubscriber: M.call().returns(SubscriberShape),
-        getMetrics: M.call().returns(SubscriberShape),
         getQuotes: M.call().returns(NotifierShape),
         getCompoundedInterest: M.call().returns(RatioShape),
       }),
@@ -294,11 +293,11 @@ export const prepareVaultManagerKit = (
             'MakeVault',
           );
         },
-        getSubscriber() {
-          return storedAssetSubscriber;
-        },
-        getMetrics() {
-          return storedMetricsSubscriber;
+        getSubscribers() {
+          return {
+            asset: [assetSubscriber, storedAssetSubscriber.getPath()],
+            metrics: [metricsSubscriber, storedMetricsSubscriber.getPath()],
+          };
         },
         getQuotes() {
           return storedQuotesNotifier;

--- a/packages/inter-protocol/test/metrics.js
+++ b/packages/inter-protocol/test/metrics.js
@@ -45,16 +45,13 @@ export const subscriptionTracker = async (t, subscription) => {
 /**
  * For public facets that have a `getMetrics` method.
  *
- * @template {import('../src/contractSupport.js').TopicMetasRecord} R
+ * @template {{metrics: import('@agoric/notifier').TopicMeta<unknown>}} R
  * @param {import('ava').ExecutionContext} t
- * @param {{getTopics: () => Promise<R>}} publicFacet
- *
+ * @param {{getTopics: () => R}} publicFacet
  */
 export const metricsTracker = async (t, publicFacet) => {
-  const topics = await E(publicFacet).getTopics();
   /** @type {R['metrics']} */
-  // @ts-expect-error cast
-  const metrics = topics.metrics;
+  const metrics = await E.get(E(publicFacet).getTopics()).metrics;
   return subscriptionTracker(t, subscribeEach(metrics.topic));
 };
 

--- a/packages/inter-protocol/test/metrics.js
+++ b/packages/inter-protocol/test/metrics.js
@@ -45,12 +45,13 @@ export const subscriptionTracker = async (t, subscription) => {
 /**
  * For public facets that have a `getMetrics` method.
  *
- * @template {{metrics: import('@agoric/notifier').TopicMeta<unknown>}} R
+ * @template {{ metrics: import('@agoric/notifier').TopicMeta<unknown> }} R
  * @param {import('ava').ExecutionContext} t
  * @param {{getTopics: () => R}} publicFacet
  */
 export const metricsTracker = async (t, publicFacet) => {
   /** @type {R['metrics']} */
+  // @ts-expect-error xxx ERef types
   const metrics = await E.get(E(publicFacet).getTopics()).metrics;
   return subscriptionTracker(t, subscribeEach(metrics.topic));
 };

--- a/packages/inter-protocol/test/metrics.js
+++ b/packages/inter-protocol/test/metrics.js
@@ -55,7 +55,7 @@ export const metricsTracker = async (t, publicFacet) => {
   /** @type {R['metrics']} */
   // @ts-expect-error cast
   const metrics = topics.metrics;
-  return subscriptionTracker(t, subscribeEach(metrics.subscriber));
+  return subscriptionTracker(t, subscribeEach(metrics.topic));
 };
 
 /**

--- a/packages/inter-protocol/test/reserve/test-reserve.js
+++ b/packages/inter-protocol/test/reserve/test-reserve.js
@@ -172,7 +172,6 @@ test('governance add Liquidity to the AMM', async t => {
   );
 
   const metricsSub = await E(reserve.reserveCreatorFacet).getMetrics();
-  // @ts-expect-error type confusion
   const m = await subscriptionTracker(t, metricsSub);
   await m.assertInitial(reserveInitialState(AmountMath.makeEmpty(runBrand)));
 
@@ -341,7 +340,6 @@ test('reserve track shortfall', async t => {
   let runningShortfall = 1000n;
 
   const metricsSub = await E(reserve.reserveCreatorFacet).getMetrics();
-  // @ts-expect-error type confusion
   const m = await subscriptionTracker(t, metricsSub);
   await m.assertInitial(reserveInitialState(AmountMath.makeEmpty(runBrand)));
   await m.assertChange({
@@ -394,7 +392,6 @@ test('reserve burn IST', async t => {
   const runningShortfall = 1000n;
 
   const metricsSub = await E(reserve.reserveCreatorFacet).getMetrics();
-  // @ts-expect-error type confusion
   const m = await subscriptionTracker(t, metricsSub);
   await m.assertInitial(reserveInitialState(AmountMath.makeEmpty(runBrand)));
   await m.assertChange({
@@ -467,7 +464,6 @@ test('storage keys', async t => {
   );
 
   t.is(
-    // @ts-expect-error Type confusion
     await subscriptionKey(E(reserve.reserveCreatorFacet).getMetrics()),
     'mockChainStorageRoot.reserve.metrics',
   );

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -207,6 +207,18 @@ export const subscriptionKey = subscription => {
     });
 };
 
+/**
+ *
+ * @param {ERef<{getSubscribers: () => Promise<import('../src/contractSupport.js').SubscribersRecord>}>} hasSubscribers
+ * @param {string} subscriberName
+ */
+export const subscriptionPath = (hasSubscribers, subscriberName) => {
+  return E(hasSubscribers)
+    .getSubscribers()
+    .then(subscribers => subscribers[subscriberName])
+    .then(([_subscriber, path]) => path);
+};
+
 /** @type {<T>(subscriber: ERef<Subscriber<T>>) => Promise<T>} */
 export const headValue = async subscriber => {
   await eventLoopIteration();

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -209,14 +209,14 @@ export const subscriptionKey = subscription => {
 
 /**
  *
- * @param {ERef<{getSubscribers: () => Promise<import('../src/contractSupport.js').SubscribersRecord>}>} hasSubscribers
+ * @param {ERef<{getTopics: () => Promise<import('../src/contractSupport.js').TopicMetasRecord>}>} hasTopics
  * @param {string} subscriberName
  */
-export const subscriptionPath = (hasSubscribers, subscriberName) => {
-  return E(hasSubscribers)
-    .getSubscribers()
+export const topicPath = (hasTopics, subscriberName) => {
+  return E(hasTopics)
+    .getTopics()
     .then(subscribers => subscribers[subscriberName])
-    .then(([_subscriber, path]) => path);
+    .then(tr => tr.vstoragePath);
 };
 
 /** @type {<T>(subscriber: ERef<Subscriber<T>>) => Promise<T>} */

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -216,7 +216,7 @@ export const topicPath = (hasTopics, subscriberName) => {
   return E(hasTopics)
     .getTopics()
     .then(subscribers => subscribers[subscriberName])
-    .then(tr => tr.vstoragePath);
+    .then(tr => tr.storagePath);
 };
 
 /** @type {<T>(subscriber: ERef<Subscriber<T>>) => Promise<T>} */

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -209,7 +209,7 @@ export const subscriptionKey = subscription => {
 
 /**
  *
- * @param {ERef<{getTopics: () => Promise<import('../src/contractSupport.js').TopicMetasRecord>}>} hasTopics
+ * @param {ERef<{getTopics: () => Promise<import('@agoric/notifier').TopicMetasRecord>}>} hasTopics
  * @param {string} subscriberName
  */
 export const topicPath = (hasTopics, subscriberName) => {

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -209,7 +209,7 @@ export const subscriptionKey = subscription => {
 
 /**
  *
- * @param {ERef<{getTopics: () => Promise<import('@agoric/notifier').TopicMetasRecord>}>} hasTopics
+ * @param {ERef<{getTopics: () => import('@agoric/notifier').TopicMetasRecord}>} hasTopics
  * @param {string} subscriberName
  */
 export const topicPath = (hasTopics, subscriberName) => {

--- a/packages/inter-protocol/test/swingsetTests/governance/vat-alice.js
+++ b/packages/inter-protocol/test/swingsetTests/governance/vat-alice.js
@@ -48,6 +48,7 @@ const build = async (log, zoe, brands, payments, timer) => {
     );
 
     const assetNotifier = makeNotifierFromSubscriber(
+      // @ts-expect-error legit error broken in refactoring
       E(collateralManager).getSubscriber(),
     );
     const { vault } = await E(loanSeat).getOfferResult();

--- a/packages/inter-protocol/test/swingsetTests/vaultFactory/vat-alice.js
+++ b/packages/inter-protocol/test/swingsetTests/vaultFactory/vat-alice.js
@@ -38,7 +38,6 @@ const build = async (log, zoe, brands, payments, timer) => {
       publicSubscribers: { asset: assetSubscriber },
       vault,
     } = await E(loanSeat).getOfferResult();
-    // @ts-expect-error legit error broken in refactoring
     const assetNotifier = makeNotifierFromSubscriber(assetSubscriber);
     const firstNotif = await E(assetNotifier).getUpdateSince();
     log(`Alice owes ${q(await E(vault).getCurrentDebt())} after borrowing`);

--- a/packages/inter-protocol/test/swingsetTests/vaultFactory/vat-alice.js
+++ b/packages/inter-protocol/test/swingsetTests/vaultFactory/vat-alice.js
@@ -38,6 +38,7 @@ const build = async (log, zoe, brands, payments, timer) => {
       publicSubscribers: { asset: assetSubscriber },
       vault,
     } = await E(loanSeat).getOfferResult();
+    // @ts-expect-error legit error broken in refactoring
     const assetNotifier = makeNotifierFromSubscriber(assetSubscriber);
     const firstNotif = await E(assetNotifier).getUpdateSince();
     log(`Alice owes ${q(await E(vault).getCurrentDebt())} after borrowing`);

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -374,7 +374,7 @@ export const makeManagerDriver = async (
     E(lender).getCollateralManager(aeth.brand),
   ).getTopics();
   const managerNotifier = await makeNotifierFromSubscriber(
-    managerTopics.asset.subscriber,
+    managerTopics.asset.topic,
   );
   let managerNotification = await E(managerNotifier).getUpdateSince();
 

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -370,8 +370,11 @@ export const makeManagerDriver = async (
     vaultFactory: { lender, vaultFactory },
     priceAuthority,
   } = services;
+  const managerTopics = await E(
+    E(lender).getCollateralManager(aeth.brand),
+  ).getTopics();
   const managerNotifier = await makeNotifierFromSubscriber(
-    E(E(lender).getCollateralManager(aeth.brand)).getSubscriber(),
+    managerTopics.asset.subscriber,
   );
   let managerNotification = await E(managerNotifier).getUpdateSince();
 
@@ -401,7 +404,9 @@ export const makeManagerDriver = async (
     );
     const { vault, publicSubscribers } = await E(vaultSeat).getOfferResult();
     t.true(await E(vaultSeat).hasExited());
-    const notifier = makeNotifierFromSubscriber(publicSubscribers.vault);
+    const notifier = makeNotifierFromSubscriber(
+      publicSubscribers.vault.subscriber,
+    );
     return {
       getVaultSubscriber: () => publicSubscribers.vault,
       vault: () => vault,

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -405,7 +405,7 @@ export const makeManagerDriver = async (
     const { vault, publicSubscribers } = await E(vaultSeat).getOfferResult();
     t.true(await E(vaultSeat).hasExited());
     const notifier = makeNotifierFromSubscriber(
-      publicSubscribers.vault.subscriber,
+      E.get(publicSubscribers.vault).topic,
     );
     return {
       getVaultSubscriber: () => publicSubscribers.vault,

--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -4,10 +4,7 @@ import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { E } from '@endo/eventual-send';
 import { makeTracer } from '@agoric/internal';
 import '../../src/vaultFactory/types.js';
-import {
-  subscriptionKey,
-  subscriptionPath as publicationPath,
-} from '../supports.js';
+import { subscriptionKey, topicPath } from '../supports.js';
 import { makeDriverContext, makeManagerDriver } from './driver.js';
 
 /** @typedef {import('./driver.js').DriverContext & {
@@ -29,7 +26,7 @@ test('storage keys', async t => {
   // Root vault factory
   const vdp = d.getVaultDirectorPublic();
   t.is(
-    await publicationPath(E(vdp), 'metrics'),
+    await topicPath(vdp, 'metrics'),
     'mockChainStorageRoot.vaultFactory.metrics',
   );
   t.is(
@@ -40,7 +37,7 @@ test('storage keys', async t => {
   // First manager
   const managerA = await E(vdp).getCollateralManager(aeth.brand);
   t.is(
-    await publicationPath(E(managerA), 'metrics'),
+    await topicPath(managerA, 'metrics'),
     'mockChainStorageRoot.vaultFactory.manager0.metrics',
   );
   t.is(
@@ -55,7 +52,7 @@ test('storage keys', async t => {
   // Second manager
   const [managerC, chit] = await d.addVaultType('Chit');
   t.is(
-    await publicationPath(E(managerC).getPublicFacet(), 'metrics'),
+    await topicPath(E(managerC).getPublicFacet(), 'metrics'),
     'mockChainStorageRoot.vaultFactory.manager1.metrics',
   );
   t.is(
@@ -70,14 +67,14 @@ test('storage keys', async t => {
   // First aeth vault
   const vda1 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
   t.is(
-    await subscriptionKey(vda1.getVaultSubscriber()),
+    (await vda1.getVaultSubscriber()).vstoragePath,
     'mockChainStorageRoot.vaultFactory.manager0.vaults.vault1',
   );
 
   // Second aeth vault
   const vda2 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
   t.is(
-    await subscriptionKey(vda2.getVaultSubscriber()),
+    (await vda2.getVaultSubscriber()).vstoragePath,
     'mockChainStorageRoot.vaultFactory.manager0.vaults.vault2',
   );
 });

--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -67,14 +67,14 @@ test('storage keys', async t => {
   // First aeth vault
   const vda1 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
   t.is(
-    (await vda1.getVaultSubscriber()).storagePath,
+    await E.get(vda1.getVaultSubscriber()).storagePath,
     'mockChainStorageRoot.vaultFactory.manager0.vaults.vault1',
   );
 
   // Second aeth vault
   const vda2 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
   t.is(
-    (await vda2.getVaultSubscriber()).storagePath,
+    await E.get(vda2.getVaultSubscriber()).storagePath,
     'mockChainStorageRoot.vaultFactory.manager0.vaults.vault2',
   );
 });

--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -67,14 +67,14 @@ test('storage keys', async t => {
   // First aeth vault
   const vda1 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
   t.is(
-    (await vda1.getVaultSubscriber()).vstoragePath,
+    (await vda1.getVaultSubscriber()).storagePath,
     'mockChainStorageRoot.vaultFactory.manager0.vaults.vault1',
   );
 
   // Second aeth vault
   const vda2 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
   t.is(
-    (await vda2.getVaultSubscriber()).vstoragePath,
+    (await vda2.getVaultSubscriber()).storagePath,
     'mockChainStorageRoot.vaultFactory.manager0.vaults.vault2',
   );
 });

--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -4,7 +4,10 @@ import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { E } from '@endo/eventual-send';
 import { makeTracer } from '@agoric/internal';
 import '../../src/vaultFactory/types.js';
-import { subscriptionKey } from '../supports.js';
+import {
+  subscriptionKey,
+  subscriptionPath as publicationPath,
+} from '../supports.js';
 import { makeDriverContext, makeManagerDriver } from './driver.js';
 
 /** @typedef {import('./driver.js').DriverContext & {
@@ -26,7 +29,7 @@ test('storage keys', async t => {
   // Root vault factory
   const vdp = d.getVaultDirectorPublic();
   t.is(
-    await subscriptionKey(E(vdp).getMetrics()),
+    await publicationPath(E(vdp), 'metrics'),
     'mockChainStorageRoot.vaultFactory.metrics',
   );
   t.is(
@@ -37,7 +40,7 @@ test('storage keys', async t => {
   // First manager
   const managerA = await E(vdp).getCollateralManager(aeth.brand);
   t.is(
-    await subscriptionKey(E(managerA).getMetrics()),
+    await publicationPath(E(managerA), 'metrics'),
     'mockChainStorageRoot.vaultFactory.manager0.metrics',
   );
   t.is(
@@ -52,7 +55,7 @@ test('storage keys', async t => {
   // Second manager
   const [managerC, chit] = await d.addVaultType('Chit');
   t.is(
-    await subscriptionKey(E(E(managerC).getPublicFacet()).getMetrics()),
+    await publicationPath(E(managerC).getPublicFacet(), 'metrics'),
     'mockChainStorageRoot.vaultFactory.manager1.metrics',
   );
   t.is(

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -272,7 +272,7 @@ const legacyOfferResult = vaultSeat => {
       return {
         vault,
         publicNotifiers: {
-          asset: makeNotifierFromSubscriber(publicSubscribers.asset.topic),
+          asset: makeNotifierFromSubscriber(publicSubscribers.asset),
           vault: makeNotifierFromSubscriber(publicSubscribers.vault.topic),
         },
       };

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -162,11 +162,7 @@ export async function start(zcf, privateArgs, baggage) {
     managerMock,
     // eslint-disable-next-line no-plusplus
     String(vaultCounter++),
-    // TODO makeFakeStorageKit
-    {
-      node: makeFakeStorage('test.vaultContractWrapper'),
-      path: 'test.vaultContractWrapper',
-    },
+    makeFakeStorage('test.vaultContractWrapper'),
   );
 
   const advanceRecordingPeriod = async () => {
@@ -196,10 +192,7 @@ export async function start(zcf, privateArgs, baggage) {
   }));
 
   async function makeHook(seat) {
-    const vaultKit = await vault.initVaultKit(seat, {
-      node: makeFakeStorage('test'),
-      path: 'test',
-    });
+    const vaultKit = await vault.initVaultKit(seat, makeFakeStorage('test'));
     return {
       vault,
       runMint,

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -162,7 +162,11 @@ export async function start(zcf, privateArgs, baggage) {
     managerMock,
     // eslint-disable-next-line no-plusplus
     String(vaultCounter++),
-    makeFakeStorage('test.vaultContractWrapper'),
+    // TODO makeFakeStorageKit
+    {
+      node: makeFakeStorage('test.vaultContractWrapper'),
+      path: 'test.vaultContractWrapper',
+    },
   );
 
   const advanceRecordingPeriod = async () => {
@@ -192,7 +196,10 @@ export async function start(zcf, privateArgs, baggage) {
   }));
 
   async function makeHook(seat) {
-    const vaultKit = await vault.initVaultKit(seat, makeFakeStorage('test'));
+    const vaultKit = await vault.initVaultKit(seat, {
+      node: makeFakeStorage('test'),
+      path: 'test',
+    });
     return {
       vault,
       runMint,

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -31,6 +31,13 @@ const { Fail } = assert;
  * @property {() => string} getPath the chain storage path at which the node was constructed
  * @property {() => Promise<VStorageKey>} getStoreKey DEPRECATED use getPath
  * @property {(subPath: string, options?: {sequence?: boolean}) => StorageNode} makeChildNode
+ * @property {(subPath: string, options?: {sequence?: boolean}) => StorageNodeKit} makeChildNodeKit
+ */
+
+/**
+ * @typedef {object} StorageNodeKit
+ * @property {StorageNode} node
+ * @property {string} path
  */
 
 /**
@@ -104,6 +111,15 @@ export function makeChainStorageRoot(
         assertPathSegment(name);
         const mergedOptions = { sequence, ...childNodeOptions };
         return makeChainStorageNode(`${path}.${name}`, mergedOptions);
+      },
+      /** @type {(name: string, childNodeOptions?: {sequence?: boolean}) => StorageNodeKit} */
+      makeChildNodeKit(name, childNodeOptions = {}) {
+        assert.typeof(name, 'string');
+        assertPathSegment(name);
+        const mergedOptions = { sequence, ...childNodeOptions };
+        const childPath = `${path}.${name}`;
+        const childNode = makeChainStorageNode(childPath, mergedOptions);
+        return { node: childNode, path: childPath };
       },
       /** @type {(value: string) => Promise<void>} */
       async setValue(value) {

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -12,6 +12,8 @@ import {
 import { makeSubscriptionKit } from './subscriber.js';
 
 /**
+ * NB: does not yet survive upgrade https://github.com/Agoric/agoric-sdk/issues/6893
+ *
  * @template T
  * @param {Subscriber<T>} subscriber
  * @param {(v: T) => void} consumeValue

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -2,8 +2,13 @@ import { E } from '@endo/eventual-send';
 import { Far, makeMarshal } from '@endo/marshal';
 import { assertAllDefined } from '@agoric/internal';
 import { makeMarshallToStorage } from '@agoric/internal/src/lib-chainStorage.js';
+import { M } from '@agoric/store';
 import { observeIteration } from './asyncIterableAdaptor.js';
-import { makePublishKit, subscribeEach } from './publish-kit.js';
+import {
+  makePublishKit,
+  subscribeEach,
+  SubscriberShape,
+} from './publish-kit.js';
 import { makeSubscriptionKit } from './subscriber.js';
 
 /**
@@ -66,6 +71,50 @@ export const makeStoredSubscriber = (subscriber, storageNode, marshaller) => {
   });
   return storesub;
 };
+
+export const TopicMetaShape = M.splitRecord(
+  {
+    topic: SubscriberShape,
+    storagePath: M.promise(),
+  },
+  { description: M.string() },
+);
+/**
+ * @template {object} T topic value
+ * @typedef {{
+ *   description?: string,
+ *   topic: ERef<Subscriber<T>>,
+ *   storagePath: ERef<string>,
+ * }} TopicMeta
+ */
+
+export const TopicMetasRecordShape = M.recordOf(M.string(), TopicMetaShape);
+
+/**
+ * @typedef {{
+ *   [topicName: string]: TopicMeta<unknown>,
+ * }} TopicMetasRecord
+ */
+
+/**
+ * @param {Subscriber<any>} topic
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<ReturnType<typeof makeMarshal>>} marshaller
+ * @returns {void}
+ */
+export const pipeTopicToStorage = (topic, storageNode, marshaller) => {
+  assertAllDefined({ topic, storageNode, marshaller });
+
+  const marshallToStorage = makeMarshallToStorage(storageNode, marshaller);
+
+  // Start publishing the source.
+  forEachPublicationRecord(topic, marshallToStorage).catch(err => {
+    // TODO: How should we handle and/or surface this failure?
+    // https://github.com/Agoric/agoric-sdk/pull/5766#discussion_r922498088
+    console.error('followAndStoreTopic failed to iterate', err);
+  });
+};
+harden(pipeTopicToStorage);
 
 /**
  * @deprecated use makeStoredSubscriber

--- a/packages/notifier/src/types-ambient.js
+++ b/packages/notifier/src/types-ambient.js
@@ -278,6 +278,13 @@
  * @property {() => string} getPath the chain storage path at which the node was constructed
  * @property {() => Promise<VStorageKey>} getStoreKey DEPRECATED use getPath
  * @property {(subPath: string, options?: {sequence?: boolean}) => StorageNode} makeChildNode
+ * @property {(subPath: string, options?: {sequence?: boolean}) => StorageNodeKit} makeChildNodeKit
+ */
+
+/**
+ * @typedef {object} StorageNodeKit
+ * @property {StorageNode} node
+ * @property {string} path
  */
 
 /**

--- a/packages/notifier/tools/testSupports.js
+++ b/packages/notifier/tools/testSupports.js
@@ -34,6 +34,7 @@ export const makeFakeStorage = (path, publication) => {
       publication.updateState(value);
     },
     makeChildNode: () => storage,
+    makeChildNodeKit: () => ({ node: storage, path }),
     countSetValueCalls: () => setValueCalls,
   });
   return storage;

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -37,7 +37,7 @@ export const UNPUBLISHED_RESULT = 'UNPUBLISHED';
  * @param {(spec: import('./invitations').InvitationSpec) => ERef<Invitation>} opts.powers.invitationFromSpec
  * @param {(brand: Brand) => Promise<import('./types').RemotePurse>} opts.powers.purseForBrand
  * @param {(status: OfferStatus) => void} opts.onStatusChange
- * @param {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers: import('./types').PublicSubscribers ) => Promise<void>} opts.onNewContinuingOffer
+ * @param {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers: import('./types').PublicSubscribers | import('@agoric/notifier').TopicMetasRecord ) => Promise<void>} opts.onNewContinuingOffer
  */
 export const makeOfferExecutor = ({
   zoe,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -8,7 +8,7 @@ import {
   PurseShape,
 } from '@agoric/ertp';
 import { makeStoredPublishKit, observeNotifier } from '@agoric/notifier';
-import { mustMatch, M, makeScalarMapStore } from '@agoric/store';
+import { M, makeScalarMapStore, mustMatch } from '@agoric/store';
 import {
   defineVirtualExoClassKit,
   makeScalarBigMapStore,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -453,7 +453,7 @@ const SmartWalletKit = defineVirtualExoClassKit(
               status: offerStatus,
             });
           },
-          /** @type {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers?: import('./types').PublicSubscribers) => Promise<void>} */
+          /** @type {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers?: import('./types').PublicSubscribers | import('@agoric/notifier').TopicMetasRecord) => Promise<void>} */
           onNewContinuingOffer: async (
             offerId,
             invitationAmount,

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -130,12 +130,16 @@ export const assertHasData = async follower => {
  *
  * Handles the case of falsy argument so the caller can consistently await.
  *
- * @param {Record<string, ERef<StoredFacet>>} [subscribers]
+ * @param {import('./types.js').PublicSubscribers | import('@agoric/notifier').TopicMetasRecord} [subscribers]
  * @returns {ERef<Record<string, string>> | null}
  */
 export const objectMapStoragePath = subscribers => {
   if (!subscribers) {
     return null;
   }
-  return deeplyFulfilledObject(objectMap(subscribers, sub => E(sub).getPath()));
+  return deeplyFulfilledObject(
+    objectMap(subscribers, sub =>
+      'topic' in sub ? sub.storagePath : E(sub).getPath(),
+    ),
+  );
 };

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -1,4 +1,3 @@
-import { makeStoredSubscriber } from '@agoric/notifier';
 import {
   makeScalarBigMapStore,
   provide,
@@ -43,11 +42,12 @@ export const makeTopicMetaProvider = () => {
   const extant = new WeakMap();
 
   /**
-   * Provide a StoredSubscriber for the specified durable subscriber.
+   * Provide a TopicMeta for the specified durable subscriber.
+   * Caches the resolution of the promise for the storageNode's path.
    *
    * @template {object} T
    * @param {string} description
-   * @param {Subscriber<T>} durableSubscriber
+   * @param {Subscriber<T>} durableSubscriber primary key
    * @param {ERef<StorageNode>} storageNode
    * @returns {import('@agoric/notifier').TopicMeta<T>}
    */

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -1,0 +1,75 @@
+import {
+  makeScalarBigMapStore,
+  provide,
+  provideDurableSetStore,
+} from '@agoric/vat-data';
+import { Far } from '@endo/marshal';
+
+/**
+ * @template K Key
+ * @template {{}} E Ephemeral state
+ * @param {() => E} init
+ */
+export const makeEphemeraProvider = init => {
+  /** @type {Map<K, E>} */
+  const ephemeras = new Map();
+
+  /**
+   * Provide an object to hold state that need not (or cannot) be durable.
+   *
+   * @type {(key: K) => E}
+   */
+  return key => {
+    if (ephemeras.has(key)) {
+      // @ts-expect-error cast
+      return ephemeras.get(key);
+    }
+    const newEph = init();
+    ephemeras.set(key, newEph);
+    return newEph;
+  };
+};
+harden(makeEphemeraProvider);
+
+/**
+ *
+ * @param {ZCF} zcf
+ * @param {import('@agoric/ertp').Baggage} baggage
+ * @param {string} name
+ * @returns {ZCFSeat}
+ */
+export const provideEmptySeat = (zcf, baggage, name) => {
+  return provide(baggage, name, () => zcf.makeEmptySeatKit().zcfSeat);
+};
+harden(provideEmptySeat);
+
+/**
+ * For making singletons, so that each baggage carries a separate kind definition (albeit of the definer)
+ *
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {string} category diagnostic tag
+ */
+export const provideChildBaggage = (baggage, category) => {
+  const baggageSet = provideDurableSetStore(baggage, `${category}Set`);
+  return Far('childBaggageManager', {
+    // TODO(types) infer args
+    /**
+     * @template {(baggage: import('@agoric/ertp').Baggage, ...rest: any) => any} M Maker function
+     * @param {string} childName diagnostic tag
+     * @param {M} makeChild
+     * @param {...any} nonBaggageArgs
+     * @returns {ReturnType<M>}
+     */
+    addChild: (childName, makeChild, ...nonBaggageArgs) => {
+      const childStore = makeScalarBigMapStore(`${childName}${category}`, {
+        durable: true,
+      });
+      const result = makeChild(childStore, ...nonBaggageArgs);
+      baggageSet.add(childStore);
+      return result;
+    },
+    children: () => baggageSet.values(),
+  });
+};
+harden(provideChildBaggage);
+/** @typedef {ReturnType<typeof provideChildBaggage>} ChildBaggageManager */

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -6,14 +6,11 @@ export {
   calcSecondaryRequired,
 } from './bondingCurves.js';
 
+export * from './durability.js';
+
 export * from './priceAuthority.js';
 
-export {
-  getAmountIn,
-  getAmountOut,
-  getTimestamp,
-  getPriceDescription,
-} from './priceQuote.js';
+export * from './priceQuote.js';
 
 export { natSafeMath } from './safeMath.js';
 


### PR DESCRIPTION
## Description

Progress on #5285

Like https://github.com/Agoric/agoric-sdk/pull/6887 but solves the transfer/adjust timing problem by making `getTopics` synchronous within vat. This was first done by adding to StorageNode a `makeChildNodeKit` (thus the branch name) but now it's the path resolution is deferred to a Promise within the TopicMeta record.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
