### PR TITLE
bootstrap handles BundleIDs, not full bundles

### DIFF
--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -279,16 +279,7 @@
  */
 
 /**
- * @callback ShutdownWithFailure
- * Called to shut something down because something went wrong, where the reason
- * is supposed to be an Error that describes what went wrong. Some valid
- * implementations of `ShutdownWithFailure` will never return, either
- * because they throw or because they immediately shutdown the enclosing unit
- * of computation. However, they also might return, so the caller should
- * follow this call by their own defensive `throw reason;` if appropriate.
- *
- * @param {Error} reason
- * @returns {void}
+ * @typedef {import('@agoric/swingset-vat').ShutdownWithFailure} ShutdownWithFailure
  */
 
 /**

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -339,6 +339,7 @@ export {};
  */
 
 /**
+ * Vat Creation and Management
  *
  * @typedef { string } BundleID
  * @typedef {*} BundleCap
@@ -366,4 +367,49 @@ export {};
  *
  * @typedef { { enableDisavow?: boolean } } HasEnableDisavow
  * @typedef { DynamicVatOptions & HasEnableDisavow } StaticVatOptions
+ *
+ * @typedef { { vatParameters?: object, upgradeMessage: string } } VatUpgradeOptions
+ * @typedef { { incarnationNumber: number } } VatUpgradeResults
+ *
+ * @callback ShutdownWithFailure
+ * Called to shut something down because something went wrong, where the reason
+ * is supposed to be an Error that describes what went wrong. Some valid
+ * implementations of `ShutdownWithFailure` will never return, either
+ * because they throw or because they immediately shutdown the enclosing unit
+ * of computation. However, they also might return, so the caller should
+ * follow this call by their own defensive `throw reason;` if appropriate.
+ *
+ * @param {Error} reason
+ * @returns {void}
+ *
+ * @typedef {object} VatAdminFacet
+ * A powerful object corresponding with a vat
+ * that can be used to upgrade it with new code or parameters,
+ * terminate it, or be notified when it terminates.
+ *
+ * @property {() => Promise<any>} done
+ * returns a promise that will be fulfilled or rejected when the vat is
+ * terminated. If the vat terminates with a failure, the promise will be
+ * rejected with the reason. If the vat terminates successfully, the
+ * promise will fulfill to the completion value.
+ * @property {ShutdownWithFailure} terminateWithFailure
+ * Terminate the vat with a failure reason.
+ * @property {(bundlecap: BundleCap, options?: VatUpgradeOptions) => Promise<VatUpgradeResults>} upgrade
+ * Restart the vat with the specified bundle and options. This is a "baggage-style" upgrade,
+ * in which the JS memory space is abandoned. The new image is launched with access to 'baggage'
+ * and any durable storage reachable from it, and must fulfill all the obligations of the previous
+ * incarnation.
+ *
+ *
+ * @typedef {object} CreateVatResults
+ * @property {object} root
+ * @property {VatAdminFacet} adminNode
+ *
+ * @typedef {object} VatAdminSvc
+ * @property {(id: BundleID) => ERef<BundleCap>} waitForBundleCap
+ * @property {(id: BundleID) => ERef<BundleCap>} getBundleCap
+ * @property {(name: string) => ERef<BundleCap>} getNamedBundleCap
+ * @property {(name: string) => ERef<BundleID>} getBundleIDByName
+ * @property {(bundleCap: BundleCap, options?: DynamicVatOptions) => ERef<CreateVatResults>} createVat
+ *
  */

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -21,7 +21,6 @@ import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeLoopback } from '@endo/captp';
 import { E, Far } from '@endo/far';
-import { devices } from './devices.js';
 
 export { ActionType };
 
@@ -166,15 +165,11 @@ export const makeMockTestSpace = async log => {
     ),
   );
 
-  const vatPowers = {
-    D: x => x,
-  };
-
   await Promise.all([
     // @ts-expect-error
     makeBoard({ consume, produce, ...spaces }),
     makeAddressNameHubs({ consume, produce, ...spaces }),
-    installBootContracts({ vatPowers, devices, consume, produce, ...spaces }),
+    installBootContracts({ consume, produce, ...spaces }),
     setupClientManager({ consume, produce, ...spaces }),
   ]);
 

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -294,11 +294,9 @@ export const makeClientBanks = async ({
 };
 harden(makeClientBanks);
 
-/** @param {BootstrapSpace & { devices: { vatAdmin: any }, vatPowers: { D: DProxy }, }} powers */
+/** @param {BootstrapSpace} powers */
 export const installBootContracts = async ({
-  vatPowers: { D },
-  devices: { vatAdmin },
-  consume: { zoe },
+  consume: { vatAdminSvc, zoe },
   installation: {
     produce: { centralSupply, mintHolder },
   },
@@ -307,14 +305,11 @@ export const installBootContracts = async ({
     centralSupply,
     mintHolder,
   })) {
-    // This really wants to be E(vatAdminSvc).getBundleIDByName, but it's
-    // good enough to do D(vatAdmin).getBundleIDByName
-    const bundleCap = D(vatAdmin).getNamedBundleCap(name);
-
-    const bundle = D(bundleCap).getBundle();
-    // TODO (#4374) this should be E(zoe).installBundleID(bundleID);
-    const installation = E(zoe).install(bundle);
-    producer.resolve(installation);
+    const idP = E(vatAdminSvc).getBundleIDByName(name);
+    const installationP = idP.then(bundleID =>
+      E(zoe).installBundleID(bundleID),
+    );
+    producer.resolve(installationP);
   }
 };
 

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -62,8 +62,8 @@ const bootMsgEx = {
  *   produce: {vatStore: Producer<VatStore> }
  * }} powers
  *
- * @typedef {{adminNode: any, root: unknown}} VatInfo as from createVatByName
- * @typedef {MapStore<string, Promise<VatInfo>>} VatStore
+ * @typedef {import('@agoric/swingset-vat').CreateVatResults} CreateVatResults as from createVatByName
+ * @typedef {MapStore<string, Promise<CreateVatResults>>} VatStore
  */
 export const makeVatsFromBundles = async ({
   vats,
@@ -81,7 +81,7 @@ export const makeVatsFromBundles = async ({
     return bundleName => {
       const vatInfoP = provideLazy(store, bundleName, _k => {
         console.info(`createVatByName(${bundleName})`);
-        /** @type { Promise<VatInfo> } */
+        /** @type { Promise<CreateVatResults> } */
         const vatInfo = E(svc).createVatByName(bundleName, {
           ...defaultVatCreationOptions,
           name: bundleName,

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -163,9 +163,7 @@ const SHARED_CHAIN_BOOTSTRAP_MANIFEST = harden({
     home: { produce: { bank: 'bank' } },
   },
   [installBootContracts.name]: {
-    vatPowers: { D: true },
-    devices: { vatAdmin: true },
-    consume: { zoe: 'zoe' },
+    consume: { zoe: 'zoe', vatAdminSvc: true },
     installation: {
       produce: {
         centralSupply: 'zoe',

--- a/packages/vats/test/devices.js
+++ b/packages/vats/test/devices.js
@@ -30,6 +30,5 @@ export const devices = {
         return bundle;
       },
     }),
-    getBundleIDByName: name => `bundleID-${name}`,
   },
 };

--- a/packages/vats/test/devices.js
+++ b/packages/vats/test/devices.js
@@ -9,7 +9,7 @@ import centralSupply from '../bundles/bundle-centralSupply.js';
 import mintHolder from '../bundles/bundle-mintHolder.js';
 import provisionPool from '../bundles/bundle-provisionPool.js';
 
-const bundles = {
+export const bundles = {
   binaryVoteCounter,
   centralSupply,
   committee,
@@ -30,5 +30,6 @@ export const devices = {
         return bundle;
       },
     }),
+    getBundleIDByName: name => `bundleID-${name}`,
   },
 };

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -1,12 +1,9 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import {
-  makeFakeVatAdmin,
-  zcfBundleCap,
-} from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import bundleSource from '@endo/bundle-source';
-import { E, Far, passStyleOf } from '@endo/far';
+import { E, passStyleOf } from '@endo/far';
 
 import { makeZoeKit } from '@agoric/zoe';
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
@@ -20,7 +17,7 @@ import {
   makeMock,
   mockDProxy,
   mockPsmBootstrapArgs,
-  vatRoots,
+  mockSwingsetVats,
 } from '../tools/boot-test-utils.js';
 
 const argvByRole = {
@@ -49,50 +46,7 @@ const testRole = (ROLE, governanceActions) => {
         governanceActions,
       },
     );
-
-    const fakeVatAdmin = makeFakeVatAdmin(() => {}).admin;
-    const fakeBundleCaps = new Map(); // {} -> name
-    const getNamedBundleCap = name => {
-      const bundleCap = harden({});
-      fakeBundleCaps.set(bundleCap, name);
-      return bundleCap;
-    };
-    const createVat = (bundleCap, options) => {
-      const name = fakeBundleCaps.get(bundleCap);
-      assert(name);
-      switch (name) {
-        case 'zcf':
-          return fakeVatAdmin.createVat(zcfBundleCap, options);
-        default: {
-          const buildRoot = vatRoots[name];
-          if (!buildRoot) {
-            throw Error(`TODO: load vat ${name}`);
-          }
-          const vatParameters = { ...options?.vatParameters };
-          if (name === 'zoe') {
-            // basic-behaviors.js:buildZoe() provides hard-coded zcf BundleName
-            // and vat-zoe.js ignores vatParameters, but this would be the
-            // preferred way to pass the name.
-            vatParameters.zcfBundleName = 'zcf';
-          }
-          return { root: buildRoot({}, vatParameters), admin: {} };
-        }
-      }
-    };
-    const createVatByName = name => {
-      const bundleCap = getNamedBundleCap(name);
-      return createVat(bundleCap);
-    };
-
-    const criticalVatKey = harden({});
-    const vats = {
-      ...mock.vats,
-      vatAdmin: /** @type { any } */ ({
-        getCriticalVatKey: () => criticalVatKey,
-        createVatAdminService: () =>
-          Far('vatAdminSvc', { getNamedBundleCap, createVat, createVatByName }),
-      }),
-    };
+    const vats = mockSwingsetVats(mock);
     const actual = await E(root).bootstrap(vats, mock.devices);
     t.deepEqual(actual, undefined);
   });

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -4,7 +4,6 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { makeLoopback } from '@endo/captp';
 import { E, Far } from '@endo/far';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKit } from '@agoric/zoe';
 
 import { makeIssuerKit } from '@agoric/ertp';
@@ -24,12 +23,13 @@ import {
 } from '../src/core/basic-behaviors.js';
 import { Stable, Stake } from '../src/tokens.js';
 
-import { devices } from './devices.js';
+import { makePopulatedFakeVatAdmin } from '../tools/boot-test-utils.js';
 
 const setUpZoeForTest = async () => {
   const { makeFar } = makeLoopback('zoeTest');
+  const { vatAdminService } = makePopulatedFakeVatAdmin();
   const { zoeService, feeMintAccess } = await makeFar(
-    makeZoeKit(makeFakeVatAdmin(() => {}).admin, undefined, {
+    makeZoeKit(vatAdminService, undefined, {
       name: Stable.symbol,
       assetKind: Stable.assetKind,
       displayInfo: Stable.displayInfo,
@@ -38,6 +38,7 @@ const setUpZoeForTest = async () => {
   return {
     zoe: zoeService,
     feeMintAccessP: feeMintAccess,
+    vatAdminService,
   };
 };
 harden(setUpZoeForTest);
@@ -57,11 +58,13 @@ test('connectFaucet produces payments', async t => {
   const { agoricNames, spaces } = makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
 
-  const { zoe, feeMintAccessP } = await setUpZoeForTest();
+  const { zoe, feeMintAccessP, vatAdminService } = await setUpZoeForTest();
   produce.zoe.resolve(zoe);
   const fma = await feeMintAccessP;
   produce.feeMintAccess.resolve(fma);
   produce.bridgeManager.resolve(undefined);
+
+  produce.vatAdminSvc.resolve(vatAdminService);
 
   const vatLoader = name => {
     switch (name) {
@@ -118,15 +121,11 @@ test('connectFaucet produces payments', async t => {
     void E(client).assignBundle([_a => stub]);
   };
 
-  const vatPowers = {
-    D: x => x,
-  };
-
   await Promise.all([
     // @ts-expect-error missing keys: devices, vats, vatPowers, vatParameters, and 2 more.
     makeBoard({ consume, produce, ...spaces }),
     makeAddressNameHubs({ consume, produce, ...spaces }),
-    installBootContracts({ vatPowers, devices, consume, produce, ...spaces }),
+    installBootContracts({ consume, produce, ...spaces }),
     setupClientManager({ consume, produce, ...spaces }),
     connectFaucet({ consume, produce, ...spaces }),
     makeClientBanks({ consume, produce, ...spaces }),

--- a/packages/vats/test/test-vat-bank.js
+++ b/packages/vats/test/test-vat-bank.js
@@ -6,7 +6,6 @@ import { E, Far } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 import { makeZoeKit } from '@agoric/zoe';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { observeIteration } from '@agoric/notifier';
 import { buildRootObject } from '../src/vat-bank.js';
 import {
@@ -15,8 +14,7 @@ import {
   installBootContracts,
 } from '../src/core/basic-behaviors.js';
 import { makeAgoricNamesAccess, makePromiseSpace } from '../src/core/utils.js';
-
-import { devices } from './devices.js';
+import { makePopulatedFakeVatAdmin } from '../tools/boot-test-utils.js';
 
 test('communication', async t => {
   t.plan(29);
@@ -204,17 +202,12 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
   const { agoricNames, spaces } = makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
 
-  const { zoeService, feeMintAccess: fma } = makeZoeKit(
-    makeFakeVatAdmin(() => {}).admin,
-  );
+  const { vatAdminService } = makePopulatedFakeVatAdmin();
+  const { zoeService, feeMintAccess: fma } = makeZoeKit(vatAdminService);
   produce.zoe.resolve(zoeService);
   produce.feeMintAccess.resolve(fma);
-  const vatPowers = {
-    D: x => x,
-  };
+  produce.vatAdminSvc.resolve(vatAdminService);
   await installBootContracts({
-    vatPowers,
-    devices,
     consume,
     produce,
     ...spaces,

--- a/packages/vats/tools/boot-test-utils.js
+++ b/packages/vats/tools/boot-test-utils.js
@@ -5,7 +5,7 @@ import {
 } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { Far } from '@endo/marshal';
-import { devices } from '../test/devices.js';
+import { bundles, devices } from '../test/devices.js';
 
 import { buildRootObject as bankRoot } from '../src/vat-bank.js';
 import { buildRootObject as boardRoot } from '../src/vat-board.js';
@@ -75,50 +75,76 @@ export const makeMock = log =>
     },
   });
 
-export const mockSwingsetVats = mock => {
-  const { admin: fakeVatAdmin } = makeFakeVatAdmin(() => {});
-  const fakeBundleCaps = new Map(); // {} -> name
-  const getNamedBundleCap = name => {
-    const bundleCap = harden({});
-    fakeBundleCaps.set(bundleCap, name);
-    return bundleCap;
-  };
+export const makePopulatedFakeVatAdmin = () => {
+  // The .createVat() from zoe/tools/fakeVatAdmin.js only knows how to
+  // make ZCF vats, so wrap it in a form that can create the other
+  // vats too. We have two types.
+
+  const fakeCapToName = new Map(); // cap -> name
+  const fakeNameToCap = new Map(); // name -> cap
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
+  for (const name of Object.getOwnPropertyNames(vatRoots)) {
+    // These don't have real bundles (just a buildRootObject
+    // function), but fakeVatAdmin wants to see a bundle.endoZipBase64
+    // hash, so make some fake ones.
+    const id = `id-${name}`; // fake bundleID
+    const bundle = { endoZipBase64: id };
+    const cap = vatAdminState.installNamedBundle(name, id, bundle);
+    fakeCapToName.set(cap, name);
+    fakeNameToCap.set(name, cap);
+  }
+
+  for (const [name, bundle] of Object.entries(bundles)) {
+    // These *do* have real bundles, with an ID and everything.
+    const id = bundle.endoZipBase64Sha512;
+    const cap = vatAdminState.installNamedBundle(name, id, bundle);
+    fakeCapToName.set(cap, name);
+    fakeNameToCap.set(name, cap);
+  }
 
   const createVat = (bundleCap, options) => {
-    const name = fakeBundleCaps.get(bundleCap);
-    assert(name);
-    switch (name) {
-      case 'zcf':
-        return fakeVatAdmin.createVat(zcfBundleCap, options);
-      default: {
-        const buildRoot = vatRoots[name];
-        if (!buildRoot) {
-          throw Error(`TODO: load vat ${name}`);
-        }
-        const vatParameters = { ...options?.vatParameters };
-        if (name === 'zoe') {
-          // basic-behaviors.js:buildZoe() provides hard-coded zcf BundleName
-          // and vat-zoe.js ignores vatParameters, but this would be the
-          // preferred way to pass the name.
-          vatParameters.zcfBundleName = 'zcf';
-        }
-        return { root: buildRoot({}, vatParameters), admin: {} };
-      }
+    if (bundleCap === zcfBundleCap) {
+      return fakeVatAdmin.createVat(zcfBundleCap, options);
     }
+    const name = fakeCapToName.get(bundleCap);
+    assert(name);
+    const buildRoot = vatRoots[name];
+    if (!buildRoot) {
+      throw Error(`TODO: load vat ${name}`);
+    }
+    const vatParameters = { ...options?.vatParameters };
+    if (name === 'zoe') {
+      // basic-behaviors.js:buildZoe() provides hard-coded zcf BundleName
+      // and vat-zoe.js ignores vatParameters, but this would be the
+      // preferred way to pass the name.
+      vatParameters.zcfBundleName = 'zcf';
+    }
+    const adminNode =
+      /** @type {import('@agoric/swingset-vat').VatAdminFacet} */ ({});
+    return { root: buildRoot({}, vatParameters), adminNode };
   };
   const createVatByName = name => {
-    const bundleCap = getNamedBundleCap(name);
-    return createVat(bundleCap);
+    return createVat(fakeNameToCap.get(name));
   };
 
-  const criticalVatKey = harden({});
+  const vatAdminService = Far('vatAdminSvc', {
+    ...fakeVatAdmin,
+    createVat,
+    createVatByName,
+  });
+  const criticalVatKey = vatAdminState.getCriticalVatKey();
+  const getCriticalVatKey = () => criticalVatKey;
+  const createVatAdminService = () => vatAdminService;
+  /** @type { any } */
+  const vatAdminRoot = { getCriticalVatKey, createVatAdminService };
+  return { vatAdminService, vatAdminRoot };
+};
+
+export const mockSwingsetVats = mock => {
+  const { vatAdminRoot } = makePopulatedFakeVatAdmin();
   const vats = {
     ...mock.vats,
-    vatAdmin: /** @type { any } */ ({
-      getCriticalVatKey: () => criticalVatKey,
-      createVatAdminService: () =>
-        Far('vatAdminSvc', { getNamedBundleCap, createVat, createVatByName }),
-    }),
+    vatAdmin: vatAdminRoot,
   };
   return vats;
 };

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -237,27 +237,6 @@
  */
 
 /**
- * @typedef {object} RootAndAdminNode
- * @property {object} root
- * @property {AdminNode} adminNode
- */
-
-/**
- * @typedef {object} AdminNode
- * A powerful object that can be used to terminate the vat in which a contract
- * is running, to get statistics, or to be notified when it terminates.
- *
- * @property {() => Promise<Completion>} done
- * returns a promise that will be fulfilled or rejected when the contract is
- * terminated. If the contract terminates with a failure, the promise will be
- * rejected with the reason. If the contract terminates successfully, the
- * promise will fulfill to the completion value.
- * @property {ShutdownWithFailure} terminateWithFailure
- * Terminate the vat in which the contract is running as a failure.
- * @property {(bundleCap: *, options?: Record<string, any>) => Promise<RootAndAdminNode>} upgrade
- */
-
-/**
  * @callback GetAssetKindByBrand
  * Get the assetKind for a brand known by Zoe
  *

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -87,8 +87,8 @@
  * @property {DeleteInstanceAdmin} deleteInstanceAdmin
  * @property {ZoeInstanceAdminMakeInvitation} makeInvitation
  * @property {() => Issuer} getInvitationIssuer
- * @property {() => object} getRoot of a RootAndAdminNode
- * @property {() => AdminNode} getAdminNode of a RootAndAdminNode
+ * @property {() => object} getRoot of CreateVatResults
+ * @property {() => import('@agoric/swingset-vat').VatAdminFacet} getAdminNode of CreateVatResults
  */
 
 /**
@@ -146,7 +146,7 @@
  *
  * @callback CreateZCFVat
  * @param {BundleCap} contractBundleCap
- * @returns {Promise<RootAndAdminNode>}
+ * @returns {Promise<import('@agoric/swingset-vat').CreateVatResults>}
  */
 
 /**

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -282,11 +282,7 @@
  */
 
 /**
- * @typedef {object} VatAdminSvc
- * @property {(id: BundleID) => ERef<import('@agoric/swingset-vat').BundleCap>} waitForBundleCap
- * @property {(id: BundleID) => ERef<import('@agoric/swingset-vat').BundleCap>} getBundleCap
- * @property {(name: string) => ERef<import('@agoric/swingset-vat').BundleCap>} getNamedBundleCap
- * @property {(bundleCap: import('@agoric/swingset-vat').BundleCap, options?: Record<string, any>) => ERef<RootAndAdminNode>} createVat
+ * @typedef {import('@agoric/swingset-vat').VatAdminSvc} VatAdminSvc
  */
 
 /**

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -33,6 +33,8 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   const idToBundleCap = makeScalarMapStore('idToBundleCap');
   /** @type {MapStore<BundleCap, EndoZipBase64Bundle>} */
   const bundleCapToBundle = makeScalarMapStore('bundleCapToBundle');
+  /** @type {MapStore<string, BundleID>} */
+  const nameToBundleID = makeScalarMapStore('nameToBundleID');
   const fakeVatPowers = {
     exitVatWithFailure: reason => {
       exitMessage = reason;
@@ -62,8 +64,14 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
       return Promise.resolve(idToBundleCap.get(bundleID));
     },
     getNamedBundleCap: name => {
-      assert.equal(name, 'zcf', 'fakeVatAdmin only knows ZCF');
-      return Promise.resolve(zcfBundleCap);
+      if (name === 'zcf') {
+        return Promise.resolve(zcfBundleCap);
+      }
+      const id = nameToBundleID.get(name);
+      return Promise.resolve(idToBundleCap.get(id));
+    },
+    getBundleIDByName: name => {
+      return Promise.resolve().then(() => nameToBundleID.get(name));
     },
     createVat: (bundleCap, { vatParameters = {} } = {}) => {
       assert.equal(bundleCap, zcfBundleCap, 'fakeVatAdmin only knows ZCF');
@@ -112,6 +120,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
       );
     },
   });
+  const criticalVatKey = harden({});
   const vatAdminState = {
     getExitMessage: () => exitMessage,
     getHasExited: () => hasExited,
@@ -122,12 +131,18 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
           bundle.endoZipBase64,
           bundleCapToBundle.get(idToBundleCap.get(id)).endoZipBase64,
         );
-        return;
+        return idToBundleCap.get(id);
       }
       const bundleCap = fakeBundleCap();
       idToBundleCap.init(id, bundleCap);
       bundleCapToBundle.init(bundleCap, bundle);
+      return bundleCap;
     },
+    installNamedBundle: (name, id, bundle) => {
+      nameToBundleID.init(name, id);
+      return vatAdminState.installBundle(id, bundle);
+    },
+    getCriticalVatKey: () => criticalVatKey,
   };
   return { admin, vatAdminState };
 }


### PR DESCRIPTION
The core-bootstrap `installBootContracts()` step is responsible for
creating Zoe installations for each "boot contract": contracts that
are included in the initial chain configuration, and instantiated
during bootstrap (currently just `centralSupply` and
`mintHolder`). These contract bundles are specified by config.bundle
entries, which provide a `sourceSpec` that points to the bundle file
on disk.

Previously, this step obtained a full bundle for each contract, in
RAM, and then used `zoe.install(bundle)` to create the Zoe
Installation. When called this way, Zoe must store the full
bundle (about 1MB) in its durable storage, and the bundle appears as a
message argument in lots of places on its way to being evaluated
inside a ZCF vat, which slows things down and consumes more disk
space.

The preferred way to interact with bundles is through BundleCaps. This
commit changes installBootContracts to look up the BundleID of each
boot contract, and submit the ID to `zoe.installBundleID()`. This
allows Zoe to retrieve a (small) BundleCap, and store the bcap in the
installation record. With this approach, the full bundle only appears
once, when the ZCF vat retrieves its contents just prior to
evaluation.

Changing installBootContracts is straightforward, however we have a
number of mock Zoe and mock VatAdminService implementations that
appear during unit tests, and these required changes to accomodate the
new approach. `zoe/tools/fakeVatAdmin.js` provides the primary mock
service, but it is only capable of creating ZCF vats. It was augmented
to understand the full suite of `getBundleIDByName`/etc methods, with
helper tools to populate the simulated tables. Then
`vats/tools/boot-test-utils.js` acquired a wrapper around zoe's mock
service, adding the ability to create non-ZCF vats, and populating the
tables with all the bundles known to the unit tests.

refs #6826
refs #4374
