### PR TITLE
6900 durable topics

### DIFF
--- a/packages/agoric-cli/test/agops-oracle-smoketest.sh
+++ b/packages/agoric-cli/test/agops-oracle-smoketest.sh
@@ -57,6 +57,14 @@ bin/agops oracle pushPriceRound --price 101 --roundId 1 --oracleAdminAcceptOffer
 jq ".body | fromjson" <"$PROPOSAL_OFFER"
 agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET" --keyring-backend="test"
 
+# submit another price in the round from the second oracle
+PROPOSAL_OFFER=$(mktemp -t agops.XXX)
+bin/agops oracle pushPriceRound --price 201 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
+jq ".body | fromjson" <"$PROPOSAL_OFFER"
+agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET2" --keyring-backend="test"
+
+## Additional validation
+
 # verify that the offer was satisfied
 echo "Offer $ORACLE_OFFER_ID should have numWantsSatisfied: 1"
 agoric wallet show --from "$WALLET" --keyring-backend="test"
@@ -66,12 +74,6 @@ agd query vstorage keys published.priceFeed
 
 # verify that the round started
 agoric follow :published.priceFeed.ATOM-USD_price_feed.latestRound
-
-# submit another price in the round from the second oracle
-PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPriceRound --price 201 --roundId 1 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
-jq ".body | fromjson" <"$PROPOSAL_OFFER"
-agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET2" --keyring-backend="test"
 
 # second round, first oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -17,7 +17,7 @@ import { makeSlogSender } from '@agoric/telemetry';
 
 import { makeChainStorageRoot } from '@agoric/internal/src/lib-chainStorage.js';
 import { makeMarshal } from '@endo/marshal';
-import { makeStoredSubscriber, makePublishKit } from '@agoric/notifier';
+import { makePublishKit, pipeTopicToStorage } from '@agoric/notifier';
 
 import * as STORAGE_PATH from '@agoric/internal/src/chain-storage-paths.js';
 import { BridgeId as BRIDGE_ID } from '@agoric/internal';
@@ -295,7 +295,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       );
       const marshaller = makeMarshal();
       const { publisher, subscriber } = makePublishKit();
-      makeStoredSubscriber(subscriber, installationStorageNode, marshaller);
+      pipeTopicToStorage(subscriber, installationStorageNode, marshaller);
       return publisher;
     };
 

--- a/packages/inter-protocol/src/price/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/price/priceAggregatorChainlink.js
@@ -316,11 +316,11 @@ export const start = async (zcf, privateArgs, baggage) => {
     getPriceAuthority() {
       return priceAuthority;
     },
-    /** @returns {Subscriber<PriceDescription>} */
+    /** @deprecated use getPublicTopics */
     getSubscriber: () => {
       return quoteSubscriber;
     },
-    /** @returns {Subscriber<import('./roundsManager.js').LatestRound>} */
+    /** @deprecated use getPublicTopics */
     getRoundStartNotifier() {
       return latestRoundSubscriber;
     },

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -459,7 +459,7 @@ export { start };
  * @property {() => Allocation} getAllocations
  * @property {(issuer: Issuer) => void} addIssuer
  * @property {() => Invitation<ShortfallReporter>} makeShortfallReportingInvitation
- * @property {() => MetricsNotification} getMetrics
+ * @property {() => StoredSubscription<MetricsNotification>} getMetrics
  */
 
 /**

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -601,9 +601,9 @@ export const prepareVault = (baggage, marshaller, zcf) => {
 
         /**
          * @param {ZCFSeat} seat
-         * @param {ERef<StorageNode>} storageNode
+         * @param {ERef<StorageNode>} storageNodeP
          */
-        async initVaultKit(seat, storageNode) {
+        async initVaultKit(seat, storageNodeP) {
           const { state, facets } = this;
 
           const { self, helper } = facets;
@@ -657,6 +657,8 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           );
           trace('initVault updateDebtAccounting fired');
 
+          // So that makeVaultKit can be synchronous
+          const storageNode = await storageNodeP;
           const vaultKit = makeVaultKit(self, storageNode);
           state.outerUpdater = vaultKit.vaultUpdater;
           helper.updateUiState();

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -19,8 +19,8 @@ import { Far } from '@endo/marshal';
 import { AmountMath, AmountShape, BrandShape, IssuerShape } from '@agoric/ertp';
 import {
   makeStoredPublisherKit,
-  makeStoredSubscriber,
   observeIteration,
+  pipeTopicToStorage,
   prepareDurablePublishKit,
   SubscriberShape,
 } from '@agoric/notifier';
@@ -105,11 +105,8 @@ export const prepareVaultDirector = (
   const { publisher: metricsPublisher, subscriber: metricsSubscriber } =
     makeVaultDirectorPublishKit();
 
-  const storedMetricsSubscriber = makeStoredSubscriber(
-    metricsSubscriber,
-    E(storageNode).makeChildNode('metrics'),
-    marshaller,
-  );
+  const metricsNode = E(storageNode).makeChildNode('metrics');
+  pipeTopicToStorage(metricsSubscriber, metricsNode, marshaller);
 
   const managerBaggages = provideChildBaggage(baggage, 'Vault Manager baggage');
 
@@ -461,7 +458,7 @@ export const prepareVaultDirector = (
           );
         },
         getMetrics() {
-          return storedMetricsSubscriber;
+          return metricsSubscriber;
         },
         /**
          * @deprecated use getCollateralManager and then makeVaultInvitation instead

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -468,6 +468,7 @@ export const prepareVaultDirector = (
             ),
           );
         },
+        /** @deprecated use getPublicTopics */
         getMetrics() {
           return metricsSubscriber;
         },

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -84,7 +84,7 @@ export const prepareVaultHolder = (baggage, marshaller) => {
         },
       },
       holder: {
-        /** @returns {Subscriber<VaultNotification>} */
+        /** @deprecated use getPublicTopics */
         getSubscriber() {
           return this.state.subscriber;
         },

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -3,29 +3,22 @@
  */
 import { AmountShape } from '@agoric/ertp';
 import {
-  makeStoredSubscriber,
   SubscriberShape,
   prepareDurablePublishKit,
+  pipeTopicToStorage,
+  TopicsRecordShape,
 } from '@agoric/notifier';
 import { M, prepareExoClassKit } from '@agoric/vat-data';
-import { makeEphemeraProvider } from '@agoric/zoe/src/contractSupport/index.js';
+import { makePublicTopicProvider } from '@agoric/zoe/src/contractSupport/durability.js';
 import { UnguardedHelperI } from '../typeGuards.js';
 
 const { Fail } = assert;
 
 /**
- * Ephemera are the elements of state that cannot (or need not) be durable.
- *
- * @type {(durableSubscriber: Subscriber<VaultNotification>) => {
- * storedSubscriber: StoredSubscriber<VaultNotification>,
- * }} */
-// @ts-expect-error not yet defined
-const provideEphemera = makeEphemeraProvider(() => ({}));
-
-/**
  * @typedef {{
  * publisher: PublishKit<VaultNotification>['publisher'],
  * subscriber: PublishKit<VaultNotification>['subscriber'],
+ * storageNode: StorageNode,
  * vault: Vault | null,
  * }} State
  */
@@ -35,6 +28,7 @@ const HolderI = M.interface('holder', {
   getCurrentDebt: M.call().returns(AmountShape),
   getNormalizedDebt: M.call().returns(AmountShape),
   getSubscriber: M.call().returns(SubscriberShape),
+  getPublicTopics: M.call().returns(TopicsRecordShape),
   makeAdjustBalancesInvitation: M.call().returns(M.promise()),
   makeCloseInvitation: M.call().returns(M.promise()),
   makeTransferInvitation: M.call().returns(M.promise()),
@@ -45,6 +39,8 @@ const HolderI = M.interface('holder', {
  * @param {ERef<Marshaller>} marshaller
  */
 export const prepareVaultHolder = (baggage, marshaller) => {
+  const providePublicTopic = makePublicTopicProvider();
+
   const makeVaultHolderPublishKit = prepareDurablePublishKit(
     baggage,
     'Vault Holder publish kit',
@@ -60,21 +56,16 @@ export const prepareVaultHolder = (baggage, marshaller) => {
     /**
      *
      * @param {Vault} vault
-     * @param {ERef<StorageNode>} storageNode
+     * @param {StorageNode} storageNode
      * @returns {State}
      */
     (vault, storageNode) => {
       /** @type {PublishKit<VaultNotification>} */
       const { subscriber, publisher } = makeVaultHolderPublishKit();
 
-      const ephemera = provideEphemera(subscriber);
-      ephemera.storedSubscriber = makeStoredSubscriber(
-        subscriber,
-        storageNode,
-        marshaller,
-      );
+      pipeTopicToStorage(subscriber, storageNode, marshaller);
 
-      return { subscriber, publisher, vault };
+      return { publisher, storageNode, subscriber, vault };
     },
     {
       helper: {
@@ -93,10 +84,19 @@ export const prepareVaultHolder = (baggage, marshaller) => {
         },
       },
       holder: {
-        /** @returns {StoredSubscriber<VaultNotification>} */
+        /** @returns {Subscriber<VaultNotification>} */
         getSubscriber() {
-          const ephemera = provideEphemera(this.state.subscriber);
-          return ephemera.storedSubscriber;
+          return this.state.subscriber;
+        },
+        getPublicTopics() {
+          const { subscriber, storageNode } = this.state;
+          return harden({
+            vault: providePublicTopic(
+              'Vault holder status',
+              subscriber,
+              storageNode,
+            ),
+          });
         },
         makeAdjustBalancesInvitation() {
           return this.facets.helper.owned().makeAdjustBalancesInvitation();

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -18,14 +18,15 @@ export const prepareVaultKit = (baggage, marshaller) => {
    * Create a kit of utilities for use of the vault.
    *
    * @param {Vault} vault
-   * @param {ERef<StorageNode>} storageNode
+   * @param {StorageNode} storageNode
    */
   const makeVaultKit = (vault, storageNode) => {
     trace('prepareVaultKit makeVaultKit');
     const { holder, helper } = makeVaultHolder(vault, storageNode);
+    const holderTopics = holder.getPublicTopics();
     const vaultKit = harden({
       publicSubscribers: {
-        vault: holder.getSubscriber(),
+        vault: holderTopics.vault,
       },
       invitationMakers: Far('invitation makers', {
         AdjustBalances: () => holder.makeAdjustBalancesInvitation(),

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -304,9 +304,11 @@ export const prepareVaultManagerKit = (
             'MakeVault',
           );
         },
+        /** @deprecated use getPublicTopics */
         getSubscriber() {
           return assetSubscriber;
         },
+        /** @deprecated use getPublicTopics */
         getMetrics() {
           return metricsSubscriber;
         },

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -24,8 +24,8 @@ import {
 import { makeTracer } from '@agoric/internal';
 import {
   makeStoredNotifier,
-  makeStoredSubscriber,
   observeNotifier,
+  pipeTopicToStorage,
   prepareDurablePublishKit,
   SubscriberShape,
 } from '@agoric/notifier';
@@ -174,17 +174,8 @@ export const prepareVaultManagerKit = (
   const zeroCollateral = AmountMath.makeEmpty(collateralBrand, 'nat');
   const zeroDebt = AmountMath.makeEmpty(debtBrand, 'nat');
 
-  const storedMetricsSubscriber = makeStoredSubscriber(
-    metricsSubscriber,
-    E(storageNode).makeChildNode('metrics'),
-    marshaller,
-  );
-
-  const storedAssetSubscriber = makeStoredSubscriber(
-    assetSubscriber,
-    storageNode,
-    marshaller,
-  );
+  const metricsNode = E(storageNode).makeChildNode('metrics');
+  pipeTopicToStorage(metricsSubscriber, metricsNode, marshaller);
 
   const storedQuotesNotifier = makeStoredNotifier(
     E(priceAuthority).makeQuoteNotifier(collateralUnit, debtBrand),
@@ -297,10 +288,10 @@ export const prepareVaultManagerKit = (
           );
         },
         getSubscriber() {
-          return storedAssetSubscriber;
+          return assetSubscriber;
         },
         getMetrics() {
-          return storedMetricsSubscriber;
+          return metricsSubscriber;
         },
         getQuotes() {
           return storedQuotesNotifier;
@@ -663,7 +654,7 @@ export const prepareVaultManagerKit = (
           state.totalDebt = AmountMath.subtract(state.totalDebt, toBurn);
         },
         getAssetSubscriber() {
-          return storedAssetSubscriber;
+          return assetSubscriber;
         },
         getCollateralBrand() {
           return collateralBrand;

--- a/packages/inter-protocol/test/reserve/test-reserve.js
+++ b/packages/inter-protocol/test/reserve/test-reserve.js
@@ -172,7 +172,6 @@ test('governance add Liquidity to the AMM', async t => {
   );
 
   const metricsSub = await E(reserve.reserveCreatorFacet).getMetrics();
-  // @ts-expect-error type confusion
   const m = await subscriptionTracker(t, metricsSub);
   await m.assertInitial(reserveInitialState(AmountMath.makeEmpty(runBrand)));
 
@@ -341,7 +340,6 @@ test('reserve track shortfall', async t => {
   let runningShortfall = 1000n;
 
   const metricsSub = await E(reserve.reserveCreatorFacet).getMetrics();
-  // @ts-expect-error type confusion
   const m = await subscriptionTracker(t, metricsSub);
   await m.assertInitial(reserveInitialState(AmountMath.makeEmpty(runBrand)));
   await m.assertChange({
@@ -394,7 +392,6 @@ test('reserve burn IST', async t => {
   const runningShortfall = 1000n;
 
   const metricsSub = await E(reserve.reserveCreatorFacet).getMetrics();
-  // @ts-expect-error type confusion
   const m = await subscriptionTracker(t, metricsSub);
   await m.assertInitial(reserveInitialState(AmountMath.makeEmpty(runBrand)));
   await m.assertChange({
@@ -467,7 +464,6 @@ test('storage keys', async t => {
   );
 
   t.is(
-    // @ts-expect-error Type confusion
     await subscriptionKey(E(reserve.reserveCreatorFacet).getMetrics()),
     'mockChainStorageRoot.reserve.metrics',
   );

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -207,6 +207,18 @@ export const subscriptionKey = subscription => {
     });
 };
 
+/**
+ *
+ * @param {ERef<{getPublicTopics: () => import('@agoric/notifier').TopicsRecord}>} hasTopics
+ * @param {string} subscriberName
+ */
+export const topicPath = (hasTopics, subscriberName) => {
+  return E(hasTopics)
+    .getPublicTopics()
+    .then(subscribers => subscribers[subscriberName])
+    .then(tr => tr.storagePath);
+};
+
 /** @type {<T>(subscriber: ERef<Subscriber<T>>) => Promise<T>} */
 export const headValue = async subscriber => {
   await eventLoopIteration();

--- a/packages/inter-protocol/test/test-priceAggregatorChainlink.js
+++ b/packages/inter-protocol/test/test-priceAggregatorChainlink.js
@@ -762,7 +762,7 @@ test('notifications', async t => {
   // no new price yet publishable
 });
 
-test('storage keys', async t => {
+test.failing('storage keys', async t => {
   const { publicFacet } = await t.context.makeChainlinkAggregator(
     defaultConfig,
   );

--- a/packages/inter-protocol/test/test-priceAggregatorChainlink.js
+++ b/packages/inter-protocol/test/test-priceAggregatorChainlink.js
@@ -18,6 +18,7 @@ import { subscribeEach } from '@agoric/notifier';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKit } from '@agoric/zoe/src/zoeService/zoe.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { topicPath } from './supports.js';
 
 /** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeContext>>>} */
 const test = unknownTest;
@@ -762,13 +763,13 @@ test('notifications', async t => {
   // no new price yet publishable
 });
 
-test.failing('storage keys', async t => {
+test('storage keys', async t => {
   const { publicFacet } = await t.context.makeChainlinkAggregator(
     defaultConfig,
   );
 
   t.is(
-    await E(E(publicFacet).getSubscriber()).getPath(),
+    await topicPath(publicFacet, 'quotes'),
     'mockChainStorageRoot.priceAggregator.LINK-USD_price_feed',
   );
 });

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -401,7 +401,9 @@ export const makeManagerDriver = async (
     );
     const { vault, publicSubscribers } = await E(vaultSeat).getOfferResult();
     t.true(await E(vaultSeat).hasExited());
-    const notifier = makeNotifierFromSubscriber(publicSubscribers.vault);
+    const notifier = makeNotifierFromSubscriber(
+      publicSubscribers.vault.subscriber,
+    );
     return {
       getVaultSubscriber: () => publicSubscribers.vault,
       vault: () => vault,

--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -19,7 +19,7 @@ test.before(async t => {
   trace(t, 'CONTEXT');
 });
 
-test('storage keys', async t => {
+test.failing('storage keys', async t => {
   const { aeth, run } = t.context;
   const d = await makeManagerDriver(t);
 

--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -4,7 +4,7 @@ import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { E } from '@endo/eventual-send';
 import { makeTracer } from '@agoric/internal';
 import '../../src/vaultFactory/types.js';
-import { subscriptionKey } from '../supports.js';
+import { subscriptionKey, topicPath } from '../supports.js';
 import { makeDriverContext, makeManagerDriver } from './driver.js';
 
 /** @typedef {import('./driver.js').DriverContext & {
@@ -19,14 +19,14 @@ test.before(async t => {
   trace(t, 'CONTEXT');
 });
 
-test.failing('storage keys', async t => {
+test('storage keys', async t => {
   const { aeth, run } = t.context;
   const d = await makeManagerDriver(t);
 
   // Root vault factory
   const vdp = d.getVaultDirectorPublic();
   t.is(
-    await subscriptionKey(E(vdp).getMetrics()),
+    await topicPath(vdp, 'metrics'),
     'mockChainStorageRoot.vaultFactory.metrics',
   );
   t.is(
@@ -37,7 +37,7 @@ test.failing('storage keys', async t => {
   // First manager
   const managerA = await E(vdp).getCollateralManager(aeth.brand);
   t.is(
-    await subscriptionKey(E(managerA).getMetrics()),
+    await topicPath(managerA, 'metrics'),
     'mockChainStorageRoot.vaultFactory.manager0.metrics',
   );
   t.is(
@@ -52,7 +52,7 @@ test.failing('storage keys', async t => {
   // Second manager
   const [managerC, chit] = await d.addVaultType('Chit');
   t.is(
-    await subscriptionKey(E(E(managerC).getPublicFacet()).getMetrics()),
+    await topicPath(E(managerC).getPublicFacet(), 'metrics'),
     'mockChainStorageRoot.vaultFactory.manager1.metrics',
   );
   t.is(
@@ -67,14 +67,14 @@ test.failing('storage keys', async t => {
   // First aeth vault
   const vda1 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
   t.is(
-    await subscriptionKey(vda1.getVaultSubscriber()),
+    await E.get(vda1.getVaultSubscriber()).storagePath,
     'mockChainStorageRoot.vaultFactory.manager0.vaults.vault1',
   );
 
   // Second aeth vault
   const vda2 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
   t.is(
-    await subscriptionKey(vda2.getVaultSubscriber()),
+    await E.get(vda2.getVaultSubscriber()).storagePath,
     'mockChainStorageRoot.vaultFactory.manager0.vaults.vault2',
   );
 });

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -272,7 +272,7 @@ const legacyOfferResult = vaultSeat => {
       return {
         vault,
         publicNotifiers: {
-          vault: makeNotifierFromSubscriber(publicSubscribers.vault),
+          vault: makeNotifierFromSubscriber(publicSubscribers.vault.subscriber),
         },
       };
     });

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -654,7 +654,6 @@ test('price drop', async t => {
   t.truthy(await E(vaultSeat).hasExited());
 
   const metricsSub = await E(reserveCreatorFacet).getMetrics();
-  // @ts-expect-error type confusion
   const m = await subscriptionTracker(t, metricsSub);
   await m.assertInitial(reserveInitialState(run.makeEmpty()));
 
@@ -779,7 +778,6 @@ test('price falls precipitously', async t => {
   };
 
   const metricsSub = await E(reserveCreatorFacet).getMetrics();
-  // @ts-expect-error type confusion
   const m = await subscriptionTracker(t, metricsSub);
   await m.assertInitial(reserveInitialState(run.makeEmpty()));
   await manualTimer.tick(); // t 0->1, p 2200->19180
@@ -1757,7 +1755,6 @@ test('mutable liquidity triggers and interest', async t => {
   } = services;
 
   const metricsSub = await E(reserveCreatorFacet).getMetrics();
-  // @ts-expect-error type confusion
   const m = await subscriptionTracker(t, metricsSub);
   await m.assertInitial(reserveInitialState(run.makeEmpty()));
   let shortfallBalance = 0n;

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -24,3 +24,4 @@ export {
 } from './asyncIterableAdaptor.js';
 export * from './storesub.js';
 export * from './stored-notifier.js';
+export * from './stored-topic.js';

--- a/packages/notifier/src/stored-topic.js
+++ b/packages/notifier/src/stored-topic.js
@@ -1,6 +1,26 @@
 import { assertAllDefined } from '@agoric/internal';
 import { makeMarshallToStorage } from '@agoric/internal/src/lib-chainStorage.js';
+import { M } from '@agoric/store';
+import { E } from '@endo/eventual-send';
+import { SubscriberShape } from './publish-kit.js';
 import { forEachPublicationRecord } from './storesub.js';
+
+export const PublicTopicShape = M.splitRecord(
+  {
+    subscriber: SubscriberShape,
+    storagePath: M.promise(/* string */),
+  },
+  { description: M.string() },
+);
+
+/**
+ * @template {object} T topic value
+ * @typedef {{
+ *   description?: string,
+ *   subscriber: Subscriber<T>,
+ *   storagePath: ERef<string>,
+ * }} PublicTopic
+ */
 
 /**
  * NB: caller must ensure that `publisher.finish()` or `publisher.fail()` is
@@ -25,3 +45,18 @@ export const pipeTopicToStorage = (topic, storageNode, marshaller) => {
   });
 };
 harden(pipeTopicToStorage);
+
+/**
+ * @template T
+ * @param {string} description
+ * @param {Subscriber<T>} topic
+ * @param {ERef<StorageNode>} storageNode
+ * @returns {PublicTopic<T>}
+ */
+export const makePublicTopic = (description, topic, storageNode) => {
+  return {
+    description,
+    topic,
+    storagePath: E(storageNode).getPath(),
+  };
+};

--- a/packages/notifier/src/stored-topic.js
+++ b/packages/notifier/src/stored-topic.js
@@ -22,6 +22,13 @@ export const PublicTopicShape = M.splitRecord(
  * }} PublicTopic
  */
 
+export const TopicsRecordShape = M.recordOf(M.string(), PublicTopicShape);
+
+/**
+ * @typedef {{
+ *   [topicName: string]: PublicTopic<unknown>,
+ * }} TopicsRecord
+ */
 /**
  * NB: caller must ensure that `publisher.finish()` or `publisher.fail()` is
  * called when the publisher stores its final value.
@@ -49,14 +56,14 @@ harden(pipeTopicToStorage);
 /**
  * @template T
  * @param {string} description
- * @param {Subscriber<T>} topic
+ * @param {Subscriber<T>} subscriber
  * @param {ERef<StorageNode>} storageNode
  * @returns {PublicTopic<T>}
  */
-export const makePublicTopic = (description, topic, storageNode) => {
+export const makePublicTopic = (description, subscriber, storageNode) => {
   return {
     description,
-    topic,
+    subscriber,
     storagePath: E(storageNode).getPath(),
   };
 };

--- a/packages/notifier/src/stored-topic.js
+++ b/packages/notifier/src/stored-topic.js
@@ -1,0 +1,27 @@
+import { assertAllDefined } from '@agoric/internal';
+import { makeMarshallToStorage } from '@agoric/internal/src/lib-chainStorage.js';
+import { forEachPublicationRecord } from './storesub.js';
+
+/**
+ * NB: caller must ensure that `publisher.finish()` or `publisher.fail()` is
+ * called when the publisher stores its final value.
+ * Otherwise this watch is retained and can't be GCed.
+ *
+ * @param {Subscriber<any>} topic
+ * @param {ERef<StorageNode>} storageNode
+ * @param {ERef<ReturnType<import('@endo/marshal').makeMarshal>>} marshaller
+ * @returns {void}
+ */
+export const pipeTopicToStorage = (topic, storageNode, marshaller) => {
+  assertAllDefined({ topic, storageNode, marshaller });
+
+  const marshallToStorage = makeMarshallToStorage(storageNode, marshaller);
+
+  // Start publishing the source.
+  forEachPublicationRecord(topic, marshallToStorage).catch(err => {
+    // TODO: How should we handle and/or surface this failure?
+    // https://github.com/Agoric/agoric-sdk/pull/5766#discussion_r922498088
+    console.error('followAndStoreTopic failed to iterate', err);
+  });
+};
+harden(pipeTopicToStorage);

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -7,11 +7,13 @@ import { makePublishKit, subscribeEach } from './publish-kit.js';
 import { makeSubscriptionKit } from './subscriber.js';
 
 /**
+ * NB: does not yet survive upgrade https://github.com/Agoric/agoric-sdk/issues/6893
+ *
  * @template T
  * @param {Subscriber<T>} subscriber
  * @param {(v: T) => void} consumeValue
  */
-const forEachPublicationRecord = async (subscriber, consumeValue) => {
+export const forEachPublicationRecord = async (subscriber, consumeValue) => {
   const iteratorP = E(subscribeEach(subscriber))[Symbol.asyncIterator]();
 
   let finished = false;

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -37,7 +37,7 @@ export const UNPUBLISHED_RESULT = 'UNPUBLISHED';
  * @param {(spec: import('./invitations').InvitationSpec) => ERef<Invitation>} opts.powers.invitationFromSpec
  * @param {(brand: Brand) => Promise<import('./types').RemotePurse>} opts.powers.purseForBrand
  * @param {(status: OfferStatus) => void} opts.onStatusChange
- * @param {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers: import('./types').PublicSubscribers ) => Promise<void>} opts.onNewContinuingOffer
+ * @param {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers: import('./types').PublicSubscribers | import('@agoric/notifier').TopicsRecord ) => Promise<void>} opts.onNewContinuingOffer
  */
 export const makeOfferExecutor = ({
   zoe,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -541,11 +541,11 @@ export const prepareSmartWallet = (baggage, shared) => {
         getOffersFacet() {
           return this.facets.offers;
         },
-        /** @returns {Subscriber<CurrentWalletRecord>} */
+        /** @deprecated use getPublicTopics */
         getCurrentSubscriber() {
           return this.state.currentPublishKit.subscriber;
         },
-        /** @returns {Subscriber<UpdateRecord>} */
+        /** @deprecated use getPublicTopics */
         getUpdatesSubscriber() {
           return this.state.updatePublishKit.subscriber;
         },

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -214,7 +214,7 @@ export const prepareSmartWallet = (baggage, shared) => {
 
     const { walletStorageNode } = unique;
 
-    // TODO(turadg) replace StoredSubscriber with TopicMeta
+    // TODO(turadg) replace StoredSubscriber with PublicTopic
     // Start the publishing loops
     provideStoredSubscriber(
       updatePublishKit.subscriber,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -479,7 +479,7 @@ export const prepareSmartWallet = (baggage, shared) => {
                 status: offerStatus,
               });
             },
-            /** @type {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers?: import('./types').PublicSubscribers) => Promise<void>} */
+            /** @type {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers?: import('./types').PublicSubscribers | import('@agoric/notifier').TopicsRecord) => Promise<void>} */
             onNewContinuingOffer: async (
               offerId,
               invitationAmount,

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -130,12 +130,16 @@ export const assertHasData = async follower => {
  *
  * Handles the case of falsy argument so the caller can consistently await.
  *
- * @param {Record<string, ERef<StoredFacet>>} [subscribers]
+ * @param {import('./types.js').PublicSubscribers | import('@agoric/notifier').TopicsRecord} [subscribers]
  * @returns {ERef<Record<string, string>> | null}
  */
 export const objectMapStoragePath = subscribers => {
   if (!subscribers) {
     return null;
   }
-  return deeplyFulfilledObject(objectMap(subscribers, sub => E(sub).getPath()));
+  return deeplyFulfilledObject(
+    objectMap(subscribers, sub =>
+      'subscriber' in sub ? sub.storagePath : E(sub).getPath(),
+    ),
+  );
 };

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -201,6 +201,18 @@ export const mintCentralPayment = async (
   return E(supplier).getBootstrapPayment();
 };
 
+/**
+ *
+ * @param {ERef<{getPublicTopics: () => import('@agoric/notifier').TopicsRecord}>} hasTopics
+ * @param {string} subscriberName
+ */
+export const topicPath = (hasTopics, subscriberName) => {
+  return E(hasTopics)
+    .getPublicTopics()
+    .then(subscribers => subscribers[subscriberName])
+    .then(tr => tr.storagePath);
+};
+
 /** @type {<T>(subscriber: ERef<Subscriber<T>>) => Promise<T>} */
 export const headValue = async subscriber => {
   await eventLoopIteration();

--- a/packages/smart-wallet/test/test-walletFactory.js
+++ b/packages/smart-wallet/test/test-walletFactory.js
@@ -9,7 +9,7 @@ import {
   ActionType,
   headValue,
   makeMockTestSpace,
-  subscriptionKey,
+  topicPath,
 } from './supports.js';
 
 import '@agoric/vats/src/core/types.js';
@@ -126,18 +126,13 @@ test('notifiers', async t => {
   async function checkAddress(address) {
     const smartWallet = await t.context.simpleProvideWallet(address);
 
-    // xxx no type of getUpdatesSubscriber()
-    const updates = await E(smartWallet).getUpdatesSubscriber();
-
     t.is(
-      await subscriptionKey(updates),
+      await topicPath(smartWallet, 'updates'),
       `mockChainStorageRoot.wallet.${address}`,
     );
 
-    const current = await E(smartWallet).getCurrentSubscriber();
-
     t.is(
-      await subscriptionKey(current),
+      await topicPath(smartWallet, 'current'),
       `mockChainStorageRoot.wallet.${address}.current`,
     );
   }

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -1,4 +1,6 @@
-import { makePublicTopic } from '@agoric/notifier';
+import { makePublicTopic, SubscriberShape } from '@agoric/notifier';
+import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
+import { M, mustMatch } from '@agoric/store';
 import {
   makeScalarBigMapStore,
   provide,
@@ -55,6 +57,14 @@ export const makePublicTopicProvider = () => {
       // @ts-expect-error cast
       return extant.get(durableSubscriber);
     }
+    mustMatch(
+      harden({ description, durableSubscriber, storageNode }),
+      harden({
+        description: M.string(),
+        durableSubscriber: SubscriberShape,
+        storageNode: M.eref(StorageNodeShape),
+      }),
+    );
 
     /** @type {import('@agoric/notifier').PublicTopic<T>} */
     const newMeta = makePublicTopic(

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -1,4 +1,4 @@
-import { makeStoredSubscriber } from '@agoric/notifier';
+import { makePublicTopic } from '@agoric/notifier';
 import {
   makeScalarBigMapStore,
   provide,
@@ -36,40 +36,38 @@ harden(makeEphemeraProvider);
 /**
  *
  */
-export const makeEphemeralStoredSubscriberProvider = () => {
-  /** @type {WeakMap<Subscriber<any>, StoredSubscriber<any>>} */
+export const makePublicTopicProvider = () => {
+  /** @type {WeakMap<Subscriber<any>, import('@agoric/notifier').PublicTopic<any>>} */
   const extant = new WeakMap();
 
   /**
-   * Provide a StoredSubscriber for the specified durable subscriber.
+   * Provide a PublicTopic for the specified durable subscriber.
+   * Memoizes the resolution of the promise for the storageNode's path, for the lifetime of the vat.
    *
    * @template {object} T
-   * @param {Subscriber<T>} durableSubscriber
+   * @param {string} description
+   * @param {Subscriber<T>} durableSubscriber primary key
    * @param {ERef<StorageNode>} storageNode
-   * @param {ERef<Marshaller>} marshaller
-   * @returns {StoredSubscriber<T>}
+   * @returns {import('@agoric/notifier').PublicTopic<T>}
    */
-  const provideEphemeralStoredSubscriber = (
-    durableSubscriber,
-    storageNode,
-    marshaller,
-  ) => {
+  const providePublicTopic = (description, durableSubscriber, storageNode) => {
     if (extant.has(durableSubscriber)) {
       // @ts-expect-error cast
       return extant.get(durableSubscriber);
     }
 
-    const newSub = makeStoredSubscriber(
+    /** @type {import('@agoric/notifier').PublicTopic<T>} */
+    const newMeta = makePublicTopic(
+      description,
       durableSubscriber,
       storageNode,
-      marshaller,
     );
-    extant.set(durableSubscriber, newSub);
-    return newSub;
+    extant.set(durableSubscriber, newMeta);
+    return newMeta;
   };
-  return provideEphemeralStoredSubscriber;
+  return providePublicTopic;
 };
-harden(makeEphemeralStoredSubscriberProvider);
+harden(makePublicTopicProvider);
 
 /**
  * Provide an empty ZCF seat.


### PR DESCRIPTION
closes: #6900 

## Description
See #6900 for motivation and design sketch. This is a redo of https://github.com/Agoric/agoric-sdk/pull/6888 stacked on https://github.com/Agoric/agoric-sdk/pull/6871.

Some `StoredSubscriber` and `StoredSubscription` remain in Governance, but we're not tackling durability for that yet.

Review by commit is recommened. From here on I'll only do fixup commits until I get an approval; then I'll rebase to clean them before merge.

### Security Considerations

No changes in authority. 

### Scaling Considerations

This enables durability of stored subscribers. It does so with a `pipeTopicToStorage` call that was previous implicit in the construction of a StoredSubscriber. No change here but it does highlight that each spawns a loop that has to [survive upgrade](https://github.com/Agoric/agoric-sdk/issues/6893) and must be GCed. 

### Documentation Considerations

This has a breaking change to subscribers: vstorage keys should be read from `getPublicTopics()` instead of the `getSomeSubscriber`. In practice, only the Smart Wallet and tests should have been reading those paths because any other contract would not have access to vstorage and any other off-chain applications would have to get the values through Smart Wallet.

### Testing Considerations

CI plus `agops-vaults-smoketest`