### PR TITLE
feat(vats): upgradeable board

### DIFF
--- a/packages/ERTP/test/swingsetTests/ertpService/test-ertp-service-upgrade.js
+++ b/packages/ERTP/test/swingsetTests/ertpService/test-ertp-service-upgrade.js
@@ -15,6 +15,7 @@ test('ertp service upgrade', async t => {
     // defaultReapInterval: 'never',
     // defaultReapInterval: 1,
     vats: {
+      // TODO refactor to use bootstrap-relay.js
       bootstrap: { sourceSpec: bfile('bootstrap-ertp-service-upgrade.js') },
     },
     bundles: {

--- a/packages/SwingSet/test/bootstrap-relay.js
+++ b/packages/SwingSet/test/bootstrap-relay.js
@@ -1,6 +1,7 @@
 import { E } from '@endo/eventual-send';
 import { Far, isObject, makeMarshal } from '@endo/marshal';
 import { assert } from '@agoric/assert';
+import { objectMap } from '@agoric/internal';
 import { buildManualTimer } from '../tools/manual-timer.js';
 
 const { Fail, quote: q } = assert;
@@ -96,6 +97,20 @@ export const buildRootObject = () => {
       vat.incarnationNumber = incarnationNumber;
       return incarnationNumber;
     },
+
+    /**
+     * Turns an object into a remotable by ensuring that each property is a function
+     *
+     * @param {string} label
+     * @param {Record<string, any>} methodReturnValues
+     */
+    makeSimpleRemotable: (label, methodReturnValues) =>
+      // braces to unharden so it can be hardened
+      encodePassable(
+        Far(label, {
+          ...objectMap(methodReturnValues, v => () => decodePassable(v)),
+        }),
+      ),
 
     messageVat: async ({ name, methodName, args = [] }) => {
       const vat = vatData.get(name) || Fail`unknown vat name: ${q(name)}`;

--- a/packages/SwingSet/test/vat-timer-upgrade/test-vat-timer-upgrade.js
+++ b/packages/SwingSet/test/vat-timer-upgrade/test-vat-timer-upgrade.js
@@ -23,6 +23,7 @@ test('vat-timer upgrade', async t => {
   const config = {
     bootstrap: 'bootstrap',
     vats: {
+      // TODO refactor to use bootstrap-relay.js
       bootstrap: { sourceSpec: bfile('bootstrap-vat-timer-upgrade.js') },
     },
     devices: { timer: { sourceSpec: timer.srcPath } },

--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -24,6 +24,7 @@ import { Stable } from '@agoric/vats/src/tokens.js';
 import { makeNodeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { TimeMath } from '@agoric/time';
 
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 import {
   setupBootstrap,
   setUpZoeForTest,
@@ -124,8 +125,12 @@ test.before(async t => {
 const makeScenario = async (t, { env = process.env } = {}) => {
   const space = await setupBootstrap(t);
 
-  const loadVat = name =>
-    import(`@agoric/vats/src/vat-${name}.js`).then(ns => ns.buildRootObject());
+  const loadVat = name => {
+    const baggage = makeScalarBigMapStore('baggage');
+    return import(`@agoric/vats/src/vat-${name}.js`).then(ns =>
+      ns.buildRootObject({}, {}, baggage),
+    );
+  };
   space.produce.loadVat.resolve(loadVat);
   space.produce.loadCriticalVat.resolve(loadVat);
 

--- a/packages/smart-wallet/src/marshal-contexts.js
+++ b/packages/smart-wallet/src/marshal-contexts.js
@@ -6,17 +6,7 @@ import { DEFAULT_PREFIX } from '@agoric/vats/src/lib-board.js';
 
 const { Fail, quote: q } = assert;
 
-/**
- * For a value with a known id in the board, we can use
- * that board id as a slot to preserve identity when marshaling.
- *
- * The contents of the string depend on the `prefix` and `crcDigits` options:
- *    \`${prefix}${serialNum}${crc}\`
- *
- * For example, 'board0371' for 'board0', 3, 2 digits crc.
- *
- * @typedef {string} BoardId
- */
+/** @typedef {import('@agoric/vats/src/lib-board.js').BoardId} BoardId */
 
 /**
  * ID from a board made with { prefix: DEFAULT_PREFIX }

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -21,6 +21,7 @@ import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeLoopback } from '@endo/captp';
 import { E, Far } from '@endo/far';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 export { ActionType };
 
@@ -128,8 +129,10 @@ export const makeMockTestSpace = async log => {
     switch (name) {
       case 'mints':
         return mintsRoot();
-      case 'board':
-        return boardRoot();
+      case 'board': {
+        const baggage = makeScalarBigMapStore('baggage');
+        return boardRoot({}, {}, baggage);
+      }
       default:
         throw Error('unknown loadVat name');
     }

--- a/packages/smart-wallet/test/test-marshal-contexts.js
+++ b/packages/smart-wallet/test/test-marshal-contexts.js
@@ -7,7 +7,7 @@ import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 import {
   makeExportContext,
   makeImportContext,
-} from '@agoric/smart-wallet/src/marshal-contexts.js';
+} from '../src/marshal-contexts.js';
 
 /** @param {ReturnType<typeof makeBoard>} board */
 const makeAMM = board => {
@@ -119,7 +119,7 @@ test('ensureBoardId allows re-registration; initBoardId does not', t => {
   t.throws(() => context.initBoardId('board012', brandM));
 });
 
-test('makeExportContext.serialize handles unregistered identites', t => {
+test('makeExportContext.serialize handles unregistered identities', t => {
   const brand = Far('Zoe invitation brand', {});
   const instance = Far('amm instance', {});
   const invitationAmount = harden({ brand, value: [{ instance }] });

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -38,6 +38,7 @@
     "@agoric/store": "^0.8.3",
     "@agoric/swingset-vat": "^0.30.2",
     "@agoric/time": "^0.2.1",
+    "@agoric/vat-data": "^0.4.3",
     "@agoric/zoe": "^0.25.3",
     "@endo/far": "^0.2.14",
     "@endo/import-bundle": "^0.3.0",

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -1,15 +1,44 @@
 // @ts-check
+/**
+ * @file lib-board: share objects by way of plain-data ids
+ *
+ * @see prepareBoardKit()
+ */
 
-import { assert, details as X, q, Fail } from '@agoric/assert';
+import { assert, Fail, q } from '@agoric/assert';
+import { M, makeScalarBigMapStore, prepareExoClassKit } from '@agoric/vat-data';
 import { E, Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
-import { makeScalarMapStore } from '@agoric/store';
-import { crc6 } from './crc.js';
 
-import './types.js';
+import { crc6 } from './crc.js';
 
 export const DEFAULT_CRC_DIGITS = 2;
 export const DEFAULT_PREFIX = 'board0';
+
+// #region Interface Guards
+// TODO import from Endo
+const CapDataShape = { body: M.string(), slots: M.array() };
+const MarshalI = M.interface('Marshaller', {
+  serialize: M.call(M.any()).returns(CapDataShape),
+  unserialize: M.call(CapDataShape).returns(M.any()),
+});
+
+const IdShape = M.string();
+const ValShape = M.scalar();
+const BoardKitIKit = {
+  board: M.interface('Board', {
+    has: M.call(ValShape).returns(M.boolean()),
+    getValue: M.call(IdShape).returns(ValShape),
+    lookup: M.call().rest(M.arrayOf(IdShape)).returns(M.promise()),
+    getId: M.call(ValShape).returns(IdShape),
+    ids: M.call().returns(M.arrayOf(IdShape)),
+    getPublishingMarshaller: M.call().returns(M.remotable()),
+    getReadonlyMarshaller: M.call().returns(M.remotable()),
+  }),
+  publishingMarshaller: MarshalI,
+  readonlyMarshaller: MarshalI,
+};
+// #endregion
 
 /**
  * For a value with a known id in the board, we can use
@@ -28,7 +57,6 @@ export const DEFAULT_PREFIX = 'board0';
  *
  * @param {number | string} data
  * @param {number} crcDigits
- * @returns {string}
  */
 const calcCrc = (data, crcDigits) => {
   // The explicit use of crcmodels is to avoid a typing error.
@@ -40,22 +68,115 @@ const calcCrc = (data, crcDigits) => {
 };
 
 /**
- * Create a board to post things on.
+ * @see {prepareExoClassKit}
+ * @see {@link ../../SwingSet/docs/virtual-objects.md|SwingSet Virtual Objects}
+ *
+ * Hoisting this function makes defining the state type concise.
+ * @typedef {ReturnType<typeof initDurableBoardState>} BoardState
+ *
+ *
+ * // TODO: use Key from @agoric/store when available
+ * @typedef {import('@endo/marshal').Passable} Key
+ */
+
+// TODO consider tightening initSequence to bigint only
+/**
+ * Make state for the board. Hoisted up to define the BoardState type.
  *
  * @param {bigint | number} [initSequence]
  * @param {object} [options]
- * @param {string} [options.prefix]
- * @param {number} [options.crcDigits]
+ * @param {string} [options.prefix] prefix for all ids generated
+ * @param {number} [options.crcDigits] count of digits to use in CRC at end of the id
  */
-function makeBoard(
+const initDurableBoardState = (
   initSequence = 0,
   { prefix = DEFAULT_PREFIX, crcDigits = DEFAULT_CRC_DIGITS } = {},
-) {
-  const DIGITS_REGEXP = new RegExp(`^[0-9]{${crcDigits + 1},}$`);
-  let lastSequence = BigInt(initSequence);
-  const idToVal = makeScalarMapStore('boardId');
-  const valToId = makeScalarMapStore('value');
+) => {
+  const immutable = { prefix, crcDigits };
 
+  const lastSequence = BigInt(initSequence);
+  /** @type {MapStore<BoardId, Key>} */
+  const idToVal = makeScalarBigMapStore('idToVal', {
+    durable: true,
+    keyShape: IdShape,
+    valueShape: ValShape,
+  });
+  /** @type {MapStore<Key, BoardId>} */
+  const valToId = makeScalarBigMapStore('valToId', {
+    durable: true,
+    keyShape: ValShape,
+    valueShape: IdShape,
+  });
+
+  const mutable = { lastSequence, idToVal, valToId };
+
+  return {
+    ...immutable,
+    ...mutable,
+  };
+};
+
+// #region Marshaller utils
+// These utils are used by the {readonlyMarshaller, publishingMarshaller} facets
+// to serialize/unserialize. They can't return the marshallers themselves
+// because of the heap cost of maintaining those objects. Instead they make
+// transient marshallers that get GCed when the function completes.
+
+/**
+ * @param {Key} value
+ * @param {BoardState} state
+ */
+const getId = (value, state) => {
+  const { idToVal, valToId, prefix, crcDigits } = state;
+
+  if (valToId.has(value)) {
+    return valToId.get(value);
+  }
+
+  state.lastSequence += 1n;
+  const seq = state.lastSequence;
+
+  const crcInput = `${prefix}${seq}`;
+  const crc = calcCrc(crcInput, crcDigits);
+
+  const id = `${prefix}${crc}${seq}`;
+
+  valToId.init(value, id);
+  idToVal.init(id, value);
+  return id;
+};
+
+/**
+ * @param {string} id
+ * @param {Readonly<BoardState>} state
+ */
+const getValue = (id, { prefix, crcDigits, idToVal }) => {
+  id.startsWith(prefix) || Fail`id must start with ${q(prefix)}: ${id}`;
+  const digits = id.slice(prefix.length);
+  // the +1 is because the serial number will be at least one digit
+  const DIGITS_REGEXP = new RegExp(`^[0-9]{${crcDigits + 1},}$`);
+  DIGITS_REGEXP.test(digits) ||
+    Fail`id must end in at least ${q(crcDigits + 1)} digits: ${id}`;
+
+  if (idToVal.has(id)) {
+    return idToVal.get(id);
+  }
+
+  const allegedCrc = digits.slice(0, crcDigits);
+
+  const seq = digits.slice(crcDigits);
+  const crcInput = `${prefix}${seq}`;
+  const crc = calcCrc(crcInput, crcDigits);
+
+  allegedCrc === crc || Fail`id is probably a typo, cannot verify CRC: ${id}`;
+  // template Fail alone can't trigger type inference https://github.com/microsoft/TypeScript/issues/50739
+  throw Fail`board does not have id: ${id}`;
+};
+
+/**
+ * @param {BoardState} state
+ */
+const makeSlotToVal = state => {
   const ifaceAllegedPrefix = 'Alleged: ';
   const ifaceInaccessiblePrefix = 'SEVERED: ';
 
@@ -66,8 +187,7 @@ function makeBoard(
    */
   const slotToVal = (slot, iface) => {
     if (slot !== null) {
-      // eslint-disable-next-line no-use-before-define
-      return board.getValue(slot);
+      return getValue(slot, state);
     }
 
     // Private object.
@@ -76,83 +196,168 @@ function makeBoard(
     }
     return Far(`${ifaceInaccessiblePrefix}${iface}`, {});
   };
+  return slotToVal;
+};
 
-  // Create a marshaller that just looks up objects, not publish them.
-  const readonlyMarshaller = Far('board readonly marshaller', {
-    ...makeMarshal(val => {
-      if (!valToId.has(val)) {
-        // Unpublished value.
-        return null;
-      }
+/**
+ * @typedef {ReturnType<typeof makeMarshal<string>>} StringSlotMarshaller
+ * TODO make Marshall type generic on slot
+ */
 
-      // Published value.
-      return valToId.get(val);
-    }, slotToVal),
-  });
+/**
+ * @param {BoardState} state
+ * @returns {StringSlotMarshaller}
+ */
+const makeReadonlyMarshaller = state => {
+  const { valToId } = state;
+  const slotToVal = makeSlotToVal(state);
+  const valToSlot = val => {
+    if (!valToId.has(val)) {
+      // Unpublished value.
+      return null;
+    }
 
-  // Create a marshaller useful for publishing all ocaps.
-  const publishingMarshaller = Far('board publishing marshaller', {
-    ...makeMarshal(
-      // Always put the value in the board.
-      // eslint-disable-next-line no-use-before-define
-      val => board.getId(val),
-      slotToVal,
-    ),
-  });
+    // Published value.
+    return valToId.get(val);
+  };
+  return makeMarshal(valToSlot, slotToVal);
+};
 
-  const board = Far('Board', {
-    getPublishingMarshaller: () => publishingMarshaller,
-    getReadonlyMarshaller: () => readonlyMarshaller,
-    // Add if not already present
-    getId: value => {
-      if (!valToId.has(value)) {
-        lastSequence += 1n;
-        const seq = lastSequence;
+/**
+ * @param {BoardState} state
+ * @returns {StringSlotMarshaller}
+ */
+const makePublishingMarshaller = state => {
+  const slotToVal = makeSlotToVal(state);
+  // Always put the value in the board.
+  const valToSlot = val => getId(val, state);
+  return makeMarshal(valToSlot, slotToVal);
+};
+// #endregion
 
-        // Append the CRC, so that the last part of the board ID is
-        // well-distributed.
-        const crcInput = `${prefix}${seq}`;
-        const crc = calcCrc(crcInput, crcDigits);
-
-        const id = `${prefix}${crc}${seq}`;
-
-        valToId.init(value, id);
-        idToVal.init(id, value);
-      }
-      return valToId.get(value);
+/**
+ * A board is a two-way mapping between objects (such as issuers,
+ * brands, installation handles) and plain-data string IDs.
+ * A well-known board allows sharing objects by way of their ids.
+ *
+ * @param {import('@agoric/vat-data').Baggage} baggage for upgrade successors
+ * @see {@link packages/SwingSet/docs/vat-upgrade.md|Vat Upgrade}
+ */
+export const prepareBoardKit = baggage => {
+  return prepareExoClassKit(
+    baggage,
+    'Board',
+    BoardKitIKit,
+    initDurableBoardState,
+    {
+      board: {
+        /**
+         * Provide an ID for a value, generating one if not already present.
+         *
+         * Each board ID includes a CRC so that the last part is well-distributed,
+         * which mitigates typo risks.
+         *
+         * Scaling Consideration: since we cannot know when consumers
+         * are no longer interested in an ID, a board holds a strong reference
+         * to `value` for its entire lifetime. For a well-known board, this
+         * is essentially forever.
+         *
+         * @param {Key} value
+         * @throws if `value` is not a Key in the @agoric/store sense
+         */
+        getId(value) {
+          return getId(value, this.state);
+        },
+        /**
+         * @param {BoardId} id
+         * @throws if id is not in the mapping
+         */
+        getValue(id) {
+          return getValue(id, this.state);
+        },
+        /**
+         * Adapter for NameHub lookup() protocol.
+         *
+         * @param  {...string} path
+         */
+        async lookup(...path) {
+          const {
+            facets: { board },
+          } = this;
+          if (path.length === 0) {
+            return board;
+          }
+          const [first, ...rest] = path;
+          const firstValue = board.getValue(/** @type {BoardId} */ (first));
+          if (rest.length === 0) {
+            return firstValue;
+          }
+          return E(firstValue).lookup(...rest);
+        },
+        /** @param {Key} val */
+        has(val) {
+          const { state } = this;
+          return state.valToId.has(val);
+        },
+        ids() {
+          const { state } = this;
+          return harden([...state.idToVal.keys()]);
+        },
+        /**
+         * Get a marshaller that implements the convertValToSlot hook using getId(),
+         * "publishing" previously un-mapped objects.
+         */
+        getPublishingMarshaller() {
+          return this.facets.publishingMarshaller;
+        },
+        /**
+         * Get a marshaller that implements the convertValToSlot hook using getId(),
+         * only for objects that the board has().
+         *
+         * For other objects, we don't throw, but we emit a null slot.
+         * Un-serializing a null slot always produces a fresh object
+         * rather than preserving object identity.
+         */
+        getReadonlyMarshaller() {
+          return this.facets.readonlyMarshaller;
+        },
+      },
+      /**
+       * @param {string} id
+       * @throws if id is not in the mapping
+       * @returns {Marshaller}
+       */
+      readonlyMarshaller: {
+        serialize(val) {
+          const readonly = makeReadonlyMarshaller(this.state);
+          return readonly.serialize(val);
+        },
+        unserialize(data) {
+          const readonly = makeReadonlyMarshaller(this.state);
+          return readonly.unserialize(data);
+        },
+      },
+      publishingMarshaller: {
+        serialize(val) {
+          const publishing = makePublishingMarshaller(this.state);
+          return publishing.serialize(val);
+        },
+        unserialize(data) {
+          const publishing = makePublishingMarshaller(this.state);
+          return publishing.unserialize(data);
+        },
+      },
     },
-    getValue: id => {
-      assert.typeof(id, 'string', X`id must be string: ${id}`);
-      id.startsWith(prefix) || Fail`id must start with ${prefix}: ${id}`;
-      const digits = id.slice(prefix.length);
-      digits.match(DIGITS_REGEXP) ||
-        Fail`id must end in at least ${q(crcDigits + 1)} digits: ${id}`;
-      const seq = digits.slice(crcDigits);
-      const allegedCrc = digits.slice(0, crcDigits);
-      const crcInput = `${prefix}${seq}`;
-      const crc = calcCrc(crcInput, crcDigits);
-      allegedCrc === crc ||
-        Fail`id is probably a typo, cannot verify CRC: ${id}`;
-      idToVal.has(id) || Fail`board does not have id: ${id}`;
-      return idToVal.get(id);
-    },
-    // Adapter for lookup() protocol.
-    lookup: async (...path) => {
-      if (path.length === 0) {
-        return board;
-      }
-      const [first, ...rest] = path;
-      const firstValue = board.getValue(first);
-      if (rest.length === 0) {
-        return firstValue;
-      }
-      return E(firstValue).lookup(...rest);
-    },
-    has: valToId.has,
-    ids: () => harden([...idToVal.keys()]),
-  });
+  );
+};
 
-  return board;
-}
-
-export { makeBoard };
+/**
+ * @param {bigint | number} [initSequence]
+ * @param {object} [options]
+ * @param {string} [options.prefix]
+ * @param {number} [options.crcDigits]
+ */
+export const makeBoard = (initSequence = 0, options = {}) => {
+  const make = prepareBoardKit(makeScalarBigMapStore('baggage'));
+  return make(initSequence, options).board;
+};

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -12,7 +12,19 @@ export const DEFAULT_CRC_DIGITS = 2;
 export const DEFAULT_PREFIX = 'board0';
 
 /**
- * We calculate a CRC, ensuring it's of CRC_NUM_DIGITS length.
+ * For a value with a known id in the board, we can use
+ * that board id as a slot to preserve identity when marshaling.
+ *
+ * The contents of the string depend on the `prefix` and `crcDigits` options:
+ *    \`${prefix}${crc}${seq}\`
+ *
+ * For example, 'board0371' for prefix: 'board0', seq: 1, 2 digits crc.
+ *
+ * @typedef {string} BoardId
+ */
+
+/**
+ * Calculate a CRC, padding to crcDigits.
  *
  * @param {number | string} data
  * @param {number} crcDigits
@@ -46,6 +58,12 @@ function makeBoard(
 
   const ifaceAllegedPrefix = 'Alleged: ';
   const ifaceInaccessiblePrefix = 'SEVERED: ';
+
+  /**
+   * @param {BoardId} slot
+   * @param {string} iface
+   * @returns {unknown}
+   */
   const slotToVal = (slot, iface) => {
     if (slot !== null) {
       // eslint-disable-next-line no-use-before-define

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -272,7 +272,12 @@ export const prepareBoardKit = baggage => {
           return getValue(id, this.state);
         },
         /**
-         * Adapter for NameHub lookup() protocol.
+         * Convenience method for recursively traversing boards and
+         * board-like remotables to get data associated with a sequence of ids
+         * corresponding to each successive board.
+         * For example, `lookup("foo", "bar")` gets the value associated with
+         * id "foo" and returns the result of invoking `lookup("bar")` upon it
+         * to get the value it associates with id "bar".
          *
          * @param  {...string} path
          */

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -199,14 +199,10 @@ const makeSlotToVal = state => {
   return slotToVal;
 };
 
-/**
- * @typedef {ReturnType<typeof makeMarshal<string>>} StringSlotMarshaller
- * TODO make Marshall type generic on slot
- */
-
+// TODO make Marshaller type generic on slot
 /**
  * @param {BoardState} state
- * @returns {StringSlotMarshaller}
+ * @returns {ReturnType<typeof makeMarshal<string?>>}
  */
 const makeReadonlyMarshaller = state => {
   const { valToId } = state;
@@ -225,7 +221,7 @@ const makeReadonlyMarshaller = state => {
 
 /**
  * @param {BoardState} state
- * @returns {StringSlotMarshaller}
+ * @returns {ReturnType<typeof makeMarshal<string>>}
  */
 const makePublishingMarshaller = state => {
   const slotToVal = makeSlotToVal(state);

--- a/packages/vats/src/vat-board.js
+++ b/packages/vats/src/vat-board.js
@@ -1,7 +1,23 @@
-import { Far } from '@endo/far';
-import { makeBoard } from './lib-board.js';
+// @ts-check
+import { provide } from '@agoric/vat-data';
+import { Far } from '@endo/marshal';
+import { prepareBoardKit } from './lib-board.js';
 
-export function buildRootObject() {
-  const board = makeBoard();
-  return Far('board', { getBoard: () => board });
+// There is only one board in this vat.
+const THE_BOARD = 'theboard';
+
+/**
+ * @param {unknown} _vatPowers
+ * @param {unknown} _vatParameters
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ */
+export function buildRootObject(_vatPowers, _vatParameters, baggage) {
+  const makeBoardKit = prepareBoardKit(baggage);
+  const { board } = provide(
+    baggage,
+    THE_BOARD,
+    // XXX provide() type assumes the maker takes the key as its first argument
+    () => makeBoardKit(),
+  );
+  return Far('vat-board', { getBoard: () => board });
 }

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -7,6 +7,7 @@ import { E, passStyleOf } from '@endo/far';
 
 import { makeZoeKit } from '@agoric/zoe';
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { buildRootObject as buildPSMRootObject } from '../src/core/boot-psm.js';
 import { buildRootObject } from '../src/core/boot.js';
 import { bridgeCoreEval } from '../src/core/chain-behaviors.js';
@@ -72,7 +73,8 @@ test('evaluateInstallation is available to core eval', async t => {
 
     const { zoeService } = makeZoeKit(makeFakeVatAdmin(() => {}).admin);
 
-    const theBoard = boardRoot().getBoard();
+    const baggage = makeScalarBigMapStore('baggage');
+    const theBoard = boardRoot({}, {}, baggage).getBoard();
     const bundle = await bundleSource(modulePath);
 
     const installation = await E(zoeService).install(bundle);

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -11,6 +11,7 @@ import {
   connectFaucet,
   showAmount,
 } from '@agoric/inter-protocol/src/proposals/demoIssuers.js';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { setupClientManager } from '../src/core/chain-behaviors.js';
 import { makeAgoricNamesAccess, makePromiseSpace } from '../src/core/utils.js';
 import { buildRootObject as mintsRoot } from '../src/vat-mints.js';
@@ -70,8 +71,10 @@ test('connectFaucet produces payments', async t => {
     switch (name) {
       case 'mints':
         return mintsRoot();
-      case 'board':
-        return boardRoot();
+      case 'board': {
+        const baggage = makeScalarBigMapStore('baggage');
+        return boardRoot({}, {}, baggage);
+      }
       default:
         throw Error('unknown loadVat name');
     }

--- a/packages/vats/test/test-lib-board.js
+++ b/packages/vats/test/test-lib-board.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { Far } from '@endo/far';
+import { E, Far } from '@endo/far';
 import { makeBoard } from '../src/lib-board.js';
 
 test('makeBoard', async t => {
@@ -47,6 +47,14 @@ test('makeBoard', async t => {
   t.is(idObj1b, 'tooboard311');
   const idObj2b = board2.getId(obj2);
   t.is(idObj2b, 'tooboard012');
+});
+
+test('board values must be scalar keys', async t => {
+  const board = makeBoard();
+  const nonKey = harden({ a: 1 });
+  await t.throwsAsync(() => E(board).getId(nonKey), {
+    message: /arg 0: A "copyRecord" cannot be a scalar key: {"a":1}/,
+  });
 });
 
 const testBoardMarshaller = async (t, board, marshaller, publishing) => {

--- a/packages/vats/test/upgrading/test-upgrade-contracts.js
+++ b/packages/vats/test/upgrading/test-upgrade-contracts.js
@@ -35,6 +35,7 @@ test('upgrade mintHolder', async t => {
     defaultManagerType: 'xs-worker',
     bootstrap: 'bootstrap',
     vats: {
+      // TODO refactor to use bootstrap-relay.js
       bootstrap: { sourceSpec: bfile('./bootstrap.js') },
       zoe: { sourceSpec: bfile('../../src/vat-zoe.js') },
     },

--- a/packages/vats/test/upgrading/test-upgrade-vats.js
+++ b/packages/vats/test/upgrading/test-upgrade-vats.js
@@ -1,0 +1,86 @@
+/* eslint-disable no-await-in-loop */
+import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { buildVatController } from '@agoric/swingset-vat';
+import { kunser } from '@agoric/swingset-vat/src/lib/kmarshal.js';
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
+const test = anyTest;
+
+const makeTestContext = async metaUrl => {
+  const bfile = name => new URL(name, metaUrl).pathname;
+  return { bfile };
+};
+
+/**
+ * NOTE: limit ambient authority such as import.meta.url
+ * to test.before()
+ */
+test.before(async t => {
+  t.context = await makeTestContext(import.meta.url);
+});
+
+test('upgrade vat-board', async t => {
+  const { bfile } = t.context;
+
+  /** @type {SwingSetConfig} */
+  const config = {
+    includeDevDependencies: true, // for vat-data
+    defaultManagerType:
+      /** @type {import('@agoric/swingset-vat/src/types-external.js').ManagerType} */ (
+        'xs-worker'
+      ), // 'local',
+    bootstrap: 'bootstrap',
+    defaultReapInterval: 'never',
+    vats: {
+      bootstrap: {
+        sourceSpec: bfile('../../../SwingSet/test/bootstrap-relay.js'),
+      },
+    },
+    bundles: {
+      board: { sourceSpec: bfile('../../src/vat-board.js') },
+    },
+  };
+
+  const c = await buildVatController(config);
+  t.teardown(c.shutdown);
+  c.pinVatRoot('bootstrap');
+  await c.run();
+
+  const run = async (method, args = []) => {
+    assert(Array.isArray(args));
+    const kpid = c.queueToVatRoot('bootstrap', method, args);
+    await c.run();
+    const status = c.kpStatus(kpid);
+    if (status === 'fulfilled') {
+      const result = c.kpResolution(kpid);
+      return kunser(result);
+    }
+    assert(status === 'rejected');
+    const err = c.kpResolution(kpid);
+    throw kunser(err);
+  };
+  const messageVat = (name, methodName, args) =>
+    run('messageVat', [{ name, methodName, args }]);
+  const messageObject = (presence, methodName, args) =>
+    run('messageVatObject', [{ presence, methodName, args }]);
+
+  t.log('create initial version');
+  const boardVatConfig = {
+    name: 'board',
+    bundleCapName: 'board',
+  };
+  await run('createVat', [boardVatConfig]);
+  const board = await messageVat('board', 'getBoard', []);
+  const thing = await run('makeSimpleRemotable', ['Thing', {}]);
+  const thingId = await messageObject(board, 'getId', [thing]);
+  t.regex(thingId, /^board0[0-9]+$/);
+
+  t.log('now perform the null upgrade');
+  const { incarnationNumber } = await run('upgradeVat', [boardVatConfig]);
+  t.is(incarnationNumber, 2, 'Board vat must be upgraded');
+  const board2 = await messageVat('board', 'getBoard', []);
+  t.is(board2, board, 'must get the same board reference');
+  const actualThing = await messageObject(board2, 'getValue', [thingId]);
+  t.is(actualThing, thing, 'must get original value back');
+});

--- a/packages/vats/tools/boot-test-utils.js
+++ b/packages/vats/tools/boot-test-utils.js
@@ -5,6 +5,7 @@ import {
 } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { Far } from '@endo/marshal';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { bundles, devices } from '../test/devices.js';
 
 import { buildRootObject as bankRoot } from '../src/vat-bank.js';
@@ -119,9 +120,10 @@ export const makePopulatedFakeVatAdmin = () => {
       // preferred way to pass the name.
       vatParameters.zcfBundleName = 'zcf';
     }
+    const baggage = makeScalarBigMapStore('baggage');
     const adminNode =
       /** @type {import('@agoric/swingset-vat').VatAdminFacet} */ ({});
-    return { root: buildRoot({}, vatParameters), adminNode };
+    return { root: buildRoot({}, vatParameters, baggage), adminNode };
   };
   const createVatByName = name => {
     return createVat(fakeNameToCap.get(name));

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -1521,7 +1521,6 @@ export function makeWalletRoot({
     return E(board)
       .getValue(boardId)
       .then(value => {
-        // @ts-expect-error type is too specific
         context.ensureBoardId(boardId, value);
         return acceptFn(petname, value);
       });

--- a/packages/wallet/api/test/test-wallet-marshal.js
+++ b/packages/wallet/api/test/test-wallet-marshal.js
@@ -111,12 +111,12 @@ test('ensureBoardId allows re-registration; initBoardId does not', t => {
   const brandS = Far('Semolean brand', {});
 
   const context = makeExportContext();
-  context.initBoardId('board1', brandM);
-  t.throws(() => context.initBoardId('board1', brandM));
-  context.ensureBoardId('board1', brandM);
-  t.throws(() => context.ensureBoardId('board12', brandM));
-  context.ensureBoardId('board12', brandS);
-  t.throws(() => context.initBoardId('board12', brandM));
+  context.initBoardId('board01', brandM);
+  t.throws(() => context.initBoardId('board01', brandM));
+  context.ensureBoardId('board01', brandM);
+  t.throws(() => context.ensureBoardId('board012', brandM));
+  context.ensureBoardId('board012', brandS);
+  t.throws(() => context.initBoardId('board012', brandM));
 });
 
 test('makeExportContext.serialize handles unregistered identites', t => {
@@ -125,7 +125,7 @@ test('makeExportContext.serialize handles unregistered identites', t => {
   const invitationAmount = harden({ brand, value: [{ instance }] });
 
   const context = makeExportContext();
-  context.initBoardId('board1', brand);
+  context.initBoardId('board01', brand);
   const actual = context.serialize(invitationAmount);
 
   t.deepEqual(actual, {
@@ -145,7 +145,7 @@ test('makeExportContext.serialize handles unregistered identites', t => {
         },
       ],
     }),
-    slots: ['board1', 'unknown:1'],
+    slots: ['board01', 'unknown:1'],
   });
 
   t.deepEqual(context.unserialize(actual), invitationAmount);
@@ -176,9 +176,9 @@ test('fromBoard.serialize requires board ids', t => {
     message: '"key" not found: "[Alleged: InstanceHandle]"',
   });
 
-  context.ensureBoardId('board123', unpassable.instance);
+  context.ensureBoardId('board0123', unpassable.instance);
   t.deepEqual(context.fromBoard.serialize(unpassable), {
     body: '{"instance":{"@qclass":"slot","iface":"Alleged: InstanceHandle","index":0}}',
-    slots: ['board123'],
+    slots: ['board0123'],
   });
 });

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -16,23 +16,24 @@ import { Far } from '@endo/marshal';
  * representative also remains.
  *
  * @template {{}} E Ephemeral state
- * @param {() => E} init
+ * @template {{}} [K=any] key on which to provision
+ * @param {(key: K) => E} init
  */
 export const makeEphemeraProvider = init => {
-  /** @type {WeakMap<any, E>} */
+  /** @type {WeakMap<K, E>} */
   const extant = new WeakMap();
 
   /**
    * Provide an object to hold state that need not (or cannot) be durable.
    *
-   * @type {(key: any) => E}
+   * @type {(key: K) => E}
    */
   return key => {
     if (extant.has(key)) {
       // @ts-expect-error cast
       return extant.get(key);
     }
-    const newEph = init();
+    const newEph = init(key);
     extant.set(key, newEph);
     return newEph;
   };

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
@@ -17,6 +17,7 @@ test('coveredCall service upgrade', async t => {
     // defaultReapInterval: 1,
     vats: {
       bootstrap: {
+        // TODO refactor to use bootstrap-relay.js
         sourceSpec: bfile('bootstrap-coveredCall-service-upgrade.js'),
       },
       zoe: { sourceSpec: bfile('./vat-zoe.js') },


### PR DESCRIPTION
refs: #6553

## Description

Use the `prepareExoClassKit` pattern make board state virtual, durable, and heritable by upgrade successors.

Marshallers are `provide`d ephemerally, keyed by `this`.

### Security Considerations

Interface guards tighten things up a bit.

### Scaling Considerations

on `getId(val)`:
```js
      /**
       * Scaling Consideration: since we cannot know when consumers
       * are no longer interested in an ID, a board holds a strong reference
       * to `value` for its entire lifetime. For a well-known board, this
       * is essentially forever.
       */
```

### Documentation Considerations

Since this was my first (non-trivial) work with the virtual, durable, upgrade APIs, I tried to leave cookie crumbs.

Since I touched so much code, I added external API documentation to `lib-board.js` while I was at it.

### Testing Considerations

1 happy-path null upgrade test seemed sufficient to force me to get VDO / upgrade stuff right.

`test-lib-board.js` came in quite handy for testing interface guards and making sure I didn't break the marshal stuff.
I added 1 test to be more explicit that values have to be passable keys.
