### PR TITLE
chore!: remove 'asset' from publicSubscribers

### DIFF
--- a/packages/inter-protocol/src/stakeFactory/stakeFactory.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactory.js
@@ -193,8 +193,6 @@ export const start = async (
 
     return harden({
       publicSubscribers: {
-        // XXX should come from manager directly https://github.com/Agoric/agoric-sdk/issues/5814
-        asset: manager.getAssetSubscriber(),
         vault: pot.getSubscriber(),
       },
       invitationMakers: Far('invitation makers', {

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -587,11 +587,7 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           seat.exit();
 
           // eslint-disable-next-line no-use-before-define
-          const vaultKit = makeVaultKit(
-            self,
-            state.storageNode,
-            state.manager.getAssetSubscriber(),
-          );
+          const vaultKit = makeVaultKit(self, state.storageNode);
           state.outerUpdater = vaultKit.vaultUpdater;
           helper.updateUiState();
 
@@ -661,11 +657,7 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           );
           trace('initVault updateDebtAccounting fired');
 
-          const vaultKit = makeVaultKit(
-            self,
-            storageNode,
-            state.manager.getAssetSubscriber(),
-          );
+          const vaultKit = makeVaultKit(self, storageNode);
           state.outerUpdater = vaultKit.vaultUpdater;
           helper.updateUiState();
           return vaultKit;

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -19,15 +19,12 @@ export const prepareVaultKit = (baggage, marshaller) => {
    *
    * @param {Vault} vault
    * @param {ERef<StorageNode>} storageNode
-   * @param {Subscriber<import('./vaultManager').AssetState>} assetSubscriber
    */
-  const makeVaultKit = (vault, storageNode, assetSubscriber) => {
+  const makeVaultKit = (vault, storageNode) => {
     trace('prepareVaultKit makeVaultKit');
     const { holder, helper } = makeVaultHolder(vault, storageNode);
     const vaultKit = harden({
       publicSubscribers: {
-        // XXX should come from manager directly https://github.com/Agoric/agoric-sdk/issues/5814
-        asset: assetSubscriber,
         vault: holder.getSubscriber(),
       },
       invitationMakers: Far('invitation makers', {


### PR DESCRIPTION
closes: #5814

## Description

Time to remove the `asset` topic from vault offer result. It's available from the vaultManager that was used to make the vault. (Same for stakeFactory)

Simplifies https://github.com/Agoric/agoric-sdk/pull/6902/

### Security Considerations

--

### Scaling Considerations

--

### Documentation Considerations

Breaking change, denoted by the bang in the commit message.

### Testing Considerations

CI