### PR TITLE
6519 liquidationPadding

### DIFF
--- a/golang/cosmos/x/swingset/types/types.go
+++ b/golang/cosmos/x/swingset/types/types.go
@@ -25,7 +25,7 @@ func NewEgress(nickname string, peer sdk.AccAddress, powerFlags []string) *Egres
 	}
 }
 
-// FIXME: Should have @agoric/nat
+// FIXME: Should have @endo/nat
 func Nat(num float64) (uint64, error) {
 	if num < 0 {
 		return 0, errors.New("Not a natural")

--- a/packages/inter-protocol/src/proposals/demoIssuers.js
+++ b/packages/inter-protocol/src/proposals/demoIssuers.js
@@ -102,6 +102,7 @@ const defaultConfig = /** @type {const} */ ({
  *     liquidationPenalty: Rational,
  *     interestRate: Rational,
  *     loanFee: Rational,
+ *     liquidationPadding?: Rational,
  *   },
  *   trades: Array<{ central: number, collateral: bigint}>
  * }>}
@@ -448,6 +449,10 @@ export const poolRates = (issuerName, record, kits, central) => {
     liquidationPenalty: toRatio(config.liquidationPenalty, central.brand),
     interestRate: toRatio(config.interestRate, central.brand),
     loanFee: toRatio(config.loanFee, central.brand),
+    // XXX not relevant to AMM pools but poolRates is also used for addVaultType
+    liquidationPadding:
+      config.liquidationPadding &&
+      toRatio(config.liquidationPadding, central.brand),
   };
   return { rates, initialValue: inCollateral(config.collateralValue) };
 };

--- a/packages/inter-protocol/src/vaultFactory/math.js
+++ b/packages/inter-protocol/src/vaultFactory/math.js
@@ -4,17 +4,43 @@
  */
 
 import { getAmountOut } from '@agoric/zoe/src/contractSupport/priceQuote.js';
-import { floorDivideBy } from '@agoric/zoe/src/contractSupport/ratio.js';
+import {
+  addRatios,
+  floorDivideBy,
+} from '@agoric/zoe/src/contractSupport/ratio.js';
+
+/**
+ * Calculate the minimum collateralization given the liquidation margin and the "padding"
+ * from that liquidation threshold.
+ *
+ * @param {Ratio} liquidationMargin
+ * @param {Ratio} liquidationPadding
+ * @returns {Ratio}
+ */
+export const calculateMinimumCollateralization = (
+  liquidationMargin,
+  liquidationPadding,
+) => addRatios(liquidationMargin, liquidationPadding);
 
 /**
  * Calculate the maximum debt allowed based on the price quote and the lesser of
- * the `liquidationMargin` or the `minimumCollateralization`.
+ * the `liquidationMargin` or the `liquidationPadding`.
  *
  * @param {PriceQuote} quoteAmount
  * @param {Ratio} liquidationMargin
+ * @param {Ratio} liquidationPadding
  * @returns {Amount<'nat'>}
  */
-export const maxDebtForVault = (quoteAmount, liquidationMargin) => {
+export const maxDebtForVault = (
+  quoteAmount,
+  liquidationMargin,
+  liquidationPadding,
+) => {
+  const debtByQuote = getAmountOut(quoteAmount);
+  const minimumCollateralization = calculateMinimumCollateralization(
+    liquidationMargin,
+    liquidationPadding,
+  );
   // floorDivide because we want the debt ceiling lower
-  return floorDivideBy(getAmountOut(quoteAmount), liquidationMargin);
+  return floorDivideBy(debtByQuote, minimumCollateralization);
 };

--- a/packages/inter-protocol/src/vaultFactory/math.js
+++ b/packages/inter-protocol/src/vaultFactory/math.js
@@ -56,13 +56,15 @@ export const maxDebtForVault = (
  * so the simple math works.
  *
  * @param {Amount<'nat'>} currentDebt
- * @param {Amount<'nat'>} give
+ * @param {Amount<'nat'>} give excess of currentDebt is returned in 'surplus'
  * @param {Amount<'nat'>} want
  * @param {Ratio} loanFee
  */
 export const calculateLoanCosts = (currentDebt, give, want, loanFee) => {
+  const maxGive = AmountMath.min(currentDebt, give);
+  const surplus = AmountMath.subtract(give, maxGive);
   const fee = ceilMultiplyBy(want, loanFee);
   const toMint = AmountMath.add(want, fee);
-  const newDebt = addSubtract(currentDebt, toMint, give);
-  return { newDebt, toMint, fee };
+  const newDebt = addSubtract(currentDebt, toMint, maxGive);
+  return { newDebt, toMint, fee, surplus };
 };

--- a/packages/inter-protocol/src/vaultFactory/math.js
+++ b/packages/inter-protocol/src/vaultFactory/math.js
@@ -1,0 +1,20 @@
+/**
+ * @file calculations specific to the Vault Factory contract
+ * See also ../interest-math.js
+ */
+
+import { getAmountOut } from '@agoric/zoe/src/contractSupport/priceQuote.js';
+import { floorDivideBy } from '@agoric/zoe/src/contractSupport/ratio.js';
+
+/**
+ * Calculate the maximum debt allowed based on the price quote and the lesser of
+ * the `liquidationMargin` or the `minimumCollateralization`.
+ *
+ * @param {PriceQuote} quoteAmount
+ * @param {Ratio} liquidationMargin
+ * @returns {Amount<'nat'>}
+ */
+export const maxDebtForVault = (quoteAmount, liquidationMargin) => {
+  // floorDivide because we want the debt ceiling lower
+  return floorDivideBy(getAmountOut(quoteAmount), liquidationMargin);
+};

--- a/packages/inter-protocol/src/vaultFactory/types.js
+++ b/packages/inter-protocol/src/vaultFactory/types.js
@@ -35,6 +35,7 @@
  * @property {Ratio} loanFee - The fee (in BasisPoints) charged when opening
  * or increasing a loan.
  * @property {Amount<'nat'>} debtLimit
+ * @property {Ratio} [liquidationPadding] - vault must maintain this in order to remove collateral or add debt
  */
 
 /**

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -513,6 +513,18 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           const { vaultSeat } = state;
           const fp = helper.fullProposal(clientSeat.getProposal());
 
+          if (
+            allEmpty([
+              fp.give.Collateral,
+              fp.give.Minted,
+              fp.want.Collateral,
+              fp.want.Minted,
+            ])
+          ) {
+            clientSeat.exit();
+            return 'no transaction, as requested';
+          }
+
           const normalizedDebtPre = self.getNormalizedDebt();
           const collateralPre = helper.getCollateralAllocated(vaultSeat);
 
@@ -539,17 +551,6 @@ export const prepareVault = (baggage, marshaller, zcf) => {
 
           const debt = self.getCurrentDebt();
           const giveMinted = AmountMath.min(fp.give.Minted, debt);
-          if (
-            allEmpty([
-              fp.give.Collateral,
-              giveMinted,
-              fp.want.Collateral,
-              fp.want.Minted,
-            ])
-          ) {
-            clientSeat.exit();
-            return 'no transaction, as requested';
-          }
 
           // Calculate the fee, the amount to mint and the resulting debt. We'll
           // verify that the target debt doesn't violate the collateralization ratio,

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -234,7 +234,11 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           return AmountMath.makeEmpty(this.facets.helper.debtBrand());
         },
         /**
+         * @typedef {{ give: { Collateral: Amount<'nat'>, Minted: Amount<'nat'> }, want: { Collateral: Amount<'nat'>, Minted: Amount<'nat'> } }} FullProposal
+         */
+        /**
          * @param {ProposalRecord} partial
+         * @returns {FullProposal}
          */
         fullProposal(partial) {
           assertOnlyKeys(partial, ['Collateral', 'Minted']);
@@ -578,6 +582,39 @@ export const prepareVault = (baggage, marshaller, zcf) => {
           ) {
             return helper.adjustBalancesHook(clientSeat);
           }
+
+          return helper.commitBalanceAdjustment(
+            clientSeat,
+            fp,
+            {
+              newDebt,
+              fee,
+              surplus,
+              toMint,
+            },
+            { normalizedDebtPre, collateralPre },
+          );
+        },
+
+        /**
+         *
+         * @param {ZCFSeat} clientSeat
+         * @param {FullProposal} fp
+         * @param {ReturnType<typeof calculateLoanCosts>} costs
+         * @param {object} accounting
+         * @param {NormalizedDebt} accounting.normalizedDebtPre
+         * @param {Amount<'nat'>} accounting.collateralPre
+         * @returns {Promise<string>} success message
+         */
+        async commitBalanceAdjustment(
+          clientSeat,
+          fp,
+          { newDebt, fee, surplus, toMint },
+          { normalizedDebtPre, collateralPre },
+        ) {
+          const { state, facets } = this;
+          const { helper } = facets;
+          const { vaultSeat } = state;
 
           const giveMintedTaken = AmountMath.subtract(fp.give.Minted, surplus);
 

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -545,7 +545,10 @@ export const prepareVault = (baggage, marshaller, zcf) => {
             newDebt,
           });
 
+          const hasWants = !allEmpty([wantColl, wantMinted]);
           if (
+            // Skip allocations check if there are no wants. Always allow pure gives.
+            hasWants &&
             allocationsChangedSinceQuote(
               newCollateralPre,
               maxDebtPre,

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -3,7 +3,7 @@ import '@agoric/zoe/exported.js';
 import { Far } from '@endo/marshal';
 import { prepareVaultHolder } from './vaultHolder.js';
 
-const trace = makeTracer('IV', false);
+const trace = makeTracer('VK', false);
 
 /**
  *

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -41,7 +41,6 @@ import {
   assertProposalShape,
   atomicTransfer,
   ceilDivideBy,
-  floorDivideBy,
   getAmountIn,
   getAmountOut,
   makeRatio,
@@ -53,6 +52,7 @@ import { E } from '@endo/eventual-send';
 import { checkDebtLimit } from '../contractSupport.js';
 import { chargeInterest } from '../interest.js';
 import { liquidate, makeQuote, updateQuote } from './liquidation.js';
+import { maxDebtForVault } from './math.js';
 import { makePrioritizedVaults } from './prioritizedVaults.js';
 import { Phase, prepareVault } from './vault.js';
 
@@ -632,9 +632,8 @@ export const prepareVaultManagerKit = (
             debtBrand,
           );
           trace('maxDebtFor got quote', quoteAmount);
-          // floorDivide because we want the debt ceiling lower
-          return floorDivideBy(
-            getAmountOut(quoteAmount),
+          return maxDebtForVault(
+            quoteAmount,
             factoryPowers.getGovernedParams().getLiquidationMargin(),
           );
         },

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -436,6 +436,7 @@ export const prepareVaultManagerKit = (
           const { facets } = this;
           trace('reschedulePriceCheck', collateralBrand, {
             liquidationQueueing,
+            outstandingQuote: !!outstandingQuote,
           });
           // INTERLOCK: the first time through, start the activity to wait for
           // and process liquidations over time.
@@ -623,18 +624,21 @@ export const prepareVaultManagerKit = (
         },
 
         /**
+         * Consults a price authority to determine the max debt this manager
+         * config will allow for the collateral.
+         *
          * @param {Amount<'nat'>} collateralAmount
          */
         async maxDebtFor(collateralAmount) {
           trace('maxDebtFor', collateralAmount);
           assert(factoryPowers && priceAuthority);
-          const quoteAmount = await E(priceAuthority).quoteGiven(
+          const quote = await E(priceAuthority).quoteGiven(
             collateralAmount,
             debtBrand,
           );
-          trace('maxDebtFor got quote', quoteAmount);
+          trace('maxDebtFor got quote', quote.quoteAmount.value[0]);
           return maxDebtForVault(
-            quoteAmount,
+            quote,
             factoryPowers.getGovernedParams().getLiquidationMargin(),
             factoryPowers.getGovernedParams().getLiquidationPadding(),
           );

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -94,6 +94,7 @@ const trace = makeTracer('VM', false);
  *  getRecordingPeriod: () => RelativeTime,
  *  getDebtLimit: () => Amount<'nat'>,
  *  getInterestRate: () => Ratio,
+ *  getLiquidationPadding: () => Ratio,
  *  getLiquidationMargin: () => Ratio,
  *  getLiquidationPenalty: () => Ratio,
  *  getLoanFee: () => Ratio,
@@ -635,6 +636,7 @@ export const prepareVaultManagerKit = (
           return maxDebtForVault(
             quoteAmount,
             factoryPowers.getGovernedParams().getLiquidationMargin(),
+            factoryPowers.getGovernedParams().getLiquidationPadding(),
           );
         },
         /**

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -214,9 +214,9 @@ const setupAmmAndElectorate = async (t, aethLiquidity, runLiquidity) => {
 /**
  *
  * @param {import('ava').ExecutionContext<DriverContext>} t
- * @param {Amount<'nat'>} runInitialLiquidity
+ * @param {Amount<'nat'>} amt
  */
-const getRunFromFaucet = async (t, runInitialLiquidity) => {
+const getRunFromFaucet = async (t, amt) => {
   const {
     installation: { faucet: installation },
     zoe,
@@ -235,7 +235,7 @@ const getRunFromFaucet = async (t, runInitialLiquidity) => {
     await E(faucetCreator).makeFaucetInvitation(),
     harden({
       give: {},
-      want: { RUN: runInitialLiquidity },
+      want: { RUN: amt },
     }),
   );
 
@@ -552,13 +552,14 @@ export const makeManagerDriver = async (
      * @param {*} newValue
      * @param {VaultFactoryParamPath} [paramPath] defaults to root path for the factory
      */
-    setGovernedParam: async (
+    setGovernedParam: (
       name,
       newValue,
       paramPath = { key: 'governedParams' },
     ) => {
-      const vfGov = await t.context.puppetGovernors.vaultFactory;
-      await E(vfGov).changeParams(
+      trace(t, 'setGovernedParam', name);
+      const vfGov = t.context.puppetGovernors.vaultFactory;
+      return E(vfGov).changeParams(
         harden({
           paramPath,
           changes: { [name]: newValue },

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -54,7 +54,7 @@ const contractRoots = {
 };
 
 /**
- * dL: 1M, lM: 105%, lP: 10%, iR: 100, lF: 500
+ * dL: 1M, lM: 105%, lP: 10%, iR: 100, lF: 500, lP: 0%
  *
  * @param {import('../supports.js').AmountUtils} debt
  */
@@ -69,6 +69,7 @@ const defaultParamValues = debt =>
     interestRate: debt.makeRatio(100n, BASIS_POINTS),
     // charge to create or increase loan balance
     loanFee: debt.makeRatio(500n, BASIS_POINTS),
+    // NB: liquidationPadding defaults to zero in contract
   });
 
 /**
@@ -401,6 +402,52 @@ export const makeManagerDriver = async (
       vault: () => vault,
       vaultSeat: () => vaultSeat,
       notification: () => notification,
+      /**
+       *
+       * @param {bigint} collValue
+       * @param {import('../supports.js').AmountUtils} collUtils
+       * @param {bigint} [mintedValue]
+       */
+      giveCollateral: async (collValue, collUtils, mintedValue = 0n) => {
+        trace(t, 'giveCollateral', collValue);
+        const invitation = await E(vault).makeAdjustBalancesInvitation();
+        const amount = collUtils.make(collValue);
+        const seat = await E(services.zoe).offer(
+          invitation,
+          harden({
+            give: { Collateral: amount },
+            want: mintedValue ? { Minted: run.make(mintedValue) } : undefined,
+          }),
+          harden({
+            Collateral: collUtils.mint.mintPayment(amount),
+          }),
+        );
+        return E(seat).getOfferResult();
+      },
+      /**
+       *
+       * @param {bigint} mintedValue
+       * @param {import('../supports.js').AmountUtils} collUtils
+       * @param {bigint} [collValue]
+       */
+      giveMinted: async (mintedValue, collUtils, collValue = 0n) => {
+        trace(t, 'giveCollateral', mintedValue);
+        const invitation = await E(vault).makeAdjustBalancesInvitation();
+        const mintedAmount = run.make(mintedValue);
+        const seat = await E(services.zoe).offer(
+          invitation,
+          harden({
+            give: { Minted: mintedAmount },
+            want: collValue
+              ? { Collateral: collUtils.make(collValue) }
+              : undefined,
+          }),
+          harden({
+            Minted: getRunFromFaucet(t, mintedAmount),
+          }),
+        );
+        return E(seat).getOfferResult();
+      },
       close: async () => {
         currentSeat = await E(zoe).offer(E(vault).makeCloseInvitation());
         currentOfferResult = await E(currentSeat).getOfferResult();

--- a/packages/inter-protocol/test/vaultFactory/test-math.js
+++ b/packages/inter-protocol/test/vaultFactory/test-math.js
@@ -1,0 +1,40 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { makeIssuerKit } from '@agoric/ertp';
+import { maxDebtForVault } from '../../src/vaultFactory/math.js';
+import { withAmountUtils } from '../supports.js';
+
+const stable = withAmountUtils(makeIssuerKit('Stable'));
+const aeth = withAmountUtils(makeIssuerKit('Aeth'));
+
+/**
+ * Max debt for a fixed collateral of 1_000 aeth
+ *
+ * @param {*} t
+ * @param {readonly [Number, Number]} input
+ * @param {bigint} result
+ */
+function checkMax(t, [pricePerColl, liquidationMarginNum], result) {
+  const costOfCollateral = BigInt(1_000 * pricePerColl);
+
+  /** @type {PriceQuote} */
+  const quote = {
+    // @ts-expect-error cast
+    quoteAmount: { value: [{ amountOut: stable.make(costOfCollateral) }] },
+  };
+
+  // the liquidationMargin term is a ratio so we add 1 to our incoming parameter
+  const liquidationMargin = harden({
+    numerator: stable.make(1_000n + BigInt(liquidationMarginNum * 1_000)),
+    denominator: aeth.make(1_000n),
+  });
+
+  t.is(maxDebtForVault(quote, liquidationMargin).value, result);
+}
+
+test('zero liquidation margin', checkMax, [1.0, 0], 1000n);
+test('5% liquidation margin', checkMax, [1.0, 0.05], 952n);
+test('100% liquidation margin', checkMax, [1.0, 1.0], 500n);
+
+test('-5% liquidation margin', checkMax, [1.0, -0.05], 1052n);

--- a/packages/inter-protocol/test/vaultFactory/test-math.js
+++ b/packages/inter-protocol/test/vaultFactory/test-math.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-lone-blocks */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
@@ -12,10 +13,14 @@ const aeth = withAmountUtils(makeIssuerKit('Aeth'));
  * Max debt for a fixed collateral of 1_000 aeth
  *
  * @param {*} t
- * @param {readonly [Number, Number]} input
+ * @param {readonly [Number, Number, Number]} input
  * @param {bigint} result
  */
-function checkMax(t, [pricePerColl, liquidationMarginNum], result) {
+function checkMax(
+  t,
+  [pricePerColl, liquidationMarginNum, liquidationPaddingNum],
+  result,
+) {
   const costOfCollateral = BigInt(1_000 * pricePerColl);
 
   /** @type {PriceQuote} */
@@ -30,11 +35,33 @@ function checkMax(t, [pricePerColl, liquidationMarginNum], result) {
     denominator: aeth.make(1_000n),
   });
 
-  t.is(maxDebtForVault(quote, liquidationMargin).value, result);
+  const liquidationPadding = harden({
+    numerator: stable.make(BigInt(liquidationPaddingNum * 1_000)),
+    denominator: aeth.make(1_000n),
+  });
+
+  t.is(
+    maxDebtForVault(quote, liquidationMargin, liquidationPadding).value,
+    result,
+  );
 }
 
-test('zero liquidation margin', checkMax, [1.0, 0], 1000n);
-test('5% liquidation margin', checkMax, [1.0, 0.05], 952n);
-test('100% liquidation margin', checkMax, [1.0, 1.0], 500n);
+test('zero liquidation margin', checkMax, [1.0, 0, 0], 1000n);
+test('5% liquidation margin', checkMax, [1.0, 0.05, 0], 952n);
+test('100% liquidation margin', checkMax, [1.0, 1.0, 0], 500n);
 
-test('-5% liquidation margin', checkMax, [1.0, -0.05], 1052n);
+test('zero minimum collateralization', checkMax, [1.0, 0, 0], 1000n);
+test('5% minimum collateralization', checkMax, [1.0, 0, 0.05], 952n);
+test('100% minimum collateralization', checkMax, [1.0, 0, 1.0], 500n);
+
+test('zero both LM and MC', checkMax, [1.0, 0, 0], 1000n);
+test('5% both LM and MC', checkMax, [1.0, 0.05, 0.05], 909n);
+test('100% both LM and MC', checkMax, [1.0, 1.0, 1.0], 333n);
+
+test('neg liquidation margin', checkMax, [1.0, -0.05, 0], 1052n);
+
+test('negative liquidationPadding throws', t => {
+  t.throws(() => checkMax(t, [1.0, -0.05, -0.05], 0n), {
+    message: 'value "[-50n]" must be a natural number',
+  });
+});

--- a/packages/inter-protocol/test/vaultFactory/test-vault-collateralization.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-collateralization.js
@@ -1,6 +1,7 @@
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeTracer } from '@agoric/internal';
+import { E } from '@endo/eventual-send';
 import { makeDriverContext, makeManagerDriver } from './driver.js';
 
 /** @typedef {import('./driver.js').DriverContext & {
@@ -29,5 +30,71 @@ test('excessive loan', async t => {
     {
       message: /Proposed debt.*477n.*exceeds max.*476n.*for.*100n/,
     },
+  );
+});
+
+test('add debt to vault under LiquidationMarging + LiquidationPadding', async t => {
+  const { aeth, run } = t.context;
+  const md = await makeManagerDriver(t);
+
+  // take debt that comes just shy of max
+  const vd = await md.makeVaultDriver(aeth.make(1000n), run.make(4500n));
+  t.deepEqual(await E(vd.vault()).getCurrentDebt(), run.make(4725n));
+
+  const MARGIN_HOP = 20n;
+
+  // we can take a loan and pay it back
+  await vd.giveCollateral(100n, aeth, MARGIN_HOP);
+  await vd.giveMinted(MARGIN_HOP, aeth, 100n);
+
+  // but once we bump LiquidationPadding they are under
+  await md.setGovernedParam('LiquidationPadding', run.makeRatio(20n, 1n), {
+    key: { collateralBrand: aeth.brand },
+  });
+  // ...so we can't take the same loan out
+  await t.throwsAsync(
+    vd.giveCollateral(100n, aeth, MARGIN_HOP),
+    { message: /is more than the collateralization ratio allows/ },
+    'adjustment still under water',
+  );
+
+  await t.notThrowsAsync(
+    vd.giveCollateral(100n, aeth),
+    'giving collateral without any want still succeeds',
+  );
+});
+
+test('add debt to vault under LiquidationMargin', async t => {
+  const { aeth, run } = t.context;
+  const md = await makeManagerDriver(t);
+
+  // TODO revisit after the new liquidation system https://github.com/Agoric/agoric-sdk/issues/5843
+  // XXX make a worst collateralized vault for the head of the liquidation queue.
+  // Without this, the test times out because adjusting a single vault triggers
+  // `onHigherHighest` which calls `reschedulePriceCheck` which fires off a promise
+  // for updating the quote, which never resolves. This isn't a problem in the
+  // MinimumCollateralization test above so I think it's something to do with the assumptions
+  // of the liquidation engine.
+  await md.makeVaultDriver(aeth.make(1000n), run.make(4501n));
+
+  // take debt that comes just shy of max
+  const vd = await md.makeVaultDriver(aeth.make(1000n), run.make(4500n));
+  t.deepEqual(await E(vd.vault()).getCurrentDebt(), run.make(4725n));
+
+  // bump LiquidationMargin so they are under
+  await md.setGovernedParam('LiquidationMargin', run.makeRatio(20n, 1n), {
+    key: { collateralBrand: aeth.brand },
+  });
+
+  await t.throwsAsync(
+    vd.giveCollateral(100n, aeth, 10n),
+    { message: /is more than the collateralization ratio allows/ },
+    'adjustment still under water',
+  );
+
+  t.log('trying to add collateral');
+  await t.notThrowsAsync(
+    vd.giveCollateral(100n, aeth),
+    'giving collateral without any want still succeeds',
   );
 });

--- a/packages/inter-protocol/test/vaultFactory/test-vault-collateralization.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-collateralization.js
@@ -1,0 +1,33 @@
+import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { makeTracer } from '@agoric/internal';
+import { makeDriverContext, makeManagerDriver } from './driver.js';
+
+/** @typedef {import('./driver.js').DriverContext & {
+ * }} Context */
+/** @type {import('ava').TestFn<Context>} */
+const test = unknownTest;
+
+const trace = makeTracer('TestMCR');
+
+test.before(async t => {
+  t.context = await makeDriverContext();
+  trace(t, 'CONTEXT', t.context.rates);
+});
+
+test('excessive loan', async t => {
+  const { aeth, run } = t.context;
+  const md = await makeManagerDriver(t);
+
+  const threshold = 453n;
+  await t.notThrowsAsync(
+    md.makeVaultDriver(aeth.make(100n), run.make(threshold)),
+  );
+
+  await t.throwsAsync(
+    md.makeVaultDriver(aeth.make(100n), run.make(threshold + 1n)),
+    {
+      message: /Proposed debt.*477n.*exceeds max.*476n.*for.*100n/,
+    },
+  );
+});

--- a/packages/inter-protocol/test/vaultFactory/test-vault-collateralization.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-collateralization.js
@@ -9,11 +9,11 @@ import { makeDriverContext, makeManagerDriver } from './driver.js';
 /** @type {import('ava').TestFn<Context>} */
 const test = unknownTest;
 
-const trace = makeTracer('TestMCR');
+const trace = makeTracer('TestVC');
 
 test.before(async t => {
   t.context = await makeDriverContext();
-  trace(t, 'CONTEXT', t.context.rates);
+  trace(t, 'CONTEXT');
 });
 
 test('excessive loan', async t => {

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1548,6 +1548,8 @@ test('transfer vault', async t => {
     adjustInvitation,
     harden({
       give: { Minted: payoffRun2 },
+      // it's only multi-turn if there is a want
+      want: { Collateral: aeth.make(1n) },
     }),
     harden({ Minted: paybackPayment }),
   );

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -102,6 +102,7 @@ const defaultParamValues = debtBrand =>
     interestRate: makeRatio(100n, debtBrand, BASIS_POINTS),
     // charge to create or increase loan balance
     loanFee: makeRatio(500n, debtBrand, BASIS_POINTS),
+    // NB: liquidationPadding defaults to zero in contract
   });
 
 test.before(async t => {

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2163,39 +2163,7 @@ test('close loan', async t => {
   t.deepEqual(await E(aliceVault).getCollateralAmount(), aeth.makeEmpty());
 });
 
-test('excessive loan', async t => {
-  const { zoe, aeth, run } = t.context;
-
-  const services = await setupServices(
-    t,
-    [15n],
-    aeth.make(1n),
-    buildManualTimer(t.log),
-    undefined,
-    500n,
-  );
-  const { lender } = services.vaultFactory;
-
-  // Try to Create a loan for Alice for 5000 Minted with 100 aeth collateral
-  const collateralAmount = aeth.make(100n);
-  const aliceLoanAmount = run.make(5000n);
-  /** @type {UserSeat<VaultKit>} */
-  const aliceLoanSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
-    harden({
-      give: { Collateral: collateralAmount },
-      want: { Minted: aliceLoanAmount },
-    }),
-    harden({
-      Collateral: aeth.mint.mintPayment(collateralAmount),
-    }),
-  );
-  await t.throwsAsync(() => E(aliceLoanSeat).getOfferResult(), {
-    message: /exceeds max/,
-  });
-});
-
-test('loan too small', async t => {
+test('loan too small - MinInitialDebt', async t => {
   const { zoe, aeth, run } = t.context;
   t.context.minInitialDebt = 50_000n;
 
@@ -2236,7 +2204,7 @@ test('loan too small', async t => {
  * Attempts to adjust balances on vaults beyond the debt limit fail.
  * In other words, minting for anything other than charging interest fails.
  */
-test('excessive debt on collateral type', async t => {
+test('excessive debt on collateral type - debtLimit', async t => {
   const { zoe, aeth, run } = t.context;
 
   const services = await setupServices(

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -130,6 +130,10 @@ export async function start(zcf, privateArgs, baggage) {
         getChargingPeriod() {
           return DAY;
         },
+        getLiquidationPadding() {
+          // XXX re-use
+          return LIQUIDATION_MARGIN;
+        },
         getRecordingPeriod() {
           return DAY;
         },


### PR DESCRIPTION
closes: #6519
stacked on https://github.com/Agoric/agoric-sdk/pull/6919

## Description

Adds a `LiquidationPadding` parameter motivated by https://github.com/Agoric/agoric-sdk/issues/6519. However instead of MinimumCollateralization being its own parameter (which could be less than LiquidationMargin), this models a LiquidationPadding that is added to LiquidationMargin.

To ensure users can always add collateral or reduce debt, I short-cut the adjustBalancesHook when there are no wants. An upshot of this is pure-give offers can complete in one turn. Notice the change to the test of transfer during adjustment.

### Security Considerations

~`MinimumCollateralization` is assumed to never have a pathological value. It's managed by the EC which is entrusted by the system.~
^ no longer needed with `LiquidationMargin` param.

### Scaling Considerations

None.

### Documentation Considerations

The new parameter needs to be documented for EC. I think @otoole-brendan is on that.

### Testing Considerations

New CI tests suffice.