### PR TITLE
fix(cosmic-swingset): no actionQueue.consumeAll in hangover recovery

### DIFF
--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -735,14 +735,14 @@ export async function launch({
         blockParams || assert.fail(X`blockParams missing`);
 
         if (!blockNeedsExecution(blockHeight)) {
-          // We are reevaluating, so send exactly the same downcalls to the chain.
+          // We are reevaluating, so do not do any work, and send exactly the
+          // same downcalls to the chain.
           //
           // This is necessary only after a restart when Tendermint is reevaluating the
           // block that was interrupted and not committed.
           //
           // We assert that the return values are identical, which allows us to silently
           // clear the queue.
-          for (const _ of actionQueue.consumeAll());
           try {
             replayChainSends();
           } catch (e) {


### PR DESCRIPTION
closes: #5911

## Description

Consuming the `actionQueue` results in chain sends. When a hangover is detected, we replay all recorded chain sends, but should not touch the `actionQueue` independently.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

I would like to get a test covering this, but for that we'd need to stop the chain exactly after commiting a block containing entries in the actionQueue, stop the chain process, rollback the chain state 1 block, then restart. That coordination is hard to accomplish.
