### PR TITLE
5286 fix heap for getPublicTopics

### DIFF
--- a/packages/inter-protocol/src/price/priceAggregatorChainlink.js
+++ b/packages/inter-protocol/src/price/priceAggregatorChainlink.js
@@ -13,7 +13,7 @@ import {
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import {
   makeOnewayPriceAuthorityKit,
-  makePublicTopicProvider,
+  makeStorageNodePathProvider,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
@@ -141,7 +141,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const latestRoundStorageNode = E(storageNode).makeChildNode('latestRound');
   pipeTopicToStorage(latestRoundSubscriber, latestRoundStorageNode, marshaller);
 
-  const providePublicTopic = makePublicTopicProvider();
+  const memoizedPath = makeStorageNodePathProvider(baggage);
 
   /** @type {MapStore<string, *>} */
   const oracles = makeScalarBigMapStore('oracles', {
@@ -326,16 +326,16 @@ export const start = async (zcf, privateArgs, baggage) => {
     },
     getPublicTopics() {
       return {
-        quotes: providePublicTopic(
-          'Quotes from this price aggregator',
-          quoteSubscriber,
-          storageNode,
-        ),
-        latestRound: providePublicTopic(
-          'Notification of each round',
-          latestRoundSubscriber,
-          latestRoundStorageNode,
-        ),
+        quotes: {
+          description: 'Quotes from this price aggregator',
+          subscriber: quoteSubscriber,
+          storagePath: memoizedPath(storageNode),
+        },
+        latestRound: {
+          description: 'Notification of each round',
+          subscriber: latestRoundSubscriber,
+          storagePath: memoizedPath(latestRoundStorageNode),
+        },
       };
     },
   });

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -3,13 +3,13 @@
  */
 import { AmountShape } from '@agoric/ertp';
 import {
-  SubscriberShape,
-  prepareDurablePublishKit,
   pipeTopicToStorage,
+  prepareDurablePublishKit,
+  SubscriberShape,
   TopicsRecordShape,
 } from '@agoric/notifier';
 import { M, prepareExoClassKit } from '@agoric/vat-data';
-import { makePublicTopicProvider } from '@agoric/zoe/src/contractSupport/durability.js';
+import { makeStorageNodePathProvider } from '@agoric/zoe/src/contractSupport/durability.js';
 import { UnguardedHelperI } from '../typeGuards.js';
 
 const { Fail } = assert;
@@ -39,7 +39,7 @@ const HolderI = M.interface('holder', {
  * @param {ERef<Marshaller>} marshaller
  */
 export const prepareVaultHolder = (baggage, marshaller) => {
-  const providePublicTopic = makePublicTopicProvider();
+  const memoizedPath = makeStorageNodePathProvider(baggage);
 
   const makeVaultHolderPublishKit = prepareDurablePublishKit(
     baggage,
@@ -91,11 +91,11 @@ export const prepareVaultHolder = (baggage, marshaller) => {
         getPublicTopics() {
           const { subscriber, storageNode } = this.state;
           return harden({
-            vault: providePublicTopic(
-              'Vault holder status',
+            vault: {
+              description: 'Vault holder status',
               subscriber,
-              storageNode,
-            ),
+              storagePath: memoizedPath(storageNode),
+            },
           });
         },
         makeAdjustBalancesInvitation() {

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -17,7 +17,7 @@ import {
 import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
 import { M, mustMatch } from '@agoric/store';
 import { makeScalarBigMapStore, prepareExoClassKit } from '@agoric/vat-data';
-import { makePublicTopicProvider } from '@agoric/zoe/src/contractSupport/index.js';
+import { makeStorageNodePathProvider } from '@agoric/zoe/src/contractSupport/durability.js';
 import { E } from '@endo/far';
 import { makeInvitationsHelper } from './invitations.js';
 import { makeOfferExecutor } from './offers.js';
@@ -159,7 +159,7 @@ export const prepareSmartWallet = (baggage, shared) => {
     'Smart Wallet publish kit',
   );
 
-  const providePublicTopic = makePublicTopicProvider();
+  const memoizedPath = makeStorageNodePathProvider(baggage);
 
   /**
    *
@@ -557,16 +557,16 @@ export const prepareSmartWallet = (baggage, shared) => {
             walletStorageNode,
           } = this.state;
           return harden({
-            current: providePublicTopic(
-              'Current state of wallet',
-              currentPublishKit.subscriber,
-              currentStorageNode,
-            ),
-            updates: providePublicTopic(
-              'Changes to wallet',
-              updatePublishKit.subscriber,
-              walletStorageNode,
-            ),
+            current: {
+              description: 'Current state of wallet',
+              subscriber: currentPublishKit.subscriber,
+              storagePath: memoizedPath(currentStorageNode),
+            },
+            updates: {
+              description: 'Changes to wallet',
+              subscriber: updatePublishKit.subscriber,
+              storagePath: memoizedPath(walletStorageNode),
+            },
           });
         },
       },

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -11,6 +11,10 @@ import { Far } from '@endo/marshal';
 /// <reference types="@agoric/notifier/src/types-ambient.js"/>
 
 /**
+ * SCALE: Only for low cardinality provisioning. Every value from init() will
+ * remain in the map for the lifetime of the heap. If a key object is GCed, its
+ * representative also remains.
+ *
  * @template {{}} E Ephemeral state
  * @param {() => E} init
  */

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -1,9 +1,5 @@
-import { SubscriberShape, makePublicTopic } from '@agoric/notifier';
-import { StorageNodeShape } from '@agoric/notifier/src/typeGuards.js';
-import { mustMatch } from '@agoric/store';
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import {
-  M,
   makeScalarBigMapStore,
   provide,
   provideDurableMapStore,
@@ -42,50 +38,6 @@ export const makeEphemeraProvider = init => {
   };
 };
 harden(makeEphemeraProvider);
-
-/**
- *
- */
-export const makePublicTopicProvider = () => {
-  /** @type {WeakMap<Subscriber<any>, import('@agoric/notifier').PublicTopic<any>>} */
-  const extant = new WeakMap();
-
-  /**
-   * Provide a PublicTopic for the specified durable subscriber.
-   * Memoizes the resolution of the promise for the storageNode's path, for the lifetime of the vat.
-   *
-   * @template {object} T
-   * @param {string} description
-   * @param {Subscriber<T>} durableSubscriber primary key
-   * @param {ERef<StorageNode>} storageNode
-   * @returns {import('@agoric/notifier').PublicTopic<T>}
-   */
-  const providePublicTopic = (description, durableSubscriber, storageNode) => {
-    if (extant.has(durableSubscriber)) {
-      // @ts-expect-error cast
-      return extant.get(durableSubscriber);
-    }
-    mustMatch(
-      harden({ description, durableSubscriber, storageNode }),
-      harden({
-        description: M.string(),
-        durableSubscriber: SubscriberShape,
-        storageNode: M.eref(StorageNodeShape),
-      }),
-    );
-
-    /** @type {import('@agoric/notifier').PublicTopic<T>} */
-    const newMeta = makePublicTopic(
-      description,
-      durableSubscriber,
-      storageNode,
-    );
-    extant.set(durableSubscriber, newMeta);
-    return newMeta;
-  };
-  return providePublicTopic;
-};
-harden(makePublicTopicProvider);
 
 /**
  *


### PR DESCRIPTION
refs: #5286

## Description

The `makePublicTopicProvider` in https://github.com/Agoric/agoric-sdk/pull/6902 was a way to prevent repeated remote calls for the same storage path. A problem is that the map, while a WeakMap, kept values forever. This PR documents that caveat for `makeEphemeraProvider` on which `makePublicTopicProvider` was based.

For the storage path memoization functionality, it replaces the provider at the `PublicTopic` level with one at the storagePath level. This one is able to memoize into durable storage the mapping of storageNode to its path. It uses `AsyncProvider` to ensure that just one request is made per StorageNode (within a kind). This is fine because each path should appear in `getPublicTopics` of just one kind.

Related: https://github.com/Agoric/agoric-sdk/issues/6779

### Security Considerations

No new boundaries

### Scaling Considerations

Ensures the heap only grows to as many outstanding requests there are for storage paths.

### Documentation Considerations

No outward change.

### Testing Considerations

CI