### PR TITLE
test inter-protocol with puppet governance

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/assert": "^0.5.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swingset-vat": "^0.30.2",

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -1,4 +1,4 @@
-import { Nat, isNat } from '@agoric/nat';
+import { Nat, isNat } from '@endo/nat';
 
 import '../types-ambient.js';
 

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@agoric/assert": "^0.5.1",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swing-store": "^0.8.1",

--- a/packages/SwingSet/src/devices/command/command.js
+++ b/packages/SwingSet/src/devices/command/command.js
@@ -1,5 +1,5 @@
 import { makePromiseKit } from '@endo/promise-kit';
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 
 import { Fail } from '@agoric/assert';
 

--- a/packages/SwingSet/src/devices/command/device-command.js
+++ b/packages/SwingSet/src/devices/command/device-command.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { Far } from '@endo/marshal';
 
 import { Fail } from '@agoric/assert';

--- a/packages/SwingSet/src/devices/mailbox/device-mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox/device-mailbox.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { Far } from '@endo/marshal';
 
 import { assert, Fail } from '@agoric/assert';

--- a/packages/SwingSet/src/devices/mailbox/mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox/mailbox.js
@@ -64,7 +64,7 @@
 
 */
 
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 
 import { Fail } from '@agoric/assert';
 

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -22,7 +22,7 @@
  * expose only capabilities that don't reveal them.
  */
 
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 import { Far } from '@endo/marshal';
 

--- a/packages/SwingSet/src/devices/timer/timer.js
+++ b/packages/SwingSet/src/devices/timer/timer.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 
 import { Fail } from '@agoric/assert';
 

--- a/packages/SwingSet/src/devices/vat-admin/device-vat-admin.js
+++ b/packages/SwingSet/src/devices/vat-admin/device-vat-admin.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert } from '@agoric/assert';
 import { buildSerializationTools } from '../lib/deviceTools.js';
 import { insistVatID } from '../../lib/id.js';

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1,5 +1,5 @@
 import { assert, Fail } from '@agoric/assert';
-import { isNat } from '@agoric/nat';
+import { isNat } from '@endo/nat';
 import { importBundle } from '@endo/import-bundle';
 import { assertKnownOptions } from '../lib/assertOptions.js';
 import { foreverPolicy } from '../lib/runPolicies.js';

--- a/packages/SwingSet/src/kernel/parseKernelSlots.js
+++ b/packages/SwingSet/src/kernel/parseKernelSlots.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 
 // Object/promise references (in the kernel) contain a two-tuple of (type,

--- a/packages/SwingSet/src/kernel/state/deviceKeeper.js
+++ b/packages/SwingSet/src/kernel/state/deviceKeeper.js
@@ -2,7 +2,7 @@
  * Kernel's keeper of persistent state for a device.
  */
 
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 import { parseKernelSlot } from '../parseKernelSlots.js';
 import { makeVatSlot, parseVatSlot } from '../../lib/parseVatSlots.js';

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error -- https://github.com/Agoric/agoric-sdk/issues/4620 */
-import { Nat, isNat } from '@agoric/nat';
+import { Nat, isNat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 import { initializeVatState, makeVatKeeper } from './vatKeeper.js';
 import { initializeDeviceState, makeDeviceKeeper } from './deviceKeeper.js';

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -1,7 +1,7 @@
 /**
  * Kernel's keeper of persistent state for a vat.
  */
-import { Nat, isNat } from '@agoric/nat';
+import { Nat, isNat } from '@endo/nat';
 import { assert, q, Fail } from '@agoric/assert';
 import { parseKernelSlot } from '../parseKernelSlots.js';
 import { makeVatSlot, parseVatSlot } from '../../lib/parseVatSlots.js';

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop,@jessie.js/no-nested-await */
 import { assert, Fail, quote as q } from '@agoric/assert';
-import { isNat } from '@agoric/nat';
+import { isNat } from '@endo/nat';
 import { makeVatTranslators } from './vatTranslator.js';
 import { insistVatDeliveryResult } from '../lib/message.js';
 

--- a/packages/SwingSet/src/lib/id.js
+++ b/packages/SwingSet/src/lib/id.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 
 import { Fail } from '@agoric/assert';
 

--- a/packages/SwingSet/src/lib/parseVatSlots.js
+++ b/packages/SwingSet/src/lib/parseVatSlots.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 
 // NOTE: confusing terminology: "slot" vs. "reference".  All these things

--- a/packages/SwingSet/src/vats/comms/clist-xgress.js
+++ b/packages/SwingSet/src/vats/comms/clist-xgress.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { insistLocalType } from './parseLocalSlots.js';
 import { makeRemoteSlot } from './parseRemoteSlot.js';
 import { cdebug } from './cdebug.js';

--- a/packages/SwingSet/src/vats/comms/controller.js
+++ b/packages/SwingSet/src/vats/comms/controller.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 import { kser, kunser, kslot, krefOf } from '../../lib/kmarshal.js';
 

--- a/packages/SwingSet/src/vats/comms/parseLocalSlots.js
+++ b/packages/SwingSet/src/vats/comms/parseLocalSlots.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 
 // Local object/promise references (in the comms vat) contain a two-tuple of

--- a/packages/SwingSet/src/vats/comms/parseRemoteSlot.js
+++ b/packages/SwingSet/src/vats/comms/parseRemoteSlot.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 
 // Object/promise references (in remote messages) contain a three-tuple of

--- a/packages/SwingSet/src/vats/comms/remote.js
+++ b/packages/SwingSet/src/vats/comms/remote.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 import { parseLocalSlot, insistLocalType } from './parseLocalSlots.js';
 import {

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 import { insistCapData } from '../../lib/capdata.js';
 import {

--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -3,7 +3,7 @@
 import { E } from '@endo/eventual-send';
 import { Far, passStyleOf } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert } from '@agoric/assert';
 import {
   provideKindHandle,

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -9,7 +9,7 @@ import { makePromiseKit } from '@endo/promise-kit';
 import { makeNotifierKit } from '@agoric/notifier';
 import { Far, passStyleOf } from '@endo/marshal';
 import { E } from '@endo/eventual-send';
-import { Nat, isNat } from '@agoric/nat';
+import { Nat, isNat } from '@endo/nat';
 import {
   provide,
   makeScalarBigMapStore,

--- a/packages/SwingSet/test/timer-device/bootstrap.js
+++ b/packages/SwingSet/test/timer-device/bootstrap.js
@@ -1,5 +1,5 @@
 import { Fail } from '@agoric/assert';
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { Far } from '@endo/marshal';
 
 export function buildRootObject(vatPowers, vatParameters) {

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -35,7 +35,7 @@
     "@agoric/cosmic-proto": "^0.2.1",
     "@agoric/ertp": "^0.15.3",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/smart-wallet": "^0.4.2",
     "@agoric/swingset-vat": "^0.30.2",
     "@agoric/zoe": "^0.25.3",

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -4,7 +4,7 @@ import { createHash } from 'crypto';
 import path from 'path';
 import { createRequire } from 'module';
 
-import { Nat, isNat } from '@agoric/nat';
+import { Nat, isNat } from '@endo/nat';
 import { untilTrue } from '@agoric/internal';
 
 import {

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -26,7 +26,7 @@
     "@agoric/cosmos": "^0.32.2",
     "@agoric/deploy-script-support": "^0.9.4",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swing-store": "^0.8.1",

--- a/packages/cosmic-swingset/src/params.js
+++ b/packages/cosmic-swingset/src/params.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { Fail } from '@agoric/assert';
-import { Nat, isNat } from '@agoric/nat';
+import { Nat, isNat } from '@endo/nat';
 
 export const stringToNat = s => {
   typeof s === 'string' || Fail`${s} must be a string`;

--- a/packages/cosmic-swingset/src/sim-params.js
+++ b/packages/cosmic-swingset/src/sim-params.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 
 const makeStringBeans = (key, beans) => ({ key, beans: `${Nat(beans)}` });
 const makePowerFlagFee = (powerFlag, fee) => ({ powerFlag, fee });

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -38,7 +38,7 @@
     "@agoric/ertp": "^0.15.3",
     "@agoric/import-manager": "^0.3.6",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/zoe": "^0.25.3",

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -34,7 +34,7 @@
     "@agoric/assert": "^0.5.1",
     "@agoric/ertp": "^0.15.3",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swingset-vat": "^0.30.2",

--- a/packages/governance/scripts/build-bundles.js
+++ b/packages/governance/scripts/build-bundles.js
@@ -7,6 +7,10 @@ const dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 const sourceToBundle = [
   ['../src/contractGovernor.js', '../bundles/bundle-contractGovernor.js'],
+  [
+    '../tools/puppetContractGovernor.js',
+    '../bundles/bundle-puppetContractGovernor.js',
+  ],
   ['../src/committee.js', '../bundles/bundle-committee.js'],
   ['../src/noActionElectorate.js', '../bundles/bundle-noActionElectorate.js'],
   ['../src/binaryVoteCounter.js', '../bundles/bundle-binaryVoteCounter.js'],

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -1,7 +1,7 @@
 import { Far, passStyleOf } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { keyEQ, makeScalarMapStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { assertAllDefined } from '@agoric/internal';

--- a/packages/governance/src/types-ambient.js
+++ b/packages/governance/src/types-ambient.js
@@ -438,6 +438,7 @@
 /**
  * @callback UpdateParams
  * @param {Record<string,ParamValue>} paramChanges
+ * @returns {Promise<void>}
  */
 
 /**

--- a/packages/governance/tools/puppetContractGovernor.js
+++ b/packages/governance/tools/puppetContractGovernor.js
@@ -12,7 +12,7 @@ import { CONTRACT_ELECTORATE } from '../src/contractGovernance/governParam.js';
 // It adds the ability for tests to update parameters directly.
 
 /**
- * @template {() => {creatorFacet: GovernorFacet<any>, publicFacet: GovernedPublicFacetMethods} } SF Start function of governed contract
+ * @template {() => {creatorFacet: GovernorFacet<any>, publicFacet: unknown} } SF Start function of governed contract
  * @param {ZCF<{
  *   timer: import('@agoric/time/src/types').TimerService,
  *   governedContractInstallation: Installation<SF>,
@@ -41,6 +41,7 @@ export const start = async (zcf, privateArgs) => {
   const {
     creatorFacet: governedCF,
     instance: governedInstance,
+    /** @type {ReturnType<SF>['publicFacet']} */
     publicFacet: governedPF,
     adminFacet,
   } = await E(zoe).startInstance(
@@ -77,9 +78,11 @@ export const start = async (zcf, privateArgs) => {
     changeParams,
     invokeAPI,
     setFilters,
+    /** @returns {Awaited<ReturnType<SF>>['creatorFcet']} */
     getCreatorFacet: () => limitedCreatorFacet,
     getAdminFacet: () => adminFacet,
     getInstance: () => governedInstance,
+    /** @returns {Awaited<ReturnType<SF>>['publicFacet']} */
     getPublicFacet: () => governedPF,
   });
 
@@ -90,3 +93,7 @@ export const start = async (zcf, privateArgs) => {
   return { creatorFacet, publicFacet };
 };
 harden(start);
+/**
+ * @template {() => {creatorFacet: GovernorFacet<any>, publicFacet: unknown} } SF Start function of governed contract
+ * @typedef {Awaited<ReturnType<typeof start<SF>>>} PuppetContractGovernorKit<SF>
+ */

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -33,7 +33,7 @@
     "@agoric/ertp": "^0.15.3",
     "@agoric/governance": "^0.9.1",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swingset-liveslots": "^0.9.0",

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -1,6 +1,6 @@
 import { Fail, q } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
-import { isNat, Nat } from '@agoric/nat';
+import { isNat, Nat } from '@endo/nat';
 import { TimeMath } from '@agoric/time';
 import {
   defineDurableExoClassKit,

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -78,7 +78,7 @@ const MILLI = 1_000_000n;
  *   vaultFactoryKit: {
  *     publicFacet: VaultFactoryPublicFacet,
  *     creatorFacet: VaultFactoryCreatorFacet,
- *     governorCreatorFacet: GovernedContractFacetAccess<{},{}>,
+ *     governorCreatorFacet: GovernedContractFacetAccess<VaultFactoryPublicFacet, VaultFactoryCreatorFacet>,
  *     adminFacet: AdminFacet,
  *   },
  *   minInitialDebt: NatValue,

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -217,6 +217,7 @@ const start = async (zcf, privateArgs, baggage) => {
   /**
    * @param {MethodContext} context
    * @param {Brand<'nat'>} ammSecondaryBrand
+   * @returns {Promise<void>}
    */
   const addIssuerFromAmm = async (context, ammSecondaryBrand) => {
     assert(

--- a/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/addPool.js
@@ -16,7 +16,7 @@ const DISPLAY_INFO = harden({ decimalPlaces: 6 });
 /**
  * @param {ZCF} zcf
  * @param {(Brand) => boolean} isInSecondaries
- * @param {import('@agoric/store/src/stores/store-utils.js').AtomicProvider<Brand, ZCFMint>} brandToLiquidityMintProvider
+ * @param {import('@agoric/store/src/stores/store-utils.js').AtomicProvider<Brand<'nat'>, ZCFMint<'nat'>>} brandToLiquidityMintProvider
  * @param {() => (secondaryBrand: Brand<'nat'>) => Promise<void>} getAddIssuerToReserve
  */
 export const makeAddIssuer = (
@@ -30,7 +30,7 @@ export const makeAddIssuer = (
    * we'll return the issuer or a promise for it.
    *
    * @param {import('./pool.js').MethodContext} _context
-   * @param {Issuer} secondaryIssuer
+   * @param {Issuer<'nat'>} secondaryIssuer
    * @param {string} keyword
    */
   const addIssuer = async (_context, secondaryIssuer, keyword) => {
@@ -42,7 +42,7 @@ export const makeAddIssuer = (
     secondaryAssetKind === AssetKind.NAT ||
       Fail`${q(keyword)} asset not fungible (must use NAT math)`;
 
-    /** @type {(brand: Brand) => Promise<ZCFMint>} */
+    /** @type {(brand: Brand<'nat'>) => Promise<ZCFMint<'nat'>>} */
     const makeLiquidityMint = brand => {
       !isInSecondaries(brand) ||
         Fail`issuer ${secondaryIssuer} already has a pool`;

--- a/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -204,7 +204,7 @@ const start = async (zcf, privateArgs, baggage) => {
   const isSecondary = secondaryBrandToPool.has;
 
   // The liquidityBrand has to exist to allow the addPool Offer to specify want
-  /** @type {WeakMapStore<Brand,ZCFMint<'nat'>>} */
+  /** @type {WeakMapStore<Brand<'nat'>, ZCFMint<'nat'>>} */
   const secondaryBrandToLiquidityMint = provideDurableWeakMapStore(
     baggage,
     'secondaryBrandToLiquidityMint',
@@ -292,7 +292,7 @@ const start = async (zcf, privateArgs, baggage) => {
 
   /**
    * @param {MethodContext} _context
-   * @param {Brand} brand
+   * @param {Brand<'nat'>} brand
    */
   const getLiquidityIssuer = (_context, brand) =>
     secondaryBrandToLiquidityMint.get(brand).getIssuerRecord().issuer;
@@ -305,7 +305,7 @@ const start = async (zcf, privateArgs, baggage) => {
 
   /**
    * @param {MethodContext} _context
-   * @param {Brand} brand
+   * @param {Brand<'nat'>} brand
    */
   const getSecondaryIssuer = (_context, brand) => {
     assert(
@@ -359,6 +359,10 @@ const start = async (zcf, privateArgs, baggage) => {
   const getPoolAllocation = (_context, brand) =>
     getPool(brand).getPoolSeat().getCurrentAllocation();
 
+  /**
+   * @param {*} _context xxx
+   * @param {Brand} brand
+   */
   const getPriceAuthorities = (_context, brand) => {
     const pool = getPool(brand);
     return {
@@ -398,11 +402,21 @@ const start = async (zcf, privateArgs, baggage) => {
     return pool.getVPool();
   };
 
+  /**
+   * @param {*} _context xxx
+   * @param {Amount<'nat'>} amountIn
+   * @param {Amount<'nat'>} amountOut
+   */
   const getInputPrice = (_context, amountIn, amountOut) => {
     const pool = provideVPool(amountIn.brand, amountOut.brand);
     return publicPrices(pool.getPriceForInput(amountIn, amountOut));
   };
 
+  /**
+   * @param {*} _context xxx
+   * @param {Amount<'nat'>} amountIn
+   * @param {Amount<'nat'>} amountOut
+   */
   const getOutputPrice = (_context, amountIn, amountOut) => {
     const pool = provideVPool(amountIn.brand, amountOut.brand);
     return publicPrices(pool.getPriceForOutput(amountIn, amountOut));

--- a/packages/inter-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/types.js
@@ -128,7 +128,7 @@
  * using makeSwapOutInvitation at the current price
  * @property {(brand: Brand) => Record<string, Amount<'nat'>>} getPoolAllocation get an
  * AmountKeywordRecord showing the current balances in the pool for brand.
- * @property {() => Issuer<'nat'>} getQuoteIssuer - get the Issuer that attests to
+ * @property {() => Issuer<'set'>} getQuoteIssuer - get the Issuer that attests to
  * the prices in the priceQuotes issued by the PriceAuthorities
  * @property {(brand: Brand) => {toCentral: PriceAuthority, fromCentral: PriceAuthority}} getPriceAuthorities
  * get a pair of PriceAuthorities { toCentral, fromCentral } for requesting
@@ -139,7 +139,7 @@
  * @property {(brand: Brand) => StoredSubscription<PoolMetricsNotification>} getPoolMetrics
  * @property {() => bigint} getProtocolFee
  * @property {() => bigint} getPoolFee
- * @property {() => bigint} getMinInitialPoolLiquidity
+ * @property {() => Amount<'nat'>} getMinInitialPoolLiquidity
  */
 
 /**

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/setup.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/setup.js
@@ -19,7 +19,7 @@ import {
 } from '../../../src/proposals/econ-behaviors.js';
 import { startEconomicCommittee } from '../../../src/proposals/startEconCommittee.js';
 import {
-  installGovernance,
+  installPuppetGovernance,
   makeMockChainStorageRoot,
   provideBundle,
 } from '../../supports.js';
@@ -76,7 +76,7 @@ export const setupAMMBootstrap = async (
   produce.agoricNames.resolve(agoricNames);
   produce.agoricNamesAdmin.resolve(agoricNamesAdmin);
 
-  installGovernance(zoe, spaces.installation.produce);
+  installPuppetGovernance(zoe, spaces.installation.produce);
   produce.chainStorage.resolve(makeMockChainStorageRoot());
   produce.board.resolve(makeBoard());
 
@@ -137,6 +137,8 @@ export const setupAmmServices = async (
     counter: installation.consume.binaryVoteCounter,
   });
 
+  /** @type {Promise<import('@agoric/governance/tools/puppetContractGovernor.js').PuppetContractGovernorKit<import('../../../src/vpool-xyk-amm/multipoolMarketMaker.js').start>['creatorFacet']>} */
+  // @ts-expect-error cast for testing env
   const governorCreatorFacet = E.get(consume.ammKit).governorCreatorFacet;
   const governorInstance = await instance.consume.ammGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
@@ -147,7 +149,6 @@ export const setupAmmServices = async (
   };
   const governedInstance = E(governorPublicFacet).getGovernedContract();
 
-  /** @type { GovernedPublicFacet<XYKAMMPublicFacet> } */
   const ammPublicFacet = await E(governorCreatorFacet).getPublicFacet();
   const amm = {
     ammCreatorFacet: await E.get(consume.ammKit).creatorFacet,

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -640,6 +640,7 @@ test('amm jig - swapOut uneven', async t => {
   simoleanPurse.deposit(simoleanKit.mint.mintPayment(simoleans(20000000n)));
 
   /** @type {XYKAMMPublicFacet} */
+  // @ts-expect-error xxx 'amount' param can't type the brand
   const publicFacet = amm.ammPublicFacet;
   const creatorFacet = amm.ammCreatorFacet;
 

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -106,6 +106,8 @@ export const setupReserveServices = async (
   const feeMintAccess = await feeMintAccessP;
   produce.feeMintAccess.resolve(await feeMintAccess);
 
+  /** @type {Promise<import('@agoric/governance/tools/puppetContractGovernor.js').PuppetContractGovernorKit<import('../../src/reserve/assetReserve.js').start>['creatorFacet']>} */
+  // @ts-expect-error cast for testing env
   const governorCreatorFacet = E.get(consume.reserveKit).governorCreatorFacet;
   const governorInstance = await instance.consume.reserveGovernor;
   const governorPublicFacet = await E(zoe).getPublicFacet(governorInstance);
@@ -116,10 +118,8 @@ export const setupReserveServices = async (
   };
   const governedInstance = E(governorPublicFacet).getGovernedContract();
 
-  /** @type { AssetReservePublicFacet } */
   const reservePublicFacet = await E(governorCreatorFacet).getPublicFacet();
 
-  /** @type {ReserveKit} */
   const reserve = {
     reserveCreatorFacet: await E.get(consume.reserveKit).creatorFacet,
     reservePublicFacet,

--- a/packages/inter-protocol/test/reserve/test-reserve.js
+++ b/packages/inter-protocol/test/reserve/test-reserve.js
@@ -6,7 +6,6 @@ import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js'
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
-import { TimeMath } from '@agoric/time';
 
 import { setupReserveServices } from './setup.js';
 import { reserveInitialState, subscriptionTracker } from '../metrics.js';
@@ -190,26 +189,11 @@ test('governance add Liquidity to the AMM', async t => {
     `added moola to the collateral Reserve`,
   );
 
-  const [voterInvitation] = await E(
-    space.consume.economicCommitteeCreatorFacet,
-  ).getVoterInvitations();
-
-  const { voter } = await E(E(zoe).offer(voterInvitation)).getOfferResult();
-
   const params = harden([moola(90_000n), AmountMath.make(runBrand, 80_000n)]);
-  const { details: detailsP } = await E(
-    governor.governorCreatorFacet,
-  ).voteOnApiInvocation(
+  await E(governor.governorCreatorFacet).invokeAPI(
     'addLiquidityToAmmPool',
     params,
-    await space.installation.consume.binaryVoteCounter,
-    TimeMath.addAbsRel(timer.getCurrentTimestamp(), 2n),
   );
-  const details = await detailsP;
-
-  await E(voter).castBallotFor(details.questionHandle, [details.positions[0]]);
-  await timer.tick();
-  await timer.tick();
   await eventLoopIteration();
 
   t.deepEqual(
@@ -276,30 +260,11 @@ test('request more collateral than available', async t => {
     `added moola to the collateral Reserve`,
   );
 
-  const [voterInvitation] = await E(
-    space.consume.economicCommitteeCreatorFacet,
-  ).getVoterInvitations();
-
-  const { voter } = await E(E(zoe).offer(voterInvitation)).getOfferResult();
-
   const params = harden([moola(90_000n), AmountMath.make(runBrand, 80_000n)]);
-  const { details: detailsP, outcomeOfUpdate } = await E(
-    governor.governorCreatorFacet,
-  ).voteOnApiInvocation(
-    'addLiquidityToAmmPool',
-    params,
-    await space.installation.consume.binaryVoteCounter,
-    TimeMath.addAbsRel(timer.getCurrentTimestamp(), 2n),
+  await t.throwsAsync(
+    E(governor.governorCreatorFacet).invokeAPI('addLiquidityToAmmPool', params),
+    { message: 'insufficient reserves for that transaction' },
   );
-  const details = await detailsP;
-
-  await E(voter).castBallotFor(details.questionHandle, [details.positions[0]]);
-  await timer.tick();
-  await timer.tick();
-
-  await outcomeOfUpdate
-    .then(() => t.fail('expecting failure'))
-    .catch(e => t.is(e.message, 'insufficient reserves for that transaction'));
 
   const { ammPublicFacet } = space.amm;
   const moolaLiquidityIssuer = E(ammPublicFacet).getLiquidityIssuer(
@@ -425,25 +390,11 @@ test('reserve burn IST', async t => {
     'expecting more',
   );
 
-  const [voterInvitation] = await E(
-    space.consume.economicCommitteeCreatorFacet,
-  ).getVoterInvitations();
-
-  const { voter } = await E(E(zoe).offer(voterInvitation)).getOfferResult();
-
   const params = harden([oneKRun]);
-  const { details: detailsP } = await E(
-    governor.governorCreatorFacet,
-  ).voteOnApiInvocation(
+  await E(governor.governorCreatorFacet).invokeAPI(
     'burnFeesToReduceShortfall',
     params,
-    await space.installation.consume.binaryVoteCounter,
-    TimeMath.addAbsRel(timer.getCurrentTimestamp(), 2n),
   );
-  const details = await detailsP;
-  await E(voter).castBallotFor(details.questionHandle, [details.positions[0]]);
-  await timer.tick();
-  await timer.tick();
 
   await m.assertChange({
     allocations: { Fee: AmountMath.makeEmpty(runBrand) },

--- a/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
+++ b/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
@@ -755,6 +755,7 @@ const makeWorld = async t => {
         makeRatio(n, runBrand, d, brand2);
       const newValue = pairToRatio(newRunToBld, bldBrand);
 
+      // TODO use the puppet governor like vaultFactory driver.js does
       const deadline = 3n * SECONDS_PER_DAY;
       const { cast, outcome } = await E(committee).changeParam(
         harden({

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -2,6 +2,7 @@ import { AmountMath } from '@agoric/ertp';
 import binaryVoteCounterBundle from '@agoric/governance/bundles/bundle-binaryVoteCounter.js';
 import committeeBundle from '@agoric/governance/bundles/bundle-committee.js';
 import contractGovernorBundle from '@agoric/governance/bundles/bundle-contractGovernor.js';
+import puppetContractGovernorBundle from '@agoric/governance/bundles/bundle-puppetContractGovernor.js';
 import * as utils from '@agoric/vats/src/core/utils.js';
 import {
   makeAgoricNamesAccess,
@@ -98,6 +99,21 @@ export const setupBootstrap = (t, optTimer) => {
 export const installGovernance = (zoe, produce) => {
   produce.committee.resolve(E(zoe).install(committeeBundle));
   produce.contractGovernor.resolve(E(zoe).install(contractGovernorBundle));
+  produce.binaryVoteCounter.resolve(E(zoe).install(binaryVoteCounterBundle));
+};
+
+/**
+ * Install governance contracts, with a "puppet" governor for use in tests.
+ *
+ * @param {ERef<ZoeService>} zoe
+ * @param {Space['installation']['produce']} produce
+ */
+export const installPuppetGovernance = (zoe, produce) => {
+  produce.committee.resolve(E(zoe).install(committeeBundle));
+  produce.contractGovernor.resolve(
+    E(zoe).install(puppetContractGovernorBundle),
+  );
+  // ignored by puppetContractGovernor but expected by something
   produce.binaryVoteCounter.resolve(E(zoe).install(binaryVoteCounterBundle));
 };
 

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -118,6 +118,8 @@ export const installPuppetGovernance = (zoe, produce) => {
 };
 
 /**
+ * @deprecated use the puppet governor
+ *
  * Economic Committee of one.
  *
  * @param {ERef<ZoeService>} zoe

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -307,10 +307,7 @@ const setupServices = async (
   const governorCreatorFacet = E.get(
     consume.vaultFactoryKit,
   ).governorCreatorFacet;
-  /** @type {Promise<VaultFactoryCreatorFacet & LimitedCreatorFacet<any>>} */
-  const vaultFactoryCreatorFacet = /** @type { any } */ (
-    E(governorCreatorFacet).getCreatorFacet()
-  );
+  const vaultFactoryCreatorFacet = E(governorCreatorFacet).getCreatorFacet();
 
   // Add a vault that will lend on aeth collateral
   const aethVaultManagerP = E(vaultFactoryCreatorFacet).addVaultType(
@@ -320,7 +317,6 @@ const setupServices = async (
   );
 
   /** @type {[any, VaultFactoryCreatorFacet, VFC['publicFacet'], VaultManager]} */
-  // @ts-expect-error cast
   const [governorInstance, vaultFactory, lender, aethVaultManager] =
     await Promise.all([
       E(consume.agoricNames).lookup('instance', 'VaultFactoryGovernor'),

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -499,11 +499,21 @@ export const makeManagerDriver = async (
     },
     /** @param {Amount<'nat'>} p */
     setPrice: p => priceAuthority.setPrice(makeRatioFromAmounts(p, priceBase)),
-    setGovernedParam: async (name, newValue) => {
+    /**
+     *
+     * @param {string} name
+     * @param {*} newValue
+     * @param {VaultFactoryParamPath} [paramPath] defaults to root path for the factory
+     */
+    setGovernedParam: async (
+      name,
+      newValue,
+      paramPath = { key: 'governedParams' },
+    ) => {
       const vfGov = await t.context.puppetGovernors.vaultFactory;
       await E(vfGov).changeParams(
         harden({
-          paramPath: { key: 'governedParams' },
+          paramPath,
           changes: { [name]: newValue },
         }),
       );

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -1,9 +1,9 @@
 import '@agoric/zoe/exported.js';
 
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
+import { makeTracer, objectMap } from '@agoric/internal';
 import { makeNotifierFromSubscriber } from '@agoric/notifier';
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
-import { makeTracer, objectMap } from '@agoric/internal';
 import {
   ceilMultiplyBy,
   makeRatioFromAmounts,
@@ -22,7 +22,7 @@ import {
 import { startEconomicCommittee } from '../../src/proposals/startEconCommittee.js';
 import '../../src/vaultFactory/types.js';
 import {
-  installGovernance,
+  installPuppetGovernance,
   makeVoterTool,
   setupBootstrap,
   setUpZoeForTest,
@@ -151,7 +151,7 @@ const setupAmmAndElectorate = async (t, aethLiquidity, runLiquidity) => {
 
   const space = setupBootstrap(t, timer);
   const { consume, instance } = space;
-  installGovernance(zoe, space.installation.produce);
+  installPuppetGovernance(zoe, space.installation.produce);
   // TODO consider using produceInstallations()
   space.installation.produce.amm.resolve(t.context.installation.amm);
   space.installation.produce.reserve.resolve(t.context.installation.reserve);

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -42,7 +42,7 @@ import {
   vaultManagerMetricsTracker,
 } from '../metrics.js';
 import {
-  installGovernance,
+  installPuppetGovernance,
   produceInstallations,
   setupBootstrap,
   setUpZoeForTest,
@@ -167,7 +167,7 @@ const setupAmmAndElectorateAndReserve = async (
 
   const space = setupBootstrap(t, timer);
   const { consume, instance } = space;
-  installGovernance(zoe, space.installation.produce);
+  installPuppetGovernance(zoe, space.installation.produce);
   produceInstallations(space, t.context.installation);
 
   await startEconomicCommittee(space, electorateTerms);

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@agoric/assert": "^0.5.1",
     "@agoric/ertp": "^0.15.3",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swingset-vat": "^0.30.2",

--- a/packages/pegasus/src/ics20.js
+++ b/packages/pegasus/src/ics20.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { Far } from '@endo/far';
 import { assert, details as X, Fail } from '@agoric/assert';
 
@@ -82,7 +82,6 @@ export const makeICS20TransferPacket = async ({
   depositAddress,
 }) => {
   // We're using Nat as a dynamic check for overflow.
-  // @ts-expect-error - this causes errors on some versions of TS, but not others.
   const stringValue = String(Nat(value));
 
   // Generate the ics20-1 packet.

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -25,7 +25,7 @@
     "@agoric/casting": "^0.3.2",
     "@agoric/ertp": "^0.15.3",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swingset-vat": "^0.30.2",

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@agoric/assert": "^0.5.1",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/store": "^0.8.3",
     "@agoric/vat-data": "^0.4.3",
     "@endo/eventual-send": "^0.16.8",

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -5,7 +5,7 @@ import {
   makeMarshal,
 } from '@endo/marshal';
 import { assert, details as X, Fail } from '@agoric/assert';
-import { isNat } from '@agoric/nat';
+import { isNat } from '@endo/nat';
 import { isPromise } from '@endo/promise-kit';
 import { E, HandledPromise } from '@endo/eventual-send';
 import { insistVatType, makeVatSlot, parseVatSlot } from './parseVatSlots.js';

--- a/packages/swingset-liveslots/src/parseVatSlots.js
+++ b/packages/swingset-liveslots/src/parseVatSlots.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
 
 // NOTE: confusing terminology: "slot" vs. "reference".  All these things

--- a/packages/swingset-liveslots/src/virtualReferences.js
+++ b/packages/swingset-liveslots/src/virtualReferences.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define, jsdoc/require-returns-type */
 
 import { assert, Fail } from '@agoric/assert';
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { parseVatSlot } from './parseVatSlots.js';
 import {
   enumerateKeysWithPrefix,

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@agoric/assert": "^0.5.1",
     "@agoric/ertp": "^0.15.3",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/stat-logger": "^0.4.27",
     "@agoric/store": "^0.8.3",
     "@agoric/swing-store": "^0.8.1",

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/assert": "^0.5.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/store": "^0.8.3"
   },
   "devDependencies": {

--- a/packages/time/src/timeMath.js
+++ b/packages/time/src/timeMath.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { mustMatch } from '@agoric/store';
 
 import { RelativeTimeShape, TimestampShape } from './typeGuards.js';

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@agoric/assert": "^0.5.1",
     "@agoric/ertp": "^0.15.3",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@endo/eventual-send": "^0.16.8",
     "@endo/init": "^0.5.52",
     "clsx": "^1.1.1"

--- a/packages/ui-components/src/display/natValue/parseAsNat.js
+++ b/packages/ui-components/src/display/natValue/parseAsNat.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert, details } from '@agoric/assert';
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import '@agoric/ertp/exported.js';
 
 import { captureNum } from './helpers/captureNum.js';

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -32,7 +32,7 @@
     "@agoric/governance": "^0.9.1",
     "@agoric/inter-protocol": "^0.13.1",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/sharing-service": "^0.2.6",
     "@agoric/store": "^0.8.3",

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { makeScalarMapStore } from '@agoric/store';
 import { provideLazy } from '@agoric/store/src/stores/store-utils.js';
 import { E, Far } from '@endo/far';

--- a/packages/vats/src/repl.js
+++ b/packages/vats/src/repl.js
@@ -3,7 +3,7 @@ import { isPromise } from '@endo/promise-kit';
 import { E, Far } from '@endo/far';
 import * as farExports from '@endo/far';
 
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 
 const UNJSONABLES = new Map([
   [NaN, 'NaN'],

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -25,7 +25,7 @@
     "@agoric/ertp": "^0.15.3",
     "@agoric/inter-protocol": "^0.13.1",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/smart-wallet": "^0.4.2",
     "@agoric/store": "^0.8.3",

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -24,7 +24,7 @@ import { AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 
 import { makeMarshal, passStyleOf, Far, mapIterable } from '@endo/marshal';
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import {
   makeNotifierFromSubscriber,
   makeNotifierKit,

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -46,7 +46,7 @@
     "@agoric/assert": "^0.5.1",
     "@agoric/ertp": "^0.15.3",
     "@agoric/internal": "^0.2.1",
-    "@agoric/nat": "^4.1.0",
+    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swingset-vat": "^0.30.2",

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { natSafeMath } from './safeMath.js';
 
 const { subtract, add, multiply, floorDivide } = natSafeMath;

--- a/packages/zoe/src/contractSupport/priceQuote.js
+++ b/packages/zoe/src/contractSupport/priceQuote.js
@@ -1,5 +1,5 @@
 import { AmountMath } from '@agoric/ertp';
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { E } from '@endo/eventual-send';
 
 // PriceAuthorities return quotes as a pair of an amount and a payment, both

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -2,7 +2,7 @@ import './types.js';
 import { assert, details as X, q, Fail } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 import { assertRecord } from '@endo/marshal';
-import { isNat } from '@agoric/nat';
+import { isNat } from '@endo/nat';
 
 import { natSafeMath } from './safeMath.js';
 

--- a/packages/zoe/src/contractSupport/safeMath.js
+++ b/packages/zoe/src/contractSupport/safeMath.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 
 /** @typedef {(x: number | bigint, y: number | bigint) => NatValue} NatOp */
 

--- a/packages/zoe/src/contracts/loan/index.js
+++ b/packages/zoe/src/contracts/loan/index.js
@@ -1,4 +1,4 @@
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 
 import {
   assertIssuerKeywords,

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -1,5 +1,5 @@
 import { Far } from '@endo/marshal';
-import { Nat } from '@agoric/nat';
+import { Nat } from '@endo/nat';
 import { AmountMath } from '@agoric/ertp';
 import {
   makeNotifierKit,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,11 +11,6 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@agoric/nat@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-4.1.0.tgz#102794e033ffc183a20b0f86031a2e76d204b9f6"
-  integrity sha512-2oMoh3DMn0Fx8HChPPiH8irBNdT/33ttxAZJohhd3nU3gyBRQ1u+eEoOQWfSkrE6M02iMkQM7GE9MzGmjQ6bHg==
-
 "@agoric/wallet-ui@0.1.3-solo.0":
   version "0.1.3-solo.0"
   resolved "https://registry.yarnpkg.com/@agoric/wallet-ui/-/wallet-ui-0.1.3-solo.0.tgz#5f05c3dd2820d4f1efcbccbd2dc1292847ecbd2b"
@@ -1376,10 +1371,10 @@
     "@endo/nat" "^4.1.23"
     "@endo/promise-kit" "^0.2.52"
 
-"@endo/nat@^4.1.23":
-  version "4.1.23"
-  resolved "https://registry.yarnpkg.com/@endo/nat/-/nat-4.1.23.tgz#ce8c9e1def409f44a5a9a85962942338e2c9e2e9"
-  integrity sha512-n7cOUJt1neJLswQpKd9Mv3k7xaKT43fAfDDE+WT0dalUmBvevkUi+plkS9X3jyrDebtW/lN/kYdfS3bdObVn2A==
+"@endo/nat@^4.1.0", "@endo/nat@^4.1.23":
+  version "4.1.24"
+  resolved "https://registry.yarnpkg.com/@endo/nat/-/nat-4.1.24.tgz#5c20ae97e0ccf4b292ae90f176f6a7bc66f95c9c"
+  integrity sha512-NYjwmZF4ScGmFl/oB7D3SDyRT7ZJ9BhRLf1VtUQmgNztNRl97tYSl6eLQIRwtTweluqhd5Ti11WKZkNhRFecBg==
 
 "@endo/netstring@^0.3.22":
   version "0.3.22"


### PR DESCRIPTION
Pulled out of https://github.com/Agoric/agoric-sdk/pull/6910

## Description

Tests of Inter Protocol that rely on governance changes do voting but they should be able to assume that @agoric/governance works as described. Since they were written we've added the `puppetContractGovernor`.

This PR adopts that for all tests that weren't specifically integrating with voting mechanisms. For example of the latter, it leaves alone `test/psm/test-governedPsm.js` that covers electorate changes. Arguably this should be moved to a path that denotes integration with another package the way `test/smartWallet` covers integration of inter-protocol and smart-wallet packages.

It also fixes a bunch of TS types I ran into along the way.

### Security Considerations

--
### Scaling Considerations

--

### Documentation Considerations

--

### Testing Considerations

CI