### PR TITLE
test(liveslots): call startVat properly in liveslots-helpers.js

### DIFF
--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -1634,9 +1634,6 @@ function build(
   // we return 'possiblyDeadSet' for unit tests
   return harden({
     dispatch,
-    startVat,
-    vatGlobals,
-    inescapableGlobalProperties,
     m,
     possiblyDeadSet,
     testHooks,
@@ -1655,7 +1652,7 @@ function build(
  * @param {Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>} [liveSlotsConsole]
  * @param {*} [buildVatNamespace]
  *
- * @returns {*} { vatGlobals, inescapableGlobalProperties, dispatch }
+ * @returns {*} { dispatch }
  *
  * setBuildRootObject should be called, once, with a function that will
  * create a root object for the new vat The caller provided buildRootObject
@@ -1697,10 +1694,9 @@ export function makeLiveSlots(
     liveSlotsConsole,
     buildVatNamespace,
   );
-  const { dispatch, startVat, possiblyDeadSet, testHooks } = r; // omit 'm'
+  const { dispatch, possiblyDeadSet, testHooks } = r; // omit 'm'
   return harden({
     dispatch,
-    startVat,
     possiblyDeadSet,
     testHooks,
   });

--- a/packages/swingset-liveslots/test/liveslots-helpers.js
+++ b/packages/swingset-liveslots/test/liveslots-helpers.js
@@ -138,7 +138,7 @@ export async function makeDispatch(
     gcAndFinalize: makeGcAndFinalize(engineGC),
     meterControl: makeDummyMeterControl(),
   });
-  const { dispatch, startVat, testHooks } = makeLiveSlots(
+  const { dispatch, testHooks } = makeLiveSlots(
     syscall,
     vatID,
     {},
@@ -149,7 +149,7 @@ export async function makeDispatch(
       return { buildRootObject: build };
     },
   );
-  await startVat(kser());
+  await dispatch(['startVat', kser()]);
   if (returnTestHooks) {
     returnTestHooks[0] = testHooks;
   }

--- a/packages/swingset-liveslots/test/storeGC/test-refcount-management.js
+++ b/packages/swingset-liveslots/test/storeGC/test-refcount-management.js
@@ -32,18 +32,14 @@ test.serial('store refcount management 1', async t => {
   );
   const { fakestore } = v;
 
-  // TODO: once makeDispatch() delivers startVat properly, switch to this
-  // const [ mainID, mainVref ] = deduceCollectionID(fakestore, 'scalarMapStore', 1)
-  // t.is(fakestore.get(`vc.${mainID}.|entryCount`), '1');
-  // t.is(fakestore.get(`vc.${mainID}.sfoo`), vstr(null));
+  // `mainHolder` is created during startup
+  const [ mainID ] = deduceCollectionID(fakestore, 'scalarMapStore', 1)
+  t.is(fakestore.get(`vc.${mainID}.|entryCount`), '1');
+  t.is(fakestore.get(`vc.${mainID}.sfoo`), vstr(null));
 
   await dispatchMessageSuccessfully('makeAndHold'); // creates Map6, holds in RAM[heldStore]
   // `heldStore` is the most recent one created
   const [ heldID, heldVref ] = deduceCollectionID(fakestore, 'scalarMapStore', 1);
-  // and `mainHolder` was created before that
-  const [ mainID, _mainVref ] = deduceCollectionID(fakestore, 'scalarMapStore', 2)
-  t.is(fakestore.get(`vc.${mainID}.|entryCount`), '1');
-  t.is(fakestore.get(`vc.${mainID}.sfoo`), vstr(null));
 
   t.is(fakestore.get(`vc.${heldID}.|entryCount`), '0'); // heldStore is empty
   t.is(fakestore.get(`vom.rc.${heldVref}`), undefined); // no vdata references

--- a/packages/swingset-liveslots/test/test-vpid-liveslots.js
+++ b/packages/swingset-liveslots/test/test-vpid-liveslots.js
@@ -342,14 +342,12 @@ async function doVatResolveCase23(t, which, mode, stalls) {
 
   if (which === 2) {
     await dispatch(makeMessage(rootA, 'result', [], p1));
-    matchIDCounterSet(t, log);
     // the vat knows it is the decider, does not subscribe
     await dispatch(makeMessage(rootA, 'promise', [kslot(p1)]));
   } else if (which === 3) {
     await dispatch(makeMessage(rootA, 'promise', [kslot(p1)]));
     // the vat subscribes to p1, it cannot know the future
     t.deepEqual(log.shift(), { type: 'subscribe', target: p1 });
-    matchIDCounterSet(t, log);
     await dispatch(makeMessage(rootA, 'result', [], p1));
     // vat cannot unsubscribe, but is now the decider
   } else {
@@ -590,7 +588,6 @@ async function doVatResolveCase4(t, mode) {
 
   await dispatch(makeMessage(rootA, 'get', [kslot(p1)]));
   t.deepEqual(log.shift(), { type: 'subscribe', target: p1 });
-  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   await dispatch(makeMessage(rootA, 'first', [kslot(target1)]));
@@ -726,7 +723,6 @@ async function doVatResolveCase7(t, mode) {
   await dispatch(makeMessage(rootA, 'acceptPromise', [kslot(p1)]));
   // the vat subscribes to p1, it cannot know the future
   t.deepEqual(log.shift(), { type: 'subscribe', target: p1 });
-  matchIDCounterSet(t, log);
 
   const target1 = 'o-1';
   const target2 = 'o-2';
@@ -882,7 +878,6 @@ test('inter-vat circular promise references', async t => {
   // const paB = 'p-19';
 
   await dispatchA(makeMessage(rootA, 'genPromise', [], paA));
-  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   // await dispatchB(makeMessage(rootB, 'genPromise', [], pbB));

--- a/packages/swingset-liveslots/test/util.js
+++ b/packages/swingset-liveslots/test/util.js
@@ -60,6 +60,10 @@ export function makeMessage(target, method, args = [], result = null) {
   return vatDeliverObject;
 }
 
+export function makeStartVat(vatParameters) {
+  return harden(['startVat', vatParameters]);
+}
+
 export function makeBringOutYourDead() {
   return harden(['bringOutYourDead']);
 }

--- a/packages/swingset-liveslots/test/virtual-objects/test-virtualObjectGC.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-virtualObjectGC.js
@@ -1173,15 +1173,16 @@ test.serial('remotable refcount management 1', async t => {
   const { v, dispatchMessageSuccessfully } = await setupTestLiveslots(t, buildRootObject, 'bob', true);
   const { fakestore } = v;
 
-  await dispatchMessageSuccessfully('makeAndHoldRemotable');
-  // the Remotable is currently held by RAM, and doesn't get a vref
-  // until it is stored somewhere or exported
-
   // holder Kind is the next-to-last created kind, which gets idCounters.exportID-2
   const holderKindID = JSON.parse(fakestore.get(`idCounters`)).exportID - 2;
   t.is(JSON.parse(fakestore.get(`vom.vkind.${holderKindID}`)).tag, 'holder');
 
+  await dispatchMessageSuccessfully('makeAndHoldRemotable');
+  // the Remotable is currently held by RAM, and doesn't get a vref
+  // until it is stored somewhere or exported
+
   await dispatchMessageSuccessfully('prepareStore3');
+
   // Now there are three VirtualHolder objects, each holding our
   // Remotable. The Remotable's vref was the last thing assigned.
   const remotableID = JSON.parse(fakestore.get(`idCounters`)).exportID - 1;
@@ -1215,12 +1216,11 @@ test.serial('remotable refcount management 2', async t => {
   const { v, dispatchMessageSuccessfully } = await setupTestLiveslots(t, buildRootObject, 'bob', true);
   const { fakestore } = v;
 
-  await dispatchMessageSuccessfully('makeAndHoldRemotable');
   const holderKindID = JSON.parse(fakestore.get(`idCounters`)).exportID - 2;
   t.is(JSON.parse(fakestore.get(`vom.vkind.${holderKindID}`)).tag, 'holder');
 
+  await dispatchMessageSuccessfully('makeAndHoldRemotable');
   await dispatchMessageSuccessfully('prepareStore3');
-
   await dispatchMessageSuccessfully('finishDropHolders');
   // all three holders are gone
   const holderVrefs = [2,3,4].map(instanceID => `o+${holderKindID}/${instanceID}`);


### PR DESCRIPTION
The test/liveslots-helpers.js test fixture was manually calling the simulated vat's `startVat()` method, rather than going through the official `dispatch(StartVatMessage)` pathway. This accidentally bypassed post-dispatch actions like updating the `idCounters` DB entry.

This commit fixes that, which ensures that the counters have been written by the time `setupTestLiveslots()` has returned. Several test cases were changed to no longer expect the `vatstoreSet('idCounters')` to happen later, in the middle of their operations.

This also allows us to stop exporting `startVat` from the liveslots constructors. I removed some other unused exports at the same time.
