### PR TITLE
WIP refactor: expand out export star

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -13,7 +13,7 @@ const { quote: q, Fail } = assert;
  *
  * @type {{ NAT: 'nat', SET: 'set', COPY_SET: 'copySet', COPY_BAG: 'copyBag' }}
  */
-const AssetKind = harden({
+export const AssetKind = harden({
   NAT: 'nat',
   SET: 'set',
   COPY_SET: 'copySet',
@@ -25,7 +25,7 @@ const assetKindNames = harden(Object.values(AssetKind).sort());
  *
  * @param {AssetKind} allegedAK
  */
-const assertAssetKind = allegedAK => {
+export const assertAssetKind = allegedAK => {
   assetKindNames.includes(allegedAK) ||
     Fail`The assetKind ${allegedAK} must be one of ${q(assetKindNames)}`;
 };
@@ -200,7 +200,7 @@ const isGTE = (leftAmount, rightAmount, brand = undefined) => {
  * payments. They can be used to represent things like currency, stock, and the
  * abstract right to participate in a particular exchange.
  */
-const AmountMath = {
+export const AmountMath = {
   /**
    * Make an amount from a value by adding the brand.
    *
@@ -380,12 +380,10 @@ harden(AmountMath);
  *
  * @param {Amount} amount
  */
-const getAssetKind = amount => {
+export const getAssetKind = amount => {
   assertRecord(amount, 'amount');
   const { value } = amount;
   // @ts-expect-error cast (ignore b/c erroring in CI but not my IDE)
   return assertValueGetAssetKind(value);
 };
 harden(getAssetKind);
-
-export { AmountMath, AssetKind, getAssetKind, assertAssetKind };

--- a/packages/ERTP/src/index.js
+++ b/packages/ERTP/src/index.js
@@ -1,3 +1,34 @@
-export * from './amountMath.js';
-export * from './issuerKit.js';
-export * from './typeGuards.js';
+export {
+  assertValueGetHelpers,
+  AmountMath,
+  AssetKind,
+  getAssetKind,
+  assertAssetKind,
+} from './amountMath.js';
+export {
+  prepareIssuerKit,
+  hasIssuer,
+  makeDurableIssuerKit,
+  makeIssuerKit,
+} from './issuerKit.js';
+export {
+  BrandShape,
+  IssuerShape,
+  PaymentShape,
+  PurseShape,
+  DepositFacetShape,
+  NotifierShape,
+  MintShape,
+  AmountShape,
+  RatioShape,
+  isNatValue,
+  isCopySetValue,
+  isSetValue,
+  isCopyBagValue,
+  MAX_ABSOLUTE_DECIMAL_PLACES,
+  AssetKindShape,
+  DisplayInfoShape,
+  IssuerKitShape,
+  BrandI,
+  makeIssuerInterfaces,
+} from './typeGuards.js';

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -5,7 +5,19 @@ import { Stable } from '@agoric/vats/src/tokens.js';
 import { E } from '@endo/far';
 import { reserveThenGetNames } from './utils.js';
 
-export * from './startPSM.js';
+export {
+  inviteCommitteeMembers,
+  startEconCharter,
+  inviteToEconCharter,
+  startPSM,
+  makeAnchorAsset,
+  installGovAndPSMContracts,
+  PSM_GOV_MANIFEST,
+  INVITE_PSM_COMMITTEE_MANIFEST,
+  PSM_MANIFEST,
+  getManifestForPsmGovernance,
+  getManifestForPsm,
+} from './startPSM.js';
 
 /**
  * @typedef {object} InterchainAssetOptions

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -13,7 +13,12 @@ export {
   startLienBridge,
   startStakeFactory,
 } from './econ-behaviors.js';
-export * from './sim-behaviors.js';
+export {
+  connectFaucet,
+  fundAMM,
+  installSimEgress,
+  grantRunBehaviors,
+} from './sim-behaviors.js';
 // @ts-expect-error Module './econ-behaviors.js' has already exported a member
 // named 'EconomyBootstrapPowers'.
 export {

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -3,12 +3,36 @@ import * as econBehaviors from './econ-behaviors.js';
 import { ECON_COMMITTEE_MANIFEST } from './startEconCommittee.js';
 import * as simBehaviors from './sim-behaviors.js';
 
-export * from './econ-behaviors.js';
+export {
+  startInterchainPool,
+  setupAmm,
+  setupReserve,
+  startVaultFactory,
+  grantVaultFactoryControl,
+  startRewardDistributor,
+  startLienBridge,
+  startStakeFactory,
+} from './econ-behaviors.js';
 export * from './sim-behaviors.js';
 // @ts-expect-error Module './econ-behaviors.js' has already exported a member
 // named 'EconomyBootstrapPowers'.
-export * from './startPSM.js'; // eslint-disable-line import/export
-export * from './startEconCommittee.js'; // eslint-disable-line import/export
+export {
+  inviteCommitteeMembers,
+  startEconCharter,
+  inviteToEconCharter,
+  startPSM,
+  makeAnchorAsset,
+  installGovAndPSMContracts,
+  PSM_GOV_MANIFEST,
+  INVITE_PSM_COMMITTEE_MANIFEST,
+  PSM_MANIFEST,
+  getManifestForPsmGovernance,
+  getManifestForPsm,
+} from './startPSM.js'; // eslint-disable-line import/export
+export {
+  startEconomicCommittee,
+  ECON_COMMITTEE_MANIFEST,
+} from './startEconCommittee.js'; // eslint-disable-line import/export
 
 /** @type {import('@agoric/vats/src/core/manifest.js').BootstrapManifest} */
 const SHARED_MAIN_MANIFEST = harden({

--- a/packages/internal/src/index.js
+++ b/packages/internal/src/index.js
@@ -1,5 +1,22 @@
 /// <reference types="ses"/>
 
-export * from './config.js';
-export * from './debug.js';
-export * from './utils.js';
+export { BridgeId, WalletName } from './config.js';
+export { makeTracer } from './debug.js';
+export {
+  fromUniqueEntries,
+  objectMap,
+  listDifference,
+  throwLabeled,
+  applyLabelingError,
+  getMethodNames,
+  bindAllMethods,
+  deeplyFulfilledObject,
+  makeMeasureSeconds,
+  makeAggregateError,
+  PromiseAllOrErrors,
+  aggregateTryFinally,
+  assertAllDefined,
+  forever,
+  whileTrue,
+  untilTrue,
+} from './utils.js';

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -336,7 +336,8 @@ export const PromiseAllOrErrors = async values => {
  *   trier: () => Promise<T>,
  *  finalizer: (error?: unknown) => Promise<void>,
  * ) => Promise<T>}
- */ export const aggregateTryFinally = async (trier, finalizer) =>
+ */
+export const aggregateTryFinally = async (trier, finalizer) =>
   trier().then(
     async result => finalizer().then(() => result),
     async tryError =>

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -22,6 +22,17 @@ export {
   // Consider deprecating or not reexporting
   makeAsyncIterableFromNotifier,
 } from './asyncIterableAdaptor.js';
-export * from './storesub.js';
-export * from './stored-notifier.js';
-export * from './stored-topic.js';
+export {
+  forEachPublicationRecord,
+  makeStoredSubscriber,
+  makeStoredSubscription,
+  makeStoredPublisherKit,
+  makeStoredPublishKit,
+} from './storesub.js';
+export { makeStoredNotifier } from './stored-notifier.js';
+export {
+  PublicTopicShape,
+  TopicsRecordShape,
+  pipeTopicToStorage,
+  makePublicTopic,
+} from './stored-topic.js';

--- a/packages/notifier/src/stored-topic.js
+++ b/packages/notifier/src/stored-topic.js
@@ -67,3 +67,4 @@ export const makePublicTopic = (description, subscriber, storageNode) => {
     storagePath: E(storageNode).getPath(),
   };
 };
+harden(makePublicTopic);

--- a/packages/time/index.js
+++ b/packages/time/index.js
@@ -1,2 +1,10 @@
-export * from './src/timeMath.js';
-export * from './src/typeGuards.js';
+export { TimeMath } from './src/timeMath.js';
+export {
+  TimerBrandShape,
+  TimestampValueShape,
+  RelativeTimeValueShape,
+  TimestampRecordShape,
+  RelativeTimeRecordShape,
+  TimestampShape,
+  RelativeTimeShape,
+} from './src/typeGuards.js';

--- a/packages/zoe/contractFacet.js
+++ b/packages/zoe/contractFacet.js
@@ -1,1 +1,1 @@
-export * from './src/contractFacet/vatRoot.js';
+export { buildRootObject } from './src/contractFacet/vatRoot.js';

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -6,17 +6,28 @@ export {
   calcSecondaryRequired,
 } from './bondingCurves.js';
 
-export * from './durability.js';
+export {
+  makeEphemeraProvider,
+  makeStorageNodePathProvider,
+  provideEmptySeat,
+  provideChildBaggage,
+} from './durability.js';
 
-export * from './priceAuthority.js';
+export { makeOnewayPriceAuthorityKit } from './priceAuthority.js';
 
-export * from './priceQuote.js';
+export {
+  getPriceDescription,
+  getAmountIn,
+  getAmountOut,
+  getTimestamp,
+  unitAmount,
+} from './priceQuote.js';
 
 export { natSafeMath } from './safeMath.js';
 
 export { makeStateMachine } from './stateMachine.js';
 
-export * from './statistics.js';
+export { calculateMedian } from './statistics.js';
 
 export {
   atomicRearrange,

--- a/packages/zoe/src/contractSupport/priceQuote.js
+++ b/packages/zoe/src/contractSupport/priceQuote.js
@@ -18,13 +18,19 @@ export const getPriceDescription = quote => {
   );
   return quote.quoteAmount.value[0];
 };
+harden(getPriceDescription);
 
 /** @param {PriceQuote} quote */
 export const getAmountIn = quote => getPriceDescription(quote).amountIn;
+harden(getAmountIn);
+
 /** @param {PriceQuote} quote */
 export const getAmountOut = quote => getPriceDescription(quote).amountOut;
+harden(getAmountOut);
+
 /** @type {(quote: PriceQuote) => import('@agoric/time/src/types').Timestamp} */
 export const getTimestamp = quote => getPriceDescription(quote).timestamp;
+harden(getTimestamp);
 
 /** @param {Brand<'nat'>} brand */
 export const unitAmount = async brand => {


### PR DESCRIPTION
Expand out `export * ...` into their explicit exports. A bit harder to write, but helps reading and reasoning about modularity.

See https://github.com/endojs/endo/pull/1486