### PR TITLE
fix vaultManager asset topic

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -3,7 +3,7 @@ import '@agoric/zoe/exported.js';
 import { Far } from '@endo/marshal';
 import { prepareVaultHolder } from './vaultHolder.js';
 
-const trace = makeTracer('IV');
+const trace = makeTracer('IV', false);
 
 /**
  *
@@ -11,7 +11,7 @@ const trace = makeTracer('IV');
  * @param {ERef<Marshaller>} marshaller
  */
 export const prepareVaultKit = (baggage, marshaller) => {
-  trace('prepareVaultKit', baggage);
+  trace('prepareVaultKit', [...baggage.keys()]);
 
   const makeVaultHolder = prepareVaultHolder(baggage, marshaller);
   /**

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -162,13 +162,10 @@ export const prepareVaultManagerKit = (
     factoryPowers.getGovernedParams().getChargingPeriod(),
   );
 
-  const { publisher: metricsPublisher, subscriber: metricsSubscriber } =
-    makeVaultManagerPublishKit();
-
   /** @type {PublishKit<AssetState>} */
   const { publisher: assetPublisher, subscriber: assetSubscriber } =
     makeVaultManagerPublishKit();
-  pipeTopicToStorage(metricsSubscriber, storageNode, marshaller);
+  pipeTopicToStorage(assetSubscriber, storageNode, marshaller);
 
   /** @type {MapStore<string, Vault>} */
   const unsettledVaults = provideDurableMapStore(baggage, 'orderedVaultStore');
@@ -178,6 +175,8 @@ export const prepareVaultManagerKit = (
   const zeroDebt = AmountMath.makeEmpty(debtBrand, 'nat');
 
   const metricsNode = E(storageNode).makeChildNode('metrics');
+  const { publisher: metricsPublisher, subscriber: metricsSubscriber } =
+    makeVaultManagerPublishKit();
   pipeTopicToStorage(metricsSubscriber, metricsNode, marshaller);
 
   const storedQuotesNotifier = makeStoredNotifier(

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -233,8 +233,8 @@ export const subscriptionKey = subscription => {
 export const topicPath = (hasTopics, subscriberName) => {
   return E(hasTopics)
     .getPublicTopics()
-    .then(subscribers => subscribers[subscriberName])
-    .then(tr => tr.storagePath);
+    .then(topics => topics[subscriberName])
+    .then(t => t.storagePath);
 };
 
 /** @type {<T>(subscriber: ERef<Subscriber<T>>) => Promise<T>} */
@@ -242,4 +242,31 @@ export const headValue = async subscriber => {
   await eventLoopIteration();
   const record = await E(subscriber).subscribeAfter();
   return record.head.value;
+};
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ * @param {ERef<{getPublicTopics: () => import('@agoric/notifier').TopicsRecord}>} hasTopics
+ * @param {string} topicName
+ * @param {string} path
+ * @param {string[]} [dataKeys]
+ */
+export const assertTopicPathData = async (
+  t,
+  hasTopics,
+  topicName,
+  path,
+  dataKeys,
+) => {
+  const topic = await E(hasTopics)
+    .getPublicTopics()
+    .then(topics => topics[topicName]);
+  t.is(await topic.storagePath, path, 'topic storagePath must match');
+  const latest = /** @type {Record<string, unknown>} */ (
+    await headValue(topic.subscriber)
+  );
+  if (dataKeys !== undefined) {
+    // TODO consider making this a shape instead
+    t.deepEqual(Object.keys(latest), dataKeys, 'keys in topic feed must match');
+  }
 };

--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -1,10 +1,10 @@
 import '@agoric/zoe/exported.js';
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { E } from '@endo/eventual-send';
 import { makeTracer } from '@agoric/internal';
+import { E } from '@endo/eventual-send';
 import '../../src/vaultFactory/types.js';
-import { subscriptionKey, topicPath } from '../supports.js';
+import { assertTopicPathData, subscriptionKey } from '../supports.js';
 import { makeDriverContext, makeManagerDriver } from './driver.js';
 
 /** @typedef {import('./driver.js').DriverContext & {
@@ -25,9 +25,12 @@ test('storage keys', async t => {
 
   // Root vault factory
   const vdp = d.getVaultDirectorPublic();
-  t.is(
-    await topicPath(vdp, 'metrics'),
+  await assertTopicPathData(
+    t,
+    vdp,
+    'metrics',
     'mockChainStorageRoot.vaultFactory.metrics',
+    ['collaterals', 'rewardPoolAllocation'],
   );
   t.is(
     await subscriptionKey(E(vdp).getElectorateSubscription()),
@@ -36,9 +39,35 @@ test('storage keys', async t => {
 
   // First manager
   const managerA = await E(vdp).getCollateralManager(aeth.brand);
-  t.is(
-    await topicPath(managerA, 'metrics'),
+  await assertTopicPathData(
+    t,
+    managerA,
+    'asset',
+    'mockChainStorageRoot.vaultFactory.manager0',
+    [
+      'compoundedInterest',
+      'interestRate',
+      'latestInterestUpdate',
+      'liquidatorInstance',
+    ],
+  );
+  await assertTopicPathData(
+    t,
+    managerA,
+    'metrics',
     'mockChainStorageRoot.vaultFactory.manager0.metrics',
+    [
+      'numActiveVaults',
+      'numLiquidatingVaults',
+      'numLiquidationsCompleted',
+      'retainedCollateral',
+      'totalCollateral',
+      'totalCollateralSold',
+      'totalDebt',
+      'totalOverageReceived',
+      'totalProceedsReceived',
+      'totalShortfallReceived',
+    ],
   );
   t.is(
     await subscriptionKey(
@@ -51,8 +80,16 @@ test('storage keys', async t => {
 
   // Second manager
   const [managerC, chit] = await d.addVaultType('Chit');
-  t.is(
-    await topicPath(E(managerC).getPublicFacet(), 'metrics'),
+  await assertTopicPathData(
+    t,
+    E(managerC).getPublicFacet(),
+    'asset',
+    'mockChainStorageRoot.vaultFactory.manager1',
+  );
+  await assertTopicPathData(
+    t,
+    E(managerC).getPublicFacet(),
+    'metrics',
     'mockChainStorageRoot.vaultFactory.manager1.metrics',
   );
   t.is(


### PR DESCRIPTION
## Description

https://github.com/Agoric/agoric-sdk/pull/6902 made the `asset` topic pipe the `metricsSubscriber`. This is due in part to https://github.com/Agoric/agoric-sdk/pull/6902#discussion_r1093684203

We'll probably want some new patterns at some point to make the mistake harder. Meanwhile this adds a test for data feed keys, which we should have regardless.

### Security Considerations

--
### Scaling Considerations

--
### Documentation Considerations

--
### Testing Considerations

CI