### PR TITLE
chore(wallet): validate action types in contract

### DIFF
--- a/golang/cosmos/x/swingset/keeper/msg_server.go
+++ b/golang/cosmos/x/swingset/keeper/msg_server.go
@@ -87,7 +87,7 @@ func (keeper msgServer) WalletAction(goCtx context.Context, msg *types.MsgWallet
 }
 
 type walletSpendAction struct {
-	Type        string `json:"type"` // WALLET_ACTION
+	Type        string `json:"type"` // WALLET_SPEND_ACTION
 	Owner       string `json:"owner"`
 	SpendAction string `json:"spendAction"`
 	BlockHeight int64  `json:"blockHeight"`

--- a/packages/smart-wallet/src/typeGuards.js
+++ b/packages/smart-wallet/src/typeGuards.js
@@ -50,15 +50,33 @@ export const shape = {
   ),
 
   // walletFactory
-  WalletBridgeMsg: M.splitRecord(
-    {
-      owner: M.string(),
-      type: M.string(),
-      blockHeight: M.number(),
-      blockTime: M.number(),
-    },
-    {},
-    M.or({ action: M.string() }, { spendAction: M.string() }),
-  ),
+  /**
+   * Defined by walletAction struct in msg_server.go
+   *
+   * @see walletAction in msg_server.go
+   */
+  WalletActionMsg: M.splitRecord({
+    type: 'WALLET_ACTION',
+    action: M.string(),
+
+    blockHeight: M.number(),
+    blockTime: M.number(),
+    owner: M.string(),
+  }),
+
+  /**
+   * Defined by walletAction struct in msg_server.go
+   *
+   * @see walletSpendAction in msg_server.go
+   */
+  WalletSpendActionMsg: M.splitRecord({
+    type: 'WALLET_SPEND_ACTION',
+    spendAction: M.string(),
+
+    blockHeight: M.number(),
+    blockTime: M.number(),
+    owner: M.string(),
+  }),
 };
+shape.WalletBridgeMsg = M.or(shape.WalletActionMsg, shape.WalletSpendActionMsg);
 harden(shape);

--- a/packages/smart-wallet/src/types.d.ts
+++ b/packages/smart-wallet/src/types.d.ts
@@ -73,6 +73,4 @@ export type WalletSpendActionMsg = {
  * The two wallet actions are distinguished by whether the user had to confirm
  * the sending of the message (as is the case for WALLET_SPEND_ACTION).
  */
-export type WalletBridgeMsg =
-  | ({ owner: string } & WalletActionMsg)
-  | WalletSpendActionMsg;
+export type WalletBridgeMsg = WalletActionMsg | WalletSpendActionMsg;

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -148,7 +148,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     {
       /**
        *
-       * @param {import('./types.js').WalletBridgeMsg} obj
+       * @param {import('./types.js').WalletBridgeMsg} obj validated by shape.WalletBridgeMsg
        */
       fromBridge: async obj => {
         console.log('walletFactory.fromBridge:', obj);

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -88,17 +88,10 @@ const makeFakeBridgeManager = () =>
         },
         toBridge(obj) {
           assert(handler, `No handler for ${bridgeId}`);
-          switch (obj.type) {
-            case ActionType.WALLET_ACTION:
-            case ActionType.WALLET_SPEND_ACTION: {
-              // @ts-expect-error handler possibly undefined
-              return E(handler).fromBridge(obj);
-            }
-
-            default: {
-              assert.fail(`Unsupported bridge object type ${obj.type}`);
-            }
-          }
+          // Rely on interface guard for validation.
+          // This should also be validated upstream but don't rely on it.
+          // @ts-expect-error handler possibly undefined
+          return E(handler).fromBridge(obj);
         },
         setHandler(newHandler) {
           handler = newHandler;

--- a/packages/smart-wallet/test/test-walletFactory.js
+++ b/packages/smart-wallet/test/test-walletFactory.js
@@ -105,7 +105,7 @@ test('bridge with offerId string', async t => {
     proposal: {},
   };
   assert(t.context.sendToBridge);
-  const res = await t.context.sendToBridge({
+  const validMsg = {
     type: ActionType.WALLET_SPEND_ACTION,
     owner: mockAddress2,
     // consider a helper for each action type
@@ -116,8 +116,20 @@ test('bridge with offerId string', async t => {
     ),
     blockTime: 0,
     blockHeight: 0,
-  });
+  };
+  const res = await t.context.sendToBridge(validMsg);
   t.is(res, undefined);
+
+  // Verify it would have failed with a different 'type'.
+  // This arguably belongs in a new test but putting it here makes clear
+  // that everything is valid except for 'type'.
+  await t.throwsAsync(
+    t.context.sendToBridge({
+      ...validMsg,
+      type: 'BOGUS',
+    }),
+    { message: /^In "fromBridge" method/ },
+  );
 });
 
 test.todo('spend action over bridge');


### PR DESCRIPTION
closes: #6300

## Description

The `type` of the wallet message was previously only validated by the Cosmos bridge: https://github.com/Agoric/agoric-sdk/blob/8f79654d34dc48c2b3a99c6d8f80941b71751484/packages/cosmic-swingset/src/launch-chain.js#L452-L464

This makes the smart wallet contract check it too.

### Security Considerations

Improves suspicion.

### Scaling Considerations

Neglible cost to check string literal. 

### Documentation Considerations

--
### Testing Considerations

New test.