### PR TITLE
no more Closure syntax

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,6 +33,7 @@ module.exports = {
     'no-void': ['error', { allowAsStatement: true }],
     // Not severe but the default 'warning' clutters output and it's easy to fix
     'jsdoc/check-param-names': 'error',
+    'jsdoc/check-syntax': 'error',
     'jsdoc/no-multi-asterisks': 'off',
     'jsdoc/multiline-blocks': 'off',
     // Use these rules to warn about JSDoc type problems, such as after

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -183,7 +183,7 @@ const coerceLR = (h, leftAmount, rightAmount) => {
  * @template {AssetKind} [K=AssetKind]
  * @param {Amount<K>} leftAmount
  * @param {Amount<K>} rightAmount
- * @param {Brand<K>=} brand
+ * @param {Brand<K>} [brand]
  * @returns {boolean}
  */
 const isGTE = (leftAmount, rightAmount, brand = undefined) => {
@@ -278,7 +278,7 @@ const AmountMath = {
    * Return true if the Amount is empty. Otherwise false.
    *
    * @param {Amount} amount
-   * @param {Brand=} brand
+   * @param {Brand} [brand]
    * @returns {boolean}
    */
   isEmpty: (amount, brand = undefined) => {
@@ -297,7 +297,7 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} leftAmount
    * @param {Amount<K>} rightAmount
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {boolean}
    */
   isEqual: (leftAmount, rightAmount, brand = undefined) => {
@@ -314,7 +314,7 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} leftAmount
    * @param {Amount<K>} rightAmount
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {Amount<K>}
    */
   add: (leftAmount, rightAmount, brand = undefined) => {
@@ -333,7 +333,7 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} leftAmount
    * @param {Amount<K>} rightAmount
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {Amount<K>}
    */
   subtract: (leftAmount, rightAmount, brand = undefined) => {
@@ -347,7 +347,7 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} x
    * @param {Amount<K>} y
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {Amount<K>}
    */
   min: (x, y, brand = undefined) =>
@@ -363,7 +363,7 @@ const AmountMath = {
    * @template {AssetKind} [K=AssetKind]
    * @param {Amount<K>} x
    * @param {Amount<K>} y
-   * @param {Brand<K>=} brand
+   * @param {Brand<K>} [brand]
    * @returns {Amount<K>}
    */
   max: (x, y, brand = undefined) =>

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -15,7 +15,7 @@ import './types-ambient.js';
 /**
  * @template {AssetKind} K
  * @param {Baggage} issuerBaggage
- * @param {ShutdownWithFailure=} optShutdownWithFailure If this issuer fails
+ * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails
  * in the middle of an atomic action (which btw should never happen), it
  * potentially leaves its ledger in a corrupted state. If this function was
  * provided, then the failed atomic action will call it, so that some
@@ -98,7 +98,7 @@ export const hasIssuer = baggage =>
  * @param {string} name
  * @param {K} [assetKind=AssetKind.NAT]
  * @param {AdditionalDisplayInfo} [displayInfo={}]
- * @param {ShutdownWithFailure=} optShutdownWithFailure If this issuer fails
+ * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails
  * in the middle of an atomic action (which btw should never happen), it
  * potentially leaves its ledger in a corrupted state. If this function was
  * provided, then the failed atomic action will call it, so that some
@@ -143,7 +143,7 @@ harden(makeDurableIssuerKit);
  * @param {string} name
  * @param {K} [assetKind='nat']
  * @param {AdditionalDisplayInfo} [displayInfo={}]
- * @param {ShutdownWithFailure=} optShutdownWithFailure If this issuer fails
+ * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails
  * in the middle of an atomic action (which btw should never happen), it
  * potentially leaves its ledger in a corrupted state. If this function was
  * provided, then the failed atomic action will call it, so that some

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -69,7 +69,7 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
  * @param {K} assetKind
  * @param {DisplayInfo<K>} displayInfo
  * @param {Pattern} elementShape
- * @param {ShutdownWithFailure=} optShutdownWithFailure
+ * @param {ShutdownWithFailure} [optShutdownWithFailure]
  * @returns {PaymentLedger<K>}
  */
 export const preparePaymentLedger = (
@@ -211,7 +211,7 @@ export const preparePaymentLedger = (
    * Note: `optAmountShape` is user-supplied with no previous validation.
    *
    * @param {Amount} paymentBalance
-   * @param {Pattern=} optAmountShape
+   * @param {Pattern} [optAmountShape]
    * @returns {void}
    */
   const assertAmountConsistent = (paymentBalance, optAmountShape) => {
@@ -298,7 +298,7 @@ export const preparePaymentLedger = (
    * @param {(newPurseBalance: Amount) => void} updatePurseBalance -
    * commit the purse balance
    * @param {Payment} srcPayment
-   * @param {Pattern=} optAmountShape
+   * @param {Pattern} [optAmountShape]
    * @returns {Amount}
    */
   const depositInternal = (

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -68,7 +68,7 @@
 /**
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} DisplayInfo
- * @property {number=} decimalPlaces Tells the display software how
+ * @property {number} [decimalPlaces] Tells the display software how
  *   many decimal places to move the decimal over to the left, or in
  *   other words, which position corresponds to whole numbers. We
  *   require fungible digital assets to be represented in integers, in
@@ -145,7 +145,7 @@
  * resolution.
  *
  * @param {ERef<Payment>} payment
- * @param {Pattern=} optAmountShape
+ * @param {Pattern} [optAmountShape]
  * @returns {Promise<Amount>}
  */
 
@@ -163,7 +163,7 @@
  * resolution.
  *
  * @param {ERef<Payment<K>>} payment
- * @param {Pattern=} optAmountShape
+ * @param {Pattern} [optAmountShape]
  * @returns {Promise<Payment<K>>}
  */
 
@@ -177,7 +177,7 @@
  * upon resolution.
  *
  * @param {ERef<Payment<K>>[]} paymentsArray
- * @param {Amount<K>=} optTotalAmount
+ * @param {Amount<K>} [optTotalAmount]
  * @returns {Promise<Payment<K>>}
  */
 
@@ -265,7 +265,7 @@
 /**
  * @typedef {object} AdditionalDisplayInfo
  *
- * @property {number=} decimalPlaces Tells the display software how
+ * @property {number} [decimalPlaces] Tells the display software how
  *   many decimal places to move the decimal over to the left, or in
  *   other words, which position corresponds to whole numbers. We
  *   require fungible digital assets to be represented in integers, in
@@ -275,7 +275,7 @@
  *   assets, should not be specified. The decimalPlaces property
  *   should be used for *display purposes only*. Any other use is an
  *   anti-pattern.
- * @property {AssetKind=} assetKind
+ * @property {AssetKind} [assetKind]
  */
 
 /**
@@ -296,7 +296,7 @@
 /**
  * @callback DepositFacetReceive
  * @param {Payment} payment
- * @param {Pattern=} optAmountShape
+ * @param {Pattern} [optAmountShape]
  * @returns {Amount}
  */
 
@@ -314,7 +314,7 @@
  * @template {AssetKind} K
  * @callback PurseDeposit
  * @param {Payment<K>} payment
- * @param {Pattern=} optAmountShape
+ * @param {Pattern} [optAmountShape]
  * @returns {Amount<K>}
  */
 

--- a/packages/SwingSet/src/kernel/kernelQueue.js
+++ b/packages/SwingSet/src/kernel/kernelQueue.js
@@ -88,7 +88,7 @@ export function makeKernelQueueHandler(tools) {
    * @param {string} kref  Target of the message
    * @param {string} method  The method name
    * @param {any[]} args  The arguments array
-   * @param {ResolutionPolicy=} policy How the kernel should handle an eventual
+   * @param {ResolutionPolicy} [policy] How the kernel should handle an eventual
    *    resolution or rejection of the message's result promise. Should be
    *    one of 'none' (don't even create a result promise), 'ignore' (do
    *    nothing), 'logAlways' (log the resolution or rejection), 'logFailure'

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -71,7 +71,7 @@ export function initializeVatState(kvStore, streamStore, vatID) {
  * @param {*} incStat
  * @param {*} decStat
  * @param {*} getCrankNumber
- * @param {SnapStore=} snapStore
+ * @param {SnapStore} [snapStore]
  * returns an object to hold and access the kernel's state for the given vat
  */
 export function makeVatKeeper(
@@ -475,7 +475,7 @@ export function makeVatKeeper(
   /**
    * Generator function to return the vat's transcript, one entry at a time.
    *
-   * @param {StreamPosition=} startPos  Optional position to begin reading from
+   * @param {StreamPosition} [startPos]  Optional position to begin reading from
    *
    * @yields { TranscriptEntry } a stream of transcript entries
    */

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -53,7 +53,7 @@ export const makeLRU = max => {
  * @param {ReturnType<typeof import('./vat-loader/vat-loader.js').makeVatLoader>} vatLoader
  * @param {{
  *   maxVatsOnline?: number,
- * }=} policyOptions
+ * }} [policyOptions]
  *
  * @typedef {(syscall: VatSyscallObject) => ['error', string] | ['ok', null] | ['ok', Capdata]} VatSyscallHandler
  * @typedef {{ body: string, slots: unknown[] }} Capdata

--- a/packages/access-token/src/json-store.js
+++ b/packages/access-token/src/json-store.js
@@ -229,7 +229,7 @@ function makeJSONStore(dirPath, forceReset = false) {
  * serialized to a text file.  If there is an existing store at the given
  * `dirPath`, it will be reinitialized to an empty state.
  *
- * @param {string=} dirPath  Path to a directory in which database files may be kept.
+ * @param {string} [dirPath]  Path to a directory in which database files may be kept.
  *   This directory need not actually exist yet (if it doesn't it will be
  *   created) but it is reserved (by the caller) for the exclusive use of this
  *   JSON store instance.  If this is nullish, the JSON store created will

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -12,15 +12,15 @@
  * The `assert` function itself.
  *
  * @param {*} flag The truthy/falsy value
- * @param {Details=} optDetails The details to throw
- * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
+ * @param {Details} [optDetails] The details to throw
+ * @param {ErrorConstructor} [ErrorConstructor] An optional alternate error
  * constructor to use.
  * @returns {asserts flag}
  */
 
 /**
  * @typedef {object} AssertMakeErrorOptions
- * @property {string=} errorName
+ * @property {string} [errorName]
  */
 
 /**
@@ -29,10 +29,10 @@
  * The `assert.error` method, recording details for the console.
  *
  * The optional `optDetails` can be a string.
- * @param {Details=} optDetails The details of what was asserted
- * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
+ * @param {Details} [optDetails] The details of what was asserted
+ * @param {ErrorConstructor} [ErrorConstructor] An optional alternate error
  * constructor to use.
- * @param {AssertMakeErrorOptions=} options
+ * @param {AssertMakeErrorOptions} [options]
  * @returns {Error}
  */
 
@@ -47,8 +47,8 @@
  *
  * The optional `optDetails` can be a string for backwards compatibility
  * with the nodejs assertion library.
- * @param {Details=} optDetails The details of what was asserted
- * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
+ * @param {Details} [optDetails] The details of what was asserted
+ * @param {ErrorConstructor} [ErrorConstructor] An optional alternate error
  * constructor to use.
  * @returns {never}
  */
@@ -60,8 +60,8 @@
  * Assert that two values must be `Object.is`.
  * @param {*} actual The value we received
  * @param {*} expected What we wanted
- * @param {Details=} optDetails The details to throw
- * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
+ * @param {Details} [optDetails] The details to throw
+ * @param {ErrorConstructor} [ErrorConstructor] An optional alternate error
  * constructor to use.
  * @returns {void}
  */
@@ -73,7 +73,7 @@
  * @callback AssertTypeofBigint
  * @param {any} specimen
  * @param {'bigint'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is bigint}
  */
 
@@ -81,7 +81,7 @@
  * @callback AssertTypeofBoolean
  * @param {any} specimen
  * @param {'boolean'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is boolean}
  */
 
@@ -89,7 +89,7 @@
  * @callback AssertTypeofFunction
  * @param {any} specimen
  * @param {'function'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is Function}
  */
 
@@ -97,7 +97,7 @@
  * @callback AssertTypeofNumber
  * @param {any} specimen
  * @param {'number'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is number}
  */
 
@@ -105,7 +105,7 @@
  * @callback AssertTypeofObject
  * @param {any} specimen
  * @param {'object'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is Record<any, any> | null}
  */
 
@@ -113,7 +113,7 @@
  * @callback AssertTypeofString
  * @param {any} specimen
  * @param {'string'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is string}
  */
 
@@ -121,7 +121,7 @@
  * @callback AssertTypeofSymbol
  * @param {any} specimen
  * @param {'symbol'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is symbol}
  */
 
@@ -129,7 +129,7 @@
  * @callback AssertTypeofUndefined
  * @param {any} specimen
  * @param {'undefined'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is undefined}
  */
 
@@ -148,7 +148,7 @@
  *
  * Assert an expected typeof result.
  * @param {any} specimen The value to get the typeof
- * @param {Details=} optDetails The details to throw
+ * @param {Details} [optDetails] The details to throw
  * @returns {asserts specimen is string}
  */
 
@@ -207,7 +207,7 @@
  *
  * @callback AssertQuote
  * @param {*} payload What to declassify
- * @param {(string|number)=} spaces
+ * @param {(string|number)} [spaces]
  * @returns {StringablePayload} The declassified payload
  */
 
@@ -240,8 +240,8 @@
  * `optRaise` returns normally, which would be unusual, the throw following
  * `optRaise(reason)` would still happen.
  *
- * @param {Raise=} optRaise
- * @param {boolean=} unredacted
+ * @param {Raise} [optRaise]
+ * @param {boolean} [unredacted]
  * @returns {Assert}
  */
 

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -429,7 +429,7 @@ export const makeCosmjsFollower = (
    * @yields {ValueFollowerElement<T>}
    */
   async function* getLatestIterable() {
-    /** @type {number=} the last known latest height */
+    /** @type {number | undefined} the last known latest height */
     let lastHeight;
     let lastValue;
     for (;;) {

--- a/packages/deploy-script-support/src/install.js
+++ b/packages/deploy-script-support/src/install.js
@@ -7,10 +7,10 @@ import { E } from '@endo/far';
 /**
  * @callback BundleSource
  * @param {string} startFilename - the filepath to start the bundling from
- * @param {(ModuleFormat | BundleOptions)=} moduleFormat
- * @param {object=} powers
- * @param {ReadFn=} powers.read
- * @param {CanonicalFn=} powers.canonical
+ * @param {ModuleFormat | BundleOptions} [moduleFormat]
+ * @param {object} [powers]
+ * @param {ReadFn} [powers.read]
+ * @param {CanonicalFn} [powers.canonical]
  */
 
 // XXX board is Board but specifying that leads to type errors with imports which aren't worth fixing right now

--- a/packages/deploy-script-support/src/offer.js
+++ b/packages/deploy-script-support/src/offer.js
@@ -6,8 +6,8 @@ import { AmountMath } from '@agoric/ertp';
 
 /**
  * @typedef {object} OfferHelperConfig
- * @property {ERef<Invitation>=} invitation
- * @property {Partial<InvitationDetails>=} partialInvitationDetails
+ * @property {ERef<Invitation>} [invitation]
+ * @property {Partial<InvitationDetails>} [partialInvitationDetails]
  * @property {Proposal} proposal
  * @property {Record<Keyword, Petname>} paymentsWithPursePetnames
  * @property {Record<Keyword, Petname>} payoutPursePetnames

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -48,7 +48,7 @@ test('startInstance', async t => {
     },
   };
 
-  /** @type {Petname=} */
+  /** @type {Petname | undefined} */
   let addedPetname;
 
   /** @type {import('../../src/startInstance.js').InstanceManager} */

--- a/packages/governance/src/types-ambient.js
+++ b/packages/governance/src/types-ambient.js
@@ -271,7 +271,7 @@
  * @callback SubmitVote
  * @param {Handle<'Voter'>} voterHandle
  * @param {Position[]} chosenPositions
- * @param {bigint=} weight
+ * @param {bigint} [weight]
  * @returns {CompletedBallet}
  */
 

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -272,7 +272,7 @@ export const makeRoundsManagerKit = defineDurableExoClassKit(
        * @param {bigint} roundId
        * @param {OracleStatus} status
        * @param {Timestamp} blockTimestamp
-       * @returns {OracleStatus=} the new status
+       * @returns {OracleStatus | undefined} the new status
        */
       proposeNewRound(roundId, status, blockTimestamp) {
         const { helper } = this.facets;

--- a/packages/inter-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/inter-protocol/src/vaultFactory/prioritizedVaults.js
@@ -71,7 +71,7 @@ export const makePrioritizedVaults = (store, higherHighestCb = () => {}) => {
   // current high-water mark fires, we reschedule at the new (presumably
   // lower) rate.
   // Without this we'd be calling reschedulePriceCheck() unnecessarily
-  /** @type {string=} */
+  /** @type {string | undefined} */
   let firstKey;
 
   // Check if this ratio of debt to collateral would be the highest known. If
@@ -82,7 +82,7 @@ export const makePrioritizedVaults = (store, higherHighestCb = () => {}) => {
   /**
    * Ratio of the least-collateralized vault, if there is one.
    *
-   * @returns {Ratio=} actual debt over collateral
+   * @returns {Ratio | undefined} actual debt over collateral
    */
   const highestRatio = () => {
     if (vaults.getSize() === 0) {

--- a/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/internal-types.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/constantProduct/internal-types.js
@@ -22,7 +22,7 @@
  * @typedef {object} NoFeeSwapFnInput
  * @property {Amount} amountGiven
  * @property {Amount} amountWanted
- * @property {Brand=} brand
+ * @property {Brand} [brand]
  * @property {PoolAllocation} poolAllocation
  */
 
@@ -65,14 +65,14 @@
  * @callback CalcSwapInPrices
  * @param {Amount} amountGiven
  * @param {PoolAllocation} poolAllocation
- * @param {Amount=} amountWanted
+ * @param {Amount} [amountWanted]
  * @param {Ratio} protocolFeeRatio
  * @param {Ratio} poolFeeRatio
  * @returns {SinglePoolSwapResult}
  */
 /**
  * @callback CalcSwapOutPrices
- * @param {Amount=} amountGiven
+ * @param {Amount} [amountGiven]
  * @param {PoolAllocation} poolAllocation
  * @param {Amount} amountWanted
  * @param {Ratio} protocolFeeRatio
@@ -82,9 +82,9 @@
 
 /**
  * @typedef {object} GetXYParam
- * @property {Amount=} amountGiven
+ * @property {Amount} [amountGiven]
  * @property {PoolAllocation} poolAllocation
- * @property {Amount=} amountWanted
+ * @property {Amount} [amountWanted]
  */
 
 /**

--- a/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -236,7 +236,7 @@ const start = async (zcf, privateArgs, baggage) => {
     () => zcf.makeEmptySeatKit().zcfSeat,
   );
 
-  /** @type {AssetReservePublicFacet=} */
+  /** @type {AssetReservePublicFacet | undefined} */
   let reserveFacet = baggage.has('reserveFacet')
     ? baggage.get('reserveFacet')
     : undefined;

--- a/packages/inter-protocol/src/vpool-xyk-amm/priceAuthority.js
+++ b/packages/inter-protocol/src/vpool-xyk-amm/priceAuthority.js
@@ -46,7 +46,7 @@ export const makePriceAuthority = (
 
   /**
    * @param {PriceQuery} priceQuery
-   * @returns {ERef<PriceQuote>=}
+   * @returns {ERef<PriceQuote> | undefined}
    */
   function createQuote(priceQuery) {
     const quote = priceQuery(calcAmountOut, calcAmountIn);

--- a/packages/inter-protocol/test/amm/constantProduct/test-checkInvariants.js
+++ b/packages/inter-protocol/test/amm/constantProduct/test-checkInvariants.js
@@ -15,7 +15,7 @@ import { getXY } from '../../../src/vpool-xyk-amm/constantProduct/getXY.js';
  * @typedef {object} SwapPriceArgs
  * @property {Amount} amountGiven
  * @property {PoolAllocation} poolAllocation
- * @property {Amount=} amountWanted
+ * @property {Amount} [amountWanted]
  * @property {Ratio} protocolFeeRatio
  * @property {Ratio} poolFeeRatio
  */

--- a/packages/inter-protocol/test/amm/vpool-xyk-amm/setup.js
+++ b/packages/inter-protocol/test/amm/vpool-xyk-amm/setup.js
@@ -89,7 +89,7 @@ export const setupAMMBootstrap = async (
  * @param {*} t
  * @param {{ committeeName: string, committeeSize: number}} electorateTerms
  * @param {{ brand: Brand, issuer: Issuer }} centralR
- * @param {ManualTimer | undefined=} timer
+ * @param {ManualTimer} [timer]
  * @param {ERef<FarZoeKit>} [farZoeKit]
  */
 export const setupAmmServices = async (

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -83,7 +83,7 @@ export const setupPsmBootstrap = async (
 /**
  * @param {*} t
  * @param {{ committeeName: string, committeeSize: number}} electorateTerms
- * @param {ManualTimer | undefined=} timer
+ * @param {ManualTimer} [timer]
  * @param {FarZoeKit} [farZoeKit]
  */
 export const setupPsm = async (

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -74,7 +74,7 @@ const setupReserveBootstrap = async (
  *
  * @param {import("ava").ExecutionContext<unknown>} t
  * @param {{ committeeName: string, committeeSize: number}} electorateTerms
- * @param {ManualTimer | undefined=} timer
+ * @param {ManualTimer} [timer]
  */
 export const setupReserveServices = async (
   t,

--- a/packages/inter-protocol/test/test-voPool.js
+++ b/packages/inter-protocol/test/test-voPool.js
@@ -50,7 +50,7 @@ const makeAmmParamManager = async (
 };
 
 const voPoolTest = async (t, mutation, postTest) => {
-  /** @type {MakePoolMulti=} */
+  /** @type {MakePoolMulti | undefined} */
   let makePool;
   const { zoe, zcf } = await setupZCFTest();
   const invitation = await zcf.makeInvitation(() => {}, 'fake invitation');
@@ -149,7 +149,7 @@ test.serial('unchanged', async t => {
 });
 
 test.serial('one update', async t => {
-  /** @type {Notifier<unknown>=} */
+  /** @type {Notifier<unknown> | undefined} */
   let notifier;
   let initialNotifierCount;
   await voPoolTest(

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -103,7 +103,7 @@ harden(listDifference);
 /**
  * @param {Error} innerErr
  * @param {string|number} label
- * @param {ErrorConstructor=} ErrorConstructor
+ * @param {ErrorConstructor} [ErrorConstructor]
  * @returns {never}
  */
 export const throwLabeled = (innerErr, label, ErrorConstructor = undefined) => {

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -13,7 +13,7 @@ export const makeWalletStateCoalescer = () => {
   /** @type {Map<Brand, Amount>} */
   const balances = new Map();
 
-  /** @type {Brand=} */
+  /** @type {Brand | undefined} */
   let allegedInvitationBrand = undefined;
 
   /**

--- a/packages/solo/src/add-chain.js
+++ b/packages/solo/src/add-chain.js
@@ -12,7 +12,7 @@ const DEFAULT_CHAIN_CONFIG = 'https://testnet.agoric.com/network-config';
 
 /**
  * @param {string} basedir
- * @param {string=} chainConfig
+ * @param {string} [chainConfig]
  * @param {boolean} [force=false]
  */
 async function addChain(basedir, chainConfig, force = false) {

--- a/packages/store/src/keys/copyBag.js
+++ b/packages/store/src/keys/copyBag.js
@@ -49,7 +49,7 @@ const checkNoDuplicateKeys = (bagEntries, fullCompare, check) => {
 /**
  * @template T
  * @param {[T,bigint][]} bagEntries
- * @param {FullCompare=} fullCompare
+ * @param {FullCompare} [fullCompare]
  * @returns {void}
  */
 export const assertNoDuplicateKeys = (bagEntries, fullCompare = undefined) => {

--- a/packages/store/src/keys/copySet.js
+++ b/packages/store/src/keys/copySet.js
@@ -46,7 +46,7 @@ const checkNoDuplicates = (elements, fullCompare, check) => {
 /**
  * @template T
  * @param {T[]} elements
- * @param {FullCompare=} fullCompare
+ * @param {FullCompare} [fullCompare]
  * @returns {void}
  */
 export const assertNoDuplicates = (elements, fullCompare = undefined) => {

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -147,7 +147,7 @@ const makePatternKit = () => {
    * Otherwise result undefined.
    *
    * @param {string} tag
-   * @returns {MatchHelper=}
+   * @returns {MatchHelper | undefined}
    */
   const maybeMatchHelper = tag =>
     // eslint-disable-next-line no-use-before-define

--- a/packages/store/src/stores/scalarMapStore.js
+++ b/packages/store/src/stores/scalarMapStore.js
@@ -21,8 +21,8 @@ const { quote: q } = assert;
  * @param {Map<K,V>} jsmap
  * @param {(k: K, v: V) => void} assertKVOkToAdd
  * @param {(k: K, v: V) => void} assertKVOkToSet
- * @param {((k: K) => void)=} assertKeyOkToDelete
- * @param {string=} tag
+ * @param {((k: K) => void)} [assertKeyOkToDelete]
+ * @param {string} [tag]
  * @returns {MapStore<K,V>}
  */
 export const makeMapStoreMethods = (
@@ -43,8 +43,8 @@ export const makeMapStoreMethods = (
     );
 
   /**
-   * @param {Pattern=} keyPatt
-   * @param {Pattern=} valuePatt
+   * @param {Pattern} [keyPatt]
+   * @param {Pattern} [valuePatt]
    * @returns {Iterable<K>}
    */
   const keys = (keyPatt = undefined, valuePatt = undefined) => {
@@ -65,16 +65,16 @@ export const makeMapStoreMethods = (
   };
 
   /**
-   * @param {Pattern=} keyPatt
-   * @param {Pattern=} valuePatt
+   * @param {Pattern} [keyPatt]
+   * @param {Pattern} [valuePatt]
    * @returns {Iterable<V>}
    */
   const values = (keyPatt = undefined, valuePatt = undefined) =>
     mapIterable(keys(keyPatt, valuePatt), k => /** @type {V} */ (jsmap.get(k)));
 
   /**
-   * @param {Pattern=} keyPatt
-   * @param {Pattern=} valuePatt
+   * @param {Pattern} [keyPatt]
+   * @param {Pattern} [valuePatt]
    * @returns {Iterable<[K,V]>}
    */
   const entries = (keyPatt = undefined, valuePatt = undefined) =>
@@ -127,7 +127,7 @@ export const makeMapStoreMethods = (
  *
  * @template K,V
  * @param {string} [tag='key'] - the column name for the key
- * @param {StoreOptions=} options
+ * @param {StoreOptions} [options]
  * @returns {MapStore<K,V>}
  */
 export const makeScalarMapStore = (

--- a/packages/store/src/stores/scalarSetStore.js
+++ b/packages/store/src/stores/scalarSetStore.js
@@ -15,8 +15,8 @@ const { quote: q } = assert;
  * @template K
  * @param {Set<K>} jsset
  * @param {(k: K) => void} assertKeyOkToAdd
- * @param {((k: K) => void)=} assertKeyOkToDelete
- * @param {string=} keyName
+ * @param {(k: K) => void} [assertKeyOkToDelete]
+ * @param {string} [keyName]
  * @returns {SetStore<K>}
  */
 export const makeSetStoreMethods = (
@@ -36,7 +36,7 @@ export const makeSetStoreMethods = (
     );
 
   /**
-   * @param {Pattern=} keyPatt
+   * @param {Pattern} [keyPatt]
    * @returns {Iterable<K>}
    */
   const keys = (keyPatt = undefined) =>
@@ -85,7 +85,7 @@ export const makeSetStoreMethods = (
  *
  * @template K
  * @param {string} [tag='key'] - tag for debugging
- * @param {StoreOptions=} options
+ * @param {StoreOptions} [options]
  * @returns {SetStore<K>}
  */
 export const makeScalarSetStore = (

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -9,8 +9,8 @@ const { quote: q, Fail } = assert;
  * @param {WeakMap<K & object, V>} jsmap
  * @param {(k: K, v: V) => void} assertKVOkToAdd
  * @param {(k: K, v: V) => void} assertKVOkToSet
- * @param {((k: K) => void)=} assertKeyOkToDelete
- * @param {string=} keyName
+ * @param {(k: K) => void} [assertKeyOkToDelete]
+ * @param {string} [keyName]
  * @returns {WeakMapStore<K,V>}
  */
 export const makeWeakMapStoreMethods = (
@@ -85,7 +85,7 @@ export const makeWeakMapStoreMethods = (
  *
  * @template K,V
  * @param {string} [tag='key'] - tag for debugging
- * @param {StoreOptions=} options
+ * @param {StoreOptions} [options]
  * @returns {WeakMapStore<K,V>}
  */
 export const makeScalarWeakMapStore = (

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -8,8 +8,8 @@ const { quote: q, Fail } = assert;
  * @template K
  * @param {WeakSet<K & object>} jsset
  * @param {(k: K) => void} assertKeyOkToAdd
- * @param {((k: K) => void)=} assertKeyOkToDelete
- * @param {string=} keyName
+ * @param {(k: K) => void} [assertKeyOkToDelete]
+ * @param {string} [keyName]
  * @returns {WeakSetStore<K>}
  */
 export const makeWeakSetStoreMethods = (
@@ -67,7 +67,7 @@ export const makeWeakSetStoreMethods = (
  *
  * @template K
  * @param {string} [tag='key'] - tag for debugging
- * @param {StoreOptions=} options
+ * @param {StoreOptions} [options]
  * @returns {WeakSetStore<K>}
  */
 export const makeScalarWeakSetStore = (

--- a/packages/store/src/stores/store-utils.js
+++ b/packages/store/src/stores/store-utils.js
@@ -16,8 +16,8 @@ const { details: X, quote: q } = assert;
  * @param {(k: K) => boolean} checkHas
  * @param {RankCompare} compare
  * @param {(k: K, v?: V) => void} assertOkToAdd
- * @param {((k: K) => void)=} assertOkToDelete
- * @param {string=} keyName
+ * @param {(k: K) => void} [assertOkToDelete]
+ * @param {string} [keyName]
  * @returns {CurrentKeysKit<K,V>}
  */
 export const makeCurrentKeysKit = (

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -117,8 +117,8 @@
  *   intended to eventually be durable has not yet been made durable.  A store
  *   marked as fakeDurable will appear to operate normally but any attempt to
  *   upgrade its containing vat will fail with an error.
- * @property {Pattern=} keyShape
- * @property {Pattern=} valueShape
+ * @property {Pattern} [keyShape]
+ * @property {Pattern} [valueShape]
  */
 
 /**
@@ -441,7 +441,7 @@
  * return that string. Else return `undefined`. For example, a scalar-only
  * encodePassable would return `undefined` for all non-scalar keys.
  * @param {Passable} key
- * @returns {string=}
+ * @returns {string | undefined}
  */
 
 /**

--- a/packages/swingset-liveslots/src/collectionManager.js
+++ b/packages/swingset-liveslots/src/collectionManager.js
@@ -769,7 +769,7 @@ export function makeCollectionManager(
    *
    * @template K,V
    * @param {string} [label='map'] - diagnostic label for the store
-   * @param {StoreOptions=} options
+   * @param {StoreOptions} [options]
    * @returns {MapStore<K,V>}
    */
   function makeScalarBigMapStore(label = 'map', options = {}) {
@@ -814,7 +814,7 @@ export function makeCollectionManager(
    *
    * @template K,V
    * @param {string} [label='weakMap'] - diagnostic label for the store
-   * @param {StoreOptions=} options
+   * @param {StoreOptions} [options]
    * @returns {WeakMapStore<K,V>}
    */
   function makeScalarBigWeakMapStore(label = 'weakMap', options = {}) {
@@ -844,7 +844,7 @@ export function makeCollectionManager(
    *
    * @template K
    * @param {string} [label='set'] - diagnostic label for the store
-   * @param {StoreOptions=} options
+   * @param {StoreOptions} [options]
    * @returns {SetStore<K>}
    */
   function makeScalarBigSetStore(label = 'set', options = {}) {
@@ -872,7 +872,7 @@ export function makeCollectionManager(
    *
    * @template K
    * @param {string} [label='weakSet'] - diagnostic label for the store
-   * @param {StoreOptions=} options
+   * @param {StoreOptions} [options]
    * @returns {WeakSetStore<K>}
    */
   function makeScalarBigWeakSetStore(label = 'weakSet', options = {}) {

--- a/packages/telemetry/src/index.js
+++ b/packages/telemetry/src/index.js
@@ -101,7 +101,7 @@ const getPrometheusMeterProvider = ({
 /**
  * Obtain the telemetry providers used by the `@opentelemetry` packages.
  *
- * @param {Partial<Powers>=} powers
+ * @param {Partial<Powers>} [powers]
  * @returns {{ metricsProvider?: MeterProvider }}
  */
 export const getTelemetryProviders = powers => {

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -8,13 +8,16 @@
 import type {
   InterfaceGuard,
   MapStore,
+  Pattern,
   SetStore,
   StoreOptions,
   WeakMapStore,
   WeakSetStore,
 } from '@agoric/store';
 
-type Baggage = MapStore<string, unknown>;
+export type { Pattern };
+
+export type Baggage = MapStore<string, unknown>;
 
 type Tail<T extends any[]> = T extends [head: any, ...rest: infer Rest]
   ? Rest
@@ -162,7 +165,7 @@ export type VatData = {
 
 // The JSDoc is repeated here and at the function definition so it appears
 // in IDEs where it's used, regardless of type resolution.
-interface PickFacet {
+export interface PickFacet {
   /**
    * When making a multi-facet kind, it's common to pick one facet to
    * expose. E.g.,

--- a/packages/vat-data/src/types.d.ts
+++ b/packages/vat-data/src/types.d.ts
@@ -29,17 +29,19 @@ type MinusContext<
   R = ReturnType<F>, // R: the return type of F
 > = (...args: Tail<P>) => R;
 
-type KindFacet<O> = { [K in keyof O]: MinusContext<O[K]> };
+export type KindFacet<O> = { [K in keyof O]: MinusContext<O[K]> };
 
-type KindFacets<B> = {
+export type KindFacets<B> = {
   [FacetKey in keyof B]: KindFacet<B[FacetKey]>;
 };
 
-type KindContext<S, F> = { state: S; self: KindFacet<F> };
-type MultiKindContext<S, B> = { state: S; facets: KindFacets<B> };
+export type KindContext<S, F> = { state: S; self: KindFacet<F> };
+export type MultiKindContext<S, B> = { state: S; facets: KindFacets<B> };
 
-type PlusContext<C, M> = (c: C, ...args: Parameters<M>) => ReturnType<M>;
-type FunctionsPlusContext<C, O> = { [K in keyof O]: PlusContext<C, O[K]> };
+export type PlusContext<C, M> = (c: C, ...args: Parameters<M>) => ReturnType<M>;
+export type FunctionsPlusContext<C, O> = {
+  [K in keyof O]: PlusContext<C, O[K]>;
+};
 
 declare class DurableKindHandleClass {
   private descriptionTag: string;
@@ -51,7 +53,7 @@ export type DurableKindHandle = DurableKindHandleClass;
  * siblings. Not all options are meaningful in all contexts. See the
  * doc-comments on each option.
  */
-type DefineKindOptions<C> = {
+export type DefineKindOptions<C> = {
   /**
    * If provided, the `finish` function will be called after the instance is
    * made and internally registered, but before it is returned. The finish
@@ -183,7 +185,7 @@ export interface PickFacet {
 }
 
 /** @deprecated Use prepareExoClass instead */
-type PrepareKind = <P, S, F>(
+export type PrepareKind = <P, S, F>(
   baggage: Baggage,
   tag: string,
   init: (...args: P) => S,
@@ -192,7 +194,7 @@ type PrepareKind = <P, S, F>(
 ) => (...args: P) => KindFacet<F>;
 
 /** @deprecated Use prepareExoClassKit instead */
-type PrepareKindMulti = <P, S, B>(
+export type PrepareKindMulti = <P, S, B>(
   baggage: Baggage,
   tag: string,
   init: (...args: P) => S,

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -104,8 +104,8 @@ harden(partialAssign);
  *   intended to eventually be durable has not yet been made durable.  A store
  *   marked as fakeDurable will appear to operate normally but any attempt to
  *   upgrade its containing vat will fail with an error.
- * @property {Pattern=} keyShape
- * @property {Pattern=} valueShape
+ * @property {import('./types').Pattern} [keyShape]
+ * @property {import('./types').Pattern} [valueShape]
  */
 /**
  * Unlike `provideLazy`, `provide` should be called at most once

--- a/packages/vats/src/authorityViz.js
+++ b/packages/vats/src/authorityViz.js
@@ -86,7 +86,7 @@ const manifest2graph = manifest => {
   /**
    * @param {string} src
    * @param {string} dest
-   * @param {string=} style
+   * @param {string} [style]
    */
   const addEdge = (src, dest, style = '') => {
     if (!neighbors.has(src)) {
@@ -99,7 +99,7 @@ const manifest2graph = manifest => {
    * @param {string} src
    * @param {string} ty
    * @param {Record<string, Status> | undefined} item
-   * @param {boolean=} reverse
+   * @param {boolean} [reverse=false]
    */
   const level1 = (src, ty, item, reverse = false) => {
     if (item) {

--- a/packages/wallet/api/src/internal-types.js
+++ b/packages/wallet/api/src/internal-types.js
@@ -29,12 +29,12 @@
 
 /**
  * @typedef {object} Contact
- * @property {string=} depositBoardId
+ * @property {string} [depositBoardId]
  */
 
 /**
  * @typedef {object} DappRecord
- * @property {Promise<void>=} approvalP
+ * @property {Promise<void>} [approvalP]
  * @property {Petname} suggestedPetname
  * @property {Petname} petname
  * @property {boolean} enable

--- a/packages/wallet/api/src/lib-dehydrate.js
+++ b/packages/wallet/api/src/lib-dehydrate.js
@@ -88,7 +88,7 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
   /**
    * @template T
    * @param {string} kind
-   * @param {{useLegacyMap?: boolean}=} legacyOptions
+   * @param {{ useLegacyMap?: boolean }} [legacyOptions]
    * @returns {Mapping<T>}
    */
   const makeMapping = (kind, { useLegacyMap = false } = {}) => {
@@ -350,7 +350,7 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
     /**
      * @template T
      * @param {string} kind
-     * @param {{useLegacyMap?: boolean}=} legacyOptions
+     * @param {{ useLegacyMap?: boolean }} [legacyOptions]
      * @returns {Mapping<T>}
      */
     makeMapping: (kind, legacyOptions = undefined) => {

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -1414,7 +1414,7 @@ export function makeWalletRoot({
 
   /**
    * @param {ERef<Payment>} paymentP
-   * @param {Purse | Petname=} depositTo
+   * @param {Purse | Petname} [depositTo]
    */
   const addPayment = async (paymentP, depositTo = undefined) => {
     // We don't even create the record until we resolve the payment.

--- a/packages/wallet/api/src/types.js
+++ b/packages/wallet/api/src/types.js
@@ -117,7 +117,7 @@
  * @property {Brand} brand
  * @property {string} brandBoardId
  * The board ID for this purse's brand
- * @property {string=} depositBoardId
+ * @property {string} [depositBoardId]
  * The board ID for the deposit-only facet of this purse
  * @property {Petname} brandPetname
  * The petname for this purse's brand

--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -158,7 +158,7 @@ function createHarness(send) {
  * @param {*} exc
  * @param {Expectation} expectation
  * @returns {null | { expected: unknown, actual: unknown }}
- * @typedef {{ instanceOf: Function } | { message: string | RegExp }=} Expectation
+ * @typedef {{ instanceOf: Function } | { message: string | RegExp } | undefined} Expectation
  */
 function checkExpectation(exc, expectation) {
   if (!expectation) return null;
@@ -207,7 +207,7 @@ function makeTester(htest, out) {
 
   /**
    * @param {unknown} value
-   * @param {string=} msg
+   * @param {string} msg
    */
   function truthy(value, msg = 'should be truthy') {
     assert(!!value, msg);
@@ -233,21 +233,21 @@ function makeTester(htest, out) {
     truthy,
     /**
      * @param {unknown} value
-     * @param {string=} message
+     * @param {string} message
      */
     falsy(value, message = 'should be falsy') {
       assert(!value, message);
     },
     /**
      * @param {unknown} value
-     * @param {string=} message
+     * @param {string} message
      */
     true(value, message = 'should be true') {
       assert(value === true, message);
     },
     /**
      * @param {unknown} value
-     * @param {string=} message
+     * @param {string} message
      */
     false(value, message = 'should be false') {
       assert(value === false, message);

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -220,10 +220,10 @@ async function runTestScript(
  * @typedef {object} AvaXSConfig
  * @property {string[]} files - files from args or else ava.files
  * @property {string[]} require - specifiers of modules to run before each test script
- * @property {string[]=} exclude - files containing any of these should be skipped
+ * @property {string[]} [exclude] - files containing any of these should be skipped
  * @property {boolean} debug
  * @property {boolean} verbose
- * @property {string=} titleMatch
+ * @property {string} [titleMatch]
  */
 async function avaConfig(args, options, { glob, readFile }) {
   /**

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -49,7 +49,7 @@ function makeCLI(command, { spawn }) {
   return freeze({
     /**
      * @param {string[]} args
-     * @param {{ cwd?: string }=} opts
+     * @param {{ cwd?: string }} [opts]
      */
     run: (args, opts) => {
       const { cwd = '.' } = opts || {};
@@ -61,7 +61,7 @@ function makeCLI(command, { spawn }) {
     },
     /**
      * @param {string[]} args
-     * @param {{ cwd?: string }=} opts
+     * @param {{ cwd?: string }} [opts]
      */
     pipe: (args, opts) => {
       const { cwd = '.' } = opts || {};

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -92,7 +92,7 @@ export function recordXSnap(options, folderPath, { writeFileSync }) {
 
   /**
    * @param {string} kind
-   * @param {string=} ext
+   * @param {string} [ext]
    */
   const nextFile = (kind, ext = 'dat') => {
     const fn = `${pad5(ix)}-${kind}.${ext}`;

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -50,11 +50,11 @@ function echoCommand(arg) {
  * @property {string} os
  * @property {Spawn} spawn
  * @property {(request:Uint8Array) => Promise<Uint8Array>} [handleCommand]
- * @property {string=} [name]
- * @property {boolean=} [debug]
+ * @property {string} [name]
+ * @property {boolean} [debug]
  * @property {number} [netstringMaxChunkSize] in bytes (must be an integer)
- * @property {number=} [parserBufferSize] in kB (must be an integer)
- * @property {string=} [snapshot]
+ * @property {number} [parserBufferSize] in kB (must be an integer)
+ * @property {string} [snapshot]
  * @property {'ignore' | 'inherit'} [stdout]
  * @property {'ignore' | 'inherit'} [stderr]
  * @property {number} [meteringLimit]

--- a/packages/xsnap/test/message-tools.js
+++ b/packages/xsnap/test/message-tools.js
@@ -13,7 +13,7 @@ export const encode = (encoder => encoder.encode.bind(encoder))(
 
 /**
  * @param {string} url
- * @param {typeof import('fs').promises.readFile=} readFile
+ * @param {typeof import('fs').promises.readFile} [readFile]
  */
 export function loader(url, readFile = undefined) {
   /** @param {string} ref */

--- a/packages/xsnap/test/test-boot-lockdown.js
+++ b/packages/xsnap/test/test-boot-lockdown.js
@@ -17,7 +17,7 @@ const ld = loader(import.meta.url, fs.promises.readFile);
 /**
  * @param {string} name
  * @param {string} script to execute
- * @param {boolean=} savePrinted
+ * @param {boolean} [savePrinted]
  */
 async function bootWorker(name, script, savePrinted = false) {
   const opts = options(io);
@@ -46,7 +46,7 @@ async function bootWorker(name, script, savePrinted = false) {
 
 /**
  * @param {string} name
- * @param {boolean=} savePrinted
+ * @param {boolean} [savePrinted]
  */
 async function bootSESWorker(name, savePrinted = false) {
   const bootScript = await ld.asset('../dist/bundle-ses-boot.umd.js');

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -8,7 +8,7 @@
 
 /**
  * @callback ZCFMakeEmptySeatKit
- * @param {ExitRule=} exit
+ * @param {ExitRule} [exit]
  * @returns {ZcfSeatKit}
  */
 
@@ -134,7 +134,7 @@
 /**
  * @callback ZCFMintMintGains
  * @param {AmountKeywordRecord} gains
- * @param {ZCFSeat=} zcfSeat
+ * @param {ZCFSeat} [zcfSeat]
  * @returns {ZCFSeat}
  */
 
@@ -180,7 +180,7 @@
  * The brand is used for filling in an empty amount if the `keyword`
  * is not present in the allocation
  * @param {Keyword} keyword
- * @param {Brand=} brand
+ * @param {Brand} [brand]
  * @returns {Amount<any>}
  */
 
@@ -243,7 +243,7 @@
  * @typedef {object} ContractStartFnResult
  * @property {PF} publicFacet
  * @property {CF} creatorFacet
- * @property {Promise<Invitation>=} [creatorInvitation]
+ * @property {Promise<Invitation>} [creatorInvitation]
  */
 
 /**

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -120,7 +120,7 @@ export const makeZCFZygote = async (
    * @template {AssetKind} [K='nat']
    * @param {Keyword} keyword
    * @param {K} [assetKind]
-   * @param {AdditionalDisplayInfo=} displayInfo
+   * @param {AdditionalDisplayInfo} [displayInfo]
    * @returns {Promise<ZCFMint<K>>}
    */
   const makeZCFMint = async (

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -57,8 +57,8 @@ export const assertIsRatio = ratio => {
 /**
  * @param {bigint} numerator
  * @param {Brand} numeratorBrand
- * @param {bigint=} denominator The default denominator is 100
- * @param {Brand=} denominatorBrand The default is to reuse the numeratorBrand
+ * @param {bigint} [denominator] The default denominator is 100
+ * @param {Brand} [denominatorBrand] The default is to reuse the numeratorBrand
  * @returns {Ratio}
  */
 export const makeRatio = (

--- a/packages/zoe/src/contractSupport/statistics.js
+++ b/packages/zoe/src/contractSupport/statistics.js
@@ -12,7 +12,7 @@
  * @template T
  * @param {Array<T>} samples the input measurements
  * @param {TypedMath<T>} math
- * @returns {T=} the median (undefined if no samples)
+ * @returns {T | undefined} the median (undefined if no samples)
  */
 export const calculateMedian = (samples, math) => {
   const sorted = samples.sort((a, b) => {

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -5,7 +5,7 @@
  * @property {ZCFSeat} seat
  * @property {AmountKeywordRecord} gains - what the seat will
  * gain as a result of this trade
- * @property {AmountKeywordRecord=} losses - what the seat will
+ * @property {AmountKeywordRecord} losses - what the seat [will]
  * give up as a result of this trade. Losses is optional, but can
  * only be omitted if the keywords for both seats are the same.
  * If losses is not defined, the gains of the other seat is
@@ -61,7 +61,7 @@
  * Given a mapping of keywords to keywords, invert the keys and
  * values. This is used to map the offers made to another contract
  * back to the keywords used in the first contract.
- * @param {KeywordKeywordRecord=} keywordRecord
+ * @param {KeywordKeywordRecord} [keywordRecord]
  * @returns {KeywordKeywordRecord }
  */
 

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -307,7 +307,7 @@ const reverse = (keywordRecord = {}) => {
  * @param {ZCFSeat} fromSeat
  *   The seat in contractA to take the offer payments from.
  *
- * @param {ZCFSeat=} [toSeat=fromSeat]
+ * @param {ZCFSeat} [toSeat=fromSeat]
  *   The seat in contractA to deposit the payout of the offer to.
  *   If `toSeat` is not provided, this defaults to the `fromSeat`.
  *
@@ -320,8 +320,8 @@ const reverse = (keywordRecord = {}) => {
  *   deposited to the `toSeat`.
  *   Any failures of the invitation will be returned by `userSeatPromise.getOfferResult()`.
  *
- * @template {object=} Args Offer args
- * @template {object=} Result Offer result
+ * @template {object} Args Offer args
+ * @template {object} Result Offer result
  */
 export const offerTo = async (
   zcf,

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -117,7 +117,7 @@ const start = zcf => {
      * The inventory can be added in bulk before any quotes are made
      * or can be added immediately before a quote.
      *
-     * @param {IssuerKeywordRecord=} issuerKeywordRecord
+     * @param {IssuerKeywordRecord} [issuerKeywordRecord]
      * @returns {Promise<Payment>}
      */
     makeAddInventoryInvitation: async (issuerKeywordRecord = harden({})) => {

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -120,7 +120,7 @@ const start = async (zcf, privateArgs) => {
 
   /**
    * @typedef {object} OracleRecord
-   * @property {(timestamp: import('@agoric/time/src/types').Timestamp) => Promise<void>=} querier
+   * @property {(timestamp: import('@agoric/time/src/types').Timestamp) => Promise<void>} [querier]
    * @property {Ratio} lastSample
    * @property {OracleKey} oracleKey
    */
@@ -164,7 +164,7 @@ const start = async (zcf, privateArgs) => {
   const makeCreateQuote = ({ overridePrice, timestamp } = {}) =>
     /**
      * @param {PriceQuery} priceQuery
-     * @returns {ERef<PriceQuote>=}
+     * @returns {ERef<PriceQuote> | undefined}
      */
     function createQuote(priceQuery) {
       // Use the current price.
@@ -382,7 +382,7 @@ const start = async (zcf, privateArgs) => {
       E(oracleNotifier).getUpdateSince(updateCount).then(recurse);
 
       // See if we have associated parameters or just a raw value.
-      /** @type {Ratio=} */
+      /** @type {Ratio | undefined} */
       let result;
       switch (typeof value) {
         case 'number':
@@ -529,7 +529,7 @@ const start = async (zcf, privateArgs) => {
       const pushResult = result => {
         // Sample of NaN, 0, or negative numbers get culled in the median
         // calculation.
-        /** @type {Ratio=} */
+        /** @type {Ratio | undefined} */
         let ratio;
         if (typeof result === 'object') {
           ratio = makeRatioFromAmounts(result.numerator, result.denominator);

--- a/packages/zoe/src/contracts/priceAggregatorTypes.js
+++ b/packages/zoe/src/contracts/priceAggregatorTypes.js
@@ -33,7 +33,7 @@
 
 /**
  * @callback OracleCreatorFacetMakeWithdrawInvitation
- * @param {boolean=} total
+ * @param {boolean} [total]
  * @returns {ERef<Invitation>}
  */
 

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -3,7 +3,7 @@
  * @property {ProposalRecord} proposal
  * @property {Allocation} initialAllocation
  * @property {SeatHandle} seatHandle
- * @property {object=} offerArgs
+ * @property {object} [offerArgs]
  */
 
 /**
@@ -45,7 +45,7 @@
 
 /**
  * @callback ZoeSeatAdminExit
- * @param {Completion=} completion
+ * @param {Completion} [completion]
  * @returns {void}
  */
 
@@ -111,7 +111,7 @@
  * @callback ZoeInstanceAdminMakeInvitation
  * @param {InvitationHandle} invitationHandle
  * @param {string} description
- * @param {Record<string, any>=} customProperties
+ * @param {Record<string, any>} [customProperties]
  * @param {Pattern} [proposalShape]
  * @returns {Invitation}
  */
@@ -154,8 +154,8 @@
 /**
  * @callback MakeZoeMint
  * @param {Keyword} keyword
- * @param {AssetKind=} assetKind
- * @param {AdditionalDisplayInfo=} displayInfo
+ * @param {AssetKind} [assetKind]
+ * @param {AdditionalDisplayInfo} [displayInfo]
  * @param {Partial<{elementShape: Pattern}>} [options]
  * @returns {ZoeMint}
  */
@@ -210,13 +210,13 @@
  * @param {ERef<ZoeInstanceAdmin>} zoeInstanceAdmin
  * @param {InstanceRecord} instanceRecordFromZoe
  * @param {IssuerRecords} issuerStorageFromZoe
- * @param {object=} privateArgs
+ * @param {object} [privateArgs]
  * @returns {Promise<ExecuteContractResult>}
  */
 
 /**
  * @callback RestartContract
- * @param {object=} privateArgs
+ * @param {object} [privateArgs]
  * @returns {Promise<ExecuteUpgradeableContractResult>}
  */
 

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -29,7 +29,7 @@ const start = zcf => {
        * (Pretend to) color some pixels.
        *
        * @param {string} color
-       * @param {Amount=} amountToColor
+       * @param {Amount} [amountToColor]
        */
       colorPixels: (color, amountToColor = undefined) => {
         // Throw if the offer is no longer active, i.e. the user has

--- a/packages/zoe/test/unitTests/makeOffer.js
+++ b/packages/zoe/test/unitTests/makeOffer.js
@@ -4,8 +4,8 @@ import { assert } from '@agoric/assert';
 /**
  * @param {ERef<ZoeService>} zoe
  * @param {ZCF} zcf
- * @param {Proposal=} proposal
- * @param {PaymentPKeywordRecord=} payments
+ * @param {Proposal} [proposal]
+ * @param {PaymentPKeywordRecord} [payments]
  * @param {Pattern} [proposalShape]
  * @param {string} [description]
  * @returns {Promise<{zcfSeat: ZCFSeat, userSeat: UserSeat}>}

--- a/packages/zoe/tools/types-ambient.js
+++ b/packages/zoe/tools/types-ambient.js
@@ -23,7 +23,7 @@
  * The service that gave the `timestamp`
  * @property {import('@agoric/time/src/types').Timestamp} timestamp
  * A timestamp according to `timer` for the quote
- * @property {any=} conditions
+ * @property {any} [conditions]
  * Additional conditions for the quote
  */
 
@@ -144,5 +144,5 @@
  * @callback PriceQuery
  * @param {PriceCalculator} calcAmountIn
  * @param {PriceCalculator} calcAmountOut
- * @returns {{ amountIn: Amount<'nat'>, amountOut: Amount<'nat'>, timestamp?: import('@agoric/time/src/types').Timestamp }=}
+ * @returns {{ amountIn: Amount<'nat'>, amountOut: Amount<'nat'>, timestamp?: import('@agoric/time/src/types').Timestamp } | undefined}
  */


### PR DESCRIPTION
## Description

We use JSDoc and TypeScript together. They both support Closure-style syntax but allowing that has been the source of some confusion and inconsistency.

This enables the [jsdoc/check-syntax](https://github.com/gajus/eslint-plugin-jsdoc#user-content-eslint-plugin-jsdoc-rules-check-syntax) rule to enforce that the type expression syntax matches the Jsdoc "mode", which in our case is TypeScript.

### Documentation Considerations

Could be worth documenting this style, but that would risk it getting out of date. Since the style is enforced by eslint, let the eslint config suffice. A developer will learn of the requirement when they need to.

### Testing Considerations

CI