### PR TITLE
feat: complete vaults test config

### DIFF
--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -31,10 +31,10 @@ const PROVISION_COINS = [
   `5000000000000000${CENTRAL_DENOM}`,
   `100provisionpass`,
   `100sendpacketpass`,
-  `1000000000000ibc/atom1234`, // IbcATOM
+  `1000000000000ibc/toyatom`, // IbcATOM
   `1000000000000ibc/toyellie`, // AUSD
-  `1000000000000ibc/usdc1234`,
-  `1000000000000ibc/usdt5678`,
+  `1000000000000ibc/toyusdc`, // USDC
+  `1000000000000ibc/toyollie`, // USDT
 ].join(',');
 const DELEGATE0_COINS = `50000000${STAKING_DENOM}`;
 const SOLO_COINS = `13000000${STAKING_DENOM},500000000${CENTRAL_DENOM}`;

--- a/packages/agoric-cli/test/agops-governance-smoketest.sh
+++ b/packages/agoric-cli/test/agops-governance-smoketest.sh
@@ -72,7 +72,7 @@ agoric wallet send --offer "$SWAP_OFFER" --from "$WALLET" --keyring-backend="tes
 # chain logs should read like:
 # vat: v15: walletFactory: { wallet: Object [Alleged: SmartWallet self] {}, actionCapData: { body: '{"method":"executeOffer","offer":{"id":1663182246304,"invitationSpec":{"source":"contract","instance":{"@qclass":"slot","index":0},"publicInvitationMaker":"makeWantMintedInvitation"},"proposal":{"give":{"In":{"brand":{"@qclass":"slot","index":1},"value":{"@qclass":"bigint","digits":"10002"}}},"want":{"Out":{"brand":{"@qclass":"slot","index":2},"value":{"@qclass":"bigint","digits":"10000"}}}}}}', slots: [ 'board04312', 'board0223', 'board0639' ] } }
 # vat: v15: wallet agoric109q3uc0xt8aavne94rgd6rfeucavrx924e0ztf starting executeOffer 1663182246304
-# vat: v14: bank balance update { address: 'agoric109q3uc0xt8aavne94rgd6rfeucavrx924e0ztf', amount: '1121979996', denom: 'ibc/usdc1234' }
+# vat: v14: bank balance update { address: 'agoric109q3uc0xt8aavne94rgd6rfeucavrx924e0ztf', amount: '1121979996', denom: 'ibc/toyusdc' }
 #  ls: v6: Logging sent error stack (Error#1)
 #  ls: v6: Error#1: not accepting offer with description wantMinted
 #  ls: v6: Error: not accepting offer with description "wantMinted"

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -102,7 +102,7 @@ scenario1-run-chain:
 scenario1-run-client:
 	AG_SOLO_BASEDIR=$$PWD/t9/$(BASE_PORT) $(AG_SOLO) setup --network-config=http://localhost:8001/network-config --webport=$(BASE_PORT)
 
-BOOT_COINS=1000000000000000ubld,500000000000000uist,100provisionpass,100sendpacketpass,1000000000000ibc/usdc1234,1000000000000ibc/atom1234
+BOOT_COINS=1000000000000000ubld,500000000000000uist,100provisionpass,100sendpacketpass,1000000000000ibc/toyusdc,1000000000000ibc/toyatom
 
 scenario2-setup: all scenario2-setup-nobuild
 scenario2-setup-nobuild:
@@ -184,7 +184,7 @@ scenario2-run-client: t1-provision-one-with-powers t1-start-ag-solo
 
 # Provision the ag-solo from an provisionpass-holding address (idempotent).
 AGORIC_POWERS = agoric.ALL_THE_POWERS
-SOLO_COINS = 13000000ubld,12345000000uist,1122000000ibc/usdc1234,3344000000ibc/atom1234
+SOLO_COINS = 13000000ubld,12345000000uist,1122000000ibc/toyusdc,3344000000ibc/toyatom
 COSMOS_RPC_HOST = localhost
 COSMOS_RPC_PORT = 26657
 wait-for-cosmos:
@@ -218,7 +218,7 @@ fund-provision-pool:
 # The agoric1megzy… address is the account of the provisioning pool.
 # The mint limit is 1000 IST and each wallet gets 0.25 IST when
 # provisioned, so make room for 400 accounts with 100 USDC which mints 100 IST.
-	$(MAKE) ACCT_ADDR=agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 FUNDS=1000000000ibc/usdc1234 fund-acct
+	$(MAKE) ACCT_ADDR=agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 FUNDS=1000000000ibc/toyusdc fund-acct
 
 fund-acct:
 	$(AGCH) \

--- a/packages/cosmic-swingset/economy-template.json
+++ b/packages/cosmic-swingset/economy-template.json
@@ -24,7 +24,7 @@
     "args": [
       {
         "interchainAssetOptions": {
-          "denom": "ibc/atom1234",
+          "denom": "ibc/toyatom",
           "decimalPlaces": 4,
           "keyword": "IbcATOM",
           "oracleBrand": "ATOM",
@@ -39,7 +39,7 @@
     "args": [
       {
         "anchorOptions": {
-          "denom": "ibc/usdc1234",
+          "denom": "ibc/toyusdc",
           "decimalPlaces": 6,
           "keyword": "USDC_axl",
           "proposedName": "USD Coin"
@@ -81,7 +81,7 @@
     "args": [
       {
         "anchorOptions": {
-          "denom": "ibc/usdt5678",
+          "denom": "ibc/toyollie",
           "decimalPlaces": 6,
           "keyword": "USDT_grv",
           "proposedName": "Tether USD"

--- a/packages/cosmic-swingset/test/test-provision-smartwallet.js
+++ b/packages/cosmic-swingset/test/test-provision-smartwallet.js
@@ -74,7 +74,7 @@ test.skip('integration test: smart wallet provision', async t => {
     t.log('Fund pool with USDC');
     await walletTool.fundAccount(
       provisionPoolModuleAccount,
-      `${234e6}ibc/usdc1234`,
+      `${234e6}ibc/toyusdc`,
     );
     t.log('Fund user account with some BLD');
     await walletTool.fundAccount(soloAddr, `${123e6}ubld`);

--- a/packages/inter-protocol/scripts/add-collateral-core.js
+++ b/packages/inter-protocol/scripts/add-collateral-core.js
@@ -21,6 +21,7 @@ export const defaultProposalBuilder = async (
     decimalPlaces = 6,
     keyword = 'IbcATOM',
     proposedName = oracleBrand,
+    initialPricePct = undefined,
   } = interchainAssetOptions;
 
   if (!denom) {
@@ -38,6 +39,7 @@ export const defaultProposalBuilder = async (
           denom,
           issuerBoardId,
           decimalPlaces,
+          initialPricePct,
           keyword,
           proposedName,
           oracleBrand,

--- a/packages/inter-protocol/scripts/init-core.js
+++ b/packages/inter-protocol/scripts/init-core.js
@@ -160,6 +160,7 @@ export const defaultProposalBuilder = async (
       anchorDecimalPlaces = '6',
       anchorKeyword = 'AUSD',
       anchorProposedName = anchorKeyword,
+      initialPricePct = undefined,
     } = {},
     econCommitteeOptions: {
       committeeSize: econCommitteeSize = env.ECON_COMMITTEE_SIZE || '3',
@@ -173,6 +174,7 @@ export const defaultProposalBuilder = async (
   const anchorOptions = anchorDenom && {
     denom: anchorDenom,
     decimalPlaces: parseInt(anchorDecimalPlaces, 10),
+    initialPricePct: optBigInt(initialPricePct),
     keyword: anchorKeyword,
     proposedName: anchorProposedName,
   };

--- a/packages/inter-protocol/scripts/init-core.js
+++ b/packages/inter-protocol/scripts/init-core.js
@@ -154,6 +154,7 @@ export const defaultProposalBuilder = async (
     ROLE = env.ROLE || 'chain',
     vaultFactoryControllerAddress = env.VAULT_FACTORY_CONTROLLER_ADDR,
     minInitialPoolLiquidity = env.MIN_INITIAL_POOL_LIQUIDITY,
+    endorsedUi,
     anchorOptions: {
       anchorDenom = env.ANCHOR_DENOM,
       anchorDecimalPlaces = '6',
@@ -188,6 +189,7 @@ export const defaultProposalBuilder = async (
         ROLE,
         vaultFactoryControllerAddress,
         minInitialPoolLiquidity: optBigInt(minInitialPoolLiquidity),
+        endorsedUi,
         anchorOptions,
         econCommitteeOptions,
         installKeys: {

--- a/packages/inter-protocol/scripts/start-local-chain.sh
+++ b/packages/inter-protocol/scripts/start-local-chain.sh
@@ -68,7 +68,7 @@ echo "Funding your wallet account..."
 # After `fund-provision-pool` there is 900 IST remaining for other account funding.
 # A wallet can be tested with 20 BLD for provisioning wallet and 20 USDC for psm trading
 # Also include 1M IbcATOM
-make ACCT_ADDR="$WALLET_BECH32" FUNDS=20000000ubld,20000000ibc/usdc1234,1000000000000ibc/atom1234 fund-acct
+make ACCT_ADDR="$WALLET_BECH32" FUNDS=20000000ubld,20000000ibc/toyusdc,1000000000000ibc/toyatom fund-acct
 agd query bank balances "$WALLET_BECH32" | grep ubld || exit 1
 
 echo "Provisioning your smart wallet..."
@@ -80,5 +80,5 @@ agoric wallet --keyring-backend=test list
 agoric wallet --keyring-backend=test show --from "$WALLET"
 
 echo "Repeating for oracle2 account..."
-make ACCT_ADDR="$WALLET2_BECH32" FUNDS=20000000ubld,20000000ibc/usdc1234 fund-acct
+make ACCT_ADDR="$WALLET2_BECH32" FUNDS=20000000ubld,20000000ibc/toyusdc fund-acct
 agoric wallet --keyring-backend=test provision --spend --account "$WALLET2"

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -275,11 +275,12 @@ export const addAssetToVault = async (
   const vaultFactoryCreator = E.get(vaultFactoryKit).creatorFacet;
   await E(vaultFactoryCreator).addVaultType(interchainIssuer, oracleBrand, {
     debtLimit: AmountMath.make(stable, debtLimitValue),
-    // the rest of these are arbitrary, TBD by gov cttee
-    interestRate: makeRatio(1n, stable),
-    liquidationMargin: makeRatio(1n, stable),
+    // the rest of these are arbitrary but plausible, TBD by gov cttee
+    liquidationPadding: makeRatio(25n, stable),
+    liquidationMargin: makeRatio(150n, stable),
+    loanFee: makeRatio(50n, stable, 10_000n),
     liquidationPenalty: makeRatio(1n, stable),
-    loanFee: makeRatio(1n, stable),
+    interestRate: makeRatio(1n, stable),
   });
 };
 

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -15,6 +15,7 @@ export * from './startPSM.js';
  * @property {string} [proposedName]
  * @property {string} keyword
  * @property {string} oracleBrand
+ * @property {number} [initialPricePct]
  */
 
 /**
@@ -160,7 +161,7 @@ export const registerScaledPriceAuthority = async (
   { consume: { agoricNamesAdmin, zoe, priceAuthorityAdmin, priceAuthority } },
   { options: { interchainAssetOptions } },
 ) => {
-  const { keyword, oracleBrand } = interchainAssetOptions;
+  const { keyword, oracleBrand, initialPricePct } = interchainAssetOptions;
   assert.typeof(keyword, 'string');
   assert.typeof(oracleBrand, 'string');
 
@@ -215,12 +216,16 @@ export const registerScaledPriceAuthority = async (
     10n ** BigInt(decimalPlacesRun),
     runBrand,
   );
+  const initialPrice = initialPricePct
+    ? makeRatio(BigInt(initialPricePct), interchainBrand, 100n, runBrand)
+    : undefined;
 
   const terms = await deeplyFulfilledObject(
     harden({
       sourcePriceAuthority,
       scaleIn,
       scaleOut,
+      initialPrice,
     }),
   );
   const { publicFacet } = E.get(

--- a/packages/inter-protocol/src/proposals/core-proposal.js
+++ b/packages/inter-protocol/src/proposals/core-proposal.js
@@ -223,7 +223,12 @@ export const getManifestForEconCommittee = (
 
 export const getManifestForMain = (
   { restoreRef },
-  { installKeys, vaultFactoryControllerAddress, minInitialPoolLiquidity },
+  {
+    installKeys,
+    vaultFactoryControllerAddress,
+    minInitialPoolLiquidity,
+    endorsedUi,
+  },
 ) => {
   return {
     manifest: SHARED_MAIN_MANIFEST,
@@ -238,6 +243,7 @@ export const getManifestForMain = (
     options: {
       vaultFactoryControllerAddress,
       minInitialPoolLiquidity,
+      endorsedUi,
     },
   };
 };
@@ -259,6 +265,7 @@ export const getManifestForInterProtocol = (
     installKeys,
     vaultFactoryControllerAddress,
     minInitialPoolLiquidity,
+    endorsedUi,
   },
 ) => {
   const econCommitteeManifest = getManifestForEconCommittee(
@@ -271,6 +278,7 @@ export const getManifestForInterProtocol = (
       installKeys,
       vaultFactoryControllerAddress,
       minInitialPoolLiquidity,
+      endorsedUi,
     },
   );
   return {

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -357,6 +357,8 @@ export const setupReserve = async ({
  * @param {EconomyBootstrapPowers} powers
  * @param {object} config
  * @param {LoanTiming} [config.loanParams]
+ * @param {object} [config.options]
+ * @param {string} [config.options.endorsedUi]
  * @param {bigint} minInitialDebt
  */
 export const startVaultFactory = async (
@@ -392,6 +394,7 @@ export const startVaultFactory = async (
       chargingPeriod: SECONDS_PER_HOUR,
       recordingPeriod: SECONDS_PER_DAY,
     },
+    options: { endorsedUi } = {},
   } = {},
   minInitialDebt = 5_000_000n,
 ) => {
@@ -439,6 +442,7 @@ export const startVaultFactory = async (
       minInitialDebt: AmountMath.make(centralBrand, minInitialDebt),
       bootstrapPaymentValue: 0n,
       shortfallInvitationAmount,
+      endorsedUi,
     },
   );
 

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -25,6 +25,7 @@ import {
   LIQUIDATION_INSTALL_KEY,
   LIQUIDATION_TERMS_KEY,
   MIN_INITIAL_DEBT_KEY,
+  ENDORSED_UI_KEY,
 } from './params.js';
 import { prepareVaultDirector } from './vaultDirector.js';
 
@@ -76,6 +77,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     [LIQUIDATION_INSTALL_KEY]: { value: liqInstall },
     [LIQUIDATION_TERMS_KEY]: { value: liqTerms },
     [MIN_INITIAL_DEBT_KEY]: { value: minInitialDebt },
+    [ENDORSED_UI_KEY]: { value: endorsedUi },
   } = zcf.getTerms().governedParams;
   /** a powerful object; can modify the invitation */
   const vaultDirectorParamManager = await makeVaultDirectorParamManager(
@@ -86,6 +88,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     liqTerms,
     minInitialDebt,
     initialShortfallInvitation,
+    endorsedUi,
   );
 
   assertElectorateMatches(

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -33,7 +33,7 @@ const committeeAddress = 'econCommitteeMemberA';
 
 const makeTestSpace = async log => {
   const psmParams = {
-    anchorAssets: [{ denom: 'ibc/usdc1234', keyword: 'AUSD' }],
+    anchorAssets: [{ denom: 'ibc/toyusdc', keyword: 'AUSD' }],
     economicCommitteeAddresses: {
       aMember: committeeAddress,
     },

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -32,7 +32,7 @@ const committeeAddress = 'psmTestAddress';
 
 const makePsmTestSpace = async log => {
   const psmParams = {
-    anchorAssets: [{ denom: 'ibc/usdc1234', keyword: 'AUSD' }],
+    anchorAssets: [{ denom: 'ibc/toyusdc', keyword: 'AUSD' }],
     economicCommitteeAddresses: { aMember: committeeAddress },
     argv: { bootMsg: {} },
   };

--- a/packages/inter-protocol/test/test-proposal-stuff.js
+++ b/packages/inter-protocol/test/test-proposal-stuff.js
@@ -1,0 +1,36 @@
+// @ts-check
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defaultProposalBuilder } from '@agoric/inter-protocol/scripts/init-core.js';
+
+// XXX dynamic import??
+// lifted from packages/vats/decentral-test-vaults-config.json
+const prop2 = {
+  module: '@agoric/inter-protocol/scripts/init-core.js',
+  entrypoint: 'defaultProposalBuilder',
+  args: [
+    {
+      econCommitteeOptions: {
+        committeeSize: 3,
+      },
+      endorsedUi: 'deadbeef',
+      minInitialPoolLiquidity: '0',
+    },
+  ],
+};
+
+test('inter-protocol proposal handles endorsedUi option', async t => {
+  const publishRef = () => {};
+  const install = () => {};
+  const actual = await defaultProposalBuilder(
+    { publishRef, install },
+    ...prop2.args,
+  );
+  t.like(actual, {
+    getManifestCall: {
+      0: 'getManifestForInterProtocol',
+      1: { endorsedUi: 'deadbeef', minInitialPoolLiquidity: 0n },
+    },
+  });
+});

--- a/packages/inter-protocol/test/test-proposal-stuff.js
+++ b/packages/inter-protocol/test/test-proposal-stuff.js
@@ -1,80 +1,107 @@
 // @ts-check
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import * as ambientFs from 'fs';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { defaultProposalBuilder } from '@agoric/inter-protocol/scripts/init-core.js';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { defaultProposalBuilder as collateralBuilder } from '@agoric/inter-protocol/scripts/add-collateral-core.js';
+const configSpecifier = '@agoric/vats/decentral-test-vaults-config.json';
+const noop = harden(() => {});
 
-// XXX dynamic import??
-// lifted from packages/vats/decentral-test-vaults-config.json
-const prop2 = {
-  module: '@agoric/inter-protocol/scripts/init-core.js',
-  entrypoint: 'defaultProposalBuilder',
-  args: [
-    {
-      econCommitteeOptions: {
-        committeeSize: 3,
-      },
-      endorsedUi: 'deadbeef',
-      initialPricePct: 12_34,
-      minInitialPoolLiquidity: '0',
-    },
-  ],
+/** @type {import('ava').TestFn<ReturnType<typeof makeTestContext>>} */
+const test = anyTest;
+
+// #region test setup, isolating ambient authority
+const makeTestContext = t => {
+  /** @param {string} specifier */
+  const loadConfig = async specifier => {
+    const fullPath = await importMetaResolve(specifier, import.meta.url).then(
+      u => new URL(u).pathname,
+    );
+    t.is(typeof fullPath, 'string');
+    const txt = await ambientFs.promises.readFile(fullPath, 'utf-8');
+    t.is(typeof txt, 'string');
+    return JSON.parse(txt);
+  };
+
+  /** @param {{ module: string, entrypoint: string}} proposal */
+  const loadEntryPoint = async proposal => {
+    const { module, entrypoint } = proposal;
+    t.is(typeof module, 'string');
+    t.is(typeof entrypoint, 'string');
+    const modNS = await import(module);
+    t.is(typeof modNS, 'object');
+    const fn = modNS[entrypoint];
+    t.is(typeof fn, 'function');
+    return fn;
+  };
+
+  return { loadConfig, loadEntryPoint };
 };
 
-const collateralProp = {
-  module: '@agoric/inter-protocol/scripts/add-collateral-core.js',
-  entrypoint: 'defaultProposalBuilder',
-  args: [
-    {
-      interchainAssetOptions: {
-        denom: 'ibc/toyatom',
-        decimalPlaces: 4,
-        initialPricePct: 1234,
-        keyword: 'IbcATOM',
-        oracleBrand: 'ATOM',
-        proposedName: 'ATOM',
-      },
-    },
-  ],
-};
+test.before(async t => {
+  t.context = makeTestContext(t);
+});
+// #endregion
 
-test('inter-protocol proposal handles endorsedUi option', async t => {
-  const publishRef = () => {};
-  const install = () => {};
-  const actual = await defaultProposalBuilder(
-    { publishRef, install },
-    ...prop2.args,
+test('inter-protocol vaults proposal handles endorsedUi option', async t => {
+  const proposalModule = '@agoric/inter-protocol/scripts/init-core.js';
+  const endorsedUi =
+    'bafybeidvpbtlgefi3ptuqzr2fwfyfjqfj6onmye63ij7qkrb4yjxekdh3e';
+
+  t.log('loading', configSpecifier);
+  const { coreProposals } = await t.context.loadConfig(configSpecifier);
+
+  const vaultsProposal = coreProposals.find(p => p.module === proposalModule);
+
+  t.log('loading', vaultsProposal.module);
+  const builder = await t.context.loadEntryPoint(vaultsProposal);
+  const actual = await builder(
+    { publishRef: noop, install: noop },
+    ...vaultsProposal.args,
   );
+
   t.like(actual, {
     getManifestCall: {
       0: 'getManifestForInterProtocol',
-      1: { endorsedUi: 'deadbeef', minInitialPoolLiquidity: 0n },
+      1: {
+        endorsedUi,
+        minInitialPoolLiquidity: 0n,
+      },
     },
   });
 });
 
-test('inter-protocol proposal handles initialPricePct option', async t => {
-  const publishRef = () => {};
-  const install = () => {};
-  const actual = await collateralBuilder(
-    { publishRef, install, wrapInstall: undefined },
-    ...collateralProp.args,
+test('inter-protocol ATOM proposal handles initialPricePct option', async t => {
+  const proposalModule =
+    '@agoric/inter-protocol/scripts/add-collateral-core.js';
+  const interchainAssetOptions = {
+    decimalPlaces: 6,
+    denom: 'ibc/toyatom',
+    initialPricePct: 1234,
+    keyword: 'IbcATOM',
+    oracleBrand: 'ATOM',
+    proposedName: 'ATOM',
+  };
+
+  t.log('loading', configSpecifier);
+  const { coreProposals } = await t.context.loadConfig(configSpecifier);
+
+  const collateralProposal = coreProposals.find(
+    ({ module, entrypoint }) =>
+      module === proposalModule && entrypoint === 'defaultProposalBuilder',
   );
-  //   t.deepEqual(actual, {});
+
+  t.log('loading', collateralProposal.module);
+  const builder = await t.context.loadEntryPoint(collateralProposal);
+  const actual = await builder(
+    { publishRef: noop, install: noop, wrapInstall: undefined },
+    ...collateralProposal.args,
+  );
+
   t.like(actual, {
     getManifestCall: {
       0: 'getManifestForAddAssetToVault',
       1: {
-        interchainAssetOptions: {
-          decimalPlaces: 4,
-          denom: 'ibc/toyatom',
-          initialPricePct: 1234,
-          keyword: 'IbcATOM',
-          oracleBrand: 'ATOM',
-          proposedName: 'ATOM',
-        },
+        interchainAssetOptions,
       },
     },
   });

--- a/packages/inter-protocol/test/test-proposal-stuff.js
+++ b/packages/inter-protocol/test/test-proposal-stuff.js
@@ -3,6 +3,8 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { defaultProposalBuilder } from '@agoric/inter-protocol/scripts/init-core.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defaultProposalBuilder as collateralBuilder } from '@agoric/inter-protocol/scripts/add-collateral-core.js';
 
 // XXX dynamic import??
 // lifted from packages/vats/decentral-test-vaults-config.json
@@ -15,7 +17,25 @@ const prop2 = {
         committeeSize: 3,
       },
       endorsedUi: 'deadbeef',
+      initialPricePct: 12_34,
       minInitialPoolLiquidity: '0',
+    },
+  ],
+};
+
+const collateralProp = {
+  module: '@agoric/inter-protocol/scripts/add-collateral-core.js',
+  entrypoint: 'defaultProposalBuilder',
+  args: [
+    {
+      interchainAssetOptions: {
+        denom: 'ibc/toyatom',
+        decimalPlaces: 4,
+        initialPricePct: 1234,
+        keyword: 'IbcATOM',
+        oracleBrand: 'ATOM',
+        proposedName: 'ATOM',
+      },
     },
   ],
 };
@@ -31,6 +51,31 @@ test('inter-protocol proposal handles endorsedUi option', async t => {
     getManifestCall: {
       0: 'getManifestForInterProtocol',
       1: { endorsedUi: 'deadbeef', minInitialPoolLiquidity: 0n },
+    },
+  });
+});
+
+test('inter-protocol proposal handles initialPricePct option', async t => {
+  const publishRef = () => {};
+  const install = () => {};
+  const actual = await collateralBuilder(
+    { publishRef, install, wrapInstall: undefined },
+    ...collateralProp.args,
+  );
+  //   t.deepEqual(actual, {});
+  t.like(actual, {
+    getManifestCall: {
+      0: 'getManifestForAddAssetToVault',
+      1: {
+        interchainAssetOptions: {
+          decimalPlaces: 4,
+          denom: 'ibc/toyatom',
+          initialPricePct: 1234,
+          keyword: 'IbcATOM',
+          oracleBrand: 'ATOM',
+          proposedName: 'ATOM',
+        },
+      },
     },
   });
 });

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -136,6 +136,7 @@ test.before(async t => {
       recordingPeriod: 6n,
     },
     minInitialDebt: 50n,
+    endorsedUi: undefined,
     rates: defaultParamValues(run.brand),
     aethInitialLiquidity: aeth.make(300n),
   };
@@ -303,6 +304,7 @@ const setupServices = async (
     aeth,
     loanTiming,
     minInitialDebt,
+    endorsedUi,
     rates,
     aethInitialLiquidity,
   } = t.context;
@@ -355,7 +357,11 @@ const setupServices = async (
   } = space;
   iProduce.VaultFactory.resolve(t.context.installation.VaultFactory);
   iProduce.liquidate.resolve(t.context.installation.liquidate);
-  await startVaultFactory(space, { loanParams: loanTiming }, minInitialDebt);
+  await startVaultFactory(
+    space,
+    { loanParams: loanTiming, options: { endorsedUi } },
+    minInitialDebt,
+  );
 
   const governorCreatorFacet = E.get(
     consume.vaultFactoryKit,
@@ -2851,6 +2857,7 @@ test('governance publisher', async t => {
     chargingPeriod: 2n,
     recordingPeriod: 10n,
   };
+  t.context.endorsedUi = 'abracadabra';
 
   const services = await setupServices(
     t,
@@ -2874,6 +2881,7 @@ test('governance publisher', async t => {
   t.is(current.MinInitialDebt.type, 'amount');
   t.is(current.ShortfallInvitation.type, 'invitation');
   t.is(current.EndorsedUI.type, 'string');
+  t.is(current.EndorsedUI.value, 'abracadabra');
 
   const managerGovNotifier = makeNotifierFromAsyncIterable(
     E(vfPublic).getSubscription({

--- a/packages/vats/decentral-devnet-config.json
+++ b/packages/vats/decentral-devnet-config.json
@@ -26,7 +26,7 @@
       "args": [
         {
           "anchorOptions": {
-            "denom": "ibc/usdc1234",
+            "denom": "ibc/toyusdc",
             "decimalPlaces": 6,
             "keyword": "USDC_axl",
             "proposedName": "USD Coin"
@@ -68,7 +68,7 @@
       "args": [
         {
           "anchorOptions": {
-            "denom": "ibc/usdt5678",
+            "denom": "ibc/toyollie",
             "decimalPlaces": 6,
             "keyword": "USDT_grv",
             "proposedName": "Tether USD"

--- a/packages/vats/decentral-psm-config.json
+++ b/packages/vats/decentral-psm-config.json
@@ -11,7 +11,7 @@
             "keyword": "USDC_axl",
             "proposedName": "USD Coin",
             "decimalPlaces": 6,
-            "denom": "ibc/usdc1234"
+            "denom": "ibc/toyusdc"
           },
           {
             "keyword": "AUSD",

--- a/packages/vats/decentral-test-vaults-config.json
+++ b/packages/vats/decentral-test-vaults-config.json
@@ -11,6 +11,7 @@
           "econCommitteeOptions": {
             "committeeSize": 3
           },
+          "endorsedUi": "bafybeidvpbtlgefi3ptuqzr2fwfyfjqfj6onmye63ij7qkrb4yjxekdh3e",
           "minInitialPoolLiquidity": "0"
         }
       ]

--- a/packages/vats/decentral-test-vaults-config.json
+++ b/packages/vats/decentral-test-vaults-config.json
@@ -29,7 +29,8 @@
         {
           "interchainAssetOptions": {
             "denom": "ibc/toyatom",
-            "decimalPlaces": 4,
+            "decimalPlaces": 6,
+            "initialPricePct": 1234,
             "keyword": "IbcATOM",
             "oracleBrand": "ATOM",
             "proposedName": "ATOM"

--- a/packages/vats/decentral-test-vaults-config.json
+++ b/packages/vats/decentral-test-vaults-config.json
@@ -27,7 +27,7 @@
       "args": [
         {
           "interchainAssetOptions": {
-            "denom": "ibc/atom1234",
+            "denom": "ibc/toyatom",
             "decimalPlaces": 4,
             "keyword": "IbcATOM",
             "oracleBrand": "ATOM",
@@ -42,7 +42,7 @@
       "args": [
         {
           "anchorOptions": {
-            "denom": "ibc/usdc1234",
+            "denom": "ibc/toyusdc",
             "decimalPlaces": 6,
             "keyword": "USDC_axl",
             "proposedName": "USD Coin"
@@ -84,7 +84,7 @@
       "args": [
         {
           "anchorOptions": {
-            "denom": "ibc/usdt5678",
+            "denom": "ibc/toyollie",
             "decimalPlaces": 6,
             "keyword": "USDT_grv",
             "proposedName": "Tether USD"

--- a/packages/vats/decentral-test-vaults-config.json
+++ b/packages/vats/decentral-test-vaults-config.json
@@ -1,0 +1,204 @@
+{
+  "bootstrap": "bootstrap",
+  "defaultReapInterval": 1000,
+  "coreProposals": [
+    "@agoric/vats/scripts/init-core.js",
+    {
+      "module": "@agoric/inter-protocol/scripts/init-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "econCommitteeOptions": {
+            "committeeSize": 3
+          },
+          "minInitialPoolLiquidity": "0"
+        }
+      ]
+    },
+    "@agoric/pegasus/scripts/init-core.js",
+    {
+      "module": "@agoric/inter-protocol/scripts/add-collateral-core.js",
+      "entrypoint": "psmGovernanceBuilder",
+      "args": []
+    },
+    {
+      "module": "@agoric/inter-protocol/scripts/add-collateral-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "interchainAssetOptions": {
+            "denom": "ibc/atom1234",
+            "decimalPlaces": 4,
+            "keyword": "IbcATOM",
+            "oracleBrand": "ATOM",
+            "proposedName": "ATOM"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/inter-protocol/scripts/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/usdc1234",
+            "decimalPlaces": 6,
+            "keyword": "USDC_axl",
+            "proposedName": "USD Coin"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/inter-protocol/scripts/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/usdc5678",
+            "decimalPlaces": 6,
+            "keyword": "USDC_grv",
+            "proposedName": "USC Coin"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/inter-protocol/scripts/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/usdt1234",
+            "decimalPlaces": 6,
+            "keyword": "USDT_axl",
+            "proposedName": "Tether USD"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/inter-protocol/scripts/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/usdt5678",
+            "decimalPlaces": 6,
+            "keyword": "USDT_grv",
+            "proposedName": "Tether USD"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/inter-protocol/scripts/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/toyellie",
+            "decimalPlaces": 6,
+            "keyword": "AUSD",
+            "proposedName": "Anchor USD"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/inter-protocol/scripts/price-feed-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
+          "oracleAddresses": [
+            "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
+            "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang"
+          ],
+          "IN_BRAND_LOOKUP": [
+            "agoricNames",
+            "oracleBrand",
+            "ATOM"
+          ],
+          "IN_BRAND_DECIMALS": 6,
+          "OUT_BRAND_LOOKUP": [
+            "agoricNames",
+            "oracleBrand",
+            "USD"
+          ],
+          "OUT_BRAND_DECIMALS": 4
+        }
+      ]
+    },
+    {
+      "module": "@agoric/inter-protocol/scripts/invite-committee-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "voterAddresses": {
+            "gov1": "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
+            "gov2": "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang",
+            "gov3": "agoric1w8wktaur4zf8qmmtn3n7x3r0jhsjkjntcm3u6h"
+          } 
+        }
+      ]
+    }
+  ],
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "@agoric/vats/src/core/boot.js",
+      "creationOptions": {
+        "critical": true
+      }
+    }
+  },
+  "bundles": {
+    "centralSupply": {
+      "sourceSpec": "@agoric/vats/src/centralSupply.js"
+    },
+    "mintHolder": {
+      "sourceSpec": "@agoric/vats/src/mintHolder.js"
+    },
+    "zcf": {
+      "sourceSpec": "@agoric/zoe/contractFacet.js"
+    },
+    "bank": {
+      "sourceSpec": "@agoric/vats/src/vat-bank.js"
+    },
+    "board": {
+      "sourceSpec": "@agoric/vats/src/vat-board.js"
+    },
+    "chainStorage": {
+      "sourceSpec": "@agoric/vats/src/vat-chainStorage.js"
+    },
+    "ibc": {
+      "sourceSpec": "@agoric/vats/src/vat-ibc.js"
+    },
+    "mints": {
+      "sourceSpec": "@agoric/vats/src/vat-mints.js"
+    },
+    "network": {
+      "sourceSpec": "@agoric/vats/src/vat-network.js"
+    },
+    "priceAuthority": {
+      "sourceSpec": "@agoric/vats/src/vat-priceAuthority.js"
+    },
+    "provisionPool": {
+      "sourceSpec": "@agoric/vats/src/provisionPool.js"
+    },
+    "provisioning": {
+      "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
+    },
+    "sharing": {
+      "sourceSpec": "@agoric/vats/src/vat-sharing.js"
+    },
+    "walletFactory": {
+      "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
+    },
+    "zoe": {
+      "sourceSpec": "@agoric/vats/src/vat-zoe.js"
+    }
+  },
+  "defaultManagerType": "xs-worker"
+}

--- a/packages/vats/test/test-boot-config.js
+++ b/packages/vats/test/test-boot-config.js
@@ -8,16 +8,44 @@ import { mustMatch } from '@agoric/store';
 import { shape as ssShape } from '@agoric/swingset-vat';
 import { ParametersShape as BootParametersShape } from '../src/core/boot-psm.js';
 
-const pathname = new URL(import.meta.url).pathname;
-const dirname = path.dirname(pathname);
-const asset = (...ps) =>
-  fsPromises.readFile(path.join(dirname, ...ps), 'utf-8');
+const CONFIG_FILES = [
+  'decentral-core-config.json',
+  'decentral-demo-config.json',
+  'decentral-devnet-config.json',
+  'decentral-main-psm-config.json',
+  'decentral-psm-config.json',
+  'decentral-test-psm-config.json',
+  'decentral-test-vaults-config.json',
+];
 
-test('PSM config file is valid', async t => {
-  const txt = await asset('..', 'decentral-psm-config.json');
-  const config = harden(JSON.parse(txt));
-  t.notThrows(() => mustMatch(config, ssShape.SwingSetConfig));
-  t.notThrows(() =>
-    mustMatch(config.vats.bootstrap.parameters, BootParametersShape),
+/**
+ * @typedef {{
+ *   asset: (...ps: string[]) => Promise<string>,
+ * }} Context
+ * @typedef {import('ava').ExecutionContext<Context> } TestCtx
+ */
+
+// NOTE: confine ambient authority to test.before
+test.before(t => {
+  const pathname = new URL(import.meta.url).pathname;
+  const dirname = path.dirname(pathname);
+  const asset = (...ps) =>
+    fsPromises.readFile(path.join(dirname, ...ps), 'utf-8');
+  t.context = { asset };
+});
+
+test('Bootstrap SwingSet config file syntax', /** @param {TestCtx} t */ async t => {
+  const { asset } = t.context;
+
+  await Promise.all(
+    CONFIG_FILES.map(async f => {
+      const txt = await asset('..', f);
+      const config = harden(JSON.parse(txt));
+      await t.notThrows(() => mustMatch(config, ssShape.SwingSetConfig), f);
+      const parameters = config?.vats?.bootstrap?.parameters;
+      t.log('syntax check:', f, parameters ? 'and parameters' : '');
+      (await parameters) &&
+        t.notThrows(() => mustMatch(parameters, BootParametersShape), f);
+    }),
   );
 });

--- a/packages/zoe/src/contractSupport/priceAuthorityTransform.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityTransform.js
@@ -14,6 +14,7 @@ import { makeNotifier } from '@agoric/notifier';
  * @param {Brand<'nat'>} opts.sourceBrandOut
  * @param {Brand<'nat'>} [opts.actualBrandIn]
  * @param {Brand<'nat'>} [opts.actualBrandOut]
+ * @param {Ratio} [opts.initialPrice]
  * @param {(amountIn: Amount<'nat'>) => Amount<'nat'>} [opts.makeSourceAmountIn]
  * @param {(amountOut: Amount<'nat'>) => Amount<'nat'>} [opts.makeSourceAmountOut]
  * @param {(sourceAmountIn: Amount<'nat'>) => Amount<'nat'>} [opts.transformSourceAmountIn]
@@ -26,11 +27,17 @@ export const makePriceAuthorityTransform = async ({
   sourceBrandOut,
   actualBrandIn = sourceBrandIn,
   actualBrandOut = sourceBrandOut,
+  initialPrice,
   makeSourceAmountIn = x => x,
   makeSourceAmountOut = x => x,
   transformSourceAmountIn = x => x,
   transformSourceAmountOut = x => x,
 }) => {
+  if (initialPrice) {
+    assert.equal(initialPrice.numerator.brand, actualBrandIn);
+    assert.equal(initialPrice.denominator.brand, actualBrandOut);
+  }
+
   const quoteIssuer = E(quoteMint).getIssuer();
   const quoteBrand = await E(quoteIssuer).getBrand();
 
@@ -51,6 +58,27 @@ export const makePriceAuthorityTransform = async ({
       actualBrandOut,
       X`Desired brandOut ${brandOut} must match ${actualBrandOut}`,
     );
+  };
+
+  const oneQuote = async ({
+    amountIn,
+    amountOut,
+    timer = undefined,
+    timestamp = undefined,
+  }) => {
+    timer = await (timer ||
+      E(sourcePriceAuthority).getTimerService(sourceBrandIn, sourceBrandOut));
+    timestamp = await (timestamp || E(timer).getCurrentTimestamp());
+
+    const quoteAmount = {
+      brand: quoteBrand,
+      value: [{ amountIn, amountOut, timer, timestamp }],
+    };
+    const quotePayment = await E(quoteMint).mintPayment({
+      brand: quoteBrand,
+      value: [quoteAmount],
+    });
+    return harden({ quoteAmount, quotePayment });
   };
 
   /**
@@ -81,18 +109,16 @@ export const makePriceAuthorityTransform = async ({
       timer,
       timestamp,
     } = sourceQuoteValue[0];
+
     const amountIn = transformSourceAmountIn(sourceAmountIn);
     const amountOut = transformSourceAmountOut(sourceAmountOut);
 
-    const quoteAmount = {
-      brand: quoteBrand,
-      value: [{ amountIn, amountOut, timer, timestamp }],
-    };
-    const quotePayment = await E(quoteMint).mintPayment({
-      brand: quoteBrand,
-      value: [quoteAmount],
+    return oneQuote({
+      amountIn,
+      amountOut,
+      timer,
+      timestamp,
     });
-    return harden({ quoteAmount, quotePayment });
   };
 
   /**
@@ -183,9 +209,23 @@ export const makePriceAuthorityTransform = async ({
         sourceBrandOut,
       );
 
+      let initialQuote;
+      let pastInitialQuote = false;
+
       // Wrap our underlying notifier with scaled quotes.
       const scaledBaseNotifier = harden({
-        async getUpdateSince(updateCount = undefined) {
+        async getUpdateSince(updateCount = -1n) {
+          if (initialPrice && updateCount === -1n && !pastInitialQuote) {
+            if (!initialQuote) {
+              initialQuote = oneQuote({
+                amountIn: initialPrice.numerator,
+                amountOut: initialPrice.denominator,
+              }).then(value => harden({ value, updateCount: 0n }));
+            }
+            return initialQuote;
+          }
+          pastInitialQuote = true;
+
           // We use the same updateCount as our underlying notifier.
           const record = await E(notifier).getUpdateSince(updateCount);
 

--- a/packages/zoe/src/contractSupport/priceAuthorityTransform.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityTransform.js
@@ -60,12 +60,14 @@ export const makePriceAuthorityTransform = async ({
     );
   };
 
-  const oneQuote = async ({
-    amountIn,
-    amountOut,
-    timer = undefined,
-    timestamp = undefined,
-  }) => {
+  /**
+   * @param {Amount<"nat">} amountIn
+   * @param {Amount<"nat">} amountOut
+   * @param {object} [opts]
+   * @param {*} [opts.timer]
+   * @param {unknown} [opts.timestamp]
+   */
+  const oneQuote = async (amountIn, amountOut, { timer, timestamp } = {}) => {
     timer = await (timer ||
       E(sourcePriceAuthority).getTimerService(sourceBrandIn, sourceBrandOut));
     timestamp = await (timestamp || E(timer).getCurrentTimestamp());
@@ -113,9 +115,7 @@ export const makePriceAuthorityTransform = async ({
     const amountIn = transformSourceAmountIn(sourceAmountIn);
     const amountOut = transformSourceAmountOut(sourceAmountOut);
 
-    return oneQuote({
-      amountIn,
-      amountOut,
+    return oneQuote(amountIn, amountOut, {
       timer,
       timestamp,
     });
@@ -217,10 +217,10 @@ export const makePriceAuthorityTransform = async ({
         async getUpdateSince(updateCount = -1n) {
           if (initialPrice && updateCount === -1n && !pastInitialQuote) {
             if (!initialQuote) {
-              initialQuote = oneQuote({
-                amountIn: initialPrice.numerator,
-                amountOut: initialPrice.denominator,
-              }).then(value => harden({ value, updateCount: 0n }));
+              initialQuote = oneQuote(
+                initialPrice.numerator,
+                initialPrice.denominator,
+              ).then(value => harden({ value, updateCount: 0n }));
             }
             return initialQuote;
           }

--- a/packages/zoe/src/contracts/scaledPriceAuthority.js
+++ b/packages/zoe/src/contracts/scaledPriceAuthority.js
@@ -14,6 +14,7 @@ import { makePriceAuthorityTransform } from '../contractSupport/priceAuthorityTr
  * @property {ERef<PriceAuthority>} sourcePriceAuthority
  * @property {Ratio} scaleIn - sourceAmountIn:targetAmountIn
  * @property {Ratio} scaleOut - sourceAmountOut:targetAmountOut
+ * @property {Ratio} [initialPrice] - targetAmountIn:targetAmountOut
  */
 
 /**
@@ -28,7 +29,8 @@ export const start = async (
   zcf,
   { quoteMint = makeIssuerKit('quote', AssetKind.SET).mint } = {},
 ) => {
-  const { sourcePriceAuthority, scaleIn, scaleOut } = zcf.getTerms();
+  const { sourcePriceAuthority, scaleIn, scaleOut, initialPrice } =
+    zcf.getTerms();
 
   const {
     numerator: { brand: sourceBrandIn },
@@ -46,6 +48,7 @@ export const start = async (
     sourceBrandOut,
     actualBrandIn,
     actualBrandOut,
+    initialPrice,
     // It's hard to make a good guess as to the best rounding strategy for this
     // transformation, but we make sure that the amount in is generous and the
     // amount out is conservative.


### PR DESCRIPTION
closes: #6957

## Description

_suggest review by commit_

 - plausible defaults for addAssetToVault
 - plausible initial ATOM price for vaults test config
 - feat(vaults): set endorsedUi default from chain config
 - fix: align testnet -> agoric start tooling
 - bootstrap config for vaults testing

### Security Considerations

In production, we should take care that prices come from oracle operators only; we should not use the initial ATOM price option.

### Scaling Considerations

operationally, it facilitates starting test networks

### Documentation Considerations

Documentation on `coreProposals` and their args is lacking. This PR includes some increase in documentation in the form of gross syntax checks, but not the fine details.

### Testing Considerations

 - [x] tested with `agoric start` (detail below)
 - [x] limited unit tests for initial ATOM price, endorsedUi
 - [x] tested/testing with instagoric (see also #6956)
 - [x] light integration testing with some of the smoketest scripts


```console
$ cd /tmp
/tmp$ agoric init x1
/tmp$ cd x1
/tmp/x1$ CHAIN_BOOTSTRAP_VAT_CONFIG=@agoric/vats/decentral-test-vaults-config.json agoric start local-chain --reset -v
...
2023-02-09T02:33:25.836Z block-manager: block 173 begin
8:33PM INF executed block height=173 module=state num_invalid_txs=0 num_valid_txs=0
2023-02-09T02:33:25.839Z block-manager: block 173 commit
```

