### PR TITLE
feat(vat-data): prepare StoreReadonlyView

### DIFF
--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -138,7 +138,16 @@
 
 /**
  * @template {Key & object} [K=Key]
+ * @typedef {object} WeakSetStoreReadonlyView
+ * @property {(key: K) => boolean} has
+ * Check if a key exists. The key can be any JavaScript value, though the
+ * answer will always be false for keys that cannot be found in this store.
+ */
+
+/**
+ * @template K
  * @typedef {object} WeakSetStore
+ * Extends WeakSetStoreReadonlyView with mutation methods
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
  * answer will always be false for keys that cannot be found in this store.
@@ -154,7 +163,22 @@
 
 /**
  * @template {Key} [K=Key]
+ * @typedef {object} SetStoreReadonlyView
+ * Extends WeakSetStoreReadonlyView with enumeration methods
+ * @property {(key: K) => boolean} has
+ * Check if a key exists. The key can be any JavaScript value, though the
+ * answer will always be false for keys that cannot be found in this store.
+ * @property {(keyPatt?: Pattern) => Iterable<K>} keys
+ * @property {(keyPatt?: Pattern) => Iterable<K>} values
+ * @property {(keyPatt?: Pattern) => CopySet<K>} snapshot
+ * @property {(keyPatt?: Pattern) => number} getSize
+ */
+
+/**
+ * @template K
  * @typedef {object} SetStore
+ * Extends union of WeakSetStore and SetStoreReadonlyView with mutating
+ * enumeration methods
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
  * answer will always be false for keys that cannot be found in this store.
@@ -176,7 +200,17 @@
 /**
  * @template {Key & object} [K=Key]
  * @template {Passable} [V=Passable]
+ * @typedef {object} WeakMapStoreReadonlyView
+ * @property {(key: K) => boolean} has
+ * Check if a key exists. The key can be any JavaScript value, though the
+ * answer will always be false for keys that cannot be found in this store.
+ * @property {(key: K) => V} get
+ */
+
+/**
+ * @template K,V
  * @typedef {object} WeakMapStore
+ * Extends WeakMapStoreReadonlyView with mutation methods
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
  * answer will always be false for keys that cannot be found in this store.
@@ -196,7 +230,28 @@
 /**
  * @template {Key} [K=Key]
  * @template {Passable} [V=Passable]
+ * @typedef {object} MapStoreReadonlyView
+ * Extends WeakSetStoreReadonlyView with enumeration methods
+ * @property {(key: K) => boolean} has
+ * Check if a key exists. The key can be any JavaScript value, though the
+ * answer will always be false for keys that cannot be found in this map
+ * @property {(key: K) => V} get
+ * Return a value for the key. Throws if not found.
+ * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => Iterable<K>} keys
+ * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => Iterable<V>} values
+ * @property {(
+ *   keyPatt?: Pattern,
+ *   valuePatt?: Pattern
+ * ) => Iterable<[K,V]>} entries
+ * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => CopyMap<K,V>} snapshot
+ * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => number} getSize
+ */
+
+/**
+ * @template K,V
  * @typedef {object} MapStore
+ * Extends union of WeakMapStore and MapStoreReadonlyView with mutating
+ * enumeration methods
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
  * answer will always be false for keys that cannot be found in this map

--- a/packages/vat-data/src/prepare-store-readonly-view.js
+++ b/packages/vat-data/src/prepare-store-readonly-view.js
@@ -1,0 +1,54 @@
+import { objectMap } from '@agoric/internal';
+import { M } from '@agoric/store';
+import { prepareExoClass } from './exo-utils.js';
+
+const IterableShape = M.remotable('Iterable');
+
+const MapStoreReadonlyViewI = M.interface('MapStoreReadonlyView', {
+  has: M.call(M.key()).returns(M.boolean()),
+  get: M.call(M.key()).returns(M.any()),
+  keys: M.call().optional(M.pattern(), M.pattern()).returns(IterableShape),
+  values: M.call().optional(M.pattern(), M.pattern()).returns(IterableShape),
+  entries: M.call().optional(M.pattern(), M.pattern()).returns(IterableShape),
+  snapshot: M.call().optional(M.pattern(), M.pattern()).returns(M.map()),
+  getSize: M.call().optional(M.pattern(), M.pattern()).returns(M.number),
+});
+
+const SetStoreReadonlyViewI = M.interface('SetStoreReadonlyView', {
+  has: M.call(M.key()).returns(M.boolean()),
+  keys: M.call().optional(M.pattern()).returns(IterableShape),
+  values: M.call().optional(M.pattern()).returns(IterableShape),
+  entries: M.call().optional(M.pattern()).returns(IterableShape),
+  snapshot: M.call().optional(M.pattern()).returns(M.map()),
+  getSize: M.call().optional(M.pattern()).returns(M.number),
+});
+
+const methodsFor = interfaceGuard =>
+  objectMap(
+    interfaceGuard.methodGuards,
+    (_, key) =>
+      ({
+        [key](...args) {
+          const {
+            state: { target },
+          } = this;
+          return target[key](...args);
+        },
+      }[key]),
+  );
+
+const prepareStoneCaster = (baggage, label, interfaceGuard, options = {}) =>
+  prepareExoClass(
+    baggage,
+    label,
+    interfaceGuard,
+    target => ({ target }),
+    methodsFor(interfaceGuard),
+    options,
+  );
+
+export const prepareMapStoreReadonlyView = baggage =>
+  prepareStoneCaster(baggage, 'MapStoreReadonlyView', MapStoreReadonlyViewI);
+
+export const prepareSetStoreReadonlyView = baggage =>
+  prepareStoneCaster(baggage, 'SetStoreReadonlyView', SetStoreReadonlyViewI);

--- a/packages/vat-data/test/test-prepare-store-readonly-view.js
+++ b/packages/vat-data/test/test-prepare-store-readonly-view.js
@@ -1,0 +1,58 @@
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import {
+  prepareMapStoreReadonlyView,
+  prepareSetStoreReadonlyView,
+} from '../src/prepare-store-readonly-view.js';
+import {
+  makeScalarBigMapStore,
+  provideDurableMapStore,
+  provideDurableSetStore,
+} from '../src/vat-data-bindings.js';
+
+test('prepare-store-readonly-view', t => {
+  const baggage = makeScalarBigMapStore('Baggage');
+  // These are "prepare" because, with real baggage,
+  // they must occur in the first crank
+  const makeMapStoreReadonlyView = prepareMapStoreReadonlyView(baggage);
+  const makeSetStoreReadonlyView = prepareSetStoreReadonlyView(baggage);
+  // Everything else could occur in later cranks.
+
+  const m1 = provideDurableMapStore(baggage, 'm1');
+  const m2 = provideDurableMapStore(baggage, 'm2');
+  const s1 = provideDurableSetStore(baggage, 's1');
+
+  const m1ro = makeMapStoreReadonlyView(m1);
+  const s1ro = makeSetStoreReadonlyView(s1);
+
+  const keyX = 'x';
+  const valY = 'y';
+  const valZ = 'z';
+
+  t.false(m1.has(keyX));
+  t.false(m1ro.has(keyX));
+  t.false(s1.has(keyX));
+  t.false(s1ro.has(keyX));
+
+  t.throws(() => m1ro.init(keyX, valY), {
+    message: 'm1ro.init is not a function',
+  });
+  t.throws(() => s1ro.add(keyX), {
+    message: 's1ro.add is not a function',
+  });
+
+  m1.init(keyX, valY);
+  m2.init(keyX, valZ);
+  s1.add(keyX);
+
+  t.is(m1.get(keyX), valY);
+  t.is(m2.get(keyX), valZ);
+  t.true(s1.has(keyX));
+
+  t.is(m1ro.get(keyX), valY);
+  t.true(s1ro.has(keyX));
+
+  m1.set(keyX, valZ);
+  t.is(m1ro.get(keyX), valZ);
+  s1.delete(keyX);
+  t.false(s1ro.has(keyX));
+});


### PR DESCRIPTION
Minimal impact addition of upgradable ReadonlyViews for MapStore and SetStore.

Motivated by an identified need in agoric-sdk.

Could be a step towards https://github.com/tc39/proposal-readonly-collections .

Current limitations:

   * Functions to be applied to stores, rather than instance methods of the store.
   * prepare-only. No heap or virtual variant. (Revisit if https://github.com/Agoric/agoric-sdk/pull/6883 happens).
   * No ReadonlyView of WeakMapStore and WeakSetStore
   * Only defining interfaceGuards for the ReadonlyView cases. Still no interfaceGuards for MapStore and SetStore themselves
   * Not exporting these new interfaceGuards, so no one outside the module could currently depend on them anyway.
   * In previous work, using a type to create a restricting wrapper of a target has been called a "stone cast" (attn @FUDCo ). Realized that such a tool would be ideal here, so defined one: provideStoneCaster
   * Not exporting provideStoneCaster at this time either, as this PR is not trying to support other uses of it yet.
   * Mixing in the vat-data package implementations that do belong there, but some that belong instead to `@agoric/store`. That is, that belong in `@agoric/store` once we're willing to export them.
