### PR TITLE
feat(vstorage): Disambiguate empty strings and deletions

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -759,6 +759,8 @@ func NewAgoricApp(
 
 func upgrade10Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgradetypes.Plan, module.VersionMap) (module.VersionMap, error) {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVm module.VersionMap) (module.VersionMap, error) {
+		// TODO: In next upgrade handler (bulldozer), run:
+		// app.VstorageKeeper.MigrateNoDataPlaceholders(ctx)
 		return fromVm, nil
 	}
 }

--- a/golang/cosmos/x/swingset/keeper/keeper.go
+++ b/golang/cosmos/x/swingset/keeper/keeper.go
@@ -100,21 +100,23 @@ func (k Keeper) PushAction(ctx sdk.Context, action vm.Jsonable) error {
 
 	// JS uses IEEE 754 floats so avoid overflowing integers
 	if tail == MaxUint53 {
-		return errors.New("actionQueue overflow")
+		return errors.New(StoragePathActionQueue + " overflow")
 	}
 
 	// Set the vstorage corresponding to the queue entry for the current tail.
-	k.vstorageKeeper.SetStorage(ctx, vstoragetypes.NewStorageEntry(fmt.Sprintf("actionQueue.%d", tail), string(bz)))
+	path := StoragePathActionQueue + "." + strconv.FormatUint(tail, 10)
+	k.vstorageKeeper.SetStorage(ctx, vstoragetypes.NewStorageEntry(path, string(bz)))
 
 	// Update the tail to point to the next available entry.
-	k.vstorageKeeper.SetStorage(ctx, vstoragetypes.NewStorageEntry("actionQueue.tail", fmt.Sprintf("%d", tail+1)))
+	path = StoragePathActionQueue + ".tail"
+	k.vstorageKeeper.SetStorage(ctx, vstoragetypes.NewStorageEntry(path, strconv.FormatUint(tail+1, 10)))
 	return nil
 }
 
 func (k Keeper) actionQueueIndex(ctx sdk.Context, name string) (uint64, error) {
 	index := uint64(0)
 	var err error
-	indexEntry := k.vstorageKeeper.GetEntry(ctx, "actionQueue."+name)
+	indexEntry := k.vstorageKeeper.GetEntry(ctx, StoragePathActionQueue+"."+name)
 	if indexEntry.HasData() {
 		index, err = strconv.ParseUint(indexEntry.StringValue(), 10, 64)
 	}

--- a/golang/cosmos/x/swingset/keeper/querier.go
+++ b/golang/cosmos/x/swingset/keeper/querier.go
@@ -79,12 +79,12 @@ func queryMailbox(ctx sdk.Context, path []string, req abci.RequestQuery, keeper 
 
 // nolint: unparam
 func legacyQueryStorage(ctx sdk.Context, path string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) (res []byte, err error) {
-	value := keeper.vstorageKeeper.GetData(ctx, path)
-	if value == "" {
+	entry := keeper.vstorageKeeper.GetEntry(ctx, path)
+	if !entry.HasData() {
 		return []byte{}, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "could not get swingset %+v", path)
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(legacyQuerierCdc, vstoragetypes.Data{Value: value})
+	bz, err2 := codec.MarshalJSONIndent(legacyQuerierCdc, vstoragetypes.Data{Value: entry.StringValue()})
 	if err2 != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err2.Error())
 	}

--- a/golang/cosmos/x/vstorage/keeper/grpc_query.go
+++ b/golang/cosmos/x/vstorage/keeper/grpc_query.go
@@ -23,10 +23,10 @@ func (k Querier) Data(c context.Context, req *types.QueryDataRequest) (*types.Qu
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 
-	value := k.GetData(ctx, req.Path)
+	entry := k.GetEntry(ctx, req.Path)
 
 	return &types.QueryDataResponse{
-		Value: value,
+		Value: entry.StringValue(),
 	}, nil
 }
 

--- a/golang/cosmos/x/vstorage/keeper/keeper.go
+++ b/golang/cosmos/x/vstorage/keeper/keeper.go
@@ -346,3 +346,7 @@ func (k Keeper) GetStoreName() string {
 func (k Keeper) GetDataPrefix() []byte {
 	return types.EncodedDataPrefix
 }
+
+func (k Keeper) GetNoDataValue() []byte {
+	return types.EncodedNoDataValue
+}

--- a/golang/cosmos/x/vstorage/keeper/keeper.go
+++ b/golang/cosmos/x/vstorage/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -32,7 +33,7 @@ type ProposedChange struct {
 }
 
 type ChangeManager interface {
-	Track(ctx sdk.Context, k Keeper, path, value string, isLegacy bool)
+	Track(ctx sdk.Context, k Keeper, entry types.StorageEntry, isLegacy bool)
 	EmitEvents(ctx sdk.Context, k Keeper)
 	Rollback(ctx sdk.Context)
 }
@@ -44,6 +45,14 @@ type BatchingChangeManager struct {
 
 var _ ChangeManager = (*BatchingChangeManager)(nil)
 
+// TODO: Use bytes.CutPrefix once we can rely upon go >= 1.20.
+func cutPrefix(s, prefix []byte) (after []byte, found bool) {
+	if !bytes.HasPrefix(s, prefix) {
+		return s, false
+	}
+	return s[len(prefix):], true
+}
+
 // Keeper maintains the link to data storage and exposes getter/setter methods
 // for the various parts of the state machine
 type Keeper struct {
@@ -51,7 +60,11 @@ type Keeper struct {
 	storeKey      sdk.StoreKey
 }
 
-func (bcm *BatchingChangeManager) Track(ctx sdk.Context, k Keeper, path, value string, isLegacy bool) {
+func (bcm *BatchingChangeManager) Track(ctx sdk.Context, k Keeper, entry types.StorageEntry, isLegacy bool) {
+	path := entry.Path()
+	// TODO: differentiate between deletion and setting empty string?
+	// Using empty string for deletion for backwards compatibility
+	value := entry.StringValue()
 	if change, ok := bcm.changes[path]; ok {
 		change.NewValue = value
 		if isLegacy {
@@ -62,7 +75,7 @@ func (bcm *BatchingChangeManager) Track(ctx sdk.Context, k Keeper, path, value s
 	bcm.changes[path] = &ProposedChange{
 		Path:               path,
 		NewValue:           value,
-		ValueFromLastBlock: k.GetData(ctx, path),
+		ValueFromLastBlock: k.GetEntry(ctx, path).StringValue(),
 		LegacyEvents:       isLegacy,
 	}
 }
@@ -114,12 +127,19 @@ func (k Keeper) ExportStorage(ctx sdk.Context) []*types.DataEntry {
 	exported := []*types.DataEntry{}
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
-		path := types.EncodedKeyToPath(iterator.Key())
-		value := string(bytes.TrimPrefix(iterator.Value(), types.EncodedDataPrefix))
-		if len(value) == 0 {
+		rawValue := iterator.Value()
+		if len(rawValue) == 0 {
 			continue
 		}
-		entry := types.DataEntry{Path: path, Value: value}
+		if bytes.Equal(rawValue, types.EncodedNoDataValue) {
+			continue
+		}
+		path := types.EncodedKeyToPath(iterator.Key())
+		value, hasPrefix := cutPrefix(rawValue, types.EncodedDataPrefix)
+		if !hasPrefix {
+			panic(fmt.Errorf("value at path %q starts with unexpected prefix", path))
+		}
+		entry := types.DataEntry{Path: path, Value: string(value)}
 		exported = append(exported, &entry)
 	}
 	return exported
@@ -129,7 +149,7 @@ func (k Keeper) ImportStorage(ctx sdk.Context, entries []*types.DataEntry) {
 	for _, entry := range entries {
 		// This set does the bookkeeping for us in case the entries aren't a
 		// complete tree.
-		k.SetStorage(ctx, entry.Path, entry.Value)
+		k.SetStorage(ctx, types.NewStorageEntry(entry.Path, entry.Value))
 	}
 }
 
@@ -156,14 +176,23 @@ func (k Keeper) EmitChange(ctx sdk.Context, change *ProposedChange) {
 	)
 }
 
-// GetData gets generic storage.  The default value is an empty string.
-func (k Keeper) GetData(ctx sdk.Context, path string) string {
-	//fmt.Printf("GetData(%s)\n", path);
+// GetEntry gets generic storage.  The default value is an empty string.
+func (k Keeper) GetEntry(ctx sdk.Context, path string) types.StorageEntry {
+	//fmt.Printf("GetEntry(%s)\n", path);
 	store := ctx.KVStore(k.storeKey)
 	encodedKey := types.PathToEncodedKey(path)
-	bz := bytes.TrimPrefix(store.Get(encodedKey), types.EncodedDataPrefix)
-	value := string(bz)
-	return value
+	rawValue := store.Get(encodedKey)
+	if len(rawValue) == 0 {
+		return types.NewStorageEntryWithNoData(path)
+	}
+	if bytes.Equal(rawValue, types.EncodedNoDataValue) {
+		return types.NewStorageEntryWithNoData(path)
+	}
+	value, hasPrefix := cutPrefix(rawValue, types.EncodedDataPrefix)
+	if !hasPrefix {
+		panic(fmt.Errorf("value at path %q starts with unexpected prefix", path))
+	}
+	return types.NewStorageEntry(path, string(value))
 }
 
 func (k Keeper) getKeyIterator(ctx sdk.Context, path string) db.Iterator {
@@ -192,7 +221,7 @@ func (k Keeper) GetChildren(ctx sdk.Context, path string) *types.Children {
 // (just an empty string) and exist only to provide linkage to subnodes with
 // data.
 func (k Keeper) HasStorage(ctx sdk.Context, path string) bool {
-	return k.GetData(ctx, path) != ""
+	return k.GetEntry(ctx, path).HasData()
 }
 
 // HasEntry tells if a given path has either subnodes or data.
@@ -221,14 +250,14 @@ func (k Keeper) FlushChangeEvents(ctx sdk.Context) {
 	k.changeManager.Rollback(ctx)
 }
 
-func (k Keeper) SetStorageAndNotify(ctx sdk.Context, path, value string) {
-	k.changeManager.Track(ctx, k, path, value, false)
-	k.SetStorage(ctx, path, value)
+func (k Keeper) SetStorageAndNotify(ctx sdk.Context, entry types.StorageEntry) {
+	k.changeManager.Track(ctx, k, entry, false)
+	k.SetStorage(ctx, entry)
 }
 
-func (k Keeper) LegacySetStorageAndNotify(ctx sdk.Context, path, value string) {
-	k.changeManager.Track(ctx, k, path, value, true)
-	k.SetStorage(ctx, path, value)
+func (k Keeper) LegacySetStorageAndNotify(ctx sdk.Context, entry types.StorageEntry) {
+	k.changeManager.Track(ctx, k, entry, true)
+	k.SetStorage(ctx, entry)
 }
 
 func (k Keeper) AppendStorageValueAndNotify(ctx sdk.Context, path, value string) error {
@@ -236,7 +265,7 @@ func (k Keeper) AppendStorageValueAndNotify(ctx sdk.Context, path, value string)
 
 	// Preserve correctly-formatted data within the current block,
 	// otherwise initialize a blank cell.
-	currentData := k.GetData(ctx, path)
+	currentData := k.GetEntry(ctx, path).StringValue()
 	var cell StreamCell
 	_ = json.Unmarshal([]byte(currentData), &cell)
 	if cell.BlockHeight != blockHeight {
@@ -251,7 +280,7 @@ func (k Keeper) AppendStorageValueAndNotify(ctx sdk.Context, path, value string)
 	if err != nil {
 		return err
 	}
-	k.SetStorageAndNotify(ctx, path, string(bz))
+	k.SetStorageAndNotify(ctx, types.NewStorageEntry(path, string(bz)))
 	return nil
 }
 
@@ -263,22 +292,27 @@ func componentsToPath(components []string) string {
 //
 // Maintains the invariant: path entries exist if and only if self or some
 // descendant has non-empty storage
-func (k Keeper) SetStorage(ctx sdk.Context, path, value string) {
+func (k Keeper) SetStorage(ctx sdk.Context, entry types.StorageEntry) {
 	store := ctx.KVStore(k.storeKey)
+	path := entry.Path()
 	encodedKey := types.PathToEncodedKey(path)
 
-	if value == "" && !k.HasChildren(ctx, path) {
-		// We have no children, can delete.
-		store.Delete(encodedKey)
+	if !entry.HasData() {
+		if !k.HasChildren(ctx, path) {
+			// We have no children, can delete.
+			store.Delete(encodedKey)
+		} else {
+			store.Set(encodedKey, types.EncodedNoDataValue)
+		}
 	} else {
 		// Update the value.
-		bz := bytes.Join([][]byte{types.EncodedDataPrefix, []byte(value)}, []byte{})
+		bz := bytes.Join([][]byte{types.EncodedDataPrefix, []byte(entry.StringValue())}, []byte{})
 		store.Set(encodedKey, bz)
 	}
 
 	// Update our other parent children.
 	pathComponents := strings.Split(path, types.PathSeparator)
-	if value == "" {
+	if !entry.HasData() {
 		// delete placeholder ancestors if they're no longer needed
 		for i := len(pathComponents) - 1; i >= 0; i-- {
 			ancestor := componentsToPath(pathComponents[0:i])
@@ -296,7 +330,7 @@ func (k Keeper) SetStorage(ctx sdk.Context, path, value string) {
 				// The ancestor exists, implying all further ancestors exist, so we can break.
 				break
 			}
-			store.Set(types.PathToEncodedKey(ancestor), types.EncodedDataPrefix)
+			store.Set(types.PathToEncodedKey(ancestor), types.EncodedNoDataValue)
 		}
 	}
 }

--- a/golang/cosmos/x/vstorage/keeper/keeper_test.go
+++ b/golang/cosmos/x/vstorage/keeper/keeper_test.go
@@ -57,14 +57,20 @@ func TestStorage(t *testing.T) {
 	ctx, keeper := testKit.ctx, testKit.vstorageKeeper
 
 	// Test that we can store and retrieve a value.
-	keeper.SetStorage(ctx, "inited", "initValue")
-	if got := keeper.GetData(ctx, "inited"); got != "initValue" {
+	keeper.SetStorage(ctx, types.NewStorageEntry("inited", "initValue"))
+	if got := keeper.GetEntry(ctx, "inited").StringValue(); got != "initValue" {
 		t.Errorf("got %q, want %q", got, "initValue")
 	}
 
 	// Test that unknown children return empty string.
-	if got := keeper.GetData(ctx, "unknown"); got != "" {
-		t.Errorf("got %q, want empty string", got)
+	if got := keeper.GetEntry(ctx, "unknown"); got.HasData() || got.StringValue() != "" {
+		t.Errorf("got %q, want no value", got.StringValue())
+	}
+
+	// Test that we can store and retrieve an empty string value.
+	keeper.SetStorage(ctx, types.NewStorageEntry("inited", ""))
+	if got := keeper.GetEntry(ctx, "inited"); !got.HasData() || got.StringValue() != "" {
+		t.Errorf("got %q, want empty string", got.StringValue())
 	}
 
 	// Check that our children are updated as expected.
@@ -72,18 +78,18 @@ func TestStorage(t *testing.T) {
 		t.Errorf("got %q children, want [inited]", got.Children)
 	}
 
-	keeper.SetStorage(ctx, "key1", "value1")
+	keeper.SetStorage(ctx, types.NewStorageEntry("key1", "value1"))
 	if got := keeper.GetChildren(ctx, ""); !childrenEqual(got.Children, []string{"inited", "key1"}) {
 		t.Errorf("got %q children, want [inited,key1]", got.Children)
 	}
 
 	// Check alphabetical.
-	keeper.SetStorage(ctx, "alpha2", "value2")
+	keeper.SetStorage(ctx, types.NewStorageEntry("alpha2", "value2"))
 	if got := keeper.GetChildren(ctx, ""); !childrenEqual(got.Children, []string{"alpha2", "inited", "key1"}) {
 		t.Errorf("got %q children, want [alpha2,inited,key1]", got.Children)
 	}
 
-	keeper.SetStorage(ctx, "beta3", "value3")
+	keeper.SetStorage(ctx, types.NewStorageEntry("beta3", "value3"))
 	if got := keeper.GetChildren(ctx, ""); !childrenEqual(got.Children, []string{"alpha2", "beta3", "inited", "key1"}) {
 		t.Errorf("got %q children, want [alpha2,beta3,inited,key1]", got.Children)
 	}
@@ -93,8 +99,8 @@ func TestStorage(t *testing.T) {
 	}
 
 	// Check adding children.
-	keeper.SetStorage(ctx, "key1.child1", "value1child")
-	if got := keeper.GetData(ctx, "key1.child1"); got != "value1child" {
+	keeper.SetStorage(ctx, types.NewStorageEntry("key1.child1", "value1child"))
+	if got := keeper.GetEntry(ctx, "key1.child1").StringValue(); got != "value1child" {
 		t.Errorf("got %q, want %q", got, "value1child")
 	}
 
@@ -103,8 +109,8 @@ func TestStorage(t *testing.T) {
 	}
 
 	// Add a grandchild.
-	keeper.SetStorage(ctx, "key1.child1.grandchild1", "value1grandchild")
-	if got := keeper.GetData(ctx, "key1.child1.grandchild1"); got != "value1grandchild" {
+	keeper.SetStorage(ctx, types.NewStorageEntry("key1.child1.grandchild1", "value1grandchild"))
+	if got := keeper.GetEntry(ctx, "key1.child1.grandchild1").StringValue(); got != "value1grandchild" {
 		t.Errorf("got %q, want %q", got, "value1grandchild")
 	}
 
@@ -113,7 +119,7 @@ func TestStorage(t *testing.T) {
 	}
 
 	// Delete the child's contents.
-	keeper.SetStorage(ctx, "key1.child1", "")
+	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("key1.child1"))
 	if got := keeper.GetChildren(ctx, "key1"); !childrenEqual(got.Children, []string{"child1"}) {
 		t.Errorf("got %q children, want [child1]", got.Children)
 	}
@@ -123,7 +129,7 @@ func TestStorage(t *testing.T) {
 	}
 
 	// Delete the grandchild's contents.
-	keeper.SetStorage(ctx, "key1.child1.grandchild1", "")
+	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("key1.child1.grandchild1"))
 	if got := keeper.GetChildren(ctx, "key1.child1"); !childrenEqual(got.Children, []string{}) {
 		t.Errorf("got %q children, want []", got.Children)
 	}
@@ -133,13 +139,13 @@ func TestStorage(t *testing.T) {
 	}
 
 	// See about deleting the parent.
-	keeper.SetStorage(ctx, "key1", "")
+	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("key1"))
 	if got := keeper.GetChildren(ctx, ""); !childrenEqual(got.Children, []string{"alpha2", "beta3", "inited"}) {
 		t.Errorf("got %q children, want [alpha2,beta3,inited]", got.Children)
 	}
 
 	// Do a deep set.
-	keeper.SetStorage(ctx, "key2.child2.grandchild2", "value2grandchild")
+	keeper.SetStorage(ctx, types.NewStorageEntry("key2.child2.grandchild2", "value2grandchild"))
 	if got := keeper.GetChildren(ctx, ""); !childrenEqual(got.Children, []string{"alpha2", "beta3", "inited", "key2"}) {
 		t.Errorf("got %q children, want [alpha2,beta3,inited,key2]", got.Children)
 	}
@@ -151,7 +157,7 @@ func TestStorage(t *testing.T) {
 	}
 
 	// Do another deep set.
-	keeper.SetStorage(ctx, "key2.child2.grandchild2a", "value2grandchilda")
+	keeper.SetStorage(ctx, types.NewStorageEntry("key2.child2.grandchild2a", "value2grandchilda"))
 	if got := keeper.GetChildren(ctx, "key2.child2"); !childrenEqual(got.Children, []string{"grandchild2", "grandchild2a"}) {
 		t.Errorf("got %q children, want [grandchild2,grandchild2a]", got.Children)
 	}
@@ -160,7 +166,7 @@ func TestStorage(t *testing.T) {
 	expectedExport := []*types.DataEntry{
 		{Path: "alpha2", Value: "value2"},
 		{Path: "beta3", Value: "value3"},
-		{Path: "inited", Value: "initValue"},
+		{Path: "inited", Value: ""},
 		{Path: "key2.child2.grandchild2", Value: "value2grandchild"},
 		{Path: "key2.child2.grandchild2a", Value: "value2grandchilda"},
 	}
@@ -175,12 +181,12 @@ func TestStorageNotify(t *testing.T) {
 	tk := makeTestKit()
 	ctx, keeper := tk.ctx, tk.vstorageKeeper
 
-	keeper.SetStorageAndNotify(ctx, "notify.noLegacy", "noLegacyValue")
-	keeper.LegacySetStorageAndNotify(ctx, "notify.legacy", "legacyValue")
-	keeper.SetStorageAndNotify(ctx, "notify.noLegacy2", "noLegacyValue2")
-	keeper.SetStorageAndNotify(ctx, "notify.legacy2", "legacyValue2")
-	keeper.LegacySetStorageAndNotify(ctx, "notify.legacy2", "legacyValue2b")
-	keeper.SetStorageAndNotify(ctx, "notify.noLegacy2", "noLegacyValue2b")
+	keeper.SetStorageAndNotify(ctx, types.NewStorageEntry("notify.noLegacy", "noLegacyValue"))
+	keeper.LegacySetStorageAndNotify(ctx, types.NewStorageEntry("notify.legacy", "legacyValue"))
+	keeper.SetStorageAndNotify(ctx, types.NewStorageEntry("notify.noLegacy2", "noLegacyValue2"))
+	keeper.SetStorageAndNotify(ctx, types.NewStorageEntry("notify.legacy2", "legacyValue2"))
+	keeper.LegacySetStorageAndNotify(ctx, types.NewStorageEntry("notify.legacy2", "legacyValue2b"))
+	keeper.SetStorageAndNotify(ctx, types.NewStorageEntry("notify.noLegacy2", "noLegacyValue2b"))
 
 	// Check the batched events.
 	expectedBeforeFlushEvents := sdk.Events{}

--- a/golang/cosmos/x/vstorage/keeper/querier.go
+++ b/golang/cosmos/x/vstorage/keeper/querier.go
@@ -34,12 +34,12 @@ func NewQuerier(keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) sdk.Querier 
 
 // nolint: unparam
 func queryData(ctx sdk.Context, path string, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) (res []byte, err error) {
-	value := keeper.GetData(ctx, path)
-	if value == "" {
+	entry := keeper.GetEntry(ctx, path)
+	if !entry.HasData() {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "could not get vstorage path")
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(legacyQuerierCdc, types.Data{Value: value})
+	bz, err2 := codec.MarshalJSONIndent(legacyQuerierCdc, types.Data{Value: entry.StringValue()})
 	if err2 != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err2.Error())
 	}

--- a/golang/cosmos/x/vstorage/types/path_keys.go
+++ b/golang/cosmos/x/vstorage/types/path_keys.go
@@ -15,15 +15,22 @@ import (
 // digits), separated by nul, followed by the path with dots replaced with nul.
 // So the path key for the empty path is `0\0`.
 //
-// - Store entries contain `\0`-prefixed data, (just `\0` if data is
+// - Store entries exist if and only if self or some descendant has an entry
+// with data.
+//
+// - Store entries with data contain `\0`-prefixed data, (just `\0` if data is
 // empty).
 //
-// - Store entries exist if and only if self or some descendant has a
-// non-empty data entry.
+// - Placeholder store entries contain a single `\255` byte. These are used to
+// indicate that the entry does not have any data (which is different from
+// empty data). Placeholder entries are used when a descendant with data exists,
+// similar to empty non-terminals in the DNS
+// (cf. https://www.rfc-editor.org/rfc/rfc8499.html#section-7 ).
 var (
 	EncodedKeySeparator = []byte{0}
 	PathSeparator       = "."
 	EncodedDataPrefix   = []byte{0}
+	EncodedNoDataValue  = []byte{255}
 )
 
 // EncodedKeyToPath converts a byte slice key to a string path

--- a/golang/cosmos/x/vstorage/types/types.go
+++ b/golang/cosmos/x/vstorage/types/types.go
@@ -1,9 +1,71 @@
 package types
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 func NewData() *Data {
 	return &Data{}
 }
 
 func NewChildren() *Children {
 	return &Children{}
+}
+
+type StorageEntry struct {
+	path  string
+	value *string
+}
+
+func NewStorageEntry(path string, value string) StorageEntry {
+	return StorageEntry{path, &value}
+}
+
+func NewStorageEntryWithNoData(path string) StorageEntry {
+	return StorageEntry{path, nil}
+}
+
+// UnmarshalStorageEntry interprets its argument as a [key: string, value?: string | null]
+// JSON array and returns a corresponding StorageEntry.
+// The key must be a string, and the value (if present) must be a string or null.
+func UnmarshalStorageEntry(msg json.RawMessage) (entry StorageEntry, err error) {
+	var generic [2]interface{}
+	err = json.Unmarshal(msg, &generic)
+
+	if err != nil {
+		return
+	}
+
+	path, ok := generic[0].(string)
+	if !ok {
+		err = fmt.Errorf("invalid storage entry path: %q", generic[0])
+		return
+	}
+
+	switch generic[1].(type) {
+	case string:
+		entry = NewStorageEntry(path, generic[1].(string))
+	case nil:
+		entry = NewStorageEntryWithNoData(path)
+	default:
+		err = fmt.Errorf("invalid storage entry value: %q", generic[1])
+	}
+	return
+}
+
+func (se StorageEntry) HasData() bool {
+	return se.value != nil
+}
+
+func (se StorageEntry) Path() string {
+	return se.path
+}
+
+func (se StorageEntry) StringValue() string {
+	if se.value != nil {
+		return *se.value
+	} else {
+		return ""
+	}
 }

--- a/golang/cosmos/x/vstorage/vstorage.go
+++ b/golang/cosmos/x/vstorage/vstorage.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+	"github.com/Agoric/agoric-sdk/golang/cosmos/x/vstorage/types"
 )
 
 type vstorageHandler struct {
@@ -24,6 +25,14 @@ type vstorageStoreKey struct {
 	StoreName       string `json:"storeName"`
 	StoreSubkey     string `json:"storeSubkey"`
 	DataPrefixBytes string `json:"dataPrefixBytes"`
+}
+
+func MakeSetEntryFromMessage(msg *vstorageMessage) types.StorageEntry {
+	if msg.Value == "" {
+		return types.NewStorageEntryWithNoData(msg.Path)
+	} else {
+		return types.NewStorageEntry(msg.Path, msg.Value)
+	}
 }
 
 func NewStorageHandler(keeper Keeper) vstorageHandler {
@@ -57,7 +66,7 @@ func (sh vstorageHandler) Receive(cctx *vm.ControllerContext, str string) (ret s
 	// Handle generic paths.
 	switch msg.Method {
 	case "set":
-		keeper.SetStorageAndNotify(cctx.Context, msg.Path, msg.Value)
+		keeper.SetStorageAndNotify(cctx.Context, MakeSetEntryFromMessage(msg))
 		return "true", nil
 
 		// We sometimes need to use LegacySetStorageAndNotify, because the solo's
@@ -65,11 +74,11 @@ func (sh vstorageHandler) Receive(cctx *vm.ControllerContext, str string) (ret s
 		// FIXME: Use just "set" and remove this case.
 	case "legacySet":
 		//fmt.Printf("giving Keeper.SetStorage(%s) %s\n", msg.Key, msg.Value)
-		keeper.LegacySetStorageAndNotify(cctx.Context, msg.Path, msg.Value)
+		keeper.LegacySetStorageAndNotify(cctx.Context, MakeSetEntryFromMessage(msg))
 		return "true", nil
 
 	case "setWithoutNotify":
-		keeper.SetStorage(cctx.Context, msg.Path, msg.Value)
+		keeper.SetStorage(cctx.Context, MakeSetEntryFromMessage(msg))
 		return "true", nil
 
 	case "append":
@@ -81,12 +90,11 @@ func (sh vstorageHandler) Receive(cctx *vm.ControllerContext, str string) (ret s
 
 	case "get":
 		// Note that "get" does not (currently) unwrap a StreamCell.
-		value := keeper.GetData(cctx.Context, msg.Path)
-		if value == "" {
+		entry := keeper.GetEntry(cctx.Context, msg.Path)
+		if !entry.HasData() {
 			return "null", nil
 		}
-		//fmt.Printf("Keeper.GetStorage gave us %bz\n", value)
-		bz, err := json.Marshal(value)
+		bz, err := json.Marshal(entry.StringValue())
 		if err != nil {
 			return "", err
 		}
@@ -105,8 +113,8 @@ func (sh vstorageHandler) Receive(cctx *vm.ControllerContext, str string) (ret s
 		return string(bz), nil
 
 	case "has":
-		value := keeper.GetData(cctx.Context, msg.Path)
-		if value == "" {
+		value := keeper.HasStorage(cctx.Context, msg.Path)
+		if !value {
 			return "false", nil
 		}
 		return "true", nil
@@ -129,7 +137,7 @@ func (sh vstorageHandler) Receive(cctx *vm.ControllerContext, str string) (ret s
 		for i, child := range children.Children {
 			ents[i] = make([]string, 2)
 			ents[i][0] = child
-			ents[i][i] = keeper.GetData(cctx.Context, fmt.Sprintf("%s.%s", msg.Path, child))
+			ents[i][i] = keeper.GetEntry(cctx.Context, fmt.Sprintf("%s.%s", msg.Path, child)).StringValue()
 		}
 		bytes, err := json.Marshal(ents)
 		if err != nil {
@@ -141,7 +149,7 @@ func (sh vstorageHandler) Receive(cctx *vm.ControllerContext, str string) (ret s
 		children := keeper.GetChildren(cctx.Context, msg.Path)
 		vals := make([]string, len(children.Children))
 		for i, child := range children.Children {
-			vals[i] = keeper.GetData(cctx.Context, fmt.Sprintf("%s.%s", msg.Path, child))
+			vals[i] = keeper.GetEntry(cctx.Context, fmt.Sprintf("%s.%s", msg.Path, child)).StringValue()
 		}
 		bytes, err := json.Marshal(vals)
 		if err != nil {

--- a/golang/cosmos/x/vstorage/vstorage.go
+++ b/golang/cosmos/x/vstorage/vstorage.go
@@ -25,6 +25,7 @@ type vstorageStoreKey struct {
 	StoreName       string `json:"storeName"`
 	StoreSubkey     string `json:"storeSubkey"`
 	DataPrefixBytes string `json:"dataPrefixBytes"`
+	NoDataValue     string `json:"noDataValue"`
 }
 
 func MakeSetEntryFromMessage(msg *vstorageMessage) types.StorageEntry {
@@ -105,6 +106,7 @@ func (sh vstorageHandler) Receive(cctx *vm.ControllerContext, str string) (ret s
 			StoreName:       keeper.GetStoreName(),
 			StoreSubkey:     string(keeper.PathToEncodedKey(msg.Path)),
 			DataPrefixBytes: string(keeper.GetDataPrefix()),
+			NoDataValue:     string(keeper.GetNoDataValue()),
 		}
 		bz, err := json.Marshal(value)
 		if err != nil {

--- a/packages/cache/test/test-storage.js
+++ b/packages/cache/test/test-storage.js
@@ -29,9 +29,11 @@ harden(makeSimpleMarshaller);
 const setup = () => {
   const storageNodeState = {};
   const chainStorage = makeChainStorageRoot(message => {
-    assert(message.key === 'cache');
     assert(message.method === 'set');
-    storageNodeState.cache = message.value;
+    assert(message.args.length === 1);
+    const [[path, value]] = message.args;
+    assert(path === 'cache');
+    storageNodeState.cache = value;
   }, 'cache');
   const cache = makeCache(
     makeChainStorageCoordinator(chainStorage, makeSimpleMarshaller()),

--- a/packages/casting/src/casting-spec.js
+++ b/packages/casting/src/casting-spec.js
@@ -15,9 +15,11 @@ const swingsetPathToCastingSpec = storagePath =>
     storeSubkey: toAscii(`swingset/data:${storagePath}`),
   });
 
+// See details of encoding in golang/cosmos/x/vstorage/types/path_keys.go
 const KEY_SEPARATOR_BYTE = 0;
 const PATH_SEPARATOR_BYTE = '.'.charCodeAt(0);
 const DATA_PREFIX_BYTES = new Uint8Array([0]);
+const NO_DATA_VALUE = new Uint8Array([255]);
 
 /**
  * @param {string} storagePath
@@ -33,6 +35,7 @@ const vstoragePathToCastingSpec = (storagePath, storeName = 'vstorage') => {
       b === PATH_SEPARATOR_BYTE ? KEY_SEPARATOR_BYTE : b,
     ),
     dataPrefixBytes: DATA_PREFIX_BYTES,
+    noDataValue: NO_DATA_VALUE,
   });
 };
 
@@ -91,8 +94,14 @@ const te = new TextEncoder();
  * @returns {import('./types').CastingSpec}
  */
 export const makeCastingSpecFromObject = specObj => {
-  const { storeName, storeSubkey, dataPrefixBytes, subscription, notifier } =
-    specObj;
+  const {
+    storeName,
+    storeSubkey,
+    dataPrefixBytes,
+    noDataValue,
+    subscription,
+    notifier,
+  } = specObj;
   if (subscription || notifier) {
     return harden({
       subscription,
@@ -107,10 +116,15 @@ export const makeCastingSpecFromObject = specObj => {
   if (typeof dataPrefixBytes === 'string') {
     dataPrefix = te.encode(dataPrefixBytes);
   }
+  let noData = noDataValue;
+  if (typeof noDataValue === 'string') {
+    noData = te.encode(noDataValue);
+  }
   return harden({
     storeName,
     storeSubkey: subkey,
     dataPrefixBytes: dataPrefix,
+    noDataValue: noData,
   });
 };
 

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -193,6 +193,7 @@ export const makeCosmjsFollower = (
       storeName,
       storeSubkey,
       dataPrefixBytes = defaultDataPrefixBytes,
+      noDataValue,
     } = await castingSpecP;
 
     if (typeof storeName !== 'string') {
@@ -220,12 +221,15 @@ export const makeCosmjsFollower = (
     }
     assert(result);
 
-    const value =
-      result.value.length === 0
-        ? // No data.
-          result.value
-        : stripPrefix(result.value, dataPrefixBytes);
-
+    /** @type {Uint8Array} */
+    let value;
+    if (result.value.length === 0) {
+      value = result.value;
+    } else if (noDataValue && arrayEqual(result.value, noDataValue)) {
+      value = new Uint8Array();
+    } else {
+      value = stripPrefix(result.value, dataPrefixBytes);
+    }
     return { value, height: result.height };
   };
 

--- a/packages/casting/src/types.js
+++ b/packages/casting/src/types.js
@@ -69,6 +69,7 @@ export {};
  * @property {string} [storeName]
  * @property {Uint8Array} [storeSubkey]
  * @property {Uint8Array} [dataPrefixBytes]
+ * @property {Uint8Array} [noDataValue]
  * @property {ERef<Subscription<any>>} [subscription]
  * @property {ERef<Notifier<any>>} [notifier]
  */

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import { resolve as pathResolve } from 'path';
 import v8 from 'node:v8';
 import process from 'node:process';
 import fs from 'node:fs';
@@ -129,7 +129,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
         return trueValue;
       default:
         if (option) {
-          return path.resolve(option);
+          return pathResolve(option);
         } else if (envName && flagName) {
           return getPathFromEnv({ flagName, trueValue });
         } else {
@@ -326,7 +326,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     const swingStoreTraceFile = getPathFromEnv({
       envName: 'SWING_STORE_TRACE',
       flagName: 'trace-store',
-      trueValue: path.resolve(stateDBDir, 'store-trace.log'),
+      trueValue: pathResolve(stateDBDir, 'store-trace.log'),
     });
 
     const keepSnapshots =
@@ -336,7 +336,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
 
     let lastCommitTime = 0;
     let commitCallsSinceLastSnapshot = NaN;
-    const snapshotBaseDir = path.resolve(stateDBDir, 'node-heap-snapshots');
+    const snapshotBaseDir = pathResolve(stateDBDir, 'node-heap-snapshots');
 
     if (nodeHeapSnapshots >= 0) {
       fs.mkdirSync(snapshotBaseDir, { recursive: true });
@@ -372,7 +372,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
         ) {
           commitCallsSinceLastSnapshot = 0;
           heapSnapshot = `Heap-${process.pid}-${Date.now()}.heapsnapshot`;
-          const snapshotPath = path.resolve(snapshotBaseDir, heapSnapshot);
+          const snapshotPath = pathResolve(snapshotBaseDir, heapSnapshot);
           v8.writeHeapSnapshot(snapshotPath);
           heapSnapshotTime = performance.now() - t3;
         }

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -52,22 +52,24 @@ const makePrefixedBridgeStorage = (
 
   return harden({
     get: key => {
-      const retStr = call(stringify({ method: 'get', key: `${prefix}${key}` }));
+      const retStr = call(
+        stringify({ method: 'get', args: [`${prefix}${key}`] }),
+      );
       const ret = JSON.parse(retStr);
-      if (!ret) {
+      if (ret == null) {
         return undefined;
       }
       const bridgeValue = JSON.parse(ret);
       return fromBridgeValue(bridgeValue);
     },
     set: (key, value) => {
-      const valueStr =
-        value === undefined ? '' : stringify(toBridgeValue(value));
+      const path = `${prefix}${key}`;
+      const entry =
+        value == null ? [path] : [path, stringify(toBridgeValue(value))];
       call(
         stringify({
           method: setterMethod,
-          key: `${prefix}${key}`,
-          value: valueStr,
+          args: [entry],
         }),
       );
     },
@@ -257,10 +259,10 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       ),
     );
     function setActivityhash(activityhash) {
+      const entry = [STORAGE_PATH.ACTIVITYHASH, activityhash];
       const msg = stringify({
         method: 'set',
-        key: STORAGE_PATH.ACTIVITYHASH,
-        value: activityhash,
+        args: [entry],
       });
       chainSend(portNums.storage, msg);
     }

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -15,6 +15,7 @@ const { Fail } = assert;
  * @property {string} storeName
  * @property {string} storeSubkey
  * @property {string} dataPrefixBytes
+ * @property {string} [noDataValue]
  */
 
 /**

--- a/packages/internal/test/test-storage-test-utils.js
+++ b/packages/internal/test/test-storage-test-utils.js
@@ -46,13 +46,13 @@ test('makeFakeStorageKit', async t => {
   await rootNode.setValue('foo');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: rootPath, method: 'set', value: 'foo' }],
+    [{ method: 'set', args: [[rootPath, 'foo']] }],
     'root node setValue message',
   );
   await rootNode.setValue('bar');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: rootPath, method: 'set', value: 'bar' }],
+    [{ method: 'set', args: [[rootPath, 'bar']] }],
     'second setValue message',
   );
 
@@ -91,7 +91,7 @@ test('makeFakeStorageKit', async t => {
     await child.setValue('foo');
     t.deepEqual(
       messages.slice(-1),
-      [{ key: childPath, method: 'set', value: 'foo' }],
+      [{ method: 'set', args: [[childPath, 'foo']] }],
       'non-root setValue message',
     );
   }
@@ -141,26 +141,26 @@ test('makeFakeStorageKit', async t => {
   await deepNode.setValue('foo');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: deepPath, method: 'set', value: 'foo' }],
+    [{ method: 'set', args: [[deepPath, 'foo']] }],
     'level-skipping setValue message',
   );
 
   await childNode.setValue('');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: childPath, method: 'set', value: '' }],
+    [{ method: 'set', args: [[childPath]] }],
     'child setValue message',
   );
   await deepNode.setValue('');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: deepPath, method: 'set', value: '' }],
+    [{ method: 'set', args: [[deepPath]] }],
     'granchild setValue message',
   );
   await childNode.setValue('');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: childPath, method: 'set', value: '' }],
+    [{ method: 'set', args: [[childPath]] }],
     'child setValue message',
   );
 });
@@ -181,13 +181,13 @@ test('makeFakeStorageKit sequence data', async t => {
   await rootNode.setValue('foo');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: rootPath, method: 'append', value: 'foo' }],
+    [{ method: 'append', args: [[rootPath, 'foo']] }],
     'root setValue message',
   );
   await rootNode.setValue('bar');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: rootPath, method: 'append', value: 'bar' }],
+    [{ method: 'append', args: [[rootPath, 'bar']] }],
     'second setValue message',
   );
 
@@ -199,41 +199,41 @@ test('makeFakeStorageKit sequence data', async t => {
   await childNode.setValue('foo');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: childPath, method: 'append', value: 'foo' }],
+    [{ method: 'append', args: [[childPath, 'foo']] }],
     'auto-sequence child setValue message',
   );
   await deepNode.setValue('foo');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: deepPath, method: 'append', value: 'foo' }],
+    [{ method: 'append', args: [[deepPath, 'foo']] }],
     'auto-sequence grandchild setValue message',
   );
   deepNode = childNode.makeChildNode('grandchild', { sequence: false });
   await deepNode.setValue('bar');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: deepPath, method: 'set', value: 'bar' }],
+    [{ method: 'set', args: [[deepPath, 'bar']] }],
     'manual-single grandchild setValue message',
   );
   childNode = rootNode.makeChildNode('child', { sequence: false });
   await childNode.setValue('bar');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: childPath, method: 'set', value: 'bar' }],
+    [{ method: 'set', args: [[childPath, 'bar']] }],
     'manual-single child setValue message',
   );
   deepNode = childNode.makeChildNode('grandchild');
   await deepNode.setValue('baz');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: deepPath, method: 'set', value: 'baz' }],
+    [{ method: 'set', args: [[deepPath, 'baz']] }],
     'auto-single grandchild setValue message',
   );
   deepNode = childNode.makeChildNode('grandchild', { sequence: true });
   await deepNode.setValue('qux');
   t.deepEqual(
     messages.slice(-1),
-    [{ key: deepPath, method: 'append', value: 'qux' }],
+    [{ method: 'append', args: [[deepPath, 'qux']] }],
     'manual-sequence grandchild setValue message',
   );
 });

--- a/packages/notifier/src/types-ambient.js
+++ b/packages/notifier/src/types-ambient.js
@@ -262,6 +262,7 @@
  * @property {string} storeName
  * @property {string} storeSubkey
  * @property {string} dataPrefixBytes
+ * @property {string} [noDataValue]
  */
 
 /**


### PR DESCRIPTION
refs: #5542 

As usual, best reviewed commit-by-commit

## Description

As preliminary changes for #5542, we need to support empty strings as actual values in vstorage, potentially for both leaf and ancestors. golang non-nullable values leaked through the design of vstorage, and setting a value of `''` previously meant deletion.

To support empty strings as actual values, we need to:
- Support explicit deletion
- Encode noData in the cosmos KV store differently than empty string when an entry must exist (ancestor key)

### Security Considerations

None

### Scaling Considerations

An alternative would have been to encode or hilbert the state-sync values to avoid empty strings, but that would have been costly as state sync export is likely to become the biggest data generator, and would have leaked further a golang design choice.

Furthermore changing the interface allows batch setting multiple entries to avoid repeated call across the JS -> golang boundary. (Current vstorage users do not yet take advantage of this change, the mailbox probably could with some further refactoring)

### Documentation Considerations

vstorage clients need to be updated if they iterate over keys, as they may encounter a value with an unexpected prefix. The casting library is updated as part of this PR.

A migration (or export/import) will be needed at the next upgrade containing this change. The migration was implemented as part of this change, and a note left in the current upgrade handler highlighting the need to call migration at the next upgrade.

### Testing Considerations

Added unit tests, updated existing ones. 
