### PR TITLE
6701 EC addOracles to a governed fluxAggregator

### DIFF
--- a/packages/governance/src/contractGovernance/governApi.js
+++ b/packages/governance/src/contractGovernance/governApi.js
@@ -22,7 +22,7 @@ const { Fail, quote: q } = assert;
 const makeApiInvocationPositions = (apiMethodName, methodArgs) => {
   const positive = harden({ apiMethodName, methodArgs });
   const negative = harden({ dontInvoke: apiMethodName });
-  return { positive, negative };
+  return harden({ positive, negative });
 };
 
 /**
@@ -113,11 +113,11 @@ const setupApiGovernance = async (
         },
       );
 
-    return {
+    return harden({
       outcomeOfUpdate,
       instance: voteCounter,
       details: E(counterPublicFacet).getDetails(),
-    };
+    });
   };
 
   return Far('paramGovernor', {

--- a/packages/governance/src/contractGovernance/typedParamManager.js
+++ b/packages/governance/src/contractGovernance/typedParamManager.js
@@ -51,6 +51,10 @@ const isAsync = {
  * @typedef {[type: T, value: ParamValueForType<T>]} ST param spec tuple
  */
 
+/**
+ * @typedef {{ type: 'invitation', value: Amount<'set'> }} InvitationParam
+ */
+
 // XXX better to use the manifest constant ParamTypes
 // but importing that here turns this file into a module,
 // breaking the ambient typing

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -121,7 +121,11 @@ const validateQuestionFromCounter = async (zoe, electorate, voteCounter) => {
  */
 
 /**
- * @template {() => {creatorFacet: GovernorFacet<any>, publicFacet: GovernedPublicFacetMethods} } SF Start function of governed contract
+ * @typedef {() => {creatorFacet: GovernorFacet<any>, publicFacet: GovernedPublicFacetMethods}} GovernableStartFn
+ */
+
+/**
+ * @template {GovernableStartFn} SF Start function of governed contract
  * @param {ZCF<{
  *   timer: import('@agoric/time/src/types').TimerService,
  *   governedContractInstallation: Installation<SF>,

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -2,6 +2,7 @@ import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { mustMatch } from '@agoric/store';
 
+import { makeTracer } from '@agoric/internal';
 import {
   CONTRACT_ELECTORATE,
   setupParamGovernance,
@@ -11,6 +12,8 @@ import { setupFilterGovernance } from './contractGovernance/governFilter.js';
 import { ParamChangesQuestionDetailsShape } from './typeGuards.js';
 
 const { Fail } = assert;
+
+const trace = makeTracer('CGov', false);
 
 /**
  * Validate that the question details correspond to a parameter change question
@@ -125,6 +128,8 @@ const validateQuestionFromCounter = async (zoe, electorate, voteCounter) => {
  */
 
 /**
+ * Start an instance of a governor, governing a "governed" contract specified in terms.
+ *
  * @template {GovernableStartFn} SF Start function of governed contract
  * @param {ZCF<{
  *   timer: import('@agoric/time/src/types').TimerService,
@@ -139,7 +144,9 @@ const validateQuestionFromCounter = async (zoe, electorate, voteCounter) => {
  * }} privateArgs
  */
 const start = async (zcf, privateArgs) => {
+  trace('start');
   const zoe = zcf.getZoeService();
+  trace('getTerms', zcf.getTerms());
   const {
     timer,
     governedContractInstallation,
@@ -148,6 +155,7 @@ const start = async (zcf, privateArgs) => {
       terms: contractTerms,
     },
   } = zcf.getTerms();
+  trace('contractTerms', contractTerms);
   contractTerms.governedParams[CONTRACT_ELECTORATE] ||
     Fail`Contract must declare ${CONTRACT_ELECTORATE} as a governed parameter`;
 
@@ -156,6 +164,7 @@ const start = async (zcf, privateArgs) => {
     electionManager: zcf.getInstance(),
   });
 
+  trace('starting governedContractInstallation');
   const {
     creatorFacet: governedCF,
     instance: governedInstance,
@@ -195,9 +204,11 @@ const start = async (zcf, privateArgs) => {
     }
     return poserFacet;
   };
+  trace('awaiting getUpdatedPoserFacet');
   await getUpdatedPoserFacet();
   assert(poserFacet, 'question poser facet must be initialized');
 
+  trace('awaiting setupParamGovernance');
   // All governed contracts have at least a governed electorate
   const { voteOnParamChanges, createdQuestion: createdParamQuestion } =
     await setupParamGovernance(
@@ -208,6 +219,7 @@ const start = async (zcf, privateArgs) => {
       getUpdatedPoserFacet,
     );
 
+  trace('awaiting setupFilterGovernance');
   const { voteOnFilter, createdFilterQuestion } = await setupFilterGovernance(
     zoe,
     governedInstance,

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -115,7 +115,7 @@ const facetHelpers = (zcf, paramManager) => {
   /**
    * @template {{}} CF
    * @param {CF} limitedCreatorFacet
-   * @param {{}} [governedApis]
+   * @param {Record<string, (...any) => unknown>} [governedApis]
    * @returns {GovernorFacet<CF>}
    */
   const makeFarGovernorFacet = (limitedCreatorFacet, governedApis = {}) => {
@@ -127,7 +127,6 @@ const facetHelpers = (zcf, paramManager) => {
       // The contract provides a facet with the APIs that can be invoked by
       // governance
       /** @type {() => GovernedApis} */
-      // @ts-expect-error TS think this is a RemotableBrand??
       getGovernedApis: () => Far('governedAPIs', governedApis),
       // The facet returned by getGovernedApis is Far, so we can't see what
       // methods it has. There's no clean way to have contracts specify the APIs

--- a/packages/governance/tools/puppetContractGovernor.js
+++ b/packages/governance/tools/puppetContractGovernor.js
@@ -4,7 +4,10 @@ import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 
 // eslint-disable-next-line no-unused-vars
+import { Fail } from '@agoric/assert';
+// eslint-disable-next-line no-unused-vars -- used by typedef
 import { CONTRACT_ELECTORATE } from '../src/contractGovernance/governParam.js';
+import { makeApiInvocationPositions } from '../src/contractGovernance/governApi.js';
 
 // @file a version of the contractGovernor.js contract simplified for testing.
 // It removes the electorate and doesn't try to support legibility.
@@ -12,13 +15,13 @@ import { CONTRACT_ELECTORATE } from '../src/contractGovernance/governParam.js';
 // It adds the ability for tests to update parameters directly.
 
 /**
- * @template {() => {creatorFacet: GovernorFacet<any>, publicFacet: unknown} } SF Start function of governed contract
+ * @template {import('../src/contractGovernor.js').GovernableStartFn} SF Start function of governed contract
  * @param {ZCF<{
  *   timer: import('@agoric/time/src/types').TimerService,
  *   governedContractInstallation: Installation<SF>,
  *   governed: {
  *     issuerKeywordRecord: IssuerKeywordRecord,
- *     terms: {governedParams: {[CONTRACT_ELECTORATE]: Amount<'set'>}},
+ *     terms: {governedParams: {[CONTRACT_ELECTORATE]: import('../src/contractGovernance/typedParamManager.js').InvitationParam }},
  *   }
  * }>} zcf
  * @param {{
@@ -71,8 +74,17 @@ export const start = async (zcf, privateArgs) => {
    * @param {string} apiMethodName
    * @param {unknown[]} methodArgs
    */
-  const invokeAPI = (apiMethodName, methodArgs) =>
-    E(E(governedCF).getGovernedApis())[apiMethodName](...methodArgs);
+  const invokeAPI = async (apiMethodName, methodArgs) => {
+    const governedNames = await E(governedCF).getGovernedApiNames();
+    governedNames.includes(apiMethodName) ||
+      Fail`${apiMethodName} is not a governed API.`;
+
+    const { positive } = makeApiInvocationPositions(apiMethodName, methodArgs);
+
+    return E(E(governedCF).getGovernedApis())
+      [apiMethodName](...methodArgs)
+      .then(() => positive);
+  };
 
   const creatorFacet = Far('governor creatorFacet', {
     changeParams,
@@ -94,6 +106,6 @@ export const start = async (zcf, privateArgs) => {
 };
 harden(start);
 /**
- * @template {() => {creatorFacet: GovernorFacet<any>, publicFacet: unknown} } SF Start function of governed contract
+ * @template {import('../src/contractGovernor.js').GovernableStartFn} SF Start function of governed contract
  * @typedef {Awaited<ReturnType<typeof start<SF>>>} PuppetContractGovernorKit<SF>
  */

--- a/packages/governance/tools/puppetGovernance.js
+++ b/packages/governance/tools/puppetGovernance.js
@@ -1,0 +1,108 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+import bundleSource from '@endo/bundle-source';
+import { E } from '@endo/eventual-send';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
+import { CONTRACT_ELECTORATE, ParamTypes } from '../src/index.js';
+
+const makeBundle = async sourceRoot => {
+  const url = await importMetaResolve(sourceRoot, import.meta.url);
+  const path = new URL(url).pathname;
+  const contractBundle = await bundleSource(path);
+  return contractBundle;
+};
+
+// makeBundle is a slow step, so we do it once for all the tests.
+const contractGovernorBundleP = makeBundle('./puppetContractGovernor.js');
+// could be called fakeCommittee. It's used as a source of invitations only
+const autoRefundBundleP = makeBundle(
+  '@agoric/zoe/src/contracts/automaticRefund.js',
+);
+
+/**  */
+
+/**
+ * @template {import('../src/contractGovernor.js').GovernableStartFn} T governed contract startfn
+ * @param {ERef<ZoeService>} zoe
+ * @param {ERef<Installation<T>>} governedP
+ * @param {import('@agoric/swingset-vat/src/vats/timer/vat-timer.js').TimerService} timer
+ * @param {{ [k: string]: any, governedParams?: Record<string, unknown>, governedApis?: string[] }} termsOfGoverned
+ * @param {{}} privateArgsOfGoverned
+ */
+export const setUpGovernedContract = async (
+  zoe,
+  governedP,
+  timer,
+  termsOfGoverned = {},
+  privateArgsOfGoverned = {},
+) => {
+  const [contractGovernorBundle, autoRefundBundle] = await Promise.all([
+    contractGovernorBundleP,
+    autoRefundBundleP,
+  ]);
+
+  /**
+   * @type {[
+   * Installation<import('./puppetContractGovernor').start>,
+   * Installation<any>,
+   * Installation<T>,
+   * ]}
+   */
+  const [governor, autoRefund, governed] = await Promise.all([
+    E(zoe).install(contractGovernorBundle),
+    E(zoe).install(autoRefundBundle),
+    governedP,
+  ]);
+  const installs = { governor, autoRefund, governed };
+
+  /**
+   * Contract governor wants a committee invitation. Give it a random invitation.
+   */
+  async function getFakeInvitation() {
+    const autoRefundFacets = await E(zoe).startInstance(autoRefund);
+    const invitationP = E(autoRefundFacets.publicFacet).makeInvitation();
+    const [fakeInvitationPayment, fakeInvitationAmount] = await Promise.all([
+      invitationP,
+      E(E(zoe).getInvitationIssuer()).getAmountOf(invitationP),
+    ]);
+    return { fakeInvitationPayment, fakeInvitationAmount };
+  }
+
+  const { fakeInvitationAmount, fakeInvitationPayment } =
+    await getFakeInvitation();
+
+  const governedTermsWithElectorate = {
+    ...termsOfGoverned,
+    governedParams: {
+      ...termsOfGoverned.governedParams,
+      [CONTRACT_ELECTORATE]: {
+        type: ParamTypes.INVITATION,
+        value: fakeInvitationAmount,
+      },
+    },
+    governedApis: termsOfGoverned.governedApis,
+  };
+  const governorTerms = {
+    timer,
+    governedContractInstallation: governed,
+    governed: {
+      terms: governedTermsWithElectorate,
+      issuerKeywordRecord: {},
+    },
+  };
+
+  const governorFacets = await E(zoe).startInstance(
+    governor,
+    {},
+    governorTerms,
+    {
+      governed: {
+        ...privateArgsOfGoverned,
+        initialPoserInvitation: fakeInvitationPayment,
+      },
+    },
+  );
+
+  return { getFakeInvitation, governorFacets, installs };
+};
+harden(setUpGovernedContract);

--- a/packages/inter-protocol/scripts/build-bundles.js
+++ b/packages/inter-protocol/scripts/build-bundles.js
@@ -29,7 +29,10 @@ await createBundles(
       '../src/econCommitteeCharter.js',
       '../bundles/bundle-econCommitteeCharter.js',
     ],
-    ['../src/price/fluxAggregator.js', '../bundles/bundle-fluxAggregator.js'],
+    [
+      '../src/price/fluxAggregatorContract.js',
+      '../bundles/bundle-fluxAggregator.js',
+    ],
   ],
   dirname,
 );

--- a/packages/inter-protocol/scripts/price-feed-core.js
+++ b/packages/inter-protocol/scripts/price-feed-core.js
@@ -57,7 +57,7 @@ export const defaultProposalBuilder = async (
         brandOutRef: brandOut && publishRef(brandOut),
         priceAggregatorRef: publishRef(
           install(
-            '@agoric/inter-protocol/src/price/fluxAggregator.js',
+            '@agoric/inter-protocol/src/price/fluxAggregatorContract.js',
             '../bundles/bundle-fluxAggregator.js',
           ),
         ),

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -79,6 +79,32 @@ export const start = async zcf => {
     return zcf.makeInvitation(voteOnOfferFilterHandler, 'vote on offer filter');
   };
 
+  /**
+   * @param {Instance} instance
+   * @param {string} methodName
+   * @param {string[]} methodArgs
+   * @param {import('@agoric/time').TimestampValue} deadline
+   */
+  const makeApiInvocationInvitation = (
+    instance,
+    methodName,
+    methodArgs,
+    deadline,
+  ) => {
+    const handler = seat => {
+      seat.exit();
+
+      const governor = instanceToGovernor.get(instance);
+      return E(governor).voteOnApiInvocation(
+        methodName,
+        methodArgs,
+        counter,
+        deadline,
+      );
+    };
+    return zcf.makeInvitation(handler, 'vote on API invocation');
+  };
+
   const MakerI = M.interface('Charter InvitationMakers', {
     VoteOnParamChange: M.call().returns(M.promise()),
     VoteOnPauseOffers: M.call(
@@ -86,10 +112,17 @@ export const start = async zcf => {
       M.arrayOf(M.string()),
       TimestampShape,
     ).returns(M.promise()),
+    VoteOnApiCall: M.call(
+      InstanceHandleShape,
+      M.string(),
+      M.arrayOf(M.any()),
+      TimestampShape,
+    ).returns(M.promise()),
   });
   const invitationMakers = makeExo('Charter Invitation Makers', MakerI, {
     VoteOnParamChange: makeParamInvitation,
     VoteOnPauseOffers: makeOfferFilterInvitation,
+    VoteOnApiCall: makeApiInvocationInvitation,
   });
 
   const charterMemberHandler = seat => {

--- a/packages/inter-protocol/src/price/fluxAggregator.js
+++ b/packages/inter-protocol/src/price/fluxAggregator.js
@@ -2,8 +2,8 @@
  * Adaptation of Chainlink algorithm to the Agoric platform.
  * Modeled on https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/FluxAggregator.sol (version?)
  */
-import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
-import { assertAllDefined } from '@agoric/internal';
+import { AmountMath } from '@agoric/ertp';
+import { assertAllDefined, makeTracer } from '@agoric/internal';
 import {
   makeNotifierFromSubscriber,
   observeNotifier,
@@ -19,6 +19,8 @@ import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makeOracleAdmin } from './priceOracleAdmin.js';
 import { makeRoundsManagerKit } from './roundsManager.js';
+
+const trace = makeTracer('FlxAgg', false);
 
 export const INVITATION_MAKERS_DESC = 'oracle invitation';
 
@@ -63,20 +65,26 @@ const priceDescriptionFromQuote = quote => quote.quoteAmount.value[0];
  * the *Node Operator Aggregation* logic of [Chainlink price
  * feeds](https://blog.chain.link/levels-of-data-aggregation-in-chainlink-price-feeds/).
  *
+ * @param {Baggage} baggage
  * @param {ZCF<ChainlinkConfig & {
  * timer: TimerService,
  * brandIn: Brand<'nat'>,
  * brandOut: Brand<'nat'>,
  * unitAmountIn?: Amount<'nat'>,
  * }>} zcf
- * @param {{
- * marshaller: Marshaller,
- * quoteMint?: ERef<Mint<'set'>>,
- * storageNode: ERef<StorageNode>,
- * }} privateArgs
- * @param {Baggage} baggage
+ * @param {TimerService} timerPresence
+ * @param {IssuerRecord<'set'> & { mint: Mint<'set'> }} quoteKit
+ * @param {StorageNode} storageNode
+ * @param {Marshaller} marshaller
  */
-export const start = async (zcf, privateArgs, baggage) => {
+export const provideFluxAggregator = (
+  baggage,
+  zcf,
+  timerPresence,
+  quoteKit,
+  storageNode,
+  marshaller,
+) => {
   // brands come from named terms instead of `brands` key because the latter is
   // a StandardTerm that Zoe creates from the `issuerKeywordRecord` argument and
   // Oracle brands are inert (without issuers or mints).
@@ -89,7 +97,6 @@ export const start = async (zcf, privateArgs, baggage) => {
     minSubmissionValue,
     restartDelay,
     timeout,
-    timer,
 
     unitAmountIn = AmountMath.make(brandIn, 1n),
   } = zcf.getTerms();
@@ -103,26 +110,8 @@ export const start = async (zcf, privateArgs, baggage) => {
     minSubmissionValue,
     restartDelay,
     timeout,
-    timer,
     unitAmountIn,
   });
-
-  // Get the timer's identity.
-  const timerPresence = await timer;
-
-  const quoteMint =
-    privateArgs.quoteMint || makeIssuerKit('quote', AssetKind.SET).mint;
-  const quoteIssuerRecord = await zcf.saveIssuer(
-    E(quoteMint).getIssuer(),
-    'Quote',
-  );
-  const quoteKit = {
-    ...quoteIssuerRecord,
-    mint: quoteMint,
-  };
-
-  const { marshaller, storageNode } = privateArgs;
-  assertAllDefined({ marshaller, storageNode });
 
   const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,
@@ -180,7 +169,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     createQuote: roundsManagerKit.contract.makeCreateQuote(),
     notifier: makeNotifierFromSubscriber(answerSubscriber),
     quoteIssuer: quoteKit.issuer,
-    timer,
+    timer: timerPresence,
     actualBrandIn: brandIn,
     actualBrandOut: brandOut,
   });
@@ -212,6 +201,7 @@ export const start = async (zcf, privateArgs, baggage) => {
      * @param {string} oracleId unique per contract instance
      */
     makeOracleInvitation: async oracleId => {
+      trace('makeOracleInvitation', oracleId);
       /**
        * If custom arguments are supplied to the `zoe.offer` call, they can
        * indicate an OraclePriceSubmission notifier and a corresponding
@@ -258,6 +248,7 @@ export const start = async (zcf, privateArgs, baggage) => {
 
     /** @param {string} oracleId */
     async initOracle(oracleId) {
+      trace('initOracle', oracleId);
       assert.typeof(oracleId, 'string');
 
       const oracleAdmin = makeOracleAdmin(
@@ -266,7 +257,7 @@ export const start = async (zcf, privateArgs, baggage) => {
           maxSubmissionValue,
           oracleId, // must be unique per vat
           roundPowers: roundsManagerKit.oracle,
-          timer,
+          timer: timerPresence,
         }),
       );
       oracles.init(oracleId, oracleAdmin);
@@ -283,7 +274,7 @@ export const start = async (zcf, privateArgs, baggage) => {
      * @returns {Promise<RoundState>}
      */
     async oracleRoundState(oracleId, queriedRoundId) {
-      const blockTimestamp = await E(timer).getCurrentTimestamp();
+      const blockTimestamp = await E(timerPresence).getCurrentTimestamp();
       const status = await E(oracles.get(oracleId)).getStatus();
 
       const oracleCount = oracles.getSize();
@@ -342,4 +333,5 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   return harden({ creatorFacet, publicFacet });
 };
-harden(start);
+harden(provideFluxAggregator);
+/** @typedef {ReturnType<typeof provideFluxAggregator>} FluxAggregator */

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -1,0 +1,63 @@
+import { AssetKind, makeIssuerKit } from '@agoric/ertp';
+import { assertAllDefined } from '@agoric/internal';
+import { E } from '@endo/eventual-send';
+import { provideFluxAggregator } from './fluxAggregator.js';
+
+/**
+ * @typedef {import('@agoric/vat-data').Baggage} Baggage
+ * @typedef {import('@agoric/time/src/types').TimerService} TimerService
+ */
+
+/**
+ * PriceAuthority for their median. Unlike the simpler `priceAggregator.js`, this approximates
+ * the *Node Operator Aggregation* logic of [Chainlink price
+ * feeds](https://blog.chain.link/levels-of-data-aggregation-in-chainlink-price-feeds/).
+ *
+ * @param {ZCF<import('./fluxAggregator.js').ChainlinkConfig & {
+ * timer: TimerService,
+ * brandIn: Brand<'nat'>,
+ * brandOut: Brand<'nat'>,
+ * unitAmountIn?: Amount<'nat'>,
+ * }>} zcf
+ * @param {{
+ * marshaller: Marshaller,
+ * quoteMint?: ERef<Mint<'set'>>,
+ * storageNode: ERef<StorageNode>,
+ * }} privateArgs
+ * @param {Baggage} baggage
+ */
+export const start = async (zcf, privateArgs, baggage) => {
+  const { timer: timerP } = zcf.getTerms();
+
+  const quoteMintP =
+    privateArgs.quoteMint || makeIssuerKit('quote', AssetKind.SET).mint;
+  const [quoteMint, quoteIssuerRecord] = await Promise.all([
+    quoteMintP,
+    zcf.saveIssuer(E(quoteMintP).getIssuer(), 'Quote'),
+  ]);
+  const quoteKit = {
+    ...quoteIssuerRecord,
+    mint: quoteMint,
+  };
+
+  const { marshaller, storageNode: storageNodeP } = privateArgs;
+  assertAllDefined({ marshaller, storageNodeP });
+
+  const timer = await timerP;
+  const storageNode = await storageNodeP;
+
+  const fa = provideFluxAggregator(
+    baggage,
+    zcf,
+    timer,
+    quoteKit,
+    storageNode,
+    marshaller,
+  );
+
+  return harden({
+    creatorFacet: fa.creatorFacet,
+    publicFacet: fa.publicFacet,
+  });
+};
+harden(start);

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -1,8 +1,11 @@
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
-import { assertAllDefined } from '@agoric/internal';
+import { handleParamGovernance } from '@agoric/governance';
+import { assertAllDefined, makeTracer } from '@agoric/internal';
 import { E } from '@endo/eventual-send';
+import { reserveThenDeposit } from '../proposals/utils.js';
 import { provideFluxAggregator } from './fluxAggregator.js';
 
+const trace = makeTracer('FluxAgg', false);
 /**
  * @typedef {import('@agoric/vat-data').Baggage} Baggage
  * @typedef {import('@agoric/time/src/types').TimerService} TimerService
@@ -20,13 +23,16 @@ import { provideFluxAggregator } from './fluxAggregator.js';
  * unitAmountIn?: Amount<'nat'>,
  * }>} zcf
  * @param {{
+ * initialPoserInvitation: Invitation,
  * marshaller: Marshaller,
+ * namesByAddressAdmin: ERef<import('@agoric/vats').NameAdmin>,
  * quoteMint?: ERef<Mint<'set'>>,
  * storageNode: ERef<StorageNode>,
  * }} privateArgs
  * @param {Baggage} baggage
  */
 export const start = async (zcf, privateArgs, baggage) => {
+  trace('start');
   const { timer: timerP } = zcf.getTerms();
 
   const quoteMintP =
@@ -40,11 +46,18 @@ export const start = async (zcf, privateArgs, baggage) => {
     mint: quoteMint,
   };
 
-  const { marshaller, storageNode: storageNodeP } = privateArgs;
-  assertAllDefined({ marshaller, storageNodeP });
+  const {
+    initialPoserInvitation,
+    marshaller,
+    namesByAddressAdmin,
+    storageNode: storageNodeP,
+  } = privateArgs;
+  assertAllDefined({ initialPoserInvitation, marshaller, storageNodeP });
 
   const timer = await timerP;
   const storageNode = await storageNodeP;
+
+  trace('awaited args');
 
   const fa = provideFluxAggregator(
     baggage,
@@ -54,9 +67,51 @@ export const start = async (zcf, privateArgs, baggage) => {
     storageNode,
     marshaller,
   );
+  trace('got fa', fa);
 
+  const { makeGovernorFacet } = await handleParamGovernance(
+    // @ts-expect-error FIXME include Governance params
+    zcf,
+    initialPoserInvitation,
+    {
+      // No governed parameters. Governance just for API methods.
+    },
+    storageNode,
+    marshaller,
+  );
+
+  /**
+   * Initialize a new oracle and send an invitation to administer it.
+   *
+   * @param {string} addr
+   */
+  const addOracle = async addr => {
+    const invitation = await E(fa.creatorFacet).makeOracleInvitation(addr);
+    // XXX imported from 'proposals' path
+    await reserveThenDeposit(
+      `fluxAggregator oracle ${addr}`,
+      namesByAddressAdmin,
+      addr,
+      [invitation],
+    );
+    return `added ${addr}`;
+  };
+
+  const governedApis = {
+    /**
+     * Add the specified oracles. May partially fail, such that some oracles are added and others aren't.
+     *
+     * @param {string[]} oracleIds
+     * @returns {Promise<Array<PromiseSettledResult<string>>>}
+     */
+    addOracles: oracleIds => {
+      return Promise.allSettled(oracleIds.map(addOracle));
+    },
+  };
+
+  const governorFacet = makeGovernorFacet(fa.creatorFacet, governedApis);
   return harden({
-    creatorFacet: fa.creatorFacet,
+    creatorFacet: governorFacet,
     publicFacet: fa.publicFacet,
   });
 };

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -76,8 +76,12 @@ const validRoundId = roundId => {
  */
 
 /**
+ * @typedef {IssuerRecord<'set'> & { mint: Mint<'set'> }} QuoteKit
+ */
+
+/**
  * @typedef {Readonly<import('./fluxAggregator.js').ChainlinkConfig & {
- * quoteKit: IssuerRecord<'set'> & { mint: ERef<Mint<'set'>> },
+ * quoteKit: QuoteKit,
  * answerPublisher: Publisher<void>,
  * brandIn: Brand<'nat'>,
  * brandOut: Brand<'nat'>,

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -8,9 +8,10 @@ import {
 import { deeplyFulfilledObject, makeTracer } from '@agoric/internal';
 
 import { unitAmount } from '@agoric/zoe/src/contractSupport/priceQuote.js';
+import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
 import { reserveThenDeposit, reserveThenGetNames } from './utils.js';
 
-const trace = makeTracer('RunPriceFeed');
+const trace = makeTracer('RunPriceFeed', false);
 
 /** @type {(name: string) => string} */
 const sanitizePathSegment = name => {
@@ -96,6 +97,8 @@ export const createPriceFeed = async (
       chainStorage,
       chainTimerService,
       client,
+      econCharterKit,
+      economicCommitteeCreatorFacet,
       namesByAddressAdmin,
       priceAuthority,
       priceAuthorityAdmin,
@@ -124,55 +127,107 @@ export const createPriceFeed = async (
   /**
    * Values come from economy-template.json, which at this writing had IN:ATOM, OUT:USD
    *
-   * @type {[[Brand<'nat'>, Brand<'nat'>], [Installation<import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').start>]]}
+   * @type {[[Brand<'nat'>, Brand<'nat'>], [Installation<import('@agoric/governance/src/contractGovernor.js').start>, Installation<import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').start>]]}
    */
-  const [[brandIn, brandOut], [priceAggregator]] = await Promise.all([
-    reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('oracleBrand'), [
-      IN_BRAND_NAME,
-      OUT_BRAND_NAME,
-    ]),
-    reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('installation'), [
-      'priceAggregator',
-    ]),
-  ]);
+  const [[brandIn, brandOut], [contractGovernor, priceAggregator]] =
+    await Promise.all([
+      reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('oracleBrand'), [
+        IN_BRAND_NAME,
+        OUT_BRAND_NAME,
+      ]),
+      reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('installation'), [
+        'contractGovernor',
+        'priceAggregator',
+      ]),
+    ]);
+
+  trace('getPoserInvitation');
+  const poserInvitationP = E(
+    economicCommitteeCreatorFacet,
+  ).getPoserInvitation();
+  const [initialPoserInvitation, electorateInvitationAmount] =
+    await Promise.all([
+      poserInvitationP,
+      E(E(zoe).getInvitationIssuer()).getAmountOf(poserInvitationP),
+    ]);
+  trace('got initialPoserInvitation');
 
   const unitAmountIn = await unitAmount(brandIn);
-  const terms = await deeplyFulfilledObject(
+  const terms = harden({
+    ...contractTerms,
+    description: AGORIC_INSTANCE_NAME,
+    brandIn,
+    brandOut,
+    timer,
+    unitAmountIn,
+    governedParams: {
+      [CONTRACT_ELECTORATE]: {
+        type: ParamTypes.INVITATION,
+        value: electorateInvitationAmount,
+      },
+    },
+  });
+  trace('got terms');
+
+  const governorTerms = await deeplyFulfilledObject(
     harden({
-      ...contractTerms,
-      description: AGORIC_INSTANCE_NAME,
-      brandIn,
-      brandOut,
-      timer,
-      unitAmountIn,
+      timer: chainTimerService,
+      governedContractInstallation: priceAggregator,
+      governed: {
+        terms,
+      },
     }),
   );
+  trace('got governorTerms', governorTerms);
 
   const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
   const marshaller = E(board).getReadonlyMarshaller();
 
+  trace('got contractGovernor', contractGovernor);
+
+  trace('awaiting startInstance');
   // Create the price feed.
-  const aggregator = await E(zoe).startInstance(
-    priceAggregator,
+  /** @type {{ creatorFacet: import('@agoric/governance/src/contractGovernor.js').GovernedContractFnFacetAccess<import('@agoric/inter-protocol/src/price/fluxAggregator.contract.js').start>, publicFacet: GovernorPublic, instance: Instance, adminFacet: AdminFacet }} */
+  const aggregatorGovernor = await E(zoe).startInstance(
+    contractGovernor,
     undefined,
-    terms,
+    governorTerms,
     {
-      storageNode: E(storageNode).makeChildNode(
-        sanitizePathSegment(AGORIC_INSTANCE_NAME),
-      ),
-      marshaller,
+      governed: {
+        initialPoserInvitation,
+        marshaller,
+        namesByAddressAdmin,
+        storageNode: E(storageNode).makeChildNode(
+          sanitizePathSegment(AGORIC_INSTANCE_NAME),
+        ),
+      },
     },
   );
+  const faCreatorFacet = await E(
+    aggregatorGovernor.creatorFacet,
+  ).getCreatorFacet();
+  trace('got aggregator', faCreatorFacet);
+
+  const faPublic = await E(aggregatorGovernor.creatorFacet).getPublicFacet();
+  const faInstance = await E(aggregatorGovernor.creatorFacet).getInstance();
+  trace('got', { faInstance, faPublic });
 
   E(E(agoricNamesAdmin).lookupAdmin('instance')).update(
     AGORIC_INSTANCE_NAME,
-    aggregator.instance,
+    faInstance,
   );
+
+  E(E.get(econCharterKit).creatorFacet).addInstance(
+    faInstance,
+    aggregatorGovernor.creatorFacet,
+    AGORIC_INSTANCE_NAME,
+  );
+  trace('registered', AGORIC_INSTANCE_NAME, faInstance);
 
   // Publish price feed in home.priceAuthority.
   const forceReplace = true;
   void E(priceAuthorityAdmin).registerPriceAuthority(
-    E(aggregator.publicFacet).getPriceAuthority(),
+    E(faPublic).getPriceAuthority(),
     brandIn,
     brandOut,
     forceReplace,
@@ -184,9 +239,7 @@ export const createPriceFeed = async (
    * @param {string} addr
    */
   const addOracle = async addr => {
-    const invitation = await E(aggregator.creatorFacet).makeOracleInvitation(
-      addr,
-    );
+    const invitation = await E(faCreatorFacet).makeOracleInvitation(addr);
     await reserveThenDeposit(
       `${AGORIC_INSTANCE_NAME} member ${addr}`,
       namesByAddressAdmin,
@@ -220,6 +273,9 @@ export const getManifestForPriceFeed = async (
         chainStorage: t,
         chainTimerService: t,
         client: t,
+        contractGovernor: t,
+        econCharterKit: t,
+        economicCommitteeCreatorFacet: t,
         namesByAddressAdmin: t,
         priceAuthority: t,
         priceAuthorityAdmin: t,

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -92,7 +92,6 @@ export const createPriceFeed = async (
   {
     consume: {
       agoricNamesAdmin,
-      aggregators,
       board,
       chainStorage,
       chainTimerService,
@@ -102,7 +101,6 @@ export const createPriceFeed = async (
       priceAuthorityAdmin,
       zoe,
     },
-    produce: { aggregators: produceAggregators },
   },
   {
     options: {
@@ -119,8 +117,6 @@ export const createPriceFeed = async (
   trace('createPriceFeed');
   const STORAGE_PATH = 'priceFeed';
 
-  // Default to an empty Map and home.priceAuthority.
-  produceAggregators.resolve(new Map());
   void E(client).assignBundle([_addr => ({ priceAuthority })]);
 
   const timer = await chainTimerService;
@@ -167,7 +163,6 @@ export const createPriceFeed = async (
       marshaller,
     },
   );
-  await E(aggregators).set(terms, { aggregator });
 
   E(E(agoricNamesAdmin).lookupAdmin('instance')).update(
     AGORIC_INSTANCE_NAME,
@@ -176,14 +171,12 @@ export const createPriceFeed = async (
 
   // Publish price feed in home.priceAuthority.
   const forceReplace = true;
-  void E(priceAuthorityAdmin)
-    .registerPriceAuthority(
-      E(aggregator.publicFacet).getPriceAuthority(),
-      brandIn,
-      brandOut,
-      forceReplace,
-    )
-    .then(deleter => E(aggregators).set(terms, { aggregator, deleter }));
+  void E(priceAuthorityAdmin).registerPriceAuthority(
+    E(aggregator.publicFacet).getPriceAuthority(),
+    brandIn,
+    brandOut,
+    forceReplace,
+  );
 
   /**
    * Initialize a new oracle and send an invitation to administer it.
@@ -222,7 +215,6 @@ export const getManifestForPriceFeed = async (
   manifest: {
     [createPriceFeed.name]: {
       consume: {
-        aggregators: t,
         agoricNamesAdmin: t,
         board: t,
         chainStorage: t,
@@ -233,7 +225,6 @@ export const getManifestForPriceFeed = async (
         priceAuthorityAdmin: t,
         zoe: t,
       },
-      produce: { aggregators: t },
     },
     [ensureOracleBrands.name]: {
       consume: {
@@ -326,7 +317,6 @@ export const PRICE_FEEDS_MANIFEST = harden({
   [startPriceFeeds.name]: {
     consume: {
       agoricNamesAdmin: true,
-      aggregators: true,
       board: true,
       chainStorage: true,
       chainTimerService: true,
@@ -336,7 +326,6 @@ export const PRICE_FEEDS_MANIFEST = harden({
       priceAuthorityAdmin: true,
       zoe: true,
     },
-    produce: { aggregators: true },
     installation: { consume: { priceAggregator: true } },
   },
 });

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -312,20 +312,3 @@ export const startPriceFeeds = async (
   trace('startPriceFeeds complete');
 };
 harden(startPriceFeeds);
-
-export const PRICE_FEEDS_MANIFEST = harden({
-  [startPriceFeeds.name]: {
-    consume: {
-      agoricNamesAdmin: true,
-      board: true,
-      chainStorage: true,
-      chainTimerService: true,
-      client: true,
-      namesByAddressAdmin: true,
-      priceAuthority: true,
-      priceAuthorityAdmin: true,
-      zoe: true,
-    },
-    installation: { consume: { priceAggregator: true } },
-  },
-});

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -128,7 +128,7 @@ export const createPriceFeed = async (
   /**
    * Values come from economy-template.json, which at this writing had IN:ATOM, OUT:USD
    *
-   * @type {[[Brand<'nat'>, Brand<'nat'>], [Installation<import('@agoric/inter-protocol/src/price/fluxAggregator.js').start>]]}
+   * @type {[[Brand<'nat'>, Brand<'nat'>], [Installation<import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').start>]]}
    */
   const [[brandIn, brandOut], [priceAggregator]] = await Promise.all([
     reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('oracleBrand'), [

--- a/packages/inter-protocol/src/proposals/utils.js
+++ b/packages/inter-protocol/src/proposals/utils.js
@@ -1,8 +1,6 @@
+import { WalletName } from '@agoric/internal';
 import { getCopyMapEntries, makeCopyMap } from '@agoric/store';
 import { E } from '@endo/far';
-
-// must match packages/wallet/api/src/lib-wallet.js
-export const DEPOSIT_FACET = 'depositFacet';
 
 const { Fail } = assert;
 
@@ -52,6 +50,12 @@ export const reserveThenGetNames = async (nameAdmin, names) =>
     names.map(name => [name]),
   );
 
+/**
+ * @param {string} debugName
+ * @param {ERef<import('@agoric/vats').NameAdmin>} namesByAddressAdmin
+ * @param {string} addr
+ * @param {Array<ERef<Payment>>} payments
+ */
 export const reserveThenDeposit = async (
   debugName,
   namesByAddressAdmin,
@@ -60,7 +64,7 @@ export const reserveThenDeposit = async (
 ) => {
   console.info('awaiting depositFacet for', debugName);
   const [depositFacet] = await reserveThenGetNamePaths(namesByAddressAdmin, [
-    [addr, DEPOSIT_FACET],
+    [addr, WalletName.depositFacet],
   ]);
   console.info('depositing to', debugName);
   await Promise.allSettled(

--- a/packages/inter-protocol/test/price/test-fluxAggregator.js
+++ b/packages/inter-protocol/test/price/test-fluxAggregator.js
@@ -18,7 +18,8 @@ import { subscribeEach } from '@agoric/notifier';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKit } from '@agoric/zoe/src/zoeService/zoe.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
-import { topicPath } from './supports.js';
+import { provideFluxAggregator } from '../../src/price/fluxAggregator.js';
+import { topicPath } from '../supports.js';
 
 /** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeContext>>>} */
 const test = unknownTest;

--- a/packages/inter-protocol/test/price/test-fluxAggregator.js
+++ b/packages/inter-protocol/test/price/test-fluxAggregator.js
@@ -1,33 +1,24 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import path from 'path';
-
-import bundleSource from '@endo/bundle-source';
-
+import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeIssuerKit, AssetKind } from '@agoric/ertp';
 
+import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
+import { subscribeEach } from '@agoric/notifier';
 import {
   eventLoopIteration,
   makeFakeMarshaller,
 } from '@agoric/notifier/tools/testSupports.js';
-import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
-import { subscribeEach } from '@agoric/notifier';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
-import { makeZoeKit } from '@agoric/zoe/src/zoeService/zoe.js';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { provideFluxAggregator } from '../../src/price/fluxAggregator.js';
 import { topicPath } from '../supports.js';
 
 /** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeContext>>>} */
 const test = unknownTest;
-
-const filename = new URL(import.meta.url).pathname;
-const dirname = path.dirname(filename);
-
-const aggregatorPath = `${dirname}/../src/price/fluxAggregatorContract.js`;
 
 const defaultConfig = {
   maxSubmissionCount: 1000,
@@ -39,66 +30,36 @@ const defaultConfig = {
 };
 
 const makeContext = async () => {
-  // Outside of tests, we should use the long-lived Zoe on the
-  // testnet. In this test, we must create a new Zoe.
-  const { admin, vatAdminState } = makeFakeVatAdmin();
-  const { zoeService: zoe } = makeZoeKit(admin);
-
-  // Pack the contracts.
-  const aggregatorBundle = await bundleSource(aggregatorPath);
-
-  // Install the contract on Zoe, getting an installation. We can
-  // use this installation to look up the code we installed. Outside
-  // of tests, we can also send the installation to someone
-  // else, and they can use it to create a new contract instance
-  // using the same code.
-  vatAdminState.installBundle('b1-aggregator', aggregatorBundle);
-  /** @type {Installation<import('../src/price/fluxAggregatorContract.js').start>} */
-  const aggregatorInstallation = await E(zoe).installBundleID('b1-aggregator');
-
   const link = makeIssuerKit('$LINK', AssetKind.NAT);
   const usd = makeIssuerKit('$USD', AssetKind.NAT);
 
   async function makeChainlinkAggregator(config) {
-    const {
-      maxSubmissionCount,
-      maxSubmissionValue,
-      minSubmissionCount,
-      minSubmissionValue,
-      restartDelay,
-      timeout,
-    } = config;
+    const terms = { ...config, brandIn: link.brand, brandOut: usd.brand };
+    const zcfTestKit = await setupZCFTest(undefined, terms);
 
     // ??? why do we need the Far here and not in VaultFactory tests?
     const marshaller = Far('fake marshaller', { ...makeFakeMarshaller() });
     const mockStorageRoot = makeMockChainStorageRoot();
     const storageNode = E(mockStorageRoot).makeChildNode('priceAggregator');
 
-    const timer = buildManualTimer(() => {});
+    const manualTimer = buildManualTimer(() => {});
 
-    const aggregator = await E(zoe).startInstance(
-      aggregatorInstallation,
-      undefined,
-      {
-        timer,
-        brandIn: link.brand,
-        brandOut: usd.brand,
-        maxSubmissionCount,
-        minSubmissionCount,
-        restartDelay,
-        timeout,
-        minSubmissionValue,
-        maxSubmissionValue,
-      },
-      {
-        marshaller,
-        storageNode: E(storageNode).makeChildNode('LINK-USD_price_feed'),
-      },
+    const baggage = makeScalarBigMapStore('test baggage');
+    const quoteIssuerKit = makeIssuerKit('quote', AssetKind.SET);
+
+    const aggregator = provideFluxAggregator(
+      baggage,
+      zcfTestKit.zcf,
+      manualTimer,
+      { ...quoteIssuerKit, assetKind: 'set', displayInfo: undefined },
+      await E(storageNode).makeChildNode('LINK-USD_price_feed'),
+      marshaller,
     );
-    return { ...aggregator, mockStorageRoot };
+
+    return { ...aggregator, manualTimer, mockStorageRoot };
   }
 
-  return { makeChainlinkAggregator, zoe };
+  return { makeChainlinkAggregator };
 };
 
 test.before('setup aggregator and oracles', async t => {
@@ -106,12 +67,8 @@ test.before('setup aggregator and oracles', async t => {
 });
 
 test('basic', async t => {
-  const { zoe } = t.context;
-
   const aggregator = await t.context.makeChainlinkAggregator(defaultConfig);
-  /** @type {{ timer: ManualTimer }} */
-  // @ts-expect-error cast
-  const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
+  const oracleTimer = aggregator.manualTimer;
 
   const pricePushAdminA = await E(aggregator.creatorFacet).initOracle(
     'agorice1priceOracleA',
@@ -168,16 +125,12 @@ test('basic', async t => {
 });
 
 test('timeout', async t => {
-  const { zoe } = t.context;
-
   const aggregator = await t.context.makeChainlinkAggregator({
     ...defaultConfig,
     restartDelay: 2,
     timeout: 5,
   });
-  /** @type {{ timer: ManualTimer }} */
-  // @ts-expect-error cast
-  const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
+  const oracleTimer = aggregator.manualTimer;
 
   const pricePushAdminA = await E(aggregator.creatorFacet).initOracle(
     'agorice1priceOracleA',
@@ -224,15 +177,11 @@ test('timeout', async t => {
 });
 
 test('issue check', async t => {
-  const { zoe } = t.context;
-
   const aggregator = await t.context.makeChainlinkAggregator({
     ...defaultConfig,
     restartDelay: 2,
   });
-  /** @type {{ timer: ManualTimer }} */
-  // @ts-expect-error cast
-  const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
+  const oracleTimer = aggregator.manualTimer;
 
   const pricePushAdminA = await E(aggregator.creatorFacet).initOracle(
     'agorice1priceOracleA',
@@ -275,15 +224,11 @@ test('issue check', async t => {
 });
 
 test('supersede', async t => {
-  const { zoe } = t.context;
-
   const aggregator = await t.context.makeChainlinkAggregator({
     ...defaultConfig,
     restartDelay: 1,
   });
-  /** @type {{ timer: ManualTimer }} */
-  // @ts-expect-error cast
-  const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
+  const oracleTimer = aggregator.manualTimer;
 
   const pricePushAdminA = await E(aggregator.creatorFacet).initOracle(
     'agorice1priceOracleA',
@@ -334,8 +279,6 @@ test('supersede', async t => {
 });
 
 test('interleaved', async t => {
-  const { zoe } = t.context;
-
   const aggregator = await t.context.makeChainlinkAggregator({
     ...defaultConfig,
     maxSubmissionCount: 3,
@@ -343,9 +286,7 @@ test('interleaved', async t => {
     restartDelay: 1,
     timeout: 5,
   });
-  /** @type {{ timer: ManualTimer }} */
-  // @ts-expect-error cast
-  const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
+  const oracleTimer = aggregator.manualTimer;
 
   const pricePushAdminA = await E(aggregator.creatorFacet).initOracle(
     'agorice1priceOracleA',
@@ -477,17 +418,13 @@ test('interleaved', async t => {
 });
 
 test('larger', async t => {
-  const { zoe } = t.context;
-
   const aggregator = await t.context.makeChainlinkAggregator({
     ...defaultConfig,
     minSubmissionCount: 3,
     restartDelay: 1,
     timeout: 5,
   });
-  /** @type {{ timer: ManualTimer }} */
-  // @ts-expect-error cast
-  const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
+  const oracleTimer = aggregator.manualTimer;
 
   const pricePushAdminA = await E(aggregator.creatorFacet).initOracle(
     'agorice1priceOracleA',
@@ -558,17 +495,13 @@ test('larger', async t => {
 });
 
 test('suggest', async t => {
-  const { zoe } = t.context;
-
   const aggregator = await t.context.makeChainlinkAggregator({
     ...defaultConfig,
     minSubmissionCount: 3,
     restartDelay: 1,
     timeout: 5,
   });
-  /** @type {{ timer: ManualTimer }} */
-  // @ts-expect-error cast
-  const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
+  const oracleTimer = aggregator.manualTimer;
 
   const pricePushAdminA = await E(aggregator.creatorFacet).initOracle(
     'agorice1priceOracleA',
@@ -660,16 +593,12 @@ test('suggest', async t => {
 });
 
 test('notifications', async t => {
-  const { zoe } = t.context;
-
   const aggregator = await t.context.makeChainlinkAggregator({
     ...defaultConfig,
     maxSubmissionCount: 1000,
     restartDelay: 1, // have to alternate to start rounds
   });
-  /** @type {{ timer: ManualTimer }} */
-  // @ts-expect-error cast
-  const { timer: oracleTimer } = await E(zoe).getTerms(aggregator.instance);
+  const oracleTimer = aggregator.manualTimer;
 
   const pricePushAdminA = await E(aggregator.creatorFacet).initOracle(
     'agorice1priceOracleA',

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -1,6 +1,8 @@
 import { BridgeId, deeplyFulfilledObject } from '@agoric/internal';
-import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { makeStorageNodeChild } from '@agoric/internal/src/lib-chainStorage.js';
+// eslint-disable-next-line no-unused-vars -- used by TS
+import { coalesceUpdates } from '@agoric/smart-wallet/src/utils.js';
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { E } from '@endo/far';
 import path from 'path';
 import { createPriceFeed } from '../../src/proposals/price-feed-proposal.js';
@@ -136,4 +138,18 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     simpleProvideWallet,
     simpleCreatePriceFeed,
   };
+};
+
+/**
+ * @param {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord} record
+ * @param {Brand<'nat'>} brand
+ */
+export const currentPurseBalance = (record, brand) => {
+  const purses = Array.from(record.purses.values());
+  const match = purses.find(b => b.brand === brand);
+  if (!match) {
+    console.debug('purses', ...purses);
+    assert.fail(`${brand} not found in record`);
+  }
+  return match.balance.value;
 };

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -91,10 +91,10 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
       'installation',
     );
     const paBundle = await bundleCache.load(
-      '../inter-protocol/src/price/fluxAggregator.js',
+      '../inter-protocol/src/price/fluxAggregatorContract.js',
       'priceAggregator',
     );
-    /** @type {Promise<Installation<import('@agoric/inter-protocol/src/price/fluxAggregator.js').start>>} */
+    /** @type {Promise<Installation<import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').start>>} */
     const paInstallation = E(zoe).install(paBundle);
     await E(installAdmin).update('priceAggregator', paInstallation);
 

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -88,7 +88,7 @@ const setupFeedWithWallets = async (t, oracleAddresses) => {
 
   await t.context.simpleCreatePriceFeed(oracleAddresses, 'ATOM', 'USD');
 
-  /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<import('@agoric/inter-protocol/src/price/fluxAggregator.js').start>} */
+  /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').start>} */
   const priceAggregator = await E(agoricNames).lookup(
     'instance',
     'ATOM-USD price feed',

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -1,6 +1,7 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { NonNullish } from '@agoric/assert';
+import { coalesceUpdates } from '@agoric/smart-wallet/src/utils.js';
 import { buildRootObject } from '@agoric/vats/src/core/boot-psm.js';
 import '@agoric/vats/src/core/types.js';
 import {
@@ -8,15 +9,14 @@ import {
   mockPsmBootstrapArgs,
 } from '@agoric/vats/tools/boot-test-utils.js';
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
-import { E } from '@endo/far';
-
-import { coalesceUpdates } from '@agoric/smart-wallet/src/utils.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
-import { INVITATION_MAKERS_DESC } from '../../src/price/fluxAggregator.js';
+import { E } from '@endo/far';
+import { zip } from '../../src/collect.js';
+import { INVITATION_MAKERS_DESC as EC_INVITATION_MAKERS_DESC } from '../../src/econCommitteeCharter.js';
+import { INVITATION_MAKERS_DESC as ORACLE_INVITATION_MAKERS_DESC } from '../../src/price/fluxAggregator.js';
 import { ensureOracleBrands } from '../../src/proposals/price-feed-proposal.js';
 import { headValue } from '../supports.js';
-import { makeDefaultTestContext } from './contexts.js';
-import { zip } from '../../src/collect.js';
+import { currentPurseBalance, makeDefaultTestContext } from './contexts.js';
 
 /**
  * @type {import('ava').TestFn<Awaited<ReturnType<makeDefaultTestContext>>
@@ -25,11 +25,13 @@ import { zip } from '../../src/collect.js';
  */
 const test = anyTest;
 
+const committeeAddress = 'econCommitteeMemberA';
+
 const makeTestSpace = async log => {
   const psmParams = {
     anchorAssets: [{ denom: 'ibc/usdc1234', keyword: 'AUSD' }],
     economicCommitteeAddresses: {
-      /* empty */
+      aMember: committeeAddress,
     },
     argv: { bootMsg: {} },
   };
@@ -77,6 +79,11 @@ test.before(async t => {
   t.context = await makeDefaultTestContext(t, makeTestSpace);
 });
 
+/**
+ *
+ * @param {import('ava').ExecutionContext<*>} t
+ * @param {string[]} oracleAddresses
+ */
 const setupFeedWithWallets = async (t, oracleAddresses) => {
   const { agoricNames } = t.context.consume;
 
@@ -89,12 +96,12 @@ const setupFeedWithWallets = async (t, oracleAddresses) => {
   await t.context.simpleCreatePriceFeed(oracleAddresses, 'ATOM', 'USD');
 
   /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').start>} */
-  const priceAggregator = await E(agoricNames).lookup(
+  const governedPriceAggregator = await E(agoricNames).lookup(
     'instance',
     'ATOM-USD price feed',
   );
 
-  return { oracleWallets, priceAggregator };
+  return { oracleWallets, governedPriceAggregator };
 };
 
 let acceptInvitationCounter = 0;
@@ -105,7 +112,7 @@ const acceptInvitation = async (wallet, priceAggregator) => {
   const getInvMakersSpec = {
     source: 'purse',
     instance: priceAggregator,
-    description: INVITATION_MAKERS_DESC,
+    description: ORACLE_INVITATION_MAKERS_DESC,
   };
 
   /** @type {import('@agoric/smart-wallet/src/offers').OfferSpec} */
@@ -153,7 +160,9 @@ test.serial('invitations', async t => {
 
   // this returns wallets, but we need the updates subscriber to start before the price feed starts
   // so we provision the wallet earlier above
-  const { priceAggregator } = await setupFeedWithWallets(t, [operatorAddress]);
+  const { governedPriceAggregator } = await setupFeedWithWallets(t, [
+    operatorAddress,
+  ]);
 
   /**
    * get invitation details the way a user would
@@ -174,15 +183,15 @@ test.serial('invitations', async t => {
   };
 
   const proposeInvitationDetails = await getInvitationFor(
-    INVITATION_MAKERS_DESC,
+    ORACLE_INVITATION_MAKERS_DESC,
     1,
     computedState.balances,
   );
 
-  t.is(proposeInvitationDetails[0].description, INVITATION_MAKERS_DESC);
+  t.is(proposeInvitationDetails[0].description, ORACLE_INVITATION_MAKERS_DESC);
   t.is(
     proposeInvitationDetails[0].instance,
-    priceAggregator,
+    governedPriceAggregator,
     'priceAggregator',
   );
 
@@ -191,8 +200,8 @@ test.serial('invitations', async t => {
   /** @type {import('@agoric/smart-wallet/src/invitations.js').PurseInvitationSpec} */
   const getInvMakersSpec = {
     source: 'purse',
-    instance: priceAggregator,
-    description: INVITATION_MAKERS_DESC,
+    instance: governedPriceAggregator,
+    description: ORACLE_INVITATION_MAKERS_DESC,
   };
 
   const id = '33';
@@ -210,7 +219,7 @@ test.serial('invitations', async t => {
   t.deepEqual(Object.keys(currentState.offerToUsedInvitation), [id]);
   t.is(
     currentState.offerToUsedInvitation[id].value[0].description,
-    INVITATION_MAKERS_DESC,
+    ORACLE_INVITATION_MAKERS_DESC,
   );
 });
 
@@ -218,11 +227,12 @@ test.serial('admin price', async t => {
   const operatorAddress = 'adminPriceAddress';
   const { zoe } = t.context.consume;
 
-  const { oracleWallets, priceAggregator } = await setupFeedWithWallets(t, [
-    operatorAddress,
-  ]);
+  const { oracleWallets, governedPriceAggregator } = await setupFeedWithWallets(
+    t,
+    [operatorAddress],
+  );
   const wallet = oracleWallets[operatorAddress];
-  const adminOfferId = await acceptInvitation(wallet, priceAggregator);
+  const adminOfferId = await acceptInvitation(wallet, governedPriceAggregator);
 
   // Push a new price result /////////////////////////
 
@@ -239,7 +249,7 @@ test.serial('admin price', async t => {
   // trigger an aggregation (POLL_INTERVAL=1n in context)
   await E(manualTimer).tickN(1);
 
-  const paPublicFacet = await E(zoe).getPublicFacet(priceAggregator);
+  const paPublicFacet = E(zoe).getPublicFacet(governedPriceAggregator);
 
   const latestRoundSubscriber = await E(paPublicFacet).getRoundStartNotifier();
 
@@ -252,9 +262,8 @@ test.serial('admin price', async t => {
 test.serial('errors', async t => {
   const operatorAddress = 'badInputsAddress';
 
-  const { oracleWallets, priceAggregator } = await setupFeedWithWallets(t, [
-    operatorAddress,
-  ]);
+  const { oracleWallets, governedPriceAggregator: priceAggregator } =
+    await setupFeedWithWallets(t, [operatorAddress]);
   const wallet = oracleWallets[operatorAddress];
   const adminOfferId = await acceptInvitation(wallet, priceAggregator);
 
@@ -305,4 +314,210 @@ test.serial('errors', async t => {
       numWantsSatisfied: 1,
     },
   );
+});
+
+test.serial('govern addOracle', async t => {
+  const { invitationBrand } = t.context;
+
+  const newOracle = 'agoric1OracleB';
+
+  const { agoricNames, zoe } = await E.get(t.context.consume);
+  const wallet = await t.context.simpleProvideWallet(committeeAddress);
+  const computedState = coalesceUpdates(E(wallet).getUpdatesSubscriber());
+  const currentSub = E(wallet).getCurrentSubscriber();
+
+  const offersFacet = wallet.getOffersFacet();
+
+  const econCharter = await E(agoricNames).lookup(
+    'instance',
+    'econCommitteeCharter',
+  );
+  const economicCommittee = await E(agoricNames).lookup(
+    'instance',
+    'economicCommittee',
+  );
+  await eventLoopIteration();
+
+  /**
+   * get invitation details the way a user would
+   *
+   * @param {string} desc
+   * @param {number} len
+   * @param {{get: (b: Brand) => Amount | undefined}} balances
+   * @returns {Promise<[{description: string, instance: Instance}]>}
+   */
+  const getInvitationFor = async (desc, len, balances) =>
+    E(E(zoe).getInvitationIssuer())
+      .getBrand()
+      .then(brand => {
+        /** @type {any} */
+        const invitationsAmount = balances.get(brand);
+        t.is(invitationsAmount?.value.length, len);
+        return invitationsAmount.value.filter(i => i.description === desc);
+      });
+
+  const proposeInvitationDetails = await getInvitationFor(
+    EC_INVITATION_MAKERS_DESC,
+    2,
+    computedState.balances,
+  );
+
+  t.is(proposeInvitationDetails[0].description, EC_INVITATION_MAKERS_DESC);
+  t.is(proposeInvitationDetails[0].instance, econCharter, 'econCharter');
+  t.is(
+    // @ts-expect-error cast amount kind
+    currentPurseBalance(await headValue(currentSub), invitationBrand).length,
+    2,
+    'two invitations deposited',
+  );
+
+  // The purse has the invitation to get the makers ///////////
+
+  /** @type {import('@agoric/smart-wallet/src/invitations').PurseInvitationSpec} */
+  const getInvMakersSpec = {
+    source: 'purse',
+    instance: econCharter,
+    description: EC_INVITATION_MAKERS_DESC,
+  };
+
+  /** @type {import('@agoric/smart-wallet/src/offers').OfferSpec} */
+  const invMakersOffer = {
+    id: 44,
+    invitationSpec: getInvMakersSpec,
+    proposal: {},
+  };
+
+  await offersFacet.executeOffer(invMakersOffer);
+
+  /** @type {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord} */
+  let currentState = await headValue(currentSub);
+  t.is(
+    // @ts-expect-error cast amount kind
+    currentPurseBalance(currentState, invitationBrand).length,
+    1,
+    'one invitation consumed, one left',
+  );
+  t.deepEqual(Object.keys(currentState.offerToUsedInvitation), ['44']);
+  t.is(
+    currentState.offerToUsedInvitation[44].value[0].description,
+    'charter member invitation',
+  );
+
+  // Call for a vote ////////////////////////////////
+
+  const feed = await E(agoricNames).lookup('instance', 'ATOM-USD price feed');
+  t.assert(feed);
+
+  /** @type {import('@agoric/smart-wallet/src/invitations').ContinuingInvitationSpec} */
+  const proposeInvitationSpec = {
+    source: 'continuing',
+    previousOffer: 44,
+    invitationMakerName: 'VoteOnApiCall',
+    invitationArgs: harden([feed, 'addOracles', [[newOracle]], 2n]),
+  };
+
+  /** @type {import('@agoric/smart-wallet/src/offers').OfferSpec} */
+  const proposalOfferSpec = {
+    id: 45,
+    invitationSpec: proposeInvitationSpec,
+    proposal: {},
+  };
+
+  await offersFacet.executeOffer(proposalOfferSpec);
+  await eventLoopIteration();
+
+  // vote /////////////////////////
+
+  const committeePublic = E(zoe).getPublicFacet(economicCommittee);
+  const questions = await E(committeePublic).getOpenQuestions();
+  const question = E(committeePublic).getQuestion(questions[0]);
+  const { positions, issue, electionType, questionHandle } = await E(
+    question,
+  ).getDetails();
+  t.is(electionType, 'api_invocation');
+  const yesPosition = harden([positions[0]]);
+  t.deepEqual(issue, {
+    apiMethodName: 'addOracles',
+    methodArgs: [[newOracle]],
+  });
+  t.deepEqual(yesPosition, [
+    { apiMethodName: 'addOracles', methodArgs: [[newOracle]] },
+  ]);
+
+  const voteInvitationDetails = await getInvitationFor(
+    'Voter0',
+    1,
+    computedState.balances,
+  );
+  t.is(voteInvitationDetails.length, 1);
+  const voteInvitationDetail = voteInvitationDetails[0];
+  t.is(voteInvitationDetail.description, 'Voter0');
+  t.is(voteInvitationDetail.instance, economicCommittee);
+
+  /** @type {import('@agoric/smart-wallet/src/invitations').PurseInvitationSpec} */
+  const getCommitteeInvMakersSpec = {
+    source: 'purse',
+    instance: economicCommittee,
+    description: 'Voter0',
+  };
+
+  /** @type {import('@agoric/smart-wallet/src/offers').OfferSpec} */
+  const committeeInvMakersOffer = {
+    id: 46,
+    invitationSpec: getCommitteeInvMakersSpec,
+    proposal: {},
+  };
+
+  await offersFacet.executeOffer(committeeInvMakersOffer);
+  currentState = await headValue(currentSub);
+  t.is(
+    // @ts-expect-error cast amount kind
+    currentPurseBalance(currentState, invitationBrand).length,
+    0,
+    'last invitation consumed, none left',
+  );
+  t.deepEqual(Object.keys(currentState.offerToUsedInvitation), ['44', '46']);
+  // 44 tested above
+  t.is(currentState.offerToUsedInvitation[46].value[0].description, 'Voter0');
+
+  /** @type {import('@agoric/smart-wallet/src/invitations').ContinuingInvitationSpec} */
+  const getVoteSpec = {
+    source: 'continuing',
+    previousOffer: 46,
+    invitationMakerName: 'makeVoteInvitation',
+    invitationArgs: harden([yesPosition, questionHandle]),
+  };
+
+  /** @type {import('@agoric/smart-wallet/src/offers').OfferSpec} */
+  const voteOffer = {
+    id: 47,
+    invitationSpec: getVoteSpec,
+    proposal: {},
+  };
+
+  await offersFacet.executeOffer(voteOffer);
+
+  // pass time to exceed the voting deadline
+  /** @type {ERef<ManualTimer>} */
+  // @ts-expect-error cast mock
+  const timer = t.context.consume.chainTimerService;
+  await E(timer).tickN(10);
+
+  // confirm deposit /////////////////////////
+
+  const oracleWallet = await t.context.simpleProvideWallet(newOracle);
+  const oracleWalletComputedState = coalesceUpdates(
+    E(oracleWallet).getUpdatesSubscriber(),
+  );
+  await eventLoopIteration();
+
+  const oracleInvitationDetails = await getInvitationFor(
+    ORACLE_INVITATION_MAKERS_DESC,
+    1,
+    oracleWalletComputedState.balances,
+  );
+  t.log(oracleInvitationDetails);
+
+  t.is(oracleInvitationDetails[0].description, ORACLE_INVITATION_MAKERS_DESC);
+  t.is(oracleInvitationDetails[0].instance, feed, 'matches feed instance');
 });

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -14,7 +14,7 @@ import { NonNullish } from '@agoric/assert';
 
 import { coalesceUpdates } from '@agoric/smart-wallet/src/utils.js';
 import { INVITATION_MAKERS_DESC } from '../../src/econCommitteeCharter.js';
-import { makeDefaultTestContext } from './contexts.js';
+import { currentPurseBalance, makeDefaultTestContext } from './contexts.js';
 import { headValue, withAmountUtils } from '../supports.js';
 
 /**
@@ -50,20 +50,6 @@ test.before(async t => {
   // @ts-expect-error cast
   t.context = await makeDefaultTestContext(t, makePsmTestSpace);
 });
-
-/**
- * @param {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord} record
- * @param {Brand<'nat'>} brand
- */
-const currentPurseBalance = (record, brand) => {
-  const purses = Array.from(record.purses.values());
-  const match = purses.find(b => b.brand === brand);
-  if (!match) {
-    console.debug('purses', ...purses);
-    assert.fail(`${brand} not found in record`);
-  }
-  return match.balance.value;
-};
 
 test('null swap', async t => {
   const { anchor } = t.context;

--- a/packages/inter-protocol/test/test-priceAggregatorChainlink.js
+++ b/packages/inter-protocol/test/test-priceAggregatorChainlink.js
@@ -26,7 +26,7 @@ const test = unknownTest;
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
 
-const aggregatorPath = `${dirname}/../src/price/fluxAggregator.js`;
+const aggregatorPath = `${dirname}/../src/price/fluxAggregatorContract.js`;
 
 const defaultConfig = {
   maxSubmissionCount: 1000,
@@ -52,7 +52,7 @@ const makeContext = async () => {
   // else, and they can use it to create a new contract instance
   // using the same code.
   vatAdminState.installBundle('b1-aggregator', aggregatorBundle);
-  /** @type {Installation<import('../src/price/fluxAggregator.js').start>} */
+  /** @type {Installation<import('../src/price/fluxAggregatorContract.js').start>} */
   const aggregatorInstallation = await E(zoe).installBundleID('b1-aggregator');
 
   const link = makeIssuerKit('$LINK', AssetKind.NAT);
@@ -122,7 +122,7 @@ test('basic', async t => {
     'agorice1priceOracleC',
   );
 
-  // ----- round 1: basic consensus
+  t.log('----- round 1: basic consensus');
   await oracleTimer.tick();
   await E(pricePushAdminA).pushPrice({ roundId: 1, unitPrice: 100n });
   await E(pricePushAdminB).pushPrice({ roundId: 1, unitPrice: 200n });
@@ -133,7 +133,7 @@ test('basic', async t => {
   t.is(round1Attempt1.roundId, 1n);
   t.is(round1Attempt1.answer, 200n);
 
-  // ----- round 2: check restartDelay implementation
+  t.log('----- round 2: check restartDelay implementation');
   // since oracle A initialized the last round, it CANNOT start another round before
   // the restartDelay, which means its submission will be IGNORED. this means the median
   // should ONLY be between the OracleB and C values, which is why it is 25000
@@ -151,7 +151,7 @@ test('basic', async t => {
   const round2Attempt1 = await E(aggregator.creatorFacet).getRoundData(2);
   t.is(round2Attempt1.answer, 2500n);
 
-  // ----- round 3: check oracle submission order
+  t.log('----- round 3: check oracle submission order');
   // unlike the previous test, if C initializes, all submissions should be recorded,
   // which means the median will be the expected 5000 here
   await oracleTimer.tick();

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@agoric/assert": "^0.5.1",
     "@agoric/ertp": "^0.15.3",
+    "@agoric/internal": "^0.2.1",
     "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -2,6 +2,7 @@
 import { details as X } from '@agoric/assert';
 
 import { AmountMath } from '@agoric/ertp';
+import { WalletName } from '@agoric/internal';
 import { E, Far } from '@endo/far';
 import { makeOncePromiseKit } from './once-promise-kit.js';
 
@@ -95,7 +96,9 @@ export const makeCourierMaker =
       /** @type {DepositFacet} */
       const depositFacet = await E(board)
         .getValue(depositAddress)
-        .catch(_ => E(namesByAddress).lookup(depositAddress, 'depositFacet'));
+        .catch(_ =>
+          E(namesByAddress).lookup(depositAddress, WalletName.depositFacet),
+        );
 
       const { userSeat, zcfSeat } = zcf.makeEmptySeatKit();
 

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -192,7 +192,6 @@
  * @typedef {{
  *   agoricNames: NameHub,
  *   agoricNamesAdmin: import('@agoric/vats').NameAdmin,
- *   aggregators: Map<unknown, { aggregator: PriceAuthority, deleter: import('@agoric/zoe/tools/priceAuthorityRegistry').Deleter }>,
  *   bankManager: BankManager,
  *   bldIssuerKit: RemoteIssuerKit,
  *   board: import('@agoric/vats').Board,

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -13,7 +13,7 @@
 
 import { assert, q, Fail } from '@agoric/assert';
 import { makeScalarStoreCoordinator } from '@agoric/cache';
-import { objectMap } from '@agoric/internal';
+import { objectMap, WalletName } from '@agoric/internal';
 import {
   makeLegacyMap,
   makeScalarMapStore,
@@ -863,7 +863,7 @@ export function makeWalletRoot({
     if (already) {
       depositFacet = actions;
     } else {
-      depositFacet = Far('depositFacet', {
+      depositFacet = Far(WalletName.depositFacet, {
         receive(paymentP) {
           return E(actions).receive(paymentP);
         },
@@ -1987,7 +1987,10 @@ export function makeWalletRoot({
       .then(addInviteDepositFacet);
     zoeInvitePurse = wallet.getPurse(ZOE_INVITE_PURSE_PETNAME);
 
-    await E(myAddressNameAdmin).update('depositFacet', selfDepositFacet);
+    await E(myAddressNameAdmin).update(
+      WalletName.depositFacet,
+      selfDepositFacet,
+    );
   };
 
   // Importing assets as virtual purses from the bank is a highly-trusted path.


### PR DESCRIPTION
part of: #6701 
split from https://github.com/Agoric/agoric-sdk/pull/6963/ and cleaned up for easier review
Next will be `removeOracles` which requires the caretaker pattern

## Description

Grants EC the power to `addOracles` to a price feed.
- feat(price): addOracles by EC

Do that required giving the EC the ability to VoteOnApiCall:
- feat(ec-charter): VoteOnApiCall

Supporting changes:
- refactor(fluxAggregator): split singleton / contract
- feat: puppetGovernance setup tools
- fix(governApi): harden returns
- test(smartWallet): extract helpers from psm integration

PR also includes some incidental cleanup:
- BREAKING CHANGE: remove 'aggregators' from space (I don't think it worked anymore. cc @michaelfig )
- refactor: DRY WalletName.depositFacet
- test(price): rename test-fluxAggregator
- test(price): simplify fluxAggregator test


### Security Considerations

Makes the fluxAggregator subject to changes by governance. This is granted only to the EC.

### Scaling Considerations

--

### Documentation Considerations

removing `aggregators` from the space might impact REPL usage. Users are better off doing a `lookup` imo.

### Testing Considerations

New integration test of FA governance with wallet.