### PR TITLE
feat: null handlers for upgrade-10

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/simapp"
-	store "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -737,26 +736,12 @@ func NewAgoricApp(
 
 	app.UpgradeKeeper.SetUpgradeHandler(
 		upgradeName,
-		upgrade9Handler(app, upgradeName),
+		upgrade10Handler(app, upgradeName),
 	)
 	app.UpgradeKeeper.SetUpgradeHandler(
 		upgradeNameTest,
-		upgrade9Handler(app, upgradeNameTest),
+		upgrade10Handler(app, upgradeNameTest),
 	)
-
-	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
-	if err != nil {
-		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
-	}
-
-	if (upgradeInfo.Name == upgradeName || upgradeInfo.Name == upgradeNameTest) && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		storeUpgrades := store.StoreUpgrades{
-			Added: []string{swingsettypes.StoreKey, vbanktypes.StoreKey, vibc.StoreKey, vstorage.StoreKey, lien.StoreKey},
-		}
-
-		// configure store loader that checks if version == upgradeHeight and applies store upgrades
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
-	}
 
 	if loadLatest {
 		if err := app.LoadLatestVersion(); err != nil {
@@ -772,7 +757,7 @@ func NewAgoricApp(
 	return app
 }
 
-func upgrade9Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgradetypes.Plan, module.VersionMap) (module.VersionMap, error) {
+func upgrade10Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgradetypes.Plan, module.VersionMap) (module.VersionMap, error) {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVm module.VersionMap) (module.VersionMap, error) {
 		return fromVm, nil
 	}

--- a/golang/cosmos/app/const.go
+++ b/golang/cosmos/app/const.go
@@ -1,6 +1,6 @@
 package gaia
 
 const (
-	upgradeName     = "agoric-upgrade-9"
-	upgradeNameTest = "agorictest-upgrade-9"
+	upgradeName     = "agoric-upgrade-10"
+	upgradeNameTest = "agorictest-upgrade-10"
 )


### PR DESCRIPTION
closes: #6685

## Description

Null upgrade handler for upgrade-10.

Removes unneeded store upgrade (removed for upgrade-9 in release-pismo branch).


### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

Must test upgrade from Pismo-C (upgrade-9).