### PR TITLE
6707 pause feed

### DIFF
--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -129,6 +129,13 @@ export const start = async (zcf, privateArgs, baggage) => {
     removeOracles: oracleIds => {
       return Promise.allSettled(oracleIds.map(removeOracle));
     },
+
+    pause: () => {
+      return E(fa.creatorFacet).setPaused(true);
+    },
+    unpause: () => {
+      return E(fa.creatorFacet).setPaused(false);
+    },
   };
 
   const governorFacet = makeGovernorFacet(fa.creatorFacet, governedApis);


### PR DESCRIPTION
closes: #6707
stacks on https://github.com/Agoric/agoric-sdk/pull/6977

## Description

Provides EC the power to pause pushes (for all oracles) to a particular feed.

The issue described doing this by adding an identifier in the 'PushPrice' offer string. I opted against that because of,
1. the changes it would require to the middleware
2. the complexity of maintaining another identifier
3. that governance API calls are easy to add since https://github.com/Agoric/agoric-sdk/pull/6975

### Security Considerations

Grants EC the power pause price pushes to a feed.

### Scaling Considerations

--

### Documentation Considerations

Part of EC tooling documentation.

### Testing Considerations

New tests. While working in these contract/wallet/governance integration tests I think a driver may be worthwhile. I factored out `voteForOpenQuestion` here and may do more in https://github.com/Agoric/agoric-sdk/issues/6859