### PR TITLE
fix: update docker golang version

### DIFF
--- a/packages/deployment/Dockerfile
+++ b/packages/deployment/Dockerfile
@@ -3,7 +3,7 @@ ARG REPO=agoric/agoric-sdk
 
 # FIXME: Journalbeat compilation is currently broken, but non-essential.
 # Removed from the build.
-# FROM golang:buster AS go-build
+# FROM golang:1.18 AS go-build
 
 # WORKDIR /usr/src/journalbeat
 # RUN apt-get update -y && apt-get install -y libsystemd-dev

--- a/packages/deployment/Dockerfile
+++ b/packages/deployment/Dockerfile
@@ -3,7 +3,7 @@ ARG REPO=agoric/agoric-sdk
 
 # FIXME: Journalbeat compilation is currently broken, but non-essential.
 # Removed from the build.
-# FROM golang:1.18 AS go-build
+# FROM golang:1.18-buster AS go-build
 
 # WORKDIR /usr/src/journalbeat
 # RUN apt-get update -y && apt-get install -y libsystemd-dev

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -1,6 +1,6 @@
 ###########################
 # The golang build container
-FROM golang:1.18 as cosmos-go
+FROM golang:1.18-buster as cosmos-go
 
 WORKDIR /usr/src/agoric-sdk/golang/cosmos
 COPY go.mod go.sum ../../

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -1,6 +1,6 @@
 ###########################
 # The golang build container
-FROM golang:1.17-buster as cosmos-go
+FROM golang:1.18 as cosmos-go
 
 WORKDIR /usr/src/agoric-sdk/golang/cosmos
 COPY go.mod go.sum ../../


### PR DESCRIPTION
closes: #6985

## Description

Update the golang version used by Docker packaging.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

None.
