### PR TITLE
6859 CLI reserve command to burn

### DIFF
--- a/packages/agoric-cli/src/bin-agops.js
+++ b/packages/agoric-cli/src/bin-agops.js
@@ -12,6 +12,7 @@ import path from 'path';
 import { makeOracleCommand } from './commands/oracle.js';
 import { makeEconomicCommiteeCommand } from './commands/ec.js';
 import { makePsmCommand } from './commands/psm.js';
+import { makeReserveCommand } from './commands/reserve.js';
 import { makeVaultsCommand } from './commands/vaults.js';
 import { makePerfCommand } from './commands/perf.js';
 
@@ -25,6 +26,7 @@ program.addCommand(await makeOracleCommand(logger));
 program.addCommand(await makeEconomicCommiteeCommand(logger));
 program.addCommand(await makePerfCommand(logger));
 program.addCommand(await makePsmCommand(logger));
+program.addCommand(await makeReserveCommand(logger));
 program.addCommand(await makeVaultsCommand(logger));
 
 await program.parseAsync(process.argv);

--- a/packages/agoric-cli/src/bin-agops.js
+++ b/packages/agoric-cli/src/bin-agops.js
@@ -10,6 +10,7 @@ import anylogger from 'anylogger';
 import { Command } from 'commander';
 import path from 'path';
 import { makeOracleCommand } from './commands/oracle.js';
+import { makeEconomicCommiteeCommand } from './commands/ec.js';
 import { makePsmCommand } from './commands/psm.js';
 import { makeVaultsCommand } from './commands/vaults.js';
 import { makePerfCommand } from './commands/perf.js';
@@ -21,8 +22,9 @@ const program = new Command();
 program.name(progname).version('unversioned');
 
 program.addCommand(await makeOracleCommand(logger));
-program.addCommand(await makePsmCommand(logger));
+program.addCommand(await makeEconomicCommiteeCommand(logger));
 program.addCommand(await makePerfCommand(logger));
+program.addCommand(await makePsmCommand(logger));
 program.addCommand(await makeVaultsCommand(logger));
 
 await program.parseAsync(process.argv);

--- a/packages/agoric-cli/src/commands/ec.js
+++ b/packages/agoric-cli/src/commands/ec.js
@@ -1,0 +1,134 @@
+/* eslint-disable @jessie.js/no-nested-await */
+// @ts-check
+/* eslint-disable func-names */
+/* global fetch */
+import { Command } from 'commander';
+import { makeRpcUtils, storageHelper } from '../lib/rpc.js';
+import { outputAction } from '../lib/wallet.js';
+
+const { vstorage, fromBoard, agoricNames } = await makeRpcUtils({ fetch });
+
+/**
+ *
+ * @param {import('anylogger').Logger} _logger
+ */
+export const makeEconomicCommiteeCommand = async _logger => {
+  const ec = new Command('ec').description('Economic Committee commands');
+
+  ec.command('committee')
+    .description('accept invitation to join the economic committee')
+    .option(
+      '--offerId [string]',
+      'Offer id',
+      String,
+      `ecCommittee-${Date.now()}`,
+    )
+    .action(async function (opts) {
+      const { economicCommittee } = agoricNames.instance;
+      assert(economicCommittee, 'missing economicCommittee');
+
+      /** @type {import('../lib/psm.js').OfferSpec} */
+      const offer = {
+        id: opts.offerId,
+        invitationSpec: {
+          source: 'purse',
+          // @ts-expect-error xxx RpcRemote
+          instance: economicCommittee,
+          description: 'Voter0', // XXX it may not always be
+        },
+        proposal: {},
+      };
+
+      outputAction({
+        method: 'executeOffer',
+        offer,
+      });
+
+      console.warn('Now execute the prepared offer');
+    });
+
+  ec.command('charter')
+    .description('prepare an offer to accept the charter invitation')
+    .option('--offerId [string]', 'Offer id', String, `ecCharter-${Date.now()}`)
+    .action(async function (opts) {
+      const { econCommitteeCharter } = agoricNames.instance;
+      assert(econCommitteeCharter, 'missing econCommitteeCharter');
+
+      /** @type {import('../lib/psm.js').OfferSpec} */
+      const offer = {
+        id: opts.offerId,
+        invitationSpec: {
+          source: 'purse',
+          // @ts-expect-error xxx RpcRemote
+          instance: econCommitteeCharter,
+          description: 'charter member invitation',
+        },
+        proposal: {},
+      };
+
+      outputAction({
+        method: 'executeOffer',
+        offer,
+      });
+
+      console.warn('Now execute the prepared offer');
+    });
+
+  ec.command('vote')
+    .description('vote on a question (hard-coded for now))')
+    .option('--offerId [number]', 'Offer id', String, `ecVote-${Date.now()}`)
+    .requiredOption(
+      '--econCommAcceptOfferId [string]',
+      'offer that had continuing invitation result',
+    )
+    .requiredOption(
+      '--forPosition [number]',
+      'index of one position to vote for (within the question description.positions); ',
+      Number,
+    )
+    .action(async function (opts) {
+      const questionHandleCapDataStr = await vstorage.readLatest(
+        'published.committees.Economic_Committee.latestQuestion',
+      );
+      const questionDescriptions = storageHelper.unserializeTxt(
+        questionHandleCapDataStr,
+        fromBoard,
+      );
+
+      assert(questionDescriptions, 'missing questionDescriptions');
+      assert(
+        questionDescriptions.length === 1,
+        'multiple questions not supported',
+      );
+
+      const questionDesc = questionDescriptions[0];
+      // TODO support multiple position arguments
+      const chosenPositions = [questionDesc.positions[opts.forPosition]];
+      assert(chosenPositions, `undefined position index ${opts.forPosition}`);
+
+      /** @type {import('../lib/psm.js').OfferSpec} */
+      const offer = {
+        id: opts.offerId,
+        invitationSpec: {
+          source: 'continuing',
+          previousOffer: opts.econCommAcceptOfferId,
+          invitationMakerName: 'makeVoteInvitation',
+          // (positionList, questionHandle)
+          invitationArgs: harden([
+            chosenPositions,
+            questionDesc.questionHandle,
+          ]),
+        },
+        proposal: {},
+      };
+
+      outputAction({
+        method: 'executeOffer',
+        offer,
+      });
+
+      console.warn('Now execute the prepared offer');
+    });
+
+  return ec;
+};

--- a/packages/agoric-cli/src/commands/reserve.js
+++ b/packages/agoric-cli/src/commands/reserve.js
@@ -1,0 +1,70 @@
+/* eslint-disable @jessie.js/no-nested-await */
+// @ts-check
+/* eslint-disable func-names */
+/* global fetch */
+import { Command } from 'commander';
+import { makeRpcUtils } from '../lib/rpc.js';
+import { outputAction } from '../lib/wallet.js';
+
+const { agoricNames } = await makeRpcUtils({ fetch });
+
+/**
+ *
+ * @param {import('anylogger').Logger} _logger
+ */
+export const makeReserveCommand = async _logger => {
+  const reserve = new Command('reserve').description('Asset Reserve commands');
+
+  reserve
+    .command('proposeBurn')
+    .description('propose a call to burnFeesToReduceShortfall')
+    .option(
+      '--offerId [string]',
+      'Offer id',
+      String,
+      `proposePauseOffers-${Date.now()}`,
+    )
+    .requiredOption(
+      '--charterAcceptOfferId [string]',
+      'offer that had continuing invitation result',
+    )
+    .requiredOption('--value [integer]', 'value of µIST to burn', BigInt)
+    .option(
+      '--deadline [minutes]',
+      'minutes from now to close the vote',
+      Number,
+      1,
+    )
+    .action(async function (opts) {
+      const reserveInstance = agoricNames.instance.reserve;
+      assert(reserveInstance, 'missing reserve in names');
+
+      const feesToBurn = { brand: agoricNames.brand.IST, value: opts.value };
+
+      /** @type {import('../lib/psm.js').OfferSpec} */
+      const offer = {
+        id: opts.offerId,
+        invitationSpec: {
+          source: 'continuing',
+          previousOffer: opts.charterAcceptOfferId,
+          invitationMakerName: 'VoteOnApiCall',
+          invitationArgs: harden([
+            reserveInstance,
+            'burnFeesToReduceShortfall',
+            [feesToBurn],
+            BigInt(opts.deadline * 60 + Math.round(Date.now() / 1000)),
+          ]),
+        },
+        proposal: {},
+      };
+
+      outputAction({
+        method: 'executeOffer',
+        offer,
+      });
+
+      console.warn('Now execute the prepared offer');
+    });
+
+  return reserve;
+};

--- a/packages/agoric-cli/test/agops-governance-smoketest.sh
+++ b/packages/agoric-cli/test/agops-governance-smoketest.sh
@@ -31,33 +31,33 @@ set -x
 
 # Accept invitation to economic committee
 COMMITTEE_OFFER=$(mktemp -t agops.XXX)
-bin/agops psm committee >|"$COMMITTEE_OFFER"
+bin/agops ec committee >|"$COMMITTEE_OFFER"
 jq ".body | fromjson" <"$COMMITTEE_OFFER"
 agoric wallet send --from "$WALLET" --offer "$COMMITTEE_OFFER"
 # verify the offerId is readable from chain history
 agoric wallet show --from "$WALLET"
-COMMITTEE_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$COMMITTEE_OFFER")
+COMMITTEE_OFFER_ID=$(jq -r ".body | fromjson | .offer.id" <"$COMMITTEE_OFFER")
 
 # Accept invitation to be a charter member
 CHARTER_OFFER=$(mktemp -t agops.XXX)
-bin/agops psm charter >|"$CHARTER_OFFER"
+bin/agops ec charter >|"$CHARTER_OFFER"
 jq ".body | fromjson" <"$CHARTER_OFFER"
 agoric wallet send --from "$WALLET" --offer "$CHARTER_OFFER"
 # verify the offerId is readable from chain history
 agoric wallet show --from "$WALLET"
-CHARTER_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$CHARTER_OFFER")
+CHARTER_OFFER_ID=$(jq -r ".body | fromjson | .offer.id" <"$CHARTER_OFFER")
 
 ### Now we have the continuing invitationMakers saved in the wallet
 
 # Use invitation result, with continuing invitationMakers to propose a vote
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops psm proposePauseOffers --substring wantMinted --psmCharterAcceptOfferId "$CHARTER_OFFER_ID" >|"$PROPOSAL_OFFER"
+bin/agops psm proposePauseOffers --substring wantMinted --charterAcceptOfferId "$CHARTER_OFFER_ID" >|"$PROPOSAL_OFFER"
 jq ".body | fromjson" <"$PROPOSAL_OFFER"
 agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
 
 # vote on the question that was made
 VOTE_OFFER=$(mktemp -t agops.XXX)
-bin/agops psm vote --forPosition 0 --econCommAcceptOfferId "$COMMITTEE_OFFER_ID" >|"$VOTE_OFFER"
+bin/agops ec vote --forPosition 0 --econCommAcceptOfferId "$COMMITTEE_OFFER_ID" >|"$VOTE_OFFER"
 jq ".body | fromjson" <"$VOTE_OFFER"
 agoric wallet send --from "$WALLET" --offer "$VOTE_OFFER"
 ## wait for the election to be resolved (1m in commands/psm.js)
@@ -90,7 +90,7 @@ agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
 
 # vote on the question that was made
 VOTE_OFFER=$(mktemp -t agops.XXX)
-bin/agops psm vote --forPosition 0 --econCommAcceptOfferId "$COMMITTEE_OFFER_ID" >|"$VOTE_OFFER"
+bin/agops ec vote --forPosition 0 --econCommAcceptOfferId "$COMMITTEE_OFFER_ID" >|"$VOTE_OFFER"
 jq ".body | fromjson" <"$VOTE_OFFER"
 agoric wallet send --from "$WALLET" --offer "$VOTE_OFFER"
 ## wait for the election to be resolved (1m default in commands/psm.js)

--- a/packages/agoric-cli/test/agops-governance-smoketest.sh
+++ b/packages/agoric-cli/test/agops-governance-smoketest.sh
@@ -97,3 +97,15 @@ agoric wallet send --offer "$VOTE_OFFER" --from "$WALLET" --keyring-backend="tes
 
 # to see the new MintLimit
 bin/agops psm info
+
+# Propose to burn fees
+PROPOSAL_OFFER=$(mktemp -t agops.XXX)
+bin/agops reserve proposeBurn --value 1000 --charterAcceptOfferId "$CHARTER_OFFER_ID" >|"$PROPOSAL_OFFER"
+jq ".body | fromjson" <"$PROPOSAL_OFFER"
+agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET" --keyring-backend="test"
+
+# Vote for the API call
+VOTE_OFFER=$(mktemp -t agops.XXX)
+bin/agops ec vote --forPosition 0 --econCommAcceptOfferId "$COMMITTEE_OFFER_ID" >|"$VOTE_OFFER"
+jq ".body | fromjson" <"$VOTE_OFFER"
+agoric wallet send --offer "$VOTE_OFFER" --from "$WALLET" --keyring-backend="test"

--- a/packages/agoric-cli/test/agops-governance-smoketest.sh
+++ b/packages/agoric-cli/test/agops-governance-smoketest.sh
@@ -33,7 +33,7 @@ set -x
 COMMITTEE_OFFER=$(mktemp -t agops.XXX)
 bin/agops ec committee >|"$COMMITTEE_OFFER"
 jq ".body | fromjson" <"$COMMITTEE_OFFER"
-agoric wallet send --from "$WALLET" --offer "$COMMITTEE_OFFER"
+agoric wallet send --offer "$COMMITTEE_OFFER" --from "$WALLET" --keyring-backend="test"
 # verify the offerId is readable from chain history
 agoric wallet show --from "$WALLET"
 COMMITTEE_OFFER_ID=$(jq -r ".body | fromjson | .offer.id" <"$COMMITTEE_OFFER")
@@ -42,7 +42,7 @@ COMMITTEE_OFFER_ID=$(jq -r ".body | fromjson | .offer.id" <"$COMMITTEE_OFFER")
 CHARTER_OFFER=$(mktemp -t agops.XXX)
 bin/agops ec charter >|"$CHARTER_OFFER"
 jq ".body | fromjson" <"$CHARTER_OFFER"
-agoric wallet send --from "$WALLET" --offer "$CHARTER_OFFER"
+agoric wallet send --offer "$CHARTER_OFFER" --from "$WALLET" --keyring-backend="test"
 # verify the offerId is readable from chain history
 agoric wallet show --from "$WALLET"
 CHARTER_OFFER_ID=$(jq -r ".body | fromjson | .offer.id" <"$CHARTER_OFFER")
@@ -53,13 +53,13 @@ CHARTER_OFFER_ID=$(jq -r ".body | fromjson | .offer.id" <"$CHARTER_OFFER")
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
 bin/agops psm proposePauseOffers --substring wantMinted --charterAcceptOfferId "$CHARTER_OFFER_ID" >|"$PROPOSAL_OFFER"
 jq ".body | fromjson" <"$PROPOSAL_OFFER"
-agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
+agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET" --keyring-backend="test"
 
 # vote on the question that was made
 VOTE_OFFER=$(mktemp -t agops.XXX)
 bin/agops ec vote --forPosition 0 --econCommAcceptOfferId "$COMMITTEE_OFFER_ID" >|"$VOTE_OFFER"
 jq ".body | fromjson" <"$VOTE_OFFER"
-agoric wallet send --from "$WALLET" --offer "$VOTE_OFFER"
+agoric wallet send --offer "$VOTE_OFFER" --from "$WALLET" --keyring-backend="test"
 ## wait for the election to be resolved (1m in commands/psm.js)
 
 # FIXME this one failing with: Error: cannot grab 10002ibc/toyellie coins: 0ibc/toyellie is smaller than 10002ibc/toyellie: insufficient funds
@@ -67,7 +67,7 @@ agoric wallet send --from "$WALLET" --offer "$VOTE_OFFER"
 # TODO use vote outcome data https://github.com/Agoric/agoric-sdk/pull/6204/
 SWAP_OFFER=$(mktemp -t agops.XXX)
 bin/agops psm swap --wantMinted 0.01 --feePct 0.01 >|"$SWAP_OFFER"
-agoric wallet send --from "$WALLET" --offer "$SWAP_OFFER"
+agoric wallet send --offer "$SWAP_OFFER" --from "$WALLET" --keyring-backend="test"
 
 # chain logs should read like:
 # vat: v15: walletFactory: { wallet: Object [Alleged: SmartWallet self] {}, actionCapData: { body: '{"method":"executeOffer","offer":{"id":1663182246304,"invitationSpec":{"source":"contract","instance":{"@qclass":"slot","index":0},"publicInvitationMaker":"makeWantMintedInvitation"},"proposal":{"give":{"In":{"brand":{"@qclass":"slot","index":1},"value":{"@qclass":"bigint","digits":"10002"}}},"want":{"Out":{"brand":{"@qclass":"slot","index":2},"value":{"@qclass":"bigint","digits":"10000"}}}}}}', slots: [ 'board04312', 'board0223', 'board0639' ] } }
@@ -81,7 +81,7 @@ agoric wallet send --from "$WALLET" --offer "$SWAP_OFFER"
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
 bin/agops psm proposeChangeMintLimit --limit 10000 --previousOfferId "$CHARTER_OFFER_ID" >|"$PROPOSAL_OFFER"
 jq ".body | fromjson" <"$PROPOSAL_OFFER"
-agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
+agoric wallet send --offer "$PROPOSAL_OFFER" --from "$WALLET" --keyring-backend="test"
 
 # to verify that the question was proposed, you can use
 # agoric follow published.committees.Economic_Committee.latestQuestion
@@ -92,7 +92,7 @@ agoric wallet send --from "$WALLET" --offer "$PROPOSAL_OFFER"
 VOTE_OFFER=$(mktemp -t agops.XXX)
 bin/agops ec vote --forPosition 0 --econCommAcceptOfferId "$COMMITTEE_OFFER_ID" >|"$VOTE_OFFER"
 jq ".body | fromjson" <"$VOTE_OFFER"
-agoric wallet send --from "$WALLET" --offer "$VOTE_OFFER"
+agoric wallet send --offer "$VOTE_OFFER" --from "$WALLET" --keyring-backend="test"
 ## wait for the election to be resolved (1m default in commands/psm.js)
 
 # to see the new MintLimit

--- a/packages/agoric-cli/test/agops-oracle-smoketest.sh
+++ b/packages/agoric-cli/test/agops-oracle-smoketest.sh
@@ -37,7 +37,7 @@ ORACLE_OFFER=$(mktemp -t agops.XXX)
 bin/agops oracle accept >|"$ORACLE_OFFER"
 jq ".body | fromjson" <"$ORACLE_OFFER"
 agoric wallet send --offer "$ORACLE_OFFER" --from "$WALLET" --keyring-backend="test"
-ORACLE_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
+ORACLE_OFFER_ID=$(jq -r ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
 
 # verify the offerId is readable from chain history
 agoric wallet show --from "$WALLET" --keyring-backend="test"
@@ -47,7 +47,7 @@ ORACLE_OFFER=$(mktemp -t agops.XXX)
 bin/agops oracle accept >|"$ORACLE_OFFER"
 jq ".body | fromjson" <"$ORACLE_OFFER"
 agoric wallet send --offer "$ORACLE_OFFER" --from "$WALLET2" --keyring-backend="test"
-ORACLE2_OFFER_ID=$(jq ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
+ORACLE2_OFFER_ID=$(jq -r ".body | fromjson | .offer.id" <"$ORACLE_OFFER")
 
 ### Now we have the continuing invitationMakers saved in the wallets
 

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -39,6 +39,7 @@ const nonalphanumeric = /[^A-Za-z0-9]/g;
 /**
  * @typedef {{
  *   state: {
+ *     totalFeeBurned: Amount<'nat'>,
  *     totalFeeMinted: Amount<'nat'>,
  *   },
  *   facets: {
@@ -103,6 +104,7 @@ const start = async (zcf, privateArgs, baggage) => {
     'liquidityBrandForBrand',
   );
 
+  /** @type {() => Promise<ZCFMint<'nat'>>} */
   const takeFeeMint = async () => {
     if (baggage.has('feeMint')) {
       return baggage.get('feeMint');
@@ -381,7 +383,14 @@ const start = async (zcf, privateArgs, baggage) => {
     updateMetrics({ state });
   };
 
+  /**
+   *
+   * @param {MethodContext} context
+   * @param {Amount<'nat'>} reduction
+   * @returns {void}
+   */
   const burnFeesToReduceShortfall = ({ state }, reduction) => {
+    trace('burnFeesToReduceShortfall', reduction);
     reduction = AmountMath.coerce(feeKit.brand, reduction);
     const feeKeyword = keywordForBrand.get(feeKit.brand);
     const feeBalance = collateralSeat.getAmountAllocated(feeKeyword);


### PR DESCRIPTION
## Description

Part of #6859 to prove out the backend for https://github.com/Agoric/dapp-econ-gov/issues/33

Adds a `reserve` command with a `burn` subcommand to support integration testing.

Also moves some subcommands of `psm` out to `ec` for more general use.

### Security Considerations

--
### Scaling Considerations

--
### Documentation Considerations

`!` to note breaking change for `agops psm` commands.

### Testing Considerations

Ran the smoketests to validate that the `burnFeesToReduceShortfall` method was invoked by governance using `reserve burn`.