### PR TITLE
6850 targeting by agoricNames

### DIFF
--- a/packages/agoric-cli/src/commands/vaults.js
+++ b/packages/agoric-cli/src/commands/vaults.js
@@ -68,14 +68,12 @@ export const makeVaultsCommand = async logger => {
     .action(async function (opts) {
       logger.warn('running with options', opts);
 
-      const { VaultFactory } = agoricNames.instance;
-
       const spendAction = makeOpenSpendAction(
         // @ts-expect-error xxx RpcRemote
-        VaultFactory,
         agoricNames.brand,
         opts,
       );
+
       outputAction(spendAction);
     });
 

--- a/packages/agoric-cli/src/lib/rpc.js
+++ b/packages/agoric-cli/src/lib/rpc.js
@@ -152,14 +152,16 @@ export const boardSlottingMarshaller = (slotToVal = (s, _i) => s) => ({
     return JSON.parse(body, reviver);
   },
   serialize: whole => {
+    /** @type {Map<string, number>} */
     const seen = new Map();
-    const slotIndex = v => {
-      if (seen.has(v)) {
-        return seen.get(v);
+    /** @type {(boardId: string) => number} */
+    const slotIndex = boardId => {
+      let index = seen.get(boardId);
+      if (index === undefined) {
+        index = seen.size;
+        seen.set(boardId, index);
       }
-      const index = seen.size;
-      seen.set(v, index);
-      return { index, iface: v.iface };
+      return index;
     };
     const recur = part => {
       if (part === null) return null;
@@ -171,7 +173,7 @@ export const boardSlottingMarshaller = (slotToVal = (s, _i) => s) => ({
       }
       if (typeof part === 'object') {
         if ('boardId' in part) {
-          return { '@qclass': 'slot', ...slotIndex(part.boardId) };
+          return { '@qclass': 'slot', index: slotIndex(part.boardId) };
         }
         return Object.fromEntries(
           Object.entries(part).map(([k, v]) => [k, recur(v)]),

--- a/packages/agoric-cli/src/lib/vaults.js
+++ b/packages/agoric-cli/src/lib/vaults.js
@@ -51,12 +51,11 @@ const makeProposal = (brands, opts) => {
 };
 
 /**
- * @param {Instance} instance
  * @param {Record<string, Brand>} brands
  * @param {{ offerId: string, wantMinted: number, giveCollateral: number }} opts
  * @returns {BridgeAction}
  */
-export const makeOpenSpendAction = (instance, brands, opts) => {
+export const makeOpenSpendAction = (brands, opts) => {
   const proposal = makeProposal(brands, opts);
 
   console.warn('vaults open give', proposal.give);
@@ -66,13 +65,19 @@ export const makeOpenSpendAction = (instance, brands, opts) => {
   // Instead they're copyRecord like  "{"boardId":"board0257","iface":"Alleged: IST brand"}" to pass through the boardId
   // mustMatch(harden(proposal), ProposalShape);
 
+  // XXX only one supported yet
+  const collateralBrand = brands.IbcATOM;
+
   /** @type {OfferSpec} */
   const offer = {
     id: opts.offerId,
     invitationSpec: {
-      source: 'contract',
-      instance,
-      publicInvitationMaker: 'makeVaultInvitation',
+      source: 'agoricContract',
+      instancePath: ['VaultFactory'],
+      callPipe: [
+        ['getCollateralManager', [collateralBrand]],
+        ['makeVaultInvitation'],
+      ],
     },
     proposal,
   };

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -1,38 +1,56 @@
 import { AmountMath } from '@agoric/ertp';
 import { mustMatch } from '@agoric/store';
+import { InvitationHandleShape } from '@agoric/zoe/src/typeGuards.js';
 import { E } from '@endo/far';
 import { shape } from './typeGuards.js';
 
 // Ambient types. Needed only for dev but this does a runtime import.
 import '@agoric/zoe/exported.js';
 
+const { Fail } = assert;
+
+// A safety limit
+const MAX_PIPE_LENGTH = 2;
+
 /**
- * Supports three cases
- * 1. source is a contract (in which case this takes an Instance to look up in zoe)
- * 2. the invitation is already in your Zoe "invitation" purse so we need to query it
- *    - use the find/query invitation by kvs thing
- * 3. continuing invitation in which the offer result from a previous invitation had an `invitationMakers` property
- *
- * @typedef {ContractInvitationSpec | PurseInvitationSpec | ContinuingInvitationSpec} InvitationSpec
+ * @typedef {AgoricContractInvitationSpec | ContractInvitationSpec | PurseInvitationSpec | ContinuingInvitationSpec} InvitationSpec
+ * Specify how to produce an invitation. See each type in the union for details.
  */
+
 /**
+ * @typedef {{
+ * source: 'agoricContract',
+ * instancePath: string[],
+ * callPipe: Array<[methodName: string, methodArgs?: any[]]>,
+ * }} AgoricContractInvitationSpec
+ * source of invitation is a chain of calls starting with an agoricName
+ *   - the start of the pipe is a lookup of instancePath within agoricNames
+ *   - each entry in the callPipe executes a call on the preceeding result
+ *   - the end of the pipe is expected to return an Invitation
+ *
  * @typedef {{
  * source: 'contract',
  * instance: Instance,
  * publicInvitationMaker: string,
  * invitationArgs?: any[],
  * }} ContractInvitationSpec
+ * source is a contract (in which case this takes an Instance to look up in zoe)
+ *
  * @typedef {{
  * source: 'purse',
  * instance: Instance,
  * description: string,
  * }} PurseInvitationSpec
+ * the invitation is already in your Zoe "invitation" purse so we need to query it
+ *   - use the find/query invitation by kvs thing
+ *
  * @typedef {{
  * source: 'continuing',
  * previousOffer: import('./offers.js').OfferId,
  * invitationMakerName: string,
  * invitationArgs?: any[],
  * }} ContinuingInvitationSpec
+ * continuing invitation in which the offer result from a previous invitation had an `invitationMakers` property
  */
 
 /**
@@ -40,19 +58,38 @@ import '@agoric/zoe/exported.js';
  */
 
 /**
- *
  * @param {ERef<ZoeService>} zoe
+ * @param {ERef<NameHub>} agoricNames
  * @param {Brand<'set'>} invitationBrand
  * @param {Purse<'set'>} invitationsPurse
  * @param {(fromOfferId: string) => import('./types').RemoteInvitationMakers} getInvitationContinuation
  */
 export const makeInvitationsHelper = (
   zoe,
+  agoricNames,
   invitationBrand,
   invitationsPurse,
   getInvitationContinuation,
 ) => {
   const invitationGetters = /** @type {const} */ ({
+    /** @type {(spec: AgoricContractInvitationSpec) => Promise<Invitation>} */
+    async agoricContract(spec) {
+      mustMatch(spec, shape.AgoricContractInvitationSpec);
+
+      const { instancePath, callPipe } = spec;
+      instancePath.length >= 1 || Fail`instancePath path list empy`;
+      callPipe.length <= MAX_PIPE_LENGTH ||
+        Fail`callPipe longer than MAX_PIPE_LENGTH=${MAX_PIPE_LENGTH}`;
+      const instance = E(agoricNames).lookup('instance', ...instancePath);
+      let eref = E(zoe).getPublicFacet(instance);
+      for (const [methodName, methodArgs = []] of callPipe) {
+        eref = E(eref)[methodName](...methodArgs);
+      }
+
+      const invitation = await eref;
+      mustMatch(invitation, InvitationHandleShape);
+      return invitation;
+    },
     /** @type {(spec: ContractInvitationSpec) => Promise<Invitation>} */
     contract(spec) {
       mustMatch(spec, shape.ContractInvitationSpec);
@@ -115,6 +152,8 @@ export const makeInvitationsHelper = (
   /** @type {(spec: InvitationSpec) => ERef<Invitation>} */
   const invitationFromSpec = spec => {
     switch (spec.source) {
+      case 'agoricContract':
+        return invitationGetters.agoricContract(spec);
       case 'contract':
         return invitationGetters.contract(spec);
       case 'purse':

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -424,6 +424,7 @@ export const prepareSmartWallet = (baggage, shared) => {
             powers: {
               invitationFromSpec: makeInvitationsHelper(
                 zoe,
+                shared.agoricNames,
                 invitationBrand,
                 invitationPurse,
                 offerToInvitationMakers.get,

--- a/packages/smart-wallet/src/typeGuards.js
+++ b/packages/smart-wallet/src/typeGuards.js
@@ -12,6 +12,11 @@ export const shape = {
   },
 
   // invitations
+  AgoricContractInvitationSpec: {
+    source: 'agoricContract',
+    instancePath: M.arrayOf(M.string()),
+    callPipe: M.arrayOf(M.splitArray([M.string()], [M.arrayOf(M.any())])),
+  },
   ContractInvitationSpec: M.splitRecord(
     {
       source: 'contract',


### PR DESCRIPTION
closes: #6850

## Description

Smart Wallet clients need to describe a method to call to make an invitation. There are currently three ways:
- `contract` gets it from a contract instance by calling `E(zoe).getPublicFacet` on the marshaled instance
- `purse` gets it from the wallet's purse, having been deposited there
- `continuing` gets it from the wallet's store of results from previous offers

This introduces a fourth, `agoricContract`. It differs from `contract` in two ways. The first is that it takes an `instancePath`, instead of a marshaled instance, which it looks up in agoricNames. (h/t @michaelfig )

The second is that it takes a `callPipe` instead of a single call description. (h/t @samsiegart ) This is necessary to support the VaultFactory use case of `makeVaultInvitation` on something returned by a method of the VaultFactory public facet.

This demonstrates the piping with PSM offers because we have a nice fast integration test for that. We don't yet for Vault Factory (#6880) so instead I updated the `agops vaults` CLI command to demonstrate and test. 

### Security Considerations

Grants wallet holders the ability to call arbitrary methods on the results of other methods. The call chain can only start from a public facet of an instance registered in agoricNames. These are designed to transitively return publicly available capabilities.

### Scaling Considerations

It may be a vector for resource exhaustion. Callers pay by message size but the marginal cost per call may be greater than the cost of increased message size. This sets a max pipe length (call depth) limit of 2 which is all that MakeVault needs.

### Documentation Considerations

The smart wallet as a whole will need to reach agoric/documentation at some point.

### Testing Considerations

The test is in test-psm-integration right now because that has a contract and agoricNames setup to test against.

- [x] also test the vaults smoketest with the new agops cmd (this detected a CLI marshaller bug now fixed in 9a6f761c2d0c9cab25d572addd64c72d73f54cee ) 