### PR TITLE
ci: include PR body in merge commit message

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,8 @@
 # Linear queue for the main branch.
 queue_rules:
   - name: main
-    conditions:
+    commit_message_template: "Merge (#{{ number }}): {{ title }}\n\n{{ body }}"
+    merge_conditions:
       - base=master
       # Require integration tests before merging only
       - or:


### PR DESCRIPTION
## Description

We put a lot of info into our PR bodies which doesn’t get into the Git repo when we merge. The merge commit references the PR number, but that ties the repo permanently to Github. 

This modifies the `main` Mergify queue to include the PR title and body in the commit message

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
