### PR TITLE
6689 fix watchPurse race

### DIFF
--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -153,18 +153,17 @@ export async function makeStorageNodeChild(storageNodeRef, childName) {
 }
 harden(makeStorageNodeChild);
 
+// TODO find a better module for this
 /**
  *
  * @param {import('@endo/far').ERef<StorageNode>} storageNode
  * @param {import('@endo/far').ERef<Marshaller>} marshaller
  * @returns {(value: unknown) => Promise<void>}
  */
-export const makeMarshallToStorage = (storageNode, marshaller) => {
-  return value =>
-    E(marshaller)
-      .serialize(value)
-      .then(serialized => {
-        const encoded = JSON.stringify(serialized);
-        return E(storageNode).setValue(encoded);
-      });
+export const makeSerializeToStorage = (storageNode, marshaller) => {
+  return async value => {
+    const marshalled = await E(marshaller).serialize(value);
+    const serialized = JSON.stringify(marshalled);
+    return E(storageNode).setValue(serialized);
+  };
 };

--- a/packages/notifier/src/stored-notifier.js
+++ b/packages/notifier/src/stored-notifier.js
@@ -1,5 +1,5 @@
 import { assertAllDefined } from '@agoric/internal';
-import { makeMarshallToStorage } from '@agoric/internal/src/lib-chainStorage.js';
+import { makeSerializeToStorage } from '@agoric/internal/src/lib-chainStorage.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { observeNotifier } from './asyncIterableAdaptor.js';
@@ -27,7 +27,7 @@ import { observeNotifier } from './asyncIterableAdaptor.js';
 export const makeStoredNotifier = (notifier, storageNode, marshaller) => {
   assertAllDefined({ notifier, storageNode, marshaller });
 
-  const marshallToStorage = makeMarshallToStorage(storageNode, marshaller);
+  const marshallToStorage = makeSerializeToStorage(storageNode, marshaller);
 
   observeNotifier(notifier, {
     updateState(value) {

--- a/packages/notifier/src/stored-topic.js
+++ b/packages/notifier/src/stored-topic.js
@@ -1,5 +1,5 @@
 import { assertAllDefined } from '@agoric/internal';
-import { makeMarshallToStorage } from '@agoric/internal/src/lib-chainStorage.js';
+import { makeSerializeToStorage } from '@agoric/internal/src/lib-chainStorage.js';
 import { M } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { SubscriberShape } from './publish-kit.js';
@@ -42,7 +42,7 @@ export const TopicsRecordShape = M.recordOf(M.string(), PublicTopicShape);
 export const pipeTopicToStorage = (topic, storageNode, marshaller) => {
   assertAllDefined({ topic, storageNode, marshaller });
 
-  const marshallToStorage = makeMarshallToStorage(storageNode, marshaller);
+  const marshallToStorage = makeSerializeToStorage(storageNode, marshaller);
 
   // Start publishing the source.
   forEachPublicationRecord(topic, marshallToStorage).catch(err => {

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -1,7 +1,7 @@
 import { E } from '@endo/eventual-send';
 import { Far, makeMarshal } from '@endo/marshal';
 import { assertAllDefined } from '@agoric/internal';
-import { makeMarshallToStorage } from '@agoric/internal/src/lib-chainStorage.js';
+import { makeSerializeToStorage } from '@agoric/internal/src/lib-chainStorage.js';
 import { observeIteration } from './asyncIterableAdaptor.js';
 import { makePublishKit, subscribeEach } from './publish-kit.js';
 import { makeSubscriptionKit } from './subscriber.js';
@@ -45,7 +45,7 @@ export const forEachPublicationRecord = async (subscriber, consumeValue) => {
 export const makeStoredSubscriber = (subscriber, storageNode, marshaller) => {
   assertAllDefined({ subscriber, storageNode, marshaller });
 
-  const marshallToStorage = makeMarshallToStorage(storageNode, marshaller);
+  const marshallToStorage = makeSerializeToStorage(storageNode, marshaller);
 
   // Start publishing the source.
   forEachPublicationRecord(subscriber, marshallToStorage).catch(err => {

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -282,14 +282,13 @@ export const prepareSmartWallet = (baggage, shared) => {
         /**
          * @param {RemotePurse} purse
          * @param {Amount<any>} balance
-         * @param {'init'} [init]
          */
-        updateBalance(purse, balance, init) {
+        updateBalance(purse, balance) {
           const { purseBalances, updatePublishKit } = this.state;
-          if (init) {
-            purseBalances.init(purse, balance);
-          } else {
+          if (purseBalances.has(purse)) {
             purseBalances.set(purse, balance);
+          } else {
+            purseBalances.init(purse, balance);
           }
           updatePublishKit.publisher.publish({
             updated: 'balance',
@@ -330,7 +329,7 @@ export const prepareSmartWallet = (baggage, shared) => {
           // publish purse's balance and changes
           void E.when(
             E(purse).getCurrentAmount(),
-            balance => helper.updateBalance(purse, balance, 'init'),
+            balance => helper.updateBalance(purse, balance),
             err =>
               console.error(
                 address,


### PR DESCRIPTION
closes: #6689

## Description

Fixes a race condition identified in #6689

Also bundles a [code refactoring suggestion](https://github.com/Agoric/agoric-sdk/pull/6862#discussion_r1088442990) from @gibson042 

### Security Considerations

--
### Scaling Considerations

--

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

The race happened in XS only. We could have a regression test by slowing down the faster promise, but doesn't seem worth it.