### PR TITLE
fix(telemetry): handle smallcaps and msg formatting

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -216,6 +216,19 @@ sub-process which receives all SLOG events over an IPC connection.
 
 The default is `'self'`.
 
+## SLOGSENDER_FAIL_ON_ERROR
+
+Affects: cosmic-swingset
+
+Purpose: causes failures of the slogSender to be fatal
+
+Description: if set (to a non empty value), a failure of the slogSender flush
+operation will result in a rejection instead of mere logging. Can be used to
+validate during tests that complex slog senders like the otel converter do not
+have any unexpected errors.
+
+The default is `undefined`.
+
 ## SWINGSET_WORKER_TYPE
 
 Affects: solo

--- a/packages/SwingSet/src/lib-nodejs/waitUntilQuiescent.js
+++ b/packages/SwingSet/src/lib-nodejs/waitUntilQuiescent.js
@@ -11,7 +11,7 @@ export function waitUntilQuiescent() {
   // lower-priority than the Promise queue on browsers and Node 11, but on
   // Node 10 it is higher. So this trick requires Node 11.
   // https://jsblog.insiderattack.net/new-changes-to-timers-and-microtasks-from-node-v11-0-0-and-above-68d112743eb3
-  /** @type {PromiseKit<void>} */
+  /** @type {import('@endo/promise-kit').PromiseKit<void>} */
   const { promise: queueEmptyP, resolve } = makePromiseKit();
   setImmediate(() => resolve());
   return queueEmptyP;

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -367,10 +367,10 @@ export {};
  * @property {VatAdminFacet} adminNode
  *
  * @typedef {object} VatAdminSvc
- * @property {(id: BundleID) => ERef<BundleCap>} waitForBundleCap
- * @property {(id: BundleID) => ERef<BundleCap>} getBundleCap
- * @property {(name: string) => ERef<BundleCap>} getNamedBundleCap
- * @property {(name: string) => ERef<BundleID>} getBundleIDByName
- * @property {(bundleCap: BundleCap, options?: DynamicVatOptions) => ERef<CreateVatResults>} createVat
+ * @property {(id: BundleID) => import('@endo/far').ERef<BundleCap>} waitForBundleCap
+ * @property {(id: BundleID) => import('@endo/far').ERef<BundleCap>} getBundleCap
+ * @property {(name: string) => import('@endo/far').ERef<BundleCap>} getNamedBundleCap
+ * @property {(name: string) => import('@endo/far').ERef<BundleID>} getBundleIDByName
+ * @property {(bundleCap: BundleCap, options?: DynamicVatOptions) => import('@endo/far').ERef<CreateVatResults>} createVat
  *
  */

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -629,19 +629,14 @@ export async function launch({
   async function afterCommit(blockHeight, blockTime) {
     await Promise.resolve()
       .then(afterCommitCallback)
-      .then(
-        (afterCommitStats = {}) => {
-          controller.writeSlogObject({
-            type: 'cosmic-swingset-after-commit-stats',
-            blockHeight,
-            blockTime,
-            ...afterCommitStats,
-          });
-        },
-        error => {
-          console.warn('Error during afterCommitCallback', error);
-        },
-      );
+      .then((afterCommitStats = {}) => {
+        controller.writeSlogObject({
+          type: 'cosmic-swingset-after-commit-stats',
+          blockHeight,
+          blockTime,
+          ...afterCommitStats,
+        });
+      });
   }
 
   async function blockingSend(action) {

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -38,8 +38,6 @@ DOCKER_VOLUMES="$AGORIC_SDK_PATH:/usr/src/agoric-sdk" \
 "$thisdir/setup.sh" init --noninteractive
 
 # Go ahead and bootstrap with detailed debug logging.
-SLOGSENDER=@agoric/telemetry/src/flight-recorder.js,@agoric/telemetry/src/otel-trace.js \
-SLOGSENDER_AGENT=process \
 AG_COSMOS_START_ARGS="--log_level=info --trace-store=.ag-chain-cosmos/data/kvstore-trace" \
 VAULT_FACTORY_CONTROLLER_ADDR="$SOLO_ADDR" \
 CHAIN_BOOTSTRAP_VAT_CONFIG="$VAT_CONFIG" \
@@ -56,6 +54,8 @@ then
   cd /usr/src/testnet-load-generator
   SOLO_COINS=40000000000uist \
     "$AG_SETUP_COSMOS_HOME/faucet-helper.sh" add-egress loadgen "$SOLO_ADDR"
+  SLOGSENDER=@agoric/telemetry/src/otel-trace.js SOLO_SLOGSENDER= \
+  SLOGSENDER_FAIL_ON_ERROR=1 SLOGSENDER_AGENT=process \
   SDK_BUILD=0 MUST_USE_PUBLISH_BUNDLE=1 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
     --stage.save-storage --trace kvstore swingstore xsnap \
     --stages=3 --stage.duration=10 --stage.loadgen.cycles=4 \

--- a/packages/internal/src/fs-stream.js
+++ b/packages/internal/src/fs-stream.js
@@ -1,6 +1,5 @@
 import { createWriteStream } from 'node:fs';
 import { open } from 'node:fs/promises';
-import { E } from '@endo/eventual-send';
 import { makeAggregateError } from './utils.js';
 
 /**
@@ -73,8 +72,7 @@ export const makeFsStreamWriter = async filePath => {
         }
       });
     });
-    flushed = E.when(
-      flushed,
+    flushed = flushed.then(
       () => written,
       async err =>
         Promise.reject(

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -17,7 +17,7 @@ import anylogger from 'anylogger';
 // import djson from 'deterministic-json';
 
 import { assert, Fail } from '@agoric/assert';
-import { makeSlogSender } from '@agoric/telemetry';
+import { makeSlogSender, tryFlushSlogSender } from '@agoric/telemetry';
 import {
   loadSwingsetConfigFile,
   buildCommand,
@@ -248,10 +248,12 @@ const buildSwingset = async (
 
   async function processKernel() {
     await crankScheduler(policy);
-    if (swingSetRunning) {
-      await saveState();
-      deliverOutbound();
+    if (!swingSetRunning) {
+      return;
     }
+    await saveState();
+    deliverOutbound();
+    await tryFlushSlogSender(slogSender, { env, log: console.warn });
   }
 
   // Use the input queue to make sure it doesn't overlap with

--- a/packages/swingset-runner/src/slogulator.js
+++ b/packages/swingset-runner/src/slogulator.js
@@ -79,7 +79,7 @@ export function main() {
     'kernel-init-start': handleKernelInitStart,
     'clist': handleCList,
     'console': handleConsole,
-    'cosmic-swingset-after-commit-block': handleCosmicSwingsetAfterCommitBlock,
+    'cosmic-swingset-after-commit-stats': handleCosmicSwingsetAfterCommitStats,
     'cosmic-swingset-begin-block': handleCosmicSwingsetBeginBlock,
     'cosmic-swingset-bootstrap-block-finish': handleCosmicSwingsetBootstrapBlockFinish,
     'cosmic-swingset-bootstrap-block-start': handleCosmicSwingsetBootstrapBlockStart,
@@ -698,8 +698,8 @@ export function main() {
     }
   }
 
-  function handleCosmicSwingsetAfterCommitBlock(_entry) {
-    p(`cosmic-swingset-after-commit-block`);
+  function handleCosmicSwingsetAfterCommitStats(_entry) {
+    p(`cosmic-swingset-after-commit-stats`);
   }
 
   function handleCosmicSwingsetCommitBlockFinish(entry) {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -27,6 +27,7 @@
     "@agoric/store": "^0.8.1",
     "@endo/eventual-send": "^0.16.8",
     "@endo/init": "^0.5.52",
+    "@endo/marshal": "^0.8.1",
     "@endo/stream": "^0.3.21",
     "@opentelemetry/api": "^1.1.0",
     "@opentelemetry/exporter-prometheus": "^0.32.0",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -25,7 +25,6 @@
     "@agoric/assert": "^0.5.1",
     "@agoric/internal": "^0.2.1",
     "@agoric/store": "^0.8.1",
-    "@endo/eventual-send": "^0.16.8",
     "@endo/init": "^0.5.52",
     "@endo/marshal": "^0.8.1",
     "@endo/stream": "^0.3.21",

--- a/packages/telemetry/src/index.js
+++ b/packages/telemetry/src/index.js
@@ -20,6 +20,29 @@ export * from './make-slog-sender.js';
  * @property {string} [serviceName]
  */
 
+/**
+ * @param {SlogSender} [slogSender]
+ * @param {object} [options]
+ * @param {Record<string, string | undefined>} [options.env]
+ * @param {(...args: any[]) => void} [options.log]
+ */
+export const tryFlushSlogSender = async (
+  slogSender,
+  { env = {}, log } = {},
+) => {
+  await Promise.resolve(slogSender?.forceFlush?.()).catch(err => {
+    log?.('Failed to flush slog sender', err);
+    if (err.errors) {
+      err.errors.forEach(error => {
+        log?.('nested error:', error);
+      });
+    }
+    if (env.SLOGSENDER_FAIL_ON_ERROR) {
+      throw err;
+    }
+  });
+};
+
 export const getResourceAttributes = ({
   env = process.env,
   serviceName = '',

--- a/packages/telemetry/src/slog-sender-pipe.js
+++ b/packages/telemetry/src/slog-sender-pipe.js
@@ -24,7 +24,12 @@ const withMutex = operation => {
   return async (...args) => {
     await mutex.get();
     const result = operation(...args);
-    mutex.put(result.then(() => {}));
+    mutex.put(
+      result.then(
+        () => {},
+        () => {},
+      ),
+    );
     return result;
   };
 };

--- a/packages/telemetry/src/slog-sender-pipe.js
+++ b/packages/telemetry/src/slog-sender-pipe.js
@@ -2,7 +2,6 @@ import { fork } from 'child_process';
 import path from 'path';
 import anylogger from 'anylogger';
 
-import { E } from '@endo/eventual-send';
 import { makeQueue } from '@endo/stream';
 
 import { makeShutdown } from './shutdown.js';
@@ -25,7 +24,7 @@ const withMutex = operation => {
   return async (...args) => {
     await mutex.get();
     const result = operation(...args);
-    mutex.put(E.when(result, () => {}));
+    mutex.put(result.then(() => {}));
     return result;
   };
 };

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -1,6 +1,7 @@
 import otel, { SpanStatusCode } from '@opentelemetry/api';
 
 import { makeMarshal, Remotable } from '@endo/marshal';
+import { Fail, q } from '@agoric/assert';
 
 import { makeLegacyMap } from '@agoric/store';
 import {
@@ -125,7 +126,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
       }
     }
 
-    kref[0] === 'k' || assert.fail(`Unexpected non-kernel ref ${kref}`);
+    kref[0] === 'k' || Fail`Unexpected non-kernel ref ${q(kref)}`;
     val = harden(
       kref.startsWith('kp')
         ? new Promise(sink)
@@ -265,7 +266,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         break;
       }
       default: {
-        console.error(`Unknown crank-start message.type`, messageType);
+        Fail`Unknown crank-start message.type ${q(messageType)}`;
       }
     }
     return [name, attrs, links];
@@ -873,7 +874,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
           default: {
             /** @type {never} */
             const unexpectedSyscall = syscallType;
-            console.error(`Unknown syscall type:`, unexpectedSyscall);
+            Fail`Unknown syscall type ${q(unexpectedSyscall)}`;
           }
         }
         break;
@@ -917,7 +918,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         }
         dbTransactionManager.begin();
         while (spans.top()) {
-          console.error(
+          console.warn(
             `previous block was not unwound properly, unstacking ${spans.topKind()}`,
           );
           spans.pop();
@@ -967,7 +968,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
       case 'cosmic-swingset-end-block-finish': {
         // Don't record finish but make sure our span stack is clean
         while (spans.top() && spans.topKind() !== 'block') {
-          console.error(
+          console.warn(
             `End block has unexpected span stack, removing ${spans.topKind()}`,
           );
           spans.pop();
@@ -1036,7 +1037,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         break;
       }
       default: {
-        console.error(`Unknown slog type: ${slogType}`);
+        Fail`Unknown slog type: ${q(slogType)}`;
       }
     }
   };

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -892,7 +892,7 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         spans.push(['intra-block', slogAttrs.blockHeight]);
         break;
       }
-      case 'cosmic-swingset-after-commit-block': {
+      case 'cosmic-swingset-after-commit-stats': {
         // Add the event to whatever the current top span is (most likely intra-block)
         // TODO: add as a span of the block
         spans.top()?.addEvent('after-commit', cleanAttrs(slogAttrs), now);


### PR DESCRIPTION
closes: #6991

Best reviewed commit-by-commit

## Description

Handles smallcaps in messages by relying on `@endo/marshal` instead of assuming and parsing JSON for the body.

I had written this a while ago as part of wider telemetry improvements, which I partially brought over here on the premise they're self contained and my previous smallcaps integration is easier with these changes.

Rewrote the error handling logic in the flows touching the slog sender to propagate errors into the flush operation, and added an option to fail when such errors occur. This should avoid the recurring regressions we have been experiencing.

### Security Considerations

None, telemetry only

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Tested in a local loadgen run with slog-to-otel sender enabled, and the new fail option, with and without the slog sender producing errors.

The whole telemetry package still lacks unit tests, and this does not change that. It does have slightly better typing, and new checks during the deployment integration test.
