### PR TITLE
fix(scaledPriceAuthority): invert initialPrice; support quoteGiven

### DIFF
--- a/packages/inter-protocol/scripts/add-collateral-core.js
+++ b/packages/inter-protocol/scripts/add-collateral-core.js
@@ -21,7 +21,7 @@ export const defaultProposalBuilder = async (
     decimalPlaces = 6,
     keyword = 'IbcATOM',
     proposedName = oracleBrand,
-    initialPricePct = undefined,
+    initialPrice = undefined,
   } = interchainAssetOptions;
 
   if (!denom) {
@@ -39,7 +39,7 @@ export const defaultProposalBuilder = async (
           denom,
           issuerBoardId,
           decimalPlaces,
-          initialPricePct,
+          initialPrice,
           keyword,
           proposedName,
           oracleBrand,

--- a/packages/inter-protocol/scripts/init-core.js
+++ b/packages/inter-protocol/scripts/init-core.js
@@ -160,7 +160,7 @@ export const defaultProposalBuilder = async (
       anchorDecimalPlaces = '6',
       anchorKeyword = 'AUSD',
       anchorProposedName = anchorKeyword,
-      initialPricePct = undefined,
+      initialPrice = undefined,
     } = {},
     econCommitteeOptions: {
       committeeSize: econCommitteeSize = env.ECON_COMMITTEE_SIZE || '3',
@@ -174,7 +174,7 @@ export const defaultProposalBuilder = async (
   const anchorOptions = anchorDenom && {
     denom: anchorDenom,
     decimalPlaces: parseInt(anchorDecimalPlaces, 10),
-    initialPricePct: optBigInt(initialPricePct),
+    initialPrice,
     keyword: anchorKeyword,
     proposedName: anchorProposedName,
   };

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -280,7 +280,10 @@ export const addAssetToVault = async (
   const vaultFactoryCreator = E.get(vaultFactoryKit).creatorFacet;
   await E(vaultFactoryCreator).addVaultType(interchainIssuer, oracleBrand, {
     debtLimit: AmountMath.make(stable, debtLimitValue),
-    // the rest of these are arbitrary but plausible, TBD by gov cttee
+    // The rest of these we use safe defaults.
+    // In production they will be governed by the Econ Committee.
+    // Product deployments are also expected to have a low debtLimitValue at the outset,
+    // limiting the impact of these defaults.
     liquidationPadding: makeRatio(25n, stable),
     liquidationMargin: makeRatio(150n, stable),
     loanFee: makeRatio(50n, stable, 10_000n),

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -3,6 +3,7 @@ import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { deeplyFulfilledObject } from '@agoric/internal';
 import { Stable } from '@agoric/vats/src/tokens.js';
 import { E } from '@endo/far';
+import { parseRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { reserveThenGetNames } from './utils.js';
 
 export * from './startPSM.js';
@@ -15,7 +16,7 @@ export * from './startPSM.js';
  * @property {string} [proposedName]
  * @property {string} keyword
  * @property {string} oracleBrand
- * @property {number} [initialPricePct]
+ * @property {number} [initialPrice]
  */
 
 /**
@@ -161,7 +162,11 @@ export const registerScaledPriceAuthority = async (
   { consume: { agoricNamesAdmin, zoe, priceAuthorityAdmin, priceAuthority } },
   { options: { interchainAssetOptions } },
 ) => {
-  const { keyword, oracleBrand, initialPricePct } = interchainAssetOptions;
+  const {
+    keyword,
+    oracleBrand,
+    initialPrice: initialPriceRaw,
+  } = interchainAssetOptions;
   assert.typeof(keyword, 'string');
   assert.typeof(oracleBrand, 'string');
 
@@ -216,8 +221,8 @@ export const registerScaledPriceAuthority = async (
     10n ** BigInt(decimalPlacesRun),
     runBrand,
   );
-  const initialPrice = initialPricePct
-    ? makeRatio(BigInt(initialPricePct), runBrand, 100n, interchainBrand)
+  const initialPrice = initialPriceRaw
+    ? parseRatio(initialPriceRaw, runBrand, interchainBrand)
     : undefined;
 
   const terms = await deeplyFulfilledObject(

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -217,7 +217,7 @@ export const registerScaledPriceAuthority = async (
     runBrand,
   );
   const initialPrice = initialPricePct
-    ? makeRatio(BigInt(initialPricePct), interchainBrand, 100n, runBrand)
+    ? makeRatio(BigInt(initialPricePct), runBrand, 100n, interchainBrand)
     : undefined;
 
   const terms = await deeplyFulfilledObject(

--- a/packages/inter-protocol/test/test-proposal-stuff.js
+++ b/packages/inter-protocol/test/test-proposal-stuff.js
@@ -70,13 +70,13 @@ test('inter-protocol vaults proposal handles endorsedUi option', async t => {
   });
 });
 
-test('inter-protocol ATOM proposal handles initialPricePct option', async t => {
+test('inter-protocol ATOM proposal handles initialPrice option', async t => {
   const proposalModule =
     '@agoric/inter-protocol/scripts/add-collateral-core.js';
   const interchainAssetOptions = {
     decimalPlaces: 6,
     denom: 'ibc/toyatom',
-    initialPricePct: 1234,
+    initialPrice: 12.34,
     keyword: 'IbcATOM',
     oracleBrand: 'ATOM',
     proposedName: 'ATOM',

--- a/packages/vats/decentral-test-vaults-config.json
+++ b/packages/vats/decentral-test-vaults-config.json
@@ -30,7 +30,7 @@
           "interchainAssetOptions": {
             "denom": "ibc/toyatom",
             "decimalPlaces": 6,
-            "initialPricePct": 1234,
+            "initialPrice": 12.34,
             "keyword": "IbcATOM",
             "oracleBrand": "ATOM",
             "proposedName": "ATOM"
@@ -142,7 +142,7 @@
             "gov1": "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
             "gov2": "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang",
             "gov3": "agoric1w8wktaur4zf8qmmtn3n7x3r0jhsjkjntcm3u6h"
-          } 
+          }
         }
       ]
     }

--- a/packages/zoe/test/unitTests/contracts/test-scaledPriceAuthority.js
+++ b/packages/zoe/test/unitTests/contracts/test-scaledPriceAuthority.js
@@ -115,9 +115,9 @@ const makeScenario = async (t, initialPriceInCents) => {
       initialPrice: initialPriceInCents
         ? makeRatio(
             initialPriceInCents,
-            t.context.ibcAtom.brand,
-            100n,
             t.context.run.brand,
+            100n,
+            t.context.ibcAtom.brand,
           )
         : undefined,
     },
@@ -255,10 +255,11 @@ const unitAmount = async brand => {
 };
 
 test('initialPrice', /** @param {ExecutionContext} t */ async t => {
+  const { make } = AmountMath;
+  const { ibcAtom: collateral, run: debt } = t.context;
   const { timer, pa } = await makeScenario(t, 12_34n);
 
   t.log('vault manager makes unit quote notifier');
-  const { ibcAtom: collateral, run: debt } = t.context;
   const collateralUnit = await unitAmount(collateral.brand);
   const quotes = E(pa).makeQuoteNotifier(collateralUnit, debt.brand);
 
@@ -269,12 +270,16 @@ test('initialPrice', /** @param {ExecutionContext} t */ async t => {
   } = await E(quotes).getUpdateSince();
   t.deepEqual(qa1.value, [
     {
-      amountIn: { brand: collateral.brand, value: 12_34n },
-      amountOut: { brand: debt.brand, value: 100n },
+      amountIn: { brand: debt.brand, value: 12_34n },
+      amountOut: { brand: collateral.brand, value: 100n },
       timer,
       timestamp: 0n,
     },
   ]);
+
+  t.log('vault manager gets quote for 500 ATOM');
+  const q500 = await E(pa).quoteGiven(make(collateral.brand, 500n), debt.brand);
+  t.deepEqual(q500.quoteAmount.value[0].amountOut, make(debt.brand, 6170n));
 
   t.log('clients get remaining prices as usual');
   const {
@@ -288,4 +293,8 @@ test('initialPrice', /** @param {ExecutionContext} t */ async t => {
       timestamp: 0n,
     },
   ]);
+
+  t.log('vault manager gets quote for 400 ATOM at usual price');
+  const q400 = await E(pa).quoteGiven(make(collateral.brand, 400n), debt.brand);
+  t.deepEqual(q400.quoteAmount.value[0].amountOut, make(debt.brand, 14200n));
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #6957
refs: #7002 -- probably conflicts with it

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

adding `quoteGiven` to the unit exposed the fact that "12.35 ATOM / USD" is not the way we meant to state the initial price, but rather "12.35 USD / ATOM".

I also followed the `agops-vaults-smoketest.sh` script successfully.
