### PR TITLE
feat(board)!: migrate to smallCaps for boardMarshaller, vstorage, smartWallet

### DIFF
--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -293,7 +293,9 @@ export default async function main(progname, args, { env, homedir, agcc }) {
         STORAGE_PATH.BUNDLES,
         { sequence: true },
       );
-      const marshaller = makeMarshal();
+      const marshaller = makeMarshal({
+        serializeBodyFormat: 'smallcaps',
+      });
       const { publisher, subscriber } = makePublishKit();
       pipeTopicToStorage(subscriber, installationStorageNode, marshaller);
       return publisher;

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -90,6 +90,7 @@ export const makeStoredSubscription = (
   storageNode,
   marshaller = makeMarshal(undefined, undefined, {
     marshalSaveError: () => {},
+    serializeBodyFormat: 'smallcaps',
   }),
 ) => {
   /** @type {Unserializer} */

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -199,6 +199,11 @@ const makeSlotToVal = state => {
   return slotToVal;
 };
 
+/** @type {import('@endo/marshal').MakeMarshalOptions} */
+const useSmallCaps = harden({
+  serializeBodyFormat: 'smallcaps',
+});
+
 // TODO make Marshaller type generic on slot
 /**
  * @param {BoardState} state
@@ -216,7 +221,7 @@ const makeReadonlyMarshaller = state => {
     // Published value.
     return valToId.get(val);
   };
-  return makeMarshal(valToSlot, slotToVal);
+  return makeMarshal(valToSlot, slotToVal, useSmallCaps);
 };
 
 /**
@@ -227,7 +232,7 @@ const makePublishingMarshaller = state => {
   const slotToVal = makeSlotToVal(state);
   // Always put the value in the board.
   const valToSlot = val => getId(val, state);
-  return makeMarshal(valToSlot, slotToVal);
+  return makeMarshal(valToSlot, slotToVal, useSmallCaps);
 };
 // #endregion
 

--- a/packages/vats/test/test-lib-board.js
+++ b/packages/vats/test/test-lib-board.js
@@ -70,13 +70,13 @@ const testBoardMarshaller = async (t, board, marshaller, publishing) => {
       unpublished2: unpublished,
     }),
   );
-  const pub1ser = `{"@qclass":"slot","iface":"Alleged: published","index":0}`;
-  const pub2ser = `{"@qclass":"slot","index":0}`;
-  const unpub1ser = `{"@qclass":"slot","iface":"Alleged: unpublished","index":1}`;
-  const unpub2ser = `{"@qclass":"slot","index":1}`;
+  const pub1ser = '"$0.Alleged: published"';
+  const pub2ser = '"$0"';
+  const unpub1ser = '"$1.Alleged: unpublished"';
+  const unpub2ser = `"$1"`;
   t.is(
     ser.body,
-    `{"published1":${pub1ser},"published2":${pub2ser},"unpublished1":${unpub1ser},"unpublished2":${unpub2ser}}`,
+    `#{"published1":${pub1ser},"published2":${pub2ser},"unpublished1":${unpub1ser},"unpublished2":${unpub2ser}}`,
   );
   t.is(ser.slots.length, 2);
   t.is(ser.slots[0], published1id);


### PR DESCRIPTION
refs: #6822, #6646

## Description

An exploration into using smallcaps for the board marshaller and hence vstorage and the smart wallet.

### Security Considerations

Clients expecting the `@qclass` format could get confused.

### Scaling Considerations

smallCaps is quite a bit more concise. (#6646 is a nearby optimization)

_IOU measurements, I suppose_

### Documentation Considerations

This represents a burden on clients to support smallCaps.

It also puts a burden on clients that want to read data before this gets deployed to support both formats. I suggest that it's better to put this burden on clients that want to read data from the pre-bulldozer era than migrating after the bulldozer upgrade (#6644).

### Testing Considerations

 - [x] update `test-lib-board.js`
 - [ ] update any smartWallet tests that are sensitive to marshal format
 - [ ] update dapps / clients that have their own implementation of `@agoric/marshal`
    - [ ]  dapp-inter-jumper: https://github.com/Agoric/dapp-inter-jumper/commit/8ac016bbef70003e6b96ed981e93423909fad8a8#r100912032
    - [ ] indexing services?

cc @michaelfig @warner @ivanlei 
