### PR TITLE
feat(cosmic-swingset): validate smart wallet actions

### DIFF
--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -38,6 +38,8 @@
     "@endo/import-bundle": "^0.2.53",
     "@endo/init": "^0.5.49",
     "@endo/marshal": "^0.7.5",
+    "@endo/promise-kit": "^0.2.49",
+    "@endo/stream": "^0.3.18",
     "@iarna/toml": "^2.2.3",
     "@opentelemetry/sdk-metrics": "^0.32.0",
     "agoric": "^0.18.3",
@@ -49,7 +51,8 @@
   },
   "devDependencies": {
     "ava": "^4.3.1",
-    "c8": "^7.7.2"
+    "c8": "^7.7.2",
+    "readline-transform": "^1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cosmic-swingset/scripts/validate-transcript-actions.js
+++ b/packages/cosmic-swingset/scripts/validate-transcript-actions.js
@@ -1,0 +1,82 @@
+#! /usr/bin/env node
+// @ts-check
+
+// import '@endo/init';
+import '@endo/init/debug.js';
+
+import process from 'process';
+import { createReadStream } from 'node:fs';
+import { Transform } from 'stream';
+import zlib from 'zlib';
+
+import ReadlineTransform from 'readline-transform';
+import { assert, details as X, quote as q } from '@agoric/assert';
+
+import { validateWalletAction } from '../src/validate-inbound.js';
+
+/**
+ * @param {string} filePath
+ * @returns {import('stream').Readable}
+ */
+const getTranscriptStream = filePath => {
+  /** @type {import('stream').Readable} */
+  let rawStream = filePath === '-' ? process.stdin : createReadStream(filePath);
+  if (filePath.endsWith('.gz')) {
+    rawStream = rawStream.pipe(zlib.createGunzip());
+  }
+  const lineTransform = new ReadlineTransform({ readableObjectMode: true });
+  const parseStream = new Transform({
+    objectMode: true,
+    transform(line, _encodeing, callback) {
+      try {
+        callback(null, harden(JSON.parse(line)));
+      } catch (e) {
+        const error = assert.error(X`Error while parsing ${line}`);
+        assert.note(error, X`Caused by ${q(e)}`);
+        callback(error);
+      }
+    },
+  });
+  return rawStream.pipe(lineTransform).pipe(parseStream);
+};
+
+const main = async ({ inputFile }) => {
+  const chainInputTranscript = getTranscriptStream(inputFile);
+
+  for await (const event of chainInputTranscript) {
+    if (
+      event.type === 'inbound-action' &&
+      event.action.type === 'WALLET_SPEND_ACTION'
+    ) {
+      await validateWalletAction(event.action).catch(err => {
+        console.error(
+          'Smart Wallet action failed validation',
+          event.action,
+          err,
+        );
+      });
+    }
+  }
+
+  chainInputTranscript.destroy();
+};
+
+// process.once('beforeExit', exitCode => {
+//   console.log(
+//     'beforeExit',
+//     exitCode,
+//     process._getActiveRequests(),
+//     process._getActiveHandles(),
+//   );
+// });
+
+main({ inputFile: process.argv[2] }).then(
+  () => {
+    process.exit(process.exitCode || 0);
+  },
+  rej => {
+    // console.log(process._getActiveRequests(), process._getActiveHandles());
+    console.error(rej);
+    process.exit(process.exitCode || 2);
+  },
+);

--- a/packages/cosmic-swingset/src/validate-inbound.js
+++ b/packages/cosmic-swingset/src/validate-inbound.js
@@ -1,0 +1,109 @@
+import { assert, details as X } from '@agoric/assert';
+
+import * as ActionType from './action-types.js';
+
+const MAX_BODY_DEPTH = 50n;
+
+const SMART_WALLET_BODY_KEYS = new Set([
+  '',
+  'brand',
+  'digits',
+  'give',
+  'id',
+  'iface',
+  'In',
+  'index',
+  'instance',
+  'invitationSpec',
+  'method',
+  'offer',
+  'Out',
+  'proposal',
+  'publicInvitationMaker',
+  '@qclass',
+  'source',
+  'value',
+  'want',
+]);
+
+// From economicCommitteeAddresses in `decentral-main-psm-config.json`
+const SMART_WALLET_EC_COMMITTEE = new Set(
+  Object.values({
+    'Jason Potts': 'agoric1gx9uu7y6c90rqruhesae2t7c2vlw4uyyxlqxrx',
+    'Chloe White': 'agoric1d4228cvelf8tj65f4h7n2td90sscavln2283h5',
+    'Thibault Schrepel': 'agoric14543m33dr28x7qhwc558hzlj9szwhzwzpcmw6a',
+    'Chris Berg': 'agoric13p9adwk0na5npfq64g22l6xucvqdmu3xqe70wq',
+    'Youssef Amrani': 'agoric1el6zqs8ggctj5vwyukyk4fh50wcpdpwgugd5l5',
+    'Joe Clark': 'agoric1zayxg4e9vd0es9c9jlpt36qtth255txjp6a8yc',
+  }),
+);
+
+export const validateWalletAction = async action => {
+  if (SMART_WALLET_EC_COMMITTEE.has(action.owner)) {
+    // The Economic Committee uses the smart wallet for governance votes
+    // which have a less structured payload.
+    return;
+  }
+
+  const actualAction =
+    action.type === ActionType.WALLET_SPEND_ACTION
+      ? action.spendAction
+      : action.action;
+  assert(
+    actualAction !== undefined,
+    X`Wallet action undefined for ${action.type}`,
+  );
+  const actualPayloadBody = JSON.parse(actualAction).body;
+
+  assert.typeof(actualPayloadBody, 'string');
+  assert(
+    !actualPayloadBody.startsWith('#'),
+    X`Unexpected smallcaps in smart wallet payload`,
+  );
+
+  let bodyMaxDepth = 0n;
+  try {
+    bodyMaxDepth = JSON.parse(
+      actualPayloadBody,
+      function reviverCheck(key, value) {
+        if (!Array.isArray(this)) {
+          assert(
+            SMART_WALLET_BODY_KEYS.has(key),
+            X`Unexpected key in smart wallet payload: ${key}`,
+          );
+        }
+
+        switch (typeof value) {
+          case 'object': {
+            if (!value) return 0n;
+            let maxChildDepth = 0n;
+
+            for (const childDepth of Object.values(value)) {
+              if (childDepth > maxChildDepth) {
+                maxChildDepth = childDepth;
+              }
+            }
+            return 1n + maxChildDepth;
+          }
+          case 'boolean':
+          case 'number':
+          case 'string':
+            return 0n;
+          default:
+            assert.fail(X`Unexpected parsed type`);
+        }
+      },
+    );
+  } catch (err) {
+    if (err.name === 'SyntaxError') {
+      console.warn('Invalid smart wallet body', action, err);
+    } else {
+      throw err;
+    }
+  }
+
+  assert(
+    bodyMaxDepth < MAX_BODY_DEPTH,
+    X`Smart wallet message body too deep: ${bodyMaxDepth}`,
+  );
+};

--- a/packages/cosmic-swingset/test/test-validate-inbound.js
+++ b/packages/cosmic-swingset/test/test-validate-inbound.js
@@ -1,0 +1,159 @@
+import '@endo/init/debug.js';
+import test from 'ava';
+import { WALLET_SPEND_ACTION } from '../src/action-types.js';
+import { validateWalletAction } from '../src/validate-inbound.js';
+
+const makeWalletSpendAction = (actionBody, owner = 'agoric1foobar') => {
+  const blockHeight = 7123456;
+  const blockTime = Date.now();
+  const type = WALLET_SPEND_ACTION;
+
+  return harden({
+    type,
+    owner,
+    spendAction: JSON.stringify({
+      body: JSON.stringify(actionBody),
+      slots: ['foo'],
+    }),
+    blockHeight,
+    blockTime,
+  });
+};
+
+const validBody = harden({
+  method: 'executeOffer',
+  offer: {
+    id: Math.floor(Date.now()),
+    invitationSpec: {
+      instance: {
+        '@qclass': 'slot',
+        iface: 'Alleged: SEVERED: InstanceHandle',
+        index: 0,
+      },
+      publicInvitationMaker: 'makeWantMintedInvitation',
+      source: 'contract',
+    },
+    proposal: {
+      give: {
+        In: {
+          brand: {
+            '@qclass': 'slot',
+            iface: 'Alleged: USDC_axl brand',
+            index: 1,
+          },
+          value: {
+            '@qclass': 'bigint',
+            digits: '100000000',
+          },
+        },
+      },
+      want: {
+        Out: {
+          brand: {
+            '@qclass': 'slot',
+            iface: 'Alleged: IST brand',
+            index: 2,
+          },
+          value: {
+            '@qclass': 'bigint',
+            digits: '100000000',
+          },
+        },
+      },
+    },
+  },
+});
+
+const validEconomicCommitteeVote = harden({
+  method: 'executeOffer',
+  offer: {
+    id: Math.floor(Date.now()),
+    invitationSpec: {
+      source: 'continuing',
+      previousOffer: Math.floor(Date.now()) - 1000000,
+      invitationMakerName: 'VoteOnParamChange',
+    },
+    offerArgs: {
+      instance: {
+        '@qclass': 'slot',
+        index: 0,
+        iface: 'Alleged: InstanceHandle',
+      },
+      params: {
+        MintLimit: {
+          brand: {
+            '@qclass': 'slot',
+            index: 1,
+            iface: 'Alleged: IST brand',
+          },
+          value: {
+            '@qclass': 'bigint',
+            digits: '300000000000',
+          },
+        },
+      },
+      deadline: {
+        '@qclass': 'bigint',
+        digits: String(Math.floor(Date.now() / 1000) + 3600),
+      },
+    },
+    proposal: {},
+  },
+});
+
+const invalidKeyInBody = harden({
+  method: 'executeOffer',
+  offer: {
+    id: Date.now(),
+    someInvalidKey: 'foo',
+  },
+});
+
+const makeDeeplyNestedBody = depth =>
+  JSON.parse(
+    // eslint-disable-next-line prefer-template
+    '{"id":'.repeat(depth) + 'true' + '}'.repeat(depth),
+  );
+
+const allowValid = async (t, body, owner) => {
+  const action = makeWalletSpendAction(body, owner);
+  await t.notThrowsAsync(validateWalletAction(action));
+};
+
+test(
+  'validateWalletAction - allow regular spend action',
+  allowValid,
+  validBody,
+);
+test(
+  'validateWalletAction - allow economic committee action',
+  allowValid,
+  validEconomicCommitteeVote,
+  'agoric1zayxg4e9vd0es9c9jlpt36qtth255txjp6a8yc',
+);
+test(
+  'validateWalletAction - allow nested body up to a depth of 49',
+  allowValid,
+  makeDeeplyNestedBody(49),
+);
+
+const disallowInvalid = async (t, body, owner) => {
+  const action = makeWalletSpendAction(body, owner);
+  await t.throwsAsync(validateWalletAction(action));
+};
+
+test(
+  'validateWalletAction - disallow invalid key in spend action',
+  disallowInvalid,
+  invalidKeyInBody,
+);
+test(
+  'validateWalletAction - disallow economic committee action by non member',
+  disallowInvalid,
+  validEconomicCommitteeVote,
+);
+test(
+  'validateWalletAction - disallow nested body with a depth of 50',
+  disallowInvalid,
+  makeDeeplyNestedBody(50),
+);


### PR DESCRIPTION
## Description

Validate the shape of smart wallet actions for non economic committee senders before queuing the action in cosmic-swingset.

### Security Considerations

This is a consensus decision so the change must be applied to all validators. A failing check will cause the inbound action to be dropped.

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Added unit tests. Added a script to test against the chain transcript to verify this validation is compatible with all historical actions.
