### PR TITLE
6969 fix vaults error recovery

### DIFF
--- a/packages/agoric-cli/src/commands/wallet.js
+++ b/packages/agoric-cli/src/commands/wallet.js
@@ -11,6 +11,7 @@ import {
 import { Command } from 'commander';
 import fs from 'fs';
 import util from 'util';
+import { execFileSync } from 'child_process';
 import { fmtRecordOfLines, summarize } from '../lib/format.js';
 import {
   boardSlottingMarshaller,
@@ -150,9 +151,13 @@ export const makeWalletCommand = async () => {
       try {
         const summary = summarize(current, coalesced, agoricNames);
         process.stdout.write(fmtRecordOfLines(summary));
+        process.stdout.write('\n');
       } catch (e) {
         console.error('CAUGHT HERE', e);
       }
+      execFileSync('agd', [`query`, 'bank', 'balances', opts.from], {
+        stdio: 'inherit',
+      });
     });
 
   wallet

--- a/packages/inter-protocol/src/interest.js
+++ b/packages/inter-protocol/src/interest.js
@@ -147,7 +147,7 @@ const validatedBrand = (mint, debt) => {
  *
  * @param {{
  *  mint: ZCFMint<'nat'>,
- *  mintAndReallocateWithFee: MintAndReallocate,
+ *  mintAndTransferWithFee: MintAndTransfer,
  *  poolIncrementSeat: ZCFSeat,
  *  seatAllocationKeyword: Keyword }} powers
  * @param {{
@@ -209,7 +209,12 @@ export const chargeInterest = (powers, params, prior, accruedUntil) => {
 
   // mint that much of brand for the reward pool
   const rewarded = AmountMath.make(brand, interestAccrued);
-  powers.mintAndReallocateWithFee(rewarded, rewarded, powers.poolIncrementSeat);
+  powers.mintAndTransferWithFee(
+    powers.poolIncrementSeat,
+    rewarded,
+    rewarded,
+    [],
+  );
 
   return {
     compoundedInterest,

--- a/packages/inter-protocol/src/vaultFactory/types.js
+++ b/packages/inter-protocol/src/vaultFactory/types.js
@@ -56,16 +56,14 @@
  */
 
 /**
- * @callback MintAndReallocate
- *
+ * @callback MintAndTransfer
  * Mint new debt `toMint` and transfer the `fee` portion to the vaultFactory's reward
  * pool. Then reallocate over all the seat arguments and the rewardPoolSeat. Update
  * the `totalDebt` if the reallocate succeeds.
- *
- * @param {Amount} toMint
- * @param {Amount} fee
- * @param {ZCFSeat} fromSeat
- * @param {...ZCFSeat} otherSeats
+ * @param {ZCFSeat} mintReceiver
+ * @param {Amount<'nat'>} toMint
+ * @param {Amount<'nat'>} fee
+ * @param {import('@agoric/zoe/src/contractSupport/atomicTransfer.js').TransferPart[]} transfers
  * @returns {void}
  */
 

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -826,7 +826,6 @@ export const prepareVaultManagerKit = (
             const vaultKit = await vault.initVaultKit(seat, vaultStorageNode);
             // initVaultKit calls back to handleBalanceChange() which will add the
             // vault to prioritizedVaults
-            seat.exit();
 
             // initVaultKit doesn't write to the storage node until it's returning
             // so if it returned then we know the node key was consumed
@@ -849,19 +848,23 @@ export const prepareVaultManagerKit = (
                 collateralPre,
                 vaultId,
               );
-              console.error(
+              console.warn(
                 'removed vault',
                 vaultId,
                 'after initVaultKit failure',
               );
             } catch {
-              console.error(
+              console.info(
                 'vault',
                 vaultId,
                 'never stored during initVaultKit failure',
               );
             }
             throw err;
+          } finally {
+            if (!seat.hasExited()) {
+              seat.exit();
+            }
           }
         },
 

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -815,9 +815,6 @@ export const prepareVaultManagerKit = (
             want: { Minted: null },
           });
 
-          // NB: This increments even when a vault fails to init and is removed
-          // from the manager, creating a sparse series of published vaults.
-          state.vaultCounter += 1;
           const vaultId = String(state.vaultCounter);
 
           // must be a presence to be stored in vault state
@@ -835,6 +832,11 @@ export const prepareVaultManagerKit = (
             // initVaultKit calls back to handleBalanceChange() which will add the
             // vault to prioritizedVaults
             seat.exit();
+
+            // initVaultKit doesn't write to the storage node until it's returning
+            // so if it returned then we know the node key was consumed
+            state.vaultCounter += 1;
+
             return vaultKit;
           } catch (err) {
             // ??? do we still need this cleanup? it won't get into the store unless it has collateral,

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -54,7 +54,11 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     { storageNode, walletBridgeManager },
   );
 
-  /** @param {string} address */
+  /**
+   * Each test should have its own wallet to prevent leaking state between them
+   *
+   * @param {string} address
+   */
   const provideWalletAndBalances = async address => {
     // copied from makeClientBanks()
     const bank = await E(consume.bankManager).getBankForAddress(address);

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -395,7 +395,7 @@ export const makeManagerDriver = async (
       }),
     );
     const { vault, publicSubscribers } = await E(vaultSeat).getOfferResult();
-    t.true(await E(vaultSeat).hasExited());
+    t.true(await E(vaultSeat).hasExited(), 'seat must have exited');
     const notifier = makeNotifierFromSubscriber(
       publicSubscribers.vault.subscriber,
     );

--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -105,14 +105,14 @@ test('storage keys', async t => {
   const vda1 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
   t.is(
     await E.get(vda1.getVaultSubscriber()).storagePath,
-    'mockChainStorageRoot.vaultFactory.manager0.vaults.vault1',
+    'mockChainStorageRoot.vaultFactory.manager0.vaults.vault0',
   );
 
   // Second aeth vault
   const vda2 = await d.makeVaultDriver(aeth.make(1000n), run.make(50n));
   t.is(
     await E.get(vda2.getVaultSubscriber()).storagePath,
-    'mockChainStorageRoot.vaultFactory.manager0.vaults.vault2',
+    'mockChainStorageRoot.vaultFactory.manager0.vaults.vault1',
   );
 });
 

--- a/packages/zoe/src/contractSupport/atomicTransfer.js
+++ b/packages/zoe/src/contractSupport/atomicTransfer.js
@@ -1,7 +1,13 @@
 import { mustMatch, M } from '@agoric/store';
 import { assertRightsConserved } from '../contractFacet/rightsConservation.js';
+import { AmountKeywordRecordShape, SeatShape } from '../typeGuards.js';
 
 const { Fail, quote: q } = assert;
+
+export const TransferPartShape = M.splitArray(
+  harden([M.opt(SeatShape), M.opt(SeatShape), M.opt(AmountKeywordRecordShape)]),
+  harden([M.opt(AmountKeywordRecordShape)]),
+);
 
 /**
  * @typedef {[


### PR DESCRIPTION
closes: #6969

## Description

When a vault failed to init, the seat wouldn't be exited. This resulted in the funds hanging on the seat and not being returned to the caller. The fix was to move the `exit()` to `finally`.
- [fix(vaults): exit seat after failure](https://github.com/Agoric/agoric-sdk/pull/7020/commits/2321d8a7ed7667ee0397c9283fc88c31ec13bf8a)

This then sometimes errored with stagings due to https://github.com/Agoric/agoric-sdk/issues/7024 . The solution is to stop using stages, so this does that for vaultFactory as part of https://github.com/Agoric/agoric-sdk/issues/7025. It also does it for stakeFactory because they have a coupling through a shared a dependency on `chargeInterest`.
- [fix: replace staging with atomic transfer](https://github.com/Agoric/agoric-sdk/pull/7020/commits/9db9fadfd1e1391d2ede5607d0c9d89bf2a0da11)

Along the way I tried making a smart wallet integration test to detect the #6969 but it's only with vaults and we can't test that integration until #6880. I left the test in anyway.
- [test(smartWallet): failure retains bank balances](https://github.com/Agoric/agoric-sdk/pull/7020/commits/00c2b037cfad6d8e0c2309da9b36c60daf1b457d)

This also has a CLI feature that was helpful while debugging,
- [feat(wallet): show bank balances](https://github.com/Agoric/agoric-sdk/pull/7020/commits/bcebea9949b38f55f78447824e4bc67c99da6ef6)

And a drive-by for a different state problem,
- [fix(vaults): failures don't consume a vaultId](https://github.com/Agoric/agoric-sdk/pull/7020/commits/ed7899ef50e8d7d01523da8e60ae121bae53f7f6)

### Security Considerations

Prevents a theoretical exploit,
- https://github.com/Agoric/agoric-sdk/issues/7024

### Scaling Considerations

--

### Documentation Considerations

--

### Testing Considerations

Using `start-local-chain` made vaults that used to error and lose funds. Then made the fix and verified the funds are restored after error.
