### PR TITLE
fix: multiple deposits of unknown brand

### DIFF
--- a/packages/agoric-cli/test/agops-oracle-smoketest.sh
+++ b/packages/agoric-cli/test/agops-oracle-smoketest.sh
@@ -63,13 +63,14 @@ agd query vstorage keys published.priceFeed
 # verify that the round started
 agoric follow :published.priceFeed.ATOM-USD_price_feed.latestRound
 
+# Set it to $13 per ATOM
 # second round, first oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPriceRound --price 1102 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
+bin/agops oracle pushPriceRound --price 120000000 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE_OFFER_ID" >|"$PROPOSAL_OFFER"
 agoric wallet send --offer "$PROPOSAL_OFFER" --from gov1 --keyring-backend="test"
 # second round, second oracle
 PROPOSAL_OFFER=$(mktemp -t agops.XXX)
-bin/agops oracle pushPriceRound --price 1202 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
+bin/agops oracle pushPriceRound --price 14000000 --roundId 2 --oracleAdminAcceptOfferId "$ORACLE2_OFFER_ID" >|"$PROPOSAL_OFFER"
 agoric wallet send --offer "$PROPOSAL_OFFER" --from gov2 --keyring-backend="test"
 
 # see new price

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -307,26 +307,15 @@ test('govern offerFilter', async t => {
   // vote didn't raise an error.
 });
 
-test('deposit unknown brand', async t => {
-  const rial = withAmountUtils(makeIssuerKit('rial'));
-  assert(rial.mint);
-
-  const wallet = await t.context.simpleProvideWallet('agoric1queue');
-
-  const payment = rial.mint.mintPayment(rial.make(1_000n));
-  // @ts-expect-error deposit does take a FarRef<Payment>
-  const result = await wallet.getDepositFacet().receive(harden(payment));
-  // successful request but not deposited
-  t.deepEqual(result, { brand: rial.brand, value: 0n });
-});
-
-test.failing('deposit > 1 payment to unknown brand #6961', async t => {
+// XXX belongs in smart-wallet package, but needs lots of set-up that's handy here.
+test('deposit multiple payments to unknown brand', async t => {
   const rial = withAmountUtils(makeIssuerKit('rial'));
 
   const wallet = await t.context.simpleProvideWallet('agoric1queue');
 
-  for await (const _ of [1, 2]) {
-    const payment = rial.mint.mintPayment(rial.make(1_000n));
+  // assume that if the call succeeds then it's in durable storage.
+  for await (const amt of [1n, 2n]) {
+    const payment = rial.mint.mintPayment(rial.make(amt));
     // @ts-expect-error deposit does take a FarRef<Payment>
     const result = await wallet.getDepositFacet().receive(harden(payment));
     // successful request but not deposited


### PR DESCRIPTION
closes: #6961

## Description

Makes a new array instead of try to push to the hardened one. Also improved docs on how unknown brand deposits are handled.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

Failing test now passing.