### PR TITLE
feat(smart-wallet): exit offer

### DIFF
--- a/packages/inter-protocol/src/clientSupport.js
+++ b/packages/inter-protocol/src/clientSupport.js
@@ -221,7 +221,6 @@ const makeBidOffer = (brands, opts) => {
   };
   const collateralBrand = brands[opts.collateralBrandKey];
 
-  const proposal = { give };
   /** @type {import('@agoric/smart-wallet/src/offers.js').OfferSpec} */
   const offerSpec = {
     id: opts.offerId,
@@ -230,7 +229,7 @@ const makeBidOffer = (brands, opts) => {
       instancePath: ['auctioneer'],
       callPipe: [['makeBidInvitation', [collateralBrand]]],
     },
-    proposal,
+    proposal: { give, exit: { onDemand: null } },
     offerArgs: /** @type {import('./auction/auctionBook.js').BidSpec} */ ({
       want: AmountMath.make(
         collateralBrand,

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -133,7 +133,7 @@ let pushPriceCounter = 0;
  * @param {*} wallet
  * @param {string} adminOfferId
  * @param {import('@agoric/inter-protocol/src/price/roundsManager.js').PriceRound} priceRound
- * @returns
+ * @returns {Promise<string>} offer id
  */
 const pushPrice = async (wallet, adminOfferId, priceRound) => {
   /** @type {import('@agoric/smart-wallet/src/invitations.js').ContinuingInvitationSpec} */

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -93,9 +93,9 @@ test('null swap', async t => {
   t.is(await E.get(getBalanceFor(anchor.brand)).value, 0n);
   t.is(await E.get(getBalanceFor(mintedBrand)).value, 0n);
 
-  t.deepEqual(currents[0].possiblyExitableOffers, {});
-  t.deepEqual(currents[1].possiblyExitableOffers, { nullSwap: offer });
-  t.deepEqual(currents[2].possiblyExitableOffers, {});
+  t.deepEqual(currents[0].liveOffers, []);
+  t.deepEqual(currents[1].liveOffers, [['nullSwap', offer]]);
+  t.deepEqual(currents[2].liveOffers, []);
 });
 
 // we test this direction of swap because wanting anchor would require the PSM to have anchor in it first

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -16,6 +16,7 @@ import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { makeLoopback } from '@endo/captp';
 import { E } from '@endo/far';
 import { makeTracer } from '@agoric/internal';
+import { observeIteration, subscribeEach } from '@agoric/notifier';
 
 export { makeMockChainStorageRoot };
 
@@ -269,4 +270,26 @@ export const assertTopicPathData = async (
     // TODO consider making this a shape instead
     t.deepEqual(Object.keys(latest), dataKeys, 'keys in topic feed must match');
   }
+};
+
+/**
+ * Sequence currents from a wallet UpdateRecord publication feed. Note that local
+ * state may not reflect the wallet's state if the initial currents are missed.
+ *
+ * If this proves to be a problem we can add an option to this or a related
+ * utility to reset state from RPC.
+ *
+ * @param {ERef<Subscriber<import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord>>} currents
+ * @returns {Array<import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord>} array that grows as the subscription feeds
+ */
+export const sequenceCurrents = currents => {
+  const sequence = [];
+
+  void observeIteration(subscribeEach(currents), {
+    updateState: updateRecord => {
+      sequence.push(updateRecord);
+    },
+  });
+
+  return sequence;
 };

--- a/packages/inter-protocol/test/test-clientSupport.js
+++ b/packages/inter-protocol/test/test-clientSupport.js
@@ -28,6 +28,7 @@ test('Offers.auction.Bid', async t => {
         callPipe: [['makeBidInvitation', [atom.brand]]],
       },
       proposal: {
+        exit: { onDemand: null },
         give: { Currency: ist.make(4_560_000n) },
       },
       offerArgs: {

--- a/packages/internal/src/storage-test-utils.js
+++ b/packages/internal/src/storage-test-utils.js
@@ -14,7 +14,7 @@ const { Fail, quote: q } = assert;
  * @param {object} [rootOptions]
  */
 export const makeFakeStorageKit = (rootPath, rootOptions) => {
-  /** @type {Map<string, any>} */
+  /** @type {Map<string, any[]>} */
   const data = new Map();
   /** @type {import('../src/lib-chainStorage.js').StorageMessage[]} */
   const messages = [];
@@ -32,7 +32,7 @@ export const makeFakeStorageKit = (rootPath, rootOptions) => {
       case 'set':
         for (const [key, value] of message.args) {
           if (value !== undefined) {
-            data.set(key, value);
+            data.set(key, [value]);
           } else {
             data.delete(key);
           }
@@ -82,7 +82,7 @@ export const makeMockChainStorageRoot = () => {
   return Far('mockChainStorage', {
     ...bindAllMethods(rootNode),
     /**
-     *  Defaults to deserializing pass-by-presence objects into { iface } representations.
+     * Defaults to deserializing pass-by-presence objects into { iface } representations.
      * Note that this is **not** a null transformation; capdata `@qclass` and `index` properties
      * are dropped and `iface` is _added_ for repeat references.
      *
@@ -92,7 +92,7 @@ export const makeMockChainStorageRoot = () => {
      */
     getBody: (path, marshaller = defaultMarshaller) => {
       data.size || Fail`no data in storage`;
-      const dataStr = data.get(path);
+      const dataStr = data.get(path)?.at(-1);
       if (!dataStr) {
         console.debug('mockChainStorage data:', data);
         Fail`no data at ${q(path)}`;

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -97,6 +97,7 @@ export const makeOfferExecutor = ({
           offerArgs,
         );
         logger.info(id, 'seated');
+        updateStatus({});
 
         const publishResult = E.when(E(seatRef).getOfferResult(), result => {
           const passStyle = passStyleOf(result);

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -54,10 +54,11 @@ export const makeOfferExecutor = ({
      * Take an offer description provided in capData, augment it with payments and call zoe.offer()
      *
      * @param {OfferSpec} offerSpec
+     * @param {(seatRef: UserSeat) => void} onSeatCreated
      * @returns {Promise<void>} when the offer has been sent to Zoe; payouts go into this wallet's purses
      * @throws if any parts of the offer are determined to be invalid before calling Zoe's `offer()`
      */
-    async executeOffer(offerSpec) {
+    async executeOffer(offerSpec, onSeatCreated) {
       logger.info('starting executeOffer', offerSpec.id);
 
       const paymentsManager = makePaymentsHelper(purseForBrand, depositFacet);
@@ -71,6 +72,9 @@ export const makeOfferExecutor = ({
         status = { ...status, ...changes };
         onStatusChange(status);
       };
+
+      /** @type {UserSeat} */
+      let seatRef;
 
       const tryBody = async () => {
         // 1. Prepare values and validate synchronously.
@@ -90,14 +94,14 @@ export const makeOfferExecutor = ({
         // failed they'd get an 'error' status update.
 
         // eslint-disable-next-line @jessie.js/no-nested-await -- unconditional
-        const seatRef = await E(zoe).offer(
+        seatRef = await E(zoe).offer(
           invitation,
           proposal,
           paymentKeywordRecord,
           offerArgs,
         );
         logger.info(id, 'seated');
-        updateStatus({});
+        onSeatCreated(seatRef);
 
         const publishResult = E.when(E(seatRef).getOfferResult(), result => {
           const passStyle = passStyleOf(result);
@@ -175,6 +179,15 @@ export const makeOfferExecutor = ({
             updateStatus({ result });
           }
         });
+        if (seatRef) {
+          E(seatRef)
+            .hasExited()
+            .then(hasExited => {
+              if (!hasExited) {
+                E(seatRef).tryExit();
+              }
+            });
+        }
         // propagate to caller
         throw err;
       });

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -34,7 +34,21 @@ const { StorageNodeShape } = makeTypeGuards(M);
  * @see {@link ../README.md}}
  */
 
-// One method yet but structured to support more. For example,
+/**
+ * @typedef {{
+ *   method: 'executeOffer'
+ *   offer: import('./offers.js').OfferSpec,
+ * }} ExecuteOfferAction
+ */
+
+/**
+ * @typedef {{
+ *   method: 'tryExitOffer'
+ *   offerId: import('./offers.js').OfferId,
+ * }} TryExitOfferAction
+ */
+
+// Two methods yet but structured to support more. For example,
 // maybe suggestIssuer for https://github.com/Agoric/agoric-sdk/issues/6132
 // setting petnames and adding brands for https://github.com/Agoric/agoric-sdk/issues/6126
 /**
@@ -64,6 +78,7 @@ const { StorageNodeShape } = makeTypeGuards(M);
  *   purses: Array<{brand: Brand, balance: Amount}>,
  *   offerToUsedInvitation: Array<[ offerId: string, usedInvitation: Amount ]>,
  *   offerToPublicSubscriberPaths: Array<[ offerId: string, publicTopics: { [subscriberName: string]: string } ]>,
+ *   liveOffers: Array<[import('./offers.js').OfferId, import('./offers.js').OfferStatus]>,
  * }} CurrentWalletRecord
  */
 
@@ -130,6 +145,8 @@ const { StorageNodeShape } = makeTypeGuards(M);
  *   purseBalances: MapStore<RemotePurse, Amount>,
  *   updatePublishKit: PublishKit<UpdateRecord>,
  *   currentPublishKit: PublishKit<CurrentWalletRecord>,
+ *   liveOffers: MapStore<import('./offers.js').OfferId, import('./offers.js').OfferStatus>,
+ *   liveOfferSeats: WeakMapStore<import('./offers.js').OfferId, UserSeat<unknown>>,
  * }>} ImmutableState
  *
  * @typedef {{
@@ -239,6 +256,11 @@ export const prepareSmartWallet = (baggage, shared) => {
       /** @type {PublishKit<CurrentWalletRecord>} */
       currentPublishKit,
       walletStorageNode,
+      liveOffers: makeScalarBigMapStore('live offers', { durable: true }),
+      // Keep seats separate from the offers because we don't want to publish these.
+      liveOfferSeats: makeScalarBigMapStore('live offer seats', {
+        durable: true,
+      }),
     };
 
     return {
@@ -309,6 +331,7 @@ export const prepareSmartWallet = (baggage, shared) => {
             offerToUsedInvitation,
             offerToPublicSubscriberPaths,
             purseBalances,
+            liveOffers,
           } = this.state;
           currentPublishKit.publisher.publish({
             purses: [...purseBalances.values()].map(a => ({
@@ -319,6 +342,7 @@ export const prepareSmartWallet = (baggage, shared) => {
             offerToPublicSubscriberPaths: [
               ...offerToPublicSubscriberPaths.entries(),
             ],
+            liveOffers: [...liveOffers.entries()],
           });
         },
 
@@ -388,11 +412,11 @@ export const prepareSmartWallet = (baggage, shared) => {
          * Take an offer description provided in capData, augment it with payments and call zoe.offer()
          *
          * @param {import('./offers.js').OfferSpec} offerSpec
-         * @returns {Promise<void>} when the offer has been sent to Zoe; payouts go into this wallet's purses
+         * @returns {Promise<void>} after the offer has been both seated and exited by Zoe.
          * @throws if any parts of the offer can be determined synchronously to be invalid
          */
         async executeOffer(offerSpec) {
-          const { facets } = this;
+          const { facets, state } = this;
           const {
             address,
             bank,
@@ -439,6 +463,24 @@ export const prepareSmartWallet = (baggage, shared) => {
             },
             onStatusChange: offerStatus => {
               logger.info('offerStatus', offerStatus);
+
+              updatePublishKit.publisher.publish({
+                updated: 'offerStatus',
+                status: offerStatus,
+              });
+
+              const isSeatExited = 'numWantsSatisfied' in offerStatus;
+              if (isSeatExited) {
+                if (state.liveOfferSeats.has(offerStatus.id)) {
+                  state.liveOfferSeats.delete(offerStatus.id);
+                }
+
+                if (state.liveOffers.has(offerStatus.id)) {
+                  state.liveOffers.delete(offerStatus.id);
+                  facets.helper.publishCurrentState();
+                }
+              }
+
               updatePublishKit.publisher.publish({
                 updated: 'offerStatus',
                 status: offerStatus,
@@ -461,7 +503,23 @@ export const prepareSmartWallet = (baggage, shared) => {
               facets.helper.publishCurrentState();
             },
           });
-          await executor.executeOffer(offerSpec);
+
+          return executor.executeOffer(offerSpec, seatRef => {
+            state.liveOffers.init(offerSpec.id, offerSpec);
+            facets.helper.publishCurrentState();
+            state.liveOfferSeats.init(offerSpec.id, seatRef);
+          });
+        },
+        /**
+         * Take an offer's id, look up its seat, try to exit.
+         *
+         * @param {import('./offers.js').OfferId} offerId
+         * @returns {Promise<void>}
+         * @throws if the seat can't be found or E(seatRef).tryExit() fails.
+         */
+        async tryExitOffer(offerId) {
+          const seatRef = this.state.liveOfferSeats.get(offerId);
+          await E(seatRef).tryExit();
         },
       },
       self: {

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -98,19 +98,24 @@ export const coalesceUpdates = (updates, invitationBrand) => {
 };
 
 /**
+ * Sequence updates from a wallet UpdateRecord publication feed. Note that local
+ * state may not reflect the wallet's state if the initial updates are missed.
  *
- * @param {import('@agoric/casting').Follower<any>} follower
- * @throws if there is no first height
+ * If this proves to be a problem we can add an option to this or a related
+ * utility to reset state from RPC.
+ *
+ * @param {ERef<Subscriber<import('./smartWallet').UpdateRecord>>} updates
  */
-export const assertHasData = async follower => {
-  const eachIterable = E(follower).getReverseIterable();
-  const iterator = await E(eachIterable)[Symbol.asyncIterator]();
-  const el = await iterator.next();
+export const sequenceUpdates = updates => {
+  const sequence = [];
 
-  // done before we started
-  if (el.done && !el.value) {
-    assert.fail(NO_SMART_WALLET_ERROR);
-  }
+  void observeIteration(subscribeEach(updates), {
+    updateState: updateRecord => {
+      sequence.push(updateRecord);
+    },
+  });
+
+  return sequence;
 };
 
 /**

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -98,24 +98,18 @@ export const coalesceUpdates = (updates, invitationBrand) => {
 };
 
 /**
- * Sequence updates from a wallet UpdateRecord publication feed. Note that local
- * state may not reflect the wallet's state if the initial updates are missed.
- *
- * If this proves to be a problem we can add an option to this or a related
- * utility to reset state from RPC.
- *
- * @param {ERef<Subscriber<import('./smartWallet').UpdateRecord>>} updates
+ * @param {import('@agoric/casting').Follower<any>} follower
+ * @throws if there is no first height
  */
-export const sequenceUpdates = updates => {
-  const sequence = [];
+export const assertHasData = async follower => {
+  const eachIterable = E(follower).getReverseIterable();
+  const iterator = await E(eachIterable)[Symbol.asyncIterator]();
+  const el = await iterator.next();
 
-  void observeIteration(subscribeEach(updates), {
-    updateState: updateRecord => {
-      sequence.push(updateRecord);
-    },
-  });
-
-  return sequence;
+  // done before we started
+  if (el.done && !el.value) {
+    assert.fail(NO_SMART_WALLET_ERROR);
+  }
 };
 
 /**

--- a/packages/vats/src/core/lib-boot.js
+++ b/packages/vats/src/core/lib-boot.js
@@ -171,6 +171,12 @@ export const makeBootstrap = (
       const result = await E(object)[methodName](...decodedArgs);
       return encodePassable(result);
     },
+    /* Like `messageVatObject` but does not await return value */
+    messageVatObjectSendOnly: ({ presence, methodName, args = [] }) => {
+      const object = decodePassable(presence);
+      const decodedArgs = args.map(decodePassable);
+      E(object)[methodName](...decodedArgs);
+    },
     awaitVatObject: async ({ presence, path = [] }) => {
       let value = await decodePassable(presence);
       for (const key of path) {

--- a/packages/vats/src/core/lib-boot.js
+++ b/packages/vats/src/core/lib-boot.js
@@ -175,7 +175,7 @@ export const makeBootstrap = (
     messageVatObjectSendOnly: ({ presence, methodName, args = [] }) => {
       const object = decodePassable(presence);
       const decodedArgs = args.map(decodePassable);
-      E(object)[methodName](...decodedArgs);
+      void E(object)[methodName](...decodedArgs);
     },
     awaitVatObject: async ({ presence, path = [] }) => {
       let value = await decodePassable(presence);

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -174,7 +174,7 @@ export const makeWalletFactoryDriver = async (
 
   /**
    * @param {string} walletAddress
-   * @param {unknown} walletPresence
+   * @param {import('@agoric/smart-wallet/src/smartWallet.js').SmartWallet} walletPresence
    */
   const makeWalletDriver = (walletAddress, walletPresence) => ({
     /**
@@ -186,7 +186,6 @@ export const makeWalletFactoryDriver = async (
         method: 'executeOffer',
         offer,
       });
-
       return EV(walletPresence).handleBridgeAction(offerCapData, true);
     },
     /**
@@ -200,6 +199,13 @@ export const makeWalletFactoryDriver = async (
       });
 
       return EV.sendOnly(walletPresence).handleBridgeAction(offerCapData, true);
+    },
+    tryExitOffer(offerId) {
+      const capData = marshaller.serialize({
+        method: 'tryExitOffer',
+        offerId,
+      });
+      return EV(walletPresence).handleBridgeAction(capData, true);
     },
     /**
      * @template {(brands: Record<string, Brand>, ...rest: any) => import('@agoric/smart-wallet/src/offers.js').OfferSpec} M offer maker function
@@ -228,7 +234,7 @@ export const makeWalletFactoryDriver = async (
      */
     getLatestUpdateRecord() {
       const key = `published.wallet.${walletAddress}`;
-      const lastWalletStatus = JSON.parse(storage.data.get(key).at(-1));
+      const lastWalletStatus = JSON.parse(storage.data.get(key)?.at(-1));
       return JSON.parse(lastWalletStatus.body);
     },
   });

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -24,6 +24,7 @@ export const bootstrapMethods = {
   resetItem: 'resetItem',
   messageVat: 'messageVat',
   messageVatObject: 'messageVatObject',
+  messageVatObjectSendOnly: 'messageVatObjectSendOnly',
   awaitVatObject: 'awaitVatObject',
 };
 
@@ -100,6 +101,7 @@ export const makeRunUtils = (controller, log = (..._) => {}) => {
 
   /**
    * @type {( (presence: unknown) => Record<string, (...args: any) => Promise<any>> ) & {
+   *   sendOnly: (presence: unknown) => Record<string, (...args: any) => any>,
    *   get: (presence: unknown) => Record<string, Promise<any>>,
    *   vat: (name: string) => Record<string, (...args: any) => Promise<any>>,
    *   rawBoot: Record<string, (...args: any) => Promise<any>>,
@@ -126,6 +128,18 @@ export const makeRunUtils = (controller, log = (..._) => {}) => {
     get: (_t, methodName, _rx) =>
       harden((...args) => runMethod(methodName, args)),
   });
+  EV.sendOnly = presence =>
+    new Proxy(
+      {},
+      {
+        get:
+          (_t, methodName, _rx) =>
+          (...args) =>
+            runMethod('messageVatObjectSendOnly', [
+              { presence, methodName, args },
+            ]),
+      },
+    );
   EV.get = presence =>
     new Proxy(harden({}), {
       get: (_t, pathElement, _rx) =>
@@ -176,6 +190,18 @@ export const makeWalletFactoryDriver = async (
       return EV(walletPresence).handleBridgeAction(offerCapData, true);
     },
     /**
+     * @param {import('@agoric/smart-wallet/src/offers.js').OfferSpec} offer
+     * @returns {void}
+     */
+    sendOffer(offer) {
+      const offerCapData = marshaller.serialize({
+        method: 'executeOffer',
+        offer,
+      });
+
+      return EV.sendOnly(walletPresence).handleBridgeAction(offerCapData, true);
+    },
+    /**
      * @template {(brands: Record<string, Brand>, ...rest: any) => import('@agoric/smart-wallet/src/offers.js').OfferSpec} M offer maker function
      * @param {M} makeOffer
      * @param {Parameters<M>[1]} firstArg
@@ -184,8 +210,18 @@ export const makeWalletFactoryDriver = async (
      */
     executeOfferMaker(makeOffer, firstArg, secondArg) {
       const offer = makeOffer(agoricNamesRemotes.brand, firstArg, secondArg);
-
       return this.executeOffer(offer);
+    },
+    /**
+     * @template {(brands: Record<string, Brand>, ...rest: any) => import('@agoric/smart-wallet/src/offers.js').OfferSpec} M offer maker function
+     * @param {M} makeOffer
+     * @param {Parameters<M>[1]} firstArg
+     * @param {Parameters<M>[2]} [secondArg]
+     * @returns {void}
+     */
+    sendOfferMaker(makeOffer, firstArg, secondArg) {
+      const offer = makeOffer(agoricNamesRemotes.brand, firstArg, secondArg);
+      this.sendOffer(offer);
     },
     /**
      * @returns {import('@agoric/smart-wallet/src/smartWallet.js').UpdateRecord}

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -101,7 +101,7 @@ export const makeRunUtils = (controller, log = (..._) => {}) => {
 
   /**
    * @type {( (presence: unknown) => Record<string, (...args: any) => Promise<any>> ) & {
-   *   sendOnly: (presence: unknown) => Record<string, (...args: any) => any>,
+   *   sendOnly: (presence: unknown) => Record<string, (...args: any) => void>,
    *   get: (presence: unknown) => Record<string, Promise<any>>,
    *   vat: (name: string) => Record<string, (...args: any) => Promise<any>>,
    *   rawBoot: Record<string, (...args: any) => Promise<any>>,

--- a/packages/vats/tools/board-utils.js
+++ b/packages/vats/tools/board-utils.js
@@ -49,7 +49,7 @@ export const makeAgoricNamesRemotesFromFakeStorage = fakeStorageKit => {
     const key = `published.agoricNames.${kind}`;
 
     const values = data.get(key);
-    (values && values.length > 0) || Fail`no data for ${key}`;
+    if (!(values && values.length > 0)) throw Fail`no data for ${key}`;
     /** @type {import("@endo/marshal").CapData<string>} */
     const latestCapData = JSON.parse(values.at(-1));
     /** @type {Array<[string, import('@agoric/vats/tools/board-utils.js').BoardRemote]>} */


### PR DESCRIPTION
closes: #6906

## Description

Makes it possible for clients to `tryExit` a Zoe seat. For them to know what seats are live it also publishes `liveSeats` on the smart wallet's `.current` record.

### Security Considerations

Publishing status off live offers, but nothing precious.

### Scaling Considerations

Iterates over all `liveSeats` to publish them. Strictly speaking this goes against the [limit work by message size](https://github.com/Agoric/agoric-sdk/wiki/Limit-work-by-message-size) rule. But as discussed in https://github.com/Agoric/agoric-sdk/issues/6184, there are somewhat conflicting requirements here and this is the best solution on balance.

### Documentation Considerations

--

### Testing Considerations

New test `exit bid`