### PR TITLE
fix: allow exit with uncommitted allocation

### DIFF
--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -126,15 +126,6 @@ export const createSeatManager = (
     }
   };
 
-  /** @param {ZCFSeat} zcfSeat */
-  const assertNoStagedAllocation = zcfSeat => {
-    if (hasStagedAllocation(zcfSeat)) {
-      Fail`The seat could not be exited with a staged but uncommitted allocation: ${getStagedAllocation(
-        zcfSeat,
-      )}. Please reallocate over this seat or clear the staged allocation.`;
-    }
-  };
-
   const ZCFSeatI = M.interface('ZCFSeat', {}, { sloppy: true });
 
   const makeZCFSeatInternal = prepareExoClass(
@@ -156,7 +147,6 @@ export const createSeatManager = (
       exit(completion) {
         const { self } = this;
         assertActive(self);
-        assertNoStagedAllocation(self);
         doExitSeat(self);
         E(zoeInstanceAdmin).exitSeat(zcfSeatToSeatHandle.get(self), completion);
       },


### PR DESCRIPTION
closes: #7024

## Description

Allow offer exit even if there's a staged but uncommitted allocation. This will be obviated by https://github.com/Agoric/agoric-sdk/issues/3850 but meanwhile this is a simple fix.

### Security Considerations

TBD

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
