### PR TITLE
fix: omitted null case

### DIFF
--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -887,13 +887,14 @@ const makePatternKit = () => {
 
     checkKeyPattern: (kind, check) => {
       switch (kind) {
+        case 'undefined':
+        case 'null':
         case 'boolean':
         case 'number':
         case 'bigint':
         case 'string':
         case 'symbol':
-        case 'remotable':
-        case 'undefined': {
+        case 'remotable': {
           return true;
         }
         default: {


### PR DESCRIPTION
Tracks https://github.com/endojs/endo/pull/1498

Fixes https://github.com/endojs/endo/issues/1489

The `checkKeyPattern` test seems to have forgotten to include the `'null':` case. This PR adds it. (It also rearranges the cases into the order of the `PassStyle` type declaration.)

@FUDCo , `checkKeyPattern` came from you, so I need you to verify that this omission was not intentional.