### PR TITLE
fix: without assertKeyPattern

### DIFF
--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -387,7 +387,7 @@ test('virtual object gc', async t => {
     [`${v}.vs.vc.4.|entryCount`]: '0',
     [`${v}.vs.vc.4.|label`]: 'watchedPromises',
     [`${v}.vs.vc.4.|nextOrdinal`]: '1',
-    [`${v}.vs.vc.4.|schemata`]: vstr([M.string()]),
+    [`${v}.vs.vc.4.|schemata`]: vstr([M.and(M.scalar(), M.string())]),
     [`${v}.vs.vom.es.o+v10/3`]: 'r',
     [`${v}.vs.vom.o+v10/2`]: `{"label":${vstr('thing #2')}}`,
     [`${v}.vs.vom.o+v10/3`]: `{"label":${vstr('thing #3')}}`,

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -1,6 +1,7 @@
 export {
   isKey,
   assertKey,
+  assertScalarKey,
   makeCopySet,
   getCopySetKeys,
   makeCopyBag,
@@ -49,7 +50,6 @@ export {
   getRankCover,
   isPattern,
   assertPattern,
-  assertKeyPattern,
   matches,
   mustMatch,
 } from './patterns/patternMatchers.js';

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -27,7 +27,6 @@ import {
   checkKey,
   isKey,
   checkScalarKey,
-  isScalarKey,
   checkCopySet,
   checkCopyMap,
   copyMapKeySet,
@@ -358,80 +357,6 @@ const makePatternKit = () => {
     checkPattern(patt, assertChecker);
   };
 
-  // /////////////////////// isKeyPattern //////////////////////////////////////
-
-  /** @type {CheckKeyPattern} */
-  const checkKeyPattern = (patt, check) => {
-    if (isKey(patt)) {
-      // In principle, all keys are patterns, but only scalars are currently
-      // supported as keys.
-      return check(isScalarKey(patt), X`non-scalar keys are not yet supported`);
-    }
-    // eslint-disable-next-line no-use-before-define
-    return checkKeyPatternInternal(patt, check);
-  };
-
-  /**
-   * @param {Passable} patt
-   * @param {Checker} check
-   * @returns {boolean}
-   */
-  const checkKeyPatternInternal = (patt, check) => {
-    // Purposely parallels checkKey. TODO reuse more logic between them.
-    // Most of the text of the switch below not dealing with matchers is
-    // essentially identical.
-    const passStyle = passStyleOf(patt);
-    switch (passStyle) {
-      case 'copyRecord':
-      case 'copyArray': {
-        return check(false, X`non-scalar keys are not yet supported`);
-      }
-      case 'tagged': {
-        const tag = getTag(patt);
-        const matchHelper = maybeMatchHelper(tag);
-        if (matchHelper !== undefined) {
-          // This check guarantees the payload invariants assumed by the other
-          // matchHelper methods.
-          return matchHelper.checkKeyPattern(patt.payload, check);
-        }
-        switch (tag) {
-          case 'copySet':
-          case 'copyMap': {
-            return check(false, X`non-scalar keys are not yet supported`);
-          }
-          default: {
-            return check(
-              false,
-              X`A passable tagged ${q(tag)} is not a key: ${patt}`,
-            );
-          }
-        }
-      }
-      case 'error':
-      case 'promise': {
-        return check(false, X`A ${q(passStyle)} cannot be a pattern`);
-      }
-      default: {
-        // Unexpected tags are just non-patterns, but an unexpected passStyle
-        // is always an error.
-        throw Fail`unexpected passStyle ${q(passStyle)}: ${patt}`;
-      }
-    }
-  };
-
-  /**
-   * @param {Passable} patt
-   * @returns {boolean}
-   */
-  const isKeyPattern = patt => checkKeyPattern(patt, identChecker);
-
-  /**
-   * @param {Pattern} patt
-   */
-  const assertKeyPattern = patt => {
-    checkKeyPattern(patt, assertChecker);
-  };
-
   // /////////////////////// matches ///////////////////////////////////////////
 
   /**
@@ -733,8 +658,6 @@ const makePatternKit = () => {
       check(false, X`match:any payload: ${matcherPayload} - Must be undefined`),
 
     getRankCover: (_matchPayload, _encodePassable) => ['', '{'],
-
-    checkKeyPattern: (_matcherPayload, _check) => true,
   });
 
   /** @type {MatchHelper} */
@@ -757,10 +680,6 @@ const makePatternKit = () => {
         compareRank,
         patts.map(p => getRankCover(p, encodePassable)),
       ),
-
-    checkKeyPattern: (patts, check) => {
-      return patts.every(patt => checkKeyPattern(patt, check));
-    },
   });
 
   /** @type {MatchHelper} */
@@ -796,10 +715,6 @@ const makePatternKit = () => {
         compareRank,
         patts.map(p => getRankCover(p, encodePassable)),
       ),
-
-    checkKeyPattern: (patts, check) => {
-      return patts.every(patt => checkKeyPattern(patt, check));
-    },
   });
 
   /** @type {MatchHelper} */
@@ -818,8 +733,6 @@ const makePatternKit = () => {
     checkIsWellFormed: checkPattern,
 
     getRankCover: (_patt, _encodePassable) => ['', '{'],
-
-    checkKeyPattern,
   });
 
   /** @type {MatchHelper} */
@@ -830,8 +743,6 @@ const makePatternKit = () => {
     checkIsWellFormed: matchAnyHelper.checkIsWellFormed,
 
     getRankCover: (_matchPayload, _encodePassable) => ['a', 'z~'],
-
-    checkKeyPattern: (_matcherPayload, _check) => true,
   });
 
   /** @type {MatchHelper} */
@@ -842,8 +753,6 @@ const makePatternKit = () => {
     checkIsWellFormed: matchAnyHelper.checkIsWellFormed,
 
     getRankCover: (_matchPayload, _encodePassable) => ['a', 'z~'],
-
-    checkKeyPattern: (_matcherPayload, _check) => true,
   });
 
   /** @type {MatchHelper} */
@@ -854,8 +763,6 @@ const makePatternKit = () => {
     checkIsWellFormed: matchAnyHelper.checkIsWellFormed,
 
     getRankCover: (_matchPayload, _encodePassable) => ['a', 'z~'],
-
-    checkKeyPattern: (_matcherPayload, _check) => true,
   });
 
   /** @type {MatchHelper} */
@@ -884,23 +791,6 @@ const makePatternKit = () => {
       }
       return getPassStyleCover(style);
     },
-
-    checkKeyPattern: (kind, check) => {
-      switch (kind) {
-        case 'boolean':
-        case 'number':
-        case 'bigint':
-        case 'string':
-        case 'symbol':
-        case 'remotable':
-        case 'undefined': {
-          return true;
-        }
-        default: {
-          return check(false, X`${kind} keys are not supported`);
-        }
-      }
-    },
   });
 
   /** @type {MatchHelper} */
@@ -923,8 +813,6 @@ const makePatternKit = () => {
 
     getRankCover: (_matchPayload, _encodePassable) =>
       getPassStyleCover('bigint'),
-
-    checkKeyPattern: (_matcherPayload, _check) => true,
   });
 
   /** @type {MatchHelper} */
@@ -949,8 +837,6 @@ const makePatternKit = () => {
     getRankCover: (_matchPayload, _encodePassable) =>
       // TODO Could be more precise
       getPassStyleCover('bigint'),
-
-    checkKeyPattern: (_matcherPayload, _check) => true,
   });
 
   /** @type {MatchHelper} */
@@ -977,8 +863,6 @@ const makePatternKit = () => {
 
     getRankCover: (_matchPayload, _encodePassable) =>
       getPassStyleCover('string'),
-
-    checkKeyPattern: (_matcherPayload, _check) => true,
   });
 
   /** @type {MatchHelper} */
@@ -1011,8 +895,6 @@ const makePatternKit = () => {
 
     getRankCover: (_matchPayload, _encodePassable) =>
       getPassStyleCover('symbol'),
-
-    checkKeyPattern: (_matcherPayload, _check) => true,
   });
 
   /** @type {MatchHelper} */
@@ -1049,8 +931,6 @@ const makePatternKit = () => {
 
     getRankCover: (_remotableDesc, _encodePassable) =>
       getPassStyleCover('remotable'),
-
-    checkKeyPattern: (_remotableDesc, _check) => true,
   });
 
   /** @type {MatchHelper} */
@@ -1073,9 +953,6 @@ const makePatternKit = () => {
       }
       return [leftBound, rightBound];
     },
-
-    checkKeyPattern: (rightOperand, check) =>
-      checkKeyPattern(rightOperand, check),
   });
 
   /** @type {MatchHelper} */
@@ -1087,9 +964,6 @@ const makePatternKit = () => {
     checkIsWellFormed: checkKey,
 
     getRankCover: matchLTEHelper.getRankCover,
-
-    checkKeyPattern: (rightOperand, check) =>
-      checkKeyPattern(rightOperand, check),
   });
 
   /** @type {MatchHelper} */
@@ -1112,9 +986,6 @@ const makePatternKit = () => {
       }
       return [leftBound, rightBound];
     },
-
-    checkKeyPattern: (rightOperand, check) =>
-      checkKeyPattern(rightOperand, check),
   });
 
   /** @type {MatchHelper} */
@@ -1126,9 +997,6 @@ const makePatternKit = () => {
     checkIsWellFormed: checkKey,
 
     getRankCover: matchGTEHelper.getRankCover,
-
-    checkKeyPattern: (rightOperand, check) =>
-      checkKeyPattern(rightOperand, check),
   });
 
   /** @type {MatchHelper} */
@@ -1178,9 +1046,6 @@ const makePatternKit = () => {
       ),
 
     getRankCover: _entryPatt => getPassStyleCover('copyRecord'),
-
-    checkKeyPattern: (_entryPatt, check) =>
-      check(false, X`Records not yet supported as keys`),
   });
 
   /** @type {MatchHelper} */
@@ -1207,9 +1072,6 @@ const makePatternKit = () => {
       ),
 
     getRankCover: () => getPassStyleCover('copyArray'),
-
-    checkKeyPattern: (_, check) =>
-      check(false, X`Arrays not yet supported as keys`),
   });
 
   /** @type {MatchHelper} */
@@ -1237,9 +1099,6 @@ const makePatternKit = () => {
       ),
 
     getRankCover: () => getPassStyleCover('tagged'),
-
-    checkKeyPattern: (_, check) =>
-      check(false, X`CopySets not yet supported as keys`),
   });
 
   /** @type {MatchHelper} */
@@ -1280,9 +1139,6 @@ const makePatternKit = () => {
       ),
 
     getRankCover: () => getPassStyleCover('tagged'),
-
-    checkKeyPattern: (_, check) =>
-      check(false, X`CopyBags not yet supported as keys`),
   });
 
   /** @type {MatchHelper} */
@@ -1325,9 +1181,6 @@ const makePatternKit = () => {
       ),
 
     getRankCover: _entryPatt => getPassStyleCover('tagged'),
-
-    checkKeyPattern: (_entryPatt, check) =>
-      check(false, X`CopyMap not yet supported as keys`),
   });
 
   /**
@@ -1432,11 +1285,6 @@ const makePatternKit = () => {
       _optionalPatt = undefined,
       _restPatt = undefined,
     ]) => getPassStyleCover('copyArray'),
-
-    checkKeyPattern: (
-      [_requiredPatt, _optionalPatt = undefined, _restPatt = undefined],
-      check,
-    ) => check(false, X`copyRecord not yet supported as keys`),
   });
 
   /**
@@ -1545,11 +1393,6 @@ const makePatternKit = () => {
       _optionalPatt = undefined,
       _restPatt = undefined,
     ]) => getPassStyleCover(passStyleOf(requiredPatt)),
-
-    checkKeyPattern: (
-      [_requiredPatt, _optionalPatt = undefined, _restPatt = undefined],
-      check,
-    ) => check(false, X`copyRecord not yet supported as keys`),
   });
 
   /** @type {Record<string, MatchHelper>} */
@@ -1813,8 +1656,6 @@ const makePatternKit = () => {
     mustMatch,
     assertPattern,
     isPattern,
-    assertKeyPattern,
-    isKeyPattern,
     getRankCover,
     M,
   });
@@ -1832,8 +1673,6 @@ export const {
   mustMatch,
   assertPattern,
   isPattern,
-  assertKeyPattern,
-  isKeyPattern,
   getRankCover,
   M,
 } = makePatternKit();

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -428,13 +428,6 @@
  */
 
 /**
- * @callback CheckKeyPattern
- * @param {Passable} allegedPattern
- * @param {Checker} check
- * @returns {boolean}
- */
-
-/**
  * @callback KeyToDBKey
  * If this key can be encoded as a DBKey string which sorts correctly,
  * return that string. Else return `undefined`. For example, a scalar-only
@@ -735,8 +728,6 @@
  * @property {(specimen: Passable, patt: Pattern, label?: string|number) => void} mustMatch
  * @property {(patt: Pattern) => void} assertPattern
  * @property {(patt: Passable) => boolean} isPattern
- * @property {(patt: Pattern) => void} assertKeyPattern
- * @property {(patt: Passable) => boolean} isKeyPattern
  * @property {GetRankCover} getRankCover
  * @property {MatcherNamespace} M
  */
@@ -779,10 +770,4 @@
  * The left element must be before or the same rank as any possible
  * matching specimen. The right element must be after or the same
  * rank as any possible matching specimen.
- *
- * @property {(allegedPattern: Passable,
- *             check: Checker
- * ) => boolean} checkKeyPattern
- * Assumes this is the payload of a CopyTagged with the corresponding
- * matchTag. Is this a valid pattern for use as a query key or key shape?
  */

--- a/packages/swingset-liveslots/src/collectionManager.js
+++ b/packages/swingset-liveslots/src/collectionManager.js
@@ -8,7 +8,6 @@ import {
 import { compareRank } from '@endo/marshal/src/rankOrder.js';
 import {
   getRankCover,
-  assertKeyPattern,
   assertPattern,
   matches,
   mustMatch,
@@ -74,56 +73,56 @@ export function makeCollectionManager(
       hasWeakKeys: false,
       kindID: 0,
       // eslint-disable-next-line no-use-before-define
-      reanimator: reanimateScalarMapStore,
+      reanimator: reanimateMapStore,
       durable: false,
     },
     scalarWeakMapStore: {
       hasWeakKeys: true,
       kindID: 0,
       // eslint-disable-next-line no-use-before-define
-      reanimator: reanimateScalarWeakMapStore,
+      reanimator: reanimateWeakMapStore,
       durable: false,
     },
     scalarSetStore: {
       hasWeakKeys: false,
       kindID: 0,
       // eslint-disable-next-line no-use-before-define
-      reanimator: reanimateScalarSetStore,
+      reanimator: reanimateSetStore,
       durable: false,
     },
     scalarWeakSetStore: {
       hasWeakKeys: true,
       kindID: 0,
       // eslint-disable-next-line no-use-before-define
-      reanimator: reanimateScalarWeakSetStore,
+      reanimator: reanimateWeakSetStore,
       durable: false,
     },
     scalarDurableMapStore: {
       hasWeakKeys: false,
       kindID: 0,
       // eslint-disable-next-line no-use-before-define
-      reanimator: reanimateScalarMapStore,
+      reanimator: reanimateMapStore,
       durable: true,
     },
     scalarDurableWeakMapStore: {
       hasWeakKeys: true,
       kindID: 0,
       // eslint-disable-next-line no-use-before-define
-      reanimator: reanimateScalarWeakMapStore,
+      reanimator: reanimateWeakMapStore,
       durable: true,
     },
     scalarDurableSetStore: {
       hasWeakKeys: false,
       kindID: 0,
       // eslint-disable-next-line no-use-before-define
-      reanimator: reanimateScalarSetStore,
+      reanimator: reanimateSetStore,
       durable: true,
     },
     scalarDurableWeakSetStore: {
       hasWeakKeys: true,
       kindID: 0,
       // eslint-disable-next-line no-use-before-define
-      reanimator: reanimateScalarWeakSetStore,
+      reanimator: reanimateWeakSetStore,
       durable: true,
     },
   };
@@ -397,7 +396,7 @@ export function makeCollectionManager(
       valuePatt = M.any(),
     ) {
       assert(yieldKeys || yieldValues, 'useless entries()');
-      assertKeyPattern(keyPatt);
+      assertPattern(keyPatt);
       assertPattern(valuePatt);
 
       const [coverStart, coverEnd] = getRankCover(keyPatt, encodeKey);
@@ -666,7 +665,7 @@ export function makeCollectionManager(
   function makeCollection(label, kindName, isDurable, keyShape, valueShape) {
     assert.typeof(label, 'string');
     assert(storeKindInfo[kindName]);
-    assertKeyPattern(keyShape);
+    assertPattern(keyShape);
     const schemata = [keyShape];
     if (valueShape) {
       assertPattern(valueShape);
@@ -764,17 +763,16 @@ export function makeCollectionManager(
   }
 
   /**
-   * Produce a *scalar* big map: keys can only be atomic values, primitives, or
-   * remotables.
+   * Produce a big map.
    *
    * @template K,V
    * @param {string} [label='map'] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {MapStore<K,V>}
    */
-  function makeScalarBigMapStore(label = 'map', options = {}) {
+  function makeBigMapStore(label = 'map', options = {}) {
     const {
-      keyShape = M.scalar(),
+      keyShape = M.any(),
       valueShape = undefined,
       durable = false,
     } = options;
@@ -796,7 +794,7 @@ export function makeCollectionManager(
     if (baggageID) {
       return convertSlotToVal(baggageID);
     } else {
-      const baggage = makeScalarBigMapStore('baggage', {
+      const baggage = makeBigMapStore('baggage', {
         keyShape: M.string(),
         durable: true,
       });
@@ -809,17 +807,16 @@ export function makeCollectionManager(
   }
 
   /**
-   * Produce a *scalar* weak big map: keys can only be atomic values,
-   * primitives, or remotables.
+   * Produce a weak big map.
    *
    * @template K,V
    * @param {string} [label='weakMap'] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {WeakMapStore<K,V>}
    */
-  function makeScalarBigWeakMapStore(label = 'weakMap', options = {}) {
+  function makeBigWeakMapStore(label = 'weakMap', options = {}) {
     const {
-      keyShape = M.scalar(),
+      keyShape = M.any(),
       valueShape = undefined,
       durable = false,
     } = options;
@@ -839,15 +836,14 @@ export function makeCollectionManager(
   }
 
   /**
-   * Produce a *scalar* big set: keys can only be atomic values, primitives, or
-   * remotables.
+   * Produce a big set.
    *
    * @template K
    * @param {string} [label='set'] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {SetStore<K>}
    */
-  function makeScalarBigSetStore(label = 'set', options = {}) {
+  function makeBigSetStore(label = 'set', options = {}) {
     const {
       keyShape = M.scalar(),
       valueShape = undefined,
@@ -867,15 +863,14 @@ export function makeCollectionManager(
   }
 
   /**
-   * Produce a *scalar* weak big set: keys can only be atomic values,
-   * primitives, or remotables.
+   * Produce a weak big set.
    *
    * @template K
    * @param {string} [label='weakSet'] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {WeakSetStore<K>}
    */
-  function makeScalarBigWeakSetStore(label = 'weakSet', options = {}) {
+  function makeBigWeakSetStore(label = 'weakSet', options = {}) {
     const {
       keyShape = M.scalar(),
       valueShape = undefined,
@@ -914,23 +909,89 @@ export function makeCollectionManager(
     );
   }
 
-  function reanimateScalarMapStore(vobjID) {
+  function reanimateMapStore(vobjID) {
     return collectionToMapStore(reanimateCollection(vobjID));
   }
 
-  function reanimateScalarWeakMapStore(vobjID) {
+  function reanimateWeakMapStore(vobjID) {
     return collectionToWeakMapStore(reanimateCollection(vobjID));
   }
 
-  function reanimateScalarSetStore(vobjID) {
+  function reanimateSetStore(vobjID) {
     return collectionToSetStore(reanimateCollection(vobjID));
   }
 
-  function reanimateScalarWeakSetStore(vobjID) {
+  function reanimateWeakSetStore(vobjID) {
     return collectionToWeakSetStore(reanimateCollection(vobjID));
   }
 
   const testHooks = { obtainStoreKindID, storeSizeInternal, makeCollection };
+
+  /**
+   * @param {Pattern} baseKeyShape
+   * @param {StoreOptions} options
+   * @returns {StoreOptions}
+   */
+  const narrowKeyShapeOption = (baseKeyShape, options) => {
+    const { keyShape: keyShapeRestriction } = options;
+    // To prepare for pattern-based compression
+    // https://github.com/Agoric/agoric-sdk/pull/6432
+    // put the substantive pattern, if any, last in the `M.and` since
+    // an `M.and` pattern compresses only according to its last conjunct.
+    const keyShape =
+      keyShapeRestriction === undefined
+        ? baseKeyShape
+        : M.and(baseKeyShape, keyShapeRestriction);
+    return harden({ ...options, keyShape });
+  };
+
+  /**
+   * Produce a *scalar* big map: keys can only be atomic values, primitives, or
+   * remotables.
+   *
+   * @template K,V
+   * @param {string} [label='map'] - diagnostic label for the store
+   * @param {StoreOptions} [options]
+   * @returns {MapStore<K,V>}
+   */
+  const makeScalarBigMapStore = (label = 'map', options = {}) =>
+    makeBigMapStore(label, narrowKeyShapeOption(M.scalar(), options));
+
+  /**
+   * Produce a *scalar* weak big map: keys can only be atomic values,
+   * primitives, or remotables.
+   *
+   * @template K,V
+   * @param {string} [label='weakMap'] - diagnostic label for the store
+   * @param {StoreOptions} [options]
+   * @returns {WeakMapStore<K,V>}
+   */
+  const makeScalarBigWeakMapStore = (label = 'weakMap', options = {}) =>
+    makeBigWeakMapStore(label, narrowKeyShapeOption(M.scalar(), options));
+
+  /**
+   * Produce a *scalar* big set: keys can only be atomic values, primitives, or
+   * remotables.
+   *
+   * @template K
+   * @param {string} [label='set'] - diagnostic label for the store
+   * @param {StoreOptions} [options]
+   * @returns {SetStore<K>}
+   */
+  const makeScalarBigSetStore = (label = 'set', options = {}) =>
+    makeBigSetStore(label, narrowKeyShapeOption(M.scalar(), options));
+
+  /**
+   * Produce a *scalar* weak big set: keys can only be atomic values,
+   * primitives, or remotables.
+   *
+   * @template K
+   * @param {string} [label='weakSet'] - diagnostic label for the store
+   * @param {StoreOptions} [options]
+   * @returns {WeakSetStore<K>}
+   */
+  const makeScalarBigWeakSetStore = (label = 'weakSet', options = {}) =>
+    makeBigWeakSetStore(label, narrowKeyShapeOption(M.scalar(), options));
 
   return harden({
     initializeStoreKindInfo,

--- a/packages/swingset-liveslots/test/test-collections.js
+++ b/packages/swingset-liveslots/test/test-collections.js
@@ -352,24 +352,6 @@ test('constrain set key shape', t => {
   t.deepEqual(Array.from(lt47.values(M.gt(20))), [29, 46]);
 });
 
-test('bogus key shape', t => {
-  t.throws(
-    () => makeScalarBigMapStore('bogus1', { keyShape: M.promise() }),
-    m('"promise" keys are not supported'),
-  );
-  t.throws(
-    () => makeScalarBigMapStore('bogus2', { keyShape: M.error() }),
-    m('"error" keys are not supported'),
-  );
-  t.throws(
-    () =>
-      makeScalarBigMapStore('bogus3', {
-        keyShape: M.or(M.string(), M.promise()),
-      }),
-    m('"promise" keys are not supported'),
-  );
-});
-
 test('map clear', t => {
   const testStore = makeScalarBigMapStore('cmap', { keyShape: M.any() });
   testStore.init('a', 'ax');

--- a/packages/swingset-liveslots/test/test-initial-vrefs.js
+++ b/packages/swingset-liveslots/test/test-initial-vrefs.js
@@ -91,7 +91,8 @@ test('initial vatstore contents', async t => {
   t.deepEqual(kunser(JSON.parse(get(`vc.2.|schemata`))), scalarSchema);
   t.deepEqual(kunser(JSON.parse(get(`vc.3.|schemata`))), scalarSchema);
   // watchedPromises uses vref (string) keys
-  t.deepEqual(kunser(JSON.parse(get(`vc.4.|schemata`))), stringSchema);
+  const scalarStringSchema = [M.and(M.scalar(), M.string())];
+  t.deepEqual(kunser(JSON.parse(get(`vc.4.|schemata`))), scalarStringSchema);
 });
 
 test('vrefs', async t => {

--- a/packages/vat-data/test/test-scalar-only-keys.js
+++ b/packages/vat-data/test/test-scalar-only-keys.js
@@ -1,0 +1,23 @@
+// From https://github.com/Agoric/agoric-sdk/pull/6903#discussion_r1098067133
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { M, makeScalarMapStore } from '@agoric/store';
+
+import { makeScalarBigMapStore } from '../src/vat-data-bindings.js';
+
+test('scalar maps should reject non-scalar keys', t => {
+  const bigMap = makeScalarMapStore('dummy', { keyShape: M.key() });
+  t.throws(() => bigMap.init(harden({ label: 'not a scalar' })), {
+    message:
+      /A "copyRecord" cannot be a scalar key: \{"label":"not a scalar"\}/,
+  });
+});
+
+test('scalar big maps should reject non-scalar keys', t => {
+  const bigMap = makeScalarBigMapStore('dummy', { keyShape: M.key() });
+  t.throws(() => bigMap.init(harden({ label: 'not a scalar' })), {
+    message:
+      /A "copyRecord" cannot be a scalar key: \{"label":"not a scalar"\}/,
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/Agoric/agoric-sdk/issues/6953
Fixes: https://github.com/endojs/endo/issues/1489
A step towards fixing https://github.com/Agoric/agoric-sdk/issues/5263
Replaces https://github.com/endojs/endo/pull/1498
Replaces https://github.com/Agoric/agoric-sdk/pull/7034

Problem correctly diagnosed at https://github.com/Agoric/agoric-sdk/pull/6903#discussion_r1099042215 

Not only was `assertKeyPattern` broken, it also wasn't needed. At best, it was an optimization to turn 
`M.and(M.scalar(), patt)` into `patt` in the case where `patt` implied `M.scalar()`, i.e., the case where every specimen that would satisfy `patt` would necessarily also satisfy `M.scalar()`. But correctness before optimization.

It turns out that the implementation of virtual and durable stores already ***correctly*** accepts non-scalar keys. So, inside `collectionManager.js` I privately renamed and fixed them to reflect that. However, to not create any deviation from ***intended*** behavior as of this PR, I wrap these with the scalar store makers and export only them. 

This sets us up to easily expose non-scalar virtual stores later. Since this PR is not actually exposing the non-scalar stores, it also doesn't test that they are correctly non-scalar stores. I only validated this by a bit of manual testing and watching what happens under a debugger. At such a time that we do wish to expose non-scalar stores, we'll also need to implement non-scalar versions of the heap stores. This would start with the same trick: using `encodePassable` to encode the key into a sort-order preserving string. But it would need different, and non-trivial, logic for the embedded remotables. So exposed non-scalar stores remain hidden as of this PR.

Once this PR settles down, I'll make a corresponding PR to make the applicable changes identically to `@endo/patterns`