### PR TITLE
fix: pass msg into go func

### DIFF
--- a/golang/cosmos/ante/vm_admission.go
+++ b/golang/cosmos/ante/vm_admission.go
@@ -37,7 +37,7 @@ func (ad AdmissionDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate boo
 			if err := camsg.CheckAdmissibility(ctx, ad.data); err != nil {
 				errors = append(errors, err)
 				if !simulate {
-					defer func() {
+					defer func(msg sdk.Msg) {
 						telemetry.IncrCounterWithLabels(
 							[]string{"tx", "ante", "admission_refused"},
 							1,
@@ -45,7 +45,7 @@ func (ad AdmissionDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate boo
 								telemetry.NewLabel("msg", sdk.MsgTypeURL(msg)),
 							},
 						)
-					}()
+					}(msg)
 				}
 			}
 		}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #7038
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

```
% golangci-lint run                                                                                                                                                                                                                    130 ↵ ✭
golang/cosmos/ante/vm_admission.go:45:50: loopclosure: loop variable msg captured by func literal (govet)
								telemetry.NewLabel("msg", sdk.MsgTypeURL(msg)),

```

passes msg into the goroutine by arg since it's in a loop context

