### PR TITLE
fix(governance): some governance invitations use proposal patterns

### DIFF
--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -5,6 +5,7 @@ import { E } from '@endo/eventual-send';
 
 import { StorageNodeShape } from '@agoric/internal';
 import { prepareExo, provideDurableMapStore } from '@agoric/vat-data';
+import { EmptyProposalShape } from '@agoric/zoe/src/typeGuards.js';
 import {
   getOpenQuestions,
   getPoserInvitation,
@@ -79,10 +80,15 @@ export const start = (zcf, privateArgs, baggage) => {
     // This will produce unique descriptions because
     // makeCommitteeVoterInvitation() is only called within the following loop,
     // which is only called once per Electorate.
-    return zcf.makeInvitation(seat => {
-      seat.exit();
-      return makeVoterKit(index);
-    }, `Voter${index}`);
+    return zcf.makeInvitation(
+      seat => {
+        seat.exit();
+        return makeVoterKit(index);
+      },
+      `Voter${index}`,
+      undefined,
+      EmptyProposalShape,
+    );
   };
 
   const { committeeName, committeeSize } = zcf.getTerms();

--- a/packages/governance/src/electorateTools.js
+++ b/packages/governance/src/electorateTools.js
@@ -1,3 +1,4 @@
+import { EmptyProposalShape } from '@agoric/zoe/src/typeGuards.js';
 import { E } from '@endo/eventual-send';
 import { deeplyFulfilled, Far } from '@endo/marshal';
 
@@ -95,7 +96,12 @@ const getPoserInvitation = (zcf, addQuestion) => {
     seat.exit();
     return Far(`questionPoser`, { addQuestion });
   };
-  return zcf.makeInvitation(questionPoserHandler, `questionPoser`);
+  return zcf.makeInvitation(
+    questionPoserHandler,
+    `questionPoser`,
+    undefined,
+    EmptyProposalShape,
+  );
 };
 
 harden(startCounter);

--- a/packages/governance/src/noActionElectorate.js
+++ b/packages/governance/src/noActionElectorate.js
@@ -1,6 +1,7 @@
 import { makePublishKit } from '@agoric/notifier';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeExo } from '@agoric/store';
+import { EmptyProposalShape } from '@agoric/zoe/src/typeGuards.js';
 
 import { ElectoratePublicI, ElectorateCreatorI } from './typeGuards.js';
 
@@ -40,6 +41,8 @@ const start = zcf => {
       return zcf.makeInvitation(
         () => {},
         `noActionElectorate doesn't allow posing questions`,
+        undefined,
+        EmptyProposalShape,
       );
     },
     addQuestion(_instance, _question) {

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -90,6 +90,12 @@ export const FullProposalShape = harden({
 /** @see {Proposal} type */
 export const ProposalShape = M.splitRecord({}, FullProposalShape, {});
 
+export const EmptyProposalShape = M.splitRecord({
+  give: {},
+  want: {},
+  exit: { onDemand: null },
+});
+
 export const isOnDemandExitRule = exit => {
   const [exitKey] = Object.keys(exit);
   return exitKey === 'onDemand';


### PR DESCRIPTION
Start replacing uses of the deprecated `assertProposalShape` with `makeInvitation`s direct support for proposalShape patterns. This provides better protection for contracts against malformed offers. When an offer's proposal violates the contract's required proposalShape pattern, it is rejected in Zoe and the contract never even sees the malformed offer.

This PR is somewhat empirical, revising the provided proposal patterns so that they were tighter than the `assertProposalPattern` call it replaced, while still passing all tests. For each modified contract, it would be good for someone who knows the meaning of the contract to do a sanity check on the proposalShape pattern.

One particular way these patterns could be tighter, to protect the contract from seeing more malformed offers, is to use the amountShape specific to the brand the contract is willing to accept in that position. I skipped that additional work, leaving a TODO there instead. Reviewers, if you know what brand-specific amountShape I should use in any such case, please let me know.

# Upgrade considerations

We definitely need to think hard about whether this PR introduces any representation changes that create an upgrade issue. The proposal shapes that we're less worried about were extracted into https://github.com/Agoric/agoric-sdk/pull/8268 , leaving only some governance cases here.