### PR TITLE
fix(scaledPriceAuthority): timing of makeQuoteNotifier vs quoteGiven

### DIFF
--- a/packages/zoe/src/contractSupport/priceAuthorityInitial.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityInitial.js
@@ -78,8 +78,9 @@ export const makeInitialTransform = (
           return initialUpdateP;
         }
 
-        initialMode = false;
-        return E(notifier).getUpdateSince(updateCount);
+        const quote = E(notifier).getUpdateSince(updateCount);
+        void quote.then(() => (initialMode = false));
+        return quote;
       },
     });
 


### PR DESCRIPTION
closes: #7045
refs: #6957, #6960, #7008, #7016

## Description

yet another sync bug setting an initial price

### Testing Considerations

This addressed a problem in a test @turadg is developing.

I plan to look into feasibility of covering this case in the unit test

https://github.com/Agoric/agoric-sdk/blob/bb50f264fc957ba59912243e394d947c678250a9/packages/zoe/test/unitTests/contracts/test-scaledPriceAuthority.js#L257

cc @michaelfig @otoole-brendan 