### PR TITLE
fix(CI): update test-documentation to use Node 16.x, not 14.x

### DIFF
--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x']
+        node-version: ['16.x']
 
     steps:
       - name: Checkout agoric-sdk


### PR DESCRIPTION
The documentation repo recently started requiring Node 16.x (https://github.com/Agoric/documentation/pull/780), but the agoric-sdk CI was still using 14.x . This changes the CI to use the newer version.
