### PR TITLE
Consistently generate build tags on Make 4.3+

### DIFF
--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -16,7 +16,7 @@ BIN := $(shell echo $${GOBIN-$${GOPATH-$$HOME/go}/bin})
 include Makefile.ledger
 
 whitespace :=
-whitespace += $(whitespace)
+whitespace := $(whitespace) $(whitespace)
 comma := ,
 build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
 


### PR DESCRIPTION
refs: cosmos/gaia#2017

## Description

With Make 4.3+, the empty whitespace does not seem to work as originally intended. Agoric SDK only uses one build tag `"ledger"` and therefore does not currently experience malformed tags.

However, on Gaia (Cosmoshub) it was identified that build tags were produced as `"netgo ledger,"` on Ubuntu 22.04 and other systems that include the newer Make version. The build tags were originally intended as `"netgo,ledger"` which can be observed on Make 4.2 (shipped with Ubuntu 20.04).

This change ensures that in future, if Agoric decides to expand on build tags, it will work consistently across old and new systems.

This change swaps out the `+=` use in favor of an explicit `:=`. _([Make Reference](https://www.gnu.org/software/make/manual/html_node/Appending.html))_

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

None.