### PR TITLE
fix: missing zcfMint options

### DIFF
--- a/packages/ERTP/jsconfig.json
+++ b/packages/ERTP/jsconfig.json
@@ -4,7 +4,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -106,6 +106,10 @@ harden(prepareIssuerKit);
 export const hasIssuer = baggage => baggage.has(INSTANCE_KEY);
 
 /**
+ * @typedef {Partial<{elementShape: Pattern}>} IssuerOptionsRecord
+ */
+
+/**
  * @template {AssetKind} K
  * The name becomes part of the brand in asset descriptions.
  * The name is useful for debugging and double-checking
@@ -131,7 +135,7 @@ export const hasIssuer = baggage => baggage.has(INSTANCE_KEY);
  * larger unit of computation, like the enclosing vat, can be shutdown
  * before anything else is corrupted by that corrupted state.
  * See https://github.com/Agoric/agoric-sdk/issues/3434
- * @param {Partial<{elementShape: Pattern}>} [options]
+ * @param {IssuerOptionsRecord} [options]
  * @returns {IssuerKit<K>}
  */
 export const makeDurableIssuerKit = (
@@ -174,7 +178,7 @@ harden(makeDurableIssuerKit);
  * larger unit of computation, like the enclosing vat, can be shutdown
  * before anything else is corrupted by that corrupted state.
  * See https://github.com/Agoric/agoric-sdk/issues/3434
- * @param {Partial<{elementShape: Pattern}>} [options]
+ * @param {IssuerOptionsRecord} [options]
  * @returns {IssuerKit<K>}
  */
 export const makeIssuerKit = (

--- a/packages/access-token/jsconfig.json
+++ b/packages/access-token/jsconfig.json
@@ -4,13 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/agoric-cli/jsconfig.json
+++ b/packages/agoric-cli/jsconfig.json
@@ -3,15 +3,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-
     "noEmit": true,
-/*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/assert/jsconfig.json
+++ b/packages/assert/jsconfig.json
@@ -4,13 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/cache/jsconfig.json
+++ b/packages/cache/jsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/casting/jsconfig.json
+++ b/packages/casting/jsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/cosmic-proto/tsconfig.json
+++ b/packages/cosmic-proto/tsconfig.json
@@ -5,7 +5,6 @@
     "target": "esnext",
     "module": "esnext",
     "allowSyntheticDefaultImports": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/cosmic-swingset/jsconfig.json
+++ b/packages/cosmic-swingset/jsconfig.json
@@ -4,13 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/deploy-script-support/jsconfig.json
+++ b/packages/deploy-script-support/jsconfig.json
@@ -4,7 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/deploy-script-support/jsconfig.json
+++ b/packages/deploy-script-support/jsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "checkJs": true,
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,

--- a/packages/deploy-script-support/src/assertOfferResult.js
+++ b/packages/deploy-script-support/src/assertOfferResult.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { Fail } from '@agoric/assert';
 import { E } from '@endo/far';
 

--- a/packages/deploy-script-support/src/code-gen.js
+++ b/packages/deploy-script-support/src/code-gen.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { makeMarshal } from '@endo/marshal';
 import { decodeToJustin } from '@endo/marshal/src/marshal-justin.js';
 

--- a/packages/deploy-script-support/src/coreProposalBehavior.js
+++ b/packages/deploy-script-support/src/coreProposalBehavior.js
@@ -1,3 +1,4 @@
+// @ts-check
 const t = 'makeCoreProposalBehavior';
 
 /**

--- a/packages/deploy-script-support/src/depositInvitation.js
+++ b/packages/deploy-script-support/src/depositInvitation.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { E } from '@endo/far';
 
 /**

--- a/packages/deploy-script-support/src/endo-pieces-contract.js
+++ b/packages/deploy-script-support/src/endo-pieces-contract.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { E, Far } from '@endo/far';
 import { encodeBase64, decodeBase64 } from '@endo/base64';
 import { ZipWriter } from '@endo/zip';

--- a/packages/deploy-script-support/src/externalTypes.js
+++ b/packages/deploy-script-support/src/externalTypes.js
@@ -1,3 +1,4 @@
+// @ts-check
 export {};
 
 // TODO move this type somewhere better

--- a/packages/deploy-script-support/src/getBundlerMaker.js
+++ b/packages/deploy-script-support/src/getBundlerMaker.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * This helper mainly exists to bridge the gaps that would be filled by
  * bundlecap support.  It will probably go away after bundlecap support is

--- a/packages/deploy-script-support/src/helpers.js
+++ b/packages/deploy-script-support/src/helpers.js
@@ -1,3 +1,4 @@
+// @ts-check
 import '@agoric/zoe/exported.js';
 import { E } from '@endo/far';
 import bundleSource from '@endo/bundle-source';

--- a/packages/deploy-script-support/src/install.js
+++ b/packages/deploy-script-support/src/install.js
@@ -1,3 +1,4 @@
+// @ts-check
 import './externalTypes.js';
 
 import { E } from '@endo/far';

--- a/packages/deploy-script-support/src/installInPieces.js
+++ b/packages/deploy-script-support/src/installInPieces.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { E } from '@endo/far';
 import { ZipReader } from '@endo/zip';
 import { encodeBase64, decodeBase64 } from '@endo/base64';

--- a/packages/deploy-script-support/src/offer.js
+++ b/packages/deploy-script-support/src/offer.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { E } from '@endo/far';
 import { assert } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';

--- a/packages/deploy-script-support/src/saveIssuer.js
+++ b/packages/deploy-script-support/src/saveIssuer.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { E } from '@endo/far';
 
 /** @typedef {import('@agoric/deploy-script-support/src/externalTypes').Petname} Petname */

--- a/packages/deploy-script-support/src/startInstance.js
+++ b/packages/deploy-script-support/src/startInstance.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { assert } from '@agoric/assert';
 import { E, passStyleOf } from '@endo/far';
 

--- a/packages/deploy-script-support/src/writeCoreProposal.js
+++ b/packages/deploy-script-support/src/writeCoreProposal.js
@@ -1,3 +1,4 @@
+// @ts-check
 import fs from 'fs';
 import { E } from '@endo/far';
 

--- a/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
+++ b/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
@@ -1,3 +1,4 @@
+// @ts-check
 import test from 'ava';
 import '@endo/init';
 

--- a/packages/deploy-script-support/test/unitTests/test-coreProposalBehavior.js
+++ b/packages/deploy-script-support/test/unitTests/test-coreProposalBehavior.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { E } from '@endo/far';

--- a/packages/deploy-script-support/test/unitTests/test-depositInvitation.js
+++ b/packages/deploy-script-support/test/unitTests/test-depositInvitation.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';

--- a/packages/deploy-script-support/test/unitTests/test-getBundlerMaker.js
+++ b/packages/deploy-script-support/test/unitTests/test-getBundlerMaker.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import bundleSource from '@endo/bundle-source';

--- a/packages/deploy-script-support/test/unitTests/test-install.js
+++ b/packages/deploy-script-support/test/unitTests/test-install.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeZoeKit } from '@agoric/zoe';

--- a/packages/deploy-script-support/test/unitTests/test-installInPieces.js
+++ b/packages/deploy-script-support/test/unitTests/test-installInPieces.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import bundleSource from '@endo/bundle-source';

--- a/packages/deploy-script-support/test/unitTests/test-offer.js
+++ b/packages/deploy-script-support/test/unitTests/test-offer.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeZoeKit } from '@agoric/zoe';

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeZoeKit } from '@agoric/zoe';

--- a/packages/deployment/jsconfig.json
+++ b/packages/deployment/jsconfig.json
@@ -4,13 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/governance/jsconfig.json
+++ b/packages/governance/jsconfig.json
@@ -4,7 +4,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/import-manager/jsconfig.json
+++ b/packages/import-manager/jsconfig.json
@@ -1,26 +1,17 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-    "compilerOptions": {
-      "target": "esnext",
-      "module": "esnext",
-  
-      "noEmit": true,
-  /*
-      // The following flags are for creating .d.ts files:
-      "noEmit": false,
-      "declaration": true,
-      "emitDeclarationOnly": true,
-  */
-      "downlevelIteration": true,
-      "strictNullChecks": true,
-      "noImplicitThis": true,
-      "moduleResolution": "node",
-    },
-    "include": [
-      "*.js",
-      "scripts/**/*.js",
-      "src/**/*.js",
-      "test/**/*.js",
-    ],
-  }
-  
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "noEmit": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "moduleResolution": "node",
+  },
+  "include": [
+    "*.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
+}

--- a/packages/inter-protocol/jsconfig.json
+++ b/packages/inter-protocol/jsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/internal/jsconfig.json
+++ b/packages/internal/jsconfig.json
@@ -5,7 +5,6 @@
     // Disable b/c @endo/init can't pass noImplicitAny
     "checkJs": false,
     "noEmit": true,
-    "downlevelIteration": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noImplicitThis": true,

--- a/packages/notifier/jsconfig.json
+++ b/packages/notifier/jsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/pegasus/jsconfig.json
+++ b/packages/pegasus/jsconfig.json
@@ -4,13 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/same-structure/jsconfig.json
+++ b/packages/same-structure/jsconfig.json
@@ -1,26 +1,17 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-    "compilerOptions": {
-      "target": "esnext",
-      "module": "esnext",
-  
-      "noEmit": true,
-  /*
-      // The following flags are for creating .d.ts files:
-      "noEmit": false,
-      "declaration": true,
-      "emitDeclarationOnly": true,
-  */
-      "downlevelIteration": true,
-      "strictNullChecks": true,
-      "noImplicitThis": true,
-      "moduleResolution": "node",
-    },
-    "include": [
-      "*.js",
-      "scripts/**/*.js",
-      "src/**/*.js",
-      "test/**/*.js",
-    ],
-  }
-  
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "noEmit": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "moduleResolution": "node",
+  },
+  "include": [
+    "*.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
+}

--- a/packages/sharing-service/jsconfig.json
+++ b/packages/sharing-service/jsconfig.json
@@ -1,26 +1,17 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-    "compilerOptions": {
-      "target": "esnext",
-      "module": "esnext",
-  
-      "noEmit": true,
-  /*
-      // The following flags are for creating .d.ts files:
-      "noEmit": false,
-      "declaration": true,
-      "emitDeclarationOnly": true,
-  */
-      "downlevelIteration": true,
-      "strictNullChecks": true,
-      "noImplicitThis": true,
-      "moduleResolution": "node",
-    },
-    "include": [
-      "*.js",
-      "scripts/**/*.js",
-      "src/**/*.js",
-      "test/**/*.js",
-    ],
-  }
-  
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "noEmit": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "moduleResolution": "node",
+  },
+  "include": [
+    "*.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
+}

--- a/packages/smart-wallet/jsconfig.json
+++ b/packages/smart-wallet/jsconfig.json
@@ -4,7 +4,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/solo/jsconfig.json
+++ b/packages/solo/jsconfig.json
@@ -4,13 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/sparse-ints/jsconfig.json
+++ b/packages/sparse-ints/jsconfig.json
@@ -4,13 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/spawner/jsconfig.json
+++ b/packages/spawner/jsconfig.json
@@ -1,26 +1,23 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-    "compilerOptions": {
-      "target": "esnext",
-      "module": "esnext",
-  
-      "noEmit": true,
-  /*
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "noEmit": true,
+    /*
       // The following flags are for creating .d.ts files:
       "noEmit": false,
       "declaration": true,
       "emitDeclarationOnly": true,
   */
-      "downlevelIteration": true,
-      "strictNullChecks": true,
-      "noImplicitThis": true,
-      "moduleResolution": "node",
-    },
-    "include": [
-      "*.js",
-      "scripts/**/*.js",
-      "src/**/*.js",
-      "test/**/*.js",
-    ],
-  }
-  
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "moduleResolution": "node",
+  },
+  "include": [
+    "*.js",
+    "scripts/**/*.js",
+    "src/**/*.js",
+    "test/**/*.js",
+  ],
+}

--- a/packages/stat-logger/jsconfig.json
+++ b/packages/stat-logger/jsconfig.json
@@ -4,13 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/store/jsconfig.json
+++ b/packages/store/jsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/swing-store/jsconfig.json
+++ b/packages/swing-store/jsconfig.json
@@ -4,12 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/swingset-liveslots/jsconfig.json
+++ b/packages/swingset-liveslots/jsconfig.json
@@ -4,7 +4,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/swingset-runner/jsconfig.json
+++ b/packages/swingset-runner/jsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/telemetry/jsconfig.json
+++ b/packages/telemetry/jsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/time/jsconfig.json
+++ b/packages/time/jsconfig.json
@@ -4,7 +4,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/ui-components/jsconfig.json
+++ b/packages/ui-components/jsconfig.json
@@ -4,13 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/vats/jsconfig.json
+++ b/packages/vats/jsconfig.json
@@ -3,7 +3,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/wallet/api/jsconfig.json
+++ b/packages/wallet/api/jsconfig.json
@@ -4,7 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/web-components/jsconfig.json
+++ b/packages/web-components/jsconfig.json
@@ -4,13 +4,6 @@
     "target": "esnext",
     "module": "esnext",
     "noEmit": true,
-    /*
-    // The following flags are for creating .d.ts files:
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true,
-*/
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/xsnap-lockdown/jsconfig.json
+++ b/packages/xsnap-lockdown/jsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/xsnap/jsconfig.json
+++ b/packages/xsnap/jsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/zoe/jsconfig.json
+++ b/packages/zoe/jsconfig.json
@@ -4,7 +4,6 @@
     "module": "esnext",
     "checkJs": true,
     "noEmit": true,
-    "downlevelIteration": true,
     "strictNullChecks": true,
     "noImplicitThis": true,
     "moduleResolution": "node",

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -1,5 +1,7 @@
 /// <reference types="ses"/>
 
+/** @typedef {import('@agoric/ertp').IssuerOptionsRecord} IssuerOptionsRecord */
+
 // XXX can be tighter than 'any'
 /**
  * @typedef {any} Completion
@@ -39,7 +41,12 @@
  * @property {<K extends AssetKind>(issuer: Issuer<K>) => Brand<K>} getBrandForIssuer
  * @property {<K extends AssetKind>(brand: Brand<K>) => Issuer<K>} getIssuerForBrand
  * @property {GetAssetKindByBrand} getAssetKind
- * @property {<K extends AssetKind = 'nat'>(keyword: Keyword, assetKind?: K, displayInfo?: AdditionalDisplayInfo) => Promise<ZCFMint<K>>} makeZCFMint
+ * @property {<K extends AssetKind = 'nat'>(
+ *   keyword: Keyword,
+ *   assetKind?: K,
+ *   displayInfo?: AdditionalDisplayInfo,
+ *   options?: IssuerOptionsRecord
+ * ) => Promise<ZCFMint<K>>} makeZCFMint
  * @property {ZCFRegisterFeeMint} registerFeeMint
  * @property {ZCFMakeEmptySeatKit} makeEmptySeatKit
  * @property {SetTestJig} setTestJig

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -29,6 +29,8 @@ import './internal-types.js';
 import '@agoric/swingset-vat/src/types-ambient.js';
 import { HandleOfferI, InvitationHandleShape } from '../typeGuards.js';
 
+/** @typedef {import('@agoric/ertp').IssuerOptionsRecord} IssuerOptionsRecord */
+
 const { Fail } = assert;
 
 /**
@@ -121,13 +123,15 @@ export const makeZCFZygote = async (
    * @param {Keyword} keyword
    * @param {K} [assetKind]
    * @param {AdditionalDisplayInfo} [displayInfo]
+   * @param {IssuerOptionsRecord} [options]
    * @returns {Promise<ZCFMint<K>>}
    */
   const makeZCFMint = async (
     keyword,
     // @ts-expect-error possible different subtype
     assetKind = AssetKind.NAT,
-    displayInfo,
+    displayInfo = undefined,
+    options = undefined,
   ) => {
     getInstanceRecHolder().assertUniqueKeyword(keyword);
 
@@ -135,6 +139,7 @@ export const makeZCFZygote = async (
       keyword,
       assetKind,
       displayInfo,
+      options,
     );
     return zcfMintFactory.makeZCFMintInternal(keyword, zoeMint);
   };

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -156,7 +156,7 @@
  * @param {Keyword} keyword
  * @param {AssetKind} [assetKind]
  * @param {AdditionalDisplayInfo} [displayInfo]
- * @param {Partial<{elementShape: Pattern}>} [options]
+ * @param {IssuerOptionsRecord} [options]
  * @returns {ZoeMint}
  */
 

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -94,13 +94,13 @@ export const makeStartInstance = (
         const { state } = this;
         state.seatHandleToSeatAdmin.get(seatHandle).fail(reason);
       },
-      makeZoeMint(keyword, assetKind, displayInfo, pattern) {
+      makeZoeMint(keyword, assetKind, displayInfo, options) {
         const { state } = this;
         return state.instanceStorage.makeZoeMint(
           keyword,
           assetKind,
           displayInfo,
-          pattern,
+          options,
         );
       },
       registerFeeMint(keyword, feeMintAccess) {


### PR DESCRIPTION
makeZCFMint should have all the parameters it needs to pass through to makeIssuerKit. But it was not updated when we added the `options` parameter.