### PR TITLE
feat(SwingSet): loadSwingsetConfigFile detects missing files

### DIFF
--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -197,6 +197,8 @@ async function resolveSpecFromConfig(referrer, specPath) {
 async function normalizeConfigDescriptor(desc, referrer, expectParameters) {
   const normalizeSpec = async (entry, key) => {
     return resolveSpecFromConfig(referrer, entry[key]).then(spec => {
+      fs.existsSync(spec) ||
+        Fail`spec for ${entry[key]} does not exist: ${spec}`;
       entry[key] = spec;
     });
   };


### PR DESCRIPTION
refs: #7049, #6687
part of #7049

## Description

rather than running for 20 seconds and failing with the mysterious:

```
SwingSet: xsnap: v1: Error#1: Archive failed sanity check: should contain at least a compartment map file and one module file in <unknown>
```

fail early with:

```
Error#1: spec for @agoric/vats/src/core/boot.js does not exist: /.../agoric-sdk/packages/solo/@agoric/vats/src/core/boot.js
```

### Security Considerations

In its current state, this digs the ambient authority hole (#2160) a little deeper. Depending on feedback about whether this is wanted, I could clean that up.

### Testing Considerations

makes testing bootstrap quite a bit faster
