### PR TITLE
fix: step towards stratifying customDetails

### DIFF
--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1500,6 +1500,7 @@ test('transfer vault', async t => {
   /** @type {Promise<Invitation<VaultKit>>} */
   const transferInvite = E(aliceVault).makeTransferInvitation();
   const inviteProps = await getInvitationProperties(transferInvite);
+
   trace(t, 'TRANSFER INVITE', transferInvite, inviteProps);
   const transferSeat = await E(zoe).offer(transferInvite);
   const {
@@ -1520,13 +1521,15 @@ test('transfer vault', async t => {
   );
 
   t.like(inviteProps, {
-    debtSnapshot: {
-      debt: debtAmount,
-      interest: aliceFinish.value.debtSnapshot.interest,
-    },
     description: 'manager0: TransferVault',
-    locked: collateralAmount,
-    vaultState: 'active',
+    customDetails: {
+      debtSnapshot: {
+        debt: debtAmount,
+        interest: aliceFinish.value.debtSnapshot.interest,
+      },
+      locked: collateralAmount,
+      vaultState: 'active',
+    },
   });
 
   const transferStatus = await E(transferNotifier).getUpdateSince();

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -54,7 +54,7 @@ const MAX_PIPE_LENGTH = 2;
  */
 
 /**
- * @typedef {Pick<StandardInvitationDetails, 'description' | 'instance'>} InvitationsPurseQuery
+ * @typedef {Pick<InvitationDetails, 'description' | 'instance'>} InvitationsPurseQuery
  */
 
 /**

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -76,22 +76,21 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const { value: optionValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
+      const { customDetails } = optionValue[0];
+      assert(typeof customDetails === 'object');
       installation === installations.coveredCall || Fail`wrong installation`;
       optionValue[0].description === 'exerciseOption' || Fail`wrong invitation`;
       assert(
         AmountMath.isEqual(
-          optionValue[0].underlyingAssets.UnderlyingAsset,
+          customDetails.underlyingAssets.UnderlyingAsset,
           moola(3),
         ),
       );
       assert(
-        AmountMath.isEqual(
-          optionValue[0].strikePrice.StrikePrice,
-          simoleans(7),
-        ),
+        AmountMath.isEqual(customDetails.strikePrice.StrikePrice, simoleans(7)),
       );
-      optionValue[0].expirationDate === 1n || Fail`wrong expirationDate`;
-      assert(optionValue[0].timeAuthority === timer, 'wrong timer');
+      customDetails.expirationDate === 1n || Fail`wrong expirationDate`;
+      assert(customDetails.timeAuthority === timer, 'wrong timer');
       const { UnderlyingAsset, StrikePrice } = issuerKeywordRecord;
       UnderlyingAsset === moolaIssuer ||
         Fail`The underlying asset issuer should be the moola issuer`;
@@ -133,18 +132,19 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
       const optionValue = optionAmounts.value;
+      const { customDetails } = optionValue[0];
+      assert(typeof customDetails === 'object');
+
       installation === installations.coveredCall || Fail`wrong installation`;
       optionValue[0].description === 'exerciseOption' || Fail`wrong invitation`;
       AmountMath.isEqual(
-        optionValue[0].underlyingAssets.UnderlyingAsset,
+        customDetails.underlyingAssets.UnderlyingAsset,
         moola(3),
       ) || Fail`wrong underlying asset`;
-      AmountMath.isEqual(
-        optionValue[0].strikePrice.StrikePrice,
-        simoleans(7),
-      ) || Fail`wrong strike price`;
-      optionValue[0].expirationDate === 100n || Fail`wrong expiration date`;
-      optionValue[0].timeAuthority === timer || Fail`wrong timer`;
+      AmountMath.isEqual(customDetails.strikePrice.StrikePrice, simoleans(7)) ||
+        Fail`wrong strike price`;
+      customDetails.expirationDate === 100n || Fail`wrong expiration date`;
+      customDetails.timeAuthority === timer || Fail`wrong timer`;
       UnderlyingAsset === moolaIssuer ||
         Fail`The underlyingAsset issuer should be the moola issuer`;
       StrikePrice === simoleanIssuer ||
@@ -204,8 +204,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
         issuerKeywordRecord,
       ) || Fail`issuerKeywordRecord was not as expected`;
-      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3)));
-      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1)));
+      assert(keyEQ(invitationValue[0].customDetails?.minimumBid, simoleans(3)));
+      assert(
+        keyEQ(invitationValue[0].customDetails?.auctionedAssets, moola(1)),
+      );
 
       const proposal = harden({
         want: { Asset: moola(1) },
@@ -246,9 +248,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         ),
         X`issuers were not as expected`,
       );
-      keyEQ(invitationValue[0].asset, moola(3)) ||
+      keyEQ(invitationValue[0].customDetails?.asset, moola(3)) ||
         Fail`Alice made a different offer than expected`;
-      keyEQ(invitationValue[0].price, simoleans(7)) ||
+      keyEQ(invitationValue[0].customDetails?.price, simoleans(7)) ||
         Fail`Alice made a different offer than expected`;
 
       const proposal = harden({

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -30,8 +30,10 @@ const build = async (log, zoe, issuers, payments, installations) => {
         harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
         issuerKeywordRecord,
       ) || Fail`issuerKeywordRecord were not as expected`;
-      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3)));
-      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1)));
+      assert(keyEQ(invitationValue[0].customDetails?.minimumBid, simoleans(3)));
+      assert(
+        keyEQ(invitationValue[0].customDetails?.auctionedAssets, moola(1)),
+      );
 
       const proposal = harden({
         want: { Asset: moola(1) },

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -31,8 +31,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
         issuerKeywordRecord,
       ) || Fail`issuerKeywordRecord were not as expected`;
-      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3)));
-      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1)));
+      assert(keyEQ(invitationValue[0].customDetails?.minimumBid, simoleans(3)));
+      assert(
+        keyEQ(invitationValue[0].customDetails?.auctionedAssets, moola(1)),
+      );
 
       const proposal = harden({
         want: { Asset: moola(1) },
@@ -83,23 +85,30 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         issuerKeywordRecord,
       ) || Fail`issuerKeywordRecord were not as expected`;
 
+      const { customDetails: invitationCustomDetails } = invitationValue[0];
+      assert(typeof invitationCustomDetails === 'object');
+      const optionValue = optionAmounts.value;
+      const { customDetails: optionCustomDetails } = optionValue[0];
+      assert(typeof optionCustomDetails === 'object');
+
       // Dave expects that Bob has already made an offer in the swap
       // with the following rules:
-      keyEQ(invitationValue[0].asset, optionAmounts) ||
+      keyEQ(invitationCustomDetails.asset, optionAmounts) ||
         Fail`asset is the option`;
-      keyEQ(invitationValue[0].price, bucks(1n)) || Fail`price is 1 buck`;
-      const optionValue = optionAmounts.value;
+      keyEQ(invitationCustomDetails.price, bucks(1n)) || Fail`price is 1 buck`;
+
       optionValue[0].description === 'exerciseOption' || Fail`wrong invitation`;
       AmountMath.isEqual(
-        optionValue[0].underlyingAssets.UnderlyingAsset,
-        moola(3),
+        optionCustomDetails.underlyingAssets.UnderlyingAsset,
+        moola(3n),
       ) || Fail`wrong underlying asset`;
       AmountMath.isEqual(
-        optionValue[0].strikePrice.StrikePrice,
-        simoleans(7),
+        optionCustomDetails.strikePrice.StrikePrice,
+        simoleans(7n),
       ) || Fail`wrong strike price`;
-      optionValue[0].expirationDate === 100n || Fail`wrong expiration date`;
-      optionValue[0].timeAuthority === timer || Fail`wrong timer`;
+      optionCustomDetails.expirationDate === 100n ||
+        Fail`wrong expiration date`;
+      optionCustomDetails.timeAuthority === timer || Fail`wrong timer`;
 
       // Dave escrows his 1 buck with Zoe and forms his proposal
       const daveSwapProposal = harden({

--- a/packages/zoe/NEWS.md
+++ b/packages/zoe/NEWS.md
@@ -7,7 +7,7 @@ Zoe Service changes:
 * Instead of `zoe.makeInstance` returning an invite only, it now
   returns a record of `{ invite, instanceRecord }` such that
   information like the `instanceHandle` can be obtained directly from
-  the instanceRecord. 
+  the instanceRecord.
 * `installationHandle`, the identifier for the code that is used to
   create a new running contract instance, is added to the extent of
   invites for contracts so that interested parties can easily check
@@ -61,11 +61,11 @@ Built-in Zoe contract changes:
   items at a set price for money, and a generic `mintAndSellNFT`
   contract that mints NFT tokens and then immediately creates a new
   `sellItems` instance to sell them. The original operaTicket tests
-  are able to use these contracts. 
+  are able to use these contracts.
 * The `getCurrentPrice` helper in `bondingCurves.js` has been renamed
   to `getInputPrice` and now only returns the `outputExtent`.
 * A new built-in contract was added: barter-exchange.js. Barter
-  Exchange takes offers for trading arbitrary goods for one another. 
+  Exchange takes offers for trading arbitrary goods for one another.
 * Autoswap now has different keywords for different actions that can
   be taken. For example, a swap should have the keywords 'In' and
   'Out'.
@@ -83,24 +83,24 @@ Some helpers were removed, and others were added. The built-in Zoe contracts wer
   take advantage of these new helpers.
 * `satisfies` was added. It checks whether an allocation would satisfy
   a single offer's wants if that was the allocation passed to
-  `reallocate`. 
+  `reallocate`.
 * `isOfferSafe` was added. It checks whether an
   allocation for a particular offer would satisfy offer safety. Any
   allocation that returns true under `satisfy` will also return true
   under `isOfferSafe`. (`isOfferSafe` is equivalent of `satisfies` ||
-  gives a refund). 
+  gives a refund).
 * `trade` was added. `Trade` performs a trade between
   two offers given a declarative description of what each side loses
-  and gains. 
+  and gains.
 * `Swap` remains but has slightly different behavior: any
   surplus in a trade remains with the original offer
 * `canTradeWith`
   was removed and subsumed by `satisfies`.
 * `inviteAnOffer` was already
-  deprecated and was removed. 
+  deprecated and was removed.
 * `assertNatMathHelpers` was added, which
   checks whether a particular keyword is associated with an issuer
-  with natMathHelpers. 
+  with natMathHelpers.
 
 ERTP changes:
 * `purse.deposit()` now returns the amount of the deposit, rather than
@@ -116,13 +116,13 @@ ERTP changes:
   be removed in a few weeks.
 * `zcf.makeInvitation` now takes an offerHook, a required string
   `inviteDesc`, and an object of options, including the ability to add
-  `customProperties` to the extent of the invite. `inviteDesc` is
+  `customDetails` to the extent of the invite. `inviteDesc` is
   required such that different kinds of invites from the same contract
   are distinguishable.
 * The zoeHelper `inviteAnOffer` is deprecated
 * Instead of `inviteAnOffer`, we recommend using `checkHook` which
   more cleanly wraps an offerHook in a check of whether the offer
-  matches the expected proposal format. 
+  matches the expected proposal format.
 * We changed the `getOffer` and `getOffers` methods on the Zoe Service
   API to match the Zoe Contract Facet API. Now, in order to get the
   current allocation, you should call the new methods
@@ -130,7 +130,7 @@ ERTP changes:
 
 ## Release v0.4.0 (2-Apr-2020)
 
-* The `proposal` and `paymentKeywordRecord` arguments to `zoe.redeem` now default to an empty record. Previously, a user had to pass in an empty record for these arguments, which would be interpreted as a presence in @endo/marshal. 
+* The `proposal` and `paymentKeywordRecord` arguments to `zoe.redeem` now default to an empty record. Previously, a user had to pass in an empty record for these arguments, which would be interpreted as a presence in @endo/marshal.
 
 ## Release 0.3.0 (25-Mar-2020)
 
@@ -154,7 +154,7 @@ been renamed to "proposal". The structure of a proposal has changed to:
 There are no longer any keys such as 'payoutRules' or 'exitRule'. Most
 importantly, we no longer rely on the specific order of payoutRules
 arrays and payment/payout arrays to be the same. In fact, we can even
-make a partial proposal that will be filled in. 
+make a partial proposal that will be filled in.
 
 `Asset` and `Price` in the above example are called "keywords". Each
 contract has its own specific keywords. For instance, an auction
@@ -194,7 +194,7 @@ Changes to the Zoe Service (User-facing) API:
   `getOffers`, and `isOfferActive`. Note that `getOffer` and
   `getOffers` will throw if the offer is not found, whereas
   `isOfferActive` is safe to check whether an offer is still active or
-  not. 
+  not.
 
 Changes to the Contract Facet API and contract helpers:
 * The `userFlow` helpers have been renamed to `zoeHelpers`
@@ -218,7 +218,7 @@ Changes to the Contract Facet API and contract helpers:
   are the same.
 * In the offerRecord, amounts are no longer an array. Instead they are
   an `amountKeywordRecord`, an object with `keywords` as keys and `amount`
-  values. 
+  values.
 * Reallocate now takes an array of offerHandles/inviteHandles and an
   array of the above `amountKeywordRecord`s keyed on keywords.
 * AddNewIssuer now requires a keyword to be provided alongside the issuer.
@@ -226,7 +226,7 @@ Changes to the Contract Facet API and contract helpers:
 ## Release 0.2.1 (3-Feb-2020)
 
 Updates ERTP dependency to v0.3.0 and adds dependencies on new
-packages taken from ERTP. 
+packages taken from ERTP.
 
 ## Release 0.2.0 (21-Jan-2020)
 

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -96,7 +96,7 @@
  * @typedef {<Result>(
  *   offerHandler: OfferHandler<Result>,
  *   description: string,
- *   customProperties?: object,
+ *   customDetails?: object,
  *   proposalShape?: Pattern,
  * ) => Promise<Invitation<Awaited<Result>>>
  * } MakeInvitation
@@ -107,7 +107,7 @@
  * of the invitation. The contract must provide a `description` for
  * the invitation and should include whatever information is necessary
  * for a potential buyer of the invitation to know what they are
- * getting in the `customProperties`. `customProperties` will be
+ * getting in the `customDetails`. `customDetails` will be
  * placed in the details of the invitation.
  */
 

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -255,7 +255,7 @@ export const makeZCFZygote = async (
     makeInvitation: (
       offerHandler,
       description,
-      customProperties = harden({}),
+      customDetails = harden({}),
       proposalShape = undefined,
     ) => {
       typeof description === 'string' ||
@@ -271,7 +271,7 @@ export const makeZCFZygote = async (
       const invitationP = E(zoeInstanceAdmin).makeInvitation(
         invitationHandle,
         description,
-        customProperties,
+        customDetails,
         proposalShape,
       );
       return invitationP;

--- a/packages/zoe/src/contracts/auction/index.js
+++ b/packages/zoe/src/contracts/auction/index.js
@@ -132,8 +132,8 @@ const start = zcf => {
       return defaultAcceptanceMsg;
     };
 
-    const customProperties = getSessionDetails();
-    return zcf.makeInvitation(performBid, 'bid', customProperties);
+    const customDetails = getSessionDetails();
+    return zcf.makeInvitation(performBid, 'bid', customDetails);
   };
 
   const sell = seat => {

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -28,7 +28,7 @@ import { Position } from './position.js';
  * for the price oracle's quotes as to the value of the Underlying, as well as
  * the strike prices in the terms.
  *
- * The creatorInvitation has customProperties that include the amounts of the
+ * The creatorInvitation has customDetails that include the amounts of the
  * two options as longAmount and shortAmount. When the creatorInvitation is
  * exercised, the payout includes the two option positions, which are themselves
  * invitations which can be exercised for free, and provide the option payouts

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -73,13 +73,13 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
     }
 
     const exerciseOption = makeExerciser(sellSeat);
-    const customProps = harden({
+    const customDetails = harden({
       expirationDate: sellSeatExitRule.afterDeadline.deadline,
       timeAuthority: sellSeatExitRule.afterDeadline.timer,
       underlyingAssets: sellSeat.getProposal().give,
       strikePrice: sellSeat.getProposal().want,
     });
-    return zcf.makeInvitation(exerciseOption, 'exerciseOption', customProps);
+    return zcf.makeInvitation(exerciseOption, 'exerciseOption', customDetails);
   };
 
   const CoveredCallCratorFacetI = M.interface('CoveredCallCratorFacet', {

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -96,13 +96,13 @@ const start = zcf => {
       return `The option was exercised. Please collect the assets in your payout.`;
     };
 
-    const customProps = harden({
+    const customDetails = harden({
       expirationDate: sellSeatExitRule.afterDeadline.deadline,
       timeAuthority: sellSeatExitRule.afterDeadline.timer,
       underlyingAssets: sellSeat.getProposal().give,
       strikePrice: sellSeat.getProposal().want,
     });
-    return zcf.makeInvitation(exerciseOption, 'exerciseOption', customProps);
+    return zcf.makeInvitation(exerciseOption, 'exerciseOption', customDetails);
   };
 
   const creatorInvitation = zcf.makeInvitation(makeOption, 'makeCallOption');

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -60,7 +60,7 @@ export const makeCloseLoanInvitation = (zcf, config) => {
     return closeMsg;
   };
 
-  // Note: we can't put the debt to be repaid in the customProperties
+  // Note: we can't put the debt to be repaid in the customDetails
   // because it will change
   return zcf.makeInvitation(repayAndClose, 'repayAndClose');
 };

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -111,7 +111,7 @@
  * @callback ZoeInstanceAdminMakeInvitation
  * @param {InvitationHandle} invitationHandle
  * @param {string} description
- * @param {Record<string, any>} [customProperties]
+ * @param {Record<string, any>} [customDetails]
  * @param {Pattern} [proposalShape]
  * @returns {Invitation}
  */

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -54,12 +54,12 @@ export const makeStartInstance = (
       adminNode,
     }),
     {
-      makeInvitation(handle, desc, customProps, proposalShape) {
+      makeInvitation(handle, desc, customDetails, proposalShape) {
         const { state } = this;
         return state.instanceStorage.makeInvitation(
           handle,
           desc,
-          customProps,
+          customDetails,
           proposalShape,
         );
       },

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -300,15 +300,12 @@
  */
 
 /**
- * @typedef {object} StandardInvitationDetails
+ * @typedef {object} InvitationDetails
  * @property {Installation} installation
  * @property {import('./utils').Instance<any>} instance
  * @property {InvitationHandle} handle
  * @property {string} description
- */
-
-/**
- * @typedef {StandardInvitationDetails & Record<string, any>} InvitationDetails
+ * @property {Record<string, any>} [customDetails]
  */
 
 /**

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -73,13 +73,13 @@ const prepare = async (zcf, _privateArgs, instanceBaggage) => {
       );
     }
     const exerciseOption = makeExerciser(sellSeat);
-    const customProps = harden({
+    const customDetails = harden({
       expirationDate: sellSeatExitRule.afterDeadline.deadline,
       timeAuthority: sellSeatExitRule.afterDeadline.timer,
       underlyingAssets: sellSeat.getProposal().give,
       strikePrice: sellSeat.getProposal().want,
     });
-    return zcf.makeInvitation(exerciseOption, 'exerciseOption', customProps);
+    return zcf.makeInvitation(exerciseOption, 'exerciseOption', customDetails);
   };
 
   const CCallCreatorI = M.interface('CCallCreator', {

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -75,23 +75,26 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const { value: optionValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
+      const { customDetails } = optionValue[0];
+      assert(typeof customDetails === 'object');
+
       assert(installation === installations.coveredCall, X`wrong installation`);
       optionValue[0].description === 'exerciseOption' ||
         assert.fail(X`wrong invitation`);
       assert(
         AmountMath.isEqual(
-          optionValue[0].underlyingAssets.UnderlyingAsset,
+          customDetails.underlyingAssets.UnderlyingAsset,
           moola(3n),
         ),
       );
       assert(
         AmountMath.isEqual(
-          optionValue[0].strikePrice.StrikePrice,
+          customDetails.strikePrice.StrikePrice,
           simoleans(7n),
         ),
       );
-      assert(optionValue[0].expirationDate === 1n, X`wrong expirationDate`);
-      assert(optionValue[0].timeAuthority === timer, 'wrong timer');
+      assert(customDetails.expirationDate === 1n, X`wrong expirationDate`);
+      assert(customDetails.timeAuthority === timer, 'wrong timer');
       const { UnderlyingAsset, StrikePrice } = issuerKeywordRecord;
       UnderlyingAsset === moolaIssuer ||
         assert.fail(X`The underlying asset issuer should be the moola issuer`);
@@ -133,26 +136,28 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
       const optionValue = optionAmounts.value;
+      const { customDetails } = optionValue[0];
+      assert(typeof customDetails === 'object');
 
       assert(installation === installations.coveredCall, X`wrong installation`);
       optionValue[0].description === 'exerciseOption' ||
         assert.fail(X`wrong invitation`);
       assert(
         AmountMath.isEqual(
-          optionValue[0].underlyingAssets.UnderlyingAsset,
+          customDetails.underlyingAssets.UnderlyingAsset,
           moola(3n),
         ),
         X`wrong underlying asset`,
       );
       assert(
         AmountMath.isEqual(
-          optionValue[0].strikePrice.StrikePrice,
+          customDetails.strikePrice.StrikePrice,
           simoleans(7n),
         ),
         X`wrong strike price`,
       );
-      assert(optionValue[0].expirationDate === 100n, X`wrong expiration date`);
-      assert(optionValue[0].timeAuthority === timer, X`wrong timer`);
+      assert(customDetails.expirationDate === 100n, X`wrong expiration date`);
+      assert(customDetails.timeAuthority === timer, X`wrong timer`);
       UnderlyingAsset === moolaIssuer ||
         assert.fail(X`The underlyingAsset issuer should be the moola issuer`);
       StrikePrice === simoleanIssuer ||
@@ -215,8 +220,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         ),
         X`issuerKeywordRecord was not as expected`,
       );
-      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3n)));
-      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1n)));
+      assert(
+        keyEQ(invitationValue[0].customDetails?.minimumBid, simoleans(3n)),
+      );
+      assert(
+        keyEQ(invitationValue[0].customDetails?.auctionedAssets, moola(1n)),
+      );
 
       const proposal = harden({
         want: { Asset: moola(1n) },
@@ -258,9 +267,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         ),
         X`issuers were not as expected`,
       );
-      keyEQ(invitationValue[0].asset, moola(3n)) ||
+      keyEQ(invitationValue[0].customDetails?.asset, moola(3n)) ||
         assert.fail(X`Alice made a different offer than expected`);
-      keyEQ(invitationValue[0].price, simoleans(7n)) ||
+      keyEQ(invitationValue[0].customDetails?.price, simoleans(7n)) ||
         assert.fail(X`Alice made a different offer than expected`);
 
       const proposal = harden({

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -31,8 +31,12 @@ const build = async (log, zoe, issuers, payments, installations) => {
         ),
         X`issuerKeywordRecord were not as expected`,
       );
-      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3n)));
-      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1n)));
+      assert(
+        keyEQ(invitationValue[0].customDetails?.minimumBid, simoleans(3n)),
+      );
+      assert(
+        keyEQ(invitationValue[0].customDetails?.auctionedAssets, moola(1n)),
+      );
 
       const proposal = harden({
         want: { Asset: moola(1n) },

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -60,7 +60,7 @@ export const checkDescription = async (t, zoe, invitation, expected) => {
 export const checkDetails = async (t, zoe, invitation, expectedNullHandle) => {
   const details = await E(zoe).getInvitationDetails(invitation);
   const detailsNullHandle = { ...details, handle: null };
-  t.deepEqual(detailsNullHandle, expectedNullHandle);
+  t.like(detailsNullHandle, expectedNullHandle);
 };
 
 /**

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -129,7 +129,7 @@ const setupBorrowFacet = async (
   };
 };
 
-test('borrow assert customProps', async t => {
+test('borrow assert customDetails', async t => {
   const { borrowInvitation, zoe, installation, instance, maxLoan } =
     await setupBorrow();
 
@@ -138,7 +138,9 @@ test('borrow assert customProps', async t => {
     handle: null,
     installation,
     instance,
-    maxLoan,
+    customDetails: {
+      maxLoan,
+    },
   });
 });
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -103,7 +103,9 @@ test('loan - lend - exit before borrow', async t => {
     handle: null,
     installation,
     instance,
-    maxLoan,
+    customDetails: {
+      maxLoan,
+    },
   });
 
   await E(lenderSeat).tryExit();

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -100,12 +100,12 @@ test('zoe - atomicSwap', async t => {
           'installation is atomicSwap',
         );
         t.deepEqual(
-          invitationValue.asset,
+          invitationValue.customDetails?.asset,
           moola(3n),
           `asset to be traded is 3 moola`,
         );
         t.deepEqual(
-          invitationValue.price,
+          invitationValue.customDetails?.price,
           simoleans(7n),
           `price is 7 simoleans, so bob must give that`,
         );
@@ -265,12 +265,12 @@ test('zoe - non-fungible atomicSwap', async t => {
           'installation is atomicSwap',
         );
         t.deepEqual(
-          invitationValue.asset,
+          invitationValue.customDetails?.asset,
           calico37Amount,
           `asset to be traded is a particular crypto cat`,
         );
         t.deepEqual(
-          invitationValue.price,
+          invitationValue.customDetails?.price,
           vorpalAmount,
           `price is vorpalAmount, so bob must give that`,
         );
@@ -400,8 +400,8 @@ test('zoe - atomicSwap like-for-like', async t => {
 
   t.is(bobInvitationValue.installation, installation, 'bobInstallationId');
   t.deepEqual(bobIssuers, { Asset: moolaIssuer, Price: moolaIssuer });
-  t.deepEqual(bobInvitationValue.asset, moola(3n));
-  t.deepEqual(bobInvitationValue.price, moola(7n));
+  t.deepEqual(bobInvitationValue.customDetails?.asset, moola(3n));
+  t.deepEqual(bobInvitationValue.customDetails?.price, moola(7n));
 
   const bobProposal = harden({
     give: { Price: moola(7n) },

--- a/packages/zoe/test/unitTests/contracts/test-auction.js
+++ b/packages/zoe/test/unitTests/contracts/test-auction.js
@@ -107,18 +107,18 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
           'installation is secondPriceAuction',
         );
         t.deepEqual(
-          invitationValue.auctionedAssets,
+          invitationValue.customDetails?.auctionedAssets,
           moola(1n),
           `asset to be auctioned is 1 moola`,
         );
         t.deepEqual(
-          invitationValue.minimumBid,
+          invitationValue.customDetails?.minimumBid,
           simoleans(3n),
           `minimum bid is 3 simoleans`,
         );
 
         t.deepEqual(
-          invitationValue.bidDuration,
+          invitationValue.customDetails?.bidDuration,
           1n,
           `auction will be closed after 1 tick according to the timeAuthority`,
         );
@@ -607,9 +607,13 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   t.is(bobInvitationValue.installation, installation, 'bobInstallationId');
   t.deepEqual(bobIssuers, { Asset: ccIssuer, Ask: moolaIssuer }, 'bobIssuers');
-  t.deepEqual(bobInvitationValue.minimumBid, moola(3n), 'minimumBid');
   t.deepEqual(
-    bobInvitationValue.auctionedAssets,
+    bobInvitationValue.customDetails?.minimumBid,
+    moola(3n),
+    'minimumBid',
+  );
+  t.deepEqual(
+    bobInvitationValue.customDetails?.auctionedAssets,
     cryptoCats(harden(['Felix'])),
     'assets',
   );
@@ -651,9 +655,13 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     { Asset: ccIssuer, Ask: moolaIssuer },
     'carolIssuers',
   );
-  t.deepEqual(carolInvitationValue.minimumBid, moola(3n), 'carolMinimumBid');
   t.deepEqual(
-    carolInvitationValue.auctionedAssets,
+    carolInvitationValue.customDetails?.minimumBid,
+    moola(3n),
+    'carolMinimumBid',
+  );
+  t.deepEqual(
+    carolInvitationValue.customDetails?.auctionedAssets,
     cryptoCats(harden(['Felix'])),
     'carolAuctionedAssets',
   );
@@ -694,9 +702,13 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     { Asset: ccIssuer, Ask: moolaIssuer },
     'daveIssuers',
   );
-  t.deepEqual(daveInvitationValue.minimumBid, moola(3n), 'daveMinimumBid');
   t.deepEqual(
-    daveInvitationValue.auctionedAssets,
+    daveInvitationValue.customDetails?.minimumBid,
+    moola(3n),
+    'daveMinimumBid',
+  );
+  t.deepEqual(
+    daveInvitationValue.customDetails?.auctionedAssets,
     cryptoCats(harden(['Felix'])),
     'daveAssets',
   );
@@ -912,18 +924,18 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
           'installation is secondPriceAuction',
         );
         t.deepEqual(
-          invitationValue.auctionedAssets,
+          invitationValue.customDetails?.auctionedAssets,
           moola(1n),
           `asset to be auctioned is 1 moola`,
         );
         t.deepEqual(
-          invitationValue.minimumBid,
+          invitationValue.customDetails?.minimumBid,
           simoleans(3n),
           `minimum bid is 3 simoleans`,
         );
 
         t.deepEqual(
-          invitationValue.bidDuration,
+          invitationValue.customDetails?.bidDuration,
           1n,
           `auction will be closed after 1 tick according to the timeAuthority`,
         );

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -96,9 +96,12 @@ test('fundedCallSpread below Strike1', async t => {
     terms,
   );
 
-  const invitationDetail = await E(zoe).getInvitationDetails(creatorInvitation);
-  const longOptionAmount = invitationDetail.longAmount;
-  const shortOptionAmount = invitationDetail.shortAmount;
+  const { customDetails } = await E(zoe).getInvitationDetails(
+    creatorInvitation,
+  );
+  assert(typeof customDetails === 'object');
+  const longOptionAmount = customDetails.longAmount;
+  const shortOptionAmount = customDetails.shortAmount;
 
   const aliceProposal = harden({
     want: { LongOption: longOptionAmount, ShortOption: shortOptionAmount },
@@ -197,9 +200,12 @@ test('fundedCallSpread above Strike2', async t => {
     terms,
   );
 
-  const invitationDetail = await E(zoe).getInvitationDetails(creatorInvitation);
-  const longOptionAmount = invitationDetail.longAmount;
-  const shortOptionAmount = invitationDetail.shortAmount;
+  const { customDetails } = await E(zoe).getInvitationDetails(
+    creatorInvitation,
+  );
+  assert(typeof customDetails === 'object');
+  const longOptionAmount = customDetails.longAmount;
+  const shortOptionAmount = customDetails.shortAmount;
 
   const aliceProposal = harden({
     want: { LongOption: longOptionAmount, ShortOption: shortOptionAmount },
@@ -297,9 +303,12 @@ test('fundedCallSpread, mid-strike', async t => {
     terms,
   );
 
-  const invitationDetail = await E(zoe).getInvitationDetails(creatorInvitation);
-  const longOptionAmount = invitationDetail.longAmount;
-  const shortOptionAmount = invitationDetail.shortAmount;
+  const { customDetails } = await E(zoe).getInvitationDetails(
+    creatorInvitation,
+  );
+  assert(typeof customDetails === 'object');
+  const longOptionAmount = customDetails.longAmount;
+  const shortOptionAmount = customDetails.shortAmount;
 
   const aliceProposal = harden({
     want: { LongOption: longOptionAmount, ShortOption: shortOptionAmount },
@@ -397,13 +406,14 @@ test('fundedCallSpread, late exercise', async t => {
     terms,
   );
 
-  const invitationDetails = await E(zoe).getInvitationDetails(
+  const { customDetails } = await E(zoe).getInvitationDetails(
     creatorInvitation,
   );
+  assert(typeof customDetails === 'object');
   const aliceProposal = harden({
     want: {
-      LongOption: invitationDetails.longAmount,
-      ShortOption: invitationDetails.shortAmount,
+      LongOption: customDetails.longAmount,
+      ShortOption: customDetails.shortAmount,
     },
     give: { Collateral: bucks(300n) },
   });
@@ -501,9 +511,12 @@ test('fundedCallSpread, sell options', async t => {
     terms,
   );
 
-  const invitationDetail = await E(zoe).getInvitationDetails(creatorInvitation);
-  const longOptionAmount = invitationDetail.longAmount;
-  const shortOptionAmount = invitationDetail.shortAmount;
+  const { customDetails } = await E(zoe).getInvitationDetails(
+    creatorInvitation,
+  );
+  assert(typeof customDetails === 'object');
+  const longOptionAmount = customDetails.longAmount;
+  const shortOptionAmount = customDetails.shortAmount;
 
   const aliceProposal = harden({
     want: { LongOption: longOptionAmount, ShortOption: shortOptionAmount },
@@ -691,13 +704,13 @@ test('pricedCallSpread, mid-strike', async t => {
   const shortAmount = await E(invitationIssuer).getAmountOf(shortInvitation);
 
   const longOptionValue = longAmount.value[0];
-  t.is('long', longOptionValue.position);
-  const longOption = longOptionValue.option;
+  t.is('long', longOptionValue.customDetails?.position);
+  const longOption = longOptionValue.customDetails?.option;
 
   // Bob makes an offer for the long option
   const bobProposal = harden({
     want: { Option: longOption },
-    give: { Collateral: bucks(longOptionValue.collateral) },
+    give: { Collateral: bucks(longOptionValue.customDetails?.collateral) },
   });
   const bobFundingSeat = await E(zoe).offer(await longInvitation, bobProposal, {
     Collateral: bobBucksPayment,
@@ -715,13 +728,13 @@ test('pricedCallSpread, mid-strike', async t => {
   );
 
   const shortOptionValue = shortAmount.value[0];
-  t.is('short', shortOptionValue.position);
-  const shortOption = shortOptionValue.option;
+  t.is('short', shortOptionValue.customDetails?.position);
+  const shortOption = shortOptionValue.customDetails?.option;
 
   // carol makes an offer for the short option
   const carolProposal = harden({
     want: { Option: shortOption },
-    give: { Collateral: bucks(shortOptionValue.collateral) },
+    give: { Collateral: bucks(shortOptionValue.customDetails?.collateral) },
   });
   const carolFundingSeat = await E(zoe).offer(
     await shortInvitation,

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
@@ -117,12 +117,15 @@ test('zoe - coveredCall with swap for invitation', async t => {
   const bobExclOption = await E(invitationIssuer).claim(optionP);
   const optionAmount = await E(invitationIssuer).getAmountOf(bobExclOption);
   const optionDesc = optionAmount.value[0];
+  const { customDetails } = optionDesc;
+  assert(typeof customDetails === 'object');
+
   t.is(optionDesc.installation, coveredCallInstallation);
   t.is(optionDesc.description, 'exerciseOption');
-  t.deepEqual(optionDesc.underlyingAssets, { UnderlyingAsset: moola(3n) });
-  t.deepEqual(optionDesc.strikePrice, { StrikePrice: simoleans(7n) });
-  t.is(optionDesc.expirationDate, 100n);
-  t.deepEqual(optionDesc.timeAuthority, timer);
+  t.deepEqual(customDetails.underlyingAssets, { UnderlyingAsset: moola(3n) });
+  t.deepEqual(customDetails.strikePrice, { StrikePrice: simoleans(7n) });
+  t.is(customDetails.expirationDate, 100n);
+  t.deepEqual(customDetails.timeAuthority, timer);
 
   // Let's imagine that Bob wants to create a swap to trade this
   // invitation for bucks.
@@ -184,16 +187,18 @@ test('zoe - coveredCall with swap for invitation', async t => {
   const optionAmountPattern1 = harden({
     brand: M.any(),
     value: [
-      {
+      M.splitRecord({
         handle: M.any(),
         instance: M.any(),
         installation: coveredCallInstallation,
         description: 'exerciseOption',
-        underlyingAssets: { UnderlyingAsset: M.gte(moola(2n)) },
-        strikePrice: { StrikePrice: M.lte(simoleans(8n)) },
-        timeAuthority: timer,
-        expirationDate: M.and(M.gte(50n), M.lte(300n)),
-      },
+        customDetails: {
+          underlyingAssets: { UnderlyingAsset: M.gte(moola(2n)) },
+          strikePrice: { StrikePrice: M.lte(simoleans(8n)) },
+          timeAuthority: timer,
+          expirationDate: M.and(M.gte(50n), M.lte(300n)),
+        },
+      }),
     ],
   });
 
@@ -202,13 +207,15 @@ test('zoe - coveredCall with swap for invitation', async t => {
   const optionAmountPattern2 = harden({
     brand: BrandShape,
     value: [
-      M.split({
+      M.splitRecord({
         installation: coveredCallInstallation,
         description: 'exerciseOption',
-        underlyingAssets: { UnderlyingAsset: M.gte(moola(2n)) },
-        strikePrice: { StrikePrice: M.lte(simoleans(8n)) },
-        timeAuthority: timer,
-        expirationDate: M.and(M.gte(50n), M.lte(300n)),
+        customDetails: {
+          underlyingAssets: { UnderlyingAsset: M.gte(moola(2n)) },
+          strikePrice: { StrikePrice: M.lte(simoleans(8n)) },
+          timeAuthority: timer,
+          expirationDate: M.and(M.gte(50n), M.lte(300n)),
+        },
       }),
     ],
   });

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -126,19 +126,23 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
   t.truthy(await E(invitationIssuer).isLive(invitation4));
 
   t.deepEqual(
-    (await E(invitationIssuer).getAmountOf(invitation1)).value[0].query,
+    (await E(invitationIssuer).getAmountOf(invitation1)).value[0].customDetails
+      .query,
     query1,
   );
   t.deepEqual(
-    (await E(invitationIssuer).getAmountOf(invitation2)).value[0].query,
+    (await E(invitationIssuer).getAmountOf(invitation2)).value[0].customDetails
+      .query,
     query2,
   );
   t.deepEqual(
-    (await E(invitationIssuer).getAmountOf(invitation3)).value[0].query,
+    (await E(invitationIssuer).getAmountOf(invitation3)).value[0].customDetails
+      .query,
     query3,
   );
   t.deepEqual(
-    (await E(invitationIssuer).getAmountOf(invitation4)).value[0].query,
+    (await E(invitationIssuer).getAmountOf(invitation4)).value[0].customDetails
+      .query,
     query4,
   );
 

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -126,18 +126,21 @@ const makeBob = (
       const invitationIssuer = await E(zoe).getInvitationIssuer();
       const invitation = await E(invitationIssuer).claim(untrustedInvitation);
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
+      const { customDetails } = invitationValue;
+      assert(typeof customDetails === 'object');
+
       t.is(
         invitationValue.installation,
         coveredCallInstallation,
         'installation is coveredCall',
       );
       t.deepEqual(
-        invitationValue.underlyingAssets,
+        customDetails.underlyingAssets,
         { Moola: moola(3n) },
         `bob will get 3 moola`,
       );
       t.deepEqual(
-        invitationValue.strikePrice,
+        customDetails.strikePrice,
         { Simolean: simoleans(4n) },
         `bob must give 4 simoleans`,
       );
@@ -177,18 +180,21 @@ const makeBob = (
       const invitationIssuer = await E(zoe).getInvitationIssuer();
       const invitation = await E(invitationIssuer).claim(untrustedInvitation);
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
+      const { customDetails } = invitationValue;
+      assert(typeof customDetails === 'object');
+
       t.is(
         invitationValue.installation,
         coveredCallInstallation,
         'installation is coveredCall',
       );
       t.deepEqual(
-        invitationValue.underlyingAssets,
+        customDetails.underlyingAssets,
         { Moola: moola(3n) },
         `bob will get 3 moola`,
       );
       t.deepEqual(
-        invitationValue.strikePrice,
+        customDetails.strikePrice,
         { Simolean: simoleans(4n) },
         `bob must give 4 simoleans`,
       );
@@ -231,18 +237,21 @@ const makeBob = (
       const invitationIssuer = await E(zoe).getInvitationIssuer();
       const invitation = await E(invitationIssuer).claim(untrustedInvitation);
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
+      const { customDetails } = invitationValue;
+      assert(typeof customDetails === 'object');
+
       t.is(
         invitationValue.installation,
         coveredCallInstallation,
         'installation is coveredCall',
       );
       t.deepEqual(
-        invitationValue.underlyingAssets,
+        customDetails.underlyingAssets,
         { Simolean: simoleans(15n) },
         `bob will get 15 simoleans`,
       );
       t.deepEqual(
-        invitationValue.strikePrice,
+        customDetails.strikePrice,
         { Buck: bucks(500n), Moola: moola(35n) },
         `bob must give 500 bucks and 35 moola`,
       );
@@ -293,18 +302,21 @@ const makeBob = (
       const invitationIssuer = await E(zoe).getInvitationIssuer();
       const invitation = await E(invitationIssuer).claim(untrustedInvitation);
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
+      const { customDetails } = invitationValue;
+      assert(typeof customDetails === 'object');
+
       t.is(
         invitationValue.installation,
         coveredCallInstallation,
         'installation is coveredCall',
       );
       t.deepEqual(
-        invitationValue.underlyingAssets,
+        customDetails.underlyingAssets,
         { Simolean: simoleans(15n) },
         `bob will get 15 simoleans`,
       );
       t.deepEqual(
-        invitationValue.strikePrice,
+        customDetails.strikePrice,
         { Buck: bucks(500n), Moola: moola(35n) },
         `bob must give 500 bucks and 35 moola`,
       );

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -301,7 +301,7 @@ test(`zcf.makeInvitation - non-string description`, async t => {
   });
 });
 
-test(`zcf.makeInvitation - no customProperties`, async t => {
+test(`zcf.makeInvitation - no customDetails`, async t => {
   const { zcf, zoe, instance, installation } = await setupZCFTest();
   const invitationP = zcf.makeInvitation(() => {}, 'myInvitation');
   const details = await E(zoe).getInvitationDetails(invitationP);
@@ -313,7 +313,7 @@ test(`zcf.makeInvitation - no customProperties`, async t => {
   });
 });
 
-test(`zcf.makeInvitation - customProperties`, async t => {
+test(`zcf.makeInvitation - customDetails`, async t => {
   const { zcf, zoe, instance, installation } = await setupZCFTest();
   const timer = buildManualTimer(t.log);
   const invitationP = zcf.makeInvitation(() => {}, 'myInvitation', {
@@ -321,17 +321,19 @@ test(`zcf.makeInvitation - customProperties`, async t => {
     timer,
   });
   const details = await E(zoe).getInvitationDetails(invitationP);
-  t.deepEqual(details, {
+  t.like(details, {
     description: 'myInvitation',
     handle: details.handle,
     installation,
     instance,
-    timer,
-    whatever: 'whatever',
+    customDetails: {
+      timer,
+      whatever: 'whatever',
+    },
   });
 });
 
-test(`zcf.makeInvitation - customProperties overwritten`, async t => {
+test(`zcf.makeInvitation - customDetails stratification`, async t => {
   const { zcf, zoe, instance, installation } = await setupZCFTest();
   const invitationP = zcf.makeInvitation(() => {}, 'myInvitation', {
     description: 'whatever',
@@ -344,6 +346,11 @@ test(`zcf.makeInvitation - customProperties overwritten`, async t => {
     handle: details.handle,
     installation,
     instance,
+    customDetails: {
+      description: 'whatever',
+      installation: 'whatever',
+      instance: 'whatever',
+    },
   });
   t.falsy(typeof details.handle === 'string');
 });


### PR DESCRIPTION
The `customProperties` argument to `makeInvitation` has been renamed `customDetails`. This itself is not an API change, since, prior to this PR, the `customProperties` record, if any was spread out into the `invitationDetails`. But this spreading mixes the namespaces of names according to Zoe vs names according to the contract. It would prevent us from adding more names-according-to-Zoe to the invitation details over time.

This PR adds an explicit `customDetails` property to the `invitationDetails` record. But to avoid breaking things, it does yet remove the redundant spread form. The next PR #7067 does so, to be merged once all uses of the deprecated spread form are removed.

Would enable us to fix https://github.com/Agoric/agoric-sdk/issues/5903