### PR TITLE
fix: cosmic_swingset_inbound_queue_length is a gauge

### DIFF
--- a/packages/cosmic-swingset/src/kernel-stats.js
+++ b/packages/cosmic-swingset/src/kernel-stats.js
@@ -339,9 +339,14 @@ export function exportKernelStats({
     // These are not kernelStatsMetrics, they're outside the kernel.
     for (const name of ['length', 'add', 'remove']) {
       const key = `cosmic_swingset_inbound_queue_${name}`;
-      const counter = metricMeter.createObservableCounter(key, {
+      const options = {
         description: `inbound queue ${name}`,
-      });
+      };
+      const counter =
+        name === 'length'
+          ? metricMeter.createObservableUpDownCounter(key, options)
+          : metricMeter.createObservableCounter(key, options);
+
       counter.addCallback(observableResult => {
         observableResult.observe(
           inboundQueueMetrics.getStats()[key],


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #7084 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
makes length a gauge 