### PR TITLE
feat(cosmos): Limit swingset messages per transactions

### DIFF
--- a/golang/cosmos/ante/inbound.go
+++ b/golang/cosmos/ante/inbound.go
@@ -63,7 +63,7 @@ func (ia inboundAnte) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next
 						return ctx, err
 					}
 					if actions < allowed {
-						inboundsAllowed = allowed - actions
+						inboundsAllowed = 1
 					} else {
 						inboundsAllowed = 0
 					}


### PR DESCRIPTION
Allow a single Swingset message per transaction.