### PR TITLE
vaultFactory proposal shapes

### DIFF
--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -25,6 +25,7 @@ import {
   makeBrandedRatioPattern,
   priceFrom,
 } from './util.js';
+import { makeNatAmountShape } from '../contractSupport.js';
 
 const { Fail } = assert;
 
@@ -65,8 +66,8 @@ const trace = makeTracer('AucBook', false);
  * @param {Brand<'nat'>} collateralBrand
  */
 export const makeBidSpecShape = (currencyBrand, collateralBrand) => {
-  const currencyAmountShape = { brand: currencyBrand, value: M.nat() };
-  const collateralAmountShape = { brand: collateralBrand, value: M.nat() };
+  const currencyAmountShape = makeNatAmountShape(currencyBrand);
+  const collateralAmountShape = makeNatAmountShape(collateralBrand);
   return M.splitRecord(
     { want: collateralAmountShape },
     {

--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -27,6 +27,7 @@ import { makeAuctionBook, makeBidSpecShape } from './auctionBook.js';
 import { AuctionState } from './util.js';
 import { makeScheduler } from './scheduler.js';
 import { auctioneerParamTypes } from './params.js';
+import { makeNatAmountShape } from '../contractSupport.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -270,7 +271,7 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   const bidProposalShape = M.splitRecord(
     {
-      give: { Currency: { brand: brands.Currency, value: M.nat() } },
+      give: { Currency: makeNatAmountShape(brands.Currency) },
     },
     {
       want: M.or({ Collateral: AmountShape }, {}),

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -119,3 +119,8 @@ export const makeMetricsPublishKit = (storageNode, marshaller) => {
   };
 };
 harden(makeMetricsPublishKit);
+
+/**
+ * @param {Brand} brand must be a 'nat' brand, not checked
+ */
+export const makeNatAmountShape = brand => harden({ brand, value: M.nat() });


### PR DESCRIPTION
refs: #7041

## Description

`assertProposalShape` has deprecated and the replacement is to use a new argument to `makeInvitations`, which provides better protection for contracts against malformed offers. When an offer's proposal violates the contract's required proposalShape pattern, it is rejected in Zoe and the contract never even sees the malformed offer.

This does that for vaultFactory. While touching these it also specifies the brand in the shape guard. To do this without an `E(brand).getAmountShape()` remote call it uses a new helper `makeNatAmountShape()` that can be safely used in Inter Protocol because the amount kinds are known. I put it in inter-protocol's contractSupport so not endorse the usage elsewhere.

### Security Considerations

Improves guarding by testing earlier and including the brand.

### Scaling Considerations

The shape is now constructed on each makeInvitation instead of once at module scope. If this is a problem it could be memoized.

### Documentation Considerations

--
### Testing Considerations

CI