### PR TITLE
6878 wallet factory upgrade

### DIFF
--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -325,7 +325,7 @@ export {};
  * @typedef { { enableDisavow?: boolean } } HasEnableDisavow
  * @typedef { DynamicVatOptions & HasEnableDisavow } StaticVatOptions
  *
- * @typedef { { vatParameters?: object, upgradeMessage: string } } VatUpgradeOptions
+ * @typedef { { vatParameters?: object, upgradeMessage?: string } } VatUpgradeOptions
  * @typedef { { incarnationNumber: number } } VatUpgradeResults
  *
  * @callback ShutdownWithFailure

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -27,7 +27,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     `${dirname}/../../../smart-wallet/src/walletFactory.js`,
     'walletFactory',
   );
-  /** @type {Promise<Installation<import('@agoric/smart-wallet/src/walletFactory.js').start>>} */
+  /** @type {Promise<Installation<import('@agoric/smart-wallet/src/walletFactory.js').prepare>>} */
   const installation = E(zoe).install(bundle);
   // #endregion
 

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -22,6 +22,7 @@
     "ava": "^5.1.0"
   },
   "dependencies": {
+    "@agoric/assert": "^0.5.1",
     "@agoric/casting": "^0.3.2",
     "@agoric/ertp": "^0.15.3",
     "@agoric/internal": "^0.2.1",

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -126,7 +126,7 @@ const makeAssetRegistry = assetPublisher => {
  * }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
-export const start = async (zcf, privateArgs, baggage) => {
+export const prepare = async (zcf, privateArgs, baggage) => {
   const { agoricNames, board, assetPublisher } = zcf.getTerms();
 
   const zoe = zcf.getZoeService();

--- a/packages/smart-wallet/test/contexts.js
+++ b/packages/smart-wallet/test/contexts.js
@@ -24,7 +24,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     `${dirname}/../src/walletFactory.js`,
     'walletFactory',
   );
-  /** @type {Promise<Installation<import('../src/walletFactory.js').start>>} */
+  /** @type {Promise<Installation<import('../src/walletFactory.js').prepare>>} */
   const installation = E(zoe).install(bundle);
   // #endregion
 

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
@@ -1,0 +1,151 @@
+// @ts-check
+import { Fail } from '@agoric/assert';
+import { makeTracer } from '@agoric/internal';
+import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
+import { makeSubscriptionKit } from '@agoric/notifier';
+import { makeNameHubKit } from '@agoric/vats';
+import { makeAgoricNamesAccess } from '@agoric/vats/src/core/utils.js';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
+import { makeFakeBankKit } from '@agoric/vats/tools/bank-utils.js';
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+const trace = makeTracer('BootWFUpg', false);
+
+export const wfV1BundleName = 'walletFactoryV1';
+export const wfV2BundleName = 'walletFactoryV2';
+
+export const buildRootObject = () => {
+  const storageKit = makeFakeStorageKit('walletFactoryUpgradeTest');
+  const walletPath = 'walletFactoryUpgradeTest.agoric1whatever.current';
+  const board = makeBoard();
+  const { agoricNames } = makeAgoricNamesAccess();
+  const assetPublisher = Far('mockAssetPublisher', {
+    getAssetSubscription: () => makeSubscriptionKit().subscription,
+  });
+  const { nameAdmin: namesByAddressAdmin } = makeNameHubKit();
+
+  let vatAdmin;
+  /** @type {ZoeService} */
+  let zoe;
+  /** @type {AdminFacet} */
+  let adminFacet;
+  let creatorFacet;
+  let bank;
+  /** @type {import('../../../src/smartWallet.js').SmartWallet} */
+  let wallet;
+
+  // for startInstance
+  /** @type {Installation<import('../../../src/walletFactory.js').prepare>} */
+  let installation;
+  const terms = { agoricNames, board, assetPublisher };
+  const privateArgs = {
+    storageNode: storageKit.rootNode,
+    // omit walletBridgeManager
+  };
+
+  return Far('root', {
+    bootstrap: async (vats, devices) => {
+      vatAdmin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      ({ zoeService: zoe } = await E(vats.zoe).buildZoe(
+        vatAdmin,
+        undefined,
+        'zcf',
+      ));
+
+      ({ bank } = makeFakeBankKit([]));
+
+      const v1BundleId = await E(vatAdmin).getBundleIDByName(wfV1BundleName);
+      assert(v1BundleId, 'bundleId must not be empty');
+      installation = await E(zoe).installBundleID(v1BundleId);
+    },
+
+    buildV1: async () => {
+      trace(`BOOT buildV1 start`);
+      // build the contract vat from ZCF and the contract bundlecap
+
+      // Complete round-trip without upgrade
+      trace(`BOOT buildV1 startInstance`);
+      const facets = await E(zoe).startInstance(
+        installation,
+        {},
+        terms,
+        privateArgs,
+      );
+      ({ adminFacet, creatorFacet } = facets);
+      const [newWallet, isNew] = await E(creatorFacet).provideSmartWallet(
+        'agoric1whatever',
+        bank,
+        namesByAddressAdmin,
+      );
+      isNew || Fail`wallet in buildV1 should be new`;
+      wallet = newWallet;
+
+      const currentStoragePath = await E.get(
+        E.get(E(wallet).getPublicTopics()).current,
+      ).storagePath;
+      currentStoragePath === walletPath || Fail`bad storage path`;
+
+      return true;
+    },
+
+    nullUpgradeV1: async () => {
+      trace(`BOOT nullUpgradeV1 start`);
+
+      trace(`BOOT nullUpgradeV1 upgradeContract`);
+      const bundleId = await E(vatAdmin).getBundleIDByName(wfV1BundleName);
+      const upgradeResult = await E(adminFacet).upgradeContract(
+        bundleId,
+        privateArgs,
+      );
+      assert.equal(upgradeResult.incarnationNumber, 2);
+
+      const [wallet2, isNew] = await E(creatorFacet).provideSmartWallet(
+        'agoric1whatever',
+        bank,
+        namesByAddressAdmin,
+      );
+      !isNew || Fail`wallet in nullUpgradeV1 should not be new`;
+      wallet2 === wallet || Fail`must be same wallet obj`;
+
+      const currentStoragePath = await E.get(
+        E.get(E(wallet).getPublicTopics()).current,
+      ).storagePath;
+      currentStoragePath === walletPath || Fail`bad storage path`;
+
+      return true;
+    },
+
+    upgradeV2: async () => {
+      trace(`BOOT upgradeV2 start`);
+      const bundleId = await E(vatAdmin).getBundleIDByName(wfV2BundleName);
+
+      const upgradeResult = await E(adminFacet).upgradeContract(
+        bundleId,
+        privateArgs,
+      );
+      assert.equal(upgradeResult.incarnationNumber, 3);
+      trace(`BOOT upgradeV2 startInstance`);
+
+      const [wallet2, isNew] = await E(creatorFacet).provideSmartWallet(
+        'agoric1whatever',
+        bank,
+        namesByAddressAdmin,
+      );
+      !isNew || Fail`wallet in nullUpgradeV1 should not be new`;
+      wallet2 === wallet || Fail`must be same wallet obj`;
+
+      const currentStoragePath = await E.get(
+        E.get(E(wallet).getPublicTopics()).current,
+      ).storagePath;
+      currentStoragePath === walletPath || Fail`bad storage path`;
+
+      // verify new method is present
+      const result = await E(creatorFacet).sayHelloUpgrade();
+      result === 'hello, upgrade' || Fail`bad upgrade`;
+
+      trace('Boot finished test');
+      return true;
+    },
+  });
+};

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/test-walletFactory-service-upgrade.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/test-walletFactory-service-upgrade.js
@@ -1,0 +1,63 @@
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { assert } from '@agoric/assert';
+import { buildVatController } from '@agoric/swingset-vat';
+import {
+  wfV1BundleName,
+  wfV2BundleName,
+} from './bootstrap-walletFactory-service-upgrade.js';
+
+// so paths can be expresssed relative to this file and made absolute
+const bfile = name => new URL(name, import.meta.url).pathname;
+
+test('walletFactory service upgrade', async t => {
+  /** @type {SwingSetConfig} */
+  const config = {
+    defaultManagerType: 'local',
+    bundleCachePath: 'bundles/',
+    bootstrap: 'bootstrap',
+    vats: {
+      bootstrap: {
+        // TODO refactor to use bootstrap-relay.js
+        sourceSpec: bfile('bootstrap-walletFactory-service-upgrade.js'),
+      },
+      zoe: { sourceSpec: bfile('../../../../vats/src/vat-zoe.js') },
+    },
+    bundles: {
+      zcf: {
+        sourceSpec: bfile('../../../../zoe/src/contractFacet/vatRoot.js'),
+      },
+      [wfV1BundleName]: {
+        sourceSpec: bfile('../../../src/walletFactory.js'),
+      },
+      [wfV2BundleName]: { sourceSpec: bfile('walletFactory-V2.js') },
+    },
+  };
+
+  t.log('buildVatController');
+  const c = await buildVatController(config);
+  c.pinVatRoot('bootstrap');
+  t.log('run controller');
+  await c.run();
+
+  const run = async (name, args = []) => {
+    assert(Array.isArray(args));
+    const kpid = c.queueToVatRoot('bootstrap', name, args);
+    await c.run();
+    const status = c.kpStatus(kpid);
+    const capdata = c.kpResolution(kpid);
+    return [status, capdata];
+  };
+
+  t.log('create initial version');
+  const [v1status] = await run('buildV1', []);
+  t.is(v1status, 'fulfilled');
+
+  t.log('perform null upgrade');
+  const [null1status] = await run('nullUpgradeV1', []);
+  t.is(null1status, 'fulfilled');
+
+  t.log('now perform the V2 upgrade');
+  const [v2status] = await run('upgradeV2', []);
+  t.is(v2status, 'fulfilled');
+});

--- a/packages/smart-wallet/test/test-startWalletFactory.js
+++ b/packages/smart-wallet/test/test-startWalletFactory.js
@@ -27,7 +27,7 @@ const makeTestContext = async () => {
     `${dirname}/../src/walletFactory.js`,
     'walletFactory',
   );
-  /** @type {Promise<Installation<import('../src/walletFactory.js').start>>} */
+  /** @type {Promise<Installation<import('../src/walletFactory.js').prepare>>} */
   const installation = E(zoe).install(bundle);
   // #endregion
 

--- a/packages/swingset-liveslots/src/capdata.js
+++ b/packages/swingset-liveslots/src/capdata.js
@@ -9,7 +9,7 @@ import { Fail } from '@agoric/assert';
  * @param {any} capdata  The object to be tested
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
- * @returns {asserts capdata is import('@endo/marshal').CapData<string>}
+ * @returns {asserts capdata is import('./types.js').SwingSetCapData}
  */
 export function insistCapData(capdata) {
   typeof capdata.body === 'string' ||

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -15,7 +15,7 @@ const trace = makeTracer('StartWF');
 
 /**
  * @param {ERef<ZoeService>} zoe
- * @param {Installation<import('@agoric/smart-wallet/src/walletFactory').start>} inst
+ * @param {Installation<import('@agoric/smart-wallet/src/walletFactory').prepare>} inst
  * @typedef {Awaited<ReturnType<typeof startFactoryInstance>>} WalletFactoryStartResult
  */
 // eslint-disable-next-line no-unused-vars

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -173,7 +173,7 @@
  *     produce: Record<WellKnownName['installation'], Producer<Installation>>,
  *     consume: Record<WellKnownName['installation'], Promise<Installation<unknown>>> & {
  *       mintHolder: Promise<Installation<import('@agoric/vats/src/mintHolder.js').prepare>>,
- *       walletFactory: Promise<Installation<import('@agoric/smart-wallet/src/walletFactory.js').start>>,
+ *       walletFactory: Promise<Installation<import('@agoric/smart-wallet/src/walletFactory.js').prepare>>,
  *     },
  *   },
  *   instance:{

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -365,6 +365,7 @@ export const makeZCFZygote = async (
       zcfBaggage.init('zcfInstanceAdmin', instanceAdminFromZoe);
       instanceRecHolder = makeInstanceRecord(instanceRecordFromZoe);
       instantiateIssuerStorage(issuerStorageFromZoe);
+      zcfBaggage.init('instanceRecHolder', instanceRecHolder);
 
       const startFn = start || prepare;
       if (privateArgsShape) {
@@ -400,9 +401,9 @@ export const makeZCFZygote = async (
     },
 
     restartContract: async (privateArgs = undefined) => {
-      const instanceAdmin = zcfBaggage.get('zcfInstanceAdmin');
-      zoeInstanceAdmin = instanceAdmin;
       prepare || Fail`prepare must be defined to upgrade a contract`;
+      zoeInstanceAdmin = zcfBaggage.get('zcfInstanceAdmin');
+      instanceRecHolder = zcfBaggage.get('instanceRecHolder');
       initSeatMgrAndMintFactory();
 
       // restart an upgradeable contract

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -1,3 +1,4 @@
+import { allValues, objectMap } from '@agoric/internal';
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import {
   makeScalarBigMapStore,
@@ -100,3 +101,51 @@ export const provideChildBaggage = (baggage, category) => {
 };
 harden(provideChildBaggage);
 /** @typedef {ReturnType<typeof provideChildBaggage>} ChildBaggageManager */
+
+/**
+ * For use in contract upgrades to provide values that come from other vats.
+ * All vats must be able to finish their upgrade without contacting other vats,
+ * so whatever values an instance needs from other vats must be saved in the first
+ * incarnation and read from baggage in each subsequent.
+ *
+ * This abstracts that condition so that the contract can convert a dictionary of promises
+ * into a dictionary of values during its first prepare (start) and each additional
+ * automatically reads from the baggage.
+ *
+ * For example,
+ *
+ *     const invitationIssuerP = E(zoe).getInvitationIssuer();
+ *     const {
+ *       invitationIssuer,
+ *       invitationBrand,
+ *     } = await provideAll(baggage, {
+ *       invitationIssuer: invitationIssuerP,
+ *       invitationBrand: E(invitationIssuerP).getBrand(),
+ *     });
+ *
+ * @template {Record<string, Promise>} T dict of promises
+ * @param {MapStore<string, any>} baggage
+ * @param {T} keyedPromises
+ * @returns {Promise<{ [K in keyof T]: Awaited<T[K]> }>}
+ */
+export const provideAll = (baggage, keyedPromises) => {
+  const keys = Object.keys(keyedPromises);
+  // assume if any keys are defined they all are
+  const inBaggage = baggage.has(keys[0]);
+  if (inBaggage) {
+    const obj = objectMap(
+      keyedPromises,
+      /** @type {(value: any, key: string) => any} */
+      (_, k) => baggage.get(k),
+    );
+    return Promise.resolve(harden(obj));
+  }
+
+  return allValues(keyedPromises).then(keyedVals => {
+    for (const [k, v] of Object.entries(keyedVals)) {
+      baggage.init(k, v);
+    }
+    return keyedVals;
+  });
+};
+harden(provideAll);

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -239,6 +239,18 @@ export const BundleShape = M.and(
   M.recordOf(M.string(), M.string({ stringLengthLimit: Infinity })),
 );
 
+export const UnwrappedInstallationShape = M.splitRecord(
+  harden({
+    installation: InstallationShape,
+  }),
+  harden({
+    bundle: M.recordOf(M.string(), M.string({ stringLengthLimit: Infinity })),
+    bundleCap: BundleCapShape,
+    bundleID: M.string(),
+  }),
+  harden({}),
+);
+
 export const ZoeStorageManagerIKit = harden({
   zoeServiceDataAccess: M.interface('ZoeService dataAccess', {
     getTerms: M.call(InstanceHandleShape).returns(M.splitRecord(TermsShape)),
@@ -287,7 +299,9 @@ export const ZoeStorageManagerIKit = harden({
       M.or(InstanceHandleShape, BundleShape),
       M.or(BundleCapShape, BundleShape),
     ).returns(M.promise()),
-    unwrapInstallation: M.callWhen(M.eref(InstallationShape)).returns(M.any()),
+    unwrapInstallation: M.callWhen(M.eref(InstallationShape)).returns(
+      UnwrappedInstallationShape,
+    ),
   }),
   invitationIssuerAccess: M.interface('ZoeStorage invitationIssuer', {
     getInvitationIssuer: M.call().returns(IssuerShape),

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -1,16 +1,16 @@
 import { assert } from '@agoric/assert';
+import { initEmpty } from '@agoric/store';
 import {
   M,
   makeScalarBigMapStore,
-  provideDurableWeakMapStore,
   prepareExo,
   prepareKind,
+  provideDurableWeakMapStore,
 } from '@agoric/vat-data';
-import { initEmpty } from '@agoric/store';
 import {
   InstallationShape,
-  BundleCapShape,
   InstanceHandleShape,
+  UnwrappedInstallationShape,
 } from '../typeGuards.js';
 
 const { Fail } = assert;
@@ -73,18 +73,6 @@ export const makeInstallationStorage = (
     installationsBundle.init(installation, bundle);
     return installation;
   };
-
-  const UnwrappedInstallationShape = M.splitRecord(
-    harden({
-      installation: InstallationShape,
-    }),
-    harden({
-      bundle: M.recordOf(M.string(), M.string({ stringLengthLimit: Infinity })),
-      bundleCap: BundleCapShape,
-      bundleID: M.string(),
-    }),
-    harden({}),
-  );
 
   const InstallationStorageI = M.interface('InstallationStorage', {
     installBundle: M.call(

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -58,13 +58,14 @@
  * installation
  *
  * @param {ERef<Installation>} installationP
- * @returns {Promise<{
+ * @returns {ERef<{
  *   bundle?: SourceBundle,
  *   bundleCap?: BundleCap,
  *   bundleID?: BundleID,
  *   installation:Installation
- * }>}
+ * }>} XXX not really an ERef; the implemention is sync and the API is a promise because of callWhen
  */
+// TODO remove or automate ERef https://github.com/Agoric/agoric-sdk/issues/7110
 
 /**
  * @callback GetIssuerRecords
@@ -74,7 +75,6 @@
 /**
  * @typedef {object} ZoeInstanceStorageManager
  * @property {InstanceStateGetTerms} getTerms
- * @property {GetInstallation} getInstallationForInstance
  * @property {InstanceRecordGetIssuers} getIssuers
  * @property {InstanceRecordGetBrands} getBrands
  * @property {SaveIssuer} saveIssuer
@@ -82,7 +82,6 @@
  * @property {RegisterFeeMint} registerFeeMint
  * @property {GetInstanceRecord} getInstanceRecord
  * @property {GetIssuerRecords} getIssuerRecords
- * @property {WithdrawPayments} withdrawPayments
  * @property {InitInstanceAdmin} initInstanceAdmin
  * @property {DeleteInstanceAdmin} deleteInstanceAdmin
  * @property {ZoeInstanceAdminMakeInvitation} makeInvitation
@@ -104,7 +103,7 @@
  * @param {IssuerKeywordRecord} uncleanIssuerKeywordRecord
  * @param {Instance} instance
  * @param {BundleCap} contractBundleCap
- * @returns {ZoeInstanceStorageManager}
+ * @returns {Promise<ZoeInstanceStorageManager>}
  */
 
 /**

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -47,6 +47,13 @@ export const makeStartInstance = (
     zoeBaggage,
     'zoeInstanceAdmin',
     InstanceAdminI,
+    /**
+     *
+     * @param {*} instanceStorage
+     * @param {*} instanceAdmin
+     * @param {*} seatHandleToSeatAdmin
+     * @param {import('@agoric/swingset-vat').VatAdminFacet} adminNode
+     */
     (instanceStorage, instanceAdmin, seatHandleToSeatAdmin, adminNode) => ({
       instanceStorage,
       instanceAdmin,

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -18,7 +18,7 @@ import { AdminFacetI, InstanceAdminI } from '../typeGuards.js';
 const { Fail, quote: q } = assert;
 
 /**
- * @param {any} startInstanceAccess
+ * @param {Pick<ZoeStorageManager, 'makeZoeInstanceStorageManager' | 'unwrapInstallation'>} startInstanceAccess
  * @param {() => ERef<BundleCap>} getZcfBundleCapP
  * @param {(id: string) => BundleCap} getBundleCapByIdNow
  * @param {Baggage} [zoeBaggage]
@@ -157,6 +157,12 @@ export const makeStartInstance = (
     zoeBaggage,
     'adminFacet',
     AdminFacetI,
+    /**
+     *
+     * @param {import('@agoric/swingset-vat').VatAdminFacet} adminNode
+     * @param {*} zcfBundleCap
+     * @param {*} contractBundleCap
+     */
     (adminNode, zcfBundleCap, contractBundleCap) => ({
       adminNode,
       zcfBundleCap,

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -12,8 +12,11 @@ type ContractFacet<T extends {} = {}> = {
 export type AdminFacet = {
   // Completion, which is currently any
   getVatShutdownPromise: () => Promise<any>;
-  upgradeContract: (contractBundleId: string, newPrivateArgs: any) => void;
-  restartContract: (newPrivateArgs: any) => void;
+  upgradeContract: (
+    contractBundleId: string,
+    newPrivateArgs?: any,
+  ) => Promise<{ incarnationNumber: number }>;
+  restartContract: (newPrivateArgs?: any) => void;
 };
 
 /**

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -355,6 +355,7 @@ export const makeZoeStorageManager = (
   );
   const makeInstanceRecord = makeInstanceRecordStorage(zoeBaggage);
 
+  /** @type {MakeZoeInstanceStorageManager} */
   const makeZoeInstanceStorageManager = async (
     instanceBaggage,
     installation,
@@ -462,6 +463,7 @@ export const makeZoeStorageManager = (
       },
       startInstanceAccess: {
         makeZoeInstanceStorageManager,
+        /** @type {UnwrapInstallation} */
         unwrapInstallation(installation) {
           return installationStorage.unwrapInstallation(installation);
         },


### PR DESCRIPTION
progress on: #6878

## Description

Makes the walletFactory upgradable. Includes a fix for a zcfZygote bug run into. Another bug, #7108, it works around by holding the Zoe-derived objects in baggage.

Doesn't yet support durability of the assetRegistry. Saving that for another PR. 

### Security Considerations

--

### Scaling Considerations

Holds in baggage redundantly. But there's exactly one walletFactory so this is negligible.

### Documentation Considerations

--

### Testing Considerations

New test.

The zcfZygote fix doesn't have a regression test because I don't know that test code well enough. cc @Chris-Hibbert 
