### PR TITLE
refactor: clean up inbound queue ante handler and add unit tests

### DIFF
--- a/golang/cosmos/ante/inbound.go
+++ b/golang/cosmos/ante/inbound.go
@@ -111,11 +111,9 @@ func (ia inboundAnte) allowedInbound(ctx sdk.Context) (int32, error) {
 
 // inboundMessages returns the nunber of inbound queue messages in msg.
 func inboundMessages(msg sdk.Msg) int32 {
-	switch m := msg.(type) {
-	case *swingtypes.MsgDeliverInbound:
-		return int32(len(m.Messages))
-
-	case *swingtypes.MsgInstallBundle,
+	switch msg.(type) {
+	case *swingtypes.MsgDeliverInbound,
+		*swingtypes.MsgInstallBundle,
 		*swingtypes.MsgProvision,
 		*swingtypes.MsgWalletAction,
 		*swingtypes.MsgWalletSpendAction:

--- a/golang/cosmos/ante/inbound.go
+++ b/golang/cosmos/ante/inbound.go
@@ -10,23 +10,25 @@ import (
 	swingtypes "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
 )
 
-// This AnteDecorator enforces a limit on the size of the Swingset inbound
-// queue by scanning for Cosmos-messages which add Swingset-messages to
-// that queue. Note that when running DeliverTx, inbound messages are
-// staged in the actionQueue, then transferred to the inbound queue in
-// end-block processing. Previous Txs in the block will have already been
-// added to the actionQueue, so we must reject Txs which would grow the
-// actionQueue beyond the allowed inbound size.
+/*
+This AnteDecorator enforces a limit on the size of the Swingset
+inbound queue by scanning for Cosmos-messages which add Swingset-messages
+to that queue. Note that when running DeliverTx, inbound messages
+are staged in the actionQueue, then transferred to the inbound queue
+in end-block processing. Previous Txs in the block will have already
+been added to the actionQueue, so we must reject Txs which would
+grow the actionQueue beyond the allowed inbound size.
 
-// We would like to reject messages during mempool admission (CheckTx)
-// rather than during block execution (DeliverTx), but at CheckTx time
-// we don't know how many messages will be allowed at DeliverTx time,
-// nor the size of the actionQueue from preceding Txs in the block.
-// To mitigate this, Swingset should implement hysteresis by computing
-// the number of messages allowed for mempool admission as if its max queue
-// length was lower (e.g. 50%). This is the QueueInboundMempool entry in the
-// Swingset state QueueAllowed field. At DeliverTx time the QueueInbound
-// entry gives the number of allowed messages.
+We would like to reject messages during mempool admission (CheckTx)
+rather than during block execution (DeliverTx), but at CheckTx time
+we don't know how many messages will be allowed at DeliverTx time,
+nor the size of the actionQueue from preceding Txs in the block.
+To mitigate this, Swingset should implement hysteresis by computing
+the number of messages allowed for mempool admission as if its max
+queue length was lower (e.g. 50%). This is the QueueInboundMempool
+entry in the Swingset state QueueAllowed field. At DeliverTx time
+the QueueInbound entry gives the number of allowed messages.
+*/
 
 const (
 	maxInboundPerTx = 1

--- a/golang/cosmos/ante/inbound.go
+++ b/golang/cosmos/ante/inbound.go
@@ -13,15 +13,15 @@ import (
 // This AnteDecorator enforces a limit on the size of the Swingset inbound
 // queue by scanning for Cosmos-messages which add Swingset-messages to
 // that queue. Note that when running DeliverTx, inbound messages are
-// staged in the action queue, then transferred to the inbound queue in
+// staged in the actionQueue, then transferred to the inbound queue in
 // end-block processing. Previous Txs in the block will have already been
-// added to the action queue, so we must reject Txs which would grouw the
-// action queue beyond the allowed inbound size.
+// added to the actionQueue, so we must reject Txs which would grow the
+// actionQueue beyond the allowed inbound size.
 
 // We would like to reject messages during mempool admission (CheckTx)
 // rather than during block execution (DeliverTx), but at CheckTx time
 // we don't know how many messages will be allowed at DeliverTx time,
-// nor the size of the action queue from preceding Txs in the block.
+// nor the size of the actionQueue from preceding Txs in the block.
 // To mitigate this, Swingset should implement hysteresis by computing
 // the number of messages allowed for mempool admission as if its max queue
 // length was lower (e.g. 50%). This is the QueueInboundMempool entry in the

--- a/golang/cosmos/ante/inbound.go
+++ b/golang/cosmos/ante/inbound.go
@@ -10,83 +10,116 @@ import (
 	swingtypes "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
 )
 
+// This AnteDecorator enforces a limit on the size of the Swingset inbound
+// queue by scanning for Cosmos-messages which add Swingset-messages to
+// that queue. Note that when running DeliverTx, inbound messages are
+// staged in the action queue, then transferred to the inbound queue in
+// end-block processing. Previous Txs in the block will have already been
+// added to the action queue, so we must reject Txs which would grouw the
+// action queue beyond the allowed inbound size.
+
+// We would like to reject messages during mempool admission (CheckTx)
+// rather than during block execution (DeliverTx), but at CheckTx time
+// we don't know how many messages will be allowed at DeliverTx time,
+// nor the size of the action queue from preceding Txs in the block.
+// To mitigate this, Swingset should implement hysteresis by computing
+// the number of messages allowed for mempool admission as if its max queue
+// length was lower (e.g. 50%). This is the QueueInboundMempool entry in the
+// Swingset state QueueAllowed field. At DeliverTx time the QueueInbound
+// entry gives the number of allowed messages.
+
+const (
+	maxInboundPerTx = 1
+)
+
 // TODO: We don't have a more appropriate error type for this.
 var ErrInboundQueueFull = sdkerrors.ErrMempoolIsFull
 
+// inboundAnte is an sdk.AnteDecorator which enforces the allowed size of the inbound queue.
 type inboundAnte struct {
 	sk SwingsetKeeper
 }
 
-// NewInboundDecorator return an AnteDecorator which honors the allowed size of the inbound queue.
-// The swingset message types will consume one allowed entry each, and will be reflected
-// in the action queue when executed.
+// NewInboundDecorator returns an AnteDecorator which honors the allowed size of the inbound queue.
 func NewInboundDecorator(sk SwingsetKeeper) sdk.AnteDecorator {
 	return inboundAnte{sk: sk}
 }
 
-// AnteHandle implements sdk.AnteDecorator
+// AnteHandle implements sdk.AnteDecorator.
+// Lazily consults the Swingset state to avoid overhead when dealing
+// with pure Cosmos-level Txs.
 func (ia inboundAnte) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	msgs := tx.GetMsgs()
 	inboundsAllowed := int32(-1)
 	for _, msg := range msgs {
-		switch msg.(type) {
-		case *swingtypes.MsgDeliverInbound,
-			*swingtypes.MsgInstallBundle,
-			*swingtypes.MsgProvision,
-			*swingtypes.MsgWalletAction,
-			*swingtypes.MsgWalletSpendAction:
-			// Lazily compute the number of allowed messages when the transaction
-			// includes a SwingSet message. This number is the difference between
-			// the number of allowed messages initially returned by SwingSet, and
-			// the number of messages already added into the actionQueue by other
-			// transactions included in the block.
-			// We store the number of allowed messages locally since messages are
-			// added to the actionQueue after going through the ante handler (in
-			// CheckTx) and before the next transaction is processed.
-			// However in CheckTx (mempool admission check), no state is
-			// changed so it's possible for a set of transactions to exist which
-			// if all included in a block would push the actionQueue over, and thus
-			// end up in rejections instead of simply not admitting them in the
-			// mempool. To mitigate this, Swingset should compute the number of
-			// messages allowed for mempool admission as if its max queue length
-			// was lower (e.g. 50%). This is the QueueInboundMempool entry.
-			if inboundsAllowed == -1 {
-				state := ia.sk.GetState(ctx)
-				entry := swingtypes.QueueInbound
-				if ctx.IsCheckTx() {
-					entry = swingtypes.QueueInboundMempool
-				}
-				allowed, found := swingtypes.QueueSizeEntry(state.QueueAllowed, entry)
-				if found {
-					actions, err := ia.sk.ActionQueueLength(ctx)
-					if err != nil {
-						return ctx, err
-					}
-					if actions < allowed {
-						inboundsAllowed = allowed - actions
-					} else {
-						inboundsAllowed = 0
-					}
-				} else {
-					// if number of allowed entries not given, fail closed
-					inboundsAllowed = 0
-				}
+		inbounds := inboundMessages(msg)
+		if inbounds == 0 {
+			continue
+		}
+		if inboundsAllowed == -1 {
+			var err error
+			inboundsAllowed, err = ia.allowedInbound(ctx)
+			if err != nil {
+				return ctx, err
 			}
-			if inboundsAllowed > 0 {
-				inboundsAllowed--
-			} else {
-				defer func() {
-					telemetry.IncrCounterWithLabels(
-						[]string{"tx", "ante", "inbound_not_allowed"},
-						1,
-						[]metrics.Label{
-							telemetry.NewLabel("msg", sdk.MsgTypeURL(msg)),
-						},
-					)
-				}()
-				return ctx, ErrInboundQueueFull
-			}
+		}
+		if inboundsAllowed >= inbounds {
+			inboundsAllowed -= inbounds
+		} else {
+			defer func() {
+				telemetry.IncrCounterWithLabels(
+					[]string{"tx", "ante", "inbound_not_allowed"},
+					1,
+					[]metrics.Label{
+						telemetry.NewLabel("msg", sdk.MsgTypeURL(msg)),
+					},
+				)
+			}()
+			return ctx, ErrInboundQueueFull
 		}
 	}
 	return next(ctx, tx, simulate)
+}
+
+// allowedInbound returns the allowed number of inbound queue messages or an error.
+// Look up the limit from the swingset state queue sizes: from QueueInboundMempool
+// if we're running CheckTx (for the hysteresis described above), otherwise QueueAllowed.
+func (ia inboundAnte) allowedInbound(ctx sdk.Context) (int32, error) {
+	state := ia.sk.GetState(ctx)
+	entry := swingtypes.QueueInbound
+	if ctx.IsCheckTx() {
+		entry = swingtypes.QueueInboundMempool
+	}
+	allowed, found := swingtypes.QueueSizeEntry(state.QueueAllowed, entry)
+	if !found {
+		// if number of allowed entries not given, fail closed
+		return 0, nil
+	}
+	actions, err := ia.sk.ActionQueueLength(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if actions >= allowed {
+		return 0, nil
+	}
+	allowed -= actions
+	if allowed > maxInboundPerTx {
+		return maxInboundPerTx, nil
+	}
+	return allowed, nil
+}
+
+// inboundMessages returns the nunber of inbound queue messages in msg.
+func inboundMessages(msg sdk.Msg) int32 {
+	switch m := msg.(type) {
+	case *swingtypes.MsgDeliverInbound:
+		return int32(len(m.Messages))
+
+	case *swingtypes.MsgInstallBundle,
+		*swingtypes.MsgProvision,
+		*swingtypes.MsgWalletAction,
+		*swingtypes.MsgWalletSpendAction:
+		return 1
+	}
+	return 0
 }

--- a/golang/cosmos/ante/inbound.go
+++ b/golang/cosmos/ante/inbound.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
 	swingtypes "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
 )
 
@@ -113,13 +114,8 @@ func (ia inboundAnte) allowedInbound(ctx sdk.Context) (int32, error) {
 
 // inboundMessages returns the nunber of inbound queue messages in msg.
 func inboundMessages(msg sdk.Msg) int32 {
-	switch msg.(type) {
-	case *swingtypes.MsgDeliverInbound,
-		*swingtypes.MsgInstallBundle,
-		*swingtypes.MsgProvision,
-		*swingtypes.MsgWalletAction,
-		*swingtypes.MsgWalletSpendAction:
-		return 1
+	if i, ok := msg.(vm.InboundMsgCarrier); ok {
+		return i.GetInboundMsgCount()
 	}
 	return 0
 }

--- a/golang/cosmos/ante/inbound.go
+++ b/golang/cosmos/ante/inbound.go
@@ -114,8 +114,8 @@ func (ia inboundAnte) allowedInbound(ctx sdk.Context) (int32, error) {
 
 // inboundMessages returns the nunber of inbound queue messages in msg.
 func inboundMessages(msg sdk.Msg) int32 {
-	if i, ok := msg.(vm.InboundMsgCarrier); ok {
-		return i.GetInboundMsgCount()
+	if c, ok := msg.(vm.ControllerAdmissionMsg); ok {
+		return c.GetInboundMsgCount()
 	}
 	return 0
 }

--- a/golang/cosmos/ante/inbound_test.go
+++ b/golang/cosmos/ante/inbound_test.go
@@ -31,24 +31,31 @@ func TestInboundAnteHandle(t *testing.T) {
 		},
 		{
 			name:   "reject-on-zero-allowed",
-			tx:     makeTestTx(&swingtypes.MsgInstallBundle{}),
+			tx:     makeTestTx(&swingtypes.MsgDeliverInbound{}),
 			errMsg: ErrInboundQueueFull.Error(),
 		},
 		{
-			name:         "has-room",
-			tx:           makeTestTx(&swingtypes.MsgWalletAction{}),
-			inboundLimit: 10,
+			name:              "has-room",
+			tx:                makeTestTx(&swingtypes.MsgInstallBundle{}),
+			inboundLimit:      10,
+			actionQueueLength: 8,
+		},
+		{
+			name:              "at-limit",
+			tx:                makeTestTx(&swingtypes.MsgInstallBundle{}),
+			inboundLimit:      10,
+			actionQueueLength: 9,
 		},
 		{
 			name:              "no-room",
-			tx:                makeTestTx(&swingtypes.MsgWalletAction{}, &swingtypes.MsgInstallBundle{}),
+			tx:                makeTestTx(&swingtypes.MsgProvision{}),
 			inboundLimit:      10,
-			actionQueueLength: 9,
+			actionQueueLength: 10,
 			errMsg:            ErrInboundQueueFull.Error(),
 		},
 		{
 			name:                 "state-lookup-error",
-			tx:                   makeTestTx(&swingtypes.MsgWalletAction{}, &swingtypes.MsgInstallBundle{}),
+			tx:                   makeTestTx(&swingtypes.MsgWalletAction{}, &swingtypes.MsgWalletSpendAction{}),
 			inboundLimit:         10,
 			actionQueueLengthErr: fmt.Errorf("sunspots"),
 			errMsg:               "sunspots",
@@ -67,7 +74,7 @@ func TestInboundAnteHandle(t *testing.T) {
 		{
 			name:              "checktx",
 			checkTx:           true,
-			tx:                makeTestTx(&swingtypes.MsgWalletAction{}),
+			tx:                makeTestTx(&swingtypes.MsgDeliverInbound{}),
 			inboundLimit:      10,
 			mempoolLimit:      5,
 			actionQueueLength: 7,
@@ -75,38 +82,15 @@ func TestInboundAnteHandle(t *testing.T) {
 		},
 		{
 			name:         "empty-queue-allowed",
-			tx:           makeTestTx(&swingtypes.MsgWalletAction{}),
+			tx:           makeTestTx(&swingtypes.MsgInstallBundle{}),
 			inboundLimit: -1,
 			errMsg:       ErrInboundQueueFull.Error(),
 		},
 		{
 			name:              "already-full",
-			tx:                makeTestTx(&swingtypes.MsgWalletAction{}),
+			tx:                makeTestTx(&swingtypes.MsgProvision{}),
 			inboundLimit:      10,
 			actionQueueLength: 10,
-			errMsg:            ErrInboundQueueFull.Error(),
-		},
-		{
-			name:              "deliver-inbound-empty",
-			tx:                makeTestTx(&swingtypes.MsgDeliverInbound{}),
-			inboundLimit:      10,
-			actionQueueLength: 20,
-		},
-		{
-			name: "deliver-inbound-one",
-			tx: makeTestTx(&swingtypes.MsgDeliverInbound{
-				Messages: []string{"foo"},
-			}),
-			inboundLimit:      2,
-			actionQueueLength: 1,
-		},
-		{
-			name: "deliver-inbound-one",
-			tx: makeTestTx(&swingtypes.MsgDeliverInbound{
-				Messages: []string{"foo", "bar"},
-			}),
-			inboundLimit:      2,
-			actionQueueLength: 1,
 			errMsg:            ErrInboundQueueFull.Error(),
 		},
 	} {

--- a/golang/cosmos/ante/inbound_test.go
+++ b/golang/cosmos/ante/inbound_test.go
@@ -1,0 +1,188 @@
+package ante
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	swingtypes "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/gogo/protobuf/proto"
+)
+
+func TestInboundAnteHandle(t *testing.T) {
+	for _, tt := range []struct {
+		name                 string
+		checkTx              bool
+		tx                   sdk.Tx
+		simulate             bool
+		actionQueueLength    int32
+		actionQueueLengthErr error
+		inboundLimit         int32
+		mempoolLimit         int32
+		errMsg               string
+	}{
+		{
+			name: "empty-empty",
+			tx:   makeTestTx(),
+		},
+		{
+			name:   "reject-on-zero-allowed",
+			tx:     makeTestTx(&swingtypes.MsgInstallBundle{}),
+			errMsg: ErrInboundQueueFull.Error(),
+		},
+		{
+			name:         "has-room",
+			tx:           makeTestTx(&swingtypes.MsgWalletAction{}),
+			inboundLimit: 10,
+		},
+		{
+			name:              "no-room",
+			tx:                makeTestTx(&swingtypes.MsgWalletAction{}, &swingtypes.MsgInstallBundle{}),
+			inboundLimit:      10,
+			actionQueueLength: 9,
+			errMsg:            ErrInboundQueueFull.Error(),
+		},
+		{
+			name:                 "state-lookup-error",
+			tx:                   makeTestTx(&swingtypes.MsgWalletAction{}, &swingtypes.MsgInstallBundle{}),
+			inboundLimit:         10,
+			actionQueueLengthErr: fmt.Errorf("sunspots"),
+			errMsg:               "sunspots",
+		},
+		{
+			name:         "allow-non-swingset-msgs",
+			tx:           makeTestTx(&banktypes.MsgSend{}, &banktypes.MsgSend{}),
+			inboundLimit: 1,
+		},
+		{
+			name:                 "lazy-queue-length-lookup",
+			tx:                   makeTestTx(&banktypes.MsgSend{}, &banktypes.MsgSend{}),
+			inboundLimit:         1,
+			actionQueueLengthErr: fmt.Errorf("sunspots"),
+		},
+		{
+			name:              "checktx",
+			checkTx:           true,
+			tx:                makeTestTx(&swingtypes.MsgWalletAction{}),
+			inboundLimit:      10,
+			mempoolLimit:      5,
+			actionQueueLength: 7,
+			errMsg:            ErrInboundQueueFull.Error(),
+		},
+		{
+			name:         "empty-queue-allowed",
+			tx:           makeTestTx(&swingtypes.MsgWalletAction{}),
+			inboundLimit: -1,
+			errMsg:       ErrInboundQueueFull.Error(),
+		},
+		{
+			name:              "already-full",
+			tx:                makeTestTx(&swingtypes.MsgWalletAction{}),
+			inboundLimit:      10,
+			actionQueueLength: 10,
+			errMsg:            ErrInboundQueueFull.Error(),
+		},
+		{
+			name:              "deliver-inbound-empty",
+			tx:                makeTestTx(&swingtypes.MsgDeliverInbound{}),
+			inboundLimit:      10,
+			actionQueueLength: 20,
+		},
+		{
+			name: "deliver-inbound-one",
+			tx: makeTestTx(&swingtypes.MsgDeliverInbound{
+				Messages: []string{"foo"},
+			}),
+			inboundLimit:      2,
+			actionQueueLength: 1,
+		},
+		{
+			name: "deliver-inbound-one",
+			tx: makeTestTx(&swingtypes.MsgDeliverInbound{
+				Messages: []string{"foo", "bar"},
+			}),
+			inboundLimit:      2,
+			actionQueueLength: 1,
+			errMsg:            ErrInboundQueueFull.Error(),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := sdk.Context{}.WithIsCheckTx(tt.checkTx)
+			emptyQueueAllowed := false
+			if tt.inboundLimit == -1 {
+				emptyQueueAllowed = true
+			}
+			mock := mockSwingsetKeeper{
+				actionQueueLength:    tt.actionQueueLength,
+				actionQueueLengthErr: tt.actionQueueLengthErr,
+				inboundLimit:         tt.inboundLimit,
+				mempoolLimit:         tt.mempoolLimit,
+				emptyQueueAllowed:    emptyQueueAllowed,
+			}
+			decorator := NewInboundDecorator(mock)
+			newCtx, err := decorator.AnteHandle(ctx, tt.tx, tt.simulate, nilAnteHandler)
+			if !reflect.DeepEqual(newCtx, ctx) {
+				t.Errorf("want ctx %v, got %v", ctx, newCtx)
+			}
+			if err != nil {
+				if tt.errMsg == "" {
+					t.Errorf("want no error, got %s", err.Error())
+				} else if err.Error() != tt.errMsg {
+					t.Errorf("want error %s, got %s", tt.errMsg, err.Error())
+				}
+			} else if tt.errMsg != "" {
+				t.Errorf("want error %s, got none", tt.errMsg)
+			}
+		})
+	}
+}
+
+func makeTestTx(msgs ...proto.Message) sdk.Tx {
+	wrappedMsgs := make([]*types.Any, len(msgs))
+	for i, m := range msgs {
+		any, err := types.NewAnyWithValue(m)
+		if err != nil {
+			panic(err)
+		}
+		wrappedMsgs[i] = any
+	}
+	return &tx.Tx{
+		Body: &tx.TxBody{
+			Messages: wrappedMsgs,
+		},
+	}
+}
+
+func nilAnteHandler(ctx sdk.Context, tx sdk.Tx, simulate bool) (newCtx sdk.Context, err error) {
+	return ctx, nil
+}
+
+type mockSwingsetKeeper struct {
+	actionQueueLength    int32
+	actionQueueLengthErr error
+	inboundLimit         int32
+	mempoolLimit         int32
+	emptyQueueAllowed    bool
+}
+
+var _ SwingsetKeeper = mockSwingsetKeeper{}
+
+func (msk mockSwingsetKeeper) ActionQueueLength(ctx sdk.Context) (int32, error) {
+	return msk.actionQueueLength, msk.actionQueueLengthErr
+}
+
+func (msk mockSwingsetKeeper) GetState(ctx sdk.Context) swingtypes.State {
+	if msk.emptyQueueAllowed {
+		return swingtypes.State{}
+	}
+	return swingtypes.State{
+		QueueAllowed: []swingtypes.QueueSize{
+			swingtypes.NewQueueSize(swingtypes.QueueInbound, msk.inboundLimit),
+			swingtypes.NewQueueSize(swingtypes.QueueInboundMempool, msk.mempoolLimit),
+		},
+	}
+}

--- a/golang/cosmos/ante/inbound_test.go
+++ b/golang/cosmos/ante/inbound_test.go
@@ -93,6 +93,13 @@ func TestInboundAnteHandle(t *testing.T) {
 			actionQueueLength: 10,
 			errMsg:            ErrInboundQueueFull.Error(),
 		},
+		{
+			name:              "max-per-tx",
+			tx:                makeTestTx(&swingtypes.MsgWalletAction{}, &swingtypes.MsgWalletSpendAction{}),
+			inboundLimit:      10,
+			actionQueueLength: 5,
+			errMsg:            ErrInboundQueueFull.Error(),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := sdk.Context{}.WithIsCheckTx(tt.checkTx)

--- a/golang/cosmos/vm/controller.go
+++ b/golang/cosmos/vm/controller.go
@@ -12,8 +12,17 @@ type ControllerContext struct {
 	IBCChannelHandlerPort int
 }
 
+// InboundMsgCarrier should be implemented by Cosmos-messages which
+// contain Swingset-messages which will be added to the inboundQueue.
+type InboundMsgCarrier interface {
+	// GetInboundMsgCount returns the number of Swingset messages which will
+	// be added to the inboundQueue.
+	GetInboundMsgCount() int32
+}
+
 type ControllerAdmissionMsg interface {
 	sdk.Msg
+	InboundMsgCarrier
 	CheckAdmissibility(sdk.Context, interface{}) error
 }
 

--- a/golang/cosmos/vm/controller.go
+++ b/golang/cosmos/vm/controller.go
@@ -12,18 +12,13 @@ type ControllerContext struct {
 	IBCChannelHandlerPort int
 }
 
-// InboundMsgCarrier should be implemented by Cosmos-messages which
-// contain Swingset-messages which will be added to the inboundQueue.
-type InboundMsgCarrier interface {
+type ControllerAdmissionMsg interface {
+	sdk.Msg
+	CheckAdmissibility(sdk.Context, interface{}) error
+
 	// GetInboundMsgCount returns the number of Swingset messages which will
 	// be added to the inboundQueue.
 	GetInboundMsgCount() int32
-}
-
-type ControllerAdmissionMsg interface {
-	sdk.Msg
-	InboundMsgCarrier
-	CheckAdmissibility(sdk.Context, interface{}) error
 }
 
 // Jsonable is a value, j, that can be passed through json.Marshal(j).

--- a/golang/cosmos/x/swingset/types/msgs.go
+++ b/golang/cosmos/x/swingset/types/msgs.go
@@ -20,9 +20,9 @@ var (
 
 	_ vm.ControllerAdmissionMsg = &MsgDeliverInbound{}
 	_ vm.ControllerAdmissionMsg = &MsgInstallBundle{}
+	_ vm.ControllerAdmissionMsg = &MsgProvision{}
 	_ vm.ControllerAdmissionMsg = &MsgWalletAction{}
 	_ vm.ControllerAdmissionMsg = &MsgWalletSpendAction{}
-	// MsgProvision has its own fee mechanism and is intentionally omitted.
 )
 
 // Charge an account address for the beans associated with given messages.
@@ -234,6 +234,13 @@ func (msg MsgProvision) ValidateBasic() error {
 	if len(msg.Nickname) == 0 {
 		return sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "Nickname cannot be empty")
 	}
+	return nil
+}
+
+// CheckAdmissibility implements the vm.ControllerAdmissionMsg interface.
+func (msg MsgProvision) CheckAdmissibility(ctx sdk.Context, data interface{}) error {
+	// We have our own fee charging mechanism within Swingset itself,
+	// so there are no admission restriction here.
 	return nil
 }
 

--- a/golang/cosmos/x/swingset/types/msgs.go
+++ b/golang/cosmos/x/swingset/types/msgs.go
@@ -63,6 +63,11 @@ func (msg MsgDeliverInbound) CheckAdmissibility(ctx sdk.Context, data interface{
 	return chargeAdmission(ctx, keeper, msg.Submitter, msg.Messages)
 }
 
+// GetInboundMsgCount implements InboundMsgCarrier.
+func (msg MsgDeliverInbound) GetInboundMsgCount() int32 {
+	return 1
+}
+
 // Route should return the name of the module
 func (msg MsgDeliverInbound) Route() string { return RouterKey }
 
@@ -117,6 +122,11 @@ func (msg MsgWalletAction) CheckAdmissibility(ctx sdk.Context, data interface{})
 	}
 
 	return chargeAdmission(ctx, keeper, msg.Owner, []string{msg.Action})
+}
+
+// GetInboundMsgCount implements InboundMsgCarrier.
+func (msg MsgWalletAction) GetInboundMsgCount() int32 {
+	return 1
 }
 
 func (msg MsgWalletAction) GetSigners() []sdk.AccAddress {
@@ -176,6 +186,10 @@ func (msg MsgWalletSpendAction) CheckAdmissibility(ctx sdk.Context, data interfa
 	return chargeAdmission(ctx, keeper, msg.Owner, []string{msg.SpendAction})
 }
 
+// GetInboundMsgCount implements InboundMsgCarrier.
+func (msg MsgWalletSpendAction) GetInboundMsgCount() int32 {
+	return 1
+}
 func (msg MsgWalletSpendAction) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Owner}
 }
@@ -223,6 +237,11 @@ func (msg MsgProvision) ValidateBasic() error {
 	return nil
 }
 
+// GetInboundMsgCount implements InboundMsgCarrier.
+func (msg MsgProvision) GetInboundMsgCount() int32 {
+	return 1
+}
+
 // GetSignBytes encodes the message for signing
 func (msg MsgProvision) GetSignBytes() []byte {
 	if msg.PowerFlags == nil {
@@ -251,6 +270,11 @@ func (msg MsgInstallBundle) CheckAdmissibility(ctx sdk.Context, data interface{}
 	}
 
 	return chargeAdmission(ctx, keeper, msg.Submitter, []string{msg.Bundle})
+}
+
+// GetInboundMsgCount implements InboundMsgCarrier.
+func (msg MsgInstallBundle) GetInboundMsgCount() int32 {
+	return 1
 }
 
 // Route should return the name of the module


### PR DESCRIPTION
closes: #6473

## Description

Refactor and add unit tests.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

Add an FAQ entry for "Mempool is full" errors meaning that the inbound queue is full.

### Testing Considerations

None.
