### PR TITLE
refactor: faster assert style

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -313,11 +313,11 @@ export const preparePaymentLedger = (
     srcPayment,
     optAmountShape = undefined,
   ) => {
-    assert(
-      !isPromise(srcPayment),
-      `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: E.when(paymentPromise, (actualPayment => deposit(actualPayment))`,
-      TypeError,
-    );
+    !isPromise(srcPayment) ||
+      assert.fail(
+        `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: E.when(paymentPromise, (actualPayment => deposit(actualPayment))`,
+        TypeError,
+      );
     assertLivePayment(srcPayment);
     const srcPaymentBalance = paymentLedger.get(srcPayment);
     assertAmountConsistent(srcPaymentBalance, optAmountShape);

--- a/packages/internal/src/storage-test-utils.js
+++ b/packages/internal/src/storage-test-utils.js
@@ -2,6 +2,8 @@
 import { Far, makeMarshal } from '@endo/marshal';
 import { makeChainStorageRoot } from './lib-chainStorage.js';
 
+const { Fail, quote: q } = assert;
+
 /**
  * For testing, creates a chainStorage root node over an in-memory map
  * and exposes both the map and the sequence of received messages.
@@ -87,11 +89,11 @@ export const makeMockChainStorageRoot = () => {
      * @returns {unknown}
      */
     getBody: (path, marshaller = defaultMarshaller) => {
-      assert(data.size, 'no data in storage');
+      data.size || Fail`no data in storage`;
       const dataStr = data.get(path);
       if (!dataStr) {
         console.debug('mockChainStorage data:', data);
-        assert.fail(`no data at ${path}`);
+        Fail`no data at ${q(path)}`;
       }
       assert.typeof(dataStr, 'string');
       const datum = JSON.parse(dataStr);

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -174,7 +174,7 @@ harden(applyLabelingError);
  * @type {<T extends {}>(unfulfilledTerms: T) => import('@endo/far').ERef<DeeplyAwaited<T>>}
  */
 export const deeplyFulfilledObject = obj => {
-  assert(isObject(obj), 'param must be an object');
+  isObject(obj) || Fail`param must be an object`;
   return deeplyFulfilled(obj);
 };
 

--- a/packages/store/src/stores/store-utils.js
+++ b/packages/store/src/stores/store-utils.js
@@ -1,6 +1,6 @@
 import { Far } from '@endo/marshal';
 
-const { details: X, quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 /**
  * @template K,V
@@ -54,11 +54,7 @@ export const makeCurrentKeysKit = (
       let i = 0;
       return Far('Iterator of keys', {
         next: () => {
-          assert.equal(
-            generation,
-            updateCount,
-            X`Store ${q(keyName)} cursor stale`,
-          );
+          generation === updateCount || Fail`Store ${q(keyName)} cursor stale`;
           // If they're equal, then the sortedKeyMemo is the same one
           // we started with.
           for (;;) {

--- a/packages/time/src/timeMath.js
+++ b/packages/time/src/timeMath.js
@@ -3,7 +3,7 @@ import { mustMatch } from '@agoric/store';
 
 import { RelativeTimeShape, TimestampShape } from './typeGuards.js';
 
-const { details: X, quote: q } = assert;
+const { Fail, quote: q } = assert;
 /**
  * @typedef {import('./types').TimerBrand} TimerBrand
  * @typedef {import('./types').Timestamp} Timestamp
@@ -31,11 +31,8 @@ const agreedTimerBrand = (leftBrand, rightBrand) => {
   } else if (rightBrand === undefined) {
     return leftBrand;
   } else {
-    assert.equal(
-      leftBrand,
-      rightBrand,
-      X`TimerBrands must match: ${q(leftBrand)} vs ${q(rightBrand)}`,
-    );
+    leftBrand === rightBrand ||
+      Fail`TimerBrands must match: ${q(leftBrand)} vs ${q(rightBrand)}`;
     return leftBrand;
   }
 };

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -1,18 +1,18 @@
 /* global globalThis */
 
-import { assert } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import { provideLazy } from '@agoric/store';
 
 /** @type {import('./types').VatData} */
 let VatDataGlobal;
 if ('VatData' in globalThis) {
-  assert(globalThis.VatData, 'VatData defined in global as null or undefined');
+  globalThis.VatData || Fail`VatData defined in global as null or undefined`;
   VatDataGlobal = globalThis.VatData;
 } else {
   // XXX this module has been known to get imported (transitively) in cases that
   // never use it so we make a version that will satisfy module resolution but
   // fail at runtime.
-  const unvailable = () => assert.fail('VatData unavailable');
+  const unvailable = () => Fail`VatData unavailable`;
   VatDataGlobal = {
     defineKind: unvailable,
     defineKindMulti: unvailable,

--- a/packages/zoe/src/contractFacet/vatRoot.js
+++ b/packages/zoe/src/contractFacet/vatRoot.js
@@ -36,13 +36,11 @@ export async function buildRootObject(powers, vatParameters, baggage) {
     baggage.init('zoeService', zoeService);
     baggage.init('invitationIssuer', invitationIssuer);
   } else {
-    assert(!zoeService, 'On restart zoeService must not be in vatParameters');
+    !zoeService || Fail`On restart zoeService must not be in vatParameters`;
     zoeService = baggage.get('zoeService');
 
-    assert(
-      !invitationIssuer,
-      'On restart invitationIssuer must not be in vatParameters',
-    );
+    !invitationIssuer ||
+      Fail`On restart invitationIssuer must not be in vatParameters`;
     invitationIssuer = baggage.get('invitationIssuer');
   }
 

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -64,10 +64,8 @@ export const makeZCFMintFactory = async (
         mintGains: (gains, zcfSeat = makeEmptySeatKit().zcfSeat) => {
           gains = coerceAmountKeywordRecord(gains, getAssetKindByBrand);
           const totalToMint = Object.values(gains).reduce(add, empty);
-          assert(
-            !zcfSeat.hasExited(),
-            'zcfSeat must be active to mint gains for the zcfSeat',
-          );
+          !zcfSeat.hasExited() ||
+            Fail`zcfSeat must be active to mint gains for the zcfSeat`;
           const allocationPlusGains = addToAllocation(
             zcfSeat.getCurrentAllocation(),
             gains,
@@ -97,10 +95,8 @@ export const makeZCFMintFactory = async (
         burnLosses: (losses, zcfSeat) => {
           losses = coerceAmountKeywordRecord(losses, getAssetKindByBrand);
           const totalToBurn = Object.values(losses).reduce(add, empty);
-          assert(
-            !zcfSeat.hasExited(),
-            'zcfSeat must be active to burn losses from the zcfSeat',
-          );
+          !zcfSeat.hasExited() ||
+            Fail`zcfSeat must be active to burn losses from the zcfSeat`;
           const allocationMinusLosses = subtractFromAllocation(
             zcfSeat.getCurrentAllocation(),
             losses,

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -112,10 +112,8 @@ export const createSeatManager = (
   };
 
   const assertStagedAllocation = zcfSeat => {
-    assert(
-      hasStagedAllocation(zcfSeat),
-      'Reallocate failed because a seat had no staged allocation. Please add or subtract from the seat and then reallocate.',
-    );
+    hasStagedAllocation(zcfSeat) ||
+      Fail`Reallocate failed because a seat had no staged allocation. Please add or subtract from the seat and then reallocate.`;
   };
 
   const setStagedAllocation = (zcfSeat, newStagedAllocation) => {
@@ -194,10 +192,7 @@ export const createSeatManager = (
         if (currentAllocation[keyword] !== undefined) {
           return currentAllocation[keyword];
         }
-        assert(
-          brand,
-          'A brand must be supplied when the keyword is not defined',
-        );
+        brand || Fail`A brand must be supplied when the keyword is not defined`;
         const assetKind = getAssetKindByBrand(brand);
         return AmountMath.makeEmpty(brand, assetKind);
       },

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -253,7 +253,9 @@ export function makeOnewayPriceAuthorityKit(opts) {
             amountIn,
             amountOut: calcAmountOut(amountIn),
           }));
-          assert(quote, 'createQuote returned falsey');
+          if (!quote) {
+            throw Fail`createQuote returned falsey`;
+          }
 
           const value = await quote;
           return harden({

--- a/packages/zoe/src/contractSupport/priceAuthorityTransform.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityTransform.js
@@ -1,6 +1,6 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { assert, details as X } from '@agoric/assert';
+import { Fail, assert } from '@agoric/assert';
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { makeNotifier } from '@agoric/notifier';
 
@@ -70,16 +70,10 @@ export const makePriceAuthorityTransform = async ({
    * @param {Brand} brandOut
    */
   const assertBrands = (brandIn, brandOut) => {
-    assert.equal(
-      brandIn,
-      actualBrandIn,
-      X`Desired brandIn ${brandIn} must match ${actualBrandIn}`,
-    );
-    assert.equal(
-      brandOut,
-      actualBrandOut,
-      X`Desired brandOut ${brandOut} must match ${actualBrandOut}`,
-    );
+    brandIn === actualBrandIn ||
+      Fail`Desired brandIn ${brandIn} must match ${actualBrandIn}`;
+    brandOut === actualBrandOut ||
+      Fail`Desired brandOut ${brandOut} must match ${actualBrandOut}`;
   };
 
   /**
@@ -98,11 +92,8 @@ export const makePriceAuthorityTransform = async ({
       sourceQuotePayment,
     );
 
-    assert.equal(
-      sourceQuoteValue.length,
-      1,
-      X`sourceQuoteValue.length ${sourceQuoteValue.length} is not 1`,
-    );
+    sourceQuoteValue.length === 1 ||
+      Fail`sourceQuoteValue.length ${sourceQuoteValue.length} is not 1`;
 
     const {
       amountIn: sourceAmountIn,

--- a/packages/zoe/src/contractSupport/priceQuote.js
+++ b/packages/zoe/src/contractSupport/priceQuote.js
@@ -2,6 +2,8 @@ import { AmountMath } from '@agoric/ertp';
 import { Nat } from '@endo/nat';
 import { E } from '@endo/eventual-send';
 
+const { Fail } = assert;
+
 // PriceAuthorities return quotes as a pair of an amount and a payment, both
 // with the same value. The underlying amount wraps amountIn, amountOut, timer
 // and timestamp. The payment is issued by the quoteIssuer to support veracity
@@ -12,10 +14,8 @@ import { E } from '@endo/eventual-send';
  * @returns {PriceDescription}
  */
 export const getPriceDescription = quote => {
-  assert(
-    quote.quoteAmount.value.length === 1,
-    'quoteAmount set must have one member',
-  );
+  quote.quoteAmount.value.length === 1 ||
+    Fail`quoteAmount set must have one member`;
   return quote.quoteAmount.value[0];
 };
 

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -1,5 +1,5 @@
 import './types.js';
-import { assert, details as X, q, Fail } from '@agoric/assert';
+import { q, Fail } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 import { assertRecord } from '@endo/marshal';
 import { isNat } from '@endo/nat';
@@ -41,7 +41,7 @@ const ratioPropertyNames = ['numerator', 'denominator'];
 export const assertIsRatio = ratio => {
   assertRecord(ratio, 'ratio');
   const keys = Object.keys(ratio);
-  assert(keys.length === 2, X`Ratio ${ratio} must be a record with 2 fields.`);
+  keys.length === 2 || Fail`Ratio ${ratio} must be a record with 2 fields.`;
   for (const name of keys) {
     ratioPropertyNames.includes(name) ||
       Fail`Parameter must be a Ratio record, but ${ratio} has ${q(name)}`;
@@ -103,12 +103,10 @@ export const makeRatioFromAmounts = (numeratorAmount, denominatorAmount) => {
 const multiplyHelper = (amount, ratio, divideOp) => {
   AmountMath.coerce(amount.brand, amount);
   assertIsRatio(ratio);
-  assert(
-    amount.brand === ratio.denominator.brand,
-    X`amount's brand ${q(amount.brand)} must match ratio's denominator ${q(
+  amount.brand === ratio.denominator.brand ||
+    Fail`amount's brand ${q(amount.brand)} must match ratio's denominator ${q(
       ratio.denominator.brand,
-    )}`,
-  );
+    )}`;
 
   return AmountMath.make(
     ratio.numerator.brand,
@@ -143,12 +141,10 @@ export const multiplyBy = (amount, ratio) => {
 const divideHelper = (amount, ratio, divideOp) => {
   AmountMath.coerce(amount.brand, amount);
   assertIsRatio(ratio);
-  assert(
-    amount.brand === ratio.numerator.brand,
-    X`amount's brand ${q(amount.brand)} must match ratio's numerator ${q(
+  amount.brand === ratio.numerator.brand ||
+    Fail`amount's brand ${q(amount.brand)} must match ratio's numerator ${q(
       ratio.numerator.brand,
-    )}`,
-  );
+    )}`;
 
   return AmountMath.make(
     ratio.denominator.brand,
@@ -198,16 +194,10 @@ export const invertRatio = ratio => {
 export const addRatios = (left, right) => {
   assertIsRatio(right);
   assertIsRatio(left);
-  assert.equal(
-    left.numerator.brand,
-    right.numerator.brand,
-    X`numerator brands must match: ${q(left)} ${q(right)}`,
-  );
-  assert.equal(
-    left.denominator.brand,
-    right.denominator.brand,
-    X`denominator brands must match: ${q(left)} ${q(right)}`,
-  );
+  left.numerator.brand === right.numerator.brand ||
+    Fail`numerator brands must match: ${q(left)} ${q(right)}`;
+  left.denominator.brand === right.denominator.brand ||
+    Fail`denominator brands must match: ${q(left)} ${q(right)}`;
 
   // Simplifying the expression:
   //  (and + bnd) / y d**2
@@ -233,16 +223,10 @@ export const addRatios = (left, right) => {
 export const subtractRatios = (left, right) => {
   assertIsRatio(right);
   assertIsRatio(left);
-  assert.equal(
-    left.numerator.brand,
-    right.numerator.brand,
-    X`numerator brands must match: ${q(left)} ${q(right)}`,
-  );
-  assert.equal(
-    left.denominator.brand,
-    right.denominator.brand,
-    X`denominator brands must match: ${q(left)} ${q(right)}`,
-  );
+  left.numerator.brand === right.numerator.brand ||
+    Fail`numerator brands must match: ${q(left)} ${q(right)}`;
+  left.denominator.brand === right.denominator.brand ||
+    Fail`denominator brands must match: ${q(left)} ${q(right)}`;
 
   return makeRatio(
     subtract(
@@ -318,21 +302,15 @@ export const oneMinus = ratio => {
  */
 export const ratioGTE = (left, right) => {
   if (left.numerator.brand === right.numerator.brand) {
-    assert.equal(
-      left.denominator.brand,
-      right.denominator.brand,
-      X`numerator brands match, but denominator brands don't: ${q(left)} ${q(
+    left.denominator.brand === right.denominator.brand ||
+      Fail`numerator brands match, but denominator brands don't: ${q(left)} ${q(
         right,
-      )}`,
-    );
+      )}`;
   } else if (left.numerator.brand === left.denominator.brand) {
-    assert.equal(
-      right.numerator.brand,
-      right.denominator.brand,
-      X`lefthand brands match, but righthand brands don't: ${q(left)} ${q(
+    right.numerator.brand === right.denominator.brand ||
+      Fail`lefthand brands match, but righthand brands don't: ${q(left)} ${q(
         right,
-      )}`,
-    );
+      )}`;
   }
   return natSafeMath.isGTE(
     multiply(left.numerator.value, right.denominator.value),
@@ -391,7 +369,9 @@ export const parseRatio = (
   denominatorBrand = numeratorBrand,
 ) => {
   const match = `${numeric}`.match(NUMERIC_RE);
-  assert(match, X`Invalid numeric data: ${numeric}`);
+  if (!match) {
+    throw Fail`Invalid numeric data: ${numeric}`;
+  }
 
   const [whole, part = ''] = [match[1], match[2]];
   return makeRatio(
@@ -409,5 +389,5 @@ export const parseRatio = (
  */
 export const assertParsableNumber = specimen => {
   const match = `${specimen}`.match(NUMERIC_RE);
-  assert(match, X`Invalid numeric data: ${specimen}`);
+  match || Fail`Invalid numeric data: ${specimen}`;
 };

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -140,7 +140,7 @@ export const fitProposalShape = (seat, proposalShape) =>
  */
 export const assertProposalShape = (seat, expected) => {
   assert.typeof(expected, 'object');
-  assert(!Array.isArray(expected), 'Expected must be an non-array object');
+  !Array.isArray(expected) || Fail`Expected must be an non-array object`;
   const assertValuesNull = e => {
     if (e !== undefined) {
       Object.values(e).forEach(
@@ -171,10 +171,8 @@ export const assertProposalShape = (seat, expected) => {
 
 /* Given a brand, assert that brand is AssetKind.NAT. */
 export const assertNatAssetKind = (zcf, brand) => {
-  assert(
-    zcf.getAssetKind(brand) === AssetKind.NAT,
-    'brand must be AssetKind.NAT',
-  );
+  zcf.getAssetKind(brand) === AssetKind.NAT ||
+    Fail`brand must be AssetKind.NAT`;
 };
 
 export const depositToSeatSuccessMsg = `Deposit and reallocation successful.`;
@@ -191,7 +189,7 @@ export const depositToSeatSuccessMsg = `Deposit and reallocation successful.`;
  * @returns {Promise<string>} `Deposit and reallocation successful.`
  */
 export const depositToSeat = async (zcf, recipientSeat, amounts, payments) => {
-  assert(!recipientSeat.hasExited(), 'The recipientSeat cannot have exited.');
+  !recipientSeat.hasExited() || Fail`The recipientSeat cannot have exited.`;
 
   // We will create a temporary offer to be able to escrow our payments
   // with Zoe.
@@ -231,7 +229,7 @@ export const depositToSeat = async (zcf, recipientSeat, amounts, payments) => {
  * @returns {Promise<PaymentPKeywordRecord>}
  */
 export const withdrawFromSeat = async (zcf, seat, amounts) => {
-  assert(!seat.hasExited(), 'The seat cannot have exited.');
+  !seat.hasExited() || Fail`The seat cannot have exited.`;
   const { zcfSeat: tempSeat, userSeat: tempUserSeatP } = zcf.makeEmptySeatKit();
   atomicTransfer(zcf, seat, tempSeat, amounts);
   tempSeat.exit();

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -31,11 +31,10 @@ const { quote: q, Fail } = assert;
 export const makeInstanceRecordStorage = baggage => {
   provide(baggage, 'instanceRecord', () => undefined);
 
-  const assertInstantiated = instanceRecord =>
-    assert(
-      instanceRecord !== 'undefined',
-      'instanceRecord has not been instantiated',
-    );
+  const assertInstantiated = instanceRecord => {
+    instanceRecord !== 'undefined' ||
+      Fail`instanceRecord has not been instantiated`;
+  };
 
   const InstanceRecordI = M.interface('InstanceRecord', {
     addIssuer: M.call(KeywordShape, IssuerRecordShape).returns(),

--- a/packages/zoe/src/issuerStorage.js
+++ b/packages/zoe/src/issuerStorage.js
@@ -5,6 +5,8 @@ import { arrayToObj } from './objArrayConversion.js';
 import { cleanKeywords } from './cleanProposal.js';
 import { makeIssuerRecord } from './issuerRecord.js';
 
+const { Fail } = assert;
+
 const STORAGE_INSTANTIATED_KEY = 'IssuerStorageInstantiated';
 
 /**
@@ -25,8 +27,9 @@ export const provideIssuerStorage = zcfBaggage => {
   );
 
   let instantiated = zcfBaggage.has(STORAGE_INSTANTIATED_KEY);
-  const assertInstantiated = () =>
-    assert(instantiated, 'issuerStorage has not been instantiated');
+  const assertInstantiated = () => {
+    instantiated || Fail`issuerStorage has not been instantiated`;
+  };
 
   /**
    * If we already know the entire issuer record, such as for a
@@ -115,7 +118,7 @@ export const provideIssuerStorage = zcfBaggage => {
     // intend to prevent issuer misbehavior in general, so the user
     // *must* rely on the good behavior of the issuers used in the
     // smart contracts they use.
-    assert(brandIssuerMatch, `issuer was using a brand which was not its own`);
+    brandIssuerMatch || Fail`issuer was using a brand which was not its own`;
     const issuerRecord = makeIssuerRecord(brand, issuer, displayInfo);
     storeIssuerRecord(issuerRecord);
     return getByBrand(brand);

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -12,6 +12,8 @@ import {
   prepareExoClassKit,
 } from '@agoric/vat-data';
 
+const { Fail } = assert;
+
 const FEE_MINT_KIT = 'FeeMintKit';
 
 export const defaultFeeIssuerConfig = harden(
@@ -61,10 +63,8 @@ const prepareFeeMint = (zoeBaggage, feeIssuerConfig, shutdownZoeVat) => {
       feeMint: {
         getFeeIssuerKit(allegedFeeMintAccess) {
           const { facets } = this;
-          assert(
-            facets.feeMintAccess === allegedFeeMintAccess,
-            'The object representing access to the fee brand mint was not provided',
-          );
+          facets.feeMintAccess === allegedFeeMintAccess ||
+            Fail`The object representing access to the fee brand mint was not provided`;
           return mintBaggage.get(FEE_MINT_KIT);
         },
         getFeeIssuer() {

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -13,7 +13,7 @@ import {
   UnwrappedInstallationShape,
 } from '../typeGuards.js';
 
-const { Fail } = assert;
+const { Fail, quote: q } = assert;
 
 /** @typedef { import('@agoric/swingset-vat').BundleCap} BundleCap */
 /** @typedef { import('@agoric/swingset-vat').BundleID} BundleID */
@@ -42,7 +42,7 @@ export const makeInstallationStorage = (
     zoeBaggage,
     'BundleIDInstallation',
     initEmpty,
-    { getBundle: _context => assert.fail('bundleID-based Installation') },
+    { getBundle: _context => Fail`bundleID-based Installation` },
   );
 
   const makeBundleInstallation = prepareKind(
@@ -106,11 +106,10 @@ export const makeInstallationStorage = (
         const { moduleFormat } = allegedBundle;
         if (moduleFormat === 'endoZipBase64Sha512') {
           const { endoZipBase64Sha512 } = allegedBundle;
-          assert.typeof(
-            endoZipBase64Sha512,
-            'string',
-            `bundle endoZipBase64Sha512 must be a string, got ${endoZipBase64Sha512}`,
-          );
+          typeof endoZipBase64Sha512 === 'string' ||
+            Fail`bundle endoZipBase64Sha512 must be a string, got ${q(
+              endoZipBase64Sha512,
+            )}`;
           return self.installBundleID(`b1-${endoZipBase64Sha512}`);
         }
         return installSourceBundle(allegedBundle);

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -134,7 +134,7 @@ const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
       state.zoeInstanceStorageManager.getInstallation(),
     getInstance: ({ state }) => state.instanceHandle,
     assertAcceptingOffers: ({ state }) => {
-      assert(state.acceptingOffers, `No further offers are accepted`);
+      state.acceptingOffers || Fail`No further offers are accepted`;
     },
     exitAllSeats: ({ state }, completion) => {
       state.acceptingOffers = false;

--- a/packages/zoe/src/zoeService/offer/burnInvitation.js
+++ b/packages/zoe/src/zoeService/offer/burnInvitation.js
@@ -1,4 +1,4 @@
-import { assert, details as X } from '@agoric/assert';
+import { Fail, assert, details as X } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
 
 /**
@@ -23,10 +23,8 @@ export const burnInvitation = (invitationIssuer, invitation) => {
   const handleFulfilled = invitationAmount => {
     const invitationValue = invitationAmount.value;
     assert(Array.isArray(invitationValue));
-    assert(
-      invitationValue.length === 1,
-      'Only one invitation can be redeemed at a time',
-    );
+    invitationValue.length === 1 ||
+      Fail`Only one invitation can be redeemed at a time`;
     const [{ instance: instanceHandle, handle: invitationHandle }] =
       invitationValue;
     return harden({

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -14,6 +14,8 @@ import {
   PaymentPKeywordRecordShape,
 } from '../typeGuards.js';
 
+const { Fail } = assert;
+
 const ZoeSeatIKit = harden({
   zoeSeatAdmin: M.interface('ZoeSeatAdmin', {
     replaceAllocation: M.call(AmountKeywordRecordShape).returns(),
@@ -263,7 +265,7 @@ export const makeZoeSeatAdminFactory = baggage => {
         },
         async tryExit() {
           const { state } = this;
-          assert(state.exitObj, 'exitObj must be initialized before use');
+          state.exitObj || Fail`exitObj must be initialized before use`;
           assertHasNotExited(this, 'Cannot exit; seat has already exited');
 
           return E(state.exitObj).exit();

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -12,7 +12,7 @@ import { natSafeMath } from '../src/contractSupport/index.js';
 
 import './types-ambient.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 // 'if (a >= b)' becomes 'if (timestampGTE(a,b))'
 const timestampGTE = (a, b) => TimeMath.compareAbs(a, b) >= 0;
@@ -50,10 +50,9 @@ export async function makeFakePriceAuthority(options) {
     quoteMint = makeIssuerKit('quote', AssetKind.SET).mint,
   } = options;
 
-  assert(
-    tradeList || priceList,
-    'One of priceList or tradeList must be specified',
-  );
+  tradeList ||
+    priceList ||
+    Fail`One of priceList or tradeList must be specified`;
 
   const unitValueIn = AmountMath.getValue(actualBrandIn, unitAmountIn);
 
@@ -74,16 +73,10 @@ export async function makeFakePriceAuthority(options) {
    * @param {Brand} allegedBrandOut
    */
   const assertBrands = (allegedBrandIn, allegedBrandOut) => {
-    assert.equal(
-      allegedBrandIn,
-      actualBrandIn,
-      X`${allegedBrandIn} is not an expected input brand`,
-    );
-    assert.equal(
-      allegedBrandOut,
-      actualBrandOut,
-      X`${allegedBrandOut} is not an expected output brand`,
-    );
+    allegedBrandIn === actualBrandIn ||
+      Fail`${allegedBrandIn} is not an expected input brand`;
+    allegedBrandOut === actualBrandOut ||
+      Fail`${allegedBrandOut} is not an expected output brand`;
   };
 
   const quoteIssuer = E(quoteMint).getIssuer();

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -75,7 +75,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
       return Promise.resolve().then(() => nameToBundleID.get(name));
     },
     createVat: (bundleCap, { vatParameters = {} } = {}) => {
-      assert.equal(bundleCap, zcfBundleCap, 'fakeVatAdmin only knows ZCF');
+      bundleCap === zcfBundleCap || Fail`fakeVatAdmin only knows ZCF`;
       const exitKit = makePromiseKit();
       handlePKitWarning(exitKit);
       const exitVat = completion => {
@@ -115,7 +115,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
               return exitKit.promise;
             },
             terminateWithFailure: () => {},
-            upgrade: (_bundleCap, _options) => assert.fail('upgrade not faked'),
+            upgrade: (_bundleCap, _options) => Fail`upgrade not faked`,
           }),
         }),
       );

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -6,6 +6,8 @@ import { TimeMath } from '@agoric/time';
 import './types-ambient.js';
 import './internal-types.js';
 
+const { Fail } = assert;
+
 // we wrap SwingSet's buildManualTimer to accomodate the needs of
 // zoe's tests
 
@@ -77,7 +79,7 @@ const buildManualTimer = (log = nolog, startValue = 0n, options = {}) => {
   };
 
   const tickN = async (nTimes, msg) => {
-    assert(nTimes >= 1, 'invariant nTimes >= 1');
+    nTimes >= 1 || Fail`invariant nTimes >= 1`;
     for (let i = 0; i < nTimes; i += 1) {
       // eslint-disable-next-line no-await-in-loop
       await tick(msg);


### PR DESCRIPTION
Convert more code to new assert style.

Newly motivated by perf cost of old style, but these changes not measured.

See https://github.com/endojs/endo/pull/1504