### PR TITLE
6878 misc fixes and refactors

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -14,6 +14,11 @@ import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
 
 const { details: X, quote: q, Fail } = assert;
 
+/**
+ * @param {Brand} brand
+ * @param {AssetKind} assetKind
+ * @param {Matcher} elementShape
+ */
 const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
   let valueShape;
   switch (assetKind) {
@@ -81,6 +86,7 @@ export const preparePaymentLedger = (
   optShutdownWithFailure = undefined,
 ) => {
   /** @type {Brand<K>} */
+  // @ts-expect-error XXX callWhen
   const brand = prepareExo(issuerBaggage, `${name} brand`, BrandI, {
     isMyIssuer(allegedIssuer) {
       // BrandI delays calling this method until `allegedIssuer` is a Remotable
@@ -377,6 +383,7 @@ export const preparePaymentLedger = (
   );
 
   /** @type {Issuer<K>} */
+  // @ts-expect-error cast due to callWhen discrepancy
   const issuer = prepareExo(issuerBaggage, `${name} issuer`, IssuerI, {
     getBrand() {
       return brand;
@@ -393,16 +400,21 @@ export const preparePaymentLedger = (
     makeEmptyPurse() {
       return makeEmptyPurse();
     },
+    /** @param {Payment} payment awaited by callWhen */
     isLive(payment) {
       // IssuerI delays calling this method until `payment` is a Remotable
       return paymentLedger.has(payment);
     },
+    /** @param {Payment} payment awaited by callWhen */
     getAmountOf(payment) {
       // IssuerI delays calling this method until `payment` is a Remotable
       assertLivePayment(payment);
       return paymentLedger.get(payment);
     },
-
+    /**
+     * @param {Payment} payment awaited by callWhen
+     * @param {Pattern} optAmountShape
+     */
     burn(payment, optAmountShape = undefined) {
       // IssuerI delays calling this method until `payment` is a Remotable
       assertLivePayment(payment);
@@ -417,6 +429,10 @@ export const preparePaymentLedger = (
       }
       return paymentBalance;
     },
+    /**
+     * @param {Payment} srcPayment awaited by callWhen
+     * @param {Pattern} optAmountShape
+     */
     claim(srcPayment, optAmountShape = undefined) {
       // IssuerI delays calling this method until `srcPayment` is a Remotable
       assertLivePayment(srcPayment);
@@ -450,6 +466,10 @@ export const preparePaymentLedger = (
         return payment;
       });
     },
+    /**
+     * @param {Payment} srcPayment awaited by callWhen
+     * @param {Amount} paymentAmountA
+     */
     split(srcPayment, paymentAmountA) {
       // IssuerI delays calling this method until `srcPayment` is a Remotable
       paymentAmountA = coerce(paymentAmountA);
@@ -463,6 +483,10 @@ export const preparePaymentLedger = (
       );
       return newPayments;
     },
+    /**
+     * @param {Payment} srcPayment awaited by callWhen
+     * @param {*} amounts
+     */
     splitMany(srcPayment, amounts) {
       // IssuerI delays calling this method until `srcPayment` is a Remotable
       assertLivePayment(srcPayment);
@@ -480,6 +504,7 @@ export const preparePaymentLedger = (
       return issuer;
     },
     mintPayment(newAmount) {
+      // @ts-expect-error checked cast
       newAmount = coerce(newAmount);
       mustMatch(newAmount, amountShape, 'minted amount');
       const payment = makePayment();

--- a/packages/ERTP/test/swingsetTests/ertpService/test-ertp-service-upgrade.js
+++ b/packages/ERTP/test/swingsetTests/ertpService/test-ertp-service-upgrade.js
@@ -8,9 +8,10 @@ import { buildVatController } from '@agoric/swingset-vat';
 const bfile = name => new URL(name, import.meta.url).pathname;
 
 test('ertp service upgrade', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     // includeDevDependencies: true, // for vat-data
-    defaultManagerType: /** @type {const} */ ('local'), // 'xs-worker',
+    defaultManagerType: 'local',
     bootstrap: 'bootstrap',
     // defaultReapInterval: 'never',
     // defaultReapInterval: 1,

--- a/packages/SwingSet/misc-tools/measure-metering/measure.js
+++ b/packages/SwingSet/misc-tools/measure-metering/measure.js
@@ -48,6 +48,7 @@ async function run() {
   const bootFn = new URL('measurement-bootstrap.js', import.meta.url).pathname;
   const targetFn = new URL('measurement-target.js', import.meta.url).pathname;
   const zoeFn = new URL('measurement-zoe.js', import.meta.url).pathname;
+  /** @type {SwingSetConfig} */
   const config = {
     defaultManagerType: 'xs-worker',
     bootstrap: 'bootstrap',

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -202,6 +202,8 @@ async function resolveSpecFromConfig(referrer, specPath) {
 async function normalizeConfigDescriptor(desc, referrer, expectParameters) {
   const normalizeSpec = async (entry, key) => {
     return resolveSpecFromConfig(referrer, entry[key]).then(spec => {
+      fs.existsSync(spec) ||
+        Fail`spec for ${entry[key]} does not exist: ${spec}`;
       entry[key] = spec;
     });
   };

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -242,39 +242,28 @@ export {};
  */
 
 /**
- * @typedef {object} SwingSetConfig a swingset config object
+ * @typedef {object} SwingSetOptions
  * @property {string} [bootstrap]
  * @property {ConfigProposal[]} [coreProposals]
  * @property {boolean} [includeDevDependencies] indicates that
  * `devDependencies` of the surrounding `package.json` should be accessible to
  * bundles.
- * @property {ManagerType} [defaultManagerType]
  * @property {string} [bundleCachePath] if present, SwingSet will use a bundle cache at this path
- * @property {number} [snapshotInitial]
- * @property {boolean} [pinBootstrapRoot]
- * @property {number} [snapshotInterval]
- * @property {boolean} [relaxDurabilityRules]
  * @property {SwingSetConfigDescriptor} vats
  * @property {SwingSetConfigDescriptor} [bundles]
  * @property {BundleFormat} [bundleFormat] the bundle source / import bundle
  * format.
  * @property {*} [devices]
  */
+/**
+ * @typedef {KernelOptions & SwingSetOptions} SwingSetConfig a swingset config object
+ */
 
 /**
- * @typedef {object} SwingSetKernelConfig the config object passed to initializeKernel
- * @property {string} [bootstrap]
- * @property {boolean} [includeDevDependencies] indicates that
- * `devDependencies` of the surrounding `package.json` should be accessible to
- * bundles.
- * @property { ManagerType } [defaultManagerType]
- * @property {SwingSetConfigDescriptor} [vats]
- * @property {SwingSetConfigDescriptor} [bundles]
- * @property {Record<string, BundleID>} namedBundleIDs
- * @property {Record<BundleID, Bundle>} idToBundle
- * @property {BundleFormat} [bundleFormat] the bundle source / import bundle
- * format.
- * @property {*} [devices]
+ * @typedef {SwingSetConfig & {
+ *   namedBundleIDs: Record<string, BundleID>,
+ *   idToBundle: Record<BundleID, Bundle>
+ * }} SwingSetKernelConfig the config object passed to initializeKernel
  */
 
 /**

--- a/packages/SwingSet/test/device-mailbox/test-device-mailbox.js
+++ b/packages/SwingSet/test/device-mailbox/test-device-mailbox.js
@@ -133,6 +133,7 @@ test('mailbox inbound', async t => {
 async function initializeMailboxKernel(t) {
   const s = buildMailboxStateMap();
   const mb = buildMailbox(s);
+  /** @type {SwingSetConfig} */
   const config = {
     bootstrap: 'bootstrap',
     // Can't use 'local' because it's non-deterministic for 'mailbox

--- a/packages/SwingSet/test/gc/test-gc-vat.js
+++ b/packages/SwingSet/test/gc/test-gc-vat.js
@@ -29,6 +29,7 @@ function findClist(c, vatID, kref) {
 }
 
 async function dropPresence(t, dropExport) {
+  /** @type {SwingSetConfig} */
   const config = {
     bootstrap: 'bootstrap',
     defaultManagerType: 'xs-worker', // Avoid local vat nondeterminism

--- a/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
@@ -8,6 +8,7 @@ import { kunser } from '../../src/lib/kmarshal.js';
 // Dynamic vats are created without metering by default
 
 test('unmetered dynamic vat', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     bootstrap: 'bootstrap',
     defaultManagerType: 'xs-worker',

--- a/packages/SwingSet/test/run-policy/test-run-policy.js
+++ b/packages/SwingSet/test/run-policy/test-run-policy.js
@@ -11,6 +11,7 @@ import {
 import { kslot, kser } from '../../src/lib/kmarshal.js';
 
 async function testCranks(t, mode) {
+  /** @type {SwingSetConfig} */
   const config = {
     defaultReapInterval: 'never',
     vats: {

--- a/packages/SwingSet/test/test-activityhash-vs-start.js
+++ b/packages/SwingSet/test/test-activityhash-vs-start.js
@@ -19,6 +19,7 @@ const TimerSrc = new URL(
 
 test('restarting kernel does not change activityhash', async t => {
   const sourceSpec = new URL('vat-empty-setup.js', import.meta.url).pathname;
+  /** @type {SwingSetConfig} */
   const config = {
     defaultManagerType: 'xs-worker',
     bootstrap: 'bootstrap',

--- a/packages/SwingSet/test/test-vat-env.js
+++ b/packages/SwingSet/test/test-vat-env.js
@@ -64,6 +64,7 @@ test('store makers are in the test environment', t => {
 });
 
 async function testForExpectedGlobals(t, workerType) {
+  /** @type {SwingSetConfig} */
   const config = {
     bootstrap: 'bootstrap',
     vats: {

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -52,6 +52,7 @@ const makeRun = swingsetController => {
 };
 
 const testNullUpgrade = async (t, defaultManagerType) => {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
     defaultManagerType,
@@ -115,6 +116,7 @@ const testUpgrade = async (
   defaultManagerType,
   doVatAdminRestart = false,
 ) => {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
     defaultManagerType,
@@ -346,6 +348,7 @@ test('vat upgrade - xsnap', async t => {
 });
 
 test('vat upgrade - omit vatParameters', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
     defaultManagerType: 'xs-worker',
@@ -375,6 +378,7 @@ test('vat upgrade - omit vatParameters', async t => {
 });
 
 test('failed upgrade - relaxed durable rules', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     relaxDurabilityRules: true,
     includeDevDependencies: true, // for vat-data
@@ -408,6 +412,7 @@ test('failed upgrade - relaxed durable rules', async t => {
 });
 
 test('failed upgrade - lost kind', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
     defaultManagerType: 'xs-worker',
@@ -467,6 +472,7 @@ test('failed upgrade - lost kind', async t => {
 // TODO: test stopVat failure
 
 test('failed upgrade - explode', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
     defaultManagerType: 'xs-worker',
@@ -511,6 +517,7 @@ test('failed upgrade - explode', async t => {
 });
 
 async function testMultiKindUpgradeChecks(t, mode, complaint) {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
     defaultManagerType: 'xs-worker',
@@ -594,6 +601,7 @@ test('facet kind redefinition - fail on multi- to single-facet redefinition', as
 });
 
 test('failed upgrade - unknown options', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
     defaultManagerType: 'xs-worker',
@@ -627,6 +635,7 @@ test('failed upgrade - unknown options', async t => {
 });
 
 test('failed vatAdmin upgrade - bad replacement code', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
     bootstrap: 'bootstrap',

--- a/packages/SwingSet/test/vat-warehouse/test-preload.js
+++ b/packages/SwingSet/test/vat-warehouse/test-preload.js
@@ -15,6 +15,7 @@ test('only preload maxVatsOnline vats', async t => {
   const tpath = new URL('vat-preload-extra.js', import.meta.url).pathname;
   // this combination of config and initOpts means we have only two
   // initial vats: v1-bootstrap and v2-vatAdmin
+  /** @type {SwingSetConfig} */
   const config = {
     defaultManagerType: 'xs-worker',
     defaultReapInterval: 'never',

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -334,6 +334,7 @@ test('virtual object gc', async t => {
     where they were originally stashed on creation
   */
 
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
     bootstrap: 'bootstrap',

--- a/packages/SwingSet/test/zcf-ish-upgrade/test-zcf-ish-upgrade.js
+++ b/packages/SwingSet/test/zcf-ish-upgrade/test-zcf-ish-upgrade.js
@@ -9,9 +9,10 @@ import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
 const bfile = name => new URL(name, import.meta.url).pathname;
 
 test('zcf-ish upgrade', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
-    defaultManagerType: 'local', // 'xs-worker',
+    defaultManagerType: 'local',
     bootstrap: 'bootstrap',
     // defaultReapInterval: 'never',
     // defaultReapInterval: 1,

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -5,6 +5,14 @@ import { makePromiseKit } from '@endo/promise-kit';
 
 const { details: X, quote: q, Fail } = assert;
 
+/**
+ * @typedef {object} BundleMeta
+ * @property {string} bundleFileName
+ * @property {string} bundleTime as ISO string
+ * @property {{relative: string, absolute: string}} moduleSource
+ * @property {Array<{relativePath: string, mtime: string}>} contents
+ */
+
 export const makeFileReader = (fileName, { fs, path }) => {
   const make = there => makeFileReader(there, { fs, path });
   return harden({
@@ -80,6 +88,7 @@ export const makeBundleCache = (wr, bundleOptions, cwd, readPowers) => {
     await bundleWr.writeText(code);
     const { mtime: bundleTime } = await bundleWr.readOnly().stat();
 
+    /** @type {BundleMeta} */
     const meta = {
       bundleFileName,
       bundleTime: bundleTime.toISOString(),
@@ -143,6 +152,13 @@ export const makeBundleCache = (wr, bundleOptions, cwd, readPowers) => {
     return meta;
   };
 
+  /**
+   *
+   * @param {string} rootPath
+   * @param {string} targetName
+   * @param {*} log
+   * @returns {Promise<BundleMeta>}
+   */
   const validateOrAdd = async (rootPath, targetName, log = console.debug) => {
     let meta;
     if (wr.readOnly().neighbor(toBundleMeta(targetName)).exists()) {
@@ -158,7 +174,7 @@ export const makeBundleCache = (wr, bundleOptions, cwd, readPowers) => {
           bundleTime,
         );
       } catch (invalid) {
-        console.warn(invalid.message);
+        console.error('ERROR in bundleTool:', invalid.message);
       }
     }
     if (!meta) {

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -33,7 +33,7 @@ const BASIS_POINTS = 10_000n;
  * @property {Instance} psm
  * @property {Instance} psmGovernor
  * @property {Awaited<ReturnType<import('../psm/psm.js').start>>['creatorFacet']} psmCreatorFacet
- * @property {GovernedContractFacetAccess<{},{}>} psmGovernorCreatorFacet
+ * @property {GovernedContractFacetAccess<import('../../src/psm/psm.js').PsmPublicFacet,{}>} psmGovernorCreatorFacet
  * @property {AdminFacet} psmAdminFacet
  */
 

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -163,7 +163,6 @@ export const setupPsm = async (
   };
   const governedInstance = E(governorPublicFacet).getGovernedContract();
 
-  /** @type { GovernedPublicFacet<import('../../src/psm/psm.js').PsmPublicFacet> } */
   const psmPublicFacet = await E(governorCreatorFacet).getPublicFacet();
   const psm = {
     psmCreatorFacet: psmKit.psmCreatorFacet,

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -217,12 +217,10 @@ test('durable publish kit rejects non-durable values', async t => {
 });
 
 test('durable publish kit upgrade trauma (full-vat integration)', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
-    defaultManagerType:
-      /** @type {import('@agoric/swingset-vat/src/types-external.js').ManagerType} */ (
-        'xs-worker'
-      ), // 'local',
+    defaultManagerType: 'xs-worker',
     bootstrap: 'bootstrap',
     defaultReapInterval: 'never',
     vats: {

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -14,9 +14,6 @@ import { E } from '@endo/far';
 import { prepareSmartWallet } from './smartWallet.js';
 import { shape } from './typeGuards.js';
 
-// Ambient types. Needed only for dev but this does a runtime import.
-import '@agoric/vats/exported.js';
-
 export const privateArgsShape = harden(
   M.splitRecord(
     { storageNode: M.eref(M.remotable('StorageNode')) },

--- a/packages/smart-wallet/test/test-startWalletFactory.js
+++ b/packages/smart-wallet/test/test-startWalletFactory.js
@@ -72,7 +72,7 @@ test('customTermsShape', async t => {
     ),
     {
       message:
-        '{"agoricNames":"[Promise]","assetPublisher":{},"board":"[Promise]","extra":"[Seen]"} - Must not have unexpected properties: ["extra"]',
+        'customTerms: {"agoricNames":"[Promise]","assetPublisher":{},"board":"[Promise]","extra":"[Seen]"} - Must not have unexpected properties: ["extra"]',
     },
   );
 
@@ -89,7 +89,7 @@ test('customTermsShape', async t => {
     ),
     {
       message:
-        '{"agoricNames":"[Promise]"} - Must have missing properties ["board","assetPublisher"]',
+        'customTerms: {"agoricNames":"[Promise]"} - Must have missing properties ["board","assetPublisher"]',
     },
   );
 });
@@ -113,7 +113,7 @@ test('privateArgsShape', async t => {
       { bridgeManager },
     ),
     {
-      message: '{} - Must have missing properties ["storageNode"]',
+      message: 'privateArgs: {} - Must have missing properties ["storageNode"]',
     },
   );
 });

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -185,14 +185,13 @@ harden(prepareExoClassKit);
 
 // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
 /**
- * @template T
  * @template {Record<string | symbol, CallableFunction>} M methods
  * @param {Baggage} baggage
  * @param {string} kindName
  * @param {any} interfaceGuard
  * @param {M} methods
  * @param {DefineKindOptions<{ self: M }>} [options]
- * @returns {T & RemotableBrand<{}, T>}
+ * @returns {M & RemotableBrand<{}, M>}
  */
 export const prepareExo = (
   baggage,
@@ -217,13 +216,13 @@ export const prepareExo = (
 harden(prepareExo);
 
 /**
- * @template {Record<string | symbol, CallableFunction>} T methods
+ * @template {Record<string | symbol, CallableFunction>} M methods
  * @deprecated Use prepareExo instead.
  * @param {Baggage} baggage
  * @param {string} kindName
- * @param {T} methods
- * @param {DefineKindOptions<{ self: T }>} [options]
- * @returns {T & RemotableBrand<{}, T>}
+ * @param {M} methods
+ * @param {DefineKindOptions<{ self: M }>} [options]
+ * @returns {M & RemotableBrand<{}, M>}
  */
 export const prepareSingleton = (
   baggage,

--- a/packages/vat-data/test/test-prepare.js
+++ b/packages/vat-data/test/test-prepare.js
@@ -120,6 +120,7 @@ test('test prepareExo', t => {
   t.throws(() => upCounter.incr(-3), {
     message: 'In "incr" method of (upCounter): arg 0?: -3 - Must be >= 0',
   });
+  // @ts-expect-error intentional
   t.throws(() => upCounter.incr('foo'), {
     message:
       'In "incr" method of (upCounter): arg 0?: string "foo" - Must be a number',

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -283,6 +283,7 @@ const makeWalletFactoryKitFor1 = async address => {
 
   const done = new Set();
   /** @type {import('@agoric/vats/src/core/startWalletFactory').WalletFactoryStartResult['creatorFacet']} */
+  // @ts-expect-error cast mock
   const walletFactory = {
     provideSmartWallet: async (a, _b, nameAdmin) => {
       assert.equal(a, address);

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -1,29 +1,28 @@
 // @ts-check
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { test as unknownTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import path from 'path';
-import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
+import committeeBundle from '@agoric/governance/bundles/bundle-committee.js';
 import {
   makeMockChainStorageRoot,
   setUpZoeForTest,
   withAmountUtils,
 } from '@agoric/inter-protocol/test/supports.js';
-import committeeBundle from '@agoric/governance/bundles/bundle-committee.js';
-import { AmountMath, makeIssuerKit } from '@agoric/ertp';
-import { E, Far } from '@endo/far';
-import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
-import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
-import { makeScalarMapStore } from '@agoric/store';
-import { makeSubscriptionKit } from '@agoric/notifier';
-import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
-import { publishDepositFacet } from '@agoric/smart-wallet/src/walletFactory.js';
 import { WalletName } from '@agoric/internal';
-import { makeBoard } from '../src/lib-board.js';
+import { publishDepositFacet } from '@agoric/smart-wallet/src/walletFactory.js';
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
+import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
+import { E } from '@endo/far';
+import path from 'path';
 import centralSupplyBundle from '../bundles/bundle-centralSupply.js';
-import { makeBridgeProvisionTool } from '../src/provisionPool.js';
-import { makeNameHubKit } from '../src/nameHub.js';
 import { PowerFlags } from '../src/core/basic-behaviors.js';
+import { makeBoard } from '../src/lib-board.js';
+import { makeNameHubKit } from '../src/nameHub.js';
+import { makeBridgeProvisionTool } from '../src/provisionPool.js';
 import { buildRootObject as buildBankRoot } from '../src/vat-bank.js';
+import { makeFakeBankKit } from '../tools/bank-utils.js';
 
 const pathname = new URL(import.meta.url).pathname;
 const dirname = path.dirname(pathname);
@@ -129,28 +128,10 @@ const tools = context => {
   const { zoe, anchor, installs, storageRoot } = context;
   // @ts-expect-error missing mint
   const minted = withAmountUtils(context.minted);
-  const makeBank = () => {
-    const issuers = makeScalarMapStore();
-    [minted, anchor].forEach(kit => issuers.init(kit.brand, kit.issuer));
-    const purses = makeScalarMapStore();
-    [minted, anchor].forEach(kit => {
-      assert(kit.issuer);
-      purses.init(kit.brand, E(kit.issuer).makeEmptyPurse());
-    });
-
-    /** @type {SubscriptionRecord<import('../src/vat-bank.js').AssetDescriptor>} */
-    const { subscription, publication } = makeSubscriptionKit();
-
-    /** @type {import('../src/vat-bank.js').Bank} */
-    const bank = Far('mock bank', {
-      /** @param {Brand} brand */
-      getPurse: brand => purses.get(brand),
-      getAssetSubscription: () => subscription,
-    });
-
-    return { assetPublication: publication, bank };
-  };
-  const { assetPublication, bank: poolBank } = makeBank();
+  const { assetPublication, bank: poolBank } = makeFakeBankKit([
+    minted,
+    anchor,
+  ]);
 
   // Each driver needs its own to avoid state pollution between tests
   context.mockChainStorage = makeMockChainStorageRoot();
@@ -302,7 +283,6 @@ const makeWalletFactoryKitFor1 = async address => {
 
   const done = new Set();
   /** @type {import('@agoric/vats/src/core/startWalletFactory').WalletFactoryStartResult['creatorFacet']} */
-  // @ts-expect-error mock
   const walletFactory = {
     provideSmartWallet: async (a, _b, nameAdmin) => {
       assert.equal(a, address);

--- a/packages/vats/test/upgrading/test-upgrade-vats.js
+++ b/packages/vats/test/upgrading/test-upgrade-vats.js
@@ -26,10 +26,7 @@ test('upgrade vat-board', async t => {
   /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
-    defaultManagerType:
-      /** @type {import('@agoric/swingset-vat/src/types-external.js').ManagerType} */ (
-        'xs-worker'
-      ), // 'local',
+    defaultManagerType: 'xs-worker',
     bootstrap: 'bootstrap',
     defaultReapInterval: 'never',
     vats: {

--- a/packages/vats/tools/bank-utils.js
+++ b/packages/vats/tools/bank-utils.js
@@ -1,0 +1,30 @@
+// @ts-check
+import { makeSubscriptionKit } from '@agoric/notifier';
+import { makeScalarMapStore } from '@agoric/vat-data';
+import { E } from '@endo/far';
+import { Far } from '@endo/marshal';
+
+/**
+ * @param {Array<Pick<IssuerKit, 'brand' | 'issuer'>>} issuerKits
+ */
+export const makeFakeBankKit = issuerKits => {
+  const issuers = makeScalarMapStore();
+  issuerKits.forEach(kit => issuers.init(kit.brand, kit.issuer));
+  const purses = makeScalarMapStore();
+  issuerKits.forEach(kit => {
+    assert(kit.issuer);
+    purses.init(kit.brand, E(kit.issuer).makeEmptyPurse());
+  });
+
+  /** @type {SubscriptionRecord<import('../src/vat-bank.js').AssetDescriptor>} */
+  const { subscription, publication } = makeSubscriptionKit();
+
+  /** @type {import('../src/vat-bank.js').Bank} */
+  const bank = Far('mock bank', {
+    /** @param {Brand} brand */
+    getPurse: brand => purses.get(brand),
+    getAssetSubscription: () => subscription,
+  });
+
+  return { assetPublication: publication, bank };
+};

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -297,7 +297,7 @@ export const makeZCFZygote = async (
       // If the contract provided customTermsShape, validate the customTerms.
       if (customTermsShape) {
         const { brands: _b, issuers: _i, ...customTerms } = terms;
-        mustMatch(harden(customTerms), customTermsShape);
+        mustMatch(harden(customTerms), customTermsShape, 'customTerms');
       }
 
       return terms;
@@ -368,7 +368,7 @@ export const makeZCFZygote = async (
 
       const startFn = start || prepare;
       if (privateArgsShape) {
-        mustMatch(privateArgs, privateArgsShape);
+        mustMatch(privateArgs, privateArgsShape, 'privateArgs');
       }
       // start a contract for the first time
       return E.when(

--- a/packages/zoe/src/contracts/coveredCall-durable.js
+++ b/packages/zoe/src/contracts/coveredCall-durable.js
@@ -82,14 +82,14 @@ const start = async (zcf, _privateArgs, instanceBaggage) => {
     return zcf.makeInvitation(exerciseOption, 'exerciseOption', customDetails);
   };
 
-  const CoveredCallCratorFacetI = M.interface('CoveredCallCratorFacet', {
+  const CoveredCallCreatorFacetI = M.interface('CoveredCallCreatorFacet', {
     makeInvitation: M.call().returns(M.promise()),
   });
 
   const creatorFacet = prepareExo(
     instanceBaggage,
     'creatorFacet',
-    CoveredCallCratorFacetI,
+    CoveredCallCreatorFacetI,
     {
       makeInvitation() {
         return zcf.makeInvitation(makeOption, 'makeCallOption');

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -13,6 +13,7 @@ const ZOE_INVITATION_KIT = 'ZoeInvitationKit';
  * @param {ShutdownWithFailure | undefined} shutdownZoeVat
  */
 export const prepareInvitationKit = (baggage, shutdownZoeVat = undefined) => {
+  /** @type {IssuerKit<'set'> | undefined} */
   let invitationKit;
 
   const invitationKitBaggage = provideDurableMapStore(

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -33,7 +33,6 @@
  * @property {GetBrands} getBrands
  * @property {import('./utils').GetTerms} getTerms
  * @property {GetOfferFilter} getOfferFilter
- * @property {SetOfferFilter} setOfferFilter
  * @property {GetInstallationForInstance} getInstallationForInstance
  * @property {GetInstance} getInstance
  * @property {GetInstallation} getInstallation

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
@@ -8,10 +8,11 @@ import { buildVatController } from '@agoric/swingset-vat';
 const bfile = name => new URL(name, import.meta.url).pathname;
 
 test('coveredCall service upgrade', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     // includeDevDependencies: true, // for vat-data
     /** @type {ManagerType} */
-    defaultManagerType: 'xs-worker', // 'local',
+    defaultManagerType: 'xs-worker',
     bootstrap: 'bootstrap',
     // defaultReapInterval: 'never',
     // defaultReapInterval: 1,

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe-upgrade.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe-upgrade.js
@@ -8,12 +8,10 @@ import { kunser } from '@agoric/swingset-vat/src/lib/kmarshal.js';
 const bfile = name => new URL(name, import.meta.url).pathname;
 
 test('zoe vat upgrade trauma', async t => {
+  /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
-    defaultManagerType:
-      /** @type {import('@agoric/swingset-vat/src/types-external.js').ManagerType} */ (
-        'xs-worker'
-      ), // 'local',
+    defaultManagerType: 'xs-worker',
     bootstrap: 'bootstrap',
     defaultReapInterval: 'never',
     vats: {


### PR DESCRIPTION

refs: #6878

## Description

Work in https://github.com/Agoric/agoric-sdk/pull/7096 that can land sooner to reduce churn and make the upgrade easier to review.

- chore(types): remove ambient
- chore(types): use SwingSetConfig
- chore(spelling): Crator -> Creator
- feat(SwingSet): loadSwingsetConfigFile detects missing files
- chore(bundleTool): improve logging
- chore(startInstance): labels for shape check
- test(provisionPool): extract makeFakeBankKit
- chore(types): fix prepareExo return type
- chore(types): rm absent Zoe service setOfferFilter

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

CI