### PR TITLE
refactor: Simplify {jsconfig,tsconfig}.json files by inheritance

### DIFF
--- a/packages/ERTP/jsconfig.json
+++ b/packages/ERTP/jsconfig.json
@@ -1,16 +1,6 @@
+// This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-    "types": [
-      "node"
-    ]
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.js",
     "src/**/*.ts",

--- a/packages/SwingSet/jsconfig.json
+++ b/packages/SwingSet/jsconfig.json
@@ -1,14 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "lib/**/*.js",
     "src/**/*.js",

--- a/packages/access-token/jsconfig.json
+++ b/packages/access-token/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.js",
     "test/**/*.js"

--- a/packages/agoric-cli/jsconfig.json
+++ b/packages/agoric-cli/jsconfig.json
@@ -1,12 +1,8 @@
 // This file can contain .js-specific Typescript compiler config.
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
+    "checkJs": false,
   },
   "include": [
     "*.js",

--- a/packages/assert/jsconfig.json
+++ b/packages/assert/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.js",
   ],

--- a/packages/cache/jsconfig.json
+++ b/packages/cache/jsconfig.json
@@ -1,14 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "public/**/*.js",

--- a/packages/casting/jsconfig.json
+++ b/packages/casting/jsconfig.json
@@ -1,14 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "public/**/*.js",

--- a/packages/cosmic-proto/tsconfig.json
+++ b/packages/cosmic-proto/tsconfig.json
@@ -1,13 +1,9 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "declaration": true,
-    "target": "esnext",
-    "module": "esnext",
     "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
     "outDir": "dist"
   },
   "include": [

--- a/packages/cosmic-swingset/jsconfig.json
+++ b/packages/cosmic-swingset/jsconfig.json
@@ -1,12 +1,8 @@
 // This file can contain .js-specific Typescript compiler config.
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
+    "checkJs": false,
   },
   "include": [
     "calc-*.js",

--- a/packages/deploy-script-support/jsconfig.json
+++ b/packages/deploy-script-support/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "src/**/*.js",

--- a/packages/deployment/jsconfig.json
+++ b/packages/deployment/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.js",
     "test/**/*.js"

--- a/packages/governance/jsconfig.json
+++ b/packages/governance/jsconfig.json
@@ -1,13 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "build",
     "scripts",

--- a/packages/import-manager/jsconfig.json
+++ b/packages/import-manager/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/inter-protocol/jsconfig.json
+++ b/packages/inter-protocol/jsconfig.json
@@ -1,14 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "globals.d.ts",
     "scripts/**/*.js",

--- a/packages/internal/jsconfig.json
+++ b/packages/internal/jsconfig.json
@@ -1,17 +1,10 @@
+// This file can contain .js-specific Typescript compiler config.
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
     // Disable b/c @endo/init can't pass noImplicitAny
     "checkJs": false,
-    "noEmit": true,
     "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-    "types": [
-      "node"
-    ]
   },
   "include": [
     "*.js",

--- a/packages/notifier/jsconfig.json
+++ b/packages/notifier/jsconfig.json
@@ -1,14 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.js",
     "test/**/*.js",

--- a/packages/pegasus/jsconfig.json
+++ b/packages/pegasus/jsconfig.json
@@ -1,12 +1,8 @@
 // This file can contain .js-specific Typescript compiler config.
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
+    "checkJs": false,
   },
   "include": [
     "*.js",

--- a/packages/same-structure/jsconfig.json
+++ b/packages/same-structure/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/sharing-service/jsconfig.json
+++ b/packages/sharing-service/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/smart-wallet/jsconfig.json
+++ b/packages/smart-wallet/jsconfig.json
@@ -1,13 +1,6 @@
+// This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/solo/jsconfig.json
+++ b/packages/solo/jsconfig.json
@@ -1,12 +1,8 @@
 // This file can contain .js-specific Typescript compiler config.
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
+    "checkJs": false,
   },
   "include": [
     "public/**/*.js",

--- a/packages/sparse-ints/jsconfig.json
+++ b/packages/sparse-ints/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.js",
     "test/**/*.js"

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -29,11 +29,6 @@
     "src/",
     "NEWS.md"
   ],
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
   "eslintIgnore": [
     "bundle-*.js"
   ],

--- a/packages/spawner/jsconfig.json
+++ b/packages/spawner/jsconfig.json
@@ -1,19 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    /*
-      // The following flags are for creating .d.ts files:
-      "noEmit": false,
-      "declaration": true,
-      "emitDeclarationOnly": true,
-  */
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/stat-logger/jsconfig.json
+++ b/packages/stat-logger/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.js",
     "test/**/*.js"

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -32,10 +32,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
   }
 }

--- a/packages/store/jsconfig.json
+++ b/packages/store/jsconfig.json
@@ -1,14 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.js",
     "test/**/*.js",

--- a/packages/swing-store/jsconfig.json
+++ b/packages/swing-store/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.js",
     "test/**/*.js",

--- a/packages/swing-store/test/test-hasher.js
+++ b/packages/swing-store/test/test-hasher.js
@@ -32,6 +32,6 @@ test('createSHA256', t => {
 
   const h4 = createSHA256();
   h4.finish();
-  t.throws(h4.add);
-  t.throws(h4.finish);
+  t.throws(() => h4.add('a'));
+  t.throws(() => h4.finish());
 });

--- a/packages/swingset-liveslots/jsconfig.json
+++ b/packages/swingset-liveslots/jsconfig.json
@@ -1,13 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/swingset-runner/jsconfig.json
+++ b/packages/swingset-runner/jsconfig.json
@@ -1,14 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "demo/**/*.js",

--- a/packages/telemetry/jsconfig.json
+++ b/packages/telemetry/jsconfig.json
@@ -1,14 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "scripts",

--- a/packages/time/jsconfig.json
+++ b/packages/time/jsconfig.json
@@ -1,13 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "build",
     "scripts",

--- a/packages/ui-components/jsconfig.json
+++ b/packages/ui-components/jsconfig.json
@@ -1,12 +1,8 @@
 // This file can contain .js-specific Typescript compiler config.
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
+    "checkJs": false,
     "jsx": "react",
   },
   "include": [

--- a/packages/vat-data/tsconfig.json
+++ b/packages/vat-data/tsconfig.json
@@ -1,17 +1,8 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
-    "skipLibCheck": true,
-
-    "allowJs": true,
-    "checkJs": true,
     "strict": true,
     "noImplicitAny": false, // for compat with peer packages using ambient types
-    "noImplicitThis": true,
-
-    "noEmit": true,
   },
   "include": [
     "src/**/*.js",

--- a/packages/vats/jsconfig.json
+++ b/packages/vats/jsconfig.json
@@ -1,11 +1,7 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
+    "checkJs": false,
   },
   "include": [
     "*.js",

--- a/packages/wallet/api/jsconfig.json
+++ b/packages/wallet/api/jsconfig.json
@@ -1,13 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../../tsconfig.json",
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/web-components/jsconfig.json
+++ b/packages/web-components/jsconfig.json
@@ -1,12 +1,8 @@
 // This file can contain .js-specific Typescript compiler config.
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
+    "checkJs": false,
   },
   "include": [
     "*.js",

--- a/packages/xsnap-lockdown/jsconfig.json
+++ b/packages/xsnap-lockdown/jsconfig.json
@@ -1,14 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "lib/**/*.js",

--- a/packages/xsnap/jsconfig.json
+++ b/packages/xsnap/jsconfig.json
@@ -1,14 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "*.js",
     "lib/**/*.js",

--- a/packages/zoe/jsconfig.json
+++ b/packages/zoe/jsconfig.json
@@ -1,13 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "checkJs": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-  },
+  "extends": "../../tsconfig.json",
   "include": [
     "contractFacet.js",
     "scripts/**/*.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,20 @@
 {
-    "compilerOptions": {
-      "target": "esnext",
-      "module": "esnext",
-      "moduleResolution": "node",
-      "skipLibCheck": true,
-  
-      "allowJs": true,
-      "checkJs": true,
-      "strict": true,
-  
-      "noEmit": true,
-    },
-    "include": [
-      ".eslintrc.cjs",
-    ]
-  }
-  
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+
+    "allowJs": true,
+    "checkJs": true,
+    "strict": false,
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+
+    "noEmit": true
+  },
+  "include": [
+    ".eslintrc.cjs"
+  ]
+}


### PR DESCRIPTION
## Description

This applies changes like those of https://github.com/endojs/endo/pull/1499 to this repository. It is a step on the way to once again using type-aware linting as in https://github.com/endojs/endo/pull/1500, but that needs to wait behind higher-priority Vaults work.

### Security Considerations

n/a

### Scaling Considerations

This decreases the runtime of top-level `yarn lint`, but only by about 10%.

### Documentation Considerations

n/a

### Testing Considerations

n/a