### PR TITLE
feat(bundleTool): color the console output

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -21,16 +21,15 @@
     "lint:eslint": "eslint ."
   },
   "devDependencies": {
-    "@types/microtime": "^2.1.0",
-    "better-sqlite3": "^7.5.0",
     "@types/better-sqlite3": "^7.5.0",
+    "@types/microtime": "^2.1.0",
     "@types/tmp": "^0.2.0",
+    "better-sqlite3": "^7.5.0",
     "tmp": "^0.2.1"
   },
   "dependencies": {
     "@agoric/assert": "^0.5.1",
     "@agoric/internal": "^0.2.1",
-    "@endo/nat": "^4.1.0",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swing-store": "^0.8.1",
@@ -51,6 +50,7 @@
     "@endo/nat": "^4.1.23",
     "@endo/promise-kit": "^0.2.52",
     "@endo/zip": "^0.2.28",
+    "ansi-styles": "^6.2.1",
     "anylogger": "^0.21.0",
     "import-meta-resolve": "^2.2.1",
     "microtime": "^3.1.0",

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -2,6 +2,7 @@
 import bundleSource from '@endo/bundle-source';
 import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
 import { makePromiseKit } from '@endo/promise-kit';
+import styles from 'ansi-styles'; // less authority than 'chalk'
 
 const { details: X, quote: q, Fail } = assert;
 
@@ -166,15 +167,22 @@ export const makeBundleCache = (wr, bundleOptions, cwd, readPowers) => {
         meta = await validate(targetName, rootPath);
         const { bundleTime, contents } = meta;
         log(
+          styles.dim.open,
           `${wr}`,
           toBundleName(targetName),
           'valid:',
           contents.length,
           'files bundled at',
           bundleTime,
+          styles.dim.close,
         );
       } catch (invalid) {
-        console.error('ERROR in bundleTool:', invalid.message);
+        console.error(
+          styles.red.open,
+          'ERROR in bundleTool:',
+          invalid.message,
+          styles.red.close,
+        );
       }
     }
     if (!meta) {

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -57,7 +57,7 @@
     "@endo/promise-kit": "^0.2.52",
     "@iarna/toml": "^2.2.3",
     "anylogger": "^0.21.0",
-    "chalk": "^2.4.2",
+    "chalk": "^5.2.0",
     "commander": "^10.0.0",
     "dd-trace": "^3.3.0",
     "deterministic-json": "^1.0.5",

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -22,7 +22,7 @@
     "@agoric/assert": "^0.5.1",
     "@endo/init": "^0.5.52",
     "@endo/marshal": "^0.8.1",
-    "chalk": "^2.4.2",
+    "chalk": "^5.2.0",
     "deterministic-json": "^1.0.5",
     "inquirer": "^8.2.2",
     "minimist": "^1.2.0",


### PR DESCRIPTION
no ticket. faster to implement than to file.

## Description

Before:
<img width="955" alt="Screenshot 2023-03-03 at 11 20 16 AM" src="https://user-images.githubusercontent.com/21505/222808009-c8770e67-0a71-4564-9444-ec05244bcf70.png">

After:
<img width="931" alt="Screenshot 2023-03-03 at 11 17 45 AM" src="https://user-images.githubusercontent.com/21505/222807943-d5cdce0f-4da6-4644-a67e-653c7ff0a090.png">


### Security Considerations

Adds a dependency in swingset on `ansi-styles`. This is just a bunch of string helpers. We could have a local module if necessary.

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

screenshots. CI might have some extra output since this doesn't detect whether the terminal supports colors. But bundleTool is meant to run locally.