### PR TITLE
6678 assetRegistry through walletFactory upgrade

### DIFF
--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -27,6 +27,7 @@
     "@agoric/ertp": "^0.15.3",
     "@agoric/internal": "^0.2.1",
     "@endo/nat": "^4.1.0",
+    "@endo/promise-kit": "^0.2.52",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swingset-vat": "^0.30.2",

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -55,7 +55,7 @@ export const makeOfferExecutor = ({
      *
      * @param {OfferSpec} offerSpec
      * @returns {Promise<void>} when the offer has been sent to Zoe; payouts go into this wallet's purses
-     * @throws if any parts of the offer can be determined synchronously to be invalid
+     * @throws if any parts of the offer are determined to be invalid before calling Zoe's `offer()`
      */
     async executeOffer(offerSpec) {
       logger.info('starting executeOffer', offerSpec.id);
@@ -180,7 +180,11 @@ export const makeOfferExecutor = ({
           handleError,
         );
       };
-      await tryBody().catch(err => handleError(err));
+      await tryBody().catch(err => {
+        handleError(err);
+        // propagate to caller
+        throw err;
+      });
     },
   };
 };

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -539,12 +539,12 @@ export const prepareSmartWallet = (baggage, shared) => {
       },
     },
     {
-      finish: async ({ state, facets }) => {
+      finish: ({ state, facets }) => {
         const { invitationPurse } = state;
         const { helper } = facets;
 
         // @ts-expect-error RemotePurse cast
-        helper.watchPurse(invitationPurse);
+        void helper.watchPurse(invitationPurse);
       },
     },
   );

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -22,6 +22,7 @@ import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeLoopback } from '@endo/captp';
 import { E, Far } from '@endo/far';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { makeFakeBankKit } from '@agoric/vats/tools/bank-utils.js';
 
 export { ActionType };
 
@@ -142,20 +143,14 @@ export const makeMockTestSpace = async log => {
 
   produce.testFirstAnchorKit.resolve(makeIssuerKit('AUSD', 'nat'));
 
+  const fakeBankKit = makeFakeBankKit([]);
+
   produce.bankManager.resolve(
     Promise.resolve(
       Far(
         'mockBankManager',
         /** @type {any} */ ({
-          getBankForAddress: _a =>
-            Far('mockBank', {
-              getPurse: () => ({
-                deposit: async (_, _x) => {
-                  assert.fail('not impl');
-                },
-              }),
-              getAssetSubscription: () => assert.fail('not impl'),
-            }),
+          getBankForAddress: _a => fakeBankKit.bank,
         }),
       ),
     ),

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -74,12 +74,13 @@ test('avoid O(wallets) storage writes for a new asset', async t => {
   const base = await simulate(2, 'ibc/dai1', 'DAI_axl');
   const exp = await simulate(6, 'ibc/dai2', 'DAI_grv');
 
-  t.log({
-    base: { wallets: base.qty, writes: base.addedWrites },
-    test: { wallets: exp.qty + base.qty, writes: exp.addedWrites },
-  });
   t.true(
     exp.addedWrites <= (base.addedWrites * exp.qty) / base.qty / 2,
     'actual writes should be less than half of linear growth',
   );
+
+  // a stronger requirement for Cosmos balances, though that's
+  // the only kind of balance we have yet.
+  t.is(base.addedWrites, 0);
+  t.is(exp.addedWrites, 0);
 });

--- a/packages/smart-wallet/test/test-walletFactory.js
+++ b/packages/smart-wallet/test/test-walletFactory.js
@@ -60,8 +60,7 @@ test('bridge handler', async t => {
     lastOfferId: -1,
   });
 
-  assert(t.context.sendToBridge);
-  const res = await t.context.sendToBridge({
+  const validMsg = {
     type: ActionType.WALLET_SPEND_ACTION,
     owner: mockAddress1,
     // consider a helper for each action type
@@ -72,8 +71,11 @@ test('bridge handler', async t => {
     ),
     blockTime: 0,
     blockHeight: 0,
+  };
+  assert(t.context.sendToBridge);
+  await t.throwsAsync(t.context.sendToBridge(validMsg), {
+    message: 'no invitation match (0 description and 0 instance)',
   });
-  t.is(res, undefined);
 
   t.deepEqual(await headValue(updates), {
     updated: 'offerStatus',
@@ -117,8 +119,9 @@ test('bridge with offerId string', async t => {
     blockTime: 0,
     blockHeight: 0,
   };
-  const res = await t.context.sendToBridge(validMsg);
-  t.is(res, undefined);
+  await t.throwsAsync(t.context.sendToBridge(validMsg), {
+    message: 'no invitation match (0 description and 0 instance)',
+  });
 
   // Verify it would have failed with a different 'type'.
   // This arguably belongs in a new test but putting it here makes clear

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -39,7 +39,12 @@ export const makeRunUtils = (controller, log = (..._) => {}) => {
     log('runMethod', method, args, 'at', cranksRun);
     assert(Array.isArray(args));
 
-    await mutex.get();
+    try {
+      // this promise for the last lock may fail
+      await mutex.get();
+    } catch {
+      // noop because the result will resolve for the previous runMethod return
+    }
 
     const kpid = controller.queueToVatRoot('bootstrap', method, args);
 

--- a/packages/vats/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-integration.js
@@ -140,26 +140,21 @@ test('close vault', async t => {
     updated: 'offerStatus',
     status: { id: 'open-vault', numWantsSatisfied: 1 },
   });
-
   t.log('try giving more than is available in the purse/vbank');
-  await wd.executeOfferMaker(
-    Offers.vaults.CloseVault,
+  await t.throwsAsync(
+    wd.executeOfferMaker(
+      Offers.vaults.CloseVault,
+      {
+        offerId: 'close-extreme',
+        collateralBrandKey,
+        giveMinted: 99_999_999.999_999,
+      },
+      'open-vault',
+    ),
     {
-      offerId: 'close-extreme',
-      collateralBrandKey,
-      giveMinted: 99_999_999.999_999,
+      message: /^Withdrawal .* failed because the purse only contained .*/,
     },
-    'open-vault',
   );
-  t.like(wd.getLatestUpdateRecord(), {
-    updated: 'offerStatus',
-    status: {
-      id: 'close-extreme',
-      numWantsSatisfied: undefined,
-      error:
-        'Error: Withdrawal of {"brand":"[Alleged: IST brand]","value":"[99999999999999n]"} failed because the purse only contained {"brand":"[Alleged: IST brand]","value":"[14999500n]"}',
-    },
-  });
 
   await wd.executeOfferMaker(
     Offers.vaults.CloseVault,

--- a/packages/vats/tools/bank-utils.js
+++ b/packages/vats/tools/bank-utils.js
@@ -9,8 +9,10 @@ import { Far } from '@endo/marshal';
  */
 export const makeFakeBankKit = issuerKits => {
   const issuers = makeScalarMapStore();
-  issuerKits.forEach(kit => issuers.init(kit.brand, kit.issuer));
   const purses = makeScalarMapStore();
+
+  // XXX setup purses without publishing
+  issuerKits.forEach(kit => issuers.init(kit.brand, kit.issuer));
   issuerKits.forEach(kit => {
     assert(kit.issuer);
     purses.init(kit.brand, E(kit.issuer).makeEmptyPurse());
@@ -19,6 +21,23 @@ export const makeFakeBankKit = issuerKits => {
   /** @type {SubscriptionRecord<import('../src/vat-bank.js').AssetDescriptor>} */
   const { subscription, publication } = makeSubscriptionKit();
 
+  /**
+   * @param {string} denom lower-level denomination string
+   * @param {string} issuerName
+   * @param {string} proposedName
+   * @param {import('../src/vat-bank.js').AssetIssuerKit} kit ERTP issuer kit
+   */
+  const addAsset = (denom, issuerName, proposedName, kit) => {
+    issuers.init(kit.brand, kit.issuer);
+    purses.init(kit.brand, E(kit.issuer).makeEmptyPurse());
+    publication.updateState({
+      ...kit,
+      denom,
+      issuerName,
+      proposedName,
+    });
+  };
+
   /** @type {import('../src/vat-bank.js').Bank} */
   const bank = Far('mock bank', {
     /** @param {Brand} brand */
@@ -26,5 +45,5 @@ export const makeFakeBankKit = issuerKits => {
     getAssetSubscription: () => subscription,
   });
 
-  return { assetPublication: publication, bank };
+  return { addAsset, assetPublication: publication, bank };
 };


### PR DESCRIPTION
closes: #6878

## Description

6878 issue said,
> It will have to hold the issuers from before upgrade. This can be done using ZCF saveIssuer and let the ZCF be responsible for its durability. The MapStore to BrandDescription need not be durable since it's part of shared made in prepare.

This doesn't do that but it adds a test to verify that it isn't necessary. A Bank's `getAssetSubscription` comes from a `SubscriptionKit` which uses a pinnedHistoryTopic which is prefix lossy. https://github.com/Agoric/agoric-sdk/blob/71a1db7a082489aade25625298c3f4592cf24402/packages/notifier/src/subscriber.js#L57-L60

So each time an `observeIteration` is started with it, all the values will be consumed. Therefore the contract doesn't need to keep a history of them. On upgrade it reconstructs its non-durable maps using the stream.

To test this I tried to check use vstorage to confirm the offers execute, but the "secondOffer" one wasn't showing up. I don't know why and didn't want to spend too much time down that rabbit hole. Instead I made `executeOffer` throw its exceptions after trying to recover from it. (I think we had a handler to ensure there was always cleanup but it also swallowed the error unnecessarily.)

This uncovered a bug in the runUtils with calls after a rejection. This fixes that as well.

### Security Considerations

--

### Scaling Considerations

If there are many kinds of assets, walletFactory upgrade will triggeer iterating over all of them. I expect it to be order 10 until this contract is upgraded.

### Documentation Considerations

--

### Testing Considerations

New test