### PR TITLE
fix(zoe): payments more recoverable

### DIFF
--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -55,7 +55,7 @@ const setupIssuerKit = (
   // Attenuate the powerful authority to mint and change balances
   /** @type {PaymentLedger<K>} */
   // @ts-expect-error could be instantiated with different subtype of AssetKind
-  const { issuer, mint, brand } = preparePaymentLedger(
+  const { issuer, mint, brand, mintRecoveryPurse } = preparePaymentLedger(
     issuerBaggage,
     name,
     assetKind,
@@ -68,6 +68,7 @@ const setupIssuerKit = (
     brand,
     issuer,
     mint,
+    mintRecoveryPurse,
     displayInfo: cleanDisplayInfo,
   });
 };

--- a/packages/ERTP/src/legacy-payment-helpers.js
+++ b/packages/ERTP/src/legacy-payment-helpers.js
@@ -1,0 +1,101 @@
+import { mustMatch } from '@agoric/store';
+import { E } from '@endo/far';
+import { AmountMath } from './amountMath.js';
+
+const { Fail } = assert;
+
+// This file contains safer alternatives to the similarly named helpers on
+// issuer. These are parameterized by a purse. Any payments created by these
+// helper functions are in the recovery set of that purse until otherwise
+// used up.
+//
+// One helper is less safe in one way: `combine` is not failure atomic. If
+// it fails, some of the input payments may have been used up. However, even
+// in that case, no assets should be lost. The assets from the used up payments
+// will be in the argument purse.
+
+/**
+ * @param {ERef<Purse>} purse
+ * @param {ERef<Payment>} srcPaymentP
+ * @param {Pattern} [optAmountShape]
+ */
+export const claim = async (purse, srcPaymentP, optAmountShape = undefined) => {
+  const srcPayment = await srcPaymentP;
+  const amount = await E(purse).deposit(srcPayment, optAmountShape);
+  return E(purse).withdraw(amount);
+};
+harden(claim);
+
+/**
+ * Note: Not failure atomic. If any of the deposits fail, or the total does not
+ * match optTotalAmount, some payments may still have been deposited.
+ *
+ * @param {ERef<Purse>} purse
+ * @param {ERef<Payment>[]} srcPaymentsPs
+ * @param {Pattern} [optTotalAmount]
+ */
+export const combine = async (
+  purse,
+  srcPaymentsPs,
+  optTotalAmount = undefined,
+) => {
+  const [brand, ...srcPayments] = await Promise.all([
+    E(purse).getAllegedBrand(),
+    ...srcPaymentsPs,
+  ]);
+  const emptyAmount = AmountMath.makeEmpty(
+    brand,
+    brand.getDisplayInfo().assetKind,
+  );
+  const amountPs = srcPayments.map(srcPayment => E(purse).deposit(srcPayment));
+  const amounts = await Promise.all(amountPs);
+  const total = amounts.reduce(
+    (x, y) => AmountMath.add(x, y, brand),
+    emptyAmount,
+  );
+  if (optTotalAmount !== undefined) {
+    mustMatch(total, optTotalAmount, 'amount');
+  }
+  return E(purse).withdraw(total);
+};
+harden(combine);
+
+/**
+ * @param {ERef<Purse>} purse
+ * @param {ERef<Payment>} srcPaymentP
+ * @param {Amount} paymentAmountA
+ */
+export const split = async (purse, srcPaymentP, paymentAmountA) => {
+  const srcPayment = await srcPaymentP;
+  const srcAmount = await E(purse).deposit(srcPayment);
+  const paymentAmountB = AmountMath.subtract(srcAmount, paymentAmountA);
+  return Promise.all([
+    E(purse).withdraw(paymentAmountA),
+    E(purse).withdraw(paymentAmountB),
+  ]);
+};
+harden(split);
+
+/**
+ * @param {ERef<Purse>} purse
+ * @param {ERef<Payment>} srcPaymentP
+ * @param {Amount[]} amounts
+ */
+export const splitMany = async (purse, srcPaymentP, amounts) => {
+  const srcPayment = await srcPaymentP;
+  const srcAmount = await E(purse).deposit(srcPayment);
+  const brand = srcAmount.brand;
+  const emptyAmount = AmountMath.makeEmpty(
+    brand,
+    brand.getDisplayInfo().assetKind,
+  );
+  const total = amounts.reduce(
+    (x, y) => AmountMath.add(x, y, brand),
+    emptyAmount,
+  );
+  AmountMath.isEqual(srcAmount, total) ||
+    Fail`rights were not conserved: ${total} vs ${srcAmount}`;
+
+  return Promise.all(amounts.map(amount => E(purse).withdraw(amount)));
+};
+harden(splitMany);

--- a/packages/ERTP/src/legacy-payment-helpers.js
+++ b/packages/ERTP/src/legacy-payment-helpers.js
@@ -4,14 +4,16 @@ import { AmountMath } from './amountMath.js';
 
 const { Fail } = assert;
 
-// This file contains safer alternatives to the similarly named helpers on
-// issuer. These are parameterized by a purse. Any payments created by these
+// This file contains safer helper function alternatives to the
+// similarly named methods on issuer.
+// These are parameterized by a purse. Any payments created by these
 // helper functions are in the recovery set of that purse until otherwise
 // used up.
 //
-// One helper is less safe in one way: `combine` is not failure atomic. If
-// it fails, some of the input payments may have been used up. However, even
-// in that case, no assets should be lost. The assets from the used up payments
+// One of these helper functions is less safe in one way:
+// `combine` is not failure atomic. If the `combine` helper function
+// fails, some of the input payments may have been used up. However, even
+// in that case, no assets would be lost. The assets from the used up payments
 // will be in the argument purse.
 
 /**
@@ -23,8 +25,9 @@ const { Fail } = assert;
  */
 export const claim = async (purse, srcPaymentP, optAmountShape = undefined) => {
   const srcPayment = await srcPaymentP;
-  const amount = await E(purse).deposit(srcPayment, optAmountShape);
-  return E(purse).withdraw(amount);
+  return E.when(E(purse).deposit(srcPayment, optAmountShape), amount =>
+    E(purse).withdraw(amount),
+  );
 };
 harden(claim);
 

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -1,14 +1,18 @@
 /* eslint-disable no-use-before-define */
 import { isPromise } from '@endo/promise-kit';
-import { assertCopyArray } from '@endo/marshal';
 import { mustMatch, M } from '@agoric/store';
-import { provideDurableWeakMapStore, prepareExo } from '@agoric/vat-data';
+import {
+  provideDurableWeakMapStore,
+  prepareExo,
+  provideDurableSetStore,
+} from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { preparePaymentKind } from './payment.js';
 import { preparePurseKind } from './purse.js';
 
 import '@agoric/store/exported.js';
 import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
+import { claim, combine, split, splitMany } from './legacy-payment-helpers.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -104,7 +108,6 @@ export const preparePaymentLedger = (
     },
   });
 
-  const emptyAmount = AmountMath.makeEmpty(brand, assetKind);
   const amountShape = amountShapeFromElementShape(
     brand,
     assetKind,
@@ -206,7 +209,6 @@ export const preparePaymentLedger = (
   /** @type {(allegedAmount: Amount) => Amount} */
   const coerce = allegedAmount => AmountMath.coerce(brand, allegedAmount);
   /** @type {(left: Amount, right: Amount) => boolean } */
-  const isEqual = (left, right) => AmountMath.isEqual(left, right, brand);
 
   /**
    * Methods like deposit() have an optional second parameter
@@ -235,65 +237,6 @@ export const preparePaymentLedger = (
       Fail`${payment} was not a live payment for brand ${q(
         brand,
       )}. It could be a used-up payment, a payment for another brand, or it might not be a payment at all.`;
-  };
-
-  /**
-   * Reallocate assets from the `payments` passed in to new payments
-   * created and returned, with balances from `newPaymentBalances`.
-   * Enforces that total assets are conserved.
-   *
-   * Note that this is not the only operation that moves assets.
-   * `purse.deposit` and `purse.withdraw` move assets between a purse and
-   * a payment, and so must also enforce conservation there.
-   *
-   * @param {Payment[]} payments
-   * @param {Amount[]} newPaymentBalances
-   * @returns {Payment[]}
-   */
-  const moveAssets = (payments, newPaymentBalances) => {
-    assertCopyArray(payments, 'payments');
-    assertCopyArray(newPaymentBalances, 'newPaymentBalances');
-
-    // There may be zero, one, or many payments as input to
-    // moveAssets. We want to protect against someone passing in
-    // what appears to be multiple payments that turn out to actually
-    // be the same payment (an aliasing issue). The `combine` method
-    // legitimately needs to take in multiple payments, but we don't
-    // need to pay the costs of protecting against aliasing for the
-    // other uses.
-
-    if (payments.length > 1) {
-      const antiAliasingStore = new Set();
-      payments.forEach(payment => {
-        !antiAliasingStore.has(payment) ||
-          Fail`same payment ${payment} seen twice`;
-        antiAliasingStore.add(payment);
-      });
-    }
-
-    const total = payments.map(paymentLedger.get).reduce(add, emptyAmount);
-
-    const newTotal = newPaymentBalances.reduce(add, emptyAmount);
-
-    // Invariant check
-    isEqual(total, newTotal) ||
-      Fail`rights were not conserved: ${total} vs ${newTotal}`;
-
-    let newPayments;
-    try {
-      // COMMIT POINT
-      payments.forEach(payment => deletePayment(payment));
-
-      newPayments = newPaymentBalances.map(balance => {
-        const newPayment = makePayment();
-        initPayment(newPayment, balance, undefined);
-        return newPayment;
-      });
-    } catch (err) {
-      shutdownLedgerWithFailure(err);
-      throw err;
-    }
-    return harden(newPayments);
   };
 
   /**
@@ -430,73 +373,71 @@ export const preparePaymentLedger = (
       return paymentBalance;
     },
     /**
+     * Inherent to the nature of the Issuer API, this method is less safe
+     * than the similarly named helper function in legacy-payment-helpers.js
+     * since those helper functions will associate any newly created payment
+     * with the recovery set of the argument purse. The methods here are
+     * now trivial wrappers around those helpers, using a `makeEmptyPurse()`
+     * to make the needed purse, which they unsafely then drop on the floor.
+     *
+     * @deprecated Use helper function from legacy-payment-helpers.js
      * @param {Payment} srcPayment awaited by callWhen
-     * @param {Pattern} optAmountShape
+     * @param {Pattern} [optAmountShape]
      */
     claim(srcPayment, optAmountShape = undefined) {
-      // IssuerI delays calling this method until `srcPayment` is a Remotable
-      assertLivePayment(srcPayment);
-      const srcPaymentBalance = paymentLedger.get(srcPayment);
-      assertAmountConsistent(srcPaymentBalance, optAmountShape);
-      // Note COMMIT POINT within moveAssets.
-      const [payment] = moveAssets(
-        harden([srcPayment]),
-        harden([srcPaymentBalance]),
-      );
-      return payment;
-    },
-    combine(fromPaymentsPArray, optTotalAmount = undefined) {
-      // IssuerI does *not* delay calling `combine`, but rather leaves it
-      // to `combine` to delay further processing until all the elements of
-      // `fromPaymentsPArray` have fulfilled.
-
-      // Payments in `fromPaymentsPArray` must be distinct. Alias
-      // checking is delegated to the `moveAssets` function.
-      return Promise.all(fromPaymentsPArray).then(fromPaymentsArray => {
-        fromPaymentsArray.every(assertLivePayment);
-        const totalPaymentsBalance = fromPaymentsArray
-          .map(paymentLedger.get)
-          .reduce(add, emptyAmount);
-        assertAmountConsistent(totalPaymentsBalance, optTotalAmount);
-        // Note COMMIT POINT within moveAssets.
-        const [payment] = moveAssets(
-          harden(fromPaymentsArray),
-          harden([totalPaymentsBalance]),
-        );
-        return payment;
-      });
+      return claim(makeEmptyPurse(), srcPayment, optAmountShape);
     },
     /**
+     * Inherent to the nature of the Issuer API, this method is less safe
+     * than the similarly named helper function in legacy-payment-helpers.js
+     * since those helper functions will associate any newly created payment
+     * with the recovery set of the argument purse. The methods here are
+     * now trivial wrappers around those helpers, using a `makeEmptyPurse()`
+     * to make the needed purse, which they unsafely then drop on the floor.
+     *
+     * @deprecated Use helper function from legacy-payment-helpers.js
+     * @param {ERef<Payment>[]} fromPaymentsPArray
+     * @param {Pattern} [optTotalAmount]
+     */
+    combine(fromPaymentsPArray, optTotalAmount = undefined) {
+      return combine(makeEmptyPurse(), fromPaymentsPArray, optTotalAmount);
+    },
+    /**
+     * Inherent to the nature of the Issuer API, this method is less safe
+     * than the similarly named helper function in legacy-payment-helpers.js
+     * since those helper functions will associate any newly created payment
+     * with the recovery set of the argument purse. The methods here are
+     * now trivial wrappers around those helpers, using a `makeEmptyPurse()`
+     * to make the needed purse, which they unsafely then drop on the floor.
+     *
+     * @deprecated Use helper function from legacy-payment-helpers.js
      * @param {Payment} srcPayment awaited by callWhen
      * @param {Amount} paymentAmountA
      */
     split(srcPayment, paymentAmountA) {
-      // IssuerI delays calling this method until `srcPayment` is a Remotable
-      paymentAmountA = coerce(paymentAmountA);
-      assertLivePayment(srcPayment);
-      const srcPaymentBalance = paymentLedger.get(srcPayment);
-      const paymentAmountB = subtract(srcPaymentBalance, paymentAmountA);
-      // Note COMMIT POINT within moveAssets.
-      const newPayments = moveAssets(
-        harden([srcPayment]),
-        harden([paymentAmountA, paymentAmountB]),
-      );
-      return newPayments;
+      return split(makeEmptyPurse(), srcPayment, paymentAmountA);
     },
     /**
+     * Inherent to the nature of the Issuer API, this method is less safe
+     * than the similarly named helper function in legacy-payment-helpers.js
+     * since those helper functions will associate any newly created payment
+     * with the recovery set of the argument purse. The methods here are
+     * now trivial wrappers around those helpers, using a `makeEmptyPurse()`
+     * to make the needed purse, which they unsafely then drop on the floor.
+     *
+     * @deprecated Use helper function from legacy-payment-helpers.js
      * @param {Payment} srcPayment awaited by callWhen
      * @param {*} amounts
      */
     splitMany(srcPayment, amounts) {
-      // IssuerI delays calling this method until `srcPayment` is a Remotable
-      assertLivePayment(srcPayment);
-      assertCopyArray(amounts, 'amounts');
-      amounts = amounts.map(coerce);
-      // Note COMMIT POINT within moveAssets.
-      const newPayments = moveAssets(harden([srcPayment]), harden(amounts));
-      return newPayments;
+      return splitMany(makeEmptyPurse(), srcPayment, amounts);
     },
   });
+
+  const mintRecoverySet = provideDurableSetStore(
+    issuerBaggage,
+    `${name} mintRecoverySet`,
+  );
 
   /** @type {Mint<K>} */
   const mint = prepareExo(issuerBaggage, `${name} mint`, MintI, {
@@ -508,8 +449,11 @@ export const preparePaymentLedger = (
       newAmount = coerce(newAmount);
       mustMatch(newAmount, amountShape, 'minted amount');
       const payment = makePayment();
-      initPayment(payment, newAmount, undefined);
+      initPayment(payment, newAmount, mintRecoverySet);
       return payment;
+    },
+    getRecoverySet() {
+      return mintRecoverySet.snapshot();
     },
   });
 

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -176,13 +176,11 @@ export const preparePaymentLedger = (
    *
    * @param {Payment} payment
    * @param {Amount} amount
-   * @param {SetStore<Payment>} [optRecoverySet]
+   * @param {SetStore<Payment>} recoverySet
    */
-  const initPayment = (payment, amount, optRecoverySet = undefined) => {
-    if (optRecoverySet !== undefined) {
-      optRecoverySet.add(payment);
-      paymentRecoverySets.init(payment, optRecoverySet);
-    }
+  const initPayment = (payment, amount, recoverySet) => {
+    recoverySet.add(payment);
+    paymentRecoverySets.init(payment, recoverySet);
     paymentLedger.init(payment, amount);
   };
 

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -61,7 +61,6 @@ export const preparePurseKind = (
               updatePurseBalance(state, newPurseBalance, this.facets.purse),
             srcPayment,
             optAmountShape,
-            state.recoverySet,
           );
         },
         withdraw(amount) {

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -200,6 +200,7 @@ export const makeIssuerInterfaces = (
   const MintI = M.interface('Mint', {
     getIssuer: M.call().returns(IssuerShape),
     mintPayment: M.call(amountShape).returns(PaymentShape),
+    getRecoverySet: M.call().returns(M.setOf(PaymentShape)),
   });
 
   const PaymentI = M.interface('Payment', {

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -147,6 +147,7 @@ export const DisplayInfoShape = M.splitRecord(
 export const IssuerKitShape = harden({
   brand: BrandShape,
   mint: MintShape,
+  mintRecoveryPurse: PurseShape,
   issuer: IssuerShape,
   displayInfo: DisplayInfoShape,
 });
@@ -200,7 +201,6 @@ export const makeIssuerInterfaces = (
   const MintI = M.interface('Mint', {
     getIssuer: M.call().returns(IssuerShape),
     mintPayment: M.call(amountShape).returns(PaymentShape),
-    getRecoverySet: M.call().returns(M.setOf(PaymentShape)),
   });
 
   const PaymentI = M.interface('Payment', {

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -291,6 +291,14 @@
  * @property {() => Issuer<K>} getIssuer Gets the Issuer for this mint.
  * @property {(newAmount: Amount<K>) => Payment<K>} mintPayment
  * Creates a new Payment containing newly minted amount.
+ * @property {() => CopySet<Payment<K>>} getRecoverySet
+ * The set of payments created by this mint that are still live. These
+ * are the payments that can still be recovered in emergencies by, for example,
+ * depositing into a purse. Such a deposit action is like canceling an
+ * outstanding check because you're tired of waiting for it. Once your
+ * cancellation is acknowledged, you can spend the assets at stake on other
+ * things. Afterwards, if the recipient of the original check finally gets
+ * around to depositing it, their deposit fails.
  */
 
 /**
@@ -352,7 +360,7 @@
  * Withdraw amount from this purse into a new Payment.
  *
  * @property {() => CopySet<Payment<K>>} getRecoverySet
- * The set of payments associated with this purse that are still live. These
+ * The set of payments withdrawn from this purse that are still live. These
  * are the payments that can still be recovered in emergencies by, for example,
  * depositing into this purse. Such a deposit action is like canceling an
  * outstanding check because you're tired of waiting for it. Once your

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -249,6 +249,7 @@
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} PaymentLedger
  * @property {Mint<K>} mint
+ * @property {Purse<K>} mintRecoveryPurse
  * @property {Issuer<K>} issuer
  * @property {Brand<K>} brand
  */
@@ -257,6 +258,7 @@
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} IssuerKit
  * @property {Mint<K>} mint
+ * @property {Purse<K>} mintRecoveryPurse
  * @property {Issuer<K>} issuer
  * @property {Brand<K>} brand
  * @property {DisplayInfo} displayInfo
@@ -291,14 +293,6 @@
  * @property {() => Issuer<K>} getIssuer Gets the Issuer for this mint.
  * @property {(newAmount: Amount<K>) => Payment<K>} mintPayment
  * Creates a new Payment containing newly minted amount.
- * @property {() => CopySet<Payment<K>>} getRecoverySet
- * The set of payments created by this mint that are still live. These
- * are the payments that can still be recovered in emergencies by, for example,
- * depositing into a purse. Such a deposit action is like canceling an
- * outstanding check because you're tired of waiting for it. Once your
- * cancellation is acknowledged, you can spend the assets at stake on other
- * things. Afterwards, if the recipient of the original check finally gets
- * around to depositing it, their deposit fails.
  */
 
 /**

--- a/packages/ERTP/test/swingsetTests/basicFunctionality/vat-alice.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/vat-alice.js
@@ -1,6 +1,11 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '../../../src/index.js';
+import {
+  claim,
+  combine,
+  splitMany,
+} from '../../../src/legacy-payment-helpers.js';
 
 function makeAliceMaker(log) {
   return Far('aliceMaker', {
@@ -31,9 +36,8 @@ function makeAliceMaker(log) {
 
           // splitMany
           const moola200 = AmountMath.make(brand, 200n);
-          const [paymentToBurn, paymentToClaim, ...payments] = await E(
-            issuer,
-          ).splitMany(
+          const [paymentToBurn, paymentToClaim, ...payments] = await splitMany(
+            E(issuer).makeEmptyPurse(),
             newPayment,
             harden([moola200, moola200, moola200, moola200, moola200]),
           );
@@ -43,14 +47,17 @@ function makeAliceMaker(log) {
           log('burned amount: ', burnedAmount);
 
           // claim
-          const claimedPayment = await E(issuer).claim(paymentToClaim);
+          const claimedPayment = await claim(
+            E(issuer).makeEmptyPurse(),
+            paymentToClaim,
+          );
           const claimedPaymentAmount = await E(issuer).getAmountOf(
             claimedPayment,
           );
           log('claimedPayment amount: ', claimedPaymentAmount);
 
           // combine
-          const combinedPayment = E(issuer).combine(payments);
+          const combinedPayment = combine(E(issuer).makeEmptyPurse(), payments);
           const combinedPaymentAmount = await E(issuer).getAmountOf(
             combinedPayment,
           );

--- a/packages/ERTP/test/swingsetTests/splitPayments/vat-alice.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/vat-alice.js
@@ -1,6 +1,7 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '../../../src/index.js';
+import { split } from '../../../src/legacy-payment-helpers.js';
 
 function makeAliceMaker(log) {
   return Far('aliceMaker', {
@@ -8,7 +9,8 @@ function makeAliceMaker(log) {
       const alice = Far('alice', {
         async testSplitPayments() {
           log('oldPayment balance:', await E(issuer).getAmountOf(oldPaymentP));
-          const splitPayments = await E(issuer).split(
+          const splitPayments = await split(
+            E(issuer).makeEmptyPurse(),
             oldPaymentP,
             AmountMath.make(brand, 10n),
           );

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -4,6 +4,7 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { AssetKind, makeIssuerKit, AmountMath } from '../../src/index.js';
+import { claim, combine } from '../../src/legacy-payment-helpers.js';
 
 test('makeIssuerKit bad allegedName', async t => {
   // @ts-expect-error Intentional wrong type for testing
@@ -158,7 +159,7 @@ test('assertLivePayment', async t => {
   const paymentB = E(mintB).mintPayment(AmountMath.make(brandB, 837n));
 
   // payment is of the wrong brand
-  await t.throwsAsync(() => E(issuer).claim(paymentB), {
+  await t.throwsAsync(() => claim(E(issuer).makeEmptyPurse(), paymentB), {
     message:
       '"[Alleged: fungibleB payment]" was not a live payment for brand "[Alleged: fungible brand]". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
   });
@@ -166,9 +167,9 @@ test('assertLivePayment', async t => {
   // payment is used up
   const payment = E(mint).mintPayment(AmountMath.make(brand, 10n));
   // use up payment
-  await E(issuer).claim(payment);
+  await claim(E(issuer).makeEmptyPurse(), payment);
 
-  await t.throwsAsync(() => E(issuer).claim(payment), {
+  await t.throwsAsync(() => claim(E(issuer).makeEmptyPurse(), payment), {
     message:
       '"[Alleged: fungible payment]" was not a live payment for brand "[Alleged: fungible brand]". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
   });
@@ -181,9 +182,9 @@ test('issuer.combine bad payments array', async t => {
     split: () => {},
   };
   // @ts-expect-error Intentional wrong type for testing
-  await t.throwsAsync(() => E(issuer).combine(notAnArray), {
-    message:
-      'In "combine" method of (fungible issuer): cannot serialize Remotables with non-methods like "length" in {"length":2,"split":"[Function split]"}',
+  // eslint-disable-next-line no-undef
+  await t.throwsAsync(() => combine(E(issuer).makeEmptyPurse(), notAnArray), {
+    message: 'srcPaymentsPs is not iterable',
   });
 
   const notAnArray2 = Far('notAnArray2', {
@@ -191,9 +192,8 @@ test('issuer.combine bad payments array', async t => {
     split: () => {},
   });
   // @ts-expect-error Intentional wrong type for testing
-  await t.throwsAsync(() => E(issuer).combine(notAnArray2), {
-    message:
-      'In "combine" method of (fungible issuer): arg 0: remotable "[Alleged: notAnArray2]" - Must be a copyArray',
+  await t.throwsAsync(() => combine(E(issuer).makeEmptyPurse(), notAnArray2), {
+    message: 'srcPaymentsPs is not iterable',
   });
 });
 

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -3,6 +3,12 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { E } from '@endo/eventual-send';
 import { AssetKind, makeIssuerKit, AmountMath } from '../../src/index.js';
+import {
+  claim,
+  combine,
+  split,
+  splitMany,
+} from '../../src/legacy-payment-helpers.js';
 
 test('issuer.getBrand, brand.isMyIssuer', t => {
   const { issuer, brand } = makeIssuerKit('fungible');
@@ -192,7 +198,7 @@ test('purse.deposit promise', async t => {
 
   const purse = issuer.makeEmptyPurse();
   const payment = mint.mintPayment(fungible25);
-  const exclusivePaymentP = E(issuer).claim(payment);
+  const exclusivePaymentP = claim(E(issuer).makeEmptyPurse(), payment);
 
   await t.throwsAsync(
     // @ts-expect-error deliberate invalid arguments for testing
@@ -265,25 +271,23 @@ test('issuer.claim', async t => {
   t.plan(3);
   const { issuer, mint, brand } = makeIssuerKit('fungible');
   const payment1 = mint.mintPayment(AmountMath.make(brand, 2n));
-  await E(issuer)
-    .claim(payment1, AmountMath.make(brand, 2n))
-    .then(async newPayment1 => {
-      await issuer.getAmountOf(newPayment1).then(amount => {
-        t.assert(
-          AmountMath.isEqual(amount, AmountMath.make(brand, 2n)),
-          `new payment has equal balance to old payment`,
-        );
-        t.not(
-          newPayment1,
-          payment1,
-          `old payment is different than new payment`,
-        );
-      });
-
-      return t.throwsAsync(() => issuer.getAmountOf(payment1), {
-        message: /was not a live payment for brand/,
-      });
+  await claim(
+    E(issuer).makeEmptyPurse(),
+    payment1,
+    AmountMath.make(brand, 2n),
+  ).then(async newPayment1 => {
+    await issuer.getAmountOf(newPayment1).then(amount => {
+      t.assert(
+        AmountMath.isEqual(amount, AmountMath.make(brand, 2n)),
+        `new payment has equal balance to old payment`,
+      );
+      t.not(newPayment1, payment1, `old payment is different than new payment`);
     });
+
+    return t.throwsAsync(() => issuer.getAmountOf(payment1), {
+      message: /was not a live payment for brand/,
+    });
+  });
 });
 
 test('issuer.splitMany bad amount', async t => {
@@ -291,7 +295,7 @@ test('issuer.splitMany bad amount', async t => {
   const payment = mint.mintPayment(AmountMath.make(brand, 1000n));
   const badAmounts = harden(Array(2).fill(AmountMath.make(brand, 10n)));
   await t.throwsAsync(
-    _ => E(issuer).splitMany(payment, badAmounts),
+    _ => splitMany(E(issuer).makeEmptyPurse(), payment, badAmounts),
     { message: /rights were not conserved/ },
     'successfully throw if rights are not conserved in proposed new payments',
   );
@@ -321,9 +325,11 @@ test('issuer.splitMany good amount', async t => {
     );
   };
 
-  await E(issuer)
-    .splitMany(oldPayment, harden(goodAmounts))
-    .then(checkPayments);
+  await splitMany(
+    E(issuer).makeEmptyPurse(),
+    oldPayment,
+    harden(goodAmounts),
+  ).then(checkPayments);
 });
 
 test('issuer.split bad amount', async t => {
@@ -331,12 +337,16 @@ test('issuer.split bad amount', async t => {
   const { brand: otherBrand } = makeIssuerKit('other fungible');
   const payment = mint.mintPayment(AmountMath.make(brand, 1000n));
   await t.throwsAsync(
-    _ => E(issuer).split(payment, AmountMath.make(otherBrand, 10n)),
+    _ =>
+      split(
+        E(issuer).makeEmptyPurse(),
+        payment,
+        AmountMath.make(otherBrand, 10n),
+      ),
     {
       message:
-        'In "split" method of (fungible issuer): arg 1: brand: "[Alleged: other fungible brand]" - Must be: "[Alleged: fungible brand]"',
+        'Brands in left "[Alleged: fungible brand]" and right "[Alleged: other fungible brand]" should match but do not',
     },
-    'throws for bad amount',
   );
 });
 
@@ -365,9 +375,11 @@ test('issuer.split good amount', async t => {
     );
   };
 
-  await E(issuer)
-    .split(oldPayment, AmountMath.make(brand, 10n))
-    .then(checkPayments);
+  await split(
+    E(issuer).makeEmptyPurse(),
+    oldPayment,
+    AmountMath.make(brand, 10n),
+  ).then(checkPayments);
 });
 
 test('issuer.combine good payments', async t => {
@@ -397,7 +409,9 @@ test('issuer.combine good payments', async t => {
       ),
     );
   };
-  await E(issuer).combine(payments).then(checkCombinedPayment);
+  await combine(E(issuer).makeEmptyPurse(), payments).then(
+    checkCombinedPayment,
+  );
 });
 
 test('issuer.combine array of promises', async t => {
@@ -406,7 +420,7 @@ test('issuer.combine array of promises', async t => {
   const paymentsP = [];
   for (let i = 0; i < 100; i += 1) {
     const freshPayment = mint.mintPayment(AmountMath.make(brand, 1n));
-    const paymentP = issuer.claim(freshPayment);
+    const paymentP = claim(issuer.makeEmptyPurse(), freshPayment);
     paymentsP.push(paymentP);
   }
   harden(paymentsP);
@@ -416,7 +430,9 @@ test('issuer.combine array of promises', async t => {
       t.is(pAmount.value, 100n);
     });
 
-  await E(issuer).combine(paymentsP).then(checkCombinedResult);
+  await combine(E(issuer).makeEmptyPurse(), paymentsP).then(
+    checkCombinedResult,
+  );
 });
 
 test('issuer.combine bad payments', async t => {
@@ -431,7 +447,7 @@ test('issuer.combine bad payments', async t => {
   payments.push(otherPayment);
   harden(payments);
 
-  await t.throwsAsync(() => E(issuer).combine(payments), {
+  await t.throwsAsync(() => combine(E(issuer).makeEmptyPurse(), payments), {
     message:
       /^"\[Alleged: other fungible payment\]" was not a live payment for brand "\[Alleged: fungible brand\]"./,
   });

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -431,11 +431,8 @@ test('issuer.combine bad payments', async t => {
   payments.push(otherPayment);
   harden(payments);
 
-  await t.throwsAsync(
-    () => E(issuer).combine(payments),
-    {
-      message: /.* "\[Alleged: other fungible payment\]"/,
-    },
-    'payment from other mint is not found',
-  );
+  await t.throwsAsync(() => E(issuer).combine(payments), {
+    message:
+      /^"\[Alleged: other fungible payment\]" was not a live payment for brand "\[Alleged: fungible brand\]"./,
+  });
 });

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -6,6 +6,7 @@ import { assert } from '@agoric/assert';
 
 import { defineDurableKind, makeKindHandle } from '@agoric/vat-data';
 import { makeIssuerKit, AssetKind, AmountMath } from '../../src/index.js';
+import { claim, combine } from '../../src/legacy-payment-helpers.js';
 
 test('mint.getIssuer', t => {
   const { mint, issuer } = makeIssuerKit('fungible');
@@ -139,14 +140,18 @@ test('non-fungible tokens example', async t => {
   // Alice will buy ticket 1
   const paymentForAlice = balletTicketPayments[0];
   // Bob will buy tickets 3 and 4
-  const paymentForBob = balletTicketIssuer.combine(
+  const paymentForBob = combine(
+    balletTicketIssuer.makeEmptyPurse(),
     harden([balletTicketPayments[2], balletTicketPayments[3]]),
   );
 
   // ALICE SIDE
   // Alice bought ticket 1 and has access to the balletTicketIssuer, because
   // it's public
-  const myTicketPaymentAlice = await balletTicketIssuer.claim(paymentForAlice);
+  const myTicketPaymentAlice = await claim(
+    balletTicketIssuer.makeEmptyPurse(),
+    paymentForAlice,
+  );
   // the call to claim() hasn't thrown, so Alice knows myTicketPaymentAlice
   // is a genuine 'Agoric Ballet Opera tickets' payment and she has exclusive
   // access to its handle
@@ -162,7 +167,10 @@ test('non-fungible tokens example', async t => {
   // BOB SIDE
   // Bob bought ticket 3 and 4 and has access to the balletTicketIssuer, because
   // it's public
-  const bobTicketPayment = await balletTicketIssuer.claim(paymentForBob);
+  const bobTicketPayment = await claim(
+    balletTicketIssuer.makeEmptyPurse(),
+    paymentForBob,
+  );
   const paymentAmountBob = await balletTicketIssuer.getAmountOf(
     bobTicketPayment,
   );

--- a/packages/ERTP/test/unitTests/test-recovery.js
+++ b/packages/ERTP/test/unitTests/test-recovery.js
@@ -1,13 +1,13 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import { keyEQ, makeCopySet } from '@agoric/store';
+import { getCopySetKeys, keyEQ, makeCopySet } from '@agoric/store';
 
 import { makeIssuerKit, AmountMath } from '../../src/index.js';
 
 const { isEmpty, isEqual } = AmountMath;
 const emptySet = makeCopySet([]);
 
-test('payment recovery', async t => {
+test('payment recovery from purse recovery set', async t => {
   const { issuer, mint, brand } = makeIssuerKit('precious');
   const precious = num => AmountMath.make(brand, num);
   const payment1 = mint.mintPayment(precious(37n));
@@ -39,4 +39,33 @@ test('payment recovery', async t => {
   t.assert(isEqual(bobRecovered, precious(0n)));
   t.assert(isEqual(bobPurse.getCurrentAmount(), precious(46n)));
   t.assert(keyEQ(bobPurse.getRecoverySet(), emptySet));
+});
+
+test('payment recovery from mint recovery set', async t => {
+  const { issuer, mint, mintRecoveryPurse, brand } = makeIssuerKit('precious');
+  const precious = num => AmountMath.make(brand, num);
+  const mindyPurse = issuer.makeEmptyPurse();
+  const bobPurse = issuer.makeEmptyPurse();
+
+  t.assert(keyEQ(mintRecoveryPurse.getRecoverySet(), emptySet));
+  const payment1 = mint.mintPayment(precious(37n));
+  const payment2 = mint.mintPayment(precious(41n));
+  t.assert(
+    keyEQ(
+      mintRecoveryPurse.getRecoverySet(),
+      makeCopySet([payment1, payment2]),
+    ),
+  );
+
+  bobPurse.deposit(payment1);
+  const mindyRecSet = mintRecoveryPurse.getRecoverySet();
+  t.assert(keyEQ(mindyRecSet, makeCopySet([payment2])));
+  for (const payment of getCopySetKeys(mindyRecSet)) {
+    mindyPurse.deposit(payment);
+  }
+  t.assert(keyEQ(mintRecoveryPurse.getRecoverySet(), emptySet));
+  t.assert(keyEQ(mindyPurse.getCurrentAmount(), precious(41n)));
+  t.throws(() => bobPurse.deposit(payment2), {
+    message: /was not a live payment for brand/,
+  });
 });

--- a/packages/inter-protocol/src/feeDistributor.js
+++ b/packages/inter-protocol/src/feeDistributor.js
@@ -1,4 +1,5 @@
 import { AmountMath } from '@agoric/ertp';
+import { splitMany } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { E, Far } from '@endo/far';
 import { Nat } from '@endo/nat';
 import { observeNotifier } from '@agoric/notifier';
@@ -160,7 +161,8 @@ export const sharePayment = async (
     .filter(([_, amt]) => !AmountMath.isEmpty(amt));
 
   // Split the payment, which asserts conservation of the total.
-  const sharedPayment = await E(issuer).splitMany(
+  const sharedPayment = await splitMany(
+    E(issuer).makeEmptyPurse(),
     payment,
     destinedAmountEntries.map(([_dst, amt]) => amt),
   );

--- a/packages/inter-protocol/src/proposals/demoIssuers.js
+++ b/packages/inter-protocol/src/proposals/demoIssuers.js
@@ -1,5 +1,6 @@
 /* eslint-disable @jessie.js/no-nested-await -- demo file */
 import { AmountMath, AssetKind } from '@agoric/ertp';
+import { split, splitMany } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import {
   makeRatio,
   natSafeMath,
@@ -261,7 +262,8 @@ export const connectFaucet = async ({
         // TODO: what happens if faucetRunSupply doesn't have enough
         // remaining?
         let fragment;
-        [fragment, faucetRunSupply] = await E(runIssuer).split(
+        [fragment, faucetRunSupply] = await split(
+          E(runIssuer).makeEmptyPurse(),
           faucetRunSupply,
           amount,
         );
@@ -393,7 +395,8 @@ export const splitAllCentralPayments = async (
     AmountMath.make(central.brand, b),
   );
 
-  const allPayments = await E(central.issuer).splitMany(
+  const allPayments = await splitMany(
+    E(central.issuer).makeEmptyPurse(),
     bootstrapPayment,
     ammPoolAmounts,
   );

--- a/packages/inter-protocol/test/attestation/test-attestation.js
+++ b/packages/inter-protocol/test/attestation/test-attestation.js
@@ -1,6 +1,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
+import { split } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { E, Far } from '@endo/far';
 
 import { makeCopyBag } from '@agoric/store';
@@ -152,7 +153,8 @@ test('attestations can be combined and split', async t => {
   };
 
   // split the 1st attestation
-  const [attest20pmt, attestRestPmt] = await E(issuer).split(
+  const [attest20pmt, attestRestPmt] = await split(
+    E(issuer).makeEmptyPurse(),
     attest50pmt,
     AmountMath.make(brand, makeCopyBag([[address1, 20n]])),
   );

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -4,6 +4,7 @@ import '@agoric/zoe/exported.js';
 import '../../src/vaultFactory/types.js';
 
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { split } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
 import committeeBundle from '@agoric/governance/bundles/bundle-committee.js';
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
@@ -296,7 +297,8 @@ test('simple trades', async t => {
 
   const giveRun = AmountMath.make(minted.brand, scale6(100));
   trace('get minted', { giveRun, expectedRun, actualRun });
-  const [runPayment, _moreRun] = await E(minted.issuer).split(
+  const [runPayment, _moreRun] = await split(
+    E(minted.issuer).makeEmptyPurse(),
     runPayouts.Out,
     giveRun,
   );
@@ -486,7 +488,8 @@ test('anchor is 2x minted', async t => {
 
   const giveRun = AmountMath.make(minted.brand, scale6(100));
   trace('get minted ratio', { giveRun, expectedRun, actualRun });
-  const [runPayment, _moreRun] = await E(minted.issuer).split(
+  const [runPayment, _moreRun] = await split(
+    E(minted.issuer).makeEmptyPurse(),
     runPayouts.Out,
     giveRun,
   );
@@ -594,7 +597,8 @@ test('metrics', async t => {
 
   // get anchor
   const giveMinted = AmountMath.make(minted.brand, scale6(100));
-  const [runPayment, _moreRun] = await E(minted.issuer).split(
+  const [runPayment, _moreRun] = await split(
+    E(minted.issuer).makeEmptyPurse(),
     mintedPayouts.Out,
     giveMinted,
   );

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -89,7 +89,7 @@ const makeTestContext = async () => {
 
   const mintedIssuer = await E(zoe).getFeeIssuer();
   /** @type {IssuerKit<'nat'>} */
-  // @ts-expect-error missing mint but it's not needed in the test
+  // @ts-expect-error missing IssuerKit properties not needed in the test
   const mintedKit = {
     issuer: mintedIssuer,
     brand: await E(mintedIssuer).getBrand(),

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2,6 +2,7 @@ import '@agoric/zoe/exported.js';
 import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
+import { combine, split } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { makeParamManagerBuilder } from '@agoric/governance';
 import { allValues, makeTracer, objectMap } from '@agoric/internal';
 import {
@@ -404,7 +405,8 @@ test('first', async t => {
   // partially payback
   const collateralWanted = aeth.make(100n);
   const paybackAmount = run.make(200n);
-  const [paybackPayment, _remainingPayment] = await E(run.issuer).split(
+  const [paybackPayment, _remainingPayment] = await split(
+    E(run.issuer).makeEmptyPurse(),
     runLent,
     paybackAmount,
   );
@@ -1027,7 +1029,8 @@ test('adjust balances', async t => {
   runDebtLevel = AmountMath.subtract(runDebtLevel, depositRunAmount);
   collateralLevel = AmountMath.add(collateralLevel, collateralIncrement);
 
-  const [paybackPayment, _remainingPayment] = await E(run.issuer).split(
+  const [paybackPayment, _remainingPayment] = await split(
+    E(run.issuer).makeEmptyPurse(),
     runLent,
     depositRunAmount,
   );
@@ -1436,7 +1439,8 @@ test('transfer vault', async t => {
   t.deepEqual(lentAmount, aliceLoanAmount, 'received 5000 Minted');
   const borrowedRun = await aliceProceeds.Minted;
   const payoffRun2 = run.make(600n);
-  const [paybackPayment, _remainingPayment] = await E(run.issuer).split(
+  const [paybackPayment, _remainingPayment] = await split(
+    E(run.issuer).makeEmptyPurse(),
     borrowedRun,
     payoffRun2,
   );
@@ -1572,7 +1576,8 @@ test('overdeposit', async t => {
 
   // overpay debt ///////////////////////////////////// (give Minted)
 
-  const combinedRun = await E(run.issuer).combine(
+  const combinedRun = await combine(
+    E(run.issuer).makeEmptyPurse(),
     harden([borrowedRun, bobRun]),
   );
   const depositRun2 = run.make(6000n);
@@ -2014,7 +2019,10 @@ test('close loan', async t => {
 
   // close loan, using Bob's Minted /////////////////////////////////////
 
-  const runRepayment = await E(run.issuer).combine(harden([bobRun, runLent]));
+  const runRepayment = await combine(
+    E(run.issuer).makeEmptyPurse(),
+    harden([bobRun, runLent]),
+  );
 
   /** @type {UserSeat<string>} */
   const aliceCloseSeat = await E(zoe).offer(

--- a/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
@@ -2,6 +2,8 @@
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
+
 import { showPurseBalance, setupPurses } from './helpers.js';
 import { makePrintLog } from './printLog.js';
 
@@ -78,7 +80,10 @@ async function build(name, zoe, issuers, payments, publicFacet) {
     await preReport(quiet);
 
     const invitation = await invitationP;
-    const exclInvitation = await E(invitationIssuer).claim(invitation);
+    const exclInvitation = await claim(
+      E(invitationIssuer).makeEmptyPurse(),
+      invitation,
+    );
 
     const myBuyOrderProposal = harden({
       want: { Asset: moola(1) },

--- a/packages/swingset-runner/demo/swapBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/swapBenchmark/exchanger.js
@@ -2,6 +2,8 @@
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
+
 import { showPurseBalance, setupPurses } from './helpers.js';
 import { makePrintLog } from './printLog.js';
 
@@ -78,7 +80,10 @@ async function build(name, zoe, issuers, payments, installations) {
   async function respondToSwap(invitation) {
     await preReport();
 
-    const exclInvitation = await E(invitationIssuer).claim(invitation);
+    const exclInvitation = await claim(
+      E(invitationIssuer).makeEmptyPurse(),
+      invitation,
+    );
 
     const buyProposal = harden({
       want: { Asset: moola(1) },

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -2,7 +2,9 @@ import { E } from '@endo/eventual-send';
 import { assert, details as X, Fail } from '@agoric/assert';
 import { keyEQ } from '@agoric/store';
 import { AmountMath } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { Far } from '@endo/marshal';
+
 import { showPurseBalance, setupIssuers } from './helpers.js';
 
 import { makePrintLog } from './printLog.js';
@@ -20,7 +22,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     doAutomaticRefund: async invitation => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
 
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
@@ -64,7 +69,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob claims all with the Zoe invitationIssuer
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       const bobIntendedProposal = harden({
@@ -121,7 +129,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob claims all with the Zoe invitationIssuer
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
 
       const { UnderlyingAsset, StrikePrice } = await E(zoe).getIssuers(
         instance,
@@ -194,7 +205,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -236,7 +250,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -280,7 +297,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     doSimpleExchange: async invitation => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
       installation === installations.simpleExchange || Fail`wrong installation`;
       issuerKeywordRecord.Asset === moolaIssuer ||
@@ -313,7 +333,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
     doSimpleExchangeUpdates: async (invitationP, m, s) => {
-      const invitation = await E(invitationIssuer).claim(invitationP);
+      const invitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitationP,
+      );
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
@@ -475,7 +498,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     },
 
     doOTCDesk: async untrustedInvitation => {
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       assert(invitationValue.installation === installations.coveredCall);
 

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -2,6 +2,8 @@ import { E } from '@endo/eventual-send';
 import { assert, Fail } from '@agoric/assert';
 import { keyEQ } from '@agoric/store';
 import { Far } from '@endo/marshal';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
+
 import { showPurseBalance, setupIssuers } from './helpers.js';
 
 import { makePrintLog } from './printLog.js';
@@ -17,7 +19,10 @@ const build = async (log, zoe, issuers, payments, installations) => {
 
   return Far('carolstuff', {
     doSecondPriceAuctionBid: async invitationP => {
-      const invitation = await E(invitationIssuer).claim(invitationP);
+      const invitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitationP,
+      );
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -2,7 +2,9 @@ import { E } from '@endo/eventual-send';
 import { assert, Fail } from '@agoric/assert';
 import { keyEQ } from '@agoric/store';
 import { AmountMath } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { Far } from '@endo/marshal';
+
 import { showPurseBalance, setupIssuers } from './helpers.js';
 
 import { makePrintLog } from './printLog.js';
@@ -21,7 +23,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -67,7 +72,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );

--- a/packages/vats/test/test-bootstrapPayment.js
+++ b/packages/vats/test/test-bootstrapPayment.js
@@ -10,6 +10,7 @@ import '@agoric/zoe/exported.js';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKit } from '@agoric/zoe';
 import { AmountMath } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import centralSupplyBundle from '../bundles/bundle-centralSupply.js';
 import { Stable } from '../src/tokens.js';
 
@@ -120,7 +121,10 @@ test('bootstrap payment - only minted once', async (/** @type {CentralSupplyTest
 
   const issuers = { IST: istIssuer };
 
-  const claimedPayment = await E(issuers.IST).claim(bootstrapPayment);
+  const claimedPayment = await claim(
+    E(issuers.IST).makeEmptyPurse(),
+    bootstrapPayment,
+  );
   const bootstrapAmount = await E(issuers.IST).getAmountOf(claimedPayment);
 
   t.true(
@@ -134,9 +138,12 @@ test('bootstrap payment - only minted once', async (/** @type {CentralSupplyTest
 
   const bootstrapPayment2 = E(creatorFacet).getBootstrapPayment();
 
-  await t.throwsAsync(() => E(issuers.IST).claim(bootstrapPayment2), {
-    message: /was not a live payment/,
-  });
+  await t.throwsAsync(
+    () => claim(E(issuers.IST).makeEmptyPurse(), bootstrapPayment2),
+    {
+      message: /was not a live payment/,
+    },
+  );
 });
 
 test('bootstrap payment - default value is 0n', async (/** @type {CentralSupplyTestContext} */ t) => {

--- a/packages/vats/test/test-vpurse.js
+++ b/packages/vats/test/test-vpurse.js
@@ -4,6 +4,8 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { E } from '@endo/far';
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
+
 import { makeNotifierKit } from '@agoric/notifier';
 import { makeVirtualPurse } from '../src/virtual-purse.js';
 
@@ -274,7 +276,7 @@ test('vpurse.deposit promise', async t => {
   const fungible25 = AmountMath.make(brand, 25n);
 
   const payment = mint.mintPayment(fungible25);
-  const exclusivePaymentP = E(issuer).claim(payment);
+  const exclusivePaymentP = claim(E(issuer).makeEmptyPurse(), payment);
 
   await t.throwsAsync(
     // @ts-expect-error deliberate invalid arguments for testing

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -159,8 +159,8 @@ test.serial('zoe - swapForOption - valid inputs', async t => {
 const expectedSecondPriceAuctionOkLog = [
   '=> alice, bob, carol and dave are set up',
   'Carol: The offer has been accepted. Once the contract has been completed, please check your payout',
-  '@@ schedule task for:1, currently: 0 @@',
   'Bob: The offer has been accepted. Once the contract has been completed, please check your payout',
+  '@@ schedule task for:1, currently: 0 @@',
   'Dave: The offer has been accepted. Once the contract has been completed, please check your payout',
   '@@ tick:1 @@',
   'carolMoolaPurse: balance {"brand":{},"value":0}',

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -3,6 +3,7 @@ import { Far } from '@endo/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { keyEQ } from '@agoric/store';
 import { AmountMath, isSetValue } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 
 import { showPurseBalance, setupIssuers } from '../helpers.js';
 
@@ -19,7 +20,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     doAutomaticRefund: async invitation => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
 
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
@@ -63,7 +67,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob claims all with the Zoe invitationIssuer
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       const bobIntendedProposal = harden({
@@ -125,7 +132,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob claims all with the Zoe invitationIssuer
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
 
       const { UnderlyingAsset, StrikePrice } = await E(zoe).getIssuers(
         instance,
@@ -207,7 +217,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -254,7 +267,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -299,7 +315,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     doSimpleExchange: async invitation => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
       installation === installations.simpleExchange ||
         assert.fail(X`wrong installation`);
@@ -333,7 +352,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
     doSimpleExchangeUpdates: async (invitationP, m, s) => {
-      const invitation = await E(invitationIssuer).claim(invitationP);
+      const invitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitationP,
+      );
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
@@ -500,7 +522,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     },
 
     doOTCDesk: async untrustedInvitation => {
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       assert(invitationValue.installation === installations.coveredCall);
 

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -2,6 +2,7 @@ import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { keyEQ } from '@agoric/store';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { showPurseBalance, setupIssuers } from '../helpers.js';
 
 const build = async (log, zoe, issuers, payments, installations) => {
@@ -15,7 +16,10 @@ const build = async (log, zoe, issuers, payments, installations) => {
 
   return Far('build', {
     doSecondPriceAuctionBid: async invitationP => {
-      const invitation = await E(invitationIssuer).claim(invitationP);
+      const invitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitationP,
+      );
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -3,6 +3,7 @@ import { Far } from '@endo/marshal';
 import { assert, details as X, Fail } from '@agoric/assert';
 import { keyEQ } from '@agoric/store';
 import { AmountMath } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { showPurseBalance, setupIssuers } from '../helpers.js';
 
 const build = async (log, zoe, issuers, payments, installations, timer) => {
@@ -19,7 +20,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
@@ -70,7 +74,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const exclInvitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        invitation,
+      );
       const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -6,6 +6,7 @@ import path from 'path';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 
 import { setup } from '../setupBasicMints.js';
 import { setupNonFungible } from '../setupNonFungibleMints.js';
@@ -92,7 +93,10 @@ test('zoe - atomicSwap', async t => {
         // Bob is able to use the trusted invitationIssuer from Zoe to
         // transform an untrusted invitation that Alice also has access to, to
         // an
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await claim(
+          E(invitationIssuer).makeEmptyPurse(),
+          untrustedInvitation,
+        );
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
         t.is(
           invitationValue.installation,
@@ -256,7 +260,10 @@ test('zoe - non-fungible atomicSwap', async t => {
         // Bob is able to use the trusted invitationIssuer from Zoe to
         // transform an untrusted invitation that Alice also has access to, to
         // an
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await claim(
+          E(invitationIssuer).makeEmptyPurse(),
+          untrustedInvitation,
+        );
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
 
         t.is(
@@ -389,7 +396,8 @@ test('zoe - atomicSwap like-for-like', async t => {
   // counter-party.
 
   const bobInvitationP = E(aliceSeat).getOfferResult();
-  const bobExclusiveInvitation = await E(invitationIssuer).claim(
+  const bobExclusiveInvitation = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
     bobInvitationP,
   );
   const bobInvitationValue = await E(zoe).getInvitationDetails(

--- a/packages/zoe/test/unitTests/contracts/test-auction.js
+++ b/packages/zoe/test/unitTests/contracts/test-auction.js
@@ -6,6 +6,7 @@ import path from 'path';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { eventLoopIteration } from '../../../tools/eventLoopIteration.js';
@@ -97,7 +98,10 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
         // Bob is able to use the trusted invitationIssuer from Zoe to
         // transform an untrusted invitation that Alice also has access to, to
         // an
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await claim(
+          E(invitationIssuer).makeEmptyPurse(),
+          untrustedInvitation,
+        );
 
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
 
@@ -165,7 +169,10 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     return Far('losing bidder', {
       offer: async untrustedInvitation => {
         const invitationIssuer = await E(zoe).getInvitationIssuer();
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await claim(
+          E(invitationIssuer).makeEmptyPurse(),
+          untrustedInvitation,
+        );
 
         const proposal = harden({
           give: { Bid: bidAmount },
@@ -598,7 +605,10 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   // Alice spreads the invitations far and wide and Bob decides he
   // wants to participate in the auction.
-  const bobExclusiveInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const bobExclusiveInvitation = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    bobInvitation,
+  );
   const bobInvitationValue = await E(zoe).getInvitationDetails(
     bobExclusiveInvitation,
   );
@@ -640,7 +650,8 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   // Carol decides to bid for the one cc
 
-  const carolExclusiveInvitation = await E(invitationIssuer).claim(
+  const carolExclusiveInvitation = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
     carolInvitation,
   );
   const carolInvitationValue = await E(zoe).getInvitationDetails(
@@ -687,7 +698,8 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   );
 
   // Dave decides to bid for the one moola
-  const daveExclusiveInvitation = await E(invitationIssuer).claim(
+  const daveExclusiveInvitation = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
     daveInvitation,
   );
   const daveInvitationValue = await E(zoe).getInvitationDetails(
@@ -914,7 +926,10 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
         // Bob is able to use the trusted invitationIssuer from Zoe to
         // transform an untrusted invitation that Alice also has access to, to
         // an
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await claim(
+          E(invitationIssuer).makeEmptyPurse(),
+          untrustedInvitation,
+        );
 
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
 
@@ -982,7 +997,10 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
     return Far('losing bidder', {
       offer: async untrustedInvitation => {
         const invitationIssuer = await E(zoe).getInvitationIssuer();
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await claim(
+          E(invitationIssuer).makeEmptyPurse(),
+          untrustedInvitation,
+        );
 
         const proposal = harden({
           give: { Bid: bidAmount },

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -5,6 +5,7 @@ import path from 'path';
 
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
+import { claim, splitMany } from '@agoric/ertp/src/legacy-payment-helpers.js';
 
 import { setup } from '../setupBasicMints.js';
 import { setupNonFungible } from '../setupNonFungibleMints.js';
@@ -154,7 +155,10 @@ test('zoe with automaticRefund', async t => {
   // will do a claim on the invitation with the Zoe invitation issuer and
   // will check that the installation and terms match what he
   // expects
-  const exclusBobInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const exclusBobInvitation = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    bobInvitation,
+  );
 
   const {
     value: [bobInvitationValue],
@@ -238,7 +242,8 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
   // Setup Alice
   const aliceMoolaPayment = moolaKit.mint.mintPayment(moola(30n));
   const moola10 = moola(10n);
-  const aliceMoolaPayments = await moolaKit.issuer.splitMany(
+  const aliceMoolaPayments = await splitMany(
+    moolaKit.issuer.makeEmptyPurse(),
     aliceMoolaPayment,
     harden([moola10, moola10, moola10]),
   );

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -5,6 +5,8 @@ import path from 'path';
 
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
+
 import {
   makeTrader,
   outputFromInputPrice,
@@ -104,7 +106,10 @@ test('autoSwap API interactions, no jig', async t => {
   const bobInvitation = await E(publicFacet).makeSwapInvitation();
 
   // Bob claims it
-  const bobExclInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const bobExclInvitation = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    bobInvitation,
+  );
   const bobInstance = await E(zoe).getInstance(bobExclInvitation);
   const bobInstallation = await E(zoe).getInstallation(bobExclInvitation);
   t.is(bobInstallation, installation, `installation`);

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -5,6 +5,7 @@ import path from 'path';
 
 import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 
 import { setup } from '../setupBasicMints.js';
 import { installationPFromSource } from '../installFromSource.js';
@@ -76,7 +77,10 @@ test('barter with valid offers', async t => {
   const bobInstallation = await E(zoe).getInstallation(bobInvitation);
 
   // 4: Bob decides to join.
-  const bobExclusiveInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const bobExclusiveInvitation = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    bobInvitation,
+  );
 
   t.is(bobInstallation, installation);
   t.is(bobInstance, instance);

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
@@ -7,6 +7,7 @@ import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
 import { M, mustMatch, keyEQ } from '@agoric/store';
 import { AmountMath, AssetKind, BrandShape } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { setup } from '../setupBasicMints.js';
@@ -114,7 +115,10 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // that he expects (moola and simoleans)?
   const invitationIssuer = await E(zoe).getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
-  const bobExclOption = await E(invitationIssuer).claim(optionP);
+  const bobExclOption = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    optionP,
+  );
   const optionAmount = await E(invitationIssuer).getAmountOf(bobExclOption);
   const optionDesc = optionAmount.value[0];
   const { customDetails } = optionDesc;

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -7,6 +7,7 @@ import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { AmountMath, AssetKind } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { keyEQ } from '@agoric/store';
 
 import buildManualTimer from '../../../tools/manualTimer.js';
@@ -122,7 +123,10 @@ test('zoe - coveredCall', async t => {
 
         // Bob is able to use the trusted invitationIssuer from Zoe to
         // transform an untrusted invitation that Alice also has access to
-        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = await claim(
+          E(invitationIssuer).makeEmptyPurse(),
+          untrustedInvitation,
+        );
 
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
 
@@ -286,7 +290,10 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
   // already escrowed.
 
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const bobExclOption = await E(invitationIssuer).claim(optionP);
+  const bobExclOption = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    optionP,
+  );
   const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
   const { customDetails } = optionValue;
   assert(typeof customDetails === 'object');
@@ -443,7 +450,10 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // that he expects (moola and simoleans)?
   const invitationIssuer = await E(zoe).getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
-  const bobExclOption = await E(invitationIssuer).claim(optionP);
+  const bobExclOption = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    optionP,
+  );
   const optionAmount = await E(invitationIssuer).getAmountOf(bobExclOption);
   const optionDesc = optionAmount.value[0];
   const { customDetails } = optionDesc;
@@ -707,7 +717,10 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   // expected covered call installation (code)? Does it use the issuers
   // that he expects (moola and simoleans)?
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const bobExclOption = await E(invitationIssuer).claim(optionP);
+  const bobExclOption = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    optionP,
+  );
   const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
   const { customDetails } = optionValue;
   assert(typeof customDetails === 'object');
@@ -761,7 +774,10 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   // Dave is looking to buy the option to trade his 7 simoleans for
   // 3 moola, and is willing to pay 1 buck for the option. He
   // checks that this invitation matches what he wants
-  const daveExclOption = await E(invitationIssuer).claim(invitationForDaveP);
+  const daveExclOption = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    invitationForDaveP,
+  );
   const daveOptionValue = await E(zoe).getInvitationDetails(daveExclOption);
   const { customDetails: daveCustomDetails } = daveOptionValue;
   assert(typeof daveCustomDetails === 'object');
@@ -980,7 +996,10 @@ test('zoe - coveredCall non-fungible', async t => {
 
   const invitationIssuer = await E(zoe).getInvitationIssuer();
   /** @type {Payment<any>} */
-  const bobExclOption = await E(invitationIssuer).claim(optionP);
+  const bobExclOption = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    optionP,
+  );
   const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
   const { customDetails } = optionValue;
   assert(typeof customDetails === 'object');

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -6,6 +6,8 @@ import path from 'path';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
+
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
@@ -41,7 +43,10 @@ test('zoe - mint payments', async t => {
     return {
       offer: async untrustedInvitation => {
         const invitationIssuer = E(zoe).getInvitationIssuer();
-        const invitation = E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = claim(
+          E(invitationIssuer).makeEmptyPurse(),
+          untrustedInvitation,
+        );
 
         const {
           value: [invitationValue],
@@ -120,7 +125,10 @@ test('zoe - mint payments with unrelated give and want', async t => {
     return {
       offer: async untrustedInvitation => {
         const invitationIssuer = E(zoe).getInvitationIssuer();
-        const invitation = E(invitationIssuer).claim(untrustedInvitation);
+        const invitation = claim(
+          E(invitationIssuer).makeEmptyPurse(),
+          untrustedInvitation,
+        );
 
         const {
           value: [invitationValue],

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -7,6 +7,7 @@ import path from 'path';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 
 import { setup } from '../setupBasicMints.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
@@ -124,7 +125,10 @@ const makeBob = (
   return Far('Bob', {
     offerOk: async untrustedInvitation => {
       const invitationIssuer = await E(zoe).getInvitationIssuer();
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       const { customDetails } = invitationValue;
       assert(typeof customDetails === 'object');
@@ -178,7 +182,10 @@ const makeBob = (
     },
     offerExpired: async untrustedInvitation => {
       const invitationIssuer = await E(zoe).getInvitationIssuer();
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       const { customDetails } = invitationValue;
       assert(typeof customDetails === 'object');
@@ -235,7 +242,10 @@ const makeBob = (
     },
     offerWantTooMuch: async untrustedInvitation => {
       const invitationIssuer = await E(zoe).getInvitationIssuer();
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       const { customDetails } = invitationValue;
       assert(typeof customDetails === 'object');
@@ -300,7 +310,10 @@ const makeBob = (
     },
     offerNotCovered: async untrustedInvitation => {
       const invitationIssuer = await E(zoe).getInvitationIssuer();
-      const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+      const invitation = await claim(
+        E(invitationIssuer).makeEmptyPurse(),
+        untrustedInvitation,
+      );
       const invitationValue = await E(zoe).getInvitationDetails(invitation);
       const { customDetails } = invitationValue;
       assert(typeof customDetails === 'object');

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -6,7 +6,9 @@ import path from 'path';
 import { assert } from '@agoric/assert';
 import bundleSource from '@endo/bundle-source';
 import { makeIssuerKit, AmountMath, isSetValue } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import { E } from '@endo/eventual-send';
+
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
@@ -282,7 +284,10 @@ test(`mint and sell opera tickets`, async t => {
   // Joker attempts to buy ticket 1 (and should fail)
   const jokerBuysTicket1 = async (untrustedInvitation, moola100Payment) => {
     const invitationIssuer = E(zoe).getInvitationIssuer();
-    const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+    const invitation = await claim(
+      E(invitationIssuer).makeEmptyPurse(),
+      untrustedInvitation,
+    );
     const {
       value: [{ instance: ticketSalesInstance }],
     } = await E(invitationIssuer).getAmountOf(invitation);
@@ -355,7 +360,10 @@ test(`mint and sell opera tickets`, async t => {
     moola100Payment,
   ) => {
     const invitationIssuer = E(zoe).getInvitationIssuer();
-    const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+    const invitation = await claim(
+      E(invitationIssuer).makeEmptyPurse(),
+      untrustedInvitation,
+    );
     const {
       value: [{ instance: ticketSalesInstance }],
     } = await E(invitationIssuer).getAmountOf(invitation);
@@ -422,7 +430,10 @@ test(`mint and sell opera tickets`, async t => {
 
   const bobBuysTicket2And3 = async (untrustedInvitation, moola100Payment) => {
     const invitationIssuer = E(zoe).getInvitationIssuer();
-    const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+    const invitation = await claim(
+      E(invitationIssuer).makeEmptyPurse(),
+      untrustedInvitation,
+    );
     const {
       value: [{ instance: ticketSalesInstance }],
     } = await E(invitationIssuer).getAmountOf(invitation);

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -7,6 +7,8 @@ import path from 'path';
 import { E } from '@endo/eventual-send';
 
 import { AmountMath, AssetKind } from '@agoric/ertp';
+import { claim } from '@agoric/ertp/src/legacy-payment-helpers.js';
+
 import { setup } from '../setupBasicMints.js';
 import { setupNonFungible } from '../setupNonFungibleMints.js';
 import { installationPFromSource } from '../installFromSource.js';
@@ -123,7 +125,10 @@ test('simpleExchange with valid offers', async t => {
   const bobInstallation = await E(zoe).getInstallation(bobInvitation);
 
   // 5: Bob decides to join.
-  const bobExclusiveInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const bobExclusiveInvitation = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    bobInvitation,
+  );
 
   const bobIssuers = await E(zoe).getIssuers(instance);
 
@@ -262,7 +267,8 @@ test('simpleExchange with multiple sell offers', async t => {
   );
 
   // 5: Alice adds another sell order to the exchange
-  const aliceInvitation2 = await E(invitationIssuer).claim(
+  const aliceInvitation2 = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
     await E(publicFacet).makeInvitation(),
   );
   const aliceSale2OrderProposal = harden({
@@ -280,7 +286,8 @@ test('simpleExchange with multiple sell offers', async t => {
   );
 
   // 5: Alice adds a buy order to the exchange
-  const aliceInvitation3 = await E(invitationIssuer).claim(
+  const aliceInvitation3 = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
     await E(publicFacet).makeInvitation(),
   );
   const aliceBuyOrderProposal = harden({
@@ -370,7 +377,10 @@ test('simpleExchange with non-fungible assets', async t => {
   // 5: Bob decides to join.
   const bobInstance = await E(zoe).getInstance(bobInvitation);
   const bobInstallation = await E(zoe).getInstallation(bobInvitation);
-  const bobExclusiveInvitation = await E(invitationIssuer).claim(bobInvitation);
+  const bobExclusiveInvitation = await claim(
+    E(invitationIssuer).makeEmptyPurse(),
+    bobInvitation,
+  );
 
   t.is(bobInstallation, installation);
 


### PR DESCRIPTION
Recommend reviewing by commit.

To cope with the hazards of payments lost in flight, we associate a live payment with the *recovery set* of the purse it is withdrawn from. This lets the holder of that purse recover the assets from any still-live payment withdrawn from that purse. If a live payment in flight is like a non-deposited check, recovering the assets from such a payment is like canceling the check. This is consistent with the expectations of the receiver, since they do not believe themselves to be paid until they have deposited the payment into purse they control.

However, dating from before the invention of recovery sets, Issuers provide several linear methods (claim, combine, split, splitMany) for making new payments from old payments. These new payments are not associated with any purse's recovery set. From the nature of the Issuer API, they cannot usefully be. These problematic methods are also very rarely used in production. Thus, long term, it would be best to simply remove these methods and fix their few callers to not use them.

To ease this transition safely, this PR provides corresponding helper functions as alternatives to these methods. These helper functions are parameterized by a purse, and any new payments created by those helper functions are in the recovery sets of those purses.

To ease the transition further, but unsafely, this PR leaves the problematic methods on Issuer as trivial wrappers around the new helper functions. However, by the nature of the Issuer API, those methods cannot be safer than they were before this PR.

The remaining case of payments not associated with a recovery set is `mintPayments`. To fix this, we add a recovery set to each mint, and put all minted payments in there first.

A ZCFMint needs no similar adjustment, since it immediately places newly minted payments into its own escrow purses.

See https://github.com/Agoric/agoric-sdk/pull/7113