### PR TITLE
fix: remove deprecated issuer payment methods

### DIFF
--- a/packages/ERTP/src/legacy-payment-helpers.js
+++ b/packages/ERTP/src/legacy-payment-helpers.js
@@ -4,55 +4,70 @@ import { AmountMath } from './amountMath.js';
 
 const { Fail } = assert;
 
-// This file contains safer helper function alternatives to the
-// similarly named methods on issuer.
-// These are parameterized by a purse. Any payments created by these
-// helper functions are in the recovery set of that purse until otherwise
-// used up.
-//
-// One of these helper functions is less safe in one way:
-// `combine` is not failure atomic. If the `combine` helper function
-// fails, some of the input payments may have been used up. However, even
-// in that case, no assets would be lost. The assets from the used up payments
-// will be in the argument purse.
+/**
+ * @file
+ * This file contains safer helper function alternatives to the
+ * similarly named methods on issuer.
+ * These are parameterized by a purse used for recovering lost payments, which
+ * we call a `recoveryPurse`. Any payments created by these
+ * helper functions are in the recovery set of that `recoveryPurse` until
+ * otherwise used up.
+ *
+ * One of these helper functions is less safe in one way:
+ * `combine` is not failure atomic. If the `combine` helper function
+ * fails, some of the input payments may have been used up. However, even
+ * in that case, no assets would be lost. The assets from the used up payments
+ * will be in the argument `recoveryPurse`.
+ */
 
 /**
  * @template {AssetKind} K
- * @param {ERef<Purse<K>>} purse
+ * @param {ERef<Purse<K>>} recoveryPurse
  * @param {ERef<Payment<K>>} srcPaymentP
  * @param {Pattern} [optAmountShape]
  * @returns {Promise<Payment<K>>}
  */
-export const claim = async (purse, srcPaymentP, optAmountShape = undefined) => {
+export const claim = async (
+  recoveryPurse,
+  srcPaymentP,
+  optAmountShape = undefined,
+) => {
   const srcPayment = await srcPaymentP;
-  return E.when(E(purse).deposit(srcPayment, optAmountShape), amount =>
-    E(purse).withdraw(amount),
+  return E.when(E(recoveryPurse).deposit(srcPayment, optAmountShape), amount =>
+    E(recoveryPurse).withdraw(amount),
   );
 };
 harden(claim);
 
 /**
- * Note: Not failure atomic. If any of the deposits fail, or the total does not
- * match optTotalAmount, some payments may still have been deposited.
+ * Note: Not failure atomic. But as long as you don't lose the argument
+ * `recoveryPurse`, no assets are lost.
+ * If any of the deposits fail, or the total does not
+ * match optTotalAmount, some payments may still have been deposited. Those
+ * assets will be in the argument `recoveryPurse`. All undeposited payments
+ * will still be in the recovery sets of their purses of origin.
  *
  * @template {AssetKind} K
- * @param {ERef<Purse<K>>} purse
+ * @param {ERef<Purse<K>>} recoveryPurse
  * @param {ERef<Payment<K>>[]} srcPaymentsPs
  * @param {Pattern} [optTotalAmount]
  * @returns {Promise<Payment<K>>}
  */
 export const combine = async (
-  purse,
+  recoveryPurse,
   srcPaymentsPs,
   optTotalAmount = undefined,
 ) => {
+  const brandP = E(recoveryPurse).getAllegedBrand();
   const [brand, displayInfo, ...srcPayments] = await Promise.all([
-    E(purse).getAllegedBrand(),
-    E(E(purse).getAllegedBrand()).getDisplayInfo(),
+    brandP,
+    E(brandP).getDisplayInfo(),
     ...srcPaymentsPs,
   ]);
   const emptyAmount = AmountMath.makeEmpty(brand, displayInfo.assetKind);
-  const amountPs = srcPayments.map(srcPayment => E(purse).deposit(srcPayment));
+  const amountPs = srcPayments.map(srcPayment =>
+    E(recoveryPurse).deposit(srcPayment),
+  );
   const amounts = await Promise.all(amountPs);
   const total = amounts.reduce(
     (x, y) => AmountMath.add(x, y, brand),
@@ -61,38 +76,60 @@ export const combine = async (
   if (optTotalAmount !== undefined) {
     mustMatch(total, optTotalAmount, 'amount');
   }
-  return E(purse).withdraw(total);
+  return E(recoveryPurse).withdraw(total);
 };
 harden(combine);
 
 /**
+ * Note: Not failure atomic. But as long as you don't lose the argument
+ * `recoveryPurse`, no assets are lost.
+ * If the amount in `srcPaymentP` is not >= `paymentAmountA`, the payment may
+ * still be deposited anyway, before failing in the subsequent subtract.
+ * In that case, those
+ * assets will be in the argument `recoveryPurse`.
+ *
  * @template {AssetKind} K
- * @param {ERef<Purse<K>>} purse
+ * @param {ERef<Purse<K>>} recoveryPurse
  * @param {ERef<Payment<K>>} srcPaymentP
  * @param {Amount<K>} paymentAmountA
  * @returns {Promise<Payment<K>[]>}
  */
-export const split = async (purse, srcPaymentP, paymentAmountA) => {
+export const split = async (recoveryPurse, srcPaymentP, paymentAmountA) => {
   const srcPayment = await srcPaymentP;
-  const srcAmount = await E(purse).deposit(srcPayment);
+  // See https://github.com/Agoric/agoric-sdk/issues/7193 which explains
+  // how we would like to write the following line, and why we cannot yet do so.
+  const srcAmount = await E(recoveryPurse).deposit(srcPayment);
   const paymentAmountB = AmountMath.subtract(srcAmount, paymentAmountA);
   return Promise.all([
-    E(purse).withdraw(paymentAmountA),
-    E(purse).withdraw(paymentAmountB),
+    E(recoveryPurse).withdraw(paymentAmountA),
+    E(recoveryPurse).withdraw(paymentAmountB),
   ]);
 };
 harden(split);
 
 /**
+ * Note: Not failure atomic. But as long as you don't lose the argument
+ * `recoveryPurse`, no assets are lost.
+ * If the amount in `srcPaymentP` is exactly the sum of the amounts,
+ * the payment may
+ * still be deposited anyway, before failing in the subsequent equality check.
+ * In that case, those
+ * assets will be in the argument `recoveryPurse`.
+ *
  * @template {AssetKind} K
- * @param {ERef<Purse<K>>} purse
+ * @param {ERef<Purse<K>>} recoveryPurse
  * @param {ERef<Payment<K>>} srcPaymentP
  * @param {Amount<K>[]} amounts
  * @returns {Promise<Payment[]>}
  */
-export const splitMany = async (purse, srcPaymentP, amounts) => {
+export const splitMany = async (recoveryPurse, srcPaymentP, amounts) => {
   const srcPayment = await srcPaymentP;
-  const srcAmount = await E(purse).deposit(srcPayment);
+  // If we could calculate `total` before the `deposit`, then we
+  // could use the `total` as the second argument to `deposit` and be
+  // failure atomic. But this would require making an empty amount first,
+  // which is possible, but too much trouble for a deprecated legacy support
+  // method.
+  const srcAmount = await E(recoveryPurse).deposit(srcPayment);
   const brand = srcAmount.brand;
   const emptyAmount = AmountMath.makeEmptyFromAmount(srcAmount);
   const total = amounts.reduce(
@@ -102,6 +139,6 @@ export const splitMany = async (purse, srcPaymentP, amounts) => {
   AmountMath.isEqual(srcAmount, total) ||
     Fail`rights were not conserved: ${total} vs ${srcAmount}`;
 
-  return Promise.all(amounts.map(amount => E(purse).withdraw(amount)));
+  return Promise.all(amounts.map(amount => E(recoveryPurse).withdraw(amount)));
 };
 harden(splitMany);

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -12,7 +12,6 @@ import { preparePurseKind } from './purse.js';
 
 import '@agoric/store/exported.js';
 import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
-import { claim, combine, split, splitMany } from './legacy-payment-helpers.js';
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
@@ -371,66 +370,6 @@ export const preparePaymentLedger = (
         throw err;
       }
       return paymentBalance;
-    },
-    /**
-     * Inherent to the nature of the Issuer API, this method is less safe
-     * than the similarly named helper function in legacy-payment-helpers.js
-     * since those helper functions will associate any newly created payment
-     * with the recovery set of the argument purse. The methods here are
-     * now trivial wrappers around those helpers, using a `makeEmptyPurse()`
-     * to make the needed purse, which they unsafely then drop on the floor.
-     *
-     * @deprecated Use helper function from legacy-payment-helpers.js
-     * @param {Payment} srcPayment awaited by callWhen
-     * @param {Pattern} [optAmountShape]
-     */
-    claim(srcPayment, optAmountShape = undefined) {
-      return claim(makeEmptyPurse(), srcPayment, optAmountShape);
-    },
-    /**
-     * Inherent to the nature of the Issuer API, this method is less safe
-     * than the similarly named helper function in legacy-payment-helpers.js
-     * since those helper functions will associate any newly created payment
-     * with the recovery set of the argument purse. The methods here are
-     * now trivial wrappers around those helpers, using a `makeEmptyPurse()`
-     * to make the needed purse, which they unsafely then drop on the floor.
-     *
-     * @deprecated Use helper function from legacy-payment-helpers.js
-     * @param {ERef<Payment>[]} fromPaymentsPArray
-     * @param {Pattern} [optTotalAmount]
-     */
-    combine(fromPaymentsPArray, optTotalAmount = undefined) {
-      return combine(makeEmptyPurse(), fromPaymentsPArray, optTotalAmount);
-    },
-    /**
-     * Inherent to the nature of the Issuer API, this method is less safe
-     * than the similarly named helper function in legacy-payment-helpers.js
-     * since those helper functions will associate any newly created payment
-     * with the recovery set of the argument purse. The methods here are
-     * now trivial wrappers around those helpers, using a `makeEmptyPurse()`
-     * to make the needed purse, which they unsafely then drop on the floor.
-     *
-     * @deprecated Use helper function from legacy-payment-helpers.js
-     * @param {Payment} srcPayment awaited by callWhen
-     * @param {Amount} paymentAmountA
-     */
-    split(srcPayment, paymentAmountA) {
-      return split(makeEmptyPurse(), srcPayment, paymentAmountA);
-    },
-    /**
-     * Inherent to the nature of the Issuer API, this method is less safe
-     * than the similarly named helper function in legacy-payment-helpers.js
-     * since those helper functions will associate any newly created payment
-     * with the recovery set of the argument purse. The methods here are
-     * now trivial wrappers around those helpers, using a `makeEmptyPurse()`
-     * to make the needed purse, which they unsafely then drop on the floor.
-     *
-     * @deprecated Use helper function from legacy-payment-helpers.js
-     * @param {Payment} srcPayment awaited by callWhen
-     * @param {*} amounts
-     */
-    splitMany(srcPayment, amounts) {
-      return splitMany(makeEmptyPurse(), srcPayment, amounts);
     },
   });
 

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -183,19 +183,6 @@ export const makeIssuerInterfaces = (
     burn: M.callWhen(M.await(PaymentShape))
       .optional(M.pattern())
       .returns(amountShape),
-    claim: M.callWhen(M.await(PaymentShape))
-      .optional(M.pattern())
-      .returns(PaymentShape),
-    combine: M.call(M.arrayOf(M.eref(PaymentShape)))
-      .optional(amountShape)
-      .returns(M.eref(PaymentShape)),
-    split: M.callWhen(M.await(PaymentShape), amountShape).returns(
-      M.arrayOf(PaymentShape),
-    ),
-    splitMany: M.callWhen(
-      M.await(PaymentShape),
-      M.arrayOf(amountShape),
-    ).returns(M.arrayOf(PaymentShape)),
   });
 
   const MintI = M.interface('Mint', {

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -239,10 +239,6 @@
  * @property {IssuerIsLive} isLive
  * @property {IssuerGetAmountOf<K>} getAmountOf
  * @property {IssuerBurn} burn
- * @property {IssuerClaim<K>} claim
- * @property {IssuerCombine<K>} combine
- * @property {IssuerSplit<K>} split
- * @property {IssuerSplitMany} splitMany
  */
 
 /**

--- a/packages/ERTP/test/unitTests/test-legacy-payment-helpers.js
+++ b/packages/ERTP/test/unitTests/test-legacy-payment-helpers.js
@@ -1,0 +1,39 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { makeIssuerKit, AmountMath } from '../../src/index.js';
+import { combine, split } from '../../src/legacy-payment-helpers.js';
+
+const { isEqual } = AmountMath;
+
+// See https://github.com/Agoric/agoric-sdk/pull/7113#discussion_r1136255069
+test('no lost assets on non-atomic combine failure', async t => {
+  const { issuer, mint, brand } = makeIssuerKit('precious');
+  const recoveryPurse = issuer.makeEmptyPurse();
+  const precious = num => AmountMath.make(brand, num);
+  const payment1 = mint.mintPayment(precious(39n));
+  const payment2 = payment1; // "accidental" aliasing
+  await t.throwsAsync(() => combine(recoveryPurse, [payment1, payment2]), {
+    message:
+      /^".*" was not a live payment for brand ".*". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.$/,
+  });
+
+  const live = await issuer.isLive(payment1);
+  t.assert(!live); // demonstrates non-failure atomicity
+  t.assert(isEqual(recoveryPurse.getCurrentAmount(), precious(39n)));
+});
+
+// See https://github.com/Agoric/agoric-sdk/pull/7113#discussion_r1136249574
+test('no lost assets on non-atomic split failure', async t => {
+  const { issuer, mint, brand } = makeIssuerKit('precious');
+  const recoveryPurse = issuer.makeEmptyPurse();
+  const precious = num => AmountMath.make(brand, num);
+  const srcPayment = mint.mintPayment(precious(78n));
+  await t.throwsAsync(() => split(recoveryPurse, srcPayment, precious(100n)), {
+    message: '-22 is negative',
+  });
+
+  const live = await issuer.isLive(srcPayment);
+  t.assert(!live); // demonstrates non-failure atomicity
+  t.assert(isEqual(recoveryPurse.getCurrentAmount(), precious(78n)));
+});


### PR DESCRIPTION
Staged on https://github.com/Agoric/agoric-sdk/pull/7112

https://github.com/Agoric/agoric-sdk/pull/7112 removed all uses of the deprecated issuer payment methods (claim, combine, split, splitMany). Once we're convinced that they are safely gone, this PR deletes those methods themselves.