### PR TITLE
feat(cosmic-swingset): Leave inbound actions in vstorage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 replace github.com/tendermint/tendermint => github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.3
 
 // We need a fork of cosmos-sdk until all of the differences are merged.
-replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.1
+replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.1.0.20230320225042-2109765fd835
 
 replace github.com/cosmos/gaia/v7 => github.com/Agoric/ag0/v7 v7.0.2-alpha.agoric.1
 

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/Zilliqa/gozilliqa-sdk v1.2.1-0.20201201074141-dd0ecada1be6/go.mod h1:
 github.com/adlio/schema v1.3.3 h1:oBJn8I02PyTB466pZO1UZEn1TV5XLlifBSyMrmHl/1I=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
-github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.1 h1:3GHpCatyGBaZDoSr9k6Rd5/5QnNghkzxgLfkDsPDBPk=
-github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.1/go.mod h1:fdXvzy+wmYB+W+N139yb0+szbT7zAGgUjmxm5DBrjto=
+github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.1.0.20230320225042-2109765fd835 h1:Mmw52cHAUNwtaNXpk7b3lTeoCRd5Vw9Fdrly5ABIxCA=
+github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.1.0.20230320225042-2109765fd835/go.mod h1:fdXvzy+wmYB+W+N139yb0+szbT7zAGgUjmxm5DBrjto=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1 h1:2jvHI/2d+psWAZy6FQ0vXJCHUtfU3ZbbW+pQFL04arQ=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.3 h1:aq6F1r3RQkKUYNeMNjRxgGn3dayvKnDK/R6gQF0WoFs=

--- a/golang/cosmos/x/swingset/keeper/keeper.go
+++ b/golang/cosmos/x/swingset/keeper/keeper.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	stdlog "log"
 	"math"
-	"strconv"
+	"math/big"
 
 	"github.com/tendermint/tendermint/libs/log"
 
@@ -34,7 +34,8 @@ const (
 	StoragePathBundles      = "bundles"
 )
 
-const MaxUint53 = 9007199254740991 // Number.MAX_SAFE_INTEGER = 2**53 - 1
+// 2 ** 256 - 1
+var MaxSDKInt = sdk.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)))
 
 const stateKey string = "state"
 
@@ -123,34 +124,40 @@ func (k Keeper) PushAction(ctx sdk.Context, action vm.Jsonable) error {
 	}
 
 	// Get the current queue tail, defaulting to zero if its vstorage doesn't exist.
+	// The `tail` is the value of the next index to be inserted
 	tail, err := k.actionQueueIndex(ctx, "tail")
 	if err != nil {
 		return err
 	}
 
-	// JS uses IEEE 754 floats so avoid overflowing integers
-	if tail == MaxUint53 {
+	if tail.Equal(MaxSDKInt) {
 		return errors.New(StoragePathActionQueue + " overflow")
 	}
+	nextTail := tail.Add(sdk.NewInt(1))
 
 	// Set the vstorage corresponding to the queue entry for the current tail.
-	path := StoragePathActionQueue + "." + strconv.FormatUint(tail, 10)
+	path := StoragePathActionQueue + "." + tail.String()
 	k.vstorageKeeper.SetStorage(ctx, vstoragetypes.NewStorageEntry(path, string(bz)))
 
 	// Update the tail to point to the next available entry.
 	path = StoragePathActionQueue + ".tail"
-	k.vstorageKeeper.SetStorage(ctx, vstoragetypes.NewStorageEntry(path, strconv.FormatUint(tail+1, 10)))
+	k.vstorageKeeper.SetStorage(ctx, vstoragetypes.NewStorageEntry(path, nextTail.String()))
 	return nil
 }
 
-func (k Keeper) actionQueueIndex(ctx sdk.Context, name string) (uint64, error) {
-	index := uint64(0)
-	var err error
-	indexEntry := k.vstorageKeeper.GetEntry(ctx, StoragePathActionQueue+"."+name)
-	if indexEntry.HasData() {
-		index, err = strconv.ParseUint(indexEntry.StringValue(), 10, 64)
+func (k Keeper) actionQueueIndex(ctx sdk.Context, position string) (sdk.Int, error) {
+	// Position should be either "head" or "tail"
+	path := StoragePathActionQueue + "." + position
+	indexEntry := k.vstorageKeeper.GetEntry(ctx, path)
+	if !indexEntry.HasData() {
+		return sdk.NewInt(0), nil
 	}
-	return index, err
+
+	index, ok := sdk.NewIntFromString(indexEntry.StringValue())
+	if !ok {
+		return index, fmt.Errorf("couldn't parse %s as Int: %s", path, indexEntry.StringValue())
+	}
+	return index, nil
 }
 
 func (k Keeper) ActionQueueLength(ctx sdk.Context) (int32, error) {
@@ -162,11 +169,17 @@ func (k Keeper) ActionQueueLength(ctx sdk.Context) (int32, error) {
 	if err != nil {
 		return 0, err
 	}
-	size := tail - head
-	if size > math.MaxInt32 {
+	// The tail index is exclusive
+	size := tail.Sub(head)
+	if !size.IsInt64() {
+		return 0, fmt.Errorf("%s size too big: %s", StoragePathActionQueue, size)
+	}
+
+	int64Size := size.Int64()
+	if int64Size > math.MaxInt32 {
 		return math.MaxInt32, nil
 	}
-	return int32(size), nil
+	return int32(int64Size), nil
 }
 
 // BlockingSend sends a message to the controller and blocks the Golang process

--- a/golang/cosmos/x/swingset/keeper/keeper.go
+++ b/golang/cosmos/x/swingset/keeper/keeper.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	stdlog "log"
 	"math"
 	"strconv"
 
 	"github.com/tendermint/tendermint/libs/log"
 
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
@@ -35,6 +37,25 @@ const (
 const MaxUint53 = 9007199254740991 // Number.MAX_SAFE_INTEGER = 2**53 - 1
 
 const stateKey string = "state"
+
+// Contextual information about the message source of an action on the queue.
+// This context should be unique per actionQueueRecord.
+type actionContext struct {
+	// The block height in which the corresponding action was enqueued
+	BlockHeight int64 `json:"blockHeight"`
+	// The hash of the cosmos transaction that included the message
+	// If the action didn't result from a transaction message, a substitute value
+	// may be used. For example the VBANK_BALANCE_UPDATE actions use `x/vbank`.
+	TxHash string `json:"txHash"`
+	// The index of the message within the transaction. If the action didn't
+	// result from a cosmos transaction, a number should be chosen to make the
+	// actionContext unique. (for example a counter per block and source module).
+	MsgIdx int `json:"msgIdx"`
+}
+type actionQueueRecord struct {
+	Action  vm.Jsonable   `json:"action"`
+	Context actionContext `json:"context"`
+}
 
 // Keeper maintains the link to data vstorage and exposes getter/setter methods for the various parts of the state machine
 type Keeper struct {
@@ -87,7 +108,16 @@ func NewKeeper(
 // The actionQueue's format is documented by `makeChainQueue` in
 // `packages/cosmic-swingset/src/make-queue.js`.
 func (k Keeper) PushAction(ctx sdk.Context, action vm.Jsonable) error {
-	bz, err := json.Marshal(action)
+	txHash, txHashOk := ctx.Context().Value(baseapp.TxHashContextKey).(string)
+	if !txHashOk {
+		txHash = "unknown"
+	}
+	msgIdx, msgIdxOk := ctx.Context().Value(baseapp.TxMsgIdxContextKey).(int)
+	if !txHashOk || !msgIdxOk {
+		stdlog.Printf("error while extracting context for action %q\n", action)
+	}
+	record := actionQueueRecord{Action: action, Context: actionContext{BlockHeight: ctx.BlockHeight(), TxHash: txHash, MsgIdx: msgIdx}}
+	bz, err := json.Marshal(record)
 	if err != nil {
 		return err
 	}

--- a/golang/cosmos/x/vbank/vbank.go
+++ b/golang/cosmos/x/vbank/vbank.go
@@ -1,12 +1,14 @@
 package vbank
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	stdlog "log"
 	"sort"
 
 	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -241,5 +243,11 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string
 }
 
 func (am AppModule) PushAction(ctx sdk.Context, action vm.Jsonable) error {
+	// vbank actions are not triggered by a swingset message in a transaction, so we need to
+	// synthesize unique context information.
+	// We use a fixed placeholder value for the txHash context, and can simply use `0` for the
+	// message index as there is only one such action per block.
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), baseapp.TxHashContextKey, "x/vbank"))
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), baseapp.TxMsgIdxContextKey, 0))
 	return am.keeper.PushAction(ctx, action)
 }

--- a/packages/cosmic-swingset/src/bufferedStorage.js
+++ b/packages/cosmic-swingset/src/bufferedStorage.js
@@ -1,10 +1,10 @@
-import { assert, details as X, Fail } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 
 // XXX Do these "StorageAPI" functions belong in their own package?
 
 /**
  * Assert function to ensure that an object implements the StorageAPI
- * interface: methods { has, getKeys, get, set, delete }
+ * interface: methods { has, getNextKey, get, set, delete }
  * (cf. packages/SwingSet/docs/state.md#transactions).
  *
  * @param {*} kvStore  The object to be tested
@@ -15,91 +15,8 @@ import { assert, details as X, Fail } from '@agoric/assert';
  * @returns {void}
  */
 export function insistStorageAPI(kvStore) {
-  for (const n of ['has', 'getKeys', 'get', 'set', 'delete']) {
+  for (const n of ['has', 'getNextKey', 'get', 'set', 'delete']) {
     n in kvStore || Fail`kvStore.${n} is missing, cannot use`;
-  }
-}
-
-/**
- * Given two iterators over sequences of unique strings sorted in ascending
- * order lexicographically by UTF-16 code unit, produce a new iterator that will
- * output the ascending sequence of unique strings from their merged output.
- *
- * @param {Iterator} it1
- * @param {Iterator} it2
- *
- * @yields any
- */
-function* mergeUtf16SortedIterators(it1, it2) {
-  /** @type {IteratorResult<any> | null} */
-  let v1 = null;
-  /** @type {IteratorResult<any> | null} */
-  let v2 = null;
-  /** @type {IteratorResult<any> | null} */
-  let vrest = null;
-  /** @type {Iterator<any> | null} */
-  let itrest = null;
-
-  try {
-    v1 = it1.next();
-    v2 = it2.next();
-    while (!v1.done && !v2.done) {
-      if (v1.value < v2.value) {
-        const result = v1.value;
-        v1 = it1.next();
-        yield result;
-      } else if (v1.value > v2.value) {
-        const result = v2.value;
-        v2 = it2.next();
-        yield result;
-      } else {
-        // Each iterator produced the same value; consume it from both.
-        const result = v1.value;
-        v1 = it1.next();
-        v2 = it2.next();
-        yield result;
-      }
-    }
-
-    itrest = v1.done ? it2 : it1;
-    vrest = v1.done ? v2 : v1;
-    v1 = null;
-    v2 = null;
-
-    while (!vrest.done) {
-      const result = vrest.value;
-      vrest = itrest.next();
-      yield result;
-    }
-  } finally {
-    const errors = [];
-    try {
-      if (vrest && !vrest.done && itrest && itrest.return) {
-        itrest.return();
-      }
-    } catch (e) {
-      errors.push(e);
-    }
-    try {
-      if (v1 && !v1.done && it1.return) {
-        it1.return();
-      }
-    } catch (e) {
-      errors.push(e);
-    }
-    try {
-      if (v2 && !v2.done && it2.return) {
-        it2.return();
-      }
-    } catch (e) {
-      errors.push(e);
-    }
-    if (errors.length) {
-      const err = assert.error(X`Merged iterator failed to close cleanly`);
-      for (const e of errors) {
-        assert.note(err, X`Caused by ${e}`);
-      }
-    }
   }
 }
 
@@ -159,55 +76,11 @@ export function makeBufferedStorage(kvStore, listeners = {}) {
     },
 
     /**
-     * Generator function that returns an iterator over all the keys within a
-     * given range, in lexicographical order by UTF-16 code unit.
-     *
-     * Warning: this function introduces consistency risks that callers must
-     * take into account. Results do not include include keys added during
-     * iteration.  This layer of abstraction lacks the knowledge necessary to
-     * protect callers, as the nature of the risks varies depending on what a
-     * caller is trying to do.  This API should not be made available to user
-     * vat code.  Rather, it is intended as a low-level mechanism to use in
-     * implementating higher level storage abstractions that are expected to
-     * provide their own consistency protections as appropriate to their own
-     * circumstances.
-     *
-     * @param {string} start  Start of the key range of interest (inclusive).  An empty
-     *    string indicates a range from the beginning of the key set.
-     * @param {string} end  End of the key range of interest (exclusive).  An empty string
-     *    indicates a range through the end of the key set.
-     *
-     * @yields {string} an iterator for the keys from start <= key < end
-     *
-     * @throws if either parameter is not a string.
+     * @param {string} previousKey
      */
-    *getKeys(start, end) {
-      assert.typeof(start, 'string');
-      assert.typeof(end, 'string');
-
-      // Merge keys reported by the backing store and a snapshot of in-range
-      // additions into a single duplicate-free iterator.
-      const added = [];
-      for (const k of additions.keys()) {
-        if ((start === '' || start <= k) && (end === '' || k < end)) {
-          added.push(k);
-        }
-      }
-      // Note that this implicitly compares keys lexicographically by UTF-16
-      // code unit (e.g., "\u{1D306}" _precedes_ "\u{FFFD}").
-      // If kvStore.getKeys() results are not in ascending order subject to the
-      // same comparison, then output may include duplicates.
-      added.sort();
-      const merged = mergeUtf16SortedIterators(
-        added.values(),
-        kvStore.getKeys(start, end),
-      );
-
-      for (const k of merged) {
-        if (!deletions.has(k)) {
-          yield k;
-        }
-      }
+    getNextKey(previousKey) {
+      assert.typeof(previousKey, 'string');
+      throw new Error('not implemented');
     },
   };
   function commit() {
@@ -264,8 +137,7 @@ export const makeReadCachingStorage = getterSetter => {
       // Deletion in chain storage manifests as set-to-undefined.
       storage.set(key, undefined);
     },
-    // eslint-disable-next-line require-yield
-    *getKeys(_start, _end) {
+    getNextKey(_previousKey) {
       throw new Error('not implemented');
     },
   });

--- a/packages/cosmic-swingset/src/kernel-stats.js
+++ b/packages/cosmic-swingset/src/kernel-stats.js
@@ -256,9 +256,14 @@ export function makeInboundQueueMetrics(initialLength) {
   let remove = 0;
 
   return harden({
-    incStat: (delta = 1) => {
-      length += delta;
-      add += delta;
+    updateLength: newLength => {
+      const delta = newLength - length;
+      length = newLength;
+      if (delta > 0) {
+        add += delta;
+      } else {
+        remove -= delta;
+      }
     },
 
     decStat: (delta = 1) => {

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -244,14 +244,14 @@ export async function launch({
   // and disables commit/abort.
 
   const inboundQueuePrefix = getHostKey('inboundQueue.');
+  /** @type {import("./make-queue.js").QueueStorage} */
   const inboundQueueStorage = harden({
     get: key => {
-      const val = kvStore.get(inboundQueuePrefix + key);
-      return val ? JSON.parse(val) : undefined;
+      return kvStore.get(inboundQueuePrefix + key);
     },
     set: (key, value) => {
-      value !== undefined || Fail`value in inboundQueue must be defined`;
-      kvStore.set(inboundQueuePrefix + key, JSON.stringify(value));
+      typeof value === 'string' || Fail`value in inboundQueue must be a string`;
+      kvStore.set(inboundQueuePrefix + key, value);
     },
     delete: key => kvStore.delete(inboundQueuePrefix + key),
     commit: () => {}, // disable

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -217,7 +217,7 @@ export async function launch({
   replayChainSends,
   setActivityhash,
   bridgeOutbound,
-  makeInstallationPublisher = undefined,
+  makeInstallationPublisher,
   vatconfig,
   argv,
   env = process.env,
@@ -413,7 +413,6 @@ export async function launch({
       installationPublisher === undefined &&
       makeInstallationPublisher !== undefined
     ) {
-      // @ts-expect-error not really undefined. TODO give provideInstallationPublisher a signature.
       installationPublisher = makeInstallationPublisher();
     }
   }

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -210,7 +210,7 @@ function neverStop() {
 }
 
 export async function launch({
-  actionQueue,
+  actionQueueStorage,
   kernelStateDBDir,
   mailboxStorage,
   clearChainSends,
@@ -257,7 +257,10 @@ export async function launch({
     commit: () => {}, // disable
     abort: () => {}, // disable
   });
-  /** @type {ReturnType<typeof makeQueue<{context: any, action: any}>>} */
+  /** @typedef {ReturnType<typeof makeQueue<{context: any, action: any}>>} ActionQueue */
+  /** @type {ActionQueue} */
+  const actionQueue = makeQueue(actionQueueStorage);
+  /** @type {ActionQueue} */
   const inboundQueue = makeQueue(inboundQueueStorage);
 
   // Not to be confused with the gas model, this meter is for OpenTelemetry.

--- a/packages/cosmic-swingset/src/make-queue.js
+++ b/packages/cosmic-swingset/src/make-queue.js
@@ -12,6 +12,32 @@ import { Fail } from '@agoric/assert';
  */
 
 /**
+ * @typedef {{[idx: number]: string | undefined, head?: string, tail?: string}} QueueStorageDump
+ * @param {QueueStorageDump} [init]
+ * @returns {{storage: QueueStorage; dump: () => QueueStorageDump}}
+ */
+export const makeQueueStorageMock = init => {
+  const storage = new Map(init && Object.entries(init));
+  return harden({
+    storage: {
+      get(key) {
+        return storage.get(key);
+      },
+      set(key, value) {
+        typeof value === 'string' || Fail`invalid value type ${value}`;
+        storage.set(key, value);
+      },
+      delete(key) {
+        storage.delete(key);
+      },
+      commit() {},
+      abort() {},
+    },
+    dump: () => harden(Object.fromEntries(storage.entries())),
+  });
+};
+
+/**
  * Create a queue backed by some sort of scoped storage.
  *
  * The queue writes the following bare keys, and expect any prefixing/scoping

--- a/packages/cosmic-swingset/src/make-queue.js
+++ b/packages/cosmic-swingset/src/make-queue.js
@@ -50,9 +50,9 @@ export const makeQueue = storage => {
     },
     /** @returns {IterableIterator<T>} */
     consumeAll: () => {
-      let done = false;
       let head = getHead();
       const tail = getTail();
+      let done = !(head < tail);
       const iterator = {
         [Symbol.iterator]: () => iterator,
         next: () => {

--- a/packages/cosmic-swingset/src/make-queue.js
+++ b/packages/cosmic-swingset/src/make-queue.js
@@ -29,17 +29,17 @@
  * @param {QueueStorage} storage a scoped queue storage
  */
 export const makeQueue = storage => {
-  const getHead = () => Number.parseInt(storage.get('head') || '0', 10);
-  const getTail = () => Number.parseInt(storage.get('tail') || '0', 10);
+  const getHead = () => BigInt(storage.get('head') || 0);
+  const getTail = () => BigInt(storage.get('tail') || 0);
 
   const queue = {
     size: () => {
-      return getTail() - getHead();
+      return Number(getTail() - getHead());
     },
     /** @param {T} obj */
     push: obj => {
       const tail = getTail();
-      storage.set('tail', String(tail + 1));
+      storage.set('tail', String(tail + 1n));
       storage.set(`${tail}`, JSON.stringify(obj));
       storage.commit();
     },
@@ -59,7 +59,7 @@ export const makeQueue = storage => {
                   /** @type {string} */ (storage.get(headKey)),
                 );
                 storage.delete(headKey);
-                head += 1;
+                head += 1n;
                 return { value, done };
               }
               // Reached the end, so clean up our indices.

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -149,14 +149,17 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
       // Gather up the new messages into the latest block.
       const thisBlock = intoChain.splice(0, queueAllowed[QueueInbound]);
 
-      for (const [newMessages, acknum] of thisBlock) {
+      for (const [i, [newMessages, acknum]] of thisBlock.entries()) {
         aqContents.push({
-          type: 'DELIVER_INBOUND',
-          peer: bootAddress,
-          messages: newMessages,
-          ack: acknum,
-          blockHeight,
-          blockTime,
+          action: {
+            type: 'DELIVER_INBOUND',
+            peer: bootAddress,
+            messages: newMessages,
+            ack: acknum,
+            blockHeight,
+            blockTime,
+          },
+          context: { blockHeight, txHash: 'simTx', msgIdx: i },
         });
       }
       const endAction = { type: 'END_BLOCK', blockHeight, blockTime };


### PR DESCRIPTION
closes: #7102
refs: https://github.com/agoric-labs/cosmos-sdk/pull/300 (pre-requisite)

Best reviewed commit-by-commit

## Description

Remove the inboundQueue from swingstore, keep pending inbound actions in the vstorage backed `actionQueue`.
To keep functionality intact, create a new context for actions at the cosmos level, which includes `blockHeight`, `txHash` and `msgIdx`, which in the future will allow better integrated telemetry. Use that context to generate the `inboundNum` identifier.
InboundAllowed is now computed in the golang side, meaning cosmic-swingset no longer has a say in how many actions should be pending. If we need to in the future, we can re-introduce data that cosmic-swingset can return to cosmos to include in the decision.

### Security Considerations

None

### Scaling Considerations

This will potentially make 2 performance related upcoming features slightly more complicated:
- #6741 will need to cache the actionQueue in the swingstore for access after endblock. The queue synchronization is already written and I will update that PR on top of this one
- #5966 will require two vstorage backed "action queue". Cosmos already needed to be aware of the type of each message, it will now need to decorate the context with that information so that `PushAction` can pick the right queue instead of leaving that to cosmic-swingset

### Documentation Considerations

None

### Testing Considerations

Manually tested by dropping the computron limit and maxAllowedQueue size, and verified with the loadgen that inboundQueue limits still function correctly.