### PR TITLE
refactor(ertp): ertp on zones

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -43,6 +43,7 @@
     "@agoric/notifier": "^0.6.2",
     "@agoric/store": "^0.9.2",
     "@agoric/vat-data": "^0.5.2",
+    "@agoric/zone": "^0.2.2",
     "@endo/eventual-send": "^1.1.2",
     "@endo/far": "^1.0.4",
     "@endo/marshal": "^1.3.0",

--- a/packages/ERTP/src/index.js
+++ b/packages/ERTP/src/index.js
@@ -5,8 +5,8 @@ export * from './issuerKit.js';
 export * from './typeGuards.js';
 
 /**
- * Importing Baggage from `@agoric/ertp` is deprecated.
- * Import Baggage from `@agoric/vat-data` instead
+ * Importing Baggage from `@agoric/ertp` is deprecated. Import Baggage from
+ * `@agoric/vat-data` instead
  *
  * @typedef {import('@agoric/vat-data').Baggage} Baggage
  */

--- a/packages/ERTP/src/index.js
+++ b/packages/ERTP/src/index.js
@@ -3,3 +3,10 @@
 export * from './amountMath.js';
 export * from './issuerKit.js';
 export * from './typeGuards.js';
+
+/**
+ * Importing Baggage from `@agoric/ertp` is deprecated.
+ * Import Baggage from `@agoric/vat-data` instead
+ *
+ * @typedef {import('@agoric/vat-data').Baggage} Baggage
+ */

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -3,6 +3,7 @@
 import { assert } from '@agoric/assert';
 import { assertPattern } from '@agoric/store';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { makeDurableZone } from '@agoric/zone/durable.js';
 
 import { AssetKind, assertAssetKind } from './amountMath.js';
 import { coerceDisplayInfo } from './displayInfo.js';
@@ -13,6 +14,7 @@ import './types-ambient.js';
 // TODO Why does TypeScript lose the `MapStore` typing of `Baggage` here, even
 // though it knows the correct type at the exporting `@agoric/vat-data`
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
+/** @typedef {import('@agoric/zone').Zone} Zone */
 
 /**
  * @template {AssetKind} K
@@ -28,7 +30,7 @@ import './types-ambient.js';
  *
  * @template {AssetKind} K
  * @param {IssuerRecord<K>} issuerRecord
- * @param {Baggage} issuerBaggage
+ * @param {Zone} issuerZone
  * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
  *   the middle of an atomic action (which btw should never happen), it
  *   potentially leaves its ledger in a corrupted state. If this function was
@@ -40,7 +42,7 @@ import './types-ambient.js';
  */
 const setupIssuerKit = (
   { name, assetKind, displayInfo, elementShape },
-  issuerBaggage,
+  issuerZone,
   optShutdownWithFailure = undefined,
 ) => {
   assert.typeof(name, 'string');
@@ -60,7 +62,7 @@ const setupIssuerKit = (
   /** @type {PaymentLedger<K>} */
   // @ts-expect-error could be instantiated with different subtype of AssetKind
   const { issuer, mint, brand, mintRecoveryPurse } = preparePaymentLedger(
-    issuerBaggage,
+    issuerZone,
     name,
     assetKind,
     cleanDisplayInfo,
@@ -101,7 +103,8 @@ export const upgradeIssuerKit = (
   optShutdownWithFailure = undefined,
 ) => {
   const issuerRecord = issuerBaggage.get(INSTANCE_KEY);
-  return setupIssuerKit(issuerRecord, issuerBaggage, optShutdownWithFailure);
+  const issuerZone = makeDurableZone(issuerBaggage);
+  return setupIssuerKit(issuerRecord, issuerZone, optShutdownWithFailure);
 };
 harden(upgradeIssuerKit);
 
@@ -167,7 +170,8 @@ export const makeDurableIssuerKit = (
 ) => {
   const issuerData = harden({ name, assetKind, displayInfo, elementShape });
   issuerBaggage.init(INSTANCE_KEY, issuerData);
-  return setupIssuerKit(issuerData, issuerBaggage, optShutdownWithFailure);
+  const issuerZone = makeDurableZone(issuerBaggage);
+  return setupIssuerKit(issuerData, issuerZone, optShutdownWithFailure);
 };
 harden(makeDurableIssuerKit);
 

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -11,11 +11,6 @@ import { preparePaymentLedger } from './paymentLedger.js';
 
 import './types-ambient.js';
 
-// TODO Why does TypeScript lose the `MapStore` typing of `Baggage` here, even
-// though it knows the correct type at the exporting `@agoric/vat-data`
-/** @typedef {import('@agoric/vat-data').Baggage} Baggage */
-/** @typedef {import('@agoric/zone').Zone} Zone */
-
 /**
  * @template {AssetKind} K
  * @typedef {object} IssuerRecord
@@ -30,7 +25,7 @@ import './types-ambient.js';
  *
  * @template {AssetKind} K
  * @param {IssuerRecord<K>} issuerRecord
- * @param {Zone} issuerZone
+ * @param {import('@agoric/zone').Zone} issuerZone
  * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
  *   the middle of an atomic action (which btw should never happen), it
  *   potentially leaves its ledger in a corrupted state. If this function was
@@ -88,7 +83,7 @@ const INSTANCE_KEY = 'issuer';
  * make a new one.
  *
  * @template {AssetKind} K
- * @param {Baggage} issuerBaggage
+ * @param {import('@agoric/vat-data').Baggage} issuerBaggage
  * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails in
  *   the middle of an atomic action (which btw should never happen), it
  *   potentially leaves its ledger in a corrupted state. If this function was
@@ -111,7 +106,7 @@ harden(upgradeIssuerKit);
 /**
  * Does baggage already have an issuerKit?
  *
- * @param {Baggage} baggage
+ * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const hasIssuer = baggage => baggage.has(INSTANCE_KEY);
 
@@ -145,7 +140,7 @@ export const hasIssuer = baggage => baggage.has(INSTANCE_KEY);
  *   basic fungible tokens.
  *
  *   `displayInfo` gives information to the UI on how to display the amount.
- * @param {Baggage} issuerBaggage
+ * @param {import('@agoric/vat-data').Baggage} issuerBaggage
  * @param {string} name
  * @param {K} [assetKind]
  * @param {AdditionalDisplayInfo} [displayInfo]
@@ -191,7 +186,7 @@ harden(makeDurableIssuerKit);
  *   basic fungible tokens.
  *
  *   `displayInfo` gives information to the UI on how to display the amount.
- * @param {Baggage} issuerBaggage
+ * @param {import('@agoric/vat-data').Baggage} issuerBaggage
  * @param {string} name
  * @param {K} [assetKind]
  * @param {AdditionalDisplayInfo} [displayInfo]

--- a/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
@@ -12,10 +12,10 @@ import {
 } from '@agoric/store';
 import '../types-ambient.js';
 
-/** @type {CopyBag} */
+/** @type {import('@endo/patterns').CopyBag} */
 const empty = makeCopyBag([]);
 
-/** @type {MathHelpers<CopyBag>} */
+/** @type {MathHelpers<import('@endo/patterns').CopyBag>} */
 export const copyBagMathHelpers = harden({
   doCoerce: bag => {
     mustMatch(bag, M.bag(), 'bag of amount');

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -1,26 +1,24 @@
 // @jessie-check
 
 import { initEmpty } from '@agoric/store';
-import { prepareExoClass } from '@agoric/vat-data';
 
 /** @typedef {import('@endo/patterns').MethodGuard} MethodGuard */
 /**
  * @template {Record<string | symbol, MethodGuard>} [T=Record<string | symbol, MethodGuard>]
  * @typedef {import('@endo/patterns').InterfaceGuard<T>} InterfaceGuard
  */
-/** @typedef {import('@agoric/vat-data').Baggage} Baggage */
+/** @typedef {import('@agoric/zone').Zone} Zone */
 
 /**
  * @template {AssetKind} K
- * @param {Baggage} issuerBaggage
+ * @param {Zone} issuerZone
  * @param {string} name
  * @param {Brand<K>} brand
  * @param {InterfaceGuard} PaymentI
  * @returns {() => Payment<K>}
  */
-export const preparePaymentKind = (issuerBaggage, name, brand, PaymentI) => {
-  const makePayment = prepareExoClass(
-    issuerBaggage,
+export const preparePaymentKind = (issuerZone, name, brand, PaymentI) => {
+  const makePayment = issuerZone.exoClass(
     `${name} payment`,
     PaymentI,
     initEmpty,

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -2,19 +2,13 @@
 
 import { initEmpty } from '@agoric/store';
 
-/** @typedef {import('@endo/patterns').MethodGuard} MethodGuard */
-/**
- * @template {Record<string | symbol, MethodGuard>} [T=Record<string | symbol, MethodGuard>]
- * @typedef {import('@endo/patterns').InterfaceGuard<T>} InterfaceGuard
- */
-/** @typedef {import('@agoric/zone').Zone} Zone */
-
+// TODO Type InterfaceGuard better than InterfaceGuard<any>
 /**
  * @template {AssetKind} K
- * @param {Zone} issuerZone
+ * @param {import('@agoric/zone').Zone} issuerZone
  * @param {string} name
  * @param {Brand<K>} brand
- * @param {InterfaceGuard} PaymentI
+ * @param {import('@endo/patterns').InterfaceGuard<any>} PaymentI
  * @returns {() => Payment<K>}
  */
 export const preparePaymentKind = (issuerZone, name, brand, PaymentI) => {

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -10,8 +10,6 @@ import { preparePurseKind } from './purse.js';
 import '@agoric/store/exported.js';
 import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
 
-/** @typedef {import('@agoric/zone').Zone} Zone */
-
 const { details: X, quote: q, Fail } = assert;
 
 /**
@@ -69,7 +67,7 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
  * minting and transfer authority originates here.
  *
  * @template {AssetKind} K
- * @param {Zone} issuerZone
+ * @param {import('@agoric/zone').Zone} issuerZone
  * @param {string} name
  * @param {K} assetKind
  * @param {DisplayInfo<K>} displayInfo

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -3,11 +3,6 @@
 /* eslint-disable no-use-before-define */
 import { isPromise } from '@endo/promise-kit';
 import { mustMatch, M, keyEQ } from '@agoric/store';
-import {
-  provideDurableWeakMapStore,
-  prepareExo,
-  provide,
-} from '@agoric/vat-data';
 import { AmountMath } from './amountMath.js';
 import { preparePaymentKind } from './payment.js';
 import { preparePurseKind } from './purse.js';
@@ -15,7 +10,7 @@ import { preparePurseKind } from './purse.js';
 import '@agoric/store/exported.js';
 import { BrandI, makeIssuerInterfaces } from './typeGuards.js';
 
-/** @typedef {import('@agoric/vat-data').Baggage} Baggage */
+/** @typedef {import('@agoric/zone').Zone} Zone */
 
 const { details: X, quote: q, Fail } = assert;
 
@@ -74,7 +69,7 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
  * minting and transfer authority originates here.
  *
  * @template {AssetKind} K
- * @param {Baggage} issuerBaggage
+ * @param {Zone} issuerZone
  * @param {string} name
  * @param {K} assetKind
  * @param {DisplayInfo<K>} displayInfo
@@ -83,7 +78,7 @@ const amountShapeFromElementShape = (brand, assetKind, elementShape) => {
  * @returns {PaymentLedger<K>}
  */
 export const preparePaymentLedger = (
-  issuerBaggage,
+  issuerZone,
   name,
   assetKind,
   displayInfo,
@@ -91,8 +86,12 @@ export const preparePaymentLedger = (
   optShutdownWithFailure = undefined,
 ) => {
   /** @type {Brand<K>} */
-  // @ts-expect-error XXX callWhen
-  const brand = prepareExo(issuerBaggage, `${name} brand`, BrandI, {
+  // Should be
+  // at-ts-expect-error XXX callWhen
+  // but ran into the usual disagreement between local lint and CI
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore
+  const brand = issuerZone.exo(`${name} brand`, BrandI, {
     isMyIssuer(allegedIssuer) {
       // BrandI delays calling this method until `allegedIssuer` is a Remotable
       return allegedIssuer === issuer;
@@ -121,7 +120,7 @@ export const preparePaymentLedger = (
     amountShape,
   );
 
-  const makePayment = preparePaymentKind(issuerBaggage, name, brand, PaymentI);
+  const makePayment = preparePaymentKind(issuerZone, name, brand, PaymentI);
 
   /** @type {ShutdownWithFailure} */
   const shutdownLedgerWithFailure = reason => {
@@ -139,11 +138,9 @@ export const preparePaymentLedger = (
   };
 
   /** @type {WeakMapStore<Payment, Amount>} */
-  const paymentLedger = provideDurableWeakMapStore(
-    issuerBaggage,
-    'paymentLedger',
-    { valueShape: amountShape },
-  );
+  const paymentLedger = issuerZone.weakMapStore('paymentLedger', {
+    valueShape: amountShape,
+  });
 
   /**
    * A withdrawn live payment is associated with the recovery set of the purse
@@ -164,10 +161,7 @@ export const preparePaymentLedger = (
    *
    * @type {WeakMapStore<Payment, SetStore<Payment>>}
    */
-  const paymentRecoverySets = provideDurableWeakMapStore(
-    issuerBaggage,
-    'paymentRecoverySets',
-  );
+  const paymentRecoverySets = issuerZone.weakMapStore('paymentRecoverySets');
 
   /**
    * To maintain the invariants listed in the `paymentRecoverySets` comment,
@@ -293,7 +287,7 @@ export const preparePaymentLedger = (
   /** @type {() => Purse<K>} */
   // @ts-expect-error type parameter confusion
   const makeEmptyPurse = preparePurseKind(
-    issuerBaggage,
+    issuerZone,
     name,
     assetKind,
     brand,
@@ -305,8 +299,12 @@ export const preparePaymentLedger = (
   );
 
   /** @type {Issuer<K>} */
-  // @ts-expect-error cast due to callWhen discrepancy
-  const issuer = prepareExo(issuerBaggage, `${name} issuer`, IssuerI, {
+  // Should be
+  // at-ts-expect-error cast due to callWhen discrepancy
+  // but ran into the usual disagreement between local lint and CI
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore
+  const issuer = issuerZone.exo(`${name} issuer`, IssuerI, {
     getBrand() {
       return brand;
     },
@@ -359,20 +357,28 @@ export const preparePaymentLedger = (
    * Because the `mintRecoveryPurse` is placed in baggage, even if the caller of
    * `makeIssuerKit` drops it on the floor, it can still be recovered in an
    * emergency upgrade.
-   *
-   * @type {Purse<K>}
    */
-  const mintRecoveryPurse = provide(issuerBaggage, 'mintRecoveryPurse', () =>
-    makeEmptyPurse(),
+  // Should be
+  // at-ts-expect-error checked cast
+  // but ran into the usual disagreement between local lint and IDE lint.
+  // Don't know yet about lint under CI.
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+  // @ts-ignore
+  const mintRecoveryPurse = /** @type {Purse<K>} */ (
+    issuerZone.makeOnce('mintRecoveryPurse', () => makeEmptyPurse())
   );
 
   /** @type {Mint<K>} */
-  const mint = prepareExo(issuerBaggage, `${name} mint`, MintI, {
+  const mint = issuerZone.exo(`${name} mint`, MintI, {
     getIssuer() {
       return issuer;
     },
     mintPayment(newAmount) {
-      // @ts-expect-error checked cast
+      // Should be
+      // at-ts-expect-error checked cast
+      // but ran into the usual disagreement between local lint and CI
+      // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+      // @ts-ignore
       newAmount = coerce(newAmount);
       mustMatch(newAmount, amountShape, 'minted amount');
       // `rawPayment` is not associated with any recovery set, and

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -3,20 +3,17 @@ import { AmountMath } from './amountMath.js';
 import { makeTransientNotifierKit } from './transientNotifier.js';
 import { makeAmountStore } from './amountStore.js';
 
-// TODO `InterfaceGuard` type parameter
-/** @typedef {import('@endo/patterns').InterfaceGuard} InterfaceGuard */
-/** @typedef {import('@agoric/zone').Zone} Zone */
-
 const { Fail } = assert;
 
+// TODO Type InterfaceGuard better than InterfaceGuard<any>
 /**
- * @param {Zone} issuerZone
+ * @param {import('@agoric/zone').Zone} issuerZone
  * @param {string} name
  * @param {AssetKind} assetKind
  * @param {Brand} brand
  * @param {{
- *   purse: InterfaceGuard;
- *   depositFacet: InterfaceGuard;
+ *   purse: import('@endo/patterns').InterfaceGuard<any>;
+ *   depositFacet: import('@endo/patterns').InterfaceGuard<any>;
  * }} PurseIKit
  * @param {{
  *   depositInternal: any;

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -3,11 +3,6 @@
 /// <reference types="ses"/>
 
 /**
- * @template {Key} [K=Key]
- * @typedef {import('@endo/patterns').CopyBag<K>} CopyBag
- */
-
-/**
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} Amount Amounts are descriptions of digital assets,
  *   answering the questions "how much" and "of what kind". Amounts are values
@@ -22,8 +17,8 @@
  */
 
 /**
- * @typedef {NatValue | SetValue | CopySet | CopyBag} AmountValue An
- *   `AmountValue` describes a set or quantity of assets that can be owned or
+ * @typedef {NatValue | SetValue | CopySet | import('@endo/patterns').CopyBag} AmountValue
+ *   An `AmountValue` describes a set or quantity of assets that can be owned or
  *   shared.
  *
  *   A fungible `AmountValue` uses a non-negative bigint to represent a quantity
@@ -58,7 +53,7 @@
  *   : K extends 'copySet'
  *   ? CopySet
  *   : K extends 'copyBag'
- *   ? CopyBag
+ *   ? import('@endo/patterns').CopyBag
  *   : never} AssetValueForKind
  */
 
@@ -70,7 +65,7 @@
  *   ? 'set'
  *   : V extends CopySet
  *   ? 'copySet'
- *   : V extends CopyBag
+ *   : V extends import('@endo/patterns').CopyBag
  *   ? 'copyBag'
  *   : never} AssetKindForValue
  */

--- a/packages/ERTP/test/unitTests/mathHelpers/test-copyBagMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-copyBagMathHelpers.js
@@ -65,7 +65,7 @@ test('copyBag with strings getValue', t => {
   );
   t.deepEqual(
     getCopyBagEntries(
-      /** @type {CopyBag} */ (
+      /** @type {import('@endo/patterns').CopyBag} */ (
         m.getValue(
           mockBrand,
           harden({ brand: mockBrand, value: makeBag(['1']) }),


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/8021 https://github.com/Agoric/agoric-sdk/pull/8965 https://github.com/Agoric/agoric-sdk/pull/8977 https://github.com/Agoric/agoric-sdk/pull/8779

## Description

ERTP predates both durability and zones. Before zones, it was made durable using baggage-based abstractions. We want to start shifting in general from baggage-based durability to zone-based parameterizability, so that the same parameterizable abstraction can be run in different storage regimes (heap, virtual, durable).

However, the public exports of @agoric/ertp are not changed by this PR. These are the issuer making / preparing / upgrading functions to be invoked from outside @agoric/ertp, and remain parameterized by baggage as of this PR. Later PRs may also directly expose functions parameterized by zones, but this PR does not take that step. Thus, this PR by itself does not yet enable users of @agoric/ertp to parameterize issuer creation by zone.

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations

Aside from upgrade testing, nothing special. Because the publicly exported API of @agoric/ertp has not changed, nothing outside of this package needs new tests. The fact that CI runs without such modification supports that.

Likewise though less obviously for the tests inside @agoric/ertp. The fact that the change to internal APIs did not cause us to revise any tests within the package means that there are no unit tests that are using those internal APIs. A bit of a surprise, but not cause to change that in this PR.

### Upgrade Considerations

We believe we are using zones in a sufficiently literal analog to how we used to use baggage that this PR should not cause or need any change to durable state. If true, it should have no effect on upgrade. But this has not yet been tested. I would appreciate help in figuring out how to test that this PR is upgrade neutral.

