### PR TITLE
fix: patch solo wallet to not depend on local.agoric.com

### DIFF
--- a/patches/@agoric+wallet-ui+0.1.3-solo.0.patch
+++ b/patches/@agoric+wallet-ui+0.1.3-solo.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@agoric/wallet-ui/build/static/js/477.36027d30.chunk.js b/node_modules/@agoric/wallet-ui/build/static/js/477.36027d30.chunk.js
+index f6c325f..bc4f3d6 100644
+--- a/node_modules/@agoric/wallet-ui/build/static/js/477.36027d30.chunk.js
++++ b/node_modules/@agoric/wallet-ui/build/static/js/477.36027d30.chunk.js
+@@ -5,7 +5,7 @@
+           @message=${n}
+           @error=${e.onError}
+         ></agoric-iframe-messenger>
+-      `},hostConnected(){},hostDisconnected(){}}},P="https://local.agoric.com/?append=/wallet-bridge.html",S=(e,t)=>new Promise((n=>setTimeout(n,e,t))),L=function(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:v.Ol;return class extends s.oi{static get styles(){return s.iv`
++      `},hostConnected(){},hostDisconnected(){}}},P="https://wallet.agoric.app/locator/?append=/wallet-bridge.html",S=(e,t)=>new Promise((n=>setTimeout(n,e,t))),L=function(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:v.Ol;return class extends s.oi{static get styles(){return s.iv`
+         :host {
+           display: block;
+           padding: 25px;


### PR DESCRIPTION
refs: #6687

## Description

local.agoric.com was de-commissioned, but the wallet-ui package used by the solo (in `agoric start dev` mode) still referred to it.

### Security / Scaling / Documentation Considerations

none?

### Testing Considerations

@michaelfig would you double-check that this works somewhere other than my desk, please?
