### PR TITLE
fix(cosmic-swingset): Provide blockTime to bootstrap

### DIFF
--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -301,7 +301,10 @@ export async function launch({
     inboundQueueMetrics,
   });
 
-  async function bootstrapBlock() {
+  async function bootstrapBlock(_blockHeight, blockTime) {
+    // We need to let bootstrap know of the chain time. The time of the first
+    // block may be the genesis time, or the block time of the upgrade block.
+    timer.poll(blockTime);
     // This is before the initial block, we need to finish processing the
     // entire bootstrap before opening for business.
     const policy = neverStop();
@@ -687,7 +690,9 @@ export async function launch({
           blockHeight,
           runNum,
         });
-        await processAction(action.type, bootstrapBlock);
+        await processAction(action.type, async () =>
+          bootstrapBlock(blockHeight, blockTime),
+        );
         controller.writeSlogObject({
           type: 'cosmic-swingset-run-finish',
           blockHeight,


### PR DESCRIPTION
closes: #7124

## Description

call `timer.poll()` before running the bootstrap code.

The wiring of the device is performed synchronously when the devices are built, so there the implementation won't throw.
The implementation of `poll` should only access its own state since no callbacks would be registered yet, which seems safe to do before any bootstrap code has actually run. I have not fully audited the device code however to check this, just a cursory look.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Tested locally with the loadgen to make sure this change actually solves #7124 and that no timer related errors occur.
