### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,9 +6,15 @@ queue_rules:
       # Require integration tests before merging only
       - or:
           - label=bypass:integration
+          - check-failure!=Chain deployment test
+      - or:
+          - label=bypass:integration
           - check-success=deployment-test
           - check-neutral=deployment-test
           - check-skipped=deployment-test
+      - or:
+          - label=bypass:integration
+          - check-failure!=getting-started (link-cli)
       - or:
           - label=bypass:integration
           - check-skipped=getting-started
@@ -28,9 +34,15 @@ queue_rules:
       # Require integration tests before merging only
       - or:
           - label=bypass:integration
+          - check-failure!=Chain deployment test
+      - or:
+          - label=bypass:integration
           - check-success=deployment-test
           - check-neutral=deployment-test
           - check-skipped=deployment-test
+      - or:
+          - label=bypass:integration
+          - check-failure!=getting-started (link-cli)
       - or:
           - label=bypass:integration
           - check-skipped=getting-started


### PR DESCRIPTION
Refs: #6014 
Fixes: #7126 

This hopefully fixes mergify queue stalls and merge bypass we've been seeing when the integration tests fail