### PR TITLE
7004 wallet errors

### DIFF
--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -272,16 +272,14 @@ test.serial('errors', async t => {
   await eventLoopIteration();
 
   // Invalid priceRound argument
-  t.like(
-    await walletPushPrice({
+  await t.throwsAsync(
+    walletPushPrice({
       roundId: 1,
       unitPrice: 1,
     }),
     {
-      error:
-        'Error: In "pushPrice" method of (OracleKit oracle): arg 0: unitPrice: number 1 - Must be a bigint',
-      // trivially satisfied because the Want is empty
-      numWantsSatisfied: 1,
+      message:
+        'In "pushPrice" method of (OracleKit oracle): arg 0: unitPrice: number 1 - Must be a bigint',
     },
   );
   await eventLoopIteration();
@@ -300,14 +298,13 @@ test.serial('errors', async t => {
   await eventLoopIteration();
 
   // Invalid attempt to push again to the same round
-  t.like(
-    await walletPushPrice({
+  await t.throwsAsync(
+    walletPushPrice({
       roundId: 1,
       unitPrice: 1n,
     }),
     {
-      error: 'Error: cannot report on previous rounds',
-      numWantsSatisfied: 1,
+      message: 'cannot report on previous rounds',
     },
   );
 });
@@ -518,17 +515,11 @@ test.serial('govern oracles list', async t => {
   await E(timer).tickN(20);
 
   // verify removed oracle can no longer PushPrice /////////////////////////
-  {
-    const pushPriceOfferId = await pushPrice(oracleWallet, oracleOfferId, {
+  await t.throwsAsync(
+    pushPrice(oracleWallet, oracleOfferId, {
       roundId: 1,
       unitPrice: 123n,
-    });
-
-    const offerStatus =
-      oracleWalletComputedState.offerStatuses.get(pushPriceOfferId);
-    t.like(offerStatus, {
-      id: pushPriceOfferId,
-      error: 'Error: pushPrice for disabled oracle',
-    });
-  }
+    }),
+    { message: 'pushPrice for disabled oracle' },
+  );
 });

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -104,7 +104,7 @@ export const makeInvitationsHelper = (
 
       const { instance, description } = spec;
       // @ts-expect-error TS thinks it's always true. I'm doubtful.
-      assert(instance && description, 'missing instance or description');
+      (instance && description) || Fail`missing instance or description`;
       /** @type {Amount<'set'>} */
       const purseAmount = await E(invitationsPurse).getCurrentAmount();
       const invitations = AmountMath.getValue(invitationBrand, purseAmount);
@@ -142,10 +142,7 @@ export const makeInvitationsHelper = (
 
       const { previousOffer, invitationArgs = [], invitationMakerName } = spec;
       const makers = getInvitationContinuation(String(previousOffer));
-      assert(
-        makers,
-        `invalid value stored for previous offer ${previousOffer}`,
-      );
+      makers || Fail`invalid value stored for previous offer ${previousOffer}`;
       return E(makers)[invitationMakerName](...invitationArgs);
     },
   });

--- a/packages/smart-wallet/src/payments.js
+++ b/packages/smart-wallet/src/payments.js
@@ -1,3 +1,4 @@
+import { Fail } from '@agoric/assert';
 import { deeplyFulfilledObject, objectMap } from '@agoric/internal';
 import { E } from '@endo/far';
 
@@ -24,10 +25,8 @@ export const makePaymentsHelper = (purseForBrand, depositFacet) => {
      * @returns {PaymentPKeywordRecord}
      */
     withdrawGive(give) {
-      assert(
-        !keywordPaymentPromises,
-        'withdrawPayments can be called once per helper',
-      );
+      !keywordPaymentPromises ||
+        Fail`withdrawPayments can be called once per helper`;
       keywordPaymentPromises = objectMap(give, amount => {
         /** @type {Promise<import('./types').RemotePurse<any>>} */
         const purseP = purseForBrand(amount.brand);

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -65,8 +65,9 @@ const mapToRecord = map => Object.fromEntries(map.entries());
  */
 
 /**
- * @typedef {{ updated: 'offerStatus', status: import('./offers.js').OfferStatus } |
- *  { updated: 'balance'; currentAmount: Amount }
+ * @typedef {{ updated: 'offerStatus', status: import('./offers.js').OfferStatus }
+ *   | { updated: 'balance'; currentAmount: Amount }
+ *   | { updated: 'walletAction'; status: { error: string } }
  * } UpdateRecord Record of an update to the state of this wallet.
  *
  * Client is responsible for coalescing updates into a current state. See `coalesceUpdates` utility.
@@ -412,7 +413,7 @@ export const prepareSmartWallet = (baggage, shared) => {
 
           const logger = {
             info: (...args) => console.info('wallet', address, ...args),
-            error: (...args) => console.log('wallet', address, ...args),
+            error: (...args) => console.error('wallet', address, ...args),
           };
 
           const executor = makeOfferExecutor({
@@ -495,6 +496,20 @@ export const prepareSmartWallet = (baggage, shared) => {
                   throw Fail`invalid handle bridge action ${q(action)}`;
                 }
               }
+            },
+            /** @param {Error} err */
+            err => {
+              const { address, updatePublishKit } = this.state;
+              console.error(
+                'wallet',
+                address,
+                'handleBridgeAction error:',
+                err,
+              );
+              updatePublishKit.publisher.publish({
+                updated: 'walletAction',
+                status: { error: err.message },
+              });
             },
           );
         },

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -488,7 +488,7 @@ export const prepareSmartWallet = (baggage, shared) => {
             action => {
               switch (action.method) {
                 case 'executeOffer': {
-                  assert(canSpend, 'executeOffer requires spend authority');
+                  canSpend || Fail`executeOffer requires spend authority`;
                   return offers.executeOffer(action.offer);
                 }
                 default: {

--- a/packages/smart-wallet/test/devices.js
+++ b/packages/smart-wallet/test/devices.js
@@ -1,3 +1,4 @@
+import { Fail } from '@agoric/assert';
 import centralSupply from '@agoric/vats/bundles/bundle-centralSupply.js';
 import mintHolder from '@agoric/vats/bundles/bundle-mintHolder.js';
 import provisionPool from '@agoric/vats/bundles/bundle-provisionPool.js';
@@ -16,7 +17,7 @@ export const devices = {
     getNamedBundleCap: name => ({
       getBundle: () => {
         const bundle = bundles[name];
-        assert(bundle, `unknown bundle ${name}`);
+        bundle || Fail`unknown bundle ${name}`;
         return bundle;
       },
     }),

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -23,6 +23,7 @@ import { makeLoopback } from '@endo/captp';
 import { E, Far } from '@endo/far';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeFakeBankKit } from '@agoric/vats/tools/bank-utils.js';
+import { Fail } from '@agoric/assert';
 
 export { ActionType };
 
@@ -58,10 +59,8 @@ export const subscriptionKey = subscription => {
     .getStoreKey()
     .then(storeKey => {
       const [prefix, unique] = storeKey.storeSubkey.split(':');
-      assert(
-        prefix === 'fake',
-        'subscriptionKey helper only supports fake storage',
-      );
+      prefix === 'fake' ||
+        Fail`subscriptionKey helper only supports fake storage`;
       return unique;
     });
 };
@@ -89,7 +88,7 @@ const makeFakeBridgeManager = () =>
           assert.fail(`expected fromBridge`);
         },
         toBridge(obj) {
-          assert(handler, `No handler for ${bridgeId}`);
+          handler || Fail`No handler for ${bridgeId}`;
           // Rely on interface guard for validation.
           // This should also be validated upstream but don't rely on it.
           // @ts-expect-error handler possibly undefined

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
@@ -64,7 +64,7 @@ export const buildRootObject = () => {
       zoePK.resolve(zoeService);
 
       const v1BundleId = await E(vatAdmin).getBundleIDByName(wfV1BundleName);
-      assert(v1BundleId, 'bundleId must not be empty');
+      v1BundleId || Fail`bundleId must not be empty`;
       installation = await E(zoe).installBundleID(v1BundleId);
 
       const autoRefundBundleId = await E(vatAdmin).getBundleIDByName(

--- a/packages/vats/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-integration.js
@@ -203,6 +203,7 @@ test('open vault with insufficient funds gives helpful error', async t => {
   );
 
   const giveCollateral = 9.0;
+  // offer fails but execute() doesn't throw because it returns once the execution is passed to the contract
   await wd.executeOfferMaker(Offers.vaults.OpenVault, {
     offerId: 'open-vault',
     collateralBrandKey,


### PR DESCRIPTION
closes: #7004

## Description

Users need to be able find out about errors in their wallet actions. The offer handler already publishes errors to vstorage. This makes it so that errors that happen earlier, in reading the walletAction, also get published, under a new `updated: walletAction` status.

It leaves out publishing errors before that because there's no way yet to associate it with the account owner or transaction. And once there is, feeding it back will be done by the Cosmos bridge instead of the contract.

This also cleans up error handling within the offer executor. This required test changes, mostly simplifications to use `throwsAsync` instead of checking vstorage after. We have sufficient tests for offer failures writing to vstorage so we don't have to test it everywhere.

### Security Considerations

Error's `message` is logged to vstorage. The error construction should redact as needed.

### Scaling Considerations

Writes walletAction errors to vstorage.

### Documentation Considerations

--

### Testing Considerations

CI