### PR TITLE
7025 eliminate staging

### DIFF
--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -50,28 +50,6 @@ export const allEmpty = amounts => {
 };
 
 /**
- * Stage a transfer between `fromSeat` and `toSeat`, specified as the delta between
- * the gain and a loss on the `fromSeat`. The gain/loss are typically from the
- * give/want respectively of a proposal. The `key` is the allocation keyword.
- *
- * @deprecated Use atomicRearrange instead
- * @param {ZCFSeat} fromSeat
- * @param {ZCFSeat} toSeat
- * @param {Amount} fromLoses
- * @param {Amount} fromGains
- * @param {Keyword} key
- */
-export const stageDelta = (fromSeat, toSeat, fromLoses, fromGains, key) => {
-  // Must check `isEmpty`; can't subtract `empty` from a missing allocation.
-  if (!AmountMath.isEmpty(fromLoses)) {
-    toSeat.incrementBy(fromSeat.decrementBy(harden({ [key]: fromLoses })));
-  }
-  if (!AmountMath.isEmpty(fromGains)) {
-    fromSeat.incrementBy(toSeat.decrementBy(harden({ [key]: fromGains })));
-  }
-};
-
-/**
  * @param {Amount<'nat'>} debtLimit
  * @param {Amount<'nat'>} totalDebt
  * @param {Amount<'nat'>} toMint

--- a/packages/inter-protocol/src/reserve/doc.md
+++ b/packages/inter-protocol/src/reserve/doc.md
@@ -77,9 +77,7 @@ zoe ->> addCollateralHook: call addCollateralHook
 addCollateralHook ->> seat: get proposal
 
 addCollateralHook ->> addCollateralHook: get Keyword for amountIn brand
-addCollateralHook ->> seat: decrementBy amountIn
-addCollateralHook ->> collateralSeat: incrementBy collateralKeyword: amountIn
-addCollateralHook ->> zcf: reallocate collateralSeat, seat
+addCollateralHook ->> zcf: atomicTransfer amountIn from seat to collateralSeat
 addCollateralHook ->> seat: seat.exit()
 seat ->> zoe: added collateral to the reserve
 zoe ->> caller: return status

--- a/packages/inter-protocol/src/stakeFactory/stakeFactoryKit.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactoryKit.js
@@ -4,7 +4,10 @@ import { bindAllMethods, makeTracer } from '@agoric/internal';
 import { makePublishKit } from '@agoric/notifier';
 import { M, matches } from '@agoric/store';
 import { defineKindMulti } from '@agoric/vat-data';
-import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
+import {
+  assertProposalShape,
+  atomicRearrange,
+} from '@agoric/zoe/src/contractSupport/index.js';
 import { ceilMultiplyBy } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { addSubtract, assertOnlyKeys } from '../contractSupport.js';
 import { calculateCurrentDebt, reverseInterest } from '../interest-math.js';
@@ -342,14 +345,17 @@ const helperBehavior = {
     } = seat.getProposal();
     AmountMath.isGTE(runOffered, currentDebt) ||
       Fail`Offer ${runOffered} is not sufficient to pay off debt ${currentDebt}`;
-    vaultSeat.incrementBy(seat.decrementBy(harden({ [KW.Debt]: currentDebt })));
-    seat.incrementBy(
-      vaultSeat.decrementBy(
-        harden({ Attestation: vaultSeat.getAmountAllocated('Attestation') }),
-      ),
+    atomicRearrange(
+      zcf,
+      harden([
+        [seat, vaultSeat, { [KW.Debt]: currentDebt }],
+        [
+          vaultSeat,
+          seat,
+          { Attestation: vaultSeat.getAmountAllocated('Attestation') },
+        ],
+      ]),
     );
-
-    zcf.reallocate(seat, vaultSeat);
 
     manager.burnDebt(currentDebt, vaultSeat);
     state.open = false;


### PR DESCRIPTION
closes: #7025

## Description

This removes all use of zcf staging except in ZCF tests and in `atomicRearrange` that is to replace stagings.

This doesn't close https://github.com/Agoric/agoric-sdk/issues/6678, which should be closed when there is no more `.reallocate` method and the atomicRearrange function is on zcf instead.

### Security Considerations

--
### Scaling Considerations

--
### Documentation Considerations

--
### Testing Considerations

CI