### PR TITLE
use entries to represent maps in vstorage

### DIFF
--- a/packages/agoric-cli/src/commands/vaults.js
+++ b/packages/agoric-cli/src/commands/vaults.js
@@ -43,9 +43,9 @@ export const makeVaultsCommand = async logger => {
     .action(async function (opts) {
       const current = await getCurrent(opts.from, fromBoard, { vstorage });
 
-      const vaultStoragePaths = Object.values(
-        current.offerToPublicSubscriberPaths,
-      ).map(pathmap => pathmap.vault);
+      const vaultStoragePaths = current.offerToPublicSubscriberPaths.map(
+        ([_offerId, pathmap]) => pathmap.vault,
+      );
 
       for (const path of vaultStoragePaths) {
         process.stdout.write(path);

--- a/packages/agoric-cli/src/lib/format.js
+++ b/packages/agoric-cli/src/lib/format.js
@@ -167,7 +167,7 @@ export const summarize = (current, coalesced, agoricNames) => {
       // @ts-ignore xxx RpcRemote
       Object.values(agoricNames.vbankAsset),
     ),
-    usedInvitations: Object.entries(current.offerToUsedInvitation).map(
+    usedInvitations: current.offerToUsedInvitation.map(
       ([offerId, invitationAmt]) => [
         agoricNames.reverse[invitationAmt.value[0].instance.boardId],
         invitationAmt.value[0].description,

--- a/packages/agoric-cli/src/lib/format.js
+++ b/packages/agoric-cli/src/lib/format.js
@@ -159,7 +159,6 @@ export const offerStatusTuples = (state, agoricNames) => {
  */
 export const summarize = (current, coalesced, agoricNames) => {
   return {
-    lastOfferId: [current.lastOfferId],
     purses: purseBalanceTuples(
       // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- https://github.com/Agoric/agoric-sdk/issues/4620 */
       // @ts-ignore xxx RpcRemote

--- a/packages/inter-protocol/src/clientSupport.js
+++ b/packages/inter-protocol/src/clientSupport.js
@@ -136,9 +136,7 @@ const makeCloseOffer = (brands, opts, previousOffer) => {
 export const lookupOfferIdForVault = async (vaultId, currentP) => {
   const { offerToPublicSubscriberPaths } = await currentP;
 
-  for (const [offerId, publicSubscribers] of Object.entries(
-    offerToPublicSubscriberPaths,
-  )) {
+  for (const [offerId, publicSubscribers] of offerToPublicSubscriberPaths) {
     if (publicSubscribers.vault?.endsWith(vaultId)) {
       return offerId;
     }

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -212,9 +212,13 @@ test.serial('invitations', async t => {
   const currentSub = E(wallet).getCurrentSubscriber();
   /** @type {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord} */
   const currentState = await headValue(currentSub);
-  t.deepEqual(Object.keys(currentState.offerToUsedInvitation), [id]);
+  t.deepEqual(
+    currentState.offerToUsedInvitation.map(([k, _]) => k),
+    [id],
+  );
+  const usedInvitations = new Map(currentState.offerToUsedInvitation);
   t.is(
-    currentState.offerToUsedInvitation[id].value[0].description,
+    usedInvitations.get(id)?.value[0].description,
     ORACLE_INVITATION_MAKERS_DESC,
   );
 });
@@ -389,12 +393,13 @@ test.serial('govern oracles list', async t => {
       1,
       'one invitation consumed, one left',
     );
-    t.deepEqual(Object.keys(currentState.offerToUsedInvitation), [
-      'acceptEcInvitationOID',
-    ]);
+    t.deepEqual(
+      currentState.offerToUsedInvitation.map(([k, _]) => k),
+      ['acceptEcInvitationOID'],
+    );
+    let usedInvitations = new Map(currentState.offerToUsedInvitation);
     t.is(
-      currentState.offerToUsedInvitation.acceptEcInvitationOID.value[0]
-        .description,
+      usedInvitations.get('acceptEcInvitationOID')?.value[0].description,
       'charter member invitation',
     );
     await offersFacet.executeOffer({
@@ -413,15 +418,13 @@ test.serial('govern oracles list', async t => {
       0,
       'last invitation consumed, none left',
     );
-    t.deepEqual(Object.keys(currentState.offerToUsedInvitation), [
-      'acceptEcInvitationOID',
-      'acceptVoterOID',
-    ]);
-    // 'acceptEcInvitationOID' tested above
-    t.is(
-      currentState.offerToUsedInvitation.acceptVoterOID.value[0].description,
-      'Voter0',
+    t.deepEqual(
+      currentState.offerToUsedInvitation.map(([k, _]) => k),
+      ['acceptEcInvitationOID', 'acceptVoterOID'],
     );
+    // 'acceptEcInvitationOID' tested above
+    usedInvitations = new Map(currentState.offerToUsedInvitation);
+    t.is(usedInvitations.get('acceptVoterOID')?.value[0].description, 'Voter0');
   }
 
   const feed = await E(agoricNames).lookup('instance', 'ATOM-USD price feed');

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -280,12 +280,14 @@ test('govern offerFilter', async t => {
     1,
     'one invitation consumed, one left',
   );
-  t.deepEqual(Object.keys(currentState.offerToUsedInvitation), [
-    'acceptEcInvitationOID',
-  ]);
+  t.deepEqual(
+    currentState.offerToUsedInvitation.map(([k, _]) => k),
+    ['acceptEcInvitationOID'],
+  );
+
+  let usedInvitations = new Map(currentState.offerToUsedInvitation);
   t.is(
-    currentState.offerToUsedInvitation.acceptEcInvitationOID.value[0]
-      .description,
+    usedInvitations.get('acceptEcInvitationOID')?.value[0].description,
     'charter member invitation',
   );
   const voteInvitationDetails = await getInvitationFor(
@@ -317,15 +319,13 @@ test('govern offerFilter', async t => {
     0,
     'last invitation consumed, none left',
   );
-  t.deepEqual(Object.keys(currentState.offerToUsedInvitation), [
-    'acceptEcInvitationOID',
-    'acceptVoterOID',
-  ]);
-  // acceptEcInvitationOID tested above
-  t.is(
-    currentState.offerToUsedInvitation.acceptVoterOID.value[0].description,
-    'Voter0',
+  t.deepEqual(
+    currentState.offerToUsedInvitation.map(([k, _]) => k),
+    ['acceptEcInvitationOID', 'acceptVoterOID'],
   );
+  // acceptEcInvitationOID tested above
+  usedInvitations = new Map(currentState.offerToUsedInvitation);
+  t.is(usedInvitations.get('acceptVoterOID')?.value[0].description, 'Voter0');
 
   // Call for a vote ////////////////////////////////
 

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -28,8 +28,6 @@ import { objectMapStoragePath } from './utils.js';
 const { Fail, quote: q } = assert;
 const { StorageNodeShape } = makeTypeGuards(M);
 
-const ERROR_LAST_OFFER_ID = -1;
-
 /**
  * @template K, V
  * @param {MapStore<K, V> } map
@@ -60,7 +58,6 @@ const mapToRecord = map => Object.fromEntries(map.entries());
  *   purses: Array<{brand: Brand, balance: Amount}>,
  *   offerToUsedInvitation: { [offerId: string]: Amount },
  *   offerToPublicSubscriberPaths: { [offerId: string]: { [subscriberName: string]: string } },
- *   lastOfferId: string,
  * }} CurrentWalletRecord
  */
 
@@ -256,7 +253,6 @@ export const prepareSmartWallet = (baggage, shared) => {
     }),
     offers: M.interface('offers facet', {
       executeOffer: M.call(shape.OfferSpec).returns(M.promise()),
-      getLastOfferId: M.call().returns(M.number()),
     }),
     self: M.interface('selfFacetI', {
       handleBridgeAction: M.call(shape.StringCapData, M.boolean()).returns(
@@ -317,8 +313,6 @@ export const prepareSmartWallet = (baggage, shared) => {
             offerToPublicSubscriberPaths: mapToRecord(
               offerToPublicSubscriberPaths,
             ),
-            // @ts-expect-error FIXME leftover from offer id string conversion
-            lastOfferId: ERROR_LAST_OFFER_ID,
           });
         },
 
@@ -384,13 +378,6 @@ export const prepareSmartWallet = (baggage, shared) => {
         },
       },
       offers: {
-        /**
-         * @deprecated
-         * @returns {number} an error code, for backwards compatibility with clients expecting a number
-         */
-        getLastOfferId() {
-          return ERROR_LAST_OFFER_ID;
-        },
         /**
          * Take an offer description provided in capData, augment it with payments and call zoe.offer()
          *

--- a/packages/smart-wallet/test/test-walletFactory.js
+++ b/packages/smart-wallet/test/test-walletFactory.js
@@ -55,10 +55,6 @@ test('bridge handler', async t => {
       value: [],
     },
   });
-  t.like(await headValue(current), {
-    // error because it's deprecated
-    lastOfferId: -1,
-  });
 
   const validMsg = {
     type: ActionType.WALLET_SPEND_ACTION,

--- a/packages/smart-wallet/test/test-walletFactory.js
+++ b/packages/smart-wallet/test/test-walletFactory.js
@@ -28,7 +28,6 @@ test.before(async t => {
 test('bridge handler', async t => {
   const smartWallet = await t.context.simpleProvideWallet(mockAddress1);
   const updates = await E(smartWallet).getUpdatesSubscriber();
-  const current = await E(smartWallet).getCurrentSubscriber();
 
   const ctx = makeImportContext();
 


### PR DESCRIPTION
## Description

Maps are better represented as an array of entries.


### Security Considerations

--
### Scaling Considerations

--
### Documentation Considerations

This is a breaking change. The commit messages indicate that.


### Testing Considerations

CI

The CLI commands are updated. According to these queries, only dapp-econ-gov also needs updating.
https://github.com/search?q=org%3AAgoric%20offerToUsedInvitation&type=code
https://github.com/search?q=org%3AAgoric+offerToPublicSubscriberPaths&type=code

I'll make it able to handle the before and after so there's no need to synchronize release.

For lastOfferId, we'll need to update psmload2 @arirubinstein 
https://github.com/search?q=org%3AAgoric+lastOfferId&type=code
