### PR TITLE
ci(runner): bump actions/setup-node to v3

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -20,7 +20,7 @@ runs:
       with:
         clean: 'false'
         submodules: 'true'
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
     - uses: kenchan0130/actions-system-info@master

--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3
       with:
         node-version: '18.x'
     - name: cache node modules

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Prerequisites
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
       - name: cache node modules

--- a/.github/workflows/test-dapp-card-store.yml.DISABLED
+++ b/.github/workflows/test-dapp-card-store.yml.DISABLED
@@ -19,7 +19,7 @@ jobs:
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/test-dapp-fungible-faucet.yml.DISABLED
+++ b/.github/workflows/test-dapp-fungible-faucet.yml.DISABLED
@@ -19,7 +19,7 @@ jobs:
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/test-dapp-otc.yml
+++ b/.github/workflows/test-dapp-otc.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/test-dapp-pegasus.yml
+++ b/.github/workflows/test-dapp-pegasus.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/test-dapp-simple-exchange.yml
+++ b/.github/workflows/test-dapp-simple-exchange.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/test-dapp-treasury.yml.DISABLED
+++ b/.github/workflows/test-dapp-treasury.yml.DISABLED
@@ -19,7 +19,7 @@ jobs:
         with:
           path: agoric-sdk
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: cache node modules


### PR DESCRIPTION
## Description

Accommodate https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Example deprecation notices: https://github.com/Agoric/agoric-sdk/actions/runs/4376827208

Breaking changes in the version bumps:
- https://github.com/actions/setup-node/releases/tag/v2.0.0
- https://github.com/actions/setup-node/releases/tag/v3.0.0

(no other changes required)


### Testing Considerations

CI