### PR TITLE
perf(SwingSet): Skip unnecessary serialization when debug output is disabled

### DIFF
--- a/packages/SwingSet/src/kernel/cleanup.js
+++ b/packages/SwingSet/src/kernel/cleanup.js
@@ -1,39 +1,42 @@
-// import { kdebug } from '../lib/kdebug.js';
+// import { kdebug, onToggleDebug } from '../lib/kdebug.js';
 import { parseKernelSlot } from './parseKernelSlots.js';
+
+// let debugEnabled = false;
+// onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
 
 export function getKpidsToRetire(kernelKeeper, rootKPID, rootKernelData) {
   const seen = new Set();
   function scanKernelPromise(kpid, kernelData) {
-    // kdebug(`### scanning ${kpid} ${JSON.stringify(kernelData)}`);
+    // debugEnabled && kdebug(`### scanning ${kpid} ${JSON.stringify(kernelData)}`);
     seen.add(kpid);
     if (kernelData) {
       for (const slot of kernelData.slots) {
         const { type } = parseKernelSlot(slot);
-        // kdebug(`## examine ${kpid} slot ${slot}`);
+        // debugEnabled && kdebug(`## examine ${kpid} slot ${slot}`);
         if (type === 'promise') {
           if (!seen.has(slot)) {
             const kp = kernelKeeper.getKernelPromise(slot);
             const { data, state } = kp;
-            // kdebug(`## state of ${slot} is: ${JSON.stringify(kp)}`);
+            // debugEnabled && kdebug(`## state of ${slot} is: ${JSON.stringify(kp)}`);
             if (state !== 'unresolved') {
               if (data) {
                 scanKernelPromise(slot, data);
               }
             } else {
-              // kdebug(`## ${slot} is still unresolved`);
+              // debugEnabled && kdebug(`## ${slot} is still unresolved`);
             }
           } else {
-            // kdebug(`## ${slot} previously seen`);
+            // debugEnabled && kdebug(`## ${slot} previously seen`);
           }
         } else {
-          // kdebug(`## ${slot} is not a promise`);
+          // debugEnabled && kdebug(`## ${slot} is not a promise`);
         }
       }
     } else {
-      // kdebug(`## ${kpid} has no data`);
+      // debugEnabled && kdebug(`## ${kpid} has no data`);
     }
   }
-  // kdebug(`## scanning ${rootKPID}`);
+  // debugEnabled && kdebug(`## scanning ${rootKPID}`);
   scanKernelPromise(rootKPID, rootKernelData);
   return Array.from(seen);
 }

--- a/packages/SwingSet/src/kernel/cleanup.js
+++ b/packages/SwingSet/src/kernel/cleanup.js
@@ -1,42 +1,39 @@
-// import { kdebug, onToggleDebug } from '../lib/kdebug.js';
+// import { kdebug, debugging } from '../lib/kdebug.js';
 import { parseKernelSlot } from './parseKernelSlots.js';
-
-// let debugEnabled = false;
-// onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
 
 export function getKpidsToRetire(kernelKeeper, rootKPID, rootKernelData) {
   const seen = new Set();
   function scanKernelPromise(kpid, kernelData) {
-    // debugEnabled && kdebug(`### scanning ${kpid} ${JSON.stringify(kernelData)}`);
+    // debugging() && kdebug(`### scanning ${kpid} ${JSON.stringify(kernelData)}`);
     seen.add(kpid);
     if (kernelData) {
       for (const slot of kernelData.slots) {
         const { type } = parseKernelSlot(slot);
-        // debugEnabled && kdebug(`## examine ${kpid} slot ${slot}`);
+        // debugging() && kdebug(`## examine ${kpid} slot ${slot}`);
         if (type === 'promise') {
           if (!seen.has(slot)) {
             const kp = kernelKeeper.getKernelPromise(slot);
             const { data, state } = kp;
-            // debugEnabled && kdebug(`## state of ${slot} is: ${JSON.stringify(kp)}`);
+            // debugging() && kdebug(`## state of ${slot} is: ${JSON.stringify(kp)}`);
             if (state !== 'unresolved') {
               if (data) {
                 scanKernelPromise(slot, data);
               }
             } else {
-              // debugEnabled && kdebug(`## ${slot} is still unresolved`);
+              // debugging() && kdebug(`## ${slot} is still unresolved`);
             }
           } else {
-            // debugEnabled && kdebug(`## ${slot} previously seen`);
+            // debugging() && kdebug(`## ${slot} previously seen`);
           }
         } else {
-          // debugEnabled && kdebug(`## ${slot} is not a promise`);
+          // debugging() && kdebug(`## ${slot} is not a promise`);
         }
       }
     } else {
-      // debugEnabled && kdebug(`## ${kpid} has no data`);
+      // debugging() && kdebug(`## ${kpid} has no data`);
     }
   }
-  // debugEnabled && kdebug(`## scanning ${rootKPID}`);
+  // debugging() && kdebug(`## scanning ${rootKPID}`);
   scanKernelPromise(rootKPID, rootKernelData);
   return Array.from(seen);
 }

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -57,7 +57,7 @@ export function makeDeviceSlots(
   }
 
   function convertValToSlot(val) {
-    // lsdebug(`convertValToSlot`, val, Object.isFrozen(val));
+    // enableLSDebug && lsdebug(`convertValToSlot`, val, Object.isFrozen(val));
     // This is either a Presence (in presenceToImportID), a
     // previously-serialized local pass-by-presence object or
     // previously-serialized local Promise (in valToSlot), a new local
@@ -70,7 +70,7 @@ export function makeDeviceSlots(
 
     if (!valToSlot.has(val)) {
       // must be a new export
-      // lsdebug('must be a new export', JSON.stringify(val));
+      // enableLSDebug && lsdebug('must be a new export', JSON.stringify(val));
       assert.equal(passStyleOf(val), 'remotable');
       const slot = exportPassByPresence();
       parseVatSlot(slot); // assertion
@@ -87,9 +87,9 @@ export function makeDeviceSlots(
       !allocatedByVat || Fail`I don't remember allocating ${slot}`;
       if (type === 'object') {
         // this is a new import value
-        // lsdebug(`assigning new import ${slot}`);
+        // enableLSDebug && lsdebug(`assigning new import ${slot}`);
         val = makePresence(slot, iface);
-        // lsdebug(` for presence`, val);
+        // enableLSDebug && lsdebug(` for presence`, val);
       } else if (type === 'device') {
         throw Fail`devices should not be given other devices '${slot}'`;
       } else {
@@ -112,7 +112,7 @@ export function makeDeviceSlots(
   function PresenceHandler(importSlot) {
     return {
       get(_target, prop) {
-        lsdebug(`PreH proxy.get(${String(prop)})`);
+        enableLSDebug && lsdebug(`PreH proxy.get(${String(prop)})`);
         if (typeof prop !== 'string' && typeof prop !== 'symbol') {
           return undefined;
         }
@@ -194,7 +194,7 @@ export function makeDeviceSlots(
   function invoke(deviceID, method, args) {
     insistVatType('device', deviceID);
     insistCapData(args);
-    lsdebug(
+    enableLSDebug && lsdebug(
       `ls[${forDeviceName}].dispatch.invoke ${deviceID}.${method}`,
       args.slots,
     );
@@ -219,7 +219,7 @@ export function makeDeviceSlots(
     const vres = m.serialize(res);
     /** @type { DeviceInvocationResultOk } */
     const ires = harden(['ok', vres]);
-    lsdebug(` results ${vres.body} ${JSON.stringify(vres.slots)}`);
+    enableLSDebug && lsdebug(` results ${vres.body} ${JSON.stringify(vres.slots)}`);
     return ires;
   }
 

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -194,10 +194,11 @@ export function makeDeviceSlots(
   function invoke(deviceID, method, args) {
     insistVatType('device', deviceID);
     insistCapData(args);
-    enableLSDebug && lsdebug(
-      `ls[${forDeviceName}].dispatch.invoke ${deviceID}.${method}`,
-      args.slots,
-    );
+    enableLSDebug &&
+      lsdebug(
+        `ls[${forDeviceName}].dispatch.invoke ${deviceID}.${method}`,
+        args.slots,
+      );
     const t = slotToVal.get(deviceID);
     if (!(method in t)) {
       throw new TypeError(
@@ -219,7 +220,8 @@ export function makeDeviceSlots(
     const vres = m.serialize(res);
     /** @type { DeviceInvocationResultOk } */
     const ires = harden(['ok', vres]);
-    enableLSDebug && lsdebug(` results ${vres.body} ${JSON.stringify(vres.slots)}`);
+    enableLSDebug &&
+      lsdebug(` results ${vres.body} ${JSON.stringify(vres.slots)}`);
     return ires;
   }
 

--- a/packages/SwingSet/src/kernel/deviceTranslator.js
+++ b/packages/SwingSet/src/kernel/deviceTranslator.js
@@ -113,7 +113,8 @@ export function makeDSTranslator(deviceID, deviceName, kernelKeeper) {
 
   function translateVatstoreGetNextKey(priorKey) {
     assertValidVatstoreKey(priorKey);
-    debugging() && kdebug(`syscall[${deviceID}].vatstoreGetNextKey(${priorKey})`);
+    debugging() &&
+      kdebug(`syscall[${deviceID}].vatstoreGetNextKey(${priorKey})`);
     return harden(['vatstoreGetNextKey', deviceID, priorKey]);
   }
 

--- a/packages/SwingSet/src/kernel/deviceTranslator.js
+++ b/packages/SwingSet/src/kernel/deviceTranslator.js
@@ -4,8 +4,11 @@ import { insistMessage } from '../lib/message.js';
 import { insistKernelType } from './parseKernelSlots.js';
 import { insistVatType, parseVatSlot } from '../lib/parseVatSlots.js';
 import { insistCapData } from '../lib/capdata.js';
-import { kdebug } from '../lib/kdebug.js';
+import { kdebug, onToggleDebug } from '../lib/kdebug.js';
 import { assertValidVatstoreKey } from './vatTranslator.js';
+
+let debugEnabled = false;
+onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
 
 /*
  * Return a function that converts KernelInvocation objects into
@@ -84,8 +87,8 @@ export function makeDSTranslator(deviceID, deviceName, kernelKeeper) {
     const target = mapDeviceSlotToKernelSlot(targetSlot);
     assert(target, 'unable to find target');
     // const method = JSON.parse(methargs.body)[0];
-    // kdebug(`syscall[${deviceName}].send(${targetSlot}/${target}).${method}`);
-    // kdebug(`  ^target is ${target}`);
+    // debugEnabled && kdebug(`syscall[${deviceName}].send(${targetSlot}/${target}).${method}`);
+    // debugEnabled && kdebug(`  ^target is ${target}`);
     const msg = harden({
       methargs: {
         ...methargs,
@@ -100,26 +103,26 @@ export function makeDSTranslator(deviceID, deviceName, kernelKeeper) {
 
   function translateVatstoreGet(key) {
     assertValidVatstoreKey(key);
-    kdebug(`syscall[${deviceID}].vatstoreGet(${key})`);
+    debugEnabled && kdebug(`syscall[${deviceID}].vatstoreGet(${key})`);
     return harden(['vatstoreGet', deviceID, key]);
   }
 
   function translateVatstoreSet(key, value) {
     assertValidVatstoreKey(key);
     assert.typeof(value, 'string');
-    kdebug(`syscall[${deviceID}].vatstoreSet(${key},${value})`);
+    debugEnabled && kdebug(`syscall[${deviceID}].vatstoreSet(${key},${value})`);
     return harden(['vatstoreSet', deviceID, key, value]);
   }
 
   function translateVatstoreGetNextKey(priorKey) {
     assertValidVatstoreKey(priorKey);
-    kdebug(`syscall[${deviceID}].vatstoreGetNextKey(${priorKey})`);
+    debugEnabled && kdebug(`syscall[${deviceID}].vatstoreGetNextKey(${priorKey})`);
     return harden(['vatstoreGetNextKey', deviceID, priorKey]);
   }
 
   function translateVatstoreDelete(key) {
     assertValidVatstoreKey(key);
-    kdebug(`syscall[${deviceID}].vatstoreDelete(${key})`);
+    debugEnabled && kdebug(`syscall[${deviceID}].vatstoreDelete(${key})`);
     return harden(['vatstoreDelete', deviceID, key]);
   }
 

--- a/packages/SwingSet/src/kernel/deviceTranslator.js
+++ b/packages/SwingSet/src/kernel/deviceTranslator.js
@@ -4,11 +4,8 @@ import { insistMessage } from '../lib/message.js';
 import { insistKernelType } from './parseKernelSlots.js';
 import { insistVatType, parseVatSlot } from '../lib/parseVatSlots.js';
 import { insistCapData } from '../lib/capdata.js';
-import { kdebug, onToggleDebug } from '../lib/kdebug.js';
+import { kdebug, debugging } from '../lib/kdebug.js';
 import { assertValidVatstoreKey } from './vatTranslator.js';
-
-let debugEnabled = false;
-onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
 
 /*
  * Return a function that converts KernelInvocation objects into
@@ -87,8 +84,8 @@ export function makeDSTranslator(deviceID, deviceName, kernelKeeper) {
     const target = mapDeviceSlotToKernelSlot(targetSlot);
     assert(target, 'unable to find target');
     // const method = JSON.parse(methargs.body)[0];
-    // debugEnabled && kdebug(`syscall[${deviceName}].send(${targetSlot}/${target}).${method}`);
-    // debugEnabled && kdebug(`  ^target is ${target}`);
+    // debugging() && kdebug(`syscall[${deviceName}].send(${targetSlot}/${target}).${method}`);
+    // debugging() && kdebug(`  ^target is ${target}`);
     const msg = harden({
       methargs: {
         ...methargs,
@@ -103,26 +100,26 @@ export function makeDSTranslator(deviceID, deviceName, kernelKeeper) {
 
   function translateVatstoreGet(key) {
     assertValidVatstoreKey(key);
-    debugEnabled && kdebug(`syscall[${deviceID}].vatstoreGet(${key})`);
+    debugging() && kdebug(`syscall[${deviceID}].vatstoreGet(${key})`);
     return harden(['vatstoreGet', deviceID, key]);
   }
 
   function translateVatstoreSet(key, value) {
     assertValidVatstoreKey(key);
     assert.typeof(value, 'string');
-    debugEnabled && kdebug(`syscall[${deviceID}].vatstoreSet(${key},${value})`);
+    debugging() && kdebug(`syscall[${deviceID}].vatstoreSet(${key},${value})`);
     return harden(['vatstoreSet', deviceID, key, value]);
   }
 
   function translateVatstoreGetNextKey(priorKey) {
     assertValidVatstoreKey(priorKey);
-    debugEnabled && kdebug(`syscall[${deviceID}].vatstoreGetNextKey(${priorKey})`);
+    debugging() && kdebug(`syscall[${deviceID}].vatstoreGetNextKey(${priorKey})`);
     return harden(['vatstoreGetNextKey', deviceID, priorKey]);
   }
 
   function translateVatstoreDelete(key) {
     assertValidVatstoreKey(key);
-    debugEnabled && kdebug(`syscall[${deviceID}].vatstoreDelete(${key})`);
+    debugging() && kdebug(`syscall[${deviceID}].vatstoreDelete(${key})`);
     return harden(['vatstoreDelete', deviceID, key]);
   }
 

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -11,6 +11,7 @@ import makeKernelKeeper from './state/kernelKeeper.js';
 import {
   kdebug,
   kdebugEnable,
+  onToggleDebug,
   legibilizeMessageArgs,
   extractMethod,
 } from '../lib/kdebug.js';
@@ -29,6 +30,9 @@ import { makeVatLoader } from './vat-loader/vat-loader.js';
 import { makeDeviceTranslators } from './deviceTranslator.js';
 import { notifyTermination } from './notifyTermination.js';
 import { makeVatAdminHooks } from './vat-admin-hooks.js';
+
+let debugEnabled = false;
+onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
 
 /**
  * @typedef {import('@agoric/swingset-liveslots').VatDeliveryObject} VatDeliveryObject
@@ -540,7 +544,7 @@ export default function buildKernel(
     kernelKeeper.incStat('dispatches');
     const vatInfo = vatWarehouse.lookup(vatID);
     if (!vatInfo) {
-      kdebug(`dropping notify of ${kpid} to ${vatID} because vat is dead`);
+      debugEnabled && kdebug(`dropping notify of ${kpid} to ${vatID} because vat is dead`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
     const { meterID } = vatInfo;
@@ -552,14 +556,14 @@ export default function buildKernel(
     /** @type { KernelDeliveryOneNotify[] } */
     const resolutions = [];
     if (!vatKeeper.hasCListEntry(kpid)) {
-      kdebug(`vat ${vatID} has no c-list entry for ${kpid}`);
-      kdebug(`skipping notify of ${kpid} because it's already been done`);
+      debugEnabled && kdebug(`vat ${vatID} has no c-list entry for ${kpid}`);
+      debugEnabled && kdebug(`skipping notify of ${kpid} because it's already been done`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
     const targets = getKpidsToRetire(kernelKeeper, kpid, p.data);
     if (targets.length === 0) {
-      kdebug(`no kpids to retire`);
-      kdebug(`skipping notify of ${kpid} because it's already been done`);
+      debugEnabled && kdebug(`no kpids to retire`);
+      debugEnabled && kdebug(`skipping notify of ${kpid} because it's already been done`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
     for (const toResolve of targets) {
@@ -644,7 +648,7 @@ export default function buildKernel(
     insistCapData(vatParameters);
     const vatInfo = vatWarehouse.lookup(vatID);
     if (!vatInfo) {
-      kdebug(`vat ${vatID} terminated before startVat delivered`);
+      debugEnabled && kdebug(`vat ${vatID} terminated before startVat delivered`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
     const { meterID } = vatInfo;
@@ -1161,9 +1165,9 @@ export default function buildKernel(
   }
 
   async function processDeliveryMessage(message) {
-    kdebug('');
-    kdebug(`processQ ${JSON.stringify(message)}`);
-    kdebug(legibilizeMessage(message));
+    debugEnabled && kdebug('');
+    debugEnabled && kdebug(`processQ ${JSON.stringify(message)}`);
+    debugEnabled && kdebug(legibilizeMessage(message));
     kernelSlog.write({
       type: 'crank-start',
       crankType: 'delivery',
@@ -1256,7 +1260,7 @@ export default function buildKernel(
 
     if (crankResults.terminate) {
       const { vatID, reject, info } = crankResults.terminate;
-      kdebug(`vat terminated: ${JSON.stringify(info)}`);
+      debugEnabled && kdebug(`vat terminated: ${JSON.stringify(info)}`);
       kernelSlog.terminateVat(vatID, reject, info);
       // this deletes state, rejects promises, notifies vat-admin
       // eslint-disable-next-line @jessie.js/no-nested-await
@@ -1314,9 +1318,9 @@ export default function buildKernel(
   }
 
   async function processAcceptanceMessage(message) {
-    kdebug('');
-    kdebug(`processAcceptanceQ ${JSON.stringify(message)}`);
-    kdebug(legibilizeMessage(message));
+    debugEnabled && kdebug('');
+    debugEnabled && kdebug(`processAcceptanceQ ${JSON.stringify(message)}`);
+    debugEnabled && kdebug(legibilizeMessage(message));
     kernelSlog.write({
       type: 'crank-start',
       crankType: 'routing',
@@ -1419,8 +1423,9 @@ export default function buildKernel(
         // kernel bug, all of which are fatal to the vat.
         ksc = translators.vatSyscallToKernelSyscall(vatSyscallObject);
       } catch (vaterr) {
-        // prettier-ignore
-        kdebug(`vat ${vatID} terminated: error during translation: ${vaterr} ${JSON.stringify(vatSyscallObject)}`);
+        debugEnabled &&
+          // prettier-ignore
+          kdebug(`vat ${vatID} terminated: error during translation: ${vaterr} ${JSON.stringify(vatSyscallObject)}`);
         console.log(`error during syscall translation:`, vaterr);
         const problem = 'syscall translation error: prepare to die';
         vatFatalSyscall(vatID, problem);

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -541,7 +541,8 @@ export default function buildKernel(
     kernelKeeper.incStat('dispatches');
     const vatInfo = vatWarehouse.lookup(vatID);
     if (!vatInfo) {
-      debugging() && kdebug(`dropping notify of ${kpid} to ${vatID} because vat is dead`);
+      debugging() &&
+        kdebug(`dropping notify of ${kpid} to ${vatID} because vat is dead`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
     const { meterID } = vatInfo;
@@ -553,14 +554,18 @@ export default function buildKernel(
     /** @type { KernelDeliveryOneNotify[] } */
     const resolutions = [];
     if (!vatKeeper.hasCListEntry(kpid)) {
-      debugging() && kdebug(`vat ${vatID} has no c-list entry for ${kpid}`);
-      debugging() && kdebug(`skipping notify of ${kpid} because it's already been done`);
+      if (debugging()) {
+        kdebug(`vat ${vatID} has no c-list entry for ${kpid}`);
+        kdebug(`skipping notify of ${kpid} because it's already been done`);
+      }
       return NO_DELIVERY_CRANK_RESULTS;
     }
     const targets = getKpidsToRetire(kernelKeeper, kpid, p.data);
     if (targets.length === 0) {
-      debugging() && kdebug(`no kpids to retire`);
-      debugging() && kdebug(`skipping notify of ${kpid} because it's already been done`);
+      if (debugging()) {
+        kdebug(`no kpids to retire`);
+        kdebug(`skipping notify of ${kpid} because it's already been done`);
+      }
       return NO_DELIVERY_CRANK_RESULTS;
     }
     for (const toResolve of targets) {
@@ -645,6 +650,7 @@ export default function buildKernel(
     insistCapData(vatParameters);
     const vatInfo = vatWarehouse.lookup(vatID);
     if (!vatInfo) {
+      // prettier-ignore
       debugging() && kdebug(`vat ${vatID} terminated before startVat delivered`);
       return NO_DELIVERY_CRANK_RESULTS;
     }

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -11,7 +11,7 @@ import makeKernelKeeper from './state/kernelKeeper.js';
 import {
   kdebug,
   kdebugEnable,
-  onToggleDebug,
+  debugging,
   legibilizeMessageArgs,
   extractMethod,
 } from '../lib/kdebug.js';
@@ -30,9 +30,6 @@ import { makeVatLoader } from './vat-loader/vat-loader.js';
 import { makeDeviceTranslators } from './deviceTranslator.js';
 import { notifyTermination } from './notifyTermination.js';
 import { makeVatAdminHooks } from './vat-admin-hooks.js';
-
-let debugEnabled = false;
-onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
 
 /**
  * @typedef {import('@agoric/swingset-liveslots').VatDeliveryObject} VatDeliveryObject
@@ -544,7 +541,7 @@ export default function buildKernel(
     kernelKeeper.incStat('dispatches');
     const vatInfo = vatWarehouse.lookup(vatID);
     if (!vatInfo) {
-      debugEnabled && kdebug(`dropping notify of ${kpid} to ${vatID} because vat is dead`);
+      debugging() && kdebug(`dropping notify of ${kpid} to ${vatID} because vat is dead`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
     const { meterID } = vatInfo;
@@ -556,14 +553,14 @@ export default function buildKernel(
     /** @type { KernelDeliveryOneNotify[] } */
     const resolutions = [];
     if (!vatKeeper.hasCListEntry(kpid)) {
-      debugEnabled && kdebug(`vat ${vatID} has no c-list entry for ${kpid}`);
-      debugEnabled && kdebug(`skipping notify of ${kpid} because it's already been done`);
+      debugging() && kdebug(`vat ${vatID} has no c-list entry for ${kpid}`);
+      debugging() && kdebug(`skipping notify of ${kpid} because it's already been done`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
     const targets = getKpidsToRetire(kernelKeeper, kpid, p.data);
     if (targets.length === 0) {
-      debugEnabled && kdebug(`no kpids to retire`);
-      debugEnabled && kdebug(`skipping notify of ${kpid} because it's already been done`);
+      debugging() && kdebug(`no kpids to retire`);
+      debugging() && kdebug(`skipping notify of ${kpid} because it's already been done`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
     for (const toResolve of targets) {
@@ -648,7 +645,7 @@ export default function buildKernel(
     insistCapData(vatParameters);
     const vatInfo = vatWarehouse.lookup(vatID);
     if (!vatInfo) {
-      debugEnabled && kdebug(`vat ${vatID} terminated before startVat delivered`);
+      debugging() && kdebug(`vat ${vatID} terminated before startVat delivered`);
       return NO_DELIVERY_CRANK_RESULTS;
     }
     const { meterID } = vatInfo;
@@ -1165,9 +1162,9 @@ export default function buildKernel(
   }
 
   async function processDeliveryMessage(message) {
-    debugEnabled && kdebug('');
-    debugEnabled && kdebug(`processQ ${JSON.stringify(message)}`);
-    debugEnabled && kdebug(legibilizeMessage(message));
+    debugging() && kdebug('');
+    debugging() && kdebug(`processQ ${JSON.stringify(message)}`);
+    debugging() && kdebug(legibilizeMessage(message));
     kernelSlog.write({
       type: 'crank-start',
       crankType: 'delivery',
@@ -1260,7 +1257,7 @@ export default function buildKernel(
 
     if (crankResults.terminate) {
       const { vatID, reject, info } = crankResults.terminate;
-      debugEnabled && kdebug(`vat terminated: ${JSON.stringify(info)}`);
+      debugging() && kdebug(`vat terminated: ${JSON.stringify(info)}`);
       kernelSlog.terminateVat(vatID, reject, info);
       // this deletes state, rejects promises, notifies vat-admin
       // eslint-disable-next-line @jessie.js/no-nested-await
@@ -1318,9 +1315,9 @@ export default function buildKernel(
   }
 
   async function processAcceptanceMessage(message) {
-    debugEnabled && kdebug('');
-    debugEnabled && kdebug(`processAcceptanceQ ${JSON.stringify(message)}`);
-    debugEnabled && kdebug(legibilizeMessage(message));
+    debugging() && kdebug('');
+    debugging() && kdebug(`processAcceptanceQ ${JSON.stringify(message)}`);
+    debugging() && kdebug(legibilizeMessage(message));
     kernelSlog.write({
       type: 'crank-start',
       crankType: 'routing',
@@ -1423,7 +1420,7 @@ export default function buildKernel(
         // kernel bug, all of which are fatal to the vat.
         ksc = translators.vatSyscallToKernelSyscall(vatSyscallObject);
       } catch (vaterr) {
-        debugEnabled &&
+        debugging() &&
           // prettier-ignore
           kdebug(`vat ${vatID} terminated: error during translation: ${vaterr} ${JSON.stringify(vatSyscallObject)}`);
         console.log(`error during syscall translation:`, vaterr);

--- a/packages/SwingSet/src/kernel/state/deviceKeeper.js
+++ b/packages/SwingSet/src/kernel/state/deviceKeeper.js
@@ -74,7 +74,6 @@ export function makeDeviceKeeper(kvStore, deviceID, tools) {
    */
   function mapDeviceSlotToKernelSlot(devSlot) {
     typeof devSlot === 'string' || Fail`non-string devSlot: ${devSlot}`;
-    // kdebug(`mapOutbound ${devSlot}`);
     const devKey = `${deviceID}.c.${devSlot}`;
     if (!kvStore.has(devKey)) {
       const { type, allocatedByVat } = parseVatSlot(devSlot);

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -19,7 +19,7 @@ import {
   makeVatID,
   makeUpgradeID,
 } from '../../lib/id.js';
-import { kdebug, onToggleDebug } from '../../lib/kdebug.js';
+import { kdebug, debugging } from '../../lib/kdebug.js';
 import { KERNEL_STATS_METRICS } from '../metrics.js';
 import { makeKernelStats } from './stats.js';
 import {
@@ -29,9 +29,6 @@ import {
 } from './storageHelper.js';
 
 const enableKernelGC = true;
-let debugEnabled = false;
-onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
-
 
 /**
  * @typedef { import('../../types-external.js').BundleCap } BundleCap
@@ -561,7 +558,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
       id = Nat(BigInt(getRequired('ko.nextID')));
       kvStore.set('ko.nextID', `${id + 1n}`);
     }
-    debugEnabled && kdebug(`Adding kernel object ko${id} for ${ownerID}`);
+    debugging() && kdebug(`Adding kernel object ko${id} for ${ownerID}`);
     const s = makeKernelSlot('object', id);
     kvStore.set(`${s}.owner`, ownerID);
     setObjectRefCount(s, { reachable: 0, recognizable: 0 });
@@ -601,7 +598,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
   function addKernelDeviceNode(deviceID) {
     insistDeviceID(deviceID);
     const id = Nat(BigInt(getRequired('kd.nextID')));
-    debugEnabled && kdebug(`Adding kernel device kd${id} for ${deviceID}`);
+    debugging() && kdebug(`Adding kernel device kd${id} for ${deviceID}`);
     kvStore.set('kd.nextID', `${id + 1n}`);
     const s = makeKernelSlot('device', id);
     kvStore.set(`${s}.owner`, deviceID);
@@ -637,7 +634,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
   function addKernelPromiseForVat(deciderVatID) {
     insistVatID(deciderVatID);
     const kpid = addKernelPromise();
-    debugEnabled && kdebug(`Adding kernel promise ${kpid} for ${deciderVatID}`);
+    debugging() && kdebug(`Adding kernel promise ${kpid} for ${deciderVatID}`);
     kvStore.set(`${kpid}.decider`, deciderVatID);
     return kpid;
   }
@@ -862,7 +859,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
     if (newDynamicVatIDs.length !== oldDynamicVatIDs.length) {
       kvStore.set(DYNAMIC_IDS_KEY, JSON.stringify(newDynamicVatIDs));
     } else {
-      debugEnabled && kdebug(`removing static vat ${vatID}`);
+      debugging() && kdebug(`removing static vat ${vatID}`);
       for (const k of enumeratePrefixedKeys(kvStore, 'vat.name.')) {
         if (kvStore.get(k) === vatID) {
           kvStore.delete(k);
@@ -1175,7 +1172,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
     const { type } = parseKernelSlot(kernelSlot);
     if (type === 'promise') {
       const refCount = Nat(BigInt(getRequired(`${kernelSlot}.refCount`))) + 1n;
-      // debugEnabled && kdebug(`++ ${kernelSlot}  ${tag} ${refCount}`);
+      // debugging() && kdebug(`++ ${kernelSlot}  ${tag} ${refCount}`);
       kvStore.set(`${kernelSlot}.refCount`, `${refCount}`);
     }
     if (type === 'object' && !isExport) {
@@ -1184,7 +1181,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
         reachable += 1;
       }
       recognizable += 1;
-      // debugEnabled && kdebug(`++ ${kernelSlot}  ${tag} ${reachable},${recognizable}`);
+      // debugging() && kdebug(`++ ${kernelSlot}  ${tag} ${reachable},${recognizable}`);
       setObjectRefCount(kernelSlot, { reachable, recognizable });
     }
   }
@@ -1214,7 +1211,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
       let refCount = Nat(BigInt(getRequired(`${kernelSlot}.refCount`)));
       refCount > 0n || Fail`refCount underflow ${kernelSlot} ${tag}`;
       refCount -= 1n;
-      // debugEnabled && kdebug(`-- ${kernelSlot}  ${tag} ${refCount}`);
+      // debugging() && kdebug(`-- ${kernelSlot}  ${tag} ${refCount}`);
       kvStore.set(`${kernelSlot}.refCount`, `${refCount}`);
       if (refCount === 0n) {
         maybeFreeKrefs.add(kernelSlot);
@@ -1227,7 +1224,7 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
         reachable -= 1;
       }
       recognizable -= 1;
-      // debugEnabled && kdebug(`-- ${kernelSlot}  ${tag} ${reachable},${recognizable}`);
+      // debugging() && kdebug(`-- ${kernelSlot}  ${tag} ${reachable},${recognizable}`);
       if (!reachable || !recognizable) {
         maybeFreeKrefs.add(kernelSlot);
       }

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -6,15 +6,12 @@ import { assert, q, Fail } from '@agoric/assert';
 import { parseKernelSlot } from '../parseKernelSlots.js';
 import { makeVatSlot, parseVatSlot } from '../../lib/parseVatSlots.js';
 import { insistVatID } from '../../lib/id.js';
-import { kdebug, onToggleDebug } from '../../lib/kdebug.js';
+import { kdebug, debugging } from '../../lib/kdebug.js';
 import {
   parseReachableAndVatSlot,
   buildReachableAndVatSlot,
 } from './reachable.js';
 import { enumeratePrefixedKeys } from './storageHelper.js';
-
-let debugEnabled = false;
-onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
 
 /**
  * @typedef { import('../../types-external.js').KVStore } KVStore
@@ -211,7 +208,7 @@ export function makeVatKeeper(
       // eslint-disable-next-line prefer-const
       let { reachable, recognizable } = getObjectRefCount(kernelSlot);
       reachable += 1;
-      // debugEnabled && kdebug(`++ ${kernelSlot} ${tag} ${reachable},${recognizable}`);
+      // debugging() && kdebug(`++ ${kernelSlot} ${tag} ${reachable},${recognizable}`);
       setObjectRefCount(kernelSlot, { reachable, recognizable });
     }
   }
@@ -234,7 +231,7 @@ export function makeVatKeeper(
       // eslint-disable-next-line prefer-const
       let { reachable, recognizable } = getObjectRefCount(kernelSlot);
       reachable -= 1;
-      // debugEnabled && kdebug(`-- ${kernelSlot} ${tag} ${reachable},${recognizable}`);
+      // debugging() && kdebug(`-- ${kernelSlot} ${tag} ${reachable},${recognizable}`);
       setObjectRefCount(kernelSlot, { reachable, recognizable });
       if (reachable === 0) {
         addMaybeFreeKref(kernelSlot);
@@ -319,7 +316,7 @@ export function makeVatKeeper(
             vatSlot,
           );
         }
-        debugEnabled && kdebug(`Add mapping v->k ${kernelKey}<=>${vatKey}`);
+        debugging() && kdebug(`Add mapping v->k ${kernelKey}<=>${vatKey}`);
       } else {
         // the vat didn't allocate it, and the kernel didn't allocate it
         // (else it would have been in the c-list), so it must be bogus
@@ -394,7 +391,7 @@ export function makeVatKeeper(
           vatSlot,
         );
       }
-      debugEnabled && kdebug(`Add mapping k->v ${kernelKey}<=>${vatKey}`);
+      debugging() && kdebug(`Add mapping k->v ${kernelKey}<=>${vatKey}`);
     }
 
     const { isReachable, vatSlot } = getReachableAndVatSlot(vatID, kernelSlot);
@@ -435,7 +432,7 @@ export function makeVatKeeper(
     const kernelKey = `${vatID}.c.${kernelSlot}`;
     const vatKey = `${vatID}.c.${vatSlot}`;
     assert(kvStore.has(kernelKey));
-    debugEnabled && kdebug(`Delete mapping ${kernelKey}<=>${vatKey}`);
+    debugging() && kdebug(`Delete mapping ${kernelKey}<=>${vatKey}`);
     if (kernelSlog) {
       kernelSlog.changeCList(
         vatID,

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -6,12 +6,15 @@ import { assert, q, Fail } from '@agoric/assert';
 import { parseKernelSlot } from '../parseKernelSlots.js';
 import { makeVatSlot, parseVatSlot } from '../../lib/parseVatSlots.js';
 import { insistVatID } from '../../lib/id.js';
-import { kdebug } from '../../lib/kdebug.js';
+import { kdebug, onToggleDebug } from '../../lib/kdebug.js';
 import {
   parseReachableAndVatSlot,
   buildReachableAndVatSlot,
 } from './reachable.js';
 import { enumeratePrefixedKeys } from './storageHelper.js';
+
+let debugEnabled = false;
+onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
 
 /**
  * @typedef { import('../../types-external.js').KVStore } KVStore
@@ -208,7 +211,7 @@ export function makeVatKeeper(
       // eslint-disable-next-line prefer-const
       let { reachable, recognizable } = getObjectRefCount(kernelSlot);
       reachable += 1;
-      // kdebug(`++ ${kernelSlot} ${tag} ${reachable},${recognizable}`);
+      // debugEnabled && kdebug(`++ ${kernelSlot} ${tag} ${reachable},${recognizable}`);
       setObjectRefCount(kernelSlot, { reachable, recognizable });
     }
   }
@@ -231,7 +234,7 @@ export function makeVatKeeper(
       // eslint-disable-next-line prefer-const
       let { reachable, recognizable } = getObjectRefCount(kernelSlot);
       reachable -= 1;
-      // kdebug(`-- ${kernelSlot} ${tag} ${reachable},${recognizable}`);
+      // debugEnabled && kdebug(`-- ${kernelSlot} ${tag} ${reachable},${recognizable}`);
       setObjectRefCount(kernelSlot, { reachable, recognizable });
       if (reachable === 0) {
         addMaybeFreeKref(kernelSlot);
@@ -316,7 +319,7 @@ export function makeVatKeeper(
             vatSlot,
           );
         }
-        kdebug(`Add mapping v->k ${kernelKey}<=>${vatKey}`);
+        debugEnabled && kdebug(`Add mapping v->k ${kernelKey}<=>${vatKey}`);
       } else {
         // the vat didn't allocate it, and the kernel didn't allocate it
         // (else it would have been in the c-list), so it must be bogus
@@ -391,7 +394,7 @@ export function makeVatKeeper(
           vatSlot,
         );
       }
-      kdebug(`Add mapping k->v ${kernelKey}<=>${vatKey}`);
+      debugEnabled && kdebug(`Add mapping k->v ${kernelKey}<=>${vatKey}`);
     }
 
     const { isReachable, vatSlot } = getReachableAndVatSlot(vatID, kernelSlot);
@@ -432,7 +435,7 @@ export function makeVatKeeper(
     const kernelKey = `${vatID}.c.${kernelSlot}`;
     const vatKey = `${vatID}.c.${vatSlot}`;
     assert(kvStore.has(kernelKey));
-    kdebug(`Delete mapping ${kernelKey}<=>${vatKey}`);
+    debugEnabled && kdebug(`Delete mapping ${kernelKey}<=>${vatKey}`);
     if (kernelSlog) {
       kernelSlog.changeCList(
         vatID,

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -338,7 +338,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
    */
   function translateExit(isFailure, info) {
     insistCapData(info);
-    debugging() && kdebug(`syscall[${vatID}].exit(${isFailure},${legibilizeValue(info)})`);
+    debugging() &&
+      kdebug(`syscall[${vatID}].exit(${isFailure},${legibilizeValue(info)})`);
     const kernelSlots = info.slots.map(slot => mapVatSlotToKernelSlot(slot));
     const kernelInfo = harden({ ...info, slots: kernelSlots });
     return harden(['exit', vatID, !!isFailure, kernelInfo]);
@@ -435,7 +436,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       vatKeeper.deleteCListEntry(kref, vref);
       return kref;
     });
-    debugging() && kdebug(`syscall[${vatID}].retireImports(${krefs.join(' ')})`);
+    debugging() &&
+      kdebug(`syscall[${vatID}].retireImports(${krefs.join(' ')})`);
     // we've done all the work here, during translation
     return harden(['retireImports', krefs]);
   }
@@ -457,7 +459,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       vatKeeper.deleteCListEntry(kref, vref);
       return kref;
     });
-    debugging() && kdebug(`syscall[${vatID}].retireExports(${krefs.join(' ')})`);
+    debugging() &&
+      kdebug(`syscall[${vatID}].retireExports(${krefs.join(' ')})`);
     // retireExports still has work to do
     return harden(['retireExports', krefs]);
   }
@@ -478,7 +481,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       vatKeeper.deleteCListEntry(kref, vref);
       return kref;
     });
-    debugging() && kdebug(`syscall[${vatID}].abandonExports(${krefs.join(' ')})`);
+    debugging() &&
+      kdebug(`syscall[${vatID}].abandonExports(${krefs.join(' ')})`);
     // abandonExports still has work to do
     return harden(['abandonExports', vatID, krefs]);
   }
@@ -549,11 +553,12 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       const kpid = mapVatSlotToKernelSlot(vpid);
       const kernelSlots = data.slots.map(slot => mapVatSlotToKernelSlot(slot));
       const kernelData = harden({ ...data, slots: kernelSlots });
-      debugging() && kdebug(
-        `syscall[${vatID}].resolve[${idx}](${vpid}/${kpid}, ${rejected}) = ${
-          data.body
-        } ${JSON.stringify(data.slots)}/${JSON.stringify(kernelSlots)}`,
-      );
+      debugging() &&
+        kdebug(
+          `syscall[${vatID}].resolve[${idx}](${vpid}/${kpid}, ${rejected}) = ${
+            data.body
+          } ${JSON.stringify(data.slots)}/${JSON.stringify(kernelSlots)}`,
+        );
       idx += 1;
       kresolutions.push([kpid, rejected, kernelData]);
       kpidsResolved.push(kpid);

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -5,13 +5,10 @@ import { insistVatType, parseVatSlot } from '../lib/parseVatSlots.js';
 import { extractSingleSlot, insistCapData } from '../lib/capdata.js';
 import {
   kdebug,
-  onToggleDebug,
+  debugging,
   legibilizeMessageArgs,
   legibilizeValue,
 } from '../lib/kdebug.js';
-
-let debugEnabled = false;
-onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
 
 export function assertValidVatstoreKey(key) {
   assert.typeof(key, 'string');
@@ -118,7 +115,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
       /** @type { VatOneResolution } */
       const vres = [vpid, ...translatePromiseDescriptor(p)];
       vResolutions.push(vres);
-      debugEnabled && kdebug(`notify ${idx} ${kpid} ${JSON.stringify(vres)}`);
+      debugging() && kdebug(`notify ${idx} ${kpid} ${JSON.stringify(vres)}`);
       idx += 1;
     }
     /** @type { VatDeliveryNotify } */
@@ -286,7 +283,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
     const target = mapVatSlotToKernelSlot(targetSlot);
     const [method, argList] = legibilizeMessageArgs(methargs);
     // prettier-ignore
-    debugEnabled && kdebug(`syscall[${vatID}].send(${targetSlot}/${target}).${method}(${argList})`);
+    debugging() && kdebug(`syscall[${vatID}].send(${targetSlot}/${target}).${method}(${argList})`);
     const kernelSlots = methargs.slots.map(slot =>
       mapVatSlotToKernelSlot(slot),
     );
@@ -341,7 +338,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
    */
   function translateExit(isFailure, info) {
     insistCapData(info);
-    debugEnabled && kdebug(`syscall[${vatID}].exit(${isFailure},${legibilizeValue(info)})`);
+    debugging() && kdebug(`syscall[${vatID}].exit(${isFailure},${legibilizeValue(info)})`);
     const kernelSlots = info.slots.map(slot => mapVatSlotToKernelSlot(slot));
     const kernelInfo = harden({ ...info, slots: kernelSlots });
     return harden(['exit', vatID, !!isFailure, kernelInfo]);
@@ -354,7 +351,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
    */
   function translateVatstoreGet(key) {
     assertValidVatstoreKey(key);
-    debugEnabled && kdebug(`syscall[${vatID}].vatstoreGet(${key})`);
+    debugging() && kdebug(`syscall[${vatID}].vatstoreGet(${key})`);
     return harden(['vatstoreGet', vatID, key]);
   }
 
@@ -367,7 +364,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
   function translateVatstoreSet(key, value) {
     assertValidVatstoreKey(key);
     assert.typeof(value, 'string');
-    debugEnabled && kdebug(`syscall[${vatID}].vatstoreSet(${key},${value})`);
+    debugging() && kdebug(`syscall[${vatID}].vatstoreSet(${key},${value})`);
     return harden(['vatstoreSet', vatID, key, value]);
   }
 
@@ -378,7 +375,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
    */
   function translateVatstoreGetNextKey(priorKey) {
     assertValidVatstoreKey(priorKey);
-    debugEnabled && kdebug(`syscall[${vatID}].vatstoreGetNextKey(${priorKey})`);
+    debugging() && kdebug(`syscall[${vatID}].vatstoreGetNextKey(${priorKey})`);
     return harden(['vatstoreGetNextKey', vatID, priorKey]);
   }
 
@@ -389,7 +386,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
    */
   function translateVatstoreDelete(key) {
     assertValidVatstoreKey(key);
-    debugEnabled && kdebug(`syscall[${vatID}].vatstoreDelete(${key})`);
+    debugging() && kdebug(`syscall[${vatID}].vatstoreDelete(${key})`);
     return harden(['vatstoreDelete', vatID, key]);
   }
 
@@ -413,7 +410,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       clearReachableFlag(kref, 'dropI');
       return kref;
     });
-    debugEnabled && kdebug(`syscall[${vatID}].dropImports(${krefs.join(' ')})`);
+    debugging() && kdebug(`syscall[${vatID}].dropImports(${krefs.join(' ')})`);
     // we've done all the work here, during translation
     return harden(['dropImports', krefs]);
   }
@@ -438,7 +435,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       vatKeeper.deleteCListEntry(kref, vref);
       return kref;
     });
-    debugEnabled && kdebug(`syscall[${vatID}].retireImports(${krefs.join(' ')})`);
+    debugging() && kdebug(`syscall[${vatID}].retireImports(${krefs.join(' ')})`);
     // we've done all the work here, during translation
     return harden(['retireImports', krefs]);
   }
@@ -460,7 +457,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       vatKeeper.deleteCListEntry(kref, vref);
       return kref;
     });
-    debugEnabled && kdebug(`syscall[${vatID}].retireExports(${krefs.join(' ')})`);
+    debugging() && kdebug(`syscall[${vatID}].retireExports(${krefs.join(' ')})`);
     // retireExports still has work to do
     return harden(['retireExports', krefs]);
   }
@@ -481,7 +478,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       vatKeeper.deleteCListEntry(kref, vref);
       return kref;
     });
-    debugEnabled && kdebug(`syscall[${vatID}].abandonExports(${krefs.join(' ')})`);
+    debugging() && kdebug(`syscall[${vatID}].abandonExports(${krefs.join(' ')})`);
     // abandonExports still has work to do
     return harden(['abandonExports', vatID, krefs]);
   }
@@ -507,13 +504,13 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
     const kernelSlots = args.slots.map(slot => mapVatSlotToKernelSlot(slot));
     const kernelData = harden({ ...args, slots: kernelSlots });
     // prettier-ignore
-    debugEnabled && kdebug(`syscall[${vatID}].callNow(${target}/${dev}).${method}(${JSON.stringify(args)})`);
+    debugging() && kdebug(`syscall[${vatID}].callNow(${target}/${dev}).${method}(${JSON.stringify(args)})`);
     return harden(['invoke', dev, method, kernelData]);
   }
 
   function translateSubscribe(vpid) {
     const kpid = mapVatSlotToKernelSlot(vpid);
-    debugEnabled && kdebug(`syscall[${vatID}].subscribe(${vpid}/${kpid})`);
+    debugging() && kdebug(`syscall[${vatID}].subscribe(${vpid}/${kpid})`);
     kernelKeeper.hasKernelPromise(kpid) ||
       Fail`unknown kernelPromise id '${kpid}'`;
     /** @type { KernelSyscallSubscribe } */
@@ -552,7 +549,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       const kpid = mapVatSlotToKernelSlot(vpid);
       const kernelSlots = data.slots.map(slot => mapVatSlotToKernelSlot(slot));
       const kernelData = harden({ ...data, slots: kernelSlots });
-      debugEnabled && kdebug(
+      debugging() && kdebug(
         `syscall[${vatID}].resolve[${idx}](${vpid}/${kpid}, ${rejected}) = ${
           data.body
         } ${JSON.stringify(data.slots)}/${JSON.stringify(kernelSlots)}`,

--- a/packages/SwingSet/src/lib/kdebug.js
+++ b/packages/SwingSet/src/lib/kdebug.js
@@ -1,18 +1,21 @@
 let enableKDebug = false;
 
 export const debugging = () => enableKDebug;
+harden(debugging);
 
-export function kdebugEnable(flag) {
+export const kdebugEnable = flag => {
   enableKDebug = !!flag;
-}
+};
+harden(kdebugEnable);
 
-export function kdebug(...args) {
+export const kdebug = (...args) => {
   if (enableKDebug) {
     console.log(...args);
   }
-}
+};
+harden(kdebug);
 
-export function legibilizeValue(val, slots, smallcaps) {
+export const legibilizeValue = (val, slots, smallcaps) => {
   try {
     if (Array.isArray(val)) {
       let result = '[';
@@ -84,9 +87,10 @@ export function legibilizeValue(val, slots, smallcaps) {
   } catch {
     return '<unintelligible value>';
   }
-}
+};
+harden(legibilizeValue);
 
-export function legibilizeMethod(method, smallcaps) {
+export const legibilizeMethod = (method, smallcaps) => {
   try {
     if (typeof method === 'string') {
       if (!smallcaps) {
@@ -137,9 +141,10 @@ export function legibilizeMethod(method, smallcaps) {
   } catch {
     return '<unintelligible method>';
   }
-}
+};
+harden(legibilizeMethod);
 
-export function extractMethod(methargsCapdata) {
+export const extractMethod = methargsCapdata => {
   try {
     let smallcaps = false;
     let bodyString = methargsCapdata.body;
@@ -152,9 +157,10 @@ export function extractMethod(methargsCapdata) {
   } catch {
     return '<unknown>';
   }
-}
+};
+harden(extractMethod);
 
-export function legibilizeMessageArgs(methargsCapdata) {
+export const legibilizeMessageArgs = methargsCapdata => {
   try {
     let smallcaps = false;
     let bodyString = methargsCapdata.body;
@@ -172,4 +178,5 @@ export function legibilizeMessageArgs(methargsCapdata) {
   } catch {
     return '<unintelligible message args>';
   }
-}
+};
+harden(legibilizeMessageArgs);

--- a/packages/SwingSet/src/lib/kdebug.js
+++ b/packages/SwingSet/src/lib/kdebug.js
@@ -1,27 +1,9 @@
-import { assert } from '@agoric/assert';
-
 let enableKDebug = false;
-const toggleListeners = new Set();
 
-export function onToggleDebug(callback) {
-  assert.typeof(callback, 'function');
-  toggleListeners.add(callback);
-  callback(enableKDebug);
-}
-
-export function removeToggleDebugListener(callback) {
-  assert.typeof(callback, 'function');
-  return toggleListeners.delete(callback);
-}
+export const debugging = () => enableKDebug;
 
 export function kdebugEnable(flag) {
-  if (enableKDebug === !!flag) {
-    return;
-  }
-  enableKDebug = !enableKDebug;
-  for (const callback of toggleListeners) {
-    callback(enableKDebug);
-  }
+  enableKDebug = !!flag;
 }
 
 export function kdebug(...args) {

--- a/packages/SwingSet/src/lib/kdebug.js
+++ b/packages/SwingSet/src/lib/kdebug.js
@@ -1,7 +1,27 @@
+import { assert } from '@agoric/assert';
+
 let enableKDebug = false;
+const toggleListeners = new Set();
+
+export function onToggleDebug(callback) {
+  assert.typeof(callback, 'function');
+  toggleListeners.add(callback);
+  callback(enableKDebug);
+}
+
+export function removeToggleDebugListener(callback) {
+  assert.typeof(callback, 'function');
+  return toggleListeners.delete(callback);
+}
 
 export function kdebugEnable(flag) {
-  enableKDebug = !!flag;
+  if (enableKDebug === !!flag) {
+    return;
+  }
+  enableKDebug = !enableKDebug;
+  for (const callback of toggleListeners) {
+    callback(enableKDebug);
+  }
 }
 
 export function kdebug(...args) {

--- a/packages/swingset-liveslots/src/kdebug.js
+++ b/packages/swingset-liveslots/src/kdebug.js
@@ -1,18 +1,21 @@
 let enableKDebug = false;
 
 export const debugging = () => enableKDebug;
+harden(debugging);
 
-export function kdebugEnable(flag) {
+export const kdebugEnable = flag => {
   enableKDebug = !!flag;
-}
+};
+harden(kdebugEnable);
 
-export function kdebug(...args) {
+export const kdebug = (...args) => {
   if (enableKDebug) {
     console.log(...args);
   }
-}
+};
+harden(kdebug);
 
-export function legibilizeValue(val, slots, smallcaps) {
+export const legibilizeValue = (val, slots, smallcaps) => {
   try {
     if (Array.isArray(val)) {
       let result = '[';
@@ -84,9 +87,10 @@ export function legibilizeValue(val, slots, smallcaps) {
   } catch {
     return '<unintelligible value>';
   }
-}
+};
+harden(legibilizeValue);
 
-export function legibilizeMethod(method, smallcaps) {
+export const legibilizeMethod = (method, smallcaps) => {
   try {
     if (typeof method === 'string') {
       if (!smallcaps) {
@@ -137,9 +141,10 @@ export function legibilizeMethod(method, smallcaps) {
   } catch {
     return '<unintelligible method>';
   }
-}
+};
+harden(legibilizeMethod);
 
-export function extractMethod(methargsCapdata) {
+export const extractMethod = methargsCapdata => {
   try {
     let smallcaps = false;
     let bodyString = methargsCapdata.body;
@@ -152,9 +157,10 @@ export function extractMethod(methargsCapdata) {
   } catch {
     return '<unknown>';
   }
-}
+};
+harden(extractMethod);
 
-export function legibilizeMessageArgs(methargsCapdata) {
+export const legibilizeMessageArgs = methargsCapdata => {
   try {
     let smallcaps = false;
     let bodyString = methargsCapdata.body;
@@ -172,4 +178,5 @@ export function legibilizeMessageArgs(methargsCapdata) {
   } catch {
     return '<unintelligible message args>';
   }
-}
+};
+harden(legibilizeMessageArgs);

--- a/packages/swingset-liveslots/src/kdebug.js
+++ b/packages/swingset-liveslots/src/kdebug.js
@@ -1,5 +1,7 @@
 let enableKDebug = false;
 
+export const debugging = () => enableKDebug;
+
 export function kdebugEnable(flag) {
   enableKDebug = !!flag;
 }

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -347,11 +347,11 @@ function build(
     // is associated with 'slot' so that all handled messages get sent to
     // that slot: pres~.foo() causes a syscall.send(target=slot, msg=foo).
 
-    lsdebug(`makeImportedPresence(${slot})`);
+    enableLSDebug && lsdebug(`makeImportedPresence(${slot})`);
     const fulfilledHandler = {
       applyMethod(o, prop, args, returnedP) {
         // Support: o~.[prop](...args) remote method invocation
-        lsdebug(`makeImportedPresence handler.applyMethod (${slot})`);
+        enableLSDebug && lsdebug(`makeImportedPresence handler.applyMethod (${slot})`);
         if (disavowedPresences.has(o)) {
           // eslint-disable-next-line no-use-before-define
           exitVatWithFailure(disavowalError);
@@ -364,7 +364,7 @@ function build(
         return fulfilledHandler.applyMethod(o, undefined, args, returnedP);
       },
       get(o, prop) {
-        lsdebug(`makeImportedPresence handler.get (${slot})`);
+        enableLSDebug && lsdebug(`makeImportedPresence handler.get (${slot})`);
         if (disavowedPresences.has(o)) {
           // eslint-disable-next-line no-use-before-define
           exitVatWithFailure(disavowalError);
@@ -419,7 +419,7 @@ function build(
     // code, to which messages can be pipelined, and we prepare for the
     // kernel to tell us that it has been resolved in various ways.
     insistVatType('promise', vpid);
-    lsdebug(`makePipelinablePromise(${vpid})`);
+    enableLSDebug && lsdebug(`makePipelinablePromise(${vpid})`);
 
     // The Promise will we associated with a handler that converts p~.foo() into
     // a syscall.send() that targets the vpid. When the Promise is resolved
@@ -433,7 +433,7 @@ function build(
     const unfulfilledHandler = {
       applyMethod(_p, prop, args, returnedP) {
         // Support: p~.[prop](...args) remote method invocation
-        lsdebug(`makePipelinablePromise handler.applyMethod (${vpid})`);
+        enableLSDebug && lsdebug(`makePipelinablePromise handler.applyMethod (${vpid})`);
         if (!handlerActive) {
           console.error(`mIPromise handler called after resolution`);
           Fail`mIPromise handler called after resolution`;
@@ -443,7 +443,7 @@ function build(
       },
       get(p, prop) {
         // Support: p~.[prop]
-        lsdebug(`makePipelinablePromise handler.get (${vpid})`);
+        enableLSDebug && lsdebug(`makePipelinablePromise handler.get (${vpid})`);
         if (!handlerActive) {
           console.error(`mIPromise handler called after resolution`);
           Fail`mIPromise handler called after resolution`;
@@ -671,7 +671,7 @@ function build(
   );
 
   function convertValToSlot(val) {
-    // lsdebug(`serializeToSlot`, val, Object.isFrozen(val));
+    // enableLSDebug && lsdebug(`serializeToSlot`, val, Object.isFrozen(val));
     // This is either a Presence (in presenceToImportID), a
     // previously-serialized local pass-by-presence object or
     // previously-serialized local Promise (in valToSlot), a new local
@@ -685,7 +685,7 @@ function build(
     if (!valToSlot.has(val)) {
       let slot;
       // must be a new export/store
-      // lsdebug('must be a new export', JSON.stringify(val));
+      // enableLSDebug && lsdebug('must be a new export', JSON.stringify(val));
       if (isPromise(val)) {
         // the promise either appeared in outbound arguments, or in a
         // virtual-object store operation, so immediately after
@@ -879,7 +879,7 @@ function build(
     serMethargs.slots.map(retainExportedVref);
 
     const resultVPID = allocatePromiseID();
-    lsdebug(`Promise allocation ${forVatID}:${resultVPID} in queueMessage`);
+    enableLSDebug && lsdebug(`Promise allocation ${forVatID}:${resultVPID} in queueMessage`);
     // create a Promise which callers follow for the result, give it a
     // handler so we can pipeline messages to it, and prepare for the kernel
     // to notify us of its resolution
@@ -895,7 +895,7 @@ function build(
     slotToVal.set(resultVPID, new WeakRef(returnedP));
 
     // prettier-ignore
-    lsdebug(
+    enableLSDebug && lsdebug(
       `ls.qm send(${JSON.stringify(targetSlot)}, ${legibilizeMethod(prop)}) -> ${resultVPID}`,
     );
     syscall.send(targetSlot, serMethargs, resultVPID);
@@ -1032,7 +1032,7 @@ function build(
     insistCapData(methargsdata);
 
     // prettier-ignore
-    lsdebug(
+    enableLSDebug && lsdebug(
       `ls[${forVatID}].dispatch.deliver ${target}.${extractMethod(methargsdata)} -> ${resultVPID}`,
     );
     const t = convertSlotToVal(target);
@@ -1114,7 +1114,7 @@ function build(
   }
 
   function unregisterUnreferencedVPID(vpid) {
-    lsdebug(`unregisterUnreferencedVPID ${forVatID}:${vpid}`);
+    enableLSDebug && lsdebug(`unregisterUnreferencedVPID ${forVatID}:${vpid}`);
     assert.equal(parseVatSlot(vpid).type, 'promise');
     // we are only called with vpids that are in exportedVPIDs or
     // importedVPIDs, so the WeakRef should still be populated, making
@@ -1135,7 +1135,7 @@ function build(
 
     function handle(isReject, value) {
       knownResolutions.set(p, harden([isReject, value]));
-      lsdebug(`ls.thenHandler fired`, value);
+      enableLSDebug && lsdebug(`ls.thenHandler fired`, value);
       assert(exportedVPIDs.has(vpid), vpid);
       const rc = resolutionCollector();
       const resolutions = rc.forPromise(vpid, isReject, value);
@@ -1174,7 +1174,7 @@ function build(
 
   function notifyOnePromise(promiseID, rejected, data) {
     insistCapData(data);
-    lsdebug(
+    enableLSDebug && lsdebug(
       `ls.dispatch.notify(${promiseID}, ${rejected}, ${data.body}, [${data.slots}])`,
     );
     insistVatType('promise', promiseID);

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -351,7 +351,8 @@ function build(
     const fulfilledHandler = {
       applyMethod(o, prop, args, returnedP) {
         // Support: o~.[prop](...args) remote method invocation
-        enableLSDebug && lsdebug(`makeImportedPresence handler.applyMethod (${slot})`);
+        enableLSDebug &&
+          lsdebug(`makeImportedPresence handler.applyMethod (${slot})`);
         if (disavowedPresences.has(o)) {
           // eslint-disable-next-line no-use-before-define
           exitVatWithFailure(disavowalError);
@@ -433,7 +434,8 @@ function build(
     const unfulfilledHandler = {
       applyMethod(_p, prop, args, returnedP) {
         // Support: p~.[prop](...args) remote method invocation
-        enableLSDebug && lsdebug(`makePipelinablePromise handler.applyMethod (${vpid})`);
+        enableLSDebug &&
+          lsdebug(`makePipelinablePromise handler.applyMethod (${vpid})`);
         if (!handlerActive) {
           console.error(`mIPromise handler called after resolution`);
           Fail`mIPromise handler called after resolution`;
@@ -443,7 +445,8 @@ function build(
       },
       get(p, prop) {
         // Support: p~.[prop]
-        enableLSDebug && lsdebug(`makePipelinablePromise handler.get (${vpid})`);
+        enableLSDebug &&
+          lsdebug(`makePipelinablePromise handler.get (${vpid})`);
         if (!handlerActive) {
           console.error(`mIPromise handler called after resolution`);
           Fail`mIPromise handler called after resolution`;
@@ -879,7 +882,8 @@ function build(
     serMethargs.slots.map(retainExportedVref);
 
     const resultVPID = allocatePromiseID();
-    enableLSDebug && lsdebug(`Promise allocation ${forVatID}:${resultVPID} in queueMessage`);
+    enableLSDebug &&
+      lsdebug(`Promise allocation ${forVatID}:${resultVPID} in queueMessage`);
     // create a Promise which callers follow for the result, give it a
     // handler so we can pipeline messages to it, and prepare for the kernel
     // to notify us of its resolution
@@ -1174,9 +1178,9 @@ function build(
 
   function notifyOnePromise(promiseID, rejected, data) {
     insistCapData(data);
-    enableLSDebug && lsdebug(
-      `ls.dispatch.notify(${promiseID}, ${rejected}, ${data.body}, [${data.slots}])`,
-    );
+    enableLSDebug &&
+      // prettier-ignore
+      lsdebug(`ls.dispatch.notify(${promiseID}, ${rejected}, ${data.body}, [${data.slots}])`);
     insistVatType('promise', promiseID);
     const pRec = importedVPIDs.get(promiseID);
     // we check pRec to ignore stale notifies, either from before an

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -13,9 +13,7 @@ import { enumerateKeysWithPrefix } from './vatstore-iterators.js';
 const { ownKeys } = Reflect;
 const { details: X, quote: q } = assert;
 
-// import { kdebug, onToggleDebug } from './kdebug.js';
-// let debugEnabled = false;
-// onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
+// import { kdebug, debugging } from './kdebug.js';
 
 
 // Marker associated to flag objects that should be held onto strongly if
@@ -50,7 +48,7 @@ export function makeCache(size, fetch, store) {
   const cache = {
     makeRoom() {
       while (liveTable.size > size && lruTail) {
-        // debugEnabled && kdebug(`### vo LRU evict ${lruTail.baseRef} (dirty=${lruTail.dirty})`);
+        // debugging() && kdebug(`### vo LRU evict ${lruTail.baseRef} (dirty=${lruTail.dirty})`);
         liveTable.delete(lruTail.baseRef);
         if (lruTail.dirty) {
           store(lruTail.baseRef, lruTail.rawState);
@@ -111,7 +109,7 @@ export function makeCache(size, fetch, store) {
       if (!lruTail) {
         lruTail = innerObj;
       }
-      // debugEnabled && kdebug(`### vo LRU remember ${lruHead.baseRef}`);
+      // debugging() && kdebug(`### vo LRU remember ${lruHead.baseRef}`);
     },
     refresh(innerObj) {
       if (innerObj !== lruHead) {
@@ -131,7 +129,7 @@ export function makeCache(size, fetch, store) {
         innerObj.next = lruHead;
         lruHead.prev = innerObj;
         lruHead = innerObj;
-        // debugEnabled && kdebug(`### vo LRU refresh ${lruHead.baseRef}`);
+        // debugging() && kdebug(`### vo LRU refresh ${lruHead.baseRef}`);
       }
     },
     lookup(baseRef, load) {
@@ -796,7 +794,7 @@ export function makeVirtualObjectManager(
     }
 
     function reanimate(baseRef) {
-      // debugEnabled && kdebug(`vo reanimate ${baseRef}`);
+      // debugging() && kdebug(`vo reanimate ${baseRef}`);
       const innerSelf = cache.lookup(baseRef, false);
       const [toHold] = makeRepresentative(innerSelf, false);
       return toHold;
@@ -819,7 +817,7 @@ export function makeVirtualObjectManager(
     function makeNewInstance(...args) {
       const id = getNextInstanceID(kindID, isDurable);
       const baseRef = makeBaseRef(kindID, id, isDurable);
-      // debugEnabled && kdebug(`vo make ${baseRef}`);
+      // debugging() && kdebug(`vo make ${baseRef}`);
 
       const initialData = init ? init(...args) : {};
       const rawState = {};

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -15,7 +15,6 @@ const { details: X, quote: q } = assert;
 
 // import { kdebug, debugging } from './kdebug.js';
 
-
 // Marker associated to flag objects that should be held onto strongly if
 // somebody attempts to use them as keys in a VirtualObjectAwareWeakSet or
 // VirtualObjectAwareWeakMap, despite the fact that keys in such collections are

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -13,7 +13,10 @@ import { enumerateKeysWithPrefix } from './vatstore-iterators.js';
 const { ownKeys } = Reflect;
 const { details: X, quote: q } = assert;
 
-// import { kdebug } from './kdebug.js';
+// import { kdebug, onToggleDebug } from './kdebug.js';
+// let debugEnabled = false;
+// onToggleDebug(newEnableDebug => { debugEnabled = newEnableDebug; });
+
 
 // Marker associated to flag objects that should be held onto strongly if
 // somebody attempts to use them as keys in a VirtualObjectAwareWeakSet or
@@ -47,7 +50,7 @@ export function makeCache(size, fetch, store) {
   const cache = {
     makeRoom() {
       while (liveTable.size > size && lruTail) {
-        // kdebug(`### vo LRU evict ${lruTail.baseRef} (dirty=${lruTail.dirty})`);
+        // debugEnabled && kdebug(`### vo LRU evict ${lruTail.baseRef} (dirty=${lruTail.dirty})`);
         liveTable.delete(lruTail.baseRef);
         if (lruTail.dirty) {
           store(lruTail.baseRef, lruTail.rawState);
@@ -108,7 +111,7 @@ export function makeCache(size, fetch, store) {
       if (!lruTail) {
         lruTail = innerObj;
       }
-      // kdebug(`### vo LRU remember ${lruHead.baseRef}`);
+      // debugEnabled && kdebug(`### vo LRU remember ${lruHead.baseRef}`);
     },
     refresh(innerObj) {
       if (innerObj !== lruHead) {
@@ -128,7 +131,7 @@ export function makeCache(size, fetch, store) {
         innerObj.next = lruHead;
         lruHead.prev = innerObj;
         lruHead = innerObj;
-        // kdebug(`### vo LRU refresh ${lruHead.baseRef}`);
+        // debugEnabled && kdebug(`### vo LRU refresh ${lruHead.baseRef}`);
       }
     },
     lookup(baseRef, load) {
@@ -793,7 +796,7 @@ export function makeVirtualObjectManager(
     }
 
     function reanimate(baseRef) {
-      // kdebug(`vo reanimate ${baseRef}`);
+      // debugEnabled && kdebug(`vo reanimate ${baseRef}`);
       const innerSelf = cache.lookup(baseRef, false);
       const [toHold] = makeRepresentative(innerSelf, false);
       return toHold;
@@ -816,7 +819,7 @@ export function makeVirtualObjectManager(
     function makeNewInstance(...args) {
       const id = getNextInstanceID(kindID, isDurable);
       const baseRef = makeBaseRef(kindID, id, isDurable);
-      // kdebug(`vo make ${baseRef}`);
+      // debugEnabled && kdebug(`vo make ${baseRef}`);
 
       const initialData = init ? init(...args) : {};
       const rawState = {};


### PR DESCRIPTION
## Description

This applies the same reasoning that motivates ``` checkCondition() || Fail`…` ``` validation patterns to kernel logging (i.e., don't serialize a value when we know the output won't be used). I've implemented it with a hand-crafted push-style callback collection in kdebug.js to preserve the package-scoped integrity of `enableKDebug`, but would also be open to alternative approaches such as pull-style function call (e.g., `debugEnabled && kdebug(…)` → `debugEnabled() && kdebug(…)`).

### Security Considerations

n/a

### Scaling Considerations

This should improve performance, but mostly when the values to be serialized are large (which is rare in our testing). I have not attempted to quantify the improvement.

### Documentation Considerations

Probably not necessary, although we should consider where to put general guidance that covers assertions, logging, and any other scenarios where careless patterns could result in useless work.

### Testing Considerations

n/a