### PR TITLE
board remote as remotable

### DIFF
--- a/packages/agoric-cli/src/commands/ec.js
+++ b/packages/agoric-cli/src/commands/ec.js
@@ -32,7 +32,6 @@ export const makeEconomicCommiteeCommand = async _logger => {
         id: opts.offerId,
         invitationSpec: {
           source: 'purse',
-          // @ts-expect-error xxx RpcRemote
           instance: economicCommittee,
           description: 'Voter0', // XXX it may not always be
         },
@@ -56,7 +55,6 @@ export const makeEconomicCommiteeCommand = async _logger => {
         id: opts.offerId,
         invitationSpec: {
           source: 'purse',
-          // @ts-expect-error xxx RpcRemote
           instance: econCommitteeCharter,
           description: 'charter member invitation',
         },

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -66,7 +66,6 @@ export const makeOracleCommand = async logger => {
         id: Number(opts.offerId),
         invitationSpec: {
           source: 'purse',
-          // @ts-expect-error xxx RpcRemote
           instance,
           description: 'oracle invitation',
         },

--- a/packages/agoric-cli/src/commands/psm.js
+++ b/packages/agoric-cli/src/commands/psm.js
@@ -153,6 +153,8 @@ export const makePsmCommand = async logger => {
       const offer = Offers.psm.swap(instance, agoricNames.brand, {
         offerId: opts.offerId,
         feePct: opts.feePct,
+        giveMinted: opts.giveMinted,
+        wantMinted: opts.wantMinted,
       });
       outputExecuteOfferAction(offer);
     });

--- a/packages/agoric-cli/src/commands/psm.js
+++ b/packages/agoric-cli/src/commands/psm.js
@@ -150,7 +150,6 @@ export const makePsmCommand = async logger => {
     .action(async function (opts) {
       console.warn('running with options', opts);
       const instance = await lookupPsmInstance(opts.pair);
-      // @ts-expect-error xxx RpcRemote
       const offer = Offers.psm.swap(instance, agoricNames.brand, {
         offerId: opts.offerId,
         feePct: opts.feePct,

--- a/packages/agoric-cli/src/commands/wallet.js
+++ b/packages/agoric-cli/src/commands/wallet.js
@@ -155,9 +155,20 @@ export const makeWalletCommand = async () => {
       } catch (e) {
         console.error('CAUGHT HERE', e);
       }
-      execFileSync('agd', [`query`, 'bank', 'balances', opts.from], {
-        stdio: 'inherit',
-      });
+      execFileSync(
+        'agd',
+        [
+          'query',
+          '--node',
+          networkConfig.rpcAddrs[0],
+          'bank',
+          'balances',
+          opts.from,
+        ],
+        {
+          stdio: 'inherit',
+        },
+      );
     });
 
   wallet

--- a/packages/agoric-cli/src/lib/rpc.js
+++ b/packages/agoric-cli/src/lib/rpc.js
@@ -189,9 +189,10 @@ export const makeAgoricNames = async (ctx, vstorage) => {
       const content = await vstorage.readLatest(
         `published.agoricNames.${kind}`,
       );
+      /** @type {Array<[string, import('@agoric/vats/tools/board-utils.js').BoardRemote]>} */
       const parts = storageHelper.unserializeTxt(content, ctx).at(-1);
       for (const [name, remote] of parts) {
-        reverse[remote.boardId] = name;
+        reverse[remote.getBoardId()] = name;
       }
       return [kind, Object.fromEntries(parts)];
     }),

--- a/packages/inter-protocol/src/clientSupport.js
+++ b/packages/inter-protocol/src/clientSupport.js
@@ -11,7 +11,7 @@ const COSMOS_UNIT = 1_000_000n;
 /**
  * Give/want
  *
- * @param {Record<string, import('@agoric/vats/tools/board-utils').BoardRemote>} brands
+ * @param {Record<string, Brand>} brands
  * @param {{ giveMinted?: number, wantMinted?: number } | { collateralBrandKey: string, giveCollateral?: number, wantCollateral?: number }} opts
  * @returns {Proposal}
  */
@@ -54,7 +54,7 @@ const makeVaultProposal = (brands, opts) => {
 // Then these can be used in tests as arguments to `executeOffer()` without a bridge.
 
 /**
- * @param {Record<string, import('@agoric/vats/tools/board-utils').BoardRemote>} brands
+ * @param {Record<string, Brand>} brands
  * @param {{ offerId: string, wantMinted: number, giveCollateral: number, collateralBrandKey: string }} opts
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
  */
@@ -85,7 +85,7 @@ const makeOpenOffer = (brands, opts) => {
 };
 
 /**
- * @param {Record<string, import('@agoric/vats/tools/board-utils').BoardRemote>} brands
+ * @param {Record<string, Brand>} brands
  * @param {{ offerId: string, collateralBrandKey?: string, giveCollateral?: number, wantCollateral?: number, giveMinted?: number, wantMinted?: number }} opts
  * @param {string} previousOffer
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
@@ -108,7 +108,7 @@ const makeAdjustOffer = (brands, opts, previousOffer) => {
 };
 
 /**
- * @param {Record<string, import('@agoric/vats/tools/board-utils').BoardRemote>} brands
+ * @param {Record<string, Brand>} brands
  * @param {{ offerId: string, collateralBrandKey?: string, giveMinted: number }} opts
  * @param {string} previousOffer
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
@@ -147,7 +147,7 @@ export const lookupOfferIdForVault = async (vaultId, currentP) => {
 };
 
 /**
- * @param {Record<string, import('@agoric/vats/tools/board-utils').BoardRemote>} brands
+ * @param {Record<string, Brand>} brands
  * @param {({ wantMinted: number | undefined, giveMinted: number | undefined })} opts
  * @param {number} [fee=0]
  * @param {string} [anchor]
@@ -168,11 +168,9 @@ const makePsmProposal = (brands, opts, fee = 0, anchor = 'AUSD') => {
   };
   return {
     give: {
-      // @ts-expect-error XXX BoardRemote not real remote
       In: { brand: brand.in, value: adjusted.in },
     },
     want: {
-      // @ts-expect-error XXX BoardRemote not real remote
       Out: { brand: brand.out, value: adjusted.out },
     },
   };
@@ -180,7 +178,7 @@ const makePsmProposal = (brands, opts, fee = 0, anchor = 'AUSD') => {
 
 /**
  * @param {Instance} instance
- * @param {Record<string, import('@agoric/vats/tools/board-utils').BoardRemote>} brands
+ * @param {Record<string, Brand>} brands
  * @param {{ offerId: number, feePct?: number } &
  *         ({ wantMinted: number | undefined, giveMinted: number | undefined })} opts
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -15,7 +15,7 @@ export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
   /**
    * keyed by description; xxx assumes unique
    *
-   * @type {Map<import('./offers').OfferId, { acceptedIn: import('./offers').OfferId, description: string, instance: { boardId: string } }>}
+   * @type {Map<import('./offers').OfferId, { acceptedIn: import('./offers').OfferId, description: string, instance: Instance }>}
    */
   const invitationsReceived = new Map();
 

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -150,7 +150,7 @@ export const makeWalletFactoryDriver = async (
       return EV(walletPresence).handleBridgeAction(offerCapData, true);
     },
     /**
-     * @template {(brands: Record<string, import('../../tools/board-utils.js').BoardRemote>, ...rest: any) => import('@agoric/smart-wallet/src/offers.js').OfferSpec} M offer maker function
+     * @template {(brands: Record<string, Brand>, ...rest: any) => import('@agoric/smart-wallet/src/offers.js').OfferSpec} M offer maker function
      * @param {M} makeOffer
      * @param {Parameters<M>[1]} firstArg
      * @param {Parameters<M>[2]} [secondArg]

--- a/packages/vats/test/test-board-utils.js
+++ b/packages/vats/test/test-board-utils.js
@@ -152,7 +152,7 @@ test('makeAgoricNamesRemotesFromFakeStorage', t => {
   for (const path of ['brand', 'instance']) {
     t.true(
       Object.values(agoricNamesRemotes[path]).every(v =>
-        v.boardId.startsWith('board0'),
+        v.getBoardId().startsWith('board0'),
       ),
     );
   }
@@ -185,7 +185,7 @@ test(
 test(
   'board ids',
   serialize,
-  { boardId: 'board123' },
+  { getBoardId: () => 'board123' },
   { body: '{"@qclass":"slot","index":0}', slots: ['board123'] },
 );
 
@@ -193,8 +193,8 @@ test(
   'nested board ids',
   serialize,
   {
-    istBrand: { boardId: 'board123Ist' },
-    atomBrand: { boardId: 'board123Atom' },
+    istBrand: { getBoardId: () => 'board123Ist' },
+    atomBrand: { getBoardId: () => 'board123Atom' },
   },
   {
     body: '{"istBrand":{"@qclass":"slot","index":0},"atomBrand":{"@qclass":"slot","index":1}}',

--- a/packages/vats/tools/board-utils.js
+++ b/packages/vats/tools/board-utils.js
@@ -1,27 +1,40 @@
 // @ts-check
 /**
- * @typedef {{boardId: string, iface: string}} BoardRemote
+ * Should be a union with Remotable, but that's `any`, making this type meaningless
+ *
+ * @typedef {{ getBoardId: () => string }} BoardRemote
  */
 /**
  * @typedef {{
- *   brand: BoardRemote,
+ *   brand: BoardRemote & Brand,
  *   denom: string,
  *   displayInfo: DisplayInfo,
- *   issuer: BoardRemote,
+ *   issuer: BoardRemote & Issuer,
  *   issuerName: string,
  *   proposedName: string,
  * }} VBankAssetDetail
  */
 /**
  * @typedef {{
- *   brand: Record<string, BoardRemote>,
- *   instance: Record<string, BoardRemote>,
- *   vbankAsset?: Record<string, VBankAssetDetail>,
+ *   brand: Record<string, Brand>,
+ *   instance: Record<string, Instance>,
+ *   vbankAsset: Record<string, VBankAssetDetail>,
  *   reverse: Record<string, string>,
  * }} AgoricNamesRemotes
  */
 
 import { Fail } from '@agoric/assert';
+import { Far } from '@endo/marshal';
+
+/**
+ * @param {*} slotInfo
+ * @returns {BoardRemote}
+ */
+export const makeBoardRemote = ({ boardId, iface }) => {
+  const nonalleged =
+    iface && iface.length ? iface.slice('Alleged: '.length) : '';
+  return Far(`BoardRemote${nonalleged}`, { getBoardId: () => boardId });
+};
 
 /**
  * @param {import("@agoric/internal/src/storage-test-utils.js").FakeStorageKit} fakeStorageKit
@@ -39,12 +52,16 @@ export const makeAgoricNamesRemotesFromFakeStorage = fakeStorageKit => {
     (values && values.length > 0) || Fail`no data for ${key}`;
     /** @type {import("@endo/marshal").CapData<string>} */
     const latestCapData = JSON.parse(values.at(-1));
+    /** @type {Array<[string, import('@agoric/vats/tools/board-utils.js').BoardRemote]>} */
     const parts = JSON.parse(latestCapData.body).map(([name, slotInfo]) => [
       name,
-      { boardId: latestCapData.slots[slotInfo.index], iface: slotInfo.iface },
+      makeBoardRemote({
+        boardId: latestCapData.slots[slotInfo.index],
+        iface: slotInfo.iface,
+      }),
     ]);
     for (const [name, remote] of parts) {
-      reverse[remote.boardId] = name;
+      reverse[remote.getBoardId()] = name;
     }
     return [kind, Object.fromEntries(parts)];
   });
@@ -55,7 +72,7 @@ harden(makeAgoricNamesRemotesFromFakeStorage);
 /**
  * Like makeMarshal but,
  * - slotToVal takes an iface arg
- * - if a part being serialized has a boardId property, it passes through as a slot value whereas the normal marshaller would treat it as a copyRecord
+ * - if a part being serialized has getBoardId(), it passes through as a slot value whereas the normal marshaller would treat it as a copyRecord
  *
  * @param {(slot: string, iface: string) => any} slotToVal
  * @returns {import('@endo/marshal').Marshal<string>}
@@ -102,8 +119,9 @@ export const boardSlottingMarshaller = (slotToVal = (s, _i) => s) => ({
         return part.map(recur);
       }
       if (typeof part === 'object') {
-        if ('boardId' in part) {
-          return { '@qclass': 'slot', index: slotIndex(part.boardId) };
+        if ('getBoardId' in part) {
+          const index = slotIndex(part.getBoardId());
+          return { '@qclass': 'slot', index };
         }
         return Object.fromEntries(
           Object.entries(part).map(([k, v]) => [k, recur(v)]),


### PR DESCRIPTION
## Description

Changes the `BoardRemote` type to work more like a regular remotable and thus be passed through APIs that expect real remotables.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
