### PR TITLE
fix(zoe): add terms to invite details

### DIFF
--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -119,11 +119,17 @@ export const isAfterDeadlineExitRule = exit => {
   return exitKey === 'afterDeadline';
 };
 
+export const AnyTermsShape = M.splitRecord({
+  issuers: M.recordOf(KeywordShape, IssuerShape),
+  brands: M.recordOf(KeywordShape, BrandShape),
+});
+
 export const InvitationElementShape = M.splitRecord({
   description: M.string(),
   handle: InvitationHandleShape,
   instance: InstanceHandleShape,
   installation: InstallationShape,
+  terms: AnyTermsShape,
 });
 
 export const OfferHandlerI = M.interface('OfferHandler', {

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -1,6 +1,5 @@
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { E } from '@endo/eventual-send';
-import { passStyleOf } from '@endo/marshal';
 import {
   M,
   makeScalarBigMapStore,
@@ -16,7 +15,7 @@ import { AdminFacetI, InstanceAdminI } from '../typeGuards.js';
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 /** @typedef { import('@agoric/swingset-vat').BundleCap} BundleCap */
 
-const { Fail, quote: q } = assert;
+const { Fail } = assert;
 
 /**
  * @param {Pick<ZoeStorageManager, 'makeZoeInstanceStorageManager' | 'unwrapInstallation'>} startInstanceAccess
@@ -238,14 +237,6 @@ export const makeStartInstance = (
 
     const contractBundleCap = bundle || bundleCap;
     assert(contractBundleCap);
-
-    if (privateArgs !== undefined) {
-      const passStyle = passStyleOf(privateArgs);
-      passStyle === 'copyRecord' ||
-        Fail`privateArgs must be a pass-by-copy record, but instead was a ${q(
-          passStyle,
-        )}: ${privateArgs}`;
-    }
 
     const instanceHandle = makeInstanceHandle();
 

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -296,6 +296,7 @@
  * @typedef {object} InvitationDetails
  * @property {Installation} installation
  * @property {import('./utils.js').Instance<any>} instance
+ * @property {AnyTerms} terms
  * @property {InvitationHandle} handle
  * @property {string} description
  * @property {Record<string, any>} [customDetails]

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -275,6 +275,7 @@ export const makeZoeStorageManager = (
             ownKeys(customDetails).length >= 1
               ? harden({ customDetails })
               : harden({});
+          const instanceRecord = state.instanceState.getInstanceRecord();
           const invitationAmount = AmountMath.make(
             invitationKit.brand,
             harden([
@@ -282,9 +283,9 @@ export const makeZoeStorageManager = (
                 ...extraProperties,
                 description: desc,
                 handle,
-                instance: state.instanceState.getInstanceRecord().instance,
-                installation:
-                  state.instanceState.getInstanceRecord().installation,
+                instance: instanceRecord.instance,
+                installation: instanceRecord.installation,
+                terms: instanceRecord.terms,
               },
             ]),
           );

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -310,6 +310,10 @@ test(`zcf.makeInvitation - no customDetails`, async t => {
     handle: details.handle,
     installation,
     instance,
+    terms: {
+      brands: {},
+      issuers: {},
+    },
   });
 });
 
@@ -326,6 +330,10 @@ test(`zcf.makeInvitation - customDetails`, async t => {
     handle: details.handle,
     installation,
     instance,
+    terms: {
+      brands: {},
+      issuers: {},
+    },
     customDetails: {
       timer,
       whatever: 'whatever',
@@ -339,6 +347,10 @@ test(`zcf.makeInvitation - customDetails stratification`, async t => {
     description: 'whatever',
     installation: 'whatever',
     instance: 'whatever',
+    terms: {
+      brands: {},
+      issuers: {},
+    },
   });
   const details = await E(zoe).getInvitationDetails(invitationP);
   t.deepEqual(details, {
@@ -346,10 +358,18 @@ test(`zcf.makeInvitation - customDetails stratification`, async t => {
     handle: details.handle,
     installation,
     instance,
+    terms: {
+      brands: {},
+      issuers: {},
+    },
     customDetails: {
       description: 'whatever',
       installation: 'whatever',
       instance: 'whatever',
+      terms: {
+        brands: {},
+        issuers: {},
+      },
     },
   });
   t.falsy(typeof details.handle === 'string');


### PR DESCRIPTION
Fixes #5903 

Invitation amounts now include `terms` in the details as info accoring to zoe (as opposed to customDetails, which is info according to the contract).