### PR TITLE
add ensureTxn and failing DB test

### DIFF
--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -142,7 +142,7 @@ async function replay(transcriptFile) {
           return loadRaw(snapFile);
         },
       }
-    : makeSnapStore(process.cwd(), makeSnapStoreIO());
+    : makeSnapStore(process.cwd(), () => {}, makeSnapStoreIO());
   const testLog = undefined;
   const meterControl = makeDummyMeterControl();
   const gcTools = harden({

--- a/packages/SwingSet/test/test-xsnap-metering.js
+++ b/packages/SwingSet/test/test-xsnap-metering.js
@@ -45,7 +45,7 @@ function checkMetered(t, args, metered) {
 
 async function doTest(t, metered) {
   const db = sqlite3(':memory:');
-  const store = makeSnapStore(db, makeSnapStoreIO());
+  const store = makeSnapStore(db, () => {}, makeSnapStoreIO());
 
   const { p: p1, startXSnap: start1 } = make(store);
   const worker1 = await start1('vat', 'name', handleCommand, metered, false);

--- a/packages/SwingSet/test/test-xsnap-store.js
+++ b/packages/SwingSet/test/test-xsnap-store.js
@@ -60,7 +60,7 @@ test(`create XS Machine, snapshot (${snapSize.raw} Kb), compress to smaller`, as
   t.teardown(() => vat.close());
 
   const db = sqlite3(':memory:');
-  const store = makeSnapStore(db, makeMockSnapStoreIO());
+  const store = makeSnapStore(db, () => {}, makeMockSnapStoreIO());
 
   const { compressedSize } = await store.saveSnapshot(
     'vat0',
@@ -81,7 +81,7 @@ test('SES bootstrap, save, compress', async t => {
   t.teardown(() => vat.close());
 
   const db = sqlite3(':memory:');
-  const store = makeSnapStore(db, makeMockSnapStoreIO());
+  const store = makeSnapStore(db, () => {}, makeMockSnapStoreIO());
 
   await vat.evaluate('globalThis.x = harden({a: 1})');
 
@@ -101,7 +101,7 @@ test('SES bootstrap, save, compress', async t => {
 
 test('create SES worker, save, restore, resume', async t => {
   const db = sqlite3(':memory:');
-  const store = makeSnapStore(db, makeMockSnapStoreIO());
+  const store = makeSnapStore(db, () => {}, makeMockSnapStoreIO());
 
   const vat0 = await bootSESWorker('ses-boot2', async m => m);
   t.teardown(() => vat0.close());
@@ -127,7 +127,7 @@ test('create SES worker, save, restore, resume', async t => {
  */
 test('XS + SES snapshots are long-term deterministic', async t => {
   const db = sqlite3(':memory:');
-  const store = makeSnapStore(db, makeMockSnapStoreIO());
+  const store = makeSnapStore(db, () => {}, makeMockSnapStoreIO());
 
   const vat = await bootWorker('xs1', async m => m, '1 + 1');
   t.teardown(() => vat.close());
@@ -173,7 +173,7 @@ Then commit the changes in .../snapshots/ path.
 
 async function makeTestSnapshot() {
   const db = sqlite3(':memory:');
-  const store = makeSnapStore(db, makeMockSnapStoreIO());
+  const store = makeSnapStore(db, () => {}, makeMockSnapStoreIO());
   const vat = await bootWorker('xs1', async m => m, '1 + 1');
   const bootScript = await getBootScript();
   await vat.evaluate(bootScript);

--- a/packages/SwingSet/test/vat-warehouse/test-preload.js
+++ b/packages/SwingSet/test/vat-warehouse/test-preload.js
@@ -35,7 +35,7 @@ test('only preload maxVatsOnline vats', async t => {
   const argv = [];
 
   const db = sqlite3(':memory:');
-  const snapStore = makeSnapStore(db, makeSnapStoreIO());
+  const snapStore = makeSnapStore(db, () => {}, makeSnapStoreIO());
   const kernelStorage = { ...initSwingStore().kernelStorage, snapStore };
 
   await initializeSwingset(config, argv, kernelStorage, initOpts);

--- a/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
+++ b/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
@@ -24,7 +24,7 @@ test('vat reload from snapshot', async t => {
   };
 
   const db = sqlite3(':memory:');
-  const snapStore = makeSnapStore(db, makeSnapStoreIO());
+  const snapStore = makeSnapStore(db, () => {}, makeSnapStoreIO());
   const kernelStorage = { ...initSwingStore().kernelStorage, snapStore };
 
   const argv = [];

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -177,12 +177,10 @@ export function makeSwingStoreExporter(dirPath, exportMode = 'current') {
   const sqlBeginTransaction = db.prepare('BEGIN IMMEDIATE TRANSACTION');
   sqlBeginTransaction.run();
 
-  const snapStore = makeSnapStore(db, makeSnapStoreIO());
-  const transcriptStore = makeTranscriptStore(
-    db,
-    () => {},
-    () => {},
-  );
+  // ensureTxn can be a dummy, we just started one
+  const ensureTxn = () => 0;
+  const snapStore = makeSnapStore(db, ensureTxn, makeSnapStoreIO());
+  const transcriptStore = makeTranscriptStore(db, ensureTxn, () => {});
 
   const sqlGetAllKVData = db.prepare(`
     SELECT key, value
@@ -647,6 +645,7 @@ function makeSwingStore(dirPath, forceReset, options = {}) {
   );
   const { dumpSnapshots, ...snapStore } = makeSnapStore(
     db,
+    ensureTxn,
     makeSnapStoreIO(),
     noteExport,
     {

--- a/packages/swing-store/test/test-deletion.js
+++ b/packages/swing-store/test/test-deletion.js
@@ -1,0 +1,50 @@
+// @ts-check
+import test from 'ava';
+import '@endo/init/debug.js';
+import fs from 'fs';
+import { initSwingStore } from '../src/swingStore.js';
+
+async function dosnap(filePath) {
+  fs.writeFileSync(filePath, 'abc');
+}
+
+test.failing('delete snapshots with export callback', async t => {
+  const exportLog = [];
+  const exportCallback = exports => {
+    for (const [key, value] of exports) {
+      exportLog.push([key, value]);
+    }
+  };
+  const store = initSwingStore(null, { exportCallback });
+  const { kernelStorage, hostStorage } = store;
+  const { snapStore } = kernelStorage;
+  const { commit } = hostStorage;
+
+  await snapStore.saveSnapshot('v1', 10, dosnap);
+  await snapStore.saveSnapshot('v1', 11, dosnap);
+  await snapStore.saveSnapshot('v1', 12, dosnap);
+  // nothing is written to exportCallback until endCrank() or commit()
+  t.deepEqual(exportLog, []);
+
+  commit();
+
+  t.is(exportLog.length, 4);
+  t.is(exportLog[0][0], 'snapshot.v1.10');
+  t.is(exportLog[1][0], 'snapshot.v1.11');
+  t.is(exportLog[2][0], 'snapshot.v1.12');
+  t.is(exportLog[3][0], 'snapshot.v1.current');
+  exportLog.length = 0;
+
+  // in a previous version, deleteVatSnapshots caused overlapping SQL
+  // queries, and failed
+  snapStore.deleteVatSnapshots('v1');
+  commit();
+
+  t.deepEqual(exportLog, [
+    ['snapshot.v1.10', null],
+    ['snapshot.v1.11', null],
+    ['snapshot.v1.12', null],
+    ['snapshot.v1.current', null],
+  ]);
+  exportLog.length = 0;
+});

--- a/packages/swing-store/test/test-snapstore.js
+++ b/packages/swing-store/test/test-snapstore.js
@@ -25,11 +25,14 @@ function makeExportLog() {
   };
 }
 
+function ensureTxn() {}
+
 test('build temp file; compress to cache file', async t => {
   const db = sqlite3(':memory:');
   const exportLog = makeExportLog();
   const store = makeSnapStore(
     db,
+    ensureTxn,
     {
       ...tmp,
       tmpFile: tmp.file,
@@ -106,7 +109,7 @@ test('snapStore prepare / commit delete is robust', async t => {
     measureSeconds: makeMeasureSeconds(() => 0),
   };
   const db = sqlite3(':memory:');
-  const store = makeSnapStore(db, io, () => {}, {
+  const store = makeSnapStore(db, ensureTxn, io, () => {}, {
     keepSnapshots: true,
   });
 


### PR DESCRIPTION
Two items:

* add `ensureTxn()` to snapStore DB mutation sites
* add a failing test of the DB cannot-write-during-iterate problem in `deleteVatSnapshots`
