### PR TITLE
fix: awaits were missing in tests

### DIFF
--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -71,7 +71,7 @@ export async function start(zcf, privateArgs, baggage) {
     timer,
     quoteMint: makeIssuerKit('quote', AssetKind.SET).mint,
   };
-  const priceAuthority = makeFakePriceAuthority(options);
+  const priceAuthority = await makeFakePriceAuthority(options);
   const maxDebtFor = async collateralAmount => {
     const quoteAmount = await E(priceAuthority).quoteGiven(
       collateralAmount,

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -37,7 +37,7 @@ test('makeAddCollateralInvitation', async t => {
 
   const timer = buildManualTimer(t.log);
 
-  const priceAuthority = makeFakePriceAuthority({
+  const priceAuthority = await makeFakePriceAuthority({
     priceList: [],
     timer,
     actualBrandIn: collateralKit.brand,

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -61,7 +61,7 @@ test('loan - lend - exit before borrow', async t => {
 
   const timer = buildManualTimer(t.log);
 
-  const priceAuthority = makeFakePriceAuthority({
+  const priceAuthority = await makeFakePriceAuthority({
     priceList: [],
     timer,
     actualBrandIn: collateralKit.brand,

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -64,7 +64,7 @@ test('fundedCallSpread below Strike1', async t => {
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
 
   const manualTimer = buildManualTimer(t.log, 0n, { eventLoopIteration });
-  const priceAuthority = makeTestPriceAuthority(
+  const priceAuthority = await makeTestPriceAuthority(
     brands,
     [54, 20, 35, 15, 28],
     manualTimer,
@@ -175,7 +175,11 @@ test('fundedCallSpread above Strike2', async t => {
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
 
   const manualTimer = buildManualTimer(t.log, 0n, { eventLoopIteration });
-  const priceAuthority = makeTestPriceAuthority(brands, [20, 55], manualTimer);
+  const priceAuthority = await makeTestPriceAuthority(
+    brands,
+    [20, 55],
+    manualTimer,
+  );
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 2n,
@@ -279,7 +283,11 @@ test('fundedCallSpread, mid-strike', async t => {
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
 
   const manualTimer = buildManualTimer(t.log, 0n, { eventLoopIteration });
-  const priceAuthority = makeTestPriceAuthority(brands, [20, 45], manualTimer);
+  const priceAuthority = await makeTestPriceAuthority(
+    brands,
+    [20, 45],
+    manualTimer,
+  );
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 2n,
@@ -382,7 +390,11 @@ test('fundedCallSpread, late exercise', async t => {
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
 
   const manualTimer = buildManualTimer(t.log, 0n, { eventLoopIteration });
-  const priceAuthority = makeTestPriceAuthority(brands, [20, 45], manualTimer);
+  const priceAuthority = await makeTestPriceAuthority(
+    brands,
+    [20, 45],
+    manualTimer,
+  );
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 2n,
@@ -487,7 +499,11 @@ test('fundedCallSpread, sell options', async t => {
   const carolBucksPayment = bucksMint.mintPayment(bucks(100n));
 
   const manualTimer = buildManualTimer(t.log, 0n, { eventLoopIteration });
-  const priceAuthority = makeTestPriceAuthority(brands, [20, 45], manualTimer);
+  const priceAuthority = await makeTestPriceAuthority(
+    brands,
+    [20, 45],
+    manualTimer,
+  );
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 2n,


### PR DESCRIPTION
Missing `await` was causing test in https://github.com/Agoric/agoric-sdk/pull/7149 to fail at https://github.com/Agoric/agoric-sdk/blob/dd7ef095023875d2dfb0191b40b0d8d33c44bb4c/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js#L82-L84 .

Although the test does not fail on master, I'm making this a separate PR against master because my sense is that this `await` is actually needed to correctly express the intent of the test.

Without it, the `terms` of the new contract instance contain a promise. Promises are not `canBeDurable`, so in an environment where this is enforced, this contract would fail to initialize anyway.

Regarding this bug, the only thing special about #7149 is that it also depends on `terms` not having any promises for other reasons: It must be a `Key` so it can be included in an amount. (Specifically, in this case, within the invitationDetails of an invitation.)