### PR TITLE
refactor(zoe): more precise startInstance

### DIFF
--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -185,7 +185,7 @@ export const makeStartInstance = (
         const { state } = this;
 
         const vatParameters = { contractBundleCap: state.contractBundleCap };
-        return E(state.adminNode).upgrade(state.zcfBundleCap.value, {
+        return E(state.adminNode).upgrade(state.zcfBundleCap, {
           vatParameters,
         });
       },
@@ -198,7 +198,7 @@ export const makeStartInstance = (
           contractBundleCap: newContractBundleCap,
           privateArgs: newPrivateArgs,
         };
-        return E(state.adminNode).upgrade(state.zcfBundleCap.value, {
+        return E(state.adminNode).upgrade(state.zcfBundleCap, {
           vatParameters,
         });
       },
@@ -290,33 +290,26 @@ export const makeStartInstance = (
     instanceAdmin.initDelayedState(handleOfferObj, publicFacet);
 
     const settledBundleCap = await getZcfBundleCapP();
+    settledBundleCap !== undefined || Fail`the bundle cap was broken`;
+
     // creatorInvitation can be undefined, but if it is defined,
     // let's make sure it is an invitation.
     return E.when(
-      Promise.allSettled([
+      Promise.all([
         creatorInvitationP,
-        zoeInstanceStorageManager
-          .getInvitationIssuer()
-          .isLive(creatorInvitationP),
-        settledBundleCap,
+        creatorInvitationP !== undefined &&
+          zoeInstanceStorageManager
+            .getInvitationIssuer()
+            .isLive(creatorInvitationP),
       ]),
-      ([invitationResult, isLiveResult, zcfBundleCapResult]) => {
-        let creatorInvitation;
-        if (invitationResult.status === 'fulfilled') {
-          creatorInvitation = invitationResult.value;
-        }
-        if (creatorInvitation !== undefined) {
-          (isLiveResult.status === 'fulfilled' && isLiveResult.value) ||
-            Fail`The contract did not correctly return a creatorInvitation`;
-        }
-        if (zcfBundleCapResult !== undefined) {
-          (zcfBundleCapResult.status === 'fulfilled' &&
-            zcfBundleCapResult.value) ||
-            Fail`the bundle cap was broken`;
-        }
+      ([creatorInvitation, isLiveResult]) => {
+        creatorInvitation === undefined ||
+          isLiveResult ||
+          Fail`The contract did not correctly return a creatorInvitation`;
+
         const adminFacet = makeAdminFacet(
           adminNode,
-          harden(zcfBundleCapResult),
+          harden(settledBundleCap),
           contractBundleCap,
         );
 


### PR DESCRIPTION
Simplifies the `Promise.allSettled` startup logic in `startInstance.js`. For the `creatorInvitation`, we allow it to be `undefined`, but the old code would call `isLive` with it anyway, tolerating the resulting error. Throwing and tolerating an error in the normal case makes debugging difficult, unless you already know to ignore that error. (I didn't)

Aside from the `creatorInvitation` liveness test, it was manually emulating a `Promise.all` out of the `allSettled` results.

On the bundleCap, it was already the result of an `await`, and so necessarily not a promise. It did not need to go through the promise settling logic.

Ready for review.