### PR TITLE
chore: avoid some unnecessary bundling in vaultFactory etc.

### DIFF
--- a/packages/governance/src/index.js
+++ b/packages/governance/src/index.js
@@ -44,5 +44,3 @@ export {
 } from './validators.js';
 
 export { ParamTypes } from './constants.js';
-
-export { makeBinaryVoteCounter } from './binaryVoteCounter.js';

--- a/packages/governance/test/unitTests/test-binaryballotCount.js
+++ b/packages/governance/test/unitTests/test-binaryballotCount.js
@@ -12,13 +12,13 @@ import {
 
 import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
 import {
-  makeBinaryVoteCounter,
   ChoiceMethod,
   ElectionType,
   QuorumRule,
   coerceQuestionSpec,
   makeParamChangePositions,
 } from '../../src/index.js';
+import { makeBinaryVoteCounter } from '../../src/binaryVoteCounter.js';
 
 const SIMPLE_ISSUE = harden({ text: 'Fish or cut bait?' });
 const FISH = harden({ text: 'Fish' });

--- a/packages/vats/src/tokens.js
+++ b/packages/vats/src/tokens.js
@@ -10,11 +10,8 @@
  */
 const NAT = 'nat';
 
-/** @typedef {Capitalize<string>} Keyword */
-
 export const Stable = harden(
   /** @type {const } */ ({
-    /** @type {Keyword} */
     symbol: 'IST',
     denom: 'uist',
     proposedName: 'Agoric stable local currency',
@@ -28,7 +25,6 @@ export const Stable = harden(
 
 export const Stake = harden(
   /** @type {const } */ ({
-    /** @type {Keyword} */
     symbol: 'BLD',
     denom: 'ubld',
     proposedName: 'Agoric staking token',

--- a/packages/vats/src/tokens.js
+++ b/packages/vats/src/tokens.js
@@ -1,35 +1,41 @@
 // @ts-check
 
-import { AssetKind } from '@agoric/ertp';
-import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
-
 /** @typedef { 'IST' | 'BLD' } TokenKeyword */
+
+/**
+ * Use static type check and unit tests rather than runtime import
+ * to avoid bundling all of ERTP just to get Stable.symbol.
+ *
+ * @type {typeof import('@agoric/ertp').AssetKind.NAT}
+ */
+const NAT = 'nat';
+
+/** @typedef {Capitalize<string>} Keyword */
 
 export const Stable = harden(
   /** @type {const } */ ({
+    /** @type {Keyword} */
     symbol: 'IST',
     denom: 'uist',
     proposedName: 'Agoric stable local currency',
-    assetKind: AssetKind.NAT,
+    assetKind: NAT,
     displayInfo: {
       decimalPlaces: 6,
-      assetKind: AssetKind.NAT,
+      assetKind: NAT,
     },
   }),
 );
 
 export const Stake = harden(
   /** @type {const } */ ({
+    /** @type {Keyword} */
     symbol: 'BLD',
     denom: 'ubld',
     proposedName: 'Agoric staking token',
-    assetKind: AssetKind.NAT,
+    assetKind: NAT,
     displayInfo: {
       decimalPlaces: 6,
-      assetKind: AssetKind.NAT,
+      assetKind: NAT,
     },
   }),
 );
-
-assertKeywordName(Stable.symbol);
-assertKeywordName(Stake.symbol);

--- a/packages/vats/test/test-tokens.js
+++ b/packages/vats/test/test-tokens.js
@@ -1,0 +1,18 @@
+// @ts-check
+import '@endo/init';
+import test from 'ava';
+
+import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
+
+import { AssetKind } from '@agoric/ertp';
+import { Stable, Stake } from '../src/tokens.js';
+
+test('token symbols are keywords', t => {
+  t.notThrows(() => assertKeywordName(Stable.symbol));
+  t.notThrows(() => assertKeywordName(Stake.symbol));
+});
+
+test('token assetKind matches ERTP', t => {
+  t.is(Stable.assetKind, AssetKind.NAT);
+  t.is(Stake.assetKind, AssetKind.NAT);
+});


### PR DESCRIPTION
refs: #6687

## Description

 - Avoid bundling the `binaryVoteCounter.js` contract in `bundle-vaultFactory.js`
 - Use static type check and unit tests rather than runtime import to avoid bundling all of ERTP just to `import { Stable, Staking } from 'tokens.js';`.

Discovered while auditing bootstrap contents (#6687, #7049).

### Scaling Considerations

slightly smaller bundle size:

| bundle | before | after | savings |
| --- | --- | --- | --- |
| bundle-VaultFactory.js | 1492220 | 1476536 | 1% |

### Testing Considerations

Moved `assertKeywordName(Stable.symbol)` and the like from a runtime check to a unit test.
