### PR TITLE
fix(action): handle missing Collateral allocation

### DIFF
--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -85,6 +85,10 @@ export const makeBidSpecShape = (currencyBrand, collateralBrand) => {
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
+/**
+ * @param {Baggage} baggage
+ * @param {ZCF} zcf
+ */
 export const prepareAuctionBook = (baggage, zcf) => {
   const makeScaledBidBook = prepareScaledBidBook(baggage);
   const makePriceBook = preparePriceBook(baggage);

--- a/packages/inter-protocol/test/auction/test-auctionContract.js
+++ b/packages/inter-protocol/test/auction/test-auctionContract.js
@@ -873,6 +873,9 @@ test.serial('multiple bidders at one auction step', async t => {
     collateral.make(200n),
   );
 
+  // regression test for getCurrentAllocation() bug
+  await driver.bidForCollateralSeat(currency.make(210n), collateral.make(200n));
+
   assert(nextAuctionSchedule.startTime.absValue);
   now = nextAuctionSchedule.startTime.absValue;
   await driver.advanceTo(now);


### PR DESCRIPTION
refs: #6930

## Description

Fix code that assumed `getCurrentAllocation()` would include an amount in the `.Collateral` property.
Designed in collaboration with @Chris-Hibbert 

### Testing Considerations

probably merits a regression test.
