### PR TITLE
ci: code coverage for golang

### DIFF
--- a/.github/workflows/test-golang.yml
+++ b/.github/workflows/test-golang.yml
@@ -16,4 +16,7 @@ jobs:
         with:
           go-version: 1.18
       - name: go test
-        run: cd golang && go test ./...
+        run: cd golang && go test -coverprofile=coverage.txt -covermode=atomic ./...
+      - name: Upload coverage reports to Codecov
+        if: success() || failure()
+        uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+coverage.txt
 
 # nyc test coverage
 .nyc_output

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,21 +1,14 @@
 codecov:
-  require_ci_to_pass: false
+  require_ci_to_pass: true
 comment:
   behavior: default
   layout: reach,diff,flags,tree,reach
   show_carryforward_flags: false
 coverage:
-  precision: 2
-  range:
-  - 60.0
-  - 80.0
-  round: down
   status:
-    changes: false
-    default_rules:
-      flag_coverage_not_uploaded_behavior: include
-    patch: true
-    project: true
+    project:
+      default:
+        informational: true
 github_checks:
   annotations: true
 parsers:


### PR DESCRIPTION
enabled golang to output coverage deets, and makes coverage levels optional for merging