### PR TITLE
chore: Correct a misspelling of "Remotable"

### DIFF
--- a/packages/SwingSet/test/test-comms.js
+++ b/packages/SwingSet/test/test-comms.js
@@ -455,7 +455,7 @@ test('comms gc', t => {
     dispatch(makeMessage(receiverID, 'receive', [msg]));
   }
 
-  // Alice is a Remoteable on some vat of machine A
+  // Alice is a Remotable on some vat of machine A
   const aliceKernel = 'o-10';
   // const aliceLocal = ck.provideLocalForKernel(aliceKernel);
 


### PR DESCRIPTION
The supermajority of uses of the term have only two occurrences of "e" (including [docs.agoric.com](https://docs.agoric.com/guides/js-programming/far.html)), but there was a deviant.