### PR TITLE
fix(xsnap-lockdown): change the API to get hash of the lockdown bundle

### DIFF
--- a/packages/xsnap-lockdown/README.md
+++ b/packages/xsnap-lockdown/README.md
@@ -37,9 +37,9 @@ await worker.evaluate(`(${bundle.source}\n)()`.trim());
 To help detect version drift or build/import problems, the package also exports the hex-encoded SHA256 hash of the JSON-stringified bundle. This should be identical to running `/usr/bin/shasum -a 256` on the pathname recorded in the internal `bundlePaths.lockdown` (typically `xsnap-lockdown/bundles/lockdown.bundle`). Clients which have selected a particular version of `@agoric/xsnap-lockdown` in their `package.json` can retrieve this hash at import time and compare it against a hard-coded copy, to assert that their preferred version is actually in use. Such clients would need to update their copy of the hash each time they deliberately switch to a different version.
 
 ```js
-import { lockdownBundleSHA256 } from '@agoric/xsnap-lockdown';
+import { getLockdownBundleSHA256 } from '@agoric/xsnap-lockdown';
 const expected = '54434e4a0eb0c2883e30cc43a30ac66bb792bec3b4975bb147cb8f25c2c6365a';
-assert.equal(lockdownBundleSHA256, expected, 'somehow got wrong version');
+assert.equal(await getLockdownBundleSHA256(), expected, 'somehow got wrong version');
 ```
 
 ## Debug Version

--- a/packages/xsnap-lockdown/scripts/build-bundle.js
+++ b/packages/xsnap-lockdown/scripts/build-bundle.js
@@ -5,7 +5,7 @@ import { promises as fsp } from 'fs';
 import crypto from 'crypto';
 
 import bundleSource from '@endo/bundle-source';
-import { bundlePaths, entryPaths } from '../src/paths.js';
+import { bundlePaths, entryPaths, hashPaths } from '../src/paths.js';
 
 /** @param {Uint8Array} bytes */
 const computeSha256 = bytes => {
@@ -14,29 +14,24 @@ const computeSha256 = bytes => {
   return hash.digest().toString('hex');
 };
 
-const make = async (name, entrypath, spec) => {
+const make = async name => {
+  const spec = bundlePaths[name];
+  const entryPath = entryPaths[name];
+  const hashPath = hashPaths[name];
   await fsp.mkdir(path.dirname(spec), { recursive: true });
-  const format = 'nestedEvaluate';
-  const bundle = await bundleSource(entrypath, { format });
+  const bundle = await bundleSource(entryPath, { format: 'nestedEvaluate' });
   const bundleString = JSON.stringify(bundle);
   const sha256 = computeSha256(bundleString);
   await fsp.writeFile(spec, bundleString);
-  return { length: bundleString.length, sha256, spec };
+  await fsp.writeFile(hashPath, `${sha256}\n`);
+  return { length: bundleString.length, sha256, where: spec };
 };
 
 const run = async () => {
-  const ld = await make('lockdown', entryPaths.lockdown, bundlePaths.lockdown);
-  console.log(`wrote ${ld.spec}: ${ld.length} bytes`);
+  const ld = await make('lockdown');
+  console.log(`wrote ${ld.where}: ${ld.length} bytes`);
   console.log(`lockdown.bundle SHA256: ${ld.sha256}`);
-  const lockdownHashFile = `${ld.spec}.sha256.js`;
-  const template = `export const lockdownBundleSHA256 = 'HASH';\n`;
-  await fsp.writeFile(lockdownHashFile, template.replace('HASH', ld.sha256));
-
-  await make(
-    'lockdown-debug',
-    entryPaths.lockdownDebug,
-    bundlePaths.lockdownDebug,
-  );
+  await make('lockdownDebug');
 };
 
 run().catch(err => console.log(err));

--- a/packages/xsnap-lockdown/src/index.js
+++ b/packages/xsnap-lockdown/src/index.js
@@ -1,7 +1,21 @@
 import fs from 'fs';
-import { bundlePaths } from './paths.js';
+import { bundlePaths, hashPaths } from './paths.js';
 
-export { lockdownBundleSHA256 } from '../dist/lockdown.bundle.sha256.js';
+const read = (name, path) => {
+  return fs.promises.readFile(path, { encoding: 'utf-8' }).catch(err => {
+    console.error(`unable to read lockdown ${name} at ${path}`);
+    console.error(`perhaps run 'yarn build' in @agoric/xsnap-lockdown`);
+    throw err;
+  });
+};
+
+/**
+ * @returns { Promise<string> }
+ */
+export const getLockdownBundleSHA256 = async () => {
+  const path = hashPaths.lockdown;
+  return read('hash', path).then(data => data.trim());
+};
 
 /**
  * @param { boolean } debug
@@ -10,14 +24,7 @@ export { lockdownBundleSHA256 } from '../dist/lockdown.bundle.sha256.js';
  */
 const getBundle = async debug => {
   const path = debug ? bundlePaths.lockdownDebug : bundlePaths.lockdown;
-  const bundleStringP = fs.promises.readFile(path, { encoding: 'utf-8' });
-  return bundleStringP
-    .catch(err => {
-      console.error(`lockdown bundle not present at ${path}`);
-      console.error(`perhaps run 'yarn build' in @agoric/xsnap-lockdown`);
-      throw err;
-    })
-    .then(bundleString => JSON.parse(bundleString));
+  return read('bundle', path).then(bundleString => JSON.parse(bundleString));
 };
 
 export const getLockdownBundle = () => getBundle(false);

--- a/packages/xsnap-lockdown/src/paths.js
+++ b/packages/xsnap-lockdown/src/paths.js
@@ -7,6 +7,14 @@ export const bundlePaths = {
     .pathname,
 };
 
+export const hashPaths = {
+  lockdown: new URL('../dist/lockdown.bundle.sha256', import.meta.url).pathname,
+  lockdownDebug: new URL(
+    '../dist/lockdown-debug.bundle.sha256',
+    import.meta.url,
+  ).pathname,
+};
+
 export const entryPaths = {
   lockdown: new URL('../lib/ses-boot.js', import.meta.url).pathname,
   lockdownDebug: new URL('../lib/ses-boot-debug.js', import.meta.url).pathname,

--- a/packages/xsnap-lockdown/test/test-bundle.js
+++ b/packages/xsnap-lockdown/test/test-bundle.js
@@ -5,7 +5,7 @@ import crypto from 'crypto';
 
 import {
   getLockdownBundle,
-  lockdownBundleSHA256,
+  getLockdownBundleSHA256,
   getDebugLockdownBundle,
 } from '../src/index.js';
 import { bundlePaths } from '../src/paths.js';
@@ -40,7 +40,8 @@ test('bundle hash', async t => {
   const bundleString = fs.readFileSync(lockdownBundleSpec, {
     encoding: 'utf-8',
   });
-  t.is(sha256(encode(bundleString)), lockdownBundleSHA256);
+  const publishedHash = await getLockdownBundleSHA256();
+  t.is(sha256(encode(bundleString)), publishedHash);
 
   // The bundle object can be JSON-stringified and then hashed. This
   // serialization should be deterministic (JSON.stringify uses
@@ -49,5 +50,5 @@ test('bundle hash', async t => {
 
   const bundle = await getLockdownBundle();
   const bundleString2 = JSON.stringify(bundle);
-  t.is(sha256(encode(bundleString2)), lockdownBundleSHA256);
+  t.is(sha256(encode(bundleString2)), publishedHash);
 });


### PR DESCRIPTION
Mathieu pointed out that it's weird for source files to not exist until after a `yarn build`, especially when they are necessary for typechecks or lint to pass. I implemented his suggestions for swingset-xsnap-supervisor, and this commit backports the same approach to xsnap-lockdown.
