### PR TITLE
`gen-upgrade-proposal.sh` chain software upgrade helper

### DIFF
--- a/bin/agd
+++ b/bin/agd
@@ -27,6 +27,8 @@ source "$thisdir/../repoconfig.sh"
 
 if test "${1-''}" = build; then
   BUILD_ONLY=true
+  # Enable shell debugging.
+  set -x
   case "${2-''}" in
   --force | -f)
     rm -rf "$thisdir/../$STAMPS"
@@ -84,6 +86,10 @@ if $NEED_NODEJS; then
 fi
 
 (
+  # Send the build output to stderr unless we're only building.  This prevents
+  # the daemon's stdout from being polluted with build output.
+  $BUILD_ONLY || exec 1>&2
+
   cd "$thisdir/.."
   mkdir -p "$STAMPS"
 
@@ -102,25 +108,23 @@ fi
     stamp=$STAMPS/yarn-installed
     if test -e "$stamp"; then
       print=( -newer "$stamp" )
-    elif test -e node_modules; then
-      print=( -newer node_modules )
     else
       print=()
     fi
-    files=( package.json )
-    if test ${#print[@]} -gt 0; then
-      # Find the current list of package.jsons.
-      while IFS= read -r line; do
-        files+=( "$line" )
-      done < <(lazy_yarn -s workspaces info |
-        sed -ne '/"location":/{ s/.*": "//; s!",.*!/package.json!; p; }')
-    fi
     print+=( -print )
+
+    # Find the current list of package.jsons.
+    files=( package.json )
+    while IFS= read -r line; do
+      files+=( "$line" )
+    done < <(lazy_yarn -s workspaces info |
+      sed -ne '/"location":/{ s/.*": "//; s!",.*!/package.json!; p; }')
+
     src=$(find "${files[@]}" "${print[@]}" | head -1 || true)
     test -z "$src" || {
-      echo "At least $src is newer than $stamp"
+      echo "At least $src is newer than node_modules"
       rm -f "$STAMPS/yarn-built"
-      lazy_yarn install --force
+      lazy_yarn install
       date > "$stamp"
     }
 
@@ -168,7 +172,7 @@ fi
       make
     )
   }
-) 1>&2 # Send the build output to stderr.
+)
 
 if $BUILD_ONLY; then
   echo "Build complete." 1>&2

--- a/scripts/gen-upgrade-proposal.sh
+++ b/scripts/gen-upgrade-proposal.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+set -ueo pipefail
+
+cat <<EOF 1>&2
+------------------------------------------------------------
+This script shows a command for a software upgrade proposal which is
+compatible with the Cosmovisor found at:
+https://github.com/agoric-labs/cosmos-sdk/tree/Agoric/cosmovisor#readme
+------------------------------------------------------------
+EOF
+
+COMMIT_ID=$(git rev-parse HEAD)
+ZIPURL=https://github.com/Agoric/agoric-sdk/archive/$COMMIT_ID.zip
+
+echo "Verifying archive is at $ZIPURL..." 1>&2
+zipfile=$(mktemp)
+trap 'rm -f "$zipfile"' EXIT
+curl -L "$ZIPURL" -o "$zipfile"
+
+echo "Generating SHA-256 checksum..." 1>&2
+checksum=sha256:$(shasum -a 256 "$zipfile" | cut -d' ' -f1)
+
+info="{\"binaries\":{\"any\":\"$ZIPURL?checksum=$checksum\"}}"
+
+cat <<EOF 1>&2
+------------------------------------------------------------
+Here is the skeleton of the recomended upgrade proposal command.
+You'll need to fill in the details.
+
+Try \`agd tx submit-proposal software-upgrade --help\` for more info.
+
+Also, take a look at existing on-chain software upgrade proposals for
+examples.
+------------------------------------------------------------
+EOF
+
+cat <<EOF
+agd tx submit-proposal software-upgrade <UPGRADE-NAME> \\
+  --upgrade-info='$info' \\
+  --upgrade-height <HEIGHT> \\
+  --title '<TITLE>' --description '<DESCRIPTION>' \\
+  <TXOPTS>...
+EOF


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Include a script to be referenced in future release notes when describing how to submit an Agoric chain software upgrade governance proposal.  Notably, the `--upgrade-info` constructed by this script will result in a proposal compatible with Cosmovisor.

Also adds a bit of stdout/stderr management and shell script debugging features when running `bin/agd build` vs. `bin/agd something else`.  As a drive-by, while tweaking `bin/agd`, also closes: #7356.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

Cosmovisor's automatic download feature should not be used in production, though it is handy for one-off testing.

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

n/a

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

Should be described in release notes.

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

Tested manually.

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
