### PR TITLE
Implement `test:xs` for `vats` package

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -430,7 +430,9 @@ export const prepareVault = (baggage, marshaller, zcf) => {
             // you must pay off the entire remainder but if you offer too much, we won't
             // take more than you owe
             AmountMath.isGTE(given, debt) ||
-              Fail`Offer ${given} is not sufficient to pay off debt ${debt}`;
+              Fail`Offer ${q(given)} is not sufficient to pay off debt ${q(
+                debt,
+              )}`;
 
             // Return any overpayment
             atomicTransfer(

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -17,7 +17,7 @@
     "postpack": "git clean -f '*.d.ts*'",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
-    "test:xs": "exit 0",
+    "test:xs": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 'test/bootstrapTests/**/test-*.js' 'test/upgrading/**/test-*.js'",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc -p jsconfig.json",

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint-disable import/no-extraneous-dependencies */
 import { Fail } from '@agoric/assert';
 import { buildSwingset } from '@agoric/cosmic-swingset/src/launch-chain.js';
 import { BridgeId, VBankAccount } from '@agoric/internal';
@@ -24,6 +25,30 @@ export const bootstrapMethods = {
   messageVat: 'messageVat',
   messageVatObject: 'messageVatObject',
   awaitVatObject: 'awaitVatObject',
+};
+
+/**
+ * @template {PropertyKey} K
+ * @template V
+ * @param {K[]} keys
+ * @param {(key: K, i: number) => V} valueMaker
+ */
+const keysToObject = (keys, valueMaker) => {
+  return Object.fromEntries(keys.map((key, i) => [key, valueMaker(key, i)]));
+};
+
+/**
+ * AVA's default t.deepEqual() is nearly unreadable for sorted arrays of strings.
+ *
+ * @param {{ deepEqual: (a: unknown, b: unknown, message?: string) => void}} t
+ * @param {PropertyKey[]} a
+ * @param {PropertyKey[]} b
+ * @param {string} [message]
+ */
+export const keyArrayEqual = (t, a, b, message) => {
+  const aobj = keysToObject(a, () => 1);
+  const bobj = keysToObject(b, () => 1);
+  return t.deepEqual(aobj, bobj, message);
 };
 
 /**

--- a/packages/vats/test/bootstrapTests/test-demo-config.js
+++ b/packages/vats/test/bootstrapTests/test-demo-config.js
@@ -14,6 +14,7 @@ const test = anyTest;
 const makeDefaultTestContext = async t => {
   const swingsetTestKit = await makeSwingsetTestKit(
     t,
+    'bundles/demo-config',
     '@agoric/vats/decentral-demo-config.json',
   );
   return swingsetTestKit;

--- a/packages/vats/test/bootstrapTests/test-demo-config.js
+++ b/packages/vats/test/bootstrapTests/test-demo-config.js
@@ -3,7 +3,7 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { PowerFlags } from '../../src/walletFlags.js';
 
-import { makeSwingsetTestKit } from './supports.js';
+import { makeSwingsetTestKit, keyArrayEqual } from './supports.js';
 
 const { keys } = Object;
 /**
@@ -65,7 +65,7 @@ test('sim/demo config provides home with .myAddressNameAdmin', async t => {
   const home = await makeHomeFor(addr, EV);
   const actual = await EV(home.myAddressNameAdmin).getMyAddress();
   t.is(actual, addr, 'my address');
-  t.deepEqual(keys(home).sort(), homeKeys);
+  keyArrayEqual(t, keys(home).sort(), homeKeys);
 });
 
 test('sim/demo config launches Vaults as expected by loadgen', async t => {

--- a/packages/vats/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-integration.js
@@ -33,7 +33,7 @@ const likePayouts = (collateral, minted) => ({
 
 const makeDefaultTestContext = async t => {
   console.time('DefaultTestContext');
-  const swingsetTestKit = await makeSwingsetTestKit(t);
+  const swingsetTestKit = await makeSwingsetTestKit(t, 'bundles/vaults');
 
   const { runUtils, storage } = swingsetTestKit;
   console.timeLog('DefaultTestContext', 'swingsetTestKit');

--- a/packages/vats/test/upgrading/test-upgrade-contracts.js
+++ b/packages/vats/test/upgrading/test-upgrade-contracts.js
@@ -32,7 +32,7 @@ test('upgrade mintHolder', async t => {
 
   /** @type {SwingSetConfig} */
   const config = harden({
-    defaultManagerType: 'xs-worker',
+    defaultManagerType: 'local', // Overridden in CI with SWINGSET_WORKER_TYPE=xs-worker
     bootstrap: 'bootstrap',
     vats: {
       // TODO refactor to use bootstrap-relay.js

--- a/packages/vats/test/upgrading/test-upgrade-vats.js
+++ b/packages/vats/test/upgrading/test-upgrade-vats.js
@@ -38,7 +38,7 @@ const makeScenario = async (
   /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
-    defaultManagerType: 'xs-worker',
+    defaultManagerType: 'local', // Overridden in CI with SWINGSET_WORKER_TYPE=xs-worker
     bootstrap: 'bootstrap',
     defaultReapInterval: 'never',
     vats: {

--- a/scripts/configure-vscode.sh
+++ b/scripts/configure-vscode.sh
@@ -23,6 +23,7 @@ cat >.vscode/settings.json.new <<\EOF ||
   "editor.defaultFormatter": "esbenp.prettier-vscode",
 
   "typescript.preferences.importModuleSpecifierEnding": "js",
+  "typescript.tsdk": "node_modules/typescript/lib",
 
   // ESLint config
   "editor.codeActionsOnSave": {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Testing `vats` upgrade and bootstrap under both `local` and `xs-worker` systems helps our code be more robust.  This change enables those tests via our existing CI, by implementing `yarn test:xs` in `packages/vats/package.json`.

Some adjustments to the bootstrap tests were needed to accommodate differences in the environments (they were sometimes too specific to just the Node.js local worker).

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
n/a

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

Improves developer experience by speeding up `yarn test` for this package.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

n/a

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

This change should not negatively impact the CI performance, as XS and Node.js tests are already run in parallel, and XS is bypassed for most packages in the CI jobs.
