### PR TITLE
refactor(internal): Rename an object property to indicate expected string value

### DIFF
--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -20,11 +20,11 @@ import { E } from '@endo/far';
  * @returns {ReturnType<I>}
  */
 export const callSync = (callback, ...args) => {
-  const { target, method, bound } = callback;
-  if (method === undefined) {
+  const { target, methodName, bound } = callback;
+  if (methodName === undefined) {
     return target(...bound, ...args);
   }
-  return target[method](...bound, ...args);
+  return target[methodName](...bound, ...args);
 };
 
 /**
@@ -36,11 +36,11 @@ export const callSync = (callback, ...args) => {
  * @returns {Promise<Awaited<ReturnType<I>>>}
  */
 export const callE = (callback, ...args) => {
-  const { target, method, bound } = callback;
-  if (method === undefined) {
+  const { target, methodName, bound } = callback;
+  if (methodName === undefined) {
     return E(target)(...bound, ...args);
   }
-  return E(target)[method](...bound, ...args);
+  return E(target)[methodName](...bound, ...args);
 };
 
 /**
@@ -95,7 +95,7 @@ harden(makeFunctionCallback);
  */
 export const makeSyncMethodCallback = (target, methodName, ...bound) => {
   /** @type {unknown} */
-  const cb = harden({ target, method: methodName, bound });
+  const cb = harden({ target, methodName, bound });
   return /** @type {SyncCallback<I>} */ (cb);
 };
 harden(makeSyncMethodCallback);
@@ -116,7 +116,7 @@ harden(makeSyncMethodCallback);
  */
 export const makeMethodCallback = (target, methodName, ...bound) => {
   /** @type {unknown} */
-  const cb = harden({ target, method: methodName, bound });
+  const cb = harden({ target, methodName, bound });
   return /** @type {Callback<I>} */ (cb);
 };
 harden(makeMethodCallback);

--- a/packages/internal/src/types.d.ts
+++ b/packages/internal/src/types.d.ts
@@ -4,7 +4,7 @@ export declare class Callback<I extends (...args: unknown[]) => any> {
 
   public target: any;
 
-  public method?: PropertyKey;
+  public methodName?: PropertyKey;
 
   public bound: unknown[];
 }

--- a/packages/internal/test/test-callback.js
+++ b/packages/internal/test/test-callback.js
@@ -61,19 +61,19 @@ test('near method callbacks', t => {
 
   /** @type {import('../src/callback').SyncCallback<typeof o.m1>} */
   const cb0 = cb.makeSyncMethodCallback(o, 'm1');
-  t.deepEqual(cb0, { target: o, method: 'm1', bound: [] });
+  t.deepEqual(cb0, { target: o, methodName: 'm1', bound: [] });
 
   /** @type {import('../src/callback').SyncCallback<(b: number, c: string) => string>} */
   const cb1 = cb.makeSyncMethodCallback(o, 'm1', 9);
-  t.deepEqual(cb1, { target: o, method: 'm1', bound: [9] });
+  t.deepEqual(cb1, { target: o, methodName: 'm1', bound: [9] });
 
   /** @type {import('../src/callback').SyncCallback<(c: string) => string>} */
   const cb2 = cb.makeSyncMethodCallback(o, 'm1', 9, 10);
-  t.deepEqual(cb2, { target: o, method: 'm1', bound: [9, 10] });
+  t.deepEqual(cb2, { target: o, methodName: 'm1', bound: [9, 10] });
 
   // @ts-expect-error deliberate: boolean is not assignable to string
   const cb3 = cb.makeSyncMethodCallback(o, 'm1', 9, 10, true);
-  t.deepEqual(cb3, { target: o, method: 'm1', bound: [9, 10, true] });
+  t.deepEqual(cb3, { target: o, methodName: 'm1', bound: [9, 10, true] });
 
   // @ts-expect-error deliberate: Expected 4 arguments but got 5
   t.is(cb.callSync(cb0, 2, 3, 'go', 'bad'), '5go');
@@ -86,7 +86,7 @@ test('near method callbacks', t => {
 
   // @ts-expect-error deliberate: Promise provides no match for the signature
   const cbp2 = cb.makeSyncMethodCallback(Promise.resolve(o), 'm1', 9, 10);
-  t.like(cbp2, { method: 'm1', bound: [9, 10] });
+  t.like(cbp2, { methodName: 'm1', bound: [9, 10] });
   t.assert(cbp2.target instanceof Promise);
   t.throws(() => cb.callSync(cbp2, 'go'), { message: /not a function/ });
 });
@@ -107,7 +107,7 @@ test('far method callbacks', async t => {
 
   /** @type {import('../src/callback').Callback<(c: string) => Promise<string>>} */
   const cbp2 = cb.makeMethodCallback(Promise.resolve(o), 'm1', 9, 10);
-  t.like(cbp2, { method: 'm1', bound: [9, 10] });
+  t.like(cbp2, { methodName: 'm1', bound: [9, 10] });
   t.assert(cbp2.target instanceof Promise);
   // @ts-expect-error deliberate: is not assignable to SyncCallback
   const thunk = () => cb.callSync(cbp2, 'go');


### PR DESCRIPTION
I forgot to publish a review comment to this effect on #7107. `methodName` seems less likely to imply that the corresponding value is a reference than `method`.