### PR TITLE
fix devDependencies glob for import/no-extraneous-dependencies

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,7 +19,7 @@ module.exports = {
         extraFileExtensions: ['.cjs'],
       }
     : undefined,
-  plugins: ['@typescript-eslint', 'import', 'prettier'],
+  plugins: ['@typescript-eslint', 'prettier'],
   extends: ['@agoric'],
   rules: {
     '@typescript-eslint/prefer-ts-expect-error': 'warn',

--- a/packages/eslint-config/eslint-config.cjs
+++ b/packages/eslint-config/eslint-config.cjs
@@ -5,6 +5,7 @@ module.exports = {
     'plugin:jsdoc/recommended',
     'prettier',
   ],
+  plugins: ['import'],
   rules: {
     'arrow-body-style': 'off',
     'arrow-parens': 'off',
@@ -61,9 +62,10 @@ module.exports = {
         devDependencies: [
           '**/*.config.js',
           '**/*.config.*.js',
-          '*test*/**/*.js',
-          'demo*/**/*.js',
-          'scripts/**/*.js',
+          // leading wildcard to work in CLI (package path) and IDE (repo path)
+          '**/test/**',
+          '**/demo*/**/*.js',
+          '**/scripts/**/*.js',
         ],
       },
     ],

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -42,9 +42,6 @@
       "test/**/test-*.js"
     ]
   },
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -72,9 +72,6 @@
     ],
     "timeout": "10m"
   },
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -61,9 +61,6 @@
     "*.js",
     "NEWS.md"
   ],
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -62,9 +62,6 @@
     ],
     "timeout": "10m"
   },
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -37,9 +37,6 @@
     "*.js",
     "NEWS.md"
   ],
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -40,9 +40,6 @@
     "src/",
     "NEWS.md"
   ],
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -29,9 +29,6 @@
     "src/",
     "NEWS.md"
   ],
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -48,9 +48,6 @@
     "bundles/",
     "NEWS.md"
   ],
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -47,9 +47,6 @@
     "exported.js",
     "NEWS.md"
   ],
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -42,9 +42,6 @@
     "c8": "^7.13.0",
     "import-meta-resolve": "^2.2.1"
   },
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -121,9 +121,6 @@
     ],
     "timeout": "20m"
   },
-  "eslintIgnore": [
-    "bundle-*.js"
-  ],
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Description

Since https://github.com/Agoric/agoric-sdk/pull/7202 VSCode has been reporting `import/no-extraneous-dependencies` errors that CLI doesn't. It's due to the path globs. This fixes them to be more general. I considered having the two cases explicit, `packages/*/match/**` and `match/**`, for a faster glob match but it didn't seem worth it for the complexity.

### Testing Considerations

CI for package paths. I tested in VS Code for the root paths.