### PR TITLE
fix(inter-protocol): add to reserve did not update metrics

### DIFF
--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -159,10 +159,8 @@ const start = async (zcf, privateArgs, baggage) => {
 
   /**
    * Anyone can deposit any assets to the reserve
-   *
-   * @param {ZCFSeat} seat
    */
-  const addCollateralHook = async seat => {
+  const addCollateralHook = state => async (/** @type {ZCFSeat} */ seat) => {
     const {
       give: { Collateral: amountIn },
     } = seat.getProposal();
@@ -177,13 +175,14 @@ const start = async (zcf, privateArgs, baggage) => {
       { [collateralKeyword]: amountIn },
     );
     seat.exit();
+    updateMetrics({ state });
 
     trace('received collateral', amountIn);
     return 'added Collateral to the Reserve';
   };
 
-  const makeAddCollateralInvitation = () =>
-    zcf.makeInvitation(addCollateralHook, 'Add Collateral');
+  const makeAddCollateralInvitation = ({ state }) =>
+    zcf.makeInvitation(addCollateralHook(state), 'Add Collateral');
 
   /** @type {import('../contractSupport.js').MetricsPublisherKit<MetricsNotification>} */
   const { metricsPublication, metricsSubscription } = makeMetricsPublisherKit(

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -159,6 +159,8 @@ const start = async (zcf, privateArgs, baggage) => {
 
   /**
    * Anyone can deposit any assets to the reserve
+   *
+   * @param {*} state
    */
   const addCollateralHook = state => async (/** @type {ZCFSeat} */ seat) => {
     const {
@@ -175,6 +177,7 @@ const start = async (zcf, privateArgs, baggage) => {
       { [collateralKeyword]: amountIn },
     );
     seat.exit();
+    // eslint-disable-next-line no-use-before-define
     updateMetrics({ state });
 
     trace('received collateral', amountIn);


### PR DESCRIPTION
refs: https://github.com/Agoric/dapp-econ-gov/issues/33

## Description

While working on...

 - https://github.com/Agoric/dapp-econ-gov/issues/33

@samsiegart asked how to find out how much IST is available to burn. It should have been a matter of...

```
$ agoric follow :published.reserve.metrics
{
  allocations: {},
...
}
```

but it turns out the failed to update metrics after a `makeAddCollateralInvitation` offer.

### Security / Scaling / Documentation Considerations

none, I think

### Testing Considerations

refined unit test to check for this