### PR TITLE
improve error thrown during collection.get(missingRemotable)

### DIFF
--- a/packages/inter-protocol/test/auction/test-auctionContract.js
+++ b/packages/inter-protocol/test/auction/test-auctionContract.js
@@ -915,7 +915,8 @@ test('deposit unregistered collateral', async t => {
   const driver = await makeAuctionDriver(t);
 
   await t.throwsAsync(() => driver.depositCollateral(asset.make(500n), asset), {
-    message: /no ordinal/,
+    message:
+      /key "\[Alleged: Asset brand\]" not found in collection "brandToIssuerRecord"/,
   });
 });
 

--- a/packages/swingset-liveslots/src/collectionManager.js
+++ b/packages/swingset-liveslots/src/collectionManager.js
@@ -297,11 +297,14 @@ export function makeCollectionManager(
 
     function get(key) {
       mustMatch(key, keyShape, invalidKeyTypeMsg);
-      const result = syscall.vatstoreGet(keyToDBKey(key));
-      if (result) {
-        return unserializeValue(JSON.parse(result));
+      if (passStyleOf(key) === 'remotable' && getOrdinal(key) === undefined) {
+        throw Fail`key ${key} not found in collection ${q(label)}`;
       }
-      throw Fail`key ${key} not found in collection ${q(label)}`;
+      const result = syscall.vatstoreGet(keyToDBKey(key));
+      if (!result) {
+        throw Fail`key ${key} not found in collection ${q(label)}`;
+      }
+      return unserializeValue(JSON.parse(result));
     }
 
     function updateEntryCount(delta) {
@@ -366,6 +369,9 @@ export function makeCollectionManager(
 
     function deleteInternal(key) {
       mustMatch(key, keyShape, invalidKeyTypeMsg);
+      if (passStyleOf(key) === 'remotable' && getOrdinal(key) === undefined) {
+        throw Fail`key ${key} not found in collection ${q(label)}`;
+      }
       const dbKey = keyToDBKey(key);
       const rawValue = syscall.vatstoreGet(dbKey);
       rawValue || Fail`key ${key} not found in collection ${q(label)}`;

--- a/packages/swingset-liveslots/test/test-collections.js
+++ b/packages/swingset-liveslots/test/test-collections.js
@@ -22,6 +22,7 @@ function makeGenericRemotable(typeName) {
 
 const something = makeGenericRemotable('something');
 const somethingElse = makeGenericRemotable('something else');
+const somethingMissing = makeGenericRemotable('something missing');
 
 const symbolBozo = Symbol.for('bozo');
 const symbolKrusty = Symbol.for('krusty');
@@ -83,10 +84,17 @@ function exerciseMapOperations(t, collectionName, testStore) {
 
   t.truthy(testStore.has(47));
   t.falsy(testStore.has(53));
+  t.falsy(testStore.has(somethingMissing));
 
   t.throws(
     () => testStore.get(43),
     m(`key 43 not found in collection "${collectionName}"`),
+  );
+  t.throws(
+    () => testStore.get(somethingMissing),
+    m(
+      `key "[Alleged: something missing]" not found in collection "${collectionName}"`,
+    ),
   );
   t.throws(
     () => testStore.set(86, 'not work'),
@@ -95,6 +103,12 @@ function exerciseMapOperations(t, collectionName, testStore) {
   t.throws(
     () => testStore.init(47, 'already there'),
     m(`key 47 already registered in collection "${collectionName}"`),
+  );
+  t.throws(
+    () => testStore.init(something, 'already there'),
+    m(
+      `key "[Alleged: something]" already registered in collection "${collectionName}"`,
+    ),
   );
 
   testStore.set(something, somethingElse);
@@ -112,6 +126,12 @@ function exerciseMapOperations(t, collectionName, testStore) {
     () => testStore.delete(22),
     m(`key 22 not found in collection "${collectionName}"`),
   );
+  t.throws(
+    () => testStore.delete(somethingMissing),
+    m(
+      `key "[Alleged: something missing]" not found in collection "${collectionName}"`,
+    ),
+  );
 }
 
 function exerciseSetOperations(t, collectionName, testStore) {
@@ -120,6 +140,7 @@ function exerciseSetOperations(t, collectionName, testStore) {
     t.truthy(testStore.has(item[0]));
   }
   t.falsy(testStore.has(53));
+  t.falsy(testStore.has(somethingMissing));
 
   t.throws(
     () => testStore.add(47),
@@ -131,6 +152,12 @@ function exerciseSetOperations(t, collectionName, testStore) {
   t.throws(
     () => testStore.delete(22),
     m(`key 22 not found in collection "${collectionName}"`),
+  );
+  t.throws(
+    () => testStore.delete(somethingMissing),
+    m(
+      `key "[Alleged: something missing]" not found in collection "${collectionName}"`,
+    ),
   );
 }
 

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -84,6 +84,6 @@ test('throw in offerHandler', async t => {
       // https://github.com/endojs/endo/pull/640
       //
       // /"brand" not found: .*/,
-      /no ordinal for .*/,
+      'key "[Alleged: token brand]" not found in collection "brandToIssuerRecord"',
   });
 });

--- a/packages/zoe/test/unitTests/test-issuerStorage.js
+++ b/packages/zoe/test/unitTests/test-issuerStorage.js
@@ -85,7 +85,8 @@ test(`getAssetKindByBrand - brand isn't stored`, t => {
   instantiate();
   const { currencyKit } = setupIssuersForTest();
   t.throws(() => getAssetKindByBrand(currencyKit.brand), {
-    message: 'no ordinal for "[Alleged: currency brand]"',
+    message:
+      'key "[Alleged: currency brand]" not found in collection "brandToIssuerRecord"',
   });
 });
 

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -151,7 +151,7 @@ test(`zcf assertNatAssetKind - brand not registered`, async t => {
       //
       // /"brand" not found: .*/,
       // / not found: /,
-      /no ordinal /,
+      'key "[Alleged: gelt brand]" not found in collection "brandToIssuerRecord"',
   });
 });
 
@@ -219,7 +219,7 @@ test(`zcf saveAllIssuers - duplicate keyword`, async t => {
         //
         // /"issuer" not found: /,
         // /not found: /,
-        /no ordinal for /,
+        'key "[Alleged: pieces of eight issuer]" not found in collection "issuerToIssuerRecord"',
     },
     'issuer should not be found',
   );
@@ -233,7 +233,7 @@ test(`zcf saveAllIssuers - duplicate keyword`, async t => {
       //
       // /"brand" not found: /,
       // /not found: /,
-      /no ordinal for /,
+      'key "[Alleged: pieces of eight brand]" not found in collection "brandToIssuerRecord"',
   });
 });
 


### PR DESCRIPTION
Previously, doing a virtualCollection.get() on a Remotable that was not present in the Map or Set would trigger an internal assertion (complaining about a "missing ordinal"), rather than reaching the usual error message (which includes the collection's label as a debugging aid).

This fixes the `get()` path for both maps and sets to check for ordinal-less Remotables first, before attempting to convert the key into a dbKey. This let us signal the right error message.

It also updates one downstream test which was asserting the previous behavior.

closes #7231, closes #7105, closes #5776
