### PR TITLE
refactor startXSnap

### DIFF
--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -161,7 +161,7 @@ async function replay(transcriptFile) {
     const startXSnap = makeStartXSnap(bundles, {
       snapStore,
       spawn: capturePIDSpawn,
-      traceFile: RECORD_XSNAP_TRACE ? process.cwd() : undefined,
+      workerTraceRootPath: RECORD_XSNAP_TRACE ? process.cwd() : undefined,
     });
     factory = makeXsSubprocessFactory({
       kernelKeeper: fakeKernelKeeper,

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -152,10 +152,6 @@ async function replay(transcriptFile) {
       JSON.parse(fs.readFileSync('lockdown-bundle')),
       JSON.parse(fs.readFileSync('supervisor-bundle')),
     ];
-    const env = {};
-    if (RECORD_XSNAP_TRACE) {
-      env.XSNAP_TEST_RECORD = process.cwd();
-    }
 
     const capturePIDSpawn = (...args) => {
       const child = spawn(...args);
@@ -164,8 +160,8 @@ async function replay(transcriptFile) {
     };
     const startXSnap = makeStartXSnap(bundles, {
       snapStore,
-      env,
       spawn: capturePIDSpawn,
+      traceFile: RECORD_XSNAP_TRACE ? process.cwd() : undefined,
     });
     factory = makeXsSubprocessFactory({
       kernelKeeper: fakeKernelKeeper,

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -19,7 +19,7 @@ import { makeSnapStore } from '@agoric/swing-store';
 import { entryPaths as lockdownEntryPaths } from '@agoric/xsnap-lockdown/src/paths.js';
 import { entryPaths as supervisorEntryPaths } from '@agoric/swingset-xsnap-supervisor/src/paths.js';
 import { waitUntilQuiescent } from '../src/lib-nodejs/waitUntilQuiescent.js';
-import { makeStartXSnap } from '../src/controller/controller.js';
+import { makeStartXSnap } from '../src/controller/startXSnap.js';
 import { makeXsSubprocessFactory } from '../src/kernel/vat-loader/manager-subprocess-xsnap.js';
 import { makeLocalVatManagerFactory } from '../src/kernel/vat-loader/manager-local.js';
 import { requireIdentical } from '../src/kernel/vat-loader/transcript.js';

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -21,6 +21,7 @@
     "lint:eslint": "eslint ."
   },
   "devDependencies": {
+    "@endo/far": "^0.2.14",
     "@types/better-sqlite3": "^7.5.0",
     "@types/microtime": "^2.1.0",
     "@types/tmp": "^0.2.0",

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -1,19 +1,15 @@
 /* global globalThis, WeakRef, FinalizationRegistry */
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error -- https://github.com/Agoric/agoric-sdk/issues/4620 */
 
-import fs from 'fs';
-import path from 'path';
 import process from 'process';
 import crypto from 'crypto';
 import { performance } from 'perf_hooks';
 import { spawn as ambientSpawn } from 'child_process';
-import { type as osType } from 'os';
 import anylogger from 'anylogger';
 import microtime from 'microtime';
 
 import { assert, Fail } from '@agoric/assert';
 import { importBundle } from '@endo/import-bundle';
-import { xsnap, recordXSnap } from '@agoric/xsnap';
 import { initSwingStore } from '@agoric/swing-store';
 
 import { checkBundle } from '@endo/check-bundle/lite.js';
@@ -27,8 +23,7 @@ import {
   swingsetIsInitialized,
   initializeSwingset,
 } from './initializeSwingset.js';
-
-const NETSTRING_MAX_CHUNK_SIZE = 12_000_000;
+import { makeStartXSnap } from './startXSnap.js';
 
 /** @param {Uint8Array} bytes */
 export function computeSha512(bytes) {
@@ -75,95 +70,6 @@ function unhandledRejectionHandler(e, pr) {
   // Don't trigger sensitive hosts (like AVA).
   pr.catch(() => {});
   console.error('UnhandledPromiseRejectionWarning:', e);
-}
-
-/**
- * @param {{ moduleFormat: string, source: string }[]} bundles
- * @param {{
- *   snapStore?: SnapStore,
- *   spawn: typeof import('child_process').spawn
- *   debug?: boolean,
- *   traceFile?: string,
- * }} options
- */
-export function makeStartXSnap(bundles, options) {
-  // our job is to simply curry some authorities and settings into the
-  // 'startXSnap' function we return
-  const { snapStore, spawn, debug = false, traceFile } = options;
-
-  let serial = 0;
-  const makeTraceFile = traceFile
-    ? () => {
-        const workerTrace = path.resolve(`${traceFile}/${serial}`) + path.sep;
-        serial += 1;
-        return workerTrace;
-      }
-    : undefined;
-
-  /**
-   * @param {string} vatID
-   * @param {string} name
-   * @param {(request: Uint8Array) => Promise<Uint8Array>} handleCommand
-   * @param {boolean} [metered]
-   * @param {boolean} [reload]
-   */
-  async function startXSnap(
-    vatID,
-    name,
-    handleCommand,
-    metered,
-    reload = false,
-  ) {
-    /** @type { import('@agoric/xsnap/src/xsnap').XSnapOptions } */
-    const xsnapOpts = {
-      os: osType(),
-      spawn,
-      stdout: 'inherit',
-      stderr: 'inherit',
-      debug,
-      netstringMaxChunkSize: NETSTRING_MAX_CHUNK_SIZE,
-    };
-
-    let doXSnap = xsnap;
-    if (makeTraceFile) {
-      doXSnap = opts => {
-        const workerTrace = makeTraceFile();
-        console.log('SwingSet xs-worker tracing:', { workerTrace });
-        fs.mkdirSync(workerTrace, { recursive: true });
-        return recordXSnap(opts, workerTrace, {
-          writeFileSync: fs.writeFileSync,
-        });
-      };
-    }
-
-    const meterOpts = metered ? {} : { meteringLimit: 0 };
-    if (snapStore && reload) {
-      // console.log('startXSnap from', { snapshotHash });
-      return snapStore.loadSnapshot(vatID, async snapshot => {
-        const xs = doXSnap({
-          snapshot,
-          name,
-          handleCommand,
-          ...meterOpts,
-          ...xsnapOpts,
-        });
-        await xs.isReady();
-        return xs;
-      });
-    }
-    // console.log('fresh xsnap', { snapStore: snapStore });
-    const worker = doXSnap({ handleCommand, name, ...meterOpts, ...xsnapOpts });
-
-    for (const bundle of bundles) {
-      bundle.moduleFormat === 'getExport' ||
-        bundle.moduleFormat === 'nestedEvaluate' ||
-        Fail`unexpected: ${bundle.moduleFormat}`;
-      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
-      await worker.evaluate(`(${bundle.source}\n)()`.trim());
-    }
-    return worker;
-  }
-  return startXSnap;
 }
 
 /**

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -82,14 +82,14 @@ function unhandledRejectionHandler(e, pr) {
  * @param {{
  *   snapStore?: SnapStore,
  *   spawn: typeof import('child_process').spawn
- *   env: Record<string, string | undefined>,
- * }} opts
+ *   debug?: boolean,
+ *   traceFile?: string,
+ * }} options
  */
-export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
+export function makeStartXSnap(bundles, options) {
   // our job is to simply curry some authorities and settings into the
   // 'startXSnap' function we return
-  const debug = !!env.XSNAP_DEBUG;
-  const traceFile = env.XSNAP_TEST_RECORD;
+  const { snapStore, spawn, debug = false, traceFile } = options;
 
   let serial = 0;
   const makeTraceFile = traceFile
@@ -282,8 +282,9 @@ export async function makeSwingsetController(
   ];
   const startXSnap = makeStartXSnap(bundles, {
     snapStore: kernelStorage.snapStore,
-    env,
     spawn,
+    debug: !!env.XSNAP_DEBUG,
+    traceFile: env.XSNAP_TEST_RECORD,
   });
 
   const kernelEndowments = {

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -190,7 +190,7 @@ export async function makeSwingsetController(
     snapStore: kernelStorage.snapStore,
     spawn,
     debug: !!env.XSNAP_DEBUG,
-    traceFile: env.XSNAP_TEST_RECORD,
+    workerTraceRootPath: env.XSNAP_TEST_RECORD,
   });
 
   const kernelEndowments = {

--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -157,6 +157,10 @@ export async function initializeKernel(config, kernelStorage, options = {}) {
 
   // ----------------------------------------------------------------------
 
+  /**
+   * @param {import('../types-internal.js').VatID} bootstrapVatID
+   * @returns {string} the KPID of the bootstrap message result promise
+   */
   function enqueueBootstrap(bootstrapVatID) {
     // we invoke obj[0].bootstrap with an object that contains 'vats'.
     insistVatID(bootstrapVatID);
@@ -213,6 +217,7 @@ export async function initializeKernel(config, kernelStorage, options = {}) {
     const args = kunser(m.serialize(harden([vatObj0s, deviceObj0s])));
     const rootKref = exportRootObject(kernelKeeper, bootstrapVatID);
     const resultKpid = queueToKref(rootKref, 'bootstrap', args, 'panic');
+    assert(resultKpid); // appease tsc: 'panic' ensures a kpid is returned
     kernelKeeper.incrementRefCount(resultKpid, 'external');
     return resultKpid;
   }

--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -15,7 +15,8 @@ function makeVatRootObjectSlot() {
   return makeVatSlot('object', true, 0);
 }
 
-export function initializeKernel(config, kernelStorage, verbose = false) {
+export async function initializeKernel(config, kernelStorage, options = {}) {
+  const { verbose = false } = options;
   const logStartup = verbose ? console.debug : () => 0;
   insistStorageAPI(kernelStorage.kvStore);
 

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -573,5 +573,8 @@ export async function initializeSwingset(
   if (verbose) {
     kdebugEnable(true);
   }
-  return initializeKernel(kconfig, kernelStorage);
+
+  // returns the kpid of the bootstrap() result
+  const bootKpid = await initializeKernel(kconfig, kernelStorage);
+  return bootKpid;
 }

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -291,6 +291,7 @@ function sortObjectProperties(obj, firsts = []) {
  * @param {SwingStoreKernelStorage} kernelStorage
  * @param {InitializationOptions} initializationOptions
  * @param {{ env?: Record<string, string | undefined > }} runtimeOptions
+ * @returns {Promise<string | undefined>} KPID of the bootstrap message result promise
  */
 export async function initializeSwingset(
   config,

--- a/packages/SwingSet/src/controller/startXSnap.js
+++ b/packages/SwingSet/src/controller/startXSnap.js
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import path from 'path';
+import { Fail } from '@agoric/assert';
+import { type as osType } from 'os';
+import { xsnap, recordXSnap } from '@agoric/xsnap';
+
+const NETSTRING_MAX_CHUNK_SIZE = 12_000_000;
+
+/**
+ * @param {{ moduleFormat: string, source: string }[]} bundles
+ * @param {{
+ *   snapStore?: SnapStore,
+ *   spawn: typeof import('child_process').spawn
+ *   debug?: boolean,
+ *   traceFile?: string,
+ * }} options
+ */
+export function makeStartXSnap(bundles, options) {
+  // our job is to simply curry some authorities and settings into the
+  // 'startXSnap' function we return
+  const { snapStore, spawn, debug = false, traceFile } = options;
+
+  let serial = 0;
+  const makeTraceFile = traceFile
+    ? () => {
+        const workerTrace = path.resolve(`${traceFile}/${serial}`) + path.sep;
+        serial += 1;
+        return workerTrace;
+      }
+    : undefined;
+
+  /**
+   * @param {string} vatID
+   * @param {string} name
+   * @param {(request: Uint8Array) => Promise<Uint8Array>} handleCommand
+   * @param {boolean} [metered]
+   * @param {boolean} [reload]
+   */
+  async function startXSnap(
+    vatID,
+    name,
+    handleCommand,
+    metered,
+    reload = false,
+  ) {
+    /** @type { import('@agoric/xsnap/src/xsnap').XSnapOptions } */
+    const xsnapOpts = {
+      os: osType(),
+      spawn,
+      stdout: 'inherit',
+      stderr: 'inherit',
+      debug,
+      netstringMaxChunkSize: NETSTRING_MAX_CHUNK_SIZE,
+    };
+
+    let doXSnap = xsnap;
+    if (makeTraceFile) {
+      doXSnap = opts => {
+        const workerTrace = makeTraceFile();
+        console.log('SwingSet xs-worker tracing:', { workerTrace });
+        fs.mkdirSync(workerTrace, { recursive: true });
+        return recordXSnap(opts, workerTrace, {
+          writeFileSync: fs.writeFileSync,
+        });
+      };
+    }
+
+    const meterOpts = metered ? {} : { meteringLimit: 0 };
+    if (snapStore && reload) {
+      // console.log('startXSnap from', { snapshotHash });
+      return snapStore.loadSnapshot(vatID, async snapshot => {
+        const xs = doXSnap({
+          snapshot,
+          name,
+          handleCommand,
+          ...meterOpts,
+          ...xsnapOpts,
+        });
+        await xs.isReady();
+        return xs;
+      });
+    }
+    // console.log('fresh xsnap', { snapStore: snapStore });
+    const worker = doXSnap({ handleCommand, name, ...meterOpts, ...xsnapOpts });
+
+    for (const bundle of bundles) {
+      bundle.moduleFormat === 'getExport' ||
+        bundle.moduleFormat === 'nestedEvaluate' ||
+        Fail`unexpected: ${bundle.moduleFormat}`;
+      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
+      await worker.evaluate(`(${bundle.source}\n)()`.trim());
+    }
+    return worker;
+  }
+  return startXSnap;
+}

--- a/packages/SwingSet/test/bundling/test-bundles-kernel.js
+++ b/packages/SwingSet/test/bundling/test-bundles-kernel.js
@@ -13,7 +13,7 @@ import { initializeKernel } from '../../src/controller/initializeKernel.js';
 test('install bundle', async t => {
   const endowments = makeKernelEndowments();
   const { kvStore } = endowments.kernelStorage;
-  initializeKernel({}, endowments.kernelStorage);
+  await initializeKernel({}, endowments.kernelStorage);
   const kernel = buildKernel(endowments, {}, {});
   await kernel.start(); // empty queue
 

--- a/packages/SwingSet/test/test-abandon-export.js
+++ b/packages/SwingSet/test/test-abandon-export.js
@@ -7,10 +7,10 @@ import { extractMethod } from '../src/lib/kdebug.js';
 import { makeKernelEndowments, buildDispatch } from './util.js';
 import { kser, kunser, kslot } from '../src/lib/kmarshal.js';
 
-const makeKernel = () => {
+const makeKernel = async () => {
   const endowments = makeKernelEndowments();
   const { kvStore } = endowments.kernelStorage;
-  initializeKernel({}, endowments.kernelStorage);
+  await initializeKernel({}, endowments.kernelStorage);
   const kernel = buildKernel(endowments, {}, {});
   return { kernel, kvStore };
 };
@@ -77,7 +77,7 @@ async function doAbandon(t, reachable) {
   // vatB abandons it
   // vatA should retain the object
   // sending to the abandoned object should get an error
-  const { kernel, kvStore } = makeKernel();
+  const { kernel, kvStore } = await makeKernel();
   await kernel.start();
 
   const {

--- a/packages/SwingSet/test/test-gc-kernel.js
+++ b/packages/SwingSet/test/test-gc-kernel.js
@@ -56,10 +56,10 @@ function makeEndowments() {
   };
 }
 
-function makeKernel() {
+async function makeKernel() {
   const endowments = makeEndowments();
   const { kvStore } = endowments.kernelStorage;
-  initializeKernel({}, endowments.kernelStorage);
+  await initializeKernel({}, endowments.kernelStorage);
   const kernel = buildKernel(endowments, {}, {});
   return { kernel, kvStore };
 }
@@ -110,7 +110,7 @@ async function prep(t, options = {}) {
     sendToBob = true,
     sendPromiseToCarol = true,
   } = options;
-  const { kernel, kvStore } = makeKernel();
+  const { kernel, kvStore } = await makeKernel();
   await kernel.start();
 
   const vrefs = {}; // track vrefs within vats
@@ -549,7 +549,7 @@ test('mode24B', async t => {
 });
 
 test('retire before drop is error', async t => {
-  const { kernel } = makeKernel();
+  const { kernel } = await makeKernel();
   await kernel.start();
 
   const amyForAlice = 'o+101';

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -32,16 +32,16 @@ function emptySetup(_syscall) {
   return dispatch;
 }
 
-function makeKernel() {
+async function makeKernel() {
   const endowments = makeKernelEndowments();
-  initializeKernel({}, endowments.kernelStorage);
+  await initializeKernel({}, endowments.kernelStorage);
   return buildKernel(endowments, {}, {});
 }
 
 const tsv = [{ d: ['startVat', kser({})], syscalls: [] }];
 
 test('build kernel', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start(); // empty queue
   const data = kernel.dump();
   t.deepEqual(data.vatTables, []);
@@ -49,7 +49,7 @@ test('build kernel', async t => {
 });
 
 test('simple call', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
   function setup1(syscall, state, _helpers, vatPowers) {
@@ -98,7 +98,7 @@ test('simple call', async t => {
 });
 
 test('vat store', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
   function setup(syscall, _state, _helpers, _vatPowers) {
@@ -157,7 +157,7 @@ test('vat store', async t => {
 });
 
 test('map inbound', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
   function setup1(_syscall) {
@@ -209,7 +209,7 @@ test('map inbound', async t => {
 });
 
 test('addImport', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   function setup(_syscall) {
     function dispatch() {}
@@ -229,7 +229,7 @@ test('addImport', async t => {
 });
 
 test('outbound call', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
   let v1tovat25;
@@ -463,7 +463,7 @@ test('outbound call', async t => {
 });
 
 test('three-party', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
   let bobForA;
@@ -612,7 +612,7 @@ test('three-party', async t => {
 });
 
 test('transfer promise', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   let syscallA;
   const logA = [];
@@ -722,7 +722,7 @@ test('transfer promise', async t => {
 });
 
 test('subscribe to promise', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   let syscall;
   const log = [];
@@ -768,7 +768,7 @@ test('subscribe to promise', async t => {
 });
 
 test('promise resolveToData', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
 
@@ -844,7 +844,7 @@ test('promise resolveToData', async t => {
 });
 
 test('promise resolveToPresence', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
 
@@ -924,7 +924,7 @@ test('promise resolveToPresence', async t => {
 });
 
 test('promise fails when resolve to promise', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
 
@@ -982,7 +982,7 @@ test('promise fails when resolve to promise', async t => {
 });
 
 test('promise reject', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
 
@@ -1059,7 +1059,7 @@ test('promise reject', async t => {
 
 async function doResultInArgs(t, enablePipelining) {
   // https://github.com/Agoric/agoric-sdk/issues/5189
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
 
   // Alice sends a message to Bob which references its own result
@@ -1139,7 +1139,7 @@ test('result promise in args (non-pipelining)', doResultInArgs, false);
 
 test('transcript', async t => {
   const aliceForAlice = 'o+1';
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
 
   function setup(syscall, _state) {
@@ -1201,7 +1201,7 @@ test('transcript', async t => {
 // have a decider. Make sure urgh gets queued in p2 rather than exploding.
 
 test('non-pipelined promise queueing', async t => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
 
@@ -1326,7 +1326,7 @@ test('non-pipelined promise queueing', async t => {
 // get delivered to vat-with-x.
 
 const pipelinedSendTest = async (t, delayed) => {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
 
@@ -1555,7 +1555,7 @@ test('pipelined promise queueing with delay', pipelinedSendTest, true);
 
 test('xs-worker default manager type', async t => {
   const endowments = makeKernelEndowments();
-  initializeKernel(
+  await initializeKernel(
     { defaultManagerType: 'xs-worker' },
     endowments.kernelStorage,
   );
@@ -1567,7 +1567,7 @@ test('xs-worker default manager type', async t => {
 });
 
 async function reapTest(t, freq) {
-  const kernel = makeKernel();
+  const kernel = await makeKernel();
   await kernel.start();
   const log = [];
   function setup() {

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -200,7 +200,7 @@ function inCList(kernel, vatID, kpid, vpid) {
 
 async function doTest123(t, which, mode) {
   const endowments = makeEndowments();
-  initializeKernel({}, endowments.kernelStorage);
+  await initializeKernel({}, endowments.kernelStorage);
   const kernel = buildKernel(endowments, {}, {});
   await kernel.start(undefined); // no bootstrapVatName, so no bootstrap call
   // vatA is our primary actor
@@ -369,7 +369,7 @@ for (const caseNum of [1, 2, 3]) {
 
 async function doTest4567(t, which, mode) {
   const endowments = makeEndowments();
-  initializeKernel({}, endowments.kernelStorage);
+  await initializeKernel({}, endowments.kernelStorage);
   const kernel = buildKernel(endowments, {}, {});
   await kernel.start(undefined); // no bootstrapVatName, so no bootstrap call
   // vatA is our primary actor
@@ -560,7 +560,7 @@ for (const caseNum of [4, 5, 6, 7]) {
 
 test(`kernel vpid handling crossing resolutions`, async t => {
   const endowments = makeEndowments();
-  initializeKernel({}, endowments.kernelStorage);
+  await initializeKernel({}, endowments.kernelStorage);
   const kernel = buildKernel(endowments, {}, {});
   await kernel.start(undefined); // no bootstrapVatName, so no bootstrap call
   // vatX controls the scenario, vatA and vatB are the players
@@ -774,7 +774,7 @@ test(`kernel vpid handling crossing resolutions`, async t => {
 
 async function doReflectedMessageTest(t, enablePipelining) {
   const endowments = makeEndowments();
-  initializeKernel({}, endowments.kernelStorage);
+  await initializeKernel({}, endowments.kernelStorage);
   const kernel = buildKernel(endowments, {}, {});
   await kernel.start(undefined); // no bootstrapVatName, so no bootstrap call
 
@@ -878,7 +878,7 @@ test('', doReflectedMessageTest, false);
 
 test('kernel vpid handling rejects imported result promise', async t => {
   const endowments = makeEndowments();
-  initializeKernel({}, endowments.kernelStorage);
+  await initializeKernel({}, endowments.kernelStorage);
   const kernel = buildKernel(endowments, {}, {});
   await kernel.start(undefined); // no bootstrapVatName, so no bootstrap call
 
@@ -948,7 +948,7 @@ test('kernel vpid handling rejects imported result promise', async t => {
 
 test('kernel vpid handling rejects previously exported result promise', async t => {
   const endowments = makeEndowments();
-  initializeKernel({}, endowments.kernelStorage);
+  await initializeKernel({}, endowments.kernelStorage);
   const kernel = buildKernel(endowments, {}, {});
   await kernel.start(undefined); // no bootstrapVatName, so no bootstrap call
 

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -8,7 +8,7 @@ import { getLockdownBundle } from '@agoric/xsnap-lockdown';
 import { getSupervisorBundle } from '@agoric/swingset-xsnap-supervisor';
 
 import { makeXsSubprocessFactory } from '../src/kernel/vat-loader/manager-subprocess-xsnap.js';
-import { makeStartXSnap } from '../src/controller/controller.js';
+import { makeStartXSnap } from '../src/controller/startXSnap.js';
 import { kser } from '../src/lib/kmarshal.js';
 
 test('child termination distinguished from meter exhaustion', async t => {

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -20,8 +20,7 @@ test('child termination distinguished from meter exhaustion', async t => {
   let theProc;
 
   const startXSnap = makeStartXSnap(bundles, {
-    snapstorePath: undefined, // close enough for this test
-    env: {},
+    snapstore: undefined, // unused by this test
     // @ts-expect-error we only need one path thru spawn
     spawn: (command, args, opts) => {
       const noMetering = ['-l', '0'];

--- a/packages/SwingSet/test/test-xsnap-metering.js
+++ b/packages/SwingSet/test/test-xsnap-metering.js
@@ -6,7 +6,7 @@ import sqlite3 from 'better-sqlite3';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeSnapStore, makeSnapStoreIO } from '@agoric/swing-store';
 
-import { makeStartXSnap } from '../src/controller/controller.js';
+import { makeStartXSnap } from '../src/controller/startXSnap.js';
 
 // controller.js had a bug (#5040) wherein 'meterOpts' were applied
 // inconsistently to fresh workers vs ones from snapshot, allowing

--- a/packages/SwingSet/test/test-xsnap-metering.js
+++ b/packages/SwingSet/test/test-xsnap-metering.js
@@ -18,7 +18,6 @@ function make(snapStore) {
   const pk = makePromiseKit();
   const startXSnap = makeStartXSnap([], {
     snapStore,
-    env: {},
     spawn: (command, args, opts) => {
       pk.resolve(args);
       return spawn(command, args, opts);


### PR DESCRIPTION
perform some internal refactorings to make upcoming changes simpler

* make `initializeKernel` async, so it can wait for xsnap bundles in #7208
* move `makeStartXSnap` out to a separate file, simplify it
* pass specific options/flags into `makeStartXSnap`, instead of the whole environment
* then make `env` processing the responsibility of the caller
