### PR TITLE
enforce that buildRootObject() returns an ephemeral, not durable

### DIFF
--- a/packages/SwingSet/src/vats/vattp/vat-vattp.js
+++ b/packages/SwingSet/src/vats/vattp/vat-vattp.js
@@ -6,9 +6,9 @@ import {
   provideDurableMapStore,
   provideDurableSetStore,
   provideKindHandle,
-  prepareSingleton,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
 
 // See ../../docs/delivery.md for a description of the architecture of the
 // comms system.
@@ -28,7 +28,6 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
   const { D } = vatPowers;
 
   // Define all durable baggage keys and kind handles.
-  const serviceSingletonBaggageKey = 'vat-tp handler';
   const mailboxDeviceBaggageKey = 'mailboxDevice';
   const mailboxHandle = provideKindHandle(baggage, 'mailboxHandle');
   const mailboxMapBaggageKey = 'mailboxes';
@@ -285,8 +284,8 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
     },
   };
 
-  // Expose a durable service singleton.
-  return prepareSingleton(baggage, serviceSingletonBaggageKey, {
+  // Expose the service
+  return Far('vat-tp handler', {
     ...serviceMailboxFunctions,
     ...serviceNetworkFunctions,
   });

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -1437,6 +1437,10 @@ function build(
     );
     getInterfaceOf(rootObject) !== undefined ||
       Fail`buildRootObject() for vat ${forVatID} returned ${rootObject} with no interface`;
+    if (valToSlot.has(rootObject)) {
+      Fail`buildRootObject() must return ephemeral, not virtual/durable object`;
+    }
+
     // Need to load watched promises *after* buildRootObject() so that handler kindIDs
     // have a chance to be reassociated with their handlers.
     watchedPromiseManager.loadWatchedPromiseTable(unmeteredRevivePromise);


### PR DESCRIPTION
We assign the special "o+0" vref to the root object. Newly created virtual/durable objects are assigned a vref like "o+d13/5", which incorporates the KindID and the instance sequence number.

If buildRootObject() creates a virtual/durable object and returns it as the root, we now have one object with two different identities, violating the main slotToVal/valToSlot invariant. The initial Representative will have a context and a state that was created and cached under the durable vref, but by the time a method is called, valToSlot knows it as "o+0", so the vatstoreGet state lookup fails (as of course there is no state stored under "o+0").

This commit inserts a liveslots check to ensure that the root object does not already have a vref.
