### PR TITLE
ci: disable codecov annotations

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -13,9 +13,9 @@ coverage:
       default:
         informational: true
 github_checks:
-  annotations: true
+  annotations: false
 parsers:
   javascript:
     enable_partials: yes
 ignore:
-  - "coverage/*.json"
+  - 'coverage/*.json'


### PR DESCRIPTION
## Description

The coverage annotations can be distracting to code review. For example on https://github.com/Agoric/agoric-sdk/pull/7132/files
<img width="805" alt="Screenshot 2023-03-24 at 2 54 34 PM" src="https://user-images.githubusercontent.com/21505/227648383-7906cbe4-b303-4bdd-b869-f2e89b71ba1a.png">

 Having them enabled where they're not helpful conditions people to ignore them. They are useful in some cases but until we can opt in for where they're most valuable, it's better to leave them off.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
