### PR TITLE
enforce that buildRootObject() returns an ephemeral, not durable

### DIFF
--- a/packages/SwingSet/docs/static-vats.md
+++ b/packages/SwingSet/docs/static-vats.md
@@ -14,12 +14,14 @@ Static vats are defined by a JS module file which exports a function named `buil
 
 The `buildRootObject` function will be called with one object, named `vatPowers`. The contents of `vatPowers` are subject to change, but in general it provides pure functions which are inconvenient to access as imports, and vat-specific authorities that are not easy to express through syscalls. See below for the current property list.
 
-`buildRootObject` is expected to return a hardened object with callable methods and no data properties (note that `harden` is available as a global). For example:
+`buildRootObject` must return a hardened "ephemeral" object, as documented in [swingset-liveslots](https://github.com/Agoric/agoric-sdk/blob/master/packages/swingset-liveslots/docs/liveslots.md#buildrootobject). A common way to do this is with the `Far` function:
 
 ```js
+import { Far } from '@endo/far';
+
 export function buildRootObject(vatPowers) {
   let counter = 0;
-  return harden({
+  return Far('root', {
     increment() {
       counter += 1;
     },

--- a/packages/SwingSet/src/vats/vattp/vat-vattp.js
+++ b/packages/SwingSet/src/vats/vattp/vat-vattp.js
@@ -6,9 +6,9 @@ import {
   provideDurableMapStore,
   provideDurableSetStore,
   provideKindHandle,
-  prepareSingleton,
 } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
 
 // See ../../docs/delivery.md for a description of the architecture of the
 // comms system.
@@ -28,7 +28,6 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
   const { D } = vatPowers;
 
   // Define all durable baggage keys and kind handles.
-  const serviceSingletonBaggageKey = 'vat-tp handler';
   const mailboxDeviceBaggageKey = 'mailboxDevice';
   const mailboxHandle = provideKindHandle(baggage, 'mailboxHandle');
   const mailboxMapBaggageKey = 'mailboxes';
@@ -285,8 +284,8 @@ export function buildRootObject(vatPowers, _vatParams, baggage) {
     },
   };
 
-  // Expose a durable service singleton.
-  return prepareSingleton(baggage, serviceSingletonBaggageKey, {
+  // Expose the service
+  return Far('vat-tp handler', {
     ...serviceMailboxFunctions,
     ...serviceNetworkFunctions,
   });

--- a/packages/SwingSet/test/vat-admin/durable-root-vat.js
+++ b/packages/SwingSet/test/vat-admin/durable-root-vat.js
@@ -1,0 +1,12 @@
+import { makeKindHandle, defineDurableKind } from '@agoric/vat-data';
+
+// root objects must be ephemeral, not virtual/durable
+
+export function buildRootObject() {
+  const initData = () => ({});
+  const behavior = {};
+  const kh = makeKindHandle('root');
+  const makeRoot = defineDurableKind(kh, initData, behavior);
+  const root = makeRoot();
+  return root;
+}

--- a/packages/SwingSet/test/vat-admin/test-create-vat.js
+++ b/packages/SwingSet/test/vat-admin/test-create-vat.js
@@ -34,6 +34,9 @@ test.before(async t => {
   const brokenHangVatBundle = await bundleSource(
     new URL('broken-hang-vat.js', import.meta.url).pathname,
   );
+  const durableRootVatBundle = await bundleSource(
+    new URL('durable-root-vat.js', import.meta.url).pathname,
+  );
   const vatRefcountBundle = await bundleSource(
     new URL('new-vat-refcount.js', import.meta.url).pathname,
   );
@@ -44,6 +47,7 @@ test.before(async t => {
     brokenModuleVatBundle,
     brokenRootVatBundle,
     brokenHangVatBundle,
+    durableRootVatBundle,
     vatRefcountBundle,
     nonBundle,
   };
@@ -59,6 +63,7 @@ async function doTestSetup(t, doVatAdminRestart = false, enableSlog = false) {
     brokenModule: { bundle: bundles.brokenModuleVatBundle },
     brokenRoot: { bundle: bundles.brokenRootVatBundle },
     brokenHang: { bundle: bundles.brokenHangVatBundle },
+    durableRoot: { bundle: bundles.durableRootVatBundle },
   };
   let doSlog = false;
   function slogSender(slogObj) {
@@ -182,6 +187,10 @@ test('broken vat creation fails (bad buildRootObject)', async t => {
 
 test('broken vat creation fails (buildRootObject hangs)', async t => {
   await brokenVatTest(t, 'brokenHang', /buildRootObject unresolved/);
+});
+
+test('broken vat creation fails (durable root object)', async t => {
+  await brokenVatTest(t, 'durableRoot', /must return ephemeral, not virtual/);
 });
 
 test('error creating vat from non-bundle', async t => {

--- a/packages/swingset-liveslots/docs/liveslots.md
+++ b/packages/swingset-liveslots/docs/liveslots.md
@@ -13,21 +13,26 @@ The downside is that we don't have a good way to persist a vat using Liveslots. 
 Most SwingSet vats use liveslots (with the notable exception of the comms vat). The stereotypical vat definition file when using Liveslots is:
 
 ```js
+import { Far } from '@endo/far';
 
-export buildRootObject() {
-  const obj0 = Far('root', {
-    foo(arg1, arg2) {
-      // implement foo
-      return 'value';
+export function buildRootObject(vatPowers) {
+  let counter = 0;
+  return Far('root', {
+    increment() {
+      counter += 1;
     },
+    read() {
+      return counter;
+    }
   });
-  return harden(obj0);
 }
 ```
 
 See `static-vats.md`, `dynamic-vats.md`, and `vat-environment.md` in this directory for details.
 
 This function returns the "root object". A remote reference to it will be made available to the bootstrap vat, which can use it to trigger whatever initialization needs to happen.
+
+The root object *must* be a hardened "ephemeral" object (e.g., created with `Far` or `makeExo()`). It cannot be a virtual or durable object (created with a maker returned by `defineKind` or `defineDurableKind`, or the vat-data convenience wrappers like `prepareSingleton`). This ensures that the root object's identity is stable across upgrade.
 
 ## Returning New Objects
 

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -1437,6 +1437,10 @@ function build(
     );
     getInterfaceOf(rootObject) !== undefined ||
       Fail`buildRootObject() for vat ${forVatID} returned ${rootObject} with no interface`;
+    if (valToSlot.has(rootObject)) {
+      Fail`buildRootObject() must return ephemeral, not virtual/durable object`;
+    }
+
     // Need to load watched promises *after* buildRootObject() so that handler kindIDs
     // have a chance to be reassociated with their handlers.
     watchedPromiseManager.loadWatchedPromiseTable(unmeteredRevivePromise);


### PR DESCRIPTION
We assign the special "o+0" vref to the root object. Newly created virtual/durable objects are assigned a vref like "o+d13/5", which incorporates the KindID and the instance sequence number.

If buildRootObject() were to create a virtual/durable object and return it as the root, we would now have one object with two different identities, violating the main slotToVal/valToSlot invariant. Under the new/upcoming VOM implementation, the initial Representative will have a context and a state that was created and cached under the durable vref, but by the time a method is called, valToSlot knows it as "o+0", so the vatstoreGet state lookup fails (as of course there is no state stored under "o+0").

(Under the old/current VOM, this sometimes worked by accident, but we believe there were cases where it would have failed)

This commit inserts a liveslots check to ensure that the root object does not already have a vref. The documentation is updated to remind userspace vat authors of the constraint: `buildRootObject` must return an ephemeral, as created with `Far` or `makeExo`.

It also changes vattp to use an ephemeral root. Fortunately, this was the only case we could find of an existing vat using a durable root.

closes #7240
