### PR TITLE
feat(swingstore): add support for b0- bundles

### DIFF
--- a/packages/SwingSet/test/bundling/test-bundles-kernel.js
+++ b/packages/SwingSet/test/bundling/test-bundles-kernel.js
@@ -40,7 +40,7 @@ test('install bundle', async t => {
   const badVersion =
     'b2-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
   await t.throwsAsync(() => kernel.installBundle(badVersion, bundle), {
-    message: /invalid bundleID/,
+    message: /unsupported BundleID/,
   });
 
   const tooShort = 'b1-000';

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -23,6 +23,7 @@
     "@endo/base64": "^0.2.28",
     "@endo/bundle-source": "^2.4.2",
     "@endo/check-bundle": "^0.2.14",
+    "@endo/nat": "^4.1.23",
     "better-sqlite3": "^8.2.0",
     "readline-transform": "^1.0.0",
     "tmp": "^0.2.1"

--- a/packages/swing-store/src/bundleStore.js
+++ b/packages/swing-store/src/bundleStore.js
@@ -4,7 +4,9 @@ import { Readable } from 'stream';
 import { Buffer } from 'buffer';
 import { encodeBase64, decodeBase64 } from '@endo/base64';
 import { checkBundle } from '@endo/check-bundle/lite.js';
+import { Nat } from '@endo/nat';
 import { Fail, q } from '@agoric/assert';
+import { createSHA256 } from './hasher.js';
 import { buffer } from './util.js';
 
 /**
@@ -55,8 +57,8 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
     return `bundle.${bundleID}`;
   }
 
-  function bundleIdFromHash(hash) {
-    return `b1-${hash}`;
+  function bundleIdFromHash(version, hash) {
+    return `b${Nat(version)}-${hash}`;
   }
 
   const sqlAddBundle = db.prepare(`
@@ -72,15 +74,30 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
    * @param {Bundle} bundle
    */
   function addBundle(bundleID, bundle) {
-    bundleID.startsWith('b1-') || Fail`invalid bundleID ${q(bundleID)}`;
-    const { moduleFormat } = bundle;
-    if (moduleFormat !== 'endoZipBase64')
-      throw Fail`unsupported module format ${q(moduleFormat)}`;
-    const { endoZipBase64, endoZipBase64Sha512 } = bundle;
-    bundleID === bundleIdFromHash(endoZipBase64Sha512) ||
-      Fail`bundleID ${q(bundleID)} does not match bundle`;
     ensureTxn();
-    sqlAddBundle.run(bundleID, decodeBase64(endoZipBase64));
+    const { moduleFormat } = bundle;
+    let serialized;
+    if (bundleID.startsWith('b0-')) {
+      if (moduleFormat !== 'nestedEvaluate') {
+        throw Fail`unsupported b0- module format ${q(moduleFormat)}`;
+      }
+      serialized = JSON.stringify(bundle);
+      if (bundleID !== bundleIdFromHash(0, createSHA256(serialized).finish())) {
+        throw Fail`bundleID ${q(bundleID)} does not match bundle`;
+      }
+    } else if (bundleID.startsWith('b1-')) {
+      if (moduleFormat !== 'endoZipBase64') {
+        throw Fail`unsupported b1- module format ${q(moduleFormat)}`;
+      }
+      const { endoZipBase64, endoZipBase64Sha512 } = bundle;
+      if (bundleID !== bundleIdFromHash(1, endoZipBase64Sha512)) {
+        throw Fail`bundleID ${q(bundleID)} does not match bundle`;
+      }
+      serialized = decodeBase64(endoZipBase64);
+    } else {
+      throw Fail`unsupported BundleID ${bundleID}`;
+    }
+    sqlAddBundle.run(bundleID, serialized);
     noteExport(bundleArtifactName(bundleID), bundleID);
   }
 
@@ -105,17 +122,21 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
 
   /**
    * @param {string} bundleID
-   * @returns {EndoZipBase64Bundle}
+   * @returns {Bundle}
    */
   function getBundle(bundleID) {
-    bundleID.startsWith('b1-') || Fail`invalid bundleID ${q(bundleID)}`;
     const rawBundle = sqlGetBundle.get(bundleID);
     rawBundle || Fail`bundle ${q(bundleID)} not found`;
-    return harden({
-      moduleFormat: 'endoZipBase64',
-      endoZipBase64Sha512: bundleID.substring(3),
-      endoZipBase64: encodeBase64(rawBundle),
-    });
+    if (bundleID.startsWith('b0-')) {
+      return harden(JSON.parse(rawBundle));
+    } else if (bundleID.startsWith('b1-')) {
+      return harden({
+        moduleFormat: 'endoZipBase64',
+        endoZipBase64Sha512: bundleID.substring(3),
+        endoZipBase64: encodeBase64(rawBundle),
+      });
+    }
+    throw Fail`somehow found unsupported BundleID ${q(bundleID)}`;
   }
 
   const sqlDeleteBundle = db.prepare(`
@@ -150,9 +171,9 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
     // prettier-ignore
     (parts.length === 2 && type === 'bundle') ||
       Fail`expected artifact name of the form 'bundle.{bundleID}', saw ${q(name)}`;
-    const bundle = getBundle(bundleID);
-    bundle || Fail`bundle ${q(name)} not available`;
-    yield* Readable.from(Buffer.from(decodeBase64(bundle.endoZipBase64)));
+    const rawBundle = sqlGetBundle.get(bundleID);
+    rawBundle || Fail`bundle ${q(name)} not available`;
+    yield* Readable.from(Buffer.from(rawBundle));
   }
 
   const sqlGetBundleIDs = db.prepare(`
@@ -193,6 +214,7 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
    * @returns {Promise<void>}
    */
   async function importBundle(name, exporter, bundleID) {
+    await 0; // no synchronous prefix
     const parts = name.split('.');
     const [type, bundleIDkey] = parts;
     // prettier-ignore
@@ -200,19 +222,32 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
       Fail`expected artifact name of the form 'bundle.{bundleID}', saw '${q(name)}'`;
     bundleIDkey === bundleID ||
       Fail`bundle artifact name ${name} doesn't match bundleID ${bundleID}`;
-    bundleID.startsWith('b1-') || Fail`invalid bundleID ${q(bundleID)}`;
     const artifactChunks = exporter.getArtifact(name);
     const inStream = Readable.from(artifactChunks);
-    const rawBundle = await buffer(inStream);
-    /** @type {EndoZipBase64Bundle} */
-    const bundle = harden({
-      moduleFormat: 'endoZipBase64',
-      endoZipBase64Sha512: bundleID.substring(3),
-      endoZipBase64: encodeBase64(rawBundle),
-    });
-    // Assert that the bundle contents match the ID and hash
-    await checkBundle(bundle, computeSha512, bundleID);
-    addBundle(bundleID, bundle);
+    const data = await buffer(inStream);
+    if (bundleID.startsWith('b0-')) {
+      // we dissect and reassemble the bundle, to exclude unexpected properties
+      const { moduleFormat, source, sourceMap } = JSON.parse(data.toString());
+      /** @type {NestedEvaluateBundle} */
+      const bundle = harden({ moduleFormat, source, sourceMap });
+      const serialized = JSON.stringify(bundle);
+      bundleID === bundleIdFromHash(0, createSHA256(serialized).finish()) ||
+        Fail`bundleID ${q(bundleID)} does not match bundle artifact`;
+      addBundle(bundleID, bundle);
+    } else if (bundleID.startsWith('b1-')) {
+      /** @type {EndoZipBase64Bundle} */
+      const bundle = harden({
+        moduleFormat: 'endoZipBase64',
+        endoZipBase64Sha512: bundleID.substring(3),
+        endoZipBase64: encodeBase64(data),
+      });
+      // Assert that the bundle contents match the ID and hash
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      await checkBundle(bundle, computeSha512, bundleID);
+      addBundle(bundleID, bundle);
+    } else {
+      Fail`unsupported BundleID ${q(bundleID)}`;
+    }
   }
 
   const sqlDumpBundles = db.prepare(`

--- a/packages/swing-store/test/test-bundles.js
+++ b/packages/swing-store/test/test-bundles.js
@@ -1,0 +1,157 @@
+// @ts-check
+import '@endo/init/debug.js';
+import test from 'ava';
+import tmp from 'tmp';
+import { Buffer } from 'buffer';
+import { createSHA256 } from '../src/hasher.js';
+import {
+  importSwingStore,
+  initSwingStore,
+  makeSwingStoreExporter,
+} from '../src/swingStore.js';
+import { buffer } from '../src/util.js';
+
+function makeB0ID(bundle) {
+  return `b0-${createSHA256(JSON.stringify(bundle)).finish()}`;
+}
+
+test('b0 format', t => {
+  const { kernelStorage } = initSwingStore();
+  const { bundleStore } = kernelStorage;
+
+  /** @type {import('../src/bundleStore.js').Bundle} */
+  const b0A = { moduleFormat: 'nestedEvaluate', source: '1+1' };
+  const idA = makeB0ID(b0A);
+  bundleStore.addBundle(idA, b0A);
+  t.truthy(bundleStore.hasBundle(idA));
+  t.deepEqual(bundleStore.getBundle(idA), b0A);
+
+  const idBogus = `${idA}bogus`;
+  t.throws(() => bundleStore.addBundle(idBogus, b0A), {
+    message: /does not match bundle/,
+  });
+  t.falsy(bundleStore.hasBundle(idBogus));
+
+  /** @type {import('../src/bundleStore.js').Bundle} */
+  const b0B = { moduleFormat: 'getExport', source: '1+1' };
+  const idB = makeB0ID(b0B);
+  t.throws(() => bundleStore.addBundle(idB, b0B), {
+    message: /unsupported b0- module format "getExport"/,
+  });
+});
+
+function makeExportCallback() {
+  const exportData = new Map();
+  return {
+    exportData,
+    exportCallback(updates) {
+      for (const [key, value] of updates) {
+        if (value !== undefined) {
+          exportData.set(key, value);
+        } else {
+          exportData.delete(key);
+        }
+      }
+    },
+  };
+}
+
+const tmpDir = prefix =>
+  new Promise((resolve, reject) => {
+    tmp.dir({ unsafeCleanup: true, prefix }, (err, name, removeCallback) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve([name, removeCallback]);
+      }
+    });
+  });
+
+const collectArray = async iter => {
+  const items = [];
+  for await (const item of iter) {
+    items.push(item);
+  }
+  return items;
+};
+
+test('b0 export', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+  const { exportData, exportCallback } = makeExportCallback();
+  const { kernelStorage, hostStorage } = initSwingStore(dbDir, {
+    exportCallback,
+  });
+  const { bundleStore } = kernelStorage;
+
+  /** @type {import('../src/bundleStore.js').Bundle} */
+  const b0A = { moduleFormat: 'nestedEvaluate', source: '1+1' };
+  const idA = makeB0ID(b0A);
+  bundleStore.addBundle(idA, b0A);
+  hostStorage.commit();
+  t.is(exportData.get(`bundle.${idA}`), idA);
+
+  const exporter = makeSwingStoreExporter(dbDir);
+  const exportData2 = new Map();
+  for await (const [key, value] of exporter.getExportData()) {
+    exportData2.set(key, value);
+  }
+  t.is(exportData2.get(`bundle.${idA}`), idA);
+
+  const names = await collectArray(exporter.getArtifactNames());
+  t.deepEqual(names, [`bundle.${idA}`]);
+  const artifact = await buffer(exporter.getArtifact(names[0]));
+  t.is(artifact.toString(), JSON.stringify(b0A));
+});
+
+test('b0 import', async t => {
+  const b0A = { moduleFormat: 'nestedEvaluate', source: '1+1' };
+  const idA = makeB0ID(b0A);
+  const nameA = `bundle.${idA}`;
+  const exporter = {
+    getExportData: () => [
+      /** @type {import('../src/swingStore.js').KVPair} */ ([nameA, idA]),
+    ],
+    getArtifact: name => {
+      t.is(name, nameA);
+      return [Buffer.from(JSON.stringify(b0A))];
+    },
+    getArtifactNames: () => assert.fail('import should not query all names'),
+    close: async () => undefined,
+  };
+  const { kernelStorage } = await importSwingStore(exporter);
+  const { bundleStore } = kernelStorage;
+  t.truthy(bundleStore.hasBundle(idA));
+  t.deepEqual(bundleStore.getBundle(idA), b0A);
+});
+
+test('b0 bad import', async t => {
+  const b0A = { moduleFormat: 'nestedEvaluate', source: '1+1' };
+  const b0Abogus = { moduleFormat: 'nestedEvaluate', source: '1+2' };
+  const idA = makeB0ID(b0A);
+  const nameA = `bundle.${idA}`;
+  const exporter = {
+    getExportData: () => [
+      /** @type {import('../src/swingStore.js').KVPair} */ ([nameA, idA]),
+    ],
+    getArtifact: name => {
+      t.is(name, nameA);
+      return [Buffer.from(JSON.stringify(b0Abogus))];
+    },
+    getArtifactNames: () => assert.fail('import should not query all names'),
+    close: async () => undefined,
+  };
+  await t.throwsAsync(async () => importSwingStore(exporter), {
+    message: /does not match bundle artifact/,
+  });
+});
+
+test('unknown format', t => {
+  const { kernelStorage } = initSwingStore();
+  const { bundleStore } = kernelStorage;
+  const unknownID = 'b1999-whoa-futuristic';
+  /** @typedef {import('../src/bundleStore.js').Bundle} Bundle */
+  t.throws(() => bundleStore.addBundle(unknownID, /** @type {Bundle} */ ({})), {
+    message: /unsupported BundleID/,
+  });
+});


### PR DESCRIPTION
This enhances the bundleStore to accomodate NestedEvaluate -format bundles, with a BundleID that is a hash of the JSON-serialized bundle object, using a `b0-` prefix.

This adds to the previous facility which handled only EndoZipBase64 -format bundles, using a `b1-` prefixed BundleID that hashes only the compartment-map.json component of the zipfile.

It also adds a number of tests.

closes #7190
