### PR TITLE
Various swing-store fixes

### DIFF
--- a/packages/internal/src/node/buffer-line-transform.js
+++ b/packages/internal/src/node/buffer-line-transform.js
@@ -1,0 +1,119 @@
+/* global Buffer */
+/* eslint-disable no-underscore-dangle */
+
+import { Transform } from 'node:stream';
+
+/**
+ * @typedef {object} BufferLineTransformOptions
+ * @property {Buffer | string | number} [break] line break matcher for Buffer.indexOf() (default: 10)
+ * @property {BufferEncoding} [breakEncoding] if break is a string, the encoding to use
+ */
+
+export default class BufferLineTransform extends Transform {
+  /**
+   * The BufferLineTransform is reading String or Buffer content from a Readable stream
+   * and writing each line as a Buffer in object mode
+   *
+   * @param {import('node:stream').TransformOptions & BufferLineTransformOptions} [options]
+   */
+  constructor(options) {
+    const {
+      break: breakValue,
+      breakEncoding,
+      ...transformOptions
+    } = options || {};
+    super({ ...transformOptions, readableObjectMode: true });
+    this._breakValue = breakValue || 10;
+    this._breakEncoding = breakEncoding;
+
+    /** @type {number} */
+    let breakLength;
+    if (!breakValue || typeof breakValue === 'number') {
+      breakLength = 1;
+    } else if (Buffer.isBuffer(breakValue)) {
+      breakLength = breakValue.length;
+    } else {
+      breakLength = Buffer.from(breakValue, breakEncoding).length;
+    }
+    this._breakLength = breakLength;
+
+    /** @type {Array<Buffer>} */
+    this._chunks = [];
+  }
+
+  /**
+   * @override
+   * @param {any} chunk
+   * @param {BufferEncoding | 'buffer'} encoding
+   * @param {import('node:stream').TransformCallback} cb
+   */
+  _transform(chunk, encoding, cb) {
+    try {
+      /** @type {Buffer} */
+      let buf =
+        Buffer.isBuffer(chunk) || encoding === 'buffer'
+          ? chunk
+          : Buffer.from(chunk, encoding);
+
+      // In case the break value is more than a single byte, it may span
+      // multiple chunks. Since Node doesn't provide a way to get partial
+      // search result, fallback to a less optimal early concatenation
+      if (this._breakLength > 1 && this._chunks.length) {
+        buf = Buffer.concat([/** @type {Buffer} */ (this._chunks.pop()), buf]);
+      }
+
+      while (buf.length) {
+        const offset = buf.indexOf(this._breakValue, 0, this._breakEncoding);
+
+        /** @type {number} */
+        let endOffset;
+        if (offset >= 0) {
+          endOffset = offset + this._breakLength;
+          if (this._chunks.length) {
+            const concatLength = this._chunks.reduce(
+              (acc, { length }) => acc + length,
+              endOffset,
+            );
+            this._writeItem(
+              Buffer.concat(
+                [...this._chunks.splice(0, this._chunks.length), buf],
+                concatLength,
+              ),
+            );
+          } else {
+            this._writeItem(buf.subarray(0, endOffset));
+          }
+        } else {
+          endOffset = buf.length;
+          this._chunks.push(buf);
+        }
+        buf = buf.subarray(endOffset);
+      }
+      cb();
+    } catch (err) {
+      cb(/** @type {any} */ (err)); // invalid data type;
+    }
+  }
+
+  /**
+   * @override
+   * @param {import('node:stream').TransformCallback} cb
+   */
+  _flush(cb) {
+    if (this._chunks.length) {
+      this._writeItem(
+        Buffer.concat(this._chunks.splice(0, this._chunks.length)),
+      );
+    }
+    cb();
+  }
+
+  /** @param {Buffer} line */
+  _writeItem(line) {
+    if (this.readableEncoding) {
+      this.push(line.toString(this.readableEncoding), this.readableEncoding);
+    } else {
+      this.push(line);
+    }
+  }
+}

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -25,7 +25,6 @@
     "@endo/check-bundle": "^0.2.14",
     "@endo/nat": "^4.1.23",
     "better-sqlite3": "^8.2.0",
-    "readline-transform": "^1.0.0",
     "tmp": "^0.2.1"
   },
   "devDependencies": {

--- a/packages/swing-store/src/bundleStore.js
+++ b/packages/swing-store/src/bundleStore.js
@@ -26,10 +26,10 @@ import { buffer } from './util.js';
  * }} BundleStore
  *
  * @typedef {{
- *   exportBundle: (name: string) => AsyncIterable<Uint8Array>,
+ *   exportBundle: (name: string) => AsyncIterableIterator<Uint8Array>,
  *   importBundle: (artifactName: string, exporter: SwingStoreExporter, bundleID: string) => void,
- *   getExportRecords: () => Iterable<[key: string, value: string]>,
- *   getArtifactNames: () => AsyncIterable<string>,
+ *   getExportRecords: () => IterableIterator<readonly [key: string, value: string]>,
+ *   getArtifactNames: () => AsyncIterableIterator<string>,
  * }} BundleStoreInternal
  *
  * @typedef {{
@@ -162,7 +162,7 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
    * @param {string} name
    *
    * @yields {Uint8Array}
-   * @returns {AsyncIterable<Uint8Array>}
+   * @returns {AsyncIterableIterator<Uint8Array>}
    */
   async function* exportBundle(name) {
     typeof name === 'string' || Fail`artifact name must be a string`;
@@ -187,7 +187,7 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
    * Obtain artifact metadata records for bundles contained in this store.
    *
    * @yields {[key: string, value: string]}
-   * @returns {Iterable<[key: string, value: string]>}
+   * @returns {IterableIterator<readonly [key: string, value: string]>}
    */
   function* getExportRecords() {
     for (const bundleID of sqlGetBundleIDs.iterate()) {

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -38,10 +38,10 @@ import { buffer } from './util.js';
  * }} SnapStore
  *
  * @typedef {{
- *   exportSnapshot: (name: string, includeHistorical: boolean) => AsyncIterable<Uint8Array>,
+ *   exportSnapshot: (name: string, includeHistorical: boolean) => AsyncIterableIterator<Uint8Array>,
  *   importSnapshot: (artifactName: string, exporter: SwingStoreExporter, artifactMetadata: Map) => void,
- *   getExportRecords: (includeHistorical: boolean) => Iterable<[key: string, value: string]>,
- *   getArtifactNames: (includeHistorical: boolean) => AsyncIterable<string>,
+ *   getExportRecords: (includeHistorical: boolean) => IterableIterator<readonly [key: string, value: string]>,
+ *   getArtifactNames: (includeHistorical: boolean) => AsyncIterableIterator<string>,
  * }} SnapStoreInternal
  *
  * @typedef {{
@@ -291,7 +291,7 @@ export function makeSnapStore(
    *
    * @param {string} name
    * @param {boolean} includeHistorical
-   * @returns {AsyncIterable<Uint8Array>}
+   * @returns {AsyncIterableIterator<Uint8Array>}
    */
   function exportSnapshot(name, includeHistorical) {
     typeof name === 'string' || Fail`artifact name must be a string`;
@@ -486,8 +486,8 @@ export function makeSnapStore(
    * pruning historical metadata, for example after further analysis and
    * practical experience tells us that it will not be needed.
    *
-   * @yields {[key: string, value: string]}
-   * @returns {Iterable<[key: string, value: string]>}
+   * @yields {readonly [key: string, value: string]}
+   * @returns {IterableIterator<readonly [key: string, value: string]>}
    */
   function* getExportRecords(includeHistorical = true) {
     for (const rec of sqlGetSnapshotMetadata.iterate(1)) {

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -95,12 +95,14 @@ export function makeSnapStore(
     CREATE TABLE IF NOT EXISTS snapshots (
       vatID TEXT,
       endPos INTEGER,
-      inUse INTEGER,
+      inUse INTEGER CHECK(inUse = 1),
       hash TEXT,
       uncompressedSize INTEGER,
       compressedSize INTEGER,
       compressedSnapshot BLOB,
-      PRIMARY KEY (vatID, endPos)
+      PRIMARY KEY (vatID, endPos),
+      UNIQUE (vatID, inUse),
+      CHECK(compressedSnapshot is not null or inUse is null)
     )
   `);
 
@@ -122,7 +124,7 @@ export function makeSnapStore(
 
   const sqlDeleteAllUnusedSnapshots = db.prepare(`
     DELETE FROM snapshots
-    WHERE inUse = 0
+    WHERE inUse is null
   `);
 
   /**
@@ -150,10 +152,10 @@ export function makeSnapStore(
    * @param {string} vatID
    * @param {number} endPos
    * @param {string} [hash]
-   * @param {number} [inUse]
+   * @param {number | null} [inUse]
    */
   function snapshotRec(vatID, endPos, hash, inUse) {
-    return { vatID, endPos, hash, inUse };
+    return { vatID, endPos, hash, inUse: inUse ? 1 : 0 };
   }
 
   const sqlGetPriorSnapshotInfo = db.prepare(`
@@ -164,13 +166,13 @@ export function makeSnapStore(
 
   const sqlClearLastSnapshot = db.prepare(`
     UPDATE snapshots
-    SET inUse = 0, compressedSnapshot = null
+    SET inUse = null, compressedSnapshot = null
     WHERE inUse = 1 AND vatID = ?
   `);
 
   const sqlStopUsingLastSnapshot = db.prepare(`
     UPDATE snapshots
-    SET inUse = 0
+    SET inUse = null
     WHERE inUse = 1 AND vatID = ?
   `);
 
@@ -465,7 +467,7 @@ export function makeSnapStore(
   const sqlGetSnapshotMetadata = db.prepare(`
     SELECT vatID, endPos, hash, uncompressedSize, compressedSize, inUse
     FROM snapshots
-    WHERE inUse = ?
+    WHERE inUse IS ?
     ORDER BY vatID, endPos
   `);
 
@@ -497,7 +499,7 @@ export function makeSnapStore(
       yield [currentSnapshotMetadataKey(rec), snapshotArtifactName(rec)];
     }
     if (includeHistorical) {
-      for (const rec of sqlGetSnapshotMetadata.iterate(0)) {
+      for (const rec of sqlGetSnapshotMetadata.iterate(null)) {
         const exportRec = snapshotRec(rec.vatID, rec.endPos, rec.hash, 0);
         yield [snapshotMetadataKey(rec), JSON.stringify(exportRec)];
       }
@@ -509,7 +511,7 @@ export function makeSnapStore(
       yield snapshotArtifactName(rec);
     }
     if (includeHistorical) {
-      for (const rec of sqlGetSnapshotMetadata.iterate(0)) {
+      for (const rec of sqlGetSnapshotMetadata.iterate(null)) {
         yield snapshotArtifactName(rec);
       }
     }
@@ -553,7 +555,7 @@ export function makeSnapStore(
     sqlSaveSnapshot.run(
       vatID,
       endPos,
-      info.inUse,
+      info.inUse ? 1 : null,
       info.hash,
       size,
       compressedArtifact.length,
@@ -589,7 +591,12 @@ export function makeSnapStore(
       if (!dump[vatID]) {
         dump[vatID] = [];
       }
-      dump[vatID].push({ endPos, hash, compressedSnapshot, inUse });
+      dump[vatID].push({
+        endPos,
+        hash,
+        compressedSnapshot,
+        inUse: inUse ? 1 : 0,
+      });
     }
     return dump;
   }

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -130,11 +130,15 @@ function getKeyType(key) {
  * @template T
  *  @typedef  { Iterable<T> | AsyncIterable<T> } AnyIterable<T>
  */
+/**
+ * @template T
+ *  @typedef  { IterableIterator<T> | AsyncIterableIterator<T> } AnyIterableIterator<T>
+ */
 
 /**
- * @typedef {[
+ * @typedef {readonly [
  *   key: string,
- *   value: string|undefined,
+ *   value?: string | null | undefined,
  * ]} KVPair
  *
  * @typedef {object} SwingStoreExporter
@@ -146,7 +150,7 @@ function getKeyType(key) {
  * the concurrent activity of other swingStore instances, the data representing
  * the commit point will stay consistent and available.
  *
- * @property {() => AnyIterable<KVPair>} getExportData
+ * @property {() => AnyIterableIterator<KVPair>} getExportData
  *
  * Get a full copy of the first-stage export data (key-value pairs) from the
  * swingStore. This represents both the contents of the KVStore (excluding host
@@ -161,7 +165,7 @@ function getKeyType(key) {
  * - transcript.${vatID}.${startPos} = ${{ vatID, startPos, endPos, hash }}
  * - transcript.${vatID}.current = ${{ vatID, startPos, endPos, hash }}
  *
- * @property {() => AnyIterable<string>} getArtifactNames
+ * @property {() => AnyIterableIterator<string>} getArtifactNames
  *
  * Get a list of name of artifacts available from the swingStore.  A name returned
  * by this method guarantees that a call to `getArtifact` on the same exporter
@@ -172,7 +176,7 @@ function getKeyType(key) {
  * - transcript.${vatID}.${startPos}.${endPos}
  * - snapshot.${vatID}.${endPos}
  *
- * @property {(name: string) => AnyIterable<Uint8Array>} getArtifact
+ * @property {(name: string) => AnyIterableIterator<Uint8Array>} getArtifact
  *
  * Retrieve an artifact by name.  May throw if the artifact is not available,
  * which can occur if the artifact is historical and wasn't been preserved.
@@ -217,7 +221,7 @@ export function makeSwingStoreExporter(dirPath, exportMode = 'current') {
   `);
 
   /**
-   * @returns {AsyncIterable<KVPair>}
+   * @returns {AsyncIterableIterator<KVPair>}
    * @yields {KVPair}
    */
   async function* getExportData() {
@@ -233,7 +237,7 @@ export function makeSwingStoreExporter(dirPath, exportMode = 'current') {
   }
 
   /**
-   * @returns {AsyncIterable<string>}
+   * @returns {AsyncIterableIterator<string>}
    * @yields {string}
    */
   async function* getArtifactNames() {
@@ -244,7 +248,7 @@ export function makeSwingStoreExporter(dirPath, exportMode = 'current') {
 
   /**
    * @param {string} name
-   * @returns {AsyncIterable<Uint8Array>}
+   * @returns {AsyncIterableIterator<Uint8Array>}
    */
   function getArtifact(name) {
     typeof name === 'string' || Fail`artifact name must be a string`;

--- a/packages/swing-store/src/transcriptStore.js
+++ b/packages/swing-store/src/transcriptStore.js
@@ -363,16 +363,17 @@ export function makeTranscriptStore(
    * @returns {IterableIterator<string>}  An iterator over the items in the indicated span
    */
   function readSpan(vatID, startPos) {
+    /** @type {number | undefined} */
     let endPos;
     if (startPos === undefined) {
       ({ startPos, endPos } = getCurrentSpanBounds(vatID));
     } else {
       insistTranscriptPosition(startPos);
       endPos = sqlGetSpanEndPos.get(vatID, startPos);
-      typeof endPos === 'number' ||
-        Fail`no transcript span for ${q(vatID)} at ${q(startPos)}`;
+      if (typeof endPos !== 'number') {
+        throw Fail`no transcript span for ${q(vatID)} at ${q(startPos)}`;
+      }
     }
-    insistTranscriptPosition(startPos);
     startPos <= endPos || Fail`${q(startPos)} <= ${q(endPos)}}`;
 
     function* reader() {

--- a/packages/swing-store/src/transcriptStore.js
+++ b/packages/swing-store/src/transcriptStore.js
@@ -87,7 +87,7 @@ export function makeTranscriptStore(
       startPos INTEGER, -- inclusive
       endPos INTEGER, -- exclusive
       hash TEXT, -- cumulative hash of this item and previous cumulative hash
-      isCurrent INTEGER,
+      isCurrent INTEGER CHECK (isCurrent = 1),
       PRIMARY KEY (vatID, startPos),
       UNIQUE (vatID, isCurrent)
     )

--- a/packages/swing-store/src/transcriptStore.js
+++ b/packages/swing-store/src/transcriptStore.js
@@ -14,14 +14,14 @@ import { createSHA256 } from './hasher.js';
  *   getCurrentSpanBounds: (vatID: string) => { startPos: number, endPos: number, hash: string },
  *   deleteVatTranscripts: (vatID: string) => void,
  *   addItem: (vatID: string, item: string) => void,
- *   readSpan: (vatID: string, startPos?: number) => Iterable<string>,
+ *   readSpan: (vatID: string, startPos?: number) => IterableIterator<string>,
  * }} TranscriptStore
  *
  * @typedef {{
- *   exportSpan: (name: string, includeHistorical: boolean) => AsyncIterable<Uint8Array>
+ *   exportSpan: (name: string, includeHistorical: boolean) => AsyncIterableIterator<Uint8Array>
  *   importSpan: (artifactName: string, exporter: SwingStoreExporter, artifactMetadata: Map) => Promise<void>,
- *   getExportRecords: (includeHistorical: boolean) => Iterable<[key: string, value: string]>,
- *   getArtifactNames: (includeHistorical: boolean) => AsyncIterable<string>,
+ *   getExportRecords: (includeHistorical: boolean) => IterableIterator<readonly [key: string, value: string]>,
+ *   getArtifactNames: (includeHistorical: boolean) => AsyncIterableIterator<string>,
  * }} TranscriptStoreInternal
  *
  * @typedef {{
@@ -304,10 +304,10 @@ export function makeTranscriptStore(
    * replay will never be required or because such replay would be prohibitively
    * expensive regardless of need and therefor other repair strategies employed.
    *
-   * @yields {[key: string, value: string]}
-   * @returns {Iterable<[key: string, value: string]>}  An iterator over pairs of
-   *    [spanMetadataKey, rec], where `rec` is a JSON-encoded metadata record for the
-   *    span named by `spanMetadataKey`.
+   * @yields {readonly [key: string, value: string]}
+   * @returns {IterableIterator<readonly [key: string, value: string]>}
+   *    An iterator over pairs of [spanMetadataKey, rec], where `rec` is a
+   *    JSON-encoded metadata record for the span named by `spanMetadataKey`.
    */
   function* getExportRecords(includeHistorical = true) {
     const sql = includeHistorical
@@ -328,7 +328,7 @@ export function makeTranscriptStore(
    * the current span for each vat.
    *
    * @yields {string}
-   * @returns {AsyncIterable<string>}  An iterator over the names of all the artifacts requested
+   * @returns {AsyncIterableIterator<string>}  An iterator over the names of all the artifacts requested
    */
   async function* getArtifactNames(includeHistorical) {
     const sql = includeHistorical
@@ -360,7 +360,7 @@ export function makeTranscriptStore(
    * @param {number} [startPos] A start position identifying the span to be
    *    read; defaults to the current span, whatever it is
    *
-   * @returns {Iterable<string>}  An iterator over the items in the indicated span
+   * @returns {IterableIterator<string>}  An iterator over the items in the indicated span
    */
   function readSpan(vatID, startPos) {
     let endPos;
@@ -409,7 +409,7 @@ export function makeTranscriptStore(
    * @param {string} name  The name of the transcript artifact to be read
    * @param {boolean} includeHistorical  If true, allow non-current spans to be fetched
    *
-   * @returns {AsyncIterable<Uint8Array>}
+   * @returns {AsyncIterableIterator<Uint8Array>}
    * @yields {Uint8Array}
    */
   async function* exportSpan(name, includeHistorical) {

--- a/packages/swing-store/test/test-bundles.js
+++ b/packages/swing-store/test/test-bundles.js
@@ -109,12 +109,12 @@ test('b0 import', async t => {
   const idA = makeB0ID(b0A);
   const nameA = `bundle.${idA}`;
   const exporter = {
-    getExportData: () => [
-      /** @type {import('../src/swingStore.js').KVPair} */ ([nameA, idA]),
-    ],
-    getArtifact: name => {
+    async *getExportData() {
+      yield /** @type {const} */ ([nameA, idA]);
+    },
+    async *getArtifact(name) {
       t.is(name, nameA);
-      return [Buffer.from(JSON.stringify(b0A))];
+      yield Buffer.from(JSON.stringify(b0A));
     },
     getArtifactNames: () => assert.fail('import should not query all names'),
     close: async () => undefined,
@@ -131,12 +131,12 @@ test('b0 bad import', async t => {
   const idA = makeB0ID(b0A);
   const nameA = `bundle.${idA}`;
   const exporter = {
-    getExportData: () => [
-      /** @type {import('../src/swingStore.js').KVPair} */ ([nameA, idA]),
-    ],
-    getArtifact: name => {
+    async *getExportData() {
+      yield /** @type {const} */ ([nameA, idA]);
+    },
+    async *getArtifact(name) {
       t.is(name, nameA);
-      return [Buffer.from(JSON.stringify(b0Abogus))];
+      yield Buffer.from(JSON.stringify(b0Abogus));
     },
     getArtifactNames: () => assert.fail('import should not query all names'),
     close: async () => undefined,

--- a/packages/swing-store/test/test-state.js
+++ b/packages/swing-store/test/test-state.js
@@ -202,6 +202,10 @@ async function testTranscriptStore(t, dbDir) {
   t.deepEqual(exportLog.getLog(), [
     [
       [
+        'transcript.empty.current',
+        '{"vatID":"empty","startPos":0,"endPos":0,"hash":"43e6be43a3a34d60c0ebeb8498b5849b094fc20fc68483a7aeb3624fa10f79f6","isCurrent":1}',
+      ],
+      [
         'transcript.st1.0',
         '{"vatID":"st1","startPos":0,"endPos":2,"hash":"d385c43882cfb5611d255e362a9a98626ba4e55dfc308fc346c144c696ae734e","isCurrent":0}',
       ],


### PR DESCRIPTION
refs: #7026

## Description

This is a grab bag of swing-store changes and fixes. Some are required for the state-sync PR and extracted from it (#7225), some are follow up from #7026.

Most commits are independent, and best reviewed separately.

### Security Considerations

This adds a few more consistency checks on the swing-store tables, ensuring that the data doesn't get in an unexpected state due to bugs or bad manipulations of the raw DB.

### Scaling Considerations

None

### Documentation Considerations

Some type changes are there to be more explicit about the expected usage and values.

### Testing Considerations

Manually testing against state-sync branch
