### PR TITLE
chore: always get Far, E, passStyleOf, and getInterfaceOf from @endo/far

### DIFF
--- a/packages/SwingSet/demo/encouragementBot/bootstrap.js
+++ b/packages/SwingSet/demo/encouragementBot/bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 console.log(`=> loading bootstrap.js`);
 

--- a/packages/SwingSet/demo/encouragementBot/vat-bot.js
+++ b/packages/SwingSet/demo/encouragementBot/vat-bot.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {

--- a/packages/SwingSet/demo/encouragementBot/vat-user.js
+++ b/packages/SwingSet/demo/encouragementBot/vat-user.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;

--- a/packages/SwingSet/demo/encouragementBotComms/bootstrap.js
+++ b/packages/SwingSet/demo/encouragementBotComms/bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 console.log(`=> loading bootstrap.js`);
 

--- a/packages/SwingSet/demo/encouragementBotComms/vat-bot.js
+++ b/packages/SwingSet/demo/encouragementBotComms/vat-bot.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {

--- a/packages/SwingSet/demo/encouragementBotComms/vat-user.js
+++ b/packages/SwingSet/demo/encouragementBotComms/vat-user.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;

--- a/packages/SwingSet/misc-tools/measure-metering/measurement-bootstrap.js
+++ b/packages/SwingSet/misc-tools/measure-metering/measurement-bootstrap.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies,no-unused-vars,no-empty-function */
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import vaultFactoryBundle from '@agoric/inter-protocol/bundles/bundle-vaultFactory.js';
 import { makeIssuerKit } from '@agoric/ertp';
 

--- a/packages/SwingSet/misc-tools/measure-metering/measurement-target.js
+++ b/packages/SwingSet/misc-tools/measure-metering/measurement-target.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies,no-unused-vars,no-empty-function */
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 
 export function buildRootObject(vatPowers) {

--- a/packages/SwingSet/misc-tools/measure-metering/measurement-zoe.js
+++ b/packages/SwingSet/misc-tools/measure-metering/measurement-zoe.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { makeZoe } from '@agoric/zoe';
 
 export function buildRootObject(_vatPowers, vatParameters) {

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -21,7 +21,6 @@
     "lint:eslint": "eslint ."
   },
   "devDependencies": {
-    "@endo/far": "^0.2.14",
     "@types/better-sqlite3": "^7.5.0",
     "@types/microtime": "^2.1.0",
     "@types/tmp": "^0.2.0",
@@ -46,6 +45,7 @@
     "@endo/check-bundle": "^0.2.14",
     "@endo/compartment-mapper": "^0.8.0",
     "@endo/eventual-send": "^0.16.8",
+    "@endo/far": "^0.2.14",
     "@endo/import-bundle": "^0.3.0",
     "@endo/init": "^0.5.52",
     "@endo/marshal": "^0.8.1",

--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-use-before-define */
 
-import { makeMarshal, Far } from '@endo/marshal';
+import { makeMarshal } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { assert, Fail } from '@agoric/assert';
 import { assertKnownOptions } from '../lib/assertOptions.js';
 import { insistVatID } from '../lib/id.js';

--- a/packages/SwingSet/src/devices/bridge/device-bridge.js
+++ b/packages/SwingSet/src/devices/bridge/device-bridge.js
@@ -1,5 +1,5 @@
 import { Fail } from '@agoric/assert';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 function sanitize(data) {
   if (data === undefined) {

--- a/packages/SwingSet/src/devices/command/device-command.js
+++ b/packages/SwingSet/src/devices/command/device-command.js
@@ -1,5 +1,5 @@
 import { Nat } from '@endo/nat';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 import { Fail } from '@agoric/assert';
 

--- a/packages/SwingSet/src/devices/lib/deviceTools.js
+++ b/packages/SwingSet/src/devices/lib/deviceTools.js
@@ -1,5 +1,6 @@
 import { assert, Fail } from '@agoric/assert';
-import { makeMarshal, Far } from '@endo/marshal';
+import { makeMarshal } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { parseVatSlot } from '../../lib/parseVatSlots.js';
 
 // raw devices can use this to build a set of convenience tools for

--- a/packages/SwingSet/src/devices/loopbox/device-loopbox.js
+++ b/packages/SwingSet/src/devices/loopbox/device-loopbox.js
@@ -1,5 +1,5 @@
 import { Fail } from '@agoric/assert';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootDeviceNode(tools) {
   const { SO, endowments, deviceParameters, getDeviceState, setDeviceState } =

--- a/packages/SwingSet/src/devices/mailbox/device-mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox/device-mailbox.js
@@ -1,5 +1,5 @@
 import { Nat } from '@endo/nat';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 import { assert, Fail } from '@agoric/assert';
 

--- a/packages/SwingSet/src/devices/plugin/device-plugin.js
+++ b/packages/SwingSet/src/devices/plugin/device-plugin.js
@@ -1,5 +1,5 @@
 import { makeCapTP } from '@endo/captp';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { assert, details as X, Fail } from '@agoric/assert';
 
 export function buildRootDeviceNode(tools) {

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -24,7 +24,7 @@
 
 import { Nat } from '@endo/nat';
 import { assert, Fail } from '@agoric/assert';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 // Since we use harden when saving the state, we need to copy the arrays so they
 // will continue to be mutable. each record inside handlers is immutable, so we

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -1,4 +1,5 @@
-import { Remotable, passStyleOf, makeMarshal } from '@endo/marshal';
+import { Remotable, makeMarshal } from '@endo/marshal';
+import { passStyleOf } from '@endo/far';
 import { assert, Fail } from '@agoric/assert';
 import {
   insistVatType,

--- a/packages/SwingSet/src/lib/capdata.js
+++ b/packages/SwingSet/src/lib/capdata.js
@@ -1,5 +1,5 @@
 import { Fail } from '@agoric/assert';
-import { passStyleOf } from '@endo/marshal';
+import { passStyleOf } from '@endo/far';
 import { kunser, krefOf } from './kmarshal.js';
 
 /* eslint-disable jsdoc/require-returns-check */

--- a/packages/SwingSet/src/lib/kmarshal.js
+++ b/packages/SwingSet/src/lib/kmarshal.js
@@ -1,4 +1,5 @@
-import { Far, makeMarshal, passStyleOf } from '@endo/marshal';
+import { Far, passStyleOf } from '@endo/far';
+import { makeMarshal } from '@endo/marshal';
 import { assert } from '@agoric/assert';
 
 // Simple wrapper for serializing and unserializing marshalled values inside the

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -1,6 +1,5 @@
 import { makeScalarMapStore, makeLegacyMap } from '@agoric/store';
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { assert, details as X, Fail } from '@agoric/assert';
 import { whileTrue } from '@agoric/internal';

--- a/packages/SwingSet/src/vats/network/router.js
+++ b/packages/SwingSet/src/vats/network/router.js
@@ -1,5 +1,4 @@
-import { E as defaultE } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E as defaultE } from '@endo/far';
 import { makeScalarMapStore } from '@agoric/store';
 import { assert, details as X } from '@agoric/assert';
 import { makeNetworkProtocol, ENDPOINT_SEPARATOR } from './network.js';

--- a/packages/SwingSet/src/vats/plugin-manager.js
+++ b/packages/SwingSet/src/vats/plugin-manager.js
@@ -1,8 +1,9 @@
 import { makeScalarMapStore } from '@agoric/store';
 import { makeCapTP } from '@endo/captp';
 import { makePromiseKit } from '@endo/promise-kit';
-import { E, HandledPromise } from '@endo/eventual-send';
-import { Remotable, Far } from '@endo/marshal';
+import { HandledPromise } from '@endo/eventual-send';
+import { Remotable } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 import '@agoric/store/exported.js';
 

--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-use-before-define */
 
-import { E } from '@endo/eventual-send';
-import { Far, passStyleOf } from '@endo/marshal';
+import { Far, E, passStyleOf } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { Nat } from '@endo/nat';
 import { assert } from '@agoric/assert';

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -7,8 +7,7 @@
  */
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeNotifierKit } from '@agoric/notifier';
-import { Far, passStyleOf } from '@endo/marshal';
-import { E } from '@endo/eventual-send';
+import { Far, E, passStyleOf } from '@endo/far';
 import { Nat, isNat } from '@endo/nat';
 import {
   provide,

--- a/packages/SwingSet/src/vats/vattp/vat-vattp.js
+++ b/packages/SwingSet/src/vats/vattp/vat-vattp.js
@@ -7,8 +7,7 @@ import {
   provideDurableSetStore,
   provideKindHandle,
 } from '@agoric/vat-data';
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 // See ../../docs/delivery.md for a description of the architecture of the
 // comms system.

--- a/packages/SwingSet/test/basedir-circular/bootstrap.js
+++ b/packages/SwingSet/test/basedir-circular/bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   return Far('root', {

--- a/packages/SwingSet/test/basedir-circular/vat-bob.js
+++ b/packages/SwingSet/test/basedir-circular/vat-bob.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 function makePR() {
   let r;

--- a/packages/SwingSet/test/basedir-controller-2/bootstrap.js
+++ b/packages/SwingSet/test/basedir-controller-2/bootstrap.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   vatPowers.testLog(`buildRootObject called`);

--- a/packages/SwingSet/test/basedir-controller-3/bootstrap.js
+++ b/packages/SwingSet/test/basedir-controller-3/bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {

--- a/packages/SwingSet/test/basedir-controller-3/vat-left.js
+++ b/packages/SwingSet/test/basedir-controller-3/vat-left.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {

--- a/packages/SwingSet/test/basedir-controller-3/vat-right.js
+++ b/packages/SwingSet/test/basedir-controller-3/vat-right.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const obj0 = Far('root', {

--- a/packages/SwingSet/test/basedir-message-patterns/bootstrap-comms.js
+++ b/packages/SwingSet/test/basedir-message-patterns/bootstrap-comms.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 // machine names, to link vattp messages and loopbox channels
 const A = 'A';

--- a/packages/SwingSet/test/basedir-message-patterns/bootstrap-local.js
+++ b/packages/SwingSet/test/basedir-message-patterns/bootstrap-local.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {

--- a/packages/SwingSet/test/basedir-message-patterns/vat-a.js
+++ b/packages/SwingSet/test/basedir-message-patterns/vat-a.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { buildPatterns } from '../message-patterns.js';
 
 export function buildRootObject(vatPowers) {

--- a/packages/SwingSet/test/basedir-message-patterns/vat-b.js
+++ b/packages/SwingSet/test/basedir-message-patterns/vat-b.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { buildPatterns } from '../message-patterns.js';
 
 export function buildRootObject(vatPowers) {

--- a/packages/SwingSet/test/basedir-message-patterns/vat-c.js
+++ b/packages/SwingSet/test/basedir-message-patterns/vat-c.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { buildPatterns } from '../message-patterns.js';
 
 export function buildRootObject(vatPowers) {

--- a/packages/SwingSet/test/basedir-promises-2/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises-2/bootstrap.js
@@ -1,6 +1,5 @@
-import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { Fail } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {

--- a/packages/SwingSet/test/basedir-promises-2/vat-left.js
+++ b/packages/SwingSet/test/basedir-promises-2/vat-left.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const obj0 = Far('root', {

--- a/packages/SwingSet/test/basedir-promises-3/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises-3/bootstrap.js
@@ -1,6 +1,5 @@
-import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   const pk1 = makePromiseKit();

--- a/packages/SwingSet/test/basedir-promises-3/vat-right.js
+++ b/packages/SwingSet/test/basedir-promises-3/vat-right.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 
 export function buildRootObject() {

--- a/packages/SwingSet/test/basedir-promises/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises/bootstrap.js
@@ -1,6 +1,5 @@
-import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 import { Fail } from '@agoric/assert';
 

--- a/packages/SwingSet/test/basedir-promises/vat-left.js
+++ b/packages/SwingSet/test/basedir-promises/vat-left.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;

--- a/packages/SwingSet/test/basedir-promises/vat-right.js
+++ b/packages/SwingSet/test/basedir-promises/vat-right.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {

--- a/packages/SwingSet/test/basedir-transcript/bootstrap.js
+++ b/packages/SwingSet/test/basedir-transcript/bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { Fail } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {

--- a/packages/SwingSet/test/basedir-transcript/vat-left.js
+++ b/packages/SwingSet/test/basedir-transcript/vat-left.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;

--- a/packages/SwingSet/test/basedir-transcript/vat-right.js
+++ b/packages/SwingSet/test/basedir-transcript/vat-right.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {

--- a/packages/SwingSet/test/bootstrap-relay.js
+++ b/packages/SwingSet/test/bootstrap-relay.js
@@ -1,7 +1,6 @@
 import { assert } from '@agoric/assert';
 import { objectMap } from '@agoric/internal';
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { buildManualTimer } from '../tools/manual-timer.js';
 import { makePassableEncoding } from '../tools/passableEncoding.js';
 

--- a/packages/SwingSet/test/bootstrap-syscall-failure.js
+++ b/packages/SwingSet/test/bootstrap-syscall-failure.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { testLog } = vatPowers;

--- a/packages/SwingSet/test/bundling/bootstrap-bundles.js
+++ b/packages/SwingSet/test/bundling/bootstrap-bundles.js
@@ -1,6 +1,5 @@
 import { assert } from '@agoric/assert';
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { importBundle } from '@endo/import-bundle';
 
 export function buildRootObject(vatPowers) {

--- a/packages/SwingSet/test/bundling/vat-disk.js
+++ b/packages/SwingSet/test/bundling/vat-disk.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   return Far('root', {

--- a/packages/SwingSet/test/bundling/vat-install.js
+++ b/packages/SwingSet/test/bundling/vat-install.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   return Far('root', {

--- a/packages/SwingSet/test/bundling/vat-named.js
+++ b/packages/SwingSet/test/bundling/vat-named.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   return Far('root', {

--- a/packages/SwingSet/test/change-parameters/bootstrap-change-parameters.js
+++ b/packages/SwingSet/test/change-parameters/bootstrap-change-parameters.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   let vatAdmin;

--- a/packages/SwingSet/test/change-parameters/vat-carol.js
+++ b/packages/SwingSet/test/change-parameters/vat-carol.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   return Far('root', {

--- a/packages/SwingSet/test/definition/vat-liveslots.js
+++ b/packages/SwingSet/test/definition/vat-liveslots.js
@@ -1,4 +1,4 @@
-import { Far, getInterfaceOf } from '@endo/marshal';
+import { Far, getInterfaceOf } from '@endo/far';
 
 export function buildRootObject() {
   let counter = 0;

--- a/packages/SwingSet/test/definition/vat-setup.js
+++ b/packages/SwingSet/test/definition/vat-setup.js
@@ -1,4 +1,4 @@
-import { Far, getInterfaceOf } from '@endo/marshal';
+import { Far, getInterfaceOf } from '@endo/far';
 
 export function buildRootObject() {
   let counter = 0;

--- a/packages/SwingSet/test/device-bridge-bootstrap.js
+++ b/packages/SwingSet/test/device-bridge-bootstrap.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog } = vatPowers;

--- a/packages/SwingSet/test/device-hooks/bootstrap-device-hook.js
+++ b/packages/SwingSet/test/device-hooks/bootstrap-device-hook.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { D } = vatPowers;

--- a/packages/SwingSet/test/device-mailbox/bootstrap-device-mailbox.js
+++ b/packages/SwingSet/test/device-mailbox/bootstrap-device-mailbox.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { Fail } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {

--- a/packages/SwingSet/test/device-plugin/bootstrap.js
+++ b/packages/SwingSet/test/device-plugin/bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { Fail } from '@agoric/assert';
 import { makePluginManager } from '../../src/vats/plugin-manager.js';
 

--- a/packages/SwingSet/test/device-plugin/pingpong.js
+++ b/packages/SwingSet/test/device-plugin/pingpong.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function bootPlugin() {
   return Far('iface', {

--- a/packages/SwingSet/test/device-plugin/vat-bridge.js
+++ b/packages/SwingSet/test/device-plugin/vat-bridge.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { Fail } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, _vatParameters) {

--- a/packages/SwingSet/test/devices/bootstrap-2.js
+++ b/packages/SwingSet/test/devices/bootstrap-2.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { D, testLog: log } = vatPowers;

--- a/packages/SwingSet/test/devices/bootstrap-3.js
+++ b/packages/SwingSet/test/devices/bootstrap-3.js
@@ -1,5 +1,5 @@
 import { Fail } from '@agoric/assert';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;

--- a/packages/SwingSet/test/devices/bootstrap-5.js
+++ b/packages/SwingSet/test/devices/bootstrap-5.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers, _vatParameters) {
   const { D } = vatPowers;

--- a/packages/SwingSet/test/devices/bootstrap-6.js
+++ b/packages/SwingSet/test/devices/bootstrap-6.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers, _vatParameters) {
   const { D } = vatPowers;

--- a/packages/SwingSet/test/devices/bootstrap-raw.js
+++ b/packages/SwingSet/test/devices/bootstrap-raw.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 
 export function buildRootObject(vatPowers, _vatParameters) {

--- a/packages/SwingSet/test/devices/device-0.js
+++ b/packages/SwingSet/test/devices/device-0.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootDeviceNode() {
   return Far('root', {});

--- a/packages/SwingSet/test/devices/device-1.js
+++ b/packages/SwingSet/test/devices/device-1.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootDeviceNode({ testLog, endowments }) {
   return Far('root', {

--- a/packages/SwingSet/test/devices/device-2.js
+++ b/packages/SwingSet/test/devices/device-2.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootDeviceNode({
   SO,

--- a/packages/SwingSet/test/devices/device-3.js
+++ b/packages/SwingSet/test/devices/device-3.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootDeviceNode({
   setDeviceState,

--- a/packages/SwingSet/test/devices/device-5.js
+++ b/packages/SwingSet/test/devices/device-5.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootDeviceNode() {
   return Far('root', {

--- a/packages/SwingSet/test/devices/device-6.js
+++ b/packages/SwingSet/test/devices/device-6.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootDeviceNode() {
   return Far('root', {

--- a/packages/SwingSet/test/devices/vat-left.js
+++ b/packages/SwingSet/test/devices/vat-left.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { D, testLog: log } = vatPowers;

--- a/packages/SwingSet/test/files-vattp/bootstrap-test-vattp.js
+++ b/packages/SwingSet/test/files-vattp/bootstrap-test-vattp.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { Fail } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {

--- a/packages/SwingSet/test/gc-dead-vat/bootstrap.js
+++ b/packages/SwingSet/test/gc-dead-vat/bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 
 async function sendExport(doomedRoot) {

--- a/packages/SwingSet/test/gc-dead-vat/vat-doomed.js
+++ b/packages/SwingSet/test/gc-dead-vat/vat-doomed.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const pin = [];

--- a/packages/SwingSet/test/gc-device-transfer/bootstrap-gc.js
+++ b/packages/SwingSet/test/gc-device-transfer/bootstrap-gc.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 async function sendAmy(D, dev, testLog, left) {
   const amy = Far('amy', {

--- a/packages/SwingSet/test/gc-device-transfer/device-gc.js
+++ b/packages/SwingSet/test/gc-device-transfer/device-gc.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootDeviceNode({ setDeviceState }) {
   let stash;

--- a/packages/SwingSet/test/gc-device-transfer/vat-left-gc.js
+++ b/packages/SwingSet/test/gc-device-transfer/vat-left-gc.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   return Far('left', {

--- a/packages/SwingSet/test/gc-device-transfer/vat-right-gc.js
+++ b/packages/SwingSet/test/gc-device-transfer/vat-right-gc.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { D, testLog } = vatPowers;

--- a/packages/SwingSet/test/gc/bootstrap.js
+++ b/packages/SwingSet/test/gc/bootstrap.js
@@ -1,5 +1,4 @@
-import { Far } from '@endo/marshal';
-import { E } from '@endo/eventual-send';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   let A = Far('A', { hello() {} });

--- a/packages/SwingSet/test/gc/vat-fake-zoe.js
+++ b/packages/SwingSet/test/gc/vat-fake-zoe.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   const C = Far('Zoe Invitation payment', { hello() {} });

--- a/packages/SwingSet/test/gc/vat-target.js
+++ b/packages/SwingSet/test/gc/vat-target.js
@@ -1,5 +1,4 @@
-import { Far } from '@endo/marshal';
-import { E } from '@endo/eventual-send';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   return Far('root', {

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -3,10 +3,9 @@
 // I turned off dot-notation so eslint won't rewrite the grep-preserving
 // test.stuff patterns.
 
-import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { quote as q } from '@agoric/assert';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { ignore } from './vat-util.js';
 
 // Exercise a set of increasingly complex object-capability message patterns,

--- a/packages/SwingSet/test/metering/metered-dynamic-vat.js
+++ b/packages/SwingSet/test/metering/metered-dynamic-vat.js
@@ -1,5 +1,5 @@
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { meterMe } from './metered-code.js';
 
 export function buildRootObject(_dynamicVatPowers) {

--- a/packages/SwingSet/test/metering/vat-load-dynamic.js
+++ b/packages/SwingSet/test/metering/vat-load-dynamic.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { testLog: log } = vatPowers;

--- a/packages/SwingSet/test/promise-watcher/bootstrap-promise-watcher.js
+++ b/packages/SwingSet/test/promise-watcher/bootstrap-promise-watcher.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 
 export function buildRootObject() {

--- a/packages/SwingSet/test/promise-watcher/vat-upton.js
+++ b/packages/SwingSet/test/promise-watcher/vat-upton.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { initEmpty } from '@agoric/store';
 import { makePromiseKit } from '@endo/promise-kit';
 import {

--- a/packages/SwingSet/test/run-policy/vat-policy-left.js
+++ b/packages/SwingSet/test/run-policy/vat-policy-left.js
@@ -1,5 +1,4 @@
-import { Far } from '@endo/marshal';
-import { E } from '@endo/eventual-send';
+import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 
 export function buildRootObject() {

--- a/packages/SwingSet/test/run-policy/vat-policy-right.js
+++ b/packages/SwingSet/test/run-policy/vat-policy-right.js
@@ -1,5 +1,4 @@
-import { Far } from '@endo/marshal';
-import { E } from '@endo/eventual-send';
+import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 
 // this takes about 5.7M computrons

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeMarshaller } from '@agoric/swingset-liveslots';
 

--- a/packages/SwingSet/test/test-network.js
+++ b/packages/SwingSet/test/test-network.js
@@ -2,7 +2,7 @@
 import { test } from '../tools/prepare-test-env-ava.js';
 
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 import {
   parse,

--- a/packages/SwingSet/test/test-timer-device.js
+++ b/packages/SwingSet/test/test-timer-device.js
@@ -1,7 +1,7 @@
 import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import {
   makeTimerMap,
   curryPollFn,

--- a/packages/SwingSet/test/test-vat-timer.js
+++ b/packages/SwingSet/test/test-vat-timer.js
@@ -1,8 +1,7 @@
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeScalarMapStore } from '@agoric/store';
 import { TimeMath } from '@agoric/time';

--- a/packages/SwingSet/test/timer-device/bootstrap.js
+++ b/packages/SwingSet/test/timer-device/bootstrap.js
@@ -1,6 +1,6 @@
 import { Fail } from '@agoric/assert';
 import { Nat } from '@endo/nat';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;

--- a/packages/SwingSet/test/timer/bootstrap-timer.js
+++ b/packages/SwingSet/test/timer/bootstrap-timer.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   let ts;

--- a/packages/SwingSet/test/upgrade/bootstrap-scripted-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-scripted-upgrade.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { assert } from '@agoric/assert';
 import { makePromiseKit } from '@endo/promise-kit';
 

--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade-replay.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade-replay.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   let vatAdmin;

--- a/packages/SwingSet/test/upgrade/vat-ulrik-1.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-1.js
@@ -1,5 +1,4 @@
-import { Far } from '@endo/marshal';
-import { E } from '@endo/eventual-send';
+import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { initEmpty } from '@agoric/store';
 import {

--- a/packages/SwingSet/test/upgrade/vat-ulrik-2.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-2.js
@@ -1,5 +1,4 @@
-import { Far } from '@endo/marshal';
-import { E } from '@endo/eventual-send';
+import { Far, E } from '@endo/far';
 import { assert } from '@agoric/assert';
 import { initEmpty } from '@agoric/store';
 import { defineDurableKind, defineDurableKindMulti } from '@agoric/vat-data';

--- a/packages/SwingSet/test/upgrade/vat-upton-replay.js
+++ b/packages/SwingSet/test/upgrade/vat-upton-replay.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   let counter = 0;

--- a/packages/SwingSet/test/vat-activityhash-comms.js
+++ b/packages/SwingSet/test/vat-activityhash-comms.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   let comms;

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   let admin;

--- a/packages/SwingSet/test/vat-admin/new-vat-13.js
+++ b/packages/SwingSet/test/vat-admin/new-vat-13.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   const { adder } = vatParameters;

--- a/packages/SwingSet/test/vat-admin/new-vat-44.js
+++ b/packages/SwingSet/test/vat-admin/new-vat-44.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   const { adder } = vatParameters;

--- a/packages/SwingSet/test/vat-admin/new-vat-refcount.js
+++ b/packages/SwingSet/test/vat-admin/new-vat-refcount.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   const { held } = vatParameters;

--- a/packages/SwingSet/test/vat-admin/replay-bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/replay-bootstrap.js
@@ -1,6 +1,5 @@
-import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   const { promise: vatAdminSvc, resolve: gotVatAdminSvc } = makePromiseKit();

--- a/packages/SwingSet/test/vat-admin/replay-dynamic.js
+++ b/packages/SwingSet/test/vat-admin/replay-dynamic.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   let counter = 0;

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-badVatKey.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-badVatKey.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   return Far('root', {

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-cleanly.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-cleanly.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   let dude;

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-with-presence.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-with-presence.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-no-zombies.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-no-zombies.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   const self = Far('root', {

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-speak-to-dead.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-speak-to-dead.js
@@ -1,6 +1,5 @@
-import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate-with-presence.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate-with-presence.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;

--- a/packages/SwingSet/test/vat-admin/terminate/vat-dude-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/vat-dude-terminate.js
@@ -1,6 +1,5 @@
-import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   // we use testLog to attempt to deliver messages even after we're supposed

--- a/packages/SwingSet/test/vat-admin/terminate/vat-medium-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/vat-medium-terminate.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;

--- a/packages/SwingSet/test/vat-admin/terminate/vat-weatherwax-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/vat-weatherwax-terminate.js
@@ -1,5 +1,5 @@
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   // we use testLog to attempt to deliver messages even after we're supposed

--- a/packages/SwingSet/test/vat-admin/vat-export-held.js
+++ b/packages/SwingSet/test/vat-admin/vat-export-held.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   return Far('root', {

--- a/packages/SwingSet/test/vat-durable-promise-watcher.js
+++ b/packages/SwingSet/test/vat-durable-promise-watcher.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { getCopyMapEntries, M } from '@agoric/store';
 import { makePromiseKit } from '@endo/promise-kit';
 import {

--- a/packages/SwingSet/test/vat-envtest.js
+++ b/packages/SwingSet/test/vat-envtest.js
@@ -1,5 +1,5 @@
 /* global VatData */
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;

--- a/packages/SwingSet/test/vat-exomessages.js
+++ b/packages/SwingSet/test/vat-exomessages.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   const other = Far('other', {

--- a/packages/SwingSet/test/vat-exporter.js
+++ b/packages/SwingSet/test/vat-exporter.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { M, defineExoClass } from '@agoric/store';
 import {
   defineVirtualExoClass,

--- a/packages/SwingSet/test/vat-timer-upgrade/bootstrap-vat-timer-upgrade.js
+++ b/packages/SwingSet/test/vat-timer-upgrade/bootstrap-vat-timer-upgrade.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   let ts;

--- a/packages/SwingSet/test/vat-warehouse/bootstrap.js
+++ b/packages/SwingSet/test/vat-warehouse/bootstrap.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   // eslint-disable-next-line no-unused-vars

--- a/packages/SwingSet/test/vat-warehouse/vat-preload-bootstrap.js
+++ b/packages/SwingSet/test/vat-warehouse/vat-preload-bootstrap.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   const extras = new Map(); // count -> root

--- a/packages/SwingSet/test/vat-warehouse/vat-preload-extra.js
+++ b/packages/SwingSet/test/vat-warehouse/vat-preload-extra.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(_vatPowers, _vatParameters) {
   // console.log(`extra: ${vatParameters.name}`);

--- a/packages/SwingSet/test/vat-warehouse/vat-target.js
+++ b/packages/SwingSet/test/vat-warehouse/vat-target.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(_vatPowers, _vatParameters) {
   const contents = [];

--- a/packages/SwingSet/test/vat-warehouse/vat-warehouse-reload.js
+++ b/packages/SwingSet/test/vat-warehouse/vat-warehouse-reload.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { testLog: log } = vatPowers;

--- a/packages/SwingSet/test/vat-xsnap-hang.js
+++ b/packages/SwingSet/test/vat-xsnap-hang.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootObject() {
   return Far('root', {

--- a/packages/SwingSet/test/virtualObjects/collection-slots/bootstrap-collection-slots.js
+++ b/packages/SwingSet/test/virtualObjects/collection-slots/bootstrap-collection-slots.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   // build the import sensor

--- a/packages/SwingSet/test/virtualObjects/collection-slots/vat-collection-slots.js
+++ b/packages/SwingSet/test/virtualObjects/collection-slots/vat-collection-slots.js
@@ -1,5 +1,5 @@
 /* global VatData */
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 // import { makeScalarBigMapStore } from '@agoric/vat-data';
 const { makeScalarBigMapStore } = VatData;

--- a/packages/SwingSet/test/virtualObjects/delete-stored-vo/bootstrap-delete-stored-vo.js
+++ b/packages/SwingSet/test/virtualObjects/delete-stored-vo/bootstrap-delete-stored-vo.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   // build the import sensor

--- a/packages/SwingSet/test/virtualObjects/delete-stored-vo/vat-delete-stored-vo.js
+++ b/packages/SwingSet/test/virtualObjects/delete-stored-vo/vat-delete-stored-vo.js
@@ -1,5 +1,5 @@
 /* global VatData */
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 // import { defineKind, makeScalarBigMapStore } from '@agoric/vat-data';
 const { defineKind, makeScalarBigMapStore } = VatData;

--- a/packages/SwingSet/test/virtualObjects/double-retire-import/bootstrap-dri.js
+++ b/packages/SwingSet/test/virtualObjects/double-retire-import/bootstrap-dri.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   let vatAdmin;

--- a/packages/SwingSet/test/virtualObjects/double-retire-import/vat-dri.js
+++ b/packages/SwingSet/test/virtualObjects/double-retire-import/vat-dri.js
@@ -1,5 +1,5 @@
 /* global VatData */
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 // import { defineKind } from '@agoric/vat-data';
 const { defineKind } = VatData;
 

--- a/packages/SwingSet/test/virtualObjects/vat-orphan-bob.js
+++ b/packages/SwingSet/test/virtualObjects/vat-orphan-bob.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { initEmpty } from '@agoric/store';
 import { defineKindMulti } from '@agoric/vat-data';
 

--- a/packages/SwingSet/test/virtualObjects/vat-orphan-bootstrap.js
+++ b/packages/SwingSet/test/virtualObjects/vat-orphan-bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {

--- a/packages/SwingSet/test/virtualObjects/vat-representative-bootstrap.js
+++ b/packages/SwingSet/test/virtualObjects/vat-representative-bootstrap.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { defineKind } from '@agoric/vat-data';
 
 const makeThing = defineKind(

--- a/packages/SwingSet/test/virtualObjects/vat-vom-gc-bob.js
+++ b/packages/SwingSet/test/virtualObjects/vat-vom-gc-bob.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { defineKind } from '@agoric/vat-data';
 
 const things = [];

--- a/packages/SwingSet/test/virtualObjects/vat-vom-gc-bootstrap.js
+++ b/packages/SwingSet/test/virtualObjects/vat-vom-gc-bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   // eslint thinks 'other' is unused, but eslint is wrong.

--- a/packages/SwingSet/test/virtualObjects/vat-weakcollections-alice.js
+++ b/packages/SwingSet/test/virtualObjects/vat-weakcollections-alice.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { defineKind } from '@agoric/vat-data';
 
 const makeHolder = defineKind('holder-vo', value => ({ value }), {

--- a/packages/SwingSet/test/virtualObjects/vat-weakcollections-bootstrap.js
+++ b/packages/SwingSet/test/virtualObjects/vat-weakcollections-bootstrap.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;

--- a/packages/SwingSet/test/virtualObjects/vdata-promises/bootstrap-vdata-promises.js
+++ b/packages/SwingSet/test/virtualObjects/vdata-promises/bootstrap-vdata-promises.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 
 export function buildRootObject() {

--- a/packages/SwingSet/test/virtualObjects/vdata-promises/vat-vdata-promises.js
+++ b/packages/SwingSet/test/virtualObjects/vdata-promises/vat-vdata-promises.js
@@ -1,6 +1,5 @@
 /* global VatData */
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 
 // import { makeScalarBigMapStore } from '@agoric/vat-data';

--- a/packages/SwingSet/test/vo-test-harness/vat-dvo-test-test.js
+++ b/packages/SwingSet/test/vo-test-harness/vat-dvo-test-test.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import {
   provide,
   provideKindHandle,

--- a/packages/SwingSet/test/workers/bootstrap.js
+++ b/packages/SwingSet/test/workers/bootstrap.js
@@ -1,6 +1,5 @@
-import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export function buildRootObject() {
   const callbackObj = Far('callback', {

--- a/packages/SwingSet/test/workers/device-add.js
+++ b/packages/SwingSet/test/workers/device-add.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export function buildRootDeviceNode() {
   return Far('root', {

--- a/packages/SwingSet/test/workers/vat-target.js
+++ b/packages/SwingSet/test/workers/vat-target.js
@@ -1,6 +1,5 @@
-import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 function ignore(p) {
   p.then(

--- a/packages/SwingSet/test/xsnap-snapshots/bootstrap-snapshots.js
+++ b/packages/SwingSet/test/xsnap-snapshots/bootstrap-snapshots.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 
 export const buildRootObject = () => {
   let count = 0;

--- a/packages/SwingSet/test/zcf-ish-upgrade/bootstrap-zcf-ish-upgrade.js
+++ b/packages/SwingSet/test/zcf-ish-upgrade/bootstrap-zcf-ish-upgrade.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 
 export const buildRootObject = () => {
   let vatAdmin;

--- a/packages/SwingSet/test/zcf-ish-upgrade/pseudo-zcf.js
+++ b/packages/SwingSet/test/zcf-ish-upgrade/pseudo-zcf.js
@@ -1,7 +1,7 @@
 /* global VatData */
 /* eslint-disable no-unused-vars */
 
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { importBundle } from '@endo/import-bundle';
 import { defineDurableKind } from '@agoric/vat-data';
 import { assert } from '@agoric/assert';

--- a/packages/SwingSet/tools/bootstrap-dvo-test.js
+++ b/packages/SwingSet/tools/bootstrap-dvo-test.js
@@ -1,5 +1,4 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
+import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 
 export function buildRootObject() {

--- a/packages/SwingSet/tools/manual-timer.js
+++ b/packages/SwingSet/tools/manual-timer.js
@@ -1,4 +1,4 @@
-import { Far } from '@endo/marshal';
+import { Far } from '@endo/far';
 import { makeScalarMapStore } from '@agoric/store';
 import { bindAllMethods } from '@agoric/internal';
 import { buildRootObject } from '../src/vats/timer/vat-timer.js';

--- a/packages/SwingSet/tools/passableEncoding.js
+++ b/packages/SwingSet/tools/passableEncoding.js
@@ -1,5 +1,5 @@
 import { assert } from '@agoric/assert';
-import { E } from '@endo/eventual-send';
+import { E } from '@endo/far';
 import { isObject, makeMarshal } from '@endo/marshal';
 
 const { Fail, quote: q } = assert;


### PR DESCRIPTION
Cleans up imports from Endo, getting things from `@endo/far` when that's where they should come from.

Does _not_ yet obtain `Remotable` from `@endo/pass-style` because the version of that package that Endo currently exports does not pass type checking.

Closes #6830
