### PR TITLE
[LOW PRIORITY] chore: Improve liveslots-related types and documentation

### DIFF
--- a/packages/SwingSet/README.md
+++ b/packages/SwingSet/README.md
@@ -68,6 +68,8 @@ anything else.
 
 ## Vat Sources
 
+**TODO: This is outdated, should content from docs/static-vats.md move here?**
+
 Each Vat source file (like `vat-foo.js` or `vat-bar.js`) is treated as a
 starting point for the `rollup` tool, which converts the Vat's source tree
 into a single string (so it can be evaluated in a SES realm). This starting

--- a/packages/SwingSet/docs/static-vats.md
+++ b/packages/SwingSet/docs/static-vats.md
@@ -8,11 +8,13 @@ This document describes how you define and configure the static vats.
 
 ## Creating a Static Vat
 
+**TODO: Should this move into the SwingSet README and be replaced with a link to there?**
+
 The source code for all static vats must be available at the time the host application starts up. This source code, and its dependencies, must not change for the lifetime of the SwingSet machine (which, through persistence and the kernel state database, extends beyond a single process). Applications are encouraged to copy the static vat sources into a working directory during some sort of "init" step, where they'll remain untouched by normal development work on the original files. But note that this won't protect against changes in dependencies.
 
-Static vats are defined by a JS module file which exports a function named `buildRootObject`. The file may export other names; these are currently ignored. The module can import other modules, as long as they are pure JS (no native modules or binary libraries), and they are compatible with SES. See `vat-environment.md` for details of the kind of JS you can use. The static vat file will be scanned for its imports, and the entire dependency graph will be merged into a single "source bundle" object when the kernel first launches.
+Static vats are defined by a JS module file which exports a function named `buildRootObject` to be called by "liveslots", a layer which provides vats with an object-capability environment. The file may export other names; these are currently ignored. The module can import other modules, as long as they are pure JS (no native modules or binary libraries) and are compatible with SES. See [vat-environment.md](./vat-environment.md) for details of the kind of JS you can use. The static vat file will be scanned for its imports, and the entire dependency graph will be merged into a single "source bundle" object when the kernel first launches.
 
-The `buildRootObject` function will be called with one object, named `vatPowers`. The contents of `vatPowers` are subject to change, but in general it provides pure functions which are inconvenient to access as imports, and vat-specific authorities that are not easy to express through syscalls. See below for the current property list.
+Liveslots will call the `buildRootObject` function with one argument: a `vatPowers` object. The contents of `vatPowers` are subject to change, but in general it provides pure functions which are inconvenient to access as imports, and vat-specific authorities that are not easy to express through syscalls. See [below](#vatpowers) for the current property list.
 
 `buildRootObject` must return a hardened "ephemeral" object, as documented in [swingset-liveslots](https://github.com/Agoric/agoric-sdk/blob/master/packages/swingset-liveslots/docs/liveslots.md#buildrootobject). A common way to do this is with the `Far` function:
 
@@ -44,9 +46,9 @@ The *bootstrap function* is the method named `bootstrap` on a special *bootstrap
 
 ### Legacy setup() Function
 
-More generally, vats are defined in terms of a `syscall` object (for the vat to send instructions into the kernel), and a `dispatch` object (for the kernel to send messages into the vat). Vats can provide a `setup()` function which is given a `syscall`, among other things, and are expected to return a `dispatch`. Vats defined this way are not obligated to provide object-capability security within the vat. For example, `syscall.send()` can be used to send a message to any remote object that has ever been granted to anything within the vat. If everything within the vat can reach `syscall`, then every object within the vat is as powerful as any other, and there is no partitioning of authority within the vat.
+More generally, vats are defined in terms of a `syscall` object (for the vat to send instructions into the kernel), and a `dispatch` object (for the kernel to send messages into the vat). As a legacy low-level alternative to exporting a `buildRootObject` function for liveslots, vats can `export default` a `setup` function which is given a `syscall` object and the `vatPowers` object and must return a `dispatch` object. Vats defined this way are not obligated to provide object-capability security within the vat. For example, code within the vat that has access to `syscall` can use it to send a message to a remote object that is known only to _other_ code within the vat.
 
-Most vats use "liveslots", a layer which provides an object-capability environment within a vat. Liveslots is a library which provides a `makeLiveslots()` function. Vats which use liveslots will export a `setup()` function which calls `makeLiveslots()` internally. These vats tend to have boilerplate like this:
+Such vats can still use liveslots with a bit of boilerplate:
 
 ```js
 import { makeSimpleMeterControl } from '@agoric/swingset-vat';
@@ -62,7 +64,7 @@ export default function setup(syscall, state, helpers, vatPowers) {
   const gcTools = harden({
     WeakRef,
     FinalizationRegistry,
-    waitUntilQuiescent: () => 
+    waitUntilQuiescent: () =>
       new Promise(resolve => setImmediate(() => resolve())),
     gcAndFinalize: () => {},
     meterControl: makeSimpleMeterControl(),
@@ -81,9 +83,9 @@ export default function setup(syscall, state, helpers, vatPowers) {
 }
 ```
 
-These vats are still supported, for now. Any vat source file which exports `buildRootObject()` will automatically use liveslots. If the file does *not* export `buildRootObject()`, it is expected to export a `default` function that behaves like the `setup()` described above.
+These vats are still supported, for now. Any vat source file which exports `buildRootObject` will automatically use liveslots. If the file does *not* export `buildRootObject`, it is expected to `export default` a function that behaves like the `setup` described above.
 
-A few vats do not use liveslots. The main one is the "comms vat", which performs low-level mapping of kernel-sourced messages into strings that are sent off-machine to other swingsets. This mapping would be rather inefficient if it went through the serialization/deserialization layers that liveslots provides to normal vats. The comms vat will eventually be loaded with some special configuration flag to mark it as non-liveslots, rather than retaining the `default`/`setup()` fallback.
+A few vats do not use liveslots. The main one is the "comms vat", which performs low-level mapping of kernel-sourced messages into strings that are sent off-machine to other swingsets. This mapping would be rather inefficient if it went through the serialization/deserialization layers that liveslots provides to normal vats. The comms vat will eventually be loaded with some special configuration flag to mark it as non-liveslots, at which point we can drop the `export default` fallback.
 
 ## VatPowers
 

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -129,7 +129,7 @@ async function replay(transcriptFile) {
         },
       }
     : makeSnapStore(process.cwd(), () => {}, makeSnapStoreIO());
-  const testLog = undefined;
+  const testLog = (..._args) => {};
   const meterControl = makeDummyMeterControl();
   const gcTools = harden({
     WeakRef,

--- a/packages/SwingSet/src/index.js
+++ b/packages/SwingSet/src/index.js
@@ -19,6 +19,8 @@ export { buildBridge } from './devices/bridge/bridge.js';
 export { default as buildCommand } from './devices/command/command.js';
 export { buildPlugin } from './devices/plugin/plugin.js';
 
+export { makeDummyMeterControl as makeSimpleMeterControl } from './kernel/dummyMeterControl.js';
+
 // eslint-disable-next-line import/export
 export * from './types-external.js';
 

--- a/packages/SwingSet/src/kernel/vat-loader/types.js
+++ b/packages/SwingSet/src/kernel/vat-loader/types.js
@@ -7,7 +7,7 @@
 
 /**
  * @callback BuildRootObjectForTestVat
- * @param {VatPowers & {testLog: (msg: any)=> void}} vatPowers
+ * @param {VatPowers & {testLog: (...args: unknown[]) => void}} vatPowers
  * @param {Record<string, unknown> & {argv: string[]}} vatParameters
  * @returns {unknown}
  */

--- a/packages/SwingSet/src/supervisors/supervisor-helper.js
+++ b/packages/SwingSet/src/supervisors/supervisor-helper.js
@@ -8,11 +8,10 @@ import '../types-ambient.js';
 /**
  * @typedef {import('@agoric/swingset-liveslots').VatDeliveryObject} VatDeliveryObject
  * @typedef {import('@agoric/swingset-liveslots').VatDeliveryResult} VatDeliveryResult
+ * @typedef {import('@agoric/swingset-liveslots').VatDeliveryProcessor} LiveslotsVatDeliveryProcessor
  * @typedef {import('@agoric/swingset-liveslots').VatSyscallObject} VatSyscallObject
  * @typedef {import('@agoric/swingset-liveslots').VatSyscaller} VatSyscaller
  * @typedef {import('@endo/marshal').CapData<string>} SwingSetCapData
- * @typedef { (delivery: VatDeliveryObject) => (VatDeliveryResult | Promise<VatDeliveryResult>) } VatDispatcherSyncAsync
- * @typedef { (delivery: VatDeliveryObject) => Promise<VatDeliveryResult> } VatDispatcher
  */
 
 /**
@@ -22,8 +21,8 @@ import '../types-ambient.js';
  * function with this one, and call it in response to messages from the
  * manager process.
  *
- * @param {VatDispatcherSyncAsync} dispatch
- * @returns {VatDispatcher}
+ * @param {LiveslotsVatDeliveryProcessor} dispatch
+ * @returns { (delivery: VatDeliveryObject) => Promise<VatDeliveryResult> }
  */
 function makeSupervisorDispatch(dispatch) {
   /**

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -836,15 +836,15 @@ function build(
     return result;
   }
 
-  function revivePromise(slot) {
+  function revivePromise(vpid) {
     meterControl.assertNotMetered();
-    const { type } = parseVatSlot(slot);
-    type === 'promise' || Fail`revivePromise called on non-promise ${slot}`;
-    !getValForSlot(slot) || Fail`revivePromise called on pre-existing ${slot}`;
-    const pRec = makePipelinablePromise(slot);
-    importedVPIDs.set(slot, pRec);
+    const { type } = parseVatSlot(vpid);
+    type === 'promise' || Fail`revivePromise called on non-promise ${vpid}`;
+    !getValForSlot(vpid) || Fail`revivePromise called on pre-existing ${vpid}`;
+    const pRec = makePipelinablePromise(vpid);
+    importedVPIDs.set(vpid, pRec);
     const p = pRec.promise;
-    registerValue(slot, p);
+    registerValue(vpid, p);
     return p;
   }
   const unmeteredRevivePromise = meterControl.unmetered(revivePromise);

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -23,25 +23,46 @@ const DEFAULT_VIRTUAL_OBJECT_CACHE_SIZE = 3; // XXX ridiculously small value to 
 const SYSCALL_CAPDATA_BODY_SIZE_LIMIT = 10_000_000;
 const SYSCALL_CAPDATA_SLOTS_LENGTH_LIMIT = 10_000;
 
-// 'makeLiveSlots' is a dispatcher which uses javascript Maps to keep track
+// 'makeLiveSlots' returns a dispatcher which uses javascript Maps to keep track
 // of local objects which have been exported. These cannot be persisted
 // beyond the runtime of the javascript environment, so this mechanism is not
 // going to work for our in-chain hosts.
+
+/**
+ * @typedef {string} Vref
+ *
+ * @typedef {{WeakMap: typeof WeakMap, WeakSet: typeof WeakSet}} WeakConstructors
+ *
+ * @callback BuildRootObject
+ * @param {*} [vatPowers]
+ * @param {*} [vatParameters]
+ * @param {import('@agoric/vat-data').Baggage} [baggage]
+ * @returns {object | Promise<object>}
+ *
+ * @callback BuildVatNamespace
+ * @param {{VatData: import('@agoric/vat-data').VatData}} [vatGlobals]
+ * @param {WeakConstructors} [inescapableGlobalProperties]
+ * @returns {{buildRootObject: BuildRootObject}}
+ */
 
 /**
  * Instantiate the liveslots layer for a new vat and then populate the vat with
  * a new root object and its initial associated object graph, if any.
  *
  * @param {*} syscall  Kernel syscall interface that the vat will have access to
- * @param {*} forVatID  Vat ID label, for use in debug diagnostics
+ * @param {string} forVatID  Vat ID label, for use in debug diagnostics
  * @param {*} vatPowers
  * @param {import('./types').LiveSlotsOptions} liveSlotsOptions
- * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent, gcAndFinalize,
- *                      meterControl }
+ * @param {import('./types').GcTools} gcTools
  * @param {Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>} console
- * @param {*} buildVatNamespace
+ * @param {BuildVatNamespace} buildVatNamespace
  *
- * @returns {*} { dispatch }
+ * @returns {{
+ *   dispatch: import('./types').VatDeliveryProcessor,
+ *   m: ReturnType<typeof import('@endo/marshal').makeMarshal>,
+ *   possiblyDeadSet: Set<Vref>,
+ *   testHooks: object,
+ * }}
  */
 function build(
   syscall,
@@ -1627,11 +1648,11 @@ function build(
       // only after userspace is idle).
       return gcTools.waitUntilQuiescent().then(() => {
         afterDispatchActions();
-        // eslint-disable-next-line prefer-promise-reject-errors
-        return complete ? p : Promise.reject('buildRootObject unresolved');
         // the only delivery that pays attention to a user-provided
         // Promise is startVat, so the error message is specialized to
         // the only user problem that could cause complete===false
+        // eslint-disable-next-line prefer-promise-reject-errors
+        return complete ? p : Promise.reject('buildRootObject unresolved');
       });
     }
   }
@@ -1654,17 +1675,24 @@ function build(
  * @param {*} forVatID  Vat ID label, for use in debug diagostics
  * @param {*} vatPowers
  * @param {import('./types').LiveSlotsOptions} liveSlotsOptions
- * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent }
+ * @param {import('./types').GcTools} gcTools
  * @param {Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>} [liveSlotsConsole]
- * @param {*} [buildVatNamespace]
+ * @param {*} [buildVatNamespace] TODO: make required and move before console
  *
- * @returns {*} { dispatch }
+ * @returns {{
+ *   dispatch: import('./types').VatDeliveryProcessor,
+ *   possiblyDeadSet: Set<Vref>,
+ *   testHooks: object,
+ * }}
  *
- * setBuildRootObject should be called, once, with a function that will
- * create a root object for the new vat The caller provided buildRootObject
- * function produces and returns the new vat's root object:
- *
- * buildRootObject(vatPowers, vatParameters)
+ * When the returned `dispatch` function receives a 'startVat' delivery (which
+ * must only happen once and must precede any 'message' or 'notify' delivery),
+ * it will invoke the provided `buildVatNamespace` function to get an object
+ * from which it can extract a `buildRootObject` function and use that to
+ * create a root object for the new vat with an invocation like
+ * ```js
+ * const rootObject = await buildRootObject(vatPowers, vatParameters, baggage);
+ * ```
  *
  * Within the vat, `import { E } from '@endo/eventual-send'` will
  * provide the E wrapper. For any object x, E(x) returns a proxy object
@@ -1698,7 +1726,7 @@ export function makeLiveSlots(
     liveSlotsOptions,
     gcTools,
     liveSlotsConsole,
-    buildVatNamespace,
+    /** @type {BuildVatNamespace} */ (buildVatNamespace),
   );
   const { dispatch, possiblyDeadSet, testHooks } = r; // omit 'm'
   return harden({
@@ -1710,7 +1738,17 @@ export function makeLiveSlots(
 
 // for tests
 export function makeMarshaller(syscall, gcTools, vatID = 'forVatID') {
-  // @ts-expect-error missing buildVatNamespace param
-  const { m } = build(syscall, vatID, {}, {}, gcTools, console);
+  const vatPowers = {};
+  const options = {};
+  const buildRootObject = () => Fail`Unexpected attempt to build vat`;
+  const { m } = build(
+    syscall,
+    vatID,
+    vatPowers,
+    options,
+    gcTools,
+    console,
+    () => ({ buildRootObject }),
+  );
   return { m };
 }

--- a/packages/swingset-liveslots/src/types.js
+++ b/packages/swingset-liveslots/src/types.js
@@ -11,11 +11,23 @@
  *
  * @typedef {object} MeterControl
  * @property {() => boolean} isMeteringDisabled Ask whether metering is currently disabled.
- * @property {*} assertIsMetered
- * @property {*} assertNotMetered
- * @property {*} runWithoutMetering Run a callback outside metering
- * @property {*} runWithoutMeteringAsync Run an async callback outside metering
- * @property {*} unmetered Wrap a callback with runWithoutMetering
+ * @property {() => void} assertIsMetered
+ * @property {() => void} assertNotMetered
+ * @property {(fn: () => any) => ReturnType<fn>} runWithoutMetering Run a callback outside metering
+ * @property {(fn: () => any) => Promise<ReturnType<fn>>} runWithoutMeteringAsync Run an async callback outside metering
+ * @property {(fn: (...args: unknown[]) => any) => typeof fn} unmetered Wrap a callback with runWithoutMetering
+ */
+
+/**
+ * GcTools is the interface through which liveslots interacts with
+ * host environment garbage collection.
+ *
+ * @typedef {object} GcTools
+ * @property {typeof WeakRef} WeakRef
+ * @property {typeof FinalizationRegistry} FinalizationRegistry
+ * @property {() => Promise<void>} waitUntilQuiescent
+ * @property {() => Promise<void>} gcAndFinalize
+ * @property {MeterControl} meterControl
  */
 
 /**
@@ -47,9 +59,10 @@
  *          } VatDeliveryObject
  *
  * @typedef { { compute: number } } MeterConsumption
- * @typedef { [tag: 'ok', message: null, usage: MeterConsumption | null] |
- *            [tag: 'error', message: string, usage: MeterConsumption | null] } VatDeliveryResult
+ * @typedef { [tag: 'ok', problem: null, usage: MeterConsumption | null] |
+ *            [tag: 'error', problem: string, usage: MeterConsumption | null] } VatDeliveryResult
  *
+ * @typedef { (delivery: VatDeliveryObject) => (void | Promise<void>) } VatDeliveryProcessor
  *
  * @typedef { [tag: 'send', target: string, msg: Message] } VatSyscallSend
  * @typedef { [tag: 'callNow', target: string, method: string, args: SwingSetCapData]} VatSyscallCallNow

--- a/packages/swingset-liveslots/test/util.js
+++ b/packages/swingset-liveslots/test/util.js
@@ -47,54 +47,84 @@ export function buildDispatch(onDispatchCallback) {
 }
 
 /**
- *
- * @param {unknown} target
+ * @param {string} target
  * @param {string} method
  * @param {any[]} args
- * @param {unknown} result
+ * @param {string | null | undefined} result
+ * @returns {import('../src/types.js').VatDeliveryMessage}
  */
 export function makeMessage(target, method, args = [], result = null) {
   const methargs = kser([method, args]);
   const msg = { methargs, result };
+  /** @type {import('../src/types.js').VatDeliveryMessage} */
   const vatDeliverObject = harden(['message', target, msg]);
   return vatDeliverObject;
 }
 
+/**
+ * @param {import('../src/types.js').SwingSetCapData} vatParameters
+ * @returns {import('../src/types.js').VatDeliveryStartVat}
+ */
 export function makeStartVat(vatParameters) {
+  /** @type {import('../src/types.js').VatDeliveryStartVat} */
   return harden(['startVat', vatParameters]);
 }
 
+/**
+ * @returns {import('../src/types.js').VatDeliveryBringOutYourDead}
+ */
 export function makeBringOutYourDead() {
   return harden(['bringOutYourDead']);
 }
 
+/**
+ * @param {import('../src/types.js').VatOneResolution[]} resolutions
+ * @returns {import('../src/types.js').VatDeliveryNotify}
+ */
 export function makeResolutions(resolutions) {
+  /** @type {import('../src/types.js').VatDeliveryNotify} */
   const vatDeliverObject = harden(['notify', resolutions]);
   return vatDeliverObject;
 }
 
 export function makeResolve(target, result) {
+  /** @type {[import('../src/types.js').VatOneResolution]} */
   const resolutions = [[target, false, result]];
   return makeResolutions(resolutions);
 }
 
 export function makeReject(target, result) {
+  /** @type {[import('../src/types.js').VatOneResolution]} */
   const resolutions = [[target, true, result]];
-  const vatDeliverObject = harden(['notify', resolutions]);
-  return vatDeliverObject;
+  return makeResolutions(resolutions);
 }
 
+/**
+ * @param {string[]} vrefs
+ * @returns {import('../src/types.js').VatDeliveryDropExports}
+ */
 export function makeDropExports(...vrefs) {
+  /** @type {import('../src/types.js').VatDeliveryDropExports} */
   const vatDeliverObject = harden(['dropExports', vrefs]);
   return vatDeliverObject;
 }
 
+/**
+ * @param {string[]} vrefs
+ * @returns {import('../src/types.js').VatDeliveryRetireExports}
+ */
 export function makeRetireExports(...vrefs) {
+  /** @type {import('../src/types.js').VatDeliveryRetireExports} */
   const vatDeliverObject = harden(['retireExports', vrefs]);
   return vatDeliverObject;
 }
 
+/**
+ * @param {string[]} vrefs
+ * @returns {import('../src/types.js').VatDeliveryRetireImports}
+ */
 export function makeRetireImports(...vrefs) {
+  /** @type {import('../src/types.js').VatDeliveryRetireImports} */
   const vatDeliverObject = harden(['retireImports', vrefs]);
   return vatDeliverObject;
 }

--- a/packages/swingset-xsnap-supervisor/lib/supervisor-helper.js
+++ b/packages/swingset-xsnap-supervisor/lib/supervisor-helper.js
@@ -7,11 +7,10 @@ import {
 /**
  * @typedef {import('@agoric/swingset-liveslots').VatDeliveryObject} VatDeliveryObject
  * @typedef {import('@agoric/swingset-liveslots').VatDeliveryResult} VatDeliveryResult
+ * @typedef {import('@agoric/swingset-liveslots').VatDeliveryProcessor} LiveslotsVatDeliveryProcessor
  * @typedef {import('@agoric/swingset-liveslots').VatSyscallObject} VatSyscallObject
  * @typedef {import('@agoric/swingset-liveslots').VatSyscaller} VatSyscaller
  * @typedef {import('@endo/marshal').CapData<string>} SwingSetCapData
- * @typedef { (delivery: VatDeliveryObject) => (VatDeliveryResult | Promise<VatDeliveryResult>) } VatDispatcherSyncAsync
- * @typedef { (delivery: VatDeliveryObject) => Promise<VatDeliveryResult> } VatDispatcher
  */
 
 /**
@@ -21,8 +20,8 @@ import {
  * function with this one, and call it in response to messages from the
  * manager process.
  *
- * @param {VatDispatcherSyncAsync} dispatch
- * @returns {VatDispatcher}
+ * @param {LiveslotsVatDeliveryProcessor} dispatch
+ * @returns { (delivery: VatDeliveryObject) => Promise<VatDeliveryResult> }
  */
 function makeSupervisorDispatch(dispatch) {
   /**

--- a/packages/vat-data/src/index.js
+++ b/packages/vat-data/src/index.js
@@ -40,6 +40,7 @@ export {
   prepareSingleton,
 } from './exo-utils.js';
 
+/** @typedef {import('./types.js').VatData} VatData */
 /** @typedef {import('./types.js').Baggage} Baggage */
 /** @typedef {import('./types.js').DurableKindHandle} DurableKindHandle */
 /** @template T @typedef {import('./types.js').DefineKindOptions<T>} DefineKindOptions */


### PR DESCRIPTION
## Description

Addressing some incidental issues noticed as part of #7244:
* Fix a stale `setup`-style example
* Clarify the explanations of `buildRootObject` vs. `setup`
* Improve type definitions

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

packages/SwingSet/README.md is quite stale, and content in packages/SwingSet/docs/static-vats.md duplicates that but seems like it would be better placed there. Should this PR include such a move?

### Testing Considerations

n/a