### PR TITLE
Fix every assert!!  For great speediness!

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -269,11 +269,8 @@ export async function makeSwingsetController(
     assert.typeof(endoZipBase64Sha512, 'string');
     const bundleID = `b1-${endoZipBase64Sha512}`;
     if (allegedBundleID !== undefined) {
-      assert.equal(
-        bundleID,
-        allegedBundleID,
-        `alleged bundleID ${allegedBundleID} does not match actual ${bundleID}`,
-      );
+      bundleID === allegedBundleID ||
+        Fail`alleged bundleID ${allegedBundleID} does not match actual ${bundleID}`;
     }
     await kernel.installBundle(bundleID, bundle);
     return bundleID;

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -456,9 +456,11 @@ export async function initializeSwingset(
         format: config.bundleFormat,
       });
     } else if ('bundleName' in desc) {
-      assert(nameToBundle, `cannot use .bundleName in config.bundles`);
+      if (!nameToBundle) {
+        throw Fail`cannot use .bundleName in config.bundles`;
+      }
       const bundle = nameToBundle[desc.bundleName];
-      assert(bundle, `unknown bundleName ${desc.bundleName}`);
+      bundle || Fail`unknown bundleName ${desc.bundleName}`;
       return bundle;
     }
     throw Error(`unknown mode in desc`, desc);
@@ -498,10 +500,8 @@ export async function initializeSwingset(
       'bundleName',
     ]);
     const modes = allModes.filter(mode => mode in desc);
-    assert(
-      modes.length === 1,
-      `need =1 of bundle/bundleSpec/sourceSpec/bundleName, got ${modes}`,
-    );
+    modes.length === 1 ||
+      Fail`need =1 of bundle/bundleSpec/sourceSpec/bundleName, got ${modes}`;
     const mode = modes[0];
     return getBundle(desc, nameToBundle)
       .then(addBundleID)

--- a/packages/SwingSet/src/devices/plugin/device-plugin.js
+++ b/packages/SwingSet/src/devices/plugin/device-plugin.js
@@ -1,6 +1,6 @@
 import { makeCapTP } from '@endo/captp';
 import { Far } from '@endo/far';
-import { assert, details as X, Fail } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 
 export function buildRootDeviceNode(tools) {
   const { SO, getDeviceState, setDeviceState, endowments } = tools;
@@ -115,7 +115,7 @@ export function buildRootDeviceNode(tools) {
   function send(index, obj) {
     const mod = connectedMods[index];
     // console.info('send', index, obj, mod);
-    assert(mod, X`No module associated with ${index}`, TypeError);
+    mod || Fail`No module associated with ${index}`;
     if (!senderPs[index]) {
       // Lazily create a fresh sender.
       connect(mod, index);

--- a/packages/SwingSet/src/devices/vat-admin/device-vat-admin.js
+++ b/packages/SwingSet/src/devices/vat-admin/device-vat-admin.js
@@ -158,8 +158,8 @@ export function buildDevice(tools, endowments) {
         if (method === 'createMeter') {
           const args = unserialize(argsCapdata);
           const [remaining, threshold] = args;
-          assert.typeof(remaining, 'bigint', `createMeter() remaining`);
-          assert.typeof(threshold, 'bigint', `createMeter() threshold`);
+          assert.typeof(remaining, 'bigint', 'createMeter() remaining');
+          assert.typeof(threshold, 'bigint', 'createMeter() threshold');
           const meterID = meterCreate(Nat(remaining), Nat(threshold));
           return returnFromInvoke(meterID);
         }
@@ -174,8 +174,8 @@ export function buildDevice(tools, endowments) {
         if (method === 'addMeterRemaining') {
           const args = unserialize(argsCapdata);
           const [meterID, delta] = args;
-          assert.typeof(meterID, 'string', `addMeterRemaining() meterID`);
-          assert.typeof(delta, 'bigint', `addMeterRemaining() delta`);
+          assert.typeof(meterID, 'string', 'addMeterRemaining() meterID');
+          assert.typeof(delta, 'bigint', 'addMeterRemaining() delta');
           meterAddRemaining(meterID, Nat(delta));
           return returnFromInvoke(undefined);
         }
@@ -184,8 +184,8 @@ export function buildDevice(tools, endowments) {
         if (method === 'setMeterThreshold') {
           const args = unserialize(argsCapdata);
           const [meterID, threshold] = args;
-          assert.typeof(meterID, 'string', `setMeterThreshold() meterID`);
-          assert.typeof(threshold, 'bigint', `setMeterThreshold() threshold`);
+          assert.typeof(meterID, 'string', 'setMeterThreshold() meterID');
+          assert.typeof(threshold, 'bigint', 'setMeterThreshold() threshold');
           meterSetThreshold(meterID, Nat(threshold));
           return returnFromInvoke(undefined);
         }
@@ -194,7 +194,7 @@ export function buildDevice(tools, endowments) {
         if (method === 'getMeter') {
           const args = unserialize(argsCapdata);
           const [meterID] = args;
-          assert.typeof(meterID, 'string', `getMeter() meterID`);
+          assert.typeof(meterID, 'string', 'getMeter() meterID');
           return returnFromInvoke(meterGet(meterID));
         }
 
@@ -204,7 +204,7 @@ export function buildDevice(tools, endowments) {
         if (method === 'createByBundle') {
           const res = syscall.callKernelHook('createByBundle', argsCapdata);
           const vatID = kunser(res);
-          assert.typeof(vatID, 'string', `createByBundle gave non-VatID`);
+          assert.typeof(vatID, 'string', 'createByBundle gave non-VatID');
           return returnFromInvoke(vatID);
         }
 
@@ -212,7 +212,7 @@ export function buildDevice(tools, endowments) {
         if (method === 'createByBundleID') {
           const res = syscall.callKernelHook('createByID', argsCapdata);
           const vatID = kunser(res);
-          assert.typeof(vatID, 'string', `createByID gave non-VatID`);
+          assert.typeof(vatID, 'string', 'createByID gave non-VatID');
           return returnFromInvoke(vatID);
         }
 
@@ -220,10 +220,10 @@ export function buildDevice(tools, endowments) {
         if (method === 'upgradeVat') {
           const args = kunser(argsCapdata);
           assert(Array.isArray(args), 'upgradeVat() args array');
-          assert.equal(args.length, 4, `upgradeVat() args length`);
+          assert.equal(args.length, 4, 'upgradeVat() args length');
           const [vatID, bundleID, _vatParameters, upgradeMessage] = args;
           insistVatID(vatID);
-          assert.typeof(bundleID, 'string', `upgradeVat() bundleID`);
+          assert.typeof(bundleID, 'string', 'upgradeVat() bundleID');
           assert.typeof(
             upgradeMessage,
             'string',
@@ -240,9 +240,9 @@ export function buildDevice(tools, endowments) {
         if (method === 'terminateWithFailure') {
           const args = kunser(argsCapdata);
           assert(Array.isArray(args), 'terminateWithFailure() args array');
-          assert.equal(args.length, 2, `terminateWithFailure() args length`);
+          assert.equal(args.length, 2, 'terminateWithFailure() args length');
           const [vatID, _reason] = args;
-          assert.typeof(vatID, 'string', `terminateWithFailure() vatID`);
+          assert.typeof(vatID, 'string', 'terminateWithFailure() vatID');
 
           syscall.callKernelHook('terminate', argsCapdata);
           return returnFromInvoke(undefined);
@@ -252,9 +252,9 @@ export function buildDevice(tools, endowments) {
         if (method === 'changeOptions') {
           const args = kunser(argsCapdata);
           assert(Array.isArray(args), 'changeOptions() args array');
-          assert.equal(args.length, 2, `changeOptions() args length`);
+          assert.equal(args.length, 2, 'changeOptions() args length');
           const [vatID, _reason] = args;
-          assert.typeof(vatID, 'string', `changeOptions() vatID`);
+          assert.typeof(vatID, 'string', 'changeOptions() vatID');
 
           syscall.callKernelHook('changeOptions', argsCapdata);
           return returnFromInvoke(undefined);
@@ -266,7 +266,7 @@ export function buildDevice(tools, endowments) {
         if (method === 'getBundleCap') {
           const args = unserialize(argsCapdata);
           const [bundleID] = args;
-          assert.typeof(bundleID, 'string', `getBundleCap() bundleID`);
+          assert.typeof(bundleID, 'string', 'getBundleCap() bundleID');
           assert(bundleIDRE.test(bundleID), 'getBundleCap() not a bundleID');
           return returnCapForBundleID(bundleID);
         }
@@ -274,7 +274,7 @@ export function buildDevice(tools, endowments) {
         if (method === 'getNamedBundleCap') {
           const args = unserialize(argsCapdata);
           const [name] = args;
-          assert.typeof(name, 'string', `getNamedBundleCap() name`);
+          assert.typeof(name, 'string', 'getNamedBundleCap() name');
           let bundleID;
           try {
             // this throws on a bad name, so make a better error
@@ -288,7 +288,7 @@ export function buildDevice(tools, endowments) {
         if (method === 'getBundleIDByName') {
           const args = unserialize(argsCapdata);
           const [name] = args;
-          assert.typeof(name, 'string', `getBundleIDByName() name`);
+          assert.typeof(name, 'string', 'getBundleIDByName() name');
           let bundleID;
           try {
             // this throws on a bad name, so make a better error

--- a/packages/SwingSet/src/kernel/deviceManager.js
+++ b/packages/SwingSet/src/kernel/deviceManager.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 import { makeDeviceSlots } from './deviceSlots.js';
 import { insistCapData } from '../lib/capdata.js';
 
@@ -66,10 +66,8 @@ export default function makeDeviceManager(
     // maybe add state utilities
     dispatch = deviceNamespace.buildDevice(tools, endowments);
   } else {
-    assert(
-      typeof deviceNamespace.buildRootDeviceNode === 'function',
-      `device ${deviceName} lacks buildRootDeviceNode`,
-    );
+    typeof deviceNamespace.buildRootDeviceNode === 'function' ||
+      Fail`device ${deviceName} lacks buildRootDeviceNode`;
 
     // Setting up the device runtime gives us back the device's dispatch object
     dispatch = makeDeviceSlots(

--- a/packages/SwingSet/src/kernel/deviceTranslator.js
+++ b/packages/SwingSet/src/kernel/deviceTranslator.js
@@ -124,7 +124,7 @@ export function makeDSTranslator(deviceID, deviceName, kernelKeeper) {
   }
 
   function translateCallKernelHook(name, dargs) {
-    assert.typeof(name, 'string', `callKernelHook requires string hook name`);
+    assert.typeof(name, 'string', 'callKernelHook requires string hook name');
     insistCapData(dargs); // dref slots
     const kargs = harden({
       ...dargs,

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -812,7 +812,7 @@ export default function buildKernel(
    * @returns {Promise<CrankResults>}
    */
   async function processUpgradeVat(message) {
-    assert(vatAdminRootKref, `initializeKernel did not set vatAdminRootKref`);
+    assert(vatAdminRootKref, 'initializeKernel did not set vatAdminRootKref');
     const { vatID, upgradeID, bundleID, vatParameters, upgradeMessage } =
       message;
     insistCapData(vatParameters);
@@ -1090,7 +1090,7 @@ export default function buildKernel(
         }
       }
       default:
-        assert.fail(`unknown promise resolution '${kp.state}'`);
+        throw Fail`unknown promise resolution '${kp.state}'`;
     }
   }
 
@@ -1745,7 +1745,7 @@ export default function buildKernel(
             break;
           }
           default:
-            assert.fail(`this can't happen (kernel option ${option})`);
+            Fail`this can't happen (kernel option ${option})`;
         }
       }
     } finally {
@@ -1827,7 +1827,7 @@ export default function buildKernel(
             policyOutput = policy.emptyCrank();
             break;
           default:
-            assert.fail(`unknown policyInput type in ${policyInput}`);
+            Fail`unknown policyInput type in ${policyInput}`;
         }
         if (!policyOutput) {
           // console.log(`ending c.run() by policy, count=${count}`);
@@ -1921,10 +1921,14 @@ export default function buildKernel(
 
   function addDeviceHook(deviceName, hookName, hook) {
     const deviceID = kernelKeeper.getDeviceIDForName(deviceName);
-    assert(deviceID, `no such device ${deviceName}`);
-    assert(deviceHooks.has(deviceID), `no such device ${deviceID}`);
+    if (!deviceID) {
+      throw Fail`no such device ${deviceName}`;
+    }
+    deviceHooks.has(deviceID) || Fail`no such device ${deviceID}`;
     const hooks = deviceHooks.get(deviceID);
-    assert(hooks, `no hooks for ${deviceName}`);
+    if (!hooks) {
+      throw Fail`no hooks for ${deviceName}`;
+    }
     hooks[hookName] = hook;
   }
 

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -42,7 +42,7 @@ export function makeKernelSyscallHandler(tools) {
 
   function descopeVatstoreKey(vatID, dbKey) {
     const prefix = `${vatID}.vs.`;
-    assert(dbKey.startsWith(prefix), `${dbKey} must start with ${prefix}`);
+    dbKey.startsWith(prefix) || Fail`${dbKey} must start with ${prefix}`;
     return dbKey.slice(prefix.length);
   }
 
@@ -208,7 +208,7 @@ export function makeKernelSyscallHandler(tools) {
   function callKernelHook(deviceID, hookName, args) {
     const hooks = deviceHooks.get(deviceID);
     const hook = hooks[hookName];
-    assert(hook, `device ${deviceID} has no hook named ${hookName}`);
+    hook || Fail`device ${deviceID} has no hook named ${hookName}`;
     insistCapData(args);
     /** @type { SwingSetCapData } */
     const hres = hook(args);

--- a/packages/SwingSet/src/kernel/state/reachable.js
+++ b/packages/SwingSet/src/kernel/state/reachable.js
@@ -1,7 +1,7 @@
-import { assert, details as X } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 
 export function parseReachableAndVatSlot(value) {
-  assert.typeof(value, 'string', X`non-string value: ${value}`);
+  typeof value === 'string' || Fail`non-string value: ${value}`;
   const flag = value.slice(0, 1);
   assert.equal(value.slice(1, 2), ' ');
   const vatSlot = value.slice(2);
@@ -12,7 +12,7 @@ export function parseReachableAndVatSlot(value) {
   } else if (flag === '_') {
     isReachable = false;
   } else {
-    assert.fail(`flag (${flag}) must be 'R' or '_'`);
+    throw Fail`flag (${flag}) must be 'R' or '_'`;
   }
   return { isReachable, vatSlot };
 }

--- a/packages/SwingSet/src/kernel/state/stats.js
+++ b/packages/SwingSet/src/kernel/state/stats.js
@@ -1,3 +1,5 @@
+import { Fail } from '@agoric/assert';
+
 /** @typedef {'counter' | 'gauge'} KernelStatsMetricType */
 /**
  * @template {KernelStatsMetricType} [T=KernelStatsMetricType]
@@ -58,7 +60,7 @@ export const makeKernelStats = kernelStatsMetrics => {
         break;
       }
       default:
-        assert.fail(`Unknown stat type ${metricType}`);
+        Fail`Unknown stat type ${metricType}`;
     }
     allStatsKeys[key] = metricType;
   }
@@ -74,9 +76,9 @@ export const makeKernelStats = kernelStatsMetrics => {
     );
     const metricType = allStatsKeys[stat];
     if (gauge) {
-      assert(metricType === 'gauge', `Invalid kernel gauge stat ${stat}`);
+      metricType === 'gauge' || Fail`Invalid kernel gauge stat ${stat}`;
     } else {
-      assert(!!metricType, `Invalid kernel stat ${stat}`);
+      !!metricType || Fail`Invalid kernel stat ${stat}`;
     }
     return stat in kernelConsensusStats
       ? kernelConsensusStats

--- a/packages/SwingSet/src/kernel/state/storageHelper.js
+++ b/packages/SwingSet/src/kernel/state/storageHelper.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 
 /**
  * Iterate over keys with a given prefix, in lexicographic order,
@@ -45,7 +45,7 @@ function* enumerateNumericPrefixedKeys(kvStore, prefix) {
 
 export function* getPrefixedValues(kvStore, prefix) {
   for (const key of enumerateNumericPrefixedKeys(kvStore, prefix)) {
-    yield kvStore.get(key) || assert.fail('enumerate ensures get');
+    yield kvStore.get(key) || Fail`enumerate ensures get`;
   }
 }
 

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -141,7 +141,7 @@ function makeManagerKit(
    * @param {(delivery: VatDeliveryObject) => Promise<VatDeliveryResult>} dtw
    */
   function setDeliverToWorker(dtw) {
-    assert(!deliverToWorker, `setDeliverToWorker called twice`);
+    assert(!deliverToWorker, 'setDeliverToWorker called twice');
     deliverToWorker = dtw;
   }
 
@@ -171,7 +171,7 @@ function makeManagerKit(
   }
 
   async function replayOneDelivery(delivery, expectedSyscalls, deliveryNum) {
-    assert(transcriptManager, `delivery replay with no transcript`);
+    assert(transcriptManager, 'delivery replay with no transcript');
     transcriptManager.startReplay();
     transcriptManager.startReplayDelivery(expectedSyscalls);
 

--- a/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
+++ b/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
@@ -73,16 +73,16 @@ export function makeVatLoader(stuff) {
       sourceDesc = 'from source bundle';
     } else if ('bundleName' in source) {
       vatSourceBundle = kernelKeeper.getNamedBundle(source.bundleName);
-      assert(vatSourceBundle, `unknown bundle name ${source.bundleName}`);
+      vatSourceBundle || Fail`unknown bundle name ${source.bundleName}`;
       sourceDesc = `from bundleName: ${source.bundleName}`;
     } else if ('bundleID' in source) {
       vatSourceBundle = kernelKeeper.getBundle(source.bundleID);
-      assert(vatSourceBundle, `unknown bundleID ${source.bundleID}`);
+      vatSourceBundle || Fail`unknown bundleID ${source.bundleID}`;
       sourceDesc = `from bundleID: ${source.bundleID}`;
     } else {
       Fail`unknown vat source descriptor ${source}`;
     }
-    assert.typeof(vatSourceBundle, 'object', `vat creation requires bundle`);
+    assert.typeof(vatSourceBundle, 'object', 'vat creation requires bundle');
 
     assertKnownOptions(options, allowedOptions);
     const {

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -502,10 +502,8 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
     const { type } = parseKernelSlot(dev);
     type === 'device' || Fail`doCallNow must target a device, not ${dev}`;
     for (const slot of args.slots) {
-      assert(
-        parseVatSlot(slot).type !== 'promise',
-        `syscall.callNow() args cannot include promises like ${slot}`,
-      );
+      parseVatSlot(slot).type !== 'promise' ||
+        Fail`syscall.callNow() args cannot include promises like ${slot}`;
     }
     const kernelSlots = args.slots.map(slot => mapVatSlotToKernelSlot(slot));
     const kernelData = harden({ ...args, slots: kernelSlots });

--- a/packages/SwingSet/src/lib/message.js
+++ b/packages/SwingSet/src/lib/message.js
@@ -1,4 +1,4 @@
-import { assert, details as X } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 import { insistCapData } from './capdata.js';
 
 /**
@@ -18,11 +18,8 @@ import { insistCapData } from './capdata.js';
 export function insistMessage(message) {
   insistCapData(message.methargs);
   if (message.result) {
-    assert.typeof(
-      message.result,
-      'string',
-      X`message has non-string non-null .result ${message.result}`,
-    );
+    typeof message.result === 'string' ||
+      Fail`message has non-string non-null .result ${message.result}`;
   }
 }
 
@@ -82,7 +79,7 @@ export function insistVatDeliveryObject(vdo) {
       break;
     }
     default:
-      assert.fail(`unknown delivery type ${type}`);
+      Fail`unknown delivery type ${type}`;
   }
 }
 
@@ -104,7 +101,7 @@ export function insistVatDeliveryResult(vdr) {
       break;
     }
     default:
-      assert.fail(`unknown delivery result type ${type}`);
+      Fail`unknown delivery result type ${type}`;
   }
 }
 
@@ -185,7 +182,7 @@ export function insistVatSyscallObject(vso) {
       break;
     }
     default:
-      assert.fail(`unknown syscall type ${type}`);
+      Fail`unknown syscall type ${type}`;
   }
 }
 
@@ -207,6 +204,6 @@ export function insistVatSyscallResult(vsr) {
       break;
     }
     default:
-      assert.fail(`unknown syscall result type ${type}`);
+      Fail`unknown syscall result type ${type}`;
   }
 }

--- a/packages/SwingSet/src/lib/parseVatSlots.js
+++ b/packages/SwingSet/src/lib/parseVatSlots.js
@@ -212,9 +212,6 @@ export function makeVatSlot(type, allocatedByVat, id) {
  * @returns {void}
  */
 export function insistVatType(type, vatSlot) {
-  assert.equal(
-    type,
-    parseVatSlot(vatSlot).type,
-    `vatSlot ${vatSlot} is not of type ${type}`,
-  );
+  type === parseVatSlot(vatSlot).type ||
+    Fail`vatSlot ${vatSlot} is not of type ${type}`;
 }

--- a/packages/SwingSet/src/vats/comms/clist-inbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-inbound.js
@@ -1,4 +1,4 @@
-import { assert, Fail } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import {
   flipRemoteSlot,
   insistRemoteType,
@@ -51,7 +51,7 @@ export function makeInbound(state) {
     const lref = mapFromRemote(rref);
     lref || Fail`${rref} must already be in remote ${rname(remote)}`;
     if (parseRemoteSlot(rref).type === 'object') {
-      assert(isReachable(lref), `remote sending to unreachable ${lref}`);
+      isReachable(lref) || Fail`remote sending to unreachable ${lref}`;
     }
     return lref;
   }
@@ -60,10 +60,8 @@ export function makeInbound(state) {
     // The index must be allocated by them. If we allocated it, it should
     // have been in our table already, and the fact that it isn't means
     // they're reaching for something we haven't given them.
-    assert(
-      !parseRemoteSlot(roid).allocatedByRecipient,
-      `I don't remember giving ${roid} to remote ${rname(remote)}`,
-    );
+    !parseRemoteSlot(roid).allocatedByRecipient ||
+      Fail`I don't remember giving ${roid} to remote ${rname(remote)}`;
 
     // So this must be a new import. Allocate a new vat object for it, which
     // will be the local machine's proxy for use by all other local vats, as
@@ -77,10 +75,8 @@ export function makeInbound(state) {
   }
 
   function addLocalPromiseForRemote(remote, rpid) {
-    assert(
-      !parseRemoteSlot(rpid).allocatedByRecipient,
-      `I don't remember giving ${rpid} to remote ${rname(remote)}`,
-    );
+    !parseRemoteSlot(rpid).allocatedByRecipient ||
+      Fail`I don't remember giving ${rpid} to remote ${rname(remote)}`;
     // allocate a new lpNN, remember them as the decider, add to clist
     const lpid = state.allocatePromise();
     state.changeDeciderToRemote(lpid, remote.remoteID());
@@ -122,7 +118,7 @@ export function makeInbound(state) {
         const isImportFromComms = false;
         remote.setReachable(lref, isImportFromComms);
       }
-      assert(remote.isReachable(lref), `remote using unreachable ${lref}`);
+      remote.isReachable(lref) || Fail`remote using unreachable ${lref}`;
     }
 
     return lref;

--- a/packages/SwingSet/src/vats/comms/clist-kernel.js
+++ b/packages/SwingSet/src/vats/comms/clist-kernel.js
@@ -1,4 +1,4 @@
-import { assert, Fail } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import { parseVatSlot, insistVatType } from '../../lib/parseVatSlots.js';
 import { parseLocalSlot } from './parseLocalSlots.js';
 import { cdebug } from './cdebug.js';
@@ -108,10 +108,8 @@ export function makeKernel(state, syscall) {
   }
 
   function addLocalObjectForKernel(kfoid) {
-    assert(
-      !state.mapFromKernel(kfoid),
-      `I don't remember giving ${kfoid} to the kernel`,
-    );
+    !state.mapFromKernel(kfoid) ||
+      Fail`I don't remember giving ${kfoid} to the kernel`;
 
     const loid = state.allocateObject('kernel');
     state.addKernelMapping(kfoid, loid);
@@ -119,10 +117,8 @@ export function makeKernel(state, syscall) {
   }
 
   function addLocalPromiseForKernel(kfpid) {
-    assert(
-      !state.mapFromKernel(kfpid),
-      `I don't remember giving ${kfpid} to the kernel`,
-    );
+    !state.mapFromKernel(kfpid) ||
+      Fail`I don't remember giving ${kfpid} to the kernel`;
     const lpid = state.allocatePromise();
     state.changeDeciderToKernel(lpid);
     state.addKernelMapping(kfpid, lpid);
@@ -163,7 +159,7 @@ export function makeKernel(state, syscall) {
         const isImportFromComms = false;
         setReachable(lref, isImportFromComms);
       }
-      assert(isReachable(lref), `kernel using unreachable ${lref}`);
+      isReachable(lref) || Fail`kernel using unreachable ${lref}`;
     }
 
     return lref;

--- a/packages/SwingSet/src/vats/comms/clist-outbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-outbound.js
@@ -1,4 +1,4 @@
-import { assert, Fail } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import { parseLocalSlot, insistLocalType } from './parseLocalSlots.js';
 import {
   flipRemoteSlot,
@@ -18,17 +18,14 @@ export function makeOutbound(state) {
     const rref = mapToRemote(lref);
     rref || Fail`${lref} must already be in remote ${rname(remote)}`;
     if (parseRemoteSlot(rref).type === 'object') {
-      assert(isReachable(lref), `sending unreachable ${lref} to remote`);
+      isReachable(lref) || Fail`sending unreachable ${lref} to remote`;
     }
     return rref;
   }
 
   function addRemoteObjectForLocal(remote, loid) {
     const owner = state.getObject(loid);
-    assert(
-      owner !== remote,
-      `${loid} already came from remote ${rname(remote)}`,
-    );
+    owner !== remote || Fail`${loid} already came from remote ${rname(remote)}`;
 
     // The recipient will receive ro-NN
     const roid = remote.allocateRemoteObject();
@@ -96,7 +93,7 @@ export function makeOutbound(state) {
         const seqNum = remote.nextSendSeqNum();
         remote.setLastSent(lref, seqNum);
       }
-      assert(remote.isReachable(lref), `sending unreachable rref ${lref}`);
+      remote.isReachable(lref) || Fail`sending unreachable rref ${lref}`;
     }
 
     return rref;

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -1,4 +1,4 @@
-import { assert, details as X, Fail } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 import { makeVatSlot } from '../../lib/parseVatSlots.js';
 import { insistMessage } from '../../lib/message.js';
 import { makeState } from './state.js';
@@ -120,11 +120,10 @@ export function buildCommsDispatch(syscall, _state, _helpers, _vatPowers) {
     // crank).  The resulting abrupt comms vat termination should serve as a
     // diagnostic signal that we have a bug that must be corrected.
 
-    methargs.slots.forEach(s =>
-      assert(
-        !state.hasMetaObject(s),
-        X`comms meta-object ${s} not allowed in message args`,
-      ),
+    methargs.slots.forEach(
+      s =>
+        !state.hasMetaObject(s) ||
+        Fail`comms meta-object ${s} not allowed in message args`,
     );
     return sendFromKernel(target, methargs, result);
   }

--- a/packages/SwingSet/src/vats/comms/gc-comms.js
+++ b/packages/SwingSet/src/vats/comms/gc-comms.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 import { parseVatSlot } from '../../lib/parseVatSlots.js';
 import { parseRemoteSlot } from './parseRemoteSlot.js';
 
@@ -147,7 +147,7 @@ function makeGCKit(state, syscall, transmit) {
     for (const submsg of subMessages) {
       const [name, type, rref] = submsg.split(':');
       assert(name === 'gc');
-      assert(types.includes(type), `unknown GC message type ${type}`);
+      types.includes(type) || Fail`unknown GC message type ${type}`;
       assert.equal(parseRemoteSlot(rref).type, 'object');
       gc[`${type}s`].push(rref);
     }

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -277,7 +277,7 @@ export function makeState(syscall) {
    * @param {string} mode  Reference type
    */
   function incrementRefCount(lref, _tag, mode = 'data') {
-    assert(referenceModes.includes(mode), `unknown reference mode ${mode}`);
+    referenceModes.includes(mode) || Fail`unknown reference mode ${mode}`;
     const { type } = parseLocalSlot(lref);
     if (type === 'promise') {
       const refCount = parseInt(store.get(`${lref}.refCount`), 10) + 1;
@@ -303,7 +303,7 @@ export function makeState(syscall) {
    * @throws if this tries to decrement a reference count below zero.
    */
   function decrementRefCount(lref, tag, mode = 'data') {
-    assert(referenceModes.includes(mode), `unknown reference mode ${mode}`);
+    referenceModes.includes(mode) || Fail`unknown reference mode ${mode}`;
     const { type } = parseLocalSlot(lref);
     if (type === 'promise') {
       let refCount = parseInt(store.get(`${lref}.refCount`), 10);
@@ -582,29 +582,19 @@ export function makeState(syscall) {
 
   function insistDeciderIsRemote(lpid, remoteID) {
     const decider = store.getRequired(`${lpid}.decider`);
-    assert.equal(
-      decider,
-      remoteID,
-      `${lpid} is decided by ${decider}, not ${remoteID}`,
-    );
+    decider === remoteID ||
+      Fail`${lpid} is decided by ${decider}, not ${remoteID}`;
   }
 
   function insistDeciderIsComms(lpid) {
     const decider = store.getRequired(`${lpid}.decider`);
-    assert.equal(
-      decider,
-      COMMS,
-      `${decider} is the decider for ${lpid}, not me`,
-    );
+    decider === COMMS || Fail`${decider} is the decider for ${lpid}, not me`;
   }
 
   function insistDeciderIsKernel(lpid) {
     const decider = store.getRequired(`${lpid}.decider`);
-    assert.equal(
-      decider,
-      KERNEL,
-      `${decider} is the decider for ${lpid}, not kernel`,
-    );
+    decider === KERNEL ||
+      Fail`${decider} is the decider for ${lpid}, not kernel`;
   }
 
   // Decision authority always transfers through the comms vat, so the only
@@ -711,7 +701,7 @@ export function makeState(syscall) {
   }
 
   function addRemote(name, transmitterID) {
-    assert(/^[-\w.+]+$/.test(name), `not a valid remote name: ${name}`);
+    /^[-\w.+]+$/.test(name) || Fail`not a valid remote name: ${name}`;
     const nameKey = `rname.${name}`;
     !store.get(nameKey) || Fail`remote name ${name} already in use`;
 

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -1,7 +1,7 @@
 import { makeScalarMapStore, makeLegacyMap } from '@agoric/store';
 import { Far, E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
-import { assert, details as X, Fail } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import { whileTrue } from '@agoric/internal';
 import { toBytes } from './bytes.js';
 
@@ -277,7 +277,7 @@ export function makeNetworkProtocol(protocolHandler) {
       },
       async addListener(listenHandler) {
         !revoked || Fail`Port ${localAddr} is revoked`;
-        assert(listenHandler, X`listenHandler is not defined`, TypeError);
+        listenHandler || Fail`listenHandler is not defined`;
         if (listening.has(localAddr)) {
           // Last one wins.
           const [lport, lhandler] = listening.get(localAddr);

--- a/packages/SwingSet/src/vats/network/router.js
+++ b/packages/SwingSet/src/vats/network/router.js
@@ -1,6 +1,6 @@
 import { Far, E as defaultE } from '@endo/far';
 import { makeScalarMapStore } from '@agoric/store';
-import { assert, details as X } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import { makeNetworkProtocol, ENDPOINT_SEPARATOR } from './network.js';
 
 import '@agoric/store/exported.js';
@@ -53,11 +53,8 @@ export default function makeRouter() {
       prefixToRoute.init(prefix, route);
     },
     unregister(prefix, route) {
-      assert(
-        prefixToRoute.get(prefix) === route,
-        X`Router is not registered at prefix ${prefix}`,
-        TypeError,
-      );
+      prefixToRoute.get(prefix) === route ||
+        Fail`Router is not registered at prefix ${prefix}`;
       prefixToRoute.delete(prefix);
     },
   });
@@ -96,11 +93,8 @@ export function makeRouterProtocol(E = defaultE) {
   // Needs to account for multiple paths.
   function unregisterProtocolHandler(prefix, protocolHandler) {
     const ph = protocolHandlers.get(prefix);
-    assert(
-      ph === protocolHandler,
-      X`Protocol handler is not registered at prefix ${prefix}`,
-      TypeError,
-    );
+    ph === protocolHandler ||
+      Fail`Protocol handler is not registered at prefix ${prefix}`;
     router.unregister(prefix, ph);
     protocols.delete(prefix);
     protocolHandlers.delete(prefix);
@@ -109,11 +103,7 @@ export function makeRouterProtocol(E = defaultE) {
   /** @type {Protocol['bind']} */
   async function bind(localAddr) {
     const [route] = router.getRoutes(localAddr);
-    assert(
-      route !== undefined,
-      X`No registered router for ${localAddr}`,
-      TypeError,
-    );
+    route !== undefined || Fail`No registered router for ${localAddr}`;
     return E(route[1]).bind(localAddr);
   }
 

--- a/packages/SwingSet/test/bundling/test-bundles-controller.js
+++ b/packages/SwingSet/test/bundling/test-bundles-controller.js
@@ -54,7 +54,7 @@ test('install invalid bundle fails', async t => {
     () => controller.validateAndInstallBundle(bundle, wrong),
     {
       message:
-        /alleged bundleID b1-[0-9a-f]{128} does not match actual b1-[0-9a-f]{128}/,
+        /alleged bundleID "b1-[0-9a-f]{128}" does not match actual "b1-[0-9a-f]{128}"/,
     },
   );
 });

--- a/packages/SwingSet/test/commsVatDriver.js
+++ b/packages/SwingSet/test/commsVatDriver.js
@@ -251,7 +251,7 @@ function encodeCapdata(from) {
       case 'number':
         return value;
       default:
-        assert.fail(`cannot use ${typestr} values in test script`);
+        throw Fail`cannot use ${typestr} values in test script`;
     }
   }
 
@@ -693,7 +693,7 @@ export function commsVatDriver(t, verbose = false) {
         break;
       }
       default: {
-        assert.fail(`illegal op ${op}`);
+        throw Fail`illegal op ${op}`;
       }
     }
   }

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -927,10 +927,7 @@ test('failed upgrade - unknown options', async t => {
 
   await t.throwsAsync(run('doUpgradeWithBadOption', []), {
     instanceOf: Error,
-    // TODO Since we should be running with `errorTaming: unsafe`, the
-    // following should have worked.
-    // message: /upgrade\(\) received unknown options: bad/,
-    message: /upgrade\(\) received unknown options: \(a string\)/,
+    message: /upgrade\(\) received unknown options: "bad"/,
   });
 });
 

--- a/packages/SwingSet/test/vat-admin/test-create-vat.js
+++ b/packages/SwingSet/test/vat-admin/test-create-vat.js
@@ -220,7 +220,7 @@ test('error creating vat with oversized name', async t => {
   t.is(c.kpStatus(kpid), 'rejected');
   t.deepEqual(
     kunser(c.kpResolution(kpid)),
-    Error(`CreateVatOptions: oversized vat name '${'n'.repeat(200)}'`),
+    Error(`CreateVatOptions: oversized vat name "${'n'.repeat(200)}"`),
   );
 });
 
@@ -232,7 +232,7 @@ test('error creating vat with bad characters in name', async t => {
   t.is(c.kpStatus(kpid), 'rejected');
   t.deepEqual(
     kunser(c.kpResolution(kpid)),
-    Error(`CreateVatOptions: bad vat name 'no spaces'`),
+    Error(`CreateVatOptions: bad vat name "no spaces"`),
   );
 });
 
@@ -243,7 +243,7 @@ test('error creating vat with unknown options', async t => {
   t.is(c.kpStatus(kpid), 'rejected');
   t.deepEqual(
     kunser(c.kpResolution(kpid)),
-    Error('CreateVatOptions: unknown options bogus'),
+    Error('CreateVatOptions: unknown options "bogus"'),
   );
 });
 

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -4,7 +4,7 @@ import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
 import { makePromiseKit } from '@endo/promise-kit';
 import styles from 'ansi-styles'; // less authority than 'chalk'
 
-const { details: X, quote: q, Fail } = assert;
+const { quote: q, Fail } = assert;
 
 /**
  * @typedef {object} BundleMeta
@@ -133,11 +133,8 @@ export const makeBundleCache = (wr, bundleOptions, cwd, readPowers) => {
     } = meta;
     assert.equal(bundleFileName, toBundleName(targetName));
     if (rootOpt) {
-      assert.equal(
-        moduleSource,
-        cwd.neighbor(rootOpt).absolute(),
-        X`bundle ${targetName} was for ${moduleSource}, not ${rootOpt}`,
-      );
+      moduleSource === cwd.neighbor(rootOpt).absolute() ||
+        Fail`bundle ${targetName} was for ${moduleSource}, not ${rootOpt}`;
     }
     const { mtime: actualBundleTime } = await wr
       .readOnly()

--- a/packages/SwingSet/tools/manual-timer.js
+++ b/packages/SwingSet/tools/manual-timer.js
@@ -1,4 +1,5 @@
 import { Far } from '@endo/far';
+import { Fail } from '@agoric/assert';
 import { makeScalarMapStore } from '@agoric/store';
 import { bindAllMethods } from '@agoric/internal';
 import { buildRootObject } from '../src/vats/timer/vat-timer.js';
@@ -23,10 +24,8 @@ const setup = () => {
       assert.equal(state.currentWakeup, undefined, 'one at a time');
       assert.equal(state.currentHandler, undefined, 'one at a time');
       if (state.currentWakeup !== undefined) {
-        assert(
-          state.currentWakeup > state.now,
-          `too late: ${state.currentWakeup} <= ${state.now}`,
-        );
+        state.currentWakeup > state.now ||
+          Fail`too late: ${state.currentWakeup} <= ${state.now}`;
       }
       state.currentWakeup = when;
       state.currentHandler = handler;
@@ -63,7 +62,7 @@ const setup = () => {
 export const buildManualTimer = (options = {}) => {
   const { startTime = 0n, ...other } = options;
   const unrec = Object.getOwnPropertyNames(other).join(',');
-  assert.equal(unrec, '', `buildManualTimer unknown options ${unrec}`);
+  unrec === '' || Fail`buildManualTimer unknown options ${unrec}`;
   const { timerService, state } = setup();
   assert.typeof(startTime, 'bigint');
   state.now = startTime;
@@ -76,7 +75,7 @@ export const buildManualTimer = (options = {}) => {
 
   const advanceTo = when => {
     assert.typeof(when, 'bigint');
-    assert(when > state.now, `advanceTo(${when}) < current ${state.now}`);
+    when > state.now || Fail`advanceTo(${when}) < current ${state.now}`;
     state.now = when;
     wake();
     return when;

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -261,7 +261,7 @@ export function makeSwingStoreExporter(dirPath, exportMode = 'current') {
     } else if (type === 'bundle') {
       return bundleStore.exportBundle(name);
     } else {
-      assert.fail(`invalid artifact type ${q(type)}`);
+      throw Fail`invalid artifact type ${q(type)}`;
     }
   }
 

--- a/packages/swingset-liveslots/src/collectionManager.js
+++ b/packages/swingset-liveslots/src/collectionManager.js
@@ -1,4 +1,4 @@
-import { assert, details as X, q, Fail } from '@agoric/assert';
+import { assert, q, Fail } from '@agoric/assert';
 import {
   zeroPad,
   makeEncodePassable,
@@ -42,10 +42,8 @@ function matchAny(patt) {
 }
 
 function throwNotDurable(value, slotIndex, serializedValue) {
-  assert.fail(
-    // prettier-ignore
-    X`value is not durable: ${value} at slot ${q(slotIndex)} of ${serializedValue.body}`,
-  );
+  // prettier-ignore
+  Fail`value is not durable: ${value} at slot ${q(slotIndex)} of ${serializedValue.body}`;
 }
 
 export function makeCollectionManager(
@@ -199,7 +197,7 @@ export function makeCollectionManager(
   ) {
     assert.typeof(kindName, 'string');
     const kindInfo = storeKindInfo[kindName];
-    assert(kindInfo, `unknown collection kind ${kindName}`);
+    kindInfo || Fail`unknown collection kind ${kindName}`;
     const { hasWeakKeys, durable } = kindInfo;
     const dbKeyPrefix = `vc.${collectionID}.`;
     let currentGenerationNumber = 0;
@@ -646,7 +644,7 @@ export function makeCollectionManager(
   function storeSizeInternal(vobjID) {
     const { id, subid } = parseVatSlot(vobjID);
     const kindName = storeKindIDToName.get(`${id}`);
-    assert(kindName, `unknown kind ID ${id}`);
+    kindName || Fail`unknown kind ID ${id}`;
     const collection = summonCollectionInternal(false, 'test', subid, kindName);
     return collection.sizeInternal();
   }

--- a/packages/swingset-liveslots/src/message.js
+++ b/packages/swingset-liveslots/src/message.js
@@ -1,4 +1,4 @@
-import { assert, details as X } from '@agoric/assert';
+import { assert, Fail } from '@agoric/assert';
 import { insistCapData } from './capdata.js';
 
 /**
@@ -25,11 +25,8 @@ import { insistCapData } from './capdata.js';
 export function insistMessage(message) {
   insistCapData(message.methargs);
   if (message.result) {
-    assert.typeof(
-      message.result,
-      'string',
-      X`message has non-string non-null .result ${message.result}`,
-    );
+    typeof message.result === 'string' ||
+      Fail`message has non-string non-null .result ${message.result}`;
   }
 }
 
@@ -89,7 +86,7 @@ export function insistVatDeliveryObject(vdo) {
       break;
     }
     default:
-      assert.fail(`unknown delivery type ${type}`);
+      Fail`unknown delivery type ${type}`;
   }
 }
 
@@ -111,7 +108,7 @@ export function insistVatDeliveryResult(vdr) {
       break;
     }
     default:
-      assert.fail(`unknown delivery result type ${type}`);
+      Fail`unknown delivery result type ${type}`;
   }
 }
 
@@ -192,7 +189,7 @@ export function insistVatSyscallObject(vso) {
       break;
     }
     default:
-      assert.fail(`unknown syscall type ${type}`);
+      Fail`unknown syscall type ${type}`;
   }
 }
 
@@ -214,6 +211,6 @@ export function insistVatSyscallResult(vsr) {
       break;
     }
     default:
-      assert.fail(`unknown syscall result type ${type}`);
+      Fail`unknown syscall result type ${type}`;
   }
 }

--- a/packages/swingset-liveslots/src/parseVatSlots.js
+++ b/packages/swingset-liveslots/src/parseVatSlots.js
@@ -214,9 +214,6 @@ export function makeBaseRef(kindID, id, isDurable) {
  * @returns {void}
  */
 export function insistVatType(type, vatSlot) {
-  assert.equal(
-    type,
-    parseVatSlot(vatSlot).type,
-    `vatSlot ${vatSlot} is not of type ${type}`,
-  );
+  type === parseVatSlot(vatSlot).type ||
+    Fail`vatSlot ${vatSlot} is not of type ${type}`;
 }

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -984,7 +984,7 @@ export function makeVirtualObjectManager(
    * @returns {import('@agoric/vat-data').DurableKindHandle}
    */
   const makeKindHandle = tag => {
-    assert(kindIDID, `initializeKindHandleKind not called yet`);
+    assert(kindIDID, 'initializeKindHandleKind not called yet');
     const kindID = `${allocateExportID()}`;
     const kindIDvref = makeBaseRef(kindIDID, kindID, true);
     const durableKindDescriptor = { kindID, tag, nextInstanceID: 1 };
@@ -1002,15 +1002,13 @@ export function makeVirtualObjectManager(
   };
 
   function defineDurableKind(kindHandle, init, behavior, options) {
-    assert(kindHandleToID.has(kindHandle), `unknown handle ${kindHandle}`);
+    kindHandleToID.has(kindHandle) || Fail`unknown handle ${kindHandle}`;
     const kindID = kindHandleToID.get(kindHandle);
     const durableKindDescriptor = kindIDToDescriptor.get(kindID);
     assert(durableKindDescriptor);
     const { tag, nextInstanceID } = durableKindDescriptor;
-    assert(
-      !definedDurableKinds.has(kindID),
-      `redefinition of durable kind "${tag}"`,
-    );
+    !definedDurableKinds.has(kindID) ||
+      Fail`redefinition of durable kind ${tag}`;
     nextInstanceIDs.set(kindID, nextInstanceID);
     const maker = defineKindInternal(
       kindID,
@@ -1027,15 +1025,13 @@ export function makeVirtualObjectManager(
   }
 
   function defineDurableKindMulti(kindHandle, init, behavior, options) {
-    assert(kindHandleToID.has(kindHandle), `unknown handle ${kindHandle}`);
+    kindHandleToID.has(kindHandle) || Fail`unknown handle ${kindHandle}`;
     const kindID = kindHandleToID.get(kindHandle);
     const durableKindDescriptor = kindIDToDescriptor.get(kindID);
     assert(durableKindDescriptor);
     const { tag, nextInstanceID } = durableKindDescriptor;
-    assert(
-      !definedDurableKinds.has(kindID),
-      `redefinition of durable kind "${tag}"`,
-    );
+    !definedDurableKinds.has(kindID) ||
+      Fail`redefinition of durable kind "${tag}"`;
     nextInstanceIDs.set(kindID, nextInstanceID);
     const maker = defineKindInternal(
       kindID,

--- a/packages/swingset-liveslots/src/virtualReferences.js
+++ b/packages/swingset-liveslots/src/virtualReferences.js
@@ -121,10 +121,7 @@ export function makeVirtualReferenceManager(
 
   function setRefCount(baseRef, refCount) {
     const { facet } = parseVatSlot(baseRef);
-    assert(
-      !facet,
-      `setRefCount ${baseRef} should not receive individual facets`,
-    );
+    !facet || Fail`setRefCount ${baseRef} should not receive individual facets`;
     if (refCount === 0) {
       syscall.vatstoreDelete(`vom.rc.${baseRef}`);
       addToPossiblyDeadSet(baseRef);
@@ -178,7 +175,7 @@ export function makeVirtualReferenceManager(
         }
         break;
       default:
-        assert.fail(`invalid set export status ${exportStatus}`);
+        Fail`invalid set export status ${exportStatus}`;
     }
   }
 
@@ -189,7 +186,7 @@ export function makeVirtualReferenceManager(
 
   function decRefCount(baseRef) {
     const oldRefCount = getRefCount(baseRef);
-    assert(oldRefCount > 0, `attempt to decref ${baseRef} below 0`);
+    oldRefCount > 0 || Fail`attempt to decref ${baseRef} below 0`;
     setRefCount(baseRef, oldRefCount - 1);
   }
 
@@ -221,7 +218,7 @@ export function makeVirtualReferenceManager(
    */
   function rememberFacetNames(kindID, facetNames) {
     const kindInfo = kindInfoTable.get(`${kindID}`);
-    assert(kindInfo, `no kind info for ${kindID}`);
+    kindInfo || Fail`no kind info for ${kindID}`;
     assert(kindInfo.facetNames === undefined);
     kindInfo.facetNames = facetNames;
   }
@@ -299,7 +296,7 @@ export function makeVirtualReferenceManager(
     const { id } = parseVatSlot(baseRef);
     const kindID = `${id}`;
     const kindInfo = kindInfoTable.get(kindID);
-    assert(kindInfo, `no kind info for ${kindID}, call defineDurableKind`);
+    kindInfo || Fail`no kind info for ${kindID}, call defineDurableKind`;
     const { reanimator } = kindInfo;
     if (reanimator) {
       return reanimator(baseRef);
@@ -381,7 +378,7 @@ export function makeVirtualReferenceManager(
           // exported non-virtual object: Remotable
           const remotable = requiredValForSlot(vref);
           const oldRefCount = remotableRefCounts.get(remotable) || 0;
-          assert(oldRefCount > 0, `attempt to decref ${vref} below 0`);
+          oldRefCount > 0 || Fail`attempt to decref ${vref} below 0`;
           if (oldRefCount === 1) {
             remotableRefCounts.delete(remotable);
             droppedMemoryReference = true;
@@ -395,7 +392,7 @@ export function makeVirtualReferenceManager(
     } else if (type === 'promise') {
       const p = requiredValForSlot(vref);
       const oldRefCount = remotableRefCounts.get(p) || 0;
-      assert(oldRefCount > 0, `attempt to decref ${vref} below 0`);
+      oldRefCount > 0 || Fail`attempt to decref ${vref} below 0`;
       if (oldRefCount === 1) {
         remotableRefCounts.delete(p);
         droppedMemoryReference = true; // true for promises too
@@ -602,7 +599,7 @@ export function makeVirtualReferenceManager(
         } else if (recognizer instanceof Set) {
           recognizer.delete(vref);
         } else {
-          assert.fail(`unknown recognizer type ${typeof recognizer}`);
+          Fail`unknown recognizer type ${typeof recognizer}`;
         }
       }
     }

--- a/packages/swingset-liveslots/test/vat-util.js
+++ b/packages/swingset-liveslots/test/vat-util.js
@@ -1,12 +1,12 @@
 // this file is imported by some test vats, so don't import any non-pure
 // modules
 
-import { assert } from '@agoric/assert';
+import { Fail } from '@agoric/assert';
 import { kser, kunser } from './kmarshal.js';
 
 export function extractMessage(vatDeliverObject) {
   const [type, ...vdoargs] = vatDeliverObject;
-  assert.equal(type, 'message', `util.js .extractMessage got type ${type}`);
+  type === 'message' || Fail`util.js .extractMessage got type ${type}`;
   const [facetID, msg] = vdoargs;
   const { methargs, result } = msg;
   const [method, argsdata] = kunser(methargs);


### PR DESCRIPTION
Closes #7271

I'm sure this will be some kind of performance improvement, but it's possible these changes won't provide as much benefit as we originally hoped -- there proved to be far fewer asserts that mandated adjusting than I think we anticipated, since a great fraction had either a constant detail string or no details at all.

There were several detail strings that were template strings with no values injected into them at all (i.e., no embedded `${foo}` expressions) but instead were simple string literals that happened to be delimited by back-ticks instead of quotes.  These have been changed to ordinary string literals.