### PR TITLE
feat: add new bean cost for bytes in permanent storage

### DIFF
--- a/golang/cosmos/x/swingset/keeper/migrations.go
+++ b/golang/cosmos/x/swingset/keeper/migrations.go
@@ -1,0 +1,27 @@
+package keeper
+
+import (
+	v32 "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/legacy/v32"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Migrator handles in-place store migrations.
+type Migrator struct {
+	keeper Keeper
+}
+
+// NewMigrator returns a new migrator based on the keeper.
+func NewMigrator(keeper Keeper) Migrator {
+	return Migrator{keeper: keeper}
+}
+
+// Migrate1to2 migrates from version 1 to 2.
+func (m Migrator) Migrate1to2(ctx sdk.Context) error {
+	params := m.keeper.GetParams(ctx)
+	newParams, err := v32.UpdateParams(params)
+	if err != nil {
+		return err
+	}
+	m.keeper.SetParams(ctx, newParams)
+	return nil
+}

--- a/golang/cosmos/x/swingset/legacy/v32/params.go
+++ b/golang/cosmos/x/swingset/legacy/v32/params.go
@@ -1,0 +1,37 @@
+package v32
+
+import (
+	"fmt"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
+)
+
+// UpdateParams performs the parameter updates to migrate to version 2,
+// returning the updated params or an error.
+func UpdateParams(params types.Params) (types.Params, error) {
+	newBpu, err := addStorageBeanCost(params.BeansPerUnit)
+	if err != nil {
+		return params, err
+	}
+	params.BeansPerUnit = newBpu
+	return params, nil
+}
+
+// addStorageBeanCost adds the default beans per storage byte cost,
+// if it's not in the list of bean costs already, returning the possibly-updated list.
+// or an error if there's no default storage cost.
+func addStorageBeanCost(bpu []types.StringBeans) ([]types.StringBeans, error) {
+	for _, ob := range bpu {
+		if ob.Key == types.BeansPerStorageByte {
+			// success if there's already an entry
+			return bpu, nil
+		}
+	}
+	defaultParams := types.DefaultParams()
+	for _, b := range defaultParams.BeansPerUnit {
+		if b.Key == types.BeansPerStorageByte {
+			return append(bpu, b), nil
+		}
+	}
+	return bpu, fmt.Errorf("no beans per storage byte in default params %v", defaultParams)
+}

--- a/golang/cosmos/x/swingset/legacy/v32/params_test.go
+++ b/golang/cosmos/x/swingset/legacy/v32/params_test.go
@@ -1,0 +1,133 @@
+package v32
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type beans = types.StringBeans
+
+func TestAddStorageBeanCost(t *testing.T) {
+	var defaultStorageCost beans
+	for _, b := range types.DefaultParams().BeansPerUnit {
+		if b.Key == types.BeansPerStorageByte {
+			defaultStorageCost = b
+		}
+	}
+	if defaultStorageCost.Key == "" {
+		t.Fatalf("no beans per storage byte in default params")
+	}
+
+	for _, tt := range []struct {
+		name string
+		in   []beans
+		want []beans
+	}{
+		{
+			name: "empty",
+			in:   []beans{},
+			want: []beans{defaultStorageCost},
+		},
+		{
+			name: "alread_only_same",
+			in:   []beans{defaultStorageCost},
+			want: []beans{defaultStorageCost},
+		},
+		{
+			name: "already_only_different",
+			in:   []beans{types.NewStringBeans(types.BeansPerStorageByte, sdk.NewUint(123))},
+			want: []beans{types.NewStringBeans(types.BeansPerStorageByte, sdk.NewUint(123))},
+		},
+		{
+			name: "already_same",
+			in: []beans{
+				types.NewStringBeans("foo", sdk.NewUint(123)),
+				defaultStorageCost,
+				types.NewStringBeans("bar", sdk.NewUint(456)),
+			},
+			want: []beans{
+				types.NewStringBeans("foo", sdk.NewUint(123)),
+				defaultStorageCost,
+				types.NewStringBeans("bar", sdk.NewUint(456)),
+			},
+		},
+		{
+			name: "already_different",
+			in: []beans{
+				types.NewStringBeans("foo", sdk.NewUint(123)),
+				types.NewStringBeans(types.BeansPerStorageByte, sdk.NewUint(789)),
+				types.NewStringBeans("bar", sdk.NewUint(456)),
+			},
+			want: []beans{
+				types.NewStringBeans("foo", sdk.NewUint(123)),
+				types.NewStringBeans(types.BeansPerStorageByte, sdk.NewUint(789)),
+				types.NewStringBeans("bar", sdk.NewUint(456)),
+			},
+		},
+		{
+			name: "missing",
+			in: []beans{
+				types.NewStringBeans("foo", sdk.NewUint(123)),
+				types.NewStringBeans("bar", sdk.NewUint(456)),
+			},
+			want: []beans{
+				types.NewStringBeans("foo", sdk.NewUint(123)),
+				types.NewStringBeans("bar", sdk.NewUint(456)),
+				defaultStorageCost,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := addStorageBeanCost(tt.in)
+			if err != nil {
+				t.Errorf("got error %v", err)
+			} else if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("want %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestUpdateParams(t *testing.T) {
+	var defaultStorageCost beans
+	for _, b := range types.DefaultParams().BeansPerUnit {
+		if b.Key == types.BeansPerStorageByte {
+			defaultStorageCost = b
+		}
+	}
+	if defaultStorageCost.Key == "" {
+		t.Fatalf("no beans per storage byte in default params")
+	}
+
+	in := types.Params{
+		BeansPerUnit: []beans{
+			types.NewStringBeans("foo", sdk.NewUint(123)),
+			types.NewStringBeans("bar", sdk.NewUint(456)),
+		},
+		BootstrapVatConfig: "baz",
+		FeeUnitPrice:       sdk.NewCoins(sdk.NewInt64Coin("denom", 789)),
+		PowerFlagFees:      types.DefaultPowerFlagFees,
+		QueueMax:           types.DefaultQueueMax,
+	}
+	want := types.Params{
+		BeansPerUnit: []beans{
+			types.NewStringBeans("foo", sdk.NewUint(123)),
+			types.NewStringBeans("bar", sdk.NewUint(456)),
+			defaultStorageCost,
+		},
+		BootstrapVatConfig: "baz",
+		FeeUnitPrice:       sdk.NewCoins(sdk.NewInt64Coin("denom", 789)),
+		PowerFlagFees:      types.DefaultPowerFlagFees,
+		QueueMax:           types.DefaultQueueMax,
+	}
+	got, err := UpdateParams(in)
+	if err != nil {
+		t.Fatalf("UpdateParam error %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/golang/cosmos/x/swingset/legacy/v32/params_test.go
+++ b/golang/cosmos/x/swingset/legacy/v32/params_test.go
@@ -32,7 +32,7 @@ func TestAddStorageBeanCost(t *testing.T) {
 			want: []beans{defaultStorageCost},
 		},
 		{
-			name: "alread_only_same",
+			name: "already_only_same",
 			in:   []beans{defaultStorageCost},
 			want: []beans{defaultStorageCost},
 		},

--- a/golang/cosmos/x/swingset/module.go
+++ b/golang/cosmos/x/swingset/module.go
@@ -115,9 +115,11 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	querier := keeper.Querier{Keeper: am.keeper}
 	types.RegisterQueryServer(cfg.QueryServer(), querier)
+	m := keeper.NewMigrator(am.keeper)
+	cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2)
 }
 
-func (AppModule) ConsensusVersion() uint64 { return 1 }
+func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
 	err := BeginBlock(ctx, req, am.keeper)

--- a/golang/cosmos/x/swingset/module.go
+++ b/golang/cosmos/x/swingset/module.go
@@ -116,7 +116,10 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	querier := keeper.Querier{Keeper: am.keeper}
 	types.RegisterQueryServer(cfg.QueryServer(), querier)
 	m := keeper.NewMigrator(am.keeper)
-	cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2)
+	err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func (AppModule) ConsensusVersion() uint64 { return 2 }

--- a/golang/cosmos/x/swingset/types/default-params.go
+++ b/golang/cosmos/x/swingset/types/default-params.go
@@ -17,6 +17,7 @@ const (
 	BeansPerMessage           = "message"
 	BeansPerMessageByte       = "messageByte"
 	BeansPerMinFeeDebit       = "minFeeDebit"
+	BeansPerStorageByte       = "storageByte"
 	BeansPerVatCreation       = "vatCreation"
 	BeansPerXsnapComputron    = "xsnapComputron"
 
@@ -45,8 +46,9 @@ var (
 	DefaultBeansPerFeeUnit     = sdk.NewUint(1_000_000_000_000)                  // $1
 	DefaultBeansPerInboundTx   = DefaultBeansPerFeeUnit.Quo(sdk.NewUint(100))    // $0.01
 	DefaultBeansPerMessage     = DefaultBeansPerFeeUnit.Quo(sdk.NewUint(1_000))  // $0.001
-	DefaultBeansPerMessageByte = DefaultBeansPerFeeUnit.Quo(sdk.NewUint(50_000)) // $0.0002
+	DefaultBeansPerMessageByte = DefaultBeansPerFeeUnit.Quo(sdk.NewUint(50_000)) // $0.00002
 	DefaultBeansPerMinFeeDebit = DefaultBeansPerFeeUnit.Quo(sdk.NewUint(5))      // $0.2
+	DefaultBeansPerStorageByte = DefaultBeansPerFeeUnit.Quo(sdk.NewUint(500))    // $0.002
 
 	DefaultBootstrapVatConfig = "@agoric/vats/decentral-core-config.json"
 
@@ -70,6 +72,7 @@ func DefaultBeansPerUnit() []StringBeans {
 		NewStringBeans(BeansPerMessage, DefaultBeansPerMessage),
 		NewStringBeans(BeansPerMessageByte, DefaultBeansPerMessageByte),
 		NewStringBeans(BeansPerMinFeeDebit, DefaultBeansPerMinFeeDebit),
+		NewStringBeans(BeansPerStorageByte, DefaultBeansPerStorageByte),
 		NewStringBeans(BeansPerVatCreation, DefaultBeansPerVatCreation),
 		NewStringBeans(BeansPerXsnapComputron, DefaultBeansPerXsnapComputron),
 	}


### PR DESCRIPTION
closes: #6858

## Description

Adds a new bean cost category for bytes in  permanent storage, plus migration logic to add the new parameter on upgrade.

Initially set to approx $2/KB.

### Security Considerations

Fee must be high enough to prevent abuse of storage.

### Scaling Considerations

Fee must be high enough to prevent abuse of storage while still keeping valid uses affordable.

### Documentation Considerations

Developers should be given warning of costs.

### Testing Considerations

Needs to be validated during end-to-end upgrade testing.
