### PR TITLE
fix: update package.json engines to 16 LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "~4.7.4"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": ">=16.1"
   },
   "prettier": {
     "arrowParens": "avoid",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "~4.7.4"
   },
   "engines": {
-    "node": ">=16.1"
+    "node": "^16.13 || ^18.12"
   },
   "prettier": {
     "arrowParens": "avoid",


### PR DESCRIPTION
## Description

`"engines": {    "node": ">=14.15.0" },` was misleading, since we no longer support node 14.

In particular, ci is specified as...

https://github.com/Agoric/agoric-sdk/blob/f4de2ed9637a83b826f777124c9785f886250de8/.github/workflows/test-all-packages.yml#L30

### Security, Scaling, Testing Considerations

none?

## TODO to get out of DRAFT status:

 - [x] I'm not certain how to express the equivalent of `16.*` in the `engines` field.

### Documentation Considerations

I'm pretty sure node 14 doesn't actually work, so it's unlikely that anyone is using it for anything serious.

https://docs.agoric.com/guides/getting-started/#quick-start should probably be updated too.
