### PR TITLE
fix Zoe offerResult durability handling

### DIFF
--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -55,9 +55,8 @@
  * @property {(allocation: Allocation) => void} replaceAllocation
  * @property {ZoeSeatAdminExit} exit
  * @property {ShutdownWithFailure} fail called with the reason
- * @property {() => Promise<Notifier<Allocation>> } getNotifier
  * for calling fail on this seat, where reason is normally an instanceof Error.
- * @property {() => Subscriber<unknown>} getExitSubscriber
+ * @property {() => Subscriber<AmountKeywordRecord>} getExitSubscriber
  */
 
 /**
@@ -66,8 +65,8 @@
 
 /**
  * @typedef {object} HandleOfferResult
- * @property {Promise<any>} offerResultPromise
- * @property {object} exitObj
+ * @property {Promise<unknown>} offerResultPromise
+ * @property {ExitObj} exitObj
  */
 
 /**
@@ -135,7 +134,7 @@
  * @property {() => void} stopAcceptingOffers
  * @property {(strings: Array<string>) => void} setOfferFilter
  * @property {() => Array<string>} getOfferFilter
- * @property {(seatHandle: SeatHandle) => Subscriber<any>} getExitSubscriber
+ * @property {(seatHandle: SeatHandle) => Subscriber<AmountKeywordRecord>} getExitSubscriber
  */
 
 /**

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -179,8 +179,8 @@ const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
       state.handleOfferObj || Fail`incomplete setup of zoe seat`;
       E.when(
         E(state.handleOfferObj).handleOffer(invitationHandle, seatData),
-        ({ offerResultPromise, exitObj }) =>
-          zoeSeatAdmin.resolveExitAndResult(offerResultPromise, exitObj),
+        /** @param {HandleOfferResult} result */
+        result => zoeSeatAdmin.resolveExitAndResult(result),
         err => {
           state.adminNode.terminateWithFailure(err);
           throw err;

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -214,7 +214,7 @@
  * @property {() => Promise<Allocation>} getFinalAllocation
  * return a promise for the final allocation. The promise will resolve after the
  * seat has exited.
- * @property {() => Subscriber<any>} getExitSubscriber returns a subscriber that
+ * @property {() => Subscriber<AmountKeywordRecord>} getExitSubscriber returns a subscriber that
  * will be notified when the seat has exited or failed.
  */
 


### PR DESCRIPTION
## Description

While investigating https://github.com/Agoric/agoric-sdk/pull/7219 @mhofman and I noticed that the offer result for a new vault wasn't ending up in durable storage.
- https://github.com/Agoric/agoric-sdk/issues/7297

This fixes the two reasons:
- it wasn't being assigned. fixed that through some promise reordering. that revealed that the copyRecord had a promise, which made the record non-durable
- this also deeply awaits the copyRecord to try getting it into a state that can be assigned (h/t @dckc )

For review this separates the supporting refactors from the fix.

### Security Considerations

A pathological offer result could return an offerResult whose properties are not resolving, consuming heap for promise tracking until vat termination. But they can already return an unresolvable promise and they can already return non-durable values.

Once the kernel adds virtual promises, this won't cost heap:
- https://github.com/Agoric/agoric-sdk/issues/3787

### Scaling Considerations

Non-pathological offer results could also consume heap as described in Security. Should not be a problem for Vaults Release.

### Documentation Considerations

Code comments. This does not constrain the offer result return type.

### Testing Considerations

Manual run of `stress vaults`. It doesn't make the vaults heap flat but it shows no non-durable objects stored.