### PR TITLE
fix(vaults): durable invitationMakers

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -52,6 +52,11 @@ export const prepareVaultHolder = (baggage, marshaller) => {
     {
       helper: UnguardedHelperI,
       holder: HolderI,
+      invitationMakers: M.interface('invitationMakers', {
+        AdjustBalances: M.call().returns(M.promise()),
+        CloseVault: M.call().returns(M.promise()),
+        TransferVault: M.call().returns(M.promise()),
+      }),
     },
     /**
      *
@@ -81,6 +86,17 @@ export const prepareVaultHolder = (baggage, marshaller) => {
         },
         getUpdater() {
           return this.state.publisher;
+        },
+      },
+      invitationMakers: {
+        AdjustBalances() {
+          return this.facets.holder.makeAdjustBalancesInvitation();
+        },
+        CloseVault() {
+          return this.facets.holder.makeCloseInvitation();
+        },
+        TransferVault() {
+          return this.facets.holder.makeTransferInvitation();
         },
       },
       holder: {

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -1,11 +1,12 @@
-import { makeTracer } from '@agoric/internal';
 import '@agoric/zoe/exported.js';
-import { Far } from '@endo/marshal';
+
+import { makeTracer } from '@agoric/internal';
 import { prepareVaultHolder } from './vaultHolder.js';
 
 const trace = makeTracer('VK', false);
 
 /**
+ * Wrap the VaultHolder duration object in a record suitable for the result of an invitation.
  *
  * @param {import('@agoric/ertp').Baggage} baggage
  * @param {ERef<Marshaller>} marshaller
@@ -22,17 +23,16 @@ export const prepareVaultKit = (baggage, marshaller) => {
    */
   const makeVaultKit = (vault, storageNode) => {
     trace('prepareVaultKit makeVaultKit');
-    const { holder, helper } = makeVaultHolder(vault, storageNode);
+    const { holder, helper, invitationMakers } = makeVaultHolder(
+      vault,
+      storageNode,
+    );
     const holderTopics = holder.getPublicTopics();
     const vaultKit = harden({
       publicSubscribers: {
         vault: holderTopics.vault,
       },
-      invitationMakers: Far('invitation makers', {
-        AdjustBalances: () => holder.makeAdjustBalancesInvitation(),
-        CloseVault: () => holder.makeCloseInvitation(),
-        TransferVault: () => holder.makeTransferInvitation(),
-      }),
+      invitationMakers,
       vault: holder,
       vaultUpdater: helper.getUpdater(),
     });


### PR DESCRIPTION
## Description

The Far object for `invitationMakers` in the vault offer result cannot be stored durably. This fixes that by making it a durable facet. Combined with https://github.com/Agoric/agoric-sdk/pull/7294 the vault offer result can be stored durably.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

CI