### PR TITLE
fix: agops: no I/O (errors) until command action

### DIFF
--- a/packages/agoric-cli/src/commands/ec.js
+++ b/packages/agoric-cli/src/commands/ec.js
@@ -6,8 +6,6 @@ import { Command } from 'commander';
 import { makeRpcUtils, storageHelper } from '../lib/rpc.js';
 import { outputExecuteOfferAction } from '../lib/wallet.js';
 
-const { vstorage, fromBoard, agoricNames } = await makeRpcUtils({ fetch });
-
 /**
  *
  * @param {import('anylogger').Logger} _logger
@@ -24,6 +22,8 @@ export const makeEconomicCommiteeCommand = async _logger => {
       `ecCommittee-${Date.now()}`,
     )
     .action(async function (opts) {
+      const { agoricNames } = await makeRpcUtils({ fetch });
+
       const { economicCommittee } = agoricNames.instance;
       assert(economicCommittee, 'missing economicCommittee');
 
@@ -47,6 +47,8 @@ export const makeEconomicCommiteeCommand = async _logger => {
     .description('prepare an offer to accept the charter invitation')
     .option('--offerId [string]', 'Offer id', String, `ecCharter-${Date.now()}`)
     .action(async function (opts) {
+      const { agoricNames } = await makeRpcUtils({ fetch });
+
       const { econCommitteeCharter } = agoricNames.instance;
       assert(econCommitteeCharter, 'missing econCommitteeCharter');
 
@@ -79,6 +81,8 @@ export const makeEconomicCommiteeCommand = async _logger => {
       Number,
     )
     .action(async function (opts) {
+      const { vstorage, fromBoard } = await makeRpcUtils({ fetch });
+
       const questionHandleCapDataStr = await vstorage.readLatest(
         'published.committees.Economic_Committee.latestQuestion',
       );

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -9,8 +9,6 @@ import { inspect } from 'util';
 import { makeRpcUtils, storageHelper } from '../lib/rpc.js';
 import { outputAction } from '../lib/wallet.js';
 
-const { agoricNames, fromBoard, vstorage } = await makeRpcUtils({ fetch });
-
 // XXX support other decimal places
 const COSMOS_UNIT = 1_000_000n;
 const scaleDecimals = num => BigInt(num * Number(COSMOS_UNIT));
@@ -43,14 +41,20 @@ export const makeOracleCommand = async logger => {
   `,
   );
 
-  const lookupPriceAggregatorInstance = ([brandIn, brandOut]) => {
-    const name = `${brandIn}-${brandOut} price feed`;
-    const instance = agoricNames.instance[name];
-    if (!instance) {
-      logger.debug('known instances:', agoricNames.instance);
-      throw new Error(`Unknown instance ${name}`);
-    }
-    return instance;
+  const rpcTools = async () => {
+    const utils = await makeRpcUtils({ fetch });
+
+    const lookupPriceAggregatorInstance = ([brandIn, brandOut]) => {
+      const name = `${brandIn}-${brandOut} price feed`;
+      const instance = utils.agoricNames.instance[name];
+      if (!instance) {
+        logger.debug('known instances:', utils.agoricNames.instance);
+        throw new Error(`Unknown instance ${name}`);
+      }
+      return instance;
+    };
+
+    return { ...utils, lookupPriceAggregatorInstance };
   };
 
   oracle
@@ -64,6 +68,7 @@ export const makeOracleCommand = async logger => {
     )
     .option('--offerId [number]', 'Offer id', Number, Date.now())
     .action(async function (opts) {
+      const { lookupPriceAggregatorInstance } = await rpcTools();
       const instance = lookupPriceAggregatorInstance(opts.pair);
 
       /** @type {import('@agoric/smart-wallet/src/offers.js').OfferSpec} */
@@ -160,6 +165,7 @@ export const makeOracleCommand = async logger => {
     )
     .action(async function (opts) {
       const { pair } = opts;
+      const { vstorage, fromBoard } = await rpcTools();
 
       const capDataStr = await vstorage.readLatest(
         `published.priceFeed.${pair[0]}-${pair[1]}_price_feed`,

--- a/packages/agoric-cli/src/commands/psm.js
+++ b/packages/agoric-cli/src/commands/psm.js
@@ -30,25 +30,6 @@ function collectValues(val, memo) {
   return memo;
 }
 
-const { vstorage, fromBoard, agoricNames } = await makeRpcUtils({ fetch });
-
-/**
- *
- * @param {[Minted: string, Anchor: string]} pair
- */
-const getGovernanceState = async ([Minted, Anchor]) => {
-  const govContent = await vstorage.readLatest(
-    `published.psm.${Minted}.${Anchor}.governance`,
-  );
-  assert(govContent, 'no gov content');
-  const { current: governance } = last(
-    storageHelper.unserializeTxt(govContent, fromBoard),
-  );
-  const { [`psm.${Minted}.${Anchor}`]: instance } = agoricNames.instance;
-
-  return { instance, governance };
-};
-
 /**
  *
  * @param {import('anylogger').Logger} logger
@@ -81,20 +62,45 @@ export const makePsmCommand = async logger => {
   `,
   );
 
-  const lookupPsmInstance = ([minted, anchor]) => {
-    const name = `psm-${minted}-${anchor}`;
-    const instance = agoricNames.instance[name];
-    if (!instance) {
-      logger.debug('known instances:', agoricNames.instance);
-      throw new Error(`Unknown instance ${name}`);
-    }
-    return instance;
+  const rpcTools = async () => {
+    const utils = await makeRpcUtils({ fetch });
+
+    const lookupPsmInstance = ([minted, anchor]) => {
+      const name = `psm-${minted}-${anchor}`;
+      const instance = utils.agoricNames.instance[name];
+      if (!instance) {
+        logger.debug('known instances:', utils.agoricNames.instance);
+        throw new Error(`Unknown instance ${name}`);
+      }
+      return instance;
+    };
+
+    /**
+     *
+     * @param {[Minted: string, Anchor: string]} pair
+     */
+    const getGovernanceState = async ([Minted, Anchor]) => {
+      const govContent = await utils.vstorage.readLatest(
+        `published.psm.${Minted}.${Anchor}.governance`,
+      );
+      assert(govContent, 'no gov content');
+      const { current: governance } = last(
+        storageHelper.unserializeTxt(govContent, utils.fromBoard),
+      );
+      const { [`psm.${Minted}.${Anchor}`]: instance } =
+        utils.agoricNames.instance;
+
+      return { instance, governance };
+    };
+
+    return { ...utils, lookupPsmInstance, getGovernanceState };
   };
 
   psm
     .command('list')
     .description('list all PSMs in network')
     .action(async function () {
+      const { vstorage } = await rpcTools();
       const mints = await vstorage.keys('published.psm');
       for (const minted of mints) {
         const anchors = await vstorage.keys(`published.psm.${minted}`);
@@ -116,6 +122,7 @@ export const makePsmCommand = async logger => {
     )
     .action(async function (opts) {
       const { pair } = opts;
+      const { getGovernanceState } = await rpcTools();
       const { governance } = await getGovernanceState(pair);
       console.log('psm governance params', Object.keys(governance));
       console.log('MintLimit', governance.MintLimit.value);
@@ -149,6 +156,7 @@ export const makePsmCommand = async logger => {
     .option('--offerId [string]', 'Offer id', String, `swap-${Date.now()}`)
     .action(async function (opts) {
       console.warn('running with options', opts);
+      const { agoricNames, lookupPsmInstance } = await rpcTools();
       const instance = await lookupPsmInstance(opts.pair);
       const offer = Offers.psm.swap(instance, agoricNames.brand, {
         offerId: opts.offerId,
@@ -191,6 +199,7 @@ export const makePsmCommand = async logger => {
       1,
     )
     .action(async function (opts) {
+      const { lookupPsmInstance } = await rpcTools();
       const psmInstance = lookupPsmInstance(opts.pair);
 
       /** @type {import('@agoric/smart-wallet/src/offers.js').OfferSpec} */
@@ -242,6 +251,7 @@ export const makePsmCommand = async logger => {
       1,
     )
     .action(async function (opts) {
+      const { agoricNames, lookupPsmInstance } = await rpcTools();
       const psmInstance = lookupPsmInstance(opts.pair);
 
       const istBrand = agoricNames.brand.IST;

--- a/packages/agoric-cli/src/commands/reserve.js
+++ b/packages/agoric-cli/src/commands/reserve.js
@@ -6,8 +6,6 @@ import { Command } from 'commander';
 import { makeRpcUtils } from '../lib/rpc.js';
 import { outputExecuteOfferAction } from '../lib/wallet.js';
 
-const { agoricNames } = await makeRpcUtils({ fetch });
-
 /**
  *
  * @param {import('anylogger').Logger} _logger
@@ -36,6 +34,8 @@ export const makeReserveCommand = async _logger => {
       1,
     )
     .action(async function (opts) {
+      const { agoricNames } = await makeRpcUtils({ fetch });
+
       const reserveInstance = agoricNames.instance.reserve;
       assert(reserveInstance, 'missing reserve in names');
 

--- a/packages/agoric-cli/src/commands/vaults.js
+++ b/packages/agoric-cli/src/commands/vaults.js
@@ -12,10 +12,6 @@ import { normalizeAddressWithOptions } from '../lib/chain.js';
 import { makeRpcUtils } from '../lib/rpc.js';
 import { getCurrent, outputExecuteOfferAction } from '../lib/wallet.js';
 
-const { agoricNames, readLatestHead } = await makeRpcUtils({
-  fetch,
-});
-
 /**
  *
  * @param {import('anylogger').Logger} logger
@@ -43,6 +39,8 @@ export const makeVaultsCommand = async logger => {
       normalizeAddress,
     )
     .action(async function (opts) {
+      const { readLatestHead } = await makeRpcUtils({ fetch });
+
       const current = await getCurrent(opts.from, {
         readLatestHead,
       });
@@ -66,6 +64,7 @@ export const makeVaultsCommand = async logger => {
     .option('--collateralBrand [string]', 'Collateral brand key', 'IbcATOM')
     .action(async function (opts) {
       logger.warn('running with options', opts);
+      const { agoricNames } = await makeRpcUtils({ fetch });
 
       const offer = Offers.vaults.OpenVault(agoricNames.brand, {
         giveCollateral: opts.giveCollateral,
@@ -95,6 +94,7 @@ export const makeVaultsCommand = async logger => {
     .requiredOption('--vaultId [string]', 'Key of vault (e.g. vault1)')
     .action(async function (opts) {
       logger.warn('running with options', opts);
+      const { agoricNames, readLatestHead } = await makeRpcUtils({ fetch });
 
       const previousOfferId = await lookupOfferIdForVault(
         opts.vaultId,
@@ -130,6 +130,7 @@ export const makeVaultsCommand = async logger => {
     .requiredOption('--vaultId [string]', 'Key of vault (e.g. vault1)')
     .action(async function (opts) {
       logger.warn('running with options', opts);
+      const { agoricNames, readLatestHead } = await makeRpcUtils({ fetch });
 
       const previousOfferId = await lookupOfferIdForVault(
         opts.vaultId,


### PR DESCRIPTION
refs: #6930
factoring out of #7256

## Description

Each of `commands/oracle.js`, `commands/ec.js` etc. was calling `makeRpcUtils` on module import. Not only did this slow things down, it made catching I/O errors in the `agops inter` command infeasible.

### Scaling Considerations

about 20 fewer RPC requests per `agops` command.

### Security, Documentation Considerations

Not much... perhaps nicer diagnostics for `agops inter` is documentation.

### Testing Considerations

no change in the (lack of) automated testing
