### PR TITLE
fix(wallet): recording handleBridgeAction errors

### DIFF
--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -163,7 +163,7 @@ export const prepare = async (zcf, privateArgs, baggage) => {
        * associate it with. (We could have a shared `lastError` node but it would be so noisy as to
        * not provide much info to the end user.)
        *
-       * Once the owner is known, this calls handleBridgeAction which is then ensure that all errors
+       * Once the owner is known, this calls handleBridgeAction which ensures that all errors
        * are published in the owner wallet's vstorage path.
        *
        * @param {import('./types.js').WalletBridgeMsg} obj validated by shape.WalletBridgeMsg


### PR DESCRIPTION
## Description

Fixes a gap identified in https://github.com/Agoric/agoric-sdk/issues/7004#issuecomment-1492143515

The pre-offer error handler handling failures only in the promise to `E.when`, not its fulfillment handler. Simply making it catch the fulfillment handler too is wrong because once it reaches the offer executor that publishes a more useful promise and the latter handler muddies the records. So instead this explicitly handles errors before it gets to the delegated `offers` handlers.

### Security Considerations

--

### Scaling Considerations

More errors written to vstorage.

### Documentation Considerations

--
### Testing Considerations

new test