### PR TITLE
refactor: resync endo MinMethodGuard migration

### DIFF
--- a/packages/store/src/patterns/exo-tools.js
+++ b/packages/store/src/patterns/exo-tools.js
@@ -1,11 +1,19 @@
 import { E, Far } from '@endo/far';
 import { listDifference, objectMap } from '@agoric/internal';
 
-import { MinMethodGuard, mustMatch, M } from './patternMatchers.js';
+import { mustMatch, M } from './patternMatchers.js';
 
 const { quote: q, Fail } = assert;
 const { apply, ownKeys } = Reflect;
 const { defineProperties } = Object;
+
+/**
+ * A method guard, for inclusion in an interface guard, that enforces only that
+ * all arguments are passable and that the result is passable. (In far classes,
+ * "any" means any *passable*.) This is the least possible enforcement for a
+ * method guard, and is implied by all other method guards.
+ */
+const MinMethodGuard = M.call().rest(M.any()).returns(M.any());
 
 const defendSyncArgs = (args, methodGuard, label) => {
   const { argGuards, optionalArgGuards, restArgGuard } = methodGuard;

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -1695,12 +1695,4 @@ export const {
   M,
 } = makePatternKit();
 
-/**
- * A method guard, for inclusion in an interface guard, that enforces only that
- * all arguments are passable and that the result is passable. (In far classes,
- * "any" means any *passable*.) This is the least possible enforcement for a
- * method guard, and is implied by all other method guards.
- */
-export const MinMethodGuard = M.call().rest(M.any()).returns(M.any());
-
 MM = M;


### PR DESCRIPTION
See https://github.com/endojs/endo/pull/1532#discussion_r1156517994

`MinMethodGuard` is only used by `exo-tools.js`, and is not general enough to be worth making into a package export, so migrate its definition from `patternMatchers.js` to its own client, `exo-tools.js`.