### PR TITLE
scope restricted-syntax

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,7 +48,6 @@ module.exports = {
     // CI has a separate format check but keep this warn to maintain that "eslint --fix" prettifies
     // UNTIL https://github.com/Agoric/agoric-sdk/issues/4339
     'prettier/prettier': 'warn',
-    'no-restricted-syntax': ['warn', ...deprecatedTerminology],
   },
   settings: {
     jsdoc: {
@@ -83,6 +82,8 @@ module.exports = {
         // are code-reviewed.
         // TODO upgrade this to 'error'
         '@jessie.js/no-nested-await': 'warn',
+        // TODO upgrade this (or a subset) to 'error'
+        'no-restricted-syntax': ['warn', ...deprecatedTerminology],
       },
     },
     {


### PR DESCRIPTION
## Description

The no-restricted-syntax warning on tests was making a wall of warnings in my IDE, making it harder to notice more substantive ones. Some of the rules don't apply to test code (like "RUN", which is fine for tests).

So this changes the rule to apply only to product / exported code. We should prioritize burning those down and getting to 'error' so they can't reappear. Then we can decide what policy we want for tests. Most of the ones in tests will be solved by changing the code under test.

This also burns down the InterestTiming configuration.

### Security Considerations

--
### Scaling Considerations

--

### Documentation Considerations

--
### Testing Considerations

CI