### PR TITLE
Workaround ava worker deadlocks

### DIFF
--- a/packages/ERTP/test/swingsetTests/ertpService/test-ertp-service-upgrade.js
+++ b/packages/ERTP/test/swingsetTests/ertpService/test-ertp-service-upgrade.js
@@ -25,6 +25,7 @@ test('ertp service upgrade', async t => {
   };
 
   const c = await buildVatController(config);
+  t.teardown(c.shutdown);
   c.pinVatRoot('bootstrap');
   await c.run();
 

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -139,7 +139,8 @@ export async function runVatsInComms(t, name) {
     loopbox: { ...loopboxEndowments },
   };
   const { initOpts, runtimeOpts } = bundleOpts(t.context.data);
-  const kernelStorage = initSwingStore().kernelStorage;
+  const { kernelStorage, hostStorage } = initSwingStore();
+  t.teardown(hostStorage.close);
   await initializeSwingset(config, [name], kernelStorage, initOpts);
   const c = await makeSwingsetController(kernelStorage, devEndows, runtimeOpts);
   t.teardown(c.shutdown);

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate-replay.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate-replay.js
@@ -31,6 +31,7 @@ test.serial('replay does not resurrect dead vat', async t => {
     t.deepEqual(c1.kpResolution(c1.bootstrapResult), kser('bootstrap done'));
     // this comes from the dynamic vat...
     t.deepEqual(c1.dump().log, [`w: I ate'nt dead`]);
+    await c1.shutdown();
   }
 
   const serialized = ss1.debug.serialize();
@@ -43,5 +44,6 @@ test.serial('replay does not resurrect dead vat', async t => {
     await c2.run();
     // ...which shouldn't run the second time through
     t.deepEqual(c2.dump().log, []);
+    await c2.shutdown();
   }
 });

--- a/packages/SwingSet/test/zcf-ish-upgrade/test-zcf-ish-upgrade.js
+++ b/packages/SwingSet/test/zcf-ish-upgrade/test-zcf-ish-upgrade.js
@@ -26,9 +26,11 @@ test('zcf-ish upgrade', async t => {
     },
   };
 
-  const kernelStorage = initSwingStore().kernelStorage;
+  const { kernelStorage, hostStorage } = initSwingStore();
+  t.teardown(hostStorage.close);
   await initializeSwingset(config, [], kernelStorage);
   const c = await makeSwingsetController(kernelStorage);
+  t.teardown(c.shutdown);
   c.pinVatRoot('bootstrap');
   await c.run();
 

--- a/packages/agoric-cli/test/test-publish-bundle.js
+++ b/packages/agoric-cli/test/test-publish-bundle.js
@@ -167,6 +167,18 @@ test('publish bundle with fake HTTP server ok', async t => {
       t.fail(error);
     });
   });
+  t.teardown(
+    () =>
+      new Promise((resolve, reject) =>
+        server.close(err => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        }),
+      ),
+  );
 
   await new Promise(resolve => {
     server.listen(0, () => resolve(undefined));

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/test-walletFactory-service-upgrade.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/test-walletFactory-service-upgrade.js
@@ -45,6 +45,7 @@ test('walletFactory service upgrade', async t => {
 
   t.log('buildVatController');
   const c = await buildVatController(config);
+  t.teardown(c.shutdown);
   c.pinVatRoot('bootstrap');
   t.log('run controller');
   await c.run();

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -297,7 +297,7 @@ export const makeSwingsetTestKit = async (
 ) => {
   console.time('makeSwingsetTestKit');
   const configPath = await getNodeTestVaultsConfig(bundleDir, specifier);
-  const { kernelStorage } = initSwingStore();
+  const { kernelStorage, hostStorage } = initSwingStore();
 
   const storage = makeFakeStorageKit('bootstrapTests');
 
@@ -368,5 +368,8 @@ export const makeSwingsetTestKit = async (
 
   console.timeEnd('makeSwingsetTestKit');
 
-  return { controller, runUtils, storage };
+  const shutdown = async () =>
+    Promise.all([controller.shutdown(), hostStorage.close()]).then(() => {});
+
+  return { controller, runUtils, storage, shutdown };
 };

--- a/packages/vats/test/bootstrapTests/test-demo-config.js
+++ b/packages/vats/test/bootstrapTests/test-demo-config.js
@@ -21,6 +21,7 @@ const makeDefaultTestContext = async t => {
 };
 
 test.before(async t => (t.context = await makeDefaultTestContext(t)));
+test.after(async t => t.context.shutdown());
 
 // Goal: test that prod config does not expose mailbox access.
 // But on the JS side, aside from vattp, prod config exposes mailbox access

--- a/packages/vats/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-integration.js
@@ -68,7 +68,7 @@ test.before(async t => {
 });
 test.after(async t => {
   // not strictly necessary but conveys that we keep the controller around for the whole test file
-  await E(t.context.controller).shutdown();
+  await E(t.context).shutdown();
 });
 
 test('metrics path', async t => {

--- a/packages/vats/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-integration.js
@@ -67,7 +67,6 @@ test.before(async t => {
   t.context = await makeDefaultTestContext(t);
 });
 test.after(async t => {
-  // not strictly necessary but conveys that we keep the controller around for the whole test file
   await E(t.context).shutdown();
 });
 

--- a/packages/vats/test/bootstrapTests/test-vaults-performance.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-performance.js
@@ -95,7 +95,6 @@ test.before(async t => {
   t.context = await makeDefaultTestContext(t);
 });
 test.after(async t => {
-  // not strictly necessary but conveys that we keep the controller around for the whole test file
   await E(t.context).shutdown();
 });
 

--- a/packages/vats/test/bootstrapTests/test-vaults-performance.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-performance.js
@@ -96,7 +96,7 @@ test.before(async t => {
 });
 test.after(async t => {
   // not strictly necessary but conveys that we keep the controller around for the whole test file
-  await E(t.context.controller).shutdown();
+  await E(t.context).shutdown();
 });
 
 const rows = [];

--- a/packages/vats/test/upgrading/test-upgrade-contracts.js
+++ b/packages/vats/test/upgrading/test-upgrade-contracts.js
@@ -49,6 +49,7 @@ test('upgrade mintHolder', async t => {
   // console.debug('config', JSON.stringify(config, null, 2));
 
   const c = await buildVatController(config);
+  t.teardown(c.shutdown);
   c.pinVatRoot('bootstrap');
   await c.run();
 

--- a/packages/xsnap/test/test-err-stack.js
+++ b/packages/xsnap/test/test-err-stack.js
@@ -47,11 +47,15 @@ async function makeWorker() {
       const { reply } = await vat.issueStringCommand(src);
       return JSON.parse(reply);
     },
+    async close() {
+      return vat.close();
+    },
   };
 }
 
 test('XS stack traces include file, line numbers', async t => {
   const w = await makeWorker();
+  t.teardown(w.close);
 
   const x = await w.run('1+1');
   t.is(x, 2);

--- a/packages/xsnap/test/test-inspect.js
+++ b/packages/xsnap/test/test-inspect.js
@@ -85,11 +85,15 @@ async function makeWorker() {
       const { reply } = await vat.issueStringCommand(src);
       return JSON.parse(reply);
     },
+    async close() {
+      return vat.close();
+    },
   };
 }
 
 test('xsnap inspect', async t => {
   const w = await makeWorker();
+  t.teardown(w.close);
 
   const isLockdownWarning = args => args[0].startsWith('Removing intrinsics.');
   const x = await w.run(`2+3`);

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
@@ -34,6 +34,7 @@ test('coveredCall service upgrade', async t => {
   };
 
   const c = await buildVatController(config);
+  t.teardown(c.shutdown);
   c.pinVatRoot('bootstrap');
   await c.run();
 

--- a/patches/ava+5.2.0.patch
+++ b/patches/ava+5.2.0.patch
@@ -7,7 +7,7 @@ index 0000000..bee62d8
 +// XXX work around https://github.com/import-js/eslint-plugin-import/issues/1810
 +export {default} from './lib/worker/main.cjs';
 diff --git a/node_modules/ava/lib/cli.js b/node_modules/ava/lib/cli.js
-index afe5528..67f523f 100644
+index afe5528..f748fec 100644
 --- a/node_modules/ava/lib/cli.js
 +++ b/node_modules/ava/lib/cli.js
 @@ -436,6 +436,10 @@ export default async function loadCli() { // eslint-disable-line complexity
@@ -21,6 +21,74 @@ index afe5528..67f523f 100644
  	const reporter = combined.tap && !combined.watch && debug === null ? new TapReporter({
  		extensions: globs.extensions,
  		projectDir,
+diff --git a/node_modules/ava/lib/fork.js b/node_modules/ava/lib/fork.js
+index 7630baa..15647a1 100644
+--- a/node_modules/ava/lib/fork.js
++++ b/node_modules/ava/lib/fork.js
+@@ -7,6 +7,7 @@ import Emittery from 'emittery';
+ import {pEvent} from 'p-event';
+ 
+ import {controlFlow} from './ipc-flow-control.cjs';
++import {setCappedTimeout} from './now-and-timers.cjs';
+ import serializeError from './serialize-error.js';
+ 
+ let workerPath = new URL('worker/base.js', import.meta.url);
+@@ -91,6 +92,11 @@ export default function loadFork(file, options, execArgv = process.execArgv) {
+ 	});
+ 
+ 	let forcedExit = false;
++	let exitCode = null;
++	const exit = () => {
++		forcedExit = true;
++		close();
++	};
+ 	const send = evt => {
+ 		if (!finished && !forcedExit) {
+ 			postMessage({ava: evt});
+@@ -132,6 +138,12 @@ export default function loadFork(file, options, execArgv = process.execArgv) {
+ 					break;
+ 				}
+ 
++				case 'exiting': {
++					exitCode = message.ava.code;
++					setCappedTimeout(() => finished || exit(), 10_000).unref();
++					break;
++				}
++
+ 				default: {
+ 					emitStateChange(message.ava);
+ 				}
+@@ -145,9 +157,15 @@ export default function loadFork(file, options, execArgv = process.execArgv) {
+ 
+ 		worker.on('exit', (code, signal) => {
+ 			if (forcedExit) {
+-				emitStateChange({type: 'worker-finished', forcedExit});
+-			} else if (code > 0) {
+-				emitStateChange({type: 'worker-failed', nonZeroExitCode: code});
++				if (exitCode === null) {
++					emitStateChange({type: 'worker-finished', forcedExit});
++				} else if (!exitCode) {
++					emitStateChange({type: 'worker-failed', err: Error('Test did not cleanup'), signal: 'exit timeout'});
++				} else {
++					emitStateChange({type: 'worker-failed', nonZeroExitCode: exitCode});
++				}
++			} else if (code > 0 || exitCode > 0) {
++				emitStateChange({type: 'worker-failed', nonZeroExitCode: code || exitCode});
+ 			} else if (code === null && signal) {
+ 				emitStateChange({type: 'worker-failed', signal});
+ 			} else {
+@@ -163,10 +181,7 @@ export default function loadFork(file, options, execArgv = process.execArgv) {
+ 		threadId: worker.threadId,
+ 		promise,
+ 
+-		exit() {
+-			forcedExit = true;
+-			close();
+-		},
++		exit,
+ 
+ 		notifyOfPeerFailure() {
+ 			send({type: 'peer-failed'});
 diff --git a/node_modules/ava/lib/reporters/tap.js b/node_modules/ava/lib/reporters/tap.js
 index b1989a4..fa1617f 100644
 --- a/node_modules/ava/lib/reporters/tap.js
@@ -53,3 +121,24 @@ index b1989a4..fa1617f 100644
  			comment: evt.logs,
  			error: evt.err ? dumpError(evt.err) : null,
  			index: ++this.i,
+diff --git a/node_modules/ava/lib/worker/base.js b/node_modules/ava/lib/worker/base.js
+index cdd3c4a..3e2942c 100644
+--- a/node_modules/ava/lib/worker/base.js
++++ b/node_modules/ava/lib/worker/base.js
+@@ -28,12 +28,14 @@ const realExit = process.exit;
+ 
+ async function exit(code, forceSync = false) {
+ 	dependencyTracking.flush();
++	channel.send({type: 'exiting', code});
+ 	const flushing = channel.flush();
+ 	if (!forceSync) {
+ 		await flushing;
++		process.exitCode ||= code;
++	} else {
++		apply(realExit, process, [code]);
+ 	}
+-
+-	apply(realExit, process, [code]);
+ }
+ 
+ const handleProcessExit = (fn, receiver, args) => {


### PR DESCRIPTION
We've been hit by a few test failures where the process pegs the CPU at 100%, and never exits. I am convinced this is a race condition somewhere in Node.js related to message sends from the worker thread combined with a forced exit from that thread.

I implemented a work around in ava to let the worker exit on its own, with a fallback of force termination from the parent if it doesn't, which seem to consistently allow the test to exit.

While working on this, I also noticed that some tests do not shutdown the controller and/or close the DB, which may cause worker hangs.