### PR TITLE
swingStore.close() should abort any pending changes, not commit them

### DIFF
--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -826,7 +826,6 @@ function makeSwingStore(dirPath, forceReset, options = {}) {
    */
   async function close() {
     db || Fail`db not initialized`;
-    commit();
     db.close();
     db = null;
     stopTrace();


### PR DESCRIPTION
An errant `commit()` in `close()` meant that any pending changes were committed, when we document `close()` as abandoning them.

closes #7331
