### PR TITLE
feat: governable interestTiming

### DIFF
--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -237,7 +237,7 @@ const handleParamGovernance = async (
   const paramManager = await makeParamManagerFromTerms(
     publisherKit,
     zcf,
-    initialPoserInvitation,
+    { Electorate: initialPoserInvitation },
     paramTypesMap,
   );
 

--- a/packages/governance/test/unitTests/test-typedParamManager.js
+++ b/packages/governance/test/unitTests/test-typedParamManager.js
@@ -52,7 +52,7 @@ test('makeParamManagerFromTerms', async t => {
     makeStoredPublisherKit(),
     // @ts-expect-error missing governance terms
     zcf,
-    zcf.makeInvitation(() => null, 'mock poser invitation'),
+    { Electorate: zcf.makeInvitation(() => null, 'mock poser invitation') },
     {
       Mmr: 'ratio',
     },

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -258,21 +258,18 @@ export const startVaultFactory = async (
   const storageNode = await makeStorageNodeChild(chainStorage, STORAGE_PATH);
   const marshaller = await E(board).getReadonlyMarshaller();
 
-  const vaultFactoryTerms = makeGovernedVFTerms(
-    { storageNode, marshaller },
-    {
-      priceAuthority,
-      auctioneerPublicFacet,
-      reservePublicFacet,
-      interestTiming,
-      timer: chainTimerService,
-      electorateInvitationAmount: poserInvitationAmount,
-      minInitialDebt: AmountMath.make(centralBrand, minInitialDebt),
-      bootstrapPaymentValue: 0n,
-      shortfallInvitationAmount,
-      endorsedUi,
-    },
-  );
+  const vaultFactoryTerms = makeGovernedVFTerms({
+    priceAuthority,
+    auctioneerPublicFacet,
+    reservePublicFacet,
+    interestTiming,
+    timer: chainTimerService,
+    electorateInvitationAmount: poserInvitationAmount,
+    minInitialDebt: AmountMath.make(centralBrand, minInitialDebt),
+    bootstrapPaymentValue: 0n,
+    shortfallInvitationAmount,
+    endorsedUi,
+  });
 
   const governorTerms = await deeplyFulfilledObject(
     harden({

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -186,7 +186,7 @@ export const setupReserve = async ({
 /**
  * @param {EconomyBootstrapPowers} powers
  * @param {object} config
- * @param {LoanTiming} [config.loanParams]
+ * @param {InterestTiming} [config.interestTiming]
  * @param {object} [config.options]
  * @param {string} [config.options.endorsedUi]
  * @param {bigint} minInitialDebt
@@ -220,7 +220,7 @@ export const startVaultFactory = async (
     },
   },
   {
-    loanParams = {
+    interestTiming = {
       chargingPeriod: SECONDS_PER_HOUR,
       recordingPeriod: SECONDS_PER_DAY,
     },
@@ -264,7 +264,7 @@ export const startVaultFactory = async (
       priceAuthority,
       auctioneerPublicFacet,
       reservePublicFacet,
-      loanTiming: loanParams,
+      interestTiming,
       timer: chainTimerService,
       electorateInvitationAmount: poserInvitationAmount,
       minInitialDebt: AmountMath.make(centralBrand, minInitialDebt),

--- a/packages/inter-protocol/src/vaultFactory/params.js
+++ b/packages/inter-protocol/src/vaultFactory/params.js
@@ -139,7 +139,7 @@ harden(makeVaultDirectorParamManager);
  *   priceAuthority: ERef<PriceAuthority>,
  *   timer: ERef<import('@agoric/time/src/types').TimerService>,
  *   reservePublicFacet: AssetReservePublicFacet,
- *   loanTiming: LoanTiming,
+ *   interestTiming: InterestTiming,
  *   shortfallInvitationAmount: Amount,
  *   endorsedUi?: string,
  * }} opts
@@ -150,7 +150,7 @@ export const makeGovernedTerms = (
     auctioneerPublicFacet,
     bootstrapPaymentValue,
     electorateInvitationAmount,
-    loanTiming,
+    interestTiming,
     minInitialDebt,
     priceAuthority,
     reservePublicFacet,
@@ -159,16 +159,18 @@ export const makeGovernedTerms = (
     endorsedUi = 'NO ENDORSEMENT',
   },
 ) => {
-  const loanTimingParams = makeParamManagerSync(
+  const interestTimingParams = makeParamManagerSync(
+    // XXX not actually governed
+    // FIXME storage writes not tested
     makeStoredPublisherKit(storageNode, marshaller, 'timingParams'),
     {
       [CHARGING_PERIOD_KEY]: [
         'nat',
-        TimeMath.relValue(loanTiming.chargingPeriod),
+        TimeMath.relValue(interestTiming.chargingPeriod),
       ],
       [RECORDING_PERIOD_KEY]: [
         'nat',
-        TimeMath.relValue(loanTiming.recordingPeriod),
+        TimeMath.relValue(interestTiming.recordingPeriod),
       ],
     },
   ).getParams();
@@ -176,7 +178,7 @@ export const makeGovernedTerms = (
   return harden({
     auctioneerPublicFacet,
     priceAuthority,
-    loanTimingParams,
+    interestTimingParams,
     reservePublicFacet,
     timerService: timer,
     governedParams: makeVaultDirectorParams(

--- a/packages/inter-protocol/src/vaultFactory/params.js
+++ b/packages/inter-protocol/src/vaultFactory/params.js
@@ -5,7 +5,6 @@ import {
   makeParamManagerSync,
   ParamTypes,
 } from '@agoric/governance';
-import { makeParamManagerFromTerms } from '@agoric/governance/src/contractGovernance/typedParamManager.js';
 import { M } from '@agoric/store';
 import { TimeMath } from '@agoric/time';
 import { subtractRatios } from '@agoric/zoe/src/contractSupport/ratio.js';
@@ -23,6 +22,14 @@ export const LOAN_FEE_KEY = 'LoanFee';
 export const MIN_INITIAL_DEBT_KEY = 'MinInitialDebt';
 export const SHORTFALL_INVITATION_KEY = 'ShortfallInvitation';
 export const ENDORSED_UI_KEY = 'EndorsedUI';
+
+export const vaultDirectorParamTypes = {
+  [MIN_INITIAL_DEBT_KEY]: ParamTypes.AMOUNT,
+  [CHARGING_PERIOD_KEY]: ParamTypes.NAT,
+  [RECORDING_PERIOD_KEY]: ParamTypes.NAT,
+  [ENDORSED_UI_KEY]: ParamTypes.STRING,
+};
+harden(vaultDirectorParamTypes);
 
 /**
  * @param {Amount} electorateInvitationAmount
@@ -108,36 +115,6 @@ export const vaultParamPattern = M.splitRecord(
     liquidationPadding: ratioPattern,
   },
 );
-
-/**
- * @param {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} publisherKit
- * @param {ZCF<GovernanceTerms<import('./params').VaultDirectorParams>>} zcf
- * @param {Invitation} electorateInvitation
- * @param {Invitation} shortfallInvitation
- */
-export const makeVaultDirectorParamManager = async (
-  publisherKit,
-  zcf,
-  electorateInvitation,
-  shortfallInvitation,
-) => {
-  const paramTypesMap = {
-    [MIN_INITIAL_DEBT_KEY]: ParamTypes.AMOUNT,
-    [CHARGING_PERIOD_KEY]: ParamTypes.NAT,
-    [RECORDING_PERIOD_KEY]: ParamTypes.NAT,
-    [ENDORSED_UI_KEY]: ParamTypes.STRING,
-  };
-  return makeParamManagerFromTerms(
-    publisherKit,
-    zcf,
-    {
-      [CONTRACT_ELECTORATE]: electorateInvitation,
-      [SHORTFALL_INVITATION_KEY]: shortfallInvitation,
-    },
-    paramTypesMap,
-  );
-};
-harden(makeVaultDirectorParamManager);
 
 /**
  * @param {{

--- a/packages/inter-protocol/src/vaultFactory/params.js
+++ b/packages/inter-protocol/src/vaultFactory/params.js
@@ -112,32 +112,39 @@ export const vaultParamPattern = M.splitRecord(
 /**
  * @param {import('@agoric/notifier').StoredPublisherKit<GovernanceSubscriptionState>} publisherKit
  * @param {ERef<ZoeService>} zoe
- * @param {Invitation} electorateInvitation
- * @param {Amount} minInitialDebt
- * @param {Invitation} shortfallInvitation
- * @param chargingPeriod
- * @param recordingPeriod
- * @param {string} [endorsedUi]
+ * @param {GovernanceTerms<import('./params').VaultDirectorParams>['governedParams']} governedParams
+ * @param electorateInvitation
+ * @param shortfallInvitation
  */
 export const makeVaultDirectorParamManager = async (
   publisherKit,
   zoe,
+  governedParams,
   electorateInvitation,
-  minInitialDebt,
   shortfallInvitation,
-  chargingPeriod,
-  recordingPeriod,
-  endorsedUi = 'NO ENDORSEMENT',
 ) => {
   return makeParamManager(
     publisherKit,
     {
+      [MIN_INITIAL_DEBT_KEY]: [
+        governedParams[MIN_INITIAL_DEBT_KEY].type,
+        governedParams[MIN_INITIAL_DEBT_KEY].value,
+      ],
+      [CHARGING_PERIOD_KEY]: [
+        governedParams[CHARGING_PERIOD_KEY].type,
+        governedParams[CHARGING_PERIOD_KEY].value,
+      ],
+      [RECORDING_PERIOD_KEY]: [
+        governedParams[RECORDING_PERIOD_KEY].type,
+        governedParams[RECORDING_PERIOD_KEY].value,
+      ],
+      [ENDORSED_UI_KEY]: [
+        governedParams[ENDORSED_UI_KEY].type,
+        governedParams[ENDORSED_UI_KEY].value,
+      ],
+      // private invitations
       [CONTRACT_ELECTORATE]: [ParamTypes.INVITATION, electorateInvitation],
-      [MIN_INITIAL_DEBT_KEY]: [ParamTypes.AMOUNT, minInitialDebt],
       [SHORTFALL_INVITATION_KEY]: [ParamTypes.INVITATION, shortfallInvitation],
-      [CHARGING_PERIOD_KEY]: [ParamTypes.NAT, chargingPeriod],
-      [RECORDING_PERIOD_KEY]: [ParamTypes.NAT, recordingPeriod],
-      [ENDORSED_UI_KEY]: [ParamTypes.STRING, endorsedUi],
     },
     zoe,
   );

--- a/packages/inter-protocol/src/vaultFactory/types.js
+++ b/packages/inter-protocol/src/vaultFactory/types.js
@@ -98,7 +98,7 @@
  */
 
 /**
- * @typedef {object} LoanTiming
+ * @typedef {object} InterestTiming
  * @property {RelativeTime} chargingPeriod in seconds
  * @property {RelativeTime} recordingPeriod in seconds
  */

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -33,9 +33,7 @@ import { Far } from '@endo/marshal';
 import { makeTracer } from '@agoric/internal';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import {
-  CHARGING_PERIOD_KEY,
   makeVaultParamManager,
-  RECORDING_PERIOD_KEY,
   SHORTFALL_INVITATION_KEY,
   vaultParamPattern,
 } from './params.js';
@@ -361,26 +359,22 @@ export const prepareVaultDirector = (
             debtMint.burnLosses(harden({ Minted: toBurn }), seat);
           };
 
-          const { interestTimingParams } = zcf.getTerms();
-
           const factoryPowers = Far('vault factory powers', {
+            /**
+             * @returns read-only params for this manager and its director
+             */
             getGovernedParams: () =>
               Far('vault manager param manager', {
-                // one param from director scope
+                // merge direction and manager params
+                ...directorParamManager.readonly(),
+                ...vaultParamManager.readonly(),
+                // redeclare these getters as to specify the kind of the Amount
                 getMinInitialDebt: /** @type {() => Amount<'nat'>} */ (
                   directorParamManager.readonly().getMinInitialDebt
                 ),
-                ...vaultParamManager.readonly(),
-                // defined explicitly so as to specify the kind of the Amount
                 getDebtLimit: /** @type {() => Amount<'nat'>} */ (
                   vaultParamManager.readonly().getDebtLimit
                 ),
-                // XXX interestTimingParams not actually governed b/c it doesn't
-                // reach the governor facet
-                getChargingPeriod: () =>
-                  interestTimingParams[CHARGING_PERIOD_KEY].value,
-                getRecordingPeriod: () =>
-                  interestTimingParams[RECORDING_PERIOD_KEY].value,
               }),
             mintAndTransfer,
             getShortfallReporter: async () => {

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -175,7 +175,7 @@ export const prepareVaultDirector = (
 
     if (newInvitation === oldInvitation) {
       shortfallReporter ||
-        'updateShortFallReported called with repeat invitation and no prior shortfallReporter';
+        Fail`updateShortFallReported called with repeat invitation and no prior shortfallReporter`;
       return;
     }
 

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -361,7 +361,7 @@ export const prepareVaultDirector = (
             debtMint.burnLosses(harden({ Minted: toBurn }), seat);
           };
 
-          const { loanTimingParams } = zcf.getTerms();
+          const { interestTimingParams } = zcf.getTerms();
 
           const factoryPowers = Far('vault factory powers', {
             getGovernedParams: () =>
@@ -371,13 +371,16 @@ export const prepareVaultDirector = (
                   directorParamManager.readonly().getMinInitialDebt
                 ),
                 ...vaultParamManager.readonly(),
+                // defined explicitly so as to specify the kind of the Amount
                 getDebtLimit: /** @type {() => Amount<'nat'>} */ (
                   vaultParamManager.readonly().getDebtLimit
                 ),
+                // XXX interestTimingParams not actually governed b/c it doesn't
+                // reach the governor facet
                 getChargingPeriod: () =>
-                  loanTimingParams[CHARGING_PERIOD_KEY].value,
+                  interestTimingParams[CHARGING_PERIOD_KEY].value,
                 getRecordingPeriod: () =>
-                  loanTimingParams[RECORDING_PERIOD_KEY].value,
+                  interestTimingParams[RECORDING_PERIOD_KEY].value,
               }),
             mintAndTransfer,
             getShortfallReporter: async () => {

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -65,8 +65,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   /** a powerful object; can modify the invitation */
   const vaultDirectorParamManager = await makeVaultDirectorParamManager(
     makeStoredPublisherKit(storageNode, marshaller, 'governance'),
-    zcf.getZoeService(),
-    zcf.getTerms().governedParams,
+    zcf,
     initialPoserInvitation,
     initialShortfallInvitation,
   );

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -28,7 +28,8 @@ import { prepareVaultDirector } from './vaultDirector.js';
 /**
  * @typedef {ZCF<GovernanceTerms<import('./params').VaultDirectorParams> & {
  *   auctioneerPublicFacet: import('../auction/auctioneer.js').AuctioneerPublicFacet,
- *   loanTimingParams: {ChargingPeriod: ParamValueTyped<'nat'>, RecordingPeriod: ParamValueTyped<'nat'>},
+ *   interestTimingParams: {ChargingPeriod: ParamValueTyped<'nat'>, RecordingPeriod: ParamValueTyped<'nat'>},
+ *   minInitialDebt: Amount,
  *   priceAuthority: ERef<PriceAuthority>,
  *   reservePublicFacet: AssetReservePublicFacet,
  *   timerService: import('@agoric/time/src/types').TimerService,

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -22,13 +22,14 @@ import {
   makeVaultDirectorParamManager,
   MIN_INITIAL_DEBT_KEY,
   ENDORSED_UI_KEY,
+  CHARGING_PERIOD_KEY,
+  RECORDING_PERIOD_KEY,
 } from './params.js';
 import { prepareVaultDirector } from './vaultDirector.js';
 
 /**
  * @typedef {ZCF<GovernanceTerms<import('./params').VaultDirectorParams> & {
  *   auctioneerPublicFacet: import('../auction/auctioneer.js').AuctioneerPublicFacet,
- *   interestTimingParams: {ChargingPeriod: ParamValueTyped<'nat'>, RecordingPeriod: ParamValueTyped<'nat'>},
  *   minInitialDebt: Amount,
  *   priceAuthority: ERef<PriceAuthority>,
  *   reservePublicFacet: AssetReservePublicFacet,
@@ -72,6 +73,8 @@ export const start = async (zcf, privateArgs, baggage) => {
   const {
     [MIN_INITIAL_DEBT_KEY]: { value: minInitialDebt },
     [ENDORSED_UI_KEY]: { value: endorsedUi },
+    [CHARGING_PERIOD_KEY]: { value: chargingPeriod },
+    [RECORDING_PERIOD_KEY]: { value: recordingPeriod },
   } = zcf.getTerms().governedParams;
   /** a powerful object; can modify the invitation */
   const vaultDirectorParamManager = await makeVaultDirectorParamManager(
@@ -80,6 +83,8 @@ export const start = async (zcf, privateArgs, baggage) => {
     initialPoserInvitation,
     minInitialDebt,
     initialShortfallInvitation,
+    chargingPeriod,
+    recordingPeriod,
     endorsedUi,
   );
 

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -16,25 +16,17 @@ import '@agoric/zoe/src/contracts/exported.js';
 // { getParamMgrRetriever, getInvitation, getLimitedCreatorFacet }.
 
 import { assertElectorateMatches } from '@agoric/governance';
-import { makeStoredPublisherKit } from '@agoric/notifier';
 import { assertAllDefined } from '@agoric/internal';
-import {
-  makeVaultDirectorParamManager,
-  MIN_INITIAL_DEBT_KEY,
-  ENDORSED_UI_KEY,
-  CHARGING_PERIOD_KEY,
-  RECORDING_PERIOD_KEY,
-} from './params.js';
+import { makeStoredPublisherKit } from '@agoric/notifier';
+import { makeVaultDirectorParamManager } from './params.js';
 import { prepareVaultDirector } from './vaultDirector.js';
 
 /**
  * @typedef {ZCF<GovernanceTerms<import('./params').VaultDirectorParams> & {
  *   auctioneerPublicFacet: import('../auction/auctioneer.js').AuctioneerPublicFacet,
- *   minInitialDebt: Amount,
  *   priceAuthority: ERef<PriceAuthority>,
  *   reservePublicFacet: AssetReservePublicFacet,
  *   timerService: import('@agoric/time/src/types').TimerService,
- *   shortfallInvitation: 'invitation',
  * }>} VaultFactoryZCF
  */
 
@@ -70,22 +62,13 @@ export const start = async (zcf, privateArgs, baggage) => {
   }));
 
   const { timerService, auctioneerPublicFacet } = zcf.getTerms();
-  const {
-    [MIN_INITIAL_DEBT_KEY]: { value: minInitialDebt },
-    [ENDORSED_UI_KEY]: { value: endorsedUi },
-    [CHARGING_PERIOD_KEY]: { value: chargingPeriod },
-    [RECORDING_PERIOD_KEY]: { value: recordingPeriod },
-  } = zcf.getTerms().governedParams;
   /** a powerful object; can modify the invitation */
   const vaultDirectorParamManager = await makeVaultDirectorParamManager(
     makeStoredPublisherKit(storageNode, marshaller, 'governance'),
     zcf.getZoeService(),
+    zcf.getTerms().governedParams,
     initialPoserInvitation,
-    minInitialDebt,
     initialShortfallInvitation,
-    chargingPeriod,
-    recordingPeriod,
-    endorsedUi,
   );
 
   assertElectorateMatches(

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -335,11 +335,11 @@ export const prepareVaultManagerKit = (
         },
         /** @deprecated use getPublicTopics */
         getSubscriber() {
-          return assetSubscriber;
+          return topics.asset.subscriber;
         },
         /** @deprecated use getPublicTopics */
         getMetrics() {
-          return metricsSubscriber;
+          return topics.metrics.subscriber;
         },
         getQuotes() {
           return storedQuotesNotifier;

--- a/packages/inter-protocol/test/swingsetTests/setup.js
+++ b/packages/inter-protocol/test/swingsetTests/setup.js
@@ -195,6 +195,9 @@ const buildOwner = async (
     E(E(zoe).getInvitationIssuer()).getAmountOf(poserInvitationP),
   ]);
 
+  /** @type {AuctioneerPublicFacet} */
+  // @ts-expect-error cast, never used
+  const auctioneerPublicFacet = null;
   /** @type {AssetReservePublicFacet} */
   // @ts-expect-error cast, never used
   const reservePublicFacet = null;
@@ -202,20 +205,17 @@ const buildOwner = async (
   // @ts-expect-error cast, never used
   const shortfallInvitationAmount = null;
 
-  const terms = makeVaultFactoryTerms(
-    // @ts-expect-error missing storageNode and marshaller
-    {},
-    {
-      priceAuthority: priceAuthorityKit.priceAuthority,
-      interestTiming,
-      timer,
-      electorateInvitationAmount: poserInvitationAmount,
-      minInitialDebt: AmountMath.make(runBrand, 100n),
-      bootstrapPaymentValue: 0n,
-      reservePublicFacet,
-      shortfallInvitationAmount,
-    },
-  );
+  const terms = makeVaultFactoryTerms({
+    auctioneerPublicFacet,
+    priceAuthority: priceAuthorityKit.priceAuthority,
+    interestTiming,
+    timer,
+    electorateInvitationAmount: poserInvitationAmount,
+    minInitialDebt: AmountMath.make(runBrand, 100n),
+    bootstrapPaymentValue: 0n,
+    reservePublicFacet,
+    shortfallInvitationAmount,
+  });
 
   const privateVaultFactoryArgs = { feeMintAccess, initialPoserInvitation };
 

--- a/packages/inter-protocol/test/swingsetTests/setup.js
+++ b/packages/inter-protocol/test/swingsetTests/setup.js
@@ -182,7 +182,7 @@ const buildOwner = async (
 
   const vaultManagerParams = makeRates(runBrand);
 
-  const loanTiming = {
+  const interestTiming = {
     chargingPeriod: SECONDS_PER_DAY,
     recordingPeriod: SECONDS_PER_DAY,
   };
@@ -207,7 +207,7 @@ const buildOwner = async (
     {},
     {
       priceAuthority: priceAuthorityKit.priceAuthority,
-      loanTiming,
+      interestTiming,
       timer,
       electorateInvitationAmount: poserInvitationAmount,
       minInitialDebt: AmountMath.make(runBrand, 100n),

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -78,7 +78,7 @@ const defaultParamValues = debt =>
  * electorateTerms: any,
  * feeMintAccess: FeeMintAccess,
  * installation: Record<string, any>,
- * loanTiming: any,
+ * interestTiming: any,
  * minInitialDebt: bigint,
  * reserveCreatorFacet: ERef<AssetReserveCreatorFacet>,
  * rates: any,
@@ -117,7 +117,7 @@ export const makeDriverContext = async () => {
     installation,
     zoe,
     feeMintAccess,
-    loanTiming: {
+    interestTiming: {
       chargingPeriod: 2n,
       recordingPeriod: 6n,
     },
@@ -204,7 +204,7 @@ const setupServices = async (
   priceBase,
   timer = buildManualTimer(t.log),
 ) => {
-  const { zoe, run, aeth, loanTiming, minInitialDebt, rates } = t.context;
+  const { zoe, run, aeth, interestTiming, minInitialDebt, rates } = t.context;
   t.context.timer = timer;
 
   const { space } = await setupReserveAndElectorate(t);
@@ -228,7 +228,7 @@ const setupServices = async (
   iProduce.auctioneer.resolve(t.context.installation.auctioneer);
 
   await Promise.all([
-    startVaultFactory(space, { loanParams: loanTiming }, minInitialDebt),
+    startVaultFactory(space, { interestTiming }, minInitialDebt),
     startAuctioneer(space),
   ]);
 

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -52,7 +52,7 @@ import {
  * run: IssuerKit & import('../supports.js').AmountUtils,
  * bundleCache: Awaited<ReturnType<typeof unsafeMakeBundleCache>>,
  * rates: VaultManagerParamValues,
- * loanTiming: LoanTiming,
+ * interestTiming: InterestTiming,
  * zoe: ZoeService,
  * }} Context
  */
@@ -107,7 +107,7 @@ test.before(async t => {
     bundles,
     installation,
     electorateTerms: undefined,
-    loanTiming: {
+    interestTiming: {
       chargingPeriod: 2n,
       recordingPeriod: 6n,
     },
@@ -145,7 +145,7 @@ const setupServices = async (
   runInitialLiquidity,
   startFrequency = undefined,
 ) => {
-  const { zoe, run, aeth, loanTiming, minInitialDebt, endorsedUi, rates } =
+  const { zoe, run, aeth, interestTiming, minInitialDebt, endorsedUi, rates } =
     t.context;
   t.context.timer = timer;
 
@@ -193,7 +193,7 @@ const setupServices = async (
   iProduce.liquidate.resolve(t.context.installation.liquidate);
   await startVaultFactory(
     space,
-    { loanParams: loanTiming, options: { endorsedUi } },
+    { interestTiming, options: { endorsedUi } },
     minInitialDebt,
   );
 
@@ -263,7 +263,7 @@ const setupServices = async (
 
 test('first', async t => {
   const { aeth, run, zoe, rates } = t.context;
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: 2n,
     recordingPeriod: 10n,
   };
@@ -400,7 +400,7 @@ test('interest on multiple vaults', async t => {
   };
   t.context.rates = rates;
   // charging period is 1 week. Clock ticks by days
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: SECONDS_PER_WEEK,
     recordingPeriod: SECONDS_PER_WEEK,
   };
@@ -924,7 +924,7 @@ test('adjust balances after interest charges', async t => {
   const manualTimer = buildManualTimer(trace, 0n, {
     timeStep: SECONDS_PER_DAY,
   });
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: SECONDS_PER_DAY,
     recordingPeriod: SECONDS_PER_DAY,
   };
@@ -1249,22 +1249,10 @@ test('overdeposit', async t => {
   );
 });
 
-test('bad chargingPeriod', async t => {
-  t.throws(
-    () =>
-      makeParamManagerBuilder(makeStoredPublisherKit())
-        // @ts-expect-error bad value for test
-        .addNat(CHARGING_PERIOD_KEY, 2)
-        .addNat(RECORDING_PERIOD_KEY, 10n)
-        .build(),
-    { message: '2 must be a bigint' },
-  );
-});
-
 test('collect fees from vault', async t => {
   const { zoe, aeth, run, rates } = t.context;
 
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: SECONDS_PER_WEEK,
     recordingPeriod: SECONDS_PER_WEEK,
   };
@@ -1724,7 +1712,7 @@ test('manager notifiers', async t => {
     timeStep: SECONDS_PER_WEEK,
     eventLoopIteration,
   });
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: SECONDS_PER_WEEK,
     recordingPeriod: SECONDS_PER_WEEK,
   };
@@ -1980,7 +1968,7 @@ test('manager notifiers', async t => {
 
 test('governance publisher', async t => {
   const { aeth } = t.context;
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: 2n,
     recordingPeriod: 10n,
   };
@@ -2001,12 +1989,19 @@ test('governance publisher', async t => {
   let {
     value: { current },
   } = await directorGovNotifier.getUpdateSince();
-  // can't deepEqual because of non-literal objects
-  t.is(current.Electorate.type, 'invitation');
-  t.is(current.MinInitialDebt.type, 'amount');
-  t.is(current.ShortfallInvitation.type, 'invitation');
-  t.is(current.EndorsedUI.type, 'string');
-  t.is(current.EndorsedUI.value, 'abracadabra');
+  // can't deepEqual because of non-literal objects so check keys and then partial shapes
+  t.deepEqual(Object.keys(current), [
+    'Electorate',
+    'EndorsedUI',
+    'MinInitialDebt',
+    'ShortfallInvitation',
+  ]);
+  t.like(current, {
+    Electorate: { type: 'invitation' },
+    MinInitialDebt: { type: 'amount' },
+    ShortfallInvitation: { type: 'invitation' },
+    EndorsedUI: { type: 'string', value: 'abracadabra' },
+  });
 
   const managerGovNotifier = makeNotifierFromAsyncIterable(
     E(vfPublic).getSubscription({
@@ -2016,8 +2011,21 @@ test('governance publisher', async t => {
   ({
     value: { current },
   } = await managerGovNotifier.getUpdateSince());
-  // can't deepEqual because of non-literal objects
-  t.is(current.DebtLimit.type, 'amount');
-  t.is(current.InterestRate.type, 'ratio');
-  t.is(current.LoanFee.type, 'ratio');
+  // can't deepEqual because of non-literal objects so check keys and then partial shapes
+  t.deepEqual(Object.keys(current), [
+    'DebtLimit',
+    'InterestRate',
+    'LiquidationMargin',
+    'LiquidationPadding',
+    'LiquidationPenalty',
+    'LoanFee',
+  ]);
+  t.like(current, {
+    DebtLimit: { type: 'amount' },
+    InterestRate: { type: 'ratio' },
+    LiquidationMargin: { type: 'ratio' },
+    LiquidationPadding: { type: 'ratio' },
+    LiquidationPenalty: { type: 'ratio' },
+    LoanFee: { type: 'ratio' },
+  });
 });

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -3,12 +3,8 @@ import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { combine, split } from '@agoric/ertp/src/legacy-payment-helpers.js';
-import { makeParamManagerBuilder } from '@agoric/governance';
 import { allValues, makeTracer, objectMap } from '@agoric/internal';
-import {
-  makeNotifierFromAsyncIterable,
-  makeStoredPublisherKit,
-} from '@agoric/notifier';
+import { makeNotifierFromAsyncIterable } from '@agoric/notifier';
 import { M, matches } from '@agoric/store';
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import {
@@ -26,10 +22,6 @@ import { deeplyFulfilled } from '@endo/marshal';
 import { calculateCurrentDebt } from '../../src/interest-math.js';
 import { SECONDS_PER_YEAR } from '../../src/interest.js';
 import { startVaultFactory } from '../../src/proposals/econ-behaviors.js';
-import {
-  CHARGING_PERIOD_KEY,
-  RECORDING_PERIOD_KEY,
-} from '../../src/vaultFactory/params.js';
 import '../../src/vaultFactory/types.js';
 import {
   metricsTracker,
@@ -1991,16 +1983,20 @@ test('governance publisher', async t => {
   } = await directorGovNotifier.getUpdateSince();
   // can't deepEqual because of non-literal objects so check keys and then partial shapes
   t.deepEqual(Object.keys(current), [
+    'ChargingPeriod',
     'Electorate',
     'EndorsedUI',
     'MinInitialDebt',
+    'RecordingPeriod',
     'ShortfallInvitation',
   ]);
   t.like(current, {
+    ChargingPeriod: { type: 'nat', value: 2n },
     Electorate: { type: 'invitation' },
-    MinInitialDebt: { type: 'amount' },
-    ShortfallInvitation: { type: 'invitation' },
     EndorsedUI: { type: 'string', value: 'abracadabra' },
+    MinInitialDebt: { type: 'amount' },
+    RecordingPeriod: { type: 'nat', value: 10n },
+    ShortfallInvitation: { type: 'invitation' },
   });
 
   const managerGovNotifier = makeNotifierFromAsyncIterable(

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -38,7 +38,7 @@ import {
  * run: IssuerKit & import('../supports.js').AmountUtils,
  * bundleCache: Awaited<ReturnType<typeof unsafeMakeBundleCache>>,
  * rates: VaultManagerParamValues,
- * loanTiming: LoanTiming,
+ * interestTiming: InterestTiming,
  * zoe: ZoeService,
  * }} Context
  */
@@ -95,7 +95,7 @@ test.before(async t => {
     bundles,
     installation,
     electorateTerms: undefined,
-    loanTiming: {
+    interestTiming: {
       chargingPeriod: 2n,
       recordingPeriod: 6n,
     },
@@ -133,7 +133,7 @@ const setupServices = async (
   runInitialLiquidity,
   startFrequency = undefined,
 ) => {
-  const { zoe, run, aeth, loanTiming, minInitialDebt, endorsedUi, rates } =
+  const { zoe, run, aeth, interestTiming, minInitialDebt, endorsedUi, rates } =
     t.context;
   t.context.timer = timer;
 
@@ -157,7 +157,7 @@ const setupServices = async (
   iProduce.liquidate.resolve(t.context.installation.liquidate);
   await startVaultFactory(
     space,
-    { loanParams: loanTiming, options: { endorsedUi } },
+    { interestTiming, options: { endorsedUi } },
     minInitialDebt,
   );
 
@@ -289,7 +289,7 @@ test('price drop', async t => {
   // The price starts at 5 RUN per Aeth. The loan will start with 400 Aeth
   // collateral and a loan of 1600, which is a CR of 1.25. After the price falls
   // to 4, the loan will get liquidated.
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: 2n,
     recordingPeriod: 10n,
   };
@@ -437,7 +437,7 @@ test('price drop', async t => {
 
 test('price falls precipitously', async t => {
   const { zoe, aeth, run, rates } = t.context;
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: 2n,
     recordingPeriod: 10n,
   };
@@ -597,7 +597,7 @@ test('liquidate two loans', async t => {
 
   // Interest is charged daily, and auctions are every week, so we'll charge
   // interest a few times before the second auction.
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: SECONDS_PER_DAY,
     recordingPeriod: SECONDS_PER_DAY,
   };
@@ -916,7 +916,7 @@ test('sell goods at auction', async t => {
 
   // Interest is charged daily, and auctions are every week, so we'll charge
   // interest a few times before the second auction.
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: SECONDS_PER_DAY,
     recordingPeriod: SECONDS_PER_DAY,
   };
@@ -1099,7 +1099,7 @@ test('collect fees from loan', async t => {
   const { zoe, aeth, run, rates } = t.context;
   const manualTimer = buildManualTimer();
 
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: 2n,
     recordingPeriod: 10n,
   };
@@ -1341,7 +1341,7 @@ test('Auction sells all collateral w/shortfall', async t => {
   t.context.rates = rates;
 
   // Interest is charged daily, and auctions are every week
-  t.context.loanTiming = {
+  t.context.interestTiming = {
     chargingPeriod: SECONDS_PER_DAY,
     recordingPeriod: SECONDS_PER_DAY,
   };

--- a/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
@@ -27,7 +27,7 @@ export const BASIS_POINTS = 10000n;
  * run: IssuerKit & import('../supports.js').AmountUtils,
  * bundleCache: Awaited<ReturnType<typeof import('@agoric/swingset-vat/tools/bundleTool.js').unsafeMakeBundleCache>>,
  * rates: VaultManagerParamValues,
- * loanTiming: LoanTiming,
+ * interestTiming: InterestTiming,
  * zoe: ZoeService,
  * }} Context
  */


### PR DESCRIPTION
## Description

Part of #7099, rename loanTiming to interestTiming. There was a [question of whether it broke RPC](https://github.com/Agoric/agoric-sdk/pull/7323#discussion_r1157902938). It turns out that the while the values were in a paramManager, that paramManager was never under governance.

We didn't really need a separate param manager so this puts the params under governance by moving them into the directorParamManager.

It also refactors to simplify some code paths and align more with how the governance "helper" works. 

Lastly it fixes a little missed `Fail` assertion.


### Security Considerations

This makes the ChargingPeriod and RecordingPeriod governed by the EC. The values are for the factory director and thus shared across vault managers and vaults.

### Scaling Considerations

n/a

### Documentation Considerations

--
### Testing Considerations

Expanded test coverage