### PR TITLE
feat: support version suffix to publish `dev` dist-tags

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -191,6 +191,14 @@ packages (to enable `agoric install <TAG>`), use:
 ./scripts/npm-dist-tag.sh lerna add <TAG>
 ```
 
+As a special case, by supplying a version suffix argument, you can do something
+like publish a `community-dev` dist-tag for an existing dev-only Git revision:
+
+```sh
+rev=$(git rev-parse --short=7 community-dev)
+./scripts/npm-dist-tag.sh lerna add community-dev -dev-${rev}.0
+```
+
 - [ ] Push release labels as tags
 
 Perform the following for each `tag` that we will use to label this release.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: Agoric/dapp-card-store#62

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Provide a way to attach dist-tags to posthumous NPM packages published as `$package@$version-$tag`.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

No additional security considerations beyond the authority already granted to NPM accounts to manipulate dist-tags.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

n/a

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

Some description of using `yarn install community-dev` should be written to point new developers in the right direction when using the published packages as the basis for a dapp.  Also, maintainers should be educated in updating the dist-tags when advancing the `community-dev` Git branch.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Manually tested in card store dapp.
