### PR TITLE
fix(notifier): Add a makeDurablePublishKit "onUpdate" option

### DIFF
--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { E } from '@endo/far';
-import { isObject } from '@endo/marshal';
+import { isObject, isPassableSymbol } from '@endo/marshal';
 
 const { Fail } = assert;
 
@@ -104,7 +104,8 @@ export const makeSyncMethodCallback = (target, methodName, ...bound) => {
   isObject(target) ||
     Fail`sync method callback target must be an object: ${target}`;
   typeof methodName === 'string' ||
-    Fail`method name must be a string: ${methodName}`;
+    isPassableSymbol(methodName) ||
+    Fail`method name must be a string or passable symbol: ${methodName}`;
   /** @type {unknown} */
   const cb = harden({ target, methodName, bound });
   return /** @type {SyncCallback<I>} */ (cb);
@@ -128,7 +129,8 @@ harden(makeSyncMethodCallback);
 export const makeMethodCallback = (target, methodName, ...bound) => {
   isObject(target) || Fail`method callback target must be an object: ${target}`;
   typeof methodName === 'string' ||
-    Fail`method name must be a string: ${methodName}`;
+    isPassableSymbol(methodName) ||
+    Fail`method name must be a string or passable symbol: ${methodName}`;
   /** @type {unknown} */
   const cb = harden({ target, methodName, bound });
   return /** @type {Callback<I>} */ (cb);
@@ -146,7 +148,9 @@ export const isCallback = callback => {
   const { target, methodName, bound } = callback;
   return (
     isObject(target) &&
-    (methodName === undefined || typeof methodName === 'string') &&
+    (methodName === undefined ||
+      typeof methodName === 'string' ||
+      isPassableSymbol(methodName)) &&
     Array.isArray(bound)
   );
 };

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -1,5 +1,8 @@
 // @ts-check
 import { E } from '@endo/far';
+import { isObject } from '@endo/marshal';
+
+const { Fail } = assert;
 
 /**
  * @template {(...args: unknown[]) => any} I
@@ -54,6 +57,8 @@ export const callE = (callback, ...args) => {
  * @returns {SyncCallback<I>}
  */
 export const makeSyncFunctionCallback = (target, ...bound) => {
+  typeof target === 'function' ||
+    Fail`sync function callback target must be a function: ${target}`;
   /** @type {unknown} */
   const cb = harden({ target, bound });
   return /** @type {SyncCallback<I>} */ (cb);
@@ -73,6 +78,8 @@ harden(makeSyncFunctionCallback);
  * @returns {Callback<I>}
  */
 export const makeFunctionCallback = (target, ...bound) => {
+  isObject(target) ||
+    Fail`function callback target must be a function presence: ${target}`;
   /** @type {unknown} */
   const cb = harden({ target, bound });
   return /** @type {Callback<I>} */ (cb);
@@ -94,6 +101,10 @@ harden(makeFunctionCallback);
  * @returns {SyncCallback<I>}
  */
 export const makeSyncMethodCallback = (target, methodName, ...bound) => {
+  isObject(target) ||
+    Fail`sync method callback target must be an object: ${target}`;
+  typeof methodName === 'string' ||
+    Fail`method name must be a string: ${methodName}`;
   /** @type {unknown} */
   const cb = harden({ target, methodName, bound });
   return /** @type {SyncCallback<I>} */ (cb);
@@ -115,6 +126,9 @@ harden(makeSyncMethodCallback);
  * @returns {Callback<I>}
  */
 export const makeMethodCallback = (target, methodName, ...bound) => {
+  isObject(target) || Fail`method callback target must be an object: ${target}`;
+  typeof methodName === 'string' ||
+    Fail`method name must be a string: ${methodName}`;
   /** @type {unknown} */
   const cb = harden({ target, methodName, bound });
   return /** @type {Callback<I>} */ (cb);
@@ -126,12 +140,12 @@ harden(makeMethodCallback);
  * @returns {callback is Callback}
  */
 export const isCallback = callback => {
-  if (!callback || typeof callback !== 'object') {
+  if (!isObject(callback)) {
     return false;
   }
   const { target, methodName, bound } = callback;
   return (
-    !!target &&
+    isObject(target) &&
     (methodName === undefined || typeof methodName === 'string') &&
     Array.isArray(bound)
   );

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -120,3 +120,20 @@ export const makeMethodCallback = (target, methodName, ...bound) => {
   return /** @type {Callback<I>} */ (cb);
 };
 harden(makeMethodCallback);
+
+/**
+ * @param {any} callback
+ * @returns {callback is Callback}
+ */
+export const isCallback = callback => {
+  if (!callback || typeof callback !== 'object') {
+    return false;
+  }
+  const { target, methodName, bound } = callback;
+  return (
+    !!target &&
+    (methodName === undefined || typeof methodName === 'string') &&
+    Array.isArray(bound)
+  );
+};
+harden(isCallback);

--- a/packages/internal/test/test-callback.js
+++ b/packages/internal/test/test-callback.js
@@ -137,3 +137,14 @@ test('far function callbacks', async t => {
   t.assert(p2r instanceof Promise);
   t.is(await p2r, '19go');
 });
+
+test('isCallback', async t => {
+  t.true(cb.isCallback(cb.makeFunctionCallback(async () => {})));
+  t.true(cb.isCallback(cb.makeMethodCallback({ m: async () => {} }, 'm')));
+  t.true(cb.isCallback(cb.makeSyncFunctionCallback(() => {})));
+  t.true(cb.isCallback(cb.makeSyncMethodCallback({ m: () => {} }, 'm')));
+  t.false(cb.isCallback(undefined));
+  t.false(cb.isCallback(null));
+  t.false(cb.isCallback('string'));
+  t.false(cb.isCallback({}));
+});

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -179,19 +179,19 @@ harden(makePublishKit);
 /**
  * @param {object} [options]
  * @param {DurablePublishKitValueDurability & 'mandatory'} [options.valueDurability='mandatory']
- * @param {import('@agoric/internal/src/callback.js').Callback<*>} [options.onAdvance] A direct callback
+ * @param {import('@agoric/internal/src/callback.js').Callback<*>} [options.onUpdate] A direct callback
  *   to which published values should be sent, useful for receiving validated values
  *   without consuming heap RAM with ephemeral objects
  * @returns {DurablePublishKitState}
  */
 const initDurablePublishKitState = (options = {}) => {
-  const { valueDurability = 'mandatory', onAdvance } = options;
+  const { valueDurability = 'mandatory', onUpdate } = options;
   assert.equal(valueDurability, 'mandatory');
-  !onAdvance || assert(isCallback(onAdvance));
+  !onUpdate || assert(isCallback(onUpdate));
   return {
     // configuration
     valueDurability,
-    onAdvance,
+    onUpdate,
 
     // lifecycle progress
     publishCount: 0n,
@@ -294,7 +294,7 @@ const provideDurablePublishKitEphemeralData = (state, facets) => {
  */
 const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
   const { state, facets } = context;
-  const { valueDurability, onAdvance, status } = state;
+  const { valueDurability, onUpdate, status } = state;
   if (status !== 'live') {
     throw new Error('Cannot update state after termination.');
   }
@@ -306,8 +306,8 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
     provideDurablePublishKitEphemeralData(state, facets);
   const commit = resolution => {
     // Invoke a direct callback, but ignore the result.
-    if (onAdvance) {
-      callE(onAdvance, resolution).then(sink, sink);
+    if (onUpdate) {
+      void callE(onUpdate, resolution).then(sink, sink);
     }
     resolveCurrent(resolution);
   };

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -179,7 +179,7 @@ harden(makePublishKit);
 /**
  * @param {object} [options]
  * @param {DurablePublishKitValueDurability & 'mandatory'} [options.valueDurability='mandatory']
- * @param {import('@agoric/internal/src/callback.js').Callback<*>} [options.onUpdate] A direct callback
+ * @param {PublishKitOnUpdate} [options.onUpdate] A direct callback
  *   to which published values should be sent, useful for receiving validated values
  *   without consuming heap RAM with ephemeral objects
  * @returns {DurablePublishKitState}
@@ -307,7 +307,10 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
   const commit = resolution => {
     // Invoke a direct callback, but ignore the result.
     if (onUpdate) {
-      void callE(onUpdate, resolution).then(sink, sink);
+      // We use Promise.resolve to ensure that onUpdate always receives
+      // a promise while preserving the identity of any rejection.
+      // `resolution` is a safe value created in this module.
+      void callE(onUpdate, Promise.resolve(resolution));
     }
     resolveCurrent(resolution);
   };

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -2,6 +2,7 @@
 
 import { makePromiseKit } from '@endo/promise-kit';
 import { E, Far } from '@endo/far';
+import { callE, isCallback } from '@agoric/internal/src/callback.js';
 import { M } from '@agoric/store';
 import { canBeDurable, prepareExoClassKit } from '@agoric/vat-data';
 
@@ -178,14 +179,19 @@ harden(makePublishKit);
 /**
  * @param {object} [options]
  * @param {DurablePublishKitValueDurability & 'mandatory'} [options.valueDurability='mandatory']
+ * @param {import('@agoric/internal/src/callback.js').Callback<*>} [options.onAdvance] A direct callback
+ *   to which published values should be sent, useful for receiving validated values
+ *   without consuming heap RAM with ephemeral objects
  * @returns {DurablePublishKitState}
  */
 const initDurablePublishKitState = (options = {}) => {
-  const { valueDurability = 'mandatory' } = options;
+  const { valueDurability = 'mandatory', onAdvance } = options;
   assert.equal(valueDurability, 'mandatory');
+  !onAdvance || assert(isCallback(onAdvance));
   return {
     // configuration
     valueDurability,
+    onAdvance,
 
     // lifecycle progress
     publishCount: 0n,
@@ -288,7 +294,7 @@ const provideDurablePublishKitEphemeralData = (state, facets) => {
  */
 const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
   const { state, facets } = context;
-  const { valueDurability, status } = state;
+  const { valueDurability, onAdvance, status } = state;
   if (status !== 'live') {
     throw new Error('Cannot update state after termination.');
   }
@@ -298,6 +304,13 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
   }
   const { tailP: currentP, tailR: resolveCurrent } =
     provideDurablePublishKitEphemeralData(state, facets);
+  const commit = resolution => {
+    // Invoke a direct callback, but ignore the result.
+    if (onAdvance) {
+      callE(onAdvance, resolution).then(sink, sink);
+    }
+    resolveCurrent(resolution);
+  };
 
   const publishCount = state.publishCount + 1n;
   state.publishCount = publishCount;
@@ -321,7 +334,7 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
     state.hasValue = true;
     state.value = value;
     const rejection = makeQuietRejection(value);
-    resolveCurrent(rejection);
+    commit(rejection);
   } else {
     // Persist a terminal value, or a non-terminal value
     // if configured as 'mandatory' or 'opportunistic'.
@@ -333,7 +346,7 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
       state.value = undefined;
     }
 
-    resolveCurrent(
+    commit(
       harden({
         head: { value, done },
         publishCount,

--- a/packages/notifier/src/types-ambient.js
+++ b/packages/notifier/src/types-ambient.js
@@ -156,11 +156,15 @@
  */
 
 /**
+ * @typedef {import('@agoric/internal/src/callback.js').Callback<(publicationRecordP: Promise<PublicationRecord<*>>) => void>} PublishKitOnUpdate
+ */
+
+/**
  * @typedef {object} DurablePublishKitState
  *
  * @property {DurablePublishKitValueDurability} valueDurability
  *
- * @property {import('@agoric/internal/src/callback.js').Callback<*>} [onUpdate]
+ * @property {PublishKitOnUpdate} [onUpdate]
  *
  * @property {bigint} publishCount
  *

--- a/packages/notifier/src/types-ambient.js
+++ b/packages/notifier/src/types-ambient.js
@@ -160,7 +160,7 @@
  *
  * @property {DurablePublishKitValueDurability} valueDurability
  *
- * @property {import('@agoric/internal/src/callback.js').Callback<*>} [onAdvance]
+ * @property {import('@agoric/internal/src/callback.js').Callback<*>} [onUpdate]
  *
  * @property {bigint} publishCount
  *

--- a/packages/notifier/src/types-ambient.js
+++ b/packages/notifier/src/types-ambient.js
@@ -160,6 +160,8 @@
  *
  * @property {DurablePublishKitValueDurability} valueDurability
  *
+ * @property {import('@agoric/internal/src/callback.js').Callback<*>} [onAdvance]
+ *
  * @property {bigint} publishCount
  *
  * @property {'live' | 'finished' | 'failed'} status

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -333,7 +333,10 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
     const lastEntry = log
       .filter(([methodName, _publicationRecord]) => methodName === spyName)
       .at(-1);
-    const lastPublication = lastEntry[1];
+    const lastPublicationP = lastEntry[1];
+    const lastPublication = await run('awaitVatObject', [
+      { presence: lastPublicationP },
+    ]);
     return { logTail, lastPublication };
   };
   const { logTail: v1Pub2FirstLog, lastPublication: v1Pub2FirstPublication } =

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -4,6 +4,7 @@
 import '@agoric/swingset-vat/tools/prepare-test-env.js';
 import test from 'ava';
 import { E } from '@endo/far';
+import { makeMethodCallback } from '@agoric/internal/src/callback.js';
 import {
   buildKernelBundles,
   initializeSwingset,
@@ -37,6 +38,12 @@ const makers = {
     'DurablePublishKit',
   ),
 };
+
+// ava t.like does not support array shapes, but object analogs are fine
+const arrayShape = sparseArr => ({
+  length: sparseArr.length,
+  ...Object.fromEntries(Object.entries(sparseArr)),
+});
 
 const assertTransmission = async (t, publishKit, value, method = 'publish') => {
   const { publisher, subscriber } = publishKit;
@@ -277,22 +284,71 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
   const sub1 = await run('messageVat', [
     { name: 'pubsub', methodName: 'getSubscriber' },
   ]);
+  const spyName = 'receivePublicationRecord';
+  const directSubscriber = await run('makeRemotable', [
+    'directSubscriber',
+    { [spyName]: undefined },
+  ]);
+  const pub2Options = {
+    onAdvance: makeMethodCallback(directSubscriber, spyName),
+  };
+  const { publisher: pub2 } = await run('messageVat', [
+    {
+      name: 'pubsub',
+      methodName: 'makeDurablePublishKit',
+      args: [pub2Options],
+    },
+  ]);
+
+  /**
+   * Advances all publishers.
+   *
+   * @param {unknown} value
+   * @returns {Promise<void>}
+   */
+  const publish = async value => {
+    await run('messageVat', [
+      { name: 'pubsub', methodName: 'publish', args: [value] },
+    ]);
+    await run('messageVatObject', [
+      { presence: pub2, methodName: 'publish', args: [value] },
+    ]);
+  };
 
   // Verify receipt of a published value.
   const value1 = Symbol.for('value1');
-  await run('messageVat', [
-    { name: 'pubsub', methodName: 'publish', args: [value1] },
-  ]);
+  await publish(value1);
   const v1FirstCell = await run('messageVatObject', [
     { presence: sub1, methodName: 'subscribeAfter' },
   ]);
   assertCells(t, 'v1 first', [v1FirstCell], 1n, { value: value1, done: false });
 
-  // Verify receipt of a second published value via both tail and subscribeAfter.
+  // Verify receipt of published value via direct callback.
+  let pub2LogConsumedCount = 0;
+  const shiftPub2Log = async () => {
+    const log = await run('getLogForRemotable', [directSubscriber]);
+    const logTail = log.slice(pub2LogConsumedCount);
+    pub2LogConsumedCount = log.length;
+    const lastEntry = log
+      .filter(([methodName, _publicationRecord]) => methodName === spyName)
+      .at(-1);
+    const lastPublication = lastEntry[1];
+    return { logTail, lastPublication };
+  };
+  const { logTail: v1Pub2FirstLog, lastPublication: v1Pub2FirstPublication } =
+    await shiftPub2Log();
+  // eslint-disable-next-line no-sparse-arrays
+  const v1Pub2ExpectedFirstLog = [arrayShape([spyName, ,])];
+  t.like(v1Pub2FirstLog, arrayShape(v1Pub2ExpectedFirstLog));
+  assertCells(t, 'v1 first callback', [v1Pub2FirstPublication], 1n, {
+    value: value1,
+    done: false,
+  });
+
+  // Verify receipt of a second published value via tail and subscribeAfter,
+  // and independently via direct callback.
   const value2 = Symbol.for('value2');
-  await run('messageVat', [
-    { name: 'pubsub', methodName: 'publish', args: [value2] },
-  ]);
+  await publish(value2);
   await run('messageVatObject', [
     { presence: sub1, methodName: 'subscribeAfter' },
   ]);
@@ -313,6 +369,15 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
     { value: value2, done: false },
     { strict: false },
   );
+  const { logTail: v1Pub2SecondLog, lastPublication: v1Pub2SecondPublication } =
+    await shiftPub2Log();
+  // eslint-disable-next-line no-sparse-arrays
+  const v1Pub2ExpectedSecondLog = [arrayShape([spyName, ,])];
+  t.like(v1Pub2SecondLog, arrayShape(v1Pub2ExpectedSecondLog));
+  assertCells(t, 'v1 second callback', [v1Pub2SecondPublication], 2n, {
+    value: value2,
+    done: false,
+  });
 
   // Upgrade the vat, breaking promises from v1.
   await run('upgradeVat', [
@@ -346,11 +411,9 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
   ]);
   assertCells(t, 'v2 first', [v2FirstCell], 2n, { value: value2, done: false });
 
-  // Verify receipt of a published value from v2.
+  // Verify receipt of published values from v2.
   const value3 = Symbol.for('value3');
-  await run('messageVat', [
-    { name: 'pubsub', methodName: 'publish', args: [value3] },
-  ]);
+  await publish(value3);
   const v2SecondCells = [
     await run('awaitVatObject', [{ presence: v2FirstCell.tail }]),
     await run('messageVatObject', [
@@ -368,6 +431,15 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
     { value: value3, done: false },
     { strict: false },
   );
+  const { logTail: v2Pub2FirstLog, lastPublication: v2Pub2FirstPublication } =
+    await shiftPub2Log();
+  // eslint-disable-next-line no-sparse-arrays
+  const v2Pub2ExpectedFirstLog = [arrayShape([spyName, ,])];
+  t.like(v2Pub2FirstLog, arrayShape(v2Pub2ExpectedFirstLog));
+  assertCells(t, 'v2 first callback', [v2Pub2FirstPublication], 3n, {
+    value: value3,
+    done: false,
+  });
 });
 
 // TODO: Find a way to test virtual object rehydration

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -4,7 +4,7 @@
 import '@agoric/swingset-vat/tools/prepare-test-env.js';
 import test from 'ava';
 import { E } from '@endo/far';
-import { makeMethodCallback } from '@agoric/internal/src/callback.js';
+// import { makeMethodCallback } from '@agoric/internal/src/callback.js';
 import {
   buildKernelBundles,
   initializeSwingset,
@@ -290,7 +290,8 @@ test('durable publish kit upgrade trauma (full-vat integration)', async t => {
     { [spyName]: undefined },
   ]);
   const pub2Options = {
-    onAdvance: makeMethodCallback(directSubscriber, spyName),
+    // onUpdate: makeMethodCallback(directSubscriber, spyName),
+    onUpdate: { target: directSubscriber, methodName: spyName, bound: [] },
   };
   const { publisher: pub2 } = await run('messageVat', [
     {

--- a/packages/notifier/test/vat-integration/vat-pubsub.js
+++ b/packages/notifier/test/vat-integration/vat-pubsub.js
@@ -19,6 +19,7 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
     getVersion: () => version,
     getParameters: () => vatParameters,
     getSubscriber: () => subscriber,
+    makeDurablePublishKit: (...args) => makeDurablePublishKit(...args),
     publish: value => publisher.publish(value),
     finish: finalValue => publisher.finish(finalValue),
     fail: reason => publisher.fail(reason),

--- a/patches/@endo+marshal+0.8.1.patch
+++ b/patches/@endo+marshal+0.8.1.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/@endo/marshal/index.d.ts b/node_modules/@endo/marshal/index.d.ts
+index 08dd176..9472882 100644
+--- a/node_modules/@endo/marshal/index.d.ts
++++ b/node_modules/@endo/marshal/index.d.ts
+@@ -8,7 +8,7 @@ export * from "./src/types.js";
+ export { mapIterable, filterIterable } from "./src/helpers/iter-helpers.js";
+ export { PASS_STYLE, isObject, assertChecker, getTag, hasOwnPropertyOf } from "./src/helpers/passStyle-helpers.js";
+ export { getErrorConstructor, toPassableError } from "./src/helpers/error.js";
+-export { nameForPassableSymbol, passableSymbolForName } from "./src/helpers/symbol.js";
++export { isPassableSymbol, nameForPassableSymbol, passableSymbolForName } from "./src/helpers/symbol.js";
+ export { passStyleOf, assertPassable } from "./src/passStyleOf.js";
+ export { Remotable, Far, ToFarFunction } from "./src/make-far.js";
+ export { stringify, parse } from "./src/marshal-stringify.js";
+diff --git a/node_modules/@endo/marshal/index.js b/node_modules/@endo/marshal/index.js
+index 66feb4e..5b054de 100644
+--- a/node_modules/@endo/marshal/index.js
++++ b/node_modules/@endo/marshal/index.js
+@@ -11,6 +11,7 @@ export { getErrorConstructor, toPassableError } from './src/helpers/error.js';
+ export { getInterfaceOf } from './src/helpers/remotable.js';
+ 
+ export {
++  isPassableSymbol,
+   nameForPassableSymbol,
+   passableSymbolForName,
+ } from './src/helpers/symbol.js';


### PR DESCRIPTION
closes: #7303

## Description

Adds a new "onAdvance" option to `makeDurablePublishKit` to provide a callback for direct invocation upon publication of any new value. This is equivalent in functionality to subscription, but allows for better RAM utilization since callbacks (particularly those for supporting writes to chain storage) can be durable and paged out.

### Security Considerations

n/a

### Scaling Considerations

We hope to see less consumption of RAM in contract vats.

### Documentation Considerations

n/a

### Testing Considerations

Nothing special.