### PR TITLE
fix(SwingSet): Remove metering notifiers

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@agoric/assert": "^0.5.1",
     "@agoric/internal": "^0.2.1",
-    "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swing-store": "^0.8.1",
     "@agoric/swingset-liveslots": "^0.9.0",

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -43,7 +43,7 @@ export const makeConnection = (
 ) => {
   let closed;
   /**
-   * @type {Set<PromiseRecord<Bytes>>}
+   * @type {Set<import('@agoric/notifier/src/types.js').PromiseRecord<Bytes>>}
    */
   const pendingAcks = new Set();
   /**

--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -880,7 +880,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
    * @param {RelativeTime} delay
    * @param {RelativeTime} interval
    * @param {CancelToken} cancelToken
-   * @returns { BaseNotifier<Timestamp> }
+   * @returns { import('@agoric/notifier/src/types.js').BaseNotifier<Timestamp> }
    */
   const makeNotifier = (delay, interval, cancelToken) =>
     createNotifier(delay, interval, cancelToken).notifier;

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -6,7 +6,7 @@
  * device affordances into objects that can be used by code in other vats.
  */
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeNotifierKit } from '@agoric/notifier';
+// import { makeNotifierKit } from '@agoric/notifier'; // XXX RESTORE
 import { Far, E, passStyleOf } from '@endo/far';
 import { Nat, isNat } from '@endo/nat';
 import {
@@ -54,20 +54,13 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
 
   // XXX The plan is for meters to hold their notifiers, but notifiers are not
   // yet durable, which blocks making meters themselves durable unless the
-  // (currently) ephemeral notifiers are put someplace else.  So we're putting
-  // them in a WeakMap keyed by the meter itself.  The following has bits of
-  // code commented with either XXX TEMP or XXX RESTORE.  The former flags
-  // temporary code that should be removed once notifiers are durable.  The
-  // latter flags (commented out) code that should be made active once notifiers
-  // are durable.
-  //
-  // Note that this means that holders of notifiers (the ones obtained by
-  // calling `getNotifier` on the meter) will be left holding broken references
-  // after an upgrade.  The practical consequences of this are not yet clear to
-  // me, but hopefully this concern will soon be mooted by making notifiers
-  // actually durable.
-
-  const meterNotifiersTemp = new WeakMap(); // meter -> { notifier, updater } // XXX TEMP
+  // (currently) ephemeral notifiers are put someplace else.  So we're disabling
+  // them for now.
+  // The following has bits of code commented with either `XXX TEMP` or
+  // `XXX RESTORE`.  The former flags temporary code that should be removed once
+  // notifiers are durable.  The latter flags (commented out) code that should
+  // be made active once notifiers are durable.
+  // The same comments are also used in test files.
 
   const makeMeter = prepareKind(
     baggage,
@@ -89,7 +82,7 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
       },
       get: ({ state }) => D(vatAdminDev).getMeter(state.meterID), // returns BigInts
       // getNotifier: ({ state }) => state.notifier, // XXX RESTORE
-      getNotifier: ({ self }) => meterNotifiersTemp.get(self).notifier, // XXX TEMP
+      getNotifier: ({ _self }) => Fail`not implemented, see #7234`, // XXX TEMP
     },
     // eslint-disable-next-line no-use-before-define
     { finish: finishMeter },
@@ -109,7 +102,7 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
       setThreshold(_context, _newThreshold) {},
       get: () => harden({ remaining: 'unlimited', threshold: 0 }),
       // getNotifier: ({ state }) => state.notifier, // will never fire // XXX RESTORE
-      getNotifier: ({ self }) => meterNotifiersTemp.get(self).notifier, // XXX TEMP
+      getNotifier: ({ _self }) => Fail`not implemented, see #7234`, // XXX TEMP
     },
     // eslint-disable-next-line no-use-before-define
     { finish: finishMeter },
@@ -124,7 +117,6 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
     );
     // eslint-disable-next-line no-use-before-define
     meterIDByMeter.set(self, state.meterID);
-    meterNotifiersTemp.set(self, makeNotifierKit()); // XXX TEMP
   }
 
   // meterID -> { meter, updater }
@@ -135,7 +127,6 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
   const meterIDByMeter = new WeakMap(); // meter -> meterID
   for (const [meterID, meterEntry] of meterByID.entries()) {
     meterIDByMeter.set(meterEntry.meter, meterID);
-    meterNotifiersTemp.set(meterEntry.meter, makeNotifierKit()); // XXX TEMP
   }
 
   if (baggage.has('vatAdminDev')) {
@@ -562,10 +553,11 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
     // pendingUpgrades by vatID.
   }
 
+  // XXX TEMP
+  // eslint-disable-next-line no-unused-vars
   function meterCrossedThreshold(meterID, remaining) {
     // const { updater } = meterByID.get(meterID); // XXX RESTORE
-    const { updater } = meterNotifiersTemp.get(meterByID.get(meterID).meter); // XXX TEMP
-    updater.updateState(remaining);
+    // updater.updateState(remaining); // XXX RESTORE
   }
 
   // the kernel sends this when the vat halts

--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -323,16 +323,17 @@ test('meter decrements', async t => {
   let remaining = await t1.getMeter();
   // console.log(remaining);
   t.not(remaining, remaining0);
-  t.is(c.kpStatus(t1.notifyKPID), 'unresolved');
+  // t.is(c.kpStatus(t1.notifyKPID), 'unresolved'); // XXX RESTORE
+  t.is(c.kpStatus(t1.notifyKPID), 'rejected'); // XXX TEMP
   t.is(c.kpStatus(t1.doneKPID), 'unresolved');
 
   // message two should trigger notification, but not underflow
   await t1.consume(true);
   remaining = await t1.getMeter();
   // console.log(remaining);
-  t.is(c.kpStatus(t1.notifyKPID), 'fulfilled');
-  const notification = c.kpResolution(t1.notifyKPID);
-  t.is(kunser(notification).value, remaining);
+  // t.is(c.kpStatus(t1.notifyKPID), 'fulfilled'); // XXX RESTORE
+  // const notification = c.kpResolution(t1.notifyKPID); // XXX RESTORE
+  // t.is(kunser(notification).value, remaining); // XXX RESTORE
   t.is(c.kpStatus(t1.doneKPID), 'unresolved');
 
   // message three should underflow
@@ -353,10 +354,12 @@ test('meter decrements', async t => {
 
   await t2.consume(false);
   remaining = await t2.getMeter();
-  t.is(remaining, 0n); // this checks postAbortActions.deductMeter
-  t.is(c.kpStatus(t2.notifyKPID), 'fulfilled'); // and pAA.meterNotifications
-  const notify2 = c.kpResolution(t2.notifyKPID);
-  t.is(kunser(notify2).value, 0n);
+  // this checks postAbortActions.deductMeter
+  t.is(remaining, 0n);
+  // this checks pAA.meterNotifications
+  // t.is(c.kpStatus(t2.notifyKPID), 'fulfilled'); // XXX RESTORE
+  // const notify2 = c.kpResolution(t2.notifyKPID); // XXX RESTORE
+  // t.is(kunser(notify2).value, 0n); // XXX RESTORE
   kpidRejected(t, c, t2.doneKPID, 'meter underflow, vat terminated');
 });
 

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -1,0 +1,304 @@
+export {}; 
+/**
+ * @template T
+ * @typedef {import('@endo/far').ERef<T>} ERef
+ */
+
+/**
+ * @template T
+ * @typedef {import('@endo/promise-kit').PromiseKit<T>} PromiseKit
+ */
+
+/**
+ * Deprecated. Use PromiseKit instead.
+ *
+ * @template T
+ * @typedef {import('@endo/promise-kit').PromiseRecord<T>} PromiseRecord
+ */
+
+/**
+ * @template T
+ * @template [TReturn=any]
+ * @template [TNext=undefined]
+ * @typedef {AsyncIterator<T, TReturn, TNext> & {
+ *   fork(): ForkableAsyncIterator<T, TReturn, TNext>
+ * }} ForkableAsyncIterator An AsyncIterator that can be forked at a given position
+ * into multiple independent ForkableAsyncIterators starting from that position.
+ */
+
+/**
+ * @template T
+ * @template [TReturn=any]
+ * @template [TNext=undefined]
+ * @typedef {{
+ *   [Symbol.asyncIterator]: () => ForkableAsyncIterator<T, TReturn, TNext>
+ * }} ForkableAsyncIterable
+ * An AsyncIterable that produces ForkableAsyncIterators.
+ */
+
+/**
+ * @template T
+ * @typedef {object} IterationObserver<T>
+ * A valid sequence of calls to the methods of an `IterationObserver`
+ * represents an iteration. A valid sequence consists of any number of calls
+ * to `updateState` with the successive non-final values, followed by a
+ * final call to either `finish` with a successful `completion` value
+ * or `fail` with the alleged `reason` for failure. After at most one
+ * terminating calls, no further calls to these methods are valid and must be
+ * rejected.
+ * @property {(nonFinalValue: T) => void} updateState
+ * @property {(completion: T) => void} finish
+ * @property {(reason: unknown) => void} fail
+ */
+
+// /////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @template T
+ * @typedef {object} PublicationRecord
+ * Will be shared between machines, so it must be safe to expose. But software
+ * outside the current package should consider it opaque, not depending on its
+ * internal structure.
+ * @property {IteratorResult<T>} head
+ * @property {bigint} publishCount
+ * @property {Promise<PublicationRecord<T>>} tail
+ */
+
+/**
+ * @template T
+ * @typedef {object} EachTopic
+ * @property {(publishCount?: bigint) => Promise<PublicationRecord<T>>} subscribeAfter
+ * Returns a promise for a "current" PublicationRecord (referencing its
+ * immediate successor via a `tail` promise) that is later than the
+ * provided publishCount.
+ * Used to make forward-lossless ("each") iterators.
+ */
+
+/**
+ * @template T
+ * @typedef {object} LatestTopic
+ * @property {(updateCount?: bigint | number) => Promise<UpdateRecord<T>>} getUpdateSince
+ * Returns a promise for an update record as of an update count.
+ * If the `updateCount` argument is omitted or differs from the current update count,
+ * the promise promptly resolves to the current record.
+ * Otherwise, after the next state change, the promise resolves to the resulting record.
+ * This is an attenuated form of `subscribeAfter` whose return value stands alone and
+ * does not allow consumers to pin a chain of historical PublicationRecords.
+ * Used to make lossy ("latest") iterators.
+ * NOTE: Use of `number` as an `updateCount` is deprecated.
+ */
+
+/**
+ * @template T
+ * @typedef {LatestTopic<T>} BaseNotifier This type is deprecated but is still
+ * used externally.
+ */
+
+/**
+ * @template T
+ * @typedef {LatestTopic<T> & EachTopic<T>} Subscriber
+ * A stream of results that allows consumers to configure
+ * forward-lossless "each" iteration with `subscribeEach` and
+ * lossy "latest" iteration with `subscribeLatest`.
+ */
+
+/**
+ * @template T
+ * @typedef {object} Publisher
+ * A valid sequence of calls to the methods of an `IterationObserver`
+ * represents an iteration. A valid sequence consists of any number of calls
+ * to `publish` with the successive non-final values, followed by a
+ * final call to either `finish` with a successful `completion` value
+ * or `fail` with the alleged `reason` for failure. After at most one
+ * terminating calls, no further calls to these methods are valid and must be
+ * rejected.
+ * @property {(nonFinalValue: T) => void} publish
+ * @property {(completion: T) => void} finish
+ * @property {(reason: any) => void} fail
+ */
+
+/**
+ * @template T
+ * @typedef {Partial<Publisher<T>>} PublishObserver
+ */
+
+/**
+ * @template T
+ * @typedef {object} PublishKit<T>
+ * @property {Publisher<T>} publisher
+ * @property {Subscriber<T>} subscriber
+ */
+
+/**
+ * @template T
+ * @typedef {object} StoredPublishKit<T>
+ * @property {Publisher<T>} publisher
+ * @property {StoredSubscriber<T>} subscriber
+ */
+
+// /////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @typedef {'mandatory' | 'opportunistic' | 'ignored'} DurablePublishKitValueDurability
+ *
+ * Durability configures constraints on non-terminal values that can be
+ * published to a durable publish kit (terminal values sent to finish or fail
+ * must always be durable).
+ * - 'mandatory' means that each value must be durable, so it can be restored
+ *   on upgrade.
+ * - 'opportunistic' means that a durable value is persisted for post-upgrade
+ *   restoration, but a non-durable value is still accepted (and will result in
+ *   valueless restoration).
+ * - 'ignored' means that a value is not persisted for restoration even if it
+ *   is durable.
+ *
+ * 'mandatory' is the only currently-supported value, and others must not be
+ * enabled without test coverage.
+ */
+
+/**
+ * @typedef {object} DurablePublishKitState
+ *
+ * @property {DurablePublishKitValueDurability} valueDurability
+ *
+ * @property {bigint} publishCount
+ *
+ * @property {'live' | 'finished' | 'failed'} status
+ *
+ * @property {boolean} hasValue
+ * hasValue indicates the presence of value. It starts off false,
+ * and can be reset to false when a durable publish kit is restored and
+ * the previous value was not durable, or non-terminal and valueDurablity is 'ignored'.
+ *
+ * @property {any} value
+ * value holds either a non-terminal value from `publish` or a terminal value
+ * from `finish` or `fail`, depending upon the value in status.
+ */
+
+// /////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @template T
+ * @typedef {object} UpdateRecord<T>
+ * @property {T} value is whatever state the service wants to publish
+ * @property {bigint} [updateCount] is a value that identifies the update.  For
+ * the last update, it is `undefined`.
+ */
+
+/**
+ * @template T
+ * @typedef {BaseNotifier<T>} NotifierInternals Will be shared between machines,
+ * so it must be safe to expose. But other software should avoid depending on
+ * its internal structure.
+ */
+
+/**
+ * @template T
+ * @typedef {NotifierInternals<T> &
+ *   ForkableAsyncIterable<T, T> &
+ *   SharableNotifier<T>
+ * } Notifier<T> an object that can be used to get the current state or updates
+ */
+
+/**
+ * @template T
+ * @typedef {object} SharableNotifier
+ * @property {() => Promise<NotifierInternals<T>>} getSharableNotifierInternals
+ * Used to replicate the multicast values at other sites. To manually create a
+ * local representative of a Notification, do
+ * ```js
+ * localIterable =
+ *   makeNotifier(E(remoteIterable).getSharableNotifierInternals());
+ * ```
+ * The resulting `localIterable` also supports such remote use, and
+ * will return access to the same representation.
+ */
+
+/**
+ * @template T
+ * @typedef {object} NotifierRecord<T> the produced notifier/updater pair
+ * @property {IterationObserver<T>} updater the (closely-held) notifier producer
+ * @property {Notifier<T>} notifier the (widely-held) notifier consumer
+ */
+
+// /////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @template T
+ * @typedef {ForkableAsyncIterable<T, T> & EachTopic<T> &
+ *   SharableSubscription<T>} Subscription<T>
+ * A form of AsyncIterable supporting distributed and multicast usage.
+ */
+
+/**
+ * @template T
+ * @typedef {object} SharableSubscription
+ * @property {() => Promise<EachTopic<T>>} getSharableSubscriptionInternals
+ * Used to replicate the multicast values at other sites. To manually create a
+ * local representative of a Subscription, do
+ * ```js
+ * localIterable =
+ *   makeSubscription(E(remoteIterable).getSharableSubscriptionInternals());
+ * ```
+ * The resulting `localIterable` also supports such remote use, and
+ * will return access to the same representation.
+ */
+
+/**
+ * @template T
+ * @typedef {object} SubscriptionRecord<T>
+ * @property {IterationObserver<T>} publication
+ * @property {Subscription<T>} subscription
+ */
+
+// /////////////////////////////////////////////////////////////////////////////
+
+/** @typedef {ReturnType<typeof import('@endo/marshal').makeMarshal>} Marshaller */
+/** @typedef {Pick<Marshaller, 'unserialize'>} Unserializer */
+
+/**
+ * Defined by vstorageStoreKey in vstorage.go
+ *
+ * @typedef VStorageKey
+ * @property {string} storeName
+ * @property {string} storeSubkey
+ * @property {string} dataPrefixBytes
+ * @property {string} [noDataValue]
+ */
+
+/**
+ * This represents a node in an IAVL tree.
+ *
+ * The active implementation is x/vstorage, an Agoric extension of the Cosmos SDK.
+ *
+ * Vstorage is a hierarchical externally-reachable storage structure that
+ * identifies children by restricted ASCII name and is associated with arbitrary
+ * string-valued data for each node, defaulting to the empty string.
+ *
+ * @typedef {object} StorageNode
+ * @property {(data: string) => Promise<void>} setValue publishes some data (append to the node)
+ * @property {() => string} getPath the chain storage path at which the node was constructed
+ * @property {() => Promise<VStorageKey>} getStoreKey DEPRECATED use getPath
+ * @property {(subPath: string, options?: {sequence?: boolean}) => StorageNode} makeChildNode
+ */
+
+/**
+ * @typedef {object} StoredFacet
+ * @property {() => Promise<string>} getPath the chain storage path at which the node was constructed
+ * @property {StorageNode['getStoreKey']} getStoreKey DEPRECATED use getPath
+ * @property {() => Unserializer} getUnserializer get the unserializer for the stored data
+ */
+
+/**
+ * @deprecated use StoredSubscriber
+ * @template T
+ * @typedef {Subscription<T> & {
+ *   getStoreKey: () => Promise<VStorageKey & { subscription: Subscription<T> }>,
+ *   getUnserializer: () => Unserializer,
+ * }} StoredSubscription
+ */
+
+/**
+ * @template T
+ * @typedef {Subscriber<T> & StoredFacet} StoredSubscriber
+ */

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -1,4 +1,4 @@
-export {}; 
+export {};
 /**
  * @template T
  * @typedef {import('@endo/far').ERef<T>} ERef


### PR DESCRIPTION
Fixes #7324

## Description

Continues use of "XXX TEMP" and "XXX RESTORE" comments as breadcrumbs for the future.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a