### PR TITLE
7300 durable Recorder

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -4,17 +4,12 @@ import '@agoric/zoe/src/contracts/exported.js';
 import '@agoric/governance/exported.js';
 
 import { AmountMath, AmountShape, BrandShape, IssuerShape } from '@agoric/ertp';
+import { makeTracer } from '@agoric/internal';
 import {
-  makePublicTopic,
   makeStoredPublisherKit,
-  pipeTopicToStorage,
-  prepareDurablePublishKit,
   SubscriberShape,
   TopicsRecordShape,
-  makeStoredPublisherKit,
-  SubscriberShape,
 } from '@agoric/notifier';
-import { makeTracer, makeTracer } from '@agoric/internal';
 import { M, makeScalarMapStore, mustMatch } from '@agoric/store';
 import {
   defineDurableExoClassKit,
@@ -26,23 +21,22 @@ import {
   atomicRearrange,
   getAmountIn,
   getAmountOut,
-  makeRatioFromAmounts,
   makeRecorderTopic,
+  makeRatioFromAmounts,
   provideChildBaggage,
   provideEmptySeat,
-  TopicsRecordShape,
   unitAmount,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
+import { scheduleLiquidationWakeups } from './liquidation.js';
 import {
   makeVaultParamManager,
   SHORTFALL_INVITATION_KEY,
   vaultParamPattern,
 } from './params.js';
 import { prepareVaultManagerKit } from './vaultManager.js';
-import { scheduleLiquidationWakeups } from './liquidation.js';
 
 const { Fail, quote: q } = assert;
 
@@ -89,6 +83,8 @@ const shortfallInvitationKey = 'shortfallInvitation';
  * @param {ERef<import('../auction/auctioneer.js').AuctioneerPublicFacet>} auctioneer
  * @param {ERef<StorageNode>} storageNode
  * @param {ERef<Marshaller>} marshaller
+ * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit} makeRecorderKit
+ * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeERecorderKit} makeERecorderKit
  */
 export const prepareVaultDirector = (
   baggage,
@@ -99,11 +95,9 @@ export const prepareVaultDirector = (
   auctioneer,
   storageNode,
   marshaller,
+  makeRecorderKit,
+  makeERecorderKit,
 ) => {
-  const makeVaultDirectorPublishKit = prepareDurablePublishKit(
-    baggage,
-    'Vault Director publish kit',
-  );
   /** For holding newly minted tokens until transferred */
   const { zcfSeat: mintSeat } = zcf.makeEmptySeatKit();
 
@@ -119,18 +113,18 @@ export const prepareVaultDirector = (
    */
   const vaultParamManagers = makeScalarMapStore('vaultParamManagers');
 
-  /** @type {PublishKit<MetricsNotification>} */
-  const { publisher: metricsPublisher, subscriber: metricsSubscriber } =
-    makeVaultDirectorPublishKit();
-
   const metricsNode = E(storageNode).makeChildNode('metrics');
-  pipeTopicToStorage(metricsSubscriber, metricsNode, marshaller);
-  const topics = harden({
-    metrics: makePublicTopic(
-      'Vault Factory metrics',
-      metricsSubscriber,
-      metricsNode,
+
+  const metricsKit = makeERecorderKit(
+    metricsNode,
+    /** @type {import('@agoric/zoe/src/contractSupport/recorder.js').TypedMatcher<MetricsNotification>} */ (
+      M.any()
     ),
+  );
+
+  // TODO helper to make all the topics at once
+  const topics = harden({
+    metrics: makeRecorderTopic('Vault Factory metrics', metricsKit),
   });
 
   const allManagersDo = fn => {
@@ -218,7 +212,7 @@ export const prepareVaultDirector = (
         ),
         makeCollectFeesInvitation: M.call().returns(M.promise()),
         getContractGovernor: M.call().returns(M.remotable()),
-        updateMetrics: M.call().returns(),
+        updateMetrics: M.call().returns(M.promise()),
         getRewardAllocation: M.call().returns({ Minted: AmountShape }),
         makePriceLockWaker: M.call().returns(M.remotable('TimerWaker')),
         makeLiquidationWaker: M.call().returns(M.remotable('TimerWaker')),
@@ -306,8 +300,9 @@ export const prepareVaultDirector = (
 
           // counter to be incremented at end of addVaultType
           const managerId = `manager${state.managerCounter}`;
-          const managerStorageNode =
-            storageNode && E(storageNode).makeChildNode(managerId);
+          const managerStorageNode = await E(storageNode).makeChildNode(
+            managerId,
+          );
 
           /** a powerful object; can modify parameters */
           const vaultParamManager = makeVaultParamManager(
@@ -352,7 +347,7 @@ export const prepareVaultDirector = (
               debtMint.burnLosses(harden({ Minted: toMint }), mintSeat);
               throw e;
             }
-            facets.machine.updateMetrics();
+            void facets.machine.updateMetrics();
           };
 
           /**
@@ -397,6 +392,8 @@ export const prepareVaultDirector = (
             prepareVaultManagerKit,
             zcf,
             marshaller,
+            makeRecorderKit,
+            makeERecorderKit,
             {
               debtMint,
               collateralBrand,
@@ -410,7 +407,7 @@ export const prepareVaultDirector = (
 
           const { self: vm } = makeVaultManager();
           collateralTypes.init(collateralBrand, vm);
-          facets.machine.updateMetrics();
+          void facets.machine.updateMetrics();
           state.managerCounter += 1;
           return vm;
         },
@@ -426,7 +423,7 @@ export const prepareVaultDirector = (
           return zcf.getTerms().electionManager;
         },
         updateMetrics() {
-          return metricsPublisher.publish(sampleMetrics());
+          return E(metricsKit.recorderP).write(sampleMetrics());
         },
         // XXX accessors for tests
         getRewardAllocation() {
@@ -487,7 +484,7 @@ export const prepareVaultDirector = (
         },
         /** @deprecated use getPublicTopics */
         getMetrics() {
-          return metricsSubscriber;
+          return metricsKit.subscriber;
         },
         getRunIssuer() {
           return debtMint.getIssuerRecord().issuer;

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -11,7 +11,10 @@ import {
   prepareDurablePublishKit,
   SubscriberShape,
   TopicsRecordShape,
+  makeStoredPublisherKit,
+  SubscriberShape,
 } from '@agoric/notifier';
+import { makeTracer, makeTracer } from '@agoric/internal';
 import { M, makeScalarMapStore, mustMatch } from '@agoric/store';
 import {
   defineDurableExoClassKit,
@@ -24,13 +27,14 @@ import {
   getAmountIn,
   getAmountOut,
   makeRatioFromAmounts,
+  makeRecorderTopic,
   provideChildBaggage,
   provideEmptySeat,
+  TopicsRecordShape,
   unitAmount,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeTracer } from '@agoric/internal';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import {
   makeVaultParamManager,

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -23,6 +23,7 @@ import { makeParamManagerFromTerms } from '@agoric/governance/src/contractGovern
 import { assertAllDefined } from '@agoric/internal';
 import { makeStoredSubscription, makeSubscriptionKit } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
+import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { SHORTFALL_INVITATION_KEY, vaultDirectorParamTypes } from './params.js';
 import { prepareVaultDirector } from './vaultDirector.js';
 
@@ -68,6 +69,11 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   const { timerService, auctioneerPublicFacet } = zcf.getTerms();
 
+  const { makeRecorderKit, makeERecorderKit } = prepareRecorderKitMakers(
+    baggage,
+    marshaller,
+  );
+
   // XXX non-durable
   const governanceSubscriptionKit = makeSubscriptionKit();
   const governanceNode = E(storageNode).makeChildNode('governance');
@@ -103,7 +109,10 @@ export const start = async (zcf, privateArgs, baggage) => {
     timerService,
     auctioneerPublicFacet,
     storageNode,
+    // XXX remove Recorder makers; remove once we excise deprecated kits for governance
     marshaller,
+    makeRecorderKit,
+    makeERecorderKit,
   );
 
   const factory = makeVaultDirector();

--- a/packages/inter-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultKit.js
@@ -9,12 +9,12 @@ const trace = makeTracer('VK', false);
  * Wrap the VaultHolder duration object in a record suitable for the result of an invitation.
  *
  * @param {import('@agoric/ertp').Baggage} baggage
- * @param {ERef<Marshaller>} marshaller
+ * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit} makeRecorderKit
  */
-export const prepareVaultKit = (baggage, marshaller) => {
+export const prepareVaultKit = (baggage, makeRecorderKit) => {
   trace('prepareVaultKit', [...baggage.keys()]);
 
-  const makeVaultHolder = prepareVaultHolder(baggage, marshaller);
+  const makeVaultHolder = prepareVaultHolder(baggage, makeRecorderKit);
   /**
    * Create a kit of utilities for use of the vault.
    *

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -2,6 +2,16 @@
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 
 import { assert } from '@agoric/assert';
+import { makePublishKit, observeNotifier } from '@agoric/notifier';
+import {
+  makeFakeMarshaller,
+  makeFakeStorage,
+} from '@agoric/notifier/tools/testSupports.js';
+import {
+  atomicRearrange,
+  prepareRecorderKit,
+  unitAmount,
+} from '@agoric/zoe/src/contractSupport/index.js';
 import {
   floorDivideBy,
   makeRatio,
@@ -10,21 +20,12 @@ import {
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
-import { Far } from '@endo/marshal';
-import { makePublishKit, observeNotifier } from '@agoric/notifier';
-import {
-  makeFakeMarshaller,
-  makeFakeStorage,
-} from '@agoric/notifier/tools/testSupports.js';
-import {
-  atomicRearrange,
-  unitAmount,
-} from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
 
+import { priceFrom } from '../../src/auction/util.js';
 import { paymentFromZCFMint } from '../../src/vaultFactory/burn.js';
 import { prepareVault } from '../../src/vaultFactory/vault.js';
-import { priceFrom } from '../../src/auction/util';
 
 const BASIS_POINTS = 10000n;
 const SECONDS_PER_HOUR = 60n * 60n;
@@ -176,7 +177,9 @@ export async function start(zcf, privateArgs, baggage) {
     },
   });
 
-  const makeVault = prepareVault(baggage, marshaller, zcf);
+  const makeRecorderKit = prepareRecorderKit(baggage, marshaller);
+
+  const makeVault = prepareVault(baggage, makeRecorderKit, zcf);
 
   const { self: vault } = await makeVault(
     managerMock,

--- a/packages/notifier/src/stored-topic.js
+++ b/packages/notifier/src/stored-topic.js
@@ -5,6 +5,7 @@ import { E } from '@endo/far';
 import { SubscriberShape } from './publish-kit.js';
 import { forEachPublicationRecord } from './storesub.js';
 
+// XXX PublicTopic is a higher level concern
 export const PublicTopicShape = M.splitRecord(
   {
     subscriber: SubscriberShape,
@@ -54,6 +55,9 @@ export const pipeTopicToStorage = (topic, storageNode, marshaller) => {
 harden(pipeTopicToStorage);
 
 /**
+ * If the subscriber and storageNode are coming from a Recorder kit,
+ * use a makePublicTopic that takes that object directly.
+ *
  * @template T
  * @param {string} description
  * @param {Subscriber<T>} subscriber

--- a/packages/notifier/test/test-stored-subscription.js
+++ b/packages/notifier/test/test-stored-subscription.js
@@ -141,8 +141,11 @@ test('stored subscriber', async t => {
 
 test('stored subscriber with setValue failure', async t => {
   const initialValue = 'first value';
-  // no publication param, will fail setValue
-  const storage = makeFakeStorage('publish.foo.bar');
+
+  const storage = makeFakeStorage('publish.foo.bar', {
+    // @ts-expect-error faulty publication param to fail setValue
+    updateState: null,
+  });
 
   const { publisher, subscriber } = makePublishKit();
 

--- a/packages/notifier/tools/testSupports.js
+++ b/packages/notifier/tools/testSupports.js
@@ -28,10 +28,9 @@ export const makeFakeStorage = (path, publication) => {
     setValue: async value => {
       setValueCalls += 1;
       assert.typeof(value, 'string');
-      if (!publication) {
-        throw Error('publication undefined');
+      if (publication) {
+        publication.updateState(value);
       }
-      publication.updateState(value);
     },
     makeChildNode: () => storage,
     countSetValueCalls: () => setValueCalls,

--- a/packages/zoe/src/contractSupport/durability.js
+++ b/packages/zoe/src/contractSupport/durability.js
@@ -40,6 +40,7 @@ export const makeEphemeraProvider = init => {
 harden(makeEphemeraProvider);
 
 /**
+ * @deprecated use Recorder getStoragePath() which memoizes
  *
  * @param {import('@agoric/vat-data').Baggage} baggage
  */

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -6,17 +6,9 @@ export {
   calcSecondaryRequired,
 } from './bondingCurves.js';
 
-export * from './durability.js';
-
-export * from './priceAuthority.js';
-
-export * from './priceQuote.js';
-
 export { natSafeMath } from './safeMath.js';
 
 export { makeStateMachine } from './stateMachine.js';
-
-export * from './statistics.js';
 
 export {
   atomicRearrange,
@@ -58,3 +50,9 @@ export {
   subtractRatios,
   ratioToNumber,
 } from './ratio.js';
+
+export * from './durability.js';
+export * from './priceAuthority.js';
+export * from './priceQuote.js';
+export * from './statistics.js';
+export * from './recorder.js';

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -56,3 +56,4 @@ export * from './priceAuthority.js';
 export * from './priceQuote.js';
 export * from './statistics.js';
 export * from './recorder.js';
+export * from './topics.js';

--- a/packages/zoe/src/contractSupport/recorder.js
+++ b/packages/zoe/src/contractSupport/recorder.js
@@ -243,19 +243,3 @@ export const prepareRecorderKitMakers = (baggage, marshaller) => {
  * @template {TypedMatcher<any>} TM
  * @typedef {TM extends TypedMatcher<infer T> ? T : never} MatchedType
  */
-
-/**
- * @template T
- * @param {string} description
- * @param {RecorderKit<T> | EventualRecorderKit<T>} recorderKit
- * @returns {import('@agoric/notifier').PublicTopic<T>}
- */
-export const makePublicTopic = (description, recorderKit) => {
-  const recP =
-    'recorder' in recorderKit ? recorderKit.recorder : recorderKit.recorderP;
-  return {
-    description,
-    subscriber: recorderKit.subscriber,
-    storagePath: E(recP).getStoragePath(),
-  };
-};

--- a/packages/zoe/src/contractSupport/recorder.js
+++ b/packages/zoe/src/contractSupport/recorder.js
@@ -1,0 +1,261 @@
+import { Fail } from '@agoric/assert';
+import { makeTypeGuards } from '@agoric/internal';
+import { prepareDurablePublishKit } from '@agoric/notifier';
+import { mustMatch } from '@agoric/store';
+import { M, prepareExoClass } from '@agoric/vat-data';
+import { E } from '@endo/eventual-send';
+
+// XXX UNTIL https://github.com/Agoric/agoric-sdk/issues/7090
+const { StorageNodeShape } = makeTypeGuards(M);
+
+/**
+ * Recorders support publishing data to vstorage.
+ *
+ * `Recorder` is similar to `Publisher` (in that they send out data) but has different signatures:
+ * - methods are async because they await remote calls to Marshaller and StorageNode
+ * - method names convey the durability
+ * - omits fail()
+ * - adds getStorageNode() from its durable state
+ *
+ * Other names such as StoredPublisher or ChainStoragePublisher were considered, but found to be sometimes confused with *durability*, another trait of this class.
+ */
+
+/**
+ * @template T
+ * @typedef {{ getStorageNode(): StorageNode, getStoragePath(): Promise<string>, write(value: T): Promise<void>, writeFinal(value: T): Promise<void> }} Recorder
+ */
+
+/**
+ * @template T
+ * @typedef {Pick<PublishKit<T>, 'subscriber'> & { recorder: Recorder<T> }} RecorderKit
+ */
+
+/**
+ * @template T
+ * @typedef {Pick<PublishKit<T>, 'subscriber'> & { recorderP: ERef<Recorder<T>> }} EventualRecorderKit
+ */
+
+/**
+ * Wrap a Publisher to record all the values to chain storage.
+ *
+ * @param {import('@agoric/zoe').Baggage} baggage
+ * @param {ERef<Marshaller>} marshaller
+ */
+export const prepareRecorder = (baggage, marshaller) => {
+  const makeRecorder = prepareExoClass(
+    baggage,
+    'Recorder',
+    M.interface('Recorder', {
+      getStorageNode: M.call().returns(StorageNodeShape),
+      getStoragePath: M.call().returns(M.promise(/* string */)),
+      write: M.call(M.any()).returns(M.promise()),
+      writeFinal: M.call(M.any()).returns(M.promise()),
+    }),
+    /**
+     * @template T
+     * @param {PublishKit<T>['publisher']} publisher
+     * @param {StorageNode} storageNode
+     * @param {TypedMatcher<T>} [valueShape]
+     */
+    (publisher, storageNode, valueShape = M.any()) => {
+      return {
+        closed: false,
+        publisher,
+        storageNode,
+        storagePath: /** @type {string | undefined} */ (undefined),
+        valueShape,
+      };
+    },
+    {
+      getStorageNode() {
+        return this.state.storageNode;
+      },
+      /**
+       * Memoizes the remote call to the storage node
+       *
+       * @returns {Promise<string>}
+       */
+      async getStoragePath() {
+        const { storagePath: heldPath } = this.state;
+        // end synchronous prelude
+        await null;
+        if (heldPath !== undefined) {
+          return heldPath;
+        }
+        const path = await E(this.state.storageNode).getPath();
+        this.state.storagePath = path;
+        return path;
+      },
+      /**
+       * Marshalls before writing to storage or publisher to help ensure the two streams match.
+       *
+       * @param {unknown} value
+       * @returns {Promise<void>}
+       */
+      async write(value) {
+        const { closed, publisher, storageNode, valueShape } = this.state;
+        !closed || Fail`cannot write to closed recorder`;
+        mustMatch(value, valueShape);
+        const encoded = await E(marshaller).serialize(value);
+        const serialized = JSON.stringify(encoded);
+        await E(storageNode).setValue(serialized);
+
+        // below here differs from writeFinal()
+        return publisher.publish(value);
+      },
+      /**
+       * Like `write` but prevents future writes and terminates the publisher.
+       *
+       * @param {unknown} value
+       * @returns {Promise<void>}
+       */
+      async writeFinal(value) {
+        const { closed, publisher, storageNode, valueShape } = this.state;
+        !closed || Fail`cannot write to closed recorder`;
+        mustMatch(value, valueShape);
+        const encoded = await E(marshaller).serialize(value);
+        const serialized = JSON.stringify(encoded);
+        await E(storageNode).setValue(serialized);
+
+        // below here differs from writeFinal()
+        this.state.closed = true;
+        return publisher.finish(value);
+      },
+    },
+  );
+
+  return makeRecorder;
+};
+harden(prepareRecorder);
+/** @typedef {ReturnType<typeof prepareRecorder>} MakeRecorder */
+
+/**
+ * @param {{makeRecorder: MakeRecorder, makeDurablePublishKit: ReturnType<typeof prepareDurablePublishKit>}} makers
+ */
+export const defineRecorderKit = ({ makeRecorder, makeDurablePublishKit }) => {
+  /**
+   * @template T
+   * @param {StorageNode} storageNode
+   * @param {TypedMatcher<T>} [valueShape]
+   * @returns {RecorderKit<T>}
+   */
+  const makeRecorderKit = (storageNode, valueShape) => {
+    const { subscriber, publisher } = makeDurablePublishKit();
+    const recorder = makeRecorder(publisher, storageNode, valueShape);
+    return harden({ subscriber, recorder });
+  };
+  return makeRecorderKit;
+};
+/** @typedef {ReturnType<typeof defineRecorderKit>} MakeRecorderKit */
+
+/**
+ * @param {{makeRecorder: MakeRecorder, makeDurablePublishKit: ReturnType<typeof prepareDurablePublishKit>}} makers
+ */
+export const defineERecorderKit = ({ makeRecorder, makeDurablePublishKit }) => {
+  /**
+   * @template T
+   * @param {ERef<StorageNode>} storageNodeP
+   * @param {TypedMatcher<T>} [valueShape]
+   * @returns {EventualRecorderKit<T>}
+   */
+  const makeERecorderKit = (storageNodeP, valueShape) => {
+    const { publisher, subscriber } = makeDurablePublishKit();
+    const recorderP = E.when(storageNodeP, storageNode =>
+      makeRecorder(publisher, storageNode, valueShape),
+    );
+    return { subscriber, recorderP };
+  };
+  return makeERecorderKit;
+};
+harden(defineERecorderKit);
+/** @typedef {ReturnType<typeof defineERecorderKit>} MakeERecorderKit */
+
+/**
+ * Convenience wrapper to prepare the DurablePublishKit and Recorder kinds.
+ * Note that because prepareRecorder() can only be called once per baggage,
+ * this should only be used when there is no need for an EventualRecorderKit.
+ * When there is, prepare the kinds separately and pass to the kit definers.
+ *
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {ERef<Marshaller>} marshaller
+ */
+export const prepareRecorderKit = (baggage, marshaller) => {
+  const makeDurablePublishKit = prepareDurablePublishKit(
+    baggage,
+    'Durable Publish Kit',
+  );
+  const makeRecorder = prepareRecorder(baggage, marshaller);
+  return defineRecorderKit({ makeDurablePublishKit, makeRecorder });
+};
+
+/**
+ * To be called at most once per baggage.
+ *
+ * `makeRecorderKit` is suitable for making a durable `RecorderKit` which can be held in Exo state.
+ * `makeERecorderKit` is for closures that must return a `subscriber` synchronously but can defer the `recorder`.
+ *
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {ERef<Marshaller>} marshaller
+ */
+export const prepareRecorderKitMakers = (baggage, marshaller) => {
+  const makeDurablePublishKit = prepareDurablePublishKit(
+    baggage,
+    'Durable Publish Kit',
+  );
+  const makeRecorder = prepareRecorder(baggage, marshaller);
+  /**
+   * @template T
+   * @param {StorageNode} storageNode
+   * @param {TypedMatcher<T>} [valueShape]
+   * @returns {RecorderKit<T>}
+   */
+  const makeRecorderKit = (storageNode, valueShape) => {
+    const { subscriber, publisher } = makeDurablePublishKit();
+    const recorder = makeRecorder(publisher, storageNode, valueShape);
+    return harden({ subscriber, recorder });
+  };
+  /**
+   * @template T
+   * @param {ERef<StorageNode>} storageNodeP
+   * @param {TypedMatcher<T>} [valueShape]
+   * @returns {EventualRecorderKit<T>}
+   */
+  const makeERecorderKit = (storageNodeP, valueShape) => {
+    const { publisher, subscriber } = makeDurablePublishKit();
+    const recorderP = E.when(storageNodeP, storageNode =>
+      makeRecorder(publisher, storageNode, valueShape),
+    );
+    return { subscriber, recorderP };
+  };
+
+  return { makeRecorderKit, makeERecorderKit };
+};
+
+/**
+ * Stop-gap until https://github.com/Agoric/agoric-sdk/issues/6160
+ * explictly specify the type that the Pattern will verify through a match.
+ *
+ * @template T
+ * @typedef {Matcher & {validatedType?: T}} TypedMatcher
+ */
+
+/**
+ * @template {TypedMatcher<any>} TM
+ * @typedef {TM extends TypedMatcher<infer T> ? T : never} MatchedType
+ */
+
+/**
+ * @template T
+ * @param {string} description
+ * @param {RecorderKit<T> | EventualRecorderKit<T>} recorderKit
+ * @returns {import('@agoric/notifier').PublicTopic<T>}
+ */
+export const makePublicTopic = (description, recorderKit) => {
+  const recP =
+    'recorder' in recorderKit ? recorderKit.recorder : recorderKit.recorderP;
+  return {
+    description,
+    subscriber: recorderKit.subscriber,
+    storagePath: E(recP).getStoragePath(),
+  };
+};

--- a/packages/zoe/src/contractSupport/topics.js
+++ b/packages/zoe/src/contractSupport/topics.js
@@ -1,0 +1,17 @@
+import { E } from '@endo/eventual-send';
+
+/**
+ * @template T
+ * @param {string} description
+ * @param {import('./recorder.js').RecorderKit<T> | import('./recorder.js').EventualRecorderKit<T>} recorderKit
+ * @returns {import('@agoric/notifier').PublicTopic<T>}
+ */
+export const makeRecorderTopic = (description, recorderKit) => {
+  const recP =
+    'recorder' in recorderKit ? recorderKit.recorder : recorderKit.recorderP;
+  return {
+    description,
+    subscriber: recorderKit.subscriber,
+    storagePath: E(recP).getStoragePath(),
+  };
+};


### PR DESCRIPTION
refs: #7300

## Description

Publishing to vstorage in upgradable contracts requires a durable object to keep the storageNode. We explored other designs such as https://github.com/Agoric/agoric-sdk/pull/7341 but ran into problems. @gibson042 and I concluded that wrapping the `publisher` was the cleanest way forward.

This wraps only the `publisher` of the PublishKit  so `subscriber` access does not need to await resolution of storageNode.

It also wraps it opaquely because there are semantic differences in its operation and it has different requirements than a regular publisher. This implies that when introducing vstorage writes to an existing PublishKit consumer, downstream changes will be necessary. (E.g. [makeInstallationPublisher](https://github.com/Agoric/agoric-sdk/blob/79bd8b5baef7fe3a4139e3b6982e82715fe12a2b/packages/cosmic-swingset/src/chain-main.js#L282-L285) may need to return a `Recorder` and be renaming accordingly.)

This provides a design for solving #7300 and exercises it with Vault Factory. A few other places will also need updating so in a separate PR I'll do that and remove `pipeTopicToStorage`.

### Security Considerations

Authorities given to Zoe contract support functions.

### Scaling Considerations

Each durable contract with public topics will require one durable kind for the durable PublishKit and another for the Recorder. Each topic will instantiate them both.

### Documentation Considerations

--

### Testing Considerations

Zoe could use tests for these contract supports, though I contend that "real world" testing in Inter Protocol is sufficient for now.