### PR TITLE
refactor: Vaults get price updates continuously

### DIFF
--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -357,7 +357,7 @@ export const prepareAuctionBook = (baggage, zcf) => {
          *    they request inconsistent limits.
          */
         addAssets(assetAmount, sourceSeat, proceedsGoal) {
-          trace('add assets');
+          trace('add assets', { assetAmount, proceedsGoal });
           const { collateralBrand, collateralSeat, totalProceedsGoal } =
             this.state;
 

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -23,7 +23,7 @@ const { quote: q, Fail } = assert;
 
 const { StorageNodeShape } = makeTypeGuards(M);
 
-const trace = makeTracer('IV', false);
+const trace = makeTracer('Vault', false);
 
 /** @typedef {import('./storeUtils.js').NormalizedDebt} NormalizedDebt */
 
@@ -86,7 +86,7 @@ const validTransitions = {
 /**
  * @typedef {object} VaultManager
  * @property {() => Subscriber<import('./vaultManager').AssetState>} getAssetSubscriber
- * @property {(collateralAmount: Amount) => ERef<Amount<'nat'>>} maxDebtFor
+ * @property {(collateralAmount: Amount) => Amount<'nat'>} maxDebtFor
  * @property {() => Brand} getCollateralBrand
  * @property {(base: string) => string} scopeDescription
  * @property {() => Brand<'nat'>} getDebtBrand
@@ -558,7 +558,7 @@ export const prepareVault = (baggage, marshaller, zcf) => {
             fp.want.Collateral,
           );
           // max debt supported by the vault Collateral implied by the proposal
-          const maxDebtPre = await state.manager.maxDebtFor(newCollateralPre);
+          const maxDebtPre = state.manager.maxDebtFor(newCollateralPre);
           updaterPre === state.outerUpdater ||
             Fail`Transfer during vault adjustment`;
           helper.assertActive();

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -511,6 +511,7 @@ test('price falls precipitously', async t => {
 
   // @ts-expect-error it's a mock
   priceAuthority.setPrice(makeRatio(130n, run.brand, 1n, aeth.brand));
+  await eventLoopIteration();
 
   const { startTime, time } = await startAuctionClock(
     auctioneerKit,
@@ -1072,6 +1073,7 @@ test('sell goods at auction', async t => {
   // price falls
   // @ts-expect-error setupServices() should return the right type
   await priceAuthority.setPrice(makeRatio(70n, run.brand, 10n, aeth.brand));
+  await eventLoopIteration();
 
   // Bob's loan is now 777 Minted (including interest) on 100 Aeth, with the price
   // at 7. 100 * 7 > 1.05 * 777. When interest is charged again, Bob should get
@@ -1620,6 +1622,7 @@ test('liquidation Margin matters', async t => {
   // price falls to 10.00. notice that no liquidation takes place.
   // @ts-expect-error setupServices() should return the right type
   await priceAuthority.setPrice(makeRatio(1000n, run.brand, 100n, aeth.brand));
+  await eventLoopIteration();
 
   let { startTime } = await startAuctionClock(auctioneerKit, manualTimer);
 
@@ -1631,6 +1634,7 @@ test('liquidation Margin matters', async t => {
   // price falls to 9.99. Now it liquidates.
   // @ts-expect-error setupServices() should return the right type
   await priceAuthority.setPrice(makeRatio(999n, run.brand, 100n, aeth.brand));
+  await eventLoopIteration();
 
   ({ startTime } = await startAuctionClock(auctioneerKit, manualTimer));
 
@@ -1791,6 +1795,7 @@ test('reinstate vault', async t => {
   // price falls
   // @ts-expect-error setupServices() should return the right type
   await priceAuthority.setPrice(makeRatio(400n, run.brand, 100n, aeth.brand));
+  await eventLoopIteration();
 
   const { startTime } = await startAuctionClock(auctioneerKit, manualTimer);
 


### PR DESCRIPTION
closes: #6946

## Description

VaultManagers were already channeling a subscription to the priceAuthority in order to store it off chain. This uses that feed instead of requesting a fresh price when needed.

### Security Considerations

None

### Scaling Considerations

slight improvement.f

### Documentation Considerations

No impact on docs.

### Testing Considerations

updated existing tests.
