### PR TITLE
chore(store): Define narrow VOM context types

### DIFF
--- a/packages/store/src/patterns/exo-makers.js
+++ b/packages/store/src/patterns/exo-makers.js
@@ -18,19 +18,19 @@ const emptyRecord = harden({});
 export const initEmpty = () => emptyRecord;
 
 /**
- * @template [S = any]
- * @template [T = any]
- * @typedef {object} Context
- * @property {S} state
- * @property {T} self
+ * @typedef {import('./exo-tools.js').FacetName} FacetName
  */
 
 /**
  * @template [S = any]
- * @template [F = any]
- * @typedef {object} KitContext
- * @property {S} state
- * @property {F} facets
+ * @template [T = any]
+ * @typedef {import('./exo-tools.js').ClassContext} ClassContext
+ */
+
+/**
+ * @template [S = any]
+ * @template {Record<FacetName, any>} [F = any]
+ * @typedef {import('./exo-tools.js').KitContext} KitContext
  */
 
 /**
@@ -53,7 +53,7 @@ export const initEmpty = () => emptyRecord;
  * @param {any} interfaceGuard
  * @param {I} init
  * @param {M & ThisType<{ self: M, state: ReturnType<I> }>} methods
- * @param {FarClassOptions<Context<ReturnType<I>, M>>} [options]
+ * @param {FarClassOptions<ClassContext<ReturnType<I>, M>>} [options]
  * @returns {(...args: Parameters<I>) => (M & import('@endo/eventual-send').RemotableBrand<{}, M>)}
  */
 export const defineExoClass = (
@@ -63,11 +63,11 @@ export const defineExoClass = (
   methods,
   { finish = undefined } = {},
 ) => {
-  /** @type {WeakMap<M,Context<ReturnType<I>, M>>} */
+  /** @type {WeakMap<M,ClassContext<ReturnType<I>, M>>} */
   const contextMap = new WeakMap();
   const prototype = defendPrototype(
     tag,
-    self => contextMap.get(self),
+    self => /** @type {any} */ (contextMap.get(self)),
     methods,
     true,
     interfaceGuard,
@@ -82,7 +82,7 @@ export const defineExoClass = (
     // @ts-expect-error could be instantiated with different subtype
     const self = harden({ __proto__: prototype });
     // Be careful not to freeze the state record
-    /** @type {Context<ReturnType<I>,M>} */
+    /** @type {ClassContext<ReturnType<I>,M>} */
     const context = freeze({ state, self });
     contextMap.set(self, context);
     if (finish) {
@@ -97,7 +97,7 @@ harden(defineExoClass);
 
 /**
  * @template {(...args: any[]) => any} I init function
- * @template {Record<string, Record<string | symbol, CallableFunction>>} F facet methods
+ * @template {Record<FacetName, Record<string | symbol, CallableFunction>>} F facet methods
  * @param {string} tag
  * @param {any} interfaceGuardKit
  * @param {I} init
@@ -157,7 +157,7 @@ harden(defineExoClassKit);
  * @param {string} tag
  * @param {InterfaceGuard | undefined} interfaceGuard CAVEAT: static typing does not yet support `callWhen` transformation
  * @param {T} methods
- * @param {FarClassOptions<Context<{},T>>} [options]
+ * @param {FarClassOptions<ClassContext<{},T>>} [options]
  * @returns {T & import('@endo/eventual-send').RemotableBrand<{}, T>}
  */
 export const makeExo = (tag, interfaceGuard, methods, options = undefined) => {

--- a/packages/store/src/patterns/exo-makers.js
+++ b/packages/store/src/patterns/exo-makers.js
@@ -19,17 +19,18 @@ export const initEmpty = () => emptyRecord;
 
 /**
  * @typedef {import('./exo-tools.js').FacetName} FacetName
+ * @typedef {import('./exo-tools.js').Methods} Methods
  */
 
 /**
  * @template [S = any]
- * @template [T = any]
+ * @template {Methods} [M = any]
  * @typedef {import('./exo-tools.js').ClassContext} ClassContext
  */
 
 /**
  * @template [S = any]
- * @template {Record<FacetName, any>} [F = any]
+ * @template {Record<FacetName, Methods>} [F = any]
  * @typedef {import('./exo-tools.js').KitContext} KitContext
  */
 
@@ -48,7 +49,7 @@ export const initEmpty = () => emptyRecord;
 
 /**
  * @template {(...args: any[]) => any} I init function
- * @template {Record<string | symbol, CallableFunction>} M methods
+ * @template {Methods} M methods
  * @param {string} tag
  * @param {any} interfaceGuard
  * @param {I} init
@@ -97,7 +98,7 @@ harden(defineExoClass);
 
 /**
  * @template {(...args: any[]) => any} I init function
- * @template {Record<FacetName, Record<string | symbol, CallableFunction>>} F facet methods
+ * @template {Record<FacetName, Methods>} F facet methods
  * @param {string} tag
  * @param {any} interfaceGuardKit
  * @param {I} init
@@ -153,7 +154,7 @@ export const defineExoClassKit = (
 harden(defineExoClassKit);
 
 /**
- * @template {Record<string | symbol, CallableFunction>} T
+ * @template {Methods} T
  * @param {string} tag
  * @param {InterfaceGuard | undefined} interfaceGuard CAVEAT: static typing does not yet support `callWhen` transformation
  * @param {T} methods

--- a/packages/store/src/patterns/exo-tools.js
+++ b/packages/store/src/patterns/exo-tools.js
@@ -119,15 +119,19 @@ const defendMethod = (method, methodGuard, label) => {
  */
 
 /**
- * @template [S = any]
- * @template [T = any]
- * @typedef {{ self: S, state: T }} ClassContext
+ * @typedef {Record<string | symbol, CallableFunction>} Methods
  */
 
 /**
  * @template [S = any]
- * @template {Record<FacetName, any>} [F = any]
- * @typedef {{ self: S, facets: F }} KitContext
+ * @template {Methods} [M = any]
+ * @typedef {{ state: S, self: M }} ClassContext
+ */
+
+/**
+ * @template [S = any]
+ * @template {Record<FacetName, Methods>} [F = any]
+ * @typedef {{ state: S, facets: F }} KitContext
  */
 
 /**

--- a/packages/store/src/patterns/exo-tools.js
+++ b/packages/store/src/patterns/exo-tools.js
@@ -115,11 +115,27 @@ const defendMethod = (method, methodGuard, label) => {
 };
 
 /**
- * @typedef { (representative: any) => any } ContextProvider
+ * @typedef {string} FacetName
  */
 
 /**
- *
+ * @template [S = any]
+ * @template [T = any]
+ * @typedef {{ self: S, state: T }} ClassContext
+ */
+
+/**
+ * @template [S = any]
+ * @template {Record<FacetName, any>} [F = any]
+ * @typedef {{ self: S, facets: F }} KitContext
+ */
+
+/**
+ * @typedef {(facet: any) => KitContext} KitContextProvider
+ * @typedef {((representative: any) => ClassContext) | KitContextProvider} ContextProvider
+ */
+
+/**
  * @param {string} methodTag
  * @param {ContextProvider} contextProvider
  * @param {CallableFunction} behaviorMethod
@@ -244,8 +260,8 @@ harden(defendPrototype);
 
 /**
  * @param {string} tag
- * @param {Record<string, ContextProvider>} contextProviderKit
- * @param {Record<string, Record<string | symbol, CallableFunction>>} behaviorMethodsKit
+ * @param {Record<FacetName, KitContextProvider>} contextProviderKit
+ * @param {Record<FacetName, Record<string | symbol, CallableFunction>>} behaviorMethodsKit
  * @param {boolean} [thisfulMethods]
  * @param {Record<string, InterfaceGuard>} [interfaceGuardKit]
  */


### PR DESCRIPTION
Fixes #7319

## Description

Splits `ContextProvider` and related types into class vs. class-kit flavors as suggested at https://github.com/Agoric/agoric-sdk/pull/7138#discussion_r1149648437 .

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a