### PR TITLE
fix(store,ERTP): collection type param defaults

### DIFF
--- a/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
@@ -10,11 +10,11 @@ import {
 } from '@agoric/store';
 import '../types-ambient.js';
 
-/** @type {CopyBagValue} */
+/** @type {CopyBag} */
 const empty = makeCopyBag([]);
 
 /**
- * @type {MathHelpers<CopyBagValue>}
+ * @type {MathHelpers<CopyBag>}
  */
 export const copyBagMathHelpers = harden({
   doCoerce: bag => {

--- a/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
@@ -10,11 +10,11 @@ import {
 } from '@agoric/store';
 import '../types-ambient.js';
 
-/** @type {CopySetValue} */
+/** @type {CopySet} */
 const empty = makeCopySet([]);
 
 /**
- * @type {CopySetMathHelpers}
+ * @type {MathHelpers<CopySet>}
  */
 export const copySetMathHelpers = harden({
   doCoerce: set => {

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -12,7 +12,7 @@ const empty = 0n;
  *
  * Natural numbers are used for fungible erights such as money because
  * rounding issues make floats problematic. All operations should be
- * done with the smallest whole unit such that the NatMathHelpers never
+ * done with the smallest whole unit such that the `natMathHelpers` never
  * deals with fractional parts.
  *
  * @type {MathHelpers<NatValue>}

--- a/packages/ERTP/src/mathHelpers/setMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/setMathHelpers.js
@@ -16,7 +16,7 @@ const empty = harden([]);
 
 /**
  * @deprecated Replace array-based SetMath with CopySet-based CopySetMath
- * @type {SetMathHelpers}
+ * @type {MathHelpers<SetValue>}
  */
 export const setMathHelpers = harden({
   doCoerce: list => {

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -98,7 +98,7 @@ harden(isNatValue);
  * Returns true if value is a CopySet
  *
  * @param {AmountValue} value
- * @returns {value is CopySetValue}
+ * @returns {value is CopySet}
  */
 export const isCopySetValue = value => matches(value, CopySetValueShape);
 harden(isCopySetValue);
@@ -119,7 +119,7 @@ harden(isSetValue);
  * Returns true if value is a CopyBag
  *
  * @param {AmountValue} value
- * @returns {value is CopyBagValue}
+ * @returns {value is CopyBag}
  */
 export const isCopyBagValue = value => matches(value, CopyBagValueShape);
 harden(isCopyBagValue);

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -17,7 +17,7 @@
  */
 
 /**
- * @typedef {NatValue | SetValue | CopySetValue | CopyBagValue} AmountValue
+ * @typedef {NatValue | SetValue | CopySet | CopyBag} AmountValue
  * An `AmountValue` describes a set or quantity of assets that can be owned or
  * shared.
  *
@@ -30,10 +30,10 @@
  * key in a map (MapStore or CopyMap).
  *
  * `SetValue` is for the deprecated set representation, using an array directly
- * to represent the array of its elements. `CopySetValue` is the proper
+ * to represent the array of its elements. `CopySet` is the proper
  * representation using a CopySet.
  *
- * A semi-fungible `CopyBagValue` is represented as a
+ * A semi-fungible `CopyBag` is represented as a
  * `CopyBag` of `Key` objects. "Bag" is synonymous with MultiSet, where an
  * element of a bag can be present once or more times, i.e., some positive
  * bigint number of times, representing that quantity of the asset represented
@@ -50,8 +50,8 @@
  * @template {AssetKind} K
  * @typedef {K extends 'nat' ? NatValue :
  * K extends 'set' ? SetValue :
- * K extends 'copySet' ? CopySetValue:
- * K extends 'copyBag' ? CopyBagValue :
+ * K extends 'copySet' ? CopySet:
+ * K extends 'copyBag' ? CopyBag :
  * never
  * } AssetValueForKind
  */
@@ -60,8 +60,8 @@
  * @template {AmountValue} V
  * @typedef {V extends NatValue ? 'nat' :
  *  V extends SetValue ? 'set' :
- *  V extends CopySetValue ? 'copySet' :
- *  V extends CopyBagValue ? 'copyBag' :
+ *  V extends CopySet ? 'copySet' :
+ *  V extends CopyBag ? 'copyBag' :
  *  never} AssetKindForValue
  */
 
@@ -434,29 +434,5 @@
  */
 
 /**
- * @typedef {MathHelpers<NatValue>} NatMathHelpers
- */
-
-/**
  * @typedef {Array<Key>} SetValue
- */
-
-/**
- * @typedef {MathHelpers<SetValue>} SetMathHelpers
- */
-
-/**
- * @typedef {CopySet<Key>} CopySetValue
- */
-
-/**
- * @typedef {MathHelpers<CopySetValue>} CopySetMathHelpers
- */
-
-/**
- * @typedef {CopyBag<Key>} CopyBagValue
- */
-
-/**
- * @typedef {MathHelpers<CopyBagValue>} CopyBagMathHelpers
  */

--- a/packages/ERTP/test/unitTests/mathHelpers/test-copyBagMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-copyBagMathHelpers.js
@@ -65,7 +65,7 @@ test('copyBag with strings getValue', t => {
   );
   t.deepEqual(
     getCopyBagEntries(
-      /** @type {CopyBag<Key>} */ (
+      /** @type {CopyBag} */ (
         m.getValue(
           mockBrand,
           harden({ brand: mockBrand, value: makeBag(['1']) }),

--- a/packages/ERTP/test/unitTests/mathHelpers/test-copySetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-copySetMathHelpers.js
@@ -80,7 +80,7 @@ test('copySet with strings getValue', t => {
   );
   t.deepEqual(
     getCopySetKeys(
-      /** @type {CopySet<Key>} */ (
+      /** @type {CopySet} */ (
         m.getValue(
           mockBrand,
           harden({ brand: mockBrand, value: makeCopySet(['1']) }),

--- a/packages/store/src/keys/checkKey.js
+++ b/packages/store/src/keys/checkKey.js
@@ -143,7 +143,7 @@ harden(assertKey);
 // Moved to here so they can check that the copySet contains only keys
 // without creating an import cycle.
 
-/** @type WeakSet<CopySet<Key>> */
+/** @type WeakSet<CopySet> */
 const copySetMemo = new WeakSet();
 
 /**
@@ -170,7 +170,7 @@ harden(checkCopySet);
 /**
  * @callback IsCopySet
  * @param {Passable} s
- * @returns {s is CopySet<Key>}
+ * @returns {s is CopySet}
  */
 
 /** @type {IsCopySet} */
@@ -180,7 +180,7 @@ harden(isCopySet);
 /**
  * @callback AssertCopySet
  * @param {Passable} s
- * @returns {asserts s is CopySet<Key>}
+ * @returns {asserts s is CopySet}
  */
 
 /** @type {AssertCopySet} */
@@ -227,7 +227,7 @@ harden(makeCopySet);
 // Moved to here so they can check that the copyBag contains only keys
 // without creating an import cycle.
 
-/** @type WeakSet<CopyBag<Key>> */
+/** @type WeakSet<CopyBag> */
 const copyBagMemo = new WeakSet();
 
 /**
@@ -254,7 +254,7 @@ harden(checkCopyBag);
 /**
  * @callback IsCopyBag
  * @param {Passable} b
- * @returns {b is CopyBag<Key>}
+ * @returns {b is CopyBag}
  */
 
 /** @type {IsCopyBag} */
@@ -264,7 +264,7 @@ harden(isCopyBag);
 /**
  * @callback AssertCopyBag
  * @param {Passable} b
- * @returns {asserts b is CopyBag<Key>}
+ * @returns {asserts b is CopyBag}
  */
 
 /** @type {AssertCopyBag} */

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -83,7 +83,7 @@
 // TODO parameterize CopyTagged to support these refinements
 
 /**
- * @template {Key} K
+ * @template {Key} [K=Key]
  * @typedef {CopyTagged & {
  *   [Symbol.toStringTag]: 'copySet',
  *   payload: Array<K>,
@@ -94,7 +94,7 @@
  */
 
 /**
- * @template {Key} K
+ * @template {Key} [K=Key]
  * @typedef {CopyTagged & {
  *   [Symbol.toStringTag]: 'copyBag',
  *   payload: Array<[K, bigint]>,
@@ -106,8 +106,8 @@
  */
 
 /**
- * @template {Key} K
- * @template {Passable} V
+ * @template {Key} [K=Key]
+ * @template {Passable} [V=Passable]
  * @typedef {CopyTagged & {
  *   [Symbol.toStringTag]: 'copyMap',
  *   payload: { keys: Array<K>, values: Array<V> },
@@ -168,7 +168,7 @@
  */
 
 /**
- * @template {Key & object} K
+ * @template {Key & object} [K=Key]
  * @typedef {object} WeakSetStore
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
@@ -184,7 +184,7 @@
  */
 
 /**
- * @template {Key} K
+ * @template {Key} [K=Key]
  * @typedef {object} SetStore
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
@@ -205,8 +205,8 @@
  */
 
 /**
- * @template {Key & object} K
- * @template {Passable} V
+ * @template {Key & object} [K=Key]
+ * @template {Passable} [V=Passable]
  * @typedef {object} WeakMapStore
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the
@@ -225,8 +225,8 @@
  */
 
 /**
- * @template {Key} K
- * @template {Passable} V
+ * @template {Key} [K=Key]
+ * @template {Passable} [V=Passable]
  * @typedef {object} MapStore
  * @property {(key: K) => boolean} has
  * Check if a key exists. The key can be any JavaScript value, though the


### PR DESCRIPTION
Enables us to say, for example, `CopyBag` rather than `CopyBag<Key>`. Delete unnecessary names like `CopyBagValue`.

Coordinated with change to endo at https://github.com/endojs/endo/pull/1547

Will help https://github.com/Agoric/agoric-sdk/pull/7352