### PR TITLE
feat(types): parameterize InterfaceGuard

### DIFF
--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -8,7 +8,7 @@ import { prepareExoClass } from '@agoric/vat-data';
  * @param {Baggage} issuerBaggage
  * @param {string} name
  * @param {Brand<K>} brand
- * @param {InterfaceGuard} PaymentI
+ * @param {InterfaceGuard<{ getAllegedBrand: MethodGuard }>} PaymentI
  * @returns {() => Payment<K>}
  */
 export const preparePaymentKind = (issuerBaggage, name, brand, PaymentI) => {

--- a/packages/store/src/patterns/exo-makers.js
+++ b/packages/store/src/patterns/exo-makers.js
@@ -184,7 +184,7 @@ harden(defineExoClassKit);
 /**
  * @template {Methods} T
  * @param {string} tag
- * @param {InterfaceGuard | undefined} interfaceGuard CAVEAT: static typing does not yet support `callWhen` transformation
+ * @param {InterfaceGuard<{ [M in keyof T]: MethodGuard }> | undefined} interfaceGuard CAVEAT: static typing does not yet support `callWhen` transformation
  * @param {T} methods
  * @param {FarClassOptions<ClassContext<{},T>>} [options]
  * @returns {T & import('@endo/eventual-send').RemotableBrand<{}, T>}

--- a/packages/store/src/patterns/exo-tools.js
+++ b/packages/store/src/patterns/exo-tools.js
@@ -208,7 +208,7 @@ const bindMethod = (
  * @param {ContextProvider} contextProvider
  * @param {T} behaviorMethods
  * @param {boolean} [thisfulMethods]
- * @param {InterfaceGuard} [interfaceGuard]
+ * @param {InterfaceGuard<{ [M in keyof T]: MethodGuard }>} [interfaceGuard]
  * @returns {T & import('@endo/eventual-send').RemotableBrand<{}, T>}
  */
 export const defendPrototype = (

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -1547,7 +1547,7 @@ const makePatternKit = () => {
       },
       returns: (returnGuard = UndefinedShape) =>
         harden({
-          klass: 'methodGuard',
+          klass: /** @type {const} */ ('methodGuard'),
           callKind,
           argGuards,
           optionalArgGuards,
@@ -1558,7 +1558,7 @@ const makePatternKit = () => {
 
   const makeAwaitArgGuard = argGuard =>
     harden({
-      klass: 'awaitArg',
+      klass: /** @type {const} */ ('awaitArg'),
       argGuard,
     });
 
@@ -1656,7 +1656,7 @@ const makePatternKit = () => {
           Fail`unrecognize method guard ${methodGuard}`;
       }
       return harden({
-        klass: 'Interface',
+        klass: /** @type {const} */ ('Interface'),
         interfaceName,
         methodGuards,
         sloppy,

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -722,11 +722,19 @@
  */
 
 /**
- * @typedef {object} GuardMakers
- * @property {<M extends Record<any, any>>(interfaceName: string,
+ * @typedef {{
+ * <M extends Record<any, MethodGuard>>(interfaceName: string,
  *             methodGuards: M,
- *             options?: {sloppy?: boolean}
- * ) => InterfaceGuard} interface Guard an interface to a far object or facet
+ *             options?: {sloppy?: false}): InterfaceGuard<M>;
+ * (interfaceName: string,
+ *             methodGuards: any,
+ *             options?: {sloppy?: true}): InterfaceGuard<any>;
+ * }} MakeInterfaceGuard
+ */
+
+/**
+ * @typedef {object} GuardMakers
+ * @property {MakeInterfaceGuard} interface Guard an interface to a far object or facet
  *
  * @property {(...argGuards: ArgGuard[]) => MethodGuardMaker} call Guard a synchronous call
  *
@@ -741,12 +749,12 @@
 
 /** @typedef {(...args: any[]) => any} Method */
 
-// TODO parameterize this to match the behavior object it guards
 /**
+ * @template {Record<any, MethodGuard>} [M=Record<any, MethodGuard>]
  * @typedef {{
  * klass: 'Interface',
  * interfaceName: string,
- * methodGuards: Record<string | symbol, MethodGuard>
+ * methodGuards: M
  * sloppy?: boolean
  * }} InterfaceGuard
  */

--- a/packages/store/test/test-heap-classes.js
+++ b/packages/store/test/test-heap-classes.js
@@ -151,6 +151,7 @@ test('sloppy option', t => {
     () =>
       makeExo(
         'greeter',
+        // @ts-expect-error missing guard
         M.interface('greeter', emptyBehavior, { sloppy: false }),
         {
           sayHello() {
@@ -200,19 +201,56 @@ test.skip('types', () => {
   // @ts-expect-error not defined
   unguarded.notInBehavior;
 
-  // TODO when there is an interface, error if a method is missing from it
   const guarded = makeExo('upCounter', UpCounterI, {
     /** @param {number} val */
     incr(val) {
       return val;
     },
-    notInInterface() {
-      return 0;
-    },
   });
   // @ts-expect-error invalid args
   guarded.incr();
-  guarded.notInInterface();
   // @ts-expect-error not defined
   guarded.notInBehavior;
+
+  makeExo(
+    'upCounter',
+    // @ts-expect-error Property 'notInInterface' is missing from UpCounterI
+    UpCounterI,
+    {
+      /** @param {number} val */
+      incr(val) {
+        return val;
+      },
+      notInInterface() {
+        return 0;
+      },
+    },
+  );
+
+  const sloppy = makeExo(
+    'upCounter',
+    M.interface(
+      'UpCounter',
+      {
+        incr: M.call().optional(M.number()).returns(M.number()),
+      },
+      { sloppy: true },
+    ),
+    {
+      /** @param {number} val */
+      incr(val) {
+        return val;
+      },
+      notInInterface() {
+        return 0;
+      },
+    },
+  );
+  sloppy.incr(1);
+  // @ts-expect-error invalid args
+  sloppy.incr();
+  // allowed because sloppy:true
+  sloppy.notInInterface() === 0;
+  // @ts-expect-error TS infers it's literally 0
+  sloppy.notInInterface() === 1;
 });


### PR DESCRIPTION
refs: #6206

## Description

Some work for https://github.com/Agoric/agoric-sdk/pull/7350 that I didn't end up needing there.

More comprehensive typing. Immediate benefit is getting static errors for mismatch between interface guards and behavior methods.

### Security Considerations

n/a
### Scaling Considerations

n/a
### Documentation Considerations

n/a
### Testing Considerations

Some new tests