### PR TITLE
chore: install devnet `oracleAddresses`

### DIFF
--- a/packages/vats/decentral-devnet-config.json
+++ b/packages/vats/decentral-devnet-config.json
@@ -115,8 +115,11 @@
         {
           "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
           "oracleAddresses": [
-            "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
-            "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang"
+            "agoric10vjkvkmpp9e356xeh6qqlhrny2htyzp8hf88fk",
+            "agoric1chxpyq88g9vhv7lkje3ap8yexajmwkq66fyfhq",
+            "agoric1lw4e4aas9q84tq0q92j85rwjjjapf8dmnllnft",
+            "agoric1ra0g6crtsy6r3qnpu7ruvm7qd4wjnznyzg5nu4",
+            "agoric1zj6vrrrjq4gsyr9lw7dplv4vyejg3p8j2urm82"
           ],
           "IN_BRAND_LOOKUP": [
             "agoricNames",

--- a/packages/vats/decentral-devnet-config.json
+++ b/packages/vats/decentral-devnet-config.json
@@ -1,25 +1,42 @@
 {
-  "$comment": "This SwingSet config file (see loadSwingsetConfigFile) includes non-production facilities such as a faucet. It does not include vaults in coreProposals; vaults are expected to be added by devnet governance.",
+  "$comment": "This SwingSet config file (see loadSwingsetConfigFile) includes non-production facilities such as a faucet. Pending #5819, it includes vaults in coreProposals; once #5819 is done, vaults are expected to be added by devnet governance.",
   "bootstrap": "bootstrap",
   "defaultReapInterval": 1000,
-  "snapshotInterval": 1000,
   "coreProposals": [
     "@agoric/vats/scripts/init-core.js",
     {
       "module": "@agoric/inter-protocol/scripts/init-core.js",
-      "entrypoint": "committeeProposalBuilder",
+      "entrypoint": "defaultProposalBuilder",
       "args": [
         {
           "econCommitteeOptions": {
             "committeeSize": 3
-          }
+          },
+          "endorsedUi": "bafybeidvpbtlgefi3ptuqzr2fwfyfjqfj6onmye63ij7qkrb4yjxekdh3e",
+          "minInitialPoolLiquidity": "0"
         }
       ]
-    },  
+    },
     {
       "module": "@agoric/inter-protocol/scripts/add-collateral-core.js",
       "entrypoint": "psmGovernanceBuilder",
       "args": []
+    },
+    {
+      "module": "@agoric/inter-protocol/scripts/add-collateral-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "interchainAssetOptions": {
+            "denom": "ibc/toyatom",
+            "decimalPlaces": 6,
+            "initialPrice": 12.34,
+            "keyword": "IbcATOM",
+            "oracleBrand": "ATOM",
+            "proposedName": "ATOM"
+          }
+        }
+      ]
     },
     {
       "module": "@agoric/inter-protocol/scripts/add-collateral-core.js",
@@ -92,6 +109,31 @@
       ]
     },
     {
+      "module": "@agoric/inter-protocol/scripts/price-feed-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
+          "oracleAddresses": [
+            "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
+            "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang"
+          ],
+          "IN_BRAND_LOOKUP": [
+            "agoricNames",
+            "oracleBrand",
+            "ATOM"
+          ],
+          "IN_BRAND_DECIMALS": 6,
+          "OUT_BRAND_LOOKUP": [
+            "agoricNames",
+            "oracleBrand",
+            "USD"
+          ],
+          "OUT_BRAND_DECIMALS": 4
+        }
+      ]
+    },
+    {
       "module": "@agoric/inter-protocol/scripts/invite-committee-core.js",
       "entrypoint": "defaultProposalBuilder",
       "args": [
@@ -104,7 +146,7 @@
         }
       ]
     }
-  ],  
+  ],
   "vats": {
     "bootstrap": {
       "sourceSpec": "@agoric/vats/src/core/boot-chain.js",
@@ -117,8 +159,17 @@
     "bank": {
       "sourceSpec": "@agoric/vats/src/vat-bank.js"
     },
+    "board": {
+      "sourceSpec": "@agoric/vats/src/vat-board.js"
+    },
+    "bridge": {
+      "sourceSpec": "@agoric/vats/src/vat-bridge.js"
+    },
     "centralSupply": {
       "sourceSpec": "@agoric/vats/src/centralSupply.js"
+    },
+    "ibc": {
+      "sourceSpec": "@agoric/vats/src/vat-ibc.js"
     },
     "mintHolder": {
       "sourceSpec": "@agoric/vats/src/mintHolder.js"
@@ -126,23 +177,20 @@
     "mints": {
       "sourceSpec": "@agoric/vats/src/vat-mints.js"
     },
-    "board": {
-      "sourceSpec": "@agoric/vats/src/vat-board.js"
-    },
-    "ibc": {
-      "sourceSpec": "@agoric/vats/src/vat-ibc.js"
-    },
     "network": {
       "sourceSpec": "@agoric/vats/src/vat-network.js"
     },
     "priceAuthority": {
       "sourceSpec": "@agoric/vats/src/vat-priceAuthority.js"
     },
+    "provisionPool": {
+      "sourceSpec": "@agoric/vats/src/provisionPool.js"
+    },
     "provisioning": {
       "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
     },
-    "bridge": {
-      "sourceSpec": "@agoric/vats/src/vat-bridge.js"
+    "walletFactory": {
+      "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
     },
     "zcf": {
       "sourceSpec": "@agoric/zoe/contractFacet.js"

--- a/packages/vats/decentral-test-vaults-config.json
+++ b/packages/vats/decentral-test-vaults-config.json
@@ -156,15 +156,6 @@
     }
   },
   "bundles": {
-    "centralSupply": {
-      "sourceSpec": "@agoric/vats/src/centralSupply.js"
-    },
-    "mintHolder": {
-      "sourceSpec": "@agoric/vats/src/mintHolder.js"
-    },
-    "zcf": {
-      "sourceSpec": "@agoric/zoe/contractFacet.js"
-    },
     "bank": {
       "sourceSpec": "@agoric/vats/src/vat-bank.js"
     },
@@ -174,8 +165,14 @@
     "bridge": {
       "sourceSpec": "@agoric/vats/src/vat-bridge.js"
     },
+    "centralSupply": {
+      "sourceSpec": "@agoric/vats/src/centralSupply.js"
+    },
     "ibc": {
       "sourceSpec": "@agoric/vats/src/vat-ibc.js"
+    },
+    "mintHolder": {
+      "sourceSpec": "@agoric/vats/src/mintHolder.js"
     },
     "network": {
       "sourceSpec": "@agoric/vats/src/vat-network.js"
@@ -191,6 +188,9 @@
     },
     "walletFactory": {
       "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
+    },
+    "zcf": {
+      "sourceSpec": "@agoric/zoe/contractFacet.js"
     },
     "zoe": {
       "sourceSpec": "@agoric/vats/src/vat-zoe.js"


### PR DESCRIPTION
refs:
 - #5819
 - #6950

## Description

 1. revert devnet config so that vaults etc. start at bootstrap rather than separate governance decision (a regression w.r.t #5819)
 2. install devnet `oracleAddresses` from https://github.com/Agoric/agoric-sdk/issues/6950#issuecomment-1500748917

### Security Considerations

The usual key management considerations around addresses apply.

### Scaling, Documentation Considerations

none, AFAICT.

### Testing Considerations

devnet is a testing platform
