### PR TITLE
terminate bootstrap vat on startup failure

### DIFF
--- a/packages/vats/src/core/boot-chain.js
+++ b/packages/vats/src/core/boot-chain.js
@@ -23,7 +23,7 @@ export const MANIFEST = CHAIN_BOOTSTRAP_MANIFEST;
 /**
  * Build root object of the bootstrap vat.
  *
- * @param {{
+ * @param {VatPowers & {
  *   D: DProxy,
  *   logger: (msg) => void,
  * }} vatPowers

--- a/packages/vats/src/core/boot-sim.js
+++ b/packages/vats/src/core/boot-sim.js
@@ -26,7 +26,7 @@ const modules = harden({ behaviors: { ...behaviors }, utils: { ...utils } });
 /**
  * Build root object of the bootstrap vat for the simulated chain.
  *
- * @param {{
+ * @param {VatPowers & {
  *   D: DProxy,
  *   logger: (msg) => void,
  * }} vatPowers

--- a/packages/vats/src/core/boot-solo.js
+++ b/packages/vats/src/core/boot-solo.js
@@ -30,7 +30,7 @@ const modules = harden({
 /**
  * Build root object of the bootstrap vat.
  *
- * @param {{
+ * @param {VatPowers & {
  *   D: DProxy,
  *   logger: (msg) => void,
  * }} vatPowers

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -134,7 +134,13 @@ test('evaluateBundleCap is available to core eval', async (/** @type {ECtx} */ t
 });
 
 test('bootstrap provides a way to pass items to CORE_EVAL', async t => {
-  const root = buildRootObject({ D: mockDProxy, logger: t.log }, {});
+  const root = buildRootObject(
+    /** @type {VatPowers} */ /** @type {any} */ ({
+      D: mockDProxy,
+      logger: t.log,
+    }),
+    {},
+  );
 
   await E(root).produceItem('swissArmyKnife', [1, 2, 3]);
   t.deepEqual(await E(root).consumeItem('swissArmyKnife'), [1, 2, 3]);


### PR DESCRIPTION
## Description

While debugging a bootstrap manifest problem, we didn't notice the error,
```
Nested error under Error#1
Error#1: consume not permitted, only [ 'produce' ]
  at Object.get (.../vats/src/core/utils.js:144:6)
  at Proxy.startAuctioneer (.../inter-protocol/src/proposals/econ-behaviors.js:503:10)
  at eval (.../vats/src/core/utils.js:197:17)
  at async Promise.all (index 2)

Error#1 ERROR_NOTE: Rejection from: (Error#2) : 477 . 0
  Error#2: Event: 476.1
    at Proxy.fromBridge (.../eventual-send/src/E.js:60:23)
    at rawBootstrap (.../vats/src/core/lib-boot.js:128:32)

BOOTSTRAP FAILED: (Error#1)
UnhandledPromiseRejectionWarning: (Error#1)
```
Because it was followed by 330 additional lines, and the test error gave no clue:
```
  ✘ [fail]: before hook Rejected promise returned by test
    ℹ runMethod messageVat [
        {
          args: [
            'vaultFactoryKit',
          ],
          methodName: 'consumeItem',
          name: 'bootstrap',
        },
      ] at 0
    ℹ kernel ran 2 cranks
  ✘ 7 tests remaining in test/bootstrapTests/test-vaults-integration.js
  ─

  before hook
  Rejected promise returned by test. Reason:

  Error {
    message: 'unresolved for method messageVat',
  }

  › getResult (packages/vats/test/bootstrapTests/supports.js:87:17)
  › packages/vats/test/bootstrapTests/supports.js:96:14
```

The problem was that the bootstrap vat was "throwing an error" in a promise handler so it was merely rejecting the promise, which was ignored.

This makes bootstrap failure terminate the vat.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

It's not clear to me how to have an automated test for this so I tested manually by adding this claim in `startAuctioneer` without a corresponding manifest permission,
```
consume: { reserve: reserveInstance },
```


*Before*
(as in description)

*After*
Terminal window clearly shows error without scrolling:
```
Nested error under Error#1
Error#1: consume not permitted, only [ 'produce' ]
  at Object.get (.../vats/src/core/utils.js:164:6)
  at Proxy.startAuctioneer (.../inter-protocol/src/proposals/econ-behaviors.js:503:10)
  at eval (.../vats/src/core/utils.js:217:17)
  at async Promise.all (index 2)

Error#1 ERROR_NOTE: Rejection from: (Error#2) : 477 . 0
  Error#2: Event: 476.1
    at Proxy.fromBridge (.../eventual-send/src/E.js:60:23)
    at rawBootstrap (.../vats/src/core/lib-boot.js:129:32)

Error#1 ERROR_NOTE: Sent as error:liveSlots:v1#70001
Logging sent error stack (Error#1)
UnhandledPromiseRejectionWarning: (Error#1)
  ✘ [fail]: before hook Rejected promise returned by test
    ℹ runMethod messageVat [
        {
          args: [
            'vaultFactoryKit',
          ],
          methodName: 'consumeItem',
          name: 'bootstrap',
        },
      ] at 0
##### KERNEL PANIC: critical vat v1 failed #####
  ✘ 7 tests remaining in test/bootstrapTests/test-vaults-integration.js
  ─

  before hook
  Rejected promise returned by test. Reason:

  Error {
    message: 'vat name "bootstrap" must exist, but doesn\'t',
  }

  › Object.getVatIDForName (.../swingset-vat/src/kernel/state/kernelKeeper.js:1072:22)
  › Object.vatNameToID (.../swingset-vat/src/kernel/kernel.js:197:26)
  › Object.queueToVatRoot (packages/SwingSet/src/controller/controller.js:373:28)
  › runMethod (packages/vats/test/bootstrapTests/supports.js:77:29)
  › async makeDefaultTestContext (packages/vats/test/bootstrapTests/test-vaults-integration.js:44:3)
  › async packages/vats/test/bootstrapTests/test-vaults-integration.js:67:15
```
