### PR TITLE
rebalance CI

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -105,12 +105,8 @@ jobs:
       #  run: yarn ${{ steps.vars.outputs.test }}
       - name: yarn test (access-token)
         run: cd packages/access-token && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
-      - name: yarn test (agoric-cli)
-        run: cd packages/agoric-cli && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (assert)
         run: cd packages/assert && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
-      - name: yarn test (wallet/api)
-        run: cd packages/wallet/api && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (deployment)
         run: cd packages/deployment && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (ERTP)
@@ -125,8 +121,6 @@ jobs:
         run: cd packages/same-structure && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (sharing-service)
         run: cd packages/sharing-service && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
-      - name: yarn test (smart-wallet)
-        run: cd packages/smart-wallet && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (sparse-ints)
         run: cd packages/sparse-ints && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (spawner)
@@ -169,6 +163,8 @@ jobs:
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
       # END-TEST-BOILERPLATE
+      - name: yarn test (agoric-cli)
+        run: cd packages/agoric-cli && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (cosmos)
         run: cd golang/cosmos && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (cache)
@@ -179,6 +175,8 @@ jobs:
         run: cd packages/internal && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (pegasus)
         run: cd packages/pegasus && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
+      - name: yarn test (smart-wallet)
+        run: cd packages/smart-wallet && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (swingset-runner)
         run: cd packages/swingset-runner && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (telemetry)
@@ -189,6 +187,8 @@ jobs:
         run: cd packages/ui-components && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (wallet)
         run: cd packages/wallet && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
+      - name: yarn test (wallet/api)
+        run: cd packages/wallet/api && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (eslint-config)
         run: cd packages/eslint-config && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (vat-data)

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -221,7 +221,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['16.x', '18.x', 'xs']
+        # test:xs is noop in solo/package.json
+        engine: ['16.x', '18.x']
     steps:
       - name: set vars
         id: vars
@@ -250,6 +251,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # test:xs is noop in cosmic-swingset/package.json
         engine: ['16.x', '18.x', 'xs']
     steps:
       - name: set vars
@@ -282,7 +284,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        engine: ['16.x', '18.x', 'xs']
+        # test:xs is noop in inter-protocol/package.json
+        engine: ['16.x', '18.x']
     steps:
       - name: set vars
         id: vars

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -177,12 +177,8 @@ jobs:
         run: cd packages/casting && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (internal)
         run: cd packages/internal && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
-      - name: yarn test (inter-protocol)
-        run: cd packages/inter-protocol && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (pegasus)
         run: cd packages/pegasus && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
-      - name: yarn test (vats)
-        run: cd packages/vats && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (swingset-runner)
         run: cd packages/swingset-runner && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (telemetry)
@@ -273,6 +269,64 @@ jobs:
           go-version: 1.18
       - name: yarn test (cosmic-swingset)
         run: cd packages/cosmic-swingset && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
+      - uses: ./.github/actions/post-test
+        if: (success() || failure())
+        with:
+          datadog-token: ${{ secrets.DATADOG_API_KEY }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-inter-protocol:
+    # BEGIN-TEST-BOILERPLATE
+    timeout-minutes: 30
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        engine: ['16.x', '18.x', 'xs']
+    steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo "node-version=${{ matrix.engine == 'xs' && '18.x' || matrix.engine }}" >> $GITHUB_OUTPUT
+          echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
+          echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/restore-node
+        with:
+          node-version: ${{ steps.vars.outputs.node-version }}
+      # END-TEST-BOILERPLATE
+      - name: yarn test (inter-protocol)
+        run: cd packages/inter-protocol && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
+      - uses: ./.github/actions/post-test
+        if: (success() || failure())
+        with:
+          datadog-token: ${{ secrets.DATADOG_API_KEY }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-vats:
+    # BEGIN-TEST-BOILERPLATE
+    timeout-minutes: 30
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        engine: ['16.x', '18.x', 'xs']
+    steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo "node-version=${{ matrix.engine == 'xs' && '18.x' || matrix.engine }}" >> $GITHUB_OUTPUT
+          echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
+          echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/restore-node
+        with:
+          node-version: ${{ steps.vars.outputs.node-version }}
+      # END-TEST-BOILERPLATE
+      - name: yarn test (vats)
+        run: cd packages/vats && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - uses: ./.github/actions/post-test
         if: (success() || failure())
         with:


### PR DESCRIPTION
## Description

The CI refactoring in https://github.com/Agoric/agoric-sdk/pull/7391/ resulted in test-quick2 being much faster than the rest:
<img width="567" alt="Screenshot 2023-04-12 at 8 39 01 AM" src="https://user-images.githubusercontent.com/21505/231509439-b74210c0-0441-4e22-aa3e-d14287bd7384.png">

test-quick is slower than average so this rebalances them.

I also noticed we're running `test:xs` unnecessarily on some packages so this drops those.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
