### PR TITLE
refactor(cosmic-swingset): remove notifier from bundle publish

### DIFF
--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -27,7 +27,6 @@
     "@agoric/deploy-script-support": "^0.9.4",
     "@agoric/internal": "^0.2.1",
     "@endo/nat": "^4.1.0",
-    "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swing-store": "^0.8.1",
     "@agoric/swingset-vat": "^0.30.2",

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -17,9 +17,11 @@ import {
 import { Fail } from '@agoric/assert';
 import { makeSlogSender, tryFlushSlogSender } from '@agoric/telemetry';
 
-import { makeChainStorageRoot } from '@agoric/internal/src/lib-chainStorage.js';
+import {
+  makeChainStorageRoot,
+  makeSerializeToStorage,
+} from '@agoric/internal/src/lib-chainStorage.js';
 import { makeMarshal } from '@endo/marshal';
-import { makePublishKit, pipeTopicToStorage } from '@agoric/notifier';
 
 import * as STORAGE_PATH from '@agoric/internal/src/chain-storage-paths.js';
 import { BridgeId as BRIDGE_ID } from '@agoric/internal';
@@ -279,8 +281,11 @@ export default async function main(progname, args, { env, homedir, agcc }) {
         { sequence: true },
       );
       const marshaller = makeMarshal();
-      const { publisher, subscriber } = makePublishKit();
-      pipeTopicToStorage(subscriber, installationStorageNode, marshaller);
+      const publish = makeSerializeToStorage(
+        installationStorageNode,
+        marshaller,
+      );
+      const publisher = harden({ publish });
       return publisher;
     };
 

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -261,7 +261,7 @@ export async function launch({
     },
   );
 
-  /** @type {PublishKit<unknown>['publisher'] | undefined} */
+  /** @type {{publish: (value: unknown) => Promise<void>} | undefined} */
   let installationPublisher;
 
   // Artificially create load if set.
@@ -349,15 +349,17 @@ export async function launch({
 
     const { endoZipBase64Sha512 } = bundle;
 
-    if (installationPublisher !== undefined) {
-      installationPublisher.publish(
-        harden({
-          endoZipBase64Sha512,
-          installed: error === null,
-          error,
-        }),
-      );
+    if (installationPublisher === undefined) {
+      return;
     }
+
+    await installationPublisher.publish(
+      harden({
+        endoZipBase64Sha512,
+        installed: error === null,
+        error,
+      }),
+    );
   }
 
   function provideInstallationPublisher() {


### PR DESCRIPTION
refs: #7300 
refs: https://github.com/Agoric/agoric-sdk/pull/7389#discussion_r1163489395

## Description

Remove the whole notifier abstraction for published bundle since we only ever piped to vstorage anyway.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

This path is exercised and required by the loadgen.