### PR TITLE
feat(notifier): subscribeEach/subscribeLatest iterators retry when broken by vat upgrade

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1,6 +1,7 @@
 import { assert, Fail } from '@agoric/assert';
 import { isNat } from '@endo/nat';
 import { importBundle } from '@endo/import-bundle';
+import { makeUpgradeDisconnection } from '@agoric/internal/src/upgrade-api.js';
 import { assertKnownOptions } from '../lib/assertOptions.js';
 import { foreverPolicy } from '../lib/runPolicies.js';
 import { kser, kslot, makeError } from '../lib/kmarshal.js';
@@ -815,12 +816,11 @@ export default function buildKernel(
     const { meterID } = vatInfo;
     let computrons;
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
-    const disconnectObject = {
-      name: 'vatUpgraded',
+    const disconnectionObject = makeUpgradeDisconnection(
       upgradeMessage,
-      incarnationNumber: vatKeeper.getIncarnationNumber(),
-    };
-    const disconnectionCapData = kser(disconnectObject);
+      vatKeeper.getIncarnationNumber(),
+    );
+    const disconnectionCapData = kser(disconnectionObject);
 
     /**
      * Terminate the vat and translate internal-delivery results into

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -65,7 +65,7 @@ export {};
  * @typedef { import('@agoric/swingset-liveslots').Message } Message
  *
  * @typedef { 'none' | 'ignore' | 'logAlways' | 'logFailure' | 'panic' } ResolutionPolicy
- * @typedef {{ name: string, upgradeMessage: string, incarnationNumber: number }} DisconnectObject
+ * @typedef {import('@agoric/internal/src/upgrade-api.js').DisconnectionObject} DisconnectionObject
  *
  * @typedef { import('@agoric/swingset-liveslots').VatDeliveryObject } VatDeliveryObject
  * @typedef { import('@agoric/swingset-liveslots').VatDeliveryResult } VatDeliveryResult

--- a/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
+++ b/packages/inter-protocol/test/stakeFactory/test-stakeFactory.js
@@ -560,7 +560,7 @@ const makeWorld = async t => {
   const attPurse = E(attIssuer).makeEmptyPurse();
   const runPurse = E(runIssuer).makeEmptyPurse();
   const rewardPurse = E(runIssuer).makeEmptyPurse();
-  const epsilon = AmountMath.make(runBrand, micro.unit / 5n);
+  const epsilon = AmountMath.make(runBrand, micro.unit / 4n);
 
   await E(rewardPurse).deposit(
     await mintRunPayment(500n * micro.unit, {

--- a/packages/internal/src/upgrade-api.js
+++ b/packages/internal/src/upgrade-api.js
@@ -1,0 +1,41 @@
+// @ts-check
+// @jessie-check
+import { isObject } from '@endo/marshal';
+
+/**
+ * @typedef {{ name: string, upgradeMessage: string, incarnationNumber: number }} DisconnectionObject
+ */
+
+/**
+ * Makes an Error-like object for use as the rejection value of promises
+ * abandoned by upgrade.
+ *
+ * @param {string} upgradeMessage
+ * @param {number} toIncarnationNumber
+ * @returns {DisconnectionObject}
+ */
+export const makeUpgradeDisconnection = (upgradeMessage, toIncarnationNumber) =>
+  harden({
+    name: 'vatUpgraded',
+    upgradeMessage,
+    incarnationNumber: toIncarnationNumber,
+  });
+harden(makeUpgradeDisconnection);
+
+// TODO: Simplify once we have @endo/patterns (or just export the shape).
+// const upgradeDisconnectionShape = harden({
+//   name: 'vatUpgraded',
+//   upgradeMessage: M.string(),
+//   incarnationNumber: M.number(),
+// });
+// const isUpgradeDisconnection = err => matches(err, upgradeDisconnectionShape);
+/**
+ * @param {any} err
+ * @returns {err is DisconnectionObject}
+ */
+export const isUpgradeDisconnection = err =>
+  isObject(err) &&
+  err.name === 'vatUpgraded' &&
+  typeof err.upgradeMessage === 'string' &&
+  typeof err.incarnationNumber === 'number';
+harden(isUpgradeDisconnection);

--- a/packages/internal/test/test-upgrade-api.js
+++ b/packages/internal/test/test-upgrade-api.js
@@ -1,0 +1,21 @@
+// @ts-check
+import '@endo/init';
+import test from 'ava';
+import {
+  makeUpgradeDisconnection,
+  isUpgradeDisconnection,
+} from '../src/upgrade-api.js';
+
+test('isUpgradeDisconnection must recognize disconnection objects', t => {
+  const disconnection = makeUpgradeDisconnection('vat upgraded', 2);
+  t.true(isUpgradeDisconnection(disconnection));
+});
+
+test('isUpgradeDisconnection must recognize original-format disconnection objects', t => {
+  const disconnection = harden({
+    name: 'vatUpgraded',
+    upgradeMessage: 'vat upgraded',
+    incarnationNumber: 2,
+  });
+  t.true(isUpgradeDisconnection(disconnection));
+});

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -41,6 +41,7 @@
     "@agoric/vat-data": "^0.4.3",
     "@endo/far": "^0.2.18",
     "@endo/marshal": "^0.8.5",
+    "@endo/nat": "^4.1.27",
     "@endo/promise-kit": "^0.2.56"
   },
   "devDependencies": {

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -41,7 +41,6 @@
     "@agoric/vat-data": "^0.4.3",
     "@endo/far": "^0.2.18",
     "@endo/marshal": "^0.8.5",
-    "@endo/nat": "^4.1.27",
     "@endo/promise-kit": "^0.2.56"
   },
   "devDependencies": {

--- a/packages/notifier/src/subscribe.js
+++ b/packages/notifier/src/subscribe.js
@@ -114,10 +114,10 @@ const makeEachIterator = (topic, nextCellP) => {
       // with an eager consumer that doesn't wait for results to settle.
       nextCellP = reconnectAsNeeded(getSuccessor, [tailP]);
 
-      // We expect the tail to be the "cannot read past end" error at the end
-      // of the happy path.
-      // Since we are wrapping that error with eventual send, we sink the
-      // rejections here too to avoid invalid unhandled rejection issues later.
+      // Avoid unhandled rejection warnings here if the previous cell was rejected or
+      // there is no further request of this iterator.
+      // `tailP` is handled inside `reconnectAsNeeded` and `resultP` is the caller's
+      // concern, leaving only `publishCountP` and the new `nextCellP`.
       void E.when(publishCountP, sink, sink);
       void E.when(nextCellP, sink, sink);
       return resultP;

--- a/packages/notifier/src/subscribe.js
+++ b/packages/notifier/src/subscribe.js
@@ -117,8 +117,8 @@ const makeEachIterator = (topic, nextCellP) => {
       // We expect the tail to be the "cannot read past end" error at the end
       // of the happy path.
       // Since we are wrapping that error with eventual send, we sink the
-      // rejection here too so it doesn't become an invalid unhandled rejection
-      // later.
+      // rejections here too to avoid invalid unhandled rejection issues later.
+      void E.when(publishCountP, sink, sink);
       void E.when(nextCellP, sink, sink);
       return resultP;
     },

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -60,7 +60,8 @@ export {};
  * outside the current package should consider it opaque, not depending on its
  * internal structure.
  * @property {IteratorResult<T>} head
- * @property {bigint} publishCount
+ * @property {bigint} publishCount starts at 1 for the first result
+ *   and advances by 1 for each subsequent result
  * @property {Promise<PublicationRecord<T>>} tail
  */
 
@@ -105,13 +106,14 @@ export {};
 /**
  * @template T
  * @typedef {object} Publisher
- * A valid sequence of calls to the methods of an `IterationObserver`
+ * A valid sequence of calls to the methods of a Publisher
  * represents an iteration. A valid sequence consists of any number of calls
- * to `publish` with the successive non-final values, followed by a
+ * to `publish` with the successive non-final values, optionally followed by a
  * final call to either `finish` with a successful `completion` value
  * or `fail` with the alleged `reason` for failure. After at most one
- * terminating calls, no further calls to these methods are valid and must be
- * rejected.
+ * terminating call, further calls to any of these methods are invalid and
+ * must be rejected.
+ *
  * @property {(nonFinalValue: T) => void} publish
  * @property {(completion: T) => void} finish
  * @property {(reason: any) => void} fail

--- a/packages/notifier/test/test-subscriber-examples.js
+++ b/packages/notifier/test/test-subscriber-examples.js
@@ -115,17 +115,15 @@ test('subscription observeIteration on generic representative', async t => {
 test('subscribe to subscriptionIterator success example', async t => {
   const { publication, subscription } = makeSubscriptionKit();
   paula(publication);
-  const log = await carol(subscription);
+  const [log1, log2] = await carol(subscription);
 
-  t.deepEqual(log, [
-    [
-      ['non-final', 'a'],
-      ['non-final', 'b'],
-      ['finished', 'done'],
-    ],
-    [
-      ['non-final', 'b'],
-      ['finished', 'done'],
-    ],
+  t.deepEqual(log1, [
+    ['non-final', 'a'],
+    ['non-final', 'b'],
+    ['finished', 'done'],
+  ]);
+  t.deepEqual(log2, [
+    ['non-final', 'b'],
+    ['finished', 'done'],
   ]);
 });

--- a/packages/notifier/test/vat-integration/vat-pubsub.js
+++ b/packages/notifier/test/vat-integration/vat-pubsub.js
@@ -1,6 +1,10 @@
 import { Far } from '@endo/marshal';
 import { provide } from '@agoric/vat-data';
-import { prepareDurablePublishKit } from '../../src/index.js';
+import {
+  prepareDurablePublishKit,
+  subscribeEach,
+  subscribeLatest,
+} from '../../src/index.js';
 
 export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
   const makeDurablePublishKit = prepareDurablePublishKit(
@@ -19,6 +23,8 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
     getVersion: () => version,
     getParameters: () => vatParameters,
     getSubscriber: () => subscriber,
+    subscribeEach: topic => subscribeEach(topic),
+    subscribeLatest: topic => subscribeLatest(topic),
     makeDurablePublishKit: (...args) => makeDurablePublishKit(...args),
     publish: value => publisher.publish(value),
     finish: finalValue => publisher.finish(finalValue),


### PR DESCRIPTION
Fixes #5185

## Description

"latest" iterators look for rejections that indicate failure due to vat upgrade, and upon encountering them retry the `getUpdateSince` call—if the source is durable, the retry will succeed and provide the next iteration result. If the source is _not_ durable, the retry will go splat and the error associated with that will be propagated in place of the vatUpgraded rejection (which is perhaps unfortunate, but seems to be the only way of guaranteeing that a real `fail` result with unfortunate timing is not replaced by a vatUpgraded rejection).

"each" iterators behave similarly, but additionally fail if multiple values are published before they can successfully reconnect because they cannot tolerate gaps in the sequence.

### Security Considerations

A malicious source can fake vatUpgraded rejections, which the "latest" iterators will dutifully accept and respond to by retrying as long as `incarnationNumber` indicates forward progress. Something like this is necessary to handle the edge case where a _second_ upgrade occurs in between the consumer receiving a rejection and the producer receiving the retry, but we could put in a retry count limit if this is perceived as an actual risk.

### Scaling Considerations

I don't think this affects scaling.

### Documentation Considerations

These relatively fine implementation details are covered by JSDoc comments.

### Testing Considerations

The rapid-upgrade edge case is not covered by testing, but I consider that acceptable. If reviewers disagree, I think I can add a new file with manually-constructed mock producers.