### PR TITLE
fix(vats): repl tolerates toStringTag override

### DIFF
--- a/packages/vats/src/repl.js
+++ b/packages/vats/src/repl.js
@@ -66,8 +66,7 @@ function dump0(value, spaces, inProgress, depth) {
 
     const singleSep = spaces ? ' ' : '';
 
-    const proto = Object.getPrototypeOf(value);
-    const stringTag = proto ? proto[Symbol.toStringTag] : undefined;
+    const stringTag = value[Symbol.toStringTag];
     if (stringTag !== undefined) {
       // Use stringification to get the string tag out.
       ret += `[Object ${stringTag}]${singleSep}`;

--- a/packages/vats/test/test-dump.js
+++ b/packages/vats/test/test-dump.js
@@ -29,7 +29,7 @@ test('dump: the @erights challenge', async t => {
   ];
   t.is(
     dump(challenges),
-    '[[Promise],[Function foo],"[hilbert]",undefined,"undefined",[URIError: wut?],[33n,Symbol(foo),Symbol(bar),Symbol(Symbol.asyncIterator)],{"NaN":NaN,"Infinity":Infinity,"neg":-Infinity},18014398509481984,{"superTagged":{[Symbol(Symbol.toStringTag)]:"Tagged"},"subTagged":[Object Tagged]{},"subTaggedNonEmpty":[Object Tagged]{"foo":"x"}},{}]',
+    '[[Promise],[Function foo],"[hilbert]",undefined,"undefined",[URIError: wut?],[33n,Symbol(foo),Symbol(bar),Symbol(Symbol.asyncIterator)],{"NaN":NaN,"Infinity":Infinity,"neg":-Infinity},18014398509481984,{"superTagged":[Object Tagged]{[Symbol(Symbol.toStringTag)]:"Tagged"},"subTagged":[Object Tagged]{},"subTaggedNonEmpty":[Object Tagged]{"foo":"x"}},{}]',
   );
   t.is(
     dump(challenges, 2),
@@ -54,7 +54,7 @@ test('dump: the @erights challenge', async t => {
   },
   18014398509481984,
   {
-    "superTagged": {
+    "superTagged": [Object Tagged] {
       [Symbol(Symbol.toStringTag)]: "Tagged"
     },
     "subTagged": [Object Tagged] {},


### PR DESCRIPTION
Why was repl looking for toStringTag only starting with the prototype?

In preparation for the agoric-sdk sibling of https://github.com/endojs/endo/pull/1554