### PR TITLE
test(vats): use test.after.always to shutdown kernel, and disable AVA's workerThreads

### DIFF
--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -77,6 +77,7 @@
     "files": [
       "test/**/test-*.js"
     ],
-    "timeout": "20m"
+    "timeout": "20m",
+    "workerThreads": false
   }
 }

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -286,6 +286,12 @@ export const getNodeTestVaultsConfig = async (
  * For example, test accounts balances using separate wallets or test vault
  * factory metrics using separate collateral managers. (Or use test.serial)
  *
+ * The shutdown() function *must* be called after the test is
+ * complete, or else V8 will see the xsnap workers still running, and
+ * will never exit (leading to a timeout error). Use
+ * t.after.always(shutdown), because the normal t.after() hooks are
+ * not run if a test fails.
+ *
  * @param {import('ava').ExecutionContext} t
  * @param {string} bundleDir directory to write bundles and config to
  * @param {string} [specifier] bootstrap config specifier

--- a/packages/vats/test/bootstrapTests/test-demo-config.js
+++ b/packages/vats/test/bootstrapTests/test-demo-config.js
@@ -21,7 +21,7 @@ const makeDefaultTestContext = async t => {
 };
 
 test.before(async t => (t.context = await makeDefaultTestContext(t)));
-test.after(async t => t.context.shutdown());
+test.after.always(async t => t.context.shutdown());
 
 // Goal: test that prod config does not expose mailbox access.
 // But on the JS side, aside from vattp, prod config exposes mailbox access

--- a/packages/vats/test/bootstrapTests/test-demo-config.js
+++ b/packages/vats/test/bootstrapTests/test-demo-config.js
@@ -21,7 +21,7 @@ const makeDefaultTestContext = async t => {
 };
 
 test.before(async t => (t.context = await makeDefaultTestContext(t)));
-test.after.always(async t => t.context.shutdown());
+test.after.always(t => t.context.shutdown());
 
 // Goal: test that prod config does not expose mailbox access.
 // But on the JS side, aside from vattp, prod config exposes mailbox access

--- a/packages/vats/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-integration.js
@@ -6,7 +6,6 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { Fail } from '@agoric/assert';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
-import { E } from '@endo/captp';
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
 import { makeAgoricNamesRemotesFromFakeStorage } from '../../tools/board-utils.js';
 import { makeSwingsetTestKit, makeWalletFactoryDriver } from './supports.js';
@@ -66,9 +65,7 @@ const makeDefaultTestContext = async t => {
 test.before(async t => {
   t.context = await makeDefaultTestContext(t);
 });
-test.after.always(async t => {
-  await E(t.context).shutdown();
-});
+test.after.always(t => t.context.shutdown());
 
 test('metrics path', async t => {
   const { EV } = t.context.runUtils;

--- a/packages/vats/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-integration.js
@@ -66,7 +66,7 @@ const makeDefaultTestContext = async t => {
 test.before(async t => {
   t.context = await makeDefaultTestContext(t);
 });
-test.after(async t => {
+test.after.always(async t => {
   await E(t.context).shutdown();
 });
 

--- a/packages/vats/test/bootstrapTests/test-vaults-performance.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-performance.js
@@ -94,7 +94,7 @@ const makeDefaultTestContext = async t => {
 test.before(async t => {
   t.context = await makeDefaultTestContext(t);
 });
-test.after(async t => {
+test.after.always(async t => {
   await E(t.context).shutdown();
 });
 

--- a/packages/vats/test/bootstrapTests/test-vaults-performance.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-performance.js
@@ -9,7 +9,6 @@ import process from 'node:process';
 
 import { Fail } from '@agoric/assert';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
-import { E } from '@endo/captp';
 import engineGC from '@agoric/swingset-vat/src/lib-nodejs/engine-gc.js';
 
 import { eventLoopIteration } from '@agoric/zoe/tools/eventLoopIteration.js';
@@ -94,9 +93,7 @@ const makeDefaultTestContext = async t => {
 test.before(async t => {
   t.context = await makeDefaultTestContext(t);
 });
-test.after.always(async t => {
-  await E(t.context).shutdown();
-});
+test.after.always(t => t.context.shutdown());
 
 const rows = [];
 const perfObserver = new PerformanceObserver(items => {


### PR DESCRIPTION
Several swingset-using tests in packages/vats use a `t.after` hook to call `controller.shutdown()` at the end of the test. This is important to do, because the kernel/controller will have child `xsnap` processes running until it is shut down, and V8 won't exit until they're gone. This would cause a timeout error.

It turns out that `t.after` hooks do not run if any of the tests have failed. So if any of the packages/vats/ tests were to fail, we'd get a timeout error instead of the proper error message, and the error would be delayed by some arbitrary amount (currently about 30 seconds, via the patch Mathieu applied to AVA).

This changes our `t.after(` calls to use `t.after.always()` instead, which *does* run even after tests have failed. We're hoping this might fix some of the hanging tests we've been seeing, but even if it doesn't, `t.after.always` is clearly the right way to do it.

It also uses `ava.workerThreads: false` in the package.json to disable AVA's use of one-thread-per-test-file (and to use one-subprocess-per-test-file instead). Most of our other packages are already doing this, and packages/vats is the only one which has caused weird CI timeouts, so it seems like a good idea to disable them here too.
