### PR TITLE
feat: Support for labeling contract vats at runtime

### DIFF
--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -103,6 +103,7 @@
  * @param {IssuerKeywordRecord} uncleanIssuerKeywordRecord
  * @param {Instance} instance
  * @param {BundleCap} contractBundleCap
+ * @param {string} instanceLabel
  * @returns {Promise<ZoeInstanceStorageManager>}
  */
 
@@ -145,6 +146,7 @@
  *
  * @callback CreateZCFVat
  * @param {BundleCap} contractBundleCap
+ * @param {string} contractLabel
  * @returns {Promise<import('@agoric/swingset-vat').CreateVatResults>}
  */
 

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -210,6 +210,7 @@ export const makeStartInstance = (
     uncleanIssuerKeywordRecord = harden({}),
     customTerms = harden({}),
     privateArgs = undefined,
+    instanceLabel = '',
   ) => {
     const { installation, bundle, bundleCap } = await E(
       startInstanceAccess,
@@ -242,6 +243,7 @@ export const makeStartInstance = (
       uncleanIssuerKeywordRecord,
       instanceHandle,
       contractBundleCap,
+      instanceLabel,
     );
     // AWAIT ///
 

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -119,6 +119,7 @@
  * registering it with Zoe. Returns an installation.
  *
  * @param {Bundle | SourceBundle} bundle
+ * @param {string} [bundleLabel]
  * @returns {Promise<Installation>}
  */
 
@@ -130,6 +131,7 @@
  * Create an installation from a Bundle ID. Returns an installation.
  *
  * @param {BundleID} bundleID
+ * @param {string} [bundleLabel]
  * @returns {Promise<Installation>}
  */
 

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -25,6 +25,7 @@ export type AdminFacet = {
 declare const StartFunction: unique symbol;
 export type Installation<SF> = {
   getBundle: () => SourceBundle;
+  getBundleLabel: () => string;
   // because TS is structural, without this the generic is ignored
   [StartFunction]: SF;
 };

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -102,12 +102,19 @@ const makeZoeKit = (
   // This method contains the power to create a new ZCF Vat, and must
   // be closely held. vatAdminSvc is even more powerful - any vat can
   // be created. We severely restrict access to vatAdminSvc for this reason.
-  const createZCFVat = contractBundleCap => {
+  const createZCFVat = (contractBundleCap, contractLabel) => {
     zcfBundleCap || Fail`createZCFVat did not get bundleCap`;
+    const name =
+      contractLabel &&
+      typeof contractLabel === 'string' &&
+      contractLabel.length > 0
+        ? `zcf-${contractLabel}`
+        : 'zcf';
+
     return E(getActualVatAdminSvcP()).createVat(
       zcfBundleCap,
       harden({
-        name: 'zcf',
+        name,
         vatParameters: {
           contractBundleCap,
           // eslint-disable-next-line no-use-before-define
@@ -160,11 +167,11 @@ const makeZoeKit = (
 
   /** @type {ZoeService} */
   const zoeService = prepareExo(zoeBaggage, 'ZoeService', ZoeServiceI, {
-    install(bundleId) {
-      return dataAccess.installBundle(bundleId);
+    install(bundleId, bundleLabel) {
+      return dataAccess.installBundle(bundleId, bundleLabel);
     },
-    installBundleID(bundleId) {
-      return dataAccess.installBundleID(bundleId);
+    installBundleID(bundleId, bundleLabel) {
+      return dataAccess.installBundleID(bundleId, bundleLabel);
     },
     startInstance,
     offer,

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -351,6 +351,7 @@ export const makeZoeStorageManager = (
     uncleanIssuerKeywordRecord,
     instance,
     contractBundleCap,
+    instanceLabel,
   ) => {
     // Clean the issuerKeywordRecord we receive in `startInstance`
     // from the user, and save the issuers in Zoe if they are not
@@ -385,7 +386,15 @@ export const makeZoeStorageManager = (
       }),
     );
 
-    const { root, adminNode } = await createZCFVat(contractBundleCap);
+    const bundleLabel = installation.getBundleLabel() || 'unlabeledBundle';
+    const contractLabel = instanceLabel
+      ? `${bundleLabel}-${instanceLabel}`
+      : bundleLabel;
+
+    const { root, adminNode } = await createZCFVat(
+      contractBundleCap,
+      contractLabel,
+    );
     return makeInstanceStorageManager(instanceRecord, adminNode, root)
       .instanceStorageManager;
   };
@@ -430,11 +439,11 @@ export const makeZoeStorageManager = (
           return state.instanceAdmins.getInstallation(instance);
         },
         getProposalShapeForInvitation,
-        installBundle: allegedBundle => {
-          return installationStorage.installBundle(allegedBundle);
+        installBundle: (allegedBundle, bundleLabel) => {
+          return installationStorage.installBundle(allegedBundle, bundleLabel);
         },
-        installBundleID(bundleID) {
-          return installationStorage.installBundleID(bundleID);
+        installBundleID(bundleID, bundleLabel) {
+          return installationStorage.installBundleID(bundleID, bundleLabel);
         },
       },
       makeOfferAccess: {


### PR DESCRIPTION
Closes #4738

Zoe's `installSourceBundle`, `installBundle`, and `installBundleID` methods now accept an optional second parameter, a string used to label the bundle installation.  If omitted it defaults to `'unlabeledContract'`.

Zoe's `startInstance` method now accepts an optional fifth parameter, a string used to label the contract instance.  If omitted, it defaults to the empty string (i.e., no instance label).

These two strings are used to generate the name of the contract instance's ZCF vat.  This name currently appears in the vat worker process command line (visible using the `ps` shell command or any other command that interrogates the command line of running processes.  The vat name is also included as an attribute in various vat-related slog records.)

Whereas formerly all ZCF vats had the same name, `'zcf'`, now they will be named `'zcf-${bundleLabel}'` or `'zcf-${bundleLabel}-${instanceLabel}'`.  When this name appears in the worker process command line it also has the vatID prepended, e.g, `v19:zcf-myAwesomeContract-instancePrime`.

Note that the vat name is not considered authoritative in any way, as a contract may declare any bundle or instance labels it wishes, but it is helpful in debugging a running chain in that you can more easily determine which of 47 running ZCF vats is the one you care about looking more closely at.
