### PR TITLE
refactor(swingset-liveslots): rep vs instance label tests more similar

### DIFF
--- a/packages/store/test/test-label-instances.js
+++ b/packages/store/test/test-label-instances.js
@@ -20,8 +20,7 @@ const DownCounterI = M.interface('DownCounter', {
   decr: M.call().returns(M.number()),
 });
 
-// TODO unskip after reconciling with endo
-test.skip('test defineExoClass', t => {
+test('test defineExoClass', t => {
   const makeUpCounter = defineExoClass(
     'UpCounter',
     UpCounterI,
@@ -46,8 +45,7 @@ test.skip('test defineExoClass', t => {
   t.is(`${q(up2)}`, '"[Alleged: UpCounter#2]"');
 });
 
-// TODO unskip after reconciling with endo
-test.skip('test defineExoClassKit', t => {
+test('test defineExoClassKit', t => {
   const makeCounterKit = defineExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
@@ -90,8 +88,7 @@ test.skip('test defineExoClassKit', t => {
   t.is(`${q(down2)}`, '"[Alleged: Counter down#2]"');
 });
 
-// TODO unskip after reconciling with endo
-test.skip('test makeExo', t => {
+test('test makeExo', t => {
   let x = 3;
   const up1 = makeExo('upCounterA', UpCounterI, {
     incr() {

--- a/packages/swingset-liveslots/test/virtual-objects/test-rep-tostring.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-rep-tostring.js
@@ -2,6 +2,9 @@ import test from 'ava';
 import '@endo/init/debug.js';
 // this sets process.env.DEBUG = 'label-instances'
 import './set-debug-label-instances.js';
+
+import { passStyleOf } from '@endo/far';
+
 // this samples it
 import { makeFakeVirtualStuff } from '../../tools/fakeVirtualSupport.js';
 // all tests in this file will be run with DEBUG='label-instances'
@@ -12,16 +15,20 @@ const { quote: q } = assert;
 const init = () => ({});
 const behavior = {};
 const facets = { foo: {}, bar: {} };
+
 test('representatives with label-instances', async t => {
   const { fakeStuff, vom } = makeFakeVirtualStuff();
   const { getSlotForVal } = fakeStuff;
   const makeThing = vom.defineKind('thing', init, behavior);
   const thing1 = makeThing();
   const thing1vref = getSlotForVal(thing1);
-  const thing2 = makeThing();
-  const thing2vref = getSlotForVal(thing2);
+  t.is(passStyleOf(thing1), 'remotable');
   t.is(`${thing1}`, `[object Alleged: thing#${thing1vref}]`);
   t.is(`${q(thing1)}`, `"[Alleged: thing#${thing1vref}]"`);
+
+  const thing2 = makeThing();
+  const thing2vref = getSlotForVal(thing2);
+  t.is(passStyleOf(thing2), 'remotable');
   t.is(`${thing2}`, `[object Alleged: thing#${thing2vref}]`);
   t.is(`${q(thing2)}`, `"[Alleged: thing#${thing2vref}]"`);
 });
@@ -33,11 +40,13 @@ test('facets with label-instances', async t => {
   const thing1 = makeThings();
   const foo1vref = getSlotForVal(thing1.foo); // o+v10/1:1
   const foo1baseref = parseVatSlot(foo1vref).baseRef; // o+v10/1
+  t.is(passStyleOf(thing1.foo), 'remotable');
   t.is(`${thing1.foo}`, `[object Alleged: thing foo#${foo1baseref}]`);
   t.is(`${q(thing1.foo)}`, `"[Alleged: thing foo#${foo1baseref}]"`);
 
   const bar1vref = getSlotForVal(thing1.bar); // o+v10/1:0
   const bar1baseref = parseVatSlot(bar1vref).baseRef; // o+v10/1
+  t.is(passStyleOf(thing1.bar), 'remotable');
   t.is(`${thing1.bar}`, `[object Alleged: thing bar#${bar1baseref}]`);
   t.is(`${q(thing1.bar)}`, `"[Alleged: thing bar#${bar1baseref}]"`);
 });


### PR DESCRIPTION
Improve the parallelism of heap instance labeling test vs representative labeling test. In particular, add a `passStyleOf` tests that had failed before https://github.com/Agoric/agoric-sdk/pull/7273
