### PR TITLE
feat(zoe): error on unexpected properties from start()

### DIFF
--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -379,7 +379,14 @@ export const makeZCFZygote = async (
           creatorFacet = undefined,
           publicFacet = undefined,
           creatorInvitation = undefined,
+          ...unexpected
         }) => {
+          const unexpectedKeys = Object.keys(unexpected);
+          unexpectedKeys.length === 0 ||
+            Fail`contract ${
+              prepare ? 'prepare' : 'start'
+            } returned unrecognized properties ${unexpectedKeys}`;
+
           const areDurable = objectMap(
             { creatorFacet, publicFacet, creatorInvitation },
             canBeDurable,

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -172,6 +172,19 @@ test(`E(zoe).startInstance - bad issuer, makeEmptyPurse throws`, async t => {
   );
 });
 
+test(`E(zoe).startInstance - unexpected properties`, async t => {
+  const { zoe } = setup();
+
+  const contractPath = `${dirname}/unexpectedPropertiesContract.js`;
+  const bundle = await bundleSource(contractPath);
+  const installation = await E(zoe).install(bundle);
+
+  await t.throwsAsync(() => E(zoe).startInstance(installation), {
+    message:
+      'contract "start" returned unrecognized properties ["unexpectedProperty"]',
+  });
+});
+
 test(`E(zoe).offer`, async t => {
   const { zoe, zcf } = await setupZCFTest();
   const invitation = zcf.makeInvitation(() => 'result', 'invitation');

--- a/packages/zoe/test/unitTests/unexpectedPropertiesContract.js
+++ b/packages/zoe/test/unitTests/unexpectedPropertiesContract.js
@@ -1,0 +1,1 @@
+export const start = () => ({ unexpectedProperty: {} });


### PR DESCRIPTION
## Description

A bit of hygiene in case a contract author accidentally returns other facets. For example, if they made a durable object with a `helper` facet and returned the whole object as the `start` result.

### Security Considerations

Reduces chances of errantly returning extra capabilities.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

new test