### PR TITLE
feat: label contract vats

### DIFF
--- a/packages/deploy-script-support/src/coreProposalBehavior.js
+++ b/packages/deploy-script-support/src/coreProposalBehavior.js
@@ -75,7 +75,8 @@ export const makeCoreProposalBehavior = ({
         ? E(vatAdminSvc).getBundleIDByName(ref.bundleName)
         : ref.bundleID;
       const bundleID = await p;
-      return E(zoe).installBundleID(bundleID);
+      const label = bundleID.slice(0, 8);
+      return E(zoe).installBundleID(bundleID, label);
     };
     const restoreRef = overrideRestoreRef || defaultRestoreRef;
 

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -137,6 +137,7 @@ const validateQuestionFromCounter = async (zoe, electorate, voteCounter) => {
  *   governed: {
  *     issuerKeywordRecord: IssuerKeywordRecord,
  *     terms: {governedParams: {[CONTRACT_ELECTORATE]: import('./contractGovernance/typedParamManager.js').InvitationParam}},
+ *     label?: string,
  *   }
  * }>} zcf
  * @param {{
@@ -153,6 +154,7 @@ const start = async (zcf, privateArgs) => {
     governed: {
       issuerKeywordRecord: governedIssuerKeywordRecord,
       terms: contractTerms,
+      label: governedContractLabel,
     },
   } = zcf.getTerms();
   trace('contractTerms', contractTerms);
@@ -177,6 +179,7 @@ const start = async (zcf, privateArgs) => {
     // @ts-ignore XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
     augmentedTerms,
     privateArgs.governed,
+    governedContractLabel,
   );
 
   /** @type {() => Promise<Instance>} */

--- a/packages/governance/src/electorateTools.js
+++ b/packages/governance/src/electorateTools.js
@@ -40,13 +40,19 @@ const startCounter = async (
     quorumThreshold,
   };
 
+  const { deadline } = questionSpec.closingRule;
   // facets of the voteCounter. creatorInvitation and adminFacet not used
   /** @type {{ creatorFacet: VoteCounterCreatorFacet, publicFacet: VoteCounterPublicFacet, instance: Instance }} */
   const { creatorFacet, publicFacet, instance } = await E(
     zcf.getZoeService(),
-  ).startInstance(voteCounter, {}, voteCounterTerms, { outcomePublisher });
+  ).startInstance(
+    voteCounter,
+    {},
+    voteCounterTerms,
+    { outcomePublisher },
+    `voteCounter.${deadline}`,
+  );
   const details = await E(publicFacet).getDetails();
-  const { deadline } = questionSpec.closingRule;
   questionsPublisher.publish(details);
   const questionHandle = details.questionHandle;
 

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -79,7 +79,7 @@ export const publishInterchainAssetFromBank = async (
     },
   };
   const { creatorFacet: mintP, publicFacet: issuerP } = E.get(
-    E(zoe).startInstance(mintHolder, {}, terms),
+    E(zoe).startInstance(mintHolder, {}, terms, undefined, keyword),
   );
 
   const [issuer, brand] = await Promise.all([issuerP, E(issuerP).getBrand()]);
@@ -183,7 +183,13 @@ export const registerScaledPriceAuthority = async (
     }),
   );
   const { publicFacet } = E.get(
-    E(zoe).startInstance(scaledPriceAuthority, undefined, terms),
+    E(zoe).startInstance(
+      scaledPriceAuthority,
+      undefined,
+      terms,
+      undefined,
+      `scaledPriceAuthority-${keyword}`,
+    ),
   );
   await E(priceAuthorityAdmin).registerPriceAuthority(
     E(publicFacet).getPriceAuthority(),

--- a/packages/inter-protocol/src/proposals/committee-proposal.js
+++ b/packages/inter-protocol/src/proposals/committee-proposal.js
@@ -65,7 +65,13 @@ export const startEconCharter = async ({
   );
 
   /** @type {Promise<import('./econ-behaviors').EconCharterStartResult>} */
-  const startResult = E(zoe).startInstance(charterInstall, undefined, terms);
+  const startResult = E(zoe).startInstance(
+    charterInstall,
+    undefined,
+    terms,
+    undefined,
+    'econCommitteeCharter',
+  );
   instanceP.resolve(E.get(startResult).instance);
   econCharterKit.resolve(startResult);
 };

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -145,6 +145,7 @@ export const setupReserve = async ({
       governed: {
         terms: reserveTerms,
         issuerKeywordRecord: { Central: centralIssuer },
+        label: 'reserve',
       },
     }),
   );
@@ -162,6 +163,7 @@ export const setupReserve = async ({
         storageNode,
       },
     },
+    'reserve.governor',
   );
 
   const [creatorFacet, publicFacet, instance] = await Promise.all([
@@ -280,6 +282,7 @@ export const startVaultFactory = async (
       governed: {
         terms: vaultFactoryTerms,
         issuerKeywordRecord: {},
+        label: 'vaultFactory',
       },
     }),
   );
@@ -302,6 +305,7 @@ export const startVaultFactory = async (
         storageNode,
       },
     }),
+    'vaultFactory.governor',
   );
 
   const [vaultFactoryInstance, vaultFactoryCreator, publicFacet] =
@@ -417,6 +421,8 @@ export const startRewardDistributor = async ({
     feeDistributor,
     { Fee: centralIssuer },
     feeDistributorTerms,
+    undefined,
+    'feeDistributor',
   );
   await E(instanceKit.creatorFacet).setDestinations({
     RewardDistributor:
@@ -569,6 +575,7 @@ export const startAuctioneer = async (
         issuerKeywordRecord: { Currency: runIssuer },
         storageNode,
         marshaller,
+        label: 'auctioneer',
       },
     }),
   );
@@ -586,6 +593,7 @@ export const startAuctioneer = async (
         marshaller,
       },
     }),
+    'auctioneer.governor',
   );
 
   const [governedInstance, governedCreatorFacet, governedPublicFacet] =
@@ -710,6 +718,7 @@ export const startStakeFactory = async (
       governed: {
         terms: stakeFactoryTerms,
         issuerKeywordRecord: { Stake: bldIssuer },
+        label: 'stakeFactory',
       },
     }),
   );
@@ -728,6 +737,7 @@ export const startStakeFactory = async (
         marshaller,
       },
     },
+    'stakeFactory.governor',
   );
 
   const [governedInstance, governedCreatorFacet, governedPublicFacet] =

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -52,6 +52,7 @@ const BASIS_POINTS = 10_000n;
  * @typedef { WellKnownSpaces & ChainBootstrapSpace & EconomyBootstrapSpace
  * } EconomyBootstrapPowers
  * @typedef {PromiseSpaceOf<{
+ *   economicCommitteeKit: CommitteeStartResult,
  *   economicCommitteeCreatorFacet: import('@agoric/governance/src/committee.js').CommitteeElectorateCreatorFacet,
  *   feeDistributorKit: {
  *     creatorFacet: import('../feeDistributor.js').FeeDistributorCreatorFacet,
@@ -86,6 +87,7 @@ const BASIS_POINTS = 10_000n;
  */
 
 /** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('../econCommitteeCharter').start>} EconCharterStartResult */
+/** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('@agoric/governance/src/committee').start>} CommitteeStartResult */
 
 /**
  * @file A collection of productions, each of which declares inputs and outputs.

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -169,12 +169,14 @@ export const createPriceFeed = async (
   });
   trace('got terms');
 
+  const label = sanitizePathSegment(AGORIC_INSTANCE_NAME);
   const governorTerms = await deeplyFulfilledObject(
     harden({
       timer: chainTimerService,
       governedContractInstallation: priceAggregator,
       governed: {
         terms,
+        label,
       },
     }),
   );
@@ -196,11 +198,10 @@ export const createPriceFeed = async (
         initialPoserInvitation,
         marshaller,
         namesByAddressAdmin,
-        storageNode: E(storageNode).makeChildNode(
-          sanitizePathSegment(AGORIC_INSTANCE_NAME),
-        ),
+        storageNode: E(storageNode).makeChildNode(label),
       },
     },
+    label,
   );
   const faCreatorFacet = await E(
     aggregatorGovernor.creatorFacet,

--- a/packages/inter-protocol/src/proposals/startEconCommittee.js
+++ b/packages/inter-protocol/src/proposals/startEconCommittee.js
@@ -67,6 +67,7 @@ export const startEconomicCommittee = async (
       storageNode,
       marshaller,
     },
+    'economicCommittee',
   );
   const { creatorFacet, instance } = startResult;
 

--- a/packages/inter-protocol/src/proposals/startEconCommittee.js
+++ b/packages/inter-protocol/src/proposals/startEconCommittee.js
@@ -29,7 +29,7 @@ const sanitizePathSegment = name => {
 export const startEconomicCommittee = async (
   {
     consume: { board, chainStorage, zoe },
-    produce: { economicCommitteeCreatorFacet },
+    produce: { economicCommitteeKit, economicCommitteeCreatorFacet },
     installation: {
       consume: { committee },
     },
@@ -59,7 +59,7 @@ export const startEconomicCommittee = async (
   // NB: committee must only publish what it intended to be public
   const marshaller = await E(board).getPublishingMarshaller();
 
-  const { creatorFacet, instance } = await E(zoe).startInstance(
+  const startResult = await E(zoe).startInstance(
     committee,
     {},
     { committeeName, committeeSize, ...rest },
@@ -68,7 +68,9 @@ export const startEconomicCommittee = async (
       marshaller,
     },
   );
+  const { creatorFacet, instance } = startResult;
 
+  economicCommitteeKit.resolve(startResult);
   economicCommitteeCreatorFacet.resolve(creatorFacet);
   economicCommittee.resolve(instance);
 };
@@ -81,7 +83,10 @@ export const ECON_COMMITTEE_MANIFEST = harden({
       chainStorage: true,
       zoe: true,
     },
-    produce: { economicCommitteeCreatorFacet: 'economicCommittee' },
+    produce: {
+      economicCommitteeKit: true,
+      economicCommitteeCreatorFacet: 'economicCommittee',
+    },
     installation: {
       consume: { committee: 'zoe' },
     },

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -214,6 +214,8 @@ harden(startPSM);
  * Make anchor issuer out of a Cosmos asset; presumably
  * USDC over IBC. Add it to BankManager.
  *
+ * TODO: address redundancy with publishInterchainAssetFromBank
+ *
  * @param {EconomyBootstrapPowers & WellKnownSpaces} powers
  * @param {{options?: { anchorOptions?: AnchorOptions } }} [config]
  */

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -248,6 +248,7 @@ export const makeAnchorAsset = async (
       },
     }),
   );
+  // TODO: save adminFacet of this contract, like all others.
   /** @type {{ creatorFacet: ERef<Mint<'nat'>>, publicFacet: ERef<Issuer<'nat'>> }} */
   // @ts-expect-error cast
   const { creatorFacet: mint, publicFacet: issuerP } = E.get(

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -133,6 +133,7 @@ export const startPSM = async (
 
   const marshaller = await E(board).getPublishingMarshaller();
 
+  const instanceKey = `psm-${Stable.symbol}-${keyword}`;
   const governorTerms = await deeplyFulfilledObject(
     harden({
       timer: chainTimerService,
@@ -140,6 +141,7 @@ export const startPSM = async (
       governed: {
         terms,
         issuerKeywordRecord: { [keyword]: anchorIssuer },
+        label: instanceKey,
       },
     }),
   );
@@ -156,6 +158,7 @@ export const startPSM = async (
         storageNode,
       },
     }),
+    `${instanceKey}.governor`,
   );
 
   const [psm, psmCreatorFacet, psmAdminFacet] = await Promise.all([
@@ -181,7 +184,6 @@ export const startPSM = async (
   const psmKitMap = await psmKit;
 
   psmKitMap.init(anchorBrand, newpsmKit);
-  const instanceKey = `psm-${Stable.symbol}-${keyword}`;
   const instanceAdmin = E(agoricNamesAdmin).lookupAdmin('instance');
 
   await Promise.all([
@@ -252,7 +254,7 @@ export const makeAnchorAsset = async (
   /** @type {{ creatorFacet: ERef<Mint<'nat'>>, publicFacet: ERef<Issuer<'nat'>> }} */
   // @ts-expect-error cast
   const { creatorFacet: mint, publicFacet: issuerP } = E.get(
-    E(zoe).startInstance(mintHolder, {}, terms),
+    E(zoe).startInstance(mintHolder, {}, terms, undefined, keyword),
   );
   const issuer = await issuerP; // identity of issuers is important
 
@@ -305,7 +307,7 @@ export const installGovAndPSMContracts = async ({
       econCommitteeCharter,
     }).map(async ([name, producer]) => {
       const bundleID = await E(vatAdminSvc).getBundleIDByName(name);
-      const installation = await E(zoe).installBundleID(bundleID);
+      const installation = await E(zoe).installBundleID(bundleID, name);
 
       producer.resolve(installation);
     }),

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -271,7 +271,7 @@ export const installBootContracts = async ({
   })) {
     const idP = E(vatAdminSvc).getBundleIDByName(name);
     const installationP = idP.then(bundleID =>
-      E(zoe).installBundleID(bundleID),
+      E(zoe).installBundleID(bundleID, name),
     );
     producer.resolve(installationP);
   }
@@ -308,6 +308,7 @@ export const mintInitialSupply = async ({
     {},
     { bootstrapPaymentValue },
     { feeMintAccess },
+    'centralSupply',
   );
   const payment = E(creatorFacet).getBootstrapPayment();
   // TODO: shut down the centralSupply contract, now that we have the payment?
@@ -353,6 +354,8 @@ export const addBankAssets = async ({
         assetKind: Stake.assetKind,
         displayInfo: Stake.displayInfo,
       }),
+      undefined,
+      Stake.symbol,
     ),
   );
   const bldBrand = await E(bldIssuer).getBrand();

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -31,6 +31,7 @@ const StableUnit = BigInt(10 ** Stable.displayInfo.decimalPlaces);
  *   issuerKeywordRecord?: IssuerKeywordRecord,
  *   terms: Record<string, unknown>,
  *   privateArgs: any, // TODO: connect with Installation type
+ *   label: string,
  * }} zoeArgs
  * @param {{
  *   governedParams: Record<string, unknown>,
@@ -46,6 +47,7 @@ const startGovernedInstance = async (
     issuerKeywordRecord,
     terms,
     privateArgs,
+    label,
   },
   { governedParams, timer, contractGovernor, economicCommitteeCreatorFacet },
 ) => {
@@ -74,6 +76,7 @@ const startGovernedInstance = async (
           },
         },
         issuerKeywordRecord,
+        label,
       },
     }),
   );
@@ -88,6 +91,7 @@ const startGovernedInstance = async (
         initialPoserInvitation,
       },
     }),
+    `${label}-governor`,
   );
   const [instance, creatorFacet, adminFacet] = await Promise.all([
     E(governorFacets.creatorFacet).getInstance(),
@@ -206,6 +210,7 @@ export const startWalletFactory = async (
       storageNode: walletStorageNode,
       walletBridgeManager,
     },
+    'walletFactory',
   );
   walletFactoryStartResult.resolve(wfFacets);
   instanceProduce.walletFactory.resolve(wfFacets.instance);
@@ -220,6 +225,7 @@ export const startWalletFactory = async (
         storageNode: poolStorageNode,
         marshaller: E(board).getPublishingMarshaller(),
       }),
+      label: 'provisionPool',
     },
     {
       governedParams: {

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -119,8 +119,11 @@ export const makeInstallationStorage = (
         }
         return installSourceBundle(allegedBundle, bundleLabel);
       },
-      async installBundleID(bundleID, bundleLabel) {
+      async installBundleID(bundleID, bundleLabel = bundleID.slice(0, 9)) {
         typeof bundleID === 'string' || Fail`a bundle ID must be provided`;
+        typeof bundleLabel === 'string' ||
+          Fail`a bundle label must be a string`;
+
         // this waits until someone tells the host application to store the
         // bundle into the kernel, with controller.validateAndInstallBundle()
         const bundleCap = await getBundleCapForID(bundleID);

--- a/packages/zoe/src/zoeService/utils.d.ts
+++ b/packages/zoe/src/zoeService/utils.d.ts
@@ -101,6 +101,7 @@ export type StartInstance = <SF>(
   // 'brands' and 'issuers' need not be passed in; Zoe provides them as StandardTerms
   terms?: Omit<StartParams<SF>['terms'], 'brands' | 'issuers'>,
   privateArgs?: StartParams<SF>['privateArgs'],
+  label?: string,
 ) => Promise<StartedInstanceKit<SF>>;
 
 export type GetPublicFacet = <SF>(

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -386,7 +386,7 @@ export const makeZoeStorageManager = (
       }),
     );
 
-    const bundleLabel = installation.getBundleLabel() || 'unlabeledBundle';
+    const bundleLabel = installation.getBundleLabel();
     const contractLabel = instanceLabel
       ? `${bundleLabel}-${instanceLabel}`
       : bundleLabel;


### PR DESCRIPTION
refs: #4738

## Description

Fill in the `label` argument to `E(zoe).startInstance()` and `E(zoe).installBundleID()` calls in bootstrap etc.

DRAFT TODO:

 - [x] resolve [`mintHolder-BLD-mint` vs. `mintHolder-IbcATOM`](https://github.com/Agoric/agoric-sdk/pull/7426/files#r1168862912)
 - [x] ensure there's an issue re unsaved  `adminFacet`s. I fixed `economicCommittee` but not at least one case of `mintHolder` isn't saved. #7433

### Security Considerations

nothing not considered in #4738

### Scaling Considerations

helps quite a bit with observability when we get dozens of vaults

### Documentation Considerations

`ps` gets a lot more useful. For example, `pstree --hide-threads`:

```
      |-xsnap-worker,3475151 v1:bootstrap
      |-xsnap-worker,3475152 v5:timer
      |-xsnap-worker,3475156 v2:vatAdmin
      |-xsnap-worker,3475161 v4:vattp
      |-xsnap-worker,3475224 v6:priceAuthority
      |-xsnap-worker,3475247 v7:zoe
      |-xsnap-worker,3475255 v8:board
      |-xsnap-worker,3475256 v9:bridge
      |-xsnap-worker,3475260 v10:provisioning
      |-xsnap-worker,3475292 v11:network
      |-xsnap-worker,3475293 v12:ibc
      |-xsnap-worker,3475413 v14:zcf-mintHolder-BLD
      |-xsnap-worker,3475428 v15:bank
      |-xsnap-worker,3475775 v16:zcf-b1-c1224-econCommitteeCharter
      |-xsnap-worker,3475783 v17:zcf-b1-c1224-econCommitteeCharter
      |-xsnap-worker,3475831 v18:zcf-mintHolder-IbcATOM
      |-xsnap-worker,3475864 v19:zcf-mintHolder-USDC_axl
      |-xsnap-worker,3475872 v20:zcf-mintHolder-USDC_grv
      |-xsnap-worker,3475877 v21:zcf-mintHolder-USDT_axl
      |-xsnap-worker,3475918 v22:zcf-mintHolder-USDT_grv
      |-xsnap-worker,3476008 v23:zcf-mintHolder-AUSD
      |-xsnap-worker,3476016 v24:zcf-b1-868f4-feeDistributor
      |-xsnap-worker,3476138 v25:zcf-b1-d7bd1-walletFactory
      |-xsnap-worker,3476233 v26:zcf-b1-52f82-economicCommittee
      |-xsnap-worker,3476398 v27:zcf-b1-1c9fb-ATOM-USD_price_feed
      |-xsnap-worker,3476438 v28:zcf-b1-1c9fb-reserve-governor
      |-xsnap-worker,3476443 v29:zcf-b1-1c9fb-stakeFactory-governor
      |-xsnap-worker,3476498 v30:zcf-b1-1c9fb-provisionPool-governor
      |-xsnap-worker,3476602 v31:zcf-b1-1c9fb-auctioneer-governor
      |-xsnap-worker,3476607 v32:zcf-b1-1c9fb-psm-IST-USDC_axl-governor
      |-xsnap-worker,3476615 v33:zcf-b1-1c9fb-psm-IST-USDC_grv-governor
      |-xsnap-worker,3476623 v34:zcf-b1-1c9fb-psm-IST-USDT_axl-governor
      |-xsnap-worker,3476705 v35:zcf-b1-1c9fb-psm-IST-USDT_grv-governor
      |-xsnap-worker,3476787 v36:zcf-b1-1c9fb-psm-IST-AUSD-governor
      |-xsnap-worker,3476799 v37:zcf-b1-26008-ATOM-USD_price_feed
      |-xsnap-worker,3477021 v38:zcf-b1-12939-reserve
      |-xsnap-worker,3477031 v39:zcf-b1-c0a40-provisionPool
      |-xsnap-worker,3477043 v40:zcf-b1-84cf2-auctioneer
      |-xsnap-worker,3477235 v41:zcf-b1-2cfb9-stakeFactory
      |-xsnap-worker,3477251 v42:zcf-b1-5b4da-psm-IST-USDC_axl
      |-xsnap-worker,3477289 v43:zcf-b1-5b4da-psm-IST-USDC_grv
      |-xsnap-worker,3477297 v44:zcf-b1-5b4da-psm-IST-USDT_axl
      |-xsnap-worker,3477362 v45:zcf-b1-5b4da-psm-IST-USDT_grv
      |-xsnap-worker,3477490 v46:zcf-b1-5b4da-psm-IST-AUSD
      |-xsnap-worker,3477993 v47:zcf-b1-8b913-scaledPriceAuthority-IbcATOM
      |-xsnap-worker,3478005 v48:zcf-b1-1c9fb-vaultFactory-governor
      |-xsnap-worker,3478020 v49:zcf-b1-fed93-vaultFactory
```

and later...

```
      |-xsnap-worker,588264 v50:zcf-b1-c262d-voteCounter-1681516980
```

### Testing Considerations

manually tested so far.
