### PR TITLE
Port pismo replay tool improvements

### DIFF
--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -43,11 +43,11 @@ const FORCED_SNAPSHOT_INITIAL = 2;
 const FORCED_SNAPSHOT_INTERVAL = 1000;
 const FORCED_RELOAD_FROM_SNAPSHOT = false;
 const KEEP_WORKER_RECENT = 0;
-const KEEP_WORKER_INITIAL = 1;
+const KEEP_WORKER_INITIAL = 2;
 const KEEP_WORKER_INTERVAL = 1;
 
 const SKIP_EXTRA_SYSCALLS = true;
-const SIMULATE_VC_SYSCALLS = false;
+const SIMULATE_VC_SYSCALLS = true;
 
 // Use a simplified snapstore which derives the snapshot filename from the
 // transcript and doesn't compress the snapshot
@@ -182,6 +182,7 @@ async function replay(transcriptFile) {
    *  xsnapPID: number | undefined;
    *  deliveryTimeTotal: number;
    *  deliveryTimeSinceLastSnapshot: number;
+   *  loadSnapshotID: string | undefined;
    *  firstTranscriptNum: number | null;
    * }} WorkerData
    */
@@ -411,6 +412,7 @@ async function replay(transcriptFile) {
       xsnapPID: NaN,
       deliveryTimeTotal: 0,
       deliveryTimeSinceLastSnapshot: 0,
+      loadSnapshotID,
       firstTranscriptNum: null,
     };
     workers.push(workerData);
@@ -433,26 +435,25 @@ async function replay(transcriptFile) {
     return workerData;
   };
 
+  let loadLock = Promise.resolve();
   const loadSnapshot = async data => {
     if (worker !== 'xs-worker') {
       return;
     }
+    await loadLock;
+
     await Promise.all(
       workers
         .filter(
-          ({ firstTranscriptNum }) =>
+          ({ firstTranscriptNum }, idx) =>
             firstTranscriptNum != null &&
             !(
               (KEEP_WORKER_INTERVAL &&
                 Math.floor(firstTranscriptNum / FORCED_SNAPSHOT_INTERVAL) %
                   KEEP_WORKER_INTERVAL ===
                   0) ||
-              (KEEP_WORKER_RECENT > 0 &&
-                lastTranscriptNum - firstTranscriptNum <=
-                  KEEP_WORKER_RECENT * FORCED_SNAPSHOT_INTERVAL) ||
-              (KEEP_WORKER_INITIAL > 0 &&
-                firstTranscriptNum - startTranscriptNum <=
-                  KEEP_WORKER_INITIAL * FORCED_SNAPSHOT_INTERVAL)
+              idx < KEEP_WORKER_INITIAL ||
+              idx >= workers.length - KEEP_WORKER_RECENT
             ),
         )
         .map(async workerData => {
@@ -478,29 +479,49 @@ async function replay(transcriptFile) {
           );
         }),
     );
+
     loadSnapshotID = data.snapshotID;
-    if (snapshotOverrideMap.has(loadSnapshotID)) {
-      loadSnapshotID = snapshotOverrideMap.get(loadSnapshotID);
+    /** @type {() => void} */
+    let releaseLock;
+    loadLock = new Promise(resolve => {
+      releaseLock = resolve;
+    });
+    // @ts-expect-error
+    assert(releaseLock);
+    try {
+      if (snapshotOverrideMap.has(loadSnapshotID)) {
+        loadSnapshotID = snapshotOverrideMap.get(loadSnapshotID);
+      }
+      if (
+        workers.find(workerData => workerData.loadSnapshotID === loadSnapshotID)
+      ) {
+        console.log(
+          `found an existing manager for snapshot ${loadSnapshotID}, skipping duplicate creation`,
+        );
+        return;
+      }
+      if (data.vatID) {
+        vatID = data.vatID;
+      }
+      const { xsnapPID } = await createManager();
+      console.log(
+        `created manager from snapshot ${loadSnapshotID}, worker PID: ${xsnapPID}`,
+      );
+      fs.writeSync(
+        snapshotActivityFd,
+        `${JSON.stringify({
+          transcriptFile,
+          type: 'load',
+          xsnapPID,
+          vatID,
+          snapshotID: data.snapshotID,
+          loadSnapshotID,
+        })}\n`,
+      );
+    } finally {
+      loadSnapshotID = null;
+      releaseLock();
     }
-    if (data.vatID) {
-      vatID = data.vatID;
-    }
-    const { xsnapPID } = await createManager();
-    console.log(
-      `created manager from snapshot ${loadSnapshotID}, worker PID: ${xsnapPID}`,
-    );
-    fs.writeSync(
-      snapshotActivityFd,
-      `${JSON.stringify({
-        transcriptFile,
-        type: 'load',
-        xsnapPID,
-        vatID,
-        snapshotID: data.snapshotID,
-        loadSnapshotID,
-      })}\n`,
-    );
-    loadSnapshotID = null;
   };
 
   /** @type {import('stream').Readable} */
@@ -679,14 +700,13 @@ async function replay(transcriptFile) {
       }
 
       if (FORCED_RELOAD_FROM_SNAPSHOT) {
-        await Promise.all(
-          uniqueSnapshotIDs.map(async snapshotID =>
-            loadSnapshot({
-              snapshotID,
-              vatID,
-            }),
-          ),
-        );
+        for (const snapshotID of uniqueSnapshotIDs) {
+          // eslint-disable-next-line no-await-in-loop
+          await loadSnapshot({
+            snapshotID,
+            vatID,
+          });
+        }
       }
     }
   }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -26,12 +26,7 @@ import { waitUntilQuiescent } from '../src/lib-nodejs/waitUntilQuiescent.js';
 import { makeStartXSnap } from '../src/controller/startXSnap.js';
 import { makeXsSubprocessFactory } from '../src/kernel/vat-loader/manager-subprocess-xsnap.js';
 import { makeLocalVatManagerFactory } from '../src/kernel/vat-loader/manager-local.js';
-import {
-  extraSyscall,
-  missingSyscall,
-  requireIdenticalExceptStableVCSyscalls,
-  vcSyscallRE,
-} from '../src/kernel/vat-loader/transcript.js';
+import { requireIdentical } from '../src/kernel/vat-loader/transcript.js';
 import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
 import { makeGcAndFinalize } from '../src/lib-nodejs/gc-and-finalize.js';
 import engineGC from '../src/lib-nodejs/engine-gc.js';
@@ -226,7 +221,88 @@ async function replay(transcriptFile) {
     throw Error(`unhandled worker type ${worker}`);
   }
 
-  /** @type {Map<string, VatSyscallResult | undefined>} */
+  const [
+    bestRequireIdentical,
+    extraSyscall,
+    missingSyscall,
+    vcSyscallRE,
+    supportsRelaxedSyscalls,
+  ] = await (async () => {
+    /** @type {any} */
+    const transcriptModule = await import(
+      '../src/kernel/vat-loader/transcript.js'
+    );
+
+    /** @type {RegExp} */
+    const syscallRE =
+      transcriptModule.vcSyscallRE || /^vc\.\d+\.\|(?:schemata|label)$/;
+
+    if (
+      typeof transcriptModule.requireIdenticalExceptStableVCSyscalls !==
+      'function'
+    ) {
+      return [
+        requireIdentical,
+        Symbol('never extra'),
+        Symbol('never missing'),
+        syscallRE,
+        false,
+      ];
+    }
+
+    /** @type {{requireIdenticalExceptStableVCSyscalls: import('../src/kernel/vat-loader/transcript.js').CompareSyscalls}} */
+    const { requireIdenticalExceptStableVCSyscalls } = transcriptModule;
+
+    if (
+      typeof transcriptModule.extraSyscall === 'symbol' &&
+      typeof transcriptModule.missingSyscall === 'symbol'
+    ) {
+      return [
+        requireIdenticalExceptStableVCSyscalls,
+        /** @type {symbol} */ (transcriptModule.extraSyscall),
+        /** @type {symbol} */ (transcriptModule.missingSyscall),
+        syscallRE,
+        true,
+      ];
+    }
+
+    /** @type {unknown} */
+    const dynamicExtraSyscall = requireIdenticalExceptStableVCSyscalls(
+      'vat0',
+      ['vatstoreGet', 'vc.0.|label'],
+      ['vatstoreGet', 'ignoreExtraSyscall'],
+    );
+    /** @type {unknown} */
+    const dynamicMissingSyscall = requireIdenticalExceptStableVCSyscalls(
+      'vat0',
+      ['vatstoreGet', 'ignoreMissingSyscall'],
+      ['vatstoreGet', 'vc.0.|label'],
+    );
+
+    return [
+      requireIdenticalExceptStableVCSyscalls,
+      typeof dynamicExtraSyscall === 'symbol'
+        ? dynamicExtraSyscall
+        : Symbol('never extra'),
+      typeof dynamicMissingSyscall === 'symbol'
+        ? dynamicMissingSyscall
+        : Symbol('never missing'),
+      syscallRE,
+      typeof dynamicExtraSyscall === 'symbol' &&
+        typeof dynamicMissingSyscall === 'symbol',
+    ];
+  })();
+
+  if (
+    (SIMULATE_VC_SYSCALLS || SKIP_EXTRA_SYSCALLS) &&
+    !supportsRelaxedSyscalls
+  ) {
+    console.warn(
+      'Transcript replay does not support relaxed replay. Cannot simulate or skip syscalls',
+    );
+  }
+
+  /** @type {Map<string, import('@agoric/swingset-liveslots').VatSyscallResult | undefined>} */
   const knownVCSyscalls = new Map();
 
   /**
@@ -251,11 +327,7 @@ async function replay(transcriptFile) {
    */
   const makeCompareSyscalls =
     () => (_vatID, originalSyscall, newSyscall, originalResponse) => {
-      const error = requireIdenticalExceptStableVCSyscalls(
-        vatID,
-        originalSyscall,
-        newSyscall,
-      );
+      const error = bestRequireIdentical(vatID, originalSyscall, newSyscall);
       if (
         error &&
         JSON.stringify(originalSyscall).indexOf('error:liveSlots') !== -1
@@ -266,26 +338,42 @@ async function replay(transcriptFile) {
       if (error) {
         console.error(`during transcript num= ${lastTranscriptNum}`);
 
-        if (error === extraSyscall && !SKIP_EXTRA_SYSCALLS) {
+        if (
+          // @ts-expect-error may be a symbol in some versions
+          error === extraSyscall &&
+          !SKIP_EXTRA_SYSCALLS
+        ) {
           return new Error('Extra syscall disallowed');
         }
       }
 
       const newSyscallKind = newSyscall[0];
 
-      if (error === missingSyscall && !SIMULATE_VC_SYSCALLS) {
+      if (
+        // @ts-expect-error may be a symbol in some versions
+        error === missingSyscall &&
+        !SIMULATE_VC_SYSCALLS
+      ) {
         return new Error('Missing syscall disallowed');
       }
 
       if (
         SIMULATE_VC_SYSCALLS &&
+        supportsRelaxedSyscalls &&
         !error &&
         (newSyscallKind === 'vatstoreGet' ||
           newSyscallKind === 'vatstoreSet') &&
         vcSyscallRE.test(newSyscall[1])
       ) {
         if (newSyscallKind === 'vatstoreGet') {
-          knownVCSyscalls.set(newSyscall[1], originalResponse);
+          if (originalResponse !== undefined) {
+            knownVCSyscalls.set(newSyscall[1], originalResponse);
+          } else if (!knownVCSyscalls.has(newSyscall[1])) {
+            console.warn(
+              `Cannot store vc syscall result for vatstoreGet(${newSyscall[1]})`,
+            );
+            knownVCSyscalls.set(newSyscall[1], undefined);
+          }
         } else if (newSyscallKind === 'vatstoreSet') {
           knownVCSyscalls.set(newSyscall[1], ['ok', newSyscall[2]]);
         }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -41,6 +41,7 @@ const IGNORE_SNAPSHOT_HASH_DIFFERENCES = false;
 
 const FORCED_SNAPSHOT_INITIAL = 2;
 const FORCED_SNAPSHOT_INTERVAL = 1000;
+const FORCED_RELOAD_FROM_SNAPSHOT = false;
 
 // Use a simplified snapstore which derives the snapshot filename from the
 // transcript and doesn't compress the snapshot
@@ -245,6 +246,39 @@ async function replay(transcriptFile) {
     );
   };
 
+  const loadSnapshot = async data => {
+    if (worker !== 'xs-worker') {
+      return;
+    }
+    if (manager) {
+      await manager.shutdown();
+      manager = undefined;
+    }
+    loadSnapshotID = data.snapshotID;
+    if (snapshotOverrideMap.has(loadSnapshotID)) {
+      loadSnapshotID = snapshotOverrideMap.get(loadSnapshotID);
+    }
+    if (data.vatID) {
+      vatID = data.vatID;
+    }
+    await createManager();
+    console.log(
+      `created manager from snapshot ${loadSnapshotID}, worker PID: ${xsnapPID}`,
+    );
+    fs.writeSync(
+      snapshotActivityFd,
+      `${JSON.stringify({
+        transcriptFile,
+        type: 'load',
+        xsnapPID,
+        vatID,
+        snapshotID: data.snapshotID,
+        loadSnapshotID,
+      })}\n`,
+    );
+    loadSnapshotID = null;
+  };
+
   /** @type {import('stream').Readable} */
   let transcriptF = fs.createReadStream(transcriptFile);
   if (transcriptFile.endsWith('.gz')) {
@@ -259,42 +293,13 @@ async function replay(transcriptFile) {
     lineNumber += 1;
     const data = JSON.parse(line);
     if (data.type === 'heap-snapshot-load') {
-      if (worker !== 'xs-worker') {
-        if (manager) {
-          continue; // eslint-disable-line no-continue
-        } else {
-          throw Error(
-            `Cannot replay transcript in ${worker} starting with a heap snapshot load.`,
-          );
-        }
+      if (worker === 'xs-worker') {
+        await loadSnapshot(data);
+      } else if (!manager) {
+        throw Error(
+          `Cannot replay transcript in ${worker} starting with a heap snapshot load.`,
+        );
       }
-      if (manager) {
-        await manager.shutdown();
-        manager = undefined;
-      }
-      loadSnapshotID = data.snapshotID;
-      if (snapshotOverrideMap.has(loadSnapshotID)) {
-        loadSnapshotID = snapshotOverrideMap.get(loadSnapshotID);
-      }
-      if (data.vatID) {
-        vatID = data.vatID;
-      }
-      await createManager();
-      console.log(
-        `created manager from snapshot ${loadSnapshotID}, worker PID: ${xsnapPID}`,
-      );
-      fs.writeSync(
-        snapshotActivityFd,
-        `${JSON.stringify({
-          transcriptFile,
-          type: 'load',
-          xsnapPID,
-          vatID,
-          snapshotID: data.snapshotID,
-          loadSnapshotID,
-        })}\n`,
-      );
-      loadSnapshotID = null;
     } else if (!manager) {
       if (data.type !== 'create-vat') {
         throw Error(
@@ -344,6 +349,9 @@ async function replay(transcriptFile) {
         console.log(`made snapshot ${hash}`);
       }
       saveSnapshotID = null;
+      if (FORCED_RELOAD_FROM_SNAPSHOT) {
+        await loadSnapshot(data);
+      }
     } else {
       const { transcriptNum, d: delivery, syscalls } = data;
       lastTranscriptNum = transcriptNum;
@@ -385,6 +393,12 @@ async function replay(transcriptFile) {
           })}\n`,
         );
         console.log(`made snapshot ${hash} for delivery ${transcriptNum}`);
+        if (FORCED_RELOAD_FROM_SNAPSHOT) {
+          await loadSnapshot({
+            snapshotID: hash,
+            vatID,
+          });
+        }
       }
     }
   }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -42,6 +42,7 @@ const IGNORE_SNAPSHOT_HASH_DIFFERENCES = false;
 const FORCED_SNAPSHOT_INITIAL = 2;
 const FORCED_SNAPSHOT_INTERVAL = 1000;
 const FORCED_RELOAD_FROM_SNAPSHOT = false;
+const MAX_CONCURRENT_WORKERS = 1;
 
 const SKIP_EXTRA_SYSCALLS = true;
 const SIMULATE_VC_SYSCALLS = false;
@@ -172,7 +173,14 @@ async function replay(transcriptFile) {
         testLog,
       })
     );
-  let xsnapPID;
+  /**
+   * @typedef {{
+   *  manager: import('../src/types-internal.js').VatManager;
+   *  xsnapPID: number | undefined;
+   * }} WorkerData
+   */
+  /** @type {WorkerData[]} */
+  const workers = [];
 
   if (worker === 'xs-worker') {
     // eslint-disable-next-line no-constant-condition
@@ -190,7 +198,7 @@ async function replay(transcriptFile) {
       /** @param  {Parameters<typeof spawn>} args */
       (...args) => {
         const child = spawn(...args);
-        xsnapPID = child.pid;
+        workers[workers.length - 1].xsnapPID = child.pid;
         return child;
       }
     );
@@ -323,10 +331,11 @@ async function replay(transcriptFile) {
   };
 
   /**
+   * @param {WorkerData} workerData
    * @returns {import('../src/kernel/vat-loader/transcript.js').CompareSyscalls}
    */
   const makeCompareSyscalls =
-    () => (_vatID, originalSyscall, newSyscall, originalResponse) => {
+    workerData => (_vatID, originalSyscall, newSyscall, originalResponse) => {
       const error = bestRequireIdentical(vatID, originalSyscall, newSyscall);
       if (
         error &&
@@ -336,7 +345,9 @@ async function replay(transcriptFile) {
       }
 
       if (error) {
-        console.error(`during transcript num= ${lastTranscriptNum}`);
+        console.error(
+          `during transcript num= ${lastTranscriptNum} for worker PID ${workerData.xsnapPID}`,
+        );
 
         if (
           // @ts-expect-error may be a symbol in some versions
@@ -384,35 +395,47 @@ async function replay(transcriptFile) {
 
   let vatParameters;
   let vatSourceBundle;
-  /** @type {import('../src/types-internal.js').VatManager | undefined} */
-  let manager;
 
   const createManager = async () => {
+    /** @type {WorkerData} */
+    const workerData = {
+      manager: /** @type {WorkerData['manager']} */ (
+        /** @type {unknown} */ (undefined)
+      ),
+      xsnapPID: NaN,
+    };
+    workers.push(workerData);
     const managerOptions =
       /** @type {import('../src/types-internal.js').ManagerOptions} */ (
         /** @type {Partial<import('../src/types-internal.js').ManagerOptions>} */ ({
           sourcedConsole: console,
           vatParameters,
-          compareSyscalls: makeCompareSyscalls(),
+          compareSyscalls: makeCompareSyscalls(workerData),
           useTranscript: true,
         })
       );
-    manager = await factory.createFromBundle(
+    workerData.manager = await factory.createFromBundle(
       vatID,
       vatSourceBundle,
       managerOptions,
       {},
       vatSyscallHandler,
     );
+    return workerData;
   };
 
   const loadSnapshot = async data => {
     if (worker !== 'xs-worker') {
       return;
     }
-    if (manager) {
+    while (workers.length >= MAX_CONCURRENT_WORKERS) {
+      // Keep the first ever worker, unless we're allowed one max
+      const { manager, xsnapPID } = /** @type {WorkerData} */ (
+        MAX_CONCURRENT_WORKERS > 1 ? workers.splice(1, 1)[0] : workers.pop()
+      );
+      // eslint-disable-next-line no-await-in-loop
       await manager.shutdown();
-      manager = undefined;
+      console.log(`Shutdown worker PID ${xsnapPID}`);
     }
     loadSnapshotID = data.snapshotID;
     if (snapshotOverrideMap.has(loadSnapshotID)) {
@@ -421,7 +444,7 @@ async function replay(transcriptFile) {
     if (data.vatID) {
       vatID = data.vatID;
     }
-    await createManager();
+    const { xsnapPID } = await createManager();
     console.log(
       `created manager from snapshot ${loadSnapshotID}, worker PID: ${xsnapPID}`,
     );
@@ -455,12 +478,12 @@ async function replay(transcriptFile) {
     if (data.type === 'heap-snapshot-load') {
       if (worker === 'xs-worker') {
         await loadSnapshot(data);
-      } else if (!manager) {
+      } else if (!workers.length) {
         throw Error(
           `Cannot replay transcript in ${worker} starting with a heap snapshot load.`,
         );
       }
-    } else if (!manager) {
+    } else if (!workers.length) {
       if (data.type !== 'create-vat') {
         throw Error(
           `first line of transcript was not a create-vat or heap-snapshot-load`,
@@ -468,7 +491,7 @@ async function replay(transcriptFile) {
       }
       ({ vatParameters, vatSourceBundle } = data);
       vatID = data.vatID;
-      await createManager();
+      const { xsnapPID } = await createManager();
       console.log(
         `manager created from bundle source, worker PID: ${xsnapPID}`,
       );
@@ -482,32 +505,39 @@ async function replay(transcriptFile) {
         })}\n`,
       );
     } else if (data.type === 'heap-snapshot-save') {
-      if (!manager.makeSnapshot) continue; // eslint-disable-line no-continue
       saveSnapshotID = data.snapshotID;
-      const { hash } = await manager.makeSnapshot(lastTranscriptNum, snapStore);
-      snapshotOverrideMap.set(saveSnapshotID, hash);
-      fs.writeSync(
-        snapshotActivityFd,
-        `${JSON.stringify({
-          transcriptFile,
-          type: 'save',
-          xsnapPID,
-          vatID,
-          transcriptNum: lastTranscriptNum,
-          snapshotID: hash,
-          saveSnapshotID,
-        })}\n`,
+      await Promise.all(
+        workers.map(async ({ manager, xsnapPID }) => {
+          if (!manager.makeSnapshot) return;
+          const { hash } = await manager.makeSnapshot(
+            lastTranscriptNum,
+            snapStore,
+          );
+          snapshotOverrideMap.set(saveSnapshotID, hash);
+          fs.writeSync(
+            snapshotActivityFd,
+            `${JSON.stringify({
+              transcriptFile,
+              type: 'save',
+              xsnapPID,
+              vatID,
+              transcriptNum: lastTranscriptNum,
+              snapshotID: hash,
+              saveSnapshotID,
+            })}\n`,
+          );
+          if (hash !== saveSnapshotID) {
+            const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID} for worker PID ${xsnapPID}`;
+            if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
+              console.warn(errorMessage);
+            } else {
+              throw new Error(errorMessage);
+            }
+          } else {
+            console.log(`made snapshot ${hash} of worker PID ${xsnapPID}`);
+          }
+        }),
       );
-      if (hash !== saveSnapshotID) {
-        const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID}`;
-        if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
-          console.warn(errorMessage);
-        } else {
-          throw new Error(errorMessage);
-        }
-      } else {
-        console.log(`made snapshot ${hash}`);
-      }
       saveSnapshotID = null;
       if (FORCED_RELOAD_FROM_SNAPSHOT) {
         await loadSnapshot(data);
@@ -515,6 +545,10 @@ async function replay(transcriptFile) {
     } else {
       const { transcriptNum, d: delivery, syscalls } = data;
       lastTranscriptNum = transcriptNum;
+      const makeSnapshot =
+        FORCED_SNAPSHOT_INTERVAL &&
+        (transcriptNum - FORCED_SNAPSHOT_INITIAL) % FORCED_SNAPSHOT_INTERVAL ===
+          0;
       // syscalls = [{ d, response }, ..]
       // console.log(`replaying:`);
       // console.log(
@@ -530,44 +564,64 @@ async function replay(transcriptFile) {
       //     JSON.stringify(s.response[1]).slice(0, 200),
       //   );
       // }
-      await manager.replayOneDelivery(delivery, syscalls, transcriptNum);
-      // console.log(`dr`, dr);
+      const snapshotIDs = await Promise.all(
+        workers.map(async ({ manager, xsnapPID }) => {
+          await manager.replayOneDelivery(delivery, syscalls, transcriptNum);
 
-      // enable this to write periodic snapshots, for #5975 leak
-      if (
-        manager.makeSnapshot &&
-        FORCED_SNAPSHOT_INTERVAL &&
-        (transcriptNum - FORCED_SNAPSHOT_INITIAL) % FORCED_SNAPSHOT_INTERVAL ===
-          0
-      ) {
-        const { hash } = await manager.makeSnapshot(transcriptNum, snapStore);
-        fs.writeSync(
-          snapshotActivityFd,
-          `${JSON.stringify({
-            transcriptFile,
-            type: 'save',
-            xsnapPID,
-            vatID,
-            transcriptNum,
-            snapshotID: hash,
-          })}\n`,
-        );
-        console.log(`made snapshot ${hash} for delivery ${transcriptNum}`);
-        if (FORCED_RELOAD_FROM_SNAPSHOT) {
-          await loadSnapshot({
-            snapshotID: hash,
-            vatID,
-          });
+          // console.log(`dr`, dr);
+
+          // enable this to write periodic snapshots, for #5975 leak
+          if (makeSnapshot && manager.makeSnapshot) {
+            const { hash: snapshotID } = await manager.makeSnapshot(
+              transcriptNum,
+              snapStore,
+            );
+            fs.writeSync(
+              snapshotActivityFd,
+              `${JSON.stringify({
+                transcriptFile,
+                type: 'save',
+                xsnapPID,
+                vatID,
+                transcriptNum,
+                snapshotID,
+              })}\n`,
+            );
+            console.log(
+              `made snapshot ${snapshotID} after delivery ${transcriptNum} to worker PID ${xsnapPID}`,
+            );
+            return snapshotID;
+          } else {
+            return null;
+          }
+        }),
+      );
+      const uniqueSnapshotIDs = [...new Set(snapshotIDs)];
+
+      if (makeSnapshot && uniqueSnapshotIDs.length !== 1) {
+        const errorMessage = `Snapshot hashes do not match each other: ${uniqueSnapshotIDs.join(
+          ', ',
+        )}`;
+        if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
+          console.warn(errorMessage);
+        } else {
+          throw new Error(errorMessage);
         }
+      }
+
+      const snapshotID = uniqueSnapshotIDs[0];
+      if (snapshotID && FORCED_RELOAD_FROM_SNAPSHOT) {
+        await loadSnapshot({
+          snapshotID,
+          vatID,
+        });
       }
     }
   }
 
   lines.close();
   fs.closeSync(snapshotActivityFd);
-  if (manager) {
-    await manager.shutdown();
-  }
+  await Promise.all(workers.map(async ({ manager }) => manager.shutdown()));
 }
 
 async function run() {

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -244,6 +244,7 @@ async function replay(transcriptFile) {
         `manager created from bundle source, worker PID: ${xsnapPID}`,
       );
     } else if (data.type === 'heap-snapshot-save') {
+      if (!manager.makeSnapshot) continue; // eslint-disable-line no-continue
       saveSnapshotID = data.snapshotID;
       const h = await manager.makeSnapshot(snapStore);
       snapshotOverrideMap.set(saveSnapshotID, h);
@@ -280,7 +281,7 @@ async function replay(transcriptFile) {
       // console.log(`dr`, dr);
 
       // enable this to write periodic snapshots, for #5975 leak
-      if (false && deliveryNum % 10 === 8) {
+      if (false && deliveryNum % 10 === 8 && manager?.makeSnapshot) {
         console.log(`-- writing snapshot`, xsnapPID);
         const fn = 'snapshot.xss';
         const snapstore = {

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -222,6 +222,15 @@ async function replay(transcriptFile) {
     lineNumber += 1;
     const data = JSON.parse(line);
     if (data.type === 'heap-snapshot-load') {
+      if (worker !== 'xs-worker') {
+        if (manager) {
+          continue; // eslint-disable-line no-continue
+        } else {
+          throw Error(
+            `Cannot replay transcript in ${worker} starting with a heap snapshot load.`,
+          );
+        }
+      }
       if (manager) {
         await manager.shutdown();
         manager = null;

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -46,6 +46,8 @@ const USE_CUSTOM_SNAP_STORE = true;
 // Enable to output xsnap debug traces corresponding to the transcript replay
 const RECORD_XSNAP_TRACE = false;
 
+const USE_XSNAP_DEBUG = false;
+
 const pipe = promisify(pipeline);
 
 /** @type {(filename: string) => Promise<string>} */
@@ -188,6 +190,7 @@ async function replay(transcriptFile) {
     const startXSnap = makeStartXSnap({
       snapStore,
       spawn: capturePIDSpawn,
+      debug: USE_XSNAP_DEBUG,
       workerTraceRootPath: RECORD_XSNAP_TRACE ? process.cwd() : undefined,
       overrideBundles: bundles,
       bundleHandler: /** @type {*} */ (undefined),

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -38,6 +38,7 @@ const REBUILD_BUNDLES = false;
 
 // Enable to continue if snapshot hash doesn't match transcript
 const IGNORE_SNAPSHOT_HASH_DIFFERENCES = true;
+const IGNORE_CONCURRENT_WORKER_DIVERGENCES = true;
 
 const FORCED_SNAPSHOT_INITIAL = 2;
 const FORCED_SNAPSHOT_INTERVAL = 1000;
@@ -324,6 +325,68 @@ async function replay(transcriptFile) {
     );
   }
 
+  /** @type {Partial<Record<ReturnType<typeof getResultKind>, Map<string, number[]>>>} */
+  let syscallResults = {};
+
+  const getResultKind = result => {
+    if (result === extraSyscall) {
+      return 'extra';
+    } else if (result === missingSyscall) {
+      return 'missing';
+    } else if (result) {
+      return 'error';
+    } else {
+      return 'success';
+    }
+  };
+
+  const reportWorkerResult = ({
+    xsnapPID,
+    result,
+    originalSyscall,
+    newSyscall,
+  }) => {
+    if (!result) return;
+    if (workers.length <= 1) return;
+    const resultKind = getResultKind(result);
+    let kindSummary = syscallResults[resultKind];
+    if (!kindSummary) {
+      /** @type {Map<string, number[]>} */
+      kindSummary = new Map();
+      syscallResults[resultKind] = kindSummary;
+    }
+    const syscallKey = JSON.stringify(
+      resultKind === 'extra' ? originalSyscall : newSyscall,
+    );
+    let workerList = kindSummary.get(syscallKey);
+    if (!workerList) {
+      workerList = [];
+      kindSummary.set(syscallKey, workerList);
+    }
+    workerList.push(xsnapPID);
+  };
+
+  const analyzeSyscallResults = () => {
+    const numWorkers = workers.length;
+    let divergent = false;
+    for (const [kind, kindSummary] of Object.entries(syscallResults)) {
+      for (const [syscallKey, workerList] of kindSummary.entries()) {
+        if (workerList.length !== numWorkers) {
+          console.error(
+            `Divergent ${kind} syscall on deliveryNum= ${lastTranscriptNum}:\n  Worker PIDs ${workerList.join(
+              ', ',
+            )} recorded ${kind} ${syscallKey}`,
+          );
+          divergent = true;
+        }
+      }
+    }
+    syscallResults = {};
+    if (divergent && !IGNORE_CONCURRENT_WORKER_DIVERGENCES) {
+      throw new Error('Divergent execution between workers');
+    }
+  };
+
   let workersSynced = Promise.resolve();
 
   const updateWorkersSynced = () => {
@@ -333,6 +396,7 @@ async function replay(transcriptFile) {
     const newWorkersSynced = stepsCompleted.then(() => {
       if (workersSynced === newWorkersSynced) {
         updateWorkersSynced();
+        analyzeSyscallResults();
       }
     });
     workersSynced = newWorkersSynced;
@@ -453,6 +517,12 @@ async function replay(transcriptFile) {
         newSyscall,
         originalResponse,
       );
+      reportWorkerResult({
+        xsnapPID: workerData.xsnapPID,
+        result,
+        originalSyscall,
+        newSyscall,
+      });
       workerData.timeOfLastCommand = performance.now();
       return result;
     };

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -45,7 +45,7 @@ const FORCED_RELOAD_FROM_SNAPSHOT = false;
 
 // Use a simplified snapstore which derives the snapshot filename from the
 // transcript and doesn't compress the snapshot
-const USE_CUSTOM_SNAP_STORE = true;
+const USE_CUSTOM_SNAP_STORE = false;
 
 // Enable to output xsnap debug traces corresponding to the transcript replay
 const RECORD_XSNAP_TRACE = false;
@@ -156,7 +156,15 @@ async function replay(transcriptFile) {
           return loadRaw(snapFile);
         },
       })
-    : makeSnapStore(sqlite3(':memory:'), () => {}, makeSnapStoreIO());
+    : makeSnapStore(
+        sqlite3(':memory:'),
+        () => {},
+        makeSnapStoreIO(),
+        undefined,
+        {
+          keepSnapshots: true,
+        },
+      );
   const testLog = () => {};
   const meterControl = makeDummyMeterControl();
   const gcTools = harden({
@@ -357,10 +365,10 @@ async function replay(transcriptFile) {
       lastTranscriptNum = transcriptNum;
       // syscalls = [{ d, response }, ..]
       // console.log(`replaying:`);
-      console.log(
-        `delivery ${transcriptNum} (L ${lineNumber}):`,
-        JSON.stringify(delivery).slice(0, 200),
-      );
+      // console.log(
+      //   `delivery ${transcriptNum} (L ${lineNumber}):`,
+      //   JSON.stringify(delivery).slice(0, 200),
+      // );
       // for (const s of syscalls) {
       //   // s.response = 'nope';
       //   console.log(

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -133,6 +133,9 @@ const argv = yargsParser(process.argv.slice(2), {
     recordXsnapTrace: false,
     useXsnapDebug: false,
   },
+  config: {
+    config: true,
+  },
   configuration: {
     'duplicate-arguments-array': false,
     'flatten-duplicate-arrays': false,
@@ -962,6 +965,23 @@ async function replay(transcriptFile) {
               argv.keepWorkerHashDifference && divergent,
             );
           }
+        }
+
+        const loadSnapshots = [].concat(
+          argv.loadSnapshots?.[transcriptNum] || [],
+        );
+        for (const snapshotID of loadSnapshots) {
+          // eslint-disable-next-line no-await-in-loop
+          await loadSnapshot(
+            {
+              snapshotID,
+              vatID,
+            },
+            argv.keepWorkerExplicitLoad ||
+              (argv.keepWorkerHashDifference &&
+                (loadSnapshots.length > 1 ||
+                  !uniqueSnapshotIDs.includes(snapshotID))),
+          );
         }
       }
     }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -39,6 +39,9 @@ const REBUILD_BUNDLES = false;
 // Enable to continue if snapshot hash doesn't match transcript
 const IGNORE_SNAPSHOT_HASH_DIFFERENCES = false;
 
+const FORCED_SNAPSHOT_INITIAL = 2;
+const FORCED_SNAPSHOT_INTERVAL = 1000;
+
 // Use a simplified snapstore which derives the snapshot filename from the
 // transcript and doesn't compress the snapshot
 const USE_CUSTOM_SNAP_STORE = true;
@@ -363,17 +366,25 @@ async function replay(transcriptFile) {
       // console.log(`dr`, dr);
 
       // enable this to write periodic snapshots, for #5975 leak
-      if (false && transcriptNum % 10 === 8 && manager?.makeSnapshot) {
-        console.log(`-- writing snapshot`, xsnapPID);
-        const fn = 'snapshot.xss';
-        const snapstore = {
-          save(thunk) {
-            return thunk(fn);
-          },
-        };
-        // @ts-expect-error to be removed
-        await manager.makeSnapshot(snapstore);
-        // const size = fs.statSync(fn).size;
+      if (
+        manager.makeSnapshot &&
+        FORCED_SNAPSHOT_INTERVAL &&
+        (transcriptNum - FORCED_SNAPSHOT_INITIAL) % FORCED_SNAPSHOT_INTERVAL ===
+          0
+      ) {
+        const { hash } = await manager.makeSnapshot(transcriptNum, snapStore);
+        fs.writeSync(
+          snapshotActivityFd,
+          `${JSON.stringify({
+            transcriptFile,
+            type: 'save',
+            xsnapPID,
+            vatID,
+            transcriptNum,
+            snapshotID: hash,
+          })}\n`,
+        );
+        console.log(`made snapshot ${hash} for delivery ${transcriptNum}`);
       }
     }
   }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -26,7 +26,12 @@ import { waitUntilQuiescent } from '../src/lib-nodejs/waitUntilQuiescent.js';
 import { makeStartXSnap } from '../src/controller/startXSnap.js';
 import { makeXsSubprocessFactory } from '../src/kernel/vat-loader/manager-subprocess-xsnap.js';
 import { makeLocalVatManagerFactory } from '../src/kernel/vat-loader/manager-local.js';
-import { requireIdentical } from '../src/kernel/vat-loader/transcript.js';
+import {
+  extraSyscall,
+  missingSyscall,
+  requireIdenticalExceptStableVCSyscalls,
+  vcSyscallRE,
+} from '../src/kernel/vat-loader/transcript.js';
 import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
 import { makeGcAndFinalize } from '../src/lib-nodejs/gc-and-finalize.js';
 import engineGC from '../src/lib-nodejs/engine-gc.js';
@@ -42,6 +47,9 @@ const IGNORE_SNAPSHOT_HASH_DIFFERENCES = false;
 const FORCED_SNAPSHOT_INITIAL = 2;
 const FORCED_SNAPSHOT_INTERVAL = 1000;
 const FORCED_RELOAD_FROM_SNAPSHOT = false;
+
+const SKIP_EXTRA_SYSCALLS = true;
+const SIMULATE_VC_SYSCALLS = false;
 
 // Use a simplified snapstore which derives the snapshot filename from the
 // transcript and doesn't compress the snapshot
@@ -86,17 +94,6 @@ async function makeBundles() {
   fs.writeFileSync('lockdown-bundle', JSON.stringify(lockdown));
   fs.writeFileSync('supervisor-bundle', JSON.stringify(supervisor));
   console.log(`xs bundles written`);
-}
-
-function compareSyscalls(vatID, originalSyscall, newSyscall) {
-  const error = requireIdentical(vatID, originalSyscall, newSyscall);
-  if (
-    error &&
-    JSON.stringify(originalSyscall).indexOf('error:liveSlots') !== -1
-  ) {
-    return undefined; // Errors are serialized differently, sometimes
-  }
-  return error;
 }
 
 // relative timings:
@@ -229,6 +226,74 @@ async function replay(transcriptFile) {
     throw Error(`unhandled worker type ${worker}`);
   }
 
+  /** @type {Map<string, VatSyscallResult | undefined>} */
+  const knownVCSyscalls = new Map();
+
+  /**
+   * @param {import('../src/types-external.js').VatSyscallObject} vso
+   */
+  const vatSyscallHandler = vso => {
+    if (vso[0] === 'vatstoreGet') {
+      const response = knownVCSyscalls.get(vso[1]);
+
+      if (!response) {
+        throw new Error(`Unknown vc vatstore entry ${vso[1]}`);
+      }
+
+      return response;
+    }
+
+    throw new Error(`Unexpected syscall ${vso[0]}(${vso.slice(1).join(', ')})`);
+  };
+
+  /**
+   * @returns {import('../src/kernel/vat-loader/transcript.js').CompareSyscalls}
+   */
+  const makeCompareSyscalls =
+    () => (_vatID, originalSyscall, newSyscall, originalResponse) => {
+      const error = requireIdenticalExceptStableVCSyscalls(
+        vatID,
+        originalSyscall,
+        newSyscall,
+      );
+      if (
+        error &&
+        JSON.stringify(originalSyscall).indexOf('error:liveSlots') !== -1
+      ) {
+        return undefined; // Errors are serialized differently, sometimes
+      }
+
+      if (error) {
+        console.error(`during transcript num= ${lastTranscriptNum}`);
+
+        if (error === extraSyscall && !SKIP_EXTRA_SYSCALLS) {
+          return new Error('Extra syscall disallowed');
+        }
+      }
+
+      const newSyscallKind = newSyscall[0];
+
+      if (error === missingSyscall && !SIMULATE_VC_SYSCALLS) {
+        return new Error('Missing syscall disallowed');
+      }
+
+      if (
+        SIMULATE_VC_SYSCALLS &&
+        !error &&
+        (newSyscallKind === 'vatstoreGet' ||
+          newSyscallKind === 'vatstoreSet') &&
+        vcSyscallRE.test(newSyscall[1])
+      ) {
+        if (newSyscallKind === 'vatstoreGet') {
+          knownVCSyscalls.set(newSyscall[1], originalResponse);
+        } else if (newSyscallKind === 'vatstoreSet') {
+          knownVCSyscalls.set(newSyscall[1], ['ok', newSyscall[2]]);
+        }
+      }
+
+      return error;
+    };
+
   let vatParameters;
   let vatSourceBundle;
   /** @type {import('../src/types-internal.js').VatManager | undefined} */
@@ -240,11 +305,10 @@ async function replay(transcriptFile) {
         /** @type {Partial<import('../src/types-internal.js').ManagerOptions>} */ ({
           sourcedConsole: console,
           vatParameters,
-          compareSyscalls,
+          compareSyscalls: makeCompareSyscalls(),
           useTranscript: true,
         })
       );
-    const vatSyscallHandler = undefined;
     manager = await factory.createFromBundle(
       vatID,
       vatSourceBundle,

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -37,12 +37,14 @@ import engineGC from '../src/lib-nodejs/engine-gc.js';
 const REBUILD_BUNDLES = false;
 
 // Enable to continue if snapshot hash doesn't match transcript
-const IGNORE_SNAPSHOT_HASH_DIFFERENCES = false;
+const IGNORE_SNAPSHOT_HASH_DIFFERENCES = true;
 
 const FORCED_SNAPSHOT_INITIAL = 2;
 const FORCED_SNAPSHOT_INTERVAL = 1000;
 const FORCED_RELOAD_FROM_SNAPSHOT = false;
-const MAX_CONCURRENT_WORKERS = 1;
+const KEEP_WORKER_RECENT = 0;
+const KEEP_WORKER_INITIAL = 1;
+const KEEP_WORKER_INTERVAL = 1;
 
 const SKIP_EXTRA_SYSCALLS = true;
 const SIMULATE_VC_SYSCALLS = false;
@@ -106,6 +108,7 @@ async function replay(transcriptFile) {
   let loadSnapshotID = null;
   let saveSnapshotID = null;
   let lastTranscriptNum = 0;
+  let startTranscriptNum;
   const snapshotOverrideMap = new Map();
 
   const snapshotActivityFd = fs.openSync('snapshot-activity.jsonl', 'a');
@@ -434,27 +437,47 @@ async function replay(transcriptFile) {
     if (worker !== 'xs-worker') {
       return;
     }
-    while (workers.length >= MAX_CONCURRENT_WORKERS) {
-      // Keep the first ever worker, unless we're allowed one max
-      const {
-        manager,
-        xsnapPID,
-        deliveryTimeSinceLastSnapshot,
-        deliveryTimeTotal,
-        firstTranscriptNum,
-      } = /** @type {WorkerData} */ (
-        MAX_CONCURRENT_WORKERS > 1 ? workers.splice(1, 1)[0] : workers.pop()
-      );
-      // eslint-disable-next-line no-await-in-loop
-      await manager.shutdown();
-      console.log(
-        `Shutdown worker PID ${xsnapPID}.\n    Delivery time since last snapshot ${
-          Math.round(deliveryTimeSinceLastSnapshot) / 1000
-        }s. Delivery time total ${Math.round(deliveryTimeTotal) / 1000}s. Up ${
-          lastTranscriptNum - (firstTranscriptNum ?? NaN)
-        } deliveries.`,
-      );
-    }
+    await Promise.all(
+      workers
+        .filter(
+          ({ firstTranscriptNum }) =>
+            firstTranscriptNum != null &&
+            !(
+              (KEEP_WORKER_INTERVAL &&
+                Math.floor(firstTranscriptNum / FORCED_SNAPSHOT_INTERVAL) %
+                  KEEP_WORKER_INTERVAL ===
+                  0) ||
+              (KEEP_WORKER_RECENT > 0 &&
+                lastTranscriptNum - firstTranscriptNum <=
+                  KEEP_WORKER_RECENT * FORCED_SNAPSHOT_INTERVAL) ||
+              (KEEP_WORKER_INITIAL > 0 &&
+                firstTranscriptNum - startTranscriptNum <=
+                  KEEP_WORKER_INITIAL * FORCED_SNAPSHOT_INTERVAL)
+            ),
+        )
+        .map(async workerData => {
+          workers.splice(workers.indexOf(workerData), 1);
+
+          const {
+            manager,
+            xsnapPID,
+            deliveryTimeSinceLastSnapshot,
+            deliveryTimeTotal,
+            firstTranscriptNum,
+          } = workerData;
+          // eslint-disable-next-line no-await-in-loop
+          await manager.shutdown();
+          console.log(
+            `Shutdown worker PID ${xsnapPID} (first transcript num ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
+              Math.round(deliveryTimeSinceLastSnapshot) / 1000
+            }s. Delivery time total ${
+              Math.round(deliveryTimeTotal) / 1000
+            }s. Up ${
+              lastTranscriptNum - (firstTranscriptNum ?? NaN)
+            } deliveries.`,
+          );
+        }),
+    );
     loadSnapshotID = data.snapshotID;
     if (snapshotOverrideMap.has(loadSnapshotID)) {
       loadSnapshotID = snapshotOverrideMap.get(loadSnapshotID);
@@ -575,6 +598,9 @@ async function replay(transcriptFile) {
     } else {
       const { transcriptNum, d: delivery, syscalls } = data;
       lastTranscriptNum = transcriptNum;
+      if (startTranscriptNum == null) {
+        startTranscriptNum = transcriptNum;
+      }
       const makeSnapshot =
         FORCED_SNAPSHOT_INTERVAL &&
         (transcriptNum - FORCED_SNAPSHOT_INITIAL) % FORCED_SNAPSHOT_INTERVAL ===
@@ -637,7 +663,9 @@ async function replay(transcriptFile) {
           }
         }),
       );
-      const uniqueSnapshotIDs = [...new Set(snapshotIDs)];
+      const uniqueSnapshotIDs = [...new Set(snapshotIDs)].filter(
+        snapshotID => snapshotID != null,
+      );
 
       if (makeSnapshot && uniqueSnapshotIDs.length !== 1) {
         const errorMessage = `Snapshot hashes do not match each other: ${uniqueSnapshotIDs.join(
@@ -650,12 +678,15 @@ async function replay(transcriptFile) {
         }
       }
 
-      const snapshotID = uniqueSnapshotIDs[0];
-      if (snapshotID && FORCED_RELOAD_FROM_SNAPSHOT) {
-        await loadSnapshot({
-          snapshotID,
-          vatID,
-        });
+      if (FORCED_RELOAD_FROM_SNAPSHOT) {
+        await Promise.all(
+          uniqueSnapshotIDs.map(async snapshotID =>
+            loadSnapshot({
+              snapshotID,
+              vatID,
+            }),
+          ),
+        );
       }
     }
   }
@@ -673,7 +704,7 @@ async function replay(transcriptFile) {
       }) => {
         await manager.shutdown();
         console.log(
-          `Shutdown worker PID ${xsnapPID}.\n    Delivery time since last snapshot ${
+          `Shutdown worker PID ${xsnapPID} (first transcript num ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
             Math.round(deliveryTimeSinceLastSnapshot) / 1000
           }s. Delivery time total ${
             Math.round(deliveryTimeTotal) / 1000

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -641,6 +641,10 @@ async function replay(transcriptFile) {
           vatParameters,
           compareSyscalls: makeCompareSyscalls(workerData),
           useTranscript: true,
+          workerOptions: {
+            type: worker === 'xs-worker' ? 'xsnap' : worker,
+            bundleIDs: [],
+          },
         })
       );
     workerData.manager = await factory.createFromBundle(

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -111,6 +111,8 @@ async function replay(transcriptFile) {
   let lastTranscriptNum = 0;
   const snapshotOverrideMap = new Map();
 
+  const snapshotActivityFd = fs.openSync('snapshot-activity.jsonl', 'a');
+
   const fakeKernelKeeper =
     /** @type {import('../src/types-external.js').KernelKeeper} */ ({
       provideVatKeeper: _vatID =>
@@ -278,6 +280,17 @@ async function replay(transcriptFile) {
       console.log(
         `created manager from snapshot ${loadSnapshotID}, worker PID: ${xsnapPID}`,
       );
+      fs.writeSync(
+        snapshotActivityFd,
+        `${JSON.stringify({
+          transcriptFile,
+          type: 'load',
+          xsnapPID,
+          vatID,
+          snapshotID: data.snapshotID,
+          loadSnapshotID,
+        })}\n`,
+      );
       loadSnapshotID = null;
     } else if (!manager) {
       if (data.type !== 'create-vat') {
@@ -291,11 +304,32 @@ async function replay(transcriptFile) {
       console.log(
         `manager created from bundle source, worker PID: ${xsnapPID}`,
       );
+      fs.writeSync(
+        snapshotActivityFd,
+        `${JSON.stringify({
+          transcriptFile,
+          type: 'create',
+          xsnapPID,
+          vatID,
+        })}\n`,
+      );
     } else if (data.type === 'heap-snapshot-save') {
       if (!manager.makeSnapshot) continue; // eslint-disable-line no-continue
       saveSnapshotID = data.snapshotID;
       const { hash } = await manager.makeSnapshot(lastTranscriptNum, snapStore);
       snapshotOverrideMap.set(saveSnapshotID, hash);
+      fs.writeSync(
+        snapshotActivityFd,
+        `${JSON.stringify({
+          transcriptFile,
+          type: 'save',
+          xsnapPID,
+          vatID,
+          transcriptNum: lastTranscriptNum,
+          snapshotID: hash,
+          saveSnapshotID,
+        })}\n`,
+      );
       if (hash !== saveSnapshotID) {
         const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID}`;
         if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
@@ -345,6 +379,7 @@ async function replay(transcriptFile) {
   }
 
   lines.close();
+  fs.closeSync(snapshotActivityFd);
   if (manager) {
     await manager.shutdown();
   }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -186,6 +186,7 @@ async function replay(transcriptFile) {
    *  deliveryTimeTotal: number;
    *  deliveryTimeSinceLastSnapshot: number;
    *  loadSnapshotID: string | undefined;
+   *  timeOfLastCommand: number;
    *  keep: boolean;
    *  firstTranscriptNum: number | null;
    * }} WorkerData
@@ -321,6 +322,13 @@ async function replay(transcriptFile) {
     );
   }
 
+  const updateDeliveryTime = workerData => {
+    const deliveryTime = performance.now() - workerData.timeOfLastCommand;
+    workerData.timeOfLastCommand = NaN;
+    workerData.deliveryTimeTotal += deliveryTime;
+    workerData.deliveryTimeSinceLastSnapshot += deliveryTime;
+  };
+
   /** @type {Map<string, import('@agoric/swingset-liveslots').VatSyscallResult | undefined>} */
   const knownVCSyscalls = new Map();
 
@@ -345,8 +353,13 @@ async function replay(transcriptFile) {
    * @param {WorkerData} workerData
    * @returns {import('../src/kernel/vat-loader/transcript.js').CompareSyscalls}
    */
-  const makeCompareSyscalls =
-    workerData => (_vatID, originalSyscall, newSyscall, originalResponse) => {
+  const makeCompareSyscalls = workerData => {
+    const doCompare = (
+      _vatID,
+      originalSyscall,
+      newSyscall,
+      originalResponse,
+    ) => {
       const error = bestRequireIdentical(vatID, originalSyscall, newSyscall);
       if (
         error &&
@@ -403,6 +416,24 @@ async function replay(transcriptFile) {
 
       return error;
     };
+    const compareSyscalls = (
+      _vatID,
+      originalSyscall,
+      newSyscall,
+      originalResponse,
+    ) => {
+      updateDeliveryTime(workerData);
+      const result = doCompare(
+        _vatID,
+        originalSyscall,
+        newSyscall,
+        originalResponse,
+      );
+      workerData.timeOfLastCommand = performance.now();
+      return result;
+    };
+    return compareSyscalls;
+  };
 
   let vatParameters;
   let vatSourceBundle;
@@ -417,6 +448,7 @@ async function replay(transcriptFile) {
       xsnapPID: NaN,
       deliveryTimeTotal: 0,
       deliveryTimeSinceLastSnapshot: 0,
+      timeOfLastCommand: NaN,
       loadSnapshotID,
       keep,
       firstTranscriptNum: null,
@@ -680,14 +712,12 @@ async function replay(transcriptFile) {
       //     JSON.stringify(s.response[1]).slice(0, 200),
       //   );
       // }
-      const start = performance.now();
       const snapshotIDs = await Promise.all(
         workers.map(async workerData => {
           const { manager, xsnapPID } = workerData;
+          workerData.timeOfLastCommand = performance.now();
           await manager.replayOneDelivery(delivery, syscalls, transcriptNum);
-          const deliveryTime = performance.now() - start;
-          workerData.deliveryTimeTotal += deliveryTime;
-          workerData.deliveryTimeSinceLastSnapshot += deliveryTime;
+          updateDeliveryTime(workerData);
           workerData.firstTranscriptNum ??= transcriptNum - 1;
 
           // console.log(`dr`, dr);

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -675,243 +675,246 @@ async function replay(transcriptFile) {
   }
   const lines = readline.createInterface({ input: transcriptF });
   let lineNumber = 1;
-  for await (const line of lines) {
-    if (lineNumber % 1000 === 0) {
-      console.log(` (slog line ${lineNumber})`);
-    }
-    lineNumber += 1;
-    const data = JSON.parse(line);
-    if (data.type === 'heap-snapshot-load') {
-      if (worker === 'xs-worker') {
-        await loadSnapshot(data, KEEP_WORKER_EXPLICIT_LOAD);
+  try {
+    for await (const line of lines) {
+      if (lineNumber % 1000 === 0) {
+        console.log(` (slog line ${lineNumber})`);
+      }
+      lineNumber += 1;
+      const data = JSON.parse(line);
+      if (data.type === 'heap-snapshot-load') {
+        if (worker === 'xs-worker') {
+          await loadSnapshot(data, KEEP_WORKER_EXPLICIT_LOAD);
+        } else if (!workers.length) {
+          throw Error(
+            `Cannot replay transcript in ${worker} starting with a heap snapshot load.`,
+          );
+        }
       } else if (!workers.length) {
-        throw Error(
-          `Cannot replay transcript in ${worker} starting with a heap snapshot load.`,
-        );
-      }
-    } else if (!workers.length) {
-      if (data.type !== 'create-vat') {
-        throw Error(
-          `first line of transcript was not a create-vat or heap-snapshot-load`,
-        );
-      }
-      ({ vatParameters, vatSourceBundle } = data);
-      vatID = data.vatID;
-      const { xsnapPID } = await createManager(KEEP_WORKER_EXPLICIT_LOAD);
-      console.log(
-        `manager created from bundle source, worker PID: ${xsnapPID}`,
-      );
-      fs.writeSync(
-        snapshotActivityFd,
-        `${JSON.stringify({
-          transcriptFile,
-          type: 'create',
-          xsnapPID,
-          vatID,
-        })}\n`,
-      );
-    } else if (data.type === 'heap-snapshot-save') {
-      saveSnapshotID = data.snapshotID;
-
-      /** @param {WorkerData} workerData */
-      const doWorkerSnapshot = async workerData => {
-        const { manager, xsnapPID, firstTranscriptNum } = workerData;
-        if (!manager.makeSnapshot) return null;
-        const { hash, rawSaveSeconds } = await manager.makeSnapshot(
-          lastTranscriptNum,
-          snapStore,
+        if (data.type !== 'create-vat') {
+          throw Error(
+            `first line of transcript was not a create-vat or heap-snapshot-load`,
+          );
+        }
+        ({ vatParameters, vatSourceBundle } = data);
+        vatID = data.vatID;
+        const { xsnapPID } = await createManager(KEEP_WORKER_EXPLICIT_LOAD);
+        console.log(
+          `manager created from bundle source, worker PID: ${xsnapPID}`,
         );
         fs.writeSync(
           snapshotActivityFd,
           `${JSON.stringify({
             transcriptFile,
-            type: 'save',
+            type: 'create',
             xsnapPID,
             vatID,
-            transcriptNum: lastTranscriptNum,
-            snapshotID: hash,
-            saveSnapshotID,
           })}\n`,
         );
-        if (hash !== saveSnapshotID) {
-          const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID} for worker PID ${xsnapPID} (start delivery ${firstTranscriptNum})`;
+      } else if (data.type === 'heap-snapshot-save') {
+        saveSnapshotID = data.snapshotID;
+
+        /** @param {WorkerData} workerData */
+        const doWorkerSnapshot = async workerData => {
+          const { manager, xsnapPID, firstTranscriptNum } = workerData;
+          if (!manager.makeSnapshot) return null;
+          const { hash, rawSaveSeconds } = await manager.makeSnapshot(
+            lastTranscriptNum,
+            snapStore,
+          );
+          fs.writeSync(
+            snapshotActivityFd,
+            `${JSON.stringify({
+              transcriptFile,
+              type: 'save',
+              xsnapPID,
+              vatID,
+              transcriptNum: lastTranscriptNum,
+              snapshotID: hash,
+              saveSnapshotID,
+            })}\n`,
+          );
+          if (hash !== saveSnapshotID) {
+            const errorMessage = `Snapshot hash does not match. ${hash} !== ${saveSnapshotID} for worker PID ${xsnapPID} (start delivery ${firstTranscriptNum})`;
+            if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
+              console.warn(errorMessage);
+            } else {
+              throw new Error(errorMessage);
+            }
+          } else {
+            console.log(
+              `made snapshot ${hash} of worker PID ${xsnapPID} (start delivery ${firstTranscriptNum}).\n    Save time = ${
+                Math.round(rawSaveSeconds * 1000) / 1000
+              }s. Delivery time since last snapshot ${
+                Math.round(workerData.deliveryTimeSinceLastSnapshot) / 1000
+              }s. Up ${
+                lastTranscriptNum - (workerData.firstTranscriptNum ?? NaN)
+              } deliveries.`,
+            );
+          }
+          workerData.deliveryTimeSinceLastSnapshot = 0;
+          return hash;
+        };
+        const savedSnapshots = await (USE_CUSTOM_SNAP_STORE
+          ? workers.reduce(
+              async (hashes, workerData) => [
+                ...(await hashes),
+                await doWorkerSnapshot(workerData),
+              ],
+              Promise.resolve(/** @type {(string| null)[]} */ ([])),
+            )
+          : Promise.all(workers.map(doWorkerSnapshot)));
+        saveSnapshotID = null;
+
+        const uniqueSnapshotIDs = new Set(savedSnapshots);
+        let divergent = uniqueSnapshotIDs.size > 1;
+        if (
+          !uniqueSnapshotIDs.has(data.snapshotID) &&
+          (divergent || savedSnapshots[0] !== null)
+        ) {
+          divergent = true;
+          snapshotOverrideMap.set(
+            data.snapshotID,
+            /** @type {string} */ (savedSnapshots[0]),
+          );
+        }
+        if (FORCED_RELOAD_FROM_SNAPSHOT) {
+          for (const snapshotID of uniqueSnapshotIDs) {
+            // eslint-disable-next-line no-await-in-loop
+            await loadSnapshot(
+              { ...data, snapshotID },
+              KEEP_WORKER_DIVERGENT_SNAPSHOTS && divergent,
+            );
+          }
+        }
+      } else {
+        const { transcriptNum, d: delivery, syscalls } = data;
+        lastTranscriptNum = transcriptNum;
+        if (startTranscriptNum == null) {
+          startTranscriptNum = transcriptNum - 1;
+        }
+        const makeSnapshot =
+          FORCED_SNAPSHOT_INTERVAL &&
+          (transcriptNum - FORCED_SNAPSHOT_INITIAL) %
+            FORCED_SNAPSHOT_INTERVAL ===
+            0;
+        // syscalls = [{ d, response }, ..]
+        // console.log(`replaying:`);
+        // console.log(
+        //   `delivery ${transcriptNum} (L ${lineNumber}):`,
+        //   JSON.stringify(delivery).slice(0, 200),
+        // );
+        // for (const s of syscalls) {
+        //   // s.response = 'nope';
+        //   console.log(
+        //     ` syscall:`,
+        //     s.response[0],
+        //     JSON.stringify(s.d).slice(0, 200),
+        //     JSON.stringify(s.response[1]).slice(0, 200),
+        //   );
+        // }
+        const snapshotIDs = await Promise.all(
+          workers.map(async workerData => {
+            const { manager, xsnapPID } = workerData;
+            workerData.timeOfLastCommand = performance.now();
+            await manager.replayOneDelivery(delivery, syscalls, transcriptNum);
+            updateDeliveryTime(workerData);
+            workerData.firstTranscriptNum ??= transcriptNum - 1;
+            completeWorkerStep(workerData);
+            await workersSynced;
+
+            // console.log(`dr`, dr);
+
+            // enable this to write periodic snapshots, for #5975 leak
+            if (makeSnapshot && manager.makeSnapshot) {
+              const { hash: snapshotID, rawSaveSeconds } =
+                await manager.makeSnapshot(transcriptNum, snapStore);
+              fs.writeSync(
+                snapshotActivityFd,
+                `${JSON.stringify({
+                  transcriptFile,
+                  type: 'save',
+                  xsnapPID,
+                  vatID,
+                  transcriptNum,
+                  snapshotID,
+                })}\n`,
+              );
+              console.log(
+                `made snapshot ${snapshotID} after delivery ${transcriptNum} to worker PID ${xsnapPID} (start delivery ${
+                  workerData.firstTranscriptNum
+                }).\n    Save time = ${
+                  Math.round(rawSaveSeconds * 1000) / 1000
+                }s. Delivery time since last snapshot ${
+                  Math.round(workerData.deliveryTimeSinceLastSnapshot) / 1000
+                }s. Up ${
+                  transcriptNum - workerData.firstTranscriptNum
+                } deliveries.`,
+              );
+              workerData.deliveryTimeSinceLastSnapshot = 0;
+              return snapshotID;
+            } else {
+              return null;
+            }
+          }),
+        );
+        const uniqueSnapshotIDs = [...new Set(snapshotIDs)].filter(
+          snapshotID => snapshotID != null,
+        );
+
+        const divergent = uniqueSnapshotIDs.length !== 1;
+
+        if (makeSnapshot && divergent) {
+          const errorMessage = `Snapshot hashes do not match each other: ${uniqueSnapshotIDs.join(
+            ', ',
+          )}`;
           if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
             console.warn(errorMessage);
           } else {
             throw new Error(errorMessage);
           }
-        } else {
-          console.log(
-            `made snapshot ${hash} of worker PID ${xsnapPID} (start delivery ${firstTranscriptNum}).\n    Save time = ${
-              Math.round(rawSaveSeconds * 1000) / 1000
-            }s. Delivery time since last snapshot ${
-              Math.round(workerData.deliveryTimeSinceLastSnapshot) / 1000
-            }s. Up ${
-              lastTranscriptNum - (workerData.firstTranscriptNum ?? NaN)
-            } deliveries.`,
-          );
         }
-        workerData.deliveryTimeSinceLastSnapshot = 0;
-        return hash;
-      };
-      const savedSnapshots = await (USE_CUSTOM_SNAP_STORE
-        ? workers.reduce(
-            async (hashes, workerData) => [
-              ...(await hashes),
-              await doWorkerSnapshot(workerData),
-            ],
-            Promise.resolve(/** @type {(string| null)[]} */ ([])),
-          )
-        : Promise.all(workers.map(doWorkerSnapshot)));
-      saveSnapshotID = null;
 
-      const uniqueSnapshotIDs = new Set(savedSnapshots);
-      let divergent = uniqueSnapshotIDs.size > 1;
-      if (
-        !uniqueSnapshotIDs.has(data.snapshotID) &&
-        (divergent || savedSnapshots[0] !== null)
-      ) {
-        divergent = true;
-        snapshotOverrideMap.set(
-          data.snapshotID,
-          /** @type {string} */ (savedSnapshots[0]),
-        );
-      }
-      if (FORCED_RELOAD_FROM_SNAPSHOT) {
-        for (const snapshotID of uniqueSnapshotIDs) {
-          // eslint-disable-next-line no-await-in-loop
-          await loadSnapshot(
-            { ...data, snapshotID },
-            KEEP_WORKER_DIVERGENT_SNAPSHOTS && divergent,
-          );
-        }
-      }
-    } else {
-      const { transcriptNum, d: delivery, syscalls } = data;
-      lastTranscriptNum = transcriptNum;
-      if (startTranscriptNum == null) {
-        startTranscriptNum = transcriptNum - 1;
-      }
-      const makeSnapshot =
-        FORCED_SNAPSHOT_INTERVAL &&
-        (transcriptNum - FORCED_SNAPSHOT_INITIAL) % FORCED_SNAPSHOT_INTERVAL ===
-          0;
-      // syscalls = [{ d, response }, ..]
-      // console.log(`replaying:`);
-      // console.log(
-      //   `delivery ${transcriptNum} (L ${lineNumber}):`,
-      //   JSON.stringify(delivery).slice(0, 200),
-      // );
-      // for (const s of syscalls) {
-      //   // s.response = 'nope';
-      //   console.log(
-      //     ` syscall:`,
-      //     s.response[0],
-      //     JSON.stringify(s.d).slice(0, 200),
-      //     JSON.stringify(s.response[1]).slice(0, 200),
-      //   );
-      // }
-      const snapshotIDs = await Promise.all(
-        workers.map(async workerData => {
-          const { manager, xsnapPID } = workerData;
-          workerData.timeOfLastCommand = performance.now();
-          await manager.replayOneDelivery(delivery, syscalls, transcriptNum);
-          updateDeliveryTime(workerData);
-          workerData.firstTranscriptNum ??= transcriptNum - 1;
-          completeWorkerStep(workerData);
-          await workersSynced;
-
-          // console.log(`dr`, dr);
-
-          // enable this to write periodic snapshots, for #5975 leak
-          if (makeSnapshot && manager.makeSnapshot) {
-            const { hash: snapshotID, rawSaveSeconds } =
-              await manager.makeSnapshot(transcriptNum, snapStore);
-            fs.writeSync(
-              snapshotActivityFd,
-              `${JSON.stringify({
-                transcriptFile,
-                type: 'save',
-                xsnapPID,
-                vatID,
-                transcriptNum,
+        if (FORCED_RELOAD_FROM_SNAPSHOT) {
+          for (const snapshotID of uniqueSnapshotIDs) {
+            // eslint-disable-next-line no-await-in-loop
+            await loadSnapshot(
+              {
                 snapshotID,
-              })}\n`,
+                vatID,
+              },
+              KEEP_WORKER_DIVERGENT_SNAPSHOTS && divergent,
             );
-            console.log(
-              `made snapshot ${snapshotID} after delivery ${transcriptNum} to worker PID ${xsnapPID} (start delivery ${
-                workerData.firstTranscriptNum
-              }).\n    Save time = ${
-                Math.round(rawSaveSeconds * 1000) / 1000
-              }s. Delivery time since last snapshot ${
-                Math.round(workerData.deliveryTimeSinceLastSnapshot) / 1000
-              }s. Up ${
-                transcriptNum - workerData.firstTranscriptNum
-              } deliveries.`,
-            );
-            workerData.deliveryTimeSinceLastSnapshot = 0;
-            return snapshotID;
-          } else {
-            return null;
           }
-        }),
-      );
-      const uniqueSnapshotIDs = [...new Set(snapshotIDs)].filter(
-        snapshotID => snapshotID != null,
-      );
-
-      const divergent = uniqueSnapshotIDs.length !== 1;
-
-      if (makeSnapshot && divergent) {
-        const errorMessage = `Snapshot hashes do not match each other: ${uniqueSnapshotIDs.join(
-          ', ',
-        )}`;
-        if (IGNORE_SNAPSHOT_HASH_DIFFERENCES) {
-          console.warn(errorMessage);
-        } else {
-          throw new Error(errorMessage);
-        }
-      }
-
-      if (FORCED_RELOAD_FROM_SNAPSHOT) {
-        for (const snapshotID of uniqueSnapshotIDs) {
-          // eslint-disable-next-line no-await-in-loop
-          await loadSnapshot(
-            {
-              snapshotID,
-              vatID,
-            },
-            KEEP_WORKER_DIVERGENT_SNAPSHOTS && divergent,
-          );
         }
       }
     }
+  } finally {
+    lines.close();
+    fs.closeSync(snapshotActivityFd);
+    await Promise.all(
+      workers.map(
+        async ({
+          xsnapPID,
+          manager,
+          deliveryTimeSinceLastSnapshot,
+          deliveryTimeTotal,
+          firstTranscriptNum,
+        }) => {
+          await manager.shutdown();
+          console.log(
+            `Shutdown worker PID ${xsnapPID} (start delivery ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
+              Math.round(deliveryTimeSinceLastSnapshot) / 1000
+            }s. Delivery time total ${
+              Math.round(deliveryTimeTotal) / 1000
+            }s. Up ${
+              lastTranscriptNum - (firstTranscriptNum ?? NaN)
+            } deliveries.`,
+          );
+        },
+      ),
+    );
   }
-
-  lines.close();
-  fs.closeSync(snapshotActivityFd);
-  await Promise.all(
-    workers.map(
-      async ({
-        xsnapPID,
-        manager,
-        deliveryTimeSinceLastSnapshot,
-        deliveryTimeTotal,
-        firstTranscriptNum,
-      }) => {
-        await manager.shutdown();
-        console.log(
-          `Shutdown worker PID ${xsnapPID} (start delivery ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
-            Math.round(deliveryTimeSinceLastSnapshot) / 1000
-          }s. Delivery time total ${
-            Math.round(deliveryTimeTotal) / 1000
-          }s. Up ${
-            lastTranscriptNum - (firstTranscriptNum ?? NaN)
-          } deliveries.`,
-        );
-      },
-    ),
-  );
 }
 
 async function run() {
@@ -926,4 +929,7 @@ async function run() {
   await replay(transcriptFile);
 }
 
-run().catch(err => console.log('RUN ERR', err));
+run().catch(err => {
+  console.log('RUN ERR', err);
+  process.exit(process.exitCode || 1);
+});

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -25,7 +25,8 @@
     "@types/microtime": "^2.1.0",
     "@types/tmp": "^0.2.0",
     "better-sqlite3": "^8.2.0",
-    "tmp": "^0.2.1"
+    "tmp": "^0.2.1",
+    "yargs-parser": "^21.1.1"
   },
   "dependencies": {
     "@agoric/assert": "^0.5.1",

--- a/packages/SwingSet/src/controller/startXSnap.js
+++ b/packages/SwingSet/src/controller/startXSnap.js
@@ -90,10 +90,13 @@ export function makeStartXSnap(options) {
     // console.log('fresh xsnap', { snapStore: snapStore });
     const worker = doXSnap({ handleCommand, name, ...meterOpts, ...xsnapOpts });
 
-    const bundlePs = bundleIDs.map(id => bundleHandler.getBundle(id));
-    let bundles = await Promise.all(bundlePs);
+    let bundles;
     if (overrideBundles) {
-      bundles = overrideBundles; // replace the usual bundles
+      bundles = overrideBundles; // ignore the usual bundles
+    } else {
+      const bundlePs = bundleIDs.map(id => bundleHandler.getBundle(id));
+      // eslint-disable-next-line @jessie.js/no-nested-await
+      bundles = await Promise.all(bundlePs);
     }
 
     for (const bundle of bundles) {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -109,7 +109,7 @@ import { makeTranscriptManager } from './transcript.js';
  * @param {KernelSlog} kernelSlog
  * @param {(vso: VatSyscallObject) => VatSyscallResult} vatSyscallHandler
  * @param {boolean} workerCanBlock
- * @param {(vatID: any, originalSyscall: any, newSyscall: any) => Error | undefined} [compareSyscalls]
+ * @param {import('./transcript.js').CompareSyscalls} [compareSyscalls]
  * @param {boolean} [useTranscript]
  * @returns {ManagerKit}
  */
@@ -125,6 +125,7 @@ function makeManagerKit(
 ) {
   assert(kernelSlog);
   const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
+  /** @type {ReturnType<typeof makeTranscriptManager> | undefined} */
   let transcriptManager;
   if (useTranscript) {
     transcriptManager = makeTranscriptManager(
@@ -238,7 +239,6 @@ function makeManagerKit(
    * just direct).
    *
    * @param {VatSyscallObject} vso
-   * @returns {VatSyscallResult}
    */
   function syscallFromWorker(vso) {
     if (transcriptManager && transcriptManager.inReplay()) {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -267,7 +267,7 @@ function makeManagerKit(
   /**
    *
    * @param { () => Promise<void>} shutdown
-   * @param {(endPos: number, ss: SnapStore) => Promise<SnapshotResult>} makeSnapshot
+   * @param {(endPos: number, ss: SnapStore) => Promise<SnapshotResult>} [makeSnapshot]
    * @returns {VatManager}
    */
   function getManager(shutdown, makeSnapshot) {

--- a/packages/SwingSet/src/kernel/vat-loader/transcript.js
+++ b/packages/SwingSet/src/kernel/vat-loader/transcript.js
@@ -1,5 +1,25 @@
+// @ts-check
+
 import djson from '../../lib/djson.js';
 
+/** @typedef {import('@agoric/swingset-liveslots').VatSyscallObject} VatSyscallObject */
+/** @typedef {import('@agoric/swingset-liveslots').VatSyscallResult} VatSyscallResult */
+
+/** @typedef {Error | undefined} CompareSyscallsResult */
+/**
+ * @typedef {(
+ *     vatId: any,
+ *     originalSyscall: VatSyscallObject,
+ *     newSyscall: VatSyscallObject,
+ *   ) => CompareSyscallsResult
+ * } CompareSyscalls
+ */
+
+/**
+ * @param {any} vatID
+ * @param {VatSyscallObject} originalSyscall
+ * @param {VatSyscallObject} newSyscall
+ */
 export function requireIdentical(vatID, originalSyscall, newSyscall) {
   if (djson.stringify(originalSyscall) !== djson.stringify(newSyscall)) {
     console.error(`anachrophobia strikes vat ${vatID}`);
@@ -10,6 +30,11 @@ export function requireIdentical(vatID, originalSyscall, newSyscall) {
   return undefined;
 }
 
+/**
+ * @param {*} vatKeeper
+ * @param {*} vatID
+ * @param {CompareSyscalls} compareSyscalls
+ */
 export function makeTranscriptManager(
   vatKeeper,
   vatID,
@@ -58,7 +83,9 @@ export function makeTranscriptManager(
 
   let replayError;
 
+  /** @param {VatSyscallObject} newSyscall */
   function simulateSyscall(newSyscall) {
+    /** @type {{d: VatSyscallObject; response: VatSyscallResult}} */
     const s = playbackSyscalls.shift();
     const newReplayError = compareSyscalls(vatID, s.d, newSyscall);
     if (newReplayError) {

--- a/packages/SwingSet/src/types-internal.js
+++ b/packages/SwingSet/src/types-internal.js
@@ -34,7 +34,7 @@ export {};
  *   enableDisavow: boolean,
  *   useTranscript: boolean,
  *   name: string,
- *   compareSyscalls?: (originalSyscall: {}, newSyscall: {}) => Error | undefined,
+ *   compareSyscalls?: import('./kernel/vat-loader/transcript.js').CompareSyscalls,
  *   sourcedConsole: Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>,
  *   enableSetup: boolean,
  *   setup?: unknown,

--- a/packages/SwingSet/src/types-internal.js
+++ b/packages/SwingSet/src/types-internal.js
@@ -20,6 +20,7 @@ export {};
  * @typedef { import('./types-external.js').OptEnableDisavow } OptEnableDisavow
  * @typedef { import('@agoric/swingset-liveslots').VatDeliveryObject } VatDeliveryObject
  * @typedef { import('@agoric/swingset-liveslots').VatDeliveryResult } VatDeliveryResult
+ * @typedef { import('@agoric/swingset-liveslots').VatSyscallObject } VatSyscallObject
  *
  * // used by vatKeeper.setSourceAndOptions(source, RecordedVatOptions)
  *
@@ -42,8 +43,9 @@ export {};
  * }} ManagerOptions
  *
  * @typedef { { deliver: (delivery: VatDeliveryObject) => Promise<VatDeliveryResult>,
+ *              replayOneDelivery: (delivery: VatDeliveryObject, expectedSyscalls: VatSyscallObject[], deliveryNum: number) => Promise<VatDeliveryResult>,
  *              replayTranscript: (startPos: number | undefined) => Promise<number?>,
- *              makeSnapshot?: (endPos: number, ss: SnapStore) => Promise<SnapshotResult>,
+ *              makeSnapshot?: undefined | ((endPos: number, ss: SnapStore) => Promise<SnapshotResult>),
  *              shutdown: () => Promise<void>,
  *            } } VatManager
  * @typedef { { createFromBundle: (vatID: string,

--- a/packages/internal/src/queue.js
+++ b/packages/internal/src/queue.js
@@ -27,7 +27,16 @@ export const makeWithQueue = () => {
       });
   };
 
+  /**
+   * @template {any[]} T
+   * @template R
+   * @param {(...args: T) => Promise<R>} inner
+   */
   return function withQueue(inner) {
+    /**
+     * @param {T} args
+     * @returns {Promise<R>}
+     */
     return function queueCall(...args) {
       // Curry the arguments into the inner function, and
       // resolve/reject with whatever the inner function does.


### PR DESCRIPTION
refs: #6723

## Description

This is a port of the replay tool changes only of #6723, adapted for the changes in master since the pismo fork.
The changes to the extract transcript tools needed more independent work and were extracted into a separate PR: https://github.com/Agoric/agoric-sdk/pull/7434.
This does include some changes layered on top of the rebase, to make the replay tool working correctly with the new snapstore abstraction, and support the new bundle handling.

<details>
<summary>
Changes compared to original PR
</summary>

Diff of the [ported commits](https://github.com/Agoric/agoric-sdk/compare/c832a55a303dbe2f1ae750c9f6a4874ea570998c..0daf6c38f7456c9826254b177d8058e001efb054) vs [original PR](https://github.com/Agoric/agoric-sdk/commit/a756bb6611d61810068186d792dfa4a876fc208d):

```diff
--- original.diff	2023-04-17 14:55:26.487024034 +0000
+++ port.diff	2023-04-17 14:54:53.924963016 +0000
@@ -1,123 +1,68 @@
-diff --git a/packages/SwingSet/misc-tools/extract-transcript-from-kerneldb.js b/packages/SwingSet/misc-tools/extract-transcript-from-kerneldb.js
-index 107dcc704..528337fe7 100644
---- a/packages/SwingSet/misc-tools/extract-transcript-from-kerneldb.js
-+++ b/packages/SwingSet/misc-tools/extract-transcript-from-kerneldb.js
-@@ -54,6 +54,9 @@ if (!vatName) {
-       )} ${len.padStart(10)} deliveries`,
-     );
-   }
-+} else if (/(supervisor|lockdown)(B|-b)undle/.test(vatName)) {
-+  const bundle = kvStore.get(vatName.replace('-bundle', 'Bundle'));
-+  fs.writeFileSync(vatName.replace('Bundle', '-bundle'), bundle);
- } else {
-   let vatID = vatName;
-   if (allVatNames.indexOf(vatName) !== -1) {
-diff --git a/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js b/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
-index abdae8ad9..3674b83d6 100644
---- a/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
-+++ b/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
-@@ -47,7 +47,6 @@ async function run() {
-           vatParameters,
-           vatSourceBundle,
-         };
--        transcriptNum += 1;
-         // first line of transcript is the source bundle
-         fs.writeSync(fd, JSON.stringify(t));
-         fs.writeSync(fd, '\n');
-@@ -72,8 +71,8 @@ async function run() {
-       }
-       case 'deliver-result': {
-         console.log(` -- deliver-result`);
--        const entry = { transcriptNum, d: delivery, syscalls };
-         transcriptNum += 1;
-+        const entry = { transcriptNum, d: delivery, syscalls };
-         fs.writeSync(fd, JSON.stringify(entry));
-         fs.writeSync(fd, '\n');
-         break;
-@@ -82,7 +81,6 @@ async function run() {
-         console.log(' -- heap-snapshot-save');
-         const { type, snapshotID } = e;
-         const t = { transcriptNum, type, vatID, snapshotID };
--        transcriptNum += 1;
-         fs.writeSync(fd, JSON.stringify(t));
-         fs.writeSync(fd, '\n');
-         break;
 diff --git a/packages/SwingSet/misc-tools/replay-transcript.js b/packages/SwingSet/misc-tools/replay-transcript.js
-index f77a0a52a..2893270f8 100644
+index b0ffab84a..2df8c3318 100644
 --- a/packages/SwingSet/misc-tools/replay-transcript.js
 +++ b/packages/SwingSet/misc-tools/replay-transcript.js
 @@ -1,3 +1,5 @@
 +// @ts-check
 +
  /* global WeakRef FinalizationRegistry */
  /* eslint-disable no-constant-condition */
  import fs from 'fs';
-@@ -14,6 +16,8 @@ import { pipeline } from 'stream';
+@@ -13,6 +15,10 @@ import { pipeline } from 'stream';
  import { performance } from 'perf_hooks';
  // eslint-disable-next-line import/no-extraneous-dependencies
  import { file as tmpFile, tmpName } from 'tmp';
 +// eslint-disable-next-line import/no-extraneous-dependencies
++import sqlite3 from 'better-sqlite3';
++// eslint-disable-next-line import/no-extraneous-dependencies
 +import yargsParser from 'yargs-parser';
  import bundleSource from '@endo/bundle-source';
  import { makeMeasureSeconds } from '@agoric/internal';
  import { makeSnapStore } from '@agoric/swing-store';
-@@ -28,28 +32,124 @@ import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
+@@ -27,22 +33,115 @@ import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
  import { makeGcAndFinalize } from '../src/lib-nodejs/gc-and-finalize.js';
  import engineGC from '../src/lib-nodejs/engine-gc.js';
  
--// Set the absolute path of the SDK to use for bundling
--// This can help if there are symlinks in the path that should be respected
--// to match the path of the SDK that produced the initial transcript
--// For e.g. set to '/src' if replaying a docker based loadgen transcript
--const ABSOLUTE_SDK_PATH = null;
-+const pipe = promisify(pipeline);
-+
-+// TODO: switch to full yargs for documenting output
-+const argv = yargsParser(process.argv.slice(2), {
-+  string: [
-+    // Set the absolute path of the SDK to use for bundling
-+    // This can help if there are symlinks in the path that should be respected
-+    // to match the path of the SDK that produced the initial transcript
-+    // For e.g. set to '/src' if replaying a docker based loadgen transcript
-+    'absoluteSdkPath',
-+  ],
- 
 -// Rebuild the bundles when starting the replay.
 -// Disable if bundles were previously extracted form a Kernel DB, or
 -// to save a few seconds and rely upon previously built versions instead
 -const REBUILD_BUNDLES = false;
++const pipe = promisify(pipeline);
+ 
+-// Enable to continue if snapshot hash doesn't match transcript
+-const IGNORE_SNAPSHOT_HASH_DIFFERENCES = false;
++// TODO: switch to full yargs for documenting output
++const argv = yargsParser(process.argv.slice(2), {
 +  boolean: [
 +    // Rebuild the bundles when starting the replay.
 +    // Disable if bundles were previously extracted form a Kernel DB, or to
 +    // save a few seconds and rely upon previously built versions instead.
 +    'rebuildBundles',
  
--// Enable to continue if snapshot hash doesn't match transcript
--const IGNORE_SNAPSHOT_HASH_DIFFERENCES = false;
+-// Use a simplified snapstore which derives the snapshot filename from the
+-// transcript and doesn't compress the snapshot
+-const USE_CUSTOM_SNAP_STORE = true;
 +    // Enable to continue if snapshot hash doesn't match hash in transcript's
 +    // 'save', or when the hash of the concurrent workers snapshots don't all
 +    // match each other.
 +    'ignoreSnapshotHashDifference',
  
--// Use a simplified snapstore which derives the snapshot filename from the
--// transcript and doesn't compress the snapshot
--const USE_CUSTOM_SNAP_STORE = true;
+-// Enable to output xsnap debug traces corresponding to the transcript replay
+-const RECORD_XSNAP_TRACE = false;
 +    // Enable to continue if concurrent workers do not produce the exact same
 +    // set of syscalls for a delivery. With special virtual collection syscall
 +    // handling (see below), all workers would normally have to diverge from
 +    // the transcript in the same way for the delivery to be considered valid.
 +    'ignoreConcurrentWorkerDivergences',
  
--// Enable to output xsnap debug traces corresponding to the transcript replay
--const RECORD_XSNAP_TRACE = false;
+-const pipe = promisify(pipeline);
 +    // If a snapshot of a worker is taken, create a new worker from that
 +    // snapshot, even if no explicit snapshot load instruction is found in the
 +    // input transcript.
 +    'forcedReloadFromSnapshot',
- 
--const pipe = promisify(pipeline);
++
 +    // Mark workers loaded from an explicit transcript load instruction as
 +    // being ineligible from being reaped.
 +    'keepWorkerExplicitLoad',
 +
 +    // When `forcedReloadFromSnapshot` is enabled, if the hash of the/ snapshot
@@ -170,11 +115,10 @@
 +      key: 'keepWorkerTransactionNums',
 +      number: true,
 +    },
 +  ],
 +  default: {
-+    absoluteSdkPath: '',
 +    rebuildBundles: false,
 +    ignoreSnapshotHashDifference: true,
 +    ignoreConcurrentWorkerDivergences: true,
 +    forcedSnapshotInitial: 2,
 +    forcedSnapshotInterval: 1000,
@@ -201,20 +145,11 @@
 +  },
 +});
  
  /** @type {(filename: string) => Promise<string>} */
  async function fileHash(filename) {
-@@ -78,7 +178,7 @@ function makeSnapStoreIO() {
- async function makeBundles() {
-   const controllerUrl = new URL(
-     `${
--      ABSOLUTE_SDK_PATH ? `${ABSOLUTE_SDK_PATH}/packages/SwingSet` : '..'
-+      argv.absoluteSdkPath ? `${argv.absoluteSdkPath}/packages/SwingSet` : '..'
-     }/src/controller/initializeSwingset.js`,
-     import.meta.url,
-   );
-@@ -96,58 +196,64 @@ async function makeBundles() {
+@@ -78,58 +177,74 @@ async function makeBundles() {
    console.log(`xs bundles written`);
  }
  
 -function compareSyscalls(vatID, originalSyscall, newSyscall) {
 -  const error = requireIdentical(vatID, originalSyscall, newSyscall);
@@ -233,16 +168,16 @@
 +/** @type {import('../src/types-external.js').ManagerType} */
  const worker = 'xs-worker';
  
  async function replay(transcriptFile) {
    let vatID; // we learn this from the first line of the transcript
-+  /** @type {import('../src/types-external.js').VatManagerFactory} */
++  /** @type {import('../src/types-internal.js').VatManagerFactory} */
    let factory;
  
    let loadSnapshotID = null;
    let saveSnapshotID = null;
-+  let lastTranscriptNum;
++  let lastTranscriptNum = 0;
 +  let startTranscriptNum;
    const snapshotOverrideMap = new Map();
  
 -  const fakeKernelKeeper = {
 -    provideVatKeeper: _vatID => ({
@@ -256,10 +191,12 @@
 -    delivery: () => () => undefined,
 -    syscall: () => () => undefined,
 -  };
 -  const snapStore = USE_CUSTOM_SNAP_STORE
 -    ? {
+-        async save(saveRaw) {
+-          const snapFile = `${saveSnapshotID || 'unknown'}.xss`;
 +  const snapshotActivityFd = fs.openSync('snapshot-activity.jsonl', 'a');
 +
 +  const fakeKernelKeeper =
 +    /** @type {import('../src/types-external.js').KernelKeeper} */ ({
 +      provideVatKeeper: _vatID =>
@@ -282,35 +219,46 @@
 +      })
 +    );
 +
 +  const snapStore = argv.useCustomSnapStore
 +    ? /** @type {SnapStore} */ ({
-         async save(saveRaw) {
-           const snapFile = `${saveSnapshotID || 'unknown'}.xss`;
++        async saveSnapshot(_vatID, endPos, saveRaw) {
++          const snapFile = `${vatID}-${endPos}-${
++            saveSnapshotID || 'unknown'
++          }.xss`;
            await saveRaw(snapFile);
 -          const h = await fileHash(snapFile);
 -          await fs.promises.rename(snapFile, `${h}.xss`);
 -          return h;
 +          const hash = await fileHash(snapFile);
-+          const filePath = `${hash}.xss`;
++          const filePath = `${vatID}-${endPos}-${hash}.xss`;
 +          await fs.promises.rename(snapFile, filePath);
-+          return { hash, filePath };
++          return { hash };
          },
-         async load(hash, loadRaw) {
+-        async load(hash, loadRaw) {
++        async loadSnapshot(hash, loadRaw) {
            const snapFile = `${hash}.xss`;
            return loadRaw(snapFile);
          },
 -      }
--    : makeSnapStore(process.cwd(), makeSnapStoreIO());
+-    : makeSnapStore(process.cwd(), () => {}, makeSnapStoreIO());
 -  const testLog = undefined;
 +      })
-+    : makeSnapStore(process.cwd(), makeSnapStoreIO(), { keepSnapshots: true });
++    : makeSnapStore(
++        sqlite3(':memory:'),
++        () => {},
++        makeSnapStoreIO(),
++        undefined,
++        {
++          keepSnapshots: true,
++        },
++      );
 +  const testLog = () => {};
    const meterControl = makeDummyMeterControl();
    const gcTools = harden({
      WeakRef,
-@@ -156,36 +262,63 @@ async function replay(transcriptFile) {
+@@ -138,33 +253,59 @@ async function replay(transcriptFile) {
      gcAndFinalize: makeGcAndFinalize(engineGC),
      meterControl,
    });
 -  const allVatPowers = { testLog };
 -  let xsnapPID;
@@ -320,11 +268,11 @@
 +        testLog,
 +      })
 +    );
 +  /**
 +   * @typedef {{
-+   *  manager: import('../src/types-external.js').VatManager;
++   *  manager: import('../src/types-internal.js').VatManager;
 +   *  xsnapPID: number | undefined;
 +   *  deliveryTimeTotal: number;
 +   *  deliveryTimeSinceLastSnapshot: number;
 +   *  loadSnapshotID: string | undefined;
 +   *  timeOfLastCommand: number;
@@ -349,19 +297,10 @@
 -      JSON.parse(fs.readFileSync('lockdown-bundle')),
 -      JSON.parse(fs.readFileSync('supervisor-bundle')),
 +      JSON.parse(fs.readFileSync('lockdown-bundle', 'utf-8')),
 +      JSON.parse(fs.readFileSync('supervisor-bundle', 'utf-8')),
      ];
--    const env = {};
--    if (RECORD_XSNAP_TRACE) {
-+    const env = /** @type {Record<string, string>} */ ({});
-+    if (argv.recordXsnapTrace) {
-       env.XSNAP_TEST_RECORD = process.cwd();
-     }
-+    if (argv.useXsnapDebug) {
-+      env.XSNAP_DEBUG = 'true';
-+    }
  
 -    const capturePIDSpawn = (...args) => {
 -      const child = spawn(...args);
 -      xsnapPID = child.pid;
 -      return child;
@@ -372,35 +311,41 @@
 +        const child = spawn(...args);
 +        workers[workers.length - 1].xsnapPID = child.pid;
 +        return child;
 +      }
 +    );
-     const startXSnap = makeStartXSnap(bundles, {
+     const startXSnap = makeStartXSnap({
        snapStore,
-       env,
        spawn: capturePIDSpawn,
+-      workerTraceRootPath: RECORD_XSNAP_TRACE ? process.cwd() : undefined,
++      debug: argv.useXsnapDebug,
++      workerTraceRootPath: argv.recordXsnapTrace ? process.cwd() : undefined,
+       overrideBundles: bundles,
++      bundleHandler: /** @type {*} */ (undefined),
      });
      factory = makeXsSubprocessFactory({
 +      allVatPowers,
        kernelKeeper: fakeKernelKeeper,
        kernelSlog,
        startXSnap,
-@@ -219,134 +352,694 @@ async function replay(transcriptFile) {
+@@ -182,134 +323,708 @@ async function replay(transcriptFile) {
      throw Error(`unhandled worker type ${worker}`);
    }
  
 +  const [
 +    bestRequireIdentical,
 +    extraSyscall,
 +    missingSyscall,
 +    vcSyscallRE,
 +    supportsRelaxedSyscalls,
 +  ] = await (async () => {
++    /** @type {any} */
 +    const transcriptModule = await import(
 +      '../src/kernel/vat-loader/transcript.js'
 +    );
 +
++    /** @type {RegExp} */
 +    const syscallRE =
 +      transcriptModule.vcSyscallRE || /^vc\.\d+\.\|(?:schemata|label)$/;
 +
 +    if (
 +      typeof transcriptModule.requireIdenticalExceptStableVCSyscalls !==
@@ -413,30 +358,33 @@
 +        syscallRE,
 +        false,
 +      ];
 +    }
 +
++    /** @type {{requireIdenticalExceptStableVCSyscalls: import('../src/kernel/vat-loader/transcript.js').CompareSyscalls}} */
 +    const { requireIdenticalExceptStableVCSyscalls } = transcriptModule;
 +
 +    if (
 +      typeof transcriptModule.extraSyscall === 'symbol' &&
 +      typeof transcriptModule.missingSyscall === 'symbol'
 +    ) {
 +      return [
 +        requireIdenticalExceptStableVCSyscalls,
-+        transcriptModule.extraSyscall,
-+        transcriptModule.missingSyscall,
++        /** @type {symbol} */ (transcriptModule.extraSyscall),
++        /** @type {symbol} */ (transcriptModule.missingSyscall),
 +        syscallRE,
 +        true,
 +      ];
 +    }
 +
++    /** @type {unknown} */
 +    const dynamicExtraSyscall = requireIdenticalExceptStableVCSyscalls(
 +      'vat0',
 +      ['vatstoreGet', 'vc.0.|label'],
 +      ['vatstoreGet', 'ignoreExtraSyscall'],
 +    );
++    /** @type {unknown} */
 +    const dynamicMissingSyscall = requireIdenticalExceptStableVCSyscalls(
 +      'vat0',
 +      ['vatstoreGet', 'ignoreMissingSyscall'],
 +      ['vatstoreGet', 'vc.0.|label'],
 +    );
@@ -554,11 +502,11 @@
 +    workerData.timeOfLastCommand = NaN;
 +    workerData.deliveryTimeTotal += deliveryTime;
 +    workerData.deliveryTimeSinceLastSnapshot += deliveryTime;
 +  };
 +
-+  /** @type {Map<string, VatSyscallResult | undefined>} */
++  /** @type {Map<string, import('@agoric/swingset-liveslots').VatSyscallResult | undefined>} */
 +  const knownVCSyscalls = new Map();
 +
 +  /**
 +   * @param {import('../src/types-external.js').VatSyscallObject} vso
 +   */
@@ -598,18 +546,26 @@
 +      if (error) {
 +        console.error(
 +          `during transcript num= ${lastTranscriptNum} for worker PID ${workerData.xsnapPID} (start delivery ${workerData.firstTranscriptNum})`,
 +        );
 +
-+        if (error === extraSyscall && !argv.skipExtraVcSyscalls) {
++        if (
++          // @ts-expect-error may be a symbol in some versions
++          error === extraSyscall &&
++          !argv.skipExtraVcSyscalls
++        ) {
 +          return new Error('Extra syscall disallowed');
 +        }
 +      }
 +
 +      const newSyscallKind = newSyscall[0];
 +
-+      if (error === missingSyscall && !argv.simulateVcSyscalls) {
++      if (
++        // @ts-expect-error may be a symbol in some versions
++        error === missingSyscall &&
++        !argv.simulateVcSyscalls
++      ) {
 +        return new Error('Missing syscall disallowed');
 +      }
 +
 +      if (
 +        argv.simulateVcSyscalls &&
@@ -692,12 +648,12 @@
 -    manager = await factory.createFromBundle(
 +    completeWorkerStep(workerData);
 +    workers.push(workerData);
 +    updateWorkersSynced();
 +    const managerOptions =
-+      /** @type {import('../src/types-external.js').ManagerOptions} */ (
-+        /** @type {Partial<import('../src/types-external.js').ManagerOptions>} */ ({
++      /** @type {import('../src/types-internal.js').ManagerOptions} */ (
++        /** @type {Partial<import('../src/types-internal.js').ManagerOptions>} */ ({
 +          sourcedConsole: console,
 +          vatParameters,
 +          compareSyscalls: makeCompareSyscalls(workerData),
 +          useTranscript: true,
 +        })
@@ -936,10 +892,11 @@
 +        /** @param {WorkerData} workerData */
 +        const doWorkerSnapshot = async workerData => {
 +          const { manager, xsnapPID, firstTranscriptNum } = workerData;
 +          if (!manager.makeSnapshot) return null;
 +          const { hash, rawSaveSeconds } = await manager.makeSnapshot(
++            lastTranscriptNum,
 +            snapStore,
 +          );
 +          fs.writeSync(
 +            snapshotActivityFd,
 +            `${JSON.stringify({
@@ -977,11 +934,11 @@
 +          ? workers.reduce(
 +              async (hashes, workerData) => [
 +                ...(await hashes),
 +                await doWorkerSnapshot(workerData),
 +              ],
-+              Promise.resolve(/** @type {string[]} */ ([])),
++              Promise.resolve(/** @type {(string| null)[]} */ ([])),
 +            )
 +          : Promise.all(workers.map(doWorkerSnapshot)));
 +        saveSnapshotID = null;
  
 -  lines.close();
@@ -1047,11 +1004,11 @@
 +            // console.log(`dr`, dr);
 +
 +            // enable this to write periodic snapshots, for #5975 leak
 +            if (makeSnapshot && manager.makeSnapshot) {
 +              const { hash: snapshotID, rawSaveSeconds } =
-+                await manager.makeSnapshot(snapStore);
++                await manager.makeSnapshot(transcriptNum, snapStore);
 +              fs.writeSync(
 +                snapshotActivityFd,
 +                `${JSON.stringify({
 +                  transcriptFile,
 +                  type: 'save',
@@ -1175,45 +1132,45 @@
 +run().catch(err => {
 +  console.log('RUN ERR', err);
 +  process.exit(process.exitCode || 1);
 +});
 diff --git a/packages/SwingSet/package.json b/packages/SwingSet/package.json
-index cba2e5cf3..8f71b62e1 100644
+index f0419d349..16104e844 100644
 --- a/packages/SwingSet/package.json
 +++ b/packages/SwingSet/package.json
-@@ -22,7 +22,8 @@
-   },
-   "devDependencies": {
+@@ -25,7 +25,8 @@
+     "@types/microtime": "^2.1.0",
      "@types/tmp": "^0.2.0",
+     "better-sqlite3": "^8.2.0",
 -    "tmp": "^0.2.1"
 +    "tmp": "^0.2.1",
-+    "yargs-parser": "^21.0.0"
++    "yargs-parser": "^21.1.1"
    },
    "dependencies": {
      "@agoric/assert": "^0.5.1",
 diff --git a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
-index e12bbee44..dcbbaa076 100644
+index e343bea46..fbe0d28b2 100644
 --- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
 +++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
-@@ -103,7 +103,7 @@ import { makeTranscriptManager } from './transcript.js';
+@@ -109,7 +109,7 @@ import { makeTranscriptManager } from './transcript.js';
   * @param {KernelSlog} kernelSlog
   * @param {(vso: VatSyscallObject) => VatSyscallResult} vatSyscallHandler
   * @param {boolean} workerCanBlock
-- * @param {(vatID: any, originalSyscall: any, newSyscall: any) => import('./transcript.js').CompareSyscallsResult} [compareSyscalls]
+- * @param {(vatID: any, originalSyscall: any, newSyscall: any) => Error | undefined} [compareSyscalls]
 + * @param {import('./transcript.js').CompareSyscalls} [compareSyscalls]
   * @param {boolean} [useTranscript]
   * @returns {ManagerKit}
   */
-@@ -119,6 +119,7 @@ function makeManagerKit(
+@@ -125,6 +125,7 @@ function makeManagerKit(
  ) {
    assert(kernelSlog);
    const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
 +  /** @type {ReturnType<typeof makeTranscriptManager> | undefined} */
    let transcriptManager;
    if (useTranscript) {
      transcriptManager = makeTranscriptManager(
-@@ -236,7 +237,6 @@ function makeManagerKit(
+@@ -238,7 +239,6 @@ function makeManagerKit(
     * just direct).
     *
     * @param {VatSyscallObject} vso
 -   * @returns {VatSyscallResult}
     */
@@ -1221,129 +1178,94 @@
      if (transcriptManager && transcriptManager.inReplay()) {
 @@ -267,7 +267,7 @@ function makeManagerKit(
    /**
     *
     * @param { () => Promise<void>} shutdown
--   * @param {(ss: SnapStore) => Promise<SnapshotInfo>} makeSnapshot
-+   * @param {(ss: SnapStore) => Promise<SnapshotInfo>} [makeSnapshot]
+-   * @param {(endPos: number, ss: SnapStore) => Promise<SnapshotResult>} makeSnapshot
++   * @param {(endPos: number, ss: SnapStore) => Promise<SnapshotResult>} [makeSnapshot]
     * @returns {VatManager}
     */
    function getManager(shutdown, makeSnapshot) {
 diff --git a/packages/SwingSet/src/kernel/vat-loader/transcript.js b/packages/SwingSet/src/kernel/vat-loader/transcript.js
-index de5f0c892..1acb0e614 100644
+index e90100fea..45346671f 100644
 --- a/packages/SwingSet/src/kernel/vat-loader/transcript.js
 +++ b/packages/SwingSet/src/kernel/vat-loader/transcript.js
-@@ -1,20 +1,30 @@
+@@ -1,5 +1,25 @@
 +// @ts-check
 +
  import djson from '../../lib/djson.js';
  
- // Indicate that a syscall is missing from the transcript but is safe to
- // perform during replay
--const missingSyscall = Symbol('missing transcript syscall');
-+export const missingSyscall = Symbol('missing transcript syscall');
- 
- // Indicate that a syscall is recorded in the transcript but can be safely
- // ignored / skipped during replay.
--const extraSyscall = Symbol('extra transcript syscall');
-+export const extraSyscall = Symbol('extra transcript syscall');
- 
- /** @typedef {typeof missingSyscall | typeof extraSyscall | Error | undefined} CompareSyscallsResult */
++/** @typedef {import('@agoric/swingset-liveslots').VatSyscallObject} VatSyscallObject */
++/** @typedef {import('@agoric/swingset-liveslots').VatSyscallResult} VatSyscallResult */
++
++/** @typedef {Error | undefined} CompareSyscallsResult */
 +/**
 + * @typedef {(
 + *     vatId: any,
 + *     originalSyscall: VatSyscallObject,
 + *     newSyscall: VatSyscallObject,
-+ *     originalResponse?: VatSyscallResult,
 + *   ) => CompareSyscallsResult
 + * } CompareSyscalls
 + */
- 
- /**
-  * @param {any} vatID
-- * @param {object} originalSyscall
-- * @param {object} newSyscall
-- * @returns {CompareSyscallsResult}
++
++/**
++ * @param {any} vatID
 + * @param {VatSyscallObject} originalSyscall
 + * @param {VatSyscallObject} newSyscall
-  */
++ */
  export function requireIdentical(vatID, originalSyscall, newSyscall) {
    if (djson.stringify(originalSyscall) !== djson.stringify(newSyscall)) {
-@@ -26,7 +36,7 @@ export function requireIdentical(vatID, originalSyscall, newSyscall) {
+     console.error(`anachrophobia strikes vat ${vatID}`);
+@@ -10,6 +30,11 @@ export function requireIdentical(vatID, originalSyscall, newSyscall) {
    return undefined;
  }
  
--const vcSyscallRE = /^vc\.\d+\.\|(?:schemata|label)$/;
-+export const vcSyscallRE = /^vc\.\d+\.\|(?:schemata|label)$/;
- 
- /**
-  * Liveslots currently has a deficiency which results in [virtual collections
-@@ -54,8 +64,8 @@ const vcSyscallRE = /^vc\.\d+\.\|(?:schemata|label)$/;
-  * `simulateSyscall` which then performs the appropriate action.
-  *
-  * @param {any} vatID
-- * @param {object} originalSyscall
-- * @param {object} newSyscall
-+ * @param {VatSyscallObject} originalSyscall
-+ * @param {VatSyscallObject} newSyscall
-  * @returns {CompareSyscallsResult}
-  */
- export function requireIdenticalExceptStableVCSyscalls(
-@@ -87,6 +97,11 @@ export function requireIdenticalExceptStableVCSyscalls(
-   return error;
- }
- 
 +/**
 + * @param {*} vatKeeper
 + * @param {*} vatID
 + * @param {CompareSyscalls} compareSyscalls
 + */
  export function makeTranscriptManager(
    vatKeeper,
    vatID,
-@@ -135,12 +150,14 @@ export function makeTranscriptManager(
+@@ -58,7 +83,9 @@ export function makeTranscriptManager(
  
    let replayError;
  
 +  /** @param {VatSyscallObject} newSyscall */
    function simulateSyscall(newSyscall) {
-     while (playbackSyscalls.length) {
-       const compareError = compareSyscalls(
-         vatID,
-         playbackSyscalls[0].d,
-         newSyscall,
-+        playbackSyscalls[0].response,
-       );
- 
-       if (compareError === missingSyscall) {
-@@ -149,6 +166,7 @@ export function makeTranscriptManager(
-         return undefined;
-       }
- 
-+      /** @type {{d: VatSyscallObject; response: VatSyscallResult}} */
-       const s = playbackSyscalls.shift();
- 
-       if (!compareError) {
-diff --git a/packages/SwingSet/src/types-external.js b/packages/SwingSet/src/types-external.js
-index 629fa9164..18b177471 100644
---- a/packages/SwingSet/src/types-external.js
-+++ b/packages/SwingSet/src/types-external.js
-@@ -40,7 +40,7 @@ export {};
-  *   vatParameters: Record<string, unknown>,
-  *   virtualObjectCacheSize: number,
++    /** @type {{d: VatSyscallObject; response: VatSyscallResult}} */
+     const s = playbackSyscalls.shift();
+     const newReplayError = compareSyscalls(vatID, s.d, newSyscall);
+     if (newReplayError) {
+diff --git a/packages/SwingSet/src/types-internal.js b/packages/SwingSet/src/types-internal.js
+index dc6b7d716..07a10204e 100644
+--- a/packages/SwingSet/src/types-internal.js
++++ b/packages/SwingSet/src/types-internal.js
+@@ -20,6 +20,7 @@ export {};
+  * @typedef { import('./types-external.js').OptEnableDisavow } OptEnableDisavow
+  * @typedef { import('@agoric/swingset-liveslots').VatDeliveryObject } VatDeliveryObject
+  * @typedef { import('@agoric/swingset-liveslots').VatDeliveryResult } VatDeliveryResult
++ * @typedef { import('@agoric/swingset-liveslots').VatSyscallObject } VatSyscallObject
+  *
+  * // used by vatKeeper.setSourceAndOptions(source, RecordedVatOptions)
+  *
+@@ -34,7 +35,7 @@ export {};
+  *   enableDisavow: boolean,
+  *   useTranscript: boolean,
   *   name: string,
 - *   compareSyscalls?: (originalSyscall: {}, newSyscall: {}) => Error | undefined,
 + *   compareSyscalls?: import('./kernel/vat-loader/transcript.js').CompareSyscalls,
   *   sourcedConsole: Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>,
-  *   meterID?: string,
-  * } & (HasBundle | HasSetup)} ManagerOptions
-@@ -222,8 +222,9 @@ export {};
-  *                                 vatSyscallHandler: unknown) => Promise<VatManager>,
-  *            } } VatManagerFactory
+  *   enableSetup: boolean,
+  *   setup?: unknown,
+@@ -42,8 +43,9 @@ export {};
+  * }} ManagerOptions
+  *
   * @typedef { { deliver: (delivery: VatDeliveryObject) => Promise<VatDeliveryResult>,
 + *              replayOneDelivery: (delivery: VatDeliveryObject, expectedSyscalls: VatSyscallObject[], deliveryNum: number) => Promise<VatDeliveryResult>,
-  *              replayTranscript: (startPos: StreamPosition | undefined) => Promise<number?>,
-- *              makeSnapshot?: (ss: SnapStore) => Promise<SnapshotInfo>,
-+ *              makeSnapshot?: undefined | ((ss: SnapStore) => Promise<SnapshotInfo>),
+  *              replayTranscript: (startPos: number | undefined) => Promise<number?>,
+- *              makeSnapshot?: (endPos: number, ss: SnapStore) => Promise<SnapshotResult>,
++ *              makeSnapshot?: undefined | ((endPos: number, ss: SnapStore) => Promise<SnapshotResult>),
   *              shutdown: () => Promise<void>,
   *            } } VatManager
-  *
+  * @typedef { { createFromBundle: (vatID: string,
```

</details>

### Security Considerations

None, this only changes internal tools.

### Scaling Considerations

None

### Documentation Considerations

Updates and fixes a few types

### Testing Considerations

Manually verified that the transcripts generated by #7434 when running a modified `test-vaults-integration.js` could be replayed successfully.
