### PR TITLE
Fix extract transcript

### DIFF
--- a/packages/SwingSet/misc-tools/extract-bundle-from-kerneldb.js
+++ b/packages/SwingSet/misc-tools/extract-bundle-from-kerneldb.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+import '@endo/init';
+import process from 'process';
+import fs from 'fs';
+import { isSwingStore, openSwingStore } from '@agoric/swing-store';
+
+const argv = process.argv.splice(2);
+const dirPath = argv[0];
+let bundleID = argv[1];
+
+if (!dirPath) {
+  console.log('extract-bundle-from-kerneldb DBDIR : list all bundles in DB');
+  console.log(
+    'extract-bundle-from-kerneldb DBDIR bundleID|vatID : extract bundle',
+  );
+  process.exit(0);
+}
+
+if (!isSwingStore(dirPath)) {
+  throw Error(
+    `${dirPath} does not appear to be a swingstore (no ./swingstore.sqlite)`,
+  );
+}
+
+const {
+  kernelStorage: { kvStore, bundleStore },
+  internal: { bundleStore: bundleStoreInternal },
+} = openSwingStore(dirPath);
+
+if (!bundleID) {
+  console.warn(`all bundles:`);
+  for (const bundleId of bundleStoreInternal.getBundleIDs()) {
+    console.log(`${bundleId}`);
+  }
+} else if (/(supervisor|lockdown)(B|-b)undle/.test(bundleID)) {
+  const legacyBundleName = bundleID.replace('-bundle', 'Bundle');
+  const bundle = kvStore.get(legacyBundleName);
+  if (bundle === undefined) {
+    throw Error(`Inexistent legacy bundle ${legacyBundleName}`);
+  }
+  fs.writeFileSync(bundleID.replace('Bundle', '-bundle'), bundle);
+} else {
+  const vatRawSource = kvStore.get(`${bundleID}.source`);
+
+  if (vatRawSource) {
+    const vatSource = JSON.parse(vatRawSource);
+    if (vatSource.bundle) {
+      const vatSourceBundle = JSON.parse(vatSource.bundle);
+      const { moduleFormat, endoZipBase64 } = vatSourceBundle;
+      console.warn(
+        `vat ${bundleID} source is bundle, format=${moduleFormat}, endoZipBase64.length=${endoZipBase64.length}`,
+      );
+      fs.writeFileSync(`${bundleID}-bundle`, vatSource.bundle);
+      process.exit(0);
+    } else {
+      console.warn(`vat ${bundleID} source is bundle ${vatSource.bundleID}`);
+      bundleID = vatSource.bundleID;
+      // fall-throuh
+    }
+  }
+
+  const bundle = bundleStore.getBundle(bundleID);
+  console.warn(`${bundleID} is ${bundle.moduleFormat} bundle`);
+  fs.writeFileSync(`${bundleID}`, JSON.stringify(bundle));
+}

--- a/packages/SwingSet/misc-tools/extract-transcript-from-kerneldb.js
+++ b/packages/SwingSet/misc-tools/extract-transcript-from-kerneldb.js
@@ -22,7 +22,7 @@ if (!isSwingStore(dirPath)) {
 }
 
 const {
-  kernelStorage: { kvStore, bundleStore },
+  kernelStorage: { kvStore },
   internal: { transcriptStore },
 } = openSwingStore(dirPath);
 function get(key) {
@@ -65,9 +65,9 @@ if (!vatName) {
   const dynamic = allDynamicVatIDs.includes(vatID);
   const source = JSON.parse(get(`${vatID}.source`));
   let vatSourceBundle;
-  if (source.bundleID) {
-    console.log(`source bundleID: ${source.bundleID}`);
-    vatSourceBundle = bundleStore.getBundle(source.bundleID);
+  const vatSourceBundleID = source.bundleID;
+  if (vatSourceBundleID) {
+    console.log(`source bundleID: ${vatSourceBundleID}`);
   } else {
     // this doesn't actually happen, now that Zoe launches ZCF by bundlecap
     vatSourceBundle = JSON.parse(source.bundle);
@@ -86,8 +86,11 @@ if (!vatName) {
     type: 'create-vat',
     transcriptNum: 0,
     vatID,
+    vatName: options.name || vatName,
     dynamic,
     vatParameters,
+    bundleIDs: options.workerOptions.bundleIDs,
+    vatSourceBundleID,
     vatSourceBundle,
   };
 

--- a/packages/SwingSet/misc-tools/extract-transcript-from-kerneldb.js
+++ b/packages/SwingSet/misc-tools/extract-transcript-from-kerneldb.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import '@endo/init';
 import process from 'process';
 import fs from 'fs';
@@ -18,9 +20,17 @@ if (!dirPath) {
 if (!isSwingStore(dirPath)) {
   throw Error(`${dirPath} does not appear to be a swingstore (no ./data.mdb)`);
 }
-const { kvStore, transcriptStore } = openSwingStore(dirPath).kernelStorage;
+
+const {
+  kernelStorage: { kvStore, bundleStore },
+  internal: { transcriptStore },
+} = openSwingStore(dirPath);
 function get(key) {
-  return kvStore.get(key);
+  const value = kvStore.get(key);
+  if (value === undefined) {
+    throw Error(`Inexistent kvStore entry for ${key}`);
+  }
+  return value;
 }
 
 const allVatNames = JSON.parse(get('vat.names'));
@@ -30,28 +40,14 @@ if (!vatName) {
   console.log(`all vats:`);
   for (const name of allVatNames) {
     const vatID = get(`vat.name.${name}`);
-    const startPos = Number(get(`${vatID}.t.startPosition`));
-    const endPos = Number(get(`${vatID}.t.endPosition`));
-    const len = `${endPos - startPos}`;
     const status = `(static)`;
-    console.log(
-      `${vatID.padEnd(3)} : ${name.padEnd(15)} ${status.padEnd(
-        20,
-      )} ${len.padStart(10)} deliveries`,
-    );
+    console.log(`${vatID.padEnd(3)} : ${name.padEnd(15)} ${status.padEnd(20)}`);
   }
   for (const vatID of allDynamicVatIDs) {
-    const startPos = Number(get(`${vatID}.t.startPosition`));
-    const endPos = Number(get(`${vatID}.t.endPosition`));
-    const len = `${endPos - startPos}`;
     const options = JSON.parse(get(`${vatID}.options`));
     const { name, managerType } = options;
     const status = `(dynamic, ${managerType})`;
-    console.log(
-      `${vatID.padEnd(3)} : ${name.padEnd(15)} ${status.padEnd(
-        20,
-      )} ${len.padStart(10)} deliveries`,
-    );
+    console.log(`${vatID.padEnd(3)} : ${name.padEnd(15)} ${status.padEnd(20)}`);
   }
 } else {
   let vatID = vatName;
@@ -71,7 +67,7 @@ if (!vatName) {
   let vatSourceBundle;
   if (source.bundleID) {
     console.log(`source bundleID: ${source.bundleID}`);
-    vatSourceBundle = JSON.parse(get(`bundle.${source.bundleID}`));
+    vatSourceBundle = bundleStore.getBundle(source.bundleID);
   } else {
     // this doesn't actually happen, now that Zoe launches ZCF by bundlecap
     vatSourceBundle = JSON.parse(source.bundle);
@@ -84,19 +80,16 @@ if (!vatName) {
   console.log(`options:`, options);
   const { vatParameters } = options;
   console.log(`vatParameters:`, vatParameters);
-  let transcriptNum = 0;
-  const first = {
+
+  // This entry is only valid for the most recent incarnation of the vat
+  const createVatEntry = {
     type: 'create-vat',
-    transcriptNum,
+    transcriptNum: 0,
     vatID,
     dynamic,
     vatParameters,
     vatSourceBundle,
   };
-  transcriptNum += 1;
-  // first line of transcript is the source bundle
-  fs.writeSync(fd, JSON.stringify(first));
-  fs.writeSync(fd, '\n');
 
   // The transcriptStore holds concatenated transcripts from all upgraded
   // versions. For each old version, it holds every delivery from
@@ -105,35 +98,43 @@ if (!vatName) {
   // attempted, which might include one or more deliveries that have
   // been rewound (either because a single crank was abandoned, or the
   // host application failed to commit the kvStore).
-  //
-  // The kvStore `${vatID}.t.startPosition` tells us the index of the
-  // first entry of the most recent version (the most recent
-  // `startVat`), while `${vatID}.t.endPosition` tells us the last
-  // committed entry.
-  //
-  // We ignore the heap snapshot ID, because we're deliberately
-  // replaying everything from `startVat`, and therefore we also
-  // ignore `snapshot.startPos` (the index of the first delivery
-  // *after* the snapshot was taken, where normal operation would
-  // start a replay).
 
-  const startPos = Number(get(`${vatID}.t.startPosition`));
-  const endPos = Number(get(`${vatID}.t.endPosition`));
-  const transcriptLength = endPos - startPos;
-  console.log(`${transcriptLength} transcript entries`);
+  let transcriptNum = NaN;
+  let startPosition = NaN;
+  const transcript = transcriptStore.readFullVatTranscript(vatID);
+  for (const { position, item } of transcript) {
+    const entry = JSON.parse(item);
+    // Reset the transcript every time we see `startVat` since we only support
+    // the last incarnation and we have no way to get the transcript for just
+    // that incarnation.
+    if (entry.d[0] === 'startVat') {
+      fs.ftruncateSync(fd);
+      fs.writeSync(fd, `${JSON.stringify(createVatEntry)}\n`);
+      transcriptNum = 1;
+      startPosition = position;
+    }
 
-  let deliveryNum = 0;
-  const transcript = transcriptStore.readSpan(vatID, startPos, endPos);
-  for (const entry of transcript) {
-    // entry is JSON.stringify({ d, syscalls }), syscall is { d, response }
-    const t = { transcriptNum, ...JSON.parse(entry) };
-    // console.log(`t.${deliveryNum} : ${t}`);
+    // The transcript may have gotten pruned, and earlier deliveries may be
+    // missing. Ignore anything until we've seen `startVat`.
+    // Once the transcript includes snapshot load, we could relax this constraint.
+    if (Number.isNaN(startPosition)) {
+      continue;
+    }
+
+    const expectedPosition = startPosition + transcriptNum - 1;
+    if (position !== expectedPosition) {
+      throw Error(
+        `Unexpected transcript item at position ${position} (expected to see item position ${expectedPosition})`,
+      );
+    }
+    // item is JSON.stringify({ d, syscalls }), syscall is { d, response }
+    const t = { transcriptNum, ...JSON.parse(item) };
     fs.writeSync(fd, `${JSON.stringify(t)}\n`);
-    // eslint-disable-next-line no-unused-vars
-    deliveryNum += 1;
     transcriptNum += 1;
   }
 
   fs.closeSync(fd);
-  console.log(`wrote ${transcriptNum} entries for vat ${vatID} into ${fn}`);
+  console.log(
+    `wrote ${transcriptNum || 0} entries for vat ${vatID} into ${fn}`,
+  );
 }

--- a/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
+++ b/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
@@ -37,11 +37,12 @@ async function run() {
         throw Error(`unable to reconstruct transcript`);
       }
       case 'create-vat': {
-        const { type, dynamic, vatParameters, vatSourceBundle } = e;
+        const { type, name, dynamic, vatParameters, vatSourceBundle } = e;
         const t = {
-          transcriptNum,
           type,
+          transcriptNum,
           vatID,
+          vatName: name,
           dynamic,
           vatParameters,
           vatSourceBundle,

--- a/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
+++ b/packages/SwingSet/misc-tools/extract-transcript-from-slogfile.js
@@ -46,7 +46,6 @@ async function run() {
           vatParameters,
           vatSourceBundle,
         };
-        transcriptNum += 1;
         // first line of transcript is the source bundle
         fs.writeSync(fd, JSON.stringify(t));
         fs.writeSync(fd, '\n');
@@ -71,8 +70,8 @@ async function run() {
       }
       case 'deliver-result': {
         console.log(` -- deliver-result`);
-        const entry = { transcriptNum, d: delivery, syscalls };
         transcriptNum += 1;
+        const entry = { transcriptNum, d: delivery, syscalls };
         fs.writeSync(fd, JSON.stringify(entry));
         fs.writeSync(fd, '\n');
         break;
@@ -81,7 +80,6 @@ async function run() {
         console.log(' -- heap-snapshot-save');
         const { type, snapshotID } = e;
         const t = { transcriptNum, type, vatID, snapshotID };
-        transcriptNum += 1;
         fs.writeSync(fd, JSON.stringify(t));
         fs.writeSync(fd, '\n');
         break;

--- a/packages/swing-store/src/bundleStore.js
+++ b/packages/swing-store/src/bundleStore.js
@@ -30,6 +30,7 @@ import { buffer } from './util.js';
  *   importBundle: (artifactName: string, exporter: SwingStoreExporter, bundleID: string) => void,
  *   getExportRecords: () => IterableIterator<readonly [key: string, value: string]>,
  *   getArtifactNames: () => AsyncIterableIterator<string>,
+ *   getBundleIDs: () => IterableIterator<string>,
  * }} BundleStoreInternal
  *
  * @typedef {{
@@ -269,6 +270,17 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
     return dump;
   }
 
+  const sqlListBundleIDs = db.prepare(`
+  SELECT bundleID
+  FROM bundles
+  ORDER BY bundleID
+`);
+  sqlListBundleIDs.pluck(true);
+
+  function* getBundleIDs() {
+    yield* sqlListBundleIDs.iterate();
+  }
+
   return harden({
     addBundle,
     hasBundle,
@@ -278,6 +290,7 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
     getArtifactNames,
     exportBundle,
     importBundle,
+    getBundleIDs,
 
     dumpBundles,
   });


### PR DESCRIPTION
refs: #7432

## Description

Update the transcript extract tools (and swingstore) to support the latest changes to transcripts.
- Add a bundle export tools
- When exporting from kernelDB, reference bundle IDs for both the lockdown and supervisor bundles, as well as the vat source bundle
- re-order the fields of `create-vat` in the slog extract tool to be more similar to the kernel DB extract tool (minus the bundle ID changes)

The swingstore is extended as needed to support the extract tooling.

Some of these commits are cherry-picks from #6723 that were omitted from #7432

### Security Considerations

None, tooling only

### Scaling Considerations

None

### Documentation Considerations

Internal tooling 

### Testing Considerations

Manually verified with from the state and slog created by a modified `test-vaults-integration.js` bootstrap test. Verified in a merge with #7432 that the transcripts could be replayed successfully.