### PR TITLE
contract start types

### DIFF
--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -7,7 +7,7 @@ import { AmountShape, BrandShape } from '@agoric/ertp';
 import { RelativeTimeRecordShape, TimestampRecordShape } from '@agoric/time';
 import { assertElectorateMatches } from './contractGovernance/paramManager.js';
 import { makeParamManagerFromTerms } from './contractGovernance/typedParamManager.js';
-import { InvitationShape } from './typeGuards.js';
+import { GovernorFacetShape } from './typeGuards.js';
 
 const { Fail, quote: q } = assert;
 
@@ -207,14 +207,7 @@ const facetHelpers = (zcf, paramManager) => {
     const governorFacet = prepareExo(
       baggage,
       'governorFacet',
-      M.interface('governorFacet', {
-        getParamMgrRetriever: M.call().returns(M.remotable('paramRetriever')),
-        getInvitation: M.call().returns(InvitationShape),
-        getLimitedCreatorFacet: M.call().returns(M.remotable()),
-        getGovernedApis: M.call().returns(M.remotable()),
-        getGovernedApiNames: M.call().returns(M.arrayOf(M.string())),
-        setOfferFilter: M.call(M.arrayOf(M.string())).returns(M.promise()),
-      }),
+      M.interface('governorFacet', GovernorFacetShape),
       {
         getParamMgrRetriever: () =>
           Far('paramRetriever', { get: () => paramManager }),

--- a/packages/governance/src/typeGuards.js
+++ b/packages/governance/src/typeGuards.js
@@ -258,3 +258,13 @@ export const VoteCounterAdminI = M.interface('VoteCounter AdminFacet', {
 export const VoteCounterCloseI = M.interface('VoteCounter CloseFacet', {
   closeVoting: M.call().returns(),
 });
+
+export const GovernorFacetShape = {
+  getParamMgrRetriever: M.call().returns(M.remotable('paramRetriever')),
+  getInvitation: M.call().returns(InvitationShape),
+  getLimitedCreatorFacet: M.call().returns(M.remotable()),
+  getGovernedApis: M.call().returns(M.remotable('governedAPIs')),
+  getGovernedApiNames: M.call().returns(M.arrayOf(M.string())),
+  setOfferFilter: M.call(M.arrayOf(M.string())).returns(M.promise()),
+};
+harden(GovernorFacetShape);

--- a/packages/governance/src/types-ambient.js
+++ b/packages/governance/src/types-ambient.js
@@ -537,7 +537,7 @@
 
 /**
  * @typedef {object} ParamKey identifier for a paramManager within a contract
- * @property {string} key
+ * @property {unknown} key
  */
 
 /**
@@ -574,11 +574,11 @@
  * @property {VoteOnParamChanges} voteOnParamChanges
  * @property {VoteOnApiInvocation} voteOnApiInvocation
  * @property {VoteOnOfferFilter} voteOnOfferFilter
- * @property {() => Promise<LimitedCreatorFacet<CF>>} getCreatorFacet - creator
+ * @property {() => ERef<LimitedCreatorFacet<CF>>} getCreatorFacet - creator
  *   facet of the governed contract, without the tightly held ability to change
  *   param values.
  * @property {(poserInvitation: Invitation) => Promise<void>} replaceElectorate
- * @property {() => Promise<AdminFacet>} getAdminFacet
+ * @property {() => AdminFacet} getAdminFacet
  * @property {() => GovernedPublicFacet<PF>} getPublicFacet - public facet of the governed contract
  * @property {() => Instance} getInstance - instance of the governed
  *   contract

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -156,8 +156,6 @@ export const setupReserve = async ({
     {},
     reserveGovernorTerms,
     {
-      // @ts-expect-error FIXME superfluous
-      electorateCreatorFacet: committeeCreator,
       governed: {
         feeMintAccess,
         initialPoserInvitation: poserInvitation,

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -150,11 +150,13 @@ export const setupReserve = async ({
     }),
   );
   /** @type {{ creatorFacet: GovernedAssetReserveFacetAccess, publicFacet: GovernorPublic, instance: Instance, adminFacet: AdminFacet }} */
+  // @ts-expect-error XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
   const g = await E(zoe).startInstance(
     governorInstallation,
     {},
     reserveGovernorTerms,
     {
+      // @ts-expect-error FIXME superfluous
       electorateCreatorFacet: committeeCreator,
       governed: {
         feeMintAccess,
@@ -294,6 +296,7 @@ export const startVaultFactory = async (
   } = await E(zoe).startInstance(
     contractGovernorInstallation,
     undefined,
+    // @ts-expect-error XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
     governorTerms,
     harden({
       electorateCreatorFacet,
@@ -316,6 +319,7 @@ export const startVaultFactory = async (
     ]);
 
   vaultFactoryKit.resolve(
+    // @ts-expect-error XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
     harden({
       creatorFacet: vaultFactoryCreator,
       governorCreatorFacet,
@@ -589,9 +593,11 @@ export const startAuctioneer = async (
   );
 
   /** @type {{ publicFacet: GovernorPublic, creatorFacet: GovernedContractFacetAccess<AuctioneerPublicFacet,AuctioneerCreatorFacet>, adminFacet: AdminFacet}} */
+  // @ts-expect-error XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
   const governorStartResult = await E(zoe).startInstance(
     contractGovernorInstallation,
     undefined,
+    // @ts-expect-error XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
     governorTerms,
     harden({
       electorateCreatorFacet,
@@ -732,9 +738,11 @@ export const startStakeFactory = async (
   );
 
   /** @type {{ publicFacet: GovernorPublic, creatorFacet: GovernedContractFacetAccess<StakeFactoryPublic,StakeFactoryCreator>, adminFacet: AdminFacet}} */
+  // @ts-expect-error XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
   const governorStartResult = await E(zoe).startInstance(
     contractGovernorInstallation,
     {},
+    // @ts-expect-error XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
     stakeTerms,
     {
       governed: {

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -174,6 +174,7 @@ export const startPSM = async (
     psmGovernor: governorFacets.instance,
     psmCreatorFacet,
     psmAdminFacet,
+    // @ts-expect-error XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
     psmGovernorCreatorFacet: governorFacets.creatorFacet,
   };
 

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -27,6 +27,7 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { GovernorFacetShape } from '@agoric/governance/src/typeGuards.js';
 import { makeMakeCollectFeesInvitation } from '../collectFees.js';
 import { scheduleLiquidationWakeups } from './liquidation.js';
 import {
@@ -197,12 +198,7 @@ export const prepareVaultDirector = (
     makeKindHandle('VaultDirector'),
     {
       creator: M.interface('creator', {
-        getParamMgrRetriever: M.call().returns(M.remotable()),
-        getInvitation: M.call(M.string()).returns(M.promise()),
-        getLimitedCreatorFacet: M.call().returns(M.remotable()),
-        getGovernedApis: M.call().returns(M.record()),
-        getGovernedApiNames: M.call().returns(M.record()),
-        setOfferFilter: M.call(M.arrayOf(M.string())).returns(M.promise()),
+        ...GovernorFacetShape,
       }),
       machine: M.interface('machine', {
         addVaultType: M.call(IssuerShape, M.string(), M.record()).returns(
@@ -242,7 +238,9 @@ export const prepareVaultDirector = (
         getParamMgrRetriever: () =>
           Far('paramManagerRetriever', {
             /** @param {VaultFactoryParamPath} paramPath */
-            get: paramPath => {
+            get: (
+              paramPath = { key: /** @type {const} */ 'governedParams' },
+            ) => {
               if (paramPath.key === 'governedParams') {
                 return directorParamManager;
               } else if (paramPath.key.collateralBrand) {
@@ -262,10 +260,10 @@ export const prepareVaultDirector = (
           return this.facets.machine;
         },
         getGovernedApis() {
-          return harden({});
+          return Far('governedAPIs', {});
         },
         getGovernedApiNames() {
-          return harden({});
+          return harden([]);
         },
         setOfferFilter: strings => zcf.setOfferFilter(strings),
       },

--- a/packages/inter-protocol/test/psm/test-governedPsm.js
+++ b/packages/inter-protocol/test/psm/test-governedPsm.js
@@ -178,7 +178,7 @@ test('replace electorate of Economic Committee', async t => {
     harden({}),
     electorateTerms,
     {
-      // mocks
+      // @ts-expect-error mock
       marshaller: {},
       storageNode: makeFakeStorageKit('governedPsmTest').rootNode,
     },

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -173,7 +173,15 @@
  *   installation:{
  *     produce: Record<WellKnownName['installation'], Producer<Installation>>,
  *     consume: Record<WellKnownName['installation'], Promise<Installation<unknown>>> & {
+ *       centralSupply: Promise<Installation<import('@agoric/vats/src/centralSupply.js').start>>,
+ *       committee: Promise<Installation<import('@agoric/governance/src/committee.js').start>>,
+ *       contractGovernor: Promise<Installation<import('@agoric/governance/src/contractGovernor.js').start>>,
+ *       econCommitteeCharter: Promise<Installation<import('@agoric/inter-protocol/src/econCommitteeCharter.js').start>>,
+ *       feeDistributor: Promise<Installation<import('@agoric/inter-protocol/src/feeDistributor.js').start>>,
  *       mintHolder: Promise<Installation<import('@agoric/vats/src/mintHolder.js').prepare>>,
+ *       psm: Promise<Installation<import('@agoric/inter-protocol/src/psm/psm.js').start>>,
+ *       reserve: Promise<Installation<import('@agoric/inter-protocol/src/reserve/assetReserve.js').start>>,
+ *       VaultFactory: Promise<Installation<import('@agoric/inter-protocol/src/vaultFactory/vaultFactory.js').start>>,
  *       walletFactory: Promise<Installation<import('@agoric/smart-wallet/src/walletFactory.js').prepare>>,
  *     },
  *   },

--- a/packages/zoe/jsconfig.json
+++ b/packages/zoe/jsconfig.json
@@ -6,6 +6,7 @@
     "src/**/*.js",
     "src/**/*.ts",
     "test/**/*.js",
+    "test/**/*.ts",
     "tools/**/*.js",
   ],
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -46,7 +46,6 @@
     "@agoric/assert": "^0.5.1",
     "@agoric/ertp": "^0.15.3",
     "@agoric/internal": "^0.2.1",
-    "@endo/nat": "^4.1.26",
     "@agoric/notifier": "^0.5.1",
     "@agoric/store": "^0.8.3",
     "@agoric/swingset-vat": "^0.30.2",
@@ -57,6 +56,7 @@
     "@endo/far": "^0.2.17",
     "@endo/import-bundle": "^0.3.3",
     "@endo/marshal": "^0.8.4",
+    "@endo/nat": "^4.1.26",
     "@endo/promise-kit": "^0.2.55"
   },
   "devDependencies": {
@@ -64,7 +64,8 @@
     "@endo/init": "^0.5.55",
     "ava": "^5.2.0",
     "c8": "^7.13.0",
-    "import-meta-resolve": "^2.2.1"
+    "import-meta-resolve": "^2.2.1",
+    "tsd": "^0.28.1"
   },
   "files": [
     "bundles/",

--- a/packages/zoe/src/contractSupport/recorder.js
+++ b/packages/zoe/src/contractSupport/recorder.js
@@ -251,8 +251,11 @@ export const prepareMockRecorderKitMakers = () => {
  * Stop-gap until https://github.com/Agoric/agoric-sdk/issues/6160
  * explictly specify the type that the Pattern will verify through a match.
  *
+ * This is a Pattern but since that's `any`, including in the typedef turns the
+ * whole thing to `any`.
+ *
  * @template T
- * @typedef {Pattern & {validatedType?: T}} TypedMatcher
+ * @typedef {{ validatedType?: T }} TypedMatcher
  */
 
 /**

--- a/packages/zoe/test/types.test-d.ts
+++ b/packages/zoe/test/types.test-d.ts
@@ -1,0 +1,53 @@
+/**
+ * @file uses .ts syntax to be able to declare types (e.g. of kit.creatorFacet as {})
+ * because "there is no JavaScript syntax for passing a a type argument"
+ * https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html
+ */
+import { E } from '@endo/eventual-send';
+import { expectType } from 'tsd';
+
+import type { start as scaledPriceAuthorityStart } from '../src/contracts/scaledPriceAuthority.js';
+
+{
+  const zoe = {} as ZoeService;
+  const scaledPriceInstallation = {} as Installation<
+    typeof scaledPriceAuthorityStart
+  >;
+
+  const mock = null as any;
+  const kit = await E(zoe).startInstance(scaledPriceInstallation);
+  // @ts-expect-error
+  kit.notInKit;
+  E(kit.publicFacet).getPriceAuthority();
+
+  expectType<{}>(kit.creatorFacet);
+
+  const validIssuers = {};
+
+  E(zoe).startInstance(
+    scaledPriceInstallation,
+    validIssuers,
+    // @ts-expect-error missing terms
+    {},
+  );
+  const validTerms = {
+    sourcePriceAuthority: mock,
+    scaleIn: mock,
+    scaleOut: mock,
+  };
+  E(zoe).startInstance(scaledPriceInstallation, validIssuers, validTerms);
+  const validPrivates = {};
+  E(zoe).startInstance(
+    scaledPriceInstallation,
+    validIssuers,
+    validTerms,
+    validPrivates,
+  );
+  E(zoe).startInstance(
+    scaledPriceInstallation,
+    validIssuers,
+    validTerms,
+    // @ts-expect-error
+    'invalid privateArgs',
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,6 +1692,13 @@
   dependencies:
     requireindex "~1.1.0"
 
+"@jest/schemas@^29.4.3":
+  version "29.4.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.4.3.tgz#39cf1b8469afc40b6f5a2baaa146e332c4151788"
+  integrity sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==
+  dependencies:
+    "@sinclair/typebox" "^0.25.16"
+
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
@@ -2956,6 +2963,11 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz#7f698254aadf921e48dda8c0a6b304026b8a9323"
   integrity sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==
 
+"@sinclair/typebox@^0.25.16":
+  version "0.25.24"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
+  integrity sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -3007,6 +3019,11 @@
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-4.9.4.tgz#03ddbae4249621ee83bd496e701e6fec3c3d9944"
   integrity sha512-70j1vy95LsMvciXWJLrQ9pQaaG1inJJ+gZ/dW/bPdzHUH1VTeSl3BBU6QxqFWh5IjPy6s7xHcUw45R71dw4J3w==
+
+"@tsd/typescript@~5.0.2":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-5.0.4.tgz#18aa4eb2c35c6bf9aab3199c289be319bedb7e9c"
+  integrity sha512-YQi2lvZSI+xidKeUjlbv6b6Zw7qB3aXHw5oGJLs5OOGAEqKIOvz5UIAkWyg0bJbkSUWPBEtaOHpVxU4EYBO1Jg==
 
 "@types/accepts@*":
   version "1.3.5"
@@ -3427,6 +3444,14 @@
     "@typescript-eslint/types" "5.55.0"
     "@typescript-eslint/visitor-keys" "5.55.0"
 
+"@typescript-eslint/scope-manager@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz#86501d7a17885710b6716a23be2e93fc54a4fe8c"
+  integrity sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/visitor-keys" "5.59.0"
+
 "@typescript-eslint/type-utils@5.55.0":
   version "5.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.55.0.tgz#74bf0233523f874738677bb73cb58094210e01e9"
@@ -3446,6 +3471,11 @@
   version "5.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.55.0.tgz#9830f8d3bcbecf59d12f821e5bc6960baaed41fd"
   integrity sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==
+
+"@typescript-eslint/types@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.0.tgz#3fcdac7dbf923ec5251545acdd9f1d42d7c4fe32"
+  integrity sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==
 
 "@typescript-eslint/typescript-estree@5.53.0":
   version "5.53.0"
@@ -3473,7 +3503,20 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.55.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.10.2":
+"@typescript-eslint/typescript-estree@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz#8869156ee1dcfc5a95be3ed0e2809969ea28e965"
+  integrity sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/visitor-keys" "5.59.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.55.0":
   version "5.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.55.0.tgz#34e97322e7ae5b901e7a870aabb01dad90023341"
   integrity sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==
@@ -3484,6 +3527,20 @@
     "@typescript-eslint/scope-manager" "5.55.0"
     "@typescript-eslint/types" "5.55.0"
     "@typescript-eslint/typescript-estree" "5.55.0"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
+
+"@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.10.2":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.0.tgz#063d066b3bc4850c18872649ed0da9ee72d833d5"
+  integrity sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.59.0"
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/typescript-estree" "5.59.0"
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
@@ -3515,6 +3572,14 @@
   integrity sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==
   dependencies:
     "@typescript-eslint/types" "5.55.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz#a59913f2bf0baeb61b5cfcb6135d3926c3854365"
+  integrity sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
     eslint-visitor-keys "^3.3.0"
 
 "@web/browser-logs@^0.2.1", "@web/browser-logs@^0.2.2":
@@ -3907,6 +3972,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-styles@^6.0.0, ansi-styles@^6.2.1:
   version "6.2.1"
@@ -5850,6 +5920,11 @@ diagnostics_channel@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz#bd66c49124ce3bac697dff57466464487f57cea5"
   integrity sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==
+
+diff-sequences@^29.4.3:
+  version "29.4.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
+  integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
 
 diff@^5.0.0:
   version "5.0.0"
@@ -8658,6 +8733,21 @@ jessie.js@^0.3.2:
   dependencies:
     "@endo/far" "^0.2.3"
 
+jest-diff@^29.0.3:
+  version "29.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.5.0.tgz#e0d83a58eb5451dcc1fa61b1c3ee4e8f5a290d63"
+  integrity sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.4.3"
+    jest-get-type "^29.4.3"
+    pretty-format "^29.5.0"
+
+jest-get-type@^29.4.3:
+  version "29.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.4.3.tgz#1ab7a5207c995161100b5187159ca82dd48b3dd5"
+  integrity sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==
+
 js-levenshtein-esm@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/js-levenshtein-esm/-/js-levenshtein-esm-1.2.0.tgz#96532c34e0c90df198c9419963c64ca3cf43ae92"
@@ -11025,6 +11115,15 @@ prettier@^2.8.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
   integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==
 
+pretty-format@^29.5.0:
+  version "29.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.5.0.tgz#283134e74f70e2e3e7229336de0e4fce94ccde5a"
+  integrity sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==
+  dependencies:
+    "@jest/schemas" "^29.4.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 pretty-ms@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-8.0.0.tgz#a35563b2a02df01e595538f86d7de54ca23194a3"
@@ -11327,6 +11426,11 @@ react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.0.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react-test-renderer@^16.0.0-0:
   version "16.14.0"
@@ -12942,6 +13046,19 @@ tsd@^0.25.0:
     "@tsd/typescript" "~4.9.3"
     eslint-formatter-pretty "^4.1.0"
     globby "^11.0.1"
+    meow "^9.0.0"
+    path-exists "^4.0.0"
+    read-pkg-up "^7.0.0"
+
+tsd@^0.28.1:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/tsd/-/tsd-0.28.1.tgz#a470bd88a80ff138496c71606072893fe5820e62"
+  integrity sha512-FeYrfJ05QgEMW/qOukNCr4fAJHww4SaKnivAXRv4g5kj4FeLpNV7zH4dorzB9zAfVX4wmA7zWu/wQf7kkcvfbw==
+  dependencies:
+    "@tsd/typescript" "~5.0.2"
+    eslint-formatter-pretty "^4.1.0"
+    globby "^11.0.1"
+    jest-diff "^29.0.3"
     meow "^9.0.0"
     path-exists "^4.0.0"
     read-pkg-up "^7.0.0"


### PR DESCRIPTION
## Description

No ticket. Nerd-sniped in https://github.com/Agoric/agoric-sdk/pull/7426#discussion_r1168882028

Tighter definition for `startInstance`, resulting in more installation types required in bootstrap.

That then brought up some governance types inconsistencies. Those have an issue so I punted with a comment.

There were two runtime changes to vaultFactory types which I separated.

_Review by commit_ recommended.

### Security Considerations

n/a
### Scaling Considerations

n/a
### Documentation Considerations

--
### Testing Considerations

CI