### PR TITLE
feat: improved error diagnostic on timer event handler failure

### DIFF
--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -518,7 +518,7 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
         .wake(now)
         .then(
           _res => self.wakerDone(), // reschedule unless cancelled
-          _err => self.wakerFailed(), // do not reschedule
+          err => self.wakerFailed(err), // do not reschedule
         )
         .catch(err => console.log(`timer repeater error`, err));
     },
@@ -533,7 +533,11 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
       }
     },
 
-    wakerFailed({ self, state }) {
+    wakerFailed({ self, state }, err) {
+      console.log(
+        `WARNING: timer repeater descheduled (handler failed), handler=${state.handler}, interval=${state.interval}: `,
+        err,
+      );
       if (state.cancelToken) {
         removeCancel(cancels, state.cancelToken, self); // stop tracking
       }

--- a/packages/SwingSet/test/test-vat-timer.js
+++ b/packages/SwingSet/test/test-vat-timer.js
@@ -510,7 +510,7 @@ test('makeRepeater', async t => {
   // if the handler rejects, the repeater is cancelled
   const brokenHandler = Far('broken', {
     wake(_time) {
-      throw Error('expected error');
+      throw Error('deliberate handler error');
     },
   });
   r1.schedule(brokenHandler);


### PR DESCRIPTION
Closes #6767

When the `wake` handler for a repeating timer throws an error, the timer vat now prints a message to the log indicating the nature of the error and additional information to hopefully help identify which handler it was that barfed.
