### PR TITLE
refactor: stateShape causes accessor sharing

### DIFF
--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -742,6 +742,7 @@ export const makeVirtualObjectManager = (
     } = options;
 
     let facetNames; // undefined or a list of strings
+    const statePrototype = {}; // Not frozen yet
 
     // 'multifaceted' tells us which API was used: define[Durable]Kind
     // vs define[Durable]KindMulti. This function checks whether
@@ -818,9 +819,9 @@ export const makeVirtualObjectManager = (
     }
 
     /** @type {(prop: string) => void} */
-    let checkStateProperty = _prop => undefined;
+    let checkStateProperty = _prop => {};
     /** @type {(value: any, prop: string) => void} */
-    let checkStatePropertyValue = (_value, _prop) => undefined;
+    let checkStatePropertyValue = (_value, _prop) => {};
     if (stateShape) {
       checkStateProperty = prop => {
         hasOwn(stateShape, prop) ||
@@ -856,37 +857,48 @@ export const makeVirtualObjectManager = (
     // * when state.prop is written, invoking the setter
     // This will cause a syscall.vatstoreGet only once per crank.
 
+    const makeFieldDescriptor = (prop, getBaseRef) => {
+      return harden({
+        get() {
+          const baseRef = getBaseRef(this);
+          const { valueMap, capdatas } = dataCache.get(baseRef);
+          if (!valueMap.has(prop)) {
+            const value = harden(unserialize(capdatas[prop]));
+            checkStatePropertyValue(value, prop);
+            valueMap.set(prop, value);
+          }
+          return valueMap.get(prop);
+        },
+        set(value) {
+          const baseRef = getBaseRef(this);
+          checkStatePropertyValue(value, prop);
+          const capdata = serialize(value);
+          assertAcceptableSyscallCapdataSize([capdata]);
+          if (isDurable) {
+            insistDurableCapdata(vrm, prop, capdata, true);
+          }
+          const record = dataCache.get(baseRef); // mutable
+          const oldSlots = record.capdatas[prop].slots;
+          const newSlots = capdata.slots;
+          vrm.updateReferenceCounts(oldSlots, newSlots);
+          record.capdatas[prop] = capdata; // modify in place ..
+          record.valueMap.set(prop, value);
+          dataCache.set(baseRef, record); // .. but mark as dirty
+        },
+        enumerable: true,
+        configurable: false,
+      });
+    };
+
     const makeState = baseRef => {
-      const state = {};
+      const state = { __proto__: statePrototype };
       for (const prop of getOwnPropertyNames(dataCache.get(baseRef).capdatas)) {
         checkStateProperty(prop);
-        defineProperty(state, prop, {
-          get: () => {
-            const { valueMap, capdatas } = dataCache.get(baseRef);
-            if (!valueMap.has(prop)) {
-              const value = harden(unserialize(capdatas[prop]));
-              checkStatePropertyValue(value, prop);
-              valueMap.set(prop, value);
-            }
-            return valueMap.get(prop);
-          },
-          set: value => {
-            checkStatePropertyValue(value, prop);
-            const capdata = serialize(value);
-            assertAcceptableSyscallCapdataSize([capdata]);
-            if (isDurable) {
-              insistDurableCapdata(vrm, prop, capdata, true);
-            }
-            const record = dataCache.get(baseRef); // mutable
-            const oldSlots = record.capdatas[prop].slots;
-            const newSlots = capdata.slots;
-            vrm.updateReferenceCounts(oldSlots, newSlots);
-            record.capdatas[prop] = capdata; // modify in place ..
-            record.valueMap.set(prop, value);
-            dataCache.set(baseRef, record); // .. but mark as dirty
-          },
-          enumerable: true,
-        });
+        defineProperty(
+          state,
+          prop,
+          makeFieldDescriptor(prop, () => baseRef),
+        );
       }
       return harden(state);
     };


### PR DESCRIPTION
Revive https://github.com/Agoric/agoric-sdk/pull/7286

Staged on https://github.com/Agoric/agoric-sdk/pull/7443

When a kind is provided with a `stateShape`, we know exactly what the names are for all of the `state` fields across all instances. For that case, it is wasteful to create accessor properties per instance. So instead, when there is a `stateShape`, this PR will instead install similar accessors on a shared `statePrototype` object. Each `state` object is then a frozen empty object that inherits from that `statePrototype`. As with a shared prototype for methods, to make this work, we also introduce a separate state to baseRef weakmap, so the accessor can get the correct `baseRef` from its `this`, which is the empty state instance itself.

See also 
https://github.com/Agoric/agoric-sdk/pull/7289
https://github.com/Agoric/agoric-sdk/issues/6693
https://github.com/Agoric/agoric-sdk/pull/7138

To get the benefit of this PR, more exoClasses will need stateShape metaData. See https://github.com/Agoric/agoric-sdk/pull/7445

Please review while hiding whitespace differences.