### PR TITLE
refactor: More exoClasses have stateShape metadata

### DIFF
--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -114,6 +114,25 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
   const makeScaledBidBook = prepareScaledBidBook(baggage);
   const makePriceBook = preparePriceBook(baggage);
 
+  const AuctionBookStateShape = harden({
+    collateralBrand: M.any(),
+    collateralSeat: M.any(),
+    collateralAmountShape: M.any(),
+    currencyBrand: M.any(),
+    currencySeat: M.any(),
+    currencyAmountShape: M.any(),
+    priceAuthority: M.any(),
+    updatingOracleQuote: M.any(),
+    bookDataKit: M.any(),
+    priceBook: M.any(),
+    scaledBidBook: M.any(),
+    startCollateral: M.any(),
+    startProceedsGoal: M.any(),
+    lockedPriceForRound: M.any(),
+    curAuctionPrice: M.any(),
+    remainingProceedsGoal: M.any(),
+  });
+
   const makeAuctionBookKit = prepareExoClassKit(
     baggage,
     'AuctionBook',
@@ -732,6 +751,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
           },
         );
       },
+      stateShape: AuctionBookStateShape,
     },
   );
 

--- a/packages/inter-protocol/src/auction/offerBook.js
+++ b/packages/inter-protocol/src/auction/offerBook.js
@@ -33,6 +33,12 @@ const nextSequenceNumber = () => {
  * } BidderRecord
  */
 
+const ScaledBidBookStateShape = harden({
+  bidScalingPattern: M.any(),
+  collateralBrand: M.any(),
+  records: M.any(),
+});
+
 /**
  * Prices in this book are expressed as percentage of the full oracle price
  * snapshot taken when the auction started. .4 is 60% off. 1.1 is 10% above par.
@@ -116,7 +122,16 @@ export const prepareScaledBidBook = baggage =>
         }
       },
     },
+    {
+      stateShape: ScaledBidBookStateShape,
+    },
   );
+
+const PriceBookStateShape = harden({
+  priceRatioPattern: M.any(),
+  collateralBrand: M.any(),
+  records: M.any(),
+});
 
 /**
  * Prices in this book are actual prices expressed in terms of currency amount
@@ -199,5 +214,8 @@ export const preparePriceBook = baggage =>
           }
         }
       },
+    },
+    {
+      stateShape: PriceBookStateShape,
     },
   );

--- a/packages/inter-protocol/src/vaultFactory/vault.js
+++ b/packages/inter-protocol/src/vaultFactory/vault.js
@@ -174,6 +174,17 @@ export const VaultI = M.interface('Vault', {
   abortLiquidation: M.call().returns(M.string()),
 });
 
+const VaultStateShape = harden({
+  idInManager: M.any(),
+  manager: M.any(),
+  outerUpdater: M.any(),
+  phase: M.any(),
+  storageNode: M.any(),
+  vaultSeat: M.any(),
+  interestSnapshot: M.any(),
+  debtSnapshot: M.any(),
+});
+
 /**
  * @param {import('@agoric/ertp').Baggage} baggage
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit} makeRecorderKit
@@ -943,6 +954,9 @@ export const prepareVault = (baggage, makeRecorderKit, zcf) => {
           return reverseInterest(state.debtSnapshot, state.interestSnapshot);
         },
       },
+    },
+    {
+      stateShape: VaultStateShape,
     },
   );
   return maker;

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -173,6 +173,14 @@ export const makePublishKit = () => {
 };
 harden(makePublishKit);
 
+const DurablePublishKitStateShape = harden({
+  valueDurability: M.any(),
+  publishCount: M.any(),
+  status: M.any(),
+  hasValue: M.any(),
+  value: M.any(),
+});
+
 // TODO: Move durable publish kit to a new file?
 
 /**
@@ -415,6 +423,9 @@ export const prepareDurablePublishKit = (baggage, kindName) => {
           );
         },
       },
+    },
+    {
+      stateShape: DurablePublishKitStateShape,
     },
   );
 };

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -36,6 +36,11 @@ export const makeMakeExiter = baggage => {
         state.zcfSeat.exit();
       },
     },
+    {
+      stateShape: harden({
+        zcfSeat: M.any(),
+      }),
+    },
   );
   const makeWaived = prepareExoClass(
     baggage,

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -43,6 +43,13 @@ export const makeStartInstance = (
     seatHandleToZoeSeatAdmin,
   );
 
+  const InstanceAdminStateShape = harden({
+    instanceStorage: M.any(),
+    instanceAdmin: M.any(),
+    seatHandleToSeatAdmin: M.any(),
+    adminNode: M.any(),
+  });
+
   const makeZoeInstanceAdmin = prepareExoClass(
     zoeBaggage,
     'zoeInstanceAdmin',
@@ -146,6 +153,9 @@ export const makeStartInstance = (
         const { state } = this;
         return state.instanceAdmin.isBlocked(string);
       },
+    },
+    {
+      stateShape: InstanceAdminStateShape,
     },
   );
 


### PR DESCRIPTION
Adds some of the stateShape metadata needed to get the benefit of https://github.com/Agoric/agoric-sdk/pull/7444

Even when the shape of each property in the stateShape record is merely `M.any()`, we still get the full benefit of https://github.com/Agoric/agoric-sdk/pull/7444 . 

With more accurate shapes, which can be incrementally contributed later, we'll also get better error checking. If https://github.com/Agoric/agoric-sdk/pull/6432 happens, then these more accurate shapes might also reduce storage as well as serialization/deserialization time and allocations. We'll see.