### PR TITLE
fix feeDistributor bootstrap

### DIFF
--- a/packages/inter-protocol/src/feeDistributor.js
+++ b/packages/inter-protocol/src/feeDistributor.js
@@ -316,7 +316,7 @@ export const makeFeeDistributor = (feeIssuer, terms) => {
     },
 
     /**
-     * @param {Record<Keyword, FeeDestination>} newDestinations
+     * @param {Record<Keyword, ERef<FeeDestination>>} newDestinations
      */
     setDestinations: async newDestinations => {
       destinations = newDestinations;

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -417,6 +417,12 @@ export const startRewardDistributor = async ({
       return undefined;
     });
 
+  /**
+   * @type {Awaited<
+   *   ReturnType<typeof import('../feeDistributor.js').makeFeeDistributor>>
+   *   & { adminFacet: AdminFacet, instance: Instance }
+   * }
+   */
   const instanceKit = await E(zoe).startInstance(
     feeDistributor,
     { Fee: centralIssuer },
@@ -424,13 +430,15 @@ export const startRewardDistributor = async ({
     undefined,
     'feeDistributor',
   );
+  /** @type {ERef<import('../feeDistributor.js').FeeDestination>} */
   await E(instanceKit.creatorFacet).setDestinations({
-    RewardDistributor:
-      rewardDistributorDepositFacet &&
-      E(instanceKit.creatorFacet).makeDepositFacetDestination(
-        rewardDistributorDepositFacet,
-      ),
+    ...(rewardDistributorDepositFacet && {
+      RewardDistributor: E(
+        instanceKit.creatorFacet,
+      ).makeDepositFacetDestination(rewardDistributorDepositFacet),
+    }),
     Reserve: E(instanceKit.creatorFacet).makeOfferDestination(
+      zoe,
       'Collateral',
       E.get(reserveKit).publicFacet,
       'makeAddCollateralInvitation',

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -396,7 +396,7 @@ export const startRewardDistributor = async ({
       timerService,
       collectionInterval: 60n * 60n, // 1 hour
       keywordShares: {
-        RewardDistributor: 1n,
+        RewardDistributor: 0n,
         Reserve: 1n,
       },
     }),


### PR DESCRIPTION
closes: #7046

## Description

 - fix args to feeDistributor setup
 - route all rewards to the reserve

### Security, Scaling Considerations

none

### Documentation Considerations

@otoole-brendan I trust Inter docs cover this initial fee distribution policy.

### Testing Considerations

I didn't add any tests.