### PR TITLE
fix(liveslots): allow new Kind upgrade to add new facets

### DIFF
--- a/packages/SwingSet/test/upgrade/bootstrap-scripted-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-scripted-upgrade.js
@@ -196,7 +196,7 @@ export const buildRootObject = () => {
       return events;
     },
 
-    buildV1WithMultiKind: async mode => {
+    buildV1KindModeTest: async v1mode => {
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik1');
       const vatParameters = { youAre: 'v1', marker };
       const options = { vatParameters };
@@ -206,7 +206,18 @@ export const buildRootObject = () => {
       retain = await E(ulrikRoot).getExports(importSensors);
       ulrikRoot = res.root;
       ulrikAdmin = res.adminNode;
-      await E(ulrikRoot).makeMultiKind(mode);
+      if (v1mode === 'single') {
+        await E(ulrikRoot).makeSingleKind();
+      } else {
+        await E(ulrikRoot).makeMultiKind();
+      }
+      return [];
+    },
+
+    upgradeV2KindModeTest: async v2mode => {
+      const bcap = await E(vatAdmin).getNamedBundleCap('ulrik2');
+      const vatParameters = { youAre: 'v2', marker, v2mode };
+      await E(ulrikAdmin).upgrade(bcap, { vatParameters });
       return [];
     },
 

--- a/packages/SwingSet/test/upgrade/vat-ulrik-1.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-1.js
@@ -170,75 +170,19 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
       makeKindHandle('unhandled');
     },
 
-    makeMultiKind: mode => {
-      const mkh = makeKindHandle('multi');
-      baggage.init('mkh', mkh);
-      switch (mode) {
-        case 's2mFacetiousnessMismatch': {
-          // upgrade should fail
-          defineDurableKind(mkh, initEmpty, {
-            fooMethod: () => 1,
-          });
-          break;
-        }
-        case 'facetCountMismatch': {
-          // upgrade should fail
-          defineDurableKindMulti(mkh, initEmpty, {
-            foo: {
-              fooMethod: () => 1,
-            },
-            bar: {
-              barMethod: () => 1,
-            },
-          });
-          break;
-        }
-        case 'facetNameMismatch': {
-          // upgrade should fail
-          defineDurableKindMulti(mkh, initEmpty, {
-            foo: {
-              fooMethod: () => 1,
-            },
-            bar: {
-              barMethod: () => 1,
-            },
-            belch: {
-              belchMethod: () => 1,
-            },
-          });
-          break;
-        }
-        case 'facetOrderMismatch': {
-          // upgrade should succeed since facet names get sorted
-          defineDurableKindMulti(mkh, initEmpty, {
-            baz: {
-              bazMethod: () => 1,
-            },
-            foo: {
-              fooMethod: () => 1,
-            },
-            bar: {
-              barMethod: () => 1,
-            },
-          });
-          break;
-        }
-        default: {
-          // upgrade should succeed
-          defineDurableKindMulti(mkh, initEmpty, {
-            foo: {
-              fooMethod: () => 1,
-            },
-            bar: {
-              barMethod: () => 1,
-            },
-            baz: {
-              bazMethod: () => 1,
-            },
-          });
-          break;
-        }
-      }
+    makeSingleKind: () => {
+      const kh = makeKindHandle('kind');
+      baggage.init('kh', kh);
+      defineDurableKind(kh, initEmpty, {});
+    },
+
+    makeMultiKind: () => {
+      const kh = makeKindHandle('kind');
+      baggage.init('kh', kh);
+      defineDurableKindMulti(kh, initEmpty, {
+        foo: {},
+        bar: {},
+      });
     },
     pingback: handler => {
       counter += 1;

--- a/packages/SwingSet/test/upgrade/vat-ulrik-2.js
+++ b/packages/SwingSet/test/upgrade/vat-ulrik-2.js
@@ -31,24 +31,33 @@ export const buildRootObject = (_vatPowers, vatParameters, baggage) => {
     throw Error(vatParameters.explode);
   }
 
-  if (baggage.has('mkh')) {
-    const mkh = baggage.get('mkh');
-    if (vatParameters.mode === 'm2sFacetiousnessMismatch') {
-      defineDurableKind(mkh, initEmpty, {
-        fooMethod: () => 2,
-      });
-    } else {
-      defineDurableKindMulti(mkh, initEmpty, {
-        bar: {
-          barMethod: () => 2,
-        },
-        foo: {
-          fooMethod: () => 2,
-        },
-        baz: {
-          bazMethod: () => 2,
-        },
-      });
+  if (baggage.has('kh')) {
+    const kh = baggage.get('kh');
+    const { v2mode } = vatParameters;
+    switch (v2mode) {
+      case 'single':
+        defineDurableKind(kh, initEmpty, {});
+        break;
+      case 'multi-foo':
+        defineDurableKindMulti(kh, initEmpty, { foo: {} });
+        break;
+      case 'multi-foo-bar':
+        defineDurableKindMulti(kh, initEmpty, { foo: {}, bar: {} });
+        break;
+      case 'multi-bar-foo':
+        defineDurableKindMulti(kh, initEmpty, { bar: {}, foo: {} });
+        break;
+      case 'multi-foo-bar-arf': // new facet sorts earlier than others
+        defineDurableKindMulti(kh, initEmpty, { foo: {}, bar: {}, arf: {} });
+        break;
+      case 'multi-arf-foo-bar': // new facet sorts earlier than others
+        defineDurableKindMulti(kh, initEmpty, { foo: {}, bar: {}, arf: {} });
+        break;
+      case 'multi-foo-bar-baz': // new facet sorts later than others
+        defineDurableKindMulti(kh, initEmpty, { foo: {}, bar: {}, baz: {} });
+        break;
+      default:
+        throw Error(`unknown case ${v2mode}`);
     }
   }
 

--- a/packages/swingset-liveslots/src/facetiousness.js
+++ b/packages/swingset-liveslots/src/facetiousness.js
@@ -44,12 +44,15 @@ export function assessFacetiousness(obj) {
   return /** @type {Facetiousness} */ (result || 'one');
 }
 
+// note: mutates 'desc' in-place
 export const checkAndUpdateFacetiousness = (tag, desc, proposedFacetNames) => {
   // The first time a durable kind gets a definition, the saved
   // descriptor will have neither ".unfaceted" nor ".facets", and we
   // must update the details in the descriptor. When a later
   // incarnation redefines the behavior, we must check for
-  // compatibility (all old facets must still be defined).
+  // compatibility (all old facets must still be defined). We
+  // re-assign .facets/.unfaceted each time, even if we're not
+  // changing anything.
 
   if (desc.unfaceted && proposedFacetNames) {
     Fail`defineDurableKindMulti called for unfaceted KindHandle ${tag}`;

--- a/packages/swingset-liveslots/src/facetiousness.js
+++ b/packages/swingset-liveslots/src/facetiousness.js
@@ -1,3 +1,5 @@
+import { Fail } from '@agoric/assert';
+
 /**
  * Assess the facetiousness of a value.  If the value is an object containing
  * only named properties and each such property's value is a function, `obj`
@@ -41,3 +43,43 @@ export function assessFacetiousness(obj) {
   // empty objects are methodless Far objects
   return /** @type {Facetiousness} */ (result || 'one');
 }
+
+export const checkAndUpdateFacetiousness = (tag, desc, proposedFacetNames) => {
+  // The first time a durable kind gets a definition, the saved
+  // descriptor will have neither ".unfaceted" nor ".facets", and we
+  // must update the details in the descriptor. When a later
+  // incarnation redefines the behavior, we must check for
+  // compatibility (all old facets must still be defined).
+
+  if (desc.unfaceted && proposedFacetNames) {
+    Fail`defineDurableKindMulti called for unfaceted KindHandle ${tag}`;
+  }
+  if (desc.facets && !proposedFacetNames) {
+    Fail`defineDurableKind called for faceted KindHandle ${tag}`;
+  }
+  let newFacetNames;
+  if (proposedFacetNames) {
+    const oldFacetNames = desc.facets ? [...desc.facets] : [];
+    const proposal = [...proposedFacetNames];
+    newFacetNames = [];
+    // all old facets must be present in the proposal
+    for (const facet of oldFacetNames) {
+      const proposedIdx = proposal.indexOf(facet);
+      if (proposedIdx === -1) {
+        const orig = oldFacetNames.join(',');
+        const newer = proposedFacetNames.join(',');
+        Fail`durable kind "${tag}" facets (${newer}) is missing ${facet} from original definition (${orig})`;
+      }
+      proposal.splice(proposedIdx, 1); // remove from proposal
+      newFacetNames.push(facet);
+    }
+
+    // new facets are appended in alphabetic order
+    proposal.sort();
+    desc.facets = newFacetNames.concat(proposal);
+  } else {
+    desc.unfaceted = true;
+  }
+  return desc.facets; // 'undefined' for unfaceted
+  // caller will saveDurableKindDescriptor()
+};

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -1396,6 +1396,8 @@ function build(
     possiblyRetiredSet,
     slotToVal,
     valToSlot,
+    // eslint-disable-next-line no-use-before-define
+    afterDispatchActions,
   });
 
   function setVatOption(option, _value) {

--- a/packages/swingset-liveslots/src/virtualReferences.js
+++ b/packages/swingset-liveslots/src/virtualReferences.js
@@ -151,15 +151,11 @@ export function makeVirtualReferenceManager(
     const { baseRef, id, facet } = parseVatSlot(vref);
     const key = `vom.es.${baseRef}`;
     const esRaw = syscall.vatstoreGet(key);
-    // If `esRaw` is undefined, it means there's no export status information
-    // available, which can only happen when we are exporting the object for the
-    // first time, which in turn means that the object must be in memory (since
-    // export is happening when it's being serialized) and thus it has an
-    // instance or cohort record from which a facet count can be derived.  On
-    // the other hand, if `esRaw` does have a value, the value will be a string
-    // whose length is the facet count.  Either way, we will know how many
-    // facets there are.
-    const es = Array.from(esRaw || 'n'.repeat(getFacetCount(id)));
+    // 'esRaw' may be undefined (nothing is currently exported), and
+    // it might be short (saved by a previous version that had fewer
+    // facets). Pad it out to the current length, which is '1' for
+    // unfaceted Kinds
+    const es = Array.from((esRaw || '').padEnd(getFacetCount(id), 'n'));
     const facetIdx = facet === undefined ? 0 : facet;
     // The export status of each facet is encoded as:
     // 's' -> 'recognizable' ('s' for "see"), 'r' -> 'reachable', 'n' -> 'none'

--- a/packages/swingset-liveslots/test/test-facetiousness.js
+++ b/packages/swingset-liveslots/test/test-facetiousness.js
@@ -1,11 +1,19 @@
 import '@endo/init/debug.js';
 import test from 'ava';
-import { assessFacetiousness } from '../src/facetiousness.js';
+import {
+  assessFacetiousness,
+  checkAndUpdateFacetiousness,
+} from '../src/facetiousness.js';
 
 const empty = harden({});
 
 const single = harden({
   add: (a, b) => a + b,
+});
+
+const emptyMulti = harden({
+  foo: {},
+  bar: {},
 });
 
 const multi = harden({
@@ -85,6 +93,7 @@ test('facetiousness', t => {
   t.is(assessFacetiousness(single), 'one');
 
   t.is(assessFacetiousness(multi), 'many');
+  t.is(assessFacetiousness(emptyMulti), 'many');
 
   t.is(assessFacetiousness(brokenNested), 'not');
   t.is(assessFacetiousness(brokenMixed1), 'not');
@@ -95,4 +104,59 @@ test('facetiousness', t => {
   t.is(assessFacetiousness(brokenMixedData1), 'not');
   t.is(assessFacetiousness(brokenMixedData2), 'not');
   t.is(assessFacetiousness(brokenMultiNonFacet), 'not');
+});
+
+test('checkAndUpdateFacetiousness', t => {
+  const cauf = (...args) => checkAndUpdateFacetiousness('tag', ...args);
+  const desc = facets =>
+    facets ? { facets: facets.sort() } : { unfaceted: true };
+  const foo = ['foo'];
+  const foobar = ['foo', 'bar'];
+  const barfoo = ['bar', 'foo'];
+  const foobarbaz = ['foo', 'bar', 'baz'];
+  const foobazbar = ['foo', 'baz', 'bar'];
+  const barfoobaz = ['bar', 'foo', 'baz'];
+  const zotfoobazbar = ['zot', 'foo', 'baz', 'bar'];
+  const barfoobazzot = ['bar', 'foo', 'baz', 'zot'];
+
+  // new definitions use the facet names of the proposal (sorted)
+  t.is(cauf({}, undefined), undefined); // single
+  t.deepEqual(cauf({}, foo), foo);
+  t.deepEqual(cauf({}, foobar), barfoo);
+  t.deepEqual(cauf({}, barfoo), barfoo);
+
+  // a single Kind can only be redefined as another single
+  t.deepEqual(cauf(desc(), undefined), undefined);
+  t.throws(() => cauf(desc(), foo), {
+    message: 'defineDurableKindMulti called for unfaceted KindHandle "tag"',
+  });
+
+  // multi Kinds cannot be redefined as single
+  t.throws(() => cauf(desc(foo), undefined), {
+    message: 'defineDurableKind called for faceted KindHandle "tag"',
+  });
+
+  // a multi Kind can be redefined with all the original facets,
+  // possibly plus more, which are added in sorted order
+  t.deepEqual(cauf(desc(foo), foo), foo);
+  t.deepEqual(cauf(desc(foo), foobar), foobar);
+  t.deepEqual(cauf(desc(foo), barfoo), foobar);
+  t.deepEqual(cauf(desc(foo), foobarbaz), foobarbaz); // bar/baz sorted
+  t.deepEqual(cauf(desc(foo), foobazbar), foobarbaz);
+
+  t.deepEqual(cauf(desc(foobar), foobar), barfoo);
+  t.deepEqual(cauf(desc(foobar), barfoo), barfoo);
+  t.deepEqual(cauf(desc(foobar), foobarbaz), barfoobaz);
+  t.deepEqual(cauf(desc(foobar), foobarbaz), barfoobaz);
+  t.deepEqual(cauf(desc(foobar), zotfoobazbar), barfoobazzot);
+
+  // missing facets cause an error
+  t.throws(() => cauf(desc(foobar), foo), {
+    message:
+      'durable kind ""tag"" facets ("foo") is missing "bar" from original definition ("bar,foo")',
+  });
+  t.throws(() => cauf(desc(foobarbaz), foobar), {
+    message:
+      'durable kind ""tag"" facets ("bar,foo") is missing "baz" from original definition ("bar,baz,foo")',
+  });
 });

--- a/packages/swingset-liveslots/test/virtual-objects/test-kind-changes.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-kind-changes.js
@@ -1,6 +1,13 @@
 import test from 'ava';
 import '@endo/init/debug.js';
+import { Far } from '@endo/marshal';
 import { makeFakeVirtualStuff } from '../../tools/fakeVirtualSupport.js';
+import { makeLiveSlots } from '../../src/liveslots.js';
+import { parseVatSlot } from '../../src/parseVatSlots.js';
+import { kser } from '../kmarshal.js';
+import { buildSyscall } from '../liveslots-helpers.js';
+import { makeStartVat, makeMessage } from '../util.js';
+import { makeMockGC } from '../mock-gc.js';
 
 const init = () => ({});
 const behavior = {};
@@ -91,48 +98,122 @@ test('kind upgrade from multi', t => {
   };
   const works = behaviors => trial(behaviors, null);
 
-  // deleting late-alphabet facets is accepted (but shouldn't be!),
-  // but a behavior with only one facet is rejected by
-  // defendPrototypeKit
-  const err1 = { message: 'A multi-facet object must have multiple facets' };
-  trial(bBar, err1);
+  const m = (proposed, missing) => ({
+    message: `durable kind ""FooBarClu"" facets ("${proposed}") is missing "${missing}" from original definition ("bar,clu,foo")`,
+  });
+
+  // deleting late-alphabet facets is rejected by VOM
+  trial(bBar, m('bar', 'clu'));
 
   // deleting early- or middle-alphabet facets is rejected by VOM
-  const err2 = {
-    message:
-      /durable kind ""FooBarClu"" facets .* don't match original definition/,
-  };
-  trial(bFoo, err2);
-  trial(bFooBar, err2);
+  trial(bFoo, m('foo', 'bar'));
 
-  // deleting late-alphabet facets should be rejected, but isn't
-  // trial(bCluBar, err2);
-  works(bCluBar); // TODO REMOVE, SHOULD NOT WORK
+  trial(bFooBar, m('bar,foo', 'clu'));
+  trial(bCluBar, m('bar,clu', 'foo'));
 
   // same facets in same order: ok
   works(bFooBarClu);
   // same facets in different order: ok
   works(bBarFooClu);
 
-  // adding new facets ought to work, but does not. when 7437 is
-  // fixed, swap in the commented out trials
+  // adding new facets ought to work
 
-  // works(bFooBarCluZot);
-  trial(bFooBarCluZot, err2);
-  // works(bFooBarCluArf);
-  trial(bFooBarCluArf, err2);
-  // works(bFooBarCluBaz);
-  trial(bFooBarCluBaz, err2);
-  // works(bArfFooBarClu);
-  trial(bArfFooBarClu, err2);
-  // works(bZotFooBarClu);
-  trial(bZotFooBarClu, err2);
-  // works(bBazFooBarClu);
-  trial(bBazFooBarClu, err2);
+  works(bFooBarCluZot);
+  works(bFooBarCluArf);
+  works(bFooBarCluBaz);
+  works(bArfFooBarClu);
+  works(bZotFooBarClu);
+  works(bBazFooBarClu);
 
   // multi->single: error
-  const err3 = {
+  trial('single', {
     message: 'defineDurableKind called for faceted KindHandle "FooBarClu"',
-  };
-  trial('single', err3);
+  });
+});
+
+test('export status across new-facet upgrade', async t => {
+  const kvStore = new Map();
+  const { syscall: sc1, log: log1 } = buildSyscall({ kvStore });
+  const gcTools = makeMockGC();
+
+  let one1;
+
+  function build1(vatPowers, _vp, baggage) {
+    const { VatData } = vatPowers;
+    const { makeKindHandle, defineDurableKindMulti } = VatData;
+    const kh = makeKindHandle('multi');
+    baggage.init('kh', kh);
+    const one = {};
+    const two = {};
+    const bOneTwo = { one, two };
+    const make = defineDurableKindMulti(kh, init, bOneTwo);
+
+    return Far('root', {
+      exportOne: () => {
+        const obj1 = make();
+        one1 = obj1.one;
+        return one1;
+      },
+    });
+  }
+
+  const makeNS1 = () => ({ buildRootObject: build1 });
+  const ls1 = makeLiveSlots(sc1, 'vatA', {}, {}, gcTools, undefined, makeNS1);
+  await ls1.dispatch(makeStartVat(kser()));
+  log1.length = 0;
+  const rootA = 'o+0';
+  const oneKPID = 'p-1';
+  await ls1.dispatch(makeMessage(rootA, 'exportOne', [], oneKPID));
+
+  const oneVref = ls1.testHooks.valToSlot.get(one1);
+  const oneBaseRef = parseVatSlot(oneVref).baseRef;
+  const oneKind = `${parseVatSlot(oneVref).id}`;
+  const descriptorKey = `vom.dkind.${oneKind}.descriptor`;
+  const descriptor1 = JSON.parse(kvStore.get(descriptorKey));
+
+  // facets are sorted property names of the initial behavior record
+  t.deepEqual(descriptor1.facets, ['one', 'two']);
+  const es1 = kvStore.get(`vom.es.${oneBaseRef}`);
+
+  // export status is a string, one letter per facet, same order as
+  // descriptor.facets . The 'one' facet will be 'r' for reachable
+  // (since it was emitted as the resolution of oneKPID), the 'two'
+  // facet is 'n' for 'neither' (since it was not emitted).
+  t.is(es1, 'rn');
+
+  // now upgrade to a Kind with two new facets, and export the third
+
+  const { syscall: sc2, log: log2 } = buildSyscall({ kvStore });
+
+  function build2(vatPowers, _vp, baggage) {
+    const { VatData } = vatPowers;
+    const { defineDurableKindMulti } = VatData;
+    const kh = baggage.get('kh');
+    const one = { getThree: ({ facets }) => facets.three };
+    const two = {};
+    const three = {};
+    const four = {};
+    const bOneTwoThreeFour = { one, two, three, four };
+    defineDurableKindMulti(kh, init, bOneTwoThreeFour);
+
+    return Far('root', {});
+  }
+
+  const makeNS2 = () => ({ buildRootObject: build2 });
+  const ls2 = makeLiveSlots(sc2, 'vatA', {}, {}, gcTools, undefined, makeNS2);
+  await ls2.dispatch(makeStartVat(kser()));
+  log2.length = 0;
+  const threeKPID = 'p-2';
+  await ls2.dispatch(makeMessage(oneVref, 'getThree', [], threeKPID));
+  // returning/exporting 'three' will call setExportStatus() to update
+  // the export status from "only 'one' is exported'" to "both 'one'
+  // and 'three' are exported". That will see the old export status
+  // with only two items, and upgrade it to the full four items.
+
+  const descriptor2 = JSON.parse(kvStore.get(descriptorKey));
+
+  // old facets retain their position, new facets are added in sorted order
+  t.deepEqual(descriptor2.facets, ['one', 'two', 'four', 'three']);
+  const es2 = kvStore.get(`vom.es.${oneBaseRef}`);
+  t.is(es2, 'rnnr'); // 'one' and 'three' are exported
 });

--- a/packages/swingset-liveslots/test/virtual-objects/test-kind-changes.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-kind-changes.js
@@ -1,0 +1,138 @@
+import test from 'ava';
+import '@endo/init/debug.js';
+import { makeFakeVirtualStuff } from '../../tools/fakeVirtualSupport.js';
+
+const init = () => ({});
+const behavior = {};
+// (empty) facets which each Kind may or may not have
+const foo = {};
+const bar = {};
+const baz = {};
+const clu = {};
+const zot = {};
+const arf = {};
+
+// behaviors with different combinations of facets
+const bBar = { bar }; // only one facet, rejected by defendPrototypeKit
+const bFoo = { foo }; // only one facet, rejected by defendPrototypeKit
+const bFooClu = { foo, clu }; // missing alphabetic first
+const bFooBar = { foo, bar }; // missing alphabetic middle
+const bCluBar = { clu, bar }; // missing alphabetic last
+const bFooBarClu = { foo, bar, clu }; // starting point
+const bBarFooClu = { bar, foo, clu }; // same facets, different order
+const bFooBarCluZot = { foo, bar, clu, zot }; // add alphabetic last
+const bFooBarCluArf = { foo, bar, clu, arf }; // add alphabetic first
+const bFooBarCluBaz = { foo, bar, clu, baz }; // add alphabetic middle
+const bArfFooBarClu = { arf, foo, bar, clu }; // add alphabetic last
+const bZotFooBarClu = { zot, foo, bar, clu }; // add alphabetic first
+const bBazFooBarClu = { baz, foo, bar, clu }; // add alphabetic middle
+
+// durable Kinds can be upgraded to a compatible definition, but all
+// previous facets must be provided
+
+test('kind upgrade from single', t => {
+  const fakeStore = new Map();
+  // note: relaxDurabilityRules defaults to true in fake tools
+  const vs1 = makeFakeVirtualStuff({ relaxDurabilityRules: false, fakeStore });
+  const { vom: vom1, cm: cm1 } = vs1;
+  const baggage1 = cm1.provideBaggage();
+  const kh1 = vom1.makeKindHandle('single');
+  baggage1.init('kh', kh1);
+  vom1.defineDurableKind(kh1, init, behavior);
+  vom1.flushStateCache();
+  cm1.flushSchemaCache();
+
+  // Simulate upgrade by starting from the non-empty kvStore.
+  const clonedStore = new Map(fakeStore);
+  const vs2 = makeFakeVirtualStuff({
+    relaxDurabilityRules: false,
+    fakeStore: clonedStore,
+  });
+  const { vom: vom2, cm: cm2 } = vs2;
+  const baggage2 = cm2.provideBaggage();
+  const kh2 = baggage2.get('kh');
+  const err1 = {
+    message: 'defineDurableKindMulti called for unfaceted KindHandle "single"',
+  };
+  t.throws(() => vom2.defineDurableKindMulti(kh2, init, bFoo), err1);
+  t.throws(() => vom2.defineDurableKindMulti(kh2, init, bFooClu), err1);
+});
+
+test('kind upgrade from multi', t => {
+  const fakeStore = new Map();
+  const vs1 = makeFakeVirtualStuff({ relaxDurabilityRules: false, fakeStore });
+  const { vom: vom1, cm: cm1 } = vs1;
+  const baggage1 = cm1.provideBaggage();
+  const kh1 = vom1.makeKindHandle('FooBarClu');
+  baggage1.init('kh', kh1);
+  vom1.defineDurableKindMulti(kh1, init, bFooBarClu);
+  vom1.flushStateCache();
+  cm1.flushSchemaCache();
+
+  const trial = (behaviors, err) => {
+    // Simulate upgrade by starting from the non-empty kvStore.
+    const clonedStore = new Map(fakeStore);
+    const vs2 = makeFakeVirtualStuff({
+      relaxDurabilityRules: false,
+      fakeStore: clonedStore,
+    });
+    const { vom: vom2, cm: cm2 } = vs2;
+    const baggage2 = cm2.provideBaggage();
+    const kh2 = baggage2.get('kh');
+    if (err) {
+      if (behaviors === 'single') {
+        t.throws(() => vom2.defineDurableKind(kh2, init, foo), err);
+      } else {
+        t.throws(() => vom2.defineDurableKindMulti(kh2, init, behaviors), err);
+      }
+    } else {
+      t.truthy(vom2.defineDurableKindMulti(kh2, init, behaviors));
+    }
+  };
+  const works = behaviors => trial(behaviors, null);
+
+  // deleting late-alphabet facets is accepted (but shouldn't be!),
+  // but a behavior with only one facet is rejected by
+  // defendPrototypeKit
+  const err1 = { message: 'A multi-facet object must have multiple facets' };
+  trial(bBar, err1);
+
+  // deleting early- or middle-alphabet facets is rejected by VOM
+  const err2 = {
+    message:
+      /durable kind ""FooBarClu"" facets .* don't match original definition/,
+  };
+  trial(bFoo, err2);
+  trial(bFooBar, err2);
+
+  // deleting late-alphabet facets should be rejected, but isn't
+  // trial(bCluBar, err2);
+  works(bCluBar); // TODO REMOVE, SHOULD NOT WORK
+
+  // same facets in same order: ok
+  works(bFooBarClu);
+  // same facets in different order: ok
+  works(bBarFooClu);
+
+  // adding new facets ought to work, but does not. when 7437 is
+  // fixed, swap in the commented out trials
+
+  // works(bFooBarCluZot);
+  trial(bFooBarCluZot, err2);
+  // works(bFooBarCluArf);
+  trial(bFooBarCluArf, err2);
+  // works(bFooBarCluBaz);
+  trial(bFooBarCluBaz, err2);
+  // works(bArfFooBarClu);
+  trial(bArfFooBarClu, err2);
+  // works(bZotFooBarClu);
+  trial(bZotFooBarClu, err2);
+  // works(bBazFooBarClu);
+  trial(bBazFooBarClu, err2);
+
+  // multi->single: error
+  const err3 = {
+    message: 'defineDurableKind called for faceted KindHandle "FooBarClu"',
+  };
+  trial('single', err3);
+});

--- a/packages/swingset-liveslots/tools/fakeCollectionManager.js
+++ b/packages/swingset-liveslots/tools/fakeCollectionManager.js
@@ -6,7 +6,9 @@ export function makeFakeCollectionManager(vrm, fakeStuff, _options = {}) {
     makeScalarBigWeakMapStore,
     makeScalarBigSetStore,
     makeScalarBigWeakSetStore,
+    provideBaggage,
     initializeStoreKindInfo,
+    flushSchemaCache,
   } = makeCollectionManager(
     fakeStuff.syscall,
     vrm,
@@ -26,6 +28,8 @@ export function makeFakeCollectionManager(vrm, fakeStuff, _options = {}) {
     makeScalarBigWeakMapStore,
     makeScalarBigSetStore,
     makeScalarBigWeakSetStore,
+    provideBaggage,
+    flushSchemaCache,
   };
 
   const debugTools = {

--- a/packages/swingset-liveslots/tools/fakeVirtualSupport.js
+++ b/packages/swingset-liveslots/tools/fakeVirtualSupport.js
@@ -27,6 +27,7 @@ export function makeFakeLiveSlotsStuff(options = {}) {
   }
 
   const {
+    fakeStore = new Map(),
     weak = false,
     log,
     FinalizationRegistry = FakeFinalizationRegistry,
@@ -34,7 +35,6 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     addToPossiblyRetiredSet = () => {},
   } = options;
 
-  const fakeStore = new Map();
   let sortedKeys;
   let priorKeyReturned;
   let priorKeyIndex;


### PR DESCRIPTION
fix(liveslots): allow new Kind upgrade to add new facets

When a new vat's new incarnation is redefining all the existing
durable Kinds, it provides new behavior records, which might contain a
different set of facets than the previous incarnation was using.

Vats are not allowed to omit old facets: they are required to provide
definitions for every facet that the previous version defined. However
they *are* allowed to *add* facets. New calls to the maker will return
a larger cohort of Representatives than before. The new facets will be
created (during deserialization) of pre-existing objects too, however
the only way to access them will be through new behavior functions on
old facets (through e.g. `facets.newFacet`).

Previously, this new-facets compatibility check was broken. New facets
were never allowed, and even some old facets could be omitted without
causing `defineDurableKindMulti` to throw an error (although behavior
beyond that point was probably corrupt).

This commit changes the VOM to properly allow new facets, and to check
for any missing ones. This relies upon the recent change to
`setExportStatus()`, to tolerate old `vom.es.${baseRef}` records with
fewer facets than the current definition is tracking.

`checkAndUpdateFacetiousness()` is factored out into a separate file,
with extensive tests. New tests were added to test-kind-changes.js, as
well as higher-level tests in packages/SwingSet (test-upgrade.js was
rewritten to exercise the various combinations more directly).

closes #7437
