### PR TITLE
Better shutdown

### DIFF
--- a/packages/telemetry/src/index.js
+++ b/packages/telemetry/src/index.js
@@ -10,6 +10,7 @@ export * from './make-slog-sender.js';
  * @typedef {((obj: {}, jsonObj?: string | undefined) => void) & {
  *  usesJsonObject?: boolean;
  *  forceFlush?: () => Promise<void>;
+ *  shutdown?: () => Promise<void>;
  * }} SlogSender
  */
 /**

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -166,6 +166,10 @@ export const makeSlogSender = async (opts = {}) => {
           ...senders.map(sender => sender.forceFlush?.()),
           ...sendErrors.splice(0).map(err => Promise.reject(err)),
         ]).then(() => {}),
+      shutdown: async () =>
+        PromiseAllOrErrors(senders.map(sender => sender.shutdown?.())).then(
+          () => {},
+        ),
       usesJsonObject: hasSenderUsingJsonObj,
     });
   }

--- a/packages/telemetry/src/otel-trace.js
+++ b/packages/telemetry/src/otel-trace.js
@@ -56,14 +56,16 @@ export const makeSlogSender = async opts => {
 
   // Cleanly shutdown if possible.
   const { registerShutdown } = makeShutdown();
-  registerShutdown(async () => {
+  const shutdown = async () => {
     finish();
     await tracingProvider.forceFlush();
     await tracingProvider.shutdown();
-  });
+  };
+  registerShutdown(shutdown);
 
   return Object.assign(slogSender, {
     forceFlush: async () => tracingProvider.forceFlush(),
+    shutdown,
     usesJsonObject: false,
   });
 };

--- a/packages/telemetry/src/slog-file.js
+++ b/packages/telemetry/src/slog-file.js
@@ -16,6 +16,7 @@ export const makeSlogSender = async ({ env: { SLOGFILE } = {} } = {}) => {
 
   return Object.assign(slogSender, {
     forceFlush: async () => stream.flush(),
+    shutdown: async () => stream.close(),
     usesJsonObject: true,
   });
 };

--- a/packages/telemetry/src/slog-sender-pipe-entrypoint.js
+++ b/packages/telemetry/src/slog-sender-pipe-entrypoint.js
@@ -39,6 +39,7 @@ const main = async () => {
 
   registerShutdown(async () => {
     await slogSender?.forceFlush?.();
+    await slogSender?.shutdown?.();
     process.disconnect?.();
   });
 

--- a/packages/telemetry/src/slog-sender-pipe.js
+++ b/packages/telemetry/src/slog-sender-pipe.js
@@ -160,7 +160,7 @@ export const makeSlogSender = async opts => {
     void pipeSend({ type: 'send', obj });
   };
 
-  registerShutdown(async () => {
+  const shutdown = async () => {
     // logger.log('shutdown');
     if (!cp.connected) {
       return;
@@ -168,7 +168,8 @@ export const makeSlogSender = async opts => {
 
     await flush();
     cp.disconnect();
-  });
+  };
+  registerShutdown(shutdown);
 
   const { hasSender } = await init(opts).catch(err => {
     cp.disconnect();
@@ -185,6 +186,7 @@ export const makeSlogSender = async opts => {
     forceFlush: async () => {
       await flush();
     },
+    shutdown,
     usesJsonObject: false,
   });
 };


### PR DESCRIPTION
## Description

Allow to explicitly shutdown the telemetry infrastructure.
Avoid force exiting the process if it would have exited naturally.

### Security Considerations

None I can think of

### Scaling Considerations

None

### Documentation Considerations

Mostly internal, but allows to better flush our telemetry infra on exit.

### Testing Considerations

This allows tests to spin up telemetry, and be able to shut it down without tripping the ava checks on clean exit.
