### PR TITLE
fix(notifier)!: Stop retaining durable publish kit values in RAM

### DIFF
--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -15,8 +15,10 @@ const makeQuietRejection = reason => {
   void E.when(rejection, sink, sink);
   return rejection;
 };
-const makeTooFarRejection = () =>
-  makeQuietRejection(new Error('Cannot read past end of iteration.'));
+const makeTooFarRejection = () => {
+  const err = harden(new Error('Cannot read past end of iteration.'));
+  return makeQuietRejection(err);
+};
 
 export const PublisherI = M.interface('Publisher', {
   publish: M.call(M.any()).returns(),

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -15,10 +15,9 @@ const makeQuietRejection = reason => {
   void E.when(rejection, sink, sink);
   return rejection;
 };
-const makeTooFarRejection = () => {
-  const err = harden(new Error('Cannot read past end of iteration.'));
-  return makeQuietRejection(err);
-};
+const tooFarRejection = makeQuietRejection(
+  harden(new Error('Cannot read past end of iteration.')),
+);
 
 export const PublisherI = M.interface('Publisher', {
   publish: M.call(M.any()).returns(),
@@ -101,7 +100,7 @@ export const makePublishKit = () => {
     const resolveCurrent = tailR;
 
     if (done) {
-      tailP = makeTooFarRejection();
+      tailP = tooFarRejection;
       tailR = undefined;
     } else {
       ({ promise: tailP, resolve: tailR } = makePromiseKit());
@@ -294,7 +293,7 @@ const provideDurablePublishKitEphemeralData = (state, facets) => {
     ({ promise: tailP, resolve: tailR } = makePromiseKit());
     void E.when(tailP, sink, sink);
   } else if (status === 'finished' || status === 'failed') {
-    tailP = makeTooFarRejection();
+    tailP = tooFarRejection;
   } else {
     throw Fail`Invalid durable promise kit status: ${q(status)}`;
   }
@@ -332,7 +331,7 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
   let tailR;
   if (done) {
     state.status = targetStatus;
-    tailP = makeTooFarRejection();
+    tailP = tooFarRejection;
     tailR = undefined;
   } else {
     ({ promise: tailP, resolve: tailR } = makePromiseKit());

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -15,6 +15,8 @@ const makeQuietRejection = reason => {
   void E.when(rejection, sink, sink);
   return rejection;
 };
+const makeTooFarRejection = () =>
+  makeQuietRejection(new Error('Cannot read past end of iteration.'));
 
 export const PublisherI = M.interface('Publisher', {
   publish: M.call(M.any()).returns(),
@@ -97,9 +99,7 @@ export const makePublishKit = () => {
     const resolveCurrent = tailR;
 
     if (done) {
-      tailP = makeQuietRejection(
-        new Error('Cannot read past end of iteration.'),
-      );
+      tailP = makeTooFarRejection();
       tailR = undefined;
     } else {
       ({ promise: tailP, resolve: tailR } = makePromiseKit());
@@ -216,21 +216,67 @@ const initDurablePublishKitState = (options = {}) => {
  */
 const getEphemeralKey = facets => facets.publisher;
 
-/** @type {WeakMap<DurablePublishKitEphemeralKey, {currentP, tailP, tailR}>} */
+/**
+ * @typedef DurablePublishKitEphemeralData
+ * @property {Promise<*> | undefined} currentP The current-result promise
+ *   (undefined unless resolved with unrecoverable ephemeral data)
+ * @property {Promise<*>} tailP The next-result promise
+ * @property {import('@endo/promise-kit').PromiseKit<*>['resolve'] | undefined} tailR The next-result resolver
+ *   (undefined when the publish kit has terminated)
+ */
+
+/** @type {WeakMap<DurablePublishKitEphemeralKey, DurablePublishKitEphemeralData>} */
 const durablePublishKitEphemeralData = new WeakMap();
 
 /**
- * Returns the current/next-result promises and next-result resolver
- * associated with a given durable publish kit.
- * They are lost on upgrade, but recreated on-demand.
- * Such recreation preserves the value in (but not the identity of) the
- * current { value, done } result when possible, which is always the
- * case when that value is terminal (i.e., from `finish` or `fail`) or
- * when the durable publish kit is configured with
- * `valueDurability: 'mandatory'`.
+ * Returns the current-result promise associated with a given durable
+ * publish kit, recreated unless we already have one with retained
+ * ephemeral data.
  *
  * @param {DurablePublishKitState} state
  * @param {PublishKit<*>} facets
+ * @param {Promise<*>} tail
+ * @returns {Promise<*>}
+ */
+const provideCurrentP = (state, facets, tail) => {
+  const ephemeralKey = getEphemeralKey(facets);
+  const foundData = durablePublishKitEphemeralData.get(ephemeralKey);
+  const currentP = foundData?.currentP;
+  if (currentP) {
+    return currentP;
+  }
+
+  const { publishCount, status, hasValue, value } = state;
+  if (!hasValue) {
+    assert(status === 'live');
+    return tail;
+  }
+  if (status === 'live' || status === 'finished') {
+    const cell = harden({
+      head: { value, done: status !== 'live' },
+      publishCount,
+      tail,
+    });
+    return E.resolve(cell);
+  } else if (status === 'failed') {
+    return makeQuietRejection(value);
+  } else {
+    throw Fail`Invalid durable promise kit status: ${q(status)}`;
+  }
+};
+
+/**
+ * Returns the next-result promise and resolver associated with a given
+ * durable publish kit.
+ * These are lost on upgrade but recreated on-demand, preserving the
+ * value in (but not the identity of) the current { value, done } result
+ * when possible, which is always the case when that value is terminal
+ * (i.e., from `finish` or `fail`) or when the durable publish kit is
+ * configured with `valueDurability: 'mandatory'`.
+ *
+ * @param {DurablePublishKitState} state
+ * @param {PublishKit<*>} facets
+ * @returns {DurablePublishKitEphemeralData}
  */
 const provideDurablePublishKitEphemeralData = (state, facets) => {
   const ephemeralKey = getEphemeralKey(facets);
@@ -238,53 +284,22 @@ const provideDurablePublishKitEphemeralData = (state, facets) => {
   if (foundData) {
     return foundData;
   }
-  const { status, publishCount } = state;
-  /** @type {object} */
-  let newData;
-  if (status === 'failed') {
-    newData = {
-      currentP: makeQuietRejection(state.value),
-      tailP: makeQuietRejection(
-        new Error('Cannot read past end of iteration.'),
-      ),
-      tailR: undefined,
-    };
-  } else if (status === 'finished') {
-    const tailP = makeQuietRejection(
-      new Error('Cannot read past end of iteration.'),
-    );
-    newData = {
-      currentP: E.resolve(
-        harden({
-          head: { value: state.value, done: true },
-          publishCount,
-          tail: tailP,
-        }),
-      ),
-      tailP,
-      tailR: undefined,
-    };
-  } else if (status === 'live') {
-    const { promise: tailP, resolve: tailR } = makePromiseKit();
+
+  const { status } = state;
+  let tailP;
+  let tailR;
+  if (status === 'live') {
+    ({ promise: tailP, resolve: tailR } = makePromiseKit());
     void E.when(tailP, sink, sink);
-    newData = {
-      currentP: state.hasValue
-        ? E.resolve(
-            harden({
-              head: { value: state.value, done: false },
-              publishCount,
-              tail: tailP,
-            }),
-          )
-        : tailP,
-      tailP,
-      tailR,
-    };
+  } else if (status === 'finished' || status === 'failed') {
+    tailP = makeTooFarRejection();
   } else {
-    Fail`Invalid durable promise kit status: ${q(status)}`;
+    throw Fail`Invalid durable promise kit status: ${q(status)}`;
   }
-  durablePublishKitEphemeralData.set(ephemeralKey, harden(newData));
-  return newData;
+  // currentP is not ephemeral when restoring from persisted state.
+  const obj = harden({ currentP: undefined, tailP, tailR });
+  durablePublishKitEphemeralData.set(ephemeralKey, obj);
+  return obj;
 };
 
 /**
@@ -304,32 +319,30 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
   if (done || valueDurability === 'mandatory') {
     canBeDurable(value) || Fail`Cannot accept non-durable value: ${value}`;
   }
-  const { tailP: currentP, tailR: resolveCurrent } =
+  const { tailP: oldTailP, tailR: resolveOldTail } =
     provideDurablePublishKitEphemeralData(state, facets);
+  assert.typeof(resolveOldTail, 'function');
 
   const publishCount = state.publishCount + 1n;
   state.publishCount = publishCount;
+
   let tailP;
   let tailR;
-
   if (done) {
     state.status = targetStatus;
-    tailP = makeQuietRejection(new Error('Cannot read past end of iteration.'));
+    tailP = makeTooFarRejection();
     tailR = undefined;
   } else {
     ({ promise: tailP, resolve: tailR } = makePromiseKit());
     void E.when(tailP, sink, sink);
   }
-  durablePublishKitEphemeralData.set(
-    getEphemeralKey(facets),
-    harden({ currentP, tailP, tailR }),
-  );
 
+  let currentP;
   if (targetStatus === 'failed') {
     state.hasValue = true;
     state.value = value;
     const rejection = makeQuietRejection(value);
-    resolveCurrent(rejection);
+    resolveOldTail(rejection);
   } else {
     // Persist a terminal value, or a non-terminal value
     // if configured as 'mandatory' or 'opportunistic'.
@@ -339,9 +352,11 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
     } else {
       state.hasValue = false;
       state.value = undefined;
+      // Retain any promise with non-durable resolution.
+      currentP = oldTailP;
     }
 
-    resolveCurrent(
+    resolveOldTail(
       harden({
         head: { value, done },
         publishCount,
@@ -349,6 +364,11 @@ const advanceDurablePublishKit = (context, value, targetStatus = 'live') => {
       }),
     );
   }
+
+  durablePublishKitEphemeralData.set(
+    getEphemeralKey(facets),
+    harden({ currentP, tailP, tailR }),
+  );
 };
 
 /**
@@ -396,7 +416,7 @@ export const prepareDurablePublishKit = (baggage, kindName) => {
           if (publishCount === currentPublishCount) {
             return tailP;
           } else if (publishCount < currentPublishCount) {
-            return currentP;
+            return currentP || provideCurrentP(state, facets, tailP);
           } else {
             throw new Error(
               'subscribeAfter argument must be a previously-issued publishCount.',

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -223,7 +223,7 @@ const getEphemeralKey = facets => facets.publisher;
  * @property {Promise<*> | undefined} currentP The current-result promise
  *   (undefined unless resolved with unrecoverable ephemeral data)
  * @property {Promise<*>} tailP The next-result promise
- * @property {import('@endo/promise-kit').PromiseKit<*>['resolve'] | undefined} tailR The next-result resolver
+ * @property {((value: any) => void) | undefined} tailR The next-result resolver
  *   (undefined when the publish kit has terminated)
  */
 

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -242,7 +242,7 @@ const durablePublishKitEphemeralData = new WeakMap();
 const provideCurrentP = (state, facets, tail) => {
   const ephemeralKey = getEphemeralKey(facets);
   const foundData = durablePublishKitEphemeralData.get(ephemeralKey);
-  const currentP = foundData?.currentP;
+  const currentP = foundData && foundData.currentP;
   if (currentP) {
     return currentP;
   }

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -63,13 +63,23 @@ const assertCells = (t, label, cells, publishCount, expected, options = {}) => {
   t.is(firstCell.publishCount, publishCount, `${label} cell publishCount`);
 
   if (strict) {
-    t.deepEqual(
-      new Set(cells),
-      new Set([firstCell]),
-      `all ${label} cells must referentially match`,
-    );
+    const { head, ...otherProps } = firstCell;
+    for (const [headKey, headValue] of Object.entries(head)) {
+      t.deepEqual(
+        new Set(cells.map(cell => cell.head[headKey])),
+        new Set([headValue]),
+        `the head ${q(headKey)} of each ${label} cell must referentially match`,
+      );
+    }
+    for (const [key, value] of Object.entries(otherProps)) {
+      t.deepEqual(
+        new Set(cells.map(cell => cell[key])),
+        new Set([value]),
+        `the ${q(key)} of each ${label} cell must referentially match`,
+      );
+    }
   } else {
-    const { tail: _tail, ...props } = cells[0];
+    const { tail: _tail, ...props } = firstCell;
     cells.slice(1).forEach((cell, i) => {
       t.like(cell, props, `${label} cell ${i + 1} must match cell 0`);
     });


### PR DESCRIPTION
Fixes #7298

## Description

Refactor ephemeral data to retain a promise resolved to the current value only when that value is ephemeral, which is currently prohibited by the [restriction of valueDurability to 'mandatory'](https://github.com/Agoric/agoric-sdk/blob/ed68edf80ceb09e619877e820cf57266948470a2/packages/notifier/src/publish-kit.js#L185).

### Security Considerations

n/a

### Scaling Considerations

This PR reduces RAM consumption by allowing durable promise kit resolution values to be paged out.

### Documentation Considerations

This change is breaking only because the identity of promises and `head` objects is no longer preserved, but I don't believe we ever promised such preservation and it isn't observable across vat boundaries anyway.

### Testing Considerations

I still want a test that verifies lack of retention, and am open to ideas regarding the best pattern for that.