### PR TITLE
Don't retain a vat's raw bundle string after use

### DIFF
--- a/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
+++ b/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
@@ -270,10 +270,12 @@ function makeWorker(port) {
       lsEndowments,
       inescapableGlobalProperties,
     ) {
+      assert(bundle, 'bundle undefined (duplicate buildVatNamespace call?)');
       const vatNS = await importBundle(bundle, {
         endowments: { ...workerEndowments, ...lsEndowments },
         inescapableGlobalProperties,
       });
+      bundle = undefined; // overwrite to allow GC to discard big string
       workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
       return vatNS;
     }


### PR DESCRIPTION
Closes #6981

I'm having trouble believing this is as trivial as it appears to be, and I have no idea how to test it, but here we go.
