### PR TITLE
build: resolve all floating promise warnings

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -41,7 +41,7 @@ module.exports = {
   extends: ['@agoric'],
   rules: {
     '@typescript-eslint/prefer-ts-expect-error': 'warn',
-    '@typescript-eslint/no-floating-promises': lintTypes ? 'warn' : 'off',
+    '@typescript-eslint/no-floating-promises': lintTypes ? 'error' : 'off',
     // so that floating-promises can be explicitly permitted with void operator
     'no-void': ['error', { allowAsStatement: true }],
 

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -139,7 +139,7 @@ test('makeIssuerKit bad optShutdownWithFailure', async t => {
 test('brand.isMyIssuer bad issuer', async t => {
   const { brand } = makeIssuerKit('myTokens');
   // @ts-expect-error Intentional wrong type for testing
-  t.throwsAsync(() => brand.isMyIssuer('not an issuer'), {
+  await t.throwsAsync(() => brand.isMyIssuer('not an issuer'), {
     message:
       'In "isMyIssuer" method of (myTokens brand): arg 0: string "not an issuer" - Must be a remotable (Issuer)',
   });

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -108,7 +108,7 @@ test('issuer.makeEmptyPurse', async t => {
   const performWithdrawal = () => purse.withdraw(fungible837);
 
   const checkWithdrawal = async newPayment => {
-    issuer.getAmountOf(newPayment).then(amount => {
+    await issuer.getAmountOf(newPayment).then(amount => {
       t.assert(
         AmountMath.isEqual(amount, fungible837),
         `the withdrawn payment has the right balance`,

--- a/packages/agoric-cli/src/deploy.js
+++ b/packages/agoric-cli/src/deploy.js
@@ -208,9 +208,7 @@ export default async function deployMain(progname, rawArgs, powers, opts) {
     publishBundleHttp,
   });
 
-  const retryWebsocket = async () => {
-    const accessToken = await getAccessToken(`${wsurl.hostname}:${myPort}`);
-
+  const retryWebsocket = accessToken => {
     // For a WebSocket we need to put the token in the query string.
     const wsWebkey = `${wsurl}?accessToken=${encodeURIComponent(accessToken)}`;
 
@@ -509,7 +507,11 @@ export { bootPlugin } from ${JSON.stringify(absPath)};
       exit.reject(e);
     });
   };
+
+  const accessToken = await getAccessToken(`${wsurl.hostname}:${myPort}`);
+
   // Start the retry process.
-  retryWebsocket();
+  retryWebsocket(accessToken);
+
   return exit.promise;
 }

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -545,11 +545,11 @@ export default async function main(progname, args, { env, homedir, agcc }) {
           },
         );
 
-        exportData.exporter.onDone().catch(() => {
+        exportData.exporter.onDone().catch(async () => {
           if (exportData === stateSyncExport) {
             stateSyncExport = undefined;
           }
-          exportData.cleanup();
+          await exportData.cleanup();
         });
 
         return exportData.exporter.onStarted().catch(err => {

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -384,13 +384,13 @@ export const spawnSwingStoreExport = (
   cp.on('error', kits.done.reject).on('exit', onExit).on('message', onMessage);
 
   kits.done.promise
-    .catch(err => {
-      kits.started.reject(err);
-    })
     .then(() => {
       cp.off('error', kits.done.reject)
         .off('exit', onExit)
         .off('message', onMessage);
+    })
+    .catch(err => {
+      kits.started.reject(err);
     });
 
   if (cp.exitCode != null) {

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -109,7 +109,7 @@ const makeBinaryVoteCounter = (
         outcome: 'fail',
         reason: 'No quorum',
       };
-      E(publisher).publish(voteOutcome);
+      void E(publisher).publish(voteOutcome);
       return;
     }
 
@@ -122,7 +122,7 @@ const makeBinaryVoteCounter = (
     }
 
     // XXX if we should distinguish ties, publish should be called in if above
-    E.when(outcomePromise.promise, position => {
+    void E.when(outcomePromise.promise, position => {
       /** @type {OutcomeRecord} */
       const voteOutcome = {
         question: details.questionHandle,

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -377,7 +377,7 @@ const makeParamManagerBuilder = (publisherKit, zoe) => {
   const build = () => {
     // XXX let params be finished async. A concession to upgradability
     // UNTIL https://github.com/Agoric/agoric-sdk/issues/4343
-    E.when(finishBuilding(), () => publish());
+    void E.when(finishBuilding(), () => publish());
 
     // CRUCIAL: Contracts that call buildParamManager should only export the
     // resulting paramManager to their creatorFacet, where it will be picked up by

--- a/packages/governance/src/multiCandidateVoteCounter.js
+++ b/packages/governance/src/multiCandidateVoteCounter.js
@@ -96,7 +96,7 @@ const makeMultiCandidateVoteCounter = (
         outcome: 'fail',
         reason: 'No quorum',
       };
-      E(publisher).publish(voteOutcome);
+      void E(publisher).publish(voteOutcome);
       return;
     }
 
@@ -139,7 +139,7 @@ const makeMultiCandidateVoteCounter = (
       outcomePromise.resolve(untiedPositions.concat(tieWinners));
     }
 
-    E.when(outcomePromise.promise, winPositions => {
+    void E.when(outcomePromise.promise, winPositions => {
       /** @type { MultiOutcomeRecord } */
       const voteOutcome = {
         question: details.questionHandle,

--- a/packages/governance/test/unitTests/test-binaryballotCount.js
+++ b/packages/governance/test/unitTests/test-binaryballotCount.js
@@ -149,7 +149,7 @@ test('binary tied', async t => {
   const bobSeat = makeHandle('Voter');
 
   const positions = aliceTemplate.getDetails().positions;
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]]);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]]);
   await E(creatorFacet).submitVote(bobSeat, [positions[1]]);
   closeFacet.closeVoting();
   const outcome = await E(publicFacet).getOutcome();
@@ -297,7 +297,7 @@ test('binary contested', async t => {
   const positions = template.getDetails().positions;
   t.deepEqual(positions.length, 2);
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]], 23n);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]], 23n);
   await E(creatorFacet).submitVote(bobSeat, [positions[1]], 47n);
   closeFacet.closeVoting();
 
@@ -337,8 +337,8 @@ test('binary revote', async t => {
   const positions = template.getDetails().positions;
   t.deepEqual(positions.length, 2);
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]], 23n);
-  E(creatorFacet).submitVote(bobSeat, [positions[1]], 47n);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]], 23n);
+  void E(creatorFacet).submitVote(bobSeat, [positions[1]], 47n);
   await E(creatorFacet).submitVote(bobSeat, [positions[1]], 15n);
   closeFacet.closeVoting();
 

--- a/packages/governance/test/unitTests/test-multiCandidateBallotCount.js
+++ b/packages/governance/test/unitTests/test-multiCandidateBallotCount.js
@@ -71,10 +71,10 @@ test('multi candidate contested', async t => {
   const positions = template.getDetails().positions;
   t.deepEqual(positions.length, 5);
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]], 2n);
-  E(creatorFacet).submitVote(bobSeat, [positions[2]], 15n);
-  E(creatorFacet).submitVote(tedSeat, [positions[1]], 27n);
-  E(creatorFacet).submitVote(carolSeat, [positions[3]], 17n);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]], 2n);
+  void E(creatorFacet).submitVote(bobSeat, [positions[2]], 15n);
+  void E(creatorFacet).submitVote(tedSeat, [positions[1]], 27n);
+  void E(creatorFacet).submitVote(carolSeat, [positions[3]], 17n);
   await E(creatorFacet).submitVote(jackSeat, [positions[4]], 14n);
   closeFacet.closeVoting();
 
@@ -121,12 +121,12 @@ test('multi candidate tie outcome', async t => {
   const positions = template.getDetails().positions;
   t.deepEqual(positions.length, 7);
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]], 3n);
-  E(creatorFacet).submitVote(bobSeat, [positions[2]], 5n);
-  E(creatorFacet).submitVote(tedSeat, [positions[1]], 5n);
-  E(creatorFacet).submitVote(carolSeat, [positions[3]], 8n);
-  E(creatorFacet).submitVote(johnSeat, [positions[5]], 5n);
-  E(creatorFacet).submitVote(charlieSeat, [positions[6]], 5n);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]], 3n);
+  void E(creatorFacet).submitVote(bobSeat, [positions[2]], 5n);
+  void E(creatorFacet).submitVote(tedSeat, [positions[1]], 5n);
+  void E(creatorFacet).submitVote(carolSeat, [positions[3]], 8n);
+  void E(creatorFacet).submitVote(johnSeat, [positions[5]], 5n);
+  void E(creatorFacet).submitVote(charlieSeat, [positions[6]], 5n);
   await E(creatorFacet).submitVote(jackSeat, [positions[4]], 5n);
   closeFacet.closeVoting();
 
@@ -178,10 +178,10 @@ test('multi candidate tie outcome case #2', async t => {
   const positions = template.getDetails().positions;
   t.deepEqual(positions.length, 7);
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]], 3n);
-  E(creatorFacet).submitVote(bobSeat, [positions[2]], 5n);
-  E(creatorFacet).submitVote(tedSeat, [positions[1]], 5n);
-  E(creatorFacet).submitVote(carolSeat, [positions[3]], 7n);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]], 3n);
+  void E(creatorFacet).submitVote(bobSeat, [positions[2]], 5n);
+  void E(creatorFacet).submitVote(tedSeat, [positions[1]], 5n);
+  void E(creatorFacet).submitVote(carolSeat, [positions[3]], 7n);
   await E(creatorFacet).submitVote(johnSeat, [positions[5]], 8n);
   closeFacet.closeVoting();
 
@@ -265,8 +265,8 @@ test('multi candidate revote', async t => {
 
   const positions = template.getDetails().positions;
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]], 23n);
-  E(creatorFacet).submitVote(bobSeat, [positions[1]], 15n);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]], 23n);
+  void E(creatorFacet).submitVote(bobSeat, [positions[1]], 15n);
   await E(creatorFacet).submitVote(bobSeat, [positions[2]], 47n);
   closeFacet.closeVoting();
 
@@ -340,7 +340,7 @@ test('multi candidate no quorum', async t => {
   t.deepEqual(positions.length, 3);
   t.deepEqual(positions[0], FISH);
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]]);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]]);
   await E(creatorFacet).submitVote(bobSeat, [positions[1]]);
   closeFacet.closeVoting();
 
@@ -385,7 +385,7 @@ test('multi candidate specify multiple chocies', async t => {
   t.deepEqual(positions.length, 3);
   t.deepEqual(positions[0], FISH);
 
-  E(creatorFacet).submitVote(aliceSeat, [
+  void E(creatorFacet).submitVote(aliceSeat, [
     positions[0],
     positions[1],
     positions[2],
@@ -432,7 +432,7 @@ test('multi candidate specify multiple chocies with varying share weights', asyn
   t.deepEqual(positions.length, 3);
   t.deepEqual(positions[0], FISH);
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0], positions[1]], 3n);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0], positions[1]], 3n);
   await E(creatorFacet).submitVote(bobSeat, [positions[1], positions[2]], 4n);
   closeFacet.closeVoting();
 
@@ -475,8 +475,8 @@ test('multi candidate winners less than max winners', async t => {
   const positions = aliceTemplate.getDetails().positions;
   t.deepEqual(positions.length, 6);
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]]);
-  E(creatorFacet).submitVote(tedSeat, [positions[3]]);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]]);
+  void E(creatorFacet).submitVote(tedSeat, [positions[3]]);
   await E(creatorFacet).submitVote(bobSeat, [positions[5]]);
   closeFacet.closeVoting();
 
@@ -519,8 +519,8 @@ test('multi candidate single winner', async t => {
   const positions = aliceTemplate.getDetails().positions;
   t.deepEqual(positions.length, 4);
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]]);
-  E(creatorFacet).submitVote(tedSeat, [positions[2]]);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]]);
+  void E(creatorFacet).submitVote(tedSeat, [positions[2]]);
   await E(creatorFacet).submitVote(bobSeat, [positions[2]]);
   closeFacet.closeVoting();
 
@@ -563,7 +563,7 @@ test('multi candidate single winner tie outcome', async t => {
   const positions = aliceTemplate.getDetails().positions;
   t.deepEqual(positions.length, 4);
 
-  E(creatorFacet).submitVote(aliceSeat, [positions[0]]);
+  void E(creatorFacet).submitVote(aliceSeat, [positions[0]]);
   await E(creatorFacet).submitVote(bobSeat, [positions[1]]);
   closeFacet.closeVoting();
 

--- a/packages/governance/test/unitTests/test-puppetContractGovernor.js
+++ b/packages/governance/test/unitTests/test-puppetContractGovernor.js
@@ -96,7 +96,7 @@ test('change a param', async t => {
     await E(publicFacet).getSubscription(),
   );
   const update1 = await notifier.getUpdateSince();
-  publicFacet.getGovernedParams();
+  void publicFacet.getGovernedParams();
   // This value isn't available synchronously and we don't have access here to the param manager to await its finish
   // XXX UNTIL https://github.com/Agoric/agoric-sdk/issues/4343
   // t.is(

--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -468,7 +468,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
             collateralAvailable,
             currentPriceLevel: state.curAuctionPrice,
           });
-          state.bookDataKit.recorder.write(bookData);
+          void state.bookDataKit.recorder.write(bookData);
         },
       },
       self: {

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -110,7 +110,7 @@ export const makeScheduler = async (
         now,
       ),
     });
-    scheduleRecorder.write(sched);
+    void scheduleRecorder.write(sched);
   };
 
   /**

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -954,7 +954,7 @@ export const prepareVaultManagerKit = (
               oldCollateral,
             );
             // debt accounting managed through minting and burning
-            facets.helper.updateMetrics();
+            void facets.helper.updateMetrics();
           }
         },
       },
@@ -1100,7 +1100,7 @@ export const prepareVaultManagerKit = (
           );
 
           helper.markLiquidating(totalDebt, totalCollateral);
-          helper.updateMetrics();
+          void helper.updateMetrics();
 
           const { userSeatPromise, deposited } = await E.when(
             E(auctionPF).getDepositInvitation(),
@@ -1122,7 +1122,7 @@ export const prepareVaultManagerKit = (
           const [proceeds] = await Promise.all([deposited, userSeatPromise]);
 
           trace(`LiqV after long wait`, proceeds);
-          helper.distributeProceeds(
+          void helper.distributeProceeds(
             proceeds,
             totalDebt,
             storedCollateralQuote,
@@ -1145,7 +1145,7 @@ export const prepareVaultManagerKit = (
         );
 
         // push initial state of metrics
-        helper.updateMetrics();
+        void helper.updateMetrics();
 
         void observeNotifier(periodNotifier, {
           updateState: updateTime =>

--- a/packages/inter-protocol/test/auction/test-auctionContract.js
+++ b/packages/inter-protocol/test/auction/test-auctionContract.js
@@ -979,8 +979,8 @@ test.serial('onDeadline exit, with chainStorage RPC snapshot', async t => {
   await assertPayouts(t, liqSeat, currency, collateral, 116n, 0n);
 
   await driver.advanceTo(186n, 'wait');
-  scheduleTracker.assertNoUpdate();
-  bookTracker.assertNoUpdate();
+  void scheduleTracker.assertNoUpdate();
+  void bookTracker.assertNoUpdate();
 
   await driver.advanceTo(210n, 'wait');
   await scheduleTracker.assertChange({

--- a/packages/inter-protocol/test/auction/test-scheduler.js
+++ b/packages/inter-protocol/test/auction/test-scheduler.js
@@ -746,7 +746,7 @@ test('change Schedule', async t => {
 
   const newFreq = 100n;
   const newStep = 40n;
-  paramManager.updateParams({
+  void paramManager.updateParams({
     StartFrequency: TimeMath.toRel(newFreq, timerBrand),
     ClockStep: TimeMath.toRel(newStep, timerBrand),
   });

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -80,7 +80,7 @@ export async function start(zcf, privateArgs, baggage) {
     runBrand,
   );
   let storedCollateralQuote;
-  observeNotifier(quoteNotifier, {
+  void observeNotifier(quoteNotifier, {
     updateState(value) {
       storedCollateralQuote = value;
     },

--- a/packages/notifier/src/stored-notifier.js
+++ b/packages/notifier/src/stored-notifier.js
@@ -28,7 +28,7 @@ export const makeStoredNotifier = (notifier, storageNode, marshaller) => {
 
   const marshallToStorage = makeSerializeToStorage(storageNode, marshaller);
 
-  observeNotifier(notifier, {
+  void observeNotifier(notifier, {
     updateState(value) {
       marshallToStorage(value).catch(reason =>
         console.error('StoredNotifier failed to updateState', reason),

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -571,8 +571,16 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
   const sub2LIFO = [];
 
   const sub1FirstAll = [];
-  E.when(sub1.subscribeAfter(), cell => void sub1FirstAll.push(cell), t.fail);
-  E.when(sub1.subscribeAfter(), cell => void sub1FirstAll.push(cell), t.fail);
+  void E.when(
+    sub1.subscribeAfter(),
+    cell => void sub1FirstAll.push(cell),
+    t.fail,
+  );
+  void E.when(
+    sub1.subscribeAfter(),
+    cell => void sub1FirstAll.push(cell),
+    t.fail,
+  );
 
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter());
@@ -591,17 +599,17 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
 
   const sub1FirstLateAll = [];
   const sub1SecondAll = [];
-  E.when(
+  void E.when(
     sub1.subscribeAfter(),
     cell => void sub1FirstLateAll.push(cell),
     t.fail,
   );
-  E.when(
+  void E.when(
     sub1.subscribeAfter(0n),
     cell => void sub1FirstLateAll.push(cell),
     t.fail,
   );
-  E.when(
+  void E.when(
     sub1.subscribeAfter(sub1FirstAll[0].publishCount),
     cell => void sub1SecondAll.push(cell),
     t.fail,
@@ -630,9 +638,9 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
   const sub1SecondLateAll = [];
   const sub1FinalAll = [];
   for (const p of [sub1.subscribeAfter(), sub1.subscribeAfter(0n)]) {
-    E.when(p, cell => void sub1SecondLateAll.push(cell), t.fail);
+    void E.when(p, cell => void sub1SecondLateAll.push(cell), t.fail);
   }
-  E.when(
+  void E.when(
     sub1.subscribeAfter(sub1SecondAll[0].publishCount),
     result => void sub1FinalAll.push(result),
     t.fail,

--- a/packages/pegasus/scripts/build-bundles.js
+++ b/packages/pegasus/scripts/build-bundles.js
@@ -6,4 +6,4 @@ import url from 'url';
 import { defaultProposalBuilder } from './init-core.js';
 
 const dirname = url.fileURLToPath(new URL('.', import.meta.url));
-extractProposalBundles([['.', defaultProposalBuilder]], dirname);
+void extractProposalBundles([['.', defaultProposalBuilder]], dirname);

--- a/packages/pegasus/src/proposals/core-proposal.js
+++ b/packages/pegasus/src/proposals/core-proposal.js
@@ -64,7 +64,7 @@ export const addPegasusTransferPort = async (
   pegasusConnectionsAdmin,
 ) => {
   const { handler, subscription } = await E(pegasus).makePegasusConnectionKit();
-  observeIteration(subscription, {
+  void observeIteration(subscription, {
     updateState(connectionState) {
       const { localAddr, actions } = connectionState;
       if (actions) {

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -88,7 +88,7 @@ async function testRemotePeg(t) {
    * @type {import('@agoric/swingset-vat/src/vats/network').Connection?}
    */
   let gaiaConnection;
-  E(portP).addListener(
+  void E(portP).addListener(
     Far('acceptor', {
       async onAccept(_p, _localAddr, _remoteAddr) {
         return Far('handler', {
@@ -211,7 +211,7 @@ async function testRemotePeg(t) {
 
   // Wait for the packet to go through.
   t.deepEqual(await remoteDenomAit.next(), { done: false, value: 'umuon' });
-  E(pegConnActions).rejectTransfersWaitingForPegRemote('umuon');
+  void E(pegConnActions).rejectTransfersWaitingForPegRemote('umuon');
 
   const sendAckData3 = await sendAckData3P;
   const sendAck3 = JSON.parse(sendAckData3);

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -142,7 +142,9 @@ export const makeInvitationsHelper = (
 
       const { previousOffer, invitationArgs = [], invitationMakerName } = spec;
       const makers = getInvitationContinuation(String(previousOffer));
-      makers || Fail`invalid value stored for previous offer ${previousOffer}`;
+      if (!makers) {
+        Fail`invalid value stored for previous offer ${previousOffer}`;
+      }
       return E(makers)[invitationMakerName](...invitationArgs);
     },
   });

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -180,11 +180,11 @@ export const makeOfferExecutor = ({
           }
         });
         if (seatRef) {
-          E(seatRef)
+          void E(seatRef)
             .hasExited()
             .then(hasExited => {
               if (!hasExited) {
-                E(seatRef).tryExit();
+                void E(seatRef).tryExit();
               }
             });
         }

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -291,7 +291,7 @@ export const prepareSmartWallet = (baggage, shared) => {
           } else {
             purseBalances.init(purse, balance);
           }
-          updateRecorderKit.recorder.write({
+          void updateRecorderKit.recorder.write({
             updated: 'balance',
             currentAmount: balance,
           });
@@ -307,7 +307,7 @@ export const prepareSmartWallet = (baggage, shared) => {
             purseBalances,
             liveOffers,
           } = this.state;
-          currentRecorderKit.recorder.write({
+          void currentRecorderKit.recorder.write({
             purses: [...purseBalances.values()].map(a => ({
               brand: a.brand,
               balance: a,
@@ -438,7 +438,7 @@ export const prepareSmartWallet = (baggage, shared) => {
             onStatusChange: offerStatus => {
               logger.info('offerStatus', offerStatus);
 
-              updateRecorderKit.recorder.write({
+              void updateRecorderKit.recorder.write({
                 updated: 'offerStatus',
                 status: offerStatus,
               });
@@ -508,7 +508,7 @@ export const prepareSmartWallet = (baggage, shared) => {
           const recordError = err => {
             const { address, updateRecorderKit } = this.state;
             console.error('wallet', address, 'handleBridgeAction error:', err);
-            updateRecorderKit.recorder.write({
+            void updateRecorderKit.recorder.write({
               updated: 'walletAction',
               status: { error: err.message },
             });

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -85,7 +85,9 @@ const makeFakeBridgeManager = () =>
           assert.fail(`expected fromBridge`);
         },
         toBridge(obj) {
-          handler || Fail`No handler for ${bridgeId}`;
+          if (!handler) {
+            Fail`No handler for ${bridgeId}`;
+          }
           // Rely on interface guard for validation.
           // This should also be validated upstream but don't rely on it.
           // @ts-expect-error handler possibly undefined

--- a/packages/solo/public/main.js
+++ b/packages/solo/public/main.js
@@ -265,7 +265,7 @@ function run() {
     commands[commands.length - 1] = inp.value;
     commands[commands.length] = '';
     inp.value = '';
-    call({ type: 'doEval', number, body: command });
+    void call({ type: 'doEval', number, body: command });
   }
 
   function inputKeyup(ev) {

--- a/packages/solo/src/captp.js
+++ b/packages/solo/src/captp.js
@@ -42,7 +42,7 @@ export const getCapTPHandler = (send, getLocalBootstrap, fallback) => {
         dispatch,
         abort,
       });
-      doFallback('onOpen', obj, meta);
+      void doFallback('onOpen', obj, meta);
     },
     onClose(obj, meta) {
       console.debug(`Finishing CapTP`, meta);
@@ -52,7 +52,7 @@ export const getCapTPHandler = (send, getLocalBootstrap, fallback) => {
         abort();
       }
       chans.delete(meta.channelHandle);
-      doFallback('onClose', obj, meta);
+      void doFallback('onClose', obj, meta);
     },
     onError(obj, meta) {
       console.debug(`Error in CapTP`, meta, obj.error);
@@ -61,7 +61,7 @@ export const getCapTPHandler = (send, getLocalBootstrap, fallback) => {
         const { abort } = chan;
         abort(obj.error);
       }
-      doFallback('onError', obj, meta);
+      void doFallback('onError', obj, meta);
     },
     async onMessage(obj, meta) {
       console.debug('processing inbound', obj);

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -259,7 +259,7 @@ export async function connectToChain(
    */
   const getMailboxNotifier = () => {
     const { notifier, updater } = makeNotifierKit();
-    retryRpcHref(async rpcHref => {
+    void retryRpcHref(async rpcHref => {
       // Every time we enter this function, we are establishing a
       // new websocket to a potentially different RPC server.
       //
@@ -487,7 +487,7 @@ export async function connectToChain(
 
         waitForTxHash = subscribeAndWaitForTxHash;
         if (postponedTxHash) {
-          subscribeAndWaitForTxHash(postponedTxHash);
+          void waitForTxHash(postponedTxHash);
         }
 
         subscribeToStorage(`mailbox.${clientAddr}`, (err, storageValue) => {
@@ -694,7 +694,7 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
           // Wait for the transaction to be included in a block.
           const txHash = out.txhash;
 
-          waitForTxHash(txHash).then(txResult => {
+          void waitForTxHash(txHash).then(txResult => {
             // The result had an error code (not 0 or undefined for success).
             if (txResult.code) {
               // eslint-disable-next-line no-use-before-define
@@ -780,11 +780,11 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
     updateCount || Fail`Sending unexpectedly finished!`;
 
     await sendFromMessagePool().then(successfulSend, failedSend);
-    recurseEachSend(updateCount);
+    void recurseEachSend(updateCount);
   };
 
   // Begin the sender when we get the first (empty) mailbox update.
-  mbNotifier.getUpdateSince().then(() => recurseEachSend());
+  void mbNotifier.getUpdateSince().then(() => recurseEachSend());
 
   async function deliver(newMessages, acknum) {
     let doSend = false;

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -469,7 +469,7 @@ const start = async (basedir, argv) => {
 
   // Start timer here!
   startTimer(800);
-  resetOutdatedState();
+  void resetOutdatedState();
 
   // Remove wallet traces.
   await unlink('html/wallet').catch(_ => {});

--- a/packages/solo/src/vat-http.js
+++ b/packages/solo/src/vat-http.js
@@ -104,7 +104,7 @@ export function buildRootObject(vatPowers) {
 
   const { promise: walletP, resolve: resolveWallet } = makePromiseKit();
   const { promise: attMakerP, resolve: resolveAttMaker } = makePromiseKit();
-  Promise.all([walletP, attMakerP]).then(async ([wallet, attMaker]) => {
+  void Promise.all([walletP, attMakerP]).then(async ([wallet, attMaker]) => {
     const walletAdmin = await E(wallet).getAdminFacet();
     // console.debug('introduce', { wallet, walletAdmin, attMaker });
     E(walletAdmin).resolveAttMaker(attMaker);
@@ -115,7 +115,7 @@ export function buildRootObject(vatPowers) {
       commandDevice = d;
 
       const replHandler = getReplHandler(replObjects, send, vatPowers);
-      registerURLHandler(replHandler, '/private/repl');
+      void registerURLHandler(replHandler, '/private/repl');
 
       // Assign the captp handler.
       const captpHandler = Far('captpHandler', {
@@ -134,7 +134,7 @@ export function buildRootObject(vatPowers) {
           return harden(exported);
         },
       });
-      registerURLHandler(captpHandler, '/private/captp');
+      void registerURLHandler(captpHandler, '/private/captp');
     },
 
     registerURLHandler,

--- a/packages/solo/test/captp-fixture.js
+++ b/packages/solo/test/captp-fixture.js
@@ -109,7 +109,7 @@ export async function makeFixture(PORT, noisy = false) {
         // We only reject if the child exits before CapTP is established.
         reject(new Error(`CapTP fixture exited with ${code}`));
       });
-      tryConnect(resolve, reject);
+      void tryConnect(resolve, reject);
     });
   }
 

--- a/packages/store/test/test-AtomicProvider.js
+++ b/packages/store/test/test-AtomicProvider.js
@@ -28,8 +28,8 @@ test('race', async t => {
   t.is(await provider.provideAsync('a', make, finish), 'a 1');
   t.is(finishCalled, 1);
 
-  provider.provideAsync('b', make, finish);
-  provider.provideAsync('b', make, finish);
+  void provider.provideAsync('b', make, finish);
+  void provider.provideAsync('b', make, finish);
   t.is(await provider.provideAsync('b', make, finish), 'b 2');
   t.is(await provider.provideAsync('b', make, finish), 'b 2');
   t.is(finishCalled, 2);
@@ -88,8 +88,8 @@ test('far keys', async t => {
   t.is(await provider.provideAsync(moola, makeValue), 'moola 1');
   t.is(await provider.provideAsync(moola, makeValue), 'moola 1');
 
-  provider.provideAsync(moolb, makeValue);
-  provider.provideAsync(moolb, makeValue);
+  void provider.provideAsync(moolb, makeValue);
+  void provider.provideAsync(moolb, makeValue);
   t.is(await provider.provideAsync(moolb, makeValue), 'moolb 2');
   t.is(await provider.provideAsync(moolb, makeValue), 'moolb 2');
 });

--- a/packages/swing-store/test/test-bundles.js
+++ b/packages/swing-store/test/test-bundles.js
@@ -88,7 +88,7 @@ test('b0 export', async t => {
   const b0A = { moduleFormat: 'nestedEvaluate', source: '1+1' };
   const idA = makeB0ID(b0A);
   bundleStore.addBundle(idA, b0A);
-  hostStorage.commit();
+  void hostStorage.commit();
   t.is(exportData.get(`bundle.${idA}`), idA);
 
   const exporter = makeSwingStoreExporter(dbDir);

--- a/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
@@ -23,4 +23,4 @@ const generateBundlesP = Promise.all(
   }),
 );
 
-generateBundlesP.then(() => console.log('contracts prepared'));
+void generateBundlesP.then(() => console.log('contracts prepared'));

--- a/packages/swingset-runner/demo/resolvePromiseComplicated/vat-bob.js
+++ b/packages/swingset-runner/demo/resolvePromiseComplicated/vat-bob.js
@@ -24,7 +24,7 @@ export function buildRootObject() {
         r => log(`=> Bob: the parameter to second resolved to '${r}'`),
         e => log(`=> Bob: the parameter to second rejected as '${e}'`),
       );
-      Promise.resolve().then(E(carol).bar(p));
+      void Promise.resolve().then(E(carol).bar(p));
       log('=> Bob: second done');
       return `Bob's second answer`;
     },

--- a/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
@@ -23,4 +23,4 @@ const generateBundlesP = Promise.all(
   }),
 );
 
-generateBundlesP.then(() => console.log('contracts prepared'));
+void generateBundlesP.then(() => console.log('contracts prepared'));

--- a/packages/swingset-runner/demo/zoeTests/prepareContracts.js
+++ b/packages/swingset-runner/demo/zoeTests/prepareContracts.js
@@ -44,4 +44,4 @@ const generateBundlesP = Promise.all(
   }),
 );
 
-generateBundlesP.then(() => console.log('contracts prepared'));
+void generateBundlesP.then(() => console.log('contracts prepared'));

--- a/packages/swingset-runner/src/graphDisk.js
+++ b/packages/swingset-runner/src/graphDisk.js
@@ -13,4 +13,4 @@ export async function main() {
   );
 }
 
-main();
+void main();

--- a/packages/swingset-runner/src/graphMem.js
+++ b/packages/swingset-runner/src/graphMem.js
@@ -13,4 +13,4 @@ export async function main() {
   );
 }
 
-main();
+void main();

--- a/packages/swingset-runner/src/graphStats.js
+++ b/packages/swingset-runner/src/graphStats.js
@@ -13,4 +13,4 @@ export async function main() {
   );
 }
 
-main();
+void main();

--- a/packages/swingset-runner/src/graphTime.js
+++ b/packages/swingset-runner/src/graphTime.js
@@ -13,4 +13,4 @@ export async function main() {
   );
 }
 
-main();
+void main();

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -583,7 +583,7 @@ export async function main() {
     // eslint-disable-next-line @jessie.js/no-nested-await
     await slogSender.forceFlush();
   }
-  controller.shutdown();
+  void controller.shutdown();
 
   function getCrankNumber() {
     return Number(kernelStorage.kvStore.get('crankNumber'));

--- a/packages/swingset-runner/src/runner-debug-entrypoint.js
+++ b/packages/swingset-runner/src/runner-debug-entrypoint.js
@@ -11,4 +11,4 @@ import '@endo/init/pre.js';
 import '@endo/init';
 import { main } from './main.js';
 
-main();
+void main();

--- a/packages/swingset-runner/src/runner-entrypoint.js
+++ b/packages/swingset-runner/src/runner-entrypoint.js
@@ -13,4 +13,4 @@ import '@endo/init/pre-bundle-source.js';
 import '@endo/init';
 import { main } from './main.js';
 
-main();
+void main();

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -60,6 +60,10 @@
     "rules": {
       "import/no-extraneous-dependencies": "off",
       "prettier/prettier": "off"
+    },
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+      "project": "./packages/web-components/jsconfig.json"
     }
   },
   "publishConfig": {

--- a/packages/web-components/src/AgoricWalletConnection.js
+++ b/packages/web-components/src/AgoricWalletConnection.js
@@ -148,7 +148,7 @@ export const makeAgoricWalletConnection = (makeCapTP = defaultMakeCapTP) =>
           return this._bridgePK.promise;
         },
         reset: () => {
-          this.reset();
+          void this.reset();
         },
       });
 

--- a/packages/web-components/src/keplr-connection/watchWallet.js
+++ b/packages/web-components/src/keplr-connection/watchWallet.js
@@ -124,7 +124,7 @@ export const watchWallet = async (leader, address, context, rpcs) => {
     void watchBank();
   };
 
-  watchCurrent();
+  void watchCurrent();
   watchChainBalances();
 
   return {

--- a/packages/web-components/test/agoric-petimage.test.js
+++ b/packages/web-components/test/agoric-petimage.test.js
@@ -37,7 +37,9 @@ describe('AgoricPetimage', () => {
     );
 
     const inner = el.shadowRoot.querySelector('div');
-    expect(inner.getAttribute('data-powerbox-target')).to.equal('img-if-known');
-    expect(inner.getAttribute('data-powerbox-id')).to.equal('AG.1');
+    await expect(inner.getAttribute('data-powerbox-target')).to.equal(
+      'img-if-known',
+    );
+    await expect(inner.getAttribute('data-powerbox-id')).to.equal('AG.1');
   });
 });

--- a/packages/web-components/test/agoric-petname.test.js
+++ b/packages/web-components/test/agoric-petname.test.js
@@ -37,10 +37,10 @@ describe('AgoricPetname', () => {
     );
 
     const inner = el.shadowRoot.querySelector('span');
-    expect(inner.getAttribute('data-powerbox-target')).to.equal(
+    await expect(inner.getAttribute('data-powerbox-target')).to.equal(
       'petname-if-known',
     );
-    expect(inner.getAttribute('data-powerbox-id')).to.equal('AG.1');
-    expect(inner.innerText).to.equal('AG.1');
+    await expect(inner.getAttribute('data-powerbox-id')).to.equal('AG.1');
+    await expect(inner.innerText).to.equal('AG.1');
   });
 });

--- a/packages/web-components/test/agoric-wallet-connection.test.js
+++ b/packages/web-components/test/agoric-wallet-connection.test.js
@@ -76,8 +76,8 @@ describe('AgoricWalletConnection', () => {
   });
 
   it(`has a default state of 'idle' and has a walletConnection`, async () => {
-    const onState = ev => {
-      expect(ev.detail.state).to.equal('idle');
+    const onState = async ev => {
+      await expect(ev.detail.state).to.equal('idle');
     };
     const el = await fixture(
       html`
@@ -104,7 +104,7 @@ describe('AgoricWalletConnection', () => {
         <agoric-wallet-connection @state=${onState}></agoric-wallet-connection>
       `,
     );
-    expect(el.state).to.equal('locating');
+    await expect(el.state).to.equal('locating');
   });
 
   describe('on getAdminBootstrap', () => {
@@ -149,14 +149,14 @@ describe('AgoricWalletConnection', () => {
       );
     });
 
-    it('starts at locating', () => {
-      expect(el.state).to.equal('locating');
+    it('starts at locating', async () => {
+      await expect(el.state).to.equal('locating');
     });
 
-    it('starts connecting after locating completes', () => {
+    it('starts connecting after locating completes', async () => {
       iframeOnMessage('http://localhost:8000');
 
-      expect(el.state).to.equal('connecting');
+      await expect(el.state).to.equal('connecting');
     });
 
     it('goes to admin state once connected', async () => {
@@ -165,7 +165,7 @@ describe('AgoricWalletConnection', () => {
       await createStatePromise('bridged');
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      expect(el.state).to.equal('bridged');
+      await expect(el.state).to.equal('bridged');
     });
 
     it('lets the websocket dispatch messages through capTP', async () => {
@@ -173,7 +173,7 @@ describe('AgoricWalletConnection', () => {
 
       socket.send(JSON.stringify({ foo: 'bar' }));
 
-      expect(captpInnards.lastDispatched).to.deep.equal({ foo: 'bar' });
+      await expect(captpInnards.lastDispatched).to.deep.equal({ foo: 'bar' });
     });
 
     it('lets capTP send messages through the websocket', async () => {
@@ -183,7 +183,7 @@ describe('AgoricWalletConnection', () => {
       captpInnards.send({ foo: 'bar2' });
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      expect(lastMessage).to.equal(JSON.stringify({ foo: 'bar2' }));
+      await expect(lastMessage).to.equal(JSON.stringify({ foo: 'bar2' }));
     });
 
     it('aborts capTP when the socket disconnects', async () => {
@@ -191,7 +191,7 @@ describe('AgoricWalletConnection', () => {
 
       socket.close();
 
-      expect(captpInnards.isAborted).to.equal(true);
+      await expect(captpInnards.isAborted).to.equal(true);
     });
 
     it('returns the admin bootstrap', async () => {
@@ -205,7 +205,7 @@ describe('AgoricWalletConnection', () => {
     const el = await fixture(
       html` <agoric-wallet-connection></agoric-wallet-connection> `,
     );
-    expect(el.state).to.equal('idle');
+    await expect(el.state).to.equal('idle');
     expect(() => (el.state = 'notset')).to.throw(/Cannot set/);
   });
 

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -165,7 +165,7 @@ export const makeZCFMintFactory = async (
   );
 
   for (const zcfMintBaggage of zcfMintBaggageSet.values()) {
-    provideDurableZcfMint(zcfMintBaggage);
+    void provideDurableZcfMint(zcfMintBaggage);
   }
 
   return zcfMintFactory;

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -156,7 +156,10 @@ export const createSeatManager = (
         assertActive(self);
         assertNoStagedAllocation(self);
         doExitSeat(self);
-        E(zoeInstanceAdmin).exitSeat(zcfSeatToSeatHandle.get(self), completion);
+        void E(zoeInstanceAdmin).exitSeat(
+          zcfSeatToSeatHandle.get(self),
+          completion,
+        );
       },
       fail(
         reason = new Error(
@@ -173,7 +176,7 @@ export const createSeatManager = (
         }
         if (!hasExited(self)) {
           doExitSeat(self);
-          E(zoeInstanceAdmin).failSeat(
+          void E(zoeInstanceAdmin).failSeat(
             zcfSeatToSeatHandle.get(self),
             harden(reason),
           );

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -78,7 +78,7 @@ export const makeZCFZygote = async (
 
   /** @type {ShutdownWithFailure} */
   const shutdownWithFailure = reason => {
-    E(zoeInstanceAdmin).failAllSeats(reason);
+    void E(zoeInstanceAdmin).failAllSeats(reason);
     seatManager.dropAllReferences();
     // https://github.com/Agoric/agoric-sdk/issues/3239
     powers.exitVatWithFailure(reason);
@@ -110,7 +110,7 @@ export const makeZCFZygote = async (
     const zcfSeat = seatManager.makeZCFSeat(seatData);
 
     const exiter = makeExiter(seatData.proposal, zcfSeat);
-    E(zoeInstanceAdmin)
+    void E(zoeInstanceAdmin)
       .makeNoEscrowSeat(initialAllocation, proposal, exiter, seatHandle)
       .then(userSeat => userSeatPromiseKit.resolve(userSeat));
 
@@ -279,7 +279,7 @@ export const makeZCFZygote = async (
     },
     // Shutdown the entire vat and give payouts
     shutdown: completion => {
-      E(zoeInstanceAdmin).exitAllSeats(completion);
+      void E(zoeInstanceAdmin).exitAllSeats(completion);
       seatManager.dropAllReferences();
       powers.exitVat(completion);
     },
@@ -361,7 +361,7 @@ export const makeZCFZygote = async (
       privateArgs = undefined,
     ) => {
       zoeInstanceAdmin = instanceAdminFromZoe;
-      initSeatMgrAndMintFactory();
+      await initSeatMgrAndMintFactory();
 
       zcfBaggage.init('zcfInstanceAdmin', instanceAdminFromZoe);
       instanceRecHolder = makeInstanceRecord(instanceRecordFromZoe);
@@ -417,7 +417,7 @@ export const makeZCFZygote = async (
       prepare || Fail`prepare must be defined to upgrade a contract`;
       zoeInstanceAdmin = zcfBaggage.get('zcfInstanceAdmin');
       instanceRecHolder = zcfBaggage.get('instanceRecHolder');
-      initSeatMgrAndMintFactory();
+      await initSeatMgrAndMintFactory();
 
       // restart an upgradeable contract
       return E.when(

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -57,7 +57,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
 
   let haveFirstQuote = false;
 
-  E(notifier)
+  void E(notifier)
     .getUpdateSince()
     .then(_ => (haveFirstQuote = true));
 
@@ -169,7 +169,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
           );
           amountIn = coercedAmountIn;
           amountOutLimit = coercedAmountOutLimit;
-          fireTriggers(createQuote);
+          void fireTriggers(createQuote);
         },
         getPromise: () => triggerPK.promise,
       });

--- a/packages/zoe/src/contractSupport/priceAuthorityInitial.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityInitial.js
@@ -99,7 +99,7 @@ export const makeInitialTransform = (
     assert.equal(bOut, brandOut);
 
     const quoteP = E(priceAuthority).quoteGiven(amountIn, brandOut);
-    quoteP.then(() => (initialMode = false));
+    void quoteP.then(() => (initialMode = false));
     return initialMode
       ? mintCurrentQuote(amountIn, multiplyBy(amountIn, priceOutPerIn))
       : quoteP;

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -371,7 +371,7 @@ export const offerTo = async (
     depositedPromiseKit.resolve(mappedAmounts);
   };
 
-  E(userSeatPromise).getPayouts().then(doDeposit);
+  void E(userSeatPromise).getPayouts().then(doDeposit);
 
   // TODO rename return key; userSeatPromise is a remote UserSeat
   return harden({ userSeatPromise, deposited: depositedPromiseKit.promise });

--- a/packages/zoe/src/contracts/auction/index.js
+++ b/packages/zoe/src/contracts/auction/index.js
@@ -126,7 +126,7 @@ const start = zcf => {
       assertBidSeat(zcf, sellSeat, seat);
 
       // XXX await make function hanging
-      startWakeupTimerIfNeeded();
+      void startWakeupTimerIfNeeded();
 
       bidSeats.push(seat);
       return defaultAcceptanceMsg;

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -39,7 +39,7 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
   }
 
   function reallocateToSeat(seatPromise, seatPortion) {
-    E.when(seatPromise, seat => {
+    void E.when(seatPromise, seat => {
       atomicTransfer(zcf, collateralSeat, seat, { Collateral: seatPortion });
       seat.exit();
       seatsExited += 1;

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -77,7 +77,7 @@ const start = zcf => {
     'strikePrice2 must be greater than strikePrice1',
   );
 
-  zcf.saveIssuer(zcf.getInvitationIssuer(), 'Options');
+  void zcf.saveIssuer(zcf.getInvitationIssuer(), 'Options');
 
   // We will create the two options early and allocate them to this seat.
   const { zcfSeat: collateralSeat } = zcf.makeEmptySeatKit();

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -69,7 +69,7 @@ const start = async zcf => {
           Fail`Oracle required a fee but the query had none`;
         return reply;
       } catch (e) {
-        E(handler).onError(query, e);
+        void E(handler).onError(query, e);
         throw e;
       }
     },
@@ -84,10 +84,10 @@ const start = async zcf => {
             atomicTransfer(zcf, querySeat, feeSeat, { Fee: requiredFee });
           }
           querySeat.exit();
-          E(handler).onReply(query, reply, requiredFee);
+          void E(handler).onReply(query, reply, requiredFee);
           return reply;
         } catch (e) {
-          E(handler).onError(query, e);
+          void E(handler).onError(query, e);
           throw e;
         }
       };

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -154,7 +154,7 @@ const start = async (zcf, privateArgs) => {
       await Promise.all(querierPs).catch(console.error);
     },
   });
-  E(repeaterP).schedule(waker);
+  void E(repeaterP).schedule(waker);
 
   /**
    * @param {object} param0
@@ -226,17 +226,20 @@ const start = async (zcf, privateArgs) => {
     });
 
   // for each new quote from the priceAuthority, publish it to off-chain storage
-  observeNotifier(priceAuthority.makeQuoteNotifier(unitAmountIn, brandOut), {
-    updateState: quote => {
-      publisher.publish(priceDescriptionFromQuote(quote));
+  void observeNotifier(
+    priceAuthority.makeQuoteNotifier(unitAmountIn, brandOut),
+    {
+      updateState: quote => {
+        publisher.publish(priceDescriptionFromQuote(quote));
+      },
+      fail: reason => {
+        throw Error(`priceAuthority observer failed: ${reason}`);
+      },
+      finish: done => {
+        throw Error(`priceAuthority observer died: ${done}`);
+      },
     },
-    fail: reason => {
-      throw Error(`priceAuthority observer failed: ${reason}`);
-    },
-    finish: done => {
-      throw Error(`priceAuthority observer died: ${done}`);
-    },
-  });
+  );
 
   /**
    * @param {Ratio} r
@@ -381,7 +384,7 @@ const start = async (zcf, privateArgs) => {
         return;
       }
       // Queue the next update.
-      E(oracleNotifier).getUpdateSince(updateCount).then(recurse);
+      void E(oracleNotifier).getUpdateSince(updateCount).then(recurse);
 
       // See if we have associated parameters or just a raw value.
       /** @type {Ratio | undefined} */
@@ -417,7 +420,7 @@ const start = async (zcf, privateArgs) => {
     };
 
     // Start the notifier.
-    E(oracleNotifier).getUpdateSince().then(recurse);
+    void E(oracleNotifier).getUpdateSince().then(recurse);
   };
 
   const creatorFacet = Far('PriceAggregatorCreatorFacet', {
@@ -455,7 +458,7 @@ const start = async (zcf, privateArgs) => {
             assertParsableNumber(price);
             return zcf.makeInvitation(cSeat => {
               cSeat.exit();
-              admin.pushResult(price);
+              void admin.pushResult(price);
             }, 'PushPrice');
           },
         });

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -52,7 +52,7 @@ const start = zcf => {
   const sell = seat => {
     sellerSeat = seat;
 
-    observeIteration(
+    void observeIteration(
       subscribeLatest(sellerSeat.getSubscriber()),
       harden({
         updateState: sellerSeatAllocation =>

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -177,7 +177,7 @@ const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
 
       state.zoeSeatAdmins.add(zoeSeatAdmin);
       state.handleOfferObj || Fail`incomplete setup of zoe seat`;
-      E.when(
+      void E.when(
         E(state.handleOfferObj).handleOffer(invitationHandle, seatData),
         /** @param {HandleOfferResult} result */
         result => zoeSeatAdmin.resolveExitAndResult(result),

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -269,7 +269,7 @@ export const makeStartInstance = (
     );
     zoeInstanceStorageManager.initInstanceAdmin(instanceHandle, instanceAdmin);
 
-    E.when(
+    void E.when(
       E(adminNode).done(),
       completion => {
         instanceAdmin.exitAllSeats(completion);

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -52,7 +52,7 @@ const makeZoeKit = (
   let zcfBundleCap;
 
   const saveBundleCap = () => {
-    E.when(
+    void E.when(
       Promise.all([vatAdminSvcP, getZcfBundleCap(zcfSpec, vatAdminSvcP)]),
       ([vatAdminService, bundleCap]) => {
         zcfBundleCap = bundleCap;

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -158,7 +158,7 @@ export const makeZoeSeatAdminFactory = baggage => {
           assertHasNotExited(this, 'Cannot exit seat. Seat has already exited');
 
           state.exiting = true;
-          E.when(
+          void E.when(
             doExit(
               facets.zoeSeatAdmin,
               state.currentAllocation,
@@ -179,7 +179,7 @@ export const makeZoeSeatAdminFactory = baggage => {
           assertHasNotExited(this, 'Cannot fail seat. Seat has already exited');
 
           state.exiting = true;
-          E.when(
+          void E.when(
             doExit(
               facets.zoeSeatAdmin,
               state.currentAllocation,
@@ -206,7 +206,7 @@ export const makeZoeSeatAdminFactory = baggage => {
           }
 
           const pKit = ephemeralOfferResultStore.get(facets.userSeat);
-          E.when(
+          void E.when(
             offerResultPromise,
             offerResult => {
               // Resolve the ephemeral promise for offerResult

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -41,7 +41,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
     });
     const alicePayments = { Asset: moolaPayment };
 
-    logCounter(log, publicFacet);
+    void logCounter(log, publicFacet);
     const invitation = await E(publicFacet).makeThrowingInvitation();
     const seat = await E(zoe).offer(invitation, proposal, alicePayments);
 
@@ -51,7 +51,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
         () => assert(false, ' expected outcome to fail'),
         e => log(`outcome correctly resolves to broken: ${e}`),
       );
-    logCounter(log, publicFacet);
+    void logCounter(log, publicFacet);
     const moolaPayout = await E(seat).getPayout('Asset');
     const simoleanPayout = await E(seat).getPayout('Price');
 
@@ -59,7 +59,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
     await E(simoleanPurseP).deposit(simoleanPayout);
     await showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
     await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
-    logCounter(log, publicFacet);
+    void logCounter(log, publicFacet);
 
     // zoe should still be able to make new vats.
     const { publicFacet: publicFacet2 } = await E(zoe).startInstance(
@@ -86,9 +86,9 @@ const build = async (log, zoe, issuers, payments, installations) => {
     E(newPurse).deposit(swapMoolaPayout);
     E(simoleanPurseP).deposit(swapSimoleanPayout);
 
-    showPurseBalance(newPurse, 'new Purse', log);
-    showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
-    logCounter(log, publicFacet);
+    void showPurseBalance(newPurse, 'new Purse', log);
+    void showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
+    void logCounter(log, publicFacet);
   };
 
   const doThrowInApiCall = async () => {
@@ -123,7 +123,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       .getOfferResult()
       .then(
         o => {
-          E(invitationIssuer)
+          void E(invitationIssuer)
             .isLive(o)
             .then(val => {
               swapInvitationTwo = o;
@@ -132,7 +132,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
         },
         e => assert(false, X`expected outcome not to resolve yet ${e}`),
       );
-    logCounter(log, publicFacet);
+    void logCounter(log, publicFacet);
 
     E(publicFacet)
       .throwSomething()
@@ -140,10 +140,10 @@ const build = async (log, zoe, issuers, payments, installations) => {
         () => assert(false, 'expecting this to throw'),
         e => log(`throwingAPI should throw ${e}`),
       );
-    logCounter(log, publicFacet);
+    void logCounter(log, publicFacet);
 
     // These should not resolve at this point, the funds are still escrowed
-    E(swapSeat)
+    void E(swapSeat)
       .getPayouts()
       .then(async swapPayout => {
         const moolaSwapPayout = await swapPayout.Asset;
@@ -156,7 +156,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       });
 
     // show that the contract is still responsive.
-    logCounter(log, publicFacet);
+    void logCounter(log, publicFacet);
 
     // zoe should still be able to make new vats.
     const { publicFacet: publicFacet2 } = await E(zoe).startInstance(
@@ -177,7 +177,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       swapTwoProposal,
       aliceSwapTwoPayments,
     );
-    logCounter(log, publicFacet);
+    void logCounter(log, publicFacet);
 
     E(swapSeatTwo)
       .getOfferResult()

--- a/packages/zoe/test/types.test-d.ts
+++ b/packages/zoe/test/types.test-d.ts
@@ -18,13 +18,13 @@ import type { start as scaledPriceAuthorityStart } from '../src/contracts/scaled
   const kit = await E(zoe).startInstance(scaledPriceInstallation);
   // @ts-expect-error
   kit.notInKit;
-  E(kit.publicFacet).getPriceAuthority();
+  void E(kit.publicFacet).getPriceAuthority();
 
   expectType<{}>(kit.creatorFacet);
 
   const validIssuers = {};
 
-  E(zoe).startInstance(
+  void E(zoe).startInstance(
     scaledPriceInstallation,
     validIssuers,
     // @ts-expect-error missing terms
@@ -35,15 +35,15 @@ import type { start as scaledPriceAuthorityStart } from '../src/contracts/scaled
     scaleIn: mock,
     scaleOut: mock,
   };
-  E(zoe).startInstance(scaledPriceInstallation, validIssuers, validTerms);
+  void E(zoe).startInstance(scaledPriceInstallation, validIssuers, validTerms);
   const validPrivates = {};
-  E(zoe).startInstance(
+  void E(zoe).startInstance(
     scaledPriceInstallation,
     validIssuers,
     validTerms,
     validPrivates,
   );
-  E(zoe).startInstance(
+  void E(zoe).startInstance(
     scaledPriceInstallation,
     validIssuers,
     validTerms,

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -148,7 +148,7 @@ test('borrow not enough collateral', async t => {
   // collateral is 0
   const { borrowSeat, borrowFacet } = await setupBorrowFacet(0n);
   // Sink unhandled rejection
-  E.when(
+  void E.when(
     borrowFacet,
     () => {},
     () => {},
@@ -374,7 +374,7 @@ test('borrow collateral just too low', async t => {
     await setupBorrowFacet(74n);
 
   // Sink unhandled rejection
-  E.when(
+  void E.when(
     borrowFacetBad,
     () => {},
     () => {},

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -219,7 +219,7 @@ test('zoe - non-fungible atomicSwap', async t => {
 
         const seat = await E(zoe).offer(firstInvitation, proposal, payments);
 
-        seat
+        void seat
           .getPayout('Asset')
           .then(payment => ccPurse.deposit(payment))
           .then(amountDeposited =>
@@ -230,7 +230,7 @@ test('zoe - non-fungible atomicSwap', async t => {
             ),
           );
 
-        seat
+        void seat
           .getPayout('Price')
           .then(payment => rpgPurse.deposit(payment))
           .then(amountDeposited =>

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -511,7 +511,7 @@ test('autoSwap - trade attempt before init, no jig', async t => {
     proposal,
     payment,
   );
-  t.throwsAsync(
+  await t.throwsAsync(
     seat.getOfferResult(),
     { message: /Pool not initialized/ },
     'The pool has not been initialized',
@@ -662,7 +662,7 @@ test('autoSwap jig - swap varying amounts', async t => {
   // Attempt (unsuccessfully) to trade for a specified amount
   const failedSeat = await alice.offerAndTrade(simoleans(75n), moola(3n));
 
-  t.throwsAsync(
+  await t.throwsAsync(
     failedSeat.getOfferResult(),
     { message: /amountIn insufficient/ },
     'amountIn insufficient when want specified',

--- a/packages/zoe/test/unitTests/test-fakePriceAuthority.js
+++ b/packages/zoe/test/unitTests/test-fakePriceAuthority.js
@@ -125,7 +125,7 @@ test('priceAuthority quoteWhenGTE', async t => {
     manualTimer,
   );
 
-  E(priceAuthority)
+  void E(priceAuthority)
     .quoteWhenGTE(moola(1n), bucks(40n))
     .then(quote => {
       const quoteInAmount = quote.quoteAmount.value[0];
@@ -152,7 +152,7 @@ test('priceAuthority quoteWhenLT', async t => {
     manualTimer,
   );
 
-  E(priceAuthority)
+  void E(priceAuthority)
     .quoteWhenLT(moola(1n), bucks(30n))
     .then(quote => {
       const quoteInAmount = quote.quoteAmount.value[0];
@@ -178,7 +178,7 @@ test('priceAuthority quoteWhenGT', async t => {
     manualTimer,
   );
 
-  E(priceAuthority)
+  void E(priceAuthority)
     .quoteWhenGT(moola(1n), bucks(40n))
     .then(quote => {
       const quoteInAmount = quote.quoteAmount.value[0];
@@ -204,7 +204,7 @@ test('priceAuthority quoteWhenLTE', async t => {
     manualTimer,
   );
 
-  E(priceAuthority)
+  void E(priceAuthority)
     .quoteWhenLTE(moola(1n), bucks(25n))
     .then(quote => {
       const quoteInAmount = quote.quoteAmount.value[0];

--- a/packages/zoe/test/unitTests/test-manualTimer.js
+++ b/packages/zoe/test/unitTests/test-manualTimer.js
@@ -72,7 +72,7 @@ test('tick does not flush by default', async t => {
   const handler = Far('handler', {
     wake: scheduled => {
       woken = scheduled;
-      stallLots().then(() => (later = true));
+      void stallLots().then(() => (later = true));
     },
   });
   manualTimer.setWakeup(1n, handler);
@@ -98,7 +98,7 @@ test('tick can flush promise queue', async t => {
   const handler = Far('handler', {
     wake: scheduled => {
       woken = scheduled;
-      stallLots().then(() => (later = true));
+      void stallLots().then(() => (later = true));
     },
   });
   manualTimer.setWakeup(1n, handler);
@@ -125,7 +125,7 @@ test('tick does not await makeRepeater by default', async t => {
   const handler = Far('handler', {
     wake: scheduled => {
       woken = scheduled;
-      stallLots().then(() => (later = true));
+      void stallLots().then(() => (later = true));
     },
   });
 
@@ -152,7 +152,7 @@ test('tick can flush makeRepeater', async t => {
   const handler = Far('handler', {
     wake: scheduled => {
       woken = scheduled;
-      stallLots().then(() => (later = true));
+      void stallLots().then(() => (later = true));
     },
   });
 

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -215,7 +215,7 @@ test(`E(zoe).getPublicFacet`, async t => {
   /** @type {Installation<import('@agoric/zoe/src/contracts/automaticRefund').start>} */
   const installation = await E(zoe).installBundleID('b1-refund');
   const { publicFacet, instance } = await E(zoe).startInstance(installation);
-  t.throwsAsync(() =>
+  await t.throwsAsync(() =>
     // @ts-expect-error not on public facet
     E(publicFacet).missingMethod(),
   );

--- a/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
@@ -32,7 +32,7 @@ test('makeInstanceAdminStorage', async t => {
     getOfferFilter: () => ['filter'],
   });
 
-  ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin);
+  void ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin);
   t.is(await ias.accessor.getInstallation(mockInstance1), mockInstallation1);
   t.is(await ias.accessor.getBrands(mockInstance1), mockBrandRecord);
   t.is(await ias.accessor.getPublicFacet(mockInstance1), mockFacet);
@@ -56,7 +56,7 @@ test('add another instance admin for same instance', async t => {
     getOfferFilter: () => 'filter',
   });
 
-  ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
+  void ias.updater.initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
   t.is(await ias.accessor.getInstallation(mockInstance1), mockInstallation1);
 
   const mockInstanceAdmin2 = Far('mockInstanceAdmin', {});

--- a/packages/zoe/tools/manualPriceAuthority.js
+++ b/packages/zoe/tools/manualPriceAuthority.js
@@ -82,7 +82,7 @@ export function makeManualPriceAuthority(options) {
     setPrice: newPrice => {
       currentPrice = newPrice;
       updater.updateState(currentPrice);
-      fireTriggers(createQuote);
+      void fireTriggers(createQuote);
     },
     ...priceAuthority,
   });

--- a/packages/zoe/tools/scriptedPriceAuthority.js
+++ b/packages/zoe/tools/scriptedPriceAuthority.js
@@ -84,10 +84,10 @@ export function makeScriptedPriceAuthority(options) {
       currentPrice =
         priceList[Number(Number(t / quoteInterval) % priceList.length)];
 
-      fireTriggers(createQuote);
+      void fireTriggers(createQuote);
     },
   });
-  observeNotifier(notifier, priceObserver);
+  void observeNotifier(notifier, priceObserver);
 
   return priceAuthority;
 }


### PR DESCRIPTION
refs: [#6000](https://github.com/Agoric/agoric-sdk/issues/6000)

## Description

Resolve all violations of `@typescript-eslint/no-floating-promises` in all packages (except for `SwingSet` and `swingset-runner`, see discussion below).

Change rule from `warn` to `error` to ensure more instances don't come up after this effort.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

Ran `NODE_OPTIONS='--max-old-space-size=8192' AGORIC_ESLINT_TYPES=true yarn lint:eslint` in each package.


Unit tests should still pass.

Anything with a change to add explicit `void` will not change any behavior. However, it's possible that there are still hidden bugs resulting from not awaiting or catching these promises. Is it in our best interest to use `void` anywhere then? By doing so, we risk sweeping those bugs under the rug, despite appeasing the lint rule. If we must remove all `void`, then this is a much larger task.
