### PR TITLE
Only "module account" transfer events cause vpurse balance updates

### DIFF
--- a/golang/cosmos/x/vbank/README.md
+++ b/golang/cosmos/x/vbank/README.md
@@ -22,7 +22,7 @@ The Vbank module maintains no significant state, but will access stored state th
 
 Purse operations which change the balance result in a downcall to this module to update the underlying account. A downcall is also made to query the account balance.
 
-Upon an `EndBlock()` call, the module will scan the block for all `MsgSend` and `MsgMultiSend` events (see `cosmos-sdk/x/bank/spec/04_events.md`) and perform a `VBANK_BALANCE_UPDATE` upcall for all denominations held in all mentioned accounts.
+Upon an `EndBlock()` call, the module will scan the block for all `MsgSend` and `MsgMultiSend` events (see `cosmos-sdk/x/bank/spec/04_events.md`) and perform a `VBANK_BALANCE_UPDATE` upcall for all denominations held in *only the mentioned module accounts*.
 
 The following fields are common to the Vbank messages:
 - `"address"`, `"recipient"`, `"sender"`: account address as a bech32-encoded string

--- a/golang/cosmos/x/vbank/keeper/keeper.go
+++ b/golang/cosmos/x/vbank/keeper/keeper.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/vbank/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	vm "github.com/Agoric/agoric-sdk/golang/cosmos/vm"
@@ -80,6 +81,15 @@ func (k Keeper) GrabCoins(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coins) e
 
 func (k Keeper) GetModuleAccountAddress(ctx sdk.Context, name string) sdk.AccAddress {
 	return k.accountKeeper.GetModuleAddress(name)
+}
+
+func (k Keeper) IsModuleAccount(ctx sdk.Context, addr sdk.AccAddress) bool {
+	acc := k.accountKeeper.GetAccount(ctx, addr)
+	if acc == nil {
+		return false
+	}
+	_, ok := acc.(authtypes.ModuleAccountI)
+	return ok
 }
 
 func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {

--- a/golang/cosmos/x/vbank/types/expected_keepers.go
+++ b/golang/cosmos/x/vbank/types/expected_keepers.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 // A subset of github.com/cosmos/cosmos-sdk/x/bank/keeper.Keeper
@@ -17,4 +18,5 @@ type BankKeeper interface {
 
 type AccountKeeper interface {
 	GetModuleAddress(name string) sdk.AccAddress
+	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #5896

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Reduce SwingSet load by limiting `x/vbank` only to trigger vat-bank balance notifier updates upon explicit virtual purse operations, or on events caused by Cosmos "module account" balance changes.

This works because the smart wallet UI reads Cosmos (vbank) balances directly from the RPC server instead of from the virtual purse notifier.  Uses within Agoric SDK of Cosmos module accounts represented as virtual purses (like the provision pool) work the same as they did before.

Pinging @dckc for the correctness of these assumptions, and @JimLarson for Go changes.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

Improves scalability by reducing SwingSet traffic caused by user-to-user Cosmos-level transfers.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
--> 