### PR TITLE
feat: functional upgrade-10 handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 replace github.com/tendermint/tendermint => github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.3
 
 // We need a fork of cosmos-sdk until all of the differences are merged.
-replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.1.0.20230323035240-8551678e04db
+replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.2
 
 replace github.com/cosmos/gaia/v7 => github.com/Agoric/ag0/v7 v7.0.2-alpha.agoric.1
 

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/Zilliqa/gozilliqa-sdk v1.2.1-0.20201201074141-dd0ecada1be6/go.mod h1:
 github.com/adlio/schema v1.3.3 h1:oBJn8I02PyTB466pZO1UZEn1TV5XLlifBSyMrmHl/1I=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
-github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.1.0.20230323035240-8551678e04db h1:FwZL+MsLF3sLqawUJI3etRSqrxxPEvqdrWqTEQTO18Y=
-github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.1.0.20230323035240-8551678e04db/go.mod h1:fdXvzy+wmYB+W+N139yb0+szbT7zAGgUjmxm5DBrjto=
+github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.2 h1:r3I+DDs/C5BOvZZYl0nitaTKdqpE3sdLjzb5zGQgYJg=
+github.com/agoric-labs/cosmos-sdk v0.45.11-alpha.agoric.2/go.mod h1:fdXvzy+wmYB+W+N139yb0+szbT7zAGgUjmxm5DBrjto=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1 h1:2jvHI/2d+psWAZy6FQ0vXJCHUtfU3ZbbW+pQFL04arQ=
 github.com/agoric-labs/cosmos-sdk/ics23/go v0.8.0-alpha.agoric.1/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/agoric-labs/tendermint v0.34.23-alpha.agoric.3 h1:aq6F1r3RQkKUYNeMNjRxgGn3dayvKnDK/R6gQF0WoFs=

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -751,6 +751,22 @@ func NewAgoricApp(
 		upgrade10Handler(app, upgradeNameTest),
 	)
 
+	/* REVIEWER: confirm that this isn't needed
+	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
+	}
+
+	if (upgradeInfo.Name == upgradeName || upgradeInfo.Name == upgradeNameTest) && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := store.StoreUpgrades{
+			Added: []string{swingsettypes.StoreKey},
+		}
+
+		// configure store loader taht checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
+	*/
+
 	if loadLatest {
 		if err := app.LoadLatestVersion(); err != nil {
 			tmos.Exit(fmt.Sprintf("failed to load latest version: %s", err))
@@ -773,8 +789,7 @@ func NewAgoricApp(
 
 func upgrade10Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgradetypes.Plan, module.VersionMap) (module.VersionMap, error) {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVm module.VersionMap) (module.VersionMap, error) {
-		// TODO: In next upgrade handler (bulldozer), run:
-		// app.VstorageKeeper.MigrateNoDataPlaceholders(ctx)
+		app.VstorageKeeper.MigrateNoDataPlaceholders(ctx)
 		return fromVm, nil
 	}
 }

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -789,7 +789,7 @@ func NewAgoricApp(
 
 func upgrade10Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgradetypes.Plan, module.VersionMap) (module.VersionMap, error) {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVm module.VersionMap) (module.VersionMap, error) {
-		app.VstorageKeeper.MigrateNoDataPlaceholders(ctx)
+		app.VstorageKeeper.MigrateNoDataPlaceholders(ctx) // upgrade-10 only
 		return fromVm, nil
 	}
 }

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -751,22 +751,6 @@ func NewAgoricApp(
 		upgrade10Handler(app, upgradeNameTest),
 	)
 
-	/* REVIEWER: confirm that this isn't needed
-	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
-	if err != nil {
-		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
-	}
-
-	if (upgradeInfo.Name == upgradeName || upgradeInfo.Name == upgradeNameTest) && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		storeUpgrades := store.StoreUpgrades{
-			Added: []string{swingsettypes.StoreKey},
-		}
-
-		// configure store loader taht checks if version == upgradeHeight and applies store upgrades
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
-	}
-	*/
-
 	if loadLatest {
 		if err := app.LoadLatestVersion(); err != nil {
 			tmos.Exit(fmt.Sprintf("failed to load latest version: %s", err))


### PR DESCRIPTION
closes: #7357

## Description

Runs the vstorage migration function in the placeholder.

Implicitly runs per-module migration for `x/swingset` to add new beans for storage (see #7290).

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

Need to have an upgrade end-to-end test as part of release checklist.
