### PR TITLE
Eliminate nugatory "workerCanBlock" support

### DIFF
--- a/packages/SwingSet/src/kernel/vat-loader/manager-local.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-local.js
@@ -35,7 +35,7 @@ export function makeLocalVatManagerFactory({
 
       return mk.getManager(shutdown);
     }
-    const syscall = makeSupervisorSyscall(mk.syscallFromWorker, true);
+    const syscall = makeSupervisorSyscall(mk.syscallFromWorker);
     return { syscall, finish };
   }
 

--- a/packages/SwingSet/src/supervisors/supervisor-helper.js
+++ b/packages/SwingSet/src/supervisors/supervisor-helper.js
@@ -1,4 +1,3 @@
-import { assert } from '@agoric/assert';
 import {
   insistVatSyscallObject,
   insistVatSyscallResult,
@@ -60,11 +59,10 @@ export { makeSupervisorDispatch };
  * VatSyscallObject and (synchronously) returns a VatSyscallResult.
  *
  * @param {VatSyscallHandler} syscallToManager
- * @param {boolean} workerCanBlock
  * @typedef { unknown } TheSyscallObjectWithMethodsThatLiveslotsWants
  * @returns {TheSyscallObjectWithMethodsThatLiveslotsWants}
  */
-function makeSupervisorSyscall(syscallToManager, workerCanBlock) {
+function makeSupervisorSyscall(syscallToManager) {
   function doSyscall(fields) {
     insistVatSyscallObject(fields);
     /** @type { VatSyscallObject } */
@@ -75,10 +73,6 @@ function makeSupervisorSyscall(syscallToManager, workerCanBlock) {
     } catch (err) {
       console.warn(`worker got error during syscall:`, err);
       throw err;
-    }
-    if (!workerCanBlock) {
-      // we don't expect an answer
-      return null;
     }
     const vsr = r;
     insistVatSyscallResult(vsr);
@@ -126,21 +120,6 @@ function makeSupervisorSyscall(syscallToManager, workerCanBlock) {
     vatstoreSet: (key, value) => doSyscall(['vatstoreSet', key, value]),
     vatstoreDelete: key => doSyscall(['vatstoreDelete', key]),
   };
-
-  const blocking = [
-    'callNow',
-    'vatstoreGet',
-    'vatstoreGetNextKey',
-    'vatstoreSet',
-    'vatstoreDelete',
-  ];
-
-  if (!workerCanBlock) {
-    for (const name of blocking) {
-      const err = `this non-blocking worker transport cannot syscall.${name}`;
-      syscallForVat[name] = () => assert.fail(err);
-    }
-  }
 
   return harden(syscallForVat);
 }

--- a/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
+++ b/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
@@ -205,7 +205,7 @@ function makeWorker(port) {
       return result;
     }
 
-    const syscall = makeSupervisorSyscall(syscallToManager, true);
+    const syscall = makeSupervisorSyscall(syscallToManager);
 
     const vatPowers = {
       makeMarshal,


### PR DESCRIPTION
This cleans things up a bit by removing unneeded support for workers that can't block which isn't needed because they all can.
