### PR TITLE
refactor(ertp): jessie-check where easy

### DIFF
--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { Fail } from '@agoric/assert';
 import { mustMatch } from '@agoric/store';
 

--- a/packages/ERTP/src/index.js
+++ b/packages/ERTP/src/index.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 export * from './amountMath.js';
 export * from './issuerKit.js';
 export * from './typeGuards.js';

--- a/packages/ERTP/src/legacy-payment-helpers.js
+++ b/packages/ERTP/src/legacy-payment-helpers.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { mustMatch } from '@agoric/store';
 import { E } from '@endo/far';
 import { AmountMath } from './amountMath.js';

--- a/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copyBagMathHelpers.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import {
   keyEQ,
   makeCopyBag,

--- a/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/copySetMathHelpers.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import {
   keyEQ,
   makeCopySet,

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { Nat, isNat } from '@endo/nat';
 
 import '../types-ambient.js';

--- a/packages/ERTP/src/mathHelpers/setMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/setMathHelpers.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { passStyleOf } from '@endo/marshal';
 import {
   assertKey,

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { initEmpty } from '@agoric/store';
 import { prepareExoClass } from '@agoric/vat-data';
 

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 /* eslint-disable no-use-before-define */
 import { isPromise } from '@endo/promise-kit';
 import { mustMatch, M, keyEQ } from '@agoric/store';

--- a/packages/ERTP/src/transientNotifier.js
+++ b/packages/ERTP/src/transientNotifier.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { makeScalarBigWeakMapStore } from '@agoric/vat-data';
 import { provideLazy } from '@agoric/store';
 import { makeNotifierKit } from '@agoric/notifier';

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { M, matches } from '@agoric/store';
 
 export const BrandShape = M.remotable('Brand');

--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 /// <reference types="ses"/>
 
 /**


### PR DESCRIPTION
Adds @jessie-check directives to ERTP src/**/*.js files when doing so has zero problems. 

See 
https://github.com/Agoric/agoric-sdk/pull/3876
https://github.com/Agoric/agoric-sdk/pull/5497
https://github.com/Agoric/agoric-sdk/pull/7486
https://github.com/Agoric/agoric-sdk/pull/7481