### PR TITLE
feat(cosmic-swingset): Add a config property for exporting storage to bootstrap

### DIFF
--- a/golang/cosmos/x/vstorage/types/types.go
+++ b/golang/cosmos/x/vstorage/types/types.go
@@ -62,6 +62,10 @@ func (se StorageEntry) Path() string {
 	return se.path
 }
 
+func (se StorageEntry) Value() *string {
+	return se.value
+}
+
 func (se StorageEntry) StringValue() string {
 	if se.value != nil {
 		return *se.value

--- a/golang/cosmos/x/vstorage/vstorage.go
+++ b/golang/cosmos/x/vstorage/vstorage.go
@@ -194,13 +194,12 @@ func (sh vstorageHandler) Receive(cctx *vm.ControllerContext, str string) (ret s
 			return
 		}
 		children := keeper.GetChildren(cctx.Context, path)
-		ents := make([][]string, len(children.Children))
+		entries := make([][]interface{}, len(children.Children))
 		for i, child := range children.Children {
-			ents[i] = make([]string, 2)
-			ents[i][0] = child
-			ents[i][i] = keeper.GetEntry(cctx.Context, fmt.Sprintf("%s.%s", path, child)).StringValue()
+			entry := keeper.GetEntry(cctx.Context, fmt.Sprintf("%s.%s", path, child))
+			entries[i] = []interface{}{child, entry.Value()}
 		}
-		bytes, err := json.Marshal(ents)
+		bytes, err := json.Marshal(entries)
 		if err != nil {
 			return "", err
 		}

--- a/golang/cosmos/x/vstorage/vstorage_test.go
+++ b/golang/cosmos/x/vstorage/vstorage_test.go
@@ -72,7 +72,8 @@ func TestGetAndHas(t *testing.T) {
 
 	keeper.SetStorage(ctx, types.NewStorageEntry("foo", "bar"))
 	keeper.SetStorage(ctx, types.NewStorageEntry("empty", ""))
-	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("special.nodata"))
+	keeper.SetStorage(ctx, types.NewStorageEntry("top.empty-non-terminal.leaf", ""))
+	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("top.empty-non-terminal"))
 
 	type testCase struct {
 		label       string
@@ -83,7 +84,8 @@ func TestGetAndHas(t *testing.T) {
 	cases := []testCase{
 		{label: "nonempty value", args: []interface{}{"foo"}, want: `"bar"`},
 		{label: "empty string value", args: []interface{}{"empty"}, want: `""`},
-		{label: "no value", args: []interface{}{"special.nodata"}, want: `null`},
+		{label: "deep empty string", args: []interface{}{"top.empty-non-terminal.leaf"}, want: `""`},
+		{label: "empty non-terminal", args: []interface{}{"top.empty-non-terminal"}, want: `null`},
 		{label: "no entry", args: []interface{}{"nosuchpath"}, want: `null`},
 		{label: "empty args", args: []interface{}{}, errContains: ptr(`missing`)},
 		{label: "non-string arg", args: []interface{}{42}, errContains: ptr(`json`)},
@@ -261,8 +263,10 @@ func TestEntries(t *testing.T) {
 
 	keeper.SetStorage(ctx, types.NewStorageEntry("key1", "value1"))
 	keeper.SetStorage(ctx, types.NewStorageEntry("key1.child1.grandchild1", "value1grandchild"))
-	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("key1.child1.grandchild2"))
+	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("key1.child1"))
 	keeper.SetStorage(ctx, types.NewStorageEntry("key1.child1.empty-non-terminal.leaf", ""))
+	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("key2"))
+	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("key2.child2"))
 	keeper.SetStorage(ctx, types.NewStorageEntry("key2.child2.grandchild2", "value2grandchild"))
 	keeper.SetStorage(ctx, types.NewStorageEntry("key2.child2.grandchild2a", "value2grandchilda"))
 

--- a/golang/cosmos/x/vstorage/vstorage_test.go
+++ b/golang/cosmos/x/vstorage/vstorage_test.go
@@ -255,14 +255,13 @@ func TestSetWithoutNotify(t *testing.T) {
 
 // TODO: TestChildrenAndSize
 
-// TODO: TestValues
-
 func TestEntries(t *testing.T) {
 	kit := makeTestKit()
 	keeper, handler, ctx, cctx := kit.keeper, kit.handler, kit.ctx, kit.cctx
 
 	keeper.SetStorage(ctx, types.NewStorageEntry("key1", "value1"))
 	keeper.SetStorage(ctx, types.NewStorageEntry("key1.child1.grandchild1", "value1grandchild"))
+	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("key1.child1.grandchild2"))
 	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("key1.child1"))
 	keeper.SetStorage(ctx, types.NewStorageEntry("key1.child1.empty-non-terminal.leaf", ""))
 	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("key2"))

--- a/golang/cosmos/x/vstorage/vstorage_test.go
+++ b/golang/cosmos/x/vstorage/vstorage_test.go
@@ -1,0 +1,258 @@
+package vstorage
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/x/vstorage/types"
+
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	agorictypes "github.com/Agoric/agoric-sdk/golang/cosmos/types"
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+)
+
+var (
+	storeKey = storetypes.NewKVStoreKey(types.StoreKey)
+)
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+type testKit struct {
+	keeper  Keeper
+	handler vstorageHandler
+	ctx     sdk.Context
+	cctx    *vm.ControllerContext
+}
+
+func makeTestKit() testKit {
+	keeper := NewKeeper(storeKey)
+	db := dbm.NewMemDB()
+	ms := store.NewCommitMultiStore(db)
+	ms.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, db)
+	err := ms.LoadLatestVersion()
+	if err != nil {
+		panic(err)
+	}
+	ctx := sdk.NewContext(ms, tmproto.Header{}, false, log.NewNopLogger())
+	cctx := &vm.ControllerContext{Context: ctx}
+	handler := vstorageHandler{keeper}
+	return testKit{keeper, handler, ctx, cctx}
+}
+
+func callReceive(
+	handler vstorageHandler,
+	cctx *vm.ControllerContext,
+	method string,
+	args []interface{},
+) (string, error) {
+	var rawArgs []json.RawMessage
+	for _, arg := range args {
+		rawArg, _ := json.Marshal(arg)
+		rawArgs = append(rawArgs, json.RawMessage(rawArg))
+	}
+	req := vstorageMessage{method, rawArgs}
+	reqBytes, _ := json.Marshal(req)
+	return handler.Receive(cctx, string(reqBytes))
+}
+
+func TestGetAndHas(t *testing.T) {
+	kit := makeTestKit()
+	keeper, handler, ctx, cctx := kit.keeper, kit.handler, kit.ctx, kit.cctx
+
+	keeper.SetStorage(ctx, types.NewStorageEntry("foo", "bar"))
+	keeper.SetStorage(ctx, types.NewStorageEntry("empty", ""))
+	keeper.SetStorage(ctx, types.NewStorageEntryWithNoData("special.nodata"))
+
+	type testCase struct {
+		label       string
+		args        []interface{}
+		want        string
+		errContains *string
+	}
+	cases := []testCase{
+		{label: "nonempty value", args: []interface{}{"foo"}, want: `"bar"`},
+		{label: "empty string value", args: []interface{}{"empty"}, want: `""`},
+		{label: "no value", args: []interface{}{"special.nodata"}, want: `null`},
+		{label: "no entry", args: []interface{}{"nosuchpath"}, want: `null`},
+		{label: "empty args", args: []interface{}{}, errContains: ptr(`missing`)},
+		{label: "non-string arg", args: []interface{}{42}, errContains: ptr(`json`)},
+		{label: "extra args", args: []interface{}{"foo", "bar"}, errContains: ptr(`extra`)},
+	}
+	for _, desc := range cases {
+		got, err := callReceive(handler, cctx, "get", desc.args)
+		has, hasErr := callReceive(handler, cctx, "has", desc.args)
+
+		// Verify get/has error agreement.
+		if (err == nil) != (hasErr == nil) {
+			t.Errorf("%s: get/has error mismatch, %v vs. %v", desc.label, err, hasErr)
+		} else if err != nil && hasErr.Error() != err.Error() {
+			t.Errorf("%s: get/has error message mismatch, %v vs. %v", desc.label, err, hasErr)
+		}
+
+		if got != desc.want {
+			t.Errorf("%s: got %q; want %q", desc.label, got, desc.want)
+		}
+		if desc.errContains == nil {
+			if err != nil {
+				t.Errorf("%s: got unexpected error %v", desc.label, err)
+			}
+
+			// Verify that has returns false iff get returns null.
+			noData := desc.want == `null`
+			if (noData && has != `false`) || (!noData && has != `true`) {
+				t.Errorf("%s: got has %v; want %v", desc.label, has, !noData)
+			}
+		} else if err == nil {
+			t.Errorf("%s: got no error, want error %q", desc.label, *desc.errContains)
+		} else if !strings.Contains(err.Error(), *desc.errContains) {
+			t.Errorf("%s: got error %v, want error %q", desc.label, err, *desc.errContains)
+		}
+	}
+}
+
+func doTestSet(t *testing.T, method string, expectNotify bool) {
+	kit := makeTestKit()
+	keeper, handler, ctx, cctx := kit.keeper, kit.handler, kit.ctx, kit.cctx
+
+	type testCase struct {
+		label        string
+		args         []interface{}
+		errContains  *string
+		skipReadBack map[int]bool
+	}
+	cases := []testCase{
+		{label: "single value",
+			args: []interface{}{[]string{"foo", "bar"}},
+		},
+		{label: "other single value",
+			args: []interface{}{[]string{"bar", "baz"}},
+		},
+		{label: "multi-value",
+			args: []interface{}{[]string{"baz.a", "qux"}, []string{"baz.b", "qux"}},
+		},
+		{label: "other multi-value",
+			args: []interface{}{[]string{"qux", "A"}, []string{"quux", "B"}},
+		},
+		{label: "overwrites",
+			args: []interface{}{[]string{"bar"}, []string{"quux", "new"}},
+		},
+		{label: "non-string path",
+			// TODO: Fully validate input before making changes
+			// args:        []interface{}{[]string{"foo", "X"}, []interface{}{42, "new"}},
+			args:        []interface{}{[]interface{}{42, "new"}},
+			errContains: ptr("path"),
+		},
+		{label: "non-string value",
+			// TODO: Fully validate input before making changes
+			// args:        []interface{}{[]string{"foo", "X"}, []interface{}{"foo", true}},
+			args:        []interface{}{[]interface{}{"foo", true}},
+			errContains: ptr("value"),
+		},
+		{label: "self-overwrite",
+			args:         []interface{}{[]string{"final.final.corge", "grault"}, []string{"final.final.corge", "garply"}},
+			skipReadBack: map[int]bool{0: true},
+		},
+	}
+	stateChangeEvent := func(path, value string) sdk.Event {
+		return agorictypes.NewStateChangeEvent(
+			keeper.GetStoreName(),
+			keeper.PathToEncodedKey(path),
+			[]byte(value),
+		)
+	}
+	// Expect events to be alphabetized by key.
+	expectedFlushEvents := sdk.Events{
+		stateChangeEvent("baz.a", "qux"),
+		stateChangeEvent("baz.b", "qux"),
+		stateChangeEvent("final.final.corge", "garply"),
+		stateChangeEvent("foo", "bar"),
+		stateChangeEvent("quux", "new"),
+		stateChangeEvent("qux", "A"),
+	}
+	for _, desc := range cases {
+		got, err := callReceive(handler, cctx, method, desc.args)
+
+		if desc.errContains == nil {
+			if err != nil {
+				t.Errorf("%s %s: got unexpected error %v", method, desc.label, err)
+			} else if got != "true" {
+				t.Errorf("%s %s: got unexpected response %q; want %q", method, desc.label, got, "true")
+			}
+
+			// Read the data back.
+			for i, arg := range desc.args {
+				entry, ok := arg.([]string)
+				if desc.skipReadBack[i] {
+					continue
+				} else if !ok {
+					t.Errorf("%s %s: cannot convert %#v to []string!", method, desc.label, arg)
+					continue
+				}
+				path := entry[0]
+				var value *string
+				if len(entry) > 1 {
+					value = &entry[1]
+				}
+				wantBackBytes, _ := json.Marshal(value)
+				wantBack := string(wantBackBytes)
+				gotBack, err := callReceive(handler, cctx, "get", []interface{}{path})
+				if err != nil {
+					t.Errorf("%s %s read back %q: got unexpected error %v", method, desc.label, path, err)
+				} else if gotBack != wantBack {
+					t.Errorf("%s %s read back %q: got %q; want %q", method, desc.label, path, gotBack, wantBack)
+				}
+			}
+		} else if err == nil {
+			t.Errorf("%s %s: got no error, want error %q", method, desc.label, *desc.errContains)
+		} else if !strings.Contains(err.Error(), *desc.errContains) {
+			t.Errorf("%s %s: got error %v, want error %q", method, desc.label, err, *desc.errContains)
+		}
+	}
+
+	// Verify corresponding events.
+	if got := ctx.EventManager().Events(); !reflect.DeepEqual(got, sdk.Events{}) {
+		t.Errorf("%s got unexpected events before flush %#v", method, got)
+	}
+	keeper.FlushChangeEvents(ctx)
+	if !expectNotify {
+		if got := ctx.EventManager().Events(); !reflect.DeepEqual(got, sdk.Events{}) {
+			t.Errorf("%s got unexpected events after flush %#v", method, got)
+		}
+	} else if got := ctx.EventManager().Events(); !reflect.DeepEqual(got, expectedFlushEvents) {
+		for _, evt := range got {
+			attrs := make([]string, len(evt.Attributes))
+			for i, attr := range evt.Attributes {
+				attrs[i] = fmt.Sprintf("%s=%q", attr.Key, attr.Value)
+			}
+			t.Logf("%s got event %s<%s>", method, evt.Type, strings.Join(attrs, ", "))
+		}
+		t.Errorf("%s got after flush events %#v; want %#v", method, got, expectedFlushEvents)
+	}
+}
+
+func TestSet(t *testing.T) {
+	doTestSet(t, "set", true)
+}
+
+func TestSetWithoutNotify(t *testing.T) {
+	doTestSet(t, "setWithoutNotify", false)
+}
+
+// TODO: TestAppend
+
+// TODO: TestChildrenAndSize
+
+// TODO: TestValues
+
+// TODO: TestEntries

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -185,6 +185,10 @@ export {};
  * @typedef {object} SwingSetOptions
  * @property {string} [bootstrap]
  * @property {ConfigProposal[]} [coreProposals]
+ * @property {string[]} [exportStorageSubtrees] chain storage paths
+ *   for which data should be exported into bootstrap vat parameter `chainStorageEntries`
+ *   (e.g., `exportStorageSubtrees: ['a.b']` might result in vatParameters including
+ *   `chainStorageEntries: [ ['a.b', ''], ['a.b.c', '"foo"'], ['a.b.c2', '42'] ]`).
  * @property {boolean} [includeDevDependencies] indicates that
  * `devDependencies` of the surrounding `package.json` should be accessible to
  * bundles.

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -185,10 +185,10 @@ export {};
  * @typedef {object} SwingSetOptions
  * @property {string} [bootstrap]
  * @property {ConfigProposal[]} [coreProposals]
- * @property {string[]} [exportStorageSubtrees] chain storage paths
+ * @property {string[]} [exportStorageSubtrees] chain storage paths identifying roots of subtrees
  *   for which data should be exported into bootstrap vat parameter `chainStorageEntries`
- *   (e.g., `exportStorageSubtrees: ['a.b']` might result in vatParameters including
- *   `chainStorageEntries: [ ['a.b', ''], ['a.b.c', '"foo"'], ['a.b.c2', '42'] ]`).
+ *   (e.g., `exportStorageSubtrees: ['c.o']` might result in vatParameters including
+ *   `chainStorageEntries: [ ['c.o', null], ['c.o.i', null], ['c.o.i.n', '42'], ['c.o.w', '"moo"'] ]`).
  * @property {boolean} [includeDevDependencies] indicates that
  * `devDependencies` of the surrounding `package.json` should be accessible to
  * bundles.

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -139,7 +139,12 @@ export async function buildSwingset(
         );
         chainStorageEntries.push(entry);
         const [path] = entry;
-        const childEntries = callChainStorage('entries', path);
+        const childEntrySuffixes = callChainStorage('entries', path);
+        const childEntries = childEntrySuffixes.map(([nextSegment, value]) => {
+          const fullPath =
+            !path || path === '.' ? `${nextSegment}` : `${path}.${nextSegment}`;
+          return [fullPath, value];
+        });
         pendingEntries = [...childEntries, ...pendingEntries];
       }
       bootVat.parameters = { ...bootVat.parameters, chainStorageEntries };


### PR DESCRIPTION
Fixes #7156

## Description

When SwingSet configuration includes `exportStorageSubtrees`, read all chain storage data at or under the specified paths and make the resulting array of entries available to the bootstrap vat at parameter `chainStorageEntries`.

### Security Considerations

None known; launch-chain already had access to the bridge and control over configuration is already a highly privileged capability.

### Scaling Considerations

Reading the data can potentially be very slow, but we have accepted that.

### Documentation Considerations

I'm not sure where chain configuration and bootstrap vat parameters are officially documented, but would welcome suggestions.

### Testing Considerations

There doesn't seem to be any existing test framework that could verify the new behavior. :cry: