### PR TITLE
fix(vbank): properly detect module accounts

### DIFF
--- a/golang/cosmos/x/vbank/keeper/keeper.go
+++ b/golang/cosmos/x/vbank/keeper/keeper.go
@@ -80,7 +80,11 @@ func (k Keeper) GrabCoins(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coins) e
 }
 
 func (k Keeper) GetModuleAccountAddress(ctx sdk.Context, name string) sdk.AccAddress {
-	return k.accountKeeper.GetModuleAddress(name)
+	acct := k.accountKeeper.GetModuleAccount(ctx, name)
+	if acct == nil {
+		return nil
+	}
+	return acct.GetAddress()
 }
 
 func (k Keeper) IsModuleAccount(ctx sdk.Context, addr sdk.AccAddress) bool {

--- a/golang/cosmos/x/vbank/types/expected_keepers.go
+++ b/golang/cosmos/x/vbank/types/expected_keepers.go
@@ -17,6 +17,6 @@ type BankKeeper interface {
 }
 
 type AccountKeeper interface {
-	GetModuleAddress(name string) sdk.AccAddress
+	GetModuleAccount(ctx sdk.Context, name string) authtypes.ModuleAccountI
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #7473

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

The Cosmos SDK `authKeeper.GetModuleAccount()` function must be called to ensure the account's existence in the store otherwise the detection logic in #7473 would fail.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
