### PR TITLE
fix(zcf): mint kind during reincarnation

### DIFF
--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -90,7 +90,10 @@ export const makeZCFZygote = async (
   // Make the instanceRecord
   const makeInstanceRecord = makeInstanceRecordStorage(zcfBaggage);
 
-  const recordIssuer = (keyword, issuerRecord) => {
+  const recordIssuer = (
+    /** @type {string} */ keyword,
+    /** @type {IssuerRecord} */ issuerRecord,
+  ) => {
     getInstanceRecHolder().addIssuer(keyword, issuerRecord);
     storeIssuerRecord(issuerRecord);
   };
@@ -332,7 +335,7 @@ export const makeZCFZygote = async (
       zcfBaggage,
     ));
 
-    zcfMintFactory = await makeZCFMintFactory(
+    zcfMintFactory = makeZCFMintFactory(
       zcfBaggage,
       recordIssuer,
       getAssetKindByBrand,


### PR DESCRIPTION
closes: #7502 

## Description

ZCF mint types were failing to restore during reincarnation. @warner traced this down to a faulty argument to `zcfMintBaggage.add()`. That should have been caught by TypeScript but wasn't due to https://github.com/Agoric/agoric-sdk/issues/7507

There was an additional bug in awaiting a remote call (zoe vat from zcf vat) during reincarnation. This precludes the call during reincarnation by keeping the result in baggage. This changed allowed for less async handling so this also cleans up some related paths.

### Security Considerations

issuer record in baggage

### Scaling Considerations

--

### Documentation Considerations

--

### Testing Considerations

Existing tests pass. No unit tests for regression because it will be stressed by contract upgrade tests such as for https://github.com/Agoric/agoric-sdk/issues/7466 in which this problem was discovered.