### PR TITLE
refactor(notifier): jessie-check where easy

### DIFF
--- a/packages/notifier/exported.js
+++ b/packages/notifier/exported.js
@@ -1,1 +1,3 @@
+// @jessie-check
+
 import './src/types-ambient.js';

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 export {
   makePublishKit,
   prepareDurablePublishKit,

--- a/packages/notifier/src/stored-notifier.js
+++ b/packages/notifier/src/stored-notifier.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { assertAllDefined } from '@agoric/internal';
 import { makeSerializeToStorage } from '@agoric/internal/src/lib-chainStorage.js';
 import { E, Far } from '@endo/far';

--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 /// <reference types="ses"/>
 
 import { E, Far } from '@endo/far';

--- a/packages/notifier/src/topic.js
+++ b/packages/notifier/src/topic.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { Far } from '@endo/far';
 import './types-ambient.js';
 

--- a/packages/notifier/src/types-ambient.js
+++ b/packages/notifier/src/types-ambient.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 /**
  * @template T
  * @typedef {import('@endo/far').ERef<T>} ERef

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 export {};
 /**
  * @template T

--- a/packages/notifier/subscribe.js
+++ b/packages/notifier/subscribe.js
@@ -1,1 +1,3 @@
+// @jessie-check
+
 export * from './src/subscribe.js';


### PR DESCRIPTION
Adds @jessie-check directives to notifier src/**/*.js files when doing so has zero problems. 

See 
https://github.com/Agoric/agoric-sdk/pull/3876
https://github.com/Agoric/agoric-sdk/pull/5497
https://github.com/Agoric/agoric-sdk/pull/7486
https://github.com/Agoric/agoric-sdk/pull/7481