### PR TITLE
refactor(cosmic-swingset): jessie-check where easy

### DIFF
--- a/packages/cosmic-swingset/calc-rpcport.js
+++ b/packages/cosmic-swingset/calc-rpcport.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @jessie-check
 
 // NOTE: Runs outside SES
 

--- a/packages/cosmic-swingset/check-validator.cjs
+++ b/packages/cosmic-swingset/check-validator.cjs
@@ -1,4 +1,6 @@
 #! /usr/bin/env node
+// @jessie-check
+
 /* global process require Buffer */
 // check-validator - Find if there is a validator that matches the current ag-chain-cosmos
 // Michael FIG <mfig@agoric.com>, 2021-06-25

--- a/packages/cosmic-swingset/src/entrypoint.js
+++ b/packages/cosmic-swingset/src/entrypoint.js
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+// @jessie-check
 
 import '@endo/init/pre.js';
 

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -1,6 +1,7 @@
 #! /usr/bin/env node
-
 // @ts-check
+// @jessie-check
+
 import '@endo/init/unsafe-fast.js';
 
 import os from 'os';

--- a/packages/cosmic-swingset/src/helpers/is-entrypoint.js
+++ b/packages/cosmic-swingset/src/helpers/is-entrypoint.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 // Detect if this is run as a script.
 import url from 'url';
 import process from 'process';

--- a/packages/cosmic-swingset/src/import-kernel-db.js
+++ b/packages/cosmic-swingset/src/import-kernel-db.js
@@ -1,6 +1,7 @@
 #! /usr/bin/env node
-
 // @ts-check
+// @jessie-check
+
 import '@endo/init/unsafe-fast.js';
 
 import os from 'os';

--- a/packages/cosmic-swingset/src/params.js
+++ b/packages/cosmic-swingset/src/params.js
@@ -1,4 +1,6 @@
 // @ts-check
+// @jessie-check
+
 import { Fail } from '@agoric/assert';
 import { Nat, isNat } from '@endo/nat';
 

--- a/packages/cosmic-swingset/src/sim-params.js
+++ b/packages/cosmic-swingset/src/sim-params.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { Nat } from '@endo/nat';
 
 const makeStringBeans = (key, beans) => ({ key, beans: `${Nat(beans)}` });


### PR DESCRIPTION
Adds @jessie-check directives to cosmic-swingset src/**/*.js files when doing so has zero problems. 

See 
https://github.com/Agoric/agoric-sdk/pull/3876
https://github.com/Agoric/agoric-sdk/pull/5497
https://github.com/Agoric/agoric-sdk/pull/7486
https://github.com/Agoric/agoric-sdk/pull/7481