### PR TITLE
refactor(casting): jessie-check where easy

### DIFF
--- a/packages/casting/node-fetch-shim.js
+++ b/packages/casting/node-fetch-shim.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 /* global globalThis */
 import fetch from 'node-fetch';
 

--- a/packages/casting/src/follower.js
+++ b/packages/casting/src/follower.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { Far } from '@endo/far';
 import {
   mapAsyncIterable,

--- a/packages/casting/src/main.js
+++ b/packages/casting/src/main.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 // eslint-disable-next-line import/export
 export * from './types.js'; // no named exports
 export * from './defaults.js';

--- a/packages/casting/src/netconfig.js
+++ b/packages/casting/src/netconfig.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { mustMatch, M } from '@agoric/store';
 
 // NB: keep type and shape in sync manually until https://github.com/Agoric/agoric-sdk/issues/6160

--- a/packages/casting/src/types.js
+++ b/packages/casting/src/types.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 // Make this a module.
 import '@agoric/notifier';
 


### PR DESCRIPTION
Adds @jessie-check directives to casting src/**/*.js files when doing so has zero problems. 

See 
https://github.com/Agoric/agoric-sdk/pull/3876
https://github.com/Agoric/agoric-sdk/pull/5497
https://github.com/Agoric/agoric-sdk/pull/7486
https://github.com/Agoric/agoric-sdk/pull/7481