### PR TITLE
refactor(agoric-cli): jessie-check where easy

### DIFF
--- a/packages/agoric-cli/.ava-integration-test.config.js
+++ b/packages/agoric-cli/.ava-integration-test.config.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 export default {
   files: ['integration-tests/test-workflow.js'],
   timeout: '10m',

--- a/packages/agoric-cli/src/bin-agops.js
+++ b/packages/agoric-cli/src/bin-agops.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 // @ts-check
+// @jessie-check
+
 /* eslint-disable @jessie.js/no-nested-await */
 /* global fetch, setTimeout */
 

--- a/packages/agoric-cli/src/entrypoint.js
+++ b/packages/agoric-cli/src/entrypoint.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @jessie-check
 
 /* global process */
 

--- a/packages/agoric-cli/tools/resm-plugin/src/output.js
+++ b/packages/agoric-cli/tools/resm-plugin/src/output.js
@@ -1,1 +1,3 @@
+// @jessie-check
+
 export const start = 'Started plugin';

--- a/packages/agoric-cli/tools/resm-plugin/src/output.js
+++ b/packages/agoric-cli/tools/resm-plugin/src/output.js
@@ -1,3 +1,1 @@
-// @jessie-check
-
 export const start = 'Started plugin';

--- a/packages/agoric-cli/tools/resm-plugin/src/plugin.js
+++ b/packages/agoric-cli/tools/resm-plugin/src/plugin.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Far } from '@endo/marshal';
 import { start } from './output.js';


### PR DESCRIPTION
Adds @jessie-check directives to agoric-cli src/**/*.js files when doing so has zero problems. 

See 
https://github.com/Agoric/agoric-sdk/pull/3876
https://github.com/Agoric/agoric-sdk/pull/5497
https://github.com/Agoric/agoric-sdk/pull/7486
https://github.com/Agoric/agoric-sdk/pull/7481