### PR TITLE
refactor(internal): jessie-check where easy

### DIFF
--- a/packages/internal/src/action-types.js
+++ b/packages/internal/src/action-types.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 export const BOOTSTRAP_BLOCK = 'BOOTSTRAP_BLOCK';
 export const COSMOS_SNAPSHOT = 'COSMOS_SNAPSHOT';
 export const BEGIN_BLOCK = 'BEGIN_BLOCK';

--- a/packages/internal/src/batched-deliver.js
+++ b/packages/internal/src/batched-deliver.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 export const DEFAULT_BATCH_TIMEOUT_MS = 1000;
 
 /**

--- a/packages/internal/src/chain-storage-paths.js
+++ b/packages/internal/src/chain-storage-paths.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 /**
  * These identify top-level paths for SwingSet chain storage
  * (and serve as prefixes).

--- a/packages/internal/src/config.js
+++ b/packages/internal/src/config.js
@@ -1,4 +1,6 @@
 // @ts-check
+// @jessie-check
+
 /**
  * @file
  *

--- a/packages/internal/src/debug.js
+++ b/packages/internal/src/debug.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 let debugInstance = 1;
 
 /**

--- a/packages/internal/src/index.js
+++ b/packages/internal/src/index.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 /// <reference types="ses"/>
 
 export * from './config.js';

--- a/packages/internal/src/magic-cookie-test-only.js
+++ b/packages/internal/src/magic-cookie-test-only.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 const cookie = harden({});
 
 /**

--- a/packages/internal/src/queue.js
+++ b/packages/internal/src/queue.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { makePromiseKit } from '@endo/promise-kit';
 
 /**

--- a/packages/internal/src/typeGuards.js
+++ b/packages/internal/src/typeGuards.js
@@ -1,3 +1,5 @@
+// @jessie-check
+
 import { M } from '@endo/patterns';
 
 export const StorageNodeShape = M.remotable('StorageNode');

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -1,5 +1,6 @@
 // @ts-check
 // @jessie-check
+
 import { E } from '@endo/far';
 import { deeplyFulfilled, isObject } from '@endo/marshal';
 import { isPromise } from '@endo/promise-kit';


### PR DESCRIPTION
Adds @jessie-check directives to internal src/**/*.js files when doing so has zero problems. 

See 
https://github.com/Agoric/agoric-sdk/pull/3876
https://github.com/Agoric/agoric-sdk/pull/5497
https://github.com/Agoric/agoric-sdk/pull/7486
https://github.com/Agoric/agoric-sdk/pull/7481