### PR TITLE
7502 followup: factor out factory

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -22,7 +22,6 @@ const AssetKind = harden({
 const assetKindNames = harden(Object.values(AssetKind).sort());
 
 /**
- *
  * @param {AssetKind} allegedAK
  */
 const assertAssetKind = allegedAK => {
@@ -110,7 +109,6 @@ const assertValueGetAssetKind = value => {
 };
 
 /**
- *
  * Asserts that value is a valid AmountMath and returns the appropriate helpers.
  *
  * Made available only for testing, but it is harmless for other uses.
@@ -377,7 +375,6 @@ const AmountMath = {
 harden(AmountMath);
 
 /**
- *
  * @param {Amount} amount
  */
 const getAssetKind = amount => {

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -79,7 +79,6 @@ function unhandledRejectionHandler(e, pr) {
 }
 
 /**
- *
  * @param {SwingStoreKernelStorage} kernelStorage
  * @param {Record<string, unknown>} deviceEndowments
  * @param {{

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -72,7 +72,6 @@ function makeCallbackRegistry(callbacks) {
 }
 
 /**
- *
  * @param {*} slogCallbacks
  * @param {Pick<Console, 'debug'|'log'|'info'|'warn'|'error'>} dummyConsole
  * @returns {KernelSlog}
@@ -103,7 +102,6 @@ export function makeDummySlogger(slogCallbacks, dummyConsole) {
 }
 
 /**
- *
  * @param {*} slogCallbacks
  * @param {*} writeObj
  * @returns {KernelSlog}

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -56,7 +56,6 @@ import {
 // slots on the inbound (dispatch) path.
 
 /**
- *
  * @typedef { { getManager: (shutdown: () => Promise<void>,
  *                           makeSnapshot?: MakeSnapshot) => VatManager,
  *              syscallFromWorker: (vso: VatSyscallObject) => VatSyscallResult,

--- a/packages/SwingSet/src/lib/kmarshal.js
+++ b/packages/SwingSet/src/lib/kmarshal.js
@@ -15,7 +15,6 @@ import { assert } from '@agoric/assert';
 const refMap = new WeakMap();
 
 /**
- *
  * @param {string} kref
  * @param {string} [iface]
  * @returns {import('@endo/eventual-send').ERef<KCap>}
@@ -59,7 +58,6 @@ export const kslot = (kref, iface = 'undefined') => {
 };
 
 /**
- *
  * @param {any} obj
  * @returns {string}
  */

--- a/packages/SwingSet/src/lib/message.js
+++ b/packages/SwingSet/src/lib/message.js
@@ -105,7 +105,6 @@ export function insistVatDeliveryResult(vdr) {
 }
 
 /**
- *
  * @param {unknown} vso
  * @returns {asserts vso is VatSyscallObject}
  */

--- a/packages/SwingSet/src/lib/netstring.js
+++ b/packages/SwingSet/src/lib/netstring.js
@@ -8,7 +8,6 @@ const COLON = 58;
 const COMMA = 44;
 
 /**
- *
  * @param {Buffer} data
  * @returns {Buffer} netstring-wrapped
  */

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -106,7 +106,6 @@ export const makeConnection = (
 };
 
 /**
- *
  * @param {ConnectionHandler} handler0
  * @param {Endpoint} addr0
  * @param {ConnectionHandler} handler1

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -89,7 +89,6 @@ export function buildDispatch(onDispatchCallback) {
 }
 
 /**
- *
  * @param {unknown} target
  * @param {string} method
  * @param {any[]} args

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -51,7 +51,6 @@ const toBundleMeta = n => `bundle-${n}-meta.json`;
 const providedCaches = new Map();
 
 /**
- *
  * @param {ReturnType<typeof makeFileWriter>} wr
  * @param {*} bundleOptions
  * @param {ReturnType<typeof makeFileReader>} cwd

--- a/packages/agoric-cli/src/commands/ec.js
+++ b/packages/agoric-cli/src/commands/ec.js
@@ -17,7 +17,6 @@ import {
 /** @typedef {import('@agoric/smart-wallet/src/offers.js').OfferSpec} OfferSpec */
 
 /**
- *
  * @param {import('anylogger').Logger} _logger
  * @param {{
  *   env?: Record<string, string|undefined>,

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -14,7 +14,6 @@ const COSMOS_UNIT = 1_000_000n;
 const scaleDecimals = num => BigInt(num * Number(COSMOS_UNIT));
 
 /**
- *
  * @param {import('anylogger').Logger} logger
  */
 export const makeOracleCommand = logger => {

--- a/packages/agoric-cli/src/commands/perf.js
+++ b/packages/agoric-cli/src/commands/perf.js
@@ -23,7 +23,6 @@ import { networkConfig } from '../lib/rpc.js';
 const SLEEP_SECONDS = 0.1;
 
 /**
- *
  * @param {import('anylogger').Logger} logger
  */
 export const makePerfCommand = logger => {

--- a/packages/agoric-cli/src/commands/psm.js
+++ b/packages/agoric-cli/src/commands/psm.js
@@ -31,7 +31,6 @@ function collectValues(val, memo) {
 }
 
 /**
- *
  * @param {import('anylogger').Logger} logger
  */
 export const makePsmCommand = logger => {

--- a/packages/agoric-cli/src/commands/vaults.js
+++ b/packages/agoric-cli/src/commands/vaults.js
@@ -13,7 +13,6 @@ import { makeRpcUtils } from '../lib/rpc.js';
 import { getCurrent, outputExecuteOfferAction } from '../lib/wallet.js';
 
 /**
- *
  * @param {import('anylogger').Logger} logger
  */
 export const makeVaultsCommand = logger => {

--- a/packages/agoric-cli/src/lib/format.js
+++ b/packages/agoric-cli/src/lib/format.js
@@ -176,7 +176,6 @@ export const offerStatusTuples = (state, agoricNames) => {
 };
 
 /**
- *
  * @param {import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord} current
  * @param {ReturnType<import('@agoric/smart-wallet/src/utils.js').makeWalletStateCoalescer>['state']} coalesced
  * @param {Awaited<ReturnType<typeof makeAgoricNames>>} agoricNames

--- a/packages/agoric-cli/src/lib/rpc.js
+++ b/packages/agoric-cli/src/lib/rpc.js
@@ -54,7 +54,6 @@ export const networkConfig = await getNetworkConfig(process.env);
 // console.warn('networkConfig', networkConfig);
 
 /**
- *
  * @param {object} powers
  * @param {typeof window.fetch} powers.fetch
  * @param {MinimalNetworkConfig} config

--- a/packages/agoric-cli/src/scripts.js
+++ b/packages/agoric-cli/src/scripts.js
@@ -55,7 +55,6 @@ export const makeLookup =
   };
 
 /**
- *
  * @param {string[]} scripts
  * @param {{ allowUnsafePlugins: boolean, progname: string, rawArgs: string[], endowments?: Record<string, any> }} opts
  * @param {{ fs: import('fs/promises'), console: Console }} powers

--- a/packages/casting/src/casting-spec.js
+++ b/packages/casting/src/casting-spec.js
@@ -42,7 +42,6 @@ const vstoragePathToCastingSpec = (storagePath, storeName = 'vstorage') => {
 // TODO make a similar castingSpecToPath.
 // This one uses VStorageKey which has storeSubkey:string, not UInt8Array
 /**
- *
  * @param {VStorageKey} vstorageKey
  * @returns {string}
  */

--- a/packages/cosmic-swingset/src/kernel-stats.js
+++ b/packages/cosmic-swingset/src/kernel-stats.js
@@ -111,7 +111,6 @@ export function getTelemetryProviders(powers = {}) {
 }
 
 /**
- *
  * @param {import('@opentelemetry/api-metrics').Meter} metricMeter
  * @param {string} name
  */

--- a/packages/governance/src/multiCandidateVoteCounter.js
+++ b/packages/governance/src/multiCandidateVoteCounter.js
@@ -217,7 +217,6 @@ const makeMultiCandidateVoteCounter = (
 };
 
 /**
- *
  * @param {ZCF<{questionSpec: QuestionSpec, quorumThreshold: bigint }>} zcf
  * @param {{outcomePublisher: Publisher<MultiOutcomeRecord>}} outcomePublisher
  */

--- a/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
@@ -20,7 +20,6 @@ const makeVoterVat = async (log, vats, zoe) => {
 };
 
 /**
- *
  * @param {Pick<QuestionDetails, 'issue' | 'positions' | 'electionType'>} qDetails
  * @param {import('@agoric/time/src/types').Timestamp} closingTime
  * @param {{ electorateFacet: import('../../../src/committee.js').CommitteeElectorateCreatorFacet, installations: Record<string, Installation>, timer: import('@agoric/time/src/types').TimerService }} tools

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -107,7 +107,6 @@ const votersVote = async (detailsP, votersP, selections) => {
 };
 
 /**
- *
  * @param {ERef<import('./vat-voter.js').EVatVoter[]>} votersP
  * @param {ERef<QuestionDetails>} detailsP
  * @param {ERef<Instance>} governedInstanceP

--- a/packages/inter-protocol/scripts/init-core.js
+++ b/packages/inter-protocol/scripts/init-core.js
@@ -53,7 +53,6 @@ const installKeyGroups = {
 };
 
 /**
- *
  * @param {object} opts
  * @param {(i: I) => R} opts.publishRef
  * @param {(m: string, b: string, opts?: any) => I} opts.install
@@ -90,7 +89,6 @@ export const committeeProposalBuilder = async (
 };
 
 /**
- *
  * @param {object} opts
  * @param {(i: I) => R} opts.publishRef
  * @param {(m: string, b: string, opts?: any) => I} opts.install

--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -64,7 +64,6 @@ const trace = makeTracer('AucBook', false);
  * })} OfferSpec
  */
 /**
- *
  * @param {Brand<'nat'>} bidBrand
  * @param {Brand<'nat'>} collateralBrand
  */

--- a/packages/inter-protocol/src/auction/sortedOffers.js
+++ b/packages/inter-protocol/src/auction/sortedOffers.js
@@ -52,7 +52,6 @@ export const toPriceOfferKey = (offerPrice, sequenceNumber) => {
 };
 
 /**
- *
  * @param {number} floatPrice
  * @param {Brand<'nat'>} numBrand
  * @param {Brand<'nat'>} denomBrand

--- a/packages/inter-protocol/src/interest-math.js
+++ b/packages/inter-protocol/src/interest-math.js
@@ -9,7 +9,6 @@ import {
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 
 /**
- *
  * @param {Ratio} currentCompoundedInterest as coefficient
  * @param {Ratio} previousCompoundedInterest as coefficient
  * @returns {Ratio} additional compounding since the previous
@@ -26,7 +25,6 @@ const calculateRelativeCompounding = (
 };
 
 /**
- *
  * @param {Amount<'nat'>} debtSnapshot
  * @param {Ratio} interestSnapshot as coefficient
  * @param {Ratio} currentCompoundedInterest as coefficient
@@ -50,7 +48,6 @@ export const calculateCurrentDebt = (
 };
 
 /**
- *
  * @param {Amount<'nat'>} debt
  * @param {Ratio} interestApplied
  * @returns {Amount<'nat'>}

--- a/packages/inter-protocol/src/interest.js
+++ b/packages/inter-protocol/src/interest.js
@@ -131,7 +131,6 @@ export const calculateCompoundedInterest = (
 };
 
 /**
- *
  * @template {AssetKind} K
  * @param {ZCFMint<K>} mint
  * @param {Amount<K>} debt

--- a/packages/inter-protocol/src/proposals/utils.js
+++ b/packages/inter-protocol/src/proposals/utils.js
@@ -91,7 +91,6 @@ const provideWhen = async (store, key, make) => {
 };
 
 /**
- *
  * @param {{ scratch: ERef<import('@agoric/internal/src/scratch.js').ScratchPad> }} homeP
  * @param {object} opts
  * @param {(specifier: string) => Promise<{default: Bundle}>} opts.loadBundle

--- a/packages/inter-protocol/src/stakeFactory/stakeFactory.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactory.js
@@ -78,7 +78,6 @@ import { makeStakeFactoryManager } from './stakeFactoryManager.js';
  */
 
 /**
- *
  * @param {ZCF<StakeFactoryTerms>} zcf
  * @param {StakeFactoryPrivateArgs} privateArgs
  */

--- a/packages/inter-protocol/src/stakeFactory/stakeFactoryManager.js
+++ b/packages/inter-protocol/src/stakeFactory/stakeFactoryManager.js
@@ -111,7 +111,6 @@ const initState = (
 };
 
 /**
- *
  * @param {MethodContext} context
  */
 const finish = ({ state, facets }) => {

--- a/packages/inter-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/inter-protocol/src/vaultFactory/prioritizedVaults.js
@@ -19,7 +19,6 @@ import {
 const trace = makeTracer('PVaults', false);
 
 /**
- *
  * @param {Amount<'nat'>} debtAmount
  * @param {Amount<'nat'>} collateralAmount
  * @returns {Ratio}
@@ -35,7 +34,6 @@ const calculateDebtToCollateral = (debtAmount, collateralAmount) => {
 };
 
 /**
- *
  * @param {Vault} vault
  * @returns {Ratio}
  */

--- a/packages/inter-protocol/src/vaultFactory/vaultHolder.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultHolder.js
@@ -35,7 +35,6 @@ const PUBLIC_TOPICS = {
 };
 
 /**
- *
  * @param {import('@agoric/ertp').Baggage} baggage
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit} makeRecorderKit
  */

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -175,7 +175,6 @@ test.before(async t => {
 });
 
 /**
- *
  * @param {import('ava').ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
  * @param {{}} [customTerms]
  */

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -87,7 +87,6 @@ test.before(async t => {
 });
 
 /**
- *
  * @param {import('ava').ExecutionContext<*>} t
  * @param {string[]} oracleAddresses
  */

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -69,7 +69,6 @@ export const setUpZoeForTest = async (setJig = () => {}) => {
 harden(setUpZoeForTest);
 
 /**
- *
  * @param {*} t
  * @param {import('@agoric/time/src/types').TimerService} [optTimer]
  */
@@ -214,7 +213,6 @@ export const withAmountUtils = kit => {
 /** @typedef {ReturnType<typeof withAmountUtils>} AmountUtils */
 
 /**
- *
  * @param {ERef<StoredSubscription<unknown> | StoredSubscriber<unknown>>} subscription
  */
 export const subscriptionKey = subscription => {
@@ -231,7 +229,6 @@ export const subscriptionKey = subscription => {
 };
 
 /**
- *
  * @param {ERef<{getPublicTopics: () => import('@agoric/zoe/src/contractSupport').TopicsRecord}>} hasTopics
  * @param {string} subscriberName
  */

--- a/packages/inter-protocol/test/test-feeDistributor.js
+++ b/packages/inter-protocol/test/test-feeDistributor.js
@@ -40,7 +40,6 @@ const makeFakeFeeProducer = (makeEmptyPayment = () => {}) => {
   });
 };
 /**
- *
  * @param {*} t
  * @param {Promise<Payment[]>} paymentsP
  * @param {number} count

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -158,7 +158,6 @@ const setupReserveAndElectorate = async t => {
 };
 
 /**
- *
  * @param {import('ava').ExecutionContext<DriverContext>} t
  * @param {Amount<'nat'>} amt
  */

--- a/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
@@ -118,7 +118,6 @@ export const setupElectorateReserveAndAuction = async (
 };
 
 /**
- *
  * @param {import('ava').ExecutionContext<any>} t
  * @param {bigint} amount
  */

--- a/packages/internal/src/batched-deliver.js
+++ b/packages/internal/src/batched-deliver.js
@@ -7,7 +7,6 @@ export const DEFAULT_BATCH_TIMEOUT_MS = 1000;
  */
 
 /**
- *
  * @param {DeliverMessages} deliver
  * @param {{ clearTimeout: NodeJS.clearTimeout, setTimeout: NodeJS.setTimeout }} io
  * @param {number} batchTimeoutMs

--- a/packages/internal/src/debug.js
+++ b/packages/internal/src/debug.js
@@ -3,7 +3,6 @@
 let debugInstance = 1;
 
 /**
- *
  * @param {string} name
  * @param {boolean | 'verbose'} enable
  */

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -220,7 +220,6 @@ harden(makeStorageNodeChild);
 
 // TODO find a better module for this
 /**
- *
  * @param {import('@endo/far').ERef<StorageNode>} storageNode
  * @param {import('@endo/far').ERef<Marshaller>} marshaller
  * @returns {(value: unknown) => Promise<void>}

--- a/packages/internal/src/utils.js
+++ b/packages/internal/src/utils.js
@@ -89,7 +89,6 @@ export const objectMap = (original, mapFn) => {
 harden(objectMap);
 
 /**
- *
  * @param {Array<string | symbol>} leftNames
  * @param {Array<string | symbol>} rightNames
  */

--- a/packages/notifier/tools/testSupports.js
+++ b/packages/notifier/tools/testSupports.js
@@ -6,7 +6,6 @@ import '../src/types-ambient.js';
 export { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 
 /**
- *
  * @param {string} path
  * @param {IterationObserver<unknown>} [publication]
  */

--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -25,7 +25,7 @@ const MAX_PIPE_LENGTH = 2;
  * }} AgoricContractInvitationSpec
  * source of invitation is a chain of calls starting with an agoricName
  *   - the start of the pipe is a lookup of instancePath within agoricNames
- *   - each entry in the callPipe executes a call on the preceeding result
+ *   - each entry in the callPipe executes a call on the preceding result
  *   - the end of the pipe is expected to return an Invitation
  *
  * @typedef {{

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -148,7 +148,6 @@ const { Fail, quote: q } = assert;
  */
 
 /**
- *
  * @param {import('@agoric/vat-data').Baggage} baggage
  * @param {SharedParams} shared
  */

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -113,7 +113,6 @@ export const assertHasData = async follower => {
 };
 
 /**
- *
  * Handles the case of falsy argument so the caller can consistently await.
  *
  * @param {import('./types.js').PublicSubscribers | import('@agoric/zoe/src/contractSupport').TopicsRecord} [subscribers]

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -129,7 +129,6 @@ export const makeAssetRegistry = assetPublisher => {
 // 1. they should not rely on that; they may be partitioned later
 // 2. they should never be able to detect behaviors from another wallet
 /**
- *
  * @param {ZCF<SmartWalletContractTerms>} zcf
  * @param {{
  *   storageNode: ERef<StorageNode>,

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -48,7 +48,6 @@ export const withAmountUtils = kit => {
 /** @typedef {ReturnType<typeof withAmountUtils>} AmountUtils */
 
 /**
- *
  * @param {ERef<StoredFacet>} subscription
  */
 export const subscriptionKey = subscription => {
@@ -100,7 +99,6 @@ const makeFakeBridgeManager = () =>
     },
   });
 /**
- *
  * @param {*} log
  * @returns {Promise<ChainBootstrapSpace>}>}
  */
@@ -191,7 +189,6 @@ export const mintCentralPayment = async (
 };
 
 /**
- *
  * @param {ERef<{getPublicTopics: () => import('@agoric/zoe/src/contractSupport').TopicsRecord}>} hasTopics
  * @param {string} subscriberName
  */

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
@@ -18,7 +18,6 @@ import {
 } from '../../../src/walletFactory.js';
 
 /**
- *
  * @type {typeof import('../../../src/walletFactory.js').prepare}
  */
 export const prepare = async (zcf, privateArgs, baggage) => {

--- a/packages/swingset-liveslots/src/message.js
+++ b/packages/swingset-liveslots/src/message.js
@@ -113,7 +113,6 @@ export function insistVatDeliveryResult(vdr) {
 }
 
 /**
- *
  * @param {unknown} vso
  * @returns {asserts vso is VatSyscallObject}
  */

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -137,7 +137,6 @@ const makeContextCache = (makeState, makeContext) => {
  */
 
 /**
- *
  * @param {*} contextCache
  * @param {*} getSlotForVal
  * @returns {ContextProvider}

--- a/packages/swingset-liveslots/src/virtualReferences.js
+++ b/packages/swingset-liveslots/src/virtualReferences.js
@@ -324,7 +324,7 @@ export function makeVirtualReferenceManager(
     const kindID = `${id}`;
     const kindInfo = kindInfoTable.get(kindID);
     kindInfo ||
-      Fail`no kind info for ${kindID} (${baseRef}); check deserialize preceeding kind definitions`;
+      Fail`no kind info for ${kindID} (${baseRef}); check deserialize preceding kind definitions`;
     const { reanimator } = kindInfo;
     if (reanimator) {
       return reanimator(baseRef);

--- a/packages/swingset-liveslots/test/util.js
+++ b/packages/swingset-liveslots/test/util.js
@@ -47,7 +47,6 @@ export function buildDispatch(onDispatchCallback) {
 }
 
 /**
- *
  * @param {unknown} target
  * @param {string} method
  * @param {any[]} args

--- a/packages/swingset-xsnap-supervisor/src/index.js
+++ b/packages/swingset-xsnap-supervisor/src/index.js
@@ -12,7 +12,6 @@ const read = (name, path) => {
 };
 
 /**
- *
  * @returns { Promise<string> }
  */
 export const getSupervisorBundleSHA256 = async () => {
@@ -21,7 +20,6 @@ export const getSupervisorBundleSHA256 = async () => {
 };
 
 /**
- *
  * @typedef {{ moduleFormat: string, source: string, sourceMap: [string] }} Bundle
  * @returns { Promise<Bundle> }
  */

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -19,7 +19,6 @@ export const DEFAULT_SLOGSENDER_AGENT = 'self';
 const filterTruthy = arr => /** @type {any[]} */ (arr.filter(Boolean));
 
 /**
- *
  * @param {import('./index.js').MakeSlogSenderOptions} opts
  */
 export const makeSlogSender = async (opts = {}) => {

--- a/packages/ui-components/src/display/display.js
+++ b/packages/ui-components/src/display/display.js
@@ -10,7 +10,6 @@ import { parseAsCopyBag } from './copyBagValue/parseAsCopyBag.js';
 import { stringifyCopyBag } from './copyBagValue/stringifyCopyBag.js';
 
 /**
- *
  * @param {string} str - string to parse as a value
  * @param {AssetKind} [assetKind] - assetKind of the value
  * @param {number} [decimalPlaces] - places to move the decimal to the left
@@ -50,7 +49,6 @@ export const parseAsAmount = (
 };
 
 /**
- *
  * @param {AmountValue} value - value to stringify
  * @param {AssetKind} [assetKind] - assetKind of the value
  * @param {number} [decimalPlaces] - places to move the decimal to the

--- a/packages/ui-components/src/display/natValue/stringifyRatio.js
+++ b/packages/ui-components/src/display/natValue/stringifyRatio.js
@@ -5,7 +5,6 @@ import { roundToDecimalPlaces } from './helpers/roundToDecimalPlaces.js';
 const PLACES_TO_SHOW = 2;
 
 /**
- *
  * @param {Ratio} ratio
  * @param {(brand: Brand) => number | undefined} getDecimalPlaces
  * @param {number} [placesToShow]

--- a/packages/vats/src/core/client-behaviors.js
+++ b/packages/vats/src/core/client-behaviors.js
@@ -23,7 +23,6 @@ function makeVattpFrom(vats) {
 // be in the DApp environment (or only in end-user), but we're not yet
 // making a distinction, so the user also gets them.
 /**
- *
  * @param {SoloVats & SwingsetVats} vats
  * @param {SoloDevices} devices
  * @param {ERef<VatAdminSvc>} vatAdminSvc

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -24,7 +24,6 @@ const startFactoryInstance = (zoe, inst) => E(zoe).startInstance(inst);
 const StableUnit = BigInt(10 ** Stable.displayInfo.decimalPlaces);
 
 /**
- *
  * @param {{
  *   zoe: ERef<ZoeService>,
  *   governedContractInstallation: ERef<Installation>,

--- a/packages/vats/src/provisionPoolKit.js
+++ b/packages/vats/src/provisionPoolKit.js
@@ -77,7 +77,6 @@ export const makeBridgeProvisionTool = (sendInitialPayment, onProvisioned) => {
 };
 
 /**
- *
  * @param {import('@agoric/vat-data').Baggage} baggage
  * @param {{
  * makeRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit,

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -165,7 +165,6 @@ export const makeRunUtils = (controller, log = (..._) => {}) => {
 };
 
 /**
- *
  * @param {ReturnType<typeof makeRunUtils>} runUtils
  * @param {import('@agoric/internal/src/storage-test-utils.js').FakeStorageKit} storage
  * @param {import('../../tools/board-utils.js').AgoricNamesRemotes} agoricNamesRemotes

--- a/packages/vats/test/test-boot.js
+++ b/packages/vats/test/test-boot.js
@@ -47,7 +47,6 @@ test.before(t => {
  */
 
 /**
- *
  * @param {string} label
  * @param {BuildRootObject} entryPoint
  * @param {boolean} doCoreProposals

--- a/packages/vats/tools/authorityViz.js
+++ b/packages/vats/tools/authorityViz.js
@@ -64,7 +64,6 @@ function* fmtGraph(nodes, neighbors) {
 }
 
 /**
- *
  * @param {Record<string, Permit>} manifest
  * @typedef { true | {
  *   vatParameters?: Record<string, Permit>,

--- a/packages/vats/tools/boot-test-utils.js
+++ b/packages/vats/tools/boot-test-utils.js
@@ -152,7 +152,6 @@ export const mockSwingsetVats = mock => {
 };
 
 /**
- *
  * @param {(msg: string) => void} log
  */
 export const mockPsmBootstrapArgs = log => {

--- a/packages/web-components/src/keplr-connection/watchWallet.js
+++ b/packages/web-components/src/keplr-connection/watchWallet.js
@@ -21,7 +21,6 @@ import { queryBankBalances } from './queryBankBalances.js';
 const POLL_INTERVAL_MS = 6000;
 
 /**
- *
  * @param {ERef<import('@agoric/casting').Leader>} leader
  * @param {string} address
  * @param {import('@agoric/smart-wallet/src/marshal-contexts.js').ImportContext} context

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -141,17 +141,10 @@
  */
 
 /**
- * @callback ZCFMintMintGains
- * @param {AmountKeywordRecord} gains
- * @param {ZCFSeat} [zcfSeat]
- * @returns {ZCFSeat}
- */
-
-/**
  * @template {AssetKind} [K=AssetKind]
  * @typedef {object} ZCFMint
  * @property {() => IssuerRecord<K>} getIssuerRecord
- * @property {ZCFMintMintGains} mintGains
+ * @property {(gains: AmountKeywordRecord, zcfSeat?: ZCFSeat) => ZCFSeat} mintGains
  * All the amounts in gains must be of this ZCFMint's brand.
  * The gains' keywords are in the namespace of that seat.
  * Add the gains to that seat's allocation.
@@ -161,8 +154,6 @@
  * Mint that amount of assets into the pooled purse.
  * If a seat is provided, it is returned. Otherwise a new seat is
  * returned.
- * TODO unimplemented
- * This creation-on-demand is not yet implemented.
  *
  * @property {(losses: AmountKeywordRecord,
  *             zcfSeat: ZCFSeat,

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -1,171 +1,155 @@
-// @jessie-check
-
-import { E } from '@endo/eventual-send';
 import { AmountMath } from '@agoric/ertp';
-import {
-  provideDurableSetStore,
-  makeScalarBigMapStore,
-  prepareSingleton,
-  prepareExo,
-  M,
-} from '@agoric/vat-data';
+import { prepareExoClass } from '@agoric/vat-data';
+import { E } from '@endo/eventual-send';
 
 import { coerceAmountKeywordRecord } from '../cleanProposal.js';
-import { makeIssuerRecord } from '../issuerRecord.js';
+import { assertFullIssuerRecord, makeIssuerRecord } from '../issuerRecord.js';
 import { addToAllocation, subtractFromAllocation } from './allocationMath.js';
 
 import '../internal-types.js';
+import { ZcfMintI } from '../typeGuards.js';
 import './internal-types.js';
 import './types.js';
 
 const { Fail } = assert;
 
-export const makeZCFMintFactory = (
-  /** @type {import('@agoric/vat-data').Baggage} */ zcfBaggage,
-  /** @type {{ (keyword: string, issuerRecord: IssuerRecord): void }} */ recordIssuer,
-  /** @type {GetAssetKindByBrand} */ getAssetKindByBrand,
-  /** @type { (exit?: undefined) => { zcfSeat: any; userSeat: Promise<UserSeat> }} */ makeEmptySeatKit,
-  /** @type {ZcfMintReallocator} */ reallocator,
+/**
+ *
+ * @param {import('@agoric/vat-data').Baggage} zcfBaggage
+ * @param {{ (keyword: string, issuerRecord: IssuerRecord): void }} recordIssuer
+ * @param {GetAssetKindByBrand} getAssetKindByBrand
+ * @param {(exit?: undefined) => { zcfSeat: any; userSeat: Promise<UserSeat> }} makeEmptySeatKit
+ * @param {ZcfMintReallocator} reallocator
+ */
+export const prepareZcMint = (
+  zcfBaggage,
+  recordIssuer,
+  getAssetKindByBrand,
+  makeEmptySeatKit,
+  reallocator,
 ) => {
-  /** @type {SetStore<import('@agoric/vat-data').Baggage>} The set of baggages for zcfMints */
-  const zcfMintBaggageSet = provideDurableSetStore(zcfBaggage, 'baggageSet');
-
-  /**
-   * retrieve the state of the zcfMint from the baggage, and create a durable
-   * singleton reflecting that state.
-   *
-   * @param {import('@agoric/vat-data').Baggage} zcfMintBaggage
-   */
-  const provideDurableZcfMint = zcfMintBaggage => {
-    const keyword = zcfMintBaggage.get('keyword');
-    const zoeMint = zcfMintBaggage.get('zoeMint');
-    const {
-      brand: mintyBrand,
-      issuer: mintyIssuer,
-      displayInfo: mintyDisplayInfo,
-    } = zcfMintBaggage.get('issuerRecord');
-    const mintyIssuerRecord = makeIssuerRecord(
-      mintyBrand,
-      mintyIssuer,
-      mintyDisplayInfo,
-    );
-    recordIssuer(keyword, mintyIssuerRecord);
-
-    const empty = AmountMath.makeEmpty(mintyBrand, mintyDisplayInfo.assetKind);
-    const add = (total, amountToAdd) =>
-      AmountMath.add(total, amountToAdd, mintyBrand);
-
-    return prepareSingleton(
-      zcfMintBaggage,
-      'zcfMint',
-      /** @type {ZCFMint} */
-      {
-        getIssuerRecord: () => {
-          return mintyIssuerRecord;
-        },
-        /** @type {(gains: Record<string, Amount>, zcfSeat?: ZCFSeat) => ZCFSeat} */
-        mintGains: (gains, zcfSeat = makeEmptySeatKit().zcfSeat) => {
-          gains = coerceAmountKeywordRecord(gains, getAssetKindByBrand);
-          const totalToMint = Object.values(gains).reduce(add, empty);
-          !zcfSeat.hasExited() ||
-            Fail`zcfSeat must be active to mint gains for the zcfSeat`;
-          const allocationPlusGains = addToAllocation(
-            zcfSeat.getCurrentAllocation(),
-            gains,
-          );
-
-          // Increment the stagedAllocation if it exists so that the
-          // stagedAllocation is kept up to the currentAllocation
-          if (zcfSeat.hasStagedAllocation()) {
-            zcfSeat.incrementBy(gains);
-          }
-
-          // Offer safety should never be able to be violated here, as
-          // we are adding assets. However, we keep this check so that
-          // all reallocations are covered by offer safety checks, and
-          // that any bug within Zoe that may affect this is caught.
-          zcfSeat.isOfferSafe(allocationPlusGains) ||
-            Fail`The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`;
-          // No effects above, apart from incrementBy. Note COMMIT POINT within
-          // reallocator.reallocate(). The following two steps *should* be
-          // committed atomically, but it is not a disaster if they are
-          // not. If we minted only, no one would ever get those
-          // invisibly-minted assets.
-          E(zoeMint).mintAndEscrow(totalToMint);
-          reallocator.reallocate(zcfSeat, allocationPlusGains);
-          return zcfSeat;
-        },
-        burnLosses: (losses, zcfSeat) => {
-          losses = coerceAmountKeywordRecord(losses, getAssetKindByBrand);
-          const totalToBurn = Object.values(losses).reduce(add, empty);
-          !zcfSeat.hasExited() ||
-            Fail`zcfSeat must be active to burn losses from the zcfSeat`;
-          const allocationMinusLosses = subtractFromAllocation(
-            zcfSeat.getCurrentAllocation(),
-            losses,
-          );
-
-          // verifies offer safety
-          zcfSeat.isOfferSafe(allocationMinusLosses) ||
-            Fail`The allocation after burning losses ${allocationMinusLosses} for the zcfSeat was not offer safe`;
-
-          // Decrement the stagedAllocation if it exists so that the
-          // stagedAllocation is kept up to the currentAllocation
-          if (zcfSeat.hasStagedAllocation()) {
-            zcfSeat.decrementBy(losses);
-          }
-
-          // No effects above, apart from decrementBy. Note COMMIT POINT within
-          // reallocator.reallocate(). The following two steps *should* be
-          // committed atomically, but it is not a disaster if they are
-          // not. If we only commit the allocationMinusLosses no one would
-          // ever get the unburned assets.
-          reallocator.reallocate(zcfSeat, allocationMinusLosses);
-          E(zoeMint).withdrawAndBurn(totalToBurn);
-        },
-      },
-    );
-  };
-
-  const ZCFMintFactoryI = M.interface('ZCFMintFactory', {
-    makeZCFMintInternal: M.call(M.string(), M.remotable('ZoeMint')).returns(
-      M.promise(),
-    ),
-  });
-
-  /**
-   * zcfMintFactory has a method makeZCFMintInternal() that takes a keyword and the
-   * promise returned by a makeZoeMint() call. makeZCFMintInternal() creates a new
-   * baggage for the state of the zcfMint, makes a durableZcfMint from that
-   * baggage, and registers that baggage to be revived with the factory.
-   */
-  const zcfMintFactory = prepareExo(
+  const makeZcMintInternal = prepareExoClass(
     zcfBaggage,
-    'zcfMintFactory',
-    ZCFMintFactoryI,
+    'zcfMint',
+    ZcfMintI,
+    /**
+     * @template {AssetKind} [K=AssetKind]
+     * @param {string} keyword
+     * @param {ZoeMint<K>} zoeMint
+     * @param {Required<IssuerRecord<K>>} issuerRecord
+     */
+    (keyword, zoeMint, issuerRecord) => {
+      const {
+        brand: mintyBrand,
+        issuer: mintyIssuer,
+        displayInfo: mintyDisplayInfo,
+      } = issuerRecord;
+      const mintyIssuerRecord = makeIssuerRecord(
+        mintyBrand,
+        mintyIssuer,
+        mintyDisplayInfo,
+      );
+      recordIssuer(keyword, mintyIssuerRecord);
+
+      const empty = AmountMath.makeEmpty(
+        mintyBrand,
+        mintyDisplayInfo.assetKind,
+      );
+
+      return { empty, keyword, mintyBrand, zoeMint, mintyIssuerRecord };
+    },
     {
-      async makeZCFMintInternal(keyword, zoeMint) {
-        const issuerRecord = await E(zoeMint).getIssuerRecord();
+      getIssuerRecord() {
+        return this.state.mintyIssuerRecord;
+      },
+      /** @type {(gains: Record<string, Amount>, zcfSeat?: ZCFSeat) => ZCFSeat} */
+      mintGains(gains, zcfSeat = makeEmptySeatKit().zcfSeat) {
+        const { empty, mintyBrand, zoeMint } = this.state;
+        gains = coerceAmountKeywordRecord(gains, getAssetKindByBrand);
+        /** @type {(total: Amount, amountToAdd: Amount) => Amount}  */
+        const add = (total, amountToAdd) =>
+          AmountMath.add(total, amountToAdd, mintyBrand);
+        const totalToMint = Object.values(gains).reduce(add, empty);
+        !zcfSeat.hasExited() ||
+          Fail`zcfSeat must be active to mint gains for the zcfSeat`;
+        const allocationPlusGains = addToAllocation(
+          zcfSeat.getCurrentAllocation(),
+          gains,
+        );
 
-        const zcfMintBaggage = makeScalarBigMapStore('zcfMintBaggage', {
-          durable: true,
-        });
+        // Increment the stagedAllocation if it exists so that the
+        // stagedAllocation is kept up to the currentAllocation
+        if (zcfSeat.hasStagedAllocation()) {
+          zcfSeat.incrementBy(gains);
+        }
 
-        zcfMintBaggage.init('issuerRecord', issuerRecord);
-        zcfMintBaggage.init('keyword', keyword);
-        zcfMintBaggage.init('zoeMint', zoeMint);
-        zcfMintBaggageSet.add(zcfMintBaggage);
+        // Offer safety should never be able to be violated here, as
+        // we are adding assets. However, we keep this check so that
+        // all reallocations are covered by offer safety checks, and
+        // that any bug within Zoe that may affect this is caught.
+        zcfSeat.isOfferSafe(allocationPlusGains) ||
+          Fail`The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`;
+        // No effects above, apart from incrementBy. Note COMMIT POINT within
+        // reallocator.reallocate(). The following two steps *should* be
+        // committed atomically, but it is not a disaster if they are
+        // not. If we minted only, no one would ever get those
+        // invisibly-minted assets.
+        E(zoeMint).mintAndEscrow(totalToMint);
+        reallocator.reallocate(zcfSeat, allocationPlusGains);
+        return zcfSeat;
+      },
+      /**
+       * @param {AmountKeywordRecord} losses
+       * @param {ZCFSeat} zcfSeat
+       */
+      burnLosses(losses, zcfSeat) {
+        const { empty, mintyBrand, zoeMint } = this.state;
+        losses = coerceAmountKeywordRecord(losses, getAssetKindByBrand);
+        /** @type {(total: Amount, amountToAdd: Amount) => Amount}  */
+        const add = (total, amountToAdd) =>
+          AmountMath.add(total, amountToAdd, mintyBrand);
+        const totalToBurn = Object.values(losses).reduce(add, empty);
+        !zcfSeat.hasExited() ||
+          Fail`zcfSeat must be active to burn losses from the zcfSeat`;
+        const allocationMinusLosses = subtractFromAllocation(
+          zcfSeat.getCurrentAllocation(),
+          losses,
+        );
 
-        return provideDurableZcfMint(zcfMintBaggage);
+        // verifies offer safety
+        zcfSeat.isOfferSafe(allocationMinusLosses) ||
+          Fail`The allocation after burning losses ${allocationMinusLosses} for the zcfSeat was not offer safe`;
+
+        // Decrement the stagedAllocation if it exists so that the
+        // stagedAllocation is kept up to the currentAllocation
+        if (zcfSeat.hasStagedAllocation()) {
+          zcfSeat.decrementBy(losses);
+        }
+
+        // No effects above, apart from decrementBy. Note COMMIT POINT within
+        // reallocator.reallocate(). The following two steps *should* be
+        // committed atomically, but it is not a disaster if they are
+        // not. If we only commit the allocationMinusLosses no one would
+        // ever get the unburned assets.
+        reallocator.reallocate(zcfSeat, allocationMinusLosses);
+        E(zoeMint).withdrawAndBurn(totalToBurn);
       },
     },
   );
 
-  for (const zcfMintBaggage of zcfMintBaggageSet.values()) {
-    // call for side-effect of redefining the kinds
-    provideDurableZcfMint(zcfMintBaggage);
-  }
-
-  return zcfMintFactory;
+  /**
+   * @template {AssetKind} K
+   * @param {string} keyword
+   * @param {ERef<ZoeMint<K>>} zoeMintP
+   * @returns {Promise<ZCFMint<K>>}
+   */
+  return async (keyword, zoeMintP) => {
+    const [zoeMint, issuerRecord] = await Promise.all([
+      zoeMintP,
+      E(zoeMintP).getIssuerRecord(),
+    ]);
+    assertFullIssuerRecord(issuerRecord);
+    // @ts-expect-error cast, XXX AssetKind generic
+    return makeZcMintInternal(keyword, zoeMint, issuerRecord);
+  };
 };
-harden(makeZCFMintFactory);

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -32,7 +32,6 @@ export const sumAmountKeywordRecord = (amr, issuerRecord) => {
 };
 
 /**
- *
  * @param {import('@agoric/vat-data').Baggage} zcfBaggage
  * @param {{ (keyword: string, issuerRecord: IssuerRecord): void }} recordIssuer
  * @param {GetAssetKindByBrand} getAssetKindByBrand

--- a/packages/zoe/src/contractSupport/priceAuthorityTransform.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityTransform.js
@@ -7,7 +7,6 @@ import { makeNotifier } from '@agoric/notifier';
 /** @template T @typedef {import('@endo/eventual-send').EOnly<T>} EOnly */
 
 /**
- *
  * @param {Brand<'set'>} quoteBrand
  * @param {Amount<'nat'>} amountIn
  * @param {Amount<'nat'>} amountOut

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -95,7 +95,6 @@ export const makeRatioFromAmounts = (numeratorAmount, denominatorAmount) => {
 };
 
 /**
- *
  * @param {Amount<'nat'>} amount
  * @param {Ratio} ratio
  * @param {*} divideOp
@@ -133,7 +132,6 @@ export const multiplyBy = (amount, ratio) => {
 };
 
 /**
- *
  * @param {Amount<'nat'>} amount
  * @param {Ratio} ratio
  * @param {*} divideOp
@@ -171,7 +169,6 @@ export const divideBy = (amount, ratio) => {
 };
 
 /**
- *
  * @param {Ratio} ratio
  * @returns {Ratio}
  */
@@ -295,7 +292,6 @@ export const oneMinus = ratio => {
 };
 
 /**
- *
  * @param {Ratio} left
  * @param {Ratio} right
  * @returns {boolean}

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -144,7 +144,7 @@
  * @param {Keyword} keyword - the keyword to use for the issuer
  * @param {FeeMintAccess} allegedFeeMintAccess - an object that
  * purports to be the object that allows access to the feeMint
- * @returns {ZoeMint}
+ * @returns {ZoeMint<'nat'>}
  */
 
 /**
@@ -184,10 +184,11 @@
  */
 
 /**
+ * @template {AssetKind} [K=AssetKind]
  * @typedef {object} ZoeMint
- * @property {() => IssuerRecord} getIssuerRecord
- * @property {(totalToMint: Amount) => void} mintAndEscrow
- * @property {(totalToBurn: Amount) => void} withdrawAndBurn
+ * @property {() => IssuerRecord<K>} getIssuerRecord
+ * @property {(totalToMint: Amount<K>) => void} mintAndEscrow
+ * @property {(totalToBurn: Amount<K>) => void} withdrawAndBurn
  * Note that the burning is asynchronous, and so may not have happened by
  * the time withdrawAndBurn returns. We rely on our other bookkeeping so that
  * these assets are assumed burned elsewhere, so no one will try to access

--- a/packages/zoe/src/issuerRecord.js
+++ b/packages/zoe/src/issuerRecord.js
@@ -20,7 +20,6 @@ export const makeIssuerRecord = (brand, issuer, displayInfo) =>
   });
 
 /**
- *
  * @param {IssuerRecord} issuerRecord
  * @returns {asserts issuerRecord is Required<IssuerRecord>}
  */

--- a/packages/zoe/src/issuerRecord.js
+++ b/packages/zoe/src/issuerRecord.js
@@ -1,4 +1,5 @@
 // @jessie-check
+import { Fail } from '@agoric/assert';
 
 /**
  * Put together information about the issuer in a standard format that
@@ -17,3 +18,14 @@ export const makeIssuerRecord = (brand, issuer, displayInfo) =>
     assetKind: displayInfo.assetKind,
     displayInfo,
   });
+
+/**
+ *
+ * @param {IssuerRecord} issuerRecord
+ * @returns {asserts issuerRecord is Required<IssuerRecord>}
+ */
+export const assertFullIssuerRecord = issuerRecord => {
+  if (!issuerRecord.displayInfo) {
+    throw Fail`full IssuerRecord requires displayInfo`;
+  }
+};

--- a/packages/zoe/src/issuerRecord.js
+++ b/packages/zoe/src/issuerRecord.js
@@ -4,10 +4,11 @@
  * Put together information about the issuer in a standard format that
  * is synchronously accessible.
  *
- * @param {Brand} brand
- * @param {Issuer} issuer
- * @param {DisplayInfo} displayInfo
- * @returns {IssuerRecord}
+ * @template {AssetKind} K
+ * @param {Brand<K>} brand
+ * @param {Issuer<K>} issuer
+ * @param {DisplayInfo<K>} displayInfo
+ * @returns {IssuerRecord<K>}
  */
 export const makeIssuerRecord = (brand, issuer, displayInfo) =>
   harden({

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -3,15 +3,15 @@
 import {
   AmountShape,
   AssetKindShape,
-  DisplayInfoShape,
-  IssuerShape,
   BrandShape,
-  PaymentShape,
+  DisplayInfoShape,
   IssuerKitShape,
+  IssuerShape,
+  PaymentShape,
 } from '@agoric/ertp';
+import { SubscriberShape } from '@agoric/notifier';
 import { M } from '@agoric/store';
 import { TimestampValueShape } from '@agoric/time';
-import { SubscriberShape } from '@agoric/notifier';
 
 // keywords have an initial cap
 export const KeywordShape = M.string();
@@ -140,7 +140,9 @@ export const ZoeMintI = M.interface('ZoeMint', {
 
 export const ZcfMintI = M.interface('ZcfMint', {
   getIssuerRecord: M.call().returns(IssuerRecordShape),
-  mintGains: M.call(AmountKeywordRecordShape, M.remotable('zcfSeat')).returns(),
+  mintGains: M.call(AmountKeywordRecordShape)
+    .optional(M.remotable('zcfSeat'))
+    .returns(M.remotable('zcfSeat')),
   burnLosses: M.call(
     AmountKeywordRecordShape,
     M.remotable('zcfSeat'),

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -223,7 +223,6 @@
  */
 
 /**
- *
  * @typedef {Partial<ProposalRecord>} Proposal
  *
  * @typedef {{give: AmountKeywordRecord,

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -22,7 +22,6 @@ import {
 } from '../../../src/contractSupport/ratio.js';
 
 /**
- *
  * @param {*} t
  * @param {Amount<'nat'>} a1
  * @param {Amount<'nat'>} a2

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -432,7 +432,7 @@ test(`zcf.makeZCFMint - mintGains - no args`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcfMint.mintGains(), {
     message:
-      '"keywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
+      'In "mintGains" method of (zcfMint): Expected at least 1 arguments: []',
   });
 });
 
@@ -458,7 +458,7 @@ test(`zcf.makeZCFMint - mintGains - no gains`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcfMint.mintGains(undefined, zcfSeat), {
     message:
-      '"keywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
+      'In "mintGains" method of (zcfMint): arg 0: undefined "[undefined]" - Must be a copyRecord',
   });
 });
 
@@ -468,7 +468,7 @@ test(`zcf.makeZCFMint - burnLosses - no args`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcfMint.burnLosses(), {
     message:
-      '"keywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
+      'In "burnLosses" method of (zcfMint): Expected at least 2 arguments: []',
   });
 });
 
@@ -479,7 +479,7 @@ test(`zcf.makeZCFMint - burnLosses - no losses`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   t.throws(() => zcfMint.burnLosses(undefined, zcfSeat), {
     message:
-      '"keywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
+      'In "burnLosses" method of (zcfMint): arg 0: undefined "[undefined]" - Must be a copyRecord',
   });
 });
 

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -757,7 +757,6 @@ test(`zcfSeat.isOfferSafe from zcf.makeEmptySeatKit`, async t => {
 });
 
 /**
- *
  * @param {ZCF} zcf
  * @param {Keyword} zcfMintKeyword
  * @param {ZCFSeat} zcfSeat

--- a/packages/zoe/tools/manualPriceAuthority.js
+++ b/packages/zoe/tools/manualPriceAuthority.js
@@ -11,7 +11,6 @@ import {
 } from '../src/contractSupport/index.js';
 
 /**
- *
  * @param {object} options
  * @param {Brand<'nat'>} options.actualBrandIn
  * @param {Brand<'nat'>} options.actualBrandOut


### PR DESCRIPTION
## Description

https://github.com/Agoric/agoric-sdk/issues/7502 fixed an error in zcfMint kind restoration during reincarnation. While investigating it became clear that kind redefinitions could be simplified.

This turns the singleton into an Exo class, sharing the behavior across instances.

Using that prepare it also factors out the ZCFMintFactory and uses the maker directly.

Finally it has some types and helpers to support the change. 

Of note: it switches some function declarations back to the `@param` style because I learned that tsc doesn't check the arguments at the callsite without it.

### Security Considerations

noop

### Scaling Considerations

noop

### Documentation Considerations

noop

### Testing Considerations

CI. Incidentally, while iterating there were some bugs that none of the Zoe package tests caught. Only the vats bootstrapTests did.