### PR TITLE
fix(deploy-script-support): avoid pulling in notifiers

### DIFF
--- a/packages/deploy-script-support/src/offer.js
+++ b/packages/deploy-script-support/src/offer.js
@@ -1,7 +1,8 @@
 // @ts-check
 import { E } from '@endo/far';
 import { assert } from '@agoric/assert';
-import { AmountMath } from '@agoric/ertp';
+// Avoid pulling in too many dependencies like notifiers
+import { AmountMath } from '@agoric/ertp/src/amountMath.js';
 
 /** @typedef {import('@agoric/deploy-script-support/src/externalTypes').Petname} Petname */
 


### PR DESCRIPTION
## Description

When trying to merge #7459 we encountered an error in the loadgen integration test. The deploy script helpers are loaded within a dapp running in RESM mode, and through dependencies in ERTP issuers logic, notifiers was getting pulled in. The new notifier code tried to used syntax unsupported by the `esm` package (`?.`), and thus failed to import. The only dependency that deploy script support has on ERTP however is onto `AmountMath`, so this changes to a deep import until we can figure out a better cross-repo approach.


### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Manually tested to fix the loadgen test issue before the new syntax was reverted.
