### PR TITLE
fix(vat-data): normalize kindName mangling

### DIFF
--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -259,9 +259,7 @@ export const makeExoUtils = VatData => {
       options,
     );
 
-    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- https://github.com/Agoric/agoric-sdk/issues/4620
-    // @ts-ignore could be instantiated with an arbitrary type
-    return provide(baggage, `the_${kindName}`, () => makeSingleton());
+    return provide(baggage, `${kindName}_singleton`, () => makeSingleton());
   };
   harden(prepareExo);
 


### PR DESCRIPTION
closes: #7520 

Normalize kindName mangling to consistently use `kindName` as prefix, as suggested in #7520 .
