### PR TITLE
config.defaultManagerType beats env.SWINGSET_WORKER_TYPE

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -231,9 +231,30 @@ The default is `undefined`.
 
 ## SWINGSET_WORKER_TYPE
 
-Affects: solo
+Affects: solo, unit tests
 
-Purpose: select the default Worker type (default `xs-worker`)
+Purpose: select the default Worker type (default `local`)
 
-Description: default `xs-worker`, but you can use `local` to run vats within the
-same Node.js process (to facilitate debugging).
+Description: The SwingSet kernel launches each vat into a "worker" of a
+particular type. The `local` workers run in the same Node.js process as the
+kernel (which facilitates debugging). The `xsnap` workers run in a child
+process under the XS engine (which provides metering and heap snapshots, as
+well as more consistent GC behavior). `xs-worker` is an alias for `xsnap`.
+
+Applications and unit tests may specify which type of worker they use for all
+vats in their `config.defaultManagerType` record, especially if they need a
+specific type for some reason. If they do not specify it there, the environment
+variable will supply a default. The full hierarchy of controls are:
+
+* config.vats.NAME.creationOptions.managerType (highest priority, but
+                                                only for static vats)
+* config.defaultManagerType (applies to both static and dynamic vats)
+* env.SWINGSET_WORKER_TYPE
+* use a 'local' worker (lowest priority)
+
+The environment variable exists so CI commands (e.g. 'yarn test:xs') can run a
+batch of unit tests under a different worker, without editing all their config
+records individually. `config.defaultManagerType` has a higher priority so that
+tests which require a specific worker (e.g. which exercise XS heap snapshots,
+or metering) can override the env var, so they won't break under `yarn
+test:xs`.

--- a/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
@@ -7,7 +7,6 @@ import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 async function main(basedir, argv) {
   const dir = new URL(`../${basedir}`, import.meta.url).pathname;
   const config = await loadBasedir(dir);
-  config.defaultManagerType = 'xs-worker';
   const controller = await buildVatController(config, argv);
   await controller.run();
   const res = controller.dump();

--- a/packages/ERTP/test/swingsetTests/ertpService/test-ertp-service-upgrade.js
+++ b/packages/ERTP/test/swingsetTests/ertpService/test-ertp-service-upgrade.js
@@ -11,7 +11,6 @@ test('ertp service upgrade', async t => {
   /** @type {SwingSetConfig} */
   const config = {
     // includeDevDependencies: true, // for vat-data
-    defaultManagerType: 'local',
     bootstrap: 'bootstrap',
     // defaultReapInterval: 'never',
     // defaultReapInterval: 1,

--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -7,7 +7,6 @@ import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 async function main(basedir, argv) {
   const dir = new URL(`../${basedir}/`, import.meta.url).pathname;
   const config = await loadBasedir(dir);
-  config.defaultManagerType = 'xs-worker';
   const controller = await buildVatController(config, argv);
   await controller.run();
   const res = controller.dump();

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -201,7 +201,7 @@ test('XS bootstrap', async t => {
   t.deepEqual(c.dump().log, ['buildRootObject called', 'bootstrap called']);
   t.is(
     kernelStorage.kvStore.get('kernel.defaultManagerType'),
-    'xs-worker',
+    'xsnap',
     'defaultManagerType is saved by kernelKeeper',
   );
   const vatID = c.vatNameToID('bootstrap');

--- a/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
@@ -42,7 +42,7 @@ test.before(async t => {
   };
   const config = { bootstrap: 'bootstrap', vats };
   config.bundles = { zcf: { bundle: zcfBundle } };
-  config.defaultManagerType = 'xs-worker';
+  config.defaultManagerType = 'xs-worker'; // originally wanted for metering
 
   const step4 = Date.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;

--- a/packages/inter-protocol/test/swingsetTests/fluxAggregator/test-fluxAggregator-service-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/fluxAggregator/test-fluxAggregator-service-upgrade.js
@@ -14,7 +14,6 @@ test('fluxAggregator service upgrade', async t => {
   /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // test's bootstrap has some deps not needed in production
-    defaultManagerType: 'local',
     bundleCachePath: 'bundles/',
     bootstrap: 'bootstrap',
     vats: {

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/test-walletFactory-service-upgrade.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/test-walletFactory-service-upgrade.js
@@ -16,7 +16,6 @@ const bfile = name => new URL(name, import.meta.url).pathname;
 test('walletFactory service upgrade', async t => {
   /** @type {SwingSetConfig} */
   const config = {
-    defaultManagerType: 'local',
     bundleCachePath: 'bundles/',
     bootstrap: 'bootstrap',
     vats: {

--- a/packages/vats/test/upgrading/test-upgrade-contracts.js
+++ b/packages/vats/test/upgrading/test-upgrade-contracts.js
@@ -32,7 +32,6 @@ test('upgrade mintHolder', async t => {
 
   /** @type {SwingSetConfig} */
   const config = harden({
-    defaultManagerType: 'local', // Overridden in CI with SWINGSET_WORKER_TYPE=xs-worker
     bootstrap: 'bootstrap',
     vats: {
       // TODO refactor to use bootstrap-relay.js

--- a/packages/vats/test/upgrading/test-upgrade-vats.js
+++ b/packages/vats/test/upgrading/test-upgrade-vats.js
@@ -38,7 +38,6 @@ const makeScenario = async (
   /** @type {SwingSetConfig} */
   const config = {
     includeDevDependencies: true, // for vat-data
-    defaultManagerType: 'local', // Overridden in CI with SWINGSET_WORKER_TYPE=xs-worker
     bootstrap: 'bootstrap',
     defaultReapInterval: 'never',
     vats: {


### PR DESCRIPTION
Previously, the priority order of worker-type specification was:
* highest: config.vats.NAME.creationOptions.managerType
* env.SWINGSET_WORKER_TYPE
* lowest: config.defaultManagerType

The `yarn test:xs` command uses `SWINGSET_WORKER_TYPE=xs-worker` to
use an xsnap worker on any test that doesn't care to be more specific.

However, for a test to express a stronger preference (e.g. because it
looks at snapshots, transcript entries, or metering data), it would
have to use the per-vat `creationOptions` control, which is
inconvenient ot specify for every vat. Also, this control is only
available for static vats: all dynamic vats would use
`env.SWINGSET_WORKER_TYPE`, followed by `config.defaultManagerType`.

With this change, we make the environment variable the lowest-priority
control:
* highest: config.vats.NAME.creationOptions.managerType
* config.defaultManagerType
* lowest: env.SWINGSET_WORKER_TYPE

Tests which need all vats to use a 'local' worker, even under `yarn
test:xs`, can then use `config: { defaultManagerType: 'local }`
without fear of being overridden by the yarn environment.

Tests which do not care should continue to omit `defaultManagerType`,
allowing `yarn test` or `yarn test:xs` to choose for them.

I went through the other packages unit tests and tried to remove the `defaultManagerType` settings that now seem unnecessary.
