### PR TITLE
fix: Call methods on `pegasusConnectionsAdmin` eventually

### DIFF
--- a/packages/pegasus/src/proposals/core-proposal.js
+++ b/packages/pegasus/src/proposals/core-proposal.js
@@ -69,10 +69,10 @@ export const addPegasusTransferPort = async (
       const { localAddr, actions } = connectionState;
       if (actions) {
         // We're open and ready for business.
-        pegasusConnectionsAdmin.update(localAddr, connectionState);
+        E(pegasusConnectionsAdmin).update(localAddr, connectionState);
       } else {
         // We're closed.
-        pegasusConnectionsAdmin.delete(localAddr);
+        E(pegasusConnectionsAdmin).delete(localAddr);
       }
     },
   });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #7535

## Description
When I debugged the problem stated in #7535, I saw that `pegasusConnectionsAdmin` is a promise. So I wrapped around `E()`.

Debug message:

```text
2023-04-18T10:47:36.327Z SwingSet: vat: v1: PEGASUS_PORT_DETECTED { pegasusConnectionsAdmin: Promise [Promise] {}, 
```


