### PR TITLE
feat(xsnap): stream snapshots over process pipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@endo/eslint-plugin": "^0.4.3",
     "@jessie.js/eslint-plugin": "^0.3.0",
-    "@types/node": "^16.7.10",
+    "@types/node": "^16.13.0",
     "@typescript-eslint/parser": "^5.55.0",
     "ava": "^5.2.0",
     "c8": "^7.13.0",

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -226,7 +226,7 @@ export function makeXsSubprocessFactory({
       return snapStore.saveSnapshot(
         vatID,
         snapPos,
-        worker.makeSnapshot(`${vatID}-${snapPos}`),
+        worker.makeSnapshotStream(`${vatID}-${snapPos}`),
       );
     }
 

--- a/packages/SwingSet/test/test-xsnap-metering.js
+++ b/packages/SwingSet/test/test-xsnap-metering.js
@@ -64,7 +64,7 @@ async function doTest(t, metered) {
   t.teardown(() => worker1.close());
 
   // now extract a snapshot
-  await store.saveSnapshot('vat', 1, worker1.makeSnapshot());
+  await store.saveSnapshot('vat', 1, worker1.makeSnapshotStream());
 
   // and load it into a new worker
   const { p: p2, startXSnap: start2 } = make(store);

--- a/packages/SwingSet/test/test-xsnap-store.js
+++ b/packages/SwingSet/test/test-xsnap-store.js
@@ -68,7 +68,7 @@ test(`create XS Machine, snapshot (${snapSize.raw} Kb), compress to smaller`, as
   const { compressedSize } = await store.saveSnapshot(
     'vat0',
     1,
-    vat.makeSnapshot(),
+    vat.makeSnapshotStream(),
   );
 
   t.true(
@@ -89,7 +89,7 @@ test('SES bootstrap, save, compress', async t => {
   const { compressedSize } = await store.saveSnapshot(
     'vat0',
     1,
-    vat.makeSnapshot(),
+    vat.makeSnapshotStream(),
   );
 
   t.true(
@@ -105,7 +105,7 @@ test('create SES worker, save, restore, resume', async t => {
   const vat0 = await bootSESWorker('ses-boot2', async m => m);
   t.teardown(() => vat0.close());
   await vat0.evaluate('globalThis.x = harden({a: 1})');
-  await store.saveSnapshot('vat0', 1, vat0.makeSnapshot());
+  await store.saveSnapshot('vat0', 1, vat0.makeSnapshotStream());
 
   const snapshotStream = store.loadSnapshot('vat0');
 
@@ -140,7 +140,7 @@ test('XS + SES snapshots are long-term deterministic', async t => {
     filePath: _path1,
     compressedSize: _csize1,
     ...info1
-  } = await store.saveSnapshot('vat0', 1, vat.makeSnapshot());
+  } = await store.saveSnapshot('vat0', 1, vat.makeSnapshotStream());
   t.snapshot(info1, 'initial snapshot');
 
   const bootScript = await getBootScript();
@@ -150,7 +150,7 @@ test('XS + SES snapshots are long-term deterministic', async t => {
     filePath: _path2,
     compressedSize: _csize2,
     ...info2
-  } = await store.saveSnapshot('vat0', 2, vat.makeSnapshot());
+  } = await store.saveSnapshot('vat0', 2, vat.makeSnapshotStream());
   t.snapshot(
     info2,
     'after SES boot - sensitive to SES-shim, XS, and supervisor',
@@ -161,7 +161,7 @@ test('XS + SES snapshots are long-term deterministic', async t => {
     filePath: _path3,
     compressedSize: _csize3,
     ...info3
-  } = await store.saveSnapshot('vat0', 3, vat.makeSnapshot());
+  } = await store.saveSnapshot('vat0', 3, vat.makeSnapshotStream());
   t.snapshot(
     info3,
     'after use of harden() - sensitive to SES-shim, XS, and supervisor',
@@ -182,7 +182,7 @@ async function makeTestSnapshot() {
   const bootScript = await getBootScript();
   await vat.evaluate(bootScript);
   await vat.evaluate('globalThis.x = harden({a: 1})');
-  const info = await store.saveSnapshot('vat0', 1, vat.makeSnapshot());
+  const info = await store.saveSnapshot('vat0', 1, vat.makeSnapshotStream());
   await vat.close();
   return info;
 }

--- a/packages/agoric-cli/src/lib/chain.js
+++ b/packages/agoric-cli/src/lib/chain.js
@@ -75,7 +75,7 @@ export const execSwingsetTransaction = (swingsetArgs, opts) => {
   } else {
     const yesCmd = cmd.concat(['--yes']);
     if (verbose) console.log('Executing ', yesCmd);
-    return execFileSync(agdBinary, yesCmd);
+    return execFileSync(agdBinary, yesCmd, { encoding: 'utf-8' });
   }
 };
 harden(execSwingsetTransaction);

--- a/packages/xsnap/README.md
+++ b/packages/xsnap/README.md
@@ -14,7 +14,7 @@ await worker.evaluate(`
     return new TextEncoder().encode(`${number + 1}`).buffer;
   }
 `);
-await fs.writeFile('bootstrap.xss', worker.makeSnapshot());
+await fs.writeFile('bootstrap.xss', worker.makeSnapshotStream());
 await worker.close();
 ```
 

--- a/packages/xsnap/build.env
+++ b/packages/xsnap/build.env
@@ -1,4 +1,4 @@
 MODDABLE_URL=https://github.com/agoric-labs/moddable.git
 MODDABLE_COMMIT_HASH=46bbad5b8aa746c50b5f97aee1b1f235ab2a5903
 XSNAP_NATIVE_URL=https://github.com/agoric-labs/xsnap-pub
-XSNAP_NATIVE_COMMIT_HASH=53dfd5f15baa72a1aadd5d65c617083df69d6726
+XSNAP_NATIVE_COMMIT_HASH=056faf8c8930a20659dd4eaa3ebfae3a8b464c7f

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -166,9 +166,9 @@ export async function recordXSnap(options, folderPath, { writeFileSync }) {
     import: async _fileName => {
       throw Error('recording: import not supported');
     },
-    makeSnapshot(description) {
+    makeSnapshotStream(description) {
       nextFile('snapshot').putText(filenameFromDescription(description));
-      return it.makeSnapshot(description);
+      return it.makeSnapshotStream(description);
     },
   });
 }
@@ -260,7 +260,7 @@ export async function replayXSnap(
               const snapFile = await opts.fs.open(snapshotPath, 'w');
               await snapFile.writeFile(
                 // @ts-expect-error incorrect typings, does accept AsyncIterable
-                it.makeSnapshot(snapshotPath),
+                it.makeSnapshotStream(snapshotPath),
               );
               await snapFile.close();
             })().catch(err => {

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -166,9 +166,9 @@ export async function recordXSnap(options, folderPath, { writeFileSync }) {
     import: async _fileName => {
       throw Error('recording: import not supported');
     },
-    makeSnapshot: async function* makeSnapshot(description) {
+    makeSnapshot(description) {
       nextFile('snapshot').putText(filenameFromDescription(description));
-      yield* it.makeSnapshot(description);
+      return it.makeSnapshot(description);
     },
   });
 }

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -3,6 +3,8 @@
 
 /**
  * @typedef {typeof import('child_process').spawn} Spawn
+ * @typedef {import('stream').Readable} Readable
+ * @typedef {import('stream').Writable} Writable
  */
 
 /**
@@ -183,14 +185,18 @@ export async function xsnap(options) {
     });
   }
 
-  const writer = xsnapProcess.stdio[3];
-  const reader = xsnapProcess.stdio[4];
+  const xsnapProcessStdio =
+    /** @type {[undefined, Readable, Readable, Writable, Readable]} */ (
+      /** @type {(Readable | Writable | undefined | null)[]} */ (
+        xsnapProcess.stdio
+      )
+    );
 
   const messagesToXsnap = makeNetstringWriter(
-    makeNodeWriter(/** @type {import('stream').Writable} */ (writer)),
+    makeNodeWriter(xsnapProcessStdio[3]),
   );
   const messagesFromXsnap = makeNetstringReader(
-    makeNodeReader(/** @type {import('stream').Readable} */ (reader)),
+    makeNodeReader(xsnapProcessStdio[4]),
     { maxMessageLength: netstringMaxChunkSize },
   );
 

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -380,7 +380,7 @@ export async function xsnap(options) {
    * @param {string} [description]
    * @returns {AsyncGenerator<Uint8Array, void, undefined>}
    */
-  function makeSnapshot(description = 'unknown') {
+  function makeSnapshotStream(description = 'unknown') {
     const { promise: internalResult, ...batonKitResolvers } = makePromiseKit();
     const batonKit = { promise: baton, ...batonKitResolvers };
     baton = internalResult.then(noop, noop);
@@ -426,6 +426,6 @@ export async function xsnap(options) {
     evaluate,
     execute,
     import: importModule,
-    makeSnapshot,
+    makeSnapshotStream,
   });
 }

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -87,7 +87,7 @@ async function main() {
       });
     } else if (answer === 'save') {
       const file = await ask('file> ');
-      await fs.promises.writeFile(file, vat.makeSnapshot(file));
+      await fs.promises.writeFile(file, vat.makeSnapshotStream(file));
     } else {
       await vat.issueStringCommand(answer);
     }

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -7,6 +7,7 @@ import test from 'ava';
 import * as proc from 'child_process';
 import * as os from 'os';
 import fs from 'fs';
+import path from 'path';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { tmpName } from 'tmp';
 
@@ -284,7 +285,7 @@ test('write and read snapshot', async t => {
   t.deepEqual(['Hello, World!'], messages);
 });
 
-test.failing('execute immediately after makeSnapshot', async t => {
+test('execute immediately after makeSnapshot', async t => {
   const messages = [];
   async function handleCommand(message) {
     messages.push(decode(message));
@@ -400,7 +401,8 @@ function pickXSnap(env = process.env) {
     console.log('SwingSet xs-worker tracing:', { XSNAP_TEST_RECORD });
     let serial = 0;
     doXSnap = opts => {
-      const workerTrace = `${XSNAP_TEST_RECORD}/${serial}/`;
+      const workerTrace =
+        path.resolve(XSNAP_TEST_RECORD, String(serial)) + path.sep;
       serial += 1;
       fs.mkdirSync(workerTrace, { recursive: true });
       return recordXSnap(opts, workerTrace, {
@@ -439,6 +441,7 @@ test('GC after snapshot vs restore', async t => {
 
   const optClone = { ...options(io), name: 'clone', snapshotStream };
   const clone = await xsnapr(optClone);
+  await clone.isReady();
   t.log('cloned');
   t.teardown(clone.terminate);
 

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -269,7 +269,7 @@ test('write and read snapshot', async t => {
   await vat0.evaluate(`
     globalThis.hello = "Hello, World!";
   `);
-  const snapshotStream = vat0.makeSnapshot();
+  const snapshotStream = vat0.makeSnapshotStream();
 
   const vat1 = await xsnap({
     ...options(io),
@@ -285,7 +285,7 @@ test('write and read snapshot', async t => {
   t.deepEqual(['Hello, World!'], messages);
 });
 
-test('execute immediately after makeSnapshot', async t => {
+test('execute immediately after makeSnapshotStream', async t => {
   const messages = [];
   async function handleCommand(message) {
     messages.push(decode(message));
@@ -296,7 +296,7 @@ test('execute immediately after makeSnapshot', async t => {
   void vat0.evaluate(`
     globalThis.when = 'before';
   `);
-  const snapshotStream = vat0.makeSnapshot();
+  const snapshotStream = vat0.makeSnapshotStream();
 
   void vat0.evaluate(`
     globalThis.when = 'after';
@@ -437,7 +437,7 @@ test('GC after snapshot vs restore', async t => {
 
   const beforeClone = await nextGC(worker, opts);
 
-  const snapshotStream = worker.makeSnapshot();
+  const snapshotStream = worker.makeSnapshotStream();
 
   const optClone = { ...options(io), name: 'clone', snapshotStream };
   const clone = await xsnapr(optClone);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3260,10 +3260,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=13.7.0", "@types/node@^16.7.10":
+"@types/node@*", "@types/node@>= 8", "@types/node@>=13.7.0":
   version "16.7.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
   integrity sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==
+
+"@types/node@^16.13.0":
+  version "16.18.25"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.25.tgz#8863940fefa1234d3fcac7a4b7a48a6c992d67af"
+  integrity sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
closes: #6363
refs: https://github.com/agoric-labs/xsnap-pub/pull/39

## Description

This introduces support for streaming the xsnap snapshot over an stdio pipe with the worker process, removing the need to transition through the filesystem.

### Security Considerations

This ultimately might allow use to remove fs permissions from the xsnap-worker

### Scaling Considerations

This should improve the performance of snapshot load and save, and enable future optimizations like teeing a snapshot we're making into a new worker will compressing it and saving it in parallel. See #6943 

### Documentation Considerations

Internal implementation detail triggered by new option (on by default.

### Testing Considerations

Updated the xsnap snapshot test to exercise various combinations of save / load using fs or pipe, as well as making sure that multiple snapshot in a row over the pipe behave as expected.
