### PR TITLE
Address many floating promises detected by our linter

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -80,8 +80,10 @@ module.exports = {
         // contracts, but it also means kernel components that are used by
         // multiple clients. So we enable it throughout the repo and exceptions
         // are code-reviewed.
-        // TODO upgrade this to 'error'
-        '@jessie.js/no-nested-await': 'warn',
+        '@jessie.js/no-nested-await': 'off', // remove after endojs/Jessie#107
+        // TODO(https://github.com/endojs/Jessie/issues/107): use the following
+        // instead, and upgrade to 'error' when possible
+        // '@jessie.js/safe-await-separator': 'warn',
         // TODO upgrade this (or a subset) to 'error'
         'no-restricted-syntax': ['warn', ...deprecatedTerminology],
       },

--- a/packages/notifier/src/stored-notifier.js
+++ b/packages/notifier/src/stored-notifier.js
@@ -39,6 +39,8 @@ export const makeStoredNotifier = (notifier, storageNode, marshaller) => {
     fail(reason) {
       console.error('StoredNotifier failed to iterate', reason);
     },
+  }).catch(reason => {
+    console.error('StoredNotifier halted iteration', reason);
   });
 
   /** @type {Unserializer} */

--- a/packages/notifier/test/test-publish-kit.js
+++ b/packages/notifier/test/test-publish-kit.js
@@ -650,8 +650,12 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
   const sub2LIFO = [];
 
   const sub1FirstAll = [];
-  E.when(sub1.subscribeAfter(), cell => void sub1FirstAll.push(cell), t.fail);
-  E.when(sub1.subscribeAfter(), cell => void sub1FirstAll.push(cell), t.fail);
+  E.when(sub1.subscribeAfter(), cell => void sub1FirstAll.push(cell)).catch(
+    t.fail,
+  );
+  E.when(sub1.subscribeAfter(), cell => void sub1FirstAll.push(cell)).catch(
+    t.fail,
+  );
 
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter());
@@ -670,21 +674,18 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
 
   const sub1FirstLateAll = [];
   const sub1SecondAll = [];
-  E.when(
+  void E.when(
     sub1.subscribeAfter(),
     cell => void sub1FirstLateAll.push(cell),
-    t.fail,
-  );
-  E.when(
+  ).catch(t.fail);
+  void E.when(
     sub1.subscribeAfter(0n),
     cell => void sub1FirstLateAll.push(cell),
-    t.fail,
-  );
-  E.when(
+  ).catch(t.fail);
+  void E.when(
     sub1.subscribeAfter(sub1FirstAll[0].publishCount),
     cell => void sub1SecondAll.push(cell),
-    t.fail,
-  );
+  ).catch(t.fail);
 
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter(sub2LIFO[0].publishCount));
@@ -709,13 +710,12 @@ const verifySubscribeAfterSequencing = test.macro(async (t, makePublishKit) => {
   const sub1SecondLateAll = [];
   const sub1FinalAll = [];
   for (const p of [sub1.subscribeAfter(), sub1.subscribeAfter(0n)]) {
-    E.when(p, cell => void sub1SecondLateAll.push(cell), t.fail);
+    E.when(p, cell => void sub1SecondLateAll.push(cell)).catch(t.fail);
   }
-  E.when(
+  void E.when(
     sub1.subscribeAfter(sub1SecondAll[0].publishCount),
     result => void sub1FinalAll.push(result),
-    t.fail,
-  );
+  ).catch(t.fail);
 
   pub2.publish(undefined);
   sub2LIFO.unshift(await sub2.subscribeAfter(sub2LIFO[0].publishCount));

--- a/packages/store/test/test-AtomicProvider.js
+++ b/packages/store/test/test-AtomicProvider.js
@@ -28,8 +28,8 @@ test('race', async t => {
   t.is(await provider.provideAsync('a', make, finish), 'a 1');
   t.is(finishCalled, 1);
 
-  provider.provideAsync('b', make, finish);
-  provider.provideAsync('b', make, finish);
+  provider.provideAsync('b', make, finish).catch(t.fail);
+  provider.provideAsync('b', make, finish).catch(t.fail);
   t.is(await provider.provideAsync('b', make, finish), 'b 2');
   t.is(await provider.provideAsync('b', make, finish), 'b 2');
   t.is(finishCalled, 2);
@@ -88,8 +88,8 @@ test('far keys', async t => {
   t.is(await provider.provideAsync(moola, makeValue), 'moola 1');
   t.is(await provider.provideAsync(moola, makeValue), 'moola 1');
 
-  provider.provideAsync(moolb, makeValue);
-  provider.provideAsync(moolb, makeValue);
+  provider.provideAsync(moolb, makeValue).catch(t.fail);
+  provider.provideAsync(moolb, makeValue).catch(t.fail);
   t.is(await provider.provideAsync(moolb, makeValue), 'moolb 2');
   t.is(await provider.provideAsync(moolb, makeValue), 'moolb 2');
 });

--- a/packages/swing-store/test/test-bundles.js
+++ b/packages/swing-store/test/test-bundles.js
@@ -88,7 +88,7 @@ test('b0 export', async t => {
   const b0A = { moduleFormat: 'nestedEvaluate', source: '1+1' };
   const idA = makeB0ID(b0A);
   bundleStore.addBundle(idA, b0A);
-  hostStorage.commit();
+  await hostStorage.commit();
   t.is(exportData.get(`bundle.${idA}`), idA);
 
   const exporter = makeSwingStoreExporter(dbDir);

--- a/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
@@ -23,4 +23,7 @@ const generateBundlesP = Promise.all(
   }),
 );
 
-generateBundlesP.then(() => console.log('contracts prepared'));
+generateBundlesP.then(
+  () => console.log('contracts prepared'),
+  reason => console.error('Failed to generate contracts', reason),
+);

--- a/packages/swingset-runner/demo/resolvePromiseComplicated/vat-bob.js
+++ b/packages/swingset-runner/demo/resolvePromiseComplicated/vat-bob.js
@@ -24,7 +24,7 @@ export function buildRootObject() {
         r => log(`=> Bob: the parameter to second resolved to '${r}'`),
         e => log(`=> Bob: the parameter to second rejected as '${e}'`),
       );
-      Promise.resolve().then(E(carol).bar(p));
+      void Promise.resolve().then(E(carol).bar(p));
       log('=> Bob: second done');
       return `Bob's second answer`;
     },

--- a/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
@@ -23,4 +23,7 @@ const generateBundlesP = Promise.all(
   }),
 );
 
-generateBundlesP.then(() => console.log('contracts prepared'));
+generateBundlesP.then(
+  () => console.log('contracts prepared'),
+  reason => console.error('failed to prepare contracts', reason),
+);

--- a/packages/swingset-runner/demo/zoeTests/prepareContracts.js
+++ b/packages/swingset-runner/demo/zoeTests/prepareContracts.js
@@ -44,4 +44,7 @@ const generateBundlesP = Promise.all(
   }),
 );
 
-generateBundlesP.then(() => console.log('contracts prepared'));
+generateBundlesP.then(
+  () => console.log('contracts prepared'),
+  reason => console.error('failed to prepare contracts', reason),
+);

--- a/packages/swingset-runner/src/graphDisk.js
+++ b/packages/swingset-runner/src/graphDisk.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-env node */
 
 import { dataGraphApp } from './dataGraphApp.js';
 
@@ -13,4 +14,12 @@ export async function main() {
   );
 }
 
-main();
+process.exitCode = 1;
+main().then(
+  () => {
+    process.exitCode = 0;
+  },
+  error => {
+    console.error(error);
+  },
+);

--- a/packages/swingset-runner/src/graphMem.js
+++ b/packages/swingset-runner/src/graphMem.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-env node */
 
 import { dataGraphApp } from './dataGraphApp.js';
 
@@ -13,4 +14,12 @@ export async function main() {
   );
 }
 
-main();
+process.exitCode = 1;
+main().then(
+  () => {
+    process.exitCode = 0;
+  },
+  error => {
+    console.error(error);
+  },
+);

--- a/packages/swingset-runner/src/graphStats.js
+++ b/packages/swingset-runner/src/graphStats.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-env node */
 
 import { dataGraphApp } from './dataGraphApp.js';
 
@@ -13,4 +14,12 @@ export async function main() {
   );
 }
 
-main();
+process.exitCode = 1;
+main().then(
+  () => {
+    process.exitCode = 0;
+  },
+  error => {
+    console.error(error);
+  },
+);

--- a/packages/swingset-runner/src/graphTime.js
+++ b/packages/swingset-runner/src/graphTime.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-env node */
 
 import { dataGraphApp } from './dataGraphApp.js';
 
@@ -13,4 +14,12 @@ export async function main() {
   );
 }
 
-main();
+process.exitCode = 1;
+main().then(
+  () => {
+    process.exitCode = 0;
+  },
+  error => {
+    console.error(error);
+  },
+);

--- a/packages/swingset-runner/src/kerneldump-entrypoint.js
+++ b/packages/swingset-runner/src/kerneldump-entrypoint.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-env node */
 
 /**
  * Simple boilerplate program providing linkage to launch an application written
@@ -10,4 +11,12 @@
 import '@endo/init';
 import { main } from './kerneldump.js';
 
-main();
+process.exitCode = 1;
+main().then(
+  () => {
+    process.exitCode = 0;
+  },
+  error => {
+    console.error(error);
+  },
+);

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -583,7 +583,7 @@ export async function main() {
     // eslint-disable-next-line @jessie.js/no-nested-await
     await slogSender.forceFlush();
   }
-  controller.shutdown();
+  await controller.shutdown();
 
   function getCrankNumber() {
     return Number(kernelStorage.kvStore.get('crankNumber'));

--- a/packages/swingset-runner/src/runner-debug-entrypoint.js
+++ b/packages/swingset-runner/src/runner-debug-entrypoint.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S node --inspect-brk
+/* eslint-env node */
 
 /**
  * Simple boilerplate program providing linkage to launch an application written using modules within the
@@ -11,4 +12,12 @@ import '@endo/init/pre.js';
 import '@endo/init';
 import { main } from './main.js';
 
-main();
+process.exitCode = 1;
+main().then(
+  () => {
+    process.exitCode = 0;
+  },
+  error => {
+    console.error(error);
+  },
+);

--- a/packages/swingset-runner/src/runner-entrypoint.js
+++ b/packages/swingset-runner/src/runner-entrypoint.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-env node */
 
 // #!/usr/bin/env -S node --inspect-brk
 
@@ -13,4 +14,12 @@ import '@endo/init/pre-bundle-source.js';
 import '@endo/init';
 import { main } from './main.js';
 
-main();
+process.exitCode = 1;
+main().then(
+  () => {
+    process.exitCode = 0;
+  },
+  error => {
+    console.error(error);
+  },
+);

--- a/packages/swingset-runner/src/slogulator-entrypoint.js
+++ b/packages/swingset-runner/src/slogulator-entrypoint.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-env node */
 
 /**
  * Simple boilerplate program providing linkage to launch an application written using modules within the
@@ -7,4 +8,12 @@
 import '@endo/init';
 import { main } from './slogulator.js';
 
-main();
+process.exitCode = 1;
+main().then(
+  () => {
+    process.exitCode = 0;
+  },
+  error => {
+    console.error(error);
+  },
+);

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -238,11 +238,11 @@ export const makeWalletFactoryDriver = async (
      * @param {M} makeOffer
      * @param {Parameters<M>[1]} firstArg
      * @param {Parameters<M>[2]} [secondArg]
-     * @returns {void}
+     * @returns {Promise<void>}
      */
     sendOfferMaker(makeOffer, firstArg, secondArg) {
       const offer = makeOffer(agoricNamesRemotes.brand, firstArg, secondArg);
-      this.sendOffer(offer);
+      return this.sendOffer(offer);
     },
     /**
      * @returns {import('@agoric/smart-wallet/src/smartWallet.js').UpdateRecord}


### PR DESCRIPTION
refs: #6000

## Description

See #6000 for context. This change clears many of the extant dangling promises, but does not attempt to resolve the 118 cases in Zoe nor any from SwingSet since the linter does not halt. The author is not sufficiently versed in Zoe to know whether `void`, `await`, or `return` are safe for these cases and intends to follow-up.

### Security Considerations


### Scaling Considerations

There are cases where promises were not previously awaited which may cause some performance regressions.

### Documentation Considerations

This should not impact documentation.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
