### PR TITLE
feat(controller): louder UnhandledPromiseRejection log

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -75,7 +75,7 @@ function makeConsole(tagOrTagCreator) {
 function unhandledRejectionHandler(e, pr) {
   // Don't trigger sensitive hosts (like AVA).
   pr.catch(() => {});
-  console.error('UnhandledPromiseRejectionWarning:', e);
+  console.error('🤞 UnhandledPromiseRejection:', e);
 }
 
 /**


### PR DESCRIPTION
## Description

On many occasion debugging the `UnhandledPromiseRejectionWarning` string gets lost in the noise of other logs.

It's a pretty serious problem that I think deserves to be called out in the logs. Especially in production. https://github.com/Agoric/agoric-sdk/issues/6000 will help but it still leaves many `void`.

Looking for three approvals before merge, given how this affects workfow.

### Security Considerations

--

### Scaling Considerations

--
### Documentation Considerations

--

### Testing Considerations

--