### PR TITLE
fix(swingset): make slog deliveryNum match transcript position

### DIFF
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -83,7 +83,6 @@ const enableKernelGC = true;
 //   $R is 'R' when reachable, '_' when merely recognizable
 //   $vatSlot is one of: o+$NN/o-$NN/p+$NN/p-$NN/d+$NN/d-$NN
 // v$NN.c.$vatSlot = $kernelSlot = ko$NN/kp$NN/kd$NN
-// v$NN.nextDeliveryNum = $NN
 // v$NN.vs.$key = string
 // v$NN.meter = m$NN // XXX does this exist?
 // v$NN.reapInterval = $NN or 'never'

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -44,7 +44,6 @@ export function initializeVatState(kvStore, transcriptStore, vatID) {
   kvStore.set(`${vatID}.o.nextID`, `${FIRST_OBJECT_ID}`);
   kvStore.set(`${vatID}.p.nextID`, `${FIRST_PROMISE_ID}`);
   kvStore.set(`${vatID}.d.nextID`, `${FIRST_DEVICE_ID}`);
-  kvStore.set(`${vatID}.nextDeliveryNum`, `0`);
   transcriptStore.initTranscript(vatID);
 }
 
@@ -166,9 +165,8 @@ export function makeVatKeeper(
   }
 
   function nextDeliveryNum() {
-    const num = Nat(BigInt(getRequired(`${vatID}.nextDeliveryNum`)));
-    kvStore.set(`${vatID}.nextDeliveryNum`, `${num + 1n}`);
-    return num;
+    const { endPos } = transcriptStore.getCurrentSpanBounds(vatID);
+    return Nat(endPos);
   }
 
   function getIncarnationNumber() {

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -526,7 +526,7 @@ export function makeVatWarehouse({
     // then log the delivery so it appears after transcript replay
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
     const crankNum = kernelKeeper.getCrankNumber();
-    const deliveryNum = vatKeeper.nextDeliveryNum(); // increments
+    const deliveryNum = vatKeeper.nextDeliveryNum(); // transcript endPos
     /** @type { SlogFinishDelivery } */
     const finishSlog = vs.delivery(crankNum, deliveryNum, kd, vd);
 

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -522,14 +522,13 @@ test('vatKeeper', async t => {
   t.is(vk.mapVatSlotToKernelSlot(vatExport1), kernelExport1);
   t.is(vk.mapKernelSlotToVatSlot(kernelExport1), vatExport1);
   t.is(vk.nextDeliveryNum(), 0n);
-  t.is(vk.nextDeliveryNum(), 1n);
+  t.is(vk.nextDeliveryNum(), 0n); // incremented only by addToTranscript
 
   k.emitCrankHashes();
   let vk2 = duplicateKeeper(store.serialize).provideVatKeeper(v1);
   t.is(vk2.mapVatSlotToKernelSlot(vatExport1), kernelExport1);
   t.is(vk2.mapKernelSlotToVatSlot(kernelExport1), vatExport1);
-  t.is(vk2.nextDeliveryNum(), 2n);
-  t.is(vk2.nextDeliveryNum(), 3n);
+  t.is(vk2.nextDeliveryNum(), 0n);
 
   const kernelImport2 = k.addKernelObject('v1', 25);
   const vatImport2 = vk.mapKernelSlotToVatSlot(kernelImport2);

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -183,6 +183,8 @@ test('null upgrade - xsnap', async t => {
 test('kernel sends bringOutYourDead for vat upgrade', async t => {
   const config = makeConfigFromPaths('../bootstrap-relay.js', {
     defaultReapInterval: 'never',
+    snapshotInitial: 10000, // effectively disabled
+    snapshotInterval: 10000, // effectively disabled
     staticVatPaths: {
       staticVat: '../vat-exporter.js',
     },
@@ -251,10 +253,14 @@ test('kernel sends bringOutYourDead for vat upgrade', async t => {
     slogEntry => slogEntry.vatID === staticVatID,
   );
   const expectedDeliveries = [
-    messageDeliveryShape(1n, 'getVersion', []),
-    deliveryShape(2n, ['bringOutYourDead']),
-    deliveryShape(3n, ['startVat']),
-    messageDeliveryShape(4n, 'getVersion', []),
+    // 0: initialize-worker
+    // 1: startVat
+    messageDeliveryShape(2n, 'getVersion', []),
+    deliveryShape(3n, ['bringOutYourDead']),
+    // 4: shutdown-worker
+    // 5: initialize-worker
+    deliveryShape(6n, ['startVat']),
+    messageDeliveryShape(7n, 'getVersion', []),
   ];
   t.like(staticVatDeliveries, arrayShape(expectedDeliveries));
   t.is(staticVatDeliveries.length, expectedDeliveries.length);

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -465,7 +465,7 @@ test.serial('dead vat state removed', async t => {
   const { kvStore } = kernelStorage;
   t.is(kvStore.get('vat.dynamicIDs'), '["v6"]');
   t.is(kvStore.get('ko26.owner'), 'v6');
-  t.is(Array.from(enumeratePrefixedKeys(kvStore, 'v6.')).length > 30, true);
+  t.is(Array.from(enumeratePrefixedKeys(kvStore, 'v6.')).length > 10, true);
   const beforeDump = debug.dump(true);
   t.truthy(beforeDump.transcripts.v6);
   t.truthy(beforeDump.snapshots.v6);


### PR DESCRIPTION
When I added pseudo-deliveries to the transcript in #7484, I forgot to update the slog entry `deliveryNum` counter to match. As result, the `startVat` was deliveryNum 0 but transcript position 1 (since 0 is the `initialize-worker`). The gap grew by 2 after every snapshot save/load event pair.

We don't slog the pseudo-deliveries as `.type: 'deliver'` (they're recorded other ways). While it will be weird to have gaps in the slogfile's `deliveryNum` sequence, I think it's better to maintain easy correlation between the slog and the transcript.

So this changes `vatKeeper.nextDeliveryNum()`. Previously, that function maintained a separate counter (in `kvStore`) for each vat, which was only used by slog entries. Now, it queries the transcriptStore, with `getCurrentSpanBounds().endPos`. This is only incremented when we add an entry to the transcript, so the tests of `nextDeliveryNum()`'s auto-increment feature were updated too.

closes #7549
