### PR TITLE
fix(liveslots): retain WeakRefs to voAware collections

### DIFF
--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -650,6 +650,7 @@ function build(
     getSlotForVal,
     requiredValForSlot,
     FinalizationRegistry,
+    WeakRef,
     addToPossiblyDeadSet,
     addToPossiblyRetiredSet,
     relaxDurabilityRules,

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -418,7 +418,7 @@ export const makeVirtualObjectManager = (
       actualWeakMaps.set(this, new WeakMap());
       const vmap = new Map();
       virtualObjectMaps.set(this, vmap);
-      vrm.droppedCollectionRegistry.register(this, {
+      vrm.registerDroppedCollection(this, {
         collectionDeleter: voAwareWeakMapDeleter,
         vmap,
       });
@@ -496,7 +496,7 @@ export const makeVirtualObjectManager = (
       const vset = new Set();
       virtualObjectSets.set(this, vset);
 
-      vrm.droppedCollectionRegistry.register(this, {
+      vrm.registerDroppedCollection(this, {
         collectionDeleter: voAwareWeakSetDeleter,
         vset,
       });

--- a/packages/swingset-liveslots/src/virtualReferences.js
+++ b/packages/swingset-liveslots/src/virtualReferences.js
@@ -40,6 +40,10 @@ export function makeVirtualReferenceManager(
     finalizeDroppedCollection,
   );
 
+  function registerDroppedCollection(target, descriptor) {
+    droppedCollectionRegistry.register(target, descriptor);
+  }
+
   /**
    * Check if a virtual object is unreachable via virtual-data references.
    *
@@ -683,7 +687,7 @@ export function makeVirtualReferenceManager(
   }
 
   return harden({
-    droppedCollectionRegistry,
+    registerDroppedCollection,
     isDurable,
     isDurableKind,
     registerKind,

--- a/packages/swingset-liveslots/src/virtualReferences.js
+++ b/packages/swingset-liveslots/src/virtualReferences.js
@@ -17,6 +17,8 @@ import {
  *   converts an object ID (vref) to an object.
  * @param {*} FinalizationRegistry  Powerful JavaScript intrinsic normally denied
  *   by SES
+ * @param {*} WeakRef  Powerful JavaScript intrinsic normally denied
+ *   by SES
  * @param {*} addToPossiblyDeadSet  Function to record objects whose deaths
  *   should be reinvestigated
  * @param {*} addToPossiblyRetiredSet  Function to record dead objects whose
@@ -29,6 +31,7 @@ export function makeVirtualReferenceManager(
   getSlotForVal,
   requiredValForSlot,
   FinalizationRegistry,
+  WeakRef,
   addToPossiblyDeadSet,
   addToPossiblyRetiredSet,
   relaxDurabilityRules,

--- a/packages/swingset-liveslots/test/mock-gc.js
+++ b/packages/swingset-liveslots/test/mock-gc.js
@@ -46,6 +46,10 @@ export function makeMockGC() {
     log(` kill done`);
   }
 
+  function weakRefFor(val) {
+    return valToWeakRef.get(val);
+  }
+
   const mockFinalizationRegistryProto = {
     register(val, context) {
       log(`FR.register(context=${context})`);
@@ -95,6 +99,7 @@ export function makeMockGC() {
     WeakRef: mockWeakRef,
     FinalizationRegistry: mockFinalizationRegistry,
     kill,
+    weakRefFor,
     getAllFRs,
     flushAllFRs,
     waitUntilQuiescent,

--- a/packages/swingset-liveslots/test/test-dropped-collection-weakrefs.js
+++ b/packages/swingset-liveslots/test/test-dropped-collection-weakrefs.js
@@ -1,0 +1,61 @@
+import test from 'ava';
+import '@endo/init/debug.js';
+import { Far } from '@endo/marshal';
+import { makeLiveSlots } from '../src/liveslots.js';
+import { kser } from './kmarshal.js';
+import { buildSyscall } from './liveslots-helpers.js';
+import { makeStartVat } from './util.js';
+import { makeMockGC } from './mock-gc.js';
+
+test('droppedCollectionWeakRefs', async t => {
+  const { syscall } = buildSyscall();
+  const gcTools = makeMockGC();
+  let myVOAwareWeakMap;
+  let myVOAwareWeakSet;
+
+  // In XS, WeakRefs are treated as strong references except for
+  // forced GC, which reduces our sensitivity to GC timing (which is
+  // more likely to change under small upgrades of the engine). We'd
+  // like this improvement for objects tracked by
+  // FinalizationRegistries too. Liveslots has two FRs,
+  // `vreffedObjectRegistry` (whose entries all have WeakRefs in
+  // slotToVal), and `droppedCollectionRegistry` (in the VRM).
+  //
+  // `droppedCollectionRegistry` tracks the VO-aware replacements for
+  // WeakMap/Set that we impose on userspace, and these do not have
+  // vref identities, so they will never appear in slotToVal or
+  // valToSlot, so we need to create new WeakRefs to trigger the
+  // retain-under-organic-GC behavior. Those WeakRefs are held in the
+  // FR context/"heldValue" until it fires.
+
+  function buildRootObject(vatPowers) {
+    const { WeakMap, WeakSet } = vatPowers;
+    // creating a WeakMap/Set should put it in droppedCollectionWeakRefs
+    myVOAwareWeakMap = new WeakMap();
+    myVOAwareWeakSet = new WeakSet();
+    return Far('root', {});
+  }
+
+  const makeNS = () => ({ buildRootObject });
+  const ls = makeLiveSlots(syscall, 'vatA', {}, {}, gcTools, undefined, makeNS);
+  const { dispatch, testHooks } = ls;
+  await dispatch(makeStartVat(kser()));
+
+  const wmWeakRef = gcTools.weakRefFor(myVOAwareWeakMap);
+  const wsWeakRef = gcTools.weakRefFor(myVOAwareWeakSet);
+
+  // we snoop inside our mock FinalizationRegistry to get the context
+  const fr = testHooks.getDroppedCollectionRegistry();
+  t.is(fr.registry.get(myVOAwareWeakMap).wr, wmWeakRef);
+  t.is(fr.registry.get(myVOAwareWeakSet).wr, wsWeakRef);
+
+  gcTools.kill(myVOAwareWeakMap);
+  gcTools.flushAllFRs();
+  t.falsy(fr.registry.has(myVOAwareWeakMap));
+  t.truthy(fr.registry.has(myVOAwareWeakSet)); // not dead yet
+
+  gcTools.kill(myVOAwareWeakSet);
+  gcTools.flushAllFRs();
+  t.falsy(fr.registry.has(myVOAwareWeakMap));
+  t.falsy(fr.registry.has(myVOAwareWeakSet)); // dead now
+});

--- a/packages/swingset-liveslots/test/virtual-objects/test-cease-recognition.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-cease-recognition.js
@@ -1,4 +1,4 @@
-/* global FinalizationRegistry */
+/* global FinalizationRegistry WeakRef */
 import test from 'ava';
 import '@endo/init/debug.js';
 
@@ -16,6 +16,7 @@ function makeVRM() {
     getSlotForVal,
     requiredValForSlot,
     FinalizationRegistry,
+    WeakRef,
     addToPossiblyDeadSet,
     addToPossiblyRetiredSet,
     false,

--- a/packages/swingset-liveslots/tools/fakeVirtualSupport.js
+++ b/packages/swingset-liveslots/tools/fakeVirtualSupport.js
@@ -1,4 +1,5 @@
 /* global WeakRef */
+/* eslint-disable max-classes-per-file */
 import { makeMarshal } from '@endo/marshal';
 import { assert } from '@agoric/assert';
 import { parseVatSlot } from '../src/parseVatSlots.js';
@@ -19,6 +20,18 @@ class FakeFinalizationRegistry {
   unregister(_unregisterToken) {}
 }
 
+class FakeWeakRef {
+  constructor(target) {
+    this.target = target;
+  }
+
+  deref() {
+    return this.target; // strong ref
+  }
+}
+
+const RealWeakRef = WeakRef;
+
 export function makeFakeLiveSlotsStuff(options = {}) {
   let vrm;
   function setVrm(vrmToUse) {
@@ -31,6 +44,7 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     weak = false,
     log,
     FinalizationRegistry = FakeFinalizationRegistry,
+    WeakRef = FakeWeakRef, // VRM uses this
     addToPossiblyDeadSet = () => {},
     addToPossiblyRetiredSet = () => {},
   } = options;
@@ -174,7 +188,7 @@ export function makeFakeLiveSlotsStuff(options = {}) {
   }
 
   function setValForSlot(slot, val) {
-    slotToVal.set(slot, weak ? new WeakRef(val) : val);
+    slotToVal.set(slot, weak ? new RealWeakRef(val) : val);
   }
 
   function convertValToSlot(val) {
@@ -255,6 +269,7 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     marshal,
     deleteEntry,
     FinalizationRegistry,
+    WeakRef,
     addToPossiblyDeadSet,
     addToPossiblyRetiredSet,
     dumpStore,
@@ -273,6 +288,7 @@ export function makeFakeVirtualReferenceManager(
     fakeStuff.getSlotForVal,
     fakeStuff.getValForSlot,
     fakeStuff.FinalizationRegistry,
+    fakeStuff.WeakRef,
     fakeStuff.addToPossiblyDeadSet,
     fakeStuff.addToPossiblyRetiredSet,
     relaxDurabilityRules,


### PR DESCRIPTION
A lingering source of GC sensitivity is when a FinalizationRegistry is
watching an object that userspace might drop, and that FR callback
might perform syscalls, or simply consume more computrons when GC
happens than when it does not. While we expect all instances of a
consensus kernel to perform GC at the same time, any tolerance we can
maintain against divergent GC schedules will help us with
upgrade (replaying a transcript with a slightly different version of
XS).

To help this, in XS, WeakRefs are treated as strong references during
"organic" GC, and are only actually weak during the forced GC we do
inside bringOutYourDead. We'd like this improvement for objects
tracked by FinalizationRegistries too. Liveslots has two FRs,
`vreffedObjectRegistry` (whose entries all have WeakRefs in slotToVal,
so they're covered), and `droppedCollectionRegistry` (in the VRM).

The VRM's `droppedCollectionRegistry` tracks the VO-aware replacements
for WeakMap/Set that we impose on userspace, and these do not have
vref identities, so they will never appear in slotToVal or valToSlot,
so we need to create new WeakRefs to trigger the organic-GC-retention
behavior.

This commit adds a Map named `droppedCollectionWeakRefs` to the VRM,
which maps from a new 'holder' object to a special WeakRef for
each (imposed) VO-aware WeakMap/Set that userspace creates. This entry
is held until the FR callback is run, which removes it. The holder
object is tracked by the context/heldValue value that the FR passes to
its callback.

The net result is that userspace dropping their VO-aware collection
objects should not result in the FinalizationRegistry callback running
until a bringOutYourDead delivery, which happens on a fixed
(within-consensus) schedule.

This PR also performs refactoring and test tooling improvements to help test the new feature.

closes #7371
