### PR TITLE
6791 vaults upgrade dependencies

### DIFF
--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -175,7 +175,7 @@ export {};
  */
 
 /**
- * @typedef {{ module: string, entrypoint: string, args?: Array<unknown>} | string} ConfigProposal
+ * @typedef {string | { module: string, entrypoint: string, args?: Array<unknown> }} ConfigProposal
  */
 
 /**

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -31,19 +31,12 @@ const publicMixinAPI = harden({
 });
 
 /**
- * Utility function for `makeParamGovernance`.
- *
- * @template T
  * @param {ZCF<GovernanceTerms<{}> & {}>} zcf
- * @param {import('./contractGovernance/typedParamManager').TypedParamManager<T>} paramManager
+ * @param {import('./contractGovernance/typedParamManager').TypedParamManager<unknown>} paramManager
  */
-const facetHelpers = (zcf, paramManager) => {
-  const terms = zcf.getTerms();
-  const { governedParams } = terms;
-
-  // validate async to wait for params to be finished
-  // UNTIL https://github.com/Agoric/agoric-sdk/issues/4343
-  void E.when(paramManager.getParams(), finishedParams => {
+export const validateElectorate = (zcf, paramManager) => {
+  const { governedParams } = zcf.getTerms();
+  return E.when(paramManager.getParams(), finishedParams => {
     try {
       keyEQ(governedParams, finishedParams) ||
         Fail`The 'governedParams' term must be an object like ${q(
@@ -54,6 +47,20 @@ const facetHelpers = (zcf, paramManager) => {
       zcf.shutdownWithFailure(err);
     }
   });
+};
+harden(validateElectorate);
+
+/**
+ * Utility function for `makeParamGovernance`.
+ *
+ * @template T
+ * @param {ZCF<GovernanceTerms<{}> & {}>} zcf
+ * @param {import('./contractGovernance/typedParamManager').TypedParamManager<T>} paramManager
+ */
+const facetHelpers = (zcf, paramManager) => {
+  // validate async to wait for params to be finished
+  // UNTIL https://github.com/Agoric/agoric-sdk/issues/4343
+  void validateElectorate(zcf, paramManager);
 
   const typedAccessors = {
     getAmount: paramManager.getAmount,

--- a/packages/inter-protocol/scripts/add-collateral-core.js
+++ b/packages/inter-protocol/scripts/add-collateral-core.js
@@ -10,7 +10,11 @@ import { makeInstallCache } from '../src/proposals/utils.js';
 
 export const defaultProposalBuilder = async (
   { publishRef, install: install0, wrapInstall },
-  { interchainAssetOptions = /** @type {object} */ ({}) } = {},
+  {
+    debtLimitValue = undefined,
+    interestRateValue = undefined,
+    interchainAssetOptions = /** @type {object} */ ({}),
+  } = {},
   { env = process.env } = {},
 ) => {
   /** @type {import('../src/proposals/addAssetToVault.js').InterchainAssetOptions} */
@@ -35,6 +39,8 @@ export const defaultProposalBuilder = async (
     getManifestCall: [
       getManifestForAddAssetToVault.name,
       {
+        debtLimitValue: debtLimitValue && BigInt(debtLimitValue),
+        interestRateValue: interestRateValue && BigInt(interestRateValue),
         interchainAssetOptions: {
           denom,
           issuerBoardId,

--- a/packages/inter-protocol/test/vaultFactory/test-vault-collateralization.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-collateralization.js
@@ -56,7 +56,7 @@ test('add debt to vault under LiquidationMarging + LiquidationPadding', async t 
   // ...so we can't take the same loan out
   await t.throwsAsync(
     vd.giveCollateral(100n, aeth, MARGIN_HOP),
-    { message: /is more than the collateralization ratio allows/ },
+    { message: /Proposed debt.*exceeds max/ },
     'adjustment still under water',
   );
 
@@ -70,15 +70,6 @@ test('add debt to vault under LiquidationMargin', async t => {
   const { aeth, run } = t.context;
   const md = await makeManagerDriver(t);
 
-  // TODO revisit after the new liquidation system https://github.com/Agoric/agoric-sdk/issues/5843
-  // XXX make a worst collateralized vault for the head of the liquidation queue.
-  // Without this, the test times out because adjusting a single vault triggers
-  // `onHigherHighest` which calls `reschedulePriceCheck` which fires off a promise
-  // for updating the quote, which never resolves. This isn't a problem in the
-  // MinimumCollateralization test above so I think it's something to do with the assumptions
-  // of the liquidation engine.
-  await md.makeVaultDriver(aeth.make(1000n), run.make(4501n));
-
   // take debt that comes just shy of max
   const vd = await md.makeVaultDriver(aeth.make(1000n), run.make(4500n));
   t.deepEqual(await E(vd.vault()).getCurrentDebt(), run.make(4725n));
@@ -88,9 +79,10 @@ test('add debt to vault under LiquidationMargin', async t => {
     key: { collateralBrand: aeth.brand },
   });
 
+  // taking with the give fails
   await t.throwsAsync(
     vd.giveCollateral(100n, aeth, 10n),
-    { message: /is more than the collateralization ratio allows/ },
+    { message: /Proposed debt.*exceeds max/ },
     'adjustment still under water',
   );
 

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -821,12 +821,7 @@ test('adjust balances', async t => {
   );
 
   await t.throwsAsync(() => E(aliceReduceCollateralSeat2).getOfferResult(), {
-    // Double-disclosure bug endojs/endo#640
-    // wildcards were:
-    // "brand":"[Alleged: IST brand]","value":"[5829n]"
-    // "value":"[3750n]","brand":"[Alleged: IST brand]"
-    message: / is more than the collateralization ratio allows:/,
-    // message: /The requested debt {.*} is more than the collateralization ratio allows: {.*}/,
+    message: /Proposed debt.*exceeds max/,
   });
 
   // try to trade zero for zero

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -19,6 +19,8 @@ import { makeWatchedPromiseManager } from './watchedPromises.js';
 const SYSCALL_CAPDATA_BODY_SIZE_LIMIT = 10_000_000;
 const SYSCALL_CAPDATA_SLOTS_LENGTH_LIMIT = 10_000;
 
+const { details: X } = assert;
+
 // 'makeLiveSlots' is a dispatcher which uses javascript Maps to keep track
 // of local objects which have been exported. These cannot be persisted
 // beyond the runtime of the javascript environment, so this mechanism is not
@@ -791,7 +793,13 @@ function build(
     let result;
     if (virtual || durable) {
       assert.equal(type, 'object');
-      val = vrm.reanimate(baseRef);
+      try {
+        val = vrm.reanimate(baseRef);
+      } catch (err) {
+        const wrappedError = assert.error(X`failed to reanimate ${iface}`);
+        assert.note(wrappedError, X`Original error: ${err}`);
+        throw wrappedError;
+      }
       if (facet !== undefined) {
         result = vrm.getFacet(id, val, facet);
       }

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -191,10 +191,14 @@ export const makeStartInstance = (
 
         return E(state.adminNode).done();
       },
-      restartContract(_newPrivateArgs = undefined) {
+      restartContract(newPrivateArgs = undefined) {
         const { state } = this;
 
-        const vatParameters = { contractBundleCap: state.contractBundleCap };
+        const vatParameters = {
+          contractBundleCap: state.contractBundleCap,
+          privateArgs: newPrivateArgs,
+        };
+
         return E(state.adminNode).upgrade(state.zcfBundleCap, {
           vatParameters,
         });


### PR DESCRIPTION
refs: #6791

## Description

Fixes and tooling extracted from vaults upgrade (#7476 )

These are blockers for the stacked PR:
- fix(zcf): pass newPrivateArgs in restartContract @dckc 
- test(bootstrapTests): support advancing time @mhofman 
- fix(proposals): observe debtLimitValue @dckc 
- fix(vault): vestige of async price quote @Chris-Hibbert 

These are proposed improvements that can be deferred or dropped:
- feat: better diagnostic for failed reanimate @mhofman
- refactor(proposals): extract setupVaultFactoryArguments @dckc
- refactor(governance): validateElectorate helper @Chris-Hibbert 

### Security Considerations

--
### Scaling Considerations

--
### Documentation Considerations

--
### Testing Considerations

Updated tests