### PR TITLE
7494 provisionPool upgradable

### DIFF
--- a/packages/agoric-cli/test/agops-vaults-smoketest.sh
+++ b/packages/agoric-cli/test/agops-vaults-smoketest.sh
@@ -26,15 +26,18 @@ agoric wallet send --offer "$OFFER" --from gov1 --keyring-backend="test"
 # list my vaults
 bin/agops vaults list --from gov1 --keyring-backend="test"
 
+# in another terminal watch:
+agoric follow :published.vaultFactory.manager0.vaults.vault0
+
 # adjust
 OFFER=$(mktemp -t agops.XXX)
-bin/agops vaults adjust --vaultId vault1 --giveCollateral 1.0 --from gov1 --keyring-backend="test" >|"$OFFER"
+bin/agops vaults adjust --vaultId vault0 --giveCollateral 1.0 --from gov1 --keyring-backend="test" >|"$OFFER"
 jq ".body | fromjson" <"$OFFER"
 agoric wallet send --from gov1 --keyring-backend="test" --offer "$OFFER"
 
 # close a vault
 OFFER=$(mktemp -t agops.XXX)
 # 5.05 for 5.00 debt plus 1% fee
-bin/agops vaults close --vaultId vault1 --giveMinted 5.05 --from gov1 --keyring-backend="test" >|"$OFFER"
+bin/agops vaults close --vaultId vault0 --giveMinted 5.05 --from gov1 --keyring-backend="test" >|"$OFFER"
 jq ".body | fromjson" <"$OFFER"
 agoric wallet send --from gov1 --keyring-backend="test" --offer "$OFFER"

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -185,7 +185,7 @@
  *       feeDistributor: Promise<Installation<import('@agoric/inter-protocol/src/feeDistributor.js').start>>,
  *       mintHolder: Promise<Installation<import('@agoric/vats/src/mintHolder.js').prepare>>,
  *       psm: Promise<Installation<import('@agoric/inter-protocol/src/psm/psm.js')['prepare']>>,
- *       provisionPool: Promise<Installation<import('@agoric/vats/src/provisionPool.js')['start']>>,
+ *       provisionPool: Promise<Installation<import('@agoric/vats/src/provisionPool.js')['prepare']>>,
  *       reserve: Promise<Installation<import('@agoric/inter-protocol/src/reserve/assetReserve.js').start>>,
  *       stakeFactory: Promise<Installation<import('@agoric/inter-protocol/src/stakeFactory/stakeFactory.js').start>>,
  *       VaultFactory: Promise<Installation<import('@agoric/inter-protocol/src/vaultFactory/vaultFactory.js').start>>,

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -185,6 +185,7 @@
  *       feeDistributor: Promise<Installation<import('@agoric/inter-protocol/src/feeDistributor.js').start>>,
  *       mintHolder: Promise<Installation<import('@agoric/vats/src/mintHolder.js').prepare>>,
  *       psm: Promise<Installation<import('@agoric/inter-protocol/src/psm/psm.js')['prepare']>>,
+ *       provisionPool: Promise<Installation<import('@agoric/vats/src/provisionPool.js')['start']>>,
  *       reserve: Promise<Installation<import('@agoric/inter-protocol/src/reserve/assetReserve.js').start>>,
  *       stakeFactory: Promise<Installation<import('@agoric/inter-protocol/src/stakeFactory/stakeFactory.js').start>>,
  *       VaultFactory: Promise<Installation<import('@agoric/inter-protocol/src/vaultFactory/vaultFactory.js').start>>,

--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -34,7 +34,7 @@ const privateArgsShape = harden({
  * Given attenuated access to the funding purse,
  * handle requests to provision smart wallets.
  *
- * @param {(address: string, depositBank: ERef<Bank>) => Promise<void>} sendInitialPayment
+ * @param {(depositBank: ERef<Bank>) => Promise<void>} sendInitialPayment
  * @param {() => void} onProvisioned
  * @typedef {import('./vat-bank.js').Bank} Bank
  */
@@ -62,7 +62,7 @@ export const makeBridgeProvisionTool = (sendInitialPayment, onProvisioned) => {
         );
 
         const bank = E(bankManager).getBankForAddress(address);
-        await sendInitialPayment(address, bank);
+        await sendInitialPayment(bank);
         // only proceed  if we can provide funds
 
         const [_, created] = await E(walletFactory).provideSmartWallet(
@@ -202,11 +202,9 @@ export const start = async (zcf, privateArgs) => {
 
   /**
    *
-   * @param {string} address
    * @param {ERef<Bank>} destBank
    */
-  const sendInitialPayment = async (address, destBank) => {
-    console.log('sendInitialPayment', address);
+  const sendInitialPayment = async destBank => {
     const perAccountInitialAmount = /** @type {Amount<'nat'>} */ (
       params.getPerAccountInitialAmount()
     );

--- a/packages/vats/src/provisionPoolKit.js
+++ b/packages/vats/src/provisionPoolKit.js
@@ -1,0 +1,341 @@
+// @ts-check
+import { AmountMath, BrandShape } from '@agoric/ertp';
+import { UnguardedHelperI } from '@agoric/inter-protocol/src/typeGuards.js';
+import { observeIteration, observeNotifier } from '@agoric/notifier';
+import { M, makeScalarBigMapStore, prepareExoClassKit } from '@agoric/vat-data';
+import {
+  makeRecorderTopic,
+  PublicTopicShape,
+} from '@agoric/zoe/src/contractSupport/topics.js';
+import { InstanceHandleShape } from '@agoric/zoe/src/typeGuards.js';
+import { E } from '@endo/far';
+import { Far } from '@endo/marshal';
+import { PowerFlags } from './walletFlags.js';
+
+const { details: X, quote: q } = assert;
+
+/** @typedef {import('@agoric/zoe/src/zoeService/utils').Instance<import('@agoric/inter-protocol/src/psm/psm.js').prepare>} PsmInstance */
+
+/**
+ * @typedef {object} MetricsNotification
+ * Metrics naming scheme is that nouns are present values and past-participles
+ * are accumulative.
+ *
+ * @property {bigint} walletsProvisioned  count of new wallets provisioned
+ * @property {Amount<'nat'>} totalMintedProvided  running sum of Minted provided to new wallets
+ * @property {Amount<'nat'>} totalMintedConverted  running sum of Minted
+ * ever received by the contract from PSM
+ */
+
+/**
+ * Given attenuated access to the funding purse,
+ * handle requests to provision smart wallets.
+ *
+ * @param {(depositBank: ERef<Bank>) => Promise<void>} sendInitialPayment
+ * @param {() => void} onProvisioned
+ * @typedef {import('./vat-bank.js').Bank} Bank
+ */
+export const makeBridgeProvisionTool = (sendInitialPayment, onProvisioned) => {
+  /**
+   * @param {{
+   *   bankManager: ERef<BankManager>,
+   *   namesByAddressAdmin: ERef<import('@agoric/vats').NameAdmin>,
+   *   walletFactory: ERef<import('@agoric/vats/src/core/startWalletFactory').WalletFactoryStartResult['creatorFacet']>
+   * }} io
+   */
+  const makeHandler = ({ bankManager, namesByAddressAdmin, walletFactory }) =>
+    Far('provisioningHandler', {
+      fromBridge: async obj => {
+        assert.equal(
+          obj.type,
+          'PLEASE_PROVISION',
+          X`Unrecognized request ${obj.type}`,
+        );
+        console.info('PLEASE_PROVISION', obj);
+        const { address, powerFlags } = obj;
+        assert(
+          powerFlags.includes(PowerFlags.SMART_WALLET),
+          'missing SMART_WALLET in powerFlags',
+        );
+
+        const bank = E(bankManager).getBankForAddress(address);
+        await sendInitialPayment(bank);
+        // only proceed  if we can provide funds
+
+        const [_, created] = await E(walletFactory).provideSmartWallet(
+          address,
+          bank,
+          namesByAddressAdmin,
+        );
+        if (created) {
+          onProvisioned();
+        }
+        console.info(created ? 'provisioned' : 're-provisioned', address);
+      },
+    });
+  return makeHandler;
+};
+
+/**
+ *
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {{
+ * makeRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit,
+ * params: *,
+ * poolBank: import('@endo/far').ERef<Bank>,
+ * zcf: ZCF}} powers
+ */
+export const prepareProvisionPoolKit = (
+  baggage,
+  { makeRecorderKit, params, poolBank, zcf },
+) => {
+  const zoe = zcf.getZoeService();
+
+  const makeProvisionPoolKitInternal = prepareExoClassKit(
+    baggage,
+    'ProvisionPoolKit',
+    {
+      machine: M.interface('ProvisionPoolKit machine', {
+        makeHandler: M.call({
+          bankManager: M.any(),
+          namesByAddressAdmin: M.any(),
+          walletFactory: M.any(),
+        }).returns(M.remotable('BridgeHandler')),
+        initPSM: M.call(BrandShape, InstanceHandleShape).returns(),
+      }),
+      helper: UnguardedHelperI,
+      public: M.interface('ProvisionPoolKit public', {
+        getPublicTopics: M.call().returns({ metrics: PublicTopicShape }),
+      }),
+    },
+    /**
+     * @param {object} opts
+     * @param {Purse<'nat'>} opts.fundPurse
+     * @param {Brand} opts.poolBrand
+     * @param {StorageNode} opts.storageNode
+     */
+    ({ fundPurse, poolBrand, storageNode }) => {
+      /** @type {import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<MetricsNotification>} */
+      const metricsRecorderKit = makeRecorderKit(storageNode);
+
+      /** @type {MapStore<Brand, PsmInstance>} */
+      const brandToPSM = makeScalarBigMapStore('brandToPSM', { durable: true });
+
+      return {
+        brandToPSM,
+        fundPurse,
+        metricsRecorderKit,
+        poolBrand,
+        walletsProvisioned: 0n,
+        totalMintedProvided: AmountMath.makeEmpty(poolBrand),
+        totalMintedConverted: AmountMath.makeEmpty(poolBrand),
+      };
+    },
+    {
+      // aka "limitedCreatorFacet"
+      machine: {
+        /**
+         * @param {{
+         *   bankManager: *,
+         *   namesByAddressAdmin: *,
+         *   walletFactory: *,
+         * }} opts
+         */
+        makeHandler(opts) {
+          const {
+            facets: { helper },
+          } = this;
+          // a bit obtuse but leave for backwards compatibility with tests
+          const innerMake = makeBridgeProvisionTool(
+            bank => helper.sendInitialPayment(bank),
+            () => helper.onProvisioned(),
+          );
+          return innerMake(opts);
+        },
+        /**
+         *
+         * @param {Brand} brand
+         * @param {PsmInstance} instance
+         */
+        initPSM(brand, instance) {
+          const { brandToPSM } = this.state;
+          brandToPSM.init(brand, instance);
+        },
+      },
+      helper: {
+        publishMetrics() {
+          const {
+            metricsRecorderKit,
+            walletsProvisioned,
+            totalMintedConverted,
+            totalMintedProvided,
+          } = this.state;
+          void metricsRecorderKit.recorder.write(
+            harden({
+              walletsProvisioned,
+              totalMintedProvided,
+              totalMintedConverted,
+            }),
+          );
+        },
+        onTrade(converted) {
+          const { state, facets } = this;
+          state.totalMintedConverted = AmountMath.add(
+            state.totalMintedConverted,
+            converted,
+          );
+          facets.helper.publishMetrics();
+        },
+        onSendFunds(provided) {
+          const { state, facets } = this;
+          state.totalMintedProvided = AmountMath.add(
+            state.totalMintedProvided,
+            provided,
+          );
+          facets.helper.publishMetrics();
+        },
+        onProvisioned() {
+          const { state, facets } = this;
+          state.walletsProvisioned += 1n;
+          facets.helper.publishMetrics();
+        },
+        /**
+         *
+         * @param {ERef<Bank>} destBank
+         */
+        async sendInitialPayment(destBank) {
+          const {
+            facets: { helper },
+            state: { fundPurse, poolBrand },
+          } = this;
+          const perAccountInitialAmount = /** @type {Amount<'nat'>} */ (
+            params.getPerAccountInitialAmount()
+          );
+          const initialPmt = await E(fundPurse).withdraw(
+            perAccountInitialAmount,
+          );
+
+          const destPurse = E(destBank).getPurse(poolBrand);
+          return E(destPurse)
+            .deposit(initialPmt)
+            .then(amt => {
+              helper.onSendFunds(perAccountInitialAmount);
+              console.log('provisionPool sent', amt);
+            })
+            .catch(reason => {
+              console.error(X`initial deposit failed: ${q(reason)}`);
+              void E(fundPurse).deposit(initialPmt);
+              throw reason;
+            });
+        },
+        start() {
+          const {
+            state: { brandToPSM, poolBrand },
+            facets: { helper },
+          } = this;
+
+          // Must match. poolBrand is from durable state and the param is from
+          // the contract, so it technically can change between incarnations.
+          // That would be a severe bug.
+          AmountMath.coerce(poolBrand, params.getPerAccountInitialAmount());
+
+          void observeIteration(E(poolBank).getAssetSubscription(), {
+            updateState: async desc => {
+              console.log('provisionPool notified of new asset', desc.brand);
+              await zcf.saveIssuer(desc.issuer, desc.issuerName);
+              /** @type {ERef<Purse>} */
+              // @ts-expect-error vbank purse is close enough for our use.
+              const exchangePurse = E(poolBank).getPurse(desc.brand);
+              void observeNotifier(
+                E(exchangePurse).getCurrentAmountNotifier(),
+                {
+                  updateState: async amount => {
+                    console.log('provisionPool balance update', amount);
+                    if (
+                      AmountMath.isEmpty(amount) ||
+                      amount.brand === poolBrand
+                    ) {
+                      return;
+                    }
+                    if (!brandToPSM.has(desc.brand)) {
+                      console.error(
+                        'funds arrived but no PSM instance',
+                        desc.brand,
+                      );
+                      return;
+                    }
+                    const instance = brandToPSM.get(desc.brand);
+                    const payment = E(exchangePurse).withdraw(amount);
+                    await helper
+                      .swap(payment, amount, instance)
+                      .catch(async reason => {
+                        console.error(X`swap failed: ${reason}`);
+                        const resolvedPayment = await payment;
+                        return E(exchangePurse).deposit(resolvedPayment);
+                      });
+                  },
+                  fail: reason => console.error(reason),
+                },
+              );
+            },
+          });
+        },
+        /**
+         * @param {ERef<Payment>} payIn
+         * @param {Amount} amount
+         * @param {PsmInstance} instance
+         */
+        async swap(payIn, amount, instance) {
+          const {
+            facets: { helper },
+            state: { fundPurse },
+          } = this;
+          const psmPub = E(zoe).getPublicFacet(instance);
+          const proposal = harden({ give: { In: amount } });
+          const invitation = E(psmPub).makeWantMintedInvitation();
+          const seat = E(zoe).offer(invitation, proposal, { In: payIn });
+          const payout = await E(seat).getPayout('Out');
+          const rxd = await E(fundPurse).deposit(payout);
+          helper.onTrade(rxd);
+          return rxd;
+        },
+      },
+      public: {
+        getPublicTopics() {
+          return {
+            metrics: makeRecorderTopic(
+              'Provision Pool metrics',
+              this.state.metricsRecorderKit,
+            ),
+          };
+        },
+      },
+    },
+    {
+      finish: ({ facets }) => {
+        facets.helper.publishMetrics();
+      },
+    },
+  );
+
+  /**
+   * Prepare synchronous values before passing to real Exo maker
+   *
+   * @param {object} opts
+   * @param {Brand} opts.poolBrand
+   * @param {ERef<StorageNode>} opts.storageNode
+   */
+  const makeProvisionPoolKit = async ({ poolBrand, storageNode }) => {
+    /** @type {Purse<'nat'>} */
+    // @ts-expect-error vbank purse is close enough for our use.
+    const fundPurse = await E(poolBank).getPurse(poolBrand);
+
+    return makeProvisionPoolKitInternal({
+      fundPurse,
+      poolBrand,
+      storageNode: await storageNode,
+    });
+  };
+
+  return makeProvisionPoolKit;
+};

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -54,7 +54,7 @@ const makeTestContext = async () => {
   const committeeInstall = await E(zoe).install(committeeBundle);
   const psmInstall = await E(zoe).install(psmBundle);
   const centralSupply = await E(zoe).install(centralSupplyBundle);
-  /** @type {Installation<import('../src/provisionPool').start>} */
+  /** @type {Installation<import('../src/provisionPool')['prepare']>} */
   const policyInstall = await E(zoe).install(policyBundle);
 
   const mintLimit = AmountMath.make(mintedBrand, MINT_LIMIT);

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -266,7 +266,7 @@ const makeWalletFactoryKitFor1 = async address => {
   const fees = withAmountUtils(makeIssuerKit('FEE'));
   await bankManager.addAsset('ufee', 'FEE', 'FEE', fees);
 
-  const sendInitialPayment = async (_addr, dest) => {
+  const sendInitialPayment = async dest => {
     const pmt = fees.mint.mintPayment(fees.make(250n));
     return E(E(dest).getPurse(fees.brand)).deposit(pmt);
   };

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -19,7 +19,7 @@ import path from 'path';
 import centralSupplyBundle from '../bundles/bundle-centralSupply.js';
 import { makeBoard } from '../src/lib-board.js';
 import { makeNameHubKit } from '../src/nameHub.js';
-import { makeBridgeProvisionTool } from '../src/provisionPool.js';
+import { makeBridgeProvisionTool } from '../src/provisionPoolKit.js';
 import { buildRootObject as buildBankRoot } from '../src/vat-bank.js';
 import { PowerFlags } from '../src/walletFlags.js';
 import { makeFakeBankKit } from '../tools/bank-utils.js';


### PR DESCRIPTION
closes: #7494

## Description

Makes the provisionPool contract upgradable by turning most of into a durable Exo kit. That wasn't strictly necessary but it reduced the decision fatigue of how to structure the code for a singleton kind.

To support this style of singleton the PR also adds a helper to Zoe contractSupport.

### Security Considerations

no change

### Scaling Considerations

Now durable instead of heap. Negligible since there will be one provisionPool.

### Documentation Considerations

--

### Testing Considerations

Ran `test-vaults-smoketest.sh` locally (PR includes some test fixes)