### PR TITLE
fix(swingset): better snapshot scheduling, do BOYD before each

### DIFF
--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -507,11 +507,15 @@ export function makeVatKeeper(
     return snapStore?.getSnapshotInfo(vatID);
   }
 
-  function transcriptSnapshotStats() {
-    const totalEntries = getTranscriptEndPosition();
-    const snapshotInfo = getSnapshotInfo();
-    const snapshottedEntries = snapshotInfo ? snapshotInfo.snapPos : 0;
-    return { totalEntries, snapshottedEntries };
+  /**
+   * Returns count of deliveries made since initialization or
+   * load-snapshot
+   *
+   * @returns {number}
+   */
+  function transcriptSpanEntries() {
+    const { startPos, endPos } = transcriptStore.getCurrentSpanBounds(vatID);
+    return endPos - startPos;
   }
 
   /**
@@ -662,7 +666,8 @@ export function makeVatKeeper(
     deleteCListEntriesForKernelSlots,
     transcriptSize,
     getTranscript,
-    transcriptSnapshotStats,
+    getTranscriptEndPosition,
+    transcriptSpanEntries,
     addToTranscript,
     vatStats,
     dumpState,

--- a/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
+++ b/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
@@ -51,50 +51,50 @@ test('vat reload from snapshot', async t => {
   c1.queueToVatRoot('target', 'count', []);
   // * 2: message (count=0)
   // * then we hit snapshotInitial
-  // * 3: save-snapshot
-  // * 4: load-snapshot
+  // * 3: BOYD
+  // * 4: save-snapshot
+  // * 5: load-snapshot
   expected1.push(`count = 0`);
   await c1.run();
   t.deepEqual(c1.dump().log, expected1);
-  t.deepEqual(getPositions(), [3, 4, 5]);
+  t.deepEqual(getPositions(), [4, 5, 6]);
 
   for (let i = 1; i < 11; i += 1) {
     c1.queueToVatRoot('target', 'count', []);
-    // * 5: message (count=1)
-    // * 6: message (count=2)
-    // * 7: message (count=3)
+    // * 6: message (count=1)
+    // * 7: message (count=2)
+    // * 8: message (count=3)
+    // * 9: message (count=4)
     // * then we hit snapshotInterval
-    // * 8: save-snapshot
-    // * 9: load-snapshot
-    // * 10: message (count=4)
-    // * 11: message (count=5)
-    // * 12: message (count=6)
-    // * then we hit snapshotInterval
-    // * 13: save-snapshot
-    // * 14: load-snapshot
+    // * 9: BOYD
+    // * 10: save-snapshot
+    // * 11: load-snapshot
+    // * 12: message (count=5)
+    // * 13: message (count=6)
     // * 15: message (count=7)
     // * 16: message (count=8)
-    // * 17: message (count=9)
     // * then we hit snapshotInterval
+    // * 17: BOYD
     // * 18: save-snapshot
     // * 19: load-snapshot
-    // * 20: message (count=10)
+    // * 20: message (count=9)
+    // * 21: message (count=10)
     expected1.push(`count = ${i}`);
   }
   await c1.run();
   t.deepEqual(c1.dump().log, expected1);
-  t.deepEqual(getPositions(), [18, 19, 21]);
+  t.deepEqual(getPositions(), [18, 19, 22]);
   await c1.shutdown();
 
-  // the worker will start with the load-snapshot at d19, and replay d20
+  // the worker will start with the load-snapshot at d19, and replay d20+d21
   const c2 = await makeSwingsetController(kernelStorage);
-  const expected2 = [`count = 10`];
+  const expected2 = [`count = 9`, `count = 10`];
   t.deepEqual(c2.dump().log, expected2); // replayed 4 deliveries
   c2.queueToVatRoot('target', 'count', []);
-  // * 21: message(count=11)
+  // * 22: message(count=11)
   expected2.push(`count = 11`);
   await c2.run();
   t.deepEqual(c2.dump().log, expected2); // note: *not* 0-11
-  t.deepEqual(getPositions(), [18, 19, 22]);
+  t.deepEqual(getPositions(), [18, 19, 23]);
   await c2.shutdown();
 });

--- a/packages/SwingSet/test/xsnap-stable-bundles/test-stable-bundles.js
+++ b/packages/SwingSet/test/xsnap-stable-bundles/test-stable-bundles.js
@@ -173,11 +173,12 @@ test('xsnap bundles are stable', async t => {
   // snapshotInitial: 2
 
   // now allow the bootstrap message to be delivered as deliveryNum=1,
-  // which should trigger a snapshot, which is recorded in a
-  // save-snapshot as deliveryNum=2
+  // which should trigger a snapshot, which first performs a BOYD in
+  // deliveryNum=2, then the snapshot is recorded in a save-snapshot
+  // as deliveryNum=3
   t.is(snapStore.getSnapshotInfo('v1'), undefined);
   await c2.run();
-  t.is(snapStore.getSnapshotInfo('v1')?.snapPos, 2);
+  t.is(snapStore.getSnapshotInfo('v1')?.snapPos, 3);
   await c2.shutdown;
 
   // now that the worker has a snapshot, the vat preload won't fetch


### PR DESCRIPTION
This changes the snapshot scheduling logic to be more consistent. We still use `snapshotInitial` to trigger a snapshot shortly after worker initialization, and `snapshotInterval` to trigger periodic ones after that.

However the previous code compared `snapshotInitial` to the absolute deliveryNum, which meant it only applied to the first incarnation, and would not attempt to take a snapshot shortly after upgrade, leaving the kernel vulnerable to replaying the long `startVat` delivery for a larger window than we intended. And `snapshotInterval` was compared against the difference between the latest transcript and the latest snapshot, which changed with the addition of the load-worker pseudo-entry.

The new code uses `snapshotInitial` whenever there is not an existing snapshot (so the first span of *all* incarnations), and compares it against the length of the current span (so it includes all the pseudo-events). `snapshotInterval` is also compared against the length of the current span.

The result is simpler and more predictable set of rules:

* in the first span of each incarnation, trigger a snapshot once we have at least `snapshotInterval` entries
* in all other spans, trigger once we have at least `snapshotInterval`

In addition, when triggering a snapshot, we perform a BringOutYourDead delivery before asking the worker to save a snapshot. This gives us one last chance to shake out any garbage (making the snapshot as small as possible), and reduces the variation we might see forced GC that happens during snapshot write (any FinalizationRegistry callbacks should get run during the BOYD, not the save-snapshot).

closes #7553
closes #7504
