### PR TITLE
fix: do not error on shutdown

### DIFF
--- a/packages/telemetry/src/slog-sender-pipe.js
+++ b/packages/telemetry/src/slog-sender-pipe.js
@@ -157,7 +157,7 @@ export const makeSlogSender = async opts => {
   const init = async options => sendWaitReply('init', { options });
 
   const send = obj => {
-    void pipeSend({ type: 'send', obj });
+    void pipeSend({ type: 'send', obj }).catch(() => {});
   };
 
   const shutdown = async () => {


### PR DESCRIPTION
## Description

We currently attempt to shutdown cleanly, but if SwingSet is in the middle of a `controller.run()`, it will likely fail when it attempts a delivery to a closed vat. This interferes with supervisor tools (like the loadgen), that expect a tidier exit.

This changes the shutdown helper to inform callbacks whether the shutdown is nicely requested (`SIGINT`), and changes the shutdown logic in cosmic-swingset to only shutdown the controller on SIGINT, and only after waiting for the end of the current blockingSend.

Also silences telemetry send errors that are unactionable. A fatal error would be reported during a subsequent flush anyway.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Manually tested with the loadgen.
