### PR TITLE
feat(SwingSet): force reload worker from snapshot

### DIFF
--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -543,6 +543,7 @@ async function replay(transcriptFile) {
       const { hash, compressSeconds: saveSeconds } = await manager.makeSnapshot(
         lastTranscriptNum,
         snapStore,
+        false, // Do not restart, we'll do that ourselves if needed
       );
       fs.writeSync(
         snapshotActivityFd,

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -435,7 +435,7 @@ export async function makeSwingsetController(
  *   slogCallbacks?: unknown;
  *   slogSender?: import('@agoric/telemetry').SlogSender;
  *   testTrackDecref?: unknown;
- *    warehousePolicy?: { maxVatsOnline?: number };
+ *   warehousePolicy?: import('../types-external.js').VatWarehousePolicy;
  * }} runtimeOptions
  * @param {Record<string, unknown>} deviceEndowments
  * @typedef { import('@agoric/swing-store').KVStore } KVStore

--- a/packages/SwingSet/src/controller/startXSnap.js
+++ b/packages/SwingSet/src/controller/startXSnap.js
@@ -13,12 +13,21 @@ const NETSTRING_MAX_CHUNK_SIZE = 12_000_000;
  */
 
 /**
+ * @typedef {object} StartXSnapInitFromSnapshotStreamDetails
+ * @property {'snapshotStream'} from
+ * @property {AsyncIterable<Uint8Array>} snapshotStream
+ * @property {string} [snapshotDescription]
+ */
+
+/**
  * @typedef {object} StartXSnapInitFromSnapStoreDetails
  * @property {'snapStore'} from
  * @property {string} vatID
+ *
+ * TODO: transition to direct snapshot stream, and remove this option
  */
 
-/** @typedef {StartXSnapInitFromBundlesDetails | StartXSnapInitFromSnapStoreDetails} StartXSnapInitDetails */
+/** @typedef {StartXSnapInitFromBundlesDetails | StartXSnapInitFromSnapshotStreamDetails | StartXSnapInitFromSnapStoreDetails} StartXSnapInitDetails */
 
 /** @typedef {ReturnType<typeof makeStartXSnap>} StartXSnap */
 
@@ -96,6 +105,11 @@ export function makeStartXSnap(options) {
         // console.log('startXSnap from', { snapshotID });
         const snapshotStream = snapStore.loadSnapshot(vatID);
         const snapshotDescription = `${vatID}-${snapPos}-${snapshotID}`;
+        return { snapshotStream, snapshotDescription };
+      }
+
+      case 'snapshotStream': {
+        const { snapshotStream, snapshotDescription } = initDetails;
         return { snapshotStream, snapshotDescription };
       }
 

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -547,16 +547,21 @@ export function makeVatKeeper(
    * Store a snapshot, if given a snapStore.
    *
    * @param {VatManager} manager
+   * @param {boolean} [restartWorker]
    * @returns {Promise<void>}
    */
-  async function saveSnapshot(manager) {
+  async function saveSnapshot(manager, restartWorker) {
     if (!snapStore || !manager.makeSnapshot) {
       return;
     }
 
     // tell the manager to save a heap snapshot to the snapStore
     const endPosition = getTranscriptEndPosition();
-    const info = await manager.makeSnapshot(endPosition, snapStore);
+    const info = await manager.makeSnapshot(
+      endPosition,
+      snapStore,
+      restartWorker,
+    );
 
     const {
       hash: snapshotID,
@@ -586,6 +591,7 @@ export function makeVatKeeper(
       compressedSize,
       compressSeconds,
       endPosition,
+      restartWorker,
     });
   }
 

--- a/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-helper.js
@@ -11,6 +11,7 @@ import {
  * @typedef {import('@agoric/swingset-liveslots').VatSyscallObject} VatSyscallObject
  * @typedef {import('@agoric/swingset-liveslots').VatSyscallResult} VatSyscallResult
  * @typedef {import('../../types-internal.js').VatManager} VatManager
+ * @typedef {import('../../types-internal.js').MakeSnapshot} MakeSnapshot
  */
 
 // We use vat-centric terminology here, so "inbound" means "into a vat",
@@ -57,7 +58,7 @@ import {
 /**
  *
  * @typedef { { getManager: (shutdown: () => Promise<void>,
- *                           makeSnapshot?: (snapPos: number, ss: SnapStore) => Promise<SnapshotResult>) => VatManager,
+ *                           makeSnapshot?: MakeSnapshot) => VatManager,
  *              syscallFromWorker: (vso: VatSyscallObject) => VatSyscallResult,
  *              setDeliverToWorker: (dtw: unknown) => void,
  *            } } ManagerKit
@@ -170,7 +171,7 @@ function makeManagerKit(retainSyscall = false) {
   /**
    *
    * @param { () => Promise<void>} shutdown
-   * @param {(snapPos: number, ss: SnapStore) => Promise<SnapshotResult>} [makeSnapshot]
+   * @param {MakeSnapshot} [makeSnapshot]
    * @returns {VatManager}
    */
   function getManager(shutdown, makeSnapshot) {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -50,12 +50,7 @@ const makeRevokableHandleCommandKit = handleUpstream => {
  * @param {{
  *   kernelKeeper: KernelKeeper,
  *   kernelSlog: KernelSlog,
- *   startXSnap: (vatID: string, name: string,
- *                details: {
- *                 bundleIDs: BundleID[],
- *                 handleCommand: AsyncHandler,
- *                 metered?: boolean,
- *                 reload?: boolean } ) => Promise<XSnap>,
+ *   startXSnap: import('../../controller/startXSnap.js').StartXSnap,
  *   testLog: (...args: unknown[]) => void,
  * }} tools
  * @returns {VatManagerFactory}
@@ -145,11 +140,11 @@ export function makeXsSubprocessFactory({
     let handleCommandKit = makeRevokableHandleCommandKit(handleUpstream);
 
     // start the worker and establish a connection
-    const worker = await startXSnap(vatID, argName, {
+    const worker = await startXSnap(argName, {
       bundleIDs,
       handleCommand: handleCommandKit.handleCommand,
       metered,
-      reload: !!snapshotInfo,
+      init: snapshotInfo && { from: 'snapStore', vatID },
     });
 
     /** @type { (item: Tagged) => Promise<WorkerResults> } */

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -234,11 +234,16 @@ export function makeXsSubprocessFactory({
     /**
      * @param {number} snapPos
      * @param {SnapStore} snapStore
+     * @param {boolean} [restartWorker]
      * @returns {Promise<SnapshotResult>}
      */
-    async function makeSnapshot(snapPos, snapStore) {
+    async function makeSnapshot(snapPos, snapStore, restartWorker) {
       const snapshotDescription = `${vatID}-${snapPos}`;
       const snapshotStream = worker.makeSnapshotStream(snapshotDescription);
+
+      if (!restartWorker) {
+        return snapStore.saveSnapshot(vatID, snapPos, snapshotStream);
+      }
 
       /** @type {AsyncGenerator<Uint8Array, void, void>[]} */
       const [restartWorkerStream, snapStoreSaveStream] = synchronizedTee(

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -243,7 +243,8 @@ export function makeVatWarehouse({
   panic,
   warehousePolicy,
 }) {
-  const { maxVatsOnline = 50 } = warehousePolicy || {};
+  const { maxVatsOnline = 50, restartWorkerOnSnapshot = true } =
+    warehousePolicy || {};
   // Often a large contract evaluation is among the first few deliveries,
   // so let's do a snapshot after just a few deliveries.
   const snapshotInitial = kernelKeeper.getSnapshotInitial();
@@ -603,8 +604,10 @@ export function makeVatWarehouse({
     // vatKeeper.saveSnapshot() pushes a save-snapshot transcript
     // entry, then starts a new transcript span, then pushes a
     // load-snapshot entry, so that the current span always starts
-    // with an initialize-snapshot or load-snapshot pseudo-delivery
-    await vatKeeper.saveSnapshot(manager);
+    // with an initialize-snapshot or load-snapshot pseudo-delivery,
+    // regardless of whether the worker was restarted from snapshot
+    // or not.
+    await vatKeeper.saveSnapshot(manager, restartWorkerOnSnapshot);
     return true;
   }
 

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -236,6 +236,7 @@ export {};
  *
  * @typedef {object} VatWarehousePolicy
  * @property { number } [maxVatsOnline]     Limit the number of simultaneous workers
+ * @property { boolean } [restartWorkerOnSnapshot]     Reload worker immediately upon snapshot creation
  */
 
 /**

--- a/packages/SwingSet/src/types-internal.js
+++ b/packages/SwingSet/src/types-internal.js
@@ -57,9 +57,11 @@ export {};
  *   bundle?: Bundle,
  * }} ManagerOptions
  *
+ * @typedef {(snapPos: number, ss: SnapStore, restartWorker?: boolean) => Promise<SnapshotResult>} MakeSnapshot
+ *
  * @typedef { { deliver: (delivery: VatDeliveryObject, vatSyscallHandler: VatSyscallHandler)
  *                       => Promise<VatDeliveryResult>,
- *              makeSnapshot?: undefined | ((snapPos: number, ss: SnapStore) => Promise<SnapshotResult>),
+ *              makeSnapshot?: undefined | MakeSnapshot,
  *              shutdown: () => Promise<void>,
  *            } } VatManager
  * @typedef { { createFromBundle: (vatID: string,

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -255,6 +255,9 @@ test('static vats are unmetered on XS', async t => {
         limited.push(args.includes('-l'));
         return spawn(command, args, options);
       },
+      warehousePolicy: {
+        restartWorkerOnSnapshot: false,
+      },
     },
   );
   t.teardown(c.shutdown);

--- a/packages/SwingSet/test/test-xsnap-metering.js
+++ b/packages/SwingSet/test/test-xsnap-metering.js
@@ -52,11 +52,10 @@ async function doTest(t, metered) {
   const store = makeSnapStore(db, () => {}, makeSnapStoreIO());
 
   const { p: p1, startXSnap: start1 } = make(store);
-  const worker1 = await start1('vat', 'name', {
+  const worker1 = await start1('name', {
     bundleIDs: [],
     handleCommand,
     metered,
-    reload: false,
   });
   const spawnArgs1 = await p1;
   checkMetered(t, spawnArgs1, metered);
@@ -68,11 +67,11 @@ async function doTest(t, metered) {
 
   // and load it into a new worker
   const { p: p2, startXSnap: start2 } = make(store);
-  const worker2 = await start2('vat', 'name', {
+  const worker2 = await start2('name', {
     bundleIDs: [],
     handleCommand,
     metered,
-    reload: true,
+    init: { from: 'snapStore', vatID: 'vat' },
   });
   const spawnArgs2 = await p2;
   checkMetered(t, spawnArgs2, metered);

--- a/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
+++ b/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
@@ -9,7 +9,7 @@ import {
 } from '@agoric/swing-store';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
 
-test('vat reload from snapshot', async t => {
+const vatReloadFromSnapshot = async (t, restartWorkerOnSnapshot) => {
   const config = {
     defaultReapInterval: 'never',
     snapshotInitial: 3,
@@ -30,7 +30,10 @@ test('vat reload from snapshot', async t => {
   const argv = [];
   await initializeSwingset(config, argv, kernelStorage);
 
-  const c1 = await makeSwingsetController(kernelStorage, null);
+  const warehousePolicy = { restartWorkerOnSnapshot };
+  const runtimeOptions = { warehousePolicy };
+
+  const c1 = await makeSwingsetController(kernelStorage, null, runtimeOptions);
   c1.pinVatRoot('target');
   const vatID = c1.vatNameToID('target');
 
@@ -97,4 +100,7 @@ test('vat reload from snapshot', async t => {
   t.deepEqual(c2.dump().log, expected2); // note: *not* 0-11
   t.deepEqual(getPositions(), [18, 19, 23]);
   await c2.shutdown();
-});
+};
+
+test('vat reload from snapshot (restart worker)', vatReloadFromSnapshot, true);
+test('vat reload from snapshot (reuse worker)', vatReloadFromSnapshot, false);

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -29,7 +29,7 @@ import { buffer } from './util.js';
  *
  * @typedef {{
  *   loadSnapshot: (vatID: string) => AsyncIterableIterator<Uint8Array>,
- *   saveSnapshot: (vatID: string, snapPos: number, snapshotStream: AsyncIterableIterator<Uint8Array>) => Promise<SnapshotResult>,
+ *   saveSnapshot: (vatID: string, snapPos: number, snapshotStream: AsyncIterable<Uint8Array>) => Promise<SnapshotResult>,
  *   deleteAllUnusedSnapshots: () => void,
  *   deleteVatSnapshots: (vatID: string) => void,
  *   stopUsingLastSnapshot: (vatID: string) => void,
@@ -167,7 +167,7 @@ export function makeSnapStore(
    *
    * @param {string} vatID
    * @param {number} snapPos
-   * @param {AsyncIterableIterator<Uint8Array>} snapshotStream
+   * @param {AsyncIterable<Uint8Array>} snapshotStream
    * @returns {Promise<SnapshotResult>}
    */
   async function saveSnapshot(vatID, snapPos, snapshotStream) {


### PR DESCRIPTION
closes: #6943

## Description

Introduce a runtime option (enabled by default), to force reload a worker when a snapshot is taken.
This is done in a streaming fashion by tee-ing the snapshot stream into the snapStore and a new xsnap worker, then substituting the old worker transparently.

### Security Considerations

This increases the likelihood that validators will stay in consensus at the cost of potentially hiding reload based defects in xsnap. To mitigate the latter, this is a runtime option that can be disabled, and we validate new xsnap versions with the replay tool which controls and compares the behavior of reload from snapshot.

### Scaling Considerations

This would reduce memory fragmentation for large vats, potentially mitigating issues like #6661.

### Documentation Considerations

Types for new runtime option. Not documented otherwise.

### Testing Considerations

Modified the vat warehouse unit test to run both versions (reload and keep).
Manually tested on a loadgen branch (need update to support transient multiple process per worker).

(removed a ~#~ ~loadgen-branch: mhofman/fix-shutdown-and-multi-process~ comment here)
