### PR TITLE
State sync test

### DIFF
--- a/golang/cosmos/x/swingset/keeper/snapshotter.go
+++ b/golang/cosmos/x/swingset/keeper/snapshotter.go
@@ -179,7 +179,7 @@ func (snapshotter *SwingsetSnapshotter) InitiateSnapshot(height int64) error {
 		_, err = snapshotter.blockingSend(action)
 
 		if err != nil {
-			logger.Error("failed to discard of swingset snapshot", "err", err)
+			logger.Error("failed to discard swingset snapshot", "err", err)
 		}
 
 		snapshotter.activeSnapshot = nil

--- a/golang/cosmos/x/swingset/keeper/snapshotter.go
+++ b/golang/cosmos/x/swingset/keeper/snapshotter.go
@@ -138,7 +138,6 @@ func (snapshotter *SwingsetSnapshotter) InitiateSnapshot(height int64) error {
 	// Indicate that a snapshot has been initiated by setting `activeSnapshot`.
 	// This structure is used to synchronize with the goroutine spawned below.
 	// It's nilled-out before exiting (and is the only code that does so).
-	//snapshotter.Lock()
 	active := &activeSnapshot{
 		height:        height,
 		logger:        logger,

--- a/golang/cosmos/x/swingset/keeper/snapshotter_test.go
+++ b/golang/cosmos/x/swingset/keeper/snapshotter_test.go
@@ -1,0 +1,129 @@
+package keeper
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func newTestSnapshotter() SwingsetSnapshotter {
+	logger := log.NewNopLogger() // log.NewTMLogger(log.NewSyncWriter( /* os.Stdout*/ io.Discard)).With("module", "sdk/app")
+	return SwingsetSnapshotter{
+		isConfigured:      func() bool { return true },
+		takeSnapshot:      func(height int64) {},
+		newRestoreContext: func(height int64) sdk.Context { return sdk.Context{} },
+		logger:            logger,
+		blockingSend:      func(action vm.Jsonable) (string, error) { return "", nil },
+	}
+}
+
+func TestSnapshotInProgress(t *testing.T) {
+	swingsetSnapshotter := newTestSnapshotter()
+	swingsetSnapshotter.activeSnapshot = &activeSnapshot{}
+	err := swingsetSnapshotter.InitiateSnapshot(123)
+	if err == nil {
+		t.Error("wanted error for snapshot in progress")
+	}
+}
+
+func TestNotConfigured(t *testing.T) {
+	swingsetSnapshotter := newTestSnapshotter()
+	swingsetSnapshotter.isConfigured = func() bool { return false }
+	err := swingsetSnapshotter.InitiateSnapshot(123)
+	if err == nil {
+		t.Error("wanted error for unconfigured snapshot")
+	}
+}
+
+func TestSecondCommit(t *testing.T) {
+	swingsetSnapshotter := newTestSnapshotter()
+
+	// Use a channel to block the snapshot goroutine after it has started but before it exits.
+	ch := make(chan struct{}, 1)
+	swingsetSnapshotter.blockingSend = func(action vm.Jsonable) (string, error) {
+		ch <- struct{}{}
+		return "", nil
+	}
+
+	// First run through app.Commit()
+	err := swingsetSnapshotter.WaitUntilSnapshotStarted()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = swingsetSnapshotter.InitiateSnapshot(123)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second run through app.Commit() - should return right away
+	err = swingsetSnapshotter.WaitUntilSnapshotStarted()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// drain the signaling channel to let goroutine exit
+	_ = <-ch
+	_ = <-ch
+	close(ch)
+}
+
+func TestInitiateFails(t *testing.T) {
+	swingsetSnapshotter := newTestSnapshotter()
+	swingsetSnapshotter.blockingSend = func(action vm.Jsonable) (string, error) {
+		if action.(*snapshotAction).Request == "initiate" {
+			return "", errors.New("initiate failed")
+		}
+		return "", nil
+	}
+
+	err := swingsetSnapshotter.InitiateSnapshot(123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = swingsetSnapshotter.WaitUntilSnapshotStarted()
+	if err == nil {
+		t.Fatal("wanted initiation error")
+	}
+	if err.Error() != "initiate failed" {
+		t.Errorf(`wanted error "initiate failed", got "%s"`, err.Error())
+	}
+}
+
+func TestRetrievalFails(t *testing.T) {
+	swingsetSnapshotter := newTestSnapshotter()
+	swingsetSnapshotter.blockingSend = func(action vm.Jsonable) (string, error) {
+		if action.(*snapshotAction).Request == "retrieve" {
+			return "", errors.New("retrieve failed")
+		}
+		return "", nil
+	}
+	nilWriter := func(_ []byte) error { return nil }
+	var savedErr error
+	ch := make(chan struct{})
+	swingsetSnapshotter.takeSnapshot = func(height int64) {
+		// shortcut to the snapshot manager calling the extension
+		savedErr = swingsetSnapshotter.SnapshotExtension(uint64(height), nilWriter)
+		close(ch)
+	}
+
+	err := swingsetSnapshotter.InitiateSnapshot(123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = swingsetSnapshotter.WaitUntilSnapshotStarted()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = <-ch
+	if savedErr == nil {
+		t.Fatal("wanted retrieval error")
+	}
+	if savedErr.Error() != "retrieve failed" {
+		t.Errorf(`wanted error "retrieve failed", got "%s"`, savedErr.Error())
+	}
+	// goroutine has no remaining visible side-effects, so we can end the test
+}

--- a/golang/cosmos/x/swingset/keeper/snapshotter_test.go
+++ b/golang/cosmos/x/swingset/keeper/snapshotter_test.go
@@ -34,7 +34,7 @@ func TestNotConfigured(t *testing.T) {
 	swingsetSnapshotter.isConfigured = func() bool { return false }
 	err := swingsetSnapshotter.InitiateSnapshot(123)
 	if err == nil {
-		t.Error("wanted error for unconfigured snapshot")
+		t.Error("wanted error for unconfigured snapshot manager")
 	}
 }
 
@@ -89,6 +89,11 @@ func TestInitiateFails(t *testing.T) {
 	}
 	if err.Error() != "initiate failed" {
 		t.Errorf(`wanted error "initiate failed", got "%s"`, err.Error())
+	}
+	// another wait should succeed without error
+	err = swingsetSnapshotter.WaitUntilSnapshotStarted()
+	if err != nil {
+		t.Error(err)
 	}
 }
 

--- a/golang/cosmos/x/swingset/keeper/snapshotter_test.go
+++ b/golang/cosmos/x/swingset/keeper/snapshotter_test.go
@@ -147,7 +147,6 @@ func TestRetrievalFails(t *testing.T) {
 	if savedErr.Error() != "retrieve failed" {
 		t.Errorf(`wanted error "retrieve failed", got "%s"`, savedErr.Error())
 	}
-	<-swingsetSnapshotter.activeSnapshot.done
 }
 
 func TestDiscard(t *testing.T) {

--- a/golang/cosmos/x/swingset/keeper/snapshotter_test.go
+++ b/golang/cosmos/x/swingset/keeper/snapshotter_test.go
@@ -65,8 +65,8 @@ func TestSecondCommit(t *testing.T) {
 	}
 
 	// drain the signaling channel to let goroutine exit
-	_ = <-ch
-	_ = <-ch
+	<-ch
+	<-ch
 	close(ch)
 }
 
@@ -118,7 +118,7 @@ func TestRetrievalFails(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_ = <-ch
+	<-ch
 	if savedErr == nil {
 		t.Fatal("wanted retrieval error")
 	}


### PR DESCRIPTION
closes: #7349

## Description

Adds the requested unit tests to the `SwingsetSnapthotter`. The stretch goal JS tests in #7349 were not reached, so leaving that issue open for now.

Refactored `SwingsetSnapshotter` for simpler test setup with simpler control points. The tests are not black-box and require access to unexported fields.

Lastly, added an explicit `RWMutex` to control reading/writing the `activeSnapshot` field that is accessed by multiple goroutines. Though there was a discipline of one goroutine only changing from nil to non-nil, and another goroutine from non-nil to nil, the discipline is undocumented and fragile. Best practice advises us to just use a more explicit and standard idiom. (@michaelfig please look closely at this in particular.)

### Security Considerations

None beyond the correctness.

### Scaling Considerations

The changes shouldn't be significant.

### Documentation Considerations

N/A

### Testing Considerations

Note that some of the tests spawn a goroutine outside of a WaitGroup, so there is no guarantee that the goroutine has exited when the test ends. However, we do wait for all visible effects of the goroutine, so it should not matter when it ends.
