### PR TITLE
ci: add debug info for github support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,8 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
       - name: Login to Docker Registry
         uses: docker/login-action@v2
         with:
@@ -125,6 +127,8 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
       - name: Login to Docker Registry
         uses: docker/login-action@v2
         with:
@@ -195,6 +199,8 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
       - name: Login to Docker Registry
         uses: docker/login-action@v2
         with:
@@ -243,6 +249,8 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
       - name: Login to Docker Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
adds a debug flag to the docker buildaction for github support, per their request