### PR TITLE
fix(agoric-cli): dont throw when reading history

### DIFF
--- a/packages/agoric-cli/src/lib/rpc.js
+++ b/packages/agoric-cli/src/lib/rpc.js
@@ -144,7 +144,7 @@ export const makeVStorage = (powers, config = networkConfig) => {
           ));
           // console.debug('readAt returned', { blockHeight });
         } catch (err) {
-          if ('log' in err && err.log.match(/unknown request/)) {
+          if (err.message.match(/unknown request/)) {
             // console.error(err);
             break;
           }


### PR DESCRIPTION
refs https://github.com/Agoric/agoric-sdk/issues/5863

## Description

Problem:
```
$ AGORIC_NET=ollinet bin/agops inter bid list --from gov1 --keyring-backend=test
(Error#1)
Error#1: error code 6 reading data of published.wallet.agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce: could not get vstorage path: unknown request

  at packages/agoric-cli/src/lib/rpc.js:83:17
  at async Object.readAt (packages/agoric-cli/src/lib/rpc.js:119:19)
  at async Object.readFully (packages/agoric-cli/src/lib/rpc.js:141:38)
  at async storedWalletState (packages/agoric-cli/src/lib/wallet.js:176:21)
  at async Promise.all (index 1)
  at async Command.<anonymous> (packages/agoric-cli/src/commands/inter.js:563:34)
  at async packages/agoric-cli/src/bin-agops.js:76:3
  ```

### Testing Considerations

Tested manually: 
```
$ AGORIC_NET=ollinet bin/agops inter bid list --from gov1 --keyring-backend=test
{"id":"bid-1682974543140","price":"9.89 IST/IbcATOM","give":{"Bid":"10 IST"},"maxBuy":"1000000 IbcATOM","result":"Your bid has been accepted"}
{"id":"bid-1682974673998","price":"9.89 IST/IbcATOM","give":{"Bid":"10 IST"},"maxBuy":"1000000 IbcATOM","result":"Your bid has been accepted"}
```
