### PR TITLE
assetReserve upgradable

### DIFF
--- a/packages/governance/tools/puppetContractGovernor.js
+++ b/packages/governance/tools/puppetContractGovernor.js
@@ -79,6 +79,7 @@ export const start = async (zcf, privateArgs) => {
       Fail`${apiMethodName} is not a governed API.`;
 
     const { positive } = makeApiInvocationPositions(apiMethodName, methodArgs);
+    assert.typeof(apiMethodName, 'string');
 
     return E(E(governedCF).getGovernedApis())
       [apiMethodName](...methodArgs)

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -27,7 +27,6 @@ const BASIS_POINTS = 10_000n;
 /**
  * @typedef {GovernedCreatorFacet<import('../stakeFactory/stakeFactory.js').StakeFactoryCreator>} StakeFactoryCreator
  * @typedef {import('../stakeFactory/stakeFactory.js').StakeFactoryPublic} StakeFactoryPublic
- * @typedef {import('../reserve/assetReserve.js').GovernedAssetReserveFacetAccess} GovernedAssetReserveFacetAccess
  * @typedef {import('../vaultFactory/vaultFactory.js').VaultFactoryContract['publicFacet']} VaultFactoryPublicFacet
  * @typedef {import('../auction/auctioneer.js').AuctioneerPublicFacet} AuctioneerPublicFacet
  * @typedef {import('../auction/auctioneer.js').AuctioneerCreatorFacet} AuctioneerCreatorFacet

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -63,7 +63,7 @@ const BASIS_POINTS = 10_000n;
  *   psmKit: MapStore<Brand, PSMKit>,
  *   anchorBalancePayments: MapStore<Brand, Payment<'nat'>>,
  *   econCharterKit: EconCharterStartResult,
- *   reserveKit: GovernanceFacetKit<import('../reserve/assetReserve.js')['start']>,
+ *   reserveKit: GovernanceFacetKit<import('../reserve/assetReserve.js')['prepare']>,
  *   stakeFactoryKit: GovernanceFacetKit<import('../stakeFactory/stakeFactory.js')['start']>,
  *   vaultFactoryKit: GovernanceFacetKit<import('../vaultFactory/vaultFactory.js')['prepare']>,
  *   auctioneerKit: AuctioneerKit,

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -68,7 +68,7 @@ const trace = makeTracer('Reserve', false);
  * }} privateArgs
  * @param {Baggage} baggage
  */
-const start = async (zcf, privateArgs, baggage) => {
+export const prepare = async (zcf, privateArgs, baggage) => {
   // This contract mixes two styles of access to durable state. durableStores
   // are declared at the top level and referenced lexically. local state is
   // accessed via the `state` object. The latter means updates are made directly
@@ -304,10 +304,7 @@ const start = async (zcf, privateArgs, baggage) => {
     publicFacet: pFacet,
   };
 };
-
-harden(start);
-
-export { start };
+harden(prepare);
 
 /**
  * @typedef {object} ShortfallReporter
@@ -329,7 +326,7 @@ export { start };
  * @property {() => Invitation} makeAddCollateralInvitation
  */
 
-/** @typedef {Awaited<ReturnType<typeof start>>['publicFacet']} AssetReservePublicFacet */
-/** @typedef {Awaited<ReturnType<typeof start>>['creatorFacet']} AssetReserveCreatorFacet the creator facet for the governor */
+/** @typedef {Awaited<ReturnType<typeof prepare>>['publicFacet']} AssetReservePublicFacet */
+/** @typedef {Awaited<ReturnType<typeof prepare>>['creatorFacet']} AssetReserveCreatorFacet the creator facet for the governor */
 /** @typedef {OriginalAssetReserveCreatorFacet} AssetReserveLimitedCreatorFacet */
-/** @typedef {GovernorCreatorFacet<typeof start>} GovernedAssetReserveFacetAccess */
+/** @typedef {GovernorCreatorFacet<typeof prepare>} GovernedAssetReserveFacetAccess */

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -1,49 +1,20 @@
 // @jessie-check
 
-import { E, Far } from '@endo/far';
-import { AmountMath } from '@agoric/ertp';
 import { handleParamGovernance } from '@agoric/governance';
-import { atomicTransfer } from '@agoric/zoe/src/contractSupport/index.js';
-import { provideDurableMapStore, prepareKindMulti } from '@agoric/vat-data';
 import { makeTracer } from '@agoric/internal';
+import {
+  prepareRecorderKitMakers,
+  provideAll,
+} from '@agoric/zoe/src/contractSupport/index.js';
+import { prepareAssetReserveKit } from './assetReserveKit.js';
 
-import { makeMetricsPublisherKit } from '../contractSupport.js';
-
-const { Fail, quote: q } = assert;
-
-const trace = makeTracer('Reserve', false);
-
-/**
- * @typedef {object} MetricsNotification
- *
- * @property {AmountKeywordRecord} allocations
- * @property {Amount<'nat'>} shortfallBalance shortfall from liquidation that
- *   has not yet been compensated.
- * @property {Amount<'nat'>} totalFeeMinted total Fee tokens minted to date
- * @property {Amount<'nat'>} totalFeeBurned total Fee tokens burned to date
- */
+const trace = makeTracer('AR', false);
 
 /**
  * @typedef {{
  *   increaseLiquidationShortfall: (increase: Amount) => void
  *   reduceLiquidationShortfall: (reduction: Amount) => void
  * }} ShortfallReportingFacet
- */
-
-/**
- * @typedef {{
- *   state: {
- *     totalFeeBurned: Amount<'nat'>,
- *     totalFeeMinted: Amount<'nat'>,
- *   },
- *   facets: {
- *     publicFacet: {},
- *     creatorFacet: {},
- *     shortfallReportingFacet: ShortfallReportingFacet,
- *     limitedCreatorFacet: {},
- *     governedApis: {},
- *      },
- * }} MethodContext
  */
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
@@ -69,23 +40,16 @@ const trace = makeTracer('Reserve', false);
  * @param {Baggage} baggage
  */
 export const prepare = async (zcf, privateArgs, baggage) => {
+  trace('prepare', Object.keys(privateArgs), [...baggage.keys()]);
   // This contract mixes two styles of access to durable state. durableStores
   // are declared at the top level and referenced lexically. local state is
   // accessed via the `state` object. The latter means updates are made directly
   // to state and don't require reference to baggage.
 
-  /**
-   * Used to look up the unique keyword for each brand, including Fee brand.
-   *
-   * @type {MapStore<Brand, Keyword>}
-   */
-  const keywordForBrand = provideDurableMapStore(baggage, 'keywordForBrand');
-  /**
-   * Used to look up the brands for keywords, excluding Fee because it's a special case.
-   *
-   * @type {MapStore<Keyword, Brand>}
-   */
-  const brandForKeyword = provideDurableMapStore(baggage, 'brandForKeyword');
+  const { makeRecorderKit } = prepareRecorderKitMakers(
+    baggage,
+    privateArgs.marshaller,
+  );
 
   /** @type {() => Promise<ZCFMint<'nat'>>} */
   const takeFeeMint = async () => {
@@ -100,208 +64,46 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     baggage.init('feeMint', feeMintTemp);
     return feeMintTemp;
   };
+  trace('awaiting takeFeeMint');
   const feeMint = await takeFeeMint();
-  const feeKit = feeMint.getIssuerRecord();
-  const emptyAmount = AmountMath.makeEmpty(feeKit.brand);
+  const makeAssetReserveKit = await prepareAssetReserveKit(baggage, {
+    feeMint,
+    makeRecorderKit,
+    // eslint-disable-next-line @jessie.js/no-nested-await -- spurious
+    storageNode: await privateArgs.storageNode,
+    zcf,
+  });
 
-  /**
-   * @param {Brand} brand
-   * @param {Keyword} keyword
-   */
-  const saveBrandKeyword = (brand, keyword) => {
-    keywordForBrand.init(brand, keyword);
-    brandForKeyword.init(keyword, brand);
-  };
+  const { assetReserveKit } = await provideAll(baggage, {
+    assetReserveKit: makeAssetReserveKit,
+  });
 
-  saveBrandKeyword(feeKit.brand, 'Fee');
-  // no need to saveIssuer() b/c registerFeeMint did it
-
-  const { augmentVirtualPublicFacet, makeVirtualGovernorFacet } =
-    await handleParamGovernance(
-      zcf,
-      privateArgs.initialPoserInvitation,
-      {},
-      privateArgs.storageNode,
-      privateArgs.marshaller,
-    );
-
-  /**
-   * @param {MethodContext} _context
-   * @param {Issuer} issuer
-   * @param {string} keyword
-   */
-  const addIssuer = async (_context, issuer, keyword) => {
-    const brand = await E(issuer).getBrand();
-    trace('addIssuer', { brand, keyword });
-    assert(
-      keyword !== 'Fee' && brand !== feeKit.brand,
-      `'Fee' brand is a special case handled by the reserve contract`,
-    );
-
-    trace('addIssuer storing', {
-      keyword,
-      brand,
-    });
-
-    saveBrandKeyword(brand, keyword);
-    await zcf.saveIssuer(issuer, keyword);
-  };
-
-  const getKeywordForBrand = brand => {
-    keywordForBrand.has(brand) ||
-      Fail`Issuer not defined for brand ${q(brand)}; first call addIssuer()`;
-    return keywordForBrand.get(brand);
-  };
-
-  // We keep the associated liquidity tokens in the same seat
-  const { zcfSeat: collateralSeat } = zcf.makeEmptySeatKit();
-  const getAllocations = () => {
-    return collateralSeat.getCurrentAllocation();
-  };
-
-  /**
-   * Anyone can deposit any assets to the reserve
-   *
-   * @param {*} state
-   */
-  const addCollateralHook = state => async (/** @type {ZCFSeat} */ seat) => {
-    const {
-      give: { Collateral: amountIn },
-    } = seat.getProposal();
-
-    const collateralKeyword = getKeywordForBrand(amountIn.brand);
-
-    atomicTransfer(
-      zcf,
-      seat,
-      collateralSeat,
-      { Collateral: amountIn },
-      { [collateralKeyword]: amountIn },
-    );
-    seat.exit();
-    // eslint-disable-next-line no-use-before-define
-    updateMetrics({ state });
-
-    trace('received collateral', amountIn);
-    return 'added Collateral to the Reserve';
-  };
-
-  const makeAddCollateralInvitation = ({ state }) =>
-    zcf.makeInvitation(addCollateralHook(state), 'Add Collateral');
-
-  /** @type {import('../contractSupport.js').MetricsPublisherKit<MetricsNotification>} */
-  const { metricsPublication, metricsSubscription } = makeMetricsPublisherKit(
+  trace('awaiting handleParamGovernance');
+  const { makeDurableGovernorFacet } = await handleParamGovernance(
+    zcf,
+    privateArgs.initialPoserInvitation,
+    {},
     privateArgs.storageNode,
     privateArgs.marshaller,
   );
 
-  const updateMetrics = ({ state }) => {
-    const metrics = harden({
-      allocations: getAllocations(),
-      shortfallBalance: state.shortfallBalance,
-      totalFeeMinted: state.totalFeeMinted,
-      totalFeeBurned: state.totalFeeBurned,
-    });
-    metricsPublication.updateState(metrics);
-  };
-
-  const increaseLiquidationShortfall = ({ state }, shortfall) => {
-    state.shortfallBalance = AmountMath.add(state.shortfallBalance, shortfall);
-    updateMetrics({ state });
-  };
-
-  const reduceLiquidationShortfall = ({ state }, reduction) => {
-    if (AmountMath.isGTE(reduction, state.shortfallBalance)) {
-      state.shortfallBalance = emptyAmount;
-    } else {
-      state.shortfallBalance = AmountMath.subtract(
-        state.shortfallBalance,
-        reduction,
-      );
-    }
-    updateMetrics({ state });
-  };
-
-  const init = () => {
-    const initialState = {
-      totalFeeMinted: emptyAmount,
-      totalFeeBurned: emptyAmount,
-      shortfallBalance: emptyAmount,
-    };
-    updateMetrics({ state: initialState });
-    return initialState;
-  };
-
-  /**
-   *
-   * @param {MethodContext} context
-   * @param {Amount<'nat'>} reduction
-   * @returns {void}
-   */
-  const burnFeesToReduceShortfall = ({ state }, reduction) => {
-    trace('burnFeesToReduceShortfall', reduction);
-    reduction = AmountMath.coerce(feeKit.brand, reduction);
-    const feeKeyword = keywordForBrand.get(feeKit.brand);
-    const feeBalance = collateralSeat.getAmountAllocated(feeKeyword);
-    const amountToBurn = AmountMath.min(reduction, feeBalance);
-    if (AmountMath.isEmpty(amountToBurn)) {
-      return;
-    }
-
-    feeMint.burnLosses(harden({ [feeKeyword]: amountToBurn }), collateralSeat);
-    state.totalFeeBurned = AmountMath.add(state.totalFeeBurned, amountToBurn);
-    updateMetrics({ state });
-  };
-
-  const shortfallReportingFacet = {
-    increaseLiquidationShortfall,
-    // currently exposed for testing. Maybe it only gets called internally?
-    reduceLiquidationShortfall,
-  };
-
-  /** @param {MethodContext} context */
-  const makeShortfallReportingInvitation = ({ facets }) => {
-    const handleShortfallReportingOffer = () => {
-      return facets.shortfallReportingFacet;
-    };
-
-    return zcf.makeInvitation(
-      handleShortfallReportingOffer,
-      'getFacetForReportingShortfalls',
-    );
-  };
-
-  const { governorFacet, limitedCreatorFacet } = makeVirtualGovernorFacet({
-    makeAddCollateralInvitation,
-    // add makeRedeemLiquidityTokensInvitation later. For now just store them
-    getAllocations,
-    addIssuer,
-    makeShortfallReportingInvitation,
-    getMetrics: () => metricsSubscription,
-  });
-
-  const governedApis = { burnFeesToReduceShortfall };
-
-  const publicFacet = augmentVirtualPublicFacet(
-    Far('Collateral Reserve public', {
-      makeAddCollateralInvitation,
-    }),
+  const { governorFacet } = makeDurableGovernorFacet(
+    baggage,
+    assetReserveKit.machine,
+    // reconstruct facet so that the keys are enumerable and that the client can't depend on object identity
+    {
+      burnFeesToReduceShortfall: reduction =>
+        assetReserveKit.governedApis.burnFeesToReduceShortfall(reduction),
+    },
   );
 
-  const makeAssetReserve = prepareKindMulti(baggage, 'assetReserve', init, {
-    publicFacet,
-    creatorFacet: governorFacet,
-    shortfallReportingFacet,
-    limitedCreatorFacet,
-    governedApis,
-  });
-
-  const { creatorFacet, publicFacet: pFacet } = makeAssetReserve();
   return {
-    /** @type {GovernedCreatorFacet<OriginalAssetReserveCreatorFacet>} */
-    // @ts-expect-error cast
-    creatorFacet,
-    publicFacet: pFacet,
+    /** @type {GovernedCreatorFacet<typeof assetReserveKit.machine>} */
+    creatorFacet: governorFacet,
+    /** @type {GovernedPublicFacet<typeof assetReserveKit.public>} */
+    // cast due to missing governance mixins
+    // XXX https://github.com/Agoric/agoric-sdk/issues/5200
+    publicFacet: /** @type {any} */ (assetReserveKit.public),
   };
 };
 harden(prepare);
@@ -313,20 +115,11 @@ harden(prepare);
  */
 
 /**
- * @typedef {object} OriginalAssetReserveCreatorFacet
- * @property {() => Invitation} makeAddCollateralInvitation
- * @property {() => Allocation} getAllocations
+ * @typedef {object} AssetReserveLimitedCreatorFacet
  * @property {(issuer: Issuer, kwd: string) => void} addIssuer
- * @property {() => Invitation<ShortfallReporter>} makeShortfallReportingInvitation
- * @property {() => StoredSubscription<MetricsNotification>} getMetrics
- */
-
-/**
- * @typedef {object} OriginalAssetReservePublicFacet
- * @property {() => Invitation} makeAddCollateralInvitation
+ * @property {() => Allocation} getAllocations
+ * @property {() => Promise<Invitation<ShortfallReporter>>} makeShortfallReportingInvitation
  */
 
 /** @typedef {Awaited<ReturnType<typeof prepare>>['publicFacet']} AssetReservePublicFacet */
 /** @typedef {Awaited<ReturnType<typeof prepare>>['creatorFacet']} AssetReserveCreatorFacet the creator facet for the governor */
-/** @typedef {OriginalAssetReserveCreatorFacet} AssetReserveLimitedCreatorFacet */
-/** @typedef {GovernorCreatorFacet<typeof prepare>} GovernedAssetReserveFacetAccess */

--- a/packages/inter-protocol/src/reserve/assetReserveKit.js
+++ b/packages/inter-protocol/src/reserve/assetReserveKit.js
@@ -1,0 +1,303 @@
+import { Fail } from '@agoric/assert';
+import { AmountMath, AmountShape, IssuerShape } from '@agoric/ertp';
+import { makeTracer } from '@agoric/internal';
+import { M, makeScalarBigMapStore, prepareExoClassKit } from '@agoric/vat-data';
+import { atomicTransfer } from '@agoric/zoe/src/contractSupport/atomicTransfer.js';
+import {
+  makeRecorderTopic,
+  SubscriberShape,
+  TopicsRecordShape,
+} from '@agoric/zoe/src/contractSupport/topics.js';
+import { AmountKeywordRecordShape } from '@agoric/zoe/src/typeGuards.js';
+import { E } from '@endo/eventual-send';
+import { UnguardedHelperI } from '../typeGuards.js';
+
+const { quote: q } = assert;
+
+const trace = makeTracer('ReserveKit', false);
+
+/**
+ * @typedef {object} MetricsNotification
+ *
+ * @property {AmountKeywordRecord} allocations
+ * @property {Amount<'nat'>} shortfallBalance shortfall from liquidation that
+ *   has not yet been compensated.
+ * @property {Amount<'nat'>} totalFeeMinted total Fee tokens minted to date
+ * @property {Amount<'nat'>} totalFeeBurned total Fee tokens burned to date
+ */
+
+/**
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {{
+ * feeMint: ZCFMint<'nat'>,
+ * makeRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit,
+ * storageNode: StorageNode,
+ * zcf: ZCF}} powers
+ */
+export const prepareAssetReserveKit = async (
+  baggage,
+  { feeMint, makeRecorderKit, storageNode, zcf },
+) => {
+  trace('prepareAssetReserveKit', [...baggage.keys()]);
+  const feeKit = feeMint.getIssuerRecord();
+  const emptyAmount = AmountMath.makeEmpty(feeKit.brand);
+
+  const makeAssetReserveKitInternal = prepareExoClassKit(
+    baggage,
+    'AssetReserveKit',
+    {
+      helper: UnguardedHelperI,
+      governedApis: M.interface('AssetReserve governedApis', {
+        burnFeesToReduceShortfall: M.call(AmountShape).returns(),
+      }),
+      machine: M.interface('AssetReserve machine', {
+        addIssuer: M.call(IssuerShape, M.string()).returns(M.promise()),
+        getAllocations: M.call().returns(AmountKeywordRecordShape),
+        makeShortfallReportingInvitation: M.call().returns(M.promise()),
+      }),
+      public: M.interface('AssetReserve public', {
+        makeAddCollateralInvitation: M.call().returns(M.promise()),
+        getMetrics: M.call().returns(SubscriberShape),
+        getPublicTopics: M.call().returns(TopicsRecordShape),
+      }),
+      shortfallReportingFacet: M.interface('AssetReserve shortfall reporter', {
+        increaseLiquidationShortfall: M.call(AmountShape).returns(),
+        reduceLiquidationShortfall: M.call(AmountShape).returns(),
+      }),
+    },
+    /**
+     *
+     * @param {StorageNode} metricsNode
+     */
+    metricsNode => {
+      /**
+       * Used to look up the unique keyword for each brand, including Fee brand.
+       *
+       * @type {MapStore<Brand, Keyword>}
+       */
+      const keywordForBrand = makeScalarBigMapStore('keywordForBrand', {
+        durable: true,
+      });
+      /**
+       * Used to look up the brands for keywords, excluding Fee because it's a special case.
+       *
+       * @type {MapStore<Keyword, Brand>}
+       */
+      const brandForKeyword = makeScalarBigMapStore('brandForKeyword', {
+        durable: true,
+      });
+
+      return {
+        brandForKeyword,
+        // We keep the associated liquidity tokens in the same seat
+        collateralSeat: zcf.makeEmptySeatKit().zcfSeat,
+        keywordForBrand,
+        metricsKit: makeRecorderKit(
+          metricsNode,
+          /** @type {import('@agoric/zoe/src/contractSupport/recorder.js').TypedMatcher<MetricsNotification>} */ (
+            M.any()
+          ),
+        ),
+        totalFeeMinted: emptyAmount,
+        totalFeeBurned: emptyAmount,
+        shortfallBalance: emptyAmount,
+      };
+    },
+    {
+      helper: {
+        /** @param {Brand} brand */
+        getKeywordForBrand(brand) {
+          const { keywordForBrand } = this.state;
+          keywordForBrand.has(brand) ||
+            Fail`Issuer not defined for brand ${q(
+              brand,
+            )}; first call addIssuer()`;
+          return keywordForBrand.get(brand);
+        },
+
+        /**
+         * @param {Brand} brand
+         * @param {Keyword} keyword
+         */
+        saveBrandKeyword(brand, keyword) {
+          trace('saveBrandKeyword', brand, keyword);
+          const { keywordForBrand, brandForKeyword } = this.state;
+          keywordForBrand.init(brand, keyword);
+          brandForKeyword.init(keyword, brand);
+        },
+
+        writeMetrics() {
+          const { state } = this;
+          const metrics = harden({
+            allocations: state.collateralSeat.getCurrentAllocation(),
+            shortfallBalance: state.shortfallBalance,
+            totalFeeMinted: state.totalFeeMinted,
+            totalFeeBurned: state.totalFeeBurned,
+          });
+          state.metricsKit.recorder.write(metrics);
+        },
+      },
+      governedApis: {
+        /**
+         *
+         * @param {Amount<'nat'>} reduction
+         * @returns {void}
+         */
+        burnFeesToReduceShortfall(reduction) {
+          const { facets, state } = this;
+          trace('burnFeesToReduceShortfall', reduction);
+          reduction = AmountMath.coerce(feeKit.brand, reduction);
+          const feeKeyword = state.keywordForBrand.get(feeKit.brand);
+          const feeBalance =
+            state.collateralSeat.getAmountAllocated(feeKeyword);
+          const amountToBurn = AmountMath.min(reduction, feeBalance);
+          if (AmountMath.isEmpty(amountToBurn)) {
+            return;
+          }
+
+          feeMint.burnLosses(
+            harden({ [feeKeyword]: amountToBurn }),
+            state.collateralSeat,
+          );
+          state.totalFeeBurned = AmountMath.add(
+            state.totalFeeBurned,
+            amountToBurn,
+          );
+          facets.helper.writeMetrics();
+        },
+      },
+      machine: {
+        // add makeRedeemLiquidityTokensInvitation later. For now just store them
+        /**
+         * @param {Issuer} issuer
+         * @param {string} keyword
+         */
+        async addIssuer(issuer, keyword) {
+          const brand = await E(issuer).getBrand();
+          trace('addIssuer', { brand, keyword });
+          assert(
+            keyword !== 'Fee' && brand !== feeKit.brand,
+            `'Fee' brand is a special case handled by the reserve contract`,
+          );
+
+          trace('addIssuer storing', {
+            keyword,
+            brand,
+          });
+
+          this.facets.helper.saveBrandKeyword(brand, keyword);
+          await zcf.saveIssuer(issuer, keyword);
+        },
+
+        /** @deprecated use getPublicTopics metrics allocation */
+        getAllocations() {
+          return this.state.collateralSeat.getCurrentAllocation();
+        },
+
+        makeShortfallReportingInvitation() {
+          const { facets } = this;
+          const handleShortfallReportingOffer = () => {
+            return facets.shortfallReportingFacet;
+          };
+
+          return zcf.makeInvitation(
+            handleShortfallReportingOffer,
+            'getFacetForReportingShortfalls',
+          );
+        },
+      },
+      /**
+       * XXX missing governance public methods https://github.com/Agoric/agoric-sdk/issues/5200
+       */
+      public: {
+        /**
+         * Anyone can deposit any assets to the reserve
+         */
+        makeAddCollateralInvitation() {
+          /** @type {OfferHandler<Promise<string>>} */
+          const handler = async seat => {
+            const {
+              give: { Collateral: amountIn },
+            } = seat.getProposal();
+            const { facets, state } = this;
+            const { helper } = facets;
+
+            const collateralKeyword = helper.getKeywordForBrand(amountIn.brand);
+
+            atomicTransfer(
+              zcf,
+              seat,
+              state.collateralSeat,
+              { Collateral: amountIn },
+              { [collateralKeyword]: amountIn },
+            );
+            seat.exit();
+            helper.writeMetrics();
+
+            trace('received collateral', amountIn);
+            return 'added Collateral to the Reserve';
+          };
+          return zcf.makeInvitation(handler, 'Add Collateral');
+        },
+        /** @deprecated */
+        getMetrics() {
+          return this.state.metricsKit.subscriber;
+        },
+        getPublicTopics() {
+          return {
+            metrics: makeRecorderTopic(
+              'Asset Reserve metrics',
+              this.state.metricsKit,
+            ),
+          };
+        },
+      },
+      shortfallReportingFacet: {
+        /**
+         * @param {Amount<"nat">} shortfall
+         */
+        increaseLiquidationShortfall(shortfall) {
+          const { facets, state } = this;
+          state.shortfallBalance = AmountMath.add(
+            state.shortfallBalance,
+            shortfall,
+          );
+          facets.helper.writeMetrics();
+        },
+
+        // currently exposed for testing. Maybe it only gets called internally?
+        /**
+         * @param {Amount<"nat">} reduction
+         */
+        reduceLiquidationShortfall(reduction) {
+          const { state } = this;
+          if (AmountMath.isGTE(reduction, state.shortfallBalance)) {
+            state.shortfallBalance = emptyAmount;
+          } else {
+            state.shortfallBalance = AmountMath.subtract(
+              state.shortfallBalance,
+              reduction,
+            );
+          }
+          this.facets.helper.writeMetrics();
+        },
+      },
+    },
+    {
+      finish: ({ facets: { helper } }) => {
+        // no need to saveIssuer() b/c registerFeeMint did it
+        helper.saveBrandKeyword(feeKit.brand, 'Fee');
+
+        helper.writeMetrics();
+      },
+    },
+  );
+
+  const makeAssetReserveKit = async () => {
+    const metricsNode = await E(storageNode).makeChildNode('metrics');
+    return makeAssetReserveKitInternal(metricsNode);
+  };
+  return makeAssetReserveKit;
+};
+harden(prepareAssetReserveKit);
+/** @typedef {ReturnType<Awaited<ReturnType<typeof prepareAssetReserveKit>>>} AssetReserveKit */

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -489,6 +489,7 @@ export const prepareVaultManagerKit = (
 
         /** @type {(accounting: { overage: Amount<'nat'>, shortfall: Amount<'nat'> }) => void} */
         recordShortfallAndProceeds(accounting) {
+          trace('recordShortfallAndProceeds', accounting);
           const { state } = this;
 
           const { overage, shortfall } = accounting;

--- a/packages/inter-protocol/test/auction/tools.js
+++ b/packages/inter-protocol/test/auction/tools.js
@@ -18,7 +18,7 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
  * autoRefund: Installation<import('@agoric/zoe/src/contracts/automaticRefund').start>,
  * auctioneer: Installation<import('../../src/auction/auctioneer').start>,
  * governor: Installation<import('@agoric/governance/src/contractGovernor').start>,
- * reserve: Installation<import('../../src/reserve/assetReserve.js').start>,
+ * reserve: Installation<import('../../src/reserve/assetReserve.js').prepare>,
  * }} AuctionTestInstallations
  */
 

--- a/packages/inter-protocol/test/metrics.js
+++ b/packages/inter-protocol/test/metrics.js
@@ -49,8 +49,12 @@ export const subscriptionTracker = async (t, subscription) => {
     const actualDelta = diff(prevNotif.value, notif.value);
     t.deepEqual(actualDelta, expectedDelta, 'Unexpected delta');
   };
+  const assertLike = async expectedState => {
+    notif = await metrics.getUpdateSince(notif?.updateCount);
+    t.like(notif.value, expectedState, 'Unexpected state');
+  };
   const assertState = async expectedState => {
-    notif = await metrics.getUpdateSince(notif.updateCount);
+    notif = await metrics.getUpdateSince(notif?.updateCount);
     t.deepEqual(notif.value, expectedState, 'Unexpected state');
   };
   const assertNoUpdate = async () => {
@@ -60,6 +64,7 @@ export const subscriptionTracker = async (t, subscription) => {
   return {
     assertChange,
     assertInitial,
+    assertLike,
     assertState,
     getLastNotif,
     assertNoUpdate,

--- a/packages/inter-protocol/test/metrics.js
+++ b/packages/inter-protocol/test/metrics.js
@@ -1,4 +1,8 @@
-import { makeNotifierFromAsyncIterable, subscribeEach } from '@agoric/notifier';
+import {
+  makeNotifierFromAsyncIterable,
+  makeNotifierFromSubscriber,
+  subscribeEach,
+} from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
 import { diff } from 'deep-object-diff';
 
@@ -11,11 +15,22 @@ const trace = makeTracer('TestMetrics', false);
 
 /**
  * @template {object} N
+ * @param {AsyncIterable<N, N> | import('@agoric/zoe/src/contractSupport/topics.js').PublicTopic<N>} mixed
+ */
+const asNotifier = mixed => {
+  if ('subscriber' in mixed) {
+    return makeNotifierFromSubscriber(mixed.subscriber);
+  }
+  return makeNotifierFromAsyncIterable(mixed);
+};
+
+/**
+ * @template {object} N
  * @param {import('ava').ExecutionContext} t
- * @param {AsyncIterable<N, N>} subscription
+ * @param {AsyncIterable<N, N> | import('@agoric/zoe/src/contractSupport/topics.js').PublicTopic<N>} subscription
  */
 export const subscriptionTracker = async (t, subscription) => {
-  const metrics = makeNotifierFromAsyncIterable(subscription);
+  const metrics = asNotifier(subscription);
   /** @type {UpdateRecord<N>} */
   let notif;
   const getLastNotif = () => notif;

--- a/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
@@ -1,0 +1,264 @@
+// @ts-check
+
+import { Fail, NonNullish } from '@agoric/assert';
+import { makeIssuerKit } from '@agoric/ertp';
+import { CONTRACT_ELECTORATE, ParamTypes } from '@agoric/governance';
+import { deeplyFulfilledObject, makeTracer } from '@agoric/internal';
+import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
+import { makeNameHubKit } from '@agoric/vats';
+import { makeBoard } from '@agoric/vats/src/lib-board.js';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
+import { withAmountUtils } from '../../supports.js';
+
+const trace = makeTracer('BootFAUpg');
+
+export const arV1BundleName = 'assetReserveV1';
+
+const moola = withAmountUtils(makeIssuerKit('moola'));
+
+export const buildRootObject = async () => {
+  const storageKit = makeFakeStorageKit('assetReserveUpgradeTest');
+  const { nameAdmin: namesByAddressAdmin } = makeNameHubKit();
+  const timer = buildManualTimer();
+  const marshaller = makeBoard().getReadonlyMarshaller();
+
+  const { promise: committeeCreator, ...ccPK } = makePromiseKit();
+
+  /** @type {ZoeService} */
+  let zoeService;
+
+  /** @type {FeeMintAccess} */
+  let feeMintAccess;
+
+  /** @type {Subscriber<import('../../../src/reserve/assetReserveKit.js').MetricsNotification>} */
+  let metrics;
+  /** @type {UpdateRecord<import('../../../src/reserve/assetReserveKit.js').MetricsNotification>} */
+  let metricsRecord;
+
+  /** @type {VatAdminSvc} */
+  let vatAdmin;
+
+  let initialPoserInvitation;
+  let poserInvitationAmount;
+
+  // for startInstance
+  /**
+   * @type {{
+   * committee?: Installation<import('@agoric/governance/src/committee')['prepare']>,
+   * assetReserveV1?: Installation<import('../../../src/reserve/assetReserve')['prepare']>,
+   * puppetContractGovernor?: Installation<import('@agoric/governance/tools/puppetContractGovernor')['start']>,
+   * }}
+   */
+  const installations = {};
+
+  /** @type {import('@agoric/governance/tools/puppetContractGovernor').PuppetContractGovernorKit<import('../../../src/reserve/assetReserve.js').prepare>} */
+  let governorFacets;
+  /** @type {ReturnType<Awaited<ReturnType<import('../../../src/reserve/assetReserve.js').prepare>>['creatorFacet']['getLimitedCreatorFacet']>} */
+  let arLimitedFacet;
+
+  /** @type {Omit<import('@agoric/zoe/src/zoeService/utils.js').StartParams<import('../../../src/reserve/assetReserve.js').prepare>['terms'], 'issuers' | 'brands'>} */
+  const arTerms = {
+    governedParams: {
+      // @ts-expect-error missing value
+      [CONTRACT_ELECTORATE]: {
+        type: ParamTypes.INVITATION,
+      },
+    },
+  };
+  const staticPrivateArgs = {
+    storageNode: storageKit.rootNode,
+    marshaller,
+    namesByAddressAdmin,
+  };
+
+  /**
+   * @param {Amount<'nat'>} amt
+   */
+  const addCollateral = async amt => {
+    const arPublicFacet = await E(governorFacets.creatorFacet).getPublicFacet();
+    const seat = E(zoeService).offer(
+      E(arPublicFacet).makeAddCollateralInvitation(),
+      harden({
+        give: { Collateral: amt },
+      }),
+      harden({ Collateral: moola.mint.mintPayment(amt) }),
+    );
+    return seat;
+  };
+
+  return Far('root', {
+    bootstrap: async (vats, devices) => {
+      vatAdmin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      ({ feeMintAccess, zoeService } = await E(vats.zoe).buildZoe(
+        vatAdmin,
+        undefined,
+        'zcf',
+      ));
+
+      const v1BundleId = await E(vatAdmin).getBundleIDByName(arV1BundleName);
+      v1BundleId || Fail`bundleId must not be empty`;
+      installations.assetReserveV1 = await E(zoeService).installBundleID(
+        v1BundleId,
+      );
+
+      installations.puppetContractGovernor = await E(
+        zoeService,
+      ).installBundleID(
+        await E(vatAdmin).getBundleIDByName('puppetContractGovernor'),
+      );
+
+      installations.committee = await E(zoeService).installBundleID(
+        await E(vatAdmin).getBundleIDByName('committee'),
+      );
+      const ccStartResult = await E(zoeService).startInstance(
+        installations.committee,
+        harden({}),
+        {
+          committeeName: 'Demos',
+          committeeSize: 1,
+        },
+        {
+          storageNode: storageKit.rootNode.makeChildNode('thisCommittee'),
+          marshaller,
+        },
+      );
+      ccPK.resolve(ccStartResult.creatorFacet);
+
+      const poserInvitationP = E(committeeCreator).getPoserInvitation();
+      [initialPoserInvitation, poserInvitationAmount] = await Promise.all([
+        poserInvitationP,
+        E(E(zoeService).getInvitationIssuer()).getAmountOf(poserInvitationP),
+      ]);
+    },
+
+    buildV1: async () => {
+      trace(`BOOT buildV1 start`);
+      // build the contract vat from ZCF and the contract bundlecap
+
+      arTerms.governedParams[CONTRACT_ELECTORATE].value = poserInvitationAmount;
+
+      const governorTerms = await deeplyFulfilledObject(
+        harden({
+          timer,
+          governedContractInstallation: NonNullish(
+            installations.assetReserveV1,
+          ),
+          governed: {
+            terms: arTerms,
+            label: 'assetReserveV1',
+          },
+        }),
+      );
+      trace('got governorTerms', governorTerms);
+
+      // Complete round-trip without upgrade
+      trace(`BOOT buildV1 startInstance`);
+      // @ts-expect-error
+      governorFacets = await E(zoeService).startInstance(
+        NonNullish(installations.puppetContractGovernor),
+        undefined,
+        governorTerms,
+        {
+          governed: {
+            ...staticPrivateArgs,
+            feeMintAccess,
+            initialPoserInvitation,
+          },
+        },
+      );
+      trace('BOOT buildV1 started instance');
+
+      // @ts-expect-error XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
+      arLimitedFacet = await E(governorFacets.creatorFacet).getCreatorFacet();
+
+      return true;
+    },
+
+    testFunctionality1: async () => {
+      const arPublicFacet = await E(
+        governorFacets.creatorFacet,
+      ).getPublicFacet();
+
+      const publicTopics = await E(arPublicFacet).getPublicTopics();
+      assert.equal(publicTopics.metrics.description, 'Asset Reserve metrics');
+      metrics = publicTopics.metrics.subscriber;
+      metricsRecord = await E(metrics).getUpdateSince();
+      assert.equal(metricsRecord.updateCount, 1n);
+      assert.equal(metricsRecord.value.shortfallBalance.value, 0n);
+      assert.equal(metricsRecord.value.totalFeeBurned.value, 0n);
+      assert.equal(metricsRecord.value.totalFeeMinted.value, 0n);
+
+      await E(arLimitedFacet).addIssuer(moola.issuer, 'Moola');
+
+      const amt = moola.make(100_000n);
+      const collateralSeat = addCollateral(amt);
+
+      assert.equal(
+        await E(collateralSeat).getOfferResult(),
+        'added Collateral to the Reserve',
+      );
+      // new record
+      metricsRecord = await E(metrics).getUpdateSince(
+        metricsRecord.updateCount,
+      );
+      // added collateral is recorded
+      assert.equal(metricsRecord.value.allocations.Moola.value, amt.value);
+    },
+
+    nullUpgradeV1: async () => {
+      trace(`BOOT nullUpgradeV1 start`);
+
+      const bundleId = await E(vatAdmin).getBundleIDByName(arV1BundleName);
+
+      trace(`BOOT nullUpgradeV1 upgradeContract`);
+      const arAdminFacet = await E(governorFacets.creatorFacet).getAdminFacet();
+      const upgradeResult = await E(arAdminFacet).upgradeContract(bundleId, {
+        ...staticPrivateArgs,
+        initialPoserInvitation,
+      });
+      assert.equal(upgradeResult.incarnationNumber, 1);
+      trace(`BOOT nullUpgradeV1 upgradeContract completed`);
+
+      await timer.tickN(1);
+      return true;
+    },
+
+    testFunctionality2: async () => {
+      const arPublicFacet = await E(
+        governorFacets.creatorFacet,
+      ).getPublicFacet();
+
+      const publicTopics = await E(arPublicFacet).getPublicTopics();
+      assert.equal(metrics, publicTopics.metrics.subscriber);
+
+      metricsRecord = await E(metrics).getUpdateSince();
+
+      // same as last
+      assert.equal(metricsRecord.updateCount, 2n);
+
+      // add more collateral
+      const amt = moola.make(20_000n);
+      const collateralSeat = addCollateral(amt);
+
+      assert.equal(
+        await E(collateralSeat).getOfferResult(),
+        'added Collateral to the Reserve',
+      );
+      // new record
+      metricsRecord = await E(metrics).getUpdateSince(
+        metricsRecord.updateCount,
+      );
+      // collateral continued up from last state
+      assert.equal(
+        metricsRecord.value.allocations.Moola.value,
+        100_000n + amt.value,
+      );
+    },
+
+    // this test doesn't upgrade to a new bundle because we have coverage elsewhere that
+    // a new bundle will replace the behavior of the prior bundle
+  });
+};

--- a/packages/inter-protocol/test/swingsetTests/reserve/test-assetReserve-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/test-assetReserve-upgrade.js
@@ -1,0 +1,89 @@
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { assert } from '@agoric/assert';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { resolve as importMetaResolve } from 'import-meta-resolve';
+
+import { buildVatController } from '@agoric/swingset-vat';
+import { arV1BundleName } from './bootstrap-assetReserve-upgrade.js';
+
+// so paths can be expresssed relative to this file and made absolute
+const bfile = name => new URL(name, import.meta.url).pathname;
+
+test('assetReserve service upgrade', async t => {
+  /** @type {SwingSetConfig} */
+  const config = {
+    includeDevDependencies: true, // test's bootstrap has some deps not needed in production
+    bundleCachePath: 'bundles/',
+    bootstrap: 'bootstrap',
+    vats: {
+      bootstrap: {
+        // TODO refactor to use bootstrap-relay.js
+        sourceSpec: bfile('bootstrap-assetReserve-upgrade.js'),
+      },
+      zoe: {
+        sourceSpec: await importMetaResolve(
+          '@agoric/vats/src/vat-zoe.js',
+          import.meta.url,
+        ).then(href => new URL(href).pathname),
+      },
+    },
+    bundles: {
+      zcf: {
+        sourceSpec: await importMetaResolve(
+          '@agoric/zoe/src/contractFacet/vatRoot.js',
+          import.meta.url,
+        ).then(href => new URL(href).pathname),
+      },
+      committee: {
+        sourceSpec: await importMetaResolve(
+          '@agoric/governance/src/committee.js',
+          import.meta.url,
+        ).then(href => new URL(href).pathname),
+      },
+      puppetContractGovernor: {
+        sourceSpec: await importMetaResolve(
+          '@agoric/governance/tools/puppetContractGovernor.js',
+          import.meta.url,
+        ).then(href => new URL(href).pathname),
+      },
+      [arV1BundleName]: {
+        sourceSpec: await importMetaResolve(
+          '@agoric/inter-protocol/src/reserve/assetReserve.js',
+          import.meta.url,
+        ).then(href => new URL(href).pathname),
+      },
+    },
+  };
+
+  t.log('buildVatController');
+  const c = await buildVatController(config);
+  c.pinVatRoot('bootstrap');
+  t.log('run controller');
+  await c.run();
+
+  const run = async (name, args = []) => {
+    assert(Array.isArray(args));
+    const kpid = c.queueToVatRoot('bootstrap', name, args);
+    await c.run();
+    const status = c.kpStatus(kpid);
+    const capdata = c.kpResolution(kpid);
+    return [status, capdata];
+  };
+
+  t.log('create initial version');
+  const [buildV1] = await run('buildV1', []);
+  t.is(buildV1, 'fulfilled');
+
+  t.log('smoke test of functionality');
+  const [testFunctionality1] = await run('testFunctionality1', []);
+  t.is(testFunctionality1, 'fulfilled');
+
+  t.log('perform null upgrade');
+  const [nullUpgradeV1] = await run('nullUpgradeV1', []);
+  t.is(nullUpgradeV1, 'fulfilled');
+
+  t.log('smoke test of functionality');
+  const [testFunctionality2] = await run('testFunctionality2', []);
+  t.is(testFunctionality2, 'fulfilled');
+});

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -201,7 +201,8 @@ const setupServices = async (
   /** @type {Promise<VaultFactoryCreatorFacet>} */
   const vaultFactoryCreatorFacetP = E.get(consume.vaultFactoryKit).creatorFacet;
   const reserveCreatorFacet = E.get(consume.reserveKit).creatorFacet;
-  const reserveKit = { reserveCreatorFacet };
+  const reservePublicFacet = E.get(consume.reserveKit).publicFacet;
+  const reserveKit = { reserveCreatorFacet, reservePublicFacet };
 
   // Add a vault that will lend on aeth collateral
   /** @type {Promise<VaultManager>} */
@@ -1256,11 +1257,12 @@ test('collect fees from vault', async t => {
 
   const {
     vaultFactory: { lender },
-    reserveKit: { reserveCreatorFacet },
+    reserveKit: { reservePublicFacet },
   } = services;
 
-  const metricsSub = await E(reserveCreatorFacet).getMetrics();
-  const m = await subscriptionTracker(t, metricsSub);
+  const metricsTopic = await E.get(E(reservePublicFacet).getPublicTopics())
+    .metrics;
+  const m = await subscriptionTracker(t, metricsTopic);
   await m.assertInitial(reserveInitialState(run.makeEmpty()));
 
   // initial loans /////////////////////////////////////

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -186,7 +186,7 @@
  *       mintHolder: Promise<Installation<import('@agoric/vats/src/mintHolder.js').prepare>>,
  *       psm: Promise<Installation<import('@agoric/inter-protocol/src/psm/psm.js')['prepare']>>,
  *       provisionPool: Promise<Installation<import('@agoric/vats/src/provisionPool.js')['prepare']>>,
- *       reserve: Promise<Installation<import('@agoric/inter-protocol/src/reserve/assetReserve.js').start>>,
+ *       reserve: Promise<Installation<import('@agoric/inter-protocol/src/reserve/assetReserve.js').prepare>>,
  *       stakeFactory: Promise<Installation<import('@agoric/inter-protocol/src/stakeFactory/stakeFactory.js').start>>,
  *       VaultFactory: Promise<Installation<import('@agoric/inter-protocol/src/vaultFactory/vaultFactory.js')['prepare']>>,
  *       walletFactory: Promise<Installation<import('@agoric/smart-wallet/src/walletFactory.js').prepare>>,


### PR DESCRIPTION
closes: #7575

## Description

Makes assetReserve contract upgradable.

For expedience I dropped the public governance accessor methods. They didn't mix in well to the durable object. We will overhaul governance contract support for durability and can repair this at that time. (Next release, I expect)

### Security Considerations

Note the missing governance methods affect legibility but not the actual vulnerability of the contract.

Durable data is now authoritative, as with all upgradable contracts.

### Scaling Considerations

Improved by reducing reliance on closure

### Documentation Considerations

--
### Testing Considerations

New upgrade test. 