### PR TITLE
fix(oracles): set min oracles in devnet to 3

### DIFF
--- a/packages/inter-protocol/scripts/price-feed-core.js
+++ b/packages/inter-protocol/scripts/price-feed-core.js
@@ -4,7 +4,7 @@ import { makeHelpers } from '@agoric/deploy-script-support';
 const DEFAULT_CONTRACT_TERMS = {
   POLL_INTERVAL: 30n,
   maxSubmissionCount: 1000,
-  minSubmissionCount: 1,
+  minSubmissionCount: 2,
   restartDelay: 1, // the number of rounds an Oracle has to wait before they can initiate another round
   timeout: 10, // in seconds according to chainTimerService
   minSubmissionValue: 1n,

--- a/packages/vats/decentral-devnet-config.json
+++ b/packages/vats/decentral-devnet-config.json
@@ -113,6 +113,15 @@
       "entrypoint": "defaultProposalBuilder",
       "args": [
         {
+          "contractTerms": {
+            "POLL_INTERVAL": 30,
+            "maxSubmissionCount": 1000,
+            "minSubmissionCount": 3,
+            "restartDelay": 1,
+            "timeout": 10,
+            "minSubmissionValue": 1,
+            "maxSubmissionValue": 1000000000000000000
+          },
           "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
           "oracleAddresses": [
             "agoric10vjkvkmpp9e356xeh6qqlhrny2htyzp8hf88fk",

--- a/packages/vats/decentral-devnet-config.json
+++ b/packages/vats/decentral-devnet-config.json
@@ -120,7 +120,7 @@
             "restartDelay": 1,
             "timeout": 10,
             "minSubmissionValue": 1,
-            "maxSubmissionValue": 1000000000000000000
+            "maxSubmissionValue": 9007199254740991
           },
           "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
           "oracleAddresses": [

--- a/packages/vats/decentral-test-vaults-config.json
+++ b/packages/vats/decentral-test-vaults-config.json
@@ -120,7 +120,7 @@
             "restartDelay": 1,
             "timeout": 10,
             "minSubmissionValue": 1,
-            "maxSubmissionValue": 1000000000000000000
+            "maxSubmissionValue": 9007199254740991
           },
           "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
           "oracleAddresses": [

--- a/packages/vats/decentral-test-vaults-config.json
+++ b/packages/vats/decentral-test-vaults-config.json
@@ -113,6 +113,15 @@
       "entrypoint": "defaultProposalBuilder",
       "args": [
         {
+          "contractTerms": {
+            "POLL_INTERVAL": 30,
+            "maxSubmissionCount": 1000,
+            "minSubmissionCount": 1,
+            "restartDelay": 1,
+            "timeout": 10,
+            "minSubmissionValue": 1,
+            "maxSubmissionValue": 1000000000000000000
+          },
           "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
           "oracleAddresses": [
             "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",


### PR DESCRIPTION
closes: #7492

## Description

Set default minSubmissionCount in `decentral-devnet-config.json` to 3, in `decentral-test-vaults-config.json` to 1 (for ease of debugging), and in `price-feed-core` to 2 (to make it possible to tell which config is active)

### Security Considerations

production should rely on a reasonable quorum of oracles.

### Scaling Considerations

NA

### Documentation Considerations

None

### Testing Considerations

Verified, using `test-vault-integration.js` that the format is correct, and the value in `decentral-test-vaults-config.json` was in effect.

I don't know what test would verify that `decentral-devnet-config.json` is in use where it matters.