### PR TITLE
remove leftover makeMarshal from vatPowers

### DIFF
--- a/packages/SwingSet/src/kernel/vat-loader/manager-local.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-local.js
@@ -15,10 +15,7 @@ export function makeLocalVatManagerFactory({
   vatEndowments,
   gcTools,
 }) {
-  const baseVP = {
-    makeMarshal: allVatPowers.makeMarshal,
-  };
-  // testLog is also a vatPower, only for unit tests
+  const { testLog } = allVatPowers; // used by unit tests
 
   function prepare(managerOptions) {
     const { retainSyscall = false } = managerOptions;
@@ -44,10 +41,9 @@ export function makeLocalVatManagerFactory({
     assert.typeof(setup, 'function', 'setup is not an in-realm function');
 
     const { syscall, finish } = prepare(managerOptions);
-    const { testLog } = allVatPowers;
     const helpers = harden({}); // DEPRECATED, todo remove from setup()
     const state = null; // TODO remove from setup()
-    const vatPowers = harden({ ...baseVP, testLog });
+    const vatPowers = harden({ testLog });
 
     const dispatch = setup(syscall, state, helpers, vatPowers);
     return finish(dispatch);
@@ -64,10 +60,7 @@ export function makeLocalVatManagerFactory({
 
     const { syscall, finish } = prepare(managerOptions);
 
-    const vatPowers = harden({
-      ...baseVP,
-      testLog: allVatPowers.testLog,
-    });
+    const vatPowers = harden({ testLog });
 
     const makeLogMaker = source => {
       const makeLog = level => {

--- a/packages/SwingSet/src/types-ambient.js
+++ b/packages/SwingSet/src/types-ambient.js
@@ -24,7 +24,6 @@
  *
  * @typedef { import('./types-external.js').VatPowers } VatPowers
  * @typedef { import('./types-external.js').StaticVatPowers } StaticVatPowers
- * @typedef { import('./types-external.js').MarshallingVatPowers } MarshallingVatPowers
  * @typedef { import('./types-external.js').MeteringVatPowers } MeteringVatPowers
  *
  * @typedef { import('./types-external.js').TerminationVatPowers } TerminationVatPowers

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -34,14 +34,9 @@ export {};
 /**
  * See ../docs/static-vats.md#vatpowers
  *
- * @typedef { MarshallingVatPowers & TerminationVatPowers } VatPowers
+ * @typedef { TerminationVatPowers } VatPowers
  *
  * @typedef { (VatPowers & MeteringVatPowers) } StaticVatPowers
- *
- * @typedef {{
- *   Remotable: unknown,
- *   getInterfaceOf: unknown,
- * }} MarshallingVatPowers
  *
  * @typedef {{
  *   makeGetMeter: unknown,

--- a/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
+++ b/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
@@ -1,7 +1,6 @@
 /* global globalThis WeakRef FinalizationRegistry */
 import { assert, Fail } from '@agoric/assert';
 import { importBundle } from '@endo/import-bundle';
-import { makeMarshal } from '@endo/marshal';
 import {
   makeLiveSlots,
   insistVatDeliveryObject,
@@ -208,7 +207,6 @@ function makeWorker(port) {
     const syscall = makeSupervisorSyscall(syscallToManager);
 
     const vatPowers = {
-      makeMarshal,
       testLog: (...args) =>
         port.send([
           'testLog',


### PR DESCRIPTION
A long time ago, `makeMarshal` used an module-level WeakSet to keep track of which objects had been registered with Far, which mean the code doing the marshalling (i.e. liveslots) and the code providing the marshalled values (i.e. userspace, calling Far) needed to get those two pieces from the same place.

This was a problem for vats, because they bundle `@endo/marshal` or `@endo/far` independently of liveslots' copy.

We no longer do that, but for some period, we thought it was useful and important to give userspace vat code access to the same `makeMarshal` that liveslots used. To facilitate that, we included a reference in `vatPowers.makeMarshal`, which meant that the supervisors had to provide a copy in `allVatPowers`.

We remove that from manager-local a while back, but forgot to remove it from the xsnap worker.

This removes the remnants of makeMarshal from vatPowers in all manager types.
