### PR TITLE
feat(internal): new `prepareAttenuator` leveraging callbacks

### DIFF
--- a/packages/internal/src/types.d.ts
+++ b/packages/internal/src/types.d.ts
@@ -7,10 +7,14 @@ export declare class Callback<I extends (...args: unknown[]) => any> {
   public methodName?: PropertyKey;
 
   public bound: unknown[];
+
+  public isSync: boolean;
 }
 
 export declare class SyncCallback<
   I extends (...args: unknown[]) => any,
 > extends Callback<I> {
   private syncIface: I;
+
+  public isSync: true;
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -16,8 +16,8 @@
     "prepack": "tsc --build jsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*'",
     "test": "ava",
-    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
-    "test:xs": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 'test/bootstrapTests/**/test-*.js' 'test/upgrading/**/test-*.js'",
+    "test:c8": "c8 $C8_OPTIONS ava",
+    "test:xs": "SWINGSET_WORKER_TYPE=xs-worker ava 'test/bootstrapTests/**/test-*.js' 'test/upgrading/**/test-*.js'",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc -p jsconfig.json",
@@ -77,6 +77,7 @@
     "files": [
       "test/**/test-*.js"
     ],
+    "concurrency": 2,
     "timeout": "20m",
     "workerThreads": false
   }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: Needs issue

## Description

Adds a mechanism to define an exo class presenting the same external API, but backed per-instance by passable callback descriptors.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Improves encapsulation; instead of marshalling raw callback descriptors (which expose their unattenuated targets), an exo ocap can be conveyed.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
