### PR TITLE
upgradable econCommittee

### DIFF
--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -4,6 +4,7 @@ import { natSafeMath } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
+import { StorageNodeShape } from '@agoric/internal';
 import {
   getOpenQuestions,
   getPoserInvitation,
@@ -26,6 +27,12 @@ const { ceilDivide } = natSafeMath;
  * }} CommitteeElectorateCreatorFacet
  */
 
+export const privateArgsShape = {
+  storageNode: StorageNodeShape,
+  marshaller: M.remotable('Marshaller'),
+};
+harden(privateArgsShape);
+
 /**
  * Each Committee (an Electorate) represents a particular set of voters. The
  * number of voters is visible in the terms.
@@ -45,8 +52,6 @@ const { ceilDivide } = natSafeMath;
 const start = (zcf, privateArgs) => {
   /** @type {MapStore<Handle<'Question'>, import('./electorateTools.js').QuestionRecord>} */
   const allQuestions = makeScalarMapStore('Question');
-  assert(privateArgs?.storageNode, 'Missing storageNode');
-  assert(privateArgs?.marshaller, 'Missing marshaller');
   const questionNode = E(privateArgs.storageNode).makeChildNode(
     'latestQuestion',
   );

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -47,9 +47,10 @@ harden(privateArgsShape);
  *   committeeSize: number,
  * }>} zcf
  * @param {{ storageNode: ERef<StorageNode>, marshaller: ERef<Marshaller>}} privateArgs
+ * @param {import('@agoric/vat-data').Baggage} baggage
  * @returns {{creatorFacet: CommitteeElectorateCreatorFacet, publicFacet: CommitteeElectoratePublic}}
  */
-const start = (zcf, privateArgs) => {
+export const prepare = (zcf, privateArgs, baggage) => {
   /** @type {MapStore<Handle<'Question'>, import('./electorateTools.js').QuestionRecord>} */
   const allQuestions = makeScalarMapStore('Question');
   const questionNode = E(privateArgs.storageNode).makeChildNode(
@@ -191,5 +192,4 @@ const start = (zcf, privateArgs) => {
   return { publicFacet, creatorFacet };
 };
 
-harden(start);
-export { start };
+harden(prepare);

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -1,10 +1,10 @@
 import { makeStoredPublishKit } from '@agoric/notifier';
-import { makeScalarMapStore, makeExo, M } from '@agoric/store';
+import { M } from '@agoric/store';
 import { natSafeMath } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 
-import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 import { StorageNodeShape } from '@agoric/internal';
+import { prepareExo, provideDurableMapStore } from '@agoric/vat-data';
 import {
   getOpenQuestions,
   getPoserInvitation,
@@ -12,12 +12,8 @@ import {
   startCounter,
 } from './electorateTools.js';
 import { QuorumRule } from './question.js';
-import {
-  QuestionHandleShape,
-  PositionShape,
-  ElectorateCreatorI,
-  ElectoratePublicI,
-} from './typeGuards.js';
+import { ElectorateCreatorI, ElectoratePublicI } from './typeGuards.js';
+import { prepareVoterKit } from './voterKit.js';
 
 const { ceilDivide } = natSafeMath;
 
@@ -52,7 +48,21 @@ harden(privateArgsShape);
  */
 export const prepare = (zcf, privateArgs, baggage) => {
   /** @type {MapStore<Handle<'Question'>, import('./electorateTools.js').QuestionRecord>} */
-  const allQuestions = makeScalarMapStore('Question');
+  const allQuestions = provideDurableMapStore(baggage, 'Question');
+
+  // CRUCIAL: voteCap carries the ability to cast votes for any voter at
+  // any weight. It's wrapped here and given to the voter.
+  //
+  // Ensure that the voter can't get access to the unwrapped voteCap, and
+  // has no control over the voteHandle or weight
+  /** @type {Parameters<typeof prepareVoterKit>[1]['submitVote']} */
+  const submitVote = (questionHandle, voterHandle, positions, weight) => {
+    const { voteCap } = allQuestions.get(questionHandle);
+    return E(voteCap).submitVote(voterHandle, positions, weight);
+  };
+
+  const makeVoterKit = prepareVoterKit(baggage, { zcf, submitVote });
+
   const questionNode = E(privateArgs.storageNode).makeChildNode(
     'latestQuestion',
   );
@@ -61,55 +71,14 @@ export const prepare = (zcf, privateArgs, baggage) => {
     makeStoredPublishKit(questionNode, privateArgs.marshaller);
 
   const makeCommitteeVoterInvitation = index => {
-    /** @type {OfferHandler} */
-    const offerHandler = seat => {
-      const voterHandle = makeHandle('Voter');
-      seat.exit();
-
-      const VoterI = M.interface('voter', {
-        castBallotFor: M.call(
-          QuestionHandleShape,
-          M.arrayOf(PositionShape),
-        ).returns(M.promise()),
-      });
-      const InvitationMakerI = M.interface('invitationMaker', {
-        makeVoteInvitation: M.call(
-          M.arrayOf(PositionShape),
-          QuestionHandleShape,
-        ).returns(M.promise()),
-      });
-
-      // CRUCIAL: voteCap carries the ability to cast votes for any voter at
-      // any weight. It's wrapped here and given to the voter.
-      //
-      // Ensure that the voter can't get access to the unwrapped voteCap, and
-      // has no control over the voteHandle or weight
-      return harden({
-        voter: makeExo(`voter${index}`, VoterI, {
-          castBallotFor(questionHandle, positions) {
-            const { voteCap } = allQuestions.get(questionHandle);
-            return E(voteCap).submitVote(voterHandle, positions, 1n);
-          },
-        }),
-        invitationMakers: makeExo('invitation makers', InvitationMakerI, {
-          makeVoteInvitation(positions, questionHandle) {
-            const continuingVoteHandler = cSeat => {
-              cSeat.exit();
-              const { voteCap } = allQuestions.get(questionHandle);
-              return E(voteCap).submitVote(voterHandle, positions, 1n);
-            };
-
-            return zcf.makeInvitation(continuingVoteHandler, 'vote');
-          },
-        }),
-      });
-    };
-
     // https://github.com/Agoric/agoric-sdk/pull/3448/files#r704003612
     // This will produce unique descriptions because
     // makeCommitteeVoterInvitation() is only called within the following loop,
     // which is only called once per Electorate.
-    return zcf.makeInvitation(offerHandler, `Voter${index}`);
+    return zcf.makeInvitation(seat => {
+      seat.exit();
+      return makeVoterKit(index);
+    }, `Voter${index}`);
   };
 
   const { committeeName, committeeSize } = zcf.getTerms();
@@ -118,76 +87,86 @@ export const prepare = (zcf, privateArgs, baggage) => {
     [...Array(committeeSize).keys()].map(makeCommitteeVoterInvitation),
   );
 
-  const publicFacet = makeExo('Committee publicFacet', ElectoratePublicI, {
-    getQuestionSubscriber() {
-      return questionsSubscriber;
+  const publicFacet = prepareExo(
+    baggage,
+    'Committee publicFacet',
+    ElectoratePublicI,
+    {
+      getQuestionSubscriber() {
+        return questionsSubscriber;
+      },
+      getOpenQuestions() {
+        return getOpenQuestions(allQuestions);
+      },
+      getName() {
+        return committeeName;
+      },
+      getInstance() {
+        return zcf.getInstance();
+      },
+      getQuestion(handleP) {
+        return getQuestion(handleP, allQuestions);
+      },
     },
-    getOpenQuestions() {
-      return getOpenQuestions(allQuestions);
-    },
-    getName() {
-      return committeeName;
-    },
-    getInstance() {
-      return zcf.getInstance();
-    },
-    getQuestion(handleP) {
-      return getQuestion(handleP, allQuestions);
-    },
-  });
+  );
 
-  const creatorFacet = makeExo('Committee creatorFacet', ElectorateCreatorI, {
-    getPoserInvitation() {
-      return getPoserInvitation(zcf, async (voteCounter, questionSpec) =>
-        creatorFacet.addQuestion(voteCounter, questionSpec),
-      );
-    },
-    /** @type {AddQuestion} */
-    async addQuestion(voteCounter, questionSpec) {
-      const quorumThreshold = quorumRule => {
-        switch (quorumRule) {
-          case QuorumRule.MAJORITY:
-            return ceilDivide(committeeSize, 2);
-          case QuorumRule.ALL:
-            return committeeSize;
-          case QuorumRule.NO_QUORUM:
-            return 0;
-          default:
-            throw Error(`${quorumRule} is not a recognized quorum rule`);
-        }
-      };
+  const creatorFacet = prepareExo(
+    baggage,
+    'Committee creatorFacet',
+    ElectorateCreatorI,
+    {
+      getPoserInvitation() {
+        return getPoserInvitation(zcf, async (voteCounter, questionSpec) =>
+          creatorFacet.addQuestion(voteCounter, questionSpec),
+        );
+      },
+      /** @type {AddQuestion} */
+      async addQuestion(voteCounter, questionSpec) {
+        const quorumThreshold = quorumRule => {
+          switch (quorumRule) {
+            case QuorumRule.MAJORITY:
+              return ceilDivide(committeeSize, 2);
+            case QuorumRule.ALL:
+              return committeeSize;
+            case QuorumRule.NO_QUORUM:
+              return 0;
+            default:
+              throw Error(`${quorumRule} is not a recognized quorum rule`);
+          }
+        };
 
-      const outcomeNode = E(privateArgs.storageNode).makeChildNode(
-        'latestOutcome',
-      );
+        const outcomeNode = E(privateArgs.storageNode).makeChildNode(
+          'latestOutcome',
+        );
 
-      /** @type {StoredPublishKit<OutcomeRecord>} */
-      const { publisher: outcomePublisher } = makeStoredPublishKit(
-        outcomeNode,
-        privateArgs.marshaller,
-      );
+        /** @type {StoredPublishKit<OutcomeRecord>} */
+        const { publisher: outcomePublisher } = makeStoredPublishKit(
+          outcomeNode,
+          privateArgs.marshaller,
+        );
 
-      return startCounter(
-        zcf,
-        questionSpec,
-        quorumThreshold(questionSpec.quorumRule),
-        voteCounter,
-        allQuestions,
-        questionsPublisher,
-        outcomePublisher,
-      );
-    },
-    getVoterInvitations() {
-      return invitations;
-    },
-    getQuestionSubscriber() {
-      return questionsSubscriber;
-    },
+        return startCounter(
+          zcf,
+          questionSpec,
+          quorumThreshold(questionSpec.quorumRule),
+          voteCounter,
+          allQuestions,
+          questionsPublisher,
+          outcomePublisher,
+        );
+      },
+      getVoterInvitations() {
+        return invitations;
+      },
+      getQuestionSubscriber() {
+        return questionsSubscriber;
+      },
 
-    getPublicFacet() {
-      return publicFacet;
+      getPublicFacet() {
+        return publicFacet;
+      },
     },
-  });
+  );
 
   return { publicFacet, creatorFacet };
 };

--- a/packages/governance/src/electorateTools.js
+++ b/packages/governance/src/electorateTools.js
@@ -58,7 +58,7 @@ const startCounter = async (
 
   const voteCounterFacets = { voteCap: creatorFacet, publicFacet, deadline };
 
-  questionStore.init(questionHandle, voteCounterFacets);
+  questionStore.init(questionHandle, harden(voteCounterFacets));
 
   return { creatorFacet, publicFacet, instance, deadline, questionHandle };
 };

--- a/packages/governance/src/voterKit.js
+++ b/packages/governance/src/voterKit.js
@@ -1,0 +1,59 @@
+import { M, prepareExoClassKit } from '@agoric/vat-data';
+import { defineDurableHandle } from '@agoric/zoe/src/makeHandle.js';
+import { E } from '@endo/eventual-send';
+import { PositionShape, QuestionHandleShape } from './typeGuards.js';
+
+const VoterI = M.interface('voter', {
+  castBallotFor: M.call(QuestionHandleShape, M.arrayOf(PositionShape)).returns(
+    M.promise(),
+  ),
+});
+
+const InvitationMakerI = M.interface('invitationMaker', {
+  makeVoteInvitation: M.call(
+    M.arrayOf(PositionShape),
+    QuestionHandleShape,
+  ).returns(M.promise()),
+});
+
+/**
+ * Make a kit suitable for returning to a voter invited to a committee.
+ *
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {object} powers
+ * @param {ZCF} powers.zcf
+ * @param {(questionHandle: Handle<'Question'>, voterHandle: Handle<'Voter'>, chosenPositions: Position[], weight: bigint) => ERef<CompletedBallet>} powers.submitVote
+ */
+export const prepareVoterKit = (baggage, { submitVote, zcf }) => {
+  const makeVoterHandle = defineDurableHandle(baggage, 'Voter');
+  const makeVoterKit = prepareExoClassKit(
+    baggage,
+    'VoterKit',
+    { voter: VoterI, invitationMakers: InvitationMakerI },
+    id => {
+      const voterHandle = makeVoterHandle();
+      return { id, voterHandle };
+    },
+    {
+      voter: {
+        castBallotFor(questionHandle, positions, weight = 1n) {
+          const { voterHandle } = this.state;
+          return E(submitVote)(questionHandle, voterHandle, positions, weight);
+        },
+      },
+      invitationMakers: {
+        makeVoteInvitation(positions, questionHandle) {
+          const { voter } = this.facets;
+          const continuingVoteHandler = cSeat => {
+            cSeat.exit();
+            return voter.castBallotFor(questionHandle, positions);
+          };
+
+          return zcf.makeInvitation(continuingVoteHandler, 'vote');
+        },
+      },
+    },
+  );
+  return makeVoterKit;
+};
+harden(prepareVoterKit);

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
@@ -40,7 +40,7 @@ const verify = async (log, issue, electoratePublicFacet, instances) => {
 const build = async (log, zoe) => {
   return Far('voter', {
     createVoter: async (name, invitation, choice) => {
-      /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<typeof import('@agoric/governance/src/committee').start>} */
+      /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<typeof import('@agoric/governance/src/committee.js').prepare>} */
       const electorateInstance = await E(zoe).getInstance(invitation);
       const electoratePublicFacet = E(zoe).getPublicFacet(electorateInstance);
       const seat = E(zoe).offer(invitation);

--- a/packages/governance/test/unitTests/test-committee.js
+++ b/packages/governance/test/unitTests/test-committee.js
@@ -38,7 +38,7 @@ const setupContract = async () => {
     bundleSource(counterRoot),
   ]);
   // install the contract
-  /** @typedef {Installation<import('../../src/committee.js').start>} CommitteInstallation */
+  /** @typedef {Installation<import('../../src/committee.js')['prepare']>} CommitteInstallation */
   /** @typedef {Installation<import('../../src/binaryVoteCounter.js').start>} CounterInstallation */
   /** @type {[CommitteInstallation, CounterInstallation] } */
   const [electorateInstallation, counterInstallation] = await Promise.all([

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -70,7 +70,7 @@ const BASIS_POINTS = 10_000n;
  * }>} EconomyBootstrapSpace
  */
 
-/** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('../econCommitteeCharter').start>} EconCharterStartResult */
+/** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('../econCommitteeCharter')['prepare']>} EconCharterStartResult */
 /** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('@agoric/governance/src/committee').start>} CommitteeStartResult */
 
 /**

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -71,7 +71,7 @@ const BASIS_POINTS = 10_000n;
  */
 
 /** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('../econCommitteeCharter')['prepare']>} EconCharterStartResult */
-/** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('@agoric/governance/src/committee').start>} CommitteeStartResult */
+/** @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<import('@agoric/governance/src/committee.js')['prepare']>} CommitteeStartResult */
 
 /**
  * @file A collection of productions, each of which declares inputs and outputs.

--- a/packages/inter-protocol/test/psm/setupPsm.js
+++ b/packages/inter-protocol/test/psm/setupPsm.js
@@ -62,6 +62,7 @@ export const setupPsmBootstrap = async (
 
   produce.chainTimerService.resolve(timer);
   produce.zoe.resolve(wrappedZoe);
+  /** @type {Promise<ZoeService>} */
   const zoe = space.consume.zoe;
   produce.feeMintAccess.resolve(feeMintAccessP);
 

--- a/packages/inter-protocol/test/psm/test-governedPsm.js
+++ b/packages/inter-protocol/test/psm/test-governedPsm.js
@@ -1,10 +1,12 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import { makeFakeMarshaller } from '@agoric/notifier/tools/testSupports.js';
+import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
 import { setupPsm } from './setupPsm.js';
 
 test.before(async t => {
@@ -178,8 +180,7 @@ test('replace electorate of Economic Committee', async t => {
     harden({}),
     electorateTerms,
     {
-      // @ts-expect-error mock
-      marshaller: {},
+      marshaller: Far('fake marshaller', { ...makeFakeMarshaller() }),
       storageNode: makeFakeStorageKit('governedPsmTest').rootNode,
     },
   );

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -349,7 +349,7 @@ test.serial('govern oracles list', async t => {
     'instance',
     'econCommitteeCharter',
   );
-  /** @type {import('@agoric/zoe/src/zoeService/utils').Instance<import('@agoric/governance/src/committee').start> } */
+  /** @type {import('@agoric/zoe/src/zoeService/utils').Instance<import('@agoric/governance/src/committee.js')['prepare']> } */
   const economicCommittee = await E(agoricNames).lookup(
     'instance',
     'economicCommittee',

--- a/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
@@ -39,7 +39,7 @@ export const buildRootObject = async () => {
   // for startInstance
   /**
    * @type {{
-   * committee?: Installation<import('@agoric/governance/src/committee').start>,
+   * committee?: Installation<import('@agoric/governance/src/committee.js')['prepare']>,
    * fluxAggregatorV1?: Installation<import('../../../src/price/fluxAggregatorContract').prepare>,
    * puppetContractGovernor?: Installation<import('@agoric/governance/tools/puppetContractGovernor').start>,
    * }}

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
@@ -60,7 +60,7 @@ export const buildRootObject = async () => {
   // for startInstance
   /**
    * @type {{
-   * committee?: Installation<import('@agoric/governance/src/committee').start>,
+   * committee?: Installation<import('@agoric/governance/src/committee.js')['prepare']>,
    * psmV1?: Installation<PsmSF>,
    * puppetContractGovernor?: Installation<import('@agoric/governance/tools/puppetContractGovernor').start>,
    * }}

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -114,7 +114,7 @@ const startGovernedInstance = async (
  * @param {BootstrapPowers & PromiseSpaceOf<{
  *   economicCommitteeCreatorFacet: import('@agoric/governance/src/committee.js').CommitteeElectorateCreatorFacet
  *   econCharterKit: {
- *     creatorFacet: Awaited<ReturnType<import('@agoric/inter-protocol/src/econCommitteeCharter.js').start>>['creatorFacet'],
+ *     creatorFacet: Awaited<ReturnType<import('@agoric/inter-protocol/src/econCommitteeCharter.js')['prepare']>>['creatorFacet'],
  *     adminFacet: AdminFacet,
  *   } ,
  *   walletBridgeManager: import('../types.js').ScopedBridgeManager;

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -179,7 +179,7 @@
  *     consume: Record<WellKnownName['installation'], Promise<Installation<unknown>>> & {
  *       auctioneer: Promise<Installation<import('@agoric/inter-protocol/src/auction/auctioneer.js').start>>,
  *       centralSupply: Promise<Installation<import('@agoric/vats/src/centralSupply.js').start>>,
- *       committee: Promise<Installation<import('@agoric/governance/src/committee.js').start>>,
+ *       committee: Promise<Installation<import('@agoric/governance/src/committee.js')['prepare']>>,
  *       contractGovernor: Promise<Installation<import('@agoric/governance/src/contractGovernor.js').start>>,
  *       econCommitteeCharter: Promise<Installation<import('@agoric/inter-protocol/src/econCommitteeCharter.js')['prepare']>>,
  *       feeDistributor: Promise<Installation<import('@agoric/inter-protocol/src/feeDistributor.js').start>>,

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -181,7 +181,7 @@
  *       centralSupply: Promise<Installation<import('@agoric/vats/src/centralSupply.js').start>>,
  *       committee: Promise<Installation<import('@agoric/governance/src/committee.js').start>>,
  *       contractGovernor: Promise<Installation<import('@agoric/governance/src/contractGovernor.js').start>>,
- *       econCommitteeCharter: Promise<Installation<import('@agoric/inter-protocol/src/econCommitteeCharter.js').start>>,
+ *       econCommitteeCharter: Promise<Installation<import('@agoric/inter-protocol/src/econCommitteeCharter.js')['prepare']>>,
  *       feeDistributor: Promise<Installation<import('@agoric/inter-protocol/src/feeDistributor.js').start>>,
  *       mintHolder: Promise<Installation<import('@agoric/vats/src/mintHolder.js').prepare>>,
  *       psm: Promise<Installation<import('@agoric/inter-protocol/src/psm/psm.js')['prepare']>>,


### PR DESCRIPTION
refs: #5795

## Description

Makes the `econCommitteeCharter` contract have durable state, invitationMakers and facets. It's not strictly necessary for release because a proposal to upgrade to the contract could re-invite the committee members, but this will save that hassle.


### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

Not tested beyond Zoe's check that `prepare` return durable facets and that what goes into the `instanceToGovernor` store is durable. I propose that this is sufficient given current priorities and the fallback to being able to reinvite the committee.