### PR TITLE
7585 cleanup

### DIFF
--- a/packages/agoric-cli/src/lib/rpc.js
+++ b/packages/agoric-cli/src/lib/rpc.js
@@ -193,7 +193,7 @@ export const storageHelper = {
   unserializeTxt: (txt, ctx) => {
     const { capDatas } = storageHelper.parseCapData(txt);
     return capDatas.map(capData =>
-      boardSlottingMarshaller(ctx.convertSlotToVal).unserialize(capData),
+      boardSlottingMarshaller(ctx.convertSlotToVal).fromCapData(capData),
     );
   },
   /** @param {string[]} capDataStrings array of stringified capData */

--- a/packages/casting/README.md
+++ b/packages/casting/README.md
@@ -44,7 +44,7 @@ The `followerOpts` argument in `makeFollower(leader, key, followerOpts)` provide
 - the `unserializer` option can be
   - (default) - release unserialized objects using `@agoric/marshal`'s `makeMarshal()`
   - `null` - don't additionally unserialize data before releasing it
-  - any unserializer object supporting `E(unserializer).unserialize(data)`
+  - any unserializer object supporting `E(unserializer).fromCapData(data)`
 - the `crasher` option can be
   - `null` (default) follower failures only propagate an exception/rejection
   - any crasher object supporting `E(crasher).crash(reason)`

--- a/packages/casting/src/defaults.js
+++ b/packages/casting/src/defaults.js
@@ -114,6 +114,10 @@ export const MAKE_DEFAULT_UNSERIALIZER = () => {
     return obj;
   };
   return Far('marshal unserializer', {
+    fromCapData: makeMarshal(undefined, slotToVal, {
+      serializeBodyFormat: 'smallcaps',
+    }).fromCapData,
+    /** @deprecated use fromCapData */
     unserialize: makeMarshal(undefined, slotToVal, {
       serializeBodyFormat: 'smallcaps',
     }).fromCapData,

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -377,7 +377,7 @@ export const makeCosmjsFollower = (
   ) => {
     // AWAIT
     const value = await /** @type {T} */ (
-      unserializer ? E(unserializer).unserialize(data) : data
+      unserializer ? E(unserializer).fromCapData(data) : data
     );
     return { value, blockHeight, currentBlockHeight };
   };

--- a/packages/casting/src/types.js
+++ b/packages/casting/src/types.js
@@ -49,8 +49,7 @@ export {};
  */
 
 /**
- * @typedef {object} Unserializer
- * @property {(data: import('@endo/marshal').CapData<unknown>) => any} unserialize
+ * @typedef {Pick<import('@endo/marshal').Marshal<unknown>, 'fromCapData' | 'unserialize'>} Unserializer
  */
 
 /**

--- a/packages/casting/test/fake-rpc-server.js
+++ b/packages/casting/test/fake-rpc-server.js
@@ -165,7 +165,7 @@ export const startFakeServer = (t, fakeValues, options = {}) => {
           if (batchSize > 0) {
             // Return a JSON stream cell.
             const serializedValues = values.map(val =>
-              JSON.stringify(marshaller.serialize(val)),
+              JSON.stringify(marshaller.toCapData(val)),
             );
             responseValue = {
               blockHeight: String(desiredHeight - 1),
@@ -173,7 +173,7 @@ export const startFakeServer = (t, fakeValues, options = {}) => {
             };
           } else {
             // Return a single naked value.
-            responseValue = marshaller.serialize(values[0]);
+            responseValue = marshaller.toCapData(values[0]);
           }
           const responseValueBase64 = encode(responseValue);
           const result = {

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -7,7 +7,7 @@ import * as cb from './callback.js';
 const { Fail } = assert;
 
 /** @typedef {ReturnType<typeof import('@endo/marshal').makeMarshal>} Marshaller */
-/** @typedef {Pick<Marshaller, 'unserialize'>} Unserializer */
+/** @typedef {Pick<Marshaller, 'fromCapData'>} Unserializer */
 
 /**
  * Defined by vstorageStoreKey in vstorage.go

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -226,7 +226,7 @@ harden(makeStorageNodeChild);
  */
 export const makeSerializeToStorage = (storageNode, marshaller) => {
   return async value => {
-    const marshalled = await E(marshaller).serialize(value);
+    const marshalled = await E(marshaller).toCapData(value);
     const serialized = JSON.stringify(marshalled);
     return E(storageNode).setValue(serialized);
   };

--- a/packages/notifier/src/stored-notifier.js
+++ b/packages/notifier/src/stored-notifier.js
@@ -45,7 +45,8 @@ export const makeStoredNotifier = (notifier, storageNode, marshaller) => {
 
   /** @type {Unserializer} */
   const unserializer = Far('unserializer', {
-    unserialize: data => E(marshaller).unserialize(data),
+    fromCapData: data => E(marshaller).fromCapData(data),
+    unserialize: data => E(marshaller).fromCapData(data),
   });
 
   /** @type {StoredNotifier<T>} */

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -59,6 +59,7 @@ export const makeStoredSubscriber = (subscriber, storageNode, marshaller) => {
 
   /** @type {Unserializer} */
   const unserializer = Far('unserializer', {
+    fromCapData: data => E(marshaller).fromCapData(data),
     unserialize: data => E(marshaller).fromCapData(data),
   });
 
@@ -99,6 +100,7 @@ export const makeStoredSubscription = (
 ) => {
   /** @type {Unserializer} */
   const unserializer = Far('unserializer', {
+    fromCapData: data => E(marshaller).fromCapData(data),
     unserialize: data => E(marshaller).fromCapData(data),
   });
 

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -124,7 +124,7 @@ export const makeStoredSubscription = (
 
     // Publish the value, capturing any error.
     E(marshaller)
-      .serialize(obj)
+      .toCapData(obj)
       .then(serialized => {
         const encoded = JSON.stringify(serialized);
         return E(storageNode).setValue(encoded);

--- a/packages/notifier/src/types-ambient.js
+++ b/packages/notifier/src/types-ambient.js
@@ -255,7 +255,7 @@
 // /////////////////////////////////////////////////////////////////////////////
 
 /** @template [Slot=unknown] @typedef {import('@endo/marshal').Marshal<Slot>} Marshaller */
-/** @typedef {Pick<Marshaller, 'unserialize'>} Unserializer */
+/** @typedef {Pick<Marshaller, 'fromCapData'>} Unserializer */
 
 /**
  * Defined by vstorageStoreKey in vstorage.go

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -258,7 +258,7 @@ export {};
 // /////////////////////////////////////////////////////////////////////////////
 
 /** @typedef {ReturnType<typeof import('@endo/marshal').makeMarshal>} Marshaller */
-/** @typedef {Pick<Marshaller, 'unserialize'>} Unserializer */
+/** @typedef {Pick<Marshaller, 'fromCapData'>} Unserializer */
 
 /**
  * Defined by vstorageStoreKey in vstorage.go

--- a/packages/notifier/test/test-stored-subscription.js
+++ b/packages/notifier/test/test-stored-subscription.js
@@ -48,7 +48,7 @@ test('stored subscription', async t => {
       `storage iterator should not report done for ${description}`,
     );
     const storedDecoded = JSON.parse(storedEncoded);
-    const storedValue = await E(unserializer).unserialize(storedDecoded);
+    const storedValue = await E(unserializer).fromCapData(storedDecoded);
     t.deepEqual(
       storedValue,
       origValue,
@@ -111,7 +111,7 @@ test('stored subscriber', async t => {
       `storage iterator should not report done for ${description}`,
     );
     const storedDecoded = JSON.parse(storedEncoded);
-    const storedValue = await E(unserializer).unserialize(storedDecoded);
+    const storedValue = await E(unserializer).fromCapData(storedDecoded);
     t.deepEqual(
       storedValue,
       origValue,

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -540,7 +540,7 @@ export const prepareSmartWallet = (baggage, shared) => {
 
           // use E.when to retain distributed stack trace
           return E.when(
-            E(publicMarshaller).unserialize(actionCapData),
+            E(publicMarshaller).fromCapData(actionCapData),
             /** @param {BridgeAction} action */
             action => {
               try {

--- a/packages/smart-wallet/test/test-walletFactory.js
+++ b/packages/smart-wallet/test/test-walletFactory.js
@@ -60,7 +60,7 @@ test('bridge handler', async t => {
     owner: mockAddress1,
     // consider a helper for each action type
     spendAction: JSON.stringify(
-      ctx.fromBoard.serialize(
+      ctx.fromBoard.toCapData(
         harden({ method: 'executeOffer', offer: offerSpec }),
       ),
     ),
@@ -107,7 +107,7 @@ test('bridge with offerId string', async t => {
     owner: mockAddress2,
     // consider a helper for each action type
     spendAction: JSON.stringify(
-      ctx.fromBoard.serialize(
+      ctx.fromBoard.toCapData(
         harden({ method: 'executeOffer', offer: offerSpec }),
       ),
     ),
@@ -142,7 +142,7 @@ test('missing spend authority', async t => {
     type: ActionType.WALLET_ACTION, // not SPEND
     owner,
     action: JSON.stringify(
-      ctx.fromBoard.serialize(
+      ctx.fromBoard.toCapData(
         harden({ method: 'tryExitOffer', offerId: 'irrelevant' }),
       ),
     ),

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -1,7 +1,6 @@
 // @ts-check
 /* eslint-disable import/no-extraneous-dependencies */
 import { Fail } from '@agoric/assert';
-import { Far } from '@endo/far';
 import { buildSwingset } from '@agoric/cosmic-swingset/src/launch-chain.js';
 import { BridgeId, VBankAccount } from '@agoric/internal';
 import {
@@ -341,8 +340,7 @@ export const makeSwingsetTestKit = async (
 
   const storage = makeFakeStorageKit('bootstrapTests');
 
-  const slotToVal = (_slotId, iface = 'Remotable') => Far(iface);
-  const marshal = boardSlottingMarshaller(slotToVal);
+  const marshal = boardSlottingMarshaller(slotToRemotable);
 
   const readLatest = path => {
     const str = storage.data.get(path)?.at(-1);

--- a/packages/vats/tools/board-utils.js
+++ b/packages/vats/tools/board-utils.js
@@ -85,7 +85,7 @@ harden(makeAgoricNamesRemotesFromFakeStorage);
  * Remotable-bearing data.
  *
  * @param {(slot: string, iface: string) => any} [slotToVal]
- * @returns {import('@endo/marshal').Marshal<string>}
+ * @returns {Omit<import('@endo/marshal').Marshal<string>, 'serialize' | 'unserialize'>}
  */
 export const boardSlottingMarshaller = (slotToVal = undefined) => {
   return makeMarshal(boardValToSlot, slotToVal, {

--- a/packages/wallet/api/test/test-middleware.js
+++ b/packages/wallet/api/test/test-middleware.js
@@ -32,7 +32,7 @@ test('makeLoggingPresence logs calls on purse/payment actions', async t => {
   const ctx = makeExportContext();
   ctx.savePurseActions(purse.actions);
   ctx.savePaymentActions(myPayment);
-  const capData = ctx.serialize(harden([...msgs]));
+  const capData = ctx.toCapData(harden([...msgs]));
   t.deepEqual(capData, capData1);
 });
 
@@ -43,17 +43,17 @@ test('makeImportContext in wallet UI can unserialize messages', async t => {
 
   const ctx = makeImportContext(mkp);
 
-  const stuff = ctx.fromMyWallet.unserialize(capData1);
+  const stuff = ctx.fromMyWallet.fromCapData(capData1);
   t.is(stuff.length, 2);
   const [[_tag, purse, method, _args]] = stuff;
   t.is(method, 'deposit');
   await E(purse).transfer(1);
 
   // unserialization is consistent
-  const stuff2 = ctx.fromMyWallet.unserialize(capData1);
+  const stuff2 = ctx.fromMyWallet.fromCapData(capData1);
   t.deepEqual(stuff, stuff2);
 
-  const capData = ctx.fromMyWallet.serialize(harden([...msgs]));
+  const capData = ctx.fromMyWallet.toCapData(harden([...msgs]));
 
   t.deepEqual(capData, {
     body: '#[["applyMethod","$0.Alleged: purse.actions","transfer",[1]]]',

--- a/packages/zoe/src/contractSupport/recorder.js
+++ b/packages/zoe/src/contractSupport/recorder.js
@@ -101,7 +101,7 @@ export const prepareRecorder = (baggage, marshaller) => {
         const { closed, publisher, storageNode, valueShape } = this.state;
         !closed || Fail`cannot write to closed recorder`;
         mustMatch(value, valueShape);
-        const encoded = await E(marshaller).serialize(value);
+        const encoded = await E(marshaller).toCapData(value);
         const serialized = JSON.stringify(encoded);
         await E(storageNode).setValue(serialized);
 
@@ -118,7 +118,7 @@ export const prepareRecorder = (baggage, marshaller) => {
         const { closed, publisher, storageNode, valueShape } = this.state;
         !closed || Fail`cannot write to closed recorder`;
         mustMatch(value, valueShape);
-        const encoded = await E(marshaller).serialize(value);
+        const encoded = await E(marshaller).toCapData(value);
         const serialized = JSON.stringify(encoded);
         await E(storageNode).setValue(serialized);
 


### PR DESCRIPTION
## Description

Adopt some suggestions from @erights 's review of #7585 

- adopt `toCapData`/`fromCapData` instead of deprecated terms
- use `Remotable` for the slot in bootstrapTests

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
