### PR TITLE
fix(SwingSet): dedupe `bundleTool.js` with Endo

### DIFF
--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -1,247 +1,29 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import bundleSource from '@endo/bundle-source';
-import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
-import { makePromiseKit } from '@endo/promise-kit';
+import { makeNodeBundleCache as wrappedMaker } from '@endo/bundle-source/cache.js';
 import styles from 'ansi-styles'; // less authority than 'chalk'
 
-const { quote: q, Fail } = assert;
-
-/**
- * @typedef {object} BundleMeta
- * @property {string} bundleFileName
- * @property {string} bundleTime as ISO string
- * @property {{relative: string, absolute: string}} moduleSource
- * @property {Array<{relativePath: string, mtime: string}>} contents
- */
-
-export const makeFileReader = (fileName, { fs, path }) => {
-  const make = there => makeFileReader(there, { fs, path });
-  return harden({
-    toString: () => fileName,
-    readText: () => fs.promises.readFile(fileName, 'utf-8'),
-    neighbor: ref => make(path.resolve(fileName, ref)),
-    stat: () => fs.promises.stat(fileName),
-    absolute: () => path.normalize(fileName),
-    relative: there => path.relative(fileName, there),
-    exists: () => fs.existsSync(fileName),
-  });
+export const makeNodeBundleCache = async (dest, options, loadModule) => {
+  const log = (...args) => {
+    const flattened = args.map(arg =>
+      // Don't print stack traces.
+      arg instanceof Error ? arg.message : arg,
+    );
+    console.log(
+      // Make all messages prefixed and dim.
+      `${styles.dim.open}[bundleTool]`,
+      ...flattened,
+      styles.dim.close,
+    );
+  };
+  return wrappedMaker(dest, { log, ...options }, loadModule);
 };
 
-/**
- * @param {string} fileName
- * @param {{ fs: import('fs'), path: import('path') }} io
- */
-export const makeFileWriter = (fileName, { fs, path }) => {
-  const make = there => makeFileWriter(there, { fs, path });
-  return harden({
-    toString: () => fileName,
-    writeText: txt => fs.promises.writeFile(fileName, txt),
-    readOnly: () => makeFileReader(fileName, { fs, path }),
-    neighbor: ref => make(path.resolve(fileName, ref)),
-    mkdir: opts => fs.promises.mkdir(fileName, opts),
-  });
-};
-
-/** @type {(n: string) => string} */
-const toBundleName = n => `bundle-${n}.js`;
-/** @type {(n: string) => string} */
-const toBundleMeta = n => `bundle-${n}-meta.json`;
-
-/** @type {Map<string, Promise<*>>} */
+/** @type {Map<string, ReturnType<typeof makeNodeBundleCache>>} */
 const providedCaches = new Map();
 
 /**
- * @param {ReturnType<typeof makeFileWriter>} wr
- * @param {*} bundleOptions
- * @param {ReturnType<typeof makeFileReader>} cwd
- * @param {*} readPowers
- */
-export const makeBundleCache = (wr, bundleOptions, cwd, readPowers) => {
-  const dimLog = (...args) =>
-    console.log(
-      `${styles.dim.open}[bundleTool] ${[...args].join(' ')}${
-        styles.dim.close
-      }`,
-    );
-
-  const add = async (rootPath, targetName) => {
-    const srcRd = cwd.neighbor(rootPath);
-
-    const modTimeByPath = new Map();
-
-    const loggedRead = async loc => {
-      if (!loc.match(/\bpackage.json$/)) {
-        try {
-          const itemRd = cwd.neighbor(new URL(loc).pathname);
-          const ref = srcRd.relative(itemRd.absolute());
-          const { mtime } = await itemRd.stat();
-          modTimeByPath.set(ref, mtime);
-          // console.log({ loc, mtime, ref });
-        } catch (oops) {
-          console.error(oops);
-        }
-      }
-      return readPowers.read(loc);
-    };
-    const bundle = await bundleSource(rootPath, bundleOptions, {
-      ...readPowers,
-      read: loggedRead,
-    });
-
-    const { moduleFormat } = bundle;
-    assert.equal(moduleFormat, 'endoZipBase64');
-
-    const code = `export default ${JSON.stringify(bundle)};`;
-    await wr.mkdir({ recursive: true });
-    const bundleFileName = toBundleName(targetName);
-    const bundleWr = wr.neighbor(bundleFileName);
-    await bundleWr.writeText(code);
-    const { mtime: bundleTime } = await bundleWr.readOnly().stat();
-
-    /** @type {BundleMeta} */
-    const meta = {
-      bundleFileName,
-      bundleTime: bundleTime.toISOString(),
-      moduleSource: {
-        relative: bundleWr.readOnly().relative(srcRd.absolute()),
-        absolute: srcRd.absolute(),
-      },
-      contents: [...modTimeByPath.entries()].map(([relativePath, mtime]) => ({
-        relativePath,
-        mtime: mtime.toISOString(),
-      })),
-    };
-
-    await wr
-      .neighbor(toBundleMeta(targetName))
-      .writeText(JSON.stringify(meta, null, 2));
-    return meta;
-  };
-
-  const validate = async (targetName, rootOpt) => {
-    const metaRd = wr.readOnly().neighbor(toBundleMeta(targetName));
-    let txt;
-    try {
-      txt = await metaRd.readText();
-    } catch (ioErr) {
-      Fail`${q(targetName)}: cannot read bundle metadata: ${q(ioErr)}`;
-    }
-    const meta = JSON.parse(txt);
-    const {
-      bundleFileName,
-      bundleTime,
-      contents,
-      moduleSource: { absolute: moduleSource },
-    } = meta;
-    assert.equal(bundleFileName, toBundleName(targetName));
-    if (rootOpt) {
-      moduleSource === cwd.neighbor(rootOpt).absolute() ||
-        Fail`bundle ${targetName} was for ${moduleSource}, not ${rootOpt}`;
-    }
-    const { mtime: actualBundleTime } = await wr
-      .readOnly()
-      .neighbor(bundleFileName)
-      .stat();
-    assert.equal(actualBundleTime.toISOString(), bundleTime);
-    const moduleRd = wr.readOnly().neighbor(moduleSource);
-    const actualTimes = await Promise.all(
-      contents.map(async ({ relativePath }) => {
-        const itemRd = moduleRd.neighbor(relativePath);
-        const { mtime } = await itemRd.stat();
-        return { relativePath, mtime: mtime.toISOString() };
-      }),
-    );
-    const outOfDate = actualTimes.filter(({ mtime }) => mtime > bundleTime);
-    outOfDate.length === 0 ||
-      Fail`out of date: ${q(outOfDate)}. ${q(targetName)} bundled at ${q(
-        bundleTime,
-      )}`;
-    return meta;
-  };
-
-  /**
-   *
-   * @param {string} rootPath
-   * @param {string} targetName
-   * @returns {Promise<BundleMeta>}
-   */
-  const validateOrAdd = async (rootPath, targetName) => {
-    let meta;
-    if (wr.readOnly().neighbor(toBundleMeta(targetName)).exists()) {
-      try {
-        meta = await validate(targetName, rootPath);
-      } catch (invalid) {
-        dimLog(invalid.message);
-      }
-    }
-    if (!meta) {
-      dimLog(`${wr}`, 'add:', targetName, 'from', rootPath);
-      meta = await add(rootPath, targetName);
-    }
-    return meta;
-  };
-
-  const loaded = new Map();
-  /**
-   * @param {string} rootPath
-   * @param {string} [targetName]
-   */
-  const load = async (
-    rootPath,
-    targetName = readPowers.basename(rootPath, '.js'),
-  ) => {
-    const found = loaded.get(targetName);
-    // console.log('load', { targetName, found: !!found, rootPath });
-    if (found && found.rootPath === rootPath) {
-      return found.bundle;
-    }
-    const todo = makePromiseKit();
-    loaded.set(targetName, { rootPath, bundle: todo.promise });
-    const bundle = await validateOrAdd(rootPath, targetName)
-      .then(({ bundleFileName }) =>
-        import(`${wr.readOnly().neighbor(bundleFileName)}`),
-      )
-      .then(m => harden(m.default));
-    assert.equal(bundle.moduleFormat, 'endoZipBase64');
-    todo.resolve(bundle);
-    return bundle;
-  };
-
-  return harden({
-    add,
-    validate,
-    validateOrAdd,
-    load,
-  });
-};
-
-/**
- * Make a new bundle cache for the destination. If there is already one for that destination, error.
- *
- * @param {string} dest
- * @param {{ format?: string, dev?: boolean }} options
- * @param {(id: string) => Promise<any>} loadModule
- */
-export const makeNodeBundleCache = async (dest, options, loadModule) => {
-  const [fs, path, url, crypto] = await Promise.all([
-    await loadModule('fs'),
-    await loadModule('path'),
-    await loadModule('url'),
-    await loadModule('crypto'),
-  ]);
-
-  const readPowers = {
-    ...makeReadPowers({ fs, url, crypto }),
-    basename: path.basename,
-  };
-
-  const cwd = makeFileReader('', { fs, path });
-  const destWr = makeFileWriter(dest, { fs, path });
-  return makeBundleCache(destWr, options, cwd, readPowers);
-};
-
-/**
- * Make a new bundle cache for the destination. If there is already one for that destination, error.
+ * Make a new bundle cache for the destination. If there is already one for that
+ * destination, return it.
  *
  * @param {string} dest
  * @param {{ format?: string, dev?: boolean }} options
@@ -249,13 +31,12 @@ export const makeNodeBundleCache = async (dest, options, loadModule) => {
  */
 export const provideBundleCache = (dest, options, loadModule) => {
   const uniqueDest = [dest, options.format, options.dev].join('-');
-  if (!providedCaches.has(uniqueDest)) {
-    providedCaches.set(
-      uniqueDest,
-      makeNodeBundleCache(dest, options, loadModule),
-    );
+  let bundleCache = providedCaches.get(uniqueDest);
+  if (!bundleCache) {
+    bundleCache = makeNodeBundleCache(dest, options, loadModule);
+    providedCaches.set(uniqueDest, bundleCache);
   }
-  return providedCaches.get(uniqueDest);
+  return bundleCache;
 };
 harden(provideBundleCache);
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Use Endo's bundle tool infrastructure.  This PR was accidentally omitted during the Endo upgrade.

The main feature is that file locking is implemented to prevent `bundleTool.js` from clobbering bundles made by other processes or async Workers, such as under parallel AVA tests.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
