### PR TITLE
fix: remove well-known-name limitation on reserved brands etc.

### DIFF
--- a/packages/inter-protocol/README.md
+++ b/packages/inter-protocol/README.md
@@ -108,7 +108,7 @@ vaultFactoryInstance = E(home.agoricNames).lookup('instance', 'VaultFactory')
 vaultFactoryPublicFacet = E(home.zoe).getPublicFacet(vaultFactoryInstance)
 # get a reference to the minted brand (soon to be IST)
 E(home.agoricNames).lookup('brand', 'IST');
-runBrand=history[-1]
+stableBrand=history[-1]
 # get a reference to the collateral brand
 E(home.agoricNames).lookup('brand', 'ATOM')
 atomBrand=history[-1]
@@ -117,7 +117,7 @@ collateralManager = E(vaultFactoryPublicFacet).getCollateralManager(atomBrand)
 # proposal
 proposal = ({
   give: { Collateral: { brand: atomBrand, value: 1000n } },
-  want: { IST: { brand: runBrand, value: 1n } },
+  want: { IST: { brand: stableBrand, value: 1n } },
 })
 # get the ATOM purse
 E(home.wallet).getPurses()

--- a/packages/inter-protocol/src/proposals/addAssetToVault.js
+++ b/packages/inter-protocol/src/proposals/addAssetToVault.js
@@ -147,7 +147,7 @@ export const registerScaledPriceAuthority = async (
 
   const [
     sourcePriceAuthority,
-    [interchainBrand, runBrand],
+    [interchainBrand, stableBrand],
     [interchainOracleBrand, usdBrand],
     [scaledPriceAuthority],
   ] = await Promise.all([
@@ -181,7 +181,7 @@ export const registerScaledPriceAuthority = async (
     getDecimalP(interchainOracleBrand),
     getDecimalP(interchainBrand),
     getDecimalP(usdBrand),
-    getDecimalP(runBrand),
+    getDecimalP(stableBrand),
   ]);
 
   const scaleIn = makeRatio(
@@ -194,10 +194,10 @@ export const registerScaledPriceAuthority = async (
     10n ** BigInt(decimalPlacesUsd),
     usdBrand,
     10n ** BigInt(decimalPlacesRun),
-    runBrand,
+    stableBrand,
   );
   const initialPrice = initialPriceRaw
-    ? parseRatio(initialPriceRaw, runBrand, interchainBrand)
+    ? parseRatio(initialPriceRaw, stableBrand, interchainBrand)
     : undefined;
 
   const terms = await deeplyFulfilledObject(
@@ -226,7 +226,7 @@ export const registerScaledPriceAuthority = async (
     // @ts-expect-error The public facet should have getPriceAuthority
     E(spaKit.publicFacet).getPriceAuthority(),
     interchainBrand,
-    runBrand,
+    stableBrand,
     true, // force
   );
 };

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -75,7 +75,7 @@ export const setupReserveServices = async (
   const { feeMintAccessP, zoe } = farZoeKit;
 
   const runIssuer = await E(zoe).getFeeIssuer();
-  const runBrand = await E(runIssuer).getBrand();
+  const stableBrand = await E(runIssuer).getBrand();
 
   // @ts-expect-error a non-promise can be used where a promise is expected.
   const spaces = await setupReserveBootstrap(t, timer, farZoeKit);
@@ -97,7 +97,7 @@ export const setupReserveServices = async (
 
   const faucetBundle = await provideBundle(t, faucetRoot, 'faucet');
   const faucetInstallation = E(zoe).install(faucetBundle);
-  brand.produce.IST.resolve(runBrand);
+  brand.produce.IST.resolve(stableBrand);
   issuer.produce.IST.resolve(runIssuer);
   const feeMintAccess = await feeMintAccessP;
   produce.feeMintAccess.resolve(await feeMintAccess);

--- a/packages/inter-protocol/test/smartWallet/boot-psm.js
+++ b/packages/inter-protocol/test/smartWallet/boot-psm.js
@@ -343,8 +343,8 @@ export const buildRootObject = (vatPowers, vatParameters) => {
       assert.typeof(name, 'string');
       return consume[name];
     },
-    // ??? any more dangerous than produceItem/consumeItem?
-    /** @type {() => PromiseSpace} */
+    /** @type {() => ChainBootstrapSpace} */
+    // @ts-expect-error cast
     getPromiseSpace: () => ({ consume, produce, ...spaces }),
   });
 };

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -58,7 +58,6 @@ const makeTestSpace = async (log, bundleCache) => {
   // ensuring a feed for ATOM-USD
 
   /** @type {ChainBootstrapSpace} */
-  // @ts-expect-error cast
   const space = psmVatRoot.getPromiseSpace();
   await eventLoopIteration();
 
@@ -252,6 +251,7 @@ test.serial('admin price', async t => {
 
   // Verify price result
 
+  // @ts-expect-error cast
   const manualTimer = /** @type {ManualTimer} */ (
     t.context.consume.chainTimerService
   );

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -47,8 +47,7 @@ const makePsmTestSpace = async (log, bundleCache) => {
   );
   void psmVatRoot.bootstrap(...mockPsmBootstrapArgs(log));
 
-  // @ts-expect-error cast
-  return /** @type {ChainBootstrapSpace} */ (psmVatRoot.getPromiseSpace());
+  return psmVatRoot.getPromiseSpace();
 };
 
 test.before(async t => {

--- a/packages/inter-protocol/test/test-gov-collateral.js
+++ b/packages/inter-protocol/test/test-gov-collateral.js
@@ -69,7 +69,7 @@ const makeTestContext = async () => {
     await setUpZoeForTest();
 
   const runIssuer = await E(zoe).getFeeIssuer();
-  const runBrand = await E(runIssuer).getBrand();
+  const stableBrand = await E(runIssuer).getBrand();
 
   const install = (src, dest) =>
     bundleCache.load(src, dest).then(b => E(zoe).install(b));
@@ -132,7 +132,7 @@ const makeTestContext = async () => {
     feeMintAccess: await feeMintAccessP,
     vatAdminSvc,
     vatAdminState,
-    run: { issuer: runIssuer, brand: runBrand },
+    run: { issuer: runIssuer, brand: stableBrand },
     installation,
   };
 };
@@ -166,11 +166,11 @@ const makeScenario = async (t, { env = process.env } = {}) => {
         consume: { [Stable.symbol]: runIssuer },
       },
       brand: {
-        consume: { [Stable.symbol]: runBrand },
+        consume: { [Stable.symbol]: stableBrand },
       },
     } = space;
     return E(E(runIssuer).makeEmptyPurse()).withdraw(
-      AmountMath.make(await runBrand, 0n),
+      AmountMath.make(await stableBrand, 0n),
     );
   };
 
@@ -476,7 +476,7 @@ test.skip('assets are in Vaults', async t => {
     instance: { consume: instanceP },
   } = s.space;
   const brand = await E(agoricNames).lookup('brand', 'ATOM');
-  const runBrand = await E(agoricNames).lookup('brand', Stable.symbol);
+  const stableBrand = await E(agoricNames).lookup('brand', Stable.symbol);
 
   /** @type {ERef<import('../src/vaultFactory/vaultFactory').VaultFactoryContract['publicFacet']>} */
   const vaultsAPI = instanceP.VaultFactory.then(i => E(zoe).getPublicFacet(i));
@@ -487,7 +487,7 @@ test.skip('assets are in Vaults', async t => {
   t.deepEqual(params.DebtLimit, {
     type: 'amount',
     // 1000 IST is the default debtLimitValue in add-collateral-core
-    value: { brand: runBrand, value: 1_000n * UNIT },
+    value: { brand: stableBrand, value: 1_000n * UNIT },
   });
 });
 
@@ -505,7 +505,7 @@ test.skip('Committee can raise debt limit', async t => {
 
   const { agoricNames } = s.space.consume;
   const brand = await E(agoricNames).lookup('brand', 'ATOM');
-  const runBrand = await E(agoricNames).lookup('brand', Stable.symbol);
+  const stableBrand = await E(agoricNames).lookup('brand', Stable.symbol);
   const vaultsInstance = await E(agoricNames).lookup(
     'instance',
     'VaultFactory',
@@ -536,7 +536,7 @@ test.skip('Committee can raise debt limit', async t => {
     E(E(zoe).offer(charterInv)).getOfferResult(),
   ).invitationMakers;
 
-  const params = { DebtLimit: AmountMath.make(runBrand, 100n) };
+  const params = { DebtLimit: AmountMath.make(stableBrand, 100n) };
 
   // We happen to know how the timer is implemented.
   /** @type { ERef<ManualTimer> } */
@@ -594,7 +594,7 @@ test.skip('Committee can raise debt limit', async t => {
   const count = E(zoe).getPublicFacet(counterInstance);
   const outcome = await E(count).getOutcome();
   t.deepEqual(outcome, {
-    changes: { DebtLimit: { brand: runBrand, value: 100n } },
+    changes: { DebtLimit: { brand: stableBrand, value: 100n } },
   });
 });
 

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -95,9 +95,9 @@ const defaultParamValues = debt =>
 export const makeDriverContext = async () => {
   const { zoe, feeMintAccessP } = await setUpZoeForTest();
   const runIssuer = await E(zoe).getFeeIssuer();
-  const runBrand = await E(runIssuer).getBrand();
+  const stableBrand = await E(runIssuer).getBrand();
   // @ts-expect-error missing mint
-  const run = withAmountUtils({ issuer: runIssuer, brand: runBrand });
+  const run = withAmountUtils({ issuer: runIssuer, brand: stableBrand });
   const aeth = withAmountUtils(makeIssuerKit('aEth'));
   const bundleCache = await unsafeMakeBundleCache('./bundles/'); // package-relative
 

--- a/packages/inter-protocol/test/vaultFactory/test-vault-interest.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-interest.js
@@ -60,12 +60,12 @@ async function launch(zoeP, sourceRoot) {
     runMint,
     collateralKit: { mint: collateralMint, brand: collaterlBrand },
   } = testJig;
-  const { brand: runBrand } = runMint.getIssuerRecord();
+  const { brand: stableBrand } = runMint.getIssuerRecord();
 
   const collateral50 = AmountMath.make(collaterlBrand, 50n);
   const proposal = harden({
     give: { Collateral: collateral50 },
-    want: { Minted: AmountMath.make(runBrand, 70n) },
+    want: { Minted: AmountMath.make(stableBrand, 70n) },
   });
   const payments = harden({
     Collateral: collateralMint.mintPayment(collateral50),
@@ -86,14 +86,14 @@ test('charges', async t => {
   // presents a fixed price of 4 Minted per Collateral.
   await E(creatorSeat).getOfferResult();
   const { runMint, collateralKit, vault } = testJig;
-  const { brand: runBrand } = runMint.getIssuerRecord();
+  const { brand: stableBrand } = runMint.getIssuerRecord();
 
   const { brand: cBrand } = collateralKit;
 
   const startingDebt = 74n;
   t.deepEqual(
     vault.getCurrentDebt(),
-    AmountMath.make(runBrand, startingDebt),
+    AmountMath.make(stableBrand, startingDebt),
     'borrower owes 74 Minted',
   );
   t.deepEqual(
@@ -120,7 +120,7 @@ test('charges', async t => {
   trace('partially payback');
   const paybackValue = 3n;
   const collateralWanted = AmountMath.make(cBrand, 1n);
-  const paybackAmount = AmountMath.make(runBrand, paybackValue);
+  const paybackAmount = AmountMath.make(stableBrand, paybackValue);
   const payback = await E(creatorFacet).mintRun(paybackAmount);
   const paybackSeat = E(zoe).offer(
     vault.makeAdjustBalancesInvitation(),
@@ -133,12 +133,12 @@ test('charges', async t => {
   await E(paybackSeat).getOfferResult();
   t.deepEqual(
     vault.getCurrentDebt(),
-    AmountMath.make(runBrand, startingDebt + interest - paybackValue),
+    AmountMath.make(stableBrand, startingDebt + interest - paybackValue),
   );
   const normalizedPaybackValue = paybackValue - 1n;
   t.deepEqual(
     vault.getNormalizedDebt(),
-    AmountMath.make(runBrand, startingDebt - normalizedPaybackValue),
+    AmountMath.make(stableBrand, startingDebt - normalizedPaybackValue),
   );
 
   testJig.setInterestRate(25n);

--- a/packages/inter-protocol/test/vaultFactory/test-vault.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault.js
@@ -62,12 +62,12 @@ async function launch(zoeP, sourceRoot) {
     runMint,
     collateralKit: { mint: collateralMint, brand: collateralBrand },
   } = testJig;
-  const { brand: runBrand } = runMint.getIssuerRecord();
+  const { brand: stableBrand } = runMint.getIssuerRecord();
 
   const collateral50 = AmountMath.make(collateralBrand, 50n);
   const proposal = harden({
     give: { Collateral: collateral50 },
-    want: { Minted: AmountMath.make(runBrand, 70n) },
+    want: { Minted: AmountMath.make(stableBrand, 70n) },
   });
   const payments = harden({
     Collateral: collateralMint.mintPayment(collateral50),
@@ -90,13 +90,13 @@ test('first', async t => {
   // presents a fixed price of 4 Minted per Collateral.
   await E(creatorSeat).getOfferResult();
   const { runMint, collateralKit, vault } = testJig;
-  const { brand: runBrand } = runMint.getIssuerRecord();
+  const { brand: stableBrand } = runMint.getIssuerRecord();
 
   const { issuer: cIssuer, mint: cMint, brand: cBrand } = collateralKit;
 
   t.deepEqual(
     vault.getCurrentDebt(),
-    AmountMath.make(runBrand, 74n),
+    AmountMath.make(stableBrand, 74n),
     'borrower owes 74 Minted',
   );
   t.deepEqual(
@@ -114,7 +114,7 @@ test('first', async t => {
     invite,
     harden({
       give: { Collateral: collateralAmount },
-      want: {}, // Minted: AmountMath.make(runBrand, 2n) },
+      want: {}, // Minted: AmountMath.make(stableBrand, 2n) },
     }),
     harden({
       // TODO
@@ -132,7 +132,7 @@ test('first', async t => {
 
   // partially payback
   const collateralWanted = AmountMath.make(cBrand, 1n);
-  const paybackAmount = AmountMath.make(runBrand, 3n);
+  const paybackAmount = AmountMath.make(stableBrand, 3n);
   const payback = await E(creatorFacet).mintRun(paybackAmount);
   const paybackSeat = E(zoe).offer(
     vault.makeAdjustBalancesInvitation(),
@@ -149,7 +149,7 @@ test('first', async t => {
   const returnedAmount = await cIssuer.getAmountOf(returnedCollateral);
   t.deepEqual(
     vault.getCurrentDebt(),
-    AmountMath.make(runBrand, 71n),
+    AmountMath.make(stableBrand, 71n),
     'debt reduced to 71 Minted',
   );
   t.deepEqual(
@@ -175,7 +175,7 @@ test('bad collateral', async t => {
   // presents a fixed price of 4 Minted per Collateral.
   await E(offerKit).getOfferResult();
   const { brand: collateralBrand } = collateralKit;
-  const { brand: runBrand } = runMint.getIssuerRecord();
+  const { brand: stableBrand } = runMint.getIssuerRecord();
 
   t.deepEqual(
     vault.getCollateralAmount(),
@@ -184,7 +184,7 @@ test('bad collateral', async t => {
   );
   t.deepEqual(
     vault.getCurrentDebt(),
-    AmountMath.make(runBrand, 74n),
+    AmountMath.make(stableBrand, 74n),
     'borrower owes 74 Minted',
   );
 

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -81,9 +81,9 @@ export const Phase = /** @type {const} */ ({
 test.before(async t => {
   const { zoe, feeMintAccessP } = await setUpZoeForTest();
   const runIssuer = await E(zoe).getFeeIssuer();
-  const runBrand = await E(runIssuer).getBrand();
+  const stableBrand = await E(runIssuer).getBrand();
   // @ts-expect-error missing mint
-  const run = withAmountUtils({ issuer: runIssuer, brand: runBrand });
+  const run = withAmountUtils({ issuer: runIssuer, brand: stableBrand });
   const aeth = withAmountUtils(
     makeIssuerKit('aEth', AssetKind.NAT, { decimalPlaces: 6 }),
   );

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -75,9 +75,9 @@ export const Phase = /** @type {const} */ ({
 test.before(async t => {
   const { zoe, feeMintAccessP } = await setUpZoeForTest();
   const runIssuer = await E(zoe).getFeeIssuer();
-  const runBrand = await E(runIssuer).getBrand();
+  const stableBrand = await E(runIssuer).getBrand();
   // @ts-expect-error missing mint
-  const run = withAmountUtils({ issuer: runIssuer, brand: runBrand });
+  const run = withAmountUtils({ issuer: runIssuer, brand: stableBrand });
   const aeth = withAmountUtils(
     makeIssuerKit('aEth', 'nat', { decimalPlaces: 6 }),
   );

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -50,16 +50,16 @@ export async function start(zcf, privateArgs, baggage) {
     'Minted',
     privateArgs.feeMintAccess,
   );
-  const { brand: runBrand } = runMint.getIssuerRecord();
+  const { brand: stableBrand } = runMint.getIssuerRecord();
 
-  const LIQUIDATION_MARGIN = makeRatio(105n, runBrand);
+  const LIQUIDATION_MARGIN = makeRatio(105n, stableBrand);
 
   const { zcfSeat: vaultFactorySeat } = zcf.makeEmptySeatKit();
 
   let vaultCounter = 0;
 
-  let currentInterest = makeRatio(5n, runBrand); // 5%
-  let compoundedInterest = makeRatio(100n, runBrand); // starts at 1.0, no interest
+  let currentInterest = makeRatio(5n, stableBrand); // 5%
+  let compoundedInterest = makeRatio(100n, stableBrand); // starts at 1.0, no interest
 
   const { zcfSeat: mintSeat } = zcf.makeEmptySeatKit();
 
@@ -68,7 +68,7 @@ export async function start(zcf, privateArgs, baggage) {
   const timer = buildManualTimer(console.log, 0n, { timeStep: DAY });
   const options = {
     actualBrandIn: collateralBrand,
-    actualBrandOut: runBrand,
+    actualBrandOut: stableBrand,
     priceList: [80],
     tradeList: undefined,
     timer,
@@ -77,7 +77,7 @@ export async function start(zcf, privateArgs, baggage) {
   const collateralUnit = await unitAmount(collateralBrand);
   const quoteNotifier = E(priceAuthority).makeQuoteNotifier(
     collateralUnit,
-    runBrand,
+    stableBrand,
   );
   let storedCollateralQuote;
   observeNotifier(quoteNotifier, {
@@ -134,7 +134,7 @@ export async function start(zcf, privateArgs, baggage) {
           throw Error('not implemented');
         },
         getMintFee() {
-          return makeRatio(500n, runBrand, BASIS_POINTS);
+          return makeRatio(500n, stableBrand, BASIS_POINTS);
         },
         getInterestRate() {
           return currentInterest;
@@ -147,7 +147,7 @@ export async function start(zcf, privateArgs, baggage) {
           return LIQUIDATION_MARGIN;
         },
         getMinInitialDebt() {
-          return AmountMath.makeEmpty(runBrand);
+          return AmountMath.makeEmpty(stableBrand);
         },
         getRecordingPeriod() {
           return DAY;
@@ -157,7 +157,7 @@ export async function start(zcf, privateArgs, baggage) {
     getCollateralBrand() {
       return collateralBrand;
     },
-    getDebtBrand: () => runBrand,
+    getDebtBrand: () => stableBrand,
 
     getAssetSubscriber: () => assetSubscriber,
     maxDebtFor,
@@ -202,7 +202,7 @@ export async function start(zcf, privateArgs, baggage) {
   };
 
   const setInterestRate = percent => {
-    currentInterest = makeRatio(percent, runBrand);
+    currentInterest = makeRatio(percent, stableBrand);
   };
 
   zcf.setTestJig(() => ({

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -420,7 +420,6 @@ export const makeClientBanks = async ({
         !powerFlags.includes(PowerFlags.REMOTE_WALLET),
         `REMOTE and SMART_WALLET are exclusive`,
       );
-      /** @type {ERef<import('../types').MyAddressNameAdmin>} */
       const myAddressNameAdmin = E(namesByAddressAdmin).lookupAdmin(address);
 
       const smartWallet = E(walletFactoryCreatorFacet).provideSmartWallet(

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -79,7 +79,7 @@
  * @typedef {object} Producer<T>
  * @property {(v: ERef<T>) => void} resolve
  * @property {(r: unknown) => void} reject
- * @property {() => void} reset
+ * @property {(reason?: unknown) => void} reset
  * @template T
  */
 /**
@@ -91,12 +91,6 @@
  */
 
 /**
- * @template [V=unknown]
- * @typedef {{
- *   consume: Record<string, Promise<V>>,
- *   produce: Record<string, Producer<V>>,
- * }} PromiseSpace
- *
  * @typedef {{
  *   assignBundle: (ps: PropertyMaker[]) => void
  * }} ClientManager tool to put properties onto the `home` object of the client
@@ -109,7 +103,7 @@
  * @template [C={}] Consume only
  * @template [P={}] Produce only
  * @typedef {{
- *   consume: { [K in keyof (B & C)]: ERef<(B & C)[K]> },
+ *   consume: { [K in keyof (B & C)]: Promise<(B & C)[K]> },
  *   produce: { [K in keyof (B & P)]: Producer<(B & P)[K]> },
  * }} PromiseSpaceOf
  */

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -89,10 +89,12 @@
  * @typedef {(name: string, sourceRef?: VatSourceRef) => T} VatLoader<T>
  * @template T
  */
+
 /**
+ * @template [V=unknown]
  * @typedef {{
- *   consume: Record<string, Promise<unknown>>,
- *   produce: Record<string, Producer<unknown>>,
+ *   consume: Record<string, Promise<V>>,
+ *   produce: Record<string, Producer<V>>,
  * }} PromiseSpace
  *
  * @typedef {{

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -200,7 +200,7 @@ const noop = harden(() => {});
 export const makePromiseSpaceForNameHub = (nameAdmin, log = noop) => {
   const logHooks = makeLogHooks(log);
 
-  /** @type {PromiseSpace<unknown>} */
+  /** @type {PromiseSpaceOf<any>} */
   const space = makePromiseSpace({
     hooks: harden({
       ...logHooks,

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -1,18 +1,12 @@
 // @ts-check
 import { E, Far } from '@endo/far';
-import { assertPassable } from '@endo/marshal';
 import { WalletName } from '@agoric/internal';
 import { makeNameHubKit } from '../nameHub.js';
 import { Stable, Stake } from '../tokens.js';
-import { makePromiseSpace } from './promise-space.js';
+import { makeLogHooks, makePromiseSpace } from './promise-space.js';
 
 const { entries, fromEntries, keys } = Object;
 const { Fail, quote: q } = assert;
-
-/** @type { <K extends string, T, U>(obj: Record<K, T>, f: (k: K, v: T) => [K, U]) => Record<K, U>} */
-const mapEntries = (obj, f) =>
-  // @ts-expect-error entries() loses key type
-  fromEntries(entries(obj).map(([p, v]) => f(p, v)));
 
 /**
  * We reserve these keys in name hubs.
@@ -196,6 +190,61 @@ export const runModuleBehaviors = ({
 };
 harden(runModuleBehaviors);
 
+const noop = harden(() => {});
+
+/**
+ *
+ * @param {ERef<import('../types').NameAdmin>} nameAdmin
+ * @param {typeof console.log} [log]
+ */
+export const makePromiseSpaceForNameHub = (nameAdmin, log = noop) => {
+  const logHooks = makeLogHooks(log);
+
+  /** @type {PromiseSpace<unknown>} */
+  const space = makePromiseSpace({
+    hooks: harden({
+      ...logHooks,
+      onAddKey: name => {
+        void E(nameAdmin).reserve(name);
+        logHooks.onAddKey(name);
+      },
+      onResolve: (name, valueP) => {
+        void E.when(valueP, value => E(nameAdmin).update(name, value));
+      },
+      onReset: name => {
+        void E(nameAdmin).delete(name);
+      },
+    }),
+    log,
+  });
+
+  return space;
+};
+
+/**
+ * @param {import('../types').NameAdmin} parentAdmin
+ * @param {typeof console.log} [log]
+ * @param {string[]} [kinds]
+ */
+export const makeWellKnownSpaces = (
+  parentAdmin,
+  log = noop,
+  kinds = Object.keys(agoricNamesReserved),
+) => {
+  const spaces = Object.fromEntries(
+    kinds.map(kind => {
+      const { nameAdmin } = parentAdmin.provideChild(kind);
+      const subSpaceLog = (...args) => log(kind, ...args);
+      const entry = [kind, makePromiseSpaceForNameHub(nameAdmin, subSpaceLog)];
+      return entry;
+    }),
+  );
+  const typedSpaces = /** @type { WellKnownSpaces } */ (
+    /** @type {any} */ (spaces)
+  );
+  return typedSpaces;
+};
+
 /**
  * Make the well-known agoricNames namespace so that we can
  * E(home.agoricNames).lookup('issuer', 'IST') and likewise
@@ -221,29 +270,12 @@ export const makeAgoricNamesAccess = (
 ) => {
   const { nameHub: agoricNames, nameAdmin: agoricNamesAdmin } =
     makeNameHubKit();
+  const spaces = makeWellKnownSpaces(
+    agoricNamesAdmin,
+    log,
+    Object.keys(reserved),
+  );
 
-  const hubs = mapEntries(reserved, (key, _d) => {
-    const { nameHub, nameAdmin } = makeNameHubKit();
-    const passableAdmin = {
-      ...nameAdmin,
-      update: (nameKey, val) => {
-        assertPassable(val); // else we can't publish
-        return nameAdmin.update(nameKey, val);
-      },
-    };
-    agoricNamesAdmin.update(key, nameHub, passableAdmin);
-    return [key, { nameHub, nameAdmin }];
-  });
-  const spaces = mapEntries(reserved, (key, detail) => {
-    const { nameAdmin } = hubs[key];
-    const subSpaceLog = (...args) => log(key, ...args);
-    const { produce, consume } = makePromiseSpace(subSpaceLog);
-    for (const k of keys(detail)) {
-      nameAdmin.reserve(k);
-      void consume[k].then(v => nameAdmin.update(k, v));
-    }
-    return [key, { produce, consume }];
-  });
   const typedSpaces = /** @type { WellKnownSpaces } */ (
     /** @type {any} */ (spaces)
   );

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -65,11 +65,12 @@ export const makeNameHubKit = () => {
   /** @type {LegacyMap<string, NameRecord>} */
   // Legacy because a promiseKit is not a passable
   const keyToAdminRecord = makeLegacyMap('nameKey');
-  /** @type {undefined | ((entries: [string, unknown][]) => void)} */
+  /** @type {undefined | ((entries: [string, unknown][]) => ERef<void>)} */
   let updateCallback;
   const updated = () => {
+    let result;
     if (updateCallback) {
-      updateCallback(
+      result = updateCallback(
         harden(
           [
             ...mapIterable(keyToRecord.entries(), ([name, record]) =>
@@ -81,6 +82,8 @@ export const makeNameHubKit = () => {
         ),
       );
     }
+    // return Promise regardless of result type
+    return Promise.resolve(result);
   };
 
   /** @type {import('./types.js').NameAdmin} */
@@ -164,7 +167,7 @@ export const makeNameHubKit = () => {
           map.init(key, record);
         }
       }
-      updated();
+      return updated();
     },
     lookupAdmin: async (...path) => {
       if (path.length === 0) {
@@ -198,7 +201,7 @@ export const makeNameHubKit = () => {
         keyToRecord.delete(key);
       } finally {
         keyToAdminRecord.delete(key);
-        updated();
+        void updated();
       }
     },
     readonly: () => nameHub,

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -32,9 +32,10 @@ export {};
 /**
  * @typedef {object} NameAdmin write access to a node in a name hierarchy
  *
- * @property {(key: string) => void} reserve Mark a key as reserved; will
+ * @property {(key: string, reserved?: string[]) => NameHubKit} provideChild
+ * @property {(key: string) => Promise<void>} reserve Mark a key as reserved; will
  * return a promise that is fulfilled when the key is updated (or rejected when
- * deleted).
+ * deleted). If the key was already set it does nothing.
  * @property {<T>( key: string, newValue: T, newAdmin?: unknown) =>
  *   T } default Update if not already updated.  Return
  *   existing value, or newValue if not existing.

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -43,7 +43,7 @@ export {};
  *   key: string, newValue: unknown, newAdmin?: NameAdmin) => void
  * } set Update only if already initialized. Reject if not.
  * @property {(
- *   key: string, newValue: unknown, newAdmin?: NameAdmin) => void
+ *   key: string, newValue: unknown, newAdmin?: NameAdmin) => Promise<void>
  * } update Fulfill an outstanding reserved promise (if any) to the newValue and
  * set the key to the newValue.  If newAdmin is provided, set that to return via
  * lookupAdmin.
@@ -54,7 +54,7 @@ export {};
  * outstanding reserved promise (if any).
  * @property {() => NameHub} readonly get the NameHub corresponding to the
  * current NameAdmin
- * @property {(fn: undefined | ((entries: [string, unknown][]) => void)) => void} onUpdate
+ * @property {(fn: undefined | ((entries: [string, unknown][]) => void)) => ERef<void>} onUpdate
  */
 
 /**

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -36,18 +36,18 @@ export {};
  * @property {(key: string) => Promise<void>} reserve Mark a key as reserved; will
  * return a promise that is fulfilled when the key is updated (or rejected when
  * deleted). If the key was already set it does nothing.
- * @property {<T>( key: string, newValue: T, newAdmin?: unknown) =>
+ * @property {<T>( key: string, newValue: T, newAdmin?: NameAdmin) =>
  *   T } default Update if not already updated.  Return
  *   existing value, or newValue if not existing.
  * @property {(
- *   key: string, newValue: unknown, newAdmin?: unknown) => void
+ *   key: string, newValue: unknown, newAdmin?: NameAdmin) => void
  * } set Update only if already initialized. Reject if not.
  * @property {(
- *   key: string, newValue: unknown, newAdmin?: unknown) => void
+ *   key: string, newValue: unknown, newAdmin?: NameAdmin) => void
  * } update Fulfill an outstanding reserved promise (if any) to the newValue and
  * set the key to the newValue.  If newAdmin is provided, set that to return via
  * lookupAdmin.
- * @property {(...path: Array<string>) => Promise<any>} lookupAdmin Look up the
+ * @property {(...path: Array<string>) => Promise<NameAdmin>} lookupAdmin Look up the
  * `newAdmin` from the path of keys starting from the current NameAdmin.  Wait
  * on any reserved promises.
  * @property {(key: string) => void} delete Delete a value and reject an

--- a/packages/vats/test/test-name-hub-published.js
+++ b/packages/vats/test/test-name-hub-published.js
@@ -4,7 +4,10 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { makeMockChainStorageRoot } from '@agoric/inter-protocol/test/supports.js';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import { makeAgoricNamesAccess } from '../src/core/utils.js';
+import {
+  makeAgoricNamesAccess,
+  makePromiseSpaceForNameHub,
+} from '../src/core/utils.js';
 import { makePromiseSpace } from '../src/core/promise-space.js';
 import {
   publishAgoricNames,
@@ -12,6 +15,7 @@ import {
 } from '../src/core/chain-behaviors.js';
 import { makeBoard } from '../src/lib-board.js';
 import { makeAddressNameHubs } from '../src/core/basic-behaviors.js';
+import { makeNameHubKit } from '../src/nameHub.js';
 
 test('publishAgoricNames publishes AMM instance', async t => {
   const space = makePromiseSpace();
@@ -43,5 +47,18 @@ test('publishAgoricNames publishes AMM instance', async t => {
     [['amm', ammInstance]],
   );
 
-  t.throws(() => instanceAdmin.update('non-passable', new Promise(() => {})));
+  // XXX throws in a way that ava doesn't catch???
+  // t.throws(() => instanceAdmin.update('non-passable', new Promise(() => {})));
+});
+
+test('promise space reserves non-well-known names', async t => {
+  const { nameHub, nameAdmin } = makeNameHubKit();
+  const remoteAdmin = Promise.resolve(nameAdmin);
+  const space = makePromiseSpaceForNameHub(remoteAdmin);
+
+  const thing1 = space.consume.thing1;
+  space.produce.thing1.resolve(true);
+  t.is(await thing1, true);
+
+  t.is(await nameHub.lookup('thing1'), true);
 });

--- a/packages/vats/test/test-name-hub-published.js
+++ b/packages/vats/test/test-name-hub-published.js
@@ -1,6 +1,6 @@
 // @ts-check
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
 import { makeMockChainStorageRoot } from '@agoric/inter-protocol/test/supports.js';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
@@ -47,8 +47,10 @@ test('publishAgoricNames publishes AMM instance', async t => {
     [['amm', ammInstance]],
   );
 
-  // XXX throws in a way that ava doesn't catch???
-  // t.throws(() => instanceAdmin.update('non-passable', new Promise(() => {})));
+  await t.throwsAsync(instanceAdmin.update('non-passable', Promise.resolve()), {
+    message:
+      'invalid key type for collection "valToId": A "promise" cannot be a scalar key: "[Promise]"',
+  });
 });
 
 test('promise space reserves non-well-known names', async t => {

--- a/packages/vats/test/test-name-hub.js
+++ b/packages/vats/test/test-name-hub.js
@@ -170,3 +170,25 @@ test('makeNameHubKit - listen for updates', t => {
     [['IST', brandIST]],
   ]);
 });
+
+test('nameAdmin provideChild', async t => {
+  const { nameHub: namesByAddress, nameAdmin: namesByAddressAdmin } =
+    makeNameHubKit();
+  const child = namesByAddressAdmin.provideChild('ag123', [
+    'depositFacet',
+    'otherReserved',
+  ]);
+  t.deepEqual(child.nameHub.keys(), ['depositFacet', 'otherReserved']);
+  child.nameAdmin.update('depositFacet', 'D1');
+  const actual = await namesByAddress.lookup('ag123', 'depositFacet');
+  t.is(actual, 'D1');
+
+  t.truthy(
+    namesByAddress.lookup('ag123', 'otherReserved').then,
+    'reserved keys should have a promise',
+  );
+
+  await t.throwsAsync(() => namesByAddress.lookup('ag123', 'never'), {
+    message: '"nameKey" not found: "never"',
+  });
+});

--- a/packages/vats/test/test-promise-space.js
+++ b/packages/vats/test/test-promise-space.js
@@ -22,13 +22,11 @@ test('makePromiseSpace', async t => {
 
   await checkAlice(consume.alice, `Hi, I'm Alice!`);
 
-  // @ts-expect-error
   produce.alice.reset(`I'm ignored!`);
   await checkAlice(consume.alice, `Hi, I'm Alice again!`);
 
   produce.alice.reset();
   const newAlice = consume.alice;
-  // @ts-expect-error
   produce.alice.reset(`I'm rejected!`);
   await newAlice.then(
     res => t.assert(false, `unexpected resolution ${res}`),

--- a/packages/vats/test/test-promise-space.js
+++ b/packages/vats/test/test-promise-space.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 
 import { makePromiseSpace } from '../src/core/promise-space.js';
 
@@ -37,4 +38,24 @@ test('makePromiseSpace', async t => {
   const reusedAlice = consume.alice;
   produce.alice.reset();
   await checkAlice(reusedAlice, `Hi, I'm Alice 3!`);
+});
+
+test('makePromiseSpace backed by store', async t => {
+  /** @type {MapStore<string, string>} */
+  const store = makeScalarBigMapStore('stuff', { durable: true });
+  {
+    const { produce, consume } = makePromiseSpace({ store });
+    produce.alice.resolve(`Hi, I'm Alice!`);
+    await consume.alice;
+  }
+  t.is(store.get('alice'), `Hi, I'm Alice!`);
+  const p = Promise.resolve(`Hi again!`);
+  {
+    const { produce, consume } = makePromiseSpace({ store });
+    produce.alice.reset();
+    produce.alice.resolve(p);
+    await consume.alice;
+  }
+  await p;
+  t.is(store.get('alice'), `Hi again!`);
 });


### PR DESCRIPTION
refs: #4548

## Description

While refactoring the promise space to support a backing store, I it was straightforward to address a long-standing wart:

In the case of `{ brand: { consume: { abc } }`, reserve `abc`
even though it's not among the statically defined reserved names.

### Security / Scaling Considerations

none

### Documentation Considerations

This reduces a burden on MN-2 core eval proposals, as discussed recently...
https://github.com/Agoric/agoric-sdk/discussions/6839#discussioncomment-5442784

### Testing Considerations

happy-path unit tests for enhancements to PromiseSpace, NameHub APIs.
