### PR TITLE
ci: bump ava exit timeout in hope to reduce flakes

### DIFF
--- a/patches/ava+5.2.0.patch
+++ b/patches/ava+5.2.0.patch
@@ -22,7 +22,7 @@ index afe5528..f748fec 100644
  		extensions: globs.extensions,
  		projectDir,
 diff --git a/node_modules/ava/lib/fork.js b/node_modules/ava/lib/fork.js
-index 7630baa..a88bda5 100644
+index 7630baa..5754d77 100644
 --- a/node_modules/ava/lib/fork.js
 +++ b/node_modules/ava/lib/fork.js
 @@ -7,6 +7,7 @@ import Emittery from 'emittery';
@@ -51,7 +51,7 @@ index 7630baa..a88bda5 100644
  
 +				case 'exiting': {
 +					exitCode = message.ava.code;
-+					setCappedTimeout(() => finished || exit(), 30_000).unref();
++					setCappedTimeout(() => finished || exit(), 120_000).unref();
 +					break;
 +				}
 +


### PR DESCRIPTION
We've been hit by more frequent flakes in the bootstrap tests. Not sure why, but these don't reproduce locally. There seem to be some strange slowness to how ava workers in CI, so bump the timeout we added in the ava exit checks that verify we didn't leave unfinished work around.