### PR TITLE
feat(vats): allow replacing a scoped bridge handler

### DIFF
--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -14,9 +14,9 @@ export const BridgeHandlerI = M.interface('BridgeHandler', {
 export const BridgeScopedManagerI = M.interface('ScopedBridgeManager', {
   fromBridge: M.call(M.any()).returns(M.promise()),
   toBridge: M.call(M.any()).returns(M.promise()),
-  setHandler: M.call(
-    M.or(M.remotable('BridgeHandler'), M.undefined()),
-  ).returns(),
+  setHandler: M.call(M.remotable('BridgeHandler'))
+    .optional(M.remotable('BridgeHandler'))
+    .returns(),
 });
 
 export const BridgeManagerI = M.interface('BridgeManager', {
@@ -63,14 +63,14 @@ const prepareScopedManager = zone => {
         assert(inboundHandler, X`No inbound handler for ${bridgeId}`);
         return E(inboundHandler).fromBridge(obj);
       },
-      setHandler(newHandler) {
+      setHandler(newHandler, oldHandler) {
         // setHandler could probably be on a separate facet to separate it
         // from the toBridge and fromBridge powers, but it's easier to
         // implement an already set check for the handler and pass a single
         // object around.
-        // We do allow unsetting to support explicit transfer to a new handler
-        !newHandler ||
-          !this.state.inboundHandler ||
+        // We do allow explicitly replacing the handler by requiring the old
+        // handler to also be provided.
+        this.state.inboundHandler === oldHandler ||
           Fail`Bridge handler already set for ${this.state.bridgeId}`;
         this.state.inboundHandler = newHandler;
       },

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -14,7 +14,9 @@ export const BridgeHandlerI = M.interface('BridgeHandler', {
 export const BridgeScopedManagerI = M.interface('ScopedBridgeManager', {
   fromBridge: M.call(M.any()).returns(M.promise()),
   toBridge: M.call(M.any()).returns(M.promise()),
-  setHandler: M.call(M.remotable('BridgeHandler')).returns(),
+  setHandler: M.call(
+    M.or(M.remotable('BridgeHandler'), M.undefined()),
+  ).returns(),
 });
 
 export const BridgeManagerI = M.interface('BridgeManager', {
@@ -64,9 +66,11 @@ const prepareScopedManager = zone => {
       setHandler(newHandler) {
         // setHandler could probably be on a separate facet to separate it
         // from the toBridge and fromBridge powers, but it's easier to
-        // implement a set once check for the handler and pass a single
+        // implement an already set check for the handler and pass a single
         // object around.
-        !this.state.inboundHandler ||
+        // We do allow unsetting to support explicit transfer to a new handler
+        !newHandler ||
+          !this.state.inboundHandler ||
           Fail`Bridge handler already set for ${this.state.bridgeId}`;
         this.state.inboundHandler = newHandler;
       },

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -75,7 +75,7 @@ export {};
  * @typedef {object} ScopedBridgeManager An object which handles messages for a specific bridge
  * @property {(obj: any) => Promise<any>} toBridge
  * @property {(obj: any) => Promise<void>} fromBridge
- * @property {(handler: ERef<BridgeHandler>) => void} setHandler
+ * @property {(handler: ERef<BridgeHandler> | undefined) => void} setHandler
  */
 
 /**

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -75,7 +75,7 @@ export {};
  * @typedef {object} ScopedBridgeManager An object which handles messages for a specific bridge
  * @property {(obj: any) => Promise<any>} toBridge
  * @property {(obj: any) => Promise<void>} fromBridge
- * @property {(handler: ERef<BridgeHandler> | undefined) => void} setHandler
+ * @property {(handler: ERef<BridgeHandler>, oldHandler?: ERef<BridgeHandler>) => void} setHandler
  */
 
 /**


### PR DESCRIPTION
closes: #7576

## Description

Supports future upgrade paths where the handler was not durable by allowing the handler to be replaced, but only in cases where the old handler can be provided to prevent unexpected changes.

### Security Considerations

Requiring the old handler effectively restricts the capability to change handlers to the previous provider, which could have done that in the first place by updating its implementation. No new power is granted through this change.

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

The bridge manager does not have unit tests and I think it wouldn't be cost effective to add them as part of this simple change.
