### PR TITLE
fix(agoric-cli): harden bridgeAction

### DIFF
--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -106,7 +106,7 @@ export const coalesceWalletState = async (follower, invitationBrand) => {
  * }} opts
  */
 export const sendAction = async (bridgeAction, opts) => {
-  const offerBody = JSON.stringify(marshaller.toCapData(bridgeAction));
+  const offerBody = JSON.stringify(marshaller.toCapData(harden(bridgeAction)));
 
   // tryExit should not require --allow-spend
   // https://github.com/Agoric/agoric-sdk/issues/7291


### PR DESCRIPTION
refs https://github.com/Agoric/agoric-sdk/issues/5863
refs https://github.com/Agoric/agoric-sdk/issues/7601 

### Problem

```
$ bin/agops inter bid by-price --price 10.05 --give 0.05IST --from gov1 --keyring-backend=test
(Error#1)
Error#1: Cannot pass non-frozen objects like {
  method: 'executeOffer',
  offer: {
    id: 'bid-1683227276759',
    invitationSpec: {
      source: 'agoricContract',
      instancePath: [Array],
      callPipe: [Array]
    },
    proposal: { give: [Object] },
    offerArgs: { maxBuy: [Object], offerPrice: [Object] }
  }
} . Use harden()

  at sendAction (packages/agoric-cli/src/lib/wallet.js:109:47)
  at placeBid (packages/agoric-cli/src/commands/inter.js:332:26)
  at Command.<anonymous> (packages/agoric-cli/src/commands/inter.js:417:15)
  at async packages/agoric-cli/src/bin-agops.js:76:3
```

### Testing

Tested manually and saw the offer appear as pending:

![image](https://user-images.githubusercontent.com/8848650/236305684-a3c8617c-41ec-46c7-9ae0-e02cd0668fd2.png)
