### PR TITLE
Durable vat-bank and virtual-purse

### DIFF
--- a/packages/ERTP/src/types-ambient.js
+++ b/packages/ERTP/src/types-ambient.js
@@ -335,7 +335,7 @@
  * @property {() => Amount<K>} getCurrentAmount
  * Get the amount contained in this purse.
  *
- * @property {() => Notifier<Amount<K>>} getCurrentAmountNotifier
+ * @property {() => LatestTopic<Amount<K>>} getCurrentAmountNotifier
  * Get a lossy notifier for changes to this purse's balance.
  *
  * @property {PurseDeposit<K>} deposit

--- a/packages/agoric-cli/src/commands/reserve.js
+++ b/packages/agoric-cli/src/commands/reserve.js
@@ -9,7 +9,7 @@ import { outputActionAndHint } from '../lib/wallet.js';
 
 /**
  * @param {import('anylogger').Logger} _logger
- * @param io
+ * @param {*} io
  */
 export const makeReserveCommand = (_logger, io = {}) => {
   const { stdout = process.stdout, stderr = process.stderr, now } = io;

--- a/packages/agoric-cli/src/lib/format.js
+++ b/packages/agoric-cli/src/lib/format.js
@@ -93,7 +93,7 @@ export const asBoardRemote = x => {
 
 /**
  * Summarize the balances array as user-facing informative tuples
-
+ *
  * @param {import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord['purses']} purses
  * @param {AssetDescriptor[]} assets
  */

--- a/packages/inter-protocol/src/price/fluxAggregatorKit.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorKit.js
@@ -82,7 +82,6 @@ const priceDescriptionFromQuote = quote => quote.quoteAmount.value[0];
  * @param {StorageNode} storageNode
  * @param {() => PublishKit<any>} makeDurablePublishKit
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorder} makeRecorder
- * @returns a method to call once to create the prepared kit
  */
 export const prepareFluxAggregatorKit = async (
   baggage,

--- a/packages/internal/test/test-callback.js
+++ b/packages/internal/test/test-callback.js
@@ -286,6 +286,7 @@ test('makeAttenuator', async t => {
       throw Error('unexpected original.m3');
     },
   });
+  // @ts-expect-error deliberate: omitted method
   t.throws(() => makeAttenuator({ target, overrides: { m3: null } }), {
     message: `"Attenuator" overrides["m3"] not allowed by methodNames`,
   });
@@ -299,6 +300,7 @@ test('makeAttenuator', async t => {
     message: `unimplemented "Attenuator" method "m1"`,
   });
   await t.throwsAsync(() => atE.m2(), { message: `unexpected original.m2` });
+  // @ts-expect-error deliberate: omitted method
   t.throws(() => atE.m3(), { message: /not a function/ });
   await t.throwsAsync(() => atE.m4(), { message: /target has no method "m4"/ });
 
@@ -325,6 +327,7 @@ test('makeAttenuator', async t => {
   const p2 = atSync.m2();
   t.assert(p2 instanceof Promise);
   t.is(await p2, 'return abc');
+  // @ts-expect-error deliberate: omitted method
   t.throws(() => atSync.m3(), { message: /not a function/ });
   t.throws(() => atSync.m4(), { message: /not a function/ });
 });

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -97,7 +97,7 @@ export const observeIteration = (asyncIterableP, iterationObserver) => {
  * states are assumed irrelevant and dropped.
  *
  * @template T
- * @param {ERef<Notifier<T>>} notifierP
+ * @param {ERef<LatestTopic<T>>} notifierP
  * @param {Partial<IterationObserver<T>>} iterationObserver
  * @returns {Promise<undefined>}
  */

--- a/packages/notifier/src/types-ambient.js
+++ b/packages/notifier/src/types-ambient.js
@@ -31,6 +31,13 @@
  * @template T
  * @template [TReturn=any]
  * @template [TNext=undefined]
+ * @typedef {ForkableAsyncIterator<T, TReturn, TNext> & { [Symbol.asyncIterator](): ForkableAsyncIterableIterator<T, TReturn, TNext> }} ForkableAsyncIterableIterator
+ */
+
+/**
+ * @template T
+ * @template [TReturn=any]
+ * @template [TNext=undefined]
  * @typedef {{
  *   [Symbol.asyncIterator]: () => ForkableAsyncIterator<T, TReturn, TNext>
  * }} ForkableAsyncIterable

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -115,7 +115,7 @@ export const makeAssetRegistry = assetPublisher => {
  * @typedef {import('@agoric/vats').NameHub} NameHub
  *
  * @typedef {{
- *   getAssetSubscription: () => ERef<Subscription<import('@agoric/vats/src/vat-bank').AssetDescriptor>>
+ *   getAssetSubscription: () => ERef<AsyncIterable<import('@agoric/vats/src/vat-bank').AssetDescriptor>>
  * }} AssetPublisher
  */
 

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -4,6 +4,7 @@ import { E } from '@endo/far';
 import { buildRootObject as buildBankVatRoot } from '@agoric/vats/src/vat-bank.js';
 import { makeIssuerKit } from '@agoric/ertp';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import { makeScalarMapStore } from '@agoric/store';
 import { makeDefaultTestContext } from './contexts.js';
 import { makeMockTestSpace } from './supports.js';
 
@@ -13,7 +14,10 @@ const test = anyTest;
 test.before(async t => {
   const withBankManager = async () => {
     const noBridge = undefined;
-    const bankManager = E(buildBankVatRoot()).makeBankManager(noBridge);
+    const baggage = makeScalarMapStore('baggage');
+    const bankManager = E(
+      buildBankVatRoot(undefined, undefined, baggage),
+    ).makeBankManager(noBridge);
     const noop = () => {};
     const space0 = await makeMockTestSpace(noop);
     space0.produce.bankManager.reset();

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -306,7 +306,13 @@ const insistSameCapData = (oldCD, newCD) => {
  * @param {import('@endo/marshal').FromCapData<string>} unserialize  Unserializer for this vat
  * @param {*} assertAcceptableSyscallCapdataSize  Function to check for oversized
  *   syscall params
- * @param {import('./types').LiveSlotsOptions} liveSlotsOptions
+ * @param {import('./types').LiveSlotsOptions} [liveSlotsOptions]
+ * @param {{ WeakMap: typeof WeakMap, WeakSet: typeof WeakSet }} [powers]
+ * Specifying the underlying WeakMap/WeakSet objects to wrap with
+ * VirtualObjectAwareWeakMap/Set.  By default, capture the ones currently
+ * defined on `globalThis` when the maker is invoked, to avoid infinite
+ * recursion if our returned WeakMap/WeakSet wrappers are subsequently installed
+ * on globalThis.
  *
  * @returns {object} a new virtual object manager.
  *
@@ -348,6 +354,7 @@ export const makeVirtualObjectManager = (
   unserialize,
   assertAcceptableSyscallCapdataSize,
   liveSlotsOptions = {},
+  { WeakMap, WeakSet } = globalThis,
 ) => {
   const { allowStateShapeChanges = false } = liveSlotsOptions;
 

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -104,7 +104,7 @@ export const makeVatsFromBundles = async ({
 };
 harden(makeVatsFromBundles);
 
-/** @param {BootstrapPowers} powers */
+/** @param {BootstrapSpace} powers */
 export const produceStartUpgradable = async ({
   consume: { zoe },
   produce, // startUpgradable

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -50,7 +50,7 @@ export const prepareMixinMyAddress = zone => {
     ...NameHubIKit.nameAdmin.methodGuards,
     getMyAddress: M.call().returns(M.string()),
   });
-  /** @type {import('@agoric/internal/src/callback.js').AttenuatorMaker<import('./types.js').MyAddressNameAdmin>} */
+  /** @type {import('@agoric/internal/src/callback.js').MakeAttenuator<import('./types.js').MyAddressNameAdmin>} */
   const mixin = prepareGuardedAttenuator(zone, MixinI, {
     tag: 'MyAddressNameAdmin',
   });

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -196,7 +196,7 @@ const prepareBankChannelHandler = zone =>
             break;
           }
           default: {
-            Fail`Unrecognized request ${obj && obj.type}`;
+            Fail`Unrecognized request ${obj}`;
           }
         }
       },

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -4,10 +4,10 @@ import { AmountMath, AssetKind } from '@agoric/ertp';
 import { E, Far } from '@endo/far';
 import { makeNotifierKit, makeSubscriptionKit } from '@agoric/notifier';
 import { makeScalarMapStore, makeScalarWeakMapStore } from '@agoric/store';
+import { makeDurableZone } from '@agoric/zone/durable.js';
 import { prepareVirtualPurse } from './virtual-purse.js';
 
 import '@agoric/notifier/exported.js';
-import { makeDurableZone } from '@agoric/zone/durable.js';
 
 /**
  * @typedef {import('./virtual-purse').VirtualPurseController} VirtualPurseController
@@ -25,7 +25,7 @@ import { makeDurableZone } from '@agoric/zone/durable.js';
  * @param {string} denom
  * @param {Brand} brand
  * @param {string} address
- * @param {Notifier<Amount>} balanceNotifier
+ * @param {LatestTopic<Amount>} balanceNotifier
  * @param {(obj: any) => boolean} updateBalances
  * @returns {VirtualPurseController}
  */

--- a/packages/vats/src/vat-provisioning.js
+++ b/packages/vats/src/vat-provisioning.js
@@ -20,7 +20,7 @@ import {
 const prepareSpecializedNameAdmin = zone => {
   const mixinMyAddress = prepareMixinMyAddress(zone);
 
-  /** @type {import('@agoric/internal/src/callback.js').AttenuatorMaker<import('./types.js').NamesByAddressAdmin>} */
+  /** @type {import('@agoric/internal/src/callback.js').MakeAttenuator<import('./types.js').NamesByAddressAdmin>} */
   const specialize = prepareGuardedAttenuator(zone, NameHubIKit.nameAdmin, {
     tag: 'NamesByAddressAdmin',
   });

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -1,15 +1,94 @@
 // @ts-check
-import { E, Far } from '@endo/far';
-import { makeNotifierKit, observeIteration } from '@agoric/notifier';
+import { M } from '@agoric/store';
+import { E } from '@endo/far';
+import { makeNotifier } from '@agoric/notifier';
 import { isPromise } from '@endo/promise-kit';
+
+import {
+  AmountShape,
+  BrandShape,
+  DepositFacetShape,
+  NotifierShape,
+  PaymentShape,
+} from '@agoric/ertp/src/typeGuards.js';
 
 import '@agoric/ertp/exported.js';
 import '@agoric/notifier/exported.js';
+
+const { Fail } = assert;
+
+/**
+ * @param {Pattern} [brandShape]
+ * @param {Pattern} [amountShape]
+ */
+export const makeVirtualPurseKitIKit = (
+  brandShape = BrandShape,
+  amountShape = AmountShape,
+) => {
+  const VirtualPurseI = M.interface('VirtualPurse', {
+    getAllegedBrand: M.callWhen().returns(brandShape),
+    getCurrentAmount: M.callWhen().returns(amountShape),
+    getCurrentAmountNotifier: M.callWhen().returns(NotifierShape),
+    // PurseI does *not* delay `deposit` until `srcPayment` is fulfulled.
+    // Rather, the semantics of `deposit` require it to provide its
+    // callers with a strong guarantee that `deposit` messages are
+    // processed without further delay in the order they arrive.
+    // PurseI therefore requires that the `srcPayment` argument already
+    // be a remotable, not a promise.
+    // PurseI only calls this raw method after validating that
+    // `srcPayment` is a remotable, leaving it
+    // to this raw method to validate that this remotable is actually
+    // a live payment of the correct brand with sufficient funds.
+    deposit: M.callWhen(PaymentShape)
+      .optional(M.pattern())
+      .returns(amountShape),
+    getDepositFacet: M.callWhen().returns(DepositFacetShape),
+    withdraw: M.callWhen(amountShape).returns(PaymentShape),
+    getRecoverySet: M.callWhen().returns(M.setOf(PaymentShape)),
+    recoverAll: M.callWhen().returns(amountShape),
+  });
+
+  const DepositFacetI = M.interface('DepositFacet', {
+    receive: VirtualPurseI.methodGuards.deposit,
+  });
+
+  const RetainRedeemI = M.interface('RetainRedeem', {
+    retain: M.callWhen(PaymentShape).optional(amountShape).returns(amountShape),
+    redeem: M.callWhen(amountShape).returns(PaymentShape),
+  });
+
+  const UtilsI = M.interface('Utils', {
+    retain: RetainRedeemI.methodGuards.retain,
+    redeem: RetainRedeemI.methodGuards.redeem,
+    recoverableClaim: M.callWhen(M.await(PaymentShape))
+      .optional(amountShape)
+      .returns(PaymentShape),
+  });
+
+  const VirtualPurseIKit = harden({
+    depositFacet: DepositFacetI,
+    purse: VirtualPurseI,
+    escrower: RetainRedeemI,
+    minter: RetainRedeemI,
+    utils: UtilsI,
+  });
+
+  const VirtualPurseControllerI = M.interface('VirtualPurseController', {
+    pushAmount: M.callWhen(AmountShape).returns(),
+    pullAmount: M.callWhen(AmountShape).returns(),
+    getBalances: M.call(BrandShape).returns(NotifierShape),
+  });
+
+  return { VirtualPurseIKit, VirtualPurseControllerI };
+};
 
 /**
  * @template T
  * @typedef {import('@endo/far').EOnly<T>} EOnly
  */
+
+/** @typedef {(pmt: Payment, optAmountShape?: Pattern) => Promise<Amount>} Retain */
+/** @typedef {(amt: Amount) => Promise<Payment>} Redeem */
 
 /**
  * @typedef {object} VirtualPurseController The object that determines the
@@ -22,158 +101,215 @@ import '@agoric/notifier/exported.js';
  * to send an amount from the "other side" to "us".  This should resolve on
  * success and reject on failure.  We can still recover assets from failure to
  * pull.
- * @property {(brand: Brand) => AsyncIterable<Amount>} getBalances Return the
+ * @property {(brand: Brand) => LatestTopic<Amount>} getBalances Return the
  * current balance iterable for a given brand.
  */
 
 /**
- * @param {ERef<VirtualPurseController>} vpc the controller that represents the
- * "other side" of this purse.
- * @param {{ issuer: ERef<Issuer>, brand: Brand, mint?: ERef<Mint>,
- * escrowPurse?: ERef<Purse> }} kit
- * the contents of the issuer kit for "us".
- *
- * If the mint is not specified, then the virtual purse will escrow local assets
- * instead of minting/burning them.  That is a better option in general, but
- * escrow doesn't support the case where the "other side" is also minting
- * assets... our escrow purse may not have enough assets in it to redeem the
- * ones that are sent from the "other side".
- * @returns {EOnly<Purse>} This is not just a Purse because it plays
- * fast-and-loose with the synchronous Purse interface.  So, the consumer of
- * this result must only interact with the virtual purse via eventual-send (to
- * conceal the methods that are returning promises instead of synchronously).
+ * @param {import('@agoric/zone').Zone} zone
  */
-function makeVirtualPurse(vpc, kit) {
-  const { brand, issuer, mint, escrowPurse } = kit;
+const prepareVirtualPurseKit = zone =>
+  zone.exoClassKit(
+    'VirtualPurseKit',
+    makeVirtualPurseKitIKit().VirtualPurseIKit,
+    /**
+     * @param {ERef<VirtualPurseController>} vpc
+     * @param {{ issuer: ERef<Issuer>, brand: Brand, mint?: ERef<Mint> }} issuerKit
+     * @param {{ recoveryPurse: ERef<Purse>, escrowPurse?: ERef<Purse> }} purses
+     */
+    (vpc, issuerKit, purses) => ({
+      vpc,
+      ...issuerKit,
+      ...purses,
+      retainerFacet: issuerKit.mint
+        ? /** @type {const} */ ('minter')
+        : /** @type {const} */ ('escrower'),
+    }),
+    {
+      utils: {
+        /**
+         * Claim a payment for recovery via our `recoveryPurse`.  No need for this on
+         * the `retain` operations (since we are just burning the payment or
+         * depositing it directly in the `escrowPurse`).
+         *
+         * @param {ERef<Payment>} payment
+         * @param {Amount} [optAmountShape]
+         */
+        async recoverableClaim(payment, optAmountShape) {
+          const {
+            state: { recoveryPurse },
+          } = this;
+          const pmt = await payment;
+          const amt = await E(recoveryPurse).deposit(pmt, optAmountShape);
+          return E(recoveryPurse).withdraw(optAmountShape || amt);
+        },
+        /** @type {Retain} */
+        async retain(payment, optAmountShape) {
+          const {
+            state: { retainerFacet },
+            facets: { [retainerFacet]: retainer },
+          } = this;
+          return retainer.retain(payment, optAmountShape);
+        },
+        /** @type {Redeem} */
+        async redeem(amount) {
+          const {
+            state: { retainerFacet },
+            facets: { [retainerFacet]: retainer },
+          } = this;
+          return retainer.redeem(amount);
+        },
+      },
+      minter: {
+        /** @type {Retain} */
+        async retain(payment, optAmountShape) {
+          this.state.mint || Fail`minter cannot retain without a mint.`;
+          return E(this.state.issuer).burn(payment, optAmountShape);
+        },
+        /** @type {Redeem} */
+        async redeem(amount) {
+          const {
+            state: { mint },
+          } = this;
+          if (!mint) {
+            throw Fail`minter cannot redeem without a mint.`;
+          }
+          return this.facets.utils.recoverableClaim(
+            E(mint).mintPayment(amount),
+          );
+        },
+      },
+      escrower: {
+        /** @type {Retain} */
+        async retain(payment, optAmountShape) {
+          const {
+            state: { escrowPurse },
+          } = this;
+          if (!escrowPurse) {
+            throw Fail`escrower cannot retain without an escrow purse.`;
+          }
+          return E(escrowPurse).deposit(payment, optAmountShape);
+        },
+        /** @type {Redeem} */
+        async redeem(amount) {
+          const {
+            state: { escrowPurse },
+          } = this;
+          if (!escrowPurse) {
+            throw Fail`escrower cannot redeem without an escrow purse.`;
+          }
+          return this.facets.utils.recoverableClaim(
+            E(escrowPurse).withdraw(amount),
+          );
+        },
+      },
+      depositFacet: {
+        async receive(payment, optAmountShape = undefined) {
+          if (isPromise(payment)) {
+            throw TypeError(
+              `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: E.when(paymentPromise, actualPayment => deposit(actualPayment))`,
+            );
+          }
 
-  const recoveryPurse = E(issuer).makeEmptyPurse();
+          const amt = await this.facets.utils.retain(payment, optAmountShape);
+
+          // The push must always succeed.
+          //
+          // NOTE: There is no potential recovery protocol for failed `.pushAmount`,
+          // there's no path to send a new payment back to the virtual purse holder.
+          // If we don't first retain the payment, we can't be guaranteed that it is
+          // the correct value, and that would be a race where somebody else might
+          // claim the payment before us.
+          return E(this.state.vpc)
+            .pushAmount(amt)
+            .then(_ => amt);
+        },
+      },
+      purse: {
+        async deposit(payment, optAmountShape) {
+          return this.facets.depositFacet.receive(payment, optAmountShape);
+        },
+        getAllegedBrand() {
+          return this.state.brand;
+        },
+        async getCurrentAmount() {
+          const topic = E(this.state.vpc).getBalances(this.state.brand);
+          return E.get(E(topic).getUpdateSince()).value;
+        },
+        getCurrentAmountNotifier() {
+          const topic = E(this.state.vpc).getBalances(this.state.brand);
+          return topic;
+        },
+        getDepositFacet() {
+          return this.facets.depositFacet;
+        },
+        async withdraw(amount) {
+          // Both ensure that the amount exists, and have the other side "send" it
+          // to us.  If this fails, the balance is not affected and the withdraw
+          // (properly) fails, too.
+          await E(this.state.vpc).pullAmount(amount);
+          // Amount has been successfully received from the other side.
+          // Try to redeem the amount.
+          const pmt = await this.facets.utils.redeem(amount).catch(async e => {
+            // We can recover from failed redemptions... just send back what we
+            // received.
+            await E(this.state.vpc).pushAmount(amount);
+            throw e;
+          });
+          return pmt;
+        },
+        getRecoverySet() {
+          return E(this.state.recoveryPurse).getRecoverySet();
+        },
+        recoverAll() {
+          return E(this.state.recoveryPurse).recoverAll();
+        },
+      },
+    },
+  );
+
+/**
+ * @param {import('@agoric/zone').Zone} zone
+ */
+export const prepareVirtualPurse = zone => {
+  const makeVirtualPurseKit = prepareVirtualPurseKit(zone);
 
   /**
-   * Claim a payment for recovery via our `recoveryPurse`.  No need for this on
-   * the `retain` operations (since we are just burning the payment or
-   * depositing it directly in the `escrowPurse`).
+   * @param {ERef<VirtualPurseController>} vpc the controller that represents the
+   * "other side" of this purse.
+   * @param {{ issuer: ERef<Issuer>, brand: Brand, mint?: ERef<Mint>,
+   * escrowPurse?: ERef<Purse> }} params
+   * the contents of the issuer kit for "us".
    *
-   * @param {ERef<Payment>} payment
-   * @param {Amount} [optAmountShape]
+   * If the mint is not specified, then the virtual purse will escrow local assets
+   * instead of minting/burning them.  That is a better option in general, but
+   * escrow doesn't support the case where the "other side" is also minting
+   * assets... our escrow purse may not have enough assets in it to redeem the
+   * ones that are sent from the "other side".
+   * @returns {Promise<EOnly<Purse>>} This is not just a Purse because it plays
+   * fast-and-loose with the synchronous Purse interface.  So, the consumer of
+   * this result must only interact with the virtual purse via eventual-send (to
+   * conceal the methods that are returning promises instead of synchronously).
    */
-  const recoverableClaim = async (payment, optAmountShape) => {
-    const pmt = await payment;
-    const amt = await E(recoveryPurse).deposit(pmt, optAmountShape);
-    return E(recoveryPurse).withdraw(optAmountShape || amt);
+  const makeVirtualPurse = async (
+    vpc,
+    { escrowPurse: defaultEscrowPurse, ...issuerKit },
+  ) => {
+    const [recoveryPurse, escrowPurse] = await Promise.all([
+      E(issuerKit.issuer).makeEmptyPurse(),
+      // If we can't mint, then we need to escrow.
+      issuerKit.mint
+        ? defaultEscrowPurse
+        : defaultEscrowPurse || E(issuerKit.issuer).makeEmptyPurse(),
+    ]);
+    const vpurse = makeVirtualPurseKit(vpc, issuerKit, {
+      recoveryPurse,
+      escrowPurse,
+    }).purse;
+    return vpurse;
   };
 
-  /**
-   * @returns {{
-   *   retain: (pmt: Payment, optAmountShape?: Pattern) => Promise<Amount>,
-   *   redeem: (amt: Amount) => Promise<Payment>,
-   * }}
-   */
-  const makeRetainRedeem = () => {
-    if (mint) {
-      const retain = (payment, optAmountShape = undefined) =>
-        E(issuer).burn(payment, optAmountShape);
-      const redeem = amount => recoverableClaim(E(mint).mintPayment(amount));
-      return { retain, redeem };
-    }
+  return makeVirtualPurse;
+};
 
-    // If we can't mint, then we need to escrow.
-    const myEscrowPurse = escrowPurse || E(issuer).makeEmptyPurse();
-    const retain = async (payment, optAmountShape = undefined) =>
-      E(myEscrowPurse).deposit(payment, optAmountShape);
-    const redeem = amount =>
-      recoverableClaim(E(myEscrowPurse).withdraw(amount));
-
-    return { retain, redeem };
-  };
-
-  const { retain, redeem } = makeRetainRedeem();
-
-  /** @type {NotifierRecord<Amount>} */
-  const { notifier: balanceNotifier, updater: balanceUpdater } =
-    makeNotifierKit();
-
-  /** @type {ERef<Amount>} */
-  let lastBalance = E.get(balanceNotifier.getUpdateSince()).value;
-
-  // Robustly observe the balance.
-  const fail = reason => {
-    balanceUpdater.fail(reason);
-    const rej = Promise.reject(reason);
-    rej.catch(_ => {});
-    lastBalance = rej;
-  };
-  observeIteration(E(vpc).getBalances(brand), {
-    fail,
-    updateState(nonFinalValue) {
-      balanceUpdater.updateState(nonFinalValue);
-      lastBalance = nonFinalValue;
-    },
-    finish(completion) {
-      balanceUpdater.finish(completion);
-      lastBalance = completion;
-    },
-    // Propagate a failed balance properly if the iteration observer fails.
-  }).catch(fail);
-
-  /** @type {EOnly<DepositFacet>} */
-  const depositFacet = Far('Virtual Deposit Facet', {
-    async receive(payment, optAmountShape = undefined) {
-      if (isPromise(payment)) {
-        throw TypeError(
-          `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: E.when(paymentPromise, actualPayment => deposit(actualPayment))`,
-        );
-      }
-
-      const amt = await retain(payment, optAmountShape);
-
-      // The push must always succeed.
-      //
-      // NOTE: There is no potential recovery protocol for failed `.pushAmount`,
-      // there's no path to send a new payment back to the virtual purse holder.
-      // If we don't first retain the payment, we can't be guaranteed that it is
-      // the correct value, and that would be a race where somebody else might
-      // claim the payment before us.
-      return E(vpc)
-        .pushAmount(amt)
-        .then(_ => amt);
-    },
-  });
-
-  /** @type {EOnly<Purse>} */
-  const purse = Far('Virtual Purse', {
-    deposit: depositFacet.receive,
-    getAllegedBrand() {
-      return brand;
-    },
-    getCurrentAmount() {
-      return lastBalance;
-    },
-    getCurrentAmountNotifier() {
-      return balanceNotifier;
-    },
-    getDepositFacet() {
-      return depositFacet;
-    },
-    async withdraw(amount) {
-      // Both ensure that the amount exists, and have the other side "send" it
-      // to us.  If this fails, the balance is not affected and the withdraw
-      // (properly) fails, too.
-      await E(vpc).pullAmount(amount);
-      // Amount has been successfully received from the other side.
-      // Try to redeem the amount.
-      const pmt = await redeem(amount).catch(async e => {
-        // We can recover from failed redemptions... just send back what we
-        // received.
-        await E(vpc).pushAmount(amount);
-        throw e;
-      });
-      return pmt;
-    },
-    getRecoverySet: () => E(recoveryPurse).getRecoverySet(),
-    recoverAll: () => E(recoveryPurse).recoverAll(),
-  });
-  return purse;
-}
-harden(makeVirtualPurse);
-
-export { makeVirtualPurse };
+harden(prepareVirtualPurse);

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -286,7 +286,7 @@ export const prepareVirtualPurse = zone => {
    * escrow doesn't support the case where the "other side" is also minting
    * assets... our escrow purse may not have enough assets in it to redeem the
    * ones that are sent from the "other side".
-   * @returns {Promise<EOnly<Purse>>} This is not just a Purse because it plays
+   * @returns {Promise<Awaited<EOnly<Purse>>>} This is not just a Purse because it plays
    * fast-and-loose with the synchronous Purse interface.  So, the consumer of
    * this result must only interact with the virtual purse via eventual-send (to
    * conceal the methods that are returning promises instead of synchronously).

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -1,7 +1,6 @@
 // @ts-check
 import { M } from '@agoric/store';
 import { E } from '@endo/far';
-import { makeNotifier } from '@agoric/notifier';
 import { isPromise } from '@endo/promise-kit';
 
 import {

--- a/packages/vats/test/setup-vat-data.js
+++ b/packages/vats/test/setup-vat-data.js
@@ -1,0 +1,28 @@
+/* global globalThis */
+// This file produces the globalThis.VatData property outside of SwingSet so
+// that it can be used by '@agoric/vat-data' (which only *consumes*
+// `globalThis.VatData`) in code under test.
+import { makeFakeVirtualStuff } from '@agoric/swingset-liveslots/tools/fakeVirtualSupport.js';
+
+export const fakeVomKit = makeFakeVirtualStuff({
+  relaxDurabilityRules: false,
+});
+
+globalThis.WeakMap = fakeVomKit.vom.VirtualObjectAwareWeakMap;
+globalThis.WeakSet = fakeVomKit.vom.VirtualObjectAwareWeakSet;
+
+const { vom, wpm: watchedPromiseManager, cm: collectionManager } = fakeVomKit;
+globalThis.VatData = harden({
+  defineKind: vom.defineKind,
+  defineKindMulti: vom.defineKindMulti,
+  defineDurableKind: vom.defineDurableKind,
+  defineDurableKindMulti: vom.defineDurableKindMulti,
+  makeKindHandle: vom.makeKindHandle,
+  canBeDurable: vom.canBeDurable,
+  providePromiseWatcher: watchedPromiseManager.providePromiseWatcher,
+  watchPromise: watchedPromiseManager.watchPromise,
+  makeScalarBigMapStore: collectionManager.makeScalarBigMapStore,
+  makeScalarBigWeakMapStore: collectionManager.makeScalarBigWeakMapStore,
+  makeScalarBigSetStore: collectionManager.makeScalarBigSetStore,
+  makeScalarBigWeakSetStore: collectionManager.makeScalarBigWeakSetStore,
+});

--- a/packages/vats/test/test-clientBundle.js
+++ b/packages/vats/test/test-clientBundle.js
@@ -106,7 +106,6 @@ test('connectFaucet produces payments', async t => {
                 return amt;
               },
             }),
-            // @ts-expect-error mock
             getAssetSubscription: () => null,
           }),
       }),

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -16,6 +16,7 @@ import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js'
 import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { E, Far } from '@endo/far';
 import path from 'path';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
 import centralSupplyBundle from '../bundles/bundle-centralSupply.js';
 import { makeBoard } from '../src/lib-board.js';
 import { makeNameHubKit } from '../src/nameHub.js';
@@ -269,7 +270,12 @@ test('provisionPool trades provided assets for IST', async t => {
  * @param {string} address
  */
 const makeWalletFactoryKitFor1 = async address => {
-  const bankManager = await buildBankRoot().makeBankManager();
+  const baggage = makeScalarBigMapStore('bank baggage');
+  const bankManager = await buildBankRoot(
+    undefined,
+    undefined,
+    baggage,
+  ).makeBankManager();
 
   const fees = withAmountUtils(makeIssuerKit('FEE'));
   await bankManager.addAsset('ufee', 'FEE', 'FEE', fees);
@@ -280,7 +286,7 @@ const makeWalletFactoryKitFor1 = async address => {
   };
 
   const b1 = bankManager.getBankForAddress(address);
-  const p1 = b1.getPurse(fees.brand);
+  const p1 = E(b1).getPurse(fees.brand);
 
   /** @type {import('@agoric/smart-wallet/src/smartWallet.js').SmartWallet} */
   // @ts-expect-error mock

--- a/packages/vats/test/test-vat-bank-integration.js
+++ b/packages/vats/test/test-vat-bank-integration.js
@@ -1,0 +1,118 @@
+// @ts-check
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { makeScalarMapStore } from '@agoric/vat-data';
+
+import { E } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
+import { makeZoeKit } from '@agoric/zoe';
+import { observeIteration } from '@agoric/notifier';
+import { buildRootObject } from '../src/vat-bank.js';
+import {
+  mintInitialSupply,
+  addBankAssets,
+  installBootContracts,
+  produceStartUpgradable,
+} from '../src/core/basic-behaviors.js';
+import { makeAgoricNamesAccess } from '../src/core/utils.js';
+import { makePromiseSpace } from '../src/core/promise-space.js';
+import { makePopulatedFakeVatAdmin } from '../tools/boot-test-utils.js';
+
+test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
+  // Supply bootstrap prerequisites.
+  const space = /** @type { any } */ (makePromiseSpace(t.log));
+  const { produce, consume } =
+    /** @type { BootstrapPowers & { consume: { loadCriticalVat: VatLoader<any> }}} */ (
+      space
+    );
+  const { agoricNames, spaces } = await makeAgoricNamesAccess();
+  produce.agoricNames.resolve(agoricNames);
+
+  const { vatAdminService } = makePopulatedFakeVatAdmin();
+  const { zoeService, feeMintAccess: fma } = makeZoeKit(vatAdminService);
+  produce.zoe.resolve(zoeService);
+  produce.feeMintAccess.resolve(fma);
+  produce.vatAdminSvc.resolve(vatAdminService);
+  await installBootContracts({
+    consume,
+    produce,
+    ...spaces,
+  });
+
+  // Genesis RUN supply: 50
+  const bootMsg = {
+    type: 'INIT@@',
+    chainID: 'ag',
+    storagePort: 1,
+    supplyCoins: [{ amount: '50000000', denom: 'uist' }],
+    vbankPort: 2,
+    vibcPort: 3,
+  };
+
+  // Now run the function under test.
+  await mintInitialSupply({
+    vatParameters: {
+      argv: {
+        bootMsg,
+        ROLE: 'x',
+        hardcodedClientAddresses: [],
+        FIXME_GCI: '',
+        PROVISIONER_INDEX: 1,
+      },
+    },
+    consume,
+    produce,
+    devices: /** @type { any } */ ({}),
+    vats: /** @type { any } */ ({}),
+    vatPowers: /** @type { any } */ ({}),
+    runBehaviors: /** @type { any } */ ({}),
+    modules: {},
+    ...spaces,
+  });
+
+  // check results: initialSupply
+  const runIssuer = await E(zoeService).getFeeIssuer();
+  const runBrand = await E(runIssuer).getBrand();
+  const pmt = await consume.initialSupply;
+  const amt = await E(runIssuer).getAmountOf(pmt);
+  t.deepEqual(
+    amt,
+    { brand: runBrand, value: 50_000_000n },
+    'initialSupply of 50 RUN',
+  );
+
+  const loadCriticalVat = async name => {
+    assert.equal(name, 'bank');
+    return E(buildRootObject)(
+      null,
+      null,
+      makeScalarMapStore('addAssets baggage'),
+    );
+  };
+  produce.loadCriticalVat.resolve(loadCriticalVat);
+  produce.bridgeManager.resolve(undefined);
+
+  await Promise.all([
+    produceStartUpgradable({ consume, produce, ...spaces }),
+    addBankAssets({ consume, produce, ...spaces }),
+  ]);
+
+  // check results: bankManager assets
+  const assets = E(consume.bankManager).getAssetSubscription();
+  const expected = ['BLD', 'IST'];
+  const seen = new Set();
+  const done = makePromiseKit();
+  void observeIteration(assets, {
+    updateState: asset => {
+      seen.add(asset.issuerName);
+      if (asset.issuerName === 'IST') {
+        t.is(asset.issuer, runIssuer);
+      }
+      if (seen.size === expected.length) {
+        done.resolve(seen);
+      }
+    },
+  });
+  await done.promise;
+  t.deepEqual([...seen].sort(), expected);
+});

--- a/packages/vats/test/test-vat-bank.js
+++ b/packages/vats/test/test-vat-bank.js
@@ -4,11 +4,12 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { E, Far } from '@endo/far';
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
+import { heapZone } from '@agoric/zone/heap.js';
 import { buildRootObject } from '../src/vat-bank.js';
 
 test('communication', async t => {
   t.plan(29);
-  const bankVat = E(buildRootObject)();
+  const bankVat = E(buildRootObject)(null, null, heapZone.mapStore('baggage'));
 
   /** @type {undefined | ERef<import('../src/types.js').BridgeHandler>} */
   let bankHandler;

--- a/packages/vats/test/test-vat-bank.js
+++ b/packages/vats/test/test-vat-bank.js
@@ -1,23 +1,35 @@
 // @ts-check
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { E, Far } from '@endo/far';
+// eslint-disable-next-line import/order
+import { fakeVomKit } from './setup-vat-data.js';
+
+import { E } from '@endo/far';
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
-import { heapZone } from '@agoric/zone/heap.js';
+import { makeDurableZone } from '@agoric/zone/durable.js';
+import { subscribeEach } from '@agoric/notifier';
 import { buildRootObject } from '../src/vat-bank.js';
 
+const provideBaggage = key => {
+  const root = fakeVomKit.cm.provideBaggage();
+  const zone = makeDurableZone(root);
+  return zone.mapStore(`${key} baggage`);
+};
+
 test('communication', async t => {
-  t.plan(29);
-  const bankVat = E(buildRootObject)(null, null, heapZone.mapStore('baggage'));
+  t.plan(32);
+  const baggage = provideBaggage('communication');
+  const bankVat = E(buildRootObject)(null, null, baggage);
+
+  const zone = makeDurableZone(baggage);
 
   /** @type {undefined | ERef<import('../src/types.js').BridgeHandler>} */
   let bankHandler;
 
   /** @type {import('../src/types.js').ScopedBridgeManager} */
-  const bankBridgeMgr = Far('fakeBankBridgeManager', {
-    async fromBridge(_obj) {
-      t.fail('unexpected fromBridge');
+  const bankBridgeMgr = zone.exo('fakeBankBridgeManager', undefined, {
+    async fromBridge(obj) {
+      t.is(typeof obj, 'string');
     },
     async toBridge(obj) {
       let ret;
@@ -94,11 +106,11 @@ test('communication', async t => {
   const bank = E(bankMgr).getBankForAddress('agoricfoo');
 
   const sub = await E(bank).getAssetSubscription();
-  const it = sub[Symbol.asyncIterator]();
+  const it = subscribeEach(sub)[Symbol.asyncIterator]();
 
   const kit = makeIssuerKit('BLD', AssetKind.NAT, harden({ decimalPlaces: 6 }));
   await t.throwsAsync(() => E(bank).getPurse(kit.brand), {
-    message: /"brand" not found/,
+    message: /not found/,
   });
 
   /** @type {undefined | IteratorResult<{brand: Brand, issuer: ERef<Issuer>, proposedName: string}>} */

--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -132,7 +132,7 @@ async function setupTest(
 /**
  * Run a thunk and wait for the notifier to fire.
  *
- * @param {ERef<Notifier<any>>} notifier
+ * @param {ERef<LatestTopic<any>>} notifier
  * @param {() => Promise<any>} thunk
  */
 const waitForUpdate = async (notifier, thunk) => {

--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -1,3 +1,4 @@
 import './types.js';
+// eslint-disable-next-line no-restricted-syntax
 import './loan/types.js';
 import './callSpread/types.js';


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #5885
refs: #7633

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This is the first version of the vat-bank durablization that passes existing tests, and that I assert is "reachably durable".  I'd like to land these changes as a basis for upgrade testing and incremental improvements to vat-bank after the fact.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

This has not yet gone through a vat restart (null-upgrade) test.  We should do that before declaring it "upgradable".

`getAssetSubscription` was manually tested to ensure that new clients indeed receive the full asset history.  It also needs to be tested across restarts to ensure newly added assets interact well with the resume-on-upgrade feature of `subscribeEach`.  The publicationCounts used by each incarnation are intended to be deterministic, and the historical data is durable.
