### PR TITLE
update workflows to trigger merge_group checks

### DIFF
--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -19,6 +19,7 @@ on:
       - ready_for_review
       - labeled
       - auto_merge_enabled
+  merge_group:
 
 jobs:
   pre_check:

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -12,22 +12,14 @@ on:
     tags:
       - '@agoric/sdk@*'
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-      - labeled
-      - auto_merge_enabled
   merge_group:
 
-jobs:
-  pre_check:
-    uses: ./.github/workflows/pre-check-integration.yml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   deployment-test:
-    needs: pre_check
-    if: needs.pre_check.outputs.should_run == 'true'
     runs-on: ubuntu-22.04 # jammy (LTS)
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,6 +8,7 @@ on:
       - master
       - release-pismo
   pull_request:
+  merge_group:
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,7 @@ on:
       - ready_for_review
       - labeled
       - auto_merge_enabled
+  merge_group:
 
 jobs:
   pre_check:

--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -9,6 +9,7 @@ on:
       - ready_for_review
       - labeled
       - auto_merge_enabled
+  merge_group:
 
 jobs:
   pre_check:

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -3,6 +3,7 @@ name: Protobuf
 # This workflow is only run when a .proto file has been changed
 on:
   pull_request:
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -4,6 +4,7 @@ name: Test all Packages
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [master]
 

--- a/.github/workflows/test-dapp-card-store.yml
+++ b/.github/workflows/test-dapp-card-store.yml
@@ -2,6 +2,7 @@ name: Test Dapp Card Store
 
 on:
   pull_request:
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-dapp-fungible-faucet.yml.DISABLED
+++ b/.github/workflows/test-dapp-fungible-faucet.yml.DISABLED
@@ -2,6 +2,7 @@ name: Test Dapp Fungible Faucet
 
 on:
   pull_request:
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-dapp-otc.yml
+++ b/.github/workflows/test-dapp-otc.yml
@@ -2,6 +2,7 @@ name: Test Dapp OTC Desk
 
 on:
   pull_request:
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-dapp-pegasus.yml
+++ b/.github/workflows/test-dapp-pegasus.yml
@@ -2,6 +2,7 @@ name: Test Dapp Pegasus
 
 on:
   pull_request:
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-dapp-simple-exchange.yml
+++ b/.github/workflows/test-dapp-simple-exchange.yml
@@ -2,6 +2,7 @@ name: Test Dapp Simple Exchange
 
 on:
   pull_request:
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-dapp-treasury.yml.DISABLED
+++ b/.github/workflows/test-dapp-treasury.yml.DISABLED
@@ -2,6 +2,7 @@ name: Test Dapp Treasury
 
 on:
   pull_request:
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -2,6 +2,7 @@ name: Test Documentation
 
 on:
   pull_request:
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-golang.yml
+++ b/.github/workflows/test-golang.yml
@@ -2,6 +2,7 @@ name: Test Golang
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [master]
 

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -2,6 +2,7 @@ name: Run scripts tests
 
 on:
   pull_request:
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
To use GitHub's "merge queues", we need our workflows to be triggered by both `pull_request:` and the new `merge_group:` event.

Change all workflows that had one trigger to also use the other.
