### PR TITLE
Correct for premature creation of provision account during upgrade

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -774,13 +774,14 @@ func NewAgoricApp(
 func upgrade10Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgradetypes.Plan, module.VersionMap) (module.VersionMap, error) {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVm module.VersionMap) (module.VersionMap, error) {
 		app.VstorageKeeper.MigrateNoDataPlaceholders(ctx) // upgrade-10 only
-		migrateProvisionAccount(ctx, app.AccountKeeper)
+		normalizeProvisionAccount(ctx, app.AccountKeeper)
 		return fromVm, nil
 	}
 }
 
-// migrateProvisionAccount ensures that the vbank/provision account is a module account.
-func migrateProvisionAccount(ctx sdk.Context, ak authkeeper.AccountKeeper) {
+// normalizeProvisionAccount ensures that the vbank/provision account is a module account,
+// initializing or updating it if necessary.
+func normalizeProvisionAccount(ctx sdk.Context, ak authkeeper.AccountKeeper) {
 	provisionAddr := ak.GetModuleAddress(vbanktypes.ProvisionPoolName)
 	provisionAcct := ak.GetAccount(ctx, provisionAddr)
 	if _, ok := provisionAcct.(authtypes.ModuleAccountI); ok {
@@ -788,8 +789,10 @@ func migrateProvisionAccount(ctx sdk.Context, ak authkeeper.AccountKeeper) {
 	}
 	perms := maccPerms[vbanktypes.ProvisionPoolName]
 	newAcct := authtypes.NewEmptyModuleAccount(vbanktypes.ProvisionPoolName, perms...)
-	newAcct.AccountNumber = provisionAcct.GetAccountNumber()
-	newAcct.Sequence = provisionAcct.GetSequence()
+	if provisionAcct != nil {
+		newAcct.AccountNumber = provisionAcct.GetAccountNumber()
+		newAcct.Sequence = provisionAcct.GetSequence()
+	}
 	ak.SetModuleAccount(ctx, newAcct)
 }
 
@@ -870,6 +873,10 @@ func (app *GaiaApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci
 		stdlog.Printf("Genesis time %s is in %s\n", genTime, d)
 	}
 
+	// initialize the provision module account, to avoid its implicit creation
+	// as a default account upon receiving a transfer. See BockedAddrs().
+	normalizeProvisionAccount(ctx, app.AccountKeeper)
+
 	return res
 }
 
@@ -926,6 +933,9 @@ func (app *GaiaApp) BlockedAddrs() map[string]bool {
 	modAccAddrs := make(map[string]bool)
 	for acc := range maccPerms {
 		// The provision pool is not blocked from receiving funds.
+		// NOTE: because of this, the provision pool must be explicitly
+		// initialized as a module account during bootstrap to avoid
+		// implicit creation as a default accunt when funds are received.
 		if acc == vbanktypes.ProvisionPoolName {
 			continue
 		}


### PR DESCRIPTION
closes: #7622

## Description

The provision account is unlike other module accounts in that it is exempted from the list of `x/bank` blocked addresses, so that it can receive ordinary transfers from other accounts. However, this runs the risk that if a transfer happens before the provision account is used as a module account, it will be created as the default account type, not a module account.

This appears to have happened on mainnet, so we should fix it as part of upgrade-10.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

The underlying problem still exists for any freshly-created networks. Tests will need to force the creation of the provision account as a module account before transferring funds to it.
