### PR TITLE
5200 reachably durable contract governor

### DIFF
--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -143,8 +143,9 @@ const validateQuestionFromCounter = async (zoe, electorate, voteCounter) => {
  *   creatorFacet: GovernorCreatorFacet<SF>,
  *   publicFacet: GovernorPublic,
  * }>}
+ * @param {import('@agoric/vat-data').Baggage} baggage
  */
-const start = async (zcf, privateArgs) => {
+const start = async (zcf, privateArgs, baggage) => {
   trace('start');
   const zoe = zcf.getZoeService();
   trace('getTerms', zcf.getTerms());
@@ -167,12 +168,8 @@ const start = async (zcf, privateArgs) => {
   });
 
   trace('starting governedContractInstallation');
-  const {
-    creatorFacet: governedCF,
-    instance: governedInstance,
-    publicFacet: governedPF,
-    adminFacet,
-  } = await E(zoe).startInstance(
+
+  const startedInstanceKit = await E(zoe).startInstance(
     governedContractInstallation,
     governedIssuerKeywordRecord,
     // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- the build config doesn't expect an error here
@@ -181,6 +178,14 @@ const start = async (zcf, privateArgs) => {
     privateArgs.governed,
     governedContractLabel,
   );
+  // reachably durable for an upgrade of this contract to retrieve
+  baggage.init('startedInstanceKit', startedInstanceKit);
+  const {
+    creatorFacet: governedCF,
+    instance: governedInstance,
+    publicFacet: governedPF,
+    adminFacet,
+  } = startedInstanceKit;
 
   /** @type {() => Promise<Instance>} */
   const getElectorateInstance = async () => {

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -290,15 +290,14 @@ const start = async (zcf, privateArgs, baggage) => {
       createdParamQ || createdApiQ || createdFilterQ,
       'VoteCounter was not created by this contractGovernor',
     );
-    return true;
   };
 
   /** @param {ClosingRule} closingRule */
   const validateTimer = closingRule => {
     assert(closingRule.timer === timer, 'closing rule must use my timer');
-    return true;
   };
 
+  /** @param {ERef<Instance>} regP */
   const validateElectorate = async regP => {
     return E.when(regP, async reg => {
       const electorateInstance = await getElectorateInstance();
@@ -306,7 +305,6 @@ const start = async (zcf, privateArgs, baggage) => {
         reg === electorateInstance,
         "Electorate doesn't match my Electorate",
       );
-      return true;
     });
   };
 

--- a/packages/governance/src/types-ambient.js
+++ b/packages/governance/src/types-ambient.js
@@ -521,9 +521,9 @@
  * @typedef {object} GovernorPublic
  * @property {() => Promise<Instance>} getElectorate
  * @property {() => Instance} getGovernedContract
- * @property {(voteCounter: Instance) => Promise<boolean>} validateVoteCounter
- * @property {(regP: ERef<Instance>) => Promise<boolean>} validateElectorate
- * @property {(closingRule: ClosingRule) => boolean} validateTimer
+ * @property {(voteCounter: Instance) => Promise<void>} validateVoteCounter
+ * @property {(regP: ERef<Instance>) => Promise<void>} validateElectorate
+ * @property {(closingRule: ClosingRule) => void} validateTimer
  */
 
 /**

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -259,9 +259,9 @@ const validateElectorateChange = async (
 
   await assertContractElectorate(zoe, governorInstance, electorateInstance);
 
-  const [eValid, tValid] = await Promise.all([electorateValid, timerValid]);
+  await Promise.all([electorateValid, timerValid]);
 
-  return log(`Validation complete: ${eValid && tValid}`);
+  return log('Validation complete');
 };
 
 const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {

--- a/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
@@ -121,7 +121,7 @@ test.serial('change electorate', async t => {
     'params update: Electorate',
     'current value of MalleableNumber is 602214090000000000000000',
     'updated to ({"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: BundleInstallation]","instance":"[Alleged: InstanceHandle]"}]}}})',
-    'Validation complete: true',
+    'Validation complete',
     '@@ schedule task for:4, currently: 2 @@',
     'Voter Alice voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
     'Voter Bob voted for {"changes":{"MalleableNumber":"[299792458n]"}}',
@@ -152,7 +152,7 @@ test.serial('brokenUpdateStart', async t => {
     '@@ tick:1 @@',
     '@@ tick:2 @@',
     'vote outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: BundleInstallation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}}',
-    'Validation complete: true',
+    'Validation complete',
     // [`prepareToSetInvitation`](https://github.com/Agoric/agoric-sdk/blob/c6570b015fd23c411e48981bec309b32eedd3a28/packages/governance/src/contractGovernance/paramManager.js#L199-L212)
     // does a `Promise.all` on 2 calls using the `invite` promise. If that promise
     // is rejected, this will result in a rejection race between the 2 paths. The
@@ -185,7 +185,7 @@ test.serial('changeTwoParams', async t => {
     'current value of MalleableNumber is 42',
     'updated to ({"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: BundleInstallation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}})',
     'successful outcome: {"changes":{"Electorate":{"brand":"[Alleged: Zoe Invitation brand]","value":[{"description":"questionPoser","handle":"[Alleged: InvitationHandle]","installation":"[Alleged: BundleInstallation]","instance":"[Alleged: InstanceHandle]"}]},"MalleableNumber":"[42n]"}} ',
-    'Validation complete: true',
+    'Validation complete',
   ]);
 });
 

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -330,7 +330,7 @@ export const makeStartInstance = (
         );
 
         // Actually returned to the user.
-        return {
+        return harden({
           creatorFacet,
 
           // TODO (#5775) deprecate this return value from contracts.
@@ -338,10 +338,10 @@ export const makeStartInstance = (
           instance: instanceHandle,
           publicFacet,
           adminFacet,
-        };
+        });
       },
     );
   };
   // @ts-expect-error cast
-  return startInstance;
+  return harden(startInstance);
 };


### PR DESCRIPTION
## Description

A stop-gap until full durability of governance(#5200), this saves the precious state to baggage so that it's _reachably durable_ and can be retrieved by the next version of `contractGovernor`. That version will have to be fully durable and upgradable (returning durable facets).

Note that may fall fall short of release requirements because the facets returned by contractGovernor aren't durable and upon contract restart (including upgrade) will sever for any holders.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

Existing coverage. I could maybe have a test look in the baggage afterwards but I'll focus instead on trying to get durable return facets.