### PR TITLE
Bump docker package go version

### DIFF
--- a/packages/deployment/Dockerfile
+++ b/packages/deployment/Dockerfile
@@ -4,7 +4,7 @@ ARG REGISTRY=ghcr.io
 
 # FIXME: Journalbeat compilation is currently broken, but non-essential.
 # Removed from the build.
-# FROM golang:1.19 AS go-build
+# FROM golang:1.20 AS go-build
 
 # WORKDIR /usr/src/journalbeat
 # RUN apt-get update -y && apt-get install -y libsystemd-dev

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -1,6 +1,6 @@
 ###########################
 # The golang build container
-FROM golang:1.19 as cosmos-go
+FROM golang:1.20 as cosmos-go
 
 WORKDIR /usr/src/agoric-sdk/golang/cosmos
 COPY go.mod go.sum ../../


### PR DESCRIPTION
refs: #6638

## Description

Bump the go version used in Docker packages to match the new minimums from #6638.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

N/A
