### PR TITLE
5200 upgradable contractGovernor

### DIFF
--- a/packages/governance/src/contractGovernance/governApi.js
+++ b/packages/governance/src/contractGovernance/governApi.js
@@ -28,17 +28,13 @@ const makeApiInvocationPositions = (apiMethodName, methodArgs) => {
 /**
  * manage contracts that allow governance to invoke functions.
  *
- * @param {ERef<ZoeService>} zoe
- * @param {Instance} governedInstance
  * @param {ERef<{ [methodName: string]: (...args: any) => unknown }>} governedApis
  * @param {Array<string | symbol>} governedNames names of the governed API methods
  * @param {ERef<import('@agoric/time/src/types').TimerService>} timer
  * @param {() => Promise<PoserFacet>} getUpdatedPoserFacet
- * @returns {Promise<ApiGovernor>}
+ * @returns {ApiGovernor}
  */
-const setupApiGovernance = async (
-  zoe,
-  governedInstance,
+const setupApiGovernance = (
   governedApis,
   governedNames,
   timer,

--- a/packages/governance/src/contractGovernance/governFilter.js
+++ b/packages/governance/src/contractGovernance/governFilter.js
@@ -96,7 +96,7 @@ const setupFilterGovernance = (timer, getUpdatedPoserFacet, governedCF) => {
 
   return Far('filterGovernor', {
     voteOnFilter,
-    createdFilterQuestion: b => voteCounters.has(b),
+    createdQuestion: b => voteCounters.has(b),
   });
 };
 

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -24,7 +24,7 @@ const trace = makeTracer('CGov', false);
  * @param {Instance} electorate
  * @param {ParamChangeIssueDetails} details
  */
-const validateQuestionDetails = async (zoe, electorate, details) => {
+export const validateQuestionDetails = async (zoe, electorate, details) => {
   const {
     counterInstance,
     issue: { contract: governedInstance },
@@ -41,6 +41,7 @@ const validateQuestionDetails = async (zoe, electorate, details) => {
     E(governorPublic).validateTimer(details.closingRule),
   ]);
 };
+harden(validateQuestionDetails);
 
 /**
  * Validate that the questions counted by the voteCounter correspond to a
@@ -51,12 +52,17 @@ const validateQuestionDetails = async (zoe, electorate, details) => {
  * @param {Instance} electorate
  * @param {Instance} voteCounter
  */
-const validateQuestionFromCounter = async (zoe, electorate, voteCounter) => {
+export const validateQuestionFromCounter = async (
+  zoe,
+  electorate,
+  voteCounter,
+) => {
   const counterPublicP = E(zoe).getPublicFacet(voteCounter);
   const questionDetails = await E(counterPublicP).getDetails();
 
   return validateQuestionDetails(zoe, electorate, questionDetails);
 };
+harden(validateQuestionFromCounter);
 
 /**
  * @typedef {StandardTerms} ContractGovernorTerms
@@ -145,8 +151,8 @@ const validateQuestionFromCounter = async (zoe, electorate, voteCounter) => {
  * }>}
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
-const start = async (zcf, privateArgs, baggage) => {
-  trace('start');
+export const prepare = async (zcf, privateArgs, baggage) => {
+  trace('prepare');
   const zoe = zcf.getZoeService();
   trace('getTerms', zcf.getTerms());
   const {
@@ -331,8 +337,4 @@ const start = async (zcf, privateArgs, baggage) => {
 
   return { creatorFacet, publicFacet };
 };
-
-harden(start);
-harden(validateQuestionDetails);
-harden(validateQuestionFromCounter);
-export { start, validateQuestionDetails, validateQuestionFromCounter };
+harden(prepare);

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -1,14 +1,10 @@
-import { E } from '@endo/eventual-send';
-import { Far } from '@endo/marshal';
 import { mustMatch } from '@agoric/store';
+import { E } from '@endo/eventual-send';
 
 import { makeTracer } from '@agoric/internal';
-import {
-  CONTRACT_ELECTORATE,
-  setupParamGovernance,
-} from './contractGovernance/governParam.js';
-import { setupApiGovernance } from './contractGovernance/governApi.js';
-import { setupFilterGovernance } from './contractGovernance/governFilter.js';
+import { provideSingleton } from '@agoric/zoe/src/contractSupport/durability.js';
+import { CONTRACT_ELECTORATE } from './contractGovernance/governParam.js';
+import { prepareContractGovernorKit } from './contractGovernorKit.js';
 import { ParamChangesQuestionDetailsShape } from './typeGuards.js';
 
 const { Fail } = assert;
@@ -168,173 +164,44 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   contractTerms.governedParams[CONTRACT_ELECTORATE] ||
     Fail`Contract must declare ${CONTRACT_ELECTORATE} as a governed parameter`;
 
-  const augmentedTerms = harden({
-    ...contractTerms,
-    electionManager: zcf.getInstance(),
+  const makeContractGovernorKit = prepareContractGovernorKit(baggage, {
+    timer,
+    zoe,
   });
 
-  trace('starting governedContractInstallation');
+  trace('awaiting provideSingleton()');
+  const governorKit = await provideSingleton(
+    baggage,
+    'contractGovernorKit',
+    async () => {
+      const augmentedTerms = harden({
+        ...contractTerms,
+        electionManager: zcf.getInstance(),
+      });
 
-  const startedInstanceKit = await E(zoe).startInstance(
-    governedContractInstallation,
-    governedIssuerKeywordRecord,
-    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- the build config doesn't expect an error here
-    // @ts-ignore XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
-    augmentedTerms,
-    privateArgs.governed,
-    governedContractLabel,
+      trace('starting governedContractInstallation of', governedContractLabel);
+      const startedInstanceKit = await E(zoe).startInstance(
+        governedContractInstallation,
+        governedIssuerKeywordRecord,
+        // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- the build config doesn't expect an error here
+        // @ts-ignore XXX governance types https://github.com/Agoric/agoric-sdk/issues/7178
+        augmentedTerms,
+        privateArgs.governed,
+        governedContractLabel,
+      );
+      const limitedCreatorFacet = await E(
+        startedInstanceKit.creatorFacet,
+      ).getLimitedCreatorFacet();
+
+      return makeContractGovernorKit(startedInstanceKit, limitedCreatorFacet);
+    },
   );
-  // reachably durable for an upgrade of this contract to retrieve
-  baggage.init('startedInstanceKit', startedInstanceKit);
-  const {
-    creatorFacet: governedCF,
-    instance: governedInstance,
-    publicFacet: governedPF,
-    adminFacet,
-  } = startedInstanceKit;
 
-  /** @type {() => Promise<Instance>} */
-  const getElectorateInstance = async () => {
-    const invitationAmount = await E(governedPF).getInvitationAmount(
-      CONTRACT_ELECTORATE,
-    );
-    return invitationAmount.value[0].instance;
-  };
+  // At this point, some remote calls still need to be made within the governorKit.
+  // Specifically, to the vat of the governed contract for its API names. The exo
+  // defers that until API governance is requested to be invoked or validated.
 
   // CRUCIAL: only contractGovernor should get the ability to update params
-  const limitedCreatorFacet = E(governedCF).getLimitedCreatorFacet();
-
-  let currentInvitation;
-  let poserFacet;
-  /** @type {() => Promise<PoserFacet>} */
-  const getUpdatedPoserFacet = async () => {
-    const newInvitation = await E(
-      E(E(governedCF).getParamMgrRetriever()).get({ key: 'governedParams' }),
-    ).getInternalParamValue(CONTRACT_ELECTORATE);
-
-    if (newInvitation !== currentInvitation) {
-      poserFacet = E(E(zoe).offer(newInvitation)).getOfferResult();
-      currentInvitation = newInvitation;
-    }
-    return poserFacet;
-  };
-  trace('awaiting getUpdatedPoserFacet');
-  await getUpdatedPoserFacet();
-  assert(poserFacet, 'question poser facet must be initialized');
-
-  trace('awaiting setupParamGovernance');
-  // All governed contracts have at least a governed electorate
-  const { voteOnParamChanges, createdQuestion: createdParamQuestion } =
-    setupParamGovernance(
-      E(governedCF).getParamMgrRetriever(),
-      governedInstance,
-      timer,
-      getUpdatedPoserFacet,
-    );
-
-  trace('awaiting setupFilterGovernance');
-  const { voteOnFilter, createdFilterQuestion } = setupFilterGovernance(
-    timer,
-    getUpdatedPoserFacet,
-    governedCF,
-  );
-
-  /**
-   * @param {Invitation} poserInvitation
-   * @returns {Promise<void>}
-   */
-  const replaceElectorate = poserInvitation => {
-    /** @type {Promise<import('./contractGovernance/typedParamManager.js').TypedParamManager<{'Electorate': 'invitation'}>>} */
-    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- the build config doesn't expect an error here
-    // @ts-ignore cast
-    const paramMgr = E(E(governedCF).getParamMgrRetriever()).get({
-      key: 'governedParams',
-    });
-
-    // TODO use updateElectorate
-    return E(paramMgr).updateParams({
-      Electorate: poserInvitation,
-    });
-  };
-
-  // this conditional was extracted so both sides are equally asynchronous
-  /** @type {() => Promise<ApiGovernor>} */
-  const initApiGovernance = async () => {
-    const [governedApis, governedNames] = await Promise.all([
-      E(governedCF).getGovernedApis(),
-      E(governedCF).getGovernedApiNames(),
-    ]);
-    if (governedNames.length) {
-      return setupApiGovernance(
-        zoe,
-        governedInstance,
-        governedApis,
-        governedNames,
-        timer,
-        getUpdatedPoserFacet,
-      );
-    }
-
-    // if we aren't governing APIs, voteOnApiInvocation shouldn't be called
-    return {
-      voteOnApiInvocation: () => {
-        throw Error('api governance not configured');
-      },
-      createdQuestion: () => false,
-    };
-  };
-
-  const { voteOnApiInvocation, createdQuestion: createdApiQuestion } =
-    await initApiGovernance();
-
-  const validateVoteCounter = async voteCounter => {
-    const createdParamQ = await E(createdParamQuestion)(voteCounter);
-    const createdApiQ = await E(createdApiQuestion)(voteCounter);
-    const createdFilterQ = await E(createdFilterQuestion)(voteCounter);
-
-    assert(
-      createdParamQ || createdApiQ || createdFilterQ,
-      'VoteCounter was not created by this contractGovernor',
-    );
-  };
-
-  /** @param {ClosingRule} closingRule */
-  const validateTimer = closingRule => {
-    assert(closingRule.timer === timer, 'closing rule must use my timer');
-  };
-
-  /** @param {ERef<Instance>} regP */
-  const validateElectorate = async regP => {
-    return E.when(regP, async reg => {
-      const electorateInstance = await getElectorateInstance();
-      assert(
-        reg === electorateInstance,
-        "Electorate doesn't match my Electorate",
-      );
-    });
-  };
-
-  /** @type {GovernorCreatorFacet<SF>} */
-  // @ts-expect-error cast
-  const creatorFacet = Far('governor creatorFacet', {
-    replaceElectorate,
-    voteOnParamChanges,
-    voteOnApiInvocation,
-    voteOnOfferFilter: voteOnFilter,
-    getCreatorFacet: () => limitedCreatorFacet,
-    getAdminFacet: () => adminFacet,
-    getInstance: () => governedInstance,
-    getPublicFacet: () => governedPF,
-  });
-
-  const publicFacet = Far('contract governor public', {
-    getElectorate: getElectorateInstance,
-    getGovernedContract: () => governedInstance,
-    validateVoteCounter,
-    validateElectorate,
-    validateTimer,
-  });
-
-  return { creatorFacet, publicFacet };
+  return { creatorFacet: governorKit.creator, publicFacet: governorKit.public };
 };
 harden(prepare);

--- a/packages/governance/src/contractGovernorKit.js
+++ b/packages/governance/src/contractGovernorKit.js
@@ -1,0 +1,235 @@
+import { Fail } from '@agoric/assert';
+import { makeTracer } from '@agoric/internal';
+import { prepareExoClassKit } from '@agoric/vat-data';
+import { E } from '@endo/eventual-send';
+import { setupApiGovernance } from './contractGovernance/governApi.js';
+import { setupFilterGovernance } from './contractGovernance/governFilter.js';
+import {
+  CONTRACT_ELECTORATE,
+  setupParamGovernance,
+} from './contractGovernance/governParam.js';
+
+const trace = makeTracer('CGK', false);
+
+/**
+ *
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ * @param {{
+ *   timer: import('@agoric/time/src/types').TimerService,
+ *   zoe: ERef<ZoeService>,
+ * }} powers
+ */
+export const prepareContractGovernorKit = (baggage, powers) => {
+  // These are produced just-in-time because API governance makes remote calls, which prevent vat restart.
+  // The other two could happen during restart but they'd need to have a separate hook, so for consistency
+  // they're all lazy.
+  /** @type {ReturnType<typeof setupFilterGovernance>} */
+  let filterGovernance;
+  /** @type {ReturnType<typeof setupParamGovernance>} */
+  let paramGovernance;
+  /** @type {Awaited<ReturnType<typeof setupApiGovernance>>} */
+  let apiGovernance;
+
+  /** @type {any} */
+  let poserFacet;
+
+  const makeContractGovernorKit = prepareExoClassKit(
+    baggage,
+    'ContractGovernorKit',
+    undefined,
+    /**
+     * @param {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<GovernableStartFn>} startedInstanceKit
+     * @param {LimitedCF<unknown>} limitedCreatorFacet
+     */
+    (startedInstanceKit, limitedCreatorFacet) => {
+      return {
+        ...startedInstanceKit,
+        limitedCreatorFacet,
+        currentInvitation: /** @type {Invitation<unknown, never>?} */ (null),
+      };
+    },
+    {
+      helper: {
+        /** @type {() => Promise<Instance>} */
+        async getElectorateInstance() {
+          const { publicFacet } = this.state;
+          const invitationAmount = await E(publicFacet).getInvitationAmount(
+            CONTRACT_ELECTORATE,
+          );
+          return invitationAmount.value[0].instance;
+        },
+        /** @type {() => Promise<PoserFacet>} */
+        async getUpdatedPoserFacet() {
+          const { creatorFacet } = this.state;
+          const newInvitation = await E(
+            E(E(creatorFacet).getParamMgrRetriever()).get({
+              key: 'governedParams',
+            }),
+          ).getInternalParamValue(CONTRACT_ELECTORATE);
+
+          if (newInvitation !== this.state.currentInvitation) {
+            poserFacet = E(E(powers.zoe).offer(newInvitation)).getOfferResult();
+            this.state.currentInvitation = newInvitation;
+          }
+          return poserFacet;
+        },
+        async provideApiGovernance() {
+          const { timer } = powers;
+          const { creatorFacet } = this.state;
+          if (!apiGovernance) {
+            trace('awaiting governed API dependencies');
+            const [governedApis, governedNames] = await Promise.all([
+              E(creatorFacet).getGovernedApis(),
+              E(creatorFacet).getGovernedApiNames(),
+            ]);
+            trace('setupApiGovernance');
+            apiGovernance = governedNames.length
+              ? setupApiGovernance(governedApis, governedNames, timer, () =>
+                  this.facets.helper.getUpdatedPoserFacet(),
+                )
+              : {
+                  // if we aren't governing APIs, voteOnApiInvocation shouldn't be called
+                  voteOnApiInvocation: () => {
+                    throw Error('api governance not configured');
+                  },
+                  createdQuestion: () => false,
+                };
+          }
+          return apiGovernance;
+        },
+        provideFilterGovernance() {
+          if (!filterGovernance) {
+            const { timer } = powers;
+            const { creatorFacet } = this.state;
+            filterGovernance = setupFilterGovernance(
+              timer,
+              () => this.facets.helper.getUpdatedPoserFacet(),
+              creatorFacet,
+            );
+          }
+          return filterGovernance;
+        },
+        provideParamGovernance() {
+          if (!paramGovernance) {
+            const { timer } = powers;
+            const { creatorFacet, instance } = this.state;
+            paramGovernance = setupParamGovernance(
+              E(creatorFacet).getParamMgrRetriever(),
+              instance,
+              timer,
+              () => this.facets.helper.getUpdatedPoserFacet(),
+            );
+          }
+          return paramGovernance;
+        },
+      },
+      creator: {
+        /**
+         * @param {Invitation} poserInvitation
+         * @returns {Promise<void>}
+         */
+        replaceElectorate(poserInvitation) {
+          const { creatorFacet } = this.state;
+          /** @type {Promise<import('./contractGovernance/typedParamManager.js').TypedParamManager<{'Electorate': 'invitation'}>>} */
+          // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- the build config doesn't expect an error here
+          // @ts-ignore cast
+          const paramMgr = E(E(creatorFacet).getParamMgrRetriever()).get({
+            key: 'governedParams',
+          });
+
+          // TODO use updateElectorate
+          return E(paramMgr).updateParams({
+            Electorate: poserInvitation,
+          });
+        },
+        /** @type {VoteOnParamChanges} */
+        voteOnParamChanges(voteCounterInstallation, deadline, paramSpec) {
+          const { helper } = this.facets;
+          return helper
+            .provideParamGovernance()
+            .voteOnParamChanges(voteCounterInstallation, deadline, paramSpec);
+        },
+        /** @type {VoteOnApiInvocation} */
+        voteOnApiInvocation(
+          apiMethodName,
+          methodArgs,
+          voteCounterInstallation,
+          deadline,
+        ) {
+          const { helper } = this.facets;
+          return E(helper.provideApiGovernance()).voteOnApiInvocation(
+            apiMethodName,
+            methodArgs,
+            voteCounterInstallation,
+            deadline,
+          );
+        },
+        /** @type {VoteOnOfferFilter} */
+        voteOnOfferFilter(voteCounterInstallation, deadline, strings) {
+          const { helper } = this.facets;
+          return helper
+            .provideFilterGovernance()
+            .voteOnFilter(voteCounterInstallation, deadline, strings);
+        },
+        getCreatorFacet() {
+          return this.state.limitedCreatorFacet;
+        },
+        getAdminFacet() {
+          return this.state.adminFacet;
+        },
+        getInstance() {
+          return this.state.instance;
+        },
+        getPublicFacet() {
+          return this.state.publicFacet;
+        },
+      },
+      public: {
+        getElectorate() {
+          const { helper } = this.facets;
+          return helper.getElectorateInstance();
+        },
+        getGovernedContract() {
+          return this.state.instance;
+        },
+        /** @param {Instance} counter */
+        async validateVoteCounter(counter) {
+          const { helper } = this.facets;
+          const validators = [
+            E.get(helper.provideApiGovernance()).createdQuestion,
+            helper.provideFilterGovernance().createdFilterQuestion,
+            helper.provideParamGovernance().createdQuestion,
+          ];
+          const checks = await Promise.all(
+            validators.map(validate => E(validate)(counter)),
+          );
+
+          checks.some(Boolean) ||
+            Fail`VoteCounter was not created by this contractGovernor`;
+        },
+        /** @param {Instance} regP */
+        validateElectorate(regP) {
+          const { helper } = this.facets;
+          return E.when(regP, async reg => {
+            const electorateInstance = await helper.getElectorateInstance();
+            assert(
+              reg === electorateInstance,
+              "Electorate doesn't match my Electorate",
+            );
+          });
+        },
+        /** @param {ClosingRule} closingRule */
+        validateTimer(closingRule) {
+          assert(
+            closingRule.timer === powers.timer,
+            'closing rule must use my timer',
+          );
+        },
+      },
+    },
+  );
+
+  return makeContractGovernorKit;
+};
+
+/** @typedef {ReturnType<ReturnType<typeof prepareContractGovernorKit>>} ContractGovernorKit */

--- a/packages/governance/src/contractGovernorKit.js
+++ b/packages/governance/src/contractGovernorKit.js
@@ -196,12 +196,12 @@ export const prepareContractGovernorKit = (baggage, powers) => {
         async validateVoteCounter(counter) {
           const { helper } = this.facets;
           const validators = [
-            E.get(helper.provideApiGovernance()).createdQuestion,
-            helper.provideFilterGovernance().createdFilterQuestion,
-            helper.provideParamGovernance().createdQuestion,
+            E.get(helper.provideApiGovernance()),
+            helper.provideFilterGovernance(),
+            helper.provideParamGovernance(),
           ];
           const checks = await Promise.all(
-            validators.map(validate => E(validate)(counter)),
+            validators.map(validate => E(validate.createdQuestion)(counter)),
           );
 
           checks.some(Boolean) ||

--- a/packages/governance/src/types-ambient.js
+++ b/packages/governance/src/types-ambient.js
@@ -65,7 +65,7 @@
  *
  * @template {import('./contractGovernance/typedParamManager.js').ParamTypesMap} T Governed parameters of contract
  * @typedef {{
- *   electionManager: import('@agoric/zoe/src/zoeService/utils.js').Instance<import('./contractGovernor').start>,
+ *   electionManager: import('@agoric/zoe/src/zoeService/utils.js').Instance<import('./contractGovernor.js')['prepare']>,
  *   governedParams: import('./contractGovernance/typedParamManager.js').ParamRecordsFromTypes<T & {
  *     Electorate: 'invitation'
  *   }>
@@ -680,7 +680,7 @@
  * @param {ERef<ZoeService>} zoe
  * @param {import('@agoric/zoe/src/zoeService/utils.js').Instance<(zcf: ZCF<GovernanceTerms<{}>>) => {}>} allegedGoverned
  * @param {Instance} allegedGovernor
- * @param {Installation<import('@agoric/governance/src/contractGovernor').start>} contractGovernorInstallation
+ * @param {Installation<import('@agoric/governance/src/contractGovernor.js').prepare>} contractGovernorInstallation
  * @returns {Promise<GovernancePair>}
  */
 
@@ -699,7 +699,7 @@
  */
 
 /**
- * @typedef {import('./contractGovernor.js')['start']} GovernorSF
+ * @typedef {import('./contractGovernor.js')['prepare']} GovernorSF
  */
 
 // TODO find a way to parameterize the startInstance so the governed contract types flow

--- a/packages/governance/src/types-ambient.js
+++ b/packages/governance/src/types-ambient.js
@@ -624,7 +624,7 @@
  * @param {unknown[]} methodArgs
  * @param {Installation} voteCounterInstallation
  * @param {import('@agoric/time/src/types').Timestamp} deadline
- * @returns {ContractGovernanceVoteResult}
+ * @returns {Promise<ContractGovernanceVoteResult>}
  */
 
 /**

--- a/packages/governance/src/types-ambient.js
+++ b/packages/governance/src/types-ambient.js
@@ -650,7 +650,7 @@
 /**
  * @typedef {object} FilterGovernor
  * @property {VoteOnOfferFilter} voteOnFilter
- * @property {CreatedQuestion} createdFilterQuestion
+ * @property {CreatedQuestion} createdQuestion
  */
 
 /**

--- a/packages/inter-protocol/test/auction/tools.js
+++ b/packages/inter-protocol/test/auction/tools.js
@@ -17,7 +17,7 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
  * @typedef {{
  * autoRefund: Installation<import('@agoric/zoe/src/contracts/automaticRefund').start>,
  * auctioneer: Installation<import('../../src/auction/auctioneer').start>,
- * governor: Installation<import('@agoric/governance/src/contractGovernor').start>,
+ * governor: Installation<import('@agoric/governance/src/contractGovernor.js')['prepare']>,
  * reserve: Installation<import('../../src/reserve/assetReserve.js').prepare>,
  * }} AuctionTestInstallations
  */

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -178,7 +178,7 @@
  *       auctioneer: Promise<Installation<import('@agoric/inter-protocol/src/auction/auctioneer.js').start>>,
  *       centralSupply: Promise<Installation<import('@agoric/vats/src/centralSupply.js').start>>,
  *       committee: Promise<Installation<import('@agoric/governance/src/committee.js')['prepare']>>,
- *       contractGovernor: Promise<Installation<import('@agoric/governance/src/contractGovernor.js').start>>,
+ *       contractGovernor: Promise<Installation<import('@agoric/governance/src/contractGovernor.js')['prepare']>>,
  *       econCommitteeCharter: Promise<Installation<import('@agoric/inter-protocol/src/econCommitteeCharter.js')['prepare']>>,
  *       feeDistributor: Promise<Installation<import('@agoric/inter-protocol/src/feeDistributor.js').start>>,
  *       mintHolder: Promise<Installation<import('@agoric/vats/src/mintHolder.js').prepare>>,

--- a/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
@@ -190,7 +190,7 @@ test.serial('open vault', async t => {
   console.timeEnd('open vault');
 });
 
-test.serial('restart', async t => {
+test.serial('restart vaultFactory', async t => {
   const { EV } = t.context.runUtils;
   /** @type {Awaited<import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace['consume']['vaultFactoryKit']>} */
   const vaultFactoryKit = await EV.vat('bootstrap').consumeItem(
@@ -211,10 +211,30 @@ test.serial('restart', async t => {
     totalDebt: { value: 5025000n },
   };
   t.like(t.context.readCollateralMetrics(0), keyMetrics);
-  t.log('awaiting restartContract');
+  t.log('awaiting VF restartContract');
   const upgradeResult = await EV(vfAdminFacet).restartContract(privateArgs);
   t.deepEqual(upgradeResult, { incarnationNumber: 1 });
   t.like(t.context.readCollateralMetrics(0), keyMetrics); // unchanged
+});
+
+test.serial('restart contractGovernor', async t => {
+  const { EV } = t.context.runUtils;
+  /** @type {Awaited<import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace['consume']['vaultFactoryKit']>} */
+  const vaultFactoryKit = await EV.vat('bootstrap').consumeItem(
+    'vaultFactoryKit',
+  );
+
+  const governorAdminFacet = vaultFactoryKit.adminFacet;
+  // has no privateArgs of its own. the privateArgs.governed is only for the
+  // contract startInstance. any changes to those privateArgs have to happen
+  // through a restart or upgrade using the governed contract's adminFacet
+  const privateArgs = undefined;
+
+  t.log('awaiting CG restartContract');
+  const upgradeResult = await EV(governorAdminFacet).restartContract(
+    privateArgs,
+  );
+  t.deepEqual(upgradeResult, { incarnationNumber: 1 });
 });
 
 test.serial('open vault 2', async t => {

--- a/packages/zoe/test/types.test-d.ts
+++ b/packages/zoe/test/types.test-d.ts
@@ -46,8 +46,7 @@ import type { prepare as scaledPriceAuthorityStart } from '../src/contracts/scal
   E(zoe).startInstance(
     scaledPriceInstallation,
     validIssuers,
-    validTerms,
-    // @ts-expect-error
-    'invalid privateArgs',
+    // @ts-expect-error includes an extra term
+    { ...validTerms, extra: string },
   );
 }


### PR DESCRIPTION
refs: #5200 

## Description

This makes the `contractGovernor` contract upgradable. It's not yet fully durable because some facets aren't durable and the open questions can't be validated after a contract restart/upgrade, so I'm leaving #5200 open.

It does satisfy the requirement that each governor contract vat be upgradable,
- https://github.com/Agoric/agoric-sdk/issues/6553

### Security Considerations

Authority from baggage

### Scaling Considerations

Should lower memory pressure slightly

### Documentation Considerations

Little change to API. The `voteOnApiInvocation` is now async, so that it can lazily query the remote governed contract for its API methods.

### Testing Considerations

Existing tests pass. Bootstrap test of vaults upgrade now upgrades the vaultFactory's governor.