### PR TITLE
Correct infelicities in virtual collection API implementation

### DIFF
--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -56,7 +56,7 @@ export { makeScalarSetStore } from './stores/scalarSetStore.js';
 export { makeScalarWeakMapStore } from './stores/scalarWeakMapStore.js';
 export { makeScalarMapStore } from './stores/scalarMapStore.js';
 
-export { provideLazy } from './stores/store-utils.js';
+export { provideLazy, isCopyMap, isCopySet } from './stores/store-utils.js';
 
 // /////////////////////// Deprecated Legacy ///////////////////////////////////
 

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -58,8 +58,12 @@ export const makeWeakMapStoreMethods = (
     },
 
     addAll: entries => {
-      if (isCopyMap(entries)) {
-        entries = getCopyMapEntries(entries);
+      if (typeof entries[Symbol.iterator] !== 'function') {
+        if (isCopyMap(entries)) {
+          entries = getCopyMapEntries(entries);
+        } else {
+          Fail`provided data source is not iterable`;
+        }
       }
       for (const [key, value] of /** @type {Iterable<[K, V]>} */ (entries)) {
         // Don't assert that the key either does or does not exist.

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -59,10 +59,10 @@ export const makeWeakMapStoreMethods = (
 
     addAll: entries => {
       if (typeof entries[Symbol.iterator] !== 'function') {
-        if (isCopyMap(entries)) {
+        if (Object.isFrozen(entries) && isCopyMap(entries)) {
           entries = getCopyMapEntries(entries);
         } else {
-          Fail`provided data source is not iterable`;
+          Fail`provided data source is not iterable: ${entries}`;
         }
       }
       for (const [key, value] of /** @type {Iterable<[K, V]>} */ (entries)) {

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -43,10 +43,10 @@ export const makeWeakSetStoreMethods = (
 
     addAll: keys => {
       if (typeof keys[Symbol.iterator] !== 'function') {
-        if (isCopySet(keys)) {
+        if (Object.isFrozen(keys) && isCopySet(keys)) {
           keys = getCopySetKeys(keys);
         } else {
-          Fail`provided data source is not iterable`;
+          Fail`provided data source is not iterable: ${keys}`;
         }
       }
       for (const key of /** @type {Iterable<K>} */ (keys)) {

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -42,8 +42,12 @@ export const makeWeakSetStoreMethods = (
     },
 
     addAll: keys => {
-      if (isCopySet(keys)) {
-        keys = getCopySetKeys(keys);
+      if (typeof keys[Symbol.iterator] !== 'function') {
+        if (isCopySet(keys)) {
+          keys = getCopySetKeys(keys);
+        } else {
+          Fail`provided data source is not iterable`;
+        }
       }
       for (const key of /** @type {Iterable<K>} */ (keys)) {
         assertKeyOkToAdd(key);

--- a/packages/swingset-liveslots/NEWS.md
+++ b/packages/swingset-liveslots/NEWS.md
@@ -1,0 +1,41 @@
+NEXT VERSION
+
+This version introduces three changes to the virtual collections API
+implementation.  These changes bring the `ScalarBigXXXStore` collection types
+into compliance with the API as defined in the `store` package, but they _do_
+introduce potential compatibility issues that should be considered.  The changes
+are:
+
+* Removal of the `addToSet` method from the `ScalarBigSetStore` and
+  `ScalarBigWeakSetStore` types.  This was an internal implementation method
+  that should never have been present.  Since it was internal method that nobody
+  knew about it, we believe it highly unlikely to be in use.  Furthermore, we
+  have verified by inspection that there appears to be no existing contract or
+  vat code that made use of it.  However, its removal _is_ an incompatible
+  change that people should be aware of.  If anyone had been using it (in, say,
+  test code), they should replace calls to it with calls to `add`, which
+  performs the same operation.
+
+* Removal of the `entries` method from the `ScalarBigSetStore` type.  This was
+  implemented in a mistaken attempt to be compatible with the JavaScript `Set`
+  type, but stores have a slightly different API and this method should not have
+  been present.  As with `addToSet`, we have inspected existing code to verify
+  that it is not in actual use; however, while extreme care was taken during
+  this inspection, due to the ubiquity of the method name `entries` on other
+  types, we cannot be quite as confident in the inspection's correctness as we
+  are with the `addToSet` method.  One source of assurance on this score is that
+  it is common practice for tests of contract code to substitue the `SetStore`
+  implementation from the `stores` package, which lacks the offending method
+  already.  Existing uses, if any, should be replaced with calls to either the
+  `keys` or `values` method (they are equivalent), with suitable alterations to
+  account for the fact that these return a single value rather than a pair.
+
+* Addition of the `addAll` method to all the virtual collection types, which was
+  an omission from the original implementation.  Care should be taken to ensure
+  that developmental vat or contract code using this method is not deployed
+  prior to the deployment of this version of Liveslots.
+
+PRIOR VERSIONS
+
+Liveslots version `@agoric/swingset-liveslots@0.10.2` was deployed to the
+mainnet1B chain as part of `@agoric/swingset-xsnap-supervisor@0.10.2`

--- a/packages/swingset-liveslots/src/collectionManager.js
+++ b/packages/swingset-liveslots/src/collectionManager.js
@@ -629,10 +629,10 @@ export function makeCollectionManager(
 
     const addAllToSet = elems => {
       if (typeof elems[Symbol.iterator] !== 'function') {
-        if (isCopySet(elems)) {
+        if (Object.isFrozen(elems) && isCopySet(elems)) {
           elems = getCopySetKeys(elems);
         } else {
-          Fail`provided data source is not iterable`;
+          Fail`provided data source is not iterable: ${elems}`;
         }
       }
       for (const elem of elems) {
@@ -642,10 +642,10 @@ export function makeCollectionManager(
 
     const addAllToMap = mapEntries => {
       if (typeof mapEntries[Symbol.iterator] !== 'function') {
-        if (isCopyMap(mapEntries)) {
+        if (Object.isFrozen(mapEntries) && isCopyMap(mapEntries)) {
           mapEntries = getCopyMapEntries(mapEntries);
         } else {
-          Fail`provided data source is not iterable`;
+          Fail`provided data source is not iterable: ${mapEntries}`;
         }
       }
       for (const [key, value] of mapEntries) {

--- a/packages/swingset-liveslots/test/test-collections.js
+++ b/packages/swingset-liveslots/test/test-collections.js
@@ -222,6 +222,13 @@ test('weak set addAll', t => {
   exerciseSetAddAll(t, true, makeScalarBigWeakSetStore('test weak set'));
 });
 
+test('set snapshot', t => {
+  const testStore = makeScalarBigSetStore('test set');
+  const allThatStuff = stuff.map(entry => entry[0]);
+  testStore.addAll(allThatStuff);
+  t.deepEqual(testStore.snapshot(), makeCopySet(allThatStuff));
+});
+
 function exerciseMapAddAll(t, weak, testStore) {
   testStore.addAll(stuff);
   for (const [k, v] of stuff) {
@@ -250,6 +257,12 @@ test('map addAll', t => {
 
 test('weak map addAll', t => {
   exerciseMapAddAll(t, true, makeScalarBigWeakMapStore('test weak map'));
+});
+
+test('map snapshot', t => {
+  const testStore = makeScalarBigMapStore('test map');
+  testStore.addAll(stuff);
+  t.deepEqual(testStore.snapshot(), makeCopyMap(stuff));
 });
 
 test('constrain map key shape', t => {

--- a/packages/swingset-liveslots/test/test-collections.js
+++ b/packages/swingset-liveslots/test/test-collections.js
@@ -3,6 +3,7 @@ import '@endo/init/debug.js';
 
 import { Far } from '@endo/marshal';
 import { M } from '@agoric/store';
+import { makeCopyMap, makeCopySet } from '@endo/patterns';
 import { makeFakeCollectionManager } from '../tools/fakeVirtualSupport.js';
 
 const {
@@ -189,6 +190,66 @@ test('basic weak set operations', t => {
     'weak set',
     makeScalarBigWeakSetStore('weak set', { keyShape: M.any() }),
   );
+});
+
+function exerciseSetAddAll(t, weak, testStore) {
+  const allThatStuff = stuff.map(entry => entry[0]);
+
+  testStore.addAll(allThatStuff);
+  for (const elem of allThatStuff) {
+    t.truthy(testStore.has(elem));
+    testStore.delete(elem);
+  }
+  if (!weak) {
+    t.is(testStore.getSize(), 0);
+  }
+
+  testStore.addAll(makeCopySet(allThatStuff));
+  for (const elem of allThatStuff) {
+    t.truthy(testStore.has(elem));
+    testStore.delete(elem);
+  }
+  if (!weak) {
+    t.is(testStore.getSize(), 0);
+  }
+}
+
+test('set addAll', t => {
+  exerciseSetAddAll(t, false, makeScalarBigSetStore('test set'));
+});
+
+test('weak set addAll', t => {
+  exerciseSetAddAll(t, true, makeScalarBigWeakSetStore('test weak set'));
+});
+
+function exerciseMapAddAll(t, weak, testStore) {
+  testStore.addAll(stuff);
+  for (const [k, v] of stuff) {
+    t.truthy(testStore.has(k));
+    t.is(testStore.get(k), v);
+    testStore.delete(k);
+  }
+  if (!weak) {
+    t.is(testStore.getSize(), 0);
+  }
+
+  testStore.addAll(makeCopyMap(stuff));
+  for (const [k, v] of stuff) {
+    t.truthy(testStore.has(k));
+    t.is(testStore.get(k), v);
+    testStore.delete(k);
+  }
+  if (!weak) {
+    t.is(testStore.getSize(), 0);
+  }
+}
+
+test('map addAll', t => {
+  exerciseMapAddAll(t, false, makeScalarBigMapStore('test map'));
+});
+
+test('weak map addAll', t => {
+  exerciseMapAddAll(t, true, makeScalarBigWeakMapStore('test weak map'));
 });
 
 test('constrain map key shape', t => {
@@ -765,13 +826,6 @@ test('set queries', t => {
     symbolBozo,
     symbolKrusty,
     undefined,
-  ]);
-
-  // @ts-expect-error our BigSetStore has .entries, but not the SetStore type
-  t.deepEqual(Array.from(testStore.entries(M.number())), [
-    [-29, -29],
-    [3, 3],
-    [47, 47],
   ]);
 });
 

--- a/packages/swingset-liveslots/test/test-collections.js
+++ b/packages/swingset-liveslots/test/test-collections.js
@@ -212,6 +212,11 @@ function exerciseSetAddAll(t, weak, testStore) {
   if (!weak) {
     t.is(testStore.getSize(), 0);
   }
+
+  t.throws(
+    () => testStore.addAll({ bogus: 47 }),
+    m(/provided data source is not iterable/),
+  );
 }
 
 test('set addAll', t => {
@@ -249,6 +254,11 @@ function exerciseMapAddAll(t, weak, testStore) {
   if (!weak) {
     t.is(testStore.getSize(), 0);
   }
+
+  t.throws(
+    () => testStore.addAll({ bogus: 47 }),
+    m(/provided data source is not iterable/),
+  );
 }
 
 test('map addAll', t => {


### PR DESCRIPTION
Fixes #7632

These changes bring the `ScalarBigXXXStore` collection types into compliance with the API defined in the `store` package.

Adds the missing `addAll` method to the map store.
Corrects mishandling of copySet inputs to the `addAll` method in the set store.
Removes bogus internal `addToSet` methods that somehow leaked onto the exposed API surface of maps.
Adds tests for `addAll` to the collection test suite.

Also double checked that the API surface as implemented now actually matches what the `store` package specifies.

### Deployment notes

This PR makes two changes to the implemented API.

While the removal of `addToSet` is technically an incompatible change, we judge that it _should_ be benign to deploy. The method was never part of the published API and was only present due to a development error.  As best I've been able to determine, there is no existing contract code which makes use of this method; this is completely unsurprising, as there is no reason for anyone developing vat code to have been aware of the method's existence, and even if they were aware there is no particular motivation for anyone to ever use it.

The addition of `addAll` brings the implementation into compliance with the official `store` API.  Since it is an addition, it does not pose any backwards compatibility risk.  However, care will be need to be taken to ensure that no new or updated vat code that calls `addAll` on `ScalarBigMapStore` or `ScalarBigSetStore` is deployed prior to the version of Liveslots containing the addition.  Note that this is the same caveat that applies to all Liveslots API additions henceforth; there is nothing otherwise special about this particular API change per se.