### PR TITLE
[NOT FOR VAULTS] refactor: Update reviveWallet/ackWallet signatures for better promise pipelining

### DIFF
--- a/packages/vats/src/provisionPoolKit.js
+++ b/packages/vats/src/provisionPoolKit.js
@@ -120,10 +120,14 @@ export const prepareProvisionPoolKit = (
         initPSM: M.call(BrandShape, InstanceHandleShape).returns(),
       }),
       walletReviver: M.interface('ProvisionPoolKit wallet reviver', {
-        reviveWallet: M.callWhen(M.string()).returns(
+        reviveWallet: M.callWhen(M.string()).returns([
           M.remotable('SmartWallet'),
-        ),
-        ackWallet: M.call(M.string()).returns(M.boolean()),
+          M.boolean(),
+        ]),
+        ackWallet: M.call(M.string(), M.remotable('SmartWallet')).returns([
+          M.remotable('SmartWallet'),
+          M.boolean(),
+        ]),
       }),
       helper: UnguardedHelperI,
       public: M.interface('ProvisionPoolKit public', {
@@ -238,24 +242,26 @@ export const prepareProvisionPoolKit = (
           revivableAddresses.has(address) ||
             Fail`non-revivable address ${address}`;
           const bank = E(bankManager).getBankForAddress(address);
-          const [wallet, _created] = await E(walletFactory).provideSmartWallet(
+          return E(walletFactory).provideSmartWallet(
             address,
             bank,
             namesByAddressAdmin,
           );
-          return wallet;
         },
         /**
+         * @template T
          * @param {string} address
-         * @returns {boolean} isRevive
+         * @param {T} wallet
+         * @returns {[wallet: T, isNew: boolean]}
          */
-        ackWallet(address) {
+        ackWallet(address, wallet) {
           const { revivableAddresses } = this.state;
-          if (!revivableAddresses.has(address)) {
-            return false;
+          const isRevive = revivableAddresses.has(address);
+          if (isRevive) {
+            revivableAddresses.delete(address);
           }
-          revivableAddresses.delete(address);
-          return true;
+          const isNew = !isRevive;
+          return [wallet, isNew];
         },
       },
       helper: {

--- a/packages/vats/src/provisionPoolKit.js
+++ b/packages/vats/src/provisionPoolKit.js
@@ -256,12 +256,14 @@ export const prepareProvisionPoolKit = (
          */
         ackWallet(address, wallet) {
           const { revivableAddresses } = this.state;
-          const isRevive = revivableAddresses.has(address);
-          if (isRevive) {
-            revivableAddresses.delete(address);
+          if (!revivableAddresses.has(address)) {
+            // The address is unrecognized, so the wallet is new.
+            return [wallet, true];
           }
-          const isNew = !isRevive;
-          return [wallet, isNew];
+          // The wallet is not new.
+          // Clear the address as revived and return that information.
+          revivableAddresses.delete(address);
+          return [wallet, false];
         },
       },
       helper: {

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -336,9 +336,10 @@ const makeWalletFactoryKitForAddresses = async addresses => {
       let isNew = !done.has(addr);
       if (isNew) {
         if (walletReviver) {
-          isNew = await E(walletReviver)
-            .ackWallet(addr, wallet)
-            .then(([_wallet, actualIsNew]) => actualIsNew);
+          isNew = await E.when(
+            E(walletReviver).ackWallet(addr, wallet),
+            ([_wallet, actualIsNew]) => actualIsNew,
+          );
         }
         if (isNew) {
           await publishDepositFacet(addr, wallet, nameAdmin);
@@ -479,9 +480,7 @@ test('provisionPool revives old wallets', async t => {
   const reviverP = E(creatorFacet).getWalletReviver();
   await setReviver(reviverP);
   const reviveWallet = addr =>
-    E(reviverP)
-      .reviveWallet(addr)
-      .then(([wallet, _isNew]) => wallet);
+    E.when(E(reviverP).reviveWallet(addr), ([wallet, _isNew]) => wallet);
   await t.throwsAsync(
     reviveWallet('addr_unknown'),
     undefined,


### PR DESCRIPTION
refs: #7599

## Description

Not a breaking change if merged before release.
Updates the arguments and return values of `reviveWallet` and `ackWallet` to support directly returning promises constructed by E rather than performing local processing to produce a derivative promise.
This doesn't necessarily reduce round trips, but it does potentially reduce latency by allowing methods in the provision pool vat and the wallet factory vat to consume the same promises.

### Security Considerations

Minimal; this shares a reference to every new wallet with the provision pool that it could already get by invoking `provideSmartWallet`.

### Scaling Considerations

Expected to be an improvement.

### Documentation Considerations

n/a

### Testing Considerations

Covered by existing tests with modifications as appropriate.