### PR TITLE
fix(vaults): reset lockedQuote at start of auction

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -1191,6 +1191,9 @@ export const prepareVaultManagerKit = (
               debtBrand,
               collateralBrand,
             );
+          // reset lockedQuote after we've used it for the liquidation decision
+          state.lockedQuote = undefined;
+
           if (vaultData.getSize() === 0) {
             return;
           }


### PR DESCRIPTION
closes: #7670

## Description

The lockedQuote wasn't getting reset at the start of the auction, so the previous locked price was being enforced when users attempted to open new vaults.

### Security Considerations

nothing

### Scaling Considerations

Not relevent.

### Documentation Considerations

bug fix: no doc changes needed.

### Testing Considerations

There was a test that showed that the restriction on opening out-of-the-money vaults enforcement included the lock price after starting the auction. I changed the timing to show that it was enforced before the start, and not after the start.
