### PR TITLE
feat(agoric-cli): add `follow --first-value-only` or `-F`

### DIFF
--- a/packages/agoric-cli/src/follow.js
+++ b/packages/agoric-cli/src/follow.js
@@ -48,6 +48,7 @@ export default async function followerMain(progname, rawArgs, powers, opts) {
   const console = anylogger('agoric:follower');
 
   const {
+    firstValueOnly,
     proof,
     output,
     bootstrap = 'http://localhost:26657',
@@ -153,6 +154,9 @@ export default async function followerMain(progname, rawArgs, powers, opts) {
             value,
           )}\n`,
         );
+        if (firstValueOnly) {
+          return;
+        }
       }
     }),
   );

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -233,6 +233,10 @@ const main = async (progname, rawArgs, powers) => {
       DEFAULT_JITTER_SECONDS,
     )
     .option(
+      '-F, --first-value-only',
+      'only display the first value of each <path-spec>',
+    )
+    .option(
       '-o, --output <format>',
       'value output format',
       value => {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #7672

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Add an early-exit flag for `agoric follow`: either `-F` or `--first-value-only`.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
May want to create user-facing `agoric follow` documentation, based on the output of `agoric follow --help`.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Manually tested with `agoric follow -F -B https://ollinet.agoric.net/network-config`