### PR TITLE
feat: Add SwingSet configuration to purge vstorage within (re-)bootstrap

### DIFF
--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -170,20 +170,8 @@ export {};
  */
 
 /**
- * @typedef {string | { module: string, entrypoint: string, args?: Array<unknown> }} ConfigProposal
- */
-
-/**
  * @typedef {object} SwingSetOptions
  * @property {string} [bootstrap]
- * @property {ConfigProposal[]} [coreProposals]
- * @property {string[]} [clearStorageSubtrees] chain storage paths identifying roots of subtrees
- *   for which data should be deleted (except for overlaps with exportStorageSubtrees, which
- *   are preserved).
- * @property {string[]} [exportStorageSubtrees] chain storage paths identifying roots of subtrees
- *   for which data should be exported into bootstrap vat parameter `chainStorageEntries`
- *   (e.g., `exportStorageSubtrees: ['c.o']` might result in vatParameters including
- *   `chainStorageEntries: [ ['c.o', '"top"'], ['c.o.i'], ['c.o.i.n', '42'], ['c.o.w', '"moo"'] ]`).
  * @property {boolean} [includeDevDependencies] indicates that
  * `devDependencies` of the surrounding `package.json` should be accessible to
  * bundles.

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -177,6 +177,9 @@ export {};
  * @typedef {object} SwingSetOptions
  * @property {string} [bootstrap]
  * @property {ConfigProposal[]} [coreProposals]
+ * @property {string[]} [clearStorageSubtrees] chain storage paths identifying roots of subtrees
+ *   for which data should be deleted (except for overlaps with exportStorageSubtrees, which
+ *   are preserved).
  * @property {string[]} [exportStorageSubtrees] chain storage paths identifying roots of subtrees
  *   for which data should be exported into bootstrap vat parameter `chainStorageEntries`
  *   (e.g., `exportStorageSubtrees: ['c.o']` might result in vatParameters including

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -43,6 +43,20 @@ import { makeQueue } from './helpers/make-queue.js';
 const console = anylogger('launch-chain');
 const blockManagerConsole = anylogger('block-manager');
 
+/** @typedef {import('@agoric/swingset-vat').SwingSetConfig} SwingSetConfig */
+
+/**
+ * @typedef {object} CosmicSwingsetConfig
+ * @property {import('@agoric/deploy-script-support/src/extract-proposal.js').ConfigProposal[]} [coreProposals]
+ * @property {string[]} [clearStorageSubtrees] chain storage paths identifying roots of subtrees
+ *   for which data should be deleted (except for overlaps with exportStorageSubtrees, which
+ *   are preserved).
+ * @property {string[]} [exportStorageSubtrees] chain storage paths identifying roots of subtrees
+ *   for which data should be exported into bootstrap vat parameter `chainStorageEntries`
+ *   (e.g., `exportStorageSubtrees: ['c.o']` might result in vatParameters including
+ *   `chainStorageEntries: [ ['c.o', '"top"'], ['c.o.i'], ['c.o.i.n', '42'], ['c.o.w', '"moo"'] ]`).
+ */
+
 /**
  * Return the key in the reserved "host.*" section of the swing-store
  *
@@ -69,11 +83,13 @@ export async function buildSwingset(
   { debugName = undefined, slogCallbacks, slogSender },
 ) {
   const debugPrefix = debugName === undefined ? '' : `${debugName}:`;
-  /** @type {import('@agoric/swingset-vat').SwingSetConfig | null} */
-  let config = await loadSwingsetConfigFile(vatconfig);
-  if (config === null) {
-    config = loadBasedir(vatconfig);
+  let swingsetConfig = await loadSwingsetConfigFile(vatconfig);
+  if (swingsetConfig === null) {
+    swingsetConfig = loadBasedir(vatconfig);
   }
+  const config = /** @type {SwingSetConfig & CosmicSwingsetConfig} */ (
+    swingsetConfig
+  );
 
   const mbs = buildMailboxStateMap(mailboxStorage);
   const timer = buildTimer();

--- a/packages/deploy-script-support/src/extract-proposal.js
+++ b/packages/deploy-script-support/src/extract-proposal.js
@@ -10,6 +10,10 @@ import {
   makeEnactCoreProposalsFromBundleRef,
 } from './coreProposalBehavior.js';
 
+/**
+ * @typedef {string | { module: string, entrypoint: string, args?: Array<unknown> }} ConfigProposal
+ */
+
 const { details: X, Fail } = assert;
 
 const req = createRequire(import.meta.url);
@@ -42,7 +46,7 @@ const pathResolve = (...paths) => {
  * but for sim-chain and such, they can be declared statically in
  * the chain configuration, in which case they are run at bootstrap.
  *
- * @param {import('@agoric/swingset-vat').ConfigProposal[]} coreProposals - governance
+ * @param {ConfigProposal[]} coreProposals - governance
  * proposals to run at chain bootstrap for scenarios such as sim-chain.
  * @param {FilePath} [dirname]
  * @param {typeof makeEnactCoreProposalsFromBundleRef} [makeEnactCoreProposals]

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -138,8 +138,8 @@ harden(assertPathSegment);
 /**
  * Must match the switch in vstorage.go using `vstorageMessage` type
  *
- * @typedef { 'get' | 'getStoreKey' | 'has' | 'entries' | 'values' |'size' } StorageGetByPathMessageMethod
- * @typedef { 'set' | 'append' } StorageUpdateEntriesMessageMethod
+ * @typedef { 'get' | 'getStoreKey' | 'has' | 'children' | 'entries' | 'values' |'size' } StorageGetByPathMessageMethod
+ * @typedef { 'set' | 'setWithoutNotify' | 'append' } StorageUpdateEntriesMessageMethod
  * @typedef {StorageGetByPathMessageMethod | StorageUpdateEntriesMessageMethod } StorageMessageMethod
  * @typedef { [path: string] } StorageGetByPathMessageArgs
  * @typedef { [path: string, value?: string | null] } StorageEntry

--- a/packages/internal/test/test-storage-test-utils.js
+++ b/packages/internal/test/test-storage-test-utils.js
@@ -157,9 +157,19 @@ test('makeFakeStorageKit', async t => {
     'child entries',
   );
   t.deepEqual(
+    await toStorage({ method: 'children', args: [`${rootPath}.child`] }),
+    ['grandchild'],
+    'child path segments',
+  );
+  t.deepEqual(
     await toStorage({ method: 'entries', args: [rootPath] }),
     [...extremeSegments.map(segment => [segment, 'foo']), ['child']],
     'entries include empty non-terminals',
+  );
+  t.deepEqual(
+    await toStorage({ method: 'children', args: [rootPath] }),
+    [...extremeSegments, 'child'],
+    'child path segments include empty non-terminals',
   );
 
   await childNode.setValue('');

--- a/packages/vats/decentral-devnet-config.json
+++ b/packages/vats/decentral-devnet-config.json
@@ -163,6 +163,9 @@
       }
     }
   },
+  "clearStorageSubtrees": [
+    "published"
+  ],
   "exportStorageSubtrees": [
     "published.psm.IST",
     "published.wallet"

--- a/packages/vats/decentral-test-vaults-config.json
+++ b/packages/vats/decentral-test-vaults-config.json
@@ -159,6 +159,9 @@
       }
     }
   },
+  "clearStorageSubtrees": [
+    "published"
+  ],
   "exportStorageSubtrees": [
     "published.psm.IST",
     "published.wallet"

--- a/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
@@ -96,6 +96,10 @@ test.serial('re-bootstrap', async t => {
   );
   t.true(wd1.isNew);
   await oldContext.shutdown();
+  const syntheticPaths = ['published.synthetic', 'published.synthetic2.deep'];
+  for (const syntheticPath of syntheticPaths) {
+    storage.data.set(syntheticPath, 'doomed');
+  }
   const newContext = await makeDefaultTestContext(t, {
     incarnation: oldContext.incarnation + 1,
     logTiming: false,
@@ -109,6 +113,13 @@ test.serial('re-bootstrap', async t => {
     undefined,
     'must not be able to use old swingset',
   );
+  for (const syntheticPath of syntheticPaths) {
+    t.is(
+      storage.data.get(syntheticPath),
+      undefined,
+      `non-exported storage entries must be purged: ${syntheticPath}`,
+    );
+  }
   const wd2 = await newContext.walletFactoryDriver.provideSmartWallet(
     'agoric1a',
   );

--- a/packages/vats/test/test-boot-config.js
+++ b/packages/vats/test/test-boot-config.js
@@ -174,7 +174,7 @@ test('no test-only code is in production proposals', async t => {
       const fullPath = pathResolve('..', configSpec);
       const config = await loadSwingsetConfigFile(fullPath);
       if (!config) throw t.truthy(config, configSpec); // if/throw refines type
-      const { coreProposals } = config;
+      const { coreProposals } = /** @type {any} */ (config);
       return coreProposals || [];
     };
 


### PR DESCRIPTION
Fixes #7681

## Description

Adds a `clearStorageSubtrees` configuration option of the same shape as `exportStorageSubtrees`. In case of overlap, the latter wins.

### Security Considerations

We must be careful to not purge data _after_ bulldozer, but if we do then it should be possible to recover from an old vstorage snapshot.

### Scaling Considerations

We explicitly don't care about bulldozer bootstrap being slow.

### Documentation Considerations

Covered with JSDoc.

### Testing Considerations

Covered in the test-vaults-upgrade bootstrap test.