### PR TITLE
Reboot SwingSet on bulldozer upgrade

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -794,7 +794,15 @@ func upgrade10Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgr
 		app.VstorageKeeper.MigrateNoDataPlaceholders(ctx) // upgrade-10 only
 		normalizeProvisionAccount(ctx, app.AccountKeeper)
 
-		return app.mm.RunMigrations(ctx, app.configurator, fromVm)
+		mvm, err := app.mm.RunMigrations(ctx, app.configurator, fromVm)
+		if err != nil {
+			return mvm, err
+		}
+
+		// Just run the SwingSet kernel to finish bootstrap and get ready to open for
+		// business.
+		stdlog.Println("Rebooting SwingSet")
+		return mvm, swingset.BootSwingset(ctx, app.SwingSetKeeper)
 	}
 }
 

--- a/golang/cosmos/x/swingset/genesis.go
+++ b/golang/cosmos/x/swingset/genesis.go
@@ -37,13 +37,9 @@ type bootstrapBlockAction struct {
 	StoragePort int    `json:"storagePort"`
 }
 
-func InitGenesis(ctx sdk.Context, keeper Keeper, data *types.GenesisState) []abci.ValidatorUpdate {
-	keeper.SetParams(ctx, data.GetParams())
-	keeper.SetState(ctx, data.GetState())
-
-	// Just run the SwingSet kernel to finish bootstrap and get ready to open for
+func BootSwingset(ctx sdk.Context, keeper Keeper) error {
+  // Just run the SwingSet kernel to finish bootstrap and get ready to open for
 	// business.
-	stdlog.Println("Running SwingSet until bootstrap is ready")
 	action := &bootstrapBlockAction{
 		Type:        "BOOTSTRAP_BLOCK",
 		BlockTime:   ctx.BlockTime().Unix(),
@@ -51,7 +47,16 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data *types.GenesisState) []abc
 	}
 
 	_, err := keeper.BlockingSend(ctx, action)
+	return err
+}
 
+func InitGenesis(ctx sdk.Context, keeper Keeper, data *types.GenesisState) []abci.ValidatorUpdate {
+	keeper.SetParams(ctx, data.GetParams())
+	keeper.SetState(ctx, data.GetState())
+
+	stdlog.Println("Running SwingSet until bootstrap is ready")
+	err := BootSwingset(ctx, keeper)
+	
 	// fmt.Fprintf(os.Stderr, "BOOTSTRAP_BLOCK Returned from swingset: %s, %v\n", out, err)
 	if err != nil {
 		// NOTE: A failed BOOTSTRAP_BLOCK means that the SwingSet state is inconsistent.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->
refs: #6644

## Description

When upgrading to `agoric-upgrade-10`, SwingSet will be reinitialized.  This PR adds that initialization to the upgrade handler so that it completes during upgrade before any new blocks are produced.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Improves security:
- no user transactions can interpose until the upgrade is complete
- the chain will halt if there are errors during that upgrade, without committing to potentially corrupted state.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

Avoids costly upgrade work impacting blocks beyond the upgrade block itself.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
