### PR TITLE
DO NOT MERGE: to repro loss of horizontal whitespace

### DIFF
--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -25,6 +25,7 @@ const sellSeatExpiredMsg = 'The covered call option is expired.';
  * @param {import('@agoric/vat-data').Baggage} instanceBaggage
  */
 const prepare = async (zcf, _privateArgs, instanceBaggage) => {
+  debugger;
   const firstTime = !instanceBaggage.has('DidStart');
   if (firstTime) {
     instanceBaggage.init('DidStart', true);

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
@@ -12,7 +12,7 @@ test('coveredCall service upgrade', async t => {
   const config = {
     // includeDevDependencies: true, // for vat-data
     /** @type {ManagerType} */
-    defaultManagerType: 'xs-worker',
+    defaultManagerType: 'local',
     bootstrap: 'bootstrap',
     // defaultReapInterval: 'never',
     // defaultReapInterval: 1,


### PR DESCRIPTION
DO NOT MERGE! For stability, this is based on an ancient master


For reproducing the exact whitespace loss captured as follows, encountered as a developer would encounter it.

https://gist.github.com/erights/7b5ed0f47bf610ead613b197a7f4c203

![example-whitespace-loss](https://github.com/Agoric/agoric-sdk/assets/273868/41494933-150f-4ccd-b88b-214fa2be15db)

The added `debugger` is so that the vscode debugger stops at the corresponding line in the bundle. This addition is the primary reason this PR must not be merged.

The change to `defaultManagerType: 'local'` is so the bug appears in node, where the vscode debugger can see it. Otherwise it would run in XS. It would currently look the same in the XS debugger. (I assume. I have not tried it.) However, the situation under XS is not urgent as we expect to switch to their native compartment loader rather than continuing to use our rewrite.

To reproduce in vscode, open a vscode "JavaScript Terminal Window", cd to `packages/zoe` and run
```sh
$ yarn test test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js
```

See also
https://github.com/endojs/endo/issues/1044
https://github.com/endojs/endo/issues/926

