### PR TITLE
test: psm governance parameters

### DIFF
--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -65,7 +65,8 @@ ENV THIS_NAME=agoric-upgrade-10
 WORKDIR /usr/src/agoric-sdk/
 COPY ./*.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
-COPY --from=agoric-upgrade-9 /root/.agoric /root/.agoric
+COPY --from=agoric-upgrade-9-to-10 /root/.agoric /root/.agoric
+COPY --from=agoric-upgrade-9-to-10 /root/*.json /root/
 SHELL ["/bin/bash", "-c"]
 RUN . ./upgrade-test-scripts/start_to_to.sh
 

--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -39,12 +39,20 @@ ARG DEST_IMAGE
 #this is agoric-upgrade-9 / pismoC
 FROM ghcr.io/agoric/agoric-sdk:31 as agoric-upgrade-9
 ENV THIS_NAME=agoric-upgrade-9
-ENV UPGRADE_TO=agorictest-upgrade-10
 
 WORKDIR /usr/src/agoric-sdk/
 COPY ./*.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-8-1 /root/.agoric /root/.agoric
+SHELL ["/bin/bash", "-c"]
+RUN . ./upgrade-test-scripts/start_to_to.sh
+
+# this is agoric-upgrade-9 / pismoC with upgrade to agoric-upgrade-10
+FROM agoric-upgrade-9 as agoric-upgrade-9-to-10
+ENV THIS_NAME=agoric-upgrade-9
+ENV UPGRADE_TO=agorictest-upgrade-10
+
+WORKDIR /usr/src/agoric-sdk/
 SHELL ["/bin/bash", "-c"]
 RUN . ./upgrade-test-scripts/start_to_to.sh
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
@@ -16,4 +16,31 @@ test_not_val "$(agd q vstorage data published.wallet.$GOV3ADDR -o json | jq -r .
 test_val "$(agd q vstorage data published.vaultFactory.manager0.vaults.vault0 -o json | jq -r .value)" "" "ensure no vaults exist"
 
 # provision pool has right balance
-test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ') "19250000"
+test_val "$(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ')" "19250000"
+
+
+# we should have more denoms in governance
+test_not_val "$(agd q vstorage children published.psm.IST -o jsonlines | jq -r '.children | length')" "1" "more than one PSM denoms"
+test_not_val "$(agd q vstorage children published.psm.IST -o jsonlines | jq -r '.children[] | select (. == "AUSD")')" "" "AUSD in IST"
+test_not_val "$(agd q vstorage children published.psm.IST -o jsonlines | jq -r '.children[] | select (. == "ToyUSD")')" "" "ToyUSD in IST"
+test_not_val "$(agd q vstorage children published.psm.IST -o jsonlines | jq -r '.children[] | select (. == "USDC_axl")')" "" "USDC_axl in IST"
+test_not_val "$(agd q vstorage children published.psm.IST -o jsonlines | jq -r '.children[] | select (. == "USDC_grv")')" "" "USDC_grv in IST"
+test_not_val "$(agd q vstorage children published.psm.IST -o jsonlines | jq -r '.children[] | select (. == "USDT_axl")')" "" "USDT_axl in IST"
+test_not_val "$(agd q vstorage children published.psm.IST -o jsonlines | jq -r '.children[] | select (. == "USDT_grv")')" "" "USDT_grv in IST"
+
+
+## testing state from pismoC was preserved post bulldozer upgrade
+
+# provision pool has right balance 
+test_val "$(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ')" "19250000"
+
+# test that the PSM gov params were preserved
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.MintLimit.value.value')" "$(cat /root/psm_governance.json | jq -r '.current.MintLimit.value.value')" "PSM MintLimit preserved"
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.GiveMintedFee.value.numerator.value')" "0" "GiveMintedFee == 0"
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.WantMintedFee.value.numerator.value')" "0" "WantMintedFee == 0"
+
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.metrics -o jsonlines | jq -r '.anchorPoolBalance.value')" "$(cat /root/psm_metrics.json | jq -r '.anchorPoolBalance.value')" "anchorPoolBalance preserved"
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.metrics -o jsonlines | jq -r '.feePoolBalance.value')" "$(cat /root/psm_metrics.json | jq -r '.feePoolBalance.value')" "feePoolBalance preserved"
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.metrics -o jsonlines | jq -r '.mintedPoolBalance.value')" "$(cat /root/psm_metrics.json | jq -r '.mintedPoolBalance.value')" "mintedPoolBalance preserved"
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.metrics -o jsonlines | jq -r '.totalAnchorProvided.value')" "$(cat /root/psm_metrics.json | jq -r '.totalAnchorProvided.value')" "totalAnchorProvided preserved"
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.metrics -o jsonlines | jq -r '.totalMintedProvided.value')" "$(cat /root/psm_metrics.json | jq -r '.totalMintedProvided.value')" "totalMintedProvided preserved"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
@@ -3,8 +3,8 @@
 . ./upgrade-test-scripts/env_setup.sh
 
 # ensure there's only uist
+test_val "$(agd q bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | length')" "1"
 test_val "$(agd q bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances[0].denom')" "uist"
-
 
 # test wallets are provisioned
 test_not_val "$(agd q vstorage data published.wallet.$GOV1ADDR -o json | jq -r .value)" "" "ensure gov1 provisioned"
@@ -14,3 +14,6 @@ test_not_val "$(agd q vstorage data published.wallet.$GOV3ADDR -o json | jq -r .
 
 # test that we have no vaults
 test_val "$(agd q vstorage data published.vaultFactory.manager0.vaults.vault0 -o json | jq -r .value)" "" "ensure no vaults exist"
+
+# provision pool has right balance
+test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ') "19250000"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
@@ -31,13 +31,13 @@ test_not_val "$(agd q vstorage children published.psm.IST -o jsonlines | jq -r '
 
 ## testing state from pismoC was preserved post bulldozer upgrade
 
-# provision pool has right balance 
-test_val "$(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ')" "19250000"
-
 # test that the PSM gov params were preserved
+test_not_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.MintLimit.value.value')" "0" "PSM MintLimit non-zero"
 test_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.MintLimit.value.value')" "$(cat /root/psm_governance.json | jq -r '.current.MintLimit.value.value')" "PSM MintLimit preserved"
-test_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.GiveMintedFee.value.numerator.value')" "0" "GiveMintedFee == 0"
-test_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.WantMintedFee.value.numerator.value')" "0" "WantMintedFee == 0"
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.GiveMintedFee.value.numerator.value')" "0" "GiveMintedFee numerator == 0"
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.GiveMintedFee.value.denominator.value')" "$(cat /root/psm_governance.json | jq -r '.current.GiveMintedFee.value.denominator.value')" "GiveMintedFee denominator == 10000"
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.WantMintedFee.value.numerator.value')" "0" "WantMintedFee numerator == 0"
+test_val "$(agoric follow -F :published.psm.IST.ToyUSD.governance -o jsonlines | jq -r '.current.WantMintedFee.value.denominator.value')" "$(cat /root/psm_governance.json | jq -r '.current.WantMintedFee.value.denominator.value')" "WantMintedFee denominator == 10000"
 
 test_val "$(agoric follow -F :published.psm.IST.ToyUSD.metrics -o jsonlines | jq -r '.anchorPoolBalance.value')" "$(cat /root/psm_metrics.json | jq -r '.anchorPoolBalance.value')" "anchorPoolBalance preserved"
 test_val "$(agoric follow -F :published.psm.IST.ToyUSD.metrics -o jsonlines | jq -r '.feePoolBalance.value')" "$(cat /root/psm_metrics.json | jq -r '.feePoolBalance.value')" "feePoolBalance preserved"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/test.sh
@@ -3,6 +3,7 @@
 . ./upgrade-test-scripts/env_setup.sh
 
 # ensure there's only uist
+test_val "$(agd q bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | length')" "1"
 test_val "$(agd q bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances[0].denom')" "uist"
 
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/actions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. ./upgrade-test-scripts/env_setup.sh
+
+# NOTE: agoric follow doesn't have the `-F` parameter in this version
+# so we use a hack
+
+# save somewhere we can access later
+echo "Dumping PSM gov params..."
+timeout 2 agoric follow :published.psm.IST.ToyUSD.metrics -o jsonlines | tee /root/psm_metrics.json
+timeout 2 agoric follow :published.psm.IST.ToyUSD.governance -o jsonlines | tee /root/psm_governance.json

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. ./upgrade-test-scripts/env_setup.sh
+
+# provision pool has right balance 
+test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ') "19250000"
+
+# ensure PSM IST has only ToyUSD
+test_val $(agd q vstorage children published.psm.IST -o json | jq -r '.children | length') "1"
+test_val $(agd q vstorage children published.psm.IST -o json | jq -r '.children | first') "ToyUSD"


### PR DESCRIPTION
refs: #7640 

This PR improves and adds tests to ensure the vaults upgrade occurs as expected. In particular we check against the recorded governance parameters set in pismoC and check them after bulldozer upgrade has finished. To enable testing there's also some notable changes:

An additional Dockerfile stage to allow building `agoric-upgrade-9` target without needing to modify the Dockerfile:

```sh
# simply build the desired target
docker build --progress=plain --target agoric-upgrade-9 -t agoric/upgrade-test:agoric-upgrade-9 -f Dockerfile upgrade-test-scripts
# then run the tag used for the build
docker run -it -e "DEST=1" -v "${PWD}:/workspace" -p 26656:26656 -p 26657:26657 --entrypoint bash agoric/upgrade-test:agoric-upgrade-9
```


Due to the need to check various parameters, instead of hardcoding we export them to the home directory and copy them between stages. Currently we only use them for `agoric-upgrade-10`, but we may want to use them for other more dynamic data (e.g. balances that will change as more tests are added).


