### PR TITLE
chore: Make exportStorageSubtrees and clearStorageSubtrees uniform across *-config.json

### DIFF
--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -149,7 +149,7 @@ export async function buildSwingset(
       path === root || path.startsWith(`${root}.`);
 
     // Extract data from chain storage as [path, value?] pairs.
-    if (exportStorageSubtrees.length > 0) {
+    if (bridgeOutbound && exportStorageSubtrees.length > 0) {
       // Disallow exporting internal details like bundle contents and the action queue.
       const exportRoot = STORAGE_PATH.CUSTOM;
       const badPaths = exportStorageSubtrees.filter(
@@ -184,7 +184,7 @@ export async function buildSwingset(
     // Clear other chain storage data as configured.
     // NOTE THAT WE DO NOT LIMIT THIS TO THE CUSTOM PATH!
     // USE AT YOUR OWN RISK!
-    if (clearStorageSubtrees) {
+    if (bridgeOutbound && clearStorageSubtrees) {
       const pathsToClear = [];
       const batchThreshold = 100;
       const sendBatch = () => {

--- a/packages/vats/decentral-core-config.json
+++ b/packages/vats/decentral-core-config.json
@@ -10,6 +10,13 @@
       }
     }
   },
+  "clearStorageSubtrees": [
+    "published"
+  ],
+  "exportStorageSubtrees": [
+    "published.psm.IST",
+    "published.wallet"
+  ],
   "bundles": {
     "agoricNames": {
       "sourceSpec": "@agoric/vats/src/vat-agoricNames.js"

--- a/packages/vats/decentral-demo-config.json
+++ b/packages/vats/decentral-demo-config.json
@@ -108,6 +108,13 @@
       }
     }
   },
+  "clearStorageSubtrees": [
+    "published"
+  ],
+  "exportStorageSubtrees": [
+    "published.psm.IST",
+    "published.wallet"
+  ],
   "bundles": {
     "agoricNames": {
       "sourceSpec": "@agoric/vats/src/vat-agoricNames.js"

--- a/packages/vats/decentral-main-vaults-config.json
+++ b/packages/vats/decentral-main-vaults-config.json
@@ -179,6 +179,13 @@
       }
     }
   },
+  "clearStorageSubtrees": [
+    "published"
+  ],
+  "exportStorageSubtrees": [
+    "published.psm.IST",
+    "published.wallet"
+  ],
   "bundles": {
     "agoricNames": {
       "sourceSpec": "@agoric/vats/src/vat-agoricNames.js"


### PR DESCRIPTION
## Description

Universally export `published.psm.IST` and `published.wallet` vstorage data (if present) from a previous incarnation to bootstrap, and clear everything else at or under `published`.

### Security Considerations

None known.

### Scaling Considerations

None.

### Documentation Considerations

None known.

### Testing Considerations

None.