### PR TITLE
feat: test restarting all PSM instances

### DIFF
--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -28,6 +28,7 @@ const SECONDS_PER_DAY = 24n * SECONDS_PER_HOUR;
 
 /**
  * @typedef {object} PSMKit
+ * @property {string} label
  * @property {Instance} psm
  * @property {Instance} psmGovernor
  * @property {Awaited<ReturnType<Awaited<ReturnType<import('../psm/psm.js')['prepare']>>['creatorFacet']['getLimitedCreatorFacet']>>} psmCreatorFacet

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -51,7 +51,6 @@ const bootMsgEx = {
 
 /**
  * @param {BootstrapPowers & {
- *   consume: {vatStore: Promise<VatStore> }
  * }} powers
  *
  * @typedef {import('@agoric/swingset-vat').CreateVatResults} CreateVatResults as from createVatByName

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -276,6 +276,7 @@
  *   walletBridgeManager: import('../types.js').ScopedBridgeManager | undefined,
  *   walletFactoryStartResult: import('./startWalletFactory').WalletFactoryStartResult,
  *   provisionPoolStartResult: unknown,
+ *   vatStore: import('./utils.js').VatStore,
  *   zoe: ZoeService,
  * }} ChainBootstrapSpaceT
  * @typedef {PromiseSpaceOf<ChainBootstrapSpaceT>} ChainBootstrapSpace

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -317,7 +317,7 @@ export const makeMyAddressNameAdminKit = address => {
  * @param {string} [label]
  *
  * @typedef {import('@agoric/swingset-vat').CreateVatResults} CreateVatResults as from createVatByName
- * @typedef {MapStore<string, Promise<CreateVatResults>>} VatStore
+ * @typedef {MapStore<string, CreateVatResults>} VatStore
  */
 export const makeVatSpace = (
   svc,

--- a/packages/vats/src/proposals/restart-vats-proposal.js
+++ b/packages/vats/src/proposals/restart-vats-proposal.js
@@ -11,12 +11,18 @@ const trace = makeTracer('RV');
 const HR = '----------------';
 
 /**
- * TODO cover each of these collections
- * - [x] contractKits
- * - [ ] psmKit
- * - [x] governedContractKits
- * - [ ] vatStore
+ * Non-contract vats aren't automatically restarted here because doing it would
+ * break many other tests that are fragile.
  */
+const vatUpgradeStatus = {
+  agoricNames: 'UNTESTED',
+  bank: 'covered by test-upgrade-vats: upgrade vat-bank',
+  board: 'covered by test-upgrade-vats: upgrade vat-board',
+  bridge: 'covered by test-upgrade-vats: upgrade vat-bridge',
+  priceAuthority: 'covered by test-upgrade-vats: upgrade vat-priceAuthority',
+  provisioning: 'UNTESTED',
+  zoe: 'tested in @agoric/zoe',
+};
 
 /**
  * @param {BootstrapPowers & import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapSpace} space
@@ -114,6 +120,15 @@ export const restartVats = async ({ consume }, { options }) => {
     await tryRestartContract(kit.label, kit.psm, kit.psmAdminFacet);
   }
 
+  trace('iterating over vatStore');
+  for (const [name] of vatStore.entries()) {
+    const status = vatUpgradeStatus[name];
+    if (!status) {
+      Fail`unaudited vat ${name}`;
+    }
+    console.log('VAT', name, status);
+  }
+
   trace('restartVats done with ', failures.length, 'failures');
   console.log(HR);
   if (failures.length) {
@@ -132,6 +147,7 @@ export const getManifestForRestart = (_powers, options) => ({
         instancePrivateArgs: true,
         loadCriticalVat: true,
         psmKit: true,
+        vatStore: true,
         zoe: 'zoe',
         provisioning: 'provisioning',
         vaultFactoryKit: true,

--- a/packages/vats/src/vat-agoricNames.js
+++ b/packages/vats/src/vat-agoricNames.js
@@ -4,6 +4,7 @@ import { E, Far } from '@endo/far';
 import { BrandI } from '@agoric/ertp';
 import { provide } from '@agoric/vat-data';
 import { makeDurableZone } from '@agoric/zone/durable.js';
+import { provideLazy } from '@agoric/store';
 import { prepareNameHubKit } from './nameHub.js';
 
 /** @param {import('@agoric/zone').Zone} zone */
@@ -80,6 +81,8 @@ export const buildRootObject = (_vatPowers, _vatParameters, baggage) => {
      * @param {DisplayInfo} displayInfo
      */
     provideInertBrand: (keyword, displayInfo) =>
-      provide(brandStore, keyword, () => makeNatBrand(keyword, displayInfo)),
+      provideLazy(brandStore, keyword, () =>
+        makeNatBrand(keyword, displayInfo),
+      ),
   });
 };

--- a/packages/vats/test/bootstrapTests/test-vats-restart.js
+++ b/packages/vats/test/bootstrapTests/test-vats-restart.js
@@ -18,7 +18,8 @@ import { makeSwingsetTestKit, makeWalletFactoryDriver } from './supports.js';
  */
 const test = anyTest;
 
-const PLATFORM_CONFIG = '@agoric/vats/decentral-devnet-config.json';
+// main/production config doesn't have initialPrice, upon which 'open vaults' depends
+const PLATFORM_CONFIG = '@agoric/vats/decentral-test-vaults-config.json';
 
 // presently all these tests use one collateral manager
 const collateralBrandKey = 'ATOM';


### PR DESCRIPTION
closes: #7562

## Description

Test restarting all PSM instances.

Falls short of #7562 checklist "deployment test for restarting all restartable vats" because it doesn't restart the non-contract vats. That's deemed unfeasible. Instead it validates the list of vats and that each one has been audited for its upgradability.

### Security Considerations

--

### Scaling Considerations

--
### Documentation Considerations

--
### Testing Considerations

New tests