### PR TITLE
fix(agoric-cli): repair an observed type confusion

### DIFF
--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -37,7 +37,8 @@ export const getCurrent = async (addr, { readLatestHead }) => {
     throw new Error(`undefined current node for ${addr}`);
   }
 
-  // Repair a type misunderstanding seen in the wild
+  // Repair a type misunderstanding seen in the wild.
+  // See https://github.com/Agoric/agoric-sdk/pull/7139
   let offerToUsedInvitation = current.offerToUsedInvitation;
   if (
     offerToUsedInvitation &&

--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -10,6 +10,7 @@ import { boardSlottingMarshaller, makeRpcUtils } from './rpc.js';
 /** @typedef {import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes} AgoricNamesRemotes  */
 
 const { values } = Object;
+const { Fail } = assert;
 const marshaller = boardSlottingMarshaller();
 
 /** @type {CurrentWalletRecord} */
@@ -28,13 +29,28 @@ const emptyCurrentRecord = {
 export const getCurrent = async (addr, { readLatestHead }) => {
   // Partial because older writes may not have had all properties
   // NB: assumes changes are only additions
-  const current =
+  let current =
     /** @type {Partial<import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord> | undefined} */ (
       await readLatestHead(`published.wallet.${addr}.current`)
     );
   if (current === undefined) {
     throw new Error(`undefined current node for ${addr}`);
   }
+
+  // Repair a type misunderstanding seen in the wild
+  let offerToUsedInvitation = current.offerToUsedInvitation;
+  if (
+    offerToUsedInvitation &&
+    typeof offerToUsedInvitation === 'object' &&
+    !Array.isArray(offerToUsedInvitation)
+  ) {
+    offerToUsedInvitation = Object.entries(offerToUsedInvitation);
+    current = harden({
+      ...current,
+      offerToUsedInvitation,
+    });
+  }
+
   // override full empty record with defined values from published one
   return { ...emptyCurrentRecord, ...current };
 };
@@ -160,7 +176,7 @@ export const findContinuingIds = (current, agoricNames) => {
   /** @type {{ offerToUsedInvitation: [string, Amount<'set'>][]}} */
   const { offerToUsedInvitation: entries } = /** @type {any} */ (current);
 
-  assert(Array.isArray(entries));
+  Array.isArray(entries) || Fail`entries must be an array: ${entries}`;
 
   const keyOf = (obj, val) => {
     const found = Object.entries(obj).find(e => e[1] === val);


### PR DESCRIPTION
Fixes #7700 
Fixes #7701 
See https://github.com/Agoric/agoric-sdk/pull/7139

The error reported by both of these seems to be a misunderstanding of what type is expected. `getCurrent` is supposed to return a `CurrentWalletRecord` whose type says that it has a property `offerToUsedInvitation` whose value is an array of pairs, as returned by `Object.entries` applied to an object. But it gets that alleged `current` record from
```js
await readLatestHead(`published.wallet.${addr}.current`)
```
that returns a similar record, but where the value of `offerToUsedInvitation` is an object with the expected property names and values, that needs to be turned into the expected list of pairs.
