### PR TITLE
fix(cli): dont blow up from old wallet updates

### DIFF
--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -64,6 +64,11 @@ export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
         }
         break;
       }
+      // @ts-expect-error backwards compatibile
+      case 'brand': {
+        console.warn('obsolete brand update record - ignoring', updateRecord);
+        break;
+      }
       default:
         throw Error(`unknown record updated ${updated}`);
     }


### PR DESCRIPTION
refs https://github.com/Agoric/agoric-sdk/issues/7699

## Description

We removed 'brand' from wallet updates, and the cli throws when it encounters an old update record that contains 'brand'. Just warn instead.

## Testing

Getting a new error now:

```
CAUGHT HERE (TypeError#1)
TypeError#1: current.offerToUsedInvitation.map is not a function

  at summarize (packages/agoric-cli/src/lib/format.js:189:52)
  at Command.<anonymous> (packages/agoric-cli/src/commands/wallet.js:174:25)
  at async main (packages/agoric-cli/src/main.js:400:5)
```

This new error should be fixed as part of https://github.com/Agoric/agoric-sdk/issues/7700