### PR TITLE
fix: provisionPool vstorage in exportStorageSubtrees

### DIFF
--- a/packages/vats/decentral-core-config.json
+++ b/packages/vats/decentral-core-config.json
@@ -15,7 +15,8 @@
   ],
   "exportStorageSubtrees": [
     "published.psm.IST",
-    "published.wallet"
+    "published.wallet",
+    "published.provisionPool.metrics"
   ],
   "bundles": {
     "agoricNames": {

--- a/packages/vats/decentral-demo-config.json
+++ b/packages/vats/decentral-demo-config.json
@@ -113,7 +113,8 @@
   ],
   "exportStorageSubtrees": [
     "published.psm.IST",
-    "published.wallet"
+    "published.wallet",
+    "published.provisionPool.metrics"
   ],
   "bundles": {
     "agoricNames": {

--- a/packages/vats/decentral-devnet-config.json
+++ b/packages/vats/decentral-devnet-config.json
@@ -168,7 +168,8 @@
   ],
   "exportStorageSubtrees": [
     "published.psm.IST",
-    "published.wallet"
+    "published.wallet",
+    "published.provisionPool.metrics"
   ],
   "bundles": {
     "agoricNames": {

--- a/packages/vats/decentral-main-vaults-config.json
+++ b/packages/vats/decentral-main-vaults-config.json
@@ -184,7 +184,8 @@
   ],
   "exportStorageSubtrees": [
     "published.psm.IST",
-    "published.wallet"
+    "published.wallet",
+    "published.provisionPool.metrics"
   ],
   "bundles": {
     "agoricNames": {

--- a/packages/vats/decentral-test-vaults-config.json
+++ b/packages/vats/decentral-test-vaults-config.json
@@ -164,7 +164,8 @@
   ],
   "exportStorageSubtrees": [
     "published.psm.IST",
-    "published.wallet"
+    "published.wallet",
+    "published.provisionPool.metrics"
   ],
   "bundles": {
     "agoricNames": {

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -46,7 +46,8 @@
     "@endo/import-bundle": "^0.3.4",
     "@endo/init": "^0.5.56",
     "@endo/marshal": "^0.8.5",
-    "@endo/promise-kit": "^0.2.56"
+    "@endo/promise-kit": "^0.2.56",
+    "jessie.js": "^0.3.2"
   },
   "devDependencies": {
     "@agoric/cosmic-swingset": "^0.39.2",

--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -23,6 +23,8 @@ export const privateArgsShape = M.splitRecord(
   harden({
     // only necessary on first invocation, not subsequent
     initialPoserInvitation: InvitationShape,
+    // expected only in upgrade incarnations
+    metricsOverride: M.recordOf(M.string()),
   }),
 );
 
@@ -39,11 +41,12 @@ export const privateArgsShape = M.splitRecord(
  *   initialPoserInvitation: Invitation,
  *   storageNode: StorageNode,
  *   marshaller: Marshaller,
+ *   metricsOverride?: import('./provisionPoolKit').MetricsNotification,
  * }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const prepare = async (zcf, privateArgs, baggage) => {
-  const { poolBank } = privateArgs;
+  const { poolBank, metricsOverride } = privateArgs;
 
   const { makeRecorderKit } = prepareRecorderKitMakers(
     baggage,
@@ -78,8 +81,9 @@ export const prepare = async (zcf, privateArgs, baggage) => {
         // NB: changing the brand will break this pool
         poolBrand: params.getPerAccountInitialAmount().brand,
         storageNode: privateArgs.storageNode,
+        isRevived: metricsOverride !== undefined,
       }),
-    kit => kit.helper.start(),
+    kit => kit.helper.start({ metrics: metricsOverride }),
   );
 
   const publicFacet = prepareExo(

--- a/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
@@ -95,6 +95,15 @@ test.serial('re-bootstrap', async t => {
     'agoric1a',
   );
   t.true(wd1.isNew);
+  // eslint-disable-next-line no-unused-vars
+  const assertWalletCount = (walletsProvisioned, message) => {
+    // eslint-disable-next-line no-unused-vars
+    const metrics = oldContext.readLatest('published.provisionPool.metrics');
+    // disabled while wallet provisioning bypasses provisionPool
+    // t.like(metrics, { walletsProvisioned }, message);
+  };
+  // prettier-ignore
+  assertWalletCount(1n, 'wallet provisioning must be recorded in provisionPool metrics');
 
   await oldContext.shutdown();
   const walletPaths = [...storage.data.keys()].filter(path =>
@@ -130,14 +139,20 @@ test.serial('re-bootstrap', async t => {
     const msg = `non-exported storage entries must be purged: ${syntheticPath}`;
     t.is(storage.data.get(syntheticPath), undefined, msg);
   }
+  // prettier-ignore
+  assertWalletCount(1n, 'provisionPool metrics must not be modified by re-bootstrap');
   const wd2 = await newContext.walletFactoryDriver.provideSmartWallet(
     'agoric1a',
   );
   t.false(wd2.isNew);
+  // prettier-ignore
+  assertWalletCount(1n, 'wallet restoration must not affect provisionPool metrics');
   const wd3 = await newContext.walletFactoryDriver.provideSmartWallet(
     'agoric1b',
   );
   t.true(wd3.isNew);
+  // prettier-ignore
+  assertWalletCount(2n, 'new wallet provisioning must update revived provisionPool metrics');
 });
 
 test.serial('audit bootstrap exports', async t => {

--- a/packages/vats/tools/board-utils.js
+++ b/packages/vats/tools/board-utils.js
@@ -116,7 +116,7 @@ export const makeHistoryReviver = (entries, slotToVal = undefined) => {
       ),
     ]);
   };
-  return harden({ getItem, children, has: k => vsMap.has(k) });
+  return harden({ getItem, children, has: k => vsMap.get(k) !== undefined });
 };
 
 /**


### PR DESCRIPTION
closes: #7705

## Description

`provisionPool` has data we want to carry through like `published.psm.IST`. We keep `metrics` but not `governance`, because the values have never been changed from defaults (for `PerAccountInitialAmount`) and the post-bulldoze will come with the same defaults.

Analogously to PSM, we consume exported `published.provisionPool.metrics` data, translate old brand boardID values into new ones, and plumb the result into the new provisionPool incarnation via privateArgs so it can pick up where its
predecessor left off.

### Security Considerations

provisionPool can now start from a nonempty state under the control of its creator, which gets that state from exported vstorage data. But if that can be tampered with, then we've got bigger problems.

### Scaling Considerations

At most, this slows down the time to execute re-bootstrap—which we don't care about (but realistically, I don't expect any significant impact even to that).

### Documentation Considerations

n/a

### Testing Considerations

There's not really a good way to cover this with our automated testing, since real wallets are provisioned by a bridge handler (which doesn't provide a response), while test-vaults-upgrade.js bypasses that—and therefore the `helper.onProvisioned()` call that publishes metrics to chain storage—to directly invoke the wallet factory's `provideSmartWallet` method (which provides a response that is depended upon by assertions etc.).

We can probably address that given more time, but for now I've just validated manually.

As for other published storage paths, @turadg examined them all and found no gaps other than `provisionPool`.