### PR TITLE
test: check provision pool metric retention

### DIFF
--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
@@ -48,4 +48,10 @@ test_val "$(echo "$toyUSDMetrics" | jq -r '.mintedPoolBalance.value')" "$(cat /r
 test_val "$(echo "$toyUSDMetrics" | jq -r '.totalAnchorProvided.value')" "$(cat /root/.agoric/psm_metrics.json | jq -r '.totalAnchorProvided.value')" "totalAnchorProvided preserved"
 test_val "$(echo "$toyUSDMetrics" | jq -r '.totalMintedProvided.value')" "$(cat /root/.agoric/psm_metrics.json | jq -r '.totalMintedProvided.value')" "totalMintedProvided preserved"
 
+# test that provision pool metrics are retained across vaults upgrade
+provisionPoolMetrics="$(agoric follow -lF :published.provisionPool.metrics -o jsonlines)"
+test_val "$(echo "$provisionPoolMetrics" | jq -r '.totalMintedConverted.value')" "$(cat /root/.agoric/provision_pool_metrics.json | jq -r '.totalMintedConverted.value')" "totalMintedConverted preserved"
+test_val "$(echo "$provisionPoolMetrics" | jq -r '.totalMintedProvided.value')" "$(cat /root/.agoric/provision_pool_metrics.json | jq -r '.totalMintedProvided.value')" "totalMintedProvided preserved"
+test_val "$(echo "$provisionPoolMetrics" | jq -r '.walletsProvisioned')" "$(cat /root/.agoric/provision_pool_metrics.json | jq -r '.walletsProvisioned')" "walletsProvisioned preserved"
+
 test_val "$(agops vaults list --from $GOV1ADDR)" "" "gov1 has no vaults"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
@@ -102,3 +102,8 @@ test_val "$(agd q bank balances "$GOV1ADDR" --output=json --denom ubld | jq -r .
 test_val "$(agd q bank balances "$GOV1ADDR" --output=json --denom ibc/toyusdc | jq -r .amount)" "89989989" "post-swap: validate ToyUSD balance"
 
 waitForBlock 3
+
+# dump provision pool metrics
+echo "Dumping provision pool metrics..."
+timeout 2 agoric follow -l :published.provisionPool.metrics -o jsonlines | tee /root/.agoric/provision_pool_metrics.json
+test_not_val "$(cat /root/.agoric/provision_pool_metrics.json | wc -l)" "0" "provision pool metrics shouldnt be empty"


### PR DESCRIPTION
refs: #7705

As titled, testing that provision pool metrics are retained. This in effect reproduces #7705 and can help testing potential fixes.

To reproduce:
`make build`

```sh
#42 172.2 FAIL: TEST: totalMintedConverted preserved: wanted 20000000
#42 172.2 20000000, got 0
#42 ERROR: process "/bin/bash -c . ./upgrade-test-scripts/start_to_to.sh" did not complete successfully: exit code: 1
------
 > [agoric-upgrade-10 7/7] RUN . ./upgrade-test-scripts/start_to_to.sh:
------
process "/bin/bash -c . ./upgrade-test-scripts/start_to_to.sh" did not complete successfully: exit code: 1
make: *** [Makefile:13: build] Error 1
```

refs: #7640 