### PR TITLE
fix: Harden facets returned from produceStartGovernedUpgradable

### DIFF
--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -243,7 +243,7 @@ const startGovernedInstance = async (
     E(governorFacets.creatorFacet).getAdminFacet(),
   ]);
   /** @type {GovernanceFacetKit<SF>} */
-  const facets = {
+  const facets = harden({
     instance,
     publicFacet,
     governor: governorFacets.instance,
@@ -251,7 +251,7 @@ const startGovernedInstance = async (
     adminFacet,
     governorCreatorFacet: governorFacets.creatorFacet,
     governorAdminFacet: governorFacets.adminFacet,
-  };
+  });
   return facets;
 };
 


### PR DESCRIPTION
## Description

Discovered an issue during manual testing of #7708 when the collection of facets from `produceStartGovernedUpgradable` could not be transferred because the object was mutable.

### Security Considerations

None known.

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a