### PR TITLE
fix(provisionPool): publish metrics at start of every incarnation

### DIFF
--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -23,7 +23,6 @@ export const privateArgsShape = M.splitRecord(
   harden({
     // only necessary on first invocation, not subsequent
     initialPoserInvitation: InvitationShape,
-    // expected only in upgrade incarnations
     metricsOverride: M.recordOf(M.string()),
   }),
 );
@@ -81,7 +80,6 @@ export const prepare = async (zcf, privateArgs, baggage) => {
         // NB: changing the brand will break this pool
         poolBrand: params.getPerAccountInitialAmount().brand,
         storageNode: privateArgs.storageNode,
-        isRevived: metricsOverride !== undefined,
       }),
     kit => kit.helper.start({ metrics: metricsOverride }),
   );

--- a/packages/vats/src/provisionPoolKit.js
+++ b/packages/vats/src/provisionPoolKit.js
@@ -384,8 +384,8 @@ export const prepareProvisionPoolKit = (
           );
 
           if (metrics) {
-            // Restore state, but don't publishMetrics()
-            // because that already happened in the last incarnation.
+            // Restore state.
+            // we publishMetrics() below
             const {
               walletsProvisioned,
               totalMintedProvided,
@@ -432,6 +432,11 @@ export const prepareProvisionPoolKit = (
         },
       },
     },
+    {
+      finish: ({ facets }) => {
+        facets.helper.publishMetrics();
+      },
+    },
   );
 
   /**
@@ -440,28 +445,18 @@ export const prepareProvisionPoolKit = (
    * @param {object} opts
    * @param {Brand} opts.poolBrand
    * @param {ERef<StorageNode>} opts.storageNode
-   * @param {boolean} [opts.isRevived]
    */
-  const makeProvisionPoolKit = async ({
-    poolBrand,
-    storageNode,
-    isRevived,
-  }) => {
+  const makeProvisionPoolKit = async ({ poolBrand, storageNode }) => {
     /** @type {Purse<'nat'>} */
     // @ts-expect-error vbank purse is close enough for our use.
     const fundPurse = await E(poolBank).getPurse(poolBrand);
     const metricsNode = await E(storageNode).makeChildNode('metrics');
 
-    const kit = makeProvisionPoolKitInternal({
+    return makeProvisionPoolKitInternal({
       fundPurse,
       poolBrand,
       metricsNode,
     });
-    // Publish initial metrics (but don't republish revived metrics).
-    if (!isRevived) {
-      kit.helper.publishMetrics();
-    }
-    return kit;
   };
 
   return makeProvisionPoolKit;


### PR DESCRIPTION
refs: #7705

## Description

The 1st-incarnation exception to publishing metrics meant immediate post-bulldozer metrics would most likely bear the wrong brand board id.

### Security Considerations

avoids possible confusion

### Scaling / Documentation Considerations

n/a

### Testing Considerations

I'm a little surprised that none of the existing tests are sensitive to this change.

I didn't add a unit test; I gather we're doing larger validation testing.
