### PR TITLE
fix: make auction scheduler robust against bad parameter combos

### DIFF
--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -573,16 +573,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     },
   });
 
-  const scheduler = await E.when(scheduleKit.recorderP, scheduleRecorder =>
-    makeScheduler(
-      driver,
-      timer,
-      // @ts-expect-error types are correct. How to convince TS?
-      params,
-      timerBrand,
-      scheduleRecorder,
-    ),
-  );
+  // eslint-disable-next-line no-use-before-define
   const isActive = () => scheduler.getAuctionState() === AuctionState.ACTIVE;
 
   /**
@@ -649,7 +640,8 @@ export const start = async (zcf, privateArgs, baggage) => {
         );
       },
       getSchedules() {
-        return E(scheduler).getSchedule();
+        // eslint-disable-next-line no-use-before-define
+        return scheduler.getSchedule();
       },
       getScheduleUpdates() {
         return scheduleKit.subscriber;
@@ -669,6 +661,18 @@ export const start = async (zcf, privateArgs, baggage) => {
       makeDepositInvitation,
       ...params,
     }),
+  );
+
+  const scheduler = await E.when(scheduleKit.recorderP, scheduleRecorder =>
+    makeScheduler(
+      driver,
+      timer,
+      // @ts-expect-error types are correct. How to convince TS?
+      params,
+      timerBrand,
+      scheduleRecorder,
+      publicFacet.getSubscription(),
+    ),
   );
 
   const creatorFacet = makeFarGovernorFacet(

--- a/packages/inter-protocol/src/auction/scheduleMath.js
+++ b/packages/inter-protocol/src/auction/scheduleMath.js
@@ -5,7 +5,7 @@ import { natSafeMath } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeTracer } from '@agoric/internal';
 
 const { subtract, multiply, floorDivide } = natSafeMath;
-const { Fail } = assert;
+const { details: X, Fail } = assert;
 
 const trace = makeTracer('SMath', false);
 
@@ -24,25 +24,48 @@ export const computeRoundTiming = (params, baseTime) => {
   /** @type {NatValue} */
   const lowestRate = params.getLowestRate();
 
+  const noNextAuction = msg => {
+    console.error(assert.error(msg));
+    return undefined;
+  };
+
   /** @type {RelativeTime} */
   const startDelay = params.getAuctionStartDelay();
-  TimeMath.compareRel(freq, startDelay) > 0 ||
-    Fail`startFrequency must exceed startDelay, ${freq}, ${startDelay}`;
-  TimeMath.compareRel(freq, lockPeriod) > 0 ||
-    Fail`startFrequency must exceed lock period, ${freq}, ${lockPeriod}`;
+  if (TimeMath.compareRel(freq, startDelay) <= 0) {
+    return noNextAuction(
+      X`startFrequency must exceed startDelay, ${freq}, ${startDelay}`,
+    );
+  }
+  if (TimeMath.compareRel(freq, lockPeriod) <= 0) {
+    return noNextAuction(
+      X`startFrequency must exceed lock period, ${freq}, ${lockPeriod}`,
+    );
+  }
 
-  startingRate > lowestRate ||
-    Fail`startingRate ${startingRate} must be more than lowest: ${lowestRate}`;
+  if (startingRate <= lowestRate) {
+    return noNextAuction(
+      X`startingRate ${startingRate} must be more than lowest: ${lowestRate}`,
+    );
+  }
+
   const rateChange = subtract(startingRate, lowestRate);
   const requestedSteps = floorDivide(rateChange, discountStep);
-  requestedSteps > 0n ||
-    Fail`discountStep ${discountStep} too large for requested rates`;
-  TimeMath.compareRel(freq, clockStep) >= 0 ||
-    Fail`clockStep ${TimeMath.relValue(
-      clockStep,
-    )} must be shorter than startFrequency ${TimeMath.relValue(
-      freq,
-    )} to allow at least one step down`;
+
+  if (requestedSteps <= 0n) {
+    return noNextAuction(
+      X`discountStep ${discountStep} too large for requested rates`,
+    );
+  }
+
+  if (TimeMath.compareRel(freq, clockStep) < 0) {
+    return noNextAuction(
+      X`clockStep ${TimeMath.relValue(
+        clockStep,
+      )} must be shorter than startFrequency ${TimeMath.relValue(
+        freq,
+      )} to allow at least one step down`,
+    );
+  }
 
   const requestedDuration = TimeMath.multiplyRelNat(clockStep, requestedSteps);
   const targetDuration =
@@ -52,14 +75,18 @@ export const computeRoundTiming = (params, baseTime) => {
   const steps = TimeMath.divideRelRel(targetDuration, clockStep);
   const duration = TimeMath.multiplyRelNat(clockStep, steps);
 
-  steps > 0n ||
-    Fail`clockStep ${clockStep} too long for auction duration ${duration}`;
+  if (steps <= 0n) {
+    return noNextAuction(
+      X`clockStep ${clockStep} too long for auction duration ${duration}`,
+    );
+  }
+
   const endRate = subtract(startingRate, multiply(steps, discountStep));
 
   const actualDuration = TimeMath.multiplyRelNat(clockStep, steps);
-  // computed start is baseTime + freq - (now mod freq). if there are hourly
-  // starts, we add an hour to the time, and subtract now mod freq.
-  // Then we add the delay
+  // computed start is baseTime + freq - (baseTime mod freq). if there are hourly
+  // starts, we add an hour to the time, and subtract baseTime mod freq.
+  // Then we add the delay.
   /** @type {import('@agoric/time/src/types').TimestampRecord} */
   const startTime = TimeMath.addAbsRel(
     TimeMath.addAbsRel(
@@ -92,14 +119,14 @@ harden(computeRoundTiming);
  * the start of the step following the current step.
  *
  * @param {import('./scheduler.js').Schedule | undefined} liveSchedule
- * @param {import('./scheduler.js').Schedule} nextSchedule
+ * @param {import('./scheduler.js').Schedule | undefined} nextSchedule
  * @param {Timestamp} now
  */
 export const nextDescendingStepTime = (liveSchedule, nextSchedule, now) => {
   nextSchedule || Fail`nextSchedule must always be defined`;
 
   if (!liveSchedule) {
-    return nextSchedule.startTime;
+    return nextSchedule?.startTime;
   }
 
   const { startTime, endTime, clockStep } = liveSchedule;
@@ -114,7 +141,7 @@ export const nextDescendingStepTime = (liveSchedule, nextSchedule, now) => {
   const expectedNext = TimeMath.addAbsRel(lastStepStart, clockStep);
 
   if (TimeMath.compareAbs(expectedNext, endTime) > 0) {
-    return nextSchedule.startTime;
+    return nextSchedule?.startTime;
   }
 
   return expectedNext;

--- a/packages/inter-protocol/test/auction/test-computeRoundTiming.js
+++ b/packages/inter-protocol/test/auction/test-computeRoundTiming.js
@@ -66,17 +66,18 @@ const checkSchedule = (t, params, baseTime, rawExpect) => {
  * @param {any} t
  * @param {ReturnType<makeDefaultParams>} params
  * @param {number} baseTime
- * @param {any} expectMessage  XXX should be {ThrowsExpectation}
  */
-const checkScheduleThrows = (t, params, baseTime, expectMessage) => {
+const checkScheduleNull = (t, params, baseTime) => {
   /** @type {import('@agoric/time/src/types').TimestampRecord} */
   // @ts-expect-error known for testing
   const startFrequency = params.getStartFrequency();
   const brand = startFrequency.timerBrand;
-  const baseTimeRecord = TimeMath.coerceTimestampRecord(baseTime, brand);
-  t.throws(() => computeRoundTiming(params, baseTimeRecord), {
-    message: expectMessage,
-  });
+  const schedule = computeRoundTiming(
+    params,
+    TimeMath.coerceTimestampRecord(baseTime, brand),
+  );
+
+  t.is(schedule, undefined);
 };
 
 // Hourly starts. 4 steps down, 5 price levels. discount steps of 10%.
@@ -128,34 +129,30 @@ test(
 // lock Period too Long
 test(
   'long lock period',
-  checkScheduleThrows,
+  checkScheduleNull,
   makeDefaultParams({ lock: 3600 }),
   100,
-  /startFrequency must exceed lock period/,
 );
 
 test(
   'longer auction than freq',
-  checkScheduleThrows,
+  checkScheduleNull,
   makeDefaultParams({ freq: 500, lock: 300 }),
   100,
-  /clockStep .* must be shorter than startFrequency /,
 );
 
 test(
   'startDelay too long',
-  checkScheduleThrows,
+  checkScheduleNull,
   makeDefaultParams({ delay: 5000 }),
   100,
-  /startFrequency must exceed startDelay/,
 );
 
 test(
   'large discount step',
-  checkScheduleThrows,
+  checkScheduleNull,
   makeDefaultParams({ discount: 5000n }),
   100,
-  /discountStep "\[5000n]" too large for requested rates/,
 );
 
 test(
@@ -176,10 +173,9 @@ test(
 
 test(
   'lowest rate higher than start',
-  checkScheduleThrows,
+  checkScheduleNull,
   makeDefaultParams({ lowest: 10_600n }),
   100,
-  /startingRate "\[10500n]" must be more than/,
 );
 
 // If the steps are small enough that we can't get to the end_rate, we'll cut

--- a/packages/inter-protocol/test/auction/test-scheduler.js
+++ b/packages/inter-protocol/test/auction/test-scheduler.js
@@ -1,6 +1,6 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { subscribeEach } from '@agoric/notifier';
+import { subscribeEach, makePublishKit } from '@agoric/notifier';
 import { buildManualTimer } from '@agoric/swingset-vat/tools/manual-timer.js';
 import { TimeMath } from '@agoric/time';
 import { prepareMockRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
@@ -66,12 +66,15 @@ test('schedule start to finish', async t => {
     paramValues,
   );
 
+  const { subscriber } = makePublishKit();
   const scheduler = await makeScheduler(
     fakeAuctioneer,
     timer,
     paramManager,
     timer.getTimerBrand(),
     recorderKit.recorder,
+    // @ts-expect-error Oops. Wrong kind of subscriber.
+    subscriber,
   );
   const schedule = scheduler.getSchedule();
   t.deepEqual(schedule.liveAuctionSchedule, undefined);
@@ -279,17 +282,17 @@ test('lowest >= starting', async t => {
     paramValues,
   );
 
-  await t.throwsAsync(
-    () =>
-      makeScheduler(
-        fakeAuctioneer,
-        timer,
-        paramManager,
-        timer.getTimerBrand(),
-        recorderKit.recorder,
-      ),
-    { message: /startingRate "\[105n]" must be more than lowest: "\[110n]"/ },
+  const { subscriber } = makePublishKit();
+  const scheduler = await makeScheduler(
+    fakeAuctioneer,
+    timer,
+    paramManager,
+    timer.getTimerBrand(),
+    recorderKit.recorder,
+    // @ts-expect-error Oops. wrong kind of subscriber.
+    subscriber,
   );
+  t.is(scheduler.getSchedule().nextAuctionSchedule, undefined);
 });
 
 test('zero time for auction', async t => {
@@ -328,20 +331,17 @@ test('zero time for auction', async t => {
     paramValues,
   );
 
-  await t.throwsAsync(
-    () =>
-      makeScheduler(
-        fakeAuctioneer,
-        timer,
-        paramManager,
-        timer.getTimerBrand(),
-        recorderKit.recorder,
-      ),
-    {
-      message:
-        /clockStep "\[3n]" must be shorter than startFrequency "\[2n]" to allow at least one step down/,
-    },
+  const { subscriber } = makePublishKit();
+  const scheduler = await makeScheduler(
+    fakeAuctioneer,
+    timer,
+    paramManager,
+    timer.getTimerBrand(),
+    recorderKit.recorder,
+    // @ts-expect-error Oops. wrong kind of subscriber.
+    subscriber,
   );
+  t.is(scheduler.getSchedule().nextAuctionSchedule, undefined);
 });
 
 test('discountStep 0', async t => {
@@ -377,6 +377,7 @@ test('discountStep 0', async t => {
     paramValues,
   );
 
+  const { subscriber } = makePublishKit();
   await t.throwsAsync(
     () =>
       makeScheduler(
@@ -385,6 +386,8 @@ test('discountStep 0', async t => {
         paramManager,
         timer.getTimerBrand(),
         recorderKit.recorder,
+        // @ts-expect-error Oops. wrong kind of subscriber.
+        subscriber,
       ),
     { message: 'Division by zero' },
   );
@@ -424,17 +427,17 @@ test('discountStep larger than starting rate', async t => {
     paramValues,
   );
 
-  await t.throwsAsync(
-    () =>
-      makeScheduler(
-        fakeAuctioneer,
-        timer,
-        paramManager,
-        timer.getTimerBrand(),
-        recorderKit.recorder,
-      ),
-    { message: /discountStep .* too large for requested rates/ },
+  const { subscriber } = makePublishKit();
+  const scheduler = await makeScheduler(
+    fakeAuctioneer,
+    timer,
+    paramManager,
+    timer.getTimerBrand(),
+    recorderKit.recorder,
+    // @ts-expect-error Oops. wrong kind of subscriber.
+    subscriber,
   );
+  t.is(scheduler.getSchedule().nextAuctionSchedule, undefined);
 });
 
 test('start Freq 0', async t => {
@@ -470,17 +473,17 @@ test('start Freq 0', async t => {
     paramValues,
   );
 
-  await t.throwsAsync(
-    () =>
-      makeScheduler(
-        fakeAuctioneer,
-        timer,
-        paramManager,
-        timer.getTimerBrand(),
-        recorderKit.recorder,
-      ),
-    { message: /startFrequency must exceed startDelay.*0n.*10n.*/ },
+  const { subscriber } = makePublishKit();
+  const scheduler = await makeScheduler(
+    fakeAuctioneer,
+    timer,
+    paramManager,
+    timer.getTimerBrand(),
+    recorderKit.recorder,
+    // @ts-expect-error Oops. wrong kind of subscriber.
+    subscriber,
   );
+  t.is(scheduler.getSchedule().nextAuctionSchedule, undefined);
 });
 
 test('delay > freq', async t => {
@@ -517,17 +520,17 @@ test('delay > freq', async t => {
     paramValues,
   );
 
-  await t.throwsAsync(
-    () =>
-      makeScheduler(
-        fakeAuctioneer,
-        timer,
-        paramManager,
-        timer.getTimerBrand(),
-        recorderKit.recorder,
-      ),
-    { message: /startFrequency must exceed startDelay.*\[20n\].*\[40n\].*/ },
+  const { subscriber } = makePublishKit();
+  const scheduler = await makeScheduler(
+    fakeAuctioneer,
+    timer,
+    paramManager,
+    timer.getTimerBrand(),
+    recorderKit.recorder,
+    // @ts-expect-error Oops. wrong kind of subscriber.
+    subscriber,
   );
+  t.is(scheduler.getSchedule().nextAuctionSchedule, undefined);
 });
 
 test('lockPeriod > freq', async t => {
@@ -565,19 +568,17 @@ test('lockPeriod > freq', async t => {
     paramValues,
   );
 
-  await t.throwsAsync(
-    () =>
-      makeScheduler(
-        fakeAuctioneer,
-        timer,
-        paramManager,
-        timer.getTimerBrand(),
-        recorderKit.recorder,
-      ),
-    {
-      message: /startFrequency must exceed lock period.*\[3600n\].*\[7200n\].*/,
-    },
+  const { subscriber } = makePublishKit();
+  const scheduler = await makeScheduler(
+    fakeAuctioneer,
+    timer,
+    paramManager,
+    timer.getTimerBrand(),
+    recorderKit.recorder,
+    // @ts-expect-error Oops. wrong kind of subscriber.
+    subscriber,
   );
+  t.is(scheduler.getSchedule().nextAuctionSchedule, undefined);
 });
 
 // if duration = frequency, we'll cut the duration short to fit.
@@ -621,14 +622,17 @@ test('duration = freq', async t => {
     zcf,
     paramValues,
   );
-
+  const { subscriber } = makePublishKit();
   const scheduler = await makeScheduler(
     fakeAuctioneer,
     timer,
     paramManager,
     timer.getTimerBrand(),
     recorderKit.recorder,
+    // @ts-expect-error Oops. wrong kind of subscriber.
+    subscriber,
   );
+
   let schedule = scheduler.getSchedule();
   t.deepEqual(schedule.liveAuctionSchedule, undefined);
   const firstSchedule = {
@@ -710,12 +714,15 @@ test('change Schedule', async t => {
   // UNTIL https://github.com/Agoric/agoric-sdk/issues/4343
   await paramManager.getParams();
 
+  const { subscriber } = makePublishKit();
   const scheduler = await makeScheduler(
     fakeAuctioneer,
     timer,
     paramManager,
     timer.getTimerBrand(),
     recorderKit.recorder,
+    // @ts-expect-error Oops. wrong kind of subscriber.
+    subscriber,
   );
   let schedule = scheduler.getSchedule();
   t.is(schedule.liveAuctionSchedule, undefined);
@@ -843,12 +850,15 @@ test('schedule anomalies', async t => {
     paramValues,
   );
 
+  const { subscriber } = makePublishKit();
   const scheduler = await makeScheduler(
     fakeAuctioneer,
     timer,
     paramManager,
     timer.getTimerBrand(),
     recorderKit.recorder,
+    // @ts-expect-error Oops. Wrong kind of subscriber.
+    subscriber,
   );
   const firstStart = baseTime + delay;
   await scheduleTracker.assertInitial({


### PR DESCRIPTION
## Description

Testing has revealed some cases where the auctioneer gets into a loop. One plausible cause is bad combinations of parameters. This PR makes the auctioneer deschedule the next auction when it detects bad combinations, rather than going into an incoherent state.

To recover from the descheduling, we check to see if we should schedule a new auction when governed parameters change in the auction.

### Security Considerations

Testing FTW!

### Scaling Considerations

Not related to scaling

### Documentation Considerations

Not required

### Testing Considerations

Tests were corrected to show improved behavior. I didn't add a test to show changing governance parameters and recovering to a running state.
