### PR TITLE
test(xsnap-lockdown): more inspect testing

### DIFF
--- a/packages/xsnap-lockdown/lib/object-inspect.js
+++ b/packages/xsnap-lockdown/lib/object-inspect.js
@@ -1,8 +1,8 @@
-// @ts-nocheck
+/* global globalThis */
 /* eslint-disable no-empty,no-nested-ternary,no-use-before-define */
 /* eslint-enable @endo/no-polymorphic-call */
-/* global globalThis */
 // Adapted from object-inspect@1.12.0 https://github.com/inspect-js/object-inspect
+
 /*
 MIT License
 
@@ -26,9 +26,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-const mapSize = Object.getOwnPropertyDescriptor(Map.prototype, 'size').get;
+const mapSizeDesc = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+assert(mapSizeDesc !== undefined);
+const mapSize = mapSizeDesc.get;
 const mapForEach = Map.prototype.forEach;
-const setSize = Object.getOwnPropertyDescriptor(Set.prototype, 'size').get;
+const setSizeDesc = Object.getOwnPropertyDescriptor(Set.prototype, 'size');
+assert(setSizeDesc !== undefined);
+const setSize = setSizeDesc.get;
 const setForEach = Set.prototype.forEach;
 const WeakRefPrototype =
   typeof globalThis.WeakRef === 'function' ? globalThis.WeakRef.prototype : {};
@@ -180,6 +184,7 @@ function inspect0(obj, opts = {}, depth = 0, circular = new Set()) {
       mapForEach.call(obj, (value, key) => {
         mapParts.push(`${inspect(key, obj, true)} => ${inspect(value, obj)}`);
       });
+      assert(mapSize !== undefined);
       return collectionOf('Map', mapSize.call(obj), mapParts, indent);
     }
     case Set.prototype: {
@@ -187,6 +192,7 @@ function inspect0(obj, opts = {}, depth = 0, circular = new Set()) {
       setForEach.call(obj, value => {
         setParts.push(inspect(value, obj));
       });
+      assert(setSize !== undefined);
       return collectionOf('Set', setSize.call(obj), setParts, indent);
     }
     case WeakMap.prototype: {

--- a/packages/xsnap-lockdown/package.json
+++ b/packages/xsnap-lockdown/package.json
@@ -25,7 +25,8 @@
     "ava": "^5.2.0",
     "c8": "^7.13.0",
     "rollup": "^2.58.0",
-    "rollup-plugin-string": "^3.0.0"
+    "rollup-plugin-string": "^3.0.0",
+    "object-inspect": "^1.12.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/xsnap-lockdown/test/inspect-test-cases.js
+++ b/packages/xsnap-lockdown/test/inspect-test-cases.js
@@ -1,0 +1,115 @@
+// The third column, when present, shows how the original util.inspect
+// prints, so we can keep track of the differences.
+// See test-util-inspect.js
+export const testCases = [
+  '1',
+  '1n',
+  '12n',
+  '123n',
+  ['1_234n', undefined, '1234n'],
+  ['12_345n', undefined, '12345n'],
+  ['123_456n', undefined, '123456n'],
+  ['1_234_567n', undefined, '1234567n'],
+  ['12_345_678n', undefined, '12345678n'],
+  ['123_456_789n', undefined, '123456789n'],
+  ['-123_456_789n', undefined, `-123456789n`],
+  '1.1',
+  'true',
+  'false',
+  'null',
+  'undefined',
+  "''",
+  "'foo'",
+  "[ 'foo', 'bar' ]",
+  "{ foo: 'bar' }",
+  '/foo/',
+  [
+    'new Date(133)',
+    '1970-01-01T00:00:00.133Z',
+    'Wed Dec 31 1969 16:00:00 GMT-0800 (Pacific Standard Time)',
+  ],
+  ['new RegExp("foo")', '/foo/'],
+  ['new Map([["foo", "bar"]])', `Map (1) {'foo' => 'bar'}`],
+  ['new Set(["foo"])', `Set (1) {'foo'}`],
+  ['new WeakMap([[{}, "foo"]])', `WeakMap { ? }`],
+  ['new WeakSet([{}])', `WeakSet { ? }`],
+  ['Promise.resolve()', `Promise [Promise] {}`],
+  [
+    `Promise.resolve('x')`,
+    `Promise [Promise] {}`,
+    // Based on interactive testing in node repl, expected
+    // `Promise { 'foo' }`
+  ],
+  [
+    `(p => {
+        p.catch(() => {});
+        return p;
+      })(Promise.reject(Error('foo')))`,
+    `Promise [Promise] {}`,
+    // Based on interactive testing in node repl, expected
+    // `Promise { <rejected> Error: foo }`
+  ],
+  [
+    '(() => { const circ = {}; circ.ref = circ; return circ; })()',
+    '{ ref: [Circular] }',
+  ],
+  [
+    '(() => { const circ = {}; circ.ref = circ; return [circ, circ, { again: circ }]; })()',
+    '[ { ref: [Circular] }, { ref: [Circular] }, { again: { ref: [Circular] } } ]',
+  ],
+  ['Error("foo")', '[Error: foo]'],
+  ['TypeError("foo2")', '[TypeError: foo2]'],
+  ['new Function("bar", 1)', '[Function: anonymous]'],
+  ['() => "bab"', '[Function (anonymous)]'],
+  ['new Proxy({}, {})', '{}'],
+  ['new Proxy(() => {}, {})', '[Function (anonymous)]'],
+  ["new Proxy(() => {}, { get: () => 'foo' })", '[Function: foo]'],
+
+  // null prototype still works
+  ['({__proto__: null})', '[Object: null prototype] {}'],
+  [
+    `({ __proto__: null, foo: 'bar' })`,
+    "[Object: null prototype] { foo: 'bar' }",
+  ],
+
+  // throws during inspection do not propagate
+  [
+    `({
+       get foo() {
+         throw URIError("gotcha");
+       },
+     })`,
+    '[cannot inspect (object) due to [URIError: gotcha]]',
+    {
+      message: 'gotcha',
+    },
+  ],
+  [
+    `({
+       get foo() {
+         throw "gotcha";
+       },
+     })`,
+    "[cannot inspect (object) due to 'gotcha']",
+    {
+      // Ava cannot test that a function throws a non-error
+      // https://github.com/avajs/ava/blob/main/docs/03-assertions.md#throwsfn-expectation-message
+      skip: true,
+    },
+  ],
+  [
+    `({
+       get foo() {
+         throw {
+           get bar() {
+             throw "nested";
+           },
+         };
+       },
+     })`,
+    '[cannot inspect (object) due to throw]',
+    {
+      skip: true,
+    },
+  ],
+];

--- a/packages/xsnap-lockdown/test/test-inspect.js
+++ b/packages/xsnap-lockdown/test/test-inspect.js
@@ -1,95 +1,14 @@
 import test from 'ava';
 import '@endo/init/debug.js';
 import unconfinedInspect from '../lib/object-inspect.js';
+import { testCases } from './inspect-test-cases.js';
 
-const testCases = [
-  '1',
-  '1n',
-  '12n',
-  '123n',
-  '1_234n',
-  '12_345n',
-  '123_456n',
-  '1_234_567n',
-  '12_345_678n',
-  '123_456_789n',
-  '-123_456_789n',
-  '1.1',
-  'true',
-  'false',
-  'null',
-  'undefined',
-  "''",
-  "'foo'",
-  "[ 'foo', 'bar' ]",
-  "{ foo: 'bar' }",
-  '/foo/',
-  ['new Date(133)', '1970-01-01T00:00:00.133Z'],
-  ['new RegExp("foo")', '/foo/'],
-  ['new Map([["foo", "bar"]])', `Map (1) {'foo' => 'bar'}`],
-  ['new Set(["foo"])', `Set (1) {'foo'}`],
-  ['new WeakMap([[{}, "foo"]])', `WeakMap { ? }`],
-  ['new WeakSet([{}])', `WeakSet { ? }`],
-  ['Promise.resolve()', `Promise [Promise] {}`],
-  [
-    '(() => { const circ = {}; circ.ref = circ; return circ; })()',
-    '{ ref: [Circular] }',
-  ],
-  [
-    '(() => { const circ = {}; circ.ref = circ; return [circ, circ, { again: circ }]; })()',
-    '[ { ref: [Circular] }, { ref: [Circular] }, { again: { ref: [Circular] } } ]',
-  ],
-  ['Error("foo")', '[Error: foo]'],
-  ['TypeError("foo2")', '[TypeError: foo2]'],
-  ['new Function("bar", 1)', '[Function: anonymous]'],
-  ['() => "bab"', '[Function (anonymous)]'],
-  ['new Proxy({}, {})', '{}'],
-  ['new Proxy(() => {}, {})', '[Function (anonymous)]'],
-  ["new Proxy(() => {}, { get: () => 'foo' })", '[Function: foo]'],
-
-  // null prototype still works
-  ['({__proto__: null})', '[Object: null prototype] {}'],
-  [
-    `({ __proto__: null, foo: 'bar' })`,
-    "[Object: null prototype] { foo: 'bar' }",
-  ],
-
-  // throws during inspection do not propagate
-  [
-    `({
-       get foo() {
-         throw URIError("gotcha");
-       },
-     })`,
-    '[cannot inspect (object) due to [URIError: gotcha]]',
-  ],
-  [
-    `({
-       get foo() {
-         throw "gotcha";
-       },
-     })`,
-    "[cannot inspect (object) due to 'gotcha']",
-  ],
-  [
-    `({
-       get foo() {
-         throw {
-           get bar() {
-             throw "nested";
-           },
-         };
-       },
-     })`,
-    '[cannot inspect (object) due to throw]',
-  ],
-];
-
-test('unconfined inspect', async t => {
+test('unconfined inspect', t => {
   for (const testCase of testCases) {
-    const [toEval, toRender] = Array.isArray(testCase)
+    const [toEval, toRender = toEval] = Array.isArray(testCase)
       ? testCase
       : [testCase, testCase];
+    assert(typeof toEval === 'string');
     // eslint-disable-next-line no-eval
     const evaled = (1, eval)(`(${toEval})`);
     // t.log(evaled);

--- a/packages/xsnap-lockdown/test/test-util-inspect.js
+++ b/packages/xsnap-lockdown/test/test-util-inspect.js
@@ -1,0 +1,23 @@
+import test from 'ava';
+import '@endo/init/debug.js';
+import inspect from 'object-inspect';
+import { testCases } from './inspect-test-cases.js';
+
+test('ambient util.inspect', t => {
+  for (const testCase of testCases) {
+    const [toEval, toRender = toEval, toRenderOriginal = toRender] =
+      Array.isArray(testCase) ? testCase : [testCase, testCase, testCase];
+    assert(typeof toEval === 'string');
+    // eslint-disable-next-line no-eval
+    const evaled = (1, eval)(`(${toEval})`);
+    if (typeof toRenderOriginal === 'string') {
+      // t.log(evaled);
+      t.is(inspect(evaled), toRenderOriginal, toEval);
+    } else {
+      assert(toRenderOriginal && typeof toRenderOriginal === 'object');
+      if (!toRenderOriginal.skip) {
+        t.throws(() => inspect(evaled), toRenderOriginal, toEval);
+      }
+    }
+  }
+});


### PR DESCRIPTION
Spinoff from curiosity about its behavior and differences from `util.inspect`

Not at all urgent. Probably all to be migrated to endo eventually anyway.