### PR TITLE
fix(provisionPool): publishMetrics() for overrideMetrics

### DIFF
--- a/packages/vats/src/provisionPoolKit.js
+++ b/packages/vats/src/provisionPoolKit.js
@@ -399,6 +399,7 @@ export const prepareProvisionPoolKit = (
               totalMintedProvided,
               totalMintedConverted,
             });
+            helper.publishMetrics();
           }
         },
         /**


### PR DESCRIPTION
refs: #7705, #7708, #7730

## Description

`publishMetrics()` in the `helper.start()` method if `metrics` is provided.

#7730 was based on a mistaken understanding that `overrideMetrics` was handled in the exo `init` function. Now I see that the `start()` method is where they are assigned to the exo `.state`.

### Security, Scaling, Documentation Considerations

n/a

### Testing Considerations

added a unit test this time.

cc @arirubinstein 
