### PR TITLE
fix(upgrade-test): longer wait for agoric follow

### DIFF
--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
@@ -15,7 +15,7 @@ for i in "${govaccounts[@]}"; do
     for run in {1..2}; do
         echo "$i: $run: Accepting EC Committee"
         if [[ "$run" == "1" ]]; then
-            timeout 6 yarn run --silent agops ec committee --send-from "$i" || true
+            timeout 8 yarn run --silent agops ec committee --send-from "$i" || true
         else
             agops ec committee --send-from "$i" --voter "$cm"
             cm=$((cm + 1))

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
@@ -15,7 +15,7 @@ for i in "${govaccounts[@]}"; do
     for run in {1..2}; do
         echo "$i: $run: Accepting EC Committee"
         if [[ "$run" == "1" ]]; then
-            timeout 3 yarn run --silent agops ec committee --send-from "$i" || true
+            timeout 6 yarn run --silent agops ec committee --send-from "$i" || true
         else
             agops ec committee --send-from "$i" --voter "$cm"
             cm=$((cm + 1))

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
@@ -114,5 +114,5 @@ waitForBlock 3
 
 # dump provision pool metrics
 echo "Dumping provision pool metrics..."
-timeout 2 agoric follow -l :published.provisionPool.metrics -o jsonlines | tee /root/.agoric/provision_pool_metrics.json
+timeout 6 agoric follow -l :published.provisionPool.metrics -o jsonlines | tee /root/.agoric/provision_pool_metrics.json
 test_not_val "$(cat /root/.agoric/provision_pool_metrics.json | wc -l)" "0" "provision pool metrics shouldnt be empty"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
@@ -114,5 +114,5 @@ waitForBlock 3
 
 # dump provision pool metrics
 echo "Dumping provision pool metrics..."
-timeout 6 agoric follow -l :published.provisionPool.metrics -o jsonlines | tee /root/.agoric/provision_pool_metrics.json
+timeout 8 agoric follow -l :published.provisionPool.metrics -o jsonlines | tee /root/.agoric/provision_pool_metrics.json
 test_not_val "$(cat /root/.agoric/provision_pool_metrics.json | wc -l)" "0" "provision pool metrics shouldnt be empty"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/actions.sh
@@ -7,8 +7,8 @@
 
 # save somewhere we can access later
 echo "Dumping PSM gov params..."
-timeout 3 agoric follow -l :published.psm.${PSM_PAIR}.metrics -o jsonlines | tee /root/.agoric/psm_metrics.json
-timeout 3 agoric follow -l :published.psm.${PSM_PAIR}.governance -o jsonlines | tee /root/.agoric/psm_governance.json
+timeout 6 agoric follow -l :published.psm.${PSM_PAIR}.metrics -o jsonlines | tee /root/.agoric/psm_metrics.json
+timeout 6 agoric follow -l :published.psm.${PSM_PAIR}.governance -o jsonlines | tee /root/.agoric/psm_governance.json
 
 test_not_val "$(cat /root/.agoric/psm_metrics.json | wc -l)" "0" "psm metrics shouldnt be empty"
 test_not_val "$(cat /root/.agoric/psm_governance.json | wc -l)" "0" "psm gov params shouldnt be empty"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/actions.sh
@@ -7,8 +7,8 @@
 
 # save somewhere we can access later
 echo "Dumping PSM gov params..."
-timeout 6 agoric follow -l :published.psm.${PSM_PAIR}.metrics -o jsonlines | tee /root/.agoric/psm_metrics.json
-timeout 6 agoric follow -l :published.psm.${PSM_PAIR}.governance -o jsonlines | tee /root/.agoric/psm_governance.json
+timeout 8 agoric follow -l :published.psm.${PSM_PAIR}.metrics -o jsonlines | tee /root/.agoric/psm_metrics.json
+timeout 8 agoric follow -l :published.psm.${PSM_PAIR}.governance -o jsonlines | tee /root/.agoric/psm_governance.json
 
 test_not_val "$(cat /root/.agoric/psm_metrics.json | wc -l)" "0" "psm metrics shouldnt be empty"
 test_not_val "$(cat /root/.agoric/psm_governance.json | wc -l)" "0" "psm gov params shouldnt be empty"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/test.sh
@@ -12,7 +12,7 @@ test_val $(agd q vstorage children published.psm.IST -o json | jq -r '.children 
 test_val $(agd q vstorage children published.psm.IST -o json | jq -r '.children | first') ${PSM_PAIR//IST./}
 
 # Gov params
-test_not_val "$(timeout 6 agoric follow -l :published.psm.${PSM_PAIR}.governance -o jsonlines | jq -r '.current.MintLimit.value.value')" "0" "PSM MintLimit non-zero"
+test_not_val "$(timeout 8 agoric follow -l :published.psm.${PSM_PAIR}.governance -o jsonlines | jq -r '.current.MintLimit.value.value')" "0" "PSM MintLimit non-zero"
 
 test_wallet_state "$USER1ADDR" old "user1 wallet is old"
 test_wallet_state "$GOV1ADDR" old "gov1 wallet is old"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/test.sh
@@ -12,7 +12,7 @@ test_val $(agd q vstorage children published.psm.IST -o json | jq -r '.children 
 test_val $(agd q vstorage children published.psm.IST -o json | jq -r '.children | first') ${PSM_PAIR//IST./}
 
 # Gov params
-test_not_val "$(timeout 3 agoric follow -l :published.psm.${PSM_PAIR}.governance -o jsonlines | jq -r '.current.MintLimit.value.value')" "0" "PSM MintLimit non-zero"
+test_not_val "$(timeout 6 agoric follow -l :published.psm.${PSM_PAIR}.governance -o jsonlines | jq -r '.current.MintLimit.value.value')" "0" "PSM MintLimit non-zero"
 
 test_wallet_state "$USER1ADDR" old "user1 wallet is old"
 test_wallet_state "$GOV1ADDR" old "gov1 wallet is old"


### PR DESCRIPTION
Older versions of the sdk don't have #7680, so we use a hack involving bash timeout. We use `agoric follow` to dump governance parameters and metrics and later ensure they are preserved between upgrades. However, it seems sometimes the timeout isn't long enough, causing the dumps to be empty and later tests to fail. 

In #7729 we added additional tests to fail earlier in addition to increasing the timeout to result in less flaky tests. Despite that we still see occasional failures. We increase to wait longer before timing out.