### PR TITLE
upgrade-test: test vaults in main bootstrap

### DIFF
--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
@@ -10,6 +10,16 @@ set -x
 # agoric wallet show --from $GOV1ADDR
 waitForBlock 20
 
+# provision a new user wallet
+
+agd keys add user2 --keyring-backend=test  2>&1 | tee "$HOME/.agoric/user2.out"
+cat "$HOME/.agoric/user2.out" | tail -n1 | tee "$HOME/.agoric/user2.key"
+export USER2ADDR=$($binary keys show user2 -a --keyring-backend="test" 2> /dev/null)
+provisionSmartWallet $USER2ADDR "20000000ubld,100000000${ATOM_DENOM}"
+waitForBlock
+
+test_not_val "$(agd q vstorage data published.wallet.$USER2ADDR -o json | jq -r .value)" "" "ensure user2 provisioned"
+
 echo "ACTIONS Tickling the wallets so they are revived"
 # Until they are revived, the invitations can't be deposited. So the first action can't be to accept an invitation (because it won't be there).
 govaccounts=("$GOV1ADDR" "$GOV2ADDR" "$GOV3ADDR")
@@ -140,6 +150,26 @@ agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-bac
 OFFER=$(mktemp -t agops.XXX)
 agops vaults close --vaultId vault1 --giveMinted 6.06 --from $GOV1ADDR --keyring-backend="test" >|"$OFFER"
 agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test
+
+# make sure the same works for user2
+OFFER=$(mktemp -t agops.XXX)
+agops vaults open --wantMinted 7.00 --giveCollateral 11.0 >|"$OFFER"
+agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
+
+# put some IST in
+OFFER=$(mktemp -t agops.XXX)
+agops vaults adjust --vaultId vault2 --giveMinted 1.5 --from $USER2ADDR --keyring-backend=test >|"$OFFER"
+agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
+
+# add some collateral
+OFFER=$(mktemp -t agops.XXX)
+agops vaults adjust --vaultId vault2 --giveCollateral 2.0 --from $USER2ADDR --keyring-backend="test" >|"$OFFER"
+agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
+
+# close out
+OFFER=$(mktemp -t agops.XXX)
+agops vaults close --vaultId vault2 --giveMinted 5.75 --from $USER2ADDR --keyring-backend="test" >|"$OFFER"
+agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
 
 # # TODO test bidding
 # # TODO liquidations

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
@@ -92,59 +92,55 @@ test_val "$(agoric follow -l -F :published.vaultFactory.managers.manager0.govern
 
 pushPrice 12.01
 
-if [[ "$BOOTSTRAP_MODE" == "test" ]]; then
-    # TODO: support main bootstrap mode by changing the mintlimit higher
-    # vaults
-    # attempt to open vaults under the minimum amount
-    for vid in {1..2}; do
-        OFFER=$(mktemp -t agops.XXX)
-        if [[ "$vid" == "2" ]]; then
-            amount=3.00
-            collateral=5.0
-        else
-            amount=2.00
-            collateral=4.0
-        fi
-        agops vaults open --wantMinted $amount --giveCollateral $collateral >|"$OFFER"
-        agoric wallet print --file "$OFFER"
-        agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test || true
-    done
-
-    # we should still have no vaults
-    test_val "$(agops vaults list --from $GOV1ADDR)" "" "gov1 has no vaults"
-
-    # open up some vaults
-    for vid in {1..2}; do
-        OFFER=$(mktemp -t agops.XXX)
-        if [[ "$vid" == "2" ]]; then
-            amount=6.00
-            collateral=10.0
-        else
-            amount=5.00
-            collateral=9.0
-        fi
-        agops vaults open --wantMinted $amount --giveCollateral $collateral >|"$OFFER"
-        agoric wallet print --file "$OFFER"
-        agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test
-    done
-
-    # remove some collateral from the first vault
+## vaults
+# attempt to open vaults under the minimum amount
+for vid in {1..2}; do
     OFFER=$(mktemp -t agops.XXX)
-    agops vaults adjust --vaultId vault0 --wantCollateral 1.0 --from $GOV1ADDR --keyring-backend="test" >|"$OFFER"
-    agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test
+    if [[ "$vid" == "2" ]]; then
+        amount=3.00
+        collateral=5.0
+    else
+        amount=2.00
+        collateral=4.0
+    fi
+    agops vaults open --wantMinted $amount --giveCollateral $collateral >|"$OFFER"
+    agoric wallet print --file "$OFFER"
+    agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test || true
+done
 
-    # take some IST from the first vault, increasing debt
+# we should still have no vaults
+test_val "$(agops vaults list --from $GOV1ADDR)" "" "gov1 has no vaults"
+
+# open up some vaults
+for vid in {1..2}; do
     OFFER=$(mktemp -t agops.XXX)
-    agops vaults adjust --vaultId vault0 --wantMinted 1.0 --from $GOV1ADDR --keyring-backend="test" >|"$OFFER"
+    if [[ "$vid" == "2" ]]; then
+        amount=6.00
+        collateral=10.0
+    else
+        amount=5.00
+        collateral=9.0
+    fi
+    agops vaults open --wantMinted $amount --giveCollateral $collateral >|"$OFFER"
+    agoric wallet print --file "$OFFER"
     agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test
+done
 
-    # close the second vault
-    OFFER=$(mktemp -t agops.XXX)
-    agops vaults close --vaultId vault1 --giveMinted 6.06 --from $GOV1ADDR --keyring-backend="test" >|"$OFFER"
-    agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test
+# remove some collateral from the first vault
+OFFER=$(mktemp -t agops.XXX)
+agops vaults adjust --vaultId vault0 --wantCollateral 1.0 --from $GOV1ADDR --keyring-backend="test" >|"$OFFER"
+agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test
 
-    # # TODO test bidding
-    # # TODO liquidations
-    # # agops inter bid by-price --price 1 --give 1.0IST  --from $GOV1ADDR --keyring-backend test
+# take some IST from the first vault, increasing debt
+OFFER=$(mktemp -t agops.XXX)
+agops vaults adjust --vaultId vault0 --wantMinted 1.0 --from $GOV1ADDR --keyring-backend="test" >|"$OFFER"
+agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test
 
-fi
+# close the second vault
+OFFER=$(mktemp -t agops.XXX)
+agops vaults close --vaultId vault1 --giveMinted 6.06 --from $GOV1ADDR --keyring-backend="test" >|"$OFFER"
+agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test
+
+# # TODO test bidding
+# # TODO liquidations
+# # agops inter bid by-price --price 1 --give 1.0IST  --from $GOV1ADDR --keyring-backend test

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
@@ -14,6 +14,9 @@ test_not_val "$(agd q vstorage data published.wallet.$GOV1ADDR -o json | jq -r .
 test_not_val "$(agd q vstorage data published.wallet.$GOV2ADDR -o json | jq -r .value)" "" "ensure gov2 provisioned"
 test_not_val "$(agd q vstorage data published.wallet.$GOV3ADDR -o json | jq -r .value)" "" "ensure gov3 provisioned"
 
+# test user2 not provisioned
+test_val "$(agd q vstorage data published.wallet.$USER2ADDR -o json | jq -r .value)" "" "ensure user2 not provisioned"
+
 # test that we have no vaults
 test_val "$(agd q vstorage data published.vaultFactory.manager0.vaults.vault0 -o json | jq -r .value)" "" "ensure no vaults exist"
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
@@ -3,14 +3,14 @@
 . ./upgrade-test-scripts/env_setup.sh
 
 # provision pool has right balance 
-test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ') "19000000"
+test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ') "18750000"
 
 test_wallet_state "$USER1ADDR" upgraded "user1 wallet is upgraded"
 test_wallet_state "$GOV1ADDR" revived "gov1 wallet is revived"
 test_wallet_state "$GOV2ADDR" revived "gov2 wallet is revived"
 test_wallet_state "$GOV3ADDR" revived "gov3 wallet is revived"
 
-test_val $(agd q vstorage children published.vaultFactory.managers.manager0.vaults -o json | jq -r '.children | length') 2 "we only have two vaults"
+test_val $(agd q vstorage children published.vaultFactory.managers.manager0.vaults -o json | jq -r '.children | length') 3 "we have three vaults"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.numActiveVaults') 1 "only one vault is active"
 
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.totalDebt.value') "6030000" "totalDebt is correct"
@@ -25,3 +25,8 @@ test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.vaultState') "closed" "vault1 is closed"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.locked.value') "0" "vault1 contains no collateral"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.debtSnapshot.debt.value') "0" "vault1 has no debt"
+
+# user2 vault2
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault2 -o jsonlines | jq -r '.vaultState') "closed" "vault2 is closed"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault2 -o jsonlines | jq -r '.locked.value') "0" "vault2 contains no collateral"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault2 -o jsonlines | jq -r '.debtSnapshot.debt.value') "0" "vault2 has no debt"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
@@ -10,22 +10,18 @@ test_wallet_state "$GOV1ADDR" revived "gov1 wallet is revived"
 test_wallet_state "$GOV2ADDR" revived "gov2 wallet is revived"
 test_wallet_state "$GOV3ADDR" revived "gov3 wallet is revived"
 
-if [[ "$BOOTSTRAP_MODE" == "test" ]]; then
+test_val $(agd q vstorage children published.vaultFactory.managers.manager0.vaults -o json | jq -r '.children | length') 2 "we only have two vaults"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.numActiveVaults') 1 "only one vault is active"
 
-    test_val $(agd q vstorage children published.vaultFactory.managers.manager0.vaults -o json | jq -r '.children | length') 2 "we only have two vaults"
-    test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.numActiveVaults') 1 "only one vault is active"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.totalDebt.value') "6030000" "totalDebt is correct"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.totalCollateral.value') "8000000" "totalCollateral is correct"
 
-    test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.totalDebt.value') "6030000" "totalDebt is correct"
-    test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.totalCollateral.value') "8000000" "totalCollateral is correct"
+# gov1 vault0
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault0 -o jsonlines | jq -r '.vaultState') "active" "vault0 is open"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault0 -o jsonlines | jq -r '.locked.value') "8000000" "vault0 contains 8 ATOM collateral"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault0 -o jsonlines | jq -r '.debtSnapshot.debt.value') "6030000" "vault0 debt is 6.03 IST"
 
-    # gov1 vault0
-    test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault0 -o jsonlines | jq -r '.vaultState') "active" "vault0 is open"
-    test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault0 -o jsonlines | jq -r '.locked.value') "8000000" "vault0 contains 8 ATOM collateral"
-    test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault0 -o jsonlines | jq -r '.debtSnapshot.debt.value') "6030000" "vault0 debt is 6.03 IST"
-
-    # gov1 vault1
-    test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.vaultState') "closed" "vault1 is closed"
-    test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.locked.value') "0" "vault1 contains no collateral"
-    test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.debtSnapshot.debt.value') "0" "vault1 has no debt"
-
-fi
+# gov1 vault1
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.vaultState') "closed" "vault1 is closed"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.locked.value') "0" "vault1 contains no collateral"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.debtSnapshot.debt.value') "0" "vault1 has no debt"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
@@ -14,18 +14,6 @@ waitForBlock 3
 govaccounts=( "$GOV1ADDR" "$GOV2ADDR" "$GOV3ADDR" )
 govamount="200000000ubld,100000000${USDC_DENOM},100000000${ATOM_DENOM}"
 
-provisionSmartWallet() {
-  i="$1"
-  amount="$2"
-  echo "funding $i"
-  agd tx bank send "validator" "$i" "$amount" -y --keyring-backend=test --chain-id="$CHAINID"
-  waitForBlock
-  echo "provisioning $i"
-  agd tx swingset provision-one my-wallet "$i" SMART_WALLET --keyring-backend=test  --yes --chain-id="$CHAINID" --from="$i"
-  waitForBlock
-  agoric wallet show --from $i
-}
-
 for i in "${govaccounts[@]}"
 do
   provisionSmartWallet "$i" "$govamount"


### PR DESCRIPTION
When we first added bootstrap testing, there were some differences in the main bootstrap that prevented vaults:

* No debt limit, so we can't create vaults
* Debt limit needs to be voted in

After that the rest of the tests should proceed as expected. #7763 includes the required code to vote raising the debt limit. This PR completes by running those tests in main bootstrap after debt limit is raised.


We also test that we can't create vaults yet in main bootstrap _before_ raising debt limit.