### PR TITLE
fix: agd install for cli bidding

### DIFF
--- a/bin/agd
+++ b/bin/agd
@@ -174,9 +174,9 @@ fi
       esac
       # Ensure minimum patch versions of Go environment
       goversion=$(go version 2>/dev/null)
-      goregexp='go version go([0-9]+).([0-9]+)(.([0-9]+))? '
+      goregexp='go version go([0-9]+)(.([0-9]+)(.([0-9]+))?)? '
       [[ "$goversion" =~ $goregexp ]] || fatal "illegible go version '$goversion'"
-      golang_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+      golang_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[5]}"
       # Build the daemon.
       cd "$GOLANG_DIR"
       make

--- a/bin/agd
+++ b/bin/agd
@@ -174,7 +174,7 @@ fi
       esac
       # Ensure minimum patch versions of Go environment
       goversion=$(go version 2>/dev/null)
-      goregexp='go version go([0-9]+).([0-9]+).([0-9]+) '
+      goregexp='go version go([0-9]+).([0-9]+)(.([0-9]+))? '
       [[ "$goversion" =~ $goregexp ]] || fatal "illegible go version '$goversion'"
       golang_version_check "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
       # Build the daemon.

--- a/packages/inter-protocol/test/auction/README-bidding-cli.md
+++ b/packages/inter-protocol/test/auction/README-bidding-cli.md
@@ -46,10 +46,10 @@ SKIP_DOWNLOAD=false ./bin/agd build
 
 ### Locating the `agd` command
 
-`agd` follows `go` conventions, so be sure `~/go/bin` is in your `$PATH`:
+To ensure `agd` is in your `$PATH`:
 
 ```sh
-export PATH=~/go/bin:$PATH
+export PATH=$PWD/bin:$PATH
 ```
 
 Then try `agd version` to confirm.

--- a/repoconfig.sh
+++ b/repoconfig.sh
@@ -1,14 +1,15 @@
 #! /bin/sh
 # shellcheck disable=SC2034
 NODEJS_VERSION=v16
-GOLANG_VERSION=1.20
+GOLANG_VERSION=1.20.3
 GOLANG_DIR=golang/cosmos
 GOLANG_DAEMON=$GOLANG_DIR/build/agd
 
 # Args are major, minor and patch version numbers
 function golang_version_check() {
-  # Want 1.20.2+, 1.21+, or 2+
-  [ $1 -eq 1 ] && [ $2 -lt 20 ] && echo "need go version 1.20 or higher" 1>&2 && return 1
-  [ $1 -eq 1 ] && [ $2 -eq 20 ] && [ $3 -lt 2 ] && echo "need go version 1.20.2 or higher" 1>&2 && return 1
-  return 0
+  [ $1 -eq 1 ] && [ $2 -eq 20 ] && [ $3 -ge 2 ] && return 0
+  [ $1 -eq 1 ] && [ $2 -ge 21 ] && return 0
+  [ $1 -ge 2 ] && return 0
+  echo "need go version 1.20.2+, 1.21+, or 2+"
+  return 1
 }


### PR DESCRIPTION
closes: #7755

## Description

 - parse go version 20
 - find agd in `agoric-sdk/bin` rather than `~/go/bin`

### Security / Scaling Considerations

none

### Documentation / Testing Considerations

this is a fix to the bidding test tool and its docs
