### PR TITLE
handle floating promises in /inter-protocol and /vats

### DIFF
--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -383,7 +383,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
             priceBook.add(seat, price, stillWant, exitAfterBuy);
           }
 
-          helper.publishBookData();
+          void helper.publishBookData();
         },
 
         /**
@@ -437,7 +437,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
             scaledBidBook.add(seat, bidScaling, stillWant, exitAfterBuy);
           }
 
-          helper.publishBookData();
+          void helper.publishBookData();
         },
         publishBookData() {
           const { state } = this;
@@ -457,7 +457,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
             collateralAvailable,
             currentPriceLevel: state.curAuctionPrice,
           });
-          state.bookDataKit.recorder.write(bookData);
+          return state.bookDataKit.recorder.write(bookData);
         },
       },
       self: {
@@ -534,7 +534,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
           state.startCollateral = state.startCollateral
             ? AmountMath.add(state.startCollateral, assetAmount)
             : assetAmount;
-          facets.helper.publishBookData();
+          void facets.helper.publishBookData();
         },
         /** @type {(reduction: Ratio) => void} */
         settleAtNewRate(reduction) {
@@ -601,7 +601,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
             }
           }
 
-          facets.helper.publishBookData();
+          void facets.helper.publishBookData();
         },
         getCurrentPrice() {
           return this.state.curAuctionPrice;
@@ -615,7 +615,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
 
           trace(`locking `, state.updatingOracleQuote);
           state.lockedPriceForRound = state.updatingOracleQuote;
-          facets.helper.publishBookData();
+          void facets.helper.publishBookData();
         },
 
         setStartingRate(rate) {
@@ -689,7 +689,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
           state.curAuctionPrice = null;
           state.remainingProceedsGoal = null;
           state.startProceedsGoal = null;
-          facets.helper.publishBookData();
+          void facets.helper.publishBookData();
         },
         getDataUpdates() {
           return this.state.bookDataKit.subscriber;
@@ -738,7 +738,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
             });
           },
         );
-        facets.helper.publishBookData();
+        void facets.helper.publishBookData();
       },
       stateShape: AuctionBookStateShape,
     },

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -128,7 +128,7 @@ export const makeScheduler = async (
         now,
       ),
     });
-    scheduleRecorder.write(sched);
+    return scheduleRecorder.write(sched);
   };
 
   /**
@@ -202,7 +202,7 @@ export const makeScheduler = async (
         Fail`invalid case`;
     }
 
-    publishSchedule();
+    void publishSchedule();
   };
 
   // schedule the wakeups for the steps of this round
@@ -246,7 +246,7 @@ export const makeScheduler = async (
         },
       }),
     );
-    publishSchedule();
+    void publishSchedule();
   };
 
   // schedule a wakeup to lock prices
@@ -333,7 +333,7 @@ export const makeScheduler = async (
 
   // when auction parameters change, schedule a next auction if one isn't
   // already scheduled
-  observeIteration(
+  void observeIteration(
     subscribeEach(paramUpdateSubscription),
     harden({
       async updateState(_newState) {

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -133,8 +133,9 @@ export const makeScheduler = async (
 
   /**
    * @param {Schedule | null} schedule
+   * @returns {Promise<void>}
    */
-  const clockTick = schedule => {
+  const clockTick = async schedule => {
     trace('clockTick', schedule?.startTime, now);
     if (!schedule) {
       return;
@@ -161,7 +162,7 @@ export const makeScheduler = async (
       return E(timer).cancel(stepCancelToken);
     };
 
-    const advanceRound = () => {
+    const advanceRound = async () => {
       if (auctionState === AuctionState.ACTIVE) {
         auctionDriver.reducePriceAndTrade();
       } else {
@@ -176,7 +177,7 @@ export const makeScheduler = async (
               'Unable to start auction cleanly. skipping this auction round.',
             ),
           );
-          finishAuctionRound();
+          await finishAuctionRound();
 
           return false;
         }
@@ -188,15 +189,15 @@ export const makeScheduler = async (
       case 'before':
         break;
       case 'during':
-        advanceRound();
+        await advanceRound();
         break;
       case 'endExactly':
-        if (advanceRound()) {
-          finishAuctionRound();
+        if (await advanceRound()) {
+          await finishAuctionRound();
         }
         break;
       case 'after':
-        finishAuctionRound();
+        await finishAuctionRound();
         break;
       default:
         Fail`invalid case`;
@@ -226,7 +227,7 @@ export const makeScheduler = async (
         wake(time) {
           setTimeMonotonically(time);
           trace('wake step', now);
-          clockTick(liveSchedule);
+          void clockTick(liveSchedule);
         },
       }),
       stepCancelToken,

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -161,10 +161,11 @@ export const createPriceFeed = async (
     installation: priceAggregator,
   });
 
-  E(E(agoricNamesAdmin).lookupAdmin('instance')).update(
-    AGORIC_INSTANCE_NAME,
-    faKit.instance,
-  );
+  E(E(agoricNamesAdmin).lookupAdmin('instance'))
+    .update(AGORIC_INSTANCE_NAME, faKit.instance)
+    .catch(err =>
+      console.error(`🚨 failed to update ${AGORIC_INSTANCE_NAME}`, err),
+    );
 
   E(E.get(econCharterKit).creatorFacet).addInstance(
     faKit.instance,

--- a/packages/inter-protocol/src/reserve/assetReserveKit.js
+++ b/packages/inter-protocol/src/reserve/assetReserveKit.js
@@ -134,7 +134,7 @@ export const prepareAssetReserveKit = async (
             totalFeeMinted: state.totalFeeMinted,
             totalFeeBurned: state.totalFeeBurned,
           });
-          state.metricsKit.recorder.write(metrics);
+          void state.metricsKit.recorder.write(metrics);
         },
       },
       governedApis: {

--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -49,7 +49,7 @@ const scheduleLiquidationWakeups = async (
   ]);
 
   // make one observer that will usually ignore the update.
-  observeIteration(
+  void observeIteration(
     subscribeEach(E(auctioneerPublicFacet).getSubscription()),
     harden({
       async updateState(_newState) {
@@ -63,7 +63,7 @@ const scheduleLiquidationWakeups = async (
 
   const waitForNewAuctionParams = () => {
     if (cancelToken) {
-      E(timer).cancel(cancelToken);
+      void E(timer).cancel(cancelToken);
     }
     cancelToken = undefined;
   };
@@ -96,7 +96,7 @@ const scheduleLiquidationWakeups = async (
   if (TimeMath.compareAbs(now, nominalStart) > 0) {
     if (TimeMath.compareAbs(now, endTime) < 0) {
       if (cancelToken) {
-        E(timer).cancel(cancelToken);
+        void E(timer).cancel(cancelToken);
       }
 
       void E(timer).setWakeup(afterStart, reschedulerWaker);

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -540,7 +540,12 @@ export const prepareVaultDirector = (
         async start() {
           const { helper } = this.facets;
           await helper.rescheduleLiquidationWakeups();
-          await updateShortfallReporter();
+          updateShortfallReporter().catch(err =>
+            console.error(
+              '🛠️ updateShortfallReporter failed during start(); repair by updating governance',
+              err,
+            ),
+          );
         },
       },
     },
@@ -550,19 +555,15 @@ export const prepareVaultDirector = (
 harden(prepareVaultDirector);
 
 /**
- * Prepare the VaultDirector kind, get or make the singleton, and call .start() to kick off processes.
+ * Prepare the VaultDirector kind, get or make the singleton
  *
  * @type {(...pvdArgs: Parameters<typeof prepareVaultDirector>) => ReturnType<ReturnType<typeof prepareVaultDirector>>}
  */
-export const provideAndStartDirector = (...args) => {
+export const provideDirector = (...args) => {
   const makeVaultDirector = prepareVaultDirector(...args);
 
   const [baggage] = args;
 
-  const director = provide(baggage, 'director', makeVaultDirector);
-  director.helper
-    .start()
-    .catch(err => console.error('🚨 vaultDirector failed to start:', err));
-  return director;
+  return provide(baggage, 'director', makeVaultDirector);
 };
-harden(provideAndStartDirector);
+harden(provideDirector);

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -539,7 +539,7 @@ export const prepareVaultDirector = (
          */
         async start() {
           const { helper } = this.facets;
-          helper.rescheduleLiquidationWakeups();
+          await helper.rescheduleLiquidationWakeups();
           await updateShortfallReporter();
         },
       },

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -29,7 +29,7 @@ import { E } from '@endo/eventual-send';
 import { FeeMintAccessShape } from '@agoric/zoe/src/typeGuards.js';
 import { InvitationShape } from '../auction/params.js';
 import { SHORTFALL_INVITATION_KEY, vaultDirectorParamTypes } from './params.js';
-import { provideAndStartDirector } from './vaultDirector.js';
+import { provideDirector } from './vaultDirector.js';
 
 const trace = makeTracer('VF', false);
 
@@ -116,7 +116,7 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     vaultDirectorParamTypes,
   );
 
-  const director = provideAndStartDirector(
+  const director = provideDirector(
     baggage,
     zcf,
     vaultDirectorParamManager,
@@ -129,6 +129,12 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     makeRecorderKit,
     makeERecorderKit,
   );
+
+  // cannot await because it would make remote calls during vat restart
+  director.helper.start().catch(err => {
+    console.error('💀 vaultDirector failed to start:', err);
+    zcf.shutdownWithFailure(err);
+  });
 
   // validate async to wait for params to be finished
   // UNTIL https://github.com/Agoric/agoric-sdk/issues/4343

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -990,6 +990,7 @@ export const prepareVaultManagerKit = (
          * @param {VaultId} vaultId
          * @param {import('./vault.js').VaultPhase} vaultPhase at the end of whatever change updated balances
          * @param {Vault} vault
+         * @returns {void}
          */
         handleBalanceChange(
           oldDebtNormalized,
@@ -1061,7 +1062,7 @@ export const prepareVaultManagerKit = (
               oldCollateral,
             );
             // debt accounting managed through minting and burning
-            facets.helper.updateMetrics();
+            void facets.helper.updateMetrics();
           }
         },
       },
@@ -1228,7 +1229,7 @@ export const prepareVaultManagerKit = (
           );
 
           helper.markLiquidating(totalDebt, totalCollateral);
-          helper.updateMetrics();
+          void helper.updateMetrics();
 
           const { userSeatPromise, deposited } = await E.when(
             E(auctionPF).makeDepositInvitation(),
@@ -1254,7 +1255,7 @@ export const prepareVaultManagerKit = (
           );
 
           trace(`LiqV after long wait`, proceeds);
-          helper.distributeProceeds(
+          return helper.distributeProceeds(
             proceeds,
             totalDebt,
             storedCollateralQuote,
@@ -1280,7 +1281,7 @@ export const prepareVaultManagerKit = (
         );
 
         // push initial state of metrics
-        helper.updateMetrics();
+        void helper.updateMetrics();
       },
     },
   );

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -567,9 +567,17 @@ export const prepareVaultManagerKit = (
           );
           state.totalDebt = AmountMath.subtract(state.totalDebt, shortfall);
 
-          void E.when(factoryPowers.getShortfallReporter(), reporter =>
-            E(reporter).increaseLiquidationShortfall(shortfall),
-          );
+          E.when(
+            factoryPowers.getShortfallReporter(),
+            reporter => E(reporter).increaseLiquidationShortfall(shortfall),
+            err =>
+              console.error(
+                '🛠️ getShortfallReporter() failed during liquidation; repair by updating governance',
+                err,
+              ),
+          ).catch(err => {
+            console.error('🚨 failed to report liquidation shortfall', err);
+          });
         },
         /**
          * If interest was charged between liquidating and liquidated, erase it.

--- a/packages/inter-protocol/test/auction/test-auctionContract.js
+++ b/packages/inter-protocol/test/auction/test-auctionContract.js
@@ -245,7 +245,7 @@ const makeAuctionDriver = async (t, params = defaultParams) => {
       initialPrice: makeRatio(100n, bid.brand, 100n, collateralBrand),
     });
     priceAuthorities.init(collateralBrand, pa);
-    registry.registerPriceAuthority(pa, collateralBrand, bid.brand, true);
+    await registry.registerPriceAuthority(pa, collateralBrand, bid.brand, true);
 
     await E(creatorFacet).addBrand(
       issuerKit.issuer,
@@ -1015,8 +1015,8 @@ test.serial('onDeadline exit, with chainStorage RPC snapshot', async t => {
   await assertPayouts(t, liqSeat, bid, collateral, 116n, 0n);
 
   await driver.advanceTo(186n, 'wait');
-  scheduleTracker.assertNoUpdate();
-  bookTracker.assertNoUpdate();
+  await scheduleTracker.assertNoUpdate();
+  await bookTracker.assertNoUpdate();
 
   await driver.advanceTo(210n, 'wait');
   await scheduleTracker.assertChange({

--- a/packages/inter-protocol/test/auction/test-scheduler.js
+++ b/packages/inter-protocol/test/auction/test-scheduler.js
@@ -791,7 +791,7 @@ test('change Schedule', async t => {
 
   const newFreq = 100n;
   const newStep = 40n;
-  paramManager.updateParams({
+  await paramManager.updateParams({
     StartFrequency: TimeMath.coerceRelativeTimeRecord(newFreq, timerBrand),
     ClockStep: TimeMath.coerceRelativeTimeRecord(newStep, timerBrand),
   });

--- a/packages/inter-protocol/test/auction/test-scheduler.js
+++ b/packages/inter-protocol/test/auction/test-scheduler.js
@@ -224,12 +224,11 @@ test('schedule start to finish', async t => {
   t.true(fakeAuctioneer.getState().lockedPrices);
 
   // final step
-  now = await timer.advanceTo(now + 1n);
-  now = await timer.advanceTo(now + 1n);
+  now = await timer.advanceTo(now + 2n);
 
   t.is(fakeAuctioneer.getState().step, 6);
-  t.true(fakeAuctioneer.getState().final);
-  t.false(fakeAuctioneer.getState().lockedPrices);
+  t.false(fakeAuctioneer.getState().final);
+  t.true(fakeAuctioneer.getState().lockedPrices);
 
   // Auction finished, nothing else happens
   now = await timer.advanceTo(now + 1n);
@@ -1080,15 +1079,9 @@ test('schedule anomalies', async t => {
   const veryLateStart = baseTime + 5n * oneCycle;
   await timer.advanceTo(veryLateStart);
 
-  // This schedule is published as a side effect of closing out the incomplete
-  // auction. The next one follows immediately and is correct.
-  await scheduleTracker.assertChange({
-    activeStartTime: null,
-    nextDescendingStepTime: { absValue: 1700017230n },
-  });
   const veryLateActual = veryLateStart + oneCycle + delay;
   await scheduleTracker.assertChange({
-    activeStartTime: timestamp(veryLateActual),
+    activeStartTime: { absValue: veryLateActual },
     nextDescendingStepTime: { absValue: veryLateActual },
     nextStartTime: { absValue: veryLateActual + oneCycle },
   });

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -298,7 +298,7 @@ test.serial('errors', async t => {
 
   // TODO move to smart-wallet package when it has sufficient test supports
   acceptInvitationCounter -= 1; // try again with same id
-  t.throwsAsync(acceptInvitation(wallet, priceAggregator), {
+  await t.throwsAsync(acceptInvitation(wallet, priceAggregator), {
     message: `cannot re-use offer id "acceptInvitation${acceptInvitationCounter}"`,
   });
 

--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1226,7 +1226,7 @@ test('overdeposit', async t => {
     E(vaultFactory).makeCollectFeesInvitation(),
   );
   await E(collectFeesSeat).getOfferResult();
-  assertAmountsEqual(
+  await assertAmountsEqual(
     t,
     await E.get(E(collectFeesSeat).getFinalAllocation()).Fee,
     run.make(300n),

--- a/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -80,7 +80,7 @@ export async function start(zcf, privateArgs, baggage) {
     stableBrand,
   );
   let storedCollateralQuote;
-  observeNotifier(quoteNotifier, {
+  void observeNotifier(quoteNotifier, {
     updateState(value) {
       storedCollateralQuote = value;
     },

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -489,7 +489,8 @@ export const makeAddressNameHubs = async ({
 
   const perAddress = address => {
     const { nameHub, myAddressNameAdmin } = makeMyAddressNameAdminKit(address);
-    myAddressNameAdmin.reserve(WalletName.depositFacet);
+    // This may not finish before another reserve() call, but this one will win
+    void myAddressNameAdmin.reserve(WalletName.depositFacet);
 
     // This may race against walletFactory.js/publishDepositFacet, so we are
     // careful not to clobber the first nameHub that is used to update

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -305,7 +305,8 @@ export const makeMyAddressNameAdminKit = address => {
     getMyAddress: () => address,
   });
   // reserve space for deposit facet
-  myAddressNameAdmin.reserve(WalletName.depositFacet);
+  // This may not finish before another reserve() call, but this one will win
+  void myAddressNameAdmin.reserve(WalletName.depositFacet);
 
   return { nameHub, myAddressNameAdmin };
 };

--- a/packages/vats/src/virtual-purse.js
+++ b/packages/vats/src/virtual-purse.js
@@ -162,7 +162,7 @@ const prepareVirtualPurseKit = zone =>
       minter: {
         /** @type {Retain} */
         async retain(payment, optAmountShape) {
-          this.state.mint || Fail`minter cannot retain without a mint.`;
+          !!this.state.mint || Fail`minter cannot retain without a mint.`;
           return E(this.state.issuer).burn(payment, optAmountShape);
         },
         /** @type {Redeem} */

--- a/packages/vats/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-integration.js
@@ -67,7 +67,7 @@ test.before(async t => {
   t.context = await makeDefaultTestContext(t);
 });
 test.after.always(t => {
-  t.context.shutdown && t.context.shutdown();
+  return t.context.shutdown && t.context.shutdown();
 });
 
 test('metrics path', async t => {

--- a/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
@@ -398,8 +398,8 @@ test.serial('force liquidation', async t => {
     t.context.shared;
 
   // advance a year to drive interest charges
-  advanceTime(365, 'days');
-  t.is(readRewardPoolBalance(), 340000n);
+  await advanceTime(365, 'days');
+  t.is(readRewardPoolBalance(), 683693581n);
   t.like(readCollateralMetrics(0), {
     totalDebt: { value: 68340000n },
   });

--- a/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
@@ -392,35 +392,43 @@ test.serial('adjust balance of vault opened before restart', async t => {
   });
 });
 
-// charge interest to force a liquidation and verify the shortfall is transferred
+// charge interest to force a liquidation and verify it starts
 test.serial('force liquidation', async t => {
   const { advanceTime, readCollateralMetrics, readRewardPoolBalance } =
     t.context.shared;
 
   // advance a year to drive interest charges
   await advanceTime(365, 'days');
+  // accrues massively
   t.is(readRewardPoolBalance(), 683693581n);
   t.like(readCollateralMetrics(0), {
+    numActiveVaults: 2,
     totalDebt: { value: 68340000n },
   });
 
   // liquidation will have been skipped because time skipped ahead
   // so now advance slowly
   await advanceTime(1, 'hours');
-  await advanceTime(1, 'hours');
-  // wait for it...
   t.like(readCollateralMetrics(0), {
-    liquidatingCollateral: { value: 0n },
-    liquidatingDebt: { value: 0n },
+    numActiveVaults: 2,
     numLiquidatingVaults: 0,
   });
-
-  // POW
   await advanceTime(1, 'hours');
   t.like(readCollateralMetrics(0), {
-    liquidatingCollateral: { value: 9000000n },
-    liquidatingDebt: { value: 696421994n },
+    liquidatingCollateral: { value: 9_000_000n },
+    liquidatingDebt: { value: 696_421_994n },
+    numActiveVaults: 1,
     numLiquidatingVaults: 1,
+  });
+
+  // after this the liquidation aborts due to the shortfall reporter being broken after upgrade.
+  // it has to be repaired by governance until https://github.com/Agoric/agoric-sdk/issues/5200
+  await advanceTime(1, 'hours');
+  t.like(readCollateralMetrics(0), {
+    numActiveVaults: 2,
+    numLiquidatingVaults: 0,
+    numLiquidationsAborted: 1,
+    numLiquidationsCompleted: 0,
   });
 });
 

--- a/packages/vats/test/test-name-hub.js
+++ b/packages/vats/test/test-name-hub.js
@@ -67,7 +67,7 @@ test('makeNameHubKit - reserve and update', async t => {
   t.deepEqual(nameHub.entries(), []);
 
   // Try reserving and looking up.
-  nameAdmin.reserve('hello');
+  await nameAdmin.reserve('hello');
 
   let lookedUpHello = false;
   const lookupHelloP = nameHub
@@ -104,7 +104,7 @@ test('makeNameHubKit - reserve and delete', async t => {
   t.deepEqual(nameHub.values(), []);
   t.deepEqual(nameHub.entries(), []);
 
-  nameAdmin.reserve('goodbye');
+  await nameAdmin.reserve('goodbye');
   let lookedUpGoodbye = false;
   const lookupGoodbyeP = nameHub
     .lookup('bar')


### PR DESCRIPTION
refs: #6000

## Description

Because we don't have the floating promise lint in CI, they creep back. The last time inter-protocol was cleared:
- https://github.com/Agoric/agoric-sdk/pull/6803

This clears them again. To do so it reworks a few promise handling flows. Those are in separate commits from the mechanical ones.

This is stacked upon https://github.com/Agoric/agoric-sdk/pull/7752 because that changes shortfall reporting in a way that was relevant to the test changes here.

This ~has~ omits changes that are related to auction fixes:
- https://github.com/Agoric/agoric-sdk/pull/7748

### Security Considerations

n/a
### Scaling Considerations

n/a
### Documentation Considerations

n/a

### Testing Considerations

Revised tests. The vaults-upgrade bootstrapTest had to shrink in scope.