### PR TITLE
fix: invalidate docker cache for GIT_REVISION too

### DIFF
--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -9,7 +9,8 @@ RUN go mod download
 COPY golang/cosmos ./
 
 ARG GIT_COMMIT
-RUN make GIT_COMMIT="$GIT_COMMIT" MOD_READONLY= compile-go
+ARG GIT_REVISION
+RUN make GIT_COMMIT="$GIT_COMMIT" GIT_REVISION="$GIT_REVISION" MOD_READONLY= compile-go
 
 ###############################
 # OTEL fetch


### PR DESCRIPTION
## Description

fixes the situation where `make local_sdk` fails with...

```
Step 41/44 : RUN /usr/src/agoric-sdk/packages/deployment/scripts/smoketest-binaries.sh
 ---> Running in cc90f365d145
Checking agd version a
At least golang/cosmos/app/app.go is newer than golang/cosmos/build/agd
Command: agd version failed with code 127
```

### Security / Scaling  / Documentation Considerations

n/a

### Testing Considerations

makes testing more robust