### PR TITLE
upgrade-test: Don't set DEST when building 

### DIFF
--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -60,7 +60,6 @@ ARG DEST_IMAGE
 FROM ${DEST_IMAGE} as agoric-upgrade-10
 ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-10 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
-ENV DEST=1
 
 WORKDIR /usr/src/agoric-sdk/
 COPY ./*.sh ./upgrade-test-scripts/
@@ -76,7 +75,6 @@ FROM ${DEST_IMAGE} as agoric-upgrade-11
 ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-11 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 # this boot doesn't need an upgrade
-ENV DEST=1
 
 WORKDIR /usr/src/agoric-sdk/
 COPY ./*.sh ./upgrade-test-scripts/


### PR DESCRIPTION
## Description

`DEST` has changed recently to not just control whether we upgrade, but also whether we're running an interactive session, as `DEST=1` will setup a bash environment. However, when we build using `DEST=1`, since we also don't use tmux we skip running tests and actions when building, which results in the file indicating we ran actions not being touched.

As a result, when we shell in, it will also run actions and tests with tmux and any failure will cause the `agd` stdout window to exit and disappear, as well as halting the chain.

### Security Considerations

We are not running test on later, which means if we don't resolve some undetected issues could be introduced that may have security implications.

### Scaling Considerations

N/A.

### Documentation Considerations

N/A, internal. This change better reflects our documented steps.

### Testing Considerations

No changes, this actually makes it work as we expect.
