### PR TITLE
fix(vaults): Publish after collateral is returned

### DIFF
--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -1864,9 +1864,17 @@ test('reinstate vault', async t => {
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.is(aliceUpdate.value.vaultState, Phase.LIQUIDATED);
+  t.deepEqual(aliceUpdate.value.locked, aeth.make(0n));
 
+  // Reduce Bob's collateral by liquidation penalty
+  const recoveredBobCollateral = AmountMath.subtract(
+    bobCollateralAmount,
+    aeth.make(4n),
+  );
   bobUpdate = await E(bobNotifier).getUpdateSince();
   t.is(bobUpdate.value.vaultState, Phase.ACTIVE);
+  t.deepEqual(bobUpdate.value.locked, recoveredBobCollateral);
+  t.deepEqual(bobUpdate.value.debtSnapshot.debt, bobRunDebtLevel);
 
   await assertBidderPayout(t, bidderSeat, run, 66n, aeth, 8n);
 


### PR DESCRIPTION
closes: #7665

## Description
The reallocate of collateral happened after looping through the restored vaults to signal that they were completed or restored.

- collect the vaults to be liquidated and do it at the end
- collect the vaults to be reinstated, and do it after reallocate
- add test for the reinstate case for correct balance
