### PR TITLE
ci: npm pack on each PR

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -38,6 +38,21 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
   ##################
+  # NPM pack tests
+  # Check that all the packages can be packed to publish
+  npm-pack:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/restore-node
+        with:
+          node-version: '18.x'
+
+      - name: npm pack
+        run: yarn lerna exec yarn pack
+
+  ##################
   # Lint tests
   # We run per package bc of https://github.com/typescript-eslint/typescript-eslint/issues/1192
   # We split the package tests into two jobs because type linting


### PR DESCRIPTION
## Description

In a master branch CI job we run `dev-canary` to publish to NPM. It's not a required job (publishing can be flaky) so [sometimes it ends up broken](https://github.com/Agoric/agoric-sdk/actions/runs/4951922294/jobs/8857630701).

That can allow regressions like the one https://github.com/Agoric/agoric-sdk/pull/7667 fixes.

This PR does the `npm pack` step on each PR to prevent such a regression.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

Verified it fails CI when an npm pack fails: [Details](https://github.com/Agoric/agoric-sdk/actions/runs/5005975595/jobs/8970755692)

Passed after rebasing with https://github.com/Agoric/agoric-sdk/pull/7667 in master