### PR TITLE
test(upgrade-test): add a `user1` unrevived wallet

### DIFF
--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
@@ -18,7 +18,7 @@ test_not_val "$(agd q vstorage data published.wallet.$GOV3ADDR -o json | jq -r .
 test_val "$(agd q vstorage data published.vaultFactory.manager0.vaults.vault0 -o json | jq -r .value)" "" "ensure no vaults exist"
 
 # provision pool has right balance
-test_val "$(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ')" "19250000"
+test_val "$(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ')" "19000000"
 
 # we should have more denoms in governance
 psmISTChildren="$(agd q vstorage children published.psm.IST -o jsonlines)"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
@@ -3,8 +3,12 @@
 . ./upgrade-test-scripts/env_setup.sh
 
 # provision pool has right balance 
-test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ') "19250000"
+test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ') "19000000"
 
+test_wallet_state "$USER1ADDR" upgraded "user1 wallet is upgraded"
+test_wallet_state "$GOV1ADDR" revived "gov1 wallet is revived"
+test_wallet_state "$GOV2ADDR" revived "gov2 wallet is revived"
+test_wallet_state "$GOV3ADDR" revived "gov3 wallet is revived"
 
 if [[ "$BOOTSTRAP_MODE" == "test" ]]; then
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
@@ -14,16 +14,24 @@ waitForBlock 3
 govaccounts=( "$GOV1ADDR" "$GOV2ADDR" "$GOV3ADDR" )
 govamount="200000000ubld,100000000${USDC_DENOM},100000000${ATOM_DENOM}"
 
-for i in "${govaccounts[@]}"
-do
+provisionSmartWallet() {
+  i="$1"
+  amount="$2"
   echo "funding $i"
-  agd tx bank send "validator" "$i" "$govamount" -y --keyring-backend=test --chain-id="$CHAINID"
+  agd tx bank send "validator" "$i" "$amount" -y --keyring-backend=test --chain-id="$CHAINID"
   waitForBlock
   echo "provisioning $i"
   agd tx swingset provision-one my-wallet "$i" SMART_WALLET --keyring-backend=test  --yes --chain-id="$CHAINID" --from="$i"
   waitForBlock
   agoric wallet show --from $i
+}
+
+for i in "${govaccounts[@]}"
+do
+  provisionSmartWallet "$i" "$govamount"
 done
+
+provisionSmartWallet "$USER1ADDR" "20000000ubld"
 
 waitForBlock 5
 # Accept invitation to economic committee

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . ./upgrade-test-scripts/env_setup.sh
 # provision pool has right balance 
-test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount') "19250000"
+test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount') "19000000"
 
 # ensure PSM IST has only ToyUSD
 expnum=4
@@ -13,3 +13,8 @@ test_val $(agd q vstorage children published.psm.IST -o json | jq -r '.children 
 
 # Gov params
 test_not_val "$(timeout 3 agoric follow -l :published.psm.${PSM_PAIR}.governance -o jsonlines | jq -r '.current.MintLimit.value.value')" "0" "PSM MintLimit non-zero"
+
+test_wallet_state "$USER1ADDR" old "user1 wallet is old"
+test_wallet_state "$GOV1ADDR" old "gov1 wallet is old"
+test_wallet_state "$GOV2ADDR" old "gov2 wallet is old"
+test_wallet_state "$GOV3ADDR" old "gov3 wallet is old"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/env_setup.sh
@@ -145,6 +145,20 @@ test_not_val() {
   fi
 }
 
+test_wallet_state() {
+  addr=$1
+  want=$2
+  desc=$3
+  body="$(timeout 3 agoric follow -l ":published.wallet.$addr" -o text | jq -r '.body')"
+  case $body in
+  *'"@qclass":'*) state=old ;;
+  '#{}') state=upgraded ;;
+  '#'*) state=revived ;;
+  *) state=$body ;;
+  esac
+  test_val "$state" "$want" "$desc"
+}
+
 voteLatestProposalAndWait() {
   waitForBlock
   proposal=$($binary q gov proposals -o json | jq -r '.proposals[-1].proposal_id')

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/env_setup.sh
@@ -21,6 +21,7 @@ export GOV1ADDR=$($binary keys show gov1 -a --keyring-backend="test")
 export GOV2ADDR=$($binary keys show gov2 -a --keyring-backend="test")
 export GOV3ADDR=$($binary keys show gov3 -a --keyring-backend="test")
 export VALIDATORADDR=$($binary keys show validator -a --keyring-backend="test")
+export USER1ADDR=$($binary keys show user1 -a --keyring-backend="test")
 
 if [[ "$binary" == "agd" ]]; then
 # Support testnet addresses
@@ -178,6 +179,8 @@ printKeys() {
   cat ~/.agoric/gov3.key || true
   echo "validator: $VALIDATORADDR"
   cat ~/.agoric/validator.key || true
+  echo "user1: $USER1ADDR"
+  cat ~/.agoric/user1.key || true
   echo "========== GOVERNANCE KEYS =========="
 }
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/start_ag0.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/start_ag0.sh
@@ -3,8 +3,8 @@
 export CHAINID=agoriclocal
 ag0 init localnet --chain-id "$CHAINID"
 
-govaccounts=( "gov1" "gov2" "gov3" "validator" )
-for i in "${govaccounts[@]}"
+allaccounts=( "gov1" "gov2" "gov3" "user1" "validator" )
+for i in "${allaccounts[@]}"
 do
   ag0 keys add $i --keyring-backend=test  2>&1 | tee "$HOME/.agoric/$i.out"
   cat "$HOME/.agoric/$i.out" | tail -n1 | tee "$HOME/.agoric/$i.key"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: Agoric/wallet-app#76, Agoric/wallet-app#77

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
When running `cd packages/deployment/upgrade-test && TARGET=agoric-upgrade-10 make build_test run` this PR now adds a `user1` Cosmos key.  That key is provisioned with a smart wallet before `agoric-upgrade-10`, but nothing touches it to simulate the vstorage state of an upgraded wallet.

This `user1` key will also be useful for testers to try a completely unprivileged wallet address.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Now wallet states are explicitly tested during `agoric-upgrade-9` and `agoric-upgrade-10`.
