### PR TITLE
fix(auction): recovering from late start

### DIFF
--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -133,9 +133,9 @@ export const makeScheduler = async (
 
   /**
    * @param {Schedule | null} schedule
-   * @returns {Promise<void>}
+   * @returns {void}
    */
-  const clockTick = async schedule => {
+  const clockTick = schedule => {
     trace('clockTick', schedule?.startTime, now);
     if (!schedule) {
       return;
@@ -200,7 +200,7 @@ export const makeScheduler = async (
         finishAuctionRound();
         break;
       case 'after':
-        await finishAuctionRound();
+        finishAuctionRound();
         break;
       default:
         Fail`invalid case`;

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -184,12 +184,8 @@ export const makeScheduler = async (
               'Unable to start auction cleanly. skipping this auction round.',
             ),
           );
-          finishAuctionRound();
-
-          return false;
         }
       }
-      return true;
     };
 
     switch (timeVsSchedule(now, schedule)) {
@@ -199,9 +195,9 @@ export const makeScheduler = async (
         advanceRound();
         break;
       case 'endExactly':
-        if (advanceRound()) {
-          finishAuctionRound();
-        }
+        // do both the "during" and "after" behaviors
+        advanceRound();
+        finishAuctionRound();
         break;
       case 'after':
         await finishAuctionRound();

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -359,8 +359,9 @@ export const makeScheduler = async (
     subscribeEach(paramUpdateSubscription),
     harden({
       async updateState(_newState) {
-        trace('received param update');
+        trace('received param update', _newState);
         if (!nextSchedule) {
+          trace('repairing nextSchedule and restarting');
           ({ nextSchedule } = await initializeNextSchedule());
           startSchedulingFromScratch();
         }

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -178,11 +178,10 @@ export const makeScheduler = async (
           auctionDriver.startRound();
           // This has been observed to fail because prices hadn't been locked.
           // This may be an issue about timing during chain start-up.
-        } catch (e) {
+        } catch (err) {
           console.error(
-            assert.error(
-              'Unable to start auction cleanly. skipping this auction round.',
-            ),
+            'Unable to start auction cleanly. skipping this auction round.',
+            err,
           );
         }
       }
@@ -350,10 +349,12 @@ export const makeScheduler = async (
   startSchedulingFromScratch();
 
   // when auction parameters change, schedule a next auction if one isn't
-  // already scheduled
+  // already scheduled.
+  // NB: what is already scheduled (live or next) is unaffected by param changes
   void observeIteration(
     subscribeEach(paramUpdateSubscription),
     harden({
+      // NB: may be fired with the initial params as well
       async updateState(_newState) {
         trace('received param update', _newState);
         if (!nextSchedule) {

--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -101,16 +101,16 @@ const setWakeups = ({
     cancelWakeups(timer);
 
     if (TimeMath.compareAbs(now, endTime) < 0) {
-      // endTime is in the future or now to reschedule waking (case 2)
+      trace('CASE 2: endTime is in the future or now so reschedule waking');
       void E(timer).setWakeup(afterStart, reschedulerWaker);
     } else {
-      // case 3
+      trace('CASE 3: endTime is past; wait for repair');
       waitForRepair();
     }
 
     return;
   }
-  // nominalStart is now or in the future (case 1)
+  trace('CASE 1: nominalStart is now or in the future');
 
   cancelToken = cancelToken || makeCancelToken();
   const priceLockWakeTime = TimeMath.subtractAbsRel(
@@ -151,7 +151,7 @@ const setWakeupsForNextAuction = async (
     E(timer).getCurrentTimestamp(),
   ]);
 
-  trace('SCHEDULE', nextAuctionSchedule);
+  trace('SCHEDULE', now.absValue, nextAuctionSchedule);
   if (!nextAuctionSchedule) {
     // There should always be a nextAuctionSchedule. If there isn't, give up for now.
     cancelWakeups(timer);

--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -89,7 +89,6 @@ const setWakeups = ({
 
   // nominal is the declared start time, but the actual auctioning begins after auctionStartDelay
   const nominalStart = TimeMath.subtractAbsRel(startTime, auctionStartDelay);
-  const afterStart = TimeMath.addAbsRel(startTime, 1n);
 
   // Is there a problem (case 2 or 3)?
   // setWakeupsForNextAuction is supposed to be called just after an auction
@@ -97,12 +96,18 @@ const setWakeups = ({
   // we'll proceed. Reschedule for the next round if that's still in the future.
   // Otherwise, wait for governance params to change.
   if (TimeMath.compareAbs(now, nominalStart) > 0) {
-    // nominalStart is past
+    // nominalStart is past, so cancel timers and plan to recover
     cancelWakeups(timer);
 
     if (TimeMath.compareAbs(now, endTime) < 0) {
-      trace('CASE 2: endTime is in the future or now so reschedule waking');
-      void E(timer).setWakeup(afterStart, reschedulerWaker);
+      // We're currently scheduling the N+1 (where N is live), but we need to skip it.
+      // So wake up for the N+2 round's startTime
+      const afterNextStartTime = TimeMath.addAbsRel(endTime, 1n);
+      trace(
+        'CASE 2: endTime is in the future or now so reschedule waking to startTime of the following round',
+        afterNextStartTime,
+      );
+      void E(timer).setWakeup(afterNextStartTime, reschedulerWaker);
     } else {
       trace('CASE 3: endTime is past; wait for repair');
       waitForRepair();
@@ -122,6 +127,7 @@ const setWakeups = ({
   void E(timer).setWakeup(priceLockWakeTime, priceLockWaker, cancelToken);
   void E(timer).setWakeup(nominalStart, liquidationWaker, cancelToken);
   // Call setWakeupsForNextAuction again one tick after nominalStart
+  const afterStart = TimeMath.addAbsRel(startTime, 1n);
   void E(timer).setWakeup(afterStart, reschedulerWaker, cancelToken);
 };
 

--- a/packages/inter-protocol/test/auction/test-scheduler.js
+++ b/packages/inter-protocol/test/auction/test-scheduler.js
@@ -1046,13 +1046,20 @@ test('schedule anomalies', async t => {
   };
   t.deepEqual(schedule4.nextAuctionSchedule, sixthSchedule);
 
+  await scheduleTracker.assertNoUpdate();
+
   // ////////////// JUMP PAST THE END OF NEXT AUCTION ///////////
   const veryLateStart = baseTime + 5n * oneCycle;
   await timer.advanceTo(veryLateStart);
 
+  await scheduleTracker.assertChange({
+    activeStartTime: null,
+    nextDescendingStepTime: { absValue: veryLateStart - oneCycle + delay },
+  });
+
   const veryLateActual = veryLateStart + oneCycle + delay;
   await scheduleTracker.assertChange({
-    activeStartTime: { absValue: veryLateActual },
+    activeStartTime: timestamp(veryLateActual),
     nextDescendingStepTime: { absValue: veryLateActual },
     nextStartTime: { absValue: veryLateActual + oneCycle },
   });

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -520,14 +520,21 @@ export const makeManagerDriver = async (
 export const makeAuctioneerDriver = async t => {
   const auctioneerKit = await t.context.consume.auctioneerKit;
 
+  // TODO source from context or config
+  const startFrequency = 3600n;
+
   return {
     auctioneerKit,
     advanceTimerByStartFrequency: async () => {
       trace('advanceTimerByStartFrequency');
-      // TODO source from context or config
-      const startFrequency = 3600n;
       // @ts-expect-error ManualTimer debt https://github.com/Agoric/agoric-sdk/issues/7747
       await t.context.timer.advanceBy(BigInt(startFrequency));
+      await eventLoopIteration();
+    },
+    induceTimequake: async () => {
+      trace('induceTimequake');
+      // @ts-expect-error ManualTimer debt https://github.com/Agoric/agoric-sdk/issues/7747
+      await t.context.timer.advanceBy(BigInt(startFrequency) * 10n);
       await eventLoopIteration();
     },
     assertSchedulesLike: async (liveAuctionPartial, nextAuctionPartial) => {


### PR DESCRIPTION
closes: #7775

## Description

Case 2 of auction recovery didn't have test coverage. In Docker testing it was hit. The bug is that it was meant to reschedule to the "startTime" of the _next_ nextAuctionSchedule. This does that and tries to make the logic and naming more clear.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

I tried to include an integration test but it will take longer than we have. I tested in the Docker test by trying to repro 7775 and it's not. I'll keep investigating but I think we should land this because it does fix a bug and it may unblock liquidation testing.