### PR TITLE
fix(smart-wallet): handle {} wallet update records in client utils

### DIFF
--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -1,9 +1,11 @@
 /* eslint-disable no-undef-init */
-import { deeplyFulfilledObject, objectMap } from '@agoric/internal';
+import { deeplyFulfilledObject, objectMap, makeTracer } from '@agoric/internal';
 import { observeIteration, subscribeEach } from '@agoric/notifier';
 import { E } from '@endo/far';
 
 export const NO_SMART_WALLET_ERROR = 'no smart wallet';
+
+const trace = makeTracer('WUTIL', false);
 
 /** @param {Brand<'set'>} [invitationBrand] */
 export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
@@ -31,7 +33,7 @@ export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
         // last record wins
         balances.set(currentAmount.brand, currentAmount);
         if (!invitationBrand) {
-          console.warn(
+          trace(
             'balance update without invitationBrand known may be an invitation',
           );
         }
@@ -62,14 +64,14 @@ export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
               acceptedIn: status.id,
             });
           } else {
-            console.error('no record of invitation in offerStatus', status);
+            trace('no record of invitation in offerStatus', status);
           }
         }
         break;
       }
       // @ts-expect-error backwards compatibile
       case 'brand': {
-        console.warn('obsolete brand update record - ignoring', updateRecord);
+        trace('obsolete brand update record - ignoring', updateRecord);
         break;
       }
       default:

--- a/packages/smart-wallet/src/utils.js
+++ b/packages/smart-wallet/src/utils.js
@@ -19,8 +19,11 @@ export const makeWalletStateCoalescer = (invitationBrand = undefined) => {
    */
   const invitationsReceived = new Map();
 
-  /** @param {import('./smartWallet').UpdateRecord} updateRecord newer than previous */
+  /** @param {import('./smartWallet').UpdateRecord | {}} updateRecord newer than previous */
   const update = updateRecord => {
+    if (!('updated' in updateRecord)) {
+      return;
+    }
     const { updated } = updateRecord;
     switch (updateRecord.updated) {
       case 'balance': {


### PR DESCRIPTION
closes: #7777

## Description

Handle the `{}` wallet update records introduced in #7763.

Also: suppress other diagnostics about wallet update records being not quite right. They're uninteresting in contexts such as `inter bid list`.

### Security Considerations

suppressing diagnostics could hide some problems. a `--verbose` flag could be a useful enhancement.

### Scaling Considerations

n/a

### Documentation Considerations

The possibility of a `{}` is documented in the return type of `makeWalletStateCoalescer`.

### Testing Considerations

ok to skip the unit test for this basically 1-line fix?
