### PR TITLE
feat(upgrade-test): allow passing tmux flags 

### DIFF
--- a/packages/deployment/upgrade-test/Makefile
+++ b/packages/deployment/upgrade-test/Makefile
@@ -4,6 +4,11 @@ ifdef TARGET
 buildTargetFlag = --target $(TARGET)
 dockerLabel = $(TARGET)
 endif
+ifdef TMUX_CC
+	tmuxCC=1
+else
+	tmuxCC=0
+endif
 @echo buildTargetFlag: $(buildTargetFlag)
 
 local_sdk:
@@ -18,5 +23,5 @@ build_test:
 	docker build --build-arg BOOTSTRAP_MODE=test --progress=plain $(buildTargetFlag) -t $(REPOSITORY):$(dockerLabel) -f Dockerfile upgrade-test-scripts
 
 run:
-	docker run --rm -it -e "DEST=1" -p 26656:26656 -p 26657:26657 -p 1317:1317 --entrypoint "/usr/src/agoric-sdk/upgrade-test-scripts/start_to_to.sh" -v "$${PWD}:/workspace" $(REPOSITORY):$(dockerLabel)
+	docker run --rm -it -e "DEST=1" -e "TMUX_USE_CC=$(tmuxCC)" -p 26656:26656 -p 26657:26657 -p 1317:1317 --entrypoint "/usr/src/agoric-sdk/upgrade-test-scripts/start_to_to.sh" -v "$${PWD}:/workspace" $(REPOSITORY):$(dockerLabel)
 

--- a/packages/deployment/upgrade-test/Readme.md
+++ b/packages/deployment/upgrade-test/Readme.md
@@ -26,6 +26,19 @@ make build
 make run
 ```
 
+This will start a container with tmux, with the first window `0` being chain logs `agd start` and the second and current window `1` being a bash shell. You can navigate using `bind-key+B N` (assuming `bind-key` is CTRL/CMD) and N is the window. For more shortcuts see [tmux shortcuts & cheatsheet](https://gist.github.com/MohamedAlaa/2961058#list-all-shortcuts).
+
+The container and chain will halt once you detach from the session.
+
+### Using tmux control mode
+
+If you use [iTerm you can use tmux with native integration](https://iterm2.com/documentation-tmux-integration.html), called control mode, which will make your tmux session appear as a physical window. Pass `TMUX_CC=1`:
+
+```shell
+TMUX_CC=1 make run
+```
+
+### Troubleshooting
 If you get an error about port 26656 already in use, you have a local chain running on your OS.
 
 If you run into other problems, you might have a local `agoric-sdk:latest` that

--- a/packages/deployment/upgrade-test/Readme.md
+++ b/packages/deployment/upgrade-test/Readme.md
@@ -38,6 +38,8 @@ If you use [iTerm you can use tmux with native integration](https://iterm2.com/d
 TMUX_CC=1 make run
 ```
 
+**Note:** If your terminal does not support control mode, do not use this. It will show raw control codes, garbling your terminal.
+
 ### Troubleshooting
 If you get an error about port 26656 already in use, you have a local chain running on your OS.
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/bash_entrypoint.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/bash_entrypoint.sh
@@ -2,6 +2,12 @@
 cd /usr/src/agoric-sdk/ || exit 1
 tmux -V || apt install -y tmux
 
-tmux \
+if [[ $TMUX_USE_CC == "1" ]]; then
+    TMUX_FLAGS="-CC -u"
+else
+    TMUX_FLAGS=""
+fi
+
+tmux $TMUX_FLAGS \
     new-session  'SLOGFILE=slog.slog ./upgrade-test-scripts/start_to_to.sh' \; \
     new-window   'bash -i'


### PR DESCRIPTION
refs: #7797 

## Description

Note this is an optional change adding a quality of life feature. It's not required for shipping.

This PR adds allows an envvars that control whether tmux runs in control mode for terminals that support it (iTerm is the only one I'm aware of). 

You can use it by running `make run` with `TMUX_CC=1`

### Security Considerations

We opt to only allow setting this flag instead of allowing control of all tmux flags via `TMUX_FLAGS` or something similar. The latter incurs more risk, as you could inject shell commands. This is currently low risk as all the contexts require full shell access, and injecting an envvar doesn't require additional privileges than running commands (e.g. local testing, CI). This assumption may break down if things change in the future, so we intentionally keep it simple.

### Scaling Considerations


### Documentation Considerations

Testing/internal only currently. I documented the feature anyhow.

### Testing Considerations

This should make testing easier as it lowers the burden of having to remember tmux in a crunch.
