### PR TITLE
test: zoe null upgrade by swingset.CoreEval governance decision

### DIFF
--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/actions.sh
@@ -2,4 +2,8 @@
 
 . ./upgrade-test-scripts/env_setup.sh
 
-# Core-eval contract upgrade
+# CWD is agoric-sdk
+here=./upgrade-test-scripts/agoric-upgrade-11
+
+# run zoe thru "null upgrade"
+$here/zoe-upgrade/zoe-upgrade-driver.sh

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/pre_test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/pre_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+. ./upgrade-test-scripts/env_setup.sh
+
+echo Wait for upgrade to settle
+waitForBlock 5
+
+# CWD is agoric-sdk
+here=./upgrade-test-scripts/agoric-upgrade-11
+
+# zoe vat is at incarnation 0
+test_val "$(yarn --silent node $here/zoe-upgrade/vat-status.mjs zoe)" "0" "zoe vat incarnation"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+. ./upgrade-test-scripts/env_setup.sh
+
+echo Wait for actions to settle
+waitForBlock 2
+
+# CWD is agoric-sdk
+here=./upgrade-test-scripts/agoric-upgrade-11
+
+# zoe vat is at incarnation 1
+test_val "$(yarn --silent node $here/zoe-upgrade/vat-status.mjs zoe)" "1" "zoe vat incarnation"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/vat-status.mjs
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/vat-status.mjs
@@ -1,0 +1,54 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import processAmbient from 'process';
+import dbOpenAmbient from 'better-sqlite3';
+
+const dbTool = db => {
+  const prepare = (strings, ...params) => {
+    const dml = strings.join(' ? ');
+    return { stmt: db.prepare(dml), params };
+  };
+  const sql = (strings, ...args) => {
+    const { stmt, params } = prepare(strings, ...args);
+    return stmt.all(...params);
+  };
+  sql.get = (strings, ...args) => {
+    const { stmt, params } = prepare(strings, ...args);
+    return stmt.get(...params);
+  };
+  return sql;
+};
+
+const main = async (argv, { dbOpen, HOME }) => {
+  const [_node, _script, vatName] = argv;
+  if (!vatName) throw Error('vatName required');
+
+  const db = dbOpen(`${HOME}/.agoric/data/agoric/swingstore.sqlite`, {
+    readonly: true,
+  });
+  const sql = dbTool(db);
+
+  const kvGet = key => sql.get`select * from kvStore where key = ${key}`.value;
+
+  const dynamicIDs = JSON.parse(kvGet('vat.dynamicIDs'));
+  const targetVat = dynamicIDs.find(vatID => {
+    const options = JSON.parse(kvGet(`${vatID}.options`));
+    return options.name === vatName;
+  });
+
+  const source = JSON.parse(kvGet(`${targetVat}.source`));
+  const {
+    incarnation,
+  } = sql.get`select * from transcriptSpans where isCurrent = 1 and vatID = ${targetVat}`;
+  console.error(
+    JSON.stringify({ vatName, vatID: targetVat, incarnation, ...source }),
+  );
+  console.log(incarnation);
+};
+
+main(processAmbient.argv, {
+  dbOpen: dbOpenAmbient,
+  HOME: processAmbient.env.HOME,
+}).catch(err => {
+  console.error(err);
+  processAmbient.exit(1);
+});

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/vat-status.mjs
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/vat-status.mjs
@@ -1,10 +1,22 @@
-/* eslint-disable import/no-extraneous-dependencies */
+// @ts-check
 import processAmbient from 'process';
 import dbOpenAmbient from 'better-sqlite3';
 
+/**
+ * @file look up vat incarnation from kernel DB
+ * @see {main}
+ */
+
+const swingstorePath = '~/.agoric/data/agoric/swingstore.sqlite';
+
+/**
+ * SQL short-hand
+ *
+ * @param {import('better-sqlite3').Database} db
+ */
 const dbTool = db => {
   const prepare = (strings, ...params) => {
-    const dml = strings.join(' ? ');
+    const dml = strings.join('?');
     return { stmt: db.prepare(dml), params };
   };
   const sql = (strings, ...args) => {
@@ -18,30 +30,69 @@ const dbTool = db => {
   return sql;
 };
 
+/**
+ * @param {import('better-sqlite3').Database} db
+ */
+const makeSwingstore = db => {
+  const sql = dbTool(db);
+
+  /** @param {string} key */
+  const kvGet = key => sql.get`select * from kvStore where key = ${key}`.value;
+  /** @param {string} key */
+  const kvGetJSON = key => JSON.parse(kvGet(key));
+
+  /** @param {string} vatID */
+  const lookupVat = vatID => {
+    return Object.freeze({
+      source: () => kvGetJSON(`${vatID}.source`),
+      options: () => kvGetJSON(`${vatID}.options`),
+      currentSpan: () =>
+        sql.get`select * from transcriptSpans where isCurrent = 1 and vatID = ${vatID}`,
+    });
+  };
+
+  return Object.freeze({
+    /** @param {string} vatName */
+    findVat: vatName => {
+      /** @type {string[]} */
+      const dynamicIDs = kvGetJSON('vat.dynamicIDs');
+      const targetVat = dynamicIDs.find(
+        vatID => lookupVat(vatID).options().name === vatName,
+      );
+      if (!targetVat) throw Error(vatName);
+      return targetVat;
+    },
+    lookupVat,
+  });
+};
+
+/** @type {<T>(val: T | undefined) => T} */
+const NonNullish = val => {
+  if (!val) throw Error('required');
+  return val;
+};
+
+/**
+ * @param {string[]} argv
+ * @param {{ dbOpen: typeof import('better-sqlite3'), HOME?: string }} io
+ */
 const main = async (argv, { dbOpen, HOME }) => {
   const [_node, _script, vatName] = argv;
   if (!vatName) throw Error('vatName required');
 
-  const db = dbOpen(`${HOME}/.agoric/data/agoric/swingstore.sqlite`, {
-    readonly: true,
-  });
-  const sql = dbTool(db);
+  const fullPath = swingstorePath.replace(/^~/, NonNullish(HOME));
+  const kStore = makeSwingstore(dbOpen(fullPath, { readonly: true }));
 
-  const kvGet = key => sql.get`select * from kvStore where key = ${key}`.value;
+  const vatID = kStore.findVat(vatName);
+  const vatInfo = kStore.lookupVat(vatID);
 
-  const dynamicIDs = JSON.parse(kvGet('vat.dynamicIDs'));
-  const targetVat = dynamicIDs.find(vatID => {
-    const options = JSON.parse(kvGet(`${vatID}.options`));
-    return options.name === vatName;
-  });
+  const source = vatInfo.source();
+  const { incarnation } = vatInfo.currentSpan();
 
-  const source = JSON.parse(kvGet(`${targetVat}.source`));
-  const {
-    incarnation,
-  } = sql.get`select * from transcriptSpans where isCurrent = 1 and vatID = ${targetVat}`;
-  console.error(
-    JSON.stringify({ vatName, vatID: targetVat, incarnation, ...source }),
-  );
+  // misc info to stderr
+  console.error(JSON.stringify({ vatName, vatID, incarnation, ...source }));
+
+  // incarnation to stdout
   console.log(incarnation);
 };
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/zoe-upgrade-driver.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/zoe-upgrade-driver.sh
@@ -12,7 +12,7 @@ agd --chain-id=agoriclocal \
   --title="Zoe Upgrade" --description="zoe upgrade test" \
   --deposit=10000000ubld \
   --gas=auto --gas-adjustment=1.2 \
-  --yes -o json --from=validator --keyring-backend=test -b sync
+  --yes -o json --from=validator --keyring-backend=test -b block
 
 agd --chain-id=agoriclocal query gov proposals --output json | \
         jq -c '.proposals[] | [.proposal_id,.voting_end_time,.status]';

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/zoe-upgrade-driver.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/zoe-upgrade-driver.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+. ./upgrade-test-scripts/env_setup.sh
+
+set -euo pipefail
+
+here='upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade'
+
+agd --chain-id=agoriclocal \
+  tx gov submit-proposal swingset-core-eval \
+  ${here}/zoe-upgrade-permit.json ${here}/zoe-upgrade-script.js \
+  --title="Zoe Upgrade" --description="zoe upgrade test" \
+  --deposit=10000000ubld \
+  --gas=auto --gas-adjustment=1.2 \
+  --yes -o json --from=validator --keyring-backend=test -b sync
+
+agd --chain-id=agoriclocal query gov proposals --output json | \
+        jq -c '.proposals[] | [.proposal_id,.voting_end_time,.status]';
+
+voteLatestProposalAndWait
+
+# then tes some stuff???

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/zoe-upgrade-permit.json
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/zoe-upgrade-permit.json
@@ -1,0 +1,6 @@
+{
+    "consume": {
+        "vatStore": true,
+        "vatAdminSvc": true
+    }
+}

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/zoe-upgrade-script.js
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/zoe-upgrade/zoe-upgrade-script.js
@@ -1,0 +1,32 @@
+// @ts-no-check
+/* global E */
+
+// to turn on ts-check:
+// Xmport { E } from '@endo/far';
+
+console.info('zoe upgrade: evaluating script');
+
+/**
+ * Test "upgrading" zoe.
+ * It's a so-called "null" upgrade, since we don't mean to change the code.
+ * This (re-)uses the code originally bundled at swingset bootstrap.
+ *
+ * @param { BootstrapPowers } powers
+ */
+const restartZoe = async powers => {
+  console.info('restartZoe()');
+  const {
+    consume: { vatStore, vatAdminSvc },
+  } = powers;
+  console.info('restartZoe - destructured powers');
+
+  const bundleName = 'zoe';
+  const bundleCap = await E(vatAdminSvc).getNamedBundleCap(bundleName);
+  const { adminNode } = await E(vatStore).get('zoe');
+  console.info('restartZoe', { bundleName, bundleCap, adminNode });
+
+  const result = await E(adminNode).upgrade(bundleCap, {});
+  console.info('restartZoe', { result });
+};
+
+restartZoe;


### PR DESCRIPTION
closes: #7771

## Description

Using the docker upgrade-tests framework, test that we can upgrade zoe using swingset.CoreEval.

 - pre test: kernel DB shows zoe vat is at incarnation 0
 - action: use CoreEval to upgrade zoe
 - test: kernel DB shows zoe vat is at incarnation 1

### Security Considerations

simulates a BLD staker vote

### Scaling Considerations

none?

### Documentation Considerations

provides another example of using CoreEval (cc @Tyrosine22 )

### Testing Considerations

- [x] integrate with upgrade-tests
