### PR TITLE
test: patch auction timing

### DIFF
--- a/packages/deployment/upgrade-test/fix-agoric-upgrade-10.patch
+++ b/packages/deployment/upgrade-test/fix-agoric-upgrade-10.patch
@@ -1,0 +1,20 @@
+diff --git a/packages/inter-protocol/src/proposals/econ-behaviors.js b/packages/inter-protocol/src/proposals/econ-behaviors.js
+index 3897578a1..4850feec5 100644
+--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
++++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
+@@ -523,13 +523,13 @@ export const startAuctioneer = async (
+   },
+   {
+     auctionParams = {
+-      StartFrequency: 3600n,
++      StartFrequency: 10n * 60n, // 10min - convenient for testing
+       ClockStep: 3n * 60n,
+       StartingRate: 10500n,
+       LowestRate: 6500n,
+       DiscountStep: 500n,
+       AuctionStartDelay: 2n,
+-      PriceLockPeriod: 30n * 60n, // half an hour
++      PriceLockPeriod: 5n * 60n, // 5 min
+     },
+   } = {},
+ ) => {

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/start_to_to.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/start_to_to.sh
@@ -14,7 +14,7 @@ fi
 
 . ./upgrade-test-scripts/env_setup.sh
 
-if test -f "/workspace/fix-${THIS_NAME}.patch"; then
+if [[ "$BOOTSTRAP_MODE" == "test" ]] && test -f "/workspace/fix-${THIS_NAME}.patch"; then
   patch -p1 < "/workspace/fix-${THIS_NAME}.patch"
 fi
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/start_to_to.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/start_to_to.sh
@@ -14,6 +14,10 @@ fi
 
 . ./upgrade-test-scripts/env_setup.sh
 
+if test -f "/workspace/fix-${THIS_NAME}.patch"; then
+  patch -p1 < "/workspace/fix-${THIS_NAME}.patch"
+fi
+
 agd start --log_level warn &
 AGD_PID=$!
 wait_for_bootstrap


### PR DESCRIPTION
refs: #7796

## Description

To investigate a hypothesis that #7796 is caused by param changes on
running chain, we patch them in the source code before bootstrap so
that changing them via governance after bootstrap is not necessary.

As a result, `TARGET=agoric-upgrade-10 make build run` results in a
world with these params:

```
{
  "StartFrequency": {
    "type": "relativeTime",
    "value": {
      "relValue": "600",
      "timerBrand": "[Alleged: SEVERED: timerBrand {}]"
    }
  },
  "PriceLockPeriod": {
    "type": "relativeTime",
    "value": {
      "relValue": "300",
      "timerBrand": "[Alleged: SEVERED: timerBrand {}]"
    }
  }
}
```


### Security / Scaling Considerations

n/a

### Documentation Considerations

upgrade-test users need to be aware of the patched auction timing params

### Testing Considerations

designed to help test #7796