### PR TITLE
upgrade-test: isolate vaults-and-beyond env setup

### DIFF
--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -7,18 +7,18 @@ ENV UPGRADE_TO=agoric-upgrade-8 THIS_NAME=agoric-upgrade-7-2 BOOTSTRAP_MODE=${BO
 RUN echo "${BOOTSTRAP_MODE}"
 RUN mkdir -p /usr/src/agoric-sdk/upgrade-test-scripts
 WORKDIR /usr/src/agoric-sdk/
-COPY ./*.sh ./upgrade-test-scripts/
+COPY ./start_ag0.sh ./upgrade-test-scripts/
+COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 SHELL ["/bin/bash", "-c"]
 RUN . ./upgrade-test-scripts/start_ag0.sh
 
-ARG BOOTSTRAP_MODE
 ## this is agoric-upgrade-8 aka pismoA
 FROM ghcr.io/agoric/agoric-sdk:29 as agoric-upgrade-8
 ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-8 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 WORKDIR /usr/src/agoric-sdk/
 
-COPY ./*.sh ./upgrade-test-scripts/
+COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-7-2 /root/.agoric /root/.agoric
 RUN chmod +x ./upgrade-test-scripts/*.sh
@@ -32,7 +32,7 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-8-1 UPGRADE_TO=agoric-upgrade-9 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
-COPY ./*.sh ./upgrade-test-scripts/
+COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-8 /root/.agoric /root/.agoric
 RUN chmod +x ./upgrade-test-scripts/*.sh
@@ -46,7 +46,7 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-9 UPGRADE_TO=agoric-upgrade-10 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
-COPY ./*.sh ./upgrade-test-scripts/
+COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-8-1 /root/.agoric /root/.agoric
 WORKDIR /usr/src/agoric-sdk/
@@ -62,7 +62,7 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-10 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
-COPY ./*.sh ./upgrade-test-scripts/
+COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-9 /root/.agoric /root/.agoric
 RUN chmod +x ./upgrade-test-scripts/*.sh
@@ -77,7 +77,7 @@ ENV THIS_NAME=agoric-upgrade-11 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 # this boot doesn't need an upgrade
 
 WORKDIR /usr/src/agoric-sdk/
-COPY ./*.sh ./upgrade-test-scripts/
+COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-10 /root/.agoric /root/.agoric
 RUN apt install -y tmux

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/env_setup.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# agoric-upgrade-10 specific env here...
+export USER2ADDR=$($binary keys show user2 -a --keyring-backend="test" 2> /dev/null)
+
+printKeys() {
+  echo "========== GOVERNANCE KEYS =========="
+  echo "gov1: $GOV1ADDR"
+  cat ~/.agoric/gov1.key || true
+  echo "gov2: $GOV2ADDR"
+  cat ~/.agoric/gov2.key || true
+  echo "gov3: $GOV3ADDR"
+  cat ~/.agoric/gov3.key || true
+  echo "validator: $VALIDATORADDR"
+  cat ~/.agoric/validator.key || true
+  echo "user1: $USER1ADDR"
+  cat ~/.agoric/user1.key || true
+  echo "user2: $USER2ADDR"
+  cat ~/.agoric/user2.key || true
+  echo "========== GOVERNANCE KEYS =========="
+}
+
+pushPrice () {
+  echo ACTIONS pushPrice $1
+  newPrice="${1:-10.00}"
+  for oracleNum in {1..2}; do
+    if [[ ! -e "$HOME/.agoric/lastOracle" ]]; then
+      echo "$GOV1ADDR" > "$HOME/.agoric/lastOracle"
+    fi
+
+    lastOracle=$(cat "$HOME/.agoric/lastOracle")
+    nextOracle="$GOV1ADDR"
+    if [[ "$lastOracle" == "$GOV1ADDR" ]]; then
+      nextOracle="$GOV2ADDR"
+    fi
+    echo "Pushing Price from oracle $nextOracle"
+
+    oid="${nextOracle}_ORACLE"
+    offer=$(mktemp -t pushPrice.XXX)
+    agops oracle pushPriceRound --price "$newPrice" --oracleAdminAcceptOfferId "${!oid}" >|"$offer"
+    sleep 1
+    timeout --preserve-status 15 yarn run --silent agops perf satisfaction --from $nextOracle --executeOffer "$offer" --keyring-backend test
+    if [ $? -ne 0 ]; then
+      echo "WARNING: pushPrice for $nextOracle failed!"
+    fi
+    echo "$nextOracle" > "$HOME/.agoric/lastOracle"
+  done
+}
+
+
+# variant of pushPrice() that figures out which oracle to send from
+# WIP because it doesn't always work
+pushPriceOnce () {
+  echo ACTIONS pushPrice $1
+  newPrice="${1:-10.00}"
+  timeout 3 agoric follow -lF :published.priceFeed.ATOM-USD_price_feed.latestRound -ojson > "$HOME/.agoric/latestRound-ATOM.json"
+  
+  lastStartedBy=$(jq -r .startedBy "$HOME/.agoric/latestRound-ATOM.json" || echo null)
+  echo lastStartedBy $lastStartedBy
+  nextOracle="ERROR"
+  # cycle to next among oracles (first of the two governance accounts)
+  case $lastStartedBy in
+    "$GOV1ADDR") nextOracle=$GOV2ADDR;;
+    "$GOV2ADDR") nextOracle=$GOV1ADDR;;
+    *)
+      echo last price was pushed by a different account, using GOV1
+      nextOracle=$GOV1ADDR
+      ;;
+  esac
+  echo nextOracle $nextOracle
+
+  adminOfferId="${nextOracle}_ORACLE"
+
+  echo "Pushing Price from oracle $nextOracle with offer $adminOfferId"
+
+  offer=$(mktemp -t pushPrice.XXX)
+  agops oracle pushPriceRound --price "$newPrice" --oracleAdminAcceptOfferId "${adminOfferId}" >|"$offer"
+  cat "$offer"
+  sleep 1
+  timeout --preserve-status 15 yarn run --silent agops perf satisfaction --from $nextOracle --executeOffer "$offer" --keyring-backend test
+  if [ $? -eq 0 ]; then
+    echo SUCCESS
+  else
+    echo "ERROR: pushPrice failed (using $nextOracle)"
+  fi
+}

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/env_setup.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# agoric-upgrade-11 specific env here...
+export USER2ADDR=$($binary keys show user2 -a --keyring-backend="test" 2> /dev/null)
+
+printKeys() {
+  echo "========== GOVERNANCE KEYS =========="
+  echo "gov1: $GOV1ADDR"
+  cat ~/.agoric/gov1.key || true
+  echo "gov2: $GOV2ADDR"
+  cat ~/.agoric/gov2.key || true
+  echo "gov3: $GOV3ADDR"
+  cat ~/.agoric/gov3.key || true
+  echo "validator: $VALIDATORADDR"
+  cat ~/.agoric/validator.key || true
+  echo "user1: $USER1ADDR"
+  cat ~/.agoric/user1.key || true
+  echo "user2: $USER2ADDR"
+  cat ~/.agoric/user2.key || true
+  echo "========== GOVERNANCE KEYS =========="
+}
+
+pushPrice () {
+  echo ACTIONS pushPrice $1
+  newPrice="${1:-10.00}"
+  for oracleNum in {1..2}; do
+    if [[ ! -e "$HOME/.agoric/lastOracle" ]]; then
+      echo "$GOV1ADDR" > "$HOME/.agoric/lastOracle"
+    fi
+
+    lastOracle=$(cat "$HOME/.agoric/lastOracle")
+    nextOracle="$GOV1ADDR"
+    if [[ "$lastOracle" == "$GOV1ADDR" ]]; then
+      nextOracle="$GOV2ADDR"
+    fi
+    echo "Pushing Price from oracle $nextOracle"
+
+    oid="${nextOracle}_ORACLE"
+    offer=$(mktemp -t pushPrice.XXX)
+    agops oracle pushPriceRound --price "$newPrice" --oracleAdminAcceptOfferId "${!oid}" >|"$offer"
+    sleep 1
+    timeout --preserve-status 15 yarn run --silent agops perf satisfaction --from $nextOracle --executeOffer "$offer" --keyring-backend test
+    if [ $? -ne 0 ]; then
+      echo "WARNING: pushPrice for $nextOracle failed!"
+    fi
+    echo "$nextOracle" > "$HOME/.agoric/lastOracle"
+  done
+}
+
+
+# variant of pushPrice() that figures out which oracle to send from
+# WIP because it doesn't always work
+pushPriceOnce () {
+  echo ACTIONS pushPrice $1
+  newPrice="${1:-10.00}"
+  timeout 3 agoric follow -lF :published.priceFeed.ATOM-USD_price_feed.latestRound -ojson > "$HOME/.agoric/latestRound-ATOM.json"
+  
+  lastStartedBy=$(jq -r .startedBy "$HOME/.agoric/latestRound-ATOM.json" || echo null)
+  echo lastStartedBy $lastStartedBy
+  nextOracle="ERROR"
+  # cycle to next among oracles (first of the two governance accounts)
+  case $lastStartedBy in
+    "$GOV1ADDR") nextOracle=$GOV2ADDR;;
+    "$GOV2ADDR") nextOracle=$GOV1ADDR;;
+    *)
+      echo last price was pushed by a different account, using GOV1
+      nextOracle=$GOV1ADDR
+      ;;
+  esac
+  echo nextOracle $nextOracle
+
+  adminOfferId="${nextOracle}_ORACLE"
+
+  echo "Pushing Price from oracle $nextOracle with offer $adminOfferId"
+
+  offer=$(mktemp -t pushPrice.XXX)
+  agops oracle pushPriceRound --price "$newPrice" --oracleAdminAcceptOfferId "${adminOfferId}" >|"$offer"
+  cat "$offer"
+  sleep 1
+  timeout --preserve-status 15 yarn run --silent agops perf satisfaction --from $nextOracle --executeOffer "$offer" --keyring-backend test
+  if [ $? -eq 0 ]; then
+    echo SUCCESS
+  else
+    echo "ERROR: pushPrice failed (using $nextOracle)"
+  fi
+}

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/env_setup.sh
@@ -23,10 +23,6 @@ export GOV3ADDR=$($binary keys show gov3 -a --keyring-backend="test")
 export VALIDATORADDR=$($binary keys show validator -a --keyring-backend="test")
 export USER1ADDR=$($binary keys show user1 -a --keyring-backend="test")
 
-if [[ $THIS_NAME == "agoric-upgrade-10" || $THIS_NAME == "agoric-upgrade-11" ]]; then
-  export USER2ADDR=$($binary keys show user2 -a --keyring-backend="test" 2> /dev/null)
-fi
-
 if [[ "$binary" == "agd" ]]; then
 # Support testnet addresses
   sed -i "s/agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce/$GOV1ADDR/g" /usr/src/agoric-sdk/packages/vats/*.json
@@ -211,78 +207,9 @@ printKeys() {
   cat ~/.agoric/validator.key || true
   echo "user1: $USER1ADDR"
   cat ~/.agoric/user1.key || true
-  if [[ $THIS_NAME == "agoric-upgrade-10" || $THIS_NAME == "agoric-upgrade-11" ]]; then
-    cat ~/.agoric/user2.key || true
-  fi
   echo "========== GOVERNANCE KEYS =========="
 }
 
-echo ENV_SETUP finished
-
-pushPrice () {
-  echo ACTIONS pushPrice $1
-  newPrice="${1:-10.00}"
-  for oracleNum in {1..2}; do
-    if [[ ! -e "$HOME/.agoric/lastOracle" ]]; then
-      echo "$GOV1ADDR" > "$HOME/.agoric/lastOracle"
-    fi
-
-    lastOracle=$(cat "$HOME/.agoric/lastOracle")
-    nextOracle="$GOV1ADDR"
-    if [[ "$lastOracle" == "$GOV1ADDR" ]]; then
-      nextOracle="$GOV2ADDR"
-    fi
-    echo "Pushing Price from oracle $nextOracle"
-
-    oid="${nextOracle}_ORACLE"
-    offer=$(mktemp -t pushPrice.XXX)
-    agops oracle pushPriceRound --price "$newPrice" --oracleAdminAcceptOfferId "${!oid}" >|"$offer"
-    sleep 1
-    timeout --preserve-status 15 yarn run --silent agops perf satisfaction --from $nextOracle --executeOffer "$offer" --keyring-backend test
-    if [ $? -ne 0 ]; then
-      echo "WARNING: pushPrice for $nextOracle failed!"
-    fi
-    echo "$nextOracle" > "$HOME/.agoric/lastOracle"
-  done
-}
-
-
-# variant of pushPrice() that figures out which oracle to send from
-# WIP because it doesn't always work
-pushPriceOnce () {
-  echo ACTIONS pushPrice $1
-  newPrice="${1:-10.00}"
-  timeout 3 agoric follow -lF :published.priceFeed.ATOM-USD_price_feed.latestRound -ojson > "$HOME/.agoric/latestRound-ATOM.json"
-  
-  lastStartedBy=$(jq -r .startedBy "$HOME/.agoric/latestRound-ATOM.json" || echo null)
-  echo lastStartedBy $lastStartedBy
-  nextOracle="ERROR"
-  # cycle to next among oracles (first of the two governance accounts)
-  case $lastStartedBy in
-    "$GOV1ADDR") nextOracle=$GOV2ADDR;;
-    "$GOV2ADDR") nextOracle=$GOV1ADDR;;
-    *)
-      echo last price was pushed by a different account, using GOV1
-      nextOracle=$GOV1ADDR
-      ;;
-  esac
-  echo nextOracle $nextOracle
-
-  adminOfferId="${nextOracle}_ORACLE"
-
-  echo "Pushing Price from oracle $nextOracle with offer $adminOfferId"
-
-  offer=$(mktemp -t pushPrice.XXX)
-  agops oracle pushPriceRound --price "$newPrice" --oracleAdminAcceptOfferId "${adminOfferId}" >|"$offer"
-  cat "$offer"
-  sleep 1
-  timeout --preserve-status 15 yarn run --silent agops perf satisfaction --from $nextOracle --executeOffer "$offer" --keyring-backend test
-  if [ $? -eq 0 ]; then
-    echo SUCCESS
-  else
-    echo "ERROR: pushPrice failed (using $nextOracle)"
-  fi
-}
 
 export USDC_DENOM="ibc/toyusdc"
 # Recent transfer to Emerynet
@@ -293,3 +220,12 @@ if [[ "$BOOTSTRAP_MODE" == "main" ]]; then
   export ATOM_DENOM="ibc/BA313C4A19DFBF943586C0387E6B11286F9E416B4DD27574E6909CABE0E342FA"
   export PSM_PAIR="IST.USDC_axl"
 fi
+
+# additional env specific to a version
+if test -f ./upgrade-test-scripts/$THIS_NAME/env_setup.sh; then
+  echo ENV_SETUP found $THIS_NAME specific env, importing...
+  . ./upgrade-test-scripts/$THIS_NAME/env_setup.sh
+  echo ENV_SETUP imported $THIS_NAME specific env
+fi
+
+echo ENV_SETUP finished


### PR DESCRIPTION
refs: #7797 

## Description

During development of newer tests we observed that adding new utils to `env_setup.sh` required rebuild of all earlier versions, despite the utils being only relevant to `agoric-upgrade-10` and above. This was the case for `pushPrice` as well as adding a new user post-vaults, both of which don't make sense to be referenced in earlier versions.

This PR enables isolating environment setup such that adding new environment variables and bahs utils do not cause a rebuild of earlier versions.

### Security Considerations

### Scaling Considerations

This reduces build time by using cache more efficiently.

### Documentation Considerations


### Testing Considerations

Currently, the tradeoff is that each version should include its own environment for newly added things, and if an environment requires the specific environment of an earlier version (e.g. we want to re-use things from `agoric-upgrade-10` in `agoric-upgrade-11`) we need to duplicate. We can also copy the env via Dockerfile, but that's less explicit and may cause issues overwriting an existing env file if placed unaware. Open to suggestions to DRY while not causing unnecessary rebuilds.
