### PR TITLE
7794 capture market price at auction start

### DIFF
--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -566,9 +566,9 @@ export const start = async (zcf, privateArgs, baggage) => {
 
       tradeEveryBook();
     },
-    lockPrices() {
+    capturePrices() {
       for (const book of books.values()) {
-        book.lockOraclePriceForRound();
+        book.captureOraclePriceForRound();
       }
     },
   });

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -44,7 +44,7 @@ const makeCancelToken = makeCancelTokenMaker('scheduler');
  * @property {() => void} reducePriceAndTrade
  * @property {() => void} finalize
  * @property {() => void} startRound
- * @property {() => void} lockPrices
+ * @property {() => void} capturePrices
  */
 
 /**
@@ -209,9 +209,9 @@ export const makeScheduler = async (
   };
 
   // set wakeups for the steps of this round
-  const queueLiveSchedule = () => {
+  const scheduleDescendingSteps = () => {
     if (!liveSchedule) {
-      console.error('🚨 queueLiveSchedule called with no liveSchedule');
+      console.error('🚨 scheduleDescendingSteps called with no liveSchedule');
       return;
     }
 
@@ -223,7 +223,7 @@ export const makeScheduler = async (
         ? TimeMath.subtractAbsAbs(startTime, now)
         : TimeMath.subtractAbsAbs(startTime, startTime);
 
-    trace('queueLiveSchedule repeating', now, delayFromNow, startTime);
+    trace('scheduleDescendingSteps repeating', now, delayFromNow, startTime);
 
     void E(timer).repeatAfter(
       delayFromNow,
@@ -263,7 +263,7 @@ export const makeScheduler = async (
       Far('PriceLockWaker', {
         wake(time) {
           setTimeMonotonically(time);
-          auctionDriver.lockPrices();
+          auctionDriver.capturePrices();
         },
       }),
     );
@@ -318,7 +318,7 @@ export const makeScheduler = async (
       TimeMath.addAbsRel(liveSchedule.endTime, relativeTime(1n)),
     );
 
-    queueLiveSchedule();
+    scheduleDescendingSteps();
     if (nextSchedule) {
       scheduleNextRound(
         TimeMath.subtractAbsRel(
@@ -329,7 +329,7 @@ export const makeScheduler = async (
       schedulePriceLock(nextSchedule.lockTime);
     } else {
       console.warn(
-        'no nextSchedule so cannot schedule next round or price lock',
+        'no nextSchedule so cannot schedule next round or price capture',
       );
     }
   };

--- a/packages/inter-protocol/test/auction/test-auctionBook.js
+++ b/packages/inter-protocol/test/auction/test-auctionBook.js
@@ -83,7 +83,7 @@ test('states', async t => {
   const { moolaKit, simoleanKit } = basics;
   const { book } = await assembleAuctionBook(basics);
 
-  book.lockOraclePriceForRound();
+  book.captureOraclePriceForRound();
   book.setStartingRate(makeRatio(90n, moolaKit.brand, 100n));
   t.deepEqual(
     book.getCurrentPrice(),
@@ -129,7 +129,7 @@ test('simple addOffer', async t => {
   await eventLoopIteration();
 
   book.addAssets(AmountMath.make(simoleanKit.brand, 123n), donorSeat);
-  book.lockOraclePriceForRound();
+  book.captureOraclePriceForRound();
   book.setStartingRate(makeRatio(50n, moolaKit.brand, 100n));
 
   book.addOffer(
@@ -171,7 +171,7 @@ test('getOffers to a price limit', async t => {
     moolaKit,
   );
 
-  book.lockOraclePriceForRound();
+  book.captureOraclePriceForRound();
   book.setStartingRate(makeRatio(50n, moolaKit.brand, 100n));
 
   book.addOffer(
@@ -206,7 +206,7 @@ test('Bad keyword', async t => {
   await eventLoopIteration();
   book.addAssets(AmountMath.make(simoleanKit.brand, 123n), donorSeat);
 
-  book.lockOraclePriceForRound();
+  book.captureOraclePriceForRound();
   book.setStartingRate(makeRatio(50n, moolaKit.brand, 100n));
 
   const zcfSeat = await makeSeatWithAssets(
@@ -248,7 +248,7 @@ test('getOffers w/discount', async t => {
   await eventLoopIteration();
   book.addAssets(AmountMath.make(simoleanKit.brand, 123n), donorSeat);
 
-  book.lockOraclePriceForRound();
+  book.captureOraclePriceForRound();
   book.setStartingRate(makeRatio(50n, moolaKit.brand, 100n));
 
   const zcfSeat = await makeSeatWithAssets(

--- a/packages/inter-protocol/test/auction/test-scheduler.js
+++ b/packages/inter-protocol/test/auction/test-scheduler.js
@@ -91,13 +91,13 @@ test('schedule start to finish', async t => {
 
   t.false(fakeAuctioneer.getState().final);
   t.is(fakeAuctioneer.getState().step, 0);
-  t.false(fakeAuctioneer.getState().lockedPrices);
+  t.false(fakeAuctioneer.getState().capturedPrices);
 
   now = await timer.advanceTo(now + 1n);
 
   t.is(fakeAuctioneer.getState().step, 0);
   t.false(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   await scheduleTracker.assertInitial({
     activeStartTime: null,
@@ -127,7 +127,7 @@ test('schedule start to finish', async t => {
 
   t.is(fakeAuctioneer.getState().step, 1);
   t.false(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   // xxx I shouldn't have to tick twice.
   now = await timer.advanceTo(now + 1n);
@@ -139,7 +139,7 @@ test('schedule start to finish', async t => {
 
   t.is(fakeAuctioneer.getState().step, 2);
   t.false(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   // final step
   now = await timer.advanceTo(now + 1n);
@@ -151,7 +151,7 @@ test('schedule start to finish', async t => {
 
   t.is(fakeAuctioneer.getState().step, 3);
   t.true(fakeAuctioneer.getState().final);
-  t.false(fakeAuctioneer.getState().lockedPrices);
+  t.false(fakeAuctioneer.getState().capturedPrices);
 
   // Auction finished, nothing else happens
   now = await timer.advanceTo(now + 1n);
@@ -163,7 +163,7 @@ test('schedule start to finish', async t => {
 
   t.is(fakeAuctioneer.getState().step, 3);
   t.true(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   t.deepEqual(fakeAuctioneer.getStartRounds(), [0]);
 
@@ -210,7 +210,7 @@ test('schedule start to finish', async t => {
 
   t.is(fakeAuctioneer.getState().step, 4);
   t.false(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   // xxx I shouldn't have to tick twice.
   now = await timer.advanceTo(now + 1n);
@@ -221,14 +221,14 @@ test('schedule start to finish', async t => {
 
   t.is(fakeAuctioneer.getState().step, 5);
   t.false(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   // final step
   now = await timer.advanceTo(now + 2n);
 
   t.is(fakeAuctioneer.getState().step, 6);
   t.true(fakeAuctioneer.getState().final);
-  t.false(fakeAuctioneer.getState().lockedPrices);
+  t.false(fakeAuctioneer.getState().capturedPrices);
 
   // Auction finished, nothing else happens
   now = await timer.advanceTo(now + 1n);
@@ -241,7 +241,7 @@ test('schedule start to finish', async t => {
 
   t.is(fakeAuctioneer.getState().step, 6);
   t.true(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   t.deepEqual(fakeAuctioneer.getStartRounds(), [0, 3]);
 });
@@ -865,10 +865,10 @@ test('schedule anomalies', async t => {
   const schedule = scheduler.getSchedule();
   t.deepEqual(schedule.liveAuctionSchedule, null);
 
-  t.false(fakeAuctioneer.getState().lockedPrices);
-  // ////////////// LOCK TIME ///////////
+  t.false(fakeAuctioneer.getState().capturedPrices);
+  // ////////////// PRICE LOCK TIME /////////// not price capture
   now = await timer.advanceTo(baseTime + delay - lock);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   const firstSchedule = {
     startTime: timestamp(firstStart),
@@ -894,7 +894,7 @@ test('schedule anomalies', async t => {
 
   t.is(fakeAuctioneer.getState().step, 0);
   t.false(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   // ////////////// FIRST START ///////////
   now = await timer.advanceTo(firstStart);
@@ -918,7 +918,7 @@ test('schedule anomalies', async t => {
 
   t.is(fakeAuctioneer.getState().step, 1);
   t.false(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   // ////////////// DESCENDING STEP ///////////
   await timer.advanceTo(firstStart + step);
@@ -928,7 +928,7 @@ test('schedule anomalies', async t => {
 
   t.is(fakeAuctioneer.getState().step, 2);
   t.false(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   // ////////////// DESCENDING STEP ///////////
   await timer.advanceTo(firstStart + 2n * step);
@@ -940,7 +940,7 @@ test('schedule anomalies', async t => {
 
   t.is(fakeAuctioneer.getState().step, 3);
   t.true(fakeAuctioneer.getState().final);
-  t.false(fakeAuctioneer.getState().lockedPrices);
+  t.false(fakeAuctioneer.getState().capturedPrices);
 
   const secondStart = baseTime + oneCycle + delay;
   // ////////////// JUMP SLIGHTLY PAST NEXT START ///////////
@@ -953,7 +953,7 @@ test('schedule anomalies', async t => {
 
   t.is(fakeAuctioneer.getState().step, 4);
   t.false(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   t.deepEqual(fakeAuctioneer.getStartRounds(), [0, 3]);
 
@@ -988,7 +988,7 @@ test('schedule anomalies', async t => {
 
   t.is(fakeAuctioneer.getState().step, 4);
   t.false(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   // ////////////// DESCENDING STEP ///////////
   now = await timer.advanceTo(secondStart + 2n * step);
@@ -999,7 +999,7 @@ test('schedule anomalies', async t => {
 
   t.is(fakeAuctioneer.getState().step, 5);
   t.true(fakeAuctioneer.getState().final);
-  t.false(fakeAuctioneer.getState().lockedPrices);
+  t.false(fakeAuctioneer.getState().capturedPrices);
 
   // ////////////// JUMP TO THE END OF NEXT AUCTION ///////////
   const lateStart = baseTime + 2n * oneCycle + delay;
@@ -1013,7 +1013,7 @@ test('schedule anomalies', async t => {
 
   t.is(fakeAuctioneer.getState().step, 5);
   t.true(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
   t.deepEqual(fakeAuctioneer.getStartRounds(), [0, 3]);
 
   // ////////////// DESCENDING STEP ///////////
@@ -1022,7 +1022,7 @@ test('schedule anomalies', async t => {
 
   t.is(fakeAuctioneer.getState().step, 5);
   t.true(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   const schedule4 = scheduler.getSchedule();
   const fifthSchedule = {
@@ -1065,7 +1065,7 @@ test('schedule anomalies', async t => {
   });
 
   t.true(fakeAuctioneer.getState().final);
-  t.true(fakeAuctioneer.getState().lockedPrices);
+  t.true(fakeAuctioneer.getState().capturedPrices);
 
   t.deepEqual(fakeAuctioneer.getStartRounds(), [0, 3]);
 

--- a/packages/inter-protocol/test/auction/tools.js
+++ b/packages/inter-protocol/test/auction/tools.js
@@ -55,7 +55,7 @@ export const makeDefaultParams = (invitation, timerBrand) =>
   });
 
 export const makeFakeAuctioneer = () => {
-  const state = { step: 0, final: false, lockedPrices: false };
+  const state = { step: 0, final: false, capturedPrices: false };
   const startRounds = [];
 
   return Far('FakeAuctioneer', {
@@ -64,7 +64,7 @@ export const makeFakeAuctioneer = () => {
     },
     finalize: () => {
       state.final = true;
-      state.lockedPrices = false;
+      state.capturedPrices = false;
     },
     getState: () => state,
     startRound: () => {
@@ -73,7 +73,7 @@ export const makeFakeAuctioneer = () => {
       state.final = false;
     },
     getStartRounds: () => startRounds,
-    lockPrices: () => (state.lockedPrices = true),
+    capturePrices: () => (state.capturedPrices = true),
   });
 };
 


### PR DESCRIPTION
closes: #7798
closes: #7796 
closes: #7794 

## Description

I had named two things "lockedPrice", and it had confused me into scheduled the capture of the market price at the start of the auction to be at the priceLock time instead. The PR (separately) renames all lockPrice references in auction and scheduler to be variations on "capture" instead, and then corrects the timing of the capture.

### Security Considerations

Names are powerful

### Scaling Considerations

None

### Documentation Considerations

Captured price doesn't have a confusing name in the UI.

### Testing Considerations

Manual tests have exposed this issue, and the unit tests show that I have fixed the issue.