### PR TITLE
bootstrap test for liquidation

### DIFF
--- a/packages/SwingSet/src/lib/kmarshal.js
+++ b/packages/SwingSet/src/lib/kmarshal.js
@@ -74,7 +74,7 @@ export const krefOf = obj => {
   // objects created by our kslot().
   assert.equal(passStyleOf(obj), 'remotable', obj);
   const getKref = obj.getKref;
-  assert.typeof(getKref, 'function');
+  assert.typeof(getKref, 'function', 'object lacking getKref function');
   return getKref();
 };
 

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -4,6 +4,7 @@
 /* eslint-disable func-names */
 /* global fetch */
 import { Fail } from '@agoric/assert';
+import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { Nat } from '@endo/nat';
 import { Command } from 'commander';
 import { inspect } from 'util';
@@ -143,19 +144,15 @@ export const makeOracleCommand = logger => {
     .requiredOption('--price <number>', 'price', Number)
     .option('--roundId <number>', 'round', Number)
     .action(async function (opts) {
+      const { offerId } = opts;
       const unitPrice = scaleDecimals(opts.price);
       const roundId = 'roundId' in opts ? Nat(opts.roundId) : undefined;
-      /** @type {import('@agoric/smart-wallet/src/offers.js').OfferSpec} */
-      const offer = {
-        id: opts.offerId,
-        invitationSpec: {
-          source: 'continuing',
-          previousOffer: opts.oracleAdminAcceptOfferId,
-          invitationMakerName: 'PushPrice',
-          invitationArgs: harden([{ unitPrice, roundId }]),
-        },
-        proposal: {},
-      };
+
+      const offer = Offers.fluxAggregator.PushPrice(
+        {},
+        { offerId, unitPrice, roundId },
+        opts.oracleAdminAcceptOfferId,
+      );
 
       outputAction({
         method: 'executeOffer',

--- a/packages/inter-protocol/src/clientSupport.js
+++ b/packages/inter-protocol/src/clientSupport.js
@@ -305,9 +305,38 @@ const makeAddCollateralOffer = (brands, opts) => {
   return offerSpec;
 };
 
+/**
+ *
+ * @param {Record<string, Brand>} _brands
+ * @param {{
+ *   offerId: string,
+ *   roundId?: bigint,
+ *   unitPrice: bigint,
+ * }} opts
+ * @param {string} previousOffer
+ * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
+ */
+const makePushPriceOffer = (_brands, opts, previousOffer) => {
+  return {
+    id: opts.offerId,
+    invitationSpec: {
+      source: 'continuing',
+      previousOffer,
+      invitationMakerName: 'PushPrice',
+      invitationArgs: harden([
+        { unitPrice: opts.unitPrice, roundId: opts.roundId },
+      ]),
+    },
+    proposal: {},
+  };
+};
+
 export const Offers = {
   auction: {
     Bid: makeBidOffer,
+  },
+  fluxAggregator: {
+    PushPrice: makePushPriceOffer,
   },
   psm: {
     // lowercase because it's not an invitation name. Instead it's an abstraction over two invitation makers.

--- a/packages/inter-protocol/src/clientSupport.js
+++ b/packages/inter-protocol/src/clientSupport.js
@@ -331,6 +331,48 @@ const makePushPriceOffer = (_brands, opts, previousOffer) => {
   };
 };
 
+// TODO DRY with CLI wallet.js
+/**
+ * @param {{
+ *   brand: Record<string, Brand>,
+ *   vbankAsset: Record<string, { brand: Brand, displayInfo: DisplayInfo }>,
+ * }} agoricNames
+ * @param {(msg: string) => Error} makeError error constructor
+ * @returns {(a: string) => Amount<'nat'>}
+ */
+export const makeParseAmount =
+  (agoricNames, makeError = msg => RangeError(msg)) =>
+  opt => {
+    assert.typeof(opt, 'string', 'parseAmount expected string');
+    const m = opt.match(/^(?<value>[\d_]+(\.[\d_]+)?)(?<brand>[A-Z]\w*?)$/);
+    if (!m || !m.groups) {
+      throw makeError(`invalid amount: ${opt}`);
+    }
+    const anyBrand = agoricNames.brand[m.groups.brand];
+    if (!anyBrand) {
+      throw makeError(`unknown brand: ${m.groups.brand}`);
+    }
+    const assetDesc = Object.values(agoricNames.vbankAsset).find(
+      d => d.brand === anyBrand,
+    );
+    if (!assetDesc) {
+      throw makeError(`unknown brand: ${m.groups.brand}`);
+    }
+    const { displayInfo } = assetDesc;
+    if (!displayInfo.decimalPlaces || displayInfo.assetKind !== 'nat') {
+      throw makeError(`bad brand: ${displayInfo}`);
+    }
+    const value = BigInt(
+      Number(m.groups.value.replace(/_/g, '')) *
+        10 ** displayInfo.decimalPlaces,
+    );
+    /** @type {Brand<'nat'>} */
+    // @ts-expect-error dynamic cast
+    const natBrand = anyBrand;
+    const amt = { value, brand: natBrand };
+    return amt;
+  };
+
 export const Offers = {
   auction: {
     Bid: makeBidOffer,

--- a/packages/inter-protocol/src/clientSupport.js
+++ b/packages/inter-protocol/src/clientSupport.js
@@ -142,13 +142,13 @@ export const lookupOfferIdForVault = async (vaultId, currentP) => {
 
 /**
  * @param {Record<string, Brand>} brands
- * @param {({ wantMinted: number | undefined, giveMinted: number | undefined })} opts
+ * @param {({ wantMinted: number, giveMinted?: undefined } | { giveMinted: number, wantMinted?: undefined })} opts
  * @param {number} [fee=0]
  * @param {string} [anchor]
  * @returns {Proposal} XXX not a real proposal, uses BoardRemote
  */
 const makePsmProposal = (brands, opts, fee = 0, anchor = 'AUSD') => {
-  const giving = opts.giveMinted ? 'minted' : 'anchor';
+  const giving = 'giveMinted' in opts ? 'minted' : 'anchor';
   const brand =
     giving === 'anchor'
       ? { in: brands[anchor], out: brands.IST }
@@ -173,14 +173,15 @@ const makePsmProposal = (brands, opts, fee = 0, anchor = 'AUSD') => {
 /**
  * @param {Instance} instance
  * @param {Record<string, Brand>} brands
- * @param {{ offerId: number, feePct?: number } &
- *         ({ wantMinted: number | undefined, giveMinted: number | undefined, pair: [string, string] })} opts
+ * @param {{ offerId: string, feePct?: number, pair: [string, string] } &
+ *         ({ wantMinted: number } | { giveMinted: number })} opts
  * @returns {import('@agoric/smart-wallet/src/offers.js').OfferSpec}
  */
 const makePsmSwapOffer = (instance, brands, opts) => {
-  const method = opts.wantMinted
-    ? 'makeWantMintedInvitation'
-    : 'makeGiveMintedInvitation'; // ref psm.js
+  const method =
+    'wantMinted' in opts
+      ? 'makeWantMintedInvitation'
+      : 'makeGiveMintedInvitation'; // ref psm.js
   const proposal = makePsmProposal(
     brands,
     opts,

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -15,7 +15,7 @@ import { E } from '@endo/eventual-send';
 import { reserveThenDeposit } from '../proposals/utils.js';
 import { prepareFluxAggregatorKit } from './fluxAggregatorKit.js';
 
-const trace = makeTracer('FluxAgg');
+const trace = makeTracer('FluxAgg', false);
 /**
  * @typedef {import('@agoric/vat-data').Baggage} Baggage
  * @typedef {import('@agoric/time/src/types').TimerService} TimerService

--- a/packages/inter-protocol/src/price/fluxAggregatorKit.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorKit.js
@@ -189,6 +189,7 @@ export const prepareFluxAggregatorKit = async (
     priceAuthority.makeQuoteNotifier(unitAmountIn, brandOut),
     {
       updateState: quote => {
+        trace('new quote', quote);
         void priceKit.recorder.write(priceDescriptionFromQuote(quote));
       },
       fail: reason => {

--- a/packages/inter-protocol/src/price/roundsManager.js
+++ b/packages/inter-protocol/src/price/roundsManager.js
@@ -1,5 +1,6 @@
 import { Fail, q } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
+import { makeTracer } from '@agoric/internal';
 import { TimeMath } from '@agoric/time';
 import { M, makeScalarBigMapStore, prepareExoClassKit } from '@agoric/vat-data';
 import {
@@ -24,6 +25,8 @@ const V3_NO_DATA_ERROR = 'No data present';
 
 /** @type {bigint} */
 export const ROUND_MAX = BigInt(2 ** 32 - 1);
+
+const trace = makeTracer('RoundsM', false);
 
 /**
  * @param {bigint} roundId
@@ -290,6 +293,7 @@ export const prepareRoundsManagerKit = baggage =>
          * @returns {OracleStatus} the new status
          */
         recordSubmission(submission, roundId, status) {
+          trace('recordSubmission', submission, roundId, status);
           const { helper } = this.facets;
           const { details } = this.state;
           helper.acceptingSubmissions(roundId) ||
@@ -670,6 +674,7 @@ export const prepareRoundsManagerKit = baggage =>
           status,
           { roundId: roundIdRaw = undefined, unitPrice: valueRaw },
         ) {
+          trace('handlePush', status, roundIdRaw, valueRaw);
           const value = Nat(valueRaw);
           const { minSubmissionValue, maxSubmissionValue, timerPresence } =
             this.state;
@@ -681,6 +686,7 @@ export const prepareRoundsManagerKit = baggage =>
             Fail`value above maxSubmissionValue ${q(maxSubmissionValue)}`;
 
           const blockTimestamp = await E(timerPresence).getCurrentTimestamp();
+          trace('handlePush blockTimestamp', blockTimestamp.absValue);
 
           let roundId;
           if (roundIdRaw === undefined) {
@@ -718,6 +724,8 @@ export const prepareRoundsManagerKit = baggage =>
 
           helper.updateRoundAnswer(roundId, blockTimestamp);
           helper.deleteRoundDetails(roundId);
+
+          trace('handlePush returning', settledStatus);
 
           return settledStatus;
         },

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -17,6 +17,7 @@ import { makeGovernedTerms as makeGovernedVFTerms } from '../vaultFactory/params
 
 const trace = makeTracer('RunEconBehaviors', true);
 
+export const SECONDS_PER_MINUTE = 60n;
 export const SECONDS_PER_HOUR = 60n * 60n;
 export const SECONDS_PER_DAY = 24n * SECONDS_PER_HOUR;
 export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
@@ -411,7 +412,7 @@ export const startRewardDistributor = async ({
   const feeDistributorTerms = await deeplyFulfilledObject(
     harden({
       timerService,
-      collectionInterval: 60n * 60n, // 1 hour
+      collectionInterval: 1n * SECONDS_PER_HOUR,
       keywordShares: {
         RewardDistributor: 0n,
         Reserve: 1n,
@@ -523,13 +524,13 @@ export const startAuctioneer = async (
   },
   {
     auctionParams = {
-      StartFrequency: 3600n,
-      ClockStep: 3n * 60n,
+      StartFrequency: 1n * SECONDS_PER_HOUR,
+      ClockStep: 3n * SECONDS_PER_MINUTE,
       StartingRate: 10500n,
       LowestRate: 6500n,
       DiscountStep: 500n,
       AuctionStartDelay: 2n,
-      PriceLockPeriod: 30n * 60n, // half an hour
+      PriceLockPeriod: SECONDS_PER_HOUR / 2n,
     },
   } = {},
 ) => {

--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -157,7 +157,12 @@ const setWakeupsForNextAuction = async (
     E(timer).getCurrentTimestamp(),
   ]);
 
-  trace('SCHEDULE', now.absValue, nextAuctionSchedule);
+  trace(
+    'setWakeupsForNextAuction at',
+    now.absValue,
+    'with',
+    nextAuctionSchedule,
+  );
   if (!nextAuctionSchedule) {
     // There should always be a nextAuctionSchedule. If there isn't, give up for now.
     cancelWakeups(timer);

--- a/packages/internal/src/storage-test-utils.js
+++ b/packages/internal/src/storage-test-utils.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { Far } from '@endo/far';
 import { makeMarshal, Remotable } from '@endo/marshal';
+import { makeTracer } from './debug.js';
 import {
   isStreamCell,
   makeChainStorageRoot,
@@ -9,6 +10,8 @@ import {
 import { bindAllMethods } from './method-tools.js';
 
 const { Fail } = assert;
+
+const trace = makeTracer('StorTU', false);
 
 /**
  * A map corresponding with a total function such that `get(key)`
@@ -142,6 +145,7 @@ export const makeFakeStorageKit = (rootPath, rootOptions) => {
       }
       case 'set':
       case 'setWithoutNotify': {
+        trace('toStorage set', message);
         /** @type {import('../src/lib-chainStorage.js').StorageEntry[]} */
         const newEntries = message.args;
         for (const [key, value] of newEntries) {
@@ -154,6 +158,7 @@ export const makeFakeStorageKit = (rootPath, rootOptions) => {
         break;
       }
       case 'append': {
+        trace('toStorage append', message);
         /** @type {import('../src/lib-chainStorage.js').StorageEntry[]} */
         const newEntries = message.args;
         for (const [key, value] of newEntries) {

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -1,6 +1,10 @@
-import * as ActionType from '@agoric/internal/src/action-types.js';
+import { Fail } from '@agoric/assert';
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
-import centralSupplyBundle from '@agoric/vats/bundles/bundle-centralSupply.js';
+import * as ActionType from '@agoric/internal/src/action-types.js';
+import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
+import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { makeAgoricNamesAccess, makePromiseSpace } from '@agoric/vats';
 import {
   installBootContracts,
   makeAddressNameHubs,
@@ -8,17 +12,12 @@ import {
 } from '@agoric/vats/src/core/basic-behaviors.js';
 import { setupClientManager } from '@agoric/vats/src/core/chain-behaviors.js';
 import '@agoric/vats/src/core/types.js';
-import { makeAgoricNamesAccess, makePromiseSpace } from '@agoric/vats';
 import { buildRootObject as boardRoot } from '@agoric/vats/src/vat-board.js';
 import { buildRootObject as mintsRoot } from '@agoric/vats/src/vat-mints.js';
-import { makeMockChainStorageRoot } from '@agoric/internal/src/storage-test-utils.js';
-import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
-import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
-import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import { E, Far } from '@endo/far';
-import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeFakeBankKit } from '@agoric/vats/tools/bank-utils.js';
-import { Fail } from '@agoric/assert';
+import { makeRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { E, Far } from '@endo/far';
 
 export { ActionType };
 
@@ -148,31 +147,6 @@ export const makeMockTestSpace = async log => {
   ]);
 
   return space;
-};
-
-/**
- * @param {bigint} value
- * @param {{
- *   feeMintAccess: ERef<FeeMintAccess>,
- *   zoe: ERef<ZoeService>,
- * }} powers
- * @returns {Promise<Payment>}
- */
-export const mintCentralPayment = async (
-  value,
-  { feeMintAccess: feeMintAccessP, zoe },
-) => {
-  const feeMintAccess = await feeMintAccessP;
-
-  const centralSupply = await E(zoe).install(centralSupplyBundle);
-
-  const { creatorFacet: supplier } = await E(zoe).startInstance(
-    centralSupply,
-    {},
-    { bootstrapPaymentValue: value },
-    { feeMintAccess },
-  );
-  return E(supplier).getBootstrapPayment();
 };
 
 /**

--- a/packages/vats/decentral-itest-vaults-config.json
+++ b/packages/vats/decentral-itest-vaults-config.json
@@ -22,6 +22,7 @@
       "entrypoint": "defaultProposalBuilder",
       "args": [
         {
+          "interestRateValue": 1000,
           "interchainAssetOptions": {
             "denom": "ibc/toyatom",
             "decimalPlaces": 6,

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { AmountMath, AssetKind, BrandShape } from '@agoric/ertp';
-import { E, Far } from '@endo/far';
+import { deeplyFulfilledObject } from '@agoric/internal';
+import { prepareGuardedAttenuator } from '@agoric/internal/src/callback.js';
 import {
   IterableEachTopicI,
   makeNotifierKit,
@@ -10,8 +11,8 @@ import {
 } from '@agoric/notifier';
 import { M, provideLazy } from '@agoric/store';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { prepareGuardedAttenuator } from '@agoric/internal/src/callback.js';
-import { deeplyFulfilledObject } from '@agoric/internal';
+import { E, Far } from '@endo/far';
+import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import { BridgeHandlerI, BridgeScopedManagerI } from './bridge.js';
 import {
   makeVirtualPurseKitIKit,
@@ -404,6 +405,10 @@ const prepareBank = (
   const makeBalanceUpdater = prepareBalanceUpdater(zone);
   const makeBankPurseController = prepareBankPurseController(zone);
 
+  const addressDenomToPurse = zone.mapStore('addressDenomToPurse');
+  /** @type {import('@agoric/store/src/stores/store-utils.js').AtomicProvider<string, VirtualPurse>} */
+  const purseProvider = makeAtomicProvider(addressDenomToPurse);
+
   const makeBank = zone.exoClass(
     'Bank',
     BankI,
@@ -443,6 +448,7 @@ const prepareBank = (
           this.state.assetSubscriber,
         );
       },
+      /** @param {Brand} brand */
       async getPurse(brand) {
         const {
           bankChannel,
@@ -451,54 +457,53 @@ const prepareBank = (
           brandToAssetRecord,
           denomToAddressUpdater,
         } = this.state;
-
         if (brandToVPurse.has(brand)) {
           return brandToVPurse.get(brand);
         }
 
-        /** @param {ERef<VirtualPurse>} purseP */
-        const keepPurse = async purseP => {
-          const purse = await purseP;
-          // Need to recheck as we may have raced with another call.
-          if (brandToVPurse.has(brand)) {
-            return brandToVPurse.get(brand);
+        const assetRecord = brandToAssetRecord.get(brand);
+        const providerKey = `${address}:${assetRecord.denom}`;
+
+        /** @type {() => Promise<VirtualPurse>} */
+        const makePurse = async () => {
+          if (!bankChannel) {
+            // Just emulate with a real purse.
+            return E(assetRecord.issuer).makeEmptyPurse();
           }
-          brandToVPurse.init(brand, purse);
-          return purse;
+          const addressToUpdater = denomToAddressUpdater.get(assetRecord.denom);
+
+          /** @type {PublishKit<Amount>} */
+          const { publisher, subscriber } = makePublishKit();
+          const balanceUpdater = makeBalanceUpdater(brand, publisher);
+          addressToUpdater.init(address, balanceUpdater);
+          // Get the initial balance.
+          const balanceString = await bankChannel.toBridge({
+            type: 'VBANK_GET_BALANCE',
+            address,
+            denom: assetRecord.denom,
+          });
+          balanceUpdater.update(balanceString);
+
+          // Create and return the virtual purse.
+          const vpc = makeBankPurseController(
+            bankChannel,
+            assetRecord.denom,
+            brand,
+            address,
+            subscriber,
+          );
+          return makeVirtualPurse(vpc, assetRecord);
         };
 
-        const assetRecord = brandToAssetRecord.get(brand);
-        if (!bankChannel) {
-          // Just emulate with a real purse.
-          return keepPurse(E(assetRecord.issuer).makeEmptyPurse());
-        }
-
-        const addressToUpdater = denomToAddressUpdater.get(assetRecord.denom);
-
-        /** @type {PublishKit<Amount>} */
-        const { publisher, subscriber } = makePublishKit();
-        const balanceUpdater = makeBalanceUpdater(brand, publisher);
-
-        // Abort if we lost the race to another call.
-        addressToUpdater.init(address, balanceUpdater);
-
-        // Get the initial balance.
-        const balanceString = await bankChannel.toBridge({
-          type: 'VBANK_GET_BALANCE',
-          address,
-          denom: assetRecord.denom,
-        });
-        balanceUpdater.update(balanceString);
-
-        // Create and return the virtual purse.
-        const vpc = makeBankPurseController(
-          bankChannel,
-          assetRecord.denom,
-          brand,
-          address,
-          subscriber,
+        return purseProvider.provideAsync(
+          providerKey,
+          makePurse,
+          async (_key, purse) => {
+            // Move it from the provider to this Exo's storage
+            brandToVPurse.init(brand, purse);
+            addressDenomToPurse.delete(providerKey);
+          },
         );
-        return keepPurse(makeVirtualPurse(vpc, assetRecord));
       },
     },
   );

--- a/packages/vats/test/bootstrapTests/drivers.js
+++ b/packages/vats/test/bootstrapTests/drivers.js
@@ -1,0 +1,135 @@
+import { unmarshalFromVstorage } from '@agoric/internal/src/lib-chainStorage.js';
+import { slotToRemotable } from '@agoric/internal/src/storage-test-utils.js';
+import { boardSlottingMarshaller } from '../../tools/board-utils.js';
+
+/**
+ * @param {ReturnType<typeof makeRunUtils>} runUtils
+ * @param {import('@agoric/internal/src/storage-test-utils.js').FakeStorageKit} storage
+ * @param {import('../../tools/board-utils.js').AgoricNamesRemotes} agoricNamesRemotes
+ */
+export const makeWalletFactoryDriver = async (
+  runUtils,
+  storage,
+  agoricNamesRemotes,
+) => {
+  const { EV } = runUtils;
+
+  const walletFactoryStartResult = await EV.vat('bootstrap').consumeItem(
+    'walletFactoryStartResult',
+  );
+  const bankManager = await EV.vat('bootstrap').consumeItem('bankManager');
+  const namesByAddressAdmin = await EV.vat('bootstrap').consumeItem(
+    'namesByAddressAdmin',
+  );
+
+  const marshaller = boardSlottingMarshaller(slotToRemotable);
+
+  /**
+   * @param {string} walletAddress
+   * @param {import('@agoric/smart-wallet/src/smartWallet.js').SmartWallet} walletPresence
+   * @param {boolean} isNew
+   */
+  const makeWalletDriver = (walletAddress, walletPresence, isNew) => ({
+    isNew,
+
+    /**
+     * @param {import('@agoric/smart-wallet/src/offers.js').OfferSpec} offer
+     * @returns {Promise<void>}
+     */
+    executeOffer(offer) {
+      const offerCapData = marshaller.toCapData(
+        harden({
+          method: 'executeOffer',
+          offer,
+        }),
+      );
+      return EV(walletPresence).handleBridgeAction(offerCapData, true);
+    },
+    /**
+     * @param {import('@agoric/smart-wallet/src/offers.js').OfferSpec} offer
+     * @returns {Promise<void>}
+     */
+    sendOffer(offer) {
+      const offerCapData = marshaller.toCapData(
+        harden({
+          method: 'executeOffer',
+          offer,
+        }),
+      );
+
+      return EV.sendOnly(walletPresence).handleBridgeAction(offerCapData, true);
+    },
+    tryExitOffer(offerId) {
+      const capData = marshaller.toCapData(
+        harden({
+          method: 'tryExitOffer',
+          offerId,
+        }),
+      );
+      return EV(walletPresence).handleBridgeAction(capData, true);
+    },
+    /**
+     * @template {(brands: Record<string, Brand>, ...rest: any) => import('@agoric/smart-wallet/src/offers.js').OfferSpec} M offer maker function
+     * @param {M} makeOffer
+     * @param {Parameters<M>[1]} firstArg
+     * @param {Parameters<M>[2]} [secondArg]
+     * @returns {Promise<void>}
+     */
+    executeOfferMaker(makeOffer, firstArg, secondArg) {
+      const offer = makeOffer(agoricNamesRemotes.brand, firstArg, secondArg);
+      return this.executeOffer(offer);
+    },
+    /**
+     * @template {(brands: Record<string, Brand>, ...rest: any) => import('@agoric/smart-wallet/src/offers.js').OfferSpec} M offer maker function
+     * @param {M} makeOffer
+     * @param {Parameters<M>[1]} firstArg
+     * @param {Parameters<M>[2]} [secondArg]
+     * @returns {Promise<void>}
+     */
+    sendOfferMaker(makeOffer, firstArg, secondArg) {
+      const offer = makeOffer(agoricNamesRemotes.brand, firstArg, secondArg);
+      return this.sendOffer(offer);
+    },
+
+    /**
+     * @returns {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord}
+     */
+    getCurrentWalletRecord() {
+      const fromCapData = (...args) =>
+        Reflect.apply(marshaller.fromCapData, marshaller, args);
+      return unmarshalFromVstorage(
+        storage.data,
+        `published.wallet.${walletAddress}.current`,
+        fromCapData,
+      );
+    },
+
+    /**
+     * @returns {import('@agoric/smart-wallet/src/smartWallet.js').UpdateRecord}
+     */
+    getLatestUpdateRecord() {
+      const fromCapData = (...args) =>
+        Reflect.apply(marshaller.fromCapData, marshaller, args);
+      return unmarshalFromVstorage(
+        storage.data,
+        `published.wallet.${walletAddress}`,
+        fromCapData,
+      );
+    },
+  });
+
+  return {
+    /**
+     * @param {string} walletAddress
+     * @returns {Promise<ReturnType<typeof makeWalletDriver>>}
+     */
+    async provideSmartWallet(walletAddress) {
+      const bank = await EV(bankManager).getBankForAddress(walletAddress);
+      return EV(walletFactoryStartResult.creatorFacet)
+        .provideSmartWallet(walletAddress, bank, namesByAddressAdmin)
+        .then(([walletPresence, isNew]) =>
+          makeWalletDriver(walletAddress, walletPresence, isNew),
+        );
+    },
+  };
+};

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -1,21 +1,25 @@
 // @ts-check
-/* eslint-disable import/no-extraneous-dependencies */
+import { promises as fs } from 'fs';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
+import { basename } from 'path';
+import { inspect } from 'util';
+
 import { Fail } from '@agoric/assert';
 import { buildSwingset } from '@agoric/cosmic-swingset/src/launch-chain.js';
-import { BridgeId, VBankAccount } from '@agoric/internal';
+import { BridgeId, makeTracer, VBankAccount } from '@agoric/internal';
 import { unmarshalFromVstorage } from '@agoric/internal/src/lib-chainStorage.js';
-import {
-  makeFakeStorageKit,
-  slotToRemotable,
-} from '@agoric/internal/src/storage-test-utils.js';
+import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { initSwingStore } from '@agoric/swing-store';
 import { kunser } from '@agoric/swingset-liveslots/test/kmarshal.js';
 import { loadSwingsetConfigFile } from '@agoric/swingset-vat';
+/* eslint-disable import/no-extraneous-dependencies */
 import { E } from '@endo/eventual-send';
 import { makeQueue } from '@endo/stream';
-import { promises as fs } from 'fs';
-import { resolve as importMetaResolve } from 'import-meta-resolve';
-import { boardSlottingMarshaller } from '../../tools/board-utils.js';
+import { TimeMath } from '@agoric/time';
+import {
+  boardSlottingMarshaller,
+  slotToBoardRemote,
+} from '../../tools/board-utils.js';
 
 // to retain for ESlint, used by typedef
 E;
@@ -228,7 +232,7 @@ export const makeSwingsetTestKit = async (
   const configPath = await getNodeTestVaultsConfig(bundleDir, configSpecifier);
   const swingStore = initSwingStore();
   const { kernelStorage, hostStorage } = swingStore;
-  const { fromCapData } = boardSlottingMarshaller(slotToRemotable);
+  const { fromCapData } = boardSlottingMarshaller(slotToBoardRemote);
 
   const readLatest = path => {
     const data = unmarshalFromVstorage(storage.data, path, fromCapData);
@@ -276,6 +280,7 @@ export const makeSwingsetTestKit = async (
           // denom: 'ibc/toyatom',
           // type: 'VBANK_GET_BALANCE'
           case 'VBANK_GET_BALANCE': {
+            // TODO consider letting config specify vbank assets
             // empty balances for test.
             return '0';
           }
@@ -380,3 +385,4 @@ export const makeSwingsetTestKit = async (
     timer,
   };
 };
+/** @typedef {Awaited<ReturnType<typeof makeSwingsetTestKit>>} SwingsetTestKit */

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -248,6 +248,13 @@ export const makeSwingsetTestKit = async (
   const bridgeOutbound = (bridgeId, obj) => {
     switch (bridgeId) {
       case BridgeId.BANK: {
+        trace(
+          'bridgeOutbound BANK',
+          obj.type,
+          obj.recipient,
+          obj.amount,
+          obj.denom,
+        );
         // bridgeOutbound bank : {
         //   moduleName: 'vbank/reserve',
         //   type: 'VBANK_GET_MODULE_ACCOUNT_ADDRESS'

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -194,19 +194,9 @@ export const getNodeTestVaultsConfig = async (
     config.coreProposals = config.coreProposals.filter(
       v => v !== '@agoric/pegasus/scripts/init-core.js',
     );
-    for (const p of config.coreProposals) {
-      if (
-        typeof p === 'object' &&
-        p.module === '@agoric/inter-protocol/scripts/add-collateral-core.js' &&
-        p.entrypoint === 'defaultProposalBuilder'
-      ) {
-        // set vault interestRateValue high to accelerate liquidation
-        p.args[0].interestRateValue = 10 * 100; // 10x APR
-      }
-    }
   }
 
-  const testConfigPath = `${bundleDir}/decentral-test-vaults-config.json`;
+  const testConfigPath = `${bundleDir}/${basename(specifier)}`;
   await fs.writeFile(testConfigPath, JSON.stringify(config), 'utf-8');
   return testConfigPath;
 };

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -22,6 +22,8 @@ E;
 
 const sink = () => {};
 
+const trace = makeTracer('BSTSupport', false);
+
 /** @typedef {Awaited<ReturnType<import('@agoric/vats/src/core/lib-boot').makeBootstrap>>} BootstrapRootObject */
 
 /** @type {Record<keyof BootstrapRootObject, keyof BootstrapRootObject>} */
@@ -238,8 +240,11 @@ export const makeSwingsetTestKit = async (
   const { kernelStorage, hostStorage } = swingStore;
   const { fromCapData } = boardSlottingMarshaller(slotToRemotable);
 
-  const readLatest = path =>
-    unmarshalFromVstorage(storage.data, path, fromCapData);
+  const readLatest = path => {
+    const data = unmarshalFromVstorage(storage.data, path, fromCapData);
+    trace('readLatest', path, 'returning', inspect(data, false, 20, true));
+    return data;
+  };
 
   let lastNonce = 0n;
 

--- a/packages/vats/test/bootstrapTests/test-liquidation.js
+++ b/packages/vats/test/bootstrapTests/test-liquidation.js
@@ -1,0 +1,558 @@
+/* eslint-disable no-lone-blocks, no-await-in-loop */
+// @ts-check
+/**
+ * @file Bootstrap test integration vaults with smart-wallet
+ */
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { Fail, NonNullish } from '@agoric/assert';
+import {
+  makeParseAmount,
+  Offers,
+} from '@agoric/inter-protocol/src/clientSupport.js';
+import {
+  SECONDS_PER_HOUR,
+  SECONDS_PER_MINUTE,
+} from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
+import { makeAgoricNamesRemotesFromFakeStorage } from '../../tools/board-utils.js';
+import {
+  makeGovernanceDriver,
+  makePriceFeedDriver,
+  makeWalletFactoryDriver,
+} from './drivers.js';
+import { makeSwingsetTestKit } from './supports.js';
+
+/**
+ * @type {import('ava').TestFn<Awaited<ReturnType<typeof makeDefaultTestContext>>>}
+ */
+const test = anyTest;
+
+// presently all these tests use one collateral manager
+const collateralBrandKey = 'ATOM';
+
+//#region Product spec
+const setup = /** @type {const} */ ({
+  vaults: [
+    {
+      atom: 15,
+      ist: 100,
+      debt: 100.5,
+    },
+    {
+      atom: 15,
+      ist: 103,
+      debt: 103.515,
+    },
+    {
+      atom: 15,
+      ist: 105,
+      debt: 105.525,
+    },
+  ],
+  bids: [
+    {
+      give: '80IST',
+      discount: 0.1,
+    },
+    {
+      give: '90IST',
+      price: 9.0,
+    },
+    {
+      give: '150IST',
+      discount: 0.15,
+    },
+  ],
+  price: {
+    starting: 12.34,
+    trigger: 9.99,
+  },
+  auction: {
+    start: {
+      collateral: 45,
+      debt: 309.54,
+    },
+  },
+});
+
+const outcome = /** @type {const} */ ({
+  bids: [
+    {
+      payouts: {
+        Bid: 0,
+        Collateral: 8.897786,
+      },
+    },
+    {
+      payouts: {
+        Bid: 0,
+        Collateral: 10.01001,
+      },
+    },
+    {
+      payouts: {
+        Bid: 10.46,
+        Collateral: 16.432903,
+      },
+    },
+  ],
+  reserve: {
+    allocations: {
+      ATOM: 0.30985,
+    },
+    shortfall: 0,
+  },
+  vaultsSpec: [
+    {
+      locked: 3.373,
+    },
+    {
+      locked: 3.024,
+    },
+    {
+      locked: 2.792,
+    },
+  ],
+  // TODO match spec https://github.com/Agoric/agoric-sdk/issues/7837
+  vaultsActual: [
+    {
+      locked: 3.525747,
+    },
+    {
+      locked: 3.181519,
+    },
+    {
+      locked: 2.642185,
+    },
+  ],
+});
+//#endregion
+
+const scale6 = x => BigInt(Math.round(x * 1_000_000));
+const DebtLimitValue = scale6(100_000);
+
+const likePayouts = ({ Bid, Collateral }) => ({
+  Collateral: {
+    value: scale6(Collateral),
+  },
+  Bid: {
+    value: scale6(Bid),
+  },
+});
+
+const makeDefaultTestContext = async t => {
+  console.time('DefaultTestContext');
+  const swingsetTestKit = await makeSwingsetTestKit(t, 'bundles/vaults', {
+    configSpecifier: '@agoric/vats/decentral-main-vaults-config.json',
+  });
+
+  const { runUtils, storage } = swingsetTestKit;
+  console.timeLog('DefaultTestContext', 'swingsetTestKit');
+  const { EV } = runUtils;
+
+  // Wait for ATOM to make it into agoricNames
+  await EV.vat('bootstrap').consumeItem('vaultFactoryKit');
+  console.timeLog('DefaultTestContext', 'vaultFactoryKit');
+
+  // has to be late enough for agoricNames data to have been published
+  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(
+    swingsetTestKit.storage,
+  );
+  agoricNamesRemotes.brand.ATOM || Fail`ATOM missing from agoricNames`;
+  console.timeLog('DefaultTestContext', 'agoricNamesRemotes');
+
+  const walletFactoryDriver = await makeWalletFactoryDriver(
+    runUtils,
+    storage,
+    agoricNamesRemotes,
+  );
+  console.timeLog('DefaultTestContext', 'walletFactoryDriver');
+
+  const governanceDriver = await makeGovernanceDriver(
+    swingsetTestKit,
+    agoricNamesRemotes,
+    walletFactoryDriver,
+    // TODO read from the config file
+    [
+      'agoric1gx9uu7y6c90rqruhesae2t7c2vlw4uyyxlqxrx',
+      'agoric1d4228cvelf8tj65f4h7n2td90sscavln2283h5',
+      'agoric14543m33dr28x7qhwc558hzlj9szwhzwzpcmw6a',
+    ],
+  );
+  console.timeLog('DefaultTestContext', 'governanceDriver');
+
+  const priceFeedDriver = await makePriceFeedDriver(
+    storage,
+    agoricNamesRemotes,
+    walletFactoryDriver,
+    // TODO read from the config file
+    [
+      'agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr',
+      'agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8',
+      'agoric144rrhh4m09mh7aaffhm6xy223ym76gve2x7y78',
+      'agoric19d6gnr9fyp6hev4tlrg87zjrzsd5gzr5qlfq2p',
+      'agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj',
+    ],
+  );
+
+  console.timeLog('DefaultTestContext', 'priceFeedDriver');
+
+  console.timeEnd('DefaultTestContext');
+
+  return {
+    ...swingsetTestKit,
+    agoricNamesRemotes,
+    governanceDriver,
+    priceFeedDriver,
+    walletFactoryDriver,
+  };
+};
+
+test.before(async t => {
+  t.context = await makeDefaultTestContext(t);
+});
+test.after.always(t => {
+  return t.context.shutdown && t.context.shutdown();
+});
+
+// Reference: Flow 1 from https://github.com/Agoric/agoric-sdk/issues/7123
+test.serial('scenario: Flow 1', async t => {
+  const {
+    advanceTimeBy,
+    advanceTimeTo,
+    agoricNamesRemotes,
+    governanceDriver,
+    priceFeedDriver,
+    readLatest,
+    walletFactoryDriver,
+  } = t.context;
+
+  // price feed logic treats zero time as "unset" so advance to nonzero
+  await advanceTimeBy(1, 'seconds');
+
+  await priceFeedDriver.setPrice(12.34);
+
+  // raise the VaultFactory DebtLimit
+  await governanceDriver.changeParams(
+    agoricNamesRemotes.instance.VaultFactory,
+    {
+      DebtLimit: {
+        brand: agoricNamesRemotes.brand.IST,
+        value: DebtLimitValue,
+      },
+    },
+    {
+      paramPath: {
+        key: {
+          collateralBrand: agoricNamesRemotes.brand.ATOM,
+        },
+      },
+    },
+  );
+
+  // raise the PSM MintLimit
+  await governanceDriver.changeParams(
+    agoricNamesRemotes.instance['psm-IST-USDC_axl'],
+    {
+      MintLimit: {
+        brand: agoricNamesRemotes.brand.IST,
+        value: DebtLimitValue, // reuse
+      },
+    },
+  );
+
+  // confirm Relevant Governance Parameter Assumptions
+  t.like(readLatest('published.vaultFactory.managers.manager0.governance'), {
+    current: {
+      DebtLimit: { value: { value: DebtLimitValue } },
+      InterestRate: {
+        type: 'ratio',
+        value: { numerator: { value: 1n }, denominator: { value: 100n } },
+      },
+      LiquidationMargin: {
+        type: 'ratio',
+        value: { numerator: { value: 150n }, denominator: { value: 100n } },
+      },
+      LiquidationPadding: {
+        type: 'ratio',
+        value: { numerator: { value: 25n }, denominator: { value: 100n } },
+      },
+      LiquidationPenalty: {
+        type: 'ratio',
+        value: { numerator: { value: 1n }, denominator: { value: 100n } },
+      },
+      MintFee: {
+        type: 'ratio',
+        value: { numerator: { value: 50n }, denominator: { value: 10_000n } },
+      },
+    },
+  });
+  t.like(readLatest('published.auction.governance'), {
+    current: {
+      AuctionStartDelay: { type: 'relativeTime', value: { relValue: 2n } },
+      ClockStep: {
+        type: 'relativeTime',
+        value: { relValue: 3n * SECONDS_PER_MINUTE },
+      },
+      DiscountStep: { type: 'nat', value: 500n }, // 5%
+      LowestRate: { type: 'nat', value: 6500n }, // 65%
+      PriceLockPeriod: {
+        type: 'relativeTime',
+        value: { relValue: SECONDS_PER_HOUR / 2n },
+      },
+      StartFrequency: {
+        type: 'relativeTime',
+        value: { relValue: SECONDS_PER_HOUR },
+      },
+      StartingRate: { type: 'nat', value: 10500n }, // 105%
+    },
+  });
+
+  const minter = await walletFactoryDriver.provideSmartWallet('agoric1minter');
+
+  for (let i = 0; i < setup.vaults.length; i += 1) {
+    const offerId = `open-vault${i}`;
+    await minter.executeOfferMaker(Offers.vaults.OpenVault, {
+      offerId,
+      collateralBrandKey,
+      wantMinted: setup.vaults[i].ist,
+      giveCollateral: setup.vaults[i].atom,
+    });
+    t.like(minter.getLatestUpdateRecord(), {
+      updated: 'offerStatus',
+      status: { id: offerId, numWantsSatisfied: 1 },
+    });
+  }
+
+  // Verify starting balances
+  t.like(readLatest('published.vaultFactory.managers.manager0.vaults.vault0'), {
+    debtSnapshot: { debt: { value: scale6(setup.vaults[0].debt) } },
+    locked: { value: scale6(setup.vaults[0].atom) },
+    vaultState: 'active',
+  });
+  t.like(readLatest('published.vaultFactory.managers.manager0.vaults.vault1'), {
+    debtSnapshot: { debt: { value: scale6(setup.vaults[1].debt) } },
+    locked: { value: scale6(setup.vaults[1].atom) },
+    vaultState: 'active',
+  });
+  t.like(readLatest('published.vaultFactory.managers.manager0.vaults.vault2'), {
+    debtSnapshot: { debt: { value: scale6(setup.vaults[2].debt) } },
+    locked: { value: scale6(setup.vaults[2].atom) },
+    vaultState: 'active',
+  });
+
+  const buyer = await walletFactoryDriver.provideSmartWallet('agoric1buyer');
+  {
+    // ---------------
+    //  Place bids
+    // ---------------
+
+    const parseAmount = makeParseAmount(agoricNamesRemotes, Error);
+    await buyer.sendOffer(
+      Offers.psm.swap(
+        agoricNamesRemotes.instance['psm-IST-USDC_axl'],
+        agoricNamesRemotes.brand,
+        {
+          offerId: 'print-ist',
+          wantMinted: 1_000,
+          pair: ['IST', 'USDC_axl'],
+        },
+      ),
+    );
+
+    const maxBuy = '10000ATOM';
+
+    // bids are long-lasting offers so we can't wait here for completion
+    await buyer.sendOfferMaker(Offers.auction.Bid, {
+      offerId: 'bid1',
+      give: setup.bids[0].give,
+      discount: setup.bids[0].discount,
+      maxBuy,
+      parseAmount,
+    });
+
+    t.like(readLatest('published.wallet.agoric1buyer'), {
+      status: {
+        id: 'bid1',
+        result: 'Your bid has been accepted',
+        payouts: undefined,
+      },
+    });
+    await buyer.sendOfferMaker(Offers.auction.Bid, {
+      offerId: 'bid2',
+      give: setup.bids[1].give,
+      price: setup.bids[1].price,
+      maxBuy,
+      parseAmount,
+    });
+    t.like(readLatest('published.wallet.agoric1buyer'), {
+      status: {
+        id: 'bid2',
+        result: 'Your bid has been accepted',
+        payouts: undefined,
+      },
+    });
+    await buyer.sendOfferMaker(Offers.auction.Bid, {
+      offerId: 'bid3',
+      give: setup.bids[2].give,
+      discount: setup.bids[2].discount,
+      maxBuy,
+      parseAmount,
+    });
+  }
+  t.like(readLatest('published.wallet.agoric1buyer'), {
+    status: {
+      id: 'bid3',
+      result: 'Your bid has been accepted',
+      payouts: undefined,
+    },
+  });
+
+  {
+    // ---------------
+    //  Change price to trigger liquidation
+    // ---------------
+
+    await priceFeedDriver.setPrice(9.99);
+
+    // check nothing liquidating yet
+    /** @type {import('@agoric/inter-protocol/src/auction/scheduler.js').ScheduleNotification} */
+    const liveSchedule = readLatest('published.auction.schedule');
+    t.is(liveSchedule.activeStartTime, null);
+    t.like(readLatest('published.vaultFactory.managers.manager0.metrics'), {
+      numActiveVaults: setup.vaults.length,
+      numLiquidatingVaults: 0,
+    });
+
+    // advance time to start an auction
+    await advanceTimeTo(NonNullish(liveSchedule.nextDescendingStepTime));
+    t.like(readLatest('published.vaultFactory.managers.manager0.metrics'), {
+      numActiveVaults: 0,
+      numLiquidatingVaults: setup.vaults.length,
+      liquidatingCollateral: {
+        value: scale6(setup.auction.start.collateral),
+      },
+      liquidatingDebt: { value: scale6(setup.auction.start.debt) },
+    });
+
+    console.log('step 1 of 10');
+    await advanceTimeBy(3, 'minutes');
+    t.like(readLatest('published.auction.book0'), {
+      collateralAvailable: { value: scale6(setup.auction.start.collateral) },
+      startCollateral: { value: scale6(setup.auction.start.collateral) },
+      startProceedsGoal: { value: scale6(setup.auction.start.debt) },
+    });
+
+    console.log('step 2 of 10');
+    await advanceTimeBy(3, 'minutes');
+
+    console.log('step 3 of 10');
+    await advanceTimeBy(3, 'minutes');
+    // XXX updates for bid1 and bid2 are appended in the same turn so readLatest gives bid2
+    // NB: console output shows 8897786n payout which matches spec 8.897ATOM
+    // t.like(readLatest('published.wallet.agoric1buyer'), {
+    //   status: {
+    //     id: 'bid1',
+    //     payouts: {
+    //       Bid: { value: 0n },
+    //       Collateral: { value: scale6(outcome.bids[0].payouts.Collateral) },
+    //     },
+    //   },
+    // });
+
+    t.like(readLatest('published.wallet.agoric1buyer'), {
+      status: {
+        id: 'bid2',
+        payouts: likePayouts(outcome.bids[1].payouts),
+      },
+    });
+
+    console.log('step 4 of 10');
+    await advanceTimeBy(3, 'minutes');
+
+    console.log('step 5 of 10');
+    await advanceTimeBy(3, 'minutes');
+    t.like(readLatest('published.auction.book0'), {
+      collateralAvailable: { value: 9659301n },
+    });
+
+    console.log('step 6 of 10');
+    await advanceTimeBy(3, 'minutes');
+
+    console.log('step 7 of 10');
+    await advanceTimeBy(3, 'minutes');
+
+    console.log('step 8 of 10');
+    await advanceTimeBy(3, 'minutes');
+    // Not part of product spec
+    t.like(readLatest('published.vaultFactory.managers.manager0.metrics'), {
+      numActiveVaults: 0,
+      numLiquidationsCompleted: setup.vaults.length,
+      numLiquidatingVaults: 0,
+      retainedCollateral: { value: 0n },
+      totalCollateral: { value: 0n },
+      totalCollateralSold: { value: 35340699n },
+      totalDebt: { value: 0n },
+      totalOverageReceived: { value: 0n },
+      totalProceedsReceived: { value: 309540000n },
+      totalShortfallReceived: { value: 0n },
+    });
+
+    console.log('step 9 of 10');
+    await advanceTimeBy(3, 'minutes');
+
+    console.log('step 10 of 10');
+    await advanceTimeBy(3, 'minutes');
+
+    console.log('step 11 of 10');
+    await advanceTimeBy(3, 'minutes');
+
+    // bid3 still live because it's not fully satisfied
+    const { liveOffers } = readLatest('published.wallet.agoric1buyer.current');
+    t.is(liveOffers[0][1].id, 'bid3');
+    // exit to get payouts
+    await buyer.tryExitOffer('bid3');
+    t.like(readLatest('published.wallet.agoric1buyer'), {
+      status: {
+        id: 'bid3',
+        payouts: likePayouts(outcome.bids[2].payouts),
+      },
+    });
+
+    // check vault balances
+    t.like(
+      readLatest('published.vaultFactory.managers.manager0.vaults.vault0'),
+      {
+        debt: undefined,
+        vaultState: 'liquidated',
+        locked: { value: scale6(outcome.vaultsActual[0].locked) },
+      },
+    );
+    t.like(
+      readLatest('published.vaultFactory.managers.manager0.vaults.vault1'),
+      {
+        debt: undefined,
+        vaultState: 'liquidated',
+        locked: { value: scale6(outcome.vaultsActual[1].locked) },
+      },
+    );
+    t.like(
+      readLatest('published.vaultFactory.managers.manager0.vaults.vault2'),
+      {
+        debt: undefined,
+        vaultState: 'liquidated',
+        locked: { value: scale6(outcome.vaultsActual[2].locked) },
+      },
+    );
+  }
+
+  // check reserve balances
+  t.like(readLatest('published.reserve.metrics'), {
+    allocations: {
+      ATOM: { value: scale6(outcome.reserve.allocations.ATOM) },
+      // not part of product spec
+      Fee: { value: scale6(1.54) },
+    },
+    shortfallBalance: { value: scale6(outcome.reserve.shortfall) },
+  });
+});

--- a/packages/vats/test/bootstrapTests/test-vats-restart.js
+++ b/packages/vats/test/bootstrapTests/test-vats-restart.js
@@ -11,7 +11,8 @@ import { Fail } from '@agoric/assert';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { makeAgoricNamesRemotesFromFakeStorage } from '../../tools/board-utils.js';
-import { makeSwingsetTestKit, makeWalletFactoryDriver } from './supports.js';
+import { makeSwingsetTestKit } from './supports.js';
+import { makeWalletFactoryDriver } from './drivers.js';
 
 /**
  * @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>}

--- a/packages/vats/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-integration.js
@@ -13,7 +13,8 @@ import {
   makeAgoricNamesRemotesFromFakeStorage,
   slotToBoardRemote,
 } from '../../tools/board-utils.js';
-import { makeSwingsetTestKit, makeWalletFactoryDriver } from './supports.js';
+import { makeSwingsetTestKit } from './supports.js';
+import { makeWalletFactoryDriver } from './drivers.js';
 
 /**
  * @type {import('ava').TestFn<Awaited<ReturnType<typeof makeDefaultTestContext>>>}

--- a/packages/vats/test/bootstrapTests/test-vaults-performance.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-performance.js
@@ -13,7 +13,8 @@ import engineGC from '@agoric/swingset-vat/src/lib-nodejs/engine-gc.js';
 
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { makeAgoricNamesRemotesFromFakeStorage } from '../../tools/board-utils.js';
-import { makeSwingsetTestKit, makeWalletFactoryDriver } from './supports.js';
+import { makeSwingsetTestKit } from './supports.js';
+import { makeWalletFactoryDriver } from './drivers.js';
 
 /**
  * @type {import('ava').TestFn<Awaited<ReturnType<typeof makeDefaultTestContext>>>}

--- a/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
@@ -11,7 +11,8 @@ import { Fail, NonNullish } from '@agoric/assert';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { Far, makeMarshal } from '@endo/marshal';
 import { makeAgoricNamesRemotesFromFakeStorage } from '../../tools/board-utils.js';
-import { makeSwingsetTestKit, makeWalletFactoryDriver } from './supports.js';
+import { makeSwingsetTestKit } from './supports.js';
+import { makeWalletFactoryDriver } from './drivers.js';
 
 // presently all these tests use one collateral manager
 const collateralBrandKey = 'ATOM';

--- a/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
@@ -10,6 +10,7 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { Fail, NonNullish } from '@agoric/assert';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { Far, makeMarshal } from '@endo/marshal';
+import { SECONDS_PER_YEAR } from '@agoric/inter-protocol/src/interest.js';
 import { makeAgoricNamesRemotesFromFakeStorage } from '../../tools/board-utils.js';
 import { makeSwingsetTestKit } from './supports.js';
 import { makeWalletFactoryDriver } from './drivers.js';
@@ -100,6 +101,7 @@ test.serial('re-bootstrap', async t => {
   const assertWalletCount = (walletsProvisioned, message) => {
     // eslint-disable-next-line no-unused-vars
     const metrics = oldContext.readLatest('published.provisionPool.metrics');
+    // FIXME make wallet provisioning use the provisionPool
     // disabled while wallet provisioning bypasses provisionPool
     // t.like(metrics, { walletsProvisioned }, message);
   };
@@ -395,11 +397,15 @@ test.serial('adjust balance of vault opened before restart', async t => {
 
 // charge interest to force a liquidation and verify it starts
 test.serial('force liquidation', async t => {
-  const { advanceTime, readCollateralMetrics, readRewardPoolBalance } =
-    t.context.shared;
+  const {
+    advanceTimeBy,
+    jumpTimeTo,
+    readCollateralMetrics,
+    readRewardPoolBalance,
+  } = t.context.shared;
 
   // advance a year to drive interest charges
-  await advanceTime(365, 'days');
+  await jumpTimeTo(SECONDS_PER_YEAR);
   // accrues massively
   t.is(readRewardPoolBalance(), 683693581n);
   t.like(readCollateralMetrics(0), {
@@ -409,12 +415,12 @@ test.serial('force liquidation', async t => {
 
   // liquidation will have been skipped because time skipped ahead
   // so now advance slowly
-  await advanceTime(1, 'hours');
+  await advanceTimeBy(1, 'hours');
   t.like(readCollateralMetrics(0), {
     numActiveVaults: 2,
     numLiquidatingVaults: 0,
   });
-  await advanceTime(1, 'hours');
+  await advanceTimeBy(1, 'hours');
   t.like(readCollateralMetrics(0), {
     liquidatingCollateral: { value: 9_000_000n },
     liquidatingDebt: { value: 696_421_994n },
@@ -422,7 +428,7 @@ test.serial('force liquidation', async t => {
     numLiquidatingVaults: 1,
   });
 
-  await advanceTime(1, 'hours');
+  await advanceTimeBy(1, 'hours');
   t.like(readCollateralMetrics(0), {
     numActiveVaults: 1,
     numLiquidatingVaults: 1,

--- a/packages/vats/test/test-board-utils.js
+++ b/packages/vats/test/test-board-utils.js
@@ -155,6 +155,7 @@ test('makeAgoricNamesRemotesFromFakeStorage', t => {
     'brand',
     'instance',
     'reverse',
+    'vbankAsset',
   ]);
   t.true(
     Object.keys(agoricNamesRemotes.reverse).every(k => k.startsWith('board0')),

--- a/packages/vats/tools/board-utils.js
+++ b/packages/vats/tools/board-utils.js
@@ -85,7 +85,6 @@ export const makeAgoricNamesRemotesFromFakeStorage = fakeStorageKit => {
       { ...info, brand: tables.brand[info.issuerName] },
     ]),
   );
-  console.log('DEBUG vbankAsset', vbankAsset);
   return { ...tables, reverse, vbankAsset };
 };
 harden(makeAgoricNamesRemotesFromFakeStorage);


### PR DESCRIPTION
closes: #7791

## Description

This introduces a bootstrap test of liquidations (and all the new supports needed). It closes 7791 because over the course of testing I validated that most errors we weren't seeing until the docker manual testing, we were seeing in this test. In particular https://github.com/Agoric/agoric-sdk/issues/7844 which this test hit immediately.

This also includes the fix for 7844, https://github.com/Agoric/agoric-sdk/pull/7845, because it got bumped from the merge queue. This is stacked on it and since that PR is approved I'm landing the same commits here. It's appropriate to bundle since this new test serves as the requisite regression test for 7844.

### Security Considerations

--

### Scaling Considerations

--

### Documentation Considerations

This should be kept in sync with the product spec.

### Testing Considerations

It's a test!