### PR TITLE
upgrade-test: cached apt

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -707,12 +707,16 @@ jobs:
 
   test-docker-build:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1 
     timeout-minutes: 60
     strategy:
       matrix:
         bootstrap-version: ['test', 'main']
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: docker build (sdk)
         run: cd packages/deployment && ./scripts/test-docker-build.sh | $TEST_COLLECT
       - name: docker build upgrade test

--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -18,6 +18,9 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-8 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 WORKDIR /usr/src/agoric-sdk/
 
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get update && apt-get install -y tmux
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-7-2 /root/.agoric /root/.agoric
@@ -32,6 +35,9 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-8-1 UPGRADE_TO=agoric-upgrade-9 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get update && apt-get install -y tmux
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-8 /root/.agoric /root/.agoric
@@ -46,6 +52,9 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-9 UPGRADE_TO=agoric-upgrade-10 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get update && apt-get install -y tmux
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-8-1 /root/.agoric /root/.agoric
@@ -62,6 +71,9 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-10 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get update && apt-get install -y tmux
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-9 /root/.agoric /root/.agoric
@@ -77,10 +89,12 @@ ENV THIS_NAME=agoric-upgrade-11 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 # this boot doesn't need an upgrade
 
 WORKDIR /usr/src/agoric-sdk/
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get update && apt-get install -y tmux
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-10 /root/.agoric /root/.agoric
-RUN apt install -y tmux
 SHELL ["/bin/bash", "-c"]
 RUN chmod +x ./upgrade-test-scripts/*.sh
 ENTRYPOINT /usr/src/agoric-sdk/upgrade-test-scripts/start_to_to.sh

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/bash_entrypoint.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/bash_entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -i
 cd /usr/src/agoric-sdk/ || exit 1
-tmux -V || apt install -y tmux
 
 if [[ $TMUX_USE_CC == "1" ]]; then
     TMUX_FLAGS="-CC -u"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/start_to_to.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/start_to_to.sh
@@ -3,8 +3,6 @@
 grep -qF 'env_setup.sh' /root/.bashrc || echo ". ./upgrade-test-scripts/env_setup.sh" >> /root/.bashrc
 grep -qF 'printKeys' /root/.bashrc || echo "printKeys" >> /root/.bashrc
 
-tmux -V || apt install -y tmux
-
 if [[ "$DEST" == "1" ]] && [[ "$TMUX" == "" ]]; then
   echo "launching entrypoint"
   cd /usr/src/agoric-sdk || exit 1


### PR DESCRIPTION
refs: #7797 

## Description

Use `RUN --mount` with a [cache mount type](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mounttypecache) dedicated to apt. We mainly use it to install tmux. This in effect:

1. Makes the install its own separate layer that can occur in parallel with other layer steps (except the apt install itself, since apt needs exclusive access to its files).
2. Avoids re-installing unless from scratch or if there's a tmux update available.

### Security Considerations

Minor, but we can ensure tmux is up-to-date.

### Scaling Considerations

### Documentation Considerations

### Testing Considerations
