### PR TITLE
detect and limit package cycles

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -40,6 +40,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+  dependency-graph:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install graphviz
+        run: sudo apt install -y graphviz
+
+      - name: Check for cycles
+        run: scripts/check-dependency-cycles.sh 4
+
   ##################
   # Lint tests
   # We run per package bc of https://github.com/typescript-eslint/typescript-eslint/issues/1192

--- a/scripts/check-dependency-cycles.sh
+++ b/scripts/check-dependency-cycles.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Errors if number of cycle edges detected is too great
+set -ueo pipefail
+
+MAX_EDGES=$1
+
+# one of these lines is "Cycles detected"
+LINE_COUNT=$(scripts/graph.sh |wc -l)
+
+CYCLIC_EDGE_COUNT=$((LINE_COUNT - 1))
+
+echo CYCLIC_EDGE_COUNT $CYCLIC_EDGE_COUNT
+
+if [[ $CYCLIC_EDGE_COUNT -gt $MAX_EDGES ]];
+then
+  echo Greater than MAX_EDGES "$MAX_EDGES"
+  exit 1
+fi
+
+echo Less than or equal to MAX_EDGES "$MAX_EDGES"

--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# scripts/graph.sh generates packages.png, a visualization of the internal
-# package dependency graph.
+# Generates visualizations of the internal package dependency graph.
 set -ueo pipefail
 DIR=$(dirname -- "${BASH_SOURCE[0]}")
 {
     echo 'digraph {'
+    # Left is depended upon the least and right the most.
     echo 'rankdir=LR'
     cat "$DIR"/../packages/*/package.json | jq -r --slurp '
         . as $all |
@@ -19,4 +19,15 @@ DIR=$(dirname -- "${BASH_SOURCE[0]}")
         "\"\(.from)\" -> \"\(.to)\""
     '
     echo '}'
-} | dot -Tpng > "$DIR"/../packages.png
+    # normalize
+} | dot -Tcanon >packages-graph.dot
+dot -Tpng <packages-graph.dot >"$DIR"/../packages-graph.png
+
+dot -Tsvg <packages-graph.dot >"$DIR"/../packages-graph.svg
+
+if acyclic packages-graph.dot | dot -Tcanon >packages-sans-cycles.dot; then
+    echo "No cycles in 'dependencies' of packages."
+else
+    echo "Cycles detected. These lines appear only in the original graph and not the acyclic variant:"
+    comm -23 <(sort packages-graph.dot) <(sort packages-sans-cycles.dot)
+fi


### PR DESCRIPTION
## Description

https://github.com/Agoric/agoric-sdk/pull/7260 burned down some cycles in service of https://github.com/Agoric/agoric-sdk/issues/4645 but it lingered and now it's pretty stale.

I'll wait for a better time and plan before updating that which does refactorings.

Meanwhile, it's worth getting in this script that detects `dependencies` cycles (whereas Lerna conflates those with `devDependencies`). This also removes some declared dependencies that aren't actual.


### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

CI