### PR TITLE
fix(xsnap): use newer xsnap-pub, with requirement for __has_builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ to use.
 * Node.js LTS (version 14.15.0 or higher)
   * we generally support the latest LTS release: use [nvm](https://github.com/nvm-sh/nvm) to keep your local system up-to-date
 * Yarn (`npm install -g yarn`)
+* gcc-10 or newer, or a compiler with `__has_builtin()`
 
 Any version of Yarn will do: the `.yarnrc` file should ensure that all
 commands use the specific checked-in version of Yarn (stored in

--- a/packages/xsnap/build.env
+++ b/packages/xsnap/build.env
@@ -1,4 +1,4 @@
 MODDABLE_URL=https://github.com/agoric-labs/moddable.git
 MODDABLE_COMMIT_HASH=46bbad5b8aa746c50b5f97aee1b1f235ab2a5903
 XSNAP_NATIVE_URL=https://github.com/agoric-labs/xsnap-pub
-XSNAP_NATIVE_COMMIT_HASH=056faf8c8930a20659dd4eaa3ebfae3a8b464c7f
+XSNAP_NATIVE_COMMIT_HASH=25abead6b762b49faee840aed5c544556112711a


### PR DESCRIPTION
This switches to a version of `xsnap-pub` that adds a compile-time assertion of the availability of `__has_builtin()`. This function was added to gcc-10, and was missing in gcc-9. XS can produce different heap snapshots depending upon whether this function is available or not (breaking consensus, which includes the heap snapshot hashes). By mandating its presence, we ensure that all instances will behave the same way, maintaining consensus.

closes #7829
