### PR TITLE
fix(xsnap): agd checks 'xsnap -n' for agoric-upgrade-10

### DIFF
--- a/bin/agd
+++ b/bin/agd
@@ -189,6 +189,17 @@ if $BUILD_ONLY; then
   exit 0
 fi
 
+# the xsnap binary lives in a platform-specific directory
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     platform=lin;;
+    Darwin*)    platform=mac;;
+    *)          platform=win;;
+esac
+# check the xsnap version against our baked-in notion of what version we should be using
+xsnap_version=$("${thisdir}/../packages/xsnap/xsnap-native/xsnap/build/bin/${platform}/release/xsnap-worker" -n)
+[[ "${xsnap_version}" == "agoric-upgrade-10" ]] || fatal "xsnap out of date"
+
 # Run the built Cosmos daemon.
 # shellcheck disable=SC2031
 export PATH="$thisdir/../packages/cosmic-swingset/bin:$PATH"

--- a/packages/xsnap/build.env
+++ b/packages/xsnap/build.env
@@ -1,4 +1,4 @@
 MODDABLE_URL=https://github.com/agoric-labs/moddable.git
 MODDABLE_COMMIT_HASH=46bbad5b8aa746c50b5f97aee1b1f235ab2a5903
 XSNAP_NATIVE_URL=https://github.com/agoric-labs/xsnap-pub
-XSNAP_NATIVE_COMMIT_HASH=25abead6b762b49faee840aed5c544556112711a
+XSNAP_NATIVE_COMMIT_HASH=2d8ccb76b8508e490d9e03972bb4c64f402d5135


### PR DESCRIPTION
This is a quick hack to assert that xsnap has been recompiled recently. `bin/agd` now runs `xsnap -n` to get the "network upgrade version", and asserts that it matches an expected value of `agoric-update-10`. If a user has somehow failed to recompile `xsnap`, their old copy won't understand the `-n` command, and `agd` will fail, rather than running a stale version (with highly confusing results).

refs #7012

