### PR TITLE
upgrade-test: split targets

### DIFF
--- a/packages/deployment/upgrade-test/Makefile
+++ b/packages/deployment/upgrade-test/Makefile
@@ -1,27 +1,43 @@
 REPOSITORY = agoric/upgrade-test
-dockerLabel = latest
-ifdef TARGET
-buildTargetFlag = --target $(TARGET)
-dockerLabel = $(TARGET)
-endif
+BOOTSTRAP_MODE?=main
+TARGET?=agoric-upgrade-11
+dockerLabel?=$(TARGET)
 ifdef TMUX_CC
 	tmuxCC=1
 else
 	tmuxCC=0
 endif
-@echo buildTargetFlag: $(buildTargetFlag)
+@echo target: $(TARGET)
 
 local_sdk:
 	(cd ../ && make docker-build-sdk)
 
+agoric-upgrade-7-2:
+	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --progress=plain --target agoric-upgrade-7-2 -t $(REPOSITORY):agoric-upgrade-7-2 -f Dockerfile upgrade-test-scripts
+
+agoric-upgrade-8: agoric-upgrade-7-2
+	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --progress=plain --target agoric-upgrade-8 -t $(REPOSITORY):agoric-upgrade-8 -f Dockerfile upgrade-test-scripts
+
+agoric-upgrade-8-1: agoric-upgrade-8
+	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --progress=plain --target agoric-upgrade-8-1 -t $(REPOSITORY):agoric-upgrade-8-1 -f Dockerfile upgrade-test-scripts
+
+agoric-upgrade-9: agoric-upgrade-8-1
+	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --progress=plain --target agoric-upgrade-9 -t $(REPOSITORY):agoric-upgrade-9 -f Dockerfile upgrade-test-scripts
+
+agoric-upgrade-10: agoric-upgrade-9
+	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --progress=plain --target agoric-upgrade-10 -t $(REPOSITORY):agoric-upgrade-10 -f Dockerfile upgrade-test-scripts
+
+agoric-upgrade-11: agoric-upgrade-10
+	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --progress=plain --target agoric-upgrade-11 -t $(REPOSITORY):agoric-upgrade-11 -f Dockerfile upgrade-test-scripts
+
 # build main bootstrap
-build:
-	docker build --build-arg BOOTSTRAP_MODE=main --progress=plain $(buildTargetFlag) -t $(REPOSITORY):$(dockerLabel) -f Dockerfile upgrade-test-scripts
+build: $(TARGET)
 
 # build test bootstrap
-build_test:
-	docker build --build-arg BOOTSTRAP_MODE=test --progress=plain $(buildTargetFlag) -t $(REPOSITORY):$(dockerLabel) -f Dockerfile upgrade-test-scripts
+build_test: BOOTSTRAP_MODE=test
+build_test: $(TARGET)
 
 run:
 	docker run --rm -it -e "DEST=1" -e "TMUX_USE_CC=$(tmuxCC)" -p 26656:26656 -p 26657:26657 -p 1317:1317 --entrypoint "/usr/src/agoric-sdk/upgrade-test-scripts/start_to_to.sh" -v "$${PWD}:/workspace" $(REPOSITORY):$(dockerLabel)
 
+.PHONY: local_sdk agoric-upgrade-7-2 agoric-upgrade-8 agoric-upgrade-8-1 agoric-upgrade-9 agoric-upgrade-10 agoric-upgrade-11 build build_test run


### PR DESCRIPTION
refs: #7797 

## Description

This PR splits make targets to align with docker targets, allowing a particular target to tag all the predecessors to avoid a rebuild just to get a particular tag. We also refactor makefile to use this behavior, simplifying steps.

### Security Considerations

### Scaling Considerations

### Documentation Considerations

No changes in documentation.

### Testing Considerations

This should slightly benefit cache and make testing better:

For example, this should not cause a rebuild (assuming no files were changed):
`make build TARGET=agoric-upgrade-10`
`make build run TARGET=agoric-upgrade-9`

This will cause a rebuild only to maintain separate cache for test and non-test bootstraps, but thereafter should not cause rebuild:
`make build_test TARGET=agoric-upgrade-10`
`make build_test run TARGET=agoric-upgrade-9`
