### PR TITLE
fix(vat-bank): getPurse race

### DIFF
--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { AmountMath, AssetKind, BrandShape } from '@agoric/ertp';
-import { E, Far } from '@endo/far';
+import { deeplyFulfilledObject } from '@agoric/internal';
+import { prepareGuardedAttenuator } from '@agoric/internal/src/callback.js';
 import {
   IterableEachTopicI,
   makeNotifierKit,
@@ -10,8 +11,8 @@ import {
 } from '@agoric/notifier';
 import { M, provideLazy } from '@agoric/store';
 import { makeDurableZone } from '@agoric/zone/durable.js';
-import { prepareGuardedAttenuator } from '@agoric/internal/src/callback.js';
-import { deeplyFulfilledObject } from '@agoric/internal';
+import { E, Far } from '@endo/far';
+import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
 import { BridgeHandlerI, BridgeScopedManagerI } from './bridge.js';
 import {
   makeVirtualPurseKitIKit,
@@ -404,6 +405,10 @@ const prepareBank = (
   const makeBalanceUpdater = prepareBalanceUpdater(zone);
   const makeBankPurseController = prepareBankPurseController(zone);
 
+  const addressDenomToPurse = zone.mapStore('addressDenomToPurse');
+  /** @type {import('@agoric/store/src/stores/store-utils.js').AtomicProvider<string, VirtualPurse>} */
+  const purseProvider = makeAtomicProvider(addressDenomToPurse);
+
   const makeBank = zone.exoClass(
     'Bank',
     BankI,
@@ -443,6 +448,7 @@ const prepareBank = (
           this.state.assetSubscriber,
         );
       },
+      /** @param {Brand} brand */
       async getPurse(brand) {
         const {
           bankChannel,
@@ -451,54 +457,53 @@ const prepareBank = (
           brandToAssetRecord,
           denomToAddressUpdater,
         } = this.state;
-
         if (brandToVPurse.has(brand)) {
           return brandToVPurse.get(brand);
         }
 
-        /** @param {ERef<VirtualPurse>} purseP */
-        const keepPurse = async purseP => {
-          const purse = await purseP;
-          // Need to recheck as we may have raced with another call.
-          if (brandToVPurse.has(brand)) {
-            return brandToVPurse.get(brand);
+        const assetRecord = brandToAssetRecord.get(brand);
+        const providerKey = `${address}:${assetRecord.denom}`;
+
+        /** @type {() => Promise<VirtualPurse>} */
+        const makePurse = async () => {
+          if (!bankChannel) {
+            // Just emulate with a real purse.
+            return E(assetRecord.issuer).makeEmptyPurse();
           }
-          brandToVPurse.init(brand, purse);
-          return purse;
+          const addressToUpdater = denomToAddressUpdater.get(assetRecord.denom);
+
+          /** @type {PublishKit<Amount>} */
+          const { publisher, subscriber } = makePublishKit();
+          const balanceUpdater = makeBalanceUpdater(brand, publisher);
+          addressToUpdater.init(address, balanceUpdater);
+          // Get the initial balance.
+          const balanceString = await bankChannel.toBridge({
+            type: 'VBANK_GET_BALANCE',
+            address,
+            denom: assetRecord.denom,
+          });
+          balanceUpdater.update(balanceString);
+
+          // Create and return the virtual purse.
+          const vpc = makeBankPurseController(
+            bankChannel,
+            assetRecord.denom,
+            brand,
+            address,
+            subscriber,
+          );
+          return makeVirtualPurse(vpc, assetRecord);
         };
 
-        const assetRecord = brandToAssetRecord.get(brand);
-        if (!bankChannel) {
-          // Just emulate with a real purse.
-          return keepPurse(E(assetRecord.issuer).makeEmptyPurse());
-        }
-
-        const addressToUpdater = denomToAddressUpdater.get(assetRecord.denom);
-
-        /** @type {PublishKit<Amount>} */
-        const { publisher, subscriber } = makePublishKit();
-        const balanceUpdater = makeBalanceUpdater(brand, publisher);
-
-        // Abort if we lost the race to another call.
-        addressToUpdater.init(address, balanceUpdater);
-
-        // Get the initial balance.
-        const balanceString = await bankChannel.toBridge({
-          type: 'VBANK_GET_BALANCE',
-          address,
-          denom: assetRecord.denom,
-        });
-        balanceUpdater.update(balanceString);
-
-        // Create and return the virtual purse.
-        const vpc = makeBankPurseController(
-          bankChannel,
-          assetRecord.denom,
-          brand,
-          address,
-          subscriber,
+        return purseProvider.provideAsync(
+          providerKey,
+          makePurse,
+          async (_key, purse) => {
+            // Move it from the provider to this Exo's storage
+            brandToVPurse.init(brand, purse);
+            addressDenomToPurse.delete(providerKey);
+          },
         );
-        return keepPurse(makeVirtualPurse(vpc, assetRecord));
       },
     },
   );


### PR DESCRIPTION
closes: #7844

## Description

The `getPurse` method in vat-bank had a race condition. This was observed in https://github.com/Agoric/agoric-sdk/pull/7804/ but first hypothesized as an artifact of testing. In further discussion with @michaelfig we determined this may be a real race handling error that hadn't yet been exercised in tests. (While the bank has coverage of multiple getPurse calls, none were with remote vats that had real latency).

Meanwhile, the same evening testing in Ollinet showed this race in a running chain,
- https://github.com/Agoric/agoric-sdk/issues/7844

This fixes the race condition by using the AtomicProvider. That utility assumes responsibility for the durable storage, and in this case the Exo is responsible for the durable storage. Since the provider has to be on the heap (in the prepare) this uses the provider to produce the value, and in the finish() it moves the value from the provider's store to the Exo's.

### Security Considerations

Reduces potential to exploit timing.

### Scaling Considerations

The pending purses require a new durable store that holds objects temporarily. To reduce IO, the store it uses could be an in-memory store or a new utility created that only manages the "pending" map and doesn't try to store durably. 

### Documentation Considerations

--

### Testing Considerations

In master we don't have test coverage for this race behavior. https://github.com/Agoric/agoric-sdk/pull/7804/ adds test-liquidation which fails before this change and passes after. I propose that we get this PR in first and once 7804 is landed it will serve as the regression test.