### PR TITLE
fix(auction): assets added after auction start don't set IST limit

### DIFF
--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -514,7 +514,11 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
               calcTargetRatio(),
             );
 
-            if (state.remainingProceedsGoal !== null) {
+            if (
+              state.remainingProceedsGoal !== null ||
+              // XXX use this as an indication that the auction is active
+              state.curAuctionPrice !== null
+            ) {
               const incrementToGoal = state.startProceedsGoal
                 ? AmountMath.subtract(nextProceedsGoal, state.startProceedsGoal)
                 : nextProceedsGoal;
@@ -625,7 +629,11 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
             Fail`capturedPriceForRound must be set before each round`;
           assert(capturedPriceForRound);
 
-          trace('set startPrice', capturedPriceForRound);
+          trace(
+            'set startPrice',
+            capturedPriceForRound,
+            this.state.startProceedsGoal,
+          );
           this.state.remainingProceedsGoal = this.state.startProceedsGoal;
           this.state.curAuctionPrice = multiplyRatios(
             capturedPriceForRound,

--- a/packages/inter-protocol/test/auction/test-auctionContract.js
+++ b/packages/inter-protocol/test/auction/test-auctionContract.js
@@ -1113,12 +1113,15 @@ test.serial('add assets to open auction', async t => {
   const liqSeat2 = await driver.depositCollateral(
     collateral.make(2000n),
     collateral,
+    { goal: bid.make(1000n) },
   );
   const resultL2 = await E(liqSeat2).getOfferResult();
   t.is(resultL2, 'deposited');
   await bookTracker.assertChange({
     collateralAvailable: { value: 2500n },
     startCollateral: { value: 3000n },
+    startProceedsGoal: bid.make(1250n),
+    remainingProceedsGoal: bid.make(1250n),
   });
 
   await driver.advanceTo(180n);
@@ -1139,6 +1142,8 @@ test.serial('add assets to open auction', async t => {
     currentPriceLevel: null,
     startPrice: null,
     startCollateral: { value: 0n },
+    remainingProceedsGoal: null,
+    startProceedsGoal: null,
   });
   await scheduleTracker.assertChange({
     nextDescendingStepTime: { absValue: 210n },


### PR DESCRIPTION
closes: #7842

## Description

If assets are added after the beginning of an auction, the auction might not track the required IST, and so might sell more than is desired.

This fixes that.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

There was a relevant test, but it was written before liquidating vaults specified the limit. I added that to the test, and with the fix, it showed that it was now capturing the limit.
