### PR TITLE
fix(vaults): address a divide-by-zero; correct penalty w/no bidders

### DIFF
--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -1892,9 +1892,10 @@ test('reinstate vault', async t => {
   t.deepEqual(aliceUpdate.value.locked, aeth.make(0n));
 
   // Reduce Bob's collateral by liquidation penalty
+  // bob's share is 7 * 158/258, which rounds up to 5
   const recoveredBobCollateral = AmountMath.subtract(
     bobCollateralAmount,
-    aeth.make(1n),
+    aeth.make(5n),
   );
   bobUpdate = await E(bobNotifier).getUpdateSince();
   t.is(bobUpdate.value.vaultState, Phase.ACTIVE);
@@ -1908,7 +1909,7 @@ test('reinstate vault', async t => {
   const m = await subscriptionTracker(t, metricsTopic);
   await m.assertLike({
     allocations: {
-      Aeth: aeth.make(8n),
+      Aeth: aeth.make(12n),
       Fee: run.makeEmpty(),
     },
   });
@@ -2856,9 +2857,9 @@ test('Bug 7784 reconstitute both', async t => {
     numLiquidationsAborted: 2,
   });
 
-  t.deepEqual(await E(aliceVault).getCollateralAmount(), aeth.make(14_998n));
+  t.deepEqual(await E(aliceVault).getCollateralAmount(), aeth.make(14_899n));
   t.deepEqual(await E(aliceVault).getCurrentDebt(), run.make(100_500n));
-  t.deepEqual(await E(bobVault).getCollateralAmount(), aeth.make(14_998n));
+  t.deepEqual(await E(bobVault).getCollateralAmount(), aeth.make(14_896n));
   t.deepEqual(await E(bobVault).getCurrentDebt(), run.make(103_515n));
   t.deepEqual(await E(carolVault).getCollateralAmount(), aeth.makeEmpty());
   t.deepEqual(await E(carolVault).getCurrentDebt(), run.makeEmpty());
@@ -2876,7 +2877,7 @@ test('Bug 7784 reconstitute both', async t => {
     ...reserveInitialState(run.makeEmpty()),
     shortfallBalance: run.make(5_525n),
     allocations: {
-      Aeth: aeth.make(1_419n),
+      Aeth: aeth.make(1_620n),
       Fee: run.makeEmpty(),
     },
   });
@@ -3148,4 +3149,144 @@ test('Bug 7796 missing lockedPrice', async t => {
       Fee: run.makeEmpty(),
     },
   });
+});
+
+test('Bug 7851 & no bidders', async t => {
+  const { zoe, aeth, run, rates: defaultRates } = t.context;
+
+  const rates = harden({
+    ...defaultRates,
+    liquidationPenalty: makeRatio(1n, run.brand),
+    liquidationMargin: run.makeRatio(150n),
+    mintFee: run.makeRatio(50n, 10_000n),
+  });
+  t.context.rates = rates;
+
+  const manualTimer = buildManualTimer();
+  const TEN_MINUTES = 10n * SECONDS_PER_MINUTE;
+  const services = await setupServices(
+    t,
+    makeRatio(1234n, run.brand, 100n, aeth.brand),
+    aeth.make(1000n),
+    manualTimer,
+    SECONDS_PER_WEEK,
+    500n,
+    {
+      DiscountStep: 500n,
+      StartFrequency: SECONDS_PER_HOUR,
+      ClockStep: TEN_MINUTES,
+    },
+  );
+
+  const {
+    vaultFactory: { aethVaultManager, aethCollateralManager },
+    auctioneerKit: auctKit,
+    priceAuthority,
+    reserveKit: { reserveCreatorFacet, reservePublicFacet },
+  } = services;
+  await E(reserveCreatorFacet).addIssuer(aeth.issuer, 'Aeth');
+
+  const cm = await E(aethVaultManager).getPublicFacet();
+  const aethVaultMetrics = await vaultManagerMetricsTracker(t, cm);
+  await aethVaultMetrics.assertInitial({
+    // present
+    numActiveVaults: 0,
+    numLiquidatingVaults: 0,
+    totalCollateral: aeth.make(0n),
+    totalDebt: run.make(0n),
+    retainedCollateral: aeth.make(0n),
+
+    // running
+    numLiquidationsCompleted: 0,
+    numLiquidationsAborted: 0,
+    totalOverageReceived: run.make(0n),
+    totalProceedsReceived: run.make(0n),
+    totalCollateralSold: aeth.make(0n),
+    liquidatingCollateral: aeth.make(0n),
+    liquidatingDebt: run.make(0n),
+    totalShortfallReceived: run.make(0n),
+  });
+
+  const openVault = (collateral, want) =>
+    E(zoe).offer(
+      E(aethCollateralManager).makeVaultInvitation(),
+      harden({
+        give: { Collateral: collateral },
+        want: { Minted: want },
+      }),
+      harden({
+        Collateral: aeth.mint.mintPayment(collateral),
+      }),
+    );
+
+  const aliceWantMinted = run.make(100_000n);
+  const collateral = aeth.make(15_000n);
+  /** @type {UserSeat<VaultKit>} */
+  const aliceVaultSeat = await openVault(collateral, aliceWantMinted);
+  const {
+    vault: aliceVault,
+    publicNotifiers: { vault: aliceNotifier },
+  } = await legacyOfferResult(aliceVaultSeat);
+  let aliceUpdate = await E(aliceNotifier).getUpdateSince();
+  t.is(aliceUpdate.value.vaultState, Phase.ACTIVE);
+  await aethVaultMetrics.assertChange({
+    numActiveVaults: 1,
+    totalCollateral: { value: 15_000n },
+    totalDebt: { value: 100_500n },
+  });
+
+  const { Minted: aliceLentAmount } = await E(
+    aliceVaultSeat,
+  ).getFinalAllocation();
+  const aliceProceeds = await E(aliceVaultSeat).getPayouts();
+  t.deepEqual(aliceLentAmount, aliceWantMinted, 'received 95 Minted');
+
+  const aliceRunLent = await aliceProceeds.Minted;
+  t.deepEqual(await E(run.issuer).getAmountOf(aliceRunLent), aliceWantMinted);
+
+  const { startTime } = await startAuctionClock(auctKit, manualTimer);
+  await setClockAndAdvanceNTimes(manualTimer, 3n, startTime, TEN_MINUTES);
+
+  // price falls
+  // @ts-expect-error setupServices() should return the right type
+  await priceAuthority.setPrice(makeRatio(9990n, run.brand, 1000n, aeth.brand));
+  await eventLoopIteration();
+
+  await setClockAndAdvanceNTimes(
+    manualTimer,
+    5n,
+    TimeMath.addAbsRel(startTime, TimeMath.relValue(3600n)),
+    TEN_MINUTES,
+  );
+
+  await aethVaultMetrics.assertChange({
+    liquidatingDebt: { value: 100_500n },
+    liquidatingCollateral: { value: 15_000n },
+    numActiveVaults: 0,
+    numLiquidatingVaults: 1,
+  });
+
+  trace('liquidated?');
+  await eventLoopIteration();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince(aliceUpdate.updateCount);
+  debugger;
+  t.is(aliceUpdate.value.vaultState, Phase.ACTIVE);
+
+  t.deepEqual(await E(aliceVault).getCollateralAmount(), aeth.make(14_899n));
+  t.deepEqual(await E(aliceVault).getCurrentDebt(), run.make(100_500n));
+
+  const metricsTopic = await E.get(E(reservePublicFacet).getPublicTopics())
+    .metrics;
+  const m = await subscriptionTracker(t, metricsTopic);
+
+  await m.assertState({
+    ...reserveInitialState(run.makeEmpty()),
+    shortfallBalance: run.make(0n),
+    allocations: {
+      Aeth: aeth.make(101n),
+      Fee: run.makeEmpty(),
+    },
+  });
+
+  await aethVaultMetrics.assertNoUpdate();
 });

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -3214,9 +3214,13 @@ test('Bug 7851 & no bidders', async t => {
     );
 
   const aliceWantMinted = run.make(100_000n);
-  const collateral = aeth.make(15_000n);
+  const aliceDebt = 100_500n;
+  const collateral = 15_000n;
   /** @type {UserSeat<VaultKit>} */
-  const aliceVaultSeat = await openVault(collateral, aliceWantMinted);
+  const aliceVaultSeat = await openVault(
+    aeth.make(collateral),
+    aliceWantMinted,
+  );
   const {
     vault: aliceVault,
     publicNotifiers: { vault: aliceNotifier },
@@ -3225,8 +3229,8 @@ test('Bug 7851 & no bidders', async t => {
   t.is(aliceUpdate.value.vaultState, Phase.ACTIVE);
   await aethVaultMetrics.assertChange({
     numActiveVaults: 1,
-    totalCollateral: { value: 15_000n },
-    totalDebt: { value: 100_500n },
+    totalCollateral: { value: collateral },
+    totalDebt: { value: aliceDebt },
   });
 
   const { Minted: aliceLentAmount } = await E(
@@ -3249,13 +3253,13 @@ test('Bug 7851 & no bidders', async t => {
   await setClockAndAdvanceNTimes(
     manualTimer,
     5n,
-    TimeMath.addAbsRel(startTime, TimeMath.relValue(3600n)),
+    TimeMath.addAbsRel(startTime, TimeMath.relValue(ONE_HOUR)),
     10n * ONE_MINUTE,
   );
 
   await aethVaultMetrics.assertChange({
-    liquidatingDebt: { value: 100_500n },
-    liquidatingCollateral: { value: 15_000n },
+    liquidatingDebt: { value: aliceDebt },
+    liquidatingCollateral: { value: collateral },
     numActiveVaults: 0,
     numLiquidatingVaults: 1,
   });
@@ -3265,8 +3269,10 @@ test('Bug 7851 & no bidders', async t => {
   aliceUpdate = await E(aliceNotifier).getUpdateSince(aliceUpdate.updateCount);
   t.is(aliceUpdate.value.vaultState, Phase.ACTIVE);
 
-  t.deepEqual(await E(aliceVault).getCollateralAmount(), aeth.make(14_899n));
-  t.deepEqual(await E(aliceVault).getCurrentDebt(), run.make(100_500n));
+  const penalty = 101n;
+  const collateralReduced = aeth.make(collateral - penalty);
+  t.deepEqual(await E(aliceVault).getCollateralAmount(), collateralReduced);
+  t.deepEqual(await E(aliceVault).getCurrentDebt(), run.make(aliceDebt));
 
   const metricsTopic = await E.get(E(reservePublicFacet).getPublicTopics())
     .metrics;
@@ -3276,7 +3282,7 @@ test('Bug 7851 & no bidders', async t => {
     ...reserveInitialState(run.makeEmpty()),
     shortfallBalance: run.make(0n),
     allocations: {
-      Aeth: aeth.make(101n),
+      Aeth: aeth.make(penalty),
       Fee: run.makeEmpty(),
     },
   });

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -18,8 +18,13 @@ import { assertPayoutAmount } from '@agoric/zoe/test/zoeTestHelpers.js';
 import { multiplyBy } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { NonNullish } from '@agoric/assert';
 
-import { SECONDS_PER_YEAR } from '../../src/interest.js';
-import { startVaultFactory } from '../../src/proposals/econ-behaviors.js';
+import {
+  SECONDS_PER_DAY as ONE_DAY,
+  SECONDS_PER_HOUR as ONE_HOUR,
+  SECONDS_PER_MINUTE as ONE_MINUTE,
+  SECONDS_PER_WEEK as ONE_WEEK,
+  startVaultFactory,
+} from '../../src/proposals/econ-behaviors.js';
 import '../../src/vaultFactory/types.js';
 import {
   reserveInitialState,
@@ -60,11 +65,6 @@ const contractRoots = {
 /** @typedef {import('../../src/vaultFactory/vaultFactory').VaultFactoryContract} VFC */
 
 const trace = makeTracer('TestST', false);
-
-const SECONDS_PER_MINUTE = 60n;
-const SECONDS_PER_HOUR = 60n * SECONDS_PER_MINUTE;
-const SECONDS_PER_DAY = SECONDS_PER_YEAR / 365n;
-const SECONDS_PER_WEEK = SECONDS_PER_DAY * 7n;
 
 // Define locally to test that vaultFactory uses these values
 export const Phase = /** @type {const} */ ({
@@ -353,7 +353,7 @@ test('price drop', async t => {
     manualTimer,
     undefined,
     500n,
-    { StartFrequency: SECONDS_PER_HOUR },
+    { StartFrequency: ONE_HOUR },
   );
 
   const {
@@ -513,7 +513,7 @@ test('price falls precipitously', async t => {
     manualTimer,
     undefined,
     500n,
-    { StartFrequency: SECONDS_PER_HOUR },
+    { StartFrequency: ONE_HOUR },
   );
   // we start with time=0, price=2200
 
@@ -657,8 +657,8 @@ test('liquidate two loans', async t => {
   // Interest is charged daily, and auctions are every week, so we'll charge
   // interest a few times before the second auction.
   t.context.interestTiming = {
-    chargingPeriod: SECONDS_PER_DAY,
-    recordingPeriod: SECONDS_PER_DAY,
+    chargingPeriod: ONE_DAY,
+    recordingPeriod: ONE_DAY,
   };
 
   const manualTimer = buildManualTimer();
@@ -667,7 +667,7 @@ test('liquidate two loans', async t => {
     makeRatio(100n, run.brand, 10n, aeth.brand),
     aeth.make(1n),
     manualTimer,
-    SECONDS_PER_WEEK,
+    ONE_WEEK,
     500n,
   );
 
@@ -930,12 +930,7 @@ test('liquidate two loans', async t => {
   });
 
   currentTime = now3;
-  currentTime = await setClockAndAdvanceNTimes(
-    manualTimer,
-    2,
-    start3,
-    SECONDS_PER_DAY,
-  );
+  currentTime = await setClockAndAdvanceNTimes(manualTimer, 2, start3, ONE_DAY);
   trace(t, 'finished auctions', currentTime);
 
   bobUpdate = await E(bobNotifier).getUpdateSince();
@@ -977,8 +972,8 @@ test('sell goods at auction', async t => {
   // Interest is charged daily, and auctions are every week, so we'll charge
   // interest a few times before the second auction.
   t.context.interestTiming = {
-    chargingPeriod: SECONDS_PER_DAY,
-    recordingPeriod: SECONDS_PER_DAY,
+    chargingPeriod: ONE_DAY,
+    recordingPeriod: ONE_DAY,
   };
 
   // Add a vaultManager with 10000 aeth collateral at a 200 aeth/Minted rate
@@ -997,9 +992,9 @@ test('sell goods at auction', async t => {
     makeRatio(100n, run.brand, 10n, aeth.brand),
     aeth.make(1n),
     manualTimer,
-    SECONDS_PER_WEEK,
+    ONE_WEEK,
     500n,
-    { StartFrequency: SECONDS_PER_HOUR },
+    { StartFrequency: ONE_HOUR },
   );
 
   const {
@@ -1173,7 +1168,7 @@ test('collect fees from loan', async t => {
     manualTimer,
     undefined,
     500n,
-    { StartFrequency: SECONDS_PER_HOUR },
+    { StartFrequency: ONE_HOUR },
   );
 
   const {
@@ -1406,8 +1401,8 @@ test('Auction sells all collateral w/shortfall', async t => {
 
   // Interest is charged daily, and auctions are every week
   t.context.interestTiming = {
-    chargingPeriod: SECONDS_PER_DAY,
-    recordingPeriod: SECONDS_PER_DAY,
+    chargingPeriod: ONE_DAY,
+    recordingPeriod: ONE_DAY,
   };
 
   const manualTimer = buildManualTimer();
@@ -1416,9 +1411,9 @@ test('Auction sells all collateral w/shortfall', async t => {
     makeRatio(100n, run.brand, 10n, aeth.brand),
     aeth.make(1n),
     manualTimer,
-    SECONDS_PER_WEEK,
+    ONE_WEEK,
     500n,
-    { StartFrequency: SECONDS_PER_HOUR },
+    { StartFrequency: ONE_HOUR },
   );
 
   const {
@@ -1622,9 +1617,9 @@ test('liquidation Margin matters', async t => {
     makeRatio(1234n, run.brand, 100n, aeth.brand),
     aeth.make(1n),
     manualTimer,
-    SECONDS_PER_WEEK,
+    ONE_WEEK,
     500n,
-    { StartFrequency: SECONDS_PER_HOUR },
+    { StartFrequency: ONE_HOUR },
   );
 
   const {
@@ -1728,9 +1723,9 @@ test('reinstate vault', async t => {
     makeRatio(1500n, run.brand, 100n, aeth.brand),
     aeth.make(1n),
     manualTimer,
-    SECONDS_PER_WEEK,
+    ONE_WEEK,
     500n,
-    { StartFrequency: SECONDS_PER_HOUR },
+    { StartFrequency: ONE_HOUR },
   );
 
   const {
@@ -1933,7 +1928,7 @@ test('auction locks low price', async t => {
     manualTimer,
     undefined,
     500n,
-    { StartFrequency: SECONDS_PER_HOUR },
+    { StartFrequency: ONE_HOUR },
   );
   // we start with time=0, price=2200
 
@@ -2024,9 +2019,9 @@ test('Bug 7422 vault reinstated with no assets', async t => {
     makeRatio(1250n, run.brand, 100n, aeth.brand),
     aeth.make(1000n),
     manualTimer,
-    SECONDS_PER_WEEK,
+    ONE_WEEK,
     500n,
-    { StartFrequency: SECONDS_PER_HOUR },
+    { StartFrequency: ONE_HOUR },
   );
 
   const {
@@ -2251,9 +2246,9 @@ test('Bug 7346 excess collateral to holder', async t => {
     makeRatio(1234n, run.brand, 100n, aeth.brand),
     aeth.make(1_000_000n),
     manualTimer,
-    SECONDS_PER_WEEK,
+    ONE_WEEK,
     500_000n,
-    { DiscountStep: 500n, StartFrequency: SECONDS_PER_HOUR },
+    { DiscountStep: 500n, StartFrequency: ONE_HOUR },
   );
 
   const {
@@ -2513,7 +2508,7 @@ test('refund to one of two loans', async t => {
     manualTimer,
     undefined,
     500n,
-    { StartFrequency: SECONDS_PER_HOUR },
+    { StartFrequency: ONE_HOUR },
   );
 
   const {
@@ -2698,9 +2693,9 @@ test('Bug 7784 reconstitute both', async t => {
     makeRatio(1234n, run.brand, 100n, aeth.brand),
     aeth.make(1000n),
     manualTimer,
-    SECONDS_PER_WEEK,
+    ONE_WEEK,
     500n,
-    { DiscountStep: 500n, LowestRate: 6500n, StartFrequency: SECONDS_PER_HOUR },
+    { DiscountStep: 500n, LowestRate: 6500n, StartFrequency: ONE_HOUR },
   );
 
   const {
@@ -2899,17 +2894,17 @@ test('Bug 7796 missing lockedPrice', async t => {
   t.context.rates = rates;
 
   const manualTimer = buildManualTimer();
-  const TEN_MINUTES = 10n * SECONDS_PER_MINUTE;
+  const TEN_MINUTES = 10n * ONE_MINUTE;
   const services = await setupServices(
     t,
     makeRatio(1234n, run.brand, 100n, aeth.brand),
     aeth.make(1_000_000n),
     manualTimer,
-    SECONDS_PER_WEEK,
+    ONE_WEEK,
     500_000n,
     {
       DiscountStep: 500n,
-      StartFrequency: SECONDS_PER_HOUR,
+      StartFrequency: ONE_HOUR,
       ClockStep: TEN_MINUTES,
     },
   );
@@ -3074,7 +3069,7 @@ test('Bug 7796 missing lockedPrice', async t => {
   now = await setClockAndAdvanceNTimes(
     manualTimer,
     10n,
-    TimeMath.addAbsRel(now, TimeMath.relValue(3600n)),
+    TimeMath.addAbsRel(now, TimeMath.relValue(ONE_HOUR)),
     TEN_MINUTES,
   );
 
@@ -3163,18 +3158,17 @@ test('Bug 7851 & no bidders', async t => {
   t.context.rates = rates;
 
   const manualTimer = buildManualTimer();
-  const TEN_MINUTES = 10n * SECONDS_PER_MINUTE;
   const services = await setupServices(
     t,
     makeRatio(1234n, run.brand, 100n, aeth.brand),
     aeth.make(1000n),
     manualTimer,
-    SECONDS_PER_WEEK,
+    ONE_WEEK,
     500n,
     {
       DiscountStep: 500n,
-      StartFrequency: SECONDS_PER_HOUR,
-      ClockStep: TEN_MINUTES,
+      StartFrequency: ONE_HOUR,
+      ClockStep: 10n * ONE_MINUTE,
     },
   );
 
@@ -3245,7 +3239,7 @@ test('Bug 7851 & no bidders', async t => {
   t.deepEqual(await E(run.issuer).getAmountOf(aliceRunLent), aliceWantMinted);
 
   const { startTime } = await startAuctionClock(auctKit, manualTimer);
-  await setClockAndAdvanceNTimes(manualTimer, 3n, startTime, TEN_MINUTES);
+  await setClockAndAdvanceNTimes(manualTimer, 3n, startTime, 10n * ONE_MINUTE);
 
   // price falls
   // @ts-expect-error setupServices() should return the right type
@@ -3256,7 +3250,7 @@ test('Bug 7851 & no bidders', async t => {
     manualTimer,
     5n,
     TimeMath.addAbsRel(startTime, TimeMath.relValue(3600n)),
-    TEN_MINUTES,
+    10n * ONE_MINUTE,
   );
 
   await aethVaultMetrics.assertChange({
@@ -3269,7 +3263,6 @@ test('Bug 7851 & no bidders', async t => {
   trace('liquidated?');
   await eventLoopIteration();
   aliceUpdate = await E(aliceNotifier).getUpdateSince(aliceUpdate.updateCount);
-  debugger;
   t.is(aliceUpdate.value.vaultState, Phase.ACTIVE);
 
   t.deepEqual(await E(aliceVault).getCollateralAmount(), aeth.make(14_899n));

--- a/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
@@ -432,7 +432,7 @@ test.serial('force liquidation', async t => {
   t.like(readCollateralMetrics(0), {
     numActiveVaults: 1,
     numLiquidatingVaults: 1,
-    numLiquidationsAborted: 0,
+    numLiquidationsAborted: 1,
     numLiquidationsCompleted: 0,
   });
 });


### PR DESCRIPTION
closes: #7851

## Description

 #7785 calculated the price before it was needed because it could have
 been useful in two branches. Unfortunately, in the third branch the
 denominator would often be zero, which makeRatio rejects.

This moves the price calculation back to where it's needed, and where the denominator is know to be positive.

In doing so, I discovered that there was no test coverage for cases where no collateral was sold. In those cases, the penalty charged against vaults being reinstated was calculated incorrectly, so the vault wouldn't have been reinstated. This corrects that.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

Includes a new test.