### PR TITLE
exo makeMint test (WIP)

### DIFF
--- a/packages/zone/package.json
+++ b/packages/zone/package.json
@@ -7,7 +7,7 @@
   "main": "./src/index.js",
   "scripts": {
     "build": "exit 0",
-    "test": "true || ava",
+    "test": "ava",
     "test:c8": "true || c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",

--- a/packages/zone/test/makeMint.js
+++ b/packages/zone/test/makeMint.js
@@ -1,8 +1,23 @@
+// @ts-check
 /* eslint-disable import/no-extraneous-dependencies */
 import { makeWeakMap } from 'jessie.js';
 import { Nat } from '@endo/nat';
+import { NonNullish } from '@agoric/assert';
 
+/**
+ * The mint maker, in its original objects-as-closures form.
+ *
+ * taken from "From OCaps to Electronic Rights: Mint and Purse"
+ * in "Hardened JS"
+ * https://docs.agoric.com/guides/js-programming/hardened-js.html#from-ocaps-to-electronic-rights-mint-and-purse
+ * with just 1 or 2 tweaks
+ *
+ * originally from "Simple Money" in the Financial Cryptography 2000 paper
+ * http://erights.org/elib/capability/ode/ode-capabilities.html
+ *
+ */
 export const makeMint = () => {
+  /** @type {WeakMap<*, bigint>} */
   const ledger = makeWeakMap();
 
   const issuer = harden({
@@ -11,15 +26,20 @@ export const makeMint = () => {
   });
 
   const mint = harden({
+    /** @param {bigint} initialBalance */
     makePurse: initialBalance => {
       const purse = harden({
         getIssuer: () => issuer,
         getBalance: () => ledger.get(purse),
 
+        /**
+         * @param {bigint} amount
+         * @param {unknown} src
+         */
         deposit: (amount, src) => {
-          Nat(ledger.get(purse) + Nat(amount));
-          ledger.set(src, Nat(ledger.get(src) - amount));
-          ledger.set(purse, ledger.get(purse) + amount);
+          Nat(NonNullish(ledger.get(purse)) + Nat(amount));
+          ledger.set(src, Nat(NonNullish(ledger.get(src)) - amount));
+          ledger.set(purse, NonNullish(ledger.get(purse)) + amount);
         },
         withdraw: amount => {
           const newPurse = issuer.makeEmptyPurse();

--- a/packages/zone/test/makeMint.js
+++ b/packages/zone/test/makeMint.js
@@ -1,8 +1,13 @@
-const makeMint = () => {
+/* eslint-disable import/no-extraneous-dependencies */
+import { makeWeakMap } from 'jessie.js';
+import { Nat } from '@endo/nat';
+
+export const makeMint = () => {
   const ledger = makeWeakMap();
 
   const issuer = harden({
-    makeEmptyPurse: () => mint.makePurse(0),
+    // eslint-disable-next-line no-use-before-define
+    makeEmptyPurse: () => mint.makePurse(0n),
   });
 
   const mint = harden({

--- a/packages/zone/test/makeMint.js
+++ b/packages/zone/test/makeMint.js
@@ -1,0 +1,31 @@
+const makeMint = () => {
+  const ledger = makeWeakMap();
+
+  const issuer = harden({
+    makeEmptyPurse: () => mint.makePurse(0),
+  });
+
+  const mint = harden({
+    makePurse: initialBalance => {
+      const purse = harden({
+        getIssuer: () => issuer,
+        getBalance: () => ledger.get(purse),
+
+        deposit: (amount, src) => {
+          Nat(ledger.get(purse) + Nat(amount));
+          ledger.set(src, Nat(ledger.get(src) - amount));
+          ledger.set(purse, ledger.get(purse) + amount);
+        },
+        withdraw: amount => {
+          const newPurse = issuer.makeEmptyPurse();
+          newPurse.deposit(amount, purse);
+          return newPurse;
+        },
+      });
+      ledger.set(purse, initialBalance);
+      return purse;
+    },
+  });
+
+  return mint;
+};

--- a/packages/zone/test/makeMintExo.js
+++ b/packages/zone/test/makeMintExo.js
@@ -45,8 +45,8 @@ export const prepareIssuerKit = zone => {
     'Mint',
     undefined, // TODO: interface guard kit
     () => ({
-      /** @type {WeakMap<unknown, bigint>} */
-      ledger: makeWeakMap(),
+      /** @type {WeakMapStore<unknown, bigint>} */
+      ledger: zone.weakMapStore('ledger'),
     }),
     {
       issuer: {
@@ -61,7 +61,7 @@ export const prepareIssuerKit = zone => {
           const { issuer } = this.facets;
           const { ledger } = this.state;
           const purse = makePurse(issuer, ledger);
-          ledger.set(purse, initialBalance);
+          ledger.init(purse, initialBalance);
           return purse;
         },
       },

--- a/packages/zone/test/makeMintExo.js
+++ b/packages/zone/test/makeMintExo.js
@@ -1,0 +1,72 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { makeWeakMap } from 'jessie.js';
+import { Nat } from '@endo/nat';
+
+/**
+ * Mint maker, transformed to an exo class kit.
+ *
+ * @param {import('@agoric/zone').Zone} zone
+ */
+export const prepareIssuerKit = zone => {
+  const makePurse = zone.exoClass(
+    'Purse',
+    undefined,
+    (issuer, ledger) => ({ issuer, ledger }),
+    {
+      getIssuer() {
+        return this.state.issuer;
+      },
+      getBalance() {
+        const { self } = this;
+        return this.state.ledger.get(self);
+      },
+      /**
+       * @param {bigint} amount
+       * @param {unknown} src
+       */
+      deposit(amount, src) {
+        const { self } = this;
+        const { ledger } = this.state;
+        Nat(ledger.get(self) + Nat(amount));
+        ledger.set(src, Nat(ledger.get(src) - amount));
+        ledger.set(self, ledger.get(self) + amount);
+      },
+      withdraw(amount) {
+        const { self } = this;
+        const { issuer } = this.state;
+        const newPurse = issuer.makeEmptyPurse();
+        newPurse.deposit(amount, self);
+        return newPurse;
+      },
+    },
+  );
+
+  const makeIssuerKit = zone.exoClassKit(
+    'Mint',
+    undefined, // TODO: interface guard kit
+    () => ({
+      /** @type {WeakMap<unknown, bigint>} */
+      ledger: makeWeakMap(),
+    }),
+    {
+      issuer: {
+        makeEmptyPurse() {
+          const { mint } = this.facets;
+          return mint.makePurse(0n);
+        },
+      },
+      mint: {
+        /** @param {bigint} initialBalance */
+        makePurse(initialBalance) {
+          const { issuer } = this.facets;
+          const { ledger } = this.state;
+          const purse = makePurse(issuer, ledger);
+          ledger.set(purse, initialBalance);
+          return purse;
+        },
+      },
+    },
+  );
+
+  return makeIssuerKit;
+};

--- a/packages/zone/test/test-makeMint.js
+++ b/packages/zone/test/test-makeMint.js
@@ -1,7 +1,9 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { heapZone } from '../heap.js';
 
 import { makeMint } from './makeMint.js';
+import { prepareIssuerKit } from './makeMintExo.js';
 
 const qualifyImplementation = (label, maker) => {
   test(`makeMint: ${label}`, t => {
@@ -15,3 +17,7 @@ const qualifyImplementation = (label, maker) => {
 };
 
 qualifyImplementation('objects-as-closures', makeMint);
+
+// implements the same API
+const makeIssuerKit = prepareIssuerKit(heapZone);
+qualifyImplementation('exo', () => makeIssuerKit().mint);

--- a/packages/zone/test/test-makeMint.js
+++ b/packages/zone/test/test-makeMint.js
@@ -1,0 +1,13 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { makeMint } from './makeMint.js';
+
+test(`makeMint: objects as closures implementation`, t => {
+  const mint = makeMint();
+  const p1 = mint.makePurse(10n);
+  const p2 = mint.makePurse(0n);
+  p2.deposit(3n, p1.withdraw(3n));
+  t.is(p1.getBalance(), 7n);
+  t.is(p2.getBalance(), 3n);
+});

--- a/packages/zone/test/test-makeMint.js
+++ b/packages/zone/test/test-makeMint.js
@@ -3,11 +3,15 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { makeMint } from './makeMint.js';
 
-test(`makeMint: objects as closures implementation`, t => {
-  const mint = makeMint();
-  const p1 = mint.makePurse(10n);
-  const p2 = mint.makePurse(0n);
-  p2.deposit(3n, p1.withdraw(3n));
-  t.is(p1.getBalance(), 7n);
-  t.is(p2.getBalance(), 3n);
-});
+const qualifyImplementation = (label, maker) => {
+  test(`makeMint: ${label}`, t => {
+    const mint = maker();
+    const p1 = mint.makePurse(10n);
+    const p2 = mint.makePurse(0n);
+    p2.deposit(3n, p1.withdraw(3n));
+    t.is(p1.getBalance(), 7n);
+    t.is(p2.getBalance(), 3n);
+  });
+};
+
+qualifyImplementation('objects-as-closures', makeMint);

--- a/packages/zone/test/test-makeMint.js
+++ b/packages/zone/test/test-makeMint.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import { heapZone } from '../heap.js';
+import { makeScalarBigMapStore } from '@agoric/vat-data';
+import { makeDurableZone } from '../durable.js';
 
 import { makeMint } from './makeMint.js';
 import { prepareIssuerKit } from './makeMintExo.js';
@@ -19,5 +20,6 @@ const qualifyImplementation = (label, maker) => {
 qualifyImplementation('objects-as-closures', makeMint);
 
 // implements the same API
-const makeIssuerKit = prepareIssuerKit(heapZone);
+const zone = makeDurableZone(makeScalarBigMapStore('Test Baggage'));
+const makeIssuerKit = prepareIssuerKit(zone);
 qualifyImplementation('exo', () => makeIssuerKit().mint);


### PR DESCRIPTION
## Description

a somewhat mechanical conversion of `makeMint()` to an exo class kit.

### Security Considerations

n / a; this is just a test

### Scaling Considerations

`makeIssuerKit` currently uses exo singletons. Perhaps an exo class kit would be more ergonomic / scalable?

### Documentation Considerations

discussed in:

 - [May 10 office hours: upgrading HardenedJS objects with exo classes](https://github.com/Agoric/agoric-sdk/discussions/7673)

At the time, it was a [test-makeExoMint.js](https://gist.github.com/dckc/682316c071103883287af10a51b3613c#file-test-makeexomint-js) gist.

### Testing Considerations

This does 1 sanity test by way of showing that the exo version and the objects-as-closures version implement the same API.

This initial version has a known bug.

 - [ ] multiple kits should not share a ledger

I aim to add a failing test and then look into whether it's straightforward to repair.

cc @mhofman 