### PR TITLE
7850 gracefully handle failures of distributeProceeds

### DIFF
--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -2,6 +2,7 @@
 
 import { AmountMath } from '@agoric/ertp';
 import { M } from '@agoric/store';
+import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport/index.js';
 
 const { Fail, quote: q } = assert;
 
@@ -83,3 +84,7 @@ export const checkDebtLimit = (debtLimit, totalDebt, toMint) => {
  */
 export const makeNatAmountShape = (brand, min) =>
   harden({ brand, value: min ? M.gte(min) : M.nat() });
+
+/** @param {Pick<PriceDescription, 'amountIn' | 'amountOut'>} quoteAmount */
+export const quoteAsRatio = quoteAmount =>
+  makeRatioFromAmounts(quoteAmount.amountIn, quoteAmount.amountOut);

--- a/packages/inter-protocol/src/contractSupport.js
+++ b/packages/inter-protocol/src/contractSupport.js
@@ -29,6 +29,17 @@ export const addSubtract = (base, gain, loss) =>
   AmountMath.subtract(AmountMath.add(base, gain), loss);
 
 /**
+ * @template {Amount} T
+ * @param {T} left
+ * @param {T} right
+ * @returns {T}
+ */
+export const subtractToEmpty = (left, right) =>
+  AmountMath.isGTE(right, left)
+    ? /** @type {T} */ (AmountMath.makeEmptyFromAmount(left))
+    : /** @type {T} */ (AmountMath.subtract(left, right));
+
+/**
  * Verifies that every key in the proposal is in the provided list
  *
  * @param {ProposalRecord} proposal

--- a/packages/inter-protocol/src/vaultFactory/Liquidation.md
+++ b/packages/inter-protocol/src/vaultFactory/Liquidation.md
@@ -13,7 +13,7 @@ There are two interesting exception cases. All the collateral might be sold
 without covering the debt (flow 2a), or there might not be enough bids to
 purchase all the collateral (flow 2b). In the first case, vault-holders don't
 get anything back, we burn the currency we received to cover a portion of the
-debt, any excess collateral is sent to the reserve, and we report a shortfall.
+debt, and we report a shortfall.
 
 In the second case, we can't tell whether it's due to a downturn in the
 market or a DoS attack on the exchange. In hopes that it's not the latter, we

--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -185,30 +185,18 @@ harden(setWakeupsForNextAuction);
 /**
  * @param {Amount<'nat'>} debt
  * @param {Amount<'nat'>} minted
- * @returns {{ overage: Amount<'nat'>, shortfall: Amount<'nat'>, toBurn: Amount<'nat'>}}
+ * @returns {{ overage: Amount<'nat'>, shortfall: Amount<'nat'>}}
  */
 export const liquidationResults = (debt, minted) => {
   if (AmountMath.isEmpty(minted)) {
-    return {
-      overage: minted,
-      toBurn: minted,
-      shortfall: debt,
-    };
+    return { overage: minted, shortfall: debt };
   }
 
   const [overage, shortfall] = AmountMath.isGTE(debt, minted)
     ? [AmountMath.makeEmptyFromAmount(debt), AmountMath.subtract(debt, minted)]
     : [AmountMath.subtract(minted, debt), AmountMath.makeEmptyFromAmount(debt)];
 
-  const toBurn = AmountMath.min(minted, debt);
-  // debt is fully accounted for, with toBurn and shortfall
-  assert(AmountMath.isEqual(debt, AmountMath.add(toBurn, shortfall)));
-
-  return {
-    overage,
-    toBurn,
-    shortfall,
-  };
+  return { overage, shortfall };
 };
 harden(liquidationResults);
 

--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -144,7 +144,7 @@ const setWakeups = ({
  * @param {TimerWaker} reschedulerWaker
  * @returns {Promise<void>}
  */
-const setWakeupsForNextAuction = async (
+export const setWakeupsForNextAuction = async (
   auctioneerPublicFacet,
   timer,
   priceLockWaker,
@@ -180,13 +180,14 @@ const setWakeupsForNextAuction = async (
     params,
   });
 };
+harden(setWakeupsForNextAuction);
 
 /**
  * @param {Amount<'nat'>} debt
  * @param {Amount<'nat'>} minted
  * @returns {{ overage: Amount<'nat'>, shortfall: Amount<'nat'>, toBurn: Amount<'nat'>}}
  */
-const liquidationResults = (debt, minted) => {
+export const liquidationResults = (debt, minted) => {
   if (AmountMath.isEmpty(minted)) {
     return {
       overage: minted,
@@ -209,6 +210,7 @@ const liquidationResults = (debt, minted) => {
     shortfall,
   };
 };
+harden(liquidationResults);
 
 /**
  * Watch governed params for change
@@ -260,7 +262,7 @@ export const watchForGovernanceChange = (
  *    totalCollateral: Amount<'nat'>,
  *    liqSeat: ZCFSeat}}
  */
-const getLiquidatableVaults = (
+export const getLiquidatableVaults = (
   zcf,
   collateralizationDetails,
   prioritizedVaults,
@@ -303,9 +305,4 @@ const getLiquidatableVaults = (
 
   return { vaultData, totalDebt, totalCollateral, liqSeat };
 };
-
-harden(setWakeupsForNextAuction);
-harden(liquidationResults);
 harden(getLiquidatableVaults);
-
-export { setWakeupsForNextAuction, liquidationResults, getLiquidatableVaults };

--- a/packages/inter-protocol/src/vaultFactory/proceeds.js
+++ b/packages/inter-protocol/src/vaultFactory/proceeds.js
@@ -267,7 +267,7 @@ export const calculateDistributionPlan = (
       )
     ) {
       console.error(
-        `🚨 Excess collateral remaining sent to reserve. Expected ${q(
+        `⚠️ Excess collateral remaining sent to reserve. Expected ${q(
           collatRemaining,
         )}, sent ${q(collateralInLiqSeat)}`,
       );

--- a/packages/inter-protocol/src/vaultFactory/proceeds.js
+++ b/packages/inter-protocol/src/vaultFactory/proceeds.js
@@ -222,11 +222,10 @@ export const calculateDistributionPlan = (
 
       // according to #7123, Collateral for penalty =
       //    vault debt / total debt * total liquidation penalty
-      const vaultPenalty = ceilMultiplyBy(
-        debtAmount,
-        makeRatioFromAmounts(totalPenalty, totalDebt),
-      );
-      const collatPostPenalty = AmountMath.subtract(vCollat, vaultPenalty);
+      const vaultPenalty = ceilMultiplyBy(debtAmount, debtPortion);
+      const collatPostPenalty = AmountMath.isGTE(vCollat, vaultPenalty)
+        ? AmountMath.subtract(vCollat, vaultPenalty)
+        : emptyCollateral;
       const vaultDebt = floorMultiplyBy(debtAmount, debtPortion);
       if (
         reconstituteVaults &&

--- a/packages/inter-protocol/src/vaultFactory/proceeds.js
+++ b/packages/inter-protocol/src/vaultFactory/proceeds.js
@@ -35,22 +35,23 @@ import { liquidationResults } from './liquidation.js';
 /**
  * Liquidation.md describes how to process liquidation proceeds
  *
- * @param {AmountKeywordRecord} proceeds
- * @param {Amount<'nat'>} totalDebt
- * @param {Amount<'nat'>} totalCollateral
- * @param {PriceDescription} oraclePriceAtStart
- * @param {Array<{ collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>, currentDebt: Amount<'nat'> }>} vaultBalances ordered best to worst collateralized
- * @param {Ratio} penaltyRate
+ * @param {object} inputs
+ * @param {AmountKeywordRecord} inputs.proceeds
+ * @param {Amount<'nat'>} inputs.totalDebt
+ * @param {Amount<'nat'>} inputs.totalCollateral
+ * @param {PriceDescription} inputs.oraclePriceAtStart
+ * @param {Array<{ collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>, currentDebt: Amount<'nat'> }>} inputs.vaultBalances ordered best to worst collateralized
+ * @param {Ratio} inputs.penaltyRate
  * @returns {DistributionPlan}
  */
-export const calculateDistributionPlan = (
+export const calculateDistributionPlan = ({
   proceeds,
   totalDebt,
   totalCollateral,
   oraclePriceAtStart,
   vaultBalances,
   penaltyRate,
-) => {
+}) => {
   const emptyCollateral = AmountMath.makeEmptyFromAmount(totalCollateral);
   const emptyMinted = AmountMath.makeEmptyFromAmount(totalDebt);
 

--- a/packages/inter-protocol/src/vaultFactory/proceeds.js
+++ b/packages/inter-protocol/src/vaultFactory/proceeds.js
@@ -153,6 +153,7 @@ export const calculateDistributionPlan = ({
       : collateralProceeds;
   };
 
+  // Flow 2a: all collateral was sold but debt was not covered
   const runFlow2a = () => {
     // charge penalty if proceeds are sufficient
     const penaltyInMinted = ceilMultiplyBy(totalDebt, penaltyRate);
@@ -184,6 +185,7 @@ export const calculateDistributionPlan = ({
     }
   };
 
+  // Flow 2b: collateral remains but debt was not covered
   const runFlow2b = () => {
     plan.debtToBurn = totalDebt;
     plan.mintedForReserve = accounting.overage;
@@ -212,7 +214,7 @@ export const calculateDistributionPlan = ({
       const { collateral: vCollat, presaleDebt } = balances;
 
       // according to #7123, Collateral for penalty =
-      //    vault debt / total debt * total liquidation penalty
+      //   total liquidation penalty * vault debt / total debt
       const vaultPenalty = ceilMultiplyBy(presaleDebt, debtPortion);
       const collatPostPenalty = subtractToEmpty(vCollat, vaultPenalty);
       const vaultDebt = floorMultiplyBy(presaleDebt, debtPortion);
@@ -257,7 +259,7 @@ export const calculateDistributionPlan = ({
       // Flow #1: no shortfall
       runFlow1();
     } else if (AmountMath.isEmpty(collateralProceeds)) {
-      // Flow #2a
+      // Flow 2a: all collateral was sold but debt was not covered
       runFlow2a();
     } else {
       // Flow #2b: There's unsold collateral; some vaults may be reinstated.

--- a/packages/inter-protocol/src/vaultFactory/proceeds.js
+++ b/packages/inter-protocol/src/vaultFactory/proceeds.js
@@ -1,0 +1,296 @@
+import { AmountMath } from '@agoric/ertp';
+import {
+  ceilDivideBy,
+  ceilMultiplyBy,
+  floorMultiplyBy,
+  makeRatioFromAmounts,
+  multiplyRatios,
+} from '@agoric/zoe/src/contractSupport/index.js';
+import { quoteAsRatio } from '../contractSupport.js';
+import { liquidationResults } from './liquidation.js';
+
+const { quote: q } = assert;
+
+/**
+ * @typedef {{
+ *   accounting: { overage: Amount<'nat'>, shortfall: Amount<'nat'> },
+ *   collateralForReserve: Amount<'nat'>,
+ *   actualCollateralSold: Amount<'nat'>,
+ *   collateralSold: Amount<'nat'>,
+ *   debtToBurn: Amount<'nat'>,
+ *   liquidationsAborted: number,
+ *   liquidationsCompleted: number,
+ *   mintedForReserve: Amount<'nat'>,
+ *   mintedProceeds: Amount<'nat'>,
+ *   phantomInterest: Amount<'nat'>,
+ *   transfers: import('@agoric/zoe/src/contractSupport/atomicTransfer.js').TransferPart[],
+ *   vaultsToReinstate: Array<Vault>
+ * }} DistributionPlan
+ *
+ * The plan to execute for distributing proceeds of a liquidation
+ */
+
+/**
+ * Liquidation.md describes how to process liquidation proceeds
+ *
+ * @param {AmountKeywordRecord} proceeds
+ * @param {Amount<'nat'>} totalDebt
+ * @param {Amount<'nat'>} totalCollateral
+ * @param {Pick<PriceQuote, 'quoteAmount'>} oraclePriceAtStart
+ * @param {ZCFSeat} liqSeat
+ * @param {Array<[Vault, { collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>}]>} bestToWorst
+ * @param {Ratio} penaltyRate
+ * @returns {DistributionPlan}
+ */
+export const calculateDistributionPlan = (
+  proceeds,
+  totalDebt,
+  totalCollateral,
+  oraclePriceAtStart,
+  liqSeat,
+  bestToWorst,
+  penaltyRate,
+) => {
+  const debtBrand = totalDebt.brand;
+
+  const { Collateral: collateralProceeds } = proceeds;
+  /** @type {Amount<'nat'>} */
+  const collateralSold = AmountMath.subtract(
+    totalCollateral,
+    collateralProceeds,
+  );
+
+  const mintedProceeds = proceeds.Minted || AmountMath.makeEmpty(debtBrand);
+  const accounting = liquidationResults(totalDebt, mintedProceeds);
+
+  // charged in collateral
+  const totalPenalty = ceilMultiplyBy(
+    totalDebt,
+    multiplyRatios(
+      penaltyRate,
+      quoteAsRatio(oraclePriceAtStart.quoteAmount.value[0]),
+    ),
+  );
+  const debtPortion = makeRatioFromAmounts(totalPenalty, totalDebt);
+
+  // We mutate the plan so that at any point if there's an error the plan can be returned and executed.
+  // IOW the plan must always be in a valid state, though perhaps incomplete.
+  /** @type {DistributionPlan} */
+  const plan = {
+    accounting,
+    collateralForReserve: AmountMath.makeEmptyFromAmount(totalCollateral),
+    actualCollateralSold: AmountMath.makeEmptyFromAmount(totalCollateral),
+    collateralSold,
+    debtToBurn: AmountMath.makeEmptyFromAmount(totalDebt),
+    // XXX these two counts are implied by the execution of the plan, not the plan itself
+    liquidationsAborted: 0,
+    liquidationsCompleted: 0,
+    mintedForReserve: AmountMath.makeEmptyFromAmount(totalDebt),
+    mintedProceeds,
+    phantomInterest: AmountMath.makeEmptyFromAmount(totalDebt),
+    transfers: [],
+    vaultsToReinstate: [],
+  };
+
+  /**
+   * If interest was charged between liquidating and liquidated, erase it.
+   *
+   * @param {Amount<'nat'>} priorDebtAmount
+   * @param {Amount<'nat'>} currentDebt
+   */
+  const updatePhantomInterest = (priorDebtAmount, currentDebt) => {
+    const difference = AmountMath.subtract(currentDebt, priorDebtAmount);
+    plan.phantomInterest = AmountMath.add(plan.phantomInterest, difference);
+  };
+
+  const runFlow1 = () => {
+    // Flow #1: no shortfall
+    const collateralToDistribute = AmountMath.isGTE(
+      collateralProceeds,
+      totalPenalty,
+    );
+
+    const distributableCollateral = collateralToDistribute
+      ? AmountMath.subtract(collateralProceeds, totalPenalty)
+      : AmountMath.makeEmptyFromAmount(collateralProceeds);
+
+    plan.debtToBurn = totalDebt;
+    plan.mintedProceeds = mintedProceeds;
+    plan.mintedForReserve = accounting.overage;
+
+    // return remaining funds to vaults before closing
+
+    let leftToStage = distributableCollateral;
+
+    // iterate from best to worst, returning collateral until it has
+    // been exhausted. Vaults after that get nothing.
+    for (const [vault, amounts] of bestToWorst) {
+      const { collateralAmount: vCollat, debtAmount } = amounts;
+      updatePhantomInterest(debtAmount, vault.getCurrentDebt());
+
+      const price = makeRatioFromAmounts(mintedProceeds, collateralSold);
+
+      // max return is vault value reduced by debt and penalty value
+      const debtCollat = ceilDivideBy(debtAmount, price);
+      const penaltyCollat = ceilMultiplyBy(debtAmount, debtPortion);
+      const lessCollat = AmountMath.add(debtCollat, penaltyCollat);
+
+      const maxCollat = AmountMath.isGTE(vCollat, lessCollat)
+        ? AmountMath.subtract(vCollat, lessCollat)
+        : AmountMath.makeEmptyFromAmount(vCollat);
+      if (!AmountMath.isEmpty(leftToStage)) {
+        const collatReturn = AmountMath.min(leftToStage, maxCollat);
+        leftToStage = AmountMath.subtract(leftToStage, collatReturn);
+        plan.transfers.push([
+          liqSeat,
+          vault.getVaultSeat(),
+          { Collateral: collatReturn },
+        ]);
+      }
+    }
+
+    plan.collateralForReserve = collateralToDistribute
+      ? AmountMath.add(leftToStage, totalPenalty)
+      : collateralProceeds;
+    plan.liquidationsCompleted = bestToWorst.length;
+  };
+
+  const runFlow2a = () => {
+    // charge penalty if proceeds are sufficient
+    const penaltyInMinted = ceilMultiplyBy(totalDebt, penaltyRate);
+    const recoveredDebt = AmountMath.min(
+      AmountMath.add(totalDebt, penaltyInMinted),
+      mintedProceeds,
+    );
+
+    plan.debtToBurn = recoveredDebt;
+
+    const coverDebt = AmountMath.isGTE(mintedProceeds, recoveredDebt);
+    const distributable = coverDebt
+      ? AmountMath.subtract(mintedProceeds, recoveredDebt)
+      : AmountMath.makeEmptyFromAmount(mintedProceeds);
+    let mintedRemaining = distributable;
+
+    const vaultPortion = makeRatioFromAmounts(distributable, totalCollateral);
+
+    // iterate from best to worst returning remaining funds to vaults
+    /** @type {Array<[Vault, { collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>}]>} */
+    for (const [vault, balance] of bestToWorst) {
+      // from best to worst, return minted above penalty if any remains
+      const { collateralAmount: vCollat, debtAmount } = balance;
+      const vaultShare = floorMultiplyBy(vCollat, vaultPortion);
+      updatePhantomInterest(debtAmount, vault.getCurrentDebt());
+
+      if (!AmountMath.isEmpty(mintedRemaining)) {
+        const mintedToReturn = AmountMath.isGTE(mintedRemaining, vaultShare)
+          ? vaultShare
+          : mintedRemaining;
+        mintedRemaining = AmountMath.subtract(mintedRemaining, mintedToReturn);
+        const seat = vault.getVaultSeat();
+        plan.transfers.push([liqSeat, seat, { Minted: mintedToReturn }]);
+      }
+    }
+    plan.liquidationsCompleted = bestToWorst.length;
+  };
+
+  const runFlow2b = () => {
+    plan.debtToBurn = totalDebt;
+    plan.mintedForReserve = accounting.overage;
+
+    // reconstitute vaults until collateral is insufficient
+    let reconstituteVaults = AmountMath.isGTE(collateralProceeds, totalPenalty);
+
+    // charge penalty if proceeds are sufficient
+    const distributableCollateral = reconstituteVaults
+      ? AmountMath.subtract(collateralProceeds, totalPenalty)
+      : AmountMath.makeEmptyFromAmount(collateralProceeds);
+
+    let collatRemaining = distributableCollateral;
+
+    let shortfallToReserve = accounting.shortfall;
+    const reduceCollateral = amount =>
+      (plan.actualCollateralSold = AmountMath.add(
+        plan.actualCollateralSold,
+        amount,
+      ));
+
+    // iterate from best to worst attempting to reconstitute, by
+    // returning remaining funds to vaults
+    /** @type {Array<[Vault, { collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>}]>} */
+    for (const [vault, balance] of bestToWorst) {
+      const { collateralAmount: vCollat, debtAmount } = balance;
+
+      // according to #7123, Collateral for penalty =
+      //    vault debt / total debt * total liquidation penalty
+      const vaultPenalty = ceilMultiplyBy(
+        debtAmount,
+        makeRatioFromAmounts(totalPenalty, totalDebt),
+      );
+      const collatPostPenalty = AmountMath.subtract(vCollat, vaultPenalty);
+      const vaultDebt = floorMultiplyBy(debtAmount, debtPortion);
+      if (
+        reconstituteVaults &&
+        !AmountMath.isEmpty(collatPostPenalty) &&
+        AmountMath.isGTE(collatRemaining, collatPostPenalty) &&
+        AmountMath.isGTE(totalDebt, debtAmount)
+      ) {
+        collatRemaining = AmountMath.subtract(
+          collatRemaining,
+          collatPostPenalty,
+        );
+        shortfallToReserve = AmountMath.isGTE(shortfallToReserve, debtAmount)
+          ? AmountMath.subtract(shortfallToReserve, debtAmount)
+          : AmountMath.makeEmptyFromAmount(shortfallToReserve);
+        const seat = vault.getVaultSeat();
+        // must reinstate after atomicRearrange(), so we record them.
+        plan.vaultsToReinstate.push(vault);
+        reduceCollateral(vaultDebt);
+        plan.transfers.push([liqSeat, seat, { Collateral: collatPostPenalty }]);
+      } else {
+        reconstituteVaults = false;
+        plan.liquidationsCompleted += 1;
+        updatePhantomInterest(debtAmount, vault.getCurrentDebt());
+
+        reduceCollateral(vCollat);
+      }
+    }
+
+    plan.liquidationsAborted = plan.transfers.length;
+
+    const collateralInLiqSeat = liqSeat.getCurrentAllocation().Collateral;
+    plan.collateralForReserve = collateralInLiqSeat;
+
+    if (
+      !AmountMath.isEqual(
+        collateralInLiqSeat,
+        AmountMath.add(collatRemaining, totalPenalty),
+      )
+    ) {
+      console.error(
+        `🚨 Excess collateral remaining sent to reserve. Expected ${q(
+          collatRemaining,
+        )}, sent ${q(collateralInLiqSeat)}`,
+      );
+    }
+    plan.accounting.shortfall = shortfallToReserve;
+  };
+
+  try {
+    if (AmountMath.isEmpty(accounting.shortfall)) {
+      // Flow #1: no shortfall
+      runFlow1();
+    } else if (AmountMath.isEmpty(collateralProceeds)) {
+      // Flow #2a
+      runFlow2a();
+    } else {
+      // Flow #2b: There's unsold collateral; some vaults may be reinstated.
+      runFlow2b();
+    }
+  } catch (err) {
+    console.error('🚨 Failure running distribution flow:', err);
+    // continue to return `plan` in the state that was reached
+  }
+
+  return harden(plan);
+};
+harden(calculateDistributionPlan);

--- a/packages/inter-protocol/src/vaultFactory/proceeds.js
+++ b/packages/inter-protocol/src/vaultFactory/proceeds.js
@@ -31,7 +31,12 @@ import { liquidationResults } from './liquidation.js';
  */
 
 /**
- * Liquidation.md describes how to process liquidation proceeds
+ * Liquidation.md describes how to process liquidation proceeds.
+ *
+ * This function is complex and may fail. To defend against this possibility, it
+ * starts with a base plan and updates it. The updating is the complex portion
+ * and is wrapped in a try/catch. If at any point the plan revising fails, the
+ * plan is returned as is.
  *
  * @param {object} inputs
  * @param {AmountKeywordRecord} inputs.proceeds

--- a/packages/inter-protocol/src/vaultFactory/proceeds.js
+++ b/packages/inter-protocol/src/vaultFactory/proceeds.js
@@ -51,7 +51,8 @@ export const calculateDistributionPlan = (
   bestToWorst,
   penaltyRate,
 ) => {
-  const debtBrand = totalDebt.brand;
+  const emptyCollateral = AmountMath.makeEmptyFromAmount(totalCollateral);
+  const emptyMinted = AmountMath.makeEmptyFromAmount(totalDebt);
 
   const { Collateral: collateralProceeds } = proceeds;
   /** @type {Amount<'nat'>} */
@@ -60,7 +61,7 @@ export const calculateDistributionPlan = (
     collateralProceeds,
   );
 
-  const mintedProceeds = proceeds.Minted || AmountMath.makeEmpty(debtBrand);
+  const mintedProceeds = proceeds.Minted || emptyMinted;
   const accounting = liquidationResults(totalDebt, mintedProceeds);
 
   // charged in collateral
@@ -78,16 +79,16 @@ export const calculateDistributionPlan = (
   /** @type {DistributionPlan} */
   const plan = {
     accounting,
-    collateralForReserve: AmountMath.makeEmptyFromAmount(totalCollateral),
-    actualCollateralSold: AmountMath.makeEmptyFromAmount(totalCollateral),
+    collateralForReserve: emptyCollateral,
+    actualCollateralSold: emptyCollateral,
     collateralSold,
-    debtToBurn: AmountMath.makeEmptyFromAmount(totalDebt),
+    debtToBurn: emptyMinted,
     // XXX these two counts are implied by the execution of the plan, not the plan itself
     liquidationsAborted: 0,
     liquidationsCompleted: 0,
-    mintedForReserve: AmountMath.makeEmptyFromAmount(totalDebt),
+    mintedForReserve: emptyMinted,
     mintedProceeds,
-    phantomInterest: AmountMath.makeEmptyFromAmount(totalDebt),
+    phantomInterest: emptyMinted,
     transfers: [],
     vaultsToReinstate: [],
   };
@@ -112,7 +113,7 @@ export const calculateDistributionPlan = (
 
     const distributableCollateral = collateralToDistribute
       ? AmountMath.subtract(collateralProceeds, totalPenalty)
-      : AmountMath.makeEmptyFromAmount(collateralProceeds);
+      : emptyCollateral;
 
     plan.debtToBurn = totalDebt;
     plan.mintedProceeds = mintedProceeds;
@@ -137,7 +138,7 @@ export const calculateDistributionPlan = (
 
       const maxCollat = AmountMath.isGTE(vCollat, lessCollat)
         ? AmountMath.subtract(vCollat, lessCollat)
-        : AmountMath.makeEmptyFromAmount(vCollat);
+        : emptyCollateral;
       if (!AmountMath.isEmpty(leftToStage)) {
         const collatReturn = AmountMath.min(leftToStage, maxCollat);
         leftToStage = AmountMath.subtract(leftToStage, collatReturn);
@@ -168,7 +169,7 @@ export const calculateDistributionPlan = (
     const coverDebt = AmountMath.isGTE(mintedProceeds, recoveredDebt);
     const distributable = coverDebt
       ? AmountMath.subtract(mintedProceeds, recoveredDebt)
-      : AmountMath.makeEmptyFromAmount(mintedProceeds);
+      : emptyMinted;
     let mintedRemaining = distributable;
 
     const vaultPortion = makeRatioFromAmounts(distributable, totalCollateral);
@@ -203,7 +204,7 @@ export const calculateDistributionPlan = (
     // charge penalty if proceeds are sufficient
     const distributableCollateral = reconstituteVaults
       ? AmountMath.subtract(collateralProceeds, totalPenalty)
-      : AmountMath.makeEmptyFromAmount(collateralProceeds);
+      : emptyCollateral;
 
     let collatRemaining = distributableCollateral;
 
@@ -239,7 +240,7 @@ export const calculateDistributionPlan = (
         );
         shortfallToReserve = AmountMath.isGTE(shortfallToReserve, debtAmount)
           ? AmountMath.subtract(shortfallToReserve, debtAmount)
-          : AmountMath.makeEmptyFromAmount(shortfallToReserve);
+          : emptyMinted;
         const seat = vault.getVaultSeat();
         // must reinstate after atomicRearrange(), so we record them.
         plan.vaultsToReinstate.push(vault);

--- a/packages/inter-protocol/src/vaultFactory/proceeds.js
+++ b/packages/inter-protocol/src/vaultFactory/proceeds.js
@@ -11,7 +11,8 @@ import { liquidationResults } from './liquidation.js';
 
 /**
  * @typedef {{
- *   accounting: { overage: Amount<'nat'>, shortfall: Amount<'nat'> },
+ *   overage: Amount<'nat'>,
+ *   shortfallToReserve: Amount<'nat'>,
  *   collateralForReserve: Amount<'nat'>,
  *   actualCollateralSold: Amount<'nat'>,
  *   collateralSold: Amount<'nat'>,
@@ -82,7 +83,8 @@ export const calculateDistributionPlan = ({
   // IOW the plan must always be in a valid state, though perhaps incomplete.
   /** @type {DistributionPlan} */
   const plan = {
-    accounting,
+    overage: accounting.overage,
+    shortfallToReserve: accounting.shortfall,
     collateralForReserve: emptyCollateral,
     actualCollateralSold: emptyCollateral,
     collateralSold,
@@ -175,9 +177,7 @@ export const calculateDistributionPlan = ({
       updatePhantomDebt(balances);
 
       if (!AmountMath.isEmpty(mintedRemaining)) {
-        const mintedToReturn = AmountMath.isGTE(mintedRemaining, vaultShare)
-          ? vaultShare
-          : mintedRemaining;
+        const mintedToReturn = AmountMath.min(mintedRemaining, vaultShare);
         mintedRemaining = AmountMath.subtract(mintedRemaining, mintedToReturn);
         plan.transfersToVault.push([vaultIndex, { Minted: mintedToReturn }]);
       }
@@ -250,7 +250,7 @@ export const calculateDistributionPlan = ({
       totalPenalty,
     );
 
-    plan.accounting.shortfall = shortfallToReserve;
+    plan.shortfallToReserve = shortfallToReserve;
   };
 
   try {

--- a/packages/inter-protocol/src/vaultFactory/proceeds.js
+++ b/packages/inter-protocol/src/vaultFactory/proceeds.js
@@ -123,14 +123,13 @@ export const calculateDistributionPlan = ({
     // return remaining funds to vaults before closing
 
     let leftToStage = distributableCollateral;
+    const price = makeRatioFromAmounts(mintedProceeds, collateralSold);
 
     // iterate from best to worst, returning collateral until it has
     // been exhausted. Vaults after that get nothing.
     for (const [vaultIndex, balances] of vaultsBalances.entries()) {
       const { collateral: vCollat, presaleDebt } = balances;
       updatePhantomDebt(balances);
-
-      const price = makeRatioFromAmounts(mintedProceeds, collateralSold);
 
       // max return is vault value reduced by debt and penalty value
       const debtCollat = ceilDivideBy(presaleDebt, price);

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -84,7 +84,7 @@ const shortfallInvitationKey = 'shortfallInvitation';
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit} makeRecorderKit
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeERecorderKit} makeERecorderKit
  */
-export const prepareVaultDirector = (
+const prepareVaultDirector = (
   baggage,
   zcf,
   directorParamManager,

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -13,9 +13,9 @@ import '@agoric/zoe/src/contracts/exported.js';
 
 // This contract wants to be managed by a contractGovernor, but it isn't
 // compatible with contractGovernor, since it has a separate paramManager for
-// each Vault. This requires it to manually replicate the API of contractHelper
-// to satisfy contractGovernor. It needs to return a creatorFacet with
-// { getParamMgrRetriever, getInvitation, getLimitedCreatorFacet }.
+// each VaultManager. This requires it to manually replicate the API of
+// contractHelper to satisfy contractGovernor. It needs to return a creatorFacet
+// with { getParamMgrRetriever, getInvitation, getLimitedCreatorFacet }.
 
 import { CONTRACT_ELECTORATE } from '@agoric/governance';
 import { makeParamManagerFromTerms } from '@agoric/governance/src/contractGovernance/typedParamManager.js';

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -659,14 +659,14 @@ export const prepareVaultManagerKit = (
           harden(vaults);
           harden(vaultBalances);
 
-          const plan = calculateDistributionPlan(
+          const plan = calculateDistributionPlan({
             proceeds,
             totalDebt,
             totalCollateral,
-            oraclePriceAtStart.quoteAmount.value[0],
+            oraclePriceAtStart: oraclePriceAtStart.quoteAmount.value[0],
             vaultBalances,
             penaltyRate,
-          );
+          });
           trace('PLAN', plan);
 
           // Putting all the rearrangements after the loop ensures that errors

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -496,13 +496,15 @@ export const prepareVaultManagerKit = (
           // don't wait for response
           void E.when(invitation, invite => {
             const proposal = { give: { Collateral: penalty } };
-            void offerTo(
+            return offerTo(
               zcf,
               invite,
               { [seatKeyword]: 'Collateral' },
               proposal,
               seat,
             );
+          }).catch(reason => {
+            console.error('sendToReserve failed', reason);
           });
         },
         /** @type {(collatSold: Amount<'nat'>, completed: number, aborted?: number) => void} */

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -37,17 +37,13 @@ import {
 import { TransferPartShape } from '@agoric/zoe/src/contractSupport/atomicTransfer.js';
 import {
   atomicRearrange,
-  ceilDivideBy,
   ceilMultiplyBy,
   floorDivideBy,
-  floorMultiplyBy,
   getAmountIn,
   getAmountOut,
   makeEphemeraProvider,
   makeRatio,
-  makeRatioFromAmounts,
   makeRecorderTopic,
-  multiplyRatios,
   offerTo,
   SubscriberShape,
   TopicsRecordShape,
@@ -61,12 +57,15 @@ import {
   quoteAsRatio,
 } from '../contractSupport.js';
 import { chargeInterest } from '../interest.js';
-import { getLiquidatableVaults, liquidationResults } from './liquidation.js';
+import {
+  calculateDistributionPlan,
+  getLiquidatableVaults,
+} from './liquidation.js';
 import { calculateMinimumCollateralization, minimumPrice } from './math.js';
 import { makePrioritizedVaults } from './prioritizedVaults.js';
 import { Phase, prepareVault } from './vault.js';
 
-const { details: X, Fail, quote: q } = assert;
+const { details: X, Fail } = assert;
 
 const trace = makeTracer('VM');
 
@@ -157,10 +156,6 @@ const trace = makeTracer('VM');
  *   lockedQuote: PriceQuote | undefined,
  * }} MutableState
  */
-
-/** @param {Pick<PriceDescription, 'amountIn' | 'amountOut'>} quoteAmount */
-const quoteAsRatio = quoteAmount =>
-  makeRatioFromAmounts(quoteAmount.amountIn, quoteAmount.amountOut);
 
 /**
  * @type {(brand: Brand) => {
@@ -578,25 +573,6 @@ export const prepareVaultManagerKit = (
             console.error('🚨 failed to report liquidation shortfall', err);
           });
         },
-        /**
-         * If interest was charged between liquidating and liquidated, erase it.
-         *
-         * @param {Amount<'nat'>} priorDebtAmount
-         * @param {Amount<'nat'>} currentDebt
-         */
-        subtractPhantomInterest(priorDebtAmount, currentDebt) {
-          const { state } = this;
-          const difference = AmountMath.subtract(currentDebt, priorDebtAmount);
-
-          if (!AmountMath.isEmpty(difference)) {
-            state.totalDebt = AmountMath.subtract(state.totalDebt, difference);
-          }
-        },
-        markRestoreDebt(debt) {
-          const { state } = this;
-
-          state.totalDebt = AmountMath.add(state.totalDebt, debt);
-        },
         writeMetrics() {
           const { state } = this;
           const { collateralBrand, retainedCollateralSeat, metricsTopicKit } =
@@ -651,7 +627,6 @@ export const prepareVaultManagerKit = (
           totalCollateral,
         ) {
           const { state, facets } = this;
-          const { collateralBrand, debtBrand, liquidatingVaults } = this.state;
 
           const { Collateral: collateralProceeds } = proceeds;
           /** @type {Amount<'nat'>} */
@@ -664,307 +639,69 @@ export const prepareVaultManagerKit = (
             collateralSold,
           );
 
-          const mintedProceeds =
-            proceeds.Minted || AmountMath.makeEmpty(debtBrand);
-          const accounting = liquidationResults(totalDebt, mintedProceeds);
-
           const penaltyRate = facets.self
             .getGovernedParams()
             .getLiquidationPenalty();
-          // charged in collateral
-          const totalPenalty = ceilMultiplyBy(
-            totalDebt,
-            multiplyRatios(
-              penaltyRate,
-              quoteAsRatio(oraclePriceAtStart.quoteAmount.value[0]),
-            ),
-          );
-          const debtPortion = makeRatioFromAmounts(totalPenalty, totalDebt);
-
-          // Liquidation.md describes how to process liquidation proceeds
           const bestToWorst = [...vaultData.entries()].reverse();
 
-          const runFlow1 = () => {
-            // Flow #1: no shortfall
-            const collateralToDistribute = AmountMath.isGTE(
-              collateralProceeds,
-              totalPenalty,
-            );
+          const plan = calculateDistributionPlan(
+            proceeds,
+            totalDebt,
+            totalCollateral,
+            oraclePriceAtStart,
+            liqSeat,
+            bestToWorst,
+            penaltyRate,
+          );
+          trace('PLAN', plan);
 
-            const distributableCollateral = collateralToDistribute
-              ? AmountMath.subtract(collateralProceeds, totalPenalty)
-              : AmountMath.makeEmptyFromAmount(collateralProceeds);
-
-            facets.helper.burnToCoverDebt(totalDebt, mintedProceeds, liqSeat);
-            facets.helper.sendToReserve(accounting.overage, liqSeat, 'Minted');
-
-            // return remaining funds to vaults before closing
-
-            /** @type {import('@agoric/zoe/src/contractSupport/atomicTransfer.js').TransferPart[]} */
-            const transfers = [];
-            let leftToStage = distributableCollateral;
-
-            // iterate from best to worst, returning collateral until it has
-            // been exhausted. Vaults after that get nothing.
-            for (const [vault, amounts] of bestToWorst) {
-              const { collateralAmount: vCollat, debtAmount } = amounts;
-              facets.helper.subtractPhantomInterest(
-                debtAmount,
-                vault.getCurrentDebt(),
-              );
-
-              const price = makeRatioFromAmounts(
-                mintedProceeds,
-                collateralSold,
-              );
-
-              // max return is vault value reduced by debt and penalty value
-              const debtCollat = ceilDivideBy(debtAmount, price);
-              const penaltyCollat = ceilMultiplyBy(debtAmount, debtPortion);
-              const lessCollat = AmountMath.add(debtCollat, penaltyCollat);
-
-              const maxCollat = AmountMath.isGTE(vCollat, lessCollat)
-                ? AmountMath.subtract(vCollat, lessCollat)
-                : AmountMath.makeEmptyFromAmount(vCollat);
-              if (!AmountMath.isEmpty(leftToStage)) {
-                const collatReturn = AmountMath.min(leftToStage, maxCollat);
-                leftToStage = AmountMath.subtract(leftToStage, collatReturn);
-                transfers.push([
-                  liqSeat,
-                  vault.getVaultSeat(),
-                  { Collateral: collatReturn },
-                ]);
-              }
-            }
-            if (transfers.length > 0) {
-              atomicRearrange(zcf, harden(transfers));
-            }
-
-            const forReserve = collateralToDistribute
-              ? AmountMath.add(leftToStage, totalPenalty)
-              : collateralProceeds;
-            facets.helper.sendToReserve(forReserve, liqSeat);
-
-            facets.helper.markCollateralLiquidated(
-              totalCollateral,
-              vaultData.getSize(),
-            );
-
-            facets.helper.markDoneLiquidating(
-              totalDebt,
-              totalCollateral,
-              accounting,
-            );
-          };
-
-          const runFlow2a = () => {
-            // charge penalty if proceeds are sufficient
-            const penaltyInMinted = ceilMultiplyBy(totalDebt, penaltyRate);
-            const recoveredDebt = AmountMath.min(
-              AmountMath.add(totalDebt, penaltyInMinted),
-              mintedProceeds,
-            );
-
-            facets.helper.burnToCoverDebt(
-              recoveredDebt,
-              mintedProceeds,
-              liqSeat,
-            );
-
-            const coverDebt = AmountMath.isGTE(mintedProceeds, recoveredDebt);
-            const distributable = coverDebt
-              ? AmountMath.subtract(mintedProceeds, recoveredDebt)
-              : AmountMath.makeEmptyFromAmount(mintedProceeds);
-            let mintedRemaining = distributable;
-
-            const vaultPortion = makeRatioFromAmounts(
-              distributable,
-              totalCollateral,
-            );
-            /** @type {import('@agoric/zoe/src/contractSupport/atomicTransfer.js').TransferPart[]} */
-            const transfers = [];
-
-            // iterate from best to worst returning remaining funds to vaults
-            /** @type {Array<[Vault, { collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>}]>} */
-            for (const [vault, balance] of bestToWorst) {
-              // from best to worst, return minted above penalty if any remains
-              const { collateralAmount: vCollat, debtAmount } = balance;
-              const vaultShare = floorMultiplyBy(vCollat, vaultPortion);
-              facets.helper.subtractPhantomInterest(
-                debtAmount,
-                vault.getCurrentDebt(),
-              );
-
-              if (!AmountMath.isEmpty(mintedRemaining)) {
-                const mintedToReturn = AmountMath.isGTE(
-                  mintedRemaining,
-                  vaultShare,
-                )
-                  ? vaultShare
-                  : mintedRemaining;
-                mintedRemaining = AmountMath.subtract(
-                  mintedRemaining,
-                  mintedToReturn,
-                );
-                const seat = vault.getVaultSeat();
-                transfers.push([liqSeat, seat, { Minted: mintedToReturn }]);
-              }
-            }
-
-            if (transfers.length > 0) {
-              atomicRearrange(zcf, harden(transfers));
-            }
-
-            facets.helper.markCollateralLiquidated(
-              totalCollateral,
-              vaultData.getSize(),
-            );
-
-            facets.helper.markDoneLiquidating(
-              totalDebt,
-              totalCollateral,
-              accounting,
-            );
-          };
-
-          const runFlow2b = () => {
-            facets.helper.burnToCoverDebt(totalDebt, mintedProceeds, liqSeat);
-            facets.helper.sendToReserve(accounting.overage, liqSeat, 'Minted');
-
-            // reconstitute vaults until collateral is insufficient
-            let reconstituteVaults = AmountMath.isGTE(
-              collateralProceeds,
-              totalPenalty,
-            );
-
-            // charge penalty if proceeds are sufficient
-            const distributableCollateral = reconstituteVaults
-              ? AmountMath.subtract(collateralProceeds, totalPenalty)
-              : AmountMath.makeEmptyFromAmount(collateralProceeds);
-
-            let collatRemaining = distributableCollateral;
-            /** @type {import('@agoric/zoe/src/contractSupport/atomicTransfer.js').TransferPart[]} */
-            const transfers = [];
-            let liquidated = 0;
-            /** @type {Array<Vault>} */
-            const vaultsToReinstate = [];
-            const reinstateAll = () => {
-              const { prioritizedVaults } = collateralEphemera(collateralBrand);
-              for (const vault of vaultsToReinstate) {
-                const vaultId = vault.abortLiquidation();
-                prioritizedVaults.addVault(vaultId, vault);
-                liquidatingVaults.delete(vault);
-              }
-            };
-
-            let collateralReduction = AmountMath.makeEmpty(collateralBrand);
-            let shortfallToReserve = accounting.shortfall;
-            const reduceCollateral = amount =>
-              (collateralReduction = AmountMath.add(
-                collateralReduction,
-                amount,
-              ));
-
-            // iterate from best to worst attempting to reconstitute, by
-            // returning remaining funds to vaults
-            /** @type {Array<[Vault, { collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>}]>} */
-            for (const [vault, balance] of bestToWorst) {
-              const { collateralAmount: vCollat, debtAmount } = balance;
-
-              // according to #7123, Collateral for penalty =
-              //    vault debt / total debt * total liquidation penalty
-              const vaultPenalty = ceilMultiplyBy(
-                debtAmount,
-                makeRatioFromAmounts(totalPenalty, totalDebt),
-              );
-              const collatPostPenalty = AmountMath.subtract(
-                vCollat,
-                vaultPenalty,
-              );
-              const vaultDebt = floorMultiplyBy(debtAmount, debtPortion);
-              if (
-                reconstituteVaults &&
-                !AmountMath.isEmpty(collatPostPenalty) &&
-                AmountMath.isGTE(collatRemaining, collatPostPenalty) &&
-                AmountMath.isGTE(totalDebt, debtAmount)
-              ) {
-                collatRemaining = AmountMath.subtract(
-                  collatRemaining,
-                  collatPostPenalty,
-                );
-                shortfallToReserve = AmountMath.isGTE(
-                  shortfallToReserve,
-                  debtAmount,
-                )
-                  ? AmountMath.subtract(shortfallToReserve, debtAmount)
-                  : AmountMath.makeEmptyFromAmount(shortfallToReserve);
-                const seat = vault.getVaultSeat();
-                // must reinstate after atomicRearrange(), so we record them.
-                vaultsToReinstate.push(vault);
-                reduceCollateral(vaultDebt);
-                transfers.push([
-                  liqSeat,
-                  seat,
-                  { Collateral: collatPostPenalty },
-                ]);
-              } else {
-                reconstituteVaults = false;
-                liquidated += 1;
-                facets.helper.subtractPhantomInterest(
-                  debtAmount,
-                  vault.getCurrentDebt(),
-                );
-
-                reduceCollateral(vCollat);
-              }
-            }
-
-            // Putting all the rearrangements after the loop ensures that errors
-            // in the calculations don't result in paying back some vaults and
-            // leaving others hanging.
-            if (transfers.length > 0) {
-              atomicRearrange(zcf, harden(transfers));
-            }
-            reinstateAll();
-
-            facets.helper.markCollateralLiquidated(
-              collateralReduction,
-              liquidated,
-              transfers.length,
-            );
-
-            const collateralInLiqSeat =
-              liqSeat.getCurrentAllocation().Collateral;
-            facets.helper.sendToReserve(collateralInLiqSeat, liqSeat);
-
-            if (
-              !AmountMath.isEqual(
-                collateralInLiqSeat,
-                AmountMath.add(collatRemaining, totalPenalty),
-              )
-            ) {
-              console.error(
-                `🚨 Excess collateral remaining sent to reserve. Expected ${q(
-                  collatRemaining,
-                )}, sent ${q(collateralInLiqSeat)}`,
-              );
-            }
-            facets.helper.markDoneLiquidating(totalDebt, totalCollateral, {
-              ...accounting,
-              shortfall: shortfallToReserve,
-            });
-          };
-
-          if (AmountMath.isEmpty(accounting.shortfall)) {
-            // Flow #1: no shortfall
-            runFlow1();
-          } else if (AmountMath.isEmpty(collateralProceeds)) {
-            // Flow #2a
-            runFlow2a();
-          } else {
-            // Flow #2b: There's unsold collateral; some vaults may be revived.
-            runFlow2b();
+          // Putting all the rearrangements after the loop ensures that errors
+          // in the calculations don't result in paying back some vaults and
+          // leaving others hanging.
+          if (plan.transfers.length > 0) {
+            atomicRearrange(zcf, plan.transfers);
           }
+
+          // was reinstateAll
+          const { prioritizedVaults } = collateralEphemera(
+            totalCollateral.brand,
+          );
+          for (const vault of plan.vaultsToReinstate) {
+            const vaultId = vault.abortLiquidation();
+            prioritizedVaults.addVault(vaultId, vault);
+            state.liquidatingVaults.delete(vault);
+          }
+
+          if (!AmountMath.isEmpty(plan.phantomInterest)) {
+            state.totalDebt = AmountMath.subtract(
+              state.totalDebt,
+              plan.phantomInterest,
+            );
+          }
+
+          facets.helper.burnToCoverDebt(
+            plan.debtToBurn,
+            plan.mintedProceeds,
+            liqSeat,
+          );
+          // prior behavior is to send Minted unconditionally
+          facets.helper.sendToReserve(plan.mintedForReserve, liqSeat, 'Minted');
+          // but collateral conditionally
+          if (!AmountMath.isEmpty(plan.collateralForReserve)) {
+            facets.helper.sendToReserve(plan.collateralForReserve, liqSeat);
+          }
+
+          facets.helper.markCollateralLiquidated(
+            totalCollateral,
+            plan.liquidationsCompleted,
+            plan.liquidationsAborted,
+          );
+
+          facets.helper.markDoneLiquidating(
+            totalDebt,
+            totalCollateral,
+            plan.accounting,
+          );
 
           // liqSeat should be empty at this point, except that funds are sent
           // asynchronously to the reserve.

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -637,27 +637,27 @@ export const prepareVaultManagerKit = (
           const bestToWorst = [...vaultData.entries()].reverse();
 
           // unzip the entry tuples
-          const vaults = [];
-          const vaultBalances = [];
+          const vaults = /** @type {Vault[]} */ ([]);
+          const vaultsBalances =
+            /** @type {import('./proceeds.js').VaultBalances[]} */ ([]);
           for (const [vault, balances] of bestToWorst) {
             vaults.push(vault);
-            vaultBalances.push({
-              debtAmount: balances.debtAmount,
-              collateralAmount: balances.collateralAmount,
-              // current debt will be higher than the debtAmount before auction
-              // if interest accrued during auction
+            vaultsBalances.push({
+              collateral: balances.collateralAmount,
+              // if interest accrued during sale, the current debt will be higher
+              presaleDebt: balances.debtAmount,
               currentDebt: vault.getCurrentDebt(),
             });
           }
           harden(vaults);
-          harden(vaultBalances);
+          harden(vaultsBalances);
 
           const plan = calculateDistributionPlan({
             proceeds,
             totalDebt,
             totalCollateral,
             oraclePriceAtStart: oraclePriceAtStart.quoteAmount.value[0],
-            vaultBalances,
+            vaultsBalances,
             penaltyRate,
           });
           trace('PLAN', plan);
@@ -689,10 +689,10 @@ export const prepareVaultManagerKit = (
             state.liquidatingVaults.delete(vault);
           }
 
-          if (!AmountMath.isEmpty(plan.phantomInterest)) {
+          if (!AmountMath.isEmpty(plan.phantomDebt)) {
             state.totalDebt = AmountMath.subtract(
               state.totalDebt,
-              plan.phantomInterest,
+              plan.phantomDebt,
             );
           }
 

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -684,9 +684,13 @@ export const prepareVaultManagerKit = (
             plan.mintedProceeds,
             liqSeat,
           );
-          // prior behavior is to send Minted unconditionally
-          facets.helper.sendToReserve(plan.mintedForReserve, liqSeat, 'Minted');
-          // but collateral conditionally
+          if (!AmountMath.isEmpty(plan.mintedForReserve)) {
+            facets.helper.sendToReserve(
+              plan.mintedForReserve,
+              liqSeat,
+              'Minted',
+            );
+          }
           if (!AmountMath.isEmpty(plan.collateralForReserve)) {
             facets.helper.sendToReserve(plan.collateralForReserve, liqSeat);
           }

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -518,9 +518,10 @@ export const prepareVaultManagerKit = (
          *
          * @param {Amount<'nat'>} debt
          * @param {Amount<'nat'>} collateral
-         * @param {{ overage: Amount<'nat'>, shortfall: Amount<'nat'> }} accounting
+         * @param {Amount<'nat'>} overage
+         * @param {Amount<'nat'>} shortfall
          */
-        markDoneLiquidating(debt, collateral, accounting) {
+        markDoneLiquidating(debt, collateral, overage, shortfall) {
           const { state } = this;
 
           // update liquidation state
@@ -536,7 +537,6 @@ export const prepareVaultManagerKit = (
 
           // record shortfall and proceeds
 
-          const { overage, shortfall } = accounting;
           // cumulative values
           state.totalOverageReceived = AmountMath.add(
             state.totalOverageReceived,
@@ -732,7 +732,8 @@ export const prepareVaultManagerKit = (
           facets.helper.markDoneLiquidating(
             totalDebt,
             totalCollateral,
-            plan.accounting,
+            plan.overage,
+            plan.shortfallToReserve,
           );
 
           // liqSeat should be empty at this point, except that funds are sent

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -628,6 +628,14 @@ export const prepareVaultManagerKit = (
           return E(metricsTopicKit.recorder).write(payload);
         },
 
+        /**
+         * @param {AmountKeywordRecord} proceeds
+         * @param {Amount<'nat'>} totalDebt
+         * @param {Pick<PriceQuote, 'quoteAmount'>} oraclePriceAtStart
+         * @param {ZCFSeat} liqSeat
+         * @param {MapStore<Vault, { collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>}>} vaultData
+         * @param {Amount<'nat'>} totalCollateral
+         */
         distributeProceeds(
           proceeds,
           totalDebt,
@@ -678,9 +686,9 @@ export const prepareVaultManagerKit = (
 
           // Liquidation.md describes how to process liquidation proceeds
           const bestToWorst = [...vaultData.entries()].reverse();
-          if (AmountMath.isEmpty(accounting.shortfall)) {
-            // Flow #1: no shortfall
 
+          const runFlow1 = () => {
+            // Flow #1: no shortfall
             const collateralToDistribute = AmountMath.isGTE(
               collateralProceeds,
               totalPenalty,
@@ -751,9 +759,9 @@ export const prepareVaultManagerKit = (
               totalCollateral,
               accounting,
             );
-          } else if (AmountMath.isEmpty(collateralProceeds)) {
-            // Flow #2a
+          };
 
+          const runFlow2a = () => {
             // charge penalty if proceeds are sufficient
             const penaltyInMinted = ceilMultiplyBy(totalDebt, penaltyRate);
             const recoveredDebt = AmountMath.min(
@@ -822,9 +830,9 @@ export const prepareVaultManagerKit = (
               totalCollateral,
               accounting,
             );
-          } else {
-            // Flow #2b: There's unsold collateral; some vaults may be revived.
+          };
 
+          const runFlow2b = () => {
             facets.helper.burnToCoverDebt(totalDebt, mintedProceeds, liqSeat);
             facets.helper.sendToReserve(accounting.overage, liqSeat, 'Minted');
 
@@ -951,7 +959,19 @@ export const prepareVaultManagerKit = (
               ...accounting,
               shortfall: shortfallToReserve,
             });
+          };
+
+          if (AmountMath.isEmpty(accounting.shortfall)) {
+            // Flow #1: no shortfall
+            runFlow1();
+          } else if (AmountMath.isEmpty(collateralProceeds)) {
+            // Flow #2a
+            runFlow2a();
+          } else {
+            // Flow #2b: There's unsold collateral; some vaults may be revived.
+            runFlow2b();
           }
+
           // liqSeat should be empty at this point, except that funds are sent
           // asynchronously to the reserve.
           liquidateAll();

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -55,7 +55,11 @@ import {
 import { PriceQuoteShape, SeatShape } from '@agoric/zoe/src/typeGuards.js';
 import { E } from '@endo/eventual-send';
 import { AuctionPFShape } from '../auction/auctioneer.js';
-import { checkDebtLimit, makeNatAmountShape } from '../contractSupport.js';
+import {
+  checkDebtLimit,
+  makeNatAmountShape,
+  quoteAsRatio,
+} from '../contractSupport.js';
 import { chargeInterest } from '../interest.js';
 import { getLiquidatableVaults, liquidationResults } from './liquidation.js';
 import { calculateMinimumCollateralization, minimumPrice } from './math.js';

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -57,15 +57,13 @@ import {
   quoteAsRatio,
 } from '../contractSupport.js';
 import { chargeInterest } from '../interest.js';
-import {
-  calculateDistributionPlan,
-  getLiquidatableVaults,
-} from './liquidation.js';
+import { getLiquidatableVaults } from './liquidation.js';
 import { calculateMinimumCollateralization, minimumPrice } from './math.js';
 import { makePrioritizedVaults } from './prioritizedVaults.js';
 import { Phase, prepareVault } from './vault.js';
+import { calculateDistributionPlan } from './proceeds.js';
 
-const { details: X, Fail } = assert;
+const { details: X, Fail, quote: q } = assert;
 
 const trace = makeTracer('VM');
 
@@ -617,6 +615,7 @@ export const prepareVaultManagerKit = (
          * @param {ZCFSeat} liqSeat
          * @param {MapStore<Vault, { collateralAmount: Amount<'nat'>, debtAmount:  Amount<'nat'>}>} vaultData
          * @param {Amount<'nat'>} totalCollateral
+         * @returns {void}
          */
         distributeProceeds(
           proceeds,
@@ -648,8 +647,7 @@ export const prepareVaultManagerKit = (
             proceeds,
             totalDebt,
             totalCollateral,
-            oraclePriceAtStart,
-            liqSeat,
+            oraclePriceAtStart.quoteAmount.value[0],
             bestToWorst,
             penaltyRate,
           );
@@ -658,8 +656,16 @@ export const prepareVaultManagerKit = (
           // Putting all the rearrangements after the loop ensures that errors
           // in the calculations don't result in paying back some vaults and
           // leaving others hanging.
-          if (plan.transfers.length > 0) {
-            atomicRearrange(zcf, plan.transfers);
+          if (plan.transfersToVault.length > 0) {
+            const transfers = plan.transfersToVault.map(
+              ([vault, amounts]) =>
+                /** @type {import('@agoric/zoe/src/contractSupport/atomicTransfer.js').TransferPart} */ ([
+                  liqSeat,
+                  vault.getVaultSeat(),
+                  amounts,
+                ]),
+            );
+            atomicRearrange(zcf, harden(transfers));
           }
 
           // was reinstateAll
@@ -691,8 +697,19 @@ export const prepareVaultManagerKit = (
               'Minted',
             );
           }
-          if (!AmountMath.isEmpty(plan.collateralForReserve)) {
-            facets.helper.sendToReserve(plan.collateralForReserve, liqSeat);
+
+          // send all that's left in the seat
+          const collateralInLiqSeat = liqSeat.getCurrentAllocation().Collateral;
+          if (!AmountMath.isEmpty(collateralInLiqSeat)) {
+            facets.helper.sendToReserve(collateralInLiqSeat, liqSeat);
+          }
+          // if it didn't match what was expected, report
+          if (!AmountMath.isEqual(collateralInLiqSeat, plan.collatRemaining)) {
+            console.error(
+              `⚠️ Excess collateral remaining sent to reserve. Expected ${q(
+                plan.collatRemaining,
+              )}, sent ${q(collateralInLiqSeat)}`,
+            );
           }
 
           facets.helper.markCollateralLiquidated(
@@ -1075,7 +1092,7 @@ export const prepareVaultManagerKit = (
           trace(`LiqV after long wait`, proceeds);
           try {
             // distributeProceeds may reconstitute vaults, removing them from liquidatingVaults
-            await helper.distributeProceeds(
+            helper.distributeProceeds(
               proceeds,
               totalDebt,
               storedCollateralQuote,

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -677,7 +677,6 @@ export const prepareVaultManagerKit = (
             atomicRearrange(zcf, harden(transfers));
           }
 
-          // was reinstateAll
           const { prioritizedVaults } = collateralEphemera(
             totalCollateral.brand,
           );

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -643,12 +643,28 @@ export const prepareVaultManagerKit = (
             .getLiquidationPenalty();
           const bestToWorst = [...vaultData.entries()].reverse();
 
+          // unzip the entry tuples
+          const vaults = [];
+          const vaultBalances = [];
+          for (const [vault, balances] of bestToWorst) {
+            vaults.push(vault);
+            vaultBalances.push({
+              debtAmount: balances.debtAmount,
+              collateralAmount: balances.collateralAmount,
+              // current debt will be higher than the debtAmount before auction
+              // if interest accrued during auction
+              currentDebt: vault.getCurrentDebt(),
+            });
+          }
+          harden(vaults);
+          harden(vaultBalances);
+
           const plan = calculateDistributionPlan(
             proceeds,
             totalDebt,
             totalCollateral,
             oraclePriceAtStart.quoteAmount.value[0],
-            bestToWorst,
+            vaultBalances,
             penaltyRate,
           );
           trace('PLAN', plan);
@@ -658,10 +674,10 @@ export const prepareVaultManagerKit = (
           // leaving others hanging.
           if (plan.transfersToVault.length > 0) {
             const transfers = plan.transfersToVault.map(
-              ([vault, amounts]) =>
+              ([vaultIndex, amounts]) =>
                 /** @type {import('@agoric/zoe/src/contractSupport/atomicTransfer.js').TransferPart} */ ([
                   liqSeat,
-                  vault.getVaultSeat(),
+                  vaults[vaultIndex].getVaultSeat(),
                   amounts,
                 ]),
             );
@@ -672,7 +688,8 @@ export const prepareVaultManagerKit = (
           const { prioritizedVaults } = collateralEphemera(
             totalCollateral.brand,
           );
-          for (const vault of plan.vaultsToReinstate) {
+          for (const vaultIndex of plan.vaultsToReinstate) {
+            const vault = vaults[vaultIndex];
             const vaultId = vault.abortLiquidation();
             prioritizedVaults.addVault(vaultId, vault);
             state.liquidatingVaults.delete(vault);

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -145,10 +145,13 @@ export const produceInstallations = (space, installations) => {
   }
 };
 
+export const scale6 = x => BigInt(Math.round(x * 1_000_000));
+
 /**
  * @param {Pick<IssuerKit<'nat'>, 'brand' | 'issuer' | 'mint'>} kit
  */
 export const withAmountUtils = kit => {
+  const decimalPlaces = kit.issuer.getDisplayInfo?.()?.decimalPlaces ?? 6;
   return {
     ...kit,
     /**
@@ -161,6 +164,11 @@ export const withAmountUtils = kit => {
      * @param {NatValue} [d]
      */
     makeRatio: (n, d) => makeRatio(n, kit.brand, d),
+    /**
+     * @param {number} n
+     */
+    units: n =>
+      AmountMath.make(kit.brand, BigInt(Math.round(n * 10 ** decimalPlaces))),
   };
 };
 /** @typedef {ReturnType<typeof withAmountUtils>} AmountUtils */

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
@@ -13,7 +13,7 @@ import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
-import { withAmountUtils } from '../../supports.js';
+import { scale6, withAmountUtils } from '../../supports.js';
 
 const trace = makeTracer('BootPSMUpg');
 
@@ -21,10 +21,8 @@ export const psmV1BundleName = 'psmV1';
 
 const anchor = withAmountUtils(makeIssuerKit('bucks'));
 
-const scale6 = x => BigInt(Math.round(x * 1_000_000));
-
-const firstGive = anchor.make(scale6(21));
-const secondGive = anchor.make(scale6(3));
+const firstGive = anchor.units(21);
+const secondGive = anchor.units(3);
 
 /** @typedef {import('../../../src/psm/psm.js').prepare} PsmSF */
 

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -238,11 +238,20 @@ const setupServices = async (t, initialPrice, priceBase) => {
   ).governorCreatorFacet;
   const vaultFactoryCreatorFacet = E(governorCreatorFacet).getCreatorFacet();
 
-  // Add a vault that will lend on aeth collateral
+  // Setup default first collateral
+  const aethKeyword = 'AEth';
   const aethVaultManagerP = E(vaultFactoryCreatorFacet).addVaultType(
     aeth.issuer,
-    'AEth',
+    aethKeyword,
     rates,
+  );
+  await E(E.get(consume.auctioneerKit).creatorFacet).addBrand(
+    aeth.issuer,
+    aethKeyword,
+  );
+  await E(E.get(consume.reserveKit).creatorFacet).addIssuer(
+    aeth.issuer,
+    aethKeyword,
   );
 
   /** @type {[any, VaultFactoryCreatorFacet, VFC['publicFacet'], VaultManager]} */
@@ -461,6 +470,9 @@ export const makeManagerDriver = async (
     },
     /** @param {Amount<'nat'>} p */
     setPrice: p => priceAuthority.setPrice(makeRatioFromAmounts(p, priceBase)),
+    // XXX the paramPath should be implied by the object `setGovernedParam` is being called on.
+    // e.g. the manager driver should know the paramPath is `{ key: { collateralBrand: aeth.brand } }`
+    // and the director driver should `{ key: 'governedParams }`
     /**
      * @param {string} name
      * @param {*} newValue

--- a/packages/inter-protocol/test/vaultFactory/test-liquidation-plans.js
+++ b/packages/inter-protocol/test/vaultFactory/test-liquidation-plans.js
@@ -1,0 +1,75 @@
+import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { makeTracer } from '@agoric/internal';
+import { AmountMath } from '@agoric/ertp';
+import { SECONDS_PER_DAY } from '../../src/proposals/econ-behaviors.js';
+import {
+  makeAuctioneerDriver,
+  makeDriverContext,
+  makeManagerDriver,
+} from './driver.js';
+
+/**
+ * @typedef {import('./driver.js').DriverContext & {
+ * }} Context
+ */
+/** @type {import('ava').TestFn<Context>} */
+const test = unknownTest;
+
+const trace = makeTracer('TestLP', false);
+
+test.before(async t => {
+  // make interest slow because it's not the behavior under test
+  t.context = await makeDriverContext({
+    interestTiming: {
+      chargingPeriod: SECONDS_PER_DAY,
+      recordingPeriod: SECONDS_PER_DAY,
+    },
+  });
+  trace(t, 'CONTEXT');
+});
+
+// This doesn't test much in CI. It's meant to be used as a quick way to test
+// manually induced failures of calculateDistributionPlan. We want to be sure
+// that liquidation is robust to unexpected failures, but we don't have a way to
+// induce such failures in CI.
+//
+// We could have a double for the `proceeds.js` module but because it's an ESM
+// module that would require running Ava with a custom Node loader. For example,
+// https://github.com/testdouble/testdouble.js/blob/main/docs/7-replacing-dependencies.md#how-module-replacement-works-for-es-modules-using-import
+//
+// So instead we manually cause errors in the function and observe how the
+// vault manager executes it, verifying that the resulting state is valid.
+test('basic', async t => {
+  const { aeth, run } = t.context;
+  const md = await makeManagerDriver(t);
+  await md.setGovernedParam('DebtLimit', run.units(1000), {
+    key: { collateralBrand: aeth.brand },
+  });
+  const ad = await makeAuctioneerDriver(t);
+
+  const v1collat = aeth.units(20.0);
+  const v1debt = run.units(1.0);
+
+  const v1 = await md.makeVaultDriver(v1collat, v1debt);
+  const v2 = await md.makeVaultDriver(aeth.units(0.25), run.units(1));
+
+  // bump LiquidationMargin so they are under
+  await md.setGovernedParam('LiquidationMargin', run.makeRatio(20n, 1n), {
+    key: { collateralBrand: aeth.brand },
+  });
+  // high penalties for easy math
+  await md.setGovernedParam('LiquidationPenalty', run.makeRatio(20n, 1n), {
+    key: { collateralBrand: aeth.brand },
+  });
+
+  await ad.advanceTimerByStartFrequency();
+  await ad.advanceTimerByStartFrequency();
+
+  await v1.notified('active', {
+    locked: v1collat,
+  });
+  await v2.notified('liquidated', {
+    locked: aeth.makeEmpty(),
+  });
+});

--- a/packages/inter-protocol/test/vaultFactory/test-proceeds.js
+++ b/packages/inter-protocol/test/vaultFactory/test-proceeds.js
@@ -46,11 +46,8 @@ test('price drop', async t => {
   };
   const plan = calculateDistributionPlan(inputs);
   t.deepEqual(plan, {
-    accounting: {
-      overage: debt.makeEmpty(),
-      toBurn: debt.make(1680n),
-      shortfall: debt.makeEmpty(),
-    },
+    overage: debt.makeEmpty(),
+    shortfallToReserve: debt.makeEmpty(),
     collateralForReserve: coll.makeEmpty(),
     collatRemaining: coll.makeEmpty(),
     actualCollateralSold: coll.makeEmpty(),

--- a/packages/inter-protocol/test/vaultFactory/test-proceeds.js
+++ b/packages/inter-protocol/test/vaultFactory/test-proceeds.js
@@ -56,8 +56,6 @@ test('price drop', async t => {
     actualCollateralSold: coll.makeEmpty(),
     collateralSold: totalCollateral,
     debtToBurn: totalDebt,
-    liquidationsAborted: 0,
-    liquidationsCompleted: 1,
     mintedForReserve: debt.makeEmpty(),
     mintedProceeds: totalDebt,
     phantomInterest: debt.makeEmpty(),

--- a/packages/inter-protocol/test/vaultFactory/test-proceeds.js
+++ b/packages/inter-protocol/test/vaultFactory/test-proceeds.js
@@ -15,13 +15,15 @@ const test = unknownTest;
 /**
  * @param {bigint} debtN
  * @param {bigint} collN
+ * @param {bigint} currN
  * @returns {any}
  */
-const mockVaultEntry = (debtN, collN) => {
-  const debtAmount = debt.make(debtN);
-  const collateralAmount = coll.make(collN);
-  const vault = { getCurrentDebt: () => debtAmount };
-  return [vault, { debtAmount, collateralAmount }];
+const makeVaultBalances = (debtN, collN, currN = debtN) => {
+  return {
+    debtAmount: debt.make(debtN),
+    collateralAmount: coll.make(collN),
+    currentDebt: debt.make(currN),
+  };
 };
 
 test('price drop', async t => {
@@ -40,7 +42,7 @@ test('price drop', async t => {
     totalCollateral,
     oraclePriceAtStart: price,
     collateralInLiqSeat: coll.makeEmpty(),
-    bestToWorst: [mockVaultEntry(0n, 0n)],
+    bestToWorst: [makeVaultBalances(0n, 0n)],
     penaltyRate: makeRatio(10n, debt.brand, 100n),
   };
   const plan = calculateDistributionPlan(
@@ -62,6 +64,8 @@ test('price drop', async t => {
     actualCollateralSold: coll.makeEmpty(),
     collateralSold: totalCollateral,
     debtToBurn: totalDebt,
+    liquidationsAborted: 0,
+    liquidationsCompleted: 1,
     mintedForReserve: debt.makeEmpty(),
     mintedProceeds: totalDebt,
     phantomInterest: debt.makeEmpty(),

--- a/packages/inter-protocol/test/vaultFactory/test-proceeds.js
+++ b/packages/inter-protocol/test/vaultFactory/test-proceeds.js
@@ -18,7 +18,7 @@ const test = unknownTest;
  * @param {bigint} currN
  * @returns {any}
  */
-const makeVaultBalances = (debtN, collN, currN = debtN) => {
+const makeVaultBalance = (debtN, collN, currN = debtN) => {
   return {
     debtAmount: debt.make(debtN),
     collateralAmount: coll.make(collN),
@@ -41,18 +41,10 @@ test('price drop', async t => {
     totalDebt,
     totalCollateral,
     oraclePriceAtStart: price,
-    collateralInLiqSeat: coll.makeEmpty(),
-    bestToWorst: [makeVaultBalances(0n, 0n)],
+    vaultBalances: [makeVaultBalance(0n, 0n)],
     penaltyRate: makeRatio(10n, debt.brand, 100n),
   };
-  const plan = calculateDistributionPlan(
-    inputs.proceeds,
-    inputs.totalDebt,
-    inputs.totalCollateral,
-    inputs.oraclePriceAtStart,
-    inputs.bestToWorst,
-    inputs.penaltyRate,
-  );
+  const plan = calculateDistributionPlan(inputs);
   t.deepEqual(plan, {
     accounting: {
       overage: debt.makeEmpty(),

--- a/packages/inter-protocol/test/vaultFactory/test-proceeds.js
+++ b/packages/inter-protocol/test/vaultFactory/test-proceeds.js
@@ -1,0 +1,72 @@
+import '@agoric/zoe/exported.js';
+import { test as unknownTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { makeIssuerKit } from '@agoric/ertp';
+import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
+
+import { calculateDistributionPlan } from '../../src/vaultFactory/proceeds.js';
+import { withAmountUtils } from '../supports.js';
+
+const debt = withAmountUtils(makeIssuerKit('IST'));
+const coll = withAmountUtils(makeIssuerKit('aEth'));
+
+const test = unknownTest;
+
+/**
+ * @param {bigint} debtN
+ * @param {bigint} collN
+ * @returns {any}
+ */
+const mockVaultEntry = (debtN, collN) => {
+  const debtAmount = debt.make(debtN);
+  const collateralAmount = coll.make(collN);
+  const vault = { getCurrentDebt: () => debtAmount };
+  return [vault, { debtAmount, collateralAmount }];
+};
+
+test('price drop', async t => {
+  const totalDebt = debt.make(1680n);
+  const totalCollateral = coll.make(400n);
+  const price = /** @type {PriceDescription} */ ({
+    amountIn: coll.make(1000000n),
+    amountOut: debt.make(4000000n),
+  });
+  const inputs = {
+    proceeds: {
+      Minted: totalDebt,
+      Collateral: coll.makeEmpty(),
+    },
+    totalDebt,
+    totalCollateral,
+    oraclePriceAtStart: price,
+    collateralInLiqSeat: coll.makeEmpty(),
+    bestToWorst: [mockVaultEntry(0n, 0n)],
+    penaltyRate: makeRatio(10n, debt.brand, 100n),
+  };
+  const plan = calculateDistributionPlan(
+    inputs.proceeds,
+    inputs.totalDebt,
+    inputs.totalCollateral,
+    inputs.oraclePriceAtStart,
+    inputs.bestToWorst,
+    inputs.penaltyRate,
+  );
+  t.deepEqual(plan, {
+    accounting: {
+      overage: debt.makeEmpty(),
+      toBurn: debt.make(1680n),
+      shortfall: debt.makeEmpty(),
+    },
+    collateralForReserve: coll.makeEmpty(),
+    collatRemaining: coll.makeEmpty(),
+    actualCollateralSold: coll.makeEmpty(),
+    collateralSold: totalCollateral,
+    debtToBurn: totalDebt,
+    mintedForReserve: debt.makeEmpty(),
+    mintedProceeds: totalDebt,
+    phantomInterest: debt.makeEmpty(),
+    totalPenalty: coll.make(42n),
+    transfersToVault: [],
+    vaultsToReinstate: [],
+  });
+});

--- a/packages/inter-protocol/test/vaultFactory/test-proceeds.js
+++ b/packages/inter-protocol/test/vaultFactory/test-proceeds.js
@@ -16,12 +16,12 @@ const test = unknownTest;
  * @param {bigint} debtN
  * @param {bigint} collN
  * @param {bigint} currN
- * @returns {any}
+ * @returns {import('../../src/vaultFactory/proceeds.js').VaultBalances}
  */
 const makeVaultBalance = (debtN, collN, currN = debtN) => {
   return {
-    debtAmount: debt.make(debtN),
-    collateralAmount: coll.make(collN),
+    collateral: coll.make(collN),
+    presaleDebt: debt.make(debtN),
     currentDebt: debt.make(currN),
   };
 };
@@ -41,7 +41,7 @@ test('price drop', async t => {
     totalDebt,
     totalCollateral,
     oraclePriceAtStart: price,
-    vaultBalances: [makeVaultBalance(0n, 0n)],
+    vaultsBalances: [makeVaultBalance(0n, 0n)],
     penaltyRate: makeRatio(10n, debt.brand, 100n),
   };
   const plan = calculateDistributionPlan(inputs);
@@ -58,7 +58,7 @@ test('price drop', async t => {
     debtToBurn: totalDebt,
     mintedForReserve: debt.makeEmpty(),
     mintedProceeds: totalDebt,
-    phantomInterest: debt.makeEmpty(),
+    phantomDebt: debt.makeEmpty(),
     totalPenalty: coll.make(42n),
     transfersToVault: [],
     vaultsToReinstate: [],

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -492,8 +492,8 @@ test('price drop', async t => {
 
   await m.assertLike({
     allocations: {
-      Aeth: aeth.makeEmpty(),
-      Fee: run.makeEmpty(),
+      Aeth: undefined,
+      Fee: undefined,
     },
   });
 });
@@ -981,7 +981,7 @@ test('liquidate two loans', async t => {
   await m.assertLike({
     allocations: {
       Aeth: aeth.make(8n),
-      Fee: run.makeEmpty(),
+      Fee: undefined,
     },
   });
 });
@@ -1950,7 +1950,7 @@ test('reinstate vault', async t => {
   await m.assertLike({
     allocations: {
       Aeth: aeth.make(12n),
-      Fee: run.makeEmpty(),
+      Fee: undefined,
     },
   });
 });
@@ -2526,7 +2526,6 @@ test('Bug 7346 excess collateral to holder', async t => {
     shortfallBalance: run.makeEmpty(),
     allocations: {
       Aeth: aeth.make(309_852n),
-      Fee: run.makeEmpty(),
     },
   });
 });
@@ -2729,7 +2728,7 @@ test('refund to one of two loans', async t => {
   await m.assertLike({
     allocations: {
       Aeth: aeth.make(9n),
-      Fee: run.makeEmpty(),
+      Fee: undefined,
     },
   });
 });
@@ -2939,7 +2938,6 @@ test('Bug 7784 reconstitute both', async t => {
     shortfallBalance: run.make(5_525n),
     allocations: {
       Aeth: aeth.make(1_620n),
-      Fee: run.makeEmpty(),
     },
   });
 });
@@ -3218,7 +3216,6 @@ test('Bug 7796 missing lockedPrice', async t => {
     shortfallBalance: run.makeEmpty(),
     allocations: {
       Aeth: aeth.make(309_852n),
-      Fee: run.makeEmpty(),
     },
   });
 });
@@ -3370,7 +3367,6 @@ test('Bug 7851 & no bidders', async t => {
     shortfallBalance: run.make(0n),
     allocations: {
       Aeth: aeth.make(penalty),
-      Fee: run.makeEmpty(),
     },
   });
 

--- a/packages/zoe/tools/manualPriceAuthority.js
+++ b/packages/zoe/tools/manualPriceAuthority.js
@@ -88,3 +88,4 @@ export function makeManualPriceAuthority(options) {
     ...priceAuthority,
   });
 }
+/** @typedef {ReturnType<typeof makeManualPriceAuthority>} ManualPriceAuthority */


### PR DESCRIPTION
closes: #7850 

## Description

We had a [bug in distributeProceeds](https://github.com/Agoric/agoric-sdk/issues/7851). It's since been fixed, but it revealed that an error in that function would [leave vaults in a "liquidating" state forever](https://github.com/Agoric/agoric-sdk/issues/7850).

This moves the state transition out of `distributeProceeds` so that it always executes. It also cleans up some redundant state tracking, `vaultsToLiquidate`, which is simply the values in `liquidatingVaults` that haven't been deleted during the distribution/reconstitution.

### Security Considerations

no change

### Scaling Considerations

no change

### Documentation Considerations

--

### Testing Considerations

It would be good to have a test of this error handling but we don't have a way to induce the failure. It's not _expected_ to fail. This is a precaution in case it does anyway.