### PR TITLE
fix(xsnap): update Moddable SDK to fix BigInt arithmetic

### DIFF
--- a/packages/xsnap/build.env
+++ b/packages/xsnap/build.env
@@ -1,4 +1,4 @@
 MODDABLE_URL=https://github.com/agoric-labs/moddable.git
-MODDABLE_COMMIT_HASH=46bbad5b8aa746c50b5f97aee1b1f235ab2a5903
+MODDABLE_COMMIT_HASH=f6c5951fc055e4ca592b9166b9ae3cbb9cca6bf0
 XSNAP_NATIVE_URL=https://github.com/agoric-labs/xsnap-pub
 XSNAP_NATIVE_COMMIT_HASH=056faf8c8930a20659dd4eaa3ebfae3a8b464c7f


### PR DESCRIPTION
closes: #7864

## Description

Cherry picks a Moddable SDK commit reverting a broken change that had made it into the [3.8.7 update](https://github.com/Agoric/agoric-sdk/pull/7498).

### Security Considerations

This solves a bad arithmetic issue that was forced on as an effect of https://github.com/Agoric/agoric-sdk/pull/7830 (before that change we would have experienced a divergence between validators)

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Re-ran acceptance tests (see #6929) replaying vat42 on gcc9, 10 and clang.

We do not currently have a unit test reproducing this but may be able to derive one later.
