### PR TITLE
chore(eslint): add `safe-await-separator` and tighten rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -67,8 +67,8 @@ module.exports = {
     // that are used by multiple clients. So we enable it throughout the repo
     // and aim for no exceptions.
     //
-    // TODO the default is 'warn', but upgrade this to 'error' when possible
-    // '@jessie.js/safe-await-separator': 'error',
+    // The default is 'warn', but we want to enforce 'error'.
+    '@jessie.js/safe-await-separator': 'error',
 
     // CI has a separate format check but keep this warn to maintain that "eslint --fix" prettifies
     // UNTIL https://github.com/Agoric/agoric-sdk/issues/4339
@@ -107,6 +107,7 @@ module.exports = {
       files: [
         'packages/**/demo/**/*.js',
         'packages/*/test/**/*.js',
+        'packages/*/test/**/*.test.js',
         'packages/wallet/api/test/**/*.js',
       ],
       rules: {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,18 +4,18 @@ const process = require('process');
 
 const lintTypes = !!process.env.AGORIC_ESLINT_TYPES;
 
-const loanContractDeprecated = [
+const deprecatedForLoanContract = [
   ['currency', 'brand, asset or another descriptor'],
   ['blacklist', 'denylist'],
   ['whitelist', 'allowlist'],
   ['RUN', 'IST', '/RUN/'],
 ];
-const allDeprecated = [...loanContractDeprecated, ['loan', 'debt']];
+const allDeprecated = [...deprecatedForLoanContract, ['loan', 'debt']];
 
 const deprecatedTerminology = Object.fromEntries(
   Object.entries({
     all: allDeprecated,
-    loanContract: loanContractDeprecated,
+    loanContract: deprecatedForLoanContract,
   }).map(([category, deprecated]) => [
     category,
     deprecated.flatMap(([bad, good, badRgx = `/${bad}/i`]) =>

--- a/.github/actions/restore-golang/action.yml
+++ b/.github/actions/restore-golang/action.yml
@@ -20,18 +20,7 @@ runs:
       with:
         cache-dependency-path: golang/cosmos/go.sum
         go-version: ${{ inputs.go-version }}
-    - uses: kenchan0130/actions-system-info@master
-      id: system-info
-    - name: cache Go modules
-      id: cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.GOPATH }}/pkg/mod
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-go-${{ inputs.go-version }}-built-${{ hashFiles('golang/**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-go-${{ inputs.go-version }}-built-
     - name: go mod download
       working-directory: ./golang/cosmos
       run: go mod download
       shell: bash
-      if: steps.cache.outputs.cache-hit != 'true'

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "packageManager": "yarn@1.22.19",
   "devDependencies": {
     "@endo/eslint-plugin": "^0.4.3",
-    "@jessie.js/eslint-plugin": "^0.3.0",
+    "@jessie.js/eslint-plugin": "^0.4.0",
     "@types/node": "^16.13.0",
     "@typescript-eslint/parser": "^5.55.0",
     "ava": "^5.2.0",
@@ -77,6 +77,6 @@
     "**/puppeteer-core/node-fetch": "^2.6.5",
     "**/eslint/@babel/code-frame": "^7.12.11",
     "**/eslint-config-react-app/eslint-plugin-jest": "^26.0.0",
-    "**/@endo/eslint-config/@jessie.js/eslint-plugin": "^0.3.0"
+    "**/@endo/eslint-config/@jessie.js/eslint-plugin": "^0.4.0"
   }
 }

--- a/packages/SwingSet/misc-tools/extract-xs-snapshot.js
+++ b/packages/SwingSet/misc-tools/extract-xs-snapshot.js
@@ -4,6 +4,7 @@ import '@endo/init';
 import process from 'process';
 import fs from 'fs';
 import { isSwingStore, openSwingStore } from '@agoric/swing-store';
+import { E } from '@endo/far';
 
 const argv = process.argv.splice(2);
 const dirPath = argv[0];
@@ -53,6 +54,7 @@ if (!vatIDToExtract) {
   const { snapPos, hash } = info;
   const snapshot = snapStore.loadSnapshot(vatIDToExtract);
   const fn = `${vatIDToExtract}-${snapPos}-${hash}.xss`;
-  await fs.promises.writeFile(fn, snapshot);
-  console.log(`wrote snapshot to ${fn}`);
+  E.when(fs.promises.writeFile(fn, snapshot), () =>
+    console.log(`wrote snapshot to ${fn}`),
+  );
 }

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -290,6 +290,7 @@ async function replay(transcriptFile) {
   /** @type {WorkerData[]} */
   const workers = [];
 
+  await null;
   if (worker === 'xs-worker') {
     /** @type {import('../src/types-external.js').Bundle[] | undefined} */
     let overrideBundles;
@@ -422,6 +423,7 @@ async function replay(transcriptFile) {
     completeWorkerStep(workerData);
     workers.push(workerData);
     updateWorkersSynced();
+    const currentBundleIDs = await bundleHandler.getCurrentBundleIDs();
     const managerOptions =
       /** @type {import('../src/types-internal.js').ManagerOptions} */ (
         /** @type {Partial<import('../src/types-internal.js').ManagerOptions>} */ ({
@@ -430,7 +432,7 @@ async function replay(transcriptFile) {
           useTranscript: true,
           workerOptions: {
             type: worker === 'xs-worker' ? 'xsnap' : worker,
-            bundleIDs: await bundleHandler.getCurrentBundleIDs(),
+            bundleIDs: currentBundleIDs,
           },
         })
       );

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -482,7 +482,6 @@ async function replay(transcriptFile) {
             deliveryTimeTotal,
             firstTranscriptNum,
           } = workerData;
-          // eslint-disable-next-line no-await-in-loop
           await manager.shutdown();
           console.log(
             `Shutdown worker PID ${xsnapPID} (start delivery ${firstTranscriptNum}).\n    Delivery time since last snapshot ${
@@ -648,7 +647,6 @@ async function replay(transcriptFile) {
         }
         if (argv.forcedReloadFromSnapshot) {
           for (const snapshotID of uniqueSnapshotIDs) {
-            // eslint-disable-next-line no-await-in-loop
             await loadSnapshot(
               { ...data, snapshotID },
               argv.keepWorkerHashDifference && divergent,
@@ -722,7 +720,6 @@ async function replay(transcriptFile) {
 
         if (argv.forcedReloadFromSnapshot) {
           for (const snapshotID of uniqueSnapshotIDs) {
-            // eslint-disable-next-line no-await-in-loop
             await loadSnapshot(
               {
                 snapshotID,
@@ -737,7 +734,6 @@ async function replay(transcriptFile) {
           argv.loadSnapshots?.[transcriptNum] || [],
         );
         for (const snapshotID of loadSnapshots) {
-          // eslint-disable-next-line no-await-in-loop
           await loadSnapshot(
             {
               snapshotID,

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -168,6 +168,7 @@ export async function makeSwingsetController(
   writeSlogObject({ type: 'kernel-init-start' });
 
   writeSlogObject({ type: 'bundle-kernel-start' });
+  await null;
   const { kernelBundle = await buildKernelBundle() } = runtimeOptions;
   writeSlogObject({ type: 'bundle-kernel-finish' });
 
@@ -472,6 +473,7 @@ export async function buildVatController(
   };
   const initializationOptions = { verbose, kernelBundles };
   let bootstrapResult;
+  await null;
   if (!swingsetIsInitialized(kernelStorage)) {
     bootstrapResult = await initializeSwingset(
       config,

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -168,7 +168,6 @@ export async function makeSwingsetController(
   writeSlogObject({ type: 'kernel-init-start' });
 
   writeSlogObject({ type: 'bundle-kernel-start' });
-  // eslint-disable-next-line @jessie.js/no-nested-await
   const { kernelBundle = await buildKernelBundle() } = runtimeOptions;
   writeSlogObject({ type: 'bundle-kernel-finish' });
 
@@ -474,7 +473,6 @@ export async function buildVatController(
   const initializationOptions = { verbose, kernelBundles };
   let bootstrapResult;
   if (!swingsetIsInitialized(kernelStorage)) {
-    // eslint-disable-next-line @jessie.js/no-nested-await
     bootstrapResult = await initializeSwingset(
       config,
       argv,

--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -63,6 +63,7 @@ export async function initializeKernel(config, kernelStorage, options = {}) {
   let gotVatAdminRootKref;
 
   // generate the genesis vats
+  await null;
   if (config.vats) {
     for (const name of Object.keys(config.vats)) {
       const {

--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -91,7 +91,6 @@ export async function initializeKernel(config, kernelStorage, options = {}) {
 
       const source = { bundleID };
       const staticOptions = { name, ...creationOptions };
-      // eslint-disable-next-line @jessie.js/no-nested-await,no-await-in-loop
       await optionRecorder.recordStatic(vatID, source, staticOptions);
 
       kernelKeeper.addToAcceptanceQueue(

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -35,7 +35,6 @@ const { keys, values, fromEntries } = Object;
  * @template V
  */
 const allValues = async obj =>
-  // eslint-disable-next-line @jessie.js/no-nested-await
   fromEntries(zip(keys(obj), await Promise.all(values(obj))));
 
 const bundleRelative = rel =>
@@ -173,7 +172,6 @@ export function loadBasedir(basedir, options = {}) {
  */
 async function resolveSpecFromConfig(referrer, specPath) {
   try {
-    // eslint-disable-next-line @jessie.js/no-nested-await
     return new URL(await resolveModuleSpecifier(specPath, referrer)).pathname;
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND' && e.code !== 'ERR_MODULE_NOT_FOUND') {
@@ -239,9 +237,7 @@ export async function loadSwingsetConfigFile(configPath) {
       configPath,
       `file:///${process.cwd()}/`,
     ).toString();
-    // eslint-disable-next-line @jessie.js/no-nested-await
     await normalizeConfigDescriptor(config.vats, referrer, true);
-    // eslint-disable-next-line @jessie.js/no-nested-await
     await normalizeConfigDescriptor(config.bundles, referrer, false);
     // await normalizeConfigDescriptor(config.devices, referrer, true); // TODO: represent devices
     config.bootstrap || Fail`no designated bootstrap vat in ${configPath}`;

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -34,8 +34,10 @@ const { keys, values, fromEntries } = Object;
  * @returns {Promise<Record<string, V>>}
  * @template V
  */
-const allValues = async obj =>
-  fromEntries(zip(keys(obj), await Promise.all(values(obj))));
+const allValues = async obj => {
+  const vs = await Promise.all(values(obj));
+  return fromEntries(zip(keys(obj), vs));
+};
 
 const bundleRelative = rel =>
   bundleSource(new URL(rel, import.meta.url).pathname);
@@ -171,6 +173,7 @@ export function loadBasedir(basedir, options = {}) {
  *    determined.
  */
 async function resolveSpecFromConfig(referrer, specPath) {
+  await null;
   try {
     return new URL(await resolveModuleSpecifier(specPath, referrer)).pathname;
   } catch (e) {
@@ -231,6 +234,7 @@ async function normalizeConfigDescriptor(desc, referrer, expectParameters) {
  *    invalid.
  */
 export async function loadSwingsetConfigFile(configPath) {
+  await null;
   try {
     const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     const referrer = new URL(

--- a/packages/SwingSet/src/controller/startXSnap.js
+++ b/packages/SwingSet/src/controller/startXSnap.js
@@ -138,6 +138,7 @@ export function makeStartXSnap(options) {
   ) {
     const meterOpts = metered ? {} : { meteringLimit: 0 };
     const snapshotLoadOpts = getSnapshotLoadOptions(initDetails);
+    await null;
     if (snapshotLoadOpts) {
       const xs = await doXSnap({
         name,

--- a/packages/SwingSet/src/controller/startXSnap.js
+++ b/packages/SwingSet/src/controller/startXSnap.js
@@ -139,7 +139,6 @@ export function makeStartXSnap(options) {
     const meterOpts = metered ? {} : { meteringLimit: 0 };
     const snapshotLoadOpts = getSnapshotLoadOptions(initDetails);
     if (snapshotLoadOpts) {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const xs = await doXSnap({
         name,
         handleCommand,
@@ -147,7 +146,6 @@ export function makeStartXSnap(options) {
         ...meterOpts,
         ...xsnapOpts,
       });
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await xs.isReady();
       return xs;
     }
@@ -164,7 +162,6 @@ export function makeStartXSnap(options) {
       bundles = overrideBundles; // ignore the usual bundles
     } else {
       const bundlePs = bundleIDs.map(id => bundleHandler.getBundle(id));
-      // eslint-disable-next-line @jessie.js/no-nested-await
       bundles = await Promise.all(bundlePs);
     }
 
@@ -173,7 +170,6 @@ export function makeStartXSnap(options) {
       if (moduleFormat !== 'getExport' && moduleFormat !== 'nestedEvaluate') {
         throw Fail`unexpected moduleFormat: ${moduleFormat}`;
       }
-      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       await worker.evaluate(`(${bundle.source}\n)()`.trim());
     }
     return worker;

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -399,7 +399,6 @@ export default function buildKernel(
     const vs = kernelSlog.provideVatSlogger(vatID).vatSlog;
     try {
       /** @type { VatDeliveryResult } */
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const deliveryResult = await vatWarehouse.deliverToVat(vatID, kd, vd, vs);
       insistVatDeliveryResult(deliveryResult);
       // const [ ok, problem, usage ] = deliveryResult;
@@ -424,7 +423,6 @@ export default function buildKernel(
         //   Kinds, and we're not going to use the worker
         //
         // So in all cases, our caller should abandon the worker.
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await vatWarehouse.stopWorker(vatID);
         // TODO: does stopWorker work if the worker process just died?
         status.deliveryError = deliveryResult[1];
@@ -696,7 +694,6 @@ export default function buildKernel(
     // supervisor bundles are bad.
 
     try {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await vatWarehouse.createDynamicVat(vatID);
     } catch (err) {
       console.log('error during createDynamicVat', err);
@@ -834,7 +831,6 @@ export default function buildKernel(
     const abortUpgrade = async (badDeliveryResults, errorCapData) => {
       // get rid of the worker, so the next delivery to this vat will
       // re-create one from the previous state
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await vatWarehouse.stopWorker(vatID);
 
       // notify vat-admin of the failed upgrade without revealing error details
@@ -897,7 +893,6 @@ export default function buildKernel(
         `WARNING: vat ${vatID} failed to upgrade from incarnation ${oldIncarnation} (BOYD)`,
       );
       const { info: errorCapData } = boydResults.terminate;
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const results = await abortUpgrade(boydResults, errorCapData);
       return results;
     }
@@ -961,7 +956,6 @@ export default function buildKernel(
         `WARNING: vat ${vatID} failed to upgrade from incarnation ${oldIncarnation} (startVat)`,
       );
       const { info: errorCapData } = startVatResults.terminate;
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const results = await abortUpgrade(startVatResults, errorCapData);
       return results;
     }
@@ -1279,7 +1273,6 @@ export default function buildKernel(
     } else {
       const vatID = crankResults.didDelivery;
       if (vatID) {
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await vatWarehouse.maybeSaveSnapshot(vatID);
       }
     }
@@ -1312,7 +1305,6 @@ export default function buildKernel(
       kdebug(`vat terminated: ${JSON.stringify(info)}`);
       kernelSlog.terminateVat(vatID, reject, info);
       // this deletes state, rejects promises, notifies vat-admin
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await terminateVat(vatID, reject, info);
     }
 
@@ -1349,7 +1341,6 @@ export default function buildKernel(
     }
     processQueueRunning = Error('here');
     try {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const result = await processor(message);
       processQueueRunning = undefined;
       return result;
@@ -1650,7 +1641,6 @@ export default function buildKernel(
 
       const bundle = kernelKeeper.getBundle(source.bundleID);
       assert(bundle);
-      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       const NS = await importBundle(bundle, {
         filePrefix: `dev-${name}/...`,
         endowments: harden({ ...vatEndowments, console: devConsole, assert }),
@@ -1767,7 +1757,6 @@ export default function buildKernel(
       const { processor, message } = getNextMessageAndProcessor();
       // process a single message
       if (message) {
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await tryProcessMessage(processor, message);
         if (kernelPanic) {
           throw kernelPanic;
@@ -1806,7 +1795,6 @@ export default function buildKernel(
         }
         count += 1;
         /** @type { PolicyInput } */
-        // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
         const policyInput = await tryProcessMessage(processor, message);
         if (kernelPanic) {
           throw kernelPanic;

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -397,6 +397,7 @@ export default function buildKernel(
     assert(vatWarehouse.lookup(vatID));
     // Ensure that the vatSlogger is available before clist translation.
     const vs = kernelSlog.provideVatSlogger(vatID).vatSlog;
+    await null;
     try {
       /** @type { VatDeliveryResult } */
       const deliveryResult = await vatWarehouse.deliverToVat(vatID, kd, vd, vs);
@@ -1340,6 +1341,7 @@ export default function buildKernel(
       Fail`Kernel reentrancy is forbidden`;
     }
     processQueueRunning = Error('here');
+    await null;
     try {
       const result = await processor(message);
       processQueueRunning = undefined;
@@ -1752,6 +1754,7 @@ export default function buildKernel(
       throw Error('must do kernel.start() before step()');
     }
     kernelKeeper.startCrank();
+    await null;
     try {
       kernelKeeper.establishCrankSavepoint('start');
       const { processor, message } = getNextMessageAndProcessor();
@@ -1785,6 +1788,7 @@ export default function buildKernel(
       throw Error('must do kernel.start() before run()');
     }
     let count = 0;
+    await null;
     for (;;) {
       kernelKeeper.startCrank();
       try {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-local.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-local.js
@@ -93,6 +93,7 @@ export function makeLocalVatManagerFactory({
       return vatNS;
     }
 
+    await null;
     if (enableSetup) {
       const vatNS = await buildVatNamespace({}, {});
       const setup = vatNS.default;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-local.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-local.js
@@ -94,7 +94,6 @@ export function makeLocalVatManagerFactory({
     }
 
     if (enableSetup) {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const vatNS = await buildVatNamespace({}, {});
       const setup = vatNS.default;
       setup || Fail`vat source bundle lacks (default) setup() function`;

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -187,6 +187,7 @@ export function makeXsSubprocessFactory({
       parentLog(vatID, `sending delivery`, delivery);
       /** @type { WorkerResults } */
       let result;
+      await null;
       try {
         result = await issueTagged(['deliver', delivery]);
       } catch (err) {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -165,7 +165,6 @@ export function makeXsSubprocessFactory({
       parentLog(vatID, `snapshot loaded. dispatch ready.`);
     } else {
       parentLog(vatID, `instructing worker to load bundle..`);
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const { reply: bundleReply } = await issueTagged([
         'setBundle',
         vatID,
@@ -189,7 +188,6 @@ export function makeXsSubprocessFactory({
       /** @type { WorkerResults } */
       let result;
       try {
-        // eslint-disable-next-line @jessie.js/no-nested-await
         result = await issueTagged(['deliver', delivery]);
       } catch (err) {
         parentLog('issueTagged error:', err.code, err.message);

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -371,7 +371,6 @@ export function makeVatWarehouse({
     const { enablePipelining = false } = options;
 
     if (options.useTranscript) {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await replayTranscript(vatID, vatKeeper, manager);
     }
 
@@ -419,7 +418,6 @@ export function makeVatWarehouse({
         break;
       }
       logStartup(`provideVatKeeper for vat ${name} as vat ${vatID}`);
-      // eslint-disable-next-line no-await-in-loop
       await ensureVatOnline(vatID, recreate);
       numPreloaded += 1;
     }
@@ -431,7 +429,6 @@ export function makeVatWarehouse({
         break;
       }
       logStartup(`provideVatKeeper for dynamic vat ${vatID}`);
-      // eslint-disable-next-line no-await-in-loop
       await ensureVatOnline(vatID, recreate);
       numPreloaded += 1;
     }
@@ -670,7 +667,6 @@ export function makeVatWarehouse({
     // worker may or may not be online
     if (ephemeral.vats.has(vatID)) {
       try {
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await evict(vatID);
       } catch (err) {
         console.debug('vat termination was already reported; ignoring:', err);

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -665,6 +665,7 @@ export function makeVatWarehouse({
    */
   async function stopWorker(vatID) {
     // worker may or may not be online
+    await null;
     if (ephemeral.vats.has(vatID)) {
       try {
         await evict(vatID);

--- a/packages/SwingSet/src/lib/workerOptions.js
+++ b/packages/SwingSet/src/lib/workerOptions.js
@@ -7,7 +7,6 @@ export async function makeWorkerOptions(managerType, bundleHandler) {
   if (managerType === 'local') {
     return harden({ type: 'local' });
   } else if (managerType === 'xsnap' || managerType === 'xs-worker') {
-    // eslint-disable-next-line @jessie.js/no-nested-await, no-await-in-loop
     const bundleIDs = await bundleHandler.getCurrentBundleIDs();
     return harden({ type: 'xsnap', bundleIDs });
   }
@@ -27,7 +26,6 @@ export async function updateWorkerOptions(
   if (type === 'local') {
     return origWorkerOptions;
   } else if (type === 'xsnap') {
-    // eslint-disable-next-line @jessie.js/no-nested-await, no-await-in-loop
     const bundleIDs = await bundleHandler.getCurrentBundleIDs();
     return harden({ ...origWorkerOptions, bundleIDs });
   }

--- a/packages/SwingSet/src/lib/workerOptions.js
+++ b/packages/SwingSet/src/lib/workerOptions.js
@@ -4,6 +4,7 @@
  * @returns {Promise<import("../types-internal").WorkerOptions>}
  */
 export async function makeWorkerOptions(managerType, bundleHandler) {
+  await null;
   if (managerType === 'local') {
     return harden({ type: 'local' });
   } else if (managerType === 'xsnap' || managerType === 'xs-worker') {
@@ -23,6 +24,7 @@ export async function updateWorkerOptions(
   { bundleHandler },
 ) {
   const { type } = origWorkerOptions;
+  await null;
   if (type === 'local') {
     return origWorkerOptions;
   } else if (type === 'xsnap') {

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -228,6 +228,7 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
   }
 
   async function upgradeStaticVat(vatID, pauseTarget, bundleID, options) {
+    await null;
     if (pauseTarget) {
       await E(pauseTarget)
         .pauseService()

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -229,18 +229,15 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
 
   async function upgradeStaticVat(vatID, pauseTarget, bundleID, options) {
     if (pauseTarget) {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await E(pauseTarget)
         .pauseService()
         .catch(() => true);
     }
     let status;
     try {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       status = await upgradeVat(vatID, bundleID, options);
     } catch (e) {
       if (pauseTarget) {
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await E(pauseTarget)
           .resumeService()
           .catch(() => true);

--- a/packages/SwingSet/test/bootstrap-relay.js
+++ b/packages/SwingSet/test/bootstrap-relay.js
@@ -118,7 +118,6 @@ export const buildRootObject = () => {
     awaitVatObject: async ({ presence, path = [], rawOutput = false }) => {
       let value = await decodePassable(presence);
       for (const key of path) {
-        // eslint-disable-next-line no-await-in-loop
         value = await value[key];
       }
       return rawOutput ? value : encodePassable(value);

--- a/packages/SwingSet/test/device-plugin/test-device.js
+++ b/packages/SwingSet/test/device-plugin/test-device.js
@@ -67,7 +67,6 @@ async function setupVatController(t) {
     await c.run();
     while (inputQueue.length) {
       inputQueue.shift()();
-      // eslint-disable-next-line no-await-in-loop
       await c.run();
     }
   };

--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 // eslint-disable-next-line import/order
 import { test } from '../../tools/prepare-test-env-ava.js';
 

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -361,15 +361,12 @@ test.serial('bootstrap export', async t => {
   // or the temporary acceptance queue, so we use this helper function
   async function stepGC() {
     while (c.dump().gcActions.length) {
-      // eslint-disable-next-line no-await-in-loop
       await c.step();
     }
     while (c.dump().reapQueue.length) {
-      // eslint-disable-next-line no-await-in-loop
       await c.step();
     }
     while (c.dump().acceptanceQueue.length) {
-      // eslint-disable-next-line no-await-in-loop
       await c.step();
     }
     await c.step(); // the non- GC action
@@ -377,7 +374,6 @@ test.serial('bootstrap export', async t => {
 
   t.deepEqual(c.dump().log, []);
   for (let i = 0; i < 7; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     await stepGC(); // vat starts
   }
   // console.log('--- c.step() running bootstrap.obj0.bootstrap');

--- a/packages/SwingSet/test/test-transcript.js
+++ b/packages/SwingSet/test/test-transcript.js
@@ -10,7 +10,6 @@ async function buildTrace(c, debug) {
   const states = []; // list of { dump, serialized }
   while (c.dump().runQueue.length && c.dump().gcActions.length) {
     states.push({ dump: debug.dump(), serialized: debug.serialize() });
-    // eslint-disable-next-line no-await-in-loop
     await c.step();
   }
   states.push({ dump: debug.dump(), serialized: debug.serialize() });
@@ -58,15 +57,12 @@ test('transcript-one load', async t => {
   //                                JSON.stringify(states[j].dump)));
 
   for (let i = 0; i < states.length; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     const cfg = await loadBasedir(
       new URL('basedir-transcript', import.meta.url).pathname,
     );
     const { serialized } = states[i];
     const { kernelStorage: s, debug: d } = initSwingStore(null, { serialized });
-    // eslint-disable-next-line no-await-in-loop
     const c = await buildVatController(cfg, ['one'], { kernelStorage: s });
-    // eslint-disable-next-line no-await-in-loop
     const newstates = await buildTrace(c, d);
     // newstates.forEach((s,j) =>
     //                  fs.writeFileSync(`kdata-${i+j}-${i}+${j}.json`,

--- a/packages/SwingSet/test/test-vat-timer.js
+++ b/packages/SwingSet/test/test-vat-timer.js
@@ -1163,7 +1163,6 @@ test('iterator', async t => {
     if (state.currentWakeup && state.currentHandler) {
       state.currentHandler.wake(state.now);
     }
-    // eslint-disable-next-line no-await-in-loop
     await waitUntilQuiescent();
   }
   await p6a;
@@ -1194,7 +1193,6 @@ const drainForOf = async (n, results) => {
 const drainManual = async (n, results) => {
   const iter = n[Symbol.asyncIterator]();
   for (;;) {
-    // eslint-disable-next-line no-await-in-loop
     const res = await iter.next();
     if (res.done) {
       results.push({ returnValue: res.value });

--- a/packages/SwingSet/test/transcript/test-state-sync-reload.js
+++ b/packages/SwingSet/test/transcript/test-state-sync-reload.js
@@ -77,7 +77,6 @@ test('state-sync reload', async t => {
   // current transcript of just d20 = 'load-snapshot' and d21 =
   // 'message' (count -> 7)
   for (let i = 1; i <= 7; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     const res = await doCount(c1);
     t.is(res, i);
   }

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 // eslint-disable-next-line import/order
 import { test } from '../../tools/prepare-test-env-ava.js';
 

--- a/packages/SwingSet/test/vat-admin/test-create-vat.js
+++ b/packages/SwingSet/test/vat-admin/test-create-vat.js
@@ -338,7 +338,6 @@ test('createVat holds refcount', async t => {
 
   async function stepUntil(predicate) {
     for (;;) {
-      // eslint-disable-next-line no-await-in-loop
       const more = await c.step();
       // const { refcount, refs } = findRefs(kvStore, held);
       // const rc = kvStore.get(`${held}.refCount`);

--- a/packages/SwingSet/test/vat-warehouse/test-warehouse.js
+++ b/packages/SwingSet/test/vat-warehouse/test-warehouse.js
@@ -78,7 +78,6 @@ async function runSteps(c, t) {
   for (const { vat, online } of steps) {
     t.log('sending to vat', vat);
     c.queueToVatRoot(vat, 'append', [1]);
-    // eslint-disable-next-line no-await-in-loop
     await c.run();
     t.log(
       'max:',

--- a/packages/SwingSet/test/vat-warehouse/vat-preload-bootstrap.js
+++ b/packages/SwingSet/test/vat-warehouse/vat-preload-bootstrap.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { Far, E } from '@endo/far';
 
 export function buildRootObject() {

--- a/packages/SwingSet/test/virtualObjects/vat-weakcollections-bootstrap.js
+++ b/packages/SwingSet/test/virtualObjects/vat-weakcollections-bootstrap.js
@@ -27,12 +27,10 @@ export function buildRootObject(vatPowers) {
     },
     async runProbes() {
       for (const item of ourStuff) {
-        // eslint-disable-next-line no-await-in-loop
         const what = await E(alice).probeWeakMap(item);
         testLog(`probe of ${item} returns ${what}`);
       }
       for (const item of theirStuff) {
-        // eslint-disable-next-line no-await-in-loop
         const what = await E(alice).probeWeakMap(item);
         testLog(`probe of ${item} returns ${what}`);
       }

--- a/packages/agoric-cli/src/bin-agops.js
+++ b/packages/agoric-cli/src/bin-agops.js
@@ -2,7 +2,6 @@
 // @ts-check
 // @jessie-check
 
-/* eslint-disable @jessie.js/no-nested-await */
 /* global fetch, setTimeout */
 
 import '@agoric/casting/node-fetch-shim.js';

--- a/packages/agoric-cli/src/bin-agops.js
+++ b/packages/agoric-cli/src/bin-agops.js
@@ -4,9 +4,12 @@
 
 /* global fetch, setTimeout */
 
+import '@endo/init/pre.js';
+
 import '@agoric/casting/node-fetch-shim.js';
 import '@endo/init';
-import '@endo/init/pre.js';
+
+import { E } from '@endo/far';
 
 import { execFileSync } from 'child_process';
 import path from 'path';
@@ -73,13 +76,11 @@ program.addCommand(makeAuctionCommand(logger, { ...procIO, fetch }));
 program.addCommand(makeInterCommand(procIO, { fetch }));
 program.addCommand(makeTestCommand(procIO, { fetch }));
 
-try {
-  await program.parseAsync(process.argv);
-} catch (err) {
+E.when(program.parseAsync(process.argv), undefined, err => {
   if (err instanceof CommanderError) {
     console.error(err.message);
   } else {
     console.error(err); // CRASH! show stack trace
   }
   process.exit(1);
-}
+});

--- a/packages/agoric-cli/src/commands/auction.js
+++ b/packages/agoric-cli/src/commands/auction.js
@@ -1,4 +1,3 @@
-/* eslint-disable @jessie.js/no-nested-await */
 // @ts-check
 /* eslint-disable func-names */
 import { InvalidArgumentError } from 'commander';

--- a/packages/agoric-cli/src/commands/ec.js
+++ b/packages/agoric-cli/src/commands/ec.js
@@ -1,4 +1,3 @@
-/* eslint-disable @jessie.js/no-nested-await */
 // @ts-check
 /* eslint-disable func-names */
 /* global globalThis, process, setTimeout */

--- a/packages/agoric-cli/src/commands/inter.js
+++ b/packages/agoric-cli/src/commands/inter.js
@@ -238,7 +238,6 @@ export const makeInterCommand = (
     try {
       // XXX pass fetch to getNetworkConfig() explicitly
       // await null above makes this await safe
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const networkConfig = await getNetworkConfig(env);
       return makeWalletUtils({ fetch, execFileSync, delay }, networkConfig);
     } catch (err) {

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-/* eslint-disable @jessie.js/no-nested-await */
 // @ts-check
 /* eslint-disable func-names */
 /* global fetch, setTimeout, process */

--- a/packages/agoric-cli/src/commands/perf.js
+++ b/packages/agoric-cli/src/commands/perf.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-/* eslint-disable @jessie.js/no-nested-await */
 // @ts-check
 /* eslint-disable func-names */
 /* global process */

--- a/packages/agoric-cli/src/commands/psm.js
+++ b/packages/agoric-cli/src/commands/psm.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-/* eslint-disable @jessie.js/no-nested-await */
 // @ts-check
 /* eslint-disable func-names */
 /* global fetch, process */

--- a/packages/agoric-cli/src/commands/reserve.js
+++ b/packages/agoric-cli/src/commands/reserve.js
@@ -1,4 +1,3 @@
-/* eslint-disable @jessie.js/no-nested-await */
 // @ts-check
 /* eslint-disable func-names */
 /* global fetch, process */

--- a/packages/agoric-cli/src/commands/test-upgrade.js
+++ b/packages/agoric-cli/src/commands/test-upgrade.js
@@ -38,7 +38,6 @@ export const makeTestCommand = (
     try {
       // XXX pass fetch to getNetworkConfig() explicitly
       // await null above makes this await safe
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const networkConfig = await getNetworkConfig(env);
       return makeWalletUtils({ fetch, execFileSync, delay }, networkConfig);
     } catch (err) {

--- a/packages/agoric-cli/src/commands/vaults.js
+++ b/packages/agoric-cli/src/commands/vaults.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-/* eslint-disable @jessie.js/no-nested-await */
 // @ts-check
 /* eslint-disable func-names */
 /* global fetch, process */

--- a/packages/agoric-cli/src/init.js
+++ b/packages/agoric-cli/src/init.js
@@ -60,7 +60,6 @@ export default async function initMain(_progname, rawArgs, priv, opts) {
     const path = `${DIR}/${dir}package.json`;
     log('rewriting ', path);
 
-    // eslint-disable-next-line no-await-in-loop
     const contents = await fs.readFile(path, 'utf-8');
     const pkg = JSON.parse(contents.replace(/@DIR@/g, DIR));
     if (dir === '') {
@@ -74,7 +73,6 @@ export default async function initMain(_progname, rawArgs, priv, opts) {
     pkg.name = `${DIR}${pkg.name.substr(topLevelName.length)}`;
     const json = JSON.stringify(pkg, undefined, 2);
 
-    // eslint-disable-next-line no-await-in-loop
     await fs.writeFile(path, json);
   }
 

--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -287,6 +287,7 @@ export default async function installMain(progname, rawArgs, powers, opts) {
   await Promise.all(
     [...sdkPackageToPath.entries()].map(async ([pjName, dir]) => {
       const SUBOPTIMAL = false;
+      await null;
       if (SUBOPTIMAL) {
         // This use of yarn is noisy and slow.
         await pspawn('yarn', [...linkFlags, 'unlink', pjName]);

--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -61,7 +61,6 @@ export default async function installMain(progname, rawArgs, powers, opts) {
   const yarnInstallEachWorktree = async (phase, ...flags) => {
     for await (const workTree of workTrees) {
       log.info(`yarn install ${phase} in ${workTree}`);
-      // eslint-disable-next-line no-await-in-loop
       const yarnInstall = await pspawn(
         'yarn',
         [...linkFlags, 'install', ...flags],

--- a/packages/agoric-cli/src/lib/chain.js
+++ b/packages/agoric-cli/src/lib/chain.js
@@ -122,7 +122,6 @@ export const pollBlocks = opts => async lookup => {
     } = status;
     try {
       // see await null above
-      // eslint-disable-next-line @jessie.js/no-nested-await, no-await-in-loop
       const result = await lookup({ time, height });
       return result;
     } catch (_err) {
@@ -132,7 +131,6 @@ export const pollBlocks = opts => async lookup => {
         height,
         'retrying...',
       );
-      // eslint-disable-next-line @jessie.js/no-nested-await, no-await-in-loop
       await delay(period);
     }
   }

--- a/packages/agoric-cli/src/lib/rpc.js
+++ b/packages/agoric-cli/src/lib/rpc.js
@@ -49,7 +49,8 @@ export const getNetworkConfig = async env => {
 };
 
 /** @type {MinimalNetworkConfig} */
-export const networkConfig = await getNetworkConfig(process.env);
+const networkConfig = await getNetworkConfig(process.env);
+export { networkConfig };
 // console.warn('networkConfig', networkConfig);
 
 /**
@@ -131,6 +132,7 @@ export const makeVStorage = (powers, config = networkConfig) => {
       const parts = [];
       // undefined the first iteration, to query at the highest
       let blockHeight;
+      await null;
       do {
         // console.debug('READING', { blockHeight });
         let values;
@@ -240,6 +242,7 @@ export const makeAgoricNames = async (ctx, vstorage) => {
  * @param {MinimalNetworkConfig} config
  */
 export const makeRpcUtils = async ({ fetch }, config = networkConfig) => {
+  await null;
   try {
     const vstorage = makeVStorage({ fetch }, config);
     const fromBoard = makeFromBoard();

--- a/packages/agoric-cli/src/lib/rpc.js
+++ b/packages/agoric-cli/src/lib/rpc.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* eslint-disable @jessie.js/no-nested-await */
 /* global Buffer, fetch, process */
 
 import { NonNullish } from '@agoric/assert';
@@ -136,7 +135,6 @@ export const makeVStorage = (powers, config = networkConfig) => {
         // console.debug('READING', { blockHeight });
         let values;
         try {
-          // eslint-disable-next-line no-await-in-loop
           ({ blockHeight, values } = await this.readAt(
             path,
             blockHeight && Number(blockHeight) - 1,

--- a/packages/agoric-cli/src/lib/wallet.js
+++ b/packages/agoric-cli/src/lib/wallet.js
@@ -247,7 +247,6 @@ export const makeWalletUtils = async (
     untilNumWantsSatisfied = false,
   ) => {
     const lookup = async () => {
-      // eslint-disable-next-line @jessie.js/no-nested-await, no-await-in-loop
       const { offerStatuses } = await storedWalletState(from, minHeight);
       const offerStatus = [...offerStatuses.values()].find(s => s.id === id);
       if (!offerStatus) throw Error('retry');

--- a/packages/agoric-cli/src/main-publish.js
+++ b/packages/agoric-cli/src/main-publish.js
@@ -33,7 +33,6 @@ const publishMain = async (progname, rawArgs, powers, opts) => {
 
   for (const bundlePath of rawArgs.slice(1)) {
     // AWAIT
-    // eslint-disable-next-line no-await-in-loop,@jessie.js/no-nested-await
     const bundleText = await fs.readFile(bundlePath, 'utf-8');
     const bundle = parseLocatedJson(bundleText, bundlePath);
 
@@ -53,7 +52,6 @@ const publishMain = async (progname, rawArgs, powers, opts) => {
     });
 
     // AWAIT
-    // eslint-disable-next-line no-await-in-loop,@jessie.js/no-nested-await
     const hashedBundle = await publishBundle(bundle, connectionSpec);
     process.stdout.write(`${JSON.stringify(hashedBundle)}\n`);
   }

--- a/packages/agoric-cli/src/main-publish.js
+++ b/packages/agoric-cli/src/main-publish.js
@@ -31,6 +31,7 @@ const publishMain = async (progname, rawArgs, powers, opts) => {
     chainID,
   };
 
+  await null;
   for (const bundlePath of rawArgs.slice(1)) {
     // AWAIT
     const bundleText = await fs.readFile(bundlePath, 'utf-8');

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -1,4 +1,3 @@
-/* eslint-disable @jessie.js/no-nested-await */
 /* global process */
 import { Command } from 'commander';
 import path from 'path';

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -35,6 +35,7 @@ const main = async (progname, rawArgs, powers) => {
   const program = new Command();
 
   async function isNotBasedir() {
+    await null;
     try {
       await fs.stat(STAMP);
       return false;

--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -423,6 +423,7 @@ const publishBundle = async (
     )}, publishBundle supports only "endoZipBase64" with "endoZipBase64Sha512"`;
   }
 
+  await null;
   if (connectionSpec === undefined && getDefaultConnection !== undefined) {
     connectionSpec = await getDefaultConnection();
   }

--- a/packages/agoric-cli/src/publish.js
+++ b/packages/agoric-cli/src/publish.js
@@ -289,14 +289,12 @@ export const makeCosmosBundlePublisher = ({
       const endpoint = urlForRpcAddress(rpcAddress);
 
       // AWAIT
-      // eslint-disable-next-line no-await-in-loop,@jessie.js/no-nested-await
       const stargateClient = await connectWithSigner(endpoint, wallet, {
         gasPrice: Agoric.gasPrice,
         registry,
       });
 
       // AWAIT
-      // eslint-disable-next-line no-await-in-loop,@jessie.js/no-nested-await
       const result = await stargateClient
         .signAndBroadcast(from.address, encodeObjects, Agoric.fee)
         .catch(error => {
@@ -312,7 +310,6 @@ export const makeCosmosBundlePublisher = ({
       }
 
       // AWAIT
-      // eslint-disable-next-line no-await-in-loop,@jessie.js/no-nested-await
       await E(leader).jitter('agoric CLI deploy');
     }
 

--- a/packages/agoric-cli/src/set-defaults.js
+++ b/packages/agoric-cli/src/set-defaults.js
@@ -42,6 +42,7 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
     return fs.writeFile(fileName, contents);
   };
 
+  await null;
   if (appFile) {
     log(`read ${appFile}`);
     const appToml = await fs.readFile(appFile, 'utf-8');

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -308,7 +308,6 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     // Get or create the essential addresses.
     const addrs = {};
     for (const keyName of ['provision', 'delegate0']) {
-      /* eslint-disable no-await-in-loop */
       let statusOut = showKey(keyName);
       const exitStatusOut = await statusOut[0];
       if (exitStatusOut) {
@@ -555,7 +554,6 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     for await (const _ of untilTrue(() => hasGci)) {
       process.stdout.write('.');
 
-      // eslint-disable-next-line no-await-in-loop
       await new Promise((resolve, reject) => {
         fs.stat(gciFile).then(
           _2 => {
@@ -590,7 +588,6 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     let bestRpcAddr;
     for await (const _ of untilTrue(() => bestRpcAddr)) {
       for await (const rpcAddr of rpcAddrs) {
-        // eslint-disable-next-line no-await-in-loop
         exitStatus = await keysSpawn([
           'query',
           'swingset',
@@ -639,7 +636,6 @@ export default async function startMain(progname, rawArgs, powers, opts) {
           ];
           for (/* await */ const cmd of provCmds) {
             const statusOut = capture(keysSpawn, cmd, true);
-            // eslint-disable-next-line no-await-in-loop
             exitStatus = await statusOut[0];
             if (!exitStatus) {
               const json = statusOut[1].replace(/^gas estimate: \d+$/m, '');
@@ -664,7 +660,6 @@ export default async function startMain(progname, rawArgs, powers, opts) {
         }
       }
       if (!bestRpcAddr) {
-        // eslint-disable-next-line no-await-in-loop
         await delay(2000);
       }
     }

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -151,6 +151,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     ]);
 
   const exists = async file => {
+    await null;
     try {
       await fs.stat(file);
       return true;
@@ -173,6 +174,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     const agServer = `_agstate/agoric-servers/${profileName}`;
 
+    await null;
     if (popts.reset) {
       log(chalk.green(`removing ${agServer}`));
       // rm is available on all the unix-likes, so use it for speed.
@@ -246,6 +248,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     }
 
     const { cosmosChain, cosmosChainBuild } = getSDKBinaries(sdkPrefixes);
+    await null;
     if (popts.pull || popts.rebuild) {
       if (popts.dockerTag) {
         const exitStatus = await pspawn('docker', ['pull', SDK_IMAGE]);
@@ -448,6 +451,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const agServer = `_agstate/agoric-servers/${profileName}-${portNum}`;
 
     const { cosmosClientBuild } = getSDKBinaries(sdkPrefixes);
+    await null;
     if (popts.pull || popts.rebuild) {
       if (popts.dockerTag) {
         const exitStatus = await pspawn('docker', ['pull', SDK_IMAGE]);
@@ -685,6 +689,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
   }
 
   async function startTestnetDocker(profileName, startArgs, popts) {
+    await null;
     if (popts.dockerTag && popts.pull) {
       const exitStatus = await pspawn('docker', ['pull', SOLO_IMAGE]);
       if (exitStatus) {
@@ -724,6 +729,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const netconfig = startArgs[1] || DEFAULT_NETCONFIG;
     const agServer = `_agstate/agoric-servers/${profileName}-${port}`;
 
+    await null;
     if (popts.reset) {
       log(chalk.green(`removing ${agServer}`));
       // rm is available on all the unix-likes, so use it for speed.

--- a/packages/agoric-cli/tools/getting-started.js
+++ b/packages/agoric-cli/tools/getting-started.js
@@ -93,6 +93,7 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
     }
   };
 
+  await null;
   try {
     process.on('SIGINT', runFinalizers);
     process.on('exit', runFinalizers);

--- a/packages/agoric-cli/tools/getting-started.js
+++ b/packages/agoric-cli/tools/getting-started.js
@@ -196,7 +196,6 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
       urlReq.on('error', err => urlResolve(`Cannot connect to ${url}: ${err}`));
       urlReq.end();
       const urlTimeout = setTimeout(urlResolve, 3000, 'timeout');
-      // eslint-disable-next-line no-await-in-loop
       const urlDone = await urlP;
       clearTimeout(urlTimeout);
       t.is(urlDone, code, `${url} gave status ${code}`);

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -1,5 +1,4 @@
 /// <reference types="ses"/>
-/* eslint-disable no-await-in-loop, @jessie.js/no-nested-await */
 
 import { E, Far } from '@endo/far';
 import * as tendermint34 from '@cosmjs/tendermint-rpc';

--- a/packages/casting/src/follower-cosmjs.js
+++ b/packages/casting/src/follower-cosmjs.js
@@ -239,6 +239,7 @@ export const makeCosmjsFollower = (
    * @returns {Promise<QueryStoreResponse>}
    */
   const tryGetDataAtHeight = async blockHeight => {
+    await null;
     if (proof === 'strict') {
       // Crash hard if we can't prove.
       return getProvenDataAtHeight(blockHeight).catch(crash);
@@ -273,6 +274,7 @@ export const makeCosmjsFollower = (
    * @param {number} [blockHeight] desired height, or the latest height if not set
    */
   const getDataAtHeight = async blockHeight => {
+    await null;
     for (let attempt = 0; ; attempt += 1) {
       try {
         // AWAIT
@@ -390,6 +392,7 @@ export const makeCosmjsFollower = (
     /** @type {number | undefined} the last known latest height */
     let lastHeight;
     let lastValue;
+    await null;
     for (;;) {
       const latest = await getDataAtHeight();
       if (lastHeight && latest.height <= lastHeight) {
@@ -440,6 +443,7 @@ export const makeCosmjsFollower = (
     // block.
     // If the block has no corresponding data, wait for the first block to
     // contain data.
+    await null;
     for (;;) {
       ({ value: cursorData, height: cursorBlockHeight } = await getDataAtHeight(
         cursorBlockHeight,
@@ -552,6 +556,7 @@ export const makeCosmjsFollower = (
     // cursorBlockHeight) so we know not to emit duplicates
     // of that cell.
     let cursorData;
+    await null;
     while (cursorBlockHeight === undefined || cursorBlockHeight > 0) {
       ({ value: cursorData, height: cursorBlockHeight } = await getDataAtHeight(
         cursorBlockHeight,

--- a/packages/cosmic-swingset/scripts/clean-core-eval.js
+++ b/packages/cosmic-swingset/scripts/clean-core-eval.js
@@ -61,11 +61,16 @@ export const main = async (argv, { readFile, stdout }) => {
 
 if (isEntrypoint(import.meta.url)) {
   /* global process */
-  main([...process.argv], {
-    readFile: (await import('fs/promises')).readFile,
-    stdout: process.stdout,
-  }).catch(err => {
-    process.exitCode = 1;
-    console.error(err);
-  });
+  farExports.E.when(
+    import('fs/promises'),
+    fsp =>
+      main([...process.argv], {
+        readFile: fsp.readFile,
+        stdout: process.stdout,
+      }),
+    err => {
+      process.exitCode = 1;
+      console.error(err);
+    },
+  );
 }

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -519,7 +519,6 @@ export default async function main(progname, args, { env, homedir, agcc }) {
           });
         stateSyncExport = exportData;
 
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await new Promise((resolve, reject) => {
           tmpfs.dir(
             {

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -494,6 +494,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
   }
 
   async function handleCosmosSnapshot(blockHeight, request, requestArgs) {
+    await null;
     switch (request) {
       case 'restore': {
         const exportDir = requestArgs[0];

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -144,11 +144,9 @@ export const initiateSwingStoreExport = (
     if (includeExportData) {
       log?.(`Writing Export Data`);
       const fileName = `export-data.jsonl`;
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const exportDataFile = await open(pathResolve(exportDir, fileName), 'wx');
       cleanup.push(async () => exportDataFile.close());
 
-      // eslint-disable-next-line @jessie.js/no-nested-await
       for await (const entry of swingStoreExporter.getExportData()) {
         await exportDataFile.write(`${JSON.stringify(entry)}\n`);
       }

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -131,6 +131,7 @@ export async function buildSwingset(
       swingsetConfig.vats[swingsetConfig.bootstrap || 'bootstrap'];
 
     // Find the entrypoints for all the core proposals.
+    await null;
     if (coreProposals) {
       const { bundles, code } = await extractCoreProposalBundles(
         coreProposals,
@@ -529,6 +530,7 @@ export async function launch({
      */
     async function processActions(inboundQueue) {
       let keepGoing = true;
+      await null;
       for (const { action, context } of inboundQueue.consumeAll()) {
         const inboundNum = `${context.blockHeight}-${context.txHash}-${context.msgIdx}`;
         inboundQueueMetrics.decStat();

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -1,6 +1,5 @@
 // @ts-check
 /* global process */
-/* eslint-disable @jessie.js/no-nested-await */
 import anylogger from 'anylogger';
 
 import { E } from '@endo/far';
@@ -533,9 +532,7 @@ export async function launch({
       for (const { action, context } of inboundQueue.consumeAll()) {
         const inboundNum = `${context.blockHeight}-${context.txHash}-${context.msgIdx}`;
         inboundQueueMetrics.decStat();
-        // eslint-disable-next-line no-await-in-loop
         await performAction(action, inboundNum);
-        // eslint-disable-next-line no-await-in-loop
         keepGoing = await runSwingset();
         if (!keepGoing) {
           // any leftover actions will remain on the inbound queue for possible

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -1,5 +1,4 @@
 /* global process setTimeout clearTimeout */
-/* eslint-disable no-await-in-loop */
 import path from 'path';
 import fs from 'fs';
 import {

--- a/packages/cosmic-swingset/test/scenario2.js
+++ b/packages/cosmic-swingset/test/scenario2.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* eslint-disable no-await-in-loop */
 const { freeze, entries } = Object;
 
 const onlyStderr = ['ignore', 'ignore', 'inherit'];

--- a/packages/deployment/src/init.js
+++ b/packages/deployment/src/init.js
@@ -335,7 +335,6 @@ const doInit =
     config.NETWORK_NAME = overrideNetworkName;
 
     while (!noninteractive) {
-      // eslint-disable-next-line no-await-in-loop
       const { ROLE, ...rest } = await askPlacement({ inquirer })(
         config.PLACEMENTS,
         config.ROLES,
@@ -351,7 +350,6 @@ const doInit =
         const PROVIDER = config.PLACEMENT_PROVIDER[PLACEMENT];
         provider = PROVIDERS[PROVIDER];
       } else {
-        // eslint-disable-next-line no-await-in-loop
         const { PROVIDER } = await askProvider({ inquirer })(PROVIDERS);
         if (!PROVIDER) {
           continue;
@@ -375,7 +373,6 @@ const doInit =
         };
 
         if (provider.askDetails) {
-          // eslint-disable-next-line no-await-in-loop
           const { CANCEL, ...PLACEMENT_DETAILS } = await provider.askDetails(
             provider,
             myDetails,
@@ -402,7 +399,6 @@ const doInit =
 
       const dcs =
         provider.datacenters &&
-        // eslint-disable-next-line no-await-in-loop
         (await provider.datacenters(provider, PLACEMENT, myDetails));
       config.ROLES;
       const [_p, placement] = config.PLACEMENTS.find(
@@ -441,7 +437,6 @@ const doInit =
             }
             return ret;
           });
-        // eslint-disable-next-line no-await-in-loop
         const { DATACENTER, NUM_NODES, MORE } = await provider.askDatacenter(
           provider,
           PLACEMENT,
@@ -541,10 +536,8 @@ variable ${JSON.stringify(vname)} {
 
       // Create a placement-specific key file.
       const keyFile = `${PLACEMENT}-${config.SSH_PRIVATE_KEY_FILE}`;
-      // eslint-disable-next-line no-await-in-loop
       if (!(await rd.exists(keyFile))) {
         // Set empty password.
-        // eslint-disable-next-line no-await-in-loop
         await needDoRun([
           'ssh-keygen',
           '-N',
@@ -556,7 +549,6 @@ variable ${JSON.stringify(vname)} {
         ]);
       }
 
-      // eslint-disable-next-line no-await-in-loop
       await provider.createPlacementFiles(provider, PLACEMENT, clusterPrefix);
     }
 

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import djson from 'deterministic-json';
 import { createHash } from 'crypto';
 import chalk from 'chalk';
@@ -62,10 +61,8 @@ const waitForStatus =
     const serviceArgs = service ? [`-eservice=${service}`] : [];
     let retryNum = 0;
     for (;;) {
-      // eslint-disable-next-line no-await-in-loop
       await doRetry(retryNum);
       let buf = '';
-      // eslint-disable-next-line no-await-in-loop
       const code = await running.doRun(
         setup.playbook('status', `-euser=${user}`, ...hostArgs, ...serviceArgs),
         undefined,

--- a/packages/eslint-config/eslint-config.cjs
+++ b/packages/eslint-config/eslint-config.cjs
@@ -1,3 +1,4 @@
+/* eslint-env node */
 module.exports = {
   extends: [
     'airbnb-base',
@@ -10,6 +11,7 @@ module.exports = {
     'arrow-body-style': 'off',
     'arrow-parens': 'off',
     'no-continue': 'off',
+    'no-await-in-loop': 'off',
     'implicit-arrow-linebreak': 'off',
     'function-paren-newline': 'off',
     strict: 'off',

--- a/packages/governance/src/contractGovernorKit.js
+++ b/packages/governance/src/contractGovernorKit.js
@@ -76,6 +76,7 @@ export const prepareContractGovernorKit = (baggage, powers) => {
         async provideApiGovernance() {
           const { timer } = powers;
           const { creatorFacet } = this.state;
+          await null;
           if (!apiGovernance) {
             trace('awaiting governed API dependencies');
             const [governedApis, governedNames] = await Promise.all([

--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -333,6 +333,7 @@ export const makeScheduler = async (
       // NB: may be fired with the initial params as well
       async updateState(_newState) {
         trace('received param update', _newState);
+        await null;
         if (!nextSchedule) {
           trace('repairing nextSchedule and restarting');
           ({ nextSchedule } = await initializeNextSchedule());

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -132,7 +132,6 @@ export const prepare = async (zcf, privateArgs, baggage) => {
       [invitation],
     );
     if (highPrioritySendersManager) {
-      // eslint-disable-next-line @jessie.js/no-nested-await -- after another await
       await E(highPrioritySendersManager).add(description, addr);
     }
     return `added ${addr}`;
@@ -147,7 +146,6 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     trace('removeOracle', addr);
     await E(faKit.creator).removeOracle(addr);
     if (highPrioritySendersManager) {
-      // eslint-disable-next-line @jessie.js/no-nested-await -- after another await
       await E(highPrioritySendersManager).remove(description, addr);
     }
     return `removed ${addr}`;

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -131,9 +131,8 @@ export const prepare = async (zcf, privateArgs, baggage) => {
       addr,
       [invitation],
     );
-    if (highPrioritySendersManager) {
-      await E(highPrioritySendersManager).add(description, addr);
-    }
+    await (highPrioritySendersManager &&
+      E(highPrioritySendersManager).add(description, addr));
     return `added ${addr}`;
   };
 
@@ -145,9 +144,8 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   const removeOracle = async addr => {
     trace('removeOracle', addr);
     await E(faKit.creator).removeOracle(addr);
-    if (highPrioritySendersManager) {
-      await E(highPrioritySendersManager).remove(description, addr);
-    }
+    await (highPrioritySendersManager &&
+      E(highPrioritySendersManager).remove(description, addr));
     return `removed ${addr}`;
   };
 

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -62,7 +62,6 @@ export const ensureOracleBrands = async (
     let b = await brand;
     if (!b) {
       // not 1st await
-      // eslint-disable-next-line @jessie.js/no-nested-await
       b = await E(agoricNames).provideInertBrand(
         name,
         harden({ decimalPlaces: parseInt(decimals, 10) }),

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -369,12 +369,10 @@ export const makeAnchorAsset = async (
       makeScalarBigMapStore('Anchor balance payments', { durable: true }),
     );
     // XXX this rule should only apply to the 1st await
-    // eslint-disable-next-line @jessie.js/no-nested-await
     const anchorPaymentMap = await anchorBalancePayments;
 
     // TODO: validate that `metrics.anchorPoolBalance.value` is
     // pass-by-copy PureData (e.g., contains no remotables).
-    // eslint-disable-next-line @jessie.js/no-nested-await
     const pmt = await E(mint).mintPayment(
       AmountMath.make(brand, metrics.anchorPoolBalance.value),
     );

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -363,7 +363,10 @@ export const makeAnchorAsset = async (
     slotToBoardRemote,
   );
   const metricsKey = `${stablePsmKey}.${keyword}.metrics`;
-  if (toSlotReviver.has(metricsKey)) {
+  const maybeReviveMetrics = async () => {
+    if (!toSlotReviver.has(metricsKey)) {
+      return;
+    }
     const metrics = toSlotReviver.getItem(metricsKey);
     produceAnchorBalancePayments.resolve(
       makeScalarBigMapStore('Anchor balance payments', { durable: true }),
@@ -377,7 +380,8 @@ export const makeAnchorAsset = async (
       AmountMath.make(brand, metrics.anchorPoolBalance.value),
     );
     anchorPaymentMap.init(brand, pmt);
-  }
+  };
+  await maybeReviveMetrics();
 
   await Promise.all([
     E(E(agoricNamesAdmin).lookupAdmin('issuer')).update(keyword, kit.issuer),

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -69,7 +69,6 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   const makeAssetReserveKit = await prepareAssetReserveKit(baggage, {
     feeMint,
     makeRecorderKit,
-    // eslint-disable-next-line @jessie.js/no-nested-await -- spurious
     storageNode: await privateArgs.storageNode,
     zcf,
   });

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -66,10 +66,11 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   };
   trace('awaiting takeFeeMint');
   const feeMint = await takeFeeMint();
+  const storageNode = await privateArgs.storageNode;
   const makeAssetReserveKit = await prepareAssetReserveKit(baggage, {
     feeMint,
     makeRecorderKit,
-    storageNode: await privateArgs.storageNode,
+    storageNode,
     zcf,
   });
 

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -963,7 +963,6 @@ export const prepareVaultManagerKit = (
 
           try {
             // TODO `await` is allowed until the above ordering is fixed
-            // eslint-disable-next-line @jessie.js/no-nested-await
             const vaultKit = await vault.initVaultKit(seat, vaultStorageNode);
             // initVaultKit calls back to handleBalanceChange() which will add the
             // vault to prioritizedVaults

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -480,18 +480,15 @@ test('mix of trades: failures do not prevent later service', async t => {
   for (const [kind, give, want, ok, wants] of trades) {
     switch (kind) {
       case 'give':
-        // eslint-disable-next-line no-await-in-loop
         await giveMinted(ix, give, want, ok, wants);
         break;
       case 'want':
-        // eslint-disable-next-line no-await-in-loop
         await wantMinted(ix, give, want, ok, wants);
         break;
       default:
         assert.fail(kind);
     }
     if (kind === 'give') {
-      // eslint-disable-next-line no-await-in-loop
     }
     ix += 1;
   }

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -488,8 +488,6 @@ test('mix of trades: failures do not prevent later service', async t => {
       default:
         assert.fail(kind);
     }
-    if (kind === 'give') {
-    }
     ix += 1;
   }
 });

--- a/packages/inter-protocol/test/test-feeDistributor.js
+++ b/packages/inter-protocol/test/test-feeDistributor.js
@@ -58,7 +58,6 @@ const assertPaymentArray = async (
   const payments = await paymentsP;
   for (let i = 0; i < count; i += 1) {
     // XXX https://github.com/Agoric/agoric-sdk/issues/5527
-    // eslint-disable-next-line no-await-in-loop
     await assertPayoutAmount(
       t,
       issuer,

--- a/packages/inter-protocol/test/vaultFactory/test-vault-interest.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vault-interest.js
@@ -103,7 +103,6 @@ test('charges', async t => {
   let interest = 0n;
   for (const [i, charge] of [4n, 4n, 4n, 4n].entries()) {
     // XXX https://github.com/Agoric/agoric-sdk/issues/5527
-    // eslint-disable-next-line no-await-in-loop
     await testJig.advanceRecordingPeriod();
     interest += charge;
     t.is(
@@ -142,7 +141,6 @@ test('charges', async t => {
 
   for (const [i, charge] of [22n, 27n, 34n].entries()) {
     // XXX https://github.com/Agoric/agoric-sdk/issues/5527
-    // eslint-disable-next-line no-await-in-loop
     await testJig.advanceRecordingPeriod();
     interest += charge;
     t.is(

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -251,9 +251,7 @@ const setClockAndAdvanceNTimes = async (timer, times, start, incr = 1n) => {
   // first time through is at START, then n TIMES more plus INCR
   for (let i = 0; i <= times; i += 1) {
     trace('advancing clock to ', currentTime);
-    // eslint-disable-next-line no-await-in-loop
     await timer.advanceTo(TimeMath.absValue(currentTime));
-    // eslint-disable-next-line no-await-in-loop
     await eventLoopIteration();
     currentTime = TimeMath.addAbsRel(currentTime, TimeMath.relValue(incr));
   }

--- a/packages/internal/test/test-storage-test-utils.js
+++ b/packages/internal/test/test-storage-test-utils.js
@@ -40,7 +40,6 @@ test('makeFakeStorageKit', async t => {
     }),
   );
   for (const [label, val] of nonStrings) {
-    // eslint-disable-next-line no-await-in-loop
     await t.throwsAsync(
       // @ts-expect-error invalid value
       () => rootNode.setValue(val),

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -22,9 +22,7 @@ export const forEachPublicationRecord = async (subscriber, consumeValue) => {
   let finished = false;
   while (!finished) {
     // Allow nested awaits (in loop) because it's safe for each to run in a turn
-    // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
     const { value, done } = await iterator.next();
-    // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
     await consumeValue(value);
     finished = !!done;
   }

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -20,8 +20,8 @@ export const forEachPublicationRecord = async (subscriber, consumeValue) => {
   const iterator = subscribeEach(subscriber)[Symbol.asyncIterator]();
 
   let finished = false;
+  await null;
   while (!finished) {
-    // Allow nested awaits (in loop) because it's safe for each to run in a turn
     const { value, done } = await iterator.next();
     await consumeValue(value);
     finished = !!done;

--- a/packages/notifier/src/subscribe.js
+++ b/packages/notifier/src/subscribe.js
@@ -24,7 +24,6 @@ const reconnectAsNeeded = async (getter, seed = []) => {
   for (let i = 0; ; i += 1) {
     try {
       const resultP = i < seed.length ? seed[i] : getter();
-      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       const result = await resultP;
       return result;
     } catch (err) {

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -17,7 +17,6 @@ export const invertPromiseSettlement = promise =>
 export const delayByTurns = async turnCount => {
   while (turnCount) {
     turnCount -= 1;
-    // eslint-disable-next-line no-await-in-loop
     await undefined;
   }
 };

--- a/packages/notifier/test/test-makeNotifierFromSubscriber.js
+++ b/packages/notifier/test/test-makeNotifierFromSubscriber.js
@@ -77,16 +77,13 @@ test('makeNotifierFromSubscriber(finishes) - getUpdateSince', async t => {
   let updateCount;
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    // eslint-disable-next-line no-await-in-loop
     const result = await notifier.getUpdateSince(updateCount);
     ({ updateCount } = result);
     results.push(result.value);
-    // eslint-disable-next-line no-await-in-loop
     t.deepEqual(await notifier.getUpdateSince(), result);
     if (updateCount === undefined) {
       break;
     }
-    // eslint-disable-next-line no-await-in-loop
     await publishNextBatch();
   }
 
@@ -142,16 +139,13 @@ test('makeNotifierFromSubscriber(fails) - getUpdateSince', async t => {
   try {
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      // eslint-disable-next-line no-await-in-loop
       const result = await notifier.getUpdateSince(updateCount);
       ({ updateCount } = result);
       results.push(result.value);
-      // eslint-disable-next-line no-await-in-loop
       t.deepEqual(await notifier.getUpdateSince(), result);
       if (updateCount === undefined) {
         break;
       }
-      // eslint-disable-next-line no-await-in-loop
       await publishNextBatch();
     }
     throw Error('for-await-of completed successfully');
@@ -326,7 +320,6 @@ test('makeNotifierFromSubscriber - getUpdateSince() result identity', async t =>
   while (updateCount) {
     finalResultP = notifier.getUpdateSince(updateCount);
     publishNextBatch();
-    // eslint-disable-next-line no-await-in-loop
     finalResult = await finalResultP;
     ({ updateCount } = finalResult);
     if (updateCount) {

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -93,7 +93,6 @@ export const makeOfferExecutor = ({
         // No explicit signal to user that we reached here but if anything above
         // failed they'd get an 'error' status update.
 
-        // eslint-disable-next-line @jessie.js/no-nested-await -- unconditional
         seatRef = await E(zoe).offer(
           invitation,
           proposal,

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -51,7 +51,6 @@ test('avoid O(wallets) storage writes for a new asset', async t => {
     /** @type {bigint | undefined} */
     let publishCount;
     for (;;) {
-      // eslint-disable-next-line no-await-in-loop
       const news = await E(current).subscribeAfter(publishCount);
       publishCount = news.publishCount;
       chainStorageWrites += 1;

--- a/packages/smart-wallet/test/test-startWalletFactory.js
+++ b/packages/smart-wallet/test/test-startWalletFactory.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';

--- a/packages/smart-wallet/test/test-walletFactory.js
+++ b/packages/smart-wallet/test/test-walletFactory.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';

--- a/packages/solo/src/add-chain.js
+++ b/packages/solo/src/add-chain.js
@@ -29,6 +29,7 @@ async function addChain(basedir, chainConfig, force = false) {
   const url = new URL(actualConfig, `file://${process.cwd()}`);
   console.log('downloading netconfig from', url.href);
   let netconf;
+  await null;
   if (url.protocol === 'file:') {
     const f = fs.readFileSync(url.pathname, 'utf-8');
     netconf = JSON.parse(f);

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -177,7 +177,6 @@ export async function connectToChain(
       const thisRpcHref = rpcHrefs[rpcHrefIndex];
 
       // tryOnce will either throw if cancelled (which rejects this promise),
-      // eslint-disable-next-line no-await-in-loop
       const ret = await tryOnce(thisRpcHref);
       if (ret !== undefined) {
         // Or returns non-undefined, which we should resolve.
@@ -186,7 +185,6 @@ export async function connectToChain(
       }
 
       // It was undefined, so wait, then retry.
-      // eslint-disable-next-line no-await-in-loop
       await new Promise(resolve => setTimeout(resolve, 5000));
       rpcHrefIndex = (rpcHrefIndex + 1) % rpcHrefs.length;
     }
@@ -661,7 +659,6 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
       let retry = true;
       for await (const _ of whileTrue(() => retry)) {
         retry = false;
-        // eslint-disable-next-line no-await-in-loop
         const { stderr, stdout } = await runHelper([
           ...txArgs,
           `--sequence=${sequenceNumber}`,

--- a/packages/solo/src/main.js
+++ b/packages/solo/src/main.js
@@ -55,6 +55,7 @@ start
 `);
   }
 
+  await null;
   switch (argv[0]) {
     case 'setup': {
       const { netconfig } = parseArgs(argv.slice(1));

--- a/packages/solo/src/pipe-entrypoint.js
+++ b/packages/solo/src/pipe-entrypoint.js
@@ -33,6 +33,7 @@ const main = async () => {
     deliverator(...as).then(() => send('go'));
   });
 
+  await null;
   switch (method) {
     case 'connectToFakeChain': {
       const [basedir, GCI, delay] = margs;

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -262,6 +262,7 @@ const buildSwingset = async (
     async function deliverInboundToMbx(sender, messages, ack) {
       Array.isArray(messages) || Fail`inbound given non-Array: ${messages}`;
       // console.debug(`deliverInboundToMbx`, messages, ack);
+      await null;
       if (mb.deliverInbound(sender, messages, ack)) {
         await processKernel();
       }
@@ -316,6 +317,7 @@ const buildSwingset = async (
   const queuedMoveTimeForward = withInputQueue(
     async function moveTimeForward() {
       const now = Date.now();
+      await null;
       try {
         if (timer.poll(now)) {
           await processKernel();
@@ -489,6 +491,7 @@ const start = async (basedir, argv) => {
   let hostport;
   await Promise.all(
     connections.map(async c => {
+      await null;
       switch (c.type) {
         case 'chain-cosmos-sdk':
           {

--- a/packages/solo/src/vat-http.js
+++ b/packages/solo/src/vat-http.js
@@ -198,6 +198,7 @@ export function buildRootObject(vatPowers) {
         dispatcher = 'onMessage',
       } = rawMeta;
 
+      await null;
       try {
         let channelHandle = channelIdToHandle.get(rawChannelID);
         if (dispatcher === 'onOpen') {

--- a/packages/solo/src/web.js
+++ b/packages/solo/src/web.js
@@ -353,6 +353,7 @@ export async function makeHTTPListener(
 
     ws.on('message', async message => {
       let obj = {};
+      await null;
       try {
         obj = JSON.parse(message);
         const res = await inboundCommand(obj, meta, id);

--- a/packages/solo/test/captp-fixture.js
+++ b/packages/solo/test/captp-fixture.js
@@ -65,7 +65,6 @@ export async function makeFixture(PORT, noisy = false) {
         let lastUpdateCount;
         for (;;) {
           process.stdout.write('o');
-          // eslint-disable-next-line no-await-in-loop
           const update = await E(E.get(bootP).loadingNotifier).getUpdateSince(
             lastUpdateCount,
           );

--- a/packages/swing-store/src/bundleStore.js
+++ b/packages/swing-store/src/bundleStore.js
@@ -243,7 +243,6 @@ export function makeBundleStore(db, ensureTxn, noteExport = () => {}) {
         endoZipBase64: encodeBase64(data),
       });
       // Assert that the bundle contents match the ID and hash
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await checkBundle(bundle, computeSha512, bundleID);
       addBundle(bundleID, bundle);
     } else {

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -309,7 +309,6 @@ export function makeSnapStore(
       yield* output;
     } finally {
       gzReader.destroy();
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await finished(gzReader);
       const hash = hashStream.digest('hex');
       hash === snapshotID ||

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -305,6 +305,7 @@ export function makeSnapStore(
     snapReader.pipe(hashStream);
     snapReader.pipe(output);
 
+    await null;
     try {
       yield* output;
     } finally {

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -1094,7 +1094,6 @@ export async function importSwingStore(exporter, dirPath = null, options = {}) {
   }
 
   if (!includeHistorical) {
-    // eslint-disable-next-line @jessie.js/no-nested-await
     await exporter.close();
     return store;
   }

--- a/packages/swing-store/test/test-exportImport.js
+++ b/packages/swing-store/test/test-exportImport.js
@@ -124,7 +124,6 @@ test('crank abort leaves no debris in export log', async t => {
         crankNum % 3 === 0,
       );
     }
-    // eslint-disable-next-line no-await-in-loop
     await ssOut.hostStorage.commit();
   }
 
@@ -219,10 +218,8 @@ async function testExportImport(
       actLikeAVatRunningACrank(vat, kernelStorage, crankNum);
     }
     if (block < 3) {
-      // eslint-disable-next-line no-await-in-loop
       await fakeAVatSnapshot(vats[block % 2], kernelStorage);
     }
-    // eslint-disable-next-line no-await-in-loop
     await ssOut.hostStorage.commit();
   }
 

--- a/packages/swing-store/test/test-snapstore.js
+++ b/packages/swing-store/test/test-snapstore.js
@@ -103,7 +103,6 @@ test('snapStore prepare / commit delete is robust', async t => {
 
   const hashes = [];
   for (let i = 0; i < 5; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     const { hash } = await store.saveSnapshot(
       'fakeVatID2',
       i,
@@ -133,7 +132,6 @@ test('snapStore prepare / commit delete is robust', async t => {
   t.is(sqlCountSnapshots.get(), 0);
 
   for (let i = 0; i < 5; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     const { hash } = await store.saveSnapshot(
       'fakeVatID4',
       i,

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -257,7 +257,6 @@ function build(
       // Yes, we know this is an await inside a loop.  Too bad.  (Also, it's a
       // `do {} while` loop, which means there's no conditional bypass of the
       // await.)
-      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       await gcTools.gcAndFinalize();
 
       // possiblyDeadSet contains a baseref for everything (Presences,

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -251,12 +251,10 @@ function build(
     const importsToRetire = new Set();
     const exportsToRetire = new Set();
     let doMore;
+    await null;
     do {
       doMore = false;
 
-      // Yes, we know this is an await inside a loop.  Too bad.  (Also, it's a
-      // `do {} while` loop, which means there's no conditional bypass of the
-      // await.)
       await gcTools.gcAndFinalize();
 
       // possiblyDeadSet contains a baseref for everything (Presences,

--- a/packages/swingset-liveslots/test/test-collection-upgrade.js
+++ b/packages/swingset-liveslots/test/test-collection-upgrade.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop, @jessie.js/no-nested-await, no-shadow */
 import test from 'ava';
 import '@endo/init/debug.js';
 

--- a/packages/swingset-liveslots/test/test-handled-promises.js
+++ b/packages/swingset-liveslots/test/test-handled-promises.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop, @jessie.js/no-nested-await, no-shadow */
 import test from 'ava';
 import '@endo/init/debug.js';
 

--- a/packages/swingset-liveslots/test/test-vpid-liveslots.js
+++ b/packages/swingset-liveslots/test/test-vpid-liveslots.js
@@ -293,7 +293,6 @@ async function doVatResolveCase23(t, which, mode, stalls) {
         // another few turns. We wait some number of turns before using p1
         // again, to exercise as many race conditions as possible.
         for (let i = 0; i < stalls; i += 1) {
-          // eslint-disable-next-line no-await-in-loop
           await Promise.resolve();
         }
 

--- a/packages/swingset-runner/demo/vatStore2/bootstrap.js
+++ b/packages/swingset-runner/demo/vatStore2/bootstrap.js
@@ -38,7 +38,6 @@ export function buildRootObject() {
       for (let i = 0; i < 5; i += 1) {
         for (const { vat } of otherVats) {
           const zot = makeZot();
-          // eslint-disable-next-line no-await-in-loop
           const companion = await E(vat).introduce(zot);
           companions.push(companion);
           zots.push(zot);
@@ -64,10 +63,8 @@ export function buildRootObject() {
           }
           case 3: {
             const { vat, name } = otherVats[roll(otherVats.length)];
-            // eslint-disable-next-line no-await-in-loop
             const hasIt = await E(vat).doYouHave(companion);
             // prettier-ignore
-            // eslint-disable-next-line no-await-in-loop
             p(`vat ${name} ${hasIt ? 'has' : 'does not have'} ${await E(companion).getLabel()}`);
             break;
           }

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -317,7 +317,6 @@ export async function main() {
 
   let config;
   if (configPath) {
-    // eslint-disable-next-line @jessie.js/no-nested-await
     config = await loadSwingsetConfigFile(configPath);
     if (config === null) {
       fail(`config file ${configPath} not found`);
@@ -419,13 +418,11 @@ export async function main() {
       slogEnv.OTEL_EXPORTER_OTLP_ENDPOINT = OTEL_EXPORTER_OTLP_ENDPOINT;
       slogOpts.serviceName = TELEMETRY_SERVICE_NAME;
     }
-    // eslint-disable-next-line @jessie.js/no-nested-await
     slogSender = await makeSlogSender(slogOpts);
     runtimeOptions.slogSender = slogSender;
   }
   let bootstrapResult;
   if (forceReset) {
-    // eslint-disable-next-line @jessie.js/no-nested-await
     bootstrapResult = await initializeSwingset(
       config,
       bootstrapArgv,
@@ -433,10 +430,8 @@ export async function main() {
       { verbose },
       runtimeOptions,
     );
-    // eslint-disable-next-line @jessie.js/no-nested-await
     await hostStorage.commit();
     if (initOnly) {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await hostStorage.close();
       return;
     }
@@ -478,25 +473,20 @@ export async function main() {
   let crankNumber = 0;
   switch (command) {
     case 'run': {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await commandRun(0, blockMode);
       break;
     }
     case 'batch': {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await commandRun(batchSize, blockMode);
       break;
     }
     case 'step': {
       try {
-        // eslint-disable-next-line @jessie.js/no-nested-await
         const steps = await controller.step();
         if (activityHash) {
           log(`activityHash: ${controller.getActivityhash()}`);
         }
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await hostStorage.commit();
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await hostStorage.close();
         log(`runner stepped ${steps} crank${steps === 1 ? '' : 's'}`);
       } catch (err) {
@@ -562,7 +552,6 @@ export async function main() {
         help: 'Step the swingset one crank, without commit',
         action: async () => {
           try {
-            // eslint-disable-next-line @jessie.js/no-nested-await
             const steps = await controller.step();
             log(steps ? 'stepped one crank' : "didn't step, queue is empty");
             cli.displayPrompt();
@@ -580,7 +569,6 @@ export async function main() {
     statLogger.close();
   }
   if (slogSender) {
-    // eslint-disable-next-line @jessie.js/no-nested-await
     await slogSender.forceFlush();
   }
   await controller.shutdown();
@@ -606,7 +594,6 @@ export async function main() {
         [],
         'ignore',
       );
-      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       const [steps, deltaT] = await runBatch(0, true);
       const status = controller.kpStatus(roundResult);
       if (status === 'unresolved') {
@@ -644,7 +631,6 @@ export async function main() {
     while (requestedSteps > 0) {
       requestedSteps -= 1;
       try {
-        // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
         const stepped = await controller.step();
         if (stepped < 1) {
           break;
@@ -669,7 +655,6 @@ export async function main() {
     }
     const commitStartTime = readClock();
     if (doCommit) {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await hostStorage.commit();
     }
     const blockEndTime = readClock();
@@ -722,7 +707,6 @@ export async function main() {
     let steps;
     const runAll = stepLimit === 0;
     do {
-      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       steps = await runBlock(blockSize, doCommit);
       totalSteps += steps;
       stepLimit -= steps;
@@ -745,7 +729,6 @@ export async function main() {
 
     let [totalSteps, deltaT] = await runBatch(stepLimit, runInBlockMode);
     if (!runInBlockMode) {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await hostStorage.commit();
     }
     const cranks = getCrankNumber();
@@ -755,7 +738,6 @@ export async function main() {
       printMainStats(mainStats);
     }
     if (benchmarkRounds > 0) {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const [moreSteps, moreDeltaT] = await runBenchmark(benchmarkRounds);
       totalSteps += moreSteps;
       deltaT += moreDeltaT;

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -316,6 +316,7 @@ export async function main() {
   const bootstrapArgv = argv[0] === '--' ? argv.slice(1) : argv;
 
   let config;
+  await null;
   if (configPath) {
     config = await loadSwingsetConfigFile(configPath);
     if (config === null) {
@@ -551,6 +552,7 @@ export async function main() {
       cli.defineCommand('step', {
         help: 'Step the swingset one crank, without commit',
         action: async () => {
+          await null;
           try {
             const steps = await controller.step();
             log(steps ? 'stepped one crank' : "didn't step, queue is empty");
@@ -587,6 +589,7 @@ export async function main() {
     const rawStatsPre = controller.getStats();
     let totalSteps = 0;
     let totalDeltaT = 0n;
+    await null;
     for (let i = 0; i < rounds; i += 1) {
       const roundResult = controller.queueToVatRoot(
         launchIndirectly ? 'launcher' : 'bootstrap',
@@ -628,6 +631,7 @@ export async function main() {
       blockHeight: blockNumber,
       blockTime: blockStartTime,
     });
+    await null;
     while (requestedSteps > 0) {
       requestedSteps -= 1;
       try {
@@ -706,6 +710,7 @@ export async function main() {
     let totalSteps = 0;
     let steps;
     const runAll = stepLimit === 0;
+    await null;
     do {
       steps = await runBlock(blockSize, doCommit);
       totalSteps += steps;

--- a/packages/swingset-runner/src/vat-launcher.js
+++ b/packages/swingset-runner/src/vat-launcher.js
@@ -43,7 +43,6 @@ export function buildRootObject(_vatPowers, vatParameters) {
           critical = criticalVatKey;
         }
         // prettier-ignore
-        // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
         const vat = await E(vatMaker).createVatByName(
           bundleName,
           { vatParameters: harden(subvatParameters), critical },

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -14,7 +14,6 @@ const main = async () => {
   }
 
   for await (const file of files) {
-    // eslint-disable-next-line @jessie.js/no-nested-await
     const { readCircBuf } = await makeMemoryMappedCircularBuffer({
       circularBufferFilename: file,
       circularBufferSize: 0,
@@ -50,7 +49,6 @@ const main = async () => {
       }
 
       // If the buffer is full, wait for stdout to drain.
-      // eslint-disable-next-line no-await-in-loop, @jessie.js/no-nested-await
       await new Promise(resolve => process.stdout.once('drain', resolve));
     }
   }

--- a/packages/vats/src/core/demoIssuers.js
+++ b/packages/vats/src/core/demoIssuers.js
@@ -1,4 +1,3 @@
-/* eslint-disable @jessie.js/no-nested-await -- demo file */
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { split, splitMany } from '@agoric/ertp/src/legacy-payment-helpers.js';
 import {

--- a/packages/vats/src/core/demoIssuers.js
+++ b/packages/vats/src/core/demoIssuers.js
@@ -283,6 +283,7 @@ export const connectFaucet = async ({
       entries(FaucetPurseDetail).map(async ([issuerName, record]) => {
         /** @param {string} name */
         const provideIssuerKit = async name => {
+          await null;
           switch (name) {
             case Stable.symbol:
               return stableIssuerKit;

--- a/packages/vats/src/core/lib-boot.js
+++ b/packages/vats/src/core/lib-boot.js
@@ -213,7 +213,6 @@ export const makeBootstrap = (
     awaitVatObject: async ({ presence, path = [], rawOutput = false }) => {
       let value = await decodePassable(presence);
       for (const key of path) {
-        // eslint-disable-next-line no-await-in-loop
         value = await value[key];
       }
       return rawOutput ? value : encodePassable(value);

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -359,6 +359,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
     ...protocol,
     async fromBridge(obj) {
       console.info('IBC fromBridge', obj);
+      await null;
       switch (obj.event) {
         case 'channelOpenTry': {
           // They're (more or less politely) asking if we are listening, so make an attempt.

--- a/packages/vats/src/proposals/restart-vats-proposal.js
+++ b/packages/vats/src/proposals/restart-vats-proposal.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 // @ts-check
 
 import { Fail } from '@agoric/assert';

--- a/packages/vats/test/bootstrapTests/supports.js
+++ b/packages/vats/test/bootstrapTests/supports.js
@@ -348,7 +348,6 @@ export const makeSwingsetTestKit = async (
     while (currentTime < targetTime) {
       trace('stepping time from', currentTime, 'towards', targetTime);
       currentTime += 1n;
-      // eslint-disable-next-line no-await-in-loop
       await runUtils.runThunk(() => timer.poll(currentTime));
     }
   };

--- a/packages/vats/test/bootstrapTests/test-liquidation-1.js
+++ b/packages/vats/test/bootstrapTests/test-liquidation-1.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-lone-blocks, no-await-in-loop */
 // @ts-check
 /**
  * @file Bootstrap test integration vaults with smart-wallet

--- a/packages/vats/test/bootstrapTests/test-liquidation-2b.js
+++ b/packages/vats/test/bootstrapTests/test-liquidation-2b.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-lone-blocks, no-await-in-loop */
 // @ts-check
 /**
  * @file Bootstrap test integration vaults with smart-wallet

--- a/packages/vats/test/upgrading/test-upgrade-vats.js
+++ b/packages/vats/test/upgrading/test-upgrade-vats.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* eslint-disable no-await-in-loop */
 import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { BridgeId } from '@agoric/internal';

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -1209,6 +1209,7 @@ export function makeWalletRoot({
       updateInboxState(id, rejectOffer);
     };
 
+    await null;
     try {
       const pendingOffer = addMeta({
         ...offer,
@@ -1372,6 +1373,7 @@ export function makeWalletRoot({
       brandToAutoDepositPurse.init(brand, purse);
     }
 
+    await null;
     if (updateState) {
       await updateAllPurseState();
     }
@@ -1893,28 +1895,32 @@ export function makeWalletRoot({
   // don't really trust.
   // The param is{import('@agoric/vats/src/vat-bank.js').Bank} but that here triggers https://github.com/Agoric/agoric-sdk/issues/4620
   const importBankAssets = async bank => {
-    observeIteration(subscribeEach(E(bank).getAssetSubscription()), {
-      async updateState({ proposedName, issuerName, issuer, brand }) {
-        try {
-          issuerName = await addIssuer(issuerName, issuer);
-          const purse = await E(bank).getPurse(brand);
-          // We can import this purse, because we trust the bank.
-          await internalUnsafeImportPurse(
-            issuerName,
-            proposedName,
-            true,
-            purse,
-          );
-        } catch (e) {
-          console.error('/// could not add bank asset purse', e, {
-            issuerName,
-            proposedName,
-            issuer,
-            brand,
-          });
-        }
-      },
-    }).finally(() => console.error('/// This is the end of the bank assets'));
+    observeIteration(
+      subscribeEach(E(bank).getAssetSubscription()),
+      harden({
+        async updateState({ proposedName, issuerName, issuer, brand }) {
+          await null;
+          try {
+            issuerName = await addIssuer(issuerName, issuer);
+            const purse = await E(bank).getPurse(brand);
+            // We can import this purse, because we trust the bank.
+            await internalUnsafeImportPurse(
+              issuerName,
+              proposedName,
+              true,
+              purse,
+            );
+          } catch (e) {
+            console.error('/// could not add bank asset purse', e, {
+              issuerName,
+              proposedName,
+              issuer,
+              brand,
+            });
+          }
+        },
+      }),
+    ).finally(() => console.error('/// This is the end of the bank assets'));
   };
   return {
     admin: wallet,

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -61,6 +61,16 @@
       "import/no-extraneous-dependencies": "off",
       "prettier/prettier": "off"
     },
+    "overrides": [
+      {
+        "files": [
+          "test/**/*.test.js"
+        ],
+        "rules": {
+          "@jessie.js/safe-await-separator": "off"
+        }
+      }
+    ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
       "project": "./jsconfig.json"

--- a/packages/web-components/src/admin-websocket-connector.js
+++ b/packages/web-components/src/admin-websocket-connector.js
@@ -11,7 +11,6 @@ export const waitForBootstrap = async getBootstrap => {
   let update = await getLoadingUpdate();
   for await (const _ of whileTrue(() => update.value.includes('wallet'))) {
     console.log('waiting for wallet');
-    // eslint-disable-next-line no-await-in-loop
     update = await getLoadingUpdate(update.updateCount);
   }
 

--- a/packages/web-components/src/keplr-connection/getChainInfo.js
+++ b/packages/web-components/src/keplr-connection/getChainInfo.js
@@ -4,6 +4,7 @@ import { Errors } from './errors.js';
 export const getChainInfo = async networkConfig => {
   let chainId;
   let rpcs;
+  await null;
   try {
     const res = await fetch(networkConfig);
     const { chainName, rpcAddrs } = await res.json();

--- a/packages/web-components/src/keplr-connection/getChainInfo.js
+++ b/packages/web-components/src/keplr-connection/getChainInfo.js
@@ -5,9 +5,7 @@ export const getChainInfo = async networkConfig => {
   let chainId;
   let rpcs;
   try {
-    // eslint-disable-next-line @jessie.js/no-nested-await
     const res = await fetch(networkConfig);
-    // eslint-disable-next-line @jessie.js/no-nested-await
     const { chainName, rpcAddrs } = await res.json();
     chainId = chainName;
     rpcs = rpcAddrs;

--- a/packages/web-components/src/keplr-connection/getKeplrAddress.js
+++ b/packages/web-components/src/keplr-connection/getKeplrAddress.js
@@ -15,7 +15,6 @@ export const getKeplrAddress = async chainId => {
   const keplr = window.keplr;
 
   try {
-    // eslint-disable-next-line @jessie.js/no-nested-await
     await keplr.enable(chainId);
   } catch {
     throw Error(Errors.enableKeplr);

--- a/packages/web-components/src/keplr-connection/watchWallet.js
+++ b/packages/web-components/src/keplr-connection/watchWallet.js
@@ -51,7 +51,6 @@ export const watchWallet = async (leader, address, context, rpcs) => {
   /** @type {import('@agoric/casting').ValueFollower<import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord>} */
   const currentFollower = await followPublished(`wallet.${address}.current`);
   try {
-    // eslint-disable-next-line @jessie.js/no-nested-await
     await assertHasData(currentFollower);
   } catch {
     // XXX: We can technically show vbank purses without a smart wallet

--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -299,6 +299,7 @@ function makeTester(htest, out) {
       expectation,
       message = `should reject like ${expectation}`,
     ) {
+      await null;
       try {
         await (typeof thrower === 'function' ? thrower() : thrower);
         assert(false, message);
@@ -309,6 +310,7 @@ function makeTester(htest, out) {
     },
     /** @type {(thrower: () => Promise<unknown>, message?: string) => Promise<void> } */
     async notThrowsAsync(nonThrower, message) {
+      await null;
       try {
         await (typeof nonThrower === 'function' ? nonThrower() : nonThrower);
       } catch (ex) {
@@ -334,6 +336,7 @@ const test = (label, run, htestOpt) => {
   htest.queue(label, async () => {
     const out = tapFormat(htest.send);
     const t = makeTester(htest, out);
+    await null;
     try {
       // out.diagnostic('start', label);
       await run(t);

--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -1,5 +1,4 @@
 /* global globalThis */
-/* eslint-disable no-await-in-loop, @jessie.js/no-nested-await -- test code */
 /** global print */
 
 const { assign, freeze, keys } = Object;

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -6,7 +6,6 @@ Usage:
 
 */
 
-/* eslint-disable no-await-in-loop, @jessie.js/no-nested-await -- test code */
 import '@endo/init';
 
 import fs from 'fs';

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -128,6 +128,7 @@ async function runTestScript(
       testNames = msg.testNames;
     }
 
+    await null;
     if ('bundleSource' in msg) {
       const [startFilename, ...rest] = msg.bundleSource;
       // see also makeBundleResolve() below
@@ -243,6 +244,7 @@ async function avaConfig(args, options, { glob, readFile }) {
   let debug = false;
   let verbose = false;
   let titleMatch;
+  await null;
   while (args.length > 0) {
     const arg = args.shift();
     assert.typeof(arg, 'string');

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -175,6 +175,7 @@ async function main(args, { env, stdout, spawn, fs, os }) {
     },
   ];
 
+  await null;
   if (args.includes('--show-env')) {
     for (const submodule of submodules) {
       const { path, envPrefix, commitHash } = submodule;

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 /* global process */
-/* eslint-disable @jessie.js/no-nested-await -- test/build code */
 import * as childProcessTop from 'child_process';
 import fsTop from 'fs';
 import osTop from 'os';
@@ -182,7 +181,6 @@ async function main(args, { env, stdout, spawn, fs, os }) {
       if (!commitHash) {
         // We need to glean the commitHash and url from Git.
         const sm = makeSubmodule(path, '?', { git });
-        // eslint-disable-next-line no-await-in-loop
         const [[{ hash }], url] = await Promise.all([
           sm.status(),
           sm.config('url'),
@@ -208,13 +206,10 @@ async function main(args, { env, stdout, spawn, fs, os }) {
         // ignore
       }
       if (!fs.existsSync(submodule.path)) {
-        // eslint-disable-next-line no-await-in-loop
         await submodule.clone();
       }
-      // eslint-disable-next-line no-await-in-loop
       await submodule.checkout(commitHash);
     } else {
-      // eslint-disable-next-line no-await-in-loop
       await submodule.init();
     }
   }
@@ -229,7 +224,6 @@ async function main(args, { env, stdout, spawn, fs, os }) {
 
   const make = makeCLI(platform.make || 'make', { spawn });
   for (const goal of ModdableSDK.buildGoals) {
-    // eslint-disable-next-line no-await-in-loop
     await make.run(
       [
         `MODDABLE=${ModdableSDK.MODDABLE}`,

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -227,14 +227,12 @@ export async function replayXSnap(
       const seq = parseInt(digits, 10);
       console.log(folder, seq, kind);
       if (running && !['command', 'reply'].includes(kind)) {
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await running;
         running = undefined;
       }
       const file = rd.file(step);
       switch (kind) {
         case 'isReady':
-          // eslint-disable-next-line @jessie.js/no-nested-await
           await it.isReady();
           break;
         case 'evaluate':
@@ -254,7 +252,6 @@ export async function replayXSnap(
             console.log(folder, step, 'ignoring remaining steps from', folder);
             return;
           } else {
-            // eslint-disable-next-line @jessie.js/no-nested-await
             await (async () => {
               const snapshotPath = file.getText();
               const snapFile = await opts.fs.open(snapshotPath, 'w');

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -422,6 +422,7 @@ export async function xsnap(options) {
     let snapshotReadSize = 0;
     /** @type {number | undefined} */
     let snapshotSize;
+    await null;
     try {
       /** @type {string} */
       let snapPath;

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -119,17 +119,13 @@ export async function xsnap(options) {
     const cleanup = async () => fs.unlink(snapPath);
 
     try {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       const tmpSnap = await fs.open(snapPath, 'w');
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await tmpSnap.writeFile(
         // @ts-expect-error incorrect typings, does support AsyncIterable
         snapshotStream,
       );
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await tmpSnap.close();
     } catch (e) {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await cleanup();
       throw e;
     }
@@ -289,7 +285,6 @@ export async function xsnap(options) {
       if (loadSnapshotHandler) {
         const { cleanup } = loadSnapshotHandler;
         loadSnapshotHandler = undefined;
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await cleanup();
       }
       if (iteration.done) {
@@ -328,9 +323,7 @@ export async function xsnap(options) {
           )}`,
         );
       } else if (message[0] === QUERY) {
-        // eslint-disable-next-line @jessie.js/no-nested-await
         const commandResult = await handleCommand(message.subarray(1));
-        // eslint-disable-next-line @jessie.js/no-nested-await
         await messagesToXsnap.next([QUERY_RESPONSE_BUF, commandResult]);
       } else {
         // unrecognized responses also kill the process
@@ -444,7 +437,6 @@ export async function xsnap(options) {
 
       if (snapshotUseFs) {
         // TODO: Refactor to use tmpFile rather than tmpName.
-        // eslint-disable-next-line @jessie.js/no-nested-await
         snapPath = await ptmpName({
           template: `make-snapshot-${safeHintFromDescription(
             description,
@@ -461,7 +453,6 @@ export async function xsnap(options) {
         // then wait for the command response to pipe the file stream into the
         // output, causing the file read to begin.
 
-        // eslint-disable-next-line @jessie.js/no-nested-await
         const handle = await fs.open(snapPath, 'w+');
         // @ts-expect-error 'close' event added in Node 15.4
         handle.on('close', () => {
@@ -522,7 +513,6 @@ export async function xsnap(options) {
 
       yield* output;
     } finally {
-      // eslint-disable-next-line @jessie.js/no-nested-await
       await done;
       (piped && snapshotReadSize === snapshotSize) ||
         Fail`Snapshot size does not match. saved=${q(snapshotSize)}, read=${q(

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -1,6 +1,5 @@
 /* global process */
 /* We make exceptions for test code. This is a test utility. */
-/* eslint-disable @jessie.js/no-nested-await */
 /* eslint no-await-in-loop: ["off"] */
 
 import '@endo/init';

--- a/packages/xsnap/test/test-inspect.js
+++ b/packages/xsnap/test/test-inspect.js
@@ -108,7 +108,6 @@ test('xsnap inspect', async t => {
     const [toEval, toRender] = Array.isArray(testCase)
       ? testCase
       : [testCase, testCase];
-    // eslint-disable-next-line no-await-in-loop
     const [[renderedBox], shouldBeNull] = await w.run(
       // We need to box the value because `console.log` of plain strings won't
       // be passed through the inspector).

--- a/packages/xsnap/test/test-xs-limits.js
+++ b/packages/xsnap/test/test-xs-limits.js
@@ -25,10 +25,8 @@ test('heap exhaustion: orderly fail-stop', async t => {
   }
   `;
   for (const debug of [false, true]) {
-    // eslint-disable-next-line no-await-in-loop
     const vat = await xsnap({ ...options(io), meteringLimit: 0, debug });
     t.teardown(() => vat.terminate());
-    // eslint-disable-next-line no-await-in-loop
     await t.throwsAsync(vat.evaluate(grow), {
       code: ExitCode.E_NOT_ENOUGH_MEMORY,
     });
@@ -53,14 +51,11 @@ test.skip('property name space exhaustion: orderly fail-stop', async t => {
   }
   `;
   for (const debug of [false, true]) {
-    // eslint-disable-next-line no-await-in-loop
     const vat = await xsnap({ ...options(io), meteringLimit: 0, debug });
     t.teardown(() => vat.terminate());
     t.log({ debug, qty: 31000 });
-    // eslint-disable-next-line no-await-in-loop
     await t.notThrowsAsync(vat.evaluate(grow(31000)));
     t.log({ debug, qty: 4000000000 });
-    // eslint-disable-next-line no-await-in-loop
     await t.throwsAsync(vat.evaluate(grow(4000000000)), {
       code: ExitCode.E_NO_MORE_KEYS,
     });
@@ -97,7 +92,6 @@ test.skip('property name space exhaustion: orderly fail-stop', async t => {
         const vat = await xsnap({ ...opts, parserBufferSize });
         t.teardown(() => vat.terminate());
         const expected = failure ? [failure] : [qty * 4 + 2];
-        // eslint-disable-next-line no-await-in-loop
         await t.notThrowsAsync(vat.evaluate(grow(qty)));
         t.deepEqual(
           expected,
@@ -122,7 +116,6 @@ test.skip('property name space exhaustion: orderly fail-stop', async t => {
     test(`large sizes - abort cluster: ${statement}`, async t => {
       const vat = await xsnap(options(io));
       t.teardown(() => vat.terminate());
-      // eslint-disable-next-line no-await-in-loop
       await t.throwsAsync(
         vat.evaluate(`
         (() => {

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -404,7 +404,6 @@ async function runToGC() {
 
   let qty;
   for (qty = 0; !collected; qty += 1) {
-    // eslint-disable-next-line no-await-in-loop
     await new Promise(setImmediate);
     trashCan.push(Array(10_000).map(() => ({})));
   }
@@ -467,9 +466,7 @@ test('GC after snapshot vs restore', async t => {
   let iters = 0;
 
   while (workerGC === cloneGC && iters < 3) {
-    // eslint-disable-next-line no-await-in-loop
     workerGC = await nextGC(worker, opts);
-    // eslint-disable-next-line no-await-in-loop
     cloneGC = await nextGC(clone, optClone);
     iters += 1;
   }

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -336,6 +336,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
         deadline,
         Far('wakeObj', {
           async wake(timestamp) {
+            await null;
             try {
               const quoteP = createQuote(calcAmountOut => ({
                 amountIn,

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -60,6 +60,7 @@ const start = async zcf => {
   const publicFacet = Far('publicFacet', {
     /** @param {OracleQuery} query */
     async query(query) {
+      await null;
       try {
         assert(!revoked, revokedMsg);
         const noFee = AmountMath.makeEmpty(feeBrand);
@@ -77,6 +78,7 @@ const start = async zcf => {
     async makeQueryInvitation(query) {
       /** @type {OfferHandler} */
       const doQuery = async querySeat => {
+        await null;
         try {
           const fee = querySeat.getAmountAllocated('Fee', feeBrand);
           const { requiredFee, reply } = await E(handler).onQuery(query, fee);

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe-upgrade.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe-upgrade.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-
 import '@agoric/swingset-vat/tools/prepare-test-env.js';
 import test from 'ava';
 import { buildVatController } from '@agoric/swingset-vat';

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -254,10 +254,8 @@ export async function makeFakePriceAuthority(options) {
   async function* generateQuotes(amountIn, brandOut) {
     let record = await ticker.getUpdateSince();
     while (record.updateCount !== undefined) {
-      // eslint-disable-next-line no-await-in-loop
       const { value: timestamp } = record; // = await E(timer).getCurrentTimestamp();
       yield priceInQuote(amountIn, brandOut, timestamp);
-      // eslint-disable-next-line no-await-in-loop
       record = await ticker.getUpdateSince(record.updateCount);
     }
   }

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -95,7 +95,6 @@ const buildManualTimer = (log = nolog, startValue = 0n, options = {}) => {
   const tickN = async (nTimes, msg) => {
     nTimes >= 1 || Fail`invariant nTimes >= 1`;
     for (let i = 0; i < nTimes; i += 1) {
-      // eslint-disable-next-line no-await-in-loop
       await tick(msg);
     }
   };

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -94,6 +94,7 @@ const buildManualTimer = (log = nolog, startValue = 0n, options = {}) => {
 
   const tickN = async (nTimes, msg) => {
     nTimes >= 1 || Fail`invariant nTimes >= 1`;
+    await null;
     for (let i = 0; i < nTimes; i += 1) {
       await tick(msg);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1685,10 +1685,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jessie.js/eslint-plugin@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@jessie.js/eslint-plugin/-/eslint-plugin-0.3.0.tgz#5b084355f3cba288422d5ecf794e1290baeddd45"
-  integrity sha512-7v7lZCxP9t6eMu95+3J9nuxLHCLjBZgJ+1cICR9gAga7OGWlC1AdncDO9H2B+Tn0ATfd+w/G9w1yqJq7n53kMA==
+"@jessie.js/eslint-plugin@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@jessie.js/eslint-plugin/-/eslint-plugin-0.4.0.tgz#a351695c63a0fc1cc530a6cb67e8ebe451c8ec58"
+  integrity sha512-rzryGvF22+mm9Ge1UW+alh9S/gPuDI7pxRSbjGymJPU515KGOl1Fym4Fvt6G4elePHYX/ZFmh/uF2888HsuQ0A==
   dependencies:
     requireindex "~1.1.0"
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #6745

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Use new-and-improved Jessie await rules, and tighten up the `.eslintrc.cjs` a bit.

For comparison: these new rules now cause about 120 warnings that have since been manually fixed (with a well-placed `await null`) as opposed to the 450+ eslint-disable suppressions of the old `@jessie.js/no-nested-await` that have now been removed.

Also disable `no-await-in-loop` rule for our repository, as our safe-await-separator rule helps protect against accidental misuse.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
