### PR TITLE
fix(xsnap): Fix native timestamp overflow and portability of tv_usec

### DIFF
--- a/packages/xsnap/build.env
+++ b/packages/xsnap/build.env
@@ -1,4 +1,4 @@
 MODDABLE_URL=https://github.com/agoric-labs/moddable.git
 MODDABLE_COMMIT_HASH=f6c5951fc055e4ca592b9166b9ae3cbb9cca6bf0
 XSNAP_NATIVE_URL=https://github.com/agoric-labs/xsnap-pub
-XSNAP_NATIVE_COMMIT_HASH=2d8ccb76b8508e490d9e03972bb4c64f402d5135
+XSNAP_NATIVE_COMMIT_HASH=87566073e377cbc6fe3f874e6cbed990de3f07b6


### PR DESCRIPTION

## Description

Running xsnap with XSNAP_DEBUG=1 in the environment on a Mac revealed two bugs in the xsnap native worker code. https://github.com/agoric-labs/xsnap-pub/pull/42. For one, we did not handle the exceptional case for `snprintf` when writing a timestamp to the timestamp buffer. Also, because Darwin uses a uint32 for timeval tv_usec (microseconds since epoch seconds) but Linux uses a uint64, the format specifier did not match the memory of the variadic argument reference, resulting in capturing the subsequent unspecified bits. Since the platform is Little-endian, these manifested as unspecified bits in the high word, and the desired number in the low word. By casting the value to unsigned long regardless of platform, we ensure that the memory matches the specifier and that the high word gets filled with zeroes if necessary.

### Security Considerations

This should eliminate divergent behavior across platforms. This should also eliminate a possible vector for non-determinism, which we presumably have never observed before due to consistent allocation behavior, or simply not running long enough to see garbage in the high bits of a the timestamp mantissa. This could have resulted in at most one second of error in each timestamp. This could have invalidated assumptions about the monotonicity of timestamps on the JavaScript side of xsnap.

### Scaling Considerations

No scaling considerations.

### Documentation Considerations

No documentation considerations.

### Testing Considerations

I’ve elected not to write additional tests for this fringe behavior. I can be encouraged to think harder about how to frame such a test.