### PR TITLE
fix(auction!): don't reset an auction which is already scheduled

### DIFF
--- a/packages/inter-protocol/src/auction/scheduler.js
+++ b/packages/inter-protocol/src/auction/scheduler.js
@@ -149,18 +149,7 @@ export const makeScheduler = async (
       auctionState = AuctionState.WAITING;
       auctionDriver.finalize();
 
-      if (nextSchedule) {
-        // only recalculate the next schedule at this point if the lock time has
-        // not been reached.
-        const nextLock = nextSchedule.lockTime;
-        if (nextLock && TimeMath.compareAbs(now, nextLock) < 0) {
-          const afterNow = TimeMath.addAbsRel(
-            now,
-            TimeMath.coerceRelativeTimeRecord(1n, timerBrand),
-          );
-          nextSchedule = safelyComputeRoundTiming(params, afterNow);
-        }
-      } else {
+      if (!nextSchedule) {
         console.error(
           '🛠️ finishAuctionRound without scheduling the next; repair with new auctioneer params',
         );


### PR DESCRIPTION
closes: #7882

## Description

The auction scheduler was resetting the next schedule during cleanup from every round. If the scheduling parameters hadn't changed, this did nothing. If the parameters had changed, it reset the next schedule, without rescheduling the wakeups.

### Security Considerations

When scheduling parameters are changed, this causes an extra hiccup in the schedule.

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Added a test that goes through two complete cycles of the schedule.
