### PR TITLE
refactor(vaultFactory!): vaultFactory use zcf.atomicRearrange

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/liquidation.js
+++ b/packages/inter-protocol/src/vaultFactory/liquidation.js
@@ -5,7 +5,6 @@ import { makeTracer } from '@agoric/internal';
 import { observeIteration, subscribeEach } from '@agoric/notifier';
 import { makeScalarMapStore } from '@agoric/store';
 import { TimeMath } from '@agoric/time';
-import { atomicRearrange } from '@agoric/zoe/src/contractSupport/index.js';
 import { E } from '@endo/eventual-send';
 
 import { AUCTION_START_DELAY, PRICE_LOCK_PERIOD } from '../auction/params.js';
@@ -302,7 +301,7 @@ export const getLiquidatableVaults = (
   }
 
   if (transfers.length > 0) {
-    atomicRearrange(zcf, harden(transfers));
+    zcf.atomicRearrange(harden(transfers));
   }
 
   return { vaultData, totalDebt, totalCollateral, liqSeat };

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -18,7 +18,6 @@ import {
 } from '@agoric/vat-data';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
 import {
-  atomicRearrange,
   makeRecorderTopic,
   provideEmptySeat,
   SubscriberShape,
@@ -231,7 +230,7 @@ const prepareVaultDirector = (
         [mintSeat, mintReceiver, { Minted: kept }],
       ];
       try {
-        atomicRearrange(zcf, harden(transfers));
+        zcf.atomicRearrange(harden(transfers));
       } catch (e) {
         console.error('mintAndTransfer failed to rearrange', e);
         // If the rearrange fails, burn the newly minted tokens.

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -39,7 +39,6 @@ import {
 } from '@agoric/vat-data';
 import { TransferPartShape } from '@agoric/zoe/src/contractSupport/atomicTransfer.js';
 import {
-  atomicRearrange,
   ceilMultiplyBy,
   floorDivideBy,
   getAmountIn,
@@ -757,7 +756,7 @@ export const prepareVaultManagerKit = (
                   amounts,
                 ]),
             );
-            atomicRearrange(zcf, harden(transfers));
+            zcf.atomicRearrange(harden(transfers));
           }
 
           const { prioritizedVaults } = collateralEphemera(


### PR DESCRIPTION
refs: #6678
refs: #7900

## Description

update VaultFactory to use zcf.atomicRearrange.

This change **must not** be pushed to the chain before #7900.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

None

### Release considerations

This requires a change to Zoe (#7900). Since VaultFactory gets upgraded separately from Zoe, this is staged as a separate PR.  Once #7900 is on chain, this update can be made, even if it's in the same release cycle, as long as Zoe is upgraded first. This change is independent of changes to other contracts.
