### PR TITLE
refactor: hasOwn replaces hasOwnPropertyOf

### DIFF
--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -1,7 +1,7 @@
 /* global globalThis */
 /** global print */
 
-const { assign, freeze, keys } = Object;
+const { assign, freeze, keys, hasOwn } = Object;
 
 /**
  * deep equal value comparison
@@ -36,12 +36,8 @@ function deepDifference(x, y) {
       };
     }
 
-    const { hasOwnProperty } = Object.prototype;
-    /** @type {(obj: object, prop: string | symbol | number) => boolean} */
-    const hasOwnPropertyOf = (obj, prop) =>
-      Reflect.apply(hasOwnProperty, obj, [prop]);
     for (const prop of Reflect.ownKeys(x)) {
-      if (hasOwnPropertyOf(y, prop)) {
+      if (hasOwn(y, prop)) {
         if (!deepDifference(x[prop], y[prop])) {
           return null;
         }


### PR DESCRIPTION
See https://github.com/endojs/endo/pull/1627

Enabled by https://github.com/endojs/endo/pull/1623 , since Node 14 did not have `Object.hasOwn`.

`Object.hasOwn` replaces `hasOwnPropertyOf`.