### PR TITLE
refactor(PSM!): make PSM use zcf.atomicRearrange()

### DIFF
--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -14,7 +14,6 @@ import {
 import { StorageNodeShape } from '@agoric/internal';
 import { M, prepareExo, provide } from '@agoric/vat-data';
 import {
-  atomicRearrange,
   atomicTransfer,
   ceilMultiplyBy,
   floorDivideBy,
@@ -273,8 +272,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     const maxAnchor = floorMultiplyBy(afterFee, anchorPerMinted);
     AmountMath.isGTE(maxAnchor, wanted) ||
       Fail`wanted ${wanted} is more than ${given} minus fees ${fee}`;
-    atomicRearrange(
-      zcf,
+    zcf.atomicRearrange(
       harden([
         [seat, stage, { In: afterFee }, { Minted: afterFee }],
         [seat, feePool, { In: fee }, { Minted: fee }],
@@ -305,8 +303,7 @@ export const start = async (zcf, privateArgs, baggage) => {
       Fail`wanted ${wanted} is more than ${given} minus fees ${fee}`;
     mintMinted(asStable);
     try {
-      atomicRearrange(
-        zcf,
+      zcf.atomicRearrange(
         harden([
           [seat, anchorPool, { In: given }, { Anchor: given }],
           [stage, seat, { Minted: afterFee }, { Out: afterFee }],


### PR DESCRIPTION
closes: #6678
refs: #7900

## Description

update PSM to use `zcf.atomicRearrange()`.

This change must not be pushed to the chain before #7900.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

None

### Release considerations

This requires a change to Zoe (#7900). Since PSM gets upgraded separately from Zoe, this is staged as a separate PR. Once #7900 is on chain, this update can be made, even if it's in the same release cycle, as long as Zoe is upgraded first. This change is independent of changes to other contracts.