### PR TITLE
refactor(Auction!): make Auction use zcf.atomicRearrange()

### DIFF
--- a/packages/inter-protocol/src/auction/auctionBook.js
+++ b/packages/inter-protocol/src/auction/auctionBook.js
@@ -10,7 +10,6 @@ import { M, prepareExoClassKit } from '@agoric/vat-data';
 
 import { assertAllDefined, makeTracer } from '@agoric/internal';
 import {
-  atomicRearrange,
   ceilMultiplyBy,
   makeRatioFromAmounts,
   makeRecorderTopic,
@@ -311,8 +310,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
             seat.exit('unable to satisfy want');
           }
 
-          atomicRearrange(
-            zcf,
+          zcf.atomicRearrange(
             harden([
               [collateralSeat, seat, { Collateral: collateralTarget }],
               [seat, bidHoldingSeat, { Bid: proceedsTarget }],
@@ -569,8 +567,7 @@ export const prepareAuctionBook = (baggage, zcf, makeRecorderKit) => {
             state.startProceedsGoal = nextProceedsGoal;
           }
 
-          atomicRearrange(
-            zcf,
+          zcf.atomicRearrange(
             harden([[sourceSeat, collateralSeat, { Collateral: assetAmount }]]),
           );
 

--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -12,7 +12,6 @@ import { mustMatch } from '@agoric/store';
 import { appendToStoredArray } from '@agoric/store/src/stores/store-utils.js';
 import { M, provideDurableMapStore } from '@agoric/vat-data';
 import {
-  atomicRearrange,
   ceilDivideBy,
   ceilMultiplyBy,
   defineERecorderKit,
@@ -490,8 +489,7 @@ export const start = async (zcf, privateArgs, baggage) => {
         // send it all to the one
         const liqSeat = depositsForBrand[0].seat;
 
-        atomicRearrange(
-          zcf,
+        zcf.atomicRearrange(
           harden([
             [collateralSeat, liqSeat, collateralSeat.getCurrentAllocation()],
             [bidHoldingSeat, liqSeat, bidHoldingSeat.getCurrentAllocation()],
@@ -514,7 +512,7 @@ export const start = async (zcf, privateArgs, baggage) => {
           reserveSeat,
           brand,
         );
-        atomicRearrange(zcf, harden(transfers));
+        zcf.atomicRearrange(harden(transfers));
 
         for (const { seat } of depositsForBrand) {
           seat.exit();


### PR DESCRIPTION
refs: #6678
refs: #7900

## Description

update Auction to use `zcf.atomicRearrange()`.

This change must not be pushed to the chain before #7900.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

None

### Release considerations

This requires a change to Zoe (#7900). Since the Auction gets upgraded separately from Zoe, this is staged as a separate PR. Once #7900 is on chain, this update can be made, even if it's in the same release cycle, as long as Zoe is upgraded first. This change is independent of changes to other contracts.