### PR TITLE
build: clean up notifier deps

### DIFF
--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -35,15 +35,15 @@
   "dependencies": {
     "@agoric/assert": "^0.6.0",
     "@agoric/internal": "^0.3.2",
-    "@agoric/store": "^0.9.2",
-    "@agoric/swing-store": "^0.9.1",
-    "@agoric/swingset-vat": "^0.32.2",
     "@agoric/vat-data": "^0.5.2",
     "@endo/far": "^0.2.18",
     "@endo/marshal": "^0.8.5",
+    "@endo/patterns": "^0.2.2",
     "@endo/promise-kit": "^0.2.56"
   },
   "devDependencies": {
+    "@agoric/swing-store": "^0.9.1",
+    "@agoric/swingset-vat": "^0.32.2",
     "@endo/init": "^0.5.56",
     "@endo/ses-ava": "^0.2.40",
     "ava": "^5.3.0",

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -1,9 +1,9 @@
 /// <reference types="ses"/>
 
-import { makePromiseKit } from '@endo/promise-kit';
-import { E, Far } from '@endo/far';
-import { M } from '@agoric/store';
 import { canBeDurable, prepareExoClassKit } from '@agoric/vat-data';
+import { E, Far } from '@endo/far';
+import { M } from '@endo/patterns';
+import { makePromiseKit } from '@endo/promise-kit';
 
 import './types-ambient.js';
 

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -38,6 +38,7 @@
     "src/**/*.js",
     "src/**/*.d.ts",
     "test/**/*.js",
+    "tools",
     "exported.js"
   ],
   "repository": {


### PR DESCRIPTION
## Description

While working on https://github.com/Agoric/agoric-sdk/issues/6591 I noticed that even `yarn install` of those simple web components was causing `better-sqlite3` to build. The only @agoric package they import was notifier. That declared a runtime dependency on swingset-store, but it was only needed for tests.

This cleans up the dependency declarations of @agoric/notifier to lighten the downstream dependencies.

It also fixes a second problem, with swingset-vats exporting a test helper that depends on a tool from swingset-liveslots that's not published.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
