### PR TITLE
test: DeliverInbound from un-provisioned account is discarded

### DIFF
--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
@@ -10,6 +10,9 @@ set -x
 # agoric wallet show --from $GOV1ADDR
 waitForBlock 20
 
+# user1 has no mailbox provisioned; later we test that this was discarded
+submitDeliverInbound user1
+
 # provision a new user wallet
 
 agd keys add user2 --keyring-backend=test  2>&1 | tee "$HOME/.agoric/user2.out"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/env_setup.sh
@@ -84,3 +84,25 @@ pushPriceOnce () {
     echo "ERROR: pushPrice failed (using $nextOracle)"
   fi
 }
+
+# submit a DeliverInbound transaction
+#
+# see {agoric.swingset.MsgDeliverInbound} in swingset/msgs.proto
+# https://github.com/Agoric/agoric-sdk/blob/5cc5ec8836dcd0c6e11b10799966b6e74601295d/golang/cosmos/proto/agoric/swingset/msgs.proto#L23
+submitDeliverInbound() {
+  sender="${1:-user1}"
+
+  # ag-solo is a client that sends DeliverInbound transactions using a golang client
+  # @see {connectToChain} in chain-cosmos-sdk.js
+  # runHelper
+  # https://github.com/Agoric/agoric-sdk/blob/5cc5ec8836dcd0c6e11b10799966b6e74601295d/packages/solo/src/chain-cosmos-sdk.js
+
+  # The payload is JSON.stringify([messages, highestAck])
+  # https://github.com/Agoric/agoric-sdk/blob/5cc5ec8836dcd0c6e11b10799966b6e74601295d/packages/solo/src/chain-cosmos-sdk.js#L625
+  # for example, this json was captured from a running `agoric start local-solo`
+  json='[[[1,"1:0:deliver:ro+1:rp-44;#[\"getConfiguration\",[]]"]],0]'
+
+  agd tx swingset deliver "${json}" \
+      --chain-id="$CHAINID" -ojson --yes \
+      --from="$sender" --keyring-backend=test -b block
+}

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
@@ -2,6 +2,11 @@
 
 . ./upgrade-test-scripts/env_setup.sh
 
+# DeliverInbound from un-provisioned account is discarded
+# Note: sending to a provisioned account resulted in an .outbox of
+# [[1,"1:1:resolve:fulfill:rp+44:ro-20;#\"$0.Alleged: notifier\""]]
+test_val $(agd query swingset mailbox $USER1ADDR -o json | jq '.value |fromjson |.outbox') '[]' "DeliverInbound (getConfiguration) is discarded"
+
 # provision pool has right balance 
 test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ') "18750000"
 


### PR DESCRIPTION
refs: #5824

## Description

Test the code path that discards `DeliverInbound` messages from un-provisioned addresses.

As noted in #5824, we'd like to shorten this code path, in due course.

### Security / Scaling / Documentation Considerations

none that I can think of.

### Testing Considerations

uses the docker `upgrade-test` framework
