### PR TITLE
DO NOT MERGE test: test with current endo master

### DIFF
--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -120,6 +120,8 @@ const initKernelForTest = async (t, bundleData, config, options = {}) => {
   };
 };
 
+// Gratuitous change so I can create an otherwise identical PR
+
 const testNullUpgrade = async (t, defaultManagerType) => {
   const config = makeConfigFromPaths('../bootstrap-relay.js', {
     defaultManagerType,


### PR DESCRIPTION
#endo-branch: markm-1641-do-not-mutate-behavior-argument
Instead of master because of https://github.com/endojs/endo/issues/1641 to be fixed by https://github.com/endojs/endo/pull/1642

TODO switch back to master once https://github.com/endojs/endo/pull/1642 is merged

This PR exists only to test if the "current" agoric-sdk master is compatible with the "current" endo master.

When either master is updated, manually rebase this on agoric-sdk master to restart CI.