### PR TITLE
test: Support new error messages from endojs/endo#1606

### DIFF
--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -141,7 +141,7 @@ test('brand.isMyIssuer bad issuer', async t => {
   // @ts-expect-error Intentional wrong type for testing
   await t.throwsAsync(() => brand.isMyIssuer('not an issuer'), {
     message:
-      'In "isMyIssuer" method of (myTokens brand): arg 0: string "not an issuer" - Must be a remotable (Issuer)',
+      /In "isMyIssuer" method of \(myTokens brand\): arg 0: .*"not an issuer" - Must be a remotable/,
   });
   const fakeIssuer = /** @type {Issuer} */ (
     /** @type {unknown} */ (Far('myTokens issuer', {}))

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -205,7 +205,7 @@ test('purse.deposit promise', async t => {
     () => E(purse).deposit(exclusivePaymentP, fungible25),
     {
       message:
-        'In "deposit" method of (fungible Purse purse): arg 0: promise "[Promise]" - Must be a remotable (Payment)',
+        /In "deposit" method of \(fungible Purse purse\): arg 0: .*"\[Promise\]" - Must be a remotable/,
     },
     'failed to reject a promise for a payment',
   );

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -194,7 +194,7 @@ test('multiple params bad change', async t => {
       ),
     {
       message:
-        'In "getAmountOf" method of (Zoe Invitation issuer): arg 0: bigint "[13n]" - Must be a remotable (Payment)',
+        /In "getAmountOf" method of \(Zoe Invitation issuer\): arg 0: .*"\[13n\]" - Must be a remotable/,
     },
   );
 });

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -250,7 +250,7 @@ test(`E(zoe).getPublicFacet - no instance`, async t => {
   // @ts-expect-error deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getPublicFacet(), {
     message:
-      'In "getPublicFacet" method of (ZoeService): arg 0: undefined "[undefined]" - Must be a remotable (InstanceHandle)',
+      /In "getPublicFacet" method of \(ZoeService\): arg 0: .*"\[undefined\]" - Must be a remotable/,
   });
 });
 
@@ -281,7 +281,7 @@ test(`zoe.getIssuers - no instance`, async t => {
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getIssuers(), {
     message:
-      'In "getIssuers" method of (ZoeService): arg 0: undefined "[undefined]" - Must be a remotable (InstanceHandle)',
+      /In "getIssuers" method of \(ZoeService\): arg 0: .*"\[undefined\]" - Must be a remotable/,
   });
 });
 
@@ -312,7 +312,7 @@ test(`zoe.getBrands - no instance`, async t => {
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getBrands(), {
     message:
-      'In "getBrands" method of (ZoeService): arg 0: undefined "[undefined]" - Must be a remotable (InstanceHandle)',
+      /In "getBrands" method of \(ZoeService\): arg 0: .*"\[undefined\]" - Must be a remotable/,
   });
 });
 
@@ -368,7 +368,7 @@ test(`zoe.getTerms - no instance`, async t => {
   // @ts-expect-error invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getTerms(), {
     message:
-      'In "getTerms" method of (ZoeService): arg 0: undefined "[undefined]" - Must be a remotable (InstanceHandle)',
+      /In "getTerms" method of \(ZoeService\): arg 0: .*"\[undefined\]" - Must be a remotable/,
   });
 });
 


### PR DESCRIPTION
Fixes #7931

## Description

This is an alternative to https://github.com/endojs/endo/pull/1638 reverting code in endo.

### Security Considerations

We are slightly weakening the strictness of checks, but the current form (and probably still the new one) is overly brittle.

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

It would be good to establish better patterns, but for expediency I am not taking that step here.