### PR TITLE
test(zoe): ignore symbol-named methods in some tests

### DIFF
--- a/packages/internal/src/method-tools.js
+++ b/packages/internal/src/method-tools.js
@@ -63,6 +63,18 @@ export const getMethodNames = val => {
 harden(getMethodNames);
 
 /**
+ * The subset of `getMethodNames` containing only string names, without symbols
+ *
+ * @template {PropertyKey} K
+ * @param {Record<K, any>} val
+ * @returns {string[]}
+ */
+export const getStringMethodNames = val =>
+  /** @type {string[]} */ (
+    getMethodNames(val).filter(name => typeof name === 'string')
+  );
+
+/**
  * TODO This function exists only to ease the
  * https://github.com/Agoric/agoric-sdk/pull/5970 transition, from all methods
  * being own properties to methods being inherited from a common prototype.

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -6,7 +6,7 @@ import path from 'path';
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { passStyleOf, Far } from '@endo/marshal';
-import { getMethodNames } from '@agoric/internal';
+import { getStringMethodNames } from '@agoric/internal';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@endo/bundle-source';
@@ -124,7 +124,7 @@ test(`E(zoe).startInstance promise for installation`, async t => {
   isEmptyFacet(t, result.creatorFacet);
   t.deepEqual(result.creatorInvitation, undefined);
   facetHasMethods(t, result.publicFacet, ['makeInvitation']);
-  t.deepEqual(getMethodNames(result.adminFacet), [
+  t.deepEqual(getStringMethodNames(result.adminFacet), [
     'getVatShutdownPromise',
     'restartContract',
     'upgradeContract',

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -4,7 +4,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { Far } from '@endo/marshal';
 import { AssetKind, AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
-import { getMethodNames } from '@agoric/internal';
+import { getStringMethodNames } from '@agoric/internal';
 import { makeOffer } from '../makeOffer.js';
 
 import { setup } from '../setupBasicMints.js';
@@ -689,7 +689,7 @@ test(`zcf.makeEmptySeatKit`, async t => {
 });
 
 test(`zcfSeat from zcf.makeEmptySeatKit - only these properties exist`, async t => {
-  const expectedMethods = [
+  const expectedStringMethods = [
     'exit',
     'fail',
     'getAmountAllocated',
@@ -707,7 +707,7 @@ test(`zcfSeat from zcf.makeEmptySeatKit - only these properties exist`, async t 
   const { zcf } = await setupZCFTest();
   const makeZCFSeat = () => zcf.makeEmptySeatKit().zcfSeat;
   const seat = makeZCFSeat();
-  t.deepEqual(getMethodNames(seat), expectedMethods.sort());
+  t.deepEqual(getStringMethodNames(seat), expectedStringMethods.sort());
 });
 
 test(`zcfSeat.getProposal from zcf.makeEmptySeatKit`, async t => {


### PR DESCRIPTION
As explained at https://github.com/endojs/endo/blob/master/packages/exo/README.md , the current endo master adds a new symbol-named meta method to all exo objects. This PR fixes some tests in agoric-sdk that would break when updated to that endo. Those tests would now ignore symbol-named methods and look only at string-named methods, leaving agoric-sdk compat both before and after the next endo dependency upgrade.

I used experimental PRs like 
https://github.com/Agoric/agoric-sdk/pull/7926 
https://github.com/Agoric/agoric-sdk/pull/7915 
https://github.com/endojs/endo/pull/1630
to find these.