### PR TITLE
feat(casting): makeHttpClient for explicit net access with cosmjs

### DIFF
--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -38,6 +38,7 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
+    "@agoric/cosmic-proto": "^0.3.0",
     "@endo/ses-ava": "^0.2.40",
     "@types/node-fetch": "^2.6.2",
     "ava": "^5.3.0",

--- a/packages/casting/src/makeHttpClient.js
+++ b/packages/casting/src/makeHttpClient.js
@@ -1,0 +1,57 @@
+// @ts-check
+
+const { freeze } = Object;
+
+const filterBadStatus = res => {
+  if (res.status >= 400) {
+    throw new Error(`Bad status on response: ${res.status}`);
+  }
+  return res;
+};
+
+/**
+ * Make an RpcClient using explicit access to the network.
+ *
+ * The RpcClient implementations included in cosmjs
+ * such as {@link https://cosmos.github.io/cosmjs/latest/tendermint-rpc/classes/HttpClient.html HttpClient}
+ * use ambient authority (fetch or axios) for network access.
+ *
+ * To facilitate cooperation without vulnerability,
+ * as well as unit testing, etc. this RpcClient maker takes
+ * network access as a parameter, following
+ * {@link https://github.com/Agoric/agoric-sdk/wiki/OCap-Discipline|OCap Discipline}.
+ *
+ * @param {string} url
+ * @param {typeof window.fetch} fetch
+ * @returns {import('@cosmjs/tendermint-rpc').RpcClient}
+ */
+export const makeHttpClient = (url, fetch) => {
+  const headers = {}; // XXX needed?
+
+  // based on cosmjs 0.30.1:
+  // https://github.com/cosmos/cosmjs/blob/33271bc51cdc865cadb647a1b7ab55d873637f39/packages/tendermint-rpc/src/rpcclients/http.ts#L37
+  // https://github.com/cosmos/cosmjs/blob/33271bc51cdc865cadb647a1b7ab55d873637f39/packages/tendermint-rpc/src/rpcclients/httpclient.ts#L25
+  return freeze({
+    disconnect: () => {
+      // nothing to be done
+    },
+
+    /**
+     * @param {import('@cosmjs/json-rpc').JsonRpcRequest} request
+     */
+    execute: async request => {
+      const settings = {
+        method: 'POST',
+        body: request ? JSON.stringify(request) : undefined,
+        headers: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+      };
+      return fetch(url, settings)
+        .then(filterBadStatus)
+        .then(res => res.json());
+    },
+  });
+};

--- a/packages/casting/test/net-access-fixture.js
+++ b/packages/casting/test/net-access-fixture.js
@@ -1,5 +1,13 @@
 const { stringify: jq } = JSON;
 
+/**
+ * @file to regenerate
+ *   1. set RECORDING=true in test-interpose-net-access.js
+ *   2. run: yarn test test/test-test-interpose-net-access.js --update-snapshots
+ *   3. for each map in test-test-interpose-net-access.js.md, copy it and
+ *   4. replace all occurences of => with : and paste as args to Object.fromEntries()
+ *   5. change RECORDING back to false
+ */
 export const web1 = new Map([
   [
     jq([
@@ -7,7 +15,7 @@ export const web1 = new Map([
       {
         method: 'POST',
         body: jq({
-          id: 1,
+          id: 1208387614,
           method: 'no-such-method',
           params: [],
           jsonrpc: '2.0',
@@ -31,7 +39,7 @@ export const web1 = new Map([
         method: 'POST',
         body: jq({
           jsonrpc: '2.0',
-          id: 2,
+          id: 797030719,
           method: 'abci_query',
           params: {
             path: '/cosmos.bank.v1beta1.Query/Balance',
@@ -70,7 +78,7 @@ export const web2 = new Map([
         method: 'POST',
         body: jq({
           jsonrpc: '2.0',
-          id: 1,
+          id: 1757612624,
           method: 'abci_query',
           params: {
             path: '/agoric.vstorage.Query/Children',
@@ -103,18 +111,56 @@ export const web2 = new Map([
 ]);
 
 /**
- * capture JSON RPC IO traffic
+ * @param {string} str
+ * ack: https://stackoverflow.com/a/7616484
+ */
+const hashCode = str => {
+  let hash = 0;
+  let i;
+  let chr;
+  if (str.length === 0) return hash;
+  for (i = 0; i < str.length; i += 1) {
+    chr = str.charCodeAt(i);
+    // eslint-disable-next-line no-bitwise
+    hash = (hash << 5) - hash + chr;
+    // eslint-disable-next-line no-bitwise
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash;
+};
+
+/**
+ * Normalize JSON RPC request ID
  *
- * This was used to generate the fixtures above.
+ * tendermint-rpc generates ids using ambient access to Math.random()
+ * So we normalize them to a hash of the rest of the JSON.
+ *
+ * Earlier, we tried a sequence number, but it was non-deterministic
+ * with multiple interleaved requests.
+ *
+ * @param {string} argsKey
+ */
+const normalizeID = argsKey => {
+  // arbitrary string unlikely to occur in a request. from `pwgen 16 -1`
+  const placeholder = 'Ajaz1chei7ohnguv';
+
+  const noid = argsKey.replace(/\\"id\\":\d+/, `\\"id\\":${placeholder}`);
+  const id = Math.abs(hashCode(noid));
+  return noid.replace(placeholder, `${id}`);
+};
+
+/**
+ * Wrap `fetch` to capture JSON RPC IO traffic.
  *
  * @param {typeof window.fetch} fetch
+ * returns wraped fetch along with a .web map for use with {@link replayIO}
  */
 export const captureIO = fetch => {
   const web = new Map();
   /** @type {typeof window.fetch} */
   // @ts-expect-error mock
   const f = async (...args) => {
-    const key = JSON.stringify(args);
+    const key = normalizeID(JSON.stringify(args));
     const resp = await fetch(...args);
     return {
       json: async () => {
@@ -125,4 +171,26 @@ export const captureIO = fetch => {
     };
   };
   return { fetch: f, web };
+};
+
+/**
+ * Replay captured JSON RPC IO.
+ *
+ * @param {Map<string, any>} web map from
+ *   JSON-stringified fetch args to fetched JSON data.
+ */
+export const replayIO = web => {
+  /** @type {typeof window.fetch} */
+  // @ts-expect-error mock
+  const f = async (...args) => {
+    const key = normalizeID(JSON.stringify(args));
+    const data = web.get(key);
+    if (!data) {
+      throw Error(`no data for ${key}`);
+    }
+    return {
+      json: async () => data,
+    };
+  };
+  return f;
 };

--- a/packages/casting/test/net-access-fixture.js
+++ b/packages/casting/test/net-access-fixture.js
@@ -1,0 +1,128 @@
+const { stringify: jq } = JSON;
+
+export const web1 = new Map([
+  [
+    jq([
+      'https://emerynet.rpc.agoric.net/',
+      {
+        method: 'POST',
+        body: jq({
+          id: 1,
+          method: 'no-such-method',
+          params: [],
+          jsonrpc: '2.0',
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ]),
+    {
+      error: {
+        code: -32601,
+        message: 'Method not found',
+      },
+      id: 1208387614,
+      jsonrpc: '2.0',
+    },
+  ],
+  [
+    jq([
+      'https://emerynet.rpc.agoric.net/',
+      {
+        method: 'POST',
+        body: jq({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'abci_query',
+          params: {
+            path: '/cosmos.bank.v1beta1.Query/Balance',
+            data: '0a2d61676f726963313430646d6b727a326534326572676a6a37677976656a687a6d6a7a7572767165713832616e67120475697374',
+            prove: false,
+          },
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ]),
+    {
+      id: 797030719,
+      jsonrpc: '2.0',
+      result: {
+        response: {
+          code: 0,
+          codespace: '',
+          height: '123985',
+          index: '0',
+          info: '',
+          key: null,
+          log: '',
+          proofOps: null,
+          value: 'ChAKBHVpc3QSCDI1MDUwMDAw',
+        },
+      },
+    },
+  ],
+]);
+
+export const web2 = new Map([
+  [
+    jq([
+      'https://emerynet.rpc.agoric.net/',
+      {
+        method: 'POST',
+        body: jq({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'abci_query',
+          params: {
+            path: '/agoric.vstorage.Query/Children',
+            data: '',
+            prove: false,
+          },
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ]),
+    {
+      id: 1757612624,
+      jsonrpc: '2.0',
+      result: {
+        response: {
+          code: 0,
+          codespace: '',
+          height: '123985',
+          index: '0',
+          info: '',
+          key: null,
+          log: '',
+          proofOps: null,
+          value:
+            'CgxhY3Rpdml0eWhhc2gKCmJlYW5zT3dpbmcKBmVncmVzcwoTaGlnaFByaW9yaXR5U2VuZGVycwoJcHVibGlzaGVkCgpzd2luZ1N0b3Jl',
+        },
+      },
+    },
+  ],
+]);
+
+/**
+ * capture JSON RPC IO traffic
+ *
+ * This was used to generate the fixtures above.
+ *
+ * @param {typeof window.fetch} fetch
+ */
+export const captureIO = fetch => {
+  const web = new Map();
+  /** @type {typeof window.fetch} */
+  // @ts-expect-error mock
+  const f = async (...args) => {
+    const key = JSON.stringify(args);
+    const resp = await fetch(...args);
+    return {
+      json: async () => {
+        const data = await resp.json();
+        web.set(key, data);
+        return data;
+      },
+    };
+  };
+  return { fetch: f, web };
+};

--- a/packages/casting/test/test-interpose-net-access.js
+++ b/packages/casting/test/test-interpose-net-access.js
@@ -1,0 +1,127 @@
+// @ts-check
+/* global globalThis */
+import anyTest from 'ava';
+import {
+  createProtobufRpcClient,
+  QueryClient,
+  setupBankExtension,
+} from '@cosmjs/stargate';
+import { Tendermint34Client } from '@cosmjs/tendermint-rpc';
+import { QueryClientImpl } from '@agoric/cosmic-proto/vstorage/query.js';
+
+import { makeHttpClient } from '../src/makeHttpClient.js';
+import { captureIO, web1, web2 } from './net-access-fixture.js';
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
+const test = /** @type {any} */ (anyTest);
+
+/** @param {Map<string, any>} web */
+const replayIO = web => {
+  // tendermint-rpc generates ids using ambient access to Math.random()
+  // So we normalize them to sequence numbers.
+  let nextID = 0;
+  const normalizeID = data =>
+    data.replace(/\\"id\\":\d+/, `\\"id\\":${nextID}`);
+
+  /** @type {typeof window.fetch} */
+  // @ts-expect-error mock
+  const f = async (...args) => {
+    nextID += 1;
+    const key = normalizeID(JSON.stringify(args));
+    const data = web.get(key);
+    if (!data) throw Error(`no data for ${key}`);
+    return {
+      json: async () => data,
+    };
+  };
+  return f;
+};
+
+const makeTestContext = async () => {
+  return { fetch: globalThis.fetch };
+};
+
+test.before(async t => {
+  t.context = await makeTestContext();
+});
+
+const scenario1 = {
+  endpoint: 'https://emerynet.rpc.agoric.net/',
+  request: {
+    id: 1,
+    method: 'no-such-method',
+    params: [],
+  },
+  gov2: {
+    addr: 'agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang',
+    balance: { amount: '25050000', denom: 'uist' },
+  },
+};
+
+test('interpose net access', async t => {
+  const fetchMock = replayIO(web1);
+  const rpcClient = makeHttpClient(scenario1.endpoint, fetchMock);
+
+  t.log('raw JSON RPC');
+  const res = await rpcClient.execute({
+    ...scenario1.request,
+    jsonrpc: '2.0',
+  });
+  t.like(res, { error: { message: 'Method not found' } });
+
+  t.log('Cosmos SDK RPC: balance query');
+  const tmClient = await Tendermint34Client.create(rpcClient);
+  const qClient = new QueryClient(tmClient);
+  const ext = setupBankExtension(qClient);
+  const actual = await ext.bank.balance(
+    scenario1.gov2.addr,
+    scenario1.gov2.balance.denom,
+  );
+
+  t.deepEqual(actual, scenario1.gov2.balance);
+});
+
+const scenario2 = {
+  endpoint: 'https://emerynet.rpc.agoric.net/',
+  children: [
+    'activityhash',
+    'beansOwing',
+    'egress',
+    'highPrioritySenders',
+    'published',
+    'swingStore',
+  ],
+};
+
+test('vstorage query: Children', async t => {
+  const fetchMock = replayIO(web2);
+  const rpcClient = makeHttpClient(scenario2.endpoint, fetchMock);
+
+  const tmClient = await Tendermint34Client.create(rpcClient);
+  const qClient = new QueryClient(tmClient);
+  const rpc = createProtobufRpcClient(qClient);
+  const queryService = new QueryClientImpl(rpc);
+
+  const children = await queryService.Children({ path: '' });
+  t.deepEqual(children, {
+    children: scenario2.children,
+    pagination: undefined,
+  });
+});
+
+// Fixtures for the tests above were captured via integration testing like...
+test.skip('vstorage query: Data (capture IO)', async t => {
+  const { context: io } = t;
+  const { fetch: fetchMock, web } = captureIO(io.fetch);
+  const rpcClient = makeHttpClient(scenario2.endpoint, fetchMock);
+
+  const tmClient = await Tendermint34Client.create(rpcClient);
+  const qClient = new QueryClient(tmClient);
+  const rpc = createProtobufRpcClient(qClient);
+  const queryService = new QueryClientImpl(rpc);
+
+  const data = await queryService.Data({ path: '' });
+  t.deepEqual(data, { value: '' });
+
+  t.snapshot(web);
+});

--- a/packages/cosmic-proto/vstorage/query.js
+++ b/packages/cosmic-proto/vstorage/query.js
@@ -1,0 +1,2 @@
+/** @file for backwards compatibility */
+export * from '../dist/agoric/vstorage/query.js';


### PR DESCRIPTION
refs: #7905

stacked on #7950

## Description

`makeHttpClient` is an alternative to the cosmjs [HttpClient](https://cosmos.github.io/cosmjs/latest/tendermint-rpc/classes/HttpClient.html) that uses explicit rather than ambient access to the network.

### Security Considerations

facilitates use within a `Compartment`, for example.

In due course, I'd like other relevant APIs in the casting package to allow passing in network access likewise.

### Scaling / Documentation Considerations

n/a

### Testing Considerations

Also includes `captureIO` and `replayIO` test utilities to wrap `fetch`, record the traffic as fixtures, and then replay it from those fixtures.
