### PR TITLE
DO NOT MERGE: test "current" agoric-sdk essentially unchanged

### DIFF
--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -120,6 +120,8 @@ const initKernelForTest = async (t, bundleData, config, options = {}) => {
   };
 };
 
+// Gratuitous change so I can create an otherwise identical PR
+
 const testNullUpgrade = async (t, defaultManagerType) => {
   const config = makeConfigFromPaths('../bootstrap-relay.js', {
     defaultManagerType,


### PR DESCRIPTION
For investigating failures of https://github.com/Agoric/agoric-sdk/pull/7926 by taking "current" agoric-sdk master and having it depend on some endo.

This PR does not change which endo, so should be a clean build of agoric-sdk.