### PR TITLE
DO NOT MERGE: test "current" agoric-sdk with "current" endo master

### DIFF
--- a/packages/SwingSet/test/upgrade/upgrade.test.js
+++ b/packages/SwingSet/test/upgrade/upgrade.test.js
@@ -133,6 +133,8 @@ const initKernelForTest = async (t, bundleData, config, options = {}) => {
   };
 };
 
+// Gratuitous change so I can create an otherwise identical PR
+
 const testNullUpgrade = async (t, defaultManagerType) => {
   const config = makeConfigFromPaths('../../tools/bootstrap-relay.js', {
     defaultManagerType,


### PR DESCRIPTION
#endo-branch: master

This PR exists only to test if the "current" agoric-sdk master is compatible with the "current" endo master.

When either master is updated, manually rebase this on agoric-sdk master to restart CI.
