### PR TITLE
6678 upgrade zoe & zcf

### DIFF
--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -10,6 +10,9 @@ export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
 
   if (zoeBaggage.has(BUILD_PARAMS_KEY)) {
     const { feeIssuerConfig, zcfSpec } = zoeBaggage.get(BUILD_PARAMS_KEY);
+    // The return value is `{ zoeService, zoeConfigFacet, feeMintAccess }`. This
+    // call only needs zoeConfigFacet because the others have been returned.
+    // zoeConfigFacet was added after the first release of Zoe on-chain.
     ({ zoeConfigFacet } = makeDurableZoeKit({
       // For now Zoe will rewire vatAdminSvc on its own
       shutdownZoeVat,

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -6,15 +6,17 @@ const BUILD_PARAMS_KEY = 'buildZoeParams';
 export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
   const shutdownZoeVat = vatPowers.exitVatWithFailure;
 
+  let zoeConfigFacet;
+
   if (zoeBaggage.has(BUILD_PARAMS_KEY)) {
     const { feeIssuerConfig, zcfSpec } = zoeBaggage.get(BUILD_PARAMS_KEY);
-    makeDurableZoeKit({
+    ({ zoeConfigFacet } = makeDurableZoeKit({
       // For now Zoe will rewire vatAdminSvc on its own
       shutdownZoeVat,
       feeIssuerConfig,
       zcfSpec,
       zoeBaggage,
-    });
+    }));
   }
 
   return Far('root', {
@@ -44,5 +46,6 @@ export function buildRootObject(vatPowers, _vatParams, zoeBaggage) {
         feeMintAccess,
       });
     },
+    getZoeConfigFacet: () => zoeConfigFacet,
   });
 }

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -182,7 +182,8 @@ const makeDurableZoeKit = ({
           zcfBundleCap = bundleCap;
         },
         e => {
-          console.warn(`unable to update ZCF Bundle: `, e);
+          console.error(`'🚨 unable to update ZCF Bundle: `, e);
+          throw e;
         },
       );
     },

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -1,5 +1,10 @@
 import { E } from '@endo/far';
-import { AssetKind, makeDurableIssuerKit, AmountMath } from '@agoric/ertp';
+import {
+  AssetKind,
+  makeDurableIssuerKit,
+  AmountMath,
+  prepareIssuerKit,
+} from '@agoric/ertp';
 import {
   makeScalarBigMapStore,
   provideDurableWeakMapStore,
@@ -117,7 +122,7 @@ export const makeZoeStorageManager = (
     'zoeMintBaggageSet',
   );
   for (const issuerBaggage of zoeMintBaggageSet.values()) {
-    zoeMintBaggageSet(issuerBaggage);
+    prepareIssuerKit(issuerBaggage);
   }
 
   const makeZoeMint = prepareExoClass(


### PR DESCRIPTION
closes: #7918
refs: #6678

## Description

Changes to Zoe to enable upgrade of ZCF. Zoe needs to have a function in its creatorFacet that updates the ZCF bundle that will be used when starting or upgrading contracts. startInstance has to retrieve that value each time it is going to pass it to the kernel. (It used to be cached.) 

Additionally, discovered and fixed an issue with persisting zcfMints.

### Security Considerations

Maintain Zoe's guarantees.  Make it possible for users to know what version of ZCF will be used for new contracts.

### Scaling Considerations

N/A

### Documentation Considerations

None

### Testing Considerations

Tested in #7966 and #7969