### PR TITLE
build(deployment): use `bullseye` until `bookworm` bakes a bit

### DIFF
--- a/packages/deployment/Dockerfile
+++ b/packages/deployment/Dockerfile
@@ -4,7 +4,7 @@ ARG REGISTRY=ghcr.io
 
 # FIXME: Journalbeat compilation is currently broken, but non-essential.
 # Removed from the build.
-# FROM golang:1.20 AS go-build
+# FROM golang:1.20-bullseye AS go-build
 
 # WORKDIR /usr/src/journalbeat
 # RUN apt-get update -y && apt-get install -y libsystemd-dev

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -16,7 +16,7 @@ RUN make GIT_COMMIT="$GIT_COMMIT" GIT_REVISION="$GIT_REVISION" MOD_READONLY= com
 # OTEL fetch
 # from https://github.com/open-telemetry/opentelemetry-collector-releases/releases
 
-FROM node:lts-bullseye AS otel
+FROM node:18-bullseye AS otel
 
 ARG OTEL_VERSION=0.48.0
 ARG OTEL_HASH_arm64=846852f4c34f6e494abe202402fdf1d17e2ec3c7a7f96985b6011126ae553249
@@ -32,7 +32,7 @@ RUN set -eux; \
 
 ###############################
 # The js build container
-FROM node:lts-bullseye AS build-js
+FROM node:18-bullseye AS build-js
 
 # When changing/adding entries here, make sure to search the whole project for
 # `@@AGORIC_DOCKER_SUBMODULES@@`
@@ -68,7 +68,7 @@ RUN rm -rf packages/xsnap/moddable
 
 ###############################
 # The install container.
-FROM node:lts-bullseye AS install
+FROM node:18-bullseye AS install
 
 # Install some conveniences.
 RUN apt-get --allow-releaseinfo-change update && apt-get install -y vim jq less && apt-get clean -y

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -1,6 +1,6 @@
 ###########################
 # The golang build container
-FROM golang:1.20 as cosmos-go
+FROM golang:1.20-bullseye as cosmos-go
 
 WORKDIR /usr/src/agoric-sdk/golang/cosmos
 COPY golang/cosmos/go.mod golang/cosmos/go.sum ./
@@ -16,7 +16,7 @@ RUN make GIT_COMMIT="$GIT_COMMIT" GIT_REVISION="$GIT_REVISION" MOD_READONLY= com
 # OTEL fetch
 # from https://github.com/open-telemetry/opentelemetry-collector-releases/releases
 
-FROM node:lts AS otel
+FROM node:lts-bullseye AS otel
 
 ARG OTEL_VERSION=0.48.0
 ARG OTEL_HASH_arm64=846852f4c34f6e494abe202402fdf1d17e2ec3c7a7f96985b6011126ae553249
@@ -32,7 +32,7 @@ RUN set -eux; \
 
 ###############################
 # The js build container
-FROM node:lts AS build-js
+FROM node:lts-bullseye AS build-js
 
 # When changing/adding entries here, make sure to search the whole project for
 # `@@AGORIC_DOCKER_SUBMODULES@@`
@@ -68,7 +68,7 @@ RUN rm -rf packages/xsnap/moddable
 
 ###############################
 # The install container.
-FROM node:lts AS install
+FROM node:lts-bullseye AS install
 
 # Install some conveniences.
 RUN apt-get --allow-releaseinfo-change update && apt-get install -y vim jq less && apt-get clean -y

--- a/packages/deployment/scripts/install-deps.sh
+++ b/packages/deployment/scripts/install-deps.sh
@@ -46,6 +46,9 @@ case $VERSION_CODENAME in
   bullseye)
     VERSION_CODENAME=focal
     ;;
+  bookworm)
+    VERSION_CODENAME=jammy
+    ;;
 esac
 
 # Install Ansible.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

The `golang:1.20` and `node:lts` images recently were changed to use Debian bookworm (released just over a week ago) instead of bullseye.  Until we are more certain of bookworm's compatibility, it is probably safest to explicitly specify the use of bullseye, which is known to be compatible with the Agoric SDK and its current dependencies.

By explicit specification, we also make it easier to upgrade Debian dependencies in the future.  When we choose to upgrade the built Docker images to bookworm, it should be as easy as a string replacement.

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
Needs attention from the security team to decide the best way forward.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
