### PR TITLE
feat(cosmic-proto): stubs for vstorage/query.proto

### DIFF
--- a/packages/cosmic-proto/dist/agoric/swingset/msgs.d.ts
+++ b/packages/cosmic-proto/dist/agoric/swingset/msgs.d.ts
@@ -47,6 +47,13 @@ export interface MsgProvisionResponse {}
 export interface MsgInstallBundle {
   bundle: string;
   submitter: Uint8Array;
+  /**
+   * Either bundle or compressed_bundle will be set.
+   * Default compression algorithm is gzip.
+   */
+  compressedBundle: Uint8Array;
+  /** Size in bytes of uncompression of compressed_bundle. */
+  uncompressedSize: Long;
 }
 /**
  * MsgInstallBundleResponse is an empty acknowledgement that an install bundle
@@ -355,10 +362,91 @@ export declare const MsgInstallBundle: {
     I extends {
       bundle?: string | undefined;
       submitter?: Uint8Array | undefined;
+      compressedBundle?: Uint8Array | undefined;
+      uncompressedSize?: string | number | Long | undefined;
     } & {
       bundle?: string | undefined;
       submitter?: Uint8Array | undefined;
-    } & { [K in Exclude<keyof I, keyof MsgInstallBundle>]: never },
+      compressedBundle?: Uint8Array | undefined;
+      uncompressedSize?:
+        | string
+        | number
+        | (Long & {
+            high: number;
+            low: number;
+            unsigned: boolean;
+            add: (addend: string | number | Long) => Long;
+            and: (other: string | number | Long) => Long;
+            compare: (other: string | number | Long) => number;
+            comp: (other: string | number | Long) => number;
+            divide: (divisor: string | number | Long) => Long;
+            div: (divisor: string | number | Long) => Long;
+            equals: (other: string | number | Long) => boolean;
+            eq: (other: string | number | Long) => boolean;
+            getHighBits: () => number;
+            getHighBitsUnsigned: () => number;
+            getLowBits: () => number;
+            getLowBitsUnsigned: () => number;
+            getNumBitsAbs: () => number;
+            greaterThan: (other: string | number | Long) => boolean;
+            gt: (other: string | number | Long) => boolean;
+            greaterThanOrEqual: (other: string | number | Long) => boolean;
+            gte: (other: string | number | Long) => boolean;
+            ge: (other: string | number | Long) => boolean;
+            isEven: () => boolean;
+            isNegative: () => boolean;
+            isOdd: () => boolean;
+            isPositive: () => boolean;
+            isZero: () => boolean;
+            eqz: () => boolean;
+            lessThan: (other: string | number | Long) => boolean;
+            lt: (other: string | number | Long) => boolean;
+            lessThanOrEqual: (other: string | number | Long) => boolean;
+            lte: (other: string | number | Long) => boolean;
+            le: (other: string | number | Long) => boolean;
+            modulo: (other: string | number | Long) => Long;
+            mod: (other: string | number | Long) => Long;
+            rem: (other: string | number | Long) => Long;
+            multiply: (multiplier: string | number | Long) => Long;
+            mul: (multiplier: string | number | Long) => Long;
+            negate: () => Long;
+            neg: () => Long;
+            not: () => Long;
+            countLeadingZeros: () => number;
+            clz: () => number;
+            countTrailingZeros: () => number;
+            ctz: () => number;
+            notEquals: (other: string | number | Long) => boolean;
+            neq: (other: string | number | Long) => boolean;
+            ne: (other: string | number | Long) => boolean;
+            or: (other: string | number | Long) => Long;
+            shiftLeft: (numBits: number | Long) => Long;
+            shl: (numBits: number | Long) => Long;
+            shiftRight: (numBits: number | Long) => Long;
+            shr: (numBits: number | Long) => Long;
+            shiftRightUnsigned: (numBits: number | Long) => Long;
+            shru: (numBits: number | Long) => Long;
+            shr_u: (numBits: number | Long) => Long;
+            rotateLeft: (numBits: number | Long) => Long;
+            rotl: (numBits: number | Long) => Long;
+            rotateRight: (numBits: number | Long) => Long;
+            rotr: (numBits: number | Long) => Long;
+            subtract: (subtrahend: string | number | Long) => Long;
+            sub: (subtrahend: string | number | Long) => Long;
+            toInt: () => number;
+            toNumber: () => number;
+            toBytes: (le?: boolean | undefined) => number[];
+            toBytesLE: () => number[];
+            toBytesBE: () => number[];
+            toSigned: () => Long;
+            toString: (radix?: number | undefined) => string;
+            toUnsigned: () => Long;
+            xor: (other: string | number | Long) => Long;
+          } & {
+            [K in Exclude<keyof I['uncompressedSize'], keyof Long>]: never;
+          })
+        | undefined;
+    } & { [K_1 in Exclude<keyof I, keyof MsgInstallBundle>]: never },
   >(
     object: I,
   ): MsgInstallBundle;

--- a/packages/cosmic-proto/dist/agoric/swingset/msgs.js
+++ b/packages/cosmic-proto/dist/agoric/swingset/msgs.js
@@ -446,7 +446,12 @@ export const MsgProvisionResponse = {
   },
 };
 function createBaseMsgInstallBundle() {
-  return { bundle: '', submitter: new Uint8Array() };
+  return {
+    bundle: '',
+    submitter: new Uint8Array(),
+    compressedBundle: new Uint8Array(),
+    uncompressedSize: Long.ZERO,
+  };
 }
 export const MsgInstallBundle = {
   encode(message, writer = _m0.Writer.create()) {
@@ -455,6 +460,12 @@ export const MsgInstallBundle = {
     }
     if (message.submitter.length !== 0) {
       writer.uint32(18).bytes(message.submitter);
+    }
+    if (message.compressedBundle.length !== 0) {
+      writer.uint32(26).bytes(message.compressedBundle);
+    }
+    if (!message.uncompressedSize.isZero()) {
+      writer.uint32(32).int64(message.uncompressedSize);
     }
     return writer;
   },
@@ -471,6 +482,12 @@ export const MsgInstallBundle = {
         case 2:
           message.submitter = reader.bytes();
           break;
+        case 3:
+          message.compressedBundle = reader.bytes();
+          break;
+        case 4:
+          message.uncompressedSize = reader.int64();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -484,6 +501,12 @@ export const MsgInstallBundle = {
       submitter: isSet(object.submitter)
         ? bytesFromBase64(object.submitter)
         : new Uint8Array(),
+      compressedBundle: isSet(object.compressedBundle)
+        ? bytesFromBase64(object.compressedBundle)
+        : new Uint8Array(),
+      uncompressedSize: isSet(object.uncompressedSize)
+        ? Long.fromValue(object.uncompressedSize)
+        : Long.ZERO,
     };
   },
   toJSON(message) {
@@ -493,12 +516,27 @@ export const MsgInstallBundle = {
       (obj.submitter = base64FromBytes(
         message.submitter !== undefined ? message.submitter : new Uint8Array(),
       ));
+    message.compressedBundle !== undefined &&
+      (obj.compressedBundle = base64FromBytes(
+        message.compressedBundle !== undefined
+          ? message.compressedBundle
+          : new Uint8Array(),
+      ));
+    message.uncompressedSize !== undefined &&
+      (obj.uncompressedSize = (
+        message.uncompressedSize || Long.ZERO
+      ).toString());
     return obj;
   },
   fromPartial(object) {
     const message = createBaseMsgInstallBundle();
     message.bundle = object.bundle ?? '';
     message.submitter = object.submitter ?? new Uint8Array();
+    message.compressedBundle = object.compressedBundle ?? new Uint8Array();
+    message.uncompressedSize =
+      object.uncompressedSize !== undefined && object.uncompressedSize !== null
+        ? Long.fromValue(object.uncompressedSize)
+        : Long.ZERO;
     return message;
   },
 };

--- a/packages/cosmic-proto/dist/agoric/vstorage/query.d.ts
+++ b/packages/cosmic-proto/dist/agoric/vstorage/query.d.ts
@@ -1,0 +1,438 @@
+import Long from 'long';
+import _m0 from 'protobufjs/minimal.js';
+import {
+  PageRequest,
+  PageResponse,
+} from '../../cosmos/base/query/v1beta1/pagination.js';
+export declare const protobufPackage = 'agoric.vstorage';
+/** QueryDataRequest is the vstorage path data query. */
+export interface QueryDataRequest {
+  path: string;
+}
+/** QueryDataResponse is the vstorage path data response. */
+export interface QueryDataResponse {
+  value: string;
+}
+/** QueryChildrenRequest is the vstorage path children query. */
+export interface QueryChildrenRequest {
+  path: string;
+  pagination?: PageRequest;
+}
+/** QueryChildrenResponse is the vstorage path children response. */
+export interface QueryChildrenResponse {
+  children: string[];
+  pagination?: PageResponse;
+}
+export declare const QueryDataRequest: {
+  encode(message: QueryDataRequest, writer?: _m0.Writer): _m0.Writer;
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryDataRequest;
+  fromJSON(object: any): QueryDataRequest;
+  toJSON(message: QueryDataRequest): unknown;
+  fromPartial<
+    I extends {
+      path?: string | undefined;
+    } & {
+      path?: string | undefined;
+    } & { [K in Exclude<keyof I, 'path'>]: never },
+  >(
+    object: I,
+  ): QueryDataRequest;
+};
+export declare const QueryDataResponse: {
+  encode(message: QueryDataResponse, writer?: _m0.Writer): _m0.Writer;
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryDataResponse;
+  fromJSON(object: any): QueryDataResponse;
+  toJSON(message: QueryDataResponse): unknown;
+  fromPartial<
+    I extends {
+      value?: string | undefined;
+    } & {
+      value?: string | undefined;
+    } & { [K in Exclude<keyof I, 'value'>]: never },
+  >(
+    object: I,
+  ): QueryDataResponse;
+};
+export declare const QueryChildrenRequest: {
+  encode(message: QueryChildrenRequest, writer?: _m0.Writer): _m0.Writer;
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryChildrenRequest;
+  fromJSON(object: any): QueryChildrenRequest;
+  toJSON(message: QueryChildrenRequest): unknown;
+  fromPartial<
+    I extends {
+      path?: string | undefined;
+      pagination?:
+        | {
+            key?: Uint8Array | undefined;
+            offset?: string | number | Long | undefined;
+            limit?: string | number | Long | undefined;
+            countTotal?: boolean | undefined;
+            reverse?: boolean | undefined;
+          }
+        | undefined;
+    } & {
+      path?: string | undefined;
+      pagination?:
+        | ({
+            key?: Uint8Array | undefined;
+            offset?: string | number | Long | undefined;
+            limit?: string | number | Long | undefined;
+            countTotal?: boolean | undefined;
+            reverse?: boolean | undefined;
+          } & {
+            key?: Uint8Array | undefined;
+            offset?:
+              | string
+              | number
+              | (Long & {
+                  high: number;
+                  low: number;
+                  unsigned: boolean;
+                  add: (addend: string | number | Long) => Long;
+                  and: (other: string | number | Long) => Long;
+                  compare: (other: string | number | Long) => number;
+                  comp: (other: string | number | Long) => number;
+                  divide: (divisor: string | number | Long) => Long;
+                  div: (divisor: string | number | Long) => Long;
+                  equals: (other: string | number | Long) => boolean;
+                  eq: (other: string | number | Long) => boolean;
+                  getHighBits: () => number;
+                  getHighBitsUnsigned: () => number;
+                  getLowBits: () => number;
+                  getLowBitsUnsigned: () => number;
+                  getNumBitsAbs: () => number;
+                  greaterThan: (other: string | number | Long) => boolean;
+                  gt: (other: string | number | Long) => boolean;
+                  greaterThanOrEqual: (
+                    other: string | number | Long,
+                  ) => boolean;
+                  gte: (other: string | number | Long) => boolean;
+                  ge: (other: string | number | Long) => boolean;
+                  isEven: () => boolean;
+                  isNegative: () => boolean;
+                  isOdd: () => boolean;
+                  isPositive: () => boolean;
+                  isZero: () => boolean;
+                  eqz: () => boolean;
+                  lessThan: (other: string | number | Long) => boolean;
+                  lt: (other: string | number | Long) => boolean;
+                  lessThanOrEqual: (other: string | number | Long) => boolean;
+                  lte: (other: string | number | Long) => boolean;
+                  le: (other: string | number | Long) => boolean;
+                  modulo: (other: string | number | Long) => Long;
+                  mod: (other: string | number | Long) => Long;
+                  rem: (other: string | number | Long) => Long;
+                  multiply: (multiplier: string | number | Long) => Long;
+                  mul: (multiplier: string | number | Long) => Long;
+                  negate: () => Long;
+                  neg: () => Long;
+                  not: () => Long;
+                  countLeadingZeros: () => number;
+                  clz: () => number;
+                  countTrailingZeros: () => number;
+                  ctz: () => number;
+                  notEquals: (other: string | number | Long) => boolean;
+                  neq: (other: string | number | Long) => boolean;
+                  ne: (other: string | number | Long) => boolean;
+                  or: (other: string | number | Long) => Long;
+                  shiftLeft: (numBits: number | Long) => Long;
+                  shl: (numBits: number | Long) => Long;
+                  shiftRight: (numBits: number | Long) => Long;
+                  shr: (numBits: number | Long) => Long;
+                  shiftRightUnsigned: (numBits: number | Long) => Long;
+                  shru: (numBits: number | Long) => Long;
+                  shr_u: (numBits: number | Long) => Long;
+                  rotateLeft: (numBits: number | Long) => Long;
+                  rotl: (numBits: number | Long) => Long;
+                  rotateRight: (numBits: number | Long) => Long;
+                  rotr: (numBits: number | Long) => Long;
+                  subtract: (subtrahend: string | number | Long) => Long;
+                  sub: (subtrahend: string | number | Long) => Long;
+                  toInt: () => number;
+                  toNumber: () => number;
+                  toBytes: (le?: boolean | undefined) => number[];
+                  toBytesLE: () => number[];
+                  toBytesBE: () => number[];
+                  toSigned: () => Long;
+                  toString: (radix?: number | undefined) => string;
+                  toUnsigned: () => Long;
+                  xor: (other: string | number | Long) => Long;
+                } & {
+                  [K in Exclude<
+                    keyof I['pagination']['offset'],
+                    keyof Long
+                  >]: never;
+                })
+              | undefined;
+            limit?:
+              | string
+              | number
+              | (Long & {
+                  high: number;
+                  low: number;
+                  unsigned: boolean;
+                  add: (addend: string | number | Long) => Long;
+                  and: (other: string | number | Long) => Long;
+                  compare: (other: string | number | Long) => number;
+                  comp: (other: string | number | Long) => number;
+                  divide: (divisor: string | number | Long) => Long;
+                  div: (divisor: string | number | Long) => Long;
+                  equals: (other: string | number | Long) => boolean;
+                  eq: (other: string | number | Long) => boolean;
+                  getHighBits: () => number;
+                  getHighBitsUnsigned: () => number;
+                  getLowBits: () => number;
+                  getLowBitsUnsigned: () => number;
+                  getNumBitsAbs: () => number;
+                  greaterThan: (other: string | number | Long) => boolean;
+                  gt: (other: string | number | Long) => boolean;
+                  greaterThanOrEqual: (
+                    other: string | number | Long,
+                  ) => boolean;
+                  gte: (other: string | number | Long) => boolean;
+                  ge: (other: string | number | Long) => boolean;
+                  isEven: () => boolean;
+                  isNegative: () => boolean;
+                  isOdd: () => boolean;
+                  isPositive: () => boolean;
+                  isZero: () => boolean;
+                  eqz: () => boolean;
+                  lessThan: (other: string | number | Long) => boolean;
+                  lt: (other: string | number | Long) => boolean;
+                  lessThanOrEqual: (other: string | number | Long) => boolean;
+                  lte: (other: string | number | Long) => boolean;
+                  le: (other: string | number | Long) => boolean;
+                  modulo: (other: string | number | Long) => Long;
+                  mod: (other: string | number | Long) => Long;
+                  rem: (other: string | number | Long) => Long;
+                  multiply: (multiplier: string | number | Long) => Long;
+                  mul: (multiplier: string | number | Long) => Long;
+                  negate: () => Long;
+                  neg: () => Long;
+                  not: () => Long;
+                  countLeadingZeros: () => number;
+                  clz: () => number;
+                  countTrailingZeros: () => number;
+                  ctz: () => number;
+                  notEquals: (other: string | number | Long) => boolean;
+                  neq: (other: string | number | Long) => boolean;
+                  ne: (other: string | number | Long) => boolean;
+                  or: (other: string | number | Long) => Long;
+                  shiftLeft: (numBits: number | Long) => Long;
+                  shl: (numBits: number | Long) => Long;
+                  shiftRight: (numBits: number | Long) => Long;
+                  shr: (numBits: number | Long) => Long;
+                  shiftRightUnsigned: (numBits: number | Long) => Long;
+                  shru: (numBits: number | Long) => Long;
+                  shr_u: (numBits: number | Long) => Long;
+                  rotateLeft: (numBits: number | Long) => Long;
+                  rotl: (numBits: number | Long) => Long;
+                  rotateRight: (numBits: number | Long) => Long;
+                  rotr: (numBits: number | Long) => Long;
+                  subtract: (subtrahend: string | number | Long) => Long;
+                  sub: (subtrahend: string | number | Long) => Long;
+                  toInt: () => number;
+                  toNumber: () => number;
+                  toBytes: (le?: boolean | undefined) => number[];
+                  toBytesLE: () => number[];
+                  toBytesBE: () => number[];
+                  toSigned: () => Long;
+                  toString: (radix?: number | undefined) => string;
+                  toUnsigned: () => Long;
+                  xor: (other: string | number | Long) => Long;
+                } & {
+                  [K_1 in Exclude<
+                    keyof I['pagination']['limit'],
+                    keyof Long
+                  >]: never;
+                })
+              | undefined;
+            countTotal?: boolean | undefined;
+            reverse?: boolean | undefined;
+          } & {
+            [K_2 in Exclude<keyof I['pagination'], keyof PageRequest>]: never;
+          })
+        | undefined;
+    } & { [K_3 in Exclude<keyof I, keyof QueryChildrenRequest>]: never },
+  >(
+    object: I,
+  ): QueryChildrenRequest;
+};
+export declare const QueryChildrenResponse: {
+  encode(message: QueryChildrenResponse, writer?: _m0.Writer): _m0.Writer;
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryChildrenResponse;
+  fromJSON(object: any): QueryChildrenResponse;
+  toJSON(message: QueryChildrenResponse): unknown;
+  fromPartial<
+    I extends {
+      children?: string[] | undefined;
+      pagination?:
+        | {
+            nextKey?: Uint8Array | undefined;
+            total?: string | number | Long | undefined;
+          }
+        | undefined;
+    } & {
+      children?:
+        | (string[] &
+            string[] & {
+              [K in Exclude<keyof I['children'], keyof string[]>]: never;
+            })
+        | undefined;
+      pagination?:
+        | ({
+            nextKey?: Uint8Array | undefined;
+            total?: string | number | Long | undefined;
+          } & {
+            nextKey?: Uint8Array | undefined;
+            total?:
+              | string
+              | number
+              | (Long & {
+                  high: number;
+                  low: number;
+                  unsigned: boolean;
+                  add: (addend: string | number | Long) => Long;
+                  and: (other: string | number | Long) => Long;
+                  compare: (other: string | number | Long) => number;
+                  comp: (other: string | number | Long) => number;
+                  divide: (divisor: string | number | Long) => Long;
+                  div: (divisor: string | number | Long) => Long;
+                  equals: (other: string | number | Long) => boolean;
+                  eq: (other: string | number | Long) => boolean;
+                  getHighBits: () => number;
+                  getHighBitsUnsigned: () => number;
+                  getLowBits: () => number;
+                  getLowBitsUnsigned: () => number;
+                  getNumBitsAbs: () => number;
+                  greaterThan: (other: string | number | Long) => boolean;
+                  gt: (other: string | number | Long) => boolean;
+                  greaterThanOrEqual: (
+                    other: string | number | Long,
+                  ) => boolean;
+                  gte: (other: string | number | Long) => boolean;
+                  ge: (other: string | number | Long) => boolean;
+                  isEven: () => boolean;
+                  isNegative: () => boolean;
+                  isOdd: () => boolean;
+                  isPositive: () => boolean;
+                  isZero: () => boolean;
+                  eqz: () => boolean;
+                  lessThan: (other: string | number | Long) => boolean;
+                  lt: (other: string | number | Long) => boolean;
+                  lessThanOrEqual: (other: string | number | Long) => boolean;
+                  lte: (other: string | number | Long) => boolean;
+                  le: (other: string | number | Long) => boolean;
+                  modulo: (other: string | number | Long) => Long;
+                  mod: (other: string | number | Long) => Long;
+                  rem: (other: string | number | Long) => Long;
+                  multiply: (multiplier: string | number | Long) => Long;
+                  mul: (multiplier: string | number | Long) => Long;
+                  negate: () => Long;
+                  neg: () => Long;
+                  not: () => Long;
+                  countLeadingZeros: () => number;
+                  clz: () => number;
+                  countTrailingZeros: () => number;
+                  ctz: () => number;
+                  notEquals: (other: string | number | Long) => boolean;
+                  neq: (other: string | number | Long) => boolean;
+                  ne: (other: string | number | Long) => boolean;
+                  or: (other: string | number | Long) => Long;
+                  shiftLeft: (numBits: number | Long) => Long;
+                  shl: (numBits: number | Long) => Long;
+                  shiftRight: (numBits: number | Long) => Long;
+                  shr: (numBits: number | Long) => Long;
+                  shiftRightUnsigned: (numBits: number | Long) => Long;
+                  shru: (numBits: number | Long) => Long;
+                  shr_u: (numBits: number | Long) => Long;
+                  rotateLeft: (numBits: number | Long) => Long;
+                  rotl: (numBits: number | Long) => Long;
+                  rotateRight: (numBits: number | Long) => Long;
+                  rotr: (numBits: number | Long) => Long;
+                  subtract: (subtrahend: string | number | Long) => Long;
+                  sub: (subtrahend: string | number | Long) => Long;
+                  toInt: () => number;
+                  toNumber: () => number;
+                  toBytes: (le?: boolean | undefined) => number[];
+                  toBytesLE: () => number[];
+                  toBytesBE: () => number[];
+                  toSigned: () => Long;
+                  toString: (radix?: number | undefined) => string;
+                  toUnsigned: () => Long;
+                  xor: (other: string | number | Long) => Long;
+                } & {
+                  [K_1 in Exclude<
+                    keyof I['pagination']['total'],
+                    keyof Long
+                  >]: never;
+                })
+              | undefined;
+          } & {
+            [K_2 in Exclude<keyof I['pagination'], keyof PageResponse>]: never;
+          })
+        | undefined;
+    } & { [K_3 in Exclude<keyof I, keyof QueryChildrenResponse>]: never },
+  >(
+    object: I,
+  ): QueryChildrenResponse;
+};
+/** Query defines the gRPC querier service */
+export interface Query {
+  /** Return an arbitrary vstorage datum. */
+  Data(request: QueryDataRequest): Promise<QueryDataResponse>;
+  /** Return the children of a given vstorage path. */
+  Children(request: QueryChildrenRequest): Promise<QueryChildrenResponse>;
+}
+export declare class QueryClientImpl implements Query {
+  private readonly rpc;
+  private readonly service;
+  constructor(
+    rpc: Rpc,
+    opts?: {
+      service?: string;
+    },
+  );
+  Data(request: QueryDataRequest): Promise<QueryDataResponse>;
+  Children(request: QueryChildrenRequest): Promise<QueryChildrenResponse>;
+}
+interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array,
+  ): Promise<Uint8Array>;
+}
+declare type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+export declare type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? {
+      [K in keyof T]?: DeepPartial<T[K]>;
+    }
+  : Partial<T>;
+declare type KeysOfUnion<T> = T extends T ? keyof T : never;
+export declare type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & {
+      [K in keyof P]: Exact<P[K], I[K]>;
+    } & {
+      [K in Exclude<keyof I, KeysOfUnion<P>>]: never;
+    };
+export {};

--- a/packages/cosmic-proto/dist/agoric/vstorage/query.js
+++ b/packages/cosmic-proto/dist/agoric/vstorage/query.js
@@ -1,0 +1,250 @@
+/* eslint-disable */
+import Long from 'long';
+import _m0 from 'protobufjs/minimal.js';
+import {
+  PageRequest,
+  PageResponse,
+} from '../../cosmos/base/query/v1beta1/pagination.js';
+export const protobufPackage = 'agoric.vstorage';
+function createBaseQueryDataRequest() {
+  return { path: '' };
+}
+export const QueryDataRequest = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.path !== '') {
+      writer.uint32(10).string(message.path);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryDataRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.path = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return { path: isSet(object.path) ? String(object.path) : '' };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.path !== undefined && (obj.path = message.path);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryDataRequest();
+    message.path = object.path ?? '';
+    return message;
+  },
+};
+function createBaseQueryDataResponse() {
+  return { value: '' };
+}
+export const QueryDataResponse = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.value !== '') {
+      writer.uint32(10).string(message.value);
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryDataResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.value = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return { value: isSet(object.value) ? String(object.value) : '' };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.value !== undefined && (obj.value = message.value);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryDataResponse();
+    message.value = object.value ?? '';
+    return message;
+  },
+};
+function createBaseQueryChildrenRequest() {
+  return { path: '', pagination: undefined };
+}
+export const QueryChildrenRequest = {
+  encode(message, writer = _m0.Writer.create()) {
+    if (message.path !== '') {
+      writer.uint32(10).string(message.path);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryChildrenRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.path = reader.string();
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      path: isSet(object.path) ? String(object.path) : '',
+      pagination: isSet(object.pagination)
+        ? PageRequest.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    message.path !== undefined && (obj.path = message.path);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryChildrenRequest();
+    message.path = object.path ?? '';
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageRequest.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+};
+function createBaseQueryChildrenResponse() {
+  return { children: [], pagination: undefined };
+}
+export const QueryChildrenResponse = {
+  encode(message, writer = _m0.Writer.create()) {
+    for (const v of message.children) {
+      writer.uint32(10).string(v);
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+  decode(input, length) {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryChildrenResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.children.push(reader.string());
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object) {
+    return {
+      children: Array.isArray(object?.children)
+        ? object.children.map((e) => String(e))
+        : [],
+      pagination: isSet(object.pagination)
+        ? PageResponse.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+  toJSON(message) {
+    const obj = {};
+    if (message.children) {
+      obj.children = message.children.map((e) => e);
+    } else {
+      obj.children = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+  fromPartial(object) {
+    const message = createBaseQueryChildrenResponse();
+    message.children = object.children?.map((e) => e) || [];
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageResponse.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+};
+export class QueryClientImpl {
+  rpc;
+  service;
+  constructor(rpc, opts) {
+    this.service = opts?.service || 'agoric.vstorage.Query';
+    this.rpc = rpc;
+    this.Data = this.Data.bind(this);
+    this.Children = this.Children.bind(this);
+  }
+  Data(request) {
+    const data = QueryDataRequest.encode(request).finish();
+    const promise = this.rpc.request(this.service, 'Data', data);
+    return promise.then((data) =>
+      QueryDataResponse.decode(new _m0.Reader(data)),
+    );
+  }
+  Children(request) {
+    const data = QueryChildrenRequest.encode(request).finish();
+    const promise = this.rpc.request(this.service, 'Children', data);
+    return promise.then((data) =>
+      QueryChildrenResponse.decode(new _m0.Reader(data)),
+    );
+  }
+}
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long;
+  _m0.configure();
+}
+function isSet(value) {
+  return value !== null && value !== undefined;
+}

--- a/packages/cosmic-proto/dist/cosmos/base/query/v1beta1/pagination.d.ts
+++ b/packages/cosmic-proto/dist/cosmos/base/query/v1beta1/pagination.d.ts
@@ -1,0 +1,317 @@
+import Long from "long";
+import _m0 from "protobufjs/minimal.js";
+export declare const protobufPackage = "cosmos.base.query.v1beta1";
+/**
+ * PageRequest is to be embedded in gRPC request messages for efficient
+ * pagination. Ex:
+ *
+ *  message SomeRequest {
+ *          Foo some_parameter = 1;
+ *          PageRequest pagination = 2;
+ *  }
+ */
+export interface PageRequest {
+    /**
+     * key is a value returned in PageResponse.next_key to begin
+     * querying the next page most efficiently. Only one of offset or key
+     * should be set.
+     */
+    key: Uint8Array;
+    /**
+     * offset is a numeric offset that can be used when key is unavailable.
+     * It is less efficient than using key. Only one of offset or key should
+     * be set.
+     */
+    offset: Long;
+    /**
+     * limit is the total number of results to be returned in the result page.
+     * If left empty it will default to a value to be set by each app.
+     */
+    limit: Long;
+    /**
+     * count_total is set to true  to indicate that the result set should include
+     * a count of the total number of items available for pagination in UIs.
+     * count_total is only respected when offset is used. It is ignored when key
+     * is set.
+     */
+    countTotal: boolean;
+    /** reverse is set to true if results are to be returned in the descending order. */
+    reverse: boolean;
+}
+/**
+ * PageResponse is to be embedded in gRPC response messages where the
+ * corresponding request message has used PageRequest.
+ *
+ *  message SomeResponse {
+ *          repeated Bar results = 1;
+ *          PageResponse page = 2;
+ *  }
+ */
+export interface PageResponse {
+    /**
+     * next_key is the key to be passed to PageRequest.key to
+     * query the next page most efficiently
+     */
+    nextKey: Uint8Array;
+    /**
+     * total is total number of results available if PageRequest.count_total
+     * was set, its value is undefined otherwise
+     */
+    total: Long;
+}
+export declare const PageRequest: {
+    encode(message: PageRequest, writer?: _m0.Writer): _m0.Writer;
+    decode(input: _m0.Reader | Uint8Array, length?: number): PageRequest;
+    fromJSON(object: any): PageRequest;
+    toJSON(message: PageRequest): unknown;
+    fromPartial<I extends {
+        key?: Uint8Array | undefined;
+        offset?: string | number | Long | undefined;
+        limit?: string | number | Long | undefined;
+        countTotal?: boolean | undefined;
+        reverse?: boolean | undefined;
+    } & {
+        key?: Uint8Array | undefined;
+        offset?: string | number | (Long & {
+            high: number;
+            low: number;
+            unsigned: boolean;
+            add: (addend: string | number | Long) => Long;
+            and: (other: string | number | Long) => Long;
+            compare: (other: string | number | Long) => number;
+            comp: (other: string | number | Long) => number;
+            divide: (divisor: string | number | Long) => Long;
+            div: (divisor: string | number | Long) => Long;
+            equals: (other: string | number | Long) => boolean;
+            eq: (other: string | number | Long) => boolean;
+            getHighBits: () => number;
+            getHighBitsUnsigned: () => number;
+            getLowBits: () => number;
+            getLowBitsUnsigned: () => number;
+            getNumBitsAbs: () => number;
+            greaterThan: (other: string | number | Long) => boolean;
+            gt: (other: string | number | Long) => boolean;
+            greaterThanOrEqual: (other: string | number | Long) => boolean;
+            gte: (other: string | number | Long) => boolean;
+            ge: (other: string | number | Long) => boolean;
+            isEven: () => boolean;
+            isNegative: () => boolean;
+            isOdd: () => boolean;
+            isPositive: () => boolean;
+            isZero: () => boolean;
+            eqz: () => boolean;
+            lessThan: (other: string | number | Long) => boolean;
+            lt: (other: string | number | Long) => boolean;
+            lessThanOrEqual: (other: string | number | Long) => boolean;
+            lte: (other: string | number | Long) => boolean;
+            le: (other: string | number | Long) => boolean;
+            modulo: (other: string | number | Long) => Long;
+            mod: (other: string | number | Long) => Long;
+            rem: (other: string | number | Long) => Long;
+            multiply: (multiplier: string | number | Long) => Long;
+            mul: (multiplier: string | number | Long) => Long;
+            negate: () => Long;
+            neg: () => Long;
+            not: () => Long;
+            countLeadingZeros: () => number;
+            clz: () => number;
+            countTrailingZeros: () => number;
+            ctz: () => number;
+            notEquals: (other: string | number | Long) => boolean;
+            neq: (other: string | number | Long) => boolean;
+            ne: (other: string | number | Long) => boolean;
+            or: (other: string | number | Long) => Long;
+            shiftLeft: (numBits: number | Long) => Long;
+            shl: (numBits: number | Long) => Long;
+            shiftRight: (numBits: number | Long) => Long;
+            shr: (numBits: number | Long) => Long;
+            shiftRightUnsigned: (numBits: number | Long) => Long;
+            shru: (numBits: number | Long) => Long;
+            shr_u: (numBits: number | Long) => Long;
+            rotateLeft: (numBits: number | Long) => Long;
+            rotl: (numBits: number | Long) => Long;
+            rotateRight: (numBits: number | Long) => Long;
+            rotr: (numBits: number | Long) => Long;
+            subtract: (subtrahend: string | number | Long) => Long;
+            sub: (subtrahend: string | number | Long) => Long;
+            toInt: () => number;
+            toNumber: () => number;
+            toBytes: (le?: boolean | undefined) => number[];
+            toBytesLE: () => number[];
+            toBytesBE: () => number[];
+            toSigned: () => Long;
+            toString: (radix?: number | undefined) => string;
+            toUnsigned: () => Long;
+            xor: (other: string | number | Long) => Long;
+        } & { [K in Exclude<keyof I["offset"], keyof Long>]: never; }) | undefined;
+        limit?: string | number | (Long & {
+            high: number;
+            low: number;
+            unsigned: boolean;
+            add: (addend: string | number | Long) => Long;
+            and: (other: string | number | Long) => Long;
+            compare: (other: string | number | Long) => number;
+            comp: (other: string | number | Long) => number;
+            divide: (divisor: string | number | Long) => Long;
+            div: (divisor: string | number | Long) => Long;
+            equals: (other: string | number | Long) => boolean;
+            eq: (other: string | number | Long) => boolean;
+            getHighBits: () => number;
+            getHighBitsUnsigned: () => number;
+            getLowBits: () => number;
+            getLowBitsUnsigned: () => number;
+            getNumBitsAbs: () => number;
+            greaterThan: (other: string | number | Long) => boolean;
+            gt: (other: string | number | Long) => boolean;
+            greaterThanOrEqual: (other: string | number | Long) => boolean;
+            gte: (other: string | number | Long) => boolean;
+            ge: (other: string | number | Long) => boolean;
+            isEven: () => boolean;
+            isNegative: () => boolean;
+            isOdd: () => boolean;
+            isPositive: () => boolean;
+            isZero: () => boolean;
+            eqz: () => boolean;
+            lessThan: (other: string | number | Long) => boolean;
+            lt: (other: string | number | Long) => boolean;
+            lessThanOrEqual: (other: string | number | Long) => boolean;
+            lte: (other: string | number | Long) => boolean;
+            le: (other: string | number | Long) => boolean;
+            modulo: (other: string | number | Long) => Long;
+            mod: (other: string | number | Long) => Long;
+            rem: (other: string | number | Long) => Long;
+            multiply: (multiplier: string | number | Long) => Long;
+            mul: (multiplier: string | number | Long) => Long;
+            negate: () => Long;
+            neg: () => Long;
+            not: () => Long;
+            countLeadingZeros: () => number;
+            clz: () => number;
+            countTrailingZeros: () => number;
+            ctz: () => number;
+            notEquals: (other: string | number | Long) => boolean;
+            neq: (other: string | number | Long) => boolean;
+            ne: (other: string | number | Long) => boolean;
+            or: (other: string | number | Long) => Long;
+            shiftLeft: (numBits: number | Long) => Long;
+            shl: (numBits: number | Long) => Long;
+            shiftRight: (numBits: number | Long) => Long;
+            shr: (numBits: number | Long) => Long;
+            shiftRightUnsigned: (numBits: number | Long) => Long;
+            shru: (numBits: number | Long) => Long;
+            shr_u: (numBits: number | Long) => Long;
+            rotateLeft: (numBits: number | Long) => Long;
+            rotl: (numBits: number | Long) => Long;
+            rotateRight: (numBits: number | Long) => Long;
+            rotr: (numBits: number | Long) => Long;
+            subtract: (subtrahend: string | number | Long) => Long;
+            sub: (subtrahend: string | number | Long) => Long;
+            toInt: () => number;
+            toNumber: () => number;
+            toBytes: (le?: boolean | undefined) => number[];
+            toBytesLE: () => number[];
+            toBytesBE: () => number[];
+            toSigned: () => Long;
+            toString: (radix?: number | undefined) => string;
+            toUnsigned: () => Long;
+            xor: (other: string | number | Long) => Long;
+        } & { [K_1 in Exclude<keyof I["limit"], keyof Long>]: never; }) | undefined;
+        countTotal?: boolean | undefined;
+        reverse?: boolean | undefined;
+    } & { [K_2 in Exclude<keyof I, keyof PageRequest>]: never; }>(object: I): PageRequest;
+};
+export declare const PageResponse: {
+    encode(message: PageResponse, writer?: _m0.Writer): _m0.Writer;
+    decode(input: _m0.Reader | Uint8Array, length?: number): PageResponse;
+    fromJSON(object: any): PageResponse;
+    toJSON(message: PageResponse): unknown;
+    fromPartial<I extends {
+        nextKey?: Uint8Array | undefined;
+        total?: string | number | Long | undefined;
+    } & {
+        nextKey?: Uint8Array | undefined;
+        total?: string | number | (Long & {
+            high: number;
+            low: number;
+            unsigned: boolean;
+            add: (addend: string | number | Long) => Long;
+            and: (other: string | number | Long) => Long;
+            compare: (other: string | number | Long) => number;
+            comp: (other: string | number | Long) => number;
+            divide: (divisor: string | number | Long) => Long;
+            div: (divisor: string | number | Long) => Long;
+            equals: (other: string | number | Long) => boolean;
+            eq: (other: string | number | Long) => boolean;
+            getHighBits: () => number;
+            getHighBitsUnsigned: () => number;
+            getLowBits: () => number;
+            getLowBitsUnsigned: () => number;
+            getNumBitsAbs: () => number;
+            greaterThan: (other: string | number | Long) => boolean;
+            gt: (other: string | number | Long) => boolean;
+            greaterThanOrEqual: (other: string | number | Long) => boolean;
+            gte: (other: string | number | Long) => boolean;
+            ge: (other: string | number | Long) => boolean;
+            isEven: () => boolean;
+            isNegative: () => boolean;
+            isOdd: () => boolean;
+            isPositive: () => boolean;
+            isZero: () => boolean;
+            eqz: () => boolean;
+            lessThan: (other: string | number | Long) => boolean;
+            lt: (other: string | number | Long) => boolean;
+            lessThanOrEqual: (other: string | number | Long) => boolean;
+            lte: (other: string | number | Long) => boolean;
+            le: (other: string | number | Long) => boolean;
+            modulo: (other: string | number | Long) => Long;
+            mod: (other: string | number | Long) => Long;
+            rem: (other: string | number | Long) => Long;
+            multiply: (multiplier: string | number | Long) => Long;
+            mul: (multiplier: string | number | Long) => Long;
+            negate: () => Long;
+            neg: () => Long;
+            not: () => Long;
+            countLeadingZeros: () => number;
+            clz: () => number;
+            countTrailingZeros: () => number;
+            ctz: () => number;
+            notEquals: (other: string | number | Long) => boolean;
+            neq: (other: string | number | Long) => boolean;
+            ne: (other: string | number | Long) => boolean;
+            or: (other: string | number | Long) => Long;
+            shiftLeft: (numBits: number | Long) => Long;
+            shl: (numBits: number | Long) => Long;
+            shiftRight: (numBits: number | Long) => Long;
+            shr: (numBits: number | Long) => Long;
+            shiftRightUnsigned: (numBits: number | Long) => Long;
+            shru: (numBits: number | Long) => Long;
+            shr_u: (numBits: number | Long) => Long;
+            rotateLeft: (numBits: number | Long) => Long;
+            rotl: (numBits: number | Long) => Long;
+            rotateRight: (numBits: number | Long) => Long;
+            rotr: (numBits: number | Long) => Long;
+            subtract: (subtrahend: string | number | Long) => Long;
+            sub: (subtrahend: string | number | Long) => Long;
+            toInt: () => number;
+            toNumber: () => number;
+            toBytes: (le?: boolean | undefined) => number[];
+            toBytesLE: () => number[];
+            toBytesBE: () => number[];
+            toSigned: () => Long;
+            toString: (radix?: number | undefined) => string;
+            toUnsigned: () => Long;
+            xor: (other: string | number | Long) => Long;
+        } & { [K in Exclude<keyof I["total"], keyof Long>]: never; }) | undefined;
+    } & { [K_1 in Exclude<keyof I, keyof PageResponse>]: never; }>(object: I): PageResponse;
+};
+declare type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+export declare type DeepPartial<T> = T extends Builtin ? T : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>> : T extends {} ? {
+    [K in keyof T]?: DeepPartial<T[K]>;
+} : Partial<T>;
+declare type KeysOfUnion<T> = T extends T ? keyof T : never;
+export declare type Exact<P, I extends P> = P extends Builtin ? P : P & {
+    [K in keyof P]: Exact<P[K], I[K]>;
+} & {
+    [K in Exclude<keyof I, KeysOfUnion<P>>]: never;
+};
+export {};

--- a/packages/cosmic-proto/dist/cosmos/base/query/v1beta1/pagination.js
+++ b/packages/cosmic-proto/dist/cosmos/base/query/v1beta1/pagination.js
@@ -1,0 +1,186 @@
+/* eslint-disable */
+import Long from "long";
+import _m0 from "protobufjs/minimal.js";
+export const protobufPackage = "cosmos.base.query.v1beta1";
+function createBasePageRequest() {
+    return { key: new Uint8Array(), offset: Long.UZERO, limit: Long.UZERO, countTotal: false, reverse: false };
+}
+export const PageRequest = {
+    encode(message, writer = _m0.Writer.create()) {
+        if (message.key.length !== 0) {
+            writer.uint32(10).bytes(message.key);
+        }
+        if (!message.offset.isZero()) {
+            writer.uint32(16).uint64(message.offset);
+        }
+        if (!message.limit.isZero()) {
+            writer.uint32(24).uint64(message.limit);
+        }
+        if (message.countTotal === true) {
+            writer.uint32(32).bool(message.countTotal);
+        }
+        if (message.reverse === true) {
+            writer.uint32(40).bool(message.reverse);
+        }
+        return writer;
+    },
+    decode(input, length) {
+        const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+        let end = length === undefined ? reader.len : reader.pos + length;
+        const message = createBasePageRequest();
+        while (reader.pos < end) {
+            const tag = reader.uint32();
+            switch (tag >>> 3) {
+                case 1:
+                    message.key = reader.bytes();
+                    break;
+                case 2:
+                    message.offset = reader.uint64();
+                    break;
+                case 3:
+                    message.limit = reader.uint64();
+                    break;
+                case 4:
+                    message.countTotal = reader.bool();
+                    break;
+                case 5:
+                    message.reverse = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+            }
+        }
+        return message;
+    },
+    fromJSON(object) {
+        return {
+            key: isSet(object.key) ? bytesFromBase64(object.key) : new Uint8Array(),
+            offset: isSet(object.offset) ? Long.fromValue(object.offset) : Long.UZERO,
+            limit: isSet(object.limit) ? Long.fromValue(object.limit) : Long.UZERO,
+            countTotal: isSet(object.countTotal) ? Boolean(object.countTotal) : false,
+            reverse: isSet(object.reverse) ? Boolean(object.reverse) : false,
+        };
+    },
+    toJSON(message) {
+        const obj = {};
+        message.key !== undefined &&
+            (obj.key = base64FromBytes(message.key !== undefined ? message.key : new Uint8Array()));
+        message.offset !== undefined && (obj.offset = (message.offset || Long.UZERO).toString());
+        message.limit !== undefined && (obj.limit = (message.limit || Long.UZERO).toString());
+        message.countTotal !== undefined && (obj.countTotal = message.countTotal);
+        message.reverse !== undefined && (obj.reverse = message.reverse);
+        return obj;
+    },
+    fromPartial(object) {
+        const message = createBasePageRequest();
+        message.key = object.key ?? new Uint8Array();
+        message.offset = (object.offset !== undefined && object.offset !== null)
+            ? Long.fromValue(object.offset)
+            : Long.UZERO;
+        message.limit = (object.limit !== undefined && object.limit !== null) ? Long.fromValue(object.limit) : Long.UZERO;
+        message.countTotal = object.countTotal ?? false;
+        message.reverse = object.reverse ?? false;
+        return message;
+    },
+};
+function createBasePageResponse() {
+    return { nextKey: new Uint8Array(), total: Long.UZERO };
+}
+export const PageResponse = {
+    encode(message, writer = _m0.Writer.create()) {
+        if (message.nextKey.length !== 0) {
+            writer.uint32(10).bytes(message.nextKey);
+        }
+        if (!message.total.isZero()) {
+            writer.uint32(16).uint64(message.total);
+        }
+        return writer;
+    },
+    decode(input, length) {
+        const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+        let end = length === undefined ? reader.len : reader.pos + length;
+        const message = createBasePageResponse();
+        while (reader.pos < end) {
+            const tag = reader.uint32();
+            switch (tag >>> 3) {
+                case 1:
+                    message.nextKey = reader.bytes();
+                    break;
+                case 2:
+                    message.total = reader.uint64();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+            }
+        }
+        return message;
+    },
+    fromJSON(object) {
+        return {
+            nextKey: isSet(object.nextKey) ? bytesFromBase64(object.nextKey) : new Uint8Array(),
+            total: isSet(object.total) ? Long.fromValue(object.total) : Long.UZERO,
+        };
+    },
+    toJSON(message) {
+        const obj = {};
+        message.nextKey !== undefined &&
+            (obj.nextKey = base64FromBytes(message.nextKey !== undefined ? message.nextKey : new Uint8Array()));
+        message.total !== undefined && (obj.total = (message.total || Long.UZERO).toString());
+        return obj;
+    },
+    fromPartial(object) {
+        const message = createBasePageResponse();
+        message.nextKey = object.nextKey ?? new Uint8Array();
+        message.total = (object.total !== undefined && object.total !== null) ? Long.fromValue(object.total) : Long.UZERO;
+        return message;
+    },
+};
+var globalThis = (() => {
+    if (typeof globalThis !== "undefined") {
+        return globalThis;
+    }
+    if (typeof self !== "undefined") {
+        return self;
+    }
+    if (typeof window !== "undefined") {
+        return window;
+    }
+    if (typeof global !== "undefined") {
+        return global;
+    }
+    throw "Unable to locate global object";
+})();
+function bytesFromBase64(b64) {
+    if (globalThis.Buffer) {
+        return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
+    }
+    else {
+        const bin = globalThis.atob(b64);
+        const arr = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; ++i) {
+            arr[i] = bin.charCodeAt(i);
+        }
+        return arr;
+    }
+}
+function base64FromBytes(arr) {
+    if (globalThis.Buffer) {
+        return globalThis.Buffer.from(arr).toString("base64");
+    }
+    else {
+        const bin = [];
+        arr.forEach((byte) => {
+            bin.push(String.fromCharCode(byte));
+        });
+        return globalThis.btoa(bin.join(""));
+    }
+}
+if (_m0.util.Long !== Long) {
+    _m0.util.Long = Long;
+    _m0.configure();
+}
+function isSet(value) {
+    return value !== null && value !== undefined;
+}

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -24,6 +24,10 @@
       "types": "./dist/agoric/swingset/query.d.ts",
       "default": "./dist/agoric/swingset/query.js"
     },
+    "./vstorage/query.js": {
+      "types": "./dist/agoric/vstorage/query.d.ts",
+      "default": "./dist/agoric/vstorage/query.js"
+    },
     "./swingset/swingset.js": {
       "types": "./dist/agoric/swingset/swingset.d.ts",
       "default": "./dist/agoric/swingset/swingset.js"
@@ -32,7 +36,7 @@
   "scripts": {
     "build": "echo Use yarn rebuild to update dist output",
     "rebuild": "rm -rf gen && mkdir -p gen && yarn generate && tsc --build && yarn prettier -w dist/agoric && rm -rf gen",
-    "generate": "protoc --plugin=node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt='esModuleInterop=true,forceLong=long,useOptionals=messages' --ts_proto_out=./gen --ts_proto_opt=importSuffix=.js ./proto/agoric/swingset/msgs.proto ./proto/agoric/swingset/query.proto -I./proto",
+    "generate": "protoc --plugin=node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt='esModuleInterop=true,forceLong=long,useOptionals=messages' --ts_proto_out=./gen --ts_proto_opt=importSuffix=.js ./proto/agoric/swingset/msgs.proto ./proto/agoric/swingset/query.proto ./proto/agoric/vstorage/query.proto -I./proto",
     "test": "node test/sanity-test.js",
     "test:xs": "exit 0",
     "lint": "exit 0",

--- a/packages/cosmic-proto/test/sanity-test.js
+++ b/packages/cosmic-proto/test/sanity-test.js
@@ -1,3 +1,4 @@
 /* eslint-disable import/no-extraneous-dependencies -- bug in rule thinks this package depends on itself */
 import '@agoric/cosmic-proto/swingset/msgs.js';
 import '@agoric/cosmic-proto/swingset/query.js';
+import '@agoric/cosmic-proto/vstorage/query.js';


### PR DESCRIPTION
refs: #7905

## Description

Generate vstorage query stubs to replace ad-hoc implementation in, for example, CLI tools.

### Security / Scaling Considerations

n/a

### Documentation Considerations

makes the connection to `vstorage/query.proto` a bit more clear

cc @samsiegart - perhaps we have dapps that borrowed the 3/4ths of a `vstorage/query.proto` implementation that was in our CLI code?

### Testing Considerations

lightly tested in the context of other work (#7939)

like other code in `@agoric/cosmic-proto`, we suppose the generated code doesn't merit its own tests
