### PR TITLE
ci: properly handle subdependencies for Endo branch override

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -14,6 +14,11 @@ inputs:
     required: false
     default: '0'
 
+outputs:
+  endo-branch:
+    description: 'The branch of Endo used (NOPE if no override)'
+    value: ${{ steps.endo-branch.outputs.result }}
+
 runs:
   using: composite
   steps:
@@ -98,14 +103,18 @@ runs:
           sudo apt-get update
           sudo apt-get install libbsd-dev
         fi
-        yarn install
         # Replace the Endo packages with the ones built from the checked-out branch.
         if test -e ~/endo; then
-          scripts/replace-packages.sh ~/endo
-          rm -rf ~/endo
+          scripts/get-packed-versions.sh ~/endo | scripts/resolve-versions.sh
         fi
+        yarn install
         mkdir -p node_modules/.cache/agoric
         date > node_modules/.cache/agoric/yarn-installed
+        if test -e ~/endo; then
+          # Remove traces of the redirected `yarn install`.
+          git restore package.json yarn.lock
+          rm -rf ~/endo
+        fi
       shell: bash
       if: steps.built.outputs.cache-hit != 'true'
     - name: yarn build

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -464,6 +464,8 @@ jobs:
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
+        id: restore-node
+      - run: echo "ENDO_BRANCH=${{ steps.restore-node.outputs.endo-branch }}" >> $GITHUB_ENV
       # END-TEST-BOILERPLATE
       - name: yarn test (SwingSet)
         if: (success() || failure())
@@ -504,6 +506,8 @@ jobs:
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
+        id: restore-node
+      - run: echo "ENDO_BRANCH=${{ steps.restore-node.outputs.endo-branch }}" >> $GITHUB_ENV
       # END-TEST-BOILERPLATE
       - name: yarn test (SwingSet)
         if: (success() || failure())
@@ -553,6 +557,8 @@ jobs:
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
+        id: restore-node
+      - run: echo "ENDO_BRANCH=${{ steps.restore-node.outputs.endo-branch }}" >> $GITHUB_ENV
       # END-TEST-BOILERPLATE
       - name: yarn test (SwingSet)
         if: (success() || failure())
@@ -592,6 +598,8 @@ jobs:
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ steps.vars.outputs.node-version }}
+        id: restore-node
+      - run: echo "ENDO_BRANCH=${{ steps.restore-node.outputs.endo-branch }}" >> $GITHUB_ENV
       # END-TEST-BOILERPLATE
 
       - name: yarn test (SwingSet)

--- a/packages/SwingSet/test/test-xsnap-store.js
+++ b/packages/SwingSet/test/test-xsnap-store.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 import '@endo/init/debug.js';
 
 import { spawn } from 'child_process';
@@ -130,6 +131,13 @@ test('create SES worker, save, restore, resume', async t => {
  * They are also sensitive to the XS code itself.
  */
 test('XS + SES snapshots are long-term deterministic', async t => {
+  const ENDO_BRANCH = globalThis.process?.env?.ENDO_BRANCH;
+  if (ENDO_BRANCH && ENDO_BRANCH !== 'NOPE') {
+    t.log(`Skipping test on ENDO_BRANCH=${ENDO_BRANCH}`);
+    t.pass();
+    return;
+  }
+
   const db = sqlite3(':memory:');
   const store = makeSnapStore(db, () => {}, makeMockSnapStoreIO());
 

--- a/scripts/get-packed-versions.sh
+++ b/scripts/get-packed-versions.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+# Usage: get-packed-versions.sh <WORKDIR>
+#
+# This script creates package tarballs in the specified workspace directory and
+# writes out information for resolve-versions.sh to update a destination
+# workspace to use them.  This is useful for testing changes to dependencies of
+# the destination repository.
+set -xueo pipefail
+
+WORKDIR=${1:-.}
+cd -- "$WORKDIR" 1>&2
+
+# Install and build the source directory.
+yarn install 1>&2
+yarn build 1>&2
+yarn --silent workspaces info | jq -r '.[].location' | while read -r dir; do
+  # Skip private packages.
+  echo "dir=$dir" 1>&2
+  test "$(jq .private < "$dir/package.json")" != true || continue
+
+  ##################
+  pushd "$dir" 1>&2
+
+  # Gather the metadata.
+  name=$(jq -r .name < package.json)
+  version=$(jq -r .version < package.json)
+  stem=$(echo "$name" | sed -e 's!^@!!; s!/!-!g;')
+  file="$(pwd)/${stem}-v${version}.tgz"
+
+  # Create the tarball.
+  yarn pack 1>&2
+
+  # Write out the version entry.
+  jq -s --arg name "$name" --arg file "$file" \
+      '{ key: $name, value: ("file:" + $file) }' < /dev/null
+
+  popd 1>&2
+  ##################
+done | jq -s from_entries

--- a/scripts/resolve-versions.sh
+++ b/scripts/resolve-versions.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ueo pipefail
+
+# Accepts a dependency version map on stdin and updates the current
+# package.json's resolutions section to use the packages and versions from
+# the map.
+# This is useful for temporary bulk updates over all packages.
+
+DIR=$(dirname -- "${BASH_SOURCE[0]}")
+
+cd -- "$DIR/.."
+
+override=$(jq 'to_entries | map({ key: ("**/" + .key), value: .value }) | from_entries')
+
+PACKAGEJSONHASH=$(
+  jq --arg override "$override" '.resolutions *= ($override | fromjson)' package.json |
+  git hash-object -w --stdin
+)
+git cat-file blob "$PACKAGEJSONHASH" > package.json


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #7947

## Description

The old implementation of `#endo-branch: XXX` hacked and slashed Endo tarballs into the checked out Agoric SDK, and in doing so, was extremely sensitive to conflicts in dependency versions between the two branches.

This PR introduces a better way: use yarn `resolutions` to override the Endo versions directly with the tarballs, and let yarn sort out how the dependency version conflicts should be handled.

As an aside, don't fail the SwingSet golden xsnap hash test when using an explicit Endo branch.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
n/a

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
n/a

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
n/a

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Improves CI support.
