### PR TITLE
Vault performance benchmark

### DIFF
--- a/packages/vats/.gitignore
+++ b/packages/vats/.gitignore
@@ -1,0 +1,3 @@
+# benchmark reports and heap dumps
+benchmark-*.json
+Heap-*

--- a/packages/vats/ava.bench.config.js
+++ b/packages/vats/ava.bench.config.js
@@ -1,0 +1,5 @@
+export default {
+  files: ['test/**/bench-*.js'],
+  timeout: '20m',
+  workerThreads: false,
+};

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -20,6 +20,7 @@
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava",
     "test:xs": "SWINGSET_WORKER_TYPE=xs-worker ava 'test/bootstrapTests/**/test-*.js' 'test/upgrading/**/test-*.js'",
+    "bench": "ava --config ./ava.bench.config.js",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:types": "tsc -p jsconfig.json",


### PR DESCRIPTION
This converts the existing (but disabled and slightly bitrotted) vault performance test in the `vats` package into a benchmark, along with adding the first few bits of what we hope will be an emerging benchmarking infrastructure.

There is a new script in `vats/package.json`, `bench`, which uses Ava to execute a separate set of tests for purposes of benchmark collection.  These tests will be ignored by the regular testing and CI machinery, but can be run by issuing the command

`yarn bench`

which will scan the `test` directory for filenames of the form `bench-*.js` (much as `yarn test` scans for `test-*.js`) and runs them.  Each of these is expected to output a `benchmark-<name>.json` file containing the results, which will be harvested by a future Github action for reporting and graphing.  To begin with there is only one such benchmark test, `bootstrapTests/bench-vault-performance.js`, but we gotta start somewhere.