### PR TITLE
CI: Github Action to run vats benchmark test and upload results to datadog

### DIFF
--- a/.github/actions/publish-metric/action.yml
+++ b/.github/actions/publish-metric/action.yml
@@ -1,0 +1,52 @@
+name: Publish Datadog Metric
+description: GitHub Action to publish a metric to DD.
+
+inputs:
+  datadog-token:
+    description: 'secret datadog API token'
+    required: true
+  metric:
+    description: 'metric name for datadog'
+    required: true
+  metric-value:
+    description: 'metric value for datadog'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Publish Given Metric to Datadog using API.
+      shell: bash
+      id: publish_metric
+      env:
+        DATADOG_API_KEY: ${{ inputs.datadog-token }}
+        VALUE: ${{ inputs.metric-value }}
+        METRIC: ${{ inputs.metric }}
+      run: |
+        export NOW="$(date +%s)"
+        curl -v POST "https://api.us3.datadoghq.com/api/v1/series" \
+        -H "Content-Type: application/json" \
+        -H "DD-API-KEY: $DATADOG_API_KEY" \
+        -d @- << EOF
+        {
+            "series": [{
+                "metric": "ci.${METRIC}",
+                "points": [
+                    [
+                        $NOW,
+                        $VALUE
+                    ]
+                ],
+                "tags": [ 
+                    "os:${{ runner.os }}",
+                    "arch:${{ runner.arch }}",
+                    "repo:${{ github.repository }}",
+                    "job:${{ github.job }}",
+                    "workflow:${{ github.workflow }}",
+                    "source:Github Actions",
+                    "branch:${GITHUB_REF##*/}"
+                ],
+                "type": "gauge"
+            }]
+        }
+        EOF

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,36 @@
+name: Run Benchmarks
+
+# run on changes to trunk, and also nightly
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    # Run an hour after the daily test-all-packages.yml job, so it can
+    # populate the build caches
+    - cron: '47 6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/restore-node
+        with:
+          node-version: '18.x'
+
+      - name: yarn bench (vats)
+        shell: bash
+        run: |
+          cd packages/vats && yarn bench
+          echo "METRIC_VALUE=`cat benchmark-stress-vaults.json | jq .avgPerVaultMs`" >> $GITHUB_ENV
+
+      - uses: ./.github/actions/publish-metric
+        with:
+          metric: 'vats.perf.avgPerVaultMs'
+          metric-value: ${{env.METRIC_VALUE}}
+          datadog-token: ${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
closes: #7964
refs: #7960

## Description

Create a GitHub Actions job which runs [this](https://github.com/Agoric/agoric-sdk/pull/7960) benchmark and uploads the `avgPerVaultMs` to the datadog. The job will run daily, and also once per each push to the master branch.

Datadog Dashboard link: https://us3.datadoghq.com/dashboard/unf-58s-4ue/swingset-perf-dashboard

### Security Considerations

None

### Scaling Considerations

This job will run once per day and on each merge. Should not be an issue for datadog.

### Documentation Considerations

None

### Testing Considerations

Tested the metrics are being received by DD at  https://us3.datadoghq.com/dashboard/unf-58s-4ue/swingset-perf-dashboard
