### PR TITLE
test: a test framework for verifying upgrade of Zoe and ZCF

### DIFF
--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -15,6 +15,7 @@
     "build:boot-viz-sim-gov": "node src/authorityViz.js --sim-chain --gov >docs/boot-sim-gov.dot && dot -Tsvg docs/boot-sim-gov.dot >docs/boot-sim-gov.dot.svg",
     "build:restart-vats-proposal": "agoric run scripts/restart-vats.js",
     "build:add-STARS-proposal": "agoric run scripts/add-STARS.js",
+    "build:zcf-proposal": "agoric run scripts/replace-zoe.js",
     "prepack": "tsc --build jsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*'",
     "test": "ava",

--- a/packages/vats/scripts/replace-zoe.js
+++ b/packages/vats/scripts/replace-zoe.js
@@ -1,0 +1,19 @@
+import { makeHelpers } from '@agoric/deploy-script-support';
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').ProposalBuilder} */
+export const defaultProposalBuilder = async ({ publishRef, install }) =>
+  harden({
+    sourceSpec: '../src/proposals/zcf-proposal.js',
+    getManifestCall: [
+      'getManifestForZoe',
+      {
+        zoeRef: publishRef(install('../src/vat-zoe.js')),
+        zcfRef: publishRef(install('../../zoe/src/contractFacet/vatRoot.js')),
+      },
+    ],
+  });
+
+export default async (homeP, endowments) => {
+  const { writeCoreProposal } = await makeHelpers(homeP, endowments);
+  await writeCoreProposal('replace-zcf', defaultProposalBuilder);
+};

--- a/packages/vats/src/proposals/zcf-proposal.js
+++ b/packages/vats/src/proposals/zcf-proposal.js
@@ -1,15 +1,14 @@
 import { E } from '@endo/far';
 
 /**
- * @param { BootstrapPowers & {
+ * @param {BootstrapPowers & {
  *   consume: {
- *     vatAdminSvc: VatAdminSve,
- *     vatStore: MapStore<string, CreateVatResults>,
- *   }
+ *     vatAdminSvc: VatAdminSve;
+ *     vatStore: MapStore<string, CreateVatResults>;
+ *   };
  * }} powers
- *
  * @param {object} options
- * @param {{zoeRef: VatSourceRef, zcfRef: VatSourceRef}} options.options
+ * @param {{ zoeRef: VatSourceRef; zcfRef: VatSourceRef }} options.options
  */
 export const upgradeZcf = async (
   { consume: { vatAdminSvc, vatStore } },

--- a/packages/vats/src/proposals/zcf-proposal.js
+++ b/packages/vats/src/proposals/zcf-proposal.js
@@ -1,0 +1,46 @@
+import { E } from '@endo/far';
+
+/**
+ * @param { BootstrapPowers & {
+ *   consume: {
+ *     vatAdminSvc: VatAdminSve,
+ *     vatStore: MapStore<string, CreateVatResults>,
+ *   }
+ * }} powers
+ *
+ * @param {object} options
+ * @param {{zoeRef: VatSourceRef, zcfRef: VatSourceRef}} options.options
+ */
+export const upgradeZcf = async (
+  { consume: { vatAdminSvc, vatStore } },
+  options,
+) => {
+  const { zoeRef, zcfRef } = options.options;
+
+  const zoeBundleCap = await E(vatAdminSvc).getBundleCap(zoeRef.bundleID);
+  console.log(`ZOE BUNDLE ID: `, zoeRef.bundleID);
+
+  const { adminNode, root: zoeRoot } = await E(vatStore).get('zoe');
+
+  await E(adminNode).upgrade(zoeBundleCap, {});
+
+  const zoeConfigFacet = await E(zoeRoot).getZoeConfigFacet();
+  await E(zoeConfigFacet).updateZcfBundleId(zcfRef.bundleID);
+  console.log(`ZCF BUNDLE ID: `, zcfRef.bundleID);
+};
+
+export const getManifestForZoe = (_powers, { zoeRef, zcfRef }) => ({
+  manifest: {
+    [upgradeZcf.name]: {
+      consume: {
+        vatAdminSvc: 'vatAdminSvc',
+        vatStore: 'vatStore',
+      },
+      produce: {},
+    },
+  },
+  options: {
+    zoeRef,
+    zcfRef,
+  },
+});

--- a/packages/vats/test/bootstrapTests/drivers.js
+++ b/packages/vats/test/bootstrapTests/drivers.js
@@ -206,8 +206,10 @@ export const makePriceFeedDriver = async (
   };
 };
 
+/** @typedef {Awaited<ReturnType<import('./supports.js').makeSwingsetTestKit>>} SwingsetTestKit */
+
 /**
- * @param {import('./supports.js').SwingsetTestKit} testKit
+ * @param {SwingsetTestKit} testKit
  * @param {import('../../tools/board-utils.js').AgoricNamesRemotes} agoricNamesRemotes
  * @param {Awaited<ReturnType<typeof makeWalletFactoryDriver>>} walletFactoryDriver
  * @param {string[]} committeeAddresses
@@ -339,9 +341,6 @@ export const makeGovernanceDriver = async (
   };
 };
 
-/**
- * @param {import('./supports.js').SwingsetTestKit} testKit
- */
 export const makeZoeDriver = async testKit => {
   const { EV } = testKit.runUtils;
   const zoe = await EV.vat('bootstrap').consumeItem('zoe');

--- a/packages/vats/test/bootstrapTests/test-zcf-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-zcf-upgrade.js
@@ -1,0 +1,107 @@
+// @ts-check
+
+import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import bundleSource from '@endo/bundle-source';
+
+import path from 'path';
+import { makeZoeTestContext } from './supports.js';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const ZCF_PROBE_SRC = './zcfProbe.js';
+
+/**
+ * @file Bootstrap test of upgrading ZCF to support atomicRearrange internally.
+ *
+ * The goal is to tell Zoe about a new version of ZCF that it should use
+ * when starting new contracts. Zoe wasn't previously configurable for that, so
+ * a prerequisite was to upgrade Zoe to a version that could have its ZCF
+ * updated. To test that we install a contract that can detect the variation
+ * among zcf versions, and run it before, in the middle and after the upgrades.
+ *
+ *  0. add a contract that can report on the state of ZCF's support for
+ *     different versions of reallocation: staging, helper, and internal.
+ *  1. put new Zoe & ZCF bundles on chain
+ *  2. upgrade Zoe; return a new facet that supports ZCF update
+ *  3. tell Zoe to use new ZCF
+ *  4. restart the new contract; verify that the behavior is unchanged.
+ *  5. null upgrade the contract; verify that zcf supports internal rearrange.
+ *  6. [optional] fully upgrade the contract; verify that it works
+ */
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<typeof makeZoeTestContext>>>} */
+const test = anyTest;
+
+test.before(async t => {
+  t.context = await makeZoeTestContext(t);
+});
+test.after.always(t => t.context.shutdown?.());
+
+test('run restart-vats proposal', async t => {
+  const { controller, buildProposal, zoeDriver } = t.context;
+  const { EV } = t.context.runUtils;
+
+  const buildAndExecuteProposal = async packageSpec => {
+    const proposal = await buildProposal(packageSpec);
+
+    for await (const bundle of proposal.bundles) {
+      await controller.validateAndInstallBundle(bundle);
+    }
+
+    t.log('installed', proposal.bundles.length, 'bundles');
+
+    t.log('launching proposal');
+    const bridgeMessage = {
+      type: 'CORE_EVAL',
+      evals: proposal.evals,
+    };
+
+    t.log({ bridgeMessage });
+    /** @type {ERef<import('../../src/types.js').BridgeHandler>} */
+    const coreEvalBridgeHandler = await EV.vat('bootstrap').consumeItem(
+      'coreEvalBridgeHandler',
+    );
+    await EV(coreEvalBridgeHandler).fromBridge(bridgeMessage);
+  };
+  const source = `${dirname}/${ZCF_PROBE_SRC}`;
+
+  const zcfProbeBundle = await bundleSource(source);
+  // uncomment and add `import fs from "fs";` to generate a bundle of the prober contract
+  // fs.writeFileSync('bundles/prober-contract-bundle.json', JSON.stringify(zcfProbeBundle));
+
+  const brandRecord = await zoeDriver.instantiateProbeContract(zcfProbeBundle);
+  const { brand, issuer } = brandRecord;
+  const ducatAmountRecord = v => ({ Ducats: { brand, value: v } });
+
+  t.deepEqual(await zoeDriver.verifyRealloc(), {});
+
+  const ducats = await zoeDriver.faucet();
+  const initialAmount = await EV(issuer).getAmountOf(ducats);
+
+  const beforeResult = await zoeDriver.probeReallocation(initialAmount, ducats);
+  t.true(beforeResult.stagingResult);
+  t.true(beforeResult.helperResult);
+  // In this version of the test, we're upgrading from new ZCF to new ZCF
+  t.true(beforeResult.internalResult);
+  t.deepEqual(await zoeDriver.verifyRealloc(), ducatAmountRecord(3n));
+
+  t.log('building proposal');
+  // /////// Upgrading ////////////////////////////////
+  const zcfPackageSpec = {
+    package: 'vats',
+    packageScriptName: 'build:zcf-proposal',
+  };
+  await buildAndExecuteProposal(zcfPackageSpec);
+
+  t.log('upgrade zoe&zcf proposal executed');
+  zoeDriver.upgradeProbe(zcfProbeBundle);
+  const nextDucats = beforeResult.leftoverPayments.Ducats;
+  const nextAmount = await EV(issuer).getAmountOf(nextDucats);
+
+  const afterResult = await zoeDriver.probeReallocation(nextAmount, nextDucats);
+  t.true(afterResult.stagingResult);
+  t.true(afterResult.helperResult);
+  t.true(afterResult.internalResult);
+  t.deepEqual(await zoeDriver.verifyRealloc(), ducatAmountRecord(6n));
+});

--- a/packages/vats/test/bootstrapTests/test-zcf-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-zcf-upgrade.js
@@ -123,6 +123,7 @@ test('run restart-vats proposal', async t => {
   const source = `${dirname}/${ZCF_PROBE_SRC}`;
 
   const zcfProbeBundle = await bundleSource(source);
+  await controller.validateAndInstallBundle(zcfProbeBundle);
   // This test self-sufficiently builds all the artifacts it needs. The test in
   // .../packages/deployment/upgradeTest/upgradeTest-scripts/agoric-upgrade-11/zoe-upgrade/
   // needs a bundled copy of ./zcfProbe.js as of the final commit that will be

--- a/packages/vats/test/bootstrapTests/zcfProbe.js
+++ b/packages/vats/test/bootstrapTests/zcfProbe.js
@@ -1,3 +1,5 @@
+import '@agoric/zoe/exported.js';
+
 import { makeTracer } from '@agoric/internal';
 import { E } from '@endo/far';
 import {
@@ -17,17 +19,21 @@ const ZcfProbeI = M.interface('ZCF Probe', {
   makeFaucetInvitation: M.call().returns(M.promise()),
 });
 
+// /** @type {ContractMeta} */
+// export const meta = { upgradability: 'canUpgrade' };
+// harden(meta);
+
 /**
  * @param {ZCF} zcf
  * @param {{ storageNode: StorageNode }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, privateArgs, baggage) => {
   const { probeMint } = await provideAll(baggage, {
     probeMint: () => zcf.makeZCFMint('Ducats'),
   });
 
-  const { storageNode } = privateArgs;
+  const storageNode = privateArgs?.storageNode;
   const makeZcfProbe = await prepareExoClass(
     baggage,
     'zcfProbe',
@@ -77,7 +83,9 @@ export const prepare = async (zcf, privateArgs, baggage) => {
 
           trace('Intrinsics', result);
           // write to vstorage so a test can detect it.
-          void E(storageNode).setValue(`${result}`);
+          if (storageNode) {
+            void E(storageNode).setValue(`${result}`);
+          }
 
           return result;
         };

--- a/packages/vats/test/bootstrapTests/zcfProbe.js
+++ b/packages/vats/test/bootstrapTests/zcfProbe.js
@@ -1,0 +1,138 @@
+import { makeTracer } from '@agoric/internal';
+import { E } from '@endo/far';
+import {
+  atomicRearrange,
+  provideAll,
+} from '@agoric/zoe/src/contractSupport/index.js';
+import { M, prepareExoClass, provide } from '@agoric/vat-data';
+import { AmountMath } from '@agoric/ertp';
+
+const trace = makeTracer('ZCF Probe');
+
+const ZcfProbeI = M.interface('ZCF Probe', {
+  makeProbeHelperInvitation: M.call().returns(M.promise()),
+  makeProbeInternalInvitation: M.call().returns(M.promise()),
+  makeProbeStagingInvitation: M.call().returns(M.promise()),
+  getAllocation: M.call().returns(M.any()),
+  makeFaucetInvitation: M.call().returns(M.promise()),
+});
+
+/**
+ * @param {ZCF} zcf
+ * @param {{storageNode: StorageNode}} privateArgs
+ * @param {import('@agoric/vat-data').Baggage} baggage
+ */
+export const prepare = async (zcf, privateArgs, baggage) => {
+  const { probeMint } = await provideAll(baggage, {
+    probeMint: () => zcf.makeZCFMint('Ducats'),
+  });
+
+  const { storageNode } = privateArgs;
+  const makeZcfProbe = await prepareExoClass(
+    baggage,
+    'zcfProbe',
+    ZcfProbeI,
+    () => ({
+      stashSeat: zcf.makeEmptySeatKit().zcfSeat,
+      probeMint: null,
+    }),
+    {
+      makeProbeHelperInvitation() {
+        const { stashSeat } = this.state;
+
+        const probeHelper = seat => {
+          trace('ProbeHelper');
+          const originalAlloc = seat.getCurrentAllocation().Ducats;
+          const one = AmountMath.make(originalAlloc.brand, 1n);
+          let result;
+          try {
+            atomicRearrange(zcf, harden([[seat, stashSeat, { Ducats: one }]]));
+            result = true;
+          } catch (e) {
+            result = false;
+          }
+
+          seat.exit();
+          return result;
+        };
+
+        return zcf.makeInvitation(probeHelper, 'probe helper');
+      },
+      makeProbeInternalInvitation() {
+        const { stashSeat } = this.state;
+        const probeInternal = seat => {
+          trace('ProbeIntrinsics');
+          const originalAlloc = seat.getCurrentAllocation().Ducats;
+          const one = AmountMath.make(originalAlloc.brand, 1n);
+          let result;
+          try {
+            zcf.atomicRearrange(harden([[seat, stashSeat, { Ducats: one }]]));
+            result = true;
+          } catch (e) {
+            result = false;
+          }
+
+          seat.clear();
+          seat.exit();
+
+          trace('Intrinsics', result);
+          // write to vstorage so a test can detect it.
+          void E(storageNode).setValue(`${result}`);
+
+          return result;
+        };
+
+        return zcf.makeInvitation(probeInternal, 'probe intrinsic');
+      },
+      makeProbeStagingInvitation() {
+        const { stashSeat } = this.state;
+
+        const probeStaging = seat => {
+          trace('ProbeStaging');
+
+          const originalAlloc = seat.getCurrentAllocation().Ducats;
+          const one = AmountMath.make(originalAlloc.brand, 1n);
+          let result;
+          try {
+            stashSeat.incrementBy(seat.decrementBy({ Ducats: one }));
+            zcf.reallocate(seat, stashSeat);
+            result = true;
+          } catch (e) {
+            seat.clear();
+            stashSeat.clear();
+            result = false;
+          }
+
+          seat.exit();
+          return result;
+        };
+
+        return zcf.makeInvitation(probeStaging, 'probe staging');
+      },
+      getAllocation() {
+        const { stashSeat } = this.state;
+        trace('getAllocation');
+
+        return stashSeat.getCurrentAllocation();
+      },
+      makeFaucetInvitation() {
+        return zcf.makeInvitation(async seat => {
+          trace('faucet');
+          const { brand } = await probeMint.getIssuerRecord();
+
+          await probeMint.mintGains(
+            { Ducats: AmountMath.make(brand, 16n) },
+            seat,
+          );
+          seat.exit();
+          return 'minted 16n Ducats';
+        }, 'faucet');
+      },
+    },
+  );
+
+  const probe = await provide(baggage, 'probe', () => makeZcfProbe());
+  return harden({
+    creatorFacet: probe,
+  });
+};

--- a/packages/vats/test/bootstrapTests/zcfProbe.js
+++ b/packages/vats/test/bootstrapTests/zcfProbe.js
@@ -19,7 +19,7 @@ const ZcfProbeI = M.interface('ZCF Probe', {
 
 /**
  * @param {ZCF} zcf
- * @param {{storageNode: StorageNode}} privateArgs
+ * @param {{ storageNode: StorageNode }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
 export const prepare = async (zcf, privateArgs, baggage) => {


### PR DESCRIPTION
refs: #6678

## Description

a test framework for verifying upgrade of Zoe and ZCF. This includes bootstrap scripts that can be used to upgrade Zoe and ZCF.

The test starts from the currently installed version of Zoe and ZCF. First it verifies that reallocation via staging and via the helper work and that the version internal to ZCF is not present. It then upgrades Zoe and ZCF as necessary to introduce the new behavior. Finally, it re-runs the initial verification to show that the ZCF internal version works.

This currently fails on the first step since it runs in a state in which the new Zoe/ZCF code has already replaced the old. To check it in, we will change the parity of the test that the new internal `zcf.atomicRearrange()` is not present, since this version runs in an environment where that change has already been made. 

Variants of this test will run on master without this PR to verify that upgrading to the new Zoe/ZCF works, and in
deployment/upgrade-test to show that the upgrade to the new zoe & zcf will succeed. A copy of this code run on master without this PR, with bundles containing the new Zoe & ZCF code will show that the upgrade from the current state succeeds, and zcf's behavior in the probe contract will be different before and after. 

### Security Considerations

Validates the upgrade plan.

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

It's all about testing.
