### PR TITLE
ci: use Ava's default concurrency

### DIFF
--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -72,7 +72,6 @@
     "files": [
       "test/**/test-*.js"
     ],
-    "concurrency": 2,
     "workerThreads": false,
     "timeout": "10m"
   },

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -83,7 +83,6 @@
     "files": [
       "test/**/test-*.js"
     ],
-    "concurrency": 2,
     "timeout": "20m",
     "workerThreads": false
   }


### PR DESCRIPTION
## Description

the default is numCpuCores which is what we want. the hard-code number was to work around an obsolete problem.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
