### PR TITLE
fix(vats): update error message test

### DIFF
--- a/packages/vats/test/test-vpurse.js
+++ b/packages/vats/test/test-vpurse.js
@@ -316,7 +316,7 @@ test('vpurse.deposit promise', async t => {
     () => E(vpurse).deposit(exclusivePaymentP, fungible25),
     {
       message:
-        /deposit does not accept promises|promise .* Must be a remotable/i,
+        /In "deposit" method of \(VirtualPurseKit purse\): arg 0: .*"\[Promise\]" - Must be a remotable/,
     },
     'failed to reject a promise for a payment',
   );


### PR DESCRIPTION
To fix the version slippage error detected at https://github.com/Agoric/agoric-sdk/actions/runs/5349653284/jobs/9701289352?pr=7937#step:5:3006 , we follow @gibson042 's precedent at https://github.com/Agoric/agoric-sdk/pull/7932 . 

We test it under CI by having this PR's CI run as normal, and have https://github.com/Agoric/agoric-sdk/pull/7937 restaged on this PR, so its CI will detect whether this PR's change fixes that problem.