### PR TITLE
upgrade-test: add new pismoC wallet

### DIFF
--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
@@ -15,13 +15,13 @@ submitDeliverInbound user1
 
 # provision a new user wallet
 
-agd keys add user2 --keyring-backend=test  2>&1 | tee "$HOME/.agoric/user2.out"
-cat "$HOME/.agoric/user2.out" | tail -n1 | tee "$HOME/.agoric/user2.key"
-export USER2ADDR=$($binary keys show user2 -a --keyring-backend="test" 2> /dev/null)
-provisionSmartWallet $USER2ADDR "20000000ubld,100000000${ATOM_DENOM}"
+agd keys add user3 --keyring-backend=test  2>&1 | tee "$HOME/.agoric/user3.out"
+cat "$HOME/.agoric/user3.out" | tail -n1 | tee "$HOME/.agoric/user3.key"
+export USER3ADDR=$($binary keys show user3 -a --keyring-backend="test" 2> /dev/null)
+provisionSmartWallet $USER3ADDR "20000000ubld,100000000${ATOM_DENOM}"
 waitForBlock
 
-test_not_val "$(agd q vstorage data published.wallet.$USER2ADDR -o json | jq -r .value)" "" "ensure user2 provisioned"
+test_not_val "$(agd q vstorage data published.wallet.$USER3ADDR -o json | jq -r .value)" "" "ensure user3 provisioned"
 
 echo "ACTIONS Tickling the wallets so they are revived"
 # Until they are revived, the invitations can't be deposited. So the first action can't be to accept an invitation (because it won't be there).
@@ -154,25 +154,25 @@ OFFER=$(mktemp -t agops.XXX)
 agops vaults close --vaultId vault1 --giveMinted 6.06 --from $GOV1ADDR --keyring-backend="test" >|"$OFFER"
 agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test
 
-# make sure the same works for user2
+# make sure the same works for user3
 OFFER=$(mktemp -t agops.XXX)
 agops vaults open --wantMinted 7.00 --giveCollateral 11.0 >|"$OFFER"
-agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
+agops perf satisfaction --from "$USER3ADDR" --executeOffer "$OFFER" --keyring-backend=test
 
 # put some IST in
 OFFER=$(mktemp -t agops.XXX)
-agops vaults adjust --vaultId vault2 --giveMinted 1.5 --from $USER2ADDR --keyring-backend=test >|"$OFFER"
-agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
+agops vaults adjust --vaultId vault2 --giveMinted 1.5 --from $USER3ADDR --keyring-backend=test >|"$OFFER"
+agops perf satisfaction --from "$USER3ADDR" --executeOffer "$OFFER" --keyring-backend=test
 
 # add some collateral
 OFFER=$(mktemp -t agops.XXX)
-agops vaults adjust --vaultId vault2 --giveCollateral 2.0 --from $USER2ADDR --keyring-backend="test" >|"$OFFER"
-agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
+agops vaults adjust --vaultId vault2 --giveCollateral 2.0 --from $USER3ADDR --keyring-backend="test" >|"$OFFER"
+agops perf satisfaction --from "$USER3ADDR" --executeOffer "$OFFER" --keyring-backend=test
 
 # close out
 OFFER=$(mktemp -t agops.XXX)
-agops vaults close --vaultId vault2 --giveMinted 5.75 --from $USER2ADDR --keyring-backend="test" >|"$OFFER"
-agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
+agops vaults close --vaultId vault2 --giveMinted 5.75 --from $USER3ADDR --keyring-backend="test" >|"$OFFER"
+agops perf satisfaction --from "$USER3ADDR" --executeOffer "$OFFER" --keyring-backend=test
 
 # # TODO test bidding
 # # TODO liquidations

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/env_setup.sh
@@ -2,6 +2,7 @@
 
 # agoric-upgrade-10 specific env here...
 export USER2ADDR=$($binary keys show user2 -a --keyring-backend="test" 2> /dev/null)
+export USER3ADDR=$($binary keys show user3 -a --keyring-backend="test" 2> /dev/null)
 
 printKeys() {
   echo "========== GOVERNANCE KEYS =========="
@@ -17,6 +18,8 @@ printKeys() {
   cat ~/.agoric/user1.key || true
   echo "user2: $USER2ADDR"
   cat ~/.agoric/user2.key || true
+  echo "user3: $USER3ADDR"
+  cat ~/.agoric/user3.key || true
   echo "========== GOVERNANCE KEYS =========="
 }
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
@@ -14,14 +14,17 @@ test_not_val "$(agd q vstorage data published.wallet.$GOV1ADDR -o json | jq -r .
 test_not_val "$(agd q vstorage data published.wallet.$GOV2ADDR -o json | jq -r .value)" "" "ensure gov2 provisioned"
 test_not_val "$(agd q vstorage data published.wallet.$GOV3ADDR -o json | jq -r .value)" "" "ensure gov3 provisioned"
 
-# test user2 not provisioned
-test_val "$(agd q vstorage data published.wallet.$USER2ADDR -o json | jq -r .value)" "" "ensure user2 not provisioned"
+# test user2 provisioned
+test_not_val "$(agd q vstorage data published.wallet.$USER2ADDR -o json | jq -r .value)" "" "ensure user2 provisioned"
+
+# test user3 not provisioned
+test_val "$(agd q vstorage data published.wallet.$USER3ADDR -o json | jq -r .value)" "" "ensure user3 not provisioned"
 
 # test that we have no vaults
 test_val "$(agd q vstorage data published.vaultFactory.manager0.vaults.vault0 -o json | jq -r .value)" "" "ensure no vaults exist"
 
 # provision pool has right balance
-test_val "$(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ')" "19000000"
+test_val "$(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ')" "18750000"
 
 # we should have more denoms in governance
 psmISTChildren="$(agd q vstorage children published.psm.IST -o jsonlines)"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
@@ -31,7 +31,7 @@ test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.locked.value') "0" "vault1 contains no collateral"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.debtSnapshot.debt.value') "0" "vault1 has no debt"
 
-# user2 vault2
+# user3 vault2
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault2 -o jsonlines | jq -r '.vaultState') "closed" "vault2 is closed"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault2 -o jsonlines | jq -r '.locked.value') "0" "vault2 contains no collateral"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault2 -o jsonlines | jq -r '.debtSnapshot.debt.value') "0" "vault2 has no debt"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/env_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # agoric-upgrade-11 specific env here...
-export USER2ADDR=$($binary keys show user2 -a --keyring-backend="test" 2> /dev/null)
+export USER3ADDR=$($binary keys show user3 -a --keyring-backend="test" 2> /dev/null)
 
 printKeys() {
   echo "========== GOVERNANCE KEYS =========="
@@ -15,8 +15,8 @@ printKeys() {
   cat ~/.agoric/validator.key || true
   echo "user1: $USER1ADDR"
   cat ~/.agoric/user1.key || true
-  echo "user2: $USER2ADDR"
-  cat ~/.agoric/user2.key || true
+  echo "user3: $USER3ADDR"
+  cat ~/.agoric/user3.key || true
   echo "========== GOVERNANCE KEYS =========="
 }
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/actions.sh
@@ -5,6 +5,14 @@
 # NOTE: agoric follow doesn't have the `-F` parameter in this version
 # so we use a hack
 
+# create unused wallet
+agd keys add user2 --keyring-backend=test  2>&1 | tee "$HOME/.agoric/user2.out"
+cat "$HOME/.agoric/user2.out" | tail -n1 | tee "$HOME/.agoric/user2.key"
+export USER2ADDR=$($binary keys show user2 -a --keyring-backend="test" 2> /dev/null)
+provisionSmartWallet $USER2ADDR "20000000ubld,100000000${ATOM_DENOM}"
+waitForBlock
+
+test_not_val "$(agd q vstorage data published.wallet.$USER2ADDR -o json | jq -r .value)" "" "ensure user2 provisioned"
 # save somewhere we can access later
 echo "Dumping PSM gov params..."
 timeout 3 agoric follow -l :published.psm.${PSM_PAIR}.metrics -o jsonlines | tee /root/.agoric/psm_metrics.json

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/env_setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# agoric-upgrade-10 specific env here...
+export USER2ADDR=$($binary keys show user2 -a --keyring-backend="test" 2> /dev/null)
+
+printKeys() {
+  echo "========== GOVERNANCE KEYS =========="
+  echo "gov1: $GOV1ADDR"
+  cat ~/.agoric/gov1.key || true
+  echo "gov2: $GOV2ADDR"
+  cat ~/.agoric/gov2.key || true
+  echo "gov3: $GOV3ADDR"
+  cat ~/.agoric/gov3.key || true
+  echo "validator: $VALIDATORADDR"
+  cat ~/.agoric/validator.key || true
+  echo "user1: $USER1ADDR"
+  cat ~/.agoric/user1.key || true
+  echo "user2: $USER2ADDR"
+  cat ~/.agoric/user2.key || true
+  echo "========== GOVERNANCE KEYS =========="
+}

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-9/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . ./upgrade-test-scripts/env_setup.sh
 # provision pool has right balance 
-test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount') "19000000"
+test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount') "18750000"
 
 # ensure PSM IST has only ToyUSD
 expnum=4


### PR DESCRIPTION
## Description

In effect we rename the previous user2 wallet to user3, since it's created later.

Create a pismoC wallet, and test in Vaults that it's vstorage data is not empty. Still needs more comprehensive checks. 

### Security Considerations

N/A. 

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

Still needs appropriate checks.
