### PR TITLE
ci: split upgrade-test builds into versions

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -707,8 +707,6 @@ jobs:
 
   test-docker-build:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1 
     timeout-minutes: 60
     strategy:
       matrix:
@@ -719,10 +717,77 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: docker build (sdk)
         run: cd packages/deployment && ./scripts/test-docker-build.sh | $TEST_COLLECT
-      - name: docker build upgrade test
-        run: cd packages/deployment/upgrade-test && docker build --build-arg BOOTSTRAP_MODE=${{ matrix.bootstrap-version }} --build-arg DEST_IMAGE=ghcr.io/agoric/agoric-sdk:latest -t docker-upgrade-test:latest -f Dockerfile upgrade-test-scripts
+      - name: docker build upgrade test 7-2
+        uses: docker/build-push-action@v4
+        with:
+          file: packages/deployment/upgrade-test/Dockerfile
+          context: packages/deployment/upgrade-test/upgrade-test-scripts
+          push: false
+          tags: ghcr.io/agoric/upgrade-test:agoric-upgrade-7-2
+          target: agoric-upgrade-7-2
+          build-args: |
+            BOOTSTRAP_MODE=${{ matrix.bootstrap-version }}
+            DEST_IMAGE=ghcr.io/agoric/agoric-sdk:latest
+      - name: docker build upgrade test 8
+        uses: docker/build-push-action@v4
+        with:
+          file: packages/deployment/upgrade-test/Dockerfile
+          context: packages/deployment/upgrade-test/upgrade-test-scripts
+          push: false
+          tags: ghcr.io/agoric/upgrade-test:agoric-upgrade-8
+          target: agoric-upgrade-8
+          build-args: |
+            BOOTSTRAP_MODE=${{ matrix.bootstrap-version }}
+            DEST_IMAGE=ghcr.io/agoric/agoric-sdk:latest
+      - name: docker build upgrade test 8-1
+        uses: docker/build-push-action@v4
+        with:
+          file: packages/deployment/upgrade-test/Dockerfile
+          context: packages/deployment/upgrade-test/upgrade-test-scripts
+          push: false
+          tags: ghcr.io/agoric/upgrade-test:agoric-upgrade-8-1
+          target: agoric-upgrade-8-1
+          build-args: |
+            BOOTSTRAP_MODE=${{ matrix.bootstrap-version }}
+            DEST_IMAGE=ghcr.io/agoric/agoric-sdk:latest
+      - name: docker build upgrade test 9
+        uses: docker/build-push-action@v4
+        with:
+          file: packages/deployment/upgrade-test/Dockerfile
+          context: packages/deployment/upgrade-test/upgrade-test-scripts
+          push: false
+          tags: ghcr.io/agoric/upgrade-test:agoric-upgrade-9
+          target: agoric-upgrade-9
+          build-args: |
+            BOOTSTRAP_MODE=${{ matrix.bootstrap-version }}
+            DEST_IMAGE=ghcr.io/agoric/agoric-sdk:latest
+      - name: docker build upgrade test 10
+        uses: docker/build-push-action@v4
+        with:
+          file: packages/deployment/upgrade-test/Dockerfile
+          context: packages/deployment/upgrade-test/upgrade-test-scripts
+          push: false
+          tags: ghcr.io/agoric/upgrade-test:agoric-upgrade-10
+          target: agoric-upgrade-10
+          build-args: |
+            BOOTSTRAP_MODE=${{ matrix.bootstrap-version }}
+            DEST_IMAGE=ghcr.io/agoric/agoric-sdk:latest
+      - name: docker build upgrade test 11
+        uses: docker/build-push-action@v4
+        with:
+          file: packages/deployment/upgrade-test/Dockerfile
+          context: packages/deployment/upgrade-test/upgrade-test-scripts
+          load: true
+          push: false
+          tags: ghcr.io/agoric/upgrade-test:agoric-upgrade-11
+          target: agoric-upgrade-11
+          build-args: |
+            BOOTSTRAP_MODE=${{ matrix.bootstrap-version }}
+            DEST_IMAGE=ghcr.io/agoric/agoric-sdk:latest
+      # - name: docker build upgrade test
+      #   run: cd packages/deployment/upgrade-test && docker build --build-arg BOOTSTRAP_MODE=${{ matrix.bootstrap-version }} --build-arg DEST_IMAGE=ghcr.io/agoric/agoric-sdk:latest -t docker-upgrade-test:latest -f Dockerfile upgrade-test-scripts
       - name: docker run upgrade final stage
-        run: docker run --env "DEST=0" docker-upgrade-test:latest
+        run: docker run --env "DEST=0" ghcr.io/agoric/upgrade-test:agoric-upgrade-11
       - name: notify on failure
         if: failure() && github.event_name != 'pull_request'
         uses: ./.github/actions/notify-status

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -707,12 +707,16 @@ jobs:
 
   test-docker-build:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1 
     timeout-minutes: 60
     strategy:
       matrix:
         bootstrap-version: ['test', 'main']
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: docker build (sdk)
         run: cd packages/deployment && ./scripts/test-docker-build.sh | $TEST_COLLECT
       - name: docker build upgrade test

--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -18,6 +18,9 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-8 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 WORKDIR /usr/src/agoric-sdk/
 
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get update && apt-get install -y tmux
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-7-2 /root/.agoric /root/.agoric
@@ -32,6 +35,9 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-8-1 UPGRADE_TO=agoric-upgrade-9 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get update && apt-get install -y tmux
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-8 /root/.agoric /root/.agoric
@@ -46,6 +52,9 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-9 UPGRADE_TO=agoric-upgrade-10 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get update && apt-get install -y tmux
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-8-1 /root/.agoric /root/.agoric
@@ -62,6 +71,9 @@ ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-10 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get update && apt-get install -y tmux
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-9 /root/.agoric /root/.agoric
@@ -77,10 +89,12 @@ ENV THIS_NAME=agoric-upgrade-11 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 # this boot doesn't need an upgrade
 
 WORKDIR /usr/src/agoric-sdk/
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get update && apt-get install -y tmux
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-10 /root/.agoric /root/.agoric
-RUN apt install -y tmux
 SHELL ["/bin/bash", "-c"]
 RUN chmod +x ./upgrade-test-scripts/*.sh
 ENTRYPOINT /usr/src/agoric-sdk/upgrade-test-scripts/start_to_to.sh

--- a/packages/deployment/upgrade-test/Makefile
+++ b/packages/deployment/upgrade-test/Makefile
@@ -14,6 +14,7 @@ endif
 local_sdk:
 	(cd ../ && make docker-build-sdk)
 
+# NOTE: ensure these steps are mirrored in CI (.github/workflows/test-all-packages.yml)
 agoric-upgrade-7-2:
 	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --build-arg DEST_IMAGE=$(DEST_IMAGE) --progress=plain --target agoric-upgrade-7-2 -t $(REPOSITORY):agoric-upgrade-7-2 -f Dockerfile upgrade-test-scripts
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/bash_entrypoint.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/bash_entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -i
 cd /usr/src/agoric-sdk/ || exit 1
-tmux -V || apt install -y tmux
 
 if [[ $TMUX_USE_CC == "1" ]]; then
     TMUX_FLAGS="-CC -u"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/start_to_to.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/start_to_to.sh
@@ -3,8 +3,6 @@
 grep -qF 'env_setup.sh' /root/.bashrc || echo ". ./upgrade-test-scripts/env_setup.sh" >> /root/.bashrc
 grep -qF 'printKeys' /root/.bashrc || echo "printKeys" >> /root/.bashrc
 
-tmux -V || apt install -y tmux
-
 if [[ "$DEST" == "1" ]] && [[ "$TMUX" == "" ]]; then
   echo "launching entrypoint"
   cd /usr/src/agoric-sdk || exit 1


### PR DESCRIPTION
refs: #7797 

## Description

This PR splits docker upgrade tests into steps to match the Makefile. Rather than build all at once, each version is split into its own. 

### Security Considerations

N/A

### Scaling Considerations

Slight overhead from splitting into jobs, but failures should be easier to identify by version and rebuild faster due to caching.

### Documentation Considerations

N/A

### Testing Considerations

TBD. Expecting net CI improvement.
