### PR TITLE
upgrade-test: upgrade to agoric-upgrade-11

### DIFF
--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -59,7 +59,7 @@ ARG DEST_IMAGE
 #this is agoric-upgrade-10 / vaults
 FROM ghcr.io/agoric/agoric-sdk:34 as agoric-upgrade-10
 ARG BOOTSTRAP_MODE
-ENV THIS_NAME=agoric-upgrade-10 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
+ENV THIS_NAME=agoric-upgrade-10 UPGRADE_TO=agoric-upgrade-11 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/


### PR DESCRIPTION
refs: #7992

## Description

#7994 adds a new upgrade handler, which fails upgrade-test because it does not expect an upgrade from `agoric-upgrade-10` to `agoric-upgrade-11` (it wasn't explicitly turned on). This PR enables it to exercise the upgrade handler for `agoric-upgrade-11`.

### Security Considerations

Same as #7994. This PR simply exercises the code in tests.

### Scaling Considerations

N/A. 

### Documentation Considerations

N/A.

### Testing Considerations

With this change, I believe we fulfill the criteria of exercising the upgrade code in a full upgrade test.
