### PR TITLE
upgrade-test: do not overwrite DEST_IMAGE when set

### DIFF
--- a/packages/deployment/upgrade-test/Makefile
+++ b/packages/deployment/upgrade-test/Makefile
@@ -1,6 +1,6 @@
 REPOSITORY = agoric/upgrade-test
 # use :dev (latest prerelease image) unless we build local sdk
-DEST_IMAGE = $(if $(findstring local_sdk,$(MAKECMDGOALS)),ghcr.io/agoric/agoric-sdk:latest,ghcr.io/agoric/agoric-sdk:dev)
+DEST_IMAGE ?= $(if $(findstring local_sdk,$(MAKECMDGOALS)),ghcr.io/agoric/agoric-sdk:latest,ghcr.io/agoric/agoric-sdk:dev)
 BOOTSTRAP_MODE?=main
 TARGET?=agoric-upgrade-11
 dockerLabel?=$(TARGET)


### PR DESCRIPTION
refs: #7797

## Description

#7745 introduced a change to follow `dev`, and allows `DEST_IMAGE` being passed to makefile if we want to use something other than `dev` or locally built `latest` (perhaps a specific commit built from master). However, a logic flaw causes `DEST_IMAGE` to be overwritten. This PR changes it so the logic only applies if `DEST_IMAGE` is not passed to makefile.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

This should reflect upgrade test readme.

### Testing Considerations

None, other than some way to surface these kinds of issues maybe?

Tested with:

```sh
DEST_IMAGE=ghcr.io/agoric/agoric-sdk:latest make build
# note that previously because `local_sdk` isn't a build target, `DEST_IMAGE` is overridden to `:dev`
# now it will use `:latest` as expected
docker build --build-arg BOOTSTRAP_MODE=main --build-arg DEST_IMAGE=ghcr.io/agoric/agoric-sdk:latest --progress=plain --target agoric-upgrade-11 -t agoric/upgrade-test:agoric-upgrade-11 -f Dockerfile upgrade-test-scripts
```
