### PR TITLE
feat(cosmos): bidirectional JSON-RPC to an `agvm` subprocess

### DIFF
--- a/bin/agd
+++ b/bin/agd
@@ -148,7 +148,7 @@ fi
     print=()
   fi
   print+=( -print )
-  src=$(find "$GOLANG_DIR" \( ! -name '*_test.go' -name '*.go' -o -name 'go.*' \) "${print[@]}" | head -1 || true)
+  src=$(find "$GOLANG_DIR" \( ! -name '*_test.go' -name '*.go' -o -name '*.cc' -o -name 'go.*' \) "${print[@]}" | head -1 || true)
   test -z "$src" || {
     echo "At least $src is newer than $stamp"
 

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -1,6 +1,7 @@
 package gaia
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -287,7 +288,7 @@ func NewGaiaApp(
 	appOpts servertypes.AppOptions,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *GaiaApp {
-	defaultController := func(needReply bool, str string) (string, error) {
+	defaultController := func(ctx context.Context, needReply bool, str string) (string, error) {
 		fmt.Fprintln(os.Stderr, "FIXME: Would upcall to controller with", str)
 		return "", nil
 	}
@@ -299,7 +300,7 @@ func NewGaiaApp(
 }
 
 func NewAgoricApp(
-	sendToController func(bool, string) (string, error),
+	sendToController func(context.Context, bool, string) (string, error),
 	logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool, skipUpgradeHeights map[int64]bool,
 	homePath string, invCheckPeriod uint, encodingConfig gaiaappparams.EncodingConfig, appOpts servertypes.AppOptions, baseAppOptions ...func(*baseapp.BaseApp),
 ) *GaiaApp {
@@ -449,7 +450,7 @@ func NewAgoricApp(
 		app.CheckControllerInited(true)
 		// We use SwingSet-level metering to charge the user for the call.
 		defer vm.SetControllerContext(ctx)()
-		return sendToController(true, str)
+		return sendToController(sdk.WrapSDKContext(ctx), true, str)
 	}
 
 	setBootstrapNeeded := func() {
@@ -481,7 +482,7 @@ func NewAgoricApp(
 			if err != nil {
 				return "", err
 			}
-			return sendToController(true, string(bz))
+			return sendToController(context.Background(), true, string(bz))
 		},
 	)
 

--- a/golang/cosmos/cmd/agd/agvm.go
+++ b/golang/cosmos/cmd/agd/agvm.go
@@ -3,12 +3,15 @@ package main
 import (
 	"fmt"
 	"os"
-	osexec "os/exec"
+	"os/exec"
 
 	"github.com/tendermint/tendermint/libs/log"
 )
 
-func NewVMCommand(logger log.Logger, binary string, args []string, vmFromAgd, vmToAgd *os.File) *osexec.Cmd {
+// NewVMCommand creates a new OS command to run the Agoric VM.  It sets up the
+// file descriptors for the VM to communicate with agd, and passes the
+// `--vm-spec <spec>` arguments to the VM.
+func NewVMCommand(logger log.Logger, binary string, args []string, vmFromAgd, vmToAgd *os.File) *exec.Cmd {
 	// We start our file descriptor allocations after the standard ones, including
 	// Node.js IPC (fd=3).
 	fdStart := 4
@@ -16,17 +19,17 @@ func NewVMCommand(logger log.Logger, binary string, args []string, vmFromAgd, vm
 	args = append(args[1:], "--vm-spec", agvmSpec)
 
 	logger.Info("Start chain connecting to VM", "binary", binary, "args", args)
-	cmd := osexec.Command(binary, args...)
+	cmd := exec.Command(binary, args...)
 
 	// Manage the file descriptors.
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
-	numStdFiles := 3
-
+	numStdFiles := 3 // stdin, stdout, stderr
+	// ExtraFiles begins at fd numStdFiles, so we need to compute the array.
 	cmd.ExtraFiles = make([]*os.File, fdStart - numStdFiles + 2)
 	cmd.ExtraFiles[fdStart - numStdFiles] = vmFromAgd
 	cmd.ExtraFiles[fdStart+1 - numStdFiles] = vmToAgd
-	
+
 	return cmd
 }

--- a/golang/cosmos/cmd/agd/agvm.go
+++ b/golang/cosmos/cmd/agd/agvm.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	osexec "os/exec"
+
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func NewVMCommand(logger log.Logger, binary string, args []string, vmFromAgd, vmToAgd *os.File) *osexec.Cmd {
+	// We start our file descriptor allocations after the standard ones, including
+	// Node.js IPC (fd=3).
+	fdStart := 4
+	agvmSpec := fmt.Sprintf(`{"agd":{"fd":[%d,%d]}}`, fdStart, fdStart+1)
+	args = append(args[1:], "--vm-spec", agvmSpec)
+
+	logger.Info("Start chain connecting to VM", "binary", binary, "args", args)
+	cmd := osexec.Command(binary, args...)
+
+	// Manage the file descriptors.
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	numStdFiles := 3
+
+	cmd.ExtraFiles = make([]*os.File, fdStart - numStdFiles + 2)
+	cmd.ExtraFiles[fdStart - numStdFiles] = vmFromAgd
+	cmd.ExtraFiles[fdStart+1 - numStdFiles] = vmToAgd
+	
+	return cmd
+}

--- a/golang/cosmos/cmd/agd/agvm.go
+++ b/golang/cosmos/cmd/agd/agvm.go
@@ -9,27 +9,34 @@ import (
 )
 
 // NewVMCommand creates a new OS command to run the Agoric VM.  It sets up the
-// file descriptors for the VM to communicate with agd, and passes the
-// `--vm-spec <spec>` arguments to the VM.
+// file descriptors for the VM to communicate with agd, and passes their numbers
+// via AGVM_FROM_AGD and AGVM_TO_AGD environment variables.
 func NewVMCommand(logger log.Logger, binary string, args []string, vmFromAgd, vmToAgd *os.File) *exec.Cmd {
-	// We start our file descriptor allocations after the standard ones, including
-	// Node.js IPC (fd=3).
-	fdStart := 4
-	agvmSpec := fmt.Sprintf(`{"agd":{"fd":[%d,%d]}}`, fdStart, fdStart+1)
-	args = append(args[1:], "--vm-spec", agvmSpec)
-
-	logger.Info("Start chain connecting to VM", "binary", binary, "args", args)
-	cmd := exec.Command(binary, args...)
+	logger.Info("agd connecting to VM", "binary", binary, "args", args)
+	cmd := exec.Command(binary, args[1:]...)
 
 	// Manage the file descriptors.
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	numStdFiles := 3 // stdin, stdout, stderr
+
+	// We start our file descriptor allocations after the standard ones, including
+	// Node.js IPC (fd=3).
+	fdFromAgd := 4
+	fdToAgd := fdFromAgd + 1
+
 	// ExtraFiles begins at fd numStdFiles, so we need to compute the array.
-	cmd.ExtraFiles = make([]*os.File, fdStart - numStdFiles + 2)
-	cmd.ExtraFiles[fdStart - numStdFiles] = vmFromAgd
-	cmd.ExtraFiles[fdStart+1 - numStdFiles] = vmToAgd
+	cmd.ExtraFiles = make([]*os.File, fdToAgd - numStdFiles + 1)
+	cmd.ExtraFiles[fdFromAgd - numStdFiles] = vmFromAgd
+	cmd.ExtraFiles[fdToAgd - numStdFiles] = vmToAgd
+
+	// Pass the file descriptor numbers in the environment.
+	cmd.Env = append(
+		os.Environ(),
+		fmt.Sprintf("AGVM_FROM_AGD=%d", fdFromAgd),
+		fmt.Sprintf("AGVM_TO_AGD=%d", fdToAgd),
+	)
 
 	return cmd
 }

--- a/golang/cosmos/cmd/agd/main.go
+++ b/golang/cosmos/cmd/agd/main.go
@@ -9,24 +9,26 @@ import (
 	gaia "github.com/Agoric/agoric-sdk/golang/cosmos/app"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/daemon"
 	daemoncmd "github.com/Agoric/agoric-sdk/golang/cosmos/daemon/cmd"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 )
 
 func main() {
 	// We need to delegate to our default app for running the actual chain.
-	launchVM := func(logger log.Logger) {
+	launchVM := func(logger log.Logger, appOpts servertypes.AppOptions) error {
 		args := []string{"ag-chain-cosmos", "--home", gaia.DefaultNodeHome}
 		args = append(args, os.Args[1:]...)
 
 		binary, lookErr := FindCosmicSwingsetBinary()
 		if lookErr != nil {
-			panic(lookErr)
+			return lookErr
 		}
 
 		logger.Info("agd delegating to JS executable", "binary", binary, "args", args)
 		execErr := syscall.Exec(binary, args, os.Environ())
 		if execErr != nil {
-			panic(execErr)
+			return execErr
 		}
+		return nil
 	}
 
 	daemoncmd.OnStartHook = launchVM

--- a/golang/cosmos/cmd/agd/main.go
+++ b/golang/cosmos/cmd/agd/main.go
@@ -6,7 +6,9 @@ import (
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
+	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cast"
 	"github.com/tendermint/tendermint/libs/log"
@@ -19,13 +21,54 @@ import (
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 )
 
+// TerminateSubprocessGracePeriod is how long we wait between closing the pipe
+// waiting for it to exit, then sending a termination signal.
+const TerminateSubprocessGracePeriod = 3 * time.Second
+
+// KillSubprocessGracePeriod is how long we wait between sending a subprocess a
+// termination signal, waiting for it to exit, then killing it.
+const KillSubprocessGracePeriod = 5 * time.Second
+
+// makeShutdown returns a function that terminates the vm.
+func makeShutdown(cmd *exec.Cmd, writer *os.File) func() error {
+	return func() error {
+		// Stop talking to the subprocess.
+		_ = writer.Close()
+		go func() {
+			// Wait a bit.
+			time.Sleep(TerminateSubprocessGracePeriod)
+			// Then punch it in the shoulder.
+			_ = cmd.Process.Signal(os.Interrupt)
+			// Wait a bit.
+			time.Sleep(KillSubprocessGracePeriod)
+			// Then blow it away.
+			_ = cmd.Process.Kill()
+		}()
+		// Wait for it to keel over.
+		return cmd.Wait()
+	}
+}
+
+
+// main is the entry point of the agd daemon.  It determines whether to
+// initialize JSON-RPC communications with the separate `--split-vm` VM process,
+// or just to give up control entirely to another binary.
 func main() {
 	var vmClient *rpc.Client
+	var shutdown func() error
 
 	nodePort := 1
 	sendToNode := func(ctx context.Context, needReply bool, str string) (string, error) {
 		if vmClient == nil {
 			return "", errors.New("sendToVM called without VM client set up")
+		}
+
+		if str == "shutdown" {
+			// We could ask nicely, but don't bother.
+			if shutdown != nil {
+				return "", shutdown()
+			}
+			return "", nil
 		}
 
 		msg := vm.Message{
@@ -38,7 +81,6 @@ func main() {
 		return reply, err
 	}
 
-	// We need to delegate to our default app for running the actual chain.
 	exitCode := 0
 	launchVM := func(logger log.Logger, appOpts servertypes.AppOptions) error {
 		args := []string{"ag-chain-cosmos", "--home", gaia.DefaultNodeHome}
@@ -50,12 +92,14 @@ func main() {
 			if lookErr != nil {
 				return lookErr
 			}
-	
+
+			// We completely delegate to our default app for running the actual chain.
 			logger.Info("agd delegating to JS executable", "binary", binary, "args", args)
 			return syscall.Exec(binary, args, os.Environ())
 		}
 
-		agdFromVM, vmToAgd, err := os.Pipe()
+		// Split the execution between us and the VM.
+		agdFromVm, vmToAgd, err := os.Pipe()
 		if err != nil {
 			return err
 		}
@@ -67,6 +111,8 @@ func main() {
 		// Start the command running, then continue.
 		args[0] = binary
 		cmd := NewVMCommand(logger, binary, args, vmFromAgd, vmToAgd)
+		shutdown = makeShutdown(cmd, agdToVm)
+
 		if err := cmd.Start(); err != nil {
 			return err
 		}
@@ -78,12 +124,14 @@ func main() {
 		}
 
 		// Multiplex bidirectional JSON-RPC over the pipes.
-		agvmConn := jsonrpcconn.NewConn(agdFromVM, agdToVm)
+		agvmConn := jsonrpcconn.NewConn(agdFromVm, agdToVm)
 		clientConn, serverConn := jsonrpcconn.ClientServerConn(agvmConn)
 
 		// Set up the VM server.
 		vmServer := rpc.NewServer()
-		vmServer.RegisterName("agd", vm.NewAgdServer())
+		if err := vmServer.RegisterName("agd", vm.NewAgdServer()); err != nil {
+			return err
+		}
 		go vmServer.ServeCodec(jsonrpc.NewServerCodec(serverConn))
 
 		// Set up the VM client.
@@ -91,7 +139,7 @@ func main() {
 
 		go func() {
 			// Premature exit from `agd start` should exit the process.
-			cmd.Wait()
+			_ = cmd.Wait()
 			os.Exit(exitCode)
 		}()
 

--- a/golang/cosmos/cmd/agd/main.go
+++ b/golang/cosmos/cmd/agd/main.go
@@ -1,38 +1,110 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"net/rpc"
+	"net/rpc/jsonrpc"
 	"os"
 	"syscall"
 
+	"github.com/spf13/cast"
 	"github.com/tendermint/tendermint/libs/log"
 
 	gaia "github.com/Agoric/agoric-sdk/golang/cosmos/app"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/daemon"
 	daemoncmd "github.com/Agoric/agoric-sdk/golang/cosmos/daemon/cmd"
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm/jsonrpcconn"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 )
 
 func main() {
+	var vmClient *rpc.Client
+
+	nodePort := 1
+	sendToNode := func(ctx context.Context, needReply bool, str string) (string, error) {
+		if vmClient == nil {
+			return "", errors.New("sendToVM called without VM client set up")
+		}
+
+		msg := vm.Message{
+			Port: nodePort,
+			NeedsReply: needReply,
+			Data: str,
+		}
+		var reply string
+		err := vmClient.Call(vm.ReceiveMessageMethod, msg, &reply)
+		return reply, err
+	}
+
 	// We need to delegate to our default app for running the actual chain.
+	exitCode := 0
 	launchVM := func(logger log.Logger, appOpts servertypes.AppOptions) error {
 		args := []string{"ag-chain-cosmos", "--home", gaia.DefaultNodeHome}
 		args = append(args, os.Args[1:]...)
 
-		binary, lookErr := FindCosmicSwingsetBinary()
-		if lookErr != nil {
-			return lookErr
+		binary := cast.ToString(appOpts.Get(daemoncmd.FlagSplitVm))
+		if binary == "" {
+			binary, lookErr := FindCosmicSwingsetBinary()
+			if lookErr != nil {
+				return lookErr
+			}
+	
+			logger.Info("agd delegating to JS executable", "binary", binary, "args", args)
+			return syscall.Exec(binary, args, os.Environ())
 		}
 
-		logger.Info("agd delegating to JS executable", "binary", binary, "args", args)
-		execErr := syscall.Exec(binary, args, os.Environ())
-		if execErr != nil {
-			return execErr
+		agdFromVM, vmToAgd, err := os.Pipe()
+		if err != nil {
+			return err
 		}
+		vmFromAgd, agdToVm, err := os.Pipe()
+		if err != nil {
+			return err
+		}
+
+		// Start the command running, then continue.
+		args[0] = binary
+		cmd := NewVMCommand(logger, binary, args, vmFromAgd, vmToAgd)
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+		if vmFromAgd.Close() != nil {
+			return err
+		}
+		if vmToAgd.Close() != nil {
+			return err
+		}
+
+		// Multiplex bidirectional JSON-RPC over the pipes.
+		agvmConn := jsonrpcconn.NewConn(agdFromVM, agdToVm)
+		clientConn, serverConn := jsonrpcconn.ClientServerConn(agvmConn)
+
+		// Set up the VM server.
+		vmServer := rpc.NewServer()
+		vmServer.RegisterName("agd", vm.NewAgdServer())
+		go vmServer.ServeCodec(jsonrpc.NewServerCodec(serverConn))
+
+		// Set up the VM client.
+		vmClient = jsonrpc.NewClient(clientConn)
+
+		go func() {
+			// Premature exit from `agd start` should exit the process.
+			cmd.Wait()
+			os.Exit(exitCode)
+		}()
+
 		return nil
 	}
 
-	daemoncmd.OnStartHook = launchVM
 	daemoncmd.OnExportHook = launchVM
+	daemoncmd.OnStartHook = func (logger log.Logger, appOpts servertypes.AppOptions) error {
+		// We tried running start, which should never exit, so exit with non-zero
+		// code if we do.
+		exitCode = 99
+		return launchVM(logger, appOpts)
+	}
 
-	daemon.RunWithController(nil)
+	daemon.RunWithController(sendToNode)
 }

--- a/golang/cosmos/cmd/libdaemon/main.go
+++ b/golang/cosmos/cmd/libdaemon/main.go
@@ -10,6 +10,7 @@ package main
 import "C"
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -44,7 +45,7 @@ func RunAgCosmosDaemon(nodePort C.int, toNode C.sendFunc, cosmosArgs []*C.char) 
 	daemoncmd.AppName = "ag-chain-cosmos"
 
 	// FIXME: Decouple the sending logic from the Cosmos app.
-	sendToNode := func(needReply bool, str string) (string, error) {
+	sendToNode := func(ctx context.Context, needReply bool, str string) (string, error) {
 		var rPort int
 		if needReply {
 			lastReply++

--- a/golang/cosmos/cmd/libdaemon/main.go
+++ b/golang/cosmos/cmd/libdaemon/main.go
@@ -68,6 +68,9 @@ func RunAgCosmosDaemon(nodePort C.int, toNode C.sendFunc, cosmosArgs []*C.char) 
 
 	gaia.DefaultNodeHome = filepath.Join(userHomeDir, ".ag-chain-cosmos")
 	daemoncmd.AppName = "ag-chain-cosmos"
+	if err := os.Setenv(daemoncmd.EmbeddedVmEnvVar, "libdaemon"); err != nil {
+		panic(err)
+	}
 
 	var sendToNode daemoncmd.Sender
 

--- a/golang/cosmos/cmd/libdaemon/main.go
+++ b/golang/cosmos/cmd/libdaemon/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Agoric/agoric-sdk/golang/cosmos/daemon"
 	daemoncmd "github.com/Agoric/agoric-sdk/golang/cosmos/daemon/cmd"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 )
 
 type goReturn = struct {
@@ -84,10 +85,11 @@ func RunAgCosmosDaemon(nodePort C.int, toNode C.sendFunc, cosmosArgs []*C.char) 
 		// We run in the background, but exit when the job is over.
 		// swingset.SendToNode("hello from Initial Go!")
 		exitCode := 0
-		daemoncmd.OnStartHook = func(logger log.Logger) {
+		daemoncmd.OnStartHook = func(logger log.Logger, appOpts servertypes.AppOptions) error {
 			// We tried running start, which should never exit, so exit with non-zero
 			// code if we ever stop.
 			exitCode = 99
+			return nil
 		}
 		daemon.RunWithController(sendToNode)
 		// fmt.Fprintln(os.Stderr, "Shutting down Cosmos")

--- a/golang/cosmos/cmd/libdaemon/main.go
+++ b/golang/cosmos/cmd/libdaemon/main.go
@@ -35,11 +35,17 @@ const SwingSetPort = 123
 var vmClientCodec *vm.ClientCodec
 var agdServer *vm.AgdServer
 
+// ConnectVMClientCodec creates an RPC client codec and a sender to the
+// in-process implementation of the VM.
 func ConnectVMClientCodec(ctx context.Context, nodePort int, sendFunc func(int, int, string)) (*vm.ClientCodec, daemoncmd.Sender) {
 	vmClientCodec = vm.NewClientCodec(context.Background(), sendFunc)
 	vmClient := rpc.NewClientWithCodec(vmClientCodec)
 
 	sendToNode := func(ctx context.Context, needReply bool, str string) (string, error) {
+		if str == "shutdown" {
+			return "", vmClientCodec.Close()
+		}
+
 		msg := vm.Message{
 			Port: nodePort,
 			NeedsReply: needReply,

--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -155,8 +155,23 @@ func initRootCmd(sender Sender, rootCmd *cobra.Command, encodingConfig params.En
 	rootCmd.AddCommand(server.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Marshaler))
 }
 
+const (
+	// FlagSplitVm is the command-line flag for subcommands that can use a
+	// split-process Agoric VM.  The default is to use an embedded VM.
+	FlagSplitVm = "split-vm"
+)
+
+func addAgoricVMFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().String(
+		FlagSplitVm,
+		"",
+		"Specify the external Agoric VM program",
+	)
+}
+
 func addModuleInitFlags(startCmd *cobra.Command) {
 	crisis.AddModuleInitFlags(startCmd)
+	addAgoricVMFlags(startCmd)
 }
 
 func queryCommand() *cobra.Command {
@@ -302,6 +317,7 @@ const (
 // cosmos-sdk to add a required "export-dir" command-line flag, and create the
 // genesis export in the specified directory.
 func extendCosmosExportCommand(cmd *cobra.Command, hasVMController bool) {
+	addAgoricVMFlags(cmd)
 	cmd.Flags().String(FlagExportDir, "", "The directory where to create the genesis export")
 	err := cmd.MarkFlagRequired(FlagExportDir)
 	if err != nil {

--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -38,7 +39,7 @@ import (
 )
 
 // Sender is a function that sends a request to the controller.
-type Sender func(needReply bool, str string) (string, error)
+type Sender func(ctx context.Context, needReply bool, str string) (string, error)
 
 var AppName = "agd"
 var OnStartHook func(logger log.Logger)

--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -42,8 +42,8 @@ import (
 type Sender func(ctx context.Context, needReply bool, str string) (string, error)
 
 var AppName = "agd"
-var OnStartHook func(logger log.Logger)
-var OnExportHook func(logger log.Logger)
+var OnStartHook func(log.Logger, servertypes.AppOptions) error
+var OnExportHook func(log.Logger, servertypes.AppOptions) error
 
 // NewRootCmd creates a new root command for simd. It is called once in the
 // main function.
@@ -61,7 +61,7 @@ func NewRootCmd(sender Sender) (*cobra.Command, params.EncodingConfig) {
 
 	rootCmd := &cobra.Command{
 		Use:   AppName,
-		Short: "Stargate Agoric App",
+		Short: "Agoric Cosmos App",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			// set the default command outputs
 			cmd.SetOut(cmd.OutOrStdout())
@@ -224,7 +224,9 @@ func (ac appCreator) newApp(
 	appOpts servertypes.AppOptions,
 ) servertypes.Application {
 	if OnStartHook != nil {
-		OnStartHook(logger)
+		if err := OnStartHook(logger, appOpts); err != nil {
+			panic(err)
+		}
 	}
 
 	var cache sdk.MultiStorePersistentCache
@@ -361,7 +363,9 @@ func (ac appCreator) appExport(
 	appOpts servertypes.AppOptions,
 ) (servertypes.ExportedApp, error) {
 	if OnExportHook != nil {
-		OnExportHook(logger)
+		if err := OnExportHook(logger, appOpts); err != nil {
+			return servertypes.ExportedApp{}, err
+		}
 	}
 
 	homePath, ok := appOpts.Get(flags.FlagHome).(string)

--- a/golang/cosmos/daemon/main.go
+++ b/golang/cosmos/daemon/main.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -17,7 +18,7 @@ import (
 )
 
 // DefaultController is a stub controller.
-var DefaultController = func(needReply bool, str string) (string, error) {
+var DefaultController = func(ctx context.Context, needReply bool, str string) (string, error) {
 	return "", fmt.Errorf("Controller not configured; did you mean to use `ag-chain-cosmos` instead?")
 }
 

--- a/golang/cosmos/daemon/main.go
+++ b/golang/cosmos/daemon/main.go
@@ -35,6 +35,7 @@ func RunWithController(sendToController cmd.Sender) {
 	signal.Notify(sigs, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigs
+		_, _ = sendToController(context.Background(), false, "shutdown")
 		os.Exit(98)
 	}()
 

--- a/golang/cosmos/vm/client.go
+++ b/golang/cosmos/vm/client.go
@@ -1,0 +1,113 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"net/rpc"
+)
+
+// ReceiveMessageMethod is the name of the method we call in order to have the
+// VM receive a Message.
+const ReceiveMessageMethod = "agvm.ReceiveMessage"
+
+// Message is what we send to the VM.
+type Message struct {
+	Port int
+	Data string
+	NeedsReply bool
+}
+
+// ClientCodec implements rpc.ClientCodec.
+var _ rpc.ClientCodec = (*ClientCodec)(nil)
+
+// ClientCodec implements a net/rpc ClientCodec for the "bridge" between the Go
+// runtime and the VM in the single-process dual-runtime configuration.
+//
+// We expect to call it via the legacy API with signature:
+//    sendToController func(needsReply bool, msg string) (string, error)
+// where msg and the returned string are JSON-encoded values.
+//
+// Note that the net/rpc framework cannot express a call that does not expect a
+// response, so we'll note such calls by sending with a reply port of 0 and
+// having the WriteRequest() method fabricate a Receive() call to clear the rpc
+// state.
+type ClientCodec struct {
+	ctx context.Context
+	send func(port, rPort int, msg string)
+	outbound map[int]rpc.Request
+	inbound chan *rpc.Response
+	replies map[uint64]string
+	replyToRead uint64
+}
+
+// NewClientCodec creates a new ClientCodec.
+func NewClientCodec(ctx context.Context, send func(int, int, string)) *ClientCodec {
+	return &ClientCodec{
+		ctx: ctx,
+		send: send,
+		outbound: make(map[int]rpc.Request),
+		inbound: make(chan *rpc.Response),
+		replies: make(map[uint64]string),
+	}
+}
+
+// WriteRequest sends a request to the VM.
+func (cc *ClientCodec) WriteRequest(r *rpc.Request, body interface{}) error {
+	if r.ServiceMethod != ReceiveMessageMethod {
+		return fmt.Errorf("unknown method %s", r.ServiceMethod)
+	}
+
+	msg, ok := body.(Message)
+	if !ok {
+		return fmt.Errorf("body %T is not a Message", body)
+	}
+	rPort := int(r.Seq + 1) // rPort is 1-indexed to indicate it's required
+	cc.outbound[rPort] = *r
+	var senderReplyPort int
+	if msg.NeedsReply {
+		senderReplyPort = rPort
+	}
+	cc.send(msg.Port, senderReplyPort, msg.Data)
+	if !msg.NeedsReply {
+		return cc.Receive(rPort, false, "<no-reply-requested>")
+	}
+	return nil
+}
+
+// ReadResponseHeader decodes a response header from the VM.
+func (cc *ClientCodec) ReadResponseHeader(r *rpc.Response) error {
+	resp := <-cc.inbound
+	*r = *resp
+	cc.replyToRead = r.Seq
+	return nil
+}
+
+// ReadResponseBody decodes a response body (currently just string) from the VM.
+func (cc *ClientCodec) ReadResponseBody(body interface{}) error {
+	if body != nil {
+		*body.(*string) = cc.replies[cc.replyToRead]
+	}
+	delete(cc.replies, cc.replyToRead)
+	return nil
+}
+
+// Receive is called by the VM to send a response to the client.
+func (cc *ClientCodec) Receive(rPort int, isError bool, data string) error {
+	outb := cc.outbound[rPort]
+	delete(cc.outbound, rPort)
+	resp := &rpc.Response{
+		ServiceMethod: outb.ServiceMethod,
+		Seq: outb.Seq,
+	}
+	if isError {
+		resp.Error = data
+	} else {
+		cc.replies[resp.Seq] = data
+	}
+	cc.inbound <- resp
+	return nil
+}
+
+func (cc *ClientCodec) Close() error {
+	return nil
+}

--- a/golang/cosmos/vm/client_test.go
+++ b/golang/cosmos/vm/client_test.go
@@ -1,0 +1,184 @@
+package vm_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/rpc"
+	"testing"
+	"time"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+)
+
+type Sender func(ctx context.Context, needReply bool, str string) (string, error)
+
+type errorWrapper struct {
+	Error string `json:"error"`
+}
+
+// ConnectVMClientCodec creates an RPC client codec and a sender to the
+// in-process implementation of the VM.
+func ConnectVMClientCodec(ctx context.Context, nodePort int, sendFunc func(int, int, string)) (*vm.ClientCodec, Sender) {
+	vmClientCodec := vm.NewClientCodec(context.Background(), sendFunc)
+	vmClient := rpc.NewClientWithCodec(vmClientCodec)
+
+	sendToNode := func(ctx context.Context, needReply bool, str string) (string, error) {
+		if str == "shutdown" {
+			return "", vmClientCodec.Close()
+		}
+
+		msg := vm.Message{
+			Port: nodePort,
+			NeedsReply: needReply,
+			Data: str,
+		}
+		var reply string
+		err := vmClient.Call(vm.ReceiveMessageMethod, msg, &reply)
+		return reply, err
+	}
+
+	return vmClientCodec, sendToNode
+}
+
+type Fixture struct {
+	SendToNode Sender
+	SendToGo func (port int, msgStr string) string
+	ReplyToGo func (replyPort int, isError bool, respStr string) int
+}
+
+func NewFixture(t *testing.T) (*Fixture) {
+	nodePort := 42
+
+	f := &Fixture{}
+
+	sendFunc := func(port int, reply int, str string) {
+		switch str {
+			case "ping":
+				time.AfterFunc(100*time.Millisecond, func() {
+					fmt.Printf("sendFunc: port=%d, reply=%d, str=%s\n", port, reply, str)
+					if reply != 0 {
+						f.ReplyToGo(reply, false, "pong")
+					}
+				})
+			case "wait":
+				time.AfterFunc(300*time.Millisecond, func() {
+					fmt.Printf("sendFunc: port=%d, reply=%d, str=%s\n", port, reply, str)
+					if reply != 0 {
+						f.ReplyToGo(reply, false, "done-waiting")
+					}
+				})
+			default:
+				t.Errorf("Unexpected message %s", str)
+		}
+	}
+
+	vmClientCodec, sendToNode := ConnectVMClientCodec(
+		context.Background(),
+		int(nodePort),
+		sendFunc,
+	)
+	agdServer := vm.NewAgdServer()
+
+	f.SendToNode = sendToNode
+	f.SendToGo = func (port int, msgStr string) string {
+		fmt.Println("Send to Go", msgStr)
+		var respStr string
+		message := &vm.Message{
+			Port: int(port),
+			NeedsReply: true,
+			Data: msgStr,
+		}
+		
+		err := agdServer.ReceiveMessage(message, &respStr)
+		if err == nil {
+			return respStr
+		}
+	
+		// fmt.Fprintln(os.Stderr, "Cannot receive from controller", err)
+		errResp := errorWrapper{
+			Error: err.Error(),
+		}
+		respBytes, err := json.Marshal(&errResp)
+		if err != nil {
+			panic(err)
+		}
+		return string(respBytes)
+	}
+
+	f.ReplyToGo = func (replyPort int, isError bool, respStr string) int {
+		if err := vmClientCodec.Receive(replyPort, isError, respStr); err != nil {
+			return 1
+		}
+		return 0
+	}
+
+	return f
+}
+
+func TestClient_oneOutbound(t *testing.T) {
+	f := NewFixture(t)
+
+	// Try one blocking call.
+	ret, err := f.SendToNode(context.Background(), true, "ping")
+	if err != nil {
+		t.Error(err)
+	}
+	if ret != "pong" {
+		t.Errorf("ping want pong, got %s", ret)
+	}
+}
+
+func TestClient_ShortBg(t *testing.T) {
+
+	f := NewFixture(t)
+
+	// Try a short background call with a long overlapping call.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ret, err := f.SendToNode(context.Background(), true, "ping")
+		if err != nil {
+			t.Error(err)
+		}
+		if ret != "pong" {
+			t.Errorf("ping want pong, got %s", ret)
+		}
+	}()
+
+	ret, err := f.SendToNode(context.Background(), true, "wait")
+	if err != nil {
+		t.Error(err)
+	}
+	if ret != "done-waiting" {
+		t.Errorf("wait want done-waiting, got %s", ret)
+	}
+	<-done
+}
+
+func TestClient_LongBg(t *testing.T) {
+
+	f := NewFixture(t)
+
+	// Try a long background call with a short overlapping call.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ret, err := f.SendToNode(context.Background(), true, "wait")
+		if err != nil {
+			t.Error(err)
+		}
+		if ret != "done-waiting" {
+			t.Errorf("ping want done-waiting, got %s", ret)
+		}
+	}()
+
+	ret, err := f.SendToNode(context.Background(), true, "ping")
+	if err != nil {
+		t.Error(err)
+	}
+	if ret != "pong" {
+		t.Errorf("wait want pong, got %s", ret)
+	}
+	<-done
+}

--- a/golang/cosmos/vm/controller.go
+++ b/golang/cosmos/vm/controller.go
@@ -1,15 +1,11 @@
 package vm
 
 import (
+	"context"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
-
-type ControllerContext struct {
-	Context               sdk.Context
-	IBCChannelHandlerPort int
-}
 
 type ControllerAdmissionMsg interface {
 	sdk.Msg
@@ -31,10 +27,13 @@ type Jsonable interface{}
 // ActionPusher enqueues data for later consumption by the controller.
 type ActionPusher func(ctx sdk.Context, action Jsonable) error
 
-var controllerContext ControllerContext
+var wrappedEmptySDKContext = sdk.WrapSDKContext(
+	sdk.Context{}.WithContext(context.Background()),
+)
+var controllerContext context.Context = wrappedEmptySDKContext
 
 type PortHandler interface {
-	Receive(*ControllerContext, string) (string, error)
+	Receive(context.Context, string) (string, error)
 }
 
 var portToHandler = make(map[int]PortHandler)
@@ -45,9 +44,9 @@ var lastPort = 0
 func SetControllerContext(ctx sdk.Context) func() {
 	// We are only called by the controller, so we assume that it is billing its
 	// own meter usage.
-	controllerContext.Context = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
+	controllerContext = sdk.WrapSDKContext(ctx.WithGasMeter(sdk.NewInfiniteGasMeter()))
 	return func() {
-		controllerContext.Context = sdk.Context{}
+		controllerContext = wrappedEmptySDKContext
 	}
 }
 
@@ -75,5 +74,5 @@ func ReceiveFromController(portNum int, msg string) (string, error) {
 	if handler == nil {
 		return "", fmt.Errorf("unregistered port %d", portNum)
 	}
-	return handler.Receive(&controllerContext, msg)
+	return handler.Receive(controllerContext, msg)
 }

--- a/golang/cosmos/vm/controller.go
+++ b/golang/cosmos/vm/controller.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"context"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -67,12 +66,4 @@ func UnregisterPortHandler(portNum int) error {
 	delete(portToName, portNum)
 	delete(nameToPort, name)
 	return nil
-}
-
-func ReceiveFromController(portNum int, msg string) (string, error) {
-	handler := portToHandler[portNum]
-	if handler == nil {
-		return "", fmt.Errorf("unregistered port %d", portNum)
-	}
-	return handler.Receive(controllerContext, msg)
 }

--- a/golang/cosmos/vm/jsonrpcconn/jsonrpcconn.go
+++ b/golang/cosmos/vm/jsonrpcconn/jsonrpcconn.go
@@ -1,0 +1,160 @@
+/*
+Package jsonrpcconn provides a way to multiplex an io stream into two
+streams where incoming JSON-RPC requests go to one stream and incoming
+JSON-RPC responses go to another. Outputs are merged.
+
+The JSON-RPCv1 protocol is peer-to-peer, but the implementation in the Go
+standard library only supports client-server. By multiplexing a single
+io.ReadWriteCloser stream into separate server (receives requests) and
+client (receives responses) streams, two RPC halves can share the same
+underlying connection.
+*/
+package jsonrpcconn
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// jsonRpcMsg can unmarshal either a JSON-RPC
+// request or response object.
+type jsonRpcMsg struct {
+	Error  json.RawMessage   `json:"error"`
+	Id     json.RawMessage   `json:"id"`
+	Method *string           `json:"method"`
+	Params []json.RawMessage `json:"params"`
+	Result json.RawMessage   `json:"result"`
+}
+
+// mux holds the underlying connection and the pipe reader/writer
+// pairs for the server (request) and client (response) sides.
+// Any protocol error or closing any channel will cause shutdown.
+type mux struct {
+	conn       io.ReadWriteCloser
+	reqReader  *io.PipeReader
+	reqWriter  *io.PipeWriter
+	respReader *io.PipeReader
+	respWriter *io.PipeWriter
+}
+
+func newMux(conn io.ReadWriteCloser) mux {
+	reqReader, reqWriter := io.Pipe()
+	respReader, respWriter := io.Pipe()
+	m := mux{
+		conn:       conn,
+		reqReader:  reqReader,
+		reqWriter:  reqWriter,
+		respReader: respReader,
+		respWriter: respWriter,
+	}
+	go m.input()
+	return m
+}
+
+func (m mux) input() {
+	var err error
+	dec := json.NewDecoder(m.conn)
+	for {
+		// read the next JSON value, preserve its wire format
+		var raw json.RawMessage
+		err = dec.Decode(&raw)
+		if err != nil {
+			break
+		}
+
+		// parse as JSON-RPC
+		var msg jsonRpcMsg
+		err = json.Unmarshal(raw, &msg)
+		if err != nil {
+			break
+		}
+
+		// send to one of the outputs
+		if msg.Method != nil {
+			// presume a request, the consumer will handle any missing fields
+			_, err = m.reqWriter.Write(raw)
+		} else {
+			// presume a response, the consumer will handle any missing fields
+			_, err = m.respWriter.Write(raw)
+		}
+		if err != nil {
+			break
+		}
+	}
+	m.reqWriter.CloseWithError(err)
+	m.respWriter.CloseWithError(err)
+	m.conn.Close()
+}
+
+// clientChan is a view of the mux for the client channel.
+type clientChan mux
+
+// Close implements the io.Closer interface.
+func (c clientChan) Close() error {
+	return c.conn.Close()
+}
+
+// Read implements the io.Reader interface.
+func (c clientChan) Read(p []byte) (int, error) {
+	return c.respReader.Read(p)
+}
+
+// Write implements the io.Writer interface.
+func (c clientChan) Write(p []byte) (int, error) {
+	return c.conn.Write(p)
+}
+
+// serverChan is a view of the mux for the server channel.
+type serverChan mux
+
+// Close implements the io.Closer interface.
+func (s serverChan) Close() error {
+	return s.conn.Close()
+}
+
+// Read implements the io.Reader interface.
+func (s serverChan) Read(p []byte) (int, error) {
+	return s.reqReader.Read(p)
+}
+
+// Write implements the io.Writer interface.
+func (s serverChan) Write(p []byte) (int, error) {
+	return s.conn.Write(p)
+}
+
+// ClientServerConn multiplexes an input/output stream for the JSON-RPCv1
+// protocol into streams specific for client traffic and server traffic.
+// Full JSON objects must be written atomically to either stream to
+// interleave correctly.
+func ClientServerConn(conn io.ReadWriteCloser) (clientConn io.ReadWriteCloser, serverConn io.ReadWriteCloser) {
+	m := newMux(conn)
+	clientConn = clientChan(m)
+	serverConn = serverChan(m)
+	return
+}
+
+type conn struct {
+	rd io.ReadCloser
+	wr io.WriteCloser
+}
+
+// Close implments the io.Closer interface.
+func (e conn) Close() error {
+	e.rd.Close()
+	return e.wr.Close()
+}
+
+// Read implements the io.Reader interface.
+func (e conn) Read(p []byte) (int, error) {
+	return e.rd.Read(p)
+}
+
+// Write implements the io.Writer interface.
+func (e conn) Write(p []byte) (int, error) {
+	return e.wr.Write(p)
+}
+
+// NewConn returns a connection from a reader and a writer.
+func NewConn(rd io.ReadCloser, wr io.WriteCloser) io.ReadWriteCloser {
+	return conn{rd: rd, wr: wr}
+}

--- a/golang/cosmos/vm/jsonrpcconn/jsonrpcconn_test.go
+++ b/golang/cosmos/vm/jsonrpcconn/jsonrpcconn_test.go
@@ -1,0 +1,126 @@
+package jsonrpcconn_test
+
+import (
+	"fmt"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"testing"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm/jsonrpcconn"
+)
+
+/*
+type testConn struct {
+	input  *bytes.Buffer
+	output *bytes.Buffer
+	done   chan struct{}
+}
+
+func newTestConn(input string) io.ReadWriteCloser {
+	return testConn{
+		input:  bytes.NewBufferString(input),
+		output: new(bytes.Buffer),
+		done:   make(chan struct{}),
+	}
+}
+
+func (tc testConn) Read(p []byte) (int, error) {
+	n, err := tc.input.Read(p)
+	if err == io.EOF {
+		<-tc.done
+	}
+	return n, err
+}
+
+func (tc testConn) Write(p []byte) (int, error) {
+	return tc.output.Write(p)
+}
+
+func (tc testConn) Close() error {
+	close(tc.done)
+	return nil
+}
+
+func TestMux(t *testing.T) {
+	input := `{"id": 1, "method": "foo", "params": [1, 2]}
+	{"id": "aaa", "result": true, "error": null}
+	{"id": null, "method": "bar", "params": ["string", 3, false]}`
+	tc := newTestConn(input)
+	client, server := jsonrpcconn.ClientServerConn(tc)
+	client.Read
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+
+	}()
+	wg.Wait()
+} */
+
+type Args struct {
+	A, B int
+}
+
+type Arith struct{}
+
+func (a *Arith) Add(args Args, reply *int) error {
+	*reply = args.A + args.B
+	return nil
+}
+
+func (a *Arith) Mul(args Args, reply *int) error {
+	*reply = args.A * args.B
+	return nil
+}
+
+func (a *Arith) Oops(args Args, reply *int) error {
+	return fmt.Errorf("oops")
+}
+
+func TestJsonRPC(t *testing.T) {
+	left, right := net.Pipe()
+	leftClientConn, leftServerConn := jsonrpcconn.ClientServerConn(left)
+	rightClientConn, rightServerConn := jsonrpcconn.ClientServerConn(right)
+
+	leftClient := jsonrpc.NewClient(leftClientConn)
+	leftServer := rpc.NewServer()
+	err := leftServer.RegisterName("foo", new(Arith))
+	if err != nil {
+		t.Fatal(err)
+	}
+	go leftServer.ServeCodec(jsonrpc.NewServerCodec(leftServerConn))
+
+	rightClient := jsonrpc.NewClient(rightClientConn)
+	rightServer := rpc.NewServer()
+	err = rightServer.RegisterName("bar", new(Arith))
+	if err != nil {
+		t.Fatal(err)
+	}
+	go rightServer.ServeCodec(jsonrpc.NewServerCodec(rightServerConn))
+
+	var reply int
+	err = leftClient.Call("bar.Add", Args{1, 2}, &reply)
+	if err != nil {
+		t.Error(err)
+	}
+	if reply != 3 {
+		t.Errorf("bar.Add want 3, got %d", reply)
+	}
+
+	err = rightClient.Call("foo.Mul", Args{2, 3}, &reply)
+	if err != nil {
+		t.Error(err)
+	}
+	if reply != 6 {
+		t.Errorf("foo.Mul want 6, got %d", reply)
+	}
+
+	err = leftClient.Call("bar.Oops", Args{7, 11}, &reply)
+	if err == nil {
+		t.Errorf("bar.Oops want error, got reply %d", reply)
+	} else if err.Error() != "oops" {
+		t.Errorf(`bar.Oops want error "oops", got "%s"`, err.Error())
+	}
+	leftClient.Close()
+	rightClient.Close()
+}

--- a/golang/cosmos/vm/server.go
+++ b/golang/cosmos/vm/server.go
@@ -1,0 +1,23 @@
+package vm
+
+import (
+	"fmt"
+)
+
+type AgdServer struct {}
+
+func NewAgdServer() *AgdServer {
+	return &AgdServer{}
+}
+
+// ReceiveMessage is the method the VM calls in order to have agd receive a
+// Message.
+func (s AgdServer) ReceiveMessage(msg *Message, reply *string) error {
+	handler := portToHandler[msg.Port]
+	if handler == nil {
+		return fmt.Errorf("unregistered port %d", msg.Port)
+	}
+	resp, err := handler.Receive(controllerContext, msg.Data)
+	*reply = resp
+	return err
+}

--- a/golang/cosmos/x/lien/lien.go
+++ b/golang/cosmos/x/lien/lien.go
@@ -5,6 +5,7 @@
 package lien
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -70,7 +71,8 @@ const (
 // Receives and processes a bridge message, returning the
 // JSON-encoded response or error.
 // See spec/02_messages.md for the messages and responses.
-func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (string, error) {
+func (ch portHandler) Receive(cctx context.Context, str string) (string, error) {
+	ctx := sdk.UnwrapSDKContext(cctx)
 	var msg portMessage
 	err := json.Unmarshal([]byte(str), &msg)
 	if err != nil {
@@ -78,13 +80,13 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (string, er
 	}
 	switch msg.Type {
 	case LIEN_GET_ACCOUNT_STATE:
-		return ch.handleGetAccountState(ctx.Context, msg)
+		return ch.handleGetAccountState(ctx, msg)
 
 	case LIEN_GET_STAKING:
-		return ch.handleGetStaking(ctx.Context, msg)
+		return ch.handleGetStaking(ctx, msg)
 
 	case LIEN_CHANGE_LIENED:
-		return ch.handleChangeLiened(ctx.Context, msg)
+		return ch.handleChangeLiened(ctx, msg)
 	}
 	return "", fmt.Errorf("unrecognized type %s", msg.Type)
 }

--- a/golang/cosmos/x/lien/lien_test.go
+++ b/golang/cosmos/x/lien/lien_test.go
@@ -1,11 +1,11 @@
 package lien
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
 
-	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/lien/types"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
@@ -114,8 +114,8 @@ func (m *mockLienKeeper) GetDelegatorDelegations(ctx sdk.Context, delegator sdk.
 }
 
 func TestBadType(t *testing.T) {
-	ctx := sdk.Context{}
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctx := sdk.Context{}.WithContext(context.Background())
+	ctlCtx := sdk.WrapSDKContext(ctx)
 	keeper := mockLienKeeper{
 		states: map[string]types.AccountState{},
 	}
@@ -135,8 +135,8 @@ func TestBadType(t *testing.T) {
 }
 
 func TestGetAccountState(t *testing.T) {
-	ctx := sdk.Context{}
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctx := sdk.Context{}.WithContext(context.Background())
+	ctlCtx := sdk.WrapSDKContext(ctx)
 
 	keeper := mockLienKeeper{
 		states: map[string]types.AccountState{
@@ -177,8 +177,9 @@ func TestGetAccountState(t *testing.T) {
 }
 
 func TestGetAccountState_badRequest(t *testing.T) {
-	ctx := sdk.Context{}
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctx := sdk.Context{}.WithContext(context.Background())
+	ctlCtx := sdk.WrapSDKContext(ctx)
+
 	keeper := mockLienKeeper{
 		states: map[string]types.AccountState{},
 	}
@@ -214,8 +215,9 @@ func TestGetAccountState_badRequest(t *testing.T) {
 }
 
 func TestSetLiened_badAddr(t *testing.T) {
-	ctx := sdk.Context{}
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctx := sdk.Context{}.WithContext(context.Background())
+	ctlCtx := sdk.WrapSDKContext(ctx)
+
 	keeper := mockLienKeeper{}
 	ph := NewPortHandler(&keeper)
 	msg := portMessage{
@@ -235,8 +237,9 @@ func TestSetLiened_badAddr(t *testing.T) {
 }
 
 func TestSetLiened_badDenom(t *testing.T) {
-	ctx := sdk.Context{}
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctx := sdk.Context{}.WithContext(context.Background())
+	ctlCtx := sdk.WrapSDKContext(ctx)
+
 	keeper := mockLienKeeper{}
 	ph := NewPortHandler(&keeper)
 	msg := portMessage{
@@ -256,8 +259,9 @@ func TestSetLiened_badDenom(t *testing.T) {
 }
 
 func TestSetLiened(t *testing.T) {
-	ctx := sdk.Context{}
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctx := sdk.Context{}.WithContext(context.Background())
+	ctlCtx := sdk.WrapSDKContext(ctx)
+
 	keeper := mockLienKeeper{}
 	ph := NewPortHandler(&keeper)
 	msg := portMessage{
@@ -336,8 +340,8 @@ func TestGetStaking(t *testing.T) {
 	keeper.delegations[addr4.String()] = []stakingTypes.Delegation{}
 
 	ph := NewPortHandler(&keeper)
-	ctx := sdk.Context{}
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctx := sdk.Context{}.WithContext(context.Background())
+	ctlCtx := sdk.WrapSDKContext(ctx)
 
 	pi := func(x int64) *sdk.Int {
 		n := i(x)

--- a/golang/cosmos/x/swingset/abci.go
+++ b/golang/cosmos/x/swingset/abci.go
@@ -2,6 +2,7 @@ package swingset
 
 import (
 	// "os"
+	"context"
 	"fmt"
 	"time"
 
@@ -88,7 +89,7 @@ func CommitBlock(keeper Keeper) error {
 		BlockHeight: endBlockHeight,
 		BlockTime:   endBlockTime,
 	}
-	_, err := keeper.BlockingSend(sdk.Context{}, action)
+	_, err := keeper.BlockingSend(sdk.Context{}.WithContext(context.Background()), action)
 
 	// fmt.Fprintf(os.Stderr, "COMMIT_BLOCK Returned from SwingSet: %s, %v\n", out, err)
 	if err != nil {
@@ -107,7 +108,7 @@ func AfterCommitBlock(keeper Keeper) error {
 		BlockHeight: endBlockHeight,
 		BlockTime:   endBlockTime,
 	}
-	_, err := keeper.BlockingSend(sdk.Context{}, action)
+	_, err := keeper.BlockingSend(sdk.Context{}.WithContext(context.Background()), action)
 
 	// fmt.Fprintf(os.Stderr, "AFTER_COMMIT_BLOCK Returned from SwingSet: %s, %v\n", out, err)
 	if err != nil {

--- a/golang/cosmos/x/swingset/swingset.go
+++ b/golang/cosmos/x/swingset/swingset.go
@@ -1,6 +1,7 @@
 package swingset
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -33,7 +34,8 @@ func NewPortHandler(k Keeper) vm.PortHandler {
 // Receive implements the vm.PortHandler method.
 // It receives and processes an inbound message, returning the
 // JSON-serialized response or an error.
-func (ph portHandler) Receive(ctx *vm.ControllerContext, str string) (string, error) {
+func (ph portHandler) Receive(cctx context.Context, str string) (string, error) {
+	ctx := sdk.UnwrapSDKContext(cctx)
 	var msg swingsetMessage
 	err := json.Unmarshal([]byte(str), &msg)
 	if err != nil {
@@ -42,7 +44,7 @@ func (ph portHandler) Receive(ctx *vm.ControllerContext, str string) (string, er
 
 	switch msg.Method {
 	case SwingStoreUpdateExportData:
-		return ph.handleSwingStoreUpdateExportData(ctx.Context, msg.Args)
+		return ph.handleSwingStoreUpdateExportData(ctx, msg.Args)
 
 	default:
 		return "", fmt.Errorf("unrecognized swingset method %s", msg.Method)

--- a/golang/cosmos/x/vbank/vbank.go
+++ b/golang/cosmos/x/vbank/vbank.go
@@ -121,8 +121,9 @@ func marshal(event vm.Jsonable) ([]byte, error) {
 	return json.Marshal(event)
 }
 
-func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string, err error) {
+func (ch portHandler) Receive(cctx context.Context, str string) (ret string, err error) {
 	// fmt.Println("vbank.go downcall", str)
+	ctx := sdk.UnwrapSDKContext(cctx)
 	keeper := ch.keeper
 
 	var msg portMessage
@@ -140,7 +141,7 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string
 		if err = sdk.ValidateDenom(msg.Denom); err != nil {
 			return "", fmt.Errorf("invalid denom %s: %s", msg.Denom, err)
 		}
-		coin := keeper.GetBalance(ctx.Context, addr, msg.Denom)
+		coin := keeper.GetBalance(ctx, addr, msg.Denom)
 		packet := coin.Amount.String()
 		if err == nil {
 			bytes, err := json.Marshal(&packet)
@@ -162,12 +163,12 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string
 			return "", fmt.Errorf("cannot convert %s to int", msg.Amount)
 		}
 		coins := sdk.NewCoins(sdk.NewCoin(msg.Denom, value))
-		if err := keeper.GrabCoins(ctx.Context, addr, coins); err != nil {
+		if err := keeper.GrabCoins(ctx, addr, coins); err != nil {
 			return "", fmt.Errorf("cannot grab %s coins: %s", coins.Sort().String(), err)
 		}
 		addressToBalances := make(map[string]sdk.Coins, 1)
 		addressToBalances[msg.Sender] = sdk.NewCoins(sdk.NewInt64Coin(msg.Denom, 1))
-		bz, err := marshal(getBalanceUpdate(ctx.Context, keeper, addressToBalances))
+		bz, err := marshal(getBalanceUpdate(ctx, keeper, addressToBalances))
 		if err != nil {
 			return "", err
 		}
@@ -190,12 +191,12 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string
 			return "", fmt.Errorf("cannot convert %s to int", msg.Amount)
 		}
 		coins := sdk.NewCoins(sdk.NewCoin(msg.Denom, value))
-		if err := keeper.SendCoins(ctx.Context, addr, coins); err != nil {
+		if err := keeper.SendCoins(ctx, addr, coins); err != nil {
 			return "", fmt.Errorf("cannot give %s coins: %s", coins.Sort().String(), err)
 		}
 		addressToBalances := make(map[string]sdk.Coins, 1)
 		addressToBalances[msg.Recipient] = sdk.NewCoins(sdk.NewInt64Coin(msg.Denom, 1))
-		bz, err := marshal(getBalanceUpdate(ctx.Context, keeper, addressToBalances))
+		bz, err := marshal(getBalanceUpdate(ctx, keeper, addressToBalances))
 		if err != nil {
 			return "", err
 		}
@@ -211,20 +212,20 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string
 			return "", fmt.Errorf("cannot convert %s to int", msg.Amount)
 		}
 		coins := sdk.NewCoins(sdk.NewCoin(msg.Denom, value))
-		if err := keeper.StoreRewardCoins(ctx.Context, coins); err != nil {
+		if err := keeper.StoreRewardCoins(ctx, coins); err != nil {
 			return "", fmt.Errorf("cannot store reward %s coins: %s", coins.Sort().String(), err)
 		}
 		if err != nil {
 			return "", err
 		}
-		state := keeper.GetState(ctx.Context)
+		state := keeper.GetState(ctx)
 		state.RewardPool = state.RewardPool.Add(coins...)
-		keeper.SetState(ctx.Context, state)
+		keeper.SetState(ctx, state)
 		// We don't supply the module balance, since the controller shouldn't know.
 		ret = "true"
 
 	case "VBANK_GET_MODULE_ACCOUNT_ADDRESS":
-		addr := keeper.GetModuleAccountAddress(ctx.Context, msg.ModuleName).String()
+		addr := keeper.GetModuleAccountAddress(ctx, msg.ModuleName).String()
 		if len(addr) == 0 {
 			return "", fmt.Errorf("module account %s not found", msg.ModuleName)
 		}

--- a/golang/cosmos/x/vbank/vbank_test.go
+++ b/golang/cosmos/x/vbank/vbank_test.go
@@ -284,7 +284,7 @@ func Test_Receive_GetBalance(t *testing.T) {
 	}}
 	keeper, ctx := makeTestKit(nil, bank)
 	ch := NewPortHandler(AppModule{}, keeper)
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctlCtx := sdk.WrapSDKContext(ctx)
 
 	ret, err := ch.Receive(ctlCtx, `{
 		"type": "VBANK_GET_BALANCE",
@@ -312,7 +312,7 @@ func Test_Receive_Give(t *testing.T) {
 	}}
 	keeper, ctx := makeTestKit(nil, bank)
 	ch := NewPortHandler(AppModule{}, keeper)
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctlCtx := sdk.WrapSDKContext(ctx)
 
 	ret, err := ch.Receive(ctlCtx, `{
 		"type": "VBANK_GIVE",
@@ -349,7 +349,7 @@ func Test_Receive_GiveToRewardDistributor(t *testing.T) {
 	bank := &mockBank{}
 	keeper, ctx := makeTestKit(nil, bank)
 	ch := NewPortHandler(AppModule{}, keeper)
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctlCtx := sdk.WrapSDKContext(ctx)
 
 	tests := []struct {
 		name          string
@@ -474,7 +474,7 @@ func Test_Receive_Grab(t *testing.T) {
 	}}
 	keeper, ctx := makeTestKit(nil, bank)
 	ch := NewPortHandler(AppModule{}, keeper)
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctlCtx := sdk.WrapSDKContext(ctx)
 
 	ret, err := ch.Receive(ctlCtx, `{
 		"type": "VBANK_GRAB",
@@ -787,7 +787,7 @@ func Test_Module_Account(t *testing.T) {
 	keeper, ctx := makeTestKit(acct, nil)
 	am := AppModule{keeper: keeper}
 	ch := NewPortHandler(am, keeper)
-	ctlCtx := &vm.ControllerContext{Context: ctx}
+	ctlCtx := sdk.WrapSDKContext(ctx)
 
 	mod1 := "vbank/reserve"
 	ret, err := ch.Receive(ctlCtx, `{

--- a/golang/cosmos/x/vibc/ibc.go
+++ b/golang/cosmos/x/vibc/ibc.go
@@ -1,6 +1,7 @@
 package vibc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -63,8 +64,9 @@ func NewIBCModule(keeper Keeper) IBCModule {
 	}
 }
 
-func (ch IBCModule) Receive(ctx *vm.ControllerContext, str string) (ret string, err error) {
+func (ch IBCModule) Receive(cctx context.Context, str string) (ret string, err error) {
 	// fmt.Println("ibc.go downcall", str)
+	ctx := sdk.UnwrapSDKContext(cctx)
 	keeper := ch.keeper
 
 	msg := new(portMessage)
@@ -80,7 +82,7 @@ func (ch IBCModule) Receive(ctx *vm.ControllerContext, str string) (ret string, 
 	switch msg.Method {
 	case "sendPacket":
 		seq, ok := keeper.GetNextSequenceSend(
-			ctx.Context,
+			ctx,
 			msg.Packet.SourcePort,
 			msg.Packet.SourceChannel,
 		)
@@ -91,7 +93,7 @@ func (ch IBCModule) Receive(ctx *vm.ControllerContext, str string) (ret string, 
 		timeoutTimestamp := msg.Packet.TimeoutTimestamp
 		if msg.Packet.TimeoutHeight.IsZero() && msg.Packet.TimeoutTimestamp == 0 {
 			// Use the relative timeout if no absolute timeout is specifiied.
-			timeoutTimestamp = uint64(ctx.Context.BlockTime().UnixNano()) + msg.RelativeTimeoutNs
+			timeoutTimestamp = uint64(ctx.BlockTime().UnixNano()) + msg.RelativeTimeoutNs
 		}
 
 		packet := channeltypes.NewPacket(
@@ -100,7 +102,7 @@ func (ch IBCModule) Receive(ctx *vm.ControllerContext, str string) (ret string, 
 			msg.Packet.DestinationPort, msg.Packet.DestinationChannel,
 			msg.Packet.TimeoutHeight, timeoutTimestamp,
 		)
-		err = keeper.SendPacket(ctx.Context, packet)
+		err = keeper.SendPacket(ctx, packet)
 		if err == nil {
 			bytes, err := json.Marshal(&packet)
 			if err == nil {
@@ -109,14 +111,14 @@ func (ch IBCModule) Receive(ctx *vm.ControllerContext, str string) (ret string, 
 		}
 
 	case "receiveExecuted":
-		err = keeper.WriteAcknowledgement(ctx.Context, msg.Packet, msg.Ack)
+		err = keeper.WriteAcknowledgement(ctx, msg.Packet, msg.Ack)
 		if err == nil {
 			ret = "true"
 		}
 
 	case "startChannelOpenInit":
 		err = keeper.ChanOpenInit(
-			ctx.Context, stringToOrder(msg.Order), msg.Hops,
+			ctx, stringToOrder(msg.Order), msg.Hops,
 			msg.Packet.SourcePort,
 			msg.Packet.DestinationPort,
 			msg.Version,
@@ -126,19 +128,19 @@ func (ch IBCModule) Receive(ctx *vm.ControllerContext, str string) (ret string, 
 		}
 
 	case "startChannelCloseInit":
-		err = keeper.ChanCloseInit(ctx.Context, msg.Packet.SourcePort, msg.Packet.SourceChannel)
+		err = keeper.ChanCloseInit(ctx, msg.Packet.SourcePort, msg.Packet.SourceChannel)
 		if err == nil {
 			ret = "true"
 		}
 
 	case "bindPort":
-		err = keeper.BindPort(ctx.Context, msg.Packet.SourcePort)
+		err = keeper.BindPort(ctx, msg.Packet.SourcePort)
 		if err == nil {
 			ret = "true"
 		}
 
 	case "timeoutExecuted":
-		err = keeper.TimeoutExecuted(ctx.Context, msg.Packet)
+		err = keeper.TimeoutExecuted(ctx, msg.Packet)
 		if err == nil {
 			ret = "true"
 		}

--- a/golang/cosmos/x/vstorage/vstorage_test.go
+++ b/golang/cosmos/x/vstorage/vstorage_test.go
@@ -1,6 +1,7 @@
 package vstorage
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -14,7 +15,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	agorictypes "github.com/Agoric/agoric-sdk/golang/cosmos/types"
-	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
@@ -32,7 +32,7 @@ type testKit struct {
 	keeper  Keeper
 	handler vstorageHandler
 	ctx     sdk.Context
-	cctx    *vm.ControllerContext
+	cctx    context.Context
 }
 
 func makeTestKit() testKit {
@@ -45,14 +45,14 @@ func makeTestKit() testKit {
 		panic(err)
 	}
 	ctx := sdk.NewContext(ms, tmproto.Header{}, false, log.NewNopLogger())
-	cctx := &vm.ControllerContext{Context: ctx}
+	cctx := sdk.WrapSDKContext(ctx)
 	handler := vstorageHandler{keeper}
 	return testKit{keeper, handler, ctx, cctx}
 }
 
 func callReceive(
 	handler vstorageHandler,
-	cctx *vm.ControllerContext,
+	cctx context.Context,
 	method string,
 	args []interface{},
 ) (string, error) {

--- a/packages/deployment/scripts/capture-integration-results.sh
+++ b/packages/deployment/scripts/capture-integration-results.sh
@@ -14,6 +14,7 @@ home=/home/ag-chain-cosmos/.ag-chain-cosmos
 
 for node in validator{0,1}; do
   "$thisdir/setup.sh" ssh "$node" cat "$home/config/genesis.json" > "$RESULTSDIR/$node-genesis.json" || true
+  "$thisdir/setup.sh" ssh "$node" cat /var/log/journal/ag-chain-cosmos.service.log > "$RESULTSDIR/$node-journal.log" || true
   "$thisdir/setup.sh" ssh "$node" cat "$home/data/chain.slog" > "$RESULTSDIR/$node.slog" || \
     "$thisdir/setup.sh" ssh "$node" cat "$home/data/agoric/flight-recorder.bin" > "$RESULTSDIR/$node-flight-recorder.bin" || true
 done


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #7928
refs: #8002

## Description

Makes the Golang changes needed to implement `agd start --split-vm`.  The JS changes are in a stacked PR, #8002.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Separation of `agd` and `agvm` processes can lead to better isolation.

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

May slightly degrade performance when using the `--split-vm` flag, as communications happen over an OS pipe and not with FFI within the same process's heap.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

Initially, there will be no advertised change of agd behaviour.  `--split-vm` is opt-in, and while useful for debugging, will not be the default until it is battle hardened.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Manual and docker integration tests are based on the followup stacked PR.
