### PR TITLE
feat(zoe): internal transferables, a Spike

### DIFF
--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -42,6 +42,7 @@ const missing = /** @type {const} */ ([
   'details',
   'Fail',
   'quote',
+  'bare',
   'makeAssert',
 ]).filter(name => globalAssert[name] === undefined);
 if (missing.length > 0) {

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -344,6 +344,7 @@
  *   details: DetailsTag,
  *   Fail: FailTag,
  *   quote: AssertQuote,
+ *   bare: AssertQuote,
  *   makeAssert: MakeAssert,
  * } } Assert
  */

--- a/packages/swingset-liveslots/src/cache.js
+++ b/packages/swingset-liveslots/src/cache.js
@@ -17,7 +17,7 @@ import { Fail } from '@agoric/assert';
 /**
  * @callback CacheDelete
  * @param {string} key
- * @returns {void}
+ * @returns {boolean}
  *
  * @callback CacheFlush
  * @returns {void}
@@ -82,8 +82,9 @@ export function makeCache(readBacking, writeBacking, deleteBacking) {
     },
     delete: key => {
       assert.typeof(key, 'string');
-      stash.delete(key);
+      const result = stash.delete(key);
       dirtyKeys.add(key);
+      return result;
     },
     flush: () => {
       const keys = [...dirtyKeys.keys()];

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -928,8 +928,8 @@ export const makeVirtualObjectManager = (
       }
     };
 
-    // The contextCache holds the {state,self,revoke}
-    // or { state, facets, revoke } "context"
+    // The contextCache holds the
+    // { state, self, revoke } or { state, facets, revoke } "context"
     // object, needed by behavior functions. We keep this in a (per-crank)
     // cache because creating one requires knowledge of the state property
     // names, which requires a DB read. The property names are fixed at

--- a/packages/swingset-liveslots/src/virtualObjectManager.js
+++ b/packages/swingset-liveslots/src/virtualObjectManager.js
@@ -16,9 +16,9 @@ import {
 
 /** @template T @typedef {import('@agoric/vat-data').DefineKindOptions<T>} DefineKindOptions */
 
-const { hasOwn, defineProperty, getOwnPropertyNames } = Object;
+const { hasOwn, defineProperty, getOwnPropertyNames, entries } = Object;
 const { ownKeys } = Reflect;
-const { quote: q } = assert;
+const { quote: q, bare: b } = assert;
 
 // import { kdebug } from './kdebug.js';
 
@@ -141,9 +141,8 @@ const makeContextCache = (makeState, makeContext) => {
  * @param {*} getSlotForVal
  * @returns {ContextProvider}
  */
-const makeContextProvider = (contextCache, getSlotForVal) => {
-  return harden(rep => contextCache.get(getSlotForVal(rep)));
-};
+const makeContextProvider = (contextCache, getSlotForVal) =>
+  harden(rep => contextCache.get(getSlotForVal(rep)));
 
 const makeContextProviderKit = (contextCache, getSlotForVal, facetNames) => {
   /** @type { Record<string, any> } */
@@ -260,15 +259,15 @@ const makeFacets = (
 };
 
 const insistDurableCapdata = (vrm, what, capdata, valueFor) => {
-  capdata.slots.forEach((vref, idx) => {
+  for (const [idx, vref] of entries(capdata.slots)) {
     if (!vrm.isDurable(vref)) {
       if (valueFor) {
-        Fail`value for ${what} is not durable: slot ${q(idx)} of ${capdata}`;
+        Fail`value for ${what} is not durable: slot ${b(idx)} of ${capdata}`;
       } else {
-        Fail`${what} is not durable: slot ${q(idx)} of ${capdata}`;
+        Fail`${what} is not durable: slot ${b(idx)} of ${capdata}`;
       }
     }
-  });
+  }
 };
 
 const insistSameCapData = (oldCD, newCD) => {
@@ -281,11 +280,11 @@ const insistSameCapData = (oldCD, newCD) => {
   if (oldCD.slots.length !== newCD.slots.length) {
     Fail`durable Kind stateShape mismatch (slots.length)`;
   }
-  oldCD.slots.forEach((oldVref, idx) => {
+  for (const [idx, oldVref] of entries(oldCD.slots)) {
     if (newCD.slots[idx] !== oldVref) {
       Fail`durable Kind stateShape mismatch (slot[${idx}])`;
     }
-  });
+  }
 };
 
 /**
@@ -707,7 +706,7 @@ export const makeVirtualObjectManager = (
     durableKindDescriptor = undefined, // only for durables
   ) => {
     const {
-      finish,
+      finish = undefined,
       stateShape = undefined,
       thisfulMethods = false,
       interfaceGuard = undefined,
@@ -912,15 +911,25 @@ export const makeVirtualObjectManager = (
     const makeContext = (baseRef, state) => {
       // baseRef came from valToSlot, so must be in slotToVal
       const val = requiredValForSlot(baseRef);
+      const revoke = () => contextCache.delete(baseRef);
       // val is either 'self' or the facet record
       if (multifaceted) {
-        return harden({ state, facets: val });
+        return harden({
+          state,
+          facets: val,
+          revoke,
+        });
       } else {
-        return harden({ state, self: val });
+        return harden({
+          state,
+          self: val,
+          revoke,
+        });
       }
     };
 
-    // The contextCache holds the {state,self} or {state,facets} "context"
+    // The contextCache holds the {state,self,revoke}
+    // or { state, facets, revoke } "context"
     // object, needed by behavior functions. We keep this in a (per-crank)
     // cache because creating one requires knowledge of the state property
     // names, which requires a DB read. The property names are fixed at
@@ -974,9 +983,9 @@ export const makeVirtualObjectManager = (
       let doMoreGC = false;
       const record = dataCache.get(baseRef);
       for (const valueCD of Object.values(record.capdatas)) {
-        valueCD.slots.forEach(vref => {
+        for (const vref of valueCD.slots) {
           doMoreGC = vrm.removeReachableVref(vref) || doMoreGC;
-        });
+        }
       }
       dataCache.delete(baseRef);
       return doMoreGC;
@@ -1015,6 +1024,7 @@ export const makeVirtualObjectManager = (
         if (isDurable) {
           insistDurableCapdata(vrm, prop, valueCD, true);
         }
+        // eslint-disable-next-line github/array-foreach
         valueCD.slots.forEach(vrm.addReachableVref);
         capdatas[prop] = valueCD;
         valueMap.set(prop, value);

--- a/packages/vat-data/src/exo-utils.js
+++ b/packages/vat-data/src/exo-utils.js
@@ -81,6 +81,13 @@ export const makeExoUtils = VatData => {
     );
   harden(prepareKindMulti);
 
+  /**
+   * TODO reuse types ClassContext, ClassContextKit, etc from @endo/exo
+   *
+   * @callback RevokeExo
+   * @returns {boolean}
+   */
+
   // TODO interfaceGuard type https://github.com/Agoric/agoric-sdk/issues/6206
   /**
    * @template {(...args: any) => any} I init state function
@@ -88,8 +95,16 @@ export const makeExoUtils = VatData => {
    * @param {string} tag
    * @param {any} interfaceGuard
    * @param {I} init
-   * @param {T & ThisType<{ self: T, state: ReturnType<I> }>} methods
-   * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
+   * @param {T & ThisType<{
+   *   self: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }>} methods
+   * @param {DefineKindOptions<{
+   *   self: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }>} [options]
    * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
    */
   const defineVirtualExoClass = (tag, interfaceGuard, init, methods, options) =>
@@ -107,8 +122,16 @@ export const makeExoUtils = VatData => {
    * @param {string} tag
    * @param {any} interfaceGuardKit
    * @param {I} init
-   * @param {T & ThisType<{ facets: T, state: ReturnType<I> }> } facets
-   * @param {DefineKindOptions<{ facets: T, state: ReturnType<I> }>} [options]
+   * @param {T & ThisType<{
+   *   facets: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }> } facets
+   * @param {DefineKindOptions<{
+   *   facets: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }>} [options]
    * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
    */
   const defineVirtualExoClassKit = (
@@ -132,8 +155,16 @@ export const makeExoUtils = VatData => {
    * @param {DurableKindHandle} kindHandle
    * @param {any} interfaceGuard
    * @param {I} init
-   * @param {T & ThisType<{ self: T, state: ReturnType<I> }>} methods
-   * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
+   * @param {T & ThisType<{
+   *   self: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }>} methods
+   * @param {DefineKindOptions<{
+   *   self: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }>} [options]
    * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
    */
   const defineDurableExoClass = (
@@ -157,8 +188,16 @@ export const makeExoUtils = VatData => {
    * @param {DurableKindHandle} kindHandle
    * @param {any} interfaceGuardKit
    * @param {I} init
-   * @param {T & ThisType<{ facets: T, state: ReturnType<I>}> } facets
-   * @param {DefineKindOptions<{ facets: T, state: ReturnType<I>}>} [options]
+   * @param {T & ThisType<{
+   *   facets: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }> } facets
+   * @param {DefineKindOptions<{
+   *   facets: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }>} [options]
    * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
    */
   const defineDurableExoClassKit = (
@@ -183,8 +222,16 @@ export const makeExoUtils = VatData => {
    * @param {string} kindName
    * @param {any} interfaceGuard
    * @param {I} init
-   * @param {T & ThisType<{ self: T, state: ReturnType<I> }>} methods
-   * @param {DefineKindOptions<{ self: T, state: ReturnType<I> }>} [options]
+   * @param {T & ThisType<{
+   *   self: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }>} methods
+   * @param {DefineKindOptions<{
+   *   self: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }>} [options]
    * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
    */
   const prepareExoClass = (
@@ -212,8 +259,16 @@ export const makeExoUtils = VatData => {
    * @param {string} kindName
    * @param {any} interfaceGuardKit
    * @param {I} init
-   * @param {T & ThisType<{ facets: T, state: ReturnType<I> }> } facets
-   * @param {DefineKindOptions<{ facets: T, state: ReturnType<I> }>} [options]
+   * @param {T & ThisType<{
+   *   facets: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }> } facets
+   * @param {DefineKindOptions<{
+   *   facets: T,
+   *   state: ReturnType<I>,
+   *   revoke: RevokeExo,
+   * }>} [options]
    * @returns {(...args: Parameters<I>) => (T & RemotableBrand<{}, T>)}
    */
   const prepareExoClassKit = (

--- a/packages/vat-data/test/test-revoke-virtual.js
+++ b/packages/vat-data/test/test-revoke-virtual.js
@@ -1,0 +1,126 @@
+// Modeled on test-revoke-heap-classes.js
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { M } from '@agoric/store';
+import {
+  defineVirtualExoClass,
+  defineVirtualExoClassKit,
+} from '../src/exo-utils.js';
+
+const { apply } = Reflect;
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+  done: M.call().returns(M.boolean()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+test('test revoke defineVirtualExoClass', t => {
+  const makeUpCounter = defineVirtualExoClass(
+    'UpCounter',
+    UpCounterI,
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      incr(y = 1) {
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+      done() {
+        const { revoke } = this;
+        return revoke();
+      },
+    },
+  );
+  const upCounter = makeUpCounter(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(upCounter.done(), true);
+  t.throws(() => upCounter.incr(1), {
+    message:
+      '"In \\"incr\\" method of (UpCounter)" may only be applied to a valid instance: "[Alleged: UpCounter]"',
+  });
+});
+
+test('test revoke defineVirtualExoClassKit', t => {
+  const makeCounterKit = defineVirtualExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+        done() {
+          const { revoke } = this;
+          return revoke();
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(downCounter.decr(), 7);
+  t.is(upCounter.done(), true);
+  t.throws(() => upCounter.incr(3), {
+    message:
+      '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter up]"',
+  });
+  t.throws(() => downCounter.decr(), {
+    message:
+      '"In \\"decr\\" method of (Counter down)" may only be applied to a valid instance: "[Alleged: Counter down]"',
+  });
+});
+
+test('test virtual facet cross-talk', t => {
+  const makeCounterKit = defineVirtualExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+        done() {
+          const { revoke } = this;
+          return revoke();
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.throws(() => apply(upCounter.incr, downCounter, [2]), {
+    message: 'illegal cross-facet access',
+  });
+});


### PR DESCRIPTION
Alternative to https://github.com/Agoric/agoric-sdk/pull/8008

#endo-branch: markm-revocables-internal

Assumes and builds on https://github.com/endojs/endo/pull/1668

Staged on https://github.com/Agoric/agoric-sdk/pull/7116

- [x] Virtual and durable revocation parallel to https://github.com/endojs/endo/pull/1668
- [ ] When payments get used-up, they revoke themselves
- [ ] When payments revoke themselves, liveslots gets notified 
- [ ] so liveslots can drop the export, relieving distributed gc pressure
- [ ] Trivial use-object demonstration, where the use-object has a vaults-like `makeTransferInvitation` method
- [ ] `makeTransferInvitation` revokes its use-object
- [ ] The transfer invitation legibly describes the use-object's relevant state as of that moment.
- [ ] The transfer invitation can be redeemed for a new equivalent-enough use object
- [ ] The transfer invitation can be redeemed after upgrading the contract

In Zoe, we issue many usage rights as invitations so that they can also be a) assayable, and b) transferable erights. If the recipient receives the right from a potentially untrusted counter-party rather than from the contract itself, or if the recipient does want to transfer exclusive rights, then an invitation is needed. However, for many interesting usage rights, they are obtained directly from the contract, and they are only exercised, never transferred. For these users life would be simpler if they did not first need to get an invitation. But this only works when the direct usage right can be turned into a transferable, assayable invitation on demand. Vaults already do something like this for themselves. The goal of this PR is to make this easier, as well as to have the implied revocations (both of the use-object and of used-up payments) notify liveslots, in order to relieve distributed gc pressure.

All this can happen on current Zoe. However, once settled, it forms the seeds for Zoe2. 
