### PR TITLE
feat(vat-data): virtual exos are revocable

### DIFF
--- a/packages/swingset-liveslots/src/cache.js
+++ b/packages/swingset-liveslots/src/cache.js
@@ -17,7 +17,7 @@ import { Fail } from '@agoric/assert';
 /**
  * @callback CacheDelete
  * @param {string} key
- * @returns {void}
+ * @returns {boolean}
  *
  * @callback CacheFlush
  * @returns {void}
@@ -82,8 +82,9 @@ export function makeCache(readBacking, writeBacking, deleteBacking) {
     },
     delete: key => {
       assert.typeof(key, 'string');
-      stash.delete(key);
+      const result = stash.delete(key);
       dirtyKeys.add(key);
+      return result;
     },
     flush: () => {
       const keys = [...dirtyKeys.keys()];

--- a/packages/swingset-liveslots/src/vatDataTypes.d.ts
+++ b/packages/swingset-liveslots/src/vatDataTypes.d.ts
@@ -13,12 +13,19 @@ import type {
   WeakMapStore,
   WeakSetStore,
 } from '@agoric/store';
+import type {
+  FarClassOptions,
+  StateShape,
+  Context,
+  KitContext,
+  Revoker,
+  ReceiveRevoker,
+} from '@endo/exo';
 import type { makeWatchedPromiseManager } from './watchedPromises.js';
 
 // TODO should be moved into @endo/patterns and eventually imported here
 // instead of this local definition.
 export type InterfaceGuardKit = Record<string, InterfaceGuard>;
-
 export type { MapStore, Pattern };
 
 // This needs `any` values.  If they were `unknown`, code that uses Baggage
@@ -88,7 +95,12 @@ export type DefineKindOptions<C> = {
    * If provided, it describes the shape of all state records of instances
    * of this kind.
    */
-  stateShape?: { [name: string]: Pattern };
+  stateShape?: StateShape;
+
+  /**
+   * If provided, it is called with a revoke function as an argument.
+   */
+  receiveRevoker?: ReceiveRevoker;
 
   /**
    * Intended for internal use only.

--- a/packages/vat-data/test/test-revoke-virtual.js
+++ b/packages/vat-data/test/test-revoke-virtual.js
@@ -93,8 +93,9 @@ test('test revoke defineVirtualExoClassKit', t => {
     message:
       '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter up]"',
   });
+  t.is(downCounter.decr(), 6);
   // @ts-expect-error Does not understand that `revoke` is a function.
-  t.is(revoke(downCounter), false);
+  t.is(revoke(downCounter), true);
   t.throws(() => downCounter.decr(), {
     message:
       '"In \\"decr\\" method of (Counter down)" may only be applied to a valid instance: "[Alleged: Counter down]"',

--- a/packages/vat-data/test/test-revoke-virtual.js
+++ b/packages/vat-data/test/test-revoke-virtual.js
@@ -1,0 +1,131 @@
+// Modeled on test-revoke-heap-classes.js
+
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { M } from '@agoric/store';
+import {
+  defineVirtualExoClass,
+  defineVirtualExoClassKit,
+} from '../src/exo-utils.js';
+
+const { apply } = Reflect;
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+test('test revoke defineVirtualExoClass', t => {
+  let revoke;
+  const makeUpCounter = defineVirtualExoClass(
+    'UpCounter',
+    UpCounterI,
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      incr(y = 1) {
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+    },
+    {
+      receiveRevoker(r) {
+        revoke = r;
+      },
+    },
+  );
+  const upCounter = makeUpCounter(3);
+  t.is(upCounter.incr(5), 8);
+  // @ts-expect-error Does not understand that `revoke` is a function.
+  t.is(revoke(upCounter), true);
+  t.throws(() => upCounter.incr(1), {
+    message:
+      '"In \\"incr\\" method of (UpCounter)" may only be applied to a valid instance: "[Alleged: UpCounter]"',
+  });
+});
+
+test('test revoke defineVirtualExoClassKit', t => {
+  let revoke;
+  const makeCounterKit = defineVirtualExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+    {
+      receiveRevoker(r) {
+        revoke = r;
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(downCounter.decr(), 7);
+  // @ts-expect-error Does not understand that `revoke` is a function.
+  t.is(revoke(upCounter), true);
+  t.throws(() => upCounter.incr(3), {
+    message:
+      '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter up]"',
+  });
+  // @ts-expect-error Does not understand that `revoke` is a function.
+  t.is(revoke(downCounter), false);
+  t.throws(() => downCounter.decr(), {
+    message:
+      '"In \\"decr\\" method of (Counter down)" may only be applied to a valid instance: "[Alleged: Counter down]"',
+  });
+});
+
+test('test virtual facet cross-talk', t => {
+  const makeCounterKit = defineVirtualExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.throws(() => apply(upCounter.incr, downCounter, [2]), {
+    message: 'illegal cross-facet access',
+  });
+});


### PR DESCRIPTION
refs: #2070 

Alternative to https://github.com/Agoric/agoric-sdk/pull/8014 with external revocability

Extracted from Spike at #8008 because it is already mergeable without #8008's other support

Mirrors https://github.com/endojs/endo/pull/1666 but does not depend on it.