### PR TITLE
feat(zoe): first ownable object

### DIFF
--- a/packages/zoe/src/contractSupport/ownableKit.js
+++ b/packages/zoe/src/contractSupport/ownableKit.js
@@ -1,0 +1,94 @@
+import { M } from '@endo/patterns';
+import { prepareExo } from '@agoric/vat-data';
+import { OfferHandlerI } from '../typeGuards.js';
+
+/** @typedef {import('@agoric/vat-data').Baggage} Baggage */
+
+const { apply } = Reflect;
+
+const TransferProposalShape = harden({
+  give: {},
+  want: {},
+  exit: {
+    onDemand: {},
+  },
+});
+
+const defaultGetSelfFromThis = {
+  getSelfFromThis() {
+    const { self } = this;
+    return self;
+  },
+}.getSelfFromThis;
+
+export const makeOwnableKit = (
+  zcf,
+  baggage,
+  detailsShape,
+  makeOwnableObject,
+  getSelfFromThis = defaultGetSelfFromThis,
+) => {
+  const OwnableObjectMethodGuards = harden({
+    incr: M.call().returns(M.bigint()),
+    getCustomDetails: M.call().returns(detailsShape),
+    makeTransferInvitation: M.call().returns(M.promise()),
+  });
+
+  let revokeTransferHandler;
+
+  const transferHandler = prepareExo(
+    baggage,
+    'TransferHandler',
+    OfferHandlerI,
+    {
+      handle(seat) {
+        // @ts-expect-error Usual self-typing problem
+        const { self } = this;
+        // TODO implement *Seat.getDetails()
+        const { customDetails } = seat.getDetails();
+        seat.exit();
+        revokeTransferHandler(self);
+        return makeOwnableObject(customDetails);
+      },
+    },
+    {
+      receiveRevoker(revoke) {
+        revokeTransferHandler = revoke;
+      },
+    },
+  );
+
+  let revokeOwnableObject;
+
+  const ownableObjectMethods = harden({
+    makeTransferInvitation() {
+      const self = apply(getSelfFromThis, this, []);
+      const invitation = zcf.makeInvitation(
+        // eslint-disable-next-line no-use-before-define
+        transferHandler,
+        'transfer',
+        self.getCustomDetails(),
+        TransferProposalShape,
+      );
+      revokeOwnableObject(self);
+      return invitation;
+    },
+  });
+
+  const ownableObjectOptions = harden({
+    receiveRevoker(revoke) {
+      revokeOwnableObject = revoke;
+    },
+  });
+
+  return harden({
+    // note: includes getCustomDetails
+    OwnableObjectMethodGuards,
+    // note: does not include getCustomDetails,
+    // so getCustomDetails is effectively an abstract method that must be
+    // concretely implemented.
+    ownableObjectMethods,
+    ownableObjectOptions,
+  });
+};
+harden(makeOwnableKit);

--- a/packages/zoe/src/contracts/ownable-counter.js
+++ b/packages/zoe/src/contracts/ownable-counter.js
@@ -1,0 +1,92 @@
+import { M } from '@endo/patterns';
+import { prepareExo, prepareExoClass } from '@agoric/vat-data';
+import { makeOwnableKit } from '../contractSupport/ownableKit.js';
+
+/** @typedef {import('@agoric/vat-data').Baggage} Baggage */
+
+const CounterDetailsShape = harden({
+  count: M.bigint(),
+});
+
+/**
+ * @param {ZCF} zcf
+ * @param {{ count: bigint}} privateArgs
+ * @param {Baggage} instanceBaggage
+ */
+export const start = async (zcf, privateArgs, instanceBaggage) => {
+  const { count: startCount = 0n } = privateArgs;
+  assert.typeof(startCount, 'bigint');
+
+  // for use by upgraded versions.
+  const firstTime = !instanceBaggage.has('count');
+  if (firstTime) {
+    instanceBaggage.init('count', startCount);
+  }
+
+  const makeForwardOwnableCounter = customDetails =>
+    // eslint-disable-next-line no-use-before-define
+    makeOwnableCounter(customDetails);
+
+  const {
+    OwnableObjectMethodGuards,
+    ownableObjectMethods,
+    ownableObjectOptions,
+  } = makeOwnableKit(
+    zcf,
+    instanceBaggage,
+    CounterDetailsShape,
+    makeForwardOwnableCounter,
+  );
+
+  const OwnableCounterI = M.interface('OwnableCounter', {
+    ...OwnableObjectMethodGuards,
+    incr: M.call().returns(M.bigint()),
+  });
+
+  const makeOwnableCounter = prepareExoClass(
+    instanceBaggage,
+    'OwnableCounter',
+    OwnableCounterI,
+    customDetails => {
+      const { count } = customDetails;
+      assert(count === instanceBaggage.get('count'));
+      return harden({});
+    },
+    {
+      ...ownableObjectMethods,
+
+      incr() {
+        const count = instanceBaggage.get('count') + 1n;
+        instanceBaggage.set('count', count);
+        return count;
+      },
+
+      // note: abstract method must be concretely implemented
+      getCustomDetails() {
+        return harden({
+          count: instanceBaggage.get('count'),
+        });
+      },
+    },
+
+    {
+      ...ownableObjectOptions,
+    },
+  );
+
+  const ViewCounterI = M.interface('ViewCounter', {
+    view: M.call().returns(M.bigint()),
+  });
+
+  const viewCounter = prepareExo(instanceBaggage, 'ViewCounter', ViewCounterI, {
+    view() {
+      return instanceBaggage.get('count');
+    },
+  });
+
+  return harden({
+    creatorFacet: makeOwnableCounter(startCount),
+    publicFacet: viewCounter,
+  });
+};
+harden(start);


### PR DESCRIPTION
Staged on https://github.com/Agoric/agoric-sdk/pull/8020

The basic idea of an "ownable object" is to provide general and lower level support for approximately the pattern that vaults implement manually in an adhoc manner: A *ownable object* is an object with a `makeTransferInvitation` method that revokes the object itself, in the sense of inactivating it — it no longer provides any authority. Instead, the exclusively transferable portion of its authority is encapsulated by the returned invitation, in an allegedly legible manner. That invitation can be redeemed, via an `offer` , for a new ownable object in which the transferable authority from the original ownable object is now exercisable.

We call this an "ownable object" since the rights of ownership include
- the right to exercise (use)
- the right to exclusively transfer the rights of ownership
- the right to exclude others from being able to exercise and transfer
- the ability to legibly offer the exclusive transfer of ownership

Objects are about rights to exercise (use) and share, but not transfer, and not legibly.

ERTP is about legible exclusive transfer but not exercise.

The lifecycle of an ownable objects, transmuting between an ephemeral ownable object and an invitation to get a new “equivalent” ownable object, combines all attributes together. But the attributes are never directly present at the same time. That’s why it is the lifecycle that combines these.

This notion of "ownable" and "ownership rights" has strong echoes in programming language notions of "ownership types", "linear types", and "affine types". However, none of these, as far as we are aware, has the two-phase lifecycle of our ownable objects. Nor do they provide for legibility of offers to transfer, which is crucial for secure exchange and offer safety.

See [*Necessity* specifications for robustness](https://dl.acm.org/doi/abs/10.1145/3563317)