### PR TITLE
chore(agoric-cli): Clean up `agoric start` code

### DIFF
--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -161,6 +161,12 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     }
   };
 
+  const rmVerbose = async filePath => {
+    log(chalk.green(`removing ${filePath}`));
+    // rm is available on all the unix-likes, so use it for speed.
+    await pspawn('rm', ['-rf', filePath]);
+  };
+
   let agSolo;
   let agSoloBuild;
   if (opts.dockerTag) {
@@ -177,9 +183,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     await null;
     if (popts.reset) {
-      log(chalk.green(`removing ${serverDir}`));
-      // rm is available on all the unix-likes, so use it for speed.
-      await pspawn('rm', ['-rf', serverDir]);
+      rmVerbose(serverDir);
     }
 
     if (!opts.dockerTag) {
@@ -269,9 +273,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     const serverDir = `${SERVERS_ROOT_DIR}/${profileName}-${portNum}`;
     if (popts.reset) {
-      log(chalk.green(`removing ${serverDir}`));
-      // rm is available on all the unix-likes, so use it for speed.
-      await pspawn('rm', ['-rf', serverDir]);
+      rmVerbose(serverDir);
     }
 
     let chainSpawn;
@@ -478,9 +480,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     }
 
     if (popts.reset) {
-      log(chalk.green(`removing ${serverDir}`));
-      // rm is available on all the unix-likes, so use it for speed.
-      await pspawn('rm', ['-rf', serverDir]);
+      rmVerbose(serverDir);
     }
 
     let soloSpawn;
@@ -703,9 +703,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const serverDir = `${SERVERS_ROOT_DIR}/${profileName}-${port}`;
 
     if (popts.reset) {
-      log(chalk.green(`removing ${serverDir}`));
-      // rm is available on all the unix-likes, so use it for speed.
-      await pspawn('rm', ['-rf', serverDir]);
+      rmVerbose(serverDir);
     }
 
     const setupRun = (...bonusArgs) =>
@@ -732,9 +730,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     await null;
     if (popts.reset) {
-      log(chalk.green(`removing ${serverDir}`));
-      // rm is available on all the unix-likes, so use it for speed.
-      await pspawn('rm', ['-rf', serverDir]);
+      rmVerbose(serverDir);
     }
 
     const setupRun = (...bonusArgs) =>

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -366,7 +366,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
         `--keyring-dir=${keysHome}`,
         '--keyring-backend=test',
         `--chain-id=${CHAIN_ID}`,
-        `${DELEGATE0_COINS}`,
+        DELEGATE0_COINS,
       ]);
       if (exitStatus) {
         return exitStatus;

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -40,6 +40,7 @@ const DELEGATE0_COINS = `50000000${STAKING_DENOM}`;
 const SOLO_COINS = `13000000${STAKING_DENOM},500000000${CENTRAL_DENOM}`;
 const CHAIN_ID = 'agoriclocal';
 
+const SERVERS_ROOT_DIR = '_agstate/agoric-servers';
 const FAKE_CHAIN_DELAY =
   process.env.FAKE_CHAIN_DELAY === undefined
     ? 0
@@ -172,7 +173,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const fakeDelay =
       popts.delay === undefined ? FAKE_CHAIN_DELAY : Number(popts.delay);
 
-    const serverDir = `_agstate/agoric-servers/${profileName}`;
+    const serverDir = `${SERVERS_ROOT_DIR}/${profileName}`;
 
     await null;
     if (popts.reset) {
@@ -206,7 +207,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
         agSolo,
         ['init', profileName, '--egresses=fake', `--webport=${HOST_PORT}`],
         {
-          cwd: '_agstate/agoric-servers',
+          cwd: SERVERS_ROOT_DIR,
         },
       );
     }
@@ -266,7 +267,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       }
     }
 
-    const serverDir = `_agstate/agoric-servers/${profileName}-${portNum}`;
+    const serverDir = `${SERVERS_ROOT_DIR}/${profileName}-${portNum}`;
     if (popts.reset) {
       log(chalk.green(`removing ${serverDir}`));
       // rm is available on all the unix-likes, so use it for speed.
@@ -448,7 +449,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       return 1;
     }
 
-    const serverDir = `_agstate/agoric-servers/${profileName}-${portNum}`;
+    const serverDir = `${SERVERS_ROOT_DIR}/${profileName}-${portNum}`;
 
     const { cosmosClientBuild } = getSDKBinaries(sdkPrefixes);
     await null;
@@ -552,7 +553,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       return 0;
     }
 
-    const gciFile = `_agstate/agoric-servers/local-chain-${CHAIN_PORT}/config/genesis.json.sha256`;
+    const gciFile = `${SERVERS_ROOT_DIR}/local-chain-${CHAIN_PORT}/config/genesis.json.sha256`;
     process.stdout.write(`Waiting for local-chain-${CHAIN_PORT} to start...`);
     let hasGci = false;
     for await (const _ of untilTrue(() => hasGci)) {
@@ -699,7 +700,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     const port = startArgs[0] || PORT;
     const netconfig = startArgs[1] || DEFAULT_NETCONFIG;
-    const serverDir = `_agstate/agoric-servers/${profileName}-${port}`;
+    const serverDir = `${SERVERS_ROOT_DIR}/${profileName}-${port}`;
 
     if (popts.reset) {
       log(chalk.green(`removing ${serverDir}`));
@@ -727,7 +728,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
   async function startTestnetSdk(profileName, startArgs, popts) {
     const port = startArgs[0] || PORT;
     const netconfig = startArgs[1] || DEFAULT_NETCONFIG;
-    const serverDir = `_agstate/agoric-servers/${profileName}-${port}`;
+    const serverDir = `${SERVERS_ROOT_DIR}/${profileName}-${port}`;
 
     await null;
     if (popts.reset) {

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -172,13 +172,13 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const fakeDelay =
       popts.delay === undefined ? FAKE_CHAIN_DELAY : Number(popts.delay);
 
-    const agServer = `_agstate/agoric-servers/${profileName}`;
+    const serverDir = `_agstate/agoric-servers/${profileName}`;
 
     await null;
     if (popts.reset) {
-      log(chalk.green(`removing ${agServer}`));
+      log(chalk.green(`removing ${serverDir}`));
       // rm is available on all the unix-likes, so use it for speed.
-      await pspawn('rm', ['-rf', agServer]);
+      await pspawn('rm', ['-rf', serverDir]);
     }
 
     if (!opts.dockerTag) {
@@ -199,7 +199,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     }
 
     const fakeGCI = 'sim-chain';
-    const serverExists = await exists(agServer);
+    const serverExists = await exists(serverDir);
     if (!serverExists) {
       log(chalk.yellow(`initializing ${profileName}`));
       await pspawn(
@@ -217,7 +217,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
         agSolo,
         ['set-fake-chain', `--delay=${fakeDelay}`, fakeGCI],
         {
-          cwd: agServer,
+          cwd: serverDir,
         },
       );
     }
@@ -228,7 +228,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     }
 
     const ps = pspawn(agSolo, [...debugOpts, 'start'], {
-      cwd: agServer,
+      cwd: serverDir,
       env: nodeDebugEnv,
     });
     process.on('SIGINT', () => ps.childProcess.kill('SIGINT'));
@@ -266,17 +266,17 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       }
     }
 
-    const agServer = `_agstate/agoric-servers/${profileName}-${portNum}`;
+    const serverDir = `_agstate/agoric-servers/${profileName}-${portNum}`;
     if (popts.reset) {
-      log(chalk.green(`removing ${agServer}`));
+      log(chalk.green(`removing ${serverDir}`));
       // rm is available on all the unix-likes, so use it for speed.
-      await pspawn('rm', ['-rf', agServer]);
+      await pspawn('rm', ['-rf', serverDir]);
     }
 
     let chainSpawn;
     if (!popts.dockerTag) {
       chainSpawn = (args, spawnOpts = undefined) => {
-        return pspawn(cosmosChain, [...args, `--home=${agServer}`], spawnOpts);
+        return pspawn(cosmosChain, [...args, `--home=${serverDir}`], spawnOpts);
       };
     } else {
       chainSpawn = (args, spawnOpts = undefined, dockerArgs = []) =>
@@ -290,13 +290,13 @@ export default async function startMain(progname, rawArgs, powers, opts) {
             ...terminalOnlyFlags(`-it`),
             SDK_IMAGE,
             ...args,
-            `--home=/usr/src/dapp/${agServer}`,
+            `--home=/usr/src/dapp/${serverDir}`,
           ],
           spawnOpts,
         );
     }
 
-    const serverExists = await exists(agServer);
+    const serverExists = await exists(serverDir);
     if (!serverExists) {
       const exitStatus = await chainSpawn([
         'init',
@@ -333,7 +333,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       /* eslint-enable no-await-in-loop */
     }
 
-    const genesisFile = `${agServer}/config/genesis.json`;
+    const genesisFile = `${serverDir}/config/genesis.json`;
     const stampExists = await exists(`${genesisFile}.stamp`);
     if (!stampExists) {
       let exitStatus;
@@ -384,8 +384,8 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     // Complete the genesis file and launch the chain.
     log('read ag-chain-cosmos config');
-    const configFile = `${agServer}/config/config.toml`;
-    const appFile = `${agServer}/config/app.toml`;
+    const configFile = `${serverDir}/config/config.toml`;
+    const appFile = `${serverDir}/config/app.toml`;
     const [genesisJson, configToml, appToml] = await Promise.all([
       fs.readFile(genesisFile, 'utf-8'),
       fs.readFile(configFile, 'utf-8'),
@@ -448,7 +448,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       return 1;
     }
 
-    const agServer = `_agstate/agoric-servers/${profileName}-${portNum}`;
+    const serverDir = `_agstate/agoric-servers/${profileName}-${portNum}`;
 
     const { cosmosClientBuild } = getSDKBinaries(sdkPrefixes);
     await null;
@@ -477,9 +477,9 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     }
 
     if (popts.reset) {
-      log(chalk.green(`removing ${agServer}`));
+      log(chalk.green(`removing ${serverDir}`));
       // rm is available on all the unix-likes, so use it for speed.
-      await pspawn('rm', ['-rf', agServer]);
+      await pspawn('rm', ['-rf', serverDir]);
     }
 
     let soloSpawn;
@@ -494,7 +494,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
             'run',
             `--volume=${process.cwd()}:/usr/src/dapp`,
             `--volume=${process.env.HOME}/.agoric:/root/.agoric`,
-            `-eAG_SOLO_BASEDIR=/usr/src/dapp/${agServer}`,
+            `-eAG_SOLO_BASEDIR=/usr/src/dapp/${serverDir}`,
             `--rm`,
             ...terminalOnlyFlags(`-it`),
             `--entrypoint=ag-solo`,
@@ -506,7 +506,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
         );
     }
 
-    const serverExists = await exists(agServer);
+    const serverExists = await exists(serverDir);
     // Initialise the solo directory and key.
     if (!serverExists) {
       const initArgs = [`--webport=${portNum}`];
@@ -514,7 +514,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
         initArgs.push(`--webhost=0.0.0.0`);
       }
       const exitStatus = await soloSpawn(
-        ['init', agServer, ...initArgs],
+        ['init', serverDir, ...initArgs],
         undefined,
         [`--workdir=/usr/src/dapp`],
       );
@@ -525,7 +525,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     // Create the full economy chain config.
     const agServerResolve = spec =>
-      require.resolve(spec, { paths: [agServer] });
+      require.resolve(spec, { paths: [serverDir] });
     const coreConfigPath = agServerResolve(
       '@agoric/vats/decentral-core-config.json',
     );
@@ -533,7 +533,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       '@agoric/cosmic-swingset/economy-template.json',
     );
     const [rawSoloAddr, coreConfigJson, economyTemplJson] = await Promise.all([
-      fs.readFile(`${agServer}/ag-cosmos-helper-address`, 'utf-8'),
+      fs.readFile(`${serverDir}/ag-cosmos-helper-address`, 'utf-8'),
       fs.readFile(coreConfigPath, 'utf-8'),
       fs.readFile(economyTemplPath, 'utf-8'),
     ]);
@@ -544,7 +544,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const economyConfig = JSON.parse(coreConfigJson);
     economyConfig.coreProposals = economyProposals;
     await fs.writeFile(
-      `${agServer}/decentral-economy-config.json`,
+      `${serverDir}/decentral-economy-config.json`,
       JSON.stringify(economyConfig, null, 2),
     );
 
@@ -578,7 +578,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     const spawnOpts = {};
     if (!popts.dockerTag) {
-      spawnOpts.cwd = agServer;
+      spawnOpts.cwd = serverDir;
     }
 
     const rpcAddrs = [`localhost:${CHAIN_PORT}`];
@@ -699,12 +699,12 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     const port = startArgs[0] || PORT;
     const netconfig = startArgs[1] || DEFAULT_NETCONFIG;
-    const agServer = `_agstate/agoric-servers/${profileName}-${port}`;
+    const serverDir = `_agstate/agoric-servers/${profileName}-${port}`;
 
     if (popts.reset) {
-      log(chalk.green(`removing ${agServer}`));
+      log(chalk.green(`removing ${serverDir}`));
       // rm is available on all the unix-likes, so use it for speed.
-      await pspawn('rm', ['-rf', agServer]);
+      await pspawn('rm', ['-rf', serverDir]);
     }
 
     const setupRun = (...bonusArgs) =>
@@ -712,7 +712,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
         'run',
         `-p127.0.0.1:${HOST_PORT}:${port}`,
         `--volume=${process.cwd()}:/usr/src/dapp`,
-        `-eAG_SOLO_BASEDIR=/usr/src/dapp/${agServer}`,
+        `-eAG_SOLO_BASEDIR=/usr/src/dapp/${serverDir}`,
         `--rm`,
         ...terminalOnlyFlags(`-it`),
         SOLO_IMAGE,
@@ -727,18 +727,18 @@ export default async function startMain(progname, rawArgs, powers, opts) {
   async function startTestnetSdk(profileName, startArgs, popts) {
     const port = startArgs[0] || PORT;
     const netconfig = startArgs[1] || DEFAULT_NETCONFIG;
-    const agServer = `_agstate/agoric-servers/${profileName}-${port}`;
+    const serverDir = `_agstate/agoric-servers/${profileName}-${port}`;
 
     await null;
     if (popts.reset) {
-      log(chalk.green(`removing ${agServer}`));
+      log(chalk.green(`removing ${serverDir}`));
       // rm is available on all the unix-likes, so use it for speed.
-      await pspawn('rm', ['-rf', agServer]);
+      await pspawn('rm', ['-rf', serverDir]);
     }
 
     const setupRun = (...bonusArgs) =>
       pspawn(agSolo, [`--webport=${port}`, ...bonusArgs], {
-        env: { ...pspawnEnv, AG_SOLO_BASEDIR: agServer },
+        env: { ...pspawnEnv, AG_SOLO_BASEDIR: serverDir },
       });
 
     return setupRun('setup', `--netconfig=${netconfig}`);

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -742,27 +742,22 @@ export default async function startMain(progname, rawArgs, powers, opts) {
   }
 
   const profiles = {
+    __proto__: null,
     dev: startFakeChain,
     'local-chain': startLocalChain,
     'local-solo': startLocalSolo,
     testnet: opts.dockerTag ? startTestnetDocker : startTestnetSdk,
   };
 
-  const popts = opts;
-
-  const args = rawArgs.slice(1);
-  const profileName = args[0] || 'dev';
+  const [_command = 'start', profileName = 'dev', ...args] = rawArgs;
   const startFn = profiles[profileName];
   if (!startFn) {
+    const profileNames = Object.keys(profiles).join(', ');
     log.error(
-      `unrecognized profile name ${profileName}; use one of: ${Object.keys(
-        profiles,
-      )
-        .sort()
-        .join(', ')}`,
+      `unrecognized profile name ${profileName}; use one of: ${profileNames}`,
     );
     return 1;
   }
 
-  return startFn(profileName, args[0] ? args.slice(1) : args, popts);
+  return startFn(profileName, args, opts);
 }


### PR DESCRIPTION
## Description

* Rename variables for clarity
* DRY out "_agstate/agoric-servers" into a const
* DRY out `--reset` old directory removal
* Remove unnecessary single-string interpolation
* Improve argument handling

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a