### PR TITLE
fix(cosmos): Support building on Linux aarch64

### DIFF
--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -133,7 +133,11 @@ BUF_VERSION ?= 0.56.0
 
 PROTOC_VERSION ?= 3.11.2
 ifeq ($(UNAME_S),Linux)
-  PROTOC_ZIP ?= protoc-${PROTOC_VERSION}-linux-x86_64.zip
+  ifeq ($(UNAME_M),aarch64)
+    PROTOC_ZIP ?= protoc-${PROTOC_VERSION}-linux-aarch_64.zip
+  else
+    PROTOC_ZIP ?= protoc-${PROTOC_VERSION}-linux-x86_64.zip
+  endif
 endif
 ifeq ($(UNAME_S),Darwin)
   PROTOC_ZIP ?= protoc-${PROTOC_VERSION}-osx-x86_64.zip


### PR DESCRIPTION
## Description

Download the correct `protoc` when running Linux on aarch64 (e.g., Docker on Apple Silicon)

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a