### PR TITLE
Prettier 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "prettier": {
     "arrowParens": "avoid",
-    "trailingComma": "all",
     "singleQuote": true
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "lerna": "^3.22.1",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.8.3",
+    "prettier": "^3.0.0",
     "typescript": "~5.1.6"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-github": "^4.8.0",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsdoc": "^40.1.0",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.0-alpha.2",
     "lerna": "^3.22.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0",

--- a/packages/agoric-cli/src/commands/inter.js
+++ b/packages/agoric-cli/src/commands/inter.js
@@ -87,7 +87,7 @@ const makeFormatters = assets => {
    * @param {(_: T) => string} f
    * @returns { (x: T | null | undefined ) => string | undefined }
    */
-  const maybe = f => x => x ? f(x) : undefined;
+  const maybe = f => x => (x ? f(x) : undefined);
 
   return {
     amount,

--- a/packages/agoric-cli/src/commands/psm.js
+++ b/packages/agoric-cli/src/commands/psm.js
@@ -151,15 +151,17 @@ export const makePsmCommand = logger => {
     .option('--giveMinted <DOLLARS>', 'amount of minted tokens to give', Number)
     .option('--feePct [%]', 'Gas fee percentage', Number)
     .option('--offerId <string>', 'Offer id', String, `swap-${Date.now()}`)
-    .action(async function (
-      /** @type {Parameters<typeof Offers.psm.swap>[2]} */ opts,
-    ) {
-      console.warn('running with options', opts);
-      const { agoricNames, lookupPsmInstance } = await rpcTools();
-      const instance = await lookupPsmInstance(opts.pair);
-      const offer = Offers.psm.swap(agoricNames, instance, opts);
-      outputExecuteOfferAction(offer);
-    });
+    .action(
+      async function (
+        /** @type {Parameters<typeof Offers.psm.swap>[2]} */ opts,
+      ) {
+        console.warn('running with options', opts);
+        const { agoricNames, lookupPsmInstance } = await rpcTools();
+        const instance = await lookupPsmInstance(opts.pair);
+        const offer = Offers.psm.swap(agoricNames, instance, opts);
+        outputExecuteOfferAction(offer);
+      },
+    );
 
   psm
     .command('proposePauseOffers')

--- a/packages/cosmic-proto/dist/agoric/swingset/msgs.d.ts
+++ b/packages/cosmic-proto/dist/agoric/swingset/msgs.d.ts
@@ -506,7 +506,7 @@ interface Rpc {
     data: Uint8Array,
   ): Promise<Uint8Array>;
 }
-declare type Builtin =
+type Builtin =
   | Date
   | Function
   | Uint8Array
@@ -514,7 +514,7 @@ declare type Builtin =
   | number
   | boolean
   | undefined;
-export declare type DeepPartial<T> = T extends Builtin
+export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Long
   ? string | number | Long
@@ -527,8 +527,8 @@ export declare type DeepPartial<T> = T extends Builtin
       [K in keyof T]?: DeepPartial<T[K]>;
     }
   : Partial<T>;
-declare type KeysOfUnion<T> = T extends T ? keyof T : never;
-export declare type Exact<P, I extends P> = P extends Builtin
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & {
       [K in keyof P]: Exact<P[K], I[K]>;

--- a/packages/cosmic-proto/dist/agoric/swingset/msgs.js
+++ b/packages/cosmic-proto/dist/agoric/swingset/msgs.js
@@ -64,10 +64,10 @@ export const MsgDeliverInbound = {
   fromJSON(object) {
     return {
       messages: Array.isArray(object?.messages)
-        ? object.messages.map((e) => String(e))
+        ? object.messages.map(e => String(e))
         : [],
       nums: Array.isArray(object?.nums)
-        ? object.nums.map((e) => Long.fromValue(e))
+        ? object.nums.map(e => Long.fromValue(e))
         : [],
       ack: isSet(object.ack) ? Long.fromValue(object.ack) : Long.UZERO,
       submitter: isSet(object.submitter)
@@ -78,12 +78,12 @@ export const MsgDeliverInbound = {
   toJSON(message) {
     const obj = {};
     if (message.messages) {
-      obj.messages = message.messages.map((e) => e);
+      obj.messages = message.messages.map(e => e);
     } else {
       obj.messages = [];
     }
     if (message.nums) {
-      obj.nums = message.nums.map((e) => (e || Long.UZERO).toString());
+      obj.nums = message.nums.map(e => (e || Long.UZERO).toString());
     } else {
       obj.nums = [];
     }
@@ -97,8 +97,8 @@ export const MsgDeliverInbound = {
   },
   fromPartial(object) {
     const message = createBaseMsgDeliverInbound();
-    message.messages = object.messages?.map((e) => e) || [];
-    message.nums = object.nums?.map((e) => Long.fromValue(e)) || [];
+    message.messages = object.messages?.map(e => e) || [];
+    message.nums = object.nums?.map(e => Long.fromValue(e)) || [];
     message.ack =
       object.ack !== undefined && object.ack !== null
         ? Long.fromValue(object.ack)
@@ -378,7 +378,7 @@ export const MsgProvision = {
         ? bytesFromBase64(object.address)
         : new Uint8Array(),
       powerFlags: Array.isArray(object?.powerFlags)
-        ? object.powerFlags.map((e) => String(e))
+        ? object.powerFlags.map(e => String(e))
         : [],
       submitter: isSet(object.submitter)
         ? bytesFromBase64(object.submitter)
@@ -393,7 +393,7 @@ export const MsgProvision = {
         message.address !== undefined ? message.address : new Uint8Array(),
       ));
     if (message.powerFlags) {
-      obj.powerFlags = message.powerFlags.map((e) => e);
+      obj.powerFlags = message.powerFlags.map(e => e);
     } else {
       obj.powerFlags = [];
     }
@@ -407,7 +407,7 @@ export const MsgProvision = {
     const message = createBaseMsgProvision();
     message.nickname = object.nickname ?? '';
     message.address = object.address ?? new Uint8Array();
-    message.powerFlags = object.powerFlags?.map((e) => e) || [];
+    message.powerFlags = object.powerFlags?.map(e => e) || [];
     message.submitter = object.submitter ?? new Uint8Array();
     return message;
   },
@@ -588,35 +588,35 @@ export class MsgClientImpl {
   InstallBundle(request) {
     const data = MsgInstallBundle.encode(request).finish();
     const promise = this.rpc.request(this.service, 'InstallBundle', data);
-    return promise.then((data) =>
+    return promise.then(data =>
       MsgInstallBundleResponse.decode(new _m0.Reader(data)),
     );
   }
   DeliverInbound(request) {
     const data = MsgDeliverInbound.encode(request).finish();
     const promise = this.rpc.request(this.service, 'DeliverInbound', data);
-    return promise.then((data) =>
+    return promise.then(data =>
       MsgDeliverInboundResponse.decode(new _m0.Reader(data)),
     );
   }
   WalletAction(request) {
     const data = MsgWalletAction.encode(request).finish();
     const promise = this.rpc.request(this.service, 'WalletAction', data);
-    return promise.then((data) =>
+    return promise.then(data =>
       MsgWalletActionResponse.decode(new _m0.Reader(data)),
     );
   }
   WalletSpendAction(request) {
     const data = MsgWalletSpendAction.encode(request).finish();
     const promise = this.rpc.request(this.service, 'WalletSpendAction', data);
-    return promise.then((data) =>
+    return promise.then(data =>
       MsgWalletSpendActionResponse.decode(new _m0.Reader(data)),
     );
   }
   Provision(request) {
     const data = MsgProvision.encode(request).finish();
     const promise = this.rpc.request(this.service, 'Provision', data);
-    return promise.then((data) =>
+    return promise.then(data =>
       MsgProvisionResponse.decode(new _m0.Reader(data)),
     );
   }
@@ -653,7 +653,7 @@ function base64FromBytes(arr) {
     return globalThis.Buffer.from(arr).toString('base64');
   } else {
     const bin = [];
-    arr.forEach((byte) => {
+    arr.forEach(byte => {
       bin.push(String.fromCharCode(byte));
     });
     return globalThis.btoa(bin.join(''));

--- a/packages/cosmic-proto/dist/agoric/swingset/query.d.ts
+++ b/packages/cosmic-proto/dist/agoric/swingset/query.d.ts
@@ -374,7 +374,7 @@ interface Rpc {
     data: Uint8Array,
   ): Promise<Uint8Array>;
 }
-declare type Builtin =
+type Builtin =
   | Date
   | Function
   | Uint8Array
@@ -382,7 +382,7 @@ declare type Builtin =
   | number
   | boolean
   | undefined;
-export declare type DeepPartial<T> = T extends Builtin
+export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Long
   ? string | number | Long
@@ -395,8 +395,8 @@ export declare type DeepPartial<T> = T extends Builtin
       [K in keyof T]?: DeepPartial<T[K]>;
     }
   : Partial<T>;
-declare type KeysOfUnion<T> = T extends T ? keyof T : never;
-export declare type Exact<P, I extends P> = P extends Builtin
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & {
       [K in keyof P]: Exact<P[K], I[K]>;

--- a/packages/cosmic-proto/dist/agoric/swingset/query.js
+++ b/packages/cosmic-proto/dist/agoric/swingset/query.js
@@ -280,21 +280,21 @@ export class QueryClientImpl {
   Params(request) {
     const data = QueryParamsRequest.encode(request).finish();
     const promise = this.rpc.request(this.service, 'Params', data);
-    return promise.then((data) =>
+    return promise.then(data =>
       QueryParamsResponse.decode(new _m0.Reader(data)),
     );
   }
   Egress(request) {
     const data = QueryEgressRequest.encode(request).finish();
     const promise = this.rpc.request(this.service, 'Egress', data);
-    return promise.then((data) =>
+    return promise.then(data =>
       QueryEgressResponse.decode(new _m0.Reader(data)),
     );
   }
   Mailbox(request) {
     const data = QueryMailboxRequest.encode(request).finish();
     const promise = this.rpc.request(this.service, 'Mailbox', data);
-    return promise.then((data) =>
+    return promise.then(data =>
       QueryMailboxResponse.decode(new _m0.Reader(data)),
     );
   }
@@ -331,7 +331,7 @@ function base64FromBytes(arr) {
     return globalThis.Buffer.from(arr).toString('base64');
   } else {
     const bin = [];
-    arr.forEach((byte) => {
+    arr.forEach(byte => {
       bin.push(String.fromCharCode(byte));
     });
     return globalThis.btoa(bin.join(''));

--- a/packages/cosmic-proto/dist/agoric/swingset/swingset.d.ts
+++ b/packages/cosmic-proto/dist/agoric/swingset/swingset.d.ts
@@ -539,7 +539,7 @@ export declare const ExtensionSnapshotterArtifactPayload: {
     object: I,
   ): ExtensionSnapshotterArtifactPayload;
 };
-declare type Builtin =
+type Builtin =
   | Date
   | Function
   | Uint8Array
@@ -547,7 +547,7 @@ declare type Builtin =
   | number
   | boolean
   | undefined;
-export declare type DeepPartial<T> = T extends Builtin
+export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Long
   ? string | number | Long
@@ -560,8 +560,8 @@ export declare type DeepPartial<T> = T extends Builtin
       [K in keyof T]?: DeepPartial<T[K]>;
     }
   : Partial<T>;
-declare type KeysOfUnion<T> = T extends T ? keyof T : never;
-export declare type Exact<P, I extends P> = P extends Builtin
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & {
       [K in keyof P]: Exact<P[K], I[K]>;

--- a/packages/cosmic-proto/dist/agoric/swingset/swingset.js
+++ b/packages/cosmic-proto/dist/agoric/swingset/swingset.js
@@ -47,7 +47,7 @@ export const CoreEvalProposal = {
       title: isSet(object.title) ? String(object.title) : '',
       description: isSet(object.description) ? String(object.description) : '',
       evals: Array.isArray(object?.evals)
-        ? object.evals.map((e) => CoreEval.fromJSON(e))
+        ? object.evals.map(e => CoreEval.fromJSON(e))
         : [],
     };
   },
@@ -57,9 +57,7 @@ export const CoreEvalProposal = {
     message.description !== undefined &&
       (obj.description = message.description);
     if (message.evals) {
-      obj.evals = message.evals.map((e) =>
-        e ? CoreEval.toJSON(e) : undefined,
-      );
+      obj.evals = message.evals.map(e => (e ? CoreEval.toJSON(e) : undefined));
     } else {
       obj.evals = [];
     }
@@ -69,7 +67,7 @@ export const CoreEvalProposal = {
     const message = createBaseCoreEvalProposal();
     message.title = object.title ?? '';
     message.description = object.description ?? '';
-    message.evals = object.evals?.map((e) => CoreEval.fromPartial(e)) || [];
+    message.evals = object.evals?.map(e => CoreEval.fromPartial(e)) || [];
     return message;
   },
 };
@@ -190,33 +188,33 @@ export const Params = {
   fromJSON(object) {
     return {
       beansPerUnit: Array.isArray(object?.beansPerUnit)
-        ? object.beansPerUnit.map((e) => StringBeans.fromJSON(e))
+        ? object.beansPerUnit.map(e => StringBeans.fromJSON(e))
         : [],
       feeUnitPrice: Array.isArray(object?.feeUnitPrice)
-        ? object.feeUnitPrice.map((e) => Coin.fromJSON(e))
+        ? object.feeUnitPrice.map(e => Coin.fromJSON(e))
         : [],
       bootstrapVatConfig: isSet(object.bootstrapVatConfig)
         ? String(object.bootstrapVatConfig)
         : '',
       powerFlagFees: Array.isArray(object?.powerFlagFees)
-        ? object.powerFlagFees.map((e) => PowerFlagFee.fromJSON(e))
+        ? object.powerFlagFees.map(e => PowerFlagFee.fromJSON(e))
         : [],
       queueMax: Array.isArray(object?.queueMax)
-        ? object.queueMax.map((e) => QueueSize.fromJSON(e))
+        ? object.queueMax.map(e => QueueSize.fromJSON(e))
         : [],
     };
   },
   toJSON(message) {
     const obj = {};
     if (message.beansPerUnit) {
-      obj.beansPerUnit = message.beansPerUnit.map((e) =>
+      obj.beansPerUnit = message.beansPerUnit.map(e =>
         e ? StringBeans.toJSON(e) : undefined,
       );
     } else {
       obj.beansPerUnit = [];
     }
     if (message.feeUnitPrice) {
-      obj.feeUnitPrice = message.feeUnitPrice.map((e) =>
+      obj.feeUnitPrice = message.feeUnitPrice.map(e =>
         e ? Coin.toJSON(e) : undefined,
       );
     } else {
@@ -225,14 +223,14 @@ export const Params = {
     message.bootstrapVatConfig !== undefined &&
       (obj.bootstrapVatConfig = message.bootstrapVatConfig);
     if (message.powerFlagFees) {
-      obj.powerFlagFees = message.powerFlagFees.map((e) =>
+      obj.powerFlagFees = message.powerFlagFees.map(e =>
         e ? PowerFlagFee.toJSON(e) : undefined,
       );
     } else {
       obj.powerFlagFees = [];
     }
     if (message.queueMax) {
-      obj.queueMax = message.queueMax.map((e) =>
+      obj.queueMax = message.queueMax.map(e =>
         e ? QueueSize.toJSON(e) : undefined,
       );
     } else {
@@ -243,14 +241,14 @@ export const Params = {
   fromPartial(object) {
     const message = createBaseParams();
     message.beansPerUnit =
-      object.beansPerUnit?.map((e) => StringBeans.fromPartial(e)) || [];
+      object.beansPerUnit?.map(e => StringBeans.fromPartial(e)) || [];
     message.feeUnitPrice =
-      object.feeUnitPrice?.map((e) => Coin.fromPartial(e)) || [];
+      object.feeUnitPrice?.map(e => Coin.fromPartial(e)) || [];
     message.bootstrapVatConfig = object.bootstrapVatConfig ?? '';
     message.powerFlagFees =
-      object.powerFlagFees?.map((e) => PowerFlagFee.fromPartial(e)) || [];
+      object.powerFlagFees?.map(e => PowerFlagFee.fromPartial(e)) || [];
     message.queueMax =
-      object.queueMax?.map((e) => QueueSize.fromPartial(e)) || [];
+      object.queueMax?.map(e => QueueSize.fromPartial(e)) || [];
     return message;
   },
 };
@@ -284,14 +282,14 @@ export const State = {
   fromJSON(object) {
     return {
       queueAllowed: Array.isArray(object?.queueAllowed)
-        ? object.queueAllowed.map((e) => QueueSize.fromJSON(e))
+        ? object.queueAllowed.map(e => QueueSize.fromJSON(e))
         : [],
     };
   },
   toJSON(message) {
     const obj = {};
     if (message.queueAllowed) {
-      obj.queueAllowed = message.queueAllowed.map((e) =>
+      obj.queueAllowed = message.queueAllowed.map(e =>
         e ? QueueSize.toJSON(e) : undefined,
       );
     } else {
@@ -302,7 +300,7 @@ export const State = {
   fromPartial(object) {
     const message = createBaseState();
     message.queueAllowed =
-      object.queueAllowed?.map((e) => QueueSize.fromPartial(e)) || [];
+      object.queueAllowed?.map(e => QueueSize.fromPartial(e)) || [];
     return message;
   },
 };
@@ -395,7 +393,7 @@ export const PowerFlagFee = {
     return {
       powerFlag: isSet(object.powerFlag) ? String(object.powerFlag) : '',
       fee: Array.isArray(object?.fee)
-        ? object.fee.map((e) => Coin.fromJSON(e))
+        ? object.fee.map(e => Coin.fromJSON(e))
         : [],
     };
   },
@@ -403,7 +401,7 @@ export const PowerFlagFee = {
     const obj = {};
     message.powerFlag !== undefined && (obj.powerFlag = message.powerFlag);
     if (message.fee) {
-      obj.fee = message.fee.map((e) => (e ? Coin.toJSON(e) : undefined));
+      obj.fee = message.fee.map(e => (e ? Coin.toJSON(e) : undefined));
     } else {
       obj.fee = [];
     }
@@ -412,7 +410,7 @@ export const PowerFlagFee = {
   fromPartial(object) {
     const message = createBasePowerFlagFee();
     message.powerFlag = object.powerFlag ?? '';
-    message.fee = object.fee?.map((e) => Coin.fromPartial(e)) || [];
+    message.fee = object.fee?.map(e => Coin.fromPartial(e)) || [];
     return message;
   },
 };
@@ -514,7 +512,7 @@ export const Egress = {
         ? bytesFromBase64(object.peer)
         : new Uint8Array(),
       powerFlags: Array.isArray(object?.powerFlags)
-        ? object.powerFlags.map((e) => String(e))
+        ? object.powerFlags.map(e => String(e))
         : [],
     };
   },
@@ -526,7 +524,7 @@ export const Egress = {
         message.peer !== undefined ? message.peer : new Uint8Array(),
       ));
     if (message.powerFlags) {
-      obj.powerFlags = message.powerFlags.map((e) => e);
+      obj.powerFlags = message.powerFlags.map(e => e);
     } else {
       obj.powerFlags = [];
     }
@@ -536,7 +534,7 @@ export const Egress = {
     const message = createBaseEgress();
     message.nickname = object.nickname ?? '';
     message.peer = object.peer ?? new Uint8Array();
-    message.powerFlags = object.powerFlags?.map((e) => e) || [];
+    message.powerFlags = object.powerFlags?.map(e => e) || [];
     return message;
   },
 };
@@ -629,7 +627,7 @@ function base64FromBytes(arr) {
     return globalThis.Buffer.from(arr).toString('base64');
   } else {
     const bin = [];
-    arr.forEach((byte) => {
+    arr.forEach(byte => {
       bin.push(String.fromCharCode(byte));
     });
     return globalThis.btoa(bin.join(''));

--- a/packages/cosmic-proto/dist/agoric/vstorage/query.d.ts
+++ b/packages/cosmic-proto/dist/agoric/vstorage/query.d.ts
@@ -406,7 +406,7 @@ interface Rpc {
     data: Uint8Array,
   ): Promise<Uint8Array>;
 }
-declare type Builtin =
+type Builtin =
   | Date
   | Function
   | Uint8Array
@@ -414,7 +414,7 @@ declare type Builtin =
   | number
   | boolean
   | undefined;
-export declare type DeepPartial<T> = T extends Builtin
+export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Long
   ? string | number | Long
@@ -427,8 +427,8 @@ export declare type DeepPartial<T> = T extends Builtin
       [K in keyof T]?: DeepPartial<T[K]>;
     }
   : Partial<T>;
-declare type KeysOfUnion<T> = T extends T ? keyof T : never;
-export declare type Exact<P, I extends P> = P extends Builtin
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
   ? P
   : P & {
       [K in keyof P]: Exact<P[K], I[K]>;

--- a/packages/cosmic-proto/dist/agoric/vstorage/query.js
+++ b/packages/cosmic-proto/dist/agoric/vstorage/query.js
@@ -187,7 +187,7 @@ export const QueryChildrenResponse = {
   fromJSON(object) {
     return {
       children: Array.isArray(object?.children)
-        ? object.children.map((e) => String(e))
+        ? object.children.map(e => String(e))
         : [],
       pagination: isSet(object.pagination)
         ? PageResponse.fromJSON(object.pagination)
@@ -197,7 +197,7 @@ export const QueryChildrenResponse = {
   toJSON(message) {
     const obj = {};
     if (message.children) {
-      obj.children = message.children.map((e) => e);
+      obj.children = message.children.map(e => e);
     } else {
       obj.children = [];
     }
@@ -209,7 +209,7 @@ export const QueryChildrenResponse = {
   },
   fromPartial(object) {
     const message = createBaseQueryChildrenResponse();
-    message.children = object.children?.map((e) => e) || [];
+    message.children = object.children?.map(e => e) || [];
     message.pagination =
       object.pagination !== undefined && object.pagination !== null
         ? PageResponse.fromPartial(object.pagination)
@@ -229,14 +229,12 @@ export class QueryClientImpl {
   Data(request) {
     const data = QueryDataRequest.encode(request).finish();
     const promise = this.rpc.request(this.service, 'Data', data);
-    return promise.then((data) =>
-      QueryDataResponse.decode(new _m0.Reader(data)),
-    );
+    return promise.then(data => QueryDataResponse.decode(new _m0.Reader(data)));
   }
   Children(request) {
     const data = QueryChildrenRequest.encode(request).finish();
     const promise = this.rpc.request(this.service, 'Children', data);
-    return promise.then((data) =>
+    return promise.then(data =>
       QueryChildrenResponse.decode(new _m0.Reader(data)),
     );
   }

--- a/packages/cosmic-proto/dist/cosmos/base/query/v1beta1/pagination.d.ts
+++ b/packages/cosmic-proto/dist/cosmos/base/query/v1beta1/pagination.d.ts
@@ -304,12 +304,12 @@ export declare const PageResponse: {
         } & { [K in Exclude<keyof I["total"], keyof Long>]: never; }) | undefined;
     } & { [K_1 in Exclude<keyof I, keyof PageResponse>]: never; }>(object: I): PageResponse;
 };
-declare type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
-export declare type DeepPartial<T> = T extends Builtin ? T : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>> : T extends {} ? {
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+export type DeepPartial<T> = T extends Builtin ? T : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>> : T extends {} ? {
     [K in keyof T]?: DeepPartial<T[K]>;
 } : Partial<T>;
-declare type KeysOfUnion<T> = T extends T ? keyof T : never;
-export declare type Exact<P, I extends P> = P extends Builtin ? P : P & {
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin ? P : P & {
     [K in keyof P]: Exact<P[K], I[K]>;
 } & {
     [K in Exclude<keyof I, KeysOfUnion<P>>]: never;

--- a/packages/cosmic-proto/dist/cosmos/base/v1beta1/coin.d.ts
+++ b/packages/cosmic-proto/dist/cosmos/base/v1beta1/coin.d.ts
@@ -77,12 +77,12 @@ export declare const DecProto: {
         dec?: string | undefined;
     } & { [K in Exclude<keyof I, "dec">]: never; }>(object: I): DecProto;
 };
-declare type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
-export declare type DeepPartial<T> = T extends Builtin ? T : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>> : T extends {} ? {
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+export type DeepPartial<T> = T extends Builtin ? T : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>> : T extends {} ? {
     [K in keyof T]?: DeepPartial<T[K]>;
 } : Partial<T>;
-declare type KeysOfUnion<T> = T extends T ? keyof T : never;
-export declare type Exact<P, I extends P> = P extends Builtin ? P : P & {
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin ? P : P & {
     [K in keyof P]: Exact<P[K], I[K]>;
 } & {
     [K in Exclude<keyof I, KeysOfUnion<P>>]: never;

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -55,9 +55,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "prettier": {
-    "trailingComma": "all",
-    "singleQuote": true
   }
 }

--- a/packages/cosmic-proto/test/query-swingset-params.js
+++ b/packages/cosmic-proto/test/query-swingset-params.js
@@ -13,7 +13,7 @@ import process from 'process';
  * @param {import('@cosmjs/tendermint-rpc').Tendermint34Client} rpcClient
  * @returns {Promise<import('@agoric/cosmic-proto/swingset/query.js').QueryParamsResponse>}
  */
-const querySwingsetParams = async (rpcClient) => {
+const querySwingsetParams = async rpcClient => {
   const base = QueryClient.withExtensions(rpcClient);
   const rpc = createProtobufRpcClient(base);
   const queryService = new QueryClientImpl(rpc);
@@ -36,7 +36,7 @@ testMain().then(
   () => {
     process.exitCode = 0;
   },
-  (err) => {
+  err => {
     console.error('Failed with', err);
     process.exit(process.exitCode || 1);
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -37,6 +37,6 @@
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsdoc": "^40.1.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "prettier": "^2.8.1"
+    "prettier": "^3.0.0"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -36,7 +36,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsdoc": "^40.1.0",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.0-alpha.2",
     "prettier": "^3.0.0"
   }
 }

--- a/packages/governance/src/noActionElectorate.js
+++ b/packages/governance/src/noActionElectorate.js
@@ -37,8 +37,10 @@ const start = zcf => {
 
   const creatorFacet = makeExo('creatorFacet', ElectorateCreatorI, {
     getPoserInvitation() {
-      return zcf.makeInvitation(() => {},
-      `noActionElectorate doesn't allow posing questions`);
+      return zcf.makeInvitation(
+        () => {},
+        `noActionElectorate doesn't allow posing questions`,
+      );
     },
     addQuestion(_instance, _question) {
       throw Error(`noActionElectorate doesn't add questions.`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,6 +1688,18 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz#ad3367684a57879392513479e0a436cb2ac46dad"
   integrity sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==
 
+"@pkgr/utils@^2.3.1":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.4.2.tgz#9e638bbe9a6a6f165580dc943f138fd3309a2cbc"
+  integrity sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==
+  dependencies:
+    cross-spawn "^7.0.3"
+    fast-glob "^3.3.0"
+    is-glob "^4.0.3"
+    open "^9.1.0"
+    picocolors "^1.0.0"
+    tslib "^2.6.0"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -2697,6 +2709,11 @@ better-sqlite3@^8.2.0:
     bindings "^1.5.0"
     prebuild-install "^7.1.0"
 
+big-integer@^1.6.44:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
@@ -2760,6 +2777,13 @@ body-parser@1.20.0:
     raw-body "2.5.1"
     type-is "~1.6.18"
     unpipe "1.0.0"
+
+bplist-parser@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.2.0.tgz#43a9d183e5bf9d545200ceac3e712f79ebbe8d0e"
+  integrity sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==
+  dependencies:
+    big-integer "^1.6.44"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -2849,6 +2873,13 @@ builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
   integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
+bundle-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-3.0.0.tgz#ba59bcc9ac785fb67ccdbf104a2bf60c099f0e1a"
+  integrity sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==
+  dependencies:
+    run-applescript "^5.0.0"
 
 byline@^5.0.0:
   version "5.0.0"
@@ -3593,7 +3624,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -3767,12 +3798,35 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
+default-browser-id@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-3.0.0.tgz#bee7bbbef1f4e75d31f98f4d3f1556a14cea790c"
+  integrity sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==
+  dependencies:
+    bplist-parser "^0.2.0"
+    untildify "^4.0.0"
+
+default-browser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-4.0.0.tgz#53c9894f8810bf86696de117a6ce9085a3cbc7da"
+  integrity sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==
+  dependencies:
+    bundle-name "^3.0.0"
+    default-browser-id "^3.0.0"
+    execa "^7.1.1"
+    titleize "^3.0.0"
+
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
   integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
   dependencies:
     clone "^1.0.2"
+
+define-lazy-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
+  integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
 define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.2.0"
@@ -4328,12 +4382,20 @@ eslint-plugin-no-only-tests@^3.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz#f38e4935c6c6c4842bf158b64aaa20c366fe171b"
   integrity sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==
 
-eslint-plugin-prettier@^4.0.0, eslint-plugin-prettier@^4.2.1:
+eslint-plugin-prettier@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
   integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-prettier@^5.0.0-alpha.2:
+  version "5.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0-alpha.2.tgz#4dd7edf88ff9bc13a3bbd91c059aae267dac4576"
+  integrity sha512-F6YBCbrRzvZwcINw3crm1+/uX/i+rJYaFErPtwCfUoPLywRfY7pwBtI3yMe5OpIotuaiws8cd29oM80ca6NQSQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+    synckit "^0.8.5"
 
 eslint-rule-docs@^1.1.5:
   version "1.1.231"
@@ -4519,6 +4581,36 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
+execa@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-7.1.1.tgz#3eb3c83d239488e7b409d48e8813b76bb55c9c43"
+  integrity sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.1"
+    human-signals "^4.3.0"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^3.0.7"
+    strip-final-newline "^3.0.0"
+
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -4656,10 +4748,10 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.2.11, fast-glob@^3.2.9:
-  version "3.2.12"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
-  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.0.tgz#7c40cb491e1e2ed5664749e87bfb516dbe8727c0"
+  integrity sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -5087,6 +5179,11 @@ get-stream@^4.0.0, get-stream@^4.1.0:
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
   dependencies:
     pump "^3.0.0"
+
+get-stream@^6.0.0, get-stream@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 get-symbol-description@^1.0.0:
   version "1.0.0"
@@ -5519,6 +5616,16 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+human-signals@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
+  integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -5873,6 +5980,11 @@ is-docker@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
+is-docker@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
+  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
+
 is-error@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-error/-/is-error-2.2.2.tgz#c10ade187b3c93510c5470a5567833ee25649843"
@@ -5935,6 +6047,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-inside-container@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
+  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
+  dependencies:
+    is-docker "^3.0.0"
 
 is-interactive@^1.0.0:
   version "1.0.0"
@@ -6063,6 +6182,11 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
+
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
@@ -6127,7 +6251,7 @@ is-windows@^1.0.0, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is-wsl@^2.1.1:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -6896,6 +7020,11 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -7504,6 +7633,20 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
+
+npm-run-path@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.1.0.tgz#bc62f7f3f6952d9894bd08944ba011a6ee7b7e00"
+  integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
+  dependencies:
+    path-key "^4.0.0"
+
 npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -7678,12 +7821,19 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-onetime@^5.1.0:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
 
 open@^7.4.2:
   version "7.4.2"
@@ -7692,6 +7842,16 @@ open@^7.4.2:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
+
+open@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-9.1.0.tgz#684934359c90ad25742f5a26151970ff8c6c80b6"
+  integrity sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==
+  dependencies:
+    default-browser "^4.0.0"
+    define-lazy-prop "^3.0.0"
+    is-inside-container "^1.0.0"
+    is-wsl "^2.2.0"
 
 opener@^1.5.2:
   version "1.5.2"
@@ -8042,10 +8202,15 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-key@^3.1.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
 
 path-parse@^1.0.7:
   version "1.0.7"
@@ -8801,6 +8966,13 @@ rollup@endojs/endo#rollup-2.7.1-patch-1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+run-applescript@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-5.0.0.tgz#e11e1c932e055d5c6b40d98374e0268d9b11899c"
+  integrity sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==
+  dependencies:
+    execa "^5.0.0"
+
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -8993,7 +9165,7 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.7:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -9430,6 +9602,16 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
+
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
@@ -9514,6 +9696,14 @@ symbol-observable@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
   integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
+
+synckit@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.5.tgz#b7f4358f9bb559437f9f167eb6bc46b3c9818fa3"
+  integrity sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==
+  dependencies:
+    "@pkgr/utils" "^2.3.1"
+    tslib "^2.5.0"
 
 table@^6.7.1:
   version "6.8.1"
@@ -9671,6 +9861,11 @@ time-zone@^1.0.0:
   resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
   integrity sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==
 
+titleize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53"
+  integrity sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9827,10 +10022,10 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2.1.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+tslib@^2.1.0, tslib@^2.5.0, tslib@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
+  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
 tsutils@^3.21.0, tsutils@~3.21.0:
   version "3.21.0"
@@ -10027,6 +10222,11 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+untildify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 upath@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8194,10 +8194,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.2.1, prettier@^2.8.3:
+prettier@^2.2.1:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
+prettier@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
+  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 pretty-format@^29.5.0:
   version "29.5.0"


### PR DESCRIPTION
## Description

https://prettier.io/blog/2023/07/05/3.0.0.html

Also has a 'yarn rebuild' of cosmic-proto that was affected by https://github.com/Agoric/agoric-sdk/pull/7822 

uses alpha version of `eslint-plugin-prettier` due to https://github.com/prettier/eslint-plugin-prettier/issues/562

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

CI