### PR TITLE
lint: replace forEach in SwingSet with for..of

### DIFF
--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -128,7 +128,7 @@ export function loadBasedir(basedir, options = {}) {
   const vats = {};
   const subs = fs.readdirSync(basedir, { withFileTypes: true });
   subs.sort(byName);
-  subs.forEach(dirent => {
+  for (const dirent of subs) {
     if (
       dirent.name.startsWith('vat-') &&
       dirent.name.endsWith('.js') &&
@@ -138,7 +138,7 @@ export function loadBasedir(basedir, options = {}) {
       const vatSourcePath = path.resolve(basedir, dirent.name);
       vats[name] = { sourceSpec: vatSourcePath, parameters: {} };
     }
-  });
+  }
   /** @type {string | void} */
   let bootstrapPath = path.resolve(basedir, 'bootstrap.js');
   try {

--- a/packages/SwingSet/src/devices/mailbox/device-mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox/device-mailbox.js
@@ -16,10 +16,10 @@ export function buildRootDeviceNode(tools) {
       );
     }
     assert.typeof(peer, 'string');
-    messages.forEach(m => {
+    for (const m of messages) {
       Nat(m[0]);
       assert.typeof(m[1], 'string');
-    });
+    }
     Nat(ack);
     if (messages.length) {
       deliverInboundMessages(peer, harden(messages));

--- a/packages/SwingSet/src/devices/mailbox/mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox/mailbox.js
@@ -74,9 +74,9 @@ import { Fail } from '@agoric/assert';
 
 export function importMailbox(data, inout = {}) {
   const outbox = new Map();
-  data.outbox.forEach(m => {
+  for (const m of data.outbox) {
     outbox.set(Nat(m[0]), m[1]);
-  });
+  }
   inout.ack = Nat(data.ack);
   inout.outbox = outbox;
   return inout;
@@ -84,9 +84,9 @@ export function importMailbox(data, inout = {}) {
 
 export function exportMailbox(inout) {
   const messages = [];
-  inout.outbox.forEach((body, msgnum) => {
+  for (const [msgnum, body] of inout.outbox) {
     messages.push([Number(msgnum), body]);
-  });
+  }
   messages.sort((a, b) => a[0] - b[0]);
   return {
     ack: Number(inout.ack),
@@ -121,13 +121,13 @@ export function buildMailboxStateMap(state = harden(new Map())) {
 
   function exportToData() {
     const data = {};
-    state.forEach((inout, peer) => {
+    for (const [peer, inout] of state.entries()) {
       const exported = exportMailbox(inout);
       data[peer] = {
         inboundAck: exported.ack,
         outbox: exported.outbox,
       };
-    });
+    }
     return harden(data);
   }
 

--- a/packages/SwingSet/src/devices/plugin/device-plugin.js
+++ b/packages/SwingSet/src/devices/plugin/device-plugin.js
@@ -132,12 +132,12 @@ export function buildRootDeviceNode(tools) {
   }
 
   endowments.registerResetter(() => {
-    connectedMods.forEach((mod, index) => {
+    for (const [index, mod] of connectedMods.entries()) {
       if (mod) {
         // console.info('Startup resetting', index, mod, nextEpochs[index]);
         SO(registeredReceiver).reset(index, nextEpochs[index]);
       }
-    });
+    }
   });
 
   return Far('root', {

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -182,7 +182,7 @@ function curryPollFn(SO, repeaters, deadlines, getLastPolledFn, saveStateFn) {
   function poll(now) {
     const timeAndEvents = deadlines.removeEventsThrough(now);
     let wokeAnything = false;
-    timeAndEvents.forEach(events => {
+    for (const events of timeAndEvents) {
       const { time, handlers } = events;
       assert.typeof(time, 'bigint');
       for (const { index, handler } of handlers) {
@@ -197,7 +197,7 @@ function curryPollFn(SO, repeaters, deadlines, getLastPolledFn, saveStateFn) {
         }
         wokeAnything = true;
       }
-    });
+    }
     if (wokeAnything) {
       saveStateFn();
     }

--- a/packages/SwingSet/src/kernel/kernelQueue.js
+++ b/packages/SwingSet/src/kernel/kernelQueue.js
@@ -98,7 +98,9 @@ export function makeKernelQueueHandler(tools) {
     // queue a message on the end of the queue, with 'absolute' krefs.
     // Use 'step' or 'run' to execute it
     const methargs = kser([method, args]);
-    methargs.slots.forEach(s => parseKernelSlot(s));
+    for (const s of methargs.slots) {
+      parseKernelSlot(s);
+    }
     let resultKPID;
     if (policy !== 'none') {
       resultKPID = kernelKeeper.addKernelPromise(policy);

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -671,7 +671,9 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
           body: kvStore.get(`${kernelSlot}.data.body`),
           slots: commaSplit(kvStore.get(`${kernelSlot}.data.slots`)),
         };
-        p.data.slots.forEach(parseKernelSlot);
+        for (const s of p.data.slots) {
+          parseKernelSlot(s);
+        }
         break;
       }
       default: {
@@ -1434,13 +1436,17 @@ export default function makeKernelKeeper(kernelStorage, kernelSlog) {
           state: { transcript: Array.from(vk.getTranscript()) },
         };
         vatTables.push(vatTable);
-        vk.dumpState().forEach(e => kernelTable.push(e));
+        for (const e of vk.dumpState()) {
+          kernelTable.push(e);
+        }
       }
     }
 
     for (const deviceID of getAllDeviceIDs()) {
       const dk = allocateDeviceKeeperIfNeeded(deviceID);
-      dk.dumpState().forEach(e => kernelTable.push(e));
+      for (const e of dk.dumpState()) {
+        kernelTable.push(e);
+      }
     }
 
     function compareNumbers(a, b) {

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -108,7 +108,7 @@ export function makeSyscallSimulator(
 
   const explain = () => {
     console.log(`anachrophobia strikes ${vatID} on delivery ${deliveryNum}`);
-    syscallStatus.forEach((status, idx) => {
+    for (const [idx, status] of syscallStatus.entries()) {
       const expected = syscallsExpected[idx];
       const got = syscallsMade[idx];
       switch (status) {
@@ -133,7 +133,7 @@ export function makeSyscallSimulator(
         default:
           Fail`bad ${status}`;
       }
-    });
+    }
   };
 
   const syscallHandler = vso => {

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -127,7 +127,9 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     const vrefs = krefs.map(kref =>
       mapKernelSlotToVatSlot(kref, gcDeliveryMapOpts),
     );
-    krefs.forEach(kref => vatKeeper.clearReachableFlag(kref, 'dropE'));
+    for (const kref of krefs) {
+      vatKeeper.clearReachableFlag(kref, 'dropE');
+    }
     /** @type { VatDeliveryDropExports } */
     const vatDelivery = harden(['dropExports', vrefs]);
     return vatDelivery;

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -120,11 +120,10 @@ export function buildCommsDispatch(syscall, _state, _helpers, _vatPowers) {
     // crank).  The resulting abrupt comms vat termination should serve as a
     // diagnostic signal that we have a bug that must be corrected.
 
-    methargs.slots.forEach(
-      s =>
-        !state.hasMetaObject(s) ||
-        Fail`comms meta-object ${s} not allowed in message args`,
-    );
+    for (const s of methargs.slots) {
+      !state.hasMetaObject(s) ||
+        Fail`comms meta-object ${s} not allowed in message args`;
+    }
     return sendFromKernel(target, methargs, result);
   }
 

--- a/packages/SwingSet/src/vats/timer/vat-timer.js
+++ b/packages/SwingSet/src/vats/timer/vat-timer.js
@@ -351,7 +351,9 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
   const processAndReschedule = () => {
     // first, service everything that is ready
     const now = getNow();
-    removeEventsUpTo(schedule, now).forEach(event => event.fired(now));
+    for (const event of removeEventsUpTo(schedule, now)) {
+      event.fired(now);
+    }
     // then, reschedule for whatever is up next
     reschedule();
   };
@@ -642,7 +644,9 @@ export const buildRootObject = (vatPowers, _vatParameters, baggage) => {
     if (cancels.has(cancelToken)) {
       const cancelled = cancels.get(cancelToken);
       cancels.delete(cancelToken);
-      cancelled.forEach(thing => thing.cancel());
+      for (const thing of cancelled) {
+        thing.cancel();
+      }
     }
   };
 

--- a/packages/SwingSet/test/device-mailbox/bootstrap-device-mailbox.js
+++ b/packages/SwingSet/test/device-mailbox/bootstrap-device-mailbox.js
@@ -22,9 +22,9 @@ export function buildRootObject(vatPowers, vatParameters) {
         const handler = Far('mailbox', {
           deliverInboundMessages(peer, messages) {
             log(`dm-${peer}`);
-            messages.forEach(m => {
+            for (const m of messages) {
               log(`m-${m[0]}-${m[1]}`);
-            });
+            }
           },
           deliverInboundAck(peer, ack) {
             log(`da-${peer}-${ack}`);

--- a/packages/SwingSet/test/test-gc-kernel.js
+++ b/packages/SwingSet/test/test-gc-kernel.js
@@ -610,7 +610,9 @@ test('retire before drop is error', async t => {
   await kernel.run();
 
   let survivingVats = new Set();
-  kernel.dump().vatTables.forEach(v => survivingVats.add(v.vatID));
+  for (const v of kernel.dump().vatTables) {
+    survivingVats.add(v.vatID);
+  }
   t.true(survivingVats.has(vatB));
 
   kernel.queueToKref(bob, 'retire', [], 'none');
@@ -625,7 +627,9 @@ test('retire before drop is error', async t => {
 
   // vat should be terminated
   survivingVats = new Set();
-  kernel.dump().vatTables.forEach(v => survivingVats.add(v.vatID));
+  for (const v of kernel.dump().vatTables) {
+    survivingVats.add(v.vatID);
+  }
   t.false(survivingVats.has(vatB));
 });
 
@@ -1046,9 +1050,13 @@ test('terminated vat', async t => {
   function getRefCountsAndOwners() {
     const refcounts = {};
     const data = c.dump();
-    data.objects.forEach(o => (refcounts[o[0]] = [o[2], o[3]]));
+    for (const o of data.objects) {
+      refcounts[o[0]] = [o[2], o[3]];
+    }
     const owners = {};
-    data.objects.forEach(o => (owners[o[0]] = o[1]));
+    for (const o of data.objects) {
+      owners[o[0]] = o[1];
+    }
     return [refcounts, owners];
   }
 
@@ -1066,7 +1074,9 @@ test('terminated vat', async t => {
       .kernelTable.filter(o => o[1] === doomedVat)
       .map(o => [o[0], o[2]]);
     const vrefs = {};
-    usedByDoomed.forEach(([kref, vref]) => (vrefs[vref] = kref));
+    for (const [kref, vref] of usedByDoomed) {
+      vrefs[vref] = kref;
+    }
     return vrefs;
   }
   // console.log(`usedByDoomed vrefs`, vrefs);

--- a/packages/SwingSet/test/test-transcript.js
+++ b/packages/SwingSet/test/test-transcript.js
@@ -40,9 +40,9 @@ test('transcript-one save', async t => {
   });
   const states2 = await buildTrace(c2, debug2);
 
-  states1.forEach((s, i) => {
+  for (const [i, s] of states1.entries()) {
     t.deepEqual(s.dump, states2[i].dump);
-  });
+  }
 });
 
 test('transcript-one load', async t => {

--- a/packages/SwingSet/test/virtualObjects/vdata-promises/bootstrap-vdata-promises.js
+++ b/packages/SwingSet/test/virtualObjects/vdata-promises/bootstrap-vdata-promises.js
@@ -54,7 +54,9 @@ export function buildRootObject() {
       const data = await E(targetvat).storePromiseStep1(subscriber);
       const subscriberEntries = await Promise.all(subscriberStash);
       const resolutions = {};
-      subscriberEntries.forEach(([name, res]) => (resolutions[name] = res));
+      for (const [name, res] of subscriberEntries) {
+        resolutions[name] = res;
+      }
       return { data, resolutions };
     },
   });

--- a/packages/SwingSet/tools/baggage-check.js
+++ b/packages/SwingSet/tools/baggage-check.js
@@ -118,18 +118,29 @@ export function checkBaggage(db, vatID, verbose = false) {
 
   // Kinds which have been used but whose kindID handles have not been seen
   const usedButNotKnownKinds = new Set();
-  usedKinds.forEach(v => usedButNotKnownKinds.add(v));
-  knownKinds.forEach(v => usedButNotKnownKinds.delete(v));
+  for (const v of usedKinds) {
+    usedButNotKnownKinds.add(v);
+  }
+  for (const v of knownKinds) {
+    usedButNotKnownKinds.delete(v);
+  }
 
   // Kinds which exist but whose kind handles have not been seen
   const extantButNotSeen = new Map();
-  extantKinds.forEach((k, v) => extantButNotSeen.set(v, k));
-  knownKinds.forEach(k => extantButNotSeen.delete(k));
-
+  for (const [k, v] of extantKinds) {
+    extantButNotSeen.set(v, k);
+  }
+  for (const k of knownKinds) {
+    extantButNotSeen.delete(k);
+  }
   // Kinds which exist but are not used
   const extantButNotUsed = new Map();
-  extantKinds.forEach((k, v) => extantButNotUsed.set(v, k));
-  usedKinds.forEach(k => extantButNotUsed.delete(k));
+  for (const [k, v] of extantKinds) {
+    extantButNotUsed.set(v, k);
+  }
+  for (const k of usedKinds) {
+    extantButNotUsed.delete(k);
+  }
 
   if (verbose || usedButNotKnownKinds.size > 0) {
     console.log('predefinedKinds', predefinedKinds);


### PR DESCRIPTION
refs: #7983

## Description

Replace `Array.forEach` in SwingSet with `for..of`. This PR will remove lint warnings in SwingSet package.

Ref: https://github.com/github/eslint-plugin-github/blob/main/docs/rules/array-foreach.md

### Security Considerations
### Scaling Considerations
### Documentation Considerations
### Testing Considerations
`yarn lint`
CI