### PR TITLE
refactor(swingset-vat): Match bundles with pattern

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -48,6 +48,7 @@
     "@endo/init": "^0.5.57",
     "@endo/marshal": "^0.8.6",
     "@endo/nat": "^4.1.28",
+    "@endo/patterns": "^0.2.3",
     "@endo/promise-kit": "^0.2.57",
     "@endo/ses-ava": "^0.2.41",
     "@endo/zip": "^0.2.32",

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -37,7 +37,7 @@ import { makeStartSubprocessWorkerNode } from './startNodeSubprocess.js';
 const endoZipBase64Sha512Shape = harden({
   moduleFormat: 'endoZipBase64',
   endoZipBase64: M.string(),
-  endoZipBase64Sha512: M.string(),
+  endoZipBase64Sha512: M.string(harden({ stringLengthLimit: Infinity })),
 });
 
 /** @param {Uint8Array} bytes */

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -36,8 +36,8 @@ import { makeStartSubprocessWorkerNode } from './startNodeSubprocess.js';
 
 const endoZipBase64Sha512Shape = harden({
   moduleFormat: 'endoZipBase64',
-  endoZipBase64: M.string(),
-  endoZipBase64Sha512: M.string(harden({ stringLengthLimit: Infinity })),
+  endoZipBase64: M.string(harden({ stringLengthLimit: Infinity })),
+  endoZipBase64Sha512: M.string(),
 });
 
 /** @param {Uint8Array} bytes */


### PR DESCRIPTION
closes: #8034
 
## Description

This change replaces a cryptic error emitted when publishing a bundle to the chain with a pattern matcher. The resulting error will at least be more specific about how the the bundle failed to match the pattern. Although this doesn’t fully describe how the bundle fails the pattern, that is a problem that can be addressed with further development of `@endo/patterns`.

### Security Considerations

We rely on this pattern to ensure that the bundle submitted by a user is digestible by the SwingSet controller. The behavior in the success path must be equivalent to the original code. To that end, we are relying on the pattern matcher to:

- ensure that the bundle has no accessor properties,
- the bundle is hardened (unless `harden` is fake!),
- that there are no extraneous properties,
- that all of the identified properties are present,
- that all of the identified properties are strings, and
- in the case of `moduleFormat`, an exact string. This could be relaxed since `chuckBundle` will do that job.

### Scaling Considerations

Not likely to be relevant, though the new code is probably slower.

### Documentation Considerations

The change should only improve the easy diagnosis of bundle publication errors and should require no further documentation. Our knowledgebase might benefit from a hint that this error means the publisher may have accidentaly submitted a non-bundle JSON file, like a `package.json`.

### Testing Considerations

`agoric publish` does not have an automated test. To verify this change, you will need to stand up a chain and use `agoric publish valid-bundle.json` and `agoric publish invalid-bundle.json` (e.g., `package.json`) and use `agoric follow :data.published` to see the results.