### PR TITLE
perf(swingset): Faster and bug fixed `insistVatId`

### DIFF
--- a/packages/SwingSet/src/lib/id.js
+++ b/packages/SwingSet/src/lib/id.js
@@ -37,7 +37,9 @@ export function insistVatID(s) {
  * @returns {string} a vat ID string of the form "vNN" where NN is the index.
  */
 export function makeVatID(index) {
-  return `v${Nat(index)}`;
+  const vatID = `v${Nat(index)}`;
+  insistVatID(vatID);
+  return vatID;
 }
 
 /**
@@ -66,7 +68,9 @@ export function insistDeviceID(s) {
  * @returns {string} a device ID string of the form "dNN" where NN is the index.
  */
 export function makeDeviceID(index) {
-  return `d${Nat(index)}`;
+  const deviceID = `d${Nat(index)}`;
+  insistDeviceID(deviceID);
+  return deviceID;
 }
 
 export function makeUpgradeID(index) {

--- a/packages/SwingSet/src/lib/id.js
+++ b/packages/SwingSet/src/lib/id.js
@@ -37,9 +37,7 @@ export function insistVatID(s) {
  * @returns {string} a vat ID string of the form "vNN" where NN is the index.
  */
 export function makeVatID(index) {
-  const vatID = `v${Nat(index)}`;
-  insistVatID(vatID);
-  return vatID;
+  return `v${Nat(index)}`;
 }
 
 /**
@@ -68,9 +66,7 @@ export function insistDeviceID(s) {
  * @returns {string} a device ID string of the form "dNN" where NN is the index.
  */
 export function makeDeviceID(index) {
-  const deviceID = `d${Nat(index)}`;
-  insistDeviceID(deviceID);
-  return deviceID;
+  return `d${Nat(index)}`;
 }
 
 export function makeUpgradeID(index) {

--- a/packages/SwingSet/src/lib/id.js
+++ b/packages/SwingSet/src/lib/id.js
@@ -22,13 +22,9 @@ import { Fail } from '@agoric/assert';
  * @returns {void}
  */
 export function insistVatID(s) {
-  try {
-    typeof s === 'string' || Fail`not a string`;
-    s.startsWith(`v`) || Fail`does not start with 'v'`;
-    Nat(BigInt(s.slice(1)));
-  } catch (e) {
-    Fail`${s} is not a 'vNN'-style VatID: ${e}`;
-  }
+  typeof s === 'string' || Fail`not a string`;
+  const pattern = /^v\d+$/;
+  pattern.test(s) || Fail`${s} is not a 'vNN'-style VatID`;
 }
 
 /**
@@ -54,15 +50,10 @@ export function makeVatID(index) {
  * @returns {void}
  */
 export function insistDeviceID(s) {
-  try {
-    if (typeof s !== 'string') {
-      throw Fail`not a string`;
-    }
-    s.startsWith(`d`) || Fail`does not start with 'd'`;
-    Nat(BigInt(s.slice(1)));
-  } catch (e) {
-    Fail`${s} is not a 'dNN'-style DeviceID: ${e}`;
-  }
+  typeof s === 'string' || Fail`not a string`;
+  const pattern = /^d\d+$/;
+  // @ts-expect-error
+  pattern.test(s) || Fail`${s} is not a 'dNN'-style DeviceID`;
 }
 
 /**
@@ -74,36 +65,6 @@ export function insistDeviceID(s) {
  */
 export function makeDeviceID(index) {
   return `d${Nat(index)}`;
-}
-
-/**
- * Parse a vat or device ID string into its constituent parts.
- *
- * @param {string} s  The string to be parsed.
- *
- * @returns {{ type: 'vat' | 'device', id: bigint}} an object: {
- *    type: STRING, // 'vat' or 'device', accordingly
- *    id: Nat       // the index
- *  }
- *
- * @throws {Error} if the parameter is not a string or is malformed.
- */
-export function parseVatOrDeviceID(s) {
-  typeof s === 'string' ||
-    Fail`${s} is not a string, so cannot be a VatID/DeviceID`;
-  /** @type {'vat' | 'device' | undefined} */
-  let type;
-  let idSuffix;
-  if (s.startsWith('v')) {
-    type = 'vat';
-    idSuffix = s.slice(1);
-  } else if (s.startsWith('d')) {
-    type = 'device';
-    idSuffix = s.slice(1);
-  } else {
-    throw Fail`${s} is neither a VatID nor a DeviceID`;
-  }
-  return harden({ type, id: Nat(BigInt(idSuffix)) });
 }
 
 export function makeUpgradeID(index) {

--- a/packages/SwingSet/src/lib/id.js
+++ b/packages/SwingSet/src/lib/id.js
@@ -2,8 +2,8 @@ import { Nat } from '@endo/nat';
 
 import { Fail } from '@agoric/assert';
 
-const vatIDPattern = /^v[1-9]\d*$/;
-const deviceIDPattern = /^d[1-9]\d*$/;
+const vatIDPattern = /^v\d+$/;
+const deviceIDPattern = /^d\d+$/;
 
 // Vats are identified by an integer index, which (for typechecking purposes)
 // is encoded as `vNN`. Devices are similarly identified as `dNN`. Both have

--- a/packages/SwingSet/src/lib/id.js
+++ b/packages/SwingSet/src/lib/id.js
@@ -2,6 +2,9 @@ import { Nat } from '@endo/nat';
 
 import { Fail } from '@agoric/assert';
 
+const vatIDPattern = /^v[1-9]\d*$/;
+const deviceIDPattern = /^d[1-9]\d*$/;
+
 // Vats are identified by an integer index, which (for typechecking purposes)
 // is encoded as `vNN`. Devices are similarly identified as `dNN`. Both have
 // human-readable names, which are provided to controller.addGenesisVat(),
@@ -23,8 +26,7 @@ import { Fail } from '@agoric/assert';
  */
 export function insistVatID(s) {
   typeof s === 'string' || Fail`not a string`;
-  const pattern = /^v\d+$/;
-  pattern.test(s) || Fail`${s} is not a 'vNN'-style VatID`;
+  vatIDPattern.test(s) || Fail`${s} is not a 'vNN'-style VatID`;
 }
 
 /**
@@ -51,9 +53,9 @@ export function makeVatID(index) {
  */
 export function insistDeviceID(s) {
   typeof s === 'string' || Fail`not a string`;
-  const pattern = /^d\d+$/;
+
   // @ts-expect-error
-  pattern.test(s) || Fail`${s} is not a 'dNN'-style DeviceID`;
+  deviceIDPattern.test(s) || Fail`${s} is not a 'dNN'-style DeviceID`;
 }
 
 /**

--- a/packages/SwingSet/test/test-id.js
+++ b/packages/SwingSet/test/test-id.js
@@ -1,0 +1,57 @@
+import { test } from '../tools/prepare-test-env-ava.js';
+import {
+  insistVatID,
+  makeVatID,
+  insistDeviceID,
+  makeDeviceID,
+} from '../src/lib/id.js';
+
+test('makeVatID', async t => {
+  t.is(makeVatID(0), 'v0');
+  t.is(makeVatID(100n ** 10n), 'v100000000000000000000');
+
+  t.throws(() => makeVatID());
+  t.throws(() => makeVatID(-1));
+  t.throws(() => makeVatID(3.14));
+  t.throws(() => makeVatID('3'));
+  t.throws(() => makeVatID('3n'));
+});
+
+test('insistVatId', async t => {
+  t.notThrows(() => insistVatID('v0'));
+  t.notThrows(() => insistVatID('v0001'));
+  t.notThrows(() => insistVatID('v100000000000000000000'));
+
+  t.throws(() => insistVatID(null));
+  t.throws(() => insistVatID(undefined));
+  t.throws(() => insistVatID(''));
+  t.throws(() => insistVatID('v'));
+  t.throws(() => insistVatID('v-1'));
+  t.throws(() => insistVatID('v3.14'));
+  t.throws(() => insistVatID('v100n'));
+});
+
+test('makeDeviceID', async t => {
+  t.is(makeDeviceID(0), 'd0');
+  t.is(makeDeviceID(100n ** 10n), 'd100000000000000000000');
+
+  t.throws(() => makeDeviceID());
+  t.throws(() => makeDeviceID(-1));
+  t.throws(() => makeDeviceID(3.14));
+  t.throws(() => makeDeviceID('3'));
+  t.throws(() => makeDeviceID('3n'));
+});
+
+test('insistDeviceID', async t => {
+  t.notThrows(() => insistDeviceID('d0'));
+  t.notThrows(() => insistDeviceID('d0001'));
+  t.notThrows(() => insistDeviceID('d100000000000000000000'));
+
+  t.throws(() => insistDeviceID(null));
+  t.throws(() => insistDeviceID(undefined));
+  t.throws(() => insistDeviceID(''));
+  t.throws(() => insistDeviceID('d'));
+  t.throws(() => insistDeviceID('d-1'));
+  t.throws(() => insistDeviceID('d3.14'));
+  t.throws(() => insistDeviceID('d100n'));
+});

--- a/packages/SwingSet/test/test-id.js
+++ b/packages/SwingSet/test/test-id.js
@@ -11,6 +11,7 @@ test('makeVatID', async t => {
   t.is(makeVatID(100n ** 10n), 'v100000000000000000000');
 
   t.throws(() => makeVatID());
+  t.throws(() => makeVatID(0));
   t.throws(() => makeVatID(-1));
   t.throws(() => makeVatID(3.14));
   t.throws(() => makeVatID('3'));
@@ -37,6 +38,7 @@ test('makeDeviceID', async t => {
   t.is(makeDeviceID(100n ** 10n), 'd100000000000000000000');
 
   t.throws(() => makeDeviceID());
+  t.throws(() => makeDeviceID(0));
   t.throws(() => makeDeviceID(-1));
   t.throws(() => makeDeviceID(3.14));
   t.throws(() => makeDeviceID('3'));

--- a/packages/SwingSet/test/test-id.js
+++ b/packages/SwingSet/test/test-id.js
@@ -7,6 +7,7 @@ import {
 } from '../src/lib/id.js';
 
 test('makeVatID', async t => {
+  t.is(makeVatID(0), 'v0');
   t.is(makeVatID(1), 'v1');
   t.is(makeVatID(100n ** 10n), 'v100000000000000000000');
 
@@ -18,21 +19,22 @@ test('makeVatID', async t => {
 });
 
 test('insistVatId', async t => {
+  t.notThrows(() => insistVatID('v0'));
   t.notThrows(() => insistVatID('v1'));
   t.notThrows(() => insistVatID('v100000000000000000000'));
+  t.notThrows(() => insistVatID('v0001'));
 
   t.throws(() => insistVatID(null));
   t.throws(() => insistVatID(undefined));
   t.throws(() => insistVatID(''));
   t.throws(() => insistVatID('v'));
-  t.throws(() => insistVatID('v0'));
   t.throws(() => insistVatID('v-1'));
   t.throws(() => insistVatID('v3.14'));
   t.throws(() => insistVatID('v100n'));
-  t.throws(() => insistVatID('v0001'));
 });
 
 test('makeDeviceID', async t => {
+  t.is(makeDeviceID(0), 'd0');
   t.is(makeDeviceID(1), 'd1');
   t.is(makeDeviceID(100n ** 10n), 'd100000000000000000000');
 
@@ -44,16 +46,16 @@ test('makeDeviceID', async t => {
 });
 
 test('insistDeviceID', async t => {
+  t.notThrows(() => insistDeviceID('d0'));
   t.notThrows(() => insistDeviceID('d1'));
   t.notThrows(() => insistDeviceID('d100000000000000000000'));
+  t.notThrows(() => insistDeviceID('d0001'));
 
   t.throws(() => insistDeviceID(null));
   t.throws(() => insistDeviceID(undefined));
   t.throws(() => insistDeviceID(''));
   t.throws(() => insistDeviceID('d'));
-  t.throws(() => insistDeviceID('d0'));
   t.throws(() => insistDeviceID('d-1'));
   t.throws(() => insistDeviceID('d3.14'));
   t.throws(() => insistDeviceID('d100n'));
-  t.throws(() => insistDeviceID('d0001'));
 });

--- a/packages/SwingSet/test/test-id.js
+++ b/packages/SwingSet/test/test-id.js
@@ -11,7 +11,6 @@ test('makeVatID', async t => {
   t.is(makeVatID(100n ** 10n), 'v100000000000000000000');
 
   t.throws(() => makeVatID());
-  t.throws(() => makeVatID(0));
   t.throws(() => makeVatID(-1));
   t.throws(() => makeVatID(3.14));
   t.throws(() => makeVatID('3'));
@@ -38,7 +37,6 @@ test('makeDeviceID', async t => {
   t.is(makeDeviceID(100n ** 10n), 'd100000000000000000000');
 
   t.throws(() => makeDeviceID());
-  t.throws(() => makeDeviceID(0));
   t.throws(() => makeDeviceID(-1));
   t.throws(() => makeDeviceID(3.14));
   t.throws(() => makeDeviceID('3'));

--- a/packages/SwingSet/test/test-id.js
+++ b/packages/SwingSet/test/test-id.js
@@ -7,7 +7,7 @@ import {
 } from '../src/lib/id.js';
 
 test('makeVatID', async t => {
-  t.is(makeVatID(0), 'v0');
+  t.is(makeVatID(1), 'v1');
   t.is(makeVatID(100n ** 10n), 'v100000000000000000000');
 
   t.throws(() => makeVatID());
@@ -18,21 +18,22 @@ test('makeVatID', async t => {
 });
 
 test('insistVatId', async t => {
-  t.notThrows(() => insistVatID('v0'));
-  t.notThrows(() => insistVatID('v0001'));
+  t.notThrows(() => insistVatID('v1'));
   t.notThrows(() => insistVatID('v100000000000000000000'));
 
   t.throws(() => insistVatID(null));
   t.throws(() => insistVatID(undefined));
   t.throws(() => insistVatID(''));
   t.throws(() => insistVatID('v'));
+  t.throws(() => insistVatID('v0'));
   t.throws(() => insistVatID('v-1'));
   t.throws(() => insistVatID('v3.14'));
   t.throws(() => insistVatID('v100n'));
+  t.throws(() => insistVatID('v0001'));
 });
 
 test('makeDeviceID', async t => {
-  t.is(makeDeviceID(0), 'd0');
+  t.is(makeDeviceID(1), 'd1');
   t.is(makeDeviceID(100n ** 10n), 'd100000000000000000000');
 
   t.throws(() => makeDeviceID());
@@ -43,15 +44,16 @@ test('makeDeviceID', async t => {
 });
 
 test('insistDeviceID', async t => {
-  t.notThrows(() => insistDeviceID('d0'));
-  t.notThrows(() => insistDeviceID('d0001'));
+  t.notThrows(() => insistDeviceID('d1'));
   t.notThrows(() => insistDeviceID('d100000000000000000000'));
 
   t.throws(() => insistDeviceID(null));
   t.throws(() => insistDeviceID(undefined));
   t.throws(() => insistDeviceID(''));
   t.throws(() => insistDeviceID('d'));
+  t.throws(() => insistDeviceID('d0'));
   t.throws(() => insistDeviceID('d-1'));
   t.throws(() => insistDeviceID('d3.14'));
   t.throws(() => insistDeviceID('d100n'));
+  t.throws(() => insistDeviceID('d0001'));
 });


### PR DESCRIPTION
closes: #8039

## Description
* Fix bug to not accepts `'v'` as valid Id.
* Improve speed of the insistVatId by 50%.
* Remove dead code

Quick local benchmark:
Old insistVatID: 55.093ms
Regex insistVatID: 19.377ms

Thanks @mhofman for regex.

### Security Considerations

### Scaling Considerations

### Documentation Considerations

### Testing Considerations

Unit tests added
