### PR TITLE
chore(swingset): Fix default param lint warnings

### DIFF
--- a/packages/SwingSet/src/devices/plugin/device-plugin.js
+++ b/packages/SwingSet/src/devices/plugin/device-plugin.js
@@ -96,7 +96,7 @@ export function buildRootDeviceNode(tools) {
    * Load a module and connect to it.
    *
    * @param {string} mod module with an exported `bootPlugin(state = undefined)`
-   * @param {number} [index=connectedMods.length] the module instance index
+   * @param {number} [index] the module instance index
    * @returns {number} the allocated index
    */
   function connect(mod, index = connectedMods.length) {

--- a/packages/SwingSet/src/devices/timer/device-timer.js
+++ b/packages/SwingSet/src/devices/timer/device-timer.js
@@ -71,7 +71,7 @@ function copyState(schedState) {
  * incoming event), we'd want to tell the host loop when we should next be
  * scheduled.
  *
- * @param {Array<Event>} [state=undefined]
+ * @param {Array<Event>} [state]
  */
 function makeTimerMap(state = undefined) {
   /**

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -32,7 +32,7 @@ export const rethrowUnlessMissing = err => {
  * @param {ConnectionHandler} handler
  * @param {Endpoint} localAddr
  * @param {Endpoint} remoteAddr
- * @param {Set<Closable>} [current=new Set()]
+ * @param {Set<Closable>} [current]
  * @returns {Connection}
  */
 export const makeConnection = (
@@ -110,7 +110,7 @@ export const makeConnection = (
  * @param {Endpoint} addr0
  * @param {ConnectionHandler} handler1
  * @param {Endpoint} addr1
- * @param {WeakSet<Connection>} [current=new WeakSet()]
+ * @param {WeakSet<Connection>} [current]
  * @returns {[Connection, Connection]}
  */
 export function crossoverConnection(

--- a/packages/SwingSet/src/vats/network/router.js
+++ b/packages/SwingSet/src/vats/network/router.js
@@ -70,7 +70,7 @@ export default function makeRouter() {
 /**
  * Create a router that behaves like a Protocol.
  *
- * @param {typeof defaultE} [E=defaultE] Eventual sender
+ * @param {typeof defaultE} [E] Eventual sender
  * @returns {RouterProtocol} The new delegated protocol
  */
 export function makeRouterProtocol(E = defaultE) {

--- a/packages/SwingSet/test/upgrade/test-upgrade.js
+++ b/packages/SwingSet/test/upgrade/test-upgrade.js
@@ -76,7 +76,6 @@ const makeConfigFromPaths = (bootstrapVatPath, options = {}) => {
  * @param {SwingSetConfig} config
  * @param {object} [options]
  * @param {object} [options.extraRuntimeOpts]
- * @param {boolean} [options.holdObjectRefs=true] - DEPRECATED -
  * Refcount incrementing should be manual,
  * see https://github.com/Agoric/agoric-sdk/issues/7213
  * @returns {Promise<{
@@ -306,8 +305,8 @@ test('kernel sends bringOutYourDead for vat upgrade', async t => {
  * @param {import('ava').ExecutionContext} t
  * @param {ManagerType} defaultManagerType
  * @param {object} [options]
- * @param {boolean} [options.restartVatAdmin=false]
- * @param {boolean} [options.suppressGC=false]
+ * @param {boolean} [options.restartVatAdmin]
+ * @param {boolean} [options.suppressGC]
  */
 const testUpgrade = async (t, defaultManagerType, options = {}) => {
   const { restartVatAdmin: doVatAdminRestart = false, suppressGC = false } =
@@ -411,7 +410,7 @@ const testUpgrade = async (t, defaultManagerType, options = {}) => {
    * @param {string} when
    * @param {object} expectations
    * @param {boolean} expectations.afterGC
-   * @param {string[]} [expectations.stillOwned=retainedNames]
+   * @param {string[]} [expectations.stillOwned]
    */
   const verifyObjectTracking = (when, expectations) => {
     const { afterGC, stillOwned = retainedNames } = expectations;


### PR DESCRIPTION
refs: #8032

## Description

This PR removes the following lint warnings that were problem introduced by updated in the lint version in #8032.
```
GitHub Actions / lint-rest 
Defaults are not permitted on @param
```
### Security Considerations
### Scaling Considerations
### Documentation Considerations
### Testing Considerations
CI