### PR TITLE
feat: use x/swingset DB for swing-store shadow copy

### DIFF
--- a/docs/architecture/state-sync.md
+++ b/docs/architecture/state-sync.md
@@ -58,9 +58,14 @@ sequenceDiagram
   TM->>+A-M: EndBlock
   A-M->>+CM: END_BLOCK
   CM->>CM: runKernel()
-  CM-)A-M: vstorage->setWithoutNotify(prefixedExportDataEntries)
+  CM-)A-M: swingset->swingStoreUpdateExportData(exportDataEntries)
+  A-M->>A-M: swingStore := NewPrefixStore("swingStore.")
   loop each data entry
-    A-M->>+MS-M: vstorage.SetStorage()
+    alt has value
+      A-M->>+MS-M: swingStore.Set(key, value)
+    else no value
+      A-M->>+MS-M: swingStore.Delete(key)
+    end
     MS-M-->>-A-M: 
   end
   CM-->>-A-M: 
@@ -247,8 +252,8 @@ sequenceDiagram
       SSEH-CS->>+D-CS: MkDir(exportDir)
       D-CS-->>-SSEH-CS: 
       SSEH-CS->>+SSES-CS: provider.GetExportDataReader()
-      SSES-CS->>+MS-CS: ExportStorageFromPrefix<br/>("swingStore.")
-      MS-CS-->>-SSES-CS: vstorage data entries
+      SSES-CS->>MS-CS: PrefixStore.Iterator()<br/>("swingStore.")
+      MS-CS--)SSES-CS: sdk.Iterator
       SSES-CS--)-SSEH-CS: export data reader
       loop each data entry
         SSEH-CS->>+D-CS: Append(export-data.jsonl, <br/>"JSON(entry tuple)\n")

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -202,6 +202,7 @@ type GaiaApp struct { // nolint: golint
 	controllerInited bool
 	bootstrapNeeded  bool
 	lienPort         int
+	swingsetPort     int
 	vbankPort        int
 	vibcPort         int
 	vstoragePort     int
@@ -459,6 +460,7 @@ func NewAgoricApp(
 		app.VstorageKeeper, vbanktypes.ReservePoolName,
 		callToController,
 	)
+	app.swingsetPort = vm.RegisterPortHandler("swingset", swingset.NewPortHandler(app.SwingSetKeeper))
 
 	app.SwingStoreExportsHandler = *swingsetkeeper.NewSwingStoreExportsHandler(
 		app.Logger(),
@@ -842,17 +844,18 @@ func normalizeModuleAccount(ctx sdk.Context, ak authkeeper.AccountKeeper, name s
 }
 
 type cosmosInitAction struct {
-	Type        string             `json:"type"`
-	ChainID     string             `json:"chainID"`
-	BlockTime   int64              `json:"blockTime,omitempty"`
-	IsBootstrap bool               `json:"isBootstrap"`
-	Params      swingset.Params    `json:"params"`
-	SupplyCoins sdk.Coins          `json:"supplyCoins"`
-	UpgradePlan *upgradetypes.Plan `json:"upgradePlan,omitempty"`
-	LienPort    int                `json:"lienPort"`
-	StoragePort int                `json:"storagePort"`
-	VbankPort   int                `json:"vbankPort"`
-	VibcPort    int                `json:"vibcPort"`
+	Type         string             `json:"type"`
+	ChainID      string             `json:"chainID"`
+	BlockTime    int64              `json:"blockTime,omitempty"`
+	IsBootstrap  bool               `json:"isBootstrap"`
+	Params       swingset.Params    `json:"params"`
+	SupplyCoins  sdk.Coins          `json:"supplyCoins"`
+	UpgradePlan  *upgradetypes.Plan `json:"upgradePlan,omitempty"`
+	LienPort     int                `json:"lienPort"`
+	StoragePort  int                `json:"storagePort"`
+	SwingsetPort int                `json:"swingsetPort"`
+	VbankPort    int                `json:"vbankPort"`
+	VibcPort     int                `json:"vibcPort"`
 }
 
 // Name returns the name of the App
@@ -882,17 +885,18 @@ func (app *GaiaApp) initController(ctx sdk.Context, bootstrap bool) {
 
 	// Begin initializing the controller here.
 	action := &cosmosInitAction{
-		Type:        "AG_COSMOS_INIT",
-		ChainID:     ctx.ChainID(),
-		BlockTime:   blockTime,
-		IsBootstrap: bootstrap,
-		Params:      app.SwingSetKeeper.GetParams(ctx),
-		SupplyCoins: sdk.NewCoins(app.BankKeeper.GetSupply(ctx, "uist")),
-		UpgradePlan: app.upgradePlan,
-		LienPort:    app.lienPort,
-		StoragePort: app.vstoragePort,
-		VbankPort:   app.vbankPort,
-		VibcPort:    app.vibcPort,
+		Type:         "AG_COSMOS_INIT",
+		ChainID:      ctx.ChainID(),
+		BlockTime:    blockTime,
+		IsBootstrap:  bootstrap,
+		Params:       app.SwingSetKeeper.GetParams(ctx),
+		SupplyCoins:  sdk.NewCoins(app.BankKeeper.GetSupply(ctx, "uist")),
+		UpgradePlan:  app.upgradePlan,
+		LienPort:     app.lienPort,
+		StoragePort:  app.vstoragePort,
+		SwingsetPort: app.swingsetPort,
+		VbankPort:    app.vbankPort,
+		VibcPort:     app.vibcPort,
 	}
 	// This really abuses `BlockingSend` to get back at `sendToController`
 	out, err := app.SwingSetKeeper.BlockingSend(ctx, action)

--- a/golang/cosmos/proto/agoric/swingset/genesis.proto
+++ b/golang/cosmos/proto/agoric/swingset/genesis.proto
@@ -13,4 +13,14 @@ message GenesisState {
     Params params = 2 [(gogoproto.nullable) = false];
 
     State state = 3 [(gogoproto.nullable) = false];
+
+    repeated SwingStoreExportDataEntry swing_store_export_data = 4 [
+        (gogoproto.jsontag)    = "swingStoreExportData"
+    ];
+}
+
+// A SwingStore "export data" entry.
+message SwingStoreExportDataEntry {
+    string key = 1;
+    string value = 2;
 }

--- a/golang/cosmos/types/kv_entry_helpers.go
+++ b/golang/cosmos/types/kv_entry_helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	swingsettypes "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
 	vstoragetypes "github.com/Agoric/agoric-sdk/golang/cosmos/x/vstorage/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -36,6 +37,8 @@ import (
 //     types are available:
 //     - NewVstorageDataEntriesReader constructs a reader from a slice of
 //       vstorage DataEntry values.
+//     - NewSwingStoreExportDataEntriesReader constructs a reader from a slice
+//       of SwingStoreExportDataEntry values.
 //     - NewJsonRawMessageKVEntriesReader constructs a reader from a slice of
 //       [key: string, value?: string | null] JSON array values.
 //   - NewJsonlKVEntryDecoderReader constructs a reader from an io.ReadCloser
@@ -150,6 +153,17 @@ func NewVstorageDataEntriesReader(vstorageDataEntries []*vstoragetypes.DataEntry
 		entries: vstorageDataEntries,
 		toKVEntry: func(sourceEntry *vstoragetypes.DataEntry) (KVEntry, error) {
 			return NewKVEntry(sourceEntry.Path, sourceEntry.Value), nil
+		},
+	}
+}
+
+// NewSwingStoreExportDataEntriesReader creates a KVEntryReader backed by
+// a SwingStoreExportDataEntry slice
+func NewSwingStoreExportDataEntriesReader(exportDataEntries []*swingsettypes.SwingStoreExportDataEntry) KVEntryReader {
+	return &kvEntriesReader[*swingsettypes.SwingStoreExportDataEntry]{
+		entries: exportDataEntries,
+		toKVEntry: func(sourceEntry *swingsettypes.SwingStoreExportDataEntry) (KVEntry, error) {
+			return NewKVEntry(sourceEntry.Key, sourceEntry.Value), nil
 		},
 	}
 }

--- a/golang/cosmos/x/swingset/genesis.go
+++ b/golang/cosmos/x/swingset/genesis.go
@@ -8,10 +8,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func NewGenesisState() *types.GenesisState {
-	return &types.GenesisState{}
-}
-
 func ValidateGenesis(data *types.GenesisState) error {
 	if data == nil {
 		return fmt.Errorf("swingset genesis data cannot be nil")
@@ -24,7 +20,9 @@ func ValidateGenesis(data *types.GenesisState) error {
 
 func DefaultGenesisState() *types.GenesisState {
 	return &types.GenesisState{
-		Params: types.DefaultParams(),
+		Params:               types.DefaultParams(),
+		State:                types.State{},
+		SwingStoreExportData: []*types.SwingStoreExportDataEntry{},
 	}
 }
 
@@ -34,13 +32,37 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data *types.GenesisState) bool 
 	keeper.SetParams(ctx, data.GetParams())
 	keeper.SetState(ctx, data.GetState())
 
+	swingStoreExportData := data.GetSwingStoreExportData()
+	if len(swingStoreExportData) > 0 {
+		// See https://github.com/Agoric/agoric-sdk/issues/6527
+		panic("genesis with swing-store state not implemented")
+	}
+
 	// TODO: bootstrap only if not restoring swing-store from genesis state
 	return true
 }
 
 func ExportGenesis(ctx sdk.Context, k Keeper) *types.GenesisState {
-	gs := NewGenesisState()
-	gs.Params = k.GetParams(ctx)
-	gs.State = k.GetState(ctx)
+	gs := &types.GenesisState{
+		Params:               k.GetParams(ctx),
+		State:                k.GetState(ctx),
+		SwingStoreExportData: []*types.SwingStoreExportDataEntry{},
+	}
+
+	// Only export the swing-store shadow copy for now
+	// TODO:
+	// - perform state-sync export with check blockHeight (figure out how to
+	//   handle export of historical height),
+	// - include swing-store artifacts in genesis state
+	// See https://github.com/Agoric/agoric-sdk/issues/6527
+	exportDataIterator := k.GetSwingStore(ctx).Iterator(nil, nil)
+	defer exportDataIterator.Close()
+	for ; exportDataIterator.Valid(); exportDataIterator.Next() {
+		entry := types.SwingStoreExportDataEntry{
+			Key:   string(exportDataIterator.Key()),
+			Value: string(exportDataIterator.Value()),
+		}
+		gs.SwingStoreExportData = append(gs.SwingStoreExportData, &entry)
+	}
 	return gs
 }

--- a/golang/cosmos/x/swingset/keeper/keeper.go
+++ b/golang/cosmos/x/swingset/keeper/keeper.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -20,7 +21,6 @@ import (
 	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
 	vstoragekeeper "github.com/Agoric/agoric-sdk/golang/cosmos/x/vstorage/keeper"
-	vstoragetypes "github.com/Agoric/agoric-sdk/golang/cosmos/x/vstorage/types"
 )
 
 // Top-level paths for chain storage should remain synchronized with
@@ -37,7 +37,10 @@ const (
 	StoragePathSwingStore          = "swingStore"
 )
 
-const stateKey string = "state"
+const (
+	stateKey            = "state"
+	swingStoreKeyPrefix = "swingStore."
+)
 
 // Contextual information about the message source of an action on an inbound queue.
 // This context should be unique per inboundQueueRecord.
@@ -435,8 +438,9 @@ func (k Keeper) SetMailbox(ctx sdk.Context, peer string, mailbox string) {
 	k.vstorageKeeper.LegacySetStorageAndNotify(ctx, agoric.NewKVEntry(path, mailbox))
 }
 
-func (k Keeper) ExportSwingStore(ctx sdk.Context) []*vstoragetypes.DataEntry {
-	return k.vstorageKeeper.ExportStorageFromPrefix(ctx, StoragePathSwingStore)
+func (k Keeper) GetSwingStore(ctx sdk.Context) sdk.KVStore {
+	store := ctx.KVStore(k.storeKey)
+	return prefix.NewStore(store, []byte(swingStoreKeyPrefix))
 }
 
 func (k Keeper) PathToEncodedKey(path string) []byte {

--- a/golang/cosmos/x/swingset/keeper/keeper_test.go
+++ b/golang/cosmos/x/swingset/keeper/keeper_test.go
@@ -1,10 +1,17 @@
 package keeper
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	prefixstore "github.com/cosmos/cosmos-sdk/store/prefix"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	dbm "github.com/tendermint/tm-db"
 )
 
 func mkcoin(denom string) func(amt int64) sdk.Coin {
@@ -179,5 +186,75 @@ func Test_calculateFees(t *testing.T) {
 				t.Errorf("calculateFees() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+var (
+	swingsetStoreKey = storetypes.NewKVStoreKey(types.StoreKey)
+)
+
+func makeTestStore() sdk.KVStore {
+	db := dbm.NewMemDB()
+	ms := store.NewCommitMultiStore(db)
+	ms.MountStoreWithDB(swingsetStoreKey, sdk.StoreTypeIAVL, db)
+	err := ms.LoadLatestVersion()
+	if err != nil {
+		panic(err)
+	}
+	kvStore := ms.GetKVStore(swingsetStoreKey)
+	prefixStore := prefixstore.NewStore(kvStore, []byte("swingStore."))
+	return prefixStore
+}
+
+func TestSwingStore(t *testing.T) {
+	store := makeTestStore()
+
+	// Test that we can store and retrieve a value.
+	store.Set([]byte("someKey"), []byte("someValue"))
+	if got := string(store.Get([]byte("someKey"))); got != "someValue" {
+		t.Errorf("got %q, want %q", got, "someValue")
+	}
+
+	// Test that we can update and retrieve an updated value.
+	store.Set([]byte("someKey"), []byte("someNewValue"))
+	if got := string(store.Get([]byte("someKey"))); got != "someNewValue" {
+		t.Errorf("got %q, want %q", got, "someNewValue")
+	}
+
+	// Test that we can store and retrieve empty values
+	store.Set([]byte("someEmptyKey"), []byte(""))
+	if got := store.Get([]byte("someEmptyKey")); got == nil || string(got) != "" {
+		t.Errorf("got %#v, want empty string", got)
+	}
+
+	// Test that we can store and delete values.
+	store.Set([]byte("someOtherKey"), []byte("someOtherValue"))
+	store.Delete([]byte("someOtherKey"))
+	if store.Has([]byte("someOtherKey")) {
+		t.Errorf("has value, expected not")
+	}
+
+	// Test that we can delete non existing keys (e.g. delete twice)
+	store.Delete([]byte("someMissingKey"))
+
+	// Check the iterated values
+	expectedEntries := [][2]string{
+		{"someEmptyKey", "[]byte{}"},
+		{"someKey", "[]byte{0x73, 0x6f, 0x6d, 0x65, 0x4e, 0x65, 0x77, 0x56, 0x61, 0x6c, 0x75, 0x65}"},
+	}
+
+	iter := store.Iterator(nil, nil)
+	gotEntries := [][2]string{}
+	for ; iter.Valid(); iter.Next() {
+		entry := [2]string{
+			string(iter.Key()),
+			fmt.Sprintf("%#v", iter.Value()),
+		}
+		gotEntries = append(gotEntries, entry)
+	}
+	iter.Close()
+
+	if !reflect.DeepEqual(gotEntries, expectedEntries) {
+		t.Errorf("got export %q, want %q", gotEntries, expectedEntries)
 	}
 }

--- a/golang/cosmos/x/swingset/swingset.go
+++ b/golang/cosmos/x/swingset/swingset.go
@@ -1,0 +1,40 @@
+package swingset
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+)
+
+// portHandler implements vm.PortHandler
+// for processing inbound messages from Swingset.
+type portHandler struct {
+	keeper Keeper
+}
+
+type swingsetMessage struct {
+	Method string            `json:"method"`
+	Args   []json.RawMessage `json:"args"`
+}
+
+// NewPortHandler returns a port handler for a swingset Keeper.
+func NewPortHandler(k Keeper) vm.PortHandler {
+	return portHandler{keeper: k}
+}
+
+// Receive implements the vm.PortHandler method.
+// It receives and processes an inbound message, returning the
+// JSON-serialized response or an error.
+func (ph portHandler) Receive(ctx *vm.ControllerContext, str string) (string, error) {
+	var msg swingsetMessage
+	err := json.Unmarshal([]byte(str), &msg)
+	if err != nil {
+		return "", err
+	}
+
+	switch msg.Method {
+	default:
+		return "", fmt.Errorf("unrecognized swingset method %s", msg.Method)
+	}
+}

--- a/golang/cosmos/x/swingset/swingset.go
+++ b/golang/cosmos/x/swingset/swingset.go
@@ -3,8 +3,11 @@ package swingset
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 
+	agoric "github.com/Agoric/agoric-sdk/golang/cosmos/types"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // portHandler implements vm.PortHandler
@@ -17,6 +20,10 @@ type swingsetMessage struct {
 	Method string            `json:"method"`
 	Args   []json.RawMessage `json:"args"`
 }
+
+const (
+	SwingStoreUpdateExportData = "swingStoreUpdateExportData"
+)
 
 // NewPortHandler returns a port handler for a swingset Keeper.
 func NewPortHandler(k Keeper) vm.PortHandler {
@@ -34,7 +41,31 @@ func (ph portHandler) Receive(ctx *vm.ControllerContext, str string) (string, er
 	}
 
 	switch msg.Method {
+	case SwingStoreUpdateExportData:
+		return ph.handleSwingStoreUpdateExportData(ctx.Context, msg.Args)
+
 	default:
 		return "", fmt.Errorf("unrecognized swingset method %s", msg.Method)
+	}
+}
+
+func (ph portHandler) handleSwingStoreUpdateExportData(ctx sdk.Context, entries []json.RawMessage) (ret string, err error) {
+	store := ph.keeper.GetSwingStore(ctx)
+	exportDataReader := agoric.NewJsonRawMessageKVEntriesReader(entries)
+	defer exportDataReader.Close()
+	for {
+		entry, err := exportDataReader.Read()
+		if err == io.EOF {
+			return "true", nil
+		} else if err != nil {
+			return ret, err
+		}
+
+		key := []byte(entry.Key())
+		if !entry.HasValue() {
+			store.Delete(key)
+		} else {
+			store.Set(key, []byte(entry.StringValue()))
+		}
 	}
 }

--- a/golang/cosmos/x/swingset/types/genesis.pb.go
+++ b/golang/cosmos/x/swingset/types/genesis.pb.go
@@ -25,8 +25,9 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The initial or exported state.
 type GenesisState struct {
-	Params Params `protobuf:"bytes,2,opt,name=params,proto3" json:"params"`
-	State  State  `protobuf:"bytes,3,opt,name=state,proto3" json:"state"`
+	Params               Params                       `protobuf:"bytes,2,opt,name=params,proto3" json:"params"`
+	State                State                        `protobuf:"bytes,3,opt,name=state,proto3" json:"state"`
+	SwingStoreExportData []*SwingStoreExportDataEntry `protobuf:"bytes,4,rep,name=swing_store_export_data,json=swingStoreExportData,proto3" json:"swingStoreExportData"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }
@@ -76,29 +77,96 @@ func (m *GenesisState) GetState() State {
 	return State{}
 }
 
+func (m *GenesisState) GetSwingStoreExportData() []*SwingStoreExportDataEntry {
+	if m != nil {
+		return m.SwingStoreExportData
+	}
+	return nil
+}
+
+// A SwingStore "export data" entry.
+type SwingStoreExportDataEntry struct {
+	Key   string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value string `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+}
+
+func (m *SwingStoreExportDataEntry) Reset()         { *m = SwingStoreExportDataEntry{} }
+func (m *SwingStoreExportDataEntry) String() string { return proto.CompactTextString(m) }
+func (*SwingStoreExportDataEntry) ProtoMessage()    {}
+func (*SwingStoreExportDataEntry) Descriptor() ([]byte, []int) {
+	return fileDescriptor_49b057311de9d296, []int{1}
+}
+func (m *SwingStoreExportDataEntry) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SwingStoreExportDataEntry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SwingStoreExportDataEntry.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SwingStoreExportDataEntry) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SwingStoreExportDataEntry.Merge(m, src)
+}
+func (m *SwingStoreExportDataEntry) XXX_Size() int {
+	return m.Size()
+}
+func (m *SwingStoreExportDataEntry) XXX_DiscardUnknown() {
+	xxx_messageInfo_SwingStoreExportDataEntry.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SwingStoreExportDataEntry proto.InternalMessageInfo
+
+func (m *SwingStoreExportDataEntry) GetKey() string {
+	if m != nil {
+		return m.Key
+	}
+	return ""
+}
+
+func (m *SwingStoreExportDataEntry) GetValue() string {
+	if m != nil {
+		return m.Value
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*GenesisState)(nil), "agoric.swingset.GenesisState")
+	proto.RegisterType((*SwingStoreExportDataEntry)(nil), "agoric.swingset.SwingStoreExportDataEntry")
 }
 
 func init() { proto.RegisterFile("agoric/swingset/genesis.proto", fileDescriptor_49b057311de9d296) }
 
 var fileDescriptor_49b057311de9d296 = []byte{
-	// 234 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4d, 0x4c, 0xcf, 0x2f,
-	0xca, 0x4c, 0xd6, 0x2f, 0x2e, 0xcf, 0xcc, 0x4b, 0x2f, 0x4e, 0x2d, 0xd1, 0x4f, 0x4f, 0xcd, 0x4b,
-	0x2d, 0xce, 0x2c, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0xe2, 0x87, 0x48, 0xeb, 0xc1, 0xa4,
-	0xa5, 0x44, 0xd2, 0xf3, 0xd3, 0xf3, 0xc1, 0x72, 0xfa, 0x20, 0x16, 0x44, 0x99, 0x94, 0x1c, 0xba,
-	0x29, 0x30, 0x06, 0x44, 0x5e, 0xa9, 0x9e, 0x8b, 0xc7, 0x1d, 0x62, 0x6e, 0x70, 0x49, 0x62, 0x49,
-	0xaa, 0x90, 0x29, 0x17, 0x5b, 0x41, 0x62, 0x51, 0x62, 0x6e, 0xb1, 0x04, 0x93, 0x02, 0xa3, 0x06,
-	0xb7, 0x91, 0xb8, 0x1e, 0x9a, 0x3d, 0x7a, 0x01, 0x60, 0x69, 0x27, 0x96, 0x13, 0xf7, 0xe4, 0x19,
-	0x82, 0xa0, 0x8a, 0x85, 0x8c, 0xb8, 0x58, 0x8b, 0x41, 0xfa, 0x25, 0x98, 0xc1, 0xba, 0xc4, 0x30,
-	0x74, 0x81, 0x4d, 0x87, 0x6a, 0x82, 0x28, 0xb5, 0x62, 0x79, 0xb1, 0x40, 0x9e, 0xc1, 0x29, 0xf4,
-	0xc4, 0x23, 0x39, 0xc6, 0x0b, 0x8f, 0xe4, 0x18, 0x1f, 0x3c, 0x92, 0x63, 0x9c, 0xf0, 0x58, 0x8e,
-	0xe1, 0xc2, 0x63, 0x39, 0x86, 0x1b, 0x8f, 0xe5, 0x18, 0xa2, 0xac, 0xd3, 0x33, 0x4b, 0x32, 0x4a,
-	0x93, 0xf4, 0x92, 0xf3, 0x73, 0xf5, 0x1d, 0x21, 0xbe, 0x80, 0x98, 0xaa, 0x5b, 0x9c, 0x92, 0xad,
-	0x9f, 0x9e, 0x9f, 0x93, 0x98, 0x97, 0xae, 0x9f, 0x9c, 0x5f, 0x9c, 0x9b, 0x5f, 0xac, 0x5f, 0x81,
-	0xf0, 0x60, 0x49, 0x65, 0x41, 0x6a, 0x71, 0x12, 0x1b, 0xd8, 0x7b, 0xc6, 0x80, 0x00, 0x00, 0x00,
-	0xff, 0xff, 0x65, 0xe6, 0xb9, 0x87, 0x46, 0x01, 0x00, 0x00,
+	// 334 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x91, 0xcf, 0x4b, 0x02, 0x41,
+	0x1c, 0xc5, 0x77, 0xf2, 0x07, 0x38, 0x06, 0xc5, 0x22, 0xb9, 0x09, 0x8d, 0xe2, 0x49, 0x82, 0x76,
+	0xc0, 0xe8, 0x52, 0xa7, 0x2c, 0xe9, 0x1a, 0x2b, 0x5d, 0xba, 0xc8, 0xa8, 0xc3, 0xb4, 0xa8, 0x3b,
+	0xcb, 0x7c, 0xc7, 0x52, 0xfa, 0x27, 0xfa, 0x13, 0xfa, 0x73, 0x3c, 0x7a, 0xec, 0x24, 0xa1, 0x97,
+	0xe8, 0x6f, 0xe8, 0x10, 0x3b, 0xa3, 0x04, 0x6a, 0xb7, 0xb7, 0xfb, 0x79, 0xef, 0x0d, 0x33, 0x0f,
+	0x9f, 0x30, 0x21, 0x55, 0xd8, 0xa5, 0xf0, 0x12, 0x46, 0x02, 0xb8, 0xa6, 0x82, 0x47, 0x1c, 0x42,
+	0xf0, 0x63, 0x25, 0xb5, 0x74, 0x0f, 0x2c, 0xf6, 0xd7, 0xb8, 0x54, 0x10, 0x52, 0x48, 0xc3, 0x68,
+	0xa2, 0xac, 0xad, 0x44, 0x36, 0x5b, 0xd6, 0xc2, 0xf2, 0xea, 0x0f, 0xc2, 0xfb, 0x77, 0xb6, 0xb8,
+	0xa5, 0x99, 0xe6, 0xee, 0x05, 0xce, 0xc6, 0x4c, 0xb1, 0x21, 0x78, 0x7b, 0x15, 0x54, 0xcb, 0xd7,
+	0x8b, 0xfe, 0xc6, 0x41, 0xfe, 0xbd, 0xc1, 0x8d, 0xf4, 0x74, 0x5e, 0x76, 0x82, 0x95, 0xd9, 0xad,
+	0xe3, 0x0c, 0x24, 0x79, 0x2f, 0x65, 0x52, 0x47, 0x5b, 0x29, 0xd3, 0xbe, 0x0a, 0x59, 0xab, 0xfb,
+	0x8a, 0x8b, 0x06, 0xb7, 0x41, 0x4b, 0xc5, 0xdb, 0x7c, 0x1c, 0x4b, 0xa5, 0xdb, 0x3d, 0xa6, 0x99,
+	0x97, 0xae, 0xa4, 0x6a, 0xf9, 0xfa, 0xe9, 0x76, 0x4b, 0x22, 0x5a, 0x89, 0xbd, 0x69, 0xdc, 0xb7,
+	0x4c, 0xb3, 0x66, 0xa4, 0xd5, 0xa4, 0xe1, 0x7d, 0xcf, 0xcb, 0x05, 0xd8, 0x81, 0x83, 0x9d, 0x7f,
+	0x2f, 0xd3, 0x5f, 0xef, 0x65, 0xa7, 0x7a, 0x83, 0x8f, 0xff, 0xad, 0x74, 0x0f, 0x71, 0xaa, 0xcf,
+	0x27, 0x1e, 0xaa, 0xa0, 0x5a, 0x2e, 0x48, 0xa4, 0x5b, 0xc0, 0x99, 0x67, 0x36, 0x18, 0x71, 0xf3,
+	0x36, 0xb9, 0xc0, 0x7e, 0x34, 0x1e, 0xa6, 0x0b, 0x82, 0x66, 0x0b, 0x82, 0x3e, 0x17, 0x04, 0xbd,
+	0x2d, 0x89, 0x33, 0x5b, 0x12, 0xe7, 0x63, 0x49, 0x9c, 0xc7, 0x2b, 0x11, 0xea, 0xa7, 0x51, 0xc7,
+	0xef, 0xca, 0x21, 0xbd, 0xb6, 0x43, 0xd8, 0x1b, 0x9d, 0x41, 0xaf, 0x4f, 0x85, 0x1c, 0xb0, 0x48,
+	0xd0, 0xae, 0x84, 0xa1, 0x04, 0x3a, 0xfe, 0xdb, 0x48, 0x4f, 0x62, 0x0e, 0x9d, 0xac, 0x59, 0xe8,
+	0xfc, 0x37, 0x00, 0x00, 0xff, 0xff, 0x94, 0xe9, 0x22, 0x36, 0x09, 0x02, 0x00, 0x00,
 }
 
 func (m *GenesisState) Marshal() (dAtA []byte, err error) {
@@ -121,6 +189,20 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.SwingStoreExportData) > 0 {
+		for iNdEx := len(m.SwingStoreExportData) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.SwingStoreExportData[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintGenesis(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
 	{
 		size, err := m.State.MarshalToSizedBuffer(dAtA[:i])
 		if err != nil {
@@ -141,6 +223,43 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	i--
 	dAtA[i] = 0x12
+	return len(dAtA) - i, nil
+}
+
+func (m *SwingStoreExportDataEntry) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SwingStoreExportDataEntry) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SwingStoreExportDataEntry) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = encodeVarintGenesis(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Key) > 0 {
+		i -= len(m.Key)
+		copy(dAtA[i:], m.Key)
+		i = encodeVarintGenesis(dAtA, i, uint64(len(m.Key)))
+		i--
+		dAtA[i] = 0xa
+	}
 	return len(dAtA) - i, nil
 }
 
@@ -165,6 +284,29 @@ func (m *GenesisState) Size() (n int) {
 	n += 1 + l + sovGenesis(uint64(l))
 	l = m.State.Size()
 	n += 1 + l + sovGenesis(uint64(l))
+	if len(m.SwingStoreExportData) > 0 {
+		for _, e := range m.SwingStoreExportData {
+			l = e.Size()
+			n += 1 + l + sovGenesis(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *SwingStoreExportDataEntry) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Key)
+	if l > 0 {
+		n += 1 + l + sovGenesis(uint64(l))
+	}
+	l = len(m.Value)
+	if l > 0 {
+		n += 1 + l + sovGenesis(uint64(l))
+	}
 	return n
 }
 
@@ -268,6 +410,154 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 			if err := m.State.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SwingStoreExportData", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SwingStoreExportData = append(m.SwingStoreExportData, &SwingStoreExportDataEntry{})
+			if err := m.SwingStoreExportData[len(m.SwingStoreExportData)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenesis(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SwingStoreExportDataEntry) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenesis
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SwingStoreExportDataEntry: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SwingStoreExportDataEntry: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Key = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Value = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -298,20 +298,20 @@ export default async function main(progname, args, { env, homedir, agcc }) {
         if (typeof key !== 'string') {
           throw Fail`Unexpected swingStore exported key ${q(key)}`;
         }
-        const path = `${STORAGE_PATH.SWING_STORE}.${key}`;
         if (value == null) {
-          return [path];
+          return [key];
         }
         if (typeof value !== 'string') {
           throw Fail`Unexpected ${typeof value} value for swingStore exported key ${q(
             key,
           )}`;
         }
-        return [path, value];
+        return [key, value];
       });
-      sendToChainStorage(
+      chainSend(
+        portNums.swingset,
         stringify({
-          method: 'setWithoutNotify',
+          method: 'swingStoreUpdateExportData',
           args: entries,
         }),
       );

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -652,6 +652,10 @@ export default async function main(progname, args, { env, homedir, agcc }) {
 
         !blockingSend || Fail`Swingset already initialized`;
 
+        if (action.swingsetPort) {
+          portNums.swingset = action.swingsetPort;
+        }
+
         if (action.vibcPort) {
           portNums.dibc = action.vibcPort;
         }

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -39,6 +39,7 @@ const bootMsgEx = {
     { denom: 'ubld', amount: '1000000000000000' },
     { denom: 'uist', amount: '50000000000' },
   ],
+  swingsetPort: 4,
   vbankPort: 3,
   vibcPort: 2,
 };

--- a/packages/vats/test/test-vat-bank-integration.js
+++ b/packages/vats/test/test-vat-bank-integration.js
@@ -51,6 +51,7 @@ test('mintInitialSupply, addBankAssets bootstrap actions', async t => {
     chainID: 'ag',
     storagePort: 1,
     supplyCoins: [{ amount: '50000000', denom: 'uist' }],
+    swingsetPort: 4,
     vbankPort: 2,
     vibcPort: 3,
   };


### PR DESCRIPTION
refs: #8031

Best reviewed commit-by-commit

## Description

Add a prefix DB to the `x/swingset`'s module store, and use it for the swing-store shadow copy / export data instead of vstorage. The export (used by state-sync restore, and genesis export) now uses a proper iterator.

We also add this data to the genesis export, however as with the current vstorage based implementation, this is not comprehensive (omits necessary artifacts), and doesn't support init from such genesis yet (no restore of swing-store). This will be addressed with https://github.com/Agoric/agoric-sdk/issues/6527

This does not include a migration from existing swing-store data in vstorage, and as such cannot be used for an upgrade yet.

### Security Considerations

This reduces the dependencies between the vstorage and swingset modules, making it easier to reason about the responsibilities of each.

### Scaling Considerations

By using a plain prefix DB we avoid the more costly key encodings of vstorage, which is particularly impactful for iterations.

### Documentation Considerations

None

### Testing Considerations

The new store comes with unit tests
Ran the deployment integration test which exercises state-sync end-to-end.
