### PR TITLE
use contract "start" consistently

### DIFF
--- a/packages/agoric-cli/test/upgrade-contract/fixed-contract.js
+++ b/packages/agoric-cli/test/upgrade-contract/fixed-contract.js
@@ -1,12 +1,18 @@
 import { AmountMath } from '@agoric/ertp';
 import { makeDurableZone } from '@agoric/zone/durable.js';
 
+/** @type {ContractMeta} */
+export const meta = {
+  upgradability: 'canUpgrade',
+};
+harden(meta);
+
 /**
  * @param {ZCF} zcf
  * @param {*} _privateArgs
  * @param {MapStore<any, any>} baggage
  */
-export const prepare = async (zcf, _privateArgs, baggage) => {
+export const start = async (zcf, _privateArgs, baggage) => {
   const zone = makeDurableZone(baggage);
 
   /** @type {ZCFMint} */

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -29,6 +29,7 @@ export const meta = {
     storageNode: StorageNodeShape,
     marshaller: M.remotable('Marshaller'),
   },
+  upgradability: 'canUpgrade',
 };
 harden(meta);
 
@@ -49,7 +50,7 @@ harden(meta);
  * @param {import('@agoric/vat-data').Baggage} baggage
  * @returns {{creatorFacet: CommitteeElectorateCreatorFacet, publicFacet: CommitteeElectoratePublic}}
  */
-export const prepare = (zcf, privateArgs, baggage) => {
+export const start = (zcf, privateArgs, baggage) => {
   /** @type {MapStore<Handle<'Question'>, import('./electorateTools.js').QuestionRecord>} */
   const allQuestions = provideDurableMapStore(baggage, 'Question');
 
@@ -173,4 +174,4 @@ export const prepare = (zcf, privateArgs, baggage) => {
 
   return { publicFacet, creatorFacet };
 };
-harden(prepare);
+harden(start);

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -23,11 +23,14 @@ const { ceilDivide } = natSafeMath;
  * }} CommitteeElectorateCreatorFacet
  */
 
-export const privateArgsShape = {
-  storageNode: StorageNodeShape,
-  marshaller: M.remotable('Marshaller'),
+/** @type {ContractMeta} */
+export const meta = {
+  privateArgsShape: {
+    storageNode: StorageNodeShape,
+    marshaller: M.remotable('Marshaller'),
+  },
 };
-harden(privateArgsShape);
+harden(meta);
 
 /**
  * Each Committee (an Electorate) represents a particular set of voters. The
@@ -170,5 +173,4 @@ export const prepare = (zcf, privateArgs, baggage) => {
 
   return { publicFacet, creatorFacet };
 };
-
 harden(prepare);

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -11,6 +11,12 @@ const { Fail } = assert;
 
 const trace = makeTracer('CGov', false);
 
+/** @type {ContractMeta} */
+export const meta = {
+  upgradability: 'canUpgrade',
+};
+harden(meta);
+
 /**
  * Validate that the question details correspond to a parameter change question
  * that the electorate hosts, and that the voteCounter and other details are
@@ -147,8 +153,8 @@ harden(validateQuestionFromCounter);
  * }>}
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
-  trace('prepare');
+export const start = async (zcf, privateArgs, baggage) => {
+  trace('start');
   const zoe = zcf.getZoeService();
   trace('getTerms', zcf.getTerms());
   const {
@@ -202,9 +208,9 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   // Specifically, to the vat of the governed contract for its API names. The exo
   // defers that until API governance is requested to be invoked or validated.
 
-  trace('prepare complete');
+  trace('start complete');
 
   // CRUCIAL: only contractGovernor should get the ability to update params
   return { creatorFacet: governorKit.creator, publicFacet: governorKit.public };
 };
-harden(prepare);
+harden(start);

--- a/packages/governance/src/types-ambient.js
+++ b/packages/governance/src/types-ambient.js
@@ -65,7 +65,7 @@
  *
  * @template {import('./contractGovernance/typedParamManager.js').ParamTypesMap} T Governed parameters of contract
  * @typedef {{
- *   electionManager: import('@agoric/zoe/src/zoeService/utils.js').Instance<import('./contractGovernor.js')['prepare']>,
+ *   electionManager: import('@agoric/zoe/src/zoeService/utils.js').Instance<import('./contractGovernor.js')['start']>,
  *   governedParams: import('./contractGovernance/typedParamManager.js').ParamRecordsFromTypes<T & {
  *     Electorate: 'invitation'
  *   }>
@@ -680,7 +680,7 @@
  * @param {ERef<ZoeService>} zoe
  * @param {import('@agoric/zoe/src/zoeService/utils.js').Instance<(zcf: ZCF<GovernanceTerms<{}>>) => {}>} allegedGoverned
  * @param {Instance} allegedGovernor
- * @param {Installation<import('@agoric/governance/src/contractGovernor.js').prepare>} contractGovernorInstallation
+ * @param {Installation<import('@agoric/governance/src/contractGovernor.js').start>} contractGovernorInstallation
  * @returns {Promise<GovernancePair>}
  */
 
@@ -699,7 +699,7 @@
  */
 
 /**
- * @typedef {import('./contractGovernor.js')['prepare']} GovernorSF
+ * @typedef {import('./contractGovernor.js')['start']} GovernorSF
  */
 
 // TODO find a way to parameterize the startInstance so the governed contract types flow

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
@@ -40,7 +40,7 @@ const verify = async (log, issue, electoratePublicFacet, instances) => {
 const build = async (log, zoe) => {
   return Far('voter', {
     createVoter: async (name, invitation, choice) => {
-      /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<typeof import('@agoric/governance/src/committee.js').prepare>} */
+      /** @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<typeof import('@agoric/governance/src/committee.js').start>} */
       const electorateInstance = await E(zoe).getInstance(invitation);
       const electoratePublicFacet = E(zoe).getPublicFacet(electorateInstance);
       const seat = E(zoe).offer(invitation);

--- a/packages/governance/test/unitTests/test-committee.js
+++ b/packages/governance/test/unitTests/test-committee.js
@@ -37,7 +37,7 @@ const setupContract = async () => {
     bundleSource(counterRoot),
   ]);
   // install the contract
-  /** @typedef {Installation<import('../../src/committee.js')['prepare']>} CommitteInstallation */
+  /** @typedef {Installation<import('../../src/committee.js')['start']>} CommitteInstallation */
   /** @typedef {Installation<import('../../src/binaryVoteCounter.js').start>} CounterInstallation */
   /** @type {[CommitteInstallation, CounterInstallation] } */
   const [electorateInstallation, counterInstallation] = await Promise.all([

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -44,6 +44,7 @@ export const meta = {
   customTermsShape: {
     binaryVoteCounterInstallation: InstallationShape,
   },
+  upgradability: 'canUpgrade',
 };
 harden(meta);
 
@@ -52,7 +53,7 @@ harden(meta);
  * @param {undefined} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, privateArgs, baggage) => {
   const { binaryVoteCounterInstallation: counter } = zcf.getTerms();
   /** @type {MapStore<Instance, GovernorCreatorFacet<any>>} */
   const instanceToGovernor = provideDurableMapStore(
@@ -183,3 +184,4 @@ export const prepare = async (zcf, privateArgs, baggage) => {
 
   return harden({ creatorFacet });
 };
+harden(start);

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -39,10 +39,13 @@ const ParamChangesOfferArgsShape = M.splitRecord(
   },
 );
 
-/** A pattern for Zoe to check custom terms before `start()`ing the contract. */
-export const customTermsShape = harden({
-  binaryVoteCounterInstallation: InstallationShape,
-});
+/** @type {ContractMeta} */
+export const meta = {
+  customTermsShape: {
+    binaryVoteCounterInstallation: InstallationShape,
+  },
+};
+harden(meta);
 
 /**
  * @param {ZCF<{ binaryVoteCounterInstallation: Installation }>} zcf

--- a/packages/inter-protocol/src/feeDistributor.js
+++ b/packages/inter-protocol/src/feeDistributor.js
@@ -9,12 +9,15 @@ import { KeywordShape } from '@agoric/zoe/src/typeGuards.js';
 
 const KeywordSharesShape = M.recordOf(KeywordShape, M.nat());
 
-/** A pattern for Zoe to check custom terms before `start()`ing the contract. */
-export const customTermsShape = harden({
-  keywordShares: KeywordSharesShape,
-  timerService: M.eref(M.remotable('TimerService')),
-  collectionInterval: RelativeTimeShape,
-});
+/** @type {ContractMeta} */
+export const meta = {
+  customTermsShape: {
+    keywordShares: KeywordSharesShape,
+    timerService: M.eref(M.remotable('TimerService')),
+    collectionInterval: RelativeTimeShape,
+  },
+};
+harden(meta);
 
 /**
  * @typedef {import('@agoric/time/src/types').RelativeTime} RelativeTime

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -40,6 +40,7 @@ export const meta = {
       initialPoserInvitation: M.remotable('Invitation'),
     },
   ),
+  upgradability: 'canUpgrade',
 };
 harden(meta);
 
@@ -66,7 +67,7 @@ harden(meta);
  * }} privateArgs
  * @param {Baggage} baggage
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, privateArgs, baggage) => {
   trace('prepare with baggage keys', [...baggage.keys()]);
 
   // xxx uses contract baggage as issuerBagage, assumes one issuer in this contract
@@ -192,4 +193,4 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     publicFacet: faKit.public,
   });
 };
-harden(prepare);
+harden(start);

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -22,22 +22,26 @@ const trace = makeTracer('FluxAgg', false);
  * @typedef {import('@agoric/time/src/types').TimerService} TimerService
  */
 
-export const privateArgsShape = M.splitRecord(
-  harden({
-    storageNode: StorageNodeShape,
-    marshaller: M.eref(M.remotable('marshaller')),
-    namesByAddressAdmin: M.any(),
-  }),
-  harden({
-    // always optional. XXX some code is including the key, set to null
-    highPrioritySendersManager: M.or(
-      M.remotable('prioritySenders manager'),
-      M.null(),
-    ),
-    // only necessary on first invocation, not subsequent
-    initialPoserInvitation: M.remotable('Invitation'),
-  }),
-);
+/** @type {ContractMeta} */
+export const meta = {
+  privateArgsShape: M.splitRecord(
+    {
+      storageNode: StorageNodeShape,
+      marshaller: M.eref(M.remotable('marshaller')),
+      namesByAddressAdmin: M.any(),
+    },
+    {
+      // always optional. XXX some code is including the key, set to null
+      highPrioritySendersManager: M.or(
+        M.remotable('prioritySenders manager'),
+        M.null(),
+      ),
+      // only necessary on first invocation, not subsequent
+      initialPoserInvitation: M.remotable('Invitation'),
+    },
+  ),
+};
+harden(meta);
 
 /**
  * PriceAuthority for their median. Unlike the simpler `priceAggregator.js`,

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -36,11 +36,11 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
  * @property {Awaited<
  *   ReturnType<
  *     Awaited<
- *       ReturnType<import('../psm/psm.js')['prepare']>
+ *       ReturnType<import('../psm/psm.js')['start']>
  *     >['creatorFacet']['getLimitedCreatorFacet']
  *   >
  * >} psmCreatorFacet
- * @property {GovernorCreatorFacet<import('../../src/psm/psm.js')['prepare']>} psmGovernorCreatorFacet
+ * @property {GovernorCreatorFacet<import('../../src/psm/psm.js')['start']>} psmGovernorCreatorFacet
  * @property {AdminFacet} psmAdminFacet
  */
 
@@ -63,10 +63,10 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
  *   anchorBalancePayments: MapStore<Brand, Payment<'nat'>>;
  *   econCharterKit: EconCharterStartResult;
  *   reserveKit: GovernanceFacetKit<
- *     import('../reserve/assetReserve.js')['prepare']
+ *     import('../reserve/assetReserve.js')['start']
  *   >;
  *   vaultFactoryKit: GovernanceFacetKit<
- *     import('../vaultFactory/vaultFactory.js')['prepare']
+ *     import('../vaultFactory/vaultFactory.js')['start']
  *   >;
  *   auctioneerKit: AuctioneerKit;
  *   minInitialDebt: NatValue;
@@ -75,12 +75,12 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
 
 /**
  * @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<
- *   import('../econCommitteeCharter')['prepare']
+ *   import('../econCommitteeCharter')['start']
  * >} EconCharterStartResult
  */
 /**
  * @typedef {import('@agoric/zoe/src/zoeService/utils.js').StartedInstanceKit<
- *   import('@agoric/governance/src/committee.js')['prepare']
+ *   import('@agoric/governance/src/committee.js')['start']
  * >} CommitteeStartResult
  */
 

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -137,7 +137,7 @@ export const createPriceFeed = async (
    *   [Brand<'nat'>, Brand<'nat'>],
    *   [
    *     Installation<
-   *       import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').prepare
+   *       import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js')['start]
    *     >,
    *   ],
    * ]}

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -64,40 +64,41 @@ const { Fail } = assert;
 
 /** @typedef {import('@agoric/vat-data').Baggage} Baggage */
 
-export const customTermsShape = {
-  anchorBrand: BrandShape,
-  anchorPerMinted: RatioShape,
-  electionManager: InstanceHandleShape,
-  governedParams: {
-    [CONTRACT_ELECTORATE]: {
-      type: ParamTypes.INVITATION,
-      value: AmountShape,
+/** @type {ContractMeta} */
+export const meta = {
+  customTermsShape: {
+    anchorBrand: BrandShape,
+    anchorPerMinted: RatioShape,
+    electionManager: InstanceHandleShape,
+    governedParams: {
+      [CONTRACT_ELECTORATE]: {
+        type: ParamTypes.INVITATION,
+        value: AmountShape,
+      },
+      WantMintedFee: {
+        type: ParamTypes.RATIO,
+        value: RatioShape,
+      },
+      GiveMintedFee: {
+        type: ParamTypes.RATIO,
+        value: RatioShape,
+      },
+      MintLimit: { type: ParamTypes.AMOUNT, value: AmountShape },
     },
-    WantMintedFee: {
-      type: ParamTypes.RATIO,
-      value: RatioShape,
-    },
-    GiveMintedFee: {
-      type: ParamTypes.RATIO,
-      value: RatioShape,
-    },
-    MintLimit: { type: ParamTypes.AMOUNT, value: AmountShape },
   },
+  privateArgsShape: M.splitRecord(
+    {
+      marshaller: M.remotable('Marshaller'),
+      storageNode: StorageNodeShape,
+    },
+    {
+      // only necessary on first invocation, not subsequent
+      feeMintAccess: FeeMintAccessShape,
+      initialPoserInvitation: InvitationShape,
+    },
+  ),
 };
-harden(customTermsShape);
-
-export const privateArgsShape = M.splitRecord(
-  harden({
-    marshaller: M.remotable('Marshaller'),
-    storageNode: StorageNodeShape,
-  }),
-  harden({
-    // only necessary on first invocation, not subsequent
-    feeMintAccess: FeeMintAccessShape,
-    initialPoserInvitation: InvitationShape,
-  }),
-);
-harden(privateArgsShape);
+harden(meta);
 
 /**
  * @param {ZCF<

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -66,6 +66,7 @@ const { Fail } = assert;
 
 /** @type {ContractMeta} */
 export const meta = {
+  upgradability: 'canUpgrade',
   customTermsShape: {
     anchorBrand: BrandShape,
     anchorPerMinted: RatioShape,
@@ -119,7 +120,7 @@ harden(meta);
  * }} privateArgs
  * @param {Baggage} baggage
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, privateArgs, baggage) => {
   const { anchorBrand, anchorPerMinted } = zcf.getTerms();
   console.log('PSM Starting', anchorBrand, anchorPerMinted);
 
@@ -444,5 +445,6 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     publicFacet,
   });
 };
+harden(start);
 
-/** @typedef {Awaited<ReturnType<typeof prepare>>['publicFacet']} PsmPublicFacet */
+/** @typedef {Awaited<ReturnType<typeof start>>['publicFacet']} PsmPublicFacet */

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -10,6 +10,12 @@ import { prepareAssetReserveKit } from './assetReserveKit.js';
 
 const trace = makeTracer('AR', true);
 
+/** @type {ContractMeta} */
+export const meta = {
+  upgradability: 'canUpgrade',
+};
+harden(meta);
+
 /**
  * @typedef {{
  *   increaseLiquidationShortfall: (increase: Amount) => void;
@@ -39,7 +45,7 @@ const trace = makeTracer('AR', true);
  * }} privateArgs
  * @param {Baggage} baggage
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, privateArgs, baggage) => {
   trace('prepare', Object.keys(privateArgs), [...baggage.keys()]);
   // This contract mixes two styles of access to durable state. durableStores
   // are declared at the top level and referenced lexically. local state is
@@ -106,7 +112,7 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     publicFacet: /** @type {any} */ (assetReserveKit.public),
   };
 };
-harden(prepare);
+harden(start);
 
 /**
  * @typedef {object} ShortfallReporter
@@ -121,8 +127,8 @@ harden(prepare);
  * @property {() => Promise<Invitation<ShortfallReporter>>} makeShortfallReportingInvitation
  */
 
-/** @typedef {Awaited<ReturnType<typeof prepare>>['publicFacet']} AssetReservePublicFacet */
+/** @typedef {Awaited<ReturnType<typeof start>>['publicFacet']} AssetReservePublicFacet */
 /**
- * @typedef {Awaited<ReturnType<typeof prepare>>['creatorFacet']} AssetReserveCreatorFacet
+ * @typedef {Awaited<ReturnType<typeof start>>['creatorFacet']} AssetReserveCreatorFacet
  *   the creator facet for the governor
  */

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -58,6 +58,7 @@ export const meta = {
       initialShortfallInvitation: InvitationShape,
     },
   ),
+  upgradability: 'canUpgrade',
 };
 harden(meta);
 
@@ -72,7 +73,7 @@ harden(meta);
  * }} privateArgs
  * @param {import('@agoric/ertp').Baggage} baggage
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, privateArgs, baggage) => {
   trace('prepare start', privateArgs, [...baggage.keys()]);
   const {
     initialPoserInvitation,
@@ -150,5 +151,6 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     publicFacet: director.public,
   });
 };
+harden(start);
 
-/** @typedef {ContractOf<typeof prepare>} VaultFactoryContract */
+/** @typedef {ContractOf<typeof start>} VaultFactoryContract */

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -44,19 +44,22 @@ const trace = makeTracer('VF', true);
  * >} VaultFactoryZCF
  */
 
-export const privateArgsShape = M.splitRecord(
-  harden({
-    marshaller: M.remotable('Marshaller'),
-    storageNode: StorageNodeShape,
-  }),
-  harden({
-    // only necessary on first invocation, not subsequent
-    feeMintAccess: FeeMintAccessShape,
-    initialPoserInvitation: InvitationShape,
-    initialShortfallInvitation: InvitationShape,
-  }),
-);
-harden(privateArgsShape);
+/** @type {ContractMeta} */
+export const meta = {
+  privateArgsShape: M.splitRecord(
+    {
+      marshaller: M.remotable('Marshaller'),
+      storageNode: StorageNodeShape,
+    },
+    {
+      // only necessary on first invocation, not subsequent
+      feeMintAccess: FeeMintAccessShape,
+      initialPoserInvitation: InvitationShape,
+      initialShortfallInvitation: InvitationShape,
+    },
+  ),
+};
+harden(meta);
 
 /**
  * @param {VaultFactoryZCF} zcf

--- a/packages/inter-protocol/test/auction/tools.js
+++ b/packages/inter-protocol/test/auction/tools.js
@@ -17,9 +17,9 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
  *   >;
  *   auctioneer: Installation<import('../../src/auction/auctioneer').start>;
  *   governor: Installation<
- *     import('@agoric/governance/src/contractGovernor.js')['prepare']
+ *     import('@agoric/governance/src/contractGovernor.js')['start']
  *   >;
- *   reserve: Installation<import('../../src/reserve/assetReserve.js').prepare>;
+ *   reserve: Installation<import('../../src/reserve/assetReserve.js').start>;
  * }} AuctionTestInstallations
  */
 

--- a/packages/inter-protocol/test/psm/test-psm.js
+++ b/packages/inter-protocol/test/psm/test-psm.js
@@ -197,7 +197,7 @@ async function makePsmDriver(t, customTerms) {
   // Each driver needs its own to avoid state pollution between tests
   const mockChainStorage = makeMockChainStorageRoot();
 
-  /** @type {Awaited<ReturnType<import('../../src/psm/psm.js').prepare>>} */
+  /** @type {Awaited<ReturnType<import('../../src/psm/psm.js').start>>} */
   const { creatorFacet, publicFacet } = await E(zoe).startInstance(
     psmInstall,
     harden({ AUSD: anchor.issuer }),

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -64,7 +64,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
   );
   /**
    * @type {Promise<
-   *   Installation<import('@agoric/smart-wallet/src/walletFactory.js').prepare>
+   *   Installation<import('@agoric/smart-wallet/src/walletFactory.js').start>
    * >}
    */
   const installation = E(zoe).install(bundle);
@@ -160,7 +160,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     /**
      * @type {Promise<
      *   Installation<
-     *     import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').prepare
+     *     import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').start
      *   >
      * >}
      */

--- a/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-oracle-integration.js
@@ -121,7 +121,7 @@ const setupFeedWithWallets = async (t, oracleAddresses) => {
 
   /**
    * @type {import('@agoric/zoe/src/zoeService/utils.js').Instance<
-   *   import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').prepare
+   *   import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').start
    * >}
    */
   const governedPriceAggregator = await E(agoricNames).lookup(
@@ -373,7 +373,7 @@ test.serial('govern oracles list', async t => {
   );
   /**
    * @type {import('@agoric/zoe/src/zoeService/utils').Instance<
-   *   import('@agoric/governance/src/committee.js')['prepare']
+   *   import('@agoric/governance/src/committee.js')['start']
    * >}
    */
   const economicCommittee = await E(agoricNames).lookup(

--- a/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
@@ -40,10 +40,10 @@ export const buildRootObject = async () => {
   /**
    * @type {{
    *   committee?: Installation<
-   *     import('@agoric/governance/src/committee.js')['prepare']
+   *     import('@agoric/governance/src/committee.js')['start']
    *   >;
    *   fluxAggregatorV1?: Installation<
-   *     import('../../../src/price/fluxAggregatorContract').prepare
+   *     import('../../../src/price/fluxAggregatorContract').start
    *   >;
    *   puppetContractGovernor?: Installation<
    *     import('@agoric/governance/tools/puppetContractGovernor').start
@@ -57,7 +57,7 @@ export const buildRootObject = async () => {
    * @type {ReturnType<
    *   Awaited<
    *     ReturnType<
-   *       import('../../../src/price/fluxAggregatorContract.js').prepare
+   *       import('../../../src/price/fluxAggregatorContract.js').start
    *     >
    *   >['creatorFacet']['getLimitedCreatorFacet']
    * >}
@@ -74,7 +74,7 @@ export const buildRootObject = async () => {
   /**
    * @type {Omit<
    *   import('@agoric/zoe/src/zoeService/utils.js').StartParams<
-   *     import('../../../src/price/fluxAggregatorContract.js').prepare
+   *     import('../../../src/price/fluxAggregatorContract.js').start
    *   >['terms'],
    *   'issuers' | 'brands'
    * >}

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
@@ -24,7 +24,7 @@ const anchor = withAmountUtils(makeIssuerKit('bucks'));
 const firstGive = anchor.units(21);
 const secondGive = anchor.units(3);
 
-/** @typedef {import('../../../src/psm/psm.js').prepare} PsmSF */
+/** @typedef {import('../../../src/psm/psm.js').start} PsmSF */
 
 export const buildRootObject = async () => {
   const storageKit = makeFakeStorageKit('psmUpgradeTest');
@@ -67,7 +67,7 @@ export const buildRootObject = async () => {
   /**
    * @type {{
    *   committee?: Installation<
-   *     import('@agoric/governance/src/committee.js')['prepare']
+   *     import('@agoric/governance/src/committee.js')['start']
    *   >;
    *   psmV1?: Installation<PsmSF>;
    *   puppetContractGovernor?: Installation<

--- a/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
@@ -56,10 +56,10 @@ export const buildRootObject = async () => {
   /**
    * @type {{
    *   committee?: Installation<
-   *     import('@agoric/governance/src/committee')['prepare']
+   *     import('@agoric/governance/src/committee')['start']
    *   >;
    *   assetReserveV1?: Installation<
-   *     import('../../../src/reserve/assetReserve')['prepare']
+   *     import('../../../src/reserve/assetReserve')['start']
    *   >;
    *   puppetContractGovernor?: Installation<
    *     import('@agoric/governance/tools/puppetContractGovernor')['start']
@@ -70,14 +70,14 @@ export const buildRootObject = async () => {
 
   /**
    * @type {import('@agoric/governance/tools/puppetContractGovernor').PuppetContractGovernorKit<
-   *     import('../../../src/reserve/assetReserve.js').prepare
+   *     import('../../../src/reserve/assetReserve.js').start
    *   >}
    */
   let governorFacets;
   /**
    * @type {ReturnType<
    *   Awaited<
-   *     ReturnType<import('../../../src/reserve/assetReserve.js').prepare>
+   *     ReturnType<import('../../../src/reserve/assetReserve.js').start>
    *   >['creatorFacet']['getLimitedCreatorFacet']
    * >}
    */
@@ -86,7 +86,7 @@ export const buildRootObject = async () => {
   /**
    * @type {Omit<
    *   import('@agoric/zoe/src/zoeService/utils.js').StartParams<
-   *     import('../../../src/reserve/assetReserve.js').prepare
+   *     import('../../../src/reserve/assetReserve.js').start
    *   >['terms'],
    *   'issuers' | 'brands'
    * >}

--- a/packages/inter-protocol/test/test-feeDistributor.js
+++ b/packages/inter-protocol/test/test-feeDistributor.js
@@ -8,7 +8,7 @@ import { setup } from '@agoric/zoe/test/unitTests/setupBasicMints.js';
 import { assertPayoutAmount } from '@agoric/zoe/test/zoeTestHelpers.js';
 import { E, Far } from '@endo/far';
 import { mustMatch } from '@agoric/store';
-import { makeFeeDistributor, customTermsShape } from '../src/feeDistributor.js';
+import { makeFeeDistributor, meta } from '../src/feeDistributor.js';
 
 /** @param {Issuer} feeIssuer */
 const makeFakeFeeDepositFacetKit = feeIssuer => {
@@ -254,7 +254,7 @@ test('feeDistributor custom terms shape catches non-Nat bigint', t => {
           timerService,
           collectionInterval: 2n,
         }),
-        customTermsShape,
+        meta.customTermsShape,
       ),
     { message: 'keywordShares: Reserve: [1]: "[-1n]" - Must be non-negative' },
   );

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -27,6 +27,7 @@ export const meta = {
     { storageNode: M.eref(M.remotable('StorageNode')) },
     { walletBridgeManager: M.eref(M.remotable('walletBridgeManager')) },
   ),
+  upgradability: 'canUpgrade',
 };
 harden(meta);
 
@@ -142,7 +143,7 @@ export const makeAssetRegistry = assetPublisher => {
  * }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, privateArgs, baggage) => {
   const { agoricNames, board, assetPublisher } = zcf.getTerms();
 
   const zoe = zcf.getZoeService();
@@ -300,3 +301,4 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     creatorFacet,
   };
 };
+harden(start);

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -16,18 +16,19 @@ import { shape } from './typeGuards.js';
 
 const trace = makeTracer('WltFct');
 
-export const privateArgsShape = harden(
-  M.splitRecord(
+/** @type {ContractMeta} */
+export const meta = {
+  customTermsShape: {
+    agoricNames: M.eref(M.remotable('agoricNames')),
+    board: M.eref(M.remotable('board')),
+    assetPublisher: M.eref(M.remotable('Bank')),
+  },
+  privateArgsShape: M.splitRecord(
     { storageNode: M.eref(M.remotable('StorageNode')) },
     { walletBridgeManager: M.eref(M.remotable('walletBridgeManager')) },
   ),
-);
-
-export const customTermsShape = harden({
-  agoricNames: M.eref(M.remotable('agoricNames')),
-  board: M.eref(M.remotable('board')),
-  assetPublisher: M.eref(M.remotable('Bank')),
-});
+};
+harden(meta);
 
 /**
  * Provide a NameHub for this address and insert depositFacet only if not

--- a/packages/smart-wallet/test/contexts.js
+++ b/packages/smart-wallet/test/contexts.js
@@ -24,7 +24,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     `${dirname}/../src/walletFactory.js`,
     'walletFactory',
   );
-  /** @type {Promise<Installation<import('../src/walletFactory.js').prepare>>} */
+  /** @type {Promise<Installation<import('../src/walletFactory.js').start>>} */
   const installation = E(zoe).install(bundle);
   //#endregion
 

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
@@ -41,7 +41,7 @@ export const buildRootObject = async () => {
   let wallet;
 
   // for startInstance
-  /** @type {Installation<import('../../../src/walletFactory.js').prepare>} */
+  /** @type {Installation<import('../../../src/walletFactory.js').start>} */
   let installation;
   const terms = {
     agoricNames,

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/walletFactory-V2.js
@@ -17,10 +17,16 @@ import {
   publishDepositFacet,
 } from '../../../src/walletFactory.js';
 
+/** @type {ContractMeta} */
+export const meta = {
+  upgradability: 'canUpgrade',
+};
+harden(meta);
+
 /**
- * @type {typeof import('../../../src/walletFactory.js').prepare}
+ * @type {typeof import('../../../src/walletFactory.js').start}
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, privateArgs, baggage) => {
   // copy paste from original contract, with type imports fixed and sayHelloUpgrade method added to creatorFacet)
   const { agoricNames, board, assetPublisher } = zcf.getTerms();
 

--- a/packages/smart-wallet/test/test-startWalletFactory.js
+++ b/packages/smart-wallet/test/test-startWalletFactory.js
@@ -26,7 +26,7 @@ const makeTestContext = async () => {
     `${dirname}/../src/walletFactory.js`,
     'walletFactory',
   );
-  /** @type {Promise<Installation<import('../src/walletFactory.js').prepare>>} */
+  /** @type {Promise<Installation<import('../src/walletFactory.js').start>>} */
   const installation = E(zoe).install(bundle);
   //#endregion
 

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -18,7 +18,7 @@ const trace = makeTracer('StartWF');
 /**
  * @param {ERef<ZoeService>} zoe
  * @param {Installation<
- *   import('@agoric/smart-wallet/src/walletFactory').prepare
+ *   import('@agoric/smart-wallet/src/walletFactory').start
  * >} inst
  *
  * @typedef {Awaited<ReturnType<typeof startFactoryInstance>>} WalletFactoryStartResult
@@ -66,7 +66,7 @@ const publishRevivableWalletState = async (
  *     econCharterKit: {
  *       creatorFacet: Awaited<
  *         ReturnType<
- *           import('@agoric/inter-protocol/src/econCommitteeCharter.js')['prepare']
+ *           import('@agoric/inter-protocol/src/econCommitteeCharter.js')['start']
  *         >
  *       >['creatorFacet'];
  *       adminFacet: AdminFacet;

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -248,18 +248,16 @@
  *         Installation<import('@agoric/vats/src/centralSupply.js').start>
  *       >;
  *       committee: Promise<
- *         Installation<
- *           import('@agoric/governance/src/committee.js')['prepare']
- *         >
+ *         Installation<import('@agoric/governance/src/committee.js')['start']>
  *       >;
  *       contractGovernor: Promise<
  *         Installation<
- *           import('@agoric/governance/src/contractGovernor.js')['prepare']
+ *           import('@agoric/governance/src/contractGovernor.js')['start']
  *         >
  *       >;
  *       econCommitteeCharter: Promise<
  *         Installation<
- *           import('@agoric/inter-protocol/src/econCommitteeCharter.js')['prepare']
+ *           import('@agoric/inter-protocol/src/econCommitteeCharter.js')['start']
  *         >
  *       >;
  *       feeDistributor: Promise<
@@ -268,29 +266,29 @@
  *         >
  *       >;
  *       mintHolder: Promise<
- *         Installation<import('@agoric/vats/src/mintHolder.js').prepare>
+ *         Installation<import('@agoric/vats/src/mintHolder.js').start>
  *       >;
  *       psm: Promise<
  *         Installation<
- *           import('@agoric/inter-protocol/src/psm/psm.js')['prepare']
+ *           import('@agoric/inter-protocol/src/psm/psm.js')['start']
  *         >
  *       >;
  *       provisionPool: Promise<
- *         Installation<import('@agoric/vats/src/provisionPool.js')['prepare']>
+ *         Installation<import('@agoric/vats/src/provisionPool.js')['start']>
  *       >;
  *       reserve: Promise<
  *         Installation<
- *           import('@agoric/inter-protocol/src/reserve/assetReserve.js')['prepare']
+ *           import('@agoric/inter-protocol/src/reserve/assetReserve.js')['start']
  *         >
  *       >;
  *       VaultFactory: Promise<
  *         Installation<
- *           import('@agoric/inter-protocol/src/vaultFactory/vaultFactory.js')['prepare']
+ *           import('@agoric/inter-protocol/src/vaultFactory/vaultFactory.js')['start']
  *         >
  *       >;
  *       walletFactory: Promise<
  *         Installation<
- *           import('@agoric/smart-wallet/src/walletFactory.js').prepare
+ *           import('@agoric/smart-wallet/src/walletFactory.js').start
  *         >
  *       >;
  *     };

--- a/packages/vats/src/mintHolder.js
+++ b/packages/vats/src/mintHolder.js
@@ -32,6 +32,12 @@ function provideIssuerKit(zcf, baggage) {
   }
 }
 
+/** @type {ContractMeta} */
+export const meta = {
+  upgradability: 'canUpgrade',
+};
+harden(meta);
+
 /**
  * This contract holds one mint; it basically wraps makeIssuerKit in its own
  * contract, and hence in its own vat.
@@ -41,7 +47,7 @@ function provideIssuerKit(zcf, baggage) {
  * @param {undefined} _privateArgs
  * @param {Baggage} instanceBaggage
  */
-export const prepare = (zcf, _privateArgs, instanceBaggage) => {
+export const start = (zcf, _privateArgs, instanceBaggage) => {
   const { mint, issuer } = provideIssuerKit(zcf, instanceBaggage);
 
   return {
@@ -49,4 +55,4 @@ export const prepare = (zcf, _privateArgs, instanceBaggage) => {
     creatorFacet: mint,
   };
 };
-harden(prepare);
+harden(start);

--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -14,18 +14,22 @@ import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/record
 import { TopicsRecordShape } from '@agoric/zoe/src/contractSupport/topics.js';
 import { prepareProvisionPoolKit } from './provisionPoolKit.js';
 
-export const privateArgsShape = M.splitRecord(
-  harden({
-    poolBank: M.eref(M.remotable('bank')),
-    storageNode: M.eref(M.remotable('storageNode')),
-    marshaller: M.eref(M.remotable('marshaller')),
-  }),
-  harden({
-    // only necessary on first invocation, not subsequent
-    initialPoserInvitation: InvitationShape,
-    metricsOverride: M.recordOf(M.string()),
-  }),
-);
+/** @type {ContractMeta} */
+export const meta = {
+  privateArgsShape: M.splitRecord(
+    {
+      poolBank: M.eref(M.remotable('bank')),
+      storageNode: M.eref(M.remotable('storageNode')),
+      marshaller: M.eref(M.remotable('marshaller')),
+    },
+    {
+      // only necessary on first invocation, not subsequent
+      initialPoserInvitation: InvitationShape,
+      metricsOverride: M.recordOf(M.string()),
+    },
+  ),
+};
+harden(meta);
 
 /**
  * @typedef {StandardTerms &

--- a/packages/vats/src/provisionPool.js
+++ b/packages/vats/src/provisionPool.js
@@ -28,6 +28,7 @@ export const meta = {
       metricsOverride: M.recordOf(M.string()),
     },
   ),
+  upgradability: 'canUpgrade',
 };
 harden(meta);
 
@@ -47,7 +48,7 @@ harden(meta);
  * }} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, privateArgs, baggage) => {
   const { poolBank, metricsOverride } = privateArgs;
 
   const { makeRecorderKit } = prepareRecorderKitMakers(
@@ -113,4 +114,4 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   });
 };
 
-harden(prepare);
+harden(start);

--- a/packages/vats/src/provisionPoolKit.js
+++ b/packages/vats/src/provisionPoolKit.js
@@ -25,7 +25,7 @@ const { details: X, quote: q, Fail } = assert;
 
 /**
  * @typedef {import('@agoric/zoe/src/zoeService/utils').Instance<
- *   import('@agoric/inter-protocol/src/psm/psm.js').prepare
+ *   import('@agoric/inter-protocol/src/psm/psm.js').start
  * >} PsmInstance
  */
 

--- a/packages/vats/test/test-provisionPool.js
+++ b/packages/vats/test/test-provisionPool.js
@@ -63,7 +63,7 @@ const makeTestContext = async () => {
   const committeeInstall = await E(zoe).install(committeeBundle);
   const psmInstall = await E(zoe).install(psmBundle);
   const centralSupply = await E(zoe).install(centralSupplyBundle);
-  /** @type {Installation<import('../src/provisionPool')['prepare']>} */
+  /** @type {Installation<import('../src/provisionPool')['start']>} */
   const policyInstall = await E(zoe).install(policyBundle);
 
   const mintLimit = AmountMath.make(mintedBrand, MINT_LIMIT);

--- a/packages/zoe/README.md
+++ b/packages/zoe/README.md
@@ -82,7 +82,7 @@ import { prepareExo, prepareExoClass } from '@agoric/vat-data';
 
 const { quote: q, Fail } = assert;
 
-export const prepare = async (zcf, _privateArgs, instanceBaggage) => {
+export const start = async (zcf, _privateArgs, instanceBaggage) => {
   const CODE_VERSION = 2;
   const isFirstIncarnation = !instanceBaggage.has('codeVersion');
   if (isFirstIncarnation) {
@@ -128,7 +128,7 @@ export const prepare = async (zcf, _privateArgs, instanceBaggage) => {
   );
   return harden({ creatorFacet });
 };
-harden(prepare);
+harden(start);
 ```
 
 For an example contract upgrade, see the test at https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/test/swingsetTests/upgradeCoveredCall/test-coveredCall-service-upgrade.js .

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -221,6 +221,12 @@
  */
 
 /**
+ * @typedef ContractMeta
+ * @property {CopyRecord<Pattern>} [customTermsShape]
+ * @property {CopyRecord<Pattern>} [privateArgsShape]
+ */
+
+/**
  * API for a contract start function.
  *
  * CAVEAT: assumes synchronous
@@ -234,6 +240,7 @@
  * @callback ContractStartFn
  * @param {ZCF<CT>} zcf
  * @param {PA} privateArgs
+ * @param {MapStore} [baggage]
  * @returns {ContractStartFnResult<PF, CF>}
  */
 

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -224,6 +224,7 @@
  * @typedef ContractMeta
  * @property {CopyRecord<Pattern>} [customTermsShape]
  * @property {CopyRecord<Pattern>} [privateArgsShape]
+ * @property {'canBeUpgraded' | 'canUpgrade'} [upgradability]
  */
 
 /**

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -403,7 +403,7 @@ export const makeZCFZygote = async (
           const allDurable = Object.values(areDurable).every(Boolean);
           if (durabilityRequired) {
             allDurable ||
-              Fail`values from prepare() must be durable ${areDurable}`;
+              Fail`with ${meta.upgradability}, values from start() must be durable ${areDurable}`;
           }
 
           if (allDurable) {

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -222,13 +222,7 @@ export const makeZCFZygote = async (
     return evalContractBundle(bundle);
   };
   // evaluate the contract (either the first version, or an upgrade)
-  const {
-    start,
-    buildRootObject,
-    privateArgsShape,
-    customTermsShape,
-    prepare,
-  } = await evaluateContract();
+  const { start, buildRootObject, meta, prepare } = await evaluateContract();
 
   if (start === undefined && prepare === undefined) {
     buildRootObject === undefined ||
@@ -300,6 +294,7 @@ export const makeZCFZygote = async (
       const terms = getInstanceRecHolder().getTerms();
 
       // If the contract provided customTermsShape, validate the customTerms.
+      const { customTermsShape } = meta;
       if (customTermsShape) {
         const { brands: _b, issuers: _i, ...customTerms } = terms;
         mustMatch(harden(customTerms), customTermsShape, 'customTerms');
@@ -373,6 +368,7 @@ export const makeZCFZygote = async (
       zcfBaggage.init('instanceRecHolder', instanceRecHolder);
 
       const startFn = start || prepare;
+      const { privateArgsShape } = meta;
       if (privateArgsShape) {
         mustMatch(privateArgs, privateArgsShape, 'privateArgs');
       }
@@ -423,6 +419,7 @@ export const makeZCFZygote = async (
       instanceRecHolder = zcfBaggage.get('instanceRecHolder');
       initSeatMgrAndMintKind();
 
+      const { privateArgsShape } = meta;
       if (privateArgsShape) {
         mustMatch(privateArgs, privateArgsShape, 'privateArgs');
       }

--- a/packages/zoe/src/contracts/scaledPriceAuthority.js
+++ b/packages/zoe/src/contracts/scaledPriceAuthority.js
@@ -17,6 +17,12 @@ import { provideQuoteMint } from '../contractSupport/priceAuthorityQuoteMint.js'
  * @property {Ratio} [initialPrice] - targetAmountIn:targetAmountOut
  */
 
+/** @type {ContractMeta} */
+export const meta = {
+  upgradability: 'canUpgrade',
+};
+harden(meta);
+
 /**
  * A contract that scales a source price authority to a target price authority
  * via ratios.
@@ -30,7 +36,7 @@ import { provideQuoteMint } from '../contractSupport/priceAuthorityQuoteMint.js'
  * @param {object} privateArgs
  * @param {import('@agoric/vat-data').Baggage} baggage
  */
-export const prepare = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, privateArgs, baggage) => {
   const quoteMint = provideQuoteMint(baggage);
 
   const { sourcePriceAuthority, scaleIn, scaleOut, initialPrice } =
@@ -85,3 +91,4 @@ export const prepare = async (zcf, privateArgs, baggage) => {
   );
   return harden({ publicFacet });
 };
+harden(start);

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -204,7 +204,7 @@
 /**
  * @typedef {object} ExecuteContractResult
  * @property {object} creatorFacet
- * @property {Promise<Invitation>} creatorInvitation
+ * @property {Promise<Invitation>} [creatorInvitation]
  * @property {object} publicFacet
  * @property {HandleOfferObj} handleOfferObj
  */

--- a/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
+++ b/packages/zoe/test/swingsetTests/upgradeCoveredCall/coveredCall-durable-V3.js
@@ -13,6 +13,12 @@ const { details: X } = assert;
 
 const sellSeatExpiredMsg = 'The covered call option is expired.';
 
+/** @type {ContractMeta} */
+export const meta = {
+  upgradability: 'canUpgrade',
+};
+harden(meta);
+
 /**
  * @see original version in .../zoe/src/contracts/coveredCall.js and upgradeable
  * version in contracts/coveredCall-durable.js.
@@ -24,7 +30,7 @@ const sellSeatExpiredMsg = 'The covered call option is expired.';
  * @param {unknown} _privateArgs
  * @param {import('@agoric/vat-data').Baggage} instanceBaggage
  */
-const prepare = async (zcf, _privateArgs, instanceBaggage) => {
+export const start = async (zcf, _privateArgs, instanceBaggage) => {
   const firstTime = !instanceBaggage.has('DidStart');
   if (firstTime) {
     instanceBaggage.init('DidStart', true);
@@ -98,6 +104,4 @@ const prepare = async (zcf, _privateArgs, instanceBaggage) => {
   );
   return harden({ creatorFacet });
 };
-
-harden(prepare);
-export { prepare };
+harden(start);

--- a/packages/zoe/test/types.test-d.ts
+++ b/packages/zoe/test/types.test-d.ts
@@ -6,7 +6,7 @@
 import { E } from '@endo/eventual-send';
 import { expectType } from 'tsd';
 
-import type { prepare as scaledPriceAuthorityStart } from '../src/contracts/scaledPriceAuthority.js';
+import type { start as scaledPriceAuthorityStart } from '../src/contracts/scaledPriceAuthority.js';
 
 {
   const zoe = {} as ZoeService;

--- a/packages/zoe/test/unitTests/contracts/test-scaledPriceAuthority.js
+++ b/packages/zoe/test/unitTests/contracts/test-scaledPriceAuthority.js
@@ -18,7 +18,7 @@ import '../../../src/contracts/exported.js';
 /**
  * @typedef {object} TestContext
  * @property {ZoeService} zoe
- * @property {Installation<typeof import('../../../src/contracts/scaledPriceAuthority.js').prepare>} scaledPriceInstallation
+ * @property {Installation<typeof import('../../../src/contracts/scaledPriceAuthority.js').start>} scaledPriceInstallation
  * @property {Brand<'nat'>} atomBrand
  * @property {Brand<'nat'>} usdBrand
  * @property {IssuerKit<'nat'>} atom


### PR DESCRIPTION
## Description

While describing contract upgrade to @carlos-kryha I couldn't come up with a good explanation for why upgradable contracts name the start function`prepare`.

This keeps the `start` name and makes an explicit declaration under `meta` of the upgradability the contract claims.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

Any other docs about "prepare" will need to be updated.

This is a breaking change to downstream consumers, but will appear in the changelogs and is trivial to comply with.

### Testing Considerations

CI