### PR TITLE
export inter-protocol types

### DIFF
--- a/packages/ERTP/jsconfig.build.json
+++ b/packages/ERTP/jsconfig.build.json
@@ -1,12 +1,6 @@
 {
-    "extends": "./jsconfig.json",
-    "compilerOptions": {
-        "noEmit": false,
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "declarationMap": true
-    },
-    "exclude": [
-        "test/"
+    "extends": [
+        "./jsconfig.json",
+        "../../tsconfig-build-options.json"
     ]
 }

--- a/packages/casting/jsconfig.build.json
+++ b/packages/casting/jsconfig.build.json
@@ -1,12 +1,6 @@
 {
-    "extends": "./jsconfig.json",
-    "compilerOptions": {
-        "noEmit": false,
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "declarationMap": true
-    },
-    "exclude": [
-        "test/"
+    "extends": [
+        "./jsconfig.json",
+        "../../tsconfig-build-options.json"
     ]
 }

--- a/packages/governance/jsconfig.build.json
+++ b/packages/governance/jsconfig.build.json
@@ -1,13 +1,6 @@
 {
-    "extends": "./jsconfig.json",
-    "compilerOptions": {
-        "noEmit": false,
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "declarationMap": true
-    },
-    "exclude": [
-        "scripts",
-        "test/",
+    "extends": [
+        "./jsconfig.json",
+        "../../tsconfig-build-options.json"
     ]
 }

--- a/packages/inter-protocol/jsconfig.build.json
+++ b/packages/inter-protocol/jsconfig.build.json
@@ -1,0 +1,6 @@
+{
+    "extends": [
+        "./jsconfig.json",
+        "../../tsconfig-build-options.json"
+    ]
+}

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -11,6 +11,8 @@
     "build": "yarn build:bundles",
     "build:bundles": "node ./scripts/build-bundles.js",
     "build:add-STARS-proposal": "agoric run scripts/add-STARS.js",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*' src/types.js",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -345,13 +345,14 @@ export const makeAnchorAsset = async (
     }),
   );
 
-  /** @type {{ creatorFacet: ERef<Mint<'nat'>>, publicFacet: ERef<Issuer<'nat'>> }} */
-  // @ts-expect-error cast
-  const { creatorFacet: mint, publicFacet: issuer } = await E(startUpgradable)({
-    installation: mintHolder,
-    label: keyword,
-    terms,
-  });
+  const { creatorFacet: mint, publicFacet: issuer } =
+    /** @type {{ creatorFacet: ERef<Mint<'nat'>>, publicFacet: ERef<Issuer<'nat'>> }} */ (
+      await E(startUpgradable)({
+        installation: mintHolder,
+        label: keyword,
+        terms,
+      })
+    );
 
   const brand = await E(issuer).getBrand();
   const kit = harden({ mint, issuer, brand });

--- a/packages/internal/jsconfig.build.json
+++ b/packages/internal/jsconfig.build.json
@@ -1,12 +1,6 @@
 {
-    "extends": "./jsconfig.json",
-    "compilerOptions": {
-        "noEmit": false,
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "declarationMap": true
-    },
-    "exclude": [
-        "test/"
+    "extends": [
+        "./jsconfig.json",
+        "../../tsconfig-build-options.json"
     ]
 }

--- a/packages/notifier/jsconfig.build.json
+++ b/packages/notifier/jsconfig.build.json
@@ -1,13 +1,6 @@
 {
-    "extends": "./jsconfig.json",
-    "compilerOptions": {
-        "noEmit": false,
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "declarationMap": true
-    },
-    "exclude": [
-        "scripts",
-        "test/",
+    "extends": [
+        "./jsconfig.json",
+        "../../tsconfig-build-options.json"
     ]
 }

--- a/packages/smart-wallet/jsconfig.build.json
+++ b/packages/smart-wallet/jsconfig.build.json
@@ -1,12 +1,6 @@
 {
-    "extends": "./jsconfig.json",
-    "compilerOptions": {
-        "noEmit": false,
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "declarationMap": true
-    },
-    "exclude": [
-        "test/"
+    "extends": [
+        "./jsconfig.json",
+        "../../tsconfig-build-options.json"
     ]
 }

--- a/packages/vats/jsconfig.build.json
+++ b/packages/vats/jsconfig.build.json
@@ -1,12 +1,6 @@
 {
-    "extends": "./jsconfig.json",
-    "compilerOptions": {
-        "noEmit": false,
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "declarationMap": true
-    },
-    "exclude": [
-        "test/"
+    "extends": [
+        "./jsconfig.json",
+        "../../tsconfig-build-options.json"
     ]
 }

--- a/packages/zoe/jsconfig.build.json
+++ b/packages/zoe/jsconfig.build.json
@@ -1,12 +1,6 @@
 {
-    "extends": "./jsconfig.json",
-    "compilerOptions": {
-        "noEmit": false,
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "declarationMap": true
-    },
-    "exclude": [
-        "test/"
+    "extends": [
+        "./jsconfig.json",
+        "../../tsconfig-build-options.json"
     ]
 }

--- a/tsconfig-build-options.json
+++ b/tsconfig-build-options.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "noEmit": false,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "declarationMap": true
+    },
+    "exclude": [
+        "**/scripts",
+        "**/test"
+    ]
+}


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/issues/6343

## Description

DRYs out the configs for `jsconfig.build.json`.
Also exports types from inter-protocol to exercise the config.

I named the PR for the latter since that's more consequential.


### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

changelog sufficient

### Testing Considerations

CI