### PR TITLE
refactor: add `passStyleOf` to `VatData` global

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -49,6 +49,7 @@
     "@endo/init": "^1.0.4",
     "@endo/marshal": "^1.3.0",
     "@endo/nat": "^5.0.4",
+    "@endo/pass-style": "^1.2.0",
     "@endo/patterns": "^1.2.0",
     "@endo/promise-kit": "^1.0.4",
     "@endo/ses-ava": "^1.1.2",

--- a/packages/swingset-liveslots/src/vatDataTypes.d.ts
+++ b/packages/swingset-liveslots/src/vatDataTypes.d.ts
@@ -194,6 +194,7 @@ export type VatData = {
     options?: StoreOptions,
   ) => WeakSetStore<K>;
   canBeDurable: (specimen: unknown) => boolean;
+  passStyleOf: (specimen: unknown) => string;
 };
 
 // The JSDoc is repeated here and at the function definition so it appears

--- a/packages/swingset-liveslots/tools/setup-vat-data.js
+++ b/packages/swingset-liveslots/tools/setup-vat-data.js
@@ -3,6 +3,7 @@
 // This file produces the globalThis.VatData property outside of a running
 // SwingSet so that it can be used by '@agoric/vat-data' (which only *consumes*
 // `globalThis.VatData`) in code under test.
+import { passStyleOf } from '@endo/pass-style';
 import { makeFakeVirtualStuff } from './fakeVirtualSupport.js';
 
 const { WeakMap, WeakSet } = globalThis;
@@ -35,6 +36,7 @@ globalThis.VatData = harden({
     fakeVomKit.cm.makeScalarBigSetStore(...args),
   makeScalarBigWeakSetStore: (...args) =>
     fakeVomKit.cm.makeScalarBigWeakSetStore(...args),
+  passStyleOf,
 });
 
 export const reincarnate = (options = {}) => {

--- a/packages/vat-data/src/vat-data-bindings.js
+++ b/packages/vat-data/src/vat-data-bindings.js
@@ -26,6 +26,7 @@ if ('VatData' in globalThis) {
     makeScalarBigSetStore: unavailable,
     makeScalarBigWeakSetStore: unavailable,
     canBeDurable: unavailable,
+    passStyleOf: unavailable, // not exported from here in any case
   };
 }
 

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -38,6 +38,7 @@
     "@endo/import-bundle": "^1.0.4",
     "@endo/marshal": "^1.3.0",
     "@endo/nat": "^5.0.4",
+    "@endo/pass-style": "^1.2.0",
     "@endo/patterns": "^1.2.0",
     "@endo/promise-kit": "^1.0.4",
     "import-meta-resolve": "^2.2.1",


### PR DESCRIPTION
See https://github.com/endojs/endo/pull/1676

https://github.com/Agoric/agoric-sdk/pull/9431 currently staged on this PR

Harmless for now. Eventually to be picked up by `@endo/pass-style` as imported after liveslots, so it will use the one from liveslots. This makes the determinism of user code depend on `passStyleOf` really being deterministic. Otherwise, user code could observe GC.