### PR TITLE
chore(packages): fix default param lint warnings

### DIFF
--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -127,8 +127,8 @@ export const hasIssuer = baggage => baggage.has(INSTANCE_KEY);
  *
  * @param {Baggage} issuerBaggage
  * @param {string} name
- * @param {K} [assetKind=AssetKind.NAT]
- * @param {AdditionalDisplayInfo} [displayInfo={}]
+ * @param {K} [assetKind]
+ * @param {AdditionalDisplayInfo} [displayInfo]
  * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails
  * in the middle of an atomic action (which btw should never happen), it
  * potentially leaves its ledger in a corrupted state. If this function was
@@ -155,7 +155,7 @@ export const makeDurableIssuerKit = (
 harden(makeDurableIssuerKit);
 
 /**
- * @template {AssetKind} [K='nat']
+ * @template {AssetKind} K
  * The name becomes part of the brand in asset descriptions.
  * The name is useful for debugging and double-checking
  * assumptions, but should not be trusted wrt any external namespace.
@@ -170,8 +170,8 @@ harden(makeDurableIssuerKit);
  *  `displayInfo` gives information to the UI on how to display the amount.
  *
  * @param {string} name
- * @param {K} [assetKind='nat']
- * @param {AdditionalDisplayInfo} [displayInfo={}]
+ * @param {K} [assetKind]
+ * @param {AdditionalDisplayInfo} [displayInfo]
  * @param {ShutdownWithFailure} [optShutdownWithFailure] If this issuer fails
  * in the middle of an atomic action (which btw should never happen), it
  * potentially leaves its ledger in a corrupted state. If this function was

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -265,7 +265,7 @@ export const prepareAttenuator = (
     /**
      * @param {object} opts
      * @param {any} [opts.target]
-     * @param {boolean} [opts.isSync=false]
+     * @param {boolean} [opts.isSync]
      * @param {Overrides} [opts.overrides]
      */
     ({

--- a/packages/internal/src/marshal.js
+++ b/packages/internal/src/marshal.js
@@ -65,7 +65,7 @@ harden(assertCapData);
  * @param {Map<string, string>} data
  * @param {string} key
  * @param {ReturnType<typeof import('@endo/marshal').makeMarshal>['fromCapData']} fromCapData
- * @param {number} [index=-1] index of the desired value in a deserialized stream cell
+ * @param {number} [index] index of the desired value in a deserialized stream cell
  */
 export const unmarshalFromVstorage = (data, key, fromCapData, index = -1) => {
   const serialized = data.get(key) || Fail`no data for ${key}`;

--- a/packages/notifier/src/publish-kit.js
+++ b/packages/notifier/src/publish-kit.js
@@ -209,7 +209,7 @@ const DurablePublishKitStateShape = harden({
 
 /**
  * @param {object} [options]
- * @param {DurablePublishKitValueDurability & 'mandatory'} [options.valueDurability='mandatory']
+ * @param {DurablePublishKitValueDurability & 'mandatory'} [options.valueDurability]
  * @returns {DurablePublishKitState}
  */
 const initDurablePublishKitState = (options = {}) => {

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -316,8 +316,8 @@ const makePegasus = (zcf, board, namesByAddress) => {
     /**
      * Return a handler that can be used with the Network API.
      *
-     * @param {ERef<TransferProtocol>} [transferProtocol=DEFAULT_TRANSFER_PROTOCOL]
-     * @param {ERef<DenomTransformer>} [denomTransformer=DEFAULT_DENOM_TRANSFORMER]
+     * @param {ERef<TransferProtocol>} [transferProtocol]
+     * @param {ERef<DenomTransformer>} [denomTransformer]
      * @returns {PegasusConnectionKit}
      */
     makePegasusConnectionKit(

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -520,7 +520,7 @@ export const prepareSmartWallet = (baggage, shared) => {
          * Umarshals the actionCapData and delegates to the appropriate action handler.
          *
          * @param {import('@endo/marshal').CapData<string>} actionCapData of type BridgeAction
-         * @param {boolean} [canSpend=false]
+         * @param {boolean} [canSpend]
          * @returns {Promise<void>}
          */
         handleBridgeAction(actionCapData, canSpend = false) {

--- a/packages/solo/src/add-chain.js
+++ b/packages/solo/src/add-chain.js
@@ -13,7 +13,7 @@ const DEFAULT_CHAIN_CONFIG = 'https://testnet.agoric.com/network-config';
 /**
  * @param {string} basedir
  * @param {string} [chainConfig]
- * @param {boolean} [force=false]
+ * @param {boolean} [force]
  */
 async function addChain(basedir, chainConfig, force = false) {
   let actualConfig = chainConfig;

--- a/packages/store/src/legacy/legacyMap.js
+++ b/packages/store/src/legacy/legacyMap.js
@@ -30,7 +30,7 @@ import '../types.js';
  *
  * @deprecated switch to ScalarMap if possible, Map otherwise
  * @template K,V
- * @param {string} [tag='key'] - tag for debugging
+ * @param {string} [tag] - tag for debugging
  * @returns {LegacyMap<K,V>}
  */
 export const makeLegacyMap = (tag = 'key') => {

--- a/packages/store/src/legacy/legacyWeakMap.js
+++ b/packages/store/src/legacy/legacyWeakMap.js
@@ -6,7 +6,7 @@ import '../types.js';
  *
  * @deprecated switch to ScalarWeakMap if possible, WeakMap otherwise
  * @template K,V
- * @param {string} [tag='key'] - tag for debugging
+ * @param {string} [tag] - tag for debugging
  * @returns {LegacyWeakMap<K,V>}
  */
 export const makeLegacyWeakMap = (tag = 'key') => {

--- a/packages/store/src/stores/scalarMapStore.js
+++ b/packages/store/src/stores/scalarMapStore.js
@@ -129,7 +129,7 @@ export const makeMapStoreMethods = (
  *
  * @template {Key} K
  * @template {Passable} V
- * @param {string} [tag='key'] - the column name for the key
+ * @param {string} [tag] - the column name for the key
  * @param {StoreOptions} [options]
  * @returns {MapStore<K,V>}
  */

--- a/packages/store/src/stores/scalarSetStore.js
+++ b/packages/store/src/stores/scalarSetStore.js
@@ -85,7 +85,7 @@ export const makeSetStoreMethods = (
  * copyRecords, as keys and look them up based on equality of their contents.
  *
  * @template K
- * @param {string} [tag='key'] - tag for debugging
+ * @param {string} [tag] - tag for debugging
  * @param {StoreOptions} [options]
  * @returns {SetStore<K>}
  */

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -88,7 +88,7 @@ export const makeWeakMapStoreMethods = (
  * remotables, since the other primitives may always reappear.
  *
  * @template K,V
- * @param {string} [tag='key'] - tag for debugging
+ * @param {string} [tag] - tag for debugging
  * @param {StoreOptions} [options]
  * @returns {WeakMapStore<K,V>}
  */

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -70,7 +70,7 @@ export const makeWeakSetStoreMethods = (
  * remotables, since the other primitives may always appear.
  *
  * @template K
- * @param {string} [tag='key'] - tag for debugging
+ * @param {string} [tag] - tag for debugging
  * @param {StoreOptions} [options]
  * @returns {WeakSetStore<K>}
  */

--- a/packages/swingset-liveslots/src/collectionManager.js
+++ b/packages/swingset-liveslots/src/collectionManager.js
@@ -896,7 +896,7 @@ export function makeCollectionManager(
    * Produce a big map.
    *
    * @template K,V
-   * @param {string} [label='map'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {MapStore<K,V>}
    */
@@ -940,7 +940,7 @@ export function makeCollectionManager(
    * Produce a weak big map.
    *
    * @template K,V
-   * @param {string} [label='weakMap'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {WeakMapStore<K,V>}
    */
@@ -969,7 +969,7 @@ export function makeCollectionManager(
    * Produce a big set.
    *
    * @template K
-   * @param {string} [label='set'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {SetStore<K>}
    */
@@ -996,7 +996,7 @@ export function makeCollectionManager(
    * Produce a weak big set.
    *
    * @template K
-   * @param {string} [label='weakSet'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {WeakSetStore<K>}
    */
@@ -1073,7 +1073,7 @@ export function makeCollectionManager(
    * remotables.
    *
    * @template K,V
-   * @param {string} [label='map'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {MapStore<K,V>}
    */
@@ -1085,7 +1085,7 @@ export function makeCollectionManager(
    * primitives, or remotables.
    *
    * @template K,V
-   * @param {string} [label='weakMap'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {WeakMapStore<K,V>}
    */
@@ -1097,7 +1097,7 @@ export function makeCollectionManager(
    * remotables.
    *
    * @template K
-   * @param {string} [label='set'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {SetStore<K>}
    */
@@ -1109,7 +1109,7 @@ export function makeCollectionManager(
    * primitives, or remotables.
    *
    * @template K
-   * @param {string} [label='weakSet'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {WeakSetStore<K>}
    */

--- a/packages/swingset-liveslots/test/liveslots-helpers.js
+++ b/packages/swingset-liveslots/test/liveslots-helpers.js
@@ -16,8 +16,8 @@ import { kser } from './kmarshal.js';
 
 /**
  * @param {object} [options]
- * @param {boolean} [options.skipLogging = false]
- * @param {Map<string, string>} [options.kvStore = new Map()]
+ * @param {boolean} [options.skipLogging]
+ * @param {Map<string, string>} [options.kvStore]
  */
 export function buildSyscall(options = {}) {
   const { skipLogging = false, kvStore: fakestore = new Map() } = options;
@@ -168,9 +168,9 @@ function makeRPMaker(nextNumber = 1) {
  * @param {string} vatName
  * @param {object} [options]
  * @param {boolean} [options.forceGC]
- * @param {Map<string, string>} [options.kvStore = new Map()]
+ * @param {Map<string, string>} [options.kvStore]
  * @param {number} [options.nextPromiseImportNumber]
- * @param {boolean} [options.skipLogging = false]
+ * @param {boolean} [options.skipLogging]
  */
 export async function setupTestLiveslots(
   t,

--- a/packages/swingset-liveslots/tools/fakeVirtualSupport.js
+++ b/packages/swingset-liveslots/tools/fakeVirtualSupport.js
@@ -315,8 +315,8 @@ export function makeFakeWatchedPromiseManager(
  * Configure virtual stuff with relaxed durability rules and fake liveslots
  *
  * @param {object} [options]
- * @param {number} [options.cacheSize=3]
- * @param {boolean} [options.relaxDurabilityRules=true]
+ * @param {number} [options.cacheSize]
+ * @param {boolean} [options.relaxDurabilityRules]
  */
 export function makeFakeVirtualStuff(options = {}) {
   const actualOptions = {

--- a/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
+++ b/packages/vats/test/bootstrapTests/test-vaults-upgrade.js
@@ -21,8 +21,8 @@ const collateralBrandKey = 'ATOM';
 /**
  * @param {import('ava').ExecutionContext} t
  * @param {object} [options]
- * @param {number} [options.incarnation=1]
- * @param {boolean} [options.logTiming=true]
+ * @param {number} [options.incarnation]
+ * @param {boolean} [options.logTiming]
  * @param {import('@agoric/internal/src/storage-test-utils.js').FakeStorageKit} [options.storage]
  */
 const makeDefaultTestContext = async (

--- a/packages/vats/tools/authorityViz.js
+++ b/packages/vats/tools/authorityViz.js
@@ -103,7 +103,7 @@ const manifest2graph = manifest => {
    * @param {string} src
    * @param {string} ty
    * @param {Permit} item
-   * @param {boolean} [reverse=false]
+   * @param {boolean} [reverse]
    */
   const level1 = (src, ty, item, reverse = false) => {
     if (!item) return;

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -27,7 +27,7 @@ const BASIS_POINTS = 10000n; // TODO change to 10_000n once tooling copes.
  * pool of the kind of asset sent in
  * @param {any} outputReserve - the value in the liquidity
  * pool of the kind of asset to be sent out
- * @param {bigint} [feeBasisPoints=30n] - the fee taken in
+ * @param {bigint} [feeBasisPoints] - the fee taken in
  * basis points. The default is 0.3% or 30 basis points. The fee
  * is taken from inputValue
  * @returns {NatValue} outputValue - the current price, in value form
@@ -66,7 +66,7 @@ export const getInputPrice = (
  * pool of the asset being spent
  * @param {any} outputReserve - the value in the liquidity
  * pool of the kind of asset to be sent out
- * @param {bigint} [feeBasisPoints=30n] - the fee taken in
+ * @param {bigint} [feeBasisPoints] - the fee taken in
  * basis points. The default is 0.3% or 30 basis points. The fee is taken from
  * outputValue
  * @returns {NatValue} inputValue - the value of input required to purchase output

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -305,7 +305,7 @@ const reverse = (keywordRecord = {}) => {
  * @param {ZCFSeat} fromSeat
  *   The seat in contractA to take the offer payments from.
  *
- * @param {ZCFSeat} [toSeat=fromSeat]
+ * @param {ZCFSeat} [toSeat]
  *   The seat in contractA to deposit the payout of the offer to.
  *   If `toSeat` is not provided, this defaults to the `fromSeat`.
  *


### PR DESCRIPTION
refs: #8032

## Description

This PR removes the following lint warnings:
```
GitHub Actions / lint-rest 
Defaults are not permitted on @param
```

With the [recent update of eslint-plugin-jsdoc](https://github.com/Agoric/agoric-sdk/commit/3c2cf6f2face5ae4ab84a7229da6dcd3c6a48c7f#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R28), we got a change in their [rules to warn about this](https://github.com/gajus/eslint-plugin-jsdoc/blob/v46.4.3/src/index.js#L148). This link has detail on why they recommend to not use defaults with @param: https://github.com/gajus/eslint-plugin-jsdoc/blob/main/.README/rules/no-defaults.md


### Security Considerations

### Scaling Considerations

### Documentation Considerations

### Testing Considerations

