### PR TITLE
Refactor liveslots vatstore usage

### DIFF
--- a/packages/swingset-liveslots/src/collectionManager.js
+++ b/packages/swingset-liveslots/src/collectionManager.js
@@ -380,11 +380,11 @@ export function makeCollectionManager(
       currentGenerationNumber += 1;
       assertAcceptableSyscallCapdataSize([serializedValue]);
       if (durable) {
-        serializedValue.slots.forEach((vref, slotIndex) => {
+        for (const [slotIndex, vref] of serializedValue.slots.entries()) {
           if (!vrm.isDurable(vref)) {
             throwNotDurable(value, slotIndex, serializedValue);
           }
-        });
+        }
       }
       if (passStyleOf(key) === 'remotable') {
         /** @type {string} */
@@ -400,7 +400,9 @@ export function makeCollectionManager(
           vrm.addReachableVref(vref);
         }
       }
-      serializedValue.slots.forEach(vrm.addReachableVref);
+      for (const vref of serializedValue.slots) {
+        vrm.addReachableVref(vref);
+      }
       syscall.vatstoreSet(keyToDBKey(key), JSON.stringify(serializedValue));
       updateEntryCount(1);
     };
@@ -419,11 +421,11 @@ export function makeCollectionManager(
       const after = serializeValue(harden(value));
       assertAcceptableSyscallCapdataSize([after]);
       if (durable) {
-        after.slots.forEach((vref, i) => {
+        for (const [i, vref] of after.slots.entries()) {
           if (!vrm.isDurable(vref)) {
             throwNotDurable(value, i, after);
           }
-        });
+        }
       }
       const dbKey = keyToDBKey(key);
       const rawBefore = syscall.vatstoreGet(dbKey);
@@ -793,13 +795,15 @@ export function makeCollectionManager(
     }
     const schemataCapData = serialize(harden(schemata));
     if (isDurable) {
-      schemataCapData.slots.forEach((vref, slotIndex) => {
+      for (const [slotIndex, vref] of schemataCapData.slots.entries()) {
         if (!vrm.isDurable(vref)) {
           throwNotDurable(vref, slotIndex, schemataCapData);
         }
-      });
+      }
     }
-    schemataCapData.slots.forEach(vrm.addReachableVref);
+    for (const vref of schemataCapData.slots) {
+      vrm.addReachableVref(vref);
+    }
 
     schemaCache.set(
       collectionID,
@@ -896,7 +900,7 @@ export function makeCollectionManager(
    * Produce a big map.
    *
    * @template K,V
-   * @param {string} [label='map'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {MapStore<K,V>}
    */
@@ -940,7 +944,7 @@ export function makeCollectionManager(
    * Produce a weak big map.
    *
    * @template K,V
-   * @param {string} [label='weakMap'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {WeakMapStore<K,V>}
    */
@@ -969,7 +973,7 @@ export function makeCollectionManager(
    * Produce a big set.
    *
    * @template K
-   * @param {string} [label='set'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {SetStore<K>}
    */
@@ -996,7 +1000,7 @@ export function makeCollectionManager(
    * Produce a weak big set.
    *
    * @template K
-   * @param {string} [label='weakSet'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {WeakSetStore<K>}
    */
@@ -1073,7 +1077,7 @@ export function makeCollectionManager(
    * remotables.
    *
    * @template K,V
-   * @param {string} [label='map'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {MapStore<K,V>}
    */
@@ -1085,7 +1089,7 @@ export function makeCollectionManager(
    * primitives, or remotables.
    *
    * @template K,V
-   * @param {string} [label='weakMap'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {WeakMapStore<K,V>}
    */
@@ -1097,7 +1101,7 @@ export function makeCollectionManager(
    * remotables.
    *
    * @template K
-   * @param {string} [label='set'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {SetStore<K>}
    */
@@ -1109,7 +1113,7 @@ export function makeCollectionManager(
    * primitives, or remotables.
    *
    * @template K
-   * @param {string} [label='weakSet'] - diagnostic label for the store
+   * @param {string} [label] - diagnostic label for the store
    * @param {StoreOptions} [options]
    * @returns {WeakSetStore<K>}
    */

--- a/packages/swingset-liveslots/test/liveslots-helpers.js
+++ b/packages/swingset-liveslots/test/liveslots-helpers.js
@@ -16,8 +16,8 @@ import { kser } from './kmarshal.js';
 
 /**
  * @param {object} [options]
- * @param {boolean} [options.skipLogging = false]
- * @param {Map<string, string>} [options.kvStore = new Map()]
+ * @param {boolean} [options.skipLogging]
+ * @param {Map<string, string>} [options.kvStore]
  */
 export function buildSyscall(options = {}) {
   const { skipLogging = false, kvStore: fakestore = new Map() } = options;
@@ -168,9 +168,9 @@ function makeRPMaker(nextNumber = 1) {
  * @param {string} vatName
  * @param {object} [options]
  * @param {boolean} [options.forceGC]
- * @param {Map<string, string>} [options.kvStore = new Map()]
+ * @param {Map<string, string>} [options.kvStore]
  * @param {number} [options.nextPromiseImportNumber]
- * @param {boolean} [options.skipLogging = false]
+ * @param {boolean} [options.skipLogging]
  */
 export async function setupTestLiveslots(
   t,

--- a/packages/swingset-liveslots/test/test-collections.js
+++ b/packages/swingset-liveslots/test/test-collections.js
@@ -489,7 +489,9 @@ test('map fail on concurrent modification', t => {
   const primeMap = makeScalarBigMapStore('fmap', {
     keyShape: M.number(),
   });
-  primes.forEach((v, i) => primeMap.init(v, `${v} is prime #${i + 1}`));
+  for (const [i, v] of primes.entries()) {
+    primeMap.init(v, `${v} is prime #${i + 1}`);
+  }
 
   let iter = primeMap.keys()[Symbol.iterator]();
   t.deepEqual(iter.next(), { done: false, value: 2 });
@@ -517,7 +519,9 @@ test('set fail on concurrent modification', t => {
   const primeSet = makeScalarBigSetStore('fset', {
     keyShape: M.number(),
   });
-  primes.forEach(v => primeSet.add(v));
+  for (const v of primes) {
+    primeSet.add(v);
+  }
 
   let iter = primeSet.keys()[Symbol.iterator]();
   t.deepEqual(iter.next(), { done: false, value: 2 });
@@ -545,7 +549,9 @@ test('map ok with concurrent deletion', t => {
   const primeMap = makeScalarBigMapStore('fmap', {
     keyShape: M.number(),
   });
-  primes.forEach((v, i) => primeMap.init(v, `${v} is prime #${i + 1}`));
+  for (const [i, v] of primes.entries()) {
+    primeMap.init(v, `${v} is prime #${i + 1}`);
+  }
   const iter = primeMap.keys()[Symbol.iterator]();
   t.deepEqual(iter.next(), { done: false, value: 2 });
   primeMap.delete(3);
@@ -560,7 +566,9 @@ test('set ok with concurrent deletion', t => {
   const primeSet = makeScalarBigSetStore('fset', {
     keyShape: M.number(),
   });
-  primes.forEach(v => primeSet.add(v));
+  for (const v of primes) {
+    primeSet.add(v);
+  }
 
   const iter = primeSet.keys()[Symbol.iterator]();
   t.deepEqual(iter.next(), { done: false, value: 2 });
@@ -875,7 +883,9 @@ test('complex map queries', t => {
   const primeStore = makeScalarBigMapStore('prime map', {
     keyShape: M.number(),
   });
-  primes.forEach((v, i) => primeStore.init(v, `${v} is prime #${i + 1}`));
+  for (const [i, v] of primes.entries()) {
+    primeStore.init(v, `${v} is prime #${i + 1}`);
+  }
 
   t.deepEqual(Array.from(primeStore.values()), [
     '2 is prime #1',
@@ -1050,7 +1060,9 @@ test('complex set queries', t => {
   const primeStore = makeScalarBigSetStore('prime set', {
     keyShape: M.number(),
   });
-  primes.forEach(v => primeStore.add(v));
+  for (const v of primes) {
+    primeStore.add(v);
+  }
 
   t.deepEqual(
     Array.from(primeStore.values()),

--- a/packages/swingset-liveslots/test/virtual-objects/test-virtualObjectManager.js
+++ b/packages/swingset-liveslots/test/virtual-objects/test-virtualObjectManager.js
@@ -128,6 +128,7 @@ test('multifaceted virtual objects', t => {
   flushStateCache();
   t.deepEqual(log.splice(0), [
     `get kindIDID => undefined`,
+    `get idCounters => undefined`,
     `set kindIDID 1`,
     `set vom.vkind.2.descriptor {"kindID":"2","tag":"multithing"}`,
     `set vom.${kid}/1 ${multiThingVal('foo', 1)}`,
@@ -203,6 +204,7 @@ test('virtual object operations', t => {
   const thing4 = makeThing('thing-4', 300); // [t4-0* t3-0* t2-0* t1-0*]
   // t4-0: 'thing-4' 300 0
   t.is(log.shift(), `get kindIDID => undefined`);
+  t.is(log.shift(), `get idCounters => undefined`);
   t.is(log.shift(), `set kindIDID 1`);
   t.is(log.shift(), `set vom.vkind.2.descriptor {"kindID":"2","tag":"thing"}`);
   t.is(log.shift(), `set vom.vkind.3.descriptor {"kindID":"3","tag":"zot"}`);
@@ -467,6 +469,7 @@ test('symbol named methods', t => {
   const thing2 = makeThing('thing-2', 100); // [t1-0* t2-0*]
   // t2-0: 'thing-2' 100 0
   t.is(log.shift(), `get kindIDID => undefined`);
+  t.is(log.shift(), `get idCounters => undefined`);
   t.is(log.shift(), `set kindIDID 1`);
   t.is(
     log.shift(),
@@ -647,6 +650,7 @@ test('virtual object gc', t => {
   });
 
   t.is(log.shift(), `get kindIDID => undefined`);
+  t.is(log.shift(), `get idCounters => undefined`);
   t.is(log.shift(), `set kindIDID 1`);
   const skit = [
     'storeKindIDTable',

--- a/packages/swingset-liveslots/tools/fakeVirtualSupport.js
+++ b/packages/swingset-liveslots/tools/fakeVirtualSupport.js
@@ -151,18 +151,12 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     },
   };
 
-  let nextExportID = 1;
   function allocateExportID() {
-    const exportID = nextExportID;
-    nextExportID += 1;
-    return exportID;
+    return vrm.allocateNextID('exportID');
   }
 
-  let nextCollectionID = 1;
   function allocateCollectionID() {
-    const collectionID = nextCollectionID;
-    nextCollectionID += 1;
-    return collectionID;
+    return vrm.allocateNextID('collectionID');
   }
 
   // note: The real liveslots slotToVal() maps slots (vrefs) to a WeakRef,
@@ -326,9 +320,9 @@ export function makeFakeVirtualStuff(options = {}) {
   const { relaxDurabilityRules } = actualOptions;
   const fakeStuff = makeFakeLiveSlotsStuff(actualOptions);
   const vrm = makeFakeVirtualReferenceManager(fakeStuff, relaxDurabilityRules);
+  fakeStuff.setVrm(vrm);
   const vom = makeFakeVirtualObjectManager(vrm, fakeStuff);
   vom.initializeKindHandleKind();
-  fakeStuff.setVrm(vrm);
   const cm = makeFakeCollectionManager(vrm, fakeStuff, actualOptions);
   const wpm = makeFakeWatchedPromiseManager(vrm, vom, cm, fakeStuff);
   return { fakeStuff, vrm, vom, cm, wpm };
@@ -338,9 +332,9 @@ export function makeStandaloneFakeVirtualObjectManager(options = {}) {
   const fakeStuff = makeFakeLiveSlotsStuff(options);
   const { relaxDurabilityRules = true } = options;
   const vrm = makeFakeVirtualReferenceManager(fakeStuff, relaxDurabilityRules);
+  fakeStuff.setVrm(vrm);
   const vom = makeFakeVirtualObjectManager(vrm, fakeStuff);
   vom.initializeKindHandleKind();
-  fakeStuff.setVrm(vrm);
   return vom;
 }
 
@@ -348,6 +342,7 @@ export function makeStandaloneFakeCollectionManager(options = {}) {
   const fakeStuff = makeFakeLiveSlotsStuff(options);
   const { relaxDurabilityRules = true } = options;
   const vrm = makeFakeVirtualReferenceManager(fakeStuff, relaxDurabilityRules);
+  fakeStuff.setVrm(vrm);
   return makeFakeCollectionManager(vrm, fakeStuff, options);
 }
 

--- a/packages/swingset-liveslots/tools/fakeVirtualSupport.js
+++ b/packages/swingset-liveslots/tools/fakeVirtualSupport.js
@@ -233,9 +233,9 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     setValForSlot(baseRef, val);
     if (valIsCohort) {
       const { id } = parseVatSlot(baseRef);
-      vrm.getFacetNames(id).forEach((name, index) => {
+      for (const [index, name] of vrm.getFacetNames(id).entries()) {
         valToSlot.set(val[name], `${baseRef}:${index}`);
-      });
+      }
     } else {
       valToSlot.set(val, baseRef);
     }
@@ -315,8 +315,8 @@ export function makeFakeWatchedPromiseManager(
  * Configure virtual stuff with relaxed durability rules and fake liveslots
  *
  * @param {object} [options]
- * @param {number} [options.cacheSize=3]
- * @param {boolean} [options.relaxDurabilityRules=true]
+ * @param {number} [options.cacheSize]
+ * @param {boolean} [options.relaxDurabilityRules]
  */
 export function makeFakeVirtualStuff(options = {}) {
   const actualOptions = {


### PR DESCRIPTION
There were a few direct accesses to the vatstore inside `liveslots.js`, which meant that things that the fakestore code, which virtualizes vatstore access outside of liveslots, missed them.  This broke some tests that @michaelfig had under development.  This commit relocates those accesses into the virtual reference manager, so that they are also handled correctly when the vatstore is virtualized by the fake virtual store support.

Fixes #8012

Note to reviewers: there are two commits here.  The first is the actual refactor that fixes the bug.  The second is a bunch of cleanup that fixes various eslint whinges that resulted on account of new eslint rules that have been introduced since this code was last changed.  It is probably best to examine the two commits individually.
