### PR TITLE
fix: reset lockedQuote even when nothing will be auctioned

### DIFF
--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -1101,6 +1101,7 @@ export const prepareVaultManagerKit = (
           state.lockedQuote = undefined;
 
           if (vaultData.getSize() === 0) {
+            void helper.writeMetrics();
             return;
           }
           trace(

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -1051,7 +1051,7 @@ export const prepareVaultManagerKit = (
           );
 
           state.lockedQuote = storedCollateralQuote;
-          facets.helper.writeMetrics();
+          void facets.helper.writeMetrics();
           return storedCollateralQuote;
         },
         /** @param {ERef<AuctioneerPublicFacet>} auctionPF */
@@ -1165,7 +1165,7 @@ export const prepareVaultManagerKit = (
             liquidatingVaults.delete(vault);
           }
 
-          await facets.helper.writeMetrics();
+          void helper.writeMetrics();
         },
       },
     },

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -949,8 +949,17 @@ test('liquidate two loans', async t => {
     manualTimer,
   );
 
-  totalDebt += 7n;
+  totalDebt += 6n;
   await aethVaultMetrics.assertChange({
+    lockedQuote: null,
+    totalDebt: { value: totalDebt },
+  });
+  totalDebt += 1n;
+  await aethVaultMetrics.assertChange({
+    lockedQuote: makeRatioFromAmounts(
+      aeth.make(1_000_000n),
+      run.make(7_000_000n),
+    ),
     totalDebt: { value: totalDebt },
   });
   totalDebt += 6n;
@@ -3156,7 +3165,13 @@ test('Bug 7796 missing lockedPrice', async t => {
   const penaltyAeth = 309_850n;
 
   await aethVaultMetrics.assertChange({
-    lockedQuote: { denominator: { value: 9_990_000n } },
+    lockedQuote: null,
+  });
+  await aethVaultMetrics.assertChange({
+    lockedQuote: makeRatioFromAmounts(
+      aeth.make(1_000_000n),
+      run.make(9_990_000n),
+    )
   });
   await aethVaultMetrics.assertChange({
     liquidatingDebt: { value: totalDebt },
@@ -3346,7 +3361,13 @@ test('Bug 7851 & no bidders', async t => {
   );
 
   await aethVaultMetrics.assertChange({
-    lockedQuote: { denominator: { value: 9_990_000n } },
+    lockedQuote: null,
+  });
+  await aethVaultMetrics.assertChange({
+    lockedQuote: makeRatioFromAmounts(
+      aeth.make(1_000_000n),
+      run.make(9_990_000n),
+    ),
   });
   await aethVaultMetrics.assertChange({
     liquidatingDebt: { value: aliceDebt },

--- a/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultLiquidation.js
@@ -3171,7 +3171,7 @@ test('Bug 7796 missing lockedPrice', async t => {
     lockedQuote: makeRatioFromAmounts(
       aeth.make(1_000_000n),
       run.make(9_990_000n),
-    )
+    ),
   });
   await aethVaultMetrics.assertChange({
     liquidatingDebt: { value: totalDebt },


### PR DESCRIPTION
closes: #8041

## Description

When there were no vaults to be liquidated, we exited early, and missed the step of reseting the locked quote. This fixes that oversight.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Appropriate tests were sensitive to the change and had to be updated.
