### PR TITLE
feat(smart-wallet): trading in well-known non-vbank assets

### DIFF
--- a/packages/boot/test/bootstrapTests/drivers.js
+++ b/packages/boot/test/bootstrapTests/drivers.js
@@ -110,6 +110,7 @@ export const makeWalletFactoryDriver = async (
         storage.data,
         `published.wallet.${walletAddress}.current`,
         fromCapData,
+        -1,
       );
     },
 
@@ -121,6 +122,7 @@ export const makeWalletFactoryDriver = async (
         storage.data,
         `published.wallet.${walletAddress}`,
         fromCapData,
+        -1,
       );
     },
   });

--- a/packages/boot/test/bootstrapTests/supports.js
+++ b/packages/boot/test/bootstrapTests/supports.js
@@ -341,7 +341,7 @@ export const makeSwingsetTestKit = async (
   const { fromCapData } = boardSlottingMarshaller(slotToBoardRemote);
 
   const readLatest = path => {
-    const data = unmarshalFromVstorage(storage.data, path, fromCapData);
+    const data = unmarshalFromVstorage(storage.data, path, fromCapData, -1);
     trace('readLatest', path, 'returning', inspect(data, false, 20, true));
     return data;
   };

--- a/packages/boot/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/boot/test/bootstrapTests/test-vaults-integration.js
@@ -345,7 +345,12 @@ test('propose change to auction governance param', async t => {
 
   const { fromCapData } = makeMarshal(undefined, slotToBoardRemote);
   const key = `published.committees.Economic_Committee.latestQuestion`;
-  const lastQuestion = unmarshalFromVstorage(storage.data, key, fromCapData);
+  const lastQuestion = unmarshalFromVstorage(
+    storage.data,
+    key,
+    fromCapData,
+    -1,
+  );
   const changes = lastQuestion?.issue?.spec?.changes;
   t.log('check Economic_Committee.latestQuestion against proposal');
   t.like(changes, { StartFrequency: { relValue: 300n } });

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -123,7 +123,6 @@ test('want stable', async t => {
   t.log('Fund the wallet');
   assert(anchor.mint);
   const payment = anchor.mint.mintPayment(anchor.make(swapSize));
-  // @ts-expect-error deposit does take a FarRef<Payment>
   await wallet.getDepositFacet().receive(payment);
 
   t.log('Execute the swap');
@@ -169,7 +168,6 @@ test('want stable (insufficient funds)', async t => {
   t.log('Fund the wallet insufficiently');
   assert(anchor.mint);
   const payment = anchor.mint.mintPayment(anchor.make(anchorFunding));
-  // @ts-expect-error deposit does take a FarRef<Payment>
   await wallet.getDepositFacet().receive(payment);
 
   t.log('Execute the swap');
@@ -382,7 +380,6 @@ test('deposit multiple payments to unknown brand', async t => {
   // assume that if the call succeeds then it's in durable storage.
   for await (const amt of [1n, 2n]) {
     const payment = rial.mint.mintPayment(rial.make(amt));
-    // @ts-expect-error deposit does take a FarRef<Payment>
     const result = await wallet.getDepositFacet().receive(harden(payment));
     // successful request but not deposited
     t.deepEqual(result, { brand: rial.brand, value: 0n });

--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -380,9 +380,9 @@ test('deposit multiple payments to unknown brand', async t => {
   // assume that if the call succeeds then it's in durable storage.
   for await (const amt of [1n, 2n]) {
     const payment = rial.mint.mintPayment(rial.make(amt));
-    const result = await wallet.getDepositFacet().receive(harden(payment));
-    // successful request but not deposited
-    t.deepEqual(result, { brand: rial.brand, value: 0n });
+    await t.throwsAsync(wallet.getDepositFacet().receive(harden(payment)), {
+      message: /cannot deposit .*: no purse/,
+    });
   }
 });
 

--- a/packages/internal/src/marshal.js
+++ b/packages/internal/src/marshal.js
@@ -65,11 +65,12 @@ harden(assertCapData);
  * @param {Map<string, string>} data
  * @param {string} key
  * @param {ReturnType<typeof import('@endo/marshal').makeMarshal>['fromCapData']} fromCapData
- * @param {number} [index] index of the desired value in a deserialized stream cell
+ * @param {number} index index of the desired value in a deserialized stream cell
  */
-export const unmarshalFromVstorage = (data, key, fromCapData, index = -1) => {
+export const unmarshalFromVstorage = (data, key, fromCapData, index) => {
   const serialized = data.get(key) || Fail`no data for ${key}`;
   assert.typeof(serialized, 'string');
+  assert.typeof(index, 'number');
 
   const streamCell = JSON.parse(serialized);
   if (!isStreamCell(streamCell)) {
@@ -102,7 +103,7 @@ export const makeHistoryReviver = (entries, slotToVal = undefined) => {
   const vsMap = new Map(entries);
   const fromCapData = (...args) =>
     Reflect.apply(board.fromCapData, board, args);
-  const getItem = key => unmarshalFromVstorage(vsMap, key, fromCapData);
+  const getItem = key => unmarshalFromVstorage(vsMap, key, fromCapData, -1);
   const children = prefix => {
     prefix.endsWith('.') || Fail`prefix must end with '.'`;
     return harden([

--- a/packages/internal/src/storage-test-utils.js
+++ b/packages/internal/src/storage-test-utils.js
@@ -215,14 +215,15 @@ export const makeMockChainStorageRoot = () => {
      *
      * @param {string} path
      * @param {import('./lib-chainStorage.js').Marshaller} marshaller
+     * @param {number} [index]
      * @returns {unknown}
      */
-    getBody: (path, marshaller = defaultMarshaller) => {
+    getBody: (path, marshaller = defaultMarshaller, index = -1) => {
       data.size || Fail`no data in storage`;
       /** @type {ReturnType<typeof import('@endo/marshal').makeMarshal>['fromCapData']} */
       const fromCapData = (...args) =>
         Reflect.apply(marshaller.fromCapData, marshaller, args);
-      return unmarshalFromVstorage(data, path, fromCapData);
+      return unmarshalFromVstorage(data, path, fromCapData, index);
     },
     keys: () => [...data.keys()],
   });

--- a/packages/smart-wallet/package.json
+++ b/packages/smart-wallet/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@agoric/cosmic-proto": "^0.3.0",
+    "@endo/bundle-source": "^2.5.2",
     "@endo/captp": "^3.1.2",
     "@endo/init": "^0.5.57",
     "ava": "^5.3.0",

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -1,4 +1,5 @@
 import { E, passStyleOf } from '@endo/far';
+import { deeplyFulfilledObject } from '@agoric/internal';
 import { makePaymentsHelper } from './payments.js';
 
 /**
@@ -80,14 +81,14 @@ export const makeOfferExecutor = ({
         // 1. Prepare values and validate synchronously.
         const { id, invitationSpec, proposal, offerArgs } = offerSpec;
 
+        /** @type {PaymentKeywordRecord | undefined} */
+        const paymentKeywordRecord = await (proposal?.give &&
+          deeplyFulfilledObject(paymentsManager.withdrawGive(proposal.give)));
+
         const invitation = invitationFromSpec(invitationSpec);
         const invitationAmount = await E(invitationIssuer).getAmountOf(
           invitation,
         );
-
-        const paymentKeywordRecord = proposal?.give
-          ? paymentsManager.withdrawGive(proposal.give)
-          : undefined;
 
         // 2. Begin executing offer
         // No explicit signal to user that we reached here but if anything above

--- a/packages/smart-wallet/test/gameAssetContract.js
+++ b/packages/smart-wallet/test/gameAssetContract.js
@@ -1,0 +1,68 @@
+/** @file illustrates using non-vbank assets */
+
+// deep import to avoid dependency on all of ERTP, vat-data
+import { AmountShape } from '@agoric/ertp';
+import { AmountMath, AssetKind } from '@agoric/ertp/src/amountMath.js';
+import { makeTracer } from '@agoric/internal';
+import { M, getCopyBagEntries } from '@agoric/store';
+import { atomicRearrange } from '@agoric/zoe/src/contractSupport/index.js';
+import { E, Far } from '@endo/far';
+
+const { Fail, quote: q } = assert;
+
+const trace = makeTracer('Game', true);
+
+/** @param {Amount<'copyBag'>} amt */
+const totalPlaces = amt => {
+  /** @type {[unknown, bigint][]} */
+  const entries = getCopyBagEntries(amt.value); // XXX getCopyBagEntries returns any???
+  const total = entries.reduce((acc, [_place, qty]) => acc + qty, 0n);
+  return total;
+};
+
+/**
+ * @param {ZCF<{joinPrice: Amount}>} zcf
+ */
+export const start = async zcf => {
+  const { joinPrice } = zcf.getTerms();
+  const stableIssuer = await E(zcf.getZoeService()).getFeeIssuer();
+  zcf.saveIssuer(stableIssuer, 'Price');
+
+  const { zcfSeat: gameSeat } = zcf.makeEmptySeatKit();
+  const mint = await zcf.makeZCFMint('Place', AssetKind.COPY_BAG);
+
+  const joinShape = harden({
+    give: { Price: AmountShape },
+    want: { Places: AmountShape },
+    exit: M.any(),
+  });
+
+  /** @param {ZCFSeat} playerSeat */
+  const joinHook = playerSeat => {
+    const { give, want } = playerSeat.getProposal();
+    trace('join', 'give', give, 'want', want.Places.value);
+
+    AmountMath.isGTE(give.Price, joinPrice) ||
+      Fail`${q(give.Price)} below joinPrice of ${q(joinPrice)}}`;
+
+    totalPlaces(want.Places) <= 3n || Fail`only 3 places allowed when joining`;
+
+    atomicRearrange(
+      zcf,
+      harden([
+        [playerSeat, gameSeat, give],
+        [mint.mintGains(want), playerSeat, want],
+      ]),
+    );
+    playerSeat.exit(true);
+    return 'welcome to the game';
+  };
+
+  const publicFacet = Far('API', {
+    makeJoinInvitation: () =>
+      zcf.makeInvitation(joinHook, 'join', undefined, joinShape),
+  });
+
+  return harden({ publicFacet });
+};
+harden(start);

--- a/packages/smart-wallet/test/supports.js
+++ b/packages/smart-wallet/test/supports.js
@@ -94,8 +94,10 @@ export const makeMockTestSpace = async log => {
     /** @type { BootstrapPowers & { consume: { loadVat: (n: 'mints') => MintsVat, loadCriticalVat: (n: 'mints') => MintsVat }} } */ (
       space
     );
-  const { agoricNames, spaces } = await makeAgoricNamesAccess();
+  const { agoricNames, agoricNamesAdmin, spaces } =
+    await makeAgoricNamesAccess();
   produce.agoricNames.resolve(agoricNames);
+  produce.agoricNamesAdmin.resolve(agoricNamesAdmin);
 
   const { zoe, feeMintAccessP } = await setUpZoeForTest();
   produce.zoe.resolve(zoe);

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
@@ -111,7 +111,6 @@ export const buildRootObject = async () => {
       const payment = moolaKit.mint.mintPayment(
         AmountMath.make(moolaKit.brand, 100n),
       );
-      // @ts-expect-error casting far for test
       await E(depositFacet).receive(payment);
 
       return true;

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -1,12 +1,22 @@
 // @ts-check
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
-import { E } from '@endo/far';
+import { E, Far } from '@endo/far';
 import { buildRootObject as buildBankVatRoot } from '@agoric/vats/src/vat-bank.js';
-import { makeIssuerKit } from '@agoric/ertp';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import { makeScalarMapStore } from '@agoric/store';
+import { makeCopyBag, makeScalarMapStore } from '@agoric/store';
+import { makePromiseKit } from '@endo/promise-kit';
+import bundleSource from '@endo/bundle-source';
+import { makeMarshal } from '@endo/marshal';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { makeDefaultTestContext } from './contexts.js';
-import { makeMockTestSpace } from './supports.js';
+import { ActionType, headValue, makeMockTestSpace } from './supports.js';
+import { makeImportContext } from '../src/marshal-contexts.js';
+
+const { Fail } = assert;
+
+const importSpec = spec =>
+  importMetaResolve(spec, import.meta.url).then(u => new URL(u).pathname);
 
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeDefaultTestContext>>>} */
 const test = anyTest;
@@ -33,11 +43,14 @@ const bigIntReplacer = (_key, val) =>
 
 const range = qty => [...Array(qty).keys()];
 
+// We use test.serial() because
+// agoricNames and vstorage are shared mutable state.
+
 /**
  * NOTE: this doesn't test all forms of work.
  * A better test would measure inter-vat messages or some such.
  */
-test('avoid O(wallets) storage writes for a new asset', async t => {
+test.serial('avoid O(wallets) storage writes for a new asset', async t => {
   const bankManager = t.context.consume.bankManager;
 
   let chainStorageWrites = 0;
@@ -86,4 +99,440 @@ test('avoid O(wallets) storage writes for a new asset', async t => {
   // the only kind of balance we have yet.
   t.is(base.addedWrites, 0);
   t.is(exp.addedWrites, 0);
+});
+
+const BOARD_AUX = 'boardAux';
+/**
+ * Make a storage node for auxilliary data for a value on the board.
+ *
+ * @param {ERef<StorageNode>} chainStorage
+ * @param {string} boardId
+ */
+const makeBoardAuxNode = async (chainStorage, boardId) => {
+  const boardAux = E(chainStorage).makeChildNode(BOARD_AUX);
+  return E(boardAux).makeChildNode(boardId);
+};
+
+const marshalData = makeMarshal(_val => Fail`data only`);
+
+/** @type {<T>(xP: Promise<T | null | undefined>) => Promise<T>} */
+const the = async xP => {
+  const x = await xP;
+  assert(x != null, 'resolution is unexpectedly nullish');
+  return x;
+};
+
+/** @typedef {import('@agoric/internal/src/storage-test-utils.js').MockChainStorageRoot} MockVStorageRoot */
+
+const IST_UNIT = 1_000_000n;
+const CENT = IST_UNIT / 100n;
+
+/** @param {import('ava').ExecutionContext<Awaited<ReturnType<makeDefaultTestContext>>>} t */
+const makeScenario = t => {
+  /**
+   * A player and their user agent (wallet UI, signer)
+   *
+   * @param {string} addr
+   * @param {PromiseKit<*>} bridgeKit - to announce UI is ready
+   * @param {MockVStorageRoot} vsRPC - access to vstorage via RPC
+   * @param {typeof t.context.sendToBridge} broadcastMsg
+   * @param {*} walletUpdates - access to wallet updates via RPC
+   */
+  const aPlayer = async (
+    addr,
+    bridgeKit,
+    vsRPC,
+    broadcastMsg,
+    walletUpdates,
+  ) => {
+    const ctx = makeImportContext();
+    const vsGet = path =>
+      E(vsRPC).getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard);
+
+    // Ingest well-known brands, instances.
+    // Wait for vstorage publication to settle first.
+    await eventLoopIteration();
+    /** @type {Record<string, Brand>} */
+    // @ts-expect-error unsafe testing cast
+    const wkBrand = Object.fromEntries(await vsGet(`agoricNames.brand`));
+    await vsGet(`agoricNames.instance`);
+    t.log(addr, 'wallet UI: ingest well-known brands', wkBrand.Place);
+
+    assert(broadcastMsg);
+    /** @param {import('../src/smartWallet.js').BridgeAction} action */
+    const signAndBroadcast = async action => {
+      const actionEncoding = ctx.fromBoard.toCapData(action);
+      const addIssuerMsg = {
+        type: ActionType.WALLET_SPEND_ACTION,
+        owner: addr,
+        spendAction: JSON.stringify(actionEncoding),
+        blockTime: 0,
+        blockHeight: 0,
+      };
+      t.log(addr, 'walletUI: broadcast signed message', action.method);
+      await broadcastMsg(addIssuerMsg);
+    };
+
+    const auxInfo = async obj => {
+      const slot = ctx.fromBoard.toCapData(obj).slots[0];
+      return vsGet(`${BOARD_AUX}.${slot}`);
+    };
+
+    const { entries } = Object;
+    const uiBridge = Far('UIBridge', {
+      /** @param {import('@endo/marshal').CapData<string>} offerEncoding */
+      proposeOffer: async offerEncoding => {
+        /** @type {import('../src/offers.js').OfferSpec} */
+        const offer = ctx.fromBoard.fromCapData(offerEncoding);
+        const { give, want } = offer.proposal;
+        for await (const [kw, amt] of entries({ ...give, ...want })) {
+          // @ts-expect-error
+          const { displayInfo } = await auxInfo(amt.brand);
+          const kind = displayInfo?.assetKind === 'nat' ? 'fungible' : 'NFT';
+          t.log('wallet:', kind, 'display for', kw, amt.brand);
+        }
+        t.log(addr, 'walletUI: approve offer:', offer.id);
+        await signAndBroadcast(harden({ method: 'executeOffer', offer }));
+      },
+    });
+    bridgeKit.resolve(uiBridge);
+    return walletUpdates;
+  };
+
+  return { aPlayer };
+};
+
+test.serial('trading in non-vbank asset: game real-estate NFTs', async t => {
+  const pettyCashQty = 1000n;
+  const pettyCashPK = makePromiseKit();
+
+  const publishBrandInfo = async (chainStorage, board, brand) => {
+    const [id, displayInfo] = await Promise.all([
+      E(board).getId(brand),
+      E(brand).getDisplayInfo(),
+    ]);
+    const node = makeBoardAuxNode(chainStorage, id);
+    const aux = marshalData.toCapData(harden({ displayInfo }));
+    await E(node).setValue(JSON.stringify(aux));
+  };
+
+  /**
+   * @param {BootstrapPowers} powers
+   * @param {Record<string, Bundle>} bundles
+   */
+  const finishBootstrap = async ({ consume }, bundles) => {
+    const kindAdmin = kind => E(consume.agoricNamesAdmin).lookupAdmin(kind);
+
+    const publishAgoricNames = async () => {
+      const { board, chainStorage } = consume;
+      const pubm = E(board).getPublishingMarshaller();
+      const namesNode = await E(chainStorage)?.makeChildNode('agoricNames');
+      assert(namesNode);
+      for (const kind of ['brand', 'instance']) {
+        const kindNode = await E(namesNode).makeChildNode(kind);
+        const kindUpdater = Far('Updater', {
+          write: async x => {
+            // console.log('marshal for vstorage write', x);
+            const capData = await E(pubm).toCapData(x);
+            await E(kindNode).setValue(JSON.stringify(capData));
+          },
+        });
+        await E(kindAdmin(kind)).onUpdate(kindUpdater);
+      }
+      t.log('bootstrap: share agoricNames updates via vstorage RPC');
+    };
+
+    const shareIST = async () => {
+      const { chainStorage, bankManager, board, feeMintAccess, zoe } = consume;
+      const stable = await E(zoe)
+        .getFeeIssuer()
+        .then(issuer => {
+          return E(issuer)
+            .getBrand()
+            .then(brand => ({ issuer, brand }));
+        });
+      await E(kindAdmin('issuer')).update('IST', stable.issuer);
+      await E(kindAdmin('brand')).update('IST', stable.brand);
+      // TODO: publishBrandInfo for all brands in agoricNames.brand
+      await publishBrandInfo(chainStorage, board, stable.brand);
+
+      const invitation = await E(E(zoe).getInvitationIssuer()).getBrand();
+      await E(kindAdmin('brand')).update('Zoe Invitation', invitation);
+
+      const { creatorFacet: supplier } = await E(zoe).startInstance(
+        E(zoe).install(bundles.centralSupply),
+        {},
+        { bootstrapPaymentValue: pettyCashQty * IST_UNIT },
+        { feeMintAccess: await feeMintAccess },
+      );
+      const bootPmt = await E(supplier).getBootstrapPayment();
+      const stableSupply = E(stable.issuer).makeEmptyPurse();
+      await E(stableSupply).deposit(bootPmt);
+      pettyCashPK.resolve(stableSupply);
+
+      await E(bankManager).addAsset(
+        'uist',
+        'IST',
+        'Inter Stable Token',
+        stable,
+      );
+    };
+
+    await Promise.all([publishAgoricNames(), shareIST()]);
+  };
+
+  /**
+   * Core eval script to start contract
+   *
+   * @param {BootstrapPowers} permittedPowers
+   * @param {Bundle} bundle - in prod: a bundleId
+   */
+  const startGameContract = async ({ consume }, bundle) => {
+    const { agoricNames, agoricNamesAdmin, board, chainStorage, zoe } = consume;
+    const istBrand = await E(agoricNames).lookup('brand', 'IST');
+    const ist = {
+      brand: istBrand,
+    };
+    const terms = { joinPrice: AmountMath.make(ist.brand, 25n * CENT) };
+    const installationP = E(zoe).install(bundle); // in prod: installBundleId
+    // in prod: use startUpgradeable() to save adminFacet
+    const { instance } = await E(zoe).startInstance(installationP, {}, terms);
+    t.log('CoreEval script: started game contract', instance);
+    const {
+      brands: { Place: brand },
+      issuers: { Place: issuer },
+    } = await E(zoe).getTerms(instance);
+
+    t.log('CoreEval script: share via agoricNames:', brand);
+    const kindAdmin = kind => E(agoricNamesAdmin).lookupAdmin(kind);
+    await Promise.all([
+      E(kindAdmin('instance')).update('game1', instance),
+      E(kindAdmin('issuer')).update('Place', issuer),
+      E(kindAdmin('brand')).update('Place', brand),
+      publishBrandInfo(the(chainStorage), board, brand),
+    ]);
+  };
+
+  /**
+   * @param {MockVStorageRoot} rpc - access to vstorage (in prod: via RPC)
+   * @param {*} walletBridge - iframe connection to wallet UI
+   */
+  const dappFrontEnd = async (rpc, walletBridge) => {
+    const { fromEntries } = Object;
+    const ctx = makeImportContext();
+    await eventLoopIteration();
+    const vsGet = path =>
+      E(rpc).getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard);
+
+    // @ts-expect-error unsafe testing cast
+    const wkBrand = fromEntries(await vsGet(`agoricNames.brand`));
+    // @ts-expect-error unsafe testing cast
+    const wkInstance = fromEntries(await vsGet(`agoricNames.instance`));
+    t.log('game UI: ingested well-known brands:', wkBrand.Place);
+
+    const choices = ['Park Place', 'Boardwalk'];
+    const want = {
+      Places: AmountMath.make(
+        wkBrand.Place,
+        makeCopyBag(choices.map(name => [name, 1n])),
+      ),
+    };
+    const give = { Price: AmountMath.make(wkBrand.IST, 25n * CENT) };
+    /** @type {import('../src/offers.js').OfferSpec} */
+    const offer1 = harden({
+      id: 'joinGame1234',
+      invitationSpec: {
+        source: 'contract',
+        instance: wkInstance.game1,
+        publicInvitationMaker: 'makeJoinInvitation',
+      },
+      proposal: { give, want },
+    });
+    t.log('game UI: propose offer of 0.25IST for', choices.join(', '));
+    await E(walletBridge).proposeOffer(ctx.fromBoard.toCapData(offer1));
+  };
+
+  // TODO: hoist the functions above out of the test
+  // so that t.context is not in scope?
+  const { consume, simpleProvideWallet, sendToBridge } = t.context;
+
+  const bundles = {
+    game: await importSpec('./gameAssetContract.js').then(bundleSource),
+    centralSupply: await importSpec('@agoric/vats/src/centralSupply.js').then(
+      bundleSource,
+    ),
+  };
+
+  const fundWalletAndSubscribe = async (addr, istQty) => {
+    const purse = pettyCashPK.promise;
+    const spendBrand = await E(purse).getAllegedBrand();
+    const spendingPmt = await E(purse).withdraw(
+      AmountMath.make(spendBrand, istQty * IST_UNIT),
+    );
+    const wallet = simpleProvideWallet(addr);
+    t.log('deposit', istQty, 'IST into wallet of', addr);
+    await E(E(wallet).getDepositFacet()).receive(spendingPmt);
+    const updates = await E(wallet).getUpdatesSubscriber();
+    return updates;
+  };
+
+  /** @type {BootstrapPowers} */
+  // @ts-expect-error mock
+  const somePowers = { consume };
+
+  /** @type {MockVStorageRoot} */
+  // @ts-expect-error mock
+  const mockStorage = await consume.chainStorage;
+  await finishBootstrap(somePowers, bundles);
+  t.log(
+    'install game contract bundle with hash:',
+    bundles.game.endoZipBase64Sha512.slice(0, 24),
+    '...',
+  );
+
+  {
+    const addr1 = 'agoric1player1';
+    const walletUIbridge = makePromiseKit();
+    const { aPlayer } = makeScenario(t);
+
+    const [_1, _2, updates] = await Promise.all([
+      startGameContract(somePowers, bundles.game),
+      dappFrontEnd(mockStorage, walletUIbridge.promise),
+      aPlayer(
+        addr1,
+        walletUIbridge,
+        mockStorage,
+        sendToBridge,
+        fundWalletAndSubscribe(addr1, 10n),
+      ),
+    ]);
+
+    /** @type {[string, bigint][]} */
+    const expected = [
+      ['Park Place', 1n],
+      ['Boardwalk', 1n],
+    ];
+
+    /** @type {import('../src/smartWallet.js').UpdateRecord} */
+    const update = await headValue(updates);
+    assert(update.updated === 'offerStatus');
+    // t.log(update.status);
+    t.like(update, {
+      updated: 'offerStatus',
+      status: {
+        id: 'joinGame1234',
+        invitationSpec: { publicInvitationMaker: 'makeJoinInvitation' },
+        numWantsSatisfied: 1,
+        payouts: { Places: { value: { payload: expected } } },
+        result: 'welcome to the game',
+      },
+    });
+    const {
+      status: { id, result, payouts },
+    } = update;
+    // @ts-expect-error cast value to copyBag
+    const names = payouts?.Places.value.payload.map(([name, _qty]) => name);
+    t.log(id, 'result:', result, ', payouts:', names.join(', '));
+
+    // wallet balance was also updated
+    const ctx = makeImportContext();
+    const vsGet = (path, ix = -1) =>
+      mockStorage.getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard, ix);
+    /** @type {Record<string, Brand>} */
+    const wkb = Object.fromEntries(
+      // @ts-expect-error unsafe testing cast
+      vsGet(`agoricNames.brand`),
+    );
+    vsGet(`agoricNames.instance`);
+
+    const balanceUpdate = vsGet(`wallet.${addr1}`, -2);
+    t.deepEqual(balanceUpdate, {
+      updated: 'balance',
+      currentAmount: { brand: wkb.Place, value: makeCopyBag(expected) },
+    });
+  }
+});
+
+test.serial('non-vbank asset: give before deposit', async t => {
+  /**
+   * Goofy client: proposes to give Places before we have any
+   *
+   * @param {MockVStorageRoot} rpc - access to vstorage (in prod: via RPC)
+   * @param {*} walletBridge - iframe connection to wallet UI
+   */
+  const goofyClient = async (rpc, walletBridge) => {
+    const { fromEntries } = Object;
+    const ctx = makeImportContext();
+    const vsGet = path =>
+      E(rpc).getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard);
+    // @ts-expect-error unsafe testing cast
+    const wkBrand = fromEntries(await vsGet(`agoricNames.brand`));
+    // @ts-expect-error unsafe testing cast
+    const wkInstance = fromEntries(await vsGet(`agoricNames.instance`));
+
+    const choices = ['Disney Land'];
+    const give = {
+      Places: AmountMath.make(
+        wkBrand.Place,
+        makeCopyBag(choices.map(name => [name, 1n])),
+      ),
+    };
+    const want = { Price: AmountMath.make(wkBrand.IST, 25n * CENT) };
+
+    /** @type {import('../src/offers.js').OfferSpec} */
+    const offer1 = harden({
+      id: 'joinGame2345',
+      invitationSpec: {
+        source: 'contract',
+        instance: wkInstance.game1,
+        publicInvitationMaker: 'makeJoinInvitation',
+      },
+      proposal: { give, want },
+    });
+    t.log('goofy client: propose to give', choices.join(', '));
+    await E(walletBridge).proposeOffer(ctx.fromBoard.toCapData(offer1));
+  };
+
+  {
+    const addr2 = 'agoric1player2';
+    const walletUIbridge = makePromiseKit();
+    // await eventLoopIteration();
+
+    const { simpleProvideWallet, consume, sendToBridge } = t.context;
+    const wallet = simpleProvideWallet(addr2);
+    const updates = await E(wallet).getUpdatesSubscriber();
+    /** @type {MockVStorageRoot} */
+    // @ts-expect-error mock
+    const mockStorage = await consume.chainStorage;
+    const { aPlayer } = makeScenario(t);
+
+    aPlayer(addr2, walletUIbridge, mockStorage, sendToBridge, updates);
+    const c2 = goofyClient(mockStorage, walletUIbridge.promise);
+    await t.throwsAsync(c2, { message: /Withdrawal of {.*} failed/ });
+    await eventLoopIteration();
+
+    // wallet balance was also updated
+    const ctx = makeImportContext();
+    const vsGet = (path, ix = -1) =>
+      mockStorage.getBody(`mockChainStorageRoot.${path}`, ctx.fromBoard, ix);
+    vsGet(`agoricNames.brand`);
+    vsGet(`agoricNames.instance`);
+
+    /** @type {import('../src/smartWallet.js').UpdateRecord & {updated: 'offerStatus'}} */
+    let offerUpdate;
+    let ix = -1;
+    for (;;) {
+      /** @type {import('../src/smartWallet.js').UpdateRecord} */
+      // @ts-expect-error
+      const update = vsGet(`wallet.${addr2}`, ix);
+      if (update.updated === 'offerStatus') {
+        offerUpdate = update;
+        break;
+      }
+      ix -= 1;
+    }
+
+    t.regex(offerUpdate.status.error || '', /Withdrawal of {.*} failed/);
+    t.log(offerUpdate.status.id, offerUpdate.status.error);
+  }
 });

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -74,7 +74,9 @@ test.serial('avoid O(wallets) storage writes for a new asset', async t => {
   };
 
   const simulate = async (qty, denom, name) => {
-    range(qty).forEach(startUser);
+    for (const idx of range(qty)) {
+      void startUser(idx);
+    }
     await eventLoopIteration();
     const initialWrites = chainStorageWrites;
 

--- a/packages/vats/tools/board-utils.js
+++ b/packages/vats/tools/board-utils.js
@@ -54,6 +54,7 @@ export const makeAgoricNamesRemotesFromFakeStorage = fakeStorageKit => {
       data,
       `published.agoricNames.${kind}`,
       fromCapData,
+      -1,
     );
     for (const [name, remote] of parts) {
       reverse[remote.getBoardId()] = name;
@@ -67,6 +68,7 @@ export const makeAgoricNamesRemotesFromFakeStorage = fakeStorageKit => {
       data,
       `published.agoricNames.vbankAsset`,
       fromCapData,
+      -1,
     ).map(([_denom, info]) => [
       info.issuerName,
       { ...info, brand: tables.brand[info.issuerName] },


### PR DESCRIPTION
refs: #7226

## Description

Enrich the offer and deposit handling in the smart wallet to support well-known issuers -- that is, issuers in `agoricNames.issuer` and correspondingly `agoricNames.brand`.

Also, demonstrate in a test how permissioned contract deployment would enable trading in non-vbank assets.

### Security Considerations

To date, aside from EC member invitations and Oracle operator invitations, the smart wallet contract held no precious assets; assets such as IST and USDC are reflected from cosmos `bank` module balances via the `vbank`.

This PR adds purses that hold assets that are not recorded anywhere else.

### Scaling Considerations

When we make a new purse from a well-known issuer, we do a reverse-lookup by brand. One approach would be to add a method on `NameHub` for that, as discussed in...

 - #5107

The current approach here is to use the existing `E(E(agoricNames).lookup('brand')).entries()` API and then search thru the entries on the caller's side.

### Documentation Considerations

The convention for publishing `{ displayInfo }` at `published.boardAux.board0123` is only documented in a test. (That'll change in the subsequent upgrade PR).

`agoricNamesAdmin` is noted in the [discussion of consume](https://dc-permissioned-deployment.documentation-7tp.pages.dev/guides/coreeval/permissions.html#top-level-consume-section) under Permisioned Deployment, but the whole `NameHub` API is more or less undocumented:

 - https://github.com/Agoric/documentation/issues/807

### Testing Considerations

The tests tell a bit of a story using `t.log()`. (details [below](#issuecomment-1650924936))

  ✔ trading in non-vbank asset: game real-estate NFTs (2.7s)
  ✔ non-vbank asset: give before deposit

Given that we're introducing purses that store precious assets, would it be cost-effective to test that we know how to trace purse ownership and balance at the kernel database level? https://github.com/Agoric/agoric-sdk/issues/8138

### Upgrade Considerations

Upgrading the `walletFactory` contract and to publish displayInfo for IST etc. under `boardAux` is to follow in a separate PR.
