### PR TITLE
swingstore import should not discard historical metadata, and add repair function

### DIFF
--- a/packages/swing-store/docs/swingstore.md
+++ b/packages/swing-store/docs/swingstore.md
@@ -1,0 +1,52 @@
+# SwingStore Data Model
+
+The "SwingStore" provides a database to hold SwingSet kernel state, with an API crafted to help both the kernel and the host application mutate, commit, export, and import this state.
+
+The state is broken up into several pieces, or "stores":
+
+* `bundleStore`: a string-keyed Bundle-value table, holding source bundles which can be evaluated by `importBundle` to create vats, or new Compartments within a vat
+* `transcriptStore`: records a linear sequence of deliveries and syscalls (with results), collectively known as "transcript entries", for each vat
+* `snapStore`: records one or more XS heap snapshots for each vat, to rebuild a worker more efficiently than replaying all transcript entries from the beginning
+* `kvStore`: a string-keyed string-valued table, which holds everything else. Currently, this holds each vat's c-list and vatstore data, as well as the kernel-wide object and promise tables, and run-queues.
+
+## Incarnations, Spans, Snapshots
+
+The kernel tracks the state of one or more vats. Each vat's execution is split into "incarnations", which are separated by a "vat upgrade" (a call to `E(vatAdminFacet).upgrade(newBundleCap, options)`, see https://github.com/Agoric/agoric-sdk/blob/master/packages/SwingSet/docs/vat-upgrade.md for details). Each incarnation gets a new worker, which erases the heap state and only retains durable vatstore data across the upgrade. Every active vat has a "current incarnation", and zero or more "historic incarnations". Only the current incarnation is instantiated.
+
+Within each incarnation, execution is broken into one or more "spans", with a "current span" and zero or more "historic spans". This breaks up the transcript into corresponding spans.
+
+Each historic span ends with a `save-snapshot` entry which records the creation and saving of an XS heap snapshot. The initial span starts with a `start-worker` entry, while all non-initial spans start with a `load-snapshot` entry. The final span of historic incarnations each end with a `shutdown-worker` entry.
+
+Each `save-snapshot` entry adds a new snapshot to the `snapStore`, so each vat has zero or more snapshots, of which the last one is called the "current" or "in-use" snapshot, and the earlier ones are called "historical snapshots".
+
+(note: the `deliveryNum` counter is scoped to the vat and does not reset at incarnation or span boundaries)
+
+## Artifacts
+
+The import/export process (using `makeSwingStoreExporter` and `importSwingStore`) defines some number of "artifacts" to contain much of the SwingStore data. Each bundle is a separate artifact, as is each heap snapshot. Each transcript span is a separate artifact (an aggregate of the individual transcript entries comprising that span).
+
+During export, the `getArtifactNames()` method provides a list of all available artifacts, while `getArtifact(name)` is used to retrieve the actual data. The import function processes each artifact separately.
+
+## Populated vs Pruned
+
+For normal operation, the kernel does not require historical incarnations, spans, or snapshots. It only needs the ability to reconstruct a worker for the current incarnation of each vat, which means loading the current snapshot (if any), and replaying the contents of the current transcript span.
+
+For this reason, the swingstore must always contain the current transcript span, and the current snapshot (if any), for every vat.
+
+However, to save space, historical spans/snapshots might be pruned, by deleting their contents from the database (but retaining the metadata, which includes a hash of the contents for later validation). Historical snapshots are pruned by default (unless `openSwingStore()` is given an options bag with `keepSnapshots: true`). Historical spans are not currently pruned (the `keepTranscripts` option defaults to `true`), but that may change.
+
+In addition, `importSwingStore()` can be used to create a SwingStore from data exported out of some other SwingStore. The export-then-import process might result in a pruned DB in one of three ways:
+
+* the import-time options might instruct the import process to ignore some of the available data
+* the export-time options might have done the same
+* the original DB was itself already pruned, so the data was not available in the first place
+
+In the future, a separate SwingStore API will exist to allow previously-pruned artifacts to be repopulated. Every artifact has a metadata record which *is* included in the export (in the `exportData` section, but separate from the kvStore shadow table entries, see [data-export.md](./data-export.md)), regardless of pruning modes, to ensure that this API can check the integrity of these repopulated artifacts. This reduces the reliance set and trust burden of the repopulation process (we can safely use untrusted artifact providers).
+
+When a snapshot is pruned, the `snapshots` SQL table row is modified, replacing its `compressedSnapshot` BLOB with a NULL. The other columns are left alone, especially the `hash` column, which retains the integrity-checking metadata to support a future repopulation.
+
+When a transcript span is pruned, the `transcriptSpans` row is left alone, but the collection of `transcriptItems` rows are deleted. Any span for which all the `transcriptItems` rows are present is said to be "populated", while any span that is missing one or more `transcriptItems` rows is said to be "pruned". (There is no good reason for a span to be only partially pruned, but until we compress historical spans into a single row, in some new table, there remains the possibility of partial pruning).
+
+During import, we create the metadata first (as the export-data is parsed), then later, we fill in the details as the artifacts are read.
+
+Bundles are never pruned, however during import, the `bundles` table will temporarily contain rows whose `bundle` BLOB is NULL.

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -3,7 +3,10 @@
   "version": "0.9.1",
   "description": "Persistent storage for SwingSet",
   "type": "module",
-  "main": "src/swingStore.js",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",
   "license": "Apache-2.0",

--- a/packages/swing-store/src/assertComplete.js
+++ b/packages/swing-store/src/assertComplete.js
@@ -1,0 +1,22 @@
+/**
+ * @param {import('./internal.js').SwingStoreInternal} internal
+ * @param {'operational'} level
+ * @returns {void}
+ */
+export function assertComplete(internal, level) {
+  assert.equal(level, 'operational'); // only option for now
+  // every bundle must be populated
+  internal.bundleStore.assertComplete(level);
+
+  // every 'isCurrent' transcript span must have all items
+  // TODO: every vat with any data must have a isCurrent transcript
+  // span
+  internal.transcriptStore.assertComplete(level);
+
+  // every 'inUse' snapshot must be populated
+  internal.snapStore.assertComplete(level);
+
+  // TODO: every isCurrent span that starts with load-snapshot has a
+  // matching snapshot (counter-argument: swing-store should not know
+  // those details about transcript entries)
+}

--- a/packages/swing-store/src/bundleStore.js
+++ b/packages/swing-store/src/bundleStore.js
@@ -16,7 +16,7 @@ import { buffer } from './util.js';
  * @typedef { EndoZipBase64Bundle | GetExportBundle | NestedEvaluateBundle } Bundle
  */
 /**
- * @typedef { import('./swingStore').SwingStoreExporter } SwingStoreExporter
+ * @typedef { import('./exporter').SwingStoreExporter } SwingStoreExporter
  *
  * @typedef {{
  *   addBundle: (bundleID: string, bundle: Bundle) => void;

--- a/packages/swing-store/src/exporter.js
+++ b/packages/swing-store/src/exporter.js
@@ -1,0 +1,173 @@
+import sqlite3 from 'better-sqlite3';
+
+import { Fail, q } from '@agoric/assert';
+
+import { dbFileInDirectory } from './util.js';
+import { getKeyType } from './kvStore.js';
+import { makeBundleStore } from './bundleStore.js';
+import { makeSnapStore } from './snapStore.js';
+import { makeSnapStoreIO } from './snapStoreIO.js';
+import { makeTranscriptStore } from './transcriptStore.js';
+
+/**
+ * @template T
+ *  @typedef  { Iterable<T> | AsyncIterable<T> } AnyIterable<T>
+ */
+/**
+ * @template T
+ *  @typedef  { IterableIterator<T> | AsyncIterableIterator<T> } AnyIterableIterator<T>
+ */
+
+/**
+ *
+ * @typedef {readonly [
+ *   key: string,
+ *   value?: string | null | undefined,
+ * ]} KVPair
+ *
+ * @typedef {object} SwingStoreExporter
+ *
+ * Allows export of data from a swingStore as a fixed view onto the content as
+ * of the most recent commit point at the time the exporter was created.  The
+ * exporter may be used while another SwingStore instance is active for the same
+ * DB, possibly in another thread or process.  It guarantees that regardless of
+ * the concurrent activity of other swingStore instances, the data representing
+ * the commit point will stay consistent and available.
+ *
+ * @property {() => AnyIterableIterator<KVPair>} getExportData
+ *
+ * Get a full copy of the first-stage export data (key-value pairs) from the
+ * swingStore. This represents both the contents of the KVStore (excluding host
+ * and local prefixes), as well as any data needed to validate all artifacts,
+ * both current and historical. As such it represents the root of trust for the
+ * application.
+ *
+ * Content of validation data (with supporting entries for indexing):
+ * - kv.${key} = ${value}  // ordinary kvStore data entry
+ * - snapshot.${vatID}.${snapPos} = ${{ vatID, snapPos, hash });
+ * - snapshot.${vatID}.current = `snapshot.${vatID}.${snapPos}`
+ * - transcript.${vatID}.${startPos} = ${{ vatID, startPos, endPos, hash }}
+ * - transcript.${vatID}.current = ${{ vatID, startPos, endPos, hash }}
+ *
+ * @property {() => AnyIterableIterator<string>} getArtifactNames
+ *
+ * Get a list of name of artifacts available from the swingStore.  A name returned
+ * by this method guarantees that a call to `getArtifact` on the same exporter
+ * instance will succeed. Options control the filtering of the artifact names
+ * yielded.
+ *
+ * Artifact names:
+ * - transcript.${vatID}.${startPos}.${endPos}
+ * - snapshot.${vatID}.${snapPos}
+ *
+ * @property {(name: string) => AnyIterableIterator<Uint8Array>} getArtifact
+ *
+ * Retrieve an artifact by name.  May throw if the artifact is not available,
+ * which can occur if the artifact is historical and wasn't been preserved.
+ *
+ * @property {() => Promise<void>} close
+ *
+ * Dispose of all resources held by this exporter. Any further operation on this
+ * exporter or its outstanding iterators will fail.
+ */
+
+/**
+ * @typedef {'current' | 'archival' | 'debug'} ExportMode
+ */
+
+/**
+ * @param {string} dirPath
+ * @param { ExportMode } exportMode
+ * @returns {SwingStoreExporter}
+ */
+export function makeSwingStoreExporter(dirPath, exportMode = 'current') {
+  typeof dirPath === 'string' || Fail`dirPath must be a string`;
+  exportMode === 'current' ||
+    exportMode === 'archival' ||
+    exportMode === 'debug' ||
+    Fail`invalid exportMode ${q(exportMode)}`;
+  const exportHistoricalSnapshots = exportMode === 'debug';
+  const exportHistoricalTranscripts = exportMode !== 'current';
+  const filePath = dbFileInDirectory(dirPath);
+  const db = sqlite3(filePath);
+
+  // Execute the data export in a (read) transaction, to ensure that we are
+  // capturing the state of the database at a single point in time. Our close()
+  // will ROLLBACK the txn just in case some bug tried to change the DB.
+  const sqlBeginTransaction = db.prepare('BEGIN TRANSACTION');
+  sqlBeginTransaction.run();
+
+  // ensureTxn can be a dummy, we just started one
+  const ensureTxn = () => {};
+  const snapStore = makeSnapStore(db, ensureTxn, makeSnapStoreIO());
+  const bundleStore = makeBundleStore(db, ensureTxn);
+  const transcriptStore = makeTranscriptStore(db, ensureTxn, () => {});
+
+  const sqlGetAllKVData = db.prepare(`
+    SELECT key, value
+    FROM kvStore
+    ORDER BY key
+  `);
+
+  /**
+   * @returns {AsyncIterableIterator<KVPair>}
+   * @yields {KVPair}
+   */
+  async function* getExportData() {
+    const kvPairs = sqlGetAllKVData.iterate();
+    for (const kv of kvPairs) {
+      if (getKeyType(kv.key) === 'consensus') {
+        yield [`kv.${kv.key}`, kv.value];
+      }
+    }
+    yield* snapStore.getExportRecords(true);
+    yield* transcriptStore.getExportRecords(true);
+    yield* bundleStore.getExportRecords();
+  }
+
+  /**
+   * @returns {AsyncIterableIterator<string>}
+   * @yields {string}
+   */
+  async function* getArtifactNames() {
+    yield* snapStore.getArtifactNames(exportHistoricalSnapshots);
+    yield* transcriptStore.getArtifactNames(exportHistoricalTranscripts);
+    yield* bundleStore.getArtifactNames();
+  }
+
+  /**
+   * @param {string} name
+   * @returns {AsyncIterableIterator<Uint8Array>}
+   */
+  function getArtifact(name) {
+    typeof name === 'string' || Fail`artifact name must be a string`;
+    const [type] = name.split('.', 1);
+
+    if (type === 'snapshot') {
+      return snapStore.exportSnapshot(name, exportHistoricalSnapshots);
+    } else if (type === 'transcript') {
+      return transcriptStore.exportSpan(name, exportHistoricalTranscripts);
+    } else if (type === 'bundle') {
+      return bundleStore.exportBundle(name);
+    } else {
+      throw Fail`invalid artifact type ${q(type)}`;
+    }
+  }
+
+  const sqlAbort = db.prepare('ROLLBACK');
+
+  async function close() {
+    // After all the data has been extracted, always abort the export
+    // transaction to ensure that the export was read-only (i.e., that no bugs
+    // inadvertantly modified the database).
+    sqlAbort.run();
+    db.close();
+  }
+
+  return harden({
+    getExportData,
+    getArtifactNames,
+    getArtifact,
+    close,
+  });
+}

--- a/packages/swing-store/src/importer.js
+++ b/packages/swing-store/src/importer.js
@@ -1,204 +1,121 @@
 import { Fail, q } from '@agoric/assert';
 
 import { makeSwingStore } from './swingStore.js';
+import { buffer } from './util.js';
+import { assertComplete } from './assertComplete.js';
+
+/**
+ * @typedef { object } ImportSwingStoreOptions
+ * @property { boolean } [includeHistorical]  Should the importer pay attention to historical artifacts?
+ */
 
 /**
  * Function used to create a new swingStore from an object implementing the
  * exporter API. The exporter API may be provided by a swingStore instance, or
  * implemented by a host to restore data that was previously exported.
  *
- * @typedef { import('./exporter').SwingStoreExporter } SwingStoreExporter
- * @typedef { import('./swingStore').SwingStore } SwingStore
- * @typedef {(exporter: SwingStoreExporter) => Promise<SwingStore>} ImportSwingStore
- */
-
-function parseVatArtifactExportKey(key) {
-  const parts = key.split('.');
-  const [_type, vatID, rawPos] = parts;
-  // prettier-ignore
-  parts.length === 3 ||
-    Fail`expected artifact name of the form '{type}.{vatID}.{pos}', saw ${q(key)}`;
-  const isCurrent = rawPos === 'current';
-  let pos;
-  if (isCurrent) {
-    pos = -1;
-  } else {
-    pos = Number(rawPos);
-  }
-
-  return { vatID, isCurrent, pos };
-}
-
-function artifactKey(type, vatID, pos) {
-  return `${type}.${vatID}.${pos}`;
-}
-
-/**
- * @param {SwingStoreExporter} exporter
+ * @param {import('./exporter').SwingStoreExporter} exporter
  * @param {string | null} [dirPath]
- * @param {object} options
- * @returns {Promise<SwingStore>}
+ * @param {ImportSwingStoreOptions} options
+ * @returns {Promise<import('./swingStore').SwingStore>}
  */
 export async function importSwingStore(exporter, dirPath = null, options = {}) {
-  if (dirPath) {
-    typeof dirPath === 'string' || Fail`dirPath must be a string`;
+  if (dirPath && typeof dirPath !== 'string') {
+    Fail`dirPath must be a string`;
   }
   const { includeHistorical = false } = options;
   const store = makeSwingStore(dirPath, true, options);
   const { kernelStorage, internal } = store;
 
-  // Artifact metadata, keyed as `${type}.${vatID}.${pos}`
-  //
-  // Note that this key is almost but not quite the artifact name, since the
-  // names of transcript span artifacts also include the endPos, but the endPos
-  // value is in flux until the span is complete.
-  const artifactMetadata = new Map();
+  // For every exportData entry, we add a DB record. 'kv' entries are
+  // the "kvStore shadow table", and are not associated with any
+  // artifacts. All other entries are associated with an artifact,
+  // however the import may or may not contain that artifact (the
+  // dataset can be incomplete: either the original DB was pruned at
+  // some point, or the exporter did not choose to include
+  // everything). The DB records we add are marked as incomplete (as
+  // if they had been pruned locally), and can be populated later when
+  // the artifact is retrieved.
 
-  // Each vat requires a transcript span and (usually) a snapshot.  This table
-  // tracks which of these we've seen, keyed by vatID.
-  // vatID -> { snapshotKey: metadataKey, transcriptKey: metatdataKey }
-  const vatArtifacts = new Map();
-  const bundleArtifacts = new Map();
+  // While unlikely, the getExportData() protocol *is* allowed to
+  // deliver multiple values for the same key (last one wins), or use
+  // 'null' to delete a previously-defined key. So our first pass both
+  // installs the kvStore shadow records, and de-dups/deletes the
+  // metadata records into this Map.
+
+  const allMetadata = new Map();
 
   for await (const [key, value] of exporter.getExportData()) {
     const [tag] = key.split('.', 1);
-    const subKey = key.substring(tag.length + 1);
     if (tag === 'kv') {
       // 'kv' keys contain individual kvStore entries
+      const subKey = key.substring(tag.length + 1);
       if (value == null) {
         // Note '==' rather than '===': any nullish value implies deletion
         kernelStorage.kvStore.delete(subKey);
       } else {
         kernelStorage.kvStore.set(subKey, value);
       }
-    } else if (tag === 'bundle') {
-      // 'bundle' keys contain bundle IDs
-      if (value == null) {
-        bundleArtifacts.delete(key);
-      } else {
-        bundleArtifacts.set(key, value);
-      }
-    } else if (tag === 'transcript' || tag === 'snapshot') {
-      // 'transcript' and 'snapshot' keys contain artifact description info.
-      assert(value); // make TypeScript shut up
-      const { vatID, isCurrent, pos } = parseVatArtifactExportKey(key);
-      if (isCurrent) {
-        const vatInfo = vatArtifacts.get(vatID) || {};
-        if (tag === 'snapshot') {
-          // `export.snapshot.{vatID}.current` directly identifies the current snapshot artifact
-          vatInfo.snapshotKey = value;
-        } else if (tag === 'transcript') {
-          // `export.transcript.${vatID}.current` contains a metadata record for the current
-          // state of the current transcript span as of the time of export
-          const metadata = JSON.parse(value);
-          vatInfo.transcriptKey = artifactKey(tag, vatID, metadata.startPos);
-          artifactMetadata.set(vatInfo.transcriptKey, metadata);
-        }
-        vatArtifacts.set(vatID, vatInfo);
-      } else {
-        artifactMetadata.set(artifactKey(tag, vatID, pos), JSON.parse(value));
-      }
+    } else if (value == null) {
+      allMetadata.delete(key);
     } else {
-      Fail`unknown artifact type tag ${q(tag)} on import`;
+      allMetadata.set(key, value);
     }
   }
 
-  // At this point we should have acquired the entire KV store state, plus
-  // sufficient metadata to identify the complete set of artifacts we'll need to
-  // fetch along with the information required to validate each of them after
-  // fetching.
-  //
-  // Depending on how the export was parameterized, the metadata may also include
-  // information about historical artifacts that we might or might not actually
-  // fetch depending on how this import was parameterized
+  // Now take each metadata record and install the stub/pruned entry
+  // into the DB.
 
-  // Fetch the set of current artifacts.
-
-  // Keep track of fetched artifacts in this set so we don't fetch them a second
-  // time if we are trying for historical artifacts also.
-  const fetchedArtifacts = new Set();
-
-  for await (const [vatID, vatInfo] of vatArtifacts.entries()) {
-    // For each vat, we *must* have a transcript span.  If this is not the very
-    // first transcript span in the history of that vat, then we also must have
-    // a snapshot for the state of the vat immediately prior to when the
-    // transcript span begins.
-    vatInfo.transcriptKey ||
-      Fail`missing current transcript key for vat ${q(vatID)}`;
-    const transcriptInfo = artifactMetadata.get(vatInfo.transcriptKey);
-    transcriptInfo || Fail`missing transcript metadata for vat ${q(vatID)}`;
-    let snapshotInfo;
-    if (vatInfo.snapshotKey) {
-      snapshotInfo = artifactMetadata.get(vatInfo.snapshotKey);
-      snapshotInfo || Fail`missing snapshot metadata for vat ${q(vatID)}`;
-    }
-    if (!snapshotInfo) {
-      transcriptInfo.startPos === 0 ||
-        Fail`missing current snapshot for vat ${q(vatID)}`;
+  for (const [key, value] of allMetadata.entries()) {
+    const [tag] = key.split('.', 1);
+    if (tag === 'bundle') {
+      internal.bundleStore.importBundleRecord(key, value);
+    } else if (tag === 'snapshot') {
+      internal.snapStore.importSnapshotRecord(key, value);
+    } else if (tag === 'transcript') {
+      internal.transcriptStore.importTranscriptSpanRecord(key, value);
     } else {
-      snapshotInfo.snapPos + 1 === transcriptInfo.startPos ||
-        Fail`current transcript for vat ${q(vatID)} doesn't go with snapshot`;
-      fetchedArtifacts.add(vatInfo.snapshotKey);
+      Fail`unknown export-data type ${q(tag)} on import`;
     }
-    await (!snapshotInfo ||
-      internal.snapStore.importSnapshot(
-        vatInfo.snapshotKey,
-        exporter,
-        snapshotInfo,
-      ));
-
-    const transcriptArtifactName = `${vatInfo.transcriptKey}.${transcriptInfo.endPos}`;
-    await internal.transcriptStore.importSpan(
-      transcriptArtifactName,
-      exporter,
-      transcriptInfo,
-    );
-    fetchedArtifacts.add(transcriptArtifactName);
-  }
-  const bundleArtifactNames = Array.from(bundleArtifacts.keys()).sort();
-  for await (const bundleArtifactName of bundleArtifactNames) {
-    await internal.bundleStore.importBundle(
-      bundleArtifactName,
-      exporter,
-      bundleArtifacts.get(bundleArtifactName),
-    );
   }
 
-  if (!includeHistorical) {
-    await exporter.close();
-    return store;
-  }
+  // All the metadata is now installed, and we're prepared for
+  // artifacts. We walk `getArtifactNames()` and offer each one to the
+  // submodule, which ignores historical ones (unless
+  // 'includeHistorical' is true), and validates+accepts the
+  // rest. This is an initial import, so we don't need to check if we
+  // already have the data, but the submodule function is free to do
+  // that check if they want.
 
-  // If we're also importing historical artifacts, have the exporter enumerate
-  // the complete set of artifacts it has and fetch all of them except for the
-  // ones we've already fetched.
-  for await (const artifactName of exporter.getArtifactNames()) {
-    if (fetchedArtifacts.has(artifactName)) {
-      continue;
-    }
-    let fetchedP;
-    if (artifactName.startsWith('snapshot.')) {
-      fetchedP = internal.snapStore.importSnapshot(
-        artifactName,
-        exporter,
-        artifactMetadata.get(artifactName),
+  for await (const name of exporter.getArtifactNames()) {
+    const makeChunkIterator = () => exporter.getArtifact(name);
+    const dataProvider = async () => buffer(makeChunkIterator());
+    const [tag] = name.split('.', 1);
+    // TODO: pass the same args to all artifact importers, and let
+    // stores register their functions by
+    // 'type'. https://github.com/Agoric/agoric-sdk/pull/8075#discussion_r1285265453
+    if (tag === 'bundle') {
+      await internal.bundleStore.importBundle(name, dataProvider);
+    } else if (tag === 'snapshot') {
+      await internal.snapStore.populateSnapshot(name, makeChunkIterator, {
+        includeHistorical,
+      });
+    } else if (tag === 'transcript') {
+      await internal.transcriptStore.populateTranscriptSpan(
+        name,
+        makeChunkIterator,
+        { includeHistorical },
       );
-    } else if (artifactName.startsWith('transcript.')) {
-      // strip endPos off artifact name
-      const metadataKey = artifactName.split('.').slice(0, 3).join('.');
-      fetchedP = internal.transcriptStore.importSpan(
-        artifactName,
-        exporter,
-        artifactMetadata.get(metadataKey),
-      );
-    } else if (artifactName.startsWith('bundle.')) {
-      // already taken care of
-      continue;
     } else {
-      Fail`unknown artifact type: ${artifactName}`;
+      Fail`unknown artifact type ${q(tag)} on import`;
     }
-    await fetchedP;
   }
+
+  // We've installed all the artifacts that we could, now do a
+  // completeness check.
+
+  assertComplete(internal, 'operational');
+
   await exporter.close();
   return store;
 }

--- a/packages/swing-store/src/importer.js
+++ b/packages/swing-store/src/importer.js
@@ -1,0 +1,204 @@
+import { Fail, q } from '@agoric/assert';
+
+import { makeSwingStore } from './swingStore.js';
+
+/**
+ * Function used to create a new swingStore from an object implementing the
+ * exporter API. The exporter API may be provided by a swingStore instance, or
+ * implemented by a host to restore data that was previously exported.
+ *
+ * @typedef { import('./exporter').SwingStoreExporter } SwingStoreExporter
+ * @typedef { import('./swingStore').SwingStore } SwingStore
+ * @typedef {(exporter: SwingStoreExporter) => Promise<SwingStore>} ImportSwingStore
+ */
+
+function parseVatArtifactExportKey(key) {
+  const parts = key.split('.');
+  const [_type, vatID, rawPos] = parts;
+  // prettier-ignore
+  parts.length === 3 ||
+    Fail`expected artifact name of the form '{type}.{vatID}.{pos}', saw ${q(key)}`;
+  const isCurrent = rawPos === 'current';
+  let pos;
+  if (isCurrent) {
+    pos = -1;
+  } else {
+    pos = Number(rawPos);
+  }
+
+  return { vatID, isCurrent, pos };
+}
+
+function artifactKey(type, vatID, pos) {
+  return `${type}.${vatID}.${pos}`;
+}
+
+/**
+ * @param {SwingStoreExporter} exporter
+ * @param {string | null} [dirPath]
+ * @param {object} options
+ * @returns {Promise<SwingStore>}
+ */
+export async function importSwingStore(exporter, dirPath = null, options = {}) {
+  if (dirPath) {
+    typeof dirPath === 'string' || Fail`dirPath must be a string`;
+  }
+  const { includeHistorical = false } = options;
+  const store = makeSwingStore(dirPath, true, options);
+  const { kernelStorage, internal } = store;
+
+  // Artifact metadata, keyed as `${type}.${vatID}.${pos}`
+  //
+  // Note that this key is almost but not quite the artifact name, since the
+  // names of transcript span artifacts also include the endPos, but the endPos
+  // value is in flux until the span is complete.
+  const artifactMetadata = new Map();
+
+  // Each vat requires a transcript span and (usually) a snapshot.  This table
+  // tracks which of these we've seen, keyed by vatID.
+  // vatID -> { snapshotKey: metadataKey, transcriptKey: metatdataKey }
+  const vatArtifacts = new Map();
+  const bundleArtifacts = new Map();
+
+  for await (const [key, value] of exporter.getExportData()) {
+    const [tag] = key.split('.', 1);
+    const subKey = key.substring(tag.length + 1);
+    if (tag === 'kv') {
+      // 'kv' keys contain individual kvStore entries
+      if (value == null) {
+        // Note '==' rather than '===': any nullish value implies deletion
+        kernelStorage.kvStore.delete(subKey);
+      } else {
+        kernelStorage.kvStore.set(subKey, value);
+      }
+    } else if (tag === 'bundle') {
+      // 'bundle' keys contain bundle IDs
+      if (value == null) {
+        bundleArtifacts.delete(key);
+      } else {
+        bundleArtifacts.set(key, value);
+      }
+    } else if (tag === 'transcript' || tag === 'snapshot') {
+      // 'transcript' and 'snapshot' keys contain artifact description info.
+      assert(value); // make TypeScript shut up
+      const { vatID, isCurrent, pos } = parseVatArtifactExportKey(key);
+      if (isCurrent) {
+        const vatInfo = vatArtifacts.get(vatID) || {};
+        if (tag === 'snapshot') {
+          // `export.snapshot.{vatID}.current` directly identifies the current snapshot artifact
+          vatInfo.snapshotKey = value;
+        } else if (tag === 'transcript') {
+          // `export.transcript.${vatID}.current` contains a metadata record for the current
+          // state of the current transcript span as of the time of export
+          const metadata = JSON.parse(value);
+          vatInfo.transcriptKey = artifactKey(tag, vatID, metadata.startPos);
+          artifactMetadata.set(vatInfo.transcriptKey, metadata);
+        }
+        vatArtifacts.set(vatID, vatInfo);
+      } else {
+        artifactMetadata.set(artifactKey(tag, vatID, pos), JSON.parse(value));
+      }
+    } else {
+      Fail`unknown artifact type tag ${q(tag)} on import`;
+    }
+  }
+
+  // At this point we should have acquired the entire KV store state, plus
+  // sufficient metadata to identify the complete set of artifacts we'll need to
+  // fetch along with the information required to validate each of them after
+  // fetching.
+  //
+  // Depending on how the export was parameterized, the metadata may also include
+  // information about historical artifacts that we might or might not actually
+  // fetch depending on how this import was parameterized
+
+  // Fetch the set of current artifacts.
+
+  // Keep track of fetched artifacts in this set so we don't fetch them a second
+  // time if we are trying for historical artifacts also.
+  const fetchedArtifacts = new Set();
+
+  for await (const [vatID, vatInfo] of vatArtifacts.entries()) {
+    // For each vat, we *must* have a transcript span.  If this is not the very
+    // first transcript span in the history of that vat, then we also must have
+    // a snapshot for the state of the vat immediately prior to when the
+    // transcript span begins.
+    vatInfo.transcriptKey ||
+      Fail`missing current transcript key for vat ${q(vatID)}`;
+    const transcriptInfo = artifactMetadata.get(vatInfo.transcriptKey);
+    transcriptInfo || Fail`missing transcript metadata for vat ${q(vatID)}`;
+    let snapshotInfo;
+    if (vatInfo.snapshotKey) {
+      snapshotInfo = artifactMetadata.get(vatInfo.snapshotKey);
+      snapshotInfo || Fail`missing snapshot metadata for vat ${q(vatID)}`;
+    }
+    if (!snapshotInfo) {
+      transcriptInfo.startPos === 0 ||
+        Fail`missing current snapshot for vat ${q(vatID)}`;
+    } else {
+      snapshotInfo.snapPos + 1 === transcriptInfo.startPos ||
+        Fail`current transcript for vat ${q(vatID)} doesn't go with snapshot`;
+      fetchedArtifacts.add(vatInfo.snapshotKey);
+    }
+    await (!snapshotInfo ||
+      internal.snapStore.importSnapshot(
+        vatInfo.snapshotKey,
+        exporter,
+        snapshotInfo,
+      ));
+
+    const transcriptArtifactName = `${vatInfo.transcriptKey}.${transcriptInfo.endPos}`;
+    await internal.transcriptStore.importSpan(
+      transcriptArtifactName,
+      exporter,
+      transcriptInfo,
+    );
+    fetchedArtifacts.add(transcriptArtifactName);
+  }
+  const bundleArtifactNames = Array.from(bundleArtifacts.keys()).sort();
+  for await (const bundleArtifactName of bundleArtifactNames) {
+    await internal.bundleStore.importBundle(
+      bundleArtifactName,
+      exporter,
+      bundleArtifacts.get(bundleArtifactName),
+    );
+  }
+
+  if (!includeHistorical) {
+    await exporter.close();
+    return store;
+  }
+
+  // If we're also importing historical artifacts, have the exporter enumerate
+  // the complete set of artifacts it has and fetch all of them except for the
+  // ones we've already fetched.
+  for await (const artifactName of exporter.getArtifactNames()) {
+    if (fetchedArtifacts.has(artifactName)) {
+      continue;
+    }
+    let fetchedP;
+    if (artifactName.startsWith('snapshot.')) {
+      fetchedP = internal.snapStore.importSnapshot(
+        artifactName,
+        exporter,
+        artifactMetadata.get(artifactName),
+      );
+    } else if (artifactName.startsWith('transcript.')) {
+      // strip endPos off artifact name
+      const metadataKey = artifactName.split('.').slice(0, 3).join('.');
+      fetchedP = internal.transcriptStore.importSpan(
+        artifactName,
+        exporter,
+        artifactMetadata.get(metadataKey),
+      );
+    } else if (artifactName.startsWith('bundle.')) {
+      // already taken care of
+      continue;
+    } else {
+      Fail`unknown artifact type: ${artifactName}`;
+    }
+    await fetchedP;
+  }
+  await exporter.close();
+  return store;
+}

--- a/packages/swing-store/src/index.js
+++ b/packages/swing-store/src/index.js
@@ -1,0 +1,11 @@
+export { initSwingStore, openSwingStore, isSwingStore } from './swingStore.js';
+export { makeSwingStoreExporter } from './exporter.js';
+export { importSwingStore } from './importer.js';
+
+// temporary, for the benefit of SwingSet/misc-tools/replay-transcript.js
+export { makeSnapStore } from './snapStore.js';
+// and less temporary, for SwingSet/test/vat-warehouse/test-reload-snapshot.js
+export { makeSnapStoreIO } from './snapStoreIO.js';
+
+// eslint-disable-next-line import/export
+export * from './types.js';

--- a/packages/swing-store/src/internal.js
+++ b/packages/swing-store/src/internal.js
@@ -1,0 +1,14 @@
+/**
+ * @typedef { import('./snapStore').SnapStoreInternal } SnapStoreInternal
+ * @typedef { import('./transcriptStore').TranscriptStoreInternal } TranscriptStoreInternal
+ * @typedef { import('./bundleStore').BundleStoreInternal } BundleStoreInternal
+ *
+ * @typedef {{
+ *    transcriptStore: TranscriptStoreInternal,
+ *    snapStore: SnapStoreInternal,
+ *    bundleStore: BundleStoreInternal,
+ * }} SwingStoreInternal
+ */
+
+// Ensure this is a module.
+export {};

--- a/packages/swing-store/src/kvStore.js
+++ b/packages/swing-store/src/kvStore.js
@@ -1,0 +1,172 @@
+// @ts-check
+import { Fail } from '@agoric/assert';
+
+/**
+ * @typedef {{
+ *   has: (key: string) => boolean,
+ *   get: (key: string) => string | undefined,
+ *   getNextKey: (previousKey: string) => string | undefined,
+ *   set: (key: string, value: string, bypassHash?: boolean ) => void,
+ *   delete: (key: string) => void,
+ * }} KVStore
+ */
+
+/**
+ * @param {string} key
+ */
+export function getKeyType(key) {
+  if (key.startsWith('local.')) {
+    return 'local';
+  } else if (key.startsWith('host.')) {
+    return 'host';
+  }
+  return 'consensus';
+}
+
+/**
+ * @param {object} db  The SQLite database connection.
+ * @param {() => void} ensureTxn  Called before mutating methods to establish a DB transaction
+ * @param {(...args: string[]) => void} trace  Called after sets/gets to record a debug log
+ * @returns { KVStore }
+ */
+
+export function makeKVStore(db, ensureTxn, trace) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS kvStore (
+      key TEXT,
+      value TEXT,
+      PRIMARY KEY (key)
+    )
+  `);
+
+  const sqlKVGet = db.prepare(`
+    SELECT value
+    FROM kvStore
+    WHERE key = ?
+  `);
+  sqlKVGet.pluck(true);
+
+  /**
+   * Obtain the value stored for a given key.
+   *
+   * @param {string} key  The key whose value is sought.
+   *
+   * @returns {string | undefined} the (string) value for the given key, or
+   *    undefined if there is no such value.
+   *
+   * @throws if key is not a string.
+   */
+  function get(key) {
+    typeof key === 'string' || Fail`key must be a string`;
+    return sqlKVGet.get(key);
+  }
+
+  const sqlKVGetNextKey = db.prepare(`
+    SELECT key
+    FROM kvStore
+    WHERE key > ?
+    LIMIT 1
+  `);
+  sqlKVGetNextKey.pluck(true);
+
+  /**
+   * getNextKey enables callers to iterate over all keys within a
+   * given range. To build an iterator of all keys from start
+   * (inclusive) to end (exclusive), do:
+   *
+   * function* iterate(start, end) {
+   *   if (kvStore.has(start)) {
+   *     yield start;
+   *   }
+   *   let prev = start;
+   *   while (true) {
+   *     let next = kvStore.getNextKey(prev);
+   *     if (!next || next >= end) {
+   *       break;
+   *     }
+   *     yield next;
+   *     prev = next;
+   *   }
+   * }
+   *
+   * @param {string} previousKey  The key returned will always be later than this one.
+   *
+   * @returns {string | undefined} a key string, or undefined if we reach the end of the store
+   *
+   * @throws if previousKey is not a string
+   */
+
+  function getNextKey(previousKey) {
+    typeof previousKey === 'string' || Fail`previousKey must be a string`;
+    return sqlKVGetNextKey.get(previousKey);
+  }
+
+  /**
+   * Test if the state contains a value for a given key.
+   *
+   * @param {string} key  The key that is of interest.
+   *
+   * @returns {boolean} true if a value is stored for the key, false if not.
+   *
+   * @throws if key is not a string.
+   */
+  function has(key) {
+    typeof key === 'string' || Fail`key must be a string`;
+    return get(key) !== undefined;
+  }
+
+  const sqlKVSet = db.prepare(`
+    INSERT INTO kvStore (key, value)
+    VALUES (?, ?)
+    ON CONFLICT DO UPDATE SET value = excluded.value
+  `);
+
+  /**
+   * Store a value for a given key.  The value will replace any prior value if
+   * there was one.
+   *
+   * @param {string} key  The key whose value is being set.
+   * @param {string} value  The value to set the key to.
+   *
+   * @throws if either parameter is not a string.
+   */
+  function set(key, value) {
+    typeof key === 'string' || Fail`key must be a string`;
+    typeof value === 'string' || Fail`value must be a string`;
+    // synchronous read after write within a transaction is safe
+    // The transaction's overall success will be awaited during commit
+    ensureTxn();
+    sqlKVSet.run(key, value);
+    trace('set', key, value);
+  }
+
+  const sqlKVDel = db.prepare(`
+    DELETE FROM kvStore
+    WHERE key = ?
+  `);
+
+  /**
+   * Remove any stored value for a given key.  It is permissible for there to
+   * be no existing stored value for the key.
+   *
+   * @param {string} key  The key whose value is to be deleted
+   *
+   * @throws if key is not a string.
+   */
+  function del(key) {
+    typeof key === 'string' || Fail`key must be a string`;
+    ensureTxn();
+    sqlKVDel.run(key);
+    trace('del', key);
+  }
+
+  const kvStore = {
+    has,
+    get,
+    getNextKey,
+    set,
+    delete: del,
+  };
+
+  return kvStore;
+}

--- a/packages/swing-store/src/repairMetadata.js
+++ b/packages/swing-store/src/repairMetadata.js
@@ -1,0 +1,65 @@
+import { Fail, q } from '@agoric/assert';
+import { assertComplete } from './assertComplete.js';
+
+/**
+ * Given a pre-existing swingstore and a SwingStoreExporter, read in
+ * all the metadata from the exporter and use it to regenerate any
+ * missing metadata records. This can be used to fix the damage caused
+ * by #8025.
+ *
+ * The repair method will call `exporter.getExportData` and examine
+ * all entries to do one of three things:
+ *
+ * 1: kvStore records are ignored (they are not metadata)
+ * 2: bundle/snapshot/transcript records whose keys already exist will
+ *    be compared against the existing data, and an error thrown if
+ *    they do not match
+ * 3: new snapshot/transcript records will be silently added to
+ *    the swingstore (new bundle records are an error, since we do not
+ *    tolerate pruned bundles)
+ *
+ * It will not call `exporter.getArtifactNames` or `getArtifacts`.
+ *
+ * At the end of the process, the DB will contain pending changes in
+ * an open transaction. The caller is responsible for calling
+ * `hostStorage.commit()` when they are ready.
+ *
+ * @param {import('./internal.js').SwingStoreInternal} internal
+ * @param {import('./exporter').SwingStoreExporter} exporter
+ * @returns {Promise<void>}
+ */
+export async function doRepairMetadata(internal, exporter) {
+  // first we strip kvStore entries and deduplicate the rest
+
+  const allMetadata = new Map();
+
+  for await (const [key, value] of exporter.getExportData()) {
+    const [tag] = key.split('.', 1);
+    if (tag === 'kv') {
+      continue;
+    } else if (value == null) {
+      allMetadata.delete(key);
+    } else {
+      allMetadata.set(key, value);
+    }
+  }
+
+  // then process the metadata records
+
+  for (const [key, value] of allMetadata.entries()) {
+    const [tag] = key.split('.', 1);
+    if (tag === 'bundle') {
+      internal.bundleStore.repairBundleRecord(key, value);
+    } else if (tag === 'snapshot') {
+      internal.snapStore.repairSnapshotRecord(key, value);
+    } else if (tag === 'transcript') {
+      internal.transcriptStore.repairTranscriptSpanRecord(key, value);
+    } else {
+      Fail`unknown export-data type in key ${q(key)} on repairMetadata`;
+    }
+  }
+
+  // and do a completeness check
+  assertComplete(internal, 'operational');
+  await exporter.close();
+}

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -25,7 +25,7 @@ import { buffer } from './util.js';
  */
 
 /**
- * @typedef { import('./swingStore').SwingStoreExporter } SwingStoreExporter
+ * @typedef { import('./exporter').SwingStoreExporter } SwingStoreExporter
  *
  * @typedef {{
  *   loadSnapshot: (vatID: string) => AsyncIterableIterator<Uint8Array>,

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -25,6 +25,11 @@ import { buffer } from './util.js';
  */
 
 /**
+ * @template T
+ *  @typedef { import('./exporter').AnyIterableIterator<T> } AnyIterableIterator<T>
+ */
+
+/**
  * @typedef { import('./exporter').SwingStoreExporter } SwingStoreExporter
  *
  * @typedef {{
@@ -37,10 +42,12 @@ import { buffer } from './util.js';
  * }} SnapStore
  *
  * @typedef {{
- *   exportSnapshot: (name: string, includeHistorical: boolean) => AsyncIterableIterator<Uint8Array>,
- *   importSnapshot: (artifactName: string, exporter: SwingStoreExporter, artifactMetadata: Map) => void,
+ *   exportSnapshot: (name: string) => AsyncIterableIterator<Uint8Array>,
  *   getExportRecords: (includeHistorical: boolean) => IterableIterator<readonly [key: string, value: string]>,
  *   getArtifactNames: (includeHistorical: boolean) => AsyncIterableIterator<string>,
+ *   importSnapshotRecord: (key: string, value: string) => void,
+ *   populateSnapshot: (name: string, makeChunkIterator: () => AnyIterableIterator<Uint8Array>, options: { includeHistorical: boolean }) => Promise<void>,
+ *   assertComplete: (level: 'operational') => void,
  * }} SnapStoreInternal
  *
  * @typedef {{
@@ -81,10 +88,25 @@ export function makeSnapStore(
       compressedSize INTEGER,
       compressedSnapshot BLOB,
       PRIMARY KEY (vatID, snapPos),
-      UNIQUE (vatID, inUse),
-      CHECK(compressedSnapshot is not null or inUse is null)
+      UNIQUE (vatID, inUse)
     )
   `);
+
+  // NOTE: there are two versions of this schema. The original, which
+  // we'll call "version 1A", has a:
+  //   CHECK(compressedSnapshot is not null or inUse is null)
+  // in the table. Version 1B is missing that constraint. Any DB
+  // created by the original code will use 1A. Any DB created by the
+  // new version will use 1B. The import process needs to temporarily
+  // violate that check, but any DB created by `importSwingStore` is
+  // (by definition) new, so it will use 1B, which doesn't enforce the
+  // check. We expect to implement schema migration
+  // (https://github.com/Agoric/agoric-sdk/issues/8089) soon, which
+  // will upgrade both 1A and 1B to "version 2", which will omit the
+  // check (in addition to any other changes we need at that point)
+
+  // pruned snapshots will have compressedSnapshot of NULL, and might
+  // also have NULL for uncompressedSize and compressedSize
 
   const sqlDeleteAllUnusedSnapshots = db.prepare(`
     DELETE FROM snapshots
@@ -98,6 +120,12 @@ export function makeSnapStore(
   function deleteAllUnusedSnapshots() {
     ensureTxn();
     sqlDeleteAllUnusedSnapshots.run();
+
+    // NOTE: this is more than pruning the snapshot data, it deletes
+    // the metadata/hash as well, making it impossible to safely
+    // repopulate the snapshot data from an untrusted source. We need
+    // to replace this with a method that merely nulls out the
+    // 'compressedSnapshot' field.
   }
 
   function snapshotArtifactName(rec) {
@@ -255,10 +283,9 @@ export function makeSnapStore(
    *   `snapshot.${vatID}.${startPos}`
    *
    * @param {string} name
-   * @param {boolean} includeHistorical
    * @returns {AsyncIterableIterator<Uint8Array>}
    */
-  function exportSnapshot(name, includeHistorical) {
+  function exportSnapshot(name) {
     typeof name === 'string' || Fail`artifact name must be a string`;
     const parts = name.split('.');
     const [type, vatID, pos] = parts;
@@ -268,9 +295,8 @@ export function makeSnapStore(
     const snapPos = Number(pos);
     const snapshotInfo = sqlGetSnapshot.get(vatID, snapPos);
     snapshotInfo || Fail`snapshot ${q(name)} not available`;
-    const { inUse, compressedSnapshot } = snapshotInfo;
+    const { compressedSnapshot } = snapshotInfo;
     compressedSnapshot || Fail`artifact ${q(name)} is not available`;
-    inUse || includeHistorical || Fail`artifact ${q(name)} is not available`;
     // weird construct here is because we need to be able to throw before the generator starts
     async function* exporter() {
       const gzReader = Readable.from(compressedSnapshot);
@@ -412,6 +438,13 @@ export function makeSnapStore(
     ORDER BY vatID, snapPos
   `);
 
+  const sqlGetAvailableSnapshots = db.prepare(`
+    SELECT vatID, snapPos, hash, uncompressedSize, compressedSize, inUse
+    FROM snapshots
+    WHERE inUse IS ? AND compressedSnapshot is not NULL
+    ORDER BY vatID, snapPos
+  `);
+
   /**
    * Obtain artifact metadata records for spanshots contained in this store.
    *
@@ -448,40 +481,85 @@ export function makeSnapStore(
   }
 
   async function* getArtifactNames(includeHistorical) {
-    for (const rec of sqlGetSnapshotMetadata.iterate(1)) {
+    for (const rec of sqlGetAvailableSnapshots.iterate(1)) {
       yield snapshotArtifactName(rec);
     }
     if (includeHistorical) {
-      for (const rec of sqlGetSnapshotMetadata.iterate(null)) {
+      for (const rec of sqlGetAvailableSnapshots.iterate(null)) {
         yield snapshotArtifactName(rec);
       }
     }
   }
 
+  const sqlAddSnapshotRecord = db.prepare(`
+    INSERT INTO snapshots (vatID, snapPos, hash, inUse)
+    VALUES (?, ?, ?, ?)
+  `);
+
+  function importSnapshotRecord(key, value) {
+    ensureTxn();
+    const [tag, ...pieces] = key.split('.');
+    assert.equal(tag, 'snapshot');
+    const [_vatID, endPos] = pieces;
+    if (endPos === 'current') {
+      // metadata['snapshot.v1.current'] = 'snapshot.v1.5' , i.e. it
+      // points to the name of the current artifact. We could
+      // conceivably remember this and compare it against the .inUse
+      // property of that record, but it's not worth the effort (we
+      // might encounter the records in either order).
+      return;
+    }
+    const metadata = JSON.parse(value);
+    const { vatID, snapPos, hash, inUse } = metadata;
+    vatID || Fail`snapshot metadata missing vatID: ${metadata}`;
+    snapPos !== undefined ||
+      Fail`snapshot metadata missing snapPos: ${metadata}`;
+    hash || Fail`snapshot metadata missing hash: ${metadata}`;
+    inUse !== undefined || Fail`snapshot metadata missing inUse: ${metadata}`;
+
+    sqlAddSnapshotRecord.run(vatID, snapPos, hash, inUse ? 1 : null);
+  }
+
+  const sqlGetSnapshotHashFor = db.prepare(`
+    SELECT hash, inUse
+    FROM snapshots
+    WHERE vatID = ? AND snapPos = ?
+  `);
+
+  const sqlPopulateSnapshot = db.prepare(`
+    UPDATE snapshots SET
+      uncompressedSize = ?, compressedSize = ?, compressedSnapshot = ?
+    WHERE vatID = ? AND snapPos = ?
+  `);
+
   /**
    * @param {string} name  Artifact name of the snapshot
-   * @param {SwingStoreExporter} exporter  Whence to get the bits
-   * @param {object} info  Metadata describing the artifact
+   * @param {() => AnyIterableIterator<Uint8Array>} makeChunkIterator  get an iterator of snapshot byte chunks
+   * @param {object} options
+   * @param {boolean} options.includeHistorical
    * @returns {Promise<void>}
    */
-  async function importSnapshot(name, exporter, info) {
+  async function populateSnapshot(name, makeChunkIterator, options) {
+    ensureTxn();
+    const { includeHistorical } = options;
     const parts = name.split('.');
     const [type, vatID, rawEndPos] = parts;
     // prettier-ignore
     parts.length === 3 && type === 'snapshot' ||
       Fail`expected snapshot name of the form 'snapshot.{vatID}.{snapPos}', saw '${q(name)}'`;
-    // prettier-ignore
-    info.vatID === vatID ||
-      Fail`snapshot name says vatID ${q(vatID)}, metadata says ${q(info.vatID)}`;
     const snapPos = Number(rawEndPos);
-    // prettier-ignore
-    info.snapPos === snapPos ||
-      Fail`snapshot name says snapPos ${q(snapPos)}, metadata says ${q(info.snapPos)}`;
+    const metadata =
+      sqlGetSnapshotHashFor.get(vatID, snapPos) ||
+      Fail`no metadata for snapshot ${name}`;
 
-    const artifactChunks = exporter.getArtifact(name);
+    if (!metadata.inUse && !includeHistorical) {
+      return; // ignore old snapshots
+    }
+
+    const artifactChunks = makeChunkIterator();
     const inStream = Readable.from(artifactChunks);
-    let size = 0;
-    inStream.on('data', chunk => (size += chunk.length));
+    let uncompressedSize = 0;
+    inStream.on('data', chunk => (uncompressedSize += chunk.length));
     const hashStream = createHash('sha256');
     const gzip = createGzip();
     inStream.pipe(hashStream);
@@ -489,19 +567,35 @@ export function makeSnapStore(
     const compressedArtifact = await buffer(gzip);
     await finished(inStream);
     const hash = hashStream.digest('hex');
+
+    // validate against the previously-established metadata
     // prettier-ignore
-    info.hash === hash ||
-      Fail`snapshot ${q(name)} hash is ${q(hash)}, metadata says ${q(info.hash)}`;
-    ensureTxn();
-    sqlSaveSnapshot.run(
-      vatID,
-      snapPos,
-      info.inUse ? 1 : null,
-      info.hash,
-      size,
+    metadata.hash === hash ||
+      Fail`snapshot ${q(name)} hash is ${q(hash)}, metadata says ${q(metadata.hash)}`;
+
+    sqlPopulateSnapshot.run(
+      uncompressedSize,
       compressedArtifact.length,
       compressedArtifact,
+      vatID,
+      snapPos,
     );
+  }
+
+  const sqlListPrunedCurrentSnapshots = db.prepare(`
+    SELECT vatID FROM snapshots
+      WHERE inUse = 1 AND compressedSnapshot IS NULL
+      ORDER BY vatID
+  `);
+  sqlListPrunedCurrentSnapshots.pluck();
+
+  function assertComplete(level) {
+    assert.equal(level, 'operational'); // for now
+    // every 'inUse' snapshot must be populated
+    const vatIDs = sqlListPrunedCurrentSnapshots.all();
+    if (vatIDs.length) {
+      throw Fail`current snapshots are pruned for vats ${vatIDs.join(',')}`;
+    }
   }
 
   const sqlListAllSnapshots = db.prepare(`
@@ -563,10 +657,14 @@ export function makeSnapStore(
     deleteVatSnapshots,
     stopUsingLastSnapshot,
     getSnapshotInfo,
+
     getExportRecords,
     getArtifactNames,
     exportSnapshot,
-    importSnapshot,
+
+    importSnapshotRecord,
+    populateSnapshot,
+    assertComplete,
 
     hasHash,
     listAllSnapshots,

--- a/packages/swing-store/src/snapStoreIO.js
+++ b/packages/swing-store/src/snapStoreIO.js
@@ -1,0 +1,8 @@
+import { performance } from 'perf_hooks';
+import { makeMeasureSeconds } from '@agoric/internal';
+
+export function makeSnapStoreIO() {
+  return {
+    measureSeconds: makeMeasureSeconds(performance.now),
+  };
+}

--- a/packages/swing-store/src/transcriptStore.js
+++ b/packages/swing-store/src/transcriptStore.js
@@ -6,7 +6,7 @@ import BufferLineTransform from '@agoric/internal/src/node/buffer-line-transform
 import { createSHA256 } from './hasher.js';
 
 /**
- * @typedef { import('./swingStore').SwingStoreExporter } SwingStoreExporter
+ * @typedef { import('./exporter').SwingStoreExporter } SwingStoreExporter
  *
  * @typedef {{
  *   initTranscript: (vatID: string) => void,

--- a/packages/swing-store/src/types.d.ts
+++ b/packages/swing-store/src/types.d.ts
@@ -1,0 +1,14 @@
+export type {
+  SwingStore,
+  SwingStoreKernelStorage,
+  SwingStoreHostStorage,
+} from './src/swingStore.js';
+export type { KVStore } from './src/kvStore.js';
+export type { BundleStore } from './src/bundleStore.js';
+export type {
+  SnapStore,
+  SnapshotResult,
+  SnapshotInfo,
+} from './src/snapStore.js';
+export type { TranscriptStore } from './src/transcriptStore.js';
+export type { SwingStoreExporter, ExportMode } from './src/exporter.js';

--- a/packages/swing-store/src/types.js
+++ b/packages/swing-store/src/types.js
@@ -1,0 +1,6 @@
+// Types for the public API
+
+// Everything this "exports" actually comes from the neighboring types.d.ts file
+
+// Ensure this is a module.
+export {};

--- a/packages/swing-store/src/util.js
+++ b/packages/swing-store/src/util.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import { Buffer } from 'buffer';
 
 /**
@@ -5,7 +6,7 @@ import { Buffer } from 'buffer';
  * 'stream/consumers' package, which unfortunately only exists in newer versions
  * of Node.
  *
- * @param {import('./swingStore').AnyIterable<Uint8Array>} inStream
+ * @param {import('./exporter').AnyIterable<Uint8Array>} inStream
  */
 export const buffer = async inStream => {
   const chunks = [];
@@ -14,3 +15,8 @@ export const buffer = async inStream => {
   }
   return Buffer.concat(chunks);
 };
+
+export function dbFileInDirectory(dirPath) {
+  const filePath = path.resolve(dirPath, 'swingstore.sqlite');
+  return filePath;
+}

--- a/packages/swing-store/test/test-bundles.js
+++ b/packages/swing-store/test/test-bundles.js
@@ -4,11 +4,9 @@ import test from 'ava';
 import tmp from 'tmp';
 import { Buffer } from 'buffer';
 import { createSHA256 } from '../src/hasher.js';
-import {
-  importSwingStore,
-  initSwingStore,
-  makeSwingStoreExporter,
-} from '../src/index.js';
+import { initSwingStore } from '../src/swingStore.js';
+import { makeSwingStoreExporter } from '../src/exporter.js';
+import { importSwingStore } from '../src/importer.js';
 import { buffer } from '../src/util.js';
 
 function makeB0ID(bundle) {
@@ -116,7 +114,9 @@ test('b0 import', async t => {
       t.is(name, nameA);
       yield Buffer.from(JSON.stringify(b0A));
     },
-    getArtifactNames: () => assert.fail('import should not query all names'),
+    async *getArtifactNames() {
+      yield* [nameA];
+    },
     close: async () => undefined,
   };
   const { kernelStorage } = await importSwingStore(exporter);
@@ -138,7 +138,9 @@ test('b0 bad import', async t => {
       t.is(name, nameA);
       yield Buffer.from(JSON.stringify(b0Abogus));
     },
-    getArtifactNames: () => assert.fail('import should not query all names'),
+    async *getArtifactNames() {
+      yield* [nameA];
+    },
     close: async () => undefined,
   };
   await t.throwsAsync(async () => importSwingStore(exporter), {

--- a/packages/swing-store/test/test-bundles.js
+++ b/packages/swing-store/test/test-bundles.js
@@ -8,7 +8,7 @@ import {
   importSwingStore,
   initSwingStore,
   makeSwingStoreExporter,
-} from '../src/swingStore.js';
+} from '../src/index.js';
 import { buffer } from '../src/util.js';
 
 function makeB0ID(bundle) {

--- a/packages/swing-store/test/test-export.js
+++ b/packages/swing-store/test/test-export.js
@@ -1,0 +1,308 @@
+import '@endo/init/debug.js';
+
+import test from 'ava';
+
+import { buffer } from '../src/util.js';
+import { initSwingStore, makeSwingStoreExporter } from '../src/index.js';
+
+import { tmpDir, getSnapshotStream, makeB0ID } from './util.js';
+
+const snapshotData = 'snapshot data';
+// this snapHash was computed manually
+const snapHash =
+  'e7dee7266896538616b630a5da40a90e007726a383e005a9c9c5dd0c2daf9329';
+
+/** @type {import('../src/bundleStore.js').Bundle} */
+const bundle0 = { moduleFormat: 'nestedEvaluate', source: '1+1' };
+const bundle0ID = makeB0ID(bundle0);
+
+const exportTest = test.macro(async (t, mode) => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+  // const dbDir = 't-db';
+
+  const options = {};
+  if (mode === 'debug') {
+    options.keepSnapshots = true; // else old snapshots are deleted
+  }
+  const ss1 = initSwingStore(dbDir, options);
+  const ks = ss1.kernelStorage;
+
+  // build a DB with three spans (only one inUse) and two snapshots
+  // (same)
+
+  ks.kvStore.set('key1', 'value1');
+  ks.bundleStore.addBundle(bundle0ID, bundle0);
+  ks.transcriptStore.initTranscript('v1');
+
+  ks.transcriptStore.addItem('v1', 'start-worker'); // 0
+  ks.transcriptStore.addItem('v1', 'delivery1'); // 1
+  await ks.snapStore.saveSnapshot('v1', 2, getSnapshotStream(snapshotData));
+  ks.transcriptStore.addItem('v1', 'save-snapshot'); // 2
+  ks.transcriptStore.rolloverSpan('v1'); // range= 0..3
+  const spanHash1 =
+    '57152efdd7fdf75c03371d2b4f1088d5bf3eae7fe643babce527ff81df38998c';
+
+  ks.transcriptStore.addItem('v1', 'load-snapshot'); // 3
+  ks.transcriptStore.addItem('v1', 'delivery2'); // 4
+  await ks.snapStore.saveSnapshot('v1', 5, getSnapshotStream(snapshotData));
+  ks.transcriptStore.addItem('v1', 'save-snapshot'); // 5
+  ks.transcriptStore.rolloverSpan('v1'); // range= 3..6
+  const spanHash2 =
+    '1947001e78e01bd1e773feb22b4ffc530447373b9de9274d5d5fbda3f23dbf2b';
+
+  ks.transcriptStore.addItem('v1', 'load-snapshot'); // 6
+  ks.transcriptStore.addItem('v1', 'delivery3'); // 7
+  const spanHash3 =
+    'e6b42c6a3fb94285a93162f25a9fc0145fd4c5bb144917dc572c50ae2d02ee69';
+  // current range= 6..8
+
+  ss1.hostStorage.commit();
+
+  // create an export, and assert that the pieces match what we
+  // expect. exportMode='current' means we get all metadata, no
+  // historical transcript spans, and no historical snapshots
+
+  assert.typeof(mode, 'string');
+  /** @typedef {import('../src/exporter.js').ExportMode} ExportMode */
+  let exportMode = /** @type {ExportMode} */ (mode);
+  if (mode === 'debug-on-pruned') {
+    exportMode = 'debug';
+  }
+  const exporter = makeSwingStoreExporter(dbDir, exportMode);
+
+  // exportData
+  {
+    const exportData = new Map();
+    for await (const [key, value] of exporter.getExportData()) {
+      exportData.set(key, value);
+    }
+    // console.log('exportData:', exportData);
+
+    const check = (key, expected) => {
+      t.true(exportData.has(key));
+      let value = exportData.get(key);
+      exportData.delete(key);
+      if (typeof expected === 'object') {
+        value = JSON.parse(value);
+      }
+      t.deepEqual(value, expected);
+    };
+
+    check('kv.key1', 'value1');
+    check('snapshot.v1.2', {
+      vatID: 'v1',
+      snapPos: 2,
+      inUse: 0,
+      hash: snapHash,
+    });
+    check('snapshot.v1.5', {
+      vatID: 'v1',
+      snapPos: 5,
+      inUse: 1,
+      hash: snapHash,
+    });
+    check('snapshot.v1.current', 'snapshot.v1.5');
+    const base = { vatID: 'v1', incarnation: 0, isCurrent: 0 };
+    check('transcript.v1.0', {
+      ...base,
+      startPos: 0,
+      endPos: 3,
+      hash: spanHash1,
+    });
+    check('transcript.v1.3', {
+      ...base,
+      startPos: 3,
+      endPos: 6,
+      hash: spanHash2,
+    });
+    check('transcript.v1.current', {
+      ...base,
+      startPos: 6,
+      endPos: 8,
+      isCurrent: 1,
+      hash: spanHash3,
+    });
+    check(`bundle.${bundle0ID}`, bundle0ID);
+
+    // the above list is supposed to be exhaustive
+    if (exportData.size) {
+      console.log('unexpected exportData keys');
+      console.log(exportData);
+      t.fail('unexpected exportData keys');
+    }
+  }
+
+  // artifacts
+  {
+    const names = new Set();
+    const contents = new Map();
+    for await (const name of exporter.getArtifactNames()) {
+      names.add(name);
+      contents.set(name, (await buffer(exporter.getArtifact(name))).toString());
+    }
+    // console.log('artifacts:', contents);
+
+    const check = async (name, expected) => {
+      t.true(names.has(name));
+      names.delete(name);
+      let data = contents.get(name);
+      if (typeof expected === 'object') {
+        data = JSON.parse(data);
+      }
+      t.deepEqual(data, expected);
+    };
+
+    // export mode 'current' means we omit historical snapshots and
+    // transcript spans
+
+    await check('snapshot.v1.5', 'snapshot data');
+    await check('transcript.v1.6.8', 'load-snapshot\ndelivery3\n');
+    await check(`bundle.${bundle0ID}`, bundle0);
+
+    if (mode === 'archival' || mode === 'debug' || mode === 'debug-on-pruned') {
+      // adds the old transcript spans
+      await check(
+        'transcript.v1.0.3',
+        'start-worker\ndelivery1\nsave-snapshot\n',
+      );
+      await check(
+        'transcript.v1.3.6',
+        'load-snapshot\ndelivery2\nsave-snapshot\n',
+      );
+    }
+
+    if (mode === 'debug') {
+      // adds the old snapshots, which are only present if
+      // initSwingStore() was given {keepSnapshots: true}
+      await check('snapshot.v1.2', 'snapshot data');
+      // mode='debug-on-pruned' exercises the keepSnapshots:false case
+    }
+
+    if (names.size) {
+      console.log(`unexpected artifacts:`);
+      console.log(names);
+      t.fail('unexpected artifacts');
+    }
+  }
+});
+
+test('export current', exportTest, 'current');
+test('export archival', exportTest, 'archival');
+test('export debug', exportTest, 'debug');
+test('export debug-on-pruned', exportTest, 'debug-on-pruned');
+
+test('export omits pruned span artifacts', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+  // const dbDir = 't-db';
+
+  // use keepTranscripts=false to simulate an explicit prune of the
+  // old span
+  const options = { keepTranscripts: false };
+  const ss1 = initSwingStore(dbDir, options);
+  const ks = ss1.kernelStorage;
+
+  // build a DB with two spans, one is inUse, other is pruned
+
+  ks.transcriptStore.initTranscript('v1');
+  ks.transcriptStore.addItem('v1', 'start-worker'); // 0
+  ks.transcriptStore.addItem('v1', 'delivery1'); // 1
+  await ks.snapStore.saveSnapshot('v1', 2, getSnapshotStream(snapshotData));
+  ks.transcriptStore.addItem('v1', 'save-snapshot'); // 2
+  ks.transcriptStore.rolloverSpan('v1'); // range= 0..3
+  const spanHash1 =
+    '57152efdd7fdf75c03371d2b4f1088d5bf3eae7fe643babce527ff81df38998c';
+  // rolloverSpan prunes the contents of the old span
+
+  ks.transcriptStore.addItem('v1', 'load-snapshot'); // 3
+  ks.transcriptStore.addItem('v1', 'delivery2'); // 4
+  const spanHash2 =
+    'b26c8faf425c3c2738e0c5a5e9a7cd71075c68f0c9f2d6cdfd83c68204801dbb';
+
+  ss1.hostStorage.commit();
+
+  const exporter = makeSwingStoreExporter(dbDir, 'archival');
+
+  // exportData
+  {
+    const exportData = new Map();
+    for await (const [key, value] of exporter.getExportData()) {
+      exportData.set(key, value);
+    }
+    // console.log('exportData:', exportData);
+
+    const check = (key, expected) => {
+      t.true(exportData.has(key));
+      let value = exportData.get(key);
+      exportData.delete(key);
+      if (typeof expected === 'object') {
+        value = JSON.parse(value);
+      }
+      t.deepEqual(value, expected);
+    };
+
+    check('snapshot.v1.2', {
+      vatID: 'v1',
+      snapPos: 2,
+      inUse: 1,
+      hash: snapHash,
+    });
+    check('snapshot.v1.current', 'snapshot.v1.2');
+    const base = { vatID: 'v1', incarnation: 0, isCurrent: 0 };
+    check('transcript.v1.0', {
+      ...base,
+      startPos: 0,
+      endPos: 3,
+      hash: spanHash1,
+    });
+    check('transcript.v1.current', {
+      ...base,
+      startPos: 3,
+      endPos: 5,
+      isCurrent: 1,
+      hash: spanHash2,
+    });
+
+    // the above list is supposed to be exhaustive
+    if (exportData.size) {
+      console.log('unexpected exportData keys');
+      console.log(exportData);
+      t.fail('unexpected exportData keys');
+    }
+  }
+
+  // artifacts
+  {
+    const names = new Set();
+    const contents = new Map();
+    for await (const name of exporter.getArtifactNames()) {
+      names.add(name);
+      contents.set(name, (await buffer(exporter.getArtifact(name))).toString());
+    }
+    // console.log('artifacts:', contents);
+
+    const check = async (name, expected) => {
+      t.true(names.has(name));
+      names.delete(name);
+      let data = contents.get(name);
+      if (typeof expected === 'object') {
+        data = JSON.parse(data);
+      }
+      t.deepEqual(data, expected);
+    };
+
+    // export mode 'archival' means we include all available
+    // historical snapshots and transcript spans
+
+    await check('snapshot.v1.2', 'snapshot data');
+    // no transcript.v1.0.3 because the contents were pruned
+    await check('transcript.v1.3.5', 'load-snapshot\ndelivery2\n');
+
+    if (names.size) {
+      console.log(`unexpected artifacts:`);
+      console.log(names);
+      t.fail('unexpected artifacts');
+    }
+  }
+});

--- a/packages/swing-store/test/test-exportImport.js
+++ b/packages/swing-store/test/test-exportImport.js
@@ -7,11 +7,9 @@ import test from 'ava';
 import tmp from 'tmp';
 import bundleSource from '@endo/bundle-source';
 
-import {
-  initSwingStore,
-  makeSwingStoreExporter,
-  importSwingStore,
-} from '../src/swingStore.js';
+import { initSwingStore } from '../src/swingStore.js';
+import { makeSwingStoreExporter } from '../src/exporter.js';
+import { importSwingStore } from '../src/importer.js';
 
 function makeExportLog() {
   const exportLog = [];

--- a/packages/swing-store/test/test-import.js
+++ b/packages/swing-store/test/test-import.js
@@ -1,0 +1,476 @@
+// @ts-check
+
+import '@endo/init/debug.js';
+
+import path from 'path';
+import { createGunzip } from 'zlib';
+import { Readable } from 'stream';
+import { Buffer } from 'buffer';
+
+import sqlite3 from 'better-sqlite3';
+import test from 'ava';
+import { decodeBase64 } from '@endo/base64';
+
+import { buffer } from '../src/util.js';
+import { importSwingStore, makeSwingStoreExporter } from '../src/index.js';
+
+import { tmpDir, makeB0ID } from './util.js';
+
+const snapshotData = 'snapshot data';
+// this snapHash was computed manually
+const snapHash =
+  'e7dee7266896538616b630a5da40a90e007726a383e005a9c9c5dd0c2daf9329';
+
+/** @type {import('../src/bundleStore.js').Bundle} */
+const bundle0 = { moduleFormat: 'nestedEvaluate', source: '1+1' };
+const bundle0ID = makeB0ID(bundle0);
+
+function convert(orig) {
+  const bundles = Object.fromEntries(
+    Object.entries(orig.bundles).map(([bundleID, encBundle]) => {
+      const s = new TextDecoder().decode(decodeBase64(encBundle));
+      assert(bundleID.startsWith('b0-'), bundleID);
+      const bundle = JSON.parse(s);
+      return [bundleID, bundle];
+    }),
+  );
+  return { ...orig, bundles };
+}
+
+/**
+ * @typedef { import('../src/exporter').KVPair } KVPair
+ */
+
+/**
+ * @param { Map<string, string | null> } exportData
+ * @param { Map<string, string> } artifacts
+ */
+function makeExporter(exportData, artifacts) {
+  return {
+    async *getExportData() {
+      for (const [key, value] of exportData.entries()) {
+        /** @type { KVPair } */
+        const pair = [key, value];
+        yield pair;
+      }
+    },
+    async *getArtifactNames() {
+      for (const name of artifacts.keys()) {
+        yield name;
+      }
+    },
+    async *getArtifact(name) {
+      const data = artifacts.get(name);
+      assert(data, `missing artifact ${name}`);
+      yield Buffer.from(data);
+    },
+    // eslint-disable-next-line no-empty-function
+    async close() {},
+  };
+}
+
+test('import empty', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+  const exporter = makeExporter(new Map(), new Map());
+  const ss = await importSwingStore(exporter, dbDir);
+  ss.hostStorage.commit();
+  const data = convert(ss.debug.dump());
+  t.deepEqual(data, {
+    kvEntries: {},
+    transcripts: {},
+    snapshots: {},
+    bundles: {},
+  });
+});
+
+function buildData() {
+  // build an export manually
+  const exportData = new Map();
+  const artifacts = new Map();
+
+  // shadow kvStore
+  exportData.set('kv.key1', 'value1');
+
+  // now add artifacts and metadata in pairs
+
+  artifacts.set(`bundle.${bundle0ID}`, JSON.stringify(bundle0));
+  exportData.set(`bundle.${bundle0ID}`, bundle0ID);
+
+  const sbase = { vatID: 'v1', hash: snapHash, inUse: 0 };
+  const tbase = { vatID: 'v1', startPos: 0, isCurrent: 0, incarnation: 0 };
+  const addTS = (key, obj) =>
+    exportData.set(key, JSON.stringify({ ...tbase, ...obj }));
+  const t0hash =
+    '57152efdd7fdf75c03371d2b4f1088d5bf3eae7fe643babce527ff81df38998c';
+  const t3hash =
+    '1947001e78e01bd1e773feb22b4ffc530447373b9de9274d5d5fbda3f23dbf2b';
+  const t6hash =
+    'e6b42c6a3fb94285a93162f25a9fc0145fd4c5bb144917dc572c50ae2d02ee69';
+
+  addTS(`transcript.v1.0`, { endPos: 3, hash: t0hash });
+  artifacts.set(
+    `transcript.v1.0.3`,
+    'start-worker\ndelivery1\nsave-snapshot\n',
+  );
+  exportData.set(`snapshot.v1.2`, JSON.stringify({ ...sbase, snapPos: 2 }));
+  artifacts.set(`snapshot.v1.2`, snapshotData);
+
+  addTS(`transcript.v1.3`, { startPos: 3, endPos: 6, hash: t3hash });
+  artifacts.set(
+    'transcript.v1.3.6',
+    'load-snapshot\ndelivery2\nsave-snapshot\n',
+  );
+  exportData.set(
+    `snapshot.v1.5`,
+    JSON.stringify({ ...sbase, snapPos: 5, inUse: 1 }),
+  );
+  artifacts.set(`snapshot.v1.5`, snapshotData);
+
+  artifacts.set('transcript.v1.6.8', 'load-snapshot\ndelivery3\n');
+  exportData.set(`snapshot.v1.current`, 'snapshot.v1.5');
+  addTS(`transcript.v1.current`, {
+    startPos: 6,
+    endPos: 8,
+    isCurrent: 1,
+    hash: t6hash,
+  });
+
+  return { exportData, artifacts, t0hash, t3hash, t6hash };
+}
+
+const importTest = test.macro(async (t, mode) => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const { exportData, artifacts, t0hash, t3hash, t6hash } = buildData();
+
+  const exporter = makeExporter(exportData, artifacts);
+
+  // now import
+  const includeHistorical = mode === 'historical';
+  const options = { includeHistorical };
+  const ss = await importSwingStore(exporter, dbDir, options);
+  ss.hostStorage.commit();
+  const data = convert(ss.debug.dump());
+
+  const convertTranscript = (items, startPos = 0) => {
+    const out = {};
+    let pos = startPos;
+    for (const item of items) {
+      out[pos] = item;
+      pos += 1;
+    }
+    return out;
+  };
+
+  const convertSnapshots = async allVatSnapshots => {
+    const out = {};
+    for await (const [vatID, snapshots] of Object.entries(allVatSnapshots)) {
+      const convertedSnapshots = [];
+      for await (const snapshot of snapshots) {
+        if (!snapshot.compressedSnapshot) {
+          continue;
+        }
+        const gzReader = Readable.from(snapshot.compressedSnapshot);
+        const unzipper = createGunzip();
+        const snapshotReader = gzReader.pipe(unzipper);
+        const uncompressedSnapshot = await buffer(snapshotReader);
+        const converted = { ...snapshot, uncompressedSnapshot };
+        delete converted.compressedSnapshot;
+        convertedSnapshots.push(converted);
+      }
+      out[vatID] = convertedSnapshots;
+    }
+    return out;
+  };
+
+  t.deepEqual(data.kvEntries, { key1: 'value1' });
+  let ts = [];
+  let tsStart = 6; // start of current span
+  if (mode === 'historical') {
+    tsStart = 0; // historical means we get all spans
+    ts = ts.concat(['start-worker', 'delivery1', 'save-snapshot']); // 0,1,2
+    ts = ts.concat(['load-snapshot', 'delivery2', 'save-snapshot']); // 3,4,5
+  }
+  ts = ts.concat(['load-snapshot', 'delivery3']); // 6,7
+
+  const expectedTranscript = convertTranscript(ts, tsStart);
+  t.deepEqual(data.transcripts, { v1: expectedTranscript });
+  const uncompressedSnapshot = Buffer.from(snapshotData);
+  const expectedSnapshots = [];
+  if (mode === 'historical') {
+    expectedSnapshots.push({
+      uncompressedSnapshot,
+      hash: snapHash,
+      inUse: 0,
+      snapPos: 2,
+    });
+  }
+  expectedSnapshots.push({
+    uncompressedSnapshot,
+    hash: snapHash,
+    inUse: 1,
+    snapPos: 5,
+  });
+  t.deepEqual(await convertSnapshots(data.snapshots), {
+    v1: expectedSnapshots,
+  });
+  t.deepEqual(data.bundles, { [bundle0ID]: bundle0 });
+
+  // look directly at the DB to confirm presence of metadata rows
+  const db = sqlite3(path.join(dbDir, 'swingstore.sqlite'));
+  const spanRows = [
+    ...db.prepare('SELECT * FROM transcriptSpans ORDER BY startPos').iterate(),
+  ];
+  t.deepEqual(
+    spanRows.map(sr => sr.startPos),
+    [0, 3, 6],
+  );
+
+  // and a new export should include all metadata, regardless of import mode
+
+  const reExporter = makeSwingStoreExporter(dbDir, 'current');
+  const reExportData = new Map();
+  for await (const [key, value] of reExporter.getExportData()) {
+    reExportData.set(key, value);
+  }
+  // console.log(reExportData);
+
+  const check = (key, expected) => {
+    t.true(reExportData.has(key), `missing exportData ${key}`);
+    let value = reExportData.get(key);
+    reExportData.delete(key);
+    if (typeof expected === 'object') {
+      value = JSON.parse(value);
+    }
+    t.deepEqual(value, expected);
+  };
+
+  check('kv.key1', 'value1');
+  check('snapshot.v1.2', { vatID: 'v1', snapPos: 2, inUse: 0, hash: snapHash });
+  check('snapshot.v1.5', { vatID: 'v1', snapPos: 5, inUse: 1, hash: snapHash });
+  check('snapshot.v1.current', 'snapshot.v1.5');
+  const base = { vatID: 'v1', incarnation: 0, isCurrent: 0 };
+  check('transcript.v1.0', { ...base, startPos: 0, endPos: 3, hash: t0hash });
+  check('transcript.v1.3', { ...base, startPos: 3, endPos: 6, hash: t3hash });
+  check('transcript.v1.current', {
+    ...base,
+    startPos: 6,
+    endPos: 8,
+    isCurrent: 1,
+    hash: t6hash,
+  });
+  check(`bundle.${bundle0ID}`, bundle0ID);
+
+  // the above list is supposed to be exhaustive
+  if (reExportData.size) {
+    console.log(reExportData);
+    t.fail('unexpected exportData keys');
+  }
+});
+
+test('import current', importTest, 'current');
+test('import historical', importTest, 'historical');
+
+test('import is missing bundle', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const exportData = new Map();
+  exportData.set(`bundle.${bundle0ID}`, bundle0ID);
+  // but there is no artifact to match
+  const exporter = makeExporter(exportData, new Map());
+  await t.throwsAsync(async () => importSwingStore(exporter, dbDir), {
+    message: /missing bundles for:/,
+  });
+});
+
+test('import is missing snapshot', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const exportData = new Map();
+  exportData.set(
+    `snapshot.v1.2`,
+    JSON.stringify({ vatID: 'v1', hash: snapHash, inUse: 1, snapPos: 2 }),
+  );
+  // but there is no artifact to match
+  const exporter = makeExporter(exportData, new Map());
+  await t.throwsAsync(async () => importSwingStore(exporter, dbDir), {
+    message: /current snapshots are pruned for vats/,
+  });
+});
+
+test('import is missing transcript span', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const exportData = new Map();
+  const t0hash =
+    '57152efdd7fdf75c03371d2b4f1088d5bf3eae7fe643babce527ff81df38998c';
+  exportData.set(
+    `transcript.v1.current`,
+    JSON.stringify({
+      vatID: 'v1',
+      startPos: 0,
+      endPos: 3,
+      hash: t0hash,
+      isCurrent: 1,
+      incarnation: 0,
+    }),
+  );
+  // but there is no artifact to match
+  const exporter = makeExporter(exportData, new Map());
+  await t.throwsAsync(async () => importSwingStore(exporter, dbDir), {
+    message: /incomplete current transcript/,
+  });
+});
+
+test('import has mismatched transcript span', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const exportData = new Map();
+  const t0hash =
+    '57152efdd7fdf75c03371d2b4f1088d5bf3eae7fe643babce527ff81df38998c';
+  exportData.set(
+    `transcript.v1.current`,
+    JSON.stringify({
+      vatID: 'v1',
+      startPos: 0,
+      endPos: 3,
+      hash: t0hash,
+      isCurrent: 0, // mismatch
+      incarnation: 0,
+    }),
+  );
+  const exporter = makeExporter(exportData, new Map());
+  await t.throwsAsync(async () => importSwingStore(exporter, dbDir), {
+    message: /transcript key "transcript.v1.current" mismatches metadata/,
+  });
+});
+
+test('import has incomplete transcript span', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const exportData = new Map();
+  const artifacts = new Map();
+  const t0hash =
+    '57152efdd7fdf75c03371d2b4f1088d5bf3eae7fe643babce527ff81df38998c';
+  exportData.set(
+    `transcript.v1.current`,
+    JSON.stringify({
+      vatID: 'v1',
+      startPos: 0,
+      endPos: 4, // expect 4 items
+      hash: t0hash,
+      isCurrent: 1,
+      incarnation: 0,
+    }),
+  );
+  // but artifact only contains 3
+  artifacts.set(
+    `transcript.v1.0.4`,
+    'start-worker\ndelivery1\nsave-snapshot\n',
+  );
+
+  const exporter = makeExporter(exportData, artifacts);
+  await t.throwsAsync(async () => importSwingStore(exporter, dbDir), {
+    message: /artifact "transcript.v1.0.4" is not complete/,
+  });
+});
+
+test('import has corrupt transcript span', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const exportData = new Map();
+  const artifacts = new Map();
+  const t0hash =
+    '57152efdd7fdf75c03371d2b4f1088d5bf3eae7fe643babce527ff81df38998c';
+  exportData.set(
+    `transcript.v1.current`,
+    JSON.stringify({
+      vatID: 'v1',
+      startPos: 0,
+      endPos: 3,
+      hash: t0hash,
+      isCurrent: 1,
+      incarnation: 0,
+    }),
+  );
+  artifacts.set(
+    `transcript.v1.0.3`,
+    'start-worker\nBAD-DELIVERY1\nsave-snapshot\n',
+  );
+
+  const exporter = makeExporter(exportData, artifacts);
+  await t.throwsAsync(async () => importSwingStore(exporter, dbDir), {
+    message: /artifact "transcript.v1.0.3" hash is.*metadata says/,
+  });
+});
+
+test('import has corrupt snapshot', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const exportData = new Map();
+  const artifacts = new Map();
+  exportData.set(
+    `snapshot.v1.2`,
+    JSON.stringify({
+      vatID: 'v1',
+      snapPos: 2,
+      hash: snapHash,
+      inUse: 1,
+    }),
+  );
+  artifacts.set('snapshot.v1.2', `${snapshotData}WRONG`);
+
+  const exporter = makeExporter(exportData, artifacts);
+  await t.throwsAsync(async () => importSwingStore(exporter, dbDir), {
+    message: /snapshot "snapshot.v1.2" hash is.*metadata says/,
+  });
+});
+
+test('import has corrupt bundle', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const exportData = new Map();
+  const artifacts = new Map();
+  exportData.set(`bundle.${bundle0ID}`, bundle0ID);
+  const badBundle = { ...bundle0, source: 'WRONG' };
+  artifacts.set(`bundle.${bundle0ID}`, JSON.stringify(badBundle));
+
+  const exporter = makeExporter(exportData, artifacts);
+  await t.throwsAsync(async () => importSwingStore(exporter, dbDir), {
+    message: /bundleID ".*" does not match bundle artifact/,
+  });
+});
+
+test('import has unknown metadata tag', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const exportData = new Map();
+  exportData.set(`unknown.v1.current`, 'value');
+  const exporter = makeExporter(exportData, new Map());
+  await t.throwsAsync(async () => importSwingStore(exporter, dbDir), {
+    message: /unknown export-data type "unknown" on import/,
+  });
+});
+
+test('import has unknown artifact tag', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const artifacts = new Map();
+  artifacts.set('unknown.v1.current', 'value');
+  const exporter = makeExporter(new Map(), artifacts);
+  await t.throwsAsync(async () => importSwingStore(exporter, dbDir), {
+    message: /unknown artifact type "unknown" on import/,
+  });
+});

--- a/packages/swing-store/test/test-import.js
+++ b/packages/swing-store/test/test-import.js
@@ -45,7 +45,7 @@ function convert(orig) {
  * @param { Map<string, string | null> } exportData
  * @param { Map<string, string> } artifacts
  */
-function makeExporter(exportData, artifacts) {
+export function makeExporter(exportData, artifacts) {
   return {
     async *getExportData() {
       for (const [key, value] of exportData.entries()) {
@@ -84,7 +84,7 @@ test('import empty', async t => {
   });
 });
 
-function buildData() {
+export function buildData() {
   // build an export manually
   const exportData = new Map();
   const artifacts = new Map();

--- a/packages/swing-store/test/test-repair-metadata.js
+++ b/packages/swing-store/test/test-repair-metadata.js
@@ -1,0 +1,131 @@
+// @ts-check
+
+import '@endo/init/debug.js';
+
+import path from 'path';
+import test from 'ava';
+import sqlite3 from 'better-sqlite3';
+
+import { importSwingStore } from '../src/index.js';
+
+import { makeExporter, buildData } from './test-import.js';
+import { tmpDir } from './util.js';
+
+test('repair metadata', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const { exportData, artifacts } = buildData();
+
+  // simulate a swingstore broken by #8025 by importing everything,
+  // then manually deleting the historical metadata entries from the
+  // DB
+  const exporter = makeExporter(exportData, artifacts);
+  const ss = await importSwingStore(exporter, dbDir);
+  await ss.hostStorage.commit();
+
+  const filePath = path.join(dbDir, 'swingstore.sqlite');
+  const db = sqlite3(filePath);
+
+  const getTS = db.prepare(
+    'SELECT startPos FROM transcriptSpans WHERE vatID = ? ORDER BY startPos',
+  );
+  getTS.pluck();
+  const getSS = db.prepare(
+    'SELECT snapPos FROM snapshots WHERE vatID = ? ORDER BY snapPos',
+  );
+  getSS.pluck();
+
+  // assert that all the metadata is there at first
+  const ts1 = getTS.all('v1');
+  t.deepEqual(ts1, [0, 3, 6]); // three spans
+  const ss1 = getSS.all('v1');
+  t.deepEqual(ss1, [2, 5]); // two snapshots
+
+  // now clobber them to simulate #8025 (note: these auto-commit)
+  db.prepare('DELETE FROM transcriptSpans WHERE isCurrent IS NULL').run();
+  db.prepare('DELETE FROM snapshots WHERE inUSE IS NULL').run();
+
+  // confirm that we clobbered them
+  const ts2 = getTS.all('v1');
+  t.deepEqual(ts2, [6]); // only the latest
+  const ss2 = getSS.all('v1');
+  t.deepEqual(ss2, [5]);
+
+  // now fix it
+  await ss.hostStorage.repairMetadata(exporter);
+  await ss.hostStorage.commit();
+
+  // and check that the metadata is back
+  const ts3 = getTS.all('v1');
+  t.deepEqual(ts3, [0, 3, 6]); // all three again
+  const ss3 = getSS.all('v1');
+  t.deepEqual(ss3, [2, 5]);
+
+  // repair should be idempotent
+  await ss.hostStorage.repairMetadata(exporter);
+
+  const ts4 = getTS.all('v1');
+  t.deepEqual(ts4, [0, 3, 6]); // still there
+  const ss4 = getSS.all('v1');
+  t.deepEqual(ss4, [2, 5]);
+});
+
+test('repair metadata ignores kvStore entries', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const { exportData, artifacts } = buildData();
+
+  const exporter = makeExporter(exportData, artifacts);
+  const ss = await importSwingStore(exporter, dbDir);
+  await ss.hostStorage.commit();
+
+  // perform the repair with spurious kv entries
+  exportData.set('kv.key2', 'value2');
+  await ss.hostStorage.repairMetadata(exporter);
+  await ss.hostStorage.commit();
+
+  // the spurious kv entry should be ignored
+  t.deepEqual(ss.debug.dump().kvEntries, { key1: 'value1' });
+});
+
+test('repair metadata rejects mismatched snapshot entries', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const { exportData, artifacts } = buildData();
+
+  const exporter = makeExporter(exportData, artifacts);
+  const ss = await importSwingStore(exporter, dbDir);
+  await ss.hostStorage.commit();
+
+  // perform the repair with mismatched snapshot entry
+  const old = JSON.parse(exportData.get('snapshot.v1.2'));
+  const wrong = { ...old, hash: 'wrong' };
+  exportData.set('snapshot.v1.2', JSON.stringify(wrong));
+
+  await t.throwsAsync(async () => ss.hostStorage.repairMetadata(exporter), {
+    message: /repairSnapshotRecord metadata mismatch/,
+  });
+});
+
+test('repair metadata rejects mismatched transcript span', async t => {
+  const [dbDir, cleanup] = await tmpDir('testdb');
+  t.teardown(cleanup);
+
+  const { exportData, artifacts } = buildData();
+
+  const exporter = makeExporter(exportData, artifacts);
+  const ss = await importSwingStore(exporter, dbDir);
+  await ss.hostStorage.commit();
+
+  // perform the repair with mismatched transcript span entry
+  const old = JSON.parse(exportData.get('transcript.v1.0'));
+  const wrong = { ...old, hash: 'wrong' };
+  exportData.set('transcript.v1.0', JSON.stringify(wrong));
+
+  await t.throwsAsync(async () => ss.hostStorage.repairMetadata(exporter), {
+    message: /repairTranscriptSpanRecord metadata mismatch/,
+  });
+});

--- a/packages/swing-store/test/util.js
+++ b/packages/swing-store/test/util.js
@@ -1,0 +1,26 @@
+import { Buffer } from 'node:buffer';
+import tmp from 'tmp';
+import { createSHA256 } from '../src/hasher.js';
+
+/**
+ * @param {string} [prefix]
+ * @returns {Promise<[string, () => void]>}
+ */
+export const tmpDir = prefix =>
+  new Promise((resolve, reject) => {
+    tmp.dir({ unsafeCleanup: true, prefix }, (err, name, removeCallback) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve([name, removeCallback]);
+      }
+    });
+  });
+
+export async function* getSnapshotStream(contents) {
+  yield Buffer.from(contents);
+}
+
+export function makeB0ID(bundle) {
+  return `b0-${createSHA256(JSON.stringify(bundle)).finish()}`;
+}


### PR DESCRIPTION
Previously, the swingstore importer would ignore "historical
metadata": records (with hashes) for transcripts and heap snapshots
that are not strictly necessary to rebuild workers. This was a
mistake: our intention was to always preserve these hashes, so that we
might safely (with integrity) repopulate the corresponding data in the
future, using artifacts from untrusted sources.

This commit rewrites the importer to record *all* metadata records in
the first pass, regardless of whether we want historical data or
not. All of these records will be stubs: missing the actual bundle or
snapshot or transcript items, as if they had been pruned. Then, in the
second pass, we populate those stubs using the matching artifats (or
ignore the historical ones, as configured by the `includeHistorical`
option). A final `assertComplete` pass insists that all the
important (non-historical) records are fully populated.

New tests were added to assert that metadata is preserved regardless
of import mode, and that the `assertComplete` pass really catches
everything.

A new `docs/swingstore.md` was added to describe the data model,
including what it means for records to be pruned.

In addition, a `repairMetadata()` function was added to help with
repairing a swingstore that has been damaged by the problem.

fixes #8025
