### PR TITLE
fix(ci): checkout agoric-sdk in sub folder

### DIFF
--- a/.github/actions/restore-golang/action.yml
+++ b/.github/actions/restore-golang/action.yml
@@ -5,6 +5,10 @@ inputs:
   go-version:
     description: 'The version of Go to use'
     required: true
+  path:
+    description: 'The relative path to the agoric-sdk directory'
+    required: false
+    default: '.'
 
 runs:
   using: composite
@@ -14,13 +18,14 @@ runs:
       shell: bash
     - uses: actions/checkout@v3
       with:
+        path: ${{ inputs.path }}
         clean: 'false'
         submodules: 'true'
     - uses: actions/setup-go@v4
       with:
-        cache-dependency-path: golang/cosmos/go.sum
+        cache-dependency-path: ${{ inputs.path }}/golang/cosmos/go.sum
         go-version: ${{ inputs.go-version }}
     - name: go mod download
-      working-directory: ./golang/cosmos
+      working-directory: ${{ inputs.path }}/golang/cosmos
       run: go mod download
       shell: bash

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -27,13 +27,17 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
+          path: ./agoric-sdk
       - run: sudo packages/deployment/scripts/install-deps.sh
-      - uses: ./.github/actions/restore-golang
+        working-directory: ./agoric-sdk
+      - uses: ./agoric-sdk/.github/actions/restore-golang
         with:
           go-version: '1.20'
-      - uses: ./.github/actions/restore-node
+          path: ./agoric-sdk
+      - uses: ./agoric-sdk/.github/actions/restore-node
         with:
           node-version: 18.x
+          path: ./agoric-sdk
           # Forces xsnap to initialize all memory to random data, which increases
           # the chances the content of snapshots may deviate between validators
           xsnap-random-init: '1'
@@ -63,15 +67,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Agoric/testnet-load-generator
-          path: testnet-load-generator
+          path: ./testnet-load-generator
           ref: ${{steps.get-loadgen-branch.outputs.result}}
 
       - name: Build cosmic-swingset dependencies
+        working-directory: ./agoric-sdk
         run: |
           set -e
           cd packages/cosmic-swingset
           make install
-      - run: |
+      - name: Run integration test
+        working-directory: ./agoric-sdk
+        run: |
           set -xe
           DOCKER_VOLUMES="$PWD:/usr/src/agoric-sdk" \
           packages/deployment/scripts/integration-test.sh
@@ -80,6 +87,7 @@ jobs:
           NETWORK_NAME: chaintest
       - name: capture results
         if: always()
+        working-directory: ./agoric-sdk
         run: |
           NOW=$(date -u +%Y%m%dT%H%M%S)
           echo "NOW=$NOW" >> "$GITHUB_ENV"
@@ -98,11 +106,11 @@ jobs:
         if: always()
         with:
           name: deployment-test-results-${{ env.NOW }}
-          path: chaintest/results
+          path: ./agoric-sdk/chaintest/results
 
       - name: notify on failure
         if: failure() && github.event_name != 'pull_request'
-        uses: ./.github/actions/notify-status
+        uses: ./agoric-sdk/.github/actions/notify-status
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           from: ${{ secrets.NOTIFY_EMAIL_FROM }}

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
           set -xe
           DOCKER_VOLUMES="$PWD:/usr/src/agoric-sdk" \
+          LOADGEN=1 \
           packages/deployment/scripts/integration-test.sh
         timeout-minutes: 90
         env:

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -76,38 +76,42 @@ jobs:
           set -e
           cd packages/cosmic-swingset
           make install
+      - name: Make networks directory
+        run: |
+          set -e
+          mkdir networks
       - name: Run integration test
-        working-directory: ./agoric-sdk
+        working-directory: ./networks
         run: |
           set -xe
-          DOCKER_VOLUMES="$PWD:/usr/src/agoric-sdk" \
+          DOCKER_VOLUMES="$PWD/../agoric-sdk:/usr/src/agoric-sdk" \
           LOADGEN=1 \
-          packages/deployment/scripts/integration-test.sh
+          ../agoric-sdk/packages/deployment/scripts/integration-test.sh
         timeout-minutes: 90
         env:
           NETWORK_NAME: chaintest
       - name: capture results
         if: always()
-        working-directory: ./agoric-sdk
+        working-directory: ./networks
         run: |
           NOW=$(date -u +%Y%m%dT%H%M%S)
           echo "NOW=$NOW" >> "$GITHUB_ENV"
 
           # Stop the chain from running.
-          packages/deployment/scripts/setup.sh play stop || true
+          ../agoric-sdk/packages/deployment/scripts/setup.sh play stop || true
 
           # Get the results.
-          packages/deployment/scripts/capture-integration-results.sh "${{ job.status == 'failure' }}"
+          ../agoric-sdk/packages/deployment/scripts/capture-integration-results.sh "${{ job.status == 'failure' }}"
 
           # Tear down the nodes.
-          echo yes | packages/deployment/scripts/setup.sh destroy || true
+          echo yes | ../agoric-sdk/packages/deployment/scripts/setup.sh destroy || true
         env:
           NETWORK_NAME: chaintest
       - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: deployment-test-results-${{ env.NOW }}
-          path: ./agoric-sdk/chaintest/results
+          path: ./networks/chaintest/results
 
       - name: notify on failure
         if: failure() && github.event_name != 'pull_request'

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -69,7 +69,7 @@ then
   cp ag-chain-cosmos/data/genesis.json "$RESULTSDIR/genesis.json"
   cp "$AG_SETUP_COSMOS_HOME/ag-chain-cosmos/data/genesis.json" "$RESULTSDIR/genesis.json"
   cd "$LOADGEN"
-  SOLO_COINS=40000000000uist \
+  SOLO_COINS=40000000000uist PATH="$thisdir/../bin:$PATH" \
     "$AG_SETUP_COSMOS_HOME/faucet-helper.sh" add-egress loadgen "$SOLO_ADDR"
   SLOGSENDER=@agoric/telemetry/src/otel-trace.js SOLO_SLOGSENDER="" \
   SLOGSENDER_FAIL_ON_ERROR=1 SLOGSENDER_AGENT=process \

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -9,16 +9,24 @@ export NETWORK_NAME=${NETWORK_NAME-localtest}
 
 SDK_SRC=${SDK_SRC-$(cd "$thisdir/../../.." > /dev/null && pwd -P)}
 
-DEFAULT_LOADGEN=/usr/src/testnet-load-generator
 LOADGEN=${LOADGEN-""}
-if [ -n "$LOADGEN" ]; then
+if [ -z "$LOADGEN" ] || [ "x$LOADGEN" = "x1" ]; then
+  for dir in "$SDK_SRC/../testnet-load-generator" /usr/src/testnet-load-generator; do
+    if [ -d "$dir" ]; then
+      LOADGEN="$dir"
+      break
+    fi
+  done
+fi
+
+if [ -d "$LOADGEN" ]; then
+  # Get the absolute path.
   LOADGEN=$(cd "$LOADGEN" > /dev/null && pwd -P)
-elif [ -d "$SDK_SRC/../testnet-load-generator" ]; then
-  LOADGEN=$(cd "$SDK_SRC/../testnet-load-generator" > /dev/null && pwd -P)
-elif [ -d "$DEFAULT_LOADGEN" ]; then
-  LOADGEN=$(cd "$DEFAULT_LOADGEN" > /dev/null && pwd -P)
+elif [ -n "$LOADGEN" ]; then
+  echo "Cannot find loadgen (\$LOADGEN=$LOADGEN)" >&2
+  exit 2
 else
-  LOADGEN=
+  echo "Running chain without loadgen" >&2
 fi
 
 SOLO_ADDR=

--- a/scripts/run-deployment-integration.sh
+++ b/scripts/run-deployment-integration.sh
@@ -28,6 +28,7 @@ yarn install && XSNAP_RANDOM_INIT=1 yarn build && make -C packages/cosmic-swings
 # change to "false" to skip extraction on success like in CI
 testfailure="unknown"
 DOCKER_VOLUMES="$AGORIC_SDK_PATH:/usr/src/agoric-sdk" \
+LOADGEN=1 \
 packages/deployment/scripts/integration-test.sh || {
   echo "Test failed!!!"
   testfailure="true"

--- a/scripts/run-deployment-integration.sh
+++ b/scripts/run-deployment-integration.sh
@@ -11,8 +11,6 @@ export AGORIC_SDK_PATH="${AGORIC_SDK_PATH-$SDK_SRC}"
 
 export NETWORK_NAME=chaintest
 
-sudo ln -sf "$SDK_SRC/packages/deployment/bin/ag-setup-cosmos" /usr/local/bin/ag-setup-cosmos
-
 # Note: the deployment test and the loadgen test in testnet mode modify some
 # directories in $HOME so provide an empty $HOME for them.
 export HOME="$(mktemp -d -t deployment-integration-home.XXXXX)"


### PR DESCRIPTION
Fixes #8086

## Description

#8004 silently broke the loadgen part of the deployment CI job. This PR fixes it by removing an implicit `$PATH` dependency in `integration-test.sh`.

This PR also improves that test by checking out agoric-sdk in a subfolder, making `testnet-load-generator` a normal sibling of `agoric-sdk`.  It also fails the deployment-test if the loadgen isn't found.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Manual verification of deployment-test CI job.

### Upgrade Considerations

None