### PR TITLE
feat(telemetry): add datadog slog sender

### DIFF
--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -38,7 +38,8 @@
     "anylogger": "^0.21.0",
     "better-sqlite3": "^8.2.0",
     "bufferfromfile": "agoric-labs/BufferFromFile#Agoric-built",
-    "tmp": "^0.2.1"
+    "tmp": "^0.2.1",
+    "winston": "^3.10.0"
   },
   "devDependencies": {
     "@endo/lockdown": "^0.1.29",

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -6,6 +6,7 @@ import { serializeSlogObj } from './serialize-slog-obj.js';
 export const DEFAULT_SLOGSENDER_MODULE =
   '@agoric/telemetry/src/flight-recorder.js';
 export const SLOGFILE_SENDER_MODULE = '@agoric/telemetry/src/slog-file.js';
+export const DATADOG_SENDER_MODULE = '@agoric/telemetry/src/slog-datadog.js';
 
 export const DEFAULT_SLOGSENDER_AGENT = 'self';
 
@@ -41,6 +42,7 @@ export const makeSlogSender = async (opts = {}) => {
   const slogSenderModules = [
     ...new Set([
       ...(agentEnv.SLOGFILE ? [SLOGFILE_SENDER_MODULE] : []),
+      ...(agentEnv.DATADOG_LOG_FILE ? [DATADOG_SENDER_MODULE] : []),
       ...SLOGSENDER.split(',')
         .filter(Boolean)
         .map(modulePath =>

--- a/packages/telemetry/src/slog-datadog.js
+++ b/packages/telemetry/src/slog-datadog.js
@@ -1,0 +1,37 @@
+import { createLogger, format, transports } from 'winston';
+
+/** @param {import('./index.js').MakeSlogSenderOptions} opts */
+export const makeSlogSender = async ({
+  env: { DATADOG_LOG_FILE } = {},
+} = {}) => {
+  if (!DATADOG_LOG_FILE) {
+    return undefined;
+  }
+
+  const logger = createLogger({
+    exitOnError: false,
+    format: format.logstash(),
+    transports: [
+      new transports.File({
+        filename: DATADOG_LOG_FILE,
+        maxsize: 104857600, // 100MB
+        maxFiles: 10,
+        tailable: true,
+      }),
+    ],
+  });
+
+  if (!logger) {
+    return undefined;
+  }
+
+  const slogSender = slogObj => {
+    logger.info(slogObj);
+  };
+
+  return Object.assign(slogSender, {
+    forceFlush: async () => {},
+    shutdown: async () => logger.close(),
+    usesJsonObject: true,
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2668,7 +2668,7 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-async@^3.1.0:
+async@^3.1.0, async@^3.2.3:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
@@ -6922,7 +6922,7 @@ log-symbols@^4.0.0, log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-logform@^2.2.0, logform@^2.3.2:
+logform@^2.2.0, logform@^2.3.2, logform@^2.4.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/logform/-/logform-2.5.1.tgz#44c77c34becd71b3a42a3970c77929e52c6ed48b"
   integrity sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==
@@ -10841,7 +10841,7 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
-winston-transport@^4.4.0:
+winston-transport@^4.4.0, winston-transport@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.5.0.tgz#6e7b0dd04d393171ed5e4e4905db265f7ab384fa"
   integrity sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==
@@ -10864,6 +10864,23 @@ winston@3.3.3:
     stack-trace "0.0.x"
     triple-beam "^1.3.0"
     winston-transport "^4.4.0"
+
+winston@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.10.0.tgz#d033cb7bd3ced026fed13bf9d92c55b903116803"
+  integrity sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.4.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.5.0"
 
 wordwrap@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description
Add slog sender for datadog. 
To use this sender, set to datadog log file. Datadog client library (winston) will send the logs to this file. The datadog agent should be configured to read from this file. 


Example datadog agent config for logs
```
logs:
  - type: file
    path: "/logs/datadog.log"
    service: devnode
    source: nodejs
    sourcecategory: sourcecode
```

Example usage:
```
DATADOG_LOG_FILE=/logs/datadog.log make scenario2-run-chain
```
![Screenshot 2023-07-24 at 7 15 45 PM](https://github.com/Agoric/agoric-sdk/assets/6778940/b0c5ef5c-a87b-4c6e-a589-2a68136e1f05)

### Security Considerations

### Scaling Considerations
There is a limit set to how big log files can grow. If the host does not have extra 1GB (100MB * 10 files) on disk than they should not configure this sender. If required we can make it configurable in future through environment variables.

### Documentation Considerations
Set ` DATADOG_LOG_FILE` to enable this sender.

### Testing Considerations
Local testing with datadog.

### Upgrade Considerations

None