### PR TITLE
fix(resolve-versions): tolerate missing `package.json` resolutions

### DIFF
--- a/scripts/resolve-versions.sh
+++ b/scripts/resolve-versions.sh
@@ -13,7 +13,7 @@ cd -- "$DIR/.."
 override=$(jq 'to_entries | map({ key: ("**/" + .key), value: .value }) | from_entries')
 
 PACKAGEJSONHASH=$(
-  jq --arg override "$override" '.resolutions *= ($override | fromjson)' package.json |
+  jq --arg override "$override" '. * { resolutions: ($override | fromjson) }' package.json |
   git hash-object -w --stdin
 )
 git cat-file blob "$PACKAGEJSONHASH" > package.json


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

The nightly test against Endo master was failing with:
```
+ read -r dir
jq: error (at package.json:88): null (null) and object ({"**/@endo/...) cannot be multiplied
```

It turns out the `resolve-versions.sh` script assumed that there must be a `packageJson.resolutions` property, which was removed by #5927.  This PR makes the script properly robust, creating a `resolutions` property if there isn't one to merge against.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
n/a

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
n/a

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
n/a

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Manually verified.  Will be tested in nightly CI after merge.

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
n/a