### PR TITLE
fix(swingset-liveslots): Throw a "not found" error for store.set(missingRemotable, val)

### DIFF
--- a/packages/swingset-liveslots/src/collectionManager.js
+++ b/packages/swingset-liveslots/src/collectionManager.js
@@ -432,6 +432,9 @@ export function makeCollectionManager(
           }
         }
       }
+      if (passStyleOf(key) === 'remotable' && getOrdinal(key) === undefined) {
+        failNotFound(label, key);
+      }
       const dbKey = keyToDBKey(key);
       const rawBefore = syscall.vatstoreGet(dbKey) || failNotFound(label, key);
       const before = JSON.parse(rawBefore);

--- a/packages/swingset-liveslots/test/test-collections.js
+++ b/packages/swingset-liveslots/test/test-collections.js
@@ -102,6 +102,12 @@ function exerciseMapOperations(t, collectionName, testStore) {
     m(`key 86 not found in collection "${collectionName}"`),
   );
   t.throws(
+    () => testStore.set(somethingMissing, 'not work'),
+    m(
+      `key "[Alleged: something missing]" not found in collection "${collectionName}"`,
+    ),
+  );
+  t.throws(
     () => testStore.init(47, 'already there'),
     m(`key 47 already registered in collection "${collectionName}"`),
   );
@@ -118,10 +124,16 @@ function exerciseMapOperations(t, collectionName, testStore) {
   t.is(testStore.get(somethingElse), something);
 
   testStore.delete(47);
+  testStore.delete(something);
   t.falsy(testStore.has(47));
+  t.falsy(testStore.has(something));
   t.throws(
     () => testStore.get(47),
     m(`key 47 not found in collection "${collectionName}"`),
+  );
+  t.throws(
+    () => testStore.get(something),
+    m(`key "[Alleged: something]" not found in collection "${collectionName}"`),
   );
   t.throws(
     () => testStore.delete(22),
@@ -147,7 +159,9 @@ function exerciseSetOperations(t, collectionName, testStore) {
   t.notThrows(() => testStore.add(47));
 
   testStore.delete(47);
+  testStore.delete(something);
   t.falsy(testStore.has(47));
+  t.falsy(testStore.has(something));
   t.throws(
     () => testStore.delete(22),
     m(`key 22 not found in collection "${collectionName}"`),


### PR DESCRIPTION
Fixes #8098

## Description

Updates collection `set` to detect a missing remotable key and throw an appropriate error. Also includes moderate refactoring of collectionManager.js to DRY out code and ensure consistent error messages.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

Updates tests accordingly.

### Upgrade Considerations

This changes error messages, but I don't think we guarantee that those are stable. As long as restart/upgrade of any particular vat is in consensus across validators, then they will all agree on whether its liveslots dependency includes or does not include this change.