### PR TITLE
fix(cosmos): don't init controller before upgrade

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -598,7 +598,7 @@ func NewAgoricApp(
 		transferModule,
 		icaModule,
 		vstorage.NewAppModule(app.VstorageKeeper),
-		swingset.NewAppModule(app.SwingSetKeeper, setBootstrapNeeded),
+		swingset.NewAppModule(app.SwingSetKeeper, setBootstrapNeeded, app.ensureControllerInited),
 		vibcModule,
 		vbankModule,
 		lienModule,
@@ -631,6 +631,8 @@ func NewAgoricApp(
 		paramstypes.ModuleName,
 		vestingtypes.ModuleName,
 		vstorage.ModuleName,
+		// This will cause the swingset controller to init if it hadn't yet, passing
+		// any upgrade plan or bootstrap flag when starting at an upgrade height
 		swingset.ModuleName,
 		vibc.ModuleName,
 		vbank.ModuleName,
@@ -792,6 +794,7 @@ func NewAgoricApp(
 // upgrade11Handler performs standard upgrade actions plus custom actions for upgrade-11.
 func upgrade11Handler(app *GaiaApp, targetUpgrade string) func(sdk.Context, upgradetypes.Plan, module.VersionMap) (module.VersionMap, error) {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVm module.VersionMap) (module.VersionMap, error) {
+		app.CheckControllerInited(false)
 		// Record the plan to send to SwingSet
 		app.upgradePlan = &plan
 
@@ -847,13 +850,21 @@ func (app *GaiaApp) CheckControllerInited(expected bool) {
 	}
 }
 
+type bootstrapBlockAction struct {
+	Type      string `json:"type"`
+	BlockTime int64  `json:"blockTime"`
+}
+
 // initController sends the initialization message to the VM.
 // Exits if the controller has already been initialized.
+// The init message will contain any upgrade plan if we're starting after an
+// upgrade, and a flag indicating whether this is a bootstrap of the controller.
 func (app *GaiaApp) initController(ctx sdk.Context, bootstrap bool) {
 	app.CheckControllerInited(false)
 	app.controllerInited = true
 	// Begin initializing the controller here.
-	action := &cosmosInitAction{
+	var action vm.Jsonable
+	action = &cosmosInitAction{
 		Type:        "AG_COSMOS_INIT",
 		ChainID:     ctx.ChainID(),
 		IsBootstrap: bootstrap,
@@ -881,35 +892,46 @@ func (app *GaiaApp) initController(ctx sdk.Context, bootstrap bool) {
 	if !res {
 		panic(fmt.Errorf("controller negative init response"))
 	}
-}
 
-type bootstrapBlockAction struct {
-	Type      string `json:"type"`
-	BlockTime int64  `json:"blockTime"`
-}
-
-// BootstrapController initializes the controller (with the bootstrap flag) and sends a bootstrap action.
-func (app *GaiaApp) BootstrapController(ctx sdk.Context) error {
-	app.initController(ctx, true)
+	if !bootstrap {
+		return
+	}
 
 	stdlog.Println("Running SwingSet until bootstrap is ready")
 	// Just run the SwingSet kernel to finish bootstrap and get ready to open for
 	// business.
-	action := &bootstrapBlockAction{
+	action = &bootstrapBlockAction{
 		Type:      "BOOTSTRAP_BLOCK",
 		BlockTime: ctx.BlockTime().Unix(),
 	}
 
-	_, err := app.SwingSetKeeper.BlockingSend(ctx, action)
-	return err
+	_, err = app.SwingSetKeeper.BlockingSend(ctx, action)
+	// fmt.Fprintf(os.Stderr, "BOOTSTRAP_BLOCK Returned from swingset: %s, %v\n", out, err)
+	if err != nil {
+		// NOTE: A failed BOOTSTRAP_BLOCK means that the SwingSet state is inconsistent.
+		// Panic here, in the hopes that a replay from scratch will fix the problem.
+		panic(err)
+	}
+}
+
+// ensureControllerInited inits the controller if needed. It's used by the
+// x/swingset module's BeginBlock to lazily start the JS controller.
+// We cannot init early as we don't know when starting the software if this
+// might be a simple restart, or a chain init from genesis or upgrade which
+// require the controller to not be inited yet.
+func (app *GaiaApp) ensureControllerInited(ctx sdk.Context) {
+	if app.controllerInited {
+		return
+	}
+
+	// While we don't expect it anymore, some upgrade may want to throw away
+	// the current JS state and bootstrap again (bulldozer). In that case the
+	// upgrade handler can just set the bootstrapNeeded flag.
+	app.initController(ctx, app.bootstrapNeeded)
 }
 
 // BeginBlocker application updates every begin block
 func (app *GaiaApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
-	if !app.controllerInited {
-		app.initController(ctx, false)
-	}
-
 	return app.mm.BeginBlock(ctx, req)
 }
 
@@ -933,14 +955,9 @@ func (app *GaiaApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci
 	normalizeModuleAccount(ctx, app.AccountKeeper, vbanktypes.ProvisionPoolName)
 	normalizeModuleAccount(ctx, app.AccountKeeper, vbanktypes.ReservePoolName)
 
+	// Init early (before first BeginBlock) to run the potentially lengthy bootstrap
 	if app.bootstrapNeeded {
-		err := app.BootstrapController(ctx)
-		// fmt.Fprintf(os.Stderr, "BOOTSTRAP_BLOCK Returned from swingset: %s, %v\n", out, err)
-		if err != nil {
-			// NOTE: A failed BOOTSTRAP_BLOCK means that the SwingSet state is inconsistent.
-			// Panic here, in the hopes that a replay from scratch will fix the problem.
-			panic(err)
-		}
+		app.initController(ctx, true)
 	}
 
 	// Agoric: report the genesis time explicitly.

--- a/golang/cosmos/x/swingset/module.go
+++ b/golang/cosmos/x/swingset/module.go
@@ -80,16 +80,18 @@ func (AppModuleBasic) GetTxCmd() *cobra.Command {
 
 type AppModule struct {
 	AppModuleBasic
-	keeper             Keeper
-	setBootstrapNeeded func()
+	keeper                 Keeper
+	setBootstrapNeeded     func()
+	ensureControllerInited func(sdk.Context)
 }
 
 // NewAppModule creates a new AppModule Object
-func NewAppModule(k Keeper, setBootstrapNeeded func()) AppModule {
+func NewAppModule(k Keeper, setBootstrapNeeded func(), ensureControllerInited func(sdk.Context)) AppModule {
 	am := AppModule{
-		AppModuleBasic:     AppModuleBasic{},
-		keeper:             k,
-		setBootstrapNeeded: setBootstrapNeeded,
+		AppModuleBasic:         AppModuleBasic{},
+		keeper:                 k,
+		setBootstrapNeeded:     setBootstrapNeeded,
+		ensureControllerInited: ensureControllerInited,
 	}
 	return am
 }
@@ -127,6 +129,8 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
+	am.ensureControllerInited(ctx)
+
 	err := BeginBlock(ctx, req, am.keeper)
 	if err != nil {
 		fmt.Println("BeginBlock error:", err)

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -45,8 +45,6 @@ import { performStateSyncImport } from './import-kernel-db.js';
 // eslint-disable-next-line no-unused-vars
 let whenHellFreezesOver = null;
 
-const AG_COSMOS_INIT = 'AG_COSMOS_INIT';
-
 const TELEMETRY_SERVICE_NAME = 'agd-cosmos';
 
 const toNumber = specimen => {
@@ -619,7 +617,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     await null;
 
     switch (action.type) {
-      case AG_COSMOS_INIT: {
+      case ActionType.AG_COSMOS_INIT: {
         // console.error('got AG_COSMOS_INIT', action);
 
         !blockingSend || Fail`Swingset already initialized`;
@@ -644,7 +642,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
         // Ensure that initialization has completed.
         blockingSend = await launchAndInitializeSwingSet(action);
 
-        return true;
+        return blockingSend(action);
       }
 
       // Snapshot actions are specific to cosmos chains and handled here

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -673,13 +673,8 @@ export async function launch({
   // Handle block related actions
   // Some actions that are integration specific may be handled by the caller
   // For example COSMOS_SNAPSHOT is handled in chain-main.js
-  async function blockingSend(action) {
-    if (decohered) {
-      throw decohered;
-    }
-
-    await afterCommitWorkDone;
-
+  async function doBlockingSend(action) {
+    await null;
     // blockManagerConsole.warn(
     //   'FIGME: blockHeight',
     //   action.blockHeight,
@@ -842,7 +837,7 @@ export async function launch({
 
           // We write out our on-chain state as a number of chainSends.
           const start = Date.now();
-          await Promise.all([saveChainState(), pendingSwingStoreExport]);
+          await saveChainState();
           chainTime = Date.now() - start;
 
           // Advance our saved state variables.
@@ -864,6 +859,15 @@ export async function launch({
         throw Fail`Unrecognized action ${action}; are you sure you didn't mean to queue it?`;
       }
     }
+  }
+  async function blockingSend(action) {
+    if (decohered) {
+      throw decohered;
+    }
+
+    await afterCommitWorkDone;
+
+    return doBlockingSend(action).finally(() => pendingSwingStoreExport);
   }
 
   async function shutdown() {

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -672,7 +672,7 @@ export async function launch({
 
   // Handle block related actions
   // Some actions that are integration specific may be handled by the caller
-  // For example COSMOS_SNAPSHOT and AG_COSMOS_INIT are handled in chain-main.js
+  // For example COSMOS_SNAPSHOT is handled in chain-main.js
   async function blockingSend(action) {
     if (decohered) {
       throw decohered;
@@ -687,9 +687,12 @@ export async function launch({
     //   action.type,
     // );
     switch (action.type) {
-      case ActionType.BOOTSTRAP_BLOCK: {
+      case ActionType.AG_COSMOS_INIT: {
+        const { isBootstrap, blockTime } = action;
         // This only runs for the very first block on the chain.
-        const { blockTime } = action;
+        if (!isBootstrap) {
+          return true;
+        }
         verboseBlocks && blockManagerConsole.info('block bootstrap');
         if (savedHeight !== 0) {
           throw Error(`Cannot run a bootstrap block at height ${savedHeight}`);
@@ -718,7 +721,7 @@ export async function launch({
           type: 'cosmic-swingset-bootstrap-block-finish',
           blockTime,
         });
-        return undefined;
+        return true;
       }
 
       case ActionType.COMMIT_BLOCK: {

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -201,11 +201,12 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
       return;
     }
     // The before-first-block is special... do it now.
-    // This emulates what x/swingset does to run a BOOTSTRAP_BLOCK
+    // This emulates what x/swingset does when bootstrapping
     // before continuing with the real initialHeight.
     await blockingSend({
-      type: 'BOOTSTRAP_BLOCK',
+      type: 'AG_COSMOS_INIT',
       blockTime: scaleBlockTime(Date.now()),
+      isBootstrap: true,
     });
     blockHeight = initialHeight;
   };

--- a/packages/internal/src/action-types.js
+++ b/packages/internal/src/action-types.js
@@ -1,6 +1,6 @@
 // @jessie-check
 
-export const BOOTSTRAP_BLOCK = 'BOOTSTRAP_BLOCK';
+export const AG_COSMOS_INIT = 'AG_COSMOS_INIT';
 export const COSMOS_SNAPSHOT = 'COSMOS_SNAPSHOT';
 export const BEGIN_BLOCK = 'BEGIN_BLOCK';
 export const CALCULATE_FEES_IN_BEANS = 'CALCULATE_FEES_IN_BEANS';

--- a/packages/telemetry/src/slog-to-otel.js
+++ b/packages/telemetry/src/slog-to-otel.js
@@ -908,6 +908,17 @@ export const makeSlogToOtelKit = (tracer, overrideAttrs = {}) => {
         dbTransactionManager.end();
         break;
       }
+      case 'cosmic-swingset-upgrade-start': {
+        dbTransactionManager.begin();
+        assert(!spans.top());
+        spans.push(['upgrade', slogAttrs.blockHeight]);
+        break;
+      }
+      case 'cosmic-swingset-upgrade-finish': {
+        spans.pop(['slogAttrs.blockHeight', slogAttrs.blockHeight]);
+        dbTransactionManager.end();
+        break;
+      }
       case 'cosmic-swingset-begin-block': {
         if (spans.topKind() === 'intra-block') {
           spans.pop('intra-block');


### PR DESCRIPTION

refs: #8060

## Description

While testing upgrade handlers and migrations for #8031, I encountered an issue where the swingset controller was initialized before the migration starts. #8060 refactored some of this logic, but didn't fix this issue.

This PR moves the init step to be triggered by the swingset module, and add guards making sure the upgrade handler is executed before init.
It also consolidates the bootstrap into the init message, which will allow the JS side to have stronger assertions about the expected swing-store state when initializing.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None, internal logic. Add some comments about the different use cases supported

### Testing Considerations

The existing docker upgrade test should cover the new assertion, and any cosmic-swingset test already covers the bootstrap logic. Further tests will be added in the migration PR addressing #8031

### Upgrade Considerations

None, this simply enforces what were the expected upgrade start flow.