### PR TITLE
chore(smart-wallet): don't try to distinguish presences statically

### DIFF
--- a/packages/smart-wallet/src/invitations.js
+++ b/packages/smart-wallet/src/invitations.js
@@ -62,7 +62,7 @@ const MAX_PIPE_LENGTH = 2;
  * @param {ERef<NameHub>} agoricNames
  * @param {Brand<'set'>} invitationBrand
  * @param {Purse<'set'>} invitationsPurse
- * @param {(fromOfferId: string) => import('./types').RemoteInvitationMakers} getInvitationContinuation
+ * @param {(fromOfferId: string) => import('./types').InvitationMakers} getInvitationContinuation
  */
 export const makeInvitationsHelper = (
   zoe,

--- a/packages/smart-wallet/src/offers.js
+++ b/packages/smart-wallet/src/offers.js
@@ -35,9 +35,9 @@ export const UNPUBLISHED_RESULT = 'UNPUBLISHED';
  * @param {object} opts.powers
  * @param {Pick<Console, 'info'| 'error'>} opts.powers.logger
  * @param {(spec: import('./invitations').InvitationSpec) => ERef<Invitation>} opts.powers.invitationFromSpec
- * @param {(brand: Brand) => Promise<import('./types').RemotePurse>} opts.powers.purseForBrand
+ * @param {(brand: Brand) => Promise<Purse>} opts.powers.purseForBrand
  * @param {(status: OfferStatus) => void} opts.onStatusChange
- * @param {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers: import('./types').PublicSubscribers | import('@agoric/zoe/src/contractSupport').TopicsRecord ) => Promise<void>} opts.onNewContinuingOffer
+ * @param {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').InvitationMakers, publicSubscribers: import('./types').PublicSubscribers | import('@agoric/zoe/src/contractSupport').TopicsRecord ) => Promise<void>} opts.onNewContinuingOffer
  */
 export const makeOfferExecutor = ({
   zoe,

--- a/packages/smart-wallet/src/payments.js
+++ b/packages/smart-wallet/src/payments.js
@@ -5,7 +5,7 @@ import { E } from '@endo/far';
 /**
  * Used in an offer execution to manage payments state safely.
  *
- * @param {(brand: Brand) => Promise<import('./types').RemotePurse>} purseForBrand
+ * @param {(brand: Brand) => Promise<Purse>} purseForBrand
  * @param {{ receive: (payment: *) => Promise<Amount> }} depositFacet
  */
 export const makePaymentsHelper = (purseForBrand, depositFacet) => {
@@ -15,7 +15,7 @@ export const makePaymentsHelper = (purseForBrand, depositFacet) => {
   /**
    * Tracks from whence our payment came.
    *
-   * @type {Map<Payment, import('./types').RemotePurse>}
+   * @type {Map<Payment, Purse>}
    */
   const paymentToPurse = new Map();
 
@@ -28,7 +28,7 @@ export const makePaymentsHelper = (purseForBrand, depositFacet) => {
       !keywordPaymentPromises ||
         Fail`withdrawPayments can be called once per helper`;
       keywordPaymentPromises = objectMap(give, amount => {
-        /** @type {Promise<import('./types').RemotePurse<any>>} */
+        /** @type {Promise<Purse>} */
         const purseP = purseForBrand(amount.brand);
         return Promise.all([purseP, E(purseP).withdraw(amount)]).then(
           ([purse, payment]) => {

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -102,9 +102,6 @@ const { Fail, quote: q } = assert;
  * For use by clients to describe brands to users. Includes `displayInfo` to save a remote call.
  */
 
-// imports
-/** @typedef {import('./types').RemotePurse} RemotePurse */
-
 /**
  * @typedef {{
  *   address: string,
@@ -133,10 +130,10 @@ const { Fail, quote: q } = assert;
  *
  * @typedef {Readonly<UniqueParams & {
  *   paymentQueues: MapStore<Brand, Array<import('@endo/far').FarRef<Payment>>>,
- *   offerToInvitationMakers: MapStore<string, import('./types').RemoteInvitationMakers>,
+ *   offerToInvitationMakers: MapStore<string, import('./types').InvitationMakers>,
  *   offerToPublicSubscriberPaths: MapStore<string, Record<string, string>>,
  *   offerToUsedInvitation: MapStore<string, Amount>,
- *   purseBalances: MapStore<RemotePurse, Amount>,
+ *   purseBalances: MapStore<Purse, Amount>,
  *   updateRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<UpdateRecord>,
  *   currentRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').RecorderKit<CurrentWalletRecord>,
  *   liveOffers: MapStore<import('./offers.js').OfferId, import('./offers.js').OfferStatus>,
@@ -303,7 +300,7 @@ export const prepareSmartWallet = (baggage, shared) => {
           !used || Fail`cannot re-use offer id ${id}`;
         },
         /**
-         * @param {RemotePurse} purse
+         * @param {Purse} purse
          * @param {Amount<any>} balance
          */
         updateBalance(purse, balance) {
@@ -342,7 +339,7 @@ export const prepareSmartWallet = (baggage, shared) => {
           });
         },
 
-        /** @type {(purse: ERef<RemotePurse>) => Promise<void>} */
+        /** @type {(purse: ERef<Purse>) => Promise<void>} */
         async watchPurse(purseRef) {
           const { address } = this.state;
 
@@ -445,14 +442,13 @@ export const prepareSmartWallet = (baggage, shared) => {
               ),
               /**
                * @param {Brand} brand
-               * @returns {Promise<RemotePurse>}
+               * @returns {Promise<Purse>}
                */
               purseForBrand: async brand => {
                 if (registry.has(brand)) {
-                  // @ts-expect-error RemotePurse cast
+                  // @ts-expect-error virtual purse
                   return E(bank).getPurse(brand);
                 } else if (invitationBrand === brand) {
-                  // @ts-expect-error RemotePurse cast
                   return invitationPurse;
                 }
                 throw Fail`cannot find/make purse for ${brand}`;
@@ -479,7 +475,7 @@ export const prepareSmartWallet = (baggage, shared) => {
                 }
               }
             },
-            /** @type {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').RemoteInvitationMakers, publicSubscribers?: import('./types').PublicSubscribers | import('@agoric/zoe/src/contractSupport').TopicsRecord) => Promise<void>} */
+            /** @type {(offerId: string, invitationAmount: Amount<'set'>, invitationMakers: import('./types').InvitationMakers, publicSubscribers?: import('./types').PublicSubscribers | import('@agoric/zoe/src/contractSupport').TopicsRecord) => Promise<void>} */
             onNewContinuingOffer: async (
               offerId,
               invitationAmount,
@@ -604,7 +600,6 @@ export const prepareSmartWallet = (baggage, shared) => {
         const { invitationPurse } = state;
         const { helper } = facets;
 
-        // @ts-expect-error RemotePurse cast
         void helper.watchPurse(invitationPurse);
       },
     },

--- a/packages/smart-wallet/src/types.d.ts
+++ b/packages/smart-wallet/src/types.d.ts
@@ -5,7 +5,7 @@
  * Downside is it can't reference any ambient types, which most of agoric-sdk type are presently.
  */
 
-import type { ERef, FarRef } from '@endo/far';
+import type { ERef } from '@endo/far';
 import type { CapData } from '@endo/marshal';
 import type { MsgWalletSpendAction } from '@agoric/cosmic-proto/swingset/msgs';
 import type { AgoricNamesRemotes } from '@agoric/vats/tools/board-utils.js';
@@ -21,10 +21,9 @@ declare const CapDataShape: unique symbol;
  */
 export type Petname = string | string[];
 
-export type RemotePurse<T = unknown> = FarRef<Purse<T>>;
-
-export type RemoteInvitationMakers = FarRef<
-  Record<string, (...args: any[]) => Promise<Invitation>>
+export type InvitationMakers = Record<
+  string,
+  (...args: any[]) => Promise<Invitation>
 >;
 
 export type PublicSubscribers = Record<string, ERef<StoredFacet>>;


### PR DESCRIPTION
refs: #7226, #8071

## Description

Using static types to distinguish a Purse from a presence-for-a-Purse (likewise Payment) is not common in our code; the attempt to do it here seems to cause unwarranted friction.

### Security...Testing Considerations

none; types only
