### PR TITLE
fix: tolerate golden error property orders

### DIFF
--- a/packages/inter-protocol/test/smartWallet/test-psm-integration.js
+++ b/packages/inter-protocol/test/smartWallet/test-psm-integration.js
@@ -465,7 +465,9 @@ test('agoricName invitation source errors', async t => {
     }),
     {
       message:
-        '{"source":"agoricContract","instancePath":["psm-IST-AUSD"]} - Must have missing properties ["callPipe"]',
+        // TODO The pattern is here only as a temporary measure to tolerate
+        // the property order being sorted and not.
+        /\{("instancePath":\["psm-IST-AUSD"\]|,|"source":"agoricContract"){3}\} - Must have missing properties \["callPipe"\]/,
     },
   );
   t.is(await E.get(getBalanceFor(anchor.brand)).value, 0n);

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -231,7 +231,9 @@ test('cleanProposal - other wrong stuff', t => {
     t,
     { exit: { afterDeadline: 'foo' } },
     'nat',
-    /"foo" - Must be a copyRecord to match a copyRecord pattern: {"timer":.*/,
+    // TODO The outer pattern is here only as a temporary measure to tolerate
+    // the property order being sorted and not.
+    /"foo" - Must be a copyRecord to match a copyRecord pattern: \{("deadline":.*|,|"timer":.*){3}\}/,
   );
   proposeBad(
     t,
@@ -249,7 +251,9 @@ test('cleanProposal - other wrong stuff', t => {
     t,
     { exit: { afterDeadline: { timer, deadline: 3n, extra: 'foo' } } },
     'nat',
-    'proposal: exit: afterDeadline?: {"timer":"[Alleged: ManualTimer]","deadline":"[3n]","extra":"foo"} - Must not have unexpected properties: ["extra"]',
+    // TODO The pattern is here only as a temporary measure to tolerate
+    // the property order being sorted and not.
+    /proposal: exit: afterDeadline\?: \{("deadline":"\[3n\]"|,|"extra":"foo"|,|"timer":"\[Alleged: ManualTimer\]"){5}\} - Must not have unexpected properties: \["extra"\]/,
   );
   proposeBad(
     t,

--- a/packages/zoe/test/unitTests/test-testHelpers.js
+++ b/packages/zoe/test/unitTests/test-testHelpers.js
@@ -72,8 +72,10 @@ test('assertAmountsEqual - Nat vs. Set', async t => {
     harden({ brand: shinyAmount.brand, value: 0n }),
   );
   const message =
-    'Asset kinds must match: got [{"name":"hat","description":"hat","power":"shiny"}], expected "[0n]"';
-  t.is(fakeT.getError(), message);
+    // TODO The pattern is here only as a temporary measure to tolerate
+    // the property order being sorted and not.
+    /Asset kinds must match: got \[\{("description":"hat"|,|"name":"hat"|,|"power":"shiny"){5}\}\], expected "\[0n\]"/;
+  t.assert(message.test(fakeT.getError()));
   await t.throwsAsync(resultP, { message });
 });
 
@@ -87,8 +89,10 @@ test('assertAmountsEqual - false Set', async t => {
   const fakeT = makeFakeT();
   const resultP = assertAmountsEqual(fakeT, shinyAmount, sparklyAmount);
   const message =
-    'Values must match: got [{"name":"hat","description":"hat","power":"shiny"}], expected [{"name":"hat","description":"hat","power":"sparkly"}]';
-  t.is(fakeT.getError(), message);
+    // TODO The pattern is here only as a temporary measure to tolerate
+    // the property order being sorted and not.
+    /Values must match: got \[\{("description":"hat"|,|"name":"hat"|,|"power":"shiny"){5}\}\], expected \[\{("description":"hat"|,|"name":"hat"|,|"power":"sparkly){5}"\}\]/;
+  t.assert(message.test(fakeT.getError()));
   await t.throwsAsync(resultP, { message });
 });
 


### PR DESCRIPTION
https://github.com/endojs/endo/pull/1678 is now merged into endo. It ensures the property order seen in error message is in sorted order. That fix breaks goldens using non-sorted orders, which are inherently fragile anyway. But agoric-sdk currently depends on an endo prior to https://github.com/endojs/endo/pull/1678 .

Specifically for those tests that would be broken by https://github.com/endojs/endo/pull/1678 , this PR changes them to be tolerant of being in sorted order or not.

https://github.com/Agoric/agoric-sdk/pull/8055 is just like this PR but tested against "current" endo master. If both are green under CI, then this PR should prepare agoric-sdk for that upgrade without breaking it in the meantime.
