### PR TITLE
feat(x/swingset): include swing-store in genesis

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -126,6 +126,14 @@ import (
 
 const appName = "agoric"
 
+// FlagSwingStoreExportDir defines the config flag used to specify where a
+// genesis swing-store export is expected. For start from genesis, the default
+// value is config/swing-store in the home directory. For genesis export, the
+// value is always a "swing-store" directory sibling to the exported
+// genesis.json file.
+// TODO: document this flag in config, likely alongside the genesis path
+const FlagSwingStoreExportDir = "swing-store-export-dir"
+
 var (
 	// DefaultNodeHome default home directories for the application daemon
 	DefaultNodeHome string
@@ -588,6 +596,7 @@ func NewAgoricApp(
 	app.EvidenceKeeper = *evidenceKeeper
 
 	skipGenesisInvariants := cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
+	swingStoreExportDir := cast.ToString(appOpts.Get(FlagSwingStoreExportDir))
 
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
@@ -617,7 +626,7 @@ func NewAgoricApp(
 		transferModule,
 		icaModule,
 		vstorage.NewAppModule(app.VstorageKeeper),
-		swingset.NewAppModule(app.SwingSetKeeper, setBootstrapNeeded, app.ensureControllerInited),
+		swingset.NewAppModule(app.SwingSetKeeper, &app.SwingStoreExportsHandler, setBootstrapNeeded, app.ensureControllerInited, swingStoreExportDir),
 		vibcModule,
 		vbankModule,
 		lienModule,

--- a/golang/cosmos/cmd/agd/main.go
+++ b/golang/cosmos/cmd/agd/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	// We need to delegate to our default app for running the actual chain.
-	daemoncmd.OnStartHook = func(logger log.Logger) {
+	launchVM := func(logger log.Logger) {
 		args := []string{"ag-chain-cosmos", "--home", gaia.DefaultNodeHome}
 		args = append(args, os.Args[1:]...)
 
@@ -22,12 +22,15 @@ func main() {
 			panic(lookErr)
 		}
 
-		logger.Info("Start chain delegating to JS executable", "binary", binary, "args", args)
+		logger.Info("agd delegating to JS executable", "binary", binary, "args", args)
 		execErr := syscall.Exec(binary, args, os.Environ())
 		if execErr != nil {
 			panic(execErr)
 		}
 	}
+
+	daemoncmd.OnStartHook = launchVM
+	daemoncmd.OnExportHook = launchVM
 
 	daemon.RunWithController(nil)
 }

--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
@@ -242,6 +243,13 @@ func (ac appCreator) newApp(
 	}
 
 	homePath := cast.ToString(appOpts.Get(flags.FlagHome))
+
+	// Set a default value for FlagSwingStoreExportDir based on the homePath
+	// in case we need to InitGenesis with swing-store data
+	viper, ok := appOpts.(*viper.Viper)
+	if ok && cast.ToString(appOpts.Get(gaia.FlagSwingStoreExportDir)) == "" {
+		viper.Set(gaia.FlagSwingStoreExportDir, filepath.Join(homePath, "config", ExportedSwingStoreDirectoryName))
+	}
 
 	snapshotDir := filepath.Join(homePath, "data", "snapshots")
 	snapshotDB, err := sdk.NewLevelDB("metadata", snapshotDir)

--- a/golang/cosmos/daemon/cmd/root.go
+++ b/golang/cosmos/daemon/cmd/root.go
@@ -40,7 +40,8 @@ import (
 type Sender func(needReply bool, str string) (string, error)
 
 var AppName = "agd"
-var OnStartHook func(log.Logger)
+var OnStartHook func(logger log.Logger)
+var OnExportHook func(logger log.Logger)
 
 // NewRootCmd creates a new root command for simd. It is called once in the
 // main function.
@@ -272,6 +273,9 @@ func (ac appCreator) appExport(
 	jailAllowedAddrs []string,
 	appOpts servertypes.AppOptions,
 ) (servertypes.ExportedApp, error) {
+	if OnExportHook != nil {
+		OnExportHook(logger)
+	}
 
 	homePath, ok := appOpts.Get(flags.FlagHome).(string)
 	if !ok || homePath == "" {

--- a/golang/cosmos/x/swingset/module.go
+++ b/golang/cosmos/x/swingset/module.go
@@ -163,7 +163,8 @@ func (am AppModule) checkSwingStoreExportSetup() {
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.RawMessage) []abci.ValidatorUpdate {
 	var genesisState types.GenesisState
 	cdc.MustUnmarshalJSON(data, &genesisState)
-	bootstrapNeeded := InitGenesis(ctx, am.keeper, &genesisState)
+	am.checkSwingStoreExportSetup()
+	bootstrapNeeded := InitGenesis(ctx, am.keeper, am.swingStoreExportsHandler, am.swingStoreExportDir, &genesisState)
 	if bootstrapNeeded {
 		am.setBootstrapNeeded()
 	}

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -584,7 +584,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
           );
         });
 
-        console.info(
+        console.warn(
           'Initiating SwingSet state snapshot at block height',
           blockHeight,
           'with options',

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -351,7 +351,7 @@ export const main = async (
     {
       fs,
       pathResolve,
-      log: verbose ? console.log : null,
+      log: verbose ? console.warn : null,
     },
   );
 

--- a/packages/cosmic-swingset/test/scenario2.js
+++ b/packages/cosmic-swingset/test/scenario2.js
@@ -81,7 +81,10 @@ export const makeScenario2 = ({ pspawnMake, pspawnAgd, log }) => {
       return runMake(['scenario2-run-rosetta-ci'], { stdio: onlyStderr });
     },
     export: () =>
-      pspawnAgd(['export', '--home=t1/n0'], { stdio: onlyStderr }).exit,
+      pspawnAgd(
+        ['export', '--home=t1/n0', '--export-dir=t1/n0/genesis-export'],
+        { stdio: onlyStderr },
+      ).exit,
   });
 };
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/actions.sh
@@ -18,7 +18,6 @@ mv -n $HOME/.agoric/data/agoric/swing-store-historical-artifacts/* $EXPORT_DIR |
 mv $EXPORT_DIR/export-manifest.json $EXPORT_DIR/export-manifest-original.json
 cat $EXPORT_DIR/export-manifest-original.json | jq -r ".artifacts = .artifacts + [${HISTORICAL_ARTIFACTS%%,}] | del(.artifactMode)" > $EXPORT_DIR/export-manifest.json
 restore_swing_store_snapshot $EXPORT_DIR || fail "Couldn't restore swing-store snapshot"
-rmdir $HOME/.agoric/data/agoric/swing-store-historical-artifacts
 rm -rf $EXPORT_DIR
 startAgd
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/actions.sh
@@ -11,8 +11,7 @@ upgrade11=./upgrade-test-scripts/agoric-upgrade-11
 # hacky restore of pruned artifacts
 killAgd
 EXPORT_DIR=$(mktemp -t -d swing-store-export-upgrade-11-XXX)
-make_swing_store_snapshot $EXPORT_DIR --artifact-mode debug || fail "Couldn't make swing-store snapshot"
-test_val "$(compare_swing_store_export_data $EXPORT_DIR)" "match" "swing-store export data"
+WITHOUT_GENESIS_EXPORT=1 make_swing_store_snapshot $EXPORT_DIR --artifact-mode debug || fail "Couldn't make swing-store snapshot"
 HISTORICAL_ARTIFACTS="$(cd $HOME/.agoric/data/agoric/swing-store-historical-artifacts/; for i in *; do echo -n "[\"$i\",\"$i\"],"; done)"
 mv -n $HOME/.agoric/data/agoric/swing-store-historical-artifacts/* $EXPORT_DIR || fail "some historical artifacts not pruned"
 mv $EXPORT_DIR/export-manifest.json $EXPORT_DIR/export-manifest-original.json

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/env_setup.sh
@@ -86,14 +86,16 @@ pushPriceOnce () {
 }
 
 export_genesis() {
-  HEIGHT_ARG=
+  GENESIS_EXPORT_DIR="$1"
+  shift
+  GENESIS_HEIGHT_ARG=
 
   if [ -n "$1" ]; then
-    HEIGHT_ARG="--height $1"
+    GENESIS_HEIGHT_ARG="--height $1"
     shift
   fi
 
-  agd export $HEIGHT_ARG "$@"
+  agd export --export-dir "$GENESIS_EXPORT_DIR" $GENESIS_HEIGHT_ARG "$@"
 }
 
 make_swing_store_snapshot() {( set -euo pipefail
@@ -108,7 +110,8 @@ make_swing_store_snapshot() {( set -euo pipefail
   EXPORT_MANIFEST="$(cat $EXPORT_MANIFEST_FILE)"
 
   mv "$EXPORT_DATA_FILE" "$EXPORT_DATA_UNTRUSTED_FILE"
-  export_genesis $EXPORT_HEIGHT | jq -cr '.app_state.swingset.swing_store_export_data[] | [.key,.value]' > "$EXPORT_DATA_FILE"
+  export_genesis "$EXPORT_DIR/genesis-export" $EXPORT_HEIGHT 
+  cat $EXPORT_DIR/genesis-export/genesis.json | jq -cr '.app_state.swingset.swing_store_export_data[] | [.key,.value]' > "$EXPORT_DATA_FILE"
 
   jq -n "$EXPORT_MANIFEST | .untrustedData=\"$(basename -- "$EXPORT_DATA_UNTRUSTED_FILE")\"" > "$EXPORT_MANIFEST_FILE"
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-11/test.sh
@@ -8,13 +8,21 @@ waitForBlock 2
 # CWD is agoric-sdk
 upgrade11=./upgrade-test-scripts/agoric-upgrade-11
 
-# verify swing-store export-data is consistent
+# verify swing-store export-data is consistent and perform genesis style "upgrade"
 killAgd
 EXPORT_DIR=$(mktemp -t -d swing-store-export-upgrade-11-XXX)
 make_swing_store_snapshot $EXPORT_DIR --artifact-mode none || fail "Couldn't make swing-store snapshot"
-test_val "$(compare_swing_store_export_data $EXPORT_DIR)" "match" "swing-store consistent state-sync"
-rm -rf $EXPORT_DIR
+test_val "$(compare_swing_store_export_data $EXPORT_DIR)" "match" "swing-store consistent cosmos kvstore"
+
+TMP_GENESIS_DIR=$EXPORT_DIR/genesis-export
+cp $HOME/.agoric/config/genesis.json $TMP_GENESIS_DIR/old_genesis.json
+cp $HOME/.agoric/data/priv_validator_state.json $TMP_GENESIS_DIR/priv_validator_state.json
+rm -rf $HOME/.agoric/data
+mkdir $HOME/.agoric/data
+mv $TMP_GENESIS_DIR/priv_validator_state.json $HOME/.agoric/data
+mv $TMP_GENESIS_DIR/* $HOME/.agoric/config/
 startAgd
+rm -rf $EXPORT_DIR
 
 # zoe vat is at incarnation 1
 echo "FIXME: bypassed zoe-full-upgrade validation"; return 0


### PR DESCRIPTION
closes: #6527

## Description

This PR adds swing-store artifacts to the genesis export, and the ability to start from a genesis that includes a full swing-store export.

The artifacts are exported and imported from a directory alongside the `genesis.json` file, instead of being inlined like other state.

While the full swing-store state is now included in the genesis state, it doesn't mean it's editable in any kind of capacity. Most swingset state is likely replicated in multiple places inside the swing-store, like transcripts and xsnap heap snapshots.

### Security Considerations

As with any genesis start, the validators are in charge of verifying the validity of the genesis file against an expected hash, this PR does not change that.

They do not need to perform manual validation of the artifacts since those are checked for consistency by the swing-store import process, using metadata stored in the genesis file.

### Scaling Considerations

The swing-store artifacts are pretty large binary blobs, and as such are not included in the protobuf (genesis state) that ends up JSON serialized. However their size is still significant, and I believe a genesis export of mainnet would result in a total size of about 10GB today. Validators may want to exchange the genesis and artifacts compressed as that should compress down to about 800MB as seen with state-sync snapshots.

### Documentation Considerations

A new `--export-dir` option is required for `agd export` to specify a path to a directory where the genesis export process will create the `genesis.json` file and a `swing-store` directory containing the swing-store export artifacts. On start from genesis, this `swing-store` directory must be placed in the `config` folder of the node's home (alongside where the `genesis.json` usual reside), at least until InitGenesis has completed.

We do not expect this mechanism to be used for normal operations, just as a backstop in case of chain failure.

### Testing Considerations

Added a genesis test to the docker upgrade test framework.

### Upgrade Considerations

While this mechanism can be used for manual chain upgrades, it is fully transparent to any swingset operation.