### PR TITLE
ci(restore-node): avoid clobbering `#endo-branch:` setup

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -27,13 +27,13 @@ runs:
       shell: bash
     - uses: actions/checkout@v3
       with:
-        clean: 'false'
+        clean: false
         submodules: 'true'
         persist-credentials: false
         path: ${{ inputs.path }}
     # Select a branch on Endo to test against by adding text to the body of the
     # pull request. For example: #endo-branch: some-pr-branch
-    # The default is '*NONE*' to indicate not to check out Endo, just use
+    # The default is '*NOPE*' to indicate not to check out Endo, just use
     # the published NPM packages.
     - name: Get the appropriate Endo branch
       id: endo-branch
@@ -111,8 +111,8 @@ runs:
         mkdir -p node_modules/.cache/agoric
         date > node_modules/.cache/agoric/yarn-installed
         if test -e ~/endo; then
-          # Remove traces of the redirected `yarn install`.
-          git restore package.json yarn.lock
+          # Stage the redirected `yarn install` consequences.
+          git add package.json yarn.lock
           rm -rf ~/endo
         fi
       shell: bash
@@ -131,9 +131,11 @@ runs:
     - name: git dirty check
       working-directory: ${{ inputs.path }}
       run: |-
-        if [ -n "$(git status --porcelain)" ];
-        then
+        set -x
+        # In case of Endo override, ignore staged changes.
+        if [ -n "$(git status --porcelain | grep -Eve '^A  '; true)" ]; then
           git status
+          echo "Unexpected dirty git status" 1>&2
           exit 1
         fi
       shell: bash


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

#not-endo-branch: markm-options-harmony
closes: #8148

## Description

As described in https://github.com/Agoric/agoric-sdk/issues/8148#issuecomment-1667184868 , fix two problems with the `.github/actions/restore-node` composite CI action that interacted badly with the `#endo-branch:` PR setting.

Background: the `#endo-branch: XXX` comment in a PR description will cause `restore-node` to override package references in `yarn.lock` with packages built from the `XXX` branch of https://github.com/endojs/endo

The compounding problems:
1. `restore-node` patched `package.json` and then, after running `yarn install`, restored it and `yarn.lock`.  This meant any subsequent installs would overwrite packages installed by the override with the repository default versions.
2. `restore-node` also used `clean: 'false'` instead of `clean: false`.  The string `'false'` is truthy, so that caused `test-cosmic-swingset`'s use of `bin/agd` to detect changes in installation timestamps and thereby rerun `yarn install`, provoking the above problem.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
n/a

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Slightly speeds up `test-cosmic-swingset`.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
n/a

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Tested by examining the output of `#endo-branch: markm-options-harmony`'s run of `test-cosmic-swingset`.

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
n/a