### PR TITLE
fix(upgrade-test): use correct mainnet-1b image

### DIFF
--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -57,7 +57,7 @@ RUN . ./upgrade-test-scripts/start_to_to.sh
 
 ARG DEST_IMAGE
 #this is agoric-upgrade-10 / vaults
-FROM ghcr.io/agoric/agoric-sdk:34 as agoric-upgrade-10
+FROM ghcr.io/agoric/agoric-sdk:35 as agoric-upgrade-10
 ARG BOOTSTRAP_MODE
 ENV THIS_NAME=agoric-upgrade-10 UPGRADE_TO=agoric-upgrade-11 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 


### PR DESCRIPTION
## Description

I mistakenly used the wrong image for mainnet1b, it should be `agoric-sdk:35`, and we use the previous rc.

### Security Considerations

Ensures correctness between what's deployed and what we test against. 

### Scaling Considerations

N/A

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

This should correct the tests.

### Upgrade Considerations

Same as security and testing -- this enables testing against the correct versions.
