### PR TITLE
feat(upgrade-test): plumb and use `UPGRADE_INFO`

### DIFF
--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -73,7 +73,7 @@ RUN . ./upgrade-test-scripts/start_to_to.sh
 ARG DEST_IMAGE
 #this is agoric-upgrade-10 upgrading to 11
 #it's a separate target because agoric-upgrade-10 takes so long to test
-FROM ghcr.io/agoric/agoric-sdk:34 as agoric-upgrade-10-to-11
+FROM ghcr.io/agoric/agoric-sdk:35 as agoric-upgrade-10-to-11
 # This default UPGRADE_INFO_11 is to test core proposals like the network vat.
 # TODO: Maybe replace with a Zoe core proposal, or remove when other paths test it.
 ARG BOOTSTRAP_MODE UPGRADE_INFO_11='{"coreProposals":["@agoric/vats/scripts/init-network.js"]}'

--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -74,7 +74,9 @@ ARG DEST_IMAGE
 #this is agoric-upgrade-10 upgrading to 11
 #it's a separate target because agoric-upgrade-10 takes so long to test
 FROM ghcr.io/agoric/agoric-sdk:34 as agoric-upgrade-10-to-11
-ARG BOOTSTRAP_MODE UPGRADE_INFO_11
+# This default UPGRADE_INFO_11 is to test core proposals like the network vat.
+# TODO: Maybe replace with a Zoe core proposal, or remove when other paths test it.
+ARG BOOTSTRAP_MODE UPGRADE_INFO_11='{"coreProposals":["@agoric/vats/scripts/init-network.js"]}'
 ENV THIS_NAME=agoric-upgrade-10-to-11 UPGRADE_TO=agoric-upgrade-11 UPGRADE_INFO=${UPGRADE_INFO_11} BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/

--- a/packages/deployment/upgrade-test/Dockerfile
+++ b/packages/deployment/upgrade-test/Dockerfile
@@ -3,7 +3,8 @@ ARG BOOTSTRAP_MODE=main
 # on agoric-uprade-7-2, with upgrade to agoric-upgrade-8
 FROM ghcr.io/agoric/ag0:agoric-upgrade-7-2 as agoric-upgrade-7-2
 ARG BOOTSTRAP_MODE
-ENV UPGRADE_TO=agoric-upgrade-8 THIS_NAME=agoric-upgrade-7-2 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
+ARG UPGRADE_INFO_8
+ENV UPGRADE_TO=agoric-upgrade-8 UPGRADE_INFO=${UPGRADE_INFO_8} THIS_NAME=agoric-upgrade-7-2 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 RUN echo "${BOOTSTRAP_MODE}"
 RUN mkdir -p /usr/src/agoric-sdk/upgrade-test-scripts
 WORKDIR /usr/src/agoric-sdk/
@@ -28,8 +29,8 @@ RUN . ./upgrade-test-scripts/start_to_to.sh
 ARG DEST_IMAGE
 #this is agoric-upgrade-8-1 aka pismoB
 FROM ghcr.io/agoric/agoric-sdk:30 as agoric-upgrade-8-1
-ARG BOOTSTRAP_MODE
-ENV THIS_NAME=agoric-upgrade-8-1 UPGRADE_TO=agoric-upgrade-9 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
+ARG BOOTSTRAP_MODE UPGRADE_INFO_9
+ENV THIS_NAME=agoric-upgrade-8-1 UPGRADE_TO=agoric-upgrade-9 UPGRADE_INFO=${UPGRADE_INFO_9} BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
@@ -42,8 +43,8 @@ RUN . ./upgrade-test-scripts/start_to_to.sh
 ARG DEST_IMAGE
 # this is agoric-upgrade-9 / pismoC with upgrade to agoric-upgrade-10
 FROM ghcr.io/agoric/agoric-sdk:31 as agoric-upgrade-9
-ARG BOOTSTRAP_MODE
-ENV THIS_NAME=agoric-upgrade-9 UPGRADE_TO=agoric-upgrade-10 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
+ARG BOOTSTRAP_MODE UPGRADE_INFO_10
+ENV THIS_NAME=agoric-upgrade-9 UPGRADE_TO=agoric-upgrade-10 UPGRADE_INFO=${UPGRADE_INFO_10} BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
@@ -59,12 +60,27 @@ ARG DEST_IMAGE
 #this is agoric-upgrade-10 / vaults
 FROM ghcr.io/agoric/agoric-sdk:35 as agoric-upgrade-10
 ARG BOOTSTRAP_MODE
-ENV THIS_NAME=agoric-upgrade-10 UPGRADE_TO=agoric-upgrade-11 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
+ENV THIS_NAME=agoric-upgrade-10 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 
 WORKDIR /usr/src/agoric-sdk/
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
 COPY --from=agoric-upgrade-9 /root/.agoric /root/.agoric
+RUN chmod +x ./upgrade-test-scripts/*.sh
+SHELL ["/bin/bash", "-c"]
+RUN . ./upgrade-test-scripts/start_to_to.sh
+
+ARG DEST_IMAGE
+#this is agoric-upgrade-10 upgrading to 11
+#it's a separate target because agoric-upgrade-10 takes so long to test
+FROM ghcr.io/agoric/agoric-sdk:34 as agoric-upgrade-10-to-11
+ARG BOOTSTRAP_MODE UPGRADE_INFO_11
+ENV THIS_NAME=agoric-upgrade-10-to-11 UPGRADE_TO=agoric-upgrade-11 UPGRADE_INFO=${UPGRADE_INFO_11} BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
+
+WORKDIR /usr/src/agoric-sdk/
+COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
+COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
+COPY --from=agoric-upgrade-10 /root/.agoric /root/.agoric
 RUN chmod +x ./upgrade-test-scripts/*.sh
 SHELL ["/bin/bash", "-c"]
 RUN . ./upgrade-test-scripts/start_to_to.sh
@@ -79,7 +95,7 @@ ENV THIS_NAME=agoric-upgrade-11 BOOTSTRAP_MODE=${BOOTSTRAP_MODE}
 WORKDIR /usr/src/agoric-sdk/
 COPY ./bash_entrypoint.sh ./env_setup.sh ./start_to_to.sh ./upgrade-test-scripts/
 COPY ./${THIS_NAME} ./upgrade-test-scripts/${THIS_NAME}/
-COPY --from=agoric-upgrade-10 /root/.agoric /root/.agoric
+COPY --from=agoric-upgrade-10-to-11 /root/.agoric /root/.agoric
 RUN apt install -y tmux
 SHELL ["/bin/bash", "-c"]
 RUN chmod +x ./upgrade-test-scripts/*.sh

--- a/packages/deployment/upgrade-test/Makefile
+++ b/packages/deployment/upgrade-test/Makefile
@@ -46,11 +46,18 @@ build: $(TARGET)
 build_test: BOOTSTRAP_MODE=test
 build_test: $(TARGET)
 
+DEBUG ?= SwingSet:ls,SwingSet:vat
+RUN = docker run --rm -it \
+	-p 26656:26656 -p 26657:26657 -p 1317:1317 \
+	-v "$${PWD}:/workspace" \
+	-e "DEST=1" -e "DEBUG=$(DEBUG)"
+
 run:
-	docker run --rm -it -e "DEST=1" -e "TMUX_USE_CC=$(tmuxCC)" -p 26656:26656 -p 26657:26657 -p 1317:1317 --entrypoint "/usr/src/agoric-sdk/upgrade-test-scripts/start_to_to.sh" -v "$${PWD}:/workspace" $(REPOSITORY):$(dockerLabel)
+	$(RUN) -e "TMUX_USE_CC=$(tmuxCC)" \
+		--entrypoint /usr/src/agoric-sdk/upgrade-test-scripts/start_to_to.sh \
+		 $(REPOSITORY):$(dockerLabel)
 
 run_bash:
-	docker run --rm -it -e "DEST=1" -p 26656:26656 -p 26657:26657 -p 1317:1317\
-   --entrypoint "/bin/bash" -v "$${PWD}:/workspace" $(REPOSITORY):$(dockerLabel)
+	$(RUN) --entrypoint /bin/bash $(REPOSITORY):$(dockerLabel)
 
 .PHONY: local_sdk agoric-upgrade-7-2 agoric-upgrade-8 agoric-upgrade-8-1 agoric-upgrade-9 agoric-upgrade-10 agoric-upgrade-11 build build_test run

--- a/packages/deployment/upgrade-test/Makefile
+++ b/packages/deployment/upgrade-test/Makefile
@@ -14,23 +14,30 @@ endif
 local_sdk:
 	(cd ../ && make docker-build-sdk)
 
+BUILD = docker build --progress=plain $(BUILD_OPTS) \
+	--build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --build-arg DEST_IMAGE=$(DEST_IMAGE) \
+	-f Dockerfile upgrade-test-scripts
+
 agoric-upgrade-7-2:
-	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --build-arg DEST_IMAGE=$(DEST_IMAGE) --progress=plain --target agoric-upgrade-7-2 -t $(REPOSITORY):agoric-upgrade-7-2 -f Dockerfile upgrade-test-scripts
+	$(BUILD) --target agoric-upgrade-7-2 -t $(REPOSITORY):agoric-upgrade-7-2
 
 agoric-upgrade-8: agoric-upgrade-7-2
-	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --build-arg DEST_IMAGE=$(DEST_IMAGE) --progress=plain --target agoric-upgrade-8 -t $(REPOSITORY):agoric-upgrade-8 -f Dockerfile upgrade-test-scripts
+	$(BUILD) --target agoric-upgrade-8 -t $(REPOSITORY):agoric-upgrade-8
 
 agoric-upgrade-8-1: agoric-upgrade-8
-	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --build-arg DEST_IMAGE=$(DEST_IMAGE) --progress=plain --target agoric-upgrade-8-1 -t $(REPOSITORY):agoric-upgrade-8-1 -f Dockerfile upgrade-test-scripts
+	$(BUILD) --target agoric-upgrade-8-1 -t $(REPOSITORY):agoric-upgrade-8-1
 
 agoric-upgrade-9: agoric-upgrade-8-1
-	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --build-arg DEST_IMAGE=$(DEST_IMAGE) --progress=plain --target agoric-upgrade-9 -t $(REPOSITORY):agoric-upgrade-9 -f Dockerfile upgrade-test-scripts
+	$(BUILD) --target agoric-upgrade-9 -t $(REPOSITORY):agoric-upgrade-9
 
 agoric-upgrade-10: agoric-upgrade-9
-	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --build-arg DEST_IMAGE=$(DEST_IMAGE) --progress=plain --target agoric-upgrade-10 -t $(REPOSITORY):agoric-upgrade-10 -f Dockerfile upgrade-test-scripts
+	$(BUILD) --target agoric-upgrade-10 -t $(REPOSITORY):agoric-upgrade-10
 
-agoric-upgrade-11: agoric-upgrade-10
-	docker build --build-arg BOOTSTRAP_MODE=$(BOOTSTRAP_MODE) --build-arg DEST_IMAGE=$(DEST_IMAGE) --progress=plain --target agoric-upgrade-11 -t $(REPOSITORY):agoric-upgrade-11 -f Dockerfile upgrade-test-scripts
+agoric-upgrade-10-to-11: agoric-upgrade-10
+	$(BUILD) --target agoric-upgrade-10-to-11 -t $(REPOSITORY):agoric-upgrade-10-to-11
+
+agoric-upgrade-11: agoric-upgrade-10-to-11
+	$(BUILD) --target agoric-upgrade-11 -t $(REPOSITORY):agoric-upgrade-11
 
 # build main bootstrap
 build: $(TARGET)

--- a/packages/deployment/upgrade-test/Readme.md
+++ b/packages/deployment/upgrade-test/Readme.md
@@ -77,6 +77,16 @@ docker ps
 docker attach sweet_edison
 ```
 
+**To pass specific `software-upgrade --upgrade-info`**
+
+```shell
+json='{"some":"json","here":123}'
+make build BUILD_OPTS="--build-arg UPGRADE_INFO_11='$json'"
+```
+
+Search this directory for `UPGRADE_INFO` if you want to see how it is plumbed
+through.
+
 **To test CLI**
 
 You can point your local CLI tools to the chain running in Docker. Our Docker config binds on the same port (26656) as running a local chain. So you can use the agoric-cli commands on the Docker chain the same way. But note that the Cosmos account keys will be different from in your dev keyring.

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/env_setup.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/env_setup.sh
@@ -202,12 +202,18 @@ voteLatestProposalAndWait() {
 
   while true; do
     status=$($binary q gov proposal $proposal -ojson | jq -r .status)
-    if [ "$status" == "PROPOSAL_STATUS_PASSED" ]; then
+    case $status in
+    PROPOSAL_STATUS_PASSED)
       break
-    else
-      echo "Waiting for proposal to pass"
+      ;;
+    PROPOSAL_STATUS_REJECTED)
+      echo "Proposal rejected"
+      exit 1
+      ;;
+    *)
+      echo "Waiting for proposal to pass (status=$status)"
       sleep 1
-    fi
+    esac
   done
 }
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/start_ag0.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/start_ag0.sh
@@ -65,7 +65,18 @@ if [[ "$BOOTSTRAP_MODE" == "test" ]]; then
   UPGRADE_TO=${UPGRADE_TO//agoric-/agorictest-}
 fi
 
-ag0 tx gov submit-proposal software-upgrade "$UPGRADE_TO" --upgrade-height="$height" --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" --from=validator --chain-id="$CHAINID" --yes --keyring-backend=test
+info=${UPGRADE_INFO-"{}"}
+if echo "$info" | jq .; then :
+else
+  status=$?
+  echo "Upgrade info is not valid JSON: $info"
+  exit $status
+fi
+ag0 tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
+  --upgrade-height="$height" --upgrade-info="$info" \
+  --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
+  --from=validator --chain-id="$CHAINID" \
+  --yes --keyring-backend=test
 waitForBlock
 
 voteLatestProposalAndWait

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/start_to_to.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/start_to_to.sh
@@ -39,7 +39,18 @@ if [[ "$DEST" != "1" ]]; then
   voting_period_s=10
   latest_height=$(agd status | jq -r .SyncInfo.latest_block_height)
   height=$(( $latest_height + $voting_period_s + 10 ))
-  agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" --upgrade-height="$height" --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" --from=validator --chain-id="$CHAINID" --yes --keyring-backend=test
+  info=${UPGRADE_INFO-"{}"}
+  if echo "$info" | jq .; then :
+  else
+    status=$?
+    echo "Upgrade info is not valid JSON: $info"
+    exit $status
+  fi
+  agd tx gov submit-proposal software-upgrade "$UPGRADE_TO" \
+    --upgrade-height="$height" --upgrade-info="$info" \
+    --title="Upgrade to ${UPGRADE_TO}" --description="upgrades" \
+    --from=validator --chain-id="$CHAINID" \
+    --yes --keyring-backend=test
   waitForBlock
 
   voteLatestProposalAndWait


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #8112

## Description

- parameterize the Docker upgrade test scripts to allow specifying `software-upgrade --upgrade-info=...` 
- split off `agoric-upgrade-10-to-11` from `agoric-upgrade-10` to avoid rerunning tests of 10 just because the upgrade to 11 changed.
- drive-by: make upgrade test more robust to rejected Cosmos governance proposals instead of polling forever
- update mainnet-1b tag to 35 since 34 was just a release candidate

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
n/a

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Makes running the agoric-upgrade-11 handler faster.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
n/a

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
n/a

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
Makes it easier to test the agoric-upgrade-11 handler.
