### PR TITLE
test: remove an inadvertent test.only addition

### DIFF
--- a/packages/inter-protocol/test/vaultFactory/test-storage.js
+++ b/packages/inter-protocol/test/vaultFactory/test-storage.js
@@ -20,7 +20,7 @@ test.before(async t => {
   trace(t, 'CONTEXT');
 });
 
-test.only('storage keys', async t => {
+test('storage keys', async t => {
   const { aeth, run } = t.context;
   const d = await makeManagerDriver(t);
 


### PR DESCRIPTION
## Description

I just noticed that #7868 introduced a `test.only` inadvertently. This removes it to re-expose the other tests there.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

I have a grep for `test.only` in my standard pre-submit, but I have to run it manually.

### Upgrade Considerations

None.