### PR TITLE
lint error on floating promises

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,8 +1,5 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-env node */
-const process = require('process');
-
-const lintTypes = !!process.env.AGORIC_ESLINT_TYPES;
 
 const deprecatedForLoanContract = [
   ['currency', 'brand, asset or another descriptor'],
@@ -34,26 +31,24 @@ const deprecatedTerminology = Object.fromEntries(
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  parserOptions: lintTypes
-    ? {
-        // this is not yet compatible with eslint lsp so it's conditioned on AGORIC_ESLINT_TYPES
-        EXPERIMENTAL_useProjectService: true,
-        sourceType: 'module',
-        project: [
-          './packages/*/tsconfig.json',
-          './packages/*/tsconfig.json',
-          './packages/wallet/*/tsconfig.json',
-          './tsconfig.json',
-        ],
-        tsconfigRootDir: __dirname,
-        extraFileExtensions: ['.cjs'],
-      }
-    : undefined,
+  parserOptions: {
+    // this is not yet compatible with eslint lsp so it's conditioned on AGORIC_ESLINT_TYPES
+    EXPERIMENTAL_useProjectService: true,
+    sourceType: 'module',
+    project: [
+      './packages/*/tsconfig.json',
+      './packages/*/tsconfig.json',
+      './packages/wallet/*/tsconfig.json',
+      './tsconfig.json',
+    ],
+    tsconfigRootDir: __dirname,
+    extraFileExtensions: ['.cjs'],
+  },
   plugins: ['@typescript-eslint', 'prettier'],
   extends: ['@agoric'],
   rules: {
     '@typescript-eslint/prefer-ts-expect-error': 'warn',
-    '@typescript-eslint/no-floating-promises': lintTypes ? 'warn' : 'off',
+    '@typescript-eslint/no-floating-promises': 'warn',
     // so that floating-promises can be explicitly permitted with void operator
     'no-void': ['error', { allowAsStatement: true }],
 

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,7 +48,7 @@ module.exports = {
   extends: ['@agoric'],
   rules: {
     '@typescript-eslint/prefer-ts-expect-error': 'warn',
-    '@typescript-eslint/no-floating-promises': 'warn',
+    '@typescript-eslint/no-floating-promises': 'error',
     // so that floating-promises can be explicitly permitted with void operator
     'no-void': ['error', { allowAsStatement: true }],
 

--- a/packages/SwingSet/misc-tools/extract-xs-snapshot.js
+++ b/packages/SwingSet/misc-tools/extract-xs-snapshot.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 import '@endo/init';
 import process from 'process';

--- a/packages/SwingSet/test/test-vat-timer.js
+++ b/packages/SwingSet/test/test-vat-timer.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 

--- a/packages/SwingSet/test/transcript/test-state-sync-reload.js
+++ b/packages/SwingSet/test/transcript/test-state-sync-reload.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import test from 'ava';
 import '@endo/init/debug.js';
 import tmp from 'tmp';

--- a/packages/SwingSet/test/transcript/test-transcript-entries.js
+++ b/packages/SwingSet/test/transcript/test-transcript-entries.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import test from 'ava';
 import '@endo/init/debug.js';
 import { initSwingStore } from '@agoric/swing-store';

--- a/packages/agoric-cli/src/bin-agops.js
+++ b/packages/agoric-cli/src/bin-agops.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // @ts-check
 // @jessie-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 /* global fetch, setTimeout */
 

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 /* global process setTimeout */
 import chalk from 'chalk';
 import { createHash } from 'crypto';

--- a/packages/boot/test/bootstrapTests/test-vaults-integration.js
+++ b/packages/boot/test/bootstrapTests/test-vaults-integration.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 /** @file Bootstrap test integration vaults with smart-wallet */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 

--- a/packages/boot/test/bootstrapTests/test-zcf-upgrade.js
+++ b/packages/boot/test/bootstrapTests/test-zcf-upgrade.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import bundleSource from '@endo/bundle-source';

--- a/packages/cosmic-swingset/scripts/clean-core-eval.js
+++ b/packages/cosmic-swingset/scripts/clean-core-eval.js
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import '@endo/init/debug.js';
 import * as farExports from '@endo/far';
 import { isEntrypoint } from '../src/helpers/is-entrypoint.js';

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeExo, keyEQ, makeScalarMapStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';

--- a/packages/governance/src/contractGovernance/paramManager.js
+++ b/packages/governance/src/contractGovernance/paramManager.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { Far, passStyleOf } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';

--- a/packages/governance/src/multiCandidateVoteCounter.js
+++ b/packages/governance/src/multiCandidateVoteCounter.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { keyEQ, makeExo, makeScalarMapStore } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/governance/test/unitTests/test-binaryballotCount.js
+++ b/packages/governance/test/unitTests/test-binaryballotCount.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import '@agoric/zoe/exported.js';
 import { E } from '@endo/eventual-send';

--- a/packages/governance/test/unitTests/test-multiCandidateBallotCount.js
+++ b/packages/governance/test/unitTests/test-multiCandidateBallotCount.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { makeStoredPublishKit } from '@agoric/notifier';
 import {

--- a/packages/governance/test/unitTests/test-puppetContractGovernor.js
+++ b/packages/governance/test/unitTests/test-puppetContractGovernor.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeNotifierFromAsyncIterable } from '@agoric/notifier';

--- a/packages/internal/src/queue.js
+++ b/packages/internal/src/queue.js
@@ -1,4 +1,5 @@
 // @jessie-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 import { makePromiseKit } from '@endo/promise-kit';
 

--- a/packages/pegasus/src/proposals/core-proposal.js
+++ b/packages/pegasus/src/proposals/core-proposal.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { E, Far } from '@endo/far';
 import { makeNameHubKit } from '@agoric/vats/src/nameHub.js';
 import { observeIteration, subscribeEach } from '@agoric/notifier';

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import path from 'path';

--- a/packages/smart-wallet/test/gameAssetContract.js
+++ b/packages/smart-wallet/test/gameAssetContract.js
@@ -1,4 +1,5 @@
 /** @file illustrates using non-vbank assets */
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 // deep import to avoid dependency on all of ERTP, vat-data
 import { AmountShape } from '@agoric/ertp';

--- a/packages/smart-wallet/test/test-addAsset.js
+++ b/packages/smart-wallet/test/test-addAsset.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { E, Far } from '@endo/far';
 import { buildRootObject as buildBankVatRoot } from '@agoric/vats/src/vat-bank.js';

--- a/packages/solo/public/main.js
+++ b/packages/solo/public/main.js
@@ -1,4 +1,5 @@
 /* global setTimeout */
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 // NOTE: Runs outside SES
 
 /* global WebSocket fetch document window walletFrame localStorage */

--- a/packages/solo/src/captp.js
+++ b/packages/solo/src/captp.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { E, makeCapTP } from '@endo/captp';
 import { Far } from '@endo/marshal';
 

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -1,4 +1,5 @@
 /* global clearTimeout setTimeout Buffer */
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import path from 'path';
 import fs from 'fs';
 import url from 'url';

--- a/packages/solo/src/vat-http.js
+++ b/packages/solo/src/vat-http.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { makeNotifierKit } from '@agoric/notifier';
 import { makeCache } from '@agoric/cache';
 import { E } from '@endo/eventual-send';

--- a/packages/solo/test/captp-fixture.js
+++ b/packages/solo/test/captp-fixture.js
@@ -1,4 +1,5 @@
 /* global process setTimeout */
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { spawn } from 'child_process';
 import WebSocket from 'ws';
 import { makeCapTP, E } from '@endo/captp';

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import {
   Remotable,
   passStyleOf,

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 /**
  * This file defines the wallet internals without dependency on the ag-solo on

--- a/packages/wallet/api/src/wallet.js
+++ b/packages/wallet/api/src/wallet.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 /**
  * This file defines the vat launched by the spawner in the ../deploy.js script.

--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import bundleSource from '@endo/bundle-source';

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 /* avaXS - ava style test runner for XS
 
 Usage:

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -1,4 +1,5 @@
 /* global process */
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 /* eslint no-await-in-loop: ["off"] */
 
 /**

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 /* global process */
 /* We make exceptions for test code. This is a test utility. */
 /* eslint no-await-in-loop: ["off"] */

--- a/packages/xsnap/test/fixture-xsnap-script.js
+++ b/packages/xsnap/test/fixture-xsnap-script.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 /* global issueCommand */
 (async () => {
   issueCommand(new TextEncoder().encode('Hello, World!').buffer);

--- a/packages/zoe/src/contractFacet/zcfMint.js
+++ b/packages/zoe/src/contractFacet/zcfMint.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { AmountMath } from '@agoric/ertp';
 import { prepareExoClass } from '@agoric/vat-data';
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import {
   makeScalarBigWeakMapStore,
   prepareExoClass,

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { AssetKind } from '@agoric/ertp';
 import { assertPattern, mustMatch } from '@agoric/store';
 import {

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 /// <reference types="@agoric/time/src/types.d.ts" />
 
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/src/contractSupport/priceAuthorityInitial.js
+++ b/packages/zoe/src/contractSupport/priceAuthorityInitial.js
@@ -1,5 +1,6 @@
 // @ts-check
 // @jessie-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 import { E } from '@endo/far';
 import { Far } from '@endo/marshal';

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { mustMatch, keyEQ } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/zoe/src/contracts/auction/index.js
+++ b/packages/zoe/src/contracts/auction/index.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { E } from '@endo/eventual-send';
 import { mustMatch } from '@endo/patterns';
 import { Far } from '@endo/marshal';

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import './types.js';
 
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import './types.js';
 
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { assert, Fail } from '@agoric/assert';
 import { Far } from '@endo/marshal';
 import { AmountMath } from '@agoric/ertp';

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 /// <reference types="@agoric/time/src/types.d.ts" />
 
 import { Fail, q } from '@agoric/assert';

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { Far } from '@endo/marshal';
 import { Nat } from '@endo/nat';
 import { AmountMath } from '@agoric/ertp';

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import {
   canBeDurable,
   makeScalarBigSetStore,

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { E } from '@endo/eventual-send';
 import { passStyleOf } from '@endo/marshal';
 import {

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -1,4 +1,5 @@
 // @jessie-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 /**
  * Zoe uses ERTP, the Electronic Rights Transfer Protocol

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { prepareDurablePublishKit, SubscriberShape } from '@agoric/notifier';
 import { E } from '@endo/eventual-send';
 import { M, prepareExoClassKit } from '@agoric/vat-data';

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';

--- a/packages/zoe/test/types.test-d.ts
+++ b/packages/zoe/test/types.test-d.ts
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 /**
  * @file uses .ts syntax to be able to declare types (e.g. of kit.creatorFacet as {})
  * because "there is no JavaScript syntax for passing a a type argument"

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import '@agoric/swingset-liveslots/tools/prepare-test-env.js';
 
 import path from 'path';

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import '../../../../exported.js';
 

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import path from 'path';

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import path from 'path';

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test as unknownTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import path from 'path';

--- a/packages/zoe/test/unitTests/test-fakePriceAuthority.js
+++ b/packages/zoe/test/unitTests/test-fakePriceAuthority.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/test/unitTests/test-manualTimer.js
+++ b/packages/zoe/test/unitTests/test-manualTimer.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { Far } from '@endo/marshal';

--- a/packages/zoe/test/unitTests/zoe/test-escrowStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-escrowStorage.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 

--- a/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { Far } from '@endo/marshal';

--- a/packages/zoe/tools/manualPriceAuthority.js
+++ b/packages/zoe/tools/manualPriceAuthority.js
@@ -1,4 +1,5 @@
 // @jessie-check
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';

--- a/packages/zoe/tools/scriptedPriceAuthority.js
+++ b/packages/zoe/tools/scriptedPriceAuthority.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';


### PR DESCRIPTION
closes: #7888

## Description

Since #8058 it's been enabled in CI. (#8061 will consolidate the two jobs into one, but that's outside the scope of this issue).

This PR enables it outside CI too (so that it always has type info and always warns on floating promisees).

Then it upgrades the warn to an error and suppresses the rule in all files that don't yet comply. It's separate work to resolve all of those: https://github.com/Agoric/agoric-sdk/issues/6000. 

### Security Considerations

--

### Scaling Considerations

--

### Documentation Considerations

Notify developers of the new error and that their IDE and local lint output will no emit warnings.

### Testing Considerations

CI

### Upgrade Considerations

n/a