### PR TITLE
disable no-lone-blocks rule in tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -113,6 +113,9 @@ module.exports = {
         'packages/wallet/api/test/**/*.js',
       ],
       rules: {
+        // sometimes used for organizing logic
+        'no-lone-blocks': 'off',
+
         // NOTE: This rule is enabled for the repository in general.  We turn it
         // off for test code for now.
         '@jessie.js/safe-await-separator': 'off',

--- a/packages/SwingSet/test/device-hooks/test-device-hooks.js
+++ b/packages/SwingSet/test/device-hooks/test-device-hooks.js
@@ -1,5 +1,4 @@
 // @ts-nocheck
-/* eslint-disable no-lone-blocks */
 // eslint-disable-next-line import/order
 import { test } from '../../tools/prepare-test-env-ava.js';
 

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -1,4 +1,3 @@
-/* eslint no-lone-blocks: "off" */
 /* eslint dot-notation: "off" */
 // I turned off dot-notation so eslint won't rewrite the grep-preserving
 // test.stuff patterns.

--- a/packages/inter-protocol/test/vaultFactory/test-math.js
+++ b/packages/inter-protocol/test/vaultFactory/test-math.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-lone-blocks */
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit } from '@agoric/ertp';


### PR DESCRIPTION
## Description

prompted by https://github.com/Agoric/agoric-sdk/pull/4981#issuecomment-1679514480

We've decided to allow blocks even when they are redundant because it makes for more consistency with cases in which they're necessary. One could argue it's better to be able to tell from reading the code whether the block is necessary (i.e. that there's a new binding that should not escape the block). This allows it in tests only because in production code it is important that it's clear whether the block was necessary or not.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
